### PR TITLE
fix(session): reset totalTokens after compaction when estimate unavailablefix(session): reset totalTokens after compaction when estimate unavai…

### DIFF
--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -258,6 +258,13 @@ export async function incrementCompactionCount(params: {
     // Clear input/output breakdown since we only have the total estimate after compaction
     updates.inputTokens = undefined;
     updates.outputTokens = undefined;
+  } else {
+    // Reset totalTokens to 0 when estimation is unavailable to prevent
+    // stale pre-compaction values from triggering false memory flush cycles.
+    // The correct value will be populated on the next turn via persistSessionUsageUpdate.
+    updates.totalTokens = 0;
+    updates.inputTokens = undefined;
+    updates.outputTokens = undefined;
   }
   sessionStore[sessionKey] = {
     ...entry,


### PR DESCRIPTION
## Summary
When estimateCompactionTokensAfter() returns undefined, the pre-compaction totalTokens was left unchanged. This caused shouldRunMemoryFlush() to read stale high values and trigger unnecessary memory flushes immediately after compaction, potentially creating a compaction-flush bounce cycle.

## Changes
- In incrementCompactionCount(), reset totalTokens to 0 when tokensAfter is unavailable
- - The correct value is populated on the next turn via persistSessionUsageUpdate
- 
- ## Why this works
- Setting totalTokens to 0 is safe because persistSessionUsageUpdate runs on the very next turn and overwrites it with the actual value from the model response. The brief window where totalTokens=0 prevents the false flush trigger.
- 
- Fixes #15101…lable

When estimateCompactionTokensAfter() returns undefined, the pre-compaction totalTokens was left unchanged. This caused shouldRunMemoryFlush() to read stale high values and trigger unnecessary memory flushes immediately after compaction, potentially creating a compaction-flush bounce cycle.

Reset totalTokens to 0 when tokensAfter is unavailable. The correct value is populated on the next turn via persistSessionUsageUpdate.

Fixes #15101

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `incrementCompactionCount` in `src/auto-reply/reply/session-updates.ts` to avoid stale `totalTokens` values immediately after a compaction when no post-compaction token estimate is available. In the `tokensAfter`-missing path, it now sets `updates.totalTokens = 0` (and clears `inputTokens`/`outputTokens`) so `shouldRunMemoryFlush` won’t see a high pre-compaction token count and immediately trigger a flush.

This fits with the existing `shouldRunMemoryFlush` logic (`src/auto-reply/reply/memory-flush.ts:83-86`), which returns `false` when `totalTokens` is falsy/<=0, so the post-compaction window won’t cause an immediate flush-trigger bounce.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is small, localized to session token bookkeeping after compaction, and aligns with existing `shouldRunMemoryFlush` behavior (treating `totalTokens<=0` as no-flush). No other callsites depend on `totalTokens` being preserved in the specific case where no `tokensAfter` estimate is available.
- src/auto-reply/reply/session-updates.ts

<sub>Last reviewed commit: 657170a</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->