### PR TITLE
fix: pass agentId to resolveSessionFilePath for multi-agent path validation

### DIFF
--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -436,6 +436,7 @@ export function createSessionStatusTool(opts?: {
           ...agentDefaults,
           model: agentModel,
         },
+        agentId,
         sessionEntry: resolved.entry,
         sessionKey: resolved.key,
         groupActivation,

--- a/src/auto-reply/reply/commands-compact.ts
+++ b/src/auto-reply/reply/commands-compact.ts
@@ -79,7 +79,9 @@ export const handleCompactCommand: CommandHandler = async (params) => {
     groupChannel: params.sessionEntry.groupChannel,
     groupSpace: params.sessionEntry.space,
     spawnedBy: params.sessionEntry.spawnedBy,
-    sessionFile: resolveSessionFilePath(sessionId, params.sessionEntry),
+    sessionFile: resolveSessionFilePath(sessionId, params.sessionEntry, {
+      agentId: params.agentId,
+    }),
     workspaceDir: params.workspaceDir,
     config: params.cfg,
     skillsSnapshot: params.sessionEntry.skillsSnapshot,

--- a/src/auto-reply/reply/commands-session.ts
+++ b/src/auto-reply/reply/commands-session.ts
@@ -167,6 +167,7 @@ export const handleUsageCommand: CommandHandler = async (params, allowTextComman
       sessionEntry: params.sessionEntry,
       sessionFile: params.sessionEntry?.sessionFile,
       config: params.cfg,
+      agentId: params.agentId,
     });
     const summary = await loadCostUsageSummary({ days: 30, config: params.cfg });
 

--- a/src/auto-reply/reply/commands-status.ts
+++ b/src/auto-reply/reply/commands-status.ts
@@ -222,6 +222,7 @@ export async function buildStatusReply(params: {
       verboseDefault: agentDefaults.verboseDefault,
       elevatedDefault: agentDefaults.elevatedDefault,
     },
+    agentId: statusAgentId,
     sessionEntry,
     sessionKey,
     sessionScope,

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -316,7 +316,7 @@ export async function runPreparedReply(
     }
   }
   const sessionIdFinal = sessionId ?? crypto.randomUUID();
-  const sessionFile = resolveSessionFilePath(sessionIdFinal, sessionEntry);
+  const sessionFile = resolveSessionFilePath(sessionIdFinal, sessionEntry, { agentId });
   const queueBodyBase = baseBodyForPrompt;
   const queuedBody = mediaNote
     ? [mediaNote, mediaReplyHint, queueBodyBase].filter(Boolean).join("\n").trim()

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -55,12 +55,13 @@ export type SessionInitResult = {
 
 function forkSessionFromParent(params: {
   parentEntry: SessionEntry;
+  agentId: string;
   sessionsDir: string;
 }): { sessionId: string; sessionFile: string } | null {
   const parentSessionFile = resolveSessionFilePath(
     params.parentEntry.sessionId,
     params.parentEntry,
-    { sessionsDir: params.sessionsDir },
+    { agentId: params.agentId, sessionsDir: params.sessionsDir },
   );
   if (!parentSessionFile || !fs.existsSync(parentSessionFile)) {
     return null;
@@ -322,6 +323,7 @@ export async function initSessionState(params: {
     );
     const forked = forkSessionFromParent({
       parentEntry: sessionStore[parentSessionKey],
+      agentId,
       sessionsDir: path.dirname(storePath),
     });
     if (forked) {

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -56,6 +56,7 @@ type QueueStatus = {
 type StatusArgs = {
   config?: OpenClawConfig;
   agent: AgentConfig;
+  agentId?: string;
   sessionEntry?: SessionEntry;
   sessionKey?: string;
   sessionScope?: SessionScope;
@@ -165,6 +166,7 @@ const formatQueueDetails = (queue?: QueueStatus) => {
 const readUsageFromSessionLog = (
   sessionId?: string,
   sessionEntry?: SessionEntry,
+  agentId?: string,
 ):
   | {
       input: number;
@@ -178,7 +180,7 @@ const readUsageFromSessionLog = (
   if (!sessionId) {
     return undefined;
   }
-  const logPath = resolveSessionFilePath(sessionId, sessionEntry);
+  const logPath = resolveSessionFilePath(sessionId, sessionEntry, { agentId });
   if (!fs.existsSync(logPath)) {
     return undefined;
   }
@@ -333,7 +335,7 @@ export function buildStatusMessage(args: StatusArgs): string {
   // Prefer prompt-size tokens from the session transcript when it looks larger
   // (cached prompt tokens are often missing from agent meta/store).
   if (args.includeTranscriptUsage) {
-    const logUsage = readUsageFromSessionLog(entry?.sessionId, entry);
+    const logUsage = readUsageFromSessionLog(entry?.sessionId, entry, args.agentId);
     if (logUsage) {
       const candidate = logUsage.promptTokens || logUsage.total;
       if (!totalTokens || totalTokens === 0 || candidate > totalTokens) {

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -494,11 +494,13 @@ export const usageHandlers: GatewayRequestHandlers = {
     };
 
     for (const merged of limitedEntries) {
+      const agentId = parseAgentSessionKey(merged.key)?.agentId;
       const usage = await loadSessionCostSummary({
         sessionId: merged.sessionId,
         sessionEntry: merged.storeEntry,
         sessionFile: merged.sessionFile,
         config,
+        agentId,
         startMs,
         endMs,
       });
@@ -517,7 +519,6 @@ export const usageHandlers: GatewayRequestHandlers = {
         aggregateTotals.missingCostEntries += usage.missingCostEntries;
       }
 
-      const agentId = parseAgentSessionKey(merged.key)?.agentId;
       const channel = merged.storeEntry?.channel ?? merged.storeEntry?.origin?.provider;
       const chatType = merged.storeEntry?.chatType ?? merged.storeEntry?.origin?.chatType;
 
@@ -794,6 +795,7 @@ export const usageHandlers: GatewayRequestHandlers = {
       sessionEntry: entry,
       sessionFile,
       config,
+      agentId,
       maxPoints: 200,
     });
 
@@ -847,6 +849,7 @@ export const usageHandlers: GatewayRequestHandlers = {
       sessionEntry: entry,
       sessionFile,
       config,
+      agentId,
       limit,
     });
 

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -561,12 +561,17 @@ export async function loadSessionCostSummary(params: {
   sessionEntry?: SessionEntry;
   sessionFile?: string;
   config?: OpenClawConfig;
+  agentId?: string;
   startMs?: number;
   endMs?: number;
 }): Promise<SessionCostSummary | null> {
   const sessionFile =
     params.sessionFile ??
-    (params.sessionId ? resolveSessionFilePath(params.sessionId, params.sessionEntry) : undefined);
+    (params.sessionId
+      ? resolveSessionFilePath(params.sessionId, params.sessionEntry, {
+          agentId: params.agentId,
+        })
+      : undefined);
   if (!sessionFile || !fs.existsSync(sessionFile)) {
     return null;
   }
@@ -851,11 +856,16 @@ export async function loadSessionUsageTimeSeries(params: {
   sessionEntry?: SessionEntry;
   sessionFile?: string;
   config?: OpenClawConfig;
+  agentId?: string;
   maxPoints?: number;
 }): Promise<SessionUsageTimeSeries | null> {
   const sessionFile =
     params.sessionFile ??
-    (params.sessionId ? resolveSessionFilePath(params.sessionId, params.sessionEntry) : undefined);
+    (params.sessionId
+      ? resolveSessionFilePath(params.sessionId, params.sessionEntry, {
+          agentId: params.agentId,
+        })
+      : undefined);
   if (!sessionFile || !fs.existsSync(sessionFile)) {
     return null;
   }
@@ -931,11 +941,16 @@ export async function loadSessionLogs(params: {
   sessionEntry?: SessionEntry;
   sessionFile?: string;
   config?: OpenClawConfig;
+  agentId?: string;
   limit?: number;
 }): Promise<SessionLogEntry[] | null> {
   const sessionFile =
     params.sessionFile ??
-    (params.sessionId ? resolveSessionFilePath(params.sessionId, params.sessionEntry) : undefined);
+    (params.sessionId
+      ? resolveSessionFilePath(params.sessionId, params.sessionEntry, {
+          agentId: params.agentId,
+        })
+      : undefined);
   if (!sessionFile || !fs.existsSync(sessionFile)) {
     return null;
   }


### PR DESCRIPTION
## Problem

Non-main agents crash when running `/compact` or hitting other session file resolution paths:

```
Error: Session file path must be within sessions directory
```

## Root Cause

`resolveSessionFilePath()` takes an optional `opts.agentId` to determine which agent's sessions directory to validate against. Multiple callers omit this parameter, so it defaults to the `main` agent's sessions dir.

When a non-main agent has an absolute `sessionFile` path in its session store (e.g. `~/.openclaw/agents/other-agent/sessions/xxx.jsonl`), the path validation in `resolvePathWithinSessionsDir()` computes a relative path from the main agent's dir — which starts with `../..` — and rejects it as directory traversal.

### Introduced by

Commit `4199f9889` (`fix: harden session transcript path resolution`) added `resolvePathWithinSessionsDir` as a security hardening measure for path traversal prevention. It updated `resolveSessionFilePath` to validate the `sessionFile` candidate against the sessions directory, but only updated some callers (gateway, subagent-announce, transcript) to pass `agentId` — missing the auto-reply paths (`commands-compact`, `get-reply-run`, `status`, `session-cost-usage`, etc.).

Before that commit, `resolveSessionFilePath` returned `entry.sessionFile` as-is with no validation, so the missing `agentId` was harmless.

## Fix

Pass `agentId` to all call sites of `resolveSessionFilePath()` that were missing it:

- `commands-compact.ts` — the immediate crash site (`/compact` command)
- `get-reply-run.ts` — main reply path
- `session.ts` — session fork/init
- `status.ts` — `/status` transcript usage reading
- `commands-status.ts` — status command
- `commands-session.ts` — `/usage` command
- `session-status-tool.ts` — agent session status tool
- `session-cost-usage.ts` — cost summary, time series, and log loading (3 call sites)
- `usage.ts` (gateway) — usage API handlers (3 call sites)

All patched callers already had `agentId` available in their scope/params.

## Testing

- Verified `pnpm build` succeeds
- The fix is a strict superset: main-agent behavior is unchanged (agentId defaults to `main`), non-main agents now resolve paths against their own sessions directory

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes multi-agent session transcript path validation by consistently passing `agentId` to `resolveSessionFilePath()` at call sites that resolve/validate a session’s transcript path.

The underlying issue is that `resolveSessionFilePath()` validates `entry.sessionFile` against an agent-scoped sessions directory; if callers omit `opts.agentId`, it defaults to the main agent’s sessions dir and rejects non-main agents’ absolute stored paths as traversal. The updates in:
- auto-reply command handlers (`/compact`, `/status`, `/usage`)
- the main reply run path
- session forking/init
- the session status tool
- gateway usage handlers
- session cost/usage loading helpers

ensure that non-main agents validate and resolve against their own sessions directory while leaving main-agent behavior unchanged (default remains `main`).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped to threading an existing `agentId` through to `resolveSessionFilePath()` and related usage loaders. Verified that `resolveSessionFilePath` uses `agentId` to select the correct agent sessions directory for validation, and that gateway session keys are canonicalized with `agent:<agentId>:` so the new `agentId` derivation is stable.
- No files require special attention

<sub>Last reviewed commit: ee26f95</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->