### PR TITLE
fix(hooks): reuse sessionId for non-cron hook sessions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@grammyjs/runner": "^2.0.3",
         "@grammyjs/transformer-throttler": "^1.2.1",
         "@homebridge/ciao": "^1.3.5",
-        "@larksuiteoapi/node-sdk": "^1.58.0",
+        "@larksuiteoapi/node-sdk": "^1.59.0",
         "@line/bot-sdk": "^10.6.0",
         "@lydell/node-pty": "1.2.0-beta.3",
         "@mariozechner/pi-agent-core": "0.52.9",
@@ -74,13 +74,13 @@
         "@types/proper-lockfile": "^4.1.4",
         "@types/qrcode-terminal": "^0.12.2",
         "@types/ws": "^8.18.1",
-        "@typescript/native-preview": "7.0.0-dev.20260211.1",
+        "@typescript/native-preview": "7.0.0-dev.20260212.1",
         "@vitest/coverage-v8": "^4.0.18",
         "lit": "^3.3.2",
         "ollama": "^0.6.3",
-        "oxfmt": "0.31.0",
-        "oxlint": "^1.46.0",
-        "oxlint-tsgolint": "^0.12.0",
+        "oxfmt": "0.32.0",
+        "oxlint": "^1.47.0",
+        "oxlint-tsgolint": "^0.12.1",
         "rolldown": "1.0.0-rc.4",
         "tsdown": "^0.20.3",
         "tsx": "^4.21.0",
@@ -3670,9 +3670,9 @@
       }
     },
     "node_modules/@oxfmt/binding-android-arm-eabi": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.31.0.tgz",
-      "integrity": "sha512-2A7s+TmsY7xF3yM0VWXq2YJ82Z7Rd7AOKraotyp58Fbk7q9cFZKczW6Zrz/iaMaJYfR/UHDxF3kMR11vayflug==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.32.0.tgz",
+      "integrity": "sha512-DpVyuVzgLH6/MvuB/YD3vXO9CN/o9EdRpA0zXwe/tagP6yfVSFkFWkPqTROdqp0mlzLH5Yl+/m+hOrcM601EbA==",
       "cpu": [
         "arm"
       ],
@@ -3687,9 +3687,9 @@
       }
     },
     "node_modules/@oxfmt/binding-android-arm64": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.31.0.tgz",
-      "integrity": "sha512-3ppKOIf2lQv/BFhRyENWs/oarueppCEnPNo0Az2fKkz63JnenRuJPoHaGRrMHg1oFMUitdYy+YH29Cv5ISZWRQ==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.32.0.tgz",
+      "integrity": "sha512-w1cmNXf9zs0vKLuNgyUF3hZ9VUAS1hBmQGndYJv1OmcVqStBtRTRNxSWkWM0TMkrA9UbvIvM9gfN+ib4Wy6lkQ==",
       "cpu": [
         "arm64"
       ],
@@ -3704,9 +3704,9 @@
       }
     },
     "node_modules/@oxfmt/binding-darwin-arm64": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.31.0.tgz",
-      "integrity": "sha512-eFhNnle077DPRW6QPsBtl/wEzPoqgsB1LlzDRYbbztizObHdCo6Yo8T0hew9+HoYtnVMAP19zcRE7VG9OfqkMw==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.32.0.tgz",
+      "integrity": "sha512-m6wQojz/hn94XdZugFPtdFbOvXbOSYEqPsR2gyLyID3BvcrC2QsJyT1o3gb4BZEGtZrG1NiKVGwDRLM0dHd2mg==",
       "cpu": [
         "arm64"
       ],
@@ -3721,9 +3721,9 @@
       }
     },
     "node_modules/@oxfmt/binding-darwin-x64": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.31.0.tgz",
-      "integrity": "sha512-9UQSunEqokhR1WnlQCgJjkjw13y8PSnBvR98L78beGudTtNSaPMgwE7t/T0IPDibtDTxeEt+IQVKoQJ+8Jo6Lg==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.32.0.tgz",
+      "integrity": "sha512-hN966Uh6r3Erkg2MvRcrJWaB6QpBzP15rxWK/QtkUyD47eItJLsAQ2Hrm88zMIpFZ3COXZLuN3hqgSlUtvB0Xw==",
       "cpu": [
         "x64"
       ],
@@ -3738,9 +3738,9 @@
       }
     },
     "node_modules/@oxfmt/binding-freebsd-x64": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.31.0.tgz",
-      "integrity": "sha512-FHo7ITkDku3kQ8/44nU6IGR1UNH22aqYM3LV2ytV40hWSMVllXFlM+xIVusT+I/SZBAtuFpwEWzyS+Jn4TkkAQ==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.32.0.tgz",
+      "integrity": "sha512-g5UZPGt8tJj263OfSiDGdS54HPa0KgFfspLVAUivVSdoOgsk6DkwVS9nO16xQTDztzBPGxTvrby8WuufF0g86Q==",
       "cpu": [
         "x64"
       ],
@@ -3755,9 +3755,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm-gnueabihf": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.31.0.tgz",
-      "integrity": "sha512-o1NiDlJDO9SOoY5wH8AyPUX60yQcOwu5oVuepi2eetArBp0iFF9qIH1uLlZsUu4QQ6ywqxcJSMjXCqGKC5uQFg==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.32.0.tgz",
+      "integrity": "sha512-F4ZY83/PVQo9ZJhtzoMqbmjqEyTVEZjbaw4x1RhzdfUhddB41ZB2Vrt4eZi7b4a4TP85gjPRHgQBeO0c1jbtaw==",
       "cpu": [
         "arm"
       ],
@@ -3772,9 +3772,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm-musleabihf": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.31.0.tgz",
-      "integrity": "sha512-VXiRxlBz7ivAIjhnnVBEYdjCQ66AsjM0YKxYAcliS0vPqhWKiScIT61gee0DPCVaw1XcuW8u19tfRwpfdYoreg==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.32.0.tgz",
+      "integrity": "sha512-olR37eG16Lzdj9OBSvuoT5RxzgM5xfQEHm1OEjB3M7Wm4KWa5TDWIT13Aiy74GvAN77Hq1+kUKcGVJ/0ynf75g==",
       "cpu": [
         "arm"
       ],
@@ -3789,9 +3789,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm64-gnu": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.31.0.tgz",
-      "integrity": "sha512-ryGPOtPViNcjs8N8Ap+wn7SM6ViiLzR9f0Pu7yprae+wjl6qwnNytzsUe7wcb+jT43DJYmvemFqE8tLVUavYbQ==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.32.0.tgz",
+      "integrity": "sha512-eZhk6AIjRCDeLoXYBhMW7qq/R1YyVi+tGnGfc3kp7AZQrMsFaWtP/bgdCJCTNXMpbMwymtVz0qhSQvR5w2sKcg==",
       "cpu": [
         "arm64"
       ],
@@ -3806,9 +3806,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm64-musl": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.31.0.tgz",
-      "integrity": "sha512-BA3Euxp4bfd+AU3cKPgmHL44BbuBtmQTyAQoVDhX/nqPgbS/auoGp71uQBE4SAPTsQM/FcXxfKmCAdBS7ygF9w==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.32.0.tgz",
+      "integrity": "sha512-UYiqO9MlipntFbdbUKOIo84vuyzrK4TVIs7Etat91WNMFSW54F6OnHq08xa5ZM+K9+cyYMgQPXvYCopuP+LyKw==",
       "cpu": [
         "arm64"
       ],
