### PR TITLE
fix(cron): reset token counters when creating new isolated session

### DIFF
--- a/src/cron/isolated-agent/session.ts
+++ b/src/cron/isolated-agent/session.ts
@@ -16,6 +16,8 @@ export function resolveCronSession(params: {
   const entry = store[params.sessionKey];
   const sessionId = crypto.randomUUID();
   const systemSent = false;
+  // Token counters (contextTokens, inputTokens, outputTokens, totalTokens) intentionally
+  // omitted to start fresh - they will be set during/after the run with actual usage.
   const sessionEntry: SessionEntry = {
     sessionId,
     updatedAt: params.nowMs,
@@ -25,7 +27,7 @@ export function resolveCronSession(params: {
     model: entry?.model,
     modelOverride: entry?.modelOverride,
     providerOverride: entry?.providerOverride,
-    contextTokens: entry?.contextTokens,
+    totalTokensFresh: false,
     sendPolicy: entry?.sendPolicy,
     lastChannel: entry?.lastChannel,
     lastTo: entry?.lastTo,


### PR DESCRIPTION
## Summary

Fixes stale token counters appearing in Sessions view after a cron session is deleted and recreated.

Fixes #13730

### Problem

After deleting an isolated cron session and letting the cron run again:
- A new session is created with a new `sessionId`
- But the Sessions view still shows the old token count (e.g., `272000 / 272000`) instead of the fresh usage (~23k)

### Root Cause

`resolveCronSession()` was preserving `contextTokens` from the old session entry. While `totalTokens` wasn't explicitly preserved, this could lead to confusing state where old context values persisted.

### Solution

Explicitly clear all token-related fields when creating a new cron session:
- `contextTokens`: Don't preserve from old entry — will be set during the run based on actual model
- `inputTokens`, `outputTokens`, `totalTokens`: Set to `undefined`
- `totalTokensFresh`: Set to `false` until actual usage is recorded

This ensures the Sessions view shows accurate "unknown" state until the run completes with real usage data.

### Testing
- [x] `pnpm run lint` passes
- [x] `pnpm vitest run src/cron` — all 128 tests pass

### AI Disclosure
🤖 This PR was AI-assisted (Claude via OpenClaw).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates cron isolated-session creation (`resolveCronSession`) to avoid carrying over stale token counters when an isolated session is deleted and later recreated. The new session entry now explicitly clears `contextTokens`, `inputTokens`, `outputTokens`, and `totalTokens`, and sets `totalTokensFresh` to `false` so downstream consumers treat usage as unknown until the run records real token usage.

This fits the existing session metadata model (`SessionEntry`) and its freshness helpers (`resolveFreshSessionTotalTokens`), preventing misleading “old” utilization in the Sessions view after session recreation.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge.
- Single-file, narrowly-scoped change that clears optional token fields on new cron session creation and uses existing freshness semantics to prevent stale usage values from being displayed. Aligns with the SessionEntry type and helper functions.
- No files require special attention

<sub>Last reviewed commit: 795aec3</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->