### PR TITLE
fix(config): accept $schema key in root config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 - Exec/Allowlist: allow multiline heredoc bodies (`<<`, `<<-`) while keeping multiline non-heredoc shell commands blocked, so exec approval parsing permits heredoc input safely without allowing general newline command chaining. (#13811) Thanks @mcaxtr.
 - Docs/Mermaid: remove hardcoded Mermaid init theme blocks from four docs diagrams so dark mode inherits readable theme defaults. (#15157) Thanks @heytulsiprasad.
 - Outbound/Threading: pass `replyTo` and `threadId` from `message send` tool actions through the core outbound send path to channel adapters, preserving thread/reply routing. (#14948) Thanks @mcaxtr.
+- Config: accept `$schema` key in config file so JSON Schema editor tooling works without validation errors. (#14998)
 
 ## 2026.2.12
 

--- a/src/config/config.schema-key.test.ts
+++ b/src/config/config.schema-key.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { OpenClawSchema } from "./zod-schema.js";
+
+describe("$schema key in config", () => {
+  it("accepts config with $schema string", () => {
+    const result = OpenClawSchema.safeParse({
+      $schema: "https://openclaw.ai/config.json",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts config without $schema", () => {
+    const result = OpenClawSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects non-string $schema", () => {
+    const result = OpenClawSchema.safeParse({ $schema: 123 });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -94,6 +94,7 @@ const MemorySchema = z
 
 export const OpenClawSchema = z
   .object({
+    $schema: z.string().optional(),
     meta: z
       .object({
         lastTouchedVersion: z.string().optional(),


### PR DESCRIPTION
## Summary

The root config Zod schema uses `.strict()`, which rejects any key not explicitly listed. The standard JSON Schema `$schema` key (used by VS Code, JetBrains, and other editors for auto-completion and validation) was not listed, causing config validation to fail with:

```
<root>: Unrecognized key: "$schema"
```

This prevented users from adding `"$schema": "https://openclaw.ai/config.json"` to their config file.

## Fix

Add `$schema: z.string().optional()` to `OpenClawSchema` so the key is accepted (and ignored at runtime).

## Test

Added `config.schema-key.test.ts` with three cases:
- accepts config with `$schema` string
- accepts config without `$schema`
- rejects non-string `$schema`

All 373 config tests pass.

Closes #14998

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the root config Zod schema (`OpenClawSchema`) to accept an optional JSON Schema metadata field `$schema` (string) while keeping the schema `.strict()` for all other unknown top-level keys.

It also adds a focused test verifying that configs with `$schema` parse successfully, configs without `$schema` still parse successfully, and non-string `$schema` values are rejected. This aligns config validation behavior with common editor tooling expectations (VS Code / JetBrains JSON Schema support) without changing runtime config semantics.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrow (adds a single optional root key) and preserves strict validation for all other fields; accompanying tests exercise the intended acceptance/rejection behavior. No other config validation or schema-generation code paths rely on `$schema` being absent.
- No files require special attention

<sub>Last reviewed commit: 4f2a8a0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->