### PR TITLE
fix: guard against undefined modelId to prevent .trim() crash in subagent spawn (#15125)

### DIFF
--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -101,7 +101,7 @@ export function buildSystemPrompt(params: {
   });
 }
 
-export function normalizeCliModel(modelId: string, backend: CliBackendConfig): string {
+export function normalizeCliModel(modelId: string | undefined, backend: CliBackendConfig): string {
   if (!modelId || typeof modelId !== "string") {
     console.warn(
       `[openclaw] normalizeCliModel called with invalid modelId: ${String(modelId)}. ` +

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -102,6 +102,13 @@ export function buildSystemPrompt(params: {
 }
 
 export function normalizeCliModel(modelId: string, backend: CliBackendConfig): string {
+  if (!modelId || typeof modelId !== "string") {
+    console.warn(
+      `[openclaw] normalizeCliModel called with invalid modelId: ${String(modelId)}. ` +
+        `This indicates a bug in the caller.`,
+    );
+    return "";
+  }
   const trimmed = modelId.trim();
   if (!trimmed) {
     return trimmed;

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -42,7 +42,7 @@ export function buildInlineProviderModels(
 
 export function resolveModel(
   provider: string,
-  modelId: string,
+  modelId: string | undefined,
   agentDir?: string,
   cfg?: OpenClawConfig,
 ): {

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -51,6 +51,23 @@ export function resolveModel(
   authStorage: AuthStorage;
   modelRegistry: ModelRegistry;
 } {
+  // Guard against undefined/null modelId — log a warning so the upstream caller
+  // can be traced, then return an error instead of crashing on .trim().
+  if (!modelId || typeof modelId !== "string") {
+    console.warn(
+      `[openclaw] resolveModel called with invalid modelId: ${String(modelId)} (provider=${provider}). ` +
+        `This indicates a bug in the caller — modelId should always be a non-empty string.`,
+    );
+    const resolvedAgentDir = agentDir ?? resolveOpenClawAgentDir();
+    const authStorage = discoverAuthStorage(resolvedAgentDir);
+    const modelRegistry = discoverModels(authStorage, resolvedAgentDir);
+    return {
+      error: `Invalid modelId: ${String(modelId)}. Check model configuration or session overrides.`,
+      authStorage,
+      modelRegistry,
+    };
+  }
+
   const resolvedAgentDir = agentDir ?? resolveOpenClawAgentDir();
   const authStorage = discoverAuthStorage(resolvedAgentDir);
   const modelRegistry = discoverModels(authStorage, resolvedAgentDir);


### PR DESCRIPTION
## Problem

All subagent spawns crash with:

```
TypeError: Cannot read properties of undefined (reading 'trim')
```

100% reproducible. The crash occurs in `resolveModel()` and `normalizeCliModel()` when `modelId` is `undefined`.

## Root Cause

Session model overrides or misconfigured model references can pass `undefined` as `modelId` to functions that call `.trim()` without checking.

## Fix

Add defensive guards with `console.warn()` in both `resolveModel()` and `normalizeCliModel()` so:
1. The crash is prevented (returns error/empty string instead)
2. A warning is logged with the invalid value, making it easy to trace the upstream caller

## Changes (v2)

- **Removed** unrelated compaction reset changes (now covered by the `totalTokensFresh` approach in #15133)
- **Added** `console.warn()` to both guards so the root cause caller can be traced in logs
- **Added** DCO sign-off
- Rebased on latest `main`

Fixes #15125