### PR TITLE
auto-reply: add message_time and compact inbound metadata JSON

### DIFF
--- a/src/auto-reply/envelope.ts
+++ b/src/auto-reply/envelope.ts
@@ -102,7 +102,7 @@ function resolveEnvelopeTimezone(options: NormalizedEnvelopeOptions): ResolvedEn
   return explicit ? { mode: "iana", timeZone: explicit } : { mode: "utc" };
 }
 
-function formatTimestamp(
+export function formatEnvelopeTimestamp(
   ts: number | Date | undefined,
   options?: EnvelopeFormatOptions,
 ): string | undefined {
@@ -179,7 +179,7 @@ export function formatAgentEnvelope(params: AgentEnvelopeParams): string {
   if (params.ip?.trim()) {
     parts.push(sanitizeEnvelopeHeaderPart(params.ip.trim()));
   }
-  const ts = formatTimestamp(params.timestamp, resolved);
+  const ts = formatEnvelopeTimestamp(params.timestamp, resolved);
   if (ts) {
     parts.push(ts);
   }

--- a/src/auto-reply/reply.raw-body.test.ts
+++ b/src/auto-reply/reply.raw-body.test.ts
@@ -84,8 +84,8 @@ describe("RawBody directive parsing", () => {
         (agentMocks.runEmbeddedPiAgent.mock.calls[0]?.[0] as { prompt?: string } | undefined)
           ?.prompt ?? "";
       expect(prompt).toContain("Chat history since last reply (untrusted, for context):");
-      expect(prompt).toContain('"sender": "Peter"');
-      expect(prompt).toContain('"body": "hello"');
+      expect(prompt).toContain('"sender":"Peter"');
+      expect(prompt).toContain('"body":"hello"');
       expect(prompt).toContain("status please");
       expect(prompt).not.toContain("/think:high");
     });

--- a/src/auto-reply/reply.triggers.group-intro-prompts.test.ts
+++ b/src/auto-reply/reply.triggers.group-intro-prompts.test.ts
@@ -19,6 +19,14 @@ function getLastExtraSystemPrompt() {
   return getRunEmbeddedPiAgentMock().mock.calls.at(-1)?.[0]?.extraSystemPrompt ?? "";
 }
 
+function parseInboundMetaPayload(text: string): Record<string, unknown> {
+  const match = text.match(/```json\n([\s\S]*?)\n```/);
+  if (!match?.[1]) {
+    throw new Error("missing inbound meta json block");
+  }
+  return JSON.parse(match[1]) as Record<string, unknown>;
+}
+
 describe("group intro prompts", () => {
   const groupParticipationNote =
     "Be a good group participant: mostly lurk and follow the conversation; reply only when directly addressed or you can add clear value. Emoji reactions are welcome when available. Write like a human. Avoid Markdown tables. Don't type literal \\n sequences; use real line breaks sparingly.";
@@ -43,7 +51,8 @@ describe("group intro prompts", () => {
 
       expect(getRunEmbeddedPiAgentMock()).toHaveBeenCalledOnce();
       const extraSystemPrompt = getLastExtraSystemPrompt();
-      expect(extraSystemPrompt).toContain('"channel": "discord"');
+      const inboundMeta = parseInboundMetaPayload(extraSystemPrompt);
+      expect(inboundMeta["channel"]).toBe("discord");
       expect(extraSystemPrompt).toContain(
         `You are in the Discord group chat "Release Squad". Participants: Alice, Bob.`,
       );
@@ -71,7 +80,8 @@ describe("group intro prompts", () => {
 
       expect(getRunEmbeddedPiAgentMock()).toHaveBeenCalledOnce();
       const extraSystemPrompt = getLastExtraSystemPrompt();
-      expect(extraSystemPrompt).toContain('"channel": "whatsapp"');
+      const inboundMeta = parseInboundMetaPayload(extraSystemPrompt);
+      expect(inboundMeta["channel"]).toBe("whatsapp");
       expect(extraSystemPrompt).toContain(`You are in the WhatsApp group chat "Ops".`);
       expect(extraSystemPrompt).toContain(
         `WhatsApp IDs: SenderId is the participant JID (group participant id).`,
@@ -100,7 +110,8 @@ describe("group intro prompts", () => {
 
       expect(getRunEmbeddedPiAgentMock()).toHaveBeenCalledOnce();
       const extraSystemPrompt = getLastExtraSystemPrompt();
-      expect(extraSystemPrompt).toContain('"channel": "telegram"');
+      const inboundMeta = parseInboundMetaPayload(extraSystemPrompt);
+      expect(inboundMeta["channel"]).toBe("telegram");
       expect(extraSystemPrompt).toContain(`You are in the Telegram group chat "Dev Chat".`);
       expect(extraSystemPrompt).toContain(
         `Activation: trigger-only (you are invoked only when explicitly mentioned; recent context may be included). ${groupParticipationNote} Address the specific sender noted in the message context.`,

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -21,6 +21,7 @@ import { clearCommandLane, getQueueSize } from "../../process/command-queue.js";
 import { normalizeMainKey } from "../../routing/session-key.js";
 import { isReasoningTagProvider } from "../../utils/provider-utils.js";
 import { hasControlCommand } from "../command-detection.js";
+import { resolveEnvelopeFormatOptions } from "../envelope.js";
 import { buildInboundMediaNote } from "../media-note.js";
 import type { MsgContext, TemplateContext } from "../templating.js";
 import {
@@ -218,6 +219,7 @@ export async function runPreparedReply(
             : {}),
         }
       : { ...sessionCtx, ThreadStarterBody: undefined },
+    { envelope: resolveEnvelopeFormatOptions(cfg) },
   );
   const baseBodyForPrompt = isBareSessionReset
     ? baseBodyFinal

--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -90,7 +90,46 @@ describe("buildInboundUserContextPrefix", () => {
     } as TemplateContext);
 
     expect(text).toContain("Conversation info (untrusted metadata):");
-    expect(text).toContain('"conversation_label": "ops-room"');
+    expect(text).toContain('"conversation_label":"ops-room"');
+  });
+});
+
+describe("buildInboundUserContextPrefix", () => {
+  it("includes message_time from ctx.Timestamp using envelope formatting", () => {
+    const text = buildInboundUserContextPrefix(
+      {
+        ChatType: "group",
+        ConversationLabel: "Ops",
+        Timestamp: 1700000000000,
+      } satisfies TemplateContext,
+      { envelope: { timezone: "utc" } },
+    );
+
+    expect(text).toContain("Conversation info (untrusted metadata):");
+    expect(text).toContain('"message_time":"Tue 2023-11-14T22:13Z"');
+  });
+
+  it("omits message_time when Timestamp is missing", () => {
+    const text = buildInboundUserContextPrefix({
+      ChatType: "group",
+      ConversationLabel: "Ops",
+    } satisfies TemplateContext);
+
+    expect(text).toContain("Conversation info (untrusted metadata):");
+    expect(text).not.toContain('"message_time"');
+  });
+
+  it("respects envelopeTimestamp=off and omits message_time", () => {
+    const text = buildInboundUserContextPrefix(
+      {
+        ChatType: "group",
+        ConversationLabel: "Ops",
+        Timestamp: 1700000000000,
+      } satisfies TemplateContext,
+      { envelope: { timezone: "utc", includeTimestamp: false } },
+    );
+
+    expect(text).not.toContain('"message_time"');
   });
 
   it("includes sender identifier in conversation info", () => {


### PR DESCRIPTION
## Summary

This patch improves prompt context reliability and token efficiency for structured inbound metadata:

1. Add `message_time` to `Conversation info (untrusted metadata)` so the model can see the current inbound message time in areadable, timezone-aware format.
2. Reuse envelope timestamp formatting logic for consistent timezone handling.
3. Compact JSON output for inbound metadata blocks to reduce prompt token usage.

## Problem

During the prompt-shaping migration from legacy envelope lines to structured metadata blocks, the current-message timestamp was not carried over into inbound metadata.
As a result, the model can lose explicit time context for the latest user turn even when `ctx.Timestamp` is available.

## Before / After

Before migration (legacy envelope format, timestamp present):

```text
[Telegram [User] id:123456 +5s Fri 2026-02-10 10:23 GMT+8]
```

After migration (structured metadata, current-message timestamp missing):

Conversation info (untrusted metadata):
```json
{
    "conversation_label": "[User] id:123456"
}
```

After this patch (structured metadata + readable current-message time):

Conversation info (untrusted metadata):
```json
{"conversation_label":"[User] id:123456","message_time":"Fri 2026-02-10 10:23 GMT+8"}
```

Also in this patch, metadata JSON formatting is compacted (single-line JSON) to reduce prompt token usage.

## What Changed

- `src/auto-reply/reply/inbound-meta.ts`
  - Added optional envelope-format options to `buildInboundUserContextPrefix(...)`.
  - Added `message_time` into `Conversation info (untrusted metadata)` when `ctx.Timestamp` is available.
  - Switched all inbound metadata JSON rendering from pretty (`JSON.stringify(..., null, 2)`) to compact (`JSON.stringify(...)`).

- `src/auto-reply/reply/get-reply-run.ts`
  - Pass envelope formatting config (`resolveEnvelopeFormatOptions(cfg)`) into `buildInboundUserContextPrefix(...)`.

- `src/auto-reply/envelope.ts`
  - Exported timestamp formatter as `formatEnvelopeTimestamp(...)` for shared use.

- Tests
  - Added `src/auto-reply/reply/inbound-meta.test.ts`.
  - Updated `src/auto-reply/reply.raw-body.test.ts` assertions for compact JSON output.

## Behavior Notes

- `message_time` is sourced from `ctx.Timestamp` only.
- `message_time` respects envelope timestamp visibility config (`agents.defaults.envelopeTimestamp`), i.e. it is omitted when timestamp output is disabled.
- No message interval field is added.

## AI-Assisted Transparency (Vibe-Coded)

- AI-assisted: **Yes** (Codex, gpt-5.3-codex high).
- Testing degree: **Fully tested** (`pnpm test` full suite passed).
- Deployment validation: **Passed** in personal production deployment.
- Author understanding: I reviewed and understand the implemented changes and their runtime behavior.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates auto-reply prompt shaping to (1) include the current inbound message timestamp in the user-role “Conversation info (untrusted metadata)” block as `message_time`, formatted using the same envelope timestamp logic and honoring `agents.defaults.envelopeTimestamp`, and (2) compact JSON rendering for inbound metadata blocks (switching from pretty-printed `JSON.stringify(..., null, 2)` to compact `JSON.stringify(...)`) to reduce prompt token usage.

Changes are localized to the auto-reply prompt construction pipeline: `formatEnvelopeTimestamp` is exported from `src/auto-reply/envelope.ts` and reused by `src/auto-reply/reply/inbound-meta.ts`; `runPreparedReply` now passes resolved envelope formatting options into `buildInboundUserContextPrefix`. Tests are updated/added to assert compact JSON output and the new `message_time` behavior.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are small and well-contained to prompt formatting: exporting an existing timestamp formatter, threading envelope options through one call site, and switching JSON output to compact form. Type definitions confirm `TemplateContext.Timestamp` is numeric, and repo-wide search shows no remaining references to the old private formatter name that would break builds.
- No files require special attention

<sub>Last reviewed commit: e80af47</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->