### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ COPY ui/package.json ./ui/package.json
 COPY patches ./patches
 COPY scripts ./scripts
 
-RUN pnpm install --frozen-lockfile
+RUN pnpm install
 
 COPY . .
 RUN pnpm build


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Docker build step to run `pnpm install` without `--frozen-lockfile`.

Given the image copies `pnpm-lock.yaml` into the build context, removing `--frozen-lockfile` makes dependency resolution non-deterministic and can allow the lockfile to be mutated during builds, which undermines reproducibility and can introduce hard-to-debug CI/local mismatches.

<h3>Confidence Score: 3/5</h3>

- Mergeable, but the Docker build is now non-reproducible due to unfrozen dependency installs.
- The only change is removing `--frozen-lockfile` from `pnpm install`. That won’t always break builds immediately, but it can change dependency resolution across builds and hide lockfile drift, which is a real source of production/CI inconsistencies.
- Dockerfile

<sub>Last reviewed commit: 5c9d014</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->