### PR TITLE
feat(irc): support self-signed TLS certificates via fingerprint pinning and insecure mode

### DIFF
--- a/docs/channels/irc.md
+++ b/docs/channels/irc.md
@@ -219,6 +219,51 @@ Optional one-time registration on connect:
 
 Disable `register` after the nick is registered to avoid repeated REGISTER attempts.
 
+## Self-signed TLS certificates
+
+When connecting to IRC servers with self-signed or untrusted TLS certificates, Node.js will reject the connection by default. Two options are available:
+
+### `tlsInsecure` — skip all certificate verification
+
+```json
+{
+  "channels": {
+    "irc": {
+      "tls": true,
+      "tlsInsecure": true
+    }
+  }
+}
+```
+
+This disables all certificate verification. The connection is encrypted but vulnerable to man-in-the-middle attacks. A security warning will appear in the status output.
+
+### `tlsFingerprints` — pin to specific certificate fingerprints
+
+```json
+{
+  "channels": {
+    "irc": {
+      "tls": true,
+      "tlsFingerprints": [
+        "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99"
+      ]
+    }
+  }
+}
+```
+
+This bypasses CA verification but checks that the server's SHA-256 certificate fingerprint matches one of the provided values. This is strictly more secure than `tlsInsecure` because it pins to specific certificates.
+
+To find a server's certificate fingerprint:
+
+```bash
+openssl s_client -connect irc.example.com:6697 < /dev/null 2>/dev/null \
+  | openssl x509 -noout -fingerprint -sha256
+```
+
+If both `tlsInsecure` and `tlsFingerprints` are set, `tlsInsecure` takes precedence (fingerprints are not checked).
+
 ## Environment variables
 
 Default account supports:
@@ -226,6 +271,7 @@ Default account supports:
 - `IRC_HOST`
 - `IRC_PORT`
 - `IRC_TLS`
+- `IRC_TLS_INSECURE`
 - `IRC_NICK`
 - `IRC_USERNAME`
 - `IRC_REALNAME`
@@ -239,3 +285,4 @@ Default account supports:
 - If the bot connects but never replies in channels, verify `channels.irc.groups` **and** whether mention-gating is dropping messages (`missing-mention`). If you want it to reply without pings, set `requireMention:false` for the channel.
 - If login fails, verify nick availability and server password.
 - If TLS fails on a custom network, verify host/port and certificate setup.
+- If TLS fails with a self-signed certificate, use `tlsFingerprints` to pin the server's certificate (preferred) or `tlsInsecure: true` to skip verification entirely. See [Self-signed TLS certificates](#self-signed-tls-certificates) above.

--- a/docs/channels/irc.md
+++ b/docs/channels/irc.md
@@ -223,7 +223,7 @@ Disable `register` after the nick is registered to avoid repeated REGISTER attem
 
 When connecting to IRC servers with self-signed or untrusted TLS certificates, Node.js will reject the connection by default. Two options are available:
 
