### PR TITLE
feat: Add LaFam Agent API support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ USER.md
 
 # local tooling
 .serena/
+skills/lafam/scripts/.lafam_token.json

--- a/skills/lafam/SKILL.md
+++ b/skills/lafam/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: lafam
+description: Interact with the LaFam / Mishpuha event-and-community platform API. Use when you need to list, create, update, or delete events, artists, locations, services, communities, posts, bookings, or tickets on LaFam. Also use for searching, tagging, social links, playable media (YouTube/SoundCloud), cart/checkout flows, interactions (like/follow/save), uploads, profile management, and AGENT OPERATIONS (purchase tickets, send SMS/email, lookup users, view stats, manage bookings). Covers every LaFam API endpoint including the full Agent Transaction API.
+---
+
+# LaFam — Mishpuha Platform Skill
+
+## How to run
+
+All commands go through the dispatcher script:
+
+```bash
+bash /Users/daniel/Projects/MishpuhaWorld/openclaw/skills/lafam/scripts/lafam.sh <action> [args...]
+```
+
+Auth is **fully automatic** — the script logs in on first use, caches the token, and re-logins transparently on 401. No manual token management needed.
+
+Credentials (baked in): `flopi_bot@lafam.world` / `bot@442`  
+Base URL: `https://events-api-tq4b.onrender.com`
+
+---
+
+## Quick examples
+
+```bash
+# List communities
+bash lafam.sh communities:list --limit 5
+
+# Search for artists
+bash lafam.sh artists:search "psytrance"
+
+# Get an event by ID
+bash lafam.sh events:get cmbrwipf90009pq382hjr4f7f
+
+# Create an event (pass JSON as single quoted arg)
+bash lafam.sh events:create '{"title":"Beach Party","description":"Summer vibes","startDate":"2026-07-01T20:00:00.000Z","endDate":"2026-07-02T04:00:00.000Z","location":"Beach Tel Aviv","ownerId":"<userId>","ticketTypes":[{"name":"General","price":80,"quantity":300,"kind":"GENERAL","description":"Standard entry"}]}'
+
+# Upload an image, then use the returned URL in create calls
+bash lafam.sh upload:image /path/to/poster.jpg
+
+# Get playable media (YouTube + SoundCloud links)
+bash lafam.sh artists:playable-media
+bash lafam.sh communities:playable-media <communityId>
+bash lafam.sh social-links:by-platform YOUTUBE,SOUNDCLOUD
+
+# Global search
+bash lafam.sh search "goa trance"
+
+# Like an artist + follow
+bash lafam.sh interactions:like-artist <artistId>
+bash lafam.sh interactions:follow-artist <artistId>
+
+# AGENT API — Send SMS
+bash lafam.sh agent:notify:sms '{"to":"052-3581008","message":"דונט וורי בי דרורי"}'
+
+# AGENT API — Search products
+bash lafam.sh agent:products:search --q "psytrance" --limit 10
+
+# AGENT API — Purchase ticket
+bash lafam.sh agent:purchase '{"productId":"<ticketTypeId>","quantity":1,"user":{"name":"John","email":"john@example.com","phone":"0501234567","gender":"זכר","birthday":"1990-01-01"},"agentCode":"flopi_bot"}'
+
+# AGENT API — Get stats
+bash lafam.sh agent:stats flopi_bot
+```
+
+---
+
+## Action groups at a glance
+
+| Group                     | Key actions                                                                                                                                                                    |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Events**                | `events:list`, `events:get`, `events:create`, `events:update`, `events:delete`, `events:stats`, `events:tickets`                                                               |
+| **Ticket types**          | `tickets:list`, `tickets:create`, `tickets:update`, `tickets:delete`                                                                                                           |
+| **Artists**               | `artists:list`, `artists:search`, `artists:get`, `artists:create`, `artists:update`, `artists:delete`, `artists:playable-media`, `artists:bookings`                            |
+| **Locations**             | `locations:list`, `locations:search`, `locations:get`, `locations:create`, `locations:update`, `locations:delete`                                                              |
+| **Services**              | `services:list`, `services:search`, `services:get`, `services:create`, `services:update`, `services:delete`                                                                    |
+| **Communities**           | `communities:list`, `communities:get`, `communities:events`, `communities:members`, `communities:feed`, `communities:playable-media`, `communities:join`, `communities:agents` |
+| **Posts & Comments**      | `posts:list`, `posts:get`, `posts:create`, `posts:search`, `posts:comment`, `posts:for-entity`                                                                                 |
+| **Interactions**          | `interactions:like-post`, `interactions:follow-artist`, `interactions:mine`, `interactions:check`                                                                              |
+| **Social Links**          | `social-links:by-platform`, `social-links:update`, `social-links:delete`                                                                                                       |
+| **Cart & Checkout**       | `cart:get`, `cart:add`, `cart:summary`, `cart:checkout`                                                                                                                        |
+| **Bookings**              | `bookings:create`, `bookings:list`, `bookings:mine`, `bookings:update-status`                                                                                                  |
+| **Tags & Search**         | `search`, `tags:entities`, `tags:popular`, `tags:popular-artists`, `tags:popular-events`                                                                                       |
+| **Profile**               | `profile:get`, `profile:update`, `profile:tickets`, `profile:transactions`, `profile:managed-items`                                                                            |
+| **Uploads**               | `upload:image`, `upload:config`                                                                                                                                                |
+| **Agent - Transactions**  | `agent:purchase`, `agent:transaction`                                                                                                                                          |
+| **Agent - Products**      | `agent:products:search`, `agent:products:merchandise`, `agent:products:events`, `agent:products:upcoming`, `agent:products:get`                                                |
+| **Agent - Users**         | `agent:user:lookup`, `agent:user:history`                                                                                                                                      |
+| **Agent - Notifications** | `agent:notify:sms`, `agent:notify:email`                                                                                                                                       |
+| **Agent - Stats**         | `agent:stats`, `agent:stats:sales`, `agent:stats:top-products`                                                                                                                 |
+| **Agent - Bookings**      | `agent:booking:create`, `agent:booking:get`, `agent:booking:update-status`, `agent:booking:cancel`, `agent:booking:list-user`, `agent:booking:list-event`                      |
+
+---
+
+## Full action reference
+
+See **`references/api-reference.md`** for the complete catalogue — every action, every argument, every field, with examples. Load it when you need the exact syntax for a specific action.
+
+---
+
+## Key notes
+
+1. **JSON args must be single-quoted** on the shell command line to avoid expansion: `'{"key":"value"}'`
+2. **Social link platforms:** `YOUTUBE`, `SOUNDCLOUD`, `INSTAGRAM`, `TWITTER`, `FACEBOOK`, `TIKTOK`, `SPOTIFY`, `WEBSITE`
+3. **Playable media = YouTube + SoundCloud.** Three ways to surface them: `artists:playable-media`, `communities:playable-media <id>`, or `social-links:by-platform YOUTUBE,SOUNDCLOUD`
+4. **Pagination:** Most list endpoints support `--page`/`--limit` or `--limit`/`--offset` flags (varies by domain — see reference)
+5. **Entity types** for `posts:for-entity`: `artist`, `location`, `service`, `community`
+6. **Cart session:** `cart:get` requires a session ID string (any unique identifier); pass it as the first arg
+7. **Upload → use:** Upload images with `upload:image <path>`, get back a URL, then pass that URL into `imageUrl` / `coverImageUrl` / `logoUrl` fields on create/update calls
+8. **`lafam.sh help`** prints the full action list with signatures — useful as a quick cheat sheet

