### PR TITLE
feat(web-fetch): Add Accept header for Cloudflare Markdown for Agents [AI-assisted]

### DIFF
--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -409,7 +409,7 @@ async function runWebFetch(params: {
       timeoutMs: params.timeoutSeconds * 1000,
       init: {
         headers: {
-          Accept: "*/*",
+          Accept: "text/markdown, text/html;q=0.9, */*;q=0.8",
           "User-Agent": params.userAgent,
           "Accept-Language": "en-US,en;q=0.9",
         },


### PR DESCRIPTION
## Summary

This PR implements support for [Cloudflare's Markdown for Agents](https://blog.cloudflare.com/markdown-for-agents/) feature by updating the `Accept` header in `web_fetch`.

## Changes

- Changed Accept header from `*/*` to `text/markdown, text/html;q=0.9, */*;q=0.8`
- Implements backward-compatible content negotiation using quality values

## How it works

The updated Accept header uses HTTP content negotiation with quality values (q=):
1. **Prefers `text/markdown`** (q=1.0 implicit) - Cloudflare will serve optimized markdown if available
2. **Falls back to `text/html`** (q=0.9) - Standard HTML if markdown not available  
3. **Accepts any content type** (q=0.8) - Ensures compatibility with all servers

This is **fully backward-compatible**: servers that don't support `text/markdown` will continue serving HTML or other formats as before, with no breaking changes.

## Testing

- **Degree of testing**: Lightly tested
- Verified the change compiles and affects only HTTP request headers
- No runtime behavior change for servers that don't support `text/markdown`

Fixes #14999

---

## 🤖 AI Transparency

**Generated with**: OpenAI Codex (GPT-5.2) via [OpenClaw](https://github.com/openclaw/openclaw)

**Degree of testing**: Lightly tested (compilation verified, single-line change)

**Session log**: Available on request

**Code understanding confirmed**: ✅
- The change is a single-line modification to the `Accept` header in `src/agents/tools/web-fetch.ts`
- HTTP content negotiation with q-values ensures backward compatibility
- Servers respond with their preferred format from the Accept list; markdown-capable servers (Cloudflare) will serve markdown, others continue serving HTML
