### PR TITLE
fix: suppress ghost bubble when stream is NO_REPLY or HEARTBEAT_OK

### DIFF
--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -524,7 +524,10 @@ function buildChatItems(props: ChatProps): Array<ChatItem | MessageGroup> {
 
   if (props.stream !== null) {
     const key = `stream:${props.sessionKey}:${props.streamStartedAt ?? "live"}`;
-    if (props.stream.trim().length > 0) {
+    const trimmed = props.stream.trim();
+    const isSilentReply = trimmed === "NO_REPLY" || trimmed === "HEARTBEAT_OK";
+    
+    if (trimmed.length > 0 && !isSilentReply) {
       items.push({
         kind: "stream",
         key,


### PR DESCRIPTION
## Problem

When the AI model responds with `NO_REPLY` or `HEARTBEAT_OK` (silent reply tokens), the webchat UI briefly displays a chat bubble during streaming. Once the stream completes, the bubble appears empty or minimal, leaving a small visual artifact (a "dot" or "stain") in the conversation.

## Root Cause

During streaming, the webchat client receives tokens via WebSocket and creates a message bubble for any non-empty stream content. When the model outputs `NO_REPLY` or `HEARTBEAT_OK`, the client creates a bubble. The backend then detects these as silent replies and suppresses delivery—but the already-created bubble persists in the UI with the literal text "NO_REPLY" or "HEARTBEAT_OK" visible.

## Solution

Treat `NO_REPLY` and `HEARTBEAT_OK` the same as empty streams. Instead of rendering a message bubble, show the reading indicator (typing dots) which is more appropriate for silent replies.

The fix adds a check in `ui/src/ui/views/chat.ts`:
```ts
const isSilentReply = trimmed === "NO_REPLY" || trimmed === "HEARTBEAT_OK";

if (trimmed.length > 0 && !isSilentReply) {
  // render stream bubble
} else {
  // show reading indicator
}
```

## Testing

1. Send a heartbeat poll or other message that triggers a `NO_REPLY` response
2. Observe that no ghost bubble appears in the webchat UI
3. Verify normal messages still stream correctly

Fixes #15060

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the webchat streaming renderer (`ui/src/ui/views/chat.ts`) to treat the sentinel stream payloads `NO_REPLY` and `HEARTBEAT_OK` as “silent replies”. When the current streamed text trims to one of those values, the UI now renders the reading indicator group instead of creating a streaming message bubble, preventing the brief “ghost bubble” artifact during silent responses.

The change is localized to `buildChatItems()` and only affects the `props.stream !== null` branch; normal streaming and grouped message rendering paths are unchanged.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is small, isolated to UI rendering for streamed content, and uses a straightforward equality check against two sentinel values without affecting other chat state flows.
- No files require special attention

<sub>Last reviewed commit: c6d4c77</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->