### PR TITLE
feat(hooks): add exec:completed and exec:failed hook events

### DIFF
--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -207,7 +207,7 @@ Each event includes:
 
 ```typescript
 {
-  type: 'command' | 'session' | 'agent' | 'gateway',
+  type: 'command' | 'session' | 'agent' | 'gateway' | 'exec',
   action: string,              // e.g., 'new', 'reset', 'stop'
   sessionKey: string,          // Session identifier
   timestamp: Date,             // When the event occurred

--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -1,5 +1,5 @@
 ---
-summary: "Hooks: event-driven automation for commands and lifecycle events"
+summary: "Hooks: event-driven automation for commands, exec completion, and lifecycle events"
 read_when:
   - You want event-driven automation for /new, /reset, /stop, and agent lifecycle events
   - You want to build, install, or debug hooks
@@ -245,6 +245,53 @@ Triggered when agent commands are issued:
 Triggered when the gateway starts:
 
 - **`gateway:startup`**: After channels start and hooks are loaded
+
+### Exec Events
+
+Triggered when an exec/process tool invocation finishes (local, gateway-approved, or remote node):
+
+- **`exec:completed`**: Process exited successfully (exit code 0)
+- **`exec:failed`**: Process exited with non-zero code, was killed by signal, or timed out
+- **`exec`**: General listener — fires for both completed and failed
+
+Exec events fire for **all** exec completions, not just backgrounded ones. The event context includes:
+
+```typescript
+{
+  sessionId: string;      // Process session id
+  slug?: string;          // Human-readable slug (if available)
+  exitCode: number | null;
+  exitSignal: string | number | null;
+  timedOut: boolean;
+  durationMs: number;     // Wall-clock duration
+  tailOutput: string;     // Tail of stdout+stderr
+  backgrounded: boolean;  // Whether the process was backgrounded
+  nodeId?: string;        // Node id (for remote node exec)
+}
+```
+
+**Example: notify when a long training run finishes**
+
+```typescript
+import type { HookHandler } from "../../src/hooks/hooks.js";
+import { isExecCompletionEvent } from "../../src/hooks/hooks.js";
+
+const handler: HookHandler = async (event) => {
+  if (!isExecCompletionEvent(event)) return;
+  if (!event.context.backgrounded) return;  // only care about background jobs
+
+  const { sessionId, exitCode, durationMs, tailOutput } = event.context;
+  const minutes = Math.round(durationMs / 60000);
+  console.log(`[exec-notify] Process ${sessionId} finished (code ${exitCode}) after ${minutes}m`);
+
+  // Push a message back to the session
+  event.messages.push(
+    `🏁 Background process finished (${event.action}, ${minutes}m): ${tailOutput.slice(0, 200)}`
+  );
+};
+
+export default handler;
+```
 
 ### Tool Result Hooks (Plugin API)
 

--- a/src/hooks/exec-completion-hooks.test.ts
+++ b/src/hooks/exec-completion-hooks.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  createExecCompletionEvent,
+  isExecCompletionEvent,
+  createInternalHookEvent,
+  registerInternalHook,
+  unregisterInternalHook,
+  clearInternalHooks,
+  triggerInternalHook,
+} from "./internal-hooks.js";
+import type { ExecCompletionHookContext, InternalHookEvent } from "./internal-hooks.js";
+
+describe("exec completion hook events", () => {
+  beforeEach(() => {
+    clearInternalHooks();
+  });
+
+  it("creates a completed event with correct shape", () => {
+    const ctx: ExecCompletionHookContext = {
+      sessionId: "abc-123",
+      slug: "test-slug",
+      exitCode: 0,
+      exitSignal: null,
+      timedOut: false,
+      durationMs: 1500,
+      tailOutput: "hello world",
+      backgrounded: true,
+    };
+    const event = createExecCompletionEvent("completed", "agent:main:main", ctx);
+
+    expect(event.type).toBe("exec");
+    expect(event.action).toBe("completed");
+    expect(event.sessionKey).toBe("agent:main:main");
+    expect(event.context.exitCode).toBe(0);
+    expect(event.context.sessionId).toBe("abc-123");
+    expect(event.context.tailOutput).toBe("hello world");
+    expect(event.timestamp).toBeInstanceOf(Date);
+    expect(event.messages).toEqual([]);
+  });
+
+  it("creates a failed event for signal kill", () => {
+    const event = createExecCompletionEvent("failed", "agent:main:main", {
+      sessionId: "def-456",
+      exitCode: null,
+      exitSignal: "SIGKILL",
+      timedOut: false,
+      durationMs: 30000,
+      tailOutput: "",
+      backgrounded: false,
+    });
+
+    expect(event.type).toBe("exec");
+    expect(event.action).toBe("failed");
+    expect(event.context.exitSignal).toBe("SIGKILL");
+    expect(event.context.exitCode).toBeNull();
+  });
+
+  it("creates a failed event for timeout", () => {
+    const event = createExecCompletionEvent("failed", "agent:main:main", {
+      sessionId: "ghi-789",
+      exitCode: null,
+      exitSignal: "SIGKILL",
+      timedOut: true,
+      durationMs: 60000,
+      tailOutput: "partial output",
+      backgrounded: true,
+    });
+
+    expect(event.context.timedOut).toBe(true);
+  });
+
+  it("includes nodeId for remote exec", () => {
+    const event = createExecCompletionEvent("completed", "agent:main:main", {
+      sessionId: "node-run-1",
+      exitCode: 0,
+      exitSignal: null,
+      timedOut: false,
+      durationMs: 5000,
+      tailOutput: "done",
+      backgrounded: false,
+      nodeId: "gruntnode1",
+    });
+
+    expect(event.context.nodeId).toBe("gruntnode1");
+  });
+
+  it("isExecCompletionEvent returns true for exec events", () => {
+    const execEvent = createExecCompletionEvent("completed", "test", {
+      sessionId: "s1",
+      exitCode: 0,
+      exitSignal: null,
+      timedOut: false,
+      durationMs: 100,
+      tailOutput: "",
+      backgrounded: false,
+    });
+    expect(isExecCompletionEvent(execEvent)).toBe(true);
+  });
+
+  it("isExecCompletionEvent returns false for non-exec events", () => {
+    const commandEvent = createInternalHookEvent("command", "new", "test");
+    expect(isExecCompletionEvent(commandEvent)).toBe(false);
+  });
+
+  it("triggers exec:completed handlers", async () => {
+    const captured: InternalHookEvent[] = [];
+    const handler = (event: InternalHookEvent) => {
+      captured.push(event);
+    };
+
+    registerInternalHook("exec:completed", handler);
+
+    const event = createExecCompletionEvent("completed", "agent:main:main", {
+      sessionId: "trigger-test",
+      exitCode: 0,
+      exitSignal: null,
+      timedOut: false,
+      durationMs: 200,
+      tailOutput: "success",
+      backgrounded: true,
+    });
+
+    await triggerInternalHook(event);
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0].type).toBe("exec");
+    expect(captured[0].action).toBe("completed");
+
+    unregisterInternalHook("exec:completed", handler);
+  });
+
+  it("triggers exec:failed handlers", async () => {
+    const captured: InternalHookEvent[] = [];
+    registerInternalHook("exec:failed", (event) => {
+      captured.push(event);
+    });
+
+    const event = createExecCompletionEvent("failed", "agent:main:main", {
+      sessionId: "fail-test",
+      exitCode: 1,
+      exitSignal: null,
+      timedOut: false,
+      durationMs: 500,
+      tailOutput: "error occurred",
+      backgrounded: false,
+    });
+
+    await triggerInternalHook(event);
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0].action).toBe("failed");
+  });
+
+  it("triggers general exec handler for both completed and failed", async () => {
+    const captured: InternalHookEvent[] = [];
+    registerInternalHook("exec", (event) => {
+      captured.push(event);
+    });
+
+    const completedEvent = createExecCompletionEvent("completed", "test", {
+      sessionId: "s1",
+      exitCode: 0,
+      exitSignal: null,
+      timedOut: false,
+      durationMs: 100,
+      tailOutput: "",
+      backgrounded: false,
+    });
+
+    const failedEvent = createExecCompletionEvent("failed", "test", {
+      sessionId: "s2",
+      exitCode: 1,
+      exitSignal: null,
+      timedOut: false,
+      durationMs: 100,
+      tailOutput: "",
+      backgrounded: false,
+    });
+
+    await triggerInternalHook(completedEvent);
+    await triggerInternalHook(failedEvent);
+
+    expect(captured).toHaveLength(2);
+    expect(captured[0].action).toBe("completed");
+    expect(captured[1].action).toBe("failed");
+  });
+
+  it("handler errors do not prevent other handlers from running", async () => {
+    const captured: string[] = [];
+
+    registerInternalHook("exec:completed", () => {
+      throw new Error("handler 1 fails");
+    });
+    registerInternalHook("exec:completed", () => {
+      captured.push("handler 2 ran");
+    });
+
+    const event = createExecCompletionEvent("completed", "test", {
+      sessionId: "err-test",
+      exitCode: 0,
+      exitSignal: null,
+      timedOut: false,
+      durationMs: 100,
+      tailOutput: "",
+      backgrounded: false,
+    });
+
+    // Should not throw
+    await triggerInternalHook(event);
+    expect(captured).toEqual(["handler 2 ran"]);
+  });
+});

--- a/src/hooks/hooks.ts
+++ b/src/hooks/hooks.ts
@@ -3,6 +3,8 @@ export * from "./internal-hooks.js";
 export type HookEventType = import("./internal-hooks.js").InternalHookEventType;
 export type HookEvent = import("./internal-hooks.js").InternalHookEvent;
 export type HookHandler = import("./internal-hooks.js").InternalHookHandler;
+export type ExecCompletionEvent = import("./internal-hooks.js").ExecCompletionHookEvent;
+export type ExecCompletionContext = import("./internal-hooks.js").ExecCompletionHookContext;
 
 export {
   registerInternalHook as registerHook,
@@ -11,4 +13,6 @@ export {
   getRegisteredEventKeys as getRegisteredHookEventKeys,
   triggerInternalHook as triggerHook,
   createInternalHookEvent as createHookEvent,
+  createExecCompletionEvent,
+  isExecCompletionEvent,
 } from "./internal-hooks.js";


### PR DESCRIPTION
## Summary

Adds event-driven hook events for exec/process completion, closing a gap in the hooks system where exec lifecycle has no hook coverage.

### Motivation

Currently, the only way to know when a backgrounded exec finishes is via the system-event notification (which requires `notifyOnExit` and only fires for backgrounded processes). Hooks like training monitors, CI pipelines, and deployment scripts need event-driven notification when *any* exec finishes — not just backgrounded ones with `notifyOnExit` set.

This enables patterns like:
- **Training monitor hook**: Get notified when a long ML training run finishes without polling
- **CI/CD hook**: Trigger deployment when a build completes
- **Audit hook**: Log all exec completions with exit codes and duration

### Changes

**New events:**
- `exec:completed` — Process exited with code 0
- `exec:failed` — Non-zero exit, signal kill, or timeout
- `exec` — General listener that fires for both

**Event context payload:**
```typescript
{
  sessionId: string;
  slug?: string;
  exitCode: number | null;
  exitSignal: string | number | null;
  timedOut: boolean;
  durationMs: number;
  tailOutput: string;
  backgrounded: boolean;
  nodeId?: string;  // for remote node exec
}
```

**Coverage:** Fires for all three exec paths:
- Local foreground/background processes
- Gateway-approved (deferred) exec
- Remote node exec via `node.invoke`

### Files Changed

| File | Change |
|------|--------|
| `src/hooks/internal-hooks.ts` | New types + `createExecCompletionEvent()` + `isExecCompletionEvent()` |
| `src/hooks/hooks.ts` | Re-export new types and helpers |
| `src/agents/bash-tools.exec.ts` | Emit hooks at all exit points |
| `src/hooks/exec-completion-hooks.test.ts` | 10 unit tests |
| `docs/automation/hooks.md` | Exec Events section with example hook |

### Test Plan

- [x] 10 unit tests covering event creation, type guards, handler dispatch, error isolation
- [x] Verified all three exec paths emit the hook
- [x] Documentation updated with example training monitor hook

### Design Decisions

- **Fires for ALL exec completions**, not just backgrounded ones — hooks can filter by `context.backgrounded` if they only care about background jobs
- **Fire-and-forget** (`void triggerInternalHook(...)`) — exec completion is not blocked by hook handlers
- **`nodeId` field** distinguishes local vs remote exec for hooks that need to know
- Follows existing hook patterns: same event shape, same error isolation, same registration API

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds new internal hook events for exec completion (`exec:completed`, `exec:failed`, and the general `exec` listener) by extending the hook event type union, introducing `ExecCompletionHookContext`/`ExecCompletionHookEvent` plus helpers (`createExecCompletionEvent`, `isExecCompletionEvent`), and emitting these events from the exec tool across local, gateway-approved (deferred), and node exec paths. It also adds unit tests for event creation/dispatch and updates the hooks docs with an “Exec Events” section and example handler.

Main correctness concern: the local exec timeout path emits an exec completion hook event with `timedOut: false`, even though the execution outcome is settled with `timedOut: true`, so hook consumers won’t be able to detect timeouts reliably from the documented context payload.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a correctness issue in the local timeout hook payload and a couple of documentation/cleanup fixes to address.
- Hook wiring and tests look coherent, but `exec:failed` events for local timeouts currently misreport `context.timedOut`, which breaks the advertised contract for hook consumers. Docs also contain an outdated event type union snippet, and there’s a duplicated JSDoc block in the exec tool file.
- src/agents/bash-tools.exec.ts, docs/automation/hooks.md

<sub>Last reviewed commit: df0775c</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->