### PR TITLE
feat: web_fetch sends Accept: text/markdown for Cloudflare Markdown for Agents

### DIFF
--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -409,7 +409,7 @@ async function runWebFetch(params: {
       timeoutMs: params.timeoutSeconds * 1000,
       init: {
         headers: {
-          Accept: "*/*",
+          Accept: "text/markdown, text/html;q=0.9, */*;q=0.8",
           "User-Agent": params.userAgent,
           "Accept-Language": "en-US,en;q=0.9",
         },
@@ -522,7 +522,12 @@ async function runWebFetch(params: {
     let title: string | undefined;
     let extractor = "raw";
     let text = body;
-    if (contentType.includes("text/html")) {
+    if (contentType.includes("text/markdown")) {
+      // Cloudflare Markdown for Agents (or any server returning native markdown)
+      // — skip HTML extraction, use content directly.
+      text = params.extractMode === "text" ? markdownToText(body) : body;
+      extractor = "markdown-native";
+    } else if (contentType.includes("text/html")) {
       if (params.readabilityEnabled) {
         const readable = await extractReadableContent({
           html: body,


### PR DESCRIPTION
## Summary

Send `Accept: text/markdown, text/html;q=0.9, */*;q=0.8` header in web_fetch requests. When the server responds with `Content-Type: text/markdown` (e.g. Cloudflare sites with Markdown for Agents enabled), skip HTML extraction and return the markdown directly.

## Why

- **~80% token reduction** on Cloudflare-hosted sites (their blog: 16K HTML tokens → 3K markdown)
- Claude Code and OpenCode already send this header
- Cloudflare covers a huge chunk of the web — free optimization
- Zero impact on non-Cloudflare sites (they ignore the Accept preference and return HTML as usual)

## Changes

### `src/agents/tools/web-fetch.ts`
1. Changed `Accept` header from `*/*` to `text/markdown, text/html;q=0.9, */*;q=0.8`
2. Added `text/markdown` content type handling — when server responds with native markdown, skip Readability extraction and use content directly (extractor: `markdown-native`)

## References
- Cloudflare blog: https://blog.cloudflare.com/markdown-for-agents/
- Cloudflare docs: https://developers.cloudflare.com/fundamentals/reference/markdown-for-agents/

Closes #15254

Signed-off-by: echoVic <nicepeng@foxmail.com>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates the `web_fetch` tool’s outbound request headers to prefer markdown (`Accept: text/markdown, text/html;q=0.9, */*;q=0.8`). It also adds a fast path when the server responds with `Content-Type: text/markdown`, bypassing Readability/HTML extraction and returning the markdown directly (optionally converting it to plain text when `extractMode="text"`).

The change is localized to `src/agents/tools/web-fetch.ts` inside `runWebFetch`, and preserves the existing behavior for HTML and JSON responses, as well as the existing Firecrawl fallbacks and external-content wrapping.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The diff is small, localized, and preserves existing control flow for HTML/JSON responses while adding a straightforward markdown fast path. No security boundaries are loosened (SSRF guard, wrapping/truncation, and caching remain unchanged).
- No files require special attention

<sub>Last reviewed commit: 42766ae</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->