### PR TITLE
Update clawdock-helpers.sh compatibility with Zsh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Clawdock: avoid Zsh readonly variable collisions in helper scripts. (#15501) Thanks @nkelner.
 - Discord: route autoThread replies to existing threads instead of the root channel. (#8302) Thanks @gavinbmoore, @thewilloftheshadow.
 - Agents/Image tool: cap image-analysis completion `maxTokens` by model capability (`min(4096, model.maxTokens)`) to avoid over-limit provider failures while still preventing truncation. (#11770) Thanks @detecti1.
 - TUI/Streaming: preserve richer streamed assistant text when final payload drops pre-tool-call text blocks, while keeping non-empty final payload authoritative for plain-text updates. (#15452) Thanks @TsekaLuk.

--- a/scripts/shell-helpers/clawdock-helpers.sh
+++ b/scripts/shell-helpers/clawdock-helpers.sh
@@ -275,11 +275,11 @@ clawdock-dashboard() {
   _clawdock_ensure_dir || return 1
 
   echo "🦞 Getting dashboard URL..."
-  local output status url
+  local output exit_status url
   output=$(_clawdock_compose run --rm openclaw-cli dashboard --no-open 2>&1)
-  status=$?
+  exit_status=$?
   url=$(printf "%s\n" "$output" | _clawdock_filter_warnings | grep -o 'http[s]\?://[^[:space:]]*' | head -n 1)
-  if [[ $status -ne 0 ]]; then
+  if [[ $exit_status -ne 0 ]]; then
     echo "❌ Failed to get dashboard URL"
     echo -e "   Try restarting: $(_cmd clawdock-restart)"
     return 1
@@ -304,11 +304,11 @@ clawdock-devices() {
   _clawdock_ensure_dir || return 1
 
   echo "🔍 Checking device pairings..."
-  local output status
+  local output exit_status
   output=$(_clawdock_compose exec openclaw-gateway node dist/index.js devices list 2>&1)
-  status=$?
+  exit_status=$?
   printf "%s\n" "$output" | _clawdock_filter_warnings
-  if [ $status -ne 0 ]; then
+  if [ $exit_status -ne 0 ]; then
     echo ""
     echo -e "${_CLR_CYAN}💡 If you see token errors above:${_CLR_RESET}"
     echo -e "   1. Verify token is set: $(_cmd clawdock-token)"


### PR DESCRIPTION
Unlike Bash, Zsh has several "special" readonly variables (status, pipestatus, etc.) that the shell manages automatically. Shadowing them with local declarations triggers an error.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `scripts/shell-helpers/clawdock-helpers.sh` to avoid declaring local variables that collide with Zsh’s special readonly variables (e.g., `status`, `pipestatus`). The change should improve cross-shell compatibility when the helpers are sourced/run under Zsh by preventing `readonly variable` errors that would otherwise abort execution.

Overall, the change is localized to the helper script and aligns with the repository’s goal of supporting multiple shells for developer tooling.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped to renaming/avoiding Zsh-reserved variable names in a shell helper script, with no broader behavioral changes detected and low blast radius.
- scripts/shell-helpers/clawdock-helpers.sh

<sub>Last reviewed commit: a5a1889</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->