### PR TITLE
fix(memory): use OR instead of AND in FTS5 query builder

### DIFF
--- a/src/memory/hybrid.test.ts
+++ b/src/memory/hybrid.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, it } from "vitest";
 import { bm25RankToScore, buildFtsQuery, mergeHybridResults } from "./hybrid.js";
 
 describe("memory hybrid helpers", () => {
-  it("buildFtsQuery tokenizes and AND-joins", () => {
-    expect(buildFtsQuery("hello world")).toBe('"hello" AND "world"');
-    expect(buildFtsQuery("FOO_bar baz-1")).toBe('"FOO_bar" AND "baz" AND "1"');
+  it("buildFtsQuery tokenizes and OR-joins", () => {
+    expect(buildFtsQuery("hello world")).toBe('"hello" OR "world"');
+    expect(buildFtsQuery("FOO_bar baz-1")).toBe('"FOO_bar" OR "baz" OR "1"');
     expect(buildFtsQuery("金银价格")).toBe('"金银价格"');
-    expect(buildFtsQuery("価格 2026年")).toBe('"価格" AND "2026年"');
+    expect(buildFtsQuery("価格 2026年")).toBe('"価格" OR "2026年"');
     expect(buildFtsQuery("   ")).toBeNull();
   });
 

--- a/src/memory/hybrid.ts
+++ b/src/memory/hybrid.ts
@@ -40,7 +40,7 @@ export function buildFtsQuery(raw: string): string | null {
     return null;
   }
   const quoted = tokens.map((t) => `"${t.replaceAll('"', "")}"`);
-  return quoted.join(" AND ");
+  return quoted.join(" OR ");
 }
 
 export function bm25RankToScore(rank: number): number {


### PR DESCRIPTION
`buildFtsQuery` joins tokens with `AND`, so multi-word queries like "meeting budget review" only match if all three words appear in a single chunk. In practice this means most multi-word searches return nothing.

Changed the join to `OR`. BM25 ranking already pushes multi-match results to the top, so recall improves without hurting precision.

Updated tests to match. All 4 hybrid tests pass.

Fixes #15226