### PR TITLE
Gateway/Control UI: preserve partial output on abort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -340,6 +340,7 @@ Docs: https://docs.openclaw.ai
 - Configure/Gateway: reject literal `"undefined"`/`"null"` token input and validate gateway password prompt values to avoid invalid password-mode configs. (#13767) Thanks @omair445.
 - Gateway: handle async `EPIPE` on stdout/stderr during shutdown. (#13414) Thanks @keshav55.
 - Gateway/Control UI: resolve missing dashboard assets when `openclaw` is installed globally via symlink-based Node managers (nvm/fnm/n/Homebrew). (#14919) Thanks @aynorica.
+- Gateway/Control UI: keep partial assistant output visible when runs are aborted, and persist aborted partials to session transcripts for follow-up context.
 - Cron: use requested `agentId` for isolated job auth resolution. (#13983) Thanks @0xRaini.
 - Cron: prevent cron jobs from skipping execution when `nextRunAtMs` advances. (#14068) Thanks @WalterSumbon.
 - Cron: pass `agentId` to `runHeartbeatOnce` for main-session jobs. (#14140) Thanks @ishikawa-pro.

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -96,6 +96,10 @@ Cron jobs panel notes:
   - Click **Stop** (calls `chat.abort`)
   - Type `/stop` (or `stop|esc|abort|wait|exit|interrupt`) to abort out-of-band
   - `chat.abort` supports `{ sessionKey }` (no `runId`) to abort all active runs for that session
+- Abort partial retention:
+  - When a run is aborted, partial assistant text can still be shown in the UI
+  - Gateway persists aborted partial assistant text into transcript history when buffered output exists
+  - Persisted entries include abort metadata so transcript consumers can tell abort partials from normal completion output
 
 ## Tailnet access (recommended)
 

--- a/docs/web/webchat.md
+++ b/docs/web/webchat.md
@@ -25,6 +25,8 @@ Status: the macOS/iOS SwiftUI chat UI talks directly to the Gateway WebSocket.
 
 - The UI connects to the Gateway WebSocket and uses `chat.history`, `chat.send`, and `chat.inject`.
 - `chat.inject` appends an assistant note directly to the transcript and broadcasts it to the UI (no agent run).
+- Aborted runs can keep partial assistant output visible in the UI.
+- Gateway persists aborted partial assistant text into transcript history when buffered output exists, and marks those entries with abort metadata.
 - History is always fetched from the gateway (no local file watching).
 - If the gateway is unreachable, WebChat is read-only.
 

--- a/src/gateway/chat-abort.test.ts
+++ b/src/gateway/chat-abort.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  abortChatRunById,
+  type ChatAbortOps,
+  type ChatAbortControllerEntry,
+} from "./chat-abort.js";
+
+function createActiveEntry(sessionKey: string): ChatAbortControllerEntry {
+  const now = Date.now();
+  return {
+    controller: new AbortController(),
+    sessionId: "sess-1",
+    sessionKey,
+    startedAtMs: now,
+    expiresAtMs: now + 10_000,
+  };
+}
+
+function createOps(params: {
+  runId: string;
+  entry: ChatAbortControllerEntry;
+  buffer?: string;
+}): ChatAbortOps & {
+  broadcast: ReturnType<typeof vi.fn>;
+  nodeSendToSession: ReturnType<typeof vi.fn>;
+  removeChatRun: ReturnType<typeof vi.fn>;
+} {
+  const { runId, entry, buffer } = params;
+  const broadcast = vi.fn();
+  const nodeSendToSession = vi.fn();
+  const removeChatRun = vi.fn();
+
+  return {
+    chatAbortControllers: new Map([[runId, entry]]),
+    chatRunBuffers: new Map(buffer !== undefined ? [[runId, buffer]] : []),
+    chatDeltaSentAt: new Map([[runId, Date.now()]]),
+    chatAbortedRuns: new Map(),
+    removeChatRun,
+    agentRunSeq: new Map(),
+    broadcast,
+    nodeSendToSession,
+  };
+}
+
+describe("abortChatRunById", () => {
+  it("broadcasts aborted payload with partial message when buffered text exists", () => {
+    const runId = "run-1";
+    const sessionKey = "main";
+    const entry = createActiveEntry(sessionKey);
+    const ops = createOps({ runId, entry, buffer: "  Partial reply  " });
+
+    const result = abortChatRunById(ops, { runId, sessionKey, stopReason: "user" });
+
+    expect(result).toEqual({ aborted: true });
+    expect(entry.controller.signal.aborted).toBe(true);
+    expect(ops.chatAbortControllers.has(runId)).toBe(false);
+    expect(ops.chatRunBuffers.has(runId)).toBe(false);
+    expect(ops.chatDeltaSentAt.has(runId)).toBe(false);
+    expect(ops.removeChatRun).toHaveBeenCalledWith(runId, runId, sessionKey);
+
+    expect(ops.broadcast).toHaveBeenCalledTimes(1);
+    const payload = ops.broadcast.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(payload).toEqual(
+      expect.objectContaining({
+        runId,
+        sessionKey,
+        seq: 1,
+        state: "aborted",
+        stopReason: "user",
+      }),
+    );
+    expect(payload.message).toEqual(
+      expect.objectContaining({
+        role: "assistant",
+        content: [{ type: "text", text: "  Partial reply  " }],
+      }),
+    );
+    expect((payload.message as { timestamp?: unknown }).timestamp).toEqual(expect.any(Number));
+    expect(ops.nodeSendToSession).toHaveBeenCalledWith(sessionKey, "chat", payload);
+  });
+
+  it("omits aborted message when buffered text is empty", () => {
+    const runId = "run-1";
+    const sessionKey = "main";
+    const entry = createActiveEntry(sessionKey);
+    const ops = createOps({ runId, entry, buffer: "   " });
+
+    const result = abortChatRunById(ops, { runId, sessionKey });
+
+    expect(result).toEqual({ aborted: true });
+    const payload = ops.broadcast.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(payload.message).toBeUndefined();
+  });
+
+  it("preserves partial message even when abort listeners clear buffers synchronously", () => {
+    const runId = "run-1";
+    const sessionKey = "main";
+    const entry = createActiveEntry(sessionKey);
+    const ops = createOps({ runId, entry, buffer: "streamed text" });
+
+    // Simulate synchronous cleanup triggered by AbortController listeners.
+    entry.controller.signal.addEventListener("abort", () => {
+      ops.chatRunBuffers.delete(runId);
+    });
+
+    const result = abortChatRunById(ops, { runId, sessionKey });
+
+    expect(result).toEqual({ aborted: true });
+    const payload = ops.broadcast.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(payload.message).toEqual(
+      expect.objectContaining({
+        role: "assistant",
+        content: [{ type: "text", text: "streamed text" }],
+      }),
+    );
+  });
+});

--- a/src/gateway/chat-abort.test.ts
+++ b/src/gateway/chat-abort.test.ts
@@ -48,6 +48,9 @@ describe("abortChatRunById", () => {
     const sessionKey = "main";
     const entry = createActiveEntry(sessionKey);
     const ops = createOps({ runId, entry, buffer: "  Partial reply  " });
+    ops.agentRunSeq.set(runId, 2);
+    ops.agentRunSeq.set("client-run-1", 4);
+    ops.removeChatRun.mockReturnValue({ sessionKey, clientRunId: "client-run-1" });
 
     const result = abortChatRunById(ops, { runId, sessionKey, stopReason: "user" });
 
@@ -57,6 +60,8 @@ describe("abortChatRunById", () => {
     expect(ops.chatRunBuffers.has(runId)).toBe(false);
     expect(ops.chatDeltaSentAt.has(runId)).toBe(false);
     expect(ops.removeChatRun).toHaveBeenCalledWith(runId, runId, sessionKey);
+    expect(ops.agentRunSeq.has(runId)).toBe(false);
+    expect(ops.agentRunSeq.has("client-run-1")).toBe(false);
 
     expect(ops.broadcast).toHaveBeenCalledTimes(1);
     const payload = ops.broadcast.mock.calls[0]?.[1] as Record<string, unknown>;
@@ -64,7 +69,7 @@ describe("abortChatRunById", () => {
       expect.objectContaining({
         runId,
         sessionKey,
-        seq: 1,
+        seq: 3,
         state: "aborted",
         stopReason: "user",
       }),

--- a/src/gateway/server-methods/chat.abort-persistence.test.ts
+++ b/src/gateway/server-methods/chat.abort-persistence.test.ts
@@ -1,0 +1,252 @@
+import { CURRENT_SESSION_VERSION } from "@mariozechner/pi-coding-agent";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+type TranscriptLine = {
+  message?: Record<string, unknown>;
+};
+
+function createActiveRun(sessionKey: string, sessionId: string) {
+  const now = Date.now();
+  return {
+    controller: new AbortController(),
+    sessionId,
+    sessionKey,
+    startedAtMs: now,
+    expiresAtMs: now + 30_000,
+  };
+}
+
+async function writeTranscriptHeader(transcriptPath: string, sessionId: string) {
+  const header = {
+    type: "session",
+    version: CURRENT_SESSION_VERSION,
+    id: sessionId,
+    timestamp: new Date(0).toISOString(),
+    cwd: "/tmp",
+  };
+  await fs.writeFile(transcriptPath, `${JSON.stringify(header)}\n`, "utf-8");
+}
+
+async function readTranscriptLines(transcriptPath: string): Promise<TranscriptLine[]> {
+  const raw = await fs.readFile(transcriptPath, "utf-8");
+  return raw
+    .split(/\r?\n/)
+    .filter((line) => line.trim().length > 0)
+    .map((line) => {
+      try {
+        return JSON.parse(line) as TranscriptLine;
+      } catch {
+        return {};
+      }
+    });
+}
+
+async function importChatHandlersWithSession(transcriptPath: string, sessionId: string) {
+  vi.resetModules();
+  vi.doMock("../session-utils.js", async (importOriginal) => {
+    const original = await importOriginal();
+    return {
+      ...original,
+      loadSessionEntry: () => ({
+        cfg: {},
+        storePath: path.join(path.dirname(transcriptPath), "sessions.json"),
+        entry: {
+          sessionId,
+          sessionFile: transcriptPath,
+        },
+        canonicalKey: "main",
+      }),
+    };
+  });
+  return import("./chat.js");
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+});
+
+describe("chat abort transcript persistence", () => {
+  it("persists run-scoped abort partial with rpc metadata and idempotency", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-chat-abort-run-"));
+    const transcriptPath = path.join(dir, "sess-main.jsonl");
+    const sessionId = "sess-main";
+    const runId = "idem-abort-run-1";
+    await writeTranscriptHeader(transcriptPath, sessionId);
+
+    const { chatHandlers } = await importChatHandlersWithSession(transcriptPath, sessionId);
+    const respond = vi.fn();
+    const context = {
+      chatAbortControllers: new Map([[runId, createActiveRun("main", sessionId)]]),
+      chatRunBuffers: new Map([[runId, "Partial from run abort"]]),
+      chatDeltaSentAt: new Map([[runId, Date.now()]]),
+      chatAbortedRuns: new Map<string, number>(),
+      removeChatRun: vi
+        .fn()
+        .mockReturnValue({ sessionKey: "main", clientRunId: "client-idem-abort-run-1" }),
+      agentRunSeq: new Map<string, number>([
+        [runId, 2],
+        ["client-idem-abort-run-1", 3],
+      ]),
+      broadcast: vi.fn(),
+      nodeSendToSession: vi.fn(),
+      logGateway: { warn: vi.fn() },
+    };
+
+    await chatHandlers["chat.abort"]({
+      params: { sessionKey: "main", runId },
+      respond,
+      context: context as never,
+    });
+
+    const [ok1, payload1] = respond.mock.calls.at(-1) ?? [];
+    expect(ok1).toBe(true);
+    expect(payload1).toMatchObject({ aborted: true, runIds: [runId] });
+
+    context.chatAbortControllers.set(runId, createActiveRun("main", sessionId));
+    context.chatRunBuffers.set(runId, "Partial from run abort");
+    context.chatDeltaSentAt.set(runId, Date.now());
+
+    await chatHandlers["chat.abort"]({
+      params: { sessionKey: "main", runId },
+      respond,
+      context: context as never,
+    });
+
+    const lines = await readTranscriptLines(transcriptPath);
+    const persisted = lines
+      .map((line) => line.message)
+      .filter(
+        (message): message is Record<string, unknown> =>
+          Boolean(message) && message?.idempotencyKey === `${runId}:assistant`,
+      );
+
+    expect(persisted).toHaveLength(1);
+    expect(persisted[0]).toMatchObject({
+      stopReason: "stop",
+      idempotencyKey: `${runId}:assistant`,
+      openclawAbort: {
+        aborted: true,
+        origin: "rpc",
+        runId,
+      },
+    });
+  });
+
+  it("persists session-scoped abort partials with rpc metadata", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-chat-abort-session-"));
+    const transcriptPath = path.join(dir, "sess-main.jsonl");
+    const sessionId = "sess-main";
+    await writeTranscriptHeader(transcriptPath, sessionId);
+
+    const { chatHandlers } = await importChatHandlersWithSession(transcriptPath, sessionId);
+    const respond = vi.fn();
+    const context = {
+      chatAbortControllers: new Map([
+        ["run-a", createActiveRun("main", sessionId)],
+        ["run-b", createActiveRun("main", sessionId)],
+      ]),
+      chatRunBuffers: new Map([
+        ["run-a", "Session abort partial"],
+        ["run-b", "   "],
+      ]),
+      chatDeltaSentAt: new Map([
+        ["run-a", Date.now()],
+        ["run-b", Date.now()],
+      ]),
+      chatAbortedRuns: new Map<string, number>(),
+      removeChatRun: vi
+        .fn()
+        .mockImplementation((run: string) => ({ sessionKey: "main", clientRunId: run })),
+      agentRunSeq: new Map<string, number>(),
+      broadcast: vi.fn(),
+      nodeSendToSession: vi.fn(),
+      logGateway: { warn: vi.fn() },
+    };
+
+    await chatHandlers["chat.abort"]({
+      params: { sessionKey: "main" },
+      respond,
+      context: context as never,
+    });
+
+    const [ok, payload] = respond.mock.calls.at(-1) ?? [];
+    expect(ok).toBe(true);
+    expect(payload).toMatchObject({ aborted: true });
+    expect(payload.runIds).toEqual(expect.arrayContaining(["run-a", "run-b"]));
+
+    const lines = await readTranscriptLines(transcriptPath);
+    const runAPersisted = lines
+      .map((line) => line.message)
+      .find((message) => message?.idempotencyKey === "run-a:assistant");
+    const runBPersisted = lines
+      .map((line) => line.message)
+      .find((message) => message?.idempotencyKey === "run-b:assistant");
+
+    expect(runAPersisted).toMatchObject({
+      idempotencyKey: "run-a:assistant",
+      openclawAbort: {
+        aborted: true,
+        origin: "rpc",
+        runId: "run-a",
+      },
+    });
+    expect(runBPersisted).toBeUndefined();
+  });
+
+  it("persists /stop partials with stop-command metadata", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-chat-stop-"));
+    const transcriptPath = path.join(dir, "sess-main.jsonl");
+    const sessionId = "sess-main";
+    await writeTranscriptHeader(transcriptPath, sessionId);
+
+    const { chatHandlers } = await importChatHandlersWithSession(transcriptPath, sessionId);
+    const respond = vi.fn();
+    const context = {
+      chatAbortControllers: new Map([["run-stop-1", createActiveRun("main", sessionId)]]),
+      chatRunBuffers: new Map([["run-stop-1", "Partial from /stop"]]),
+      chatDeltaSentAt: new Map([["run-stop-1", Date.now()]]),
+      chatAbortedRuns: new Map<string, number>(),
+      removeChatRun: vi.fn().mockReturnValue({ sessionKey: "main", clientRunId: "client-stop-1" }),
+      agentRunSeq: new Map<string, number>([["run-stop-1", 1]]),
+      broadcast: vi.fn(),
+      nodeSendToSession: vi.fn(),
+      logGateway: { warn: vi.fn() },
+      dedupe: {
+        get: vi.fn(),
+      },
+    };
+
+    await chatHandlers["chat.send"]({
+      params: {
+        sessionKey: "main",
+        message: "/stop",
+        idempotencyKey: "idem-stop-req",
+      },
+      respond,
+      context: context as never,
+      client: undefined,
+    });
+
+    const [ok, payload] = respond.mock.calls.at(-1) ?? [];
+    expect(ok).toBe(true);
+    expect(payload).toMatchObject({ aborted: true, runIds: ["run-stop-1"] });
+
+    const lines = await readTranscriptLines(transcriptPath);
+    const persisted = lines
+      .map((line) => line.message)
+      .find((message) => message?.idempotencyKey === "run-stop-1:assistant");
+
+    expect(persisted).toMatchObject({
+      idempotencyKey: "run-stop-1:assistant",
+      openclawAbort: {
+        aborted: true,
+        origin: "stop-command",
+        runId: "run-stop-1",
+      },
+    });
+  });
+});

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -92,4 +92,93 @@ describe("handleChatEvent", () => {
     expect(state.chatStream).toBe(null);
     expect(state.chatStreamStartedAt).toBe(null);
   });
+
+  it("processes aborted from own run and keeps partial assistant message", () => {
+    const existingMessage = {
+      role: "user",
+      content: [{ type: "text", text: "Hi" }],
+      timestamp: 1,
+    };
+    const partialMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: "Partial reply" }],
+      timestamp: 2,
+    };
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "Partial reply",
+      chatStreamStartedAt: 100,
+      chatMessages: [existingMessage],
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "aborted",
+      message: partialMessage,
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("aborted");
+    expect(state.chatRunId).toBe(null);
+    expect(state.chatStream).toBe(null);
+    expect(state.chatStreamStartedAt).toBe(null);
+    expect(state.chatMessages).toEqual([existingMessage, partialMessage]);
+  });
+
+  it("processes aborted from own run without message and keeps streamed partial", () => {
+    const existingMessage = {
+      role: "user",
+      content: [{ type: "text", text: "Hi" }],
+      timestamp: 1,
+    };
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "Partial reply",
+      chatStreamStartedAt: 100,
+      chatMessages: [existingMessage],
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "aborted",
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("aborted");
+    expect(state.chatRunId).toBe(null);
+    expect(state.chatStream).toBe(null);
+    expect(state.chatStreamStartedAt).toBe(null);
+    expect(state.chatMessages).toHaveLength(2);
+    expect(state.chatMessages[0]).toEqual(existingMessage);
+    expect(state.chatMessages[1]).toMatchObject({
+      role: "assistant",
+      content: [{ type: "text", text: "Partial reply" }],
+    });
+  });
+
+  it("processes aborted from own run without message and empty stream", () => {
+    const existingMessage = {
+      role: "user",
+      content: [{ type: "text", text: "Hi" }],
+      timestamp: 1,
+    };
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "",
+      chatStreamStartedAt: 100,
+      chatMessages: [existingMessage],
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "aborted",
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("aborted");
+    expect(state.chatRunId).toBe(null);
+    expect(state.chatStream).toBe(null);
+    expect(state.chatStreamStartedAt).toBe(null);
+    expect(state.chatMessages).toEqual([existingMessage]);
+  });
 });

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -198,6 +198,21 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
     state.chatRunId = null;
     state.chatStreamStartedAt = null;
   } else if (payload.state === "aborted") {
+    if (payload.message !== undefined) {
+      state.chatMessages = [...state.chatMessages, payload.message];
+    } else {
+      const streamedText = state.chatStream ?? "";
+      if (streamedText.trim()) {
+        state.chatMessages = [
+          ...state.chatMessages,
+          {
+            role: "assistant",
+            content: [{ type: "text", text: streamedText }],
+            timestamp: Date.now(),
+          },
+        ];
+      }
+    }
     state.chatStream = null;
     state.chatRunId = null;
     state.chatStreamStartedAt = null;


### PR DESCRIPTION
## Summary
- include partial assistant text in `chat` aborted events when buffered output exists
- persist aborted partials to the session transcript so follow-up turns keep context
- update Control UI abort handling to append the aborted message (or fallback to current stream) instead of discarding it
- add gateway and UI tests for aborted partial retention and race safety

## Testing
- `pnpm check`
- `pnpm vitest run src/gateway/chat-abort.test.ts`
- `pnpm --dir ui exec vitest run --config vitest.config.ts --browser.enabled false src/ui/controllers/chat.test.ts`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes gateway abort behavior to preserve partial assistant output: `abortChatRunById` now includes an optional assistant `message` in `chat` aborted events when there’s buffered text, and gateway abort handlers persist those partials into the session transcript for follow-up context. The Control UI’s chat controller is updated to keep aborted partials visible by either appending the server-provided aborted message or falling back to the locally streamed buffer. New Vitest coverage is added for both gateway abort payload behavior and UI aborted handling.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but needs fixes to avoid mislabeling persisted aborted output and to harden UI state against malformed aborted payloads.
- Core behavior changes are well-targeted and tested, but persisted aborted partials are currently written as `stopReason: "stop"` (which can misrepresent aborts in transcripts), and the UI appends an `unknown` message object directly into `chatMessages` on abort events without shape validation.
- src/gateway/server-methods/chat.ts, ui/src/ui/controllers/chat.ts

<sub>Last reviewed commit: 6496f4a</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->