### PR TITLE
feat(mattermost): add emoji reactions support (#14305)

### DIFF
--- a/extensions/mattermost/src/channel.test.ts
+++ b/extensions/mattermost/src/channel.test.ts
@@ -68,6 +68,23 @@ describe("mattermostPlugin", () => {
       expect(actions).toEqual([]);
     });
 
+    it("hides react when actions.reactions is false", () => {
+      const cfg: OpenClawConfig = {
+        channels: {
+          mattermost: {
+            enabled: true,
+            botToken: "test-token",
+            baseUrl: "https://chat.example.com",
+            actions: { reactions: false },
+          },
+        },
+      };
+
+      const actions = mattermostPlugin.actions?.listActions?.({ cfg }) ?? [];
+      expect(actions).toContain("send");
+      expect(actions).not.toContain("react");
+    });
+
     it("handles react by calling Mattermost reactions API", async () => {
       const cfg: OpenClawConfig = {
         channels: {

--- a/extensions/mattermost/src/channel.test.ts
+++ b/extensions/mattermost/src/channel.test.ts
@@ -1,6 +1,6 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import { createReplyPrefixOptions } from "openclaw/plugin-sdk";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mattermostPlugin } from "./channel.js";
 
 describe("mattermostPlugin", () => {
@@ -34,6 +34,91 @@ describe("mattermostPlugin", () => {
 
       expect(normalize("@Alice")).toBe("alice");
       expect(normalize("user:USER123")).toBe("user123");
+    });
+  });
+
+  describe("messageActions", () => {
+    it("exposes react when mattermost is configured", () => {
+      const cfg: OpenClawConfig = {
+        channels: {
+          mattermost: {
+            enabled: true,
+            botToken: "test-token",
+            baseUrl: "https://chat.example.com",
+          },
+        },
+      };
+
+      const actions = mattermostPlugin.actions?.listActions?.({ cfg }) ?? [];
+      expect(actions).toContain("send");
+      expect(actions).toContain("react");
+      expect(mattermostPlugin.actions?.supportsAction?.({ action: "react" })).toBe(true);
+    });
+
+    it("hides react when mattermost is not configured", () => {
+      const cfg: OpenClawConfig = {
+        channels: {
+          mattermost: {
+            enabled: true,
+          },
+        },
+      };
+
+      const actions = mattermostPlugin.actions?.listActions?.({ cfg }) ?? [];
+      expect(actions).toEqual([]);
+    });
+
+    it("handles react by calling Mattermost reactions API", async () => {
+      const cfg: OpenClawConfig = {
+        channels: {
+          mattermost: {
+            enabled: true,
+            botToken: "test-token",
+            baseUrl: "https://chat.example.com",
+          },
+        },
+      };
+
+      const fetchImpl = vi.fn(async (url: any, init?: any) => {
+        if (String(url).endsWith("/api/v4/users/me")) {
+          return new Response(JSON.stringify({ id: "BOT123" }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        if (String(url).endsWith("/api/v4/reactions")) {
+          expect(init?.method).toBe("POST");
+          expect(JSON.parse(init?.body)).toEqual({
+            user_id: "BOT123",
+            post_id: "POST1",
+            emoji_name: "thumbsup",
+          });
+          return new Response(JSON.stringify({ ok: true }), {
+            status: 201,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        throw new Error(`unexpected url: ${url}`);
+      });
+
+      const prevFetch = globalThis.fetch;
+      (globalThis as any).fetch = fetchImpl;
+      try {
+        const result = await mattermostPlugin.actions?.handleAction?.({
+          channel: "mattermost",
+          action: "react",
+          params: { messageId: "POST1", emoji: "thumbsup" },
+          cfg,
+          accountId: "default",
+        } as any);
+
+        expect(result?.content).toEqual([
+          { type: "text", text: "Reacted with :thumbsup: on POST1" },
+        ]);
+        expect(result?.details).toEqual({});
+      } finally {
+        (globalThis as any).fetch = prevFetch;
+      }
     });
   });
 

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -39,7 +39,12 @@ const mattermostMessageActions: ChannelMessageActionAdapter = {
       return [];
     }
 
-    const actions = new Set<ChannelMessageActionName>(["send", "react"]);
+    const actions = new Set<ChannelMessageActionName>(["send"]);
+    const actionsConfig = cfg.channels?.mattermost?.actions as { reactions?: boolean } | undefined;
+    const reactionsEnabled = actionsConfig?.reactions !== false;
+    if (reactionsEnabled) {
+      actions.add("react");
+    }
     return Array.from(actions);
   },
   supportsAction: ({ action }) => {

--- a/extensions/mattermost/src/config-schema.ts
+++ b/extensions/mattermost/src/config-schema.ts
@@ -28,6 +28,11 @@ const MattermostAccountSchemaBase = z
     blockStreaming: z.boolean().optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
     responsePrefix: z.string().optional(),
+    actions: z
+      .object({
+        reactions: z.boolean().optional(),
+      })
+      .optional(),
   })
   .strict();
 

--- a/extensions/mattermost/src/mattermost/client.test.ts
+++ b/extensions/mattermost/src/mattermost/client.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from "vitest";
+import { createMattermostClient } from "./client.js";
+
+describe("mattermost client", () => {
+  it("request returns undefined on 204 responses", async () => {
+    const fetchImpl = vi.fn(async () => {
+      return new Response(null, { status: 204 });
+    });
+
+    const client = createMattermostClient({
+      baseUrl: "https://chat.example.com",
+      botToken: "test-token",
+      fetchImpl: fetchImpl as any,
+    });
+
+    const result = await client.request<unknown>("/anything", { method: "DELETE" });
+    expect(result).toBeUndefined();
+  });
+});

--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -97,7 +97,17 @@ export function createMattermostClient(params: {
         `Mattermost API ${res.status} ${res.statusText}: ${detail || "unknown error"}`,
       );
     }
-    return (await res.json()) as T;
+
+    if (res.status === 204) {
+      return undefined as T;
+    }
+
+    const contentType = res.headers.get("content-type") ?? "";
+    if (contentType.includes("application/json")) {
+      return (await res.json()) as T;
+    }
+
+    return (await res.text()) as T;
   };
 
   return { baseUrl, apiBaseUrl, token, request };

--- a/extensions/mattermost/src/mattermost/reactions.test.ts
+++ b/extensions/mattermost/src/mattermost/reactions.test.ts
@@ -1,0 +1,80 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { describe, expect, it, vi } from "vitest";
+import { addMattermostReaction, removeMattermostReaction } from "./reactions.js";
+
+function createCfg(): OpenClawConfig {
+  return {
+    channels: {
+      mattermost: {
+        enabled: true,
+        botToken: "test-token",
+        baseUrl: "https://chat.example.com",
+      },
+    },
+  };
+}
+
+describe("mattermost reactions", () => {
+  it("adds reactions by calling /users/me then POST /reactions", async () => {
+    const fetchImpl = vi.fn(async (url: any, init?: any) => {
+      if (String(url).endsWith("/api/v4/users/me")) {
+        return new Response(JSON.stringify({ id: "BOT123" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (String(url).endsWith("/api/v4/reactions")) {
+        expect(init?.method).toBe("POST");
+        expect(JSON.parse(init?.body)).toEqual({
+          user_id: "BOT123",
+          post_id: "POST1",
+          emoji_name: "thumbsup",
+        });
+        return new Response(JSON.stringify({ ok: true }), {
+          status: 201,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      throw new Error(`unexpected url: ${url}`);
+    });
+
+    const result = await addMattermostReaction({
+      cfg: createCfg(),
+      postId: "POST1",
+      emojiName: "thumbsup",
+      fetchImpl,
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(fetchImpl).toHaveBeenCalled();
+  });
+
+  it("removes reactions by calling /users/me then DELETE /users/:id/posts/:postId/reactions/:emoji", async () => {
+    const fetchImpl = vi.fn(async (url: any, init?: any) => {
+      if (String(url).endsWith("/api/v4/users/me")) {
+        return new Response(JSON.stringify({ id: "BOT123" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (String(url).endsWith("/api/v4/users/BOT123/posts/POST1/reactions/thumbsup")) {
+        expect(init?.method).toBe("DELETE");
+        return new Response(null, {
+          status: 204,
+          headers: { "content-type": "text/plain" },
+        });
+      }
+      throw new Error(`unexpected url: ${url}`);
+    });
+
+    const result = await removeMattermostReaction({
+      cfg: createCfg(),
+      postId: "POST1",
+      emojiName: "thumbsup",
+      fetchImpl,
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(fetchImpl).toHaveBeenCalled();
+  });
+});

--- a/extensions/mattermost/src/mattermost/reactions.ts
+++ b/extensions/mattermost/src/mattermost/reactions.ts
@@ -1,0 +1,102 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { resolveMattermostAccount } from "./accounts.js";
+import { createMattermostClient, fetchMattermostMe, type MattermostClient } from "./client.js";
+
+type Result = { ok: true } | { ok: false; error: string };
+
+export async function addMattermostReaction(params: {
+  cfg: OpenClawConfig;
+  postId: string;
+  emojiName: string;
+  accountId?: string | null;
+  fetchImpl?: typeof fetch;
+}): Promise<Result> {
+  const resolved = resolveMattermostAccount({ cfg: params.cfg, accountId: params.accountId });
+  const baseUrl = resolved.baseUrl?.trim();
+  const botToken = resolved.botToken?.trim();
+  if (!baseUrl || !botToken) {
+    return { ok: false, error: "Mattermost botToken/baseUrl missing." };
+  }
+
+  const client = createMattermostClient({
+    baseUrl,
+    botToken,
+    fetchImpl: params.fetchImpl,
+  });
+
+  const me = await fetchMattermostMe(client);
+  const userId = me?.id?.trim();
+  if (!userId) {
+    return { ok: false, error: "Mattermost reactions failed: could not resolve bot user id." };
+  }
+
+  await createReaction(client, {
+    userId,
+    postId: params.postId,
+    emojiName: params.emojiName,
+  });
+
+  return { ok: true };
+}
+
+export async function removeMattermostReaction(params: {
+  cfg: OpenClawConfig;
+  postId: string;
+  emojiName: string;
+  accountId?: string | null;
+  fetchImpl?: typeof fetch;
+}): Promise<Result> {
+  const resolved = resolveMattermostAccount({ cfg: params.cfg, accountId: params.accountId });
+  const baseUrl = resolved.baseUrl?.trim();
+  const botToken = resolved.botToken?.trim();
+  if (!baseUrl || !botToken) {
+    return { ok: false, error: "Mattermost botToken/baseUrl missing." };
+  }
+
+  const client = createMattermostClient({
+    baseUrl,
+    botToken,
+    fetchImpl: params.fetchImpl,
+  });
+
+  const me = await fetchMattermostMe(client);
+  const userId = me?.id?.trim();
+  if (!userId) {
+    return { ok: false, error: "Mattermost reactions failed: could not resolve bot user id." };
+  }
+
+  await deleteReaction(client, {
+    userId,
+    postId: params.postId,
+    emojiName: params.emojiName,
+  });
+
+  return { ok: true };
+}
+
+async function createReaction(
+  client: MattermostClient,
+  params: { userId: string; postId: string; emojiName: string },
+): Promise<void> {
+  await client.request<Record<string, unknown>>("/reactions", {
+    method: "POST",
+    body: JSON.stringify({
+      user_id: params.userId,
+      post_id: params.postId,
+      emoji_name: params.emojiName,
+    }),
+  });
+}
+
+async function deleteReaction(
+  client: MattermostClient,
+  params: { userId: string; postId: string; emojiName: string },
+): Promise<void> {
+  const emoji = encodeURIComponent(params.emojiName);
+  await client.request<unknown>(
+    `/users/${params.userId}/posts/${params.postId}/reactions/${emoji}`,
+    {
+      method: "DELETE",
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Adds emoji reaction support (add/remove) to the Mattermost extension, closing #14305.

## Changes

- **`reactions.ts`** — `addMattermostReaction()` / `removeMattermostReaction()` using Mattermost API v4
- **`client.ts`** — Handle 204 No Content and non-JSON responses gracefully
- **`channel.ts`** — Wire up `actions` adapter with `react` support (returns `AgentToolResult` format)
- **Tests** — 11 tests across 3 files (reactions, client, channel)

## Validation

- `pnpm check` ✅ (format + tsgo + lint — 0 errors)
- `pnpm exec vitest run` ✅ (11/11 tests pass)

## Notes

- AI-assisted implementation (Nova/Claude)
- Follows TDD red→green→refactor cycle per CONTRIBUTING.md
- Extension plugins use `ChannelPlugin.actions` (not runtime `messageActions`)

Closes #14305

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds Mattermost emoji reaction support end-to-end:
- New reactions API helpers (`addMattermostReaction` / `removeMattermostReaction`) using Mattermost v4 endpoints.
- Extends the Mattermost channel plugin with an `actions` adapter that exposes a `react` action (config-gated via `channels.mattermost.actions.reactions`).
- Updates the Mattermost client request helper to tolerate `204 No Content` and non-JSON responses.
- Enhances the Mattermost websocket monitor to process `reaction_added` / `reaction_removed` events and emit system events.

Overall the changes fit the existing extension structure (client helpers in `mattermost/`, plugin wiring in `channel.ts`, runtime event ingestion in `monitor.ts`) and include targeted tests for the new behaviors.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a couple of routing/action-contract issues that can cause runtime failures or misrouted events.
- Core functionality is well covered by tests and the API/client changes are straightforward, but (1) the actions adapter advertises `send` without a corresponding `handleAction` implementation, and (2) reaction websocket events bypass the normal routing logic and hardcode `agent:main`, which will misroute events in multi-agent setups.
- extensions/mattermost/src/channel.ts, extensions/mattermost/src/mattermost/monitor.ts

<sub>Last reviewed commit: 0072d62</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->