### PR TITLE
feat: Dynamic thinking level pre-routing based on message complexity

### DIFF
--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -3,6 +3,7 @@ import type { ModelCatalogEntry } from "./model-catalog.js";
 import { resolveAgentModelPrimary } from "./agent-scope.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "./defaults.js";
 import { normalizeGoogleModelId } from "./models-config.providers.js";
+import { routeThinkingLevel, type ThinkingRouterContext } from "./thinking-router.js";
 
 export type ModelRef = {
   provider: string;
@@ -405,7 +406,21 @@ export function resolveThinkingDefault(params: {
   provider: string;
   model: string;
   catalog?: ModelCatalogEntry[];
+  /** User message for dynamic routing (optional). */
+  message?: string;
+  /** Session type for routing context (optional). */
+  sessionType?: ThinkingRouterContext["sessionType"];
 }): ThinkLevel {
+  // Check for dynamic thinking router configuration
+  const routerConfig = params.cfg.agents?.defaults?.thinkingRouter;
+  if (routerConfig?.enabled && params.message) {
+    return routeThinkingLevel(
+      { message: params.message, sessionType: params.sessionType },
+      routerConfig,
+    );
+  }
+
+  // Fall back to static thinkingDefault
   const configured = params.cfg.agents?.defaults?.thinkingDefault;
   if (configured) {
     return configured;

--- a/src/agents/thinking-router.ts
+++ b/src/agents/thinking-router.ts
@@ -102,9 +102,10 @@ export const DEFAULT_MEDIUM_THINKING_KEYWORDS = [
 
 /**
  * Default thinking router configuration.
+ * Note: disabled by default for backward compatibility.
  */
 export const DEFAULT_THINKING_ROUTER_CONFIG: ThinkingRouterConfig = {
-  enabled: true,
+  enabled: false,
   default: "low",
   rules: [
     {
@@ -180,10 +181,14 @@ function matchesRule(
     return false;
   }
 
-  // Regex pattern
+  // Regex pattern (invalid patterns cause rule to not match)
   if (match.pattern) {
     const regex = getOrCreateRegex(match.pattern);
-    if (regex && !regex.test(message)) {
+    if (!regex) {
+      // Invalid regex pattern - rule cannot match
+      return false;
+    }
+    if (!regex.test(message)) {
       return false;
     }
   }

--- a/src/agents/thinking-router.ts
+++ b/src/agents/thinking-router.ts
@@ -1,0 +1,263 @@
+/**
+ * Dynamic thinking level router.
+ * Analyzes incoming messages and determines optimal thinking level.
+ *
+ * @module thinking-router
+ */
+
+import type { ThinkLevel } from "../auto-reply/thinking.js";
+
+export interface ThinkingRouterRule {
+  match: {
+    /** Keywords that trigger this rule (case-insensitive). */
+    keywords?: string[];
+    /** Minimum message length in characters. */
+    minLength?: number;
+    /** Maximum message length in characters. */
+    maxLength?: number;
+    /** Message contains code blocks. */
+    hasCode?: boolean;
+    /** Session type filter. */
+    sessionType?: "main" | "subagent" | "cron";
+    /** Regex pattern to match (string form). */
+    pattern?: string;
+  };
+  /** Thinking level to apply when rule matches. */
+  thinking: ThinkLevel;
+  /** Higher priority rules are checked first (default: 0). */
+  priority?: number;
+}
+
+export interface ThinkingRouterConfig {
+  /** Enable dynamic thinking routing. */
+  enabled?: boolean;
+  /** Default thinking level when no rules match. */
+  default: ThinkLevel;
+  /** Routing rules (checked in priority order). */
+  rules: ThinkingRouterRule[];
+}
+
+export interface ThinkingRouterContext {
+  /** The user's message text. */
+  message?: string;
+  /** Session type (main, subagent, cron). */
+  sessionType?: "main" | "subagent" | "cron";
+  /** Number of recent tool calls in session. */
+  recentToolCalls?: number;
+}
+
+// Pre-compiled regex cache for performance
+const patternCache = new Map<string, RegExp>();
+
+function getOrCreateRegex(pattern: string): RegExp | null {
+  if (patternCache.has(pattern)) {
+    return patternCache.get(pattern)!;
+  }
+  try {
+    const regex = new RegExp(pattern, "i");
+    patternCache.set(pattern, regex);
+    return regex;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * High-value keywords that suggest complex reasoning tasks.
+ * Used as default rules when no custom rules are configured.
+ */
+export const DEFAULT_HIGH_THINKING_KEYWORDS = [
+  "architect",
+  "architecture",
+  "design",
+  "implement",
+  "debug",
+  "analyze",
+  "evaluate",
+  "compare",
+  "complex",
+  "strategy",
+  "optimize",
+  "refactor",
+  "migrate",
+  "security",
+  "performance",
+];
+
+export const DEFAULT_MEDIUM_THINKING_KEYWORDS = [
+  "build",
+  "create",
+  "code",
+  "write",
+  "develop",
+  "fix",
+  "update",
+  "modify",
+  "change",
+  "add",
+  "remove",
+  "test",
+  "review",
+];
+
+/**
+ * Default thinking router configuration.
+ */
+export const DEFAULT_THINKING_ROUTER_CONFIG: ThinkingRouterConfig = {
+  enabled: true,
+  default: "low",
+  rules: [
+    {
+      match: { keywords: DEFAULT_HIGH_THINKING_KEYWORDS },
+      thinking: "high",
+      priority: 100,
+    },
+    {
+      match: { keywords: DEFAULT_MEDIUM_THINKING_KEYWORDS },
+      thinking: "medium",
+      priority: 80,
+    },
+    {
+      match: { minLength: 500 },
+      thinking: "medium",
+      priority: 50,
+    },
+    {
+      match: { hasCode: true },
+      thinking: "medium",
+      priority: 60,
+    },
+    {
+      match: { sessionType: "subagent" },
+      thinking: "high",
+      priority: 90,
+    },
+  ],
+};
+
+/**
+ * Check if a message contains code blocks.
+ */
+function hasCodeBlocks(message: string): boolean {
+  // Fenced code blocks or inline code
+  return /```[\s\S]*```|`[^`]+`/.test(message);
+}
+
+/**
+ * Check if a rule matches the given context.
+ */
+function matchesRule(
+  context: ThinkingRouterContext,
+  match: ThinkingRouterRule["match"],
+): boolean {
+  const message = context.message ?? "";
+  const msgLower = message.toLowerCase();
+
+  // Keyword matching (any keyword present = match)
+  if (match.keywords?.length) {
+    const hasKeyword = match.keywords.some((kw) =>
+      msgLower.includes(kw.toLowerCase()),
+    );
+    if (!hasKeyword) return false;
+  }
+
+  // Message length bounds
+  if (match.minLength !== undefined && message.length < match.minLength) {
+    return false;
+  }
+  if (match.maxLength !== undefined && message.length > match.maxLength) {
+    return false;
+  }
+
+  // Code detection
+  if (match.hasCode !== undefined) {
+    const messageHasCode = hasCodeBlocks(message);
+    if (messageHasCode !== match.hasCode) return false;
+  }
+
+  // Session type
+  if (match.sessionType && context.sessionType !== match.sessionType) {
+    return false;
+  }
+
+  // Regex pattern
+  if (match.pattern) {
+    const regex = getOrCreateRegex(match.pattern);
+    if (regex && !regex.test(message)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Route thinking level based on message content and context.
+ *
+ * @param context - The routing context (message, session type, etc.)
+ * @param config - Router configuration (rules, default level)
+ * @returns The resolved thinking level
+ */
+export function routeThinkingLevel(
+  context: ThinkingRouterContext,
+  config: ThinkingRouterConfig,
+): ThinkLevel {
+  if (!config.enabled) {
+    return config.default;
+  }
+
+  // Sort rules by priority (descending)
+  const sortedRules = [...config.rules].sort(
+    (a, b) => (b.priority ?? 0) - (a.priority ?? 0),
+  );
+
+  for (const rule of sortedRules) {
+    if (matchesRule(context, rule.match)) {
+      return rule.thinking;
+    }
+  }
+
+  return config.default;
+}
+
+/**
+ * Quick heuristic check for high-complexity messages.
+ * Used when full router config isn't available.
+ *
+ * @param message - The user's message
+ * @returns Suggested thinking level based on heuristics
+ */
+export function quickRouteThinking(message: string): ThinkLevel | null {
+  if (!message?.trim()) {
+    return null;
+  }
+
+  const msgLower = message.toLowerCase();
+
+  // Check for high-complexity keywords
+  for (const kw of DEFAULT_HIGH_THINKING_KEYWORDS) {
+    if (msgLower.includes(kw)) {
+      return "high";
+    }
+  }
+
+  // Check for medium-complexity keywords
+  for (const kw of DEFAULT_MEDIUM_THINKING_KEYWORDS) {
+    if (msgLower.includes(kw)) {
+      return "medium";
+    }
+  }
+
+  // Long messages likely need more thinking
+  if (message.length > 500) {
+    return "medium";
+  }
+
+  // Code blocks suggest technical work
+  if (hasCodeBlocks(message)) {
+    return "medium";
+  }
+
+  // No heuristic match - return null to use default
+  return null;
+}

--- a/src/agents/thinking-router.ts
+++ b/src/agents/thinking-router.ts
@@ -154,7 +154,9 @@ function matchesRule(context: ThinkingRouterContext, match: ThinkingRouterRule["
   // Keyword matching (any keyword present = match)
   if (match.keywords?.length) {
     const hasKeyword = match.keywords.some((kw) => msgLower.includes(kw.toLowerCase()));
-    if (!hasKeyword) return false;
+    if (!hasKeyword) {
+      return false;
+    }
   }
 
   // Message length bounds
@@ -168,7 +170,9 @@ function matchesRule(context: ThinkingRouterContext, match: ThinkingRouterRule["
   // Code detection
   if (match.hasCode !== undefined) {
     const messageHasCode = hasCodeBlocks(message);
-    if (messageHasCode !== match.hasCode) return false;
+    if (messageHasCode !== match.hasCode) {
+      return false;
+    }
   }
 
   // Session type
@@ -207,7 +211,7 @@ export function routeThinkingLevel(
   }
 
   // Sort rules by priority (descending)
-  const sortedRules = [...config.rules].sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0));
+  const sortedRules = config.rules.toSorted((a, b) => (b.priority ?? 0) - (a.priority ?? 0));
 
   for (const rule of sortedRules) {
     if (matchesRule(context, rule.match)) {

--- a/src/agents/thinking-router.ts
+++ b/src/agents/thinking-router.ts
@@ -147,18 +147,13 @@ function hasCodeBlocks(message: string): boolean {
 /**
  * Check if a rule matches the given context.
  */
-function matchesRule(
-  context: ThinkingRouterContext,
-  match: ThinkingRouterRule["match"],
-): boolean {
+function matchesRule(context: ThinkingRouterContext, match: ThinkingRouterRule["match"]): boolean {
   const message = context.message ?? "";
   const msgLower = message.toLowerCase();
 
   // Keyword matching (any keyword present = match)
   if (match.keywords?.length) {
-    const hasKeyword = match.keywords.some((kw) =>
-      msgLower.includes(kw.toLowerCase()),
-    );
+    const hasKeyword = match.keywords.some((kw) => msgLower.includes(kw.toLowerCase()));
     if (!hasKeyword) return false;
   }
 
@@ -212,9 +207,7 @@ export function routeThinkingLevel(
   }
 
   // Sort rules by priority (descending)
-  const sortedRules = [...config.rules].sort(
-    (a, b) => (b.priority ?? 0) - (a.priority ?? 0),
-  );
+  const sortedRules = [...config.rules].sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0));
 
   for (const rule of sortedRules) {
     if (matchesRule(context, rule.match)) {

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -394,6 +394,9 @@ export async function resolveReplyDirectives(params: {
     model,
     hasModelDirective: directives.hasModelDirective,
     hasResolvedHeartbeatModelOverride,
+    // Dynamic thinking routing
+    message: ctx.Body ?? ctx.CommandBody,
+    sessionType: ctx.ParentSessionKey ? "subagent" : "main",
   });
   provider = modelState.provider;
   model = modelState.model;

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -274,6 +274,10 @@ export async function createModelSelectionState(params: {
   /** True when heartbeat.model was explicitly resolved for this run.
    *  In that case, skip session-stored overrides so the heartbeat selection wins. */
   hasResolvedHeartbeatModelOverride?: boolean;
+  /** User message for dynamic thinking routing (optional). */
+  message?: string;
+  /** Session type for thinking routing context (optional). */
+  sessionType?: "main" | "subagent" | "cron";
 }): Promise<ModelSelectionState> {
   const {
     cfg,
@@ -391,6 +395,8 @@ export async function createModelSelectionState(params: {
       provider,
       model,
       catalog: catalogForThinking,
+      message: params.message,
+      sessionType: params.sessionType,
     });
     defaultThinkingLevel =
       resolved ?? (agentCfg?.thinkingDefault as ThinkLevel | undefined) ?? "off";

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -1,3 +1,4 @@
+import type { ThinkingRouterConfig } from "../agents/thinking-router.js";
 import type { ChannelId } from "../channels/plugins/types.js";
 import type {
   BlockStreamingChunkConfig,
@@ -136,6 +137,8 @@ export type AgentDefaultsConfig = {
   memorySearch?: MemorySearchConfig;
   /** Default thinking level when no /think directive is present. */
   thinkingDefault?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
+  /** Dynamic thinking level router (auto-adjusts thinking based on message). */
+  thinkingRouter?: ThinkingRouterConfig;
   /** Default verbose level when no /verbose directive is present. */
   verboseDefault?: "off" | "on" | "full";
   /** Default elevated level when no /elevated directive is present. */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -12,6 +12,7 @@ import {
   CliBackendSchema,
   HumanDelaySchema,
 } from "./zod-schema.core.js";
+import { ThinkingRouterSchema } from "./zod-schema.thinking-router.js";
 
 export const AgentDefaultsSchema = z
   .object({
@@ -115,6 +116,7 @@ export const AgentDefaultsSchema = z
         z.literal("xhigh"),
       ])
       .optional(),
+    thinkingRouter: ThinkingRouterSchema,
     verboseDefault: z.union([z.literal("off"), z.literal("on"), z.literal("full")]).optional(),
     elevatedDefault: z
       .union([z.literal("off"), z.literal("on"), z.literal("ask"), z.literal("full")])

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -116,7 +116,7 @@ export const AgentDefaultsSchema = z
         z.literal("xhigh"),
       ])
       .optional(),
-    thinkingRouter: ThinkingRouterSchema,
+    thinkingRouter: ThinkingRouterSchema.optional(),
     verboseDefault: z.union([z.literal("off"), z.literal("on"), z.literal("full")]).optional(),
     elevatedDefault: z
       .union([z.literal("off"), z.literal("on"), z.literal("ask"), z.literal("full")])

--- a/src/config/zod-schema.thinking-router.ts
+++ b/src/config/zod-schema.thinking-router.ts
@@ -1,0 +1,56 @@
+/**
+ * Zod schema for thinking router configuration.
+ */
+
+import { z } from "zod";
+
+const ThinkLevelSchema = z.union([
+  z.literal("off"),
+  z.literal("minimal"),
+  z.literal("low"),
+  z.literal("medium"),
+  z.literal("high"),
+  z.literal("xhigh"),
+]);
+
+const ThinkingRouterRuleMatchSchema = z
+  .object({
+    /** Keywords that trigger this rule (case-insensitive). */
+    keywords: z.array(z.string()).optional(),
+    /** Minimum message length in characters. */
+    minLength: z.number().int().positive().optional(),
+    /** Maximum message length in characters. */
+    maxLength: z.number().int().positive().optional(),
+    /** Message contains code blocks. */
+    hasCode: z.boolean().optional(),
+    /** Session type filter. */
+    sessionType: z.union([z.literal("main"), z.literal("subagent"), z.literal("cron")]).optional(),
+    /** Regex pattern to match (string form). */
+    pattern: z.string().optional(),
+  })
+  .strict();
+
+const ThinkingRouterRuleSchema = z
+  .object({
+    /** Match conditions for this rule. */
+    match: ThinkingRouterRuleMatchSchema,
+    /** Thinking level to apply when rule matches. */
+    thinking: ThinkLevelSchema,
+    /** Higher priority rules are checked first (default: 0). */
+    priority: z.number().int().optional(),
+  })
+  .strict();
+
+export const ThinkingRouterSchema = z
+  .object({
+    /** Enable dynamic thinking routing. */
+    enabled: z.boolean().optional(),
+    /** Default thinking level when no rules match. */
+    default: ThinkLevelSchema,
+    /** Routing rules (checked in priority order). */
+    rules: z.array(ThinkingRouterRuleSchema),
+  })
+  .strict()
+  .optional();
+
+export type ThinkingRouterConfig = z.infer<typeof ThinkingRouterSchema>;


### PR DESCRIPTION
## Summary

Adds a configurable rules-based router that analyzes incoming messages and sets optimal thinking level before Claude API calls.

## Problem

Currently, thinking level is set statically via `thinkingDefault` in config. Users must manually toggle thinking levels for different task complexities.

**User feedback:** *"Why can't you change thinking based on the question? Why do I have to change it every time?"*

## Solution

A pre-routing layer with configurable rules:

- **Keyword detection**: "architect", "debug", "analyze" → high thinking
- **Message length**: Long messages → medium thinking  
- **Code detection**: Code blocks → medium thinking
- **Session type**: Subagents → high thinking
- **Custom regex patterns**: User-defined rules

## Files Added

- `src/agents/thinking-router.ts` - Core routing logic (195 lines)
- `src/config/zod-schema.thinking-router.ts` - Config schema

## Example Config

```json
{
  "agents": {
    "defaults": {
      "thinkingRouter": {
        "enabled": true,
        "default": "low",
        "rules": [
          { "match": { "keywords": ["architect", "debug"] }, "thinking": "high", "priority": 100 },
          { "match": { "minLength": 500 }, "thinking": "medium", "priority": 50 }
        ]
      }
    }
  }
}
```

## Benefits

- **Cost optimization**: Only use high thinking tokens when needed
- **Better UX**: No manual toggling
- **Zero latency**: Pure heuristics, no LLM overhead
- **Backward compatible**: Disabled by default

## Next Steps (for maintainers)

Integration needed in `resolveThinkingDefault()` at `src/agents/model-selection.ts` to thread message content through and apply the router.

---

*Submitted by Byzu (OpenClaw agent) on behalf of @phani-D*

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a message-complexity “thinking router” (`src/agents/thinking-router.ts`) plus a Zod schema for configuring routing rules (`src/config/zod-schema.thinking-router.ts`). The router supports keyword/length/code/sessionType/regex matching and returns a `ThinkLevel` based on highest-priority matching rule.

However, the configuration schema is currently not integrated into the existing config parsing layer: `agents.defaults` is validated by `AgentDefaultsSchema` which is strict and doesn’t include `thinkingRouter`, so the documented config shape can’t be expressed without schema changes. There are also behavior mismatches and edge cases (e.g., default router config is enabled despite the PR claiming it’s disabled by default; invalid regex patterns silently skip the constraint and can cause unexpected matches).

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is due to config/schema integration and correctness issues.
- Core router logic is straightforward, but the config schema isn’t wired into the repo’s strict config validation (so users can’t actually configure it), and there are correctness mismatches (default enabled vs stated disabled-by-default, invalid regex patterns effectively matching). These issues would lead to broken/undeliverable functionality or surprising behavior once integration lands.
- src/config/zod-schema.agent-defaults.ts, src/config/zod-schema.thinking-router.ts, src/agents/thinking-router.ts

<sub>Last reviewed commit: 6c0aac1</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->