### PR TITLE
feat(exec): support `background: false` to force synchronous execution

### DIFF
--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -81,7 +81,13 @@ export const execSchema = Type.Object({
       description: "Milliseconds to wait before backgrounding (default 10000)",
     }),
   ),
-  background: Type.Optional(Type.Boolean({ description: "Run in background immediately" })),
+  background: Type.Optional(
+    Type.Boolean({
+      description:
+        "Run in background immediately (true) or force synchronous execution (false). " +
+        "When false, the command runs to completion regardless of yieldMs/backgroundMs.",
+    }),
+  ),
   timeout: Type.Optional(
     Type.Number({
       description: "Timeout in seconds (optional, kills process on expiry)",

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -200,7 +200,7 @@ export function createExecTool(
     name: "exec",
     label: "exec",
     description:
-      "Execute shell commands with background continuation. Use yieldMs/background to continue later via process tool. Use pty=true for TTY-required commands (terminal UIs, coding agents).",
+      "Execute shell commands with background continuation. Use yieldMs/background=true to continue later via process tool. Use background=false to force synchronous execution (no auto-backgrounding). Use pty=true for TTY-required commands (terminal UIs, coding agents).",
     parameters: execSchema,
     execute: async (_toolCallId, args, signal, onUpdate) => {
       const params = args as {
@@ -227,19 +227,22 @@ export function createExecTool(
       const warnings: string[] = [];
       let execCommandOverride: string | undefined;
       const backgroundRequested = params.background === true;
+      const synchronousRequested = params.background === false;
       const yieldRequested = typeof params.yieldMs === "number";
       if (!allowBackground && (backgroundRequested || yieldRequested)) {
         warnings.push("Warning: background execution is disabled; running synchronously.");
       }
       const yieldWindow = allowBackground
-        ? backgroundRequested
-          ? 0
-          : clampWithDefault(
-              params.yieldMs ?? defaultBackgroundMs,
-              defaultBackgroundMs,
-              10,
-              120_000,
-            )
+        ? synchronousRequested
+          ? null
+          : backgroundRequested
+            ? 0
+            : clampWithDefault(
+                params.yieldMs ?? defaultBackgroundMs,
+                defaultBackgroundMs,
+                10,
+                120_000,
+              )
         : null;
       const elevatedDefaults = defaults?.elevated;
       const elevatedAllowed = Boolean(elevatedDefaults?.enabled && elevatedDefaults.allowed);

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -163,6 +163,21 @@ describe("exec tool backgrounding", () => {
     expect(sessions.find((s) => s.sessionId === sessionId)?.name).toBe("echo hello");
   });
 
+  it("forces synchronous execution with background=false", async () => {
+    // With a very low backgroundMs, a normal command would be backgrounded.
+    // background=false should override and run synchronously to completion.
+    const tool = createExecTool({ backgroundMs: 10 });
+    const result = await tool.execute("call1", {
+      command: joinCommands([yieldDelayCmd, "echo sync-done"]),
+      background: false,
+    });
+
+    // Should complete synchronously, not return status "running"
+    expect(result.details.status).toBe("completed");
+    const text = result.content.find((c) => c.type === "text")?.text ?? "";
+    expect(text).toContain("sync-done");
+  });
+
   it("uses default timeout when timeout is omitted", async () => {
     const customBash = createTestExecTool({
       timeoutSec: 0.05,


### PR DESCRIPTION
## Summary

- Gives `background: false` an explicit meaning: **force synchronous execution**, suppressing the yield timer entirely
- Previously `false` was a no-op (treated the same as omitting the parameter) — no backwards-compatibility impact
- Adds a test verifying synchronous completion even with an aggressive `backgroundMs: 10`

### Semantics after this change

| Value | Behavior |
|---|---|
| `background: true` | Immediate background (unchanged) |
| `background: undefined` | Timer-based auto-background via `yieldMs`/`backgroundMs` (unchanged) |
| `background: false` | **Synchronous — no yield timer, blocks until completion (new)** |

## Motivation

I'm building [agentpass](https://github.com/TorbenWetter/agentpass), a security gateway that mediates AI agent requests to Home Assistant through human approval on Telegram. The `agentpass request` CLI command blocks for up to 15 minutes while waiting for the guardian to approve or deny.

With the current exec tool, the default 10-second yield timer backgrounds these commands prematurely, causing the agent to announce intermediate status messages instead of waiting silently for the result. Neither `yieldMs` (clamped to 120s) nor globally raising `backgroundMs` solve this cleanly — you'd need per-command control.

`background: false` is the natural inverse of `background: true` and gives skills exactly that control. 

## Implementation

When `background: false` is passed, `yieldWindow` is set to `null` — the same value used when `allowBackground` is globally disabled. This means no `setTimeout` race is created, and the code falls through to the synchronous `run.promise.then(...)` path.

## Test plan

- [x] New test: `"forces synchronous execution with background=false"` — creates an exec tool with `backgroundMs: 10`, runs a command with `background: false`, asserts `status === "completed"` (not `"running"`)
- [x] All 22 existing tests in `bash-tools.test.ts` and `bash-tools.exec.background-abort.test.ts` still pass
- [x] `pnpm build && pnpm check` passes (oxfmt, tsgo, oxlint — 0 warnings, 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the `exec` agent tool to give `background: false` explicit semantics: it disables the yield/background timer entirely and forces the tool call to wait for command completion. The change is implemented by treating `background === false` as a request for synchronous execution (`yieldWindow = null`), which skips the `setTimeout` yield race and falls through to the existing `run.promise.then(...)` completion path.

A new unit test is added to `bash-tools.test.ts` to ensure a command completes synchronously even when `backgroundMs` is configured aggressively low (10ms). Existing `background: true` and timer-based yield behavior (`yieldMs`/`backgroundMs`) are unchanged.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped (only affects yield-timer selection) and is covered by a targeted new unit test. The synchronous path already exists; this PR just makes it reachable via an explicit parameter. No additional callsites or side effects were introduced in the reviewed code.
- No files require special attention

<sub>Last reviewed commit: 461484b</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->