### PR TITLE
fix(agent.wait): return deterministic final assistant text to avoid history races

### DIFF
--- a/src/agents/tools/agent-step.test.ts
+++ b/src/agents/tools/agent-step.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const callGatewayMock = vi.fn();
+
+vi.mock("../../gateway/call.js", () => ({
+  callGateway: (opts: unknown) => callGatewayMock(opts),
+}));
+
+import { runAgentStep } from "./agent-step.js";
+
+describe("runAgentStep", () => {
+  beforeEach(() => {
+    callGatewayMock.mockReset();
+  });
+
+  it("uses finalAssistantText from agent.wait without chat.history fallback", async () => {
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string };
+      if (request.method === "agent") {
+        return { runId: "run-1" };
+      }
+      if (request.method === "agent.wait") {
+        return { status: "ok", finalAssistantText: "reply from wait" };
+      }
+      if (request.method === "chat.history") {
+        throw new Error("chat.history should not be called when wait reply is available");
+      }
+      return {};
+    });
+
+    const reply = await runAgentStep({
+      sessionKey: "agent:coder:test",
+      message: "ping",
+      extraSystemPrompt: "step",
+      timeoutMs: 5_000,
+    });
+    expect(reply).toBe("reply from wait");
+    expect(
+      callGatewayMock.mock.calls.some(
+        (call) => (call[0] as { method?: string }).method === "chat.history",
+      ),
+    ).toBe(false);
+  });
+
+  it("falls back to chat.history when agent.wait has no finalAssistantText", async () => {
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string };
+      if (request.method === "agent") {
+        return { runId: "run-2" };
+      }
+      if (request.method === "agent.wait") {
+        return { status: "ok" };
+      }
+      if (request.method === "chat.history") {
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [{ type: "text", text: "reply from history" }],
+            },
+          ],
+        };
+      }
+      return {};
+    });
+
+    const reply = await runAgentStep({
+      sessionKey: "agent:coder:test",
+      message: "ping",
+      extraSystemPrompt: "step",
+      timeoutMs: 5_000,
+    });
+    expect(reply).toBe("reply from history");
+  });
+
+  it("returns undefined when agent.wait does not finish with ok", async () => {
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string };
+      if (request.method === "agent") {
+        return { runId: "run-3" };
+      }
+      if (request.method === "agent.wait") {
+        return { status: "timeout" };
+      }
+      if (request.method === "chat.history") {
+        throw new Error("chat.history should not be called for non-ok wait status");
+      }
+      return {};
+    });
+
+    const reply = await runAgentStep({
+      sessionKey: "agent:coder:test",
+      message: "ping",
+      extraSystemPrompt: "step",
+      timeoutMs: 5_000,
+    });
+    expect(reply).toBeUndefined();
+  });
+});

