### PR TITLE
fix(auto-reply): keep cron systemEvent payloads that start with 'Read HEARTBEAT.md'

### DIFF
--- a/src/auto-reply/reply/session-resets.test.ts
+++ b/src/auto-reply/reply/session-resets.test.ts
@@ -639,4 +639,46 @@ describe("prependSystemEvents", () => {
       vi.useRealTimers();
     }
   });
+
+  it("keeps user cron payloads that start with Read HEARTBEAT.md", async () => {
+    try {
+      enqueueSystemEvent("Read HEARTBEAT.md if it exists. Reminder: send daily report.", {
+        sessionKey: "agent:main:main",
+      });
+
+      const result = await prependSystemEvents({
+        cfg: {} as OpenClawConfig,
+        sessionKey: "agent:main:main",
+        isMainSession: false,
+        isNewSession: false,
+        prefixedBodyBase: "User: hi",
+      });
+
+      expect(result).toContain("Read HEARTBEAT.md if it exists. Reminder: send daily report.");
+    } finally {
+      resetSystemEventsForTest();
+    }
+  });
+
+  it("still drops heartbeat poll/wake noise", async () => {
+    try {
+      enqueueSystemEvent("heartbeat poll: pending", { sessionKey: "agent:main:main" });
+      enqueueSystemEvent("heartbeat wake complete", { sessionKey: "agent:main:main" });
+      enqueueSystemEvent("Reminder: check CI at 9 PM", { sessionKey: "agent:main:main" });
+
+      const result = await prependSystemEvents({
+        cfg: {} as OpenClawConfig,
+        sessionKey: "agent:main:main",
+        isMainSession: false,
+        isNewSession: false,
+        prefixedBodyBase: "User: hi",
+      });
+
+      expect(result).toContain("Reminder: check CI at 9 PM");
+      expect(result).not.toContain("heartbeat poll");
+      expect(result).not.toContain("heartbeat wake");
+    } finally {
+      resetSystemEventsForTest();
+    }
+  });
 });

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -29,12 +29,7 @@ export async function prependSystemEvents(params: {
     if (lower.includes("reason periodic")) {
       return null;
     }
-    // Filter out the actual heartbeat prompt, but not cron jobs that mention "heartbeat"
-    // The heartbeat prompt starts with "Read HEARTBEAT.md" - cron payloads won't match this
-    if (lower.startsWith("read heartbeat.md")) {
-      return null;
-    }
-    // Also filter heartbeat poll/wake noise
+    // Filter heartbeat poll/wake noise.
     if (lower.includes("heartbeat poll") || lower.includes("heartbeat wake")) {
       return null;
     }


### PR DESCRIPTION
## Summary
- stop dropping system events just because text starts with `Read HEARTBEAT.md`
- keep existing heartbeat poll/wake noise filtering unchanged
- add regression tests to ensure user cron payloads with this prefix are preserved

## Why
`compactSystemEvent()` used a text-prefix heuristic that filtered legitimate user-configured cron payloads (issue #15399).

## Testing
- `pnpm --dir /root/clawd/work/openclaw exec vitest run src/auto-reply/reply/session-resets.test.ts`
- `pnpm --dir /root/clawd/work/openclaw exec vitest run src/infra/system-events.test.ts`

Fixes #15399

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change adjusts `prependSystemEvents` to stop dropping queued system events purely because their text starts with `Read HEARTBEAT.md`, while keeping the existing filtering for heartbeat poll/wake noise.

In context, cron jobs enqueue their payloads into the system-events queue (see `src/gateway/server-cron.ts`), and `prependSystemEvents` is responsible for prefixing that queue into the next prompt. The added regression tests assert that user-configured cron payloads starting with `Read HEARTBEAT.md` are preserved, and that poll/wake noise continues to be removed.


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a narrow removal of an over-broad text-prefix filter in `prependSystemEvents`, and tests cover both the regression case and preservation of existing heartbeat poll/wake filtering. Heartbeat prompting itself is handled via the heartbeat runner as a user message, so preserving system events that start with `Read HEARTBEAT.md` aligns with current architecture.
- No files require special attention

<sub>Last reviewed commit: a090aed</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->