### PR TITLE
fix: explicitly exit after onboarding command completes

### DIFF
--- a/src/cli/program/register.onboard.ts
+++ b/src/cli/program/register.onboard.ts
@@ -185,6 +185,7 @@ export function registerOnboardCommand(program: Command) {
           },
           defaultRuntime,
         );
+        defaultRuntime.exit(0);
       });
     });
 }


### PR DESCRIPTION
# Fix hanging process after onboarding completion

## limit
Fixes an issue where the `openclaw onboard` command would hang indefinitely after successfully completing the wizard, preventing automated setup scripts (like [docker-setup.sh](file:///Users/jeroen/code/openclaw/docker-setup.sh)) from proceeding.

## Summary
The [onboard](file:///Users/jeroen/code/openclaw/src/commands/onboard.ts#12-82) command completes all interactive steps but does not terminate the process, likely due to lingering event loop handles (e.g., database connections, intervals) that are not fully cleaned up. This causes the Docker setup script to stall at the `openclaw-cli onboard` step, as it waits for the container to exit before starting the `openclaw-gateway` service.

## Changes
- **src/commands/onboard.ts**: Added an explicit `runtime.exit(0)` call at the end of [onboardCommand](file:///Users/jeroen/code/openclaw/src/commands/onboard.ts#12-82) to ensure the process terminates immediately upon successful completion of the wizard.

## Verification
- Verified that [docker-setup.sh](file:///Users/jeroen/code/openclaw/docker-setup.sh) now proceeds correctly past the onboarding step and starts the gateway service without manual intervention.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds an explicit `runtime.exit(0)` at the end of `onboardCommand` to prevent the `openclaw onboard` wizard from hanging after successful completion.

The change is localized to `src/commands/onboard.ts`, which is used by multiple CLI entrypoints (including `openclaw onboard` and `openclaw setup --wizard`). Because the exit is inside the shared command function (not the top-level CLI wiring), it changes behavior for any other caller that expects `onboardCommand` to return normally.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a behavior change that can break other command paths.
- The core fix (forcing process exit) addresses the reported hang for `openclaw onboard`, but placing `runtime.exit(0)` inside `onboardCommand` makes it non-composable and will terminate the process even when invoked via `openclaw setup --wizard`, preventing callers from continuing or performing any cleanup.
- src/commands/onboard.ts

<sub>Last reviewed commit: c24cd4f</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->