### PR TITLE
fix(feishu): route tool credentials by account parameter

### DIFF
--- a/extensions/feishu/src/bitable.ts
+++ b/extensions/feishu/src/bitable.ts
@@ -1,7 +1,9 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { Type } from "@sinclair/typebox";
-import type { FeishuConfig } from "./types.js";
+import type { FeishuConfig, ResolvedFeishuAccount } from "./types.js";
+import { listEnabledFeishuAccounts } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
+import { AccountParam, createAccountAwareClientResolver } from "./tool-account.js";
 
 // ============ Helpers ============
 
@@ -251,6 +253,7 @@ const GetMetaSchema = Type.Object({
   url: Type.String({
     description: "Bitable URL. Supports both formats: /base/XXX?table=YYY or /wiki/XXX?table=YYY",
   }),
+  account: AccountParam,
 });
 
 const ListFieldsSchema = Type.Object({
@@ -258,6 +261,7 @@ const ListFieldsSchema = Type.Object({
     description: "Bitable app token (use feishu_bitable_get_meta to get from URL)",
   }),
   table_id: Type.String({ description: "Table ID (from URL: ?table=YYY)" }),
+  account: AccountParam,
 });
 
 const ListRecordsSchema = Type.Object({
@@ -275,6 +279,7 @@ const ListRecordsSchema = Type.Object({
   page_token: Type.Optional(
     Type.String({ description: "Pagination token from previous response" }),
   ),
+  account: AccountParam,
 });
 
 const GetRecordSchema = Type.Object({
@@ -283,6 +288,7 @@ const GetRecordSchema = Type.Object({
   }),
   table_id: Type.String({ description: "Table ID (from URL: ?table=YYY)" }),
   record_id: Type.String({ description: "Record ID to retrieve" }),
+  account: AccountParam,
 });
 
 const CreateRecordSchema = Type.Object({
@@ -294,6 +300,7 @@ const CreateRecordSchema = Type.Object({
     description:
       "Field values keyed by field name. Format by type: Text='string', Number=123, SingleSelect='Option', MultiSelect=['A','B'], DateTime=timestamp_ms, User=[{id:'ou_xxx'}], URL={text:'Display',link:'https://...'}",
   }),
+  account: AccountParam,
 });
 
 const UpdateRecordSchema = Type.Object({
@@ -305,18 +312,38 @@ const UpdateRecordSchema = Type.Object({
   fields: Type.Record(Type.String(), Type.Any(), {
     description: "Field values to update (same format as create_record)",
   }),
+  account: AccountParam,
 });
 
 // ============ Tool Registration ============
 
 export function registerFeishuBitableTools(api: OpenClawPluginApi) {
-  const feishuCfg = api.config?.channels?.feishu as FeishuConfig | undefined;
-  if (!feishuCfg?.appId || !feishuCfg?.appSecret) {
-    api.logger.debug?.("feishu_bitable: Feishu credentials not configured, skipping bitable tools");
+  if (!api.config) {
+    api.logger.debug?.("feishu_bitable: No config available, skipping bitable tools");
     return;
   }
 
-  const getClient = () => createFeishuClient(feishuCfg);
+  const accounts = listEnabledFeishuAccounts(api.config);
+  let firstAccount: ResolvedFeishuAccount | undefined = accounts[0];
+  if (!firstAccount) {
+    // Backward compatibility: build account from top-level credentials
+    const feishuCfg = api.config?.channels?.feishu as FeishuConfig | undefined;
+    if (!feishuCfg?.appId || !feishuCfg?.appSecret) {
+      api.logger.debug?.("feishu_bitable: No Feishu accounts configured, skipping bitable tools");
+      return;
+    }
+    firstAccount = {
+      accountId: "_legacy",
+      enabled: true,
+      configured: true,
+      appId: feishuCfg.appId,
+      appSecret: feishuCfg.appSecret,
+      domain: feishuCfg.domain ?? "feishu",
+      config: feishuCfg,
+    };
+  }
+
+  const resolveClient = createAccountAwareClientResolver(api.config, firstAccount);
 
   // Tool 0: feishu_bitable_get_meta (helper to parse URLs)
   api.registerTool(
@@ -327,9 +354,9 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
         "Parse a Bitable URL and get app_token, table_id, and table list. Use this first when given a /wiki/ or /base/ URL.",
       parameters: GetMetaSchema,
       async execute(_toolCallId, params) {
-        const { url } = params as { url: string };
+        const { url, account } = params as { url: string; account?: string };
         try {
-          const result = await getBitableMeta(getClient(), url);
+          const result = await getBitableMeta(resolveClient(account), url);
           return json(result);
         } catch (err) {
           return json({ error: err instanceof Error ? err.message : String(err) });
@@ -347,9 +374,13 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
       description: "List all fields (columns) in a Bitable table with their types and properties",
       parameters: ListFieldsSchema,
       async execute(_toolCallId, params) {
-        const { app_token, table_id } = params as { app_token: string; table_id: string };
+        const { app_token, table_id, account } = params as {
+          app_token: string;
+          table_id: string;
+          account?: string;
+        };
         try {
-          const result = await listFields(getClient(), app_token, table_id);
+          const result = await listFields(resolveClient(account), app_token, table_id);
           return json(result);
         } catch (err) {
           return json({ error: err instanceof Error ? err.message : String(err) });
@@ -367,14 +398,21 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
       description: "List records (rows) from a Bitable table with pagination support",
       parameters: ListRecordsSchema,
       async execute(_toolCallId, params) {
-        const { app_token, table_id, page_size, page_token } = params as {
+        const { app_token, table_id, page_size, page_token, account } = params as {
           app_token: string;
           table_id: string;
           page_size?: number;
           page_token?: string;
+          account?: string;
         };
         try {
-          const result = await listRecords(getClient(), app_token, table_id, page_size, page_token);
+          const result = await listRecords(
+            resolveClient(account),
+            app_token,
+            table_id,
+            page_size,
+            page_token,
+          );
           return json(result);
         } catch (err) {
           return json({ error: err instanceof Error ? err.message : String(err) });
@@ -392,13 +430,14 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
       description: "Get a single record by ID from a Bitable table",
       parameters: GetRecordSchema,
       async execute(_toolCallId, params) {
-        const { app_token, table_id, record_id } = params as {
+        const { app_token, table_id, record_id, account } = params as {
           app_token: string;
           table_id: string;
           record_id: string;
+          account?: string;
         };
         try {
-          const result = await getRecord(getClient(), app_token, table_id, record_id);
+          const result = await getRecord(resolveClient(account), app_token, table_id, record_id);
           return json(result);
         } catch (err) {
           return json({ error: err instanceof Error ? err.message : String(err) });
@@ -416,13 +455,14 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
       description: "Create a new record (row) in a Bitable table",
       parameters: CreateRecordSchema,
       async execute(_toolCallId, params) {
-        const { app_token, table_id, fields } = params as {
+        const { app_token, table_id, fields, account } = params as {
           app_token: string;
           table_id: string;
           fields: Record<string, unknown>;
+          account?: string;
         };
         try {
-          const result = await createRecord(getClient(), app_token, table_id, fields);
+          const result = await createRecord(resolveClient(account), app_token, table_id, fields);
           return json(result);
         } catch (err) {
           return json({ error: err instanceof Error ? err.message : String(err) });
@@ -440,14 +480,21 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
       description: "Update an existing record (row) in a Bitable table",
       parameters: UpdateRecordSchema,
       async execute(_toolCallId, params) {
-        const { app_token, table_id, record_id, fields } = params as {
+        const { app_token, table_id, record_id, fields, account } = params as {
           app_token: string;
           table_id: string;
           record_id: string;
           fields: Record<string, unknown>;
+          account?: string;
         };
         try {
-          const result = await updateRecord(getClient(), app_token, table_id, record_id, fields);
+          const result = await updateRecord(
+            resolveClient(account),
+            app_token,
+            table_id,
+            record_id,
+            fields,
+          );
           return json(result);
         } catch (err) {
           return json({ error: err instanceof Error ? err.message : String(err) });

--- a/extensions/feishu/src/doc-schema.ts
+++ b/extensions/feishu/src/doc-schema.ts
@@ -1,9 +1,11 @@
 import { Type, type Static } from "@sinclair/typebox";
+import { AccountParam } from "./tool-account.js";
 
 export const FeishuDocSchema = Type.Union([
   Type.Object({
     action: Type.Literal("read"),
     doc_token: Type.String({ description: "Document token (extract from URL /docx/XXX)" }),
+    account: AccountParam,
   }),
   Type.Object({
     action: Type.Literal("write"),
@@ -11,36 +13,43 @@ export const FeishuDocSchema = Type.Union([
     content: Type.String({
       description: "Markdown content to write (replaces entire document content)",
     }),
+    account: AccountParam,
   }),
   Type.Object({
     action: Type.Literal("append"),
     doc_token: Type.String({ description: "Document token" }),
     content: Type.String({ description: "Markdown content to append to end of document" }),
+    account: AccountParam,
   }),
   Type.Object({
     action: Type.Literal("create"),
     title: Type.String({ description: "Document title" }),
     folder_token: Type.Optional(Type.String({ description: "Target folder token (optional)" })),
+    account: AccountParam,
   }),
   Type.Object({
     action: Type.Literal("list_blocks"),
     doc_token: Type.String({ description: "Document token" }),
+    account: AccountParam,
   }),
   Type.Object({
     action: Type.Literal("get_block"),
     doc_token: Type.String({ description: "Document token" }),
     block_id: Type.String({ description: "Block ID (from list_blocks)" }),
+    account: AccountParam,
   }),
   Type.Object({
     action: Type.Literal("update_block"),
     doc_token: Type.String({ description: "Document token" }),
     block_id: Type.String({ description: "Block ID (from list_blocks)" }),
     content: Type.String({ description: "New text content" }),
+    account: AccountParam,
   }),
   Type.Object({
     action: Type.Literal("delete_block"),
     doc_token: Type.String({ description: "Document token" }),
     block_id: Type.String({ description: "Block ID" }),
+    account: AccountParam,
   }),
 ]);
 

--- a/extensions/feishu/src/drive-schema.ts
+++ b/extensions/feishu/src/drive-schema.ts
@@ -1,4 +1,5 @@
 import { Type, type Static } from "@sinclair/typebox";
+import { AccountParam } from "./tool-account.js";
 
 const FileType = Type.Union([
   Type.Literal("doc"),
@@ -17,11 +18,13 @@ export const FeishuDriveSchema = Type.Union([
     folder_token: Type.Optional(
       Type.String({ description: "Folder token (optional, omit for root directory)" }),
     ),
+    account: AccountParam,
   }),
   Type.Object({
     action: Type.Literal("info"),
     file_token: Type.String({ description: "File or folder token" }),
     type: FileType,
+    account: AccountParam,
   }),
   Type.Object({
     action: Type.Literal("create_folder"),
@@ -29,17 +32,20 @@ export const FeishuDriveSchema = Type.Union([
     folder_token: Type.Optional(
       Type.String({ description: "Parent folder token (optional, omit for root)" }),
     ),
+    account: AccountParam,
   }),
   Type.Object({
     action: Type.Literal("move"),
     file_token: Type.String({ description: "File token to move" }),
     type: FileType,
     folder_token: Type.String({ description: "Target folder token" }),
+    account: AccountParam,
   }),
   Type.Object({
     action: Type.Literal("delete"),
     file_token: Type.String({ description: "File token to delete" }),
     type: FileType,
+    account: AccountParam,
   }),
 ]);
 

--- a/extensions/feishu/src/drive.ts
+++ b/extensions/feishu/src/drive.ts
@@ -3,6 +3,7 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { listEnabledFeishuAccounts } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
 import { FeishuDriveSchema, type FeishuDriveParams } from "./drive-schema.js";
+import { createAccountAwareClientResolver } from "./tool-account.js";
 import { resolveToolsConfig } from "./tools-config.js";
 
 // ============ Helpers ============
@@ -187,7 +188,7 @@ export function registerFeishuDriveTools(api: OpenClawPluginApi) {
     return;
   }
 
-  const getClient = () => createFeishuClient(firstAccount);
+  const resolveClient = createAccountAwareClientResolver(api.config!, firstAccount);
 
   api.registerTool(
     {
@@ -199,7 +200,7 @@ export function registerFeishuDriveTools(api: OpenClawPluginApi) {
       async execute(_toolCallId, params) {
         const p = params as FeishuDriveParams;
         try {
-          const client = getClient();
+          const client = resolveClient(p.account);
           switch (p.action) {
             case "list":
               return json(await listFolder(client, p.folder_token));

--- a/extensions/feishu/src/perm-schema.ts
+++ b/extensions/feishu/src/perm-schema.ts
@@ -1,4 +1,5 @@
 import { Type, type Static } from "@sinclair/typebox";
+import { AccountParam } from "./tool-account.js";
 
 const TokenType = Type.Union([
   Type.Literal("doc"),
@@ -31,6 +32,7 @@ export const FeishuPermSchema = Type.Union([
     action: Type.Literal("list"),
     token: Type.String({ description: "File token" }),
     type: TokenType,
+    account: AccountParam,
   }),
   Type.Object({
     action: Type.Literal("add"),
@@ -39,6 +41,7 @@ export const FeishuPermSchema = Type.Union([
     member_type: MemberType,
     member_id: Type.String({ description: "Member ID (email, open_id, user_id, etc.)" }),
     perm: Permission,
+    account: AccountParam,
   }),
   Type.Object({
     action: Type.Literal("remove"),
@@ -46,6 +49,7 @@ export const FeishuPermSchema = Type.Union([
     type: TokenType,
     member_type: MemberType,
     member_id: Type.String({ description: "Member ID to remove" }),
+    account: AccountParam,
   }),
 ]);
 

--- a/extensions/feishu/src/perm.ts
+++ b/extensions/feishu/src/perm.ts
@@ -3,6 +3,7 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { listEnabledFeishuAccounts } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
 import { FeishuPermSchema, type FeishuPermParams } from "./perm-schema.js";
+import { createAccountAwareClientResolver } from "./tool-account.js";
 import { resolveToolsConfig } from "./tools-config.js";
 
 // ============ Helpers ============
@@ -136,7 +137,7 @@ export function registerFeishuPermTools(api: OpenClawPluginApi) {
     return;
   }
 
-  const getClient = () => createFeishuClient(firstAccount);
+  const resolveClient = createAccountAwareClientResolver(api.config!, firstAccount);
 
   api.registerTool(
     {
@@ -147,7 +148,7 @@ export function registerFeishuPermTools(api: OpenClawPluginApi) {
       async execute(_toolCallId, params) {
         const p = params as FeishuPermParams;
         try {
-          const client = getClient();
+          const client = resolveClient(p.account);
           switch (p.action) {
             case "list":
               return json(await listMembers(client, p.token, p.type));

--- a/extensions/feishu/src/tool-account.ts
+++ b/extensions/feishu/src/tool-account.ts
@@ -1,0 +1,46 @@
+import type * as Lark from "@larksuiteoapi/node-sdk";
+import type { ClawdbotConfig } from "openclaw/plugin-sdk";
+import { Type } from "@sinclair/typebox";
+import type { ResolvedFeishuAccount } from "./types.js";
+import { resolveFeishuAccount, listEnabledFeishuAccounts } from "./accounts.js";
+import { createFeishuClient } from "./client.js";
+
+/**
+ * Optional account parameter for Feishu tool schemas.
+ * When provided, the tool uses the specified account's credentials
+ * instead of the default account.
+ */
+export const AccountParam = Type.Optional(
+  Type.String({
+    description:
+      "Feishu account ID to use (matches keys in channels.feishu.accounts). " +
+      "Omit to use the default account.",
+  }),
+);
+
+/**
+ * Create a function that resolves a Feishu client based on an optional account ID.
+ * If accountId is provided, uses that account's credentials.
+ * Otherwise falls back to the default (first) account.
+ */
+export function createAccountAwareClientResolver(
+  cfg: ClawdbotConfig,
+  defaultAccount: ResolvedFeishuAccount,
+): (accountId?: string) => Lark.Client {
+  return (accountId?: string) => {
+    if (accountId) {
+      const accounts = listEnabledFeishuAccounts(cfg);
+      const match = accounts.find((a) => a.accountId === accountId);
+      if (match) {
+        return createFeishuClient(match);
+      }
+      // Try resolving even if not in the enabled list (user might know what they're doing)
+      const resolved = resolveFeishuAccount({ cfg, accountId });
+      if (resolved.configured) {
+        return createFeishuClient(resolved);
+      }
+      // Fall through to default if account not found
+    }
+    return createFeishuClient(defaultAccount);
+  };
+}

--- a/extensions/feishu/src/wiki-schema.ts
+++ b/extensions/feishu/src/wiki-schema.ts
@@ -1,8 +1,10 @@
 import { Type, type Static } from "@sinclair/typebox";
+import { AccountParam } from "./tool-account.js";
 
 export const FeishuWikiSchema = Type.Union([
   Type.Object({
     action: Type.Literal("spaces"),
+    account: AccountParam,
   }),
   Type.Object({
     action: Type.Literal("nodes"),
@@ -10,15 +12,18 @@ export const FeishuWikiSchema = Type.Union([
     parent_node_token: Type.Optional(
       Type.String({ description: "Parent node token (optional, omit for root)" }),
     ),
+    account: AccountParam,
   }),
   Type.Object({
     action: Type.Literal("get"),
     token: Type.String({ description: "Wiki node token (from URL /wiki/XXX)" }),
+    account: AccountParam,
   }),
   Type.Object({
     action: Type.Literal("search"),
     query: Type.String({ description: "Search query" }),
     space_id: Type.Optional(Type.String({ description: "Limit search to this space (optional)" })),
+    account: AccountParam,
   }),
   Type.Object({
     action: Type.Literal("create"),
@@ -32,6 +37,7 @@ export const FeishuWikiSchema = Type.Union([
     parent_node_token: Type.Optional(
       Type.String({ description: "Parent node token (optional, omit for root)" }),
     ),
+    account: AccountParam,
   }),
   Type.Object({
     action: Type.Literal("move"),
@@ -43,12 +49,14 @@ export const FeishuWikiSchema = Type.Union([
     target_parent_token: Type.Optional(
       Type.String({ description: "Target parent node token (optional, root if omitted)" }),
     ),
+    account: AccountParam,
   }),
   Type.Object({
     action: Type.Literal("rename"),
     space_id: Type.String({ description: "Knowledge space ID" }),
     node_token: Type.String({ description: "Node token to rename" }),
     title: Type.String({ description: "New title" }),
+    account: AccountParam,
   }),
 ]);
 

--- a/extensions/feishu/src/wiki.ts
+++ b/extensions/feishu/src/wiki.ts
@@ -2,6 +2,7 @@ import type * as Lark from "@larksuiteoapi/node-sdk";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { listEnabledFeishuAccounts } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
+import { createAccountAwareClientResolver } from "./tool-account.js";
 import { resolveToolsConfig } from "./tools-config.js";
 import { FeishuWikiSchema, type FeishuWikiParams } from "./wiki-schema.js";
 
@@ -175,7 +176,7 @@ export function registerFeishuWikiTools(api: OpenClawPluginApi) {
     return;
   }
 
-  const getClient = () => createFeishuClient(firstAccount);
+  const resolveClient = createAccountAwareClientResolver(api.config!, firstAccount);
 
   api.registerTool(
     {
@@ -187,7 +188,7 @@ export function registerFeishuWikiTools(api: OpenClawPluginApi) {
       async execute(_toolCallId, params) {
         const p = params as FeishuWikiParams;
         try {
-          const client = getClient();
+          const client = resolveClient(p.account);
           switch (p.action) {
             case "spaces":
               return json(await listSpaces(client));


### PR DESCRIPTION
## Summary

Fixes #13916

All Feishu MCP tools (doc, wiki, drive, bitable, perm, scopes) previously captured a single account's credentials at plugin boot time via closure. In multi-account setups (e.g., 食小亨 + 圈宝), every agent shared the same Feishu app identity regardless of their configured binding in `openclaw.json`.

### Root Cause

- `registerFeishu*Tools()` functions called `createFeishuClient(firstAccount)` once at boot, storing the result in a `getClient` closure
- The `execute()` function signature has no agent context — it receives only `(toolCallId, params)`
- `registerTool()` is global scope — no per-agent tool scoping exists in the plugin SDK
- `bitable.ts` used an entirely separate code path reading top-level `channels.feishu.appId/appSecret` directly, bypassing the accounts system

### Fix

- **New `tool-account.ts`**: Shared utility with `createAccountAwareClientResolver()` — returns a function that resolves the correct `Lark.Client` based on an optional `account` parameter, falling back to the default account
- **Schema changes**: Added optional `account` parameter to all tool schemas (doc-schema, wiki-schema, drive-schema, perm-schema, bitable inline schemas) so the LLM can specify which Feishu account to use per invocation
- **Tool registration changes**: Replaced closure-captured `getClient()` with `resolveClient(p.account)` in all 5 tool registration files
- **Bitable migration**: Migrated `bitable.ts` from legacy top-level config reading to the accounts system (with backward compatibility fallback for deployments using top-level credentials)

### Files Changed

| File | Change |
|------|--------|
| `tool-account.ts` | **New** — `AccountParam` schema + `createAccountAwareClientResolver()` |
| `doc-schema.ts` | Added `account: AccountParam` to 8 action variants |
| `wiki-schema.ts` | Added `account: AccountParam` to 7 action variants |
| `drive-schema.ts` | Added `account: AccountParam` to 5 action variants |
| `perm-schema.ts` | Added `account: AccountParam` to 3 action variants |
| `bitable.ts` | Migrated to accounts system + added `account` to 6 schemas + extract from params |
| `docx.ts` | `getClient()` → `resolveClient(p.account)` |
| `wiki.ts` | `getClient()` → `resolveClient(p.account)` |
| `drive.ts` | `getClient()` → `resolveClient(p.account)` |
| `perm.ts` | `getClient()` → `resolveClient(p.account)` |

### Backward Compatibility

- The `account` parameter is optional (`Type.Optional`). When omitted, tools use the default (first) account — identical to current behavior
- Bitable registration retains the top-level `channels.feishu.appId/appSecret` fallback check for deployments that haven't migrated to the accounts config structure
- No changes to the Plugin SDK API surface

## Test plan

- [ ] Verify single-account deployments still work (no `account` param passed → uses default)
- [ ] Verify multi-account setup: invoke `feishu_doc` with `account: "shixiaoheng"` vs `account: "quanbao"` and confirm different app identities are used
- [ ] Verify `feishu_bitable_*` tools work with the accounts system (previously used legacy top-level config)
- [ ] Verify backward compat: top-level `channels.feishu.appId` config without accounts still registers bitable tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates Feishu MCP tools to support multi-account credential routing by adding an optional `account` parameter to tool schemas and resolving the correct `Lark.Client` per invocation (instead of capturing a single client at plugin boot).

The main issue is in `extensions/feishu/src/bitable.ts`: the new backward-compat path checks for top-level `channels.feishu.appId/appSecret`, but still proceeds to build a resolver using `accounts[0]` even when `accounts` is empty, which will break legacy deployments that rely on top-level credentials only.

Other tool registration files (`docx.ts`, `wiki.ts`, `drive.ts`, `perm.ts`) correctly require at least one enabled+configured account before registering tools, and use the new resolver to select accounts per call.

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe to merge, but has a concrete backward-compat runtime bug in Feishu Bitable tool registration.
- Most changes are mechanical and consistent (schema + per-invocation client resolution). However, `bitable.ts` currently can crash during tool registration for configs that only set top-level Feishu credentials, which the PR explicitly aims to keep supporting.
- extensions/feishu/src/bitable.ts

<sub>Last reviewed commit: e202e60</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->