### PR TITLE
fix: clear stale token totals after compaction

### DIFF
--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -253,7 +253,7 @@ export async function incrementCompactionCount(params: {
     updatedAt: now,
   };
   // If tokensAfter is provided, update the cached token counts to reflect post-compaction state
-  if (tokensAfter != null) {
+  if (typeof tokensAfter === "number") {
     if (tokensAfter > 0) {
       updates.totalTokens = tokensAfter;
       // Clear input/output breakdown since we only have the total estimate after compaction

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -253,16 +253,18 @@ export async function incrementCompactionCount(params: {
     updatedAt: now,
   };
   // If tokensAfter is provided, update the cached token counts to reflect post-compaction state
-  if (tokensAfter != null && tokensAfter > 0) {
-    updates.totalTokens = tokensAfter;
-    // Clear input/output breakdown since we only have the total estimate after compaction
-    updates.inputTokens = undefined;
-    updates.outputTokens = undefined;
-  } else if (tokensAfter == null || tokensAfter <= 0) {
-    // Clear stale totals when we don't have a reliable post-compaction estimate
-    updates.totalTokens = undefined;
-    updates.inputTokens = undefined;
-    updates.outputTokens = undefined;
+  if (tokensAfter != null) {
+    if (tokensAfter > 0) {
+      updates.totalTokens = tokensAfter;
+      // Clear input/output breakdown since we only have the total estimate after compaction
+      updates.inputTokens = undefined;
+      updates.outputTokens = undefined;
+    } else {
+      // Clear stale totals when we have an explicit invalid post-compaction estimate
+      updates.totalTokens = undefined;
+      updates.inputTokens = undefined;
+      updates.outputTokens = undefined;
+    }
   }
   sessionStore[sessionKey] = {
     ...entry,

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -258,6 +258,11 @@ export async function incrementCompactionCount(params: {
     // Clear input/output breakdown since we only have the total estimate after compaction
     updates.inputTokens = undefined;
     updates.outputTokens = undefined;
+  } else if (tokensAfter == null || tokensAfter <= 0) {
+    // Clear stale totals when we don't have a reliable post-compaction estimate
+    updates.totalTokens = undefined;
+    updates.inputTokens = undefined;
+    updates.outputTokens = undefined;
   }
   sessionStore[sessionKey] = {
     ...entry,


### PR DESCRIPTION
Fixes #15101. Clears stale session token totals when compaction does not provide a valid post-compaction estimate, preventing false memory flush triggers.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `incrementCompactionCount` to clear cached token totals when compaction doesn’t provide a valid `tokensAfter` estimate, aiming to avoid false memory-flush triggers from stale counts.

The key behavioral change is that `tokensAfter` being omitted now also triggers clearing `totalTokens`/`inputTokens`/`outputTokens`. In the current codebase there are call sites (notably the memory-flush compaction path) that call `incrementCompactionCount` without a post-compaction estimate, and downstream logic (`shouldRunMemoryFlush`) depends on `entry.totalTokens` being present. As written, this can clear totals in those flows and prevent future memory flushes from triggering until totals are repopulated elsewhere.

<h3>Confidence Score: 2/5</h3>

- This PR introduces a behavior change that can break memory-flush triggering when compaction counts are incremented without a post-compaction token estimate.
- Although the intent is to prevent stale totals from causing false triggers, the implementation treats an omitted `tokensAfter` the same as an invalid estimate and clears cached totals. Verified call sites omit `tokensAfter`, and the memory flush decision path requires `totalTokens`, so this can cause real functional regressions and also appears to break an existing test expectation.
- src/auto-reply/reply/session-updates.ts

<sub>Last reviewed commit: ca944c5</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->