### PR TITLE
fix(memory): handle mixed/no-results QMD query output

### DIFF
--- a/src/memory/qmd-query-parser.test.ts
+++ b/src/memory/qmd-query-parser.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { parseQmdQueryJson } from "./qmd-query-parser.js";
+
+describe("parseQmdQueryJson", () => {
+  it("parses plain JSON output", () => {
+    const result = parseQmdQueryJson(
+      '[{"docid":"#abc123","score":0.9,"file":"qmd://citadel/a.md","snippet":"hello"}]',
+      "",
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0]?.docid).toBe("#abc123");
+  });
+
+  it("parses JSON payload when progress lines are mixed into stdout", () => {
+    const stdout = [
+      "Expanding query...",
+      "Searching 2 lexical + 2 vector queries...",
+      "\u001b]9;4;3\u0007Reranking not supported by OpenAI provider, returning original order.",
+      "\u001b]9;4;0\u0007",
+      "[",
+      '  {"docid":"#abc123","score":1,"file":"qmd://citadel/a.md","snippet":"text"}',
+      "]",
+    ].join("\n");
+
+    const result = parseQmdQueryJson(stdout, "");
+    expect(result).toHaveLength(1);
+    expect(result[0]?.file).toBe("qmd://citadel/a.md");
+  });
+
+  it("returns empty when no-results marker is present", () => {
+    const stdout = [
+      "Expanding query...",
+      "Searching 2 lexical + 2 vector queries...",
+      "No results found above minimum score threshold.",
+    ].join("\n");
+
+    const result = parseQmdQueryJson(stdout, "");
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty when stderr contains no-results marker and stdout is empty", () => {
+    const result = parseQmdQueryJson("", "No results found.");
+    expect(result).toEqual([]);
+  });
+
+  it("throws when output has no JSON payload and no no-results marker", () => {
+    expect(() => parseQmdQueryJson("Reranking documents...", "bad things happened")).toThrow(
+      "qmd query returned invalid JSON",
+    );
+  });
+});

--- a/src/memory/qmd-query-parser.ts
+++ b/src/memory/qmd-query-parser.ts
@@ -1,6 +1,9 @@
 import { createSubsystemLogger } from "../logging/subsystem.js";
 
 const log = createSubsystemLogger("memory");