@@ -3823,9 +3823,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-ppc64-gnu": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.31.0.tgz",
-      "integrity": "sha512-wIiKHulVWE9s6PSftPItucTviyCvjugwPqEyUl1VD47YsFqa5UtQTknBN49NODHJvBgO+eqqUodgRqmNMp3xyw==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.32.0.tgz",
+      "integrity": "sha512-IDH/fxMv+HmKsMtsjEbXqhScCKDIYp38sgGEcn0QKeXMxrda67PPZA7HMfoUwEtFUG+jsO1XJxTrQsL+kQ90xQ==",
       "cpu": [
         "ppc64"
       ],
@@ -3840,9 +3840,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-riscv64-gnu": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.31.0.tgz",
-      "integrity": "sha512-6cM8Jt54bg9V/JoeUWhwnzHAS9Kvgc0oFsxql8PVs/njAGs0H4r+GEU4d+LXZPwI3b3ZUuzpbxlRJzer8KW+Cg==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.32.0.tgz",
+      "integrity": "sha512-bQFGPDa0buYWJFeK2I7ah8wRZjrAgamaG2OAGv+Ua5UMYEnHxmHcv+r8lWUUrwP2oqQGvp1SB8JIVtBbYuAueQ==",
       "cpu": [
         "riscv64"
       ],
@@ -3857,9 +3857,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-riscv64-musl": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.31.0.tgz",
-      "integrity": "sha512-d+b05wXVRGaO6gobTaDqUdBvTXwYc0ro7k1UVC37k4VimLRQOzEZqTwVinqIX3LxTaFCmfO1yG00u9Pct3AKwQ==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.32.0.tgz",
+      "integrity": "sha512-3vFp9DW1ItEKWltADzCFqG5N7rYFToT4ztlhg8wALoo2E2VhveLD88uAF4FF9AxD9NhgHDGmPCV+WZl/Qlj8cQ==",
       "cpu": [
         "riscv64"
       ],
@@ -3874,9 +3874,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-s390x-gnu": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.31.0.tgz",
-      "integrity": "sha512-Q+i2kj8e+two9jTZ3vxmxdNlg++qShe1ODL6xV4+Qt6SnJYniMxfcqphuXli4ft270kuHqd8HSVZs84CsSh1EA==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.32.0.tgz",
+      "integrity": "sha512-Fub2y8S9ImuPzAzpbgkoz/EVTWFFBolxFZYCMRhRZc8cJZI2gl/NlZswqhvJd/U0Jopnwgm/OJ2x128vVzFFWA==",
       "cpu": [
         "s390x"
       ],
@@ -3891,9 +3891,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-x64-gnu": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.31.0.tgz",
-      "integrity": "sha512-F2Z5ffj2okhaQBi92MylwZddKvFPBjrsZnGvvRmVvWRf8WJ0WkKUTtombDgRYNDgoW7GBUUrNNNgWhdB7kVjBA==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.32.0.tgz",
+      "integrity": "sha512-XufwsnV3BF81zO2ofZvhT4FFaMmLTzZEZnC9HpFz/quPeg9C948+kbLlZnsfjmp+1dUxKMCpfmRMqOfF4AOLsA==",
       "cpu": [
         "x64"
       ],
@@ -3908,9 +3908,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-x64-musl": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.31.0.tgz",
-      "integrity": "sha512-Vz7dZQd1yhE5wTWujGanPmZgDtzLZS1PQoeMmUj89p4eMTmpIkvWaIr3uquJCbh8dQd5cPZrFvMmdDgcY5z+GA==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.32.0.tgz",
+      "integrity": "sha512-u2f9tC2qYfikKmA2uGpnEJgManwmk0ZXWs5BB4ga4KDu2JNLdA3i634DGHeMLK9wY9+iRf3t7IYpgN3OVFrvDw==",
       "cpu": [
         "x64"
       ],
@@ -3925,9 +3925,9 @@
       }
     },
     "node_modules/@oxfmt/binding-openharmony-arm64": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.31.0.tgz",
-      "integrity": "sha512-nm0gus6R5V9tM1XaELiiIduUzmdBuCefkwToWKL4UtuFoMCGkigVQnbzHwPTGLVWOEF6wTQucFA8Fn1U8hxxVw==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.32.0.tgz",
+      "integrity": "sha512-5ZXb1wrdbZ1YFXuNXNUCePLlmLDy4sUt4evvzD4Cgumbup5wJgS9PIe5BOaLywUg9f1wTH6lwltj3oT7dFpIGA==",
       "cpu": [
         "arm64"
       ],
@@ -3942,9 +3942,9 @@
       }
     },
     "node_modules/@oxfmt/binding-win32-arm64-msvc": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.31.0.tgz",
-      "integrity": "sha512-mMpvvPpoLD97Q2TMhjWDJSn+ib3kN+H+F4gq9p88zpeef6sqWc9djorJ3JXM2sOZMJ6KZ+1kSJfe0rkji74Pog==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.32.0.tgz",
+      "integrity": "sha512-IGSMm/Agq+IA0++aeAV/AGPfjcBdjrsajB5YpM3j7cMcwoYgUTi/k2YwAmsHH3ueZUE98pSM/Ise2J7HtyRjOA==",
       "cpu": [
         "arm64"
       ],
@@ -3959,9 +3959,9 @@
       }
     },
     "node_modules/@oxfmt/binding-win32-ia32-msvc": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.31.0.tgz",
-      "integrity": "sha512-zTngbPyrTDBYJFVQa4OJldM6w1Rqzi8c0/eFxAEbZRoj6x149GkyMkAY3kM+09ZhmszFitCML2S3p10NE2XmHA==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.32.0.tgz",
+      "integrity": "sha512-H/9gsuqXmceWMsVoCPZhtJG2jLbnBeKr7xAXm2zuKpxLVF7/2n0eh7ocOLB6t+L1ARE76iORuUsRMnuGjj8FjQ==",
       "cpu": [
         "ia32"
       ],
@@ -3976,9 +3976,9 @@
       }
     },
     "node_modules/@oxfmt/binding-win32-x64-msvc": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.31.0.tgz",
-      "integrity": "sha512-TB30D+iRLe6eUbc/utOA93+FNz5C6vXSb/TEhwvlODhKYZZSSKn/lFpYzZC7bdhx3a8m4Jq8fEUoCJ6lKnzdpA==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.32.0.tgz",
+      "integrity": "sha512-fF8VIOeligq+mA6KfKvWtFRXbf0EFy73TdR6ZnNejdJRM8VWN1e3QFhYgIwD7O8jBrQsd7EJbUpkAr/YlUOokg==",
       "cpu": [
         "x64"
       ],
