### PR TITLE
fix(ci): sync extension versions to 2026.2.13

### DIFF
--- a/extensions/bluebubbles/package.json
+++ b/extensions/bluebubbles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/bluebubbles",
-  "version": "2026.2.12",
+  "version": "2026.2.13",
   "description": "OpenClaw BlueBubbles channel plugin",
   "type": "module",
   "devDependencies": {

--- a/extensions/copilot-proxy/package.json
+++ b/extensions/copilot-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/copilot-proxy",
-  "version": "2026.2.12",
+  "version": "2026.2.13",
   "private": true,
   "description": "OpenClaw Copilot Proxy provider plugin",
   "type": "module",

--- a/extensions/diagnostics-otel/package.json
+++ b/extensions/diagnostics-otel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/diagnostics-otel",
-  "version": "2026.2.12",
+  "version": "2026.2.13",
   "description": "OpenClaw diagnostics OpenTelemetry exporter",
   "type": "module",
   "dependencies": {

--- a/extensions/discord/package.json
+++ b/extensions/discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/discord",
-  "version": "2026.2.12",
+  "version": "2026.2.13",
   "description": "OpenClaw Discord channel plugin",
   "type": "module",
   "devDependencies": {

--- a/extensions/feishu/package.json
+++ b/extensions/feishu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/feishu",
-  "version": "2026.2.12",
+  "version": "2026.2.13",
   "description": "OpenClaw Feishu/Lark channel plugin (community maintained by @m1heng)",
   "type": "module",
   "dependencies": {

--- a/extensions/google-antigravity-auth/package.json
+++ b/extensions/google-antigravity-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/google-antigravity-auth",
-  "version": "2026.2.12",
+  "version": "2026.2.13",
   "private": true,
   "description": "OpenClaw Google Antigravity OAuth provider plugin",
   "type": "module",

--- a/extensions/google-gemini-cli-auth/package.json
+++ b/extensions/google-gemini-cli-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/google-gemini-cli-auth",
-  "version": "2026.2.12",
+  "version": "2026.2.13",
   "private": true,
   "description": "OpenClaw Gemini CLI OAuth provider plugin",
   "type": "module",

--- a/extensions/googlechat/package.json
+++ b/extensions/googlechat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/googlechat",
-  "version": "2026.2.12",
+  "version": "2026.2.13",
   "private": true,
   "description": "OpenClaw Google Chat channel plugin",
   "type": "module",

--- a/extensions/imessage/package.json
+++ b/extensions/imessage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/imessage",
-  "version": "2026.2.12",
+  "version": "2026.2.13",
   "private": true,
   "description": "OpenClaw iMessage channel plugin",
   "type": "module",

--- a/extensions/irc/package.json
+++ b/extensions/irc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/irc",
-  "version": "2026.2.12",
+  "version": "2026.2.13",
   "description": "OpenClaw IRC channel plugin",
   "type": "module",
   "devDependencies": {

--- a/extensions/line/package.json
+++ b/extensions/line/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/line",
-  "version": "2026.2.12",
+  "version": "2026.2.13",
   "private": true,
   "description": "OpenClaw LINE channel plugin",
   "type": "module",

--- a/extensions/llm-task/package.json
+++ b/extensions/llm-task/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/llm-task",
-  "version": "2026.2.12",
+  "version": "2026.2.13",
   "private": true,
   "description": "OpenClaw JSON-only LLM task plugin",
   "type": "module",

--- a/extensions/lobster/package.json
+++ b/extensions/lobster/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/lobster",
-  "version": "2026.2.12",
+  "version": "2026.2.13",
   "description": "Lobster workflow tool plugin (typed pipelines + resumable approvals)",
   "type": "module",
   "devDependencies": {

--- a/extensions/matrix/CHANGELOG.md
+++ b/extensions/matrix/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026.2.13
+
+### Changes
+
+- Version alignment with core OpenClaw release numbers.
+
 ## 2026.2.6-3
 
 ### Changes

--- a/extensions/matrix/package.json
+++ b/extensions/matrix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/matrix",
-  "version": "2026.2.12",
+  "version": "2026.2.13",
   "description": "OpenClaw Matrix channel plugin",
   "type": "module",
   "dependencies": {

--- a/extensions/mattermost/package.json
+++ b/extensions/mattermost/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/mattermost",
-  "version": "2026.2.12",
+  "version": "2026.2.13",
   "private": true,
   "description": "OpenClaw Mattermost channel plugin",
   "type": "module",

--- a/extensions/memory-core/package.json
+++ b/extensions/memory-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/memory-core",
-  "version": "2026.2.12",
+  "version": "2026.2.13",
   "private": true,
   "description": "OpenClaw core memory search plugin",
   "type": "module",

--- a/extensions/memory-lancedb/package.json
+++ b/extensions/memory-lancedb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/memory-lancedb",
-  "version": "2026.2.12",
+  "version": "2026.2.13",
   "private": true,
   "description": "OpenClaw LanceDB-backed long-term memory plugin with auto-recall/capture",
   "type": "module",

--- a/extensions/minimax-portal-auth/package.json
+++ b/extensions/minimax-portal-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/minimax-portal-auth",
-  "version": "2026.2.12",
+  "version": "2026.2.13",
   "private": true,
   "description": "OpenClaw MiniMax Portal OAuth provider plugin",
   "type": "module",

--- a/extensions/msteams/CHANGELOG.md
+++ b/extensions/msteams/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026.2.13
+
+### Changes
+
+- Version alignment with core OpenClaw release numbers.
+
 ## 2026.2.6-3
 
 ### Changes

--- a/extensions/msteams/package.json
+++ b/extensions/msteams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/msteams",
-  "version": "2026.2.12",
+  "version": "2026.2.13",
   "description": "OpenClaw Microsoft Teams channel plugin",
   "type": "module",
   "dependencies": {

--- a/extensions/nextcloud-talk/package.json
+++ b/extensions/nextcloud-talk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/nextcloud-talk",
-  "version": "2026.2.12",
+  "version": "2026.2.13",
   "description": "OpenClaw Nextcloud Talk channel plugin",
   "type": "module",
   "devDependencies": {

--- a/extensions/nostr/CHANGELOG.md
+++ b/extensions/nostr/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026.2.13
+
+### Changes
+
+- Version alignment with core OpenClaw release numbers.
+
 ## 2026.2.6-3
 
 ### Changes

--- a/extensions/nostr/package.json
+++ b/extensions/nostr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/nostr",
-  "version": "2026.2.12",
+  "version": "2026.2.13",
   "description": "OpenClaw Nostr channel plugin for NIP-04 encrypted DMs",
   "type": "module",
   "dependencies": {

--- a/extensions/open-prose/package.json
+++ b/extensions/open-prose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/open-prose",
-  "version": "2026.2.12",
+  "version": "2026.2.13",
   "private": true,
   "description": "OpenProse VM skill pack plugin (slash command + telemetry).",
   "type": "module",

--- a/extensions/signal/package.json
+++ b/extensions/signal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/signal",
-  "version": "2026.2.12",
+  "version": "2026.2.13",
   "private": true,
   "description": "OpenClaw Signal channel plugin",
   "type": "module",

--- a/extensions/slack/package.json
+++ b/extensions/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/slack",
-  "version": "2026.2.12",
+  "version": "2026.2.13",
   "private": true,
   "description": "OpenClaw Slack channel plugin",
   "type": "module",

--- a/extensions/telegram/package.json
+++ b/extensions/telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/telegram",
-  "version": "2026.2.12",
+  "version": "2026.2.13",
   "private": true,
   "description": "OpenClaw Telegram channel plugin",
   "type": "module",

--- a/extensions/tlon/package.json
+++ b/extensions/tlon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/tlon",
-  "version": "2026.2.12",
+  "version": "2026.2.13",
   "private": true,
   "description": "OpenClaw Tlon/Urbit channel plugin",
   "type": "module",

--- a/extensions/twitch/CHANGELOG.md
+++ b/extensions/twitch/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026.2.13
+
+### Changes
+
+- Version alignment with core OpenClaw release numbers.
+
 ## 2026.2.6-3
 
 ### Changes

--- a/extensions/twitch/package.json
+++ b/extensions/twitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/twitch",
-  "version": "2026.2.12",
+  "version": "2026.2.13",
   "private": true,
   "description": "OpenClaw Twitch channel plugin",
   "type": "module",

--- a/extensions/voice-call/CHANGELOG.md
+++ b/extensions/voice-call/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026.2.13
+
+### Changes
+
+- Version alignment with core OpenClaw release numbers.
+
 ## 2026.2.6-3
 
 ### Changes

--- a/extensions/voice-call/package.json
+++ b/extensions/voice-call/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/voice-call",
-  "version": "2026.2.12",
+  "version": "2026.2.13",
   "description": "OpenClaw voice-call plugin",
   "type": "module",
   "dependencies": {

--- a/extensions/whatsapp/package.json
+++ b/extensions/whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/whatsapp",
-  "version": "2026.2.12",
+  "version": "2026.2.13",
   "private": true,
   "description": "OpenClaw WhatsApp channel plugin",
   "type": "module",

--- a/extensions/zalo/CHANGELOG.md
+++ b/extensions/zalo/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026.2.13
+
+### Changes
+
+- Version alignment with core OpenClaw release numbers.
+
 ## 2026.2.6-3
 
 ### Changes

--- a/extensions/zalo/package.json
+++ b/extensions/zalo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/zalo",
-  "version": "2026.2.12",
+  "version": "2026.2.13",
   "description": "OpenClaw Zalo channel plugin",
   "type": "module",
   "dependencies": {

--- a/extensions/zalouser/CHANGELOG.md
+++ b/extensions/zalouser/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026.2.13
+
+### Changes
+
+- Version alignment with core OpenClaw release numbers.
+
 ## 2026.2.6-3
 
 ### Changes

--- a/extensions/zalouser/package.json
+++ b/extensions/zalouser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/zalouser",
-  "version": "2026.2.12",
+  "version": "2026.2.13",
   "description": "OpenClaw Zalo Personal Account plugin via zca-cli",
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
## Summary

Fix `release-check` CI failures caused by extension package versions lagging behind the root release version.

## Root Cause

`pnpm release:check` requires extension package versions to match the root package version (`2026.2.13`).
Several extension packages were still on `2026.2.12`.

## Changes

- Ran `pnpm plugins:sync`
- Updated extension `package.json` versions to `2026.2.13`
- Kept extension changelogs in sync where the sync script updates them

## Verification

- `pnpm release:check`
- `pnpm check`

## Reference

- Recent failing run: `release-check` in run `21974719316`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates multiple extension `package.json` versions from `2026.2.12` to `2026.2.13` to match the root OpenClaw release version, addressing `pnpm release:check` CI failures. A few extension `CHANGELOG.md` files also gain a `2026.2.13` entry noting version alignment.

No functional code changes were introduced; the diff is limited to version metadata and changelog bookkeeping in the extensions workspace.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Diff is limited to extension version bumps and corresponding changelog entries; no runtime logic or dependencies were changed, and the stated CI goal directly matches the edits.
- No files require special attention

<sub>Last reviewed commit: bd9e014</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->