### PR TITLE
feat(channels): cross-channel awareness + conversation context

### DIFF
--- a/src/channels/conversation-context.ts
+++ b/src/channels/conversation-context.ts
@@ -1,0 +1,179 @@
+/**
+ * Level 102: 對話脈絡檢查
+ *
+ * 在消息因為沒有 @mention 而即將被跳過時，檢查是否在活躍對話中。
+ * 如果是，則覆蓋跳過決定，允許消息被處理。
+ */
+
+import { existsSync } from "fs";
+import { resolve } from "path";
+
+// Time Tunnel 查詢模塊的路徑（容器內）
+const TIME_TUNNEL_QUERY_PATH = "/app/workspace/hooks/time-tunnel/query.js";
+
+// 緩存導入的模塊
+let timeTunnelModule: {
+  getConversationState: (
+    chatId: string,
+    channel?: string,
+  ) => {
+    isActive: boolean;
+    minutesSinceReply?: number;
+    lastReplyTo?: string;
+    lastTopic?: string;
+  };
+  quickJudge: (params: {
+    chatId: string;
+    channel?: string;
+    newMessage: string;
+    sender: string;
+  }) => {
+    shouldRespond: boolean;
+    judgment: string;
+    confidence: number;
+    reasoning: string;
+  };
+  judgeConversation: (params: {
+    chatId: string;
+    channel?: string;
+    newMessage: string;
+    sender: string;
+  }) => Promise<{
+    shouldRespond: boolean;
+    judgment: string;
+    confidence: number;
+    reasoning: string;
+    method: string;
+    latencyMs: number;
+  }>;
+} | null = null;
+
+/**
+ * 動態載入 Time Tunnel 模塊
+ */
+async function loadTimeTunnelModule() {
+  if (timeTunnelModule) {
+    return timeTunnelModule;
+  }
+
+  try {
+    // 檢查文件是否存在
+    if (!existsSync(TIME_TUNNEL_QUERY_PATH)) {
+      console.log("[conversation-context] Time Tunnel module not found, skipping");
+      return null;
+    }
+
+    // 動態導入
+    const module = await import(TIME_TUNNEL_QUERY_PATH);
+    timeTunnelModule = {
+      getConversationState: module.getConversationState,
+      quickJudge: module.quickJudge,
+      judgeConversation: module.judgeConversation,
+    };
+
+    console.log("[conversation-context] Time Tunnel module loaded successfully");
+    return timeTunnelModule;
+  } catch (err) {
+    console.error("[conversation-context] Failed to load Time Tunnel module:", err);
+    return null;
+  }
+}
+
+export type ConversationContextResult = {
+  shouldRespond: boolean;
+  reason: string;
+  method: "conversation-context" | "disabled" | "not-active" | "error";
+  confidence?: number;
+  latencyMs?: number;
+};
+
+/**
+ * 檢查對話脈絡，決定是否應該回應
+ *
+ * @param chatId - 群組/聊天 ID（支援帶前綴格式如 "telegram:-5262004625"）
+ * @param message - 消息內容
+ * @param senderId - 發送者 ID
+ * @param senderName - 發送者名稱
+ * @param channel - 頻道類型
+ * @param useLLM - 是否使用 LLM 判斷（預設 false，使用快速規則）
+ */
+export async function checkConversationContext(
+  chatId: string | number,
+  message: string,
+  senderId?: string | number,
+  senderName?: string,
+  channel: string = "telegram",
+  useLLM: boolean = false,
+): Promise<ConversationContextResult> {
+  const startTime = Date.now();
+
+  try {
+    const module = await loadTimeTunnelModule();
+    if (!module) {
+      return {
+        shouldRespond: false,
+        reason: "Time Tunnel 模塊未載入",
+        method: "disabled",
+      };
+    }
+
+    // 清理 chatId（去除 channel 前綴）
+    const cleanChatId = String(chatId).replace(/^[a-z]+:/, "");
+
+    // 1. 先檢查對話狀態
+    const state = module.getConversationState(cleanChatId, channel);
+
+    if (!state.isActive) {
+      return {
+        shouldRespond: false,
+        reason: "不在活躍對話中",
+        method: "not-active",
+      };
+    }
+
+    // 2. 使用規則或 LLM 判斷
+    const sender = senderName || String(senderId) || "unknown";
+
+    if (useLLM) {
+      // 使用 LLM 判斷（較慢但更準確）
+      const result = await module.judgeConversation({
+        chatId: cleanChatId,
+        channel,
+        newMessage: message,
+        sender,
+      });
+
+      return {
+        shouldRespond: result.shouldRespond,
+        reason: result.reasoning,
+        method: "conversation-context",
+        confidence: result.confidence,
+        latencyMs: Date.now() - startTime,
+      };
+    } else {
+      // 使用快速規則判斷
+      const result = module.quickJudge({
+        chatId: cleanChatId,
+        channel,
+        newMessage: message,
+        sender,
+      });
+
+      return {
+        shouldRespond: result.shouldRespond,
+        reason: result.reasoning,
+        method: "conversation-context",
+        confidence: result.confidence,
+        latencyMs: Date.now() - startTime,
+      };
+    }
+  } catch (err) {
+    console.error("[conversation-context] Error checking conversation context:", err);
+    return {
+      shouldRespond: false,
+      reason: `檢查失敗: ${err instanceof Error ? err.message : String(err)}`,
+      method: "error",
+      latencyMs: Date.now() - startTime,
+    };
+  }
+}

