### PR TITLE
fix(sessions): normalize absolute sessionFile paths for v2026.2.12 compatibility

### DIFF
--- a/src/config/sessions/paths.test.ts
+++ b/src/config/sessions/paths.test.ts
@@ -72,6 +72,42 @@ describe("session path safety", () => {
     expect(resolved).toBe(path.resolve(sessionsDir, "subdir/threaded-session.jsonl"));
   });
 
+  it("accepts absolute sessionFile paths that resolve within the sessions dir", () => {
+    const sessionsDir = "/tmp/openclaw/agents/main/sessions";
+
+    const resolved = resolveSessionFilePath(
+      "sess-1",
+      { sessionFile: "/tmp/openclaw/agents/main/sessions/abc-123.jsonl" },
+      { sessionsDir },
+    );
+
+    expect(resolved).toBe(path.resolve(sessionsDir, "abc-123.jsonl"));
+  });
+
+  it("accepts absolute sessionFile with topic suffix within the sessions dir", () => {
+    const sessionsDir = "/tmp/openclaw/agents/main/sessions";
+
+    const resolved = resolveSessionFilePath(
+      "sess-1",
+      { sessionFile: "/tmp/openclaw/agents/main/sessions/abc-123-topic-42.jsonl" },
+      { sessionsDir },
+    );
+
+    expect(resolved).toBe(path.resolve(sessionsDir, "abc-123-topic-42.jsonl"));
+  });
+
+  it("rejects absolute sessionFile paths outside the sessions dir", () => {
+    const sessionsDir = "/tmp/openclaw/agents/main/sessions";
+
+    expect(() =>
+      resolveSessionFilePath(
+        "sess-1",
+        { sessionFile: "/tmp/openclaw/agents/work/sessions/abc-123.jsonl" },
+        { sessionsDir },
+      ),
+    ).toThrow(/within sessions directory/);
+  });
+
   it("uses agent sessions dir fallback for transcript path", () => {
     const resolved = resolveSessionTranscriptPath("sess-1", "main");
     expect(resolved.endsWith(path.join("agents", "main", "sessions", "sess-1.jsonl"))).toBe(true);

--- a/src/config/sessions/paths.ts
+++ b/src/config/sessions/paths.ts
@@ -77,12 +77,14 @@ function resolvePathWithinSessionsDir(sessionsDir: string, candidate: string): s
     throw new Error("Session file path must not be empty");
   }
   const resolvedBase = path.resolve(sessionsDir);
-  const resolvedCandidate = path.resolve(resolvedBase, trimmed);
-  const relative = path.relative(resolvedBase, resolvedCandidate);
-  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+  // Normalize absolute paths that are within the sessions directory.
+  // Older versions stored absolute sessionFile paths in sessions.json;
+  // convert them to relative so the containment check passes.
+  const normalized = path.isAbsolute(trimmed) ? path.relative(resolvedBase, trimmed) : trimmed;
+  if (!normalized || normalized.startsWith("..") || path.isAbsolute(normalized)) {
     throw new Error("Session file path must be within sessions directory");
   }
-  return resolvedCandidate;
+  return path.resolve(resolvedBase, normalized);
 }
 
 export function resolveSessionTranscriptPathInDir(


### PR DESCRIPTION
## Summary

Fixes the "Session file path must be within sessions directory" error that breaks all Telegram/WhatsApp group handlers in v2026.2.12.

## Root Cause

Older OpenClaw versions stored **absolute** `sessionFile` paths in `sessions.json`. v2026.2.12 added path traversal security in `resolvePathWithinSessionsDir()` that rejected these absolute paths.

## Changes

- `resolvePathWithinSessionsDir()` now normalizes absolute paths that resolve within the sessions directory, converting them to relative before validation
- Added 3 tests for absolute path handling (within dir ✅, with topic ✅, outside dir ❌)

## Fixes

Fixes #15283
Closes #15214, #15237, #15216, #15152, #15213

## Testing

- [x] `pnpm build` passes
- [x] `pnpm lint` passes (0 warnings, 0 errors)  
- [x] `src/config/sessions/paths.test.ts` passes (12/12 tests)
- [ ] Full test suite (CI will verify)

## Checklist

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Tests added
- [x] Build passes
- [x] Lint passes

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates session transcript path resolution to maintain compatibility with older `sessions.json` entries that stored absolute `sessionFile` paths.

Specifically, `resolvePathWithinSessionsDir()` now converts absolute candidates into a relative path *when they are within* the configured sessions directory, and continues to reject paths that would escape the sessions directory. The PR also adds targeted Vitest coverage for absolute paths (inside dir, with topic suffix, and outside dir rejection).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is localized to session path normalization, preserves the existing containment check behavior for relative inputs, and adds direct tests for the new absolute-path compatibility behavior (including a negative case). No unhandled exceptions or API changes were introduced.
- No files require special attention

<sub>Last reviewed commit: 1ad5abe</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->