### PR TITLE
fix(slack): process all file attachments instead of only the first

### DIFF
--- a/src/slack/monitor/media.ts
+++ b/src/slack/monitor/media.ts
@@ -119,12 +119,9 @@ export async function resolveSlackMedia(params: {
   files?: SlackFile[];
   token: string;
   maxBytes: number;
-}): Promise<{
-  path: string;
-  contentType?: string;
-  placeholder: string;
-} | null> {
+}): Promise<Array<{ path: string; contentType?: string; placeholder: string }>> {
   const files = params.files ?? [];
+  const results: Array<{ path: string; contentType?: string; placeholder: string }> = [];
   for (const file of files) {
     const url = file.url_private_download ?? file.url_private;
     if (!url) {
@@ -151,16 +148,16 @@ export async function resolveSlackMedia(params: {
         params.maxBytes,
       );
       const label = fetched.fileName ?? file.name;
-      return {
+      results.push({
         path: saved.path,
         contentType: saved.contentType,
         placeholder: label ? `[Slack file: ${label}]` : "[Slack file]",
-      };
+      });
     } catch {
       // Ignore download failures and fall through to the next file.
     }
   }
-  return null;
+  return results;
 }
 
 export type SlackThreadStarter = {

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -495,8 +495,8 @@ export async function prepareSlackMessage(params: {
           token: ctx.botToken,
           maxBytes: ctx.mediaMaxBytes,
         });
-        threadStarterMedia = starterMediaList.length > 0
-          ? buildSlackMediaPayload(starterMediaList) : null;
+        threadStarterMedia =
+          starterMediaList.length > 0 ? buildSlackMediaPayload(starterMediaList) : null;
         if (threadStarterMedia) {
           logVerbose(
             `slack: hydrated thread starter file ${threadStarterMedia.placeholder} from root message`,


### PR DESCRIPTION
## Summary
- `resolveSlackMedia()` now returns all successfully fetched files 
  instead of returning after the first one
- Added `buildSlackMediaPayload()` helper following the existing 
  Discord pattern, populating both singular and plural media fields
- Updated tests for new array return type + added multi-file test

Fixes #15190

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates Slack inbound media handling so `resolveSlackMedia()` returns *all* successfully fetched attachments rather than stopping after the first. `prepareSlackMessage()` is updated to consume the new array return type and to populate both singular (`MediaPath`/`MediaUrl`/`MediaType`) and plural (`MediaPaths`/`MediaUrls`/`MediaTypes`) context fields via a new `buildSlackMediaPayload()` helper, matching the pattern used by other providers.

Tests were updated to assert the new empty-array behavior and to cover multi-file handling.

<h3>Confidence Score: 5/5</h3>

- This PR appears safe to merge with minimal risk.
- Changes are localized to Slack inbound media resolution and message preparation, with tests updated/expanded to cover the new multi-file behavior and the return-type change. Downstream context fields already support plural media arrays and similar providers use the same local-path-as-URL pattern.
- No files require special attention

<sub>Last reviewed commit: 53fe2f4</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->