--- a/src/agents/tools/agent-step.ts
+++ b/src/agents/tools/agent-step.ts
@@ -52,7 +52,7 @@ export async function runAgentStep(params: {
   const stepRunId = typeof response?.runId === "string" && response.runId ? response.runId : "";
   const resolvedRunId = stepRunId || stepIdem;
   const stepWaitMs = Math.min(params.timeoutMs, 60_000);
-  const wait = await callGateway<{ status?: string }>({
+  const wait = await callGateway<{ status?: string; finalAssistantText?: string }>({
     method: "agent.wait",
     params: {
       runId: resolvedRunId,
@@ -62,6 +62,9 @@ export async function runAgentStep(params: {
   });
   if (wait?.status !== "ok") {
     return undefined;
+  }
+  if (typeof wait?.finalAssistantText === "string" && wait.finalAssistantText.trim()) {
+    return wait.finalAssistantText;
   }
   return await readLatestAssistantReply({ sessionKey: params.sessionKey });
 }

--- a/src/agents/tools/sessions-send-tool.a2a.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.ts
@@ -32,7 +32,7 @@ export async function runSessionsSendA2AFlow(params: {
     let latestReply = params.roundOneReply;
     if (!primaryReply && params.waitRunId) {
       const waitMs = Math.min(params.announceTimeoutMs, 60_000);
-      const wait = await callGateway<{ status: string }>({
+      const wait = await callGateway<{ status: string; finalAssistantText?: string }>({
         method: "agent.wait",
         params: {
           runId: params.waitRunId,
@@ -41,9 +41,12 @@ export async function runSessionsSendA2AFlow(params: {
         timeoutMs: waitMs + 2000,
       });
       if (wait?.status === "ok") {
-        primaryReply = await readLatestAssistantReply({
-          sessionKey: params.targetSessionKey,
-        });
+        primaryReply =
+          typeof wait?.finalAssistantText === "string" && wait.finalAssistantText.trim()
+            ? wait.finalAssistantText
+            : await readLatestAssistantReply({
+                sessionKey: params.targetSessionKey,
+              });
         latestReply = primaryReply;
       }
     }

--- a/src/gateway/server-methods/agent-job.ts
+++ b/src/gateway/server-methods/agent-job.ts
@@ -11,13 +11,26 @@ type AgentRunSnapshot = {
   startedAt?: number;
   endedAt?: number;
   error?: string;
+  finalAssistantText?: string;
   ts: number;
 };
+
+type AgentRunAssistantText = {
+  text: string;
+  ts: number;
+};
+
+const agentRunAssistantTexts = new Map<string, AgentRunAssistantText>();
 
 function pruneAgentRunCache(now = Date.now()) {
   for (const [runId, entry] of agentRunCache) {
     if (now - entry.ts > AGENT_RUN_CACHE_TTL_MS) {
       agentRunCache.delete(runId);
+    }
+  }
+  for (const [runId, entry] of agentRunAssistantTexts) {
+    if (now - entry.ts > AGENT_RUN_CACHE_TTL_MS) {
+      agentRunAssistantTexts.delete(runId);
     }
   }
 }
@@ -27,6 +40,29 @@ function recordAgentRunSnapshot(entry: AgentRunSnapshot) {
   agentRunCache.set(entry.runId, entry);
 }
 
+function extractAssistantText(data: Record<string, unknown> | undefined): string | undefined {
+  if (!data) {
+    return undefined;
+  }
+  const text = data.text;
+  if (typeof text !== "string" || !text.trim()) {
+    return undefined;
+  }
+  return text;
+}
+
+function recordAssistantText(runId: string, text: string) {
+  const ts = Date.now();
+  pruneAgentRunCache(ts);
+  agentRunAssistantTexts.set(runId, { text, ts });
+}
+
+function consumeAssistantText(runId: string): string | undefined {
+  const entry = agentRunAssistantTexts.get(runId);
+  agentRunAssistantTexts.delete(runId);
+  return entry?.text;
+}
+
 function ensureAgentRunListener() {
   if (agentRunListenerStarted) {
     return;
@@ -34,6 +70,13 @@ function ensureAgentRunListener() {
   agentRunListenerStarted = true;
   onAgentEvent((evt) => {
     if (!evt) {
+      return;
+    }
+    if (evt.stream === "assistant") {
+      const text = extractAssistantText(evt.data);
+      if (text) {
+        recordAssistantText(evt.runId, text);
+      }
       return;
     }
     if (evt.stream !== "lifecycle") {
@@ -52,6 +95,7 @@ function ensureAgentRunListener() {
       typeof evt.data?.startedAt === "number" ? evt.data.startedAt : agentRunStarts.get(evt.runId);
     const endedAt = typeof evt.data?.endedAt === "number" ? evt.data.endedAt : undefined;
     const error = typeof evt.data?.error === "string" ? evt.data.error : undefined;
+    const finalAssistantText = consumeAssistantText(evt.runId);
     agentRunStarts.delete(evt.runId);
     recordAgentRunSnapshot({
       runId: evt.runId,
@@ -59,6 +103,7 @@ function ensureAgentRunListener() {
       startedAt,
       endedAt,
       error,
+      finalAssistantText,
       ts: Date.now(),
     });
   });
@@ -95,7 +140,17 @@ export async function waitForAgentJob(params: {
       resolve(entry);
     };
     const unsubscribe = onAgentEvent((evt) => {
-      if (!evt || evt.stream !== "lifecycle") {
+      if (!evt) {
+        return;
+      }
+      if (evt.stream === "assistant" && evt.runId === runId) {
+        const text = extractAssistantText(evt.data);
+        if (text) {
+          recordAssistantText(runId, text);
+        }
+        return;
+      }
+      if (evt.stream !== "lifecycle") {
         return;
       }
       if (evt.runId !== runId) {
@@ -116,12 +171,14 @@ export async function waitForAgentJob(params: {
           : agentRunStarts.get(evt.runId);
       const endedAt = typeof evt.data?.endedAt === "number" ? evt.data.endedAt : undefined;
       const error = typeof evt.data?.error === "string" ? evt.data.error : undefined;
+      const finalAssistantText = consumeAssistantText(evt.runId);
       const snapshot: AgentRunSnapshot = {
         runId: evt.runId,
         status: phase === "error" ? "error" : evt.data?.aborted ? "timeout" : "ok",
         startedAt,
         endedAt,
         error,
+        finalAssistantText,
         ts: Date.now(),
       };
       recordAgentRunSnapshot(snapshot);

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -522,6 +522,7 @@ export const agentHandlers: GatewayRequestHandlers = {
       startedAt: snapshot.startedAt,
       endedAt: snapshot.endedAt,
       error: snapshot.error,
+      finalAssistantText: snapshot.finalAssistantText,
     });
   },
 };


### PR DESCRIPTION
## 背景 / Background

当前链路里，`sessions_send` / 子会话步骤在 `agent.wait` 返回 `ok` 后，仍依赖 `chat.history` 读取“最后一条 assistant 消息”。在高并发或事件时序下，这一步可能读到旧消息，导致：

1. 已完成 run 被误判为未拿到结果（stale read）
2. announce/reply 步骤读到前一轮内容
3. 上层看起来像“卡住”或“继续执行不稳定”

In the current flow, `sessions_send` and subagent step logic call `chat.history` after `agent.wait=ok` to fetch the latest assistant reply. Under event ordering races, this can return stale transcript data and produce unstable behavior.

## 变更 / What changed

1. `agent.wait` 底层新增可选返回字段 `finalAssistantText`
2. `waitForAgentJob` 监听并缓存同一 `runId` 的最新 `assistant` 文本，在生命周期结束时写入快照
3. `sessions_send` 主路径优先使用 `agent.wait.finalAssistantText`，缺失时才回退 `chat.history`
4. A2A announce 流程和 `runAgentStep` 同样优先使用 `finalAssistantText`
5. 补充单测覆盖 deterministic 回传和 fallback 逻辑

Added an optional `finalAssistantText` field on `agent.wait`, populated from assistant events for the same `runId`. `sessions_send` / A2A / `runAgentStep` now prefer this deterministic value and only fall back to `chat.history` when absent.

## 兼容性 / Compatibility

- 新字段是可选字段，未使用该字段的调用方不受影响。
- 保留原有 `chat.history` fallback，兼容未产出 assistant 事件的场景。

The new field is optional and backward compatible. Existing callers continue to work, with history fallback preserved.

## 测试 / Tests

- `pnpm vitest src/gateway/server-methods/agent-job.test.ts`
- `pnpm vitest src/agents/tools/agent-step.test.ts`
- `pnpm vitest src/agents/openclaw-tools.sessions.test.ts`
- `pnpm vitest run --config vitest.e2e.config.ts src/gateway/server.sessions-send.e2e.test.ts`

All passed locally.

## 关联 / Link

- Related: #14046

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds an optional `finalAssistantText` field to `agent.wait` responses and updates session-send / A2A / `runAgentStep` to prefer this deterministic value over reading the latest assistant message from `chat.history`, reducing stale-history races after `agent.wait` returns `ok`.

The value is populated in the gateway by listening for `assistant` agent events for a given `runId`, caching the latest text seen, and snapshotting it into the run’s lifecycle-end record so later `agent.wait` calls can return it without touching history.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but the new deterministic reply field won’t work for delta-only assistant event streams.
- Core change is additive and keeps history fallback, so it won’t break existing callers. However, the gateway-side capture only looks at `evt.data.text`, while the codebase also emits assistant events as `delta` chunks in streaming paths; those runs will never populate `finalAssistantText`, reducing the intended determinism for common streaming scenarios.
- src/gateway/server-methods/agent-job.ts

<sub>Last reviewed commit: 2e8a838</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->

## 与 #15383 的关系 / Relation to #15383

这是同一问题的“底层确定性解法（infrastructure-level fix）”。

- 本 PR（#15402）让 `agent.wait` 返回可选 `finalAssistantText`，调用方可优先使用确定结果，降低 `chat.history` 时序竞态。
- 互补 PR（#15383）在 announce 投递前增加上层防护，作为快速缓解层。

### 为什么拆成两个 PR / Why split into two PRs

1. 变更层级不同：#15402 改的是网关等待结果契约；#15383 改的是 A2A announce 业务防护。
2. 评审关注点不同：一个偏 API/并发语义，一个偏业务行为防抖。
3. 便于维护者选择：可单独接受高层或底层方案，也可组合合并。

### 结论 / Outcome

两者都针对 #14046；单独合并任一条都能改善，组合合并效果最佳。

Related: #14046, #15383
