### PR TITLE
fix: enforce per-agent heartbeat intervals for all trigger reasons (#14986)

### DIFF
--- a/src/infra/heartbeat-runner.scheduler.test.ts
+++ b/src/infra/heartbeat-runner.scheduler.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { startHeartbeatRunner } from "./heartbeat-runner.js";
+import { requestHeartbeatNow } from "./heartbeat-wake.js";
 
 describe("startHeartbeatRunner", () => {
   afterEach(() => {
@@ -51,6 +52,85 @@ describe("startHeartbeatRunner", () => {
     expect(runSpy.mock.calls[2]?.[0]).toEqual(
       expect.objectContaining({ agentId: "ops", heartbeat: { every: "15m" } }),
     );
+
+    runner.stop();
+  });
+
+  it("non-interval triggers respect per-agent intervals (#14986)", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(0));
+
+    const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+
+    const runner = startHeartbeatRunner({
+      cfg: {
+        agents: {
+          defaults: { heartbeat: { every: "30m" } },
+          list: [
+            { id: "main", heartbeat: { every: "30m" } },
+            { id: "secondary", heartbeat: { every: "4h" } },
+          ],
+        },
+      } as OpenClawConfig,
+      runOnce: runSpy,
+    });
+
+    // Advance past main's first interval
+    await vi.advanceTimersByTimeAsync(31 * 60_000);
+
+    // Only main should have fired
+    expect(runSpy).toHaveBeenCalledTimes(1);
+    expect(runSpy.mock.calls[0]?.[0]).toEqual(expect.objectContaining({ agentId: "main" }));
+
+    // Trigger a non-interval wake (e.g. exec-event).
+    // Before the fix, this would run ALL agents regardless of their interval.
+    runSpy.mockClear();
+    requestHeartbeatNow({ reason: "exec-event" });
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    // Only the default (main) agent should fire; secondary is NOT due.
+    const mainCalls = runSpy.mock.calls.filter((call) => call[0]?.agentId === "main");
+    const secondaryCalls = runSpy.mock.calls.filter((call) => call[0]?.agentId === "secondary");
+    expect(mainCalls.length).toBe(1);
+    expect(secondaryCalls.length).toBe(0);
+
+    runner.stop();
+  });
+
+  it("secondary agent fires only after its own interval elapses", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(0));
+
+    const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+
+    const runner = startHeartbeatRunner({
+      cfg: {
+        agents: {
+          defaults: { heartbeat: { every: "30m" } },
+          list: [
+            { id: "main", heartbeat: { every: "30m" } },
+            { id: "secondary", heartbeat: { every: "2h" } },
+          ],
+        },
+      } as OpenClawConfig,
+      runOnce: runSpy,
+    });
+
+    // Advance ~91 minutes - main should fire 3 times, secondary 0 times
+    await vi.advanceTimersByTimeAsync(91 * 60_000);
+
+    const mainCalls = runSpy.mock.calls.filter((call) => call[0]?.agentId === "main");
+    const secondaryCalls = runSpy.mock.calls.filter((call) => call[0]?.agentId === "secondary");
+    expect(mainCalls.length).toBe(3);
+    expect(secondaryCalls.length).toBe(0);
+
+    // Advance to 2h+ total - secondary should now fire exactly once
+    await vi.advanceTimersByTimeAsync(30 * 60_000);
+
+    const secondaryCallsAfter = runSpy.mock.calls.filter(
+      (call) => call[0]?.agentId === "secondary",
+    );
+    expect(secondaryCallsAfter.length).toBe(1);
 
     runner.stop();
   });


### PR DESCRIPTION
## Problem

In multi-agent setups, each agent's `heartbeat.every` config was being ignored — all agents fired whenever any heartbeat trigger occurred, regardless of their individual intervals.

The root cause was in `heartbeat-runner.ts`'s `run` handler: the per-agent `nextDueMs` check was only applied when `reason === "interval"`. For **all other trigger reasons** (exec-event, cron, hooks, wake), the check was bypassed and every agent ran unconditionally.

```typescript
// Before (bug): only enforced for interval triggers
if (isInterval && now < agent.nextDueMs) {
  continue;
}
```

This meant any external event (exec completion, cron job, hook, etc.) caused ALL agents to fire — including secondary agents with long intervals like `4h`.

## Fix

1. **Always enforce per-agent interval checks** regardless of trigger reason:
```typescript
// After: always enforced
if (now < agent.nextDueMs) {
  continue;
}
```

2. **For event-driven (non-interval) triggers**, the default agent is made immediately due so it can still process pending system events (exec results, cron summaries, hook payloads) without delay. Other agents continue to respect their own configured intervals.

## Tests

Added two new test cases to `heartbeat-runner.scheduler.test.ts`:
- **non-interval triggers respect per-agent intervals (#14986)**: verifies that an `exec-event` trigger only fires the default agent, not the secondary
- **secondary agent fires only after its own interval elapses**: verifies that over 2+ hours, main fires on its 30m schedule while secondary only fires once at its 2h interval

Closes #14986

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes multi-agent heartbeat scheduling so per-agent `nextDueMs` is enforced for *all* wake reasons (interval, exec-event, cron, hooks, etc.) instead of only for `reason === "interval"`. It also makes the default agent immediately due on non-interval wakes so system-event driven triggers (like exec results / cron reminders) can be processed promptly, while secondary agents still respect their configured intervals.

Tests were added in `src/infra/heartbeat-runner.scheduler.test.ts` to ensure non-interval wakes don’t run secondary agents prematurely and that agents with longer intervals only fire once their own interval elapses.

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe to merge, but there are scheduling semantics issues around event-driven wakes that can delay normal interval heartbeats and misreport skipped reasons.
- Core fix (enforcing per-agent due checks on all wake reasons) is straightforward and covered by tests, but the new behavior that forces the default agent due on non-interval wakes can unintentionally advance the schedule even on no-op skips, and the return reason for non-interval no-op runs is misleading ("disabled"). Both affect runtime behavior and observability.
- src/infra/heartbeat-runner.ts

<sub>Last reviewed commit: 9d197f2</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->