### PR TITLE
fix: prevent heartbeat scheduler silent death from wake handler race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 - Onboarding/CLI: restore terminal state without resuming paused `stdin`, so onboarding exits cleanly after choosing Web UI and the installer returns instead of appearing stuck.
 - macOS Voice Wake: fix a crash in trigger trimming for CJK/Unicode transcripts by matching and slicing on original-string ranges instead of transformed-string indices. (#11052) Thanks @Flash-LHR.
+- Heartbeat: prevent scheduler silent-death races during runner reloads, preserve retry cooldown backoff under wake bursts, and prioritize user/action wake causes over interval/retry reasons when coalescing. (#15108) Thanks @joeykrug.
 
 ## 2026.2.12
 

--- a/src/infra/heartbeat-runner.scheduler.test.ts
+++ b/src/infra/heartbeat-runner.scheduler.test.ts
@@ -87,6 +87,57 @@ describe("startHeartbeatRunner", () => {
     runner.stop();
   });
 
+  it("cleanup is idempotent and does not clear a newer runner's handler", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(0));
+
+    const runSpy1 = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+    const runSpy2 = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+
+    const cfg = {
+      agents: { defaults: { heartbeat: { every: "30m" } } },
+    } as OpenClawConfig;
+
+    // Start runner A
+    const runnerA = startHeartbeatRunner({ cfg, runOnce: runSpy1 });
+
+    // Start runner B (simulates lifecycle reload)
+    const runnerB = startHeartbeatRunner({ cfg, runOnce: runSpy2 });
+
+    // Stop runner A (stale cleanup) — should NOT kill runner B's handler
+    runnerA.stop();
+
+    // Runner B should still fire
+    await vi.advanceTimersByTimeAsync(30 * 60_000 + 1_000);
+    expect(runSpy2).toHaveBeenCalledTimes(1);
+    expect(runSpy1).not.toHaveBeenCalled();
+
+    // Double-stop should be safe (idempotent)
+    runnerA.stop();
+
+    runnerB.stop();
+  });
+
+  it("run() returns skipped when runner is stopped", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(0));
+
+    const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+
+    const runner = startHeartbeatRunner({
+      cfg: {
+        agents: { defaults: { heartbeat: { every: "30m" } } },
+      } as OpenClawConfig,
+      runOnce: runSpy,
+    });
+
+    runner.stop();
+
+    // After stopping, no heartbeats should fire
+    await vi.advanceTimersByTimeAsync(60 * 60_000);
+    expect(runSpy).not.toHaveBeenCalled();
+  });
+
   it("reschedules timer when runOnce returns requests-in-flight", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(0));

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -1006,7 +1006,9 @@ export function startHeartbeatRunner(opts: {
   updateConfig(state.cfg);
 
   const cleanup = () => {
-    if (state.stopped) return;
+    if (state.stopped) {
+      return;
+    }
     state.stopped = true;
     disposeWakeHandler();
     if (state.timer) {

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -880,6 +880,7 @@ export function startHeartbeatRunner(opts: {
     }
     const delay = Math.max(0, nextDue - now);
     state.timer = setTimeout(() => {
+      state.timer = null;
       requestHeartbeatNow({ reason: "interval", coalesceMs: 0 });
     }, delay);
     state.timer.unref?.();
@@ -933,6 +934,12 @@ export function startHeartbeatRunner(opts: {
   };
 
   const run: HeartbeatWakeHandler = async (params) => {
+    if (state.stopped) {
+      return {
+        status: "skipped",
+        reason: "disabled",
+      } satisfies HeartbeatRunResult;
+    }
     if (!heartbeatsEnabled) {
       return {
         status: "skipped",
@@ -994,12 +1001,14 @@ export function startHeartbeatRunner(opts: {
     return { status: "skipped", reason: isInterval ? "not-due" : "disabled" };
   };
 
-  setHeartbeatWakeHandler(async (params) => run({ reason: params.reason }));
+  const wakeHandler: HeartbeatWakeHandler = async (params) => run({ reason: params.reason });
+  const disposeWakeHandler = setHeartbeatWakeHandler(wakeHandler);
   updateConfig(state.cfg);
 
   const cleanup = () => {
+    if (state.stopped) return;
     state.stopped = true;
-    setHeartbeatWakeHandler(null);
+    disposeWakeHandler();
     if (state.timer) {
       clearTimeout(state.timer);
     }

--- a/src/infra/heartbeat-wake.ts
+++ b/src/infra/heartbeat-wake.ts
@@ -6,20 +6,33 @@ export type HeartbeatRunResult =
 export type HeartbeatWakeHandler = (opts: { reason?: string }) => Promise<HeartbeatRunResult>;
 
 let handler: HeartbeatWakeHandler | null = null;
+let handlerGeneration = 0;
 let pendingReason: string | null = null;
 let scheduled = false;
 let running = false;
 let timer: NodeJS.Timeout | null = null;
+let timerDueAt: number | null = null;
 
 const DEFAULT_COALESCE_MS = 250;
 const DEFAULT_RETRY_MS = 1_000;
 
 function schedule(coalesceMs: number) {
+  const delay = Number.isFinite(coalesceMs) ? Math.max(0, coalesceMs) : DEFAULT_COALESCE_MS;
+  const dueAt = Date.now() + delay;
   if (timer) {
-    return;
+    // If existing timer fires sooner or at the same time, keep it.
+    if (typeof timerDueAt === "number" && timerDueAt <= dueAt) {
+      return;
+    }
+    // New request needs to fire sooner — preempt the existing timer.
+    clearTimeout(timer);
+    timer = null;
+    timerDueAt = null;
   }
+  timerDueAt = dueAt;
   timer = setTimeout(async () => {
     timer = null;
+    timerDueAt = null;
     scheduled = false;
     const active = handler;
     if (!active) {
@@ -27,7 +40,7 @@ function schedule(coalesceMs: number) {
     }
     if (running) {
       scheduled = true;
-      schedule(coalesceMs);
+      schedule(delay);
       return;
     }
 
@@ -48,18 +61,32 @@ function schedule(coalesceMs: number) {
     } finally {
       running = false;
       if (pendingReason || scheduled) {
-        schedule(coalesceMs);
+        schedule(delay);
       }
     }
-  }, coalesceMs);
+  }, delay);
   timer.unref?.();
 }
 
-export function setHeartbeatWakeHandler(next: HeartbeatWakeHandler | null) {
+/**
+ * Register (or clear) the heartbeat wake handler.
+ * Returns a disposer function that clears this specific registration.
+ * Stale disposers (from previous registrations) are no-ops, preventing
+ * a race where an old runner's cleanup clears a newer runner's handler.
+ */
+export function setHeartbeatWakeHandler(next: HeartbeatWakeHandler | null): () => void {
+  handlerGeneration += 1;
+  const generation = handlerGeneration;
   handler = next;
   if (handler && pendingReason) {
     schedule(DEFAULT_COALESCE_MS);
   }
+  return () => {
+    if (handlerGeneration !== generation) return;
+    if (handler !== next) return;
+    handlerGeneration += 1;
+    handler = null;
+  };
 }
 
 export function requestHeartbeatNow(opts?: { reason?: string; coalesceMs?: number }) {


### PR DESCRIPTION
## Problem

The heartbeat scheduler silently stops firing after 1-3 hours of operation. Gateway restart temporarily fixes it. This is a different root cause than #14892 (fixed by #14901).

## Root Cause

Three interrelated issues in `heartbeat-wake.ts` and `heartbeat-runner.ts`:

### 1. Wake handler ownership race
`setHeartbeatWakeHandler()` is a global setter with no ownership protection. During lifecycle reloads, a stale runner's `cleanup()` calls `setHeartbeatWakeHandler(null)`, which clears the **newer** runner's handler. All future wake attempts see `handler === null` and silently return.

### 2. Lossy wake scheduling
`schedule()` has `if (timer) return` — new requests are silently dropped while any timer exists, even if the new request should fire sooner.

### 3. Timer state leak in scheduleNext
The `scheduleNext()` setTimeout callback calls `requestHeartbeatNow()` without clearing `state.timer` first, leaving stale state.

## Fix

- `setHeartbeatWakeHandler()` returns a **generation-based disposer**. Stale disposers from previous registrations are no-ops — they cannot clear a newer handler.
- `schedule()` **compares due times**: earlier requests preempt later timers; later requests are coalesced.
- `scheduleNext` callback clears `state.timer` before calling `requestHeartbeatNow()`.
- Runner cleanup is **idempotent** (guards on `state.stopped`).
- `run()` checks `state.stopped` before executing.

## Changes

| File | Changes |
|------|---------|
| `heartbeat-wake.ts` | Generation-based disposer, timer preemption |
| `heartbeat-runner.ts` | Disposer-based cleanup, stopped guard, timer cleanup |
| `heartbeat-wake.test.ts` | 3 new tests (stale disposer, timer preemption, timer coalescing) |
| `heartbeat-runner.scheduler.test.ts` | 2 new tests (overlapping runners, stopped guard) |

## Testing

5 new tests covering all failure modes. Existing tests unmodified and should pass.

Fixes #15106
Related: #14892, #14901

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes a race where a stale heartbeat runner cleanup could clear the *new* wake handler, causing the heartbeat scheduler to stop firing silently.

Key changes:
- `src/infra/heartbeat-wake.ts` now makes `setHeartbeatWakeHandler()` return a generation-based disposer so older registrations can’t clear newer ones, and updates `schedule()` to preempt timers when a sooner due time is requested.
- `src/infra/heartbeat-runner.ts` uses the disposer on cleanup, makes cleanup idempotent via `state.stopped`, clears `state.timer` before issuing a wake, and returns `skipped` early when stopped.
- Adds focused unit tests in `heartbeat-wake.test.ts` and `heartbeat-runner.scheduler.test.ts` to cover stale disposer behavior, timer preemption/coalescing, overlapping runners, and stopped-runner behavior.

Overall, the changes fit the existing architecture where `heartbeat-runner` registers a single global wake handler and `heartbeat-wake` provides coalesced scheduling around that handler, improving correctness under lifecycle reloads and heavy wake traffic.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are localized to the heartbeat wake/runner modules, address a concrete race and timer-state bug, and are covered by new unit tests that exercise the previously failing scenarios (stale disposer, timer preemption/coalescing, overlapping runners, stopped guard). No additional call sites are impacted by the wake handler API change.
- No files require special attention

<sub>Last reviewed commit: 5052035</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->