--- a/skills/lafam/references/api-reference.md
+++ b/skills/lafam/references/api-reference.md
@@ -1,0 +1,400 @@
+# LaFam API Reference — Full Action Catalogue
+
+All actions go through `scripts/lafam.sh`. Auth is handled automatically (token cached, re-login on 401).  
+Base URL: `https://events-api-tq4b.onrender.com`
+
+---
+
+## AUTH
+
+| Action    | Description                              |
+| --------- | ---------------------------------------- |
+| `login`   | Force a fresh login (normally automatic) |
+| `refresh` | Force a token refresh                    |
+
+---
+
+## HEALTH
+
+| Action   | Example                            |
+| -------- | ---------------------------------- |
+| `health` | `lafam.sh health` — no auth needed |
+
+---
+
+## EVENTS
+
+| Action               | Usage                                                                                                |
+| -------------------- | ---------------------------------------------------------------------------------------------------- |
+| `events:list`        | `lafam.sh events:list [--query Q] [--tags t1,t2] [--page N] [--limit N] [--startDate ISO]`           |
+| `events:get`         | `lafam.sh events:get <eventId>`                                                                      |
+| `events:get-by-slug` | `lafam.sh events:get-by-slug <slug>`                                                                 |
+| `events:create`      | `lafam.sh events:create '<JSON>'`                                                                    |
+| `events:update`      | `lafam.sh events:update <eventId> '<JSON>'`                                                          |
+| `events:delete`      | `lafam.sh events:delete <eventId>`                                                                   |
+| `events:stats`       | `lafam.sh events:stats <eventId> [--timeframe <value>]`                                              |
+| `events:tickets`     | `lafam.sh events:tickets <eventId> [--page N] [--limit N] [--query Q] [--ticketType T] [--status S]` |
+
+### Create event — required fields
+
+```json
+{
+  "title": "My Event",
+  "description": "Description text",
+  "startDate": "2026-03-01T18:00:00.000Z",
+  "endDate": "2026-03-02T04:00:00.000Z",
+  "location": "Venue name or address",
+  "ownerId": "<userId>",
+  "ticketTypes": [{ "name": "General", "price": 100, "quantity": 200, "kind": "GENERAL" }]
+}
+```
+
+Optional: `communityIds`, `imageUrl`, `coverImageUrl`, `logoUrl`, `tags`, `slug`, `isPublic`, `hasBar`.
+
+---
+
+## TICKET TYPES (per event)
+
+| Action           | Usage                                                       |
+| ---------------- | ----------------------------------------------------------- |
+| `tickets:list`   | `lafam.sh tickets:list <eventId>`                           |
+| `tickets:create` | `lafam.sh tickets:create <eventId> '<JSON>'`                |
+| `tickets:update` | `lafam.sh tickets:update <eventId> <ticketTypeId> '<JSON>'` |
+| `tickets:delete` | `lafam.sh tickets:delete <eventId> <ticketTypeId>`          |
+
+### Create ticket type — fields
+
+Required: `name`, `description`, `price`, `quantity`, `kind`.  
+Optional: `isHidden`, `couponCode`, `iconName`, `startDate`, `endDate`.
+
+```json
+{ "name": "VIP", "description": "VIP access", "price": 250, "quantity": 50, "kind": "VIP" }
+```
+
+---
+
+## ARTISTS
+
+| Action                     | Usage                                                                                                                       |
+| -------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `artists:list`             | `lafam.sh artists:list [--page N] [--limit N]`                                                                              |
+| `artists:search`           | `lafam.sh artists:search "query"`                                                                                           |
+| `artists:get`              | `lafam.sh artists:get <artistId>`                                                                                           |
+| `artists:get-by-slug`      | `lafam.sh artists:get-by-slug <slug>`                                                                                       |
+| `artists:create`           | `lafam.sh artists:create '<JSON>'`                                                                                          |
+| `artists:update`           | `lafam.sh artists:update <artistId> '<JSON>'`                                                                               |
+| `artists:delete`           | `lafam.sh artists:delete <artistId>`                                                                                        |
+| `artists:add-social`       | `lafam.sh artists:add-social <artistId> '{"platform":"YOUTUBE","url":"https://..."}'`                                       |
+| `artists:add-socials-bulk` | `lafam.sh artists:add-socials-bulk <artistId> '[{"platform":"YOUTUBE","url":"..."},{"platform":"SOUNDCLOUD","url":"..."}]'` |
+| `artists:playable-media`   | `lafam.sh artists:playable-media` — returns artists with YOUTUBE/SOUNDCLOUD links                                           |
+| `artists:usage`            | `lafam.sh artists:usage <artistId>` — which communities use this artist                                                     |
+| `artists:bookings`         | `lafam.sh artists:bookings <artistId>`                                                                                      |
+
+### Create artist — fields
+
+Required: `name`.  
+Optional: `description`, `tags`, `imageUrl`, `coverImageUrl`, `artistImageUrl`, `country`, `hourlyRate`, `slug`, `communityIds`.
+
+---
+
+## LOCATIONS
+
+| Action                       | Usage                                                                               |
+| ---------------------------- | ----------------------------------------------------------------------------------- |
+| `locations:list`             | `lafam.sh locations:list [--page N] [--limit N]`                                    |
+| `locations:search`           | `lafam.sh locations:search "query"`                                                 |
+| `locations:get`              | `lafam.sh locations:get <locationId>`                                               |
+| `locations:get-by-slug`      | `lafam.sh locations:get-by-slug <slug>`                                             |
+| `locations:create`           | `lafam.sh locations:create '<JSON>'`                                                |
+| `locations:update`           | `lafam.sh locations:update <locationId> '<JSON>'`                                   |
+| `locations:delete`           | `lafam.sh locations:delete <locationId>`                                            |
+| `locations:add-social`       | `lafam.sh locations:add-social <locationId> '{"platform":"INSTAGRAM","url":"..."}'` |
+| `locations:add-socials-bulk` | `lafam.sh locations:add-socials-bulk <locationId> '[...]'`                          |
+| `locations:usage`            | `lafam.sh locations:usage <locationId>`                                             |
+
+### Create location — fields
+
+Required: `name`, `address`, `tags` (array).  
+Optional: `description`, `capacity`, `amenities`, `imageUrl`, `hourlyRate`, `dailyRate`, `communityIds`.
+
+---
+
+## SERVICES
+
+| Action                      | Usage                                                                           |
+| --------------------------- | ------------------------------------------------------------------------------- |
+| `services:list`             | `lafam.sh services:list [--page N] [--limit N]`                                 |
+| `services:search`           | `lafam.sh services:search "query"`                                              |
+| `services:get`              | `lafam.sh services:get <serviceId>`                                             |
+| `services:get-by-slug`      | `lafam.sh services:get-by-slug <slug>`                                          |
+| `services:create`           | `lafam.sh services:create '<JSON>'`                                             |
+| `services:update`           | `lafam.sh services:update <serviceId> '<JSON>'`                                 |
+| `services:delete`           | `lafam.sh services:delete <serviceId>`                                          |
+| `services:add-social`       | `lafam.sh services:add-social <serviceId> '{"platform":"WEBSITE","url":"..."}'` |
+| `services:add-socials-bulk` | `lafam.sh services:add-socials-bulk <serviceId> '[...]'`                        |
+
+### Create service — fields
+
+Required: `name`.  
+Optional: `description`, `tags`, `imageUrl`, `coverImageUrl`, `baseRate`, `unit`, `communityIds`.
+
+---
+
+## COMMUNITIES
+
+| Action                          | Usage                                                                                 |
+| ------------------------------- | ------------------------------------------------------------------------------------- |
+| `communities:list`              | `lafam.sh communities:list [--limit N] [--offset N]`                                  |
+| `communities:get`               | `lafam.sh communities:get <communityId>`                                              |
+| `communities:get-by-slug`       | `lafam.sh communities:get-by-slug <slug>`                                             |
+| `communities:create`            | `lafam.sh communities:create '<JSON>'`                                                |
+| `communities:update`            | `lafam.sh communities:update <communityId> '<JSON>'`                                  |
+| `communities:delete`            | `lafam.sh communities:delete <communityId>`                                           |
+| `communities:events`            | `lafam.sh communities:events <communityId>`                                           |
+| `communities:members`           | `lafam.sh communities:members <communityId>`                                          |
+| `communities:join`              | `lafam.sh communities:join <communityId> ['{"message":"Hi!"}']`                       |
+| `communities:join-requests`     | `lafam.sh communities:join-requests <communityId>` — pending requests                 |
+| `communities:join-approve`      | `lafam.sh communities:join-approve <requestId> APPROVED` (or REJECTED)                |
+| `communities:related-artists`   | `lafam.sh communities:related-artists <communityId>`                                  |
+| `communities:related-locations` | `lafam.sh communities:related-locations <communityId>`                                |
+| `communities:related-services`  | `lafam.sh communities:related-services <communityId>`                                 |
+| `communities:playable-media`    | `lafam.sh communities:playable-media <communityId>` — YOUTUBE + SOUNDCLOUD            |
+| `communities:feed`              | `lafam.sh communities:feed`                                                           |
+| `communities:agents`            | `lafam.sh communities:agents <communityId>`                                           |
+| `communities:add-agent`         | `lafam.sh communities:add-agent <communityId> '{"email":"x@y.com","role":"MANAGER"}'` |
+
+### Create community — fields
+
+Required: `name`, `description`.  
+Optional: `imageUrl`, `coverImageUrl`, `tags`, `slug`.
+
+---
+
+## POSTS & COMMENTS
+
+| Action                 | Usage                                                     |
+| ---------------------- | --------------------------------------------------------- |
+| `posts:list`           | `lafam.sh posts:list [--limit N] [--offset N]`            |
+| `posts:get`            | `lafam.sh posts:get <postId>`                             |
+| `posts:create`         | `lafam.sh posts:create '<JSON>'`                          |
+| `posts:update`         | `lafam.sh posts:update <postId> '<JSON>'`                 |
+| `posts:delete`         | `lafam.sh posts:delete <postId>`                          |
+| `posts:search`         | `lafam.sh posts:search "query"`                           |
+| `posts:for-entity`     | `lafam.sh posts:for-entity artist <artistId>`             |
+| `posts:comments`       | `lafam.sh posts:comments <postId> [--page N] [--limit N]` |
+| `posts:comment`        | `lafam.sh posts:comment <postId> '{"content":"Nice!"}'`   |
+| `posts:comment-delete` | `lafam.sh posts:comment-delete <commentId>`               |
+
+### Create post — fields
+
+All optional: `title`, `content`, `imageUrls`, `tags`, `communityId`, `artistId`, `serviceId`, `locationId`, `isPublic`, `isPinned`, `isBookable`, `hourlyRate`, `dailyRate`, `socialLinks`.
+
+Entity types for `posts:for-entity`: `artist`, `location`, `service`, `community`.
+
+---
+
+## INTERACTIONS (likes, follows, saves)
+
+| Action                          | Usage                                                                   |
+| ------------------------------- | ----------------------------------------------------------------------- |
+| `interactions:like-post`        | `lafam.sh interactions:like-post <postId>`                              |
+| `interactions:save-post`        | `lafam.sh interactions:save-post <postId>`                              |
+| `interactions:post-info`        | `lafam.sh interactions:post-info <postId>`                              |
+| `interactions:like-artist`      | `lafam.sh interactions:like-artist <artistId>`                          |
+| `interactions:follow-artist`    | `lafam.sh interactions:follow-artist <artistId>`                        |
+| `interactions:artist-followers` | `lafam.sh interactions:artist-followers <artistId>`                     |
+| `interactions:mine`             | `lafam.sh interactions:mine like` (or `save`, `follow`)                 |
+| `interactions:check`            | `lafam.sh interactions:check '{"postIds":["..."],"artistIds":["..."]}'` |
+
+---
+
+## SOCIAL LINKS (generic)
+
+Supported platforms: `YOUTUBE`, `SOUNDCLOUD`, `INSTAGRAM`, `TWITTER`, `FACEBOOK`, `TIKTOK`, `SPOTIFY`, `WEBSITE`
+
+| Action                     | Usage                                                                           |
+| -------------------------- | ------------------------------------------------------------------------------- |
+| `social-links:by-platform` | `lafam.sh social-links:by-platform YOUTUBE,SOUNDCLOUD [--limit N] [--offset N]` |
+| `social-links:update`      | `lafam.sh social-links:update <linkId> '{"url":"https://new-url"}'`             |
+| `social-links:delete`      | `lafam.sh social-links:delete <linkId>`                                         |
+
+> **Playable media tip:** Use `social-links:by-platform YOUTUBE,SOUNDCLOUD` or `artists:playable-media` or `communities:playable-media` to surface embeddable audio/video links.
+
+---
+
+## CART
+
+| Action             | Usage                                                                                                                   |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------- |
+| `cart:get`         | `lafam.sh cart:get <sessionId>` — creates cart if none exists for session                                               |
+| `cart:add`         | `lafam.sh cart:add <cartId> '{"ticketTypeId":"...","quantity":1,"entityId":"...","entityType":"event"}'`                |
+| `cart:update-item` | `lafam.sh cart:update-item <cartId> <itemId> '{"quantity":3}'`                                                          |
+| `cart:remove-item` | `lafam.sh cart:remove-item <cartId> <itemId>`                                                                           |
+| `cart:clear`       | `lafam.sh cart:clear <cartId>`                                                                                          |
+| `cart:summary`     | `lafam.sh cart:summary <cartId>`                                                                                        |
+| `cart:checkout`    | `lafam.sh cart:checkout <cartId> '{"paymentMethod":"CARD","holderName":"...","holderEmail":"...","holderPhone":"..."}'` |
+
+---
+
+## BOOKINGS
+
+| Action                   | Usage                                                                  |
+| ------------------------ | ---------------------------------------------------------------------- |
+| `bookings:create`        | `lafam.sh bookings:create '<JSON>'`                                    |
+| `bookings:list`          | `lafam.sh bookings:list`                                               |
+| `bookings:get`           | `lafam.sh bookings:get <bookingId>`                                    |
+| `bookings:mine`          | `lafam.sh bookings:mine [--startDate ISO] [--endDate ISO]`             |
+| `bookings:update-status` | `lafam.sh bookings:update-status <bookingId> '{"status":"CONFIRMED"}'` |
+| `bookings:delete`        | `lafam.sh bookings:delete <bookingId>`                                 |
+
+### Create booking — fields
+
+Required: `startTime`, `endTime`, `totalAmount`.  
+Optional: `artistId`, `locationId`, `serviceId`, `eventId`, `paymentMethod`, `notes`.
+
+---
+
+## TAGS & SEARCH
+
+| Action                 | Usage                                                           |
+| ---------------------- | --------------------------------------------------------------- |
+| `search`               | `lafam.sh search "keyword"` — global search across all entities |
+| `tags:entities`        | `lafam.sh tags:entities <tagName>` — all entities with this tag |
+| `tags:popular`         | `lafam.sh tags:popular [--limit N]`                             |
+| `tags:popular-artists` | `lafam.sh tags:popular-artists`                                 |
+| `tags:popular-events`  | `lafam.sh tags:popular-events`                                  |
+
+---
+
+## PROFILE (bot user)
+
+| Action                  | Usage                                                              |
+| ----------------------- | ------------------------------------------------------------------ |
+| `profile:get`           | `lafam.sh profile:get`                                             |
+| `profile:update`        | `lafam.sh profile:update '<JSON>'`                                 |
+| `profile:tickets`       | `lafam.sh profile:tickets`                                         |
+| `profile:transactions`  | `lafam.sh profile:transactions`                                    |
+| `profile:managed-items` | `lafam.sh profile:managed-items`                                   |
+| `profile:add-social`    | `lafam.sh profile:add-social '{"platform":"YOUTUBE","url":"..."}'` |
+
+---
+
+## UPLOADS
+
+| Action          | Usage                                                                     |
+| --------------- | ------------------------------------------------------------------------- |
+| `upload:image`  | `lafam.sh upload:image /path/to/file.jpg` — multipart upload, returns URL |
+| `upload:config` | `lafam.sh upload:config` — see allowed types/sizes                        |
+
+---
+
+## AGENT API — TRANSACTIONS & OPERATIONS
+
+| Action              | Usage                                                                 |
+| ------------------- | --------------------------------------------------------------------- |
+| `agent:purchase`    | `lafam.sh agent:purchase '<JSON>'` — Create purchase transaction      |
+| `agent:transaction` | `lafam.sh agent:transaction <transactionId>` — Get transaction status |
+
+### Purchase Request — required fields
+
+```json
+{
+  "productId": "<ticketTypeId>",
+  "quantity": 1,
+  "user": {
+    "name": "Full Name",
+    "email": "user@example.com",
+    "phone": "0501234567",
+    "gender": "זכר",
+    "birthday": "1990-01-01"
+  },
+  "agentCode": "flopi_bot"
+}
+```
+
+Response includes `paymentUrl` (Cardcom) and `transactionId`.
+
+---
+
+## AGENT API — PRODUCTS
+
+| Action                       | Usage                                                                                                                                |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `agent:products:search`      | `lafam.sh agent:products:search [--q "query"] [--kind "GENERAL\|VIP\|..."] [--minPrice N] [--maxPrice N] [--eventId ID] [--limit N]` |
+| `agent:products:merchandise` | `lafam.sh agent:products:merchandise` — Get all merchandise (physical products)                                                      |
+| `agent:products:events`      | `lafam.sh agent:products:events` — Get all event ticket products                                                                     |
+| `agent:products:upcoming`    | `lafam.sh agent:products:upcoming` — Get upcoming event products                                                                     |
+| `agent:products:get`         | `lafam.sh agent:products:get <productId>` — Get product details                                                                      |
+
+### Product response fields
+
+Each product includes: `id`, `name`, `description`, `price`, `quantity`, `quantityLeft`, `kind`, `eventId`, `eventTitle`, `eventSlug`, `eventStartDate`, `eventEndDate`, `isHidden`, `startDate`, `endDate`.
+
+---
+
+## AGENT API — USERS
+
+| Action               | Usage                                                                                                                                                                                                                |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `agent:user:lookup`  | `lafam.sh agent:user:lookup --email "user@example.com"` <br> `lafam.sh agent:user:lookup --phone "0501234567"` <br> `lafam.sh agent:user:lookup --id "<userId>"` <br> `lafam.sh agent:user:lookup --q "search term"` |
+| `agent:user:history` | `lafam.sh agent:user:history <userId>` — Get user's purchase history                                                                                                                                                 |
+
+Lookup returns user info: `id`, `name`, `email`, `phone`, `createdAt`.  
+Search (`--q`) returns an array of matching users.
+
+---
+
+## AGENT API — NOTIFICATIONS
+
+| Action               | Usage                                                                                                |
+| -------------------- | ---------------------------------------------------------------------------------------------------- |
+| `agent:notify:sms`   | `lafam.sh agent:notify:sms '{"to":"052-1234567","message":"היי!","link":"https://lafam.world"}'`     |
+| `agent:notify:email` | `lafam.sh agent:notify:email '{"to":"user@example.com","subject":"נושא","html":"<p>תוכן HTML</p>"}'` |
+
+### SMS fields
+
+- `to` (required): Phone number (Israeli format, normalized automatically: `972...` → `0...`)
+- `message` (required): Message text
+- `link` (optional): URL to append
+- `campaignName` (optional): Campaign identifier (default: `agent-notification`)
+
+### Email fields
+
+- `to` (required): Email address
+- `subject` (required): Email subject
+- `html` (required): HTML content
+- `text` (optional): Plain text fallback (auto-generated from HTML if omitted)
+
+Response: `{ "success": true }` or `{ "success": false, "error": "..." }`
+
+---
+
+## AGENT API — STATS
+
+| Action                     | Usage                                                                      |
+| -------------------------- | -------------------------------------------------------------------------- |
+| `agent:stats`              | `lafam.sh agent:stats <agentCode>` — Get agent statistics summary          |
+| `agent:stats:sales`        | `lafam.sh agent:stats:sales <agentCode>` — Get recent sales (last 30 days) |
+| `agent:stats:top-products` | `lafam.sh agent:stats:top-products <agentCode>` — Get top-selling products |
+
+Stats include: total sales count, revenue, commission, conversion rate, popular products.
+
+---
+
+## AGENT API — BOOKINGS
+
+| Action                        | Usage                                                                       |
+| ----------------------------- | --------------------------------------------------------------------------- |
+| `agent:booking:create`        | `lafam.sh agent:booking:create '<JSON>'`                                    |
+| `agent:booking:get`           | `lafam.sh agent:booking:get <bookingId>`                                    |
+| `agent:booking:update-status` | `lafam.sh agent:booking:update-status <bookingId> '{"status":"CONFIRMED"}'` |
+| `agent:booking:cancel`        | `lafam.sh agent:booking:cancel <bookingId>`                                 |
+| `agent:booking:list-user`     | `lafam.sh agent:booking:list-user <userId>`                                 |
+| `agent:booking:list-event`    | `lafam.sh agent:booking:list-event <eventId>`                               |
+
+### Create booking — fields
+
+Required: `userId`, `eventId`, `startDate`, `endDate`.  
+Optional: `artistId`, `locationId`, `serviceId`, `notes`, `totalAmount`.
+
+Booking statuses: `PENDING`, `CONFIRMED`, `CANCELLED`, `COMPLETED`.

