### PR TITLE
feat(feishu): Add native audio message support (voice bubble)

### DIFF
--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -353,13 +353,77 @@ export async function sendImageFeishu(params: {
 }
 
 /**
+ * Send an audio message using a file_key (native voice bubble)
+ * Requires the file to be uploaded with file_type: "opus"
+ */
+export async function sendAudioFeishu(params: {
+  cfg: ClawdbotConfig;
+  to: string;
+  fileKey: string;
+  replyToMessageId?: string;
+  accountId?: string;
+}): Promise<SendMediaResult> {
+  const { cfg, to, fileKey, replyToMessageId, accountId } = params;
+  const account = resolveFeishuAccount({ cfg, accountId });
+  if (!account.configured) {
+    throw new Error(`Feishu account "${account.accountId}" not configured`);
+  }
+
+  const client = createFeishuClient(account);
+  const receiveId = normalizeFeishuTarget(to);
+  if (!receiveId) {
+    throw new Error(`Invalid Feishu target: ${to}`);
+  }
+
+  const receiveIdType = resolveReceiveIdType(receiveId);
+  const content = JSON.stringify({ file_key: fileKey });
+
+  if (replyToMessageId) {
+    const response = await client.im.message.reply({
+      path: { message_id: replyToMessageId },
+      data: {
+        content,
+        msg_type: "audio",
+      },
+    });
+
+    if (response.code !== 0) {
+      throw new Error(`Feishu audio reply failed: ${response.msg || `code ${response.code}`}`);
+    }
+
+    return {
+      messageId: response.data?.message_id ?? "unknown",
+      chatId: receiveId,
+    };
+  }
+
+  const response = await client.im.message.create({
+    params: { receive_id_type: receiveIdType },
+    data: {
+      receive_id: receiveId,
+      content,
+      msg_type: "audio",
+    },
+  });
+
+  if (response.code !== 0) {
+    throw new Error(`Feishu audio send failed: ${response.msg || `code ${response.code}`}`);
+  }
+
+  return {
+    messageId: response.data?.message_id ?? "unknown",
+    chatId: receiveId,
+  };
+}
+
+/**
  * Send a file message using a file_key
  */
 export async function sendFileFeishu(params: {
   cfg: ClawdbotConfig;
   to: string;
   fileKey: string;
-  /** Use "media" for audio/video files, "file" for documents */
+  /** Use "media" for video files, "file" for documents */
   msgType?: "file" | "media";
   replyToMessageId?: string;
   accountId?: string;
@@ -511,14 +575,27 @@ export async function sendMediaFeishu(params: {
     throw new Error("Either mediaUrl or mediaBuffer must be provided");
   }
 
-  // Determine if it's an image based on extension
+  // Determine media type based on extension
   const ext = path.extname(name).toLowerCase();
   const isImage = [".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".ico", ".tiff"].includes(ext);
+  const isAudio = [".opus", ".ogg"].includes(ext);
+  const isVideo = [".mp4", ".mov", ".avi"].includes(ext);
 
   if (isImage) {
     const { imageKey } = await uploadImageFeishu({ cfg, image: buffer, accountId });
     return sendImageFeishu({ cfg, to, imageKey, replyToMessageId, accountId });
-  } else {
+  } else if (isAudio) {
+    // Use msg_type "audio" for native voice bubble UI
+    const { fileKey } = await uploadFileFeishu({
+      cfg,
+      file: buffer,
+      fileName: name,
+      fileType: "opus",
+      accountId,
+    });
+    return sendAudioFeishu({ cfg, to, fileKey, replyToMessageId, accountId });
+  } else if (isVideo) {
+    // Use msg_type "media" for video files
     const fileType = detectFileType(name);
     const { fileKey } = await uploadFileFeishu({
       cfg,
@@ -527,13 +604,29 @@ export async function sendMediaFeishu(params: {
       fileType,
       accountId,
     });
-    // Feishu requires msg_type "media" for audio/video, "file" for documents
-    const isMedia = fileType === "mp4" || fileType === "opus";
     return sendFileFeishu({
       cfg,
       to,
       fileKey,
-      msgType: isMedia ? "media" : "file",
+      msgType: "media",
+      replyToMessageId,
+      accountId,
+    });
+  } else {
+    // Use msg_type "file" for documents
+    const fileType = detectFileType(name);
+    const { fileKey } = await uploadFileFeishu({
+      cfg,
+      file: buffer,
+      fileName: name,
+      fileType,
+      accountId,
+    });
+    return sendFileFeishu({
+      cfg,
+      to,
+      fileKey,
+      msgType: "file",
       replyToMessageId,
       accountId,
     });


### PR DESCRIPTION
## Summary

Add support for sending native voice messages (audio bubbles) in Feishu instead of file attachments.

## Problem

Currently, when sending audio files via the Feishu plugin, they are sent as file attachments (`msg_type: "file"` or `msg_type: "media"`) instead of native voice messages (`msg_type: "audio"`). This results in a poor user experience as users see a file download link instead of a playable voice bubble with duration indicator.

## Solution

1. **Add `sendAudioFeishu` function**: A new function that sends audio messages using `msg_type: "audio"`, which displays as a native voice bubble in Feishu client.

2. **Modify `sendMediaFeishu`**: Updated to detect audio files (`.opus`, `.ogg`) and route them to `sendAudioFeishu` instead of `sendFileFeishu`.

3. **Separate media type handling**:
   - Audio files (`.opus`, `.ogg`) → `msg_type: "audio"` (voice bubble)
   - Video files (`.mp4`, `.mov`, `.avi`) → `msg_type: "media"` (video player)
   - Other files → `msg_type: "file"` (file attachment)

## Testing

Tested with:
- Edge TTS generated audio converted to opus format
- Various audio lengths (3s to 68s)
- Successfully displays as native voice bubble in Feishu client (desktop and mobile)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a dedicated `sendAudioFeishu` path that sends Feishu `msg_type: "audio"` messages (voice bubble UI) and updates `sendMediaFeishu` to route `.opus`/`.ogg` through this audio path, while routing common video extensions through `msg_type: "media"` and leaving other files as `msg_type: "file"`.

The change fits the existing media module pattern: upload via `im.file.create` / `im.image.create`, then send via `im.message.create` (or `reply`) using the returned key. The new logic mainly affects how audio is uploaded/sent and removes the prior `fileType === "opus" => msg_type: "media"` behavior in favor of a native audio message.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a likely Feishu API contract mismatch for audio uploads.
- Core routing logic is straightforward and consistent with existing send paths, but the new audio upload path appears to omit required metadata (`duration`) and may mislabel `.ogg` content as `opus`, which can cause send/upload failures in real use.
- extensions/feishu/src/media.ts

<sub>Last reviewed commit: 5f8ca8e</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->