### PR TITLE
test: comprehensive test coverage expansion

### DIFF
--- a/src/auto-reply/reply/block-reply-coalescer.test.ts
+++ b/src/auto-reply/reply/block-reply-coalescer.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from "vitest";
+import { createBlockReplyCoalescer } from "./block-reply-coalescer.js";
+
+function makeConfig(overrides = {}) {
+  return {
+    minChars: 10,
+    maxChars: 100,
+    idleMs: 0,
+    joiner: "",
+    flushOnEnqueue: false,
+    ...overrides,
+  };
+}
+
+describe("createBlockReplyCoalescer", () => {
+  it("buffers text below minChars", () => {
+    const onFlush = vi.fn();
+    const coalescer = createBlockReplyCoalescer({
+      config: makeConfig({ minChars: 20 }),
+      shouldAbort: () => false,
+      onFlush,
+    });
+    coalescer.enqueue({ text: "short" });
+    expect(coalescer.hasBuffered()).toBe(true);
+    expect(onFlush).not.toHaveBeenCalled();
+    coalescer.stop();
+  });
+
+  it("flushes when buffer exceeds maxChars", async () => {
+    const onFlush = vi.fn();
+    const coalescer = createBlockReplyCoalescer({
+      config: makeConfig({ minChars: 1, maxChars: 10 }),
+      shouldAbort: () => false,
+      onFlush,
+    });
+    coalescer.enqueue({ text: "a".repeat(15) });
+    // Large payload flushed directly
+    expect(onFlush).toHaveBeenCalled();
+    coalescer.stop();
+  });
+
+  it("force flush sends buffered text", async () => {
+    const onFlush = vi.fn();
+    const coalescer = createBlockReplyCoalescer({
+      config: makeConfig({ minChars: 100 }),
+      shouldAbort: () => false,
+      onFlush,
+    });
+    coalescer.enqueue({ text: "buffered" });
+    await coalescer.flush({ force: true });
+    expect(onFlush).toHaveBeenCalledWith(expect.objectContaining({ text: "buffered" }));
+    expect(coalescer.hasBuffered()).toBe(false);
+    coalescer.stop();
+  });
+
+  it("media payloads bypass coalescing", () => {
+    const onFlush = vi.fn();
+    const coalescer = createBlockReplyCoalescer({
+      config: makeConfig(),
+      shouldAbort: () => false,
+      onFlush,
+    });
+    coalescer.enqueue({ text: "caption", mediaUrl: "http://img.png" });
+    expect(onFlush).toHaveBeenCalled();
+    coalescer.stop();
+  });
+
+  it("skips enqueue when aborted", () => {
+    const onFlush = vi.fn();
+    const coalescer = createBlockReplyCoalescer({
+      config: makeConfig(),
+      shouldAbort: () => true,
+      onFlush,
+    });
+    coalescer.enqueue({ text: "should not buffer" });
+    expect(coalescer.hasBuffered()).toBe(false);
+    expect(onFlush).not.toHaveBeenCalled();
+    coalescer.stop();
+  });
+
+  it("uses joiner between concatenated texts", async () => {
+    const onFlush = vi.fn();
+    const coalescer = createBlockReplyCoalescer({
+      config: makeConfig({ minChars: 1, maxChars: 200, joiner: "\n" }),
+      shouldAbort: () => false,
+      onFlush,
+    });
+    coalescer.enqueue({ text: "line1" });
+    coalescer.enqueue({ text: "line2" });
+    await coalescer.flush({ force: true });
+    expect(onFlush).toHaveBeenCalledWith(expect.objectContaining({ text: "line1\nline2" }));
+    coalescer.stop();
+  });
+
+  it("flushOnEnqueue sends each payload separately", () => {
+    const onFlush = vi.fn();
+    const coalescer = createBlockReplyCoalescer({
+      config: makeConfig({ flushOnEnqueue: true, minChars: 1 }),
+      shouldAbort: () => false,
+      onFlush,
+    });
+    coalescer.enqueue({ text: "first" });
+    coalescer.enqueue({ text: "second" });
+    expect(onFlush).toHaveBeenCalledTimes(2);
+    coalescer.stop();
+  });
+
+  it("ignores empty text", () => {
+    const onFlush = vi.fn();
+    const coalescer = createBlockReplyCoalescer({
+      config: makeConfig(),
+      shouldAbort: () => false,
+      onFlush,
+    });
+    coalescer.enqueue({ text: "" });
+    coalescer.enqueue({ text: "   " });
+    expect(coalescer.hasBuffered()).toBe(false);
+    expect(onFlush).not.toHaveBeenCalled();
+    coalescer.stop();
+  });
+});

--- a/src/auto-reply/reply/config-value.test.ts
+++ b/src/auto-reply/reply/config-value.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { parseConfigValue } from "./config-value.js";
+
+describe("parseConfigValue", () => {
+  it("returns error for empty string", () => {
+    expect(parseConfigValue("")).toEqual({ error: "Missing value." });
+    expect(parseConfigValue("   ")).toEqual({ error: "Missing value." });
+  });
+
+  it("parses true/false/null", () => {
+    expect(parseConfigValue("true")).toEqual({ value: true });
+    expect(parseConfigValue("false")).toEqual({ value: false });
+    expect(parseConfigValue("null")).toEqual({ value: null });
+  });
+
+  it("parses integers", () => {
+    expect(parseConfigValue("42")).toEqual({ value: 42 });
+    expect(parseConfigValue("-7")).toEqual({ value: -7 });
+    expect(parseConfigValue("0")).toEqual({ value: 0 });
+  });
+
+  it("parses floats", () => {
+    expect(parseConfigValue("3.14")).toEqual({ value: 3.14 });
+    expect(parseConfigValue("-0.5")).toEqual({ value: -0.5 });
+  });
+
+  it("parses JSON objects", () => {
+    expect(parseConfigValue('{"a":1}')).toEqual({ value: { a: 1 } });
+  });
+
+  it("parses JSON arrays", () => {
+    expect(parseConfigValue("[1,2,3]")).toEqual({ value: [1, 2, 3] });
+  });
+
+  it("returns error for invalid JSON objects", () => {
+    const result = parseConfigValue("{bad}");
+    expect(result.error).toContain("Invalid JSON");
+  });
+
+  it("strips double quotes", () => {
+    expect(parseConfigValue('"hello"')).toEqual({ value: "hello" });
+  });
+
+  it("strips single quotes", () => {
+    expect(parseConfigValue("'world'")).toEqual({ value: "world" });
+  });
+
+  it("returns plain string as-is", () => {
+    expect(parseConfigValue("some text")).toEqual({ value: "some text" });
+  });
+
+  it("trims whitespace", () => {
+    expect(parseConfigValue("  42  ")).toEqual({ value: 42 });
+    expect(parseConfigValue("  hello  ")).toEqual({ value: "hello" });
+  });
+});

--- a/src/auto-reply/reply/directive-handling.shared.test.ts
+++ b/src/auto-reply/reply/directive-handling.shared.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import {
+  SYSTEM_MARK,
+  formatDirectiveAck,
+  formatOptionsLine,
+  withOptions,
+  formatElevatedRuntimeHint,
+  formatElevatedEvent,
+  formatReasoningEvent,
+} from "./directive-handling.shared.js";
+
+describe("formatDirectiveAck", () => {
+  it("returns empty string unchanged", () => {
+    expect(formatDirectiveAck("")).toBe("");
+  });
+
+  it("prepends system mark", () => {
+    expect(formatDirectiveAck("hello")).toBe(`${SYSTEM_MARK} hello`);
+  });
+
+  it("does not double-prepend system mark", () => {
+    const already = `${SYSTEM_MARK} already marked`;
+    expect(formatDirectiveAck(already)).toBe(already);
+  });
+});
+
+describe("formatOptionsLine", () => {
+  it("wraps options text", () => {
+    expect(formatOptionsLine("on | off")).toBe("Options: on | off.");
+  });
+});
+
+describe("withOptions", () => {
+  it("appends options on new line", () => {
+    expect(withOptions("Set mode.", "a | b")).toBe("Set mode.\nOptions: a | b.");
+  });
+});
+
+describe("formatElevatedRuntimeHint", () => {
+  it("contains system mark", () => {
+    expect(formatElevatedRuntimeHint()).toContain(SYSTEM_MARK);
+  });
+});
+
+describe("formatElevatedEvent", () => {
+  it("formats full level", () => {
+    expect(formatElevatedEvent("full")).toContain("FULL");
+  });
+
+  it("formats ask level", () => {
+    expect(formatElevatedEvent("ask")).toContain("ASK");
+  });
+
+  it("formats on level as ASK", () => {
+    expect(formatElevatedEvent("on")).toContain("ASK");
+  });
+
+  it("formats off level", () => {
+    expect(formatElevatedEvent("off")).toContain("OFF");
+  });
+});
+
+describe("formatReasoningEvent", () => {
+  it("formats stream level", () => {
+    expect(formatReasoningEvent("stream")).toContain("STREAM");
+  });
+
+  it("formats on level", () => {
+    expect(formatReasoningEvent("on")).toContain("ON");
+  });
+
+  it("formats off level", () => {
+    expect(formatReasoningEvent("off")).toContain("OFF");
+  });
+});

--- a/src/auto-reply/reply/directives.test.ts
+++ b/src/auto-reply/reply/directives.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractThinkDirective,
+  extractVerboseDirective,
+  extractElevatedDirective,
+  extractReasoningDirective,
+  extractStatusDirective,
+  extractNoticeDirective,
+} from "./directives.js";
+
+describe("extractThinkDirective", () => {
+  it("returns no directive for plain text", () => {
+    const result = extractThinkDirective("hello world");
+    expect(result.hasDirective).toBe(false);
+    expect(result.cleaned).toBe("hello world");
+  });
+
+  it("returns empty for undefined", () => {
+    expect(extractThinkDirective(undefined).cleaned).toBe("");
+  });
+
+  it("extracts /think directive", () => {
+    const result = extractThinkDirective("hello /think high");
+    expect(result.hasDirective).toBe(true);
+    expect(result.thinkLevel).toBe("high");
+    expect(result.cleaned).toBe("hello");
+  });
+
+  it("extracts /thinking directive", () => {
+    const result = extractThinkDirective("/thinking low message");
+    expect(result.hasDirective).toBe(true);
+    expect(result.thinkLevel).toBe("low");
+    expect(result.cleaned).toBe("message");
+  });
+
+  it("extracts /t shorthand", () => {
+    const result = extractThinkDirective("/t off");
+    expect(result.hasDirective).toBe(true);
+    expect(result.cleaned).toBe("");
+  });
+
+  it("handles colon separator", () => {
+    const result = extractThinkDirective("/think: high rest");
+    expect(result.hasDirective).toBe(true);
+    expect(result.rawLevel).toBe("high");
+  });
+});
+
+describe("extractVerboseDirective", () => {
+  it("extracts /verbose directive", () => {
+    const result = extractVerboseDirective("msg /verbose on");
+    expect(result.hasDirective).toBe(true);
+    expect(result.verboseLevel).toBe("on");
+  });
+
+  it("extracts /v shorthand", () => {
+    const result = extractVerboseDirective("/v off");
+    expect(result.hasDirective).toBe(true);
+  });
+});
+
+describe("extractElevatedDirective", () => {
+  it("extracts /elevated directive", () => {
+    const result = extractElevatedDirective("msg /elevated full");
+    expect(result.hasDirective).toBe(true);
+    expect(result.elevatedLevel).toBe("full");
+    expect(result.cleaned).toBe("msg");
+  });
+
+  it("extracts /elev shorthand", () => {
+    const result = extractElevatedDirective("/elev on");
+    expect(result.hasDirective).toBe(true);
+  });
+
+  it("returns no directive for undefined", () => {
+    expect(extractElevatedDirective(undefined).hasDirective).toBe(false);
+  });
+});
+
+describe("extractReasoningDirective", () => {
+  it("extracts /reasoning directive", () => {
+    const result = extractReasoningDirective("msg /reasoning stream");
+    expect(result.hasDirective).toBe(true);
+    expect(result.reasoningLevel).toBe("stream");
+  });
+
+  it("extracts /reason shorthand", () => {
+    const result = extractReasoningDirective("/reason on text");
+    expect(result.hasDirective).toBe(true);
+    expect(result.cleaned).toBe("text");
+  });
+});
+
+describe("extractStatusDirective", () => {
+  it("extracts /status directive", () => {
+    const result = extractStatusDirective("/status");
+    expect(result.hasDirective).toBe(true);
+    expect(result.cleaned).toBe("");
+  });
+
+  it("returns no directive for plain text", () => {
+    expect(extractStatusDirective("hello").hasDirective).toBe(false);
+  });
+
+  it("returns empty for undefined", () => {
+    expect(extractStatusDirective(undefined).cleaned).toBe("");
+  });
+});
+
+describe("extractNoticeDirective", () => {
+  it("extracts /notice directive", () => {
+    const result = extractNoticeDirective("/notice off");
+    expect(result.hasDirective).toBe(true);
+  });
+
+  it("extracts /notices directive", () => {
+    const result = extractNoticeDirective("/notices on");
+    expect(result.hasDirective).toBe(true);
+  });
+});

--- a/src/auto-reply/reply/inbound-dedupe.test.ts
+++ b/src/auto-reply/reply/inbound-dedupe.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import type { MsgContext } from "../templating.js";
+import { buildInboundDedupeKey } from "./inbound-dedupe.js";
+
+describe("buildInboundDedupeKey", () => {
+  it("returns null when provider is missing", () => {
+    expect(buildInboundDedupeKey({ MessageSid: "m1", To: "chat1" } as MsgContext)).toBeNull();
+  });
+
+  it("returns null when messageId is missing", () => {
+    expect(buildInboundDedupeKey({ Provider: "telegram", To: "chat1" } as MsgContext)).toBeNull();
+  });
+
+  it("returns null when peerId is missing", () => {
+    expect(
+      buildInboundDedupeKey({ Provider: "telegram", MessageSid: "m1" } as MsgContext),
+    ).toBeNull();
+  });
+
+  it("builds key with minimal fields", () => {
+    const key = buildInboundDedupeKey({
+      Provider: "telegram",
+      MessageSid: "msg123",
+      To: "chat1",
+    } as MsgContext);
+    expect(key).toBeTruthy();
+    expect(key).toContain("telegram");
+    expect(key).toContain("msg123");
+    expect(key).toContain("chat1");
+  });
+
+  it("includes account and session in key", () => {
+    const key = buildInboundDedupeKey({
+      Provider: "telegram",
+      MessageSid: "m1",
+      To: "chat1",
+      AccountId: "acct1",
+      SessionKey: "sess1",
+    } as MsgContext);
+    expect(key).toContain("acct1");
+    expect(key).toContain("sess1");
+  });
+
+  it("includes thread ID when present", () => {
+    const key = buildInboundDedupeKey({
+      Provider: "telegram",
+      MessageSid: "m1",
+      To: "chat1",
+      MessageThreadId: 42,
+    } as MsgContext);
+    expect(key).toContain("42");
+  });
+
+  it("prefers OriginatingChannel over Provider", () => {
+    const key = buildInboundDedupeKey({
+      Provider: "telegram",
+      OriginatingChannel: "discord",
+      MessageSid: "m1",
+      To: "chat1",
+    } as MsgContext);
+    expect(key).toContain("discord");
+  });
+
+  it("prefers OriginatingTo as peerId", () => {
+    const key = buildInboundDedupeKey({
+      Provider: "slack",
+      MessageSid: "m1",
+      To: "chat1",
+      OriginatingTo: "orig-dest",
+    } as MsgContext);
+    expect(key).toContain("orig-dest");
+  });
+
+  it("normalizes provider to lowercase", () => {
+    const key = buildInboundDedupeKey({
+      Provider: "TELEGRAM",
+      MessageSid: "m1",
+      To: "chat1",
+    } as MsgContext);
+    expect(key).toContain("telegram");
+    expect(key).not.toContain("TELEGRAM");
+  });
+});

--- a/src/auto-reply/reply/inbound-sender-meta.test.ts
+++ b/src/auto-reply/reply/inbound-sender-meta.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import type { MsgContext } from "../templating.js";
+import { formatInboundBodyWithSenderMeta } from "./inbound-sender-meta.js";
+
+describe("formatInboundBodyWithSenderMeta", () => {
+  it("returns empty body unchanged", () => {
+    const ctx = { ChatType: "group", SenderName: "Alice" } as MsgContext;
+    expect(formatInboundBodyWithSenderMeta({ body: "", ctx })).toBe("");
+  });
+
+  it("returns body unchanged for direct chat", () => {
+    const ctx = { ChatType: "direct", SenderName: "Alice" } as MsgContext;
+    expect(formatInboundBodyWithSenderMeta({ body: "hello", ctx })).toBe("hello");
+  });
+
+  it("returns body unchanged when no chat type", () => {
+    const ctx = {} as MsgContext;
+    expect(formatInboundBodyWithSenderMeta({ body: "hello", ctx })).toBe("hello");
+  });
+
+  it("appends sender meta for group chat", () => {
+    const ctx = {
+      ChatType: "group",
+      SenderName: "Alice",
+    } as MsgContext;
+    const result = formatInboundBodyWithSenderMeta({ body: "hello", ctx });
+    expect(result).toContain("[from: Alice]");
+  });
+
+  it("returns body unchanged when no sender label available", () => {
+    const ctx = { ChatType: "group" } as MsgContext;
+    expect(formatInboundBodyWithSenderMeta({ body: "hello", ctx })).toBe("hello");
+  });
+
+  it("does not duplicate [from:] if already present", () => {
+    const ctx = {
+      ChatType: "group",
+      SenderName: "Alice",
+    } as MsgContext;
+    const body = "hello\n[from: Alice]";
+    expect(formatInboundBodyWithSenderMeta({ body, ctx })).toBe(body);
+  });
+
+  it("detects sender prefix in envelope format", () => {
+    const ctx = {
+      ChatType: "group",
+      SenderName: "Bob",
+    } as MsgContext;
+    const body = "[Signal Group] Bob: hello";
+    expect(formatInboundBodyWithSenderMeta({ body, ctx })).toBe(body);
+  });
+});

--- a/src/auto-reply/reply/inbound-text.test.ts
+++ b/src/auto-reply/reply/inbound-text.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { normalizeInboundTextNewlines } from "./inbound-text.js";
+
+describe("normalizeInboundTextNewlines", () => {
+  it("returns empty string unchanged", () => {
+    expect(normalizeInboundTextNewlines("")).toBe("");
+  });
+
+  it("returns plain text unchanged", () => {
+    expect(normalizeInboundTextNewlines("hello world")).toBe("hello world");
+  });
+
+  it("converts \\r\\n to \\n", () => {
+    expect(normalizeInboundTextNewlines("a\r\nb")).toBe("a\nb");
+  });
+
+  it("converts bare \\r to \\n", () => {
+    expect(normalizeInboundTextNewlines("a\rb")).toBe("a\nb");
+  });
+
+  it("converts escaped \\\\n to real \\n", () => {
+    expect(normalizeInboundTextNewlines("a\\nb")).toBe("a\nb");
+  });
+
+  it("handles mixed newline styles", () => {
+    expect(normalizeInboundTextNewlines("a\r\nb\\nc\rd")).toBe("a\nb\nc\nd");
+  });
+
+  it("handles multiple consecutive newlines", () => {
+    expect(normalizeInboundTextNewlines("a\r\n\r\nb")).toBe("a\n\nb");
+  });
+});