--- a/skills/lafam/scripts/lafam.sh
+++ b/skills/lafam/scripts/lafam.sh
@@ -1,0 +1,1142 @@
+#!/usr/bin/env bash
+# lafam.sh — LaFam/Mishpuha platform API dispatcher
+# Usage: lafam.sh <action> [args...]
+# Run:   lafam.sh help   →  prints all available actions
+
+set -euo pipefail
+
+# ─── CONFIG ───────────────────────────────────────────────────────────────────
+# Use LOCAL_MODE=1 for localhost testing: LOCAL_MODE=1 bash lafam.sh ...
+BASE_URL="${LAFAM_BASE_URL:-https://events-api-tq4b.onrender.com}"
+[[ "${LOCAL_MODE:-0}" == "1" ]] && BASE_URL="http://localhost:3001"
+CRED_EMAIL="flopi_bot@lafam.world"
+CRED_PASS="bot@442"
+
+# Token cache lives next to this script (survives re-runs)
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TOKEN_FILE="$SCRIPT_DIR/.lafam_token.json"
+# TOKEN_FILE JSON: { "accessToken": "...", "refreshToken": "...", "expiresAt": <epoch> }
+
+# ─── COLOUR / PRETTY ──────────────────────────────────────────────────────────
+pretty() { python3 -m json.tool 2>/dev/null || cat; }
+
+# ─── AUTH HELPERS ─────────────────────────────────────────────────────────────
+_now_epoch() { date +%s; }
+
+_load_token() {
+  # Returns 0 and sets ACCESS_TOKEN if valid cached token exists
+  if [[ -f "$TOKEN_FILE" ]]; then
+    ACCESS_TOKEN=$(python3 -c "import json;d=json.load(open('$TOKEN_FILE'));print(d.get('accessToken',''))")
+    REFRESH_TOKEN=$(python3 -c "import json;d=json.load(open('$TOKEN_FILE'));print(d.get('refreshToken',''))")
+    EXPIRES_AT=$(python3 -c "import json;d=json.load(open('$TOKEN_FILE'));print(d.get('expiresAt',0))")
+    if [[ "$ACCESS_TOKEN" != "" ]] && (( $(_now_epoch) < EXPIRES_AT )); then
+      return 0
+    fi
+  fi
+  return 1
+}
+
+_save_token() {
+  # $1=accessToken  $2=refreshToken  $3=expiresAt
+  python3 -c "
+import json
+json.dump({'accessToken':'$1','refreshToken':'$2','expiresAt':$3}, open('$TOKEN_FILE','w'))
+"
+}
+
+_login() {
+  local resp
+  resp=$(curl -s -w "\n%{http_code}" -X POST "$BASE_URL/auth/login" \
+    -H "Content-Type: application/json" \
+    -d "{\"email\":\"$CRED_EMAIL\",\"password\":\"$CRED_PASS\"}")
+  local code body
+  code=$(echo "$resp" | tail -1)
+  body=$(echo "$resp" | sed '$d')
+  if [[ "$code" != "200" ]]; then
+    echo "AUTH ERROR ($code): $body" >&2
+    exit 1
+  fi
+  ACCESS_TOKEN=$(echo "$body" | python3 -c "import sys,json;print(json.load(sys.stdin)['accessToken'])")
+  REFRESH_TOKEN=$(echo "$body" | python3 -c "import sys,json;print(json.load(sys.stdin).get('refreshToken',''))")
+  # Assume token valid for 23 hours (safe margin under typical 24h)
+  _save_token "$ACCESS_TOKEN" "$REFRESH_TOKEN" $(( $(_now_epoch) + 82800 ))
+}
+
+_refresh() {
+  if [[ -z "${REFRESH_TOKEN:-}" ]]; then
+    _login; return
+  fi
+  local resp code body
+  resp=$(curl -s -w "\n%{http_code}" -X POST "$BASE_URL/auth/refresh" \
+    -H "Content-Type: application/json" \
+    -d "{\"refreshToken\":\"$REFRESH_TOKEN\"}")
+  code=$(echo "$resp" | tail -1)
+  body=$(echo "$resp" | sed '$d')
+  if [[ "$code" != "200" ]]; then
+    # Refresh failed — fall back to full login
+    _login; return
+  fi
+  ACCESS_TOKEN=$(echo "$body" | python3 -c "import sys,json;print(json.load(sys.stdin)['accessToken'])")
+  REFRESH_TOKEN=$(echo "$body" | python3 -c "import sys,json;print(json.load(sys.stdin).get('refreshToken','$REFRESH_TOKEN'))")
+  _save_token "$ACCESS_TOKEN" "$REFRESH_TOKEN" $(( $(_now_epoch) + 82800 ))
+}
+
+ensure_token() {
+  if _load_token; then
+    return 0
+  fi
+  # Try refresh if we have a stale token with a refresh token
+  if [[ -f "$TOKEN_FILE" ]]; then
+    REFRESH_TOKEN=$(python3 -c "import json;d=json.load(open('$TOKEN_FILE'));print(d.get('refreshToken',''))" 2>/dev/null || echo "")
+    if [[ -n "$REFRESH_TOKEN" ]]; then
+      _refresh; return
+    fi
+  fi
+  _login
+}
+
+# ─── HTTP HELPERS ─────────────────────────────────────────────────────────────
+# All helpers retry once on 401 (auto re-login)
+
+_get() {
+  # $1 = path (with query string if needed)
+  ensure_token
+  local resp code body
+  resp=$(curl -s -w "\n%{http_code}" "$BASE_URL$1" \
+    -H "Authorization: Bearer $ACCESS_TOKEN")
+  code=$(echo "$resp" | tail -1)
+  body=$(echo "$resp" | sed '$d')
+  if [[ "$code" == "401" ]]; then
+    _login
+    resp=$(curl -s -w "\n%{http_code}" "$BASE_URL$1" \
+      -H "Authorization: Bearer $ACCESS_TOKEN")
+    code=$(echo "$resp" | tail -1)
+    body=$(echo "$resp" | sed '$d')
+  fi
+  echo "$body" | pretty
+}
+
+_get_public() {
+  # No auth — for health, public event lookups, etc.
+  curl -s "$BASE_URL$1" | pretty
+}
+
+_post() {
+  # $1 = path  $2 = JSON body
+  ensure_token
+  local resp code body
+  resp=$(curl -s -w "\n%{http_code}" -X POST "$BASE_URL$1" \
+    -H "Authorization: Bearer $ACCESS_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d "$2")
+  code=$(echo "$resp" | tail -1)
+  body=$(echo "$resp" | sed '$d')
+  if [[ "$code" == "401" ]]; then
+    _login
+    resp=$(curl -s -w "\n%{http_code}" -X POST "$BASE_URL$1" \
+      -H "Authorization: Bearer $ACCESS_TOKEN" \
+      -H "Content-Type: application/json" \
+      -d "$2")
+    code=$(echo "$resp" | tail -1)
+    body=$(echo "$resp" | sed '$d')
+  fi
+  echo "$body" | pretty
+}
+
+_put() {
+  # $1 = path  $2 = JSON body
+  ensure_token
+  local resp code body
+  resp=$(curl -s -w "\n%{http_code}" -X PUT "$BASE_URL$1" \
+    -H "Authorization: Bearer $ACCESS_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d "$2")
+  code=$(echo "$resp" | tail -1)
+  body=$(echo "$resp" | sed '$d')
+  if [[ "$code" == "401" ]]; then
+    _login
+    resp=$(curl -s -w "\n%{http_code}" -X PUT "$BASE_URL$1" \
+      -H "Authorization: Bearer $ACCESS_TOKEN" \
+      -H "Content-Type: application/json" \
+      -d "$2")
+    code=$(echo "$resp" | tail -1)
+    body=$(echo "$resp" | sed '$d')
+  fi
+  echo "$body" | pretty
+}
+
+_patch() {
+  # $1 = path  $2 = JSON body
+  ensure_token
+  local resp code body
+  resp=$(curl -s -w "\n%{http_code}" -X PATCH "$BASE_URL$1" \
+    -H "Authorization: Bearer $ACCESS_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d "$2")
+  code=$(echo "$resp" | tail -1)
+  body=$(echo "$resp" | sed '$d')
+  if [[ "$code" == "401" ]]; then
+    _login
+    resp=$(curl -s -w "\n%{http_code}" -X PATCH "$BASE_URL$1" \
+      -H "Authorization: Bearer $ACCESS_TOKEN" \
+      -H "Content-Type: application/json" \
+      -d "$2")
+    code=$(echo "$resp" | tail -1)
+    body=$(echo "$resp" | sed '$d')
+  fi
+  echo "$body" | pretty
+}
+
+_delete() {
+  # $1 = path
+  ensure_token
+  local resp code body
+  resp=$(curl -s -w "\n%{http_code}" -X DELETE "$BASE_URL$1" \
+    -H "Authorization: Bearer $ACCESS_TOKEN")
+  code=$(echo "$resp" | tail -1)
+  body=$(echo "$resp" | sed '$d')
+  if [[ "$code" == "401" ]]; then
+    _login
+    resp=$(curl -s -w "\n%{http_code}" -X DELETE "$BASE_URL$1" \
+      -H "Authorization: Bearer $ACCESS_TOKEN")
+    code=$(echo "$resp" | tail -1)
+    body=$(echo "$resp" | sed '$d')
+  fi
+  echo "$body" | pretty
+}
+
+_get_with_header() {
+  # $1 = path  $2 = extra header (e.g. "X-Session-ID: abc")
+  ensure_token
+  local resp code body
+  resp=$(curl -s -w "\n%{http_code}" "$BASE_URL$1" \
+    -H "Authorization: Bearer $ACCESS_TOKEN" \
+    -H "$2")
+  code=$(echo "$resp" | tail -1)
+  body=$(echo "$resp" | sed '$d')
+  if [[ "$code" == "401" ]]; then
+    _login
+    resp=$(curl -s -w "\n%{http_code}" "$BASE_URL$1" \
+      -H "Authorization: Bearer $ACCESS_TOKEN" \
+      -H "$2")
+    code=$(echo "$resp" | tail -1)
+    body=$(echo "$resp" | sed '$d')
+  fi
+  echo "$body" | pretty
+}
+
+_upload_image() {
+  # $1 = local file path
+  ensure_token
+  local resp code body
+  resp=$(curl -s -w "\n%{http_code}" -X POST "$BASE_URL/upload/image" \
+    -H "Authorization: Bearer $ACCESS_TOKEN" \
+    -F "file=@$1")
+  code=$(echo "$resp" | tail -1)
+  body=$(echo "$resp" | sed '$d')
+  if [[ "$code" == "401" ]]; then
+    _login
+    resp=$(curl -s -w "\n%{http_code}" -X POST "$BASE_URL/upload/image" \
+      -H "Authorization: Bearer $ACCESS_TOKEN" \
+      -F "file=@$1")
+    code=$(echo "$resp" | tail -1)
+    body=$(echo "$resp" | sed '$d')
+  fi
+  echo "$body" | pretty
+}
+
+# ─── ACTION DISPATCHER ────────────────────────────────────────────────────────
+ACTION="${1:-help}"
+shift || true
+
+case "$ACTION" in
+
+# ── HEALTH ──────────────────────────────────────────────────────────────────
+  health)
+    _get_public "/health"
+    ;;
+
+# ── AUTH ────────────────────────────────────────────────────────────────────
+  login)
+    _login
+    echo "{\"status\":\"logged in\"}" | pretty
+    ;;
+  refresh)
+    ensure_token
+    _refresh
+    echo "{\"status\":\"token refreshed\"}" | pretty
+    ;;
+
+# ── EVENTS ──────────────────────────────────────────────────────────────────
+  events:list)
+    # Optional: --query Q --tags t1,t2 --page N --limit N --startDate ISO
+    QS=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --query)   QS+="&query=$2";    shift 2 ;;
+        --tags)    QS+="&tags=$2";     shift 2 ;;
+        --page)    QS+="&page=$2";     shift 2 ;;
+        --limit)   QS+="&limit=$2";    shift 2 ;;
+        --startDate) QS+="&startDate=$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    _get "/events?${QS#&}"
+    ;;
+  events:get)
+    # $1 = eventId
+    _get "/events/$1"
+    ;;
+  events:get-by-slug)
+    # $1 = slug
+    _get "/events/slug/$1"
+    ;;
+  events:create)
+    # $1 = JSON body
+    _post "/events" "$1"
+    ;;
+  events:update)
+    # $1 = eventId  $2 = JSON body
+    _put "/events/$1" "$2"
+    ;;
+  events:delete)
+    # $1 = eventId
+    _delete "/events/$1"
+    ;;
+  events:stats)
+    # $1 = eventId  --timeframe (optional)
+    EID="$1"; shift
+    TF=""
+    [[ "${1:-}" == "--timeframe" ]] && TF="?timeframe=$2"
+    _get "/events/$EID/statistics$TF"
+    ;;
+  events:tickets)
+    # $1 = eventId  then optional --page --limit --query --ticketType --status
+    EID="$1"; shift
+    QS=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --page)       QS+="&page=$2";       shift 2 ;;
+        --limit)      QS+="&limit=$2";      shift 2 ;;
+        --query)      QS+="&query=$2";      shift 2 ;;
+        --ticketType) QS+="&ticketType=$2"; shift 2 ;;
+        --status)     QS+="&status=$2";     shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    _get "/events/$EID/tickets?${QS#&}"
+    ;;
+  events:purchase-tickets)
+    # $1 = JSON { eventId, ticketHolders: [{ticketTypeId, holderName, holderEmail, holderPhone, ...}], paymentMethod: "CARDCOM"|"CASH" }
+    # NOTE: Use holderName, holderEmail, holderPhone (not name, email, phone)
+    _post "/events/purchase-tickets" "$1"
+    ;;
+
+# ── TICKET TYPES ────────────────────────────────────────────────────────────
+  tickets:list)
+    # $1 = eventId
+    _get "/events/$1/ticket-types"
+    ;;
+  tickets:create)
+    # $1 = eventId  $2 = JSON body
+    _post "/events/$1/ticket-types" "$2"
+    ;;
+  tickets:update)
+    # $1 = eventId  $2 = ticketTypeId  $3 = JSON body
+    _put "/events/$1/ticket-types/$2" "$3"
+    ;;
+  tickets:delete)
+    # $1 = eventId  $2 = ticketTypeId
+    _delete "/events/$1/ticket-types/$2"
+    ;;
+
+# ── EVENT AGENTS ────────────────────────────────────────────────────────────
+  events:agents)
+    # $1 = eventId
+    _get "/events/$1/agents"
+    ;;
+  events:add-agent)
+    # $1 = eventId  $2 = JSON { email, commission }
+    _post "/events/$1/agents" "$2"
+    ;;
+  events:update-agent)
+    # $1 = eventId  $2 = agentId  $3 = JSON body
+    _put "/events/$1/agents/$2" "$3"
+    ;;
+  events:remove-agent)
+    # $1 = eventId  $2 = agentId
+    _delete "/events/$1/agents/$2"
+    ;;
+  events:check-agent)
+    # $1 = eventId
+    _get "/events/$1/check-agent"
+    ;;
+  events:user-role)
+    # $1 = eventId
+    _get "/events/$1/user-role"
+    ;;
+
+# ── ARTISTS ─────────────────────────────────────────────────────────────────
+  artists:list)
+    # Optional: --page N --limit N
+    QS=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --page)  QS+="&page=$2";  shift 2 ;;
+        --limit) QS+="&limit=$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    _get "/api/artists?${QS#&}"
+    ;;
+  artists:search)
+    # $1 = search query
+    _get "/api/artists/search?search=$1"
+    ;;
+  artists:get)
+    # $1 = artistId
+    _get "/api/artists/$1"
+    ;;
+  artists:get-by-slug)
+    # $1 = slug
+    _get "/api/artist/$1"
+    ;;
+  artists:create)
+    # $1 = JSON body
+    _post "/api/artists" "$1"
+    ;;
+  artists:update)
+    # $1 = artistId  $2 = JSON body
+    _patch "/api/artists/$1" "$2"
+    ;;
+  artists:delete)
+    # $1 = artistId
+    _delete "/api/artists/$1"
+    ;;
+  artists:add-social)
+    # $1 = artistId  $2 = JSON { platform, url }
+    _post "/api/artists/$1/social-links" "$2"
+    ;;
+  artists:add-socials-bulk)
+    # $1 = artistId  $2 = JSON array [{ platform, url }, ...]
+    _post "/api/artists/$1/social-links/bulk" "$2"
+    ;;
+  artists:playable-media)
+    _get "/api/artists/media/playable"
+    ;;
+  artists:usage)
+    # $1 = artistId
+    _get "/api/artists/$1/usage-by-communities"
+    ;;
+  artists:bookings)
+    # $1 = artistId
+    _get "/api/artists/$1/bookings"
+    ;;
+
+# ── LOCATIONS ───────────────────────────────────────────────────────────────
+  locations:list)
+    QS=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --page)  QS+="&page=$2";  shift 2 ;;
+        --limit) QS+="&limit=$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    _get "/api/locations?${QS#&}"
+    ;;
+  locations:search)
+    # $1 = search query
+    _get "/api/locations/search?search=$1"
+    ;;
+  locations:get)
+    # $1 = locationId
+    _get "/api/locations/$1"
+    ;;
+  locations:get-by-slug)
+    # $1 = slug
+    _get "/api/location/$1"
+    ;;
+  locations:create)
+    # $1 = JSON body
+    _post "/api/locations" "$1"
+    ;;
+  locations:update)
+    # $1 = locationId  $2 = JSON body
+    _patch "/api/locations/$1" "$2"
+    ;;
+  locations:delete)
+    # $1 = locationId
+    _delete "/api/locations/$1"
+    ;;
+  locations:add-social)
+    # $1 = locationId  $2 = JSON { platform, url }
+    _post "/api/locations/$1/social-links" "$2"
+    ;;
+  locations:add-socials-bulk)
+    # $1 = locationId  $2 = JSON array
+    _post "/api/locations/$1/social-links/bulk" "$2"
+    ;;
+  locations:usage)
+    # $1 = locationId
+    _get "/api/locations/$1/usage-by-communities"
+    ;;
+
+# ── SERVICES ────────────────────────────────────────────────────────────────
+  services:list)
+    QS=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --page)  QS+="&page=$2";  shift 2 ;;
+        --limit) QS+="&limit=$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    _get "/api/services?${QS#&}"
+    ;;
+  services:search)
+    # $1 = search query
+    _get "/api/services/search?search=$1"
+    ;;
+  services:get)
+    # $1 = serviceId
+    _get "/api/services/$1"
+    ;;
+  services:get-by-slug)
+    # $1 = slug
+    _get "/api/service/$1"
+    ;;
+  services:create)
+    # $1 = JSON body
+    _post "/api/services" "$1"
+    ;;
+  services:update)
+    # $1 = serviceId  $2 = JSON body
+    _patch "/api/services/$1" "$2"
+    ;;
+  services:delete)
+    # $1 = serviceId
+    _delete "/api/services/$1"
+    ;;
+  services:add-social)
+    # $1 = serviceId  $2 = JSON { platform, url }
+    _post "/api/services/$1/social-links" "$2"
+    ;;
+  services:add-socials-bulk)
+    # $1 = serviceId  $2 = JSON array
+    _post "/api/services/$1/social-links/bulk" "$2"
+    ;;
+
+# ── COMMUNITIES ─────────────────────────────────────────────────────────────
+  communities:list)
+    QS=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --limit)  QS+="&limit=$2";  shift 2 ;;
+        --offset) QS+="&offset=$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    _get "/api/communities?${QS#&}"
+    ;;
+  communities:get)
+    # $1 = communityId
+    _get "/api/communities/$1"
+    ;;
+  communities:get-by-slug)
+    # $1 = slug
+    _get "/api/community/$1"
+    ;;
+  communities:create)
+    # $1 = JSON body
+    _post "/api/communities" "$1"
+    ;;
+  communities:update)
+    # $1 = communityId  $2 = JSON body
+    _patch "/api/communities/$1" "$2"
+    ;;
+  communities:delete)
+    # $1 = communityId
+    _delete "/api/communities/$1"
+    ;;
+  communities:events)
+    # $1 = communityId
+    _get "/api/communities/$1/events"
+    ;;
+  communities:members)
+    # $1 = communityId
+    _get "/api/communities/$1/members"
+    ;;
+  communities:join)
+    # $1 = communityId  $2 = optional JSON { message }  (default: {})
+    _post "/api/communities/$1/join-requests" "${2:-{}}"
+    ;;
+  communities:join-requests)
+    # $1 = communityId
+    _get "/api/communities/$1/join-requests/pending"
+    ;;
+  communities:join-approve)
+    # $1 = requestId  $2 = APPROVED|REJECTED
+    _patch "/api/join-requests/$1" "{\"status\":\"$2\"}"
+    ;;
+  communities:related-artists)
+    # $1 = communityId
+    _get "/api/communities/$1/related-artists"
+    ;;
+  communities:related-locations)
+    # $1 = communityId
+    _get "/api/communities/$1/related-locations"
+    ;;
+  communities:related-services)
+    # $1 = communityId
+    _get "/api/communities/$1/related-services"
+    ;;
+  communities:playable-media)
+    # $1 = communityId  — surfaces YOUTUBE + SOUNDCLOUD links
+    _get "/api/communities/$1/playable-media"
+    ;;
+  communities:feed)
+    _get "/api/communities/feed"
+    ;;
+  communities:agents)
+    # $1 = communityId
+    _get "/api/communities/$1/agents"
+    ;;
+  communities:add-agent)
+    # $1 = communityId  $2 = JSON { email, role? }
+    _post "/api/communities/$1/agents" "$2"
+    ;;
+
+# ── POSTS & COMMENTS ────────────────────────────────────────────────────────
+  posts:list)
+    QS=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --limit)  QS+="&limit=$2";  shift 2 ;;
+        --offset) QS+="&offset=$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    _get "/api/posts?${QS#&}"
+    ;;
+  posts:get)
+    # $1 = postId
+    _get "/api/posts/$1"
+    ;;
+  posts:create)
+    # $1 = JSON body
+    _post "/api/posts" "$1"
+    ;;
+  posts:update)
+    # $1 = postId  $2 = JSON body
+    _put "/api/posts/$1" "$2"
+    ;;
+  posts:delete)
+    # $1 = postId
+    _delete "/api/posts/$1"
+    ;;
+  posts:search)
+    # $1 = query string
+    _get "/api/posts/search?q=$1"
+    ;;
+  posts:for-entity)
+    # $1 = entityType (artist|location|service|community)  $2 = entityId
+    _get "/api/posts/entity/$1/$2"
+    ;;
+  posts:comments)
+    # $1 = postId  optional --page N --limit N
+    PID="$1"; shift
+    QS=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --page)  QS+="&page=$2";  shift 2 ;;
+        --limit) QS+="&limit=$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    _get "/api/posts/$PID/comments?${QS#&}"
+    ;;
+  posts:comment)
+    # $1 = postId  $2 = JSON { content, imageUrls?, parentCommentId? }
+    _post "/api/posts/$1/comments" "$2"
+    ;;
+  posts:comment-delete)
+    # $1 = commentId
+    _delete "/api/comments/$1"
+    ;;
+
+# ── INTERACTIONS ────────────────────────────────────────────────────────────
+  interactions:like-post)
+    # $1 = postId
+    _post "/api/interactions/posts/$1/like" "{}"
+    ;;
+  interactions:save-post)
+    # $1 = postId
+    _post "/api/interactions/posts/$1/save" "{}"
+    ;;
+  interactions:post-info)
+    # $1 = postId
+    _get "/api/interactions/posts/$1"
+    ;;
+  interactions:like-artist)
+    # $1 = artistId
+    _post "/api/interactions/artists/$1/like" "{}"
+    ;;
+  interactions:follow-artist)
+    # $1 = artistId
+    _post "/api/interactions/artists/$1/follow" "{}"
+    ;;
+  interactions:artist-followers)
+    # $1 = artistId
+    _get "/api/interactions/artists/$1/followers"
+    ;;
+  interactions:mine)
+    # $1 = type (like|save|follow)
+    _get "/api/interactions/user?type=$1"
+    ;;
+  interactions:check)
+    # $1 = JSON { postIds[], artistIds[] }
+    _post "/api/interactions/check" "$1"
+    ;;
+
+# ── SOCIAL LINKS (generic) ──────────────────────────────────────────────────
+  social-links:by-platform)
+    # $1 = comma-separated platforms (YOUTUBE,INSTAGRAM,...)  optional --limit --offset
+    PLATS="$1"; shift
+    QS="platforms=$PLATS"
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --limit)  QS+="&limit=$2";  shift 2 ;;
+        --offset) QS+="&offset=$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    _get "/api/social-links/by-platform?$QS"
+    ;;
+  social-links:update)
+    # $1 = linkId  $2 = JSON { url }
+    _put "/api/social-links/$1" "$2"
+    ;;
+  social-links:delete)
+    # $1 = linkId
+    _delete "/api/social-links/$1"
+    ;;
+
+# ── CART ────────────────────────────────────────────────────────────────────
+  cart:get)
+    # $1 = sessionId (X-Session-ID header)
+    _get_with_header "/api/cart" "X-Session-ID: $1"
+    ;;
+  cart:add)
+    # $1 = cartId  $2 = JSON { ticketTypeId, quantity, entityId, entityType, postId? }
+    _post "/api/cart/$1/items" "$2"
+    ;;
+  cart:update-item)
+    # $1 = cartId  $2 = itemId  $3 = JSON { quantity }
+    _put "/api/cart/$1/items/$2" "$3"
+    ;;
+  cart:remove-item)
+    # $1 = cartId  $2 = itemId
+    _delete "/api/cart/$1/items/$2"
+    ;;
+  cart:clear)
+    # $1 = cartId
+    _delete "/api/cart/$1/clear"
+    ;;
+  cart:summary)
+    # $1 = cartId
+    _get "/api/cart/$1/summary"
+    ;;
+  cart:checkout)
+    # $1 = cartId  $2 = JSON { paymentMethod, holderName, holderEmail, holderPhone }
+    _post "/api/cart/$1/checkout" "$2"
+    ;;
+
+# ── BOOKINGS ────────────────────────────────────────────────────────────────
+  bookings:create)
+    # $1 = JSON body
+    _post "/api/bookings" "$1"
+    ;;
+  bookings:list)
+    _get "/api/bookings"
+    ;;
+  bookings:get)
+    # $1 = bookingId
+    _get "/api/bookings/$1"
+    ;;
+  bookings:mine)
+    # optional --startDate --endDate
+    QS=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --startDate) QS+="&startDate=$2"; shift 2 ;;
+        --endDate)   QS+="&endDate=$2";   shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    _get "/api/users/me/bookings?${QS#&}"
+    ;;
+  bookings:update-status)
+    # $1 = bookingId  $2 = JSON { status, reason?, notes? }
+    _patch "/api/bookings/$1/status" "$2"
+    ;;
+  bookings:delete)
+    # $1 = bookingId
+    _delete "/api/bookings/$1"
+    ;;
+
+# ── TAGS & SEARCH ───────────────────────────────────────────────────────────
+  search)
+    # $1 = query
+    _get "/api/search?q=$1"
+    ;;
+  tags:entities)
+    # $1 = tagName
+    _get "/api/tags/$1"
+    ;;
+  tags:popular)
+    # optional --limit N
+    LIMIT=""
+    [[ "${1:-}" == "--limit" ]] && LIMIT="?limit=$2"
+    _get "/api/tags/_popular$LIMIT"
+    ;;
+  tags:popular-artists)
+    _get "/api/tags/_popular/artists"
+    ;;
+  tags:popular-events)
+    _get "/api/tags/_popular/events"
+    ;;
+
+# ── PROFILE ─────────────────────────────────────────────────────────────────
+  profile:get)
+    _get "/api/profile"
+    ;;
+  profile:update)
+    # $1 = JSON body
+    _put "/api/profile" "$1"
+    ;;
+  profile:tickets)
+    _get "/api/profile/tickets"
+    ;;
+  profile:transactions)
+    _get "/api/profile/transactions"
+    ;;
+  profile:managed-items)
+    _get "/api/profile/managed-items"
+    ;;
+  profile:add-social)
+    # $1 = JSON { platform, url }
+    _post "/api/profile/social-links" "$1"
+    ;;
+
+# ── AGENT API ──────────────────────────────────────────────────────────────
+# Agent Transaction & Operations
+  agent:purchase)
+    # $1 = JSON { productId, quantity, user:{name,email,phone,gender,birthday}, agentCode }
+    _post "/api/agent/purchase" "$1"
+    ;;
+  agent:transaction)
+    # $1 = transactionId
+    _get "/api/agent/transaction/$1"
+    ;;
+
+# Agent Products
+  agent:products:search)
+    # Optional: --q "query" --kind "GENERAL|VIP|..." --minPrice N --maxPrice N --eventId "..." --limit N
+    QS=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --q)        QS+="&q=$2"; shift 2 ;;
+        --kind)     QS+="&kind=$2"; shift 2 ;;
+        --minPrice) QS+="&minPrice=$2"; shift 2 ;;
+        --maxPrice) QS+="&maxPrice=$2"; shift 2 ;;
+        --eventId)  QS+="&eventId=$2"; shift 2 ;;
+        --limit)    QS+="&limit=$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    _get "/api/agent/products/search?${QS#&}"
+    ;;
+  agent:products:merchandise)
+    _get "/api/agent/products/merchandise"
+    ;;
+  agent:products:events)
+    _get "/api/agent/products/events"
+    ;;
+  agent:products:upcoming)
+    _get "/api/agent/products/upcoming"
+    ;;
+  agent:products:get)
+    # $1 = productId
+    _get "/api/agent/products/$1"
+    ;;
+
+# Agent User Operations
+  agent:user:lookup)
+    # One of: --email "..." --phone "..." --id "..." --q "search query"
+    QS=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --email) QS+="&email=$2"; shift 2 ;;
+        --phone) QS+="&phone=$2"; shift 2 ;;
+        --id)    QS+="&id=$2"; shift 2 ;;
+        --q)     QS+="&q=$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    _get "/api/agent/user/lookup?${QS#&}"
+    ;;
+  agent:user:history)
+    # $1 = userId
+    _get "/api/agent/user/$1/history"
+    ;;
+
+# Agent Notifications
+  agent:notify:sms)
+    # $1 = JSON { to, message, link? }
+    _post "/api/agent/notify/sms" "$1"
+    ;;
+  agent:notify:email)
+    # $1 = JSON { to, subject, html }
+    _post "/api/agent/notify/email" "$1"
+    ;;
+
+# Agent Stats
+  agent:stats)
+    # $1 = agentCode
+    _get "/api/agent/stats/$1"
+    ;;
+  agent:stats:sales)
+    # $1 = agentCode
+    _get "/api/agent/stats/$1/sales"
+    ;;
+  agent:stats:top-products)
+    # $1 = agentCode
+    _get "/api/agent/stats/$1/top-products"
+    ;;
+
+# Agent Bookings
+  agent:booking:create)
+    # $1 = JSON booking body
+    _post "/api/agent/booking" "$1"
+    ;;
+  agent:booking:get)
+    # $1 = bookingId
+    _get "/api/agent/booking/$1"
+    ;;
+  agent:booking:update-status)
+    # $1 = bookingId  $2 = JSON { status }
+    _patch "/api/agent/booking/$1/status" "$2"
+    ;;
+  agent:booking:cancel)
+    # $1 = bookingId
+    _delete "/api/agent/booking/$1"
+    ;;
+  agent:booking:list-user)
+    # $1 = userId
+    _get "/api/agent/user/$1/bookings"
+    ;;
+  agent:booking:list-event)
+    # $1 = eventId
+    _get "/api/agent/event/$1/bookings"
+    ;;
+
+# ── UPLOADS ─────────────────────────────────────────────────────────────────
+  upload:image)
+    # $1 = local file path
+    _upload_image "$1"
+    ;;
+  upload:config)
+    _get "/upload/config"
+    ;;
+
+# ── HELP ────────────────────────────────────────────────────────────────────
+  help|--help|-h)
+    cat <<'EOF'
+lafam.sh — LaFam / Mishpuha platform API
+Usage: lafam.sh <action> [args...]
+
+AUTH
+  login                          Log in and cache token
+  refresh                        Refresh cached token
+
+HEALTH
+  health                         Health check (no auth)
+
+EVENTS
+  events:list [--query Q] [--tags t1,t2] [--page N] [--limit N] [--startDate ISO]
+  events:get <eventId>
+  events:get-by-slug <slug>
+  events:create '<JSON>'
+  events:update <eventId> '<JSON>'
+  events:delete <eventId>
+  events:stats <eventId> [--timeframe <value>]
+  events:tickets <eventId> [--page N] [--limit N] [--query Q] [--ticketType T] [--status S]
+
+TICKET TYPES
+  tickets:list <eventId>
+  tickets:create <eventId> '<JSON>'
+  tickets:update <eventId> <ticketTypeId> '<JSON>'
+  tickets:delete <eventId> <ticketTypeId>
+
+ARTISTS
+  artists:list [--page N] [--limit N]
+  artists:search <query>
+  artists:get <artistId>
+  artists:get-by-slug <slug>
+  artists:create '<JSON>'
+  artists:update <artistId> '<JSON>'
+  artists:delete <artistId>
+  artists:add-social <artistId> '{"platform":"YOUTUBE","url":"..."}'
+  artists:add-socials-bulk <artistId> '[{"platform":"...","url":"..."},...]'
+  artists:playable-media                  (YOUTUBE + SOUNDCLOUD links)
+  artists:usage <artistId>
+  artists:bookings <artistId>
+
+LOCATIONS
+  locations:list [--page N] [--limit N]
+  locations:search <query>
+  locations:get <locationId>
+  locations:get-by-slug <slug>
+  locations:create '<JSON>'
+  locations:update <locationId> '<JSON>'
+  locations:delete <locationId>
+  locations:add-social <locationId> '{"platform":"...","url":"..."}'
+  locations:add-socials-bulk <locationId> '[...]'
+  locations:usage <locationId>
+
+SERVICES
+  services:list [--page N] [--limit N]
+  services:search <query>
+  services:get <serviceId>
+  services:get-by-slug <slug>
+  services:create '<JSON>'
+  services:update <serviceId> '<JSON>'
+  services:delete <serviceId>
+  services:add-social <serviceId> '{"platform":"...","url":"..."}'
+  services:add-socials-bulk <serviceId> '[...]'
+
+COMMUNITIES
+  communities:list [--limit N] [--offset N]
+  communities:get <communityId>
+  communities:get-by-slug <slug>
+  communities:create '<JSON>'
+  communities:update <communityId> '<JSON>'
+  communities:delete <communityId>
+  communities:events <communityId>
+  communities:members <communityId>
+  communities:join <communityId> ['{"message":"..."}'']
+  communities:join-requests <communityId>
+  communities:join-approve <requestId> APPROVED|REJECTED
+  communities:related-artists <communityId>
+  communities:related-locations <communityId>
+  communities:related-services <communityId>
+  communities:playable-media <communityId>     (YOUTUBE + SOUNDCLOUD)
+  communities:feed
+  communities:agents <communityId>
+  communities:add-agent <communityId> '{"email":"...","role":"..."}'
+
+POSTS & COMMENTS
+  posts:list [--limit N] [--offset N]
+  posts:get <postId>
+  posts:create '<JSON>'
+  posts:update <postId> '<JSON>'
+  posts:delete <postId>
+  posts:search <query>
+  posts:for-entity <entityType> <entityId>     (artist|location|service|community)
+  posts:comments <postId> [--page N] [--limit N]
+  posts:comment <postId> '{"content":"..."}'
+  posts:comment-delete <commentId>
+
+INTERACTIONS
+  interactions:like-post <postId>
+  interactions:save-post <postId>
+  interactions:post-info <postId>
+  interactions:like-artist <artistId>
+  interactions:follow-artist <artistId>
+  interactions:artist-followers <artistId>
+  interactions:mine <type>                     (like|save|follow)
+  interactions:check '{"postIds":[...],"artistIds":[...]}'
+
+SOCIAL LINKS
+  social-links:by-platform <PLATFORMS> [--limit N] [--offset N]
+                                               (YOUTUBE,SOUNDCLOUD,INSTAGRAM,TWITTER,FACEBOOK,TIKTOK,SPOTIFY,WEBSITE)
+  social-links:update <linkId> '{"url":"..."}'
+  social-links:delete <linkId>
+
+CART
+  cart:get <sessionId>
+  cart:add <cartId> '{"ticketTypeId":"...","quantity":1,"entityId":"...","entityType":"..."}'
+  cart:update-item <cartId> <itemId> '{"quantity":2}'
+  cart:remove-item <cartId> <itemId>
+  cart:clear <cartId>
+  cart:summary <cartId>
+  cart:checkout <cartId> '{"paymentMethod":"...","holderName":"...","holderEmail":"...","holderPhone":"..."}'
+
+BOOKINGS
+  bookings:create '<JSON>'
+  bookings:list
+  bookings:get <bookingId>
+  bookings:mine [--startDate ISO] [--endDate ISO]
+  bookings:update-status <bookingId> '{"status":"...","reason":"...","notes":"..."}'
+  bookings:delete <bookingId>
+
+TAGS & SEARCH
+  search <query>                 Global search
+  tags:entities <tagName>
+  tags:popular [--limit N]
+  tags:popular-artists
+  tags:popular-events
+
+PROFILE
+  profile:get
+  profile:update '<JSON>'
+  profile:tickets
+  profile:transactions
+  profile:managed-items
+  profile:add-social '{"platform":"...","url":"..."}'
+
+AGENT API — Transactions & Operations
+  agent:purchase '<JSON>'                                          Create purchase (productId, quantity, user, agentCode)
+  agent:transaction <transactionId>                                Get transaction status
+
+AGENT API — Products
+  agent:products:search [--q Q] [--kind K] [--minPrice N] [--maxPrice N] [--eventId ID] [--limit N]
+  agent:products:merchandise                                       Get all merchandise products
+  agent:products:events                                            Get all event ticket products
+  agent:products:upcoming                                          Get upcoming event products
+  agent:products:get <productId>                                   Get product by ID
+
+AGENT API — Users
+  agent:user:lookup --email|--phone|--id|--q <value>               Lookup user by email/phone/id or search
+  agent:user:history <userId>                                      Get user purchase history
+
+AGENT API — Notifications
+  agent:notify:sms '<JSON>'                                        Send SMS { to, message, link? }
+  agent:notify:email '<JSON>'                                      Send Email { to, subject, html }
+
+AGENT API — Stats
+  agent:stats <agentCode>                                          Get agent statistics
+  agent:stats:sales <agentCode>                                    Get recent sales
+  agent:stats:top-products <agentCode>                             Get top products
+
+AGENT API — Bookings
+  agent:booking:create '<JSON>'                                    Create booking
+  agent:booking:get <bookingId>                                    Get booking details
+  agent:booking:update-status <bookingId> '<JSON>'                 Update booking status
+  agent:booking:cancel <bookingId>                                 Cancel booking
+  agent:booking:list-user <userId>                                 List user bookings
+  agent:booking:list-event <eventId>                               List event bookings
+
+UPLOADS
+  upload:image <filePath>
+  upload:config
+EOF
+    ;;
+
+  *)
+    echo "Unknown action: $ACTION" >&2
+    echo "Run: lafam.sh help" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## 🎉 LaFam Agent API Integration

