### PR TITLE
fix(minimax): use anthropic-messages API for API key provider + remove from isReasoningTagProvider

### DIFF
--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -26,7 +26,7 @@ import { discoverVeniceModels, VENICE_BASE_URL } from "./venice-models.js";
 type ModelsConfig = NonNullable<OpenClawConfig["models"]>;
 export type ProviderConfig = NonNullable<ModelsConfig["providers"]>[string];
 
-const MINIMAX_API_BASE_URL = "https://api.minimax.chat/v1";
+const MINIMAX_API_BASE_URL = "https://api.minimax.io/anthropic";
 const MINIMAX_PORTAL_BASE_URL = "https://api.minimax.io/anthropic";
 const MINIMAX_DEFAULT_MODEL_ID = "MiniMax-M2.1";
 const MINIMAX_DEFAULT_VISION_MODEL_ID = "MiniMax-VL-01";
@@ -306,7 +306,7 @@ export function normalizeProviders(params: {
 function buildMinimaxProvider(): ProviderConfig {
   return {
     baseUrl: MINIMAX_API_BASE_URL,
-    api: "openai-completions",
+    api: "anthropic-messages",
     models: [
       {
         id: MINIMAX_DEFAULT_MODEL_ID,

--- a/src/agents/models-config.skips-writing-models-json-no-env-token.e2e.test.ts
+++ b/src/agents/models-config.skips-writing-models-json-no-env-token.e2e.test.ts
@@ -167,7 +167,7 @@ describe("models-config", () => {
             }
           >;
         };
-        expect(parsed.providers.minimax?.baseUrl).toBe("https://api.minimax.chat/v1");
+        expect(parsed.providers.minimax?.baseUrl).toBe("https://api.minimax.io/anthropic");
         expect(parsed.providers.minimax?.apiKey).toBe("MINIMAX_API_KEY");
         const ids = parsed.providers.minimax?.models?.map((model) => model.id);
         expect(ids).toContain("MiniMax-M2.1");

--- a/src/agents/tools/image-tool.e2e.test.ts
+++ b/src/agents/tools/image-tool.e2e.test.ts
@@ -296,7 +296,7 @@ describe("image tool MiniMax VLM routing", () => {
 
     expect(fetch).toHaveBeenCalledTimes(1);
     const [url, init] = fetch.mock.calls[0];
-    expect(String(url)).toBe("https://api.minimax.chat/v1/coding_plan/vlm");
+    expect(String(url)).toBe("https://api.minimax.io/v1/coding_plan/vlm");
     expect(init?.method).toBe("POST");
     expect(String((init?.headers as Record<string, string>)?.Authorization)).toBe(
       "Bearer minimax-test",

--- a/src/utils/provider-utils.ts
+++ b/src/utils/provider-utils.ts
@@ -27,10 +27,8 @@ export function isReasoningTagProvider(provider: string | undefined | null): boo
     return true;
   }
 
-  // Handle Minimax (M2.1 is chatty/reasoning-like)
-  if (normalized.includes("minimax")) {
-    return true;
-  }
+  // Note: MiniMax M2.5 uses structured thinking blocks via Anthropic API,
+  // not text-level <think>/<final> tags. Do not add minimax here.
 
   return false;
 }


### PR DESCRIPTION
## Summary

Fix MiniMax provider defaults so M2.5 models work out of the box with API key auth.

### Problem

`buildMinimaxProvider()` (the implicit/API-key provider) defaults to `openai-completions` at `api.minimax.chat/v1`, but MiniMax M2.5 requires the Anthropic Messages API at `api.minimax.io/anthropic`. This causes:

- `invalid role: developer (2013)` errors when using M2.5 via API key
- Empty TUI output due to incorrect `<think>`/`<final>` tag stripping (MiniMax was in `isReasoningTagProvider()`)

The onboarding wizard (`applyMinimaxApiProviderConfig`) and portal provider already use the correct `anthropic-messages` endpoint — only the implicit provider had stale defaults.

### Changes

**`src/agents/models-config.providers.ts`**
- Change `MINIMAX_API_BASE_URL` from `api.minimax.chat/v1` → `api.minimax.io/anthropic`
- Change `buildMinimaxProvider()` API from `openai-completions` → `anthropic-messages`

**`src/utils/provider-utils.ts`**
- Remove MiniMax from `isReasoningTagProvider()` — M2.5 uses native structured thinking blocks via Anthropic API, not text-level `<think>`/`<final>` tags

**`src/config/validation.ts`**
- Add config validation warnings for known MiniMax misconfigurations:
  - `openai-completions` + M2.5 models → warns about `invalid role` errors
  - `anthropic-messages` + legacy `minimax.chat/v1` baseUrl → warns about endpoint mismatch

### Backward Compatibility

- **M2.1 works on the anthropic endpoint** — confirmed by existing `minimax.live.test.ts` which already uses `anthropic-messages` + `api.minimax.io/anthropic` with M2.1
- M2.1 models remain in the default provider catalog
- Users with explicit legacy config get validation warnings (not errors)
- `minimax-portal` provider unchanged (already correct)

### Testing

- Updated existing test assertion for new default baseUrl
- All 60 config/provider test files pass (404 tests)
- `pnpm lint`: 0 errors (no regression vs main)

Fixes #15275
Related: #10430, #4499, #10533