### PR TITLE
feat(web-fetch): add Accept: text/markdown header for Cloudflare Markdown for Agents

### DIFF
--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -409,7 +409,7 @@ async function runWebFetch(params: {
       timeoutMs: params.timeoutSeconds * 1000,
       init: {
         headers: {
-          Accept: "*/*",
+          Accept: "text/markdown, text/html;q=0.9, */*;q=0.8",
           "User-Agent": params.userAgent,
           "Accept-Language": "en-US,en;q=0.9",
         },
@@ -522,7 +522,12 @@ async function runWebFetch(params: {
     let title: string | undefined;
     let extractor = "raw";
     let text = body;
-    if (contentType.includes("text/html")) {
+    if (contentType.includes("text/markdown")) {
+      // Cloudflare Markdown for Agents (and similar): server returned markdown directly.
+      // Use as-is, skip HTML extraction — saves ~80% tokens on supporting sites.
+      text = body;
+      extractor = "markdown-native";
+    } else if (contentType.includes("text/html")) {
       if (params.readabilityEnabled) {
         const readable = await extractReadableContent({
           html: body,


### PR DESCRIPTION
## Summary

Adds `Accept: text/markdown, text/html;q=0.9, */*;q=0.8` to `web_fetch` HTTP requests, enabling [Cloudflare Markdown for Agents](https://blog.cloudflare.com/markdown-for-agents/) support.

When a server returns `Content-Type: text/markdown`, the body is used directly (extractor: `markdown-native`) — skipping HTML extraction entirely. This can reduce token consumption by ~80% on supporting sites.

**Fully backward-compatible:** non-supporting sites return `text/html` as usual and hit the existing Readability/Firecrawl pipeline.

## Changes

- `src/agents/tools/web-fetch.ts`: Updated `Accept` header + added `text/markdown` content-type handling

## Testing

- TypeScript compiles clean (`tsc --noEmit`)
- All 11 existing web-fetch tests pass
- Linter (oxlint) + formatter (oxfmt) clean

Closes #15393

🤖 AI-assisted (Claude Opus 4)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates `web_fetch` to send an `Accept: text/markdown, text/html;q=0.9, */*;q=0.8` header and adds a fast-path for `Content-Type: text/markdown` responses (marking them as `extractor="markdown-native"` and skipping the HTML Readability/Firecrawl extraction pipeline).

Overall this fits cleanly into the existing fetch/extract flow, but there are a couple of behavioral inconsistencies to fix so `extractMode` remains the primary contract and content-type detection is robust.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge after fixing output-format consistency for markdown responses.
- The PR is small and well-scoped, but currently changes `web_fetch` semantics in a way that can surprise callers: `extractMode: "text"` can return markdown when a server replies `text/markdown`, and Content-Type detection is case-sensitive. Both are straightforward to address.
- src/agents/tools/web-fetch.ts

<sub>Last reviewed commit: 8de4bb6</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->