### PR TITLE
fix(googlechat): convert Markdown formatting to Google Chat markupfix(googlechat): convert Markdown formatting to Google Chat markup

### DIFF
--- a/extensions/googlechat/src/api.test.ts
+++ b/extensions/googlechat/src/api.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ResolvedGoogleChatAccount } from "./accounts.js";
-import { downloadGoogleChatMedia } from "./api.js";
+import { downloadGoogleChatMedia, markdownToGoogleChat } from "./api.js";
 
 vi.mock("./auth.js", () => ({
   getGoogleChatAccessToken: vi.fn().mockResolvedValue("token"),
@@ -12,6 +12,32 @@ const account = {
   credentialSource: "inline",
   config: {},
 } as ResolvedGoogleChatAccount;
+
+describe("markdownToGoogleChat", () => {
+  it("converts bold from Markdown to Google Chat format", () => {
+    expect(markdownToGoogleChat("Hello **world**")).toBe("Hello *world*");
+  });
+
+  it("converts strikethrough from Markdown to Google Chat format", () => {
+    expect(markdownToGoogleChat("Hello ~~world~~")).toBe("Hello ~world~");
+  });
+
+  it("converts both bold and strikethrough", () => {
+    expect(markdownToGoogleChat("**bold** and ~~strike~~")).toBe("*bold* and ~strike~");
+  });
+
+  it("leaves plain text unchanged", () => {
+    expect(markdownToGoogleChat("no formatting here")).toBe("no formatting here");
+  });
+
+  it("preserves single asterisk italic", () => {
+    expect(markdownToGoogleChat("*italic* text")).toBe("*italic* text");
+  });
+
+  it("handles multiple bold segments", () => {
+    expect(markdownToGoogleChat("**a** and **b**")).toBe("*a* and *b*");
+  });
+});
 
 describe("downloadGoogleChatMedia", () => {
   afterEach(() => {


### PR DESCRIPTION
## Summary
Google Chat uses its own markup syntax (*bold*, ~strikethrough~) but OpenClaw sends standard Markdown (**bold**, ~~strikethrough~~). This adds a conversion function applied before sending messages.

## Changes
- Added markdownToGoogleChat() in extensions/googlechat/src/api.ts
- - Converts **bold** to *bold* and ~~strikethrough~~ to ~strikethrough~
- - Applied to both sendGoogleChatMessage and updateGoogleChatMessage
- - Added 6 unit tests
- 
- Fixes #14825Google Chat uses its own markup syntax (* for bold, ~ for strikethrough) but OpenClaw sends standard Markdown (** for bold, ~~ for strikethrough). This adds a conversion function applied before sending messages.

Fixes #14825

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a `markdownToGoogleChat()` helper in `extensions/googlechat/src/api.ts` to translate a subset of Markdown formatting into Google Chat’s markup, and applies it to both `sendGoogleChatMessage` and `updateGoogleChatMessage`. Unit tests were added to cover bold/strikethrough conversions and basic no-op cases.

This fits into the Google Chat extension by transforming outgoing message text right before hitting the Chat API, so upstream components can keep generating standard Markdown while the provider-specific API layer adapts it.

<h3>Confidence Score: 3/5</h3>

- Merge is moderately risky until code-span handling is addressed.
- Core change is small and covered by unit tests, but the conversion currently applies inside inline/fenced code spans, which will corrupt code snippets in real messages. Also a docstring/test mismatch should be reconciled.
- extensions/googlechat/src/api.ts

<sub>Last reviewed commit: dede735</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->