-### `tlsInsecure` — skip all certificate verification
+### `tlsInsecure`: skip all certificate verification
 
 ```json
 {
@@ -238,7 +238,7 @@ When connecting to IRC servers with self-signed or untrusted TLS certificates, N
 
 This disables all certificate verification. The connection is encrypted but vulnerable to man-in-the-middle attacks. A security warning will appear in the status output.
 
-### `tlsFingerprints` — pin to specific certificate fingerprints
+### `tlsFingerprints`: pin to specific certificate fingerprints
 
 ```json
 {

--- a/extensions/irc/src/accounts.ts
+++ b/extensions/irc/src/accounts.ts
@@ -21,6 +21,8 @@ export type ResolvedIrcAccount = {
   realname: string;
   password: string;
   passwordSource: "env" | "passwordFile" | "config" | "none";
+  tlsInsecure: boolean;
+  tlsFingerprints: string[];
   config: IrcAccountConfig;
 };
 
@@ -198,6 +200,14 @@ export function resolveIrcAccount(params: {
       "OpenClaw"
     ).trim();
 
+    const tlsInsecure =
+      typeof merged.tlsInsecure === "boolean"
+        ? merged.tlsInsecure
+        : accountId === DEFAULT_ACCOUNT_ID
+          ? parseTruthy(process.env.IRC_TLS_INSECURE)
+          : false;
+    const tlsFingerprints = merged.tlsFingerprints ?? [];
+
     const passwordResolution = resolvePassword(accountId, merged);
     const nickserv = resolveNickServConfig(accountId, merged.nickserv);
 
@@ -226,6 +236,8 @@ export function resolveIrcAccount(params: {
       realname,
       password: passwordResolution.password,
       passwordSource: passwordResolution.source,
+      tlsInsecure,
+      tlsFingerprints,
       config,
     } satisfies ResolvedIrcAccount;
   };

--- a/extensions/irc/src/channel.startup.test.ts
+++ b/extensions/irc/src/channel.startup.test.ts
@@ -38,6 +38,8 @@ describe("ircPlugin gateway.startAccount", () => {
       realname: "OpenClaw",
       password: "",
       passwordSource: "none",
+      tlsInsecure: false,
+      tlsFingerprints: [],
       config: {} as ResolvedIrcAccount["config"],
     };
 

--- a/extensions/irc/src/channel.ts
+++ b/extensions/irc/src/channel.ts
@@ -164,6 +164,11 @@ export const ircPlugin: ChannelPlugin<ResolvedIrcAccount, IrcProbe> = {
           "- IRC TLS is disabled (channels.irc.tls=false); traffic and credentials are plaintext.",
         );
       }
+      if (account.tlsInsecure) {
+        warnings.push(
+          "- IRC TLS certificate verification is disabled (channels.irc.tlsInsecure=true); connection is vulnerable to MITM.",
+        );
+      }
       if (account.config.nickserv?.register) {
         warnings.push(
           '- IRC NickServ registration is enabled (channels.irc.nickserv.register=true); this sends "REGISTER" on every connect. Disable after first successful registration.',

--- a/extensions/irc/src/channel.ts
+++ b/extensions/irc/src/channel.ts
@@ -107,6 +107,8 @@ export const ircPlugin: ChannelPlugin<ResolvedIrcAccount, IrcProbe> = {
           "host",
           "port",
           "tls",
+          "tlsInsecure",
+          "tlsFingerprints",
           "nick",
           "username",
           "realname",

--- a/extensions/irc/src/client.test.ts
+++ b/extensions/irc/src/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildIrcNickServCommands } from "./client.js";
+import { buildIrcNickServCommands, normalizeTlsFingerprint } from "./client.js";
 
 describe("irc client nickserv", () => {
   it("builds IDENTIFY command when password is set", () => {
@@ -39,5 +39,48 @@ describe("irc client nickserv", () => {
         password: "secret\r\nJOIN #bad",
       }),
     ).toEqual(["PRIVMSG NickServ :IDENTIFY secret JOIN #bad"]);
+  });
+});
+
+describe("normalizeTlsFingerprint", () => {
+  it("normalizes lowercase colon-separated (openssl output format)", () => {
+    const input =
+      "aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99";
+    expect(normalizeTlsFingerprint(input)).toBe(
+      "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99",
+    );
+  });
+
+  it("normalizes bare lowercase hex (no separators)", () => {
+    const input = "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899";
+    expect(normalizeTlsFingerprint(input)).toBe(
+      "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99",
+    );
+  });
+
+  it("is idempotent on already-normalized uppercase colon form", () => {
+    const input =
+      "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99";
+    expect(normalizeTlsFingerprint(input)).toBe(input);
+  });
+
+  it("strips non-hex characters like hyphens", () => {
+    const input =
+      "AA-BB-CC-DD-EE-FF-00-11-22-33-44-55-66-77-88-99-AA-BB-CC-DD-EE-FF-00-11-22-33-44-55-66-77-88-99";
+    expect(normalizeTlsFingerprint(input)).toBe(
+      "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99",
+    );
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(normalizeTlsFingerprint("")).toBe("");
+  });
+
+  it("returns a deterministic but non-matching result for malformed (short) input", () => {
+    // Odd-length hex: produces a string that can never match a valid 64-char SHA-256
+    // fingerprint, so checkServerIdentity will always reject it (fail-safe behavior).
+    const result = normalizeTlsFingerprint("abc");
+    expect(result).toBe("AB:C");
+    expect(result.replace(/:/g, "").length).not.toBe(64);
   });
 });

--- a/extensions/irc/src/client.ts
+++ b/extensions/irc/src/client.ts
@@ -89,7 +89,7 @@ function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): 
  * Normalize a TLS certificate fingerprint to uppercase colon-separated hex
  * so that comparisons are consistent regardless of input format.
  */
-function normalizeTlsFingerprint(fp: string): string {
+export function normalizeTlsFingerprint(fp: string): string {
   const hex = fp.replace(/[^0-9a-fA-F]/g, "").toUpperCase();
   return hex.replace(/(.{2})(?=.)/g, "$1:");
 }

--- a/extensions/irc/src/client.ts
+++ b/extensions/irc/src/client.ts
@@ -38,6 +38,7 @@ export type IrcClientOptions = {
   onNotice?: (text: string, target?: string) => void;
   onError?: (error: Error) => void;
   onLine?: (line: string) => void;
+  log?: (message: string) => void;
 };
 
 export type IrcNickServOptions = {
@@ -51,6 +52,7 @@ export type IrcNickServOptions = {
 export type IrcClient = {
   nick: string;
   isReady: () => boolean;
+  closed: Promise<void>;
   sendRaw: (line: string) => void;
   join: (channel: string) => void;
   sendPrivmsg: (target: string, text: string) => void;
@@ -143,30 +145,56 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
   let nickServRecoverAttempted = false;
   let fallbackNickAttempted = false;
 
-  const bypassTlsVerification = Boolean(options.tlsInsecure || options.tlsFingerprints?.length);
-  const socket = options.tls
-    ? tls.connect({
-        host: options.host,
-        port: options.port,
-        servername: options.host,
-        rejectUnauthorized: !bypassTlsVerification,
-      })
-    : net.connect({ host: options.host, port: options.port });
+  const log = options.log ?? (() => {});
 
-  if (options.tls && !options.tlsInsecure && options.tlsFingerprints?.length) {
-    const allowedFingerprints = new Set(options.tlsFingerprints.map(normalizeTlsFingerprint));
-    const tlsSocket = socket as tls.TLSSocket;
-    tlsSocket.once("secureConnect", () => {
-      const cert = tlsSocket.getPeerCertificate();
+  log(`connecting to ${options.host}:${options.port} (tls=${options.tls}, nick=${desiredNick})`);
+
+  const bypassTlsVerification = Boolean(options.tlsInsecure || options.tlsFingerprints?.length);
+  if (options.tls) {
+    log(
+      `tls config: tlsInsecure=${Boolean(options.tlsInsecure)}, ` +
+        `tlsFingerprints=[${(options.tlsFingerprints ?? []).join(", ")}], ` +
+        `rejectUnauthorized=${!bypassTlsVerification}`,
+    );
+  }
+
+  const fingerprintSet =
+    options.tls && !options.tlsInsecure && options.tlsFingerprints?.length
+      ? new Set(options.tlsFingerprints.map(normalizeTlsFingerprint))
+      : null;
+
+  if (fingerprintSet) {
+    log(`fingerprint validation enabled: expecting one of [${[...fingerprintSet].join(", ")}]`);
+  }
+
+  const tlsOptions: tls.ConnectionOptions = {
+    host: options.host,
+    port: options.port,
+    servername: options.host,
+    rejectUnauthorized: !bypassTlsVerification,
+  };
+
+  if (fingerprintSet) {
+    tlsOptions.checkServerIdentity = (_host: string, cert: tls.PeerCertificate) => {
       const peerFingerprint = normalizeTlsFingerprint(cert.fingerprint256 ?? "");
-      if (!peerFingerprint || !allowedFingerprints.has(peerFingerprint)) {
-        tlsSocket.destroy(
-          new Error(
-            `TLS certificate fingerprint mismatch: got ${peerFingerprint}, expected one of [${[...allowedFingerprints].join(", ")}]`,
-          ),
+      log(`peer certificate fingerprint: ${peerFingerprint || "(empty)"}`);
+      if (!peerFingerprint || !fingerprintSet.has(peerFingerprint)) {
+        log(`fingerprint mismatch — aborting handshake`);
+        return new Error(
+          `TLS certificate fingerprint mismatch: got ${peerFingerprint}, expected one of [${[...fingerprintSet].join(", ")}]`,
         );
       }
-    });
+      log(`fingerprint matched`);
+      return undefined;
+    };
+  }
+
+  const socket = options.tls
+    ? tls.connect(tlsOptions)
+    : net.connect({ host: options.host, port: options.port });
+
+  if (options.tls && options.tlsInsecure) {
+    log(`tls verification fully bypassed (tlsInsecure=true)`);
   }
 
   socket.setEncoding("utf8");
@@ -176,6 +204,11 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
   const readyPromise = new Promise<void>((resolve, reject) => {
     resolveReady = resolve;
     rejectReady = reject;
+  });
+
+  let resolveClosed: (() => void) | null = null;
+  const closedPromise = new Promise<void>((resolve) => {
+    resolveClosed = resolve;
   });
 
   const fail = (err: unknown) => {
@@ -354,8 +387,12 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
         if (nickParam && nickParam.trim()) {
           currentNick = nickParam.trim();
         }
+        log(`received 001 (welcome) as ${currentNick}`);
         try {
           const nickServCommands = buildIrcNickServCommands(options.nickserv);
+          if (nickServCommands.length > 0) {
+            log(`sending ${nickServCommands.length} NickServ command(s)`);
+          }
           for (const command of nickServCommands) {
             sendRaw(command);
           }
@@ -368,6 +405,7 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
             continue;
           }
           try {
+            log(`joining ${trimmed}`);
             join(trimmed);
           } catch (err) {
             fail(err);
@@ -416,10 +454,13 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
   });
 
   socket.once("connect", () => {
+    log(`socket connected to ${options.host}:${options.port}`);
     try {
       if (options.password && options.password.trim()) {
+        log(`sending PASS`);
         sendRaw(`PASS ${options.password.trim()}`);
       }
+      log(`sending NICK ${options.nick.trim()}`);
       sendRaw(`NICK ${options.nick.trim()}`);
       sendRaw(`USER ${options.username.trim()} 0 * :${sanitizeIrcOutboundText(options.realname)}`);
     } catch (err) {
@@ -429,16 +470,20 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
   });
 
   socket.once("error", (err: unknown) => {
+    log(`socket error: ${err instanceof Error ? err.message : String(err)}`);
     fail(err);
   });
 
   socket.once("close", () => {
+    log(`socket closed (ready=${ready}, closed=${closed})`);
     if (!closed) {
       closed = true;
       if (!ready) {
         fail(new Error("IRC connection closed before ready"));
       }
     }
+    resolveClosed?.();
+    resolveClosed = null;
   });
 
   if (options.abortSignal) {
@@ -459,6 +504,7 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
       return currentNick;
     },
     isReady: () => ready && !closed,
+    closed: closedPromise,
     sendRaw,
     join,
     sendPrivmsg,

--- a/extensions/irc/src/config-schema.ts
+++ b/extensions/irc/src/config-schema.ts
@@ -65,6 +65,8 @@ export const IrcAccountSchemaBase = z
     mentionPatterns: z.array(z.string()).optional(),
     markdown: MarkdownConfigSchema,
     ...ReplyRuntimeConfigSchemaShape,
+    tlsInsecure: z.boolean().optional(),
+    tlsFingerprints: z.array(z.string()).optional(),
   })
   .strict();
 

--- a/extensions/irc/src/connect-options.ts
+++ b/extensions/irc/src/connect-options.ts
@@ -18,6 +18,8 @@ export function buildIrcConnectOptions(
     username: account.username,
     realname: account.realname,
     password: account.password,
+    tlsInsecure: account.tlsInsecure,
+    tlsFingerprints: account.tlsFingerprints,
     nickserv: {
       enabled: account.config.nickserv?.enabled,
       service: account.config.nickserv?.service,

--- a/extensions/irc/src/monitor.ts
+++ b/extensions/irc/src/monitor.ts
@@ -59,10 +59,19 @@ export async function monitorIrcProvider(opts: IrcMonitorOptions): Promise<{ sto
 
   let client: IrcClient | null = null;
 
+  logger.info(
+    `[${account.accountId}] connecting to ${account.host}:${account.port} ` +
+      `(tls=${account.tls}, tlsInsecure=${account.tlsInsecure}, ` +
+      `tlsFingerprints=[${account.tlsFingerprints.join(", ")}])`,
+  );
+
   client = await connectIrcClient(
     buildIrcConnectOptions(account, {
       channels: account.config.channels,
       abortSignal: opts.abortSignal,
+      log: (message) => {
+        logger.info(`[${account.accountId}] ${message}`);
+      },
       onLine: (line) => {
         if (core.logging.shouldLogVerbose()) {
           logger.debug?.(`[${account.accountId}] << ${line}`);
@@ -137,10 +146,13 @@ export async function monitorIrcProvider(opts: IrcMonitorOptions): Promise<{ sto
     `[${account.accountId}] connected to ${account.host}:${account.port}${account.tls ? " (tls)" : ""} as ${client.nick}`,
   );
 
-  return {
-    stop: () => {
-      client?.quit("shutdown");
-      client = null;
-    },
+  const stop = () => {
+    client?.quit("shutdown");
+    client = null;
   };
+
+  // Stay alive until the socket closes so the gateway doesn't auto-restart.
+  await client.closed;
+
+  return { stop };
 }

--- a/extensions/irc/src/types.ts
+++ b/extensions/irc/src/types.ts
@@ -64,6 +64,8 @@ export type IrcAccountConfig = {
   blockStreamingCoalesce?: BlockStreamingCoalesceConfig;
   responsePrefix?: string;
   mediaMaxMb?: number;
+  tlsInsecure?: boolean;
+  tlsFingerprints?: string[];
 };
 
 export type IrcConfig = IrcAccountConfig & {

--- a/src/config/types.irc.ts
+++ b/src/config/types.irc.ts
@@ -51,6 +51,10 @@ export type IrcAccountConfig = CommonChannelMessagingConfig & {
   >;
   /** Optional mention patterns specific to IRC channel messages. */
   mentionPatterns?: string[];
+  /** Skip all TLS certificate verification (insecure; vulnerable to MITM). */
+  tlsInsecure?: boolean;
+  /** Accept only TLS certificates matching these SHA-256 fingerprints (colon-separated hex). */
+  tlsFingerprints?: string[];
 };
 
 export type IrcConfig = {

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -1127,6 +1127,8 @@ export const IrcAccountSchemaBase = z
     mediaMaxMb: z.number().positive().optional(),
     heartbeat: ChannelHeartbeatVisibilitySchema,
     responsePrefix: z.string().optional(),
+    tlsInsecure: z.boolean().optional(),
+    tlsFingerprints: z.array(z.string()).optional(),
   })
   .strict();
 


### PR DESCRIPTION
## Summary

- Add `tlsInsecure` option to skip all TLS certificate verification for IRC connections (encrypted but no cert validation)
- Add `tlsFingerprints` option to pin connections to specific SHA-256 certificate fingerprints, allowing self-signed certs while still validating identity
- Add connection-level logging throughout the IRC client for easier debugging of TLS and connection issues
- Fix missing TLS options (`tlsInsecure`, `tlsFingerprints`) not being forwarded on transient send and probe connections

## Motivation

Users connecting to IRC servers (or bouncers) with self-signed or private CA certificates had no way to establish TLS connections — Node.js rejects untrusted certificates by default. Fingerprint pinning provides a secure alternative to fully disabling verification.

## Changes

- **`extensions/irc/src/client.ts`** — Accept `tlsInsecure` and `tlsFingerprints` options; set `rejectUnauthorized: false` when either is present; validate peer fingerprint on `secureConnect` when pinning; add `log` callback for connection lifecycle events
- **`extensions/irc/src/accounts.ts`** — Resolve `tlsInsecure` (with `IRC_TLS_INSECURE` env var fallback) and `tlsFingerprints` from config
- **`extensions/irc/src/monitor.ts`**, **`send.ts`**, **`probe.ts`** — Forward the new TLS options to `connectIrcClient`
- **`extensions/irc/src/channel.ts`** — Emit security warning when `tlsInsecure` is enabled
- **`extensions/irc/src/config-schema.ts`**, **`types.ts`** — Add schema and type definitions
- **`src/config/types.irc.ts`**, **`src/config/zod-schema.providers-core.ts`** — Add core config types and validation
- **`docs/channels/irc.md`** — Document both options with examples and fingerprint retrieval instructions

## AI Disclosure

* Built with [Claude Code](https://claude.ai/claude-code) (AI-assisted)
* **Testing:** Fully tested — running in production with `tlsFingerprints` allowlist against a bouncer with a self-signed cert; also verified `tlsInsecure` mode during initial development
* I understand what the code does and have reviewed all changes

## Greptile Feedback — Resolved

The automated review flagged that fingerprint validation on `secureConnect` could leak credentials before the check runs. This has been fixed by moving fingerprint validation to use `checkServerIdentity`, which rejects the TLS handshake itself before any IRC protocol-level data (PASS/USER/NICK/...) is sent.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds IRC TLS options to support self-signed certs: `tlsInsecure` (disable verification) and `tlsFingerprints` (SHA-256 fingerprint pinning). It wires these options through account resolution, config schemas/types (extension + core), and forwards them into monitor/probe/transient send connections. It also adds connection lifecycle logging to the IRC client and monitor.

One issue to address before merge: the fingerprint validation currently happens on `secureConnect`, but the client sends IRC authentication commands in the socket `connect` handler. For TLS pinning, this can send credentials before the fingerprint check runs, which undermines the security goal of pinning.

<h3>Confidence Score: 2/5</h3>

- This PR should not merge until the TLS fingerprint pinning handshake ordering is fixed.
- Fingerprint pinning is meant to prevent MITM, but the current implementation validates the fingerprint on `secureConnect` while sending PASS/NICK/USER on `connect`, which can run before validation and leak credentials. Once that ordering is corrected, the rest of the changes are straightforward schema/type plumbing and logging.
- extensions/irc/src/client.ts

<sub>Last reviewed commit: 4584cb1</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->