### PR TITLE
fix(slack): download all files in multi-image messages

### DIFF
--- a/extensions/feishu/package.json
+++ b/extensions/feishu/package.json
@@ -8,6 +8,9 @@
     "@sinclair/typebox": "0.34.48",
     "zod": "^4.3.6"
   },
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -312,6 +312,10 @@ importers:
       zod:
         specifier: ^4.3.6
         version: 4.3.6
+    devDependencies:
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
 
   extensions/google-antigravity-auth:
     devDependencies:
@@ -6845,7 +6849,7 @@ snapshots:
 
   '@larksuiteoapi/node-sdk@1.59.0':
     dependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       lodash.identity: 3.0.0
       lodash.merge: 4.6.2
       lodash.pickby: 4.6.0
@@ -6861,7 +6865,7 @@ snapshots:
     dependencies:
       '@types/node': 24.10.13
     optionalDependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
     transitivePeerDependencies:
       - debug
 
@@ -7064,7 +7068,7 @@ snapshots:
       '@azure/core-auth': 1.10.1
       '@azure/msal-node': 3.8.7
       '@microsoft/agents-activity': 1.2.3
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       jsonwebtoken: 9.0.3
       jwks-rsa: 3.2.2
       object-path: 0.11.8
@@ -8011,7 +8015,7 @@ snapshots:
       '@slack/types': 2.20.0
       '@slack/web-api': 7.14.0
       '@types/express': 5.0.6
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       express: 5.2.1
       path-to-regexp: 8.3.0
       raw-body: 3.0.2
@@ -8057,7 +8061,7 @@ snapshots:
       '@slack/types': 2.20.0
       '@types/node': 25.2.3
       '@types/retry': 0.12.0
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       eventemitter3: 5.0.4
       form-data: 2.5.4
       is-electron: 2.2.2
@@ -8951,14 +8955,6 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  axios@1.13.5:
-    dependencies:
-      follow-redirects: 1.15.11
-      form-data: 2.5.4
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
   axios@1.13.5(debug@4.4.3):
     dependencies:
       follow-redirects: 1.15.11(debug@4.4.3)
@@ -9541,8 +9537,6 @@ snapshots:
       array-back: 3.1.0
 
   flatbuffers@24.12.23: {}
-
-  follow-redirects@1.15.11: {}
 
   follow-redirects@1.15.11(debug@4.4.3):
     optionalDependencies:

--- a/scripts/write-plugin-sdk-entry-dts.ts
+++ b/scripts/write-plugin-sdk-entry-dts.ts
@@ -1,9 +1,15 @@
 import fs from "node:fs";
 import path from "node:path";
 
-// `tsc` emits the entry d.ts at `dist/plugin-sdk/plugin-sdk/index.d.ts` because
-// the source lives at `src/plugin-sdk/index.ts` and `rootDir` is `src/`.
-// Keep a stable `dist/plugin-sdk/index.d.ts` alongside `index.js` for TS users.
-const out = path.join(process.cwd(), "dist/plugin-sdk/index.d.ts");
-fs.mkdirSync(path.dirname(out), { recursive: true });
-fs.writeFileSync(out, 'export * from "./plugin-sdk/index";\n', "utf8");
+// `tsc` emits declarations under `dist/plugin-sdk/plugin-sdk/*` because the source lives
+// at `src/plugin-sdk/*` and `rootDir` is `src/`.
+//
+// Our package export map points subpath `types` at `dist/plugin-sdk/<entry>.d.ts`, so we
+// generate stable entry d.ts files that re-export the real declarations.
+const entrypoints = ["index", "account-id"] as const;
+for (const entry of entrypoints) {
+  const out = path.join(process.cwd(), `dist/plugin-sdk/${entry}.d.ts`);
+  fs.mkdirSync(path.dirname(out), { recursive: true });
+  // NodeNext: reference the runtime specifier with `.js`, TS will map it to `.d.ts`.
+  fs.writeFileSync(out, `export * from "./plugin-sdk/${entry}.js";\n`, "utf8");
+}

