### PR TITLE
feat: configurable workspace context files (agents.defaults.contextFiles)

### DIFF
--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -27,7 +27,7 @@ export async function resolveBootstrapFilesForRun(params: {
 }): Promise<WorkspaceBootstrapFile[]> {
   const sessionKey = params.sessionKey ?? params.sessionId;
   const bootstrapFiles = filterBootstrapFilesForSession(
-    await loadWorkspaceBootstrapFiles(params.workspaceDir),
+    await loadWorkspaceBootstrapFiles(params.workspaceDir, params.config),
     sessionKey,
   );
   return applyBootstrapHookOverrides({

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -108,6 +108,8 @@ export type AgentDefaultsConfig = {
   skipBootstrap?: boolean;
   /** Max chars for injected bootstrap files before truncation (default: 20000). */
   bootstrapMaxChars?: number;
+  /** Additional workspace files to inject into the system prompt alongside the defaults. */
+  contextFiles?: string[];
   /** Optional IANA timezone for the user (used in system prompt; defaults to host timezone). */
   userTimezone?: string;
   /** Time format in system prompt: auto (OS preference), 12-hour, or 24-hour. */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -47,6 +47,7 @@ export const AgentDefaultsSchema = z
     repoRoot: z.string().optional(),
     skipBootstrap: z.boolean().optional(),
     bootstrapMaxChars: z.number().int().positive().optional(),
+    contextFiles: z.array(z.string()).optional(),
     userTimezone: z.string().optional(),
     timeFormat: z.union([z.literal("auto"), z.literal("12"), z.literal("24")]).optional(),
     envelopeTimezone: z.string().optional(),


### PR DESCRIPTION
## Summary

Add support for injecting additional workspace files into the system prompt via a new `contextFiles` config option.

Closes #15566

## Config Example

```json
{
  "agents": {
    "defaults": {
      "contextFiles": ["RUNBOOK.md", "KNOWLEDGE.md"]
    }
  }
}
```

These files are injected alongside the existing defaults (AGENTS.md, SOUL.md, etc.), subject to the same `bootstrapMaxChars` truncation rules.

## Changes

| File | Change |
|---|---|
| `src/config/types.agent-defaults.ts` | Add `contextFiles?: string[]` to `AgentDefaultsConfig` |
| `src/config/zod-schema.agent-defaults.ts` | Add `contextFiles` to Zod validation schema |
| `src/agents/workspace.ts` | Accept config param in `loadWorkspaceBootstrapFiles()`, append user-specified files with dedup |
| `src/agents/bootstrap-files.ts` | Pass config through to `loadWorkspaceBootstrapFiles()` |

## Details

- Custom files are appended **after** the default set + memory entries
- Duplicate filenames are skipped (if a custom file matches a default, the default wins)
- Type `WorkspaceBootstrapFileName` widened with `| (string & {})` to accept custom names while preserving autocomplete for defaults
- TypeScript compiles cleanly (`tsc --noEmit` passes with zero errors)

## Use Case

Users who maintain operational runbooks, domain knowledge bases, or project-specific reference files currently must rely on the agent manually `read`-ing them each session. This is unreliable — the agent may skip it. With `contextFiles`, these are guaranteed to be injected every turn.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new `agents.defaults.contextFiles` config option, validates it via Zod, and threads the config through bootstrap resolution so additional workspace files can be injected into the system prompt alongside existing defaults (AGENTS.md, SOUL.md, memory entries, etc.).

The main concern is that `contextFiles` values are treated as arbitrary path segments and read from disk via `path.join(resolvedDir, trimmed)` in `loadWorkspaceBootstrapFiles`, which allows `..`/path-separator escapes and could inject files outside the workspace into the prompt. Consider constraining entries to workspace-contained paths (or validating containment) before reading.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a prompt-injection data exposure risk via path traversal in contextFiles.
- The feature is small and wiring looks correct, but `contextFiles` can escape the workspace and read arbitrary local files into the system prompt unless containment is enforced.
- src/agents/workspace.ts

<sub>Last reviewed commit: a463789</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->