### PR TITLE
fix(antigravity): strip unsigned thinking blocks in agent loop via transformContext

### DIFF
--- a/src/agents/pi-embedded-runner.google-sanitize-thinking.e2e.test.ts
+++ b/src/agents/pi-embedded-runner.google-sanitize-thinking.e2e.test.ts
@@ -343,7 +343,7 @@ describe("sanitizeAntigravityThinkingBlocks (transformContext path)", () => {
   it("strips unsigned thinking blocks from accumulated tool-call context", () => {
     // Simulates the context that accumulates during an agent loop:
     // user turn → assistant with unsigned thinking + tool call → tool result → assistant again
-    const messages: AgentMessage[] = [
+    const messages = [
       { role: "user", content: "read /tmp/file and summarize" },
       {
         role: "assistant",
@@ -360,7 +360,7 @@ describe("sanitizeAntigravityThinkingBlocks (transformContext path)", () => {
       },
     ];
 
-    const out = sanitizeAntigravityThinkingBlocks(messages);
+    const out = sanitizeAntigravityThinkingBlocks(messages as AgentMessage[]);
 
     // Unsigned thinking block should be stripped; toolCall preserved.
     const assistant = out.find((m) => m.role === "assistant") as {
@@ -372,7 +372,7 @@ describe("sanitizeAntigravityThinkingBlocks (transformContext path)", () => {
   });
 
   it("preserves signed thinking blocks in accumulated context", () => {
-    const messages: AgentMessage[] = [
+    const messages = [
       { role: "user", content: "hello" },
       {
         role: "assistant",
@@ -383,14 +383,14 @@ describe("sanitizeAntigravityThinkingBlocks (transformContext path)", () => {
       },
     ];
 
-    const out = sanitizeAntigravityThinkingBlocks(messages);
+    const out = sanitizeAntigravityThinkingBlocks(messages as AgentMessage[]);
 
     // Should be unchanged (same reference).
     expect(out).toBe(messages);
   });
 
   it("normalizes signature field variants to thinkingSignature", () => {
-    const messages: AgentMessage[] = [
+    const messages = [
       { role: "user", content: "hi" },
       {
         role: "assistant",
@@ -398,7 +398,7 @@ describe("sanitizeAntigravityThinkingBlocks (transformContext path)", () => {
       },
     ];
 
-    const out = sanitizeAntigravityThinkingBlocks(messages);
+    const out = sanitizeAntigravityThinkingBlocks(messages as AgentMessage[]);
 
     const assistant = out.find((m) => m.role === "assistant") as {
       content?: Array<{ type?: string; thinkingSignature?: string; signature?: string }>;
@@ -407,7 +407,7 @@ describe("sanitizeAntigravityThinkingBlocks (transformContext path)", () => {
   });
 
   it("drops assistant messages entirely when only content is unsigned thinking", () => {
-    const messages: AgentMessage[] = [
+    const messages = [
       { role: "user", content: "hi" },
       {
         role: "assistant",
@@ -416,7 +416,7 @@ describe("sanitizeAntigravityThinkingBlocks (transformContext path)", () => {
       { role: "user", content: "hello again" },
     ];
 
-    const out = sanitizeAntigravityThinkingBlocks(messages);
+    const out = sanitizeAntigravityThinkingBlocks(messages as AgentMessage[]);
 
     // The all-unsigned assistant message should be dropped entirely.
     expect(out.filter((m) => m.role === "assistant")).toHaveLength(0);
@@ -424,12 +424,12 @@ describe("sanitizeAntigravityThinkingBlocks (transformContext path)", () => {
   });
 
   it("returns same array reference when no changes needed", () => {
-    const messages: AgentMessage[] = [
+    const messages = [
       { role: "user", content: "hi" },
       { role: "assistant", content: [{ type: "text", text: "hello" }] },
     ];
 
-    const out = sanitizeAntigravityThinkingBlocks(messages);
+    const out = sanitizeAntigravityThinkingBlocks(messages as AgentMessage[]);
 
     expect(out).toBe(messages);
   });

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -647,6 +647,18 @@ export async function runEmbeddedAttempt(
         params.streamParams,
       );
 
+      // Strip unsigned thinking blocks between tool-call iterations.
+      // Antigravity returns thinking blocks without signatures; pi-ai's agent loop
+      // accumulates them in context.messages and replays them on the next API call.
+      if (transcriptPolicy.normalizeAntigravityThinkingBlocks) {
+        (
+          activeSession.agent as unknown as {
+            transformContext: (msgs: AgentMessage[]) => Promise<AgentMessage[]>;
+          }
+        ).transformContext = async (messages: AgentMessage[]) =>
+          sanitizeAntigravityThinkingBlocks(messages);
+      }
+
       if (cacheTrace) {
         cacheTrace.recordStage("session:loaded", {
           messages: activeSession.messages,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1,10 +1,9 @@
+import fs from "node:fs/promises";
+import os from "node:os";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { ImageContent } from "@mariozechner/pi-ai";
 import { streamSimple } from "@mariozechner/pi-ai";
 import { createAgentSession, SessionManager, SettingsManager } from "@mariozechner/pi-coding-agent";
-import fs from "node:fs/promises";
-import os from "node:os";
-import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./types.js";
 import { resolveHeartbeatPrompt } from "../../../auto-reply/heartbeat.js";
 import { resolveChannelCapabilities } from "../../../config/channel-capabilities.js";
 import { getMachineDisplayName } from "../../../infra/machine-name.js";
@@ -107,6 +106,7 @@ import {
   shouldFlagCompactionTimeout,
 } from "./compaction-timeout.js";
 import { detectAndLoadPromptImages } from "./images.js";
+import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./types.js";
 
 export function injectHistoryImagesIntoMessages(
   messages: AgentMessage[],
@@ -654,7 +654,7 @@ export async function runEmbeddedAttempt(
       // pi-agent-core library renames/removes this hook the assignment silently no-ops.
       // The runtime check below detects that scenario.
       if (transcriptPolicy.normalizeAntigravityThinkingBlocks) {
-        const agentRecord = activeSession.agent as Record<string, unknown>;
+        const agentRecord = activeSession.agent as unknown as Record<string, unknown>;
         const hook = async (messages: AgentMessage[]) =>
           sanitizeAntigravityThinkingBlocks(messages);
         agentRecord.transformContext = hook;

--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -39,4 +39,32 @@ describe("resolveTranscriptPolicy", () => {
     expect(policy.sanitizeToolCallIds).toBe(false);
     expect(policy.toolCallIdMode).toBeUndefined();
   });
+
+  it("enables normalizeAntigravityThinkingBlocks for Antigravity Claude models", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "google-antigravity",
+      modelId: "anthropic/claude-opus-4-6",
+      modelApi: "google-antigravity",
+    });
+    expect(policy.normalizeAntigravityThinkingBlocks).toBe(true);
+    expect(policy.preserveSignatures).toBe(true);
+  });
+
+  it("does not enable normalizeAntigravityThinkingBlocks for Gemini via Antigravity", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "google-antigravity",
+      modelId: "google/gemini-2.0-flash",
+      modelApi: "google-antigravity",
+    });
+    expect(policy.normalizeAntigravityThinkingBlocks).toBe(false);
+  });
+
+  it("does not enable normalizeAntigravityThinkingBlocks for direct Anthropic API", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "anthropic",
+      modelId: "claude-opus-4-6",
+      modelApi: "anthropic-messages",
+    });
+    expect(policy.normalizeAntigravityThinkingBlocks).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #13826

Google Antigravity returns Claude thinking blocks without `signature` fields. The existing `sanitizeAntigravityThinkingBlocks` in `sanitizeSessionHistory` only runs once per user turn (at session load), but within the same turn, pi-ai's `agent-loop.js` accumulates assistant responses—with unsigned thinking blocks—in `context.messages` and replays them on subsequent API calls during tool-call iterations. This causes:

```
LLM request rejected: messages.N.content.0.thinking.signature: Field required
```

### Fix

Use the `Agent.transformContext` hook (called by the agent loop before every API call) to run `sanitizeAntigravityThinkingBlocks`, stripping unsigned thinking blocks both at session replay **and** between tool-call iterations within a single turn.

The hook is only set when `transcriptPolicy.normalizeAntigravityThinkingBlocks` is true (i.e., Antigravity providers), so non-Antigravity providers are unaffected.

### Code flow (before fix)

```
agent-loop.js: streamAssistantResponse()
  → API returns assistant with thinking block (no signature)
  → stored in context.messages

agent-loop.js: tool execution → next streamAssistantResponse()
  → context.messages still has unsigned thinking blocks
  → API rejects: "thinking.signature: Field required"
```

### Code flow (after fix)

```
agent-loop.js: streamAssistantResponse()
  → config.transformContext(messages)  ← strips unsigned thinking blocks
  → clean messages sent to API
```

## Test plan

- [x] All 81 `pi-embedded-runner` tests pass
- [x] `pnpm build && pnpm check` clean
- [x] Verified on live Antigravity deployment with tool-calling conversations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a runtime error (`thinking.signature: Field required`) that occurs during multi-step tool-calling conversations with Google Antigravity Claude models. The root cause: unsigned thinking blocks accumulate in `context.messages` between tool-call iterations within the agent loop, and the existing `sanitizeSessionHistory` only runs once at session load. The fix hooks `sanitizeAntigravityThinkingBlocks` into the agent's `transformContext` callback (called before every API request), ensuring unsigned thinking blocks are stripped both at session replay and between tool-call iterations.

- Hooks `sanitizeAntigravityThinkingBlocks` via `Agent.transformContext` in `attempt.ts`, gated behind `transcriptPolicy.normalizeAntigravityThinkingBlocks` (only active for Antigravity Claude models)
- Includes a runtime reference-comparison guard to detect if the `transformContext` property assignment fails (e.g., due to `Object.freeze` or a read-only setter)
- Adds comprehensive unit tests for `sanitizeAntigravityThinkingBlocks` covering the `transformContext` code path (stripping unsigned blocks, preserving signed blocks, normalizing signature variants, dropping empty messages, reference identity)
- Adds transcript policy tests verifying `normalizeAntigravityThinkingBlocks` is enabled only for Antigravity Claude and not Gemini-via-Antigravity or direct Anthropic API

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it's a targeted fix for a specific runtime error with good test coverage and minimal risk to non-Antigravity code paths.
- Score of 4 reflects a well-scoped fix with comprehensive tests and clear documentation. The only caveat is the reliance on an undocumented `transformContext` hook via type casting, but this is mitigated by the runtime guard and clear comments explaining the trade-off. The change is gated behind `normalizeAntigravityThinkingBlocks` so non-Antigravity providers are completely unaffected.
- `src/agents/pi-embedded-runner/run/attempt.ts` — the `transformContext` hook assignment relies on an undocumented upstream API; worth monitoring on pi-agent-core upgrades.

<sub>Last reviewed commit: a3a1680</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->