### PR TITLE
z

### DIFF
--- a/OLLAMA_SETUP.md
+++ b/OLLAMA_SETUP.md
@@ -1,0 +1,67 @@
+# Quick Fix: Using Ollama with OpenClaw
+
+## The Issue
+
+You're getting "Unknown model: ollama/llama3.3" because:
+1. Model discovery needs OLLAMA_API_KEY set
+2. The gateway connection is failing (falling back to embedded)
+3. Embedded mode needs Ollama accessible at 127.0.0.1:11434
+
+## Quick Solution
+
+### Option 1: Use Local Mode with Ollama on Host
+
+Since your Ollama runs on your Mac (not in Docker), use `--local` mode:
+
+```bash
+export OLLAMA_API_KEY="ollama-local"
+export OLLAMA_BASE="http://127.0.0.1:11434"
+
+openclaw agent --agent default --local --message "Create a YouTube short from https://www.youtube.com/watch?v=VIDEO_ID"
+```
+
+### Option 2: Fix Gateway Connection
+
+The gateway WebSocket is failing. Try:
+
+1. **Check gateway is running:**
+   ```bash
+   docker-compose ps
+   docker-compose logs gateway --tail 20
+   ```
+
+2. **Restart gateway:**
+   ```bash
+   docker-compose restart gateway
+   ```
+
+3. **Use gateway (without --local):**
+   ```bash
+   export OLLAMA_API_KEY="ollama-local"
+   openclaw agent --agent default --message "Create a YouTube short from https://www.youtube.com/watch?v=VIDEO_ID"
+   ```
+
+### Option 3: Configure Agent Properly
+
+The agent needs Ollama configured. Since model discovery isn't working, let's use a workaround:
+
+1. **Set environment variables permanently:**
+   Add to your `~/.zshrc` or `~/.bashrc`:
+   ```bash
+   export OLLAMA_API_KEY="ollama-local"
+   export OLLAMA_BASE="http://127.0.0.1:11434"
+   ```
+
+2. **Use the main agent** (which might be configured differently):
+   ```bash
+   openclaw agent --agent main --local --message "Create a YouTube short from https://www.youtube.com/watch?v=VIDEO_ID"
+   ```
+
+## Recommended Approach
+
+For now, use **Option 1** (local mode) since:
+- Ollama runs on your Mac (127.0.0.1:11434)
+- Gateway connection is having issues
+- Local mode works directly with Ollama
+
+Once gateway is stable, you can remove `--local` and it will use the Docker gateway.

--- a/QUICKSTART_DOCKER.md
+++ b/QUICKSTART_DOCKER.md
@@ -1,0 +1,73 @@
+# Quick Start: YouTube Shorts with OpenClaw Docker
+
+## 1. Start OpenClaw Gateway
+
+```bash
+docker-compose up -d
+```
+
+This will:
+- Start the gateway container
+- Install dependencies (ffmpeg, jq, yt-dlp) on first run
+- Connect to Ollama at `host.docker.internal:11434`
+
+## 2. Verify Everything is Running
+
+```bash
+# Check gateway status
+openclaw gateway status
+
+# Check container logs
+docker-compose logs gateway
+
+# Verify skill is available
+openclaw skills list | grep youtube-shorts
+```
+
+## 3. Create a YouTube Short
+
+```bash
+openclaw agent --agent default --message "Create a YouTube short from https://www.youtube.com/watch?v=VIDEO_ID"
+```
+
+Replace `VIDEO_ID` with an actual YouTube video ID.
+
+### Example:
+
+```bash
+openclaw agent --agent default --message "Create a YouTube short from https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+```
+
+## 4. Find Your Short
+
+The created short will be saved to:
+```
+workspace/youtube-shorts/short_VIDEO_ID_TIMESTAMP.mp4
+```
+
+## Troubleshooting
+
+**Gateway not running?**
+```bash
+docker-compose restart gateway
+docker-compose logs gateway
+```
+
+**Dependencies missing?**
+The docker-compose.yml installs them automatically. If issues persist:
+```bash
+docker-compose exec gateway sh -c "apt-get update && apt-get install -y ffmpeg jq python3-pip && pip3 install yt-dlp"
+```
+
+**Ollama not accessible?**
+Make sure Ollama is running on your Mac:
+```bash
+ollama list
+```
+
+**Agent not found?**
+List agents and create one if needed:
+```bash
+openclaw agents list
+openclaw agents add default
+```

--- a/WORKAROUND_YOUTUBE_SHORTS.md
+++ b/WORKAROUND_YOUTUBE_SHORTS.md
@@ -1,0 +1,66 @@
+# Workaround: Create YouTube Shorts Without Model Discovery
+
+Since Ollama model discovery isn't working properly, here's a workaround to create YouTube Shorts using the scripts directly.
+
+## Option 1: Use Scripts Directly (Recommended)
+
+The YouTube Shorts skill scripts are ready to use. You can run them directly:
+
+```bash
+# Download video
+./workspace/skills/youtube-shorts/scripts/download-video.sh 'https://www.youtube.com/watch?v=fvvNdW5Urpo' /tmp/videos
+
+# Analyze segments (this requires Ollama - we'll skip AI analysis for now)
+# Or manually specify start time:
+START_TIME=0  # Start at beginning
+DURATION=60   # 60 seconds
+
+# Create short format
+./workspace/skills/youtube-shorts/scripts/create-short-format.sh /tmp/videos/video.mp4 $START_TIME $DURATION /tmp/short.mp4
+```
+
+## Option 2: Use OpenClaw Exec Tool (When Gateway Works)
+
+Once the gateway connection is fixed, you can use OpenClaw's `exec` tool:
+
+```bash
+openclaw agent --agent default --message "Use exec to run: ./workspace/skills/youtube-shorts/scripts/create-short.sh 'https://www.youtube.com/watch?v=VIDEO_ID'"
+```
+
+## Option 3: Fix Model Discovery
+
+The root issue is that Ollama model discovery isn't working. To fix:
+
+1. **Check if OLLAMA_API_KEY is set in the right place:**
+   ```bash
+   echo $OLLAMA_API_KEY
+   ```
+
+2. **Make sure Ollama is accessible:**
+   ```bash
+   curl http://127.0.0.1:11434/api/tags
+   ```
+
+3. **Try restarting OpenClaw gateway:**
+   ```bash
+   docker-compose restart gateway
+   ```
+
+4. **Check gateway logs for discovery errors:**
+   ```bash
+   docker-compose logs gateway | grep -i ollama
+   ```
+
+## Current Status
+
+- ✅ YouTube Shorts scripts are created and ready
+- ✅ Dependencies installed (ffmpeg, yt-dlp, jq)  
+- ✅ Gateway is running in Docker
+- ❌ Ollama model discovery not working
+- ❌ Gateway WebSocket connection failing
+
+## Next Steps
+
+1. **Immediate**: Use scripts directly (Option 1)
+2. **Short-term**: Fix gateway connection issue
+3. **Long-term**: Fix Ollama model discovery or use explicit provider config

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,46 +1,40 @@
 services:
-  openclaw-gateway:
-    image: ${OPENCLAW_IMAGE:-openclaw:local}
-    environment:
-      HOME: /home/node
-      TERM: xterm-256color
-      OPENCLAW_GATEWAY_TOKEN: ${OPENCLAW_GATEWAY_TOKEN}
-      CLAUDE_AI_SESSION_KEY: ${CLAUDE_AI_SESSION_KEY}
-      CLAUDE_WEB_SESSION_KEY: ${CLAUDE_WEB_SESSION_KEY}
-      CLAUDE_WEB_COOKIE: ${CLAUDE_WEB_COOKIE}
-    volumes:
-      - ${OPENCLAW_CONFIG_DIR}:/home/node/.openclaw
-      - ${OPENCLAW_WORKSPACE_DIR}:/home/node/.openclaw/workspace
+  gateway:
+    image: openclaw/gateway:latest  # Pulls latest patched
+    build: .  # Builds if needed (ARM-native)
     ports:
-      - "${OPENCLAW_GATEWAY_PORT:-18789}:18789"
-      - "${OPENCLAW_BRIDGE_PORT:-18790}:18790"
-    init: true
-    restart: unless-stopped
-    command:
-      [
-        "node",
-        "dist/index.js",
-        "gateway",
-        "--bind",
-        "${OPENCLAW_GATEWAY_BIND:-lan}",
-        "--port",
-        "18789",
-      ]
-
-  openclaw-cli:
-    image: ${OPENCLAW_IMAGE:-openclaw:local}
-    environment:
-      HOME: /home/node
-      TERM: xterm-256color
-      OPENCLAW_GATEWAY_TOKEN: ${OPENCLAW_GATEWAY_TOKEN}
-      BROWSER: echo
-      CLAUDE_AI_SESSION_KEY: ${CLAUDE_AI_SESSION_KEY}
-      CLAUDE_WEB_SESSION_KEY: ${CLAUDE_WEB_SESSION_KEY}
-      CLAUDE_WEB_COOKIE: ${CLAUDE_WEB_COOKIE}
+      - "127.0.0.1:18789:18789"  # Localhost-only (safer than "18789:18789")
     volumes:
-      - ${OPENCLAW_CONFIG_DIR}:/home/node/.openclaw
-      - ${OPENCLAW_WORKSPACE_DIR}:/home/node/.openclaw/workspace
-    stdin_open: true
-    tty: true
-    init: true
-    entrypoint: ["node", "dist/index.js"]
+      - /Users/home/GitHub/openclaw/config:/app/config  # Use ABSOLUTE paths on Mac (replace /full/path/to/openclaw/)
+      - /Users/home/GitHub/openclaw/workspace:/app/workspace
+      - /Users/home/GitHub/openclaw/credentials:/root/.openclaw/credentials
+    environment:
+      - NODE_ENV=production
+      - PORT=18789
+      - OPENCLAW_GATEWAY_TOKEN=${OPENCLAW_GATEWAY_TOKEN}
+      - OLLAMA_BASE=http://host.docker.internal:11434
+      - OLLAMA_API_KEY=ollama-local
+    # Install dependencies on startup (yt-dlp, ffmpeg, jq)
+    # Note: Container runs as non-root 'node' user, so we use sudo or install at build time
+    user: "0:0"  # Temporarily run as root to install packages
+    command: >
+      sh -c "
+        apt-get update -qq 2>/dev/null &&
+        apt-get install -y -qq ffmpeg jq python3-pip curl sudo 2>/dev/null &&
+        pip3 install --break-system-packages -q yt-dlp 2>/dev/null || true &&
+        chown -R node:node /app &&
+        su node -c 'node dist/index.js gateway --allow-unconfigured --port 18789'
+      "
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 4G  # Cap to protect your MacBook
+    # NO privileged: true – keeps it sandboxed (no host root/shell)
+
+  # models:  # Optional: API proxy (add local Ollama later)
+  #   image: openclaw/models:latest
+  #   environment:
+  #     - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+  #     - OPENAI_API_KEY=${OPENAI_API_KEY}
+  #   restart: unless-stopped

--- a/skills/youtube-shorts/DOCKER_SETUP.md
+++ b/skills/youtube-shorts/DOCKER_SETUP.md
@@ -1,0 +1,231 @@
+# Running YouTube Shorts Skill in Docker
+
+This guide shows how to run OpenClaw in Docker and use the YouTube Shorts skill.
+
+## Prerequisites
+
+1. **Copy the skill to workspace** (already done if you ran the setup):
+   ```bash
+   mkdir -p workspace/skills
+   cp -r skills/youtube-shorts workspace/skills/
+   ```
+
+2. **Install dependencies in Docker container**:
+   The Docker container needs `yt-dlp`, `ffmpeg`, and `jq`. You have two options:
+
+   **Option A: Install via Dockerfile** (recommended for production)
+   
+   Create a custom Dockerfile that extends the base image:
+   ```dockerfile
+   FROM openclaw/gateway:latest
+   RUN apt-get update && apt-get install -y \
+       ffmpeg \
+       jq \
+       python3-pip \
+       && pip3 install yt-dlp \
+       && rm -rf /var/lib/apt/lists/*
+   ```
+
+   **Option B: Install at runtime** (quick test)
+   
+   We'll install dependencies when starting the container.
+
+3. **Ensure Ollama is running** on your host machine (accessible at `host.docker.internal:11434`)
+
+## Step 1: Start OpenClaw Gateway in Docker
+
+### Option 1: Using docker-compose (Recommended)
+
+Update your `docker-compose.yml` to install dependencies:
+
+```yaml
+services:
+  gateway:
+    image: openclaw/gateway:latest
+    build: .
+    ports:
+      - "127.0.0.1:18789:18789"
+    volumes:
+      - /Users/home/GitHub/openclaw/config:/app/config
+      - /Users/home/GitHub/openclaw/workspace:/app/workspace
+      - /Users/home/GitHub/openclaw/credentials:/root/.openclaw/credentials
+    environment:
+      - NODE_ENV=production
+      - PORT=18789
+      - OPENCLAW_GATEWAY_TOKEN=${OPENCLAW_GATEWAY_TOKEN}
+      - OLLAMA_BASE=http://host.docker.internal:11434
+    # Install dependencies on startup
+    command: >
+      sh -c "
+        apt-get update -qq &&
+        apt-get install -y -qq ffmpeg jq python3-pip > /dev/null 2>&1 &&
+        pip3 install -q yt-dlp > /dev/null 2>&1 || true &&
+        node /app/dist/cli/gateway.js run --port 18789
+      "
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 4G
+```
+
+Then start it:
+
+```bash
+docker-compose up -d
+```
+
+### Option 2: Manual Docker run
+
+```bash
+docker run -d \
+  --name openclaw-gateway \
+  -p 127.0.0.1:18789:18789 \
+  -v /Users/home/GitHub/openclaw/config:/app/config \
+  -v /Users/home/GitHub/openclaw/workspace:/app/workspace \
+  -v /Users/home/GitHub/openclaw/credentials:/root/.openclaw/credentials \
+  -e NODE_ENV=production \
+  -e PORT=18789 \
+  -e OPENCLAW_GATEWAY_TOKEN=73ad9a94cc4f6143272c207a4a3971411dbff2166c2ae84e8daf28b3c7dfc1f1 \
+  -e OLLAMA_BASE=http://host.docker.internal:11434 \
+  openclaw/gateway:latest \
+  sh -c "apt-get update -qq && apt-get install -y -qq ffmpeg jq python3-pip > /dev/null 2>&1 && pip3 install -q yt-dlp > /dev/null 2>&1 || true && node /app/dist/cli/gateway.js run --port 18789"
+```
+
+## Step 2: Verify Gateway is Running
+
+```bash
+# Check status
+openclaw gateway status
+
+# Or check logs
+docker-compose logs gateway
+# or
+docker logs openclaw-gateway
+```
+
+## Step 3: Install Dependencies (if not in Dockerfile)
+
+If you didn't install dependencies in the Dockerfile, install them now:
+
+```bash
+docker-compose exec gateway sh -c "apt-get update && apt-get install -y ffmpeg jq python3-pip && pip3 install yt-dlp"
+```
+
+Or for manual Docker run:
+
+```bash
+docker exec -it openclaw-gateway sh -c "apt-get update && apt-get install -y ffmpeg jq python3-pip && pip3 install yt-dlp"
+```
+
+## Step 4: Verify Skill is Loaded
+
+Check that the skill is available:
+
+```bash
+openclaw skills list | grep youtube-shorts
+```
+
+Or check in the container:
+
+```bash
+docker-compose exec gateway ls -la /app/workspace/skills/youtube-shorts/
+```
+
+## Step 5: Run the Command
+
+Now you can create a YouTube short! Use the `openclaw agent` command:
+
+```bash
+openclaw agent --agent default --message "Create a YouTube short from https://www.youtube.com/watch?v=VIDEO_ID"
+```
+
+Replace `VIDEO_ID` with an actual YouTube video ID.
+
+### Example:
+
+```bash
+openclaw agent --agent default --message "Create a YouTube short from https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+```
+
+### With Options:
+
+```bash
+# Custom duration (45 seconds)
+openclaw agent --agent default --message "Create a YouTube short from https://www.youtube.com/watch?v=VIDEO_ID with duration 45 seconds"
+
+# Manual start time
+openclaw agent --agent default --message "Create a YouTube short from https://www.youtube.com/watch?v=VIDEO_ID starting at 2 minutes"
+```
+
+## Troubleshooting
+
+### Gateway not reachable
+
+```bash
+# Check if gateway is running
+docker-compose ps
+
+# Check gateway logs
+docker-compose logs gateway
+
+# Restart gateway
+docker-compose restart gateway
+```
+
+### Skill not found
+
+Make sure the skill is in the workspace:
+```bash
+ls -la workspace/skills/youtube-shorts/
+```
+
+If missing, copy it:
+```bash
+cp -r skills/youtube-shorts workspace/skills/
+```
+
+### Dependencies missing
+
+Install them in the container:
+```bash
+docker-compose exec gateway sh -c "apt-get update && apt-get install -y ffmpeg jq python3-pip && pip3 install yt-dlp"
+```
+
+### Ollama connection fails
+
+1. Ensure Ollama is running on your host:
+   ```bash
+   ollama list
+   ```
+
+2. Test connection from container:
+   ```bash
+   docker-compose exec gateway curl -s http://host.docker.internal:11434/api/tags
+   ```
+
+3. If it fails, check your `.env` file has `OLLAMA_BASE=http://host.docker.internal:11434`
+
+### Agent not found
+
+List available agents:
+```bash
+openclaw agents list
+```
+
+Use the correct agent ID, or create one:
+```bash
+openclaw agents add default
+```
+
+## Output Location
+
+The created shorts will be saved to:
+- Inside container: `/app/workspace/youtube-shorts/`
+- On host: `workspace/youtube-shorts/` (since workspace is mounted)
+
+## Next Steps
+
+- Configure YouTube API credentials for automatic upload (see `README.md`)
+- Customize the skill scripts for your needs
+- Set up multiple agents for different purposes

