### PR TITLE
feat(messages): add debounceMedia option for inbound debouncing

### DIFF
--- a/docs/concepts/messages.md
+++ b/docs/concepts/messages.md
@@ -49,6 +49,7 @@ Config (global default + per-channel overrides):
   messages: {
     inbound: {
       debounceMs: 2000,
+      debounceMedia: true, // also debounce media/attachments (default: false)
       byChannel: {
         whatsapp: 5000,
         slack: 1500,
@@ -61,7 +62,10 @@ Config (global default + per-channel overrides):
 
 Notes:
 
-- Debounce applies to **text-only** messages; media/attachments flush immediately.
+- By default, debounce applies to **text-only** messages; media/attachments flush immediately.
+- Set `debounceMedia: true` to include media messages in debouncing. This is useful in group
+  chats where users send multiple screenshots that should be processed as a single batch.
+  When enabled, debounced media from the same sender is combined into one agent turn.
 - Control commands bypass debouncing so they remain standalone.
 
 ## Sessions and devices

--- a/src/auto-reply/inbound-debounce.ts
+++ b/src/auto-reply/inbound-debounce.ts
@@ -33,6 +33,10 @@ export function resolveInboundDebounceMs(params: {
   return override ?? byChannel ?? base ?? 0;
 }
 
+export function resolveDebounceMedia(cfg: OpenClawConfig): boolean {
+  return cfg.messages?.inbound?.debounceMedia === true;
+}
+
 type DebounceBuffer<T> = {
   items: T[];
   timeout: ReturnType<typeof setTimeout> | null;

--- a/src/auto-reply/inbound.test.ts
+++ b/src/auto-reply/inbound.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import type { GroupKeyResolution } from "../config/sessions.js";
-import { createInboundDebouncer } from "./inbound-debounce.js";
+import { createInboundDebouncer, resolveDebounceMedia } from "./inbound-debounce.js";
 import { resolveGroupRequireMention } from "./reply/groups.js";
 import { finalizeInboundContext } from "./reply/inbound-context.js";
 import {
@@ -201,6 +201,24 @@ describe("createInboundDebouncer", () => {
     expect(calls).toEqual([["1"], ["2"]]);
 
     vi.useRealTimers();
+  });
+});
+
+describe("resolveDebounceMedia", () => {
+  it("returns false when not configured", () => {
+    expect(resolveDebounceMedia({} as OpenClawConfig)).toBe(false);
+  });
+
+  it("returns false when explicitly false", () => {
+    expect(
+      resolveDebounceMedia({ messages: { inbound: { debounceMedia: false } } } as OpenClawConfig),
+    ).toBe(false);
+  });
+
+  it("returns true when enabled", () => {
+    expect(
+      resolveDebounceMedia({ messages: { inbound: { debounceMedia: true } } } as OpenClawConfig),
+    ).toBe(true);
   });
 });
 

--- a/src/config/types.messages.ts
+++ b/src/config/types.messages.ts
@@ -25,6 +25,8 @@ export type InboundDebounceByProvider = Record<string, number>;
 export type InboundDebounceConfig = {
   debounceMs?: number;
   byChannel?: InboundDebounceByProvider;
+  /** When true, media/attachment messages are debounced like text (default: false). */
+  debounceMedia?: boolean;
 };
 
 export type BroadcastStrategy = "parallel" | "sequential";

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -340,6 +340,7 @@ export const InboundDebounceSchema = z
   .object({
     debounceMs: z.number().int().nonnegative().optional(),
     byChannel: DebounceMsBySurfaceSchema,
+    debounceMedia: z.boolean().optional(),
   })
   .strict()
   .optional();

--- a/src/discord/monitor/message-handler.ts
+++ b/src/discord/monitor/message-handler.ts
@@ -7,6 +7,7 @@ import type { DiscordMessageEvent, DiscordMessageHandler } from "./listeners.js"
 import { hasControlCommand } from "../../auto-reply/command-detection.js";
 import {
   createInboundDebouncer,
+  resolveDebounceMedia,
   resolveInboundDebounceMs,
 } from "../../auto-reply/inbound-debounce.js";
 import { danger } from "../../globals.js";
@@ -40,6 +41,7 @@ export function createDiscordMessageHandler(params: {
   const groupPolicy = params.discordConfig?.groupPolicy ?? "open";
   const ackReactionScope = params.cfg.messages?.ackReactionScope ?? "group-mentions";
   const debounceMs = resolveInboundDebounceMs({ cfg: params.cfg, channel: "discord" });
+  const debounceMedia = resolveDebounceMedia(params.cfg);
 
   const debouncer = createInboundDebouncer<{ data: DiscordMessageEvent; client: Client }>({
     debounceMs,
@@ -60,11 +62,11 @@ export function createDiscordMessageHandler(params: {
       if (!message) {
         return false;
       }
-      if (message.attachments && message.attachments.length > 0) {
+      if (message.attachments && message.attachments.length > 0 && !debounceMedia) {
         return false;
       }
       const baseText = resolveDiscordMessageText(message, { includeForwarded: false });
-      if (!baseText.trim()) {
+      if (!baseText.trim() && !(message.attachments && message.attachments.length > 0)) {
         return false;
       }
       return !hasControlCommand(baseText, params.cfg);

--- a/src/discord/monitor/message-handler.ts
+++ b/src/discord/monitor/message-handler.ts
@@ -97,7 +97,7 @@ export function createDiscordMessageHandler(params: {
       const syntheticMessage = {
         ...last.data.message,
         content: combinedBaseText,
-        attachments: [],
+        attachments: entries.flatMap((entry) => entry.data.message?.attachments ?? []),
         message_snapshots: (last.data.message as { message_snapshots?: unknown }).message_snapshots,
         messageSnapshots: (last.data.message as { messageSnapshots?: unknown }).messageSnapshots,
         rawData: {

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -5,6 +5,7 @@ import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { hasControlCommand } from "../auto-reply/command-detection.js";
 import {
   createInboundDebouncer,
+  resolveDebounceMedia,
   resolveInboundDebounceMs,
 } from "../auto-reply/inbound-debounce.js";
 import { buildCommandsPaginationKeyboard } from "../auto-reply/reply/commands-info.js";
@@ -75,6 +76,7 @@ export const registerTelegramHandlers = ({
   let textFragmentProcessing: Promise<void> = Promise.resolve();
 
   const debounceMs = resolveInboundDebounceMs({ cfg, channel: "telegram" });
+  const debounceMedia = resolveDebounceMedia(cfg);
   type TelegramDebounceEntry = {
     ctx: TelegramContext;
     msg: Message;
@@ -87,11 +89,11 @@ export const registerTelegramHandlers = ({
     debounceMs,
     buildKey: (entry) => entry.debounceKey,
     shouldDebounce: (entry) => {
-      if (entry.allMedia.length > 0) {
+      if (entry.allMedia.length > 0 && !debounceMedia) {
         return false;
       }
       const text = entry.msg.text ?? entry.msg.caption ?? "";
-      if (!text.trim()) {
+      if (!text.trim() && entry.allMedia.length === 0) {
         return false;
       }
       return !hasControlCommand(text, cfg, { botUsername: entry.botUsername });
@@ -109,7 +111,8 @@ export const registerTelegramHandlers = ({
         .map((entry) => entry.msg.text ?? entry.msg.caption ?? "")
         .filter(Boolean)
         .join("\n");
-      if (!combinedText.trim()) {
+      const combinedMedia = entries.flatMap((entry) => entry.allMedia);
+      if (!combinedText.trim() && combinedMedia.length === 0) {
         return;
       }
       const first = entries[0];
@@ -118,7 +121,7 @@ export const registerTelegramHandlers = ({
         typeof baseCtx.getFile === "function" ? baseCtx.getFile.bind(baseCtx) : async () => ({});
       const syntheticMessage: Message = {
         ...first.msg,
-        text: combinedText,
+        text: combinedText || undefined,
         caption: undefined,
         caption_entities: undefined,
         entities: undefined,
@@ -127,7 +130,7 @@ export const registerTelegramHandlers = ({
       const messageIdOverride = last.msg.message_id ? String(last.msg.message_id) : undefined;
       await processMessage(
         { message: syntheticMessage, me: baseCtx.me, getFile },
-        [],
+        combinedMedia,
         first.storeAllowFrom,
         messageIdOverride ? { messageIdOverride } : undefined,
       );

--- a/src/web/auto-reply/monitor.ts
+++ b/src/web/auto-reply/monitor.ts
@@ -1,6 +1,9 @@
 import type { WebChannelStatus, WebInboundMsg, WebMonitorTuning } from "./types.js";
 import { hasControlCommand } from "../../auto-reply/command-detection.js";
-import { resolveInboundDebounceMs } from "../../auto-reply/inbound-debounce.js";
+import {
+  resolveDebounceMedia,
+  resolveInboundDebounceMs,
+} from "../../auto-reply/inbound-debounce.js";
 import { getReplyFromConfig } from "../../auto-reply/reply.js";
 import { DEFAULT_GROUP_HISTORY_LIMIT } from "../../auto-reply/reply/history.js";
 import { formatCliCommand } from "../../cli/command-format.js";
@@ -176,8 +179,9 @@ export async function monitorWebChannel(
     });
 
     const inboundDebounceMs = resolveInboundDebounceMs({ cfg, channel: "whatsapp" });
+    const debounceMediaEnabled = resolveDebounceMedia(cfg);
     const shouldDebounce = (msg: WebInboundMsg) => {
-      if (msg.mediaPath || msg.mediaType) {
+      if ((msg.mediaPath || msg.mediaType) && !debounceMediaEnabled) {
         return false;
       }
       if (msg.location) {


### PR DESCRIPTION
## Summary

- Add `messages.inbound.debounceMedia` config option (boolean, default `false`)
- When enabled, media/attachment messages are debounced like text instead of flushing immediately
- Debounced media from the same sender is combined into a single agent turn with all attachments

## Problem

In group chats, users often send multiple screenshots in quick succession (e.g., customer service calibration, multi-image bug reports). Currently each image bypasses inbound debouncing and triggers a separate agent run, causing the bot to respond N times instead of once. This wastes tokens and creates a poor user experience.

## Changes

| File | Change |
|------|--------|
| `src/config/types.messages.ts` | Add `debounceMedia?: boolean` to `InboundDebounceConfig` |
| `src/config/zod-schema.core.ts` | Add schema validation for the new field |
| `src/auto-reply/inbound-debounce.ts` | Add `resolveDebounceMedia()` helper |
| `src/telegram/bot-handlers.ts` | Respect config; combine media in `onFlush` |
| `src/discord/monitor/message-handler.ts` | Respect config for attachments |
| `src/web/auto-reply/monitor.ts` | Respect config for WhatsApp media |
| `src/auto-reply/inbound.test.ts` | Unit tests for `resolveDebounceMedia` |
| `docs/concepts/messages.md` | Document new option |

## Usage

```json5
{
  messages: {
    inbound: {
      debounceMs: 5000,
      debounceMedia: true,
    },
  },
}
```

## Backward compatibility

Default is `false` — existing behavior is completely unchanged. Opt-in only.

## Test plan

- [x] `pnpm tsc --noEmit` passes
- [x] `resolveDebounceMedia` unit tests pass (3 cases: unset, false, true)
- [x] All existing inbound debounce tests still pass
- [x] Linter + formatter pass
- [ ] Manual: send multiple images in Telegram group with `debounceMedia: true`, verify single batched response

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new `messages.inbound.debounceMedia` boolean config (default `false`) and threads it through inbound debouncing for Telegram, Discord, and WhatsApp Web so that media/attachment messages can be batched instead of flushing immediately. It also adds schema/type support and documents the new option.

Main concern: the Discord implementation currently drops attachments when combining debounced messages. `shouldDebounce` will allow attachment messages when `debounceMedia` is enabled, but `onFlush` constructs a synthetic message with `attachments: []`, and downstream media extraction relies on `message.attachments`. This means batched Discord media turns will lose all attachments instead of combining them.

<h3>Confidence Score: 3/5</h3>

- Mergeable after fixing a functional bug in Discord attachment batching.
- Most changes are straightforward config plumbing and behavior gating. However, the Discord debounced-flush path currently clears `message.attachments`, so enabling `debounceMedia` would silently drop attachments in batched turns; this is a user-visible functional regression for the new feature.
- src/discord/monitor/message-handler.ts

<sub>Last reviewed commit: d87823f</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->