### PR TITLE
fix(ios): resolve SwiftLint empty_count violation in WakeWordGate

### DIFF
--- a/Swabble/Sources/SwabbleKit/WakeWordGate.swift
+++ b/Swabble/Sources/SwabbleKit/WakeWordGate.swift
@@ -77,7 +77,7 @@ public enum WakeWordGate {
 
         for trigger in triggerTokens {
             let count = trigger.tokens.count
-            guard count > 0, tokens.count > count else { continue }
+            guard !trigger.tokens.isEmpty, tokens.count > count else { continue }
             for i in 0...(tokens.count - count - 1) {
                 let matched = (0..<count).allSatisfy { tokens[i + $0].normalized == trigger.tokens[$0] }
                 if !matched { continue }
@@ -195,3 +195,4 @@ public enum WakeWordSpeechSegments {
     }
 }
 #endif
+


### PR DESCRIPTION
## Summary

`Swabble/Sources/SwabbleKit/WakeWordGate.swift:80` uses `count > 0` instead of `!isEmpty`, triggering the `empty_count` SwiftLint opt-in rule during iOS pre-build lint.

```swift
// before
guard count > 0, tokens.count > count else { continue }

// after
guard !trigger.tokens.isEmpty, tokens.count > count else { continue }
```

## Root cause

The `empty_count` opt-in rule was added in `2e62659` (Dec 6, 2025), but `WakeWordGate.swift` was moved into the iOS lint scope later in `ef35868` (Dec 23, 2025) without a regression lint pass. The violation was introduced at the same time the file entered the filelist.

Closes #15486

## Test plan

- Verify iOS build succeeds without SwiftLint error
- Verify wake word functionality remains unchanged (logic is equivalent)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `Swabble/Sources/SwabbleKit/WakeWordGate.swift` to satisfy SwiftLint’s `empty_count` opt-in rule by replacing a `count > 0` emptiness check with `!isEmpty` on the underlying collection.

Behavior remains the same because `count` is derived from `trigger.tokens.count`, so `count > 0` is equivalent to `!trigger.tokens.isEmpty`. The rest of the matching logic (range bounds and indexing) continues to use the cached `count` as before. A trailing newline was also added at EOF.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a one-line SwiftLint compliance refactor that is logically equivalent (emptiness check on the same array) plus an EOF newline; no control flow or indexing behavior changes beyond the equivalent guard condition.
- No files require special attention

<sub>Last reviewed commit: 07a1d91</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->