### PR TITLE
fix(cli): resolve agent workspace from --session-id

### DIFF
--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -205,8 +205,10 @@ export async function agentCommand(
       );
     }
   }
-  if (agentIdOverride && opts.sessionKey) {
-    const sessionAgentId = resolveAgentIdFromSessionKey(opts.sessionKey);
+  // Extract agent ID from session key or session ID
+  const sessionKeyOrId = opts.sessionKey?.trim() || opts.sessionId?.trim();
+  if (agentIdOverride && sessionKeyOrId) {
+    const sessionAgentId = resolveAgentIdFromSessionKey(sessionKeyOrId);
     if (sessionAgentId !== agentIdOverride) {
       throw new Error(
         `Agent id "${agentIdOverrideRaw}" does not match session key agent "${sessionAgentId}".`,
@@ -214,7 +216,7 @@ export async function agentCommand(
     }
   }
   const agentCfg = cfg.agents?.defaults;
-  const sessionAgentId = agentIdOverride ?? resolveAgentIdFromSessionKey(opts.sessionKey?.trim());
+  const sessionAgentId = agentIdOverride ?? resolveAgentIdFromSessionKey(sessionKeyOrId);
   const workspaceDirRaw = resolveAgentWorkspaceDir(cfg, sessionAgentId);
   const agentDir = resolveAgentDir(cfg, sessionAgentId);
   const workspace = await ensureAgentWorkspace({

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -60,7 +60,7 @@ import { resolveMessageChannel } from "../utils/message-channel.js";
 import { deliverAgentCommandResult } from "./agent/delivery.js";
 import { resolveAgentRunContext } from "./agent/run-context.js";
 import { updateSessionStoreAfterAgentRun } from "./agent/session-store.js";
-import { resolveSession } from "./agent/session.js";
+import { findSessionKeyByUuid, resolveSession } from "./agent/session.js";
 import type { AgentCommandOpts } from "./agent/types.js";
 
 type PersistSessionEntryParams = {
@@ -205,18 +205,26 @@ export async function agentCommand(
       );
     }
   }
-  // Extract agent ID from session key or session ID
-  const sessionKeyOrId = opts.sessionKey?.trim() || opts.sessionId?.trim();
-  if (agentIdOverride && sessionKeyOrId) {
-    const sessionAgentId = resolveAgentIdFromSessionKey(sessionKeyOrId);
-    if (sessionAgentId !== agentIdOverride) {
-      throw new Error(
-        `Agent id "${agentIdOverrideRaw}" does not match session key agent "${sessionAgentId}".`,
-      );
-    }
+  // Resolve session key from --session-key or --session-id
+  // If --session-id is a UUID (not agent:... format), look it up across all agent stores
+  let resolvedSessionKey = opts.sessionKey?.trim();
+  if (!resolvedSessionKey && opts.sessionId?.trim()) {
+    const sessionIdValue = opts.sessionId.trim();
+    resolvedSessionKey = sessionIdValue.toLowerCase().startsWith("agent:")
+      ? sessionIdValue
+      : findSessionKeyByUuid({ cfg, sessionId: sessionIdValue });
+  }
+
+  // Extract agent ID from the resolved session key (only call once)
+  const keyAgentId = resolveAgentIdFromSessionKey(resolvedSessionKey);
+  const sessionAgentId = agentIdOverride ?? keyAgentId;
+
+  if (agentIdOverride && keyAgentId && keyAgentId !== agentIdOverride) {
+    throw new Error(
+      `Agent id "${agentIdOverrideRaw}" does not match session key agent "${keyAgentId}".`,
+    );
   }
   const agentCfg = cfg.agents?.defaults;
-  const sessionAgentId = agentIdOverride ?? resolveAgentIdFromSessionKey(sessionKeyOrId);
   const workspaceDirRaw = resolveAgentWorkspaceDir(cfg, sessionAgentId);
   const agentDir = resolveAgentDir(cfg, sessionAgentId);
   const workspace = await ensureAgentWorkspace({

--- a/src/commands/agent/session.ts
+++ b/src/commands/agent/session.ts
@@ -22,6 +22,38 @@ import {
 } from "../../config/sessions.js";
 import { normalizeMainKey } from "../../routing/session-key.js";
 
+/**
+ * Find a session key by its UUID across all agent session stores.
+ * This is needed when --session-id is a UUID (not an agent:... format key),
+ * since we don't know which agent's store contains the session.
+ *
+ * Note: A global UUID→sessionKey index could improve this from
+ * O(agents * sessions) to O(1), but would require storage changes.
+ *
+ * @returns The session key if found, undefined otherwise
+ */
+export function findSessionKeyByUuid(opts: {
+  cfg: OpenClawConfig;
+  sessionId: string;
+}): string | undefined {
+  const sessionCfg = opts.cfg.session;
+  const agentIds = listAgentIds(opts.cfg);
+
+  for (const agentId of agentIds) {
+    const storePath = resolveStorePath(sessionCfg?.store, { agentId });
+    const sessionStore = loadSessionStore(storePath);
+
+    const foundKey = Object.keys(sessionStore).find(
+      (key) => sessionStore[key]?.sessionId === opts.sessionId,
+    );
+    if (foundKey) {
+      return foundKey;
+    }
+  }
+
+  return undefined;
+}
+
 export type SessionResolution = {
   sessionId: string;
   sessionKey?: string;


### PR DESCRIPTION
## Summary

Fixes agent workspace resolution when using `--session-id` instead of `--session-key`.

Fixes #13635

### Problem

When using `openclaw agent --session-id agent:jarvis:main`, the agent workspace was not being resolved from the session key. The code only checked `opts.sessionKey`, but `--session-id` maps to `opts.sessionId`.

This caused the workspace to fall back to the default agent's workspace instead of the sub-agent's configured workspace.

### Solution

Extract agent ID from either `sessionKey` or `sessionId` (whichever is provided), and apply the same validation for both.

### Testing
- [x] `pnpm run lint` passes
- [x] `pnpm vitest run src/commands/agent` — all 40 tests pass

### AI Disclosure
🤖 This PR was AI-assisted (Claude via OpenClaw).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change makes `agentCommand` derive an agent id from either `--session-key` or `--session-id` to decide which agent workspace to use, and applies the existing `--agent` vs session agent-id consistency check to both flags.

However, the current implementation treats `sessionId` as interchangeable with a session key. `resolveAgentIdFromSessionKey()` only parses `agent:...`-shaped keys and otherwise falls back to the default agent id (`main`), so `--session-id <uuid>` can still resolve the wrong workspace for non-default-agent sessions. The session resolution path (`resolveSession()`) can already map a UUID session id back to its stored session key/entry, which should be used to determine the agent workspace.

<h3>Confidence Score: 2/5</h3>

- This PR is not safe to merge as-is due to incorrect workspace resolution for UUID-shaped --session-id values.
- Although it fixes the specific case where --session-id carries an agent session key, it can still mis-resolve the agent workspace when --session-id is a UUID (because agent id derivation is done via session-key parsing and falls back to 'main'). That breaks the core intended behavior for sessions belonging to non-default agents.
- src/commands/agent.ts

<sub>Last reviewed commit: f6386ab</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->