### PR TITLE
feat: support freshness parameter for Perplexity web_search provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,4 @@ USER.md
 .agent/*.json
 !.agent/workflows/
 local/
+package-lock.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ Docs: https://docs.openclaw.ai
 - Cron: add regression coverage for announce-mode isolated jobs so runs that already report `delivered: true` do not enqueue duplicate main-session relays, including delivery configs where `mode` is omitted and defaults to announce. (#15737) Thanks @brandonwise.
 - Cron: honor `deleteAfterRun` in isolated announce delivery by mapping it to subagent announce cleanup mode, so cron run sessions configured for deletion are removed after completion. (#15368) Thanks @arosstale.
 - Web tools/web_fetch: prefer `text/markdown` responses for Cloudflare Markdown for Agents, add `cf-markdown` extraction for markdown bodies, and redact fetched URLs in `x-markdown-tokens` debug logs to avoid leaking raw paths/query params. (#15376) Thanks @Yaxuan42.
+- Tools/web_search: support `freshness` for the Perplexity provider by mapping `pd`/`pw`/`pm`/`py` to Perplexity `search_recency_filter` values and including freshness in the Perplexity cache key. (#15343) Thanks @echoVic.
 - Clawdock: avoid Zsh readonly variable collisions in helper scripts. (#15501) Thanks @nkelner.
 - Memory: switch default local embedding model to the QAT `embeddinggemma-300m-qat-Q8_0` variant for better quality at the same footprint. (#15429) Thanks @azade-c.
 - Docs/Mermaid: remove hardcoded Mermaid init theme blocks from four docs diagrams so dark mode inherits readable theme defaults. (#15157) Thanks @heytulsiprasad.

--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -175,7 +175,9 @@ Search the web using your configured provider.
 - `country` (optional): 2-letter country code for region-specific results (e.g., "DE", "US", "ALL"). If omitted, Brave chooses its default region.
 - `search_lang` (optional): ISO language code for search results (e.g., "de", "en", "fr")
 - `ui_lang` (optional): ISO language code for UI elements
-- `freshness` (optional, Brave only): filter by discovery time (`pd`, `pw`, `pm`, `py`, or `YYYY-MM-DDtoYYYY-MM-DD`)
+- `freshness` (optional): filter by discovery time
+  - Brave: `pd`, `pw`, `pm`, `py`, or `YYYY-MM-DDtoYYYY-MM-DD`
+  - Perplexity: `pd`, `pw`, `pm`, `py`
 
 **Examples:**
 

--- a/src/agents/tools/web-search.e2e.test.ts
+++ b/src/agents/tools/web-search.e2e.test.ts
@@ -31,6 +31,7 @@ const {
   isDirectPerplexityBaseUrl,
   resolvePerplexityRequestModel,
   normalizeFreshness,
+  freshnessToPerplexityRecency,
   resolveGrokApiKey,
   resolveGrokModel,
   resolveGrokInlineCitations,
@@ -125,6 +126,24 @@ describe("web_search freshness normalization", () => {
     expect(normalizeFreshness("2024-13-01to2024-01-31")).toBeUndefined();
     expect(normalizeFreshness("2024-02-30to2024-03-01")).toBeUndefined();
     expect(normalizeFreshness("2024-03-10to2024-03-01")).toBeUndefined();
+  });
+});
+
+describe("freshnessToPerplexityRecency", () => {
+  it("maps Brave shortcuts to Perplexity recency values", () => {
+    expect(freshnessToPerplexityRecency("pd")).toBe("day");
+    expect(freshnessToPerplexityRecency("pw")).toBe("week");
+    expect(freshnessToPerplexityRecency("pm")).toBe("month");
+    expect(freshnessToPerplexityRecency("py")).toBe("year");
+  });
+
+  it("returns undefined for date ranges (not supported by Perplexity)", () => {
+    expect(freshnessToPerplexityRecency("2024-01-01to2024-01-31")).toBeUndefined();
+  });
+
+  it("returns undefined for undefined/empty input", () => {
+    expect(freshnessToPerplexityRecency(undefined)).toBeUndefined();
+    expect(freshnessToPerplexityRecency("")).toBeUndefined();
   });
 });
 

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -569,7 +569,7 @@ async function runWebSearch(params: {
     params.provider === "brave"
       ? `${params.provider}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || "default"}:${params.ui_lang || "default"}:${params.freshness || "default"}`
       : params.provider === "perplexity"
-        ? `${params.provider}:${params.query}:${params.perplexityBaseUrl ?? DEFAULT_PERPLEXITY_BASE_URL}:${params.perplexityModel ?? DEFAULT_PERPLEXITY_MODEL}`
+        ? `${params.provider}:${params.query}:${params.perplexityBaseUrl ?? DEFAULT_PERPLEXITY_BASE_URL}:${params.perplexityModel ?? DEFAULT_PERPLEXITY_MODEL}:${params.freshness || "default"}`
         : `${params.provider}:${params.query}:${params.grokModel ?? DEFAULT_GROK_MODEL}:${String(params.grokInlineCitations ?? false)}`,
   );
   const cached = readCache(SEARCH_CACHE, cacheKey);

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -64,7 +64,7 @@ const WebSearchSchema = Type.Object({
   freshness: Type.Optional(
     Type.String({
       description:
-        "Filter results by discovery time (Brave only). Values: 'pd' (past 24h), 'pw' (past week), 'pm' (past month), 'py' (past year), or date range 'YYYY-MM-DDtoYYYY-MM-DD'.",
+        "Filter results by discovery time. Brave supports 'pd', 'pw', 'pm', 'py', and date range 'YYYY-MM-DDtoYYYY-MM-DD'. Perplexity supports 'pd', 'pw', 'pm', and 'py'.",
     }),
   ),
 });

--- a/src/agents/tools/web-tools.enabled-defaults.e2e.test.ts
+++ b/src/agents/tools/web-tools.enabled-defaults.e2e.test.ts
@@ -159,7 +159,7 @@ describe("web_search perplexity baseUrl defaults", () => {
     expect(body.model).toBe("sonar-pro");
   });
 
-  it("rejects freshness for Perplexity provider", async () => {
+  it("passes freshness to Perplexity provider as search_recency_filter", async () => {
     vi.stubEnv("PERPLEXITY_API_KEY", "pplx-test");
     const mockFetch = vi.fn(() =>
       Promise.resolve({
@@ -174,10 +174,11 @@ describe("web_search perplexity baseUrl defaults", () => {
       config: { tools: { web: { search: { provider: "perplexity" } } } },
       sandboxed: true,
     });
-    const result = await tool?.execute?.(1, { query: "test", freshness: "pw" });
+    await tool?.execute?.(1, { query: "perplexity-freshness-test", freshness: "pw" });
 
-    expect(mockFetch).not.toHaveBeenCalled();
-    expect(result?.details).toMatchObject({ error: "unsupported_freshness" });
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body as string);
+    expect(body.search_recency_filter).toBe("week");
   });
 
   it("defaults to OpenRouter when OPENROUTER_API_KEY is set", async () => {


### PR DESCRIPTION
## Summary

Map the existing `freshness` parameter (pd/pw/pm/py) to Perplexity's `search_recency_filter` (day/week/month/year) in web_search.

## Problem

`freshness` was rejected with "only supported by Brave" when using Perplexity Sonar, even though Perplexity supports equivalent recency filtering via `search_recency_filter`.

## Changes

### `src/agents/tools/web-search.ts`
1. Added `freshnessToPerplexityRecency()` — maps pd→day, pw→week, pm→month, py→year
2. Updated `runPerplexitySearch()` to accept and pass `search_recency_filter` in the request body
3. Updated freshness validation to allow both Brave and Perplexity providers
4. Passed `freshness` through to the Perplexity search call

### `src/agents/tools/web-search.test.ts`
- Added tests for `freshnessToPerplexityRecency()` mapping, including edge cases

| freshness | Perplexity search_recency_filter |
|-----------|----------------------------------|
| pd        | day                              |
| pw        | week                             |
| pm        | month                            |
| py        | year                             |
| date range | not supported (Perplexity only accepts shortcuts) |

## References
- [Perplexity Sonar Date/Time Filters](https://docs.perplexity.ai/docs/sonar/filters)

Closes #15212

Signed-off-by: echoVic <nicepeng@foxmail.com>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends the `web_search` tool’s `freshness` parameter support to the Perplexity provider by mapping the existing Brave-style shortcuts (`pd/pw/pm/py`) onto Perplexity’s `search_recency_filter` values (`day/week/month/year`). It does this by adding a small mapper helper, wiring the mapped filter into the Perplexity `/chat/completions` request body, relaxing provider validation to allow `freshness` for both Brave and Perplexity, and adding unit tests for the new mapping helper.

Overall this fits cleanly into the existing provider-specific branching inside `src/agents/tools/web-search.ts` (Brave query params vs Perplexity request body vs Grok responses API).

<h3>Confidence Score: 4/5</h3>

- Generally safe to merge, but has a correctness issue around caching for Perplexity freshness-filtered searches.
- The new freshness-to-recency mapping and request wiring are straightforward and covered by unit tests, but the Perplexity cache key does not incorporate freshness, so cached results can be wrong when users change freshness values.
- src/agents/tools/web-search.ts

<sub>Last reviewed commit: baea07b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->