### PR TITLE
Cosine/add openrouter support

### DIFF
--- a/docs/cli/onboard.md
+++ b/docs/cli/onboard.md
@@ -26,6 +26,19 @@ openclaw onboard --flow manual
 openclaw onboard --mode remote --remote-url ws://gateway-host:18789
 ```
 
+OpenRouter free models preset (API key + auto scan):
+
+```bash
+openclaw onboard --auth-choice openrouter-free \
+  --openrouter-api-key "$OPENROUTER_API_KEY"
+```
+
+This preset will:
+
+- Set your OpenRouter API key (same as `openrouter-api-key`).
+- Automatically run `openclaw models scan --yes --set-default --set-image` under the hood to
+  configure free OpenRouter models (primary + image) in your config.
+
 Non-interactive custom provider:
 
 ```bash

--- a/docs/providers/openrouter.md
+++ b/docs/providers/openrouter.md
@@ -30,6 +30,14 @@ export OPENROUTER_API_KEY="sk-or-..."
 openclaw models scan --yes --set-default --set-image
 ```
 
+Alternatively, you can wire this into onboarding directly with the `openrouter-free`
+preset, which sets your API key and runs the same scan under the hood:
+
+```bash
+openclaw onboard --auth-choice openrouter-free \
+  --openrouter-api-key "$OPENROUTER_API_KEY"
+```
+
 This will:
 
 - Call OpenRouter's `/models` endpoint and filter to free models (by `:free` suffix or zero pricing).

--- a/docs/providers/openrouter.md
+++ b/docs/providers/openrouter.md
@@ -17,7 +17,34 @@ endpoint and API key. It is OpenAI-compatible, so most OpenAI SDKs work by switc
 openclaw onboard --auth-choice apiKey --token-provider openrouter --token "$OPENROUTER_API_KEY"
 ```
 
-## Config snippet
+## Free models quickstart
+
+OpenClaw can automatically discover and configure **free** OpenRouter models via the
+built-in scan command:
+
+```bash
+# 1) Ensure your OpenRouter key is available
+export OPENROUTER_API_KEY="sk-or-..."
+
+# 2) Scan only free models, probe tools/images, and write them into openclaw.json
+openclaw models scan --yes --set-default --set-image
+```
+
+This will:
+
+- Call OpenRouter's `/models` endpoint and filter to free models (by `:free` suffix or zero pricing).
+- Probe candidate models for **tool** and **image** support (unless you add `--no-probe`).
+- Update your `openclaw.json` so that:
+  - `agents.defaults.model` points at a good free text model.
+  - `agents.defaults.imageModel` points at a free vision model (when available).
+  - `agents.defaults.models` contains an allowlist of the selected OpenRouter models.
+
+After that, `/model` in chat and the various UIs will list those free OpenRouter models
+like any other provider.
+
+## Manual config snippet
+
+If you prefer to configure a specific OpenRouter model by hand:
 
 ```json5
 {

--- a/src/commands/auth-choice-options.test.ts
+++ b/src/commands/auth-choice-options.test.ts
@@ -134,4 +134,14 @@ describe("buildAuthChoiceOptions", () => {
 
     expect(options.some((opt) => opt.value === "xai-api-key")).toBe(true);
   });
+
+  it("includes OpenRouter free models auth choice", () => {
+    const store: AuthProfileStore = { version: 1, profiles: {} };
+    const options = buildAuthChoiceOptions({
+      store,
+      includeSkip: false,
+    });
+
+    expect(options.some((opt) => opt.value === "openrouter-free")).toBe(true);
+  });
 });

--- a/src/commands/auth-choice-options.ts
+++ b/src/commands/auth-choice-options.ts
@@ -82,7 +82,7 @@ const AUTH_CHOICE_GROUP_DEFS: {
     value: "openrouter",
     label: "OpenRouter",
     hint: "API key",
-    choices: ["openrouter-api-key"],
+    choices: ["openrouter-api-key", "openrouter-free"],
   },
   {
     value: "qwen",
@@ -189,6 +189,11 @@ export function buildAuthChoiceOptions(params: {
     label: "Qianfan API key",
   });
   options.push({ value: "openrouter-api-key", label: "OpenRouter API key" });
+  options.push({
+    value: "openrouter-free",
+    label: "OpenRouter (free models)",
+    hint: "API key + auto-select free models via scan",
+  });
   options.push({
     value: "litellm-api-key",
     label: "LiteLLM API key",

--- a/src/commands/auth-choice.preferred-provider.ts
+++ b/src/commands/auth-choice.preferred-provider.ts
@@ -11,6 +11,7 @@ const PREFERRED_PROVIDER_BY_AUTH_CHOICE: Partial<Record<AuthChoice, string>> = {
   chutes: "chutes",
   "openai-api-key": "openai",
   "openrouter-api-key": "openrouter",
+  "openrouter-free": "openrouter",
   "ai-gateway-api-key": "vercel-ai-gateway",
   "cloudflare-ai-gateway-api-key": "cloudflare-ai-gateway",
   "moonshot-api-key": "moonshot",

--- a/src/commands/auth-choice.test.ts
+++ b/src/commands/auth-choice.test.ts
@@ -1116,6 +1116,10 @@ describe("resolvePreferredProviderForAuthChoice", () => {
     expect(resolvePreferredProviderForAuthChoice("qwen-portal")).toBe("qwen-portal");
   });
 
+  it("maps openrouter-free to openrouter", () => {
+    expect(resolvePreferredProviderForAuthChoice("openrouter-free")).toBe("openrouter");
+  });
+
   it("returns undefined for unknown choices", () => {
     expect(resolvePreferredProviderForAuthChoice("unknown" as AuthChoice)).toBeUndefined();
   });

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -12,6 +12,7 @@ export type AuthChoice =
   | "openai-codex"
   | "openai-api-key"
   | "openrouter-api-key"
+  | "openrouter-free"
   | "litellm-api-key"
   | "ai-gateway-api-key"
   | "cloudflare-ai-gateway-api-key"


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds an `openrouter-free` onboarding preset alongside the existing OpenRouter API-key option. The preset stores an OpenRouter API key, then runs `openclaw models scan --yes --set-default --set-image` under the hood to discover free OpenRouter models and populate `agents.defaults` (model/imageModel/models allowlist). It also updates the auth-choice option lists, preferred-provider mapping, and adds tests/docs for the new flow.

Key integration point: both interactive (`applyAuthChoiceApiProviders`) and non-interactive (`applyNonInteractiveAuthChoice`) onboarding paths now invoke `modelsScanCommand()` and then re-read `readConfigFileSnapshot()` to copy the resulting defaults into the in-memory config.

<h3>Confidence Score: 3/5</h3>

- This PR is mergeable after addressing config write side-effects during onboarding.
- The feature is well-scoped and has tests/docs, but `openrouter-free` currently runs `modelsScanCommand()` which writes to the on-disk config mid-onboarding, creating a real risk of partial or divergent config writes if onboarding later fails/cancels or if config-path resolution differs between contexts.
- src/commands/auth-choice.apply.api-providers.ts, src/commands/onboard-non-interactive/local/auth-choice.ts

<sub>Last reviewed commit: 357394a</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->