### PR TITLE
feat(gateway): add auth rate-limiting & brute-force protection

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1893,6 +1893,12 @@ See [Plugins](/tools/plugin).
       token: "your-token",
       // password: "your-password", // or OPENCLAW_GATEWAY_PASSWORD
       allowTailscale: true,
+      rateLimit: {
+        maxAttempts: 10,
+        windowMs: 60000,
+        lockoutMs: 300000,
+        exemptLoopback: true,
+      },
     },
     tailscale: {
       mode: "off", // off | serve | funnel
@@ -1923,6 +1929,8 @@ See [Plugins](/tools/plugin).
 - `bind`: `auto`, `loopback` (default), `lan` (`0.0.0.0`), `tailnet` (Tailscale IP only), or `custom`.
 - **Auth**: required by default. Non-loopback binds require a shared token/password. Onboarding wizard generates a token by default.
 - `auth.allowTailscale`: when `true`, Tailscale Serve identity headers satisfy auth (verified via `tailscale whois`). Defaults to `true` when `tailscale.mode = "serve"`.
+- `auth.rateLimit`: optional failed-auth limiter. Applies per client IP and per auth scope (shared-secret and device-token are tracked independently). Blocked attempts return `429` + `Retry-After`.
+  - `auth.rateLimit.exemptLoopback` defaults to `true`; set `false` when you intentionally want localhost traffic rate-limited too (for test setups or strict proxy deployments).
 - `tailscale.mode`: `serve` (tailnet only, loopback bind) or `funnel` (public, requires auth).
 - `remote.transport`: `ssh` (default) or `direct` (ws/wss). For `direct`, `remote.url` must be `ws://` or `wss://`.
 - `gateway.remote.token` is for remote CLI calls only; does not enable local gateway auth.

--- a/docs/gateway/openai-http-api.md
+++ b/docs/gateway/openai-http-api.md
@@ -26,6 +26,7 @@ Notes:
 
 - When `gateway.auth.mode="token"`, use `gateway.auth.token` (or `OPENCLAW_GATEWAY_TOKEN`).
 - When `gateway.auth.mode="password"`, use `gateway.auth.password` (or `OPENCLAW_GATEWAY_PASSWORD`).
+- If `gateway.auth.rateLimit` is configured and too many auth failures occur, the endpoint returns `429` with `Retry-After`.
 
 ## Choosing an agent
 

--- a/docs/gateway/openresponses-http-api.md
+++ b/docs/gateway/openresponses-http-api.md
@@ -28,6 +28,7 @@ Notes:
 
 - When `gateway.auth.mode="token"`, use `gateway.auth.token` (or `OPENCLAW_GATEWAY_TOKEN`).
 - When `gateway.auth.mode="password"`, use `gateway.auth.password` (or `OPENCLAW_GATEWAY_PASSWORD`).
+- If `gateway.auth.rateLimit` is configured and too many auth failures occur, the endpoint returns `429` with `Retry-After`.
 
 ## Choosing an agent
 

--- a/docs/gateway/tools-invoke-http-api.md
+++ b/docs/gateway/tools-invoke-http-api.md
@@ -25,6 +25,7 @@ Notes:
 
 - When `gateway.auth.mode="token"`, use `gateway.auth.token` (or `OPENCLAW_GATEWAY_TOKEN`).
 - When `gateway.auth.mode="password"`, use `gateway.auth.password` (or `OPENCLAW_GATEWAY_PASSWORD`).
+- If `gateway.auth.rateLimit` is configured and too many auth failures occur, the endpoint returns `429` with `Retry-After`.
 
 ## Request body
 
@@ -68,6 +69,7 @@ To help group policies resolve context, you can optionally set:
 - `200` → `{ ok: true, result }`
 - `400` → `{ ok: false, error: { type, message } }` (invalid request or tool error)
 - `401` → unauthorized
+- `429` → auth rate-limited (`Retry-After` set)
 - `404` → tool not available (not found or not allowlisted)
 - `405` → method not allowed
 

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -98,6 +98,8 @@ export type GatewayAuthRateLimitConfig = {
   windowMs?: number;
   /** Lockout duration in milliseconds after the limit is exceeded.  @default 300000 (5 min) */
   lockoutMs?: number;
+  /** Exempt localhost/loopback addresses from auth rate limiting.  @default true */
+  exemptLoopback?: boolean;
 };
 
 export type GatewayTailscaleMode = "off" | "serve" | "funnel";

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -87,6 +87,17 @@ export type GatewayAuthConfig = {
   password?: string;
   /** Allow Tailscale identity headers when serve mode is enabled. */
   allowTailscale?: boolean;
+  /** Rate-limit configuration for failed authentication attempts. */
+  rateLimit?: GatewayAuthRateLimitConfig;
+};
+
+export type GatewayAuthRateLimitConfig = {
+  /** Maximum failed attempts per IP before blocking.  @default 10 */
+  maxAttempts?: number;
+  /** Sliding window duration in milliseconds.  @default 60000 (1 min) */
+  windowMs?: number;
+  /** Lockout duration in milliseconds after the limit is exceeded.  @default 300000 (5 min) */
+  lockoutMs?: number;
 };
 
 export type GatewayTailscaleMode = "off" | "serve" | "funnel";

--- a/src/gateway/auth-rate-limit.test.ts
+++ b/src/gateway/auth-rate-limit.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createAuthRateLimiter, type AuthRateLimiter } from "./auth-rate-limit.js";
+
+describe("auth rate limiter", () => {
+  let limiter: AuthRateLimiter;
+
+  afterEach(() => {
+    limiter?.dispose();
+  });
+
+  // ---------- basic sliding window ----------
+
+  it("allows requests when no failures have been recorded", () => {
+    limiter = createAuthRateLimiter({ maxAttempts: 5, windowMs: 60_000, lockoutMs: 300_000 });
+    const result = limiter.check("192.168.1.1");
+    expect(result.allowed).toBe(true);
+    expect(result.remaining).toBe(5);
+    expect(result.retryAfterMs).toBe(0);
+  });
+
+  it("decrements remaining count after each failure", () => {
+    limiter = createAuthRateLimiter({ maxAttempts: 3, windowMs: 60_000, lockoutMs: 300_000 });
+    limiter.recordFailure("10.0.0.1");
+    expect(limiter.check("10.0.0.1").remaining).toBe(2);
+    limiter.recordFailure("10.0.0.1");
+    expect(limiter.check("10.0.0.1").remaining).toBe(1);
+  });
+
+  it("blocks the IP once maxAttempts is reached", () => {
+    limiter = createAuthRateLimiter({ maxAttempts: 2, windowMs: 60_000, lockoutMs: 10_000 });
+    limiter.recordFailure("10.0.0.2");
+    limiter.recordFailure("10.0.0.2");
+    const result = limiter.check("10.0.0.2");
+    expect(result.allowed).toBe(false);
+    expect(result.remaining).toBe(0);
+    expect(result.retryAfterMs).toBeGreaterThan(0);
+    expect(result.retryAfterMs).toBeLessThanOrEqual(10_000);
+  });
+
+  // ---------- lockout expiry ----------
+
+  it("unblocks after the lockout period expires", () => {
+    vi.useFakeTimers();
+    try {
+      limiter = createAuthRateLimiter({ maxAttempts: 2, windowMs: 60_000, lockoutMs: 5_000 });
+      limiter.recordFailure("10.0.0.3");
+      limiter.recordFailure("10.0.0.3");
+      expect(limiter.check("10.0.0.3").allowed).toBe(false);
+
+      // Advance just past the lockout.
+      vi.advanceTimersByTime(5_001);
+      const result = limiter.check("10.0.0.3");
+      expect(result.allowed).toBe(true);
+      expect(result.remaining).toBe(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // ---------- sliding window expiry ----------
+
+  it("expires old failures outside the window", () => {
+    vi.useFakeTimers();
+    try {
+      limiter = createAuthRateLimiter({ maxAttempts: 3, windowMs: 10_000, lockoutMs: 60_000 });
+      limiter.recordFailure("10.0.0.4");
+      limiter.recordFailure("10.0.0.4");
+      expect(limiter.check("10.0.0.4").remaining).toBe(1);
+
+      // Move past the window so the two old failures expire.
+      vi.advanceTimersByTime(11_000);
+      expect(limiter.check("10.0.0.4").remaining).toBe(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // ---------- per-IP isolation ----------
+
+  it("tracks IPs independently", () => {
+    limiter = createAuthRateLimiter({ maxAttempts: 2, windowMs: 60_000, lockoutMs: 60_000 });
+    limiter.recordFailure("10.0.0.10");
+    limiter.recordFailure("10.0.0.10");
+    expect(limiter.check("10.0.0.10").allowed).toBe(false);
+
+    // A different IP should be unaffected.
+    expect(limiter.check("10.0.0.11").allowed).toBe(true);
+    expect(limiter.check("10.0.0.11").remaining).toBe(2);
+  });
+
+  // ---------- loopback exemption ----------
+
+  it("exempts loopback addresses by default", () => {
+    limiter = createAuthRateLimiter({ maxAttempts: 1, windowMs: 60_000, lockoutMs: 60_000 });
+    limiter.recordFailure("127.0.0.1");
+    // Should still be allowed even though maxAttempts is 1.
+    expect(limiter.check("127.0.0.1").allowed).toBe(true);
+  });
+
+  it("exempts IPv6 loopback by default", () => {
+    limiter = createAuthRateLimiter({ maxAttempts: 1, windowMs: 60_000, lockoutMs: 60_000 });
+    limiter.recordFailure("::1");
+    expect(limiter.check("::1").allowed).toBe(true);
+  });
+
+  it("rate-limits loopback when exemptLoopback is false", () => {
+    limiter = createAuthRateLimiter({
+      maxAttempts: 1,
+      windowMs: 60_000,
+      lockoutMs: 60_000,
+      exemptLoopback: false,
+    });
+    limiter.recordFailure("127.0.0.1");
+    expect(limiter.check("127.0.0.1").allowed).toBe(false);
+  });
+
+  // ---------- reset ----------
+
+  it("clears tracking state when reset is called", () => {
+    limiter = createAuthRateLimiter({ maxAttempts: 2, windowMs: 60_000, lockoutMs: 60_000 });
+    limiter.recordFailure("10.0.0.20");
+    limiter.recordFailure("10.0.0.20");
+    expect(limiter.check("10.0.0.20").allowed).toBe(false);
+
+    limiter.reset("10.0.0.20");
+    expect(limiter.check("10.0.0.20").allowed).toBe(true);
+    expect(limiter.check("10.0.0.20").remaining).toBe(2);
+  });
+
+  // ---------- prune ----------
+
+  it("prune removes stale entries", () => {
+    vi.useFakeTimers();
+    try {
+      limiter = createAuthRateLimiter({ maxAttempts: 5, windowMs: 5_000, lockoutMs: 5_000 });
+      limiter.recordFailure("10.0.0.30");
+      expect(limiter.size()).toBe(1);
+
+      vi.advanceTimersByTime(6_000);
+      limiter.prune();
+      expect(limiter.size()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("prune keeps entries that are still locked out", () => {
+    vi.useFakeTimers();
+    try {
+      limiter = createAuthRateLimiter({ maxAttempts: 1, windowMs: 5_000, lockoutMs: 30_000 });
+      limiter.recordFailure("10.0.0.31");
+      expect(limiter.check("10.0.0.31").allowed).toBe(false);
+
+      // Move past the window but NOT past the lockout.
+      vi.advanceTimersByTime(6_000);
+      limiter.prune();
+      expect(limiter.size()).toBe(1); // Still locked-out, not pruned.
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // ---------- undefined / empty IP ----------
+
+  it("normalizes undefined IP to 'unknown'", () => {
+    limiter = createAuthRateLimiter({ maxAttempts: 2, windowMs: 60_000, lockoutMs: 60_000 });
+    limiter.recordFailure(undefined);
+    limiter.recordFailure(undefined);
+    expect(limiter.check(undefined).allowed).toBe(false);
+    expect(limiter.size()).toBe(1);
+  });
+
+  it("normalizes empty-string IP to 'unknown'", () => {
+    limiter = createAuthRateLimiter({ maxAttempts: 2, windowMs: 60_000, lockoutMs: 60_000 });
+    limiter.recordFailure("");
+    limiter.recordFailure("");
+    expect(limiter.check("").allowed).toBe(false);
+  });
+
+  // ---------- dispose ----------
+
+  it("dispose clears all entries", () => {
+    limiter = createAuthRateLimiter();
+    limiter.recordFailure("10.0.0.40");
+    expect(limiter.size()).toBe(1);
+    limiter.dispose();
+    expect(limiter.size()).toBe(0);
+  });
+});

--- a/src/gateway/auth-rate-limit.ts
+++ b/src/gateway/auth-rate-limit.ts
@@ -1,0 +1,197 @@
+/**
+ * In-memory sliding-window rate limiter for gateway authentication attempts.
+ *
+ * Tracks failed auth attempts per client IP and blocks further attempts once
+ * the configured threshold is exceeded within a sliding time window.  An
+ * optional lockout period forces the client to wait before retrying.
+ *
+ * Design decisions:
+ * - Pure in-memory Map – no external dependencies; suitable for a single
+ *   gateway process.  The Map is periodically pruned to avoid unbounded
+ *   growth.
+ * - Loopback addresses (127.0.0.1 / ::1) are exempt by default so that local
+ *   CLI sessions are never locked out.
+ * - The module is side-effect-free: callers create an instance via
+ *   {@link createAuthRateLimiter} and pass it where needed.
+ */
+
+import { isLoopbackAddress } from "./net.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface RateLimitConfig {
+  /** Maximum failed attempts before blocking.  @default 10 */
+  maxAttempts?: number;
+  /** Sliding window duration in milliseconds.     @default 60_000 (1 min) */
+  windowMs?: number;
+  /** Lockout duration in milliseconds after the limit is exceeded.  @default 300_000 (5 min) */
+  lockoutMs?: number;
+  /** Exempt loopback (localhost) addresses from rate limiting.  @default true */
+  exemptLoopback?: boolean;
+}
+
+export interface RateLimitEntry {
+  /** Timestamps (epoch ms) of recent failed attempts inside the window. */
+  attempts: number[];
+  /** If set, requests from this IP are blocked until this epoch-ms instant. */
+  lockedUntil?: number;
+}
+
+export interface RateLimitCheckResult {
+  /** Whether the request is allowed to proceed. */
+  allowed: boolean;
+  /** Number of remaining attempts before the limit is reached. */
+  remaining: number;
+  /** Milliseconds until the lockout expires (0 when not locked). */
+  retryAfterMs: number;
+}
+
+export interface AuthRateLimiter {
+  /** Check whether `ip` is currently allowed to attempt authentication. */
+  check(ip: string | undefined): RateLimitCheckResult;
+  /** Record a failed authentication attempt for `ip`. */
+  recordFailure(ip: string | undefined): void;
+  /** Reset the rate-limit state for `ip` (e.g. after a successful login). */
+  reset(ip: string | undefined): void;
+  /** Return the current number of tracked IPs (useful for diagnostics). */
+  size(): number;
+  /** Remove expired entries and release memory. */
+  prune(): void;
+  /** Dispose the limiter and cancel periodic cleanup timers. */
+  dispose(): void;
+}
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+
+const DEFAULT_MAX_ATTEMPTS = 10;
+const DEFAULT_WINDOW_MS = 60_000; // 1 minute
+const DEFAULT_LOCKOUT_MS = 300_000; // 5 minutes
+const PRUNE_INTERVAL_MS = 60_000; // prune stale entries every minute
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+export function createAuthRateLimiter(config?: RateLimitConfig): AuthRateLimiter {
+  const maxAttempts = config?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+  const windowMs = config?.windowMs ?? DEFAULT_WINDOW_MS;
+  const lockoutMs = config?.lockoutMs ?? DEFAULT_LOCKOUT_MS;
+  const exemptLoopback = config?.exemptLoopback ?? true;
+
+  const entries = new Map<string, RateLimitEntry>();
+
+  // Periodic cleanup to avoid unbounded map growth.
+  const pruneTimer = setInterval(() => prune(), PRUNE_INTERVAL_MS);
+  // Allow the Node.js process to exit even if the timer is still active.
+  if (pruneTimer.unref) {
+    pruneTimer.unref();
+  }
+
+  function normalizeIp(ip: string | undefined): string {
+    return (ip ?? "").trim() || "unknown";
+  }
+
+  function isExempt(ip: string): boolean {
+    return exemptLoopback && isLoopbackAddress(ip);
+  }
+
+  function slideWindow(entry: RateLimitEntry, now: number): void {
+    const cutoff = now - windowMs;
+    // Remove attempts that fell outside the window.
+    entry.attempts = entry.attempts.filter((ts) => ts > cutoff);
+  }
+
+  function check(rawIp: string | undefined): RateLimitCheckResult {
+    const ip = normalizeIp(rawIp);
+    if (isExempt(ip)) {
+      return { allowed: true, remaining: maxAttempts, retryAfterMs: 0 };
+    }
+
+    const now = Date.now();
+    const entry = entries.get(ip);
+
+    if (!entry) {
+      return { allowed: true, remaining: maxAttempts, retryAfterMs: 0 };
+    }
+
+    // Still locked out?
+    if (entry.lockedUntil && now < entry.lockedUntil) {
+      return {
+        allowed: false,
+        remaining: 0,
+        retryAfterMs: entry.lockedUntil - now,
+      };
+    }
+
+    // Lockout expired – clear it.
+    if (entry.lockedUntil && now >= entry.lockedUntil) {
+      entry.lockedUntil = undefined;
+      entry.attempts = [];
+    }
+
+    slideWindow(entry, now);
+    const remaining = Math.max(0, maxAttempts - entry.attempts.length);
+    return { allowed: remaining > 0, remaining, retryAfterMs: 0 };
+  }
+
+  function recordFailure(rawIp: string | undefined): void {
+    const ip = normalizeIp(rawIp);
+    if (isExempt(ip)) {
+      return;
+    }
+
+    const now = Date.now();
+    let entry = entries.get(ip);
+
+    if (!entry) {
+      entry = { attempts: [] };
+      entries.set(ip, entry);
+    }
+
+    // If currently locked, do nothing (already blocked).
+    if (entry.lockedUntil && now < entry.lockedUntil) {
+      return;
+    }
+
+    slideWindow(entry, now);
+    entry.attempts.push(now);
+
+    if (entry.attempts.length >= maxAttempts) {
+      entry.lockedUntil = now + lockoutMs;
+    }
+  }
+
+  function reset(rawIp: string | undefined): void {
+    const ip = normalizeIp(rawIp);
+    entries.delete(ip);
+  }
+
+  function prune(): void {
+    const now = Date.now();
+    for (const [ip, entry] of entries) {
+      // If locked out, keep the entry until the lockout expires.
+      if (entry.lockedUntil && now < entry.lockedUntil) {
+        continue;
+      }
+      slideWindow(entry, now);
+      if (entry.attempts.length === 0) {
+        entries.delete(ip);
+      }
+    }
+  }
+
+  function size(): number {
+    return entries.size;
+  }
+
+  function dispose(): void {
+    clearInterval(pruneTimer);
+    entries.clear();
+  }
+
+  return { check, recordFailure, reset, size, prune, dispose };
+}

--- a/src/gateway/http-common.ts
+++ b/src/gateway/http-common.ts
@@ -24,6 +24,18 @@ export function sendUnauthorized(res: ServerResponse) {
   });
 }
 
+export function sendRateLimited(res: ServerResponse, retryAfterMs?: number) {
+  if (retryAfterMs && retryAfterMs > 0) {
+    res.setHeader("Retry-After", String(Math.ceil(retryAfterMs / 1000)));
+  }
+  sendJson(res, 429, {
+    error: {
+      message: "Too many failed authentication attempts. Please try again later.",
+      type: "rate_limited",
+    },
+  });
+}
+
 export function sendInvalidRequest(res: ServerResponse, message: string) {
   sendJson(res, 400, {
     error: { message, type: "invalid_request_error" },

--- a/src/gateway/http-common.ts
+++ b/src/gateway/http-common.ts
@@ -1,4 +1,5 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
+import type { GatewayAuthResult } from "./auth.js";
 import { readJsonBody } from "./hooks.js";
 
 export function sendJson(res: ServerResponse, status: number, body: unknown) {
@@ -34,6 +35,14 @@ export function sendRateLimited(res: ServerResponse, retryAfterMs?: number) {
       type: "rate_limited",
     },
   });
+}
+
+export function sendGatewayAuthFailure(res: ServerResponse, authResult: GatewayAuthResult) {
+  if (authResult.rateLimited) {
+    sendRateLimited(res, authResult.retryAfterMs);
+    return;
+  }
+  sendUnauthorized(res);
 }
 
 export function sendInvalidRequest(res: ServerResponse, message: string) {

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -9,10 +9,9 @@ import { defaultRuntime } from "../runtime.js";
 import { authorizeGatewayConnect, type ResolvedGatewayAuth } from "./auth.js";
 import {
   readJsonBodyOrError,
+  sendGatewayAuthFailure,
   sendJson,
   sendMethodNotAllowed,
-  sendRateLimited,
-  sendUnauthorized,
   setSseHeaders,
   writeDone,
 } from "./http-common.js";
@@ -195,11 +194,7 @@ export async function handleOpenAiHttpRequest(
     rateLimiter: opts.rateLimiter,
   });
   if (!authResult.ok) {
-    if (authResult.rateLimited) {
-      sendRateLimited(res, authResult.retryAfterMs);
-    } else {
-      sendUnauthorized(res);
-    }
+    sendGatewayAuthFailure(res, authResult);
     return true;
   }
 

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -38,10 +38,9 @@ import { defaultRuntime } from "../runtime.js";
 import { authorizeGatewayConnect, type ResolvedGatewayAuth } from "./auth.js";
 import {
   readJsonBodyOrError,
+  sendGatewayAuthFailure,
   sendJson,
   sendMethodNotAllowed,
-  sendRateLimited,
-  sendUnauthorized,
   setSseHeaders,
   writeDone,
 } from "./http-common.js";
@@ -370,11 +369,7 @@ export async function handleOpenResponsesHttpRequest(
     rateLimiter: opts.rateLimiter,
   });
   if (!authResult.ok) {
-    if (authResult.rateLimited) {
-      sendRateLimited(res, authResult.retryAfterMs);
-    } else {
-      sendUnauthorized(res);
-    }
+    sendGatewayAuthFailure(res, authResult);
     return true;
   }
 

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -4,6 +4,7 @@ import type { CliDeps } from "../cli/deps.js";
 import type { createSubsystemLogger } from "../logging/subsystem.js";
 import type { PluginRegistry } from "../plugins/registry.js";
 import type { RuntimeEnv } from "../runtime.js";
+import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
 import type { ChatAbortControllerEntry } from "./chat-abort.js";
 import type { ControlUiRootState } from "./control-ui.js";
@@ -37,6 +38,8 @@ export async function createGatewayRuntimeState(params: {
   openResponsesEnabled: boolean;
   openResponsesConfig?: import("../config/types.gateway.js").GatewayHttpResponsesConfig;
   resolvedAuth: ResolvedGatewayAuth;
+  /** Optional rate limiter for auth brute-force protection. */
+  rateLimiter?: AuthRateLimiter;
   gatewayTls?: GatewayTlsRuntime;
   hooksConfig: () => HooksConfigResolved | null;
   pluginRegistry: PluginRegistry;
@@ -139,6 +142,7 @@ export async function createGatewayRuntimeState(params: {
       handleHooksRequest,
       handlePluginRequest,
       resolvedAuth: params.resolvedAuth,
+      rateLimiter: params.rateLimiter,
       tlsOptions: params.gatewayTls?.enabled ? params.gatewayTls.tlsOptions : undefined,
     });
     try {
@@ -174,6 +178,7 @@ export async function createGatewayRuntimeState(params: {
       canvasHost,
       clients,
       resolvedAuth: params.resolvedAuth,
+      rateLimiter: params.rateLimiter,
     });
   }
 

--- a/src/gateway/server-ws-runtime.ts
+++ b/src/gateway/server-ws-runtime.ts
@@ -1,5 +1,6 @@
 import type { WebSocketServer } from "ws";
 import type { createSubsystemLogger } from "../logging/subsystem.js";
+import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
 import type { GatewayRequestContext, GatewayRequestHandlers } from "./server-methods/types.js";
 import type { GatewayWsClient } from "./server/ws-types.js";
@@ -13,6 +14,8 @@ export function attachGatewayWsHandlers(params: {
   canvasHostEnabled: boolean;
   canvasHostServerPort?: number;
   resolvedAuth: ResolvedGatewayAuth;
+  /** Optional rate limiter for auth brute-force protection. */
+  rateLimiter?: AuthRateLimiter;
   gatewayMethods: string[];
   events: string[];
   logGateway: ReturnType<typeof createSubsystemLogger>;
@@ -37,6 +40,7 @@ export function attachGatewayWsHandlers(params: {
     canvasHostEnabled: params.canvasHostEnabled,
     canvasHostServerPort: params.canvasHostServerPort,
     resolvedAuth: params.resolvedAuth,
+    rateLimiter: params.rateLimiter,
     gatewayMethods: params.gatewayMethods,
     events: params.events,
     logGateway: params.logGateway,

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -1,6 +1,7 @@
 import type { WebSocket, WebSocketServer } from "ws";
 import { randomUUID } from "node:crypto";
 import type { createSubsystemLogger } from "../../logging/subsystem.js";
+import type { AuthRateLimiter } from "../auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "../auth.js";
 import type { GatewayRequestContext, GatewayRequestHandlers } from "../server-methods/types.js";
 import type { GatewayWsClient } from "./ws-types.js";
@@ -24,6 +25,8 @@ export function attachGatewayWsConnectionHandler(params: {
   canvasHostEnabled: boolean;
   canvasHostServerPort?: number;
   resolvedAuth: ResolvedGatewayAuth;
+  /** Optional rate limiter for auth brute-force protection. */
+  rateLimiter?: AuthRateLimiter;
   gatewayMethods: string[];
   events: string[];
   logGateway: SubsystemLogger;
@@ -48,6 +51,7 @@ export function attachGatewayWsConnectionHandler(params: {
     canvasHostEnabled,
     canvasHostServerPort,
     resolvedAuth,
+    rateLimiter,
     gatewayMethods,
     events,
     logGateway,
@@ -240,6 +244,7 @@ export function attachGatewayWsConnectionHandler(params: {
       canvasHostUrl,
       connectNonce,
       resolvedAuth,
+      rateLimiter,
       gatewayMethods,
       events,
       extraHandlers,

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -2,8 +2,7 @@ import type { IncomingMessage } from "node:http";
 import type { WebSocket } from "ws";
 import os from "node:os";
 import type { createSubsystemLogger } from "../../../logging/subsystem.js";
-import type { AuthRateLimiter } from "../../auth-rate-limit.js";
-import type { ResolvedGatewayAuth } from "../../auth.js";
+import type { GatewayAuthResult, ResolvedGatewayAuth } from "../../auth.js";
 import type { GatewayRequestContext, GatewayRequestHandlers } from "../../server-methods/types.js";
 import type { GatewayWsClient } from "../ws-types.js";
 import { loadConfig } from "../../../config/config.js";
@@ -26,6 +25,11 @@ import { upsertPresence } from "../../../infra/system-presence.js";
 import { loadVoiceWakeConfig } from "../../../infra/voicewake.js";
 import { rawDataToString } from "../../../infra/ws.js";
 import { isGatewayCliClient, isWebchatClient } from "../../../utils/message-channel.js";
+import {
+  AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN,
+  AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET,
+  type AuthRateLimiter,
+} from "../../auth-rate-limit.js";
 import { authorizeGatewayConnect, isLocalDirectRequest } from "../../auth.js";
 import { buildDeviceAuthPayload } from "../../device-auth.js";
 import { isLoopbackAddress, isTrustedProxyAddress, resolveGatewayClientIp } from "../../net.js";
@@ -118,6 +122,10 @@ function formatGatewayAuthFailureMessage(params: {
       return "unauthorized: tailscale identity check failed (use Tailscale Serve auth or gateway token/password)";
     case "tailscale_user_mismatch":
       return "unauthorized: tailscale identity mismatch (use Tailscale Serve auth or gateway token/password)";
+    case "rate_limited":
+      return "unauthorized: too many failed authentication attempts (retry later)";
+    case "device_token_mismatch":
+      return "unauthorized: device token mismatch (rotate/reissue device token)";
     default:
       break;
   }
@@ -409,14 +417,36 @@ export function attachGatewayWsMessageHandler(params: {
         const allowControlUiBypass = allowInsecureControlUi || disableControlUiDeviceAuth;
         const device = disableControlUiDeviceAuth ? null : deviceRaw;
 
-        const authResult = await authorizeGatewayConnect({
+        const hasDeviceTokenCandidate = Boolean(connectParams.auth?.token && device);
+        let authResult: GatewayAuthResult = await authorizeGatewayConnect({
           auth: resolvedAuth,
           connectAuth: connectParams.auth,
           req: upgradeReq,
           trustedProxies,
-          rateLimiter,
+          rateLimiter: hasDeviceTokenCandidate ? undefined : rateLimiter,
           clientIp,
+          rateLimitScope: AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET,
         });
+
+        if (
+          hasDeviceTokenCandidate &&
+          authResult.ok &&
+          rateLimiter &&
+          (authResult.method === "token" || authResult.method === "password")
+        ) {
+          const sharedRateCheck = rateLimiter.check(clientIp, AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET);
+          if (!sharedRateCheck.allowed) {
+            authResult = {
+              ok: false,
+              reason: "rate_limited",
+              rateLimited: true,
+              retryAfterMs: sharedRateCheck.retryAfterMs,
+            };
+          } else {
+            rateLimiter.reset(clientIp, AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET);
+          }
+        }
+
         let authOk = authResult.ok;
         let authMethod =
           authResult.method ?? (resolvedAuth.mode === "password" ? "password" : "token");
@@ -426,18 +456,18 @@ export function attachGatewayWsMessageHandler(params: {
               connectAuth: connectParams.auth,
               req: upgradeReq,
               trustedProxies,
-              // Intentionally omit rateLimiter here — the primary authResult
-              // call above already tracked the attempt for this IP.  Passing
-              // the limiter again would double-count the same credentials.
+              // Shared-auth probe only; rate-limit side effects are handled in
+              // the primary auth flow (or deferred for device-token candidates).
+              rateLimitScope: AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET,
             })
           : null;
         const sharedAuthOk =
           sharedAuthResult?.ok === true &&
           (sharedAuthResult.method === "token" || sharedAuthResult.method === "password");
-        const rejectUnauthorized = () => {
+        const rejectUnauthorized = (failedAuth: GatewayAuthResult) => {
           setHandshakeState("failed");
           logWsControl.warn(
-            `unauthorized conn=${connId} remote=${remoteAddr ?? "?"} client=${clientLabel} ${connectParams.client.mode} v${connectParams.client.version} reason=${authResult.reason ?? "unknown"}`,
+            `unauthorized conn=${connId} remote=${remoteAddr ?? "?"} client=${clientLabel} ${connectParams.client.mode} v${connectParams.client.version} reason=${failedAuth.reason ?? "unknown"}`,
           );
           const authProvided: AuthProvidedKind = connectParams.auth?.token
             ? "token"
@@ -447,13 +477,13 @@ export function attachGatewayWsMessageHandler(params: {
           const authMessage = formatGatewayAuthFailureMessage({
             authMode: resolvedAuth.mode,
             authProvided,
-            reason: authResult.reason,
+            reason: failedAuth.reason,
             client: connectParams.client,
           });
           setCloseCause("unauthorized", {
             authMode: resolvedAuth.mode,
             authProvided,
-            authReason: authResult.reason,
+            authReason: failedAuth.reason,
             allowTailscale: resolvedAuth.allowTailscale,
             client: connectParams.client.id,
             clientDisplayName: connectParams.client.displayName,
@@ -493,7 +523,7 @@ export function attachGatewayWsMessageHandler(params: {
           // Allow shared-secret authenticated connections (e.g., control-ui) to skip device identity
           if (!canSkipDevice) {
             if (!authOk && hasSharedAuth) {
-              rejectUnauthorized();
+              rejectUnauthorized(authResult);
               return;
             }
             setHandshakeState("failed");
@@ -663,19 +693,36 @@ export function attachGatewayWsMessageHandler(params: {
         }
 
         if (!authOk && connectParams.auth?.token && device) {
-          const tokenCheck = await verifyDeviceToken({
-            deviceId: device.id,
-            token: connectParams.auth.token,
-            role,
-            scopes,
-          });
-          if (tokenCheck.ok) {
-            authOk = true;
-            authMethod = "device-token";
+          if (rateLimiter) {
+            const deviceRateCheck = rateLimiter.check(clientIp, AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN);
+            if (!deviceRateCheck.allowed) {
+              authResult = {
+                ok: false,
+                reason: "rate_limited",
+                rateLimited: true,
+                retryAfterMs: deviceRateCheck.retryAfterMs,
+              };
+            }
+          }
+          if (!authResult.rateLimited) {
+            const tokenCheck = await verifyDeviceToken({
+              deviceId: device.id,
+              token: connectParams.auth.token,
+              role,
+              scopes,
+            });
+            if (tokenCheck.ok) {
+              authOk = true;
+              authMethod = "device-token";
+              rateLimiter?.reset(clientIp, AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN);
+            } else {
+              authResult = { ok: false, reason: "device_token_mismatch" };
+              rateLimiter?.recordFailure(clientIp, AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN);
+            }
           }
         }
         if (!authOk) {
-          rejectUnauthorized();
+          rejectUnauthorized(authResult);
           return;
         }
 

--- a/src/gateway/tools-invoke-http.ts
+++ b/src/gateway/tools-invoke-http.ts
@@ -25,11 +25,10 @@ import { normalizeMessageChannel } from "../utils/message-channel.js";
 import { authorizeGatewayConnect, type ResolvedGatewayAuth } from "./auth.js";
 import {
   readJsonBodyOrError,
+  sendGatewayAuthFailure,
   sendInvalidRequest,
   sendJson,
   sendMethodNotAllowed,
-  sendRateLimited,
-  sendUnauthorized,
 } from "./http-common.js";
 import { getBearerToken, getHeader } from "./http-utils.js";
 
@@ -131,11 +130,7 @@ export async function handleToolsInvokeHttpRequest(
     rateLimiter: opts.rateLimiter,
   });
   if (!authResult.ok) {
-    if (authResult.rateLimited) {
-      sendRateLimited(res, authResult.retryAfterMs);
-    } else {
-      sendUnauthorized(res);
-    }
+    sendGatewayAuthFailure(res, authResult);
     return true;
   }
 

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -383,6 +383,19 @@ function collectGatewayConfigFindings(
     });
   }
 
+  if (bind !== "loopback" && !cfg.gateway?.auth?.rateLimit) {
+    findings.push({
+      checkId: "gateway.auth_no_rate_limit",
+      severity: "warn",
+      title: "No auth rate limiting configured",
+      detail:
+        "gateway.bind is not loopback but no gateway.auth.rateLimit is configured. " +
+        "Without rate limiting, brute-force auth attacks are not mitigated.",
+      remediation:
+        "Set gateway.auth.rateLimit (e.g. { maxAttempts: 10, windowMs: 60000, lockoutMs: 300000 }).",
+    });
+  }
+
   return findings;
 }
 


### PR DESCRIPTION
## Hallo Peter Steinberger, Dear code maintainer,

I just saw you on Lex Fridman (https://www.youtube.com/watch?v=YFjfBk8HI5o&t=1212s) and got inspired to help to IT-security improve the code. => This is the first PR which protects against brute-force credential guessing.

Verified by Opus 4.6:
## Summary

Adds a per-IP sliding-window rate limiter to Gateway authentication endpoints
(HTTP, WebSocket upgrade, and WS message-level auth). Protects against brute-force
credential guessing when the Gateway is exposed beyond loopback.

## Motivation

When `gateway.bind` is set to `lan`, `tailnet`, or `auto`, the auth endpoints are network-reachable. Without rate limiting, an attacker
can attempt unlimited password/token guesses. This PR closes that gap.

## What's included

| Description                                                                    | File                                                    |
| ------------------------------------------------------------------------------ | ------------------------------------------------------- |
| Core rate limiter (sliding window, per-IP, configurable lockout)               | `src/gateway/auth-rate-limit.ts`                      |
| 15 unit tests (window, lockout, isolation, loopback exemption, prune, dispose) | `src/gateway/auth-rate-limit.test.ts`                 |
| `GatewayAuthRateLimitConfig` type                                            | `src/config/types.gateway.ts`                         |
| `rateLimited` / `retryAfterMs` fields + check/record/reset in auth flow    | `src/gateway/auth.ts`                                 |
| `sendRateLimited()` — HTTP 429 + `Retry-After` helper                     | `src/gateway/http-common.ts`                          |
| Thread rateLimiter through HTTP server, canvas auth, upgrade handler           | `src/gateway/server-http.ts`                          |
| Thread rateLimiter + 429 response for `/v1/chat/completions`                 | `src/gateway/openai-http.ts`                          |
| Thread rateLimiter + 429 response for `/v1/responses`                        | `src/gateway/openresponses-http.ts`                   |
| Thread rateLimiter + 429 response for `/tools/invoke`                        | `src/gateway/tools-invoke-http.ts`                    |
| Thread rateLimiter through runtime state                                       | `src/gateway/server-runtime-state.ts`                 |
| Thread rateLimiter through WS runtime                                          | `src/gateway/server-ws-runtime.ts`                    |
| Thread rateLimiter through WS connection                                       | `src/gateway/server/ws-connection.ts`                 |
| Pass to primary auth only (avoid double-count); use proxy-aware `clientIp`   | `src/gateway/server/ws-connection/message-handler.ts` |
| Create, wire, and dispose `authRateLimiter`                                  | `src/gateway/server.impl.ts`                          |
| `gateway.auth_no_rate_limit` security audit finding                          | `src/security/audit.ts`                               |

## Design decisions

- **Sliding window** — fairer than fixed-window; resets naturally as old attempts expire.
- **Loopback exempt** — `127.0.0.1` / `::1` skip the check (local dev shouldn't be blocked).
- **Optional & backward-compatible** — everything is `undefined`-safe; zero behaviour change when `rateLimit` is not configured.
- **Single count per WS handshake** — the secondary `sharedAuth` call in `message-handler.ts` intentionally omits the limiter to avoid double-counting a single connection attempt.
- **Proxy-aware IP keying** — WS rate-limit uses `resolveGatewayClientIp()` (respects `X-Forwarded-For` / `X-Real-IP` with trusted-proxy validation) instead of raw `remoteAddr`, so users behind a reverse proxy are tracked individually.
- **All auth-protected HTTP endpoints covered** — `/v1/chat/completions`, `/v1/responses`, `/tools/invoke`, `/api/channels/*`, and canvas auth all thread the rate limiter and return proper 429 + `Retry-After` responses.
- **Dispose on shutdown** — the prune timer is `unref()`'d and explicitly cleared in the server close handler.

## Configuration example

```yaml
gateway:
  auth:
    rateLimit:
      maxAttempts: 10
      windowMs: 60000
      lockoutMs: 300000
```

## Test results

```
✓ src/gateway/auth-rate-limit.test.ts (15 tests) — all pass
✓ src/gateway/auth.test.ts (7 tests) — all pass
✓ All 285 gateway tests (46 files) — all pass
✓ TypeScript: zero errors on all 15 changed files
```

## Checklist

- [X] New code follows existing patterns (pure functions, explicit DI, `.js` import extensions)
- [X] All parameters are optional / backward-compatible
- [X] Unit tests cover happy path, edge cases, and cleanup
- [X] No new dependencies added
- [X] Existing tests unaffected (285/285 pass)
- [X] `npx tsc --noEmit` clean on all touched files
- [X] All auth-protected HTTP endpoints thread the rate limiter
- [X] WS rate-limit keying uses proxy-aware client IP resolution