### PR TITLE
fix: validate session file paths against any agent sessions dir

### DIFF
--- a/src/config/sessions/paths.test.ts
+++ b/src/config/sessions/paths.test.ts
@@ -127,4 +127,21 @@ describe("session path safety", () => {
     const opts = resolveSessionFilePathOptions({ agentId: "ops" });
     expect(opts).toEqual({ agentId: "ops" });
   });
+
+  it("accepts absolute sessionFile paths within a different agent's sessions dir", () => {
+    const mainSessionsDir = path.join(
+      resolveSessionTranscriptPath("dummy", "main").replace(/dummy\.jsonl$/, ""),
+    ).replace(/\/$/, "");
+    const smolSessionFile = resolveSessionTranscriptPath("sess-2", "smol");
+
+    // This should NOT throw — smol's session path is valid even when
+    // validated against main's sessions dir
+    const resolved = resolveSessionFilePath(
+      "sess-2",
+      { sessionFile: smolSessionFile },
+      { sessionsDir: mainSessionsDir },
+    );
+
+    expect(resolved).toBe(smolSessionFile);
+  });
 });

--- a/src/config/sessions/paths.test.ts
+++ b/src/config/sessions/paths.test.ts
@@ -129,13 +129,9 @@ describe("session path safety", () => {
   });
 
   it("accepts absolute sessionFile paths within a different agent's sessions dir", () => {
-    const mainSessionsDir = path.join(
-      resolveSessionTranscriptPath("dummy", "main").replace(/dummy\.jsonl$/, ""),
-    ).replace(/\/$/, "");
+    const mainSessionsDir = path.dirname(resolveSessionTranscriptPath("dummy", "main"));
     const smolSessionFile = resolveSessionTranscriptPath("sess-2", "smol");
 
-    // This should NOT throw — smol's session path is valid even when
-    // validated against main's sessions dir
     const resolved = resolveSessionFilePath(
       "sess-2",
       { sessionFile: smolSessionFile },

--- a/src/config/sessions/paths.ts
+++ b/src/config/sessions/paths.ts
@@ -82,6 +82,26 @@ function resolvePathWithinSessionsDir(sessionsDir: string, candidate: string): s
   // convert them to relative so the containment check passes.
   const normalized = path.isAbsolute(trimmed) ? path.relative(resolvedBase, trimmed) : trimmed;
   if (!normalized || normalized.startsWith("..") || path.isAbsolute(normalized)) {
+    // If the candidate is an absolute path pointing to a valid agent sessions
+    // directory, allow it. This supports multi-agent setups where session file
+    // paths reference a different agent's sessions directory.
+    if (path.isAbsolute(trimmed)) {
+      const candidateDir = path.dirname(path.resolve(trimmed));
+      const stateDir = resolveStateDir(process.env);
+      const agentsDir = path.join(stateDir, "agents");
+      const relToAgents = path.relative(agentsDir, candidateDir);
+      // Allow paths like <stateDir>/agents/<id>/sessions[/...]
+      // but enforce that the path is specifically within a sessions directory
+      const relParts = relToAgents.split(path.sep);
+      if (
+        !relToAgents.startsWith("..") &&
+        !path.isAbsolute(relToAgents) &&
+        relParts.length >= 2 &&
+        relParts[1] === "sessions"
+      ) {
+        return path.resolve(trimmed);
+      }
+    }
     throw new Error("Session file path must be within sessions directory");
   }
   return path.resolve(resolvedBase, normalized);


### PR DESCRIPTION
## Problem

In multi-agent setups where sub-agents have their own `agentDir`, session file paths from one agent get validated against the main agent's sessions directory. This causes:

```
Error: Session file path must be within sessions directory
```

The root cause is in `resolvePathWithinSessionsDir` — when `entry.sessionFile` is an absolute path pointing to a different agent's sessions dir (e.g., `/home/user/.openclaw/agents/smol/sessions/xxx.jsonl`), it fails the relative path check against main's sessions dir (`/home/user/.openclaw/agents/main/sessions`).

## Fix

When the candidate is an absolute path and the initial check fails, verify whether the path falls within any agent's sessions directory under the state dir (`<stateDir>/agents/<id>/sessions/...`). If so, allow it.

## Reproduction

1. Create a sub-agent with explicit `agentDir`: `openclaw agents add smol --workspace /path/to/workspace`
2. Set main agent's `agentDir` explicitly in config
3. Try to message the sub-agent via Telegram or TUI
4. Error: `Session file path must be within sessions directory`

## Changes

- `src/config/sessions/paths.ts`: Added fallback check for absolute paths within any agent's sessions dir
- `src/config/sessions/paths.test.ts`: Added test for cross-agent session file path resolution

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds fallback validation for cross-agent session file paths in multi-agent setups. When an absolute session file path fails the initial containment check (because it belongs to a different agent's sessions directory), the code now verifies the path falls within `<stateDir>/agents/<agentId>/sessions/...` before allowing it. The fix addresses errors when sub-agents with explicit `agentDir` configurations try to reference their own session files while being validated against the main agent's sessions directory.

<h3>Confidence Score: 5/5</h3>

- Safe to merge with minimal risk
- The fix is narrowly scoped, addresses a specific multi-agent validation bug, includes test coverage, and the path validation logic correctly enforces that files must be in `agents/<id>/sessions/` directories. The previous thread's concern about overbroad validation was already addressed by requiring `relParts[1] === "sessions"`.
- No files require special attention

<sub>Last reviewed commit: 06238e4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->