### PR TITLE
fix: update totalTokens in session store after auto-compaction

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -409,6 +409,7 @@ export async function runEmbeddedPiAgent(
       let toolResultTruncationAttempted = false;
       const usageAccumulator = createUsageAccumulator();
       let autoCompactionCount = 0;
+      let lastCompactionTokensAfter: number | undefined;
       try {
         while (true) {
           attemptedThinking.add(thinkLevel);
@@ -552,6 +553,9 @@ export async function runEmbeddedPiAgent(
               });
               if (compactResult.compacted) {
                 autoCompactionCount += 1;
+                if (compactResult.result?.tokensAfter != null) {
+                  lastCompactionTokensAfter = compactResult.result.tokensAfter;
+                }
                 log.info(`auto-compaction succeeded for ${provider}/${modelId}; retrying prompt`);
                 continue;
               }
@@ -826,6 +830,7 @@ export async function runEmbeddedPiAgent(
             model: lastAssistant?.model ?? model.id,
             usage,
             compactionCount: autoCompactionCount > 0 ? autoCompactionCount : undefined,
+            compactionTokensAfter: autoCompactionCount > 0 ? lastCompactionTokensAfter : undefined,
           };
 
           const payloads = buildEmbeddedRunPayloads({

--- a/src/agents/pi-embedded-runner/types.ts
+++ b/src/agents/pi-embedded-runner/types.ts
@@ -6,6 +6,8 @@ export type EmbeddedPiAgentMeta = {
   provider: string;
   model: string;
   compactionCount?: number;
+  /** Post-compaction token count (set when auto-compaction occurred during the run). */
+  compactionTokensAfter?: number;
   usage?: {
     input?: number;
     output?: number;

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -96,7 +96,7 @@ export async function runMemoryFlushIfNeeded(params: {
     .filter(Boolean)
     .join("\n\n");
   try {
-    await runWithModelFallback({
+    const memoryFlushFallbackResult = await runWithModelFallback({
       cfg: params.followupRun.run.config,
       provider: params.followupRun.run.provider,
       model: params.followupRun.run.model,
@@ -172,6 +172,7 @@ export async function runMemoryFlushIfNeeded(params: {
         sessionStore: activeSessionStore,
         sessionKey: params.sessionKey,
         storePath: params.storePath,
+        tokensAfter: memoryFlushFallbackResult.result.meta.agentMeta?.compactionTokensAfter,
       });
       if (typeof nextCount === "number") {
         memoryFlushCompactionCount = nextCount;

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -500,6 +500,7 @@ export async function runReplyAgent(params: {
         sessionStore: activeSessionStore,
         sessionKey,
         storePath,
+        tokensAfter: runResult.meta.agentMeta?.compactionTokensAfter,
       });
       if (verboseEnabled) {
         const suffix = typeof count === "number" ? ` (count ${count})` : "";

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -268,6 +268,7 @@ export function createFollowupRunner(params: {
           sessionStore,
           sessionKey,
           storePath,
+          tokensAfter: runResult.meta.agentMeta?.compactionTokensAfter,
         });
         if (queued.run.verboseLevel && queued.run.verboseLevel !== "off") {
           const suffix = typeof count === "number" ? ` (count ${count})` : "";

--- a/src/auto-reply/reply/session-updates.test.ts
+++ b/src/auto-reply/reply/session-updates.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../config/sessions.js", () => ({
+  updateSessionStore: vi.fn(async (_path: string, fn: (store: Record<string, unknown>) => void) => {
+    const store: Record<string, unknown> = {};
+    fn(store);
+    return store;
+  }),
+}));
+
+import type { SessionEntry } from "../../config/sessions.js";
+import { updateSessionStore } from "../../config/sessions.js";
+import { incrementCompactionCount } from "./session-updates.js";
+
+const mockedUpdateSessionStore = vi.mocked(updateSessionStore);
+
+describe("incrementCompactionCount", () => {
+  it("updates totalTokens in sessionStore when tokensAfter is provided", async () => {
+    const sessionStore: Record<string, SessionEntry> = {
+      main: {
+        sessionId: "session-1",
+        updatedAt: Date.now(),
+        totalTokens: 181000,
+        inputTokens: 160000,
+        outputTokens: 21000,
+        compactionCount: 0,
+      },
+    };
+
+    const count = await incrementCompactionCount({
+      sessionStore,
+      sessionKey: "main",
+      tokensAfter: 10000,
+    });
+
+    expect(count).toBe(1);
+    expect(sessionStore.main.totalTokens).toBe(10000);
+    expect(sessionStore.main.inputTokens).toBeUndefined();
+    expect(sessionStore.main.outputTokens).toBeUndefined();
+    expect(sessionStore.main.compactionCount).toBe(1);
+  });
+
+  it("does not update totalTokens when tokensAfter is not provided", async () => {
+    const sessionStore: Record<string, SessionEntry> = {
+      main: {
+        sessionId: "session-1",
+        updatedAt: Date.now(),
+        totalTokens: 181000,
+        inputTokens: 160000,
+        outputTokens: 21000,
+        compactionCount: 0,
+      },
+    };
+
+    const count = await incrementCompactionCount({
+      sessionStore,
+      sessionKey: "main",
+    });
+
+    expect(count).toBe(1);
+    // totalTokens should remain unchanged when tokensAfter is not provided
+    expect(sessionStore.main.totalTokens).toBe(181000);
+    expect(sessionStore.main.inputTokens).toBe(160000);
+    expect(sessionStore.main.outputTokens).toBe(21000);
+  });
+
+  it("persists totalTokens to the store file when storePath is provided", async () => {
+    const sessionStore: Record<string, SessionEntry> = {
+      main: {
+        sessionId: "session-1",
+        updatedAt: Date.now(),
+        totalTokens: 181000,
+        compactionCount: 0,
+      },
+    };
+
+    await incrementCompactionCount({
+      sessionStore,
+      sessionKey: "main",
+      storePath: "/tmp/sessions.json",
+      tokensAfter: 10000,
+    });
+
+    expect(mockedUpdateSessionStore).toHaveBeenCalledWith(
+      "/tmp/sessions.json",
+      expect.any(Function),
+    );
+
+    // Verify the update function writes totalTokens
+    const updateFn = mockedUpdateSessionStore.mock.calls[0][1] as (
+      store: Record<string, Partial<SessionEntry>>,
+    ) => void;
+    const fileStore: Record<string, Partial<SessionEntry>> = { main: { totalTokens: 181000 } };
+    updateFn(fileStore);
+    expect(fileStore.main.totalTokens).toBe(10000);
+  });
+
+  it("returns undefined when sessionStore or sessionKey is missing", async () => {
+    const result1 = await incrementCompactionCount({
+      sessionKey: "main",
+      tokensAfter: 10000,
+    });
+    expect(result1).toBeUndefined();
+
+    const result2 = await incrementCompactionCount({
+      sessionStore: {},
+      tokensAfter: 10000,
+    });
+    expect(result2).toBeUndefined();
+  });
+});

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -253,7 +253,7 @@ export async function incrementCompactionCount(params: {
     updatedAt: now,
   };
   // If tokensAfter is provided, update the cached token counts to reflect post-compaction state
-  if (tokensAfter != null && tokensAfter > 0) {
+  if (tokensAfter != null && tokensAfter >= 0) {
     updates.totalTokens = tokensAfter;
     // Clear input/output breakdown since we only have the total estimate after compaction
     updates.inputTokens = undefined;


### PR DESCRIPTION
## Summary

- Propagate `tokensAfter` from compaction results through `agentMeta` so `incrementCompactionCount` can update the session store's `totalTokens`
- Clear stale `inputTokens`/`outputTokens` after compaction since only a total estimate is available
- Add tests for both the run-loop propagation and session store update logic

Closes #14979

## Test plan

- [x] New unit tests for `compactionTokensAfter` propagation in `run.overflow-compaction.test.ts`
- [x] New unit tests for `incrementCompactionCount` token updates in `session-updates.test.ts`
- [ ] Manual: run `/compact`, then `openclaw sessions` — token count should reflect post-compaction value

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR propagates post-auto-compaction token totals (`tokensAfter`) from the embedded Pi runner into `agentMeta` (`compactionTokensAfter`) and threads that value into the reply/memory-flush/followup runners so `incrementCompactionCount` can update the session store’s `totalTokens`. It also clears `inputTokens`/`outputTokens` after compaction because only a total estimate is available, and adds unit tests for the propagation and store update behavior.

Key risk areas are around correctness of the session-store update guard conditions and test stability (module mocking).

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge after fixing a couple of edge-case and test-stability issues.
- Core propagation logic looks consistent end-to-end (runner → agentMeta → session updates) and is covered by new unit tests, but there’s a real correctness gap if `tokensAfter` can be 0 (session totals won’t update) and the new unit test’s module mock may not reliably intercept the intended module depending on resolution of the `.js` specifier under test.
- src/auto-reply/reply/session-updates.ts; src/auto-reply/reply/session-updates.test.ts

<sub>Last reviewed commit: b5d3265</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->