### PR TITLE
Signal: enforce E.164 account validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Docs: https://docs.openclaw.ai
 - BlueBubbles: fix webhook auth bypass via loopback proxy trust. (#13787) Thanks @coygeek.
 - Slack: change default replyToMode from "off" to "all". (#14364) Thanks @nm-de.
 - Slack: detect control commands when channel messages start with bot mention prefixes (for example, `@Bot /new`). (#14142) Thanks @beefiker.
+- Signal: enforce E.164 validation for the Signal bot account prompt so mistyped numbers are caught early. (#15063) Thanks @Duartemartins.
 - Signal: render mention placeholders as `@uuid`/`@phone` so mention gating and Clawdbot targeting work. (#2013) Thanks @alexgleason.
 - Onboarding/Providers: add Z.AI endpoint-specific auth choices (`zai-coding-global`, `zai-coding-cn`, `zai-global`, `zai-cn`) and expand default Z.AI model wiring. (#13456) Thanks @tomsun28.
 - Onboarding/Providers: update MiniMax API default/recommended models from M2.1 to M2.5, add M2.5/M2.5-Lightning model entries, and include `minimax-m2.5` in modern model filtering. (#14865) Thanks @adao-max.

--- a/src/channels/plugins/onboarding/signal.test.ts
+++ b/src/channels/plugins/onboarding/signal.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeSignalAccountInput } from "./signal.js";
+
+describe("normalizeSignalAccountInput", () => {
+  it("accepts already normalized numbers", () => {
+    expect(normalizeSignalAccountInput("+15555550123")).toBe("+15555550123");
+  });
+
+  it("normalizes formatted input", () => {
+    expect(normalizeSignalAccountInput("  +1 (555) 000-1234 ")).toBe("+15550001234");
+  });
+
+  it("rejects empty input", () => {
+    expect(normalizeSignalAccountInput("   ")).toBeNull();
+  });
+
+  it("rejects non-numeric input", () => {
+    expect(normalizeSignalAccountInput("ok")).toBeNull();
+    expect(normalizeSignalAccountInput("++--")).toBeNull();
+  });
+
+  it("rejects numbers that are too short or too long", () => {
+    expect(normalizeSignalAccountInput("+1234")).toBeNull();
+    expect(normalizeSignalAccountInput("+1234567890123456")).toBeNull();
+  });
+});

--- a/src/channels/plugins/onboarding/signal.test.ts
+++ b/src/channels/plugins/onboarding/signal.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-
 import { normalizeSignalAccountInput } from "./signal.js";
 
 describe("normalizeSignalAccountInput", () => {
@@ -18,6 +17,11 @@ describe("normalizeSignalAccountInput", () => {
   it("rejects non-numeric input", () => {
     expect(normalizeSignalAccountInput("ok")).toBeNull();
     expect(normalizeSignalAccountInput("++--")).toBeNull();
+  });
+
+  it("rejects inputs with stray + characters", () => {
+    expect(normalizeSignalAccountInput("++12345")).toBeNull();
+    expect(normalizeSignalAccountInput("+1+2345")).toBeNull();
   });
 
   it("rejects numbers that are too short or too long", () => {

--- a/src/channels/plugins/onboarding/signal.ts
+++ b/src/channels/plugins/onboarding/signal.ts
@@ -16,6 +16,23 @@ import { normalizeE164 } from "../../../utils.js";
 import { addWildcardAllowFrom, promptAccountId } from "./helpers.js";
 
 const channel = "signal" as const;
+const MIN_E164_DIGITS = 5;
+const MAX_E164_DIGITS = 15;
+const INVALID_SIGNAL_ACCOUNT_ERROR =
+  "Invalid E.164 phone number (must start with + and country code, e.g. +15555550123)";
+
+export function normalizeSignalAccountInput(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const normalized = normalizeE164(trimmed);
+  const digits = normalized.slice(1);
+  if (digits.length < MIN_E164_DIGITS || digits.length > MAX_E164_DIGITS) {
+    return null;
+  }
+  return normalized;
+}
 
 function setSignalDmPolicy(cfg: OpenClawConfig, dmPolicy: DmPolicy) {
   const allowFrom =
@@ -243,22 +260,34 @@ export const signalOnboardingAdapter: ChannelOnboardingAdapter = {
 
     let account = accountConfig.account ?? "";
     if (account) {
-      const keep = await prompter.confirm({
-        message: `Signal account set (${account}). Keep it?`,
-        initialValue: true,
-      });
-      if (!keep) {
+      const normalizedExisting = normalizeSignalAccountInput(account);
+      if (!normalizedExisting) {
+        await prompter.note(
+          "Existing Signal account isn't a valid E.164 number. Please enter it again.",
+          "Signal",
+        );
         account = "";
+      } else {
+        account = normalizedExisting;
+        const keep = await prompter.confirm({
+          message: `Signal account set (${account}). Keep it?`,
+          initialValue: true,
+        });
+        if (!keep) account = "";
       }
     }
 
     if (!account) {
-      account = String(
+      const rawAccount = String(
         await prompter.text({
           message: "Signal bot number (E.164)",
-          validate: (value) => (value?.trim() ? undefined : "Required"),
+          validate: (value) =>
+            normalizeSignalAccountInput(String(value ?? ""))
+              ? undefined
+              : INVALID_SIGNAL_ACCOUNT_ERROR,
         }),
-      ).trim();
+      );
+      account = normalizeSignalAccountInput(rawAccount) ?? "";
     }
 
     if (account) {

--- a/src/channels/plugins/onboarding/signal.ts
+++ b/src/channels/plugins/onboarding/signal.ts
@@ -18,6 +18,7 @@ import { addWildcardAllowFrom, promptAccountId } from "./helpers.js";
 const channel = "signal" as const;
 const MIN_E164_DIGITS = 5;
 const MAX_E164_DIGITS = 15;
+const DIGITS_ONLY = /^\d+$/;
 const INVALID_SIGNAL_ACCOUNT_ERROR =
   "Invalid E.164 phone number (must start with + and country code, e.g. +15555550123)";
 
@@ -28,10 +29,13 @@ export function normalizeSignalAccountInput(value: string | null | undefined): s
   }
   const normalized = normalizeE164(trimmed);
   const digits = normalized.slice(1);
+  if (!DIGITS_ONLY.test(digits)) {
+    return null;
+  }
   if (digits.length < MIN_E164_DIGITS || digits.length > MAX_E164_DIGITS) {
     return null;
   }
-  return normalized;
+  return `+${digits}`;
 }
 
 function setSignalDmPolicy(cfg: OpenClawConfig, dmPolicy: DmPolicy) {
@@ -273,7 +277,9 @@ export const signalOnboardingAdapter: ChannelOnboardingAdapter = {
           message: `Signal account set (${account}). Keep it?`,
           initialValue: true,
         });
-        if (!keep) account = "";
+        if (!keep) {
+          account = "";
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- introduce a shared `normalizeSignalAccountInput` helper so we validate + normalize Signal account numbers consistently
- prompt refuses inputs that aren't real E.164 numbers (or that are too short/long), re-prompts when an existing config is invalid, and stores the normalized value once it passes validation
- add unit coverage for the helper

Thanks to @Duartemartins for calling out the original gap in #2208—we borrowed the user-facing copy from that PR while tightening the validation semantics.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces a shared `normalizeSignalAccountInput` helper and wires it into the Signal onboarding flow so the configured bot number is normalized/stored in E.164 form and re-prompted when an existing config is invalid. It also adds unit coverage for the helper.

The change primarily affects the interactive onboarding validation and the persisted `channels.signal.account` value, aiming to ensure consistent E.164 formatting.

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe, but the new validation helper currently allows some invalid non-E.164 inputs to be accepted and persisted.
- Main risk is correctness of the new shared validator: because it relies on `normalizeE164` (which preserves extra '+') and only checks length, some malformed inputs can slip through. Aside from that, the changes are localized and covered by tests (though tests don’t cover this edge case).
- src/channels/plugins/onboarding/signal.ts

<sub>Last reviewed commit: 22bc5e5</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->