### PR TITLE
feat(web-fetch): support Cloudflare Markdown for Agents

### DIFF
--- a/src/agents/tools/web-fetch.cf-markdown.test.ts
+++ b/src/agents/tools/web-fetch.cf-markdown.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as ssrf from "../../infra/net/ssrf.js";
+import * as logger from "../../logger.js";
 
 const lookupMock = vi.fn();
 const resolvePinnedHostname = ssrf.resolvePinnedHostname;
@@ -108,7 +109,7 @@ describe("web_fetch Cloudflare Markdown for Agents", () => {
   });
 
   it("logs x-markdown-tokens when header is present", async () => {
-    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const logSpy = vi.spyOn(logger, "logDebug").mockImplementation(() => {});
     const fetchSpy = vi
       .fn()
       .mockResolvedValue(markdownResponse("# Tokens Test", { "x-markdown-tokens": "1500" }));
@@ -124,7 +125,7 @@ describe("web_fetch Cloudflare Markdown for Agents", () => {
 
     await tool?.execute?.("call", { url: "https://example.com/tokens" });
 
-    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("x-markdown-tokens: 1500"));
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("x-markdown-tokens: 1500"));
   });
 
   it("converts markdown to text when extractMode is text", async () => {
@@ -155,7 +156,7 @@ describe("web_fetch Cloudflare Markdown for Agents", () => {
   });
 
   it("does not log x-markdown-tokens when header is absent", async () => {
-    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const logSpy = vi.spyOn(logger, "logDebug").mockImplementation(() => {});
     const fetchSpy = vi.fn().mockResolvedValue(markdownResponse("# No tokens"));
     // @ts-expect-error mock fetch
     global.fetch = fetchSpy;
@@ -169,7 +170,7 @@ describe("web_fetch Cloudflare Markdown for Agents", () => {
 
     await tool?.execute?.("call", { url: "https://example.com/no-tokens" });
 
-    const tokenLogs = consoleSpy.mock.calls.filter(
+    const tokenLogs = logSpy.mock.calls.filter(
       (args) => typeof args[0] === "string" && args[0].includes("x-markdown-tokens"),
     );
     expect(tokenLogs).toHaveLength(0);

--- a/src/agents/tools/web-fetch.cf-markdown.test.ts
+++ b/src/agents/tools/web-fetch.cf-markdown.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as ssrf from "../../infra/net/ssrf.js";
+
+const lookupMock = vi.fn();
+const resolvePinnedHostname = ssrf.resolvePinnedHostname;
+
+function makeHeaders(map: Record<string, string>): { get: (key: string) => string | null } {
+  return {
+    get: (key) => map[key.toLowerCase()] ?? null,
+  };
+}
+
+function markdownResponse(body: string, extraHeaders: Record<string, string> = {}): Response {
+  return {
+    ok: true,
+    status: 200,
+    headers: makeHeaders({ "content-type": "text/markdown; charset=utf-8", ...extraHeaders }),
+    text: async () => body,
+  } as Response;
+}
+
+function htmlResponse(body: string): Response {
+  return {
+    ok: true,
+    status: 200,
+    headers: makeHeaders({ "content-type": "text/html; charset=utf-8" }),
+    text: async () => body,
+  } as Response;
+}
+
+describe("web_fetch Cloudflare Markdown for Agents", () => {
+  const priorFetch = global.fetch;
+
+  beforeEach(() => {
+    lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+    vi.spyOn(ssrf, "resolvePinnedHostname").mockImplementation((hostname) =>
+      resolvePinnedHostname(hostname, lookupMock),
+    );
+  });
+
+  afterEach(() => {
+    // @ts-expect-error restore
+    global.fetch = priorFetch;
+    lookupMock.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it("sends Accept header preferring text/markdown", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(markdownResponse("# Test Page\n\nHello world."));
+    // @ts-expect-error mock fetch
+    global.fetch = fetchSpy;
+
+    const { createWebFetchTool } = await import("./web-tools.js");
+    const tool = createWebFetchTool({
+      config: {
+        tools: { web: { fetch: { cacheTtlMinutes: 0, firecrawl: { enabled: false } } } },
+      },
+    });
+
+    await tool?.execute?.("call", { url: "https://example.com/page" });
+
+    expect(fetchSpy).toHaveBeenCalled();
+    const [, init] = fetchSpy.mock.calls[0];
+    expect(init.headers.Accept).toBe("text/markdown, text/html;q=0.9, */*;q=0.1");
+  });
+
+  it("uses cf-markdown extractor for text/markdown responses", async () => {
+    const md = "# CF Markdown\n\nThis is server-rendered markdown.";
+    const fetchSpy = vi.fn().mockResolvedValue(markdownResponse(md));
+    // @ts-expect-error mock fetch
+    global.fetch = fetchSpy;
+
+    const { createWebFetchTool } = await import("./web-tools.js");
+    const tool = createWebFetchTool({
+      config: {
+        tools: { web: { fetch: { cacheTtlMinutes: 0, firecrawl: { enabled: false } } } },
+      },
+    });
+
+    const result = await tool?.execute?.("call", { url: "https://example.com/cf" });
+    expect(result?.details).toMatchObject({
+      status: 200,
+      extractor: "cf-markdown",
+      contentType: "text/markdown",
+    });
+    // The body should contain the original markdown (wrapped with security markers)
+    expect(result?.details?.text).toContain("CF Markdown");
+    expect(result?.details?.text).toContain("server-rendered markdown");
+  });
+
+  it("falls back to readability for text/html responses", async () => {
+    const html =
+      "<html><body><article><h1>HTML Page</h1><p>Content here.</p></article></body></html>";
+    const fetchSpy = vi.fn().mockResolvedValue(htmlResponse(html));
+    // @ts-expect-error mock fetch
+    global.fetch = fetchSpy;
+
+    const { createWebFetchTool } = await import("./web-tools.js");
+    const tool = createWebFetchTool({
+      config: {
+        tools: { web: { fetch: { cacheTtlMinutes: 0, firecrawl: { enabled: false } } } },
+      },
+    });
+
+    const result = await tool?.execute?.("call", { url: "https://example.com/html" });
+    expect(result?.details?.extractor).not.toBe("cf-markdown");
+    expect(result?.details?.contentType).toBe("text/html");
+  });
+
+  it("logs x-markdown-tokens when header is present", async () => {
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValue(markdownResponse("# Tokens Test", { "x-markdown-tokens": "1500" }));
+    // @ts-expect-error mock fetch
+    global.fetch = fetchSpy;
+
+    const { createWebFetchTool } = await import("./web-tools.js");
+    const tool = createWebFetchTool({
+      config: {
+        tools: { web: { fetch: { cacheTtlMinutes: 0, firecrawl: { enabled: false } } } },
+      },
+    });
+
+    await tool?.execute?.("call", { url: "https://example.com/tokens" });
+
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("x-markdown-tokens: 1500"));
+  });
+
+  it("converts markdown to text when extractMode is text", async () => {
+    const md = "# Heading\n\n**Bold text** and [a link](https://example.com).";
+    const fetchSpy = vi.fn().mockResolvedValue(markdownResponse(md));
+    // @ts-expect-error mock fetch
+    global.fetch = fetchSpy;
+
+    const { createWebFetchTool } = await import("./web-tools.js");
+    const tool = createWebFetchTool({
+      config: {
+        tools: { web: { fetch: { cacheTtlMinutes: 0, firecrawl: { enabled: false } } } },
+      },
+    });
+
+    const result = await tool?.execute?.("call", {
+      url: "https://example.com/text-mode",
+      extractMode: "text",
+    });
+    expect(result?.details).toMatchObject({
+      extractor: "cf-markdown",
+      extractMode: "text",
+    });
+    // Text mode strips header markers (#) and link syntax
+    expect(result?.details?.text).not.toContain("# Heading");
+    expect(result?.details?.text).toContain("Heading");
+    expect(result?.details?.text).not.toContain("[a link](https://example.com)");
+  });
+
+  it("does not log x-markdown-tokens when header is absent", async () => {
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const fetchSpy = vi.fn().mockResolvedValue(markdownResponse("# No tokens"));
+    // @ts-expect-error mock fetch
+    global.fetch = fetchSpy;
+
+    const { createWebFetchTool } = await import("./web-tools.js");
+    const tool = createWebFetchTool({
+      config: {
+        tools: { web: { fetch: { cacheTtlMinutes: 0, firecrawl: { enabled: false } } } },
+      },
+    });
+
+    await tool?.execute?.("call", { url: "https://example.com/no-tokens" });
+
+    const tokenLogs = consoleSpy.mock.calls.filter(
+      (args) => typeof args[0] === "string" && args[0].includes("x-markdown-tokens"),
+    );
+    expect(tokenLogs).toHaveLength(0);
+  });
+});

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -3,6 +3,7 @@ import type { OpenClawConfig } from "../../config/config.js";
 import type { AnyAgentTool } from "./common.js";
 import { fetchWithSsrFGuard } from "../../infra/net/fetch-guard.js";
 import { SsrFBlockedError } from "../../infra/net/ssrf.js";
+import { logDebug } from "../../logger.js";
 import { wrapExternalContent, wrapWebContent } from "../../security/external-content.js";
 import { normalizeSecretInput } from "../../utils/normalize-secret-input.js";
 import { stringEnum } from "../schema/typebox.js";
@@ -422,7 +423,7 @@ async function runWebFetch(params: {
     // Cloudflare Markdown for Agents — log token budget hint when present
     const markdownTokens = res.headers.get("x-markdown-tokens");
     if (markdownTokens) {
-      console.log(`[web-fetch] x-markdown-tokens: ${markdownTokens} (${finalUrl})`);
+      logDebug(`[web-fetch] x-markdown-tokens: ${markdownTokens} (${finalUrl})`);
     }
   } catch (error) {
     if (error instanceof SsrFBlockedError) {


### PR DESCRIPTION
## Summary

- **Add Cloudflare Markdown for Agents support** to `web_fetch` — when a Cloudflare-proxied site returns `text/markdown` via content negotiation, use the pre-rendered Markdown directly instead of parsing HTML through Readability/htmlToMarkdown
- **Prefer `text/markdown`** in the Accept header (`text/markdown, text/html;q=0.9, */*;q=0.1`) so CF sites serve Markdown when available
- **Log `x-markdown-tokens`** response header for observability when Cloudflare includes its token budget hint

## Motivation

Cloudflare's [Markdown for Agents](https://blog.cloudflare.com/markdown-for-bots) lets CF-proxied sites return clean, pre-rendered Markdown when the client sends `Accept: text/markdown`. This eliminates HTML parsing overhead and produces 3-10x more token-efficient content for AI agents. Currently `web_fetch` sends `Accept: */*`, so it never receives Markdown even from sites that support it.

## Changes

| File | Change | Lines |
|------|--------|-------|
| `src/agents/tools/web-fetch.ts` | Accept header + cf-markdown extractor branch + x-markdown-tokens log | +14, -2 |
| `src/agents/tools/web-fetch.cf-markdown.test.ts` | **NEW** — 6 unit tests | +183 |

### Detail

1. **Accept header** — `*/*` → `text/markdown, text/html;q=0.9, */*;q=0.1` (RFC 7231 content negotiation)
2. **`cf-markdown` extractor branch** — when `content-type` includes `text/markdown`, use response body as-is (skip Readability/htmlToMarkdown). Supports `extractMode: "text"` via existing `markdownToText()`
3. **`x-markdown-tokens` logging** — log Cloudflare's token budget hint header when present, using existing `[web-fetch]` prefix convention

## Backward Compatibility

- **Zero breaking changes** — the entire `text/html` code path is structurally identical; only a new `if` branch is inserted before it
- **Non-CF servers unaffected** — servers that don't support `text/markdown` ignore the Accept preference per RFC 7231 and return HTML as before
- **Graceful degradation** — `q=0.9` weight ensures HTML is still accepted when Markdown isn't available

## Test Plan

- [x] 6 new unit tests: Accept header, cf-markdown extractor, HTML fallback, x-markdown-tokens logging, text extract mode, negative token case
- [x] 6 existing tests pass (5 SSRF + 1 Firecrawl) — no regression
- [x] Live verification: `blog.cloudflare.com` returns `text/markdown; charset=utf-8` with `x-markdown-tokens: 1921`
- [x] Live verification: `developers.cloudflare.com` returns `text/markdown; charset=utf-8` with `x-markdown-tokens: 64`
- [x] Control: `example.com` returns `text/html` — HTML fallback intact
- [x] oxlint: 0 warnings, 0 errors
- [x] oxfmt: formatted

## Risk & Rollback

| Risk | Level | Detail |
|------|-------|--------|
| Backward compat | **None** | text/html path structurally identical |
| Server behavior | **None** | Non-CF servers ignore text/markdown preference per RFC 7231 |
| Token budget | **Positive** | Markdown responses are 3-10x smaller than HTML |
| Rollback | **Trivial** | Revert single commit |

🤖 Generated with [Claude Code](https://claude.ai/code) — AI-assisted with human review

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the `web_fetch` agent tool to prefer Cloudflare’s “Markdown for Agents” responses by sending an `Accept` header that prioritizes `text/markdown`, and adds a new extraction branch that uses `text/markdown` bodies directly (optionally converting to plain text via existing `markdownToText`). It also adds unit tests covering the new Accept header behavior, markdown extraction, HTML fallback, and token-hint logging.

The change fits into the existing `runWebFetch` pipeline in `src/agents/tools/web-fetch.ts`, which fetches with SSRF guarding, selects an extractor based on `Content-Type`, then wraps/truncates untrusted content before returning tool results.

<h3>Confidence Score: 4/5</h3>

- This PR is close to safe to merge; one logging issue should be addressed to match project conventions.
- Core behavior change is narrowly scoped (Accept header + content-type branch) and is covered by new unit tests; however the new `console.log` bypasses the repo logging layer and may produce unwanted stdout noise in production.
- src/agents/tools/web-fetch.ts

<sub>Last reviewed commit: b6f282a</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->