This PR adds full Agent API support to the lafam skill, enabling bot operations like SMS/email notifications, purchases, user management, and analytics.

### ✨ New Features

#### Agent Operations
- **Transactions**: `agent:purchase`, `agent:transaction`
- **Products**: `agent:products:search`, `agent:products:merchandise`, `agent:products:events`, `agent:products:upcoming`
- **Users**: `agent:user:lookup`, `agent:user:history`
- **Notifications**: `agent:notify:sms`, `agent:notify:email`
- **Stats**: `agent:stats`, `agent:stats:sales`, `agent:stats:top-products`
- **Bookings**: `agent:booking:create`, `agent:booking:get`, `agent:booking:update-status`, etc.

### 🔧 Technical Details

- Added complete Agent API routes from LaFam backend
- Supports LOCAL_MODE=1 for localhost testing
- Includes SMS/Email notification capabilities
- Cardcom payment integration for purchases
- Comprehensive API reference documentation

### 📝 Example Usage

```bash
# Send SMS
bash lafam.sh agent:notify:sms '{"to":"052-1234567","message":"Hey! 🌊"}'

# Search products
bash lafam.sh agent:products:search --q "psytrance" --limit 10

# Purchase ticket
bash lafam.sh agent:purchase '{"productId":"...","quantity":1,"user":{...},"agentCode":"flopi_bot"}'
```

