### PR TITLE
fix: reset stale execution state after SIGUSR1 in-process restart

### DIFF
--- a/scripts/recover-orphaned-processes.sh
+++ b/scripts/recover-orphaned-processes.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Scan for orphaned coding agent processes after a gateway restart.
+#
+# Background coding agents (Claude Code, Codex CLI) spawned by the gateway
+# can outlive the session that started them when the gateway restarts.
+# This script finds them and reports their state.
+#
+# Usage:
+#   recover-orphaned-processes.sh [--json]
+#
+# Output: JSON with orphaned process info, or empty array if none found.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: recover-orphaned-processes.sh [--json]
+
+Scans for likely orphaned coding agent processes and prints JSON.
+EOF
+}
+
+if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+  usage
+  exit 0
+fi
+
+if [ "$#" -gt 1 ] || { [ "$#" -eq 1 ] && [ "${1:-}" != "--json" ]; }; then
+  usage >&2
+  exit 2
+fi
+
+node <<'NODE'
+const { execSync } = require("node:child_process");
+const fs = require("node:fs");
+
+function run(cmd) {
+  try {
+    return execSync(cmd, { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] });
+  } catch {
+    return "";
+  }
+}
+
+function resolveStarted(pid) {
+  const started = run(`ps -o lstart= -p ${pid}`).trim();
+  return started.length > 0 ? started : "unknown";
+}
+
+function resolveCwd(pid) {
+  if (process.platform === "linux") {
+    try {
+      return fs.readlinkSync(`/proc/${pid}/cwd`);
+    } catch {
+      return "unknown";
+    }
+  }
+  const lsof = run(`lsof -a -d cwd -p ${pid} -Fn`);
+  const match = lsof.match(/^n(.+)$/m);
+  return match ? match[1] : "unknown";
+}
+
+const lines = run("ps -axo pid=,command=").split("\n");
+const includePatterns = [/\bcodex\b/i, /\bclaude\b/i, /claude\s+code/i];
+const excludePatterns = [
+  /openclaw-gateway/i,
+  /signal-cli/i,
+  /node_modules\/\.bin\/openclaw/i,
+  /recover-orphaned-processes\.sh/i,
+];
+
+const orphaned = [];
+
+for (const rawLine of lines) {
+  const line = rawLine.trim();
+  if (!line) {
+    continue;
+  }
+  const match = line.match(/^(\d+)\s+(.+)$/);
+  if (!match) {
+    continue;
+  }
+
+  const pid = Number(match[1]);
+  const cmd = match[2];
+  if (!Number.isInteger(pid) || pid <= 0 || pid === process.pid) {
+    continue;
+  }
+  if (!includePatterns.some((pattern) => pattern.test(cmd))) {
+    continue;
+  }
+  if (excludePatterns.some((pattern) => pattern.test(cmd))) {
+    continue;
+  }
+
+  orphaned.push({
+    pid,
+    cmd,
+    cwd: resolveCwd(pid),
+    started: resolveStarted(pid),
+  });
+}
+
+process.stdout.write(
+  JSON.stringify({
+    orphaned,
+    ts: new Date().toISOString(),
+  }) + "\n",
+);
+NODE

--- a/src/infra/heartbeat-wake.ts
+++ b/src/infra/heartbeat-wake.ts
@@ -1,3 +1,5 @@
+import { resetAllLanes } from "../process/command-queue.js";
+
 export type HeartbeatRunResult =
   | { status: "ran"; durationMs: number }
   | { status: "skipped"; reason: string }
@@ -146,6 +148,28 @@ export function setHeartbeatWakeHandler(next: HeartbeatWakeHandler | null): () =
   handlerGeneration += 1;
   const generation = handlerGeneration;
   handler = next;
+  if (next) {
+    // New lifecycle starting (e.g. after SIGUSR1 in-process restart).
+    // Clear any timer metadata from the previous lifecycle so stale retry
+    // cooldowns do not delay a fresh handler.
+    if (timer) {
+      clearTimeout(timer);
+    }
+    timer = null;
+    timerDueAt = null;
+    timerKind = null;
+    // Reset module-level execution state that may be stale from interrupted
+    // runs in the previous lifecycle. Without this, `running === true` from
+    // an interrupted heartbeat blocks all future schedule() attempts, and
+    // `scheduled === true` can cause spurious immediate re-runs.
+    running = false;
+    scheduled = false;
+    // Reset command queue lane counters. Interrupted tasks from the previous
+    // lifecycle may have left `active` counts elevated, permanently blocking
+    // message processing. The drain timeout (waitForActiveTasks) may not have
+    // been sufficient to clear all in-flight work.
+    resetAllLanes();
+  }
   if (handler && pendingWake) {
     schedule(DEFAULT_COALESCE_MS, "normal");
   }


