### PR TITLE
fix(agents): add cache_control breakpoint to system prompt on OpenRouter Anthropic path

### DIFF
--- a/src/agents/openrouter-system-cache.test.ts
+++ b/src/agents/openrouter-system-cache.test.ts
@@ -1,0 +1,157 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import { describe, expect, it, vi } from "vitest";
+import { wrapStreamFnWithSystemCacheControl } from "./openrouter-system-cache.js";
+
+// Minimal model stubs matching StreamFn's model parameter shape
+const openRouterAnthropicModel = {
+  provider: "openrouter",
+  id: "anthropic/claude-opus-4-6",
+  api: "openai",
+  baseUrl: "https://openrouter.ai/api/v1",
+} as Parameters<StreamFn>[0];
+
+const openaiModel = {
+  provider: "openai",
+  id: "gpt-4o",
+  api: "openai",
+  baseUrl: "https://api.openai.com/v1",
+} as Parameters<StreamFn>[0];
+
+const fakeContext = { messages: [], systemPrompt: "" } as Parameters<StreamFn>[1];
+const fakeStream = { [Symbol.asyncIterator]: () => ({}) } as ReturnType<StreamFn>;
+
+type Params = Record<string, unknown>;
+type MsgArray = Array<{ role: string; content: unknown }>;
+
+function makeInnerStreamFn(paramsFactory: () => Params): [StreamFn, () => Params | undefined] {
+  let captured: Params | undefined;
+  const fn = vi.fn(
+    (
+      _model: Parameters<StreamFn>[0],
+      _context: Parameters<StreamFn>[1],
+      options?: Record<string, unknown>,
+    ) => {
+      const params = paramsFactory();
+      (options?.onPayload as ((p: Params) => void) | undefined)?.(params);
+      captured = params;
+      return fakeStream;
+    },
+  ) as unknown as StreamFn;
+  return [fn, () => captured];
+}
+
+describe("wrapStreamFnWithSystemCacheControl", () => {
+  it("adds cache_control to string system message content", () => {
+    const [inner, getParams] = makeInnerStreamFn(() => ({
+      model: "anthropic/claude-opus-4-6",
+      messages: [
+        { role: "system", content: "You are a helpful assistant." },
+        { role: "user", content: "Hello" },
+      ],
+    }));
+
+    const wrapped = wrapStreamFnWithSystemCacheControl(inner);
+    void wrapped(openRouterAnthropicModel, fakeContext, {});
+
+    const systemMsg = (getParams()!.messages as MsgArray)[0];
+    expect(systemMsg.role).toBe("system");
+    expect(Array.isArray(systemMsg.content)).toBe(true);
+    expect((systemMsg.content as Array<Record<string, unknown>>)[0]).toEqual({
+      type: "text",
+      text: "You are a helpful assistant.",
+      cache_control: { type: "ephemeral" },
+    });
+  });
+
+  it("adds cache_control to last text part of array system message content", () => {
+    const [inner, getParams] = makeInnerStreamFn(() => ({
+      model: "anthropic/claude-opus-4-6",
+      messages: [
+        {
+          role: "developer",
+          content: [
+            { type: "text", text: "Part 1" },
+            { type: "text", text: "Part 2" },
+          ],
+        },
+        { role: "user", content: "Hello" },
+      ],
+    }));
+
+    const wrapped = wrapStreamFnWithSystemCacheControl(inner);
+    void wrapped(openRouterAnthropicModel, fakeContext, {});
+
+    const systemMsg = (getParams()!.messages as MsgArray)[0];
+    const content = systemMsg.content as Array<Record<string, unknown>>;
+    expect(systemMsg.role).toBe("developer");
+    expect(content[0].cache_control).toBeUndefined();
+    expect(content[1].cache_control).toEqual({ type: "ephemeral" });
+  });
+
+  it("preserves existing onPayload callback", () => {
+    const originalOnPayload = vi.fn();
+
+    const [inner] = makeInnerStreamFn(() => ({
+      messages: [
+        { role: "system", content: "System prompt" },
+        { role: "user", content: "Hello" },
+      ],
+    }));
+
+    const wrapped = wrapStreamFnWithSystemCacheControl(inner);
+    void wrapped(openRouterAnthropicModel, fakeContext, {
+      onPayload: originalOnPayload,
+    });
+
+    expect(originalOnPayload).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not modify non-OpenRouter models", () => {
+    const [inner, getParams] = makeInnerStreamFn(() => ({
+      messages: [
+        { role: "system", content: "System prompt" },
+        { role: "user", content: "Hello" },
+      ],
+    }));
+
+    const wrapped = wrapStreamFnWithSystemCacheControl(inner);
+    void wrapped(openaiModel, fakeContext, {});
+
+    const systemMsg = (getParams()!.messages as MsgArray)[0];
+    expect(typeof systemMsg.content).toBe("string");
+  });
+
+  it("does not modify non-Anthropic OpenRouter models", () => {
+    const nonAnthropicModel = {
+      ...openRouterAnthropicModel,
+      id: "google/gemini-pro",
+    } as Parameters<StreamFn>[0];
+
+    const [inner, getParams] = makeInnerStreamFn(() => ({
+      messages: [
+        { role: "system", content: "System prompt" },
+        { role: "user", content: "Hello" },
+      ],
+    }));
+
+    const wrapped = wrapStreamFnWithSystemCacheControl(inner);
+    void wrapped(nonAnthropicModel, fakeContext, {});
+
+    const systemMsg = (getParams()!.messages as MsgArray)[0];
+    expect(typeof systemMsg.content).toBe("string");
+  });
+
+  it("handles messages with no system message gracefully", () => {
+    const [inner, getParams] = makeInnerStreamFn(() => ({
+      messages: [
+        { role: "user", content: "Hello" },
+        { role: "assistant", content: "Hi" },
+      ],
+    }));
+
+    const wrapped = wrapStreamFnWithSystemCacheControl(inner);
+    void wrapped(openRouterAnthropicModel, fakeContext, {});
+
+    expect((getParams()!.messages as MsgArray)[0].content).toBe("Hello");
+  });
+});

