### PR TITLE
agents: add always mode for context pruning

### DIFF
--- a/docs/concepts/session-pruning.md
+++ b/docs/concepts/session-pruning.md
@@ -12,11 +12,12 @@ Session pruning trims **old tool results** from the in-memory context right befo
 
 ## When it runs
 
-- When `mode: "cache-ttl"` is enabled and the last Anthropic call for the session is older than `ttl`.
+- When `mode: "always"` is enabled, pruning runs before every LLM call.
+- When `mode: "cache-ttl"` is enabled, pruning runs only when the last Anthropic call for the session is older than `ttl`.
 - Only affects the messages sent to the model for that request.
-- Only active for Anthropic API calls (and OpenRouter Anthropic models).
-- For best results, match `ttl` to your model `cacheControlTtl`.
-- After a prune, the TTL window resets so subsequent requests keep cache until `ttl` expires again.
+- `cache-ttl` is only active for Anthropic API calls (and OpenRouter Anthropic models).
+- For `cache-ttl`, match `ttl` to your model `cacheControlTtl` where possible.
+- After a `cache-ttl` prune, the TTL window resets so subsequent requests keep cache until `ttl` expires again.
 
 ## Smart defaults (Anthropic)
 
@@ -50,6 +51,12 @@ Pruning uses an estimated context window (chars ≈ tokens × 4). The base windo
 If `agents.defaults.contextTokens` is set, it is treated as a cap (min) on the resolved window.
 
 ## Mode
+
+### always
+
+- Provider-agnostic mode for continuous context pressure control.
+- Pruning logic is the same (soft-trim first, then optional hard-clear), but it runs on every request.
+- Recommended when you want predictable token control across providers that do not use Anthropic cache semantics.
 
 ### cache-ttl
 
@@ -103,6 +110,16 @@ Enable TTL-aware pruning:
 {
   agent: {
     contextPruning: { mode: "cache-ttl", ttl: "5m" },
+  },
+}
+```
+
+Enable provider-agnostic pruning on every request:
+
+```json5
+{
+  agent: {
+    contextPruning: { mode: "always" },
   },
 }
 ```

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -753,7 +753,7 @@ Prunes **old tool results** from in-memory context before sending to the LLM. Do
   agents: {
     defaults: {
       contextPruning: {
-        mode: "cache-ttl", // off | cache-ttl
+        mode: "cache-ttl", // off | always | cache-ttl
         ttl: "1h", // duration (ms/s/m/h), default unit: minutes
         keepLastAssistants: 3,
         softTrimRatio: 0.3,
@@ -783,6 +783,20 @@ Notes:
 - Image blocks are never trimmed/cleared.
 - Ratios are character-based (approximate), not exact token counts.
 - If fewer than `keepLastAssistants` assistant messages exist, pruning is skipped.
+
+</Accordion>
+
+<Accordion title="always mode behavior">
+
+- `mode: "always"` enables pruning passes on every request.
+- Uses the same soft-trim + hard-clear logic as `cache-ttl`.
+- `ttl` is ignored in this mode.
+
+Notes:
+
+- Useful for non-Anthropic providers (for example MiniMax/OpenAI-compatible endpoints) when you need steady context pressure control.
+- Image blocks are never trimmed/cleared.
+- Ratios are character-based (approximate), not exact token counts.
 
 </Accordion>
 

--- a/docs/pi.md
+++ b/docs/pi.md
@@ -388,10 +388,13 @@ if (resolveCompactionMode(params.cfg) === "safeguard") {
 
 ### Context Pruning
 
-`pi-extensions/context-pruning.ts` implements cache-TTL based context pruning:
+`pi-extensions/context-pruning.ts` implements context pruning modes (`always` and `cache-ttl`):
 
 ```typescript
-if (cfg?.agents?.defaults?.contextPruning?.mode === "cache-ttl") {
+if (
+  cfg?.agents?.defaults?.contextPruning?.mode === "always" ||
+  cfg?.agents?.defaults?.contextPruning?.mode === "cache-ttl"
+) {
   setContextPruningRuntime(params.sessionManager, {
     settings,
     contextWindowTokens,

--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -43,10 +43,11 @@ function buildContextPruningExtension(params: {
   model: Model<Api> | undefined;
 }): { additionalExtensionPaths?: string[] } {
   const raw = params.cfg?.agents?.defaults?.contextPruning;
-  if (raw?.mode !== "cache-ttl") {
+  const mode = raw?.mode;
+  if (mode !== "cache-ttl" && mode !== "always") {
     return {};
   }
-  if (!isCacheTtlEligibleProvider(params.provider, params.modelId)) {
+  if (mode === "cache-ttl" && !isCacheTtlEligibleProvider(params.provider, params.modelId)) {
     return {};
   }
 
@@ -59,7 +60,8 @@ function buildContextPruningExtension(params: {
     settings,
     contextWindowTokens: resolveContextWindowTokens(params),
     isToolPrunable: makeToolPrunablePredicate(settings.tools),
-    lastCacheTouchAt: readLastCacheTtlTimestamp(params.sessionManager),
+    lastCacheTouchAt:
+      mode === "cache-ttl" ? readLastCacheTtlTimestamp(params.sessionManager) : undefined,
   });
 
   return {

--- a/src/agents/pi-extensions/context-pruning.test.ts
+++ b/src/agents/pi-extensions/context-pruning.test.ts
@@ -403,7 +403,6 @@ describe("context-pruning", () => {
       },
       contextWindowTokens: 1000,
       isToolPrunable: () => true,
-      lastCacheTouchAt: Date.now(),
     });
 
     const messages: AgentMessage[] = [

--- a/src/agents/pi-extensions/context-pruning/settings.ts
+++ b/src/agents/pi-extensions/context-pruning/settings.ts
@@ -4,7 +4,7 @@ export type ContextPruningToolMatch = {
   allow?: string[];
   deny?: string[];
 };
-export type ContextPruningMode = "off" | "cache-ttl";
+export type ContextPruningMode = "off" | "cache-ttl" | "always";
 
 export type ContextPruningConfig = {
   mode?: ContextPruningMode;
@@ -69,7 +69,7 @@ export function computeEffectiveSettings(raw: unknown): EffectiveContextPruningS
     return null;
   }
   const cfg = raw as ContextPruningConfig;
-  if (cfg.mode !== "cache-ttl") {
+  if (cfg.mode !== "cache-ttl" && cfg.mode !== "always") {
     return null;
   }
 

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -26,7 +26,7 @@ export type AgentModelListConfig = {
 };
 
 export type AgentContextPruningConfig = {
-  mode?: "off" | "cache-ttl";
+  mode?: "off" | "cache-ttl" | "always";
   /** TTL to consider cache expired (duration string, default unit: minutes). */
   ttl?: string;
   keepLastAssistants?: number;

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -57,7 +57,7 @@ export const AgentDefaultsSchema = z
     memorySearch: MemorySearchSchema,
     contextPruning: z
       .object({
-        mode: z.union([z.literal("off"), z.literal("cache-ttl")]).optional(),
+        mode: z.union([z.literal("off"), z.literal("cache-ttl"), z.literal("always")]).optional(),
         ttl: z.string().optional(),
         keepLastAssistants: z.number().int().nonnegative().optional(),
         softTrimRatio: z.number().min(0).max(1).optional(),


### PR DESCRIPTION
## Summary
- add `agents.defaults.contextPruning.mode: "always"` as a provider-agnostic mode
- keep existing `cache-ttl` behavior unchanged (still Anthropic/OpenRouter Anthropic scoped)
- wire the new mode through runtime settings, config types, and zod schema
- document the new mode in session pruning + configuration reference + Pi docs

## Why
`cache-ttl` is optimized for Anthropic cache semantics. For providers that do not share those semantics (for example MiniMax/OpenAI-compatible endpoints), operators still need steady context pressure control. `always` enables the same pruning logic on every request without changing `cache-ttl` defaults.

## Tests
- `pnpm vitest src/agents/pi-extensions/context-pruning.test.ts src/config/config.pruning-defaults.test.ts --run`
- `pnpm check`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces a new provider-agnostic context pruning mode (`agents.defaults.contextPruning.mode: "always"`) that runs the existing pruning logic before every LLM call, while keeping the existing `cache-ttl` behavior scoped to Anthropic/OpenRouter Anthropic. The change is wired through config types + zod schema, the embedded runner’s extension activation logic, and updated docs describing the new mode and its semantics (including `ttl` being ignored in always mode).

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge after fixing a small test fixture mismatch.
- Core runtime wiring for the new `always` mode is consistent (extension activates for always/cache-ttl, cache-ttl eligibility gating remains, and TTL checks run only in cache-ttl mode). The only issue found is in tests: the always-mode test passes `lastCacheTouchAt` even though production does not, which can hide regressions.
- src/agents/pi-extensions/context-pruning.test.ts

<sub>Last reviewed commit: 4b27cef</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->