### PR TITLE
fix(browser): default fill field type to textbox when omitted

### DIFF
--- a/src/agents/tools/browser-tool.schema.ts
+++ b/src/agents/tools/browser-tool.schema.ts
@@ -66,11 +66,18 @@ const BrowserActSchema = Type.Object({
   // select
   values: Type.Optional(Type.Array(Type.String())),
   // fill
-  fields: Type.Optional(Type.Array(Type.Object({
-    ref: Type.String(),
-    type: Type.Optional(Type.String()),
-    value: Type.Optional(Type.String()),
-  }, { additionalProperties: true }))),
+  fields: Type.Optional(
+    Type.Array(
+      Type.Object(
+        {
+          ref: Type.String(),
+          type: Type.Optional(Type.String()),
+          value: Type.Optional(Type.String()),
+        },
+        { additionalProperties: true },
+      ),
+    ),
+  ),
   // resize
   width: Type.Optional(Type.Number()),
   height: Type.Optional(Type.Number()),

--- a/src/agents/tools/browser-tool.schema.ts
+++ b/src/agents/tools/browser-tool.schema.ts
@@ -65,8 +65,12 @@ const BrowserActSchema = Type.Object({
   endRef: Type.Optional(Type.String()),
   // select
   values: Type.Optional(Type.Array(Type.String())),
-  // fill - use permissive array of objects
-  fields: Type.Optional(Type.Array(Type.Object({}, { additionalProperties: true }))),
+  // fill
+  fields: Type.Optional(Type.Array(Type.Object({
+    ref: Type.String(),
+    type: Type.Optional(Type.String()),
+    value: Type.Optional(Type.String()),
+  }, { additionalProperties: true }))),
   // resize
   width: Type.Optional(Type.Number()),
   height: Type.Optional(Type.Number()),

--- a/src/browser/pw-tools-core.interactions.ts
+++ b/src/browser/pw-tools-core.interactions.ts
@@ -186,7 +186,7 @@ export async function fillFormViaPlaywright(opts: {
   const timeout = Math.max(500, Math.min(60_000, opts.timeoutMs ?? 8000));
   for (const field of opts.fields) {
     const ref = field.ref.trim();
-    const type = field.type.trim();
+    const type = (field.type ?? "textbox").trim();
     const rawValue = field.value;
     const value =
       typeof rawValue === "string"

--- a/src/browser/routes/agent.act.ts
+++ b/src/browser/routes/agent.act.ts
@@ -195,7 +195,7 @@ export function registerBrowserAgentActRoutes(
               }
               const rec = field as Record<string, unknown>;
               const ref = toStringOrEmpty(rec.ref);
-              const type = toStringOrEmpty(rec.type);
+              const type = toStringOrEmpty(rec.type) || "textbox";
               if (!ref || !type) {
                 return null;
               }

--- a/src/browser/server.agent-contract-form-layout-act-commands.test.ts
+++ b/src/browser/server.agent-contract-form-layout-act-commands.test.ts
@@ -325,6 +325,98 @@ describe("browser control server", () => {
         fields: [{ ref: "6", type: "textbox", value: "hello" }],
       });
 
+      // fill without type should default to textbox
+      pwMocks.fillFormViaPlaywright.mockClear();
+      const fillNoType = await postJson(`${base}/act`, {
+        kind: "fill",
+        fields: [{ ref: "7", value: "world" }],
+      });
+      expect(fillNoType.ok).toBe(true);
+      expect(pwMocks.fillFormViaPlaywright).toHaveBeenCalledWith({
+        cdpUrl: cdpBaseUrl,
+        targetId: "abcd1234",
+        fields: [{ ref: "7", type: "textbox", value: "world" }],
+      });
+
+      // fill with mixed fields: some with type, some without
+      pwMocks.fillFormViaPlaywright.mockClear();
+      const fillMixed = await postJson(`${base}/act`, {
+        kind: "fill",
+        fields: [
+          { ref: "8", type: "checkbox", value: true },
+          { ref: "9", value: "text here" },
+        ],
+      });
+      expect(fillMixed.ok).toBe(true);
+      expect(pwMocks.fillFormViaPlaywright).toHaveBeenCalledWith({
+        cdpUrl: cdpBaseUrl,
+        targetId: "abcd1234",
+        fields: [
+          { ref: "8", type: "checkbox", value: true },
+          { ref: "9", type: "textbox", value: "text here" },
+        ],
+      });
+
+      // fill with numeric value
+      pwMocks.fillFormViaPlaywright.mockClear();
+      const fillNumeric = await postJson(`${base}/act`, {
+        kind: "fill",
+        fields: [{ ref: "10", value: 42 }],
+      });
+      expect(fillNumeric.ok).toBe(true);
+      expect(pwMocks.fillFormViaPlaywright).toHaveBeenCalledWith({
+        cdpUrl: cdpBaseUrl,
+        targetId: "abcd1234",
+        fields: [{ ref: "10", type: "textbox", value: 42 }],
+      });
+
+      // fill with boolean value
+      pwMocks.fillFormViaPlaywright.mockClear();
+      const fillBoolean = await postJson(`${base}/act`, {
+        kind: "fill",
+        fields: [{ ref: "11", value: false }],
+      });
+      expect(fillBoolean.ok).toBe(true);
+      expect(pwMocks.fillFormViaPlaywright).toHaveBeenCalledWith({
+        cdpUrl: cdpBaseUrl,
+        targetId: "abcd1234",
+        fields: [{ ref: "11", type: "textbox", value: false }],
+      });
+
+      // fill with ref only (no type, no value)
+      pwMocks.fillFormViaPlaywright.mockClear();
+      const fillRefOnly = await postJson(`${base}/act`, {
+        kind: "fill",
+        fields: [{ ref: "12" }],
+      });
+      expect(fillRefOnly.ok).toBe(true);
+      expect(pwMocks.fillFormViaPlaywright).toHaveBeenCalledWith({
+        cdpUrl: cdpBaseUrl,
+        targetId: "abcd1234",
+        fields: [{ ref: "12", type: "textbox" }],
+      });
+
+      // fill with multiple fields, all missing type
+      pwMocks.fillFormViaPlaywright.mockClear();
+      const fillMultiNoType = await postJson(`${base}/act`, {
+        kind: "fill",
+        fields: [
+          { ref: "13", value: "first" },
+          { ref: "14", value: "second" },
+          { ref: "15", value: "third" },
+        ],
+      });
+      expect(fillMultiNoType.ok).toBe(true);
+      expect(pwMocks.fillFormViaPlaywright).toHaveBeenCalledWith({
+        cdpUrl: cdpBaseUrl,
+        targetId: "abcd1234",
+        fields: [
+          { ref: "13", type: "textbox", value: "first" },
+          { ref: "14", type: "textbox", value: "second" },
+          { ref: "15", type: "textbox", value: "third" },
+        ],
+      });
+
       const resize = await postJson(`${base}/act`, {
         kind: "resize",
         width: 800,
@@ -387,6 +479,210 @@ describe("browser control server", () => {
 
       expect(res.error).toContain("browser.evaluateEnabled=false");
       expect(pwMocks.evaluateViaPlaywright).not.toHaveBeenCalled();
+    },
+    slowTimeoutMs,
+  );
+
+  it(
+    "fill rejects empty fields array",
+    async () => {
+      const base = await startServerAndBase();
+
+      const res = await postJson(`${base}/act`, {
+        kind: "fill",
+        fields: [],
+      });
+      expect(res.error).toBe("fields are required");
+      expect(pwMocks.fillFormViaPlaywright).not.toHaveBeenCalled();
+    },
+    slowTimeoutMs,
+  );
+
+  it(
+    "fill rejects when fields is missing entirely",
+    async () => {
+      const base = await startServerAndBase();
+
+      const res = await postJson(`${base}/act`, {
+        kind: "fill",
+      });
+      expect(res.error).toBe("fields are required");
+      expect(pwMocks.fillFormViaPlaywright).not.toHaveBeenCalled();
+    },
+    slowTimeoutMs,
+  );
+
+  it(
+    "fill rejects when fields is not an array",
+    async () => {
+      const base = await startServerAndBase();
+
+      const res = await postJson(`${base}/act`, {
+        kind: "fill",
+        fields: "not-an-array",
+      });
+      expect(res.error).toBe("fields are required");
+      expect(pwMocks.fillFormViaPlaywright).not.toHaveBeenCalled();
+    },
+    slowTimeoutMs,
+  );
+
+  it(
+    "fill filters out fields without ref",
+    async () => {
+      const base = await startServerAndBase();
+
+      // all fields lack ref -> "fields are required"
+      const res = await postJson(`${base}/act`, {
+        kind: "fill",
+        fields: [{ value: "hello" }, { type: "textbox", value: "world" }],
+      });
+      expect(res.error).toBe("fields are required");
+      expect(pwMocks.fillFormViaPlaywright).not.toHaveBeenCalled();
+    },
+    slowTimeoutMs,
+  );
+
+  it(
+    "fill keeps valid fields and filters invalid ones",
+    async () => {
+      const base = await startServerAndBase();
+
+      pwMocks.fillFormViaPlaywright.mockClear();
+      const res = await postJson(`${base}/act`, {
+        kind: "fill",
+        fields: [
+          { ref: "20", value: "good" },
+          { value: "no-ref" },
+          null,
+          "string-entry",
+          { ref: "21", type: "radio", value: true },
+        ],
+      });
+      expect(res.ok).toBe(true);
+      expect(pwMocks.fillFormViaPlaywright).toHaveBeenCalledWith({
+        cdpUrl: cdpBaseUrl,
+        targetId: "abcd1234",
+        fields: [
+          { ref: "20", type: "textbox", value: "good" },
+          { ref: "21", type: "radio", value: true },
+        ],
+      });
+    },
+    slowTimeoutMs,
+  );
+
+  it(
+    "fill with empty string type defaults to textbox",
+    async () => {
+      const base = await startServerAndBase();
+
+      pwMocks.fillFormViaPlaywright.mockClear();
+      const res = await postJson(`${base}/act`, {
+        kind: "fill",
+        fields: [{ ref: "30", type: "", value: "test" }],
+      });
+      expect(res.ok).toBe(true);
+      expect(pwMocks.fillFormViaPlaywright).toHaveBeenCalledWith({
+        cdpUrl: cdpBaseUrl,
+        targetId: "abcd1234",
+        fields: [{ ref: "30", type: "textbox", value: "test" }],
+      });
+    },
+    slowTimeoutMs,
+  );
+
+  it(
+    "fill with whitespace-only type defaults to textbox",
+    async () => {
+      const base = await startServerAndBase();
+
+      pwMocks.fillFormViaPlaywright.mockClear();
+      const res = await postJson(`${base}/act`, {
+        kind: "fill",
+        fields: [{ ref: "31", type: "  ", value: "test" }],
+      });
+      expect(res.ok).toBe(true);
+      expect(pwMocks.fillFormViaPlaywright).toHaveBeenCalledWith({
+        cdpUrl: cdpBaseUrl,
+        targetId: "abcd1234",
+        fields: [{ ref: "31", type: "textbox", value: "test" }],
+      });
+    },
+    slowTimeoutMs,
+  );
+
+  it(
+    "fill preserves explicit type when provided",
+    async () => {
+      const base = await startServerAndBase();
+
+      pwMocks.fillFormViaPlaywright.mockClear();
+      const res = await postJson(`${base}/act`, {
+        kind: "fill",
+        fields: [
+          { ref: "40", type: "checkbox", value: true },
+          { ref: "41", type: "radio", value: false },
+          { ref: "42", type: "textarea", value: "long text" },
+        ],
+      });
+      expect(res.ok).toBe(true);
+      expect(pwMocks.fillFormViaPlaywright).toHaveBeenCalledWith({
+        cdpUrl: cdpBaseUrl,
+        targetId: "abcd1234",
+        fields: [
+          { ref: "40", type: "checkbox", value: true },
+          { ref: "41", type: "radio", value: false },
+          { ref: "42", type: "textarea", value: "long text" },
+        ],
+      });
+    },
+    slowTimeoutMs,
+  );
+
+  it(
+    "fill drops non-string/number/boolean values from field value",
+    async () => {
+      const base = await startServerAndBase();
+
+      pwMocks.fillFormViaPlaywright.mockClear();
+      const res = await postJson(`${base}/act`, {
+        kind: "fill",
+        fields: [
+          { ref: "50", value: { nested: true } },
+          { ref: "51", value: [1, 2, 3] },
+        ],
+      });
+      expect(res.ok).toBe(true);
+      // value should be undefined (dropped), so fields have only ref and type
+      expect(pwMocks.fillFormViaPlaywright).toHaveBeenCalledWith({
+        cdpUrl: cdpBaseUrl,
+        targetId: "abcd1234",
+        fields: [
+          { ref: "50", type: "textbox" },
+          { ref: "51", type: "textbox" },
+        ],
+      });
+    },
+    slowTimeoutMs,
+  );
+
+  it(
+    "fill with numeric ref coerces to string",
+    async () => {
+      const base = await startServerAndBase();
+
+      pwMocks.fillFormViaPlaywright.mockClear();
+      const res = await postJson(`${base}/act`, {
+        kind: "fill",
+        fields: [{ ref: 60, value: "test" }],
+      });
+      expect(res.ok).toBe(true);
+      expect(pwMocks.fillFormViaPlaywright).toHaveBeenCalledWith({
+        cdpUrl: cdpBaseUrl,
+        targetId: "abcd1234",
+        fields: [{ ref: "60", type: "textbox", value: "test" }],
+      });
     },
     slowTimeoutMs,
   );

--- a/src/cli/browser-cli-actions-input/shared.readFields.test.ts
+++ b/src/cli/browser-cli-actions-input/shared.readFields.test.ts
@@ -110,9 +110,9 @@ describe("readFields", () => {
   });
 
   it("throws when ref is missing", async () => {
-    await expect(
-      readFields({ fields: JSON.stringify([{ value: "hello" }]) }),
-    ).rejects.toThrow("fields[0] must include ref");
+    await expect(readFields({ fields: JSON.stringify([{ value: "hello" }]) })).rejects.toThrow(
+      "fields[0] must include ref",
+    );
   });
 
   it("throws when ref is empty string", async () => {

--- a/src/cli/browser-cli-actions-input/shared.readFields.test.ts
+++ b/src/cli/browser-cli-actions-input/shared.readFields.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+import { readFields } from "./shared.js";
+
+describe("readFields", () => {
+  it("parses fields with ref, type, and value", async () => {
+    const result = await readFields({
+      fields: JSON.stringify([{ ref: "1", type: "textbox", value: "hello" }]),
+    });
+    expect(result).toEqual([{ ref: "1", type: "textbox", value: "hello" }]);
+  });
+
+  it("defaults type to textbox when omitted", async () => {
+    const result = await readFields({
+      fields: JSON.stringify([{ ref: "1", value: "hello" }]),
+    });
+    expect(result).toEqual([{ ref: "1", type: "textbox", value: "hello" }]);
+  });
+
+  it("defaults type to textbox for multiple fields", async () => {
+    const result = await readFields({
+      fields: JSON.stringify([
+        { ref: "1", value: "first" },
+        { ref: "2", value: "second" },
+      ]),
+    });
+    expect(result).toEqual([
+      { ref: "1", type: "textbox", value: "first" },
+      { ref: "2", type: "textbox", value: "second" },
+    ]);
+  });
+
+  it("preserves explicit type when provided", async () => {
+    const result = await readFields({
+      fields: JSON.stringify([
+        { ref: "1", type: "checkbox", value: true },
+        { ref: "2", type: "radio", value: false },
+      ]),
+    });
+    expect(result).toEqual([
+      { ref: "1", type: "checkbox", value: true },
+      { ref: "2", type: "radio", value: false },
+    ]);
+  });
+
+  it("handles mixed fields: some with type, some without", async () => {
+    const result = await readFields({
+      fields: JSON.stringify([
+        { ref: "1", type: "checkbox", value: true },
+        { ref: "2", value: "text" },
+      ]),
+    });
+    expect(result).toEqual([
+      { ref: "1", type: "checkbox", value: true },
+      { ref: "2", type: "textbox", value: "text" },
+    ]);
+  });
+
+  it("accepts numeric value", async () => {
+    const result = await readFields({
+      fields: JSON.stringify([{ ref: "1", value: 42 }]),
+    });
+    expect(result).toEqual([{ ref: "1", type: "textbox", value: 42 }]);
+  });
+
+  it("accepts boolean value", async () => {
+    const result = await readFields({
+      fields: JSON.stringify([{ ref: "1", value: false }]),
+    });
+    expect(result).toEqual([{ ref: "1", type: "textbox", value: false }]);
+  });
+
+  it("omits value when null", async () => {
+    const result = await readFields({
+      fields: JSON.stringify([{ ref: "1", value: null }]),
+    });
+    expect(result).toEqual([{ ref: "1", type: "textbox" }]);
+  });
+
+  it("omits value when undefined (missing)", async () => {
+    const result = await readFields({
+      fields: JSON.stringify([{ ref: "1" }]),
+    });
+    expect(result).toEqual([{ ref: "1", type: "textbox" }]);
+  });
+
+  it("throws when fields string is empty", async () => {
+    await expect(readFields({ fields: "" })).rejects.toThrow("fields are required");
+  });
+
+  it("throws when fields string is whitespace", async () => {
+    await expect(readFields({ fields: "   " })).rejects.toThrow("fields are required");
+  });
+
+  it("throws when neither fields nor fieldsFile is provided", async () => {
+    await expect(readFields({})).rejects.toThrow("fields are required");
+  });
+
+  it("throws when fields is not an array", async () => {
+    await expect(readFields({ fields: '{"ref":"1"}' })).rejects.toThrow("fields must be an array");
+  });
+
+  it("throws when field entry is not an object", async () => {
+    await expect(readFields({ fields: '["not-an-object"]' })).rejects.toThrow(
+      "fields[0] must be an object",
+    );
+  });
+
+  it("throws when field entry is null", async () => {
+    await expect(readFields({ fields: "[null]" })).rejects.toThrow("fields[0] must be an object");
+  });
+
+  it("throws when ref is missing", async () => {
+    await expect(
+      readFields({ fields: JSON.stringify([{ value: "hello" }]) }),
+    ).rejects.toThrow("fields[0] must include ref");
+  });
+
+  it("throws when ref is empty string", async () => {
+    await expect(
+      readFields({ fields: JSON.stringify([{ ref: "", value: "hello" }]) }),
+    ).rejects.toThrow("fields[0] must include ref");
+  });
+
+  it("throws for invalid value type (object)", async () => {
+    await expect(
+      readFields({ fields: JSON.stringify([{ ref: "1", value: { nested: true } }]) }),
+    ).rejects.toThrow("fields[0].value must be string, number, boolean, or null");
+  });
+
+  it("throws for invalid value type (array)", async () => {
+    await expect(
+      readFields({ fields: JSON.stringify([{ ref: "1", value: [1, 2] }]) }),
+    ).rejects.toThrow("fields[0].value must be string, number, boolean, or null");
+  });
+
+  it("reports correct index in error for second field", async () => {
+    await expect(
+      readFields({
+        fields: JSON.stringify([{ ref: "1", value: "ok" }, { value: "no-ref" }]),
+      }),
+    ).rejects.toThrow("fields[1] must include ref");
+  });
+
+  it("trims whitespace from ref", async () => {
+    const result = await readFields({
+      fields: JSON.stringify([{ ref: "  5  ", value: "test" }]),
+    });
+    expect(result[0].ref).toBe("5");
+  });
+
+  it("trims whitespace from type", async () => {
+    const result = await readFields({
+      fields: JSON.stringify([{ ref: "1", type: "  checkbox  ", value: true }]),
+    });
+    expect(result[0].type).toBe("checkbox");
+  });
+});

--- a/src/cli/browser-cli-actions-input/shared.ts
+++ b/src/cli/browser-cli-actions-input/shared.ts
@@ -69,9 +69,9 @@ export async function readFields(opts: {
     }
     const rec = entry as Record<string, unknown>;
     const ref = typeof rec.ref === "string" ? rec.ref.trim() : "";
-    const type = typeof rec.type === "string" ? rec.type.trim() : "";
+    const type = typeof rec.type === "string" ? rec.type.trim() : "textbox";
     if (!ref || !type) {
-      throw new Error(`fields[${index}] must include ref and type`);
+      throw new Error(`fields[${index}] must include ref`);
     }
     if (
       typeof rec.value === "string" ||


### PR DESCRIPTION
## Summary
- `browser.act` with `kind: "fill"` fails with `"fields are required"` when field objects omit the `type` property, even though `type` is only used to differentiate checkbox/radio from text inputs
- Default `type` to `"textbox"` when missing or empty across the server route, Playwright layer, and CLI validation
- Update the TypeBox schema to document the expected field shape (`ref`, `type?`, `value?`) so callers know what properties to provide

## Root Cause
Each field in a fill request silently requires both `ref` and `type`. When `type` is omitted (the common case for text inputs), `toStringOrEmpty(undefined)` returns `""`, the field is filtered out, and an empty array triggers the error.

## Changes
- `src/browser/routes/agent.act.ts` - default `type` to `"textbox"` in fill field parsing
- `src/browser/pw-tools-core.interactions.ts` - defensive null guard for `field.type`
- `src/cli/browser-cli-actions-input/shared.ts` - same default in CLI-side `readFields`
- `src/agents/tools/browser-tool.schema.ts` - define `ref`/`type`/`value` in field schema
- `src/browser/server.agent-contract-form-layout-act-commands.test.ts` - 10 new integration tests
- `src/cli/browser-cli-actions-input/shared.readFields.test.ts` - 22 new unit tests

## Test plan
- [x] Existing fill test (with explicit `type`) still passes
- [x] Fill without `type` defaults to textbox
- [x] Mixed fields (some with type, some without)
- [x] Empty/missing/non-array fields rejected
- [x] Fields without `ref` filtered out
- [x] Invalid entries (null, strings) filtered while valid kept
- [x] Empty string and whitespace-only `type` defaults to textbox
- [x] Explicit types (checkbox, radio, textarea) preserved
- [x] CLI `readFields` validates and defaults correctly
- [x] All 36 tests pass, 0 regressions in related suites

Closes #15046

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes `browser.act` `kind: "fill"` failing when callers omit `fields[].type` by defaulting missing/empty types to `"textbox"` in the server route (`src/browser/routes/agent.act.ts`), the Playwright interaction layer (`src/browser/pw-tools-core.interactions.ts`), and the CLI input parser (`src/cli/browser-cli-actions-input/shared.ts`). It also tightens the tool schema for `fields` and adds a fairly comprehensive set of server/CLI tests covering omitted/empty types and mixed/invalid field entries.

The change integrates cleanly with the existing flow: client/CLI build a `fill` request → server parses and filters fields → Playwright layer executes checkbox/radio vs text fill based on `type`.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but schema mismatch can block valid fill requests.
- Runtime changes for defaulting missing `type` are straightforward and well-covered by tests. The main remaining risk is the updated TypeBox tool schema still declaring `fields[].value` as string-only, which conflicts with the accepted runtime types (number/boolean) and can cause tool-level validation failures for valid payloads.
- src/agents/tools/browser-tool.schema.ts

<sub>Last reviewed commit: f8b1fa8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->