### PR TITLE
fix: add adapter-path after_tool_call dispatch guards (follow-up to #15012)

### DIFF
--- a/src/agents/pi-tool-definition-adapter.after-tool-call.test.ts
+++ b/src/agents/pi-tool-definition-adapter.after-tool-call.test.ts
@@ -1,0 +1,113 @@
+import type { AgentTool } from "@mariozechner/pi-agent-core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { toToolDefinitions } from "./pi-tool-definition-adapter.js";
+
+const hookMocks = vi.hoisted(() => ({
+  runner: {
+    hasHooks: vi.fn(() => false),
+    runAfterToolCall: vi.fn(async () => {}),
+  },
+  runBeforeToolCallHook: vi.fn(async ({ params }: { params: unknown }) => ({
+    blocked: false,
+    params,
+  })),
+}));
+
+vi.mock("../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: () => hookMocks.runner,
+}));
+
+vi.mock("./pi-tools.before-tool-call.js", () => ({
+  runBeforeToolCallHook: hookMocks.runBeforeToolCallHook,
+}));
+
+describe("pi tool definition adapter after_tool_call", () => {
+  beforeEach(() => {
+    hookMocks.runner.hasHooks.mockReset();
+    hookMocks.runner.runAfterToolCall.mockReset();
+    hookMocks.runner.runAfterToolCall.mockResolvedValue(undefined);
+    hookMocks.runBeforeToolCallHook.mockReset();
+    hookMocks.runBeforeToolCallHook.mockImplementation(async ({ params }) => ({
+      blocked: false,
+      params,
+    }));
+  });
+
+  it("dispatches after_tool_call once on successful adapter execution", async () => {
+    hookMocks.runner.hasHooks.mockImplementation((name: string) => name === "after_tool_call");
+    hookMocks.runBeforeToolCallHook.mockResolvedValue({
+      blocked: false,
+      params: { mode: "safe" },
+    });
+    const tool = {
+      name: "read",
+      label: "Read",
+      description: "reads",
+      parameters: {},
+      execute: vi.fn(async () => ({ content: [], details: { ok: true } })),
+    } satisfies AgentTool<unknown, unknown>;
+
+    const defs = toToolDefinitions([tool]);
+    const result = await defs[0].execute("call-ok", { path: "/tmp/file" }, undefined, undefined);
+
+    expect(result.details).toMatchObject({ ok: true });
+    expect(hookMocks.runner.runAfterToolCall).toHaveBeenCalledTimes(1);
+    expect(hookMocks.runner.runAfterToolCall).toHaveBeenCalledWith(
+      {
+        toolName: "read",
+        params: { mode: "safe" },
+        result,
+      },
+      { toolName: "read" },
+    );
+  });
+
+  it("dispatches after_tool_call once on adapter error with normalized tool name", async () => {
+    hookMocks.runner.hasHooks.mockImplementation((name: string) => name === "after_tool_call");
+    const tool = {
+      name: "bash",
+      label: "Bash",
+      description: "throws",
+      parameters: {},
+      execute: vi.fn(async () => {
+        throw new Error("boom");
+      }),
+    } satisfies AgentTool<unknown, unknown>;
+
+    const defs = toToolDefinitions([tool]);
+    const result = await defs[0].execute("call-err", { cmd: "ls" }, undefined, undefined);
+
+    expect(result.details).toMatchObject({
+      status: "error",
+      tool: "exec",
+      error: "boom",
+    });
+    expect(hookMocks.runner.runAfterToolCall).toHaveBeenCalledTimes(1);
+    expect(hookMocks.runner.runAfterToolCall).toHaveBeenCalledWith(
+      {
+        toolName: "exec",
+        params: { cmd: "ls" },
+        error: "boom",
+      },
+      { toolName: "exec" },
+    );
+  });
+
+  it("does not break execution when after_tool_call hook throws", async () => {
+    hookMocks.runner.hasHooks.mockImplementation((name: string) => name === "after_tool_call");
+    hookMocks.runner.runAfterToolCall.mockRejectedValue(new Error("hook failed"));
+    const tool = {
+      name: "read",
+      label: "Read",
+      description: "reads",
+      parameters: {},
+      execute: vi.fn(async () => ({ content: [], details: { ok: true } })),
+    } satisfies AgentTool<unknown, unknown>;
+
+    const defs = toToolDefinitions([tool]);
+    const result = await defs[0].execute("call-ok2", { path: "/tmp/file" }, undefined, undefined);
+
+    expect(result.details).toMatchObject({ ok: true });
+    expect(hookMocks.runner.runAfterToolCall).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add dedicated adapter-path tests for `after_tool_call` dispatch on success and error
- add single-dispatch guard coverage so adapter-path calls are asserted exactly once per execution
- run existing embedded-path `after_tool_call` wiring tests alongside adapter-path tests

## Context
Deep-review remediation for merged PR #15012.

## Validation
- pnpm exec vitest run src/agents/pi-tool-definition-adapter.after-tool-call.test.ts src/plugins/wired-hooks-after-tool-call.test.ts

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a dedicated Vitest suite (`src/agents/pi-tool-definition-adapter.after-tool-call.test.ts`) to validate `after_tool_call` hook dispatch behavior for the PI tool-definition adapter.

The tests cover:
- successful tool execution dispatching `after_tool_call` exactly once with the adjusted params returned from `before_tool_call`
- tool execution errors dispatching `after_tool_call` exactly once with the normalized tool name (e.g., `bash` → `exec`) and the error message
- hook runner failures not breaking tool execution (hook errors are caught/logged)

These tests exercise the adapter-path hook wiring in `src/agents/pi-tool-definition-adapter.ts` and complement existing wired hook tests (embedded path).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is isolated to a new test file; assertions match current adapter behavior for both success and error paths, and mocks are correctly reset between tests.
- src/agents/pi-tool-definition-adapter.after-tool-call.test.ts

<sub>Last reviewed commit: a395cdf</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->