### PR TITLE
feat(telegram): support URL buttons in inline keyboards

### DIFF
--- a/src/agents/tools/telegram-actions.ts
+++ b/src/agents/tools/telegram-actions.ts
@@ -25,7 +25,8 @@ import {
 
 type TelegramButton = {
   text: string;
-  callback_data: string;
+  callback_data?: string;
+  url?: string;
 };
 
 export function readTelegramButtons(
@@ -54,13 +55,26 @@ export function readTelegramButtons(
         typeof (button as { callback_data?: unknown }).callback_data === "string"
           ? (button as { callback_data: string }).callback_data.trim()
           : "";
-      if (!text || !callbackData) {
-        throw new Error(`buttons[${rowIndex}][${buttonIndex}] requires text and callback_data`);
+      const url =
+        typeof (button as { url?: unknown }).url === "string"
+          ? (button as { url: string }).url.trim()
+          : "";
+      if (!text) {
+        throw new Error(`buttons[${rowIndex}][${buttonIndex}] requires text`);
       }
-      if (callbackData.length > 64) {
+      if (!callbackData && !url) {
+        throw new Error(`buttons[${rowIndex}][${buttonIndex}] requires callback_data or url`);
+      }
+      if (callbackData && url) {
+        throw new Error(`buttons[${rowIndex}][${buttonIndex}] cannot have both callback_data and url`);
+      }
+      if (callbackData && callbackData.length > 64) {
         throw new Error(
           `buttons[${rowIndex}][${buttonIndex}] callback_data too long (max 64 chars)`,
         );
+      }
+      if (url) {
+        return { text, url };
       }
       return { text, callback_data: callbackData };
     });

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -52,8 +52,8 @@ type TelegramSendOpts = {
   quoteText?: string;
   /** Forum topic thread ID (for forum supergroups) */
   messageThreadId?: number;
-  /** Inline keyboard buttons (reply markup). */
-  buttons?: Array<Array<{ text: string; callback_data: string }>>;
+  /** Inline keyboard buttons (reply markup). Each button must have text and either callback_data or url. */
+  buttons?: Array<Array<{ text: string; callback_data?: string; url?: string }>>;
 };
 
 type TelegramSendResult = {
@@ -214,12 +214,14 @@ export function buildInlineKeyboard(
   const rows = buttons
     .map((row) =>
       row
-        .filter((button) => button?.text && button?.callback_data)
+        .filter((button) => button?.text && (button?.callback_data || button?.url))
         .map(
-          (button): InlineKeyboardButton => ({
-            text: button.text,
-            callback_data: button.callback_data,
-          }),
+          (button): InlineKeyboardButton => {
+            if (button.url) {
+              return { text: button.text, url: button.url };
+            }
+            return { text: button.text, callback_data: button.callback_data! };
+          },
         ),
     )
     .filter((row) => row.length > 0);


### PR DESCRIPTION
## Summary
Telegram inline keyboard buttons can be either:
- `callback_data`: triggers callback query to bot
- `url`: opens a URL directly in user's browser

This PR allows agents to send buttons with `url` property in addition to `callback_data`, enabling direct links to external resources (e.g., web dashboards, documentation) from Telegram messages.

## Usage
```javascript
buttons=[[{"text": "Open Dashboard", "url": "https://example.com"}]]
```

## Changes
- Updated `TelegramButton` type to support optional `url`
- Updated `readTelegramButtons()` validation to accept either `callback_data` OR `url` (but not both)
- Updated `buildInlineKeyboard()` to construct url-type buttons

## Testing
- Buttons with only `callback_data` work as before
- Buttons with only `url` now open the URL directly
- Validation rejects buttons with both or neither

Closes #4280 (related)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends Telegram inline keyboard support to allow URL buttons (`{text, url}`) in addition to callback buttons (`{text, callback_data}`): agent-side parameter parsing (`readTelegramButtons`) now validates “exactly one of callback_data/url”, and `buildInlineKeyboard()` now emits `InlineKeyboardButton` objects with either `url` or `callback_data`.

However, the edit-message path is still typed as callback-only: `handleTelegramAction(action="editMessage")` passes the newly-supported URL button shapes through to `editMessageTelegram()`, but `TelegramEditOpts.buttons` hasn’t been updated, making URL buttons effectively unsupported for edits and creating an inconsistency between send vs edit APIs.

<h3>Confidence Score: 3/5</h3>

- Moderately safe to merge, but URL buttons are not consistently supported across send vs edit paths.
- Core parsing and keyboard construction changes look correct, but `editMessageTelegram` still accepts callback-only button types while agent actions can now produce URL buttons for edits; this mismatch will break type-checking or prevent the feature from working in the editMessage flow.
- src/telegram/send.ts

<sub>Last reviewed commit: 6a231eb</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->