### PR TITLE
Harden config redaction defaults; add explicit --show-secrets opt-in

### DIFF
--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -235,9 +235,7 @@ export async function runConfigGet(opts: {
   try {
     const parsedPath = parseRequiredPath(opts.path);
     const snapshot = await loadValidConfig(runtime);
-    const sourceConfig = opts.showSecrets
-      ? snapshot.config
-      : redactConfigObject(snapshot.config);
+    const sourceConfig = opts.showSecrets ? snapshot.config : redactConfigObject(snapshot.config);
     if (opts.showSecrets) {
       runtime.error(
         theme.warn("Warning: --show-secrets prints sensitive values to your terminal history."),

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -235,7 +235,9 @@ export async function runConfigGet(opts: {
   try {
     const parsedPath = parseRequiredPath(opts.path);
     const snapshot = await loadValidConfig(runtime);
-    const sourceConfig = opts.showSecrets ? snapshot.config : redactConfigObject(snapshot.config);
+    const sourceConfig = opts.showSecrets
+      ? snapshot.config
+      : redactConfigObject(snapshot.config);
     if (opts.showSecrets) {
       runtime.error(
         theme.warn("Warning: --show-secrets prints sensitive values to your terminal history."),

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -2,6 +2,7 @@ import type { Command } from "commander";
 import JSON5 from "json5";
 import type { RuntimeEnv } from "../runtime.js";
 import { readConfigFileSnapshot, writeConfigFile } from "../config/config.js";
+import { redactConfigObject } from "../config/redact-snapshot.js";
 import { danger, info } from "../globals.js";
 import { defaultRuntime } from "../runtime.js";
 import { formatDocsLink } from "../terminal/links.js";
@@ -224,12 +225,23 @@ function parseRequiredPath(path: string): PathSegment[] {
   return parsedPath;
 }
 
-export async function runConfigGet(opts: { path: string; json?: boolean; runtime?: RuntimeEnv }) {
+export async function runConfigGet(opts: {
+  path: string;
+  json?: boolean;
+  showSecrets?: boolean;
+  runtime?: RuntimeEnv;
+}) {
   const runtime = opts.runtime ?? defaultRuntime;
   try {
     const parsedPath = parseRequiredPath(opts.path);
     const snapshot = await loadValidConfig(runtime);
-    const res = getAtPath(snapshot.config, parsedPath);
+    const sourceConfig = opts.showSecrets ? snapshot.config : redactConfigObject(snapshot.config);
+    if (opts.showSecrets) {
+      runtime.error(
+        theme.warn("Warning: --show-secrets prints sensitive values to your terminal history."),
+      );
+    }
+    const res = getAtPath(sourceConfig, parsedPath);
     if (!res.found) {
       runtime.error(danger(`Config path not found: ${opts.path}`));
       runtime.exit(1);
@@ -322,8 +334,13 @@ export function registerConfigCli(program: Command) {
     .description("Get a config value by dot path")
     .argument("<path>", "Config path (dot or bracket notation)")
     .option("--json", "Output JSON", false)
+    .option("--show-secrets", "Show unredacted secret values (unsafe)", false)
     .action(async (path: string, opts) => {
-      await runConfigGet({ path, json: Boolean(opts.json) });
+      await runConfigGet({
+        path,
+        json: Boolean(opts.json),
+        showSecrets: Boolean(opts.showSecrets),
+      });
     });
 
   cmd


### PR DESCRIPTION
## Summary
This PR hardens config secret handling in a **CLI-only** way:
- `openclaw config get` now returns redacted values by default.
- `--show-secrets` is the explicit unsafe opt-in for local debugging.

## Changes
- Updated `openclaw config get` to read from a redacted config view by default.
- Added `--show-secrets` flag to reveal raw values intentionally.
- Added a warning when `--show-secrets` is used.
- Reverted the earlier gateway-side `showSecrets` path (schema/server/test), so gateway `config.get` remains redacted-only.

## Why
The goal is secure-by-default behavior for routine config inspection while still preserving an explicit local escape hatch for trusted debugging workflows.

## Security Notes
- Secrets remain redacted by default.
- Unredacted output now requires explicit local CLI intent (`--show-secrets`).
- No remote/API toggle exists for unredacted `config.get` responses.

## Testing
- Verified CLI path behavior:
  - default `config get` => redacted values
  - `config get --show-secrets` => raw values with warning
- Confirmed gateway path stays redacted (gateway `showSecrets` support removed).

## Backward Compatibility
- Scripts relying on plaintext output from `openclaw config get` must now pass `--show-secrets`.
- Gateway clients are unaffected except that no new `showSecrets` parameter is supported.
