### PR TITLE
fix(web-search): handle direct output_text blocks in xAI Responses API

### DIFF
--- a/src/agents/tools/web-search.e2e.test.ts
+++ b/src/agents/tools/web-search.e2e.test.ts
@@ -231,6 +231,23 @@ describe("web_search grok response parsing", () => {
     expect(result.annotationCitations).toEqual(["https://example.com/a", "https://example.com/b"]);
   });
 
+  it("extracts content from direct output_text blocks (grok-4 + server-side tools)", () => {
+    const result = extractGrokContent({
+      output: [
+        { type: "web_search_call", id: "ws_1", status: "completed", action: { type: "search", query: "test" } },
+        {
+          type: "output_text",
+          text: "hello from direct output_text",
+          annotations: [
+            { type: "url_citation", url: "https://example.com/direct", start_index: 0, end_index: 5 },
+          ],
+        },
+      ],
+    });
+    expect(result.text).toBe("hello from direct output_text");
+    expect(result.annotationCitations).toEqual(["https://example.com/direct"]);
+  });
+
   it("falls back to deprecated output_text", () => {
     const result = extractGrokContent({ output_text: "hello from output_text" });
     expect(result.text).toBe("hello from output_text");

--- a/src/agents/tools/web-search.e2e.test.ts
+++ b/src/agents/tools/web-search.e2e.test.ts
@@ -234,12 +234,22 @@ describe("web_search grok response parsing", () => {
   it("extracts content from direct output_text blocks (grok-4 + server-side tools)", () => {
     const result = extractGrokContent({
       output: [
-        { type: "web_search_call", id: "ws_1", status: "completed", action: { type: "search", query: "test" } },
+        {
+          type: "web_search_call",
+          id: "ws_1",
+          status: "completed",
+          action: { type: "search", query: "test" },
+        },
         {
           type: "output_text",
           text: "hello from direct output_text",
           annotations: [
-            { type: "url_citation", url: "https://example.com/direct", start_index: 0, end_index: 5 },
+            {
+              type: "url_citation",
+              url: "https://example.com/direct",
+              start_index: 0,
+              end_index: 5,
+            },
           ],
         },
       ],


### PR DESCRIPTION
## Summary

The Grok web_search provider returns "No response" with empty citations for all queries.

## Root Cause

`extractGrokContent()` only checks for `output_text` blocks nested inside `type: "message"` wrapper items. However, xAI's `/v1/responses` API (grok-4 family with server-side tools like `web_search`) returns `output_text` blocks **directly** in the output array without a message wrapper.

## Changes

- Check for `output_text` type at the top level of the output array (direct blocks)
- Keep existing `message` wrapper check as fallback
- Update `GrokSearchResponse` type to include direct `text`/`annotations` fields
- Add test case for direct `output_text` extraction

## Testing

- Verified fix against live xAI API with `grok-4-1-fast` model
- Direct curl to `/v1/responses` confirms the response format
- New test case covers the direct output_text scenario
- Existing tests continue to pass

## AI Disclosure

- [x] AI-assisted (Claude via OpenClaw)
- [x] Lightly tested (live API verification + unit test added)
- [x] I understand what the code does

Fixes #15179

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes Grok (`xAI /v1/responses`) web_search parsing by teaching `extractGrokContent()` to recognize `output_text` blocks that appear *directly* in the top-level `output` array (a format returned by grok-4 models with server-side tools), while keeping the existing fallback that scans `message.content[]` blocks. It also updates the local response typing (`GrokSearchResponse`) to include `text`/`annotations` on top-level output items and adds a unit test covering the direct `output_text` shape.

The change is localized to the Grok provider path in `src/agents/tools/web-search.ts`, and only affects how web_search result text + citations are extracted before being wrapped and returned by the `web_search` tool.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge and fixes Grok response parsing, with low regression risk.
- Changes are narrowly scoped to Grok response parsing, preserve the existing message-wrapper parsing as a fallback, and include a unit test for the new response shape. Only minor type looseness is introduced (new top-level `text`/`annotations` on output items) and behavior stays backward-compatible via the `output_text` fallback. I couldn't execute tests in this environment due to missing Node/pnpm, but the test and code changes are straightforward TypeScript and consistent with existing patterns.
- src/agents/tools/web-search.ts (response typing + extraction order)

<sub>Last reviewed commit: 8cd3ce5</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->