### PR TITLE
Fix OpenAI/Codex tool call id sanitization for transcript policy

### DIFF
--- a/src/agents/pi-embedded-helpers/images.ts
+++ b/src/agents/pi-embedded-helpers/images.ts
@@ -51,10 +51,9 @@ export async function sanitizeSessionMessagesImages(
   const allowNonImageSanitization = sanitizeMode === "full";
   // We sanitize historical session messages because Anthropic can reject a request
   // if the transcript contains oversized base64 images (see MAX_IMAGE_DIMENSION_PX).
-  const sanitizedIds =
-    allowNonImageSanitization && options?.sanitizeToolCallIds
-      ? sanitizeToolCallIdsForCloudCodeAssist(messages, options.toolCallIdMode)
-      : messages;
+  const sanitizedIds = options?.sanitizeToolCallIds
+    ? sanitizeToolCallIdsForCloudCodeAssist(messages, options.toolCallIdMode)
+    : messages;
   const out: AgentMessage[] = [];
   for (const msg of sanitizedIds) {
     if (!msg || typeof msg !== "object") {

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -94,7 +94,7 @@ describe("sanitizeSessionHistory", () => {
     );
   });
 
-  it("does not sanitize tool call ids for openai-responses", async () => {
+  it("sanitizes tool call ids for openai-responses while keeping images-only mode", async () => {
     vi.mocked(helpers.isGoogleModelApi).mockReturnValue(false);
 
     await sanitizeSessionHistory({
@@ -108,7 +108,11 @@ describe("sanitizeSessionHistory", () => {
     expect(helpers.sanitizeSessionMessagesImages).toHaveBeenCalledWith(
       mockMessages,
       "session:history",
-      expect.objectContaining({ sanitizeMode: "images-only", sanitizeToolCallIds: false }),
+      expect.objectContaining({
+        sanitizeMode: "images-only",
+        sanitizeToolCallIds: true,
+        toolCallIdMode: "strict",
+      }),
     );
   });
 

--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -30,12 +30,13 @@ describe("resolveTranscriptPolicy", () => {
     expect(policy.toolCallIdMode).toBe("strict9");
   });
 
-  it("disables sanitizeToolCallIds for OpenAI provider", () => {
+  it("enables sanitizeToolCallIds for OpenAI provider", () => {
     const policy = resolveTranscriptPolicy({
       provider: "openai",
       modelId: "gpt-4o",
       modelApi: "openai",
     });
-    expect(policy.sanitizeToolCallIds).toBe(false);
+    expect(policy.sanitizeToolCallIds).toBe(true);
+    expect(policy.toolCallIdMode).toBe("strict");
   });
 });

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -95,7 +95,7 @@ export function resolveTranscriptPolicy(params: {
 
   const needsNonImageSanitize = isGoogle || isAnthropic || isMistral || isOpenRouterGemini;
 
-  const sanitizeToolCallIds = isGoogle || isMistral || isAnthropic;
+  const sanitizeToolCallIds = isGoogle || isMistral || isAnthropic || isOpenAi;
   const toolCallIdMode: ToolCallIdMode | undefined = isMistral
     ? "strict9"
     : sanitizeToolCallIds
@@ -109,7 +109,7 @@ export function resolveTranscriptPolicy(params: {
 
   return {
     sanitizeMode: isOpenAi ? "images-only" : needsNonImageSanitize ? "full" : "images-only",
-    sanitizeToolCallIds: !isOpenAi && sanitizeToolCallIds,
+    sanitizeToolCallIds,
     toolCallIdMode,
     repairToolUseResultPairing: !isOpenAi && repairToolUseResultPairing,
     preserveSignatures: isAntigravityClaudeModel,


### PR DESCRIPTION
This PR fixes how tool call ids are sanitized for OpenAI/Codex models in the transcript policy.

### Changes

- Enable `sanitizeToolCallIds` for OpenAI in `resolveTranscriptPolicy`, while keeping `sanitizeMode = "images-only"` so we don't over-sanitize non-image content.
- Treat OpenAI alongside Google/Mistral/Anthropic/OpenRouter Gemini for tool call id sanitization.
- Use `toolCallIdMode = "strict"` for OpenAI (while Mistral keeps `strict9`).
- Update `sanitizeSessionHistory` tests to assert that OpenAI responses still use images-only sanitization but now also sanitize tool call ids.
- Update transcript policy tests to reflect the new OpenAI behavior.

### Rationale

Codex/OpenAI-backed tool use APIs are sensitive to malformed or extremely long tool call ids.
By sanitizing tool call ids while keeping the transcript in images-only sanitize mode, we reduce Codex API errors without changing the overall content sanitization behavior for OpenAI models.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates transcript sanitization policy so OpenAI/Codex models sanitize tool call IDs (mode `strict`) while still keeping overall transcript sanitization in `images-only` mode. The policy logic in `src/agents/transcript-policy.ts` now treats OpenAI like Google/Mistral/Anthropic for tool-call-id sanitization, and the session history sanitizer (`sanitizeSessionMessagesImages`) now applies tool-call-id rewriting whenever `sanitizeToolCallIds` is enabled (independent of `sanitizeMode`). Tests were updated to assert OpenAI keeps `images-only` mode but now enables tool-call-id sanitization, and that OpenAI policy resolves to `sanitizeToolCallIds: true` with `toolCallIdMode: strict`.


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are small and targeted: OpenAI is explicitly opted into tool-call-id sanitization while preserving images-only sanitization, and the updated tests cover the intended new behavior. The tool-call-id sanitizer only rewrites tool-call and tool-result ID fields, so it should not affect non-image content sanitization semantics.
- No files require special attention

<sub>Last reviewed commit: a411e3f</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->