--- a/skills/youtube-shorts/README.md
+++ b/skills/youtube-shorts/README.md
@@ -1,0 +1,155 @@
+# YouTube Shorts Creator Skill
+
+Automatically create YouTube Shorts from your YouTube videos using AI analysis (Ollama) and video editing (ffmpeg).
+
+## Quick Start
+
+### 1. Install Dependencies
+
+```bash
+brew install yt-dlp ffmpeg jq
+```
+
+### 2. Set Up Ollama
+
+Make sure Ollama is running and pull a model:
+
+```bash
+ollama pull llama3.3
+# or
+ollama pull qwen2.5-coder:32b
+```
+
+### 3. Configure OpenClaw
+
+Ensure Ollama is configured in your OpenClaw setup. If using Docker (like in your `docker-compose.yml`), set:
+
+```bash
+export OLLAMA_BASE=http://host.docker.internal:11434
+```
+
+### 4. Use the Skill
+
+Ask your OpenClaw agent:
+
+```
+Create a YouTube short from https://www.youtube.com/watch?v=VIDEO_ID
+```
+
+Or use the exec tool directly:
+
+```bash
+openclaw agent --message "create a short from https://youtube.com/watch?v=VIDEO_ID"
+```
+
+## How It Works
+
+1. **Download**: Uses `yt-dlp` to download the YouTube video
+2. **Analyze**: Uses Ollama to analyze the video transcript and identify the most engaging segment
+3. **Edit**: Uses `ffmpeg` to create a vertical (9:16) short format video
+4. **Upload** (optional): Uploads to YouTube if credentials are configured
+
+## Configuration
+
+### Ollama Model
+
+Default: Auto-detects available models. Override:
+
+```bash
+export OLLAMA_MODEL="ollama/llama3.3"
+```
+
+### Output Directory
+
+Default: `~/.openclaw/workspace/youtube-shorts/`
+
+Override:
+
+```bash
+export YOUTUBE_SHORTS_OUTPUT_DIR="/path/to/output"
+```
+
+### YouTube Upload (Optional)
+
+To enable automatic upload:
+
+1. Go to [Google Cloud Console](https://console.cloud.google.com/)
+2. Create a project and enable YouTube Data API v3
+3. Create OAuth2 credentials
+4. Set environment variables:
+
+```bash
+export YOUTUBE_CLIENT_ID="your-client-id"
+export YOUTUBE_CLIENT_SECRET="your-client-secret"
+export YOUTUBE_REFRESH_TOKEN="your-refresh-token"
+```
+
+## Examples
+
+### Basic Usage
+
+```bash
+# Via OpenClaw agent
+openclaw agent --message "create a short from https://youtube.com/watch?v=dQw4w9WgXcQ"
+
+# Direct script execution
+./skills/youtube-shorts/scripts/create-short.sh 'https://youtube.com/watch?v=VIDEO_ID'
+```
+
+### Custom Duration
+
+```bash
+./skills/youtube-shorts/scripts/create-short.sh 'https://youtube.com/watch?v=VIDEO_ID' --duration 45
+```
+
+### Manual Segment Selection
+
+```bash
+./skills/youtube-shorts/scripts/create-short.sh 'https://youtube.com/watch?v=VIDEO_ID' --start 120 --duration 60
+```
+
+### Specific Model
+
+```bash
+./skills/youtube-shorts/scripts/create-short.sh 'https://youtube.com/watch?v=VIDEO_ID' --model ollama/qwen2.5-coder:32b
+```
+
+## Troubleshooting
+
+### yt-dlp fails
+
+- Update: `brew upgrade yt-dlp`
+- Some videos may require cookies (private/unlisted videos)
+
+### Ollama connection fails
+
+- Verify Ollama is running: `ollama list`
+- Check `OLLAMA_BASE` environment variable
+- In Docker: Use `http://host.docker.internal:11434`
+- Locally: Use `http://127.0.0.1:11434`
+
+### ffmpeg errors
+
+- Ensure ffmpeg is installed: `ffmpeg -version`
+- Check video file is valid: `ffprobe <video_file>`
+
+### Upload fails
+
+- Verify YouTube API credentials are set
+- Check OAuth token is valid
+- Review YouTube API quota limits
+
+## Scripts Reference
+
+- `create-short.sh` - Main workflow orchestrator
+- `download-video.sh` - Download YouTube videos
+- `analyze-segments.sh` - AI analysis with Ollama
+- `create-short-format.sh` - Video editing with ffmpeg
+- `upload-youtube.sh` - YouTube API upload
+
+## Notes
+
+- Videos are automatically cropped/scaled to 9:16 aspect ratio
+- Maximum duration is 60 seconds (YouTube Shorts requirement)
+- Output format: MP4 (H.264/AAC) compatible with YouTube
+- Intermediate files are cleaned up unless `--keep-files` is used

--- a/skills/youtube-shorts/SKILL.md
+++ b/skills/youtube-shorts/SKILL.md
@@ -1,0 +1,243 @@
+---
+name: youtube-shorts
+description: Create YouTube Shorts from YouTube videos using Ollama AI analysis and ffmpeg editing.
+homepage: https://github.com/openclaw/openclaw
+metadata:
+  {
+    "openclaw": {
+      "emoji": "🎬",
+      "requires": { "bins": ["yt-dlp", "ffmpeg", "jq"] },
+      "install": [
+        {
+          "id": "brew",
+          "kind": "brew",
+          "formula": "yt-dlp",
+          "bins": ["yt-dlp"],
+          "label": "Install yt-dlp (brew)",
+        },
+        {
+          "id": "brew-ffmpeg",
+          "kind": "brew",
+          "formula": "ffmpeg",
+          "bins": ["ffmpeg"],
+          "label": "Install ffmpeg (brew)",
+        },
+        {
+          "id": "brew-jq",
+          "kind": "brew",
+          "formula": "jq",
+          "bins": ["jq"],
+          "label": "Install jq (brew)",
+        },
+      ],
+    },
+  }
+---
+
+# YouTube Shorts Creator
+
+Automatically create YouTube Shorts from your YouTube videos using AI analysis (Ollama) to identify interesting segments, then edit them into shorts format (9:16 aspect ratio, <60 seconds).
+
+## When to use (trigger phrases)
+
+Use this skill when the user asks:
+
+- "create a YouTube short from [video URL]"
+- "make a short from my YouTube video"
+- "convert this video to a YouTube short"
+- "create shorts from my YouTube videos"
+
+## Prerequisites
+
+1. **Install dependencies:**
+   ```bash
+   brew install yt-dlp ffmpeg jq
+   ```
+
+2. **Configure Ollama:**
+   - Ensure Ollama is running and accessible
+   - Set `OLLAMA_API_KEY` environment variable (or configure in OpenClaw config)
+   - Pull a model: `ollama pull llama3.3` or `ollama pull qwen2.5-coder:32b`
+
+3. **Optional: YouTube API credentials** (for uploading):
+   - Set `YOUTUBE_CLIENT_ID` and `YOUTUBE_CLIENT_SECRET`
+   - Or use manual upload after creation
+
+## Quick start
+
+### Basic usage (download + analyze + create short)
+
+```bash
+# Using exec tool
+exec command:"{baseDir}/scripts/create-short.sh 'https://youtube.com/watch?v=VIDEO_ID'"
+```
+
+### With custom options
+
+```bash
+exec command:"{baseDir}/scripts/create-short.sh 'https://youtube.com/watch?v=VIDEO_ID' --duration 45 --model ollama/llama3.3"
+```
+
+## Workflow
+
+The skill performs these steps:
+
+1. **Download**: Uses `yt-dlp` to download the video
+2. **Analyze**: Uses Ollama to analyze transcript/timestamps and identify interesting segments
+3. **Edit**: Uses `ffmpeg` to create a short (9:16, <60s) from the identified segment
+4. **Upload** (optional): Uploads to YouTube if credentials are configured
+
+## Scripts
+
+### `create-short.sh` (main workflow)
+
+Orchestrates the entire process.
+
+**Usage:**
+```bash
+{baseDir}/scripts/create-short.sh <youtube_url> [options]
+```
+
+**Options:**
+- `--duration <seconds>`: Target duration (default: 60, max: 60 for shorts)
+- `--model <model>`: Ollama model to use (default: auto-detect)
+- `--start <timestamp>`: Manual start time (HH:MM:SS or seconds)
+- `--output <path>`: Output file path (default: auto-generated)
+- `--no-upload`: Skip YouTube upload even if credentials are set
+- `--keep-files`: Keep intermediate files after completion
+
+### `download-video.sh`
+
+Downloads a YouTube video using yt-dlp.
+
+**Usage:**
+```bash
+{baseDir}/scripts/download-video.sh <youtube_url> [output_dir]
+```
+
+### `analyze-segments.sh`
+
+Uses Ollama to analyze video transcript and identify interesting segments.
+
+**Usage:**
+```bash
+{baseDir}/scripts/analyze-segments.sh <video_file> [model] [target_duration]
+```
+
+Returns JSON with recommended segments:
+```json
+{
+  "segments": [
+    {
+      "start": 120.5,
+      "end": 180.0,
+      "reason": "High engagement moment with key insight"
+    }
+  ]
+}
+```
+
+### `create-short-format.sh`
+
+Edits video into YouTube Shorts format (9:16 aspect ratio, vertical).
+
+**Usage:**
+```bash
+{baseDir}/scripts/create-short-format.sh <input_video> <start_time> <duration> [output_file]
+```
+
+**Parameters:**
+- `input_video`: Source video file
+- `start_time`: Start timestamp (seconds or HH:MM:SS)
+- `duration`: Duration in seconds (max 60)
+- `output_file`: Output path (optional, auto-generated if not provided)
+
+### `upload-youtube.sh` (optional)
+
+Uploads the short to YouTube using YouTube API.
+
+**Usage:**
+```bash
+{baseDir}/scripts/upload-youtube.sh <video_file> <title> [description] [tags]
+```
+
+**Environment variables:**
+- `YOUTUBE_CLIENT_ID`: YouTube API client ID
+- `YOUTUBE_CLIENT_SECRET`: YouTube API client secret
+- `YOUTUBE_REFRESH_TOKEN`: OAuth refresh token (obtain via OAuth flow)
+
+## Examples
+
+### Example 1: Simple short creation
+
+```bash
+exec command:"{baseDir}/scripts/create-short.sh 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'"
+```
+
+### Example 2: Custom duration and model
+
+```bash
+exec command:"{baseDir}/scripts/create-short.sh 'https://www.youtube.com/watch?v=VIDEO_ID' --duration 45 --model ollama/qwen2.5-coder:32b"
+```
+
+### Example 3: Manual segment selection
+
+```bash
+exec command:"{baseDir}/scripts/create-short.sh 'https://www.youtube.com/watch?v=VIDEO_ID' --start 120 --duration 60"
+```
+
+### Example 4: Download only (no editing)
+
+```bash
+exec command:"{baseDir}/scripts/download-video.sh 'https://www.youtube.com/watch?v=VIDEO_ID' /tmp/videos"
+```
+
+## Configuration
+
+### Ollama model selection
+
+The script auto-detects available Ollama models. To specify:
+
+```bash
+export OLLAMA_MODEL="ollama/llama3.3"
+```
+
+Or pass via `--model` flag.
+
+### Output directory
+
+Default: `~/.openclaw/workspace/youtube-shorts/`
+
+Override:
+```bash
+export YOUTUBE_SHORTS_OUTPUT_DIR="/path/to/output"
+```
+
+## Notes
+
+- **Video format**: Output is MP4 (H.264/AAC) compatible with YouTube Shorts
+- **Aspect ratio**: Automatically crops/letterboxes to 9:16 (vertical)
+- **Duration**: YouTube Shorts must be ≤60 seconds
+- **Quality**: Preserves original quality; may re-encode for format compliance
+- **Transcripts**: Uses yt-dlp's transcript extraction; falls back to audio transcription if unavailable
+- **AI analysis**: Uses Ollama to identify high-engagement moments based on transcript content
+
+## Troubleshooting
+
+**yt-dlp fails:**
+- Update: `brew upgrade yt-dlp`
+- Check video is publicly accessible (or provide cookies)
+
+**Ollama connection fails:**
+- Verify Ollama is running: `ollama list`
+- Check `OLLAMA_BASE` environment variable matches your setup
+- Default: `http://127.0.0.1:11434` (or `http://host.docker.internal:11434` in Docker)
+
+**ffmpeg errors:**
+- Ensure ffmpeg is installed: `ffmpeg -version`
+- Check video file is valid: `ffprobe <video_file>`
+
+**Upload fails:**
+- Verify YouTube API credentials
+- Check OAuth token is valid and not expired
+- Review YouTube API quota limits

--- a/skills/youtube-shorts/scripts/add-captions.sh
+++ b/skills/youtube-shorts/scripts/add-captions.sh
@@ -1,0 +1,294 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Add bold English captions to a video file
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: add-captions.sh <video_file> [youtube_url] [output_file] [vtt_file]
+
+Adds bold, engaging English captions to a video optimized for YouTube Shorts.
+If youtube_url is provided, extracts transcript from YouTube.
+If vtt_file is provided, uses that VTT file directly (for segment-adjusted subtitles).
+EOF
+  exit 2
+}
+
+if [[ "${1:-}" == "" ]]; then
+  usage
+fi
+
+VIDEO_FILE="${1:-}"
+YOUTUBE_URL="${2:-}"
+OUTPUT_FILE="${3:-}"
+PROVIDED_VTT="${4:-}"
+
+if [[ ! -f "$VIDEO_FILE" ]]; then
+  echo "Error: Video file not found: $VIDEO_FILE" >&2
+  exit 1
+fi
+
+if ! command -v ffmpeg &> /dev/null; then
+  echo "Error: ffmpeg not found. Install with: brew install ffmpeg" >&2
+  exit 1
+fi
+
+# Generate output filename if not provided
+if [[ -z "$OUTPUT_FILE" ]]; then
+  BASE_NAME=$(basename "$VIDEO_FILE" .mp4)
+  OUTPUT_DIR=$(dirname "$VIDEO_FILE")
+  OUTPUT_FILE="$OUTPUT_DIR/${BASE_NAME}_captioned.mp4"
+fi
+
+mkdir -p "$(dirname "$OUTPUT_FILE")"
+
+# Get video duration
+VIDEO_DURATION=$(ffprobe -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 "$VIDEO_FILE" 2>/dev/null | cut -d. -f1 || echo "60")
+
+echo "🎬 Adding captions to video..."
+echo "  Input: $VIDEO_FILE"
+echo "  Output: $OUTPUT_FILE"
+
+# Try to extract transcript from YouTube URL or use provided VTT
+TRANSCRIPT_VTT=""
+SUBTITLE_FILE=$(mktemp).vtt
+
+# Use provided VTT file if available (for segment-adjusted subtitles)
+if [[ -n "$PROVIDED_VTT" ]] && [[ -f "$PROVIDED_VTT" ]]; then
+  cp "$PROVIDED_VTT" "$SUBTITLE_FILE"
+  TRANSCRIPT_VTT="$SUBTITLE_FILE"
+  echo "📝 Using provided transcript file" >&2
+elif [[ -n "$YOUTUBE_URL" ]] && command -v yt-dlp &> /dev/null; then
+  echo "📝 Extracting transcript from YouTube..." >&2
+  TEMP_VTT=$(mktemp)
+  if yt-dlp --skip-download --write-auto-sub --sub-lang en --sub-format vtt --output "$TEMP_VTT" "$YOUTUBE_URL" 2>/dev/null; then
+    if [[ -f "${TEMP_VTT}.en.vtt" ]]; then
+      TRANSCRIPT_VTT="${TEMP_VTT}.en.vtt"
+      echo "✅ Transcript extracted" >&2
+    fi
+  fi
+fi
+
+# If no transcript, we'll generate a simple caption file
+if [[ -z "$TRANSCRIPT_VTT" ]]; then
+  echo "⚠️  No transcript available, creating placeholder captions" >&2
+  # Create a simple VTT file with placeholder
+  cat > "$SUBTITLE_FILE" <<EOF
+WEBVTT
+
+00:00:00.000 --> 00:00:${VIDEO_DURATION}.000
+<v Engaging Content>
+Watch till the end!
+EOF
+else
+  # Use the extracted VTT file
+  cp "$TRANSCRIPT_VTT" "$SUBTITLE_FILE"
+fi
+
+# Create ASS subtitle file with bold styling for YouTube Shorts
+ASS_FILE=$(mktemp).ass
+cat > "$ASS_FILE" <<'EOF'
+[Script Info]
+Title: YouTube Shorts Captions
+ScriptType: v4.00+
+
+[V4+ Styles]
+Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
+Style: Default,Arial,72,&H00FFFFFF,&H000000FF,&H00000000,&H80000000,1,0,0,0,100,100,0,0,1,4,0,2,20,20,60,1
+Style: Bold,Arial Bold,80,&H00FFFFFF,&H000000FF,&H00000000,&H80000000,1,0,0,0,100,100,0,0,1,5,0,2,20,20,60,1
+
+[Events]
+Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
+EOF
+
+# Convert VTT to ASS format with bold styling
+# Use Python for better VTT parsing if available
+if command -v python3 &> /dev/null && [[ -f "$SUBTITLE_FILE" ]] && [[ -s "$SUBTITLE_FILE" ]]; then
+  python3 <<PYTHON_SCRIPT > "${ASS_FILE}.tmp"
+import re
+import sys
+
+# ASS header
+ass_content = """[Script Info]
+Title: YouTube Shorts Captions
+ScriptType: v4.00+
+
+[V4+ Styles]
+Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
+Style: Bold,Arial Bold,80,&H00FFFFFF,&H000000FF,&H00000000,&H80000000,1,0,0,0,100,100,0,0,1,6,3,2,20,20,80,1
+
+[Events]
+Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
+"""
+
+# Parse VTT file
+current_start = ""
+current_end = ""
+current_text = []
+
+try:
+    with open("$SUBTITLE_FILE", 'r', encoding='utf-8', errors='ignore') as f:
+        for line in f:
+            line = line.strip()
+            if not line or line == "WEBVTT" or re.match(r'^NOTE', line) or re.match(r'^\d+$', line):
+                continue
+            
+            # Match timestamp line: 00:00:00.000 --> 00:00:05.000
+            timestamp_match = re.match(r'(\d{2}):(\d{2}):(\d{2})\.(\d{3})\s*-->\s*(\d{2}):(\d{2}):(\d{2})\.(\d{3})', line)
+            if timestamp_match:
+                # Save previous dialogue if exists
+                if current_start and current_text:
+                    text = ' '.join(current_text)
+                    # Clean HTML tags and escape special chars
+                    text = re.sub(r'<[^>]+>', '', text)
+                    text = text.replace('&', r'\\&').replace('{', r'\\{').replace('}', r'\\}')
+                    # Convert to ASS timestamp (HH:MM:SS.mm)
+                    start_ass = f"{timestamp_match.group(1)}:{timestamp_match.group(2)}:{timestamp_match.group(3)}.{timestamp_match.group(4)[:2]}"
+                    end_ass = f"{timestamp_match.group(5)}:{timestamp_match.group(6)}:{timestamp_match.group(7)}.{timestamp_match.group(8)[:2]}"
+                    ass_content += f"Dialogue: 0,{current_start},{end_ass},Bold,,0,0,0,,{{\\\\b1}}{text}{{\\\\b0}}\n"
+                
+                current_start = f"{timestamp_match.group(1)}:{timestamp_match.group(2)}:{timestamp_match.group(3)}.{timestamp_match.group(4)[:2]}"
+                current_end = f"{timestamp_match.group(5)}:{timestamp_match.group(6)}:{timestamp_match.group(7)}.{timestamp_match.group(8)[:2]}"
+                current_text = []
+            else:
+                # Text line - clean HTML tags
+                clean_line = re.sub(r'<[^>]+>', '', line)
+                if clean_line:
+                    current_text.append(clean_line)
+
+    # Add last dialogue
+    if current_start and current_text:
+        text = ' '.join(current_text)
+        text = re.sub(r'<[^>]+>', '', text)
+        text = text.replace('&', r'\\&').replace('{', r'\\{').replace('}', r'\\}')
+        ass_content += f"Dialogue: 0,{current_start},{current_end},Bold,,0,0,0,,{{\\\\b1}}{text}{{\\\\b0}}\n"
+except Exception as e:
+    # Fallback on error - use VIDEO_DURATION from bash variable
+    video_dur = int("""$VIDEO_DURATION""")
+    ass_content += f"Dialogue: 0,0:00:00.00,0:00:{video_dur}.00,Bold,,0,0,0,,{{\\\\b1}}Engaging Content{{\\\\b0}}\n"
+
+print(ass_content, end='')
+PYTHON_SCRIPT
+  if [[ -f "${ASS_FILE}.tmp" ]] && [[ -s "${ASS_FILE}.tmp" ]]; then
+    mv "${ASS_FILE}.tmp" "$ASS_FILE"
+  else
+    # Fallback if Python conversion failed
+    cat >> "$ASS_FILE" <<EOF
+Dialogue: 0,0:00:00.00,0:00:${VIDEO_DURATION}.00,Bold,,0,0,0,,{\\b1}Engaging Content{\\b0}
+EOF
+  fi
+else
+  # Fallback: Simple conversion without Python
+  echo "⚠️  Python not found or no transcript, using simple caption generation" >&2
+  cat >> "$ASS_FILE" <<EOF
+Dialogue: 0,0:00:00.00,0:00:${VIDEO_DURATION}.00,Bold,,0,0,0,,{\\b1}Engaging Content - Watch till the end!{\\b0}
+EOF
+fi
+
+# Use ffmpeg to burn in subtitles with bold styling
+echo "🎨 Rendering captions..." >&2
+
+# Extract captions from ASS/VTT and create drawtext filter chain
+# This approach is more reliable than subtitles filter
+DRAWTEXT_FILTER_FILE=$(mktemp)
+
+python3 <<PYTHON_CAPTIONS > "$DRAWTEXT_FILTER_FILE"
+import re
+import sys
+
+drawtext_filters = []
+
+try:
+    # Read ASS file
+    with open("$ASS_FILE", 'r', encoding='utf-8', errors='ignore') as f:
+        for line in f:
+            if line.startswith("Dialogue:"):
+                # Parse ASS dialogue: Dialogue: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
+                parts = line.split(",", 9)
+                if len(parts) >= 10:
+                    start_time = parts[1].strip()
+                    end_time = parts[2].strip()
+                    text_part = parts[9].strip()
+                    
+                    # Extract text (remove ASS formatting codes)
+                    text = re.sub(r'\{[^}]*\}', '', text_part)
+                    text = text.replace("\\N", " ").replace("\\n", " ").replace("\\h", " ")
+                    text = text.strip()
+                    
+                    if not text:
+                        continue
+                    
+                    # Convert ASS time (HH:MM:SS.mm) to seconds
+                    def ass_to_sec(ass_time):
+                        try:
+                            time_parts = ass_time.split(":")
+                            if len(time_parts) == 3:
+                                h, m, s = map(float, time_parts)
+                                return h * 3600 + m * 60 + s
+                        except:
+                            pass
+                        return 0
+                    
+                    start_sec = ass_to_sec(start_time)
+                    end_sec = ass_to_sec(end_time)
+                    
+                    # Skip if outside video duration
+                    if end_sec <= start_sec or start_sec < 0:
+                        continue
+                    
+                    # Escape text for drawtext (escape single quotes properly)
+                    # Replace single quotes with escaped version for shell
+                    text_escaped = text.replace("'", "'\\''")
+                    
+                    # Create drawtext filter with bold styling
+                    # Position: centered horizontally, near bottom (100px from bottom)
+                    # Style: Large white text with black box background for readability
+                    filter_str = (
+                        f"drawtext=text='{text_escaped}':"
+                        f"fontsize=85:"
+                        f"fontcolor=white:"
+                        f"x=(w-text_w)/2:"  # Center horizontally
+                        f"y=h-th-120:"     # Near bottom (120px margin for YouTube Shorts)
+                        f"enable='between(t,{start_sec:.2f},{end_sec:.2f})':"  # Show only during this time
+                        f"box=1:"          # Enable background box
+                        f"boxcolor=black@0.85:"  # Semi-transparent black background (darker for better contrast)
+                        f"boxborderw=12:"  # Thick border for bold effect
+                        f"bordercolor=black@1.0"  # Solid black border
+                    )
+                    drawtext_filters.append(filter_str)
+except Exception as e:
+    sys.stderr.write(f"Error processing captions: {e}\n")
+    pass
+
+if drawtext_filters:
+    # Chain all drawtext filters together
+    filter_chain = "[" + "][".join(drawtext_filters) + "]"
+    print(filter_chain)
+else:
+    # Fallback: single placeholder caption
+    print("drawtext=text='Engaging Content':fontsize=80:fontcolor=white:x=(w-text_w)/2:y=h-th-100:box=1:boxcolor=black@0.8:boxborderw=10")
+PYTHON_CAPTIONS
+
+DRAWTEXT_FILTER=$(cat "$DRAWTEXT_FILTER_FILE")
+rm -f "$DRAWTEXT_FILTER_FILE"
+
+# Apply captions using drawtext filter
+ffmpeg -hide_banner -loglevel warning -y \
+  -i "$VIDEO_FILE" \
+  -vf "$DRAWTEXT_FILTER" \
+  -c:v libx264 \
+  -preset medium \
+  -crf 23 \
+  -c:a copy \
+  -movflags +faststart \
+  "$OUTPUT_FILE"
+
+if [[ -f "$OUTPUT_FILE" ]]; then
+  echo "✅ Created captioned video: $OUTPUT_FILE"
+  echo "$OUTPUT_FILE"
+  rm -f "$SUBTITLE_FILE" "$ASS_FILE" "${TEMP_VTT}.en.vtt" 2>/dev/null
+else
+  echo "Error: Failed to add captions" >&2
+  rm -f "$SUBTITLE_FILE" "$ASS_FILE" "${TEMP_VTT}.en.vtt" 2>/dev/null
+  exit 1
+fi