@@ -6300,28 +6300,28 @@
       }
     },
     "node_modules/@typescript/native-preview": {
-      "version": "7.0.0-dev.20260211.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20260211.1.tgz",
-      "integrity": "sha512-6chHuRpRMTFuSnlGdm+L72q3PBcsH/Tm4KZpCe90T+0CPbJZVewNGEl3PNOqsLBv9LYni4kVTgVXpYNzKXJA5g==",
+      "version": "7.0.0-dev.20260212.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20260212.1.tgz",
+      "integrity": "sha512-VHAVbp8d2VGm90EK//brKIYvT3iPrLXMq4/LApCdkKww/Hfn33zPRVmig4rswNaJiVu8XhcdHld5yfMw6d5A9Q==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsgo": "bin/tsgo.js"
       },
       "optionalDependencies": {
-        "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260211.1",
-        "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260211.1",
-        "@typescript/native-preview-linux-arm": "7.0.0-dev.20260211.1",
-        "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260211.1",
-        "@typescript/native-preview-linux-x64": "7.0.0-dev.20260211.1",
-        "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260211.1",
-        "@typescript/native-preview-win32-x64": "7.0.0-dev.20260211.1"
+        "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260212.1",
+        "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260212.1",
+        "@typescript/native-preview-linux-arm": "7.0.0-dev.20260212.1",
+        "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260212.1",
+        "@typescript/native-preview-linux-x64": "7.0.0-dev.20260212.1",
+        "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260212.1",
+        "@typescript/native-preview-win32-x64": "7.0.0-dev.20260212.1"
       }
     },
     "node_modules/@typescript/native-preview-darwin-arm64": {
-      "version": "7.0.0-dev.20260211.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20260211.1.tgz",
-      "integrity": "sha512-xRuGrUMmC8/CapuCdlIT/Iw3xq9UQAH2vjReHA3eE4zkK5VLRNOEJFpXduBwBOwTaxfhAZl74Ht0eNg/PwSqVA==",
+      "version": "7.0.0-dev.20260212.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20260212.1.tgz",
+      "integrity": "sha512-HH4bOVbNW6ITv00VSaE3aZjCuU2d+amgFZKdhbq7NpcJDxFvxyy9GT9gkKV0D1DXz5qoxZIcyBEIbwrhABb9vg==",
       "cpu": [
         "arm64"
       ],
@@ -6333,9 +6333,9 @@
       ]
     },
     "node_modules/@typescript/native-preview-darwin-x64": {
-      "version": "7.0.0-dev.20260211.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20260211.1.tgz",
-      "integrity": "sha512-rYbpbt395w8YZgNotEZQxBoa9p7xHDhK3TH2xCV8pZf5GVsBqi76NHAS1EXiJ3njmmx7OdyPPNjCNfdmQkAgqg==",
+      "version": "7.0.0-dev.20260212.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20260212.1.tgz",
+      "integrity": "sha512-vnQ2xRJscbtyS/jHO5QY2xAZ3c11Yn1ZAor/XODDrxd7N7jIrm0Vtc2CIwsi51oncLS1SZtUd9cHZmJg5zUJrQ==",
       "cpu": [
         "x64"
       ],
@@ -6347,9 +6347,9 @@
       ]
     },
     "node_modules/@typescript/native-preview-linux-arm": {
-      "version": "7.0.0-dev.20260211.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20260211.1.tgz",
-      "integrity": "sha512-v72/IFGifEyt5ZFjmX5G4cnCL2JU2kXnfpJ/9HS7FJFTjvY6mT2mnahTq/emVXf+5y4ee7vRLukQP5bPJqiaWQ==",
+      "version": "7.0.0-dev.20260212.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20260212.1.tgz",
+      "integrity": "sha512-T8sF3YtYtODhWnFNhVuL/GABCHpKJs6ZxTtSC1LtXoM/CE0Ai06k5WKOxJG5rJrBtLIW+Dempk7qKPfhNliDTA==",
       "cpu": [
         "arm"
       ],
@@ -6361,9 +6361,9 @@
       ]
     },
     "node_modules/@typescript/native-preview-linux-arm64": {
-      "version": "7.0.0-dev.20260211.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20260211.1.tgz",
-      "integrity": "sha512-10rfJdz5wxaCh643qaQJkPVF500eCX3HWHyTXaA2bifSHZzeyjYzFL5EOzNKZuurGofJYPWXDXmmBOBX4au8rA==",
+      "version": "7.0.0-dev.20260212.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20260212.1.tgz",
+      "integrity": "sha512-suA5OryrhL/tE7AiQXiNNV88XwKEOfO0sypJQj+cfg/fpQ2trFyDZcsdMLYVZ7J0zirDai6H3TDETYYoNFE1/g==",
       "cpu": [
         "arm64"
       ],
@@ -6375,9 +6375,9 @@
       ]
     },
     "node_modules/@typescript/native-preview-linux-x64": {
-      "version": "7.0.0-dev.20260211.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20260211.1.tgz",
-      "integrity": "sha512-xpJ1KFvMXklzpqpysrzwlDhhFYJnXZyaubyX3xLPO0Ct9Beuf9TzYa1tzO4+cllQB6aSQ1PgPIVbbzB+B5Gfsw==",
+      "version": "7.0.0-dev.20260212.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20260212.1.tgz",
+      "integrity": "sha512-w687rpZKJM0Lev0ya0GYJlnFCITTUmN8jDpwLXn60jrNEZzL2J4F7biA6papr2sMdKRfWvRklhjB1TKHbJ6FKA==",
       "cpu": [
         "x64"
       ],
@@ -6389,9 +6389,9 @@
       ]
     },
     "node_modules/@typescript/native-preview-win32-arm64": {
-      "version": "7.0.0-dev.20260211.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20260211.1.tgz",
-      "integrity": "sha512-ccqtRDV76NTLZ1lWrYBPom2b0+4c5CWfG5jXLcZVkei5/DUKScV7/dpQYcoQMNekGppj8IerdAw4G3FlDcOU7w==",
+      "version": "7.0.0-dev.20260212.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20260212.1.tgz",
+      "integrity": "sha512-NhCXPQF6OTNEZl8iwRE1ef/zHiqit5p3m7hdT2vfAOi1iA2eoazX0zTSdhgjX83o9cLjen3V1R7nbSYehFHaqw==",
       "cpu": [
         "arm64"
       ],
@@ -6403,9 +6403,9 @@
       ]
     },
     "node_modules/@typescript/native-preview-win32-x64": {
-      "version": "7.0.0-dev.20260211.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20260211.1.tgz",
-      "integrity": "sha512-ZGMsSiNUuBEP4gKfuxBPuXj0ebSVS51hYy8fbYldluZvPTiphhOBkSm911h89HYXhTK/1P4x00n58eKd0JL7zQ==",
+      "version": "7.0.0-dev.20260212.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20260212.1.tgz",
+      "integrity": "sha512-0yqSBlASRx9rqM12QvaWc227w+bIsuI2EwAiNsoB1ybRbCXoXMah1RQlfjjTpD02eWCe/029vwrNhq+FLn7Z8A==",
       "cpu": [
         "x64"
       ],
@@ -10632,9 +10632,9 @@
       }
     },
     "node_modules/oxfmt": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.31.0.tgz",
