### PR TITLE
fix: Grok web_search extracts output_text blocks at top level

### DIFF
--- a/src/agents/tools/web-search.e2e.test.ts
+++ b/src/agents/tools/web-search.e2e.test.ts
@@ -219,4 +219,26 @@ describe("web_search grok response parsing", () => {
     expect(result.text).toBeUndefined();
     expect(result.annotationCitations).toEqual([]);
   });
+
+  it("extracts output_text blocks directly in output array (no message wrapper)", () => {
+    const result = extractGrokContent({
+      output: [
+        { type: "web_search_call" },
+        {
+          type: "output_text",
+          text: "direct output text",
+          annotations: [
+            {
+              type: "url_citation",
+              url: "https://example.com/direct",
+              start_index: 0,
+              end_index: 5,
+            },
+          ],
+        },
+      ],
+    } as Parameters<typeof extractGrokContent>[0]);
+    expect(result.text).toBe("direct output text");
+    expect(result.annotationCitations).toEqual(["https://example.com/direct"]);
+  });
 });


### PR DESCRIPTION
## Summary

Fix `extractGrokContent()` to handle xAI's Responses API format where `output_text` blocks appear directly in the output array without a `message` wrapper.

## Problem

xAI's `/v1/responses` API returns two formats:
1. `output_text` nested under `type: "message"` (handled ✅)
2. `output_text` directly in the output array (missed ❌ → returned "No response")

```json
{
  "output": [
    { "type": "web_search_call", ... },
    { "type": "output_text", "text": "...", "annotations": [...] }
  ]
}
```

## Fix

Check for `output_text` blocks both inside `message` wrappers and at the top level of the output array. Extract `url_citation` annotations from both locations.

## Changes

- `src/agents/tools/web-search.ts`: Handle top-level `output_text` in `extractGrokContent()`
- `src/agents/tools/web-search.test.ts`: Added test for unwrapped `output_text` case

Closes #15179

Signed-off-by: echoVic <nicepeng@foxmail.com>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates Grok `/v1/responses` parsing in `extractGrokContent()` to also extract `output_text` blocks that appear directly in the top-level `output` array (in addition to the existing `type: "message"` wrapper format). A test was added to cover the unwrapped `output_text` case and validate URL citation extraction.

Main issue to address before merge: the new parsing branch relies on type casts because `GrokSearchResponse.output` is currently typed as only `{ type?, role?, content? }`. The response type should be widened to a union that includes the top-level `output_text` shape so the new logic is compiler-checked rather than casted.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge once the Grok response type is updated to match the new top-level output_text parsing.
- Behavioral change is small and test-covered, but the current implementation depends on unsafe casts because the declared GrokSearchResponse type does not model top-level output_text items. Fixing the type/union will prevent future regressions and ensures TypeScript can validate the new branch.
- src/agents/tools/web-search.ts

<sub>Last reviewed commit: c96cced</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->