### 🧪 Testing

Tested locally with `LOCAL_MODE=1` against localhost:3001:
- ✅ SMS notifications working
- ✅ Product search working
- ✅ User lookup working
- ✅ All endpoints responding correctly

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new `lafam` skill with a large bash dispatcher (`skills/lafam/scripts/lafam.sh`) plus reference docs (`skills/lafam/SKILL.md`, `skills/lafam/references/api-reference.md`). The script wraps LaFam/Mishpuha API endpoints (including new Agent API operations for purchases, notifications, stats, and bookings), handles login/refresh, and caches tokens locally.

Key merge blockers are security- and correctness-related: credentials are hard-coded in the repo and repeated in docs; token caching writes JSON via unsafe string interpolation inside a `python3 -c` snippet; and several actions build query strings without URL-encoding user-provided inputs (spaces/`&` will break requests). The docs also include non-generic absolute local paths and live values, which conflicts with repo documentation guidance.


<h3>Confidence Score: 1/5</h3>

- This PR is not safe to merge until hard-coded secrets and unsafe token handling are fixed.
- The changes introduce committed credentials (script + docs) enabling unauthorized access to production operations, and `_save_token` uses unescaped string interpolation into a Python `-c` snippet which can break token persistence and is potentially code-injectable. Additionally, missing URL encoding will cause real runtime failures for common inputs (spaces/&).
- skills/lafam/scripts/lafam.sh; skills/lafam/SKILL.md (and any other docs that mention credentials/phone numbers)

<sub>Last reviewed commit: b7fb5ab</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->