### PR TITLE
Pass current message to bootstrap hook context

### DIFF
--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -24,6 +24,7 @@ export async function resolveBootstrapFilesForRun(params: {
   sessionKey?: string;
   sessionId?: string;
   agentId?: string;
+  currentMessage?: string;
 }): Promise<WorkspaceBootstrapFile[]> {
   const sessionKey = params.sessionKey ?? params.sessionId;
   const bootstrapFiles = filterBootstrapFilesForSession(
@@ -37,6 +38,7 @@ export async function resolveBootstrapFilesForRun(params: {
     sessionKey: params.sessionKey,
     sessionId: params.sessionId,
     agentId: params.agentId,
+    currentMessage: params.currentMessage,
   });
 }
 
@@ -46,6 +48,7 @@ export async function resolveBootstrapContextForRun(params: {
   sessionKey?: string;
   sessionId?: string;
   agentId?: string;
+  currentMessage?: string;
   warn?: (message: string) => void;
 }): Promise<{
   bootstrapFiles: WorkspaceBootstrapFile[];

--- a/src/agents/bootstrap-hooks.test.ts
+++ b/src/agents/bootstrap-hooks.test.ts
@@ -37,4 +37,35 @@ describe("applyBootstrapHookOverrides", () => {
     expect(updated).toHaveLength(2);
     expect(updated[1]?.name).toBe("EXTRA.md");
   });
+
+  it("passes currentMessage to hook context", async () => {
+    let receivedMessage: string | undefined;
+    registerInternalHook("agent:bootstrap", (event) => {
+      const context = event.context as AgentBootstrapHookContext;
+      receivedMessage = context.currentMessage;
+    });
+
+    await applyBootstrapHookOverrides({
+      files: [makeFile()],
+      workspaceDir: "/tmp",
+      currentMessage: "hello world",
+    });
+
+    expect(receivedMessage).toBe("hello world");
+  });
+
+  it("currentMessage is undefined when not provided", async () => {
+    let receivedMessage: string | undefined = "sentinel";
+    registerInternalHook("agent:bootstrap", (event) => {
+      const context = event.context as AgentBootstrapHookContext;
+      receivedMessage = context.currentMessage;
+    });
+
+    await applyBootstrapHookOverrides({
+      files: [makeFile()],
+      workspaceDir: "/tmp",
+    });
+
+    expect(receivedMessage).toBeUndefined();
+  });
 });

--- a/src/agents/bootstrap-hooks.ts
+++ b/src/agents/bootstrap-hooks.ts
@@ -11,6 +11,7 @@ export async function applyBootstrapHookOverrides(params: {
   sessionKey?: string;
   sessionId?: string;
   agentId?: string;
+  currentMessage?: string;
 }): Promise<WorkspaceBootstrapFile[]> {
   const sessionKey = params.sessionKey ?? params.sessionId ?? "unknown";
   const agentId =
@@ -23,6 +24,7 @@ export async function applyBootstrapHookOverrides(params: {
     sessionKey: params.sessionKey,
     sessionId: params.sessionId,
     agentId,
+    currentMessage: params.currentMessage,
   };
   const event = createInternalHookEvent("agent", "bootstrap", sessionKey, context);
   await triggerInternalHook(event);

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -196,6 +196,7 @@ export async function runEmbeddedAttempt(
         config: params.config,
         sessionKey: params.sessionKey,
         sessionId: params.sessionId,
+        currentMessage: params.prompt,
         warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),
       });
     const workspaceNotes = hookAdjustedBootstrapFiles.some(

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -17,6 +17,7 @@ export type AgentBootstrapHookContext = {
   sessionKey?: string;
   sessionId?: string;
   agentId?: string;
+  currentMessage?: string;
 };
 
 export type AgentBootstrapHookEvent = InternalHookEvent & {


### PR DESCRIPTION
Bootstrap hooks currently fire before the LLM processes the current user message. The hook context includes the session transcript and workspace info, but not the message that actually triggered the run. This means any hook that wants to do message-aware preprocessing (like contextual retrieval) is always working one turn behind.

This adds an optional `currentMessage` field to `AgentBootstrapHookContext`, populated from `params.prompt` at the run attempt call site.

### Use case

I built a context injection hook that searches memory/docs based on what the user just said and injects relevant snippets into the bootstrap files. Without the current message, the hook can only see the *previous* turn's transcript — so context is always stale by one exchange. With this change, the hook gets the actual triggering message and can provide relevant context immediately.

### Changes

- `internal-hooks.ts`: added `currentMessage?: string` to `AgentBootstrapHookContext`
- `bootstrap-hooks.ts`: accepts and passes `currentMessage` into context
- `bootstrap-files.ts`: threads `currentMessage` through both resolve functions
- `run/attempt.ts`: passes `params.prompt` as `currentMessage`
- 2 new tests verifying the field propagates correctly

Fully backward-compatible — `currentMessage` is optional and existing hooks don't need to change.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds an optional `currentMessage?: string` field to the `AgentBootstrapHookContext` and threads it through bootstrap file/context resolution into the internal `agent:bootstrap` hook event. The embedded runner populates it from `params.prompt` so bootstrap hooks can inspect the triggering user message (instead of relying on the transcript’s previous turn). Two unit tests were added to confirm propagation and the undefined default when not provided.

The change fits cleanly into the existing internal hook architecture: bootstrap files are loaded and filtered, then passed through `applyBootstrapHookOverrides`, which constructs the hook context and triggers `agent:bootstrap`. Existing call sites remain compatible because the new field is optional.

<h3>Confidence Score: 5/5</h3>

- This PR appears safe to merge with minimal risk.
- Changes are additive and backward-compatible (`currentMessage` is optional), with straightforward plumbing through existing bootstrap hook context and a single call-site update. I verified other call sites remain valid and the new tests cover the new field’s propagation and default behavior.
- No files require special attention

<sub>Last reviewed commit: 1db9f03</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->