### PR TITLE
fix(memory): use QAT variant of embedding model for better quality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Memory: switch default local embedding model to the QAT `embeddinggemma-300m-qat-Q8_0` variant for better quality at the same footprint. (#15429) Thanks @azade-c.
 - Agents/Compaction: centralize exec default resolution in the shared tool factory so per-agent `tools.exec` overrides (host/security/ask/node and related defaults) persist across compaction retries. (#15833) Thanks @napetrov.
 - CLI/Completion: route plugin-load logs to stderr and write generated completion scripts directly to stdout to avoid `source <(openclaw completion ...)` corruption. (#15481) Thanks @arosstale.
 - Gateway/Agents: stop injecting a phantom `main` agent into gateway agent listings when `agents.list` explicitly excludes it. (#11450) Thanks @arosstale.

--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -535,7 +535,7 @@ Notes:
 
 ### Local embedding auto-download
 
-- Default local embedding model: `hf:ggml-org/embeddinggemma-300M-GGUF/embeddinggemma-300M-Q8_0.gguf` (~0.6 GB).
+- Default local embedding model: `hf:ggml-org/embeddinggemma-300m-qat-q8_0-GGUF/embeddinggemma-300m-qat-Q8_0.gguf` (~0.6 GB).
 - When `memorySearch.provider = "local"`, `node-llama-cpp` resolves `modelPath`; if the GGUF is missing it **auto-downloads** to the cache (or `local.modelCacheDir` if set), then loads it. Downloads resume on retry.
 - Native build requirement: run `pnpm approve-builds`, pick `node-llama-cpp`, then `pnpm rebuild node-llama-cpp`.
 - Fallback: if local setup fails and `memorySearch.fallback = "openai"`, we automatically switch to remote embeddings (`openai/text-embedding-3-small` unless overridden) and record the reason.

--- a/src/memory/embeddings.test.ts
+++ b/src/memory/embeddings.test.ts
@@ -313,6 +313,7 @@ describe("local embedding normalization", () => {
 
   it("normalizes local embeddings to magnitude ~1.0", async () => {
     const unnormalizedVector = [2.35, 3.45, 0.63, 4.3, 1.2, 5.1, 2.8, 3.9];
+    const resolveModelFileMock = vi.fn(async () => "/fake/model.gguf");
 
     importNodeLlamaCppMock.mockResolvedValue({
       getLlama: async () => ({
@@ -324,7 +325,7 @@ describe("local embedding normalization", () => {
           }),
         }),
       }),
-      resolveModelFile: async () => "/fake/model.gguf",
+      resolveModelFile: resolveModelFileMock,
       LlamaLogLevel: { error: 0 },
     });
 
@@ -340,6 +341,10 @@ describe("local embedding normalization", () => {
     const magnitude = Math.sqrt(embedding.reduce((sum, x) => sum + x * x, 0));
 
     expect(magnitude).toBeCloseTo(1.0, 5);
+    expect(resolveModelFileMock).toHaveBeenCalledWith(
+      "hf:ggml-org/embeddinggemma-300m-qat-q8_0-GGUF/embeddinggemma-300m-qat-Q8_0.gguf",
+      undefined,
+    );
   });
 
   it("handles zero vector without division by zero", async () => {

--- a/src/memory/embeddings.ts
+++ b/src/memory/embeddings.ts
@@ -56,7 +56,8 @@ export type EmbeddingProviderOptions = {
   };
 };
 
-const DEFAULT_LOCAL_MODEL = "hf:ggml-org/embeddinggemma-300M-GGUF/embeddinggemma-300M-Q8_0.gguf";
+const DEFAULT_LOCAL_MODEL =
+  "hf:ggml-org/embeddinggemma-300m-qat-q8_0-GGUF/embeddinggemma-300m-qat-Q8_0.gguf";
 
 function canAutoSelectLocal(options: EmbeddingProviderOptions): boolean {
   const modelPath = options.local?.modelPath?.trim();


### PR DESCRIPTION
## Summary

Switch default local embedding model from `embeddinggemma-300M` to `embeddinggemma-300m-qat` (Quantization Aware Training variant).

## Why

The current default model uses post-training quantization, while the QAT variant was trained with quantization in mind — yielding better embedding quality at the same size (Q8_0). Same footprint, better results.

## Changes

- Updated `DEFAULT_LOCAL_MODEL` in `src/memory/embeddings.ts`

## Testing

- [x] Build passes (lint clean)
- Model available on HuggingFace: `ggml-org/embeddinggemma-300m-qat-q8_0-GGUF`

Supersedes #4750 (closed during feature freeze as `feat`, resubmitted as `fix`).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the default local embeddings model string in `src/memory/embeddings.ts` to use the quantization-aware-trained (QAT) `embeddinggemma-300m-qat` Q8_0 GGUF variant.

The change affects only the fallback model used when `options.local.modelPath` is unset/blank; the rest of the embeddings flow remains unchanged (delegating model resolution/loading to `node-llama-cpp` via `resolveModelFile`).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The PR changes a single constant (the default HF model identifier) and does not alter any control flow, error handling, or API surface. No in-repo logic depends on the specific string beyond passing it through to node-llama-cpp for resolution/loading.
- src/memory/embeddings.ts

<sub>Last reviewed commit: 25cff7b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->