### PR TITLE
fix: auto-inject replyToCurrent so replyToMode actually threads replies (#14974)

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
+import type { ReplyToMode } from "../../config/types.js";
 import type { TemplateContext } from "../templating.js";
 import type { VerboseLevel } from "../thinking.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
@@ -66,6 +67,7 @@ export async function runAgentTurnWithFallback(params: {
     flushOnParagraph?: boolean;
   };
   resolvedBlockStreamingBreak: "text_end" | "message_end";
+  replyToMode: ReplyToMode;
   applyReplyToMode: (payload: ReplyPayload) => ReplyPayload;
   shouldEmitToolResult: () => boolean;
   shouldEmitToolOutput: () => boolean;
@@ -375,7 +377,7 @@ export async function runAgentTurnWithFallback(params: {
                       mediaUrl: payload.mediaUrls?.[0],
                       replyToId: payload.replyToId,
                       replyToTag: payload.replyToTag,
-                      replyToCurrent: payload.replyToCurrent,
+                      replyToCurrent: payload.replyToCurrent || params.replyToMode !== "off",
                     },
                     currentMessageId,
                   );

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -317,6 +317,7 @@ export async function runReplyAgent(params: {
       blockStreamingEnabled,
       blockReplyChunking,
       resolvedBlockStreamingBreak,
+      replyToMode,
       applyReplyToMode,
       shouldEmitToolResult,
       shouldEmitToolOutput,

--- a/src/auto-reply/reply/reply-payloads.reply-threading.test.ts
+++ b/src/auto-reply/reply/reply-payloads.reply-threading.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { applyReplyTagsToPayload, applyReplyThreading } from "./reply-payloads.js";
+
+describe("applyReplyTagsToPayload", () => {
+  it("sets replyToId from currentMessageId when replyToCurrent is true", () => {
+    const result = applyReplyTagsToPayload({ text: "hello", replyToCurrent: true }, "msg-123");
+    expect(result.replyToId).toBe("msg-123");
+  });
+
+  it("does not set replyToId when replyToCurrent is falsy", () => {
+    const result = applyReplyTagsToPayload({ text: "hello" }, "msg-123");
+    expect(result.replyToId).toBeUndefined();
+  });
+
+  it("does not overwrite existing replyToId when replyToCurrent is true", () => {
+    const result = applyReplyTagsToPayload(
+      { text: "hello", replyToCurrent: true, replyToId: "existing-456" },
+      "msg-123",
+    );
+    expect(result.replyToId).toBe("existing-456");
+  });
+});
+
+describe("applyReplyThreading", () => {
+  it("auto-threads payloads when replyToMode is 'all'", () => {
+    const result = applyReplyThreading({
+      payloads: [{ text: "first" }, { text: "second" }],
+      replyToMode: "all",
+      currentMessageId: "msg-100",
+    });
+    expect(result).toHaveLength(2);
+    expect(result[0].replyToId).toBe("msg-100");
+    expect(result[1].replyToId).toBe("msg-100");
+  });
+
+  it("auto-threads only the first payload when replyToMode is 'first'", () => {
+    const result = applyReplyThreading({
+      payloads: [{ text: "first" }, { text: "second" }],
+      replyToMode: "first",
+      currentMessageId: "msg-100",
+    });
+    expect(result).toHaveLength(2);
+    expect(result[0].replyToId).toBe("msg-100");
+    expect(result[1].replyToId).toBeUndefined();
+  });
+
+  it("does not auto-thread payloads when replyToMode is 'off'", () => {
+    const result = applyReplyThreading({
+      payloads: [{ text: "first" }, { text: "second" }],
+      replyToMode: "off",
+      currentMessageId: "msg-100",
+    });
+    expect(result).toHaveLength(2);
+    expect(result[0].replyToId).toBeUndefined();
+    expect(result[1].replyToId).toBeUndefined();
+  });
+
+  it("does not set replyToId when currentMessageId is undefined", () => {
+    const result = applyReplyThreading({
+      payloads: [{ text: "hello" }],
+      replyToMode: "all",
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].replyToId).toBeUndefined();
+  });
+
+  it("filters out empty payloads", () => {
+    const result = applyReplyThreading({
+      payloads: [{ text: "" }, { text: "hello" }],
+      replyToMode: "all",
+      currentMessageId: "msg-100",
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].text).toBe("hello");
+    expect(result[0].replyToId).toBe("msg-100");
+  });
+
+  it("preserves existing replyToId set by LLM tags", () => {
+    const result = applyReplyThreading({
+      payloads: [{ text: "hello", replyToId: "custom-id" }],
+      replyToMode: "all",
+      currentMessageId: "msg-100",
+    });
+    expect(result).toHaveLength(1);
+    // replyToCurrent=true is injected, but applyReplyTagsToPayload
+    // does not overwrite an existing replyToId
+    expect(result[0].replyToId).toBe("custom-id");
+  });
+});

--- a/src/auto-reply/reply/reply-payloads.ts
+++ b/src/auto-reply/reply/reply-payloads.ts
@@ -62,8 +62,14 @@ export function applyReplyThreading(params: {
 }): ReplyPayload[] {
   const { payloads, replyToMode, replyToChannel, currentMessageId } = params;
   const applyReplyToMode = createReplyToModeFilterForChannel(replyToMode, replyToChannel);
+  const shouldAutoThread = replyToMode !== "off";
   return payloads
-    .map((payload) => applyReplyTagsToPayload(payload, currentMessageId))
+    .map((payload) =>
+      applyReplyTagsToPayload(
+        shouldAutoThread ? { ...payload, replyToCurrent: true } : payload,
+        currentMessageId,
+      ),
+    )
     .filter(isRenderablePayload)
     .map(applyReplyToMode);
 }


### PR DESCRIPTION
## Summary

Fixes #14974 — `replyToMode` config option (`"first"` / `"all"`) had no effect because `replyToId` was only populated when the LLM emitted a `[[reply_to_current]]` tag, which almost never happens unprompted.

## Root Cause

`replyToMode` was implemented as a **filter** (`createReplyToModeFilter`) that strips or keeps `replyToId` on payloads. But `replyToId` was only set when `replyToCurrent` was true on the payload — which only happened if the LLM emitted `[[reply_to_current]]` in its response text. Since LLMs almost never do this unprompted, `replyToId` was never populated, and the filter had nothing to act on.

## Fix

When `replyToMode` is not `"off"`, auto-inject `replyToCurrent: true` on payloads **before** they pass through `applyReplyTagsToPayload`. This ensures `replyToId` is populated with `currentMessageId`, and the existing `replyToMode` filter then correctly decides whether to keep or strip it based on the configured mode.

Both code paths are fixed:
- **Final-reply path**: `applyReplyThreading()` in `src/auto-reply/reply/reply-payloads.ts`
- **Block-streaming path**: `onBlockReply` handler in `src/auto-reply/reply/agent-runner-execution.ts` (added `replyToMode` param to `runAgentTurnWithFallback`)

## Tests

Added `reply-payloads.reply-threading.test.ts` with 9 tests covering:
- `applyReplyTagsToPayload` correctly sets `replyToId` when `replyToCurrent` is true
- `applyReplyThreading` auto-threads all payloads with mode `"all"`
- `applyReplyThreading` threads only first payload with mode `"first"`
- `applyReplyThreading` does not thread with mode `"off"`
- Edge cases: missing `currentMessageId`, empty payloads, pre-existing `replyToId`

## Verification

- `pnpm check` passes (format ✓, typecheck ✓, lint ✓)
- All existing tests pass
- All new tests pass

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes `replyToMode` threading by ensuring `replyToId` is actually populated even when the model doesn’t emit `[[reply_to_current]]` tags. It does that by auto-injecting `replyToCurrent: true` whenever `replyToMode !== "off"` in both the final-reply path (`applyReplyThreading()` in `src/auto-reply/reply/reply-payloads.ts`) and the block-streaming path (`onBlockReply` in `src/auto-reply/reply/agent-runner-execution.ts`, via a new `replyToMode` param passed from `runReplyAgent`). It also adds a Vitest suite covering `applyReplyTagsToPayload` and the new auto-threading behavior for `applyReplyThreading`.

One functional concern remains in the block-streaming handler: reply-threading directives can be lost if they arrive in an otherwise-empty/whitespace-only streaming chunk, because that chunk is skipped before tag parsing, preventing explicit `[[reply_to_*]]` tags from taking effect during streaming.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but block-streaming reply directives can be dropped in a realistic case.
- Core change (auto-injecting `replyToCurrent` when `replyToMode` is enabled) is coherent and covered by new unit tests, and call sites were updated consistently. However, the block-streaming path can skip chunks that contain only reply tags (empty after sanitization), so explicit `[[reply_to_*]]` directives may not be applied during streaming, which undermines the intent for models that emit tags separately from content.
- src/auto-reply/reply/agent-runner-execution.ts

<sub>Last reviewed commit: 544b216</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->