### PR TITLE
fix(sessions): handle absolute paths in session file validation

### DIFF
--- a/src/config/sessions/paths.test.ts
+++ b/src/config/sessions/paths.test.ts
@@ -71,6 +71,40 @@ describe("session path safety", () => {
     expect(resolved).toBe(path.resolve(sessionsDir, "subdir/threaded-session.jsonl"));
   });
 
+  it("accepts absolute sessionFile within the same sessions dir", () => {
+    const sessionsDir = "/tmp/openclaw/agents/main/sessions";
+    const absoluteFile = path.resolve(sessionsDir, "sess-1.jsonl");
+
+    const resolved = resolveSessionFilePath(
+      "sess-1",
+      { sessionFile: absoluteFile },
+      { sessionsDir },
+    );
+
+    expect(resolved).toBe(absoluteFile);
+  });
+
+  it("accepts absolute sessionFile from a sibling agent sessions dir", () => {
+    const sessionsDir = "/tmp/openclaw/agents/default/sessions";
+    const siblingFile = path.resolve("/tmp/openclaw/agents/main/sessions", "sess-1.jsonl");
+
+    const resolved = resolveSessionFilePath(
+      "sess-1",
+      { sessionFile: siblingFile },
+      { sessionsDir },
+    );
+
+    expect(resolved).toBe(siblingFile);
+  });
+
+  it("rejects absolute sessionFile outside the agents hierarchy", () => {
+    const sessionsDir = "/tmp/openclaw/agents/main/sessions";
+
+    expect(() =>
+      resolveSessionFilePath("sess-1", { sessionFile: "/etc/passwd" }, { sessionsDir }),
+    ).toThrow(/within sessions directory/);
+  });
+
   it("uses agent sessions dir fallback for transcript path", () => {
     const resolved = resolveSessionTranscriptPath("sess-1", "main");
     expect(resolved.endsWith(path.join("agents", "main", "sessions", "sess-1.jsonl"))).toBe(true);

--- a/src/config/sessions/paths.ts
+++ b/src/config/sessions/paths.ts
@@ -60,6 +60,17 @@ function resolvePathWithinSessionsDir(sessionsDir: string, candidate: string): s
   const resolvedCandidate = path.resolve(resolvedBase, trimmed);
   const relative = path.relative(resolvedBase, resolvedCandidate);
   if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    // Absolute candidates may have been resolved against a different agent's
+    // sessions directory (e.g. stored with agentId "main" but validated with
+    // "default").  Accept them if they still fall within the shared agents
+    // hierarchy — i.e. <stateRoot>/agents/*/sessions/*.
+    if (path.isAbsolute(trimmed)) {
+      const agentsRoot = path.resolve(resolvedBase, "..", "..");
+      const relToAgents = path.relative(agentsRoot, resolvedCandidate);
+      if (!relToAgents.startsWith("..") && !path.isAbsolute(relToAgents)) {
+        return resolvedCandidate;
+      }
+    }
     throw new Error("Session file path must be within sessions directory");
   }
   return resolvedCandidate;


### PR DESCRIPTION
## Summary

- Session entries store absolute transcript paths resolved against a specific agent's sessions directory (e.g. `agents/main/sessions/...`)
- When later validated against a different agent's sessions dir (e.g. `agents/default/sessions/...`), the `path.relative()` check produces a `..` prefix and rejects the path
- Relaxes `resolvePathWithinSessionsDir()` to accept absolute candidates that still fall within the shared agents hierarchy (`<stateRoot>/agents/*/sessions/*`), while continuing to reject paths outside the hierarchy (e.g. `/etc/passwd`)

Fixes #15152

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR relaxes `resolvePathWithinSessionsDir()` to handle absolute `sessionFile` values that were previously rejected when validated against a different agent’s sessions directory. It also adds tests covering absolute paths within the same sessions dir, sibling agent sessions dir, and rejecting absolute paths outside the hierarchy.

The core behavior change is in `src/config/sessions/paths.ts`, which now treats certain absolute candidates as valid if they fall under an “agents root” computed from the provided `sessionsDir`, so multi-agent session entries can be reused across agents without failing the `path.relative()` safety check.

<h3>Confidence Score: 2/5</h3>

- This PR has a security-sensitive path validation change that likely needs tightening before merge.
- The new absolute-path exception accepts any file under an inferred agents root (derived from `sessionsDir`) rather than restricting to an agent’s sessions directory, which expands the allowed file set beyond what the PR description claims and can change behavior based on `sessionsDir` overrides.
- src/config/sessions/paths.ts

<sub>Last reviewed commit: 2a8f437</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->