### PR TITLE
docs: Compare minimum node version directly

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -70,6 +70,12 @@ Verify your Node.js version:
 node --version  # Should be v22.12.0 or later
 ```
 
+Or compare directly:
+
+```bash
+node --version | { read ver; [ "$(printf '%s\n' "v22.12.0" "$ver" | sort -V | head -1)" = "v22.12.0" ] && echo "Node version $ver is OK" || echo "Node version $ver must be v22.12.0 or later" }
+```
+
 ### Docker Security
 
 When running OpenClaw in Docker:


### PR DESCRIPTION
### Docs
- Add a helpful code line to compare the minimum `node --version` directly

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `SECURITY.md` to add a one-liner that compares the currently installed `node --version` against the documented minimum (v22.12.0) using `sort -V`, giving a pass/fail message.

This fits into the existing “Runtime Requirements → Node.js Version” section as an optional convenience command for users who want an automated check rather than manual inspection.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but the added version-compare snippet can give incorrect results on some Node builds.
- Change is docs-only and localized, but the recommended shell one-liner relies on `node --version` being a plain semver; packaging metadata can cause miscomparison and misleading “OK” output.
- SECURITY.md

<sub>Last reviewed commit: a61dd45</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->