### PR TITLE
feat(tts): add new OpenAI TTS voices (marin, cedar, verse, ballad)

### DIFF
--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -842,13 +842,18 @@ function isCustomOpenAIEndpoint(): boolean {
 export const OPENAI_TTS_VOICES = [
   "alloy",
   "ash",
+  "ballad",
   "coral",
   "echo",
   "fable",
-  "onyx",
   "nova",
+  "onyx",
   "sage",
   "shimmer",
+  "verse",
+  // gpt-4o-mini-tts exclusive voices (recommended for best quality)
+  "marin",
+  "cedar",
 ] as const;
 
 type OpenAiTtsVoice = (typeof OPENAI_TTS_VOICES)[number];


### PR DESCRIPTION
## Summary

OpenAI's gpt-4o-mini-tts model supports additional voices that were missing from the `OPENAI_TTS_VOICES` array:

- `ballad`
- `verse`
- `marin` (recommended for best quality)
- `cedar` (recommended for best quality)

## Reference

- [OpenAI TTS Documentation](https://platform.openai.com/docs/guides/text-to-speech)

> For best quality, we recommend using marin or cedar.

## Changes

- Added 4 new voices to `src/tts/tts.ts`

## Testing

Verified that the OpenAI API accepts these voices with `gpt-4o-mini-tts` model.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends the OpenAI TTS voice allowlist (`OPENAI_TTS_VOICES`) in `src/tts/tts.ts` by adding the new `gpt-4o-mini-tts` voices: `ballad`, `verse`, `marin`, and `cedar`.

In the current codebase, this array is used to validate user-specified/override voices before making the OpenAI `/audio/speech` request (`isValidOpenAIVoice()`), so expanding the list enables these voices without changing request behavior for existing voices.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is a small, localized allowlist expansion for OpenAI TTS voice validation only; no behavioral logic changes beyond accepting additional valid voice strings.
- No files require special attention

<sub>Last reviewed commit: d3d9c47</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->