### PR TITLE
fix(transcript-repair): validate tool call id and name to prevent Gemini 400 errors

### DIFF
--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -116,8 +116,7 @@ export function repairToolCallInputs(messages: AgentMessage[]): ToolCallInputRep
       continue;
     }
 
-    const nextContent: any[] = [];
-    let droppedInMessage = 0;
+    const nextContent: unknown[] = [];
     let messageChanged = false;
 
     for (const block of msg.content) {
@@ -130,7 +129,6 @@ export function repairToolCallInputs(messages: AgentMessage[]): ToolCallInputRep
         // This minimizes the "orphan results" issue highlighted in PR review.
         if (!id || !hasToolCallInput(b)) {
           droppedToolCalls += 1;
-          droppedInMessage += 1;
           messageChanged = true;
           continue;
         }
@@ -159,7 +157,7 @@ export function repairToolCallInputs(messages: AgentMessage[]): ToolCallInputRep
         droppedAssistantMessages += 1;
         continue;
       }
-      out.push({ ...msg, content: nextContent });
+      out.push({ ...msg, content: nextContent as any });
       continue;
     }
 

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -215,6 +215,10 @@ export function repairToolUseResultPairing(messages: AgentMessage[]): ToolUseRep
     if (id) {
       seenToolResultIds.add(id);
     }
+    if (!msg.toolName || !msg.toolName.trim()) {
+      msg = { ...msg, toolName: "unknown" };
+      changed = true;
+    }
     out.push(msg);
   };
 

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -157,7 +157,10 @@ export function repairToolCallInputs(messages: AgentMessage[]): ToolCallInputRep
         droppedAssistantMessages += 1;
         continue;
       }
-      out.push({ ...msg, content: nextContent as any });
+      out.push({
+        ...msg,
+        content: nextContent as unknown as Extract<AgentMessage, { role: "assistant" }>["content"],
+      });
       continue;
     }
 

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -116,7 +116,7 @@ export function repairToolCallInputs(messages: AgentMessage[]): ToolCallInputRep
       continue;
     }
 
-    const nextContent = [];
+    const nextContent: any[] = [];
     let droppedInMessage = 0;
     let messageChanged = false;
 


### PR DESCRIPTION
This PR adds defensive validation to transcript repair to ensure tool calls have both an ID and a non-empty name. This prevents 400 REQUIRED_FIELD_MISSING errors from Gemini API caused by malformed tool calls in session history. Changes: 1. Added isValidToolCallBlock to check for id and name. 2. Updated repairToolCallInputs to drop invalid tool call blocks. 3. Hardened makeMissingToolResult to use "unknown" for empty names. 4. Updated extractToolCallsFromAssistant to skip tool calls with missing names.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens transcript sanitization/repair for tool use by normalizing tool call IDs and names, filling missing `toolName` fields with `"unknown"`, and dropping assistant tool-call blocks that are missing required inputs/ids. It also updates tool call extraction so synthetic tool results always have a non-empty name, reducing Gemini “REQUIRED_FIELD_MISSING” 400s when session history contains malformed tool calls.

These changes fit into the existing `sanitizeToolCallInputs` → `sanitizeToolUseResultPairing` pipeline in `src/agents/session-transcript-repair.ts`, whose goal is to produce provider-compatible message histories by ensuring tool calls have matching, adjacent tool results and by removing/repairing malformed entries.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but there is one normalization mismatch that can still orphan and drop valid tool results in edge cases.
- The changes are narrow and defensive, and they reduce malformed tool-call data reaching strict providers. The main remaining concern is inconsistent id normalization (toolCall ids are trimmed, toolResult ids are not), which can break pairing and cause silent toolResult drops when ids contain whitespace in persisted transcripts.
- src/agents/session-transcript-repair.ts

<sub>Last reviewed commit: 04f3747</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->