### PR TITLE
fix(media): recognize MP3 and M4A as voice-compatible audio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 - Exec/Allowlist: allow multiline heredoc bodies (`<<`, `<<-`) while keeping multiline non-heredoc shell commands blocked, so exec approval parsing permits heredoc input safely without allowing general newline command chaining. (#13811) Thanks @mcaxtr.
 - Docs/Mermaid: remove hardcoded Mermaid init theme blocks from four docs diagrams so dark mode inherits readable theme defaults. (#15157) Thanks @heytulsiprasad.
 - Outbound/Threading: pass `replyTo` and `threadId` from `message send` tool actions through the core outbound send path to channel adapters, preserving thread/reply routing. (#14948) Thanks @mcaxtr.
+- Telegram/Matrix: treat MP3 and M4A (including `audio/mp4`) as voice-compatible for `asVoice` routing, and keep WAV/AAC falling back to regular audio sends. (#15438) Thanks @azade-c.
 - Sessions/Agents: pass `agentId` when resolving existing transcript paths in reply runs so non-default agents and heartbeat/chat handlers no longer fail with `Session file path must be within sessions directory`. (#15141) Thanks @Goldenmonstew.
 - Status/Sessions: stop clamping derived `totalTokens` to context-window size, keep prompt-token snapshots wired through session accounting, and surface context usage as unknown when fresh snapshot data is missing to avoid false 100% reports. (#15114) Thanks @echoVic.
 

--- a/src/media/audio.test.ts
+++ b/src/media/audio.test.ts
@@ -8,6 +8,8 @@ describe("isVoiceCompatibleAudio", () => {
     { contentType: "audio/ogg; codecs=opus", fileName: null },
     { contentType: "audio/mpeg", fileName: null },
     { contentType: "audio/mp3", fileName: null },
+    { contentType: "audio/mp4", fileName: null },
+    { contentType: "audio/mp4; codecs=mp4a.40.2", fileName: null },
     { contentType: "audio/x-m4a", fileName: null },
     { contentType: "audio/m4a", fileName: null },
   ])("returns true for MIME type $contentType", (opts) => {
@@ -21,7 +23,6 @@ describe("isVoiceCompatibleAudio", () => {
   it.each([
     { contentType: "audio/wav", fileName: null },
     { contentType: "audio/flac", fileName: null },
-    { contentType: "audio/mp4", fileName: null },
     { contentType: "audio/aac", fileName: null },
     { contentType: "video/mp4", fileName: null },
   ])("returns false for unsupported MIME $contentType", (opts) => {

--- a/src/media/audio.test.ts
+++ b/src/media/audio.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { isVoiceCompatibleAudio } from "./audio.js";
+
+describe("isVoiceCompatibleAudio", () => {
+  it.each([
+    { contentType: "audio/ogg", fileName: null },
+    { contentType: "audio/opus", fileName: null },
+    { contentType: "audio/ogg; codecs=opus", fileName: null },
+    { contentType: "audio/mpeg", fileName: null },
+    { contentType: "audio/mp3", fileName: null },
+    { contentType: "audio/mp4", fileName: null },
+    { contentType: "audio/x-m4a", fileName: null },
+    { contentType: "audio/m4a", fileName: null },
+    { contentType: "audio/aac", fileName: null },
+  ])("returns true for MIME type $contentType", (opts) => {
+    expect(isVoiceCompatibleAudio(opts)).toBe(true);
+  });
+
+  it.each([".ogg", ".oga", ".opus", ".mp3", ".m4a"])("returns true for extension %s", (ext) => {
+    expect(isVoiceCompatibleAudio({ fileName: `voice${ext}` })).toBe(true);
+  });
+
+  it.each([
+    { contentType: "audio/wav", fileName: null },
+    { contentType: "audio/flac", fileName: null },
+    { contentType: "video/mp4", fileName: null },
+  ])("returns false for unsupported MIME $contentType", (opts) => {
+    expect(isVoiceCompatibleAudio(opts)).toBe(false);
+  });
+
+  it.each([".wav", ".flac", ".webm"])("returns false for extension %s", (ext) => {
+    expect(isVoiceCompatibleAudio({ fileName: `audio${ext}` })).toBe(false);
+  });
+
+  it("returns false when no contentType and no fileName", () => {
+    expect(isVoiceCompatibleAudio({})).toBe(false);
+  });
+
+  it("prefers MIME type over extension", () => {
+    expect(isVoiceCompatibleAudio({ contentType: "audio/mpeg", fileName: "file.wav" })).toBe(true);
+  });
+});

--- a/src/media/audio.test.ts
+++ b/src/media/audio.test.ts
@@ -8,10 +8,8 @@ describe("isVoiceCompatibleAudio", () => {
     { contentType: "audio/ogg; codecs=opus", fileName: null },
     { contentType: "audio/mpeg", fileName: null },
     { contentType: "audio/mp3", fileName: null },
-    { contentType: "audio/mp4", fileName: null },
     { contentType: "audio/x-m4a", fileName: null },
     { contentType: "audio/m4a", fileName: null },
-    { contentType: "audio/aac", fileName: null },
   ])("returns true for MIME type $contentType", (opts) => {
     expect(isVoiceCompatibleAudio(opts)).toBe(true);
   });
@@ -23,6 +21,8 @@ describe("isVoiceCompatibleAudio", () => {
   it.each([
     { contentType: "audio/wav", fileName: null },
     { contentType: "audio/flac", fileName: null },
+    { contentType: "audio/mp4", fileName: null },
+    { contentType: "audio/aac", fileName: null },
     { contentType: "video/mp4", fileName: null },
   ])("returns false for unsupported MIME $contentType", (opts) => {
     expect(isVoiceCompatibleAudio(opts)).toBe(false);

--- a/src/media/audio.ts
+++ b/src/media/audio.ts
@@ -12,6 +12,7 @@ const VOICE_MIME_TYPES = new Set([
   "audio/opus",
   "audio/mpeg",
   "audio/mp3",
+  "audio/mp4",
   "audio/x-m4a",
   "audio/m4a",
 ]);

--- a/src/media/audio.ts
+++ b/src/media/audio.ts
@@ -12,10 +12,8 @@ const VOICE_MIME_TYPES = new Set([
   "audio/opus",
   "audio/mpeg",
   "audio/mp3",
-  "audio/mp4",
   "audio/x-m4a",
   "audio/m4a",
-  "audio/aac",
 ]);
 
 export function isVoiceCompatibleAudio(opts: {

--- a/src/media/audio.ts
+++ b/src/media/audio.ts
@@ -1,14 +1,33 @@
 import { getFileExtension } from "./mime.js";
 
-const VOICE_AUDIO_EXTENSIONS = new Set([".oga", ".ogg", ".opus"]);
+const VOICE_AUDIO_EXTENSIONS = new Set([".oga", ".ogg", ".opus", ".mp3", ".m4a"]);
+
+/**
+ * MIME types compatible with voice messages.
+ * Telegram sendVoice supports OGG/Opus, MP3, and M4A.
+ * https://core.telegram.org/bots/api#sendvoice
+ */
+const VOICE_MIME_TYPES = new Set([
+  "audio/ogg",
+  "audio/opus",
+  "audio/mpeg",
+  "audio/mp3",
+  "audio/mp4",
+  "audio/x-m4a",
+  "audio/m4a",
+  "audio/aac",
+]);
 
 export function isVoiceCompatibleAudio(opts: {
   contentType?: string | null;
   fileName?: string | null;
 }): boolean {
-  const mime = opts.contentType?.toLowerCase();
-  if (mime && (mime.includes("ogg") || mime.includes("opus"))) {
-    return true;
+  const mime = opts.contentType?.toLowerCase().trim();
+  if (mime) {
+    const baseMime = mime.split(";")[0].trim();
+    if (VOICE_MIME_TYPES.has(baseMime)) {
+      return true;
+    }
   }
   const fileName = opts.fileName?.trim();
   if (!fileName) {

--- a/src/telegram/send.returns-undefined-empty-input.test.ts
+++ b/src/telegram/send.returns-undefined-empty-input.test.ts
@@ -438,6 +438,41 @@ describe("sendMessageTelegram", () => {
 
     loadWebMedia.mockResolvedValueOnce({
       buffer: Buffer.from("audio"),
+      contentType: "audio/wav",
+      fileName: "clip.wav",
+    });
+
+    await sendMessageTelegram(chatId, "caption", {
+      token: "tok",
+      api,
+      mediaUrl: "https://example.com/clip.wav",
+      asVoice: true,
+    });
+
+    expect(sendAudio).toHaveBeenCalledWith(chatId, expect.anything(), {
+      caption: "caption",
+      parse_mode: "HTML",
+    });
+    expect(sendVoice).not.toHaveBeenCalled();
+  });
+
+  it("sends MP3 as voice when asVoice is true", async () => {
+    const chatId = "123";
+    const sendAudio = vi.fn().mockResolvedValue({
+      message_id: 16,
+      chat: { id: chatId },
+    });
+    const sendVoice = vi.fn().mockResolvedValue({
+      message_id: 17,
+      chat: { id: chatId },
+    });
+    const api = { sendAudio, sendVoice } as unknown as {
+      sendAudio: typeof sendAudio;
+      sendVoice: typeof sendVoice;
+    };
+
+    loadWebMedia.mockResolvedValueOnce({
+      buffer: Buffer.from("audio"),
       contentType: "audio/mpeg",
       fileName: "clip.mp3",
     });
@@ -449,11 +484,11 @@ describe("sendMessageTelegram", () => {
       asVoice: true,
     });
 
-    expect(sendAudio).toHaveBeenCalledWith(chatId, expect.anything(), {
+    expect(sendVoice).toHaveBeenCalledWith(chatId, expect.anything(), {
       caption: "caption",
       parse_mode: "HTML",
     });
-    expect(sendVoice).not.toHaveBeenCalled();
+    expect(sendAudio).not.toHaveBeenCalled();
   });
 
   it("includes message_thread_id for forum topic messages", async () => {

--- a/src/telegram/voice.test.ts
+++ b/src/telegram/voice.test.ts
@@ -18,13 +18,13 @@ describe("resolveTelegramVoiceSend", () => {
     const logFallback = vi.fn();
     const result = resolveTelegramVoiceSend({
       wantsVoice: true,
-      contentType: "audio/mpeg",
-      fileName: "track.mp3",
+      contentType: "audio/wav",
+      fileName: "track.wav",
       logFallback,
     });
     expect(result.useVoice).toBe(false);
     expect(logFallback).toHaveBeenCalledWith(
-      "Telegram voice requested but media is audio/mpeg (track.mp3); sending as audio file instead.",
+      "Telegram voice requested but media is audio/wav (track.wav); sending as audio file instead.",
     );
   });
 
@@ -34,6 +34,21 @@ describe("resolveTelegramVoiceSend", () => {
       wantsVoice: true,
       contentType: "audio/ogg",
       fileName: "voice.ogg",
+      logFallback,
+    });
+    expect(result.useVoice).toBe(true);
+    expect(logFallback).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { contentType: "audio/mpeg", fileName: "track.mp3" },
+    { contentType: "audio/mp4", fileName: "track.m4a" },
+  ])("keeps voice for compatible MIME $contentType", ({ contentType, fileName }) => {
+    const logFallback = vi.fn();
+    const result = resolveTelegramVoiceSend({
+      wantsVoice: true,
+      contentType,
+      fileName,
       logFallback,
     });
     expect(result.useVoice).toBe(true);


### PR DESCRIPTION
## Problem

`isVoiceCompatibleAudio` only recognizes OGG/Opus formats, but Telegram's `sendVoice` also supports MP3 and M4A ([docs](https://core.telegram.org/bots/api#sendvoice)). Audio files in these formats are sent as file attachments instead of voice bubbles.

## Changes

- Add `.mp3` and `.m4a` to recognized voice extensions
- Replace substring matching (`includes('ogg')`) with an explicit MIME type set
- Handle MIME parameters (e.g. `audio/ogg; codecs=opus`)
- Add comprehensive test coverage (`audio.test.ts`, 22 cases)

## Testing

```
✓ src/media/audio.test.ts (22 tests) 10ms
```

Supersedes #8687.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates `isVoiceCompatibleAudio` to recognize MP3 and M4A in addition to OGG/Opus, switching from substring matching to explicit allowlists for extensions and MIME types and normalizing MIME parameters (e.g. `audio/ogg; codecs=opus`). Adds a dedicated `audio.test.ts` with table-driven coverage.

The change fits into the media pipeline by improving how audio is classified before choosing Telegram’s `sendVoice` vs generic file upload behavior, which affects how recipients see and play back audio (voice bubble vs attachment).

<h3>Confidence Score: 3/5</h3>

- Mostly safe, but current MIME allowlist likely misclassifies some audio as voice messages.
- Core refactor (explicit MIME set + parameter stripping) is straightforward and well-tested, but the chosen MIME allowlist includes `audio/mp4` and `audio/aac`, which are broader than the stated Telegram `sendVoice` formats and can cause incorrect behavior in production if those types occur.
- src/media/audio.ts, src/media/audio.test.ts

<sub>Last reviewed commit: a3af7d7</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->