### PR TITLE
Agents: support per-agent thinking defaults

### DIFF
--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -30,6 +30,7 @@ type ResolvedAgentConfig = {
   agentDir?: string;
   model?: AgentEntry["model"];
   skills?: AgentEntry["skills"];
+  thinkingDefault?: AgentEntry["thinkingDefault"];
   memorySearch?: AgentEntry["memorySearch"];
   humanDelay?: AgentEntry["humanDelay"];
   heartbeat?: AgentEntry["heartbeat"];
@@ -132,6 +133,7 @@ export function resolveAgentConfig(
         ? entry.model
         : undefined,
     skills: Array.isArray(entry.skills) ? entry.skills : undefined,
+    thinkingDefault: entry.thinkingDefault,
     memorySearch: entry.memorySearch,
     humanDelay: entry.humanDelay,
     heartbeat: entry.heartbeat,

--- a/src/auto-reply/reply/get-reply.reset-hooks-fallback.test.ts
+++ b/src/auto-reply/reply/get-reply.reset-hooks-fallback.test.ts
@@ -11,6 +11,14 @@ const mocks = vi.hoisted(() => ({
 
 registerGetReplyCommonMocks();
 
+// PR addition: mock resolveAgentConfig for per-agent thinking defaults
+vi.mock("../../agents/agent-scope.js", () => ({
+  resolveAgentConfig: vi.fn(() => undefined),
+  resolveAgentDir: vi.fn(() => "/tmp/agent"),
+  resolveAgentWorkspaceDir: vi.fn(() => "/tmp/workspace"),
+  resolveSessionAgentId: vi.fn(() => "main"),
+  resolveAgentSkillsFilter: vi.fn(() => undefined),
+}));
 vi.mock("../../link-understanding/apply.js", () => ({
   applyLinkUnderstanding: vi.fn(async () => undefined),
 }));

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -78,9 +78,10 @@ export async function getReplyFromConfig(
 
   // Merge per-agent config (e.g. thinkingDefault) with global defaults.
   const perAgentConfig = resolveAgentConfig(cfg, agentId);
-  const agentCfg = perAgentConfig?.thinkingDefault
-    ? { ...cfg.agents?.defaults, thinkingDefault: perAgentConfig.thinkingDefault }
-    : cfg.agents?.defaults;
+  const agentCfg =
+    perAgentConfig?.thinkingDefault != null
+      ? { ...cfg.agents?.defaults, thinkingDefault: perAgentConfig.thinkingDefault }
+      : cfg.agents?.defaults;
 
   const sessionCfg = cfg.session;
   const { defaultProvider, defaultModel, aliasIndex } = resolveDefaultModel({

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -1,4 +1,5 @@
 import {
+  resolveAgentConfig,
   resolveAgentDir,
   resolveAgentWorkspaceDir,
   resolveSessionAgentId,
@@ -74,7 +75,13 @@ export async function getReplyFromConfig(
   );
   const resolvedOpts =
     mergedSkillFilter !== undefined ? { ...opts, skillFilter: mergedSkillFilter } : opts;
-  const agentCfg = cfg.agents?.defaults;
+
+  // Merge per-agent config (e.g. thinkingDefault) with global defaults.
+  const perAgentConfig = resolveAgentConfig(cfg, agentId);
+  const agentCfg = perAgentConfig?.thinkingDefault
+    ? { ...cfg.agents?.defaults, thinkingDefault: perAgentConfig.thinkingDefault }
+    : cfg.agents?.defaults;
+
   const sessionCfg = cfg.session;
   const { defaultProvider, defaultModel, aliasIndex } = resolveDefaultModel({
     cfg,

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -396,7 +396,7 @@ export async function createModelSelectionState(params: {
       catalog: catalogForThinking,
     });
     defaultThinkingLevel =
-      resolved ?? (agentCfg?.thinkingDefault as ThinkLevel | undefined) ?? "off";
+      (agentCfg?.thinkingDefault as ThinkLevel | undefined) ?? resolved ?? "off";
     return defaultThinkingLevel;
   };
 

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -6,6 +6,7 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 const log = createSubsystemLogger("commands/agent");
 import {
   listAgentIds,
+  resolveAgentConfig,
   resolveAgentDir,
   resolveEffectiveModelFallbacks,
   resolveSessionAgentId,
@@ -476,7 +477,15 @@ async function prepareAgentCommandExecution(
       );
     }
   }
-  const agentCfg = cfg.agents?.defaults;
+  // Merge per-agent config (e.g. thinkingDefault) with global defaults.
+  // sessionAgentId / workspaceDir etc. are resolved later (line ~330).
+  const earlyAgentId = agentIdOverride ?? resolveAgentIdFromSessionKey(opts.sessionKey?.trim());
+  const perAgentConfig = resolveAgentConfig(cfg, earlyAgentId);
+  const agentCfg = perAgentConfig
+    ? Object.assign({}, cfg.agents?.defaults, {
+        thinkingDefault: perAgentConfig.thinkingDefault ?? cfg.agents?.defaults?.thinkingDefault,
+      })
+    : cfg.agents?.defaults;
   const configuredModel = resolveConfiguredModelRef({
     cfg,
     defaultProvider: DEFAULT_PROVIDER,

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -68,7 +68,7 @@ export type AgentConfig = {
   /** Optional allowlist of skills for this agent (omit = all skills; empty = none). */
   skills?: string[];
   /** Default thinking level for this agent (auto-downgrades for unsupported models). */
-  thinkingDefault?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
+  thinkingDefault?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "adaptive";
   memorySearch?: MemorySearchConfig;
   /** Human-like delay between block replies for this agent. */
   humanDelay?: HumanDelayConfig;

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -67,6 +67,8 @@ export type AgentConfig = {
   model?: AgentModelConfig;
   /** Optional allowlist of skills for this agent (omit = all skills; empty = none). */
   skills?: string[];
+  /** Default thinking level for this agent (auto-downgrades for unsupported models). */
+  thinkingDefault?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
   memorySearch?: MemorySearchConfig;
   /** Human-like delay between block replies for this agent. */
   humanDelay?: HumanDelayConfig;

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -723,6 +723,7 @@ export const AgentEntrySchema = z
         z.literal("medium"),
         z.literal("high"),
         z.literal("xhigh"),
+        z.literal("adaptive"),
       ])
       .optional(),
     memorySearch: MemorySearchSchema,

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -715,6 +715,16 @@ export const AgentEntrySchema = z
     agentDir: z.string().optional(),
     model: AgentModelSchema.optional(),
     skills: z.array(z.string()).optional(),
+    thinkingDefault: z
+      .union([
+        z.literal("off"),
+        z.literal("minimal"),
+        z.literal("low"),
+        z.literal("medium"),
+        z.literal("high"),
+        z.literal("xhigh"),
+      ])
+      .optional(),
     memorySearch: MemorySearchSchema,
     humanDelay: HumanDelaySchema.optional(),
     heartbeat: HeartbeatSchema,


### PR DESCRIPTION
## Summary

Adds a `thinkingDefault` field to agent config so each agent can have its own default thinking level (`off`, `low`, `medium`, `high`).

### Changes
- **Config schema**: Add optional `thinkingDefault` to agent config with validation
- **Model selection**: Resolve per-agent thinking default when no explicit level is set
- **Chat server**: Thread agent thinking default through reply pipeline
- **Lint fix**: Remove unused imports in chat server methods

### Testing
- Fully tested, using it in production with 11 agents at different thinking levels

---
*Clean rebased branch — 3 commits on current main.*

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds an optional `thinkingDefault` field to per-agent configuration (schema + types), threads it through agent config resolution, and uses it during reply/model selection and in the gateway chat history response. It also includes a small lint-only cleanup in the chat server.

Key integration points:
- `src/agents/agent-scope.ts` exposes `thinkingDefault` via `resolveAgentConfig`.
- `src/auto-reply/reply/get-reply.ts` and `src/commands/agent.ts` merge per-agent values into `cfg.agents.defaults` so the existing reply pipeline can consume them.
- `src/auto-reply/reply/model-selection.ts` adjusts default thinking resolution to prefer the per-agent value.

Main issue to fix before merge: `getReplyFromConfig` currently uses a truthiness check when merging `thinkingDefault`, which breaks the ability to set a per-agent default of `"off"` to override a global non-off default.

<h3>Confidence Score: 3/5</h3>

- This PR is close, but there is at least one confirmed precedence bug that can prevent per-agent config from taking effect in common configurations.
- Most changes are straightforward schema/plumbing. However, `getReplyFromConfig` will ignore an explicit per-agent `thinkingDefault: "off"` when global defaults set a non-off value, which contradicts the feature intent and will produce wrong runtime behavior for affected agents. There is also a significant precedence behavior change in model-selection that should be confirmed as intended.
- src/auto-reply/reply/get-reply.ts, src/auto-reply/reply/model-selection.ts

<sub>Last reviewed commit: 804fd10</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

## AI-Assisted
Yes — implemented and reviewed with AI assistance.

## Local Validation

```bash
pnpm build && pnpm check && pnpm test
```

All tests pass. TypeScript compilation clean. Lint passes.