--- a/src/channels/cross-channel-context.test.ts
+++ b/src/channels/cross-channel-context.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { formatElapsed } from "./cross-channel-context.js";
+
+// ---------------------------------------------------------------------------
+// formatElapsed
+// ---------------------------------------------------------------------------
+
+describe("formatElapsed", () => {
+  it("returns 'just now' for timestamps less than 1 minute ago", () => {
+    const now = new Date().toISOString();
+    expect(formatElapsed(now)).toBe("just now");
+  });
+
+  it("returns minutes for timestamps < 60 minutes ago", () => {
+    const fiveMinAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+    expect(formatElapsed(fiveMinAgo)).toBe("5m ago");
+  });
+
+  it("returns hours and minutes for timestamps >= 60 minutes ago", () => {
+    const ninetyMinAgo = new Date(Date.now() - 90 * 60 * 1000).toISOString();
+    expect(formatElapsed(ninetyMinAgo)).toBe("1h30m ago");
+  });
+
+  it("handles exactly 1 hour", () => {
+    const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    expect(formatElapsed(oneHourAgo)).toBe("1h0m ago");
+  });
+
+  it("handles multi-hour timestamps", () => {
+    const threeHoursAgo = new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString();
+    expect(formatElapsed(threeHoursAgo)).toBe("3h0m ago");
+  });
+
+  it("returns 'just now' for timestamp 30 seconds ago", () => {
+    const thirtySecAgo = new Date(Date.now() - 30 * 1000).toISOString();
+    expect(formatElapsed(thirtySecAgo)).toBe("just now");
+  });
+
+  it("returns '1m ago' for timestamp exactly 1 minute ago", () => {
+    const oneMinAgo = new Date(Date.now() - 60 * 1000).toISOString();
+    expect(formatElapsed(oneMinAgo)).toBe("1m ago");
+  });
+});

