### PR TITLE
fix: exclude cache tokens from session totalTokens derivation

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -474,6 +474,7 @@ public struct AgentParams: Codable, Sendable {
     public let replyto: String?
     public let sessionid: String?
     public let sessionkey: String?
+    public let model: String?
     public let thinking: String?
     public let deliver: Bool?
     public let attachments: [AnyCodable]?
@@ -499,6 +500,7 @@ public struct AgentParams: Codable, Sendable {
         replyto: String?,
         sessionid: String?,
         sessionkey: String?,
+        model: String?,
         thinking: String?,
         deliver: Bool?,
         attachments: [AnyCodable]?,
@@ -523,6 +525,7 @@ public struct AgentParams: Codable, Sendable {
         self.replyto = replyto
         self.sessionid = sessionid
         self.sessionkey = sessionkey
+        self.model = model
         self.thinking = thinking
         self.deliver = deliver
         self.attachments = attachments
@@ -548,6 +551,7 @@ public struct AgentParams: Codable, Sendable {
         case replyto = "replyTo"
         case sessionid = "sessionId"
         case sessionkey = "sessionKey"
+        case model
         case thinking
         case deliver
         case attachments

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -474,6 +474,7 @@ public struct AgentParams: Codable, Sendable {
     public let replyto: String?
     public let sessionid: String?
     public let sessionkey: String?
+    public let model: String?
     public let thinking: String?
     public let deliver: Bool?
     public let attachments: [AnyCodable]?
@@ -499,6 +500,7 @@ public struct AgentParams: Codable, Sendable {
         replyto: String?,
         sessionid: String?,
         sessionkey: String?,
+        model: String?,
         thinking: String?,
         deliver: Bool?,
         attachments: [AnyCodable]?,
@@ -523,6 +525,7 @@ public struct AgentParams: Codable, Sendable {
         self.replyto = replyto
         self.sessionid = sessionid
         self.sessionkey = sessionkey
+        self.model = model
         self.thinking = thinking
         self.deliver = deliver
         self.attachments = attachments
@@ -548,6 +551,7 @@ public struct AgentParams: Codable, Sendable {
         case replyto = "replyTo"
         case sessionid = "sessionId"
         case sessionkey = "sessionKey"
+        case model
         case thinking
         case deliver
         case attachments

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -87,6 +87,7 @@ vi.mock("@opentelemetry/resources", () => ({
     // eslint-disable-next-line @typescript-eslint/no-useless-constructor
     constructor(_value?: unknown) {}
   },
+  resourceFromAttributes: vi.fn(() => ({})),
 }));
 
 vi.mock("@opentelemetry/semantic-conventions", () => ({

--- a/extensions/twitch/src/outbound.test.ts
+++ b/extensions/twitch/src/outbound.test.ts
@@ -36,7 +36,7 @@ vi.mock("./utils/twitch.js", () => ({
 describe("outbound", () => {
   const mockAccount = {
     username: "testbot",
-    token: "oauth:test123",
+    accessToken: "oauth:test123",
     clientId: "test-client-id",
     channel: "#testchannel",
   };
@@ -196,7 +196,6 @@ describe("outbound", () => {
 
       expect(result.channel).toBe("twitch");
       expect(result.messageId).toBe("twitch-msg-123");
-      expect(result.to).toBe("testchannel");
       expect(result.timestamp).toBeGreaterThan(0);
     });
 

--- a/extensions/twitch/src/probe.test.ts
+++ b/extensions/twitch/src/probe.test.ts
@@ -54,7 +54,8 @@ vi.mock("@twurple/auth", () => ({
 describe("probeTwitch", () => {
   const mockAccount: TwitchAccountConfig = {
     username: "testbot",
-    token: "oauth:test123456789",
+    accessToken: "oauth:test123456789",
+    clientId: "test-client-id",
     channel: "testchannel",
   };
 
@@ -74,7 +75,7 @@ describe("probeTwitch", () => {
   });
 
   it("returns error when token is missing", async () => {
-    const account = { ...mockAccount, token: "" };
+    const account = { ...mockAccount, accessToken: "" };
     const result = await probeTwitch(account, 5000);
 
     expect(result.ok).toBe(false);
@@ -84,7 +85,7 @@ describe("probeTwitch", () => {
   it("attempts connection regardless of token prefix", async () => {
     // Note: probeTwitch doesn't validate token format - it tries to connect with whatever token is provided
     // The actual connection would fail in production with an invalid token
-    const account = { ...mockAccount, token: "raw_token_no_prefix" };
+    const account = { ...mockAccount, accessToken: "raw_token_no_prefix" };
     const result = await probeTwitch(account, 5000);
 
     // With mock, connection succeeds even without oauth: prefix
@@ -166,7 +167,7 @@ describe("probeTwitch", () => {
   it("trims token before validation", async () => {
     const account: TwitchAccountConfig = {
       ...mockAccount,
-      token: "  oauth:test123456789  ",
+      accessToken: "  oauth:test123456789  ",
     };
 
     const result = await probeTwitch(account, 5000);

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -297,6 +297,7 @@ export async function runCliAgent(params: {
           provider: params.provider,
           model: modelId,
           usage: output.usage,
+          promptUsage: output.usage,
         },
       },
     };

--- a/src/agents/compaction.test.ts
+++ b/src/agents/compaction.test.ts
@@ -1,6 +1,7 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { describe, expect, it } from "vitest";
 import {
+  __testing,
   estimateMessagesTokens,
   pruneHistoryForContextShare,
   splitMessagesByTokenShare,
@@ -42,6 +43,21 @@ describe("splitMessagesByTokenShare", () => {
 
     const parts = splitMessagesByTokenShare(messages, 3);
     expect(parts.flat().map((msg) => msg.timestamp)).toEqual(messages.map((msg) => msg.timestamp));
+  });
+});
+
+describe("areReserveTokensEquivalent", () => {
+  it("treats NaN values as equivalent", () => {
+    expect(__testing.areReserveTokensEquivalent(Number.NaN, Number.NaN)).toBe(true);
+  });
+
+  it("does not treat NaN as equal to numbers", () => {
+    expect(__testing.areReserveTokensEquivalent(Number.NaN, 42)).toBe(false);
+  });
+
+  it("respects strict equality for normal values", () => {
+    expect(__testing.areReserveTokensEquivalent(1024, 1024)).toBe(true);
+    expect(__testing.areReserveTokensEquivalent(1024, 2048)).toBe(false);
   });
 });
 

--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -24,6 +24,17 @@ function normalizeParts(parts: number, messageCount: number): number {
   return Math.min(Math.max(1, Math.floor(parts)), Math.max(1, messageCount));
 }
 
+function normalizeReserveTokens(reserveTokens: number): number {
+  if (typeof reserveTokens === "number" && Number.isFinite(reserveTokens) && reserveTokens > 0) {
+    return Math.max(1, Math.floor(reserveTokens));
+  }
+  return 1;
+}
+
+function areReserveTokensEquivalent(left: number, right: number): boolean {
+  return left === right || (Number.isNaN(left) && Number.isNaN(right));
+}
+
 export function splitMessagesByTokenShare(
   messages: AgentMessage[],
   parts = DEFAULT_PARTS,
@@ -185,14 +196,17 @@ export async function summarizeWithFallback(params: {
   previousSummary?: string;
 }): Promise<string> {
   const { messages, contextWindow } = params;
+  const reserveTokens = normalizeReserveTokens(params.reserveTokens);
+  const reserveTokensUnchanged = areReserveTokensEquivalent(reserveTokens, params.reserveTokens);
+  const normalizedParams = reserveTokensUnchanged ? params : { ...params, reserveTokens };
 
   if (messages.length === 0) {
-    return params.previousSummary ?? DEFAULT_SUMMARY_FALLBACK;
+    return normalizedParams.previousSummary ?? DEFAULT_SUMMARY_FALLBACK;
   }
 
   // Try full summarization first
   try {
-    return await summarizeChunks(params);
+    return await summarizeChunks(normalizedParams);
   } catch (fullError) {
     console.warn(
       `Full summarization failed, trying partial: ${
@@ -220,7 +234,7 @@ export async function summarizeWithFallback(params: {
   if (smallMessages.length > 0) {
     try {
       const partialSummary = await summarizeChunks({
-        ...params,
+        ...normalizedParams,
         messages: smallMessages,
       });
       const notes = oversizedNotes.length > 0 ? `\n\n${oversizedNotes.join("\n")}` : "";
@@ -371,3 +385,7 @@ export function pruneHistoryForContextShare(params: {
 export function resolveContextWindowTokens(model?: ExtensionContext["model"]): number {
   return Math.max(1, Math.floor(model?.contextWindow ?? DEFAULT_CONTEXT_TOKENS));
 }
+
+export const __testing = {
+  areReserveTokensEquivalent,
+} as const;

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -56,6 +56,11 @@ describe("sanitizeUserFacingText", () => {
     expect(sanitizeUserFacingText(text)).toBe("Hello there!");
   });
 
+  it("strips leading blank lines", () => {
+    expect(sanitizeUserFacingText("\n\nHello there!")).toBe("Hello there!");
+    expect(sanitizeUserFacingText("\n \n\t\nHello")).toBe("Hello");
+  });
+
   it("does not collapse distinct paragraphs", () => {
     const text = "Hello there!\n\nDifferent line.";
     expect(sanitizeUserFacingText(text)).toBe(text);

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -407,9 +407,10 @@ export function sanitizeUserFacingText(text: string): string {
     return text;
   }
   const stripped = stripFinalTagsFromText(text);
-  const trimmed = stripped.trim();
+  const cleaned = stripped.replace(/^(?:[ \t]*\n)+/, "");
+  const trimmed = cleaned.trim();
   if (!trimmed) {
-    return stripped;
+    return cleaned;
   }
 
   if (/incorrect role information|roles must alternate/i.test(trimmed)) {
@@ -444,7 +445,7 @@ export function sanitizeUserFacingText(text: string): string {
     return formatRawAssistantErrorForUi(trimmed);
   }
 
-  return collapseConsecutiveDuplicateBlocks(stripped);
+  return collapseConsecutiveDuplicateBlocks(cleaned);
 }
 
 export function isRateLimitAssistantError(msg: AssistantMessage | undefined): boolean {

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -182,6 +182,28 @@ describe("sanitizeSessionHistory", () => {
     expect(result.map((msg) => msg.role)).toEqual(["user"]);
   });
 
+  it("filters foreign tool-use messages before repair for anthropic", async () => {
+    const messages: AgentMessage[] = [
+      { role: "user", content: "hello" },
+      {
+        role: "assistant",
+        provider: "openai",
+        api: "openai-responses",
+        content: [{ type: "toolCall", id: "call_1", name: "read", arguments: {} }],
+      },
+    ];
+
+    const result = await sanitizeSessionHistory({
+      messages,
+      modelApi: "anthropic-messages",
+      provider: "anthropic",
+      sessionManager: mockSessionManager,
+      sessionId: "test-session",
+    });
+
+    expect(result).toEqual([{ role: "user", content: "hello" }]);
+  });
+
   it("does not downgrade openai reasoning when the model has not changed", async () => {
     const sessionEntries: Array<{ type: string; customType: string; data: unknown }> = [
       {

--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -16,8 +16,10 @@ function resolvePiExtensionPath(id: string): string {
   const self = fileURLToPath(import.meta.url);
   const dir = path.dirname(self);
   // In dev this file is `.ts` (tsx), in production it's `.js`.
-  const ext = path.extname(self) === ".ts" ? "ts" : "js";
-  return path.join(dir, "..", "pi-extensions", `${id}.${ext}`);
+  const isTs = path.extname(self) === ".ts";
+  const ext = isTs ? "ts" : "js";
+  const baseDir = isTs ? path.join(dir, "..") : dir;
+  return path.join(baseDir, "pi-extensions", `${id}.${ext}`);
 }
 
 function resolveContextWindowTokens(params: {

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -119,6 +119,84 @@ function sanitizeAntigravityThinkingBlocks(messages: AgentMessage[]): AgentMessa
   return touched ? out : messages;
 }
 
+function isDeliveryMirrorMessage(message: AgentMessage): boolean {
+  return (
+    message &&
+    typeof message === "object" &&
+    (message as { role?: unknown }).role === "assistant" &&
+    (message as { model?: unknown }).model === "delivery-mirror" &&
+    (message as { provider?: unknown }).provider === "openclaw"
+  );
+}
+
+function filterDeliveryMirrorMessages(messages: AgentMessage[]): AgentMessage[] {
+  let touched = false;
+  const out: AgentMessage[] = [];
+  for (const msg of messages) {
+    if (isDeliveryMirrorMessage(msg)) {
+      touched = true;
+      continue;
+    }
+    out.push(msg);
+  }
+  return touched ? out : messages;
+}
+
+function hasToolCallBlocks(message: AgentMessage): boolean {
+  if (!message || typeof message !== "object" || message.role !== "assistant") {
+    return false;
+  }
+  const content = message.content;
+  if (!Array.isArray(content)) {
+    return false;
+  }
+  return content.some((block) => {
+    if (!block || typeof block !== "object") {
+      return false;
+    }
+    const rec = block as { type?: unknown };
+    return rec.type === "toolCall" || rec.type === "toolUse" || rec.type === "functionCall";
+  });
+}
+
+function isForeignToolUseMessage(
+  message: AgentMessage,
+  ctx: { provider?: string | null; modelApi?: string | null },
+): boolean {
+  if (!hasToolCallBlocks(message)) {
+    return false;
+  }
+  const normalize = (value: unknown) =>
+    typeof value === "string" ? value.trim().toLowerCase() : "";
+  const expectedProvider = normalize(ctx.provider);
+  const expectedApi = normalize(ctx.modelApi);
+  const msgProvider = normalize((message as { provider?: unknown }).provider);
+  const msgApi = normalize((message as { api?: unknown }).api);
+  if (expectedProvider && msgProvider && expectedProvider !== msgProvider) {
+    return true;
+  }
+  if (expectedApi && msgApi && expectedApi !== msgApi) {
+    return true;
+  }
+  return false;
+}
+
+function filterForeignToolUseMessages(
+  messages: AgentMessage[],
+  ctx: { provider?: string | null; modelApi?: string | null },
+): AgentMessage[] {
+  let touched = false;
+  const out: AgentMessage[] = [];
+  for (const msg of messages) {
+    if (isForeignToolUseMessage(msg, ctx)) {
+      touched = true;
+      continue;
+    }
+    out.push(msg);
+  }
+  return touched ? out : messages;
+}
+
 function findUnsupportedSchemaKeywords(schema: unknown, path: string): string[] {
   if (!schema || typeof schema !== "object") {
     return [];
@@ -339,13 +417,22 @@ export async function sanitizeSessionHistory(params: {
       provider: params.provider,
       modelId: params.modelId,
     });
-  const sanitizedImages = await sanitizeSessionMessagesImages(params.messages, "session:history", {
-    sanitizeMode: policy.sanitizeMode,
-    sanitizeToolCallIds: policy.sanitizeToolCallIds,
-    toolCallIdMode: policy.toolCallIdMode,
-    preserveSignatures: policy.preserveSignatures,
-    sanitizeThoughtSignatures: policy.sanitizeThoughtSignatures,
+  const withoutDeliveryMirror = filterDeliveryMirrorMessages(params.messages);
+  const withoutForeignToolUse = filterForeignToolUseMessages(withoutDeliveryMirror, {
+    provider: params.provider,
+    modelApi: params.modelApi,
   });
+  const sanitizedImages = await sanitizeSessionMessagesImages(
+    withoutForeignToolUse,
+    "session:history",
+    {
+      sanitizeMode: policy.sanitizeMode,
+      sanitizeToolCallIds: policy.sanitizeToolCallIds,
+      toolCallIdMode: policy.toolCallIdMode,
+      preserveSignatures: policy.preserveSignatures,
+      sanitizeThoughtSignatures: policy.sanitizeThoughtSignatures,
+    },
+  );
   const sanitizedThinking = policy.normalizeAntigravityThinkingBlocks
     ? sanitizeAntigravityThinkingBlocks(sanitizedImages)
     : sanitizedImages;

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -153,250 +153,244 @@ export async function runEmbeddedPiAgent(
       : "markdown");
   const isProbeSession = params.sessionId?.startsWith("probe-") ?? false;
 
-  return enqueueSession(() =>
-    enqueueGlobal(async () => {
-      const started = Date.now();
-      const workspaceResolution = resolveRunWorkspaceDir({
-        workspaceDir: params.workspaceDir,
-        sessionKey: params.sessionKey,
-        agentId: params.agentId,
-        config: params.config,
-      });
-      const resolvedWorkspace = workspaceResolution.workspaceDir;
-      const redactedSessionId = redactRunIdentifier(params.sessionId);
-      const redactedSessionKey = redactRunIdentifier(params.sessionKey);
-      const redactedWorkspace = redactRunIdentifier(resolvedWorkspace);
-      if (workspaceResolution.usedFallback) {
-        log.warn(
-          `[workspace-fallback] caller=runEmbeddedPiAgent reason=${workspaceResolution.fallbackReason} run=${params.runId} session=${redactedSessionId} sessionKey=${redactedSessionKey} agent=${workspaceResolution.agentId} workspace=${redactedWorkspace}`,
-        );
-      }
-      const prevCwd = process.cwd();
+  const started = Date.now();
+  const workspaceResolution = resolveRunWorkspaceDir({
+    workspaceDir: params.workspaceDir,
+    sessionKey: params.sessionKey,
+    agentId: params.agentId,
+    config: params.config,
+  });
+  const resolvedWorkspace = workspaceResolution.workspaceDir;
+  const redactedSessionId = redactRunIdentifier(params.sessionId);
+  const redactedSessionKey = redactRunIdentifier(params.sessionKey);
+  const redactedWorkspace = redactRunIdentifier(resolvedWorkspace);
+  if (workspaceResolution.usedFallback) {
+    log.warn(
+      `[workspace-fallback] caller=runEmbeddedPiAgent reason=${workspaceResolution.fallbackReason} run=${params.runId} session=${redactedSessionId} sessionKey=${redactedSessionKey} agent=${workspaceResolution.agentId} workspace=${redactedWorkspace}`,
+    );
+  }
+  const prevCwd = process.cwd();
 
-      const provider = (params.provider ?? DEFAULT_PROVIDER).trim() || DEFAULT_PROVIDER;
-      const modelId = (params.model ?? DEFAULT_MODEL).trim() || DEFAULT_MODEL;
-      const agentDir = params.agentDir ?? resolveOpenClawAgentDir();
-      const fallbackConfigured =
-        (params.config?.agents?.defaults?.model?.fallbacks?.length ?? 0) > 0;
-      await ensureOpenClawModelsJson(params.config, agentDir);
+  const provider = (params.provider ?? DEFAULT_PROVIDER).trim() || DEFAULT_PROVIDER;
+  const modelId = (params.model ?? DEFAULT_MODEL).trim() || DEFAULT_MODEL;
+  const agentDir = params.agentDir ?? resolveOpenClawAgentDir();
+  const fallbackConfigured = (params.config?.agents?.defaults?.model?.fallbacks?.length ?? 0) > 0;
+  await ensureOpenClawModelsJson(params.config, agentDir);
 
-      const { model, error, authStorage, modelRegistry } = resolveModel(
+  const { model, error, authStorage, modelRegistry } = resolveModel(
+    provider,
+    modelId,
+    agentDir,
+    params.config,
+  );
+  if (!model) {
+    throw new Error(error ?? `Unknown model: ${provider}/${modelId}`);
+  }
+
+  const ctxInfo = resolveContextWindowInfo({
+    cfg: params.config,
+    provider,
+    modelId,
+    modelContextWindow: model.contextWindow,
+    defaultTokens: DEFAULT_CONTEXT_TOKENS,
+  });
+  const ctxGuard = evaluateContextWindowGuard({
+    info: ctxInfo,
+    warnBelowTokens: CONTEXT_WINDOW_WARN_BELOW_TOKENS,
+    hardMinTokens: CONTEXT_WINDOW_HARD_MIN_TOKENS,
+  });
+  if (ctxGuard.shouldWarn) {
+    log.warn(
+      `low context window: ${provider}/${modelId} ctx=${ctxGuard.tokens} (warn<${CONTEXT_WINDOW_WARN_BELOW_TOKENS}) source=${ctxGuard.source}`,
+    );
+  }
+  if (ctxGuard.shouldBlock) {
+    log.error(
+      `blocked model (context window too small): ${provider}/${modelId} ctx=${ctxGuard.tokens} (min=${CONTEXT_WINDOW_HARD_MIN_TOKENS}) source=${ctxGuard.source}`,
+    );
+    throw new FailoverError(
+      `Model context window too small (${ctxGuard.tokens} tokens). Minimum is ${CONTEXT_WINDOW_HARD_MIN_TOKENS}.`,
+      { reason: "unknown", provider, model: modelId },
+    );
+  }
+
+  const authStore = ensureAuthProfileStore(agentDir, { allowKeychainPrompt: false });
+  const preferredProfileId = params.authProfileId?.trim();
+  let lockedProfileId = params.authProfileIdSource === "user" ? preferredProfileId : undefined;
+  if (lockedProfileId) {
+    const lockedProfile = authStore.profiles[lockedProfileId];
+    if (
+      !lockedProfile ||
+      normalizeProviderId(lockedProfile.provider) !== normalizeProviderId(provider)
+    ) {
+      lockedProfileId = undefined;
+    }
+  }
+  const profileOrder = resolveAuthProfileOrder({
+    cfg: params.config,
+    store: authStore,
+    provider,
+    preferredProfile: preferredProfileId,
+  });
+  if (lockedProfileId && !profileOrder.includes(lockedProfileId)) {
+    throw new Error(`Auth profile "${lockedProfileId}" is not configured for ${provider}.`);
+  }
+  const profileCandidates = lockedProfileId
+    ? [lockedProfileId]
+    : profileOrder.length > 0
+      ? profileOrder
+      : [undefined];
+  let profileIndex = 0;
+
+  const initialThinkLevel = params.thinkLevel ?? "off";
+  let thinkLevel = initialThinkLevel;
+  const attemptedThinking = new Set<ThinkLevel>();
+  let apiKeyInfo: ApiKeyInfo | null = null;
+  let lastProfileId: string | undefined;
+
+  const resolveAuthProfileFailoverReason = (params: {
+    allInCooldown: boolean;
+    message: string;
+  }): FailoverReason => {
+    if (params.allInCooldown) {
+      return "rate_limit";
+    }
+    const classified = classifyFailoverReason(params.message);
+    return classified ?? "auth";
+  };
+
+  const throwAuthProfileFailover = (params: {
+    allInCooldown: boolean;
+    message?: string;
+    error?: unknown;
+  }): never => {
+    const fallbackMessage = `No available auth profile for ${provider} (all in cooldown or unavailable).`;
+    const message =
+      params.message?.trim() ||
+      (params.error ? describeUnknownError(params.error).trim() : "") ||
+      fallbackMessage;
+    const reason = resolveAuthProfileFailoverReason({
+      allInCooldown: params.allInCooldown,
+      message,
+    });
+    if (fallbackConfigured) {
+      throw new FailoverError(message, {
+        reason,
         provider,
-        modelId,
-        agentDir,
-        params.config,
-      );
-      if (!model) {
-        throw new Error(error ?? `Unknown model: ${provider}/${modelId}`);
-      }
+        model: modelId,
+        status: resolveFailoverStatus(reason),
+        cause: params.error,
+      });
+    }
+    if (params.error instanceof Error) {
+      throw params.error;
+    }
+    throw new Error(message);
+  };
 
-      const ctxInfo = resolveContextWindowInfo({
-        cfg: params.config,
-        provider,
-        modelId,
-        modelContextWindow: model.contextWindow,
-        defaultTokens: DEFAULT_CONTEXT_TOKENS,
-      });
-      const ctxGuard = evaluateContextWindowGuard({
-        info: ctxInfo,
-        warnBelowTokens: CONTEXT_WINDOW_WARN_BELOW_TOKENS,
-        hardMinTokens: CONTEXT_WINDOW_HARD_MIN_TOKENS,
-      });
-      if (ctxGuard.shouldWarn) {
-        log.warn(
-          `low context window: ${provider}/${modelId} ctx=${ctxGuard.tokens} (warn<${CONTEXT_WINDOW_WARN_BELOW_TOKENS}) source=${ctxGuard.source}`,
+  const resolveApiKeyForCandidate = async (candidate?: string) => {
+    return getApiKeyForModel({
+      model,
+      cfg: params.config,
+      profileId: candidate,
+      store: authStore,
+      agentDir,
+    });
+  };
+
+  const applyApiKeyInfo = async (candidate?: string): Promise<void> => {
+    apiKeyInfo = await resolveApiKeyForCandidate(candidate);
+    const resolvedProfileId = apiKeyInfo.profileId ?? candidate;
+    if (!apiKeyInfo.apiKey) {
+      if (apiKeyInfo.mode !== "aws-sdk") {
+        throw new Error(
+          `No API key resolved for provider "${model.provider}" (auth mode: ${apiKeyInfo.mode}).`,
         );
       }
-      if (ctxGuard.shouldBlock) {
-        log.error(
-          `blocked model (context window too small): ${provider}/${modelId} ctx=${ctxGuard.tokens} (min=${CONTEXT_WINDOW_HARD_MIN_TOKENS}) source=${ctxGuard.source}`,
-        );
-        throw new FailoverError(
-          `Model context window too small (${ctxGuard.tokens} tokens). Minimum is ${CONTEXT_WINDOW_HARD_MIN_TOKENS}.`,
-          { reason: "unknown", provider, model: modelId },
-        );
-      }
-
-      const authStore = ensureAuthProfileStore(agentDir, { allowKeychainPrompt: false });
-      const preferredProfileId = params.authProfileId?.trim();
-      let lockedProfileId = params.authProfileIdSource === "user" ? preferredProfileId : undefined;
-      if (lockedProfileId) {
-        const lockedProfile = authStore.profiles[lockedProfileId];
-        if (
-          !lockedProfile ||
-          normalizeProviderId(lockedProfile.provider) !== normalizeProviderId(provider)
-        ) {
-          lockedProfileId = undefined;
-        }
-      }
-      const profileOrder = resolveAuthProfileOrder({
-        cfg: params.config,
-        store: authStore,
-        provider,
-        preferredProfile: preferredProfileId,
+      lastProfileId = resolvedProfileId;
+      return;
+    }
+    if (model.provider === "github-copilot") {
+      const { resolveCopilotApiToken } = await import("../../providers/github-copilot-token.js");
+      const copilotToken = await resolveCopilotApiToken({
+        githubToken: apiKeyInfo.apiKey,
       });
-      if (lockedProfileId && !profileOrder.includes(lockedProfileId)) {
-        throw new Error(`Auth profile "${lockedProfileId}" is not configured for ${provider}.`);
+      authStorage.setRuntimeApiKey(model.provider, copilotToken.token);
+    } else {
+      authStorage.setRuntimeApiKey(model.provider, apiKeyInfo.apiKey);
+    }
+    lastProfileId = apiKeyInfo.profileId;
+  };
+
+  const advanceAuthProfile = async (): Promise<boolean> => {
+    if (lockedProfileId) {
+      return false;
+    }
+    let nextIndex = profileIndex + 1;
+    while (nextIndex < profileCandidates.length) {
+      const candidate = profileCandidates[nextIndex];
+      if (candidate && isProfileInCooldown(authStore, candidate)) {
+        nextIndex += 1;
+        continue;
       }
-      const profileCandidates = lockedProfileId
-        ? [lockedProfileId]
-        : profileOrder.length > 0
-          ? profileOrder
-          : [undefined];
-      let profileIndex = 0;
-
-      const initialThinkLevel = params.thinkLevel ?? "off";
-      let thinkLevel = initialThinkLevel;
-      const attemptedThinking = new Set<ThinkLevel>();
-      let apiKeyInfo: ApiKeyInfo | null = null;
-      let lastProfileId: string | undefined;
-
-      const resolveAuthProfileFailoverReason = (params: {
-        allInCooldown: boolean;
-        message: string;
-      }): FailoverReason => {
-        if (params.allInCooldown) {
-          return "rate_limit";
-        }
-        const classified = classifyFailoverReason(params.message);
-        return classified ?? "auth";
-      };
-
-      const throwAuthProfileFailover = (params: {
-        allInCooldown: boolean;
-        message?: string;
-        error?: unknown;
-      }): never => {
-        const fallbackMessage = `No available auth profile for ${provider} (all in cooldown or unavailable).`;
-        const message =
-          params.message?.trim() ||
-          (params.error ? describeUnknownError(params.error).trim() : "") ||
-          fallbackMessage;
-        const reason = resolveAuthProfileFailoverReason({
-          allInCooldown: params.allInCooldown,
-          message,
-        });
-        if (fallbackConfigured) {
-          throw new FailoverError(message, {
-            reason,
-            provider,
-            model: modelId,
-            status: resolveFailoverStatus(reason),
-            cause: params.error,
-          });
-        }
-        if (params.error instanceof Error) {
-          throw params.error;
-        }
-        throw new Error(message);
-      };
-
-      const resolveApiKeyForCandidate = async (candidate?: string) => {
-        return getApiKeyForModel({
-          model,
-          cfg: params.config,
-          profileId: candidate,
-          store: authStore,
-          agentDir,
-        });
-      };
-
-      const applyApiKeyInfo = async (candidate?: string): Promise<void> => {
-        apiKeyInfo = await resolveApiKeyForCandidate(candidate);
-        const resolvedProfileId = apiKeyInfo.profileId ?? candidate;
-        if (!apiKeyInfo.apiKey) {
-          if (apiKeyInfo.mode !== "aws-sdk") {
-            throw new Error(
-              `No API key resolved for provider "${model.provider}" (auth mode: ${apiKeyInfo.mode}).`,
-            );
-          }
-          lastProfileId = resolvedProfileId;
-          return;
-        }
-        if (model.provider === "github-copilot") {
-          const { resolveCopilotApiToken } =
-            await import("../../providers/github-copilot-token.js");
-          const copilotToken = await resolveCopilotApiToken({
-            githubToken: apiKeyInfo.apiKey,
-          });
-          authStorage.setRuntimeApiKey(model.provider, copilotToken.token);
-        } else {
-          authStorage.setRuntimeApiKey(model.provider, apiKeyInfo.apiKey);
-        }
-        lastProfileId = apiKeyInfo.profileId;
-      };
-
-      const advanceAuthProfile = async (): Promise<boolean> => {
-        if (lockedProfileId) {
-          return false;
-        }
-        let nextIndex = profileIndex + 1;
-        while (nextIndex < profileCandidates.length) {
-          const candidate = profileCandidates[nextIndex];
-          if (candidate && isProfileInCooldown(authStore, candidate)) {
-            nextIndex += 1;
-            continue;
-          }
-          try {
-            await applyApiKeyInfo(candidate);
-            profileIndex = nextIndex;
-            thinkLevel = initialThinkLevel;
-            attemptedThinking.clear();
-            return true;
-          } catch (err) {
-            if (candidate && candidate === lockedProfileId) {
-              throw err;
-            }
-            nextIndex += 1;
-          }
-        }
-        return false;
-      };
-
       try {
-        while (profileIndex < profileCandidates.length) {
-          const candidate = profileCandidates[profileIndex];
-          if (
-            candidate &&
-            candidate !== lockedProfileId &&
-            isProfileInCooldown(authStore, candidate)
-          ) {
-            profileIndex += 1;
-            continue;
-          }
-          await applyApiKeyInfo(profileCandidates[profileIndex]);
-          break;
-        }
-        if (profileIndex >= profileCandidates.length) {
-          throwAuthProfileFailover({ allInCooldown: true });
-        }
+        await applyApiKeyInfo(candidate);
+        profileIndex = nextIndex;
+        thinkLevel = initialThinkLevel;
+        attemptedThinking.clear();
+        return true;
       } catch (err) {
-        if (err instanceof FailoverError) {
+        if (candidate && candidate === lockedProfileId) {
           throw err;
         }
-        if (profileCandidates[profileIndex] === lockedProfileId) {
-          throwAuthProfileFailover({ allInCooldown: false, error: err });
-        }
-        const advanced = await advanceAuthProfile();
-        if (!advanced) {
-          throwAuthProfileFailover({ allInCooldown: false, error: err });
-        }
+        nextIndex += 1;
       }
+    }
+    return false;
+  };
 
-      const MAX_OVERFLOW_COMPACTION_ATTEMPTS = 3;
-      let overflowCompactionAttempts = 0;
-      let toolResultTruncationAttempted = false;
-      const usageAccumulator = createUsageAccumulator();
-      let autoCompactionCount = 0;
-      try {
-        while (true) {
-          attemptedThinking.add(thinkLevel);
-          await fs.mkdir(resolvedWorkspace, { recursive: true });
+  try {
+    while (profileIndex < profileCandidates.length) {
+      const candidate = profileCandidates[profileIndex];
+      if (candidate && candidate !== lockedProfileId && isProfileInCooldown(authStore, candidate)) {
+        profileIndex += 1;
+        continue;
+      }
+      await applyApiKeyInfo(profileCandidates[profileIndex]);
+      break;
+    }
+    if (profileIndex >= profileCandidates.length) {
+      throwAuthProfileFailover({ allInCooldown: true });
+    }
+  } catch (err) {
+    if (err instanceof FailoverError) {
+      throw err;
+    }
+    if (profileCandidates[profileIndex] === lockedProfileId) {
+      throwAuthProfileFailover({ allInCooldown: false, error: err });
+    }
+    const advanced = await advanceAuthProfile();
+    if (!advanced) {
+      throwAuthProfileFailover({ allInCooldown: false, error: err });
+    }
+  }
 
-          const prompt =
-            provider === "anthropic" ? scrubAnthropicRefusalMagic(params.prompt) : params.prompt;
+  const MAX_OVERFLOW_COMPACTION_ATTEMPTS = 3;
+  let overflowCompactionAttempts = 0;
+  let toolResultTruncationAttempted = false;
+  const usageAccumulator = createUsageAccumulator();
+  let autoCompactionCount = 0;
+  try {
+    while (true) {
+      attemptedThinking.add(thinkLevel);
+      await fs.mkdir(resolvedWorkspace, { recursive: true });
 
-          const attempt = await runEmbeddedAttempt({
+      const prompt =
+        provider === "anthropic" ? scrubAnthropicRefusalMagic(params.prompt) : params.prompt;
+
+      const attempt = await enqueueSession(() =>
+        enqueueGlobal(async () =>
+          runEmbeddedAttempt({
             sessionId: params.sessionId,
             sessionKey: params.sessionKey,
             messageChannel: params.messageChannel,
@@ -451,416 +445,422 @@ export async function runEmbeddedPiAgent(
             streamParams: params.streamParams,
             ownerNumbers: params.ownerNumbers,
             enforceFinalTag: params.enforceFinalTag,
-          });
+          }),
+        ),
+      );
 
-          const { aborted, promptError, timedOut, sessionIdUsed, lastAssistant } = attempt;
-          mergeUsageIntoAccumulator(
-            usageAccumulator,
-            attempt.attemptUsage ?? normalizeUsage(lastAssistant?.usage as UsageLike),
+      const { aborted, promptError, timedOut, sessionIdUsed, lastAssistant } = attempt;
+      mergeUsageIntoAccumulator(
+        usageAccumulator,
+        attempt.attemptUsage ?? normalizeUsage(lastAssistant?.usage as UsageLike),
+      );
+      autoCompactionCount += Math.max(0, attempt.compactionCount ?? 0);
+      const formattedAssistantErrorText = lastAssistant
+        ? formatAssistantErrorText(lastAssistant, {
+            cfg: params.config,
+            sessionKey: params.sessionKey ?? params.sessionId,
+          })
+        : undefined;
+      const assistantErrorText =
+        lastAssistant?.stopReason === "error"
+          ? lastAssistant.errorMessage?.trim() || formattedAssistantErrorText
+          : undefined;
+
+      const contextOverflowError = !aborted
+        ? (() => {
+            if (promptError) {
+              const errorText = describeUnknownError(promptError);
+              if (isContextOverflowError(errorText)) {
+                return { text: errorText, source: "promptError" as const };
+              }
+              // Prompt submission failed with a non-overflow error. Do not
+              // inspect prior assistant errors from history for this attempt.
+              return null;
+            }
+            if (assistantErrorText && isContextOverflowError(assistantErrorText)) {
+              return { text: assistantErrorText, source: "assistantError" as const };
+            }
+            return null;
+          })()
+        : null;
+
+      if (contextOverflowError) {
+        const errorText = contextOverflowError.text;
+        const msgCount = attempt.messagesSnapshot?.length ?? 0;
+        log.warn(
+          `[context-overflow-diag] sessionKey=${params.sessionKey ?? params.sessionId} ` +
+            `provider=${provider}/${modelId} source=${contextOverflowError.source} ` +
+            `messages=${msgCount} sessionFile=${params.sessionFile} ` +
+            `compactionAttempts=${overflowCompactionAttempts} error=${errorText.slice(0, 200)}`,
+        );
+        const isCompactionFailure = isCompactionFailureError(errorText);
+        // Attempt auto-compaction on context overflow (not compaction_failure)
+        if (
+          !isCompactionFailure &&
+          (attempt.compactionCount ?? 0) === 0 &&
+          overflowCompactionAttempts < MAX_OVERFLOW_COMPACTION_ATTEMPTS
+        ) {
+          overflowCompactionAttempts++;
+          log.warn(
+            `context overflow detected (attempt ${overflowCompactionAttempts}/${MAX_OVERFLOW_COMPACTION_ATTEMPTS}); attempting auto-compaction for ${provider}/${modelId}`,
           );
-          autoCompactionCount += Math.max(0, attempt.compactionCount ?? 0);
-          const formattedAssistantErrorText = lastAssistant
-            ? formatAssistantErrorText(lastAssistant, {
-                cfg: params.config,
-                sessionKey: params.sessionKey ?? params.sessionId,
-              })
-            : undefined;
-          const assistantErrorText =
-            lastAssistant?.stopReason === "error"
-              ? lastAssistant.errorMessage?.trim() || formattedAssistantErrorText
-              : undefined;
-
-          const contextOverflowError = !aborted
-            ? (() => {
-                if (promptError) {
-                  const errorText = describeUnknownError(promptError);
-                  if (isContextOverflowError(errorText)) {
-                    return { text: errorText, source: "promptError" as const };
-                  }
-                  // Prompt submission failed with a non-overflow error. Do not
-                  // inspect prior assistant errors from history for this attempt.
-                  return null;
-                }
-                if (assistantErrorText && isContextOverflowError(assistantErrorText)) {
-                  return { text: assistantErrorText, source: "assistantError" as const };
-                }
-                return null;
-              })()
-            : null;
-
-          if (contextOverflowError) {
-            const errorText = contextOverflowError.text;
-            const msgCount = attempt.messagesSnapshot?.length ?? 0;
-            log.warn(
-              `[context-overflow-diag] sessionKey=${params.sessionKey ?? params.sessionId} ` +
-                `provider=${provider}/${modelId} source=${contextOverflowError.source} ` +
-                `messages=${msgCount} sessionFile=${params.sessionFile} ` +
-                `compactionAttempts=${overflowCompactionAttempts} error=${errorText.slice(0, 200)}`,
-            );
-            const isCompactionFailure = isCompactionFailureError(errorText);
-            // Attempt auto-compaction on context overflow (not compaction_failure)
-            if (
-              !isCompactionFailure &&
-              overflowCompactionAttempts < MAX_OVERFLOW_COMPACTION_ATTEMPTS
-            ) {
-              overflowCompactionAttempts++;
-              log.warn(
-                `context overflow detected (attempt ${overflowCompactionAttempts}/${MAX_OVERFLOW_COMPACTION_ATTEMPTS}); attempting auto-compaction for ${provider}/${modelId}`,
-              );
-              const compactResult = await compactEmbeddedPiSessionDirect({
-                sessionId: params.sessionId,
-                sessionKey: params.sessionKey,
-                messageChannel: params.messageChannel,
-                messageProvider: params.messageProvider,
-                agentAccountId: params.agentAccountId,
-                authProfileId: lastProfileId,
-                sessionFile: params.sessionFile,
-                workspaceDir: resolvedWorkspace,
-                agentDir,
-                config: params.config,
-                skillsSnapshot: params.skillsSnapshot,
-                senderIsOwner: params.senderIsOwner,
-                provider,
-                model: modelId,
-                thinkLevel,
-                reasoningLevel: params.reasoningLevel,
-                bashElevated: params.bashElevated,
-                extraSystemPrompt: params.extraSystemPrompt,
-                ownerNumbers: params.ownerNumbers,
-              });
-              if (compactResult.compacted) {
-                autoCompactionCount += 1;
-                log.info(`auto-compaction succeeded for ${provider}/${modelId}; retrying prompt`);
-                continue;
-              }
-              log.warn(
-                `auto-compaction failed for ${provider}/${modelId}: ${compactResult.reason ?? "nothing to compact"}`,
-              );
-            }
-            // Fallback: try truncating oversized tool results in the session.
-            // This handles the case where a single tool result exceeds the
-            // context window and compaction cannot reduce it further.
-            if (!toolResultTruncationAttempted) {
-              const contextWindowTokens = ctxInfo.tokens;
-              const hasOversized = attempt.messagesSnapshot
-                ? sessionLikelyHasOversizedToolResults({
-                    messages: attempt.messagesSnapshot,
-                    contextWindowTokens,
-                  })
-                : false;
-
-              if (hasOversized) {
-                toolResultTruncationAttempted = true;
-                log.warn(
-                  `[context-overflow-recovery] Attempting tool result truncation for ${provider}/${modelId} ` +
-                    `(contextWindow=${contextWindowTokens} tokens)`,
-                );
-                const truncResult = await truncateOversizedToolResultsInSession({
-                  sessionFile: params.sessionFile,
-                  contextWindowTokens,
-                  sessionId: params.sessionId,
-                  sessionKey: params.sessionKey,
-                });
-                if (truncResult.truncated) {
-                  log.info(
-                    `[context-overflow-recovery] Truncated ${truncResult.truncatedCount} tool result(s); retrying prompt`,
-                  );
-                  // Session is now smaller; allow compaction retries again.
-                  overflowCompactionAttempts = 0;
-                  continue;
-                }
-                log.warn(
-                  `[context-overflow-recovery] Tool result truncation did not help: ${truncResult.reason ?? "unknown"}`,
-                );
-              }
-            }
-            const kind = isCompactionFailure ? "compaction_failure" : "context_overflow";
-            return {
-              payloads: [
-                {
-                  text:
-                    "Context overflow: prompt too large for the model. " +
-                    "Try again with less input or a larger-context model.",
-                  isError: true,
-                },
-              ],
-              meta: {
-                durationMs: Date.now() - started,
-                agentMeta: {
-                  sessionId: sessionIdUsed,
-                  provider,
-                  model: model.id,
-                },
-                systemPromptReport: attempt.systemPromptReport,
-                error: { kind, message: errorText },
-              },
-            };
-          }
-
-          if (promptError && !aborted) {
-            const errorText = describeUnknownError(promptError);
-            // Handle role ordering errors with a user-friendly message
-            if (/incorrect role information|roles must alternate/i.test(errorText)) {
-              return {
-                payloads: [
-                  {
-                    text:
-                      "Message ordering conflict - please try again. " +
-                      "If this persists, use /new to start a fresh session.",
-                    isError: true,
-                  },
-                ],
-                meta: {
-                  durationMs: Date.now() - started,
-                  agentMeta: {
-                    sessionId: sessionIdUsed,
-                    provider,
-                    model: model.id,
-                  },
-                  systemPromptReport: attempt.systemPromptReport,
-                  error: { kind: "role_ordering", message: errorText },
-                },
-              };
-            }
-            // Handle image size errors with a user-friendly message (no retry needed)
-            const imageSizeError = parseImageSizeError(errorText);
-            if (imageSizeError) {
-              const maxMb = imageSizeError.maxMb;
-              const maxMbLabel =
-                typeof maxMb === "number" && Number.isFinite(maxMb) ? `${maxMb}` : null;
-              const maxBytesHint = maxMbLabel ? ` (max ${maxMbLabel}MB)` : "";
-              return {
-                payloads: [
-                  {
-                    text:
-                      `Image too large for the model${maxBytesHint}. ` +
-                      "Please compress or resize the image and try again.",
-                    isError: true,
-                  },
-                ],
-                meta: {
-                  durationMs: Date.now() - started,
-                  agentMeta: {
-                    sessionId: sessionIdUsed,
-                    provider,
-                    model: model.id,
-                  },
-                  systemPromptReport: attempt.systemPromptReport,
-                  error: { kind: "image_size", message: errorText },
-                },
-              };
-            }
-            const promptFailoverReason = classifyFailoverReason(errorText);
-            if (promptFailoverReason && promptFailoverReason !== "timeout" && lastProfileId) {
-              await markAuthProfileFailure({
-                store: authStore,
-                profileId: lastProfileId,
-                reason: promptFailoverReason,
-                cfg: params.config,
-                agentDir: params.agentDir,
-              });
-            }
-            if (
-              isFailoverErrorMessage(errorText) &&
-              promptFailoverReason !== "timeout" &&
-              (await advanceAuthProfile())
-            ) {
-              continue;
-            }
-            const fallbackThinking = pickFallbackThinkingLevel({
-              message: errorText,
-              attempted: attemptedThinking,
-            });
-            if (fallbackThinking) {
-              log.warn(
-                `unsupported thinking level for ${provider}/${modelId}; retrying with ${fallbackThinking}`,
-              );
-              thinkLevel = fallbackThinking;
-              continue;
-            }
-            // FIX: Throw FailoverError for prompt errors when fallbacks configured
-            // This enables model fallback for quota/rate limit errors during prompt submission
-            if (fallbackConfigured && isFailoverErrorMessage(errorText)) {
-              throw new FailoverError(errorText, {
-                reason: promptFailoverReason ?? "unknown",
-                provider,
-                model: modelId,
-                profileId: lastProfileId,
-                status: resolveFailoverStatus(promptFailoverReason ?? "unknown"),
-              });
-            }
-            throw promptError;
-          }
-
-          const fallbackThinking = pickFallbackThinkingLevel({
-            message: lastAssistant?.errorMessage,
-            attempted: attemptedThinking,
-          });
-          if (fallbackThinking && !aborted) {
-            log.warn(
-              `unsupported thinking level for ${provider}/${modelId}; retrying with ${fallbackThinking}`,
-            );
-            thinkLevel = fallbackThinking;
+          const compactResult = await enqueueSession(() =>
+            compactEmbeddedPiSessionDirect({
+              sessionId: params.sessionId,
+              sessionKey: params.sessionKey,
+              messageChannel: params.messageChannel,
+              messageProvider: params.messageProvider,
+              agentAccountId: params.agentAccountId,
+              authProfileId: lastProfileId,
+              sessionFile: params.sessionFile,
+              workspaceDir: resolvedWorkspace,
+              agentDir,
+              config: params.config,
+              skillsSnapshot: params.skillsSnapshot,
+              skipSkillEnvOverrides: true,
+              senderIsOwner: params.senderIsOwner,
+              provider,
+              model: modelId,
+              thinkLevel,
+              reasoningLevel: params.reasoningLevel,
+              bashElevated: params.bashElevated,
+              extraSystemPrompt: params.extraSystemPrompt,
+              ownerNumbers: params.ownerNumbers,
+            }),
+          );
+          if (compactResult.compacted) {
+            autoCompactionCount += 1;
+            log.info(`auto-compaction succeeded for ${provider}/${modelId}; retrying prompt`);
             continue;
           }
+          log.warn(
+            `auto-compaction failed for ${provider}/${modelId}: ${compactResult.reason ?? "nothing to compact"}`,
+          );
+        }
+        // Fallback: try truncating oversized tool results in the session.
+        // This handles the case where a single tool result exceeds the
+        // context window and compaction cannot reduce it further.
+        if (!toolResultTruncationAttempted) {
+          const contextWindowTokens = ctxInfo.tokens;
+          const hasOversized = attempt.messagesSnapshot
+            ? sessionLikelyHasOversizedToolResults({
+                messages: attempt.messagesSnapshot,
+                contextWindowTokens,
+              })
+            : false;
 
-          const authFailure = isAuthAssistantError(lastAssistant);
-          const rateLimitFailure = isRateLimitAssistantError(lastAssistant);
-          const billingFailure = isBillingAssistantError(lastAssistant);
-          const failoverFailure = isFailoverAssistantError(lastAssistant);
-          const assistantFailoverReason = classifyFailoverReason(lastAssistant?.errorMessage ?? "");
-          const cloudCodeAssistFormatError = attempt.cloudCodeAssistFormatError;
-          const imageDimensionError = parseImageDimensionError(lastAssistant?.errorMessage ?? "");
-
-          if (imageDimensionError && lastProfileId) {
-            const details = [
-              imageDimensionError.messageIndex !== undefined
-                ? `message=${imageDimensionError.messageIndex}`
-                : null,
-              imageDimensionError.contentIndex !== undefined
-                ? `content=${imageDimensionError.contentIndex}`
-                : null,
-              imageDimensionError.maxDimensionPx !== undefined
-                ? `limit=${imageDimensionError.maxDimensionPx}px`
-                : null,
-            ]
-              .filter(Boolean)
-              .join(" ");
+          if (hasOversized) {
+            toolResultTruncationAttempted = true;
             log.warn(
-              `Profile ${lastProfileId} rejected image payload${details ? ` (${details})` : ""}.`,
+              `[context-overflow-recovery] Attempting tool result truncation for ${provider}/${modelId} ` +
+                `(contextWindow=${contextWindowTokens} tokens)`,
             );
-          }
-
-          // Treat timeout as potential rate limit (Antigravity hangs on rate limit)
-          const shouldRotate = (!aborted && failoverFailure) || timedOut;
-
-          if (shouldRotate) {
-            if (lastProfileId) {
-              const reason =
-                timedOut || assistantFailoverReason === "timeout"
-                  ? "timeout"
-                  : (assistantFailoverReason ?? "unknown");
-              await markAuthProfileFailure({
-                store: authStore,
-                profileId: lastProfileId,
-                reason,
-                cfg: params.config,
-                agentDir: params.agentDir,
-              });
-              if (timedOut && !isProbeSession) {
-                log.warn(
-                  `Profile ${lastProfileId} timed out (possible rate limit). Trying next account...`,
-                );
-              }
-              if (cloudCodeAssistFormatError) {
-                log.warn(
-                  `Profile ${lastProfileId} hit Cloud Code Assist format error. Tool calls will be sanitized on retry.`,
-                );
-              }
-            }
-
-            const rotated = await advanceAuthProfile();
-            if (rotated) {
+            const truncResult = await enqueueSession(() =>
+              truncateOversizedToolResultsInSession({
+                sessionFile: params.sessionFile,
+                contextWindowTokens,
+                sessionId: params.sessionId,
+                sessionKey: params.sessionKey,
+              }),
+            );
+            if (truncResult.truncated) {
+              log.info(
+                `[context-overflow-recovery] Truncated ${truncResult.truncatedCount} tool result(s); retrying prompt`,
+              );
+              // Session is now smaller; allow compaction retries again.
+              overflowCompactionAttempts = 0;
               continue;
             }
-
-            if (fallbackConfigured) {
-              // Prefer formatted error message (user-friendly) over raw errorMessage
-              const message =
-                (lastAssistant
-                  ? formatAssistantErrorText(lastAssistant, {
-                      cfg: params.config,
-                      sessionKey: params.sessionKey ?? params.sessionId,
-                    })
-                  : undefined) ||
-                lastAssistant?.errorMessage?.trim() ||
-                (timedOut
-                  ? "LLM request timed out."
-                  : rateLimitFailure
-                    ? "LLM request rate limited."
-                    : billingFailure
-                      ? BILLING_ERROR_USER_MESSAGE
-                      : authFailure
-                        ? "LLM request unauthorized."
-                        : "LLM request failed.");
-              const status =
-                resolveFailoverStatus(assistantFailoverReason ?? "unknown") ??
-                (isTimeoutErrorMessage(message) ? 408 : undefined);
-              throw new FailoverError(message, {
-                reason: assistantFailoverReason ?? "unknown",
-                provider,
-                model: modelId,
-                profileId: lastProfileId,
-                status,
-              });
-            }
+            log.warn(
+              `[context-overflow-recovery] Tool result truncation did not help: ${truncResult.reason ?? "unknown"}`,
+            );
           }
-
-          const usage = toNormalizedUsage(usageAccumulator);
-          const agentMeta: EmbeddedPiAgentMeta = {
-            sessionId: sessionIdUsed,
-            provider: lastAssistant?.provider ?? provider,
-            model: lastAssistant?.model ?? model.id,
-            usage,
-            compactionCount: autoCompactionCount > 0 ? autoCompactionCount : undefined,
-          };
-
-          const payloads = buildEmbeddedRunPayloads({
-            assistantTexts: attempt.assistantTexts,
-            toolMetas: attempt.toolMetas,
-            lastAssistant: attempt.lastAssistant,
-            lastToolError: attempt.lastToolError,
-            config: params.config,
-            sessionKey: params.sessionKey ?? params.sessionId,
-            verboseLevel: params.verboseLevel,
-            reasoningLevel: params.reasoningLevel,
-            toolResultFormat: resolvedToolResultFormat,
-            inlineToolResultsAllowed: false,
-          });
-
-          log.debug(
-            `embedded run done: runId=${params.runId} sessionId=${params.sessionId} durationMs=${Date.now() - started} aborted=${aborted}`,
-          );
-          if (lastProfileId) {
-            await markAuthProfileGood({
-              store: authStore,
+        }
+        const kind = isCompactionFailure ? "compaction_failure" : "context_overflow";
+        return {
+          payloads: [
+            {
+              text:
+                "Context overflow: prompt too large for the model. " +
+                "Try again with less input or a larger-context model.",
+              isError: true,
+            },
+          ],
+          meta: {
+            durationMs: Date.now() - started,
+            agentMeta: {
+              sessionId: sessionIdUsed,
               provider,
-              profileId: lastProfileId,
-              agentDir: params.agentDir,
-            });
-            await markAuthProfileUsed({
-              store: authStore,
-              profileId: lastProfileId,
-              agentDir: params.agentDir,
-            });
-          }
+              model: model.id,
+            },
+            systemPromptReport: attempt.systemPromptReport,
+            error: { kind, message: errorText },
+          },
+        };
+      }
+
+      if (promptError && !aborted) {
+        const errorText = describeUnknownError(promptError);
+        // Handle role ordering errors with a user-friendly message
+        if (/incorrect role information|roles must alternate/i.test(errorText)) {
           return {
-            payloads: payloads.length ? payloads : undefined,
+            payloads: [
+              {
+                text:
+                  "Message ordering conflict - please try again. " +
+                  "If this persists, use /new to start a fresh session.",
+                isError: true,
+              },
+            ],
             meta: {
               durationMs: Date.now() - started,
-              agentMeta,
-              aborted,
+              agentMeta: {
+                sessionId: sessionIdUsed,
+                provider,
+                model: model.id,
+              },
               systemPromptReport: attempt.systemPromptReport,
-              // Handle client tool calls (OpenResponses hosted tools)
-              stopReason: attempt.clientToolCall ? "tool_calls" : undefined,
-              pendingToolCalls: attempt.clientToolCall
-                ? [
-                    {
-                      id: `call_${Date.now()}`,
-                      name: attempt.clientToolCall.name,
-                      arguments: JSON.stringify(attempt.clientToolCall.params),
-                    },
-                  ]
-                : undefined,
+              error: { kind: "role_ordering", message: errorText },
             },
-            didSendViaMessagingTool: attempt.didSendViaMessagingTool,
-            messagingToolSentTexts: attempt.messagingToolSentTexts,
-            messagingToolSentTargets: attempt.messagingToolSentTargets,
           };
         }
-      } finally {
-        process.chdir(prevCwd);
+        // Handle image size errors with a user-friendly message (no retry needed)
+        const imageSizeError = parseImageSizeError(errorText);
+        if (imageSizeError) {
+          const maxMb = imageSizeError.maxMb;
+          const maxMbLabel =
+            typeof maxMb === "number" && Number.isFinite(maxMb) ? `${maxMb}` : null;
+          const maxBytesHint = maxMbLabel ? ` (max ${maxMbLabel}MB)` : "";
+          return {
+            payloads: [
+              {
+                text:
+                  `Image too large for the model${maxBytesHint}. ` +
+                  "Please compress or resize the image and try again.",
+                isError: true,
+              },
+            ],
+            meta: {
+              durationMs: Date.now() - started,
+              agentMeta: {
+                sessionId: sessionIdUsed,
+                provider,
+                model: model.id,
+              },
+              systemPromptReport: attempt.systemPromptReport,
+              error: { kind: "image_size", message: errorText },
+            },
+          };
+        }
+        const promptFailoverReason = classifyFailoverReason(errorText);
+        if (promptFailoverReason && promptFailoverReason !== "timeout" && lastProfileId) {
+          await markAuthProfileFailure({
+            store: authStore,
+            profileId: lastProfileId,
+            reason: promptFailoverReason,
+            cfg: params.config,
+            agentDir: params.agentDir,
+          });
+        }
+        if (
+          isFailoverErrorMessage(errorText) &&
+          promptFailoverReason !== "timeout" &&
+          (await advanceAuthProfile())
+        ) {
+          continue;
+        }
+        const fallbackThinking = pickFallbackThinkingLevel({
+          message: errorText,
+          attempted: attemptedThinking,
+        });
+        if (fallbackThinking) {
+          log.warn(
+            `unsupported thinking level for ${provider}/${modelId}; retrying with ${fallbackThinking}`,
+          );
+          thinkLevel = fallbackThinking;
+          continue;
+        }
+        // FIX: Throw FailoverError for prompt errors when fallbacks configured
+        // This enables model fallback for quota/rate limit errors during prompt submission
+        if (fallbackConfigured && isFailoverErrorMessage(errorText)) {
+          throw new FailoverError(errorText, {
+            reason: promptFailoverReason ?? "unknown",
+            provider,
+            model: modelId,
+            profileId: lastProfileId,
+            status: resolveFailoverStatus(promptFailoverReason ?? "unknown"),
+          });
+        }
+        throw promptError;
       }
-    }),
-  );
+
+      const fallbackThinking = pickFallbackThinkingLevel({
+        message: lastAssistant?.errorMessage,
+        attempted: attemptedThinking,
+      });
+      if (fallbackThinking && !aborted) {
+        log.warn(
+          `unsupported thinking level for ${provider}/${modelId}; retrying with ${fallbackThinking}`,
+        );
+        thinkLevel = fallbackThinking;
+        continue;
+      }
+
+      const authFailure = isAuthAssistantError(lastAssistant);
+      const rateLimitFailure = isRateLimitAssistantError(lastAssistant);
+      const billingFailure = isBillingAssistantError(lastAssistant);
+      const failoverFailure = isFailoverAssistantError(lastAssistant);
+      const assistantFailoverReason = classifyFailoverReason(lastAssistant?.errorMessage ?? "");
+      const cloudCodeAssistFormatError = attempt.cloudCodeAssistFormatError;
+      const imageDimensionError = parseImageDimensionError(lastAssistant?.errorMessage ?? "");
+
+      if (imageDimensionError && lastProfileId) {
+        const details = [
+          imageDimensionError.messageIndex !== undefined
+            ? `message=${imageDimensionError.messageIndex}`
+            : null,
+          imageDimensionError.contentIndex !== undefined
+            ? `content=${imageDimensionError.contentIndex}`
+            : null,
+          imageDimensionError.maxDimensionPx !== undefined
+            ? `limit=${imageDimensionError.maxDimensionPx}px`
+            : null,
+        ]
+          .filter(Boolean)
+          .join(" ");
+        log.warn(
+          `Profile ${lastProfileId} rejected image payload${details ? ` (${details})` : ""}.`,
+        );
+      }
+
+      // Treat timeout as potential rate limit (Antigravity hangs on rate limit)
+      const shouldRotate = (!aborted && failoverFailure) || timedOut;
+
+      if (shouldRotate) {
+        if (lastProfileId) {
+          const reason =
+            timedOut || assistantFailoverReason === "timeout"
+              ? "timeout"
+              : (assistantFailoverReason ?? "unknown");
+          await markAuthProfileFailure({
+            store: authStore,
+            profileId: lastProfileId,
+            reason,
+            cfg: params.config,
+            agentDir: params.agentDir,
+          });
+          if (timedOut && !isProbeSession) {
+            log.warn(
+              `Profile ${lastProfileId} timed out (possible rate limit). Trying next account...`,
+            );
+          }
+          if (cloudCodeAssistFormatError) {
+            log.warn(
+              `Profile ${lastProfileId} hit Cloud Code Assist format error. Tool calls will be sanitized on retry.`,
+            );
+          }
+        }
+
+        const rotated = await advanceAuthProfile();
+        if (rotated) {
+          continue;
+        }
+
+        if (fallbackConfigured) {
+          // Prefer formatted error message (user-friendly) over raw errorMessage
+          const message =
+            (lastAssistant
+              ? formatAssistantErrorText(lastAssistant, {
+                  cfg: params.config,
+                  sessionKey: params.sessionKey ?? params.sessionId,
+                })
+              : undefined) ||
+            lastAssistant?.errorMessage?.trim() ||
+            (timedOut
+              ? "LLM request timed out."
+              : rateLimitFailure
+                ? "LLM request rate limited."
+                : billingFailure
+                  ? BILLING_ERROR_USER_MESSAGE
+                  : authFailure
+                    ? "LLM request unauthorized."
+                    : "LLM request failed.");
+          const status =
+            resolveFailoverStatus(assistantFailoverReason ?? "unknown") ??
+            (isTimeoutErrorMessage(message) ? 408 : undefined);
+          throw new FailoverError(message, {
+            reason: assistantFailoverReason ?? "unknown",
+            provider,
+            model: modelId,
+            profileId: lastProfileId,
+            status,
+          });
+        }
+      }
+
+      const usage = toNormalizedUsage(usageAccumulator);
+      const agentMeta: EmbeddedPiAgentMeta = {
+        sessionId: sessionIdUsed,
+        provider: lastAssistant?.provider ?? provider,
+        model: lastAssistant?.model ?? model.id,
+        usage,
+        compactionCount: autoCompactionCount > 0 ? autoCompactionCount : undefined,
+      };
+
+      const payloads = buildEmbeddedRunPayloads({
+        assistantTexts: attempt.assistantTexts,
+        toolMetas: attempt.toolMetas,
+        lastAssistant: attempt.lastAssistant,
+        lastToolError: attempt.lastToolError,
+        config: params.config,
+        sessionKey: params.sessionKey ?? params.sessionId,
+        verboseLevel: params.verboseLevel,
+        reasoningLevel: params.reasoningLevel,
+        toolResultFormat: resolvedToolResultFormat,
+        inlineToolResultsAllowed: false,
+      });
+
+      log.debug(
+        `embedded run done: runId=${params.runId} sessionId=${params.sessionId} durationMs=${Date.now() - started} aborted=${aborted}`,
+      );
+      if (lastProfileId) {
+        await markAuthProfileGood({
+          store: authStore,
+          provider,
+          profileId: lastProfileId,
+          agentDir: params.agentDir,
+        });
+        await markAuthProfileUsed({
+          store: authStore,
+          profileId: lastProfileId,
+          agentDir: params.agentDir,
+        });
+      }
+      return {
+        payloads: payloads.length ? payloads : undefined,
+        meta: {
+          durationMs: Date.now() - started,
+          agentMeta,
+          aborted,
+          systemPromptReport: attempt.systemPromptReport,
+          // Handle client tool calls (OpenResponses hosted tools)
+          stopReason: attempt.clientToolCall ? "tool_calls" : undefined,
+          pendingToolCalls: attempt.clientToolCall
+            ? [
+                {
+                  id: `call_${Date.now()}`,
+                  name: attempt.clientToolCall.name,
+                  arguments: JSON.stringify(attempt.clientToolCall.params),
+                },
+              ]
+            : undefined,
+        },
+        didSendViaMessagingTool: attempt.didSendViaMessagingTool,
+        messagingToolSentTexts: attempt.messagingToolSentTexts,
+        messagingToolSentTargets: attempt.messagingToolSentTargets,
+      };
+    }
+  } finally {
+    process.chdir(prevCwd);
+  }
 }

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -450,10 +450,9 @@ export async function runEmbeddedPiAgent(
       );
 
       const { aborted, promptError, timedOut, sessionIdUsed, lastAssistant } = attempt;
-      mergeUsageIntoAccumulator(
-        usageAccumulator,
-        attempt.attemptUsage ?? normalizeUsage(lastAssistant?.usage as UsageLike),
-      );
+      const lastAssistantUsage =
+        attempt.lastAssistantUsage ?? normalizeUsage(lastAssistant?.usage as UsageLike);
+      mergeUsageIntoAccumulator(usageAccumulator, attempt.attemptUsage ?? lastAssistantUsage);
       autoCompactionCount += Math.max(0, attempt.compactionCount ?? 0);
       const formattedAssistantErrorText = lastAssistant
         ? formatAssistantErrorText(lastAssistant, {
@@ -804,6 +803,7 @@ export async function runEmbeddedPiAgent(
         provider: lastAssistant?.provider ?? provider,
         model: lastAssistant?.model ?? model.id,
         usage,
+        promptUsage: lastAssistantUsage,
         compactionCount: autoCompactionCount > 0 ? autoCompactionCount : undefined,
       };
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -87,6 +87,7 @@ import {
 } from "../system-prompt.js";
 import { splitSdkTools } from "../tool-split.js";
 import { describeUnknownError, mapThinkingLevel } from "../utils.js";
+import { createAutoCompactionRetryHook } from "./auto-compaction-retry-hook.js";
 import { detectAndLoadPromptImages } from "./images.js";
 
 export function injectHistoryImagesIntoMessages(
@@ -400,6 +401,35 @@ export async function runEmbeddedAttempt(
     const systemPromptOverride = createSystemPromptOverride(appendPrompt);
     const systemPromptText = systemPromptOverride();
 
+    // Slim retry prompt for Pi-internal auto-compaction retry. Key difference: no injected workspace files.
+    const retrySystemPromptText = buildEmbeddedSystemPrompt({
+      workspaceDir: effectiveWorkspace,
+      defaultThinkLevel: params.thinkLevel,
+      reasoningLevel: params.reasoningLevel ?? "off",
+      extraSystemPrompt: params.extraSystemPrompt,
+      ownerNumbers: params.ownerNumbers,
+      reasoningTagHint,
+      heartbeatPrompt: isDefaultAgent
+        ? resolveHeartbeatPrompt(params.config?.agents?.defaults?.heartbeat?.prompt)
+        : undefined,
+      skillsPrompt,
+      docsPath: docsPath ?? undefined,
+      ttsHint,
+      workspaceNotes,
+      reactionGuidance,
+      promptMode: "minimal",
+      runtimeInfo,
+      messageToolHints,
+      sandboxInfo,
+      tools,
+      modelAliasLines: buildModelAliasLines(params.config),
+      userTimezone,
+      userTime,
+      userTimeFormat,
+      contextFiles: [],
+      memoryCitationsMode: params.config?.memory?.citations,
+    });
+
     const sessionLock = await acquireSessionWriteLock({
       sessionFile: params.sessionFile,
     });
@@ -492,6 +522,22 @@ export async function runEmbeddedAttempt(
         throw new Error("Embedded agent session missing");
       }
       const activeSession = session;
+
+      // Prevent compaction cascades: if Pi compacts due to overflow and retries internally,
+      // downgrade the system prompt (drop injected workspace files) when needed to fit.
+      const autoCompactionRetryHook = createAutoCompactionRetryHook({
+        retrySystemPrompt: retrySystemPromptText,
+        onDowngradeSystemPrompt: () =>
+          applySystemPromptOverrideToSession(activeSession, retrySystemPromptText),
+        logger: log,
+        logPrefix: `runId=${params.runId} sessionId=${params.sessionId}`,
+      });
+      (
+        activeSession as {
+          setAutoCompactionRetryHook?: (hook: typeof autoCompactionRetryHook) => void;
+        }
+      ).setAutoCompactionRetryHook?.(autoCompactionRetryHook);
+
       const cacheTrace = createCacheTrace({
         cfg: params.config,
         env: process.env,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -697,6 +697,7 @@ export async function runEmbeddedAttempt(
         didSendViaMessagingTool,
         getLastToolError,
         getUsageTotals,
+        getLastAssistantUsage,
         getCompactionCount,
       } = subscription;
 
@@ -956,6 +957,7 @@ export async function runEmbeddedAttempt(
         cloudCodeAssistFormatError: Boolean(
           lastAssistant?.errorMessage && isCloudCodeAssistFormatError(lastAssistant.errorMessage),
         ),
+        lastAssistantUsage: getLastAssistantUsage(),
         attemptUsage: getUsageTotals(),
         compactionCount: getCompactionCount(),
         // Client tool call detected (OpenResponses hosted tools)

--- a/src/agents/pi-embedded-runner/run/auto-compaction-retry-hook.test.ts
+++ b/src/agents/pi-embedded-runner/run/auto-compaction-retry-hook.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from "vitest";
+import { createAutoCompactionRetryHook } from "./auto-compaction-retry-hook.js";
+
+describe("createAutoCompactionRetryHook", () => {
+  it("proceeds without changes when the full prompt fits", () => {
+    const warn = vi.fn();
+    const hook = createAutoCompactionRetryHook({
+      retrySystemPrompt: "SLIM",
+      onDowngradeSystemPrompt: vi.fn(),
+      logger: { warn },
+      logPrefix: "t",
+    });
+
+    const decision = hook({
+      estimates: {
+        messageTokens: 100,
+        systemPromptTokens: 100,
+        totalTokens: 200,
+        tokenBudget: 250,
+        overBy: 0,
+      },
+    });
+
+    expect(decision).toEqual({ action: "proceed" });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("downgrades the prompt when needed and the retry prompt fits", () => {
+    const warn = vi.fn();
+    const onDowngradeSystemPrompt = vi.fn();
+    const retrySystemPrompt = "x".repeat(400); // ~100 tokens
+    const hook = createAutoCompactionRetryHook({
+      retrySystemPrompt,
+      onDowngradeSystemPrompt,
+      logger: { warn },
+      logPrefix: "t",
+    });
+
+    const decision = hook({
+      estimates: {
+        messageTokens: 100,
+        systemPromptTokens: 500,
+        totalTokens: 600,
+        tokenBudget: 250,
+        overBy: 350,
+      },
+    });
+
+    expect(onDowngradeSystemPrompt).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(decision).toEqual({ action: "proceed", systemPrompt: retrySystemPrompt });
+  });
+
+  it("cancels retry when even the slim prompt cannot fit", () => {
+    const warn = vi.fn();
+    const onDowngradeSystemPrompt = vi.fn();
+    const retrySystemPrompt = "x".repeat(400); // ~100 tokens
+    const hook = createAutoCompactionRetryHook({
+      retrySystemPrompt,
+      onDowngradeSystemPrompt,
+      logger: { warn },
+      logPrefix: "t",
+    });
+
+    const decision = hook({
+      estimates: {
+        messageTokens: 500,
+        systemPromptTokens: 500,
+        totalTokens: 1000,
+        tokenBudget: 250,
+        overBy: 750,
+      },
+    });
+
+    expect(onDowngradeSystemPrompt).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(decision.action).toBe("cancel");
+    if (decision.action !== "cancel") {
+      throw new Error("expected cancel");
+    }
+    expect(decision.errorMessage).toContain("Auto-compaction succeeded");
+  });
+});

--- a/src/agents/pi-embedded-runner/run/auto-compaction-retry-hook.ts
+++ b/src/agents/pi-embedded-runner/run/auto-compaction-retry-hook.ts
@@ -1,0 +1,60 @@
+export type AutoCompactionRetryHookResult =
+  | { action: "proceed" }
+  | { action: "proceed"; systemPrompt: string }
+  | { action: "cancel"; errorMessage: string };
+
+export type AutoCompactionRetryHookContextLike = {
+  estimates: {
+    messageTokens: number;
+    systemPromptTokens: number;
+    totalTokens: number;
+    tokenBudget: number;
+    overBy: number;
+  };
+};
+
+type LoggerLike = {
+  warn: (message: string) => void;
+};
+
+export function createAutoCompactionRetryHook(params: {
+  retrySystemPrompt: string;
+  onDowngradeSystemPrompt: () => void;
+  logger: LoggerLike;
+  logPrefix: string;
+}): (ctx: AutoCompactionRetryHookContextLike) => AutoCompactionRetryHookResult {
+  const retrySystemPrompt = params.retrySystemPrompt.trim();
+  const retrySystemPromptTokens = Math.ceil(retrySystemPrompt.length / 4);
+
+  const cancelMessage =
+    "Auto-compaction succeeded, but retry would still overflow due to system prompt size. " +
+    "Try a larger-context model or reduce injected workspace files.";
+
+  return (ctx) => {
+    // Fits already: keep the full system prompt.
+    if (ctx.estimates.totalTokens <= ctx.estimates.tokenBudget) {
+      return { action: "proceed" };
+    }
+
+    const totalSlim = ctx.estimates.messageTokens + retrySystemPromptTokens;
+    if (totalSlim <= ctx.estimates.tokenBudget) {
+      params.logger.warn(
+        `${params.logPrefix} auto-compaction retry prompt downgraded: ` +
+          `overBy=${ctx.estimates.overBy} tokenBudget=${ctx.estimates.tokenBudget} ` +
+          `messageTokens=${ctx.estimates.messageTokens} ` +
+          `systemPromptTokens=${ctx.estimates.systemPromptTokens} ` +
+          `retrySystemPromptTokens=${retrySystemPromptTokens}`,
+      );
+      params.onDowngradeSystemPrompt();
+      return { action: "proceed", systemPrompt: retrySystemPrompt };
+    }
+
+    params.logger.warn(
+      `${params.logPrefix} auto-compaction retry blocked: ` +
+        `stillOverBy=${Math.max(0, totalSlim - ctx.estimates.tokenBudget)} ` +
+        `tokenBudget=${ctx.estimates.tokenBudget} messageTokens=${ctx.estimates.messageTokens} ` +
+        `retrySystemPromptTokens=${retrySystemPromptTokens}`,
+    );
+    return { action: "cancel", errorMessage: cancelMessage };
+  };
+}

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -107,6 +107,7 @@ export type EmbeddedRunAttemptResult = {
   messagingToolSentTexts: string[];
   messagingToolSentTargets: MessagingToolSend[];
   cloudCodeAssistFormatError: boolean;
+  lastAssistantUsage?: NormalizedUsage;
   attemptUsage?: NormalizedUsage;
   compactionCount?: number;
   /** Client tool call detected (OpenResponses hosted tools). */

--- a/src/agents/pi-embedded-runner/types.ts
+++ b/src/agents/pi-embedded-runner/types.ts
@@ -13,6 +13,13 @@ export type EmbeddedPiAgentMeta = {
     cacheWrite?: number;
     total?: number;
   };
+  promptUsage?: {
+    input?: number;
+    output?: number;
+    cacheRead?: number;
+    cacheWrite?: number;
+    total?: number;
+  };
 };
 
 export type EmbeddedPiRunMeta = {

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -104,6 +104,7 @@ export type EmbeddedPiSubscribeContext = {
   recordAssistantUsage: (usage: unknown) => void;
   incrementCompactionCount: () => void;
   getUsageTotals: () => NormalizedUsage | undefined;
+  getLastAssistantUsage: () => NormalizedUsage | undefined;
   getCompactionCount: () => number;
 };
 

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -449,7 +449,10 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
       return;
     }
     // Strip <think> and <final> blocks across chunk boundaries to avoid leaking reasoning.
-    const chunk = stripBlockTags(text, state.blockState).trimEnd();
+    const raw = stripBlockTags(text, state.blockState);
+    const cleaned =
+      state.lastBlockReplyText === undefined ? raw.replace(/^(?:[ \t]*\n)+/, "") : raw;
+    const chunk = cleaned.trimEnd();
     if (!chunk) {
       return;
     }

--- a/src/agents/pi-extensions/compaction-safeguard.test.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.test.ts
@@ -14,6 +14,8 @@ const {
   BASE_CHUNK_RATIO,
   MIN_CHUNK_RATIO,
   SAFETY_MARGIN,
+  resolveReserveTokens,
+  DEFAULT_RESERVE_TOKENS,
 } = __testing;
 
 describe("compaction-safeguard tool failures", () => {
@@ -209,6 +211,20 @@ describe("isOversizedForSummary", () => {
     const isOversized = isOversizedForSummary(msg, CONTEXT_WINDOW);
     // Due to token estimation, this could be either true or false at the boundary
     expect(typeof isOversized).toBe("boolean");
+  });
+});
+
+describe("resolveReserveTokens", () => {
+  it("falls back to default when reserveTokens is undefined", () => {
+    expect(resolveReserveTokens({})).toBe(DEFAULT_RESERVE_TOKENS);
+  });
+
+  it("prefers reserveTokens when valid", () => {
+    expect(resolveReserveTokens({ reserveTokens: 1234 })).toBe(1234);
+  });
+
+  it("uses reserveTokensFloor when reserveTokens is invalid", () => {
+    expect(resolveReserveTokens({ reserveTokens: undefined, reserveTokensFloor: 2048 })).toBe(2048);
   });
 });
 

--- a/src/agents/pi-extensions/context-pruning.test.ts
+++ b/src/agents/pi-extensions/context-pruning.test.ts
@@ -74,6 +74,33 @@ function makeAssistant(text: string): AgentMessage {
   };
 }
 
+function makeAssistantWithBlocks(
+  blocks: Array<{ type: string; [key: string]: unknown }>,
+): AgentMessage {
+  return {
+    role: "assistant",
+    content: blocks as unknown as AgentMessage["content"],
+    api: "openai-responses",
+    provider: "openai",
+    model: "fake",
+    usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, total: 2 },
+    stopReason: "stop",
+    timestamp: Date.now(),
+  } as AgentMessage;
+}
+
+function getThinkingBlocks(msg: AgentMessage): string[] {
+  if (msg.role !== "assistant" || !Array.isArray(msg.content)) {
+    return [];
+  }
+  return (
+    msg.content.filter((b) => b.type === "thinking") as Array<{
+      type: "thinking";
+      thinking: string;
+    }>
+  ).map((b) => b.thinking);
+}
+
 function makeUser(text: string): AgentMessage {
   return { role: "user", content: text, timestamp: Date.now() };
 }
@@ -521,5 +548,112 @@ describe("context-pruning", () => {
     expect(text).toContain("abcdef");
     expect(text).toContain("efghij");
     expect(text).toContain("[Tool result trimmed:");
+  });
+
+  it("stripThinking=false leaves thinking blocks untouched", () => {
+    const messages: AgentMessage[] = [
+      makeUser("u1"),
+      makeAssistantWithBlocks([
+        { type: "thinking", thinking: "hidden" },
+        { type: "text", text: "answer" },
+      ]),
+    ];
+
+    const settings = {
+      ...DEFAULT_CONTEXT_PRUNING_SETTINGS,
+      keepLastAssistants: 0,
+      stripThinking: false,
+    };
+
+    const ctx = {
+      model: { contextWindow: 1000 },
+    } as unknown as ExtensionContext;
+    const next = pruneContextMessages({ messages, settings, ctx });
+
+    expect(getThinkingBlocks(next[1])).toEqual(["hidden"]);
+  });
+
+  it("stripThinking=true strips thinking before cutoff", () => {
+    const messages: AgentMessage[] = [
+      makeUser("u1"),
+      makeAssistantWithBlocks([
+        { type: "thinking", thinking: "hidden" },
+        { type: "text", text: "answer" },
+      ]),
+    ];
+
+    const settings = {
+      ...DEFAULT_CONTEXT_PRUNING_SETTINGS,
+      keepLastAssistants: 0,
+      stripThinking: true,
+    };
+
+    const ctx = {
+      model: { contextWindow: 1000 },
+    } as unknown as ExtensionContext;
+    const next = pruneContextMessages({ messages, settings, ctx });
+    const assistant = next[1];
+
+    expect(getThinkingBlocks(assistant)).toEqual([]);
+    if (assistant.role !== "assistant" || !Array.isArray(assistant.content)) {
+      throw new Error("expected assistant content array");
+    }
+    expect(assistant.content.some((b) => b.type === "text")).toBe(true);
+  });
+
+  it("stripThinking=true preserves thinking in protected tail", () => {
+    const messages: AgentMessage[] = [
+      makeUser("u1"),
+      makeAssistantWithBlocks([
+        { type: "thinking", thinking: "old" },
+        { type: "text", text: "a1" },
+      ]),
+      makeUser("u2"),
+      makeAssistantWithBlocks([
+        { type: "thinking", thinking: "new" },
+        { type: "text", text: "a2" },
+      ]),
+    ];
+
+    const settings = {
+      ...DEFAULT_CONTEXT_PRUNING_SETTINGS,
+      keepLastAssistants: 1,
+      stripThinking: true,
+    };
+
+    const ctx = {
+      model: { contextWindow: 1000 },
+    } as unknown as ExtensionContext;
+    const next = pruneContextMessages({ messages, settings, ctx });
+
+    expect(getThinkingBlocks(next[1])).toEqual([]);
+    expect(getThinkingBlocks(next[3])).toEqual(["new"]);
+  });
+
+  it("stripThinking=true replaces empty assistant content with blank text", () => {
+    const messages: AgentMessage[] = [
+      makeUser("u1"),
+      makeAssistantWithBlocks([{ type: "thinking", thinking: "secret" }]),
+    ];
+
+    const settings = {
+      ...DEFAULT_CONTEXT_PRUNING_SETTINGS,
+      keepLastAssistants: 0,
+      stripThinking: true,
+    };
+
+    const ctx = {
+      model: { contextWindow: 1000 },
+    } as unknown as ExtensionContext;
+    const next = pruneContextMessages({ messages, settings, ctx });
+    const assistant = next[1];
+
+    expect(getThinkingBlocks(assistant)).toEqual([]);
+    if (assistant.role !== "assistant" || !Array.isArray(assistant.content)) {
+      throw new Error("expected assistant content array");
+    }
+    expect(assistant.content).toHaveLength(1);
+    expect(assistant.content[0]?.type).toBe("text");
+    expect(assistant.content[0]?.text).toBe("");
   });
 });

--- a/src/agents/pi-extensions/context-pruning/pruner.ts
+++ b/src/agents/pi-extensions/context-pruning/pruner.ts
@@ -150,8 +150,22 @@ function estimateMessageChars(message: AgentMessage): number {
   return 256;
 }
 
-function estimateContextChars(messages: AgentMessage[]): number {
+export function estimateContextChars(messages: AgentMessage[]): number {
   return messages.reduce((sum, m) => sum + estimateMessageChars(m), 0);
+}
+
+export function estimateContextUsageRatio(
+  messages: AgentMessage[],
+  contextWindowTokens?: number | null,
+): number {
+  if (!contextWindowTokens || !Number.isFinite(contextWindowTokens) || contextWindowTokens <= 0) {
+    return 0;
+  }
+  const charWindow = contextWindowTokens * CHARS_PER_TOKEN_ESTIMATE;
+  if (charWindow <= 0) {
+    return 0;
+  }
+  return estimateContextChars(messages) / charWindow;
 }
 
 function findAssistantCutoffIndex(

--- a/src/agents/pi-extensions/context-pruning/pruner.ts
+++ b/src/agents/pi-extensions/context-pruning/pruner.ts
@@ -260,16 +260,48 @@ export function pruneContextMessages(params: {
 
   const totalCharsBefore = estimateContextChars(messages);
   let totalChars = totalCharsBefore;
+  let next: AgentMessage[] | null = null;
+
+  if (settings.stripThinking) {
+    for (let i = pruneStartIndex; i < cutoffIndex; i++) {
+      const msg = messages[i];
+      if (!msg || msg.role !== "assistant") {
+        continue;
+      }
+      const content = msg.content;
+      if (!Array.isArray(content)) {
+        continue;
+      }
+      let removedChars = 0;
+      const filtered = content.filter((block) => {
+        if (block.type === "thinking") {
+          removedChars += block.thinking.length;
+          return false;
+        }
+        return true;
+      });
+      if (removedChars === 0) {
+        continue;
+      }
+      const nextContent = filtered.length > 0 ? filtered : [asText("")];
+      if (!next) {
+        next = messages.slice();
+      }
+      next[i] = { ...msg, content: nextContent } as AgentMessage;
+      totalChars = Math.max(0, totalChars - removedChars);
+    }
+  }
+
   let ratio = totalChars / charWindow;
   if (ratio < settings.softTrimRatio) {
-    return messages;
+    return next ?? messages;
   }
 
   const prunableToolIndexes: number[] = [];
-  let next: AgentMessage[] | null = null;
+  const sourceMessages = next ?? messages;
 
   for (let i = pruneStartIndex; i < cutoffIndex; i++) {
-    const msg = messages[i];
+    const msg = sourceMessages[i];
     if (!msg || msg.role !== "toolResult") {
       continue;
     }

--- a/src/agents/pi-extensions/context-pruning/settings.ts
+++ b/src/agents/pi-extensions/context-pruning/settings.ts
@@ -12,6 +12,7 @@ export type ContextPruningConfig = {
   ttl?: string;
   keepLastAssistants?: number;
   stripThinking?: boolean;
+  forcePruneRatio?: number;
   softTrimRatio?: number;
   hardClearRatio?: number;
   minPrunableToolChars?: number;
@@ -32,6 +33,7 @@ export type EffectiveContextPruningSettings = {
   ttlMs: number;
   keepLastAssistants: number;
   stripThinking: boolean;
+  forcePruneRatio?: number;
   softTrimRatio: number;
   hardClearRatio: number;
   minPrunableToolChars: number;
@@ -92,6 +94,9 @@ export function computeEffectiveSettings(raw: unknown): EffectiveContextPruningS
   }
   if (typeof cfg.stripThinking === "boolean") {
     s.stripThinking = cfg.stripThinking;
+  }
+  if (typeof cfg.forcePruneRatio === "number" && Number.isFinite(cfg.forcePruneRatio)) {
+    s.forcePruneRatio = Math.min(1, Math.max(0, cfg.forcePruneRatio));
   }
   if (typeof cfg.softTrimRatio === "number" && Number.isFinite(cfg.softTrimRatio)) {
     s.softTrimRatio = Math.min(1, Math.max(0, cfg.softTrimRatio));

--- a/src/agents/pi-extensions/context-pruning/settings.ts
+++ b/src/agents/pi-extensions/context-pruning/settings.ts
@@ -11,6 +11,7 @@ export type ContextPruningConfig = {
   /** TTL to consider cache expired (duration string, default unit: minutes). */
   ttl?: string;
   keepLastAssistants?: number;
+  stripThinking?: boolean;
   softTrimRatio?: number;
   hardClearRatio?: number;
   minPrunableToolChars?: number;
@@ -30,6 +31,7 @@ export type EffectiveContextPruningSettings = {
   mode: Exclude<ContextPruningMode, "off">;
   ttlMs: number;
   keepLastAssistants: number;
+  stripThinking: boolean;
   softTrimRatio: number;
   hardClearRatio: number;
   minPrunableToolChars: number;
@@ -49,6 +51,7 @@ export const DEFAULT_CONTEXT_PRUNING_SETTINGS: EffectiveContextPruningSettings =
   mode: "cache-ttl",
   ttlMs: 5 * 60 * 1000,
   keepLastAssistants: 3,
+  stripThinking: false,
   softTrimRatio: 0.3,
   hardClearRatio: 0.5,
   minPrunableToolChars: 50_000,
@@ -86,6 +89,9 @@ export function computeEffectiveSettings(raw: unknown): EffectiveContextPruningS
 
   if (typeof cfg.keepLastAssistants === "number" && Number.isFinite(cfg.keepLastAssistants)) {
     s.keepLastAssistants = Math.max(0, Math.floor(cfg.keepLastAssistants));
+  }
+  if (typeof cfg.stripThinking === "boolean") {
+    s.stripThinking = cfg.stripThinking;
   }
   if (typeof cfg.softTrimRatio === "number" && Number.isFinite(cfg.softTrimRatio)) {
     s.softTrimRatio = Math.min(1, Math.max(0, cfg.softTrimRatio));

--- a/src/agents/pi-extensions/transcript-sanitize.test.ts
+++ b/src/agents/pi-extensions/transcript-sanitize.test.ts
@@ -1,0 +1,49 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { describe, expect, it } from "vitest";
+import transcriptSanitizeExtension from "./transcript-sanitize.js";
+
+describe("transcript-sanitize extension", () => {
+  it("filters foreign tool-use messages before repair", () => {
+    let handler:
+      | ((
+          event: { messages: AgentMessage[] },
+          ctx: ExtensionContext,
+        ) => { messages: AgentMessage[] } | undefined)
+      | null = null;
+
+    const api = {
+      on(event, cb) {
+        if (event === "context") {
+          handler = cb;
+        }
+      },
+    } as unknown as ExtensionAPI;
+
+    transcriptSanitizeExtension(api);
+
+    if (!handler) {
+      throw new Error("missing context handler");
+    }
+
+    const messages: AgentMessage[] = [
+      { role: "user", content: "hello" },
+      {
+        role: "assistant",
+        provider: "openai",
+        api: "openai-responses",
+        content: [{ type: "toolCall", id: "call_1", name: "read", arguments: {} }],
+      },
+    ];
+
+    const result = handler({ messages }, {
+      model: {
+        provider: "anthropic",
+        api: "anthropic-messages",
+        id: "claude-3-7",
+      },
+    } as ExtensionContext);
+
+    expect(result).toEqual({ messages: [{ role: "user", content: "hello" }] });
+  });
+});

--- a/src/agents/pi-extensions/transcript-sanitize.ts
+++ b/src/agents/pi-extensions/transcript-sanitize.ts
@@ -1,0 +1,121 @@
+/**
+ * Transcript repair/sanitization extension.
+ *
+ * Runs on every context build to prevent strict provider request rejections:
+ * - duplicate or displaced tool results (Anthropic-compatible APIs, MiniMax, Cloud Code Assist)
+ * - Cloud Code Assist tool call ID constraints + collision-safe sanitization
+ */
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { isGoogleModelApi } from "../pi-embedded-helpers.js";
+import { repairToolUseResultPairing } from "../session-transcript-repair.js";
+import { sanitizeToolCallIdsForCloudCodeAssist } from "../tool-call-id.js";
+
+function isDeliveryMirrorMessage(message: AgentMessage): boolean {
+  return (
+    message &&
+    typeof message === "object" &&
+    (message as { role?: unknown }).role === "assistant" &&
+    (message as { model?: unknown }).model === "delivery-mirror" &&
+    (message as { provider?: unknown }).provider === "openclaw"
+  );
+}
+
+function filterDeliveryMirrorMessages(messages: AgentMessage[]): AgentMessage[] {
+  let touched = false;
+  const out: AgentMessage[] = [];
+  for (const msg of messages) {
+    if (isDeliveryMirrorMessage(msg)) {
+      touched = true;
+      continue;
+    }
+    out.push(msg);
+  }
+  return touched ? out : messages;
+}
+
+function hasToolCallBlocks(message: AgentMessage): boolean {
+  if (!message || typeof message !== "object" || message.role !== "assistant") {
+    return false;
+  }
+  const content = message.content;
+  if (!Array.isArray(content)) {
+    return false;
+  }
+  return content.some((block) => {
+    if (!block || typeof block !== "object") {
+      return false;
+    }
+    const rec = block as { type?: unknown };
+    return rec.type === "toolCall" || rec.type === "toolUse" || rec.type === "functionCall";
+  });
+}
+
+function isForeignToolUseMessage(
+  message: AgentMessage,
+  ctx: { provider?: string | null; modelApi?: string | null },
+): boolean {
+  if (!hasToolCallBlocks(message)) {
+    return false;
+  }
+  const normalize = (value: unknown) =>
+    typeof value === "string" ? value.trim().toLowerCase() : "";
+  const expectedProvider = normalize(ctx.provider);
+  const expectedApi = normalize(ctx.modelApi);
+  const msgProvider = normalize((message as { provider?: unknown }).provider);
+  const msgApi = normalize((message as { api?: unknown }).api);
+  if (expectedProvider && msgProvider && expectedProvider !== msgProvider) {
+    return true;
+  }
+  if (expectedApi && msgApi && expectedApi !== msgApi) {
+    return true;
+  }
+  return false;
+}
+
+function filterForeignToolUseMessages(
+  messages: AgentMessage[],
+  ctx: { provider?: string | null; modelApi?: string | null },
+): AgentMessage[] {
+  let touched = false;
+  const out: AgentMessage[] = [];
+  for (const msg of messages) {
+    if (isForeignToolUseMessage(msg, ctx)) {
+      touched = true;
+      continue;
+    }
+    out.push(msg);
+  }
+  return touched ? out : messages;
+}
+
+export default function transcriptSanitizeExtension(api: ExtensionAPI): void {
+  api.on("context", (event, ctx) => {
+    let next = event.messages;
+    const withoutDeliveryMirror = filterDeliveryMirrorMessages(next);
+    if (withoutDeliveryMirror !== next) {
+      next = withoutDeliveryMirror;
+    }
+    const withoutForeignToolUse = filterForeignToolUseMessages(next, {
+      provider: ctx.model?.provider,
+      modelApi: ctx.model?.api,
+    });
+    if (withoutForeignToolUse !== next) {
+      next = withoutForeignToolUse;
+    }
+    const repaired = repairToolUseResultPairing(next);
+    if (repaired.messages !== next) {
+      next = repaired.messages;
+    }
+    if (isGoogleModelApi(ctx.model?.api)) {
+      const repairedIds = sanitizeToolCallIdsForCloudCodeAssist(next);
+      if (repairedIds !== next) {
+        next = repairedIds;
+      }
+    }
+    if (next === event.messages) {
+      return undefined;
+    }
+    return { messages: next };
+  });
+}

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -1,6 +1,6 @@
 import crypto from "node:crypto";
 import path from "node:path";
-import { resolveQueueSettings } from "../auto-reply/reply/queue.js";
+import { getFollowupQueueDepth, resolveQueueSettings } from "../auto-reply/reply/queue.js";
 import { loadConfig } from "../config/config.js";
 import {
   loadSessionStore,
@@ -514,10 +514,39 @@ export async function runSubagentAnnounceFlow(params: {
       return true;
     }
 
+    // Fix 2: If the followup queue has pending items for this session,
+    // enqueue the announce instead of sending directly. This prevents
+    // the timing gap where clearActiveEmbeddedRun has fired (so
+    // maybeQueueSubagentAnnounce returns "none") but the followup drain
+    // hasn't started yet — a direct callGateway("agent") here would
+    // jump ahead of queued user messages.
+    const { cfg, entry, canonicalKey } = loadRequesterSessionEntry(params.requesterSessionKey);
+    if (getFollowupQueueDepth(canonicalKey) > 0) {
+      const queueSettings = resolveQueueSettings({
+        cfg,
+        channel: entry?.channel ?? entry?.lastChannel,
+        sessionEntry: entry,
+      });
+      const origin = resolveAnnounceOrigin(entry, requesterOrigin);
+      enqueueAnnounce({
+        key: canonicalKey,
+        item: {
+          prompt: triggerMessage,
+          summaryLine: taskLabel,
+          enqueuedAt: Date.now(),
+          sessionKey: canonicalKey,
+          origin,
+        },
+        settings: queueSettings,
+        send: sendAnnounce,
+      });
+      didAnnounce = true;
+      return true;
+    }
+
     // Send to main agent - it will respond in its own voice
     let directOrigin = requesterOrigin;
     if (!directOrigin) {
-      const { entry } = loadRequesterSessionEntry(params.requesterSessionKey);
       directOrigin = deliveryContextFromSession(entry);
     }
     await callGateway({

--- a/src/agents/tools/sessions-helpers.ts
+++ b/src/agents/tools/sessions-helpers.ts
@@ -1,6 +1,8 @@
 import type { OpenClawConfig } from "../../config/config.js";
 import { callGateway } from "../../gateway/call.js";
+import { capArrayByJsonBytes } from "../../gateway/session-utils.fs.js";
 import { isAcpSessionKey, normalizeMainKey } from "../../routing/session-key.js";
+import { truncateUtf16Safe } from "../../utils.js";
 import { sanitizeUserFacingText } from "../pi-embedded-helpers.js";
 import {
   stripDowngradedToolCallText,
@@ -9,6 +11,10 @@ import {
 } from "../pi-embedded-utils.js";
 
 export type SessionKind = "main" | "group" | "cron" | "hook" | "node" | "other";
+
+export const SESSIONS_HISTORY_MAX_BYTES = 80 * 1024;
+const SESSIONS_HISTORY_TEXT_MAX_CHARS = 4000;
+const SESSIONS_HISTORY_TEXT_TRUNCATED_SUFFIX = "\n…(truncated)…";
 
 export type SessionListDeliveryContext = {
   channel?: string;
@@ -348,6 +354,194 @@ export function stripToolMessages(messages: unknown[]): unknown[] {
     const role = (msg as { role?: unknown }).role;
     return role !== "toolResult";
   });
+}
+
+function truncateHistoryText(text: string): { text: string; truncated: boolean } {
+  if (text.length <= SESSIONS_HISTORY_TEXT_MAX_CHARS) {
+    return { text, truncated: false };
+  }
+  // Keep the *final* string (including the suffix) within the hard cap.
+  const maxPrefixChars = Math.max(
+    0,
+    SESSIONS_HISTORY_TEXT_MAX_CHARS - SESSIONS_HISTORY_TEXT_TRUNCATED_SUFFIX.length,
+  );
+  const cut = truncateUtf16Safe(text, maxPrefixChars);
+  return { text: `${cut}${SESSIONS_HISTORY_TEXT_TRUNCATED_SUFFIX}`, truncated: true };
+}
+
+function sanitizeHistoryContentBlock(params: { block: unknown; includeThinking: boolean }): {
+  block: unknown;
+  truncated: boolean;
+} {
+  const block = params.block;
+  if (!block || typeof block !== "object") {
+    return { block, truncated: false };
+  }
+  const entry = { ...(block as Record<string, unknown>) };
+  let truncated = false;
+  const type = typeof entry.type === "string" ? entry.type : "";
+
+  const hasThinkingSignature = "thinkingSignature" in entry;
+  if (!params.includeThinking && (type === "thinking" || hasThinkingSignature)) {
+    // Thinking blocks (and thinking-like blocks) can contain large encrypted signatures; omit by default.
+    // This is policy-based omission, not "truncation due to size limits".
+    return { block: null, truncated: false };
+  }
+
+  if (typeof entry.text === "string") {
+    const res = truncateHistoryText(entry.text);
+    entry.text = res.text;
+    truncated ||= res.truncated;
+  }
+  if (type === "thinking") {
+    if (typeof entry.thinking === "string") {
+      const res = truncateHistoryText(entry.thinking);
+      entry.thinking = res.text;
+      truncated ||= res.truncated;
+    }
+  }
+  // The encrypted signature can be extremely large and is not useful for history recall.
+  // Strip it regardless of block type so minor schema drift can't leak it.
+  if (hasThinkingSignature) {
+    delete entry.thinkingSignature;
+    truncated = true;
+  }
+  if (typeof entry.partialJson === "string") {
+    const res = truncateHistoryText(entry.partialJson);
+    entry.partialJson = res.text;
+    truncated ||= res.truncated;
+  }
+  if (type === "image") {
+    const data = typeof entry.data === "string" ? entry.data : undefined;
+    if (data !== undefined) {
+      const bytes = Buffer.byteLength(data, "utf8");
+      delete entry.data;
+      entry.omitted = true;
+      entry.bytes = bytes;
+      truncated = true;
+    }
+  }
+  return { block: entry, truncated };
+}
+
+function sanitizeHistoryMessage(params: { message: unknown; includeThinking: boolean }): {
+  message: unknown;
+  truncated: boolean;
+} {
+  const message = params.message;
+  if (!message || typeof message !== "object") {
+    return { message, truncated: false };
+  }
+  const entry = { ...(message as Record<string, unknown>) };
+  let truncated = false;
+
+  // Tool result details often contain very large nested payloads.
+  if ("details" in entry) {
+    delete entry.details;
+    truncated = true;
+  }
+  if ("usage" in entry) {
+    delete entry.usage;
+    truncated = true;
+  }
+  if ("cost" in entry) {
+    delete entry.cost;
+    truncated = true;
+  }
+
+  if (typeof entry.content === "string") {
+    const res = truncateHistoryText(entry.content);
+    entry.content = res.text;
+    truncated ||= res.truncated;
+  } else if (Array.isArray(entry.content)) {
+    const updated = entry.content.map((block) =>
+      sanitizeHistoryContentBlock({ block, includeThinking: params.includeThinking }),
+    );
+    entry.content = updated.flatMap((item) =>
+      item.block === null || item.block === undefined ? [] : [item.block],
+    );
+    truncated ||= updated.some((item) => item.truncated);
+  }
+  if (typeof entry.text === "string") {
+    const res = truncateHistoryText(entry.text);
+    entry.text = res.text;
+    truncated ||= res.truncated;
+  }
+  return { message: entry, truncated };
+}
+
+function jsonUtf8Bytes(value: unknown): number {
+  try {
+    return Buffer.byteLength(JSON.stringify(value), "utf8");
+  } catch {
+    return Buffer.byteLength(String(value), "utf8");
+  }
+}
+
+function enforceSessionsHistoryHardCap(params: {
+  items: unknown[];
+  bytes: number;
+  maxBytes: number;
+  placeholderText: string;
+}): { items: unknown[]; bytes: number; hardCapped: boolean } {
+  if (params.bytes <= params.maxBytes) {
+    return { items: params.items, bytes: params.bytes, hardCapped: false };
+  }
+
+  const last = params.items.at(-1);
+  const lastOnly = last ? [last] : [];
+  const lastBytes = jsonUtf8Bytes(lastOnly);
+  if (lastBytes <= params.maxBytes) {
+    return { items: lastOnly, bytes: lastBytes, hardCapped: true };
+  }
+
+  const placeholder = [
+    {
+      role: "assistant",
+      content: params.placeholderText,
+    },
+  ];
+  return { items: placeholder, bytes: jsonUtf8Bytes(placeholder), hardCapped: true };
+}
+
+export function sanitizeAndCapSessionMessages(params: {
+  messages: unknown[];
+  includeThinking: boolean;
+  maxBytes: number;
+  placeholderText: string;
+}): {
+  messages: unknown[];
+  bytes: number;
+  truncated: boolean;
+  droppedMessages: boolean;
+  contentTruncated: boolean;
+} {
+  const messages = Array.isArray(params.messages) ? params.messages : [];
+  const sanitizedMessages = messages.map((message) =>
+    sanitizeHistoryMessage({ message, includeThinking: params.includeThinking }),
+  );
+  const contentTruncated = sanitizedMessages.some((entry) => entry.truncated);
+
+  const cappedMessages = capArrayByJsonBytes(
+    sanitizedMessages.map((entry) => entry.message),
+    params.maxBytes,
+  );
+  const droppedMessages = cappedMessages.items.length < messages.length;
+  const hardened = enforceSessionsHistoryHardCap({
+    items: cappedMessages.items,
+    bytes: cappedMessages.bytes,
+    maxBytes: params.maxBytes,
+    placeholderText: params.placeholderText,
+  });
+  const truncated = droppedMessages || contentTruncated || hardened.hardCapped;
+
+  return {
+    messages: hardened.items,
+    bytes: hardened.bytes,
+    truncated,
+    droppedMessages: droppedMessages || hardened.hardCapped,
+    contentTruncated,
+  };
 }
 
 /**

--- a/src/agents/tools/sessions-history-tool.ts
+++ b/src/agents/tools/sessions-history-tool.ts
@@ -2,9 +2,7 @@ import { Type } from "@sinclair/typebox";
 import type { AnyAgentTool } from "./common.js";
 import { loadConfig } from "../../config/config.js";
 import { callGateway } from "../../gateway/call.js";
-import { capArrayByJsonBytes } from "../../gateway/session-utils.fs.js";
 import { isSubagentSessionKey, resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
-import { truncateUtf16Safe } from "../../utils.js";
 import { jsonResult, readStringParam } from "./common.js";
 import {
   createAgentToAgentPolicy,
@@ -12,6 +10,8 @@ import {
   resolveMainSessionAlias,
   resolveInternalSessionKey,
   SessionListRow,
+  SESSIONS_HISTORY_MAX_BYTES,
+  sanitizeAndCapSessionMessages,
   stripToolMessages,
 } from "./sessions-helpers.js";
 
@@ -19,132 +19,8 @@ const SessionsHistoryToolSchema = Type.Object({
   sessionKey: Type.String(),
   limit: Type.Optional(Type.Number({ minimum: 1 })),
   includeTools: Type.Optional(Type.Boolean()),
+  includeThinking: Type.Optional(Type.Boolean()),
 });
-
-const SESSIONS_HISTORY_MAX_BYTES = 80 * 1024;
-const SESSIONS_HISTORY_TEXT_MAX_CHARS = 4000;
-
-function truncateHistoryText(text: string): { text: string; truncated: boolean } {
-  if (text.length <= SESSIONS_HISTORY_TEXT_MAX_CHARS) {
-    return { text, truncated: false };
-  }
-  const cut = truncateUtf16Safe(text, SESSIONS_HISTORY_TEXT_MAX_CHARS);
-  return { text: `${cut}\n…(truncated)…`, truncated: true };
-}
-
-function sanitizeHistoryContentBlock(block: unknown): { block: unknown; truncated: boolean } {
-  if (!block || typeof block !== "object") {
-    return { block, truncated: false };
-  }
-  const entry = { ...(block as Record<string, unknown>) };
-  let truncated = false;
-  const type = typeof entry.type === "string" ? entry.type : "";
-  if (typeof entry.text === "string") {
-    const res = truncateHistoryText(entry.text);
-    entry.text = res.text;
-    truncated ||= res.truncated;
-  }
-  if (type === "thinking") {
-    if (typeof entry.thinking === "string") {
-      const res = truncateHistoryText(entry.thinking);
-      entry.thinking = res.text;
-      truncated ||= res.truncated;
-    }
-    // The encrypted signature can be extremely large and is not useful for history recall.
-    if ("thinkingSignature" in entry) {
-      delete entry.thinkingSignature;
-      truncated = true;
-    }
-  }
-  if (typeof entry.partialJson === "string") {
-    const res = truncateHistoryText(entry.partialJson);
-    entry.partialJson = res.text;
-    truncated ||= res.truncated;
-  }
-  if (type === "image") {
-    const data = typeof entry.data === "string" ? entry.data : undefined;
-    const bytes = data ? data.length : undefined;
-    if ("data" in entry) {
-      delete entry.data;
-      truncated = true;
-    }
-    entry.omitted = true;
-    if (bytes !== undefined) {
-      entry.bytes = bytes;
-    }
-  }
-  return { block: entry, truncated };
-}
-
-function sanitizeHistoryMessage(message: unknown): { message: unknown; truncated: boolean } {
-  if (!message || typeof message !== "object") {
-    return { message, truncated: false };
-  }
-  const entry = { ...(message as Record<string, unknown>) };
-  let truncated = false;
-  // Tool result details often contain very large nested payloads.
-  if ("details" in entry) {
-    delete entry.details;
-    truncated = true;
-  }
-  if ("usage" in entry) {
-    delete entry.usage;
-    truncated = true;
-  }
-  if ("cost" in entry) {
-    delete entry.cost;
-    truncated = true;
-  }
-
-  if (typeof entry.content === "string") {
-    const res = truncateHistoryText(entry.content);
-    entry.content = res.text;
-    truncated ||= res.truncated;
-  } else if (Array.isArray(entry.content)) {
-    const updated = entry.content.map((block) => sanitizeHistoryContentBlock(block));
-    entry.content = updated.map((item) => item.block);
-    truncated ||= updated.some((item) => item.truncated);
-  }
-  if (typeof entry.text === "string") {
-    const res = truncateHistoryText(entry.text);
-    entry.text = res.text;
-    truncated ||= res.truncated;
-  }
-  return { message: entry, truncated };
-}
-
-function jsonUtf8Bytes(value: unknown): number {
-  try {
-    return Buffer.byteLength(JSON.stringify(value), "utf8");
-  } catch {
-    return Buffer.byteLength(String(value), "utf8");
-  }
-}
-
-function enforceSessionsHistoryHardCap(params: {
-  items: unknown[];
-  bytes: number;
-  maxBytes: number;
-}): { items: unknown[]; bytes: number; hardCapped: boolean } {
-  if (params.bytes <= params.maxBytes) {
-    return { items: params.items, bytes: params.bytes, hardCapped: false };
-  }
-
-  const last = params.items.at(-1);
-  const lastOnly = last ? [last] : [];
-  const lastBytes = jsonUtf8Bytes(lastOnly);
-  if (lastBytes <= params.maxBytes) {
-    return { items: lastOnly, bytes: lastBytes, hardCapped: true };
-  }
-
-  const placeholder = [
-    {
-      role: "assistant",
-      content: "[sessions_history omitted: message too large]",
-    },
-  ];
-  return { items: placeholder, bytes: jsonUtf8Bytes(placeholder), hardCapped: true };
-}
 
 function resolveSandboxSessionToolsVisibility(cfg: ReturnType<typeof loadConfig>) {
   return cfg.agents?.defaults?.sandbox?.sessionToolsVisibility ?? "spawned";
@@ -252,32 +128,27 @@ export function createSessionsHistoryTool(opts?: {
         typeof params.limit === "number" && Number.isFinite(params.limit)
           ? Math.max(1, Math.floor(params.limit))
           : undefined;
-      const includeTools = Boolean(params.includeTools);
+      const includeTools = params.includeTools === true;
+      const includeThinking = params.includeThinking === true;
       const result = await callGateway<{ messages: Array<unknown> }>({
         method: "chat.history",
         params: { sessionKey: resolvedKey, limit },
       });
       const rawMessages = Array.isArray(result?.messages) ? result.messages : [];
       const selectedMessages = includeTools ? rawMessages : stripToolMessages(rawMessages);
-      const sanitizedMessages = selectedMessages.map((message) => sanitizeHistoryMessage(message));
-      const contentTruncated = sanitizedMessages.some((entry) => entry.truncated);
-      const cappedMessages = capArrayByJsonBytes(
-        sanitizedMessages.map((entry) => entry.message),
-        SESSIONS_HISTORY_MAX_BYTES,
-      );
-      const droppedMessages = cappedMessages.items.length < selectedMessages.length;
-      const hardened = enforceSessionsHistoryHardCap({
-        items: cappedMessages.items,
-        bytes: cappedMessages.bytes,
+      const sanitized = sanitizeAndCapSessionMessages({
+        messages: selectedMessages,
+        includeThinking,
         maxBytes: SESSIONS_HISTORY_MAX_BYTES,
+        placeholderText: "[sessions_history omitted: message too large]",
       });
       return jsonResult({
         sessionKey: displayKey,
-        messages: hardened.items,
-        truncated: droppedMessages || contentTruncated || hardened.hardCapped,
-        droppedMessages: droppedMessages || hardened.hardCapped,
-        contentTruncated,
-        bytes: hardened.bytes,
+        messages: sanitized.messages,
+        truncated: sanitized.truncated,
+        droppedMessages: sanitized.droppedMessages,
+        contentTruncated: sanitized.contentTruncated,
+        bytes: sanitized.bytes,
       });
     },
   };

--- a/src/agents/tools/sessions-list-tool.ts
+++ b/src/agents/tools/sessions-list-tool.ts
@@ -13,6 +13,8 @@ import {
   resolveInternalSessionKey,
   resolveMainSessionAlias,
   type SessionListRow,
+  SESSIONS_HISTORY_MAX_BYTES,
+  sanitizeAndCapSessionMessages,
   stripToolMessages,
 } from "./sessions-helpers.js";
 
@@ -21,6 +23,7 @@ const SessionsListToolSchema = Type.Object({
   limit: Type.Optional(Type.Number({ minimum: 1 })),
   activeMinutes: Type.Optional(Type.Number({ minimum: 1 })),
   messageLimit: Type.Optional(Type.Number({ minimum: 0 })),
+  includeThinking: Type.Optional(Type.Boolean()),
 });
 
 function resolveSandboxSessionToolsVisibility(cfg: ReturnType<typeof loadConfig>) {
@@ -76,6 +79,7 @@ export function createSessionsListTool(opts?: {
           ? Math.max(0, Math.floor(params.messageLimit))
           : 0;
       const messageLimit = Math.min(messageLimitRaw, 20);
+      const includeThinking = params.includeThinking === true;
 
       const list = await callGateway<{ sessions: Array<SessionListRow>; path: string }>({
         method: "sessions.list",
@@ -200,7 +204,13 @@ export function createSessionsListTool(opts?: {
           });
           const rawMessages = Array.isArray(history?.messages) ? history.messages : [];
           const filtered = stripToolMessages(rawMessages);
-          row.messages = filtered.length > messageLimit ? filtered.slice(-messageLimit) : filtered;
+          const limited = filtered.length > messageLimit ? filtered.slice(-messageLimit) : filtered;
+          row.messages = sanitizeAndCapSessionMessages({
+            messages: limited,
+            includeThinking,
+            maxBytes: SESSIONS_HISTORY_MAX_BYTES,
+            placeholderText: "[sessions_list omitted: message too large]",
+          }).messages;
         }
 
         rows.push(row);

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -245,28 +245,32 @@ export function createSessionsSpawnTool(opts?: {
       const childIdem = crypto.randomUUID();
       let childRunId: string = childIdem;
       try {
+        const agentParams: Record<string, unknown> = {
+          message: task,
+          sessionKey: childSessionKey,
+          channel: requesterOrigin?.channel,
+          to: requesterOrigin?.to ?? undefined,
+          accountId: requesterOrigin?.accountId ?? undefined,
+          threadId:
+            requesterOrigin?.threadId != null ? String(requesterOrigin.threadId) : undefined,
+          idempotencyKey: childIdem,
+          deliver: false,
+          lane: AGENT_LANE_SUBAGENT,
+          extraSystemPrompt: childSystemPrompt,
+          thinking: thinkingOverride,
+          timeout: runTimeoutSeconds > 0 ? runTimeoutSeconds : undefined,
+          label: label || undefined,
+          spawnedBy: spawnedByKey,
+          groupId: opts?.agentGroupId ?? undefined,
+          groupChannel: opts?.agentGroupChannel ?? undefined,
+          groupSpace: opts?.agentGroupSpace ?? undefined,
+        };
+        if (resolvedModel && modelApplied) {
+          agentParams.model = resolvedModel;
+        }
         const response = await callGateway<{ runId: string }>({
           method: "agent",
-          params: {
-            message: task,
-            sessionKey: childSessionKey,
-            channel: requesterOrigin?.channel,
-            to: requesterOrigin?.to ?? undefined,
-            accountId: requesterOrigin?.accountId ?? undefined,
-            threadId:
-              requesterOrigin?.threadId != null ? String(requesterOrigin.threadId) : undefined,
-            idempotencyKey: childIdem,
-            deliver: false,
-            lane: AGENT_LANE_SUBAGENT,
-            extraSystemPrompt: childSystemPrompt,
-            thinking: thinkingOverride,
-            timeout: runTimeoutSeconds > 0 ? runTimeoutSeconds : undefined,
-            label: label || undefined,
-            spawnedBy: spawnedByKey,
-            groupId: opts?.agentGroupId ?? undefined,
-            groupChannel: opts?.agentGroupChannel ?? undefined,
-            groupSpace: opts?.agentGroupSpace ?? undefined,
-          },
+          params: agentParams,
           timeoutMs: 10_000,
         });
         if (typeof response?.runId === "string" && response.runId) {

--- a/src/agents/tools/sessions-tools.sanitization.test.ts
+++ b/src/agents/tools/sessions-tools.sanitization.test.ts
@@ -1,0 +1,471 @@
+import { describe, expect, it, vi } from "vitest";
+
+const callGatewayMock = vi.fn();
+vi.mock("../../gateway/call.js", () => ({
+  callGateway: (opts: unknown) => callGatewayMock(opts),
+}));
+
+vi.mock("../../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config/config.js")>();
+  return {
+    ...actual,
+    loadConfig: () =>
+      ({
+        session: { scope: "per-sender", mainKey: "main" },
+        tools: { agentToAgent: { enabled: false } },
+      }) as never,
+  };
+});
+
+import { sanitizeAndCapSessionMessages, SESSIONS_HISTORY_MAX_BYTES } from "./sessions-helpers.js";
+import { createSessionsHistoryTool } from "./sessions-history-tool.js";
+import { createSessionsListTool } from "./sessions-list-tool.js";
+
+function jsonBytes(value: unknown): number {
+  return Buffer.byteLength(JSON.stringify(value), "utf8");
+}
+
+describe("sessions_list sanitization", () => {
+  it("drops thinking blocks by default (includeThinking=false)", async () => {
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const method = (opts as { method?: unknown }).method;
+      if (method === "sessions.list") {
+        return {
+          path: "/tmp/sessions.json",
+          sessions: [{ key: "agent:main:main", kind: "direct" }],
+        };
+      }
+      if (method === "chat.history") {
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [
+                {
+                  type: "thinking",
+                  thinking: "secret",
+                  thinkingSignature: "abc123",
+                },
+                { type: "text", text: "hello" },
+              ],
+            },
+          ],
+        };
+      }
+      throw new Error(`unexpected gateway method: ${String(method)}`);
+    });
+
+    const tool = createSessionsListTool({ agentSessionKey: "agent:main:main" });
+    const result = await tool.execute("call1", { messageLimit: 1 });
+    const messages =
+      (result.details as { sessions: Array<{ messages?: unknown[] }> }).sessions[0].messages ?? [];
+    expect(messages).toHaveLength(1);
+    const content = (messages[0] as { content?: unknown }).content as unknown[];
+    expect(Array.isArray(content)).toBe(true);
+    expect(content.some((b) => (b as { type?: unknown }).type === "thinking")).toBe(false);
+  });
+
+  it("strips thinkingSignature when includeThinking=true", async () => {
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const method = (opts as { method?: unknown }).method;
+      if (method === "sessions.list") {
+        return {
+          path: "/tmp/sessions.json",
+          sessions: [{ key: "agent:main:main", kind: "direct" }],
+        };
+      }
+      if (method === "chat.history") {
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [
+                {
+                  type: "thinking",
+                  thinking: "secret",
+                  thinkingSignature: "a".repeat(50_000),
+                },
+              ],
+            },
+          ],
+        };
+      }
+      throw new Error(`unexpected gateway method: ${String(method)}`);
+    });
+
+    const tool = createSessionsListTool({ agentSessionKey: "agent:main:main" });
+    const result = await tool.execute("call1", { messageLimit: 1, includeThinking: true });
+    const messages =
+      (result.details as { sessions: Array<{ messages?: unknown[] }> }).sessions[0].messages ?? [];
+    const content = (messages[0] as { content?: unknown }).content as unknown[];
+    expect(content.some((b) => (b as { type?: unknown }).type === "thinking")).toBe(true);
+    const thinking = content.find((b) => (b as { type?: unknown }).type === "thinking") as Record<
+      string,
+      unknown
+    >;
+    expect("thinkingSignature" in thinking).toBe(false);
+  });
+
+  it("truncates text + partialJson to 4000 chars", async () => {
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const method = (opts as { method?: unknown }).method;
+      if (method === "sessions.list") {
+        return {
+          path: "/tmp/sessions.json",
+          sessions: [{ key: "agent:main:main", kind: "direct" }],
+        };
+      }
+      if (method === "chat.history") {
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [
+                { type: "text", text: "x".repeat(5000) },
+                { type: "json", partialJson: "y".repeat(5000) },
+              ],
+            },
+          ],
+        };
+      }
+      throw new Error(`unexpected gateway method: ${String(method)}`);
+    });
+
+    const tool = createSessionsListTool({ agentSessionKey: "agent:main:main" });
+    const result = await tool.execute("call1", { messageLimit: 1 });
+    const messages =
+      (result.details as { sessions: Array<{ messages?: unknown[] }> }).sessions[0].messages ?? [];
+    const content = (messages[0] as { content?: unknown }).content as Array<
+      Record<string, unknown>
+    >;
+
+    const textBlock = content.find((b) => (b as { type?: unknown }).type === "text") as {
+      text?: unknown;
+    };
+    expect(typeof textBlock.text).toBe("string");
+    expect(String(textBlock.text)).toContain("…(truncated)…");
+    expect(String(textBlock.text).length).toBeLessThanOrEqual(4000);
+
+    const jsonBlock = content.find((b) => (b as { type?: unknown }).type === "json") as {
+      partialJson?: unknown;
+    };
+    expect(typeof jsonBlock.partialJson).toBe("string");
+    expect(String(jsonBlock.partialJson)).toContain("…(truncated)…");
+    expect(String(jsonBlock.partialJson).length).toBeLessThanOrEqual(4000);
+  });
+
+  it("treats includeThinking='false' (string) as false", async () => {
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const method = (opts as { method?: unknown }).method;
+      if (method === "sessions.list") {
+        return {
+          path: "/tmp/sessions.json",
+          sessions: [{ key: "agent:main:main", kind: "direct" }],
+        };
+      }
+      if (method === "chat.history") {
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [
+                {
+                  type: "thinking",
+                  thinking: "secret",
+                  thinkingSignature: "abc123",
+                },
+                { type: "text", text: "hello" },
+              ],
+            },
+          ],
+        };
+      }
+      throw new Error(`unexpected gateway method: ${String(method)}`);
+    });
+
+    const tool = createSessionsListTool({ agentSessionKey: "agent:main:main" });
+    const result = await tool.execute("call1", {
+      messageLimit: 1,
+      includeThinking: "false" as never,
+    });
+    const messages =
+      (result.details as { sessions: Array<{ messages?: unknown[] }> }).sessions[0].messages ?? [];
+    const content = (messages[0] as { content?: unknown }).content as unknown[];
+    expect(content.some((b) => (b as { type?: unknown }).type === "thinking")).toBe(false);
+  });
+
+  it("strips thinkingSignature regardless of content block type, and drops signature-bearing blocks when includeThinking=false", async () => {
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const method = (opts as { method?: unknown }).method;
+      if (method === "sessions.list") {
+        return {
+          path: "/tmp/sessions.json",
+          sessions: [{ key: "agent:main:main", kind: "direct" }],
+        };
+      }
+      if (method === "chat.history") {
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [
+                {
+                  type: "reasoning",
+                  thinking: "secret",
+                  thinkingSignature: "abc123",
+                },
+              ],
+            },
+          ],
+        };
+      }
+      throw new Error(`unexpected gateway method: ${String(method)}`);
+    });
+
+    const tool = createSessionsListTool({ agentSessionKey: "agent:main:main" });
+
+    const included = await tool.execute("call1", { messageLimit: 1, includeThinking: true });
+    {
+      const messages =
+        (included.details as { sessions: Array<{ messages?: unknown[] }> }).sessions[0].messages ??
+        [];
+      const content = (messages[0] as { content?: unknown }).content as Array<
+        Record<string, unknown>
+      >;
+      expect(content).toHaveLength(1);
+      expect("thinkingSignature" in content[0]).toBe(false);
+    }
+
+    const omitted = await tool.execute("call1", { messageLimit: 1 });
+    {
+      const messages =
+        (omitted.details as { sessions: Array<{ messages?: unknown[] }> }).sessions[0].messages ??
+        [];
+      const content = (messages[0] as { content?: unknown }).content as Array<
+        Record<string, unknown>
+      >;
+      expect(content).toHaveLength(0);
+    }
+  });
+
+  it("does not mark url-only image blocks as omitted", async () => {
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const method = (opts as { method?: unknown }).method;
+      if (method === "sessions.list") {
+        return {
+          path: "/tmp/sessions.json",
+          sessions: [{ key: "agent:main:main", kind: "direct" }],
+        };
+      }
+      if (method === "chat.history") {
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [{ type: "image", url: "https://example.com/foo.png" }],
+            },
+          ],
+        };
+      }
+      throw new Error(`unexpected gateway method: ${String(method)}`);
+    });
+
+    const tool = createSessionsListTool({ agentSessionKey: "agent:main:main" });
+    const result = await tool.execute("call1", { messageLimit: 1 });
+    const messages =
+      (result.details as { sessions: Array<{ messages?: unknown[] }> }).sessions[0].messages ?? [];
+    const content = (messages[0] as { content?: unknown }).content as Array<
+      Record<string, unknown>
+    >;
+    const image =
+      content.find((b) => (b as { type?: unknown }).type === "image") ??
+      ({} as Record<string, unknown>);
+    expect("omitted" in image).toBe(false);
+  });
+
+  it("applies the 80KB cap to sessions_list message payloads", async () => {
+    const bigMessages = Array.from({ length: 20 }, () => ({
+      role: "assistant",
+      // 20 messages with a single 4000-char block can fit under ~80KB; use multiple blocks per message
+      // so we reliably exceed the cap and validate message dropping.
+      content: Array.from({ length: 5 }, () => ({ type: "text", text: "a".repeat(4000) })),
+    }));
+
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const method = (opts as { method?: unknown }).method;
+      if (method === "sessions.list") {
+        return {
+          path: "/tmp/sessions.json",
+          sessions: [{ key: "agent:main:main", kind: "direct" }],
+        };
+      }
+      if (method === "chat.history") {
+        return { messages: bigMessages };
+      }
+      throw new Error(`unexpected gateway method: ${String(method)}`);
+    });
+
+    const tool = createSessionsListTool({ agentSessionKey: "agent:main:main" });
+    const result = await tool.execute("call1", { messageLimit: 20 });
+    const messages = (result.details as { sessions: Array<{ messages?: unknown[] }> }).sessions[0]
+      .messages;
+    expect(Array.isArray(messages)).toBe(true);
+    expect(jsonBytes(messages)).toBeLessThanOrEqual(SESSIONS_HISTORY_MAX_BYTES);
+    expect(messages?.length).toBeLessThan(bigMessages.length);
+  });
+});
+
+describe("sessions_history sanitization", () => {
+  it("drops thinking blocks by default (includeThinking=false)", async () => {
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const method = (opts as { method?: unknown }).method;
+      if (method === "chat.history") {
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [
+                {
+                  type: "thinking",
+                  thinking: "secret",
+                  thinkingSignature: "abc123",
+                },
+                { type: "text", text: "hello" },
+              ],
+            },
+          ],
+        };
+      }
+      throw new Error(`unexpected gateway method: ${String(method)}`);
+    });
+
+    const tool = createSessionsHistoryTool({ agentSessionKey: "agent:main:main" });
+    const result = await tool.execute("call1", { sessionKey: "main", limit: 1 });
+    const messages = (result.details as { messages: unknown[] }).messages;
+    const content = (messages[0] as { content?: unknown }).content as unknown[];
+    expect(content.some((b) => (b as { type?: unknown }).type === "thinking")).toBe(false);
+  });
+
+  it("includeThinking=true preserves thinking blocks but strips thinkingSignature", async () => {
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const method = (opts as { method?: unknown }).method;
+      if (method === "chat.history") {
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [
+                {
+                  type: "thinking",
+                  thinking: "x".repeat(5000),
+                  thinkingSignature: "a".repeat(50_000),
+                },
+              ],
+            },
+          ],
+        };
+      }
+      throw new Error(`unexpected gateway method: ${String(method)}`);
+    });
+
+    const tool = createSessionsHistoryTool({ agentSessionKey: "agent:main:main" });
+    const result = await tool.execute("call1", {
+      sessionKey: "main",
+      limit: 1,
+      includeThinking: true,
+    });
+    const messages = (result.details as { messages: unknown[] }).messages;
+    const content = (messages[0] as { content?: unknown }).content as Array<
+      Record<string, unknown>
+    >;
+    expect(content.some((b) => (b as { type?: unknown }).type === "thinking")).toBe(true);
+    const thinking =
+      content.find((b) => (b as { type?: unknown }).type === "thinking") ??
+      ({} as Record<string, unknown>);
+    expect("thinkingSignature" in thinking).toBe(false);
+    const thinkingText = (thinking as { thinking?: unknown }).thinking;
+    expect(typeof thinkingText).toBe("string");
+    expect(String(thinkingText)).toContain("…(truncated)…");
+    expect(String(thinkingText).length).toBeLessThanOrEqual(4000);
+  });
+
+  it("treats includeThinking='false' and includeTools='false' (string) as false", async () => {
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const method = (opts as { method?: unknown }).method;
+      if (method === "chat.history") {
+        return {
+          messages: [
+            { role: "toolResult", content: "tool stuff" },
+            {
+              role: "assistant",
+              content: [
+                { type: "thinking", thinking: "secret", thinkingSignature: "abc123" },
+                { type: "text", text: "hello" },
+              ],
+            },
+          ],
+        };
+      }
+      throw new Error(`unexpected gateway method: ${String(method)}`);
+    });
+
+    const tool = createSessionsHistoryTool({ agentSessionKey: "agent:main:main" });
+    const result = await tool.execute("call1", {
+      sessionKey: "main",
+      limit: 10,
+      includeThinking: "false" as never,
+      includeTools: "false" as never,
+    });
+    const messages = (result.details as { messages: Array<{ role?: unknown; content?: unknown }> })
+      .messages;
+    expect(messages.some((m) => m.role === "toolResult")).toBe(false);
+    const content = (messages[0] as { content?: unknown }).content as unknown[];
+    expect(content.some((b) => (b as { type?: unknown }).type === "thinking")).toBe(false);
+  });
+
+  it("returns a placeholder when a single message exceeds 80KB after sanitization", async () => {
+    const bigMessage = {
+      role: "assistant",
+      content: Array.from({ length: 40 }, () => ({ type: "text", text: "a".repeat(4000) })),
+    };
+    const res = sanitizeAndCapSessionMessages({
+      messages: [bigMessage],
+      includeThinking: false,
+      maxBytes: SESSIONS_HISTORY_MAX_BYTES,
+      placeholderText: "[sessions_history omitted: message too large]",
+    });
+    expect(res.messages).toHaveLength(1);
+    expect(res.messages[0]).toEqual({
+      role: "assistant",
+      content: "[sessions_history omitted: message too large]",
+    });
+    expect(res.bytes).toBeLessThanOrEqual(SESSIONS_HISTORY_MAX_BYTES);
+  });
+
+  it("handles empty message arrays and empty/undefined/null content blocks", async () => {
+    {
+      const res = sanitizeAndCapSessionMessages({
+        messages: [],
+        includeThinking: false,
+        maxBytes: SESSIONS_HISTORY_MAX_BYTES,
+        placeholderText: "[sessions_history omitted: message too large]",
+      });
+      expect(res.messages).toEqual([]);
+    }
+
+    const res = sanitizeAndCapSessionMessages({
+      messages: [
+        { role: "assistant" },
+        { role: "assistant", content: [] },
+        { role: "assistant", content: [undefined, null, { type: "text", text: "ok" }] },
+      ],
+      includeThinking: false,
+      maxBytes: SESSIONS_HISTORY_MAX_BYTES,
+      placeholderText: "[sessions_history omitted: message too large]",
+    });
+    expect(res.messages).toHaveLength(3);
+    const third = res.messages[2] as { content?: unknown };
+    expect(Array.isArray(third.content)).toBe(true);
+    expect((third.content as unknown[]).length).toBe(1);
+  });
+});

--- a/src/agents/usage.test.ts
+++ b/src/agents/usage.test.ts
@@ -52,9 +52,10 @@ describe("normalizeUsage", () => {
       deriveSessionTotalTokens({
         usage: {
           input: 27,
+          output: 2_400_000,
           cacheRead: 2_400_000,
           cacheWrite: 0,
-          total: 2_402_300,
+          total: 4_800_300,
         },
         contextTokens: 200_000,
       }),
@@ -66,6 +67,7 @@ describe("normalizeUsage", () => {
       deriveSessionTotalTokens({
         usage: {
           input: 1_200,
+          output: 300,
           cacheRead: 300,
           cacheWrite: 50,
           total: 2_000,

--- a/src/agents/usage.test.ts
+++ b/src/agents/usage.test.ts
@@ -72,6 +72,6 @@ describe("normalizeUsage", () => {
         },
         contextTokens: 200_000,
       }),
-    ).toBe(1_550);
+    ).toBe(1_500);
   });
 });

--- a/src/agents/usage.test.ts
+++ b/src/agents/usage.test.ts
@@ -47,7 +47,7 @@ describe("normalizeUsage", () => {
     expect(hasNonzeroUsage({ total: 1 })).toBe(true);
   });
 
-  it("caps derived session total tokens to the context window", () => {
+  it("does not cap derived session total tokens to the context window", () => {
     expect(
       deriveSessionTotalTokens({
         usage: {
@@ -58,7 +58,7 @@ describe("normalizeUsage", () => {
         },
         contextTokens: 200_000,
       }),
-    ).toBe(200_000);
+    ).toBe(2_400_027);
   });
 
   it("uses prompt tokens when within context window", () => {

--- a/src/agents/usage.ts
+++ b/src/agents/usage.ts
@@ -99,8 +99,7 @@ export function derivePromptTokens(usage?: {
   }
   const input = usage.input ?? 0;
   const cacheRead = usage.cacheRead ?? 0;
-  const cacheWrite = usage.cacheWrite ?? 0;
-  const sum = input + cacheRead + cacheWrite;
+  const sum = input + cacheRead;
   return sum > 0 ? sum : undefined;
 }
 

--- a/src/agents/usage.ts
+++ b/src/agents/usage.ts
@@ -91,6 +91,7 @@ export function normalizeUsage(raw?: UsageLike | null): NormalizedUsage | undefi
 
 export function derivePromptTokens(usage?: {
   input?: number;
+  output?: number;
   cacheRead?: number;
   cacheWrite?: number;
 }): number | undefined {
@@ -98,14 +99,15 @@ export function derivePromptTokens(usage?: {
     return undefined;
   }
   const input = usage.input ?? 0;
-  const cacheRead = usage.cacheRead ?? 0;
-  const sum = input + cacheRead;
+  const output = usage.output ?? 0;
+  const sum = input + output;
   return sum > 0 ? sum : undefined;
 }
 
 export function deriveSessionTotalTokens(params: {
   usage?: {
     input?: number;
+    output?: number;
     total?: number;
     cacheRead?: number;
     cacheWrite?: number;
@@ -119,6 +121,7 @@ export function deriveSessionTotalTokens(params: {
   const input = usage.input ?? 0;
   const promptTokens = derivePromptTokens({
     input: usage.input,
+    output: usage.output,
     cacheRead: usage.cacheRead,
     cacheWrite: usage.cacheWrite,
   });

--- a/src/agents/usage.ts
+++ b/src/agents/usage.ts
@@ -128,9 +128,5 @@ export function deriveSessionTotalTokens(params: {
     return undefined;
   }
 
-  const contextTokens = params.contextTokens;
-  if (typeof contextTokens === "number" && Number.isFinite(contextTokens) && contextTokens > 0) {
-    total = Math.min(total, contextTokens);
-  }
   return total;
 }

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -36,7 +36,12 @@ import { appendUsageLine, formatResponseUsageLine } from "./agent-runner-utils.j
 import { createAudioAsVoiceBuffer, createBlockReplyPipeline } from "./block-reply-pipeline.js";
 import { resolveBlockStreamingCoalescing } from "./block-streaming.js";
 import { createFollowupRunner } from "./followup-runner.js";
-import { enqueueFollowupRun, type FollowupRun, type QueueSettings } from "./queue.js";
+import {
+  enqueueFollowupRun,
+  scheduleFollowupDrain,
+  type FollowupRun,
+  type QueueSettings,
+} from "./queue.js";
 import { createReplyToModeFilterForChannel, resolveReplyToMode } from "./reply-threading.js";
 import { incrementCompactionCount } from "./session-updates.js";
 import { persistSessionUsageUpdate } from "./session-usage.js";
@@ -521,5 +526,7 @@ export async function runReplyAgent(params: {
   } finally {
     blockReplyPipeline?.stop();
     typing.markRunComplete();
+    // Ensure queued followups are drained even if the run errors before finalizeWithFollowup().
+    scheduleFollowupDrain(queueKey, runFollowupTurn);
   }
 }

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -377,7 +377,7 @@ export async function runReplyAgent(params: {
     }
 
     const usage = runResult.meta.agentMeta?.usage;
-    const promptUsage = runResult.meta.agentMeta?.promptUsage ?? usage;
+    const promptUsage = runResult.meta.agentMeta?.promptUsage;
     const modelUsed = runResult.meta.agentMeta?.model ?? fallbackModel ?? defaultModel;
     const providerUsed =
       runResult.meta.agentMeta?.provider ?? fallbackProvider ?? followupRun.run.provider;
@@ -393,7 +393,8 @@ export async function runReplyAgent(params: {
     await persistSessionUsageUpdate({
       storePath,
       sessionKey,
-      usage: promptUsage,
+      usage,
+      promptUsage,
       modelUsed,
       providerUsed,
       contextTokensUsed,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -377,6 +377,7 @@ export async function runReplyAgent(params: {
     }
 
     const usage = runResult.meta.agentMeta?.usage;
+    const promptUsage = runResult.meta.agentMeta?.promptUsage ?? usage;
     const modelUsed = runResult.meta.agentMeta?.model ?? fallbackModel ?? defaultModel;
     const providerUsed =
       runResult.meta.agentMeta?.provider ?? fallbackProvider ?? followupRun.run.provider;
@@ -392,7 +393,7 @@ export async function runReplyAgent(params: {
     await persistSessionUsageUpdate({
       storePath,
       sessionKey,
-      usage,
+      usage: promptUsage,
       modelUsed,
       providerUsed,
       contextTokensUsed,

--- a/src/auto-reply/reply/commands-status.ts
+++ b/src/auto-reply/reply/commands-status.ts
@@ -242,7 +242,7 @@ export async function buildStatusReply(params: {
     },
     subagentsLine,
     mediaDecisions: params.mediaDecisions,
-    includeTranscriptUsage: false,
+    includeTranscriptUsage: true,
   });
 
   return { text: statusText };

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -196,7 +196,7 @@ export function createFollowupRunner(params: {
 
       if (storePath && sessionKey) {
         const usage = runResult.meta.agentMeta?.usage;
-        const promptUsage = runResult.meta.agentMeta?.promptUsage ?? usage;
+        const promptUsage = runResult.meta.agentMeta?.promptUsage;
         const modelUsed = runResult.meta.agentMeta?.model ?? fallbackModel ?? defaultModel;
         const contextTokensUsed =
           agentCfgContextTokens ??
@@ -207,7 +207,8 @@ export function createFollowupRunner(params: {
         await persistSessionUsageUpdate({
           storePath,
           sessionKey,
-          usage: promptUsage,
+          usage,
+          promptUsage,
           modelUsed,
           providerUsed: fallbackProvider,
           contextTokensUsed,

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -22,7 +22,7 @@ import {
 } from "./reply-payloads.js";
 import { resolveReplyToMode } from "./reply-threading.js";
 import { isRoutableChannel, routeReply } from "./route-reply.js";
-import { incrementCompactionCount } from "./session-updates.js";
+import { estimateCompactionTokensAfter, incrementCompactionCount } from "./session-updates.js";
 import { persistSessionUsageUpdate } from "./session-usage.js";
 import { createTypingSignaler } from "./typing-mode.js";
 
@@ -265,11 +265,16 @@ export function createFollowupRunner(params: {
       }
 
       if (autoCompactionCompleted) {
+        const tokensAfter = estimateCompactionTokensAfter({
+          sessionFile: queued.run.sessionFile ?? sessionEntry?.sessionFile,
+          tokensBefore: sessionEntry?.totalTokens,
+        });
         const count = await incrementCompactionCount({
           sessionEntry,
           sessionStore,
           sessionKey,
           storePath,
+          tokensAfter,
         });
         if (queued.run.verboseLevel && queued.run.verboseLevel !== "off") {
           const suffix = typeof count === "number" ? ` (count ${count})` : "";

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -196,6 +196,7 @@ export function createFollowupRunner(params: {
 
       if (storePath && sessionKey) {
         const usage = runResult.meta.agentMeta?.usage;
+        const promptUsage = runResult.meta.agentMeta?.promptUsage ?? usage;
         const modelUsed = runResult.meta.agentMeta?.model ?? fallbackModel ?? defaultModel;
         const contextTokensUsed =
           agentCfgContextTokens ??
@@ -206,7 +207,7 @@ export function createFollowupRunner(params: {
         await persistSessionUsageUpdate({
           storePath,
           sessionKey,
-          usage,
+          usage: promptUsage,
           modelUsed,
           providerUsed: fallbackProvider,
           contextTokensUsed,

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -258,6 +258,8 @@ export async function incrementCompactionCount(params: {
     // Clear input/output breakdown since we only have the total estimate after compaction
     updates.inputTokens = undefined;
     updates.outputTokens = undefined;
+  } else if (tokensAfter == null) {
+    updates.totalTokens = 0;
   }
   sessionStore[sessionKey] = {
     ...entry,

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -142,6 +142,7 @@ export async function agentCommand(
     sessionId: opts.sessionId,
     sessionKey: opts.sessionKey,
     agentId: agentIdOverride,
+    sessionEntry: opts.sessionEntry,
   });
 
   const {

--- a/src/commands/agent/session.ts
+++ b/src/commands/agent/session.ts
@@ -87,6 +87,7 @@ export function resolveSession(opts: {
   sessionId?: string;
   sessionKey?: string;
   agentId?: string;
+  sessionEntry?: SessionEntry;
 }): SessionResolution {
   const sessionCfg = opts.cfg.session;
   const { sessionKey, sessionStore, storePath } = resolveSessionKeyForRequest({
@@ -98,7 +99,7 @@ export function resolveSession(opts: {
   });
   const now = Date.now();
 
-  const sessionEntry = sessionKey ? sessionStore[sessionKey] : undefined;
+  const sessionEntry = opts.sessionEntry ?? (sessionKey ? sessionStore[sessionKey] : undefined);
 
   const resetType = resolveSessionResetType({ sessionKey });
   const channelReset = resolveChannelResetConfig({

--- a/src/commands/agent/types.ts
+++ b/src/commands/agent/types.ts
@@ -1,5 +1,6 @@
 import type { ClientToolDefinition } from "../../agents/pi-embedded-runner/run/params.js";
 import type { ChannelOutboundTargetMode } from "../../channels/plugins/types.js";
+import type { SessionEntry } from "../../config/sessions.js";
 
 /** Image content block for Claude API multimodal messages. */
 export type ImageContent = {
@@ -37,6 +38,8 @@ export type AgentCommandOpts = {
   to?: string;
   sessionId?: string;
   sessionKey?: string;
+  /** Optional session entry override (used when caller already resolved session data). */
+  sessionEntry?: SessionEntry;
   thinking?: string;
   thinkingOnce?: string;
   verbose?: string;

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -31,6 +31,7 @@ export type AgentContextPruningConfig = {
   ttl?: string;
   keepLastAssistants?: number;
   stripThinking?: boolean;
+  forcePruneRatio?: number;
   softTrimRatio?: number;
   hardClearRatio?: number;
   minPrunableToolChars?: number;

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -30,6 +30,7 @@ export type AgentContextPruningConfig = {
   /** TTL to consider cache expired (duration string, default unit: minutes). */
   ttl?: string;
   keepLastAssistants?: number;
+  stripThinking?: boolean;
   softTrimRatio?: number;
   hardClearRatio?: number;
   minPrunableToolChars?: number;

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -61,6 +61,7 @@ export const AgentDefaultsSchema = z
         ttl: z.string().optional(),
         keepLastAssistants: z.number().int().nonnegative().optional(),
         stripThinking: z.boolean().optional(),
+        forcePruneRatio: z.number().min(0).max(1).optional(),
         softTrimRatio: z.number().min(0).max(1).optional(),
         hardClearRatio: z.number().min(0).max(1).optional(),
         minPrunableToolChars: z.number().int().nonnegative().optional(),

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -60,6 +60,7 @@ export const AgentDefaultsSchema = z
         mode: z.union([z.literal("off"), z.literal("cache-ttl")]).optional(),
         ttl: z.string().optional(),
         keepLastAssistants: z.number().int().nonnegative().optional(),
+        stripThinking: z.boolean().optional(),
         softTrimRatio: z.number().min(0).max(1).optional(),
         hardClearRatio: z.number().min(0).max(1).optional(),
         minPrunableToolChars: z.number().int().nonnegative().optional(),

--- a/src/extensionAPI.ts
+++ b/src/extensionAPI.ts
@@ -12,3 +12,6 @@ export {
   saveSessionStore,
   resolveSessionFilePath,
 } from "./config/sessions.ts";
+
+export { default as contextPruningExtension } from "./agents/pi-extensions/context-pruning/extension.js";
+export { estimateContextUsageRatio } from "./agents/pi-extensions/context-pruning/pruner.js";

--- a/src/gateway/protocol/schema/agent.ts
+++ b/src/gateway/protocol/schema/agent.ts
@@ -50,6 +50,7 @@ export const AgentParamsSchema = Type.Object(
     replyTo: Type.Optional(Type.String()),
     sessionId: Type.Optional(Type.String()),
     sessionKey: Type.Optional(Type.String()),
+    model: Type.Optional(NonEmptyString),
     thinking: Type.Optional(Type.String()),
     deliver: Type.Optional(Type.Boolean()),
     attachments: Type.Optional(Type.Array(Type.Unknown())),

--- a/src/gateway/server-startup-memory.test.ts
+++ b/src/gateway/server-startup-memory.test.ts
@@ -1,0 +1,291 @@
+import { EventEmitter } from "node:events";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+function createTestLogger() {
+  const info = vi.fn();
+  const warn = vi.fn();
+  const child = vi.fn(() => ({ ...logger, child }));
+  const logger = {
+    subsystem: "memory",
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info,
+    warn,
+    error: vi.fn(),
+    fatal: vi.fn(),
+    raw: vi.fn(),
+    child,
+  };
+  return { logger, info, warn };
+}
+
+describe("startGatewayMemoryBackendOnBoot", () => {
+  const resolveMemoryBackendConfig = vi.fn();
+  const getMemorySearchManager = vi.fn();
+  const log = createTestLogger();
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+    resolveMemoryBackendConfig.mockReset();
+    getMemorySearchManager.mockReset();
+    log.info.mockReset();
+    log.warn.mockReset();
+
+    vi.doMock("../logging/subsystem.js", () => ({
+      createSubsystemLogger: () => log.logger,
+    }));
+    vi.doMock("../memory/backend-config.js", () => ({
+      resolveMemoryBackendConfig,
+    }));
+    vi.doMock("../memory/search-manager.js", () => ({
+      getMemorySearchManager,
+    }));
+  });
+
+  afterEach(() => {
+    vi.unmock("../logging/subsystem.js");
+    vi.unmock("../memory/backend-config.js");
+    vi.unmock("../memory/search-manager.js");
+    vi.doUnmock("../logging/subsystem.js");
+    vi.doUnmock("../memory/backend-config.js");
+    vi.doUnmock("../memory/search-manager.js");
+  });
+
+  it("eagerly initializes QMD on boot for the default agent", async () => {
+    resolveMemoryBackendConfig.mockReturnValue({
+      backend: "qmd",
+      citations: "auto",
+      qmd: {},
+    });
+    getMemorySearchManager.mockResolvedValue({ manager: {}, backend: "qmd" });
+
+    const { startGatewayMemoryBackendOnBoot } = await import("./server-startup-memory.js");
+    const cfg = { agents: { list: [{ id: "main", default: true }] } } as never;
+    await startGatewayMemoryBackendOnBoot({ cfg });
+
+    expect(getMemorySearchManager).toHaveBeenCalledTimes(1);
+    expect(getMemorySearchManager).toHaveBeenCalledWith({ cfg, agentId: "main" });
+    expect(log.info).toHaveBeenCalledWith("initialized on boot");
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it("does not log success when QMD init fails and builtin fallback is used", async () => {
+    resolveMemoryBackendConfig.mockReturnValue({
+      backend: "qmd",
+      citations: "auto",
+      qmd: {},
+    });
+    getMemorySearchManager.mockResolvedValue({
+      manager: {},
+      backend: "builtin",
+      error: "qmd missing",
+    });
+
+    const { startGatewayMemoryBackendOnBoot } = await import("./server-startup-memory.js");
+    const cfg = { agents: { list: [{ id: "main", default: true }] } } as never;
+    await startGatewayMemoryBackendOnBoot({ cfg });
+
+    expect(log.info).not.toHaveBeenCalled();
+    expect(log.warn).toHaveBeenCalledWith("boot init failed, using builtin fallback", {
+      error: "qmd missing",
+    });
+  });
+
+  it("defaults the boot init to agentId=main when agents.list is missing/empty", async () => {
+    resolveMemoryBackendConfig.mockReturnValue({
+      backend: "qmd",
+      citations: "auto",
+      qmd: {},
+    });
+    getMemorySearchManager.mockResolvedValue({ manager: {}, backend: "qmd" });
+
+    const { startGatewayMemoryBackendOnBoot } = await import("./server-startup-memory.js");
+    const cfg = {} as never;
+    await startGatewayMemoryBackendOnBoot({ cfg });
+
+    expect(getMemorySearchManager).toHaveBeenCalledWith({ cfg, agentId: "main" });
+  });
+
+  it("does not initialize when memory backend is not qmd", async () => {
+    resolveMemoryBackendConfig.mockReturnValue({
+      backend: "builtin",
+      citations: "auto",
+    });
+
+    const { startGatewayMemoryBackendOnBoot } = await import("./server-startup-memory.js");
+    const cfg = { agents: { list: [{ id: "main", default: true }] } } as never;
+    await startGatewayMemoryBackendOnBoot({ cfg });
+
+    expect(getMemorySearchManager).not.toHaveBeenCalled();
+    expect(log.info).not.toHaveBeenCalled();
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+});
+
+describe("getMemorySearchManager", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unmock("../logging/subsystem.js");
+    vi.doUnmock("../memory/search-manager.js");
+    vi.doUnmock("../memory/qmd-manager.js");
+    vi.doUnmock(import.meta.resolve("../memory/qmd-manager.js"));
+    vi.doUnmock("node:child_process");
+    vi.unstubAllGlobals();
+  });
+
+  it("dedups concurrent QMD init so only one QmdMemoryManager is created", async () => {
+    vi.resetModules();
+    vi.doUnmock("../memory/search-manager.js");
+    vi.doUnmock("../memory/qmd-manager.js");
+
+    const warnSpy = vi.fn();
+    const testLogger = {
+      subsystem: "memory",
+      trace: vi.fn(),
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: warnSpy,
+      error: vi.fn(),
+      fatal: vi.fn(),
+      raw: vi.fn(),
+      child: () => testLogger,
+    };
+    vi.doMock("../logging/subsystem.js", () => ({
+      createSubsystemLogger: () => testLogger,
+    }));
+
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-state-"));
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-"));
+    const originalStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+
+    // Avoid spawning real qmd; always succeed fast.
+    vi.doMock("node:child_process", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("node:child_process")>();
+      return {
+        ...actual,
+        spawn: () => {
+          const child = new EventEmitter() as never;
+          (child as { stdout: EventEmitter }).stdout = new EventEmitter();
+          (child as { stderr: EventEmitter }).stderr = new EventEmitter();
+          (child as { kill: (signal: string) => void }).kill = () => {};
+          queueMicrotask(() => {
+            (child as { stdout: EventEmitter }).stdout.emit("data", "[]");
+            (child as EventEmitter).emit("close", 0);
+          });
+          return child;
+        },
+      };
+    });
+
+    const setIntervalSpy = vi
+      .spyOn(globalThis, "setInterval")
+      .mockImplementation((_fn: never, _ms?: number) => ({}) as never);
+
+    try {
+      const { getMemorySearchManager } = await import("../memory/search-manager.js");
+      expect(vi.isMockFunction(getMemorySearchManager)).toBe(false);
+      const cfg = {
+        agents: { defaults: { workspace: workspaceDir }, list: [{ id: "main", default: true }] },
+        memory: {
+          backend: "qmd",
+          qmd: {
+            includeDefaultMemory: false,
+            update: { interval: "1s", onBoot: false },
+            sessions: { enabled: false },
+          },
+        },
+      } as never;
+      const p1 = getMemorySearchManager({ cfg, agentId: "main" });
+      const p2 = getMemorySearchManager({ cfg, agentId: "main" });
+
+      const [r1, r2] = await Promise.all([p1, p2]);
+      if (!r1.manager || !r2.manager) {
+        throw new Error(
+          `expected qmd manager; got null manager(s). warnings=${JSON.stringify(
+            warnSpy.mock.calls,
+          )} r1=${JSON.stringify(r1)} r2=${JSON.stringify(r2)}`,
+        );
+      }
+      expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      process.env.OPENCLAW_STATE_DIR = originalStateDir;
+      setIntervalSpy.mockRestore();
+    }
+  });
+});
+
+describe("QmdMemoryManager.initialize", () => {
+  const ORIGINAL_STATE_DIR = process.env.OPENCLAW_STATE_DIR;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unmock("../logging/subsystem.js");
+    process.env.OPENCLAW_STATE_DIR = ORIGINAL_STATE_DIR;
+  });
+
+  it("arms the interval timer even if the boot update fails", async () => {
+    vi.resetModules();
+
+    const log = createTestLogger();
+    vi.doMock("../logging/subsystem.js", () => ({
+      createSubsystemLogger: () => log.logger,
+    }));
+
+    const setIntervalSpy = vi
+      .spyOn(globalThis, "setInterval")
+      .mockImplementation((_fn: never, _ms?: number) => ({}) as never);
+
+    // Ensure we load the real class (not a prior mock).
+    vi.doUnmock("../memory/qmd-manager.js");
+    vi.unmock("../memory/qmd-manager.js");
+    const { QmdMemoryManager } = await import("../memory/qmd-manager.js");
+
+    vi.spyOn(QmdMemoryManager.prototype as never, "runQmd" as never).mockResolvedValue({
+      stdout: "[]",
+      stderr: "",
+    });
+
+    const bootError = new Error("boot update timed out");
+    const runUpdateSpy = vi
+      .spyOn(QmdMemoryManager.prototype as never, "runUpdate" as never)
+      .mockRejectedValueOnce(bootError);
+
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-state-"));
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-"));
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+
+    const cfg = {
+      agents: { defaults: { workspace: workspaceDir }, list: [{ id: "main", default: true }] },
+    } as never;
+
+    const resolved = {
+      backend: "qmd",
+      citations: "auto",
+      qmd: {
+        command: "qmd",
+        collections: [],
+        sessions: { enabled: false },
+        includeDefaultMemory: false,
+        update: { intervalMs: 1, debounceMs: 0, onBoot: true, embedIntervalMs: 0 },
+        limits: { maxResults: 1, maxSnippetChars: 10, maxInjectedChars: 100, timeoutMs: 1 },
+      },
+    } as never;
+
+    const manager = await QmdMemoryManager.create({ cfg, agentId: "main", resolved });
+    expect(manager).not.toBeNull();
+    expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+    expect(runUpdateSpy).toHaveBeenCalled();
+
+    const intervalOrder = setIntervalSpy.mock.invocationCallOrder[0];
+    const updateOrder = runUpdateSpy.mock.invocationCallOrder[0];
+    expect(intervalOrder).toBeLessThan(updateOrder);
+
+    setIntervalSpy.mockRestore();
+  });
+});

--- a/src/gateway/server-startup-memory.ts
+++ b/src/gateway/server-startup-memory.ts
@@ -1,0 +1,39 @@
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { resolveMemoryBackendConfig } from "../memory/backend-config.js";
+import { getMemorySearchManager } from "../memory/search-manager.js";
+
+const log = createSubsystemLogger("memory").child("qmd");
+
+/**
+ * QMD (memory sidecar) is lazily initialized by memory tool calls. After a gateway restart,
+ * the in-memory manager and its interval timer are gone unless a memory tool is invoked.
+ *
+ * This boot hook eagerly creates the manager for the default agent (when configured),
+ * which arms the periodic update/embed timer without changing the lazy tool-call path.
+ */
+export async function startGatewayMemoryBackendOnBoot(params: {
+  cfg: OpenClawConfig;
+}): Promise<void> {
+  try {
+    const agentId = resolveDefaultAgentId(params.cfg);
+    const resolved = resolveMemoryBackendConfig({ cfg: params.cfg, agentId });
+    if (resolved.backend !== "qmd") {
+      return;
+    }
+
+    const { manager, backend, error } = await getMemorySearchManager({ cfg: params.cfg, agentId });
+    if (manager) {
+      if (backend === "qmd") {
+        log.info("initialized on boot");
+        return;
+      }
+      log.warn("boot init failed, using builtin fallback", { error });
+      return;
+    }
+    log.warn("failed to initialize on boot", { error: error ?? "unknown error" });
+  } catch (err) {
+    log.warn("failed to initialize on boot", { err });
+  }
+}

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -65,6 +65,7 @@ import { resolveGatewayRuntimeConfig } from "./server-runtime-config.js";
 import { createGatewayRuntimeState } from "./server-runtime-state.js";
 import { resolveSessionKeyForRun } from "./server-session-key.js";
 import { logGatewayStartup } from "./server-startup-log.js";
+import { startGatewayMemoryBackendOnBoot } from "./server-startup-memory.js";
 import { startGatewaySidecars } from "./server-startup.js";
 import { startGatewayTailscaleExposure } from "./server-tailscale.js";
 import { createWizardSessionTracker } from "./server-wizard-sessions.js";
@@ -557,6 +558,12 @@ export async function startGatewayServer(
     logChannels,
     logBrowser,
   }));
+
+  // Boot hook: if memory.backend resolves to QMD, eagerly create the manager once so its
+  // periodic update/embed interval is armed even if no memory tool is called after restart.
+  // Intentionally fire-and-forget: we don't want to block gateway startup, and shutdown/restart
+  // does not currently cancel this in-flight initialization.
+  void startGatewayMemoryBackendOnBoot({ cfg: cfgAtStart });
 
   const { applyHotReload, requestGatewayRestart } = createGatewayReloadHandlers({
     deps,

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -12,6 +12,7 @@ import {
 } from "../agents/agent-scope.js";
 import { resolveUserTimezone } from "../agents/date-time.js";
 import { resolveEffectiveMessagesConfig } from "../agents/identity.js";
+import { isEmbeddedPiRunActive } from "../agents/pi-embedded.js";
 import { DEFAULT_HEARTBEAT_FILENAME } from "../agents/workspace.js";
 import {
   DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
@@ -545,6 +546,10 @@ export async function runHeartbeatOnce(opts: {
   }
 
   const { entry, sessionKey, storePath } = resolveHeartbeatSession(cfg, agentId, heartbeat);
+  const sessionId = entry?.sessionId;
+  if (sessionId && isEmbeddedPiRunActive(sessionId)) {
+    return { status: "skipped", reason: "session-busy" };
+  }
   const previousUpdatedAt = entry?.updatedAt;
   const delivery = resolveHeartbeatDeliveryTarget({ cfg, entry, heartbeat });
   const heartbeatAccountId = heartbeat?.accountId?.trim();

--- a/src/memory/backend-config.test.ts
+++ b/src/memory/backend-config.test.ts
@@ -29,7 +29,7 @@ describe("resolveMemoryBackendConfig", () => {
     expect(resolved.qmd?.update.waitForBootSync).toBe(false);
     expect(resolved.qmd?.update.commandTimeoutMs).toBe(30_000);
     expect(resolved.qmd?.update.updateTimeoutMs).toBe(120_000);
-    expect(resolved.qmd?.update.embedTimeoutMs).toBe(120_000);
+    expect(resolved.qmd?.update.embedTimeoutMs).toBe(600_000);
   });
 
   it("parses quoted qmd command paths", () => {

--- a/src/memory/backend-config.ts
+++ b/src/memory/backend-config.ts
@@ -67,7 +67,7 @@ const DEFAULT_QMD_TIMEOUT_MS = 4_000;
 const DEFAULT_QMD_EMBED_INTERVAL = "60m";
 const DEFAULT_QMD_COMMAND_TIMEOUT_MS = 30_000;
 const DEFAULT_QMD_UPDATE_TIMEOUT_MS = 120_000;
-const DEFAULT_QMD_EMBED_TIMEOUT_MS = 120_000;
+const DEFAULT_QMD_EMBED_TIMEOUT_MS = 600_000;
 const DEFAULT_QMD_LIMITS: ResolvedQmdLimitsConfig = {
   maxResults: 6,
   maxSnippetChars: 700,
@@ -138,6 +138,13 @@ function resolveEmbedIntervalMs(raw: string | undefined): number {
   } catch {
     return parseDurationMs(DEFAULT_QMD_EMBED_INTERVAL, { defaultUnit: "m" });
   }
+}
+
+function resolveEmbedTimeoutMs(raw: number | undefined): number {
+  if (typeof raw === "number" && Number.isFinite(raw) && raw > 0) {
+    return Math.floor(raw);
+  }
+  return DEFAULT_QMD_EMBED_TIMEOUT_MS;
 }
 
 function resolveDebounceMs(raw: number | undefined): number {
@@ -282,10 +289,7 @@ export function resolveMemoryBackendConfig(params: {
         qmdCfg?.update?.updateTimeoutMs,
         DEFAULT_QMD_UPDATE_TIMEOUT_MS,
       ),
-      embedTimeoutMs: resolveTimeoutMs(
-        qmdCfg?.update?.embedTimeoutMs,
-        DEFAULT_QMD_EMBED_TIMEOUT_MS,
-      ),
+      embedTimeoutMs: resolveEmbedTimeoutMs(qmdCfg?.update?.embedTimeoutMs),
     },
     limits: resolveLimits(qmdCfg?.limits),
     scope: qmdCfg?.scope ?? DEFAULT_QMD_SCOPE,

--- a/src/memory/backend-config.ts
+++ b/src/memory/backend-config.ts
@@ -254,6 +254,8 @@ export function resolveMemoryBackendConfig(params: {
 }): ResolvedMemoryBackendConfig {
   const backend = params.cfg.memory?.backend ?? DEFAULT_BACKEND;
   const citations = params.cfg.memory?.citations ?? DEFAULT_CITATIONS;
+  // NOTE: Today, anything other than "qmd" is treated as "builtin".
+  // If additional backends are introduced, this resolver must be updated.
   if (backend !== "qmd") {
     return { backend: "builtin", citations };
   }

--- a/src/memory/qmd-manager.test.ts
+++ b/src/memory/qmd-manager.test.ts
@@ -50,6 +50,7 @@ vi.mock("../logging/subsystem.js", () => ({
       warn: logWarnMock,
       debug: logDebugMock,
       info: logInfoMock,
+      error: vi.fn(),
       child: () => logger,
     };
     return logger;

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -155,25 +155,26 @@ export class QmdMemoryManager implements MemorySearchManager {
 
     this.bootstrapCollections();
     await this.ensureCollections();
+    if (this.qmd.update.intervalMs > 0) {
+      this.updateTimer = setInterval(() => {
+        void this.runUpdate("interval").catch((err) => {
+          log.warn("qmd update failed (interval)", { err });
+        });
+      }, this.qmd.update.intervalMs);
+    }
 
+    // Arm the interval before attempting the boot update so failures/timeouts don't prevent retries.
     if (this.qmd.update.onBoot) {
       const bootRun = this.runUpdate("boot", true);
       if (this.qmd.update.waitForBootSync) {
         await bootRun.catch((err) => {
-          log.warn(`qmd boot update failed: ${String(err)}`);
+          log.warn("qmd update failed (boot)", { err });
         });
       } else {
         void bootRun.catch((err) => {
-          log.warn(`qmd boot update failed: ${String(err)}`);
+          log.warn("qmd update failed (boot)", { err });
         });
       }
-    }
-    if (this.qmd.update.intervalMs > 0) {
-      this.updateTimer = setInterval(() => {
-        void this.runUpdate("interval").catch((err) => {
-          log.warn(`qmd update failed (${String(err)})`);
-        });
-      }, this.qmd.update.intervalMs);
     }
   }
 

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -90,6 +90,7 @@ export class QmdMemoryManager implements MemorySearchManager {
   private db: SqliteDatabase | null = null;
   private lastUpdateAt: number | null = null;
   private lastEmbedAt: number | null = null;
+  private lastEmbedError: string | null = null;
 
   private constructor(params: {
     cfg: OpenClawConfig;
@@ -374,6 +375,8 @@ export class QmdMemoryManager implements MemorySearchManager {
         qmd: {
           collections: this.qmd.collections.length,
           lastUpdateAt: this.lastUpdateAt,
+          lastEmbedAt: this.lastEmbedAt,
+          lastEmbedError: this.lastEmbedError,
         },
       },
     };
@@ -434,16 +437,20 @@ export class QmdMemoryManager implements MemorySearchManager {
       }
       await this.runQmd(["update"], { timeoutMs: this.qmd.update.updateTimeoutMs });
       const embedIntervalMs = this.qmd.update.embedIntervalMs;
+      const embedTimeoutMs = this.qmd.update.embedTimeoutMs ?? 600_000;
       const shouldEmbed =
         Boolean(force) ||
         this.lastEmbedAt === null ||
         (embedIntervalMs > 0 && Date.now() - this.lastEmbedAt > embedIntervalMs);
       if (shouldEmbed) {
         try {
-          await this.runQmd(["embed"], { timeoutMs: this.qmd.update.embedTimeoutMs });
+          await this.runQmd(["embed"], { timeoutMs: embedTimeoutMs });
           this.lastEmbedAt = Date.now();
+          this.lastEmbedError = null;
         } catch (err) {
-          log.warn(`qmd embed failed (${reason}): ${String(err)}`);
+          const message = `qmd embed failed (${reason}, timeout ${embedTimeoutMs}ms): ${String(err)}`;
+          this.lastEmbedError = message;
+          log.error(message);
         }
       }
       this.lastUpdateAt = Date.now();

--- a/src/memory/search-manager.test.ts
+++ b/src/memory/search-manager.test.ts
@@ -65,6 +65,7 @@ vi.mock("./manager.js", () => ({
   },
 }));
 
+import { MemoryIndexManager } from "./manager.js";
 import { QmdMemoryManager } from "./qmd-manager.js";
 import { getMemorySearchManager } from "./search-manager.js";
 
@@ -84,6 +85,7 @@ beforeEach(() => {
   fallbackManager.probeVectorAvailability.mockClear();
   fallbackManager.close.mockClear();
   QmdMemoryManager.create.mockClear();
+  MemoryIndexManager.get.mockClear();
 });
 
 describe("getMemorySearchManager caching", () => {
@@ -178,5 +180,108 @@ describe("getMemorySearchManager caching", () => {
     expect(results).toHaveLength(1);
     expect(results[0]?.path).toBe("MEMORY.md");
     expect(fallbackSearch).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("FallbackMemoryManager QMD recovery", () => {
+  const mockFallback = {
+    search: vi.fn(async () => [
+      {
+        path: "MEMORY.md",
+        startLine: 1,
+        endLine: 1,
+        score: 1,
+        snippet: "",
+        source: "memory" as const,
+      },
+    ]),
+    readFile: vi.fn(async () => ({ text: "", path: "MEMORY.md" })),
+    status: vi.fn(() => mockPrimary.status()),
+    sync: vi.fn(async () => {}),
+    probeEmbeddingAvailability: vi.fn(async () => ({ ok: true })),
+    probeVectorAvailability: vi.fn(async () => true),
+    close: vi.fn(async () => {}),
+  };
+
+  beforeEach(() => {
+    mockFallback.search.mockClear();
+    mockFallback.readFile.mockClear();
+    mockFallback.status.mockClear();
+    mockFallback.sync.mockClear();
+    mockFallback.probeEmbeddingAvailability.mockClear();
+    mockFallback.probeVectorAvailability.mockClear();
+    mockFallback.close.mockClear();
+  });
+
+  it("falls back per-query on transient errors without closing QMD", async () => {
+    MemoryIndexManager.get.mockResolvedValue(mockFallback);
+    mockPrimary.search
+      .mockRejectedValueOnce(new Error("qmd query timed out after 100ms"))
+      .mockResolvedValueOnce([]);
+
+    const cfg = {
+      memory: { backend: "qmd", qmd: {} },
+      agents: { list: [{ id: "timeout", default: true, workspace: "/tmp/workspace" }] },
+    } as const;
+
+    const result = await getMemorySearchManager({ cfg, agentId: "timeout" });
+    expect(result.manager).not.toBeNull();
+
+    const first = await result.manager!.search("hello");
+    const second = await result.manager!.search("hello");
+
+    expect(first).toHaveLength(1);
+    expect(second).toEqual([]);
+    expect(mockPrimary.close).not.toHaveBeenCalled();
+    expect(mockPrimary.search).toHaveBeenCalledTimes(2);
+    expect(mockFallback.search).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables and closes QMD after 5 consecutive non-transient failures", async () => {
+    MemoryIndexManager.get.mockResolvedValue(mockFallback);
+    mockPrimary.search.mockRejectedValue(new Error("qmd query failed (code 1): bad"));
+
+    const cfg = {
+      memory: { backend: "qmd", qmd: {} },
+      agents: { list: [{ id: "fatal", default: true, workspace: "/tmp/workspace" }] },
+    } as const;
+
+    const result = await getMemorySearchManager({ cfg, agentId: "fatal" });
+    expect(result.manager).not.toBeNull();
+
+    for (let i = 0; i < 6; i += 1) {
+      const res = await result.manager!.search("hello");
+      expect(res).toHaveLength(1);
+    }
+
+    // 5 attempts reach the threshold, 6th bypasses primary entirely.
+    expect(mockPrimary.search).toHaveBeenCalledTimes(5);
+    expect(mockPrimary.close).toHaveBeenCalledTimes(1);
+    expect(mockFallback.search).toHaveBeenCalledTimes(6);
+  });
+
+  it("resets the failure counter when QMD succeeds after previous failures", async () => {
+    MemoryIndexManager.get.mockResolvedValue(mockFallback);
+    mockPrimary.search
+      .mockRejectedValueOnce(new Error("qmd query failed (code 1): bad"))
+      .mockRejectedValueOnce(new Error("qmd query failed (code 1): bad"))
+      .mockResolvedValueOnce([])
+      .mockRejectedValue(new Error("qmd query failed (code 1): bad"));
+
+    const cfg = {
+      memory: { backend: "qmd", qmd: {} },
+      agents: { list: [{ id: "reset", default: true, workspace: "/tmp/workspace" }] },
+    } as const;
+
+    const result = await getMemorySearchManager({ cfg, agentId: "reset" });
+    expect(result.manager).not.toBeNull();
+
+    // 2 failures -> fallback; 1 success -> primary; then 4 failures -> fallback.
+    for (let i = 0; i < 7; i += 1) {
+      await result.manager!.search("hello");
+    }
+
+    // If the counter had not reset after the success, we would have hit 5 consecutive failures and closed.
+    expect(mockPrimary.close).not.toHaveBeenCalled();
   });
 });

--- a/src/memory/search-manager.ts
+++ b/src/memory/search-manager.ts
@@ -66,9 +66,11 @@ export async function getMemorySearchManager(params: {
 
 class FallbackMemoryManager implements MemorySearchManager {
   private fallback: MemorySearchManager | null = null;
-  private primaryFailed = false;
+  private primaryDisabled = false;
+  private consecutivePrimaryFailures = 0;
   private lastError?: string;
   private cacheEvicted = false;
+  private readonly maxConsecutiveFailuresBeforeDisable: number;
 
   constructor(
     private readonly deps: {
@@ -76,22 +78,60 @@ class FallbackMemoryManager implements MemorySearchManager {
       fallbackFactory: () => Promise<MemorySearchManager | null>;
     },
     private readonly onClose?: () => void,
-  ) {}
+    opts?: { maxConsecutiveFailuresBeforeDisable?: number },
+  ) {
+    this.maxConsecutiveFailuresBeforeDisable = Math.max(
+      1,
+      opts?.maxConsecutiveFailuresBeforeDisable ?? 5,
+    );
+  }
 
   async search(
     query: string,
     opts?: { maxResults?: number; minScore?: number; sessionKey?: string },
   ) {
-    if (!this.primaryFailed) {
+    if (!this.primaryDisabled) {
       try {
-        return await this.deps.primary.search(query, opts);
+        const results = await this.deps.primary.search(query, opts);
+        if (this.consecutivePrimaryFailures > 0) {
+          log.info(
+            `qmd memory recovered after ${this.consecutivePrimaryFailures} failure(s); resuming primary`,
+          );
+          this.consecutivePrimaryFailures = 0;
+          this.lastError = undefined;
+        }
+        return results;
       } catch (err) {
-        this.primaryFailed = true;
         this.lastError = err instanceof Error ? err.message : String(err);
-        log.warn(`qmd memory failed; switching to builtin index: ${this.lastError}`);
-        await this.deps.primary.close?.().catch(() => {});
         // Evict the failed wrapper so the next request can retry QMD with a fresh manager.
         this.evictCacheEntry();
+        const transient = isTransientQmdError(err);
+
+        if (transient) {
+          // Per-query fallback only. Do not permanently disable QMD for transient failures.
+          log.warn(
+            `qmd memory search failed (transient; consecutive=${this.consecutivePrimaryFailures}); falling back to builtin for this query: ${this.lastError}`,
+          );
+        } else {
+          this.consecutivePrimaryFailures += 1;
+          const threshold = this.maxConsecutiveFailuresBeforeDisable;
+          if (this.consecutivePrimaryFailures >= threshold) {
+            this.primaryDisabled = true;
+            log.warn(
+              `qmd memory search failed ${this.consecutivePrimaryFailures}x; disabling qmd and switching to builtin index: ${this.lastError}`,
+            );
+            await this.deps.primary.close?.().catch(() => {});
+          } else {
+            log.warn(
+              `qmd memory search failed (consecutive=${this.consecutivePrimaryFailures}/${threshold}); falling back to builtin for this query: ${this.lastError}`,
+            );
+          }
+        }
+
+        const fallback = await this.ensureFallback();
+        if (fallback) {
+          return await fallback.search(query, opts);
+        }
       }
     }
     const fallback = await this.ensureFallback();
@@ -102,7 +142,7 @@ class FallbackMemoryManager implements MemorySearchManager {
   }
 
   async readFile(params: { relPath: string; from?: number; lines?: number }) {
-    if (!this.primaryFailed) {
+    if (!this.primaryDisabled) {
       return await this.deps.primary.readFile(params);
     }
     const fallback = await this.ensureFallback();
@@ -113,8 +153,23 @@ class FallbackMemoryManager implements MemorySearchManager {
   }
 
   status() {
-    if (!this.primaryFailed) {
-      return this.deps.primary.status();
+    if (!this.primaryDisabled) {
+      const status = this.deps.primary.status();
+      const custom = status.custom ?? {};
+      if (this.consecutivePrimaryFailures > 0) {
+        return {
+          ...status,
+          custom: {
+            ...custom,
+            fallback: {
+              ...custom.fallback,
+              consecutiveFailures: this.consecutivePrimaryFailures,
+              lastError: this.lastError ?? "unknown",
+            },
+          },
+        };
+      }
+      return status;
     }
     const fallbackStatus = this.fallback?.status();
     const fallbackInfo = { from: "qmd", reason: this.lastError ?? "unknown" };
@@ -146,7 +201,7 @@ class FallbackMemoryManager implements MemorySearchManager {
     force?: boolean;
     progress?: (update: MemorySyncProgressUpdate) => void;
   }) {
-    if (!this.primaryFailed) {
+    if (!this.primaryDisabled) {
       await this.deps.primary.sync?.(params);
       return;
     }
@@ -155,7 +210,7 @@ class FallbackMemoryManager implements MemorySearchManager {
   }
 
   async probeEmbeddingAvailability(): Promise<MemoryEmbeddingProbeResult> {
-    if (!this.primaryFailed) {
+    if (!this.primaryDisabled) {
       return await this.deps.primary.probeEmbeddingAvailability();
     }
     const fallback = await this.ensureFallback();
@@ -166,7 +221,7 @@ class FallbackMemoryManager implements MemorySearchManager {
   }
 
   async probeVectorAvailability() {
-    if (!this.primaryFailed) {
+    if (!this.primaryDisabled) {
       return await this.deps.primary.probeVectorAvailability();
     }
     const fallback = await this.ensureFallback();
@@ -203,6 +258,39 @@ class FallbackMemoryManager implements MemorySearchManager {
 
 function buildQmdCacheKey(agentId: string, config: ResolvedQmdConfig): string {
   return `${agentId}:${stableSerialize(config)}`;
+}
+
+function isTransientQmdError(err: unknown): boolean {
+  const code = err && typeof err === "object" ? (err as { code?: unknown }).code : undefined;
+  if (typeof code === "string") {
+    if (code === "ENOENT") {
+      return false;
+    }
+    if (
+      code === "ETIMEDOUT" ||
+      code === "ECONNRESET" ||
+      code === "EPIPE" ||
+      code === "EAI_AGAIN" ||
+      code === "ECONNREFUSED" ||
+      code === "ENETUNREACH" ||
+      code === "EHOSTUNREACH"
+    ) {
+      return true;
+    }
+  }
+
+  const message = err instanceof Error ? err.message : String(err);
+  const lower = message.toLowerCase();
+  if (lower.includes("timed out") || lower.includes("timeout")) {
+    return true;
+  }
+  if (lower.includes("database is locked") || lower.includes("resource busy")) {
+    return true;
+  }
+  if (lower.includes("temporarily unavailable") || lower.includes("try again")) {
+    return true;
+  }
+  return false;
 }
 
 function stableSerialize(value: unknown): string {

--- a/src/memory/search-manager.ts
+++ b/src/memory/search-manager.ts
@@ -10,9 +10,13 @@ import { resolveMemoryBackendConfig } from "./backend-config.js";
 
 const log = createSubsystemLogger("memory");
 const QMD_MANAGER_CACHE = new Map<string, MemorySearchManager>();
+const QMD_INFLIGHT = new Map<string, Promise<MemorySearchManagerResult>>();
+
+export type MemorySearchManagerBackend = "qmd" | "builtin";
 
 export type MemorySearchManagerResult = {
   manager: MemorySearchManager | null;
+  backend?: MemorySearchManagerBackend;
   error?: string;
 };
 
@@ -25,43 +29,58 @@ export async function getMemorySearchManager(params: {
     const cacheKey = buildQmdCacheKey(params.agentId, resolved.qmd);
     const cached = QMD_MANAGER_CACHE.get(cacheKey);
     if (cached) {
-      return { manager: cached };
+      return { manager: cached, backend: "qmd" };
     }
-    try {
-      const { QmdMemoryManager } = await import("./qmd-manager.js");
-      const primary = await QmdMemoryManager.create({
-        cfg: params.cfg,
-        agentId: params.agentId,
-        resolved,
-      });
-      if (primary) {
-        const wrapper = new FallbackMemoryManager(
-          {
-            primary,
-            fallbackFactory: async () => {
-              const { MemoryIndexManager } = await import("./manager.js");
-              return await MemoryIndexManager.get(params);
+
+    const inflight = QMD_INFLIGHT.get(cacheKey);
+    if (inflight) {
+      return await inflight;
+    }
+
+    const create = (async (): Promise<MemorySearchManagerResult> => {
+      try {
+        const { QmdMemoryManager } = await import("./qmd-manager.js");
+        const primary = await QmdMemoryManager.create({
+          cfg: params.cfg,
+          agentId: params.agentId,
+          resolved,
+        });
+        if (primary) {
+          const wrapper = new FallbackMemoryManager(
+            {
+              primary,
+              fallbackFactory: async () => {
+                const { MemoryIndexManager } = await import("./manager.js");
+                return await MemoryIndexManager.get(params);
+              },
             },
-          },
-          () => QMD_MANAGER_CACHE.delete(cacheKey),
-        );
-        QMD_MANAGER_CACHE.set(cacheKey, wrapper);
-        return { manager: wrapper };
+            () => QMD_MANAGER_CACHE.delete(cacheKey),
+          );
+          QMD_MANAGER_CACHE.set(cacheKey, wrapper);
+          return { manager: wrapper, backend: "qmd" };
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        log.warn("qmd memory unavailable; falling back to builtin", { err });
+        const builtin = await tryGetBuiltinManager(params);
+        return builtin.manager
+          ? { ...builtin, backend: "builtin", error: message }
+          : { ...builtin, backend: "builtin", error: builtin.error ?? message };
       }
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      log.warn(`qmd memory unavailable; falling back to builtin: ${message}`);
-    }
+
+      // Should not happen (we already gated on resolved.qmd), but keep behavior predictable.
+      const builtin = await tryGetBuiltinManager(params);
+      return builtin.manager ? { ...builtin, backend: "builtin" } : builtin;
+    })().finally(() => {
+      QMD_INFLIGHT.delete(cacheKey);
+    });
+
+    QMD_INFLIGHT.set(cacheKey, create);
+    return await create;
   }
 
-  try {
-    const { MemoryIndexManager } = await import("./manager.js");
-    const manager = await MemoryIndexManager.get(params);
-    return { manager };
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    return { manager: null, error: message };
-  }
+  const builtin = await tryGetBuiltinManager(params);
+  return builtin.manager ? { ...builtin, backend: "builtin" } : builtin;
 }
 
 class FallbackMemoryManager implements MemorySearchManager {
@@ -260,37 +279,18 @@ function buildQmdCacheKey(agentId: string, config: ResolvedQmdConfig): string {
   return `${agentId}:${stableSerialize(config)}`;
 }
 
-function isTransientQmdError(err: unknown): boolean {
-  const code = err && typeof err === "object" ? (err as { code?: unknown }).code : undefined;
-  if (typeof code === "string") {
-    if (code === "ENOENT") {
-      return false;
-    }
-    if (
-      code === "ETIMEDOUT" ||
-      code === "ECONNRESET" ||
-      code === "EPIPE" ||
-      code === "EAI_AGAIN" ||
-      code === "ECONNREFUSED" ||
-      code === "ENETUNREACH" ||
-      code === "EHOSTUNREACH"
-    ) {
-      return true;
-    }
+async function tryGetBuiltinManager(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+}): Promise<MemorySearchManagerResult> {
+  try {
+    const { MemoryIndexManager } = await import("./manager.js");
+    const manager = await MemoryIndexManager.get(params);
+    return { manager };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { manager: null, error: message };
   }
-
-  const message = err instanceof Error ? err.message : String(err);
-  const lower = message.toLowerCase();
-  if (lower.includes("timed out") || lower.includes("timeout")) {
-    return true;
-  }
-  if (lower.includes("database is locked") || lower.includes("resource busy")) {
-    return true;
-  }
-  if (lower.includes("temporarily unavailable") || lower.includes("try again")) {
-    return true;
-  }
-  return false;
 }
 
 function stableSerialize(value: unknown): string {

--- a/src/memory/search-manager.ts
+++ b/src/memory/search-manager.ts
@@ -183,7 +183,9 @@ class FallbackMemoryManager implements MemorySearchManager {
           custom: {
             ...custom,
             fallback: {
-              ...custom.fallback,
+              ...(typeof custom.fallback === "object" && custom.fallback != null
+                ? custom.fallback
+                : {}),
               consecutiveFailures: this.consecutivePrimaryFailures,
               lastError: this.lastError ?? "unknown",
             },

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -37,6 +37,17 @@ export default defineConfig([
     platform: "node",
   },
   {
+    entry: [
+      "src/agents/pi-extensions/context-pruning.ts",
+      "src/agents/pi-extensions/compaction-safeguard.ts",
+      "src/agents/pi-extensions/transcript-sanitize.ts",
+    ],
+    outDir: "dist/pi-extensions",
+    env,
+    fixedExtension: false,
+    platform: "node",
+  },
+  {
     entry: ["src/hooks/bundled/*/handler.ts", "src/hooks/llm-slug-generator.ts"],
     env,
     fixedExtension: false,


### PR DESCRIPTION
Fixes #15006

## Changes

1. **Remove cacheWrite from prompt token derivation** — `derivePromptTokens()` no longer includes `cacheWrite` in the sum
2. **Remove cacheRead from prompt token derivation** — cache tokens are API-level accounting, not context window usage
3. **Refresh totalTokens after auto-compaction** — estimates tokens from the compacted session file and updates the cached total to prevent repeated triggers

## Testing

Before fix: 13/14 compaction events in a day were false alarms (tokens appeared at ~170-200k but actual usage was far lower)
After fix: totalTokens reflects actual context usage (input + output only), compaction triggers only when context is genuinely full

Cherry-picked from:
- fix/token-accounting-v2 (c73dd74eb) — primary fix
- fix/compaction-frequency (ac15637e8) — post-compaction refresh
- Additional: cacheRead exclusion (1b1d3dbde)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts token accounting across the agent runtime to better reflect actual context-window usage: it changes how prompt/session totals are derived (excluding cache tokens), threads a separate `promptUsage` through the reply/followup runners into session persistence, and refreshes stored `totalTokens` after auto-compaction by estimating tokens from the compacted session file.

Changes touch the core usage helpers (`src/agents/usage.ts`), session persistence (`src/auto-reply/reply/session-usage.ts`), and compaction bookkeeping (`src/auto-reply/reply/session-updates.ts`), along with a broad set of related runner/extension updates and tests to align with the new accounting behavior.

<h3>Confidence Score: 3/5</h3>

- This PR is close, but there are a couple of accounting regressions that can corrupt stored token totals.
- Main logic change (excluding cache tokens) is reasonable and broadly wired through, but (1) `derivePromptTokens` now includes output tokens despite its name/semantics, and (2) post-compaction refresh can overwrite `totalTokens` with 0 when estimation is unavailable, breaking future compaction heuristics and reporting.
- src/agents/usage.ts; src/auto-reply/reply/session-updates.ts

<sub>Last reviewed commit: 1b1d3db</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->