--- a/src/media/server.test.ts
+++ b/src/media/server.test.ts
@@ -46,7 +46,7 @@ describe("media server", () => {
     await fs.writeFile(file, "hello");
     const server = await startMediaServer(0, 5_000);
     const port = (server.address() as AddressInfo).port;
-    const res = await fetch(`http://localhost:${port}/media/file1`);
+    const res = await fetch(`http://127.0.0.1:${port}/media/file1`);
     expect(res.status).toBe(200);
     expect(await res.text()).toBe("hello");
     await waitForFileRemoval(file);
@@ -60,7 +60,7 @@ describe("media server", () => {
     await fs.utimes(file, past / 1000, past / 1000);
     const server = await startMediaServer(0, 1_000);
     const port = (server.address() as AddressInfo).port;
-    const res = await fetch(`http://localhost:${port}/media/old`);
+    const res = await fetch(`http://127.0.0.1:${port}/media/old`);
     expect(res.status).toBe(410);
     await expect(fs.stat(file)).rejects.toThrow();
     await new Promise((r) => server.close(r));
@@ -70,7 +70,7 @@ describe("media server", () => {
     const server = await startMediaServer(0, 5_000);
     const port = (server.address() as AddressInfo).port;
     // URL-encoded "../" to bypass client-side path normalization
-    const res = await fetch(`http://localhost:${port}/media/%2e%2e%2fpackage.json`);
+    const res = await fetch(`http://127.0.0.1:${port}/media/%2e%2e%2fpackage.json`);
     expect(res.status).toBe(400);
     expect(await res.text()).toBe("invalid path");
     await new Promise((r) => server.close(r));
@@ -83,7 +83,7 @@ describe("media server", () => {
 
     const server = await startMediaServer(0, 5_000);
     const port = (server.address() as AddressInfo).port;
-    const res = await fetch(`http://localhost:${port}/media/link-out`);
+    const res = await fetch(`http://127.0.0.1:${port}/media/link-out`);
     expect(res.status).toBe(400);
     expect(await res.text()).toBe("invalid path");
     await new Promise((r) => server.close(r));
@@ -94,7 +94,7 @@ describe("media server", () => {
     await fs.writeFile(file, "hello");
     const server = await startMediaServer(0, 5_000);
     const port = (server.address() as AddressInfo).port;
-    const res = await fetch(`http://localhost:${port}/media/invalid%20id`);
+    const res = await fetch(`http://127.0.0.1:${port}/media/invalid%20id`);
     expect(res.status).toBe(400);
     expect(await res.text()).toBe("invalid path");
     await new Promise((r) => server.close(r));
@@ -106,7 +106,7 @@ describe("media server", () => {
     await fs.truncate(file, MEDIA_MAX_BYTES + 1);
     const server = await startMediaServer(0, 5_000);
     const port = (server.address() as AddressInfo).port;
-    const res = await fetch(`http://localhost:${port}/media/big`);
+    const res = await fetch(`http://127.0.0.1:${port}/media/big`);
     expect(res.status).toBe(413);
     expect(await res.text()).toBe("too large");
     await new Promise((r) => server.close(r));

--- a/src/slack/monitor/media.test.ts
+++ b/src/slack/monitor/media.test.ts
@@ -338,7 +338,46 @@ describe("resolveSlackMedia", () => {
     });
 
     expect(result).not.toBeNull();
+    expect(result).toHaveLength(1);
     expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns all successfully downloaded files as an array", async () => {
+    // Mock the store module
+    vi.doMock("../../media/store.js", () => ({
+      saveMediaBuffer: vi
+        .fn()
+        .mockResolvedValueOnce({ path: "/tmp/a.jpg", contentType: "image/jpeg" })
+        .mockResolvedValueOnce({ path: "/tmp/b.png", contentType: "image/png" }),
+    }));
+
+    const { resolveSlackMedia } = await import("./media.js");
+
+    const responseA = new Response(Buffer.from("image a"), {
+      status: 200,
+      headers: { "content-type": "image/jpeg" },
+    });
+    const responseB = new Response(Buffer.from("image b"), {
+      status: 200,
+      headers: { "content-type": "image/png" },
+    });
+
+    mockFetch.mockResolvedValueOnce(responseA).mockResolvedValueOnce(responseB);
+
+    const result = await resolveSlackMedia({
+      files: [
+        { url_private: "https://files.slack.com/a.jpg", name: "a.jpg" },
+        { url_private: "https://files.slack.com/b.png", name: "b.png" },
+      ],
+      token: "xoxb-test-token",
+      maxBytes: 1024 * 1024,
+    });
+
+    expect(result).toHaveLength(2);
+    expect(result![0].path).toBe("/tmp/a.jpg");
+    expect(result![0].placeholder).toBe("[Slack file: a.jpg]");
+    expect(result![1].path).toBe("/tmp/b.png");
+    expect(result![1].placeholder).toBe("[Slack file: b.png]");
   });
 });
 

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -605,16 +605,12 @@ export async function prepareSlackMessage(params: {
     MediaType: effectiveMedia?.[0]?.contentType,
     MediaUrl: effectiveMedia?.[0]?.path,
     MediaPaths:
-      effectiveMedia && effectiveMedia.length > 0
-        ? effectiveMedia.map((m) => m.path)
-        : undefined,
+      effectiveMedia && effectiveMedia.length > 0 ? effectiveMedia.map((m) => m.path) : undefined,
     MediaUrls:
-      effectiveMedia && effectiveMedia.length > 0
-        ? effectiveMedia.map((m) => m.path)
-        : undefined,
+      effectiveMedia && effectiveMedia.length > 0 ? effectiveMedia.map((m) => m.path) : undefined,
     MediaTypes:
       effectiveMedia && effectiveMedia.length > 0
-        ? (effectiveMedia.map((m) => m.contentType).filter(Boolean) as string[])
+        ? effectiveMedia.map((m) => m.contentType ?? "application/octet-stream")
         : undefined,
     CommandAuthorized: commandAuthorized,
     OriginatingChannel: "slack" as const,

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -342,7 +342,8 @@ export async function prepareSlackMessage(params: {
     token: ctx.botToken,
     maxBytes: ctx.mediaMaxBytes,
   });
-  const rawBody = (message.text ?? "").trim() || media?.placeholder || "";
+  const mediaPlaceholder = media ? media.map((m) => m.placeholder).join(" ") : undefined;
+  const rawBody = (message.text ?? "").trim() || mediaPlaceholder || "";
   if (!rawBody) {
     return null;
   }
@@ -488,8 +489,9 @@ export async function prepareSlackMessage(params: {
           maxBytes: ctx.mediaMaxBytes,
         });
         if (threadStarterMedia) {
+          const starterPlaceholders = threadStarterMedia.map((m) => m.placeholder).join(", ");
           logVerbose(
-            `slack: hydrated thread starter file ${threadStarterMedia.placeholder} from root message`,
+            `slack: hydrated thread starter file ${starterPlaceholders} from root message`,
           );
         }
       }
@@ -599,9 +601,21 @@ export async function prepareSlackMessage(params: {
     ThreadLabel: threadLabel,
     Timestamp: message.ts ? Math.round(Number(message.ts) * 1000) : undefined,
     WasMentioned: isRoomish ? effectiveWasMentioned : undefined,
-    MediaPath: effectiveMedia?.path,
-    MediaType: effectiveMedia?.contentType,
-    MediaUrl: effectiveMedia?.path,
+    MediaPath: effectiveMedia?.[0]?.path,
+    MediaType: effectiveMedia?.[0]?.contentType,
+    MediaUrl: effectiveMedia?.[0]?.path,
+    MediaPaths:
+      effectiveMedia && effectiveMedia.length > 0
+        ? effectiveMedia.map((m) => m.path)
+        : undefined,
+    MediaUrls:
+      effectiveMedia && effectiveMedia.length > 0
+        ? effectiveMedia.map((m) => m.path)
+        : undefined,
+    MediaTypes:
+      effectiveMedia && effectiveMedia.length > 0
+        ? (effectiveMedia.map((m) => m.contentType).filter(Boolean) as string[])
+        : undefined,
     CommandAuthorized: commandAuthorized,
     OriginatingChannel: "slack" as const,
     OriginatingTo: slackTo,

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -560,6 +560,10 @@ export async function prepareSlackMessage(params: {
 
   // Use thread starter media if current message has none
   const effectiveMedia = media ?? threadStarterMedia;
+  const firstMedia = effectiveMedia?.[0];
+  const firstMediaType = firstMedia
+    ? (firstMedia.contentType ?? "application/octet-stream")
+    : undefined;
 
   const inboundHistory =
     isRoomish && ctx.historyLimit > 0
@@ -601,9 +605,9 @@ export async function prepareSlackMessage(params: {
     ThreadLabel: threadLabel,
     Timestamp: message.ts ? Math.round(Number(message.ts) * 1000) : undefined,
     WasMentioned: isRoomish ? effectiveWasMentioned : undefined,
-    MediaPath: effectiveMedia?.[0]?.path,
-    MediaType: effectiveMedia?.[0]?.contentType,
-    MediaUrl: effectiveMedia?.[0]?.path,
+    MediaPath: firstMedia?.path,
+    MediaType: firstMediaType,
+    MediaUrl: firstMedia?.path,
     MediaPaths:
       effectiveMedia && effectiveMedia.length > 0 ? effectiveMedia.map((m) => m.path) : undefined,
     MediaUrls:


### PR DESCRIPTION
## Summary

- `resolveSlackMedia()` now collects all successfully downloaded files into an array instead of returning after the first one
- `prepareSlackMessage()` populates `MediaPaths`, `MediaUrls`, and `MediaTypes` arrays, matching the pattern used by Telegram, Line, Discord, and iMessage adapters
- Backward compatible: single-image messages produce an array of length 1, and singular `MediaPath`/`MediaType`/`MediaUrl` fields are still populated from the first element

## Problem

When a Slack user sends multiple images in a single message, only the first image is downloaded and processed. The `resolveSlackMedia()` function returns immediately after the first successful file download (`return { path, contentType, placeholder }`), discarding all subsequent files.

This is particularly impactful for use cases like nutrition logging where users photograph multiple dishes in one message.

Fixes #11892, #7536

## Changes

### `src/slack/monitor/media.ts`
- Changed `resolveSlackMedia()` return type from `Promise<{path, contentType, placeholder} | null>` to `Promise<SlackMediaResult[] | null>`
- The loop now pushes each result to an array instead of returning early
- Added exported `SlackMediaResult` type

### `src/slack/monitor/message-handler/prepare.ts`
- `rawBody` placeholder: joins all file placeholders with spaces
- `effectiveMedia` context fields: `MediaPath`/`MediaType`/`MediaUrl` use first element; new `MediaPaths`/`MediaUrls`/`MediaTypes` arrays carry all elements
- Thread starter media log message updated for array format

### `src/slack/monitor/media.test.ts`
- Added assertion that error-fallback test returns array of length 1
- Added new test: "returns all successfully downloaded files as an array" — verifies both files are returned with correct paths and placeholders

## Test plan

- [ ] Existing `resolveSlackMedia` tests pass with updated assertions
- [ ] New multi-file test verifies both files are returned
- [ ] Single-image Slack messages continue to work (array of 1)
- [ ] Multi-image Slack messages now process all images
- [ ] `MediaPath` singular field still populated (backward compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates Slack inbound media handling to support multi-file messages: `resolveSlackMedia()` now downloads all successfully fetched attachments and returns them as an array, and `prepareSlackMessage()` populates both legacy single-value media fields and new `MediaPaths`/`MediaUrls`/`MediaTypes` arrays.

Main issue to address before merge: `MediaTypes` is currently derived with a `filter(Boolean)` which can shrink the array and break index alignment with `MediaPaths`/`MediaUrls`. Several downstream components treat these arrays as index-correlated (or require equal lengths), so this can cause MIME hints to be dropped or misapplied for multi-attachment messages.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but fix MediaTypes index alignment for multi-attachment messages first.
- Core change (returning an array from resolveSlackMedia and plumbing MediaPaths/Urls/Types) is straightforward and test-covered. The remaining issue is a concrete data-shape bug: filtering falsy MediaTypes values can desync arrays and break downstream assumptions about attachment indexing.
- src/slack/monitor/message-handler/prepare.ts

<sub>Last reviewed commit: ddfb393</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->