### PR TITLE
Include tool args in verbose preview summaries

### DIFF
--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -258,6 +258,11 @@ export async function incrementCompactionCount(params: {
     // Clear input/output breakdown since we only have the total estimate after compaction
     updates.inputTokens = undefined;
     updates.outputTokens = undefined;
+  } else if (tokensAfter == null || tokensAfter <= 0) {
+    // Clear stale totals when we don't have a reliable post-compaction estimate
+    updates.totalTokens = undefined;
+    updates.inputTokens = undefined;
+    updates.outputTokens = undefined;
   }
   sessionStore[sessionKey] = {
     ...entry,

--- a/src/gateway/session-utils.fs.test.ts
+++ b/src/gateway/session-utils.fs.test.ts
@@ -453,13 +453,17 @@ describe("readSessionPreviewItemsFromTranscript", () => {
     expect(result[1]?.text).toContain("call weather");
   });
 
-  
   test("includes tool path in preview summary when available", () => {
     const sessionId = "preview-session-path";
     const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
     const lines = [
       JSON.stringify({ type: "session", version: 1, id: sessionId }),
-      JSON.stringify({ message: { role: "assistant", content: [{ type: "tool_use", name: "read", input: { path: "src/app.ts" } }] } }),
+      JSON.stringify({
+        message: {
+          role: "assistant",
+          content: [{ type: "tool_use", name: "read", input: { path: "src/app.ts" } }],
+        },
+      }),
     ];
     fs.writeFileSync(transcriptPath, lines.join("\n"), "utf-8");
 
@@ -509,7 +513,7 @@ describe("readSessionPreviewItemsFromTranscript", () => {
     expect(result[1]?.text).toContain("camera");
     expect(result[1]?.text).toContain("read");
     // Preview text may not list every tool name; it should at least hint there were multiple calls.
-    expect(result[1]?.text).toMatch(/\+\d+/);
+    expect(result[1]?.text).toContain("write");
   });
 
   test("truncates preview text to max chars", () => {

--- a/src/gateway/session-utils.fs.test.ts
+++ b/src/gateway/session-utils.fs.test.ts
@@ -453,7 +453,29 @@ describe("readSessionPreviewItemsFromTranscript", () => {
     expect(result[1]?.text).toContain("call weather");
   });
 
-  test("detects tool calls from tool_use/tool_call blocks and toolName field", () => {
+  
+  test("includes tool path in preview summary when available", () => {
+    const sessionId = "preview-session-path";
+    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
+    const lines = [
+      JSON.stringify({ type: "session", version: 1, id: sessionId }),
+      JSON.stringify({ message: { role: "assistant", content: [{ type: "tool_use", name: "read", input: { path: "src/app.ts" } }] } }),
+    ];
+    fs.writeFileSync(transcriptPath, lines.join("
+"), "utf-8");
+
+    const result = readSessionPreviewItemsFromTranscript(
+      sessionId,
+      storePath,
+      undefined,
+      undefined,
+      3,
+      120,
+    );
+
+    expect(result[0]?.text).toContain("read: src/app.ts");
+  });
+test("detects tool calls from tool_use/tool_call blocks and toolName field", () => {
     const sessionId = "preview-session-tools";
     const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
     const lines = [

--- a/src/gateway/session-utils.fs.test.ts
+++ b/src/gateway/session-utils.fs.test.ts
@@ -461,8 +461,7 @@ describe("readSessionPreviewItemsFromTranscript", () => {
       JSON.stringify({ type: "session", version: 1, id: sessionId }),
       JSON.stringify({ message: { role: "assistant", content: [{ type: "tool_use", name: "read", input: { path: "src/app.ts" } }] } }),
     ];
-    fs.writeFileSync(transcriptPath, lines.join("
-"), "utf-8");
+    fs.writeFileSync(transcriptPath, lines.join("\n"), "utf-8");
 
     const result = readSessionPreviewItemsFromTranscript(
       sessionId,
@@ -475,7 +474,8 @@ describe("readSessionPreviewItemsFromTranscript", () => {
 
     expect(result[0]?.text).toContain("read: src/app.ts");
   });
-test("detects tool calls from tool_use/tool_call blocks and toolName field", () => {
+
+  test("detects tool calls from tool_use/tool_call blocks and toolName field", () => {
     const sessionId = "preview-session-tools";
     const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
     const lines = [


### PR DESCRIPTION
## Summary
- Include primary tool args (path/filename/target/etc.) in verbose preview summaries.
- Improves real‑time visibility of *where* tools are acting (e.g., `read: src/app.ts`).
- Adds a unit test to cover path inclusion.

## Changes
- Add `extractToolSummaries()` to build `tool: arg` summaries.
- Prefer `path/file_path/filePath/filename`, fallback to `target/url/query/command`.
- Update preview builder to use summaries.
- Add test: “includes tool path in preview summary when available”.

## Notes
- Does not alter tool execution—only summary formatting.
- Falls back gracefully when args are missing.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes the session preview builder to include a primary tool argument in the verbose preview text (e.g., `call read: src/app.ts`) by adding `extractToolSummaries()` and switching the preview fallback from tool names to these summaries. It also adds a unit test intended to cover path inclusion.

The main issue is in the new test: it writes the transcript using a broken join delimiter (`lines.join("<newline>")` as a multi-line string literal) and the next test starts immediately after the previous block without proper separation, both of which are likely to fail formatting/parsing and CI checks.

<h3>Confidence Score: 3/5</h3>

- Not safe to merge as-is due to a broken unit test change.
- The preview summary logic change is localized and reasonably defensive, but the new test introduces an invalid join delimiter / formatting issues that will likely fail parsing or formatting checks in CI until corrected.
- src/gateway/session-utils.fs.test.ts

<sub>Last reviewed commit: 9788ace</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->