### PR TITLE
fix: respect payload.model for cron session model assignment (#14981)

### DIFF
--- a/src/cron/isolated-agent.cron-payload-model-session.test.ts
+++ b/src/cron/isolated-agent.cron-payload-model-session.test.ts
@@ -1,0 +1,230 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CliDeps } from "../cli/deps.js";
+import type { OpenClawConfig } from "../config/config.js";
+import type { CronJob } from "./types.js";
+import { withTempHome as withTempHomeBase } from "../../test/helpers/temp-home.js";
+
+vi.mock("../agents/pi-embedded.js", () => ({
+  abortEmbeddedPiRun: vi.fn().mockReturnValue(false),
+  runEmbeddedPiAgent: vi.fn(),
+  resolveEmbeddedSessionLane: (key: string) => `session:${key.trim() || "main"}`,
+}));
+vi.mock("../agents/model-catalog.js", () => ({
+  loadModelCatalog: vi.fn(),
+}));
+
+import { loadModelCatalog } from "../agents/model-catalog.js";
+import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
+import { runCronIsolatedAgentTurn } from "./isolated-agent.js";
+
+async function withTempHome<T>(fn: (home: string) => Promise<T>): Promise<T> {
+  return withTempHomeBase(fn, { prefix: "openclaw-cron-model-" });
+}
+
+async function writeSessionStore(home: string) {
+  const dir = path.join(home, ".openclaw", "sessions");
+  await fs.mkdir(dir, { recursive: true });
+  const storePath = path.join(dir, "sessions.json");
+  await fs.writeFile(
+    storePath,
+    JSON.stringify(
+      {
+        "agent:main:main": {
+          sessionId: "main-session",
+          updatedAt: Date.now(),
+          lastProvider: "webchat",
+          lastTo: "",
+        },
+      },
+      null,
+      2,
+    ),
+    "utf-8",
+  );
+  return storePath;
+}
+
+async function readSessionStore(storePath: string) {
+  const raw = await fs.readFile(storePath, "utf-8");
+  return JSON.parse(raw) as Record<
+    string,
+    { sessionId?: string; model?: string; modelProvider?: string }
+  >;
+}
+
+function makeCfg(
+  home: string,
+  storePath: string,
+  overrides: Partial<OpenClawConfig> = {},
+): OpenClawConfig {
+  const base: OpenClawConfig = {
+    agents: {
+      defaults: {
+        model: "anthropic/claude-opus-4-5",
+        workspace: path.join(home, "openclaw"),
+      },
+    },
+    session: { store: storePath, mainKey: "main" },
+  } as OpenClawConfig;
+  return { ...base, ...overrides };
+}
+
+function makeJob(payload: CronJob["payload"]): CronJob {
+  const now = Date.now();
+  return {
+    id: "job-model",
+    enabled: true,
+    createdAtMs: now,
+    updatedAtMs: now,
+    schedule: { kind: "every", everyMs: 60_000 },
+    sessionTarget: "isolated",
+    wakeMode: "now",
+    payload,
+    state: {},
+  };
+}
+
+const makeDeps = (): CliDeps => ({
+  sendMessageWhatsApp: vi.fn(),
+  sendMessageTelegram: vi.fn(),
+  sendMessageDiscord: vi.fn(),
+  sendMessageSignal: vi.fn(),
+  sendMessageIMessage: vi.fn(),
+});
+
+describe("cron payload.model session assignment (#14981)", () => {
+  beforeEach(() => {
+    vi.mocked(runEmbeddedPiAgent).mockReset();
+    vi.mocked(loadModelCatalog).mockResolvedValue([]);
+  });
+
+  it("assigns payload.model to the session entry before the agent run", async () => {
+    await withTempHome(async (home) => {
+      const storePath = await writeSessionStore(home);
+
+      // Capture the model passed to runEmbeddedPiAgent
+      vi.mocked(runEmbeddedPiAgent).mockResolvedValue({
+        payloads: [{ text: "done" }],
+        meta: {
+          durationMs: 5,
+          agentMeta: {
+            sessionId: "s",
+            provider: "openai",
+            model: "gpt-nano",
+          },
+        },
+      });
+
+      const res = await runCronIsolatedAgentTurn({
+        cfg: makeCfg(home, storePath),
+        deps: makeDeps(),
+        job: makeJob({ kind: "agentTurn", message: "hello", model: "openai/gpt-nano" }),
+        message: "hello",
+        sessionKey: "cron:job-model",
+        lane: "cron",
+      });
+
+      expect(res.status).toBe("ok");
+
+      // The model passed to runEmbeddedPiAgent should be the payload model
+      const call = vi.mocked(runEmbeddedPiAgent).mock.calls[0]?.[0];
+      expect(call?.model).toBe("gpt-nano");
+      expect(call?.provider).toBe("openai");
+
+      // The session entry in the store should have the payload model
+      const store = await readSessionStore(storePath);
+      const cronKey = "agent:main:cron:job-model";
+      const entry = store[cronKey];
+      expect(entry).toBeDefined();
+      expect(entry?.model).toBe("gpt-nano");
+      expect(entry?.modelProvider).toBe("openai");
+    });
+  });
+
+  it("uses the gateway default model when payload.model is not set", async () => {
+    await withTempHome(async (home) => {
+      const storePath = await writeSessionStore(home);
+
+      vi.mocked(runEmbeddedPiAgent).mockResolvedValue({
+        payloads: [{ text: "done" }],
+        meta: {
+          durationMs: 5,
+          agentMeta: {
+            sessionId: "s",
+            provider: "anthropic",
+            model: "claude-opus-4-5",
+          },
+        },
+      });
+
+      const res = await runCronIsolatedAgentTurn({
+        cfg: makeCfg(home, storePath),
+        deps: makeDeps(),
+        job: makeJob({ kind: "agentTurn", message: "hello" }),
+        message: "hello",
+        sessionKey: "cron:job-model",
+        lane: "cron",
+      });
+
+      expect(res.status).toBe("ok");
+
+      // Should use the default model from config
+      const call = vi.mocked(runEmbeddedPiAgent).mock.calls[0]?.[0];
+      expect(call?.model).toBe("claude-opus-4-5");
+      expect(call?.provider).toBe("anthropic");
+
+      // Session entry should also reflect the default model
+      const store = await readSessionStore(storePath);
+      const cronKey = "agent:main:cron:job-model";
+      const entry = store[cronKey];
+      expect(entry).toBeDefined();
+      expect(entry?.model).toBe("claude-opus-4-5");
+      expect(entry?.modelProvider).toBe("anthropic");
+    });
+  });
+
+  it("persists the payload model to the session store before the run starts", async () => {
+    await withTempHome(async (home) => {
+      const storePath = await writeSessionStore(home);
+      let sessionModelDuringRun: string | undefined;
+      let sessionProviderDuringRun: string | undefined;
+
+      vi.mocked(runEmbeddedPiAgent).mockImplementation(async () => {
+        // Read the session store mid-run to verify model was persisted
+        const store = await readSessionStore(storePath);
+        const cronKey = "agent:main:cron:job-model";
+        const entry = store[cronKey];
+        sessionModelDuringRun = entry?.model;
+        sessionProviderDuringRun = entry?.modelProvider;
+
+        return {
+          payloads: [{ text: "done" }],
+          meta: {
+            durationMs: 5,
+            agentMeta: {
+              sessionId: "s",
+              provider: "openai",
+              model: "gpt-nano",
+            },
+          },
+        };
+      });
+
+      const res = await runCronIsolatedAgentTurn({
+        cfg: makeCfg(home, storePath),
+        deps: makeDeps(),
+        job: makeJob({ kind: "agentTurn", message: "hello", model: "openai/gpt-nano" }),
+        message: "hello",
+        sessionKey: "cron:job-model",
+        lane: "cron",
+      });
+
+      expect(res.status).toBe("ok");
+      // The session store should have the payload model DURING the run
+      expect(sessionModelDuringRun).toBe("gpt-nano");
+      expect(sessionProviderDuringRun).toBe("openai");
+    });
+  });
+});

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -213,6 +213,10 @@ export async function runCronIsolatedAgentTurn(params: {
     agentId,
     nowMs: now,
   });
