### PR TITLE
fix: reset totalTokens after compaction when estimation fails (#15101)

### DIFF
--- a/src/auto-reply/reply/session-updates.incrementcompactioncount.test.ts
+++ b/src/auto-reply/reply/session-updates.incrementcompactioncount.test.ts
@@ -70,7 +70,7 @@ describe("incrementCompactionCount", () => {
     expect(stored[sessionKey].outputTokens).toBeUndefined();
   });
 
-  it("does not update totalTokens when tokensAfter is not provided", async () => {
+  it("resets totalTokens to 0 when tokensAfter is not provided", async () => {
     const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-compact-"));
     const storePath = path.join(tmp, "sessions.json");
     const sessionKey = "main";
@@ -92,7 +92,9 @@ describe("incrementCompactionCount", () => {
 
     const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));
     expect(stored[sessionKey].compactionCount).toBe(1);
-    // totalTokens unchanged
-    expect(stored[sessionKey].totalTokens).toBe(180_000);
+    // totalTokens reset to 0 to prevent stale values from triggering false memory flushes
+    expect(stored[sessionKey].totalTokens).toBe(0);
+    expect(stored[sessionKey].inputTokens).toBe(0);
+    expect(stored[sessionKey].outputTokens).toBe(0);
   });
 });


### PR DESCRIPTION
## Problem

When `estimateCompactionTokensAfter()` returns `undefined`, `incrementCompactionCount()` leaves the pre-compaction `totalTokens` on the session entry unchanged. On the next turn, `shouldRunMemoryFlush()` reads this stale high value and triggers a memory flush immediately after compaction, even though the context is now small.

This creates a compaction → flush → compaction bounce cycle.

## Root Cause

In `session-updates.ts`, the `else` branch was missing:

```ts
if (tokensAfter != null && tokensAfter > 0) {
  updates.totalTokens = tokensAfter;
  updates.inputTokens = undefined;
  updates.outputTokens = undefined;
}
// else: totalTokens stays at the pre-compaction value ← BUG
```

`estimateCompactionTokensAfter()` returns `undefined` when:
- Session file is missing
- Estimated `tokensAfter > tokensBefore` (heuristic overcount)
- Estimation fails for any other reason

## Fix

Reset `totalTokens`/`inputTokens`/`outputTokens` to 0 when `tokensAfter` is unavailable. The correct count is restored on the next turn when `persistSessionUsageUpdate` runs with fresh usage data from the model.

## Why this is safe

Setting to 0 is conservative — it prevents false memory flush triggers. The actual token count self-corrects on the very next model call via `persistSessionUsageUpdate`, which uses the `promptTokens` override from the latest API response (added in #14102).

## Test

Updated `session-updates.incrementcompactioncount.test.ts` to verify the new reset behavior.

Closes #15101

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `incrementCompactionCount` to clear stale cached token counts after compaction when `tokensAfter` (the post-compaction token estimate) is unavailable. Previously, the pre-compaction `totalTokens` could remain in the session entry and cause `shouldRunMemoryFlush` to immediately trigger a flush on the next turn, creating a compaction→flush bounce.

The change resets `totalTokens/inputTokens/outputTokens` to `0` in the “estimation failed” case, relying on `persistSessionUsageUpdate` to restore accurate counts on the next model call. Tests were updated to assert the new reset behavior.


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is localized to session token bookkeeping after compaction and is covered by an updated unit test; related code paths (`shouldRunMemoryFlush`, `persistSessionUsageUpdate`) align with the new semantics (0 disables flush; next call repopulates usage).
- No files require special attention

<sub>Last reviewed commit: 7b33bd8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->