-      "integrity": "sha512-ukl7nojEuJUGbqR4ijC0Z/7a6BYpD4RxLS2UsyJKgbeZfx6TNrsa48veG0z2yQbhTx1nVnes4GIcqMn7n2jFtw==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.32.0.tgz",
+      "integrity": "sha512-KArQhGzt/Y8M1eSAX98Y8DLtGYYDQhkR55THUPY5VNcpFQ+9nRZkL3ULXhagHMD2hIvjy8JSeEQEP5/yYJSrLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10650,25 +10650,25 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxfmt/binding-android-arm-eabi": "0.31.0",
-        "@oxfmt/binding-android-arm64": "0.31.0",
-        "@oxfmt/binding-darwin-arm64": "0.31.0",
-        "@oxfmt/binding-darwin-x64": "0.31.0",
-        "@oxfmt/binding-freebsd-x64": "0.31.0",
-        "@oxfmt/binding-linux-arm-gnueabihf": "0.31.0",
-        "@oxfmt/binding-linux-arm-musleabihf": "0.31.0",
-        "@oxfmt/binding-linux-arm64-gnu": "0.31.0",
-        "@oxfmt/binding-linux-arm64-musl": "0.31.0",
-        "@oxfmt/binding-linux-ppc64-gnu": "0.31.0",
-        "@oxfmt/binding-linux-riscv64-gnu": "0.31.0",
-        "@oxfmt/binding-linux-riscv64-musl": "0.31.0",
-        "@oxfmt/binding-linux-s390x-gnu": "0.31.0",
-        "@oxfmt/binding-linux-x64-gnu": "0.31.0",
-        "@oxfmt/binding-linux-x64-musl": "0.31.0",
-        "@oxfmt/binding-openharmony-arm64": "0.31.0",
-        "@oxfmt/binding-win32-arm64-msvc": "0.31.0",
-        "@oxfmt/binding-win32-ia32-msvc": "0.31.0",
-        "@oxfmt/binding-win32-x64-msvc": "0.31.0"
+        "@oxfmt/binding-android-arm-eabi": "0.32.0",
+        "@oxfmt/binding-android-arm64": "0.32.0",
+        "@oxfmt/binding-darwin-arm64": "0.32.0",
+        "@oxfmt/binding-darwin-x64": "0.32.0",
+        "@oxfmt/binding-freebsd-x64": "0.32.0",
+        "@oxfmt/binding-linux-arm-gnueabihf": "0.32.0",
+        "@oxfmt/binding-linux-arm-musleabihf": "0.32.0",
+        "@oxfmt/binding-linux-arm64-gnu": "0.32.0",
+        "@oxfmt/binding-linux-arm64-musl": "0.32.0",
+        "@oxfmt/binding-linux-ppc64-gnu": "0.32.0",
+        "@oxfmt/binding-linux-riscv64-gnu": "0.32.0",
+        "@oxfmt/binding-linux-riscv64-musl": "0.32.0",
+        "@oxfmt/binding-linux-s390x-gnu": "0.32.0",
+        "@oxfmt/binding-linux-x64-gnu": "0.32.0",
+        "@oxfmt/binding-linux-x64-musl": "0.32.0",
+        "@oxfmt/binding-openharmony-arm64": "0.32.0",
+        "@oxfmt/binding-win32-arm64-msvc": "0.32.0",
+        "@oxfmt/binding-win32-ia32-msvc": "0.32.0",
+        "@oxfmt/binding-win32-x64-msvc": "0.32.0"
       }
     },
     "node_modules/oxlint": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@grammyjs/runner": "^2.0.3",
         "@grammyjs/transformer-throttler": "^1.2.1",
         "@homebridge/ciao": "^1.3.5",
-        "@larksuiteoapi/node-sdk": "^1.59.0",
+        "@larksuiteoapi/node-sdk": "^1.58.0",
         "@line/bot-sdk": "^10.6.0",
         "@lydell/node-pty": "1.2.0-beta.3",
         "@mariozechner/pi-agent-core": "0.52.9",
@@ -74,13 +74,13 @@
         "@types/proper-lockfile": "^4.1.4",
         "@types/qrcode-terminal": "^0.12.2",
         "@types/ws": "^8.18.1",
-        "@typescript/native-preview": "7.0.0-dev.20260212.1",
+        "@typescript/native-preview": "7.0.0-dev.20260211.1",
         "@vitest/coverage-v8": "^4.0.18",
         "lit": "^3.3.2",
         "ollama": "^0.6.3",
-        "oxfmt": "0.32.0",
-        "oxlint": "^1.47.0",
-        "oxlint-tsgolint": "^0.12.1",
+        "oxfmt": "0.31.0",
+        "oxlint": "^1.46.0",
+        "oxlint-tsgolint": "^0.12.0",
         "rolldown": "1.0.0-rc.4",
         "tsdown": "^0.20.3",
         "tsx": "^4.21.0",
@@ -3670,9 +3670,9 @@
       }
     },
     "node_modules/@oxfmt/binding-android-arm-eabi": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.32.0.tgz",
-      "integrity": "sha512-DpVyuVzgLH6/MvuB/YD3vXO9CN/o9EdRpA0zXwe/tagP6yfVSFkFWkPqTROdqp0mlzLH5Yl+/m+hOrcM601EbA==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.31.0.tgz",
+      "integrity": "sha512-2A7s+TmsY7xF3yM0VWXq2YJ82Z7Rd7AOKraotyp58Fbk7q9cFZKczW6Zrz/iaMaJYfR/UHDxF3kMR11vayflug==",
       "cpu": [
         "arm"
       ],
@@ -3687,9 +3687,9 @@
       }
     },
     "node_modules/@oxfmt/binding-android-arm64": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.32.0.tgz",
-      "integrity": "sha512-w1cmNXf9zs0vKLuNgyUF3hZ9VUAS1hBmQGndYJv1OmcVqStBtRTRNxSWkWM0TMkrA9UbvIvM9gfN+ib4Wy6lkQ==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.31.0.tgz",
+      "integrity": "sha512-3ppKOIf2lQv/BFhRyENWs/oarueppCEnPNo0Az2fKkz63JnenRuJPoHaGRrMHg1oFMUitdYy+YH29Cv5ISZWRQ==",
       "cpu": [
         "arm64"
       ],
@@ -3704,9 +3704,9 @@
       }
     },
     "node_modules/@oxfmt/binding-darwin-arm64": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.32.0.tgz",
-      "integrity": "sha512-m6wQojz/hn94XdZugFPtdFbOvXbOSYEqPsR2gyLyID3BvcrC2QsJyT1o3gb4BZEGtZrG1NiKVGwDRLM0dHd2mg==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.31.0.tgz",
+      "integrity": "sha512-eFhNnle077DPRW6QPsBtl/wEzPoqgsB1LlzDRYbbztizObHdCo6Yo8T0hew9+HoYtnVMAP19zcRE7VG9OfqkMw==",
       "cpu": [
         "arm64"
       ],
@@ -3721,9 +3721,9 @@
       }
     },
     "node_modules/@oxfmt/binding-darwin-x64": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.32.0.tgz",
-      "integrity": "sha512-hN966Uh6r3Erkg2MvRcrJWaB6QpBzP15rxWK/QtkUyD47eItJLsAQ2Hrm88zMIpFZ3COXZLuN3hqgSlUtvB0Xw==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.31.0.tgz",
+      "integrity": "sha512-9UQSunEqokhR1WnlQCgJjkjw13y8PSnBvR98L78beGudTtNSaPMgwE7t/T0IPDibtDTxeEt+IQVKoQJ+8Jo6Lg==",
       "cpu": [
         "x64"
       ],
