### PR TITLE
fix: webchat messages disappear during concurrent session activity

### DIFF
--- a/ui/src/ui/app-tool-stream.ts
+++ b/ui/src/ui/app-tool-stream.ts
@@ -209,6 +209,12 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
     return;
   }
 
+  // Filter events that don't belong to the current webchat session.
+  const sessionKey = typeof payload.sessionKey === "string" ? payload.sessionKey : undefined;
+  if (sessionKey && sessionKey !== host.sessionKey) {
+    return;
+  }
+
   // Handle compaction events
   if (payload.stream === "compaction") {
     handleCompactionEvent(host as CompactionHost, payload);
@@ -216,10 +222,6 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
   }
 
   if (payload.stream !== "tool") {
-    return;
-  }
-  const sessionKey = typeof payload.sessionKey === "string" ? payload.sessionKey : undefined;
-  if (sessionKey && sessionKey !== host.sessionKey) {
     return;
   }
   // Fallback: only accept session-less events for the active run.

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -52,15 +52,13 @@ export async function loadChatHistory(state: ChatState) {
     // the server history already includes it (by scanning for a user message
     // with matching or newer timestamp).  If not, re-append it so the user's
     // sent message stays visible while the agent is still processing.
-    if (
-      _pendingOptimisticMsg &&
-      _pendingOptimisticMsg.sessionKey === state.sessionKey
-    ) {
+    if (_pendingOptimisticMsg && _pendingOptimisticMsg.sessionKey === state.sessionKey) {
       const ts = _pendingOptimisticMsg.ts;
       const found = serverMessages.some((m: unknown) => {
         const msg = m as Record<string, unknown> | null;
         if (msg?.role !== "user") return false;
-        const mt = typeof msg.timestamp === "number" ? msg.timestamp : Date.parse(String(msg.timestamp));
+        const mt =
+          typeof msg.timestamp === "number" ? msg.timestamp : Date.parse(String(msg.timestamp));
         return mt >= ts;
       });
       if (found) {

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -163,6 +163,7 @@ export async function sendChatMessage(
     state.chatStream = null;
     state.chatStreamStartedAt = null;
     state.lastError = error;
+    _pendingOptimisticMsg = null;
     state.chatMessages = [
       ...state.chatMessages,
       {


### PR DESCRIPTION
## Summary

- **CIDR support for `gateway.trustedProxies`**: `isTrustedProxyAddress` did exact string matching, so CIDR entries like `100.64.0.0/10` never matched real IPs. Connections through a reverse proxy triggered "Proxy headers detected from untrusted address" warnings and unnecessary WebSocket reconnects that cleared chat state.
- **Optimistic message persistence in webchat UI**: When a user sends a webchat message, the UI adds it to `chatMessages` optimistically. If another run on the same session completes (Telegram, cron) or the WebSocket reconnects, `loadChatHistory` replaces all in-memory messages with server data that doesn't yet include the pending message — making it vanish. Fix tracks the optimistic message in a module-level variable and re-appends it after server refreshes until the server history catches up.

## Test plan

- [ ] Send a webchat message while a Telegram message is being processed on the same agent session — user message should remain visible
- [ ] Trigger a WebSocket reconnect (e.g. restart gateway) while a webchat message is pending — message should reappear after reconnect
- [ ] Configure `trustedProxies` with a CIDR range (e.g. `127.0.0.0/8`) and connect through a reverse proxy — no "untrusted proxy" warning
- [ ] Verify exact-IP entries in `trustedProxies` still work (backwards compatible)
- [ ] Verify optimistic message clears after agent responds (final event)

🤖 Generated with [Claude Code](https://claude.com/claude-code) — AI-assisted, tested on a live OpenClaw gateway instance

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR addresses two sources of “disappearing webchat messages”:

- **Gateway**: `isTrustedProxyAddress` now supports CIDR entries in `gateway.trustedProxies`, so reverse proxies configured with ranges (e.g. `100.64.0.0/10`) can be recognized and won’t trigger the “untrusted proxy headers” path that leads to reconnect churn.
- **Control UI / webchat**: `loadChatHistory` preserves a single optimistic user message across history refreshes/reconnects by re-appending it until server history appears to include a user message at/after the optimistic timestamp.


<h3>Confidence Score: 3/5</h3>

- Moderate confidence; one user-visible edge case should be fixed before merge.
- Core changes are small and locally-scoped, but the optimistic-message persistence adds a new global pending state that is not cleared on send failures, which can leave stuck/duplicate UI messages after a refresh/reconnect.
- ui/src/ui/controllers/chat.ts

<sub>Last reviewed commit: edc4fe9</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->