### PR TITLE
fix(errors): classify connection errors as retryable failover reason

### DIFF
--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -108,6 +108,19 @@ describe("formatAssistantErrorText", () => {
     expect(result).toContain("API provider");
     expect(result).toBe(BILLING_ERROR_USER_MESSAGE);
   });
+  it("returns a friendly message for connection errors", () => {
+    const msg = makeAssistantError("Connection error.");
+    expect(formatAssistantErrorText(msg)).toBe(
+      "The AI service encountered a connection error. Please try again in a moment.",
+    );
+  });
+  it("returns a friendly message for APIConnectionError", () => {
+    const msg = makeAssistantError("APIConnectionError: Connection error.");
+    expect(formatAssistantErrorText(msg)).toBe(
+      "The AI service encountered a connection error. Please try again in a moment.",
+    );
+  });
+
   it("returns a friendly message for rate limit errors", () => {
     const msg = makeAssistantError("429 rate limit reached");
     expect(formatAssistantErrorText(msg)).toContain("rate limit reached");

--- a/src/agents/pi-embedded-helpers.isconnectionerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isconnectionerrormessage.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { isConnectionErrorMessage } from "./pi-embedded-helpers.js";
+
+describe("isConnectionErrorMessage", () => {
+  it("returns true for Anthropic SDK APIConnectionError message", () => {
+    expect(isConnectionErrorMessage("Connection error.")).toBe(true);
+  });
+
+  it("returns true for common connection failure patterns", () => {
+    expect(isConnectionErrorMessage("socket hang up")).toBe(true);
+    expect(isConnectionErrorMessage("connect ECONNREFUSED 127.0.0.1:443")).toBe(true);
+    expect(isConnectionErrorMessage("read ECONNRESET")).toBe(true);
+    expect(isConnectionErrorMessage("getaddrinfo ENOTFOUND api.anthropic.com")).toBe(true);
+    expect(isConnectionErrorMessage("fetch failed")).toBe(true);
+    expect(isConnectionErrorMessage("network error")).toBe(true);
+    expect(isConnectionErrorMessage("DNS lookup failed")).toBe(true);
+    expect(isConnectionErrorMessage("APIConnectionError: Connection error.")).toBe(true);
+  });
+
+  it("returns false for non-connection errors", () => {
+    expect(isConnectionErrorMessage("rate limit exceeded")).toBe(false);
+    expect(isConnectionErrorMessage("invalid api key")).toBe(false);
+    expect(isConnectionErrorMessage("timeout")).toBe(false);
+    expect(isConnectionErrorMessage("overloaded")).toBe(false);
+    expect(isConnectionErrorMessage("402 Payment Required")).toBe(false);
+  });
+});

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -28,6 +28,7 @@ export {
   isCloudflareOrHtmlErrorPage,
   isCloudCodeAssistFormatError,
   isCompactionFailureError,
+  isConnectionErrorMessage,
   isContextOverflowError,
   isLikelyContextOverflowError,
   isFailoverAssistantError,

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -7,6 +7,7 @@ import {
   isAuthErrorMessage,
   isAuthPermanentErrorMessage,
   isBillingErrorMessage,
+  isConnectionErrorMessage,
   isOverloadedErrorMessage,
   isPeriodicUsageLimitErrorMessage,
   isRateLimitErrorMessage,
@@ -19,6 +20,7 @@ export {
   isAuthErrorMessage,
   isAuthPermanentErrorMessage,
   isBillingErrorMessage,
+  isConnectionErrorMessage,
   isOverloadedErrorMessage,
   isRateLimitErrorMessage,
   isTimeoutErrorMessage,
@@ -700,6 +702,10 @@ export function formatAssistantErrorText(
     return `LLM request rejected: ${invalidRequest[1]}`;
   }
 
+  if (isConnectionErrorMessage(raw)) {
+    return "The AI service encountered a connection error. Please try again in a moment.";
+  }
+
   const transientCopy = formatRateLimitOrOverloadedErrorCopy(raw);
   if (transientCopy) {
     return transientCopy;
@@ -977,6 +983,9 @@ export function classifyFailoverReason(raw: string): FailoverReason | null {
   }
   if (isBillingErrorMessage(raw)) {
     return "billing";
+  }
+  if (isConnectionErrorMessage(raw)) {
+    return "timeout";
   }
   if (isTimeoutErrorMessage(raw)) {
     return "timeout";

--- a/src/agents/pi-embedded-helpers/failover-matches.ts
+++ b/src/agents/pi-embedded-helpers/failover-matches.ts
@@ -92,6 +92,16 @@ const ERROR_PATTERNS = {
     "invalid request format",
     /tool call id was.*must be/i,
   ],
+  connection: [
+    "connection error",
+    "apiconnectionerror",
+    "socket hang up",
+    /\beconn(?:refused|reset|aborted)\b/i,
+    /\benotfound\b/i,
+    "fetch failed",
+    "network error",
+    "dns lookup failed",
+  ],
 } as const;
 
 const BILLING_ERROR_HEAD_RE =
@@ -159,4 +169,8 @@ export function isAuthErrorMessage(raw: string): boolean {
 
 export function isOverloadedErrorMessage(raw: string): boolean {
   return matchesErrorPatterns(raw, ERROR_PATTERNS.overloaded);
+}
+
+export function isConnectionErrorMessage(raw: string): boolean {
+  return matchesErrorPatterns(raw, ERROR_PATTERNS.connection);
 }


### PR DESCRIPTION
## Summary
- Add `connection` error patterns (`ECONNREFUSED`, `ECONNRESET`, `socket hang up`, `fetch failed`, `APIConnectionError`, etc.) to `ERROR_PATTERNS`
- Wire `isConnectionErrorMessage()` into `classifyFailoverReason()` as `"timeout"` (retryable), so the failover mechanism can retry on a different provider
- Return a friendly user-facing message instead of leaking raw error text to channels

## Test plan
- [x] New `isConnectionErrorMessage` test suite (3 tests: SDK message, common patterns, negative cases)
- [x] New `formatAssistantErrorText` tests for connection error messages (2 tests)
- [x] All 269 existing tests pass
- [x] `pnpm build && pnpm check` clean

Fixes #15083

lobster-biscuit

> 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change adds a new `connection` bucket to the agent error pattern matcher, exposes it via `isConnectionErrorMessage()`, and uses it in two places:

- `formatAssistantErrorText()` now rewrites connection-related failures (e.g., `ECONNREFUSED`, `ECONNRESET`, `socket hang up`, `fetch failed`, `APIConnectionError`) into a stable, user-friendly message.
- `classifyFailoverReason()` treats those connection errors as retryable transport failures by mapping them to the existing `"timeout"` failover reason.

New Vitest suites cover both the message classifier and the formatting behavior.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are localized to error classification/formatting, are covered by new unit tests, and preserve existing failover reason types by mapping connection errors to the already-supported "timeout" category.
- No files require special attention

<sub>Last reviewed commit: 932a781</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->