### PR TITLE
feat(web-fetch): Add Accept: text/markdown for Cloudflare Markdown for Agents

### DIFF
--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -519,6 +519,8 @@ async function runWebFetch(params: {
 
     const contentType = res.headers.get("content-type") ?? "application/octet-stream";
     const normalizedContentType = normalizeContentType(contentType) ?? "application/octet-stream";
+    // Lowercase for case-insensitive MIME type comparisons (Content-Type is case-insensitive per RFC 7231)
+    const ct = normalizedContentType.toLowerCase();
     const body = await readResponseText(res);
 
     let title: string | undefined;
@@ -527,10 +529,10 @@ async function runWebFetch(params: {
 
     // Cloudflare Markdown for Agents: if server returns text/markdown, use directly
     // This can reduce token consumption by ~80% vs HTML extraction
-    if (contentType.includes("text/markdown")) {
+    if (ct === "text/markdown") {
       extractor = "markdown-native";
       // text is already markdown, no extraction needed
-    } else if (contentType.includes("text/html")) {
+    } else if (ct === "text/html") {
       if (params.readabilityEnabled) {
         const readable = await extractReadableContent({
           html: body,
@@ -558,7 +560,7 @@ async function runWebFetch(params: {
           "Web fetch extraction failed: Readability disabled and Firecrawl unavailable.",
         );
       }
-    } else if (contentType.includes("application/json")) {
+    } else if (ct === "application/json") {
       try {
         text = JSON.stringify(JSON.parse(body), null, 2);
         extractor = "json";


### PR DESCRIPTION
## Summary

Cloudflare just launched **Markdown for Agents** (2026-02-12), which allows websites on Cloudflare to return Markdown directly via content negotiation. This can reduce token consumption by ~80%.

**Blog post:** https://blog.cloudflare.com/markdown-for-agents/

## Changes

1. Update `Accept` header in web_fetch to prefer `text/markdown`:
   ```
   Accept: text/markdown, text/html;q=0.9, */*;q=0.8
   ```

2. Add `markdown-native` extractor path that uses the response body directly when server returns `Content-Type: text/markdown`

3. Skip HTML-to-markdown extraction when markdown is returned natively

## Benefits

- **~80% token reduction** on Cloudflare-hosted sites that enable this feature
- **Zero downside** — non-supporting sites return HTML as usual, fully backward compatible
- Aligns with the emerging standard for agent-friendly web content

## Testing

- Sites without markdown support: unchanged behavior (HTML → Readability extraction)
- Sites with markdown support: `extractor: 'markdown-native'` in response, raw markdown used

Closes #15393

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the `web_fetch` tool to send an `Accept` header preferring `text/markdown` (for Cloudflare “Markdown for Agents”) and adds a `markdown-native` extraction path when the response `Content-Type` is markdown, skipping HTML→markdown conversion.

Overall this fits cleanly into the existing `runWebFetch` extraction pipeline (HTML via Readability/Firecrawl, JSON passthrough, etc.), but there are a couple of correctness issues around content-type detection and `extractMode` handling that should be fixed before merge.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge once the markdown-native branch matches existing extractMode/content-type handling expectations.
- Change is small and localized, but the new markdown-native path currently returns markdown even in extractMode=text, and content-type detection is brittle due to checking the raw header string without normalization/lowercasing. Fixing these should make behavior consistent with the rest of the extraction pipeline.
- src/agents/tools/web-fetch.ts

<sub>Last reviewed commit: 4ad9481</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->