### PR TITLE
feat(skills): add controller-cli

### DIFF
--- a/skills/controller-cli/SKILL.md
+++ b/skills/controller-cli/SKILL.md
@@ -25,7 +25,9 @@ Use this skill when you need to run the Cartridge Controller CLI (`controller-cl
 ## Quick Start (Install)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/cartridge-gg/controller-cli/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/cartridge-gg/controller-cli/main/install.sh -o /tmp/controller-cli-install.sh
+# Review the script before running it (it installs the `controller` binary).
+bash /tmp/controller-cli-install.sh
 export PATH="$PATH:$HOME/.local/bin"
 controller --version
 ```
@@ -44,6 +46,7 @@ Behavior:
 
 - Adds `--json` if missing.
 - Refuses to run `call|execute|register|transaction` without `--chain-id` or `--rpc-url`.
+- Times out after 900 seconds by default (override with `CONTROLLER_SAFE_TIMEOUT_SECONDS`; set to `0` to disable).
 - Parses stdout as JSON.
 - If `.status == "error"`, prints `error_code`, `message`, `recovery_hint` and exits non-zero.
 
@@ -197,8 +200,8 @@ Common recoveries:
 
 ## Input Validation
 
-Addresses must be `0x`-prefixed hex.
+Addresses must be `0x`-prefixed hex (up to 64 hex chars after `0x`; leading zeros may be omitted).
 
 ```bash
-python3 scripts/validate_hex_address.py 0xabc...
+python3 {baseDir}/scripts/validate_hex_address.py 0xabc...
 ```

--- a/skills/controller-cli/SKILL.md
+++ b/skills/controller-cli/SKILL.md
@@ -27,6 +27,7 @@ Use this skill when you need to run the Cartridge Controller CLI (`controller-cl
 ```bash
 curl -fsSL https://raw.githubusercontent.com/cartridge-gg/controller-cli/main/install.sh -o /tmp/controller-cli-install.sh
 # Review the script before running it (it installs the `controller` binary).
+# For reproducibility, consider pinning to a tag/commit SHA instead of `main`.
 bash /tmp/controller-cli-install.sh
 export PATH="$PATH:$HOME/.local/bin"
 controller --version
@@ -201,7 +202,9 @@ Common recoveries:
 ## Input Validation
 
 Addresses must be `0x`-prefixed hex (up to 64 hex chars after `0x`; leading zeros may be omitted).
+If you require a canonical `0x` + 64-hex format, use `--strict-64`.
 
 ```bash
 python3 {baseDir}/scripts/validate_hex_address.py 0xabc...
+python3 {baseDir}/scripts/validate_hex_address.py --strict-64 0x00...01
 ```

--- a/skills/controller-cli/SKILL.md
+++ b/skills/controller-cli/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: controller-cli
+description: Install and operate the Cartridge Controller CLI (`controller`) for human-approved sessions and Starknet transaction execution (JSON-only, explicit network, least-privilege policies, paymaster control, error recovery).
+homepage: https://github.com/cartridge-gg/controller-cli
+metadata: { "openclaw": { "emoji": "🎮", "requires": { "bins": ["controller"] } } }
+user-invocable: true
+---
+
+# Cartridge Controller CLI
+
+Use this skill when you need to run the Cartridge Controller CLI (`controller-cli`) to create a scoped session (human-approved) and then execute Starknet transactions via that session.
+
+## Non-Negotiable Rules
+
+- Always pass `--json` and treat outputs as JSON.
+- Always be explicit about network. Never rely on defaults:
+  - `--chain-id SN_MAIN|SN_SEPOLIA`, or
+  - `--rpc-url <explicit url>`.
+- `controller register` requires human browser authorization. Do not automate/bypass it.
+- Use least-privilege policies only. Do not add token transfer permissions unless explicitly requested.
+- Transaction links: use Voyager only:
+  - Mainnet: `https://voyager.online/tx/0x...`
+  - Sepolia: `https://sepolia.voyager.online/tx/0x...`
+
+## Quick Start (Install)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/cartridge-gg/controller-cli/main/install.sh | bash
+export PATH="$PATH:$HOME/.local/bin"
+controller --version
+```
+
+## Safer Wrapper (Recommended)
+
+This skill includes a small wrapper that enforces the rules above and normalizes output:
+
+```bash
+python3 {baseDir}/scripts/controller_safe.py status
+python3 {baseDir}/scripts/controller_safe.py register --preset loot-survivor --chain-id SN_MAIN
+python3 {baseDir}/scripts/controller_safe.py execute 0xCONTRACT entrypoint 0xCALLDATA --rpc-url https://api.cartridge.gg/x/starknet/sepolia
+```
+
+Behavior:
+
+- Adds `--json` if missing.
+- Refuses to run `call|execute|register|transaction` without `--chain-id` or `--rpc-url`.
+- Parses stdout as JSON.
+- If `.status == "error"`, prints `error_code`, `message`, `recovery_hint` and exits non-zero.
+
+## Deterministic Workflow
+
+### 1) Generate Keypair
+
+```bash
+controller generate --json
+```
+
+The private key is stored locally (typically `~/.config/controller-cli/`).
+
+### 2) Check Session Status
+
+```bash
+controller status --json
+```
+
+Common states:
+
+- `no_session` (no keypair)
+- `keypair_only` (needs registration)
+- `active` (registered and not expired)
+
+### 3) Register Session (Human Approval Required)
+
+Requirement: a human must approve in a browser.
+
+Option A (preferred): preset policies:
+
+```bash
+controller register --preset loot-survivor --chain-id SN_MAIN --json
+```
+
+Option B: least-privilege policy file:
+
+```bash
+controller register --file policy.json --rpc-url https://api.cartridge.gg/x/starknet/sepolia --json
+```
+
+Authorization output includes `short_url` and/or `authorization_url`:
+
+- Display `short_url` if present; otherwise display `authorization_url`.
+- Ask the user to open it and approve.
+- The CLI blocks until approved or timeout (typically ~6 minutes).
+
+### 4) Execute Transaction
+
+Single call (positional args: contract, entrypoint, calldata):
+
+```bash
+controller execute 0xCONTRACT transfer 0xRECIPIENT,0xAMOUNT_LOW,0xAMOUNT_HIGH \
+  --rpc-url https://api.cartridge.gg/x/starknet/sepolia \
+  --json
+```
+
+Multiple calls from file:
+
+```bash
+controller execute --file calls.json --rpc-url https://api.cartridge.gg/x/starknet/sepolia --json
+```
+
+Optional confirmation wait:
+
+```bash
+controller execute --file calls.json --rpc-url https://api.cartridge.gg/x/starknet/sepolia --wait --timeout 300 --json
+```
+
+### 5) Read-Only Call (No Session Needed)
+
+```bash
+controller call 0xCONTRACT balance_of 0xADDRESS --chain-id SN_SEPOLIA --json
+```
+
+### 6) Transaction Status
+
+```bash
+controller transaction 0xTX_HASH --chain-id SN_SEPOLIA --wait --timeout 300 --json
+```
+
+### 7) Lookup Usernames / Addresses
+
+```bash
+controller lookup --usernames alice,bob --json
+controller lookup --addresses 0x123...,0x456... --json
+```
+
+## Network Selection
+
+Always be explicit about network.
+
+Supported networks:
+
+| Chain ID     | RPC URL                                       |
+| ------------ | --------------------------------------------- |
+| `SN_MAIN`    | `https://api.cartridge.gg/x/starknet/mainnet` |
+| `SN_SEPOLIA` | `https://api.cartridge.gg/x/starknet/sepolia` |
+
+Priority order:
+
+1. `--rpc-url` flag
+2. Stored session RPC URL (from registration)
+3. Config default (lowest)
+
+If network is ambiguous:
+
+1. Run `controller status --json`
+2. Match the session `chain_id`, or ask the user
+
+## Paymaster Control
+
+Default behavior uses the paymaster (free execution). If the paymaster is unavailable, the transaction fails (no silent fallback).
+
+To self-pay with user funds:
+
+```bash
+controller execute ... --no-paymaster --json
+```
+
+## Amount Encoding (u256)
+
+Many ERC20-style amounts are `u256` split into `(low, high)` u128 limbs.
+
+For values that fit in u128 (most cases): set `high = 0x0`.
+
+Example calldata:
+`0xRECIPIENT,0x64,0x0`
+
+## Error Handling
+
+Errors are JSON:
+
+```json
+{
+  "status": "error",
+  "error_code": "ErrorType",
+  "message": "...",
+  "recovery_hint": "..."
+}
+```
+
+Always branch on `error_code` and follow `recovery_hint`.
+
+Common recoveries:
+
+- `NoSession`: run `controller generate --json`
+- `SessionExpired`: re-run `controller register ... --json`
+- `ManualExecutionRequired`: policy does not authorize the call; tighten/adjust policy and re-register
+- `CallbackTimeout`: user did not approve quickly enough; re-run `register` and retry
+
+## Input Validation
+
+Addresses must be `0x`-prefixed hex.
+
+```bash
+python3 scripts/validate_hex_address.py 0xabc...
+```

--- a/skills/controller-cli/scripts/controller_safe.py
+++ b/skills/controller-cli/scripts/controller_safe.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""
+controller_safe.py
+
+Wrapper around `controller` (controller-cli) that enforces:
+- JSON output
+- explicit network selection for networked commands
+- structured error handling
+
+Stdlib-only so it can run in CI and constrained environments.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+
+
+NETWORK_REQUIRED = {"call", "execute", "register", "transaction"}
+
+
+def _has_flag(args: list[str], flag: str) -> bool:
+    return flag in args
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print("usage: controller_safe.py <subcommand> [args...]", file=sys.stderr)
+        return 2
+
+    if shutil.which("controller") is None:
+        print("error: 'controller' not found in PATH (install controller-cli first)", file=sys.stderr)
+        return 127
+
+    subcmd = argv[1]
+    args = argv[2:]
+
+    if subcmd in NETWORK_REQUIRED and not (_has_flag(args, "--chain-id") or _has_flag(args, "--rpc-url")):
+        print(
+            f"error: controller '{subcmd}' requires explicit network: pass --chain-id SN_MAIN|SN_SEPOLIA or --rpc-url <url>",
+            file=sys.stderr,
+        )
+        return 2
+
+    if not _has_flag(args, "--json"):
+        args = [*args, "--json"]
+
+    proc = subprocess.run(
+        ["controller", subcmd, *args],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    if proc.stderr.strip():
+        print(proc.stderr.rstrip("\n"), file=sys.stderr)
+
+    stdout = proc.stdout.strip()
+    try:
+        payload = json.loads(stdout)
+    except Exception:
+        print(f"error: controller output is not valid JSON (exit {proc.returncode})", file=sys.stderr)
+        if stdout:
+            print(stdout, file=sys.stderr)
+        return 1
+
+    if payload.get("status") == "error":
+        code = payload.get("error_code") or "unknown"
+        msg = payload.get("message") or ""
+        hint = payload.get("recovery_hint") or ""
+
+        print(f"controller error: {code}", file=sys.stderr)
+        if msg:
+            print(f"message: {msg}", file=sys.stderr)
+        if hint:
+            print(f"recovery_hint: {hint}", file=sys.stderr)
+        return 1
+
+    # If controller returned a non-zero status but didn't include an error payload,
+    # treat it as failure (don't silently succeed).
+    if proc.returncode != 0:
+        print(f"error: controller exited with {proc.returncode} without a JSON error payload", file=sys.stderr)
+        json.dump(payload, sys.stderr, indent=2)
+        sys.stderr.write("\n")
+        return proc.returncode
+
+    json.dump(payload, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))
+

--- a/skills/controller-cli/scripts/validate_hex_address.py
+++ b/skills/controller-cli/scripts/validate_hex_address.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+import sys
+
+
+HEX_ADDRESS = re.compile(r"^0x[0-9a-fA-F]+$")
+MAX_ADDRESS_LEN = 66  # 0x + up to 64 hex chars (allow leading-zero padding)
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print("usage: validate_hex_address.py <0x...> [more...]", file=sys.stderr)
+        return 2
+
+    bad = 0
+    for s in argv[1:]:
+        if not HEX_ADDRESS.match(s):
+            print(f"invalid hex address: {s}", file=sys.stderr)
+            bad = 1
+            continue
+        if len(s) > MAX_ADDRESS_LEN:
+            print(f"invalid hex address (too long): {s}", file=sys.stderr)
+            bad = 1
+    return bad
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/skills/controller-cli/scripts/validate_hex_address.py
+++ b/skills/controller-cli/scripts/validate_hex_address.py
@@ -6,7 +6,7 @@ import sys
 
 
 HEX_ADDRESS = re.compile(r"^0x[0-9a-fA-F]+$")
-MAX_ADDRESS_LEN = 66  # 0x + up to 64 hex chars (allow leading-zero padding)
+MAX_ADDRESS_LEN = 66  # Accept 0x + 1..64 hex chars (leading zeros may be omitted)
 
 
 def main(argv: list[str]) -> int:

--- a/skills/controller-cli/scripts/validate_hex_address.py
+++ b/skills/controller-cli/scripts/validate_hex_address.py
@@ -7,21 +7,31 @@ import sys
 
 HEX_ADDRESS = re.compile(r"^0x[0-9a-fA-F]+$")
 MAX_ADDRESS_LEN = 66  # Accept 0x + 1..64 hex chars (leading zeros may be omitted)
+STRICT_LEN = 66  # 0x + exactly 64 hex chars
 
 
 def main(argv: list[str]) -> int:
-    if len(argv) < 2:
-        print("usage: validate_hex_address.py <0x...> [more...]", file=sys.stderr)
+    args = argv[1:]
+    strict = False
+    if args and args[0] in ("--strict", "--strict-64"):
+        strict = True
+        args = args[1:]
+
+    if not args:
+        print("usage: validate_hex_address.py [--strict-64] <0x...> [more...]", file=sys.stderr)
         return 2
 
     bad = 0
-    for s in argv[1:]:
+    for s in args:
         if not HEX_ADDRESS.match(s):
             print(f"invalid hex address: {s}", file=sys.stderr)
             bad = 1
             continue
         if len(s) > MAX_ADDRESS_LEN:
             print(f"invalid hex address (too long): {s}", file=sys.stderr)
+            bad = 1
+        if strict and len(s) != STRICT_LEN:
+            print(f"invalid hex address (expected 0x + 64 hex chars): {s}", file=sys.stderr)
             bad = 1
     return bad
 


### PR DESCRIPTION
Adds `skills/controller-cli` (Cartridge Controller CLI) for human-approved session registration and Starknet transaction execution.

Includes:
- `SKILL.md` workflow + best practices (JSON-only, explicit network selection, least-privilege policies)
- `scripts/controller_safe.py` wrapper to enforce `--json`, explicit network flags, and non-zero exit on `.status=="error"`
- `scripts/validate_hex_address.py` helper (bounds 0x + 64 hex chars)

Testing:
- `pnpm build` OK
- `pnpm check` OK
- `pnpm test` is very heavy locally; it flaked once on `src/browser/cdp.test.ts` (fetchJson 1500ms AbortError under parallel load). Re-running the file alone passes: `pnpm vitest run src/browser/cdp.test.ts`.

AI-assisted: yes (Codex).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new `controller-cli` skill with operational guidance for Cartridge Controller CLI: installing the `controller` binary, registering a human-approved session, and executing/calling Starknet transactions with JSON-only output and explicit network selection.

The PR also adds two small stdlib-only Python helpers under the skill:
- `scripts/controller_safe.py`: a wrapper that enforces `--json`, requires explicit `--chain-id`/`--rpc-url` for networked subcommands, parses stdout as JSON, and exits non-zero on `.status == "error"`.
- `scripts/validate_hex_address.py`: a CLI helper to validate that inputs look like `0x`-prefixed hex addresses.

These changes fit the existing skills structure (YAML frontmatter + optional scripts) and aim to standardize safer usage patterns for an external CLI.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge after addressing a few correctness and safety gaps in the helper scripts/docs.
- Changes are isolated to a new skill and helper scripts, but the address validator currently does not match the stated fixed-length constraint, the wrapper can hang indefinitely, and the install instructions encourage piping remote scripts to bash without warnings/safer alternatives.
- skills/controller-cli/scripts/validate_hex_address.py; skills/controller-cli/scripts/controller_safe.py; skills/controller-cli/SKILL.md

<sub>Last reviewed commit: a57fb80</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->