@@ -3738,9 +3738,9 @@
       }
     },
     "node_modules/@oxfmt/binding-freebsd-x64": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.32.0.tgz",
-      "integrity": "sha512-g5UZPGt8tJj263OfSiDGdS54HPa0KgFfspLVAUivVSdoOgsk6DkwVS9nO16xQTDztzBPGxTvrby8WuufF0g86Q==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.31.0.tgz",
+      "integrity": "sha512-FHo7ITkDku3kQ8/44nU6IGR1UNH22aqYM3LV2ytV40hWSMVllXFlM+xIVusT+I/SZBAtuFpwEWzyS+Jn4TkkAQ==",
       "cpu": [
         "x64"
       ],
@@ -3755,9 +3755,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm-gnueabihf": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.32.0.tgz",
-      "integrity": "sha512-F4ZY83/PVQo9ZJhtzoMqbmjqEyTVEZjbaw4x1RhzdfUhddB41ZB2Vrt4eZi7b4a4TP85gjPRHgQBeO0c1jbtaw==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.31.0.tgz",
+      "integrity": "sha512-o1NiDlJDO9SOoY5wH8AyPUX60yQcOwu5oVuepi2eetArBp0iFF9qIH1uLlZsUu4QQ6ywqxcJSMjXCqGKC5uQFg==",
       "cpu": [
         "arm"
       ],
@@ -3772,9 +3772,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm-musleabihf": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.32.0.tgz",
-      "integrity": "sha512-olR37eG16Lzdj9OBSvuoT5RxzgM5xfQEHm1OEjB3M7Wm4KWa5TDWIT13Aiy74GvAN77Hq1+kUKcGVJ/0ynf75g==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.31.0.tgz",
+      "integrity": "sha512-VXiRxlBz7ivAIjhnnVBEYdjCQ66AsjM0YKxYAcliS0vPqhWKiScIT61gee0DPCVaw1XcuW8u19tfRwpfdYoreg==",
       "cpu": [
         "arm"
       ],
@@ -3789,9 +3789,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm64-gnu": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.32.0.tgz",
-      "integrity": "sha512-eZhk6AIjRCDeLoXYBhMW7qq/R1YyVi+tGnGfc3kp7AZQrMsFaWtP/bgdCJCTNXMpbMwymtVz0qhSQvR5w2sKcg==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.31.0.tgz",
+      "integrity": "sha512-ryGPOtPViNcjs8N8Ap+wn7SM6ViiLzR9f0Pu7yprae+wjl6qwnNytzsUe7wcb+jT43DJYmvemFqE8tLVUavYbQ==",
       "cpu": [
         "arm64"
       ],
@@ -3806,9 +3806,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-arm64-musl": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.32.0.tgz",
-      "integrity": "sha512-UYiqO9MlipntFbdbUKOIo84vuyzrK4TVIs7Etat91WNMFSW54F6OnHq08xa5ZM+K9+cyYMgQPXvYCopuP+LyKw==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.31.0.tgz",
+      "integrity": "sha512-BA3Euxp4bfd+AU3cKPgmHL44BbuBtmQTyAQoVDhX/nqPgbS/auoGp71uQBE4SAPTsQM/FcXxfKmCAdBS7ygF9w==",
       "cpu": [
         "arm64"
       ],
@@ -3823,9 +3823,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-ppc64-gnu": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.32.0.tgz",
-      "integrity": "sha512-IDH/fxMv+HmKsMtsjEbXqhScCKDIYp38sgGEcn0QKeXMxrda67PPZA7HMfoUwEtFUG+jsO1XJxTrQsL+kQ90xQ==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.31.0.tgz",
+      "integrity": "sha512-wIiKHulVWE9s6PSftPItucTviyCvjugwPqEyUl1VD47YsFqa5UtQTknBN49NODHJvBgO+eqqUodgRqmNMp3xyw==",
       "cpu": [
         "ppc64"
       ],
@@ -3840,9 +3840,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-riscv64-gnu": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.32.0.tgz",
-      "integrity": "sha512-bQFGPDa0buYWJFeK2I7ah8wRZjrAgamaG2OAGv+Ua5UMYEnHxmHcv+r8lWUUrwP2oqQGvp1SB8JIVtBbYuAueQ==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.31.0.tgz",
+      "integrity": "sha512-6cM8Jt54bg9V/JoeUWhwnzHAS9Kvgc0oFsxql8PVs/njAGs0H4r+GEU4d+LXZPwI3b3ZUuzpbxlRJzer8KW+Cg==",
       "cpu": [
         "riscv64"
       ],
@@ -3857,9 +3857,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-riscv64-musl": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.32.0.tgz",
-      "integrity": "sha512-3vFp9DW1ItEKWltADzCFqG5N7rYFToT4ztlhg8wALoo2E2VhveLD88uAF4FF9AxD9NhgHDGmPCV+WZl/Qlj8cQ==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.31.0.tgz",
+      "integrity": "sha512-d+b05wXVRGaO6gobTaDqUdBvTXwYc0ro7k1UVC37k4VimLRQOzEZqTwVinqIX3LxTaFCmfO1yG00u9Pct3AKwQ==",
       "cpu": [
         "riscv64"
       ],
@@ -3874,9 +3874,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-s390x-gnu": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.32.0.tgz",
-      "integrity": "sha512-Fub2y8S9ImuPzAzpbgkoz/EVTWFFBolxFZYCMRhRZc8cJZI2gl/NlZswqhvJd/U0Jopnwgm/OJ2x128vVzFFWA==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.31.0.tgz",
+      "integrity": "sha512-Q+i2kj8e+two9jTZ3vxmxdNlg++qShe1ODL6xV4+Qt6SnJYniMxfcqphuXli4ft270kuHqd8HSVZs84CsSh1EA==",
       "cpu": [
         "s390x"
       ],
@@ -3891,9 +3891,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-x64-gnu": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.32.0.tgz",
-      "integrity": "sha512-XufwsnV3BF81zO2ofZvhT4FFaMmLTzZEZnC9HpFz/quPeg9C948+kbLlZnsfjmp+1dUxKMCpfmRMqOfF4AOLsA==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.31.0.tgz",
+      "integrity": "sha512-F2Z5ffj2okhaQBi92MylwZddKvFPBjrsZnGvvRmVvWRf8WJ0WkKUTtombDgRYNDgoW7GBUUrNNNgWhdB7kVjBA==",
       "cpu": [
         "x64"
       ],
@@ -3908,9 +3908,9 @@
       }
     },
     "node_modules/@oxfmt/binding-linux-x64-musl": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.32.0.tgz",
-      "integrity": "sha512-u2f9tC2qYfikKmA2uGpnEJgManwmk0ZXWs5BB4ga4KDu2JNLdA3i634DGHeMLK9wY9+iRf3t7IYpgN3OVFrvDw==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.31.0.tgz",
+      "integrity": "sha512-Vz7dZQd1yhE5wTWujGanPmZgDtzLZS1PQoeMmUj89p4eMTmpIkvWaIr3uquJCbh8dQd5cPZrFvMmdDgcY5z+GA==",
       "cpu": [
         "x64"
       ],
@@ -3925,9 +3925,9 @@
       }
     },
     "node_modules/@oxfmt/binding-openharmony-arm64": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.32.0.tgz",
