### PR TITLE
fix(providers): switch MiniMax API-key provider to anthropic-messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ Docs: https://docs.openclaw.ai
 - Process/Exec: avoid shell execution for `.exe` commands on Windows so env overrides work reliably in `runCommandWithTimeout`. Thanks @thewilloftheshadow.
 - Web tools/web_fetch: prefer `text/markdown` responses for Cloudflare Markdown for Agents, add `cf-markdown` extraction for markdown bodies, and redact fetched URLs in `x-markdown-tokens` debug logs to avoid leaking raw paths/query params. (#15376) Thanks @Yaxuan42.
 - Config: keep legacy audio transcription migration strict by rejecting non-string/unsafe command tokens while still migrating valid custom script executables. (#5042) Thanks @shayan919293.
+- Status/Sessions: stop clamping derived `totalTokens` to context-window size, keep prompt-token snapshots wired through session accounting, and surface context usage as unknown when fresh snapshot data is missing to avoid false 100% reports. (#15114) Thanks @echoVic.
+- Providers/MiniMax: switch implicit MiniMax API-key provider from `openai-completions` to `anthropic-messages` with the correct Anthropic-compatible base URL, fixing `invalid role: developer (2013)` errors on MiniMax M2.5. (#15275)
 
 ## 2026.2.12
 

--- a/src/agents/models-config.providers.minimax.test.ts
+++ b/src/agents/models-config.providers.minimax.test.ts
@@ -1,0 +1,26 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveImplicitProviders } from "./models-config.providers.js";
+
+describe("MiniMax implicit provider (#15275)", () => {
+  it("should use anthropic-messages API for API-key provider", async () => {
+    const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
+    const previous = process.env.MINIMAX_API_KEY;
+    process.env.MINIMAX_API_KEY = "test-key";
+
+    try {
+      const providers = await resolveImplicitProviders({ agentDir });
+      expect(providers?.minimax).toBeDefined();
+      expect(providers?.minimax?.api).toBe("anthropic-messages");
+      expect(providers?.minimax?.baseUrl).toBe("https://api.minimax.io/anthropic");
+    } finally {
+      if (previous === undefined) {
+        delete process.env.MINIMAX_API_KEY;
+      } else {
+        process.env.MINIMAX_API_KEY = previous;
+      }
+    }
+  });
+});

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -32,7 +32,6 @@ import { discoverVeniceModels, VENICE_BASE_URL } from "./venice-models.js";
 type ModelsConfig = NonNullable<OpenClawConfig["models"]>;
 export type ProviderConfig = NonNullable<ModelsConfig["providers"]>[string];
 
-const MINIMAX_API_BASE_URL = "https://api.minimax.chat/v1";
 const MINIMAX_PORTAL_BASE_URL = "https://api.minimax.io/anthropic";
 const MINIMAX_DEFAULT_MODEL_ID = "MiniMax-M2.1";
 const MINIMAX_DEFAULT_VISION_MODEL_ID = "MiniMax-VL-01";

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -380,8 +380,8 @@ export function normalizeProviders(params: {
 
 function buildMinimaxProvider(): ProviderConfig {
   return {
-    baseUrl: MINIMAX_API_BASE_URL,
-    api: "openai-completions",
+    baseUrl: MINIMAX_PORTAL_BASE_URL,
+    api: "anthropic-messages",
     models: [
       {
         id: MINIMAX_DEFAULT_MODEL_ID,


### PR DESCRIPTION
## Summary

`buildMinimaxProvider()` in `models-config.providers.ts` defaults to `api: "openai-completions"` at `baseUrl: "https://api.minimax.chat/v1"`, but MiniMax M2.5 (and all current MiniMax models) requires `api: "anthropic-messages"` at `https://api.minimax.io/anthropic`.

This causes `invalid role: developer (2013)` errors when users configure MiniMax via API key without going through the onboarding wizard.

## Root Cause

`buildMinimaxProvider()` (used by `resolveImplicitProviders` for API-key auth) had:
- `api: "openai-completions"` ❌
- `baseUrl: "https://api.minimax.chat/v1"` ❌

While `buildMinimaxPortalProvider()` (used for OAuth) and `applyMinimaxApiProviderConfig()` (onboarding wizard) both correctly use:
- `api: "anthropic-messages"` ✅
- `baseUrl: "https://api.minimax.io/anthropic"` ✅

## Fix

Switch `buildMinimaxProvider()` to use `MINIMAX_PORTAL_BASE_URL` (`https://api.minimax.io/anthropic`) and `api: "anthropic-messages"`, aligning it with the portal provider and onboarding config. Remove the now-unused `MINIMAX_API_BASE_URL` constant.

## Test

### Before (on main)
```
× should use anthropic-messages API for API-key provider
  Expected: "anthropic-messages"
  Received: "openai-completions"
Tests: 1 failed
```

### After (on fix branch)
```
✓ should use anthropic-messages API for API-key provider
Tests: 1 passed
```

All 46 provider + onboard-auth tests pass.

Closes #15275

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR aligns the implicit MiniMax API-key provider created by `resolveImplicitProviders` with the already-correct OAuth/onboarding paths by switching MiniMax to use the Anthropic-compatible endpoint.

Concretely, `buildMinimaxProvider()` in `src/agents/models-config.providers.ts` now uses `api: "anthropic-messages"` and the `https://api.minimax.io/anthropic` base URL (via `MINIMAX_PORTAL_BASE_URL`), and removes the now-unused `MINIMAX_API_BASE_URL` constant. A new Vitest regression test (`src/agents/models-config.providers.minimax.test.ts`) asserts that when `MINIMAX_API_KEY` is set, the implicit provider configuration uses the correct API and baseUrl, preventing the reported `invalid role: developer (2013)` errors.

No merge-blocking issues found in the changes.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are small, localized, and bring the implicit MiniMax provider into alignment with existing portal/onboarding configuration. A targeted regression test was added. No broken references were found after verifying other MiniMax base URL constants are defined in separate modules.
- No files require special attention

<sub>Last reviewed commit: 5f16219</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->