+const ANSI_CSI_RE = new RegExp(String.raw`\u001b\[[0-?]*[ -/]*[@-~]`, "g");
+const ANSI_OSC_RE = new RegExp(String.raw`\u001b\][^\u0007]*(?:\u0007|\u001b\\)`, "g");
+const NO_RESULTS_LINE_RE = /^no results found(?: above minimum score threshold)?\.?$/i;
 
 export type QmdQueryResult = {
   docid?: string;
@@ -11,21 +14,32 @@ export type QmdQueryResult = {
 };
 
 export function parseQmdQueryJson(stdout: string, stderr: string): QmdQueryResult[] {
-  const trimmedStdout = stdout.trim();
-  const trimmedStderr = stderr.trim();
-  const stdoutIsMarker = trimmedStdout.length > 0 && isQmdNoResultsOutput(trimmedStdout);
-  const stderrIsMarker = trimmedStderr.length > 0 && isQmdNoResultsOutput(trimmedStderr);
-  if (stdoutIsMarker || (!trimmedStdout && stderrIsMarker)) {
-    return [];
+  const normalizedStdout = normalizeQmdOutput(stdout);
+  const normalizedStderr = normalizeQmdOutput(stderr);
+  const stdoutHasNoResults = containsNoResultsMarker(normalizedStdout);
+  const stderrHasNoResults = containsNoResultsMarker(normalizedStderr);
+  const jsonPayload = extractJsonArray(normalizedStdout) ?? extractJsonArray(normalizedStderr);
+
+  if (!jsonPayload) {
+    if (stdoutHasNoResults || (!normalizedStdout.trim() && stderrHasNoResults)) {
+      return [];
+    }
+    if (stderrHasNoResults) {
+      return [];
+    }
   }
-  if (!trimmedStdout) {
-    const context = trimmedStderr ? ` (stderr: ${summarizeQmdStderr(trimmedStderr)})` : "";
-    const message = `stdout empty${context}`;
+
+  if (!jsonPayload) {
+    const context = normalizedStderr.trim()
+      ? ` (stderr: ${summarizeQmdStderr(normalizedStderr.trim())})`
+      : "";
+    const message = `stdout did not contain JSON array${context}`;
     log.warn(`qmd query returned invalid JSON: ${message}`);
     throw new Error(`qmd query returned invalid JSON: ${message}`);
   }
+
   try {
-    const parsed = JSON.parse(trimmedStdout) as unknown;
+    const parsed = JSON.parse(jsonPayload) as unknown;
     if (!Array.isArray(parsed)) {
       throw new Error("qmd query JSON response was not an array");
     }
@@ -37,9 +51,95 @@ export function parseQmdQueryJson(stdout: string, stderr: string): QmdQueryResul
   }
 }
 
-function isQmdNoResultsOutput(raw: string): boolean {
-  const normalized = raw.trim().toLowerCase().replace(/\s+/g, " ");
-  return normalized === "no results found" || normalized === "no results found.";
+function normalizeQmdOutput(raw: string): string {
+  if (!raw) {
+    return "";
+  }
+  return raw.replace(ANSI_OSC_RE, "").replace(ANSI_CSI_RE, "").replace(/\r/g, "");
+}
+
+function containsNoResultsMarker(raw: string): boolean {
+  if (!raw.trim()) {
+    return false;
+  }
+  const lines = raw
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+  for (const line of lines) {
+    const normalized = line.toLowerCase().replace(/\s+/g, " ");
+    if (NO_RESULTS_LINE_RE.test(normalized)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function extractJsonArray(raw: string): string | null {
+  const text = raw.trim();
+  if (!text) {
+    return null;
+  }
+  for (let i = 0; i < text.length; i += 1) {
+    if (text[i] !== "[") {
+      continue;
+    }
+    const candidate = extractBalancedArray(text, i);
+    if (!candidate) {
+      continue;
+    }
+    try {
+      const parsed = JSON.parse(candidate) as unknown;
+      if (Array.isArray(parsed)) {
+        return candidate;
+      }
+    } catch {
+      // keep scanning for the next potential payload
+    }
+  }
+  return null;
+}
+
+function extractBalancedArray(raw: string, startIdx: number): string | null {
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let idx = startIdx; idx < raw.length; idx += 1) {
+    const ch = raw[idx];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+      if (ch === "\\") {
+        escaped = true;
+        continue;
+      }
+      if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+      continue;
+    }
+    if (ch === "[") {
+      depth += 1;
+      continue;
+    }
+    if (ch !== "]") {
+      continue;
+    }
+    depth -= 1;
+    if (depth === 0) {
+      return raw.slice(startIdx, idx + 1);
+    }
+    if (depth < 0) {
+      return null;
+    }
+  }
+  return null;
 }
 
 function summarizeQmdStderr(raw: string): string {


### PR DESCRIPTION
## Summary\n- normalize QMD stdout/stderr by stripping ANSI CSI/OSC sequences before parsing\n- extract balanced JSON array payloads from mixed output (progress + payload)\n- treat `No results found` markers as an empty result set instead of parse failures\n- add parser-focused unit tests for mixed output, no-results markers, and invalid payload paths\n\n## Verification\n- `pnpm exec oxlint src/memory/qmd-query-parser.ts src/memory/qmd-query-parser.test.ts`\n- `pnpm exec tsc -p tsconfig.json --noEmit`\n- `pnpm exec vitest run src/memory/qmd-query-parser.test.ts src/memory/qmd-manager.test.ts --reporter=dot`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens QMD query parsing by normalizing CLI output (stripping ANSI CSI/OSC sequences and CRs), scanning mixed stdout/stderr for a balanced JSON array payload, and treating known “No results found …” markers as an empty result set instead of a parsing failure. It also adds unit tests covering plain JSON, mixed progress+payload output, no-results markers (stdout/stderr), and the error path when no JSON payload is present.

In the codebase, `QmdMemoryManager.search()` shells out to the `qmd` CLI and calls `parseQmdQueryJson(stdout, stderr)` to turn that output into structured results; this change makes that integration resilient to extra non-JSON output emitted by the CLI.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are localized to QMD output parsing and are backed by focused unit tests for the new behaviors (mixed output, no-results markers, and error cases). The parser still throws on truly invalid output and only relaxes behavior for known benign output patterns.
- src/memory/qmd-query-parser.ts

<sub>Last reviewed commit: 229d6b6</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->