### PR TITLE
fix: clean up transcript paths on session corruption with proper error handling

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -13,6 +13,7 @@ import {
 } from "../../agents/pi-embedded-helpers.js";
 import { runEmbeddedPiAgent } from "../../agents/pi-embedded.js";
 import {
+  resolveAgentIdFromSessionKey,
   resolveGroupSessionKey,
   resolveSessionTranscriptPath,
   type SessionEntry,

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -518,12 +518,23 @@ export async function runAgentTurnWithFallback(params: {
 
         try {
           // Delete transcript file if it exists
+          // Try both thread-scoped and non-thread-scoped paths
           if (corruptedSessionId) {
-            const transcriptPath = resolveSessionTranscriptPath(corruptedSessionId);
-            try {
-              fs.unlinkSync(transcriptPath);
-            } catch {
-              // Ignore if file doesn't exist
+            const agentId = resolveAgentIdFromSessionKey(sessionKey);
+            const transcriptCandidates = [
+              resolveSessionTranscriptPath(corruptedSessionId, agentId),
+              resolveSessionTranscriptPath(
+                corruptedSessionId,
+                agentId,
+                params.sessionCtx.MessageThreadId,
+              ),
+            ];
+            for (const candidate of transcriptCandidates) {
+              try {
+                await fs.promises.unlink(candidate);
+              } catch {
+                // Ignore if file doesn't exist
+              }
             }
           }
 

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -518,22 +518,31 @@ export async function runAgentTurnWithFallback(params: {
 
         try {
           // Delete transcript file if it exists
-          // Try both thread-scoped and non-thread-scoped paths
+          // Clean up non-thread-scoped transcript, and thread-scoped if applicable
           if (corruptedSessionId) {
             const agentId = resolveAgentIdFromSessionKey(sessionKey);
             const transcriptCandidates = [
               resolveSessionTranscriptPath(corruptedSessionId, agentId),
-              resolveSessionTranscriptPath(
-                corruptedSessionId,
-                agentId,
-                params.sessionCtx.MessageThreadId,
-              ),
             ];
+            // Add thread-scoped path if MessageThreadId is present and non-empty
+            let threadId = params.sessionCtx.MessageThreadId;
+            if (typeof threadId === "string") {
+              threadId = threadId.trim() || undefined;
+            }
+            if (threadId != null && threadId !== "") {
+              transcriptCandidates.push(
+                resolveSessionTranscriptPath(corruptedSessionId, agentId, threadId),
+              );
+            }
             for (const candidate of transcriptCandidates) {
               try {
                 await fs.promises.unlink(candidate);
-              } catch {
-                // Ignore if file doesn't exist
+              } catch (err) {
+                // Ignore if file doesn't exist, but log other errors
+                const errCode = (err as NodeJS.ErrnoException).code;
+                if (errCode !== "ENOENT") {
+                  defaultRuntime.error(`Failed to delete transcript ${candidate}: ${String(err)}`);
+                }
               }
             }
           }


### PR DESCRIPTION
## Summary

Fixes transcript file cleanup during **Gemini session corruption recovery** to properly handle both thread-scoped and non-thread-scoped transcript paths, with improved error handling.

## Changes

- **Add agentId parameter** to `resolveSessionTranscriptPath` calls (was missing, causing lookups in wrong directory)
- **Conditionally clean up thread-scoped transcripts** - only when `MessageThreadId` is present and non-empty, avoiding wasteful duplicate deletion attempts
- **Improve error handling** - log non-ENOENT errors instead of silently suppressing all failures
- **Switch to async** - use `fs.promises.unlink()` instead of `fs.unlinkSync()`

## Context

When a **Gemini** session becomes corrupted (function call ordering error: `"function call turn comes immediately after"`), the auto-recovery logic resets the session and attempts to delete the transcript file. Previously, it:

1. Only tried the non-thread-scoped path
2. Didn't pass the agentId parameter (potentially wrong directory)
3. Always tried both paths even when thread ID was absent (duplicate deletion)
4. Silently swallowed all errors including permission/IO errors

This fix ensures proper cleanup of all transcript variants while avoiding unnecessary operations and providing better error visibility.

## Scope

**This PR specifically fixes the Gemini corruption handler** (triggered by `isSessionCorruption`), but the codebase has other corruption handlers that likely have similar bugs:

- `isRoleOrderingError` - Generic role alternation errors (Anthropic, OpenAI, etc.)
- `isCompactionFailure` - Compaction errors (any provider)

The improvements in this PR (agentId, thread-scoped cleanup, error logging) are reusable patterns that could benefit those other handlers in future work.

## Testing

- ✅ Build passed
- ✅ TypeScript type-checking passed
- ✅ Linting passed (0 errors)
- ✅ Formatting passed

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates the Gemini session-corruption recovery path in `src/auto-reply/reply/agent-runner-execution.ts` to delete the correct transcript file(s) when resetting a corrupted session.

Key behavior changes:
- Transcript deletion now resolves paths with the **agentId** derived from the session key, so cleanup targets the right `~/.openclaw/agents/<agentId>/sessions/*.jsonl` directory.
- Cleanup attempts both the non-thread-scoped transcript and, when a non-empty `MessageThreadId` is present, the thread-scoped `-topic-...` transcript variant.
- Deletion is now async (`fs.promises.unlink`) and only suppresses `ENOENT`, logging other unlink failures.

This fits into the existing auto-recovery block guarded by `isSessionCorruption` (Gemini-specific), before the session entry is removed from the in-memory snapshot and the on-disk session store via `updateSessionStore`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is localized to Gemini session-corruption recovery and primarily improves correctness of transcript path resolution (agent-scoped + optional thread-scoped) while switching to async unlink with selective error logging. No remaining unverified or reproducible functional issues were found in the modified logic.
- No files require special attention

<sub>Last reviewed commit: deb2a48</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->