### PR TITLE
fix(cron): fall back to direct delivery when announce agent drops message (#14997)

### DIFF
--- a/src/agents/subagent-announce.empty-payloads-14997.test.ts
+++ b/src/agents/subagent-announce.empty-payloads-14997.test.ts
@@ -1,0 +1,184 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const agentSpy = vi.fn(async () => ({
+  runId: "run-main",
+  status: "ok",
+  result: { payloads: [{ text: "summary" }] },
+}));
+const sessionsDeleteSpy = vi.fn();
+const sessionsPatchSpy = vi.fn();
+const _readLatestAssistantReplyMock = vi.fn(async () => "raw subagent reply");
+
+let sessionStore: Record<string, Record<string, unknown>> = {};
+let configOverride: ReturnType<(typeof import("../config/config.js"))["loadConfig"]> = {
+  session: {
+    mainKey: "main",
+    scope: "per-sender",
+  },
+};
+
+vi.mock("../gateway/call.js", () => ({
+  callGateway: vi.fn(async (req: unknown) => {
+    const typed = req as { method: string; params?: Record<string, unknown> };
+    if (typed.method === "agent") {
+      return await agentSpy(typed);
+    }
+    if (typed.method === "sessions.patch") {
+      sessionsPatchSpy(typed);
+      return {};
+    }
+    if (typed.method === "sessions.delete") {
+      sessionsDeleteSpy(typed);
+      return {};
+    }
+    if (typed.method === "chat.history") {
+      return { messages: [] };
+    }
+    return {};
+  }),
+}));
+
+vi.mock("../config/config.js", () => ({
+  loadConfig: () => configOverride,
+  resolveGatewayPort: () => 3000,
+  resolveConfigPath: () => "/tmp/test-config.json",
+  resolveStateDir: () => "/tmp/test-state",
+}));
+
+vi.mock("../config/sessions.js", () => ({
+  loadSessionStore: () => sessionStore,
+  resolveStorePath: () => "/tmp/test-store.json",
+  resolveAgentIdFromSessionKey: (key: string) => {
+    const agentPrefix = "agent:";
+    if (key.startsWith(agentPrefix)) {
+      const parts = key.slice(agentPrefix.length).split(":");
+      return parts[0] ?? "main";
+    }
+    return "main";
+  },
+  resolveMainSessionKey: () => "agent:main:main",
+  resolveAgentMainSessionKey: () => "agent:main:main",
+}));
+
+vi.mock("../agents/pi-embedded-runner.js", () => ({
+  isEmbeddedPiRunActive: vi.fn(() => false),
+  isEmbeddedPiRunStreaming: vi.fn(() => false),
+  queueEmbeddedPiMessage: vi.fn(() => false),
+  waitForEmbeddedPiRunEnd: vi.fn(async () => true),
+}));
+vi.mock("../agents/pi-embedded-runner/runs.js", () => ({
+  isEmbeddedPiRunActive: vi.fn(() => false),
+  isEmbeddedPiRunStreaming: vi.fn(() => false),
+  queueEmbeddedPiMessage: vi.fn(() => false),
+  waitForEmbeddedPiRunEnd: vi.fn(async () => true),
+}));
+
+vi.mock("../agents/tools/agent-step.js", () => ({
+  readLatestAssistantReply: vi.fn(async () => "raw subagent reply"),
+}));
+
+vi.mock("../auto-reply/reply/queue.js", () => ({
+  resolveQueueSettings: () => ({
+    mode: "interrupt",
+    debounceMs: 500,
+    cap: 20,
+    dropPolicy: "summarize",
+  }),
+}));
+
+import { runSubagentAnnounceFlow } from "./subagent-announce.js";
+
+describe("runSubagentAnnounceFlow – empty payloads detection (#14997)", () => {
+  beforeEach(() => {
+    agentSpy.mockClear();
+    sessionsDeleteSpy.mockClear();
+    sessionsPatchSpy.mockClear();
+    sessionStore = {
+      "agent:main:main": {
+        sessionId: "main-session",
+        updatedAt: Date.now(),
+        lastChannel: "telegram",
+        lastTo: "123",
+      },
+    };
+    configOverride = {
+      session: { mainKey: "main", scope: "per-sender" },
+    };
+  });
+
+  it("returns true when announce agent delivers payloads", async () => {
+    agentSpy.mockResolvedValue({
+      runId: "run-main",
+      status: "ok",
+      result: { payloads: [{ text: "Here is the summary" }] },
+    });
+
+    const result = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:cron:job-1:run:abc",
+      childRunId: "job-1:abc",
+      requesterSessionKey: "agent:main:main",
+      requesterOrigin: { channel: "telegram", to: "123" },
+      requesterDisplayKey: "agent:main:main",
+      task: "weather check",
+      timeoutMs: 30_000,
+      cleanup: "keep",
+      roundOneReply: "Weather is sunny and warm today",
+      waitForCompletion: false,
+      outcome: { status: "ok" },
+      announceType: "cron job",
+    });
+
+    expect(result).toBe(true);
+    expect(agentSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns false when announce agent produces empty payloads (NO_REPLY)", async () => {
+    agentSpy.mockResolvedValue({
+      runId: "run-main",
+      status: "ok",
+      result: { payloads: [] },
+    });
+
+    const result = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:cron:job-1:run:abc",
+      childRunId: "job-1:abc",
+      requesterSessionKey: "agent:main:main",
+      requesterOrigin: { channel: "telegram", to: "123" },
+      requesterDisplayKey: "agent:main:main",
+      task: "weather check",
+      timeoutMs: 30_000,
+      cleanup: "keep",
+      roundOneReply: "Weather is sunny and warm today",
+      waitForCompletion: false,
+      outcome: { status: "ok" },
+      announceType: "cron job",
+    });
+
+    expect(result).toBe(false);
+    expect(agentSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns true when response has no result field (legacy/unknown format)", async () => {
+    agentSpy.mockResolvedValue({
+      runId: "run-main",
+      status: "ok",
+    });
+
+    const result = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:cron:job-1:run:abc",
+      childRunId: "job-1:abc",
+      requesterSessionKey: "agent:main:main",
+      requesterOrigin: { channel: "telegram", to: "123" },
+      requesterDisplayKey: "agent:main:main",
+      task: "weather check",
+      timeoutMs: 30_000,
+      cleanup: "keep",
+      roundOneReply: "Weather is sunny",
+      waitForCompletion: false,
+      outcome: { status: "ok" },
+      announceType: "cron job",
+    });
+
+    expect(result).toBe(true);
+  });
+});