-      "integrity": "sha512-5ZXb1wrdbZ1YFXuNXNUCePLlmLDy4sUt4evvzD4Cgumbup5wJgS9PIe5BOaLywUg9f1wTH6lwltj3oT7dFpIGA==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.31.0.tgz",
+      "integrity": "sha512-nm0gus6R5V9tM1XaELiiIduUzmdBuCefkwToWKL4UtuFoMCGkigVQnbzHwPTGLVWOEF6wTQucFA8Fn1U8hxxVw==",
       "cpu": [
         "arm64"
       ],
@@ -3942,9 +3942,9 @@
       }
     },
     "node_modules/@oxfmt/binding-win32-arm64-msvc": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.32.0.tgz",
-      "integrity": "sha512-IGSMm/Agq+IA0++aeAV/AGPfjcBdjrsajB5YpM3j7cMcwoYgUTi/k2YwAmsHH3ueZUE98pSM/Ise2J7HtyRjOA==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.31.0.tgz",
+      "integrity": "sha512-mMpvvPpoLD97Q2TMhjWDJSn+ib3kN+H+F4gq9p88zpeef6sqWc9djorJ3JXM2sOZMJ6KZ+1kSJfe0rkji74Pog==",
       "cpu": [
         "arm64"
       ],
@@ -3959,9 +3959,9 @@
       }
     },
     "node_modules/@oxfmt/binding-win32-ia32-msvc": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.32.0.tgz",
-      "integrity": "sha512-H/9gsuqXmceWMsVoCPZhtJG2jLbnBeKr7xAXm2zuKpxLVF7/2n0eh7ocOLB6t+L1ARE76iORuUsRMnuGjj8FjQ==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.31.0.tgz",
+      "integrity": "sha512-zTngbPyrTDBYJFVQa4OJldM6w1Rqzi8c0/eFxAEbZRoj6x149GkyMkAY3kM+09ZhmszFitCML2S3p10NE2XmHA==",
       "cpu": [
         "ia32"
       ],
@@ -3976,9 +3976,9 @@
       }
     },
     "node_modules/@oxfmt/binding-win32-x64-msvc": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.32.0.tgz",
-      "integrity": "sha512-fF8VIOeligq+mA6KfKvWtFRXbf0EFy73TdR6ZnNejdJRM8VWN1e3QFhYgIwD7O8jBrQsd7EJbUpkAr/YlUOokg==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.31.0.tgz",
+      "integrity": "sha512-TB30D+iRLe6eUbc/utOA93+FNz5C6vXSb/TEhwvlODhKYZZSSKn/lFpYzZC7bdhx3a8m4Jq8fEUoCJ6lKnzdpA==",
       "cpu": [
         "x64"
       ],
@@ -6300,28 +6300,28 @@
       }
     },
     "node_modules/@typescript/native-preview": {
-      "version": "7.0.0-dev.20260212.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20260212.1.tgz",
-      "integrity": "sha512-VHAVbp8d2VGm90EK//brKIYvT3iPrLXMq4/LApCdkKww/Hfn33zPRVmig4rswNaJiVu8XhcdHld5yfMw6d5A9Q==",
+      "version": "7.0.0-dev.20260211.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20260211.1.tgz",
+      "integrity": "sha512-6chHuRpRMTFuSnlGdm+L72q3PBcsH/Tm4KZpCe90T+0CPbJZVewNGEl3PNOqsLBv9LYni4kVTgVXpYNzKXJA5g==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsgo": "bin/tsgo.js"
       },
       "optionalDependencies": {
-        "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260212.1",
-        "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260212.1",
-        "@typescript/native-preview-linux-arm": "7.0.0-dev.20260212.1",
-        "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260212.1",
-        "@typescript/native-preview-linux-x64": "7.0.0-dev.20260212.1",
-        "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260212.1",
-        "@typescript/native-preview-win32-x64": "7.0.0-dev.20260212.1"
+        "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260211.1",
+        "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260211.1",
+        "@typescript/native-preview-linux-arm": "7.0.0-dev.20260211.1",
+        "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260211.1",
+        "@typescript/native-preview-linux-x64": "7.0.0-dev.20260211.1",
+        "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260211.1",
+        "@typescript/native-preview-win32-x64": "7.0.0-dev.20260211.1"
       }
     },
     "node_modules/@typescript/native-preview-darwin-arm64": {
-      "version": "7.0.0-dev.20260212.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20260212.1.tgz",
-      "integrity": "sha512-HH4bOVbNW6ITv00VSaE3aZjCuU2d+amgFZKdhbq7NpcJDxFvxyy9GT9gkKV0D1DXz5qoxZIcyBEIbwrhABb9vg==",
+      "version": "7.0.0-dev.20260211.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20260211.1.tgz",
+      "integrity": "sha512-xRuGrUMmC8/CapuCdlIT/Iw3xq9UQAH2vjReHA3eE4zkK5VLRNOEJFpXduBwBOwTaxfhAZl74Ht0eNg/PwSqVA==",
       "cpu": [
         "arm64"
       ],
@@ -6333,9 +6333,9 @@
       ]
     },
     "node_modules/@typescript/native-preview-darwin-x64": {
-      "version": "7.0.0-dev.20260212.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20260212.1.tgz",
-      "integrity": "sha512-vnQ2xRJscbtyS/jHO5QY2xAZ3c11Yn1ZAor/XODDrxd7N7jIrm0Vtc2CIwsi51oncLS1SZtUd9cHZmJg5zUJrQ==",
+      "version": "7.0.0-dev.20260211.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20260211.1.tgz",
+      "integrity": "sha512-rYbpbt395w8YZgNotEZQxBoa9p7xHDhK3TH2xCV8pZf5GVsBqi76NHAS1EXiJ3njmmx7OdyPPNjCNfdmQkAgqg==",
       "cpu": [
         "x64"
       ],
@@ -6347,9 +6347,9 @@
       ]
     },
     "node_modules/@typescript/native-preview-linux-arm": {
-      "version": "7.0.0-dev.20260212.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20260212.1.tgz",
-      "integrity": "sha512-T8sF3YtYtODhWnFNhVuL/GABCHpKJs6ZxTtSC1LtXoM/CE0Ai06k5WKOxJG5rJrBtLIW+Dempk7qKPfhNliDTA==",
+      "version": "7.0.0-dev.20260211.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20260211.1.tgz",
+      "integrity": "sha512-v72/IFGifEyt5ZFjmX5G4cnCL2JU2kXnfpJ/9HS7FJFTjvY6mT2mnahTq/emVXf+5y4ee7vRLukQP5bPJqiaWQ==",
       "cpu": [
         "arm"
       ],
@@ -6361,9 +6361,9 @@
       ]
     },
     "node_modules/@typescript/native-preview-linux-arm64": {
-      "version": "7.0.0-dev.20260212.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20260212.1.tgz",
-      "integrity": "sha512-suA5OryrhL/tE7AiQXiNNV88XwKEOfO0sypJQj+cfg/fpQ2trFyDZcsdMLYVZ7J0zirDai6H3TDETYYoNFE1/g==",
+      "version": "7.0.0-dev.20260211.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20260211.1.tgz",
+      "integrity": "sha512-10rfJdz5wxaCh643qaQJkPVF500eCX3HWHyTXaA2bifSHZzeyjYzFL5EOzNKZuurGofJYPWXDXmmBOBX4au8rA==",
       "cpu": [
         "arm64"
       ],
@@ -6375,9 +6375,9 @@
       ]
     },
     "node_modules/@typescript/native-preview-linux-x64": {
-      "version": "7.0.0-dev.20260212.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20260212.1.tgz",
-      "integrity": "sha512-w687rpZKJM0Lev0ya0GYJlnFCITTUmN8jDpwLXn60jrNEZzL2J4F7biA6papr2sMdKRfWvRklhjB1TKHbJ6FKA==",
+      "version": "7.0.0-dev.20260211.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20260211.1.tgz",
+      "integrity": "sha512-xpJ1KFvMXklzpqpysrzwlDhhFYJnXZyaubyX3xLPO0Ct9Beuf9TzYa1tzO4+cllQB6aSQ1PgPIVbbzB+B5Gfsw==",
       "cpu": [
         "x64"
       ],
@@ -6389,9 +6389,9 @@
       ]
     },
     "node_modules/@typescript/native-preview-win32-arm64": {
-      "version": "7.0.0-dev.20260212.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20260212.1.tgz",
-      "integrity": "sha512-NhCXPQF6OTNEZl8iwRE1ef/zHiqit5p3m7hdT2vfAOi1iA2eoazX0zTSdhgjX83o9cLjen3V1R7nbSYehFHaqw==",
+      "version": "7.0.0-dev.20260211.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20260211.1.tgz",
+      "integrity": "sha512-ccqtRDV76NTLZ1lWrYBPom2b0+4c5CWfG5jXLcZVkei5/DUKScV7/dpQYcoQMNekGppj8IerdAw4G3FlDcOU7w==",
       "cpu": [
         "arm64"
       ],
@@ -6403,9 +6403,9 @@
       ]
     },
     "node_modules/@typescript/native-preview-win32-x64": {
-      "version": "7.0.0-dev.20260212.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20260212.1.tgz",
-      "integrity": "sha512-0yqSBlASRx9rqM12QvaWc227w+bIsuI2EwAiNsoB1ybRbCXoXMah1RQlfjjTpD02eWCe/029vwrNhq+FLn7Z8A==",
+      "version": "7.0.0-dev.20260211.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20260211.1.tgz",
+      "integrity": "sha512-ZGMsSiNUuBEP4gKfuxBPuXj0ebSVS51hYy8fbYldluZvPTiphhOBkSm911h89HYXhTK/1P4x00n58eKd0JL7zQ==",
       "cpu": [
         "x64"
       ],
@@ -10632,9 +10632,9 @@
       }
     },
     "node_modules/oxfmt": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.32.0.tgz",