### PR DESCRIPTION
## Problem

After a SIGUSR1 in-process restart, the gateway can enter a permanent zombie state:
- Heartbeat scheduler logs `[heartbeat] started` but never fires
- Incoming messages are received but permanently queued — never processed
- Event loop stays alive (cron polls, timers fire), masking the problem
- Only a SIGTERM (full process kill) recovers

This happens when SIGUSR1 fires while work is in-flight.

## Root Cause

Module-level state survives the in-process restart boundary but doesn't get reset:

### 1. `running` flag in `heartbeat-wake.ts`
When a heartbeat handler is executing (`running = true`) and SIGUSR1 fires, the in-flight run can be abandoned before its `finally` block runs, so `running` stays `true`. The new lifecycle's `schedule()` calls see `running === true` and loop forever without executing.

**The drain mechanism (`waitForActiveTasks`) doesn't help here** — heartbeat runs execute directly via the wake handler, not through command queue lanes.

### 2. Lane `active` counters in `command-queue.ts`
When `waitForActiveTasks` times out (30s default), interrupted tasks leave stale `active` counts. The new lifecycle's `drainLane()` sees `active >= maxConcurrent` and never dequeues new work.

## Fix

### `heartbeat-wake.ts`
In `setHeartbeatWakeHandler()` for a new (non-null) handler:
- Clear stale timer state (`timer`, `timerDueAt`, `timerKind`) so retry backoff from the previous lifecycle cannot delay the new one
- Reset `running` and `scheduled`
- Call `resetAllLanes()`

This is the lifecycle-start signal — the old handler has been disposed via the generation-based disposer (#15108), so old in-flight work is either drained or abandoned.

### `command-queue.ts`
Add `resetAllLanes()` — resets per-lane runtime counters (`active`, `activeTaskIds`, `draining`) and immediately re-pumps queued work, without clearing queued entries.

### `recover-orphaned-processes.sh`
Utility script to find coding agent processes (Claude Code, Codex CLI) that may have been orphaned by a gateway restart. Works regardless of whether agents were run with `--dangerously-*` flags.

## Changes

| File | Changes |
|------|---------|
| `src/infra/heartbeat-wake.ts` | Reset stale timer/runtime state + call `resetAllLanes()` on new handler registration |
| `src/process/command-queue.ts` | Add exported `resetAllLanes()`, clamp stale decrements, and re-pump queues after reset |
| `src/infra/heartbeat-wake.test.ts` | 2 new tests: SIGUSR1 mid-run reset and stale retry-timer cleanup |
| `src/process/command-queue.test.ts` | 2 new tests: no-lane safety and `resetAllLanes()` unblocks queued work |
| `scripts/recover-orphaned-processes.sh` | Portable orphaned-agent scanner with JSON-safe output |

## Testing

4 new unit tests cover both failure modes and startup-reset edge cases.

## Related

- #14892 — Original heartbeat death report
- #14901 — Heartbeat stall fix (error handling + retry) — merged in 2026.2.12
- #15108 — Wake handler race fix (generation-based disposer) — merged to main
- #13931 — Drain active turns before restart — merged in 2026.2.12

Fixes #15177

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR addresses a zombie gateway state after SIGUSR1 in-process restarts by resetting module-level heartbeat wake state and introducing a `resetAllLanes()` helper for the in-process command queue. It also adds unit tests for both stale heartbeat scheduling state and stale lane activity counters, plus a utility script to detect potentially orphaned coding-agent processes.

Key integration point: `setHeartbeatWakeHandler()` now treats registering a new handler as a lifecycle-start signal, clearing wake timers/flags and calling `resetAllLanes()` so queued work can drain again after a restart boundary.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is due to a concurrency invariant break in the command queue reset path.
- `resetAllLanes()` can start new tasks while old tasks are still executing by zeroing `active` and re-pumping queues, which can violate main-lane serialization during the exact SIGUSR1 mid-flight scenario this PR targets. The added script also has a documented/actual output mismatch, but the queue invariant issue is the primary blocker.
- src/process/command-queue.ts

<sub>Last reviewed commit: ce372fa</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->