### PR TITLE
fix: dispatch before_tool_call and after_tool_call hooks from both tool execution paths

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -455,6 +455,9 @@ export async function runEmbeddedAttempt(
         model: params.model,
       });
 
+      // Get hook runner early so it's available when creating tools
+      const hookRunner = getGlobalHookRunner();
+
       const { builtInTools, customTools } = splitSdkTools({
         tools,
         sandboxEnabled: !!sandbox?.enabled,
@@ -632,6 +635,7 @@ export async function runEmbeddedAttempt(
       const subscription = subscribeEmbeddedPiSession({
         session: activeSession,
         runId: params.runId,
+        hookRunner: getGlobalHookRunner() ?? undefined,
         verboseLevel: params.verboseLevel,
         reasoningMode: params.reasoningLevel ?? "off",
         toolResultFormat: params.toolResultFormat,
@@ -715,8 +719,7 @@ export async function runEmbeddedAttempt(
         }
       }
 
-      // Get hook runner once for both before_agent_start and agent_end hooks
-      const hookRunner = getGlobalHookRunner();
+      // Hook runner was already obtained earlier before tool creation
       const hookAgentId =
         typeof params.agentId === "string" && params.agentId.trim()
           ? normalizeAgentId(params.agentId)

--- a/src/agents/pi-embedded-subscribe.handlers.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.ts
@@ -42,7 +42,10 @@ export function createEmbeddedPiSessionEventHandler(ctx: EmbeddedPiSubscribeCont
         handleToolExecutionUpdate(ctx, evt as never);
         return;
       case "tool_execution_end":
-        handleToolExecutionEnd(ctx, evt as never);
+        // Async handler - best-effort, non-blocking
+        handleToolExecutionEnd(ctx, evt as never).catch((err) => {
+          ctx.log.debug(`tool_execution_end handler failed: ${String(err)}`);
+        });
         return;
       case "agent_start":
         handleAgentStart(ctx);

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -2,6 +2,7 @@ import type { AgentEvent, AgentMessage } from "@mariozechner/pi-agent-core";
 import type { ReplyDirectiveParseResult } from "../auto-reply/reply/reply-directives.js";
 import type { ReasoningLevel } from "../auto-reply/thinking.js";
 import type { InlineCodeState } from "../markdown/code-spans.js";
+import type { HookRunner } from "../plugins/hooks.js";
 import type { EmbeddedBlockChunker } from "./pi-embedded-block-chunker.js";
 import type { MessagingToolSend } from "./pi-embedded-messaging.js";
 import type {
@@ -9,7 +10,6 @@ import type {
   SubscribeEmbeddedPiSessionParams,
 } from "./pi-embedded-subscribe.types.js";
 import type { NormalizedUsage } from "./usage.js";
-import type { HookRunner } from "../plugins/hooks.js";
 
 export type EmbeddedSubscribeLogger = {
   debug: (message: string) => void;

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -9,6 +9,7 @@ import type {
   SubscribeEmbeddedPiSessionParams,
 } from "./pi-embedded-subscribe.types.js";
 import type { NormalizedUsage } from "./usage.js";
+import type { HookRunner } from "../plugins/hooks.js";
 
 export type EmbeddedSubscribeLogger = {
   debug: (message: string) => void;
@@ -69,6 +70,7 @@ export type EmbeddedPiSubscribeContext = {
   log: EmbeddedSubscribeLogger;
   blockChunking?: BlockReplyChunking;
   blockChunker: EmbeddedBlockChunker | null;
+  hookRunner?: HookRunner;
 
   shouldEmitToolResult: () => boolean;
   shouldEmitToolOutput: () => boolean;

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -575,6 +575,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     log,
     blockChunking,
     blockChunker,
+    hookRunner: params.hookRunner,
     shouldEmitToolResult,
     shouldEmitToolOutput,
     emitToolSummary,

--- a/src/agents/pi-embedded-subscribe.types.ts
+++ b/src/agents/pi-embedded-subscribe.types.ts
@@ -1,12 +1,14 @@
 import type { AgentSession } from "@mariozechner/pi-coding-agent";
 import type { ReasoningLevel, VerboseLevel } from "../auto-reply/thinking.js";
 import type { BlockReplyChunking } from "./pi-embedded-block-chunker.js";
+import type { HookRunner } from "../plugins/hooks.js";
 
 export type ToolResultFormat = "markdown" | "plain";
 
 export type SubscribeEmbeddedPiSessionParams = {
   session: AgentSession;
   runId: string;
+  hookRunner?: HookRunner;
   verboseLevel?: VerboseLevel;
   reasoningMode?: ReasoningLevel;
   toolResultFormat?: ToolResultFormat;

--- a/src/agents/pi-embedded-subscribe.types.ts
+++ b/src/agents/pi-embedded-subscribe.types.ts
@@ -1,7 +1,7 @@
 import type { AgentSession } from "@mariozechner/pi-coding-agent";
 import type { ReasoningLevel, VerboseLevel } from "../auto-reply/thinking.js";
-import type { BlockReplyChunking } from "./pi-embedded-block-chunker.js";
 import type { HookRunner } from "../plugins/hooks.js";
+import type { BlockReplyChunking } from "./pi-embedded-block-chunker.js";
 
 export type ToolResultFormat = "markdown" | "plain";
 

--- a/src/agents/pi-tool-definition-adapter.ts
+++ b/src/agents/pi-tool-definition-adapter.ts
@@ -108,11 +108,17 @@ export function toToolDefinitions(tools: AnyAgentTool[]): ToolDefinition[] {
           if (hookRunner?.hasHooks("after_tool_call")) {
             try {
               await hookRunner.runAfterToolCall(
-                { toolName: name, params: isPlainObject(adjustedParams) ? adjustedParams : {}, result },
+                {
+                  toolName: name,
+                  params: isPlainObject(adjustedParams) ? adjustedParams : {},
+                  result,
+                },
                 { toolName: name },
               );
             } catch (hookErr) {
-              logDebug(`after_tool_call hook failed: tool=${normalizedName} error=${String(hookErr)}`);
+              logDebug(
+                `after_tool_call hook failed: tool=${normalizedName} error=${String(hookErr)}`,
+              );
             }
           }
 
@@ -145,11 +151,17 @@ export function toToolDefinitions(tools: AnyAgentTool[]): ToolDefinition[] {
           if (hookRunner?.hasHooks("after_tool_call")) {
             try {
               await hookRunner.runAfterToolCall(
-                { toolName: normalizedName, params: isPlainObject(params) ? params : {}, error: described.message },
+                {
+                  toolName: normalizedName,
+                  params: isPlainObject(params) ? params : {},
+                  error: described.message,
+                },
                 { toolName: normalizedName },
               );
             } catch (hookErr) {
-              logDebug(`after_tool_call hook failed: tool=${normalizedName} error=${String(hookErr)}`);
+              logDebug(
+                `after_tool_call hook failed: tool=${normalizedName} error=${String(hookErr)}`,
+              );
             }
           }
 

--- a/src/agents/pi-tool-definition-adapter.ts
+++ b/src/agents/pi-tool-definition-adapter.ts
@@ -6,6 +6,7 @@ import type {
 import type { ToolDefinition } from "@mariozechner/pi-coding-agent";
 import type { ClientToolDefinition } from "./pi-embedded-runner/run/params.js";
 import { logDebug, logError } from "../logger.js";
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { isPlainObject } from "../utils.js";
 import { runBeforeToolCallHook } from "./pi-tools.before-tool-call.js";
 import { normalizeToolName } from "./tool-policy.js";
@@ -90,7 +91,32 @@ export function toToolDefinitions(tools: AnyAgentTool[]): ToolDefinition[] {
       execute: async (...args: ToolExecuteArgs): Promise<AgentToolResult<unknown>> => {
         const { toolCallId, params, onUpdate, signal } = splitToolExecuteArgs(args);
         try {
-          return await tool.execute(toolCallId, params, signal, onUpdate);
+          // Call before_tool_call hook
+          const hookOutcome = await runBeforeToolCallHook({
+            toolName: name,
+            params,
+            toolCallId,
+          });
+          if (hookOutcome.blocked) {
+            throw new Error(hookOutcome.reason);
+          }
+          const adjustedParams = hookOutcome.params;
+          const result = await tool.execute(toolCallId, adjustedParams, signal, onUpdate);
+
+          // Call after_tool_call hook
+          const hookRunner = getGlobalHookRunner();
+          if (hookRunner?.hasHooks("after_tool_call")) {
+            try {
+              await hookRunner.runAfterToolCall(
+                { toolName: name, params: isPlainObject(adjustedParams) ? adjustedParams : {}, result },
+                { toolName: name },
+              );
+            } catch (hookErr) {
+              logDebug(`after_tool_call hook failed: tool=${normalizedName} error=${String(hookErr)}`);
+            }
+          }
+
+          return result;
         } catch (err) {
           if (signal?.aborted) {
             throw err;
@@ -107,11 +133,27 @@ export function toToolDefinitions(tools: AnyAgentTool[]): ToolDefinition[] {
             logDebug(`tools: ${normalizedName} failed stack:\n${described.stack}`);
           }
           logError(`[tools] ${normalizedName} failed: ${described.message}`);
-          return jsonResult({
+
+          const errorResult = jsonResult({
             status: "error",
             tool: normalizedName,
             error: described.message,
           });
+
+          // Call after_tool_call hook for errors too
+          const hookRunner = getGlobalHookRunner();
+          if (hookRunner?.hasHooks("after_tool_call")) {
+            try {
+              await hookRunner.runAfterToolCall(
+                { toolName: normalizedName, params: isPlainObject(params) ? params : {}, error: described.message },
+                { toolName: normalizedName },
+              );
+            } catch (hookErr) {
+              logDebug(`after_tool_call hook failed: tool=${normalizedName} error=${String(hookErr)}`);
+            }
+          }
+
+          return errorResult;
         }
       },
     } satisfies ToolDefinition;

--- a/src/plugins/wired-hooks-after-tool-call.test.ts
+++ b/src/plugins/wired-hooks-after-tool-call.test.ts
@@ -72,7 +72,7 @@ describe("after_tool_call hook wiring", () => {
       } as never,
     );
 
-    handleToolExecutionEnd(
+    await handleToolExecutionEnd(
       ctx as never,
       {
         type: "tool_execution_end",
@@ -138,7 +138,7 @@ describe("after_tool_call hook wiring", () => {
       } as never,
     );
 
-    handleToolExecutionEnd(
+    await handleToolExecutionEnd(
       ctx as never,
       {
         type: "tool_execution_end",
@@ -184,7 +184,7 @@ describe("after_tool_call hook wiring", () => {
       trimMessagingToolSent: vi.fn(),
     };
 
-    handleToolExecutionEnd(
+    await handleToolExecutionEnd(
       ctx as never,
       {
         type: "tool_execution_end",


### PR DESCRIPTION
## Summary
- Adds `after_tool_call` hook dispatch to `pi-tool-definition-adapter.ts` (was completely missing)
- Adds `before_tool_call` and `after_tool_call` hook dispatch to the embedded subscribe handler path
- Threads `hookRunner` through the embedded subscribe context so hooks dispatch via the typed plugin system (`registry.typedHooks`)
- `after_tool_call` fires on both success and error paths

## Context
The typed plugin hook system supports `before_tool_call` and `after_tool_call` hooks (registered via `api.on()`), but they were only partially wired — `before_tool_call` worked in the adapter path via `runBeforeToolCallHook`, but `after_tool_call` was never dispatched from there, and neither hook was dispatched from the embedded subscribe path. This meant plugins couldn't observe tool execution outcomes.

## Test plan
- [ ] Verify `before_tool_call` hooks fire before tool execution in both code paths
- [ ] Verify `after_tool_call` hooks fire after successful tool execution
- [ ] Verify `after_tool_call` hooks fire after failed tool execution (with error info)
- [ ] Verify hook failures don't block tool execution (caught and logged)
- [ ] Verify no regression in tool execution behavior when no hooks are registered

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR wires the typed plugin hook system into both Pi tool execution paths:

- `pi-tool-definition-adapter.ts` now runs `before_tool_call` (with block/param adjustment) and dispatches `after_tool_call` on both success and error.
- The embedded subscribe event handler path now dispatches `before_tool_call` at `tool_execution_start` and `after_tool_call` at `tool_execution_end`, threading a `hookRunner` through `subscribeEmbeddedPiSession` to avoid relying on globals.

Key issues to address before merge:
- The embedded subscribe `after_tool_call` event currently always sends `params: {}` (because end events don’t carry args), which makes the hook much less useful and inconsistent with the adapter path.
- The adapter path uses different `toolName` values between success (`name`) and error (`normalizedName`) when dispatching `after_tool_call`, which will break plugins that key off tool name.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has hook payload inconsistencies that will break plugin expectations.
- Core behavior changes are localized, but (1) embedded subscribe `after_tool_call` omits params entirely, and (2) adapter hook dispatch uses inconsistent toolName normalization between success and error. Both issues affect correctness of the new hook feature and should be fixed before relying on it.
- src/agents/pi-embedded-subscribe.handlers.tools.ts, src/agents/pi-tool-definition-adapter.ts

<sub>Last reviewed commit: 59f9da0</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->