### PR TITLE
docs(web_fetch): document markdown-first Accept header and cf-markdown extraction

### DIFF
--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -254,6 +254,7 @@ Notes:
 - Enable via `tools.web.fetch.enabled`.
 - `maxChars` is clamped by `tools.web.fetch.maxCharsCap` (default 50000).
 - Responses are cached (default 15 min).
+- Requests prefer markdown with `Accept: text/markdown, text/html;q=0.9, */*;q=0.1`.
 - For JS-heavy sites, prefer the browser tool.
 - See [Web tools](/tools/web) for setup.
 - See [Firecrawl](/tools/firecrawl) for the optional anti-bot fallback.

--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -249,9 +249,10 @@ Fetch a URL and extract readable content.
 
 Notes:
 
-- `web_fetch` uses Readability (main-content extraction) first, then Firecrawl (if configured). If both fail, the tool returns an error.
+- `web_fetch` uses `cf-markdown` extraction when the response is `text/markdown`; otherwise it uses Readability (main-content extraction) first, then Firecrawl (if configured). If all extraction paths fail, the tool returns an error.
 - Firecrawl requests use bot-circumvention mode and cache results by default.
 - `web_fetch` sends a Chrome-like User-Agent and `Accept-Language` by default; override `userAgent` if needed.
+- `web_fetch` also sends `Accept: text/markdown, text/html;q=0.9, */*;q=0.1` so services like Cloudflare Markdown for Agents can return markdown directly.
 - `web_fetch` blocks private/internal hostnames and re-checks redirects (limit with `maxRedirects`).
 - `maxChars` is clamped to `tools.web.fetch.maxCharsCap`.
 - `web_fetch` is best-effort extraction; some sites will need the browser tool.


### PR DESCRIPTION
Docs follow-up for recent web_fetch markdown handling changes.

This updates docs to clarify:
- web_fetch sends markdown-first Accept header:
  `text/markdown, text/html;q=0.9, */*;q=0.1`
- text/markdown responses use the `cf-markdown` extraction path

Updated files:
- docs/tools/web.md
- docs/tools/index.md

No code changes; documentation-only PR.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR is a documentation-only follow-up clarifying `web_fetch`’s markdown-first `Accept` header (`text/markdown, text/html;q=0.9, */*;q=0.1`) and that `text/markdown` responses use the `cf-markdown` extraction path.

The docs match the implementation in `src/agents/tools/web-fetch.ts` for the `Accept` header and `text/markdown` handling. One note in `docs/tools/web.md` overstates when `web_fetch` errors: for other content types the tool can return the raw body (`extractor: "raw"`) rather than failing extraction.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge after a small docs precision fix.
- Changes are documentation-only and align with the current `web_fetch` implementation for the markdown-first Accept header and `cf-markdown` extractor. The only issue found is a slightly misleading error-condition sentence in the web_fetch notes section.
- docs/tools/web.md

<sub>Last reviewed commit: 7339d66</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->