### PR TITLE
slack: handle approval block actions in socket mode

### DIFF
--- a/src/slack/monitor/slash.ts
+++ b/src/slack/monitor/slash.ts
@@ -19,7 +19,10 @@ import { resolveConversationLabel } from "../../channels/conversation-label.js";
 import { createReplyPrefixOptions } from "../../channels/reply-prefix.js";
 import { resolveNativeCommandsEnabled, resolveNativeSkillsEnabled } from "../../config/commands.js";
 import { resolveMarkdownTableMode } from "../../config/markdown-tables.js";
+import { resolveMainSessionKeyFromConfig } from "../../config/sessions/main-session.js";
 import { danger, logVerbose } from "../../globals.js";
+import { requestHeartbeatNow } from "../../infra/heartbeat-wake.js";
+import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { buildPairingReply } from "../../pairing/pairing-messages.js";
 import {
   readChannelAllowFromStore,
@@ -107,6 +110,73 @@ function parseSlackCommandArgValue(raw?: string | null): {
     value: decodedValue,
     userId: decodedUserId,
   };
+}
+
+type SlackApprovalDecision = "approve" | "reject";
+
+function inferSlackApprovalDecision(raw?: string | null): SlackApprovalDecision | null {
+  const normalized = (raw ?? "").trim().toLowerCase();
+  if (!normalized) {
+    return null;
+  }
+  if (normalized.includes("approve")) {
+    return "approve";
+  }
+  if (normalized.includes("reject") || normalized.includes("deny")) {
+    return "reject";
+  }
+  return null;
+}
+
+function resolveSlackApprovalSessionKey(params: {
+  channelId?: string;
+  threadTs?: string;
+  sessionKeyFromValue?: string;
+}): string {
+  const sessionKeyFromValue = params.sessionKeyFromValue?.trim();
+  if (sessionKeyFromValue?.startsWith("agent:main:")) {
+    return sessionKeyFromValue;
+  }
+
+  const channelId = params.channelId?.trim() ?? "";
+  const threadTs = params.threadTs?.trim() ?? "";
+
+  if (channelId.toUpperCase().startsWith("D")) {
+    return threadTs ? `agent:main:main:thread:${threadTs}` : resolveMainSessionKeyFromConfig();
+  }
+
+  const kind = channelId.toUpperCase().startsWith("C") ? "channel" : "group";
+  const base = channelId
+    ? `agent:main:slack:${kind}:${channelId.toLowerCase()}`
+    : resolveMainSessionKeyFromConfig();
+  return threadTs ? `${base}:thread:${threadTs}` : base;
+}
+
+function buildSlackApprovalContextKey(params: {
+  requestId?: string;
+  threadTs?: string;
+  channelId?: string;
+  actionTs?: string;
+}): string {
+  return `slack:approval:${params.requestId || params.threadTs || params.channelId || "unknown"}:${params.actionTs ?? "na"}`;
+}
+
+function buildSlackApprovalEventText(params: {
+  decision: SlackApprovalDecision;
+  requestId?: string;
+  actorId?: string;
+  actionId?: string;
+  actionValue?: string;
+}): string {
+  return [
+    `Slack approval decision: ${params.decision.toUpperCase()}`,
+    params.requestId ? `request_id: ${params.requestId}` : null,
+    params.actorId ? `actor: ${params.actorId}` : null,
+    params.actionId ? `action_id: ${params.actionId}` : null,
+    params.actionValue ? `value: ${params.actionValue}` : null,
+  ]
+    .filter(Boolean)
+    .join("\n");
 }
 
 function buildSlackCommandArgMenuBlocks(params: {
@@ -550,6 +620,118 @@ export function registerSlackMonitorSlashCommands(params: {
     );
   } else {
     logVerbose("slack: slash commands disabled");
+  }
+
+  if (typeof (ctx.app as { action?: unknown }).action === "function") {
+    (
+      ctx.app as unknown as {
+        action: NonNullable<(typeof ctx.app & { action?: unknown })["action"]>;
+      }
+    ).action(
+      /^(maya_approval_|openclaw_approval_|approval_)/,
+      async (args: SlackActionMiddlewareArgs) => {
+        const { ack, body, respond } = args;
+        const action = args.action as {
+          action_id?: string;
+          value?: string;
+          action_ts?: string;
+        };
+
+        await ack();
+
+        const actionId = action.action_id?.trim().toLowerCase() ?? "";
+        const actionValue = action.value?.trim() ?? "";
+
+        let decision = inferSlackApprovalDecision(actionId);
+        let requestId = "";
+        let sessionKeyFromValue = "";
+
+        if (actionValue) {
+          try {
+            const parsed = JSON.parse(actionValue) as {
+              decision?: string;
+              action?: string;
+              requestId?: string;
+              request_id?: string;
+              sessionKey?: string;
+              session_key?: string;
+            };
+            decision =
+              decision ?? inferSlackApprovalDecision(parsed.decision) ?? inferSlackApprovalDecision(parsed.action);
+            requestId = (parsed.requestId ?? parsed.request_id ?? "").trim();
+            sessionKeyFromValue = (parsed.sessionKey ?? parsed.session_key ?? "").trim();
+          } catch {
+            decision = decision ?? inferSlackApprovalDecision(actionValue);
+          }
+        }
+
+        if (!decision) {
+          if (respond) {
+            await respond({
+              text: "Unsupported approval action.",
+              response_type: "ephemeral",
+            });
+          }
+          return;
+        }
+
+        const channelId = body.channel?.id?.trim() ?? "";
+        const threadTs =
+          (body as { container?: { thread_ts?: string; message_ts?: string }; message?: { thread_ts?: string; ts?: string } })
+            .container?.thread_ts ??
+          (body as { message?: { thread_ts?: string; ts?: string } }).message?.thread_ts ??
+          (body as { message?: { ts?: string } }).message?.ts ??
+          (body as { container?: { message_ts?: string } }).container?.message_ts ??
+          "";
+        const actorId = body.user?.id?.trim() ?? "unknown";
+        const sessionKey = resolveSlackApprovalSessionKey({
+          channelId,
+          threadTs,
+          sessionKeyFromValue,
+        });
+
+        enqueueSystemEvent(
+          buildSlackApprovalEventText({
+            decision,
+            requestId,
+            actorId,
+            actionId,
+            actionValue,
+          }),
+          {
+            sessionKey,
+            contextKey: buildSlackApprovalContextKey({
+              requestId,
+              threadTs,
+              channelId,
+              actionTs: action.action_ts,
+            }),
+          },
+        );
+        requestHeartbeatNow({ reason: "slack-approval-action" });
+
+        const confirmation = decision === "approve" ? "✅ Approved received." : "❌ Rejected received.";
+        if (respond) {
+          await respond({
+            text: confirmation,
+            response_type: "ephemeral",
+          });
+        }
+
+        if (channelId) {
+          try {
+            await ctx.app.client.chat.postMessage({
+              token: ctx.botToken,
+              channel: channelId,
+              text: confirmation,
+              thread_ts: threadTs || undefined,
+            });
+          } catch (err) {
+            runtime.error?.(danger(`slack approval post failed: ${String(err)}`));
+          }
+        }
+      },
+    );
   }
 
   if (nativeCommands.length === 0 || !supportsInteractiveArgMenus) {


### PR DESCRIPTION
## Purpose
Enable reliable Slack approval button handling in Socket Mode so `approval_*` actions are acknowledged, routed to the correct OpenClaw session/thread, and confirmed in-thread.

## Problem this fixes
- Button clicks could spin/fail when handler registration was gated.
- Decisions could route to a wrong/new session.
- No consistent confirmation UX for approver.

## What changed
- Added `app.action(/^(maya_approval_|openclaw_approval_|approval_)/, ...)` in `src/slack/monitor/slash.ts`.
- Parse decision + metadata from `action_id` and JSON `value`.
- Support optional `sessionKey` in action payload (`sessionKey` / `session_key`) and prioritize it when valid.
- Fallback routing by Slack channel/thread context:
  - DM -> `agent:main:main:thread:<threadTs>` (or main fallback)
  - channel/group -> `agent:main:slack:<kind>:<channel>[:thread:<threadTs>]`
- Emit system event via `enqueueSystemEvent(...)` and trigger `requestHeartbeatNow(...)`.
- Send ephemeral + in-thread confirmation (`✅ Approved received.` / `❌ Rejected received.`).

## Scope
This PR only adds Slack approval action handling. No cron/plugin/config changes are included.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new Slack Bolt `app.action(...)` handler in `src/slack/monitor/slash.ts` to process `approval_*`-style interactive button clicks in Socket Mode. The handler acks the action, infers approve/reject from `action_id` or JSON `value`, derives a session routing key (optionally from a provided `sessionKey`), enqueues a system event for the routed session, requests an immediate heartbeat wake, and sends both ephemeral and in-thread confirmation messages back to Slack.

The change fits alongside existing Slack slash/interactive handling in this file (slash command routing and command-arg menu actions), extending the monitor to support approval workflows via interactive components.

<h3>Confidence Score: 3/5</h3>

- This PR is mostly safe to merge, but approval routing via unvalidated sessionKey needs tightening.
- The handler structure (ack/respond, parsing, enqueueing, posting confirmation) is straightforward and aligns with existing Slack monitor patterns. The main concern is that a user-controlled `value.sessionKey` is accepted with minimal validation, which can route approval decisions into arbitrary `agent:main:*` sessions. Fixing that should make the change low-risk.
- src/slack/monitor/slash.ts

<sub>Last reviewed commit: dfde4ec</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->