### PR TITLE
perf(workspace): lazy-load templates only for missing files

### DIFF
--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -348,16 +348,35 @@ export async function ensureAgentWorkspace(params?: {
   const bootstrapPath = path.join(dir, DEFAULT_BOOTSTRAP_FILENAME);
   const statePath = resolveWorkspaceStatePath(dir);
 
-  const isBrandNewWorkspace = await (async () => {
-    const templatePaths = [agentsPath, soulPath, toolsPath, identityPath, userPath, heartbeatPath];
-    const userContentPaths = [
-      path.join(dir, "memory"),
-      path.join(dir, DEFAULT_MEMORY_FILENAME),
-      path.join(dir, ".git"),
-    ];
-    const paths = [...templatePaths, ...userContentPaths];
-    const existing = await Promise.all(
-      paths.map(async (p) => {
+  // Check which files are missing - only load templates for those
+  const filesToCheck = [
+    { path: agentsPath, template: DEFAULT_AGENTS_FILENAME },
+    { path: soulPath, template: DEFAULT_SOUL_FILENAME },
+    { path: toolsPath, template: DEFAULT_TOOLS_FILENAME },
+    { path: identityPath, template: DEFAULT_IDENTITY_FILENAME },
+    { path: userPath, template: DEFAULT_USER_FILENAME },
+    { path: heartbeatPath, template: DEFAULT_HEARTBEAT_FILENAME },
+  ];
+
+  const userContentPaths = [
+    path.join(dir, "memory"),
+    path.join(dir, DEFAULT_MEMORY_FILENAME),
+    path.join(dir, ".git"),
+  ];
+
+  const [missingFiles, userContentExists] = await Promise.all([
+    Promise.all(
+      filesToCheck.map(async ({ path: filePath, template }) => {
+        try {
+          await fs.access(filePath);
+          return null; // File exists, no need to load template
+        } catch {
+          return { path: filePath, template };
+        }
+      }),
+    ),
+    Promise.all(
+      userContentPaths.map(async (p) => {
         try {
           await fs.access(p);
           return true;
@@ -365,23 +384,26 @@ export async function ensureAgentWorkspace(params?: {
           return false;
         }
       }),
-    );
-    return existing.every((v) => !v);
-  })();
+    ).then((results) => results.some((v) => v)),
+  ]);
 
-  const agentsTemplate = await loadTemplate(DEFAULT_AGENTS_FILENAME);
-  const soulTemplate = await loadTemplate(DEFAULT_SOUL_FILENAME);
-  const toolsTemplate = await loadTemplate(DEFAULT_TOOLS_FILENAME);
-  const identityTemplate = await loadTemplate(DEFAULT_IDENTITY_FILENAME);
-  const userTemplate = await loadTemplate(DEFAULT_USER_FILENAME);
-  const heartbeatTemplate = await loadTemplate(DEFAULT_HEARTBEAT_FILENAME);
-  await writeFileIfMissing(agentsPath, agentsTemplate);
-  await writeFileIfMissing(soulPath, soulTemplate);
-  await writeFileIfMissing(toolsPath, toolsTemplate);
-  await writeFileIfMissing(identityPath, identityTemplate);
-  await writeFileIfMissing(userPath, userTemplate);
-  await writeFileIfMissing(heartbeatPath, heartbeatTemplate);
+  const filesToCreate = missingFiles.filter(
+    (f): f is { path: string; template: string } => f !== null,
+  );
+  const isBrandNewWorkspace = filesToCreate.length === filesToCheck.length && !userContentExists;
 
+  // Only load and write templates for files that are actually missing
+  // Also collect templates we need for legacy migration check
+  const templateCache: Map<string, string> = new Map();
+  await Promise.all(
+    filesToCreate.map(async ({ path: filePath, template }) => {
+      const content = await loadTemplate(template);
+      templateCache.set(template, content);
+      await writeFileIfMissing(filePath, content);
+    }),
+  );
+
+  // Onboarding state management
   let state = await readWorkspaceOnboardingState(statePath);
   let stateDirty = false;
   const markState = (next: Partial<WorkspaceOnboardingState>) => {
@@ -403,6 +425,13 @@ export async function ensureAgentWorkspace(params?: {
     // Legacy migration path: if USER/IDENTITY diverged from templates, or if user-content
     // indicators exist, treat onboarding as complete and avoid recreating BOOTSTRAP for
     // already-onboarded workspaces.
+    // Only load templates if not already cached and files exist (need comparison)
+    const identityTemplate =
+      templateCache.get(DEFAULT_IDENTITY_FILENAME) ??
+      (await loadTemplate(DEFAULT_IDENTITY_FILENAME));
+    const userTemplate =
+      templateCache.get(DEFAULT_USER_FILENAME) ?? (await loadTemplate(DEFAULT_USER_FILENAME));
+
     const [identityContent, userContent] = await Promise.all([
       fs.readFile(identityPath, "utf-8"),
       fs.readFile(userPath, "utf-8"),

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -425,35 +425,26 @@ export async function ensureAgentWorkspace(params?: {
     // Legacy migration path: if USER/IDENTITY diverged from templates, or if user-content
     // indicators exist, treat onboarding as complete and avoid recreating BOOTSTRAP for
     // already-onboarded workspaces.
-    // Only load templates if not already cached and files exist (need comparison)
-    const identityTemplate =
-      templateCache.get(DEFAULT_IDENTITY_FILENAME) ??
-      (await loadTemplate(DEFAULT_IDENTITY_FILENAME));
-    const userTemplate =
-      templateCache.get(DEFAULT_USER_FILENAME) ?? (await loadTemplate(DEFAULT_USER_FILENAME));
+    const identityFresh = filesToCreate.some((f) => f.template === DEFAULT_IDENTITY_FILENAME);
+    const userFresh = filesToCreate.some((f) => f.template === DEFAULT_USER_FILENAME);
+    const bothFresh = identityFresh && userFresh;
 
-    const [identityContent, userContent] = await Promise.all([
-      fs.readFile(identityPath, "utf-8"),
-      fs.readFile(userPath, "utf-8"),
-    ]);
-    const hasUserContent = await (async () => {
-      const indicators = [
-        path.join(dir, "memory"),
-        path.join(dir, DEFAULT_MEMORY_FILENAME),
-        path.join(dir, ".git"),
-      ];
-      for (const indicator of indicators) {
-        try {
-          await fs.access(indicator);
-          return true;
-        } catch {
-          // continue
-        }
-      }
-      return false;
-    })();
-    const legacyOnboardingCompleted =
-      identityContent !== identityTemplate || userContent !== userTemplate || hasUserContent;
+    // Fresh files = first-time onboarding, will need bootstrap; only compare if files pre-existed
+    // Also check userContentExists (memory/, MEMORY.md, .git) which indicates an established workspace
+    let legacyOnboardingCompleted = userContentExists;
+    if (!legacyOnboardingCompleted && !bothFresh) {
+      const [identityTemplate, userTemplate] = await Promise.all([
+        templateCache.get(DEFAULT_IDENTITY_FILENAME) ?? loadTemplate(DEFAULT_IDENTITY_FILENAME),
+        templateCache.get(DEFAULT_USER_FILENAME) ?? loadTemplate(DEFAULT_USER_FILENAME),
+      ]);
+      const [identityContent, userContent] = await Promise.all([
+        fs.readFile(identityPath, "utf-8"),
+        fs.readFile(userPath, "utf-8"),
+      ]);
+      legacyOnboardingCompleted =
+        identityContent !== identityTemplate || userContent !== userTemplate;
+    }
+
     if (legacyOnboardingCompleted) {
       markState({ onboardingCompletedAt: nowIso() });
     } else {


### PR DESCRIPTION
## Summary

Reduces unnecessary file I/O during workspace setup by only loading templates for files that are actually missing.

**Supersedes #5927** (rebased on main, workspace optimization only; Chrome extension changes no longer needed).

### Problem

Previously, `ensureAgentWorkspace` loaded all 7 template files on every startup, even when all workspace files already existed. This was wasteful for the common case (existing workspace).

### Solution

1. Check which workspace files are missing first
2. Only load templates for files that need to be created
3. Process missing files in parallel for efficiency

### Impact

For existing workspaces (the common case), this eliminates ~7 template file reads per startup.

### Testing
- [x] `pnpm run lint` passes
- [x] `vitest run src/agents/workspace.test.ts` - all 4 tests pass

### AI Disclosure
🤖 This PR was AI-assisted (Claude via OpenClaw). I understand the changes and have tested them locally.