### PR TITLE
fix(docs): remove hardcoded Mermaid init blocks that break dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 - macOS Voice Wake: fix a crash in trigger trimming for CJK/Unicode transcripts by matching and slicing on original-string ranges instead of transformed-string indices. (#11052) Thanks @Flash-LHR.
 - Heartbeat: prevent scheduler silent-death races during runner reloads, preserve retry cooldown backoff under wake bursts, and prioritize user/action wake causes over interval/retry reasons when coalescing. (#15108) Thanks @joeykrug.
 - Exec/Allowlist: allow multiline heredoc bodies (`<<`, `<<-`) while keeping multiline non-heredoc shell commands blocked, so exec approval parsing permits heredoc input safely without allowing general newline command chaining. (#13811) Thanks @mcaxtr.
+- Docs/Mermaid: remove hardcoded Mermaid init theme blocks from four docs diagrams so dark mode inherits readable theme defaults. (#15157) Thanks @heytulsiprasad.
 
 ## 2026.2.12
 

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -56,22 +56,6 @@ Protocol details:
 ## Connection lifecycle (single client)
 
 ```mermaid
-%%{init: {
-  'theme': 'base',
-  'themeVariables': {
-    'primaryColor': '#ffffff',
-    'primaryTextColor': '#000000',
-    'primaryBorderColor': '#000000',
-    'lineColor': '#000000',
-    'secondaryColor': '#f9f9fb',
-    'tertiaryColor': '#ffffff',
-    'clusterBkg': '#f9f9fb',
-    'clusterBorder': '#000000',
-    'nodeBorder': '#000000',
-    'mainBkg': '#ffffff',
-    'edgeLabelBackground': '#ffffff'
-  }
-}}%%
 sequenceDiagram
     participant Client
     participant Gateway

--- a/docs/gateway/remote-gateway-readme.md
+++ b/docs/gateway/remote-gateway-readme.md
@@ -11,22 +11,6 @@ OpenClaw.app uses SSH tunneling to connect to a remote gateway. This guide shows
 ## Overview
 
 ```mermaid
-%%{init: {
-  'theme': 'base',
-  'themeVariables': {
-    'primaryColor': '#ffffff',
-    'primaryTextColor': '#000000',
-    'primaryBorderColor': '#000000',
-    'lineColor': '#000000',
-    'secondaryColor': '#f9f9fb',
-    'tertiaryColor': '#ffffff',
-    'clusterBkg': '#f9f9fb',
-    'clusterBorder': '#000000',
-    'nodeBorder': '#000000',
-    'mainBkg': '#ffffff',
-    'edgeLabelBackground': '#ffffff'
-  }
-}}%%
 flowchart TB
     subgraph Client["Client Machine"]
         direction TB

--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -801,22 +801,6 @@ Commit the updated `.secrets.baseline` once it reflects the intended state.
 ## The Trust Hierarchy
 
 ```mermaid
-%%{init: {
-  'theme': 'base',
-  'themeVariables': {
-    'primaryColor': '#ffffff',
-    'primaryTextColor': '#000000',
-    'primaryBorderColor': '#000000',
-    'lineColor': '#000000',
-    'secondaryColor': '#f9f9fb',
-    'tertiaryColor': '#ffffff',
-    'clusterBkg': '#f9f9fb',
-    'clusterBorder': '#000000',
-    'nodeBorder': '#000000',
-    'mainBkg': '#ffffff',
-    'edgeLabelBackground': '#ffffff'
-  }
-}}%%
 flowchart TB
     A["Owner (Peter)"] -- Full trust --> B["AI (Clawd)"]
     B -- Trust but verify --> C["Friends in allowlist"]

--- a/docs/start/openclaw.md
+++ b/docs/start/openclaw.md
@@ -34,22 +34,6 @@ Start conservative:
 You want this:
 
 ```mermaid
-%%{init: {
-  'theme': 'base',
-  'themeVariables': {
-    'primaryColor': '#ffffff',
-    'primaryTextColor': '#000000',
-    'primaryBorderColor': '#000000',
-    'lineColor': '#000000',
-    'secondaryColor': '#f9f9fb',
-    'tertiaryColor': '#ffffff',
-    'clusterBkg': '#f9f9fb',
-    'clusterBorder': '#000000',
-    'nodeBorder': '#000000',
-    'mainBkg': '#ffffff',
-    'edgeLabelBackground': '#ffffff'
-  }
-}}%%
 flowchart TB
     A["<b>Your Phone (personal)<br></b><br>Your WhatsApp<br>+1-555-YOU"] -- message --> B["<b>Second Phone (assistant)<br></b><br>Assistant WA<br>+1-555-ASSIST"]
     B -- linked via QR --> C["<b>Your Mac (openclaw)<br></b><br>Pi agent"]


### PR DESCRIPTION
## Summary

- Four Mermaid diagrams had `%%{init: { 'theme': 'base', 'themeVariables': { ... } }}%%` blocks that hardcoded black text (`#000000`) and white backgrounds (`#ffffff`), overriding Mintlify's native dark mode theming
- This made the diagrams unreadable in dark mode — text was invisible against the dark background
- Removed these init blocks so the diagrams use Mermaid's default theme, which Mintlify automatically adapts for both light and dark modes

## Before / After (Dark Mode)

### `/concepts/architecture` — Connection Lifecycle

| Before | After |
|--------|-------|
| ![before](https://iili.io/qHB17nt.png) | ![after](https://iili.io/qHB1WtS.png) |

### `/start/openclaw` — Two-Phone Setup

| Before | After |
|--------|-------|
| ![before](https://iili.io/qHB1jV9.png) | ![after](https://iili.io/qHB1OKu.png) |

### `/gateway/security` — Trust Hierarchy

| Before | After |
|--------|-------|
| ![before](https://iili.io/qHB1kSj.png) | ![after](https://iili.io/qHB1SAQ.png) |

### `/gateway/remote-gateway-readme` — Overview

| Before | After |
|--------|-------|
| ![before](https://iili.io/qHB1gDB.png) | ![after](https://iili.io/qHB16V1.png) |

## Files Changed

- `docs/concepts/architecture.md` — removed 16-line init block
- `docs/start/openclaw.md` — removed 16-line init block
- `docs/gateway/security/index.md` — removed 16-line init block
- `docs/gateway/remote-gateway-readme.md` — removed 16-line init block

## Test Plan

- [ ] Toggle dark mode on each of the 4 affected pages — diagrams should be readable
- [ ] Verify light mode still renders correctly (no regressions)
- [ ] Check remaining Mermaid diagrams (index, troubleshooting, zh-CN/index, ja-JP/index) are unaffected

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates four Mintlify documentation pages by removing hardcoded Mermaid `%%{init: ...}%%` blocks that forced a light theme (`#ffffff` backgrounds and `#000000` text/lines). With the init blocks removed, the diagrams fall back to Mermaid’s default theming so Mintlify can apply its native light/dark mode styling consistently.

Changes are limited to Markdown docs under `docs/` and only affect Mermaid diagram rendering; no runtime code or configuration is modified.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The diff only removes Mermaid initialization blocks from four documentation files, reducing theme overrides and improving compatibility with Mintlify dark mode. No behavior-affecting code, configuration, or generated artifacts are changed.
- No files require special attention

<sub>Last reviewed commit: 3239baa</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->