### PR TITLE
MS Teams: add user mention support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Security/Gateway + ACP: block high-risk tools (`sessions_spawn`, `sessions_send`, `gateway`, `whatsapp_login`) from HTTP `/tools/invoke` by default with `gateway.tools.{allow,deny}` overrides, and harden ACP permission selection to fail closed when tool identity/options are ambiguous while supporting `allow_always`/`reject_always`. (#15390) Thanks @aether-ai-agent.
+- MS Teams: preserve parsed mention entities/text when appending OneDrive fallback file links, and accept broader real-world Teams mention ID formats (`29:...`, `8:orgid:...`) while still rejecting placeholder patterns. (#15436) Thanks @hyojin.
 - Security/Audit: distinguish external webhooks (`hooks.enabled`) from internal hooks (`hooks.internal.enabled`) in attack-surface summaries to avoid false exposure signals when only internal hooks are enabled. (#13474) Thanks @mcaxtr.
 - Auto-reply/Threading: auto-inject implicit reply threading so `replyToMode` works without requiring model-emitted `[[reply_to_current]]`, while preserving `replyToMode: "off"` behavior for implicit Slack replies and keeping block-streaming chunk coalescing stable under `replyToMode: "first"`. (#14976) Thanks @Diaspar4u.
 - Sandbox: pass configured `sandbox.docker.env` variables to sandbox containers at `docker create` time. (#15138) Thanks @stevebot-alive.

--- a/docs/channels/msteams.md
+++ b/docs/channels/msteams.md
@@ -423,6 +423,8 @@ If you need images/files in **channels** or want to fetch **message history**, y
 3. Bump the Teams app **manifest version**, re-upload, and **reinstall the app in Teams**.
 4. **Fully quit and relaunch Teams** to clear cached app metadata.
 
+**Additional permission for user mentions:** User @mentions work out of the box for users in the conversation. However, if you want to dynamically search and mention users who are **not in the current conversation**, add `User.Read.All` (Application) permission and grant admin consent.
+
 ## Known Limitations
 
 ### Webhook timeouts

--- a/extensions/msteams/src/mentions.test.ts
+++ b/extensions/msteams/src/mentions.test.ts
@@ -208,4 +208,16 @@ describe("formatMentionText", () => {
 
     expect(result).toBe("Hello world");
   });
+
+  it("escapes regex metacharacters in names", () => {
+    const text = "Hey @John(Test) and @Alice.Smith";
+    const mentions = [
+      { id: "28:xxx", name: "John(Test)" },
+      { id: "28:yyy", name: "Alice.Smith" },
+    ];
+
+    const result = formatMentionText(text, mentions);
+
+    expect(result).toBe("Hey <at>John(Test)</at> and <at>Alice.Smith</at>");
+  });
 });

--- a/extensions/msteams/src/mentions.test.ts
+++ b/extensions/msteams/src/mentions.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from "vitest";
+import { buildMentionEntities, formatMentionText, parseMentions } from "./mentions.js";
+
+describe("parseMentions", () => {
+  it("parses single mention", () => {
+    const result = parseMentions("Hello @[John Doe](28:a1b2c3-d4e5f6)!");
+
+    expect(result.text).toBe("Hello <at>John Doe</at>!");
+    expect(result.entities).toHaveLength(1);
+    expect(result.entities[0]).toEqual({
+      type: "mention",
+      text: "<at>John Doe</at>",
+      mentioned: {
+        id: "28:a1b2c3-d4e5f6",
+        name: "John Doe",
+      },
+    });
+  });
+
+  it("parses multiple mentions", () => {
+    const result = parseMentions("Hey @[Alice](28:aaa) and @[Bob](28:bbb), can you review this?");
+
+    expect(result.text).toBe("Hey <at>Alice</at> and <at>Bob</at>, can you review this?");
+    expect(result.entities).toHaveLength(2);
+    expect(result.entities[0]).toEqual({
+      type: "mention",
+      text: "<at>Alice</at>",
+      mentioned: {
+        id: "28:aaa",
+        name: "Alice",
+      },
+    });
+    expect(result.entities[1]).toEqual({
+      type: "mention",
+      text: "<at>Bob</at>",
+      mentioned: {
+        id: "28:bbb",
+        name: "Bob",
+      },
+    });
+  });
+
+  it("handles text without mentions", () => {
+    const result = parseMentions("Hello world!");
+
+    expect(result.text).toBe("Hello world!");
+    expect(result.entities).toHaveLength(0);
+  });
+
+  it("handles empty text", () => {
+    const result = parseMentions("");
+
+    expect(result.text).toBe("");
+    expect(result.entities).toHaveLength(0);
+  });
+
+  it("handles mention with spaces in name", () => {
+    const result = parseMentions("@[John Peter Smith](28:a1b2c3)");
+
+    expect(result.text).toBe("<at>John Peter Smith</at>");
+    expect(result.entities[0]?.mentioned.name).toBe("John Peter Smith");
+  });
+
+  it("trims whitespace from id and name", () => {
+    const result = parseMentions("@[ John Doe ]( 28:a1b2c3 )");
+
+    expect(result.entities[0]).toEqual({
+      type: "mention",
+      text: "<at>John Doe</at>",
+      mentioned: {
+        id: "28:a1b2c3",
+        name: "John Doe",
+      },
+    });
+  });
+
+  it("handles Japanese characters in mention at start of message", () => {
+    const input = "@[タナカ タロウ](a1b2c3d4-e5f6-7890-abcd-ef1234567890) スキル化完了しました！";
+    const result = parseMentions(input);
+
+    expect(result.text).toBe("<at>タナカ タロウ</at> スキル化完了しました！");
+    expect(result.entities).toHaveLength(1);
+    expect(result.entities[0]).toEqual({
+      type: "mention",
+      text: "<at>タナカ タロウ</at>",
+      mentioned: {
+        id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        name: "タナカ タロウ",
+      },
+    });
+
+    // Verify entity text exactly matches what's in the formatted text
+    const entityText = result.entities[0]?.text;
+    expect(result.text).toContain(entityText);
+    expect(result.text.indexOf(entityText)).toBe(0);
+  });
+
+  it("skips mention-like patterns with non-Teams IDs (e.g. in code blocks)", () => {
+    // This reproduces the actual failing payload: the message contains a real mention
+    // plus `@[表示名](ユーザーID)` as documentation text inside backticks.
+    const input =
+      "@[タナカ タロウ](a1b2c3d4-e5f6-7890-abcd-ef1234567890) スキル化完了しました！📋\n\n" +
+      "**作成したスキル:** `teams-mention`\n" +
+      "- 機能: Teamsでのメンション形式 `@[表示名](ユーザーID)`\n\n" +
+      "**追加対応:**\n" +
+      "- ユーザーのID `a1b2c3d4-e5f6-7890-abcd-ef1234567890` を登録済み";
+    const result = parseMentions(input);
+
+    // Only the real mention should be parsed; the documentation example should be left as-is
+    expect(result.entities).toHaveLength(1);
+    expect(result.entities[0]?.mentioned.id).toBe("a1b2c3d4-e5f6-7890-abcd-ef1234567890");
+    expect(result.entities[0]?.mentioned.name).toBe("タナカ タロウ");
+
+    // The documentation pattern must remain untouched in the text
+    expect(result.text).toContain("`@[表示名](ユーザーID)`");
+  });
+
+  it("accepts Bot Framework IDs (28:xxx)", () => {
+    const result = parseMentions("@[Bot](28:abc-123)");
+    expect(result.entities).toHaveLength(1);
+    expect(result.entities[0]?.mentioned.id).toBe("28:abc-123");
+  });
+
+  it("accepts AAD object IDs (UUIDs)", () => {
+    const result = parseMentions("@[User](a1b2c3d4-e5f6-7890-abcd-ef1234567890)");
+    expect(result.entities).toHaveLength(1);
+    expect(result.entities[0]?.mentioned.id).toBe("a1b2c3d4-e5f6-7890-abcd-ef1234567890");
+  });
+
+  it("rejects non-ID strings as mention targets", () => {
+    const result = parseMentions("See @[docs](https://example.com) for details");
+    expect(result.entities).toHaveLength(0);
+    // Original text preserved
+    expect(result.text).toBe("See @[docs](https://example.com) for details");
+  });
+});
+
+describe("buildMentionEntities", () => {
+  it("builds entities from mention info", () => {
+    const mentions = [
+      { id: "28:aaa", name: "Alice" },
+      { id: "28:bbb", name: "Bob" },
+    ];
+
+    const entities = buildMentionEntities(mentions);
+
+    expect(entities).toHaveLength(2);
+    expect(entities[0]).toEqual({
+      type: "mention",
+      text: "<at>Alice</at>",
+      mentioned: {
+        id: "28:aaa",
+        name: "Alice",
+      },
+    });
+    expect(entities[1]).toEqual({
+      type: "mention",
+      text: "<at>Bob</at>",
+      mentioned: {
+        id: "28:bbb",
+        name: "Bob",
+      },
+    });
+  });
+
+  it("handles empty list", () => {
+    const entities = buildMentionEntities([]);
+    expect(entities).toHaveLength(0);
+  });
+});
+
+describe("formatMentionText", () => {
+  it("formats text with single mention", () => {
+    const text = "Hello @John!";
+    const mentions = [{ id: "28:xxx", name: "John" }];
+
+    const result = formatMentionText(text, mentions);
+
+    expect(result).toBe("Hello <at>John</at>!");
+  });
+
+  it("formats text with multiple mentions", () => {
+    const text = "Hey @Alice and @Bob";
+    const mentions = [
+      { id: "28:aaa", name: "Alice" },
+      { id: "28:bbb", name: "Bob" },
+    ];
+
+    const result = formatMentionText(text, mentions);
+
+    expect(result).toBe("Hey <at>Alice</at> and <at>Bob</at>");
+  });
+
+  it("handles case-insensitive matching", () => {
+    const text = "Hey @alice and @ALICE";
+    const mentions = [{ id: "28:aaa", name: "Alice" }];
+
+    const result = formatMentionText(text, mentions);
+
+    expect(result).toBe("Hey <at>Alice</at> and <at>Alice</at>");
+  });
+
+  it("handles text without mentions", () => {
+    const text = "Hello world";
+    const mentions = [{ id: "28:xxx", name: "John" }];
+
+    const result = formatMentionText(text, mentions);
+
+    expect(result).toBe("Hello world");
+  });
+});

--- a/extensions/msteams/src/mentions.test.ts
+++ b/extensions/msteams/src/mentions.test.ts
@@ -121,6 +121,18 @@ describe("parseMentions", () => {
     expect(result.entities[0]?.mentioned.id).toBe("28:abc-123");
   });
 
+  it("accepts Bot Framework IDs with non-hex payloads (29:xxx)", () => {
+    const result = parseMentions("@[Bot](29:08q2j2o3jc09au90eucae)");
+    expect(result.entities).toHaveLength(1);
+    expect(result.entities[0]?.mentioned.id).toBe("29:08q2j2o3jc09au90eucae");
+  });
+
+  it("accepts org-scoped IDs with extra segments (8:orgid:...)", () => {
+    const result = parseMentions("@[User](8:orgid:2d8c2d2c-1111-2222-3333-444444444444)");
+    expect(result.entities).toHaveLength(1);
+    expect(result.entities[0]?.mentioned.id).toBe("8:orgid:2d8c2d2c-1111-2222-3333-444444444444");
+  });
+
   it("accepts AAD object IDs (UUIDs)", () => {
     const result = parseMentions("@[User](a1b2c3d4-e5f6-7890-abcd-ef1234567890)");
     expect(result.entities).toHaveLength(1);

--- a/extensions/msteams/src/mentions.ts
+++ b/extensions/msteams/src/mentions.ts
@@ -25,17 +25,17 @@ export type MentionInfo = {
 /**
  * Check whether an ID looks like a valid Teams user/bot identifier.
  * Accepts:
- * - Bot Framework IDs: "28:xxx..." or "29:xxx..."
+ * - Bot Framework IDs: "28:xxx..." / "29:xxx..." / "8:orgid:..."
  * - AAD object IDs (UUIDs): "d5318c29-33ac-4e6b-bd42-57b8b793908f"
  *
- * This prevents false positives from text like `@[表示名](ユーザーID)`
- * that appears in code snippets or documentation within messages.
+ * Keep this permissive enough for real Teams IDs while still rejecting
+ * documentation placeholders like `@[表示名](ユーザーID)`.
  */
-const TEAMS_ID_PATTERN =
-  /^(?:\d+:[a-f0-9-]+|[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})$/i;
+const TEAMS_BOT_ID_PATTERN = /^\d+:[a-z0-9._=-]+(?::[a-z0-9._=-]+)*$/i;
+const AAD_OBJECT_ID_PATTERN = /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i;
 
 function isValidTeamsId(id: string): boolean {
-  return TEAMS_ID_PATTERN.test(id);
+  return TEAMS_BOT_ID_PATTERN.test(id) || AAD_OBJECT_ID_PATTERN.test(id);
 }
 
 /**

--- a/extensions/msteams/src/mentions.ts
+++ b/extensions/msteams/src/mentions.ts
@@ -1,0 +1,113 @@
+/**
+ * MS Teams mention handling utilities.
+ *
+ * Mentions in Teams require:
+ * 1. Text containing <at>Name</at> tags
+ * 2. entities array with mention metadata
+ */
+
+export type MentionEntity = {
+  type: "mention";
+  text: string;
+  mentioned: {
+    id: string;
+    name: string;
+  };
+};
+
+export type MentionInfo = {
+  /** User/bot ID (e.g., "28:xxx" or AAD object ID) */
+  id: string;
+  /** Display name */
+  name: string;
+};
+
+/**
+ * Check whether an ID looks like a valid Teams user/bot identifier.
+ * Accepts:
+ * - Bot Framework IDs: "28:xxx..." or "29:xxx..."
+ * - AAD object IDs (UUIDs): "d5318c29-33ac-4e6b-bd42-57b8b793908f"
+ *
+ * This prevents false positives from text like `@[表示名](ユーザーID)`
+ * that appears in code snippets or documentation within messages.
+ */
+const TEAMS_ID_PATTERN =
+  /^(?:\d+:[a-f0-9-]+|[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})$/i;
+
+function isValidTeamsId(id: string): boolean {
+  return TEAMS_ID_PATTERN.test(id);
+}
+
+/**
+ * Parse mentions from text in the format @[Name](id).
+ * Example: "Hello @[John Doe](28:xxx-yyy-zzz)!"
+ *
+ * Only matches where the id looks like a real Teams user/bot ID are treated
+ * as mentions. This avoids false positives from documentation or code samples
+ * embedded in the message (e.g. `@[表示名](ユーザーID)` in backticks).
+ *
+ * Returns both the formatted text with <at> tags and the entities array.
+ */
+export function parseMentions(text: string): {
+  text: string;
+  entities: MentionEntity[];
+} {
+  const mentionPattern = /@\[([^\]]+)\]\(([^)]+)\)/g;
+  const entities: MentionEntity[] = [];
+
+  // Replace @[Name](id) with <at>Name</at> only for valid Teams IDs
+  const formattedText = text.replace(mentionPattern, (match, name, id) => {
+    const trimmedId = id.trim();
+
+    // Skip matches where the id doesn't look like a real Teams identifier
+    if (!isValidTeamsId(trimmedId)) {
+      return match;
+    }
+
+    const trimmedName = name.trim();
+    const mentionTag = `<at>${trimmedName}</at>`;
+    entities.push({
+      type: "mention",
+      text: mentionTag,
+      mentioned: {
+        id: trimmedId,
+        name: trimmedName,
+      },
+    });
+    return mentionTag;
+  });
+
+  return {
+    text: formattedText,
+    entities,
+  };
+}
+
+/**
+ * Build mention entities array from a list of mentions.
+ * Use this when you already have the mention info and formatted text.
+ */
+export function buildMentionEntities(mentions: MentionInfo[]): MentionEntity[] {
+  return mentions.map((mention) => ({
+    type: "mention",
+    text: `<at>${mention.name}</at>`,
+    mentioned: {
+      id: mention.id,
+      name: mention.name,
+    },
+  }));
+}
+
+/**
+ * Format text with mentions using <at> tags.
+ * This is a convenience function when you want to manually format mentions.
+ */
+export function formatMentionText(text: string, mentions: MentionInfo[]): string {
+  let formatted = text;
+  for (const mention of mentions) {
+    // Replace @Name or @name with <at>Name</at>
+    const namePattern = new RegExp(`@${mention.name}`, "gi");
+    formatted = formatted.replace(namePattern, `<at>${mention.name}</at>`);
+  }
+  return formatted;
+}

--- a/extensions/msteams/src/mentions.ts
+++ b/extensions/msteams/src/mentions.ts
@@ -106,7 +106,8 @@ export function formatMentionText(text: string, mentions: MentionInfo[]): string
   let formatted = text;
   for (const mention of mentions) {
     // Replace @Name or @name with <at>Name</at>
-    const namePattern = new RegExp(`@${mention.name}`, "gi");
+    const escapedName = mention.name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const namePattern = new RegExp(`@${escapedName}`, "gi");
     formatted = formatted.replace(namePattern, `<at>${mention.name}</at>`);
   }
   return formatted;

--- a/extensions/msteams/src/messenger.ts
+++ b/extensions/msteams/src/messenger.ts
@@ -19,6 +19,7 @@ import {
   uploadAndShareSharePoint,
 } from "./graph-upload.js";
 import { extractFilename, extractMessageId, getMimeType, isLocalPath } from "./media-helpers.js";
+import { parseMentions } from "./mentions.js";
 import { getMSTeamsRuntime } from "./runtime.js";
 
 /**
@@ -269,7 +270,14 @@ async function buildActivity(
   const activity: Record<string, unknown> = { type: "message" };
 
   if (msg.text) {
-    activity.text = msg.text;
+    // Parse mentions from text (format: @[Name](id))
+    const { text: formattedText, entities } = parseMentions(msg.text);
+    activity.text = formattedText;
+
+    // Add mention entities if any mentions were found
+    if (entities.length > 0) {
+      activity.entities = entities;
+    }
   }
 
   if (msg.mediaUrl) {

--- a/extensions/msteams/src/messenger.ts
+++ b/extensions/msteams/src/messenger.ts
@@ -358,7 +358,8 @@ async function buildActivity(
 
         // Bot Framework doesn't support "reference" attachment type for sending
         const fileLink = `📎 [${uploaded.name}](${uploaded.shareUrl})`;
-        activity.text = msg.text ? `${msg.text}\n\n${fileLink}` : fileLink;
+        const existingText = typeof activity.text === "string" ? activity.text : undefined;
+        activity.text = existingText ? `${existingText}\n\n${fileLink}` : fileLink;
         return activity;
       }
 


### PR DESCRIPTION
# MS Teams: add user mention support

  ## What
  Adds support for @mentions in Microsoft Teams channel, enabling:
  - Parse mention entities from Teams messages
  - Validate mention IDs to prevent false positives from code snippets
  - Proper whitespace handling for mention text
  - Documentation for `User.Read.All` permission requirement

  ## Why
  Enables OpenClaw to properly handle @mentions in Teams conversations, improving interaction quality and allowing dynamic user search.

  ## Changes
  - **New**: `extensions/msteams/src/mentions.ts` - Core mention parsing and validation logic
  - **New**: `extensions/msteams/src/mentions.test.ts` - Comprehensive test suite (17 tests)
  - **Modified**: `extensions/msteams/src/messenger.ts` - Integration with message handling
  - **Docs**: `docs/channels/msteams.md` - Added `User.Read.All` permission documentation

  ## Testing
  - ✅ 17 unit tests passing
  - ✅ Build successful
  - ✅ Lint/format checks passed
  - ✅ Integration tested with MS Teams messenger

  ## AI-Assisted Development
  - **Tool**: Claude (Sonnet)
  - **Testing**: Fully tested with comprehensive unit test coverage
  - **Verification**: All code reviewed and understood

  ## Notes
  - User mentions work out of the box for conversation participants
  - `User.Read.All` permission only needed for searching users **not** in the current conversation
  - Fake placeholders used in tests to protect privacy

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds outbound Microsoft Teams user-mention support by introducing a mention parser (`extensions/msteams/src/mentions.ts`) that converts `@[Name](id)` markup into Teams `<at>Name</at>` tags plus `entities` payloads, and wiring it into message sending (`extensions/msteams/src/messenger.ts`). Includes a new vitest suite covering mention parsing/validation cases and updates MS Teams docs to note the `User.Read.All` permission requirement for mentioning users outside the current conversation.

<h3>Confidence Score: 4/5</h3>

- This PR is close to mergeable but has a concrete edge case that can cause runtime failures in mention formatting.
- The integration point in `messenger.ts` is straightforward (only adds `entities` when present) and the new parsing logic is covered by tests, but `formatMentionText` constructs regexes from unescaped user display names, which can throw or replace unintended text for names containing regex metacharacters.
- extensions/msteams/src/mentions.ts

<sub>Last reviewed commit: b781104</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->