### PR TITLE
fix(sandbox): pass docker.env into sandbox container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Sandbox: pass configured `sandbox.docker.env` variables to sandbox containers at `docker create` time. (#15138) Thanks @stevebot-alive.
 - Onboarding/CLI: restore terminal state without resuming paused `stdin`, so onboarding exits cleanly after choosing Web UI and the installer returns instead of appearing stuck.
 - macOS Voice Wake: fix a crash in trigger trimming for CJK/Unicode transcripts by matching and slicing on original-string ranges instead of transformed-string indices. (#11052) Thanks @Flash-LHR.
 - Heartbeat: prevent scheduler silent-death races during runner reloads, preserve retry cooldown backoff under wake bursts, and prioritize user/action wake causes over interval/retry reasons when coalescing. (#15108) Thanks @joeykrug.

--- a/src/agents/sandbox-create-args.test.ts
+++ b/src/agents/sandbox-create-args.test.ts
@@ -78,6 +78,7 @@ describe("buildSandboxCreateArgs", () => {
         "1.5",
       ]),
     );
+    expect(args).toEqual(expect.arrayContaining(["--env", "LANG=C.UTF-8"]));
 
     const ulimitValues: string[] = [];
     for (let i = 0; i < args.length; i += 1) {

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -155,6 +155,10 @@ export function buildSandboxCreateArgs(params: {
   if (params.cfg.user) {
     args.push("--user", params.cfg.user);
   }
+  for (const [key, value] of Object.entries(params.cfg.env ?? {})) {
+    if (!key.trim()) continue;
+    args.push("--env", key + "=" + value);
+  }
   for (const cap of params.cfg.capDrop) {
     args.push("--cap-drop", cap);
   }

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -156,7 +156,9 @@ export function buildSandboxCreateArgs(params: {
     args.push("--user", params.cfg.user);
   }
   for (const [key, value] of Object.entries(params.cfg.env ?? {})) {
-    if (!key.trim()) continue;
+    if (!key.trim()) {
+      continue;
+    }
     args.push("--env", key + "=" + value);
   }
   for (const cap of params.cfg.capDrop) {


### PR DESCRIPTION
AI-assisted.

## Problem
Docs say `agents.defaults.sandbox.docker.env` is the way to pass env vars into sandboxed skills/tools, but sandbox containers are currently created with only `PATH` in `.Config.Env` (no configured env vars make it into the container).

This blocks common setups like providing `GH_TOKEN`, `GEMINI_API_KEY`, etc. to tools running inside the sandbox.

## Change
When creating the sandbox container, emit `docker create --env KEY=VALUE` for each entry in `SandboxDockerConfig.env`.

Code:
- `src/agents/sandbox/docker.ts` (`buildSandboxCreateArgs`)

## How to verify
1. Set a sandbox env var in config, e.g.:
   - `agents.defaults.sandbox.docker.env.GH_TOKEN = "test"`
2. Recreate the sandbox container
3. Confirm it’s present:
   ```bash
   docker inspect <container> --format '{{range .Config.Env}}{{println .}}{{end}}' | grep '^GH_TOKEN='

I did not run full  locally in this environment (no node/pnpm available); change is small and directly maps config -> docker CLI flags.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change threads the sandbox docker config’s environment map into container creation by appending `--env` flags in `buildSandboxCreateArgs` (used by `createSandboxContainer` before `docker create`). This aligns the container’s runtime environment with configured settings, and the values are included in the sandbox config hash so changes to the env map will be treated as a config change.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is small and localized to docker container creation args, uses existing typed config (`env?: Record<string,string>`), and integrates cleanly with existing config hashing/recreate behavior. No functional regressions were identified in the surrounding docker argument construction logic.
- src/agents/sandbox/docker.ts

<sub>Last reviewed commit: 78195eb</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->