### PR TITLE
fix(ui): fallbacks input always empty even when config has models (#15131)

### DIFF
--- a/ui/src/ui/views/agents-fallbacks.node.test.ts
+++ b/ui/src/ui/views/agents-fallbacks.node.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { resolveModelFallbacks } from "./agents.ts";
+
+describe("resolveModelFallbacks", () => {
+  it("returns null for undefined model", () => {
+    expect(resolveModelFallbacks(undefined)).toBeNull();
+  });
+
+  it("returns null for string model (no fallbacks)", () => {
+    expect(resolveModelFallbacks("anthropic/claude-sonnet-4-5")).toBeNull();
+  });
+
+  it("extracts fallbacks from object model with fallbacks array", () => {
+    const model = {
+      primary: "anthropic/claude-sonnet-4-5",
+      fallbacks: ["openai/gpt-4o", "anthropic/claude-haiku-4-5-20241022"],
+    };
+    expect(resolveModelFallbacks(model)).toEqual([
+      "openai/gpt-4o",
+      "anthropic/claude-haiku-4-5-20241022",
+    ]);
+  });
+
+  it("extracts fallbacks from object model with fallback (singular) array", () => {
+    const model = {
+      primary: "anthropic/claude-sonnet-4-5",
+      fallback: ["openai/gpt-4o"],
+    };
+    expect(resolveModelFallbacks(model)).toEqual(["openai/gpt-4o"]);
+  });
+
+  it("returns null for object model without fallbacks", () => {
+    expect(resolveModelFallbacks({ primary: "anthropic/claude-sonnet-4-5" })).toBeNull();
+  });
+
+  it("filters out non-string entries", () => {
+    const model = {
+      primary: "anthropic/claude-sonnet-4-5",
+      fallbacks: ["openai/gpt-4o", 42, null, "anthropic/claude-haiku-4-5-20241022"],
+    };
+    expect(resolveModelFallbacks(model)).toEqual([
+      "openai/gpt-4o",
+      "anthropic/claude-haiku-4-5-20241022",
+    ]);
+  });
+});

--- a/ui/src/ui/views/agents.ts
+++ b/ui/src/ui/views/agents.ts
@@ -381,7 +381,7 @@ function resolveModelPrimary(model?: unknown): string | null {
   return null;
 }
 
-function resolveModelFallbacks(model?: unknown): string[] | null {
+export function resolveModelFallbacks(model?: unknown): string[] | null {
   if (!model || typeof model === "string") {
     return null;
   }
@@ -820,7 +820,8 @@ function renderAgentOverview(params: {
     resolveModelPrimary(config.defaults?.model) ||
     (defaultModel !== "-" ? normalizeModelValue(defaultModel) : null);
   const effectivePrimary = modelPrimary ?? defaultPrimary ?? null;
-  const modelFallbacks = resolveModelFallbacks(config.entry?.model);
+  const modelFallbacks =
+    resolveModelFallbacks(config.entry?.model) ?? resolveModelFallbacks(config.defaults?.model);
   const fallbackText = modelFallbacks ? modelFallbacks.join(", ") : "";
   const identityName =
     agentIdentity?.name?.trim() ||

--- a/vitest.unit.config.ts
+++ b/vitest.unit.config.ts
@@ -7,13 +7,14 @@ const include = baseTest.include ?? [
   "extensions/**/*.test.ts",
   "test/format-error.test.ts",
 ];
+const extraIncludes = ["ui/src/**/*.node.test.ts"];
 const exclude = baseTest.exclude ?? [];
 
 export default defineConfig({
   ...baseConfig,
   test: {
     ...baseTest,
-    include,
+    include: [...include, ...extraIncludes],
     exclude: [...exclude, "src/gateway/**", "extensions/**"],
   },
 });


### PR DESCRIPTION
#### Summary

The Fallbacks input field on the Agent Overview page is always empty, even when `agents.defaults.model.fallbacks` has entries. The Primary Model label correctly shows `(+2 fallback)` but the input below it doesn't get populated.

Closes #15131

lobster-biscuit

#### Repro Steps

1. Set `agents.defaults.model.fallbacks` in `openclaw.json` with 2+ models
2. Open Control UI → Agents → Overview tab
3. The "Fallbacks (comma-separated)" input is empty despite the label showing the correct count

#### Root Cause

`renderAgentOverview` in `agents.ts` resolves fallback models from `config.entry?.model` only. Single-agent setups (and any agent without a per-agent model override) don't populate `config.entry.model`, so `resolveModelFallbacks` returns `null` and the input stays empty. The label works because `resolveModelLabel` already checks both entry and defaults.

#### Behavior Changes
- Before: Fallbacks input always empty when using global defaults
- After: Fallbacks input shows the configured fallback models from `agents.defaults.model.fallbacks`

#### Tests

- `agents-fallbacks.node.test.ts` — covers `resolveModelFallbacks` for undefined, string, object with fallbacks/fallback, missing fallbacks, and non-string filtering
- build, check pass

**Sign-Off**
- Models used: N/A
- Submitter effort: traced the mismatch between the label and input field, one-line fallback chain fix
- Agent notes: N/A

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes the Agents → Overview “Fallbacks (comma-separated)” field not being pre-populated when fallback models are only configured via `agents.defaults.model.fallbacks`. It does this by falling back to `config.defaults?.model` when `config.entry?.model` doesn’t define fallbacks, and adds a Vitest unit test file covering `resolveModelFallbacks` behavior for several model shapes (string, object w/ `fallbacks` or `fallback`, missing, and mixed-type arrays).

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge after ensuring the new test actually runs in CI.
- The functional change is small and localized (fallback chain in `renderAgentOverview`) and matches existing UI behavior for labels. The main remaining concern is whether the newly-added `*.node.test.ts` file is picked up by the project’s Vitest include pattern; if it isn’t, the regression coverage claimed by the PR won’t exist.
- ui/src/ui/views/agents-fallbacks.node.test.ts (confirm Vitest includes this pattern or rename)

<sub>Last reviewed commit: 757c4cf</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->