--- a/skills/youtube-shorts/scripts/analyze-segments.sh
+++ b/skills/youtube-shorts/scripts/analyze-segments.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Analyze video transcript and identify interesting segments using Ollama
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: analyze-segments.sh <video_file> [model] [target_duration] [youtube_url]
+
+Analyzes video transcript and returns JSON with recommended segments for shorts.
+EOF
+  exit 2
+}
+
+if [[ "${1:-}" == "" || "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+fi
+
+VIDEO_FILE="${1:-}"
+MODEL="${2:-}"
+TARGET_DURATION="${3:-60}"
+YOUTUBE_URL="${4:-${YOUTUBE_URL:-}}"
+
+if [[ ! -f "$VIDEO_FILE" ]]; then
+  echo "Error: Video file not found: $VIDEO_FILE" >&2
+  exit 1
+fi
+
+# Get video duration using ffprobe
+if ! command -v ffprobe &> /dev/null; then
+  echo "Error: ffprobe not found. Install ffmpeg: brew install ffmpeg" >&2
+  exit 1
+fi
+
+VIDEO_DURATION=$(ffprobe -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 "$VIDEO_FILE" | cut -d. -f1)
+VIDEO_DURATION=${VIDEO_DURATION:-0}
+
+if [[ $VIDEO_DURATION -eq 0 ]]; then
+  echo "Error: Could not determine video duration" >&2
+  exit 1
+fi
+
+# Try to extract transcript using yt-dlp (if available)
+TRANSCRIPT_FILE=$(mktemp)
+TRANSCRIPT_AVAILABLE=false
+
+# First try: Extract transcript from YouTube URL if available
+if command -v yt-dlp &> /dev/null && [[ -n "${YOUTUBE_URL:-}" ]]; then
+  echo "Extracting transcript from YouTube..." >&2
+  # Try to get transcript using yt-dlp
+  if yt-dlp --skip-download --write-auto-sub --sub-lang en --sub-format vtt --output "$TRANSCRIPT_FILE" "$YOUTUBE_URL" 2>/dev/null; then
+    # Convert VTT to plain text
+    if [[ -f "${TRANSCRIPT_FILE}.en.vtt" ]]; then
+      # Extract text from VTT, remove timestamps and formatting
+      grep -v "^[0-9]" "${TRANSCRIPT_FILE}.en.vtt" | grep -v "^WEBVTT" | grep -v "^$" | sed 's/<[^>]*>//g' | tr '\n' ' ' > "$TRANSCRIPT_FILE" 2>/dev/null
+      if [[ -s "$TRANSCRIPT_FILE" ]]; then
+        TRANSCRIPT_AVAILABLE=true
+        echo "✅ Transcript extracted" >&2
+      fi
+      rm -f "${TRANSCRIPT_FILE}.en.vtt" 2>/dev/null
+    fi
+  fi
+fi
+
+# Fallback: Use summarize.sh if available
+if [[ "$TRANSCRIPT_AVAILABLE" != "true" ]] && command -v summarize &> /dev/null && [[ -n "${YOUTUBE_URL:-}" ]]; then
+  echo "Trying summarize.sh for transcript..." >&2
+  if summarize "$YOUTUBE_URL" --youtube auto --extract-only > "$TRANSCRIPT_FILE" 2>/dev/null; then
+    if [[ -s "$TRANSCRIPT_FILE" ]]; then
+      TRANSCRIPT_AVAILABLE=true
+      echo "✅ Transcript extracted via summarize" >&2
+    fi
+  fi
+fi
+
+# Determine Ollama endpoint
+OLLAMA_BASE="${OLLAMA_BASE:-http://127.0.0.1:11434}"
+if [[ "$OLLAMA_BASE" == "http://host.docker.internal:11434" ]]; then
+  # Docker environment
+  OLLAMA_BASE="http://host.docker.internal:11434"
+fi
+
+# Auto-detect model if not provided
+if [[ -z "$MODEL" ]]; then
+  if command -v ollama &> /dev/null; then
+    # Try to list models and pick the first tool-capable one
+    AVAILABLE_MODELS=$(ollama list 2>/dev/null | awk 'NR>1 {print $1}' | head -1 || echo "")
+    if [[ -n "$AVAILABLE_MODELS" ]]; then
+      MODEL="$AVAILABLE_MODELS"
+    else
+      MODEL="llama3.3"
+    fi
+  else
+    MODEL="llama3.3"
+  fi
+fi
+
+# Remove "ollama/" prefix if present
+MODEL=$(echo "$MODEL" | sed 's|^ollama/||')
+
+# Create analysis prompt with better instructions
+TRANSCRIPT_TEXT=""
+if [[ "$TRANSCRIPT_AVAILABLE" == "true" ]]; then
+  TRANSCRIPT_TEXT=$(cat "$TRANSCRIPT_FILE" | head -c 4000)
+fi
+
+# Build prompt safely to avoid quote issues - escape single quotes in transcript
+if [[ "$TRANSCRIPT_AVAILABLE" == "true" ]] && [[ -n "$TRANSCRIPT_TEXT" ]]; then
+  ESCAPED_TRANSCRIPT=$(printf '%s\n' "$TRANSCRIPT_TEXT" | sed "s/'/'\"'\"'/g")
+  TRANSCRIPT_PART="Full transcript: ${ESCAPED_TRANSCRIPT}
+
+"
+else
+  TRANSCRIPT_PART=""
+fi
+
+PROMPT=$(cat <<EOF
+You are analyzing a YouTube video to find the BEST ${TARGET_DURATION}-second segment for a YouTube Short that will maximize engagement and retention.
+
+Video duration: ${VIDEO_DURATION} seconds
+Target segment length: ${TARGET_DURATION} seconds
+
+${TRANSCRIPT_PART}
+
+CRITICAL INSTRUCTIONS:
+1. **AVOID THE INTRO** - Skip the first 10-15 seconds (usually just greetings/introductions)
+2. Find segments with:
+   - A strong hook or attention-grabbing statement
+   - High-value content (tips, insights, revelations, key moments)
+   - Emotional peaks (surprise, excitement, controversy)
+   - Visual interest or action
+   - Self-contained narratives that don't need context
+3. **Prefer middle-to-end segments** over intro segments
+4. Look for moments where the speaker:
+   - Reveals something important
+   - Shares a key insight or tip
+   - Tells an interesting story
+   - Demonstrates something visually engaging
+   - Has high energy or emotion
+
+Analyze the ENTIRE video and identify the SINGLE BEST ${TARGET_DURATION}-second segment that would perform best as a YouTube Short.
+
+Return JSON in this exact format:
+{
+  "segments": [
+    {
+      "start": <start_time_in_seconds_as_number>,
+      "end": <end_time_in_seconds_as_number>,
+      "reason": "<specific explanation of why this segment is engaging>"
+    }
+  ]
+}
+
+CRITICAL INSTRUCTIONS:
+1. **AVOID THE INTRO** - Skip the first 10-15 seconds (usually just greetings/introductions)
+2. Find segments with:
+   - A strong hook or attention-grabbing statement
+   - High-value content (tips, insights, revelations, key moments)
+   - Emotional peaks (surprise, excitement, controversy)
+   - Visual interest or action
+   - Self-contained narratives that don't need context
+3. **Prefer middle-to-end segments** over intro segments
+4. Look for moments where the speaker:
+   - Reveals something important
+   - Shares a key insight or tip
+   - Tells an interesting story
+   - Demonstrates something visually engaging
+   - Has high energy or emotion
+
+Analyze the ENTIRE video and identify the SINGLE BEST ${TARGET_DURATION}-second segment that would perform best as a YouTube Short.
+
+Return JSON in this exact format:
+{
+  "segments": [
+    {
+      "start": <start_time_in_seconds_as_number>,
+      "end": <end_time_in_seconds_as_number>,
+      "reason": "<specific explanation of why this segment is engaging>"
+    }
+  ]
+}
+
+${TRANSCRIPT_AVAILABLE:+Use the transcript timestamps to find the exact moment.}${TRANSCRIPT_AVAILABLE:-If no transcript is available, suggest a segment starting around 30% through the video (around $(($VIDEO_DURATION * 30 / 100)) seconds), avoiding the intro.}
+EOF
+)
+
+# Call Ollama API
+PROMPT_JSON=$(echo "$PROMPT" | jq -Rs .)
+RESPONSE=$(curl -s "${OLLAMA_BASE}/api/generate" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"model\": \"${MODEL}\",
+    \"prompt\": ${PROMPT_JSON},
+    \"stream\": false,
+    \"options\": {
+      \"temperature\": 0.7,
+      \"num_predict\": 500
+    }
+  }" 2>/dev/null || echo "")
+
+if [[ -z "$RESPONSE" ]]; then
+  echo "Error: Failed to connect to Ollama at $OLLAMA_BASE" >&2
+  echo "Make sure Ollama is running and accessible." >&2
+  exit 1
+fi
+
+# Extract JSON from response
+JSON_RESPONSE=$(echo "$RESPONSE" | jq -r '.response' 2>/dev/null || echo "")
+
+# Try to extract JSON object from the response
+if echo "$JSON_RESPONSE" | jq -e '.segments' > /dev/null 2>&1; then
+  echo "$JSON_RESPONSE" | jq '.segments'
+else
+  # Fallback: try to parse JSON from the text
+  EXTRACTED_JSON=$(echo "$JSON_RESPONSE" | grep -o '{[^}]*"segments"[^}]*}' | head -1 || echo "")
+  if [[ -n "$EXTRACTED_JSON" ]]; then
+    echo "$EXTRACTED_JSON" | jq '.segments'
+  else
+    # Ultimate fallback: return first segment
+    cat <<EOF
+{
+  "segments": [
+    {
+      "start": 0,
+      "end": ${TARGET_DURATION},
+      "reason": "Fallback: first ${TARGET_DURATION} seconds"
+    }
+  ]
+}
+EOF
+  fi
+fi
+
+rm -f "$TRANSCRIPT_FILE"

--- a/skills/youtube-shorts/scripts/create-short-format.sh
+++ b/skills/youtube-shorts/scripts/create-short-format.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Create YouTube Shorts format video (9:16 aspect ratio, vertical)
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: create-short-format.sh <input_video> <start_time> <duration> [output_file]
+
+Creates a YouTube Shorts format video:
+- 9:16 aspect ratio (vertical)
+- Duration: <duration> seconds (max 60)
+- Starts at <start_time> (seconds or HH:MM:SS format)
+
+Parameters:
+  input_video   Source video file
+  start_time    Start timestamp (seconds or HH:MM:SS)
+  duration      Duration in seconds (max 60)
+  output_file   Output path (optional, auto-generated if not provided)
+EOF
+  exit 2
+}
+
+if [[ "${1:-}" == "" || "${2:-}" == "" || "${3:-}" == "" ]]; then
+  usage
+fi
+
+INPUT_VIDEO="${1:-}"
+START_TIME="${2:-}"
+DURATION="${3:-60}"
+OUTPUT_FILE="${4:-}"
+
+if [[ ! -f "$INPUT_VIDEO" ]]; then
+  echo "Error: Input video not found: $INPUT_VIDEO" >&2
+  exit 1
+fi
+
+if ! command -v ffmpeg &> /dev/null; then
+  echo "Error: ffmpeg not found. Install with: brew install ffmpeg" >&2
+  exit 1
+fi
+
+# Validate duration (simple integer comparison)
+if [[ $DURATION -gt 60 ]]; then
+  echo "Warning: YouTube Shorts must be ≤60 seconds. Clamping to 60." >&2
+  DURATION=60
+fi
+
+# Convert start_time to seconds if it's in HH:MM:SS format
+if [[ "$START_TIME" =~ ^[0-9]+:[0-9]+:[0-9]+$ ]]; then
+  # HH:MM:SS format
+  IFS=':' read -r hours minutes seconds <<< "$START_TIME"
+  START_TIME=$((hours * 3600 + minutes * 60 + seconds))
+fi
+
+# Generate output filename if not provided
+if [[ -z "$OUTPUT_FILE" ]]; then
+  BASE_NAME=$(basename "$INPUT_VIDEO" .mp4)
+  OUTPUT_DIR=$(dirname "$INPUT_VIDEO")
+  OUTPUT_FILE="$OUTPUT_DIR/${BASE_NAME}_short_${START_TIME}s_${DURATION}s.mp4"
+fi
+
+mkdir -p "$(dirname "$OUTPUT_FILE")"
+
+echo "Creating short format video..."
+echo "  Input: $INPUT_VIDEO"
+echo "  Start: ${START_TIME}s"
+echo "  Duration: ${DURATION}s"
+echo "  Output: $OUTPUT_FILE"
+
+# Target aspect ratio: 9:16 (vertical)
+TARGET_WIDTH=1080
+TARGET_HEIGHT=1920
+
+# Use ffmpeg to create the short with smart cropping
+# The scale filter with crop will automatically handle aspect ratio conversion
+# This approach scales to fit 9:16, then crops to exact dimensions (centered)
+ffmpeg -hide_banner -loglevel warning -y \
+  -ss "$START_TIME" \
+  -i "$INPUT_VIDEO" \
+  -t "$DURATION" \
+  -vf "scale=${TARGET_WIDTH}:${TARGET_HEIGHT}:force_original_aspect_ratio=increase,crop=${TARGET_WIDTH}:${TARGET_HEIGHT},scale=${TARGET_WIDTH}:${TARGET_HEIGHT}" \
+  -c:v libx264 \
+  -preset medium \
+  -crf 23 \
+  -c:a aac \
+  -b:a 128k \
+  -movflags +faststart \
+  "$OUTPUT_FILE"
+
+if [[ -f "$OUTPUT_FILE" ]]; then
+  echo "✅ Created short: $OUTPUT_FILE"
+  echo "$OUTPUT_FILE"
+else
+  echo "Error: Failed to create short video" >&2
+  exit 1
+fi

