### PR TITLE
fix: allow $schema key in config for JSON Schema editor support

### DIFF
--- a/src/config/config.schema-key.test.ts
+++ b/src/config/config.schema-key.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+
+describe("$schema key in config", () => {
+  it("accepts config with $schema key at root level", async () => {
+    vi.resetModules();
+    const { validateConfigObject } = await import("./config.js");
+    const res = validateConfigObject({
+      $schema: "https://openclaw.ai/config.json",
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it("accepts config with $schema alongside other keys", async () => {
+    vi.resetModules();
+    const { validateConfigObject } = await import("./config.js");
+    const res = validateConfigObject({
+      $schema: "https://openclaw.ai/config.json",
+      agents: {
+        list: [{ id: "main" }],
+      },
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it("accepts config without $schema key", async () => {
+    vi.resetModules();
+    const { validateConfigObject } = await import("./config.js");
+    const res = validateConfigObject({});
+    expect(res.ok).toBe(true);
+  });
+
+  it("rejects $schema with non-string value", async () => {
+    vi.resetModules();
+    const { validateConfigObject } = await import("./config.js");
+    const res = validateConfigObject({
+      $schema: 123,
+    });
+    expect(res.ok).toBe(false);
+  });
+});

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -26,6 +26,8 @@ import type { SkillsConfig } from "./types.skills.js";
 import type { ToolsConfig } from "./types.tools.js";
 
 export type OpenClawConfig = {
+  /** JSON Schema URI for editor auto-completion and validation. */
+  $schema?: string;
   meta?: {
     /** Last OpenClaw version that wrote this config. */
     lastTouchedVersion?: string;

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -93,6 +93,7 @@ const MemorySchema = z
 
 export const OpenClawSchema = z
   .object({
+    $schema: z.string().optional(),
     meta: z
       .object({
         lastTouchedVersion: z.string().optional(),


### PR DESCRIPTION
Fixes #14998

## Problem

The config validation system rejects the `$schema` key at the root of `openclaw.json`, even though this is a standard JSON Schema convention used by editors (VS Code, JetBrains) for auto-completion and validation.

The root `OpenClawSchema` uses Zod `.strict()` mode, which rejects any unrecognized keys. Since `$schema` was not declared in the schema, configs like:

```json
{
  "$schema": "https://openclaw.ai/config.json",
  "auth": { ... }
}
```

would fail with: `Unrecognized key: "$schema"`

## Fix

Added `$schema` as an optional string property to:
- `OpenClawSchema` in `zod-schema.ts` (Zod validation)
- `OpenClawConfig` type in `types.openclaw.ts` (TypeScript type)

This is the minimal, targeted fix — it allows the key through validation without changing any other behavior.

## Tests

Added `config.schema-key.test.ts` with 4 tests:
- Accepts config with `$schema` at root level
- Accepts config with `$schema` alongside other keys
- Accepts config without `$schema` (no regression)
- Rejects `$schema` with non-string value (type safety)

All existing tests continue to pass. `pnpm check` (format, typecheck, lint) passes.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change makes the root OpenClaw config schema accept the standard `$schema` key used by editors for JSON Schema association. It updates both the runtime validator (`OpenClawSchema` in `src/config/zod-schema.ts`) and the TypeScript config type (`OpenClawConfig` in `src/config/types.openclaw.ts`), and adds a focused Vitest suite verifying `$schema` is allowed when it’s a string and rejected otherwise.

The update preserves the existing strict-root validation behavior (unknown keys still fail), while allowing `$schema` through as a special-case root property for IDE support.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped: adding an optional `$schema` string to the root Zod schema and TS type. The behavior stays strict for all other unknown keys, and the accompanying tests match existing test patterns in this repo. No logic paths outside config parsing/typing are affected.
- No files require special attention

<sub>Last reviewed commit: 6cb31d2</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->