### PR TITLE
fix(heartbeat): keep scheduler chain alive on requests-in-flight skip

### DIFF
--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -983,8 +983,7 @@ export function startHeartbeatRunner(opts: {
       }
       if (res.status === "skipped" && res.reason === "requests-in-flight") {
         advanceAgentSchedule(agent, now);
-        scheduleNext();
-        return res;
+        continue;
       }
       if (res.status !== "skipped" || res.reason !== "disabled") {
         advanceAgentSchedule(agent, now);


### PR DESCRIPTION
## Summary
Fix heartbeat runner control flow so `requests-in-flight` means **defer**, not early exit.

## Problem
`requests-in-flight` is documented as "skip now, retry later", but the current loop exits early in this branch, making scheduling continuity branch-dependent.

## Root cause
In `src/infra/heartbeat-runner.ts`, the `requests-in-flight` path returns from inside the per-agent loop.

## Fix
In that branch, switch to loop continuation (`continue`) so execution reaches the shared end-of-run scheduling path.

This complements:
- #14901 (scheduler continuity when `runOnce()` throws)
- #14396 (busy-lane skip conditions)

## Validation
- ✅ `src/infra/heartbeat-wake.test.ts`
- ✅ `src/infra/heartbeat-runner.ghost-reminder.test.ts`

## Risk
Minimal diff, no config/API changes, preserves intended "skip + retry later" semantics.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes the heartbeat runner’s per-agent control flow so the `requests-in-flight` skip path uses `continue` instead of returning early, aiming to keep the shared end-of-run scheduling path (`scheduleNext()`) consistent.

However, `startHeartbeatRunner` is also the wake handler used by `heartbeat-wake.ts`, and that wake layer depends on the runner returning `{ status: "skipped", reason: "requests-in-flight" }` to trigger a short retry backoff. With the new `continue`, the runner can lose that skip reason and fall through to `{ status: "skipped", reason: isInterval ? "not-due" : "disabled" }`, which prevents the wake layer from retrying promptly under main-lane load.

<h3>Confidence Score: 2/5</h3>

- This PR has a functional regression in the wake retry control flow and is not safe to merge as-is.
- Although the change keeps `scheduleNext()` reachable, it causes `startHeartbeatRunner` to stop returning the `requests-in-flight` skip reason that `heartbeat-wake.ts` uses to schedule a fast retry. Under load, this can delay or suppress retries and misreport manual/exec/hook wakes as "disabled".
- src/infra/heartbeat-runner.ts

<sub>Last reviewed commit: a23f144</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->