### PR TITLE
fix: queue messages during compaction instead of dropping them

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
@@ -3,6 +3,7 @@ import type { EmbeddedPiSubscribeContext } from "./pi-embedded-subscribe.handler
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { createInlineCodeState } from "../markdown/code-spans.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+import { flushPendingCompactionMessages } from "./pi-embedded-runner/runs.js";
 
 export function handleAgentStart(ctx: EmbeddedPiSubscribeContext) {
   ctx.log.debug(`embedded run agent start: runId=${ctx.params.runId}`);
@@ -89,6 +90,12 @@ export function handleAutoCompactionEnd(
         .catch((err) => {
           ctx.log.warn(`after_compaction hook failed: ${String(err)}`);
         });
+    }
+
+    // Flush any messages that were queued during compaction
+    const sessionId = (ctx.params.session as { id?: string }).id;
+    if (sessionId) {
+      flushPendingCompactionMessages(sessionId);
     }
   }
 }

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
@@ -93,7 +93,7 @@ export function handleAutoCompactionEnd(
     }
 
     // Flush any messages that were queued during compaction
-    const sessionId = (ctx.params.session as { id?: string }).id;
+    const sessionId = (ctx.params.session as { sessionId?: string }).sessionId;
     if (sessionId) {
       flushPendingCompactionMessages(sessionId);
     }


### PR DESCRIPTION
## Problem

When an embedded PI session is compacting, incoming messages were silently dropped. This caused agent unresponsiveness when messages arrived during the compaction window — the user sends a message, it arrives during compaction, and it's silently lost.

## Solution

Instead of dropping messages during compaction, queue them (up to 10) and flush them when compaction completes.

### Changes

1. **runs.ts**
   - Add `PENDING_COMPACTION_MESSAGES` map to queue messages during compaction
   - Limit queue to 10 messages to prevent unbounded growth
   - Add `flushPendingCompactionMessages()` to process queue after compaction
   - Combine queued messages into single agent turn to avoid spam

2. **pi-embedded-subscribe.handlers.lifecycle.ts**  
   - Call `flushPendingCompactionMessages()` in `handleAutoCompactionEnd()` when compaction completes (without retry)

## Testing

Deployed locally and verified messages are now preserved through compaction. Queued messages appear with a header indicating they were queued while the agent was busy.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes embedded PI message steering during compaction: instead of rejecting messages when `isCompacting()` is true, it buffers up to 10 per session and flushes them on compaction end by combining them into a single agent turn. It also hooks the compaction-end lifecycle handler to trigger a flush when compaction completes without retry.

Main integration points are `queueEmbeddedPiMessage()` / `flushPendingCompactionMessages()` in `src/agents/pi-embedded-runner/runs.ts` and the call from `handleAutoCompactionEnd()` in `src/agents/pi-embedded-subscribe.handlers.lifecycle.ts`.

<h3>Confidence Score: 3/5</h3>

- Mostly safe, but a race can still drop queued messages in some end-of-compaction scenarios.
- Core behavior matches the PR intent, but `flushPendingCompactionMessages()` deletes the pending queue before verifying an active, streaming handle. If compaction-end is observed after run teardown (or streaming flips false), buffered messages are lost, which undermines the fix. Also includes an unused `onCompactionComplete` field.
- src/agents/pi-embedded-runner/runs.ts

<sub>Last reviewed commit: 3be17ab</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->