### PR TITLE
feat(web-fetch): support Cloudflare Markdown for Agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 - Sessions/Agents: pass `agentId` when resolving existing transcript paths in reply runs so non-default agents and heartbeat/chat handlers no longer fail with `Session file path must be within sessions directory`. (#15141) Thanks @Goldenmonstew.
 - Sessions/Agents: pass `agentId` through status and usage transcript-resolution paths (auto-reply, gateway usage APIs, and session cost/log loaders) so non-default agents can resolve absolute session files without path-validation failures. (#15103) Thanks @jalehman.
 - Signal/Install: auto-install `signal-cli` via Homebrew on non-x64 Linux architectures, avoiding x86_64 native binary `Exec format error` failures on arm64/arm hosts. (#15443) Thanks @jogvan-k.
+- Web tools/web_fetch: prefer `text/markdown` responses for Cloudflare Markdown for Agents, add `cf-markdown` extraction for markdown bodies, and redact fetched URLs in `x-markdown-tokens` debug logs to avoid leaking raw paths/query params. (#15376) Thanks @Yaxuan42.
 
 ## 2026.2.12
 

--- a/src/agents/tools/web-fetch.cf-markdown.test.ts
+++ b/src/agents/tools/web-fetch.cf-markdown.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as ssrf from "../../infra/net/ssrf.js";
+import * as logger from "../../logger.js";
 
 const lookupMock = vi.fn();
 const resolvePinnedHostname = ssrf.resolvePinnedHostname;
@@ -108,7 +109,7 @@ describe("web_fetch Cloudflare Markdown for Agents", () => {
   });
 
   it("logs x-markdown-tokens when header is present", async () => {
-    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const logSpy = vi.spyOn(logger, "logDebug").mockImplementation(() => {});
     const fetchSpy = vi
       .fn()
       .mockResolvedValue(markdownResponse("# Tokens Test", { "x-markdown-tokens": "1500" }));
@@ -124,7 +125,7 @@ describe("web_fetch Cloudflare Markdown for Agents", () => {
 
     await tool?.execute?.("call", { url: "https://example.com/tokens" });
 
-    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("x-markdown-tokens: 1500"));
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("x-markdown-tokens: 1500"));
   });
 
   it("converts markdown to text when extractMode is text", async () => {
@@ -155,7 +156,7 @@ describe("web_fetch Cloudflare Markdown for Agents", () => {
   });
 
   it("does not log x-markdown-tokens when header is absent", async () => {
-    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const logSpy = vi.spyOn(logger, "logDebug").mockImplementation(() => {});
     const fetchSpy = vi.fn().mockResolvedValue(markdownResponse("# No tokens"));
     // @ts-expect-error mock fetch
     global.fetch = fetchSpy;
@@ -169,7 +170,7 @@ describe("web_fetch Cloudflare Markdown for Agents", () => {
 
     await tool?.execute?.("call", { url: "https://example.com/no-tokens" });
 
-    const tokenLogs = consoleSpy.mock.calls.filter(
+    const tokenLogs = logSpy.mock.calls.filter(
       (args) => typeof args[0] === "string" && args[0].includes("x-markdown-tokens"),
     );
     expect(tokenLogs).toHaveLength(0);

--- a/src/agents/tools/web-fetch.cf-markdown.test.ts
+++ b/src/agents/tools/web-fetch.cf-markdown.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as ssrf from "../../infra/net/ssrf.js";
+
+const lookupMock = vi.fn();
+const resolvePinnedHostname = ssrf.resolvePinnedHostname;
+
+function makeHeaders(map: Record<string, string>): { get: (key: string) => string | null } {
+  return {
+    get: (key) => map[key.toLowerCase()] ?? null,
+  };
+}
+
+function markdownResponse(body: string, extraHeaders: Record<string, string> = {}): Response {
+  return {
+    ok: true,
+    status: 200,
+    headers: makeHeaders({ "content-type": "text/markdown; charset=utf-8", ...extraHeaders }),
+    text: async () => body,
+  } as Response;
+}
+
+function htmlResponse(body: string): Response {
+  return {
+    ok: true,
+    status: 200,
+    headers: makeHeaders({ "content-type": "text/html; charset=utf-8" }),
+    text: async () => body,
+  } as Response;
+}
+
+describe("web_fetch Cloudflare Markdown for Agents", () => {
+  const priorFetch = global.fetch;
+
+  beforeEach(() => {
+    lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+    vi.spyOn(ssrf, "resolvePinnedHostname").mockImplementation((hostname) =>
+      resolvePinnedHostname(hostname, lookupMock),
+    );
+  });
+
+  afterEach(() => {
+    // @ts-expect-error restore
+    global.fetch = priorFetch;
+    lookupMock.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it("sends Accept header preferring text/markdown", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(markdownResponse("# Test Page\n\nHello world."));
+    // @ts-expect-error mock fetch
+    global.fetch = fetchSpy;
+
+    const { createWebFetchTool } = await import("./web-tools.js");
+    const tool = createWebFetchTool({
+      config: {
+        tools: { web: { fetch: { cacheTtlMinutes: 0, firecrawl: { enabled: false } } } },
+      },
+    });
+
+    await tool?.execute?.("call", { url: "https://example.com/page" });
+
+    expect(fetchSpy).toHaveBeenCalled();
+    const [, init] = fetchSpy.mock.calls[0];
+    expect(init.headers.Accept).toBe("text/markdown, text/html;q=0.9, */*;q=0.1");
+  });
+
+  it("uses cf-markdown extractor for text/markdown responses", async () => {
+    const md = "# CF Markdown\n\nThis is server-rendered markdown.";
+    const fetchSpy = vi.fn().mockResolvedValue(markdownResponse(md));
+    // @ts-expect-error mock fetch
+    global.fetch = fetchSpy;
+
+    const { createWebFetchTool } = await import("./web-tools.js");
+    const tool = createWebFetchTool({
+      config: {
+        tools: { web: { fetch: { cacheTtlMinutes: 0, firecrawl: { enabled: false } } } },
+      },
+    });
+
+    const result = await tool?.execute?.("call", { url: "https://example.com/cf" });
+    expect(result?.details).toMatchObject({
+      status: 200,
+      extractor: "cf-markdown",
+      contentType: "text/markdown",
+    });
+    // The body should contain the original markdown (wrapped with security markers)
+    expect(result?.details?.text).toContain("CF Markdown");
+    expect(result?.details?.text).toContain("server-rendered markdown");
+  });
+
+  it("falls back to readability for text/html responses", async () => {
+    const html =
+      "<html><body><article><h1>HTML Page</h1><p>Content here.</p></article></body></html>";
+    const fetchSpy = vi.fn().mockResolvedValue(htmlResponse(html));
+    // @ts-expect-error mock fetch
+    global.fetch = fetchSpy;
+
+    const { createWebFetchTool } = await import("./web-tools.js");
+    const tool = createWebFetchTool({
+      config: {
+        tools: { web: { fetch: { cacheTtlMinutes: 0, firecrawl: { enabled: false } } } },
+      },
+    });
+
+    const result = await tool?.execute?.("call", { url: "https://example.com/html" });
+    expect(result?.details?.extractor).not.toBe("cf-markdown");
+    expect(result?.details?.contentType).toBe("text/html");
+  });
+
+  it("logs x-markdown-tokens when header is present", async () => {
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValue(markdownResponse("# Tokens Test", { "x-markdown-tokens": "1500" }));
+    // @ts-expect-error mock fetch
+    global.fetch = fetchSpy;
+
+    const { createWebFetchTool } = await import("./web-tools.js");
+    const tool = createWebFetchTool({
+      config: {
+        tools: { web: { fetch: { cacheTtlMinutes: 0, firecrawl: { enabled: false } } } },
+      },
+    });
+
+    await tool?.execute?.("call", { url: "https://example.com/tokens" });
+
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("x-markdown-tokens: 1500"));
+  });
+
+  it("converts markdown to text when extractMode is text", async () => {
+    const md = "# Heading\n\n**Bold text** and [a link](https://example.com).";
+    const fetchSpy = vi.fn().mockResolvedValue(markdownResponse(md));
+    // @ts-expect-error mock fetch
+    global.fetch = fetchSpy;
+
+    const { createWebFetchTool } = await import("./web-tools.js");
+    const tool = createWebFetchTool({
+      config: {
+        tools: { web: { fetch: { cacheTtlMinutes: 0, firecrawl: { enabled: false } } } },
+      },
+    });
+
+    const result = await tool?.execute?.("call", {
+      url: "https://example.com/text-mode",
+      extractMode: "text",
+    });
+    expect(result?.details).toMatchObject({
+      extractor: "cf-markdown",
+      extractMode: "text",
+    });
+    // Text mode strips header markers (#) and link syntax
+    expect(result?.details?.text).not.toContain("# Heading");
+    expect(result?.details?.text).toContain("Heading");
+    expect(result?.details?.text).not.toContain("[a link](https://example.com)");
+  });
+
+  it("does not log x-markdown-tokens when header is absent", async () => {
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const fetchSpy = vi.fn().mockResolvedValue(markdownResponse("# No tokens"));
+    // @ts-expect-error mock fetch
+    global.fetch = fetchSpy;
+
+    const { createWebFetchTool } = await import("./web-tools.js");
+    const tool = createWebFetchTool({
+      config: {
+        tools: { web: { fetch: { cacheTtlMinutes: 0, firecrawl: { enabled: false } } } },
+      },
+    });
+
+    await tool?.execute?.("call", { url: "https://example.com/no-tokens" });
+
+    const tokenLogs = consoleSpy.mock.calls.filter(
+      (args) => typeof args[0] === "string" && args[0].includes("x-markdown-tokens"),
+    );
+    expect(tokenLogs).toHaveLength(0);
+  });
+});

--- a/src/agents/tools/web-fetch.cf-markdown.test.ts
+++ b/src/agents/tools/web-fetch.cf-markdown.test.ts
@@ -123,9 +123,17 @@ describe("web_fetch Cloudflare Markdown for Agents", () => {
       },
     });
 
-    await tool?.execute?.("call", { url: "https://example.com/tokens" });
+    await tool?.execute?.("call", { url: "https://example.com/tokens/private?token=secret" });
 
-    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("x-markdown-tokens: 1500"));
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining("x-markdown-tokens: 1500 (https://example.com/...)"),
+    );
+    const tokenLogs = logSpy.mock.calls
+      .map(([message]) => String(message))
+      .filter((message) => message.includes("x-markdown-tokens"));
+    expect(tokenLogs).toHaveLength(1);
+    expect(tokenLogs[0]).not.toContain("token=secret");
+    expect(tokenLogs[0]).not.toContain("/tokens/private");
   });
 
   it("converts markdown to text when extractMode is text", async () => {

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -3,6 +3,7 @@ import type { OpenClawConfig } from "../../config/config.js";
 import type { AnyAgentTool } from "./common.js";
 import { fetchWithSsrFGuard } from "../../infra/net/fetch-guard.js";
 import { SsrFBlockedError } from "../../infra/net/ssrf.js";
+import { logDebug } from "../../logger.js";
 import { wrapExternalContent, wrapWebContent } from "../../security/external-content.js";
 import { normalizeSecretInput } from "../../utils/normalize-secret-input.js";
 import { stringEnum } from "../schema/typebox.js";
@@ -422,7 +423,7 @@ async function runWebFetch(params: {
     // Cloudflare Markdown for Agents — log token budget hint when present
     const markdownTokens = res.headers.get("x-markdown-tokens");
     if (markdownTokens) {
-      console.log(`[web-fetch] x-markdown-tokens: ${markdownTokens} (${finalUrl})`);
+      logDebug(`[web-fetch] x-markdown-tokens: ${markdownTokens} (${finalUrl})`);
     }
   } catch (error) {
     if (error instanceof SsrFBlockedError) {

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -213,6 +213,15 @@ function formatWebFetchErrorDetail(params: {
   return truncated.text;
 }
 
+function redactUrlForDebugLog(rawUrl: string): string {
+  try {
+    const parsed = new URL(rawUrl);
+    return parsed.pathname && parsed.pathname !== "/" ? `${parsed.origin}/...` : parsed.origin;
+  } catch {
+    return "[invalid-url]";
+  }
+}
+
 const WEB_FETCH_WRAPPER_WITH_WARNING_OVERHEAD = wrapWebContent("", "web_fetch").length;
 const WEB_FETCH_WRAPPER_NO_WARNING_OVERHEAD = wrapExternalContent("", {
   source: "web_fetch",
@@ -423,7 +432,9 @@ async function runWebFetch(params: {
     // Cloudflare Markdown for Agents — log token budget hint when present
     const markdownTokens = res.headers.get("x-markdown-tokens");
     if (markdownTokens) {
-      logDebug(`[web-fetch] x-markdown-tokens: ${markdownTokens} (${finalUrl})`);
+      logDebug(
+        `[web-fetch] x-markdown-tokens: ${markdownTokens} (${redactUrlForDebugLog(finalUrl)})`,
+      );
     }
   } catch (error) {
     if (error instanceof SsrFBlockedError) {


### PR DESCRIPTION
# Completion Report: openclaw-markdown-fetch-upgrade (upstream PR)

## PR Materials — Ready to Submit

### PR Title

```
feat(web-fetch): support Cloudflare Markdown for Agents
```

### PR Summary

#### Background / Motivation

Cloudflare's [Markdown for Agents](https://blog.cloudflare.com/markdown-for-bots) feature allows Cloudflare-proxied websites to return pre-rendered Markdown instead of HTML when the client sends `Accept: text/markdown`. This eliminates the need for HTML parsing (Readability, htmlToMarkdown) and provides cleaner, more token-efficient content for AI agents.

Currently, `web_fetch` sends `Accept: */*`, so it never receives Markdown even from sites that support it. This PR adds first-class support.

#### What Changed

Three targeted changes in `src/agents/tools/web-fetch.ts`:

1. **Accept header** — Changed from `*/*` to `text/markdown, text/html;q=0.9, */*;q=0.1` so Cloudflare-proxied sites can serve Markdown directly.

2. **`cf-markdown` extractor branch** — When `content-type` includes `text/markdown`, the response body is used as-is (skipping Readability/htmlToMarkdown). Supports `extractMode: "text"` via `markdownToText()`.

3. **`x-markdown-tokens` logging** — When the response includes the `x-markdown-tokens` header (Cloudflare's token budget hint), it's logged for observability.

#### Why This Approach

- **Zero new dependencies** — uses existing `markdownToText` for text mode
- **Minimal diff** — 14 lines added, 2 lines changed in one file
- **Backward-compatible** — servers that don't support Markdown ignore the Accept header and return HTML as before; the entire `text/html` path is untouched
- **Graceful degradation** — the `q=0.9` weight ensures HTML is still accepted when Markdown isn't available

### Change List

| File | Change | Lines |
|------|--------|-------|
| `src/agents/tools/web-fetch.ts` | Accept header + cf-markdown branch + x-markdown-tokens log | +14, -2 |
| `src/agents/tools/web-fetch.cf-markdown.test.ts` | **NEW** — 6 unit tests | +170 |

### Diff

```diff
-          Accept: "*/*",
+          Accept: "text/markdown, text/html;q=0.9, */*;q=0.1",

+    // Cloudflare Markdown for Agents — log token budget hint when present
+    const markdownTokens = res.headers.get("x-markdown-tokens");
+    if (markdownTokens) {
+      console.log(`[web-fetch] x-markdown-tokens: ${markdownTokens} (${finalUrl})`);
+    }

+    if (contentType.includes("text/markdown")) {
+      // Cloudflare Markdown for Agents: server returned pre-rendered markdown
+      extractor = "cf-markdown";
+      if (params.extractMode === "text") {
+        text = markdownToText(body);
+      }
+    } else if (contentType.includes("text/html")) {
```

### Test Evidence

#### Unit Tests (6 new + 6 existing regression)

| Test | Result |
|------|--------|
| sends Accept header preferring text/markdown | PASS |
| uses cf-markdown extractor for text/markdown responses | PASS |
| falls back to readability for text/html responses | PASS |
| logs x-markdown-tokens when header is present | PASS |
| converts markdown to text when extractMode is text | PASS |
| does not log x-markdown-tokens when header is absent | PASS |
| SSRF tests (5 existing) | ALL PASS |
| Firecrawl API key normalization (1 existing) | PASS |

#### Live Verification (Cloudflare-hosted sites)

| Site | content-type | x-markdown-tokens | Status |
|------|-------------|-------------------|--------|
| blog.cloudflare.com | text/markdown; charset=utf-8 | 1921 | 200 |
| developers.cloudflare.com | text/markdown; charset=utf-8 | 64 | 200 |
| example.com (control) | text/html | — | 200 |

### Risk & Rollback

| Risk | Level | Detail |
|------|-------|--------|
| Backward compat | **None** | text/html path is structurally identical; only a new `if` branch added before it |
| Server behavior | **None** | Servers that don't support `text/markdown` ignore it per HTTP content negotiation (RFC 7231) |
| Token budget | **Positive** | Markdown responses are typically 3-10x smaller than HTML, reducing token usage |
| Rollback | **Trivial** | Revert single commit; or change Accept back to `*/*` and remove the `cf-markdown` branch |

### Reviewer Checklist

- [ ] Accept header change (`*/*` → `text/markdown, text/html;q=0.9, */*;q=0.1`) — does content negotiation follow RFC 7231?
- [ ] `text/markdown` branch placement — must come before `text/html` check (order matters)
- [ ] `cf-markdown` extractor label — acceptable new extractor name?
- [ ] `markdownToText` applied when `extractMode === "text"` — consistent with existing text mode behavior?
- [ ] `x-markdown-tokens` log format — `[web-fetch]` prefix matches existing logging convention?
- [ ] Security wrapping — `wrapWebFetchContent` still applies to markdown responses (same as raw path)
- [ ] Cache key unchanged — markdown responses cached with same key format
- [ ] Existing tests unaffected — SSRF + Firecrawl tests all pass
- [ ] AI-assisted: Yes — Claude Code with human review. Fully tested.

---

## Source Code Location

- **Repo**: `/Users/yaxuan/.openclaw/source` (cloned from `github.com/openclaw/openclaw`)
- **Branch**: `feat/cf-markdown-for-agents`
- **Base**: `main`

## Previous dist patches

The dist patches from the earlier phase remain in `/opt/homebrew/lib/node_modules/openclaw/dist/` but will be overwritten on next `npm update`. The source changes in this phase are the permanent upstream solution.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the `web_fetch` tool to prefer Cloudflare’s “Markdown for Agents” responses by sending an `Accept: text/markdown, ...` header, adds a `text/markdown` handling branch that bypasses HTML readability conversion (and uses `markdownToText()` for `extractMode: "text"`), and adds a unit test suite covering the new behavior.

The core integration (content negotiation + extractor selection) fits cleanly into the existing `runWebFetch` flow and preserves the existing HTML/readability + Firecrawl fallback paths.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but one logging behavior should be fixed first.
- The functional changes are small and well-covered by tests, and the markdown branch is isolated ahead of the HTML path. The main concern is the new unconditional `console.log` that can leak fetched URLs and produce noisy/unstructured stdout in production contexts.
- src/agents/tools/web-fetch.ts

<sub>Last reviewed commit: b6f282a</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->