### PR TITLE
fix(sessions): handle absolute sessionFile paths in resolveSessionFilePath (#15152)

### DIFF
--- a/src/config/sessions/paths.test.ts
+++ b/src/config/sessions/paths.test.ts
@@ -54,9 +54,14 @@ describe("session path safety", () => {
       resolveSessionFilePath("sess-1", { sessionFile: "../../etc/passwd" }, { sessionsDir }),
     ).toThrow(/within sessions directory/);
 
-    expect(() =>
-      resolveSessionFilePath("sess-1", { sessionFile: "/etc/passwd" }, { sessionsDir }),
-    ).toThrow(/within sessions directory/);
+    // Absolute paths outside the sessions dir fall back to basename resolution
+    // rather than throwing, since initSessionState stores absolute paths.
+    const resolved = resolveSessionFilePath(
+      "sess-1",
+      { sessionFile: "/etc/passwd" },
+      { sessionsDir },
+    );
+    expect(resolved).toBe(path.resolve(sessionsDir, "passwd"));
   });
 
   it("accepts sessionFile candidates within the sessions dir", () => {
@@ -69,6 +74,87 @@ describe("session path safety", () => {
     );
 
     expect(resolved).toBe(path.resolve(sessionsDir, "subdir/threaded-session.jsonl"));
+  });
+
+  it("accepts absolute sessionFile paths that are within the sessions dir (#15152)", () => {
+    const sessionsDir = "/tmp/openclaw/agents/default/sessions";
+    const absoluteSessionFile = path.join(sessionsDir, "abc123.jsonl");
+
+    // initSessionState stores absolute paths in sessionEntry.sessionFile;
+    // resolveSessionFilePath must accept them when they're inside the sessions dir.
+    const resolved = resolveSessionFilePath(
+      "sess-1",
+      { sessionFile: absoluteSessionFile },
+      { sessionsDir },
+    );
+
+    expect(resolved).toBe(absoluteSessionFile);
+  });
+
+  it("accepts absolute sessionFile in a subdirectory of the sessions dir (#15152)", () => {
+    const sessionsDir = "/tmp/openclaw/agents/default/sessions";
+    const absoluteSessionFile = path.join(sessionsDir, "sub", "forked.jsonl");
+
+    const resolved = resolveSessionFilePath(
+      "sess-1",
+      { sessionFile: absoluteSessionFile },
+      { sessionsDir },
+    );
+
+    expect(resolved).toBe(absoluteSessionFile);
+  });
+
+  it("accepts absolute sessionFile when no opts are passed (#15152)", () => {
+    // initSessionState stores absolute paths; callers like get-reply-run.ts
+    // call resolveSessionFilePath(id, entry) without opts, so the sessions dir
+    // is resolved from the default agent. The stored absolute path must still
+    // be accepted as long as it doesn't escape the resolved sessions dir.
+    const resolved = resolveSessionFilePath("sess-1", {
+      sessionFile: resolveSessionTranscriptPath("sess-1"),
+    });
+
+    expect(resolved).toBe(resolveSessionTranscriptPath("sess-1"));
+  });
+
+  it("accepts absolute sessionFile when sessionsDir differs from stored path (#15152)", () => {
+    // When session.store is configured to a custom path, the sessionsDir at
+    // read time (path.dirname(storePath)) differs from the agent sessions dir
+    // used at write time. The absolute path falls back to basename resolution.
+    const agentSessionsDir = "/home/user/.openclaw/agents/main/sessions";
+    const customStoreDir = "/data/openclaw/sessions";
+    const storedAbsolutePath = path.join(agentSessionsDir, "sess-1.jsonl");
+
+    const resolved = resolveSessionFilePath(
+      "sess-1",
+      { sessionFile: storedAbsolutePath },
+      { sessionsDir: customStoreDir },
+    );
+
+    // Falls back to basename within the current sessionsDir
+    expect(resolved).toBe(path.resolve(customStoreDir, "sess-1.jsonl"));
+  });
+
+  it("rejects absolute sessionFile paths outside the sessions dir", () => {
+    const sessionsDir = "/tmp/openclaw/agents/default/sessions";
+
+    // /etc/passwd basename is "passwd", resolved within sessionsDir
+    const resolved = resolveSessionFilePath(
+      "sess-1",
+      { sessionFile: "/etc/passwd" },
+      { sessionsDir },
+    );
+    expect(resolved).toBe(path.resolve(sessionsDir, "passwd"));
+  });
+
+  it("rejects absolute sessionFile that escapes via different agent dir (#15152)", () => {
+    const sessionsDir = "/tmp/openclaw/agents/default/sessions";
+    // A path under a sibling agent dir falls back to basename
+    const resolved = resolveSessionFilePath(
+      "sess-1",
+      { sessionFile: "/tmp/openclaw/agents/research/sessions/abc.jsonl" },
+      { sessionsDir },
+    );
+    expect(resolved).toBe(path.resolve(sessionsDir, "abc.jsonl"));
   });
 
   it("uses agent sessions dir fallback for transcript path", () => {


### PR DESCRIPTION
#### Summary

Inbound WhatsApp messages crash with "Session file path must be within sessions directory" since the session path hardening in 2026.2.12. `initSessionState` stores absolute paths in `sessionEntry.sessionFile`, but `resolveSessionFilePath` passes them into `resolvePathWithinSessionsDir` which rejects them when the read-time sessions dir doesn't match the write-time dir.

Closes #15152

lobster-biscuit

#### Repro Steps

1. Configure a WhatsApp channel
2. Send an inbound message
3. Check logs for "Session file path must be within sessions directory"

#### Root Cause

`resolvePathWithinSessionsDir` does `path.resolve(base, candidate)` — when `candidate` is already absolute, `path.resolve` ignores `base`, and the relative-path containment check fails if the read-time `sessionsDir` differs from the one used at write time (e.g. custom `session.store` config, or callers that don't pass `agentId`/`sessionsDir` opts).

#### Behavior Changes

- Before: `resolveSessionFilePath` throws when `sessionEntry.sessionFile` is an absolute path outside the current `sessionsDir`
- After: absolute paths try the containment check first, then fall back to basename resolution within the current `sessionsDir`

#### Tests

- `paths.test.ts` — 6 new tests covering absolute sessionFile paths (within dir, subdirectory, no opts, mismatched sessionsDir, outside dir, different agent dir)
- Updated existing "rejects unsafe sessionFile" test to match new fallback behavior for absolute paths
- build, check, all sessions/ tests pass

**Sign-Off**

- Models used: N/A
- Submitter effort: traced the regression from the hardening commit, wrote failing test, minimal fix in resolveSessionFilePath
- Agent notes: N/A

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates `resolveSessionFilePath` to handle `sessionEntry.sessionFile` values that are absolute paths (as stored by `initSessionState`). It first tries the existing sessions-dir containment check, and if that fails for an absolute path, it falls back to resolving the basename within the current `sessionsDir`. The accompanying tests expand coverage around absolute paths and the new fallback behavior.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a couple of edge cases that can change behavior unexpectedly.
- Core fix addresses the reported regression and is covered by new tests, but the absolute-path branch currently (1) catches all errors and silently falls back, and (2) relies on platform-specific `path.isAbsolute` behavior that can break Windows-style absolute paths when read on POSIX.
- src/config/sessions/paths.ts

<sub>Last reviewed commit: b23377e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->