### PR TITLE
models auth: support built-in openai-codex login path

### DIFF
--- a/src/commands/models/auth.login-openai-codex.test.ts
+++ b/src/commands/models/auth.login-openai-codex.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  let codexProfiles = 0;
+  return {
+    codexProfilesRef: {
+      get: () => codexProfiles,
+      set: (value: number) => {
+        codexProfiles = value;
+      },
+    },
+    readConfigFileSnapshot: vi.fn().mockResolvedValue({ valid: true, config: {} }),
+    resolveDefaultAgentId: vi.fn().mockReturnValue("main"),
+    resolveAgentDir: vi.fn().mockReturnValue("/tmp/openclaw-agent"),
+    resolveAgentWorkspaceDir: vi.fn().mockReturnValue("/tmp/openclaw-workspace"),
+    resolveDefaultAgentWorkspaceDir: vi.fn().mockReturnValue("/tmp/openclaw-workspace"),
+    resolvePluginProviders: vi.fn(),
+    createClackPrompter: vi.fn().mockReturnValue({}),
+    applyAuthChoice: vi.fn(async () => {
+      codexProfiles = 1;
+      return { config: {} };
+    }),
+    loadAuthProfileStore: vi.fn().mockReturnValue({}),
+    listProfilesForProvider: vi.fn(() => (codexProfiles > 0 ? ["openai-codex:default"] : [])),
+    updateConfig: vi.fn(async () => undefined),
+    logConfigUpdated: vi.fn(),
+  };
+});
+
+vi.mock("../../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config/config.js")>();
+  return {
+    ...actual,
+    readConfigFileSnapshot: mocks.readConfigFileSnapshot,
+  };
+});
+
+vi.mock("../../agents/agent-scope.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../agents/agent-scope.js")>();
+  return {
+    ...actual,
+    resolveDefaultAgentId: mocks.resolveDefaultAgentId,
+    resolveAgentDir: mocks.resolveAgentDir,
+    resolveAgentWorkspaceDir: mocks.resolveAgentWorkspaceDir,
+  };
+});
+
+vi.mock("../../agents/workspace.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../agents/workspace.js")>();
+  return {
+    ...actual,
+    resolveDefaultAgentWorkspaceDir: mocks.resolveDefaultAgentWorkspaceDir,
+  };
+});
+
+vi.mock("../../plugins/providers.js", () => ({
+  resolvePluginProviders: mocks.resolvePluginProviders,
+}));
+
+vi.mock("../../wizard/clack-prompter.js", () => ({
+  createClackPrompter: mocks.createClackPrompter,
+}));
+
+vi.mock("../auth-choice.apply.js", () => ({
+  applyAuthChoice: mocks.applyAuthChoice,
+}));
+
+vi.mock("../../agents/auth-profiles.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../agents/auth-profiles.js")>();
+  return {
+    ...actual,
+    loadAuthProfileStore: mocks.loadAuthProfileStore,
+    listProfilesForProvider: mocks.listProfilesForProvider,
+  };
+});
+
+vi.mock("./shared.js", () => ({
+  updateConfig: mocks.updateConfig,
+}));
+
+vi.mock("../../config/logging.js", () => ({
+  logConfigUpdated: mocks.logConfigUpdated,
+}));
+
+import { modelsAuthLoginCommand } from "./auth.js";
+
+describe("modelsAuthLoginCommand", () => {
+  it("supports built-in openai-codex login path without plugin providers", async () => {
+    mocks.codexProfilesRef.set(0);
+    mocks.resolvePluginProviders.mockReturnValue([]);
+
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+    };
+
+    const originalTTY = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, "isTTY", {
+      configurable: true,
+      value: true,
+    });
+
+    try {
+      await modelsAuthLoginCommand(
+        { provider: "openai-codex", setDefault: false },
+        runtime as never,
+      );
+    } finally {
+      Object.defineProperty(process.stdin, "isTTY", {
+        configurable: true,
+        value: originalTTY,
+      });
+    }
+
+    expect(mocks.applyAuthChoice).toHaveBeenCalledWith(
+      expect.objectContaining({ authChoice: "openai-codex" }),
+    );
+    expect(mocks.resolvePluginProviders).not.toHaveBeenCalled();
+    expect(mocks.logConfigUpdated).toHaveBeenCalled();
+    expect(runtime.log).toHaveBeenCalledWith(
+      "Auth profile: openai-codex:default (openai-codex/oauth)",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a built-in compatibility path for `openclaw models auth login --provider openai-codex`
- route that provider through the existing OpenAI Codex OAuth flow (`applyAuthChoice` with `authChoice: openai-codex`)
- keep plugin-provider behavior intact for all plugin-backed providers
- when an explicit unknown `--provider` is passed, return an explicit error instead of silently opening the provider picker

## Why
`openai-codex` is documented and referenced by doctor hints, but `models auth login` currently only discovers plugin providers. Passing `--provider openai-codex` falls through to the plugin picker (often showing only Google Antigravity), which is confusing and blocks the expected Codex OAuth login path.

## Validation
- `pnpm -C /tmp/openclaw-upstream exec tsc -p tsconfig.json --noEmit`
- `pnpm -C /tmp/openclaw-upstream exec vitest run src/commands/models/auth.login-openai-codex.test.ts`
- `pnpm -C /tmp/openclaw-upstream exec vitest run src/commands/doctor-auth.deprecated-cli-profiles.test.ts`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change adds a built-in special-case for `models auth login --provider openai-codex`, routing that provider through the existing `applyAuthChoice({ authChoice: "openai-codex" })` OAuth flow rather than relying on plugin-discovered providers. It also tightens behavior when `--provider` is explicitly set but doesn’t match any plugin provider by throwing a clearer error instead of falling back to the interactive picker.

A new Vitest file covers the built-in `openai-codex` login path and asserts that plugin provider resolution is skipped in that scenario.

<h3>Confidence Score: 4/5</h3>

- This PR is close to safe to merge; the main code path change is straightforward, but the added test may be brittle across environments due to direct TTY mutation.
- The production change is a narrowly-scoped provider routing tweak and improves error handling for explicit unknown providers. The only clear fix needed before merge is making the new unit test resilient: redefining `process.stdin.isTTY` can throw depending on runtime/property descriptors, causing CI flakes or immediate failures.
- src/commands/models/auth.login-openai-codex.test.ts

<sub>Last reviewed commit: a9d8850</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->