### PR TITLE
fix(discord): resolve numeric channelId in guildId/channelId allowlist entries

### DIFF
--- a/src/discord/resolve-channels.ts
+++ b/src/discord/resolve-channels.ts
@@ -66,6 +66,12 @@ function parseDiscordChannelInput(raw: string): {
       return guild ? { guild: guild.trim(), guildOnly: true } : {};
     }
     if (guild && /^\d+$/.test(guild)) {
+      // When both parts are numeric (e.g. "guildId/channelId"), treat
+      // the second part as a channel ID so it resolves via REST lookup
+      // instead of name-based matching (fixes #15532).
+      if (/^\d+$/.test(channel)) {
+        return { guildId: guild, channelId: channel };
+      }
       return { guildId: guild, channel };
     }
     return { guild, channel };


### PR DESCRIPTION
## Summary

Fixes #15532

When `guilds` config uses numeric channel IDs in the allowlist:

```json
"guilds": {
  "1457738053895328004": {
    "channels": {
      "1471863670718857247": { "allow": true }
    }
  }
}
```

`parseDiscordChannelInput()` parsed the channel ID as a channel **name**, causing name-based matching to always fail. Channels remained permanently "unresolved" and all inbound messages were silently dropped.

## Changes

**`src/discord/resolve-channels.ts`**
- Added numeric check for the second part of `guildId/channelId` pairs
- When both parts are numeric, returns `{ guildId, channelId }` instead of `{ guildId, channel }`
- This routes to the `fetchChannel()` REST API lookup path, which correctly resolves the channel

**`src/discord/resolve-channels.test.ts`**
- Added test case for numeric `guildId/channelId` resolution

## Testing

- All 3 tests pass (2 existing + 1 new)
- Verified the bug by inspecting gateway logs showing `channels unresolved` for valid, accessible channels
- Confirmed workaround (`groupPolicy: "open"`) works as expected

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts Discord allowlist parsing so `guildId/channelId` entries where both parts are numeric are treated as IDs (`{ guildId, channelId }`) rather than a guild ID + channel *name*. That routes these entries through the existing REST `/channels/:id` lookup path, preventing channels from remaining unresolved and messages being dropped. A new Vitest case covers the numeric `guildId/channelId` scenario.


<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but error handling around REST channel lookups needs tightening to avoid aborting resolution on bad entries.
- The parsing change is small and targeted and the added test covers the reported regression. Main risk is that REST lookup errors (404/403/429) can currently throw and fail the entire allowlist resolution call instead of producing an unresolved entry, which can turn a single misconfigured allowlist entry into a hard failure.
- src/discord/resolve-channels.ts

<sub>Last reviewed commit: fa5bcd6</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->