### PR TITLE
fix: use Homebrew for signal-cli install on non-x64 architectures (bug #15372)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 - Outbound/Threading: pass `replyTo` and `threadId` from `message send` tool actions through the core outbound send path to channel adapters, preserving thread/reply routing. (#14948) Thanks @mcaxtr.
 - Sessions/Agents: pass `agentId` when resolving existing transcript paths in reply runs so non-default agents and heartbeat/chat handlers no longer fail with `Session file path must be within sessions directory`. (#15141) Thanks @Goldenmonstew.
 - Sessions/Agents: pass `agentId` through status and usage transcript-resolution paths (auto-reply, gateway usage APIs, and session cost/log loaders) so non-default agents can resolve absolute session files without path-validation failures. (#15103) Thanks @jalehman.
+- Signal/Install: auto-install `signal-cli` via Homebrew on non-x64 Linux architectures, avoiding x86_64 native binary `Exec format error` failures on arm64/arm hosts. (#15443) Thanks @jogvan-k.
 
 ## 2026.2.12
 

--- a/src/commands/signal-install.test.ts
+++ b/src/commands/signal-install.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import type { ReleaseAsset } from "./signal-install.js";
+import { looksLikeArchive, pickAsset } from "./signal-install.js";
+
+// Realistic asset list modelled after an actual signal-cli GitHub release.
+const SAMPLE_ASSETS: ReleaseAsset[] = [
+  {
+    name: "signal-cli-0.13.14-Linux-native.tar.gz",
+    browser_download_url: "https://example.com/linux-native.tar.gz",
+  },
+  {
+    name: "signal-cli-0.13.14-Linux-native.tar.gz.asc",
+    browser_download_url: "https://example.com/linux-native.tar.gz.asc",
+  },
+  {
+    name: "signal-cli-0.13.14-macOS-native.tar.gz",
+    browser_download_url: "https://example.com/macos-native.tar.gz",
+  },
+  {
+    name: "signal-cli-0.13.14-macOS-native.tar.gz.asc",
+    browser_download_url: "https://example.com/macos-native.tar.gz.asc",
+  },
+  {
+    name: "signal-cli-0.13.14-Windows-native.zip",
+    browser_download_url: "https://example.com/windows-native.zip",
+  },
+  {
+    name: "signal-cli-0.13.14-Windows-native.zip.asc",
+    browser_download_url: "https://example.com/windows-native.zip.asc",
+  },
+  { name: "signal-cli-0.13.14.tar.gz", browser_download_url: "https://example.com/jvm.tar.gz" },
+  {
+    name: "signal-cli-0.13.14.tar.gz.asc",
+    browser_download_url: "https://example.com/jvm.tar.gz.asc",
+  },
+];
+
+describe("looksLikeArchive", () => {
+  it("recognises .tar.gz", () => {
+    expect(looksLikeArchive("foo.tar.gz")).toBe(true);
+  });
+
+  it("recognises .tgz", () => {
+    expect(looksLikeArchive("foo.tgz")).toBe(true);
+  });
+
+  it("recognises .zip", () => {
+    expect(looksLikeArchive("foo.zip")).toBe(true);
+  });
+
+  it("rejects signature files", () => {
+    expect(looksLikeArchive("foo.tar.gz.asc")).toBe(false);
+  });
+
+  it("rejects unrelated files", () => {
+    expect(looksLikeArchive("README.md")).toBe(false);
+  });
+});
+
+describe("pickAsset", () => {
+  describe("linux", () => {
+    it("selects the Linux-native asset on x64", () => {
+      const result = pickAsset(SAMPLE_ASSETS, "linux", "x64");
+      expect(result).toBeDefined();
+      expect(result!.name).toContain("Linux-native");
+      expect(result!.name).toMatch(/\.tar\.gz$/);
+    });
+
+    it("returns undefined on arm64 (triggers brew fallback)", () => {
+      const result = pickAsset(SAMPLE_ASSETS, "linux", "arm64");
+      expect(result).toBeUndefined();
+    });
+
+    it("returns undefined on arm (32-bit)", () => {
+      const result = pickAsset(SAMPLE_ASSETS, "linux", "arm");
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("darwin", () => {
+    it("selects the macOS-native asset", () => {
+      const result = pickAsset(SAMPLE_ASSETS, "darwin", "arm64");
+      expect(result).toBeDefined();
+      expect(result!.name).toContain("macOS-native");
+    });
+
+    it("selects the macOS-native asset on x64", () => {
+      const result = pickAsset(SAMPLE_ASSETS, "darwin", "x64");
+      expect(result).toBeDefined();
+      expect(result!.name).toContain("macOS-native");
+    });
+  });
+
+  describe("win32", () => {
+    it("selects the Windows-native asset", () => {
+      const result = pickAsset(SAMPLE_ASSETS, "win32", "x64");
+      expect(result).toBeDefined();
+      expect(result!.name).toContain("Windows-native");
+      expect(result!.name).toMatch(/\.zip$/);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("returns undefined for an empty asset list", () => {
+      expect(pickAsset([], "linux", "x64")).toBeUndefined();
+    });
+
+    it("skips assets with missing name or url", () => {
+      const partial: ReleaseAsset[] = [
+        { name: "signal-cli.tar.gz" },
+        { browser_download_url: "https://example.com/file.tar.gz" },
+      ];
+      expect(pickAsset(partial, "linux", "x64")).toBeUndefined();
+    });
+
+    it("falls back to first archive for unknown platform", () => {
+      const result = pickAsset(SAMPLE_ASSETS, "freebsd" as NodeJS.Platform, "x64");
+      expect(result).toBeDefined();
+      expect(result!.name).toMatch(/\.tar\.gz$/);
+    });
+
+    it("never selects .asc signature files", () => {
+      const result = pickAsset(SAMPLE_ASSETS, "linux", "x64");
+      expect(result).toBeDefined();
+      expect(result!.name).not.toMatch(/\.asc$/);
+    });
+  });
+});

--- a/src/commands/signal-install.ts
+++ b/src/commands/signal-install.ts
@@ -9,12 +9,12 @@ import { resolveBrewExecutable } from "../infra/brew.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { CONFIG_DIR } from "../utils.js";
 
-type ReleaseAsset = {
+export type ReleaseAsset = {
   name?: string;
   browser_download_url?: string;
 };
 
-type NamedAsset = {
+export type NamedAsset = {
   name: string;
   browser_download_url: string;
 };
@@ -31,7 +31,8 @@ export type SignalInstallResult = {
   error?: string;
 };
 
-function looksLikeArchive(name: string): boolean {
+/** @internal Exported for testing. */
+export function looksLikeArchive(name: string): boolean {
   return name.endsWith(".tar.gz") || name.endsWith(".tgz") || name.endsWith(".zip");
 }
 
@@ -43,7 +44,8 @@ function looksLikeArchive(name: string): boolean {
  * returns `undefined` so the caller can fall back to a different install
  * strategy (e.g. Homebrew).
  */
-function pickAsset(
+/** @internal Exported for testing. */
+export function pickAsset(
   assets: ReleaseAsset[],
   platform: NodeJS.Platform,
   arch: string,

--- a/src/commands/signal-install.ts
+++ b/src/commands/signal-install.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { pipeline } from "node:stream/promises";
 import type { RuntimeEnv } from "../runtime.js";
+import { resolveBrewExecutable } from "../infra/brew.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { CONFIG_DIR } from "../utils.js";
 
@@ -34,35 +35,49 @@ function looksLikeArchive(name: string): boolean {
   return name.endsWith(".tar.gz") || name.endsWith(".tgz") || name.endsWith(".zip");
 }
 
-function pickAsset(assets: ReleaseAsset[], platform: NodeJS.Platform) {
+/**
+ * Pick a native release asset from the official GitHub releases.
+ *
+ * The official signal-cli releases only publish native (GraalVM) binaries for
+ * x86-64 Linux.  On architectures where no native asset is available this
+ * returns `undefined` so the caller can fall back to a different install
+ * strategy (e.g. Homebrew).
+ */
+function pickAsset(
+  assets: ReleaseAsset[],
+  platform: NodeJS.Platform,
+  arch: string,
+): NamedAsset | undefined {
   const withName = assets.filter((asset): asset is NamedAsset =>
     Boolean(asset.name && asset.browser_download_url),
   );
+
+  // Archives only, excluding signature files (.asc)
+  const archives = withName.filter((a) => looksLikeArchive(a.name.toLowerCase()));
+
   const byName = (pattern: RegExp) =>
-    withName.find((asset) => pattern.test(asset.name.toLowerCase()));
+    archives.find((asset) => pattern.test(asset.name.toLowerCase()));
 
   if (platform === "linux") {
-    return (
-      byName(/linux-native/) ||
-      byName(/linux/) ||
-      withName.find((asset) => looksLikeArchive(asset.name.toLowerCase()))
-    );
+    // The official "Linux-native" asset is an x86-64 GraalVM binary.
+    // On non-x64 architectures it will fail with "Exec format error",
+    // so only select it when the host architecture matches.
+    if (arch === "x64") {
+      return byName(/linux-native/) || byName(/linux/) || archives[0];
+    }
+    // No native release for this arch — caller should fall back.
+    return undefined;
   }
 
   if (platform === "darwin") {
-    return (
-      byName(/macos|osx|darwin/) ||
-      withName.find((asset) => looksLikeArchive(asset.name.toLowerCase()))
-    );
+    return byName(/macos|osx|darwin/) || archives[0];
   }
 
   if (platform === "win32") {
-    return (
-      byName(/windows|win/) || withName.find((asset) => looksLikeArchive(asset.name.toLowerCase()))
-    );
+    return byName(/windows|win/) || archives[0];
   }
 
-  return withName.find((asset) => looksLikeArchive(asset.name.toLowerCase()));
+  return archives[0];
 }
 
 async function downloadToFile(url: string, dest: string, maxRedirects = 5): Promise<void> {
@@ -110,14 +125,84 @@ async function findSignalCliBinary(root: string): Promise<string | null> {
   return candidates[0] ?? null;
 }
 
-export async function installSignalCli(runtime: RuntimeEnv): Promise<SignalInstallResult> {
-  if (process.platform === "win32") {
+// ---------------------------------------------------------------------------
+// Brew-based install (used on architectures without an official native build)
+// ---------------------------------------------------------------------------
+
+async function resolveBrewSignalCliPath(brewExe: string): Promise<string | null> {
+  try {
+    const result = await runCommandWithTimeout([brewExe, "--prefix", "signal-cli"], {
+      timeoutMs: 10_000,
+    });
+    if (result.code === 0 && result.stdout.trim()) {
+      const prefix = result.stdout.trim();
+      // Homebrew installs the wrapper script at <prefix>/bin/signal-cli
+      const candidate = path.join(prefix, "bin", "signal-cli");
+      try {
+        await fs.access(candidate);
+        return candidate;
+      } catch {
+        // Fall back to searching the prefix
+        return findSignalCliBinary(prefix);
+      }
+    }
+  } catch {
+    // ignore
+  }
+  return null;
+}
+
+async function installSignalCliViaBrew(runtime: RuntimeEnv): Promise<SignalInstallResult> {
+  const brewExe = resolveBrewExecutable();
+  if (!brewExe) {
     return {
       ok: false,
-      error: "Signal CLI auto-install is not supported on Windows yet.",
+      error:
+        `No native signal-cli build is available for ${process.arch}. ` +
+        "Install Homebrew (https://brew.sh) and try again, or install signal-cli manually.",
     };
   }
 
+  runtime.log(`Installing signal-cli via Homebrew (${brewExe})…`);
+  const result = await runCommandWithTimeout([brewExe, "install", "signal-cli"], {
+    timeoutMs: 15 * 60_000, // brew builds from source; can take a while
+  });
+
+  if (result.code !== 0) {
+    return {
+      ok: false,
+      error: `brew install signal-cli failed (exit ${result.code}): ${result.stderr.trim().slice(0, 200)}`,
+    };
+  }
+
+  const cliPath = await resolveBrewSignalCliPath(brewExe);
+  if (!cliPath) {
+    return {
+      ok: false,
+      error: "brew install succeeded but signal-cli binary was not found.",
+    };
+  }
+
+  // Extract version from the installed binary.
+  let version: string | undefined;
+  try {
+    const vResult = await runCommandWithTimeout([cliPath, "--version"], {
+      timeoutMs: 10_000,
+    });
+    // Output is typically "signal-cli 0.13.24"
+    version = vResult.stdout.trim().replace(/^signal-cli\s+/, "") || undefined;
+  } catch {
+    // non-critical; leave version undefined
+  }
+
+  return { ok: true, cliPath, version };
+}
+
+// ---------------------------------------------------------------------------
+// Direct download install (used when an official native asset is available)
+// ---------------------------------------------------------------------------
+
+async function installSignalCliFromRelease(runtime: RuntimeEnv): Promise<SignalInstallResult> {
   const apiUrl = "https://api.github.com/repos/AsamK/signal-cli/releases/latest";
   const response = await fetch(apiUrl, {
     headers: {
@@ -136,11 +221,9 @@ export async function installSignalCli(runtime: RuntimeEnv): Promise<SignalInsta
   const payload = (await response.json()) as ReleaseResponse;
   const version = payload.tag_name?.replace(/^v/, "") ?? "unknown";
   const assets = payload.assets ?? [];
-  const asset = pickAsset(assets, process.platform);
-  const assetName = asset?.name ?? "";
-  const assetUrl = asset?.browser_download_url ?? "";
+  const asset = pickAsset(assets, process.platform, process.arch);
 
-  if (!assetName || !assetUrl) {
+  if (!asset) {
     return {
       ok: false,
       error: "No compatible release asset found for this platform.",
@@ -148,35 +231,59 @@ export async function installSignalCli(runtime: RuntimeEnv): Promise<SignalInsta
   }
 
   const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-signal-"));
-  const archivePath = path.join(tmpDir, assetName);
+  const archivePath = path.join(tmpDir, asset.name);
 
-  runtime.log(`Downloading signal-cli ${version} (${assetName})…`);
-  await downloadToFile(assetUrl, archivePath);
+  runtime.log(`Downloading signal-cli ${version} (${asset.name})…`);
+  await downloadToFile(asset.browser_download_url, archivePath);
 
   const installRoot = path.join(CONFIG_DIR, "tools", "signal-cli", version);
   await fs.mkdir(installRoot, { recursive: true });
 
-  if (assetName.endsWith(".zip")) {
+  if (asset.name.endsWith(".zip")) {
     await runCommandWithTimeout(["unzip", "-q", archivePath, "-d", installRoot], {
       timeoutMs: 60_000,
     });
-  } else if (assetName.endsWith(".tar.gz") || assetName.endsWith(".tgz")) {
+  } else if (asset.name.endsWith(".tar.gz") || asset.name.endsWith(".tgz")) {
     await runCommandWithTimeout(["tar", "-xzf", archivePath, "-C", installRoot], {
       timeoutMs: 60_000,
     });
   } else {
-    return { ok: false, error: `Unsupported archive type: ${assetName}` };
+    return { ok: false, error: `Unsupported archive type: ${asset.name}` };
   }
 
   const cliPath = await findSignalCliBinary(installRoot);
   if (!cliPath) {
     return {
       ok: false,
-      error: `signal-cli binary not found after extracting ${assetName}`,
+      error: `signal-cli binary not found after extracting ${asset.name}`,
     };
   }
 
   await fs.chmod(cliPath, 0o755).catch(() => {});
 
   return { ok: true, cliPath, version };
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+export async function installSignalCli(runtime: RuntimeEnv): Promise<SignalInstallResult> {
+  if (process.platform === "win32") {
+    return {
+      ok: false,
+      error: "Signal CLI auto-install is not supported on Windows yet.",
+    };
+  }
+
+  // The official signal-cli GitHub releases only ship a native binary for
+  // x86-64 Linux.  On other architectures (arm64, armv7, etc.) we delegate
+  // to Homebrew which builds from source and bundles the JRE automatically.
+  const hasNativeRelease = process.platform !== "linux" || process.arch === "x64";
+
+  if (hasNativeRelease) {
+    return installSignalCliFromRelease(runtime);
+  }
+
+  return installSignalCliViaBrew(runtime);
 }


### PR DESCRIPTION
# Summary
AI-assisted The signal-cli auto-installer downloads x86-64 GraalVM native binaries regardless of host architecture. On non-x64 systems (e.g., Raspberry Pi aarch64) this causes Exec format error when the binary is executed.
This PR makes pickAsset architecture-aware and adds a Homebrew fallback for non-x64 Linux, since official signal-cli releases only publish native binaries for x86-64.
Closes #15372

## Repro Steps
1. Run OpenClaw on an arm64 Linux system (e.g., Raspberry Pi 4/5)
2. Trigger signal-cli onboarding / auto-install
3. The installer downloads signal-cli-*-Linux-native.tar.gz (x86-64 binary)
4. Running the binary fails with: Exec format error

## Root Cause
pickAsset() selected release assets based on OS only, with no architecture check. The Linux-native asset is an x86-64 GraalVM binary, but it was selected on all Linux architectures.
Behavior Changes
- x64 Linux / macOS / Windows: No change. Downloads the native binary from GitHub releases as before.
- Non-x64 Linux (arm64, armv7, etc.): pickAsset now returns undefined, and the installer falls back to brew install signal-cli. Homebrew builds from source and bundles the JRE automatically.
- Non-x64 Linux without Homebrew: Returns a clear error message directing the user to install Homebrew or install signal-cli manually.
- 15-minute timeout for the brew install path (building from source takes time).
- Version is extracted from signal-cli --version after brew install.
Codebase and GitHub Search
- Searched src/commands/signal-install.ts — the only hardcoded binary installer for signal-cli.
- Verified src/infra/brew.ts exports resolveBrewExecutable() which handles macOS + Linuxbrew path detection — reused here.
- Confirmed other tool installers (brew/go/node/uv-based skills) delegate to package managers that handle architecture natively — not affected.
Tests
Fully tested. 15 new unit tests in src/commands/signal-install.test.ts (all passing):
- looksLikeArchive: recognises .tar.gz, .tgz, .zip; rejects .asc and unrelated files
- pickAsset linux: selects native asset on x64; returns undefined on arm64 and arm (triggers brew fallback)
- pickAsset darwin: selects macOS asset on both arm64 and x64
- pickAsset win32: selects Windows asset
- pickAsset edge cases: empty assets, missing fields, unknown platform, .asc exclusion
pnpm vitest run src/commands/signal-install.test.ts
 ✓ src/commands/signal-install.test.ts (15 tests) 44ms
 Test Files  1 passed (1)
      Tests  15 passed (15)
      
## Manual Testing
Tested on a Raspberry Pi 4 (aarch64 Linux) — When using `openclaw config` to set up Signal, brew install signal-cli completes successfully and the installed binary works.


## Sign-Off
- Models used: claude-opus-4.6 (via OpenCode)
- AI-assisted: Yes — code authored by AI agent, iteratively tested and directed by human on real hardware
- Degree of testing: Fully tested (15 unit tests + manual verification on Raspberry Pi aarch64)
- Submitter effort: Collaborative — user reported the bug, tested each iteration on Pi, chose the Homebrew approach over alternatives (JVM archive, community binaries)
- Agent notes: pickAsset and looksLikeArchive were exported (@internal annotated) to enable direct unit testing without mocking I/O.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates signal-cli auto-install to avoid selecting the x86_64 Linux-native asset on non-x64 Linux and instead fall back to installing via Homebrew. It also refactors asset selection into exported helpers (`looksLikeArchive`, `pickAsset`) and adds unit tests covering platform/arch-aware asset picking and skipping `.asc` signatures.

The main flow now chooses between “download from GitHub release assets” and “brew install signal-cli” based on `process.platform`/`process.arch`, then returns a `SignalInstallResult` with the installed binary path and version when available.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a couple of real failure modes in the new Homebrew fallback path.
- Core refactor and tests look consistent, but the brew fallback can incorrectly claim Homebrew is missing (no PATH lookup) and can throw on spawn errors instead of returning a structured failure, which will break the intended installer UX on some systems.
- src/commands/signal-install.ts

<sub>Last reviewed commit: 4ee37d1</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->