--- a/src/channels/cross-channel-context.ts
+++ b/src/channels/cross-channel-context.ts
@@ -1,0 +1,117 @@
+/**
+ * Level 105: Cross-channel context awareness
+ *
+ * Queries Time Tunnel for recent messages from OTHER channels handled by
+ * the same agent, so the agent can see what was discussed elsewhere.
+ */
+
+import { existsSync } from "fs";
+
+const TIME_TUNNEL_QUERY_PATH = "/app/workspace/hooks/time-tunnel/query.js";
+
+let timeTunnelModule: {
+  getCrossChannelContext: (params: {
+    agentId: string;
+    currentChannel: string;
+    minutesBack?: number;
+    limit?: number;
+  }) => Array<{
+    timestamp: string;
+    channel: string;
+    direction: string;
+    sender: string;
+    content: string;
+  }>;
+} | null = null;
+
+async function loadModule() {
+  if (timeTunnelModule) {
+    return timeTunnelModule;
+  }
+
+  try {
+    if (!existsSync(TIME_TUNNEL_QUERY_PATH)) {
+      return null;
+    }
+
+    const mod = await import(TIME_TUNNEL_QUERY_PATH);
+    if (typeof mod.getCrossChannelContext !== "function") {
+      console.log("[cross-channel] getCrossChannelContext not found in Time Tunnel module");
+      return null;
+    }
+
+    timeTunnelModule = { getCrossChannelContext: mod.getCrossChannelContext };
+    console.log("[cross-channel] Time Tunnel module loaded");
+    return timeTunnelModule;
+  } catch (err) {
+    console.error("[cross-channel] Failed to load Time Tunnel module:", err);
+    return null;
+  }
+}
+
+export function formatElapsed(isoTimestamp: string): string {
+  const diffMs = Date.now() - new Date(isoTimestamp).getTime();
+  const mins = Math.floor(diffMs / 60000);
+  if (mins < 1) {
+    return "just now";
+  }
+  if (mins < 60) {
+    return `${mins}m ago`;
+  }
+  const hours = Math.floor(mins / 60);
+  return `${hours}h${mins % 60}m ago`;
+}
+
+/**
+ * Build a text block of recent messages from other channels for the same agent.
+ * Returns null if no cross-channel messages found or module unavailable.
+ */
+export async function buildCrossChannelContext(params: {
+  currentChannel: string;
+  agentId?: string;
+  minutesBack?: number;
+  messageLimit?: number;
+}): Promise<string | null> {
+  const { currentChannel, agentId, minutesBack = 30, messageLimit = 10 } = params;
+
+  if (!agentId) {
+    return null;
+  }
+
+  try {
+    const mod = await loadModule();
+    if (!mod) {
+      return null;
+    }
+
+    const messages = mod.getCrossChannelContext({
+      agentId,
+      currentChannel,
+      minutesBack,
+      limit: messageLimit,
+    });
+
+    if (!messages || messages.length === 0) {
+      return null;
+    }
+
+    const lines = messages.map((msg) => {
+      const elapsed = formatElapsed(msg.timestamp);
+      const channel = msg.channel?.toUpperCase() || "OTHER";
+      const sender = msg.direction === "outbound" ? "You replied" : msg.sender || "unknown";
+      const content = (msg.content || "").substring(0, 300);
+      return `[${channel} ${elapsed}] ${sender}: ${content}`;
+    });
+
+    console.log(`[cross-channel] Injecting ${messages.length} messages from other channels`);
+
+    return [
+      "[Recent activity on other channels]",
+      ...lines,
+      "[/Recent activity on other channels]",
+    ].join("\n");
+  } catch (err) {
+    console.error("[cross-channel] Error building context:", err);
+    return null;
+  }
+}

--- a/src/channels/plugins/group-mentions.test.ts
+++ b/src/channels/plugins/group-mentions.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeDiscordSlug,
+  normalizeSlackSlug,
+  parseTelegramGroupId,
+} from "./group-mentions.js";
+
+// ---------------------------------------------------------------------------
+// normalizeDiscordSlug
+// ---------------------------------------------------------------------------
+
+describe("normalizeDiscordSlug", () => {
+  it("returns empty string for null/undefined/empty", () => {
+    expect(normalizeDiscordSlug(null)).toBe("");
+    expect(normalizeDiscordSlug(undefined)).toBe("");
+    expect(normalizeDiscordSlug("")).toBe("");
+    expect(normalizeDiscordSlug("   ")).toBe("");
+  });
+
+  it("lowercases input", () => {
+    expect(normalizeDiscordSlug("General")).toBe("general");
+    expect(normalizeDiscordSlug("MY-CHANNEL")).toBe("my-channel");
+  });
+
+  it("strips leading @ and # characters", () => {
+    expect(normalizeDiscordSlug("#general")).toBe("general");
+    expect(normalizeDiscordSlug("##general")).toBe("general");
+    expect(normalizeDiscordSlug("@user")).toBe("user");
+  });
+
+  it("converts spaces and underscores to dashes", () => {
+    expect(normalizeDiscordSlug("my channel")).toBe("my-channel");
+    expect(normalizeDiscordSlug("my_channel")).toBe("my-channel");
+    expect(normalizeDiscordSlug("my  channel")).toBe("my-channel");
+  });
+
+  it("removes non-alphanumeric characters (except dashes)", () => {
+    expect(normalizeDiscordSlug("hello!world")).toBe("hello-world");
+    expect(normalizeDiscordSlug("a&b*c")).toBe("a-b-c");
+  });
+
+  it("collapses multiple dashes and trims edge dashes", () => {
+    expect(normalizeDiscordSlug("--hello--world--")).toBe("hello-world");
+    expect(normalizeDiscordSlug("a---b")).toBe("a-b");
+  });
+
+  it("handles typical Discord channel names", () => {
+    expect(normalizeDiscordSlug("#🎮-gaming-chat")).toBe("gaming-chat");
+    expect(normalizeDiscordSlug("dev-ops")).toBe("dev-ops");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeSlackSlug
+// ---------------------------------------------------------------------------
+
+describe("normalizeSlackSlug", () => {
+  it("returns empty string for null/undefined/empty", () => {
+    expect(normalizeSlackSlug(null)).toBe("");
+    expect(normalizeSlackSlug(undefined)).toBe("");
+    expect(normalizeSlackSlug("")).toBe("");
+    expect(normalizeSlackSlug("   ")).toBe("");
+  });
+
+  it("lowercases input", () => {
+    expect(normalizeSlackSlug("General")).toBe("general");
+  });
+
+  it("converts spaces to dashes", () => {
+    expect(normalizeSlackSlug("my channel")).toBe("my-channel");
+    expect(normalizeSlackSlug("a  b")).toBe("a-b");
+  });
+
+  it("preserves Slack-valid chars: #, @, ., +, _", () => {
+    expect(normalizeSlackSlug("#general")).toBe("#general");
+    expect(normalizeSlackSlug("@user")).toBe("@user");
+    expect(normalizeSlackSlug("dev.ops")).toBe("dev.ops");
+    expect(normalizeSlackSlug("c++")).toBe("c++");
+    expect(normalizeSlackSlug("my_channel")).toBe("my_channel");
+  });
+
+  it("removes invalid characters", () => {
+    expect(normalizeSlackSlug("hello!world")).toBe("hello-world");
+    expect(normalizeSlackSlug("a&b")).toBe("a-b");
+  });
+
+  it("collapses multiple dashes and trims edge dashes/dots", () => {
+    expect(normalizeSlackSlug("--hello--")).toBe("hello");
+    expect(normalizeSlackSlug("..hello..")).toBe("hello");
+    expect(normalizeSlackSlug("-.hello.-")).toBe("hello");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseTelegramGroupId
+// ---------------------------------------------------------------------------
+
+describe("parseTelegramGroupId", () => {
+  it("returns undefined chatId/topicId for null/undefined/empty", () => {
+    expect(parseTelegramGroupId(null)).toEqual({ chatId: undefined, topicId: undefined });
+    expect(parseTelegramGroupId(undefined)).toEqual({ chatId: undefined, topicId: undefined });
+    expect(parseTelegramGroupId("")).toEqual({ chatId: undefined, topicId: undefined });
+    expect(parseTelegramGroupId("   ")).toEqual({ chatId: undefined, topicId: undefined });
+  });
+
+  it("parses plain chat ID (no topic)", () => {
+    expect(parseTelegramGroupId("-1001234567890")).toEqual({
+      chatId: "-1001234567890",
+      topicId: undefined,
+    });
+  });
+
+  it("parses chatId:topicId format", () => {
+    expect(parseTelegramGroupId("-100123:456")).toEqual({
+      chatId: "-100123",
+      topicId: "456",
+    });
+  });
+
+  it("parses chatId:topic:topicId format", () => {
+    expect(parseTelegramGroupId("-100123:topic:789")).toEqual({
+      chatId: "-100123",
+      topicId: "789",
+    });
+  });
+
+  it("prefers :topic: format over plain two-part", () => {
+    // When three+ parts with :topic: marker, uses that parser branch
+    expect(parseTelegramGroupId("-100123:topic:42")).toEqual({
+      chatId: "-100123",
+      topicId: "42",
+    });
+  });
+
+  it("returns raw as chatId for non-numeric input", () => {
+    expect(parseTelegramGroupId("my-group")).toEqual({
+      chatId: "my-group",
+      topicId: undefined,
+    });
+  });
+
+  it("handles positive chat IDs", () => {
+    expect(parseTelegramGroupId("12345")).toEqual({
+      chatId: "12345",
+      topicId: undefined,
+    });
+  });
+
+  it("handles positive chatId:topicId", () => {
+    expect(parseTelegramGroupId("12345:99")).toEqual({
+      chatId: "12345",
+      topicId: "99",
+    });
+  });
+});

--- a/src/channels/plugins/group-mentions.ts
+++ b/src/channels/plugins/group-mentions.ts
@@ -23,7 +23,7 @@ type GroupMentionParams = {
   senderE164?: string | null;
 };
 
-function normalizeDiscordSlug(value?: string | null) {
+export function normalizeDiscordSlug(value?: string | null) {
   if (!value) {
     return "";
   }
@@ -38,7 +38,7 @@ function normalizeDiscordSlug(value?: string | null) {
   return text;
 }
 
-function normalizeSlackSlug(raw?: string | null) {
+export function normalizeSlackSlug(raw?: string | null) {
   const trimmed = raw?.trim().toLowerCase() ?? "";
   if (!trimmed) {
     return "";
@@ -48,7 +48,7 @@ function normalizeSlackSlug(raw?: string | null) {
   return cleaned.replace(/-{2,}/g, "-").replace(/^[-.]+|[-.]+$/g, "");
 }
 
-function parseTelegramGroupId(value?: string | null) {
+export function parseTelegramGroupId(value?: string | null) {
   const raw = value?.trim() ?? "";
   if (!raw) {
     return { chatId: undefined, topicId: undefined };

--- a/src/line/sender-name-cache.ts
+++ b/src/line/sender-name-cache.ts
@@ -1,0 +1,170 @@
+/**
+ * LINE Sender Name Cache — 從本地快取解析 LINE userId → 顯示名稱
+ *
+ * 優先級：
+ *   1. 記憶體快取（5 分鐘 TTL）
+ *   2. 本地 JSON 檔（line-profile-cache.json）
+ *   3. LINE API fallback（getUserProfile，自動回寫 JSON）
+ *   4. fallback → undefined（讓上層用 userId）
+ *
+ * 快取檔案位置：workspace/references/line-profile-cache.json
+ * 格式：{ [groupId]: { [userId]: displayName } }
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { logVerbose } from "../globals.js";
+
+type ProfileCache = Record<string, Record<string, string>>;
+
+let _cache: ProfileCache | null = null;
+let _cacheLoadedAt = 0;
+const CACHE_RELOAD_INTERVAL = 5 * 60 * 1000; // 每 5 分鐘重新讀取 JSON
+
+// API fallback 的 pending 追蹤（避免同一 userId 同時多次打 API）
+const _pendingLookups = new Set<string>();
+
+function resolveCachePath(): string | null {
+  const candidates = [
+    path.resolve(process.cwd(), "workspace/references/line-profile-cache.json"),
+    path.resolve(
+      process.env.HOME ?? "/root",
+      ".openclaw/workspace/references/line-profile-cache.json",
+    ),
+  ];
+  for (const p of candidates) {
+    try {
+      fs.accessSync(path.dirname(p));
+      return p;
+    } catch {
+      // 繼續
+    }
+  }
+  return candidates[0]; // fallback 用第一個
+}
+
+function loadCache(): ProfileCache {
+  const now = Date.now();
+  if (_cache && now - _cacheLoadedAt < CACHE_RELOAD_INTERVAL) {
+    return _cache;
+  }
+
+  const cachePath = resolveCachePath();
+  if (cachePath) {
+    try {
+      const raw = fs.readFileSync(cachePath, "utf-8");
+      _cache = JSON.parse(raw) as ProfileCache;
+      _cacheLoadedAt = now;
+      logVerbose(`line: loaded sender name cache from ${cachePath}`);
+      return _cache;
+    } catch {
+      // 檔案不存在或壞掉
+    }
+  }
+
+  _cache = {};
+  _cacheLoadedAt = now;
+  return _cache;
+}
+
+/**
+ * 將新的 userId → displayName 寫入快取（記憶體 + 檔案）
+ */
+function writeToCache(userId: string, displayName: string, groupId?: string): void {
+  const cache = loadCache();
+  const key = groupId ?? "_direct";
+
+  if (!cache[key]) {
+    cache[key] = {};
+  }
+  cache[key][userId] = displayName;
+
+  // 寫回 JSON 檔案（非同步，不阻塞）
+  const cachePath = resolveCachePath();
+  if (cachePath) {
+    try {
+      fs.writeFileSync(cachePath, JSON.stringify(cache, null, 2), "utf-8");
+      logVerbose(`line: wrote ${displayName} (${userId}) to sender name cache`);
+    } catch (err) {
+      logVerbose(`line: failed to write sender name cache: ${err}`);
+    }
+  }
+}
+
+/**
+ * 從本地快取解析 LINE userId → 顯示名稱（同步，零延遲）
+ */
+export function resolveLineSenderName(userId: string, groupId?: string): string | undefined {
+  if (!userId || userId === "unknown") {
+    return undefined;
+  }
+
+  const cache = loadCache();
+
+  // 1. 群組快取：精確匹配
+  if (groupId && cache[groupId]?.[userId]) {
+    return cache[groupId][userId];
+  }
+
+  // 2. 跨群組掃描
+  for (const members of Object.values(cache)) {
+    if (members[userId]) {
+      return members[userId];
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * 非同步解析：先查快取，cache miss 時打 LINE API，並回寫快取
+ * 用於 inbound 流程 — 第一次見到新成員時自動學習
+ */
+export async function resolveLineSenderNameAsync(
+  userId: string,
+  groupId: string | undefined,
+  opts: {
+    getUserProfile?: (userId: string) => Promise<{ displayName: string } | null>;
+  },
+): Promise<string | undefined> {
+  // 1. 先查同步快取
+  const cached = resolveLineSenderName(userId, groupId);
+  if (cached) {
+    return cached;
+  }
+
+  // 2. 沒有 API function → 放棄
+  if (!opts.getUserProfile) {
+    return undefined;
+  }
+
+  // 3. 避免重複打 API
+  if (_pendingLookups.has(userId)) {
+    return undefined;
+  }
+  _pendingLookups.add(userId);
+
+  try {
+    const profile = await opts.getUserProfile(userId);
+    if (profile?.displayName) {
+      writeToCache(userId, profile.displayName, groupId);
+      return profile.displayName;
+    }
+  } catch (err) {
+    logVerbose(`line: API fallback failed for ${userId}: ${err}`);
+  } finally {
+    _pendingLookups.delete(userId);
+  }
+
+  return undefined;
+}
+
+/**
+ * 取得指定群組的所有成員名稱映射
+ */
+export function getGroupMembers(groupId: string): Record<string, string> {
+  if (!groupId) {
+    return {};
+  }
+  const cache = loadCache();
+  return cache[groupId] ?? {};
+}


### PR DESCRIPTION
## Summary

- New `conversation-context.ts`: builds rich conversation context from message history for agent consumption
- New `cross-channel-context.ts`: enables agents to be aware of activity across different channels (e.g., a LINE agent seeing relevant Telegram context)
- Updated `group-mentions.ts`: adjusted group mention handling for cross-channel scenarios
- LINE integration (`bot-message-context.ts`): injects cross-channel context into inbound message body; adds `sender-name-cache.ts` for LINE display name resolution
- Telegram integration (`bot-message-context.ts`): parallel cross-channel context injection with conversation context rescue

## Test plan

- [ ] `cross-channel-context.test.ts` validates context building across channel boundaries
- [ ] `group-mentions.test.ts` covers updated mention behavior
- [ ] LINE and Telegram bots correctly inject cross-channel context into agent-facing payloads
- [ ] Sender name cache handles cache misses gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds two new channel utilities: (1) `conversation-context.ts` (Level 102) which consults an optional Time Tunnel hook to decide whether to override “skip if no mention” behavior when a conversation is active, and (2) `cross-channel-context.ts` (Level 105) which queries Time Tunnel for recent messages from other channels for the same agent and formats them into a text block.

It also updates Telegram’s inbound context builder to use the conversation-context override before dropping group messages without mentions, and to prepend cross-channel context into the combined inbound `Body`. LINE’s inbound context builder is updated to resolve sender display names via a new local JSON-backed cache and to prepend cross-channel context into `Body`.

Net effect: agents can retain conversational continuity without explicit mentions and can “see” relevant activity across channels, assuming downstream consumers actually ingest the injected context.

<h3>Confidence Score: 3/5</h3>

- This PR is mergeable but has a few correctness/performance issues that should be addressed first.
- Core functionality is straightforward and guarded behind an optional Time Tunnel module, but there are concrete issues: an unused import likely failing CI, synchronous disk I/O in the inbound path, and LINE’s cross-channel context injection going into `Body` while `BodyForAgent` remains `rawBody` (so the new context may be ignored by downstream agent consumers).
- src/line/bot-message-context.ts, src/line/sender-name-cache.ts, src/channels/conversation-context.ts

<sub>Last reviewed commit: 2cedeb5</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->