### PR TITLE
fix: replace workspace:* with peerDependencies in all extensions

### DIFF
--- a/extensions/bluebubbles/package.json
+++ b/extensions/bluebubbles/package.json
@@ -3,8 +3,8 @@
   "version": "2026.1.30",
   "description": "OpenClaw BlueBubbles channel plugin",
   "type": "module",
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/copilot-proxy/package.json
+++ b/extensions/copilot-proxy/package.json
@@ -3,8 +3,8 @@
   "version": "2026.1.30",
   "description": "OpenClaw Copilot Proxy provider plugin",
   "type": "module",
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/diagnostics-otel/package.json
+++ b/extensions/diagnostics-otel/package.json
@@ -16,8 +16,8 @@
     "@opentelemetry/sdk-trace-base": "^2.5.0",
     "@opentelemetry/semantic-conventions": "^1.39.0"
   },
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/discord/package.json
+++ b/extensions/discord/package.json
@@ -3,8 +3,8 @@
   "version": "2026.1.30",
   "description": "OpenClaw Discord channel plugin",
   "type": "module",
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/google-antigravity-auth/package.json
+++ b/extensions/google-antigravity-auth/package.json
@@ -3,8 +3,8 @@
   "version": "2026.1.30",
   "description": "OpenClaw Google Antigravity OAuth provider plugin",
   "type": "module",
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/google-gemini-cli-auth/package.json
+++ b/extensions/google-gemini-cli-auth/package.json
@@ -3,8 +3,8 @@
   "version": "2026.1.30",
   "description": "OpenClaw Gemini CLI OAuth provider plugin",
   "type": "module",
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/googlechat/package.json
+++ b/extensions/googlechat/package.json
@@ -6,8 +6,8 @@
   "dependencies": {
     "google-auth-library": "^10.5.0"
   },
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "peerDependencies": {
     "openclaw": ">=2026.1.26"

--- a/extensions/googlechat/package.json
+++ b/extensions/googlechat/package.json
@@ -7,9 +7,6 @@
     "google-auth-library": "^10.5.0"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.0.0"
-  },
-  "peerDependencies": {
     "openclaw": ">=2026.1.26"
   },
   "openclaw": {

--- a/extensions/imessage/package.json
+++ b/extensions/imessage/package.json
@@ -3,8 +3,8 @@
   "version": "2026.1.30",
   "description": "OpenClaw iMessage channel plugin",
   "type": "module",
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/line/package.json
+++ b/extensions/line/package.json
@@ -3,8 +3,8 @@
   "version": "2026.1.30",
   "description": "OpenClaw LINE channel plugin",
   "type": "module",
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/llm-task/package.json
+++ b/extensions/llm-task/package.json
@@ -3,8 +3,8 @@
   "version": "2026.1.30",
   "description": "OpenClaw JSON-only LLM task plugin",
   "type": "module",
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/lobster/package.json
+++ b/extensions/lobster/package.json
@@ -3,8 +3,8 @@
   "version": "2026.1.30",
   "description": "Lobster workflow tool plugin (typed pipelines + resumable approvals)",
   "type": "module",
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/matrix/package.json
+++ b/extensions/matrix/package.json
@@ -10,8 +10,8 @@
     "music-metadata": "^11.11.1",
     "zod": "^4.3.6"
   },
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/mattermost/package.json
+++ b/extensions/mattermost/package.json
@@ -3,8 +3,8 @@
   "version": "2026.1.30",
   "description": "OpenClaw Mattermost channel plugin",
   "type": "module",
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/memory-core/package.json
+++ b/extensions/memory-core/package.json
@@ -4,9 +4,6 @@
   "description": "OpenClaw core memory search plugin",
   "type": "module",
   "peerDependencies": {
-    "openclaw": ">=2026.0.0"
-  },
-  "peerDependencies": {
     "openclaw": ">=2026.1.26"
   },
   "openclaw": {

--- a/extensions/memory-core/package.json
+++ b/extensions/memory-core/package.json
@@ -3,8 +3,8 @@
   "version": "2026.1.30",
   "description": "OpenClaw core memory search plugin",
   "type": "module",
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "peerDependencies": {
     "openclaw": ">=2026.1.26"

--- a/extensions/memory-lancedb/package.json
+++ b/extensions/memory-lancedb/package.json
@@ -8,8 +8,8 @@
     "@sinclair/typebox": "0.34.48",
     "openai": "^6.17.0"
   },
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/minimax-portal-auth/package.json
+++ b/extensions/minimax-portal-auth/package.json
@@ -3,8 +3,8 @@
   "version": "2026.1.30",
   "description": "OpenClaw MiniMax Portal OAuth provider plugin",
   "type": "module",
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/msteams/package.json
+++ b/extensions/msteams/package.json
@@ -8,7 +8,6 @@
     "@microsoft/agents-hosting-express": "^1.2.3",
     "@microsoft/agents-hosting-extensions-teams": "^1.2.3",
     "express": "^5.2.1",
-    "openclaw": ">=2026.0.0",
     "proper-lockfile": "^4.1.2"
   },
   "peerDependencies": {

--- a/extensions/msteams/package.json
+++ b/extensions/msteams/package.json
@@ -8,11 +8,11 @@
     "@microsoft/agents-hosting-express": "^1.2.3",
     "@microsoft/agents-hosting-extensions-teams": "^1.2.3",
     "express": "^5.2.1",
-    "openclaw": "workspace:*",
+    "openclaw": ">=2026.0.0",
     "proper-lockfile": "^4.1.2"
   },
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/nextcloud-talk/package.json
+++ b/extensions/nextcloud-talk/package.json
@@ -3,8 +3,8 @@
   "version": "2026.1.30",
   "description": "OpenClaw Nextcloud Talk channel plugin",
   "type": "module",
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/nostr/package.json
+++ b/extensions/nostr/package.json
@@ -5,11 +5,11 @@
   "type": "module",
   "dependencies": {
     "nostr-tools": "^2.22.1",
-    "openclaw": "workspace:*",
+    "openclaw": ">=2026.0.0",
     "zod": "^4.3.6"
   },
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/nostr/package.json
+++ b/extensions/nostr/package.json
@@ -5,7 +5,6 @@
   "type": "module",
   "dependencies": {
     "nostr-tools": "^2.22.1",
-    "openclaw": ">=2026.0.0",
     "zod": "^4.3.6"
   },
   "peerDependencies": {

--- a/extensions/open-prose/package.json
+++ b/extensions/open-prose/package.json
@@ -3,8 +3,8 @@
   "version": "2026.1.30",
   "description": "OpenProse VM skill pack plugin (slash command + telemetry).",
   "type": "module",
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/signal/package.json
+++ b/extensions/signal/package.json
@@ -3,8 +3,8 @@
   "version": "2026.1.30",
   "description": "OpenClaw Signal channel plugin",
   "type": "module",
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/slack/package.json
+++ b/extensions/slack/package.json
@@ -3,8 +3,8 @@
   "version": "2026.1.30",
   "description": "OpenClaw Slack channel plugin",
   "type": "module",
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/telegram/package.json
+++ b/extensions/telegram/package.json
@@ -3,8 +3,8 @@
   "version": "2026.1.30",
   "description": "OpenClaw Telegram channel plugin",
   "type": "module",
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/tlon/package.json
+++ b/extensions/tlon/package.json
@@ -7,8 +7,8 @@
     "@urbit/aura": "^3.0.0",
     "@urbit/http-api": "^3.0.0"
   },
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/twitch/package.json
+++ b/extensions/twitch/package.json
@@ -9,8 +9,8 @@
     "@twurple/chat": "^8.0.3",
     "zod": "^4.3.6"
   },
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/voice-call/package.json
+++ b/extensions/voice-call/package.json
@@ -8,8 +8,8 @@
     "ws": "^8.19.0",
     "zod": "^4.3.6"
   },
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/whatsapp/package.json
+++ b/extensions/whatsapp/package.json
@@ -3,8 +3,8 @@
   "version": "2026.1.30",
   "description": "OpenClaw WhatsApp channel plugin",
   "type": "module",
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/zalo/package.json
+++ b/extensions/zalo/package.json
@@ -4,11 +4,11 @@
   "description": "OpenClaw Zalo channel plugin",
   "type": "module",
   "dependencies": {
-    "openclaw": "workspace:*",
+    "openclaw": ">=2026.0.0",
     "undici": "7.19.2"
   },
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/zalo/package.json
+++ b/extensions/zalo/package.json
@@ -4,7 +4,6 @@
   "description": "OpenClaw Zalo channel plugin",
   "type": "module",
   "dependencies": {
-    "openclaw": ">=2026.0.0",
     "undici": "7.19.2"
   },
   "peerDependencies": {

--- a/extensions/zalouser/package.json
+++ b/extensions/zalouser/package.json
@@ -5,10 +5,10 @@
   "type": "module",
   "dependencies": {
     "@sinclair/typebox": "0.34.48",
-    "openclaw": "workspace:*"
+    "openclaw": ">=2026.0.0"
   },
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/zalouser/package.json
+++ b/extensions/zalouser/package.json
@@ -4,8 +4,7 @@
   "description": "OpenClaw Zalo Personal Account plugin via zca-cli",
   "type": "module",
   "dependencies": {
-    "@sinclair/typebox": "0.34.48",
-    "openclaw": ">=2026.0.0"
+    "@sinclair/typebox": "0.34.48"
   },
   "peerDependencies": {
     "openclaw": ">=2026.0.0"


### PR DESCRIPTION
## Summary

Fixes extension installation failures caused by `workspace:*` in devDependencies by moving `openclaw` to `peerDependencies` only.

## Changes

### All 29 extensions
- Replaced `workspace:*` with `>=2026.0.0` version constraint
- Moved `openclaw` from devDependencies to peerDependencies

### Additional fixes
- **nostr, zalo**: Removed `openclaw` from runtime dependencies (keep only in peerDependencies)
- **googlechat, memory-core**: Merged duplicate `peerDependencies` keys
- **msteams**: Removed `openclaw` from dependencies (keep only in peerDependencies)

## Why

When npm publishes to registry, `workspace:*` isn't resolved, causing `npm install --omit=dev` to abort before installing production dependencies.

Extensions should declare `openclaw` as a peer dependency so the host installation provides it, not try to install it themselves.

## Testing

- ✅ All extensions now install correctly with `openclaw channels add`
- ✅ No duplicate JSON keys
- ✅ `openclaw` only in `peerDependencies` (host-provided)

Fixes #14042

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates extension `package.json` files to avoid publishing `workspace:*` version specifiers by switching `openclaw` to a registry-compatible constraint and (mostly) moving it to `peerDependencies` so the host provides it.

It also removes `openclaw` from runtime `dependencies` for some extensions and eliminates duplicate `peerDependencies` keys in a couple of manifests, aligning extension install behavior with `openclaw channels add` / `npm install --omit=dev` flows.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but one extension still pulls in openclaw as a runtime dependency.
- The changes are limited to package manifests and consistently replace `workspace:*` with semver constraints while moving `openclaw` to `peerDependencies`. However, `extensions/zalouser/package.json` still lists `openclaw` under `dependencies`, which undermines the stated fix and can reintroduce installation/runtime coupling issues for that extension.
- extensions/zalouser/package.json

<sub>Last reviewed commit: b718afc</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->