### PR TITLE
fix: update contextTokens when model is switched via /model (#14969)

### DIFF
--- a/src/auto-reply/reply/directive-handling.impl.ts
+++ b/src/auto-reply/reply/directive-handling.impl.ts
@@ -9,6 +9,8 @@ import {
   resolveAgentDir,
   resolveSessionAgentId,
 } from "../../agents/agent-scope.js";
+import { lookupContextTokens } from "../../agents/context.js";
+import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { resolveSandboxRuntimeStatus } from "../../agents/sandbox.js";
 import { type SessionEntry, updateSessionStore } from "../../config/sessions.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
@@ -354,6 +356,16 @@ export async function handleDirectiveOnly(params: {
       selection: modelSelection,
       profileOverride,
     });
+    // Update contextTokens to reflect the new model's context window
+    // so /status shows the correct limit immediately after switching.
+    const agentDefaults = params.cfg.agents?.defaults;
+    const newContextTokens =
+      agentDefaults?.contextTokens ??
+      lookupContextTokens(modelSelection.model) ??
+      DEFAULT_CONTEXT_TOKENS;
+    if (sessionEntry.contextTokens !== newContextTokens) {
+      sessionEntry.contextTokens = newContextTokens;
+    }
   }
   if (directives.hasQueueDirective && directives.queueReset) {
     delete sessionEntry.queueMode;

--- a/src/auto-reply/reply/directive-handling.persist.ts
+++ b/src/auto-reply/reply/directive-handling.persist.ts
@@ -179,6 +179,13 @@ export async function persistInlineDirectives(params: {
               contextKey: `model:${nextLabel}`,
             });
           }
+          // Update contextTokens to reflect the new model's context window
+          // so /status shows the correct limit immediately after switching.
+          const newContextTokens =
+            agentCfg?.contextTokens ?? lookupContextTokens(model) ?? DEFAULT_CONTEXT_TOKENS;
+          if (sessionEntry.contextTokens !== newContextTokens) {
+            sessionEntry.contextTokens = newContextTokens;
+          }
           updated = updated || modelUpdated;
         }
       }


### PR DESCRIPTION
## Summary

Fixes #14969 — When switching models mid-session using `/model`, the session's `contextTokens` value remained cached from the original model instead of updating to the new model's context window.

## Problem

After `/model gemini3f` (switching from Opus 200k to Gemini 1M+), `/status` still showed `XXk/200k` instead of `XXk/1049k`.

The root cause: `applyModelOverrideToSessionEntry()` updates `modelOverride` and `providerOverride` on the session entry but never touches `contextTokens`. The value was only refreshed on the next agent run (via `persistSessionUsageUpdate`), not on the `/model` command itself.

## Fix

Update `sessionEntry.contextTokens` immediately when the model is switched, in both code paths:

- **`directive-handling.impl.ts`** (`handleDirectiveOnly`): standalone `/model` commands
- **`directive-handling.persist.ts`** (`persistInlineDirectives`): `/model` combined with a message

Both now compute and persist the new model's context window using the same `agentCfg.contextTokens ?? lookupContextTokens(model) ?? DEFAULT_CONTEXT_TOKENS` logic already used elsewhere.

## Tests

Added 3 tests in `directive-handling.model.test.ts`:
- Updates contextTokens when switching from Opus (200k) to GPT-4o (128k)
- Updates contextTokens when switching to Gemini (1M+)
- Does not change contextTokens when re-selecting the same model

All existing tests continue to pass (`pnpm check` ✅, 78 related tests ✅).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates directive handling so switching models via `/model` immediately refreshes the session’s `contextTokens` (both for directive-only commands and inline directives), aligning `/status` output with the newly selected model’s context window. It does this by recomputing `contextTokens` using the existing pattern: `agentCfg.contextTokens ?? lookupContextTokens(model) ?? DEFAULT_CONTEXT_TOKENS`, and persisting the updated session entry.

The added tests cover switching between known models (Opus → GPT-4o, Opus → Gemini) and the no-op case when re-selecting the same model.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge once the test mock matches production defaults.
- Implementation change is localized and follows existing context-token resolution patterns, but the new tests currently mock DEFAULT_CONTEXT_TOKENS to a different value than production (200k), which can hide fallback regressions and should be corrected.
- src/auto-reply/reply/directive-handling.model.test.ts

<sub>Last reviewed commit: b2e0de5</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->