### PR DESCRIPTION
## Bug

Cron jobs with `delivery.mode: "announce"` intermittently fail to deliver messages to Telegram. The agent completes successfully and produces the correct reply text (confirmed in session transcript), but the gateway logs "No reply from agent" and the message is never sent.

## Root Cause

When the cron isolated agent uses the announce flow (`runSubagentAnnounceFlow`), the output is routed through the main agent session for summarisation. If the announce agent responds with `NO_REPLY` (filtered by `isSilentReplyText` in `buildEmbeddedRunPayloads`), the gateway's `deliverAgentCommandResult` logs "No reply from agent" and returns `{ payloads: [] }`. However, `callGateway` resolves successfully, so `didAnnounce` is set to `true` — the cron job reports success even though the message was never delivered to Telegram.

## Fix

**1. `subagent-announce.ts`**: After the direct `callGateway` send, inspect the response payload. When `result.payloads` is an explicitly empty array (announce agent produced no deliverable output), return `didAnnounce = false` instead of `true`.

**2. `isolated-agent/run.ts`**: When `runSubagentAnnounceFlow` returns `false`, fall back to delivering the original cron output directly via `deliverOutboundPayloads`, so the message reaches Telegram even when the summarisation step fails.

## Tests

- **`subagent-announce.empty-payloads-14997.test.ts`** — 3 tests verifying the announce flow correctly returns `false` for empty payloads and `true` for non-empty/legacy responses.
- **`isolated-agent.announce-fallback-14997.test.ts`** — 4 tests verifying the cron isolated agent falls back to direct delivery when announce fails, handles missing delivery targets, and respects best-effort mode.
- Updated 2 existing tests to reflect the new fallback behaviour.

All 46 affected tests pass. `pnpm check` (format, typecheck, lint) clean.

Closes #14997

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes an intermittent cron delivery gap when `delivery.mode: "announce"` is used and the announce/summarization step results in a silent `NO_REPLY`.

Key changes:
- `src/agents/subagent-announce.ts` now inspects the gateway `agent` RPC response and treats an explicitly empty `result.payloads` array as a failed announce (`didAnnounce=false`).
- `src/cron/isolated-agent/run.ts` now falls back to `deliverOutboundPayloads` with the original cron output when `runSubagentAnnounceFlow()` reports failure, so the message still reaches the outbound channel.
- Adds targeted Vitest coverage for empty-payload detection and announce→direct delivery fallback, and updates existing tests to reflect the new behavior.

Overall this aligns cron’s success signal with actual delivery: the cron run no longer reports success when the announce flow produced no deliverable outbound payloads.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, but there are a couple of edge cases where the new “empty payloads” detection can still misreport success and suppress fallback delivery.
- Core behavior change is narrow and covered by new tests, but the announce success heuristic only treats `payloads: []` as failure; responses like `{ result: {} }` (or missing `payloads`) would be treated as success and could reintroduce silent non-delivery. The fallback path in cron is also gated on `deliveryPayloads.length > 0`, which can skip fallback in some no-text/no-payload scenarios even when `didAnnounce=false` indicates non-delivery.
- src/agents/subagent-announce.ts, src/cron/isolated-agent/run.ts

<sub>Last reviewed commit: 54a2ef9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->