### PR TITLE
telegram: treat mp3 as voice-compatible when asVoice=true

### DIFF
--- a/src/media/audio.ts
+++ b/src/media/audio.ts
@@ -1,13 +1,13 @@
 import { getFileExtension } from "./mime.js";
 
-const VOICE_AUDIO_EXTENSIONS = new Set([".oga", ".ogg", ".opus"]);
+const VOICE_AUDIO_EXTENSIONS = new Set([".oga", ".ogg", ".opus", ".mp3"]);
 
 export function isVoiceCompatibleAudio(opts: {
   contentType?: string | null;
   fileName?: string | null;
 }): boolean {
   const mime = opts.contentType?.toLowerCase();
-  if (mime && (mime.includes("ogg") || mime.includes("opus"))) {
+  if (mime && (mime.includes("ogg") || mime.includes("opus") || mime.includes("mp3"))) {
     return true;
   }
   const fileName = opts.fileName?.trim();

--- a/src/telegram/send.returns-undefined-empty-input.test.ts
+++ b/src/telegram/send.returns-undefined-empty-input.test.ts
@@ -421,7 +421,7 @@ describe("sendMessageTelegram", () => {
     expect(sendAudio).not.toHaveBeenCalled();
   });
 
-  it("falls back to audio when asVoice is true but media is not voice compatible", async () => {
+  it("sends voice when asVoice is true for mp3 media", async () => {
     const chatId = "123";
     const sendAudio = vi.fn().mockResolvedValue({
       message_id: 14,
@@ -449,11 +449,11 @@ describe("sendMessageTelegram", () => {
       asVoice: true,
     });
 
-    expect(sendAudio).toHaveBeenCalledWith(chatId, expect.anything(), {
+    expect(sendVoice).toHaveBeenCalledWith(chatId, expect.anything(), {
       caption: "caption",
       parse_mode: "HTML",
     });
-    expect(sendVoice).not.toHaveBeenCalled();
+    expect(sendAudio).not.toHaveBeenCalled();
   });
 
   it("includes message_thread_id for forum topic messages", async () => {

--- a/src/telegram/voice.test.ts
+++ b/src/telegram/voice.test.ts
@@ -14,7 +14,7 @@ describe("resolveTelegramVoiceSend", () => {
     expect(logFallback).not.toHaveBeenCalled();
   });
 
-  it("logs fallback for incompatible media", () => {
+  it("treats mp3 as voice compatible", () => {
     const logFallback = vi.fn();
     const result = resolveTelegramVoiceSend({
       wantsVoice: true,
@@ -22,10 +22,8 @@ describe("resolveTelegramVoiceSend", () => {
       fileName: "track.mp3",
       logFallback,
     });
-    expect(result.useVoice).toBe(false);
-    expect(logFallback).toHaveBeenCalledWith(
-      "Telegram voice requested but media is audio/mpeg (track.mp3); sending as audio file instead.",
-    );
+    expect(result.useVoice).toBe(true);
+    expect(logFallback).not.toHaveBeenCalled();
   });
 
   it("keeps voice when compatible", () => {


### PR DESCRIPTION
Summary

This PR makes Telegram treat MP3 as voice-compatible when asVoice=true, so messages are sent as voice notes (sendVoice) instead of regular audio files (sendAudio).

Problem:
Currently, voice compatibility accepts only OGG/OPUS (.oga/.ogg/.opus and ogg/opus mime).
Common TTS output is MP3, so asVoice=true can fall back to audio file behavior.

Change

    Added .mp3 to VOICE_AUDIO_EXTENSIONS
    Extended mime compatibility check to include 
[SNIPPETS-BEFORE-AFTER.md](https://github.com/user-attachments/files/25288803/SNIPPETS-BEFORE-AFTER.md)
mp3

Why

This improves UX consistency: when voice is requested, Telegram receives a voice note bubble.
Validation

    Reproduced on OpenClaw 2026.2.12
    Before: asVoice=true + mp3 -> sendAudio
    After: asVoice=true + mp3 -> sendVoice

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change expands `isVoiceCompatibleAudio` (`src/media/audio.ts`) to treat MP3 (`.mp3` / MIME containing `mp3`) as “voice-compatible”, which makes Telegram’s `asVoice=true` decision route MP3 audio through `sendVoice` instead of `sendAudio`.

The main follow-up needed before merge is updating the Telegram unit test(s) that currently encode the old behavior (MP3 not voice-compatible), otherwise the test suite will no longer match the new intended routing.

<h3>Confidence Score: 3/5</h3>

- This PR is small and localized, but it requires updating existing Telegram tests that will now be incorrect.
- The implementation change is straightforward (extension + MIME substring check), but an existing unit test explicitly expects MP3 to fall back to sendAudio; without test updates the PR will be inconsistent with repo expectations. Tooling limitations in this environment prevented running the test suite to confirm.
- src/telegram/send.returns-undefined-empty-input.test.ts (and any other Telegram send tests asserting MP3 fallback)

<sub>Last reviewed commit: 1450c17</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->