--- a/skills/youtube-shorts/scripts/create-short.sh
+++ b/skills/youtube-shorts/scripts/create-short.sh
@@ -1,0 +1,303 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# YouTube Shorts Creator - Main workflow script
+# Downloads, analyzes, and creates YouTube Shorts from YouTube videos
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BASE_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: create-short.sh <youtube_url> [options]
+
+Options:
+  --duration <seconds>    Target duration (default: 60, max: 60)
+  --model <model>         Ollama model (default: auto-detect)
+  --start <timestamp>     Manual start time (HH:MM:SS or seconds)
+  --output <path>         Output file path (default: auto-generated)
+  --no-upload            Skip YouTube upload
+  --keep-files           Keep intermediate files
+  --no-captions          Skip adding captions (default: captions enabled)
+
+Examples:
+  create-short.sh 'https://youtube.com/watch?v=VIDEO_ID'
+  create-short.sh 'https://youtube.com/watch?v=VIDEO_ID' --duration 45
+  create-short.sh 'https://youtube.com/watch?v=VIDEO_ID' --start 120 --duration 60
+EOF
+  exit 2
+}
+
+if [[ "${1:-}" == "" || "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+fi
+
+YOUTUBE_URL="${1:-}"
+shift || true
+
+DURATION=60
+MODEL=""
+START_TIME=""
+OUTPUT_FILE=""
+NO_UPLOAD=false
+KEEP_FILES=false
+ADD_CAPTIONS=true
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --duration)
+      DURATION="${2:-}"
+      shift 2
+      ;;
+    --model)
+      MODEL="${2:-}"
+      shift 2
+      ;;
+    --start)
+      START_TIME="${2:-}"
+      shift 2
+      ;;
+    --output)
+      OUTPUT_FILE="${2:-}"
+      shift 2
+      ;;
+    --no-upload)
+      NO_UPLOAD=true
+      shift
+      ;;
+    --keep-files)
+      KEEP_FILES=true
+      shift
+      ;;
+    --no-captions)
+      ADD_CAPTIONS=false
+      shift
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage
+      ;;
+  esac
+done
+
+# Export YouTube URL for transcript extraction
+export YOUTUBE_URL
+
+# Validate duration
+if [[ $DURATION -gt 60 ]]; then
+  echo "Warning: YouTube Shorts must be ≤60 seconds. Clamping to 60." >&2
+  DURATION=60
+fi
+
+# Setup directories
+OUTPUT_DIR="${YOUTUBE_SHORTS_OUTPUT_DIR:-$HOME/.openclaw/workspace/youtube-shorts}"
+TEMP_DIR="${OUTPUT_DIR}/temp/$(date +%s)"
+mkdir -p "$TEMP_DIR"
+mkdir -p "$OUTPUT_DIR"
+
+cleanup() {
+  if [[ "$KEEP_FILES" != "true" ]]; then
+    rm -rf "$TEMP_DIR"
+  else
+    echo "Keeping intermediate files in: $TEMP_DIR"
+  fi
+}
+trap cleanup EXIT
+
+echo "📥 Step 1: Downloading video..."
+DOWNLOADED_VIDEO="$TEMP_DIR/video.mp4"
+if ! "$SCRIPT_DIR/download-video.sh" "$YOUTUBE_URL" "$TEMP_DIR"; then
+  echo "Error: Failed to download video" >&2
+  exit 1
+fi
+
+# Find the downloaded video file
+if [[ -f "$TEMP_DIR/video.mp4" ]]; then
+  DOWNLOADED_VIDEO="$TEMP_DIR/video.mp4"
+elif [[ -f "$TEMP_DIR"/*.mp4 ]]; then
+  DOWNLOADED_VIDEO=$(ls "$TEMP_DIR"/*.mp4 | head -1)
+else
+  echo "Error: Could not find downloaded video file" >&2
+  exit 1
+fi
+
+echo "✅ Downloaded: $DOWNLOADED_VIDEO"
+
+# Extract transcript VTT for sentence boundary detection
+TRANSCRIPT_VTT=""
+if [[ -n "$YOUTUBE_URL" ]] && command -v yt-dlp &> /dev/null; then
+  echo "📝 Extracting transcript for sentence boundary detection..." >&2
+  TEMP_VTT_BASE=$(mktemp)
+  if yt-dlp --skip-download --write-auto-sub --sub-lang en --sub-format vtt --output "$TEMP_VTT_BASE" "$YOUTUBE_URL" 2>/dev/null; then
+    if [[ -f "${TEMP_VTT_BASE}.en.vtt" ]]; then
+      TRANSCRIPT_VTT="${TEMP_VTT_BASE}.en.vtt"
+      echo "✅ Transcript extracted" >&2
+    fi
+  fi
+fi
+
+# Determine start time
+if [[ -z "$START_TIME" ]]; then
+  echo "🤖 Step 2: Analyzing video with Ollama to find best segment..."
+  SEGMENT_JSON="$TEMP_DIR/segments.json"
+  export YOUTUBE_URL
+  if ! "$SCRIPT_DIR/analyze-segments.sh" "$DOWNLOADED_VIDEO" "${MODEL:-}" "$DURATION" "$YOUTUBE_URL" > "$SEGMENT_JSON"; then
+    echo "Warning: AI analysis failed" >&2
+    # Smart fallback: use middle section instead of intro
+    VIDEO_DURATION=$(ffprobe -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 "$DOWNLOADED_VIDEO" 2>/dev/null | cut -d. -f1 || echo "0")
+    if [[ $VIDEO_DURATION -gt $((DURATION * 2)) ]]; then
+      # Start at 25% through the video (skip intro, get to content)
+      START_TIME=$((VIDEO_DURATION * 25 / 100))
+      echo "📊 Using smart fallback: starting at ${START_TIME}s (25% through video)" >&2
+    else
+      START_TIME=0
+      echo "Warning: Video too short, using first ${DURATION}s" >&2
+    fi
+  else
+    # Extract start time from JSON
+    if command -v jq &> /dev/null; then
+      START_TIME=$(jq -r '.segments[0].start // 0' "$SEGMENT_JSON" 2>/dev/null || echo "0")
+      # Validate start time (ensure it's not just the intro)
+      if [[ $START_TIME -lt 10 ]]; then
+        echo "⚠️  Analysis suggested intro (${START_TIME}s), using smarter fallback" >&2
+        VIDEO_DURATION=$(ffprobe -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 "$DOWNLOADED_VIDEO" 2>/dev/null | cut -d. -f1 || echo "0")
+        if [[ $VIDEO_DURATION -gt $((DURATION * 2)) ]]; then
+          START_TIME=$((VIDEO_DURATION * 30 / 100))
+          echo "📊 Using segment starting at ${START_TIME}s (30% through video)" >&2
+        fi
+      else
+        echo "📊 Recommended segment: starts at ${START_TIME}s"
+      fi
+    else
+      echo "Warning: jq not found, using smart fallback" >&2
+      VIDEO_DURATION=$(ffprobe -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 "$DOWNLOADED_VIDEO" 2>/dev/null | cut -d. -f1 || echo "0")
+      START_TIME=$((VIDEO_DURATION * 25 / 100))
+    fi
+  fi
+fi
+
+# Step 2.5: Adjust duration to complete sentences (dynamic duration)
+if [[ -n "$TRANSCRIPT_VTT" ]] && [[ -f "$TRANSCRIPT_VTT" ]]; then
+  echo "🔍 Finding sentence boundary to avoid cutting mid-sentence..."
+  ADJUSTED_DURATION=$("$SCRIPT_DIR/find-sentence-boundary.sh" "$TRANSCRIPT_VTT" "$START_TIME" "$DURATION")
+  if [[ $ADJUSTED_DURATION -ne $DURATION ]] && [[ $ADJUSTED_DURATION -le 60 ]]; then
+    echo "📏 Adjusted duration from ${DURATION}s to ${ADJUSTED_DURATION}s to complete sentence"
+    DURATION=$ADJUSTED_DURATION
+  elif [[ $ADJUSTED_DURATION -gt 60 ]]; then
+    echo "⚠️  Sentence completion would exceed 60s limit, using ${DURATION}s"
+  fi
+fi
+
+# Generate output filename
+if [[ -z "$OUTPUT_FILE" ]]; then
+  VIDEO_ID=$(echo "$YOUTUBE_URL" | sed -E 's/.*[?&]v=([^&]*).*/\1/' || echo "video")
+  OUTPUT_FILE="$OUTPUT_DIR/short_${VIDEO_ID}_$(date +%Y%m%d_%H%M%S).mp4"
+fi
+
+echo "✂️  Step 3: Creating short format (9:16, ${DURATION}s)..."
+SHORT_NO_CAPTIONS="${OUTPUT_FILE%.mp4}_nocaptions.mp4"
+if ! "$SCRIPT_DIR/create-short-format.sh" "$DOWNLOADED_VIDEO" "$START_TIME" "$DURATION" "$SHORT_NO_CAPTIONS"; then
+  echo "Error: Failed to create short format" >&2
+  exit 1
+fi
+
+# Step 4: Add captions if requested
+if [[ "$ADD_CAPTIONS" == "true" ]]; then
+  echo "📝 Step 4: Adding bold captions..."
+  # Pass the transcript VTT file path if available
+  if [[ -n "$TRANSCRIPT_VTT" ]] && [[ -f "$TRANSCRIPT_VTT" ]]; then
+    # Create a temporary VTT file adjusted for the segment
+    ADJUSTED_VTT="$TEMP_DIR/adjusted_subtitles.vtt"
+    if command -v python3 &> /dev/null; then
+      python3 <<PYTHON_ADJUST > "$ADJUSTED_VTT"
+import re
+
+start_offset = $START_TIME
+try:
+    with open("$TRANSCRIPT_VTT", 'r', encoding='utf-8', errors='ignore') as f:
+        content = f.read()
+        # Adjust timestamps by subtracting start_offset
+        def adjust_timestamp(match):
+            h, m, s, ms = map(int, match.groups()[:4])
+            total_sec = h * 3600 + m * 60 + s + ms / 1000.0
+            if total_sec < start_offset:
+                return ""
+            adjusted_sec = total_sec - start_offset
+            if adjusted_sec > $DURATION:
+                return ""
+            new_h = int(adjusted_sec // 3600)
+            new_m = int((adjusted_sec % 3600) // 60)
+            new_s = int(adjusted_sec % 60)
+            new_ms = int((adjusted_sec % 1) * 1000)
+            return f"{new_h:02d}:{new_m:02d}:{new_s:02d}.{new_ms:03d}"
+        
+        # Adjust all timestamps
+        pattern = r'(\d{2}):(\d{2}):(\d{2})\.(\d{3})\s*-->\s*(\d{2}):(\d{2}):(\d{2})\.(\d{3})'
+        adjusted = re.sub(pattern, lambda m: adjust_timestamp(m) + " --> " + adjust_timestamp(re.match(r'(\d{2}):(\d{2}):(\d{2})\.(\d{3})', m.group(5) + ":" + m.group(6) + ":" + m.group(7) + "." + m.group(8))) if m.group(5) else "", content)
+        print(adjusted)
+except:
+    pass
+PYTHON_ADJUST
+      if [[ -s "$ADJUSTED_VTT" ]]; then
+        # Use adjusted VTT for captions (pass as 4th parameter)
+        TRANSCRIPT_VTT_ARG="$ADJUSTED_VTT"
+      else
+        TRANSCRIPT_VTT_ARG=""
+      fi
+    else
+      TRANSCRIPT_VTT_ARG=""
+    fi
+    
+    # Call add-captions with VTT file if available
+    if [[ -n "$TRANSCRIPT_VTT_ARG" ]] && [[ -f "$TRANSCRIPT_VTT_ARG" ]]; then
+      # Use provided VTT file
+      if ! "$SCRIPT_DIR/add-captions.sh" "$SHORT_NO_CAPTIONS" "" "$OUTPUT_FILE" "$TRANSCRIPT_VTT_ARG"; then
+        echo "Warning: Failed to add captions with provided VTT, trying YouTube extraction" >&2
+        if ! "$SCRIPT_DIR/add-captions.sh" "$SHORT_NO_CAPTIONS" "$YOUTUBE_URL" "$OUTPUT_FILE"; then
+          echo "Warning: Failed to add captions, using video without captions" >&2
+          mv "$SHORT_NO_CAPTIONS" "$OUTPUT_FILE"
+        else
+          rm -f "$SHORT_NO_CAPTIONS"
+        fi
+      else
+        rm -f "$SHORT_NO_CAPTIONS"
+      fi
+    else
+      # Use original method (extract from YouTube)
+      if ! "$SCRIPT_DIR/add-captions.sh" "$SHORT_NO_CAPTIONS" "$YOUTUBE_URL" "$OUTPUT_FILE"; then
+        echo "Warning: Failed to add captions, using video without captions" >&2
+        mv "$SHORT_NO_CAPTIONS" "$OUTPUT_FILE"
+      else
+        rm -f "$SHORT_NO_CAPTIONS"
+      fi
+    fi
+  else
+    # No transcript VTT, use original method
+    if ! "$SCRIPT_DIR/add-captions.sh" "$SHORT_NO_CAPTIONS" "$YOUTUBE_URL" "$OUTPUT_FILE"; then
+      echo "Warning: Failed to add captions, using video without captions" >&2
+      mv "$SHORT_NO_CAPTIONS" "$OUTPUT_FILE"
+    else
+      rm -f "$SHORT_NO_CAPTIONS"
+    fi
+  fi
+else
+  mv "$SHORT_NO_CAPTIONS" "$OUTPUT_FILE"
+fi
+
+echo "✅ Created short: $OUTPUT_FILE"
+
+# Upload if requested
+if [[ "$NO_UPLOAD" != "true" ]] && [[ -n "${YOUTUBE_CLIENT_ID:-}" ]] && [[ -n "${YOUTUBE_CLIENT_SECRET:-}" ]]; then
+  echo "📤 Step 5: Uploading to YouTube..."
+  TITLE="Short from $(basename "$OUTPUT_FILE" .mp4)"
+  if ! "$SCRIPT_DIR/upload-youtube.sh" "$OUTPUT_FILE" "$TITLE"; then
+    echo "Warning: Upload failed, but video is ready at: $OUTPUT_FILE" >&2
+  else
+    echo "✅ Uploaded successfully!"
+  fi
+else
+  echo "ℹ️  Skipping upload (use --no-upload to suppress this message, or configure YouTube API)"
+fi
+
+echo ""
+echo "🎉 Success! Short created at: $OUTPUT_FILE"

--- a/skills/youtube-shorts/scripts/download-video.sh
+++ b/skills/youtube-shorts/scripts/download-video.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Download YouTube video using yt-dlp
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: download-video.sh <youtube_url> [output_dir]
+
+Downloads a YouTube video and saves it as video.mp4 in the output directory.
+EOF
+  exit 2
+}
+
+if [[ "${1:-}" == "" || "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+fi
+
+YOUTUBE_URL="${1:-}"
+OUTPUT_DIR="${2:-$(pwd)}"
+
+if ! command -v yt-dlp &> /dev/null; then
+  echo "Error: yt-dlp not found. Install with: brew install yt-dlp" >&2
+  exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR"
+
+echo "Downloading: $YOUTUBE_URL"
+
+# Download video (best quality MP4, or best available)
+yt-dlp \
+  --format "bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best" \
+  --merge-output-format mp4 \
+  --output "$OUTPUT_DIR/video.%(ext)s" \
+  --no-playlist \
+  "$YOUTUBE_URL"
+
+# Find the downloaded file
+if [[ -f "$OUTPUT_DIR/video.mp4" ]]; then
+  echo "$OUTPUT_DIR/video.mp4"
+elif [[ -f "$OUTPUT_DIR"/*.mp4 ]]; then
+  ls "$OUTPUT_DIR"/*.mp4 | head -1
+else
+  echo "Error: Could not find downloaded video" >&2
+  exit 1
+fi

--- a/skills/youtube-shorts/scripts/find-sentence-boundary.sh
+++ b/skills/youtube-shorts/scripts/find-sentence-boundary.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Find the next sentence boundary after a given timestamp to avoid cutting mid-sentence
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: find-sentence-boundary.sh <vtt_file> <start_time_seconds> <max_duration>
+
+Finds the end of the last complete sentence within max_duration from start_time.
+Returns the adjusted duration that completes the sentence.
+EOF
+  exit 2
+}
+
+if [[ "${1:-}" == "" || "${2:-}" == "" || "${3:-}" == "" ]]; then
+  usage
+fi
+
+VTT_FILE="${1:-}"
+START_TIME="${2:-0}"
+MAX_DURATION="${3:-60}"
+
+if [[ ! -f "$VTT_FILE" ]]; then
+  echo "$MAX_DURATION"  # Return max duration if no VTT file
+  exit 0
+fi
+
+# Convert start_time to seconds if needed
+if [[ "$START_TIME" =~ ^[0-9]+:[0-9]+:[0-9]+$ ]]; then
+  IFS=':' read -r hours minutes seconds <<< "$START_TIME"
+  START_TIME=$((hours * 3600 + minutes * 60 + seconds))
+fi
+
+END_TIME=$((START_TIME + MAX_DURATION))
+TARGET_END=$END_TIME
+
+# Parse VTT file to find sentence boundaries
+# Look for timestamps and text that ends with sentence punctuation
+if command -v python3 &> /dev/null; then
+  python3 <<PYTHON_SCRIPT
+import re
+import sys
+
+start_time = $START_TIME
+max_end = $END_TIME
+target_end = max_end
+
+try:
+    segments = []
+    current_text = ""
+    current_start_sec = 0
+    current_end_sec = 0
+    
+    with open("$VTT_FILE", 'r', encoding='utf-8', errors='ignore') as f:
+        for line in f:
+            line = line.strip()
+            if not line or line == "WEBVTT" or re.match(r'^NOTE', line) or re.match(r'^\d+$', line):
+                continue
+            
+            # Match timestamp: 00:00:00.000 --> 00:00:05.000
+            timestamp_match = re.match(r'(\d{2}):(\d{2}):(\d{2})\.(\d{3})\s*-->\s*(\d{2}):(\d{2}):(\d{2})\.(\d{3})', line)
+            if timestamp_match:
+                # Save previous segment if exists
+                if current_text:
+                    segments.append({
+                        'start': current_start_sec,
+                        'end': current_end_sec,
+                        'text': current_text
+                    })
+                
+                # Convert timestamp to seconds
+                h1, m1, s1, ms1 = map(int, timestamp_match.groups()[:4])
+                h2, m2, s2, ms2 = map(int, timestamp_match.groups()[4:])
+                current_start_sec = h1 * 3600 + m1 * 60 + s1 + ms1 / 1000.0
+                current_end_sec = h2 * 3600 + m2 * 60 + s2 + ms2 / 1000.0
+                current_text = ""
+            else:
+                # Accumulate text
+                clean_line = re.sub(r'<[^>]+>', '', line)
+                if clean_line:
+                    current_text += " " + clean_line if current_text else clean_line
+        
+        # Add last segment
+        if current_text:
+            segments.append({
+                'start': current_start_sec,
+                'end': current_end_sec,
+                'text': current_text
+            })
+    
+    # Find the best sentence boundary
+    best_end = start_time + $MAX_DURATION
+    
+    for seg in segments:
+        seg_start = seg['start']
+        seg_end = seg['end']
+        text = seg['text']
+        
+        # Check if segment overlaps with our time range
+        if seg_start < start_time + $MAX_DURATION and seg_end > start_time:
+            # Check for sentence endings
+            # Look for punctuation followed by space or end of text
+            sentences = re.split(r'([.!?]+[\s\n]*)', text)
+            
+            # Reconstruct sentences with punctuation
+            full_sentences = []
+            for i in range(0, len(sentences) - 1, 2):
+                if i + 1 < len(sentences):
+                    full_sentences.append(sentences[i] + sentences[i + 1])
+                else:
+                    full_sentences.append(sentences[i])
+            
+            # Find where complete sentences end
+            cumulative_length = 0
+            for sentence in full_sentences:
+                if sentence.strip() and re.search(r'[.!?]', sentence):
+                    # This is a complete sentence
+                    # Estimate its end time proportionally
+                    sentence_ratio = len(sentence) / len(text) if text else 0
+                    sentence_end = seg_start + (seg_end - seg_start) * (cumulative_length + len(sentence)) / len(text) if text else seg_end
+                    
+                    if sentence_end <= start_time + $MAX_DURATION and sentence_end > start_time:
+                        best_end = max(best_end, sentence_end)
+                    
+                    cumulative_length += len(sentence)
+                else:
+                    cumulative_length += len(sentence)
+            
+            # Also check if the entire segment ends with sentence punctuation
+            if re.search(r'[.!?]\s*$', text.strip()):
+                if seg_end <= start_time + $MAX_DURATION:
+                    best_end = max(best_end, seg_end)
+    
+    # Calculate duration (ensure it's within limits)
+    duration = best_end - start_time
+    duration = max(1, min(int(duration), $MAX_DURATION))
+    print(duration)
+        
+except Exception as e:
+    # Fallback: return max duration
+    print($MAX_DURATION)
+PYTHON_SCRIPT
+else
+  # Fallback: return max duration
+  echo "$MAX_DURATION"
+fi

--- a/skills/youtube-shorts/scripts/upload-youtube.sh
+++ b/skills/youtube-shorts/scripts/upload-youtube.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Upload video to YouTube using YouTube Data API v3
+# Requires OAuth2 credentials
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: upload-youtube.sh <video_file> <title> [description] [tags]
+
+Uploads a video to YouTube using YouTube Data API v3.
+
+Required environment variables:
+  YOUTUBE_CLIENT_ID       OAuth2 client ID
+  YOUTUBE_CLIENT_SECRET   OAuth2 client secret
+  YOUTUBE_REFRESH_TOKEN   OAuth2 refresh token
+
+To obtain credentials:
+1. Go to https://console.cloud.google.com/
+2. Create a project and enable YouTube Data API v3
+3. Create OAuth2 credentials
+4. Use OAuth2 flow to get refresh token
+EOF
+  exit 2
+}
+
+if [[ "${1:-}" == "" || "${2:-}" == "" ]]; then
+  usage
+fi
+
+VIDEO_FILE="${1:-}"
+TITLE="${2:-}"
+DESCRIPTION="${3:-YouTube Short created with OpenClaw}"
+TAGS="${4:-shorts,openclaw}"
+
+if [[ ! -f "$VIDEO_FILE" ]]; then
+  echo "Error: Video file not found: $VIDEO_FILE" >&2
+  exit 1
+fi
+
+# Check for required environment variables
+if [[ -z "${YOUTUBE_CLIENT_ID:-}" ]] || [[ -z "${YOUTUBE_CLIENT_SECRET:-}" ]]; then
+  echo "Error: YOUTUBE_CLIENT_ID and YOUTUBE_CLIENT_SECRET must be set" >&2
+  echo ""
+  usage
+  exit 1
+fi
+
+# Check for Python (needed for YouTube API)
+if ! command -v python3 &> /dev/null; then
+  echo "Error: python3 not found. YouTube upload requires Python." >&2
+  echo "Install Python or skip upload with --no-upload flag" >&2
+  exit 1
+fi
+
+# Check if google-api-python-client is installed
+if ! python3 -c "import googleapiclient.discovery" 2>/dev/null; then
+  echo "Installing required Python packages..."
+  pip3 install --user google-api-python-client google-auth-httplib2 google-auth-oauthlib 2>&1 | grep -v "already satisfied" || true
+fi
+
+# Create a temporary Python script for upload
+UPLOAD_SCRIPT=$(mktemp)
+cat > "$UPLOAD_SCRIPT" <<'PYTHON_SCRIPT'
+import os
+import sys
+from googleapiclient.discovery import build
+from googleapiclient.http import MediaFileUpload
+from google_auth_oauthlib.flow import InstalledAppFlow
+from google.auth.transport.requests import Request
+import pickle
+
+SCOPES = ['https://www.googleapis.com/auth/youtube.upload']
+
+def get_authenticated_service():
+    client_id = os.environ.get('YOUTUBE_CLIENT_ID')
+    client_secret = os.environ.get('YOUTUBE_CLIENT_SECRET')
+    refresh_token = os.environ.get('YOUTUBE_REFRESH_TOKEN')
+    
+    if not all([client_id, client_secret]):
+        print("Error: YOUTUBE_CLIENT_ID and YOUTUBE_CLIENT_SECRET must be set", file=sys.stderr)
+        sys.exit(1)
+    
+    # Create credentials dict
+    credentials_info = {
+        "installed": {
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+            "token_uri": "https://oauth2.googleapis.com/token",
+            "redirect_uris": ["http://localhost"]
+        }
+    }
+    
+    creds = None
+    token_file = os.path.expanduser('~/.openclaw/youtube_token.pickle')
+    
+    if os.path.exists(token_file):
+        with open(token_file, 'rb') as token:
+            creds = pickle.load(token)
+    
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        elif refresh_token:
+            # Use refresh token to get new access token
+            from google.oauth2.credentials import Credentials
+            creds = Credentials(
+                None,
+                refresh_token=refresh_token,
+                token_uri="https://oauth2.googleapis.com/token",
+                client_id=client_id,
+                client_secret=client_secret
+            )
+            creds.refresh(Request())
+        else:
+            print("Error: No valid credentials. Run OAuth flow or set YOUTUBE_REFRESH_TOKEN", file=sys.stderr)
+            sys.exit(1)
+        
+        os.makedirs(os.path.dirname(token_file), exist_ok=True)
+        with open(token_file, 'wb') as token:
+            pickle.dump(creds, token)
+    
+    return build('youtube', 'v3', credentials=creds)
+
+def upload_video(video_file, title, description, tags):
+    youtube = get_authenticated_service()
+    
+    body = {
+        'snippet': {
+            'title': title,
+            'description': description,
+            'tags': tags.split(',') if tags else [],
+            'categoryId': '24'  # Entertainment
+        },
+        'status': {
+            'privacyStatus': 'private',  # Change to 'public' or 'unlisted' as needed
+            'selfDeclaredMadeForKids': False
+        }
+    }
+    
+    # YouTube Shorts must be marked as such
+    body['snippet']['categoryId'] = '24'
+    
+    media = MediaFileUpload(video_file, chunksize=-1, resumable=True, mimetype='video/mp4')
+    
+    insert_request = youtube.videos().insert(
+        part=','.join(body.keys()),
+        body=body,
+        media_body=media
+    )
+    
+    response = None
+    while response is None:
+        status, response = insert_request.next_chunk()
+        if status:
+            print(f"Upload progress: {int(status.progress() * 100)}%", file=sys.stderr)
+    
+    if 'id' in response:
+        video_id = response['id']
+        print(f"https://www.youtube.com/watch?v={video_id}")
+        return video_id
+    else:
+        print(f"Error: Upload failed: {response}", file=sys.stderr)
+        sys.exit(1)
+
+if __name__ == '__main__':
+    if len(sys.argv) < 3:
+        print("Usage: upload-youtube.py <video_file> <title> [description] [tags]", file=sys.stderr)
+        sys.exit(1)
+    
+    video_file = sys.argv[1]
+    title = sys.argv[2]
+    description = sys.argv[3] if len(sys.argv) > 3 else "YouTube Short created with OpenClaw"
+    tags = sys.argv[4] if len(sys.argv) > 4 else "shorts,openclaw"
+    
+    upload_video(video_file, title, description, tags)
+PYTHON_SCRIPT
+
+# Run the upload script
+python3 "$UPLOAD_SCRIPT" "$VIDEO_FILE" "$TITLE" "$DESCRIPTION" "$TAGS"
+EXIT_CODE=$?
+
+rm -f "$UPLOAD_SCRIPT"
+
+exit $EXIT_CODE

--- a/workspace/skills/youtube-shorts/README.md
+++ b/workspace/skills/youtube-shorts/README.md
@@ -1,0 +1,155 @@
+# YouTube Shorts Creator Skill
+
+Automatically create YouTube Shorts from your YouTube videos using AI analysis (Ollama) and video editing (ffmpeg).
+
+## Quick Start
+
+### 1. Install Dependencies
+
+```bash
+brew install yt-dlp ffmpeg jq
+```
+
+### 2. Set Up Ollama
+
+Make sure Ollama is running and pull a model:
+
+```bash
+ollama pull llama3.3
+# or
+ollama pull qwen2.5-coder:32b
+```
+
+### 3. Configure OpenClaw
+
+Ensure Ollama is configured in your OpenClaw setup. If using Docker (like in your `docker-compose.yml`), set:
+
+```bash
+export OLLAMA_BASE=http://host.docker.internal:11434
+```
+
+### 4. Use the Skill
+
+Ask your OpenClaw agent:
+
+```
+Create a YouTube short from https://www.youtube.com/watch?v=VIDEO_ID
+```
+
+Or use the exec tool directly:
+
+```bash
+openclaw agent --message "create a short from https://youtube.com/watch?v=VIDEO_ID"
+```
+
+## How It Works
+
+1. **Download**: Uses `yt-dlp` to download the YouTube video
+2. **Analyze**: Uses Ollama to analyze the video transcript and identify the most engaging segment
+3. **Edit**: Uses `ffmpeg` to create a vertical (9:16) short format video
+4. **Upload** (optional): Uploads to YouTube if credentials are configured
+
+## Configuration
+
+### Ollama Model
+
+Default: Auto-detects available models. Override:
+
+```bash
+export OLLAMA_MODEL="ollama/llama3.3"
+```
+
+### Output Directory
+
+Default: `~/.openclaw/workspace/youtube-shorts/`
+
+Override:
+
+```bash
+export YOUTUBE_SHORTS_OUTPUT_DIR="/path/to/output"
+```
+
+### YouTube Upload (Optional)
+
+To enable automatic upload:
+
+1. Go to [Google Cloud Console](https://console.cloud.google.com/)
+2. Create a project and enable YouTube Data API v3
+3. Create OAuth2 credentials
+4. Set environment variables:
+
+```bash
+export YOUTUBE_CLIENT_ID="your-client-id"
+export YOUTUBE_CLIENT_SECRET="your-client-secret"
+export YOUTUBE_REFRESH_TOKEN="your-refresh-token"
+```
+
+## Examples
+
+### Basic Usage
+
+```bash
+# Via OpenClaw agent
+openclaw agent --message "create a short from https://youtube.com/watch?v=dQw4w9WgXcQ"
+
+# Direct script execution
+./skills/youtube-shorts/scripts/create-short.sh 'https://youtube.com/watch?v=VIDEO_ID'
+```
+
+### Custom Duration
+
+```bash
+./skills/youtube-shorts/scripts/create-short.sh 'https://youtube.com/watch?v=VIDEO_ID' --duration 45
+```
+
+### Manual Segment Selection
+
+```bash
+./skills/youtube-shorts/scripts/create-short.sh 'https://youtube.com/watch?v=VIDEO_ID' --start 120 --duration 60
+```
+
+### Specific Model
+
+```bash
+./skills/youtube-shorts/scripts/create-short.sh 'https://youtube.com/watch?v=VIDEO_ID' --model ollama/qwen2.5-coder:32b
+```
+
+## Troubleshooting
+
+### yt-dlp fails
+
+- Update: `brew upgrade yt-dlp`
+- Some videos may require cookies (private/unlisted videos)
+
+### Ollama connection fails
+
+- Verify Ollama is running: `ollama list`
+- Check `OLLAMA_BASE` environment variable
+- In Docker: Use `http://host.docker.internal:11434`
+- Locally: Use `http://127.0.0.1:11434`
+
+### ffmpeg errors
+
+- Ensure ffmpeg is installed: `ffmpeg -version`
+- Check video file is valid: `ffprobe <video_file>`
+
+### Upload fails
+
+- Verify YouTube API credentials are set
+- Check OAuth token is valid
+- Review YouTube API quota limits
+
+## Scripts Reference
+
+- `create-short.sh` - Main workflow orchestrator
+- `download-video.sh` - Download YouTube videos
+- `analyze-segments.sh` - AI analysis with Ollama
+- `create-short-format.sh` - Video editing with ffmpeg
+- `upload-youtube.sh` - YouTube API upload
+
+## Notes
+
+- Videos are automatically cropped/scaled to 9:16 aspect ratio
+- Maximum duration is 60 seconds (YouTube Shorts requirement)
+- Output format: MP4 (H.264/AAC) compatible with YouTube
+- Intermediate files are cleaned up unless `--keep-files` is used

--- a/workspace/skills/youtube-shorts/SKILL.md
+++ b/workspace/skills/youtube-shorts/SKILL.md
@@ -1,0 +1,243 @@
+---
+name: youtube-shorts
+description: Create YouTube Shorts from YouTube videos using Ollama AI analysis and ffmpeg editing.
+homepage: https://github.com/openclaw/openclaw
+metadata:
+  {
+    "openclaw": {
+      "emoji": "🎬",
+      "requires": { "bins": ["yt-dlp", "ffmpeg", "jq"] },
+      "install": [
+        {
+          "id": "brew",
+          "kind": "brew",
+          "formula": "yt-dlp",
+          "bins": ["yt-dlp"],
+          "label": "Install yt-dlp (brew)",
+        },
+        {
+          "id": "brew-ffmpeg",
+          "kind": "brew",
+          "formula": "ffmpeg",
+          "bins": ["ffmpeg"],
+          "label": "Install ffmpeg (brew)",
+        },
+        {
+          "id": "brew-jq",
+          "kind": "brew",
+          "formula": "jq",
+          "bins": ["jq"],
+          "label": "Install jq (brew)",
+        },
+      ],
+    },
+  }
+---
+
+# YouTube Shorts Creator
+
+Automatically create YouTube Shorts from your YouTube videos using AI analysis (Ollama) to identify interesting segments, then edit them into shorts format (9:16 aspect ratio, <60 seconds).
+
+## When to use (trigger phrases)
+
+Use this skill when the user asks:
+
+- "create a YouTube short from [video URL]"
+- "make a short from my YouTube video"
+- "convert this video to a YouTube short"
+- "create shorts from my YouTube videos"
+
+## Prerequisites
+
+1. **Install dependencies:**
+   ```bash
+   brew install yt-dlp ffmpeg jq
+   ```
+
+2. **Configure Ollama:**
+   - Ensure Ollama is running and accessible
+   - Set `OLLAMA_API_KEY` environment variable (or configure in OpenClaw config)
+   - Pull a model: `ollama pull llama3.3` or `ollama pull qwen2.5-coder:32b`
+
+3. **Optional: YouTube API credentials** (for uploading):
+   - Set `YOUTUBE_CLIENT_ID` and `YOUTUBE_CLIENT_SECRET`
+   - Or use manual upload after creation
+
+## Quick start
+
+### Basic usage (download + analyze + create short)
+
+```bash
+# Using exec tool
+exec command:"{baseDir}/scripts/create-short.sh 'https://youtube.com/watch?v=VIDEO_ID'"
+```
+
+### With custom options
+
+```bash
+exec command:"{baseDir}/scripts/create-short.sh 'https://youtube.com/watch?v=VIDEO_ID' --duration 45 --model ollama/llama3.3"
+```
+
+## Workflow
+
+The skill performs these steps:
+
+1. **Download**: Uses `yt-dlp` to download the video
+2. **Analyze**: Uses Ollama to analyze transcript/timestamps and identify interesting segments
+3. **Edit**: Uses `ffmpeg` to create a short (9:16, <60s) from the identified segment
+4. **Upload** (optional): Uploads to YouTube if credentials are configured
+
+## Scripts
+
+### `create-short.sh` (main workflow)
+
+Orchestrates the entire process.
+
+**Usage:**
+```bash
+{baseDir}/scripts/create-short.sh <youtube_url> [options]
+```
+
+**Options:**
+- `--duration <seconds>`: Target duration (default: 60, max: 60 for shorts)
+- `--model <model>`: Ollama model to use (default: auto-detect)
+- `--start <timestamp>`: Manual start time (HH:MM:SS or seconds)
+- `--output <path>`: Output file path (default: auto-generated)
+- `--no-upload`: Skip YouTube upload even if credentials are set
+- `--keep-files`: Keep intermediate files after completion
+
+### `download-video.sh`
+
+Downloads a YouTube video using yt-dlp.
+
+**Usage:**
+```bash
+{baseDir}/scripts/download-video.sh <youtube_url> [output_dir]
+```
+
+### `analyze-segments.sh`
+
+Uses Ollama to analyze video transcript and identify interesting segments.
+
+**Usage:**
+```bash
+{baseDir}/scripts/analyze-segments.sh <video_file> [model] [target_duration]
+```
+
+Returns JSON with recommended segments:
+```json
+{
+  "segments": [
+    {
+      "start": 120.5,
+      "end": 180.0,
+      "reason": "High engagement moment with key insight"
+    }
+  ]
+}
+```
+
+### `create-short-format.sh`
+
+Edits video into YouTube Shorts format (9:16 aspect ratio, vertical).
+
+**Usage:**
+```bash
+{baseDir}/scripts/create-short-format.sh <input_video> <start_time> <duration> [output_file]
+```
+
+**Parameters:**
+- `input_video`: Source video file
+- `start_time`: Start timestamp (seconds or HH:MM:SS)
+- `duration`: Duration in seconds (max 60)
+- `output_file`: Output path (optional, auto-generated if not provided)
+
+### `upload-youtube.sh` (optional)
+
+Uploads the short to YouTube using YouTube API.
+
+**Usage:**
+```bash
+{baseDir}/scripts/upload-youtube.sh <video_file> <title> [description] [tags]
+```
+
+**Environment variables:**
+- `YOUTUBE_CLIENT_ID`: YouTube API client ID
+- `YOUTUBE_CLIENT_SECRET`: YouTube API client secret
+- `YOUTUBE_REFRESH_TOKEN`: OAuth refresh token (obtain via OAuth flow)
+
+## Examples
+
+### Example 1: Simple short creation
+
+```bash
+exec command:"{baseDir}/scripts/create-short.sh 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'"
+```
+
+### Example 2: Custom duration and model
+
+```bash
+exec command:"{baseDir}/scripts/create-short.sh 'https://www.youtube.com/watch?v=VIDEO_ID' --duration 45 --model ollama/qwen2.5-coder:32b"
+```
+
+### Example 3: Manual segment selection
+
+```bash
+exec command:"{baseDir}/scripts/create-short.sh 'https://www.youtube.com/watch?v=VIDEO_ID' --start 120 --duration 60"
+```
+
+### Example 4: Download only (no editing)
+
+```bash
+exec command:"{baseDir}/scripts/download-video.sh 'https://www.youtube.com/watch?v=VIDEO_ID' /tmp/videos"
+```
+
+## Configuration
+
+### Ollama model selection
+
+The script auto-detects available Ollama models. To specify:
+
+```bash
+export OLLAMA_MODEL="ollama/llama3.3"
+```
+
+Or pass via `--model` flag.
+
+### Output directory
+
+Default: `~/.openclaw/workspace/youtube-shorts/`
+
+Override:
+```bash
+export YOUTUBE_SHORTS_OUTPUT_DIR="/path/to/output"
+```
+
+## Notes
+
+- **Video format**: Output is MP4 (H.264/AAC) compatible with YouTube Shorts
+- **Aspect ratio**: Automatically crops/letterboxes to 9:16 (vertical)
+- **Duration**: YouTube Shorts must be ≤60 seconds
+- **Quality**: Preserves original quality; may re-encode for format compliance
+- **Transcripts**: Uses yt-dlp's transcript extraction; falls back to audio transcription if unavailable
+- **AI analysis**: Uses Ollama to identify high-engagement moments based on transcript content
+
+## Troubleshooting
+
+**yt-dlp fails:**
+- Update: `brew upgrade yt-dlp`
+- Check video is publicly accessible (or provide cookies)
+
+**Ollama connection fails:**
+- Verify Ollama is running: `ollama list`
+- Check `OLLAMA_BASE` environment variable matches your setup
+- Default: `http://127.0.0.1:11434` (or `http://host.docker.internal:11434` in Docker)
+
+**ffmpeg errors:**
+- Ensure ffmpeg is installed: `ffmpeg -version`
+- Check video file is valid: `ffprobe <video_file>`
+
+**Upload fails:**
+- Verify YouTube API credentials
+- Check OAuth token is valid and not expired
+- Review YouTube API quota limits

--- a/workspace/skills/youtube-shorts/scripts/add-captions.sh
+++ b/workspace/skills/youtube-shorts/scripts/add-captions.sh
@@ -1,0 +1,294 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Add bold English captions to a video file
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: add-captions.sh <video_file> [youtube_url] [output_file] [vtt_file]
+
+Adds bold, engaging English captions to a video optimized for YouTube Shorts.
+If youtube_url is provided, extracts transcript from YouTube.
+If vtt_file is provided, uses that VTT file directly (for segment-adjusted subtitles).
+EOF
+  exit 2
+}
+
+if [[ "${1:-}" == "" ]]; then
+  usage
+fi
+
+VIDEO_FILE="${1:-}"
+YOUTUBE_URL="${2:-}"
+OUTPUT_FILE="${3:-}"
+PROVIDED_VTT="${4:-}"
+
+if [[ ! -f "$VIDEO_FILE" ]]; then
+  echo "Error: Video file not found: $VIDEO_FILE" >&2
+  exit 1
+fi
+
+if ! command -v ffmpeg &> /dev/null; then
+  echo "Error: ffmpeg not found. Install with: brew install ffmpeg" >&2
+  exit 1
+fi
+
+# Generate output filename if not provided
+if [[ -z "$OUTPUT_FILE" ]]; then
+  BASE_NAME=$(basename "$VIDEO_FILE" .mp4)
+  OUTPUT_DIR=$(dirname "$VIDEO_FILE")
+  OUTPUT_FILE="$OUTPUT_DIR/${BASE_NAME}_captioned.mp4"
+fi
+
+mkdir -p "$(dirname "$OUTPUT_FILE")"
+
+# Get video duration
+VIDEO_DURATION=$(ffprobe -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 "$VIDEO_FILE" 2>/dev/null | cut -d. -f1 || echo "60")
+
+echo "🎬 Adding captions to video..."
+echo "  Input: $VIDEO_FILE"
+echo "  Output: $OUTPUT_FILE"
+
+# Try to extract transcript from YouTube URL or use provided VTT
+TRANSCRIPT_VTT=""
+SUBTITLE_FILE=$(mktemp).vtt
+
+# Use provided VTT file if available (for segment-adjusted subtitles)
+if [[ -n "$PROVIDED_VTT" ]] && [[ -f "$PROVIDED_VTT" ]]; then
+  cp "$PROVIDED_VTT" "$SUBTITLE_FILE"
+  TRANSCRIPT_VTT="$SUBTITLE_FILE"
+  echo "📝 Using provided transcript file" >&2
+elif [[ -n "$YOUTUBE_URL" ]] && command -v yt-dlp &> /dev/null; then
+  echo "📝 Extracting transcript from YouTube..." >&2
+  TEMP_VTT=$(mktemp)
+  if yt-dlp --skip-download --write-auto-sub --sub-lang en --sub-format vtt --output "$TEMP_VTT" "$YOUTUBE_URL" 2>/dev/null; then
+    if [[ -f "${TEMP_VTT}.en.vtt" ]]; then
+      TRANSCRIPT_VTT="${TEMP_VTT}.en.vtt"
+      echo "✅ Transcript extracted" >&2
+    fi
+  fi
+fi
+
+# If no transcript, we'll generate a simple caption file
+if [[ -z "$TRANSCRIPT_VTT" ]]; then
+  echo "⚠️  No transcript available, creating placeholder captions" >&2
+  # Create a simple VTT file with placeholder
+  cat > "$SUBTITLE_FILE" <<EOF
+WEBVTT
+
+00:00:00.000 --> 00:00:${VIDEO_DURATION}.000
+<v Engaging Content>
+Watch till the end!
+EOF
+else
+  # Use the extracted VTT file
+  cp "$TRANSCRIPT_VTT" "$SUBTITLE_FILE"
+fi
+
+# Create ASS subtitle file with bold styling for YouTube Shorts
+ASS_FILE=$(mktemp).ass
+cat > "$ASS_FILE" <<'EOF'
+[Script Info]
+Title: YouTube Shorts Captions
+ScriptType: v4.00+
+
+[V4+ Styles]
+Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
+Style: Default,Arial,72,&H00FFFFFF,&H000000FF,&H00000000,&H80000000,1,0,0,0,100,100,0,0,1,4,0,2,20,20,60,1
+Style: Bold,Arial Bold,80,&H00FFFFFF,&H000000FF,&H00000000,&H80000000,1,0,0,0,100,100,0,0,1,5,0,2,20,20,60,1
+
+[Events]
+Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
+EOF
+
+# Convert VTT to ASS format with bold styling
+# Use Python for better VTT parsing if available
+if command -v python3 &> /dev/null && [[ -f "$SUBTITLE_FILE" ]] && [[ -s "$SUBTITLE_FILE" ]]; then
+  python3 <<PYTHON_SCRIPT > "${ASS_FILE}.tmp"
+import re
+import sys
+
+# ASS header
+ass_content = """[Script Info]
+Title: YouTube Shorts Captions
+ScriptType: v4.00+
+
+[V4+ Styles]
+Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
+Style: Bold,Arial Bold,80,&H00FFFFFF,&H000000FF,&H00000000,&H80000000,1,0,0,0,100,100,0,0,1,6,3,2,20,20,80,1
+
+[Events]
+Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
+"""
+
+# Parse VTT file
+current_start = ""
+current_end = ""
+current_text = []
+
+try:
+    with open("$SUBTITLE_FILE", 'r', encoding='utf-8', errors='ignore') as f:
+        for line in f:
+            line = line.strip()
+            if not line or line == "WEBVTT" or re.match(r'^NOTE', line) or re.match(r'^\d+$', line):
+                continue
+            
+            # Match timestamp line: 00:00:00.000 --> 00:00:05.000
+            timestamp_match = re.match(r'(\d{2}):(\d{2}):(\d{2})\.(\d{3})\s*-->\s*(\d{2}):(\d{2}):(\d{2})\.(\d{3})', line)
+            if timestamp_match:
+                # Save previous dialogue if exists
+                if current_start and current_text:
+                    text = ' '.join(current_text)
+                    # Clean HTML tags and escape special chars
+                    text = re.sub(r'<[^>]+>', '', text)
+                    text = text.replace('&', r'\\&').replace('{', r'\\{').replace('}', r'\\}')
+                    # Convert to ASS timestamp (HH:MM:SS.mm)
+                    start_ass = f"{timestamp_match.group(1)}:{timestamp_match.group(2)}:{timestamp_match.group(3)}.{timestamp_match.group(4)[:2]}"
+                    end_ass = f"{timestamp_match.group(5)}:{timestamp_match.group(6)}:{timestamp_match.group(7)}.{timestamp_match.group(8)[:2]}"
+                    ass_content += f"Dialogue: 0,{current_start},{end_ass},Bold,,0,0,0,,{{\\\\b1}}{text}{{\\\\b0}}\n"
+                
+                current_start = f"{timestamp_match.group(1)}:{timestamp_match.group(2)}:{timestamp_match.group(3)}.{timestamp_match.group(4)[:2]}"
+                current_end = f"{timestamp_match.group(5)}:{timestamp_match.group(6)}:{timestamp_match.group(7)}.{timestamp_match.group(8)[:2]}"
+                current_text = []
+            else:
+                # Text line - clean HTML tags
+                clean_line = re.sub(r'<[^>]+>', '', line)
+                if clean_line:
+                    current_text.append(clean_line)
+
+    # Add last dialogue
+    if current_start and current_text:
+        text = ' '.join(current_text)
+        text = re.sub(r'<[^>]+>', '', text)
+        text = text.replace('&', r'\\&').replace('{', r'\\{').replace('}', r'\\}')
+        ass_content += f"Dialogue: 0,{current_start},{current_end},Bold,,0,0,0,,{{\\\\b1}}{text}{{\\\\b0}}\n"
+except Exception as e:
+    # Fallback on error - use VIDEO_DURATION from bash variable
+    video_dur = int("""$VIDEO_DURATION""")
+    ass_content += f"Dialogue: 0,0:00:00.00,0:00:{video_dur}.00,Bold,,0,0,0,,{{\\\\b1}}Engaging Content{{\\\\b0}}\n"
+
+print(ass_content, end='')
+PYTHON_SCRIPT
+  if [[ -f "${ASS_FILE}.tmp" ]] && [[ -s "${ASS_FILE}.tmp" ]]; then
+    mv "${ASS_FILE}.tmp" "$ASS_FILE"
+  else
+    # Fallback if Python conversion failed
+    cat >> "$ASS_FILE" <<EOF
+Dialogue: 0,0:00:00.00,0:00:${VIDEO_DURATION}.00,Bold,,0,0,0,,{\\b1}Engaging Content{\\b0}
+EOF
+  fi
+else
+  # Fallback: Simple conversion without Python
+  echo "⚠️  Python not found or no transcript, using simple caption generation" >&2
+  cat >> "$ASS_FILE" <<EOF
+Dialogue: 0,0:00:00.00,0:00:${VIDEO_DURATION}.00,Bold,,0,0,0,,{\\b1}Engaging Content - Watch till the end!{\\b0}
+EOF
+fi
+
+# Use ffmpeg to burn in subtitles with bold styling
+echo "🎨 Rendering captions..." >&2
+
+# Extract captions from ASS/VTT and create drawtext filter chain
+# This approach is more reliable than subtitles filter
+DRAWTEXT_FILTER_FILE=$(mktemp)
+
+python3 <<PYTHON_CAPTIONS > "$DRAWTEXT_FILTER_FILE"
+import re
+import sys
+
+drawtext_filters = []
+
+try:
+    # Read ASS file
+    with open("$ASS_FILE", 'r', encoding='utf-8', errors='ignore') as f:
+        for line in f:
+            if line.startswith("Dialogue:"):
+                # Parse ASS dialogue: Dialogue: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
+                parts = line.split(",", 9)
+                if len(parts) >= 10:
+                    start_time = parts[1].strip()
+                    end_time = parts[2].strip()
+                    text_part = parts[9].strip()
+                    
+                    # Extract text (remove ASS formatting codes)
+                    text = re.sub(r'\{[^}]*\}', '', text_part)
+                    text = text.replace("\\N", " ").replace("\\n", " ").replace("\\h", " ")
+                    text = text.strip()
+                    
+                    if not text:
+                        continue
+                    
+                    # Convert ASS time (HH:MM:SS.mm) to seconds
+                    def ass_to_sec(ass_time):
+                        try:
+                            time_parts = ass_time.split(":")
+                            if len(time_parts) == 3:
+                                h, m, s = map(float, time_parts)
+                                return h * 3600 + m * 60 + s
+                        except:
+                            pass
+                        return 0
+                    
+                    start_sec = ass_to_sec(start_time)
+                    end_sec = ass_to_sec(end_time)
+                    
+                    # Skip if outside video duration
+                    if end_sec <= start_sec or start_sec < 0:
+                        continue
+                    
+                    # Escape text for drawtext (escape single quotes properly)
+                    # Replace single quotes with escaped version for shell
+                    text_escaped = text.replace("'", "'\\''")
+                    
+                    # Create drawtext filter with bold styling
+                    # Position: centered horizontally, near bottom (100px from bottom)
+                    # Style: Large white text with black box background for readability
+                    filter_str = (
+                        f"drawtext=text='{text_escaped}':"
+                        f"fontsize=85:"
+                        f"fontcolor=white:"
+                        f"x=(w-text_w)/2:"  # Center horizontally
+                        f"y=h-th-120:"     # Near bottom (120px margin for YouTube Shorts)
+                        f"enable='between(t,{start_sec:.2f},{end_sec:.2f})':"  # Show only during this time
+                        f"box=1:"          # Enable background box
+                        f"boxcolor=black@0.85:"  # Semi-transparent black background (darker for better contrast)
+                        f"boxborderw=12:"  # Thick border for bold effect
+                        f"bordercolor=black@1.0"  # Solid black border
+                    )
+                    drawtext_filters.append(filter_str)
+except Exception as e:
+    sys.stderr.write(f"Error processing captions: {e}\n")
+    pass
+
+if drawtext_filters:
+    # Chain all drawtext filters together
+    filter_chain = "[" + "][".join(drawtext_filters) + "]"
+    print(filter_chain)
+else:
+    # Fallback: single placeholder caption
+    print("drawtext=text='Engaging Content':fontsize=80:fontcolor=white:x=(w-text_w)/2:y=h-th-100:box=1:boxcolor=black@0.8:boxborderw=10")
+PYTHON_CAPTIONS
+
+DRAWTEXT_FILTER=$(cat "$DRAWTEXT_FILTER_FILE")
+rm -f "$DRAWTEXT_FILTER_FILE"
+
+# Apply captions using drawtext filter
+ffmpeg -hide_banner -loglevel warning -y \
+  -i "$VIDEO_FILE" \
+  -vf "$DRAWTEXT_FILTER" \
+  -c:v libx264 \
+  -preset medium \
+  -crf 23 \
+  -c:a copy \
+  -movflags +faststart \
+  "$OUTPUT_FILE"
+
+if [[ -f "$OUTPUT_FILE" ]]; then
+  echo "✅ Created captioned video: $OUTPUT_FILE"
+  echo "$OUTPUT_FILE"
+  rm -f "$SUBTITLE_FILE" "$ASS_FILE" "${TEMP_VTT}.en.vtt" 2>/dev/null
+else
+  echo "Error: Failed to add captions" >&2
+  rm -f "$SUBTITLE_FILE" "$ASS_FILE" "${TEMP_VTT}.en.vtt" 2>/dev/null
+  exit 1
+fi

--- a/workspace/skills/youtube-shorts/scripts/analyze-segments.sh
+++ b/workspace/skills/youtube-shorts/scripts/analyze-segments.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Analyze video transcript and identify interesting segments using Ollama
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: analyze-segments.sh <video_file> [model] [target_duration] [youtube_url]
+
+Analyzes video transcript and returns JSON with recommended segments for shorts.
+EOF
+  exit 2
+}
+
+if [[ "${1:-}" == "" || "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+fi
+
+VIDEO_FILE="${1:-}"
+MODEL="${2:-}"
+TARGET_DURATION="${3:-60}"
+YOUTUBE_URL="${4:-${YOUTUBE_URL:-}}"
+
+if [[ ! -f "$VIDEO_FILE" ]]; then
+  echo "Error: Video file not found: $VIDEO_FILE" >&2
+  exit 1
+fi
+
+# Get video duration using ffprobe
+if ! command -v ffprobe &> /dev/null; then
+  echo "Error: ffprobe not found. Install ffmpeg: brew install ffmpeg" >&2
+  exit 1
+fi
+
+VIDEO_DURATION=$(ffprobe -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 "$VIDEO_FILE" | cut -d. -f1)
+VIDEO_DURATION=${VIDEO_DURATION:-0}
+
+if [[ $VIDEO_DURATION -eq 0 ]]; then
+  echo "Error: Could not determine video duration" >&2
+  exit 1
+fi
+
+# Try to extract transcript using yt-dlp (if available)
+TRANSCRIPT_FILE=$(mktemp)
+TRANSCRIPT_AVAILABLE=false
+
+# First try: Extract transcript from YouTube URL if available
+if command -v yt-dlp &> /dev/null && [[ -n "${YOUTUBE_URL:-}" ]]; then
+  echo "Extracting transcript from YouTube..." >&2
+  # Try to get transcript using yt-dlp
+  if yt-dlp --skip-download --write-auto-sub --sub-lang en --sub-format vtt --output "$TRANSCRIPT_FILE" "$YOUTUBE_URL" 2>/dev/null; then
+    # Convert VTT to plain text
+    if [[ -f "${TRANSCRIPT_FILE}.en.vtt" ]]; then
+      # Extract text from VTT, remove timestamps and formatting
+      grep -v "^[0-9]" "${TRANSCRIPT_FILE}.en.vtt" | grep -v "^WEBVTT" | grep -v "^$" | sed 's/<[^>]*>//g' | tr '\n' ' ' > "$TRANSCRIPT_FILE" 2>/dev/null
+      if [[ -s "$TRANSCRIPT_FILE" ]]; then
+        TRANSCRIPT_AVAILABLE=true
+        echo "✅ Transcript extracted" >&2
+      fi
+      rm -f "${TRANSCRIPT_FILE}.en.vtt" 2>/dev/null
+    fi
+  fi
+fi
+
+# Fallback: Use summarize.sh if available
+if [[ "$TRANSCRIPT_AVAILABLE" != "true" ]] && command -v summarize &> /dev/null && [[ -n "${YOUTUBE_URL:-}" ]]; then
+  echo "Trying summarize.sh for transcript..." >&2
+  if summarize "$YOUTUBE_URL" --youtube auto --extract-only > "$TRANSCRIPT_FILE" 2>/dev/null; then
+    if [[ -s "$TRANSCRIPT_FILE" ]]; then
+      TRANSCRIPT_AVAILABLE=true
+      echo "✅ Transcript extracted via summarize" >&2
+    fi
+  fi
+fi
+
+# Determine Ollama endpoint
+OLLAMA_BASE="${OLLAMA_BASE:-http://127.0.0.1:11434}"
+if [[ "$OLLAMA_BASE" == "http://host.docker.internal:11434" ]]; then
+  # Docker environment
+  OLLAMA_BASE="http://host.docker.internal:11434"
+fi
+
+# Auto-detect model if not provided
+if [[ -z "$MODEL" ]]; then
+  if command -v ollama &> /dev/null; then
+    # Try to list models and pick the first tool-capable one
+    AVAILABLE_MODELS=$(ollama list 2>/dev/null | awk 'NR>1 {print $1}' | head -1 || echo "")
+    if [[ -n "$AVAILABLE_MODELS" ]]; then
+      MODEL="$AVAILABLE_MODELS"
+    else
+      MODEL="llama3.3"
+    fi
+  else
+    MODEL="llama3.3"
+  fi
+fi
+
+# Remove "ollama/" prefix if present
+MODEL=$(echo "$MODEL" | sed 's|^ollama/||')
+
+# Create analysis prompt with better instructions
+TRANSCRIPT_TEXT=""
+if [[ "$TRANSCRIPT_AVAILABLE" == "true" ]]; then
+  TRANSCRIPT_TEXT=$(cat "$TRANSCRIPT_FILE" | head -c 4000)
+fi
+
+# Build prompt safely to avoid quote issues - escape single quotes in transcript
+if [[ "$TRANSCRIPT_AVAILABLE" == "true" ]] && [[ -n "$TRANSCRIPT_TEXT" ]]; then
+  ESCAPED_TRANSCRIPT=$(printf '%s\n' "$TRANSCRIPT_TEXT" | sed "s/'/'\"'\"'/g")
+  TRANSCRIPT_PART="Full transcript: ${ESCAPED_TRANSCRIPT}
+
+"
+else
+  TRANSCRIPT_PART=""
+fi
+
+PROMPT=$(cat <<EOF
+You are analyzing a YouTube video to find the BEST ${TARGET_DURATION}-second segment for a YouTube Short that will maximize engagement and retention.
+
+Video duration: ${VIDEO_DURATION} seconds
+Target segment length: ${TARGET_DURATION} seconds
+
+${TRANSCRIPT_PART}
+
+CRITICAL INSTRUCTIONS:
+1. **AVOID THE INTRO** - Skip the first 10-15 seconds (usually just greetings/introductions)
+2. Find segments with:
+   - A strong hook or attention-grabbing statement
+   - High-value content (tips, insights, revelations, key moments)
+   - Emotional peaks (surprise, excitement, controversy)
+   - Visual interest or action
+   - Self-contained narratives that don't need context
+3. **Prefer middle-to-end segments** over intro segments
+4. Look for moments where the speaker:
+   - Reveals something important
+   - Shares a key insight or tip
+   - Tells an interesting story
+   - Demonstrates something visually engaging
+   - Has high energy or emotion
+
+Analyze the ENTIRE video and identify the SINGLE BEST ${TARGET_DURATION}-second segment that would perform best as a YouTube Short.
+
+Return JSON in this exact format:
+{
+  "segments": [
+    {
+      "start": <start_time_in_seconds_as_number>,
+      "end": <end_time_in_seconds_as_number>,
+      "reason": "<specific explanation of why this segment is engaging>"
+    }
+  ]
+}
+
+CRITICAL INSTRUCTIONS:
+1. **AVOID THE INTRO** - Skip the first 10-15 seconds (usually just greetings/introductions)
+2. Find segments with:
+   - A strong hook or attention-grabbing statement
+   - High-value content (tips, insights, revelations, key moments)
+   - Emotional peaks (surprise, excitement, controversy)
+   - Visual interest or action
+   - Self-contained narratives that don't need context
+3. **Prefer middle-to-end segments** over intro segments
+4. Look for moments where the speaker:
+   - Reveals something important
+   - Shares a key insight or tip
+   - Tells an interesting story
+   - Demonstrates something visually engaging
+   - Has high energy or emotion
+
+Analyze the ENTIRE video and identify the SINGLE BEST ${TARGET_DURATION}-second segment that would perform best as a YouTube Short.
+
+Return JSON in this exact format:
+{
+  "segments": [
+    {
+      "start": <start_time_in_seconds_as_number>,
+      "end": <end_time_in_seconds_as_number>,
+      "reason": "<specific explanation of why this segment is engaging>"
+    }
+  ]
+}
+
+${TRANSCRIPT_AVAILABLE:+Use the transcript timestamps to find the exact moment.}${TRANSCRIPT_AVAILABLE:-If no transcript is available, suggest a segment starting around 30% through the video (around $(($VIDEO_DURATION * 30 / 100)) seconds), avoiding the intro.}
+EOF
+)
+
+# Call Ollama API
+PROMPT_JSON=$(echo "$PROMPT" | jq -Rs .)
+RESPONSE=$(curl -s "${OLLAMA_BASE}/api/generate" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"model\": \"${MODEL}\",
+    \"prompt\": ${PROMPT_JSON},
+    \"stream\": false,
+    \"options\": {
+      \"temperature\": 0.7,
+      \"num_predict\": 500
+    }
+  }" 2>/dev/null || echo "")
+
+if [[ -z "$RESPONSE" ]]; then
+  echo "Error: Failed to connect to Ollama at $OLLAMA_BASE" >&2
+  echo "Make sure Ollama is running and accessible." >&2
+  exit 1
+fi
+
+# Extract JSON from response
+JSON_RESPONSE=$(echo "$RESPONSE" | jq -r '.response' 2>/dev/null || echo "")
+
+# Try to extract JSON object from the response
+if echo "$JSON_RESPONSE" | jq -e '.segments' > /dev/null 2>&1; then
+  echo "$JSON_RESPONSE" | jq '.segments'
+else
+  # Fallback: try to parse JSON from the text
+  EXTRACTED_JSON=$(echo "$JSON_RESPONSE" | grep -o '{[^}]*"segments"[^}]*}' | head -1 || echo "")
+  if [[ -n "$EXTRACTED_JSON" ]]; then
+    echo "$EXTRACTED_JSON" | jq '.segments'
+  else
+    # Ultimate fallback: return first segment
+    cat <<EOF
+{
+  "segments": [
+    {
+      "start": 0,
+      "end": ${TARGET_DURATION},
+      "reason": "Fallback: first ${TARGET_DURATION} seconds"
+    }
+  ]
+}
+EOF
+  fi
+fi
+
+rm -f "$TRANSCRIPT_FILE"

--- a/workspace/skills/youtube-shorts/scripts/create-short-format.sh
+++ b/workspace/skills/youtube-shorts/scripts/create-short-format.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Create YouTube Shorts format video (9:16 aspect ratio, vertical)
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: create-short-format.sh <input_video> <start_time> <duration> [output_file]
+
+Creates a YouTube Shorts format video:
+- 9:16 aspect ratio (vertical)
+- Duration: <duration> seconds (max 60)
+- Starts at <start_time> (seconds or HH:MM:SS format)
+
+Parameters:
+  input_video   Source video file
+  start_time    Start timestamp (seconds or HH:MM:SS)
+  duration      Duration in seconds (max 60)
+  output_file   Output path (optional, auto-generated if not provided)
+EOF
+  exit 2
+}
+
+if [[ "${1:-}" == "" || "${2:-}" == "" || "${3:-}" == "" ]]; then
+  usage
+fi
+
+INPUT_VIDEO="${1:-}"
+START_TIME="${2:-}"
+DURATION="${3:-60}"
+OUTPUT_FILE="${4:-}"
+
+if [[ ! -f "$INPUT_VIDEO" ]]; then
+  echo "Error: Input video not found: $INPUT_VIDEO" >&2
+  exit 1
+fi
+
+if ! command -v ffmpeg &> /dev/null; then
+  echo "Error: ffmpeg not found. Install with: brew install ffmpeg" >&2
+  exit 1
+fi
+
+# Validate duration (simple integer comparison)
+if [[ $DURATION -gt 60 ]]; then
+  echo "Warning: YouTube Shorts must be ≤60 seconds. Clamping to 60." >&2
+  DURATION=60
+fi
+
+# Convert start_time to seconds if it's in HH:MM:SS format
+if [[ "$START_TIME" =~ ^[0-9]+:[0-9]+:[0-9]+$ ]]; then
+  # HH:MM:SS format
+  IFS=':' read -r hours minutes seconds <<< "$START_TIME"
+  START_TIME=$((hours * 3600 + minutes * 60 + seconds))
+fi
+
+# Generate output filename if not provided
+if [[ -z "$OUTPUT_FILE" ]]; then
+  BASE_NAME=$(basename "$INPUT_VIDEO" .mp4)
+  OUTPUT_DIR=$(dirname "$INPUT_VIDEO")
+  OUTPUT_FILE="$OUTPUT_DIR/${BASE_NAME}_short_${START_TIME}s_${DURATION}s.mp4"
+fi
+
+mkdir -p "$(dirname "$OUTPUT_FILE")"
+
+echo "Creating short format video..."
+echo "  Input: $INPUT_VIDEO"
+echo "  Start: ${START_TIME}s"
+echo "  Duration: ${DURATION}s"
+echo "  Output: $OUTPUT_FILE"
+
+# Target aspect ratio: 9:16 (vertical)
+TARGET_WIDTH=1080
+TARGET_HEIGHT=1920
+
+# Use ffmpeg to create the short with smart cropping
+# The scale filter with crop will automatically handle aspect ratio conversion
+# This approach scales to fit 9:16, then crops to exact dimensions (centered)
+ffmpeg -hide_banner -loglevel warning -y \
+  -ss "$START_TIME" \
+  -i "$INPUT_VIDEO" \
+  -t "$DURATION" \
+  -vf "scale=${TARGET_WIDTH}:${TARGET_HEIGHT}:force_original_aspect_ratio=increase,crop=${TARGET_WIDTH}:${TARGET_HEIGHT},scale=${TARGET_WIDTH}:${TARGET_HEIGHT}" \
+  -c:v libx264 \
+  -preset medium \
+  -crf 23 \
+  -c:a aac \
+  -b:a 128k \
+  -movflags +faststart \
+  "$OUTPUT_FILE"
+
+if [[ -f "$OUTPUT_FILE" ]]; then
+  echo "✅ Created short: $OUTPUT_FILE"
+  echo "$OUTPUT_FILE"
+else
+  echo "Error: Failed to create short video" >&2
+  exit 1
+fi

--- a/workspace/skills/youtube-shorts/scripts/create-short.sh
+++ b/workspace/skills/youtube-shorts/scripts/create-short.sh
@@ -1,0 +1,303 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# YouTube Shorts Creator - Main workflow script
+# Downloads, analyzes, and creates YouTube Shorts from YouTube videos
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BASE_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: create-short.sh <youtube_url> [options]
+
+Options:
+  --duration <seconds>    Target duration (default: 60, max: 60)
+  --model <model>         Ollama model (default: auto-detect)
+  --start <timestamp>     Manual start time (HH:MM:SS or seconds)
+  --output <path>         Output file path (default: auto-generated)
+  --no-upload            Skip YouTube upload
+  --keep-files           Keep intermediate files
+  --no-captions          Skip adding captions (default: captions enabled)
+
+Examples:
+  create-short.sh 'https://youtube.com/watch?v=VIDEO_ID'
+  create-short.sh 'https://youtube.com/watch?v=VIDEO_ID' --duration 45
+  create-short.sh 'https://youtube.com/watch?v=VIDEO_ID' --start 120 --duration 60
+EOF
+  exit 2
+}
+
+if [[ "${1:-}" == "" || "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+fi
+
+YOUTUBE_URL="${1:-}"
+shift || true
+
+DURATION=60
+MODEL=""
+START_TIME=""
+OUTPUT_FILE=""
+NO_UPLOAD=false
+KEEP_FILES=false
+ADD_CAPTIONS=true
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --duration)
+      DURATION="${2:-}"
+      shift 2
+      ;;
+    --model)
+      MODEL="${2:-}"
+      shift 2
+      ;;
+    --start)
+      START_TIME="${2:-}"
+      shift 2
+      ;;
+    --output)
+      OUTPUT_FILE="${2:-}"
+      shift 2
+      ;;
+    --no-upload)
+      NO_UPLOAD=true
+      shift
+      ;;
+    --keep-files)
+      KEEP_FILES=true
+      shift
+      ;;
+    --no-captions)
+      ADD_CAPTIONS=false
+      shift
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage
+      ;;
+  esac
+done
+
+# Export YouTube URL for transcript extraction
+export YOUTUBE_URL
+
+# Validate duration
+if [[ $DURATION -gt 60 ]]; then
+  echo "Warning: YouTube Shorts must be ≤60 seconds. Clamping to 60." >&2
+  DURATION=60
+fi
+
+# Setup directories
+OUTPUT_DIR="${YOUTUBE_SHORTS_OUTPUT_DIR:-$HOME/.openclaw/workspace/youtube-shorts}"
+TEMP_DIR="${OUTPUT_DIR}/temp/$(date +%s)"
+mkdir -p "$TEMP_DIR"
+mkdir -p "$OUTPUT_DIR"
+
+cleanup() {
+  if [[ "$KEEP_FILES" != "true" ]]; then
+    rm -rf "$TEMP_DIR"
+  else
+    echo "Keeping intermediate files in: $TEMP_DIR"
+  fi
+}
+trap cleanup EXIT
+
+echo "📥 Step 1: Downloading video..."
+DOWNLOADED_VIDEO="$TEMP_DIR/video.mp4"
+if ! "$SCRIPT_DIR/download-video.sh" "$YOUTUBE_URL" "$TEMP_DIR"; then
+  echo "Error: Failed to download video" >&2
+  exit 1
+fi
+
+# Find the downloaded video file
+if [[ -f "$TEMP_DIR/video.mp4" ]]; then
+  DOWNLOADED_VIDEO="$TEMP_DIR/video.mp4"
+elif [[ -f "$TEMP_DIR"/*.mp4 ]]; then
+  DOWNLOADED_VIDEO=$(ls "$TEMP_DIR"/*.mp4 | head -1)
+else
+  echo "Error: Could not find downloaded video file" >&2
+  exit 1
+fi
+
+echo "✅ Downloaded: $DOWNLOADED_VIDEO"
+
+# Extract transcript VTT for sentence boundary detection
+TRANSCRIPT_VTT=""
+if [[ -n "$YOUTUBE_URL" ]] && command -v yt-dlp &> /dev/null; then
+  echo "📝 Extracting transcript for sentence boundary detection..." >&2
+  TEMP_VTT_BASE=$(mktemp)
+  if yt-dlp --skip-download --write-auto-sub --sub-lang en --sub-format vtt --output "$TEMP_VTT_BASE" "$YOUTUBE_URL" 2>/dev/null; then
+    if [[ -f "${TEMP_VTT_BASE}.en.vtt" ]]; then
+      TRANSCRIPT_VTT="${TEMP_VTT_BASE}.en.vtt"
+      echo "✅ Transcript extracted" >&2
+    fi
+  fi
+fi
+
+# Determine start time
+if [[ -z "$START_TIME" ]]; then
+  echo "🤖 Step 2: Analyzing video with Ollama to find best segment..."
+  SEGMENT_JSON="$TEMP_DIR/segments.json"
+  export YOUTUBE_URL
+  if ! "$SCRIPT_DIR/analyze-segments.sh" "$DOWNLOADED_VIDEO" "${MODEL:-}" "$DURATION" "$YOUTUBE_URL" > "$SEGMENT_JSON"; then
+    echo "Warning: AI analysis failed" >&2
+    # Smart fallback: use middle section instead of intro
+    VIDEO_DURATION=$(ffprobe -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 "$DOWNLOADED_VIDEO" 2>/dev/null | cut -d. -f1 || echo "0")
+    if [[ $VIDEO_DURATION -gt $((DURATION * 2)) ]]; then
+      # Start at 25% through the video (skip intro, get to content)
+      START_TIME=$((VIDEO_DURATION * 25 / 100))
+      echo "📊 Using smart fallback: starting at ${START_TIME}s (25% through video)" >&2
+    else
+      START_TIME=0
+      echo "Warning: Video too short, using first ${DURATION}s" >&2
+    fi
+  else
+    # Extract start time from JSON
+    if command -v jq &> /dev/null; then
+      START_TIME=$(jq -r '.segments[0].start // 0' "$SEGMENT_JSON" 2>/dev/null || echo "0")
+      # Validate start time (ensure it's not just the intro)
+      if [[ $START_TIME -lt 10 ]]; then
+        echo "⚠️  Analysis suggested intro (${START_TIME}s), using smarter fallback" >&2
+        VIDEO_DURATION=$(ffprobe -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 "$DOWNLOADED_VIDEO" 2>/dev/null | cut -d. -f1 || echo "0")
+        if [[ $VIDEO_DURATION -gt $((DURATION * 2)) ]]; then
+          START_TIME=$((VIDEO_DURATION * 30 / 100))
+          echo "📊 Using segment starting at ${START_TIME}s (30% through video)" >&2
+        fi
+      else
+        echo "📊 Recommended segment: starts at ${START_TIME}s"
+      fi
+    else
+      echo "Warning: jq not found, using smart fallback" >&2
+      VIDEO_DURATION=$(ffprobe -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 "$DOWNLOADED_VIDEO" 2>/dev/null | cut -d. -f1 || echo "0")
+      START_TIME=$((VIDEO_DURATION * 25 / 100))
+    fi
+  fi
+fi
+
+# Step 2.5: Adjust duration to complete sentences (dynamic duration)
+if [[ -n "$TRANSCRIPT_VTT" ]] && [[ -f "$TRANSCRIPT_VTT" ]]; then
+  echo "🔍 Finding sentence boundary to avoid cutting mid-sentence..."
+  ADJUSTED_DURATION=$("$SCRIPT_DIR/find-sentence-boundary.sh" "$TRANSCRIPT_VTT" "$START_TIME" "$DURATION")
+  if [[ $ADJUSTED_DURATION -ne $DURATION ]] && [[ $ADJUSTED_DURATION -le 60 ]]; then
+    echo "📏 Adjusted duration from ${DURATION}s to ${ADJUSTED_DURATION}s to complete sentence"
+    DURATION=$ADJUSTED_DURATION
+  elif [[ $ADJUSTED_DURATION -gt 60 ]]; then
+    echo "⚠️  Sentence completion would exceed 60s limit, using ${DURATION}s"
+  fi
+fi
+
+# Generate output filename
+if [[ -z "$OUTPUT_FILE" ]]; then
+  VIDEO_ID=$(echo "$YOUTUBE_URL" | sed -E 's/.*[?&]v=([^&]*).*/\1/' || echo "video")
+  OUTPUT_FILE="$OUTPUT_DIR/short_${VIDEO_ID}_$(date +%Y%m%d_%H%M%S).mp4"
+fi
+
+echo "✂️  Step 3: Creating short format (9:16, ${DURATION}s)..."
+SHORT_NO_CAPTIONS="${OUTPUT_FILE%.mp4}_nocaptions.mp4"
+if ! "$SCRIPT_DIR/create-short-format.sh" "$DOWNLOADED_VIDEO" "$START_TIME" "$DURATION" "$SHORT_NO_CAPTIONS"; then
+  echo "Error: Failed to create short format" >&2
+  exit 1
+fi
+
+# Step 4: Add captions if requested
+if [[ "$ADD_CAPTIONS" == "true" ]]; then
+  echo "📝 Step 4: Adding bold captions..."
+  # Pass the transcript VTT file path if available
+  if [[ -n "$TRANSCRIPT_VTT" ]] && [[ -f "$TRANSCRIPT_VTT" ]]; then
+    # Create a temporary VTT file adjusted for the segment
+    ADJUSTED_VTT="$TEMP_DIR/adjusted_subtitles.vtt"
+    if command -v python3 &> /dev/null; then
+      python3 <<PYTHON_ADJUST > "$ADJUSTED_VTT"
+import re
+
+start_offset = $START_TIME
+try:
+    with open("$TRANSCRIPT_VTT", 'r', encoding='utf-8', errors='ignore') as f:
+        content = f.read()
+        # Adjust timestamps by subtracting start_offset
+        def adjust_timestamp(match):
+            h, m, s, ms = map(int, match.groups()[:4])
+            total_sec = h * 3600 + m * 60 + s + ms / 1000.0
+            if total_sec < start_offset:
+                return ""
+            adjusted_sec = total_sec - start_offset
+            if adjusted_sec > $DURATION:
+                return ""
+            new_h = int(adjusted_sec // 3600)
+            new_m = int((adjusted_sec % 3600) // 60)
+            new_s = int(adjusted_sec % 60)
+            new_ms = int((adjusted_sec % 1) * 1000)
+            return f"{new_h:02d}:{new_m:02d}:{new_s:02d}.{new_ms:03d}"
+        
+        # Adjust all timestamps
+        pattern = r'(\d{2}):(\d{2}):(\d{2})\.(\d{3})\s*-->\s*(\d{2}):(\d{2}):(\d{2})\.(\d{3})'
+        adjusted = re.sub(pattern, lambda m: adjust_timestamp(m) + " --> " + adjust_timestamp(re.match(r'(\d{2}):(\d{2}):(\d{2})\.(\d{3})', m.group(5) + ":" + m.group(6) + ":" + m.group(7) + "." + m.group(8))) if m.group(5) else "", content)
+        print(adjusted)
+except:
+    pass
+PYTHON_ADJUST
+      if [[ -s "$ADJUSTED_VTT" ]]; then
+        # Use adjusted VTT for captions (pass as 4th parameter)
+        TRANSCRIPT_VTT_ARG="$ADJUSTED_VTT"
+      else
+        TRANSCRIPT_VTT_ARG=""
+      fi
+    else
+      TRANSCRIPT_VTT_ARG=""
+    fi
+    
+    # Call add-captions with VTT file if available
+    if [[ -n "$TRANSCRIPT_VTT_ARG" ]] && [[ -f "$TRANSCRIPT_VTT_ARG" ]]; then
+      # Use provided VTT file
+      if ! "$SCRIPT_DIR/add-captions.sh" "$SHORT_NO_CAPTIONS" "" "$OUTPUT_FILE" "$TRANSCRIPT_VTT_ARG"; then
+        echo "Warning: Failed to add captions with provided VTT, trying YouTube extraction" >&2
+        if ! "$SCRIPT_DIR/add-captions.sh" "$SHORT_NO_CAPTIONS" "$YOUTUBE_URL" "$OUTPUT_FILE"; then
+          echo "Warning: Failed to add captions, using video without captions" >&2
+          mv "$SHORT_NO_CAPTIONS" "$OUTPUT_FILE"
+        else
+          rm -f "$SHORT_NO_CAPTIONS"
+        fi
+      else
+        rm -f "$SHORT_NO_CAPTIONS"
+      fi
+    else
+      # Use original method (extract from YouTube)
+      if ! "$SCRIPT_DIR/add-captions.sh" "$SHORT_NO_CAPTIONS" "$YOUTUBE_URL" "$OUTPUT_FILE"; then
+        echo "Warning: Failed to add captions, using video without captions" >&2
+        mv "$SHORT_NO_CAPTIONS" "$OUTPUT_FILE"
+      else
+        rm -f "$SHORT_NO_CAPTIONS"
+      fi
+    fi
+  else
+    # No transcript VTT, use original method
+    if ! "$SCRIPT_DIR/add-captions.sh" "$SHORT_NO_CAPTIONS" "$YOUTUBE_URL" "$OUTPUT_FILE"; then
+      echo "Warning: Failed to add captions, using video without captions" >&2
+      mv "$SHORT_NO_CAPTIONS" "$OUTPUT_FILE"
+    else
+      rm -f "$SHORT_NO_CAPTIONS"
+    fi
+  fi
+else
+  mv "$SHORT_NO_CAPTIONS" "$OUTPUT_FILE"
+fi
+
+echo "✅ Created short: $OUTPUT_FILE"
+
+# Upload if requested
+if [[ "$NO_UPLOAD" != "true" ]] && [[ -n "${YOUTUBE_CLIENT_ID:-}" ]] && [[ -n "${YOUTUBE_CLIENT_SECRET:-}" ]]; then
+  echo "📤 Step 5: Uploading to YouTube..."
+  TITLE="Short from $(basename "$OUTPUT_FILE" .mp4)"
+  if ! "$SCRIPT_DIR/upload-youtube.sh" "$OUTPUT_FILE" "$TITLE"; then
+    echo "Warning: Upload failed, but video is ready at: $OUTPUT_FILE" >&2
+  else
+    echo "✅ Uploaded successfully!"
+  fi
+else
+  echo "ℹ️  Skipping upload (use --no-upload to suppress this message, or configure YouTube API)"
+fi
+
+echo ""
+echo "🎉 Success! Short created at: $OUTPUT_FILE"

--- a/workspace/skills/youtube-shorts/scripts/download-video.sh
+++ b/workspace/skills/youtube-shorts/scripts/download-video.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Download YouTube video using yt-dlp
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: download-video.sh <youtube_url> [output_dir]
+
+Downloads a YouTube video and saves it as video.mp4 in the output directory.
+EOF
+  exit 2
+}
+
+if [[ "${1:-}" == "" || "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+fi
+
+YOUTUBE_URL="${1:-}"
+OUTPUT_DIR="${2:-$(pwd)}"
+
+if ! command -v yt-dlp &> /dev/null; then
+  echo "Error: yt-dlp not found. Install with: brew install yt-dlp" >&2
+  exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR"
+
+echo "Downloading: $YOUTUBE_URL"
+
+# Download video (best quality MP4, or best available)
+yt-dlp \
+  --format "bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best" \
+  --merge-output-format mp4 \
+  --output "$OUTPUT_DIR/video.%(ext)s" \
+  --no-playlist \
+  "$YOUTUBE_URL"
+
+# Find the downloaded file
+if [[ -f "$OUTPUT_DIR/video.mp4" ]]; then
+  echo "$OUTPUT_DIR/video.mp4"
+elif [[ -f "$OUTPUT_DIR"/*.mp4 ]]; then
+  ls "$OUTPUT_DIR"/*.mp4 | head -1
+else
+  echo "Error: Could not find downloaded video" >&2
+  exit 1
+fi

--- a/workspace/skills/youtube-shorts/scripts/find-sentence-boundary.sh
+++ b/workspace/skills/youtube-shorts/scripts/find-sentence-boundary.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Find the next sentence boundary after a given timestamp to avoid cutting mid-sentence
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: find-sentence-boundary.sh <vtt_file> <start_time_seconds> <max_duration>
+
+Finds the end of the last complete sentence within max_duration from start_time.
+Returns the adjusted duration that completes the sentence.
+EOF
+  exit 2
+}
+
+if [[ "${1:-}" == "" || "${2:-}" == "" || "${3:-}" == "" ]]; then
+  usage
+fi
+
+VTT_FILE="${1:-}"
+START_TIME="${2:-0}"
+MAX_DURATION="${3:-60}"
+
+if [[ ! -f "$VTT_FILE" ]]; then
+  echo "$MAX_DURATION"  # Return max duration if no VTT file
+  exit 0
+fi
+
+# Convert start_time to seconds if needed
+if [[ "$START_TIME" =~ ^[0-9]+:[0-9]+:[0-9]+$ ]]; then
+  IFS=':' read -r hours minutes seconds <<< "$START_TIME"
+  START_TIME=$((hours * 3600 + minutes * 60 + seconds))
+fi
+
+END_TIME=$((START_TIME + MAX_DURATION))
+TARGET_END=$END_TIME
+
+# Parse VTT file to find sentence boundaries
+# Look for timestamps and text that ends with sentence punctuation
+if command -v python3 &> /dev/null; then
+  python3 <<PYTHON_SCRIPT
+import re
+import sys
+
+start_time = $START_TIME
+max_end = $END_TIME
+target_end = max_end
+
+try:
+    segments = []
+    current_text = ""
+    current_start_sec = 0
+    current_end_sec = 0
+    
+    with open("$VTT_FILE", 'r', encoding='utf-8', errors='ignore') as f:
+        for line in f:
+            line = line.strip()
+            if not line or line == "WEBVTT" or re.match(r'^NOTE', line) or re.match(r'^\d+$', line):
+                continue
+            
+            # Match timestamp: 00:00:00.000 --> 00:00:05.000
+            timestamp_match = re.match(r'(\d{2}):(\d{2}):(\d{2})\.(\d{3})\s*-->\s*(\d{2}):(\d{2}):(\d{2})\.(\d{3})', line)
+            if timestamp_match:
+                # Save previous segment if exists
+                if current_text:
+                    segments.append({
+                        'start': current_start_sec,
+                        'end': current_end_sec,
+                        'text': current_text
+                    })
+                
+                # Convert timestamp to seconds
+                h1, m1, s1, ms1 = map(int, timestamp_match.groups()[:4])
+                h2, m2, s2, ms2 = map(int, timestamp_match.groups()[4:])
+                current_start_sec = h1 * 3600 + m1 * 60 + s1 + ms1 / 1000.0
+                current_end_sec = h2 * 3600 + m2 * 60 + s2 + ms2 / 1000.0
+                current_text = ""
+            else:
+                # Accumulate text
+                clean_line = re.sub(r'<[^>]+>', '', line)
+                if clean_line:
+                    current_text += " " + clean_line if current_text else clean_line
+        
+        # Add last segment
+        if current_text:
+            segments.append({
+                'start': current_start_sec,
+                'end': current_end_sec,
+                'text': current_text
+            })
+    
+    # Find the best sentence boundary
+    best_end = start_time + $MAX_DURATION
+    
+    for seg in segments:
+        seg_start = seg['start']
+        seg_end = seg['end']
+        text = seg['text']
+        
+        # Check if segment overlaps with our time range
+        if seg_start < start_time + $MAX_DURATION and seg_end > start_time:
+            # Check for sentence endings
+            # Look for punctuation followed by space or end of text
+            sentences = re.split(r'([.!?]+[\s\n]*)', text)
+            
+            # Reconstruct sentences with punctuation
+            full_sentences = []
+            for i in range(0, len(sentences) - 1, 2):
+                if i + 1 < len(sentences):
+                    full_sentences.append(sentences[i] + sentences[i + 1])
+                else:
+                    full_sentences.append(sentences[i])
+            
+            # Find where complete sentences end
+            cumulative_length = 0
+            for sentence in full_sentences:
+                if sentence.strip() and re.search(r'[.!?]', sentence):
+                    # This is a complete sentence
+                    # Estimate its end time proportionally
+                    sentence_ratio = len(sentence) / len(text) if text else 0
+                    sentence_end = seg_start + (seg_end - seg_start) * (cumulative_length + len(sentence)) / len(text) if text else seg_end
+                    
+                    if sentence_end <= start_time + $MAX_DURATION and sentence_end > start_time:
+                        best_end = max(best_end, sentence_end)
+                    
+                    cumulative_length += len(sentence)
+                else:
+                    cumulative_length += len(sentence)
+            
+            # Also check if the entire segment ends with sentence punctuation
+            if re.search(r'[.!?]\s*$', text.strip()):
+                if seg_end <= start_time + $MAX_DURATION:
+                    best_end = max(best_end, seg_end)
+    
+    # Calculate duration (ensure it's within limits)
+    duration = best_end - start_time
+    duration = max(1, min(int(duration), $MAX_DURATION))
+    print(duration)
+        
+except Exception as e:
+    # Fallback: return max duration
+    print($MAX_DURATION)
+PYTHON_SCRIPT
+else
+  # Fallback: return max duration
+  echo "$MAX_DURATION"
+fi

--- a/workspace/skills/youtube-shorts/scripts/upload-youtube.sh
+++ b/workspace/skills/youtube-shorts/scripts/upload-youtube.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Upload video to YouTube using YouTube Data API v3
+# Requires OAuth2 credentials
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: upload-youtube.sh <video_file> <title> [description] [tags]
+
+Uploads a video to YouTube using YouTube Data API v3.
+
+Required environment variables:
+  YOUTUBE_CLIENT_ID       OAuth2 client ID
+  YOUTUBE_CLIENT_SECRET   OAuth2 client secret
+  YOUTUBE_REFRESH_TOKEN   OAuth2 refresh token
+
+To obtain credentials:
+1. Go to https://console.cloud.google.com/
+2. Create a project and enable YouTube Data API v3
+3. Create OAuth2 credentials
+4. Use OAuth2 flow to get refresh token
+EOF
+  exit 2
+}
+
+if [[ "${1:-}" == "" || "${2:-}" == "" ]]; then
+  usage
+fi
+
+VIDEO_FILE="${1:-}"
+TITLE="${2:-}"
+DESCRIPTION="${3:-YouTube Short created with OpenClaw}"
+TAGS="${4:-shorts,openclaw}"
+
+if [[ ! -f "$VIDEO_FILE" ]]; then
+  echo "Error: Video file not found: $VIDEO_FILE" >&2
+  exit 1
+fi
+
+# Check for required environment variables
+if [[ -z "${YOUTUBE_CLIENT_ID:-}" ]] || [[ -z "${YOUTUBE_CLIENT_SECRET:-}" ]]; then
+  echo "Error: YOUTUBE_CLIENT_ID and YOUTUBE_CLIENT_SECRET must be set" >&2
+  echo ""
+  usage
+  exit 1
+fi
+
+# Check for Python (needed for YouTube API)
+if ! command -v python3 &> /dev/null; then
+  echo "Error: python3 not found. YouTube upload requires Python." >&2
+  echo "Install Python or skip upload with --no-upload flag" >&2
+  exit 1
+fi
+
+# Check if google-api-python-client is installed
+if ! python3 -c "import googleapiclient.discovery" 2>/dev/null; then
+  echo "Installing required Python packages..."
+  pip3 install --user google-api-python-client google-auth-httplib2 google-auth-oauthlib 2>&1 | grep -v "already satisfied" || true
+fi
+
+# Create a temporary Python script for upload
+UPLOAD_SCRIPT=$(mktemp)
+cat > "$UPLOAD_SCRIPT" <<'PYTHON_SCRIPT'
+import os
+import sys
+from googleapiclient.discovery import build
+from googleapiclient.http import MediaFileUpload
+from google_auth_oauthlib.flow import InstalledAppFlow
+from google.auth.transport.requests import Request
+import pickle
+
+SCOPES = ['https://www.googleapis.com/auth/youtube.upload']
+
+def get_authenticated_service():
+    client_id = os.environ.get('YOUTUBE_CLIENT_ID')
+    client_secret = os.environ.get('YOUTUBE_CLIENT_SECRET')
+    refresh_token = os.environ.get('YOUTUBE_REFRESH_TOKEN')
+    
+    if not all([client_id, client_secret]):
+        print("Error: YOUTUBE_CLIENT_ID and YOUTUBE_CLIENT_SECRET must be set", file=sys.stderr)
+        sys.exit(1)
+    
+    # Create credentials dict
+    credentials_info = {
+        "installed": {
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+            "token_uri": "https://oauth2.googleapis.com/token",
+            "redirect_uris": ["http://localhost"]
+        }
+    }
+    
+    creds = None
+    token_file = os.path.expanduser('~/.openclaw/youtube_token.pickle')
+    
+    if os.path.exists(token_file):
+        with open(token_file, 'rb') as token:
+            creds = pickle.load(token)
+    
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        elif refresh_token:
+            # Use refresh token to get new access token
+            from google.oauth2.credentials import Credentials
+            creds = Credentials(
+                None,
+                refresh_token=refresh_token,
+                token_uri="https://oauth2.googleapis.com/token",
+                client_id=client_id,
+                client_secret=client_secret
+            )
+            creds.refresh(Request())
+        else:
+            print("Error: No valid credentials. Run OAuth flow or set YOUTUBE_REFRESH_TOKEN", file=sys.stderr)
+            sys.exit(1)
+        
+        os.makedirs(os.path.dirname(token_file), exist_ok=True)
+        with open(token_file, 'wb') as token:
+            pickle.dump(creds, token)
+    
+    return build('youtube', 'v3', credentials=creds)
+
+def upload_video(video_file, title, description, tags):
+    youtube = get_authenticated_service()
+    
+    body = {
+        'snippet': {
+            'title': title,
+            'description': description,
+            'tags': tags.split(',') if tags else [],
+            'categoryId': '24'  # Entertainment
+        },
+        'status': {
+            'privacyStatus': 'private',  # Change to 'public' or 'unlisted' as needed
+            'selfDeclaredMadeForKids': False
+        }
+    }
+    
+    # YouTube Shorts must be marked as such
+    body['snippet']['categoryId'] = '24'
+    
+    media = MediaFileUpload(video_file, chunksize=-1, resumable=True, mimetype='video/mp4')
+    
+    insert_request = youtube.videos().insert(
+        part=','.join(body.keys()),
+        body=body,
+        media_body=media
+    )
+    
+    response = None
+    while response is None:
+        status, response = insert_request.next_chunk()
+        if status:
+            print(f"Upload progress: {int(status.progress() * 100)}%", file=sys.stderr)
+    
+    if 'id' in response:
+        video_id = response['id']
+        print(f"https://www.youtube.com/watch?v={video_id}")
+        return video_id
+    else:
+        print(f"Error: Upload failed: {response}", file=sys.stderr)
+        sys.exit(1)
+
+if __name__ == '__main__':
+    if len(sys.argv) < 3:
+        print("Usage: upload-youtube.py <video_file> <title> [description] [tags]", file=sys.stderr)
+        sys.exit(1)
+    
+    video_file = sys.argv[1]
+    title = sys.argv[2]
+    description = sys.argv[3] if len(sys.argv) > 3 else "YouTube Short created with OpenClaw"
+    tags = sys.argv[4] if len(sys.argv) > 4 else "shorts,openclaw"
+    
+    upload_video(video_file, title, description, tags)
+PYTHON_SCRIPT
+
+# Run the upload script
+python3 "$UPLOAD_SCRIPT" "$VIDEO_FILE" "$TITLE" "$DESCRIPTION" "$TAGS"
+EXIT_CODE=$?
+
+rm -f "$UPLOAD_SCRIPT"
+
+exit $EXIT_CODE


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces an initial `youtube-shorts` skill (docs + shell scripts) and updates the repo’s `docker-compose.yml` to run the gateway with extra runtime-installed dependencies (ffmpeg/jq/yt-dlp) for short creation.

Key issues to address before merge:
- The skill’s frontmatter (`skills/youtube-shorts/SKILL.md`) is not valid YAML as written, which will likely prevent the skill from loading.
- The analyze→create pipeline has a contract mismatch: `analyze-segments.sh` outputs a segments array on the success path, while `create-short.sh` expects a JSON object with a `.segments` field.
- Captions currently require `python3` even when earlier steps attempt to fall back, and the transcript timestamp rewrite can emit invalid VTT, breaking captioning.
- The new `docker-compose.yml` is host-specific (hardcoded `/Users/...` mounts) and runs as root to apt/pip install on startup with errors suppressed, making the default compose brittle/non-portable.
- Docker setup docs include a hardcoded token value in an example; this should be replaced with a placeholder.


<h3>Confidence Score: 2/5</h3>

- This PR has functional blockers that are likely to prevent the new skill from working as intended.
- Score is reduced due to invalid skill YAML frontmatter, a definite JSON shape mismatch between analyze/create scripts, and captioning logic that can hard-fail without python3 or generate invalid VTT. The docker-compose changes are also non-portable and can mask dependency installation failures.
- skills/youtube-shorts/SKILL.md; skills/youtube-shorts/scripts/analyze-segments.sh; skills/youtube-shorts/scripts/create-short.sh; skills/youtube-shorts/scripts/add-captions.sh; docker-compose.yml; skills/youtube-shorts/DOCKER_SETUP.md

<sub>Last reviewed commit: 81a654d</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->