--- a/src/agents/openrouter-system-cache.test.ts
+++ b/src/agents/openrouter-system-cache.test.ts
@@ -154,4 +154,16 @@ describe("wrapStreamFnWithSystemCacheControl", () => {
 
     expect((getParams()!.messages as MsgArray)[0].content).toBe("Hello");
   });
+
+  it("skips malformed message entries without throwing", () => {
+    const [inner, getParams] = makeInnerStreamFn(() => ({
+      messages: ["not-an-object", { role: "system", content: "System prompt" }],
+    }));
+
+    const wrapped = wrapStreamFnWithSystemCacheControl(inner);
+    expect(() => wrapped(openRouterAnthropicModel, fakeContext, {})).not.toThrow();
+
+    const systemMsg = (getParams()!.messages as MsgArray)[1];
+    expect(Array.isArray(systemMsg.content)).toBe(true);
+  });
 });

--- a/src/agents/openrouter-system-cache.ts
+++ b/src/agents/openrouter-system-cache.ts
@@ -79,11 +79,13 @@ function addCacheControlToSystemMessage(params: Record<string, unknown>): void {
       for (let i = content.length - 1; i >= 0; i--) {
         const part = content[i];
         if (part?.type === "text") {
-          Object.assign(part, { cache_control: { type: "ephemeral" } });
+          if (typeof part === "object" && !("cache_control" in part)) {
+            Object.assign(part, { cache_control: { type: "ephemeral" } });
+          }
           return;
         }
       }
     }
-    return; // Only process the first system/developer message
+    // No patchable text found in this system/developer message; keep scanning.
   }
 }

--- a/src/agents/openrouter-system-cache.ts
+++ b/src/agents/openrouter-system-cache.ts
@@ -23,9 +23,11 @@ export function wrapStreamFnWithSystemCacheControl(streamFn: StreamFn): StreamFn
 
     const originalOnPayload = options?.onPayload;
 
-    const patchedOnPayload = (params: Record<string, unknown>) => {
-      addCacheControlToSystemMessage(params);
-      originalOnPayload?.(params);
+    const patchedOnPayload = (payload: unknown) => {
+      if (payload && typeof payload === "object") {
+        addCacheControlToSystemMessage(payload as Record<string, unknown>);
+      }
+      originalOnPayload?.(payload);
     };
 
     return streamFn(model, context, {

--- a/src/agents/openrouter-system-cache.ts
+++ b/src/agents/openrouter-system-cache.ts
@@ -1,0 +1,80 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+
+/**
+ * Apply `cache_control: { type: "ephemeral" }` to the system/developer message
+ * on OpenRouter Anthropic requests.
+ *
+ * pi-ai's `maybeAddOpenRouterAnthropicCacheControl()` already places a breakpoint
+ * on the last user/assistant message, but skips the system prompt. This wrapper
+ * fills that gap by intercepting the `onPayload` callback and mutating the first
+ * system/developer message in the request body.
+ *
+ * Anthropic supports up to 4 cache breakpoints, and OpenRouter passes them through.
+ * This adds one more (going from 1 → 2 breakpoints), well within the limit.
+ *
+ * @see https://github.com/openclaw/openclaw/issues/15151
+ */
+export function wrapStreamFnWithSystemCacheControl(streamFn: StreamFn): StreamFn {
+  return (model, context, options) => {
+    // Only apply to OpenRouter + Anthropic models
+    if (model.provider !== "openrouter" || !model.id.startsWith("anthropic/")) {
+      return streamFn(model, context, options);
+    }
+
+    const originalOnPayload = options?.onPayload;
+
+    const patchedOnPayload = (params: Record<string, unknown>) => {
+      addCacheControlToSystemMessage(params);
+      originalOnPayload?.(params);
+    };
+
+    return streamFn(model, context, {
+      ...options,
+      onPayload: patchedOnPayload,
+    });
+  };
+}
+
+/**
+ * Find the first system/developer message in the request params and add
+ * `cache_control: { type: "ephemeral" }` to its last content part.
+ *
+ * Handles both string content (converts to content array) and array content.
+ */
+function addCacheControlToSystemMessage(params: Record<string, unknown>): void {
+  const messages = params.messages;
+  if (!Array.isArray(messages)) {
+    return;
+  }
+
+  for (const msg of messages) {
+    if (msg.role !== "system" && msg.role !== "developer") {
+      continue;
+    }
+
+    const content = msg.content;
+
+    // String content → convert to array with cache_control
+    if (typeof content === "string") {
+      msg.content = [
+        Object.assign(
+          { type: "text" as const, text: content },
+          { cache_control: { type: "ephemeral" } },
+        ),
+      ];
+      return;
+    }
+
+    // Array content → add cache_control to last text part
+    if (Array.isArray(content)) {
+      for (let i = content.length - 1; i >= 0; i--) {
+        const part = content[i];
+        if (part?.type === "text") {
+          Object.assign(part, { cache_control: { type: "ephemeral" } });
+          return;
+        }
+      }
+    }
+    return; // Only process the first system/developer message
+  }
+}

--- a/src/agents/openrouter-system-cache.ts
+++ b/src/agents/openrouter-system-cache.ts
@@ -49,7 +49,14 @@ function addCacheControlToSystemMessage(params: Record<string, unknown>): void {
     return;
   }
 
-  for (const msg of messages) {
+  for (const message of messages) {
+    if (!message || typeof message !== "object") {
+      continue;
+    }
+    const msg = message as {
+      role?: unknown;
+      content?: unknown;
+    };
     if (msg.role !== "system" && msg.role !== "developer") {
       continue;
     }


### PR DESCRIPTION
## Problem

Closes #15151

Every OpenClaw user routing through OpenRouter to Anthropic models pays full input price on the system prompt (~18k tokens) on every single turn, even though the system prompt is identical across turns within a session.

The root cause: `maybeAddOpenRouterAnthropicCacheControl()` in `@mariozechner/pi-ai` only places a `cache_control: { type: "ephemeral" }` breakpoint on the last user/assistant message, but never on the system/developer message. The native Anthropic path already correctly handles system prompt caching.

## Fix

Rather than modifying the `pi-ai` dependency directly, this fix adds an OpenClaw-level `StreamFn` wrapper that intercepts the `onPayload` callback to add `cache_control` to the system message before the API request is sent.

### New file: `src/agents/openrouter-system-cache.ts`

- `wrapStreamFnWithSystemCacheControl(streamFn)` — wraps any `StreamFn` to add `cache_control: { type: "ephemeral" }` to the first system/developer message
- Only activates for OpenRouter + Anthropic models (`model.provider === "openrouter" && model.id.startsWith("anthropic/")`)
- Handles both string content (converts to array) and array content (finds last text part)
- Preserves any existing `onPayload` callback chain

### Wiring: `src/agents/pi-embedded-runner/run/attempt.ts`

Added after the existing `cacheTrace` and `anthropicPayloadLogger` wrappers, following the same pattern.

## How it works

`pi-ai`'s `streamOpenAICompletions` calls `options?.onPayload?.(params)` with the request params object **by reference** before `client.chat.completions.create(params)`. Mutating `params.messages` in the callback affects the actual API request — a clean interception point without patching `pi-ai` source.

## Measured Impact

From the issue reporter's Langfuse instrumentation on `anthropic/claude-opus-4.6`:

| Metric | Before | After |
|---|---|---|
| Cache hit rate (post turn-1) | 0% | 78% |
| Avg input cost (cache miss) | $0.1186 | $0.1186 |
| Avg input cost (cache hit) | N/A | $0.0234 |
| **Cost reduction on cached turns** | — | **~80%** |

Uses 2 of Anthropic's 4 allowed cache breakpoints (system prompt + last conversation message).

## Tests

6 new tests in `openrouter-system-cache.test.ts`:
- String system message content → converted to array with cache_control ✅
- Array system message content → cache_control on last text part ✅
- Preserves existing onPayload callback ✅
- Skips non-OpenRouter models ✅
- Skips non-Anthropic OpenRouter models ✅
- Handles missing system message gracefully ✅

All existing `attempt.test.ts` tests pass (3/3).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces a `StreamFn` wrapper (`src/agents/openrouter-system-cache.ts`) that intercepts `onPayload` for OpenRouter Anthropic requests and mutates the first system/developer message to include `cache_control: { type: "ephemeral" }`, enabling Anthropic prompt caching on the system prompt across turns. It wires the wrapper into the embedded runner (`src/agents/pi-embedded-runner/run/attempt.ts`) after the existing cache trace and Anthropic payload logger wrappers, and adds targeted unit tests covering string/array content and provider/model gating (`src/agents/openrouter-system-cache.test.ts`).

<h3>Confidence Score: 4/5</h3>

- This PR is close to safe to merge; main remaining concern is runtime robustness of the payload mutation against unexpected message shapes.
- Core behavior is small and well-tested with unit coverage for the intended payload shapes and provider/model gating. The only significant risk is that `addCacheControlToSystemMessage` assumes `params.messages` elements are objects with `role`/`content`; if upstream payload structure differs, it can throw during requests. Otherwise, the wrapper chaining preserves existing `onPayload` behavior and the integration point matches existing wrapper patterns.
- src/agents/openrouter-system-cache.ts

<sub>Last reviewed commit: edd9725</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->