--- a/src/auto-reply/reply/reply-payloads.test.ts
+++ b/src/auto-reply/reply/reply-payloads.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { isRenderablePayload } from "./reply-payloads.js";
+
+describe("isRenderablePayload", () => {
+  it("returns true for text payload", () => {
+    expect(isRenderablePayload({ text: "hello" })).toBe(true);
+  });
+
+  it("returns false for empty text with no media", () => {
+    expect(isRenderablePayload({ text: "" })).toBe(false);
+  });
+
+  it("returns false for undefined text", () => {
+    expect(isRenderablePayload({})).toBe(false);
+  });
+
+  it("returns true for mediaUrl only", () => {
+    expect(isRenderablePayload({ mediaUrl: "https://x.test/a.png" })).toBe(true);
+  });
+
+  it("returns true for mediaUrls array", () => {
+    expect(isRenderablePayload({ mediaUrls: ["https://x.test/a.png"] })).toBe(true);
+  });
+
+  it("returns false for empty mediaUrls", () => {
+    expect(isRenderablePayload({ mediaUrls: [] })).toBe(false);
+  });
+
+  it("returns true for audioAsVoice", () => {
+    expect(isRenderablePayload({ audioAsVoice: "https://x.test/a.ogg" })).toBe(true);
+  });
+
+  it("returns true for channelData", () => {
+    expect(isRenderablePayload({ channelData: { line: { msg: "flex" } } })).toBe(true);
+  });
+
+  it("returns false for empty object", () => {
+    expect(isRenderablePayload({})).toBe(false);
+  });
+});

--- a/src/auto-reply/templating.test.ts
+++ b/src/auto-reply/templating.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { applyTemplate, type TemplateContext } from "./templating.js";
+
+describe("applyTemplate", () => {
+  it("returns empty string for undefined input", () => {
+    expect(applyTemplate(undefined, {} as TemplateContext)).toBe("");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(applyTemplate("", {} as TemplateContext)).toBe("");
+  });
+
+  it("returns text unchanged without placeholders", () => {
+    expect(applyTemplate("hello world", {} as TemplateContext)).toBe("hello world");
+  });
+
+  it("replaces known placeholders", () => {
+    const ctx: TemplateContext = { Body: "hi", From: "+1234" };
+    expect(applyTemplate("msg: {{Body}} from {{From}}", ctx)).toBe("msg: hi from +1234");
+  });
+
+  it("replaces unknown keys with empty string", () => {
+    expect(applyTemplate("{{UnknownField}}", {} as TemplateContext)).toBe("");
+  });
+
+  it("handles whitespace around placeholder names", () => {
+    const ctx: TemplateContext = { Body: "test" };
+    expect(applyTemplate("{{ Body }}", ctx)).toBe("test");
+  });
+
+  it("formats numeric values", () => {
+    const ctx: TemplateContext = { Timestamp: 12345 };
+    expect(applyTemplate("ts={{Timestamp}}", ctx)).toBe("ts=12345");
+  });
+
+  it("formats boolean values", () => {
+    const ctx: TemplateContext = { WasMentioned: true };
+    expect(applyTemplate("{{WasMentioned}}", ctx)).toBe("true");
+  });
+
+  it("formats arrays as comma-separated", () => {
+    const ctx: TemplateContext = { MediaUrls: ["a.jpg", "b.png"] };
+    expect(applyTemplate("{{MediaUrls}}", ctx)).toBe("a.jpg,b.png");
+  });
+
+  it("returns empty for null/undefined values", () => {
+    const ctx: TemplateContext = { Body: undefined };
+    expect(applyTemplate("{{Body}}", ctx)).toBe("");
+  });
+
+  it("handles multiple placeholders", () => {
+    const ctx: TemplateContext = { SenderName: "Alice", ChatType: "group" };
+    expect(applyTemplate("{{SenderName}} in {{ChatType}}", ctx)).toBe("Alice in group");
+  });
+});

--- a/src/channels/allowlist-match.test.ts
+++ b/src/channels/allowlist-match.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { formatAllowlistMatchMeta } from "./allowlist-match.js";
+
+describe("formatAllowlistMatchMeta", () => {
+  it("formats with both matchKey and matchSource", () => {
+    expect(formatAllowlistMatchMeta({ matchKey: "abc", matchSource: "id" })).toBe(
+      "matchKey=abc matchSource=id",
+    );
+  });
+
+  it("returns none for undefined match", () => {
+    expect(formatAllowlistMatchMeta(undefined)).toBe("matchKey=none matchSource=none");
+  });
+
+  it("returns none for null match", () => {
+    expect(formatAllowlistMatchMeta(null)).toBe("matchKey=none matchSource=none");
+  });
+
+  it("returns none for missing keys", () => {
+    expect(formatAllowlistMatchMeta({})).toBe("matchKey=none matchSource=none");
+  });
+
+  it("handles partial match (matchKey only)", () => {
+    expect(formatAllowlistMatchMeta({ matchKey: "abc" })).toBe("matchKey=abc matchSource=none");
+  });
+
+  it("handles partial match (matchSource only)", () => {
+    expect(formatAllowlistMatchMeta({ matchSource: "tag" })).toBe("matchKey=none matchSource=tag");
+  });
+});