+  // Assign the resolved model (respecting payload.model override) to the
+  // session entry so it is persisted correctly before the agent run starts.
+  cronSession.sessionEntry.modelProvider = provider;
+  cronSession.sessionEntry.model = model;
   const runSessionId = cronSession.sessionEntry.sessionId;
   const runSessionKey = baseSessionKey.startsWith("cron:")
     ? `${agentSessionKey}:run:${runSessionId}`


### PR DESCRIPTION
## Bug

When a cron job with `payload.model: "gpt-nano"` fires, the spawned session is assigned the gateway's default model instead of the model specified in the payload.

## Root Cause

In `src/cron/isolated-agent/run.ts`, the model override from `payload.model` is correctly resolved into `provider`/`model` variables before the session is created. However, `resolveCronSession()` initialises `sessionEntry.model` from the stored entry (`entry?.model`), which is either `undefined` (for new cron jobs) or the previously stored value — not the payload model.

The resolved model was only written back to the session entry **after** the agent run completed. This meant every `persistSessionEntry()` call before and during the run wrote the wrong model.

## Fix

Set `cronSession.sessionEntry.model` and `cronSession.sessionEntry.modelProvider` immediately after `resolveCronSession()` returns, using the already-resolved `provider`/`model` variables (which incorporate the payload.model override). This ensures the correct model is persisted before the first `persistSessionEntry()` call and before the agent run starts.

## Tests

Added `src/cron/isolated-agent.cron-payload-model-session.test.ts` with 3 tests:
1. **payload.model is assigned to the session entry** — verifies both the agent call and session store reflect the payload model
2. **gateway default model used when payload.model is absent** — confirms no regression for the normal path
3. **payload model is persisted before the run starts** — reads the session store mid-run to verify the model was already written

All 110 existing cron tests continue to pass. `pnpm check` (format, typecheck, lint) clean.

Fixes #14981

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes cron isolated-agent runs so a `payload.model` override is persisted into the session store *before* the first `persistSessionEntry()` call, instead of only being written after the run completes. It also adds a new test suite that validates (1) payload model/provider flow into `runEmbeddedPiAgent`, (2) fallback to gateway default model when unset, and (3) that the session store contains the payload model mid-run.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge once the new test file type error is fixed.
- The functional change is localized and directly addresses an identified persistence timing bug; however, the new test file currently violates the `CliDeps` type (missing `sendMessageSlack`), which should be corrected to keep `pnpm check`/typecheck green.
- src/cron/isolated-agent.cron-payload-model-session.test.ts

<sub>Last reviewed commit: 928f6fd</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->