### PR TITLE
fix(session): drop tool_use blocks with empty or missing name

### DIFF
--- a/src/agents/session-transcript-repair.e2e.test.ts
+++ b/src/agents/session-transcript-repair.e2e.test.ts
@@ -242,4 +242,36 @@ describe("sanitizeToolCallInputs", () => {
       : [];
     expect(types).toEqual(["text", "toolUse"]);
   });
+
+  it("drops tool calls with empty name", () => {
+    const input: AgentMessage[] = [
+      {
+        role: "assistant",
+        content: [{ type: "toolUse", id: "call_empty", name: "", input: { path: "a" } }],
+      },
+      { role: "user", content: "hello" },
+    ];
+
+    const out = sanitizeToolCallInputs(input);
+    expect(out.map((m) => m.role)).toEqual(["user"]);
+  });
+
+  it("drops tool calls with missing name", () => {
+    const input: AgentMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "thinking" },
+          { type: "toolCall", id: "call_noname", input: { x: 1 } },
+        ],
+      },
+    ];
+
+    const out = sanitizeToolCallInputs(input);
+    const assistant = out[0] as Extract<AgentMessage, { role: "assistant" }>;
+    const types = Array.isArray(assistant.content)
+      ? assistant.content.map((block) => (block as { type?: unknown }).type)
+      : [];
+    expect(types).toEqual(["text"]);
+  });
 });

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -58,6 +58,10 @@ function hasToolCallInput(block: ToolCallBlock): boolean {
   return hasInput || hasArguments;
 }
 
+function hasToolCallName(block: ToolCallBlock): boolean {
+  return typeof block.name === "string" && block.name.length > 0;
+}
+
 function extractToolResultId(msg: Extract<AgentMessage, { role: "toolResult" }>): string | null {
   const toolCallId = (msg as { toolCallId?: unknown }).toolCallId;
   if (typeof toolCallId === "string" && toolCallId) {
@@ -118,7 +122,7 @@ export function repairToolCallInputs(messages: AgentMessage[]): ToolCallInputRep
     let droppedInMessage = 0;
 
     for (const block of msg.content) {
-      if (isToolCallBlock(block) && !hasToolCallInput(block)) {
+      if (isToolCallBlock(block) && (!hasToolCallInput(block) || !hasToolCallName(block))) {
         droppedToolCalls += 1;
         droppedInMessage += 1;
         changed = true;


### PR DESCRIPTION
## Summary

`repairToolCallInputs()` already drops tool calls without `input`/`arguments`, but passes through blocks with an empty `name` field. The Anthropic API rejects these with:

```
tool_use.name: String should have at least 1 character
```

This corrupts the session permanently — every subsequent message fails until `/new`.

## Changes

- Add `hasToolCallName()` guard in `session-transcript-repair.ts`
- Drop tool call blocks where `name` is empty string or missing
- Add 2 test cases covering empty and missing name scenarios

## Testing

All 12 tests pass in `session-transcript-repair.e2e.test.ts`.

Closes #15485

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR tightens transcript sanitization in `src/agents/session-transcript-repair.ts` by additionally dropping assistant tool-call blocks whose `name` is empty or missing, preventing provider-side 400s (`tool_use.name` must be non-empty) that can permanently break a session. It adds two E2E tests in `src/agents/session-transcript-repair.e2e.test.ts` to cover empty-name and missing-name tool blocks and asserts the sanitizer removes those blocks (and drops the now-empty assistant message when applicable).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is narrow and defensive (dropping invalid tool-call blocks already known to be rejected by providers) and is covered by new test cases; no behavioral changes outside transcript repair/sanitization logic were observed in the diff.
- No files require special attention

<sub>Last reviewed commit: 3296ced</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->