### PR TITLE
fix(tests): mock TTS to prevent prefs file leak into test environment

### DIFF
--- a/src/imessage/monitor.skips-group-messages-without-mention-by-default.test.ts
+++ b/src/imessage/monitor.skips-group-messages-without-mention-by-default.test.ts
@@ -25,6 +25,15 @@ vi.mock("../auto-reply/reply.js", () => ({
   getReplyFromConfig: (...args: unknown[]) => replyMock(...args),
 }));
 
+// Prevent TTS prefs file from leaking into tests (see web prefixes-body test for details).
+vi.mock("../tts/tts.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../tts/tts.js")>();
+  return {
+    ...actual,
+    maybeApplyTtsToPayload: async (params: { payload: unknown }) => params.payload,
+  };
+});
+
 vi.mock("./send.js", () => ({
   sendMessageIMessage: (...args: unknown[]) => sendMock(...args),
 }));

--- a/src/signal/monitor.tool-result.sends-tool-summaries-responseprefix.test.ts
+++ b/src/signal/monitor.tool-result.sends-tool-summaries-responseprefix.test.ts
@@ -26,6 +26,15 @@ vi.mock("../auto-reply/reply.js", () => ({
   getReplyFromConfig: (...args: unknown[]) => replyMock(...args),
 }));
 
+// Prevent TTS prefs file from leaking into tests (see web prefixes-body test for details).
+vi.mock("../tts/tts.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../tts/tts.js")>();
+  return {
+    ...actual,
+    maybeApplyTtsToPayload: async (params: { payload: unknown }) => params.payload,
+  };
+});
+
 vi.mock("./send.js", () => ({
   sendMessageSignal: (...args: unknown[]) => sendMock(...args),
   sendTypingSignal: vi.fn().mockResolvedValue(true),

--- a/src/telegram/bot.create-telegram-bot.applies-topic-skill-filters-system-prompts.test.ts
+++ b/src/telegram/bot.create-telegram-bot.applies-topic-skill-filters-system-prompts.test.ts
@@ -14,6 +14,15 @@ vi.mock("../web/media.js", () => ({
   loadWebMedia,
 }));
 
+// Prevent TTS prefs file from leaking into tests (see web prefixes-body test for details).
+vi.mock("../tts/tts.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../tts/tts.js")>();
+  return {
+    ...actual,
+    maybeApplyTtsToPayload: async (params: { payload: unknown }) => params.payload,
+  };
+});
+
 const { loadConfig } = vi.hoisted(() => ({
   loadConfig: vi.fn(() => ({})),
 }));

--- a/src/telegram/bot.create-telegram-bot.sends-replies-without-native-reply-threading.test.ts
+++ b/src/telegram/bot.create-telegram-bot.sends-replies-without-native-reply-threading.test.ts
@@ -19,6 +19,15 @@ vi.mock("../web/media.js", () => ({
   loadWebMedia,
 }));
 
+// Prevent TTS prefs file from leaking into tests (see web prefixes-body test for details).
+vi.mock("../tts/tts.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../tts/tts.js")>();
+  return {
+    ...actual,
+    maybeApplyTtsToPayload: async (params: { payload: unknown }) => params.payload,
+  };
+});
+
 const { loadConfig } = vi.hoisted(() => ({
   loadConfig: vi.fn(() => ({})),
 }));

--- a/src/telegram/bot.test.ts
+++ b/src/telegram/bot.test.ts
@@ -164,6 +164,15 @@ vi.mock("../auto-reply/reply.js", () => {
   return { getReplyFromConfig: replySpy, __replySpy: replySpy };
 });
 
+// Prevent TTS prefs file from leaking into tests (see web prefixes-body test for details).
+vi.mock("../tts/tts.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../tts/tts.js")>();
+  return {
+    ...actual,
+    maybeApplyTtsToPayload: async (params: { payload: unknown }) => params.payload,
+  };
+});
+
 const getOnHandler = (event: string) => {
   const handler = onSpy.mock.calls.find((call) => call[0] === event)?.[1];
   if (!handler) {

--- a/src/web/auto-reply.partial-reply-gating.test.ts
+++ b/src/web/auto-reply.partial-reply-gating.test.ts
@@ -13,6 +13,15 @@ vi.mock("../agents/pi-embedded.js", () => ({
   resolveEmbeddedSessionLane: (key: string) => `session:${key.trim() || "main"}`,
 }));
 
+// Prevent TTS prefs file from leaking into tests (see prefixes-body test for details).
+vi.mock("../tts/tts.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../tts/tts.js")>();
+  return {
+    ...actual,
+    maybeApplyTtsToPayload: async (params: { payload: unknown }) => params.payload,
+  };
+});
+
 import type { OpenClawConfig } from "../config/config.js";
 import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
 import { getReplyFromConfig } from "../auto-reply/reply.js";

--- a/src/web/auto-reply.web-auto-reply.prefixes-body-same-phone-marker-from.test.ts
+++ b/src/web/auto-reply.web-auto-reply.prefixes-body-same-phone-marker-from.test.ts
@@ -13,6 +13,17 @@ vi.mock("../agents/pi-embedded.js", () => ({
   resolveEmbeddedSessionLane: (key: string) => `session:${key.trim() || "main"}`,
 }));
 
+// Prevent TTS prefs file (~/.openclaw/settings/tts.json) from leaking into tests.
+// When the prefs file has auto:"always", maybeApplyTtsToPayload generates real audio
+// and adds mediaUrl to the payload, causing reply assertions to fail.
+vi.mock("../tts/tts.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../tts/tts.js")>();
+  return {
+    ...actual,
+    maybeApplyTtsToPayload: async (params: { payload: unknown }) => params.payload,
+  };
+});
+
 import { resetInboundDedupe } from "../auto-reply/reply/inbound-dedupe.js";
 import { resetLogger, setLoggerOverride } from "../logging.js";
 import { HEARTBEAT_TOKEN, monitorWebChannel } from "./auto-reply.js";

--- a/src/web/auto-reply.web-auto-reply.sends-tool-summaries-immediately-responseprefix.test.ts
+++ b/src/web/auto-reply.web-auto-reply.sends-tool-summaries-immediately-responseprefix.test.ts
@@ -13,6 +13,15 @@ vi.mock("../agents/pi-embedded.js", () => ({
   resolveEmbeddedSessionLane: (key: string) => `session:${key.trim() || "main"}`,
 }));
 
+// Prevent TTS prefs file from leaking into tests (see prefixes-body test for details).
+vi.mock("../tts/tts.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../tts/tts.js")>();
+  return {
+    ...actual,
+    maybeApplyTtsToPayload: async (params: { payload: unknown }) => params.payload,
+  };
+});
+
 import { resetInboundDedupe } from "../auto-reply/reply/inbound-dedupe.js";
 import { resetLogger, setLoggerOverride } from "../logging.js";
 import { monitorWebChannel } from "./auto-reply.js";


### PR DESCRIPTION
When `~/.openclaw/settings/tts.json` has `auto:"always"`, `maybeApplyTtsToPayload` generates real audio and adds mediaUrl to payloads. Since `CONFIG_DIR` resolves at module-load time (before tests can change `$HOME`), test assertions on `msg.reply()` fail because replies are routed through the media delivery path.

Mock `maybeApplyTtsToPayload` as a passthrough in all affected test files.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

These changes add a Vitest mock for `maybeApplyTtsToPayload` in multiple test files so that local user TTS preferences (e.g. `~/.openclaw/settings/tts.json` with `auto: "always"`) can’t cause tests to generate real audio and switch reply delivery into the media path.

The mock is applied at the test level (`vi.mock("../tts/tts.js", …)`), preserving the rest of the TTS module while forcing `maybeApplyTtsToPayload` to behave as a passthrough. This keeps reply assertions stable across environments where `$HOME` and `CONFIG_DIR` would otherwise resolve before tests can isolate them.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are isolated to test files and consistently mock the same TTS entrypoint used by production imports (`../tts/tts.js`), preventing environment-dependent side effects without altering runtime behavior.
- No files require special attention

<sub>Last reviewed commit: b1cf2e6</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->