--- a/src/channels/allowlists/resolve-utils.test.ts
+++ b/src/channels/allowlists/resolve-utils.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest";
+import { mergeAllowlist, summarizeMapping } from "./resolve-utils.js";
+
+// ---------------------------------------------------------------------------
+// mergeAllowlist
+// ---------------------------------------------------------------------------
+
+describe("mergeAllowlist", () => {
+  it("returns empty array for empty inputs", () => {
+    expect(mergeAllowlist({ additions: [] })).toEqual([]);
+  });
+
+  it("returns additions when no existing", () => {
+    expect(mergeAllowlist({ additions: ["alice", "bob"] })).toEqual(["alice", "bob"]);
+  });
+
+  it("merges existing and additions", () => {
+    expect(mergeAllowlist({ existing: ["alice"], additions: ["bob"] })).toEqual(["alice", "bob"]);
+  });
+
+  it("deduplicates case-insensitively", () => {
+    expect(mergeAllowlist({ existing: ["Alice"], additions: ["alice"] })).toEqual(["Alice"]);
+  });
+
+  it("preserves original casing of first occurrence", () => {
+    expect(mergeAllowlist({ additions: ["Alice", "ALICE", "alice"] })).toEqual(["Alice"]);
+  });
+
+  it("skips empty and whitespace-only strings", () => {
+    expect(mergeAllowlist({ additions: ["alice", "", "  ", "bob"] })).toEqual(["alice", "bob"]);
+  });
+
+  it("trims whitespace", () => {
+    expect(mergeAllowlist({ additions: ["  alice  ", "  bob  "] })).toEqual(["alice", "bob"]);
+  });
+
+  it("handles numeric existing entries", () => {
+    expect(mergeAllowlist({ existing: [12345, 67890], additions: [] })).toEqual(["12345", "67890"]);
+  });
+
+  it("deduplicates numbers against string additions", () => {
+    expect(mergeAllowlist({ existing: [12345], additions: ["12345"] })).toEqual(["12345"]);
+  });
+
+  it("handles undefined existing", () => {
+    expect(mergeAllowlist({ existing: undefined, additions: ["alice"] })).toEqual(["alice"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// summarizeMapping
+// ---------------------------------------------------------------------------
+
+describe("summarizeMapping", () => {
+  it("does nothing when both arrays are empty", () => {
+    const log = vi.fn();
+    summarizeMapping("test", [], [], { log } as any);
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it("logs resolved entries", () => {
+    const log = vi.fn();
+    summarizeMapping("Allowlist", ["alice", "bob"], [], { log } as any);
+    expect(log).toHaveBeenCalledWith("Allowlist resolved: alice, bob");
+  });
+
+  it("logs unresolved entries", () => {
+    const log = vi.fn();
+    summarizeMapping("Allowlist", [], ["charlie"], { log } as any);
+    expect(log).toHaveBeenCalledWith("Allowlist unresolved: charlie");
+  });
+
+  it("truncates to 6 items with count", () => {
+    const log = vi.fn();
+    const items = ["a", "b", "c", "d", "e", "f", "g", "h"];
+    summarizeMapping("Test", items, [], { log } as any);
+    expect(log).toHaveBeenCalledWith("Test resolved: a, b, c, d, e, f (+2)");
+  });
+
+  it("handles runtime without log function", () => {
+    // Should not throw
+    summarizeMapping("Test", ["alice"], [], {} as any);
+  });
+});

--- a/src/channels/plugins/media-limits.test.ts
+++ b/src/channels/plugins/media-limits.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import { resolveChannelMediaMaxBytes } from "./media-limits.js";
+
+const MB = 1024 * 1024;
+
+function makeCfg(overrides?: Partial<OpenClawConfig>): OpenClawConfig {
+  return { agents: { defaults: {} }, ...overrides } as OpenClawConfig;
+}
+
+describe("resolveChannelMediaMaxBytes", () => {
+  it("returns undefined when no limits configured", () => {
+    const result = resolveChannelMediaMaxBytes({
+      cfg: makeCfg(),
+      resolveChannelLimitMb: () => undefined,
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("uses channel-specific limit when provided", () => {
+    const result = resolveChannelMediaMaxBytes({
+      cfg: makeCfg(),
+      resolveChannelLimitMb: () => 25,
+    });
+    expect(result).toBe(25 * MB);
+  });
+
+  it("falls back to agents.defaults.mediaMaxMb", () => {
+    const result = resolveChannelMediaMaxBytes({
+      cfg: makeCfg({ agents: { defaults: { mediaMaxMb: 10 } } } as Partial<OpenClawConfig>),
+      resolveChannelLimitMb: () => undefined,
+    });
+    expect(result).toBe(10 * MB);
+  });
+
+  it("channel limit takes priority over global default", () => {
+    const result = resolveChannelMediaMaxBytes({
+      cfg: makeCfg({ agents: { defaults: { mediaMaxMb: 10 } } } as Partial<OpenClawConfig>),
+      resolveChannelLimitMb: () => 50,
+    });
+    expect(result).toBe(50 * MB);
+  });
+
+  it("passes normalized accountId to resolver", () => {
+    let receivedAccountId = "";
+    resolveChannelMediaMaxBytes({
+      cfg: makeCfg(),
+      resolveChannelLimitMb: ({ accountId }) => {
+        receivedAccountId = accountId;
+        return undefined;
+      },
+      accountId: "  MY-ACCOUNT  ",
+    });
+    // normalizeAccountId trims and lowercases
+    expect(receivedAccountId).toBe("my-account");
+  });
+
+  it("handles null accountId", () => {
+    let receivedAccountId = "";
+    resolveChannelMediaMaxBytes({
+      cfg: makeCfg(),
+      resolveChannelLimitMb: ({ accountId }) => {
+        receivedAccountId = accountId;
+        return undefined;
+      },
+      accountId: null,
+    });
+    // normalizeAccountId returns "default" for null
+    expect(receivedAccountId).toBe("default");
+  });
+});

--- a/src/channels/plugins/normalize/feishu.test.ts
+++ b/src/channels/plugins/normalize/feishu.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { normalizeFeishuTarget } from "./feishu.js";
+
+describe("normalizeFeishuTarget", () => {
+  it("returns plain ID unchanged", () => {
+    expect(normalizeFeishuTarget("oc_abc123")).toBe("oc_abc123");
+  });
+
+  it("strips feishu: prefix", () => {
+    expect(normalizeFeishuTarget("feishu:oc_abc123")).toBe("oc_abc123");
+  });
+
+  it("strips lark: prefix", () => {
+    expect(normalizeFeishuTarget("lark:oc_abc123")).toBe("oc_abc123");
+  });
+
+  it("is case-insensitive for channel prefix", () => {
+    expect(normalizeFeishuTarget("Feishu:oc_abc123")).toBe("oc_abc123");
+    expect(normalizeFeishuTarget("LARK:oc_abc123")).toBe("oc_abc123");
+  });
+
+  it("strips group: subprefix", () => {
+    expect(normalizeFeishuTarget("feishu:group:oc_abc123")).toBe("oc_abc123");
+  });
+
+  it("strips chat: subprefix", () => {
+    expect(normalizeFeishuTarget("lark:chat:oc_abc123")).toBe("oc_abc123");
+  });
+
+  it("strips user: subprefix", () => {
+    expect(normalizeFeishuTarget("feishu:user:ou_abc123")).toBe("ou_abc123");
+  });
+
+  it("strips dm: subprefix", () => {
+    expect(normalizeFeishuTarget("lark:dm:ou_abc123")).toBe("ou_abc123");
+  });
+
+  it("strips standalone group: prefix", () => {
+    expect(normalizeFeishuTarget("group:oc_abc123")).toBe("oc_abc123");
+  });
+
+  it("trims whitespace", () => {
+    expect(normalizeFeishuTarget("feishu: oc_abc123 ")).toBe("oc_abc123");
+  });
+});

--- a/src/channels/sender-label.test.ts
+++ b/src/channels/sender-label.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { resolveSenderLabel, listSenderLabelCandidates } from "./sender-label.js";
+
+// ---------------------------------------------------------------------------
+// resolveSenderLabel
+// ---------------------------------------------------------------------------
+
+describe("resolveSenderLabel", () => {
+  it("returns null when all fields empty", () => {
+    expect(resolveSenderLabel({})).toBeNull();
+    expect(resolveSenderLabel({ name: "", username: "" })).toBeNull();
+  });
+
+  it("uses name as primary label", () => {
+    expect(resolveSenderLabel({ name: "Alice" })).toBe("Alice");
+  });
+
+  it("falls back to username when no name", () => {
+    expect(resolveSenderLabel({ username: "alice_bot" })).toBe("alice_bot");
+  });
+
+  it("falls back to tag when no name/username", () => {
+    expect(resolveSenderLabel({ tag: "#admin" })).toBe("#admin");
+  });
+
+  it("appends id in parentheses when different from display", () => {
+    expect(resolveSenderLabel({ name: "Alice", id: "user123" })).toBe("Alice (user123)");
+  });
+
+  it("appends e164 in parentheses", () => {
+    expect(resolveSenderLabel({ name: "Alice", e164: "+1234567890" })).toBe("Alice (+1234567890)");
+  });
+
+  it("does not duplicate when name equals id", () => {
+    expect(resolveSenderLabel({ name: "user123", id: "user123" })).toBe("user123");
+  });
+
+  it("returns id alone when only id provided", () => {
+    expect(resolveSenderLabel({ id: "user123" })).toBe("user123");
+  });
+
+  it("returns e164 alone when only e164 provided", () => {
+    expect(resolveSenderLabel({ e164: "+1234567890" })).toBe("+1234567890");
+  });
+
+  it("trims whitespace", () => {
+    expect(resolveSenderLabel({ name: "  Alice  " })).toBe("Alice");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listSenderLabelCandidates
+// ---------------------------------------------------------------------------
+
+describe("listSenderLabelCandidates", () => {
+  it("returns empty array for empty params", () => {
+    expect(listSenderLabelCandidates({})).toEqual([]);
+  });
+
+  it("includes all non-empty fields", () => {
+    const result = listSenderLabelCandidates({
+      name: "Alice",
+      username: "alice_bot",
+      id: "123",
+    });
+    expect(result).toContain("Alice");
+    expect(result).toContain("alice_bot");
+    expect(result).toContain("123");
+  });
+
+  it("includes the resolved composite label", () => {
+    const result = listSenderLabelCandidates({
+      name: "Alice",
+      id: "123",
+    });
+    expect(result).toContain("Alice (123)");
+  });
+
+  it("deduplicates", () => {
+    const result = listSenderLabelCandidates({ name: "Alice" });
+    const aliceCount = result.filter((x) => x === "Alice").length;
+    expect(aliceCount).toBe(1);
+  });
+});

--- a/src/config/agent-limits.test.ts
+++ b/src/config/agent-limits.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "./types.js";
+import {
+  resolveAgentMaxConcurrent,
+  resolveSubagentMaxConcurrent,
+  DEFAULT_AGENT_MAX_CONCURRENT,
+  DEFAULT_SUBAGENT_MAX_CONCURRENT,
+} from "./agent-limits.js";
+
+function makeCfg(overrides?: Record<string, unknown>): OpenClawConfig {
+  return overrides as unknown as OpenClawConfig;
+}
+
+describe("resolveAgentMaxConcurrent", () => {
+  it("returns default for undefined config", () => {
+    expect(resolveAgentMaxConcurrent()).toBe(DEFAULT_AGENT_MAX_CONCURRENT);
+    expect(resolveAgentMaxConcurrent(undefined)).toBe(DEFAULT_AGENT_MAX_CONCURRENT);
+  });
+
+  it("returns default when agents.defaults.maxConcurrent is missing", () => {
+    expect(resolveAgentMaxConcurrent(makeCfg({}))).toBe(DEFAULT_AGENT_MAX_CONCURRENT);
+    expect(resolveAgentMaxConcurrent(makeCfg({ agents: {} }))).toBe(DEFAULT_AGENT_MAX_CONCURRENT);
+  });
+
+  it("uses configured value", () => {
+    expect(resolveAgentMaxConcurrent(makeCfg({ agents: { defaults: { maxConcurrent: 8 } } }))).toBe(
+      8,
+    );
+  });
+
+  it("floors fractional values", () => {
+    expect(
+      resolveAgentMaxConcurrent(makeCfg({ agents: { defaults: { maxConcurrent: 3.9 } } })),
+    ).toBe(3);
+  });
+
+  it("clamps to minimum of 1", () => {
+    expect(resolveAgentMaxConcurrent(makeCfg({ agents: { defaults: { maxConcurrent: 0 } } }))).toBe(
+      1,
+    );
+    expect(
+      resolveAgentMaxConcurrent(makeCfg({ agents: { defaults: { maxConcurrent: -5 } } })),
+    ).toBe(1);
+  });
+
+  it("returns default for NaN/Infinity", () => {
+    expect(
+      resolveAgentMaxConcurrent(makeCfg({ agents: { defaults: { maxConcurrent: NaN } } })),
+    ).toBe(DEFAULT_AGENT_MAX_CONCURRENT);
+    expect(
+      resolveAgentMaxConcurrent(makeCfg({ agents: { defaults: { maxConcurrent: Infinity } } })),
+    ).toBe(DEFAULT_AGENT_MAX_CONCURRENT);
+  });
+});
+
+describe("resolveSubagentMaxConcurrent", () => {
+  it("returns default for undefined config", () => {
+    expect(resolveSubagentMaxConcurrent()).toBe(DEFAULT_SUBAGENT_MAX_CONCURRENT);
+  });
+
+  it("uses configured value", () => {
+    const cfg = makeCfg({ agents: { defaults: { subagents: { maxConcurrent: 16 } } } });
+    expect(resolveSubagentMaxConcurrent(cfg)).toBe(16);
+  });
+
+  it("clamps to minimum of 1", () => {
+    const cfg = makeCfg({ agents: { defaults: { subagents: { maxConcurrent: 0 } } } });
+    expect(resolveSubagentMaxConcurrent(cfg)).toBe(1);
+  });
+
+  it("returns default for non-numeric", () => {
+    const cfg = makeCfg({ agents: { defaults: { subagents: { maxConcurrent: "not a number" } } } });
+    expect(resolveSubagentMaxConcurrent(cfg)).toBe(DEFAULT_SUBAGENT_MAX_CONCURRENT);
+  });
+});

--- a/src/config/group-policy.test.ts
+++ b/src/config/group-policy.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "./config.js";
+import {
+  resolveToolsBySender,
+  resolveChannelGroupPolicy,
+  resolveChannelGroupRequireMention,
+} from "./group-policy.js";
+
+function makeCfg(channels?: Record<string, unknown>): OpenClawConfig {
+  return { channels } as unknown as OpenClawConfig;
+}
+
+// ---------------------------------------------------------------------------
+// resolveToolsBySender
+// ---------------------------------------------------------------------------
+
+describe("resolveToolsBySender", () => {
+  it("returns undefined when no toolsBySender", () => {
+    expect(resolveToolsBySender({ toolsBySender: undefined })).toBeUndefined();
+  });
+
+  it("returns undefined for empty toolsBySender", () => {
+    expect(resolveToolsBySender({ toolsBySender: {} })).toBeUndefined();
+  });
+
+  it("matches by senderId", () => {
+    const policy = { mode: "allow" };
+    const result = resolveToolsBySender({
+      toolsBySender: { user123: policy },
+      senderId: "user123",
+    });
+    expect(result).toBe(policy);
+  });
+
+  it("matches case-insensitively", () => {
+    const policy = { mode: "deny" };
+    const result = resolveToolsBySender({
+      toolsBySender: { alice: policy },
+      senderId: "Alice",
+    });
+    expect(result).toBe(policy);
+  });
+
+  it("strips @ prefix when matching", () => {
+    const policy = { mode: "allow" };
+    const result = resolveToolsBySender({
+      toolsBySender: { alice: policy },
+      senderUsername: "@Alice",
+    });
+    expect(result).toBe(policy);
+  });
+
+  it("falls back to wildcard when no specific match", () => {
+    const wildcard = { mode: "limited" };
+    const result = resolveToolsBySender({
+      toolsBySender: { "*": wildcard, bob: { mode: "full" } },
+      senderId: "unknown-user",
+    });
+    expect(result).toBe(wildcard);
+  });
+
+  it("prefers specific match over wildcard", () => {
+    const specific = { mode: "full" };
+    const wildcard = { mode: "limited" };
+    const result = resolveToolsBySender({
+      toolsBySender: { "*": wildcard, alice: specific },
+      senderId: "alice",
+    });
+    expect(result).toBe(specific);
+  });
+
+  it("matches by senderName when senderId doesn't match", () => {
+    const policy = { mode: "allow" };
+    const result = resolveToolsBySender({
+      toolsBySender: { bob: policy },
+      senderId: "id-999",
+      senderName: "Bob",
+    });
+    expect(result).toBe(policy);
+  });
+
+  it("returns undefined when no match and no wildcard", () => {
+    const result = resolveToolsBySender({
+      toolsBySender: { alice: { mode: "allow" } },
+      senderId: "bob",
+    });
+    expect(result).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveChannelGroupPolicy
+// ---------------------------------------------------------------------------
+
+describe("resolveChannelGroupPolicy", () => {
+  it("returns allowlistEnabled=false when no groups configured", () => {
+    const result = resolveChannelGroupPolicy({
+      cfg: makeCfg({}),
+      channel: "telegram",
+      groupId: "123",
+    });
+    expect(result.allowlistEnabled).toBe(false);
+    expect(result.allowed).toBe(true);
+  });
+
+  it("returns allowed=true for allowlisted group", () => {
+    const cfg = makeCfg({ telegram: { groups: { "123": {} } } });
+    const result = resolveChannelGroupPolicy({ cfg, channel: "telegram", groupId: "123" });
+    expect(result.allowlistEnabled).toBe(true);
+    expect(result.allowed).toBe(true);
+  });
+
+  it("returns allowed=false for non-allowlisted group", () => {
+    const cfg = makeCfg({ telegram: { groups: { "123": {} } } });
+    const result = resolveChannelGroupPolicy({ cfg, channel: "telegram", groupId: "999" });
+    expect(result.allowlistEnabled).toBe(true);
+    expect(result.allowed).toBe(false);
+  });
+
+  it("returns allowed=true when wildcard * exists", () => {
+    const cfg = makeCfg({ telegram: { groups: { "*": {} } } });
+    const result = resolveChannelGroupPolicy({ cfg, channel: "telegram", groupId: "any-group" });
+    expect(result.allowed).toBe(true);
+  });
+
+  it("provides groupConfig for matching group", () => {
+    const groupCfg = { requireMention: false };
+    const cfg = makeCfg({ telegram: { groups: { "123": groupCfg } } });
+    const result = resolveChannelGroupPolicy({ cfg, channel: "telegram", groupId: "123" });
+    expect(result.groupConfig).toEqual(groupCfg);
+  });
+
+  it("provides defaultConfig from wildcard", () => {
+    const defaultCfg = { requireMention: true };
+    const cfg = makeCfg({ telegram: { groups: { "*": defaultCfg } } });
+    const result = resolveChannelGroupPolicy({ cfg, channel: "telegram", groupId: "123" });
+    expect(result.defaultConfig).toEqual(defaultCfg);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveChannelGroupRequireMention
+// ---------------------------------------------------------------------------
+
+describe("resolveChannelGroupRequireMention", () => {
+  it("defaults to true when no config", () => {
+    expect(resolveChannelGroupRequireMention({ cfg: makeCfg({}), channel: "telegram" })).toBe(true);
+  });
+
+  it("uses group-specific requireMention", () => {
+    const cfg = makeCfg({ telegram: { groups: { "123": { requireMention: false } } } });
+    expect(resolveChannelGroupRequireMention({ cfg, channel: "telegram", groupId: "123" })).toBe(
+      false,
+    );
+  });
+
+  it("falls back to wildcard requireMention", () => {
+    const cfg = makeCfg({ telegram: { groups: { "*": { requireMention: false } } } });
+    expect(resolveChannelGroupRequireMention({ cfg, channel: "telegram", groupId: "999" })).toBe(
+      false,
+    );
+  });
+
+  it("group-specific overrides wildcard", () => {
+    const cfg = makeCfg({
+      telegram: { groups: { "*": { requireMention: true }, "123": { requireMention: false } } },
+    });
+    expect(resolveChannelGroupRequireMention({ cfg, channel: "telegram", groupId: "123" })).toBe(
+      false,
+    );
+  });
+
+  it("respects requireMentionOverride with after-config order", () => {
+    expect(
+      resolveChannelGroupRequireMention({
+        cfg: makeCfg({}),
+        channel: "telegram",
+        requireMentionOverride: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("respects requireMentionOverride with before-config order", () => {
+    const cfg = makeCfg({ telegram: { groups: { "123": { requireMention: true } } } });
+    expect(
+      resolveChannelGroupRequireMention({
+        cfg,
+        channel: "telegram",
+        groupId: "123",
+        requireMentionOverride: false,
+        overrideOrder: "before-config",
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/config/markdown-tables.test.ts
+++ b/src/config/markdown-tables.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { resolveMarkdownTableMode } from "./markdown-tables.js";
+
+describe("resolveMarkdownTableMode", () => {
+  it("returns 'code' as default for unknown channels", () => {
+    expect(resolveMarkdownTableMode({ channel: "telegram" })).toBe("code");
+  });
+
+  it("returns 'bullets' as default for signal", () => {
+    expect(resolveMarkdownTableMode({ channel: "signal" })).toBe("bullets");
+  });
+
+  it("returns 'bullets' as default for whatsapp", () => {
+    expect(resolveMarkdownTableMode({ channel: "whatsapp" })).toBe("bullets");
+  });
+
+  it("returns 'code' when no channel provided", () => {
+    expect(resolveMarkdownTableMode({})).toBe("code");
+    expect(resolveMarkdownTableMode({ channel: null })).toBe("code");
+  });
+
+  it("uses channel-level config override", () => {
+    const cfg = {
+      channels: {
+        telegram: { markdown: { tables: "bullets" } },
+      },
+    };
+    expect(resolveMarkdownTableMode({ cfg, channel: "telegram" })).toBe("bullets");
+  });
+
+  it("uses account-level config override", () => {
+    const cfg = {
+      channels: {
+        telegram: {
+          accounts: {
+            default: { markdown: { tables: "off" } },
+          },
+        },
+      },
+    };
+    expect(resolveMarkdownTableMode({ cfg, channel: "telegram", accountId: "default" })).toBe(
+      "off",
+    );
+  });
+
+  it("account-level takes priority over channel-level", () => {
+    const cfg = {
+      channels: {
+        telegram: {
+          markdown: { tables: "code" },
+          accounts: {
+            default: { markdown: { tables: "off" } },
+          },
+        },
+      },
+    };
+    expect(resolveMarkdownTableMode({ cfg, channel: "telegram", accountId: "default" })).toBe(
+      "off",
+    );
+  });
+
+  it("falls back to channel default when config section is empty", () => {
+    const cfg = { channels: { signal: {} } };
+    expect(resolveMarkdownTableMode({ cfg, channel: "signal" })).toBe("bullets");
+  });
+});

--- a/src/config/merge-patch.test.ts
+++ b/src/config/merge-patch.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { applyMergePatch } from "./merge-patch.js";
+
+describe("applyMergePatch", () => {
+  it("returns patch when patch is not a plain object", () => {
+    expect(applyMergePatch({ a: 1 }, "hello")).toBe("hello");
+    expect(applyMergePatch({ a: 1 }, 42)).toBe(42);
+    expect(applyMergePatch({ a: 1 }, null)).toBe(null);
+    expect(applyMergePatch({ a: 1 }, true)).toBe(true);
+  });
+
+  it("returns patch array (replaces base)", () => {
+    expect(applyMergePatch({ a: 1 }, [1, 2])).toEqual([1, 2]);
+  });
+
+  it("merges top-level keys", () => {
+    const result = applyMergePatch({ a: 1, b: 2 }, { b: 3, c: 4 });
+    expect(result).toEqual({ a: 1, b: 3, c: 4 });
+  });
+
+  it("deletes keys set to null", () => {
+    const result = applyMergePatch({ a: 1, b: 2 }, { b: null });
+    expect(result).toEqual({ a: 1 });
+  });
+
+  it("recursively merges nested objects", () => {
+    const base = { a: { x: 1, y: 2 }, b: 3 };
+    const patch = { a: { y: 99, z: 100 } };
+    expect(applyMergePatch(base, patch)).toEqual({ a: { x: 1, y: 99, z: 100 }, b: 3 });
+  });
+
+  it("replaces non-object base value with object patch", () => {
+    const result = applyMergePatch({ a: "string" }, { a: { nested: true } });
+    expect(result).toEqual({ a: { nested: true } });
+  });
+
+  it("creates object from empty base when patch is object", () => {
+    expect(applyMergePatch(null, { a: 1 })).toEqual({ a: 1 });
+    expect(applyMergePatch(undefined, { a: 1 })).toEqual({ a: 1 });
+    expect(applyMergePatch("string", { a: 1 })).toEqual({ a: 1 });
+  });
+
+  it("handles deeply nested null deletions", () => {
+    const base = { a: { b: { c: 1, d: 2 } } };
+    const patch = { a: { b: { c: null } } };
+    expect(applyMergePatch(base, patch)).toEqual({ a: { b: { d: 2 } } });
+  });
+
+  it("handles empty patch (no-op)", () => {
+    const base = { a: 1, b: 2 };
+    expect(applyMergePatch(base, {})).toEqual({ a: 1, b: 2 });
+  });
+
+  it("does not mutate base", () => {
+    const base = { a: 1, b: { c: 2 } };
+    const copy = JSON.parse(JSON.stringify(base));
+    applyMergePatch(base, { a: 99 });
+    expect(base).toEqual(copy);
+  });
+});

--- a/src/config/port-defaults.test.ts
+++ b/src/config/port-defaults.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import {
+  deriveDefaultBridgePort,
+  deriveDefaultBrowserControlPort,
+  deriveDefaultCanvasHostPort,
+  deriveDefaultBrowserCdpPortRange,
+  DEFAULT_BRIDGE_PORT,
+  DEFAULT_BROWSER_CONTROL_PORT,
+  DEFAULT_CANVAS_HOST_PORT,
+  DEFAULT_BROWSER_CDP_PORT_RANGE_START,
+  DEFAULT_BROWSER_CDP_PORT_RANGE_END,
+} from "./port-defaults.js";
+
+describe("deriveDefaultBridgePort", () => {
+  it("derives from gateway port + 1", () => {
+    expect(deriveDefaultBridgePort(18789)).toBe(18790);
+  });
+
+  it("falls back to default for invalid port", () => {
+    expect(deriveDefaultBridgePort(65535)).toBe(DEFAULT_BRIDGE_PORT);
+    expect(deriveDefaultBridgePort(-1)).toBe(DEFAULT_BRIDGE_PORT);
+    expect(deriveDefaultBridgePort(NaN)).toBe(DEFAULT_BRIDGE_PORT);
+  });
+
+  it("works with non-standard ports", () => {
+    expect(deriveDefaultBridgePort(8080)).toBe(8081);
+  });
+});
+
+describe("deriveDefaultBrowserControlPort", () => {
+  it("derives from gateway port + 2", () => {
+    expect(deriveDefaultBrowserControlPort(18789)).toBe(18791);
+  });
+
+  it("falls back to default for overflow", () => {
+    expect(deriveDefaultBrowserControlPort(65534)).toBe(DEFAULT_BROWSER_CONTROL_PORT);
+  });
+});
+
+describe("deriveDefaultCanvasHostPort", () => {
+  it("derives from gateway port + 4", () => {
+    expect(deriveDefaultCanvasHostPort(18789)).toBe(18793);
+  });
+
+  it("falls back to default for overflow", () => {
+    expect(deriveDefaultCanvasHostPort(65532)).toBe(DEFAULT_CANVAS_HOST_PORT);
+  });
+});
+
+describe("deriveDefaultBrowserCdpPortRange", () => {
+  it("derives range from browser control port + 9", () => {
+    const range = deriveDefaultBrowserCdpPortRange(18791);
+    expect(range.start).toBe(18800);
+    expect(range.end).toBe(18899);
+  });
+
+  it("falls back to defaults for invalid port", () => {
+    const range = deriveDefaultBrowserCdpPortRange(NaN);
+    expect(range.start).toBe(DEFAULT_BROWSER_CDP_PORT_RANGE_START);
+    expect(range.end).toBe(DEFAULT_BROWSER_CDP_PORT_RANGE_END);
+  });
+
+  it("maintains consistent range size", () => {
+    const range = deriveDefaultBrowserCdpPortRange(8080);
+    expect(range.end - range.start).toBe(
+      DEFAULT_BROWSER_CDP_PORT_RANGE_END - DEFAULT_BROWSER_CDP_PORT_RANGE_START,
+    );
+  });
+});

--- a/src/config/version.test.ts
+++ b/src/config/version.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { parseOpenClawVersion, compareOpenClawVersions } from "./version.js";
+
+describe("parseOpenClawVersion", () => {
+  it("returns null for null", () => {
+    expect(parseOpenClawVersion(null)).toBeNull();
+  });
+
+  it("returns null for undefined", () => {
+    expect(parseOpenClawVersion(undefined)).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(parseOpenClawVersion("")).toBeNull();
+  });
+
+  it("returns null for invalid version", () => {
+    expect(parseOpenClawVersion("not-a-version")).toBeNull();
+  });
+
+  it("parses x.y.z format", () => {
+    expect(parseOpenClawVersion("2026.2.3")).toEqual({
+      major: 2026,
+      minor: 2,
+      patch: 3,
+      revision: 0,
+    });
+  });
+
+  it("parses v-prefixed version", () => {
+    expect(parseOpenClawVersion("v2026.1.15")).toEqual({
+      major: 2026,
+      minor: 1,
+      patch: 15,
+      revision: 0,
+    });
+  });
+
+  it("parses version with revision", () => {
+    expect(parseOpenClawVersion("2026.2.3-1")).toEqual({
+      major: 2026,
+      minor: 2,
+      patch: 3,
+      revision: 1,
+    });
+  });
+
+  it("trims whitespace", () => {
+    expect(parseOpenClawVersion("  1.2.3  ")).toEqual({
+      major: 1,
+      minor: 2,
+      patch: 3,
+      revision: 0,
+    });
+  });
+});
+
+describe("compareOpenClawVersions", () => {
+  it("returns null when either version is invalid", () => {
+    expect(compareOpenClawVersions(null, "1.0.0")).toBeNull();
+    expect(compareOpenClawVersions("1.0.0", null)).toBeNull();
+    expect(compareOpenClawVersions("bad", "1.0.0")).toBeNull();
+  });
+
+  it("returns 0 for equal versions", () => {
+    expect(compareOpenClawVersions("1.2.3", "1.2.3")).toBe(0);
+  });
+
+  it("compares major versions", () => {
+    expect(compareOpenClawVersions("1.0.0", "2.0.0")).toBe(-1);
+    expect(compareOpenClawVersions("2.0.0", "1.0.0")).toBe(1);
+  });
+
+  it("compares minor versions", () => {
+    expect(compareOpenClawVersions("1.1.0", "1.2.0")).toBe(-1);
+    expect(compareOpenClawVersions("1.2.0", "1.1.0")).toBe(1);
+  });
+
+  it("compares patch versions", () => {
+    expect(compareOpenClawVersions("1.0.1", "1.0.2")).toBe(-1);
+    expect(compareOpenClawVersions("1.0.2", "1.0.1")).toBe(1);
+  });
+
+  it("compares revision", () => {
+    expect(compareOpenClawVersions("1.0.0-1", "1.0.0-2")).toBe(-1);
+    expect(compareOpenClawVersions("1.0.0-2", "1.0.0-1")).toBe(1);
+  });
+
+  it("treats missing revision as 0", () => {
+    expect(compareOpenClawVersions("1.0.0", "1.0.0-0")).toBe(0);
+    expect(compareOpenClawVersions("1.0.0", "1.0.0-1")).toBe(-1);
+  });
+});

--- a/src/config/workspace-schemas.test.ts
+++ b/src/config/workspace-schemas.test.ts
@@ -1,0 +1,132 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+function loadJson(relPath: string): unknown {
+  return JSON.parse(readFileSync(path.join(repoRoot, relPath), "utf-8"));
+}
+
+// ── narrative-variants.json ──────────────────────────
+
+describe("narrative-variants.json schema", () => {
+  const data = loadJson("workspace/data/narrative-variants.json") as Record<string, unknown>;
+
+  it("has a version string", () => {
+    expect(typeof data.version).toBe("string");
+    expect(data.version).toMatch(/^\d+\.\d+$/);
+  });
+
+  it("has a non-empty agendas array", () => {
+    expect(Array.isArray(data.agendas)).toBe(true);
+    expect((data.agendas as unknown[]).length).toBeGreaterThan(0);
+  });
+
+  it("each agenda has required fields", () => {
+    for (const agenda of data.agendas as Record<string, unknown>[]) {
+      expect(typeof agenda.id).toBe("string");
+      expect(agenda.id).not.toBe("");
+      expect(typeof agenda.topic).toBe("string");
+      expect(typeof agenda.description).toBe("string");
+      expect(Array.isArray(agenda.variants)).toBe(true);
+      expect((agenda.variants as unknown[]).length).toBeGreaterThan(0);
+    }
+  });
+
+  it("each variant has required fields", () => {
+    for (const agenda of data.agendas as Record<string, unknown>[]) {
+      for (const variant of agenda.variants as Record<string, unknown>[]) {
+        expect(typeof variant.field_pattern).toBe("string");
+        expect(variant.field_pattern).not.toBe("");
+        expect(typeof variant.framing).toBe("string");
+        expect(typeof variant.tone).toBe("string");
+        expect(Array.isArray(variant.talking_points)).toBe(true);
+        expect((variant.talking_points as string[]).length).toBeGreaterThan(0);
+        for (const tp of variant.talking_points as string[]) {
+          expect(typeof tp).toBe("string");
+        }
+        expect(Array.isArray(variant.forbidden_words)).toBe(true);
+        for (const fw of variant.forbidden_words as string[]) {
+          expect(typeof fw).toBe("string");
+        }
+      }
+    }
+  });
+
+  it("agenda ids are unique", () => {
+    const ids = (data.agendas as Record<string, unknown>[]).map((a) => a.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("tracking config is valid", () => {
+    const tracking = data.tracking as Record<string, unknown>;
+    expect(typeof tracking).toBe("object");
+    expect(typeof tracking.enabled).toBe("boolean");
+    expect(typeof tracking.conversion_window_minutes).toBe("number");
+    expect(tracking.conversion_window_minutes).toBeGreaterThan(0);
+  });
+});
+
+// ── warroom_dashboard_config.json ──────────────────────────
+
+describe("warroom_dashboard_config.json schema", () => {
+  const data = loadJson("workspace/data/warroom_dashboard_config.json") as Record<string, unknown>;
+  const config = data.warroom_dashboard as Record<string, unknown>;
+
+  it("has warroom_dashboard top-level key", () => {
+    expect(config).toBeDefined();
+    expect(typeof config).toBe("object");
+  });
+
+  it("has a valid version", () => {
+    expect(typeof config.version).toBe("string");
+    expect(config.version).toMatch(/^\d+\.\d+$/);
+  });
+
+  it("has update_interval_minutes", () => {
+    expect(typeof config.update_interval_minutes).toBe("number");
+    expect(config.update_interval_minutes).toBeGreaterThan(0);
+  });
+
+  it("output has chat_id and message_id", () => {
+    const output = config.output as Record<string, unknown>;
+    expect(typeof output).toBe("object");
+    expect(typeof output.chat_id).toBe("string");
+    expect(typeof output.message_id).toBe("string");
+  });
+
+  it("has a non-empty monitored_chats array", () => {
+    expect(Array.isArray(config.monitored_chats)).toBe(true);
+    expect((config.monitored_chats as unknown[]).length).toBeGreaterThan(0);
+  });
+
+  it("each monitored chat has required fields", () => {
+    for (const chat of config.monitored_chats as Record<string, unknown>[]) {
+      expect(typeof chat.id).toBe("string");
+      expect(chat.id).not.toBe("");
+      expect(typeof chat.name).toBe("string");
+      expect(chat.name).not.toBe("");
+      expect(typeof chat.channel).toBe("string");
+      expect(["telegram", "line", "discord", "whatsapp", "slack"]).toContain(chat.channel);
+    }
+  });
+
+  it("agents in monitored chats have id and name", () => {
+    for (const chat of config.monitored_chats as Record<string, unknown>[]) {
+      if (chat.agents) {
+        expect(Array.isArray(chat.agents)).toBe(true);
+        for (const agent of chat.agents as Record<string, unknown>[]) {
+          expect(typeof agent.id).toBe("string");
+          expect(typeof agent.name).toBe("string");
+        }
+      }
+    }
+  });
+
+  it("has agent_visibility_threshold", () => {
+    expect(typeof config.agent_visibility_threshold).toBe("number");
+    expect(config.agent_visibility_threshold).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/src/discord/monitor/format.test.ts
+++ b/src/discord/monitor/format.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveDiscordSystemLocation,
+  formatDiscordReactionEmoji,
+  formatDiscordUserTag,
+  resolveTimestampMs,
+} from "./format.js";
+
+describe("resolveDiscordSystemLocation", () => {
+  it("returns DM for direct messages", () => {
+    expect(
+      resolveDiscordSystemLocation({
+        isDirectMessage: true,
+        isGroupDm: false,
+        channelName: "general",
+      }),
+    ).toBe("DM");
+  });
+
+  it("returns Group DM with channel name", () => {
+    expect(
+      resolveDiscordSystemLocation({
+        isDirectMessage: false,
+        isGroupDm: true,
+        channelName: "friends",
+      }),
+    ).toBe("Group DM #friends");
+  });
+
+  it("returns guild name with channel", () => {
+    expect(
+      resolveDiscordSystemLocation({
+        isDirectMessage: false,
+        isGroupDm: false,
+        guild: { name: "My Server" } as any,
+        channelName: "general",
+      }),
+    ).toBe("My Server #general");
+  });
+
+  it("returns channel only when no guild name", () => {
+    expect(
+      resolveDiscordSystemLocation({
+        isDirectMessage: false,
+        isGroupDm: false,
+        channelName: "general",
+      }),
+    ).toBe("#general");
+  });
+});
+
+describe("formatDiscordReactionEmoji", () => {
+  it("formats custom emoji with name and id", () => {
+    expect(formatDiscordReactionEmoji({ id: "12345", name: "thumbsup" })).toBe("thumbsup:12345");
+  });
+
+  it("returns name only for unicode emoji", () => {
+    expect(formatDiscordReactionEmoji({ name: "👍" })).toBe("👍");
+  });
+
+  it("returns 'emoji' when no name", () => {
+    expect(formatDiscordReactionEmoji({})).toBe("emoji");
+  });
+
+  it("returns 'emoji' for null name", () => {
+    expect(formatDiscordReactionEmoji({ name: null })).toBe("emoji");
+  });
+});
+
+describe("formatDiscordUserTag", () => {
+  it("returns username#discriminator for non-zero discriminator", () => {
+    expect(formatDiscordUserTag({ username: "alice", discriminator: "1234" } as any)).toBe(
+      "alice#1234",
+    );
+  });
+
+  it("returns username for discriminator '0'", () => {
+    expect(formatDiscordUserTag({ username: "alice", discriminator: "0" } as any)).toBe("alice");
+  });
+
+  it("returns username when discriminator is empty", () => {
+    expect(formatDiscordUserTag({ username: "alice", discriminator: "" } as any)).toBe("alice");
+  });
+
+  it("returns username when no discriminator", () => {
+    expect(formatDiscordUserTag({ username: "alice" } as any)).toBe("alice");
+  });
+
+  it("falls back to id when no username", () => {
+    expect(formatDiscordUserTag({ id: "999" } as any)).toBe("999");
+  });
+});
+
+describe("resolveTimestampMs", () => {
+  it("returns undefined for undefined", () => {
+    expect(resolveTimestampMs(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined for null", () => {
+    expect(resolveTimestampMs(null)).toBeUndefined();
+  });
+
+  it("returns undefined for empty string", () => {
+    expect(resolveTimestampMs("")).toBeUndefined();
+  });
+
+  it("parses ISO date string", () => {
+    expect(resolveTimestampMs("2025-01-15T12:00:00.000Z")).toBe(
+      Date.parse("2025-01-15T12:00:00.000Z"),
+    );
+  });
+
+  it("returns undefined for invalid date", () => {
+    expect(resolveTimestampMs("not-a-date")).toBeUndefined();
+  });
+});

--- a/src/feishu/domain.test.ts
+++ b/src/feishu/domain.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeFeishuDomain,
+  resolveFeishuDomain,
+  resolveFeishuApiBase,
+  FEISHU_DOMAIN,
+  LARK_DOMAIN,
+} from "./domain.js";
+
+describe("normalizeFeishuDomain", () => {
+  it("returns undefined for null/undefined/empty", () => {
+    expect(normalizeFeishuDomain(null)).toBeUndefined();
+    expect(normalizeFeishuDomain(undefined)).toBeUndefined();
+    expect(normalizeFeishuDomain("")).toBeUndefined();
+    expect(normalizeFeishuDomain("   ")).toBeUndefined();
+  });
+
+  it("maps 'feishu' to FEISHU_DOMAIN", () => {
+    expect(normalizeFeishuDomain("feishu")).toBe(FEISHU_DOMAIN);
+    expect(normalizeFeishuDomain("cn")).toBe(FEISHU_DOMAIN);
+    expect(normalizeFeishuDomain("china")).toBe(FEISHU_DOMAIN);
+  });
+
+  it("maps 'lark' to LARK_DOMAIN", () => {
+    expect(normalizeFeishuDomain("lark")).toBe(LARK_DOMAIN);
+    expect(normalizeFeishuDomain("global")).toBe(LARK_DOMAIN);
+    expect(normalizeFeishuDomain("intl")).toBe(LARK_DOMAIN);
+    expect(normalizeFeishuDomain("international")).toBe(LARK_DOMAIN);
+  });
+
+  it("is case-insensitive", () => {
+    expect(normalizeFeishuDomain("FEISHU")).toBe(FEISHU_DOMAIN);
+    expect(normalizeFeishuDomain("Lark")).toBe(LARK_DOMAIN);
+  });
+
+  it("adds https:// to bare domains", () => {
+    expect(normalizeFeishuDomain("custom.example.com")).toBe("https://custom.example.com");
+  });
+
+  it("preserves existing scheme", () => {
+    expect(normalizeFeishuDomain("https://custom.example.com")).toBe("https://custom.example.com");
+  });
+
+  it("strips trailing slashes", () => {
+    expect(normalizeFeishuDomain("https://custom.example.com/")).toBe("https://custom.example.com");
+  });
+
+  it("strips /open-apis suffix", () => {
+    expect(normalizeFeishuDomain("https://custom.example.com/open-apis")).toBe(
+      "https://custom.example.com",
+    );
+  });
+});
+
+describe("resolveFeishuDomain", () => {
+  it("defaults to FEISHU_DOMAIN when undefined", () => {
+    expect(resolveFeishuDomain(undefined)).toBe(FEISHU_DOMAIN);
+  });
+
+  it("returns custom domain when provided", () => {
+    expect(resolveFeishuDomain("lark")).toBe(LARK_DOMAIN);
+  });
+});
+
+describe("resolveFeishuApiBase", () => {
+  it("appends /open-apis to resolved domain", () => {
+    expect(resolveFeishuApiBase(undefined)).toBe(`${FEISHU_DOMAIN}/open-apis`);
+    expect(resolveFeishuApiBase("lark")).toBe(`${LARK_DOMAIN}/open-apis`);
+  });
+
+  it("strips trailing slashes before appending", () => {
+    expect(resolveFeishuApiBase("https://custom.example.com/")).toBe(
+      "https://custom.example.com/open-apis",
+    );
+  });
+});

--- a/src/gateway/device-auth.test.ts
+++ b/src/gateway/device-auth.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { buildDeviceAuthPayload } from "./device-auth.js";
+
+const base = {
+  deviceId: "dev-1",
+  clientId: "cli-1",
+  clientMode: "gateway",
+  role: "admin",
+  scopes: ["read", "write"],
+  signedAtMs: 1700000000000,
+};
+
+describe("buildDeviceAuthPayload", () => {
+  it("builds v1 payload by default (no nonce)", () => {
+    const result = buildDeviceAuthPayload(base);
+    expect(result).toBe("v1|dev-1|cli-1|gateway|admin|read,write|1700000000000|");
+  });
+
+  it("includes token when provided", () => {
+    const result = buildDeviceAuthPayload({ ...base, token: "tok-abc" });
+    expect(result).toBe("v1|dev-1|cli-1|gateway|admin|read,write|1700000000000|tok-abc");
+  });
+
+  it("uses empty string for null token", () => {
+    const result = buildDeviceAuthPayload({ ...base, token: null });
+    expect(result).toContain("|1700000000000|");
+    expect(result).toMatch(/\|$/);
+  });
+
+  it("auto-detects v2 when nonce is present", () => {
+    const result = buildDeviceAuthPayload({ ...base, nonce: "n-42" });
+    expect(result).toMatch(/^v2\|/);
+    expect(result).toMatch(/\|n-42$/);
+  });
+
+  it("appends nonce field for v2", () => {
+    const result = buildDeviceAuthPayload({ ...base, version: "v2", nonce: "n-99" });
+    const parts = result.split("|");
+    expect(parts[0]).toBe("v2");
+    expect(parts[parts.length - 1]).toBe("n-99");
+  });
+
+  it("uses empty nonce for v2 when nonce is null", () => {
+    const result = buildDeviceAuthPayload({ ...base, version: "v2", nonce: null });
+    const parts = result.split("|");
+    expect(parts[0]).toBe("v2");
+    expect(parts[parts.length - 1]).toBe("");
+  });
+
+  it("explicit version overrides auto-detection", () => {
+    const result = buildDeviceAuthPayload({ ...base, version: "v1", nonce: "ignored" });
+    expect(result).toMatch(/^v1\|/);
+    expect(result).not.toContain("ignored");
+  });
+
+  it("joins scopes with comma", () => {
+    const result = buildDeviceAuthPayload({ ...base, scopes: ["a", "b", "c"] });
+    expect(result).toContain("|a,b,c|");
+  });
+
+  it("handles empty scopes array", () => {
+    const result = buildDeviceAuthPayload({ ...base, scopes: [] });
+    expect(result).toContain("||");
+  });
+
+  it("stringifies signedAtMs", () => {
+    const result = buildDeviceAuthPayload({ ...base, signedAtMs: 0 });
+    expect(result).toContain("|0|");
+  });
+});

--- a/src/gateway/http-utils.test.ts
+++ b/src/gateway/http-utils.test.ts
@@ -1,0 +1,113 @@
+import type { IncomingMessage } from "node:http";
+import { describe, expect, it } from "vitest";
+import {
+  getHeader,
+  getBearerToken,
+  resolveAgentIdFromHeader,
+  resolveAgentIdFromModel,
+  resolveAgentIdForRequest,
+} from "./http-utils.js";
+
+function mockReq(headers: Record<string, string | string[] | undefined>): IncomingMessage {
+  return { headers } as unknown as IncomingMessage;
+}
+
+describe("getHeader", () => {
+  it("returns string header", () => {
+    expect(getHeader(mockReq({ "content-type": "text/plain" }), "Content-Type")).toBe("text/plain");
+  });
+
+  it("returns first element of array header", () => {
+    expect(getHeader(mockReq({ accept: ["text/html", "application/json"] }), "Accept")).toBe(
+      "text/html",
+    );
+  });
+
+  it("returns undefined for missing header", () => {
+    expect(getHeader(mockReq({}), "X-Missing")).toBeUndefined();
+  });
+});
+
+describe("getBearerToken", () => {
+  it("extracts bearer token", () => {
+    expect(getBearerToken(mockReq({ authorization: "Bearer abc123" }))).toBe("abc123");
+  });
+
+  it("is case-insensitive", () => {
+    expect(getBearerToken(mockReq({ authorization: "bearer TOKEN" }))).toBe("TOKEN");
+  });
+
+  it("returns undefined for non-bearer auth", () => {
+    expect(getBearerToken(mockReq({ authorization: "Basic abc" }))).toBeUndefined();
+  });
+
+  it("returns undefined for missing header", () => {
+    expect(getBearerToken(mockReq({}))).toBeUndefined();
+  });
+
+  it("returns undefined for empty token", () => {
+    expect(getBearerToken(mockReq({ authorization: "Bearer " }))).toBeUndefined();
+  });
+});
+
+describe("resolveAgentIdFromHeader", () => {
+  it("reads x-openclaw-agent-id", () => {
+    expect(resolveAgentIdFromHeader(mockReq({ "x-openclaw-agent-id": "my-agent" }))).toBe(
+      "my-agent",
+    );
+  });
+
+  it("falls back to x-openclaw-agent", () => {
+    expect(resolveAgentIdFromHeader(mockReq({ "x-openclaw-agent": "fallback" }))).toBe("fallback");
+  });
+
+  it("returns undefined for missing headers", () => {
+    expect(resolveAgentIdFromHeader(mockReq({}))).toBeUndefined();
+  });
+
+  it("trims whitespace", () => {
+    expect(resolveAgentIdFromHeader(mockReq({ "x-openclaw-agent-id": "  trimmed  " }))).toBe(
+      "trimmed",
+    );
+  });
+});
+
+describe("resolveAgentIdFromModel", () => {
+  it("extracts from openclaw/agentId", () => {
+    expect(resolveAgentIdFromModel("openclaw/my-agent")).toBe("my-agent");
+  });
+
+  it("extracts from openclaw:agentId", () => {
+    expect(resolveAgentIdFromModel("openclaw:my-agent")).toBe("my-agent");
+  });
+
+  it("extracts from agent:agentId", () => {
+    expect(resolveAgentIdFromModel("agent:my-agent")).toBe("my-agent");
+  });
+
+  it("returns undefined for plain model names", () => {
+    expect(resolveAgentIdFromModel("claude-3-opus")).toBeUndefined();
+  });
+
+  it("returns undefined for empty/undefined", () => {
+    expect(resolveAgentIdFromModel(undefined)).toBeUndefined();
+    expect(resolveAgentIdFromModel("")).toBeUndefined();
+  });
+});
+
+describe("resolveAgentIdForRequest", () => {
+  it("prefers header over model", () => {
+    const req = mockReq({ "x-openclaw-agent-id": "from-header" });
+    expect(resolveAgentIdForRequest({ req, model: "openclaw/from-model" })).toBe("from-header");
+  });
+
+  it("falls back to model", () => {
+    const req = mockReq({});
+    expect(resolveAgentIdForRequest({ req, model: "openclaw/from-model" })).toBe("from-model");
+  });
+
+  it("defaults to main", () => {
+    const req = mockReq({});
+    expect(resolveAgentIdForRequest({ req, model: "claude-3" })).toBe("main");
+  });
+});

--- a/src/infra/backoff.test.ts
+++ b/src/infra/backoff.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+import { computeBackoff, sleepWithAbort } from "./backoff.js";
+
+describe("computeBackoff", () => {
+  const policy = { initialMs: 100, maxMs: 5000, factor: 2, jitter: 0 };
+
+  it("returns initialMs for attempt 1 with no jitter", () => {
+    expect(computeBackoff(policy, 1)).toBe(100);
+  });
+
+  it("doubles for attempt 2", () => {
+    expect(computeBackoff(policy, 2)).toBe(200);
+  });
+
+  it("caps at maxMs", () => {
+    expect(computeBackoff(policy, 100)).toBe(5000);
+  });
+
+  it("treats attempt 0 same as attempt 1", () => {
+    expect(computeBackoff(policy, 0)).toBe(100);
+  });
+
+  it("adds jitter when configured", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    const jitterPolicy = { initialMs: 100, maxMs: 10000, factor: 2, jitter: 0.2 };
+    const result = computeBackoff(jitterPolicy, 1);
+    // base=100, jitter=100*0.2*0.5=10 → 110
+    expect(result).toBe(110);
+    vi.restoreAllMocks();
+  });
+
+  it("rounds to integer", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.3);
+    const jitterPolicy = { initialMs: 100, maxMs: 10000, factor: 2, jitter: 0.1 };
+    const result = computeBackoff(jitterPolicy, 1);
+    expect(Number.isInteger(result)).toBe(true);
+    vi.restoreAllMocks();
+  });
+});
+
+describe("sleepWithAbort", () => {
+  it("resolves immediately for ms <= 0", async () => {
+    await sleepWithAbort(0);
+    await sleepWithAbort(-1);
+  });
+
+  it("throws on aborted signal", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    await expect(sleepWithAbort(10000, controller.signal)).rejects.toThrow("aborted");
+  });
+});

--- a/src/infra/bonjour-errors.test.ts
+++ b/src/infra/bonjour-errors.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { formatBonjourError } from "./bonjour-errors.js";
+
+describe("formatBonjourError", () => {
+  it("formats a plain Error", () => {
+    expect(formatBonjourError(new Error("boom"))).toBe("boom");
+  });
+
+  it("formats an Error with a custom name", () => {
+    const err = new Error("bad");
+    err.name = "BonjourError";
+    expect(formatBonjourError(err)).toBe("BonjourError: bad");
+  });
+
+  it("uses message when name is generic 'Error'", () => {
+    const err = new Error("generic");
+    expect(formatBonjourError(err)).toBe("generic");
+  });
+
+  it("stringifies non-Error values", () => {
+    expect(formatBonjourError("oops")).toBe("oops");
+    expect(formatBonjourError(42)).toBe("42");
+    expect(formatBonjourError(null)).toBe("null");
+    expect(formatBonjourError(undefined)).toBe("undefined");
+  });
+
+  it("handles Error with empty message and custom name", () => {
+    const err = new Error("");
+    err.name = "TimeoutError";
+    // err.message is "", String(err) is "TimeoutError"
+    expect(formatBonjourError(err)).toContain("TimeoutError");
+  });
+});

--- a/src/infra/canvas-host-url.test.ts
+++ b/src/infra/canvas-host-url.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { resolveCanvasHostUrl } from "./canvas-host-url.js";
+
+describe("resolveCanvasHostUrl", () => {
+  it("returns undefined when no port", () => {
+    expect(resolveCanvasHostUrl({})).toBeUndefined();
+    expect(resolveCanvasHostUrl({ canvasPort: 0 })).toBeUndefined();
+  });
+
+  it("returns undefined when no host resolves", () => {
+    expect(resolveCanvasHostUrl({ canvasPort: 3000 })).toBeUndefined();
+  });
+
+  it("uses hostOverride as primary host", () => {
+    expect(resolveCanvasHostUrl({ canvasPort: 3000, hostOverride: "example.com" })).toBe(
+      "http://example.com:3000",
+    );
+  });
+
+  it("uses requestHost when no override", () => {
+    expect(resolveCanvasHostUrl({ canvasPort: 3000, requestHost: "api.example.com" })).toBe(
+      "http://api.example.com:3000",
+    );
+  });
+
+  it("uses localAddress as fallback", () => {
+    expect(resolveCanvasHostUrl({ canvasPort: 3000, localAddress: "192.168.1.100" })).toBe(
+      "http://192.168.1.100:3000",
+    );
+  });
+
+  it("rejects loopback hostOverride", () => {
+    expect(resolveCanvasHostUrl({ canvasPort: 3000, hostOverride: "localhost" })).toBeUndefined();
+    expect(resolveCanvasHostUrl({ canvasPort: 3000, hostOverride: "127.0.0.1" })).toBeUndefined();
+    expect(resolveCanvasHostUrl({ canvasPort: 3000, hostOverride: "::1" })).toBeUndefined();
+  });
+
+  it("rejects loopback requestHost when override is present", () => {
+    expect(
+      resolveCanvasHostUrl({
+        canvasPort: 3000,
+        hostOverride: "example.com",
+        requestHost: "localhost:3000",
+      }),
+    ).toBe("http://example.com:3000");
+  });
+
+  it("uses https scheme when forwardedProto is https", () => {
+    expect(
+      resolveCanvasHostUrl({
+        canvasPort: 3000,
+        hostOverride: "example.com",
+        forwardedProto: "https",
+      }),
+    ).toBe("https://example.com:3000");
+  });
+
+  it("handles array forwardedProto", () => {
+    expect(
+      resolveCanvasHostUrl({
+        canvasPort: 3000,
+        hostOverride: "example.com",
+        forwardedProto: ["https", "http"],
+      }),
+    ).toBe("https://example.com:3000");
+  });
+
+  it("wraps IPv6 address in brackets", () => {
+    expect(resolveCanvasHostUrl({ canvasPort: 3000, hostOverride: "fe80::1" })).toBe(
+      "http://[fe80::1]:3000",
+    );
+  });
+
+  it("explicit scheme overrides forwardedProto", () => {
+    expect(
+      resolveCanvasHostUrl({
+        canvasPort: 3000,
+        hostOverride: "example.com",
+        forwardedProto: "https",
+        scheme: "http",
+      }),
+    ).toBe("http://example.com:3000");
+  });
+
+  it("trims whitespace from hosts", () => {
+    expect(resolveCanvasHostUrl({ canvasPort: 3000, hostOverride: "  example.com  " })).toBe(
+      "http://example.com:3000",
+    );
+  });
+
+  it("treats empty string host as missing", () => {
+    expect(resolveCanvasHostUrl({ canvasPort: 3000, hostOverride: "  " })).toBeUndefined();
+  });
+});

--- a/src/infra/errors.test.ts
+++ b/src/infra/errors.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { extractErrorCode, formatErrorMessage, formatUncaughtError } from "./errors.js";
+
+describe("extractErrorCode", () => {
+  it("returns undefined for non-object", () => {
+    expect(extractErrorCode(null)).toBeUndefined();
+    expect(extractErrorCode("string")).toBeUndefined();
+    expect(extractErrorCode(42)).toBeUndefined();
+  });
+
+  it("extracts string code", () => {
+    expect(extractErrorCode({ code: "ENOENT" })).toBe("ENOENT");
+  });
+
+  it("extracts numeric code as string", () => {
+    expect(extractErrorCode({ code: 404 })).toBe("404");
+  });
+
+  it("returns undefined for non-string/non-number code", () => {
+    expect(extractErrorCode({ code: true })).toBeUndefined();
+    expect(extractErrorCode({})).toBeUndefined();
+  });
+});
+
+describe("formatErrorMessage", () => {
+  it("returns Error message", () => {
+    expect(formatErrorMessage(new Error("boom"))).toBe("boom");
+  });
+
+  it("returns Error name when message is empty", () => {
+    const err = new Error("");
+    err.name = "CustomError";
+    expect(formatErrorMessage(err)).toBe("CustomError");
+  });
+
+  it("returns string as-is", () => {
+    expect(formatErrorMessage("oops")).toBe("oops");
+  });
+
+  it("stringifies primitives", () => {
+    expect(formatErrorMessage(42)).toBe("42");
+    expect(formatErrorMessage(true)).toBe("true");
+    expect(formatErrorMessage(BigInt(99))).toBe("99");
+  });
+
+  it("JSON-stringifies objects", () => {
+    expect(formatErrorMessage({ a: 1 })).toBe('{"a":1}');
+  });
+
+  it("falls back for circular objects", () => {
+    const obj: any = {};
+    obj.self = obj;
+    expect(typeof formatErrorMessage(obj)).toBe("string");
+  });
+});
+
+describe("formatUncaughtError", () => {
+  it("returns message for INVALID_CONFIG errors", () => {
+    const err: any = new Error("bad config");
+    err.code = "INVALID_CONFIG";
+    expect(formatUncaughtError(err)).toBe("bad config");
+  });
+
+  it("returns stack for regular errors", () => {
+    const err = new Error("test");
+    expect(formatUncaughtError(err)).toContain("test");
+    expect(formatUncaughtError(err)).toContain("Error");
+  });
+
+  it("handles non-error values", () => {
+    expect(formatUncaughtError("string error")).toBe("string error");
+    expect(formatUncaughtError(null)).toBe("null");
+  });
+});

--- a/src/infra/exec-safety.test.ts
+++ b/src/infra/exec-safety.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { isSafeExecutableValue } from "./exec-safety.js";
+
+describe("isSafeExecutableValue", () => {
+  it("rejects null", () => {
+    expect(isSafeExecutableValue(null)).toBe(false);
+  });
+
+  it("rejects undefined", () => {
+    expect(isSafeExecutableValue(undefined)).toBe(false);
+  });
+
+  it("rejects empty string", () => {
+    expect(isSafeExecutableValue("")).toBe(false);
+  });
+
+  it("rejects whitespace-only string", () => {
+    expect(isSafeExecutableValue("   ")).toBe(false);
+  });
+
+  it("accepts bare command name", () => {
+    expect(isSafeExecutableValue("node")).toBe(true);
+    expect(isSafeExecutableValue("ffmpeg")).toBe(true);
+    expect(isSafeExecutableValue("my-tool_v2.3")).toBe(true);
+  });
+
+  it("accepts path-like values", () => {
+    expect(isSafeExecutableValue("/usr/bin/node")).toBe(true);
+    expect(isSafeExecutableValue("./run.sh")).toBe(true);
+    expect(isSafeExecutableValue("~/bin/tool")).toBe(true);
+    expect(isSafeExecutableValue("C:\\Program Files\\tool.exe")).toBe(true); // backslash triggers isLikelyPath
+  });
+
+  it("accepts Windows drive paths", () => {
+    expect(isSafeExecutableValue("C:/tools/node.exe")).toBe(true);
+  });
+
+  it("rejects shell metacharacters", () => {
+    expect(isSafeExecutableValue("cmd; rm -rf /")).toBe(false);
+    expect(isSafeExecutableValue("cmd & background")).toBe(false);
+    expect(isSafeExecutableValue("cmd | pipe")).toBe(false);
+    expect(isSafeExecutableValue("cmd `sub`")).toBe(false);
+    expect(isSafeExecutableValue("cmd $VAR")).toBe(false);
+    expect(isSafeExecutableValue("cmd < input")).toBe(false);
+    expect(isSafeExecutableValue("cmd > output")).toBe(false);
+  });
+
+  it("rejects control characters", () => {
+    expect(isSafeExecutableValue("cmd\nrm")).toBe(false);
+    expect(isSafeExecutableValue("cmd\rrm")).toBe(false);
+  });
+
+  it("rejects null bytes", () => {
+    expect(isSafeExecutableValue("cmd\0evil")).toBe(false);
+  });
+
+  it("rejects quotes", () => {
+    expect(isSafeExecutableValue(`cmd"inject`)).toBe(false);
+    expect(isSafeExecutableValue("cmd'inject")).toBe(false);
+  });
+
+  it("rejects flags (starts with dash)", () => {
+    expect(isSafeExecutableValue("-rf")).toBe(false);
+    expect(isSafeExecutableValue("--version")).toBe(false);
+  });
+
+  it("accepts names with dots, plus, dash in middle", () => {
+    expect(isSafeExecutableValue("node.js")).toBe(true);
+    expect(isSafeExecutableValue("g++")).toBe(true);
+    expect(isSafeExecutableValue("c++")).toBe(true);
+    expect(isSafeExecutableValue("tool+extra")).toBe(true);
+  });
+});

--- a/src/infra/format-duration.test.ts
+++ b/src/infra/format-duration.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { formatDurationSeconds, formatDurationMs } from "./format-duration.js";
+
+describe("formatDurationSeconds", () => {
+  it("formats milliseconds to seconds with default unit", () => {
+    expect(formatDurationSeconds(1500)).toBe("1.5s");
+  });
+
+  it("formats zero", () => {
+    expect(formatDurationSeconds(0)).toBe("0s");
+  });
+
+  it("trims trailing zeros", () => {
+    expect(formatDurationSeconds(2000)).toBe("2s");
+    expect(formatDurationSeconds(2100)).toBe("2.1s");
+  });
+
+  it("returns 'unknown' for non-finite values", () => {
+    expect(formatDurationSeconds(Infinity)).toBe("unknown");
+    expect(formatDurationSeconds(NaN)).toBe("unknown");
+  });
+
+  it("clamps negative to 0", () => {
+    expect(formatDurationSeconds(-500)).toBe("0s");
+  });
+
+  it("respects decimals option", () => {
+    expect(formatDurationSeconds(1234, { decimals: 2 })).toBe("1.23s");
+  });
+
+  it("supports 'seconds' unit", () => {
+    expect(formatDurationSeconds(3000, { unit: "seconds" })).toBe("3 seconds");
+  });
+});
+
+describe("formatDurationMs", () => {
+  it("returns ms for values under 1000", () => {
+    expect(formatDurationMs(500)).toBe("500ms");
+    expect(formatDurationMs(0)).toBe("0ms");
+    expect(formatDurationMs(999)).toBe("999ms");
+  });
+
+  it("returns seconds for values >= 1000", () => {
+    expect(formatDurationMs(1000)).toBe("1s");
+    expect(formatDurationMs(1500)).toBe("1.5s");
+  });
+
+  it("returns 'unknown' for non-finite", () => {
+    expect(formatDurationMs(Infinity)).toBe("unknown");
+    expect(formatDurationMs(NaN)).toBe("unknown");
+  });
+
+  it("supports 'seconds' unit for large values", () => {
+    expect(formatDurationMs(2000, { unit: "seconds" })).toBe("2 seconds");
+  });
+});

--- a/src/infra/heartbeat-events.test.ts
+++ b/src/infra/heartbeat-events.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import {
+  resolveIndicatorType,
+  emitHeartbeatEvent,
+  onHeartbeatEvent,
+  getLastHeartbeatEvent,
+} from "./heartbeat-events.js";
+
+describe("resolveIndicatorType", () => {
+  it("maps ok-empty to ok", () => {
+    expect(resolveIndicatorType("ok-empty")).toBe("ok");
+  });
+
+  it("maps ok-token to ok", () => {
+    expect(resolveIndicatorType("ok-token")).toBe("ok");
+  });
+
+  it("maps sent to alert", () => {
+    expect(resolveIndicatorType("sent")).toBe("alert");
+  });
+
+  it("maps failed to error", () => {
+    expect(resolveIndicatorType("failed")).toBe("error");
+  });
+
+  it("maps skipped to undefined", () => {
+    expect(resolveIndicatorType("skipped")).toBeUndefined();
+  });
+});
+
+describe("heartbeat event emitter", () => {
+  it("emits events to listeners", () => {
+    const listener = vi.fn();
+    const unsub = onHeartbeatEvent(listener);
+    emitHeartbeatEvent({ status: "sent", to: "test" });
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener.mock.calls[0][0]).toMatchObject({ status: "sent", to: "test" });
+    expect(listener.mock.calls[0][0].ts).toBeTypeOf("number");
+    unsub();
+  });
+
+  it("unsubscribes correctly", () => {
+    const listener = vi.fn();
+    const unsub = onHeartbeatEvent(listener);
+    unsub();
+    emitHeartbeatEvent({ status: "ok-empty" });
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("stores last heartbeat", () => {
+    emitHeartbeatEvent({ status: "failed", reason: "timeout" });
+    const last = getLastHeartbeatEvent();
+    expect(last).toMatchObject({ status: "failed", reason: "timeout" });
+  });
+
+  it("tolerates listener errors", () => {
+    const badListener = vi.fn(() => {
+      throw new Error("boom");
+    });
+    const goodListener = vi.fn();
+    const unsub1 = onHeartbeatEvent(badListener);
+    const unsub2 = onHeartbeatEvent(goodListener);
+    emitHeartbeatEvent({ status: "sent" });
+    expect(goodListener).toHaveBeenCalledOnce();
+    unsub1();
+    unsub2();
+  });
+});

--- a/src/infra/outbound/channel-adapters.test.ts
+++ b/src/infra/outbound/channel-adapters.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { getChannelMessageAdapter } from "./channel-adapters.js";
+
+describe("getChannelMessageAdapter", () => {
+  it("returns discord adapter with embed support", () => {
+    const adapter = getChannelMessageAdapter("discord");
+    expect(adapter.supportsEmbeds).toBe(true);
+    expect(adapter.buildCrossContextEmbeds).toBeDefined();
+  });
+
+  it("discord adapter builds cross-context embeds", () => {
+    const adapter = getChannelMessageAdapter("discord");
+    const embeds = adapter.buildCrossContextEmbeds!("TG #general");
+    expect(embeds).toEqual([{ description: "From TG #general" }]);
+  });
+
+  it("returns default adapter for telegram", () => {
+    const adapter = getChannelMessageAdapter("telegram");
+    expect(adapter.supportsEmbeds).toBe(false);
+    expect(adapter.buildCrossContextEmbeds).toBeUndefined();
+  });
+
+  it("returns default adapter for line", () => {
+    const adapter = getChannelMessageAdapter("line");
+    expect(adapter.supportsEmbeds).toBe(false);
+  });
+
+  it("returns default adapter for whatsapp", () => {
+    const adapter = getChannelMessageAdapter("whatsapp");
+    expect(adapter.supportsEmbeds).toBe(false);
+  });
+
+  it("returns default adapter for unknown channel", () => {
+    const adapter = getChannelMessageAdapter("unknown" as any);
+    expect(adapter.supportsEmbeds).toBe(false);
+  });
+});

--- a/src/infra/outbound/directory-cache.test.ts
+++ b/src/infra/outbound/directory-cache.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { buildDirectoryCacheKey, DirectoryCache } from "./directory-cache.js";
+
+describe("buildDirectoryCacheKey", () => {
+  it("builds key with all fields", () => {
+    const key = buildDirectoryCacheKey({
+      channel: "telegram" as any,
+      accountId: "main",
+      kind: "user" as any,
+      source: "cache",
+      signature: "sig1",
+    });
+    expect(key).toBe("telegram:main:user:cache:sig1");
+  });
+
+  it("defaults accountId to 'default'", () => {
+    const key = buildDirectoryCacheKey({
+      channel: "discord" as any,
+      kind: "channel" as any,
+      source: "live",
+    });
+    expect(key).toBe("discord:default:channel:live:default");
+  });
+
+  it("defaults signature to 'default'", () => {
+    const key = buildDirectoryCacheKey({
+      channel: "slack" as any,
+      accountId: "a1",
+      kind: "user" as any,
+      source: "cache",
+      signature: null,
+    });
+    expect(key).toBe("slack:a1:user:cache:default");
+  });
+});
+
+describe("DirectoryCache", () => {
+  const cfg1 = { test: 1 } as any;
+  const cfg2 = { test: 2 } as any;
+
+  it("stores and retrieves values", () => {
+    const cache = new DirectoryCache<string>(60000);
+    cache.set("k1", "v1", cfg1);
+    expect(cache.get("k1", cfg1)).toBe("v1");
+  });
+
+  it("returns undefined for missing keys", () => {
+    const cache = new DirectoryCache<string>(60000);
+    expect(cache.get("missing", cfg1)).toBeUndefined();
+  });
+
+  it("expires entries after TTL", () => {
+    vi.useFakeTimers();
+    const cache = new DirectoryCache<string>(1000);
+    cache.set("k1", "v1", cfg1);
+    expect(cache.get("k1", cfg1)).toBe("v1");
+    vi.advanceTimersByTime(1001);
+    expect(cache.get("k1", cfg1)).toBeUndefined();
+    vi.useRealTimers();
+  });
+
+  it("clears on config change", () => {
+    const cache = new DirectoryCache<string>(60000);
+    cache.set("k1", "v1", cfg1);
+    expect(cache.get("k1", cfg1)).toBe("v1");
+    // Access with different config reference
+    expect(cache.get("k1", cfg2)).toBeUndefined();
+  });
+
+  it("clearMatching removes matching keys", () => {
+    const cache = new DirectoryCache<string>(60000);
+    cache.set("telegram:a", "v1", cfg1);
+    cache.set("discord:b", "v2", cfg1);
+    cache.clearMatching((k) => k.startsWith("telegram"));
+    expect(cache.get("telegram:a", cfg1)).toBeUndefined();
+    expect(cache.get("discord:b", cfg1)).toBe("v2");
+  });
+
+  it("clear removes all entries", () => {
+    const cache = new DirectoryCache<string>(60000);
+    cache.set("k1", "v1", cfg1);
+    cache.set("k2", "v2", cfg1);
+    cache.clear(cfg1);
+    expect(cache.get("k1", cfg1)).toBeUndefined();
+    expect(cache.get("k2", cfg1)).toBeUndefined();
+  });
+});

--- a/src/infra/ports-format.test.ts
+++ b/src/infra/ports-format.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import type { PortListener } from "./ports-types.js";
+import {
+  classifyPortListener,
+  buildPortHints,
+  formatPortListener,
+  formatPortDiagnostics,
+} from "./ports-format.js";
+
+describe("classifyPortListener", () => {
+  it("classifies openclaw as gateway", () => {
+    expect(
+      classifyPortListener({ commandLine: "openclaw gateway run" } as PortListener, 18789),
+    ).toBe("gateway");
+  });
+
+  it("classifies ssh commands as ssh", () => {
+    expect(
+      classifyPortListener({ commandLine: "ssh -L 18789:localhost:18789" } as PortListener, 18789),
+    ).toBe("ssh");
+  });
+
+  it("classifies unknown commands", () => {
+    expect(classifyPortListener({ commandLine: "nginx" } as PortListener, 80)).toBe("unknown");
+  });
+
+  it("classifies empty command as unknown", () => {
+    expect(classifyPortListener({} as PortListener, 80)).toBe("unknown");
+  });
+});
+
+describe("buildPortHints", () => {
+  it("returns empty for no listeners", () => {
+    expect(buildPortHints([], 80)).toEqual([]);
+  });
+
+  it("includes gateway hint", () => {
+    const listeners = [{ commandLine: "openclaw gateway" } as PortListener];
+    const hints = buildPortHints(listeners, 80);
+    expect(hints.some((h) => h.includes("Gateway"))).toBe(true);
+  });
+
+  it("includes ssh hint", () => {
+    const listeners = [{ commandLine: "ssh -L 80" } as PortListener];
+    const hints = buildPortHints(listeners, 80);
+    expect(hints.some((h) => h.includes("SSH tunnel"))).toBe(true);
+  });
+
+  it("includes multiple listener warning", () => {
+    const listeners = [
+      { commandLine: "openclaw gateway" } as PortListener,
+      { commandLine: "ssh -L 80" } as PortListener,
+    ];
+    const hints = buildPortHints(listeners, 80);
+    expect(hints.some((h) => h.includes("Multiple"))).toBe(true);
+  });
+});
+
+describe("formatPortListener", () => {
+  it("formats with all fields", () => {
+    const result = formatPortListener({
+      pid: 1234,
+      user: "root",
+      commandLine: "openclaw gateway run",
+      address: "0.0.0.0:18789",
+    } as PortListener);
+    expect(result).toContain("pid 1234");
+    expect(result).toContain("root");
+    expect(result).toContain("openclaw gateway run");
+    expect(result).toContain("0.0.0.0:18789");
+  });
+
+  it("handles missing fields", () => {
+    const result = formatPortListener({} as PortListener);
+    expect(result).toContain("pid ?");
+    expect(result).toContain("unknown");
+  });
+});
+
+describe("formatPortDiagnostics", () => {
+  it("reports free port", () => {
+    const lines = formatPortDiagnostics({ port: 80, status: "free" } as any);
+    expect(lines[0]).toContain("free");
+  });
+
+  it("reports busy port with details", () => {
+    const lines = formatPortDiagnostics({
+      port: 80,
+      status: "busy",
+      listeners: [{ pid: 1, commandLine: "nginx" }],
+      hints: ["Another process"],
+    } as any);
+    expect(lines[0]).toContain("already in use");
+    expect(lines.length).toBeGreaterThan(1);
+  });
+});

--- a/src/infra/provider-usage.format.test.ts
+++ b/src/infra/provider-usage.format.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatUsageWindowSummary,
+  formatUsageSummaryLine,
+  formatUsageReportLines,
+} from "./provider-usage.format.js";
+
+const now = Date.now();
+
+describe("formatUsageWindowSummary", () => {
+  it("returns null for error snapshot", () => {
+    expect(formatUsageWindowSummary({ error: "failed", windows: [] } as any)).toBeNull();
+  });
+
+  it("returns null for no windows", () => {
+    expect(formatUsageWindowSummary({ windows: [] } as any)).toBeNull();
+  });
+
+  it("formats single window", () => {
+    const snapshot = {
+      windows: [{ label: "daily", usedPercent: 30 }],
+    };
+    const result = formatUsageWindowSummary(snapshot as any, { now });
+    expect(result).toContain("daily");
+    expect(result).toContain("70% left");
+  });
+
+  it("formats multiple windows", () => {
+    const snapshot = {
+      windows: [
+        { label: "daily", usedPercent: 20 },
+        { label: "monthly", usedPercent: 50 },
+      ],
+    };
+    const result = formatUsageWindowSummary(snapshot as any, { now });
+    expect(result).toContain("daily");
+    expect(result).toContain("monthly");
+    expect(result).toContain("·");
+  });
+
+  it("respects maxWindows", () => {
+    const snapshot = {
+      windows: [
+        { label: "daily", usedPercent: 20 },
+        { label: "monthly", usedPercent: 50 },
+      ],
+    };
+    const result = formatUsageWindowSummary(snapshot as any, { now, maxWindows: 1 });
+    expect(result).toContain("daily");
+    expect(result).not.toContain("monthly");
+  });
+});
+
+describe("formatUsageSummaryLine", () => {
+  it("returns null for empty providers", () => {
+    expect(formatUsageSummaryLine({ providers: [] } as any)).toBeNull();
+  });
+
+  it("returns null when all providers have errors", () => {
+    const summary = {
+      providers: [{ displayName: "Claude", error: "oops", windows: [] }],
+    };
+    expect(formatUsageSummaryLine(summary as any)).toBeNull();
+  });
+
+  it("formats provider with usage", () => {
+    const summary = {
+      providers: [
+        {
+          displayName: "Claude",
+          windows: [{ label: "daily", usedPercent: 40 }],
+        },
+      ],
+    };
+    const result = formatUsageSummaryLine(summary as any, { now });
+    expect(result).toContain("Claude");
+    expect(result).toContain("60% left");
+  });
+});
+
+describe("formatUsageReportLines", () => {
+  it("returns fallback for no providers", () => {
+    const lines = formatUsageReportLines({ providers: [] } as any);
+    expect(lines[0]).toContain("no provider usage");
+  });
+
+  it("formats provider with error", () => {
+    const summary = {
+      providers: [{ displayName: "Claude", error: "auth failed", windows: [] }],
+    };
+    const lines = formatUsageReportLines(summary as any);
+    expect(lines.some((l) => l.includes("auth failed"))).toBe(true);
+  });
+
+  it("formats provider with no data", () => {
+    const summary = {
+      providers: [{ displayName: "Claude", windows: [] }],
+    };
+    const lines = formatUsageReportLines(summary as any);
+    expect(lines.some((l) => l.includes("no data"))).toBe(true);
+  });
+
+  it("formats provider with windows", () => {
+    const summary = {
+      providers: [
+        {
+          displayName: "Claude",
+          plan: "Pro",
+          windows: [{ label: "daily", usedPercent: 25 }],
+        },
+      ],
+    };
+    const lines = formatUsageReportLines(summary as any, { now });
+    expect(lines.some((l) => l.includes("Claude") && l.includes("Pro"))).toBe(true);
+    expect(lines.some((l) => l.includes("75% left"))).toBe(true);
+  });
+});

--- a/src/infra/provider-usage.shared.test.ts
+++ b/src/infra/provider-usage.shared.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveUsageProviderId,
+  clampPercent,
+  withTimeout,
+  usageProviders,
+  PROVIDER_LABELS,
+  ignoredErrors,
+} from "./provider-usage.shared.js";
+
+describe("resolveUsageProviderId", () => {
+  it("returns undefined for null/undefined/empty", () => {
+    expect(resolveUsageProviderId(null)).toBeUndefined();
+    expect(resolveUsageProviderId(undefined)).toBeUndefined();
+    expect(resolveUsageProviderId("")).toBeUndefined();
+  });
+
+  it("resolves known provider IDs", () => {
+    expect(resolveUsageProviderId("anthropic")).toBe("anthropic");
+  });
+
+  it("returns undefined for unknown providers", () => {
+    expect(resolveUsageProviderId("unknown-provider")).toBeUndefined();
+  });
+});
+
+describe("clampPercent", () => {
+  it("returns value in range", () => {
+    expect(clampPercent(50)).toBe(50);
+  });
+
+  it("clamps below 0", () => {
+    expect(clampPercent(-10)).toBe(0);
+  });
+
+  it("clamps above 100", () => {
+    expect(clampPercent(150)).toBe(100);
+  });
+
+  it("handles non-finite values as 0", () => {
+    expect(clampPercent(NaN)).toBe(0);
+    expect(clampPercent(Infinity)).toBe(0);
+    expect(clampPercent(-Infinity)).toBe(0);
+  });
+
+  it("handles edge values", () => {
+    expect(clampPercent(0)).toBe(0);
+    expect(clampPercent(100)).toBe(100);
+  });
+});
+
+describe("withTimeout", () => {
+  it("returns work result when fast", async () => {
+    const result = await withTimeout(Promise.resolve("done"), 1000, "fallback");
+    expect(result).toBe("done");
+  });
+
+  it("returns fallback on timeout", async () => {
+    const slow = new Promise<string>((resolve) => setTimeout(() => resolve("slow"), 5000));
+    const result = await withTimeout(slow, 10, "fallback");
+    expect(result).toBe("fallback");
+  });
+});
+
+describe("constants", () => {
+  it("usageProviders has all labeled providers", () => {
+    for (const id of usageProviders) {
+      expect(PROVIDER_LABELS[id]).toBeDefined();
+    }
+  });
+
+  it("ignoredErrors is a set of strings", () => {
+    expect(ignoredErrors.has("No credentials")).toBe(true);
+    expect(ignoredErrors.has("random")).toBe(false);
+  });
+});

--- a/src/infra/ws.test.ts
+++ b/src/infra/ws.test.ts
@@ -1,0 +1,39 @@
+import { Buffer } from "node:buffer";
+import { describe, expect, it } from "vitest";
+import { rawDataToString } from "./ws.js";
+
+describe("rawDataToString", () => {
+  it("returns string data as-is", () => {
+    expect(rawDataToString("hello" as unknown as Buffer)).toBe("hello");
+  });
+
+  it("converts Buffer to utf8 string", () => {
+    const buf = Buffer.from("hello world");
+    expect(rawDataToString(buf)).toBe("hello world");
+  });
+
+  it("converts Buffer with custom encoding", () => {
+    const buf = Buffer.from("café", "utf8");
+    expect(rawDataToString(buf, "utf8")).toBe("café");
+  });
+
+  it("converts ArrayBuffer to string", () => {
+    const ab = new ArrayBuffer(5);
+    const view = new Uint8Array(ab);
+    view.set([104, 101, 108, 108, 111]); // "hello"
+    expect(rawDataToString(ab as unknown as Buffer)).toBe("hello");
+  });
+
+  it("converts Buffer array to string", () => {
+    const bufs = [Buffer.from("hel"), Buffer.from("lo")];
+    expect(rawDataToString(bufs as unknown as Buffer)).toBe("hello");
+  });
+
+  it("handles empty buffer", () => {
+    expect(rawDataToString(Buffer.alloc(0))).toBe("");
+  });
+
+  it("handles empty array of buffers", () => {
+    expect(rawDataToString([] as unknown as Buffer)).toBe("");
+  });
+});

--- a/src/link-understanding/detect.extra.test.ts
+++ b/src/link-understanding/detect.extra.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { extractLinksFromMessage } from "./detect.js";
+
+describe("extractLinksFromMessage", () => {
+  it("returns empty array for empty message", () => {
+    expect(extractLinksFromMessage("")).toEqual([]);
+    expect(extractLinksFromMessage("   ")).toEqual([]);
+  });
+
+  it("extracts bare HTTP URLs", () => {
+    const links = extractLinksFromMessage("check https://example.com for details");
+    expect(links).toEqual(["https://example.com"]);
+  });
+
+  it("extracts multiple URLs", () => {
+    const links = extractLinksFromMessage("see https://a.com and https://b.com");
+    expect(links).toEqual(["https://a.com", "https://b.com"]);
+  });
+
+  it("deduplicates identical URLs", () => {
+    const links = extractLinksFromMessage("https://a.com https://a.com");
+    expect(links).toEqual(["https://a.com"]);
+  });
+
+  it("ignores markdown link URLs", () => {
+    const links = extractLinksFromMessage("[click here](https://hidden.com) https://visible.com");
+    expect(links).toEqual(["https://visible.com"]);
+  });
+
+  it("respects maxLinks option", () => {
+    const links = extractLinksFromMessage("https://a.com https://b.com https://c.com", {
+      maxLinks: 2,
+    });
+    expect(links).toHaveLength(2);
+  });
+
+  it("filters out localhost URLs", () => {
+    const links = extractLinksFromMessage("http://127.0.0.1:3000 https://real.com");
+    expect(links).toEqual(["https://real.com"]);
+  });
+
+  it("handles http and https protocols", () => {
+    const links = extractLinksFromMessage("http://old.com https://new.com");
+    expect(links).toEqual(["http://old.com", "https://new.com"]);
+  });
+
+  it("handles URLs with paths and query params", () => {
+    const links = extractLinksFromMessage("see https://example.com/path?q=1&b=2#hash");
+    expect(links).toHaveLength(1);
+    expect(links[0]).toContain("example.com/path");
+  });
+});

--- a/src/logging/levels.test.ts
+++ b/src/logging/levels.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { normalizeLogLevel, levelToMinLevel } from "./levels.js";
+
+describe("normalizeLogLevel", () => {
+  it("returns valid log levels unchanged", () => {
+    expect(normalizeLogLevel("info")).toBe("info");
+    expect(normalizeLogLevel("debug")).toBe("debug");
+    expect(normalizeLogLevel("error")).toBe("error");
+    expect(normalizeLogLevel("warn")).toBe("warn");
+    expect(normalizeLogLevel("trace")).toBe("trace");
+    expect(normalizeLogLevel("fatal")).toBe("fatal");
+    expect(normalizeLogLevel("silent")).toBe("silent");
+  });
+
+  it("returns fallback for invalid levels", () => {
+    expect(normalizeLogLevel("verbose")).toBe("info");
+    expect(normalizeLogLevel("critical")).toBe("info");
+    expect(normalizeLogLevel("")).toBe("info");
+  });
+
+  it("returns fallback for undefined", () => {
+    expect(normalizeLogLevel(undefined)).toBe("info");
+  });
+
+  it("respects custom fallback", () => {
+    expect(normalizeLogLevel("invalid", "debug")).toBe("debug");
+    expect(normalizeLogLevel(undefined, "warn")).toBe("warn");
+  });
+
+  it("trims whitespace", () => {
+    expect(normalizeLogLevel("  debug  ")).toBe("debug");
+  });
+});
+
+describe("levelToMinLevel", () => {
+  it("maps fatal to 0", () => {
+    expect(levelToMinLevel("fatal")).toBe(0);
+  });
+
+  it("maps error to 1", () => {
+    expect(levelToMinLevel("error")).toBe(1);
+  });
+
+  it("maps warn to 2", () => {
+    expect(levelToMinLevel("warn")).toBe(2);
+  });
+
+  it("maps info to 3", () => {
+    expect(levelToMinLevel("info")).toBe(3);
+  });
+
+  it("maps debug to 4", () => {
+    expect(levelToMinLevel("debug")).toBe(4);
+  });
+
+  it("maps trace to 5", () => {
+    expect(levelToMinLevel("trace")).toBe(5);
+  });
+
+  it("maps silent to Infinity", () => {
+    expect(levelToMinLevel("silent")).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it("maintains ordering: fatal < error < warn < info < debug < trace", () => {
+    expect(levelToMinLevel("fatal")).toBeLessThan(levelToMinLevel("error"));
+    expect(levelToMinLevel("error")).toBeLessThan(levelToMinLevel("warn"));
+    expect(levelToMinLevel("warn")).toBeLessThan(levelToMinLevel("info"));
+    expect(levelToMinLevel("info")).toBeLessThan(levelToMinLevel("debug"));
+    expect(levelToMinLevel("debug")).toBeLessThan(levelToMinLevel("trace"));
+  });
+});

--- a/src/markdown/code-spans.test.ts
+++ b/src/markdown/code-spans.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { buildCodeSpanIndex, createInlineCodeState } from "./code-spans.js";
+
+describe("createInlineCodeState", () => {
+  it("returns closed state", () => {
+    const state = createInlineCodeState();
+    expect(state.open).toBe(false);
+    expect(state.ticks).toBe(0);
+  });
+});
+
+describe("buildCodeSpanIndex", () => {
+  it("marks nothing inside for plain text", () => {
+    const idx = buildCodeSpanIndex("hello world");
+    expect(idx.isInside(0)).toBe(false);
+    expect(idx.isInside(5)).toBe(false);
+  });
+
+  it("marks inline code as inside", () => {
+    const text = "before `code` after";
+    const idx = buildCodeSpanIndex(text);
+    // Characters inside backtick span should be "inside"
+    const codeStart = text.indexOf("`");
+    const codeEnd = text.lastIndexOf("`") + 1;
+    expect(idx.isInside(codeStart)).toBe(true);
+    expect(idx.isInside(codeStart + 1)).toBe(true);
+    // Outside the span
+    expect(idx.isInside(0)).toBe(false);
+    expect(idx.isInside(codeEnd)).toBe(false);
+  });
+
+  it("marks fenced code blocks as inside", () => {
+    const text = "before\n```\ncode line\n```\nafter";
+    const idx = buildCodeSpanIndex(text);
+    const codePos = text.indexOf("code line");
+    expect(idx.isInside(codePos)).toBe(true);
+    // "after" is outside the fence
+    const afterPos = text.indexOf("after");
+    expect(idx.isInside(afterPos)).toBe(false);
+  });
+
+  it("handles double backtick inline code", () => {
+    const text = "``code here`` rest";
+    const idx = buildCodeSpanIndex(text);
+    expect(idx.isInside(2)).toBe(true); // inside ``...``
+    expect(idx.isInside(text.indexOf("rest"))).toBe(false);
+  });
+
+  it("tracks state across calls for unclosed spans", () => {
+    const text1 = "start `open";
+    const idx1 = buildCodeSpanIndex(text1);
+    expect(idx1.inlineState.open).toBe(true);
+    expect(idx1.inlineState.ticks).toBe(1);
+  });
+
+  it("continues with provided inline state", () => {
+    const text = "continued` after";
+    const state = { open: true, ticks: 1 };
+    const idx = buildCodeSpanIndex(text, state);
+    // From start to the closing backtick should be "inside" (continuation of open span)
+    expect(idx.isInside(0)).toBe(true);
+    // After closing backtick
+    const afterPos = text.indexOf("after");
+    expect(idx.isInside(afterPos)).toBe(false);
+  });
+});

--- a/src/markdown/fences.test.ts
+++ b/src/markdown/fences.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { parseFenceSpans, findFenceSpanAt, isSafeFenceBreak } from "./fences.js";
+
+describe("parseFenceSpans", () => {
+  it("returns empty for plain text", () => {
+    expect(parseFenceSpans("hello world")).toEqual([]);
+  });
+
+  it("detects a backtick fence", () => {
+    const text = "before\n```\ncode\n```\nafter";
+    const spans = parseFenceSpans(text);
+    expect(spans).toHaveLength(1);
+    expect(spans[0].marker).toBe("```");
+    expect(text.slice(spans[0].start, spans[0].end)).toContain("code");
+  });
+
+  it("detects a tilde fence", () => {
+    const text = "~~~\ncode\n~~~";
+    const spans = parseFenceSpans(text);
+    expect(spans).toHaveLength(1);
+    expect(spans[0].marker).toBe("~~~");
+  });
+
+  it("detects multiple fences", () => {
+    const text = "```\na\n```\n\n```\nb\n```";
+    const spans = parseFenceSpans(text);
+    expect(spans).toHaveLength(2);
+  });
+
+  it("handles unclosed fence", () => {
+    const text = "```\nopen code";
+    const spans = parseFenceSpans(text);
+    expect(spans).toHaveLength(1);
+    expect(spans[0].end).toBe(text.length);
+  });
+
+  it("requires matching marker type to close", () => {
+    const text = "```\ncode\n~~~";
+    const spans = parseFenceSpans(text);
+    // tilde can't close backtick fence; stays open
+    expect(spans).toHaveLength(1);
+    expect(spans[0].end).toBe(text.length);
+  });
+
+  it("allows longer marker to close shorter", () => {
+    const text = "```\ncode\n````";
+    const spans = parseFenceSpans(text);
+    expect(spans).toHaveLength(1);
+    // Closed by the longer marker (end is at end-of-line = text.length since no trailing newline)
+    expect(spans[0].end).toBe(text.length);
+  });
+
+  it("captures indent", () => {
+    const text = "  ```\n  code\n  ```";
+    const spans = parseFenceSpans(text);
+    expect(spans).toHaveLength(1);
+    expect(spans[0].indent).toBe("  ");
+  });
+});
+
+describe("findFenceSpanAt", () => {
+  it("returns undefined outside any span", () => {
+    const spans = parseFenceSpans("plain text");
+    expect(findFenceSpanAt(spans, 5)).toBeUndefined();
+  });
+
+  it("finds span at index inside fence", () => {
+    const text = "before\n```\ncode\n```\nafter";
+    const spans = parseFenceSpans(text);
+    const codePos = text.indexOf("code");
+    expect(findFenceSpanAt(spans, codePos)).toBeDefined();
+  });
+
+  it("returns undefined at span boundary (start)", () => {
+    const text = "```\ncode\n```";
+    const spans = parseFenceSpans(text);
+    // At exact start boundary, findFenceSpanAt uses strict >
+    expect(findFenceSpanAt(spans, 0)).toBeUndefined();
+  });
+});
+
+describe("isSafeFenceBreak", () => {
+  it("returns true outside fences", () => {
+    const text = "a\n```\ncode\n```\nb";
+    const spans = parseFenceSpans(text);
+    expect(isSafeFenceBreak(spans, 0)).toBe(true);
+  });
+
+  it("returns false inside a fence", () => {
+    const text = "```\ncode\n```";
+    const spans = parseFenceSpans(text);
+    const codePos = text.indexOf("code");
+    expect(isSafeFenceBreak(spans, codePos)).toBe(false);
+  });
+});

--- a/src/markdown/tables.test.ts
+++ b/src/markdown/tables.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { convertMarkdownTables } from "./tables.js";
+
+describe("convertMarkdownTables", () => {
+  it("returns empty string for empty input", () => {
+    expect(convertMarkdownTables("", "bullets")).toBe("");
+  });
+
+  it("returns original for 'off' mode", () => {
+    const md = "| A | B |\n|---|---|\n| 1 | 2 |";
+    expect(convertMarkdownTables(md, "off")).toBe(md);
+  });
+
+  it("returns original when no tables present", () => {
+    const md = "Hello world\n\nNo tables here.";
+    expect(convertMarkdownTables(md, "bullets")).toBe(md);
+  });
+
+  it("converts table to bullet format", () => {
+    const md = "| Name | Age |\n|------|-----|\n| Alice | 30 |\n| Bob | 25 |";
+    const result = convertMarkdownTables(md, "bullets");
+    expect(result).not.toContain("|");
+    // Should contain the data in some structured form
+    expect(result).toContain("Alice");
+    expect(result).toContain("Bob");
+  });
+
+  it("converts table to code format", () => {
+    const md = "| Name | Age |\n|------|-----|\n| Alice | 30 |";
+    const result = convertMarkdownTables(md, "code");
+    expect(result).toContain("Alice");
+  });
+
+  it("preserves text around tables", () => {
+    const md = "Before\n\n| A | B |\n|---|---|\n| 1 | 2 |\n\nAfter";
+    const result = convertMarkdownTables(md, "bullets");
+    expect(result).toContain("Before");
+    expect(result).toContain("After");
+  });
+});

--- a/src/media/constants.test.ts
+++ b/src/media/constants.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import {
+  mediaKindFromMime,
+  maxBytesForKind,
+  MAX_IMAGE_BYTES,
+  MAX_AUDIO_BYTES,
+  MAX_VIDEO_BYTES,
+  MAX_DOCUMENT_BYTES,
+} from "./constants.js";
+
+describe("mediaKindFromMime", () => {
+  it("returns 'unknown' for null/undefined/empty", () => {
+    expect(mediaKindFromMime(null)).toBe("unknown");
+    expect(mediaKindFromMime(undefined)).toBe("unknown");
+    expect(mediaKindFromMime("")).toBe("unknown");
+  });
+
+  it("classifies image types", () => {
+    expect(mediaKindFromMime("image/png")).toBe("image");
+    expect(mediaKindFromMime("image/jpeg")).toBe("image");
+    expect(mediaKindFromMime("image/webp")).toBe("image");
+  });
+
+  it("classifies audio types", () => {
+    expect(mediaKindFromMime("audio/mpeg")).toBe("audio");
+    expect(mediaKindFromMime("audio/ogg")).toBe("audio");
+    expect(mediaKindFromMime("audio/wav")).toBe("audio");
+  });
+
+  it("classifies video types", () => {
+    expect(mediaKindFromMime("video/mp4")).toBe("video");
+    expect(mediaKindFromMime("video/webm")).toBe("video");
+  });
+
+  it("classifies PDF as document", () => {
+    expect(mediaKindFromMime("application/pdf")).toBe("document");
+  });
+
+  it("classifies other application types as document", () => {
+    expect(mediaKindFromMime("application/zip")).toBe("document");
+    expect(mediaKindFromMime("application/json")).toBe("document");
+  });
+
+  it("returns 'unknown' for text types", () => {
+    expect(mediaKindFromMime("text/plain")).toBe("unknown");
+    expect(mediaKindFromMime("text/html")).toBe("unknown");
+  });
+});
+
+describe("maxBytesForKind", () => {
+  it("returns correct limits for each kind", () => {
+    expect(maxBytesForKind("image")).toBe(MAX_IMAGE_BYTES);
+    expect(maxBytesForKind("audio")).toBe(MAX_AUDIO_BYTES);
+    expect(maxBytesForKind("video")).toBe(MAX_VIDEO_BYTES);
+    expect(maxBytesForKind("document")).toBe(MAX_DOCUMENT_BYTES);
+  });
+
+  it("returns document limit for unknown kind", () => {
+    expect(maxBytesForKind("unknown")).toBe(MAX_DOCUMENT_BYTES);
+  });
+});

--- a/src/memory/status-format.test.ts
+++ b/src/memory/status-format.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveMemoryVectorState,
+  resolveMemoryFtsState,
+  resolveMemoryCacheSummary,
+  resolveMemoryCacheState,
+} from "./status-format.js";
+
+describe("resolveMemoryVectorState", () => {
+  it("returns disabled when not enabled", () => {
+    expect(resolveMemoryVectorState({ enabled: false })).toEqual({
+      tone: "muted",
+      state: "disabled",
+    });
+  });
+
+  it("returns ready when enabled and available", () => {
+    expect(resolveMemoryVectorState({ enabled: true, available: true })).toEqual({
+      tone: "ok",
+      state: "ready",
+    });
+  });
+
+  it("returns unavailable when enabled but not available", () => {
+    expect(resolveMemoryVectorState({ enabled: true, available: false })).toEqual({
+      tone: "warn",
+      state: "unavailable",
+    });
+  });
+
+  it("returns unknown when enabled and availability undefined", () => {
+    expect(resolveMemoryVectorState({ enabled: true })).toEqual({
+      tone: "muted",
+      state: "unknown",
+    });
+  });
+});
+
+describe("resolveMemoryFtsState", () => {
+  it("returns disabled when not enabled", () => {
+    expect(resolveMemoryFtsState({ enabled: false, available: false })).toEqual({
+      tone: "muted",
+      state: "disabled",
+    });
+  });
+
+  it("returns ready when enabled and available", () => {
+    expect(resolveMemoryFtsState({ enabled: true, available: true })).toEqual({
+      tone: "ok",
+      state: "ready",
+    });
+  });
+
+  it("returns unavailable when enabled but not available", () => {
+    expect(resolveMemoryFtsState({ enabled: true, available: false })).toEqual({
+      tone: "warn",
+      state: "unavailable",
+    });
+  });
+});
+
+describe("resolveMemoryCacheSummary", () => {
+  it("returns 'cache off' when disabled", () => {
+    expect(resolveMemoryCacheSummary({ enabled: false })).toEqual({
+      tone: "muted",
+      text: "cache off",
+    });
+  });
+
+  it("returns 'cache on' when enabled without entries", () => {
+    expect(resolveMemoryCacheSummary({ enabled: true })).toEqual({ tone: "ok", text: "cache on" });
+  });
+
+  it("includes entry count when available", () => {
+    expect(resolveMemoryCacheSummary({ enabled: true, entries: 42 })).toEqual({
+      tone: "ok",
+      text: "cache on (42)",
+    });
+  });
+});
+
+describe("resolveMemoryCacheState", () => {
+  it("returns enabled", () => {
+    expect(resolveMemoryCacheState({ enabled: true })).toEqual({ tone: "ok", state: "enabled" });
+  });
+
+  it("returns disabled", () => {
+    expect(resolveMemoryCacheState({ enabled: false })).toEqual({
+      tone: "muted",
+      state: "disabled",
+    });
+  });
+});

--- a/src/slack/token.test.ts
+++ b/src/slack/token.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { normalizeSlackToken, resolveSlackBotToken, resolveSlackAppToken } from "./token.js";
+
+describe("normalizeSlackToken", () => {
+  it("returns undefined for undefined", () => {
+    expect(normalizeSlackToken(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined for empty string", () => {
+    expect(normalizeSlackToken("")).toBeUndefined();
+  });
+
+  it("returns undefined for whitespace-only", () => {
+    expect(normalizeSlackToken("   ")).toBeUndefined();
+  });
+
+  it("trims and returns valid token", () => {
+    expect(normalizeSlackToken("  xoxb-123  ")).toBe("xoxb-123");
+  });
+
+  it("returns token as-is when already trimmed", () => {
+    expect(normalizeSlackToken("xoxb-abc")).toBe("xoxb-abc");
+  });
+});
+
+describe("resolveSlackBotToken", () => {
+  it("delegates to normalizeSlackToken", () => {
+    expect(resolveSlackBotToken("  tok  ")).toBe("tok");
+    expect(resolveSlackBotToken(undefined)).toBeUndefined();
+  });
+});
+
+describe("resolveSlackAppToken", () => {
+  it("delegates to normalizeSlackToken", () => {
+    expect(resolveSlackAppToken("  tok  ")).toBe("tok");
+    expect(resolveSlackAppToken("")).toBeUndefined();
+  });
+});

--- a/src/telegram/allowed-updates.test.ts
+++ b/src/telegram/allowed-updates.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { resolveTelegramAllowedUpdates } from "./allowed-updates.js";
+
+describe("resolveTelegramAllowedUpdates", () => {
+  it("returns an array", () => {
+    const updates = resolveTelegramAllowedUpdates();
+    expect(Array.isArray(updates)).toBe(true);
+  });
+
+  it("includes message_reaction", () => {
+    const updates = resolveTelegramAllowedUpdates();
+    expect(updates).toContain("message_reaction");
+  });
+
+  it("includes default update types", () => {
+    const updates = resolveTelegramAllowedUpdates();
+    expect(updates).toContain("message");
+  });
+
+  it("returns same result on repeated calls", () => {
+    const a = resolveTelegramAllowedUpdates();
+    const b = resolveTelegramAllowedUpdates();
+    expect(a).toEqual(b);
+  });
+});

--- a/src/telegram/caption.test.ts
+++ b/src/telegram/caption.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { splitTelegramCaption, TELEGRAM_MAX_CAPTION_LENGTH } from "./caption.js";
+
+describe("splitTelegramCaption", () => {
+  it("returns both undefined for undefined input", () => {
+    const result = splitTelegramCaption(undefined);
+    expect(result.caption).toBeUndefined();
+    expect(result.followUpText).toBeUndefined();
+  });
+
+  it("returns both undefined for empty string", () => {
+    const result = splitTelegramCaption("");
+    expect(result.caption).toBeUndefined();
+    expect(result.followUpText).toBeUndefined();
+  });
+
+  it("returns both undefined for whitespace-only", () => {
+    const result = splitTelegramCaption("   ");
+    expect(result.caption).toBeUndefined();
+    expect(result.followUpText).toBeUndefined();
+  });
+
+  it("returns caption for text within limit", () => {
+    const result = splitTelegramCaption("Hello!");
+    expect(result.caption).toBe("Hello!");
+    expect(result.followUpText).toBeUndefined();
+  });
+
+  it("returns caption for text exactly at limit", () => {
+    const text = "a".repeat(TELEGRAM_MAX_CAPTION_LENGTH);
+    const result = splitTelegramCaption(text);
+    expect(result.caption).toBe(text);
+    expect(result.followUpText).toBeUndefined();
+  });
+
+  it("returns followUpText when over limit", () => {
+    const text = "a".repeat(TELEGRAM_MAX_CAPTION_LENGTH + 1);
+    const result = splitTelegramCaption(text);
+    expect(result.caption).toBeUndefined();
+    expect(result.followUpText).toBe(text);
+  });
+
+  it("trims text before checking length", () => {
+    const result = splitTelegramCaption("  hello  ");
+    expect(result.caption).toBe("hello");
+  });
+
+  it("exports correct max caption length", () => {
+    expect(TELEGRAM_MAX_CAPTION_LENGTH).toBe(1024);
+  });
+});

--- a/src/terminal/ansi.test.ts
+++ b/src/terminal/ansi.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { stripAnsi, visibleWidth } from "./ansi.js";
+
+describe("stripAnsi", () => {
+  it("returns plain text unchanged", () => {
+    expect(stripAnsi("hello")).toBe("hello");
+  });
+
+  it("strips SGR codes", () => {
+    expect(stripAnsi("\x1b[31mred\x1b[0m")).toBe("red");
+  });
+
+  it("strips bold + color codes", () => {
+    expect(stripAnsi("\x1b[1;32mbold green\x1b[0m")).toBe("bold green");
+  });
+
+  it("strips multiple SGR sequences", () => {
+    expect(stripAnsi("\x1b[31mhello\x1b[0m \x1b[34mworld\x1b[0m")).toBe("hello world");
+  });
+
+  it("strips OSC-8 hyperlinks", () => {
+    const link = "\x1b]8;;https://example.com\x1b\\Click Here\x1b]8;;\x1b\\";
+    expect(stripAnsi(link)).toBe("Click Here");
+  });
+
+  it("handles empty string", () => {
+    expect(stripAnsi("")).toBe("");
+  });
+});
+
+describe("visibleWidth", () => {
+  it("returns length for plain text", () => {
+    expect(visibleWidth("hello")).toBe(5);
+  });
+
+  it("ignores ANSI codes", () => {
+    expect(visibleWidth("\x1b[31mhello\x1b[0m")).toBe(5);
+  });
+
+  it("returns 0 for empty string", () => {
+    expect(visibleWidth("")).toBe(0);
+  });
+
+  it("counts emoji as characters", () => {
+    // Using Array.from counts grapheme clusters
+    expect(visibleWidth("hi")).toBe(2);
+  });
+});

--- a/src/terminal/note.test.ts
+++ b/src/terminal/note.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { wrapNoteMessage } from "./note.js";
+
+describe("wrapNoteMessage", () => {
+  it("returns short text unchanged", () => {
+    expect(wrapNoteMessage("hello world", { maxWidth: 80 })).toBe("hello world");
+  });
+
+  it("wraps long lines at word boundaries", () => {
+    const input = "the quick brown fox jumps over the lazy dog";
+    const result = wrapNoteMessage(input, { maxWidth: 20 });
+    const lines = result.split("\n");
+    expect(lines.length).toBeGreaterThan(1);
+    for (const line of lines) {
+      expect(line.length).toBeLessThanOrEqual(20);
+    }
+  });
+
+  it("preserves existing newlines", () => {
+    const input = "line one\nline two\nline three";
+    const result = wrapNoteMessage(input, { maxWidth: 80 });
+    expect(result).toBe("line one\nline two\nline three");
+  });
+
+  it("preserves blank lines", () => {
+    const input = "before\n\nafter";
+    const result = wrapNoteMessage(input, { maxWidth: 80 });
+    expect(result).toContain("\n\n");
+  });
+
+  it("handles bullet points with continuation indent", () => {
+    const input = "- this is a very long bullet point that should wrap to the next line properly";
+    const result = wrapNoteMessage(input, { maxWidth: 40 });
+    const lines = result.split("\n");
+    expect(lines[0]).toMatch(/^- /);
+    if (lines.length > 1) {
+      // Continuation lines should be indented to align with bullet content
+      expect(lines[1]).toMatch(/^\s{2}/);
+    }
+  });
+
+  it("handles indented text", () => {
+    const input = "  indented text here";
+    const result = wrapNoteMessage(input, { maxWidth: 80 });
+    expect(result).toMatch(/^\s{2}/);
+  });
+
+  it("splits very long words", () => {
+    const longWord = "a".repeat(100);
+    const result = wrapNoteMessage(longWord, { maxWidth: 30 });
+    const lines = result.split("\n");
+    expect(lines.length).toBeGreaterThan(1);
+  });
+
+  it("uses columns option for default width calculation", () => {
+    const input = "short";
+    const result = wrapNoteMessage(input, { columns: 120 });
+    expect(result).toBe("short");
+  });
+});

--- a/src/tui/components/fuzzy-filter.test.ts
+++ b/src/tui/components/fuzzy-filter.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vitest";
+import {
+  isWordBoundary,
+  findWordBoundaryIndex,
+  fuzzyMatchLower,
+  fuzzyFilterLower,
+  prepareSearchItems,
+} from "./fuzzy-filter.js";
+
+// ---------------------------------------------------------------------------
+// isWordBoundary
+// ---------------------------------------------------------------------------
+
+describe("isWordBoundary", () => {
+  it("returns true at index 0 (start of string)", () => {
+    expect(isWordBoundary("hello", 0)).toBe(true);
+  });
+
+  it("returns true after word boundary characters", () => {
+    expect(isWordBoundary("a-b", 2)).toBe(true);
+    expect(isWordBoundary("a_b", 2)).toBe(true);
+    expect(isWordBoundary("a b", 2)).toBe(true);
+    expect(isWordBoundary("a/b", 2)).toBe(true);
+    expect(isWordBoundary("a.b", 2)).toBe(true);
+    expect(isWordBoundary("a:b", 2)).toBe(true);
+  });
+
+  it("returns false within a word", () => {
+    expect(isWordBoundary("hello", 3)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findWordBoundaryIndex
+// ---------------------------------------------------------------------------
+
+describe("findWordBoundaryIndex", () => {
+  it("returns null for empty query", () => {
+    expect(findWordBoundaryIndex("hello world", "")).toBeNull();
+  });
+
+  it("finds match at start of string", () => {
+    expect(findWordBoundaryIndex("hello world", "hello")).toBe(0);
+  });
+
+  it("finds match at word boundary", () => {
+    expect(findWordBoundaryIndex("hello-world", "world")).toBe(6);
+  });
+
+  it("is case-insensitive", () => {
+    expect(findWordBoundaryIndex("Hello World", "world")).toBe(6);
+  });
+
+  it("returns null when no word boundary match", () => {
+    expect(findWordBoundaryIndex("helloworld", "world")).toBeNull();
+  });
+
+  it("returns null when query is longer than text", () => {
+    expect(findWordBoundaryIndex("hi", "hello")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fuzzyMatchLower
+// ---------------------------------------------------------------------------
+
+describe("fuzzyMatchLower", () => {
+  it("returns 0 for empty query", () => {
+    expect(fuzzyMatchLower("", "hello")).toBe(0);
+  });
+
+  it("returns null when query longer than text", () => {
+    expect(fuzzyMatchLower("hello", "hi")).toBeNull();
+  });
+
+  it("matches exact substring", () => {
+    const score = fuzzyMatchLower("hello", "hello world");
+    expect(score).not.toBeNull();
+  });
+
+  it("matches fuzzy characters", () => {
+    const score = fuzzyMatchLower("hlo", "hello");
+    expect(score).not.toBeNull();
+  });
+
+  it("returns null for no match", () => {
+    expect(fuzzyMatchLower("xyz", "hello")).toBeNull();
+  });
+
+  it("scores consecutive matches better than gaps", () => {
+    const consecutive = fuzzyMatchLower("hel", "hello");
+    const gapped = fuzzyMatchLower("hlo", "hello");
+    expect(consecutive).not.toBeNull();
+    expect(gapped).not.toBeNull();
+    expect(consecutive!).toBeLessThan(gapped!);
+  });
+
+  it("scores word boundary matches better", () => {
+    const boundary = fuzzyMatchLower("w", "hello-world");
+    const mid = fuzzyMatchLower("o", "hello-world");
+    expect(boundary).not.toBeNull();
+    expect(mid).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fuzzyFilterLower
+// ---------------------------------------------------------------------------
+
+describe("fuzzyFilterLower", () => {
+  const items = [
+    { searchTextLower: "apple pie" },
+    { searchTextLower: "banana split" },
+    { searchTextLower: "cherry tart" },
+  ];
+
+  it("returns all items for empty query", () => {
+    expect(fuzzyFilterLower(items, "")).toEqual(items);
+    expect(fuzzyFilterLower(items, "  ")).toEqual(items);
+  });
+
+  it("filters matching items", () => {
+    const result = fuzzyFilterLower(items, "app");
+    expect(result).toHaveLength(1);
+    expect(result[0].searchTextLower).toBe("apple pie");
+  });
+
+  it("supports space-separated token matching (all must match)", () => {
+    const result = fuzzyFilterLower(items, "ban spl");
+    expect(result).toHaveLength(1);
+    expect(result[0].searchTextLower).toBe("banana split");
+  });
+
+  it("returns empty when no matches", () => {
+    expect(fuzzyFilterLower(items, "xyz")).toEqual([]);
+  });
+
+  it("sorts by match score", () => {
+    const data = [
+      { searchTextLower: "some-config-path" },
+      { searchTextLower: "apple pie" },
+      { searchTextLower: "configuration" },
+    ];
+    const result = fuzzyFilterLower(data, "config");
+    // Non-matching "apple pie" should be excluded
+    expect(result.every((r) => r.searchTextLower !== "apple pie")).toBe(true);
+    expect(result.length).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// prepareSearchItems
+// ---------------------------------------------------------------------------
+
+describe("prepareSearchItems", () => {
+  it("combines label, description, and searchText into searchTextLower", () => {
+    const items = [{ label: "Hello", description: "World", searchText: "Extra" }];
+    const result = prepareSearchItems(items);
+    expect(result[0].searchTextLower).toBe("hello world extra");
+  });
+
+  it("handles missing fields", () => {
+    const items = [{ label: "Only Label" }];
+    const result = prepareSearchItems(items);
+    expect(result[0].searchTextLower).toBe("only label");
+  });
+
+  it("handles empty items", () => {
+    const items = [{}];
+    const result = prepareSearchItems(items);
+    expect(result[0].searchTextLower).toBe("");
+  });
+
+  it("preserves original item fields", () => {
+    const items = [{ label: "Test", extra: 42 }];
+    const result = prepareSearchItems(items);
+    expect(result[0].label).toBe("Test");
+    expect((result[0] as Record<string, unknown>).extra).toBe(42);
+  });
+});

--- a/src/utils/directive-tags.test.ts
+++ b/src/utils/directive-tags.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { parseInlineDirectives } from "./directive-tags.js";
+
+describe("parseInlineDirectives", () => {
+  it("returns defaults for empty/undefined input", () => {
+    const result = parseInlineDirectives(undefined);
+    expect(result.text).toBe("");
+    expect(result.audioAsVoice).toBe(false);
+    expect(result.replyToCurrent).toBe(false);
+    expect(result.hasAudioTag).toBe(false);
+    expect(result.hasReplyTag).toBe(false);
+  });
+
+  it("passes through plain text unchanged", () => {
+    const result = parseInlineDirectives("hello world");
+    expect(result.text).toBe("hello world");
+    expect(result.hasAudioTag).toBe(false);
+    expect(result.hasReplyTag).toBe(false);
+  });
+
+  it("detects and strips [[audio_as_voice]] tag", () => {
+    const result = parseInlineDirectives("hello [[audio_as_voice]] world");
+    expect(result.audioAsVoice).toBe(true);
+    expect(result.hasAudioTag).toBe(true);
+    expect(result.text).toBe("hello world");
+  });
+
+  it("detects [[audio_as_voice]] case-insensitively", () => {
+    const result = parseInlineDirectives("[[AUDIO_AS_VOICE]] text");
+    expect(result.audioAsVoice).toBe(true);
+  });
+
+  it("detects [[reply_to_current]] tag", () => {
+    const result = parseInlineDirectives("hello [[reply_to_current]]", {
+      currentMessageId: "msg123",
+    });
+    expect(result.replyToCurrent).toBe(true);
+    expect(result.hasReplyTag).toBe(true);
+    expect(result.replyToId).toBe("msg123");
+  });
+
+  it("detects [[reply_to: id]] tag with explicit id", () => {
+    const result = parseInlineDirectives("hello [[reply_to: msg456]]");
+    expect(result.hasReplyTag).toBe(true);
+    expect(result.replyToExplicitId).toBe("msg456");
+    expect(result.replyToId).toBe("msg456");
+  });
+
+  it("strips tags by default", () => {
+    const result = parseInlineDirectives("before [[audio_as_voice]] after");
+    expect(result.text).not.toContain("audio_as_voice");
+  });
+
+  it("preserves tags when stripAudioTag=false", () => {
+    const result = parseInlineDirectives("[[audio_as_voice]] text", { stripAudioTag: false });
+    expect(result.text).toContain("audio_as_voice");
+  });
+
+  it("preserves reply tags when stripReplyTags=false", () => {
+    const result = parseInlineDirectives("[[reply_to_current]] text", { stripReplyTags: false });
+    expect(result.text).toContain("reply_to_current");
+  });
+
+  it("normalizes whitespace after stripping", () => {
+    const result = parseInlineDirectives("  hello   [[audio_as_voice]]   world  ");
+    expect(result.text).toBe("hello world");
+  });
+
+  it("handles multiple directives", () => {
+    const result = parseInlineDirectives("text [[audio_as_voice]] more [[reply_to: msg789]] end");
+    expect(result.audioAsVoice).toBe(true);
+    expect(result.replyToExplicitId).toBe("msg789");
+    expect(result.text).toBe("text more end");
+  });
+
+  it("returns undefined replyToId when no currentMessageId and reply_to_current", () => {
+    const result = parseInlineDirectives("[[reply_to_current]]");
+    expect(result.replyToCurrent).toBe(true);
+    expect(result.replyToId).toBeUndefined();
+  });
+});

--- a/src/utils/queue-helpers.test.ts
+++ b/src/utils/queue-helpers.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import {
+  elideQueueText,
+  buildQueueSummaryLine,
+  shouldSkipQueueItem,
+  applyQueueDropPolicy,
+  type QueueState,
+} from "./queue-helpers.js";
+
+// ---------------------------------------------------------------------------
+// elideQueueText
+// ---------------------------------------------------------------------------
+
+describe("elideQueueText", () => {
+  it("returns short text unchanged", () => {
+    expect(elideQueueText("hello", 10)).toBe("hello");
+  });
+
+  it("returns text at exact limit unchanged", () => {
+    expect(elideQueueText("12345", 5)).toBe("12345");
+  });
+
+  it("truncates with ellipsis when over limit", () => {
+    const result = elideQueueText("hello world", 8);
+    expect(result).toHaveLength(8);
+    expect(result.endsWith("…")).toBe(true);
+  });
+
+  it("uses default limit of 140", () => {
+    const short = "a".repeat(140);
+    expect(elideQueueText(short)).toBe(short);
+    const long = "a".repeat(141);
+    expect(elideQueueText(long).endsWith("…")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildQueueSummaryLine
+// ---------------------------------------------------------------------------
+
+describe("buildQueueSummaryLine", () => {
+  it("collapses whitespace", () => {
+    expect(buildQueueSummaryLine("hello   world\n\nnewline")).toBe("hello world newline");
+  });
+
+  it("trims", () => {
+    expect(buildQueueSummaryLine("  padded  ")).toBe("padded");
+  });
+
+  it("truncates long text", () => {
+    const long = "a ".repeat(200);
+    const result = buildQueueSummaryLine(long, 20);
+    expect(result.length).toBeLessThanOrEqual(20);
+    expect(result.endsWith("…")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// shouldSkipQueueItem
+// ---------------------------------------------------------------------------
+
+describe("shouldSkipQueueItem", () => {
+  it("returns false without dedupe function", () => {
+    expect(shouldSkipQueueItem({ item: "a", items: ["a"] })).toBe(false);
+  });
+
+  it("delegates to dedupe function", () => {
+    const dedupe = (item: string, items: string[]) => items.includes(item);
+    expect(shouldSkipQueueItem({ item: "a", items: ["a", "b"], dedupe })).toBe(true);
+    expect(shouldSkipQueueItem({ item: "c", items: ["a", "b"], dedupe })).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyQueueDropPolicy
+// ---------------------------------------------------------------------------
+
+describe("applyQueueDropPolicy", () => {
+  function makeQueue(
+    items: string[],
+    cap: number,
+    dropPolicy: "summarize" | "old" | "new",
+  ): QueueState<string> {
+    return {
+      items: [...items],
+      cap,
+      dropPolicy,
+      droppedCount: 0,
+      summaryLines: [],
+    };
+  }
+
+  it("returns true when under cap", () => {
+    const queue = makeQueue(["a", "b"], 5, "old");
+    expect(applyQueueDropPolicy({ queue, summarize: (x) => x })).toBe(true);
+    expect(queue.items).toEqual(["a", "b"]);
+  });
+
+  it("returns false for 'new' policy when at cap", () => {
+    const queue = makeQueue(["a", "b", "c"], 3, "new");
+    expect(applyQueueDropPolicy({ queue, summarize: (x) => x })).toBe(false);
+  });
+
+  it("drops oldest items for 'old' policy", () => {
+    const queue = makeQueue(["a", "b", "c", "d"], 3, "old");
+    applyQueueDropPolicy({ queue, summarize: (x) => x });
+    // Should drop enough to make room for 1 new item
+    expect(queue.items.length).toBeLessThanOrEqual(2);
+  });
+
+  it("drops oldest and summarizes for 'summarize' policy", () => {
+    const queue = makeQueue(["msg1", "msg2", "msg3", "msg4"], 3, "summarize");
+    applyQueueDropPolicy({ queue, summarize: (x) => x });
+    expect(queue.droppedCount).toBeGreaterThan(0);
+    expect(queue.summaryLines.length).toBeGreaterThan(0);
+  });
+
+  it("respects summaryLimit", () => {
+    const queue = makeQueue(["a", "b", "c", "d", "e"], 2, "summarize");
+    applyQueueDropPolicy({ queue, summarize: (x) => x, summaryLimit: 2 });
+    expect(queue.summaryLines.length).toBeLessThanOrEqual(2);
+  });
+});

--- a/src/utils/shell-argv.test.ts
+++ b/src/utils/shell-argv.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { splitShellArgs } from "./shell-argv.js";
+
+describe("splitShellArgs", () => {
+  it("splits simple space-separated args", () => {
+    expect(splitShellArgs("a b c")).toEqual(["a", "b", "c"]);
+  });
+
+  it("returns empty array for empty string", () => {
+    expect(splitShellArgs("")).toEqual([]);
+  });
+
+  it("returns empty array for whitespace only", () => {
+    expect(splitShellArgs("   ")).toEqual([]);
+  });
+
+  it("handles single-quoted strings", () => {
+    expect(splitShellArgs("'hello world'")).toEqual(["hello world"]);
+  });
+
+  it("handles double-quoted strings", () => {
+    expect(splitShellArgs('"hello world"')).toEqual(["hello world"]);
+  });
+
+  it("handles mixed quotes", () => {
+    expect(splitShellArgs(`'a b' "c d" e`)).toEqual(["a b", "c d", "e"]);
+  });
+
+  it("handles backslash escaping outside quotes", () => {
+    expect(splitShellArgs("hello\\ world")).toEqual(["hello world"]);
+  });
+
+  it("returns null for unclosed single quote", () => {
+    expect(splitShellArgs("'unclosed")).toBeNull();
+  });
+
+  it("returns null for unclosed double quote", () => {
+    expect(splitShellArgs('"unclosed')).toBeNull();
+  });
+
+  it("returns null for trailing backslash", () => {
+    expect(splitShellArgs("trailing\\")).toBeNull();
+  });
+
+  it("preserves content inside quotes literally", () => {
+    expect(splitShellArgs(`'it\\'s fine'`)).toBeNull(); // backslash doesn't escape inside single quotes
+  });
+
+  it("handles empty quoted strings", () => {
+    expect(splitShellArgs("'' \"\"")).toEqual([]);
+  });
+
+  it("handles multiple spaces between args", () => {
+    expect(splitShellArgs("a    b    c")).toEqual(["a", "b", "c"]);
+  });
+
+  it("handles tabs as whitespace", () => {
+    expect(splitShellArgs("a\tb\tc")).toEqual(["a", "b", "c"]);
+  });
+
+  it("handles complex real-world command", () => {
+    expect(splitShellArgs('git commit -m "fix: handle edge case"')).toEqual([
+      "git",
+      "commit",
+      "-m",
+      "fix: handle edge case",
+    ]);
+  });
+});

--- a/src/utils/time-format.test.ts
+++ b/src/utils/time-format.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+import { formatRelativeTime } from "./time-format.js";
+
+describe("formatRelativeTime", () => {
+  it("returns 'just now' for < 60 seconds", () => {
+    const now = Date.now();
+    expect(formatRelativeTime(now - 5_000)).toBe("just now");
+    expect(formatRelativeTime(now - 59_000)).toBe("just now");
+  });
+
+  it("returns minutes for < 60 minutes", () => {
+    const now = Date.now();
+    expect(formatRelativeTime(now - 60_000)).toBe("1m ago");
+    expect(formatRelativeTime(now - 5 * 60_000)).toBe("5m ago");
+    expect(formatRelativeTime(now - 59 * 60_000)).toBe("59m ago");
+  });
+
+  it("returns hours for < 24 hours", () => {
+    const now = Date.now();
+    expect(formatRelativeTime(now - 60 * 60_000)).toBe("1h ago");
+    expect(formatRelativeTime(now - 12 * 60 * 60_000)).toBe("12h ago");
+  });
+
+  it("returns 'Yesterday' for 1 day", () => {
+    const now = Date.now();
+    expect(formatRelativeTime(now - 24 * 60 * 60_000)).toBe("Yesterday");
+  });
+
+  it("returns days for 2-6 days", () => {
+    const now = Date.now();
+    expect(formatRelativeTime(now - 2 * 24 * 60 * 60_000)).toBe("2d ago");
+    expect(formatRelativeTime(now - 6 * 24 * 60 * 60_000)).toBe("6d ago");
+  });
+
+  it("returns date for 7+ days", () => {
+    const now = Date.now();
+    const result = formatRelativeTime(now - 30 * 24 * 60 * 60_000);
+    // Should be a formatted date like "Jan 7" or "Dec 25"
+    expect(result).not.toContain("ago");
+    expect(result).not.toBe("just now");
+  });
+});

--- a/src/web/auto-reply/util.test.ts
+++ b/src/web/auto-reply/util.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { elide, isLikelyWhatsAppCryptoError } from "./util.js";
+
+describe("elide", () => {
+  it("returns undefined for undefined", () => {
+    expect(elide(undefined)).toBeUndefined();
+  });
+
+  it("returns empty string for empty string", () => {
+    expect(elide("")).toBe("");
+  });
+
+  it("returns text unchanged when within limit", () => {
+    expect(elide("hello", 10)).toBe("hello");
+  });
+
+  it("returns text unchanged at exact limit", () => {
+    expect(elide("hello", 5)).toBe("hello");
+  });
+
+  it("truncates text over limit", () => {
+    const result = elide("hello world", 5);
+    expect(result).toContain("hello");
+    expect(result).toContain("truncated");
+    expect(result).toContain("6 chars");
+  });
+
+  it("uses default limit of 400", () => {
+    const short = "a".repeat(400);
+    expect(elide(short)).toBe(short);
+
+    const long = "a".repeat(401);
+    expect(elide(long)).toContain("truncated");
+  });
+});
+
+describe("isLikelyWhatsAppCryptoError", () => {
+  it("returns false for null", () => {
+    expect(isLikelyWhatsAppCryptoError(null)).toBe(false);
+  });
+
+  it("returns false for generic error", () => {
+    expect(isLikelyWhatsAppCryptoError(new Error("network timeout"))).toBe(false);
+  });
+
+  it("returns false for auth error without baileys", () => {
+    expect(
+      isLikelyWhatsAppCryptoError(new Error("unsupported state or unable to authenticate data")),
+    ).toBe(false);
+  });
+
+  it("returns true for baileys crypto error", () => {
+    expect(
+      isLikelyWhatsAppCryptoError(
+        new Error("unsupported state or unable to authenticate data at @whiskeysockets/baileys"),
+      ),
+    ).toBe(true);
+  });
+
+  it("detects bad mac with baileys", () => {
+    expect(isLikelyWhatsAppCryptoError(new Error("bad mac in baileys noise-handler"))).toBe(true);
+  });
+
+  it("works with string reason", () => {
+    expect(
+      isLikelyWhatsAppCryptoError("unsupported state or unable to authenticate data baileys"),
+    ).toBe(true);
+  });
+
+  it("returns false for number", () => {
+    expect(isLikelyWhatsAppCryptoError(42)).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isLikelyWhatsAppCryptoError(undefined)).toBe(false);
+  });
+});

--- a/src/web/vcard.test.ts
+++ b/src/web/vcard.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { parseVcard } from "./vcard.js";
+
+describe("parseVcard", () => {
+  it("returns empty result for undefined input", () => {
+    expect(parseVcard(undefined)).toEqual({ phones: [] });
+  });
+
+  it("returns empty result for empty string", () => {
+    expect(parseVcard("")).toEqual({ phones: [] });
+  });
+
+  it("parses FN (formatted name)", () => {
+    const vcard = "BEGIN:VCARD\nFN:John Doe\nEND:VCARD";
+    expect(parseVcard(vcard)).toEqual({ name: "John Doe", phones: [] });
+  });
+
+  it("parses N (structured name) with semicolons", () => {
+    const vcard = "BEGIN:VCARD\nN:Doe;John;;;\nEND:VCARD";
+    const result = parseVcard(vcard);
+    expect(result.name).toBe("Doe John");
+  });
+
+  it("prefers FN over N", () => {
+    const vcard = "BEGIN:VCARD\nFN:John Doe\nN:Doe;John;;;\nEND:VCARD";
+    expect(parseVcard(vcard).name).toBe("John Doe");
+  });
+
+  it("parses phone numbers", () => {
+    const vcard = "BEGIN:VCARD\nTEL:+1234567890\nTEL:+0987654321\nEND:VCARD";
+    expect(parseVcard(vcard).phones).toEqual(["+1234567890", "+0987654321"]);
+  });
+
+  it("strips tel: prefix from phone values", () => {
+    const vcard = "BEGIN:VCARD\nTEL:tel:+1234567890\nEND:VCARD";
+    expect(parseVcard(vcard).phones).toEqual(["+1234567890"]);
+  });
+
+  it("handles TEL with parameters", () => {
+    const vcard = "BEGIN:VCARD\nTEL;TYPE=CELL:+1234567890\nEND:VCARD";
+    expect(parseVcard(vcard).phones).toEqual(["+1234567890"]);
+  });
+
+  it("handles grouped keys (e.g. item1.TEL)", () => {
+    const vcard = "BEGIN:VCARD\nitem1.TEL:+1111\nEND:VCARD";
+    expect(parseVcard(vcard).phones).toEqual(["+1111"]);
+  });
+
+  it("ignores unknown keys", () => {
+    const vcard = "BEGIN:VCARD\nEMAIL:test@example.com\nFN:Test\nEND:VCARD";
+    const result = parseVcard(vcard);
+    expect(result.name).toBe("Test");
+    expect(result.phones).toEqual([]);
+  });
+
+  it("handles Windows-style line endings", () => {
+    const vcard = "BEGIN:VCARD\r\nFN:Test\r\nTEL:+123\r\nEND:VCARD";
+    expect(parseVcard(vcard)).toEqual({ name: "Test", phones: ["+123"] });
+  });
+
+  it("cleans escaped characters in values", () => {
+    const vcard = "BEGIN:VCARD\nFN:John\\, Jr.\nEND:VCARD";
+    expect(parseVcard(vcard).name).toBe("John, Jr.");
+  });
+
+  it("handles full vcard with all fields", () => {
+    const vcard = [
+      "BEGIN:VCARD",
+      "VERSION:3.0",
+      "FN:Alice Smith",
+      "N:Smith;Alice;;;",
+      "TEL;TYPE=CELL:+1555000111",
+      "TEL;TYPE=HOME:+1555000222",
+      "EMAIL:alice@example.com",
+      "END:VCARD",
+    ].join("\n");
+    const result = parseVcard(vcard);
+    expect(result.name).toBe("Alice Smith");
+    expect(result.phones).toEqual(["+1555000111", "+1555000222"]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds 57 new test files covering modules that previously had little or no test coverage. All tests are additive (no source changes) and target existing upstream code.

**Modules covered:**
- **auto-reply**: block-reply coalescer, config values, directives, inbound deduplication/sender-meta/text, reply payloads, templating
- **channels**: allowlist matching, resolve utils, media limits, feishu normalization, sender labels
- **config**: agent limits, group policy, markdown tables, merge-patch, port defaults, version comparison, workspace schemas
- **gateway**: device auth, HTTP utils
- **infra**: backoff, bonjour errors, canvas host URL, errors, exec safety, format duration, heartbeat events, outbound channel adapters, outbound directory cache, ports format, provider usage format/shared, WebSocket
- **misc**: link understanding detection, logging levels, markdown (code spans/fences/tables), media constants, memory status format, Slack token, Telegram (allowed updates/captions), terminal (ANSI/note), TUI fuzzy filter, utils (directive tags/queue helpers/shell argv/time format), web (auto-reply util/vcard)

## Test plan

- [ ] All 57 test files pass with \`vitest\`
- [ ] No source files modified — zero risk of behavioral regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a large set of new Vitest unit tests across many modules (auto-reply, channels, config, gateway, infra, markdown, etc.) without modifying production source.

Key issues to address before merge:
- One new test (`src/infra/provider-usage.shared.test.ts`) creates a long-lived real timer that can keep the test process alive even after the assertion completes.
- One new test (`src/config/workspace-schemas.test.ts`) appears to compute the repository root incorrectly and reads JSON files from a path that doesn’t exist in the repo, which should fail with ENOENT.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is because at least one new test should fail and another can significantly slow or hang the test run.
- Confidence reduced due to a verified bad path calculation in workspace schema tests (likely ENOENT) and a real 5s timer left running in a withTimeout test, which can keep the event loop alive and slow CI.
- src/config/workspace-schemas.test.ts, src/infra/provider-usage.shared.test.ts

<sub>Last reviewed commit: ec23b22</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->