-      "integrity": "sha512-KArQhGzt/Y8M1eSAX98Y8DLtGYYDQhkR55THUPY5VNcpFQ+9nRZkL3ULXhagHMD2hIvjy8JSeEQEP5/yYJSrLA==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.31.0.tgz",
+      "integrity": "sha512-ukl7nojEuJUGbqR4ijC0Z/7a6BYpD4RxLS2UsyJKgbeZfx6TNrsa48veG0z2yQbhTx1nVnes4GIcqMn7n2jFtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10650,25 +10650,25 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxfmt/binding-android-arm-eabi": "0.32.0",
-        "@oxfmt/binding-android-arm64": "0.32.0",
-        "@oxfmt/binding-darwin-arm64": "0.32.0",
-        "@oxfmt/binding-darwin-x64": "0.32.0",
-        "@oxfmt/binding-freebsd-x64": "0.32.0",
-        "@oxfmt/binding-linux-arm-gnueabihf": "0.32.0",
-        "@oxfmt/binding-linux-arm-musleabihf": "0.32.0",
-        "@oxfmt/binding-linux-arm64-gnu": "0.32.0",
-        "@oxfmt/binding-linux-arm64-musl": "0.32.0",
-        "@oxfmt/binding-linux-ppc64-gnu": "0.32.0",
-        "@oxfmt/binding-linux-riscv64-gnu": "0.32.0",
-        "@oxfmt/binding-linux-riscv64-musl": "0.32.0",
-        "@oxfmt/binding-linux-s390x-gnu": "0.32.0",
-        "@oxfmt/binding-linux-x64-gnu": "0.32.0",
-        "@oxfmt/binding-linux-x64-musl": "0.32.0",
-        "@oxfmt/binding-openharmony-arm64": "0.32.0",
-        "@oxfmt/binding-win32-arm64-msvc": "0.32.0",
-        "@oxfmt/binding-win32-ia32-msvc": "0.32.0",
-        "@oxfmt/binding-win32-x64-msvc": "0.32.0"
+        "@oxfmt/binding-android-arm-eabi": "0.31.0",
+        "@oxfmt/binding-android-arm64": "0.31.0",
+        "@oxfmt/binding-darwin-arm64": "0.31.0",
+        "@oxfmt/binding-darwin-x64": "0.31.0",
+        "@oxfmt/binding-freebsd-x64": "0.31.0",
+        "@oxfmt/binding-linux-arm-gnueabihf": "0.31.0",
+        "@oxfmt/binding-linux-arm-musleabihf": "0.31.0",
+        "@oxfmt/binding-linux-arm64-gnu": "0.31.0",
+        "@oxfmt/binding-linux-arm64-musl": "0.31.0",
+        "@oxfmt/binding-linux-ppc64-gnu": "0.31.0",
+        "@oxfmt/binding-linux-riscv64-gnu": "0.31.0",
+        "@oxfmt/binding-linux-riscv64-musl": "0.31.0",
+        "@oxfmt/binding-linux-s390x-gnu": "0.31.0",
+        "@oxfmt/binding-linux-x64-gnu": "0.31.0",
+        "@oxfmt/binding-linux-x64-musl": "0.31.0",
+        "@oxfmt/binding-openharmony-arm64": "0.31.0",
+        "@oxfmt/binding-win32-arm64-msvc": "0.31.0",
+        "@oxfmt/binding-win32-ia32-msvc": "0.31.0",
+        "@oxfmt/binding-win32-x64-msvc": "0.31.0"
       }
     },
     "node_modules/oxlint": {

--- a/src/cron/isolated-agent/session.test.ts
+++ b/src/cron/isolated-agent/session.test.ts
@@ -70,4 +70,57 @@ describe("resolveCronSession", () => {
     expect(result.sessionEntry.providerOverride).toBeUndefined();
     expect(result.sessionEntry.model).toBeUndefined();
   });
+
+  it("always generates a new sessionId for cron keys", () => {
+    vi.mocked(loadSessionStore).mockReturnValue({
+      "cron:test-job": {
+        sessionId: "existing-session-id",
+        updatedAt: 1000,
+      },
+    });
+
+    const result = resolveCronSession({
+      cfg: {} as OpenClawConfig,
+      sessionKey: "cron:test-job",
+      agentId: "main",
+      nowMs: Date.now(),
+    });
+
+    expect(result.sessionEntry.sessionId).not.toBe("existing-session-id");
+    expect(result.isNewSession).toBe(true);
+  });
+
+  it("reuses existing sessionId for non-cron hook keys", () => {
+    vi.mocked(loadSessionStore).mockReturnValue({
+      "agent:main:hook:fizzy:card-461": {
+        sessionId: "existing-session-id",
+        updatedAt: 1000,
+        model: "claude-opus-4-5",
+      },
+    });
+
+    const result = resolveCronSession({
+      cfg: {} as OpenClawConfig,
+      sessionKey: "agent:main:hook:fizzy:card-461",
+      agentId: "main",
+      nowMs: Date.now(),
+    });
+
+    expect(result.sessionEntry.sessionId).toBe("existing-session-id");
+    expect(result.isNewSession).toBe(false);
+  });
+
+  it("generates new sessionId for non-cron keys with no existing entry", () => {
+    vi.mocked(loadSessionStore).mockReturnValue({});
+
+    const result = resolveCronSession({
+      cfg: {} as OpenClawConfig,
+      sessionKey: "agent:main:hook:webhook:new-key",
+      agentId: "main",
+      nowMs: Date.now(),
+    });
+
+    expect(result.sessionEntry.sessionId).toBeDefined();
+    expect(result.isNewSession).toBe(true);
+  });
 });

--- a/src/cron/isolated-agent/session.test.ts
+++ b/src/cron/isolated-agent/session.test.ts
@@ -73,7 +73,7 @@ describe("resolveCronSession", () => {
 
   it("always generates a new sessionId for cron keys", () => {
     vi.mocked(loadSessionStore).mockReturnValue({
-      "cron:test-job": {
+      "agent:main:cron:test-job": {
         sessionId: "existing-session-id",
         updatedAt: 1000,
       },
@@ -81,7 +81,7 @@ describe("resolveCronSession", () => {
 
     const result = resolveCronSession({
       cfg: {} as OpenClawConfig,
-      sessionKey: "cron:test-job",
+      sessionKey: "agent:main:cron:test-job",
       agentId: "main",
       nowMs: Date.now(),
     });

--- a/src/cron/isolated-agent/session.ts
+++ b/src/cron/isolated-agent/session.ts
@@ -15,8 +15,7 @@ export function resolveCronSession(params: {
   const store = loadSessionStore(storePath);
   const entry = store[params.sessionKey];
   const isCronKey = params.sessionKey.startsWith("cron:");
-  const sessionId =
-    !isCronKey && entry?.sessionId ? entry.sessionId : crypto.randomUUID();
+  const sessionId = !isCronKey && entry?.sessionId ? entry.sessionId : crypto.randomUUID();
   const isNewSession = sessionId !== entry?.sessionId;
   const systemSent = false;
   const sessionEntry: SessionEntry = {

--- a/src/cron/isolated-agent/session.ts
+++ b/src/cron/isolated-agent/session.ts
@@ -14,7 +14,7 @@ export function resolveCronSession(params: {
   });
   const store = loadSessionStore(storePath);
   const entry = store[params.sessionKey];
-  const isCronKey = params.sessionKey.startsWith("cron:");
+  const isCronKey = /(?:^|:)cron:/.test(params.sessionKey);
   const sessionId = !isCronKey && entry?.sessionId ? entry.sessionId : crypto.randomUUID();
   const isNewSession = sessionId !== entry?.sessionId;
   const systemSent = false;

--- a/src/cron/isolated-agent/session.ts
+++ b/src/cron/isolated-agent/session.ts
@@ -14,7 +14,10 @@ export function resolveCronSession(params: {
   });
   const store = loadSessionStore(storePath);
   const entry = store[params.sessionKey];
-  const sessionId = crypto.randomUUID();
+  const isCronKey = params.sessionKey.startsWith("cron:");
+  const sessionId =
+    !isCronKey && entry?.sessionId ? entry.sessionId : crypto.randomUUID();
+  const isNewSession = sessionId !== entry?.sessionId;
   const systemSent = false;
   const sessionEntry: SessionEntry = {
     sessionId,
@@ -34,5 +37,5 @@ export function resolveCronSession(params: {
     displayName: entry?.displayName,
     skillsSnapshot: entry?.skillsSnapshot,
   };
-  return { storePath, store, sessionEntry, systemSent, isNewSession: true };
+  return { storePath, store, sessionEntry, systemSent, isNewSession };
 }


### PR DESCRIPTION
## Problem

When a webhook hook provides a consistent `sessionKey` via a transform, `resolveCronSession()` in `src/cron/isolated-agent/session.ts` always generates a new `sessionId` via `crypto.randomUUID()` and hardcodes `isNewSession: true`. This means every hook dispatch creates a new transcript file, losing all conversation history.

The docs for `/hooks/agent` state:

> `sessionKey` optional (string): Using a consistent key allows for a **multi-turn conversation** within the hook context.

This does not work as documented.

## Root Cause

```typescript
// Before — always creates new session
const sessionId = crypto.randomUUID();
// ...
return { ..., isNewSession: true };
```

The `sessionId` maps to the `.jsonl` transcript file. New ID = new file = no history. This also causes orphaned transcript files to accumulate on disk.

## Fix

Reuse the existing `sessionId` when:
1. The session key does **not** start with `cron:` (cron jobs intentionally want fresh runs)
2. An existing session entry with a `sessionId` exists in the store

```typescript
const isCronKey = params.sessionKey.startsWith("cron:");
const sessionId = !isCronKey && entry?.sessionId ? entry.sessionId : crypto.randomUUID();
const isNewSession = sessionId !== entry?.sessionId;
```

This preserves existing behavior for cron jobs while enabling multi-turn history for hook sessions with deterministic keys.

## Use Cases

- Project management webhooks (e.g., Basecamp/Fizzy) routing assignment + comment events to per-card sessions
- WhatsApp ordering bots maintaining conversation context per customer (as described in #11665)
- Any webhook integration needing multi-turn context with a consistent `sessionKey`

## Tests

Added 3 new test cases to `session.test.ts`:
- Cron keys always get a new sessionId ✅
- Non-cron keys with an existing entry reuse `entry.sessionId` ✅
- Non-cron keys with no existing entry get a new sessionId ✅

All 6 tests pass.

## Backward Compatibility

- **Cron jobs:** No change — `cron:` prefixed keys always get fresh sessions
- **Hooks without `sessionKey`:** No change — random `hook:{uuid}` keys won't have existing entries
- **Hooks with consistent `sessionKey`:** Now correctly thread into the same session

Fixes #11665

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates `resolveCronSession()` to reuse an existing `sessionId` from the session store for *non-cron* session keys, while preserving the “fresh run every time” behavior for cron jobs (keys starting with `cron:`). It also replaces the previous hard-coded `isNewSession: true` with a computed value based on whether the resolved `sessionId` differs from the stored entry.

Tests were extended in `src/cron/isolated-agent/session.test.ts` to cover: (1) cron keys always getting a new `sessionId`, (2) non-cron keys reusing an existing `sessionId`, and (3) non-cron keys generating a new `sessionId` when no store entry exists.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped (sessionId selection + isNewSession computation), is covered by targeted unit tests for the new branching behavior, and preserves existing cron behavior by key prefix. The updated logic aligns with how transcripts are looked up (by stored sessionId) and doesn’t introduce new IO or concurrency paths.
- No files require special attention

<sub>Last reviewed commit: 3dcdcc8</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->