### PR TITLE
fix: complete message_sent hook dispatch coverage (follow-up to #14882)

### DIFF
--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -14,6 +14,12 @@ import {
 const mocks = vi.hoisted(() => ({
   appendAssistantMessageToSessionTranscript: vi.fn(async () => ({ ok: true, sessionFile: "x" })),
 }));
+const hookMocks = vi.hoisted(() => ({
+  runner: {
+    hasHooks: vi.fn(() => false),
+    runMessageSent: vi.fn(async () => {}),
+  },
+}));
 
 vi.mock("../../config/sessions.js", async () => {
   const actual = await vi.importActual<typeof import("../../config/sessions.js")>(
@@ -24,12 +30,19 @@ vi.mock("../../config/sessions.js", async () => {
     appendAssistantMessageToSessionTranscript: mocks.appendAssistantMessageToSessionTranscript,
   };
 });
+vi.mock("../../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: () => hookMocks.runner,
+}));
 
 const { deliverOutboundPayloads, normalizeOutboundPayloads } = await import("./deliver.js");
 
 describe("deliverOutboundPayloads", () => {
   beforeEach(() => {
     setActivePluginRegistry(defaultRegistry);
+    hookMocks.runner.hasHooks.mockReset();
+    hookMocks.runner.hasHooks.mockReturnValue(false);
+    hookMocks.runner.runMessageSent.mockReset();
+    hookMocks.runner.runMessageSent.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -421,6 +434,86 @@ describe("deliverOutboundPayloads", () => {
     expect(mocks.appendAssistantMessageToSessionTranscript).toHaveBeenCalledWith(
       expect.objectContaining({ text: "report.pdf" }),
     );
+  });
+
+  it("emits message_sent success for text-only deliveries", async () => {
+    hookMocks.runner.hasHooks.mockImplementation((name: string) => name === "message_sent");
+    const sendWhatsApp = vi.fn().mockResolvedValue({ messageId: "w1", toJid: "jid" });
+
+    await deliverOutboundPayloads({
+      cfg: {},
+      channel: "whatsapp",
+      to: "+1555",
+      payloads: [{ text: "hello" }],
+      deps: { sendWhatsApp },
+    });
+
+    await vi.waitFor(() => {
+      expect(hookMocks.runner.runMessageSent).toHaveBeenCalledWith(
+        expect.objectContaining({ to: "+1555", content: "hello", success: true }),
+        expect.objectContaining({ channelId: "whatsapp" }),
+      );
+    });
+  });
+
+  it("emits message_sent success for sendPayload deliveries", async () => {
+    hookMocks.runner.hasHooks.mockImplementation((name: string) => name === "message_sent");
+    const sendPayload = vi.fn().mockResolvedValue({ channel: "matrix", messageId: "mx-1" });
+    const sendText = vi.fn();
+    const sendMedia = vi.fn();
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "matrix",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "matrix",
+            outbound: { deliveryMode: "direct", sendPayload, sendText, sendMedia },
+          }),
+        },
+      ]),
+    );
+
+    await deliverOutboundPayloads({
+      cfg: {},
+      channel: "matrix",
+      to: "!room:1",
+      payloads: [{ text: "payload text", channelData: { mode: "custom" } }],
+    });
+
+    await vi.waitFor(() => {
+      expect(hookMocks.runner.runMessageSent).toHaveBeenCalledWith(
+        expect.objectContaining({ to: "!room:1", content: "payload text", success: true }),
+        expect.objectContaining({ channelId: "matrix" }),
+      );
+    });
+  });
+
+  it("emits message_sent failure when delivery errors", async () => {
+    hookMocks.runner.hasHooks.mockImplementation((name: string) => name === "message_sent");
+    const sendWhatsApp = vi.fn().mockRejectedValue(new Error("downstream failed"));
+
+    await expect(
+      deliverOutboundPayloads({
+        cfg: {},
+        channel: "whatsapp",
+        to: "+1555",
+        payloads: [{ text: "hi" }],
+        deps: { sendWhatsApp },
+      }),
+    ).rejects.toThrow("downstream failed");
+
+    await vi.waitFor(() => {
+      expect(hookMocks.runner.runMessageSent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: "+1555",
+          content: "hi",
+          success: false,
+          error: "downstream failed",
+        }),
+        expect.objectContaining({ channelId: "whatsapp" }),
+      );
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- ensure `message_sent` success dispatch fires for all successful outbound delivery paths
- add callsite-level outbound tests that validate `message_sent` success and failure dispatch behavior

## Context
Deep-review remediation for merged PR #14882.

## Validation
- pnpm exec vitest run src/infra/outbound/deliver.test.ts

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR expands `message_sent` hook dispatching for outbound delivery and adds tests to assert hook behavior across multiple outbound callsites.

The change fits into the outbound delivery pipeline by ensuring downstream observers (hooks) get consistent “message sent” signals when outbound delivery succeeds, and by locking that behavior in with callsite-level tests in `src/infra/outbound/deliver.test.ts`.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge but has a contract/behavior mismatch risk around what constitutes a “successful” outbound delivery.
- Tests add coverage and the intent is clear, but the implementation’s success condition appears tied to a specific result shape (`ok === true`). If any existing outbound adapter treats “no throw” or `void` return as success, the hook dispatch coverage will still be incomplete.
- src/infra/outbound/deliver.ts

<sub>Last reviewed commit: 2b18637</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->