### PR TITLE
tui: recover local no-output runs via history fallback

### DIFF
--- a/src/tui/tui-formatters.test.ts
+++ b/src/tui/tui-formatters.test.ts
@@ -4,6 +4,8 @@ import {
   extractTextFromMessage,
   extractThinkingFromMessage,
   isCommandMessage,
+  isNoOutputAssistantText,
+  resolveFinalAssistantText,
 } from "./tui-formatters.js";
 
 describe("extractTextFromMessage", () => {
@@ -104,5 +106,18 @@ describe("isCommandMessage", () => {
     expect(isCommandMessage({ command: true })).toBe(true);
     expect(isCommandMessage({ command: false })).toBe(false);
     expect(isCommandMessage({})).toBe(false);
+  });
+});
+
+describe("resolveFinalAssistantText", () => {
+  it("falls back to no-output placeholder when both final and streamed are empty", () => {
+    expect(resolveFinalAssistantText({ finalText: "", streamedText: "" })).toBe("(no output)");
+  });
+});
+
+describe("isNoOutputAssistantText", () => {
+  it("detects the no-output placeholder", () => {
+    expect(isNoOutputAssistantText("(no output)")).toBe(true);
+    expect(isNoOutputAssistantText(" done ")).toBe(false);
   });
 });

--- a/src/tui/tui-formatters.ts
+++ b/src/tui/tui-formatters.ts
@@ -1,6 +1,8 @@
 import { formatRawAssistantErrorForUi } from "../agents/pi-embedded-helpers.js";
 import { formatTokenCount } from "../utils/usage-format.js";
 
+export const NO_OUTPUT_PLACEHOLDER = "(no output)";
+
 export function resolveFinalAssistantText(params: {
   finalText?: string | null;
   streamedText?: string | null;
@@ -13,7 +15,11 @@ export function resolveFinalAssistantText(params: {
   if (streamedText.trim()) {
     return streamedText;
   }
-  return "(no output)";
+  return NO_OUTPUT_PLACEHOLDER;
+}
+
+export function isNoOutputAssistantText(text?: string | null): boolean {
+  return (text ?? "").trim() === NO_OUTPUT_PLACEHOLDER;
 }
 
 export function composeThinkingAndContent(params: {


### PR DESCRIPTION
#### Summary
Fixes a TUI reliability bug where local runs can finalize as `(no output)` even though assistant text is persisted shortly after.

Code word: lobster-biscuit

#### Repro Steps
Related reports:
- https://github.com/openclaw/openclaw/issues/4499
- https://github.com/openclaw/openclaw/issues/15432

1. Start `openclaw tui` with a provider/model that intermittently emits empty `chat.final` payload text.
2. Trigger a run that finishes with `(no output)` in TUI.
3. Reopen/reconnect TUI and observe assistant text appears from history.

#### Root Cause
`chat.final` can occasionally arrive without renderable assistant text while transcript persistence catches up moments later. TUI currently finalizes immediately and never retries history for local runs, so users see `(no output)` until reconnect.

#### Behavior Changes
- For **local runs only**, if final text resolves to `(no output)` and stopReason is not `error`, schedule two short history refresh retries (200ms, 1000ms).
- Keep existing behavior unchanged for non-local runs and for runs with valid final output.
- Centralize no-output placeholder handling in formatter helpers.

#### Codebase and GitHub Search
- Code paths searched:
  - `src/tui/tui-event-handlers.ts`
  - `src/tui/tui-stream-assembler.ts`
  - `src/tui/tui-formatters.ts`
- Issue search checked:
  - #4499 (`MiniMax responses show '(no output)' until TUI restart`)
  - #15432 (`[Bug]: no output`)

#### Tests
- `pnpm vitest src/tui/tui-event-handlers.test.ts src/tui/tui-formatters.test.ts --run`
- `pnpm check`

#### Manual Testing
### Prerequisites
- A TUI session connected to gateway.

### Steps
1. Run a local TUI conversation where a final event may be empty.
2. Confirm TUI schedules short history fallback and self-recovers without restart.
3. Confirm normal final outputs still render once with no extra history churn.

#### Evidence
- Added targeted test: local final `(no output)` triggers 2 history retries in `src/tui/tui-event-handlers.test.ts`.

**Sign-Off**
- Models used: GPT-5 Codex
- Submitter effort (self-reported): High
- Agent notes (optional, cite evidence): Local targeted tests + lint/type checks passed.
