### PR TITLE
feat: infrastructure foundation — hooks, model failover, sessions, embedded runner

### DIFF
--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -163,6 +163,21 @@ export function resolveAgentModelFallbacksOverride(
   return Array.isArray(raw.fallbacks) ? raw.fallbacks : undefined;
 }
 
+export function resolveAgentModelStrategy(
+  cfg: OpenClawConfig,
+  agentId?: string,
+): "primary" | "round_robin" | "sticky_session" | undefined {
+  const raw = agentId ? resolveAgentConfig(cfg, agentId)?.model : undefined;
+  if (raw && typeof raw === "object" && "strategy" in raw) {
+    return raw.strategy;
+  }
+  const defaults = cfg.agents?.defaults?.model;
+  if (defaults && typeof defaults === "object" && "strategy" in defaults) {
+    return defaults.strategy;
+  }
+  return undefined;
+}
+
 export function resolveAgentWorkspaceDir(cfg: OpenClawConfig, agentId: string) {
   const id = normalizeAgentId(agentId);
   const configured = resolveAgentConfig(cfg, id)?.workspace?.trim();

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1,5 +1,8 @@
 import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import { Type } from "@sinclair/typebox";
 import crypto from "node:crypto";
+import path from "node:path";
 import type { BashSandboxConfig } from "./bash-tools.shared.js";
 import {
   type ExecAsk,
@@ -16,48 +19,149 @@ import {
   resolveExecApprovals,
   resolveExecApprovalsFromFile,
 } from "../infra/exec-approvals.js";
+import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
 import { buildNodeShellCommand } from "../infra/node-shell.js";
 import {
   getShellPathFromLoginShell,
   resolveShellEnvFallbackTimeoutMs,
 } from "../infra/shell-env.js";
-import { logInfo } from "../logger.js";
+import { enqueueSystemEvent } from "../infra/system-events.js";
+import { logInfo, logWarn } from "../logger.js";
+import { formatSpawnError, spawnWithFallback } from "../process/spawn-utils.js";
 import { parseAgentSessionKey, resolveAgentIdFromSessionKey } from "../routing/session-key.js";
-import { markBackgrounded, tail } from "./bash-process-registry.js";
 import {
-  DEFAULT_APPROVAL_REQUEST_TIMEOUT_MS,
-  DEFAULT_APPROVAL_TIMEOUT_MS,
-  DEFAULT_MAX_OUTPUT,
-  DEFAULT_NOTIFY_TAIL_CHARS,
-  DEFAULT_PATH,
-  DEFAULT_PENDING_MAX_OUTPUT,
-  applyPathPrepend,
-  applyShellPath,
-  createApprovalSlug,
-  emitExecSystemEvent,
-  normalizeExecAsk,
-  normalizeExecHost,
-  normalizeExecSecurity,
-  normalizeNotifyOutput,
-  normalizePathPrepend,
-  renderExecHostLabel,
-  resolveApprovalRunningNoticeMs,
-  runExecProcess,
-  execSchema,
-  type ExecProcessHandle,
-  validateHostEnv,
-} from "./bash-tools.exec-runtime.js";
+  type ProcessSession,
+  type SessionStdin,
+  addSession,
+  appendOutput,
+  createSessionSlug,
+  markBackgrounded,
+  markExited,
+  tail,
+} from "./bash-process-registry.js";
 import {
+  buildDockerExecArgs,
   buildSandboxEnv,
+  chunkString,
   clampWithDefault,
   coerceEnv,
+  killSession,
   readEnvInt,
   resolveSandboxWorkdir,
   resolveWorkdir,
   truncateMiddle,
 } from "./bash-tools.shared.js";
+import { buildCursorPositionResponse, stripDsrRequests } from "./pty-dsr.js";
+import { getShellConfig, sanitizeBinaryOutput } from "./shell-utils.js";
 import { callGatewayTool } from "./tools/gateway.js";
 import { listNodes, resolveNodeIdFromList } from "./tools/nodes-utils.js";
+
+// Security: Blocklist of environment variables that could alter execution flow
+// or inject code when running on non-sandboxed hosts (Gateway/Node).
+const DANGEROUS_HOST_ENV_VARS = new Set([
+  "LD_PRELOAD",
+  "LD_LIBRARY_PATH",
+  "LD_AUDIT",
+  "DYLD_INSERT_LIBRARIES",
+  "DYLD_LIBRARY_PATH",
+  "NODE_OPTIONS",
+  "NODE_PATH",
+  "PYTHONPATH",
+  "PYTHONHOME",
+  "RUBYLIB",
+  "PERL5LIB",
+  "BASH_ENV",
+  "ENV",
+  "GCONV_PATH",
+  "IFS",
+  "SSLKEYLOGFILE",
+]);
+const DANGEROUS_HOST_ENV_PREFIXES = ["DYLD_", "LD_"];
+
+// Centralized sanitization helper.
+// Throws an error if dangerous variables or PATH modifications are detected on the host.
+function validateHostEnv(env: Record<string, string>): void {
+  for (const key of Object.keys(env)) {
+    const upperKey = key.toUpperCase();
+
+    // 1. Block known dangerous variables (Fail Closed)
+    if (DANGEROUS_HOST_ENV_PREFIXES.some((prefix) => upperKey.startsWith(prefix))) {
+      throw new Error(
+        `Security Violation: Environment variable '${key}' is forbidden during host execution.`,
+      );
+    }
+    if (DANGEROUS_HOST_ENV_VARS.has(upperKey)) {
+      throw new Error(
+        `Security Violation: Environment variable '${key}' is forbidden during host execution.`,
+      );
+    }
+
+    // 2. Strictly block PATH modification on host
+    // Allowing custom PATH on the gateway/node can lead to binary hijacking.
+    if (upperKey === "PATH") {
+      throw new Error(
+        "Security Violation: Custom 'PATH' variable is forbidden during host execution.",
+      );
+    }
+  }
+}
+const DEFAULT_MAX_OUTPUT = clampWithDefault(
+  readEnvInt("PI_BASH_MAX_OUTPUT_CHARS"),
+  200_000,
+  1_000,
+  200_000,
+);
+const DEFAULT_PENDING_MAX_OUTPUT = clampWithDefault(
+  readEnvInt("OPENCLAW_BASH_PENDING_MAX_OUTPUT_CHARS"),
+  200_000,
+  1_000,
+  200_000,
+);
+const DEFAULT_PATH =
+  process.env.PATH ?? "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+const DEFAULT_NOTIFY_TAIL_CHARS = 400;
+const DEFAULT_APPROVAL_TIMEOUT_MS = 120_000;
+const DEFAULT_APPROVAL_REQUEST_TIMEOUT_MS = 130_000;
+const DEFAULT_APPROVAL_RUNNING_NOTICE_MS = 10_000;
+const APPROVAL_SLUG_LENGTH = 8;
+
+type PtyExitEvent = { exitCode: number; signal?: number };
+type PtyListener<T> = (event: T) => void;
+type PtyHandle = {
+  pid: number;
+  write: (data: string | Buffer) => void;
+  onData: (listener: PtyListener<string>) => void;
+  onExit: (listener: PtyListener<PtyExitEvent>) => void;
+};
+type PtySpawn = (
+  file: string,
+  args: string[] | string,
+  options: {
+    name?: string;
+    cols?: number;
+    rows?: number;
+    cwd?: string;
+    env?: Record<string, string>;
+  },
+) => PtyHandle;
+
+type ExecProcessOutcome = {
+  status: "completed" | "failed";
+  exitCode: number | null;
+  exitSignal: NodeJS.Signals | number | null;
+  durationMs: number;
+  aggregated: string;
+  timedOut: boolean;
+  reason?: string;
+};
+
+type ExecProcessHandle = {
+  session: ProcessSession;
+  startedAt: number;
+  pid?: number;
+  promise: Promise<ExecProcessOutcome>;
+  kill: () => void;
+};
 
 export type ExecToolDefaults = {
   host?: ExecHost;
@@ -88,6 +192,54 @@ export type ExecElevatedDefaults = {
   defaultLevel: "on" | "off" | "ask" | "full";
 };
 
+const execSchema = Type.Object({
+  command: Type.String({ description: "Shell command to execute" }),
+  workdir: Type.Optional(Type.String({ description: "Working directory (defaults to cwd)" })),
+  env: Type.Optional(Type.Record(Type.String(), Type.String())),
+  yieldMs: Type.Optional(
+    Type.Number({
+      description: "Milliseconds to wait before backgrounding (default 10000)",
+    }),
+  ),
+  background: Type.Optional(Type.Boolean({ description: "Run in background immediately" })),
+  timeout: Type.Optional(
+    Type.Number({
+      description: "Timeout in seconds (optional, kills process on expiry)",
+    }),
+  ),
+  pty: Type.Optional(
+    Type.Boolean({
+      description:
+        "Run in a pseudo-terminal (PTY) when available (TTY-required CLIs, coding agents)",
+    }),
+  ),
+  elevated: Type.Optional(
+    Type.Boolean({
+      description: "Run on the host with elevated permissions (if allowed)",
+    }),
+  ),
+  host: Type.Optional(
+    Type.String({
+      description: "Exec host (sandbox|gateway|node).",
+    }),
+  ),
+  security: Type.Optional(
+    Type.String({
+      description: "Exec security mode (deny|allowlist|full).",
+    }),
+  ),
+  ask: Type.Optional(
+    Type.String({
+      description: "Exec ask mode (off|on-miss|always).",
+    }),
+  ),
+  node: Type.Optional(
+    Type.String({
+      description: "Node id/name for host=node.",
+    }),
+  ),
+});
+
 export type ExecToolDetails =
   | {
       status: "running";
@@ -114,6 +266,564 @@ export type ExecToolDetails =
       cwd?: string;
       nodeId?: string;
     };
+
+function normalizeExecHost(value?: string | null): ExecHost | null {
+  const normalized = value?.trim().toLowerCase();
+  if (normalized === "sandbox" || normalized === "gateway" || normalized === "node") {
+    return normalized;
+  }
+  return null;
+}
+
+function normalizeExecSecurity(value?: string | null): ExecSecurity | null {
+  const normalized = value?.trim().toLowerCase();
+  if (normalized === "deny" || normalized === "allowlist" || normalized === "full") {
+    return normalized;
+  }
+  return null;
+}
+
+function normalizeExecAsk(value?: string | null): ExecAsk | null {
+  const normalized = value?.trim().toLowerCase();
+  if (normalized === "off" || normalized === "on-miss" || normalized === "always") {
+    return normalized as ExecAsk;
+  }
+  return null;
+}
+
+function renderExecHostLabel(host: ExecHost) {
+  return host === "sandbox" ? "sandbox" : host === "gateway" ? "gateway" : "node";
+}
+
+function normalizeNotifyOutput(value: string) {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function normalizePathPrepend(entries?: string[]) {
+  if (!Array.isArray(entries)) {
+    return [];
+  }
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+  for (const entry of entries) {
+    if (typeof entry !== "string") {
+      continue;
+    }
+    const trimmed = entry.trim();
+    if (!trimmed || seen.has(trimmed)) {
+      continue;
+    }
+    seen.add(trimmed);
+    normalized.push(trimmed);
+  }
+  return normalized;
+}
+
+function mergePathPrepend(existing: string | undefined, prepend: string[]) {
+  if (prepend.length === 0) {
+    return existing;
+  }
+  const partsExisting = (existing ?? "")
+    .split(path.delimiter)
+    .map((part) => part.trim())
+    .filter(Boolean);
+  const merged: string[] = [];
+  const seen = new Set<string>();
+  for (const part of [...prepend, ...partsExisting]) {
+    if (seen.has(part)) {
+      continue;
+    }
+    seen.add(part);
+    merged.push(part);
+  }
+  return merged.join(path.delimiter);
+}
+
+function applyPathPrepend(
+  env: Record<string, string>,
+  prepend: string[],
+  options?: { requireExisting?: boolean },
+) {
+  if (prepend.length === 0) {
+    return;
+  }
+  if (options?.requireExisting && !env.PATH) {
+    return;
+  }
+  const merged = mergePathPrepend(env.PATH, prepend);
+  if (merged) {
+    env.PATH = merged;
+  }
+}
+
+function applyShellPath(env: Record<string, string>, shellPath?: string | null) {
+  if (!shellPath) {
+    return;
+  }
+  const entries = shellPath
+    .split(path.delimiter)
+    .map((part) => part.trim())
+    .filter(Boolean);
+  if (entries.length === 0) {
+    return;
+  }
+  const merged = mergePathPrepend(env.PATH, entries);
+  if (merged) {
+    env.PATH = merged;
+  }
+}
+
+function maybeNotifyOnExit(session: ProcessSession, status: "completed" | "failed") {
+  if (!session.backgrounded || !session.notifyOnExit || session.exitNotified) {
+    return;
+  }
+  const sessionKey = session.sessionKey?.trim();
+  if (!sessionKey) {
+    return;
+  }
+  session.exitNotified = true;
+  const exitLabel = session.exitSignal
+    ? `signal ${session.exitSignal}`
+    : `code ${session.exitCode ?? 0}`;
+  const output = normalizeNotifyOutput(
+    tail(session.tail || session.aggregated || "", DEFAULT_NOTIFY_TAIL_CHARS),
+  );
+  const summary = output
+    ? `Exec ${status} (${session.id.slice(0, 8)}, ${exitLabel}) :: ${output}`
+    : `Exec ${status} (${session.id.slice(0, 8)}, ${exitLabel})`;
+  enqueueSystemEvent(summary, { sessionKey });
+  requestHeartbeatNow({ reason: `exec:${session.id}:exit` });
+}
+
+function createApprovalSlug(id: string) {
+  return id.slice(0, APPROVAL_SLUG_LENGTH);
+}
+
+function resolveApprovalRunningNoticeMs(value?: number) {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return DEFAULT_APPROVAL_RUNNING_NOTICE_MS;
+  }
+  if (value <= 0) {
+    return 0;
+  }
+  return Math.floor(value);
+}
+
+function emitExecSystemEvent(text: string, opts: { sessionKey?: string; contextKey?: string }) {
+  const sessionKey = opts.sessionKey?.trim();
+  if (!sessionKey) {
+    return;
+  }
+  enqueueSystemEvent(text, { sessionKey, contextKey: opts.contextKey });
+  requestHeartbeatNow({ reason: "exec-event" });
+}
+
+async function runExecProcess(opts: {
+  command: string;
+  workdir: string;
+  env: Record<string, string>;
+  sandbox?: BashSandboxConfig;
+  containerWorkdir?: string | null;
+  usePty: boolean;
+  warnings: string[];
+  maxOutput: number;
+  pendingMaxOutput: number;
+  notifyOnExit: boolean;
+  scopeKey?: string;
+  sessionKey?: string;
+  timeoutSec: number;
+  onUpdate?: (partialResult: AgentToolResult<ExecToolDetails>) => void;
+}): Promise<ExecProcessHandle> {
+  const startedAt = Date.now();
+  const sessionId = createSessionSlug();
+  let child: ChildProcessWithoutNullStreams | null = null;
+  let pty: PtyHandle | null = null;
+  let stdin: SessionStdin | undefined;
+
+  if (opts.sandbox) {
+    const { child: spawned } = await spawnWithFallback({
+      argv: [
+        "docker",
+        ...buildDockerExecArgs({
+          containerName: opts.sandbox.containerName,
+          command: opts.command,
+          workdir: opts.containerWorkdir ?? opts.sandbox.containerWorkdir,
+          env: opts.env,
+          tty: opts.usePty,
+        }),
+      ],
+      options: {
+        cwd: opts.workdir,
+        env: process.env,
+        detached: process.platform !== "win32",
+        stdio: ["pipe", "pipe", "pipe"],
+        windowsHide: true,
+      },
+      fallbacks: [
+        {
+          label: "no-detach",
+          options: { detached: false },
+        },
+      ],
+      onFallback: (err, fallback) => {
+        const errText = formatSpawnError(err);
+        const warning = `Warning: spawn failed (${errText}); retrying with ${fallback.label}.`;
+        logWarn(`exec: spawn failed (${errText}); retrying with ${fallback.label}.`);
+        opts.warnings.push(warning);
+      },
+    });
+    child = spawned as ChildProcessWithoutNullStreams;
+    stdin = child.stdin;
+  } else if (opts.usePty) {
+    const { shell, args: shellArgs } = getShellConfig();
+    // WORKAROUND: Disable PTY on macOS - node-pty has issues on macOS causing EBADF after first spawn.
+    // Commands requiring TTY semantics will fall back to pipe-based stdio, which may not
+    // support interactive/TUI features. See: https://github.com/openclaw/openclaw/issues/XXXX
+    if (process.platform === "darwin") {
+      logWarn(
+        "exec: PTY requested but disabled on macOS (EBADF workaround); using pipe-based spawn",
+      );
+      const { child: spawned } = await spawnWithFallback({
+        argv: [shell, ...shellArgs, opts.command],
+        options: {
+          cwd: opts.workdir,
+          env: opts.env,
+          detached: false, // macOS workaround - detached spawn causes EBADF on Node v22
+          stdio: ["pipe", "pipe", "pipe"],
+          windowsHide: true,
+        },
+        fallbacks: [],
+        onFallback: (fallbackErr, fallback) => {
+          const fallbackText = formatSpawnError(fallbackErr);
+          const fallbackWarning = `Warning: spawn failed (${fallbackText}); retrying with ${fallback.label}.`;
+          logWarn(`exec: spawn failed (${fallbackText}); retrying with ${fallback.label}.`);
+          opts.warnings.push(fallbackWarning);
+        },
+      });
+      child = spawned as ChildProcessWithoutNullStreams;
+      stdin = child.stdin;
+    } else {
+      try {
+        const ptyModule = (await import("@lydell/node-pty")) as unknown as {
+          spawn?: PtySpawn;
+          default?: { spawn?: PtySpawn };
+        };
+        const spawnPty = ptyModule.spawn ?? ptyModule.default?.spawn;
+        if (!spawnPty) {
+          throw new Error("PTY support is unavailable (node-pty spawn not found).");
+        }
+        pty = spawnPty(shell, [...shellArgs, opts.command], {
+          cwd: opts.workdir,
+          env: opts.env,
+          name: process.env.TERM ?? "xterm-256color",
+          cols: 120,
+          rows: 30,
+        });
+        stdin = {
+          destroyed: false,
+          write: (data, cb) => {
+            try {
+              pty?.write(data);
+              cb?.(null);
+            } catch (err) {
+              cb?.(err as Error);
+            }
+          },
+          end: () => {
+            try {
+              const eof = process.platform === "win32" ? "\x1a" : "\x04";
+              pty?.write(eof);
+            } catch {
+              // ignore EOF errors
+            }
+          },
+        };
+      } catch (err) {
+        const errText = String(err);
+        const warning = `Warning: PTY spawn failed (${errText}); retrying without PTY for \`${opts.command}\`.`;
+        logWarn(`exec: PTY spawn failed (${errText}); retrying without PTY for "${opts.command}".`);
+        opts.warnings.push(warning);
+        const { child: spawned } = await spawnWithFallback({
+          argv: [shell, ...shellArgs, opts.command],
+          options: {
+            cwd: opts.workdir,
+            env: opts.env,
+            detached: process.platform !== "win32",
+            stdio: ["pipe", "pipe", "pipe"],
+            windowsHide: true,
+          },
+          fallbacks: [
+            {
+              label: "no-detach",
+              options: { detached: false },
+            },
+          ],
+          onFallback: (fallbackErr, fallback) => {
+            const fallbackText = formatSpawnError(fallbackErr);
+            const fallbackWarning = `Warning: spawn failed (${fallbackText}); retrying with ${fallback.label}.`;
+            logWarn(`exec: spawn failed (${fallbackText}); retrying with ${fallback.label}.`);
+            opts.warnings.push(fallbackWarning);
+          },
+        });
+        child = spawned as ChildProcessWithoutNullStreams;
+        stdin = child.stdin;
+      }
+    }
+  } else {
+    const { shell, args: shellArgs } = getShellConfig();
+    const { child: spawned } = await spawnWithFallback({
+      argv: [shell, ...shellArgs, opts.command],
+      options: {
+        cwd: opts.workdir,
+        env: opts.env,
+        detached: process.platform !== "win32",
+        stdio: ["pipe", "pipe", "pipe"],
+        windowsHide: true,
+      },
+      fallbacks: [
+        {
+          label: "no-detach",
+          options: { detached: false },
+        },
+      ],
+      onFallback: (err, fallback) => {
+        const errText = formatSpawnError(err);
+        const warning = `Warning: spawn failed (${errText}); retrying with ${fallback.label}.`;
+        logWarn(`exec: spawn failed (${errText}); retrying with ${fallback.label}.`);
+        opts.warnings.push(warning);
+      },
+    });
+    child = spawned as ChildProcessWithoutNullStreams;
+    stdin = child.stdin;
+  }
+
+  const session = {
+    id: sessionId,
+    command: opts.command,
+    scopeKey: opts.scopeKey,
+    sessionKey: opts.sessionKey,
+    notifyOnExit: opts.notifyOnExit,
+    exitNotified: false,
+    child: child ?? undefined,
+    stdin,
+    pid: child?.pid ?? pty?.pid,
+    startedAt,
+    cwd: opts.workdir,
+    maxOutputChars: opts.maxOutput,
+    pendingMaxOutputChars: opts.pendingMaxOutput,
+    totalOutputChars: 0,
+    pendingStdout: [],
+    pendingStderr: [],
+    pendingStdoutChars: 0,
+    pendingStderrChars: 0,
+    aggregated: "",
+    tail: "",
+    exited: false,
+    exitCode: undefined as number | null | undefined,
+    exitSignal: undefined as NodeJS.Signals | number | null | undefined,
+    truncated: false,
+    backgrounded: false,
+  } satisfies ProcessSession;
+  addSession(session);
+
+  let settled = false;
+  let timeoutTimer: NodeJS.Timeout | null = null;
+  let timeoutFinalizeTimer: NodeJS.Timeout | null = null;
+  let timedOut = false;
+  const timeoutFinalizeMs = 1000;
+  let resolveFn: ((outcome: ExecProcessOutcome) => void) | null = null;
+
+  const settle = (outcome: ExecProcessOutcome) => {
+    if (settled) {
+      return;
+    }
+    settled = true;
+    resolveFn?.(outcome);
+  };
+
+  const finalizeTimeout = () => {
+    if (session.exited) {
+      return;
+    }
+    markExited(session, null, "SIGKILL", "failed");
+    maybeNotifyOnExit(session, "failed");
+    const aggregated = session.aggregated.trim();
+    const reason = `Command timed out after ${opts.timeoutSec} seconds`;
+    settle({
+      status: "failed",
+      exitCode: null,
+      exitSignal: "SIGKILL",
+      durationMs: Date.now() - startedAt,
+      aggregated,
+      timedOut: true,
+      reason: aggregated ? `${aggregated}\n\n${reason}` : reason,
+    });
+  };
+
+  const onTimeout = () => {
+    timedOut = true;
+    killSession(session);
+    if (!timeoutFinalizeTimer) {
+      timeoutFinalizeTimer = setTimeout(() => {
+        finalizeTimeout();
+      }, timeoutFinalizeMs);
+    }
+  };
+
+  if (opts.timeoutSec > 0) {
+    timeoutTimer = setTimeout(() => {
+      onTimeout();
+    }, opts.timeoutSec * 1000);
+  }
+
+  const emitUpdate = () => {
+    if (!opts.onUpdate) {
+      return;
+    }
+    const tailText = session.tail || session.aggregated;
+    const warningText = opts.warnings.length ? `${opts.warnings.join("\n")}\n\n` : "";
+    opts.onUpdate({
+      content: [{ type: "text", text: warningText + (tailText || "") }],
+      details: {
+        status: "running",
+        sessionId,
+        pid: session.pid ?? undefined,
+        startedAt,
+        cwd: session.cwd,
+        tail: session.tail,
+      },
+    });
+  };
+
+  const handleStdout = (data: string) => {
+    const str = sanitizeBinaryOutput(data.toString());
+    for (const chunk of chunkString(str)) {
+      appendOutput(session, "stdout", chunk);
+      emitUpdate();
+    }
+  };
+
+  const handleStderr = (data: string) => {
+    const str = sanitizeBinaryOutput(data.toString());
+    for (const chunk of chunkString(str)) {
+      appendOutput(session, "stderr", chunk);
+      emitUpdate();
+    }
+  };
+
+  if (pty) {
+    const cursorResponse = buildCursorPositionResponse();
+    pty.onData((data) => {
+      const raw = data.toString();
+      const { cleaned, requests } = stripDsrRequests(raw);
+      if (requests > 0) {
+        for (let i = 0; i < requests; i += 1) {
+          pty.write(cursorResponse);
+        }
+      }
+      handleStdout(cleaned);
+    });
+  } else if (child) {
+    child.stdout.on("data", handleStdout);
+    child.stderr.on("data", handleStderr);
+  }
+
+  const promise = new Promise<ExecProcessOutcome>((resolve) => {
+    resolveFn = resolve;
+    const handleExit = (code: number | null, exitSignal: NodeJS.Signals | number | null) => {
+      if (timeoutTimer) {
+        clearTimeout(timeoutTimer);
+      }
+      if (timeoutFinalizeTimer) {
+        clearTimeout(timeoutFinalizeTimer);
+      }
+      const durationMs = Date.now() - startedAt;
+      const wasSignal = exitSignal != null;
+      const isSuccess = code === 0 && !wasSignal && !timedOut;
+      const status: "completed" | "failed" = isSuccess ? "completed" : "failed";
+      markExited(session, code, exitSignal, status);
+      maybeNotifyOnExit(session, status);
+      if (!session.child && session.stdin) {
+        session.stdin.destroyed = true;
+      }
+
+      if (settled) {
+        return;
+      }
+      const aggregated = session.aggregated.trim();
+      if (!isSuccess) {
+        const reason = timedOut
+          ? `Command timed out after ${opts.timeoutSec} seconds`
+          : wasSignal && exitSignal
+            ? `Command aborted by signal ${exitSignal}`
+            : code === null
+              ? "Command aborted before exit code was captured"
+              : `Command exited with code ${code}`;
+        const message = aggregated ? `${aggregated}\n\n${reason}` : reason;
+        settle({
+          status: "failed",
+          exitCode: code ?? null,
+          exitSignal: exitSignal ?? null,
+          durationMs,
+          aggregated,
+          timedOut,
+          reason: message,
+        });
+        return;
+      }
+      settle({
+        status: "completed",
+        exitCode: code ?? 0,
+        exitSignal: exitSignal ?? null,
+        durationMs,
+        aggregated,
+        timedOut: false,
+      });
+    };
+
+    if (pty) {
+      pty.onExit((event) => {
+        const rawSignal = event.signal ?? null;
+        const normalizedSignal = rawSignal === 0 ? null : rawSignal;
+        handleExit(event.exitCode ?? null, normalizedSignal);
+      });
+    } else if (child) {
+      child.once("close", (code, exitSignal) => {
+        handleExit(code, exitSignal);
+      });
+
+      child.once("error", (err) => {
+        if (timeoutTimer) {
+          clearTimeout(timeoutTimer);
+        }
+        if (timeoutFinalizeTimer) {
+          clearTimeout(timeoutFinalizeTimer);
+        }
+        markExited(session, null, null, "failed");
+        maybeNotifyOnExit(session, "failed");
+        const aggregated = session.aggregated.trim();
+        const message = aggregated ? `${aggregated}\n\n${String(err)}` : String(err);
+        settle({
+          status: "failed",
+          exitCode: null,
+          exitSignal: null,
+          durationMs: Date.now() - startedAt,
+          aggregated,
+          timedOut,
+          reason: message,
+        });
+      });
+    }
+  });
+
+  return {
+    session,
+    startedAt,
+    pid: session.pid ?? undefined,
+    promise,
+    kill: () => killSession(session),
+  };
+}
 
 export function createExecTool(
   defaults?: ExecToolDefaults,

--- a/src/agents/date-time.test.ts
+++ b/src/agents/date-time.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeTimestamp,
+  withNormalizedTimestamp,
+  formatUserTime,
+  resolveUserTimezone,
+} from "./date-time.js";
+
+// ---------------------------------------------------------------------------
+// normalizeTimestamp
+// ---------------------------------------------------------------------------
+
+describe("normalizeTimestamp", () => {
+  it("returns undefined for null/undefined", () => {
+    expect(normalizeTimestamp(null)).toBeUndefined();
+    expect(normalizeTimestamp(undefined)).toBeUndefined();
+  });
+
+  it("handles Date objects", () => {
+    const d = new Date("2026-01-15T12:00:00Z");
+    const result = normalizeTimestamp(d);
+    expect(result).toBeDefined();
+    expect(result!.timestampMs).toBe(d.getTime());
+    expect(result!.timestampUtc).toBe(d.toISOString());
+  });
+
+  it("handles epoch seconds (number < 1e12)", () => {
+    const epochSec = 1706000000; // ~2024-01-23
+    const result = normalizeTimestamp(epochSec);
+    expect(result).toBeDefined();
+    expect(result!.timestampMs).toBe(epochSec * 1000);
+  });
+
+  it("handles epoch milliseconds (number >= 1e12)", () => {
+    const epochMs = 1706000000000;
+    const result = normalizeTimestamp(epochMs);
+    expect(result).toBeDefined();
+    expect(result!.timestampMs).toBe(epochMs);
+  });
+
+  it("handles numeric string as epoch seconds", () => {
+    const result = normalizeTimestamp("1706000000");
+    expect(result).toBeDefined();
+    expect(result!.timestampMs).toBe(1706000000 * 1000);
+  });
+
+  it("handles numeric string with 13+ digits as epoch ms", () => {
+    const result = normalizeTimestamp("1706000000000");
+    expect(result).toBeDefined();
+    expect(result!.timestampMs).toBe(1706000000000);
+  });
+
+  it("handles float string as epoch seconds", () => {
+    const result = normalizeTimestamp("1706000000.123");
+    expect(result).toBeDefined();
+    expect(result!.timestampMs).toBe(Math.round(1706000000.123 * 1000));
+  });
+
+  it("handles ISO date string", () => {
+    const result = normalizeTimestamp("2026-01-15T12:00:00Z");
+    expect(result).toBeDefined();
+    expect(result!.timestampUtc).toBe("2026-01-15T12:00:00.000Z");
+  });
+
+  it("returns undefined for empty string", () => {
+    expect(normalizeTimestamp("")).toBeUndefined();
+    expect(normalizeTimestamp("   ")).toBeUndefined();
+  });
+
+  it("returns undefined for non-parseable string", () => {
+    expect(normalizeTimestamp("not a date")).toBeUndefined();
+  });
+
+  it("returns undefined for NaN", () => {
+    expect(normalizeTimestamp(NaN)).toBeUndefined();
+  });
+
+  it("returns undefined for Infinity", () => {
+    expect(normalizeTimestamp(Infinity)).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// withNormalizedTimestamp
+// ---------------------------------------------------------------------------
+
+describe("withNormalizedTimestamp", () => {
+  it("adds timestampMs and timestampUtc to object", () => {
+    const result = withNormalizedTimestamp({ foo: "bar" }, 1706000000000);
+    expect(result.foo).toBe("bar");
+    expect(result.timestampMs).toBe(1706000000000);
+    expect(result.timestampUtc).toBeDefined();
+  });
+
+  it("preserves existing timestampMs if valid", () => {
+    const existing = { timestampMs: 9999 };
+    const result = withNormalizedTimestamp(existing, 1706000000000);
+    expect(result.timestampMs).toBe(9999);
+  });
+
+  it("overwrites invalid existing timestampMs", () => {
+    const existing = { timestampMs: NaN };
+    const result = withNormalizedTimestamp(existing, 1706000000000);
+    expect(result.timestampMs).toBe(1706000000000);
+  });
+
+  it("returns original value if raw is unparseable", () => {
+    const original = { foo: "bar" };
+    const result = withNormalizedTimestamp(original, null);
+    expect(result).toBe(original);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveUserTimezone
+// ---------------------------------------------------------------------------
+
+describe("resolveUserTimezone", () => {
+  it("returns configured timezone when valid", () => {
+    expect(resolveUserTimezone("America/New_York")).toBe("America/New_York");
+  });
+
+  it("falls back to host timezone for invalid input", () => {
+    const tz = resolveUserTimezone("Invalid/Zone");
+    expect(tz).toBeTruthy();
+    expect(tz).not.toBe("Invalid/Zone");
+  });
+
+  it("falls back for empty/undefined", () => {
+    const tz = resolveUserTimezone(undefined);
+    expect(tz).toBeTruthy();
+  });
+
+  it("trims whitespace", () => {
+    expect(resolveUserTimezone("  UTC  ")).toBe("UTC");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatUserTime
+// ---------------------------------------------------------------------------
+
+describe("formatUserTime", () => {
+  const date = new Date("2026-01-15T14:30:00Z");
+
+  it("formats in 12-hour mode", () => {
+    const result = formatUserTime(date, "UTC", "12");
+    expect(result).toBeDefined();
+    expect(result).toContain("January");
+    expect(result).toContain("15th");
+    expect(result).toContain("2026");
+    expect(result).toMatch(/PM|AM/i);
+  });
+
+  it("formats in 24-hour mode", () => {
+    const result = formatUserTime(date, "UTC", "24");
+    expect(result).toBeDefined();
+    expect(result).toContain("14:30");
+  });
+
+  it("handles different timezones", () => {
+    const result = formatUserTime(date, "Asia/Tokyo", "24");
+    expect(result).toBeDefined();
+    expect(result).toContain("23:30");
+  });
+
+  it("returns undefined for invalid timezone", () => {
+    const result = formatUserTime(date, "Invalid/Zone", "24");
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -1,0 +1,610 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import type { AuthProfileStore } from "./auth-profiles.js";
+import { saveAuthProfileStore } from "./auth-profiles.js";
+import { AUTH_STORE_VERSION } from "./auth-profiles/constants.js";
+import { runWithModelFallback } from "./model-fallback.js";
+
+function makeCfg(overrides: Partial<OpenClawConfig> = {}): OpenClawConfig {
+  return {
+    agents: {
+      defaults: {
+        model: {
+          primary: "openai/gpt-4.1-mini",
+          fallbacks: ["anthropic/claude-haiku-3-5"],
+        },
+      },
+    },
+    ...overrides,
+  } as OpenClawConfig;
+}
+
+describe("runWithModelFallback", () => {
+  it("does not fall back on non-auth errors", async () => {
+    const cfg = makeCfg();
+    const run = vi.fn().mockRejectedValueOnce(new Error("bad request")).mockResolvedValueOnce("ok");
+
+    await expect(
+      runWithModelFallback({
+        cfg,
+        provider: "openai",
+        model: "gpt-4.1-mini",
+        run,
+      }),
+    ).rejects.toThrow("bad request");
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back on auth errors", async () => {
+    const cfg = makeCfg();
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error("nope"), { status: 401 }))
+      .mockResolvedValueOnce("ok");
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      run,
+    });
+
+    expect(result.result).toBe("ok");
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(run.mock.calls[1]?.[0]).toBe("anthropic");
+    expect(run.mock.calls[1]?.[1]).toBe("claude-haiku-3-5");
+  });
+
+  it("falls back on 402 payment required", async () => {
+    const cfg = makeCfg();
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error("payment required"), { status: 402 }))
+      .mockResolvedValueOnce("ok");
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      run,
+    });
+
+    expect(result.result).toBe("ok");
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(run.mock.calls[1]?.[0]).toBe("anthropic");
+    expect(run.mock.calls[1]?.[1]).toBe("claude-haiku-3-5");
+  });
+
+  it("falls back on billing errors", async () => {
+    const cfg = makeCfg();
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new Error(
+          "LLM request rejected: Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits.",
+        ),
+      )
+      .mockResolvedValueOnce("ok");
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      run,
+    });
+
+    expect(result.result).toBe("ok");
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(run.mock.calls[1]?.[0]).toBe("anthropic");
+    expect(run.mock.calls[1]?.[1]).toBe("claude-haiku-3-5");
+  });
+
+  it("falls back on credential validation errors", async () => {
+    const cfg = makeCfg();
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('No credentials found for profile "anthropic:default".'))
+      .mockResolvedValueOnce("ok");
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "anthropic",
+      model: "claude-opus-4",
+      run,
+    });
+
+    expect(result.result).toBe("ok");
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(run.mock.calls[1]?.[0]).toBe("anthropic");
+    expect(run.mock.calls[1]?.[1]).toBe("claude-haiku-3-5");
+  });
+
+  it("skips providers when all profiles are in cooldown", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-auth-"));
+    const provider = `cooldown-test-${crypto.randomUUID()}`;
+    const profileId = `${provider}:default`;
+
+    const store: AuthProfileStore = {
+      version: AUTH_STORE_VERSION,
+      profiles: {
+        [profileId]: {
+          type: "api_key",
+          provider,
+          key: "test-key",
+        },
+      },
+      usageStats: {
+        [profileId]: {
+          cooldownUntil: Date.now() + 60_000,
+        },
+      },
+    };
+
+    saveAuthProfileStore(store, tempDir);
+
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: `${provider}/m1`,
+            fallbacks: ["fallback/ok-model"],
+          },
+        },
+      },
+    });
+    const run = vi.fn().mockImplementation(async (providerId, modelId) => {
+      if (providerId === "fallback") {
+        return "ok";
+      }
+      throw new Error(`unexpected provider: ${providerId}/${modelId}`);
+    });
+
+    try {
+      const result = await runWithModelFallback({
+        cfg,
+        provider,
+        model: "m1",
+        agentDir: tempDir,
+        run,
+      });
+
+      expect(result.result).toBe("ok");
+      expect(run.mock.calls).toEqual([["fallback", "ok-model"]]);
+      expect(result.attempts[0]?.reason).toBe("rate_limit");
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not skip when any profile is available", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-auth-"));
+    const provider = `cooldown-mixed-${crypto.randomUUID()}`;
+    const profileA = `${provider}:a`;
+    const profileB = `${provider}:b`;
+
+    const store: AuthProfileStore = {
+      version: AUTH_STORE_VERSION,
+      profiles: {
+        [profileA]: {
+          type: "api_key",
+          provider,
+          key: "key-a",
+        },
+        [profileB]: {
+          type: "api_key",
+          provider,
+          key: "key-b",
+        },
+      },
+      usageStats: {
+        [profileA]: {
+          cooldownUntil: Date.now() + 60_000,
+        },
+      },
+    };
+
+    saveAuthProfileStore(store, tempDir);
+
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: `${provider}/m1`,
+            fallbacks: ["fallback/ok-model"],
+          },
+        },
+      },
+    });
+    const run = vi.fn().mockImplementation(async (providerId) => {
+      if (providerId === provider) {
+        return "ok";
+      }
+      return "unexpected";
+    });
+
+    try {
+      const result = await runWithModelFallback({
+        cfg,
+        provider,
+        model: "m1",
+        agentDir: tempDir,
+        run,
+      });
+
+      expect(result.result).toBe("ok");
+      expect(run.mock.calls).toEqual([[provider, "m1"]]);
+      expect(result.attempts).toEqual([]);
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not append configured primary when fallbacksOverride is set", async () => {
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-4.1-mini",
+          },
+        },
+      },
+    });
+    const run = vi
+      .fn()
+      .mockImplementation(() => Promise.reject(Object.assign(new Error("nope"), { status: 401 })));
+
+    await expect(
+      runWithModelFallback({
+        cfg,
+        provider: "anthropic",
+        model: "claude-opus-4-5",
+        fallbacksOverride: ["anthropic/claude-haiku-3-5"],
+        run,
+      }),
+    ).rejects.toThrow("All models failed");
+
+    expect(run.mock.calls).toEqual([
+      ["anthropic", "claude-opus-4-5"],
+      ["anthropic", "claude-haiku-3-5"],
+    ]);
+  });
+
+  it("uses fallbacksOverride instead of agents.defaults.model.fallbacks", async () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          model: {
+            fallbacks: ["openai/gpt-5.2"],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const calls: Array<{ provider: string; model: string }> = [];
+
+    const res = await runWithModelFallback({
+      cfg,
+      provider: "anthropic",
+      model: "claude-opus-4-5",
+      fallbacksOverride: ["openai/gpt-4.1"],
+      run: async (provider, model) => {
+        calls.push({ provider, model });
+        if (provider === "anthropic") {
+          throw Object.assign(new Error("nope"), { status: 401 });
+        }
+        if (provider === "openai" && model === "gpt-4.1") {
+          return "ok";
+        }
+        throw new Error(`unexpected candidate: ${provider}/${model}`);
+      },
+    });
+
+    expect(res.result).toBe("ok");
+    expect(calls).toEqual([
+      { provider: "anthropic", model: "claude-opus-4-5" },
+      { provider: "openai", model: "gpt-4.1" },
+    ]);
+  });
+
+  it("treats an empty fallbacksOverride as disabling global fallbacks", async () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          model: {
+            fallbacks: ["openai/gpt-5.2"],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const calls: Array<{ provider: string; model: string }> = [];
+
+    await expect(
+      runWithModelFallback({
+        cfg,
+        provider: "anthropic",
+        model: "claude-opus-4-5",
+        fallbacksOverride: [],
+        run: async (provider, model) => {
+          calls.push({ provider, model });
+          throw new Error("primary failed");
+        },
+      }),
+    ).rejects.toThrow("primary failed");
+
+    expect(calls).toEqual([{ provider: "anthropic", model: "claude-opus-4-5" }]);
+  });
+
+  it("defaults provider/model when missing (regression #946)", async () => {
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-4.1-mini",
+            fallbacks: [],
+          },
+        },
+      },
+    });
+
+    const calls: Array<{ provider: string; model: string }> = [];
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: undefined as unknown as string,
+      model: undefined as unknown as string,
+      run: async (provider, model) => {
+        calls.push({ provider, model });
+        return "ok";
+      },
+    });
+
+    expect(result.result).toBe("ok");
+    expect(calls).toEqual([{ provider: "openai", model: "gpt-4.1-mini" }]);
+  });
+
+  it("falls back on missing API key errors", async () => {
+    const cfg = makeCfg();
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("No API key found for profile openai."))
+      .mockResolvedValueOnce("ok");
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      run,
+    });
+
+    expect(result.result).toBe("ok");
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(run.mock.calls[1]?.[0]).toBe("anthropic");
+    expect(run.mock.calls[1]?.[1]).toBe("claude-haiku-3-5");
+  });
+
+  it("falls back on lowercase credential errors", async () => {
+    const cfg = makeCfg();
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("no api key found for profile openai"))
+      .mockResolvedValueOnce("ok");
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      run,
+    });
+
+    expect(result.result).toBe("ok");
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(run.mock.calls[1]?.[0]).toBe("anthropic");
+    expect(run.mock.calls[1]?.[1]).toBe("claude-haiku-3-5");
+  });
+
+  it("falls back on timeout abort errors", async () => {
+    const cfg = makeCfg();
+    const timeoutCause = Object.assign(new Error("request timed out"), { name: "TimeoutError" });
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(
+        Object.assign(new Error("aborted"), { name: "AbortError", cause: timeoutCause }),
+      )
+      .mockResolvedValueOnce("ok");
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      run,
+    });
+
+    expect(result.result).toBe("ok");
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(run.mock.calls[1]?.[0]).toBe("anthropic");
+    expect(run.mock.calls[1]?.[1]).toBe("claude-haiku-3-5");
+  });
+
+  it("falls back on abort errors with timeout reasons", async () => {
+    const cfg = makeCfg();
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(
+        Object.assign(new Error("aborted"), { name: "AbortError", reason: "deadline exceeded" }),
+      )
+      .mockResolvedValueOnce("ok");
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      run,
+    });
+
+    expect(result.result).toBe("ok");
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(run.mock.calls[1]?.[0]).toBe("anthropic");
+    expect(run.mock.calls[1]?.[1]).toBe("claude-haiku-3-5");
+  });
+
+  it("falls back when message says aborted but error is a timeout", async () => {
+    const cfg = makeCfg();
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error("request aborted"), { code: "ETIMEDOUT" }))
+      .mockResolvedValueOnce("ok");
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      run,
+    });
+
+    expect(result.result).toBe("ok");
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(run.mock.calls[1]?.[0]).toBe("anthropic");
+    expect(run.mock.calls[1]?.[1]).toBe("claude-haiku-3-5");
+  });
+
+  it("falls back on provider abort errors with request-aborted messages", async () => {
+    const cfg = makeCfg();
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(
+        Object.assign(new Error("Request was aborted"), { name: "AbortError" }),
+      )
+      .mockResolvedValueOnce("ok");
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      run,
+    });
+
+    expect(result.result).toBe("ok");
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(run.mock.calls[1]?.[0]).toBe("anthropic");
+    expect(run.mock.calls[1]?.[1]).toBe("claude-haiku-3-5");
+  });
+
+  it("does not fall back on user aborts", async () => {
+    const cfg = makeCfg();
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error("aborted"), { name: "AbortError" }))
+      .mockResolvedValueOnce("ok");
+
+    await expect(
+      runWithModelFallback({
+        cfg,
+        provider: "openai",
+        model: "gpt-4.1-mini",
+        run,
+      }),
+    ).rejects.toThrow("aborted");
+
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("rotates models when round_robin strategy is enabled", async () => {
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-4.1-mini",
+            fallbacks: ["anthropic/claude-haiku-3-5", "zai/glm-4.7"],
+            strategy: "round_robin",
+          },
+        },
+      },
+    });
+    const run = vi.fn().mockResolvedValue("ok");
+
+    await runWithModelFallback({
+      cfg,
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      run,
+    });
+    await runWithModelFallback({
+      cfg,
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      run,
+    });
+
+    expect(run.mock.calls[0]?.[0]).toBe("openai");
+    expect(run.mock.calls[0]?.[1]).toBe("gpt-4.1-mini");
+    expect(run.mock.calls[1]?.[0]).toBe("anthropic");
+    expect(run.mock.calls[1]?.[1]).toBe("claude-haiku-3-5");
+  });
+
+  it("keeps a stable model per session when sticky_session is enabled", async () => {
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-4.1-mini",
+            fallbacks: ["anthropic/claude-haiku-3-5", "zai/glm-4.7"],
+            strategy: "sticky_session",
+          },
+        },
+      },
+    });
+    const run = vi.fn().mockResolvedValue("ok");
+
+    const first = await runWithModelFallback({
+      cfg,
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      sessionKey: "agent:main:main",
+      run,
+    });
+    const second = await runWithModelFallback({
+      cfg,
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      sessionKey: "agent:main:main",
+      run,
+    });
+
+    expect(first.provider).toBe(second.provider);
+    expect(first.model).toBe(second.model);
+  });
+
+  it("appends the configured primary as a last fallback", async () => {
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-4.1-mini",
+            fallbacks: [],
+          },
+        },
+      },
+    });
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error("timeout"), { code: "ETIMEDOUT" }))
+      .mockResolvedValueOnce("ok");
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "openrouter",
+      model: "meta-llama/llama-3.3-70b:free",
+      run,
+    });
+
+    expect(result.result).toBe("ok");
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(result.provider).toBe("openai");
+    expect(result.model).toBe("gpt-4.1-mini");
+  });
+});

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -1,6 +1,16 @@
 import type { OpenClawConfig } from "../config/config.js";
 import type { FailoverReason } from "./pi-embedded-helpers.js";
 import {
+  createInternalHookEvent,
+  triggerModelCompleteHook,
+  triggerModelFailoverHook,
+  triggerModelSelectHook,
+  type ModelCompleteHookEvent,
+  type ModelFailoverHookEvent,
+  type ModelSelectHookEvent,
+} from "../hooks/internal-hooks.js";
+import { resolveAgentIdFromSessionKey, resolveAgentModelStrategy } from "./agent-scope.js";
+import {
   ensureAuthProfileStore,
   isProfileInCooldown,
   resolveAuthProfileOrder,
@@ -16,6 +26,7 @@ import {
   buildConfiguredAllowlistKeys,
   buildModelAliasIndex,
   modelKey,
+  parseModelRef,
   resolveConfiguredModelRef,
   resolveModelRefFromString,
 } from "./model-selection.js";
@@ -34,6 +45,10 @@ type FallbackAttempt = {
   code?: string;
 };
 
+type ModelSelectionStrategy = "primary" | "round_robin" | "sticky_session";
+
+const roundRobinState = new Map<string, number>();
+
 /**
  * Fallback abort check. Only treats explicit AbortError names as user aborts.
  * Message-based checks (e.g., "aborted") can mask timeouts and skip fallback.
@@ -51,6 +66,55 @@ function isFallbackAbortError(err: unknown): boolean {
 
 function shouldRethrowAbort(err: unknown): boolean {
   return isFallbackAbortError(err) && !isTimeoutError(err);
+}
+
+function hashString(input: string): number {
+  let hash = 0;
+  for (let i = 0; i < input.length; i += 1) {
+    hash = (hash * 31 + input.charCodeAt(i)) >>> 0;
+  }
+  return hash;
+}
+
+function rotateCandidates(candidates: ModelCandidate[], startIndex: number): ModelCandidate[] {
+  if (candidates.length <= 1) {
+    return candidates;
+  }
+  const start = ((startIndex % candidates.length) + candidates.length) % candidates.length;
+  if (start === 0) {
+    return candidates;
+  }
+  return candidates.slice(start).concat(candidates.slice(0, start));
+}
+
+function buildPoolKey(candidates: ModelCandidate[]): string {
+  return candidates.map((candidate) => `${candidate.provider}/${candidate.model}`).join("|");
+}
+
+function applySelectionStrategy(params: {
+  candidates: ModelCandidate[];
+  strategy: ModelSelectionStrategy;
+  sessionKey?: string;
+}): ModelCandidate[] {
+  const { candidates, strategy } = params;
+  if (candidates.length <= 1) {
+    return candidates;
+  }
+  if (strategy === "round_robin") {
+    const key = buildPoolKey(candidates);
+    const current = roundRobinState.get(key) ?? 0;
+    const next = (current + 1) % candidates.length;
+    roundRobinState.set(key, next);
+    return rotateCandidates(candidates, current);
+  }
+  if (strategy === "sticky_session") {
+    if (!params.sessionKey) {
+      return candidates;
+    }
+    const idx = hashString(params.sessionKey) % candidates.length;
+    return rotateCandidates(candidates, idx);
+  }
+  return candidates;
 }
 
 function resolveImageFallbackCandidates(params: {
@@ -211,8 +275,15 @@ export async function runWithModelFallback<T>(params: {
   provider: string;
   model: string;
   agentDir?: string;
+  sessionKey?: string;
+  /** Optional model selection strategy override. */
+  selectionStrategy?: ModelSelectionStrategy;
   /** Optional explicit fallbacks list; when provided (even empty), replaces agents.defaults.model.fallbacks. */
   fallbacksOverride?: string[];
+  /** Task hint for smart routing (e.g., "code", "chat", "math") */
+  taskHint?: string;
+  /** Estimated context length in tokens for routing decisions */
+  contextLength?: number;
   run: (provider: string, model: string) => Promise<T>;
   onError?: (attempt: {
     provider: string;
@@ -233,72 +304,237 @@ export async function runWithModelFallback<T>(params: {
     model: params.model,
     fallbacksOverride: params.fallbacksOverride,
   });
+  const strategy =
+    params.selectionStrategy ??
+    (params.cfg
+      ? resolveAgentModelStrategy(
+          params.cfg,
+          params.sessionKey ? resolveAgentIdFromSessionKey(params.sessionKey) : undefined,
+        )
+      : undefined) ??
+    "primary";
+  let orderedCandidates = applySelectionStrategy({
+    candidates,
+    strategy,
+    sessionKey: params.sessionKey,
+  });
+
+  // Trigger model:select hook for smart routing
+  try {
+    const agentId = params.sessionKey ? resolveAgentIdFromSessionKey(params.sessionKey) : undefined;
+
+    const selectEvent = createInternalHookEvent("model", "select", params.sessionKey ?? "unknown", {
+      requestedProvider: params.provider,
+      requestedModel: params.model,
+      candidates: orderedCandidates.map((c) => ({ provider: c.provider, model: c.model })),
+      strategy,
+      sessionKey: params.sessionKey,
+      agentId,
+      workspaceDir: params.agentDir,
+      taskHint: params.taskHint,
+      contextLength: params.contextLength,
+    }) as ModelSelectHookEvent;
+
+    const selectResult = await triggerModelSelectHook(selectEvent);
+
+    if (selectResult) {
+      // Handle override candidates (replaces entire list)
+      if (selectResult.overrideCandidates?.length) {
+        orderedCandidates = selectResult.overrideCandidates;
+      }
+      // Handle prepend candidates (adds to front)
+      else if (selectResult.prependCandidates?.length) {
+        const seen = new Set(selectResult.prependCandidates.map((c) => `${c.provider}/${c.model}`));
+        const filtered = orderedCandidates.filter((c) => !seen.has(`${c.provider}/${c.model}`));
+        orderedCandidates = [...selectResult.prependCandidates, ...filtered];
+      }
+      // Handle single model override
+      else if (selectResult.overrideModel) {
+        const parsed = parseModelRef(selectResult.overrideModel, params.provider);
+        if (parsed) {
+          const key = `${parsed.provider}/${parsed.model}`;
+          const filtered = orderedCandidates.filter((c) => `${c.provider}/${c.model}` !== key);
+          orderedCandidates = [{ provider: parsed.provider, model: parsed.model }, ...filtered];
+        }
+      }
+    }
+  } catch (err) {
+    console.warn(`[model-fallback] model:select hook error: ${String(err)}`);
+  }
+
   const authStore = params.cfg
     ? ensureAuthProfileStore(params.agentDir, { allowKeychainPrompt: false })
     : null;
   const attempts: FallbackAttempt[] = [];
   let lastError: unknown;
 
-  for (let i = 0; i < candidates.length; i += 1) {
-    const candidate = candidates[i];
-    if (authStore) {
-      const profileIds = resolveAuthProfileOrder({
-        cfg: params.cfg,
-        store: authStore,
-        provider: candidate.provider,
-      });
-      const isAnyProfileAvailable = profileIds.some((id) => !isProfileInCooldown(authStore, id));
+  const transientReasons = new Set<FailoverReason>(["rate_limit", "timeout"]);
+  const hardReasons = new Set<FailoverReason>(["auth", "billing", "format"]);
+  const maxPasses = 2;
+  const retryDelayMs = 750;
 
-      if (profileIds.length > 0 && !isAnyProfileAvailable) {
-        // All profiles for this provider are in cooldown; skip without attempting
+  for (let pass = 0; pass < maxPasses; pass += 1) {
+    const passStartIndex = attempts.length;
+    for (let i = 0; i < orderedCandidates.length; i += 1) {
+      const candidate = orderedCandidates[i];
+      if (authStore) {
+        const profileIds = resolveAuthProfileOrder({
+          cfg: params.cfg,
+          store: authStore,
+          provider: candidate.provider,
+        });
+        const isAnyProfileAvailable = profileIds.some((id) => !isProfileInCooldown(authStore, id));
+
+        if (profileIds.length > 0 && !isAnyProfileAvailable) {
+          // All profiles for this provider are in cooldown; skip without attempting
+          attempts.push({
+            provider: candidate.provider,
+            model: candidate.model,
+            error: `Provider ${candidate.provider} is in cooldown (all profiles unavailable)`,
+            reason: "rate_limit",
+          });
+          continue;
+        }
+      }
+      try {
+        const startTime = Date.now();
+        const result = await params.run(candidate.provider, candidate.model);
+
+        // Trigger model:complete hook on success
+        try {
+          const completeEvent = createInternalHookEvent(
+            "model",
+            "complete",
+            params.sessionKey ?? "unknown",
+            {
+              provider: candidate.provider,
+              model: candidate.model,
+              durationMs: Date.now() - startTime,
+              success: true,
+              sessionKey: params.sessionKey,
+              agentId: params.sessionKey
+                ? resolveAgentIdFromSessionKey(params.sessionKey)
+                : undefined,
+              workspaceDir: params.agentDir,
+            },
+          ) as ModelCompleteHookEvent;
+          // Fire and forget
+          triggerModelCompleteHook(completeEvent).catch(() => {});
+        } catch {
+          // Ignore hook errors
+        }
+
+        return {
+          result,
+          provider: candidate.provider,
+          model: candidate.model,
+          attempts,
+        };
+      } catch (err) {
+        if (shouldRethrowAbort(err)) {
+          throw err;
+        }
+        const normalized =
+          coerceToFailoverError(err, {
+            provider: candidate.provider,
+            model: candidate.model,
+          }) ?? err;
+        if (!isFailoverError(normalized)) {
+          throw err;
+        }
+
+        lastError = normalized;
+        const described = describeFailoverError(normalized);
         attempts.push({
           provider: candidate.provider,
           model: candidate.model,
-          error: `Provider ${candidate.provider} is in cooldown (all profiles unavailable)`,
-          reason: "rate_limit",
+          error: described.message,
+          reason: described.reason,
+          status: described.status,
+          code: described.code,
         });
+        await params.onError?.({
+          provider: candidate.provider,
+          model: candidate.model,
+          error: normalized,
+          attempt: pass * orderedCandidates.length + i + 1,
+          total: orderedCandidates.length * maxPasses,
+        });
+
+        // Call model:failover internal hook if there's a next candidate
+        const nextCandidate = orderedCandidates[i + 1];
+        if (nextCandidate) {
+          try {
+            const agentId = params.sessionKey
+              ? resolveAgentIdFromSessionKey(params.sessionKey)
+              : undefined;
+
+            const hookEvent = createInternalHookEvent(
+              "model",
+              "failover",
+              params.sessionKey ?? "unknown",
+              {
+                fromProvider: candidate.provider,
+                fromModel: candidate.model,
+                toProvider: nextCandidate.provider,
+                toModel: nextCandidate.model,
+                reason: described.reason ?? "unknown",
+                errorMessage: described.message,
+                statusCode: described.status,
+                attemptNumber: pass * orderedCandidates.length + i + 1,
+                totalCandidates: orderedCandidates.length,
+                agentId,
+                workspaceDir: params.agentDir,
+              },
+            ) as ModelFailoverHookEvent;
+
+            const hookResult = await triggerModelFailoverHook(hookEvent);
+
+            // Check for veto
+            if (hookResult?.allow === false) {
+              throw new Error(
+                `Model failover vetoed: ${hookResult.vetoReason ?? "no reason provided"}`,
+                { cause: err },
+              );
+            }
+
+            // Check for override target
+            if (hookResult?.overrideTarget) {
+              const parsed = parseModelRef(hookResult.overrideTarget, candidate.provider);
+              if (parsed) {
+                // Insert override as next candidate
+                orderedCandidates.splice(i + 1, 0, {
+                  provider: parsed.provider,
+                  model: parsed.model,
+                });
+              }
+            }
+          } catch (hookErr) {
+            // Re-throw veto errors
+            if (hookErr instanceof Error && hookErr.message.startsWith("Model failover vetoed")) {
+              throw hookErr;
+            }
+            // Log but don't fail for other hook errors
+            console.warn(`[model-fallback] model:failover hook error: ${String(hookErr)}`);
+          }
+        }
+      }
+    }
+
+    if (pass < maxPasses - 1) {
+      const passAttempts = attempts.slice(passStartIndex);
+      const hasTransient = passAttempts.some(
+        (attempt) => attempt.reason && transientReasons.has(attempt.reason),
+      );
+      const hasHard = passAttempts.some(
+        (attempt) => attempt.reason && hardReasons.has(attempt.reason),
+      );
+      if (hasTransient && !hasHard) {
+        await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
         continue;
       }
     }
-    try {
-      const result = await params.run(candidate.provider, candidate.model);
-      return {
-        result,
-        provider: candidate.provider,
-        model: candidate.model,
-        attempts,
-      };
-    } catch (err) {
-      if (shouldRethrowAbort(err)) {
-        throw err;
-      }
-      const normalized =
-        coerceToFailoverError(err, {
-          provider: candidate.provider,
-          model: candidate.model,
-        }) ?? err;
-      if (!isFailoverError(normalized)) {
-        throw err;
-      }
-
-      lastError = normalized;
-      const described = describeFailoverError(normalized);
-      attempts.push({
-        provider: candidate.provider,
-        model: candidate.model,
-        error: described.message,
-        reason: described.reason,
-        status: described.status,
-        code: described.code,
-      });
-      await params.onError?.({
-        provider: candidate.provider,
-        model: candidate.model,
-        error: normalized,
-        attempt: i + 1,
-        total: candidates.length,
-      });
-    }
+    break;
   }
 
   if (attempts.length <= 1 && lastError) {
@@ -315,9 +551,12 @@ export async function runWithModelFallback<T>(params: {
           )
           .join(" | ")
       : "unknown";
-  throw new Error(`All models failed (${attempts.length || candidates.length}): ${summary}`, {
-    cause: lastError instanceof Error ? lastError : undefined,
-  });
+  throw new Error(
+    `All models failed (${attempts.length || orderedCandidates.length}): ${summary}`,
+    {
+      cause: lastError instanceof Error ? lastError : undefined,
+    },
+  );
 }
 
 export async function runWithImageModelFallback<T>(params: {

--- a/src/agents/path-map.ts
+++ b/src/agents/path-map.ts
@@ -1,0 +1,65 @@
+import path from "node:path";
+import type { OpenClawConfig } from "../config/config.js";
+
+export type PathMapRoots = Record<string, string>;
+
+export function normalizePathMapRoots(roots?: PathMapRoots): PathMapRoots {
+  if (!roots) {
+    return {};
+  }
+  const normalized: PathMapRoots = {};
+  for (const [rawKey, rawValue] of Object.entries(roots)) {
+    const key = String(rawKey).trim();
+    const value = String(rawValue).trim();
+    if (!key || !value) {
+      continue;
+    }
+    const normKey = key.startsWith("@") ? key : `@${key}`;
+    const normValue = value.replace(/[\\/]+$/, "");
+    normalized[normKey] = normValue;
+  }
+  return normalized;
+}
+
+export function resolvePathMapRoots(cfg?: OpenClawConfig): PathMapRoots {
+  return normalizePathMapRoots(cfg?.pathMap?.roots);
+}
+
+function sortRootsByLengthDesc(roots: PathMapRoots): Array<[string, string]> {
+  return Object.entries(roots).toSorted((a, b) => b[1].length - a[1].length);
+}
+
+export function toLogicalPath(inputPath: string, roots: PathMapRoots): string {
+  const raw = String(inputPath ?? "");
+  if (!raw) {
+    return raw;
+  }
+  const entries = sortRootsByLengthDesc(roots);
+  for (const [logicalRoot, physicalRoot] of entries) {
+    if (raw === physicalRoot) {
+      return logicalRoot;
+    }
+    if (raw.startsWith(physicalRoot + path.sep) || raw.startsWith(physicalRoot + "/")) {
+      const rel = raw.slice(physicalRoot.length);
+      return `${logicalRoot}${rel}`;
+    }
+  }
+  return raw;
+}
+
+export function toPhysicalPath(inputPath: string, roots: PathMapRoots): string {
+  const raw = String(inputPath ?? "");
+  if (!raw) {
+    return raw;
+  }
+  for (const [logicalRoot, physicalRoot] of Object.entries(roots)) {
+    if (raw === logicalRoot) {
+      return physicalRoot;
+    }
+    if (raw.startsWith(logicalRoot + "/")) {
+      const rel = raw.slice(logicalRoot.length);
+      return `${physicalRoot}${rel}`;
+    }
+  }
+  return raw;
+}

--- a/src/agents/pi-embedded-helpers.formatrawassistanterrorforui.test.ts
+++ b/src/agents/pi-embedded-helpers.formatrawassistanterrorforui.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { formatRawAssistantErrorForUi } from "./pi-embedded-helpers.js";
+
+describe("formatRawAssistantErrorForUi", () => {
+  it("renders HTTP code + type + message from Anthropic payloads", () => {
+    const text = formatRawAssistantErrorForUi(
+      '429 {"type":"error","error":{"type":"rate_limit_error","message":"Rate limited."},"request_id":"req_123"}',
+    );
+
+    expect(text).toContain("temporarily overloaded");
+  });
+
+  it("renders a generic unknown error message when raw is empty", () => {
+    expect(formatRawAssistantErrorForUi("")).toContain("unknown error");
+  });
+
+  it("formats plain HTTP status lines", () => {
+    expect(formatRawAssistantErrorForUi("500 Internal Server Error")).toContain(
+      "returned an error",
+    );
+  });
+});

--- a/src/agents/pi-embedded-helpers/bootstrap.ts
+++ b/src/agents/pi-embedded-helpers/bootstrap.ts
@@ -81,7 +81,7 @@ export function stripThoughtSignatures<T>(
   }) as T;
 }
 
-export const DEFAULT_BOOTSTRAP_MAX_CHARS = 20_000;
+export const DEFAULT_BOOTSTRAP_MAX_CHARS = 8_000;
 const BOOTSTRAP_HEAD_RATIO = 0.7;
 const BOOTSTRAP_TAIL_RATIO = 0.2;
 

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -383,23 +383,31 @@ export function formatRawAssistantErrorForUi(raw?: string): string {
     return `The AI service is temporarily unavailable (HTTP ${leadingStatus.code}). Please try again in a moment.`;
   }
 
+  if (isRateLimitErrorMessage(trimmed)) {
+    return "The AI service is temporarily overloaded. Please try again in a moment.";
+  }
+
+  if (isAuthErrorMessage(trimmed)) {
+    return "The AI service requires authentication. Please try again later.";
+  }
+
+  if (isBillingErrorMessage(trimmed)) {
+    return "The AI service is unavailable due to billing limits. Please try again later.";
+  }
   const httpMatch = trimmed.match(HTTP_STATUS_PREFIX_RE);
   if (httpMatch) {
     const rest = httpMatch[2].trim();
     if (!rest.startsWith("{")) {
-      return `HTTP ${httpMatch[1]}: ${rest}`;
+      return "The AI service returned an error. Please try again.";
     }
   }
 
   const info = parseApiErrorInfo(trimmed);
   if (info?.message) {
-    const prefix = info.httpCode ? `HTTP ${info.httpCode}` : "LLM error";
-    const type = info.type ? ` ${info.type}` : "";
-    const requestId = info.requestId ? ` (request_id: ${info.requestId})` : "";
-    return `${prefix}${type}: ${info.message}${requestId}`;
+    return "The AI service returned an error. Please try again.";
   }
 
-  return trimmed.length > 600 ? `${trimmed.slice(0, 600)}…` : trimmed;
+  return "The AI service returned an error. Please try again.";
 }
 
 export function formatAssistantErrorText(

--- a/src/agents/pi-embedded-runner.get-dm-history-limit-from-session-key.returns-undefined-sessionkey-is-undefined.test.ts
+++ b/src/agents/pi-embedded-runner.get-dm-history-limit-from-session-key.returns-undefined-sessionkey-is-undefined.test.ts
@@ -1,0 +1,233 @@
+import fs from "node:fs/promises";
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { ensureOpenClawModelsJson } from "./models-config.js";
+import { getDmHistoryLimitFromSessionKey } from "./pi-embedded-runner.js";
+
+vi.mock("@mariozechner/pi-ai", async () => {
+  const actual = await vi.importActual<typeof import("@mariozechner/pi-ai")>("@mariozechner/pi-ai");
+  return {
+    ...actual,
+    streamSimple: (model: { api: string; provider: string; id: string }) => {
+      if (model.id === "mock-error") {
+        throw new Error("boom");
+      }
+      const stream = new actual.AssistantMessageEventStream();
+      queueMicrotask(() => {
+        stream.push({
+          type: "done",
+          reason: "stop",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "ok" }],
+            stopReason: "stop",
+            api: model.api,
+            provider: model.provider,
+            model: model.id,
+            usage: {
+              input: 1,
+              output: 1,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 2,
+              cost: {
+                input: 0,
+                output: 0,
+                cacheRead: 0,
+                cacheWrite: 0,
+                total: 0,
+              },
+            },
+            timestamp: Date.now(),
+          },
+        });
+      });
+      return stream;
+    },
+  };
+});
+
+const _makeOpenAiConfig = (modelIds: string[]) =>
+  ({
+    models: {
+      providers: {
+        openai: {
+          api: "openai-responses",
+          apiKey: "sk-test",
+          baseUrl: "https://example.com",
+          models: modelIds.map((id) => ({
+            id,
+            name: `Mock ${id}`,
+            reasoning: false,
+            input: ["text"],
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: 16_000,
+            maxTokens: 2048,
+          })),
+        },
+      },
+    },
+  }) satisfies OpenClawConfig;
+
+const _ensureModels = (cfg: OpenClawConfig, agentDir: string) =>
+  ensureOpenClawModelsJson(cfg, agentDir) as unknown;
+
+const _textFromContent = (content: unknown) => {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (Array.isArray(content) && content[0]?.type === "text") {
+    return (content[0] as { text?: string }).text;
+  }
+  return undefined;
+};
+
+const _readSessionMessages = async (sessionFile: string) => {
+  const raw = await fs.readFile(sessionFile, "utf-8");
+  return raw
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map(
+      (line) =>
+        JSON.parse(line) as {
+          type?: string;
+          message?: { role?: string; content?: unknown };
+        },
+    )
+    .filter((entry) => entry.type === "message")
+    .map((entry) => entry.message as { role?: string; content?: unknown });
+};
+
+describe("getDmHistoryLimitFromSessionKey", () => {
+  it("returns undefined when sessionKey is undefined", () => {
+    expect(getDmHistoryLimitFromSessionKey(undefined, {})).toBeUndefined();
+  });
+  it("returns undefined when config is undefined", () => {
+    expect(getDmHistoryLimitFromSessionKey("telegram:dm:123", undefined)).toBeUndefined();
+  });
+  it("returns dmHistoryLimit for telegram provider", () => {
+    const config = {
+      channels: { telegram: { dmHistoryLimit: 15 } },
+    } as OpenClawConfig;
+    expect(getDmHistoryLimitFromSessionKey("telegram:dm:123", config)).toBe(15);
+  });
+  it("returns dmHistoryLimit for whatsapp provider", () => {
+    const config = {
+      channels: { whatsapp: { dmHistoryLimit: 20 } },
+    } as OpenClawConfig;
+    expect(getDmHistoryLimitFromSessionKey("whatsapp:dm:123", config)).toBe(20);
+  });
+  it("returns dmHistoryLimit for agent-prefixed session keys", () => {
+    const config = {
+      channels: { telegram: { dmHistoryLimit: 10 } },
+    } as OpenClawConfig;
+    expect(getDmHistoryLimitFromSessionKey("agent:main:telegram:dm:123", config)).toBe(10);
+  });
+  it("strips thread suffix from dm session keys", () => {
+    const config = {
+      channels: { telegram: { dmHistoryLimit: 10, dms: { "123": { historyLimit: 7 } } } },
+    } as OpenClawConfig;
+    expect(getDmHistoryLimitFromSessionKey("agent:main:telegram:dm:123:thread:999", config)).toBe(
+      7,
+    );
+    expect(getDmHistoryLimitFromSessionKey("agent:main:telegram:dm:123:topic:555", config)).toBe(7);
+    expect(getDmHistoryLimitFromSessionKey("telegram:dm:123:thread:999", config)).toBe(7);
+  });
+  it("keeps non-numeric thread markers in dm ids", () => {
+    const config = {
+      channels: {
+        telegram: { dms: { "user:thread:abc": { historyLimit: 9 } } },
+      },
+    } as OpenClawConfig;
+    expect(getDmHistoryLimitFromSessionKey("agent:main:telegram:dm:user:thread:abc", config)).toBe(
+      9,
+    );
+  });
+  it("returns group default for channel kinds, undefined for unrecognized kinds", () => {
+    const config = {
+      channels: {
+        telegram: { dmHistoryLimit: 15 },
+        slack: { dmHistoryLimit: 10 },
+      },
+    } as OpenClawConfig;
+    // "channel" kind now falls under group handling with a default limit of 50
+    expect(getDmHistoryLimitFromSessionKey("agent:beta:slack:channel:c1", config)).toBe(50);
+    // Unrecognized kind "slash" still returns undefined
+    expect(getDmHistoryLimitFromSessionKey("telegram:slash:123", config)).toBeUndefined();
+  });
+  it("returns undefined for unknown provider", () => {
+    const config = {
+      channels: { telegram: { dmHistoryLimit: 15 } },
+    } as OpenClawConfig;
+    expect(getDmHistoryLimitFromSessionKey("unknown:dm:123", config)).toBeUndefined();
+  });
+  it("returns undefined when provider config has no dmHistoryLimit", () => {
+    const config = { channels: { telegram: {} } } as OpenClawConfig;
+    expect(getDmHistoryLimitFromSessionKey("telegram:dm:123", config)).toBeUndefined();
+  });
+  it("handles all supported providers", () => {
+    const providers = [
+      "telegram",
+      "whatsapp",
+      "discord",
+      "slack",
+      "signal",
+      "imessage",
+      "msteams",
+      "nextcloud-talk",
+    ] as const;
+
+    for (const provider of providers) {
+      const config = {
+        channels: { [provider]: { dmHistoryLimit: 5 } },
+      } as OpenClawConfig;
+      expect(getDmHistoryLimitFromSessionKey(`${provider}:dm:123`, config)).toBe(5);
+    }
+  });
+  it("handles per-DM overrides for all supported providers", () => {
+    const providers = [
+      "telegram",
+      "whatsapp",
+      "discord",
+      "slack",
+      "signal",
+      "imessage",
+      "msteams",
+      "nextcloud-talk",
+    ] as const;
+
+    for (const provider of providers) {
+      // Test per-DM override takes precedence
+      const configWithOverride = {
+        channels: {
+          [provider]: {
+            dmHistoryLimit: 20,
+            dms: { user123: { historyLimit: 7 } },
+          },
+        },
+      } as OpenClawConfig;
+      expect(getDmHistoryLimitFromSessionKey(`${provider}:dm:user123`, configWithOverride)).toBe(7);
+
+      // Test fallback to provider default when user not in dms
+      expect(getDmHistoryLimitFromSessionKey(`${provider}:dm:otheruser`, configWithOverride)).toBe(
+        20,
+      );
+
+      // Test with agent-prefixed key
+      expect(
+        getDmHistoryLimitFromSessionKey(`agent:main:${provider}:dm:user123`, configWithOverride),
+      ).toBe(7);
+    }
+  });
+  it("returns per-DM override when set", () => {
+    const config = {
+      channels: {
+        telegram: {
+          dmHistoryLimit: 15,
+          dms: { "123": { historyLimit: 5 } },
+        },
+      },
+    } as OpenClawConfig;
+    expect(getDmHistoryLimitFromSessionKey("telegram:dm:123", config)).toBe(5);
+  });
+});

--- a/src/agents/pi-embedded-runner/background-optimization.test.ts
+++ b/src/agents/pi-embedded-runner/background-optimization.test.ts
@@ -1,0 +1,158 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  checkBackgroundOptimization,
+  clearOptimizationState,
+  markOptimizationDone,
+  maybeScheduleBackgroundOptimization,
+  __testing,
+} from "./background-optimization.js";
+
+const { SESSION_STATE, countUserTurns } = __testing;
+
+function makeMessages(userCount: number, assistantCount = userCount): AgentMessage[] {
+  const messages: AgentMessage[] = [];
+  for (let i = 0; i < Math.max(userCount, assistantCount); i++) {
+    if (i < userCount) {
+      messages.push({ role: "user", content: `msg ${i}`, timestamp: Date.now() });
+    }
+    if (i < assistantCount) {
+      messages.push({ role: "assistant", content: `reply ${i}`, timestamp: Date.now() });
+    }
+  }
+  return messages;
+}
+
+afterEach(() => {
+  SESSION_STATE.clear();
+});
+
+describe("countUserTurns", () => {
+  it("counts user messages only", () => {
+    const messages = makeMessages(5);
+    expect(countUserTurns(messages)).toBe(5);
+  });
+
+  it("returns 0 for empty array", () => {
+    expect(countUserTurns([])).toBe(0);
+  });
+});
+
+describe("checkBackgroundOptimization", () => {
+  it("does not trigger when turns <= verbatimTurns", () => {
+    const messages = makeMessages(20); // default verbatimTurns=30
+    const result = checkBackgroundOptimization("test-session", messages);
+    expect(result.shouldOptimize).toBe(false);
+  });
+
+  it("does not trigger on first check when turns are only slightly above verbatimTurns", () => {
+    const messages = makeMessages(35); // 35 > 30 but < 30+15
+    const result = checkBackgroundOptimization("test-session", messages);
+    expect(result.shouldOptimize).toBe(false);
+  });
+
+  it("triggers on first check when turns exceed verbatimTurns + optimizeAfterTurns", () => {
+    const messages = makeMessages(50); // 50 > 30+15=45
+    const result = checkBackgroundOptimization("test-session", messages);
+    expect(result.shouldOptimize).toBe(true);
+    expect(result.reason).toContain("first check");
+  });
+
+  it("respects optimizeAfterTurns threshold after first optimization", () => {
+    const sessionId = "turns-test";
+    markOptimizationDone(sessionId, 40);
+    // Simulate time passing (set lastOptimizedAt to 30 min ago)
+    SESSION_STATE.get(sessionId)!.lastOptimizedAt = Date.now() - 30 * 60_000;
+
+    // Only 5 new turns since last (40 → 45): below 15 threshold
+    const messages45 = makeMessages(45);
+    expect(checkBackgroundOptimization(sessionId, messages45).shouldOptimize).toBe(false);
+
+    // 20 new turns since last (40 → 60): above 15 threshold
+    const messages60 = makeMessages(60);
+    expect(checkBackgroundOptimization(sessionId, messages60).shouldOptimize).toBe(true);
+  });
+
+  it("respects optimizeIntervalMin threshold", () => {
+    const sessionId = "interval-test";
+    markOptimizationDone(sessionId, 40);
+    // lastOptimizedAt is "now", so interval not met
+
+    const messages = makeMessages(60); // enough turns
+    expect(checkBackgroundOptimization(sessionId, messages).shouldOptimize).toBe(false);
+
+    // Simulate 25 min passing (default interval=20)
+    SESSION_STATE.get(sessionId)!.lastOptimizedAt = Date.now() - 25 * 60_000;
+    expect(checkBackgroundOptimization(sessionId, messages).shouldOptimize).toBe(true);
+  });
+
+  it("uses custom config when provided", () => {
+    const messages = makeMessages(12); // custom verbatimTurns=5, optimizeAfterTurns=5 → triggers at 5+5=10
+    const cfg = {
+      agents: {
+        defaults: {
+          compaction: {
+            backgroundOptimization: {
+              verbatimTurns: 5,
+              optimizeAfterTurns: 5,
+              optimizeIntervalMin: 1,
+            },
+          },
+        },
+      },
+    };
+    const result = checkBackgroundOptimization("custom-session", messages, cfg as unknown);
+    expect(result.shouldOptimize).toBe(true);
+  });
+});
+
+describe("clearOptimizationState", () => {
+  it("removes tracked state", () => {
+    markOptimizationDone("clear-test", 50);
+    expect(SESSION_STATE.has("clear-test")).toBe(true);
+    clearOptimizationState("clear-test");
+    expect(SESSION_STATE.has("clear-test")).toBe(false);
+  });
+});
+
+describe("maybeScheduleBackgroundOptimization", () => {
+  it("does not call triggerCompaction when thresholds not met", () => {
+    const trigger = vi.fn();
+    maybeScheduleBackgroundOptimization({
+      sessionId: "no-trigger",
+      messages: makeMessages(10), // below verbatimTurns
+      triggerCompaction: trigger,
+    });
+    expect(trigger).not.toHaveBeenCalled();
+  });
+
+  it("calls triggerCompaction when thresholds are met", async () => {
+    const trigger = vi.fn().mockResolvedValue({ compacted: true });
+    maybeScheduleBackgroundOptimization({
+      sessionId: "trigger-test",
+      messages: makeMessages(50),
+      triggerCompaction: trigger,
+    });
+    // Fire-and-forget — wait for microtask
+    await vi.waitFor(() => expect(trigger).toHaveBeenCalledTimes(1));
+  });
+
+  it("marks state immediately to prevent concurrent triggers", () => {
+    const trigger = vi.fn().mockResolvedValue({ compacted: true });
+    maybeScheduleBackgroundOptimization({
+      sessionId: "concurrent-test",
+      messages: makeMessages(50),
+      triggerCompaction: trigger,
+    });
+    // State should be set immediately
+    expect(SESSION_STATE.has("concurrent-test")).toBe(true);
+    // Second call should NOT trigger (turns haven't increased)
+    const trigger2 = vi.fn();
+    maybeScheduleBackgroundOptimization({
+      sessionId: "concurrent-test",
+      messages: makeMessages(50),
+      triggerCompaction: trigger2,
+    });
+    expect(trigger2).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/pi-embedded-runner/background-optimization.ts
+++ b/src/agents/pi-embedded-runner/background-optimization.ts
@@ -1,0 +1,161 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { OpenClawConfig } from "../../config/config.js";
+import {
+  resolveBackgroundOptimization,
+  type ResolvedBackgroundOptimization,
+} from "../pi-settings.js";
+import { log } from "./logger.js";
+
+/**
+ * Background memory optimization — proactively triggers compaction
+ * before context hits emergency thresholds.
+ *
+ * This module tracks per-session state and determines WHEN to optimize.
+ * The actual summarization is delegated to compactEmbeddedPiSessionDirect
+ * which reuses the full compaction-safeguard pipeline.
+ */
+
+type SessionOptState = {
+  /** Timestamp of the last background optimization. */
+  lastOptimizedAt: number;
+  /** User turn count at the time of last optimization. */
+  turnsAtLastOptimize: number;
+};
+
+const SESSION_STATE = new Map<string, SessionOptState>();
+
+/** Count user turns in a message array. */
+function countUserTurns(messages: readonly AgentMessage[]): number {
+  let count = 0;
+  for (const msg of messages) {
+    if (msg.role === "user") {
+      count++;
+    }
+  }
+  return count;
+}
+
+export type BackgroundOptimizationCheck = {
+  shouldOptimize: boolean;
+  reason?: string;
+  userTurns: number;
+  config: ResolvedBackgroundOptimization;
+};
+
+/**
+ * Check whether a session needs background optimization.
+ *
+ * Triggers when BOTH:
+ * 1. At least `optimizeAfterTurns` new user turns since last optimization
+ * 2. At least `optimizeIntervalMin` minutes since last optimization
+ *
+ * AND the total user turns exceed `verbatimTurns` (otherwise there's nothing to summarize).
+ */
+export function checkBackgroundOptimization(
+  sessionId: string,
+  messages: readonly AgentMessage[],
+  cfg?: OpenClawConfig,
+): BackgroundOptimizationCheck {
+  const config = resolveBackgroundOptimization(cfg);
+  const userTurns = countUserTurns(messages);
+  const noResult: BackgroundOptimizationCheck = { shouldOptimize: false, userTurns, config };
+
+  // Nothing to summarize if total turns are within verbatim window
+  if (userTurns <= config.verbatimTurns) {
+    return noResult;
+  }
+
+  const state = SESSION_STATE.get(sessionId);
+  const now = Date.now();
+
+  if (!state) {
+    // First check for this session — only optimize if we have significant history
+    if (userTurns > config.verbatimTurns + config.optimizeAfterTurns) {
+      return {
+        shouldOptimize: true,
+        reason: `first check: ${userTurns} turns exceed verbatim(${config.verbatimTurns}) + trigger(${config.optimizeAfterTurns})`,
+        userTurns,
+        config,
+      };
+    }
+    return noResult;
+  }
+
+  const turnsSinceLast = userTurns - state.turnsAtLastOptimize;
+  const msSinceLast = now - state.lastOptimizedAt;
+  const minIntervalMs = config.optimizeIntervalMin * 60_000;
+
+  if (turnsSinceLast < config.optimizeAfterTurns) {
+    return noResult;
+  }
+  if (msSinceLast < minIntervalMs) {
+    return noResult;
+  }
+
+  return {
+    shouldOptimize: true,
+    reason: `${turnsSinceLast} new turns, ${Math.round(msSinceLast / 60_000)}min since last`,
+    userTurns,
+    config,
+  };
+}
+
+/** Record that a background optimization was performed (or started). */
+export function markOptimizationDone(sessionId: string, userTurns: number): void {
+  SESSION_STATE.set(sessionId, {
+    lastOptimizedAt: Date.now(),
+    turnsAtLastOptimize: userTurns,
+  });
+}
+
+/** Clear tracked state for a session (e.g., on session reset). */
+export function clearOptimizationState(sessionId: string): void {
+  SESSION_STATE.delete(sessionId);
+}
+
+/**
+ * Fire-and-forget background optimization after a successful run.
+ *
+ * This is the main entry point called from run.ts. It checks thresholds
+ * and, if needed, triggers compaction via the provided callback.
+ */
+export function maybeScheduleBackgroundOptimization(params: {
+  sessionId: string;
+  messages: readonly AgentMessage[];
+  cfg?: OpenClawConfig;
+  triggerCompaction: () => Promise<{ compacted: boolean; reason?: string }>;
+}): void {
+  const check = checkBackgroundOptimization(params.sessionId, params.messages, params.cfg);
+
+  if (!check.shouldOptimize) {
+    return;
+  }
+
+  log.info(`[bg-optimize] scheduling for session=${params.sessionId}: ${check.reason}`);
+
+  // Mark optimized immediately to prevent concurrent triggers
+  markOptimizationDone(params.sessionId, check.userTurns);
+
+  // Fire and forget — never blocks the reply
+  params.triggerCompaction().then(
+    (result) => {
+      if (result.compacted) {
+        log.info(`[bg-optimize] completed for session=${params.sessionId}`);
+      } else {
+        log.debug(
+          `[bg-optimize] skipped for session=${params.sessionId}: ${result.reason ?? "nothing to compact"}`,
+        );
+      }
+    },
+    (err) => {
+      log.warn(
+        `[bg-optimize] failed for session=${params.sessionId}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    },
+  );
+}
+
+export const __testing = {
+  SESSION_STATE,
+  countUserTurns,
+} as const;

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -1,4 +1,3 @@
-import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import {
   createAgentSession,
   estimateTokens,
@@ -14,7 +13,6 @@ import type { EmbeddedPiCompactResult } from "./types.js";
 import { resolveHeartbeatPrompt } from "../../auto-reply/heartbeat.js";
 import { resolveChannelCapabilities } from "../../config/channel-capabilities.js";
 import { getMachineDisplayName } from "../../infra/machine-name.js";
-import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { type enqueueCommand, enqueueCommandInLane } from "../../process/command-queue.js";
 import { isSubagentSessionKey } from "../../routing/session-key.js";
 import { resolveSignalReactionLevel } from "../../signal/reaction-level.js";
@@ -63,7 +61,7 @@ import {
   sanitizeSessionHistory,
   sanitizeToolsForGoogle,
 } from "./google.js";
-import { getDmHistoryLimitFromSessionKey, limitHistoryTurns } from "./history.js";
+import { getHistoryLimitFromSessionKey, limitHistoryTurns } from "./history.js";
 import { resolveGlobalLane, resolveSessionLane } from "./lanes.js";
 import { log } from "./logger.js";
 import { buildModelAliasLines, resolveModel } from "./model.js";
@@ -75,12 +73,10 @@ import {
   createSystemPromptOverride,
 } from "./system-prompt.js";
 import { splitSdkTools } from "./tool-split.js";
-import { describeUnknownError, mapThinkingLevel } from "./utils.js";
-import { flushPendingToolResultsAfterIdle } from "./wait-for-idle-before-flush.js";
+import { describeUnknownError, mapThinkingLevel, resolveExecToolDefaults } from "./utils.js";
 
 export type CompactEmbeddedPiSessionParams = {
   sessionId: string;
-  runId?: string;
   sessionKey?: string;
   messageChannel?: string;
   messageProvider?: string;
@@ -107,131 +103,11 @@ export type CompactEmbeddedPiSessionParams = {
   reasoningLevel?: ReasoningLevel;
   bashElevated?: ExecElevatedDefaults;
   customInstructions?: string;
-  trigger?: "overflow" | "manual" | "cache_ttl" | "safeguard";
-  diagId?: string;
-  attempt?: number;
-  maxAttempts?: number;
   lane?: string;
   enqueue?: typeof enqueueCommand;
   extraSystemPrompt?: string;
   ownerNumbers?: string[];
 };
-
-type CompactionMessageMetrics = {
-  messages: number;
-  historyTextChars: number;
-  toolResultChars: number;
-  estTokens?: number;
-  contributors: Array<{ role: string; chars: number; tool?: string }>;
-};
-
-function createCompactionDiagId(): string {
-  return `cmp-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
-}
-
-function getMessageTextChars(msg: AgentMessage): number {
-  const content = (msg as { content?: unknown }).content;
-  if (typeof content === "string") {
-    return content.length;
-  }
-  if (!Array.isArray(content)) {
-    return 0;
-  }
-  let total = 0;
-  for (const block of content) {
-    if (!block || typeof block !== "object") {
-      continue;
-    }
-    const text = (block as { text?: unknown }).text;
-    if (typeof text === "string") {
-      total += text.length;
-    }
-  }
-  return total;
-}
-
-function resolveMessageToolLabel(msg: AgentMessage): string | undefined {
-  const candidate =
-    (msg as { toolName?: unknown }).toolName ??
-    (msg as { name?: unknown }).name ??
-    (msg as { tool?: unknown }).tool;
-  return typeof candidate === "string" && candidate.trim().length > 0 ? candidate : undefined;
-}
-
-function summarizeCompactionMessages(messages: AgentMessage[]): CompactionMessageMetrics {
-  let historyTextChars = 0;
-  let toolResultChars = 0;
-  const contributors: Array<{ role: string; chars: number; tool?: string }> = [];
-  let estTokens = 0;
-  let tokenEstimationFailed = false;
-
-  for (const msg of messages) {
-    const role = typeof msg.role === "string" ? msg.role : "unknown";
-    const chars = getMessageTextChars(msg);
-    historyTextChars += chars;
-    if (role === "toolResult") {
-      toolResultChars += chars;
-    }
-    contributors.push({ role, chars, tool: resolveMessageToolLabel(msg) });
-    if (!tokenEstimationFailed) {
-      try {
-        estTokens += estimateTokens(msg);
-      } catch {
-        tokenEstimationFailed = true;
-      }
-    }
-  }
-
-  return {
-    messages: messages.length,
-    historyTextChars,
-    toolResultChars,
-    estTokens: tokenEstimationFailed ? undefined : estTokens,
-    contributors: contributors.toSorted((a, b) => b.chars - a.chars).slice(0, 3),
-  };
-}
-
-function classifyCompactionReason(reason?: string): string {
-  const text = (reason ?? "").trim().toLowerCase();
-  if (!text) {
-    return "unknown";
-  }
-  if (text.includes("nothing to compact")) {
-    return "no_compactable_entries";
-  }
-  if (text.includes("below threshold")) {
-    return "below_threshold";
-  }
-  if (text.includes("already compacted")) {
-    return "already_compacted_recently";
-  }
-  if (text.includes("guard")) {
-    return "guard_blocked";
-  }
-  if (text.includes("summary")) {
-    return "summary_failed";
-  }
-  if (text.includes("timed out") || text.includes("timeout")) {
-    return "timeout";
-  }
-  if (
-    text.includes("400") ||
-    text.includes("401") ||
-    text.includes("403") ||
-    text.includes("429")
-  ) {
-    return "provider_error_4xx";
-  }
-  if (
-    text.includes("500") ||
-    text.includes("502") ||
-    text.includes("503") ||
-    text.includes("504")
-  ) {
-    return "provider_error_5xx";
-  }
-  return "unknown";
-}
 
 /**
  * Core compaction logic without lane queueing.
@@ -240,12 +116,6 @@ function classifyCompactionReason(reason?: string): string {
 export async function compactEmbeddedPiSessionDirect(
   params: CompactEmbeddedPiSessionParams,
 ): Promise<EmbeddedPiCompactResult> {
-  const startedAt = Date.now();
-  const diagId = params.diagId?.trim() || createCompactionDiagId();
-  const trigger = params.trigger ?? "manual";
-  const attempt = params.attempt ?? 1;
-  const maxAttempts = params.maxAttempts ?? 1;
-  const runId = params.runId ?? params.sessionId;
   const resolvedWorkspace = resolveUserPath(params.workspaceDir);
   const prevCwd = process.cwd();
 
@@ -260,17 +130,10 @@ export async function compactEmbeddedPiSessionDirect(
     params.config,
   );
   if (!model) {
-    const reason = error ?? `Unknown model: ${provider}/${modelId}`;
-    log.warn(
-      `[compaction-diag] end runId=${runId} sessionKey=${params.sessionKey ?? params.sessionId} ` +
-        `diagId=${diagId} trigger=${trigger} provider=${provider}/${modelId} ` +
-        `attempt=${attempt} maxAttempts=${maxAttempts} outcome=failed reason=${classifyCompactionReason(reason)} ` +
-        `durationMs=${Date.now() - startedAt}`,
-    );
     return {
       ok: false,
       compacted: false,
-      reason,
+      reason: error ?? `Unknown model: ${provider}/${modelId}`,
     };
   }
   try {
@@ -297,17 +160,10 @@ export async function compactEmbeddedPiSessionDirect(
       authStorage.setRuntimeApiKey(model.provider, apiKeyInfo.apiKey);
     }
   } catch (err) {
-    const reason = describeUnknownError(err);
-    log.warn(
-      `[compaction-diag] end runId=${runId} sessionKey=${params.sessionKey ?? params.sessionId} ` +
-        `diagId=${diagId} trigger=${trigger} provider=${provider}/${modelId} ` +
-        `attempt=${attempt} maxAttempts=${maxAttempts} outcome=failed reason=${classifyCompactionReason(reason)} ` +
-        `durationMs=${Date.now() - startedAt}`,
-    );
     return {
       ok: false,
       compacted: false,
-      reason,
+      reason: describeUnknownError(err),
     };
   }
 
@@ -364,6 +220,7 @@ export async function compactEmbeddedPiSessionDirect(
     const runAbortController = new AbortController();
     const toolsRaw = createOpenClawCodingTools({
       exec: {
+        ...resolveExecToolDefaults(params.config),
         elevated: params.bashElevated,
       },
       sandbox,
@@ -573,11 +430,9 @@ export async function compactEmbeddedPiSessionDirect(
         const validated = transcriptPolicy.validateAnthropicTurns
           ? validateAnthropicTurns(validatedGemini)
           : validatedGemini;
-        // Capture full message history BEFORE limiting — plugins need the complete conversation
-        const preCompactionMessages = [...session.messages];
         const truncated = limitHistoryTurns(
           validated,
-          getDmHistoryLimitFromSessionKey(params.sessionKey, params.config),
+          getHistoryLimitFromSessionKey(params.sessionKey, params.config),
         );
         // Re-run tool_use/tool_result pairing repair after truncation, since
         // limitHistoryTurns can orphan tool_result blocks by removing the
@@ -588,50 +443,6 @@ export async function compactEmbeddedPiSessionDirect(
         if (limited.length > 0) {
           session.agent.replaceMessages(limited);
         }
-        // Run before_compaction hooks (fire-and-forget).
-        // The session JSONL already contains all messages on disk, so plugins
-        // can read sessionFile asynchronously and process in parallel with
-        // the compaction LLM call — no need to block or wait for after_compaction.
-        const hookRunner = getGlobalHookRunner();
-        const hookCtx = {
-          agentId: params.sessionKey?.split(":")[0] ?? "main",
-          sessionKey: params.sessionKey,
-          sessionId: params.sessionId,
-          workspaceDir: params.workspaceDir,
-          messageProvider: params.messageChannel ?? params.messageProvider,
-        };
-        if (hookRunner?.hasHooks("before_compaction")) {
-          hookRunner
-            .runBeforeCompaction(
-              {
-                messageCount: preCompactionMessages.length,
-                compactingCount: limited.length,
-                messages: preCompactionMessages,
-                sessionFile: params.sessionFile,
-              },
-              hookCtx,
-            )
-            .catch((hookErr: unknown) => {
-              log.warn(`before_compaction hook failed: ${String(hookErr)}`);
-            });
-        }
-
-        const diagEnabled = log.isEnabled("debug");
-        const preMetrics = diagEnabled ? summarizeCompactionMessages(session.messages) : undefined;
-        if (diagEnabled && preMetrics) {
-          log.debug(
-            `[compaction-diag] start runId=${runId} sessionKey=${params.sessionKey ?? params.sessionId} ` +
-              `diagId=${diagId} trigger=${trigger} provider=${provider}/${modelId} ` +
-              `attempt=${attempt} maxAttempts=${maxAttempts} ` +
-              `pre.messages=${preMetrics.messages} pre.historyTextChars=${preMetrics.historyTextChars} ` +
-              `pre.toolResultChars=${preMetrics.toolResultChars} pre.estTokens=${preMetrics.estTokens ?? "unknown"}`,
-          );
-          log.debug(
-            `[compaction-diag] contributors diagId=${diagId} top=${JSON.stringify(preMetrics.contributors)}`,
-          );
-        }
-
-        const compactStartedAt = Date.now();
         const result = await session.compact(params.customInstructions);
         // Estimate tokens after compaction by summing token estimates for remaining messages
         let tokensAfter: number | undefined;
@@ -648,40 +459,6 @@ export async function compactEmbeddedPiSessionDirect(
           // If estimation fails, leave tokensAfter undefined
           tokensAfter = undefined;
         }
-        // Run after_compaction hooks (fire-and-forget).
-        // Also includes sessionFile for plugins that only need to act after
-        // compaction completes (e.g. analytics, cleanup).
-        if (hookRunner?.hasHooks("after_compaction")) {
-          hookRunner
-            .runAfterCompaction(
-              {
-                messageCount: session.messages.length,
-                tokenCount: tokensAfter,
-                compactedCount: limited.length - session.messages.length,
-                sessionFile: params.sessionFile,
-              },
-              hookCtx,
-            )
-            .catch((hookErr) => {
-              log.warn(`after_compaction hook failed: ${hookErr}`);
-            });
-        }
-
-        const postMetrics = diagEnabled ? summarizeCompactionMessages(session.messages) : undefined;
-        if (diagEnabled && preMetrics && postMetrics) {
-          log.debug(
-            `[compaction-diag] end runId=${runId} sessionKey=${params.sessionKey ?? params.sessionId} ` +
-              `diagId=${diagId} trigger=${trigger} provider=${provider}/${modelId} ` +
-              `attempt=${attempt} maxAttempts=${maxAttempts} outcome=compacted reason=none ` +
-              `durationMs=${Date.now() - compactStartedAt} retrying=false ` +
-              `post.messages=${postMetrics.messages} post.historyTextChars=${postMetrics.historyTextChars} ` +
-              `post.toolResultChars=${postMetrics.toolResultChars} post.estTokens=${postMetrics.estTokens ?? "unknown"} ` +
-              `delta.messages=${postMetrics.messages - preMetrics.messages} ` +
-              `delta.historyTextChars=${postMetrics.historyTextChars - preMetrics.historyTextChars} ` +
-              `delta.toolResultChars=${postMetrics.toolResultChars - preMetrics.toolResultChars} ` +
-              `delta.estTokens=${typeof preMetrics.estTokens === "number" && typeof postMetrics.estTokens === "number" ? postMetrics.estTokens - preMetrics.estTokens : "unknown"}`,
-          );
-        }
         return {
           ok: true,
           compacted: true,
@@ -694,27 +471,17 @@ export async function compactEmbeddedPiSessionDirect(
           },
         };
       } finally {
-        await flushPendingToolResultsAfterIdle({
-          agent: session?.agent,
-          sessionManager,
-        });
+        sessionManager.flushPendingToolResults?.();
         session.dispose();
       }
     } finally {
       await sessionLock.release();
     }
   } catch (err) {
-    const reason = describeUnknownError(err);
-    log.warn(
-      `[compaction-diag] end runId=${runId} sessionKey=${params.sessionKey ?? params.sessionId} ` +
-        `diagId=${diagId} trigger=${trigger} provider=${provider}/${modelId} ` +
-        `attempt=${attempt} maxAttempts=${maxAttempts} outcome=failed reason=${classifyCompactionReason(reason)} ` +
-        `durationMs=${Date.now() - startedAt}`,
-    );
     return {
       ok: false,
       compacted: false,
-      reason,
+      reason: describeUnknownError(err),
     };
   } finally {
     restoreSkillEnv?.();

--- a/src/agents/pi-embedded-runner/history.ts
+++ b/src/agents/pi-embedded-runner/history.ts
@@ -3,6 +3,12 @@ import type { OpenClawConfig } from "../../config/config.js";
 
 const THREAD_SUFFIX_REGEX = /^(.*)(?::(?:thread|topic):\d+)$/i;
 
+/**
+ * Default history limit for group sessions (generous — preserves context).
+ * Only kicks in when no per-group or per-provider override is configured.
+ */
+const DEFAULT_GROUP_HISTORY_LIMIT = 50;
+
 function stripThreadSuffix(value: string): string {
   const match = value.match(THREAD_SUFFIX_REGEX);
   return match?.[1] ?? value;
@@ -10,7 +16,7 @@ function stripThreadSuffix(value: string): string {
 
 /**
  * Limits conversation history to the last N user turns (and their associated
- * assistant responses). This reduces token usage for long-running DM sessions.
+ * assistant responses). This reduces token usage for long-running sessions.
  */
 export function limitHistoryTurns(
   messages: AgentMessage[],
@@ -35,10 +41,33 @@ export function limitHistoryTurns(
   return messages;
 }
 
+type ProviderChannelConfig = {
+  dmHistoryLimit?: number;
+  groupHistoryLimit?: number;
+  dms?: Record<string, { historyLimit?: number }>;
+  groups?: Record<string, { historyLimit?: number }>;
+};
+
+function resolveProviderConfig(
+  cfg: OpenClawConfig | undefined,
+  providerId: string,
+): ProviderChannelConfig | undefined {
+  const channels = cfg?.channels;
+  if (!channels || typeof channels !== "object") {
+    return undefined;
+  }
+  const entry = (channels as Record<string, unknown>)[providerId];
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    return undefined;
+  }
+  return entry as ProviderChannelConfig;
+}
+
 /**
- * Extract provider + user ID from a session key and look up dmHistoryLimit.
- * Supports per-DM overrides and provider defaults.
- * For channel/group sessions, uses historyLimit from provider config.
+ * Resolve history limit from a session key.
+ * Supports DMs, groups, and per-entity overrides.
+ * Groups get a generous default (50 turns) to prevent unbounded accumulation
+ * while preserving high-quality context.
  */
 export function getHistoryLimitFromSessionKey(
   sessionKey: string | undefined,
@@ -57,59 +86,30 @@ export function getHistoryLimitFromSessionKey(
   }
 
   const kind = providerParts[1]?.toLowerCase();
-  const userIdRaw = providerParts.slice(2).join(":");
-  const userId = stripThreadSuffix(userIdRaw);
-
-  const resolveProviderConfig = (
-    cfg: OpenClawConfig | undefined,
-    providerId: string,
-  ):
-    | {
-        historyLimit?: number;
-        dmHistoryLimit?: number;
-        dms?: Record<string, { historyLimit?: number }>;
-      }
-    | undefined => {
-    const channels = cfg?.channels;
-    if (!channels || typeof channels !== "object") {
-      return undefined;
-    }
-    const entry = (channels as Record<string, unknown>)[providerId];
-    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
-      return undefined;
-    }
-    return entry as {
-      historyLimit?: number;
-      dmHistoryLimit?: number;
-      dms?: Record<string, { historyLimit?: number }>;
-    };
-  };
-
+  const entityIdRaw = providerParts.slice(2).join(":");
+  const entityId = stripThreadSuffix(entityIdRaw);
   const providerConfig = resolveProviderConfig(config, provider);
-  if (!providerConfig) {
-    return undefined;
-  }
-
-  // For DM sessions: per-DM override -> dmHistoryLimit.
-  // Accept both "direct" (new) and "dm" (legacy) for backward compat.
-  if (kind === "dm" || kind === "direct") {
-    if (userId && providerConfig.dms?.[userId]?.historyLimit !== undefined) {
-      return providerConfig.dms[userId].historyLimit;
+  if (kind === "dm") {
+    if (entityId && providerConfig?.dms?.[entityId]?.historyLimit !== undefined) {
+      return providerConfig.dms[entityId].historyLimit;
     }
-    return providerConfig.dmHistoryLimit;
+    return providerConfig?.dmHistoryLimit;
   }
 
-  // For channel/group sessions: use historyLimit from provider config
-  // This prevents context overflow in long-running channel sessions
-  if (kind === "channel" || kind === "group") {
-    return providerConfig.historyLimit;
+  if (kind === "group" || kind === "supergroup" || kind === "channel") {
+    if (entityId && providerConfig?.groups?.[entityId]?.historyLimit !== undefined) {
+      return providerConfig.groups[entityId].historyLimit;
+    }
+    return providerConfig?.groupHistoryLimit ?? DEFAULT_GROUP_HISTORY_LIMIT;
   }
 
   return undefined;
 }
 
-/**
- * @deprecated Use getHistoryLimitFromSessionKey instead.
- * Alias for backward compatibility.
- */
-export const getDmHistoryLimitFromSessionKey = getHistoryLimitFromSessionKey;
+/** @deprecated Use getHistoryLimitFromSessionKey instead. */
+export function getDmHistoryLimitFromSessionKey(
+  sessionKey: string | undefined,
+  config: OpenClawConfig | undefined,
+): number | undefined {
+  return getHistoryLimitFromSessionKey(sessionKey, config);
+}

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -31,7 +31,6 @@ import { resolveOpenClawDocsPath } from "../../docs-path.js";
 import { isTimeoutError } from "../../failover-error.js";
 import { resolveModelAuthMode } from "../../model-auth.js";
 import { resolveDefaultModelForAgent } from "../../model-selection.js";
-import { createOllamaStreamFn, OLLAMA_NATIVE_BASE_URL } from "../../ollama-stream.js";
 import {
   isCloudCodeAssistFormatError,
   resolveBootstrapMaxChars,
@@ -72,7 +71,7 @@ import {
   sanitizeSessionHistory,
   sanitizeToolsForGoogle,
 } from "../google.js";
-import { getDmHistoryLimitFromSessionKey, limitHistoryTurns } from "../history.js";
+import { getHistoryLimitFromSessionKey, limitHistoryTurns } from "../history.js";
 import { log } from "../logger.js";
 import { buildModelAliasLines } from "../model.js";
 import {
@@ -90,7 +89,6 @@ import {
 } from "../system-prompt.js";
 import { splitSdkTools } from "../tool-split.js";
 import { describeUnknownError, mapThinkingLevel } from "../utils.js";
-import { flushPendingToolResultsAfterIdle } from "../wait-for-idle-before-flush.js";
 import { detectAndLoadPromptImages } from "./images.js";
 
 export function injectHistoryImagesIntoMessages(
@@ -139,69 +137,6 @@ export function injectHistoryImagesIntoMessages(
   }
 
   return didMutate;
-}
-
-function summarizeMessagePayload(msg: AgentMessage): { textChars: number; imageBlocks: number } {
-  const content = (msg as { content?: unknown }).content;
-  if (typeof content === "string") {
-    return { textChars: content.length, imageBlocks: 0 };
-  }
-  if (!Array.isArray(content)) {
-    return { textChars: 0, imageBlocks: 0 };
-  }
-
-  let textChars = 0;
-  let imageBlocks = 0;
-  for (const block of content) {
-    if (!block || typeof block !== "object") {
-      continue;
-    }
-    const typedBlock = block as { type?: unknown; text?: unknown };
-    if (typedBlock.type === "image") {
-      imageBlocks++;
-      continue;
-    }
-    if (typeof typedBlock.text === "string") {
-      textChars += typedBlock.text.length;
-    }
-  }
-
-  return { textChars, imageBlocks };
-}
-
-function summarizeSessionContext(messages: AgentMessage[]): {
-  roleCounts: string;
-  totalTextChars: number;
-  totalImageBlocks: number;
-  maxMessageTextChars: number;
-} {
-  const roleCounts = new Map<string, number>();
-  let totalTextChars = 0;
-  let totalImageBlocks = 0;
-  let maxMessageTextChars = 0;
-
-  for (const msg of messages) {
-    const role = typeof msg.role === "string" ? msg.role : "unknown";
-    roleCounts.set(role, (roleCounts.get(role) ?? 0) + 1);
-
-    const payload = summarizeMessagePayload(msg);
-    totalTextChars += payload.textChars;
-    totalImageBlocks += payload.imageBlocks;
-    if (payload.textChars > maxMessageTextChars) {
-      maxMessageTextChars = payload.textChars;
-    }
-  }
-
-  return {
-    roleCounts:
-      [...roleCounts.entries()]
-        .toSorted((a, b) => a[0].localeCompare(b[0]))
-        .map(([role, count]) => `${role}:${count}`)
-        .join(",") || "none",
-    totalTextChars,
-    totalImageBlocks,
-    maxMessageTextChars,
-  };
 }
 
 export async function runEmbeddedAttempt(
@@ -585,21 +520,8 @@ export async function runEmbeddedAttempt(
         workspaceDir: params.workspaceDir,
       });
 
-      // Ollama native API: bypass SDK's streamSimple and use direct /api/chat calls
-      // for reliable streaming + tool calling support (#11828).
-      if (params.model.api === "ollama") {
-        // Use the resolved model baseUrl first so custom provider aliases work.
-        const providerConfig = params.config?.models?.providers?.[params.model.provider];
-        const modelBaseUrl =
-          typeof params.model.baseUrl === "string" ? params.model.baseUrl.trim() : "";
-        const providerBaseUrl =
-          typeof providerConfig?.baseUrl === "string" ? providerConfig.baseUrl.trim() : "";
-        const ollamaBaseUrl = modelBaseUrl || providerBaseUrl || OLLAMA_NATIVE_BASE_URL;
-        activeSession.agent.streamFn = createOllamaStreamFn(ollamaBaseUrl);
-      } else {
-        // Force a stable streamFn reference so vitest can reliably mock @mariozechner/pi-ai.
-        activeSession.agent.streamFn = streamSimple;
-      }
+      // Force a stable streamFn reference so vitest can reliably mock @mariozechner/pi-ai.
+      activeSession.agent.streamFn = streamSimple;
 
       applyExtraParamsToAgent(
         activeSession.agent,
@@ -642,7 +564,7 @@ export async function runEmbeddedAttempt(
           : validatedGemini;
         const truncated = limitHistoryTurns(
           validated,
-          getDmHistoryLimitFromSessionKey(params.sessionKey, params.config),
+          getHistoryLimitFromSessionKey(params.sessionKey, params.config),
         );
         // Re-run tool_use/tool_result pairing repair after truncation, since
         // limitHistoryTurns can orphan tool_result blocks by removing the
@@ -655,10 +577,7 @@ export async function runEmbeddedAttempt(
           activeSession.agent.replaceMessages(limited);
         }
       } catch (err) {
-        await flushPendingToolResultsAfterIdle({
-          agent: activeSession?.agent,
-          sessionManager,
-        });
+        sessionManager.flushPendingToolResults?.();
         activeSession.dispose();
         throw err;
       }
@@ -826,7 +745,6 @@ export async function runEmbeddedAttempt(
               {
                 agentId: hookAgentId,
                 sessionKey: params.sessionKey,
-                sessionId: params.sessionId,
                 workspaceDir: params.workspaceDir,
                 messageProvider: params.messageProvider ?? undefined,
               },
@@ -880,10 +798,7 @@ export async function runEmbeddedAttempt(
             historyMessages: activeSession.messages,
             maxBytes: MAX_IMAGE_BYTES,
             // Enforce sandbox path restrictions when sandbox is enabled
-            sandbox:
-              sandbox?.enabled && sandbox?.fsBridge
-                ? { root: sandbox.workspaceDir, bridge: sandbox.fsBridge }
-                : undefined,
+            sandboxRoot: sandbox?.enabled ? sandbox.workspaceDir : undefined,
           });
 
           // Inject history images into their original message positions.
@@ -902,25 +817,6 @@ export async function runEmbeddedAttempt(
             messages: activeSession.messages,
             note: `images: prompt=${imageResult.images.length} history=${imageResult.historyImagesByIndex.size}`,
           });
-
-          // Diagnostic: log context sizes before prompt to help debug early overflow errors.
-          if (log.isEnabled("debug")) {
-            const msgCount = activeSession.messages.length;
-            const systemLen = systemPromptText?.length ?? 0;
-            const promptLen = effectivePrompt.length;
-            const sessionSummary = summarizeSessionContext(activeSession.messages);
-            log.debug(
-              `[context-diag] pre-prompt: sessionKey=${params.sessionKey ?? params.sessionId} ` +
-                `messages=${msgCount} roleCounts=${sessionSummary.roleCounts} ` +
-                `historyTextChars=${sessionSummary.totalTextChars} ` +
-                `maxMessageTextChars=${sessionSummary.maxMessageTextChars} ` +
-                `historyImageBlocks=${sessionSummary.totalImageBlocks} ` +
-                `systemPromptChars=${systemLen} promptChars=${promptLen} ` +
-                `promptImages=${imageResult.images.length} ` +
-                `historyImageMessages=${imageResult.historyImagesByIndex.size} ` +
-                `provider=${params.provider}/${params.modelId} sessionFile=${params.sessionFile}`,
-            );
-          }
 
           // Only pass images option if there are actually images to pass
           // This avoids potential issues with models that don't expect the images parameter
@@ -987,7 +883,6 @@ export async function runEmbeddedAttempt(
               {
                 agentId: hookAgentId,
                 sessionKey: params.sessionKey,
-                sessionId: params.sessionId,
                 workspaceDir: params.workspaceDir,
                 messageProvider: params.messageProvider ?? undefined,
               },
@@ -1042,17 +937,7 @@ export async function runEmbeddedAttempt(
       };
     } finally {
       // Always tear down the session (and release the lock) before we leave this attempt.
-      //
-      // BUGFIX: Wait for the agent to be truly idle before flushing pending tool results.
-      // pi-agent-core's auto-retry resolves waitForRetry() on assistant message receipt,
-      // *before* tool execution completes in the retried agent loop. Without this wait,
-      // flushPendingToolResults() fires while tools are still executing, inserting
-      // synthetic "missing tool result" errors and causing silent agent failures.
-      // See: https://github.com/openclaw/openclaw/issues/8643
-      await flushPendingToolResultsAfterIdle({
-        agent: session?.agent,
-        sessionManager,
-      });
+      sessionManager?.flushPendingToolResults?.();
       session?.dispose();
       await sessionLock.release();
     }

--- a/src/agents/pi-settings.test.ts
+++ b/src/agents/pi-settings.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR,
+  ensurePiCompactionReserveTokens,
+  resolveBackgroundOptimization,
+  resolveCompactionReserveTokensFloor,
+} from "./pi-settings.js";
+
+describe("ensurePiCompactionReserveTokens", () => {
+  it("bumps reserveTokens when below floor", () => {
+    const settingsManager = {
+      getCompactionReserveTokens: () => 16_384,
+      applyOverrides: vi.fn(),
+    };
+
+    const result = ensurePiCompactionReserveTokens({ settingsManager });
+
+    expect(result).toEqual({
+      didOverride: true,
+      reserveTokens: DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR,
+    });
+    expect(settingsManager.applyOverrides).toHaveBeenCalledWith({
+      compaction: { reserveTokens: DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR },
+    });
+  });
+
+  it("does not override when already above floor", () => {
+    const settingsManager = {
+      getCompactionReserveTokens: () => 50_000,
+      applyOverrides: vi.fn(),
+    };
+
+    const result = ensurePiCompactionReserveTokens({ settingsManager });
+
+    expect(result).toEqual({ didOverride: false, reserveTokens: 50_000 });
+    expect(settingsManager.applyOverrides).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveCompactionReserveTokensFloor", () => {
+  it("returns the default when config is missing", () => {
+    expect(resolveCompactionReserveTokensFloor()).toBe(DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR);
+  });
+
+  it("accepts configured floors, including zero", () => {
+    expect(
+      resolveCompactionReserveTokensFloor({
+        agents: { defaults: { compaction: { reserveTokensFloor: 24_000 } } },
+      }),
+    ).toBe(24_000);
+    expect(
+      resolveCompactionReserveTokensFloor({
+        agents: { defaults: { compaction: { reserveTokensFloor: 0 } } },
+      }),
+    ).toBe(0);
+  });
+});
+
+describe("resolveBackgroundOptimization", () => {
+  it("returns all defaults when config is missing", () => {
+    const result = resolveBackgroundOptimization();
+    expect(result).toEqual({
+      verbatimTurns: 30,
+      targetWaterLevel: 0.5,
+      summaryBudgetRatio: 0.25,
+      optimizeAfterTurns: 15,
+      optimizeIntervalMin: 20,
+    });
+  });
+
+  it("accepts partial overrides and fills defaults", () => {
+    const result = resolveBackgroundOptimization({
+      agents: {
+        defaults: {
+          compaction: {
+            backgroundOptimization: { verbatimTurns: 10, targetWaterLevel: 0.7 },
+          },
+        },
+      },
+    });
+    expect(result.verbatimTurns).toBe(10);
+    expect(result.targetWaterLevel).toBe(0.7);
+    expect(result.summaryBudgetRatio).toBe(0.25);
+    expect(result.optimizeAfterTurns).toBe(15);
+    expect(result.optimizeIntervalMin).toBe(20);
+  });
+
+  it("clamps out-of-range values", () => {
+    const result = resolveBackgroundOptimization({
+      agents: {
+        defaults: {
+          compaction: {
+            backgroundOptimization: {
+              verbatimTurns: 0,
+              targetWaterLevel: 2.0,
+              summaryBudgetRatio: -1,
+              optimizeAfterTurns: 999,
+              optimizeIntervalMin: 0,
+            },
+          },
+        },
+      },
+    });
+    expect(result.verbatimTurns).toBe(1);
+    expect(result.targetWaterLevel).toBe(0.9);
+    expect(result.summaryBudgetRatio).toBe(0.05);
+    expect(result.optimizeAfterTurns).toBe(100);
+    expect(result.optimizeIntervalMin).toBe(1);
+  });
+});

--- a/src/agents/pi-settings.ts
+++ b/src/agents/pi-settings.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "../config/config.js";
+import type { AgentBackgroundOptimizationConfig } from "../config/types.agent-defaults.js";
 
-export const DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR = 20_000;
+export const DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR = 40_000;
 
 type PiSettingsManagerLike = {
   getCompactionReserveTokens: () => number;
@@ -31,4 +32,54 @@ export function resolveCompactionReserveTokensFloor(cfg?: OpenClawConfig): numbe
     return Math.floor(raw);
   }
   return DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR;
+}
+
+/** Resolved background optimization settings with concrete defaults. */
+export type ResolvedBackgroundOptimization = Required<AgentBackgroundOptimizationConfig>;
+
+const BG_OPT_DEFAULTS: ResolvedBackgroundOptimization = {
+  verbatimTurns: 30,
+  targetWaterLevel: 0.5,
+  summaryBudgetRatio: 0.25,
+  optimizeAfterTurns: 15,
+  optimizeIntervalMin: 20,
+};
+
+function clampNumber(value: unknown, min: number, max: number, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return fallback;
+  }
+  return Math.max(min, Math.min(max, value));
+}
+
+/** Resolve background optimization config with validated defaults. */
+export function resolveBackgroundOptimization(
+  cfg?: OpenClawConfig,
+): ResolvedBackgroundOptimization {
+  const raw = cfg?.agents?.defaults?.compaction?.backgroundOptimization;
+  if (!raw) {
+    return { ...BG_OPT_DEFAULTS };
+  }
+  return {
+    verbatimTurns: clampNumber(raw.verbatimTurns, 1, 200, BG_OPT_DEFAULTS.verbatimTurns),
+    targetWaterLevel: clampNumber(raw.targetWaterLevel, 0.1, 0.9, BG_OPT_DEFAULTS.targetWaterLevel),
+    summaryBudgetRatio: clampNumber(
+      raw.summaryBudgetRatio,
+      0.05,
+      0.5,
+      BG_OPT_DEFAULTS.summaryBudgetRatio,
+    ),
+    optimizeAfterTurns: clampNumber(
+      raw.optimizeAfterTurns,
+      1,
+      100,
+      BG_OPT_DEFAULTS.optimizeAfterTurns,
+    ),
+    optimizeIntervalMin: clampNumber(
+      raw.optimizeIntervalMin,
+      1,
+      1440,
+      BG_OPT_DEFAULTS.optimizeIntervalMin,
+    ),
+  };
 }

--- a/src/agents/synthetic-models.test.ts
+++ b/src/agents/synthetic-models.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSyntheticModelDefinition,
+  SYNTHETIC_MODEL_CATALOG,
+  SYNTHETIC_DEFAULT_MODEL_ID,
+  SYNTHETIC_DEFAULT_COST,
+  SYNTHETIC_BASE_URL,
+} from "./synthetic-models.js";
+
+describe("SYNTHETIC_MODEL_CATALOG", () => {
+  it("contains at least one model", () => {
+    expect(SYNTHETIC_MODEL_CATALOG.length).toBeGreaterThan(0);
+  });
+
+  it("all entries have required fields", () => {
+    for (const entry of SYNTHETIC_MODEL_CATALOG) {
+      expect(entry.id).toBeTruthy();
+      expect(entry.name).toBeTruthy();
+      expect(typeof entry.reasoning).toBe("boolean");
+      expect(entry.input.length).toBeGreaterThan(0);
+      expect(entry.contextWindow).toBeGreaterThan(0);
+      expect(entry.maxTokens).toBeGreaterThan(0);
+    }
+  });
+
+  it("has unique model IDs", () => {
+    const ids = SYNTHETIC_MODEL_CATALOG.map((e) => e.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("includes the default model", () => {
+    const found = SYNTHETIC_MODEL_CATALOG.find((e) => e.id === SYNTHETIC_DEFAULT_MODEL_ID);
+    expect(found).toBeDefined();
+  });
+});
+
+describe("buildSyntheticModelDefinition", () => {
+  it("builds definition from catalog entry", () => {
+    const entry = SYNTHETIC_MODEL_CATALOG[0];
+    const def = buildSyntheticModelDefinition(entry);
+    expect(def.id).toBe(entry.id);
+    expect(def.name).toBe(entry.name);
+    expect(def.reasoning).toBe(entry.reasoning);
+    expect(def.contextWindow).toBe(entry.contextWindow);
+    expect(def.maxTokens).toBe(entry.maxTokens);
+    expect(def.cost).toEqual(SYNTHETIC_DEFAULT_COST);
+  });
+
+  it("copies input array (not shared reference)", () => {
+    const entry = SYNTHETIC_MODEL_CATALOG[0];
+    const def = buildSyntheticModelDefinition(entry);
+    expect(def.input).toEqual([...entry.input]);
+    expect(def.input).not.toBe(entry.input);
+  });
+});
+
+describe("constants", () => {
+  it("SYNTHETIC_BASE_URL is a valid URL", () => {
+    expect(() => new URL(SYNTHETIC_BASE_URL)).not.toThrow();
+  });
+
+  it("SYNTHETIC_DEFAULT_COST has zero costs", () => {
+    expect(SYNTHETIC_DEFAULT_COST.input).toBe(0);
+    expect(SYNTHETIC_DEFAULT_COST.output).toBe(0);
+    expect(SYNTHETIC_DEFAULT_COST.cacheRead).toBe(0);
+    expect(SYNTHETIC_DEFAULT_COST.cacheWrite).toBe(0);
+  });
+});

--- a/src/agents/task-classifier.ts
+++ b/src/agents/task-classifier.ts
@@ -1,0 +1,159 @@
+/**
+ * Task Classifier - 根據消息內容推斷任務類型
+ *
+ * 用於 smart-router hook 選擇最適合的模型
+ */
+
+export type TaskHint =
+  | "code"
+  | "math"
+  | "reasoning"
+  | "translation"
+  | "chinese"
+  | "chat"
+  | "complex";
+
+interface ClassificationRule {
+  hint: TaskHint;
+  patterns: RegExp[];
+  weight: number;
+}
+
+const CLASSIFICATION_RULES: ClassificationRule[] = [
+  // 代碼相關
+  {
+    hint: "code",
+    patterns: [
+      /```[\w]*\n/, // Code blocks
+      /\b(function|class|const|let|var|def|import|export|return)\b/i,
+      /\b(javascript|typescript|python|java|c\+\+|rust|go|swift)\b/i,
+      /\.(js|ts|py|java|cpp|rs|go|swift|rb|php)\b/,
+      /\b(bug|fix|refactor|implement|debug|compile|runtime)\b/i,
+      /\b(API|SDK|CLI|npm|pip|yarn|git)\b/,
+    ],
+    weight: 10,
+  },
+
+  // 數學相關
+  {
+    hint: "math",
+    patterns: [
+      /\d+\s*[+\-*/^]\s*\d+/, // Basic arithmetic
+      /\b(calculate|compute|solve|equation|formula)\b/i,
+      /\b(integral|derivative|matrix|vector|probability)\b/i,
+      /\b(數學|計算|方程|積分|微分)\b/,
+      /[∫∑∏√πθ]/, // Math symbols
+    ],
+    weight: 8,
+  },
+
+  // 推理/複雜任務
+  {
+    hint: "reasoning",
+    patterns: [
+      /\b(analyze|explain|compare|evaluate|consider)\b/i,
+      /\b(why|how come|what if|suppose|assume)\b/i,
+      /\b(pros? and cons?|trade-?offs?|advantages?|disadvantages?)\b/i,
+      /\b(分析|解釋|比較|評估|為什麼)\b/,
+    ],
+    weight: 6,
+  },
+
+  // 翻譯相關
+  {
+    hint: "translation",
+    patterns: [
+      /\b(translate|translation|翻譯|翻译)\b/i,
+      /\b(in english|in chinese|用中文|用英文)\b/i,
+      /\b(to japanese|to korean|to spanish|to french)\b/i,
+    ],
+    weight: 9,
+  },
+
+  // 中文對話
+  {
+    hint: "chinese",
+    patterns: [
+      /[\u4e00-\u9fff]{10,}/, // 10+ Chinese characters
+      /\b(中文|華語|普通話|繁體|簡體)\b/,
+    ],
+    weight: 4,
+  },
+
+  // 複雜任務（長文本）
+  {
+    hint: "complex",
+    patterns: [
+      /\b(research|investigate|comprehensive|detailed|thorough)\b/i,
+      /\b(document|report|essay|article|paper)\b/i,
+    ],
+    weight: 5,
+  },
+];
+
+/**
+ * 根據消息內容推斷任務類型
+ */
+export function classifyTask(text: string): TaskHint {
+  if (!text || typeof text !== "string") {
+    return "chat";
+  }
+
+  const scores: Record<TaskHint, number> = {
+    code: 0,
+    math: 0,
+    reasoning: 0,
+    translation: 0,
+    chinese: 0,
+    chat: 0,
+    complex: 0,
+  };
+
+  // 計算每個類型的分數
+  for (const rule of CLASSIFICATION_RULES) {
+    for (const pattern of rule.patterns) {
+      if (pattern.test(text)) {
+        scores[rule.hint] += rule.weight;
+      }
+    }
+  }
+
+  // 文本長度加分（長文本可能是複雜任務）
+  if (text.length > 2000) {
+    scores.complex += 3;
+    scores.reasoning += 2;
+  }
+
+  // 找出最高分
+  let maxHint: TaskHint = "chat";
+  let maxScore = 0;
+
+  for (const [hint, score] of Object.entries(scores) as [TaskHint, number][]) {
+    if (score > maxScore) {
+      maxScore = score;
+      maxHint = hint;
+    }
+  }
+
+  // 如果沒有明顯特徵，返回 chat
+  if (maxScore < 5) {
+    return "chat";
+  }
+
+  return maxHint;
+}
+
+/**
+ * 估算 token 數量（粗略估算）
+ */
+export function estimateTokenCount(text: string): number {
+  if (!text) {
+    return 0;
+  }
+
+  // 粗略估算：英文 ~4 chars/token，中文 ~1.5 chars/token
+  const chineseChars = (text.match(/[\u4e00-\u9fff]/g) || []).length;
+  const otherChars = text.length - chineseChars;
+
+  return Math.ceil(chineseChars / 1.5 + otherChars / 4);
+}

--- a/src/agents/tools/memory-tool.ts
+++ b/src/agents/tools/memory-tool.ts
@@ -7,7 +7,9 @@ import { resolveMemoryBackendConfig } from "../../memory/backend-config.js";
 import { getMemorySearchManager } from "../../memory/index.js";
 import { parseAgentSessionKey } from "../../routing/session-key.js";
 import { resolveSessionAgentId } from "../agent-scope.js";
+import { resolveAgentWorkspaceDir } from "../agent-scope.js";
 import { resolveMemorySearchConfig } from "../memory-search.js";
+import { resolvePathMapRoots, toLogicalPath, toPhysicalPath } from "../path-map.js";
 import { jsonResult, readNumberParam, readStringParam } from "./common.js";
 
 const MemorySearchSchema = Type.Object({
@@ -67,13 +69,20 @@ export function createMemorySearchTool(options: {
         });
         const status = manager.status();
         const decorated = decorateCitations(rawResults, includeCitations);
+        const roots = resolvePathMapRoots(cfg);
+        const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
+        const results = mapMemoryResultsToLogical({
+          results: decorated,
+          workspaceDir,
+          roots,
+        });
         const resolved = resolveMemoryBackendConfig({ cfg, agentId });
-        const results =
+        const clamped =
           status.backend === "qmd"
-            ? clampResultsByInjectedChars(decorated, resolved.qmd?.limits.maxInjectedChars)
-            : decorated;
+            ? clampResultsByInjectedChars(results, resolved.qmd?.limits.maxInjectedChars)
+            : results;
         return jsonResult({
-          results,
+          results: clamped,
           provider: status.provider,
           model: status.model,
           fallback: status.fallback,
@@ -120,12 +129,15 @@ export function createMemoryGetTool(options: {
         return jsonResult({ path: relPath, text: "", disabled: true, error });
       }
       try {
+        const roots = resolvePathMapRoots(cfg);
+        const physicalPath = toPhysicalPath(relPath, roots);
         const result = await manager.readFile({
-          relPath,
+          relPath: physicalPath,
           from: from ?? undefined,
           lines: lines ?? undefined,
         });
-        return jsonResult(result);
+        const logicalPath = toLogicalPath(result.path, roots);
+        return jsonResult({ ...result, path: logicalPath });
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         return jsonResult({ path: relPath, text: "", disabled: true, error: message });
@@ -159,6 +171,30 @@ function formatCitation(entry: MemorySearchResult): string {
       ? `#L${entry.startLine}`
       : `#L${entry.startLine}-L${entry.endLine}`;
   return `${entry.path}${lineRange}`;
+}
+
+function mapMemoryResultsToLogical(params: {
+  results: MemorySearchResult[];
+  workspaceDir: string;
+  roots: Record<string, string>;
+}): MemorySearchResult[] {
+  const { results, workspaceDir, roots } = params;
+  if (!roots || Object.keys(roots).length === 0) {
+    return results;
+  }
+  return results.map((entry) => {
+    if (!entry.path) {
+      return entry;
+    }
+    const abs = entry.path.startsWith("/")
+      ? entry.path
+      : `${workspaceDir.replace(/\/$/, "")}/${entry.path}`;
+    const logical = toLogicalPath(abs, roots);
+    if (logical === entry.path) {
+      return entry;
+    }
+    return { ...entry, path: logical };
+  });
 }
 
 function clampResultsByInjectedChars(

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -93,19 +93,6 @@ export type WorkspaceBootstrapFile = {
   missing: boolean;
 };
 
-/** Set of recognized bootstrap filenames for runtime validation */
-const VALID_BOOTSTRAP_NAMES: ReadonlySet<string> = new Set([
-  DEFAULT_AGENTS_FILENAME,
-  DEFAULT_SOUL_FILENAME,
-  DEFAULT_TOOLS_FILENAME,
-  DEFAULT_IDENTITY_FILENAME,
-  DEFAULT_USER_FILENAME,
-  DEFAULT_HEARTBEAT_FILENAME,
-  DEFAULT_BOOTSTRAP_FILENAME,
-  DEFAULT_MEMORY_FILENAME,
-  DEFAULT_MEMORY_ALT_FILENAME,
-]);
-
 async function writeFileIfMissing(filePath: string, content: string) {
   try {
     await fs.writeFile(filePath, content, {
@@ -173,6 +160,7 @@ export async function ensureAgentWorkspace(params?: {
   toolsPath?: string;
   identityPath?: string;
   userPath?: string;
+  heartbeatPath?: string;
   bootstrapPath?: string;
 }> {
   const rawDir = params?.dir?.trim() ? params.dir.trim() : DEFAULT_AGENT_WORKSPACE_DIR;
@@ -188,13 +176,11 @@ export async function ensureAgentWorkspace(params?: {
   const toolsPath = path.join(dir, DEFAULT_TOOLS_FILENAME);
   const identityPath = path.join(dir, DEFAULT_IDENTITY_FILENAME);
   const userPath = path.join(dir, DEFAULT_USER_FILENAME);
-  // HEARTBEAT.md is intentionally NOT created from template.
-  // Per docs: "If the file is missing, the heartbeat still runs and the model decides what to do."
-  // Creating it from template (which is effectively empty) would cause heartbeat to be skipped.
+  const heartbeatPath = path.join(dir, DEFAULT_HEARTBEAT_FILENAME);
   const bootstrapPath = path.join(dir, DEFAULT_BOOTSTRAP_FILENAME);
 
   const isBrandNewWorkspace = await (async () => {
-    const paths = [agentsPath, soulPath, toolsPath, identityPath, userPath];
+    const paths = [agentsPath, soulPath, toolsPath, identityPath, userPath, heartbeatPath];
     const existing = await Promise.all(
       paths.map(async (p) => {
         try {
@@ -213,6 +199,7 @@ export async function ensureAgentWorkspace(params?: {
   const toolsTemplate = await loadTemplate(DEFAULT_TOOLS_FILENAME);
   const identityTemplate = await loadTemplate(DEFAULT_IDENTITY_FILENAME);
   const userTemplate = await loadTemplate(DEFAULT_USER_FILENAME);
+  const heartbeatTemplate = await loadTemplate(DEFAULT_HEARTBEAT_FILENAME);
   const bootstrapTemplate = await loadTemplate(DEFAULT_BOOTSTRAP_FILENAME);
 
   await writeFileIfMissing(agentsPath, agentsTemplate);
@@ -220,6 +207,7 @@ export async function ensureAgentWorkspace(params?: {
   await writeFileIfMissing(toolsPath, toolsTemplate);
   await writeFileIfMissing(identityPath, identityTemplate);
   await writeFileIfMissing(userPath, userTemplate);
+  await writeFileIfMissing(heartbeatPath, heartbeatTemplate);
   if (isBrandNewWorkspace) {
     await writeFileIfMissing(bootstrapPath, bootstrapTemplate);
   }
@@ -232,6 +220,7 @@ export async function ensureAgentWorkspace(params?: {
     toolsPath,
     identityPath,
     userPath,
+    heartbeatPath,
     bootstrapPath,
   };
 }
@@ -329,7 +318,11 @@ export async function loadWorkspaceBootstrapFiles(dir: string): Promise<Workspac
   return result;
 }
 
-const SUBAGENT_BOOTSTRAP_ALLOWLIST = new Set([DEFAULT_AGENTS_FILENAME, DEFAULT_TOOLS_FILENAME]);
+const SUBAGENT_BOOTSTRAP_ALLOWLIST = new Set([
+  DEFAULT_AGENTS_FILENAME,
+  DEFAULT_TOOLS_FILENAME,
+  DEFAULT_SOUL_FILENAME,
+]);
 
 export function filterBootstrapFilesForSession(
   files: WorkspaceBootstrapFile[],
@@ -339,72 +332,4 @@ export function filterBootstrapFilesForSession(
     return files;
   }
   return files.filter((file) => SUBAGENT_BOOTSTRAP_ALLOWLIST.has(file.name));
-}
-
-export async function loadExtraBootstrapFiles(
-  dir: string,
-  extraPatterns: string[],
-): Promise<WorkspaceBootstrapFile[]> {
-  if (!extraPatterns.length) {
-    return [];
-  }
-  const resolvedDir = resolveUserPath(dir);
-  let realResolvedDir = resolvedDir;
-  try {
-    realResolvedDir = await fs.realpath(resolvedDir);
-  } catch {
-    // Keep lexical root if realpath fails.
-  }
-
-  // Resolve glob patterns into concrete file paths
-  const resolvedPaths = new Set<string>();
-  for (const pattern of extraPatterns) {
-    if (pattern.includes("*") || pattern.includes("?") || pattern.includes("{")) {
-      try {
-        const matches = fs.glob(pattern, { cwd: resolvedDir });
-        for await (const m of matches) {
-          resolvedPaths.add(m);
-        }
-      } catch {
-        // glob not available or pattern error — fall back to literal
-        resolvedPaths.add(pattern);
-      }
-    } else {
-      resolvedPaths.add(pattern);
-    }
-  }
-
-  const result: WorkspaceBootstrapFile[] = [];
-  for (const relPath of resolvedPaths) {
-    const filePath = path.resolve(resolvedDir, relPath);
-    // Guard against path traversal — resolved path must stay within workspace
-    if (!filePath.startsWith(resolvedDir + path.sep) && filePath !== resolvedDir) {
-      continue;
-    }
-    try {
-      // Resolve symlinks and verify the real path is still within workspace
-      const realFilePath = await fs.realpath(filePath);
-      if (
-        !realFilePath.startsWith(realResolvedDir + path.sep) &&
-        realFilePath !== realResolvedDir
-      ) {
-        continue;
-      }
-      // Only load files whose basename is a recognized bootstrap filename
-      const baseName = path.basename(relPath);
-      if (!VALID_BOOTSTRAP_NAMES.has(baseName)) {
-        continue;
-      }
-      const content = await fs.readFile(realFilePath, "utf-8");
-      result.push({
-        name: baseName as WorkspaceBootstrapFileName,
-        path: filePath,
-        content,
-        missing: false,
-      });
-    } catch {
-      // Silently skip missing extra files
-    }
-  }
-  return result;
 }

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -101,6 +101,7 @@ export async function runMemoryFlushIfNeeded(params: {
       provider: params.followupRun.run.provider,
       model: params.followupRun.run.model,
       agentDir: params.followupRun.run.agentDir,
+      sessionKey: params.followupRun.run.sessionKey,
       fallbacksOverride: resolveAgentModelFallbacksOverride(
         params.followupRun.run.config,
         resolveAgentIdFromSessionKey(params.followupRun.run.sessionKey),

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -129,6 +129,7 @@ export function createFollowupRunner(params: {
           provider: queued.run.provider,
           model: queued.run.model,
           agentDir: queued.run.agentDir,
+          sessionKey: queued.run.sessionKey,
           fallbacksOverride: resolveAgentModelFallbacksOverride(
             queued.run.config,
             resolveAgentIdFromSessionKey(queued.run.sessionKey),

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -13,12 +13,15 @@ import {
 import { getRemoteSkillEligibility } from "../../infra/skills-remote.js";
 import { drainSystemEventEntries } from "../../infra/system-events.js";
 
-export async function prependSystemEvents(params: {
+/**
+ * Build the system events block string (drains the event queue).
+ * Returns empty string if no events are queued.
+ */
+export async function buildSystemEventsBlock(params: {
   cfg: OpenClawConfig;
   sessionKey: string;
   isMainSession: boolean;
   isNewSession: boolean;
-  prefixedBodyBase: string;
 }): Promise<string> {
   const compactSystemEvent = (line: string): string | null => {
     const trimmed = line.trim();
@@ -104,10 +107,23 @@ export async function prependSystemEvents(params: {
     }
   }
   if (systemLines.length === 0) {
-    return params.prefixedBodyBase;
+    return "";
   }
 
-  const block = systemLines.map((l) => `System: ${l}`).join("\n");
+  return systemLines.map((l) => `System: ${l}`).join("\n");
+}
+
+export async function prependSystemEvents(params: {
+  cfg: OpenClawConfig;
+  sessionKey: string;
+  isMainSession: boolean;
+  isNewSession: boolean;
+  prefixedBodyBase: string;
+}): Promise<string> {
+  const block = await buildSystemEventsBlock(params);
+  if (!block) {
+    return params.prefixedBodyBase;
+  }
   return `${block}\n\n${params.prefixedBodyBase}`;
 }
 

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -387,6 +387,7 @@ export async function agentCommand(
         provider,
         model,
         agentDir,
+        sessionKey,
         fallbacksOverride: resolveAgentModelFallbacksOverride(cfg, sessionAgentId),
         run: (providerOverride, modelOverride) => {
           if (isCliProvider(providerOverride, cfg)) {

--- a/src/commands/onboard-non-interactive/local/workspace.ts
+++ b/src/commands/onboard-non-interactive/local/workspace.ts
@@ -12,5 +12,13 @@ export function resolveNonInteractiveWorkspaceDir(params: {
     params.baseConfig.agents?.defaults?.workspace ??
     params.defaultWorkspaceDir
   ).trim();
-  return resolveUserPath(raw);
+  let resolved = resolveUserPath(raw);
+
+  // Docker container safety: if the workspace path looks like a macOS/host path
+  // but we're in a Linux container, fall back to the container-native default.
+  if (process.platform === "linux" && resolved.startsWith("/Users/")) {
+    resolved = resolveUserPath(params.defaultWorkspaceDir);
+  }
+
+  return resolved;
 }

--- a/src/config/agent-dirs.test.ts
+++ b/src/config/agent-dirs.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "./types.js";
-import { findDuplicateAgentDirs } from "./agent-dirs.js";
+import {
+  findDuplicateAgentDirs,
+  formatDuplicateAgentDirError,
+  type DuplicateAgentDir,
+} from "./agent-dirs.js";
 
 afterEach(() => {
   vi.unstubAllEnvs();
@@ -43,5 +47,42 @@ describe("resolveEffectiveAgentDir via findDuplicateAgentDirs", () => {
     // No duplicates for a single default agent
     const dupes = findDuplicateAgentDirs(cfg, { env });
     expect(dupes).toHaveLength(0);
+  });
+});
+
+describe("formatDuplicateAgentDirError", () => {
+  it("formats a single conflict", () => {
+    const dups: DuplicateAgentDir[] = [
+      { agentDir: "/home/user/.openclaw/agents/shared", agentIds: ["agent-a", "agent-b"] },
+    ];
+    const result = formatDuplicateAgentDirError(dups);
+    expect(result).toContain("Duplicate agentDir detected");
+    expect(result).toContain("/home/user/.openclaw/agents/shared");
+    expect(result).toContain('"agent-a"');
+    expect(result).toContain('"agent-b"');
+  });
+
+  it("formats multiple conflicts", () => {
+    const dups: DuplicateAgentDir[] = [
+      { agentDir: "/path/a", agentIds: ["x", "y"] },
+      { agentDir: "/path/b", agentIds: ["p", "q", "r"] },
+    ];
+    const result = formatDuplicateAgentDirError(dups);
+    expect(result).toContain("/path/a");
+    expect(result).toContain("/path/b");
+    expect(result).toContain('"r"');
+  });
+
+  it("includes fix suggestion", () => {
+    const dups: DuplicateAgentDir[] = [{ agentDir: "/dir", agentIds: ["a", "b"] }];
+    const result = formatDuplicateAgentDirError(dups);
+    expect(result).toContain("Fix:");
+    expect(result).toContain("auth-profiles.json");
+  });
+
+  it("handles empty array", () => {
+    const result = formatDuplicateAgentDirError([]);
+    expect(result).toContain("Duplicate agentDir detected");
+    expect(result).not.toContain("- /");
   });
 });

--- a/src/config/cache-utils.test.ts
+++ b/src/config/cache-utils.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { resolveCacheTtlMs, isCacheEnabled } from "./cache-utils.js";
+
+describe("resolveCacheTtlMs", () => {
+  it("returns default when envValue is undefined", () => {
+    expect(resolveCacheTtlMs({ envValue: undefined, defaultTtlMs: 5000 })).toBe(5000);
+  });
+
+  it("returns default when envValue is empty string", () => {
+    expect(resolveCacheTtlMs({ envValue: "", defaultTtlMs: 5000 })).toBe(5000);
+  });
+
+  it("parses valid numeric envValue", () => {
+    expect(resolveCacheTtlMs({ envValue: "10000", defaultTtlMs: 5000 })).toBe(10000);
+  });
+
+  it("returns 0 when envValue is '0' (cache disabled)", () => {
+    expect(resolveCacheTtlMs({ envValue: "0", defaultTtlMs: 5000 })).toBe(0);
+  });
+
+  it("returns default for non-numeric envValue", () => {
+    expect(resolveCacheTtlMs({ envValue: "abc", defaultTtlMs: 5000 })).toBe(5000);
+  });
+
+  it("returns default for negative envValue", () => {
+    expect(resolveCacheTtlMs({ envValue: "-1", defaultTtlMs: 5000 })).toBe(5000);
+  });
+
+  it("handles large values", () => {
+    expect(resolveCacheTtlMs({ envValue: "86400000", defaultTtlMs: 5000 })).toBe(86400000);
+  });
+});
+
+describe("isCacheEnabled", () => {
+  it("returns true for positive TTL", () => {
+    expect(isCacheEnabled(5000)).toBe(true);
+    expect(isCacheEnabled(1)).toBe(true);
+  });
+
+  it("returns false for zero TTL", () => {
+    expect(isCacheEnabled(0)).toBe(false);
+  });
+
+  it("returns false for negative TTL", () => {
+    expect(isCacheEnabled(-1)).toBe(false);
+  });
+});

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { isDeepStrictEqual } from "node:util";
 import type { OpenClawConfig, ConfigFileSnapshot, LegacyConfigIssue } from "./types.js";
+import { normalizePathMapRoots } from "../agents/path-map.js";
 import { loadDotEnv } from "../infra/dotenv.js";
 import { resolveRequiredHomeDir } from "../infra/home-dir.js";
 import {
@@ -25,12 +26,7 @@ import {
   applySessionDefaults,
   applyTalkApiKey,
 } from "./defaults.js";
-import { restoreEnvVarRefs } from "./env-preserve.js";
-import {
-  MissingEnvVarError,
-  containsEnvVarReference,
-  resolveConfigEnvVars,
-} from "./env-substitution.js";
+import { MissingEnvVarError, resolveConfigEnvVars } from "./env-substitution.js";
 import { collectConfigEnvVars } from "./env-vars.js";
 import { ConfigIncludeError, resolveConfigIncludes } from "./includes.js";
 import { findLegacyConfigIssues } from "./legacy.js";
@@ -68,58 +64,9 @@ const SHELL_ENV_EXPECTED_KEYS = [
 ];
 
 const CONFIG_BACKUP_COUNT = 5;
-const CONFIG_AUDIT_LOG_FILENAME = "config-audit.jsonl";
 const loggedInvalidConfigs = new Set<string>();
 
-type ConfigWriteAuditResult = "rename" | "copy-fallback" | "failed";
-
-type ConfigWriteAuditRecord = {
-  ts: string;
-  source: "config-io";
-  event: "config.write";
-  result: ConfigWriteAuditResult;
-  configPath: string;
-  pid: number;
-  ppid: number;
-  cwd: string;
-  argv: string[];
-  execArgv: string[];
-  watchMode: boolean;
-  watchSession: string | null;
-  watchCommand: string | null;
-  existsBefore: boolean;
-  previousHash: string | null;
-  nextHash: string | null;
-  previousBytes: number | null;
-  nextBytes: number | null;
-  changedPathCount: number | null;
-  hasMetaBefore: boolean;
-  hasMetaAfter: boolean;
-  gatewayModeBefore: string | null;
-  gatewayModeAfter: string | null;
-  suspicious: string[];
-  errorCode?: string;
-  errorMessage?: string;
-};
-
 export type ParseConfigJson5Result = { ok: true; parsed: unknown } | { ok: false; error: string };
-export type ConfigWriteOptions = {
-  /**
-   * Read-time env snapshot used to validate `${VAR}` restoration decisions.
-   * If omitted, write falls back to current process env.
-   */
-  envSnapshotForRestore?: Record<string, string | undefined>;
-  /**
-   * Optional safety check: only use envSnapshotForRestore when writing the
-   * same config file path that produced the snapshot.
-   */
-  expectedConfigPath?: string;
-};
-
-export type ReadConfigFileSnapshotForWriteResult = {
-  snapshot: ConfigFileSnapshot;
-  writeOptions: ConfigWriteOptions;
-};
 
 function hashConfigRaw(raw: string | null): string {
   return crypto
@@ -153,26 +100,6 @@ function coerceConfig(value: unknown): OpenClawConfig {
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function hasConfigMeta(value: unknown): boolean {
-  if (!isPlainObject(value)) {
-    return false;
-  }
-  const meta = value.meta;
-  return isPlainObject(meta);
-}
-
-function resolveGatewayMode(value: unknown): string | null {
-  if (!isPlainObject(value)) {
-    return null;
-  }
-  const gateway = value.gateway;
-  if (!isPlainObject(gateway) || typeof gateway.mode !== "string") {
-    return null;
-  }
-  const trimmed = gateway.mode.trim();
-  return trimmed.length > 0 ? trimmed : null;
 }
 
 function cloneUnknown<T>(value: T): T {
@@ -214,132 +141,6 @@ function createMergePatch(base: unknown, target: unknown): unknown {
   return patch;
 }
 
-function collectEnvRefPaths(value: unknown, path: string, output: Map<string, string>): void {
-  if (typeof value === "string") {
-    if (containsEnvVarReference(value)) {
-      output.set(path, value);
-    }
-    return;
-  }
-  if (Array.isArray(value)) {
-    value.forEach((item, index) => {
-      collectEnvRefPaths(item, `${path}[${index}]`, output);
-    });
-    return;
-  }
-  if (isPlainObject(value)) {
-    for (const [key, child] of Object.entries(value)) {
-      const childPath = path ? `${path}.${key}` : key;
-      collectEnvRefPaths(child, childPath, output);
-    }
-  }
-}
-
-function collectChangedPaths(
-  base: unknown,
-  target: unknown,
-  path: string,
-  output: Set<string>,
-): void {
-  if (Array.isArray(base) && Array.isArray(target)) {
-    const max = Math.max(base.length, target.length);
-    for (let index = 0; index < max; index += 1) {
-      const childPath = path ? `${path}[${index}]` : `[${index}]`;
-      if (index >= base.length || index >= target.length) {
-        output.add(childPath);
-        continue;
-      }
-      collectChangedPaths(base[index], target[index], childPath, output);
-    }
-    return;
-  }
-  if (isPlainObject(base) && isPlainObject(target)) {
-    const keys = new Set([...Object.keys(base), ...Object.keys(target)]);
-    for (const key of keys) {
-      const childPath = path ? `${path}.${key}` : key;
-      const hasBase = key in base;
-      const hasTarget = key in target;
-      if (!hasTarget || !hasBase) {
-        output.add(childPath);
-        continue;
-      }
-      collectChangedPaths(base[key], target[key], childPath, output);
-    }
-    return;
-  }
-  if (!isDeepStrictEqual(base, target)) {
-    output.add(path);
-  }
-}
-
-function parentPath(value: string): string {
-  if (!value) {
-    return "";
-  }
-  if (value.endsWith("]")) {
-    const index = value.lastIndexOf("[");
-    return index > 0 ? value.slice(0, index) : "";
-  }
-  const index = value.lastIndexOf(".");
-  return index >= 0 ? value.slice(0, index) : "";
-}
-
-function isPathChanged(path: string, changedPaths: Set<string>): boolean {
-  if (changedPaths.has(path)) {
-    return true;
-  }
-  let current = parentPath(path);
-  while (current) {
-    if (changedPaths.has(current)) {
-      return true;
-    }
-    current = parentPath(current);
-  }
-  return changedPaths.has("");
-}
-
-function restoreEnvRefsFromMap(
-  value: unknown,
-  path: string,
-  envRefMap: Map<string, string>,
-  changedPaths: Set<string>,
-): unknown {
-  if (typeof value === "string") {
-    if (!isPathChanged(path, changedPaths)) {
-      const original = envRefMap.get(path);
-      if (original !== undefined) {
-        return original;
-      }
-    }
-    return value;
-  }
-  if (Array.isArray(value)) {
-    let changed = false;
-    const next = value.map((item, index) => {
-      const updated = restoreEnvRefsFromMap(item, `${path}[${index}]`, envRefMap, changedPaths);
-      if (updated !== item) {
-        changed = true;
-      }
-      return updated;
-    });
-    return changed ? next : value;
-  }
-  if (isPlainObject(value)) {
-    let changed = false;
-    const next: Record<string, unknown> = {};
-    for (const [key, child] of Object.entries(value)) {
-      const childPath = path ? `${path}.${key}` : key;
-      const updated = restoreEnvRefsFromMap(child, childPath, envRefMap, changedPaths);
-      if (updated !== child) {
-        changed = true;
-      }
-      next[key] = updated;
-    }
-    return changed ? next : value;
-  }
-  return value;
-}
-
 async function rotateConfigBackups(configPath: string, ioFs: typeof fs.promises): Promise<void> {
   if (CONFIG_BACKUP_COUNT <= 1) {
     return;
@@ -357,55 +158,6 @@ async function rotateConfigBackups(configPath: string, ioFs: typeof fs.promises)
   await ioFs.rename(backupBase, `${backupBase}.1`).catch(() => {
     // best-effort
   });
-}
-
-function resolveConfigAuditLogPath(env: NodeJS.ProcessEnv, homedir: () => string): string {
-  return path.join(resolveStateDir(env, homedir), "logs", CONFIG_AUDIT_LOG_FILENAME);
-}
-
-function resolveConfigWriteSuspiciousReasons(params: {
-  existsBefore: boolean;
-  previousBytes: number | null;
-  nextBytes: number | null;
-  hasMetaBefore: boolean;
-  gatewayModeBefore: string | null;
-  gatewayModeAfter: string | null;
-}): string[] {
-  const reasons: string[] = [];
-  if (!params.existsBefore) {
-    return reasons;
-  }
-  if (
-    typeof params.previousBytes === "number" &&
-    typeof params.nextBytes === "number" &&
-    params.previousBytes >= 512 &&
-    params.nextBytes < Math.floor(params.previousBytes * 0.5)
-  ) {
-    reasons.push(`size-drop:${params.previousBytes}->${params.nextBytes}`);
-  }
-  if (!params.hasMetaBefore) {
-    reasons.push("missing-meta-before-write");
-  }
-  if (params.gatewayModeBefore && !params.gatewayModeAfter) {
-    reasons.push("gateway-mode-removed");
-  }
-  return reasons;
-}
-
-async function appendConfigWriteAuditRecord(
-  deps: Required<ConfigIoDeps>,
-  record: ConfigWriteAuditRecord,
-): Promise<void> {
-  try {
-    const auditPath = resolveConfigAuditLogPath(deps.env, deps.homedir);
-    await deps.fs.promises.mkdir(path.dirname(auditPath), { recursive: true, mode: 0o700 });
-    await deps.fs.promises.appendFile(auditPath, `${JSON.stringify(record)}\n`, {
-      encoding: "utf-8",
-      mode: 0o600,
-    });
-  } catch {
-    // best-effort
-  }
 }
 
 export type ConfigIoDeps = {
@@ -509,43 +261,6 @@ export function parseConfigJson5(
   }
 }
 
-type ConfigReadResolution = {
-  resolvedConfigRaw: unknown;
-  envSnapshotForRestore: Record<string, string | undefined>;
-};
-
-function resolveConfigIncludesForRead(
-  parsed: unknown,
-  configPath: string,
-  deps: Required<ConfigIoDeps>,
-): unknown {
-  return resolveConfigIncludes(parsed, configPath, {
-    readFile: (candidate) => deps.fs.readFileSync(candidate, "utf-8"),
-    parseJson: (raw) => deps.json5.parse(raw),
-  });
-}
-
-function resolveConfigForRead(
-  resolvedIncludes: unknown,
-  env: NodeJS.ProcessEnv,
-): ConfigReadResolution {
-  // Apply config.env to process.env BEFORE substitution so ${VAR} can reference config-defined vars.
-  if (resolvedIncludes && typeof resolvedIncludes === "object" && "env" in resolvedIncludes) {
-    applyConfigEnv(resolvedIncludes as OpenClawConfig, env);
-  }
-
-  return {
-    resolvedConfigRaw: resolveConfigEnvVars(resolvedIncludes, env),
-    // Capture env snapshot after substitution for write-time ${VAR} restoration.
-    envSnapshotForRestore: { ...env } as Record<string, string | undefined>,
-  };
-}
-
-type ReadConfigFileSnapshotInternalResult = {
-  snapshot: ConfigFileSnapshot;
-  envSnapshotForRestore?: Record<string, string | undefined>;
-};
-
 export function createConfigIO(overrides: ConfigIoDeps = {}) {
   const deps = normalizeDeps(overrides);
   const requestedConfigPath = resolveConfigPathForDeps(deps);
@@ -572,10 +287,22 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       }
       const raw = deps.fs.readFileSync(configPath, "utf-8");
       const parsed = deps.json5.parse(raw);
-      const { resolvedConfigRaw: resolvedConfig } = resolveConfigForRead(
-        resolveConfigIncludesForRead(parsed, configPath, deps),
-        deps.env,
-      );
+
+      // Resolve $include directives before validation
+      const resolved = resolveConfigIncludes(parsed, configPath, {
+        readFile: (p) => deps.fs.readFileSync(p, "utf-8"),
+        parseJson: (raw) => deps.json5.parse(raw),
+      });
+
+      // Apply config.env to process.env BEFORE substitution so ${VAR} can reference config-defined vars
+      if (resolved && typeof resolved === "object" && "env" in resolved) {
+        applyConfigEnv(resolved as OpenClawConfig, deps.env);
+      }
+
+      // Substitute ${VAR} env var references
+      const substituted = resolveConfigEnvVars(resolved, deps.env);
+
+      const resolvedConfig = substituted;
       warnOnConfigMiskeys(resolvedConfig, deps.logger);
       if (typeof resolvedConfig !== "object" || resolvedConfig === null) {
         return {};
@@ -629,6 +356,14 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
 
       applyConfigEnv(cfg, deps.env);
 
+      // If pathMap roots are set in config, expose them to runtime via env (opt-in).
+      if (!deps.env.OPENCLAW_PATHMAP_ROOTS && cfg.pathMap?.roots) {
+        const roots = normalizePathMapRoots(cfg.pathMap.roots);
+        if (Object.keys(roots).length > 0) {
+          deps.env.OPENCLAW_PATHMAP_ROOTS = JSON.stringify(roots);
+        }
+      }
+
       const enabled = shouldEnableShellEnvFallback(deps.env) || cfg.env?.shellEnv?.enabled === true;
       if (enabled && !shouldDeferShellEnvFallback(deps.env)) {
         loadShellEnvFallback({
@@ -655,7 +390,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
     }
   }
 
-  async function readConfigFileSnapshotInternal(): Promise<ReadConfigFileSnapshotInternalResult> {
+  async function readConfigFileSnapshot(): Promise<ConfigFileSnapshot> {
     maybeLoadDotEnvForConfig(deps.env);
     const exists = deps.fs.existsSync(configPath);
     if (!exists) {
@@ -671,19 +406,17 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       );
       const legacyIssues: LegacyConfigIssue[] = [];
       return {
-        snapshot: {
-          path: configPath,
-          exists: false,
-          raw: null,
-          parsed: {},
-          resolved: {},
-          valid: true,
-          config,
-          hash,
-          issues: [],
-          warnings: [],
-          legacyIssues,
-        },
+        path: configPath,
+        exists: false,
+        raw: null,
+        parsed: {},
+        resolved: {},
+        valid: true,
+        config,
+        hash,
+        issues: [],
+        warnings: [],
+        legacyIssues,
       };
     }
 
@@ -693,183 +426,144 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       const parsedRes = parseConfigJson5(raw, deps.json5);
       if (!parsedRes.ok) {
         return {
-          snapshot: {
-            path: configPath,
-            exists: true,
-            raw,
-            parsed: {},
-            resolved: {},
-            valid: false,
-            config: {},
-            hash,
-            issues: [{ path: "", message: `JSON5 parse failed: ${parsedRes.error}` }],
-            warnings: [],
-            legacyIssues: [],
-          },
+          path: configPath,
+          exists: true,
+          raw,
+          parsed: {},
+          resolved: {},
+          valid: false,
+          config: {},
+          hash,
+          issues: [{ path: "", message: `JSON5 parse failed: ${parsedRes.error}` }],
+          warnings: [],
+          legacyIssues: [],
         };
       }
 
       // Resolve $include directives
       let resolved: unknown;
       try {
-        resolved = resolveConfigIncludesForRead(parsedRes.parsed, configPath, deps);
+        resolved = resolveConfigIncludes(parsedRes.parsed, configPath, {
+          readFile: (p) => deps.fs.readFileSync(p, "utf-8"),
+          parseJson: (raw) => deps.json5.parse(raw),
+        });
       } catch (err) {
         const message =
           err instanceof ConfigIncludeError
             ? err.message
             : `Include resolution failed: ${String(err)}`;
         return {
-          snapshot: {
-            path: configPath,
-            exists: true,
-            raw,
-            parsed: parsedRes.parsed,
-            resolved: coerceConfig(parsedRes.parsed),
-            valid: false,
-            config: coerceConfig(parsedRes.parsed),
-            hash,
-            issues: [{ path: "", message }],
-            warnings: [],
-            legacyIssues: [],
-          },
+          path: configPath,
+          exists: true,
+          raw,
+          parsed: parsedRes.parsed,
+          resolved: coerceConfig(parsedRes.parsed),
+          valid: false,
+          config: coerceConfig(parsedRes.parsed),
+          hash,
+          issues: [{ path: "", message }],
+          warnings: [],
+          legacyIssues: [],
         };
       }
 
-      let readResolution: ConfigReadResolution;
+      // Apply config.env to process.env BEFORE substitution so ${VAR} can reference config-defined vars
+      if (resolved && typeof resolved === "object" && "env" in resolved) {
+        applyConfigEnv(resolved as OpenClawConfig, deps.env);
+      }
+
+      // Substitute ${VAR} env var references
+      let substituted: unknown;
       try {
-        readResolution = resolveConfigForRead(resolved, deps.env);
+        substituted = resolveConfigEnvVars(resolved, deps.env);
       } catch (err) {
         const message =
           err instanceof MissingEnvVarError
             ? err.message
             : `Env var substitution failed: ${String(err)}`;
         return {
-          snapshot: {
-            path: configPath,
-            exists: true,
-            raw,
-            parsed: parsedRes.parsed,
-            resolved: coerceConfig(resolved),
-            valid: false,
-            config: coerceConfig(resolved),
-            hash,
-            issues: [{ path: "", message }],
-            warnings: [],
-            legacyIssues: [],
-          },
+          path: configPath,
+          exists: true,
+          raw,
+          parsed: parsedRes.parsed,
+          resolved: coerceConfig(resolved),
+          valid: false,
+          config: coerceConfig(resolved),
+          hash,
+          issues: [{ path: "", message }],
+          warnings: [],
+          legacyIssues: [],
         };
       }
 
-      const resolvedConfigRaw = readResolution.resolvedConfigRaw;
+      const resolvedConfigRaw = substituted;
       const legacyIssues = findLegacyConfigIssues(resolvedConfigRaw);
 
       const validated = validateConfigObjectWithPlugins(resolvedConfigRaw);
       if (!validated.ok) {
         return {
-          snapshot: {
-            path: configPath,
-            exists: true,
-            raw,
-            parsed: parsedRes.parsed,
-            resolved: coerceConfig(resolvedConfigRaw),
-            valid: false,
-            config: coerceConfig(resolvedConfigRaw),
-            hash,
-            issues: validated.issues,
-            warnings: validated.warnings,
-            legacyIssues,
-          },
+          path: configPath,
+          exists: true,
+          raw,
+          parsed: parsedRes.parsed,
+          resolved: coerceConfig(resolvedConfigRaw),
+          valid: false,
+          config: coerceConfig(resolvedConfigRaw),
+          hash,
+          issues: validated.issues,
+          warnings: validated.warnings,
+          legacyIssues,
         };
       }
 
       warnIfConfigFromFuture(validated.config, deps.logger);
       return {
-        snapshot: {
-          path: configPath,
-          exists: true,
-          raw,
-          parsed: parsedRes.parsed,
-          // Use resolvedConfigRaw (after $include and ${ENV} substitution but BEFORE runtime defaults)
-          // for config set/unset operations (issue #6070)
-          resolved: coerceConfig(resolvedConfigRaw),
-          valid: true,
-          config: normalizeConfigPaths(
-            applyTalkApiKey(
-              applyModelDefaults(
-                applyAgentDefaults(
-                  applySessionDefaults(
-                    applyLoggingDefaults(applyMessageDefaults(validated.config)),
-                  ),
-                ),
+        path: configPath,
+        exists: true,
+        raw,
+        parsed: parsedRes.parsed,
+        // Use resolvedConfigRaw (after $include and ${ENV} substitution but BEFORE runtime defaults)
+        // for config set/unset operations (issue #6070)
+        resolved: coerceConfig(resolvedConfigRaw),
+        valid: true,
+        config: normalizeConfigPaths(
+          applyTalkApiKey(
+            applyModelDefaults(
+              applyAgentDefaults(
+                applySessionDefaults(applyLoggingDefaults(applyMessageDefaults(validated.config))),
               ),
             ),
           ),
-          hash,
-          issues: [],
-          warnings: validated.warnings,
-          legacyIssues,
-        },
-        envSnapshotForRestore: readResolution.envSnapshotForRestore,
+        ),
+        hash,
+        issues: [],
+        warnings: validated.warnings,
+        legacyIssues,
       };
     } catch (err) {
       return {
-        snapshot: {
-          path: configPath,
-          exists: true,
-          raw: null,
-          parsed: {},
-          resolved: {},
-          valid: false,
-          config: {},
-          hash: hashConfigRaw(null),
-          issues: [{ path: "", message: `read failed: ${String(err)}` }],
-          warnings: [],
-          legacyIssues: [],
-        },
+        path: configPath,
+        exists: true,
+        raw: null,
+        parsed: {},
+        resolved: {},
+        valid: false,
+        config: {},
+        hash: hashConfigRaw(null),
+        issues: [{ path: "", message: `read failed: ${String(err)}` }],
+        warnings: [],
+        legacyIssues: [],
       };
     }
   }
 
-  async function readConfigFileSnapshot(): Promise<ConfigFileSnapshot> {
-    const result = await readConfigFileSnapshotInternal();
-    return result.snapshot;
-  }
-
-  async function readConfigFileSnapshotForWrite(): Promise<ReadConfigFileSnapshotForWriteResult> {
-    const result = await readConfigFileSnapshotInternal();
-    return {
-      snapshot: result.snapshot,
-      writeOptions: {
-        envSnapshotForRestore: result.envSnapshotForRestore,
-        expectedConfigPath: configPath,
-      },
-    };
-  }
-
-  async function writeConfigFile(cfg: OpenClawConfig, options: ConfigWriteOptions = {}) {
+  async function writeConfigFile(cfg: OpenClawConfig) {
     clearConfigCache();
     let persistCandidate: unknown = cfg;
-    const { snapshot } = await readConfigFileSnapshotInternal();
-    let envRefMap: Map<string, string> | null = null;
-    let changedPaths: Set<string> | null = null;
+    const snapshot = await readConfigFileSnapshot();
     if (snapshot.valid && snapshot.exists) {
       const patch = createMergePatch(snapshot.config, cfg);
       persistCandidate = applyMergePatch(snapshot.resolved, patch);
-      try {
-        const resolvedIncludes = resolveConfigIncludes(snapshot.parsed, configPath, {
-          readFile: (candidate) => deps.fs.readFileSync(candidate, "utf-8"),
-          parseJson: (raw) => deps.json5.parse(raw),
-        });
-        const collected = new Map<string, string>();
-        collectEnvRefPaths(resolvedIncludes, "", collected);
-        if (collected.size > 0) {
-          envRefMap = collected;
-          changedPaths = new Set<string>();
-          collectChangedPaths(snapshot.config, cfg, "", changedPaths);
-        }
-      } catch {
-        envRefMap = null;
-      }
     }
 
     const validated = validateConfigObjectRawWithPlugins(persistCandidate);
@@ -884,184 +578,49 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
         .join("\n");
       deps.logger.warn(`Config warnings:\n${details}`);
     }
-
-    // Restore ${VAR} env var references that were resolved during config loading.
-    // Read the current file (pre-substitution) and restore any references whose
-    // resolved values match the incoming config — so we don't overwrite
-    // "${ANTHROPIC_API_KEY}" with "sk-ant-..." when the caller didn't change it.
-    //
-    // We use only the root file's parsed content (no $include resolution) to avoid
-    // pulling values from included files into the root config on write-back.
-    // Apply env restoration to validated.config (which has runtime defaults stripped
-    // per issue #6070) rather than the raw caller input.
-    let cfgToWrite = validated.config;
-    try {
-      if (deps.fs.existsSync(configPath)) {
-        const currentRaw = await deps.fs.promises.readFile(configPath, "utf-8");
-        const parsedRes = parseConfigJson5(currentRaw, deps.json5);
-        if (parsedRes.ok) {
-          // Use env snapshot from when config was loaded (if available) to avoid
-          // TOCTOU issues where env changes between load and write. Falls back to
-          // live env if no snapshot exists (e.g., first write before any load).
-          const envForRestore = options.envSnapshotForRestore ?? deps.env;
-          cfgToWrite = restoreEnvVarRefs(
-            cfgToWrite,
-            parsedRes.parsed,
-            envForRestore,
-          ) as OpenClawConfig;
-        }
-      }
-    } catch {
-      // If reading the current file fails, write cfg as-is (no env restoration)
-    }
-
     const dir = path.dirname(configPath);
     await deps.fs.promises.mkdir(dir, { recursive: true, mode: 0o700 });
-    const outputConfig =
-      envRefMap && changedPaths
-        ? (restoreEnvRefsFromMap(cfgToWrite, "", envRefMap, changedPaths) as OpenClawConfig)
-        : cfgToWrite;
     // Do NOT apply runtime defaults when writing — user config should only contain
     // explicitly set values. Runtime defaults are applied when loading (issue #6070).
-    const stampedOutputConfig = stampConfigVersion(outputConfig);
-    const json = JSON.stringify(stampedOutputConfig, null, 2).trimEnd().concat("\n");
-    const nextHash = hashConfigRaw(json);
-    const previousHash = resolveConfigSnapshotHash(snapshot);
-    const changedPathCount = changedPaths?.size;
-    const previousBytes =
-      typeof snapshot.raw === "string" ? Buffer.byteLength(snapshot.raw, "utf-8") : null;
-    const nextBytes = Buffer.byteLength(json, "utf-8");
-    const hasMetaBefore = hasConfigMeta(snapshot.parsed);
-    const hasMetaAfter = hasConfigMeta(stampedOutputConfig);
-    const gatewayModeBefore = resolveGatewayMode(snapshot.resolved);
-    const gatewayModeAfter = resolveGatewayMode(stampedOutputConfig);
-    const suspiciousReasons = resolveConfigWriteSuspiciousReasons({
-      existsBefore: snapshot.exists,
-      previousBytes,
-      nextBytes,
-      hasMetaBefore,
-      gatewayModeBefore,
-      gatewayModeAfter,
-    });
-    const logConfigOverwrite = () => {
-      if (!snapshot.exists) {
-        return;
-      }
-      const isVitest = deps.env.VITEST === "true";
-      const shouldLogInVitest = deps.env.OPENCLAW_TEST_CONFIG_OVERWRITE_LOG === "1";
-      if (isVitest && !shouldLogInVitest) {
-        return;
-      }
-      const changeSummary =
-        typeof changedPathCount === "number" ? `, changedPaths=${changedPathCount}` : "";
-      deps.logger.warn(
-        `Config overwrite: ${configPath} (sha256 ${previousHash ?? "unknown"} -> ${nextHash}, backup=${configPath}.bak${changeSummary})`,
-      );
-    };
-    const logConfigWriteAnomalies = () => {
-      if (suspiciousReasons.length === 0) {
-        return;
-      }
-      deps.logger.warn(`Config write anomaly: ${configPath} (${suspiciousReasons.join(", ")})`);
-    };
-    const auditRecordBase = {
-      ts: new Date().toISOString(),
-      source: "config-io" as const,
-      event: "config.write" as const,
-      configPath,
-      pid: process.pid,
-      ppid: process.ppid,
-      cwd: process.cwd(),
-      argv: process.argv.slice(0, 8),
-      execArgv: process.execArgv.slice(0, 8),
-      watchMode: deps.env.OPENCLAW_WATCH_MODE === "1",
-      watchSession:
-        typeof deps.env.OPENCLAW_WATCH_SESSION === "string" &&
-        deps.env.OPENCLAW_WATCH_SESSION.trim().length > 0
-          ? deps.env.OPENCLAW_WATCH_SESSION.trim()
-          : null,
-      watchCommand:
-        typeof deps.env.OPENCLAW_WATCH_COMMAND === "string" &&
-        deps.env.OPENCLAW_WATCH_COMMAND.trim().length > 0
-          ? deps.env.OPENCLAW_WATCH_COMMAND.trim()
-          : null,
-      existsBefore: snapshot.exists,
-      previousHash: previousHash ?? null,
-      nextHash,
-      previousBytes,
-      nextBytes,
-      changedPathCount: typeof changedPathCount === "number" ? changedPathCount : null,
-      hasMetaBefore,
-      hasMetaAfter,
-      gatewayModeBefore,
-      gatewayModeAfter,
-      suspicious: suspiciousReasons,
-    };
-    const appendWriteAudit = async (result: ConfigWriteAuditResult, err?: unknown) => {
-      const errorCode =
-        err && typeof err === "object" && "code" in err && typeof err.code === "string"
-          ? err.code
-          : undefined;
-      const errorMessage =
-        err && typeof err === "object" && "message" in err && typeof err.message === "string"
-          ? err.message
-          : undefined;
-      await appendConfigWriteAuditRecord(deps, {
-        ...auditRecordBase,
-        result,
-        nextHash: result === "failed" ? null : auditRecordBase.nextHash,
-        nextBytes: result === "failed" ? null : auditRecordBase.nextBytes,
-        errorCode,
-        errorMessage,
-      });
-    };
+    const json = JSON.stringify(stampConfigVersion(validated.config), null, 2)
+      .trimEnd()
+      .concat("\n");
 
     const tmp = path.join(
       dir,
       `${path.basename(configPath)}.${process.pid}.${crypto.randomUUID()}.tmp`,
     );
 
-    try {
-      await deps.fs.promises.writeFile(tmp, json, {
-        encoding: "utf-8",
-        mode: 0o600,
-      });
+    await deps.fs.promises.writeFile(tmp, json, {
+      encoding: "utf-8",
+      mode: 0o600,
+    });
 
-      if (deps.fs.existsSync(configPath)) {
-        await rotateConfigBackups(configPath, deps.fs.promises);
-        await deps.fs.promises.copyFile(configPath, `${configPath}.bak`).catch(() => {
+    if (deps.fs.existsSync(configPath)) {
+      await rotateConfigBackups(configPath, deps.fs.promises);
+      await deps.fs.promises.copyFile(configPath, `${configPath}.bak`).catch(() => {
+        // best-effort
+      });
+    }
+
+    try {
+      await deps.fs.promises.rename(tmp, configPath);
+    } catch (err) {
+      const code = (err as { code?: string }).code;
+      // Windows doesn't reliably support atomic replace via rename when dest exists.
+      if (code === "EPERM" || code === "EEXIST") {
+        await deps.fs.promises.copyFile(tmp, configPath);
+        await deps.fs.promises.chmod(configPath, 0o600).catch(() => {
           // best-effort
         });
-      }
-
-      try {
-        await deps.fs.promises.rename(tmp, configPath);
-      } catch (err) {
-        const code = (err as { code?: string }).code;
-        // Windows doesn't reliably support atomic replace via rename when dest exists.
-        if (code === "EPERM" || code === "EEXIST") {
-          await deps.fs.promises.copyFile(tmp, configPath);
-          await deps.fs.promises.chmod(configPath, 0o600).catch(() => {
-            // best-effort
-          });
-          await deps.fs.promises.unlink(tmp).catch(() => {
-            // best-effort
-          });
-          logConfigOverwrite();
-          logConfigWriteAnomalies();
-          await appendWriteAudit("copy-fallback");
-          return;
-        }
         await deps.fs.promises.unlink(tmp).catch(() => {
           // best-effort
         });
-        throw err;
+        return;
       }
-      logConfigOverwrite();
-      logConfigWriteAnomalies();
-      await appendWriteAudit("rename");
-    } catch (err) {
-      await appendWriteAudit("failed", err);
+      await deps.fs.promises.unlink(tmp).catch(() => {
+        // best-effort
+      });
       throw err;
     }
   }
@@ -1070,7 +629,6 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
     configPath,
     loadConfig,
     readConfigFileSnapshot,
-    readConfigFileSnapshotForWrite,
     writeConfigFile,
   };
 }
@@ -1107,7 +665,7 @@ function shouldUseConfigCache(env: NodeJS.ProcessEnv): boolean {
   return resolveConfigCacheMs(env) > 0;
 }
 
-export function clearConfigCache(): void {
+function clearConfigCache(): void {
   configCache = null;
 }
 
@@ -1139,18 +697,7 @@ export async function readConfigFileSnapshot(): Promise<ConfigFileSnapshot> {
   return await createConfigIO().readConfigFileSnapshot();
 }
 
-export async function readConfigFileSnapshotForWrite(): Promise<ReadConfigFileSnapshotForWriteResult> {
-  return await createConfigIO().readConfigFileSnapshotForWrite();
-}
-
-export async function writeConfigFile(
-  cfg: OpenClawConfig,
-  options: ConfigWriteOptions = {},
-): Promise<void> {
-  const io = createConfigIO();
-  const sameConfigPath =
-    options.expectedConfigPath === undefined || options.expectedConfigPath === io.configPath;
-  await io.writeConfigFile(cfg, {
-    envSnapshotForRestore: sameConfigPath ? options.envSnapshotForRestore : undefined,
-  });
+export async function writeConfigFile(cfg: OpenClawConfig): Promise<void> {
+  clearConfigCache();
+  await createConfigIO().writeConfigFile(cfg);
 }

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -23,6 +23,13 @@ export type AgentModelEntryConfig = {
 export type AgentModelListConfig = {
   primary?: string;
   fallbacks?: string[];
+  /**
+   * Model selection strategy for this list.
+   * - "primary": always start with primary (default behavior)
+   * - "round_robin": rotate across primary+fallbacks per request
+   * - "sticky_session": pick a stable model per sessionKey
+   */
+  strategy?: "primary" | "round_robin" | "sticky_session";
 };
 
 export type AgentContextPruningConfig = {
@@ -254,6 +261,21 @@ export type AgentCompactionConfig = {
   maxHistoryShare?: number;
   /** Pre-compaction memory flush (agentic turn). Default: enabled. */
   memoryFlush?: AgentCompactionMemoryFlushConfig;
+  /** Background memory optimization settings. Keeps context healthy proactively. */
+  backgroundOptimization?: AgentBackgroundOptimizationConfig;
+};
+
+export type AgentBackgroundOptimizationConfig = {
+  /** Number of recent user turns kept verbatim (not summarized). Default: 30. */
+  verbatimTurns?: number;
+  /** Target context usage ratio after optimization (0.1–0.9). Default: 0.5 (50%). */
+  targetWaterLevel?: number;
+  /** Max share of context window for summaries (0.05–0.5). Default: 0.25 (25%). */
+  summaryBudgetRatio?: number;
+  /** Trigger optimization after this many new turns since last run. Default: 15. */
+  optimizeAfterTurns?: number;
+  /** Minimum minutes between optimization cycles. Default: 20. */
+  optimizeIntervalMin?: number;
 };
 
 export type AgentCompactionMemoryFlushConfig = {

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -16,6 +16,13 @@ export type AgentModelConfig =
       primary?: string;
       /** Per-agent model fallbacks (provider/model). */
       fallbacks?: string[];
+      /**
+       * Model selection strategy for this agent.
+       * - "primary": always start with primary (default behavior)
+       * - "round_robin": rotate across primary+fallbacks per request
+       * - "sticky_session": pick a stable model per sessionKey
+       */
+      strategy?: "primary" | "round_robin" | "sticky_session";
     };
 
 export type AgentConfig = {
@@ -38,7 +45,13 @@ export type AgentConfig = {
     /** Allow spawning sub-agents under other agent ids. Use "*" to allow any. */
     allowAgents?: string[];
     /** Per-agent default model for spawned sub-agents (string or {primary,fallbacks}). */
-    model?: string | { primary?: string; fallbacks?: string[] };
+    model?:
+      | string
+      | {
+          primary?: string;
+          fallbacks?: string[];
+          strategy?: "primary" | "round_robin" | "sticky_session";
+        };
   };
   sandbox?: {
     mode?: "off" | "non-main" | "all";

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -97,6 +97,13 @@ export type OpenClawConfig = {
   talk?: TalkConfig;
   gateway?: GatewayConfig;
   memory?: MemoryConfig;
+  /**
+   * Optional logical path mapping used for portability across machines.
+   * Example: {"@workspace/clawd": "/Users/name/clawd"}
+   */
+  pathMap?: {
+    roots?: Record<string, string>;
+  };
 };
 
 export type ConfigValidationIssue = {

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -19,6 +19,9 @@ export const AgentDefaultsSchema = z
       .object({
         primary: z.string().optional(),
         fallbacks: z.array(z.string()).optional(),
+        strategy: z
+          .union([z.literal("primary"), z.literal("round_robin"), z.literal("sticky_session")])
+          .optional(),
       })
       .strict()
       .optional(),

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -7,7 +7,6 @@ import {
   ToolsLinksSchema,
   ToolsMediaSchema,
 } from "./zod-schema.core.js";
-import { sensitive } from "./zod-schema.sensitive.js";
 
 export const HeartbeatSchema = z
   .object({
@@ -173,13 +172,13 @@ export const ToolsWebSearchSchema = z
   .object({
     enabled: z.boolean().optional(),
     provider: z.union([z.literal("brave"), z.literal("perplexity"), z.literal("grok")]).optional(),
-    apiKey: z.string().optional().register(sensitive),
+    apiKey: z.string().optional(),
     maxResults: z.number().int().positive().optional(),
     timeoutSeconds: z.number().int().positive().optional(),
     cacheTtlMinutes: z.number().nonnegative().optional(),
     perplexity: z
       .object({
-        apiKey: z.string().optional().register(sensitive),
+        apiKey: z.string().optional(),
         baseUrl: z.string().optional(),
         model: z.string().optional(),
       })
@@ -187,7 +186,7 @@ export const ToolsWebSearchSchema = z
       .optional(),
     grok: z
       .object({
-        apiKey: z.string().optional().register(sensitive),
+        apiKey: z.string().optional(),
         model: z.string().optional(),
         inlineCitations: z.boolean().optional(),
       })
@@ -333,7 +332,7 @@ export const MemorySearchSchema = z
     remote: z
       .object({
         baseUrl: z.string().optional(),
-        apiKey: z.string().optional().register(sensitive),
+        apiKey: z.string().optional(),
         headers: z.record(z.string(), z.string()).optional(),
         batch: z
           .object({
@@ -435,6 +434,9 @@ export const AgentModelSchema = z.union([
     .object({
       primary: z.string().optional(),
       fallbacks: z.array(z.string()).optional(),
+      strategy: z
+        .union([z.literal("primary"), z.literal("round_robin"), z.literal("sticky_session")])
+        .optional(),
     })
     .strict(),
 ]);
@@ -462,6 +464,13 @@ export const AgentEntrySchema = z
               .object({
                 primary: z.string().optional(),
                 fallbacks: z.array(z.string()).optional(),
+                strategy: z
+                  .union([
+                    z.literal("primary"),
+                    z.literal("round_robin"),
+                    z.literal("sticky_session"),
+                  ])
+                  .optional(),
               })
               .strict(),
           ])

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -5,7 +5,6 @@ import { ApprovalsSchema } from "./zod-schema.approvals.js";
 import { HexColorSchema, ModelsConfigSchema } from "./zod-schema.core.js";
 import { HookMappingSchema, HooksGmailSchema, InternalHooksSchema } from "./zod-schema.hooks.js";
 import { ChannelsSchema } from "./zod-schema.providers.js";
-import { sensitive } from "./zod-schema.sensitive.js";
 import {
   CommandsSchema,
   MessagesSchema,
@@ -93,9 +92,15 @@ const MemorySchema = z
   .strict()
   .optional();
 
+const PathMapSchema = z
+  .object({
+    roots: z.record(z.string(), z.string()).optional(),
+  })
+  .strict()
+  .optional();
+
 export const OpenClawSchema = z
   .object({
-    $schema: z.string().optional(),
     meta: z
       .object({
         lastTouchedVersion: z.string().optional(),
@@ -303,7 +308,7 @@ export const OpenClawSchema = z
       .object({
         enabled: z.boolean().optional(),
         path: z.string().optional(),
-        token: z.string().optional().register(sensitive),
+        token: z.string().optional(),
         defaultSessionKey: z.string().optional(),
         allowRequestSessionKey: z.boolean().optional(),
         allowedSessionKeyPrefixes: z.array(z.string()).optional(),
@@ -367,7 +372,7 @@ export const OpenClawSchema = z
         voiceAliases: z.record(z.string(), z.string()).optional(),
         modelId: z.string().optional(),
         outputFormat: z.string().optional(),
-        apiKey: z.string().optional().register(sensitive),
+        apiKey: z.string().optional(),
         interruptOnSpeech: z.boolean().optional(),
       })
       .strict()
@@ -399,8 +404,8 @@ export const OpenClawSchema = z
         auth: z
           .object({
             mode: z.union([z.literal("token"), z.literal("password")]).optional(),
-            token: z.string().optional().register(sensitive),
-            password: z.string().optional().register(sensitive),
+            token: z.string().optional(),
+            password: z.string().optional(),
             allowTailscale: z.boolean().optional(),
           })
           .strict()
@@ -424,8 +429,8 @@ export const OpenClawSchema = z
           .object({
             url: z.string().optional(),
             transport: z.union([z.literal("ssh"), z.literal("direct")]).optional(),
-            token: z.string().optional().register(sensitive),
-            password: z.string().optional().register(sensitive),
+            token: z.string().optional(),
+            password: z.string().optional(),
             tlsFingerprint: z.string().optional(),
             sshTarget: z.string().optional(),
             sshIdentity: z.string().optional(),
@@ -530,6 +535,7 @@ export const OpenClawSchema = z
       .strict()
       .optional(),
     memory: MemorySchema,
+    pathMap: PathMapSchema,
     skills: z
       .object({
         allowBundled: z.array(z.string()).optional(),
@@ -556,7 +562,7 @@ export const OpenClawSchema = z
             z
               .object({
                 enabled: z.boolean().optional(),
-                apiKey: z.string().optional().register(sensitive),
+                apiKey: z.string().optional(),
                 env: z.record(z.string(), z.string()).optional(),
                 config: z.record(z.string(), z.unknown()).optional(),
               })

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -4,6 +4,7 @@ import type { createSubsystemLogger } from "../logging/subsystem.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { resolveChannelDefaultAccountId } from "../channels/plugins/helpers.js";
 import { type ChannelId, getChannelPlugin, listChannelPlugins } from "../channels/plugins/index.js";
+import { createInternalHookEvent, triggerInternalHook } from "../hooks/internal-hooks.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { resetDirectoryCache } from "../infra/outbound/target-resolver.js";
 import { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
@@ -163,6 +164,18 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
             const message = formatErrorMessage(err);
             setRuntime(channelId, id, { accountId: id, lastError: message });
             log.error?.(`[${id}] channel exited: ${message}`);
+            const errEvent = createInternalHookEvent(
+              "gateway",
+              "error",
+              `gateway:${channelId}:${id}`,
+              {
+                error: message,
+                phase: "channel-runtime",
+                channelId,
+                accountId: id,
+              },
+            );
+            void triggerInternalHook(errEvent);
           })
           .finally(() => {
             store.aborts.delete(id);
@@ -180,12 +193,8 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
 
   const stopChannel = async (channelId: ChannelId, accountId?: string) => {
     const plugin = getChannelPlugin(channelId);
-    const store = getStore(channelId);
-    // Fast path: nothing running and no explicit plugin shutdown hook to run.
-    if (!plugin?.gateway?.stopAccount && store.aborts.size === 0 && store.tasks.size === 0) {
-      return;
-    }
     const cfg = loadConfig();
+    const store = getStore(channelId);
     const knownIds = new Set<string>([
       ...store.aborts.keys(),
       ...store.tasks.keys(),

--- a/src/gateway/server-startup.ts
+++ b/src/gateway/server-startup.ts
@@ -122,6 +122,14 @@ export async function startGatewaySidecars(params: {
       await params.startChannels();
     } catch (err) {
       params.logChannels.error(`channel startup failed: ${String(err)}`);
+      if (params.cfg.hooks?.internal?.enabled) {
+        const errEvent = createInternalHookEvent("gateway", "error", "gateway:error", {
+          error: String(err),
+          phase: "channel-startup",
+          workspaceDir: params.defaultWorkspaceDir,
+        });
+        void triggerInternalHook(errEvent);
+      }
     }
   } else {
     params.logChannels.info(

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -8,7 +8,13 @@
 import type { WorkspaceBootstrapFile } from "../agents/workspace.js";
 import type { OpenClawConfig } from "../config/config.js";
 
-export type InternalHookEventType = "command" | "session" | "agent" | "gateway";
+export type InternalHookEventType =
+  | "command"
+  | "session"
+  | "agent"
+  | "gateway"
+  | "model"
+  | "message";
 
 export type AgentBootstrapHookContext = {
   workspaceDir: string;
@@ -23,6 +29,152 @@ export type AgentBootstrapHookEvent = InternalHookEvent & {
   type: "agent";
   action: "bootstrap";
   context: AgentBootstrapHookContext;
+};
+
+export type ModelSelectHookContext = {
+  /** Original requested provider */
+  requestedProvider: string;
+  /** Original requested model */
+  requestedModel: string;
+  /** Resolved candidates after applying strategy */
+  candidates: Array<{ provider: string; model: string }>;
+  /** Selection strategy being used */
+  strategy: string;
+  /** Session key for context */
+  sessionKey?: string;
+  /** Agent ID if available */
+  agentId?: string;
+  /** Workspace directory */
+  workspaceDir?: string;
+  /** Estimated context length (tokens) */
+  contextLength?: number;
+  /** Task hint from caller (e.g., "code", "chat", "summary") */
+  taskHint?: string;
+};
+
+export type ModelSelectHookEvent = InternalHookEvent & {
+  type: "model";
+  action: "select";
+  context: ModelSelectHookContext;
+};
+
+export type ModelSelectHookResult = {
+  /** Override the selected model */
+  overrideModel?: string;
+  /** Override the entire candidate list */
+  overrideCandidates?: Array<{ provider: string; model: string }>;
+  /** Add candidates to the front of the list */
+  prependCandidates?: Array<{ provider: string; model: string }>;
+};
+
+export type ModelFailoverHookContext = {
+  fromProvider: string;
+  fromModel: string;
+  toProvider: string;
+  toModel: string;
+  reason: string;
+  errorMessage?: string;
+  statusCode?: number;
+  attemptNumber: number;
+  totalCandidates: number;
+  agentId?: string;
+  workspaceDir?: string;
+};
+
+export type ModelFailoverHookEvent = InternalHookEvent & {
+  type: "model";
+  action: "failover";
+  context: ModelFailoverHookContext;
+};
+
+export type ModelFailoverHookResult = {
+  allow?: boolean;
+  vetoReason?: string;
+  overrideTarget?: string;
+};
+
+// =============================================================================
+// Message Hooks - Time Tunnel 時光隧道
+// =============================================================================
+
+export type MessageHookContext = {
+  /** Message direction */
+  direction: "inbound" | "outbound";
+  /** Channel (telegram, line, discord, etc.) */
+  channel: string;
+  /** Chat ID */
+  chatId: string;
+  /** Chat type (group, dm, channel) */
+  chatType?: string;
+  /** Chat name if available */
+  chatName?: string;
+  /** Sender ID */
+  senderId?: string;
+  /** Sender name */
+  senderName?: string;
+  /** Message ID */
+  messageId?: string;
+  /** Reply to message ID */
+  replyToId?: string;
+  /** Text content */
+  content?: string;
+  /** Media type if present */
+  mediaType?: string;
+  /** Media URL if present */
+  mediaUrl?: string;
+  /** Session key */
+  sessionKey?: string;
+  /** Agent ID */
+  agentId?: string;
+  /** Workspace directory */
+  workspaceDir?: string;
+  /** Raw event data (stringified, truncated) */
+  rawEvent?: string;
+};
+
+export type MessageReceivedHookEvent = InternalHookEvent & {
+  type: "message";
+  action: "received";
+  context: MessageHookContext;
+};
+
+export type MessageSentHookEvent = InternalHookEvent & {
+  type: "message";
+  action: "sent";
+  context: MessageHookContext;
+};
+
+export type ModelCompleteHookContext = {
+  /** Provider that handled the request */
+  provider: string;
+  /** Model that handled the request */
+  model: string;
+  /** Input tokens used */
+  inputTokens?: number;
+  /** Output tokens generated */
+  outputTokens?: number;
+  /** Cache read tokens */
+  cacheReadTokens?: number;
+  /** Cache write tokens */
+  cacheWriteTokens?: number;
+  /** Total duration in milliseconds */
+  durationMs?: number;
+  /** Whether the request succeeded */
+  success: boolean;
+  /** Error message if failed */
+  errorMessage?: string;
+  /** Session key */
+  sessionKey?: string;
+  /** Agent ID */
+  agentId?: string;
+  /** Workspace directory */
+  workspaceDir?: string;
+};
+
+export type ModelCompleteHookEvent = InternalHookEvent & {
+  type: "model";
+  action: "complete";
+  context: ModelCompleteHookContext;
 };
 
 export interface InternalHookEvent {
@@ -40,7 +192,13 @@ export interface InternalHookEvent {
   messages: string[];
 }
 
-export type InternalHookHandler = (event: InternalHookEvent) => Promise<void> | void;
+export type InternalHookHandler = (
+  event: InternalHookEvent,
+) =>
+  | Promise<void | ModelFailoverHookResult | ModelSelectHookResult>
+  | void
+  | ModelFailoverHookResult
+  | ModelSelectHookResult;
 
 /** Registry of hook handlers by event key */
 const handlers = new Map<string, InternalHookHandler[]>();
@@ -178,4 +336,227 @@ export function isAgentBootstrapEvent(event: InternalHookEvent): event is AgentB
     return false;
   }
   return Array.isArray(context.bootstrapFiles);
+}
+
+export function isModelFailoverEvent(event: InternalHookEvent): event is ModelFailoverHookEvent {
+  if (event.type !== "model" || event.action !== "failover") {
+    return false;
+  }
+  const context = event.context as Partial<ModelFailoverHookContext> | null;
+  if (!context || typeof context !== "object") {
+    return false;
+  }
+  return (
+    typeof context.fromProvider === "string" &&
+    typeof context.fromModel === "string" &&
+    typeof context.toProvider === "string" &&
+    typeof context.toModel === "string"
+  );
+}
+
+export function isModelSelectEvent(event: InternalHookEvent): event is ModelSelectHookEvent {
+  if (event.type !== "model" || event.action !== "select") {
+    return false;
+  }
+  const context = event.context as Partial<ModelSelectHookContext> | null;
+  if (!context || typeof context !== "object") {
+    return false;
+  }
+  return (
+    typeof context.requestedProvider === "string" &&
+    typeof context.requestedModel === "string" &&
+    Array.isArray(context.candidates)
+  );
+}
+
+export function isModelCompleteEvent(event: InternalHookEvent): event is ModelCompleteHookEvent {
+  if (event.type !== "model" || event.action !== "complete") {
+    return false;
+  }
+  const context = event.context as Partial<ModelCompleteHookContext> | null;
+  if (!context || typeof context !== "object") {
+    return false;
+  }
+  return typeof context.provider === "string" && typeof context.model === "string";
+}
+
+/**
+ * Trigger model select hook and collect results
+ *
+ * Called before model selection to allow smart routing decisions.
+ */
+export async function triggerModelSelectHook(
+  event: ModelSelectHookEvent,
+): Promise<ModelSelectHookResult | undefined> {
+  const typeHandlers = handlers.get(event.type) ?? [];
+  const specificHandlers = handlers.get(`${event.type}:${event.action}`) ?? [];
+  const allHandlers = [...typeHandlers, ...specificHandlers];
+
+  if (allHandlers.length === 0) {
+    return undefined;
+  }
+
+  let result: ModelSelectHookResult | undefined;
+
+  for (const handler of allHandlers) {
+    try {
+      const handlerResult = await handler(event);
+      if (handlerResult && typeof handlerResult === "object") {
+        const typed = handlerResult as Record<string, unknown>;
+        // Only merge if the result contains known ModelSelectHookResult fields
+        const hasSelectFields =
+          "overrideModel" in typed || "overrideCandidates" in typed || "prependCandidates" in typed;
+        if (hasSelectFields) {
+          const selectResult = handlerResult as ModelSelectHookResult;
+          result = {
+            overrideModel: selectResult.overrideModel ?? result?.overrideModel,
+            overrideCandidates: selectResult.overrideCandidates ?? result?.overrideCandidates,
+            prependCandidates: selectResult.prependCandidates ?? result?.prependCandidates,
+          };
+        }
+      }
+    } catch (err) {
+      console.error(
+        `Hook error [${event.type}:${event.action}]:`,
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Trigger model failover hook and collect results
+ *
+ * Unlike other internal hooks, this one collects results from handlers
+ * to allow veto/override behavior.
+ */
+export async function triggerModelFailoverHook(
+  event: ModelFailoverHookEvent,
+): Promise<ModelFailoverHookResult | undefined> {
+  const typeHandlers = handlers.get(event.type) ?? [];
+  const specificHandlers = handlers.get(`${event.type}:${event.action}`) ?? [];
+  const allHandlers = [...typeHandlers, ...specificHandlers];
+
+  if (allHandlers.length === 0) {
+    return undefined;
+  }
+
+  let result: ModelFailoverHookResult | undefined;
+
+  for (const handler of allHandlers) {
+    try {
+      const handlerResult = await handler(event);
+      // Merge results if handler returns a failover-shaped object
+      if (handlerResult && typeof handlerResult === "object") {
+        const typed = handlerResult as Record<string, unknown>;
+        const hasFailoverFields =
+          "allow" in typed || "vetoReason" in typed || "overrideTarget" in typed;
+        if (hasFailoverFields) {
+          const failoverResult = handlerResult as ModelFailoverHookResult;
+          result = {
+            allow: failoverResult.allow ?? result?.allow,
+            vetoReason: failoverResult.vetoReason ?? result?.vetoReason,
+            overrideTarget: failoverResult.overrideTarget ?? result?.overrideTarget,
+          };
+        }
+      }
+    } catch (err) {
+      console.error(
+        `Hook error [${event.type}:${event.action}]:`,
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Trigger model complete hook (fire-and-forget)
+ *
+ * Called after a model request completes (success or failure) for tracking/metrics.
+ */
+export async function triggerModelCompleteHook(event: ModelCompleteHookEvent): Promise<void> {
+  const typeHandlers = handlers.get(event.type) ?? [];
+  const specificHandlers = handlers.get(`${event.type}:${event.action}`) ?? [];
+  const allHandlers = [...typeHandlers, ...specificHandlers];
+
+  if (allHandlers.length === 0) {
+    return;
+  }
+
+  for (const handler of allHandlers) {
+    try {
+      await handler(event);
+    } catch (err) {
+      console.error(
+        `Hook error [${event.type}:${event.action}]:`,
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+  }
+}
+
+/**
+ * Trigger message received hook (fire-and-forget)
+ *
+ * Called when a message is received from any channel.
+ */
+export async function triggerMessageReceivedHook(event: MessageReceivedHookEvent): Promise<void> {
+  const typeHandlers = handlers.get(event.type) ?? [];
+  const specificHandlers = handlers.get(`${event.type}:${event.action}`) ?? [];
+  const allHandlers = [...typeHandlers, ...specificHandlers];
+
+  if (allHandlers.length === 0) {
+    return;
+  }
+
+  for (const handler of allHandlers) {
+    try {
+      await handler(event);
+    } catch (err) {
+      console.error(
+        `Hook error [${event.type}:${event.action}]:`,
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+  }
+}
+
+/**
+ * Trigger message sent hook (fire-and-forget)
+ *
+ * Called when a message is sent to any channel.
+ */
+export async function triggerMessageSentHook(event: MessageSentHookEvent): Promise<void> {
+  const typeHandlers = handlers.get(event.type) ?? [];
+  const specificHandlers = handlers.get(`${event.type}:${event.action}`) ?? [];
+  const allHandlers = [...typeHandlers, ...specificHandlers];
+
+  if (allHandlers.length === 0) {
+    return;
+  }
+
+  for (const handler of allHandlers) {
+    try {
+      await handler(event);
+    } catch (err) {
+      console.error(
+        `Hook error [${event.type}:${event.action}]:`,
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+  }
+}
+
+export function isMessageReceivedEvent(
+  event: InternalHookEvent,
+): event is MessageReceivedHookEvent {
+  return event.type === "message" && event.action === "received";
+}
+
+export function isMessageSentEvent(event: InternalHookEvent): event is MessageSentHookEvent {
+  return event.type === "message" && event.action === "sent";
 }

--- a/src/infra/in-flight-tracker.test.ts
+++ b/src/infra/in-flight-tracker.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  getInFlightCount,
+  getInFlightRequests,
+  resetTracker,
+  trackMessageEnd,
+  trackMessageStart,
+  waitForInFlightCompletion,
+} from "./in-flight-tracker.js";
+
+afterEach(() => {
+  resetTracker();
+});
+
+describe("trackMessageStart / trackMessageEnd", () => {
+  it("increments count on start", () => {
+    expect(getInFlightCount()).toBe(0);
+    trackMessageStart({ chatId: "-100", channel: "telegram" });
+    expect(getInFlightCount()).toBe(1);
+  });
+
+  it("decrements count on end", () => {
+    const id = trackMessageStart({ chatId: "-100", channel: "telegram" });
+    expect(getInFlightCount()).toBe(1);
+    trackMessageEnd(id);
+    expect(getInFlightCount()).toBe(0);
+  });
+
+  it("handles multiple concurrent requests", () => {
+    const id1 = trackMessageStart({ chatId: "-100", channel: "telegram" });
+    const id2 = trackMessageStart({ chatId: "-200", channel: "line" });
+    const id3 = trackMessageStart({ chatId: "-300", channel: "discord" });
+    expect(getInFlightCount()).toBe(3);
+
+    trackMessageEnd(id2);
+    expect(getInFlightCount()).toBe(2);
+
+    trackMessageEnd(id1);
+    trackMessageEnd(id3);
+    expect(getInFlightCount()).toBe(0);
+  });
+
+  it("ignores unknown request id on end", () => {
+    trackMessageStart({ chatId: "-100", channel: "telegram" });
+    trackMessageEnd("nonexistent-id");
+    expect(getInFlightCount()).toBe(1);
+  });
+
+  it("truncates message preview to 50 chars", () => {
+    const longMessage = "a".repeat(100);
+    trackMessageStart({ chatId: "-100", channel: "telegram", messagePreview: longMessage });
+    const requests = getInFlightRequests();
+    expect(requests[0].messagePreview.length).toBeLessThanOrEqual(50);
+  });
+
+  it("uses default preview when not provided", () => {
+    trackMessageStart({ chatId: "-100", channel: "telegram" });
+    const requests = getInFlightRequests();
+    expect(requests[0].messagePreview).toBe("(no preview)");
+  });
+});
+
+describe("getInFlightRequests", () => {
+  it("returns all in-flight request details", () => {
+    trackMessageStart({ chatId: "-100", channel: "telegram", messagePreview: "hello" });
+    trackMessageStart({ chatId: "-200", channel: "line", messagePreview: "world" });
+    const requests = getInFlightRequests();
+    expect(requests).toHaveLength(2);
+  });
+
+  it("returns empty array when no requests", () => {
+    expect(getInFlightRequests()).toEqual([]);
+  });
+});
+
+describe("waitForInFlightCompletion", () => {
+  it("resolves immediately when no in-flight requests", async () => {
+    const result = await waitForInFlightCompletion();
+    expect(result.completed).toBe(true);
+    expect(result.remaining).toBe(0);
+    expect(result.timedOut).toBe(false);
+  });
+
+  it("resolves when all requests complete before timeout", async () => {
+    const id = trackMessageStart({ chatId: "-100", channel: "telegram" });
+    const promise = waitForInFlightCompletion(5000);
+
+    setTimeout(() => trackMessageEnd(id), 50);
+
+    const result = await promise;
+    expect(result.completed).toBe(true);
+    expect(result.remaining).toBe(0);
+    expect(result.timedOut).toBe(false);
+  });
+
+  it("times out when requests do not complete", async () => {
+    trackMessageStart({ chatId: "-100", channel: "telegram" });
+    const result = await waitForInFlightCompletion(100);
+    expect(result.timedOut).toBe(true);
+    expect(result.remaining).toBe(1);
+  });
+});
+
+describe("resetTracker", () => {
+  it("clears all state", () => {
+    trackMessageStart({ chatId: "-100", channel: "telegram" });
+    trackMessageStart({ chatId: "-200", channel: "line" });
+    expect(getInFlightCount()).toBe(2);
+    resetTracker();
+    expect(getInFlightCount()).toBe(0);
+  });
+});

--- a/src/infra/in-flight-tracker.ts
+++ b/src/infra/in-flight-tracker.ts
@@ -1,0 +1,157 @@
+/**
+ * Level 50: In-Flight Request Tracker
+ *
+ * 追蹤正在處理中的消息，確保 graceful shutdown 時等待完成。
+ */
+
+import { createSubsystemLogger } from "../logging/subsystem.js";
+
+const log = createSubsystemLogger("in-flight");
+
+interface InFlightRequest {
+  id: string;
+  chatId: string;
+  channel: string;
+  startedAt: number;
+  messagePreview: string;
+}
+
+// 存儲所有 in-flight 請求
+const inFlightRequests = new Map<string, InFlightRequest>();
+
+// 等待 shutdown 的 resolvers
+let shutdownWaiters: Array<() => void> = [];
+let isShuttingDown = false;
+
+/**
+ * 生成唯一請求 ID
+ */
+function generateRequestId(): string {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+}
+
+/**
+ * 記錄開始處理消息
+ */
+export function trackMessageStart(params: {
+  chatId: string;
+  channel: string;
+  messagePreview?: string;
+}): string {
+  const id = generateRequestId();
+  const request: InFlightRequest = {
+    id,
+    chatId: params.chatId,
+    channel: params.channel,
+    startedAt: Date.now(),
+    messagePreview: params.messagePreview?.slice(0, 50) || "(no preview)",
+  };
+
+  inFlightRequests.set(id, request);
+  log.info(`[+] in-flight: ${inFlightRequests.size} (${params.channel}:${params.chatId})`);
+
+  return id;
+}
+
+/**
+ * 記錄消息處理完成
+ */
+export function trackMessageEnd(requestId: string): void {
+  const request = inFlightRequests.get(requestId);
+  if (request) {
+    const duration = Date.now() - request.startedAt;
+    inFlightRequests.delete(requestId);
+    log.info(`[-] in-flight: ${inFlightRequests.size} (completed in ${duration}ms)`);
+
+    // 如果正在 shutdown 且沒有 pending 請求了，通知 waiters
+    if (isShuttingDown && inFlightRequests.size === 0) {
+      for (const resolve of shutdownWaiters) {
+        resolve();
+      }
+      shutdownWaiters = [];
+    }
+  }
+}
+
+/**
+ * 獲取當前 in-flight 請求數量
+ */
+export function getInFlightCount(): number {
+  return inFlightRequests.size;
+}
+
+/**
+ * 獲取所有 in-flight 請求詳情
+ */
+export function getInFlightRequests(): InFlightRequest[] {
+  return Array.from(inFlightRequests.values());
+}
+
+/**
+ * 等待所有 in-flight 請求完成
+ * @param timeoutMs 超時時間（毫秒），預設 30 秒
+ */
+export async function waitForInFlightCompletion(timeoutMs = 30000): Promise<{
+  completed: boolean;
+  remaining: number;
+  timedOut: boolean;
+}> {
+  isShuttingDown = true;
+
+  const count = inFlightRequests.size;
+  if (count === 0) {
+    log.info("no in-flight requests; ready to shutdown");
+    return { completed: true, remaining: 0, timedOut: false };
+  }
+
+  log.info(`waiting for ${count} in-flight request(s) to complete...`);
+
+  // 列出正在處理的請求
+  for (const req of inFlightRequests.values()) {
+    const elapsed = Date.now() - req.startedAt;
+    log.info(`  - ${req.channel}:${req.chatId} (${elapsed}ms) "${req.messagePreview}"`);
+  }
+
+  return new Promise((resolve) => {
+    const cleanup = () => {
+      shutdownWaiters = [];
+      isShuttingDown = false;
+    };
+
+    const timeoutId = setTimeout(() => {
+      const remaining = inFlightRequests.size;
+      if (remaining > 0) {
+        log.warn(`shutdown timeout: ${remaining} request(s) still pending, proceeding anyway`);
+        for (const req of inFlightRequests.values()) {
+          log.warn(`  - abandoned: ${req.channel}:${req.chatId} "${req.messagePreview}"`);
+        }
+      }
+      cleanup();
+      resolve({ completed: remaining === 0, remaining, timedOut: true });
+    }, timeoutMs);
+
+    // 如果已經沒有 pending 了
+    if (inFlightRequests.size === 0) {
+      clearTimeout(timeoutId);
+      cleanup();
+      resolve({ completed: true, remaining: 0, timedOut: false });
+      return;
+    }
+
+    // 等待所有請求完成
+    shutdownWaiters.push(() => {
+      clearTimeout(timeoutId);
+      cleanup();
+      resolve({ completed: true, remaining: 0, timedOut: false });
+    });
+  });
+}
+
+/**
+ * 重置狀態（用於測試）
+ */
+export function resetTracker(): void {
+  inFlightRequests.clear();
+  shutdownWaiters = [];
+  isShuttingDown = false;
+}

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -21,11 +21,11 @@ import {
   appendAssistantMessageToSessionTranscript,
   resolveMirroredTranscriptText,
 } from "../../config/sessions.js";
+import { triggerMessageSentHook, type MessageSentHookEvent } from "../../hooks/internal-hooks.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { markdownToSignalTextChunks, type SignalTextStyleRange } from "../../signal/format.js";
 import { sendMessageSignal } from "../../signal/send.js";
 import { throwIfAborted } from "./abort.js";
-import { ackDelivery, enqueueDelivery, failDelivery } from "./delivery-queue.js";
 import { normalizeReplyPayloadsForDelivery } from "./payloads.js";
 
 export type { NormalizedOutboundPayload } from "./payloads.js";
@@ -87,7 +87,6 @@ async function createChannelHandler(params: {
   threadId?: string | number | null;
   deps?: OutboundSendDeps;
   gifPlayback?: boolean;
-  silent?: boolean;
 }): Promise<ChannelHandler> {
   const outbound = await loadChannelOutboundAdapter(params.channel);
   if (!outbound?.sendText || !outbound?.sendMedia) {
@@ -103,7 +102,6 @@ async function createChannelHandler(params: {
     threadId: params.threadId,
     deps: params.deps,
     gifPlayback: params.gifPlayback,
-    silent: params.silent,
   });
   if (!handler) {
     throw new Error(`Outbound not configured for channel: ${params.channel}`);
@@ -121,7 +119,6 @@ function createPluginHandler(params: {
   threadId?: string | number | null;
   deps?: OutboundSendDeps;
   gifPlayback?: boolean;
-  silent?: boolean;
 }): ChannelHandler | null {
   const outbound = params.outbound;
   if (!outbound?.sendText || !outbound?.sendMedia) {
@@ -147,7 +144,6 @@ function createPluginHandler(params: {
             threadId: params.threadId,
             gifPlayback: params.gifPlayback,
             deps: params.deps,
-            silent: params.silent,
             payload,
           })
       : undefined,
@@ -161,7 +157,6 @@ function createPluginHandler(params: {
         threadId: params.threadId,
         gifPlayback: params.gifPlayback,
         deps: params.deps,
-        silent: params.silent,
       }),
     sendMedia: async (caption, mediaUrl) =>
       sendMedia({
@@ -174,12 +169,9 @@ function createPluginHandler(params: {
         threadId: params.threadId,
         gifPlayback: params.gifPlayback,
         deps: params.deps,
-        silent: params.silent,
       }),
   };
 }
-
-const isAbortError = (err: unknown): boolean => err instanceof Error && err.name === "AbortError";
 
 export async function deliverOutboundPayloads(params: {
   cfg: OpenClawConfig;
@@ -201,89 +193,6 @@ export async function deliverOutboundPayloads(params: {
     text?: string;
     mediaUrls?: string[];
   };
-  silent?: boolean;
-  /** @internal Skip write-ahead queue (used by crash-recovery to avoid re-enqueueing). */
-  skipQueue?: boolean;
-}): Promise<OutboundDeliveryResult[]> {
-  const { channel, to, payloads } = params;
-
-  // Write-ahead delivery queue: persist before sending, remove after success.
-  const queueId = params.skipQueue
-    ? null
-    : await enqueueDelivery({
-        channel,
-        to,
-        accountId: params.accountId,
-        payloads,
-        threadId: params.threadId,
-        replyToId: params.replyToId,
-        bestEffort: params.bestEffort,
-        gifPlayback: params.gifPlayback,
-        silent: params.silent,
-        mirror: params.mirror,
-      }).catch(() => null); // Best-effort — don't block delivery if queue write fails.
-
-  // Wrap onError to detect partial failures under bestEffort mode.
-  // When bestEffort is true, per-payload errors are caught and passed to onError
-  // without throwing — so the outer try/catch never fires. We track whether any
-  // payload failed so we can call failDelivery instead of ackDelivery.
-  let hadPartialFailure = false;
-  const wrappedParams = params.onError
-    ? {
-        ...params,
-        onError: (err: unknown, payload: NormalizedOutboundPayload) => {
-          hadPartialFailure = true;
-          params.onError!(err, payload);
-        },
-      }
-    : params;
-
-  try {
-    const results = await deliverOutboundPayloadsCore(wrappedParams);
-    if (queueId) {
-      if (hadPartialFailure) {
-        await failDelivery(queueId, "partial delivery failure (bestEffort)").catch(() => {});
-      } else {
-        await ackDelivery(queueId).catch(() => {}); // Best-effort cleanup.
-      }
-    }
-    return results;
-  } catch (err) {
-    if (queueId) {
-      if (isAbortError(err)) {
-        await ackDelivery(queueId).catch(() => {});
-      } else {
-        await failDelivery(queueId, err instanceof Error ? err.message : String(err)).catch(
-          () => {},
-        );
-      }
-    }
-    throw err;
-  }
-}
-
-/** Core delivery logic (extracted for queue wrapper). */
-async function deliverOutboundPayloadsCore(params: {
-  cfg: OpenClawConfig;
-  channel: Exclude<OutboundChannel, "none">;
-  to: string;
-  accountId?: string;
-  payloads: ReplyPayload[];
-  replyToId?: string | null;
-  threadId?: string | number | null;
-  deps?: OutboundSendDeps;
-  gifPlayback?: boolean;
-  abortSignal?: AbortSignal;
-  bestEffort?: boolean;
-  onError?: (err: unknown, payload: NormalizedOutboundPayload) => void;
-  onPayload?: (payload: NormalizedOutboundPayload) => void;
-  mirror?: {
-    sessionKey: string;
-    agentId?: string;
-    text?: string;
-    mediaUrls?: string[];
-  };
-  silent?: boolean;
 }): Promise<OutboundDeliveryResult[]> {
   const { cfg, channel, to, payloads } = params;
   const accountId = params.accountId;
@@ -300,7 +209,6 @@ async function deliverOutboundPayloadsCore(params: {
     replyToId: params.replyToId,
     threadId: params.threadId,
     gifPlayback: params.gifPlayback,
-    silent: params.silent,
   });
   const textLimit = handler.chunker
     ? resolveTextChunkLimit(cfg, channel, accountId, {
@@ -536,5 +444,32 @@ async function deliverOutboundPayloadsCore(params: {
       });
     }
   }
+
+  // Trigger message:sent hook for time-tunnel and other hooks
+  if (results.length > 0) {
+    const lastResult = results.at(-1);
+    const combinedText = normalizedPayloads.map((p) => p.text ?? "").join("\n");
+    const combinedMediaUrls = normalizedPayloads.flatMap((p) =>
+      p.mediaUrls?.length ? p.mediaUrls : p.mediaUrl ? [p.mediaUrl] : [],
+    );
+    void triggerMessageSentHook({
+      type: "message",
+      action: "sent",
+      sessionKey: params.mirror?.sessionKey ?? "",
+      timestamp: new Date(),
+      messages: [],
+      context: {
+        direction: "outbound",
+        channel,
+        chatId: to,
+        messageId: lastResult?.messageId,
+        content: combinedText,
+        mediaUrl: combinedMediaUrls[0],
+        sessionKey: params.mirror?.sessionKey,
+        agentId: params.mirror?.agentId,
+      },
+    } as MessageSentHookEvent);
+  }
+
   return results;
 }

--- a/src/infra/outbound/payloads.test.ts
+++ b/src/infra/outbound/payloads.test.ts
@@ -3,7 +3,79 @@ import {
   formatOutboundPayloadLog,
   normalizeOutboundPayloads,
   normalizeOutboundPayloadsForJson,
+  normalizeReplyPayloadsForDelivery,
 } from "./payloads.js";
+
+// ── normalizeReplyPayloadsForDelivery ──────────────────────────
+
+describe("normalizeReplyPayloadsForDelivery", () => {
+  it("returns empty array for empty input", () => {
+    expect(normalizeReplyPayloadsForDelivery([])).toEqual([]);
+  });
+
+  it("passes through plain text payload", () => {
+    const result = normalizeReplyPayloadsForDelivery([{ text: "hello" }]);
+    expect(result).toHaveLength(1);
+    expect(result[0].text).toBe("hello");
+  });
+
+  it("strips MEDIA: tags from text and populates mediaUrls", () => {
+    const result = normalizeReplyPayloadsForDelivery([
+      { text: "caption\nMEDIA:https://x.test/a.png" },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0].text).toBe("caption");
+    expect(result[0].mediaUrls).toContain("https://x.test/a.png");
+  });
+
+  it("deduplicates media URLs", () => {
+    const result = normalizeReplyPayloadsForDelivery([
+      {
+        text: "dup",
+        mediaUrl: "https://x.test/a.png",
+        mediaUrls: ["https://x.test/a.png", "https://x.test/b.png"],
+      },
+    ]);
+    expect(result).toHaveLength(1);
+    const urls = result[0].mediaUrls ?? [];
+    expect(urls.filter((u) => u === "https://x.test/a.png")).toHaveLength(1);
+  });
+
+  it("filters out empty text-only payloads with no media", () => {
+    const result = normalizeReplyPayloadsForDelivery([{ text: "" }]);
+    expect(result).toHaveLength(0);
+  });
+
+  it("preserves payload with only mediaUrl", () => {
+    const result = normalizeReplyPayloadsForDelivery([{ mediaUrl: "https://x.test/a.png" }]);
+    expect(result).toHaveLength(1);
+  });
+
+  it("preserves channelData payloads", () => {
+    const result = normalizeReplyPayloadsForDelivery([{ channelData: { line: { msg: "flex" } } }]);
+    expect(result).toHaveLength(1);
+    expect(result[0].channelData).toBeDefined();
+  });
+
+  it("handles multiple payloads", () => {
+    const result = normalizeReplyPayloadsForDelivery([
+      { text: "first" },
+      { text: "second" },
+      { text: "" },
+    ]);
+    expect(result).toHaveLength(2);
+  });
+
+  it("trims media URL whitespace", () => {
+    const result = normalizeReplyPayloadsForDelivery([
+      { text: "pic", mediaUrl: "  https://x.test/a.png  " },
+    ]);
+    const urls = result[0].mediaUrls ?? [];
+    expect(urls[0]).toBe("https://x.test/a.png");
+  });
+});
+
+// ── normalizeOutboundPayloadsForJson ──────────────────────────
 
 describe("normalizeOutboundPayloadsForJson", () => {
   it("normalizes payloads with mediaUrl and mediaUrls", () => {
@@ -46,7 +118,17 @@ describe("normalizeOutboundPayloadsForJson", () => {
       },
     ]);
   });
+
+  it("returns empty array for empty input", () => {
+    expect(normalizeOutboundPayloadsForJson([])).toEqual([]);
+  });
+
+  it("returns empty array for non-renderable payloads", () => {
+    expect(normalizeOutboundPayloadsForJson([{ text: "" }])).toEqual([]);
+  });
 });
+
+// ── normalizeOutboundPayloads ──────────────────────────
 
 describe("normalizeOutboundPayloads", () => {
   it("keeps channelData-only payloads", () => {
@@ -54,7 +136,44 @@ describe("normalizeOutboundPayloads", () => {
     const normalized = normalizeOutboundPayloads([{ channelData }]);
     expect(normalized).toEqual([{ text: "", mediaUrls: [], channelData }]);
   });
+
+  it("returns empty array for empty input", () => {
+    expect(normalizeOutboundPayloads([])).toEqual([]);
+  });
+
+  it("strips empty payloads", () => {
+    expect(normalizeOutboundPayloads([{ text: "" }])).toEqual([]);
+  });
+
+  it("normalizes text-only payload", () => {
+    const result = normalizeOutboundPayloads([{ text: "hello" }]);
+    expect(result).toEqual([{ text: "hello", mediaUrls: [] }]);
+  });
+
+  it("normalizes media payload", () => {
+    const result = normalizeOutboundPayloads([
+      { text: "caption", mediaUrl: "https://x.test/a.png" },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0].text).toBe("caption");
+    expect(result[0].mediaUrls).toContain("https://x.test/a.png");
+  });
+
+  it("extracts MEDIA: tags from text", () => {
+    const result = normalizeOutboundPayloads([{ text: "hello\nMEDIA:https://x.test/pic.jpg" }]);
+    expect(result).toHaveLength(1);
+    expect(result[0].text).toBe("hello");
+    expect(result[0].mediaUrls).toContain("https://x.test/pic.jpg");
+  });
+
+  it("omits empty channelData", () => {
+    const result = normalizeOutboundPayloads([{ text: "hi", channelData: {} }]);
+    expect(result).toHaveLength(1);
+    expect(result[0].channelData).toBeUndefined();
+  });
 });
+
+// ── formatOutboundPayloadLog ──────────────────────────
 
 describe("formatOutboundPayloadLog", () => {
   it("trims trailing text and appends media lines", () => {
@@ -73,5 +192,13 @@ describe("formatOutboundPayloadLog", () => {
         mediaUrls: ["https://x.test/a.png"],
       }),
     ).toBe("MEDIA:https://x.test/a.png");
+  });
+
+  it("logs text-only payloads", () => {
+    expect(formatOutboundPayloadLog({ text: "hello", mediaUrls: [] })).toBe("hello");
+  });
+
+  it("returns empty string for empty payload", () => {
+    expect(formatOutboundPayloadLog({ text: "", mediaUrls: [] })).toBe("");
   });
 });

--- a/src/infra/spawn-patch.ts
+++ b/src/infra/spawn-patch.ts
@@ -1,0 +1,54 @@
+/**
+ * Global patch for child_process.spawn to prevent fd leaks
+ *
+ * This patches all spawn() calls (including third-party dependencies)
+ * to automatically set closeOnExec: true, preventing file descriptor
+ * leaks when spawning Python or other processes that import large libraries.
+ */
+
+import type { SpawnOptions } from "node:child_process";
+import { spawn as originalSpawn } from "node:child_process";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+let patched = false;
+
+export function patchSpawnGlobally(): void {
+  if (patched) {
+    return;
+  }
+  patched = true;
+
+  const cp = require("node:child_process");
+
+  cp.spawn = function patchedSpawn(
+    command: string,
+    args?: readonly string[] | SpawnOptions,
+    options?: SpawnOptions,
+  ) {
+    // Handle overloaded signatures
+    let actualArgs: readonly string[] | undefined;
+    let actualOptions: SpawnOptions | undefined;
+
+    if (Array.isArray(args)) {
+      actualArgs = args;
+      actualOptions = options;
+    } else {
+      actualOptions = args as SpawnOptions | undefined;
+    }
+
+    // Inject closeOnExec: true if not explicitly set
+    const enhancedOptions = {
+      ...actualOptions,
+      closeOnExec: (actualOptions as unknown as Record<string, unknown>)?.closeOnExec ?? true,
+    };
+
+    // Call original spawn with enhanced options
+    if (actualArgs) {
+      return originalSpawn(command, actualArgs, enhancedOptions);
+    }
+    return originalSpawn(command, enhancedOptions);
+  };
+
+  console.log("[spawn-patch] Global spawn() patched with closeOnExec: true");
+}

--- a/src/node-host/runner.ts
+++ b/src/node-host/runner.ts
@@ -1,20 +1,51 @@
+import { spawn } from "node:child_process";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import fsPromises from "node:fs/promises";
+import path from "node:path";
+import { resolveAgentConfig } from "../agents/agent-scope.js";
 import { resolveBrowserConfig } from "../browser/config.js";
+import {
+  createBrowserControlContext,
+  startBrowserControlServiceFromConfig,
+} from "../browser/control-service.js";
+import { createBrowserRouteDispatcher } from "../browser/routes/dispatcher.js";
 import { loadConfig } from "../config/config.js";
 import { GatewayClient } from "../gateway/client.js";
 import { loadOrCreateDeviceIdentity } from "../infra/device-identity.js";
+import {
+  addAllowlistEntry,
+  analyzeArgvCommand,
+  evaluateExecAllowlist,
+  evaluateShellAllowlist,
+  requiresExecApproval,
+  normalizeExecApprovals,
+  recordAllowlistUse,
+  resolveExecApprovals,
+  resolveSafeBins,
+  ensureExecApprovals,
+  readExecApprovalsSnapshot,
+  resolveExecApprovalsSocketPath,
+  saveExecApprovals,
+  type ExecAsk,
+  type ExecSecurity,
+  type ExecApprovalsFile,
+  type ExecAllowlistEntry,
+  type ExecCommandSegment,
+} from "../infra/exec-approvals.js";
+import {
+  requestExecHostViaSocket,
+  type ExecHostRequest,
+  type ExecHostResponse,
+  type ExecHostRunResult,
+} from "../infra/exec-host.js";
 import { getMachineDisplayName } from "../infra/machine-name.js";
 import { ensureOpenClawCliOnPath } from "../infra/path-env.js";
+import { detectMime } from "../media/mime.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import { VERSION } from "../version.js";
 import { ensureNodeHostConfig, saveNodeHostConfig, type NodeHostGatewayConfig } from "./config.js";
-import {
-  coerceNodeInvokePayload,
-  handleInvoke,
-  type SkillBinsProvider,
-  buildNodeInvokeResultParams,
-} from "./invoke.js";
-
-export { buildNodeInvokeResultParams };
+import { withTimeout } from "./with-timeout.js";
 
 type NodeHostRunOptions = {
   gatewayHost: string;
@@ -25,9 +56,125 @@ type NodeHostRunOptions = {
   displayName?: string;
 };
 
-const DEFAULT_NODE_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+type SystemRunParams = {
+  command: string[];
+  rawCommand?: string | null;
+  cwd?: string | null;
+  env?: Record<string, string>;
+  timeoutMs?: number | null;
+  needsScreenRecording?: boolean | null;
+  agentId?: string | null;
+  sessionKey?: string | null;
+  approved?: boolean | null;
+  approvalDecision?: string | null;
+  runId?: string | null;
+};
 
-class SkillBinsCache implements SkillBinsProvider {
+type SystemWhichParams = {
+  bins: string[];
+};
+
+type BrowserProxyParams = {
+  method?: string;
+  path?: string;
+  query?: Record<string, string | number | boolean | null | undefined>;
+  body?: unknown;
+  timeoutMs?: number;
+  profile?: string;
+};
+
+type BrowserProxyFile = {
+  path: string;
+  base64: string;
+  mimeType?: string;
+};
+
+type BrowserProxyResult = {
+  result: unknown;
+  files?: BrowserProxyFile[];
+};
+
+type SystemExecApprovalsSetParams = {
+  file: ExecApprovalsFile;
+  baseHash?: string | null;
+};
+
+type ExecApprovalsSnapshot = {
+  path: string;
+  exists: boolean;
+  hash: string;
+  file: ExecApprovalsFile;
+};
+
+type RunResult = {
+  exitCode?: number;
+  timedOut: boolean;
+  success: boolean;
+  stdout: string;
+  stderr: string;
+  error?: string | null;
+  truncated: boolean;
+};
+
+function resolveExecSecurity(value?: string): ExecSecurity {
+  return value === "deny" || value === "allowlist" || value === "full" ? value : "allowlist";
+}
+
+function isCmdExeInvocation(argv: string[]): boolean {
+  const token = argv[0]?.trim();
+  if (!token) {
+    return false;
+  }
+  const base = path.win32.basename(token).toLowerCase();
+  return base === "cmd.exe" || base === "cmd";
+}
+
+function resolveExecAsk(value?: string): ExecAsk {
+  return value === "off" || value === "on-miss" || value === "always" ? value : "on-miss";
+}
+
+type ExecEventPayload = {
+  sessionKey: string;
+  runId: string;
+  host: string;
+  command?: string;
+  exitCode?: number;
+  timedOut?: boolean;
+  success?: boolean;
+  output?: string;
+  reason?: string;
+};
+
+type NodeInvokeRequestPayload = {
+  id: string;
+  nodeId: string;
+  command: string;
+  paramsJSON?: string | null;
+  timeoutMs?: number | null;
+  idempotencyKey?: string | null;
+};
+
+const OUTPUT_CAP = 200_000;
+const OUTPUT_EVENT_TAIL = 20_000;
+const DEFAULT_NODE_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+const BROWSER_PROXY_MAX_FILE_BYTES = 10 * 1024 * 1024;
+
+const execHostEnforced = process.env.OPENCLAW_NODE_EXEC_HOST?.trim().toLowerCase() === "app";
+const execHostFallbackAllowed =
+  process.env.OPENCLAW_NODE_EXEC_FALLBACK?.trim().toLowerCase() !== "0";
+
+const blockedEnvKeys = new Set([
+  "NODE_OPTIONS",
+  "PYTHONHOME",
+  "PYTHONPATH",
+  "PERL5LIB",
+  "PERL5OPT",
+  "RUBYOPT",
+]);
+
+const blockedEnvPrefixes = ["DYLD_", "LD_"];
+
+class SkillBinsCache {
   private bins = new Set<string>();
   private lastRefresh = 0;
   private readonly ttlMs = 90_000;
@@ -57,6 +204,271 @@ class SkillBinsCache implements SkillBinsProvider {
   }
 }
 
+function sanitizeEnv(
+  overrides?: Record<string, string> | null,
+): Record<string, string> | undefined {
+  if (!overrides) {
+    return undefined;
+  }
+  const merged = { ...process.env } as Record<string, string>;
+  const basePath = process.env.PATH ?? DEFAULT_NODE_PATH;
+  for (const [rawKey, value] of Object.entries(overrides)) {
+    const key = rawKey.trim();
+    if (!key) {
+      continue;
+    }
+    const upper = key.toUpperCase();
+    if (upper === "PATH") {
+      const trimmed = value.trim();
+      if (!trimmed) {
+        continue;
+      }
+      if (!basePath || trimmed === basePath) {
+        merged[key] = trimmed;
+        continue;
+      }
+      const suffix = `${path.delimiter}${basePath}`;
+      if (trimmed.endsWith(suffix)) {
+        merged[key] = trimmed;
+      }
+      continue;
+    }
+    if (blockedEnvKeys.has(upper)) {
+      continue;
+    }
+    if (blockedEnvPrefixes.some((prefix) => upper.startsWith(prefix))) {
+      continue;
+    }
+    merged[key] = value;
+  }
+  return merged;
+}
+
+function normalizeProfileAllowlist(raw?: string[]): string[] {
+  return Array.isArray(raw) ? raw.map((entry) => entry.trim()).filter(Boolean) : [];
+}
+
+function resolveBrowserProxyConfig() {
+  const cfg = loadConfig();
+  const proxy = cfg.nodeHost?.browserProxy;
+  const allowProfiles = normalizeProfileAllowlist(proxy?.allowProfiles);
+  const enabled = proxy?.enabled !== false;
+  return { enabled, allowProfiles };
+}
+
+let browserControlReady: Promise<void> | null = null;
+
+async function ensureBrowserControlService(): Promise<void> {
+  if (browserControlReady) {
+    return browserControlReady;
+  }
+  browserControlReady = (async () => {
+    const cfg = loadConfig();
+    const resolved = resolveBrowserConfig(cfg.browser, cfg);
+    if (!resolved.enabled) {
+      throw new Error("browser control disabled");
+    }
+    const started = await startBrowserControlServiceFromConfig();
+    if (!started) {
+      throw new Error("browser control disabled");
+    }
+  })();
+  return browserControlReady;
+}
+
+function isProfileAllowed(params: { allowProfiles: string[]; profile?: string | null }) {
+  const { allowProfiles, profile } = params;
+  if (!allowProfiles.length) {
+    return true;
+  }
+  if (!profile) {
+    return false;
+  }
+  return allowProfiles.includes(profile.trim());
+}
+
+function collectBrowserProxyPaths(payload: unknown): string[] {
+  const paths = new Set<string>();
+  const obj =
+    typeof payload === "object" && payload !== null ? (payload as Record<string, unknown>) : null;
+  if (!obj) {
+    return [];
+  }
+  if (typeof obj.path === "string" && obj.path.trim()) {
+    paths.add(obj.path.trim());
+  }
+  if (typeof obj.imagePath === "string" && obj.imagePath.trim()) {
+    paths.add(obj.imagePath.trim());
+  }
+  const download = obj.download;
+  if (download && typeof download === "object") {
+    const dlPath = (download as Record<string, unknown>).path;
+    if (typeof dlPath === "string" && dlPath.trim()) {
+      paths.add(dlPath.trim());
+    }
+  }
+  return [...paths];
+}
+
+async function readBrowserProxyFile(filePath: string): Promise<BrowserProxyFile | null> {
+  const stat = await fsPromises.stat(filePath).catch(() => null);
+  if (!stat || !stat.isFile()) {
+    return null;
+  }
+  if (stat.size > BROWSER_PROXY_MAX_FILE_BYTES) {
+    throw new Error(
+      `browser proxy file exceeds ${Math.round(BROWSER_PROXY_MAX_FILE_BYTES / (1024 * 1024))}MB`,
+    );
+  }
+  const buffer = await fsPromises.readFile(filePath);
+  const mimeType = await detectMime({ buffer, filePath });
+  return { path: filePath, base64: buffer.toString("base64"), mimeType };
+}
+
+function formatCommand(argv: string[]): string {
+  return argv
+    .map((arg) => {
+      const trimmed = arg.trim();
+      if (!trimmed) {
+        return '""';
+      }
+      const needsQuotes = /\s|"/.test(trimmed);
+      if (!needsQuotes) {
+        return trimmed;
+      }
+      return `"${trimmed.replace(/"/g, '\\"')}"`;
+    })
+    .join(" ");
+}
+
+function truncateOutput(raw: string, maxChars: number): { text: string; truncated: boolean } {
+  if (raw.length <= maxChars) {
+    return { text: raw, truncated: false };
+  }
+  return { text: `... (truncated) ${raw.slice(raw.length - maxChars)}`, truncated: true };
+}
+
+function redactExecApprovals(file: ExecApprovalsFile): ExecApprovalsFile {
+  const socketPath = file.socket?.path?.trim();
+  return {
+    ...file,
+    socket: socketPath ? { path: socketPath } : undefined,
+  };
+}
+
+function requireExecApprovalsBaseHash(
+  params: SystemExecApprovalsSetParams,
+  snapshot: ExecApprovalsSnapshot,
+) {
+  if (!snapshot.exists) {
+    return;
+  }
+  if (!snapshot.hash) {
+    throw new Error("INVALID_REQUEST: exec approvals base hash unavailable; reload and retry");
+  }
+  const baseHash = typeof params.baseHash === "string" ? params.baseHash.trim() : "";
+  if (!baseHash) {
+    throw new Error("INVALID_REQUEST: exec approvals base hash required; reload and retry");
+  }
+  if (baseHash !== snapshot.hash) {
+    throw new Error("INVALID_REQUEST: exec approvals changed; reload and retry");
+  }
+}
+
+async function runCommand(
+  argv: string[],
+  cwd: string | undefined,
+  env: Record<string, string> | undefined,
+  timeoutMs: number | undefined,
+): Promise<RunResult> {
+  return await new Promise((resolve) => {
+    let stdout = "";
+    let stderr = "";
+    let outputLen = 0;
+    let truncated = false;
+    let timedOut = false;
+    let settled = false;
+
+    const child = spawn(argv[0], argv.slice(1), {
+      cwd,
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+      // closeOnExec removed - causes EBADF when closing stdio fds
+    } as unknown as Parameters<typeof spawn>[2]);
+
+    const onChunk = (chunk: Buffer, target: "stdout" | "stderr") => {
+      if (outputLen >= OUTPUT_CAP) {
+        truncated = true;
+        return;
+      }
+      const remaining = OUTPUT_CAP - outputLen;
+      const slice = chunk.length > remaining ? chunk.subarray(0, remaining) : chunk;
+      const str = slice.toString("utf8");
+      outputLen += slice.length;
+      if (target === "stdout") {
+        stdout += str;
+      } else {
+        stderr += str;
+      }
+      if (chunk.length > remaining) {
+        truncated = true;
+      }
+    };
+
+    child.stdout?.on("data", (chunk) => onChunk(chunk as Buffer, "stdout"));
+    child.stderr?.on("data", (chunk) => onChunk(chunk as Buffer, "stderr"));
+
+    let timer: NodeJS.Timeout | undefined;
+    if (timeoutMs && timeoutMs > 0) {
+      timer = setTimeout(() => {
+        timedOut = true;
+        try {
+          child.kill("SIGKILL");
+        } catch {
+          // ignore
+        }
+      }, timeoutMs);
+    }
+
+    const finalize = (exitCode?: number, error?: string | null) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (timer) {
+        clearTimeout(timer);
+      }
+      resolve({
+        exitCode,
+        timedOut,
+        success: exitCode === 0 && !timedOut && !error,
+        stdout,
+        stderr,
+        error: error ?? null,
+        truncated,
+      });
+    };
+
+    child.on("error", (err) => {
+      finalize(undefined, err.message);
+    });
+    child.on("exit", (code) => {
+      finalize(code === null ? undefined : code, null);
+    });
+  });
+}
+
+function resolveEnvPath(env?: Record<string, string>): string[] {
+  const raw =
+    env?.PATH ??
+    (env as Record<string, string>)?.Path ??
+    process.env.PATH ??
+    process.env.Path ??
+    DEFAULT_NODE_PATH;
+  return raw.split(path.delimiter).filter(Boolean);
+}
+
 function ensureNodePathEnv(): string {
   ensureOpenClawCliOnPath({ pathEnv: process.env.PATH ?? "" });
   const current = process.env.PATH ?? "";
@@ -65,6 +477,63 @@ function ensureNodePathEnv(): string {
   }
   process.env.PATH = DEFAULT_NODE_PATH;
   return DEFAULT_NODE_PATH;
+}
+
+function resolveExecutable(bin: string, env?: Record<string, string>) {
+  if (bin.includes("/") || bin.includes("\\")) {
+    return null;
+  }
+  const extensions =
+    process.platform === "win32"
+      ? (process.env.PATHEXT ?? process.env.PathExt ?? ".EXE;.CMD;.BAT;.COM")
+          .split(";")
+          .map((ext) => ext.toLowerCase())
+      : [""];
+  for (const dir of resolveEnvPath(env)) {
+    for (const ext of extensions) {
+      const candidate = path.join(dir, bin + ext);
+      if (fs.existsSync(candidate)) {
+        return candidate;
+      }
+    }
+  }
+  return null;
+}
+
+async function handleSystemWhich(params: SystemWhichParams, env?: Record<string, string>) {
+  const bins = params.bins.map((bin) => bin.trim()).filter(Boolean);
+  const found: Record<string, string> = {};
+  for (const bin of bins) {
+    const path = resolveExecutable(bin, env);
+    if (path) {
+      found[bin] = path;
+    }
+  }
+  return { bins: found };
+}
+
+function buildExecEventPayload(payload: ExecEventPayload): ExecEventPayload {
+  if (!payload.output) {
+    return payload;
+  }
+  const trimmed = payload.output.trim();
+  if (!trimmed) {
+    return payload;
+  }
+  const { text } = truncateOutput(trimmed, OUTPUT_EVENT_TAIL);
+  return { ...payload, output: text };
+}
+
+async function runViaMacAppExecHost(params: {
+  approvals: ReturnType<typeof resolveExecApprovals>;
+  request: ExecHostRequest;
+}): Promise<ExecHostResponse | null> {
+  const { approvals, request } = params;
+  return await requestExecHostViaSocket({
+    socketPath: approvals.socketPath,
+    token: approvals.token,
+    request,
+  });
 }
 
 export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
@@ -76,7 +545,6 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
   const displayName =
     opts.displayName?.trim() || config.displayName || (await getMachineDisplayName());
   config.displayName = displayName;
-
   const gateway: NodeHostGatewayConfig = {
     host: opts.gatewayHost,
     port: opts.gatewayPort,
@@ -87,9 +555,9 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
   await saveNodeHostConfig(config);
 
   const cfg = loadConfig();
+  const browserProxy = resolveBrowserProxyConfig();
   const resolvedBrowser = resolveBrowserConfig(cfg.browser, cfg);
-  const browserProxyEnabled =
-    cfg.nodeHost?.browserProxy?.enabled !== false && resolvedBrowser.enabled;
+  const browserProxyEnabled = browserProxy.enabled && resolvedBrowser.enabled;
   const isRemoteMode = cfg.gateway?.mode === "remote";
   const token =
     process.env.OPENCLAW_GATEWAY_TOKEN?.trim() ||
@@ -159,4 +627,663 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
 
   client.start();
   await new Promise(() => {});
+}
+
+async function handleInvoke(
+  frame: NodeInvokeRequestPayload,
+  client: GatewayClient,
+  skillBins: SkillBinsCache,
+) {
+  const command = String(frame.command ?? "");
+  if (command === "system.execApprovals.get") {
+    try {
+      ensureExecApprovals();
+      const snapshot = readExecApprovalsSnapshot();
+      const payload: ExecApprovalsSnapshot = {
+        path: snapshot.path,
+        exists: snapshot.exists,
+        hash: snapshot.hash,
+        file: redactExecApprovals(snapshot.file),
+      };
+      await sendInvokeResult(client, frame, {
+        ok: true,
+        payloadJSON: JSON.stringify(payload),
+      });
+    } catch (err) {
+      const message = String(err);
+      const code = message.toLowerCase().includes("timed out") ? "TIMEOUT" : "INVALID_REQUEST";
+      await sendInvokeResult(client, frame, {
+        ok: false,
+        error: { code, message },
+      });
+    }
+    return;
+  }
+
+  if (command === "system.execApprovals.set") {
+    try {
+      const params = decodeParams<SystemExecApprovalsSetParams>(frame.paramsJSON);
+      if (!params.file || typeof params.file !== "object") {
+        throw new Error("INVALID_REQUEST: exec approvals file required");
+      }
+      ensureExecApprovals();
+      const snapshot = readExecApprovalsSnapshot();
+      requireExecApprovalsBaseHash(params, snapshot);
+      const normalized = normalizeExecApprovals(params.file);
+      const currentSocketPath = snapshot.file.socket?.path?.trim();
+      const currentToken = snapshot.file.socket?.token?.trim();
+      const socketPath =
+        normalized.socket?.path?.trim() ?? currentSocketPath ?? resolveExecApprovalsSocketPath();
+      const token = normalized.socket?.token?.trim() ?? currentToken ?? "";
+      const next: ExecApprovalsFile = {
+        ...normalized,
+        socket: {
+          path: socketPath,
+          token,
+        },
+      };
+      saveExecApprovals(next);
+      const nextSnapshot = readExecApprovalsSnapshot();
+      const payload: ExecApprovalsSnapshot = {
+        path: nextSnapshot.path,
+        exists: nextSnapshot.exists,
+        hash: nextSnapshot.hash,
+        file: redactExecApprovals(nextSnapshot.file),
+      };
+      await sendInvokeResult(client, frame, {
+        ok: true,
+        payloadJSON: JSON.stringify(payload),
+      });
+    } catch (err) {
+      await sendInvokeResult(client, frame, {
+        ok: false,
+        error: { code: "INVALID_REQUEST", message: String(err) },
+      });
+    }
+    return;
+  }
+
+  if (command === "system.which") {
+    try {
+      const params = decodeParams<SystemWhichParams>(frame.paramsJSON);
+      if (!Array.isArray(params.bins)) {
+        throw new Error("INVALID_REQUEST: bins required");
+      }
+      const env = sanitizeEnv(undefined);
+      const payload = await handleSystemWhich(params, env);
+      await sendInvokeResult(client, frame, {
+        ok: true,
+        payloadJSON: JSON.stringify(payload),
+      });
+    } catch (err) {
+      await sendInvokeResult(client, frame, {
+        ok: false,
+        error: { code: "INVALID_REQUEST", message: String(err) },
+      });
+    }
+    return;
+  }
+
+  if (command === "browser.proxy") {
+    try {
+      const params = decodeParams<BrowserProxyParams>(frame.paramsJSON);
+      const pathValue = typeof params.path === "string" ? params.path.trim() : "";
+      if (!pathValue) {
+        throw new Error("INVALID_REQUEST: path required");
+      }
+      const proxyConfig = resolveBrowserProxyConfig();
+      if (!proxyConfig.enabled) {
+        throw new Error("UNAVAILABLE: node browser proxy disabled");
+      }
+      await ensureBrowserControlService();
+      const cfg = loadConfig();
+      const resolved = resolveBrowserConfig(cfg.browser, cfg);
+      const requestedProfile = typeof params.profile === "string" ? params.profile.trim() : "";
+      const allowedProfiles = proxyConfig.allowProfiles;
+      if (allowedProfiles.length > 0) {
+        if (pathValue !== "/profiles") {
+          const profileToCheck = requestedProfile || resolved.defaultProfile;
+          if (!isProfileAllowed({ allowProfiles: allowedProfiles, profile: profileToCheck })) {
+            throw new Error("INVALID_REQUEST: browser profile not allowed");
+          }
+        } else if (requestedProfile) {
+          if (!isProfileAllowed({ allowProfiles: allowedProfiles, profile: requestedProfile })) {
+            throw new Error("INVALID_REQUEST: browser profile not allowed");
+          }
+        }
+      }
+
+      const method = typeof params.method === "string" ? params.method.toUpperCase() : "GET";
+      const path = pathValue.startsWith("/") ? pathValue : `/${pathValue}`;
+      const body = params.body;
+      const query: Record<string, unknown> = {};
+      if (requestedProfile) {
+        query.profile = requestedProfile;
+      }
+      const rawQuery = params.query ?? {};
+      for (const [key, value] of Object.entries(rawQuery)) {
+        if (value === undefined || value === null) {
+          continue;
+        }
+        query[key] = typeof value === "string" ? value : String(value);
+      }
+      const dispatcher = createBrowserRouteDispatcher(createBrowserControlContext());
+      const response = await withTimeout(
+        (signal) =>
+          dispatcher.dispatch({
+            method: method === "DELETE" ? "DELETE" : method === "POST" ? "POST" : "GET",
+            path,
+            query,
+            body,
+            signal,
+          }),
+        params.timeoutMs,
+        "browser proxy request",
+      );
+      if (response.status >= 400) {
+        const message =
+          response.body && typeof response.body === "object" && "error" in response.body
+            ? String((response.body as { error?: unknown }).error)
+            : `HTTP ${response.status}`;
+        throw new Error(message);
+      }
+      const result = response.body;
+      if (allowedProfiles.length > 0 && path === "/profiles") {
+        const obj =
+          typeof result === "object" && result !== null ? (result as Record<string, unknown>) : {};
+        const profiles = Array.isArray(obj.profiles) ? obj.profiles : [];
+        obj.profiles = profiles.filter((entry) => {
+          if (!entry || typeof entry !== "object") {
+            return false;
+          }
+          const name = (entry as Record<string, unknown>).name;
+          return typeof name === "string" && allowedProfiles.includes(name);
+        });
+      }
+      let files: BrowserProxyFile[] | undefined;
+      const paths = collectBrowserProxyPaths(result);
+      if (paths.length > 0) {
+        const loaded = await Promise.all(
+          paths.map(async (p) => {
+            try {
+              const file = await readBrowserProxyFile(p);
+              if (!file) {
+                throw new Error("file not found");
+              }
+              return file;
+            } catch (err) {
+              throw new Error(`browser proxy file read failed for ${p}: ${String(err)}`, {
+                cause: err,
+              });
+            }
+          }),
+        );
+        if (loaded.length > 0) {
+          files = loaded;
+        }
+      }
+      const payload: BrowserProxyResult = files ? { result, files } : { result };
+      await sendInvokeResult(client, frame, {
+        ok: true,
+        payloadJSON: JSON.stringify(payload),
+      });
+    } catch (err) {
+      await sendInvokeResult(client, frame, {
+        ok: false,
+        error: { code: "INVALID_REQUEST", message: String(err) },
+      });
+    }
+    return;
+  }
+
+  if (command !== "system.run") {
+    await sendInvokeResult(client, frame, {
+      ok: false,
+      error: { code: "UNAVAILABLE", message: "command not supported" },
+    });
+    return;
+  }
+
+  let params: SystemRunParams;
+  try {
+    params = decodeParams<SystemRunParams>(frame.paramsJSON);
+  } catch (err) {
+    await sendInvokeResult(client, frame, {
+      ok: false,
+      error: { code: "INVALID_REQUEST", message: String(err) },
+    });
+    return;
+  }
+
+  if (!Array.isArray(params.command) || params.command.length === 0) {
+    await sendInvokeResult(client, frame, {
+      ok: false,
+      error: { code: "INVALID_REQUEST", message: "command required" },
+    });
+    return;
+  }
+
+  const argv = params.command.map((item) => String(item));
+  const rawCommand = typeof params.rawCommand === "string" ? params.rawCommand.trim() : "";
+  const cmdText = rawCommand || formatCommand(argv);
+  const agentId = params.agentId?.trim() || undefined;
+  const cfg = loadConfig();
+  const agentExec = agentId ? resolveAgentConfig(cfg, agentId)?.tools?.exec : undefined;
+  const configuredSecurity = resolveExecSecurity(agentExec?.security ?? cfg.tools?.exec?.security);
+  const configuredAsk = resolveExecAsk(agentExec?.ask ?? cfg.tools?.exec?.ask);
+  const approvals = resolveExecApprovals(agentId, {
+    security: configuredSecurity,
+    ask: configuredAsk,
+  });
+  const security = approvals.agent.security;
+  const ask = approvals.agent.ask;
+  const autoAllowSkills = approvals.agent.autoAllowSkills;
+  const sessionKey = params.sessionKey?.trim() || "node";
+  const runId = params.runId?.trim() || crypto.randomUUID();
+  const env = sanitizeEnv(params.env ?? undefined);
+  const safeBins = resolveSafeBins(agentExec?.safeBins ?? cfg.tools?.exec?.safeBins);
+  const bins = autoAllowSkills ? await skillBins.current() : new Set<string>();
+  let analysisOk = false;
+  let allowlistMatches: ExecAllowlistEntry[] = [];
+  let allowlistSatisfied = false;
+  let segments: ExecCommandSegment[] = [];
+  if (rawCommand) {
+    const allowlistEval = evaluateShellAllowlist({
+      command: rawCommand,
+      allowlist: approvals.allowlist,
+      safeBins,
+      cwd: params.cwd ?? undefined,
+      env,
+      skillBins: bins,
+      autoAllowSkills,
+      platform: process.platform,
+    });
+    analysisOk = allowlistEval.analysisOk;
+    allowlistMatches = allowlistEval.allowlistMatches;
+    allowlistSatisfied =
+      security === "allowlist" && analysisOk ? allowlistEval.allowlistSatisfied : false;
+    segments = allowlistEval.segments;
+  } else {
+    const analysis = analyzeArgvCommand({ argv, cwd: params.cwd ?? undefined, env });
+    const allowlistEval = evaluateExecAllowlist({
+      analysis,
+      allowlist: approvals.allowlist,
+      safeBins,
+      cwd: params.cwd ?? undefined,
+      skillBins: bins,
+      autoAllowSkills,
+    });
+    analysisOk = analysis.ok;
+    allowlistMatches = allowlistEval.allowlistMatches;
+    allowlistSatisfied =
+      security === "allowlist" && analysisOk ? allowlistEval.allowlistSatisfied : false;
+    segments = analysis.segments;
+  }
+  const isWindows = process.platform === "win32";
+  const cmdInvocation = rawCommand
+    ? isCmdExeInvocation(segments[0]?.argv ?? [])
+    : isCmdExeInvocation(argv);
+  if (security === "allowlist" && isWindows && cmdInvocation) {
+    analysisOk = false;
+    allowlistSatisfied = false;
+  }
+
+  const useMacAppExec = process.platform === "darwin";
+  if (useMacAppExec) {
+    const approvalDecision =
+      params.approvalDecision === "allow-once" || params.approvalDecision === "allow-always"
+        ? params.approvalDecision
+        : null;
+    const execRequest: ExecHostRequest = {
+      command: argv,
+      rawCommand: rawCommand || null,
+      cwd: params.cwd ?? null,
+      env: params.env ?? null,
+      timeoutMs: params.timeoutMs ?? null,
+      needsScreenRecording: params.needsScreenRecording ?? null,
+      agentId: agentId ?? null,
+      sessionKey: sessionKey ?? null,
+      approvalDecision,
+    };
+    const response = await runViaMacAppExecHost({ approvals, request: execRequest });
+    if (!response) {
+      if (execHostEnforced || !execHostFallbackAllowed) {
+        await sendNodeEvent(
+          client,
+          "exec.denied",
+          buildExecEventPayload({
+            sessionKey,
+            runId,
+            host: "node",
+            command: cmdText,
+            reason: "companion-unavailable",
+          }),
+        );
+        await sendInvokeResult(client, frame, {
+          ok: false,
+          error: {
+            code: "UNAVAILABLE",
+            message: "COMPANION_APP_UNAVAILABLE: macOS app exec host unreachable",
+          },
+        });
+        return;
+      }
+    } else if (!response.ok) {
+      const reason = response.error.reason ?? "approval-required";
+      await sendNodeEvent(
+        client,
+        "exec.denied",
+        buildExecEventPayload({
+          sessionKey,
+          runId,
+          host: "node",
+          command: cmdText,
+          reason,
+        }),
+      );
+      await sendInvokeResult(client, frame, {
+        ok: false,
+        error: { code: "UNAVAILABLE", message: response.error.message },
+      });
+      return;
+    } else {
+      const result: ExecHostRunResult = response.payload;
+      const combined = [result.stdout, result.stderr, result.error].filter(Boolean).join("\n");
+      await sendNodeEvent(
+        client,
+        "exec.finished",
+        buildExecEventPayload({
+          sessionKey,
+          runId,
+          host: "node",
+          command: cmdText,
+          exitCode: result.exitCode,
+          timedOut: result.timedOut,
+          success: result.success,
+          output: combined,
+        }),
+      );
+      await sendInvokeResult(client, frame, {
+        ok: true,
+        payloadJSON: JSON.stringify(result),
+      });
+      return;
+    }
+  }
+
+  if (security === "deny") {
+    await sendNodeEvent(
+      client,
+      "exec.denied",
+      buildExecEventPayload({
+        sessionKey,
+        runId,
+        host: "node",
+        command: cmdText,
+        reason: "security=deny",
+      }),
+    );
+    await sendInvokeResult(client, frame, {
+      ok: false,
+      error: { code: "UNAVAILABLE", message: "SYSTEM_RUN_DISABLED: security=deny" },
+    });
+    return;
+  }
+
+  const requiresAsk = requiresExecApproval({
+    ask,
+    security,
+    analysisOk,
+    allowlistSatisfied,
+  });
+
+  const approvalDecision =
+    params.approvalDecision === "allow-once" || params.approvalDecision === "allow-always"
+      ? params.approvalDecision
+      : null;
+  const approvedByAsk = approvalDecision !== null || params.approved === true;
+  if (requiresAsk && !approvedByAsk) {
+    await sendNodeEvent(
+      client,
+      "exec.denied",
+      buildExecEventPayload({
+        sessionKey,
+        runId,
+        host: "node",
+        command: cmdText,
+        reason: "approval-required",
+      }),
+    );
+    await sendInvokeResult(client, frame, {
+      ok: false,
+      error: { code: "UNAVAILABLE", message: "SYSTEM_RUN_DENIED: approval required" },
+    });
+    return;
+  }
+  if (approvalDecision === "allow-always" && security === "allowlist") {
+    if (analysisOk) {
+      for (const segment of segments) {
+        const pattern = segment.resolution?.resolvedPath ?? "";
+        if (pattern) {
+          addAllowlistEntry(approvals.file, agentId, pattern);
+        }
+      }
+    }
+  }
+
+  if (security === "allowlist" && (!analysisOk || !allowlistSatisfied) && !approvedByAsk) {
+    await sendNodeEvent(
+      client,
+      "exec.denied",
+      buildExecEventPayload({
+        sessionKey,
+        runId,
+        host: "node",
+        command: cmdText,
+        reason: "allowlist-miss",
+      }),
+    );
+    await sendInvokeResult(client, frame, {
+      ok: false,
+      error: { code: "UNAVAILABLE", message: "SYSTEM_RUN_DENIED: allowlist miss" },
+    });
+    return;
+  }
+
+  if (allowlistMatches.length > 0) {
+    const seen = new Set<string>();
+    for (const match of allowlistMatches) {
+      if (!match?.pattern || seen.has(match.pattern)) {
+        continue;
+      }
+      seen.add(match.pattern);
+      recordAllowlistUse(
+        approvals.file,
+        agentId,
+        match,
+        cmdText,
+        segments[0]?.resolution?.resolvedPath,
+      );
+    }
+  }
+
+  if (params.needsScreenRecording === true) {
+    await sendNodeEvent(
+      client,
+      "exec.denied",
+      buildExecEventPayload({
+        sessionKey,
+        runId,
+        host: "node",
+        command: cmdText,
+        reason: "permission:screenRecording",
+      }),
+    );
+    await sendInvokeResult(client, frame, {
+      ok: false,
+      error: { code: "UNAVAILABLE", message: "PERMISSION_MISSING: screenRecording" },
+    });
+    return;
+  }
+
+  let execArgv = argv;
+  if (
+    security === "allowlist" &&
+    isWindows &&
+    !approvedByAsk &&
+    rawCommand &&
+    analysisOk &&
+    allowlistSatisfied &&
+    segments.length === 1 &&
+    segments[0]?.argv.length > 0
+  ) {
+    // Avoid cmd.exe in allowlist mode on Windows; run the parsed argv directly.
+    execArgv = segments[0].argv;
+  }
+
+  const result = await runCommand(
+    execArgv,
+    params.cwd?.trim() || undefined,
+    env,
+    params.timeoutMs ?? undefined,
+  );
+  if (result.truncated) {
+    const suffix = "... (truncated)";
+    if (result.stderr.trim().length > 0) {
+      result.stderr = `${result.stderr}\n${suffix}`;
+    } else {
+      result.stdout = `${result.stdout}\n${suffix}`;
+    }
+  }
+  const combined = [result.stdout, result.stderr, result.error].filter(Boolean).join("\n");
+  await sendNodeEvent(
+    client,
+    "exec.finished",
+    buildExecEventPayload({
+      sessionKey,
+      runId,
+      host: "node",
+      command: cmdText,
+      exitCode: result.exitCode,
+      timedOut: result.timedOut,
+      success: result.success,
+      output: combined,
+    }),
+  );
+
+  await sendInvokeResult(client, frame, {
+    ok: true,
+    payloadJSON: JSON.stringify({
+      exitCode: result.exitCode,
+      timedOut: result.timedOut,
+      success: result.success,
+      stdout: result.stdout,
+      stderr: result.stderr,
+      error: result.error ?? null,
+    }),
+  });
+}
+
+function decodeParams<T>(raw?: string | null): T {
+  if (!raw) {
+    throw new Error("INVALID_REQUEST: paramsJSON required");
+  }
+  return JSON.parse(raw) as T;
+}
+
+function coerceNodeInvokePayload(payload: unknown): NodeInvokeRequestPayload | null {
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+  const obj = payload as Record<string, unknown>;
+  const id = typeof obj.id === "string" ? obj.id.trim() : "";
+  const nodeId = typeof obj.nodeId === "string" ? obj.nodeId.trim() : "";
+  const command = typeof obj.command === "string" ? obj.command.trim() : "";
+  if (!id || !nodeId || !command) {
+    return null;
+  }
+  const paramsJSON =
+    typeof obj.paramsJSON === "string"
+      ? obj.paramsJSON
+      : obj.params !== undefined
+        ? JSON.stringify(obj.params)
+        : null;
+  const timeoutMs = typeof obj.timeoutMs === "number" ? obj.timeoutMs : null;
+  const idempotencyKey = typeof obj.idempotencyKey === "string" ? obj.idempotencyKey : null;
+  return {
+    id,
+    nodeId,
+    command,
+    paramsJSON,
+    timeoutMs,
+    idempotencyKey,
+  };
+}
+
+async function sendInvokeResult(
+  client: GatewayClient,
+  frame: NodeInvokeRequestPayload,
+  result: {
+    ok: boolean;
+    payload?: unknown;
+    payloadJSON?: string | null;
+    error?: { code?: string; message?: string } | null;
+  },
+) {
+  try {
+    await client.request("node.invoke.result", buildNodeInvokeResultParams(frame, result));
+  } catch {
+    // ignore: node invoke responses are best-effort
+  }
+}
+
+export function buildNodeInvokeResultParams(
+  frame: NodeInvokeRequestPayload,
+  result: {
+    ok: boolean;
+    payload?: unknown;
+    payloadJSON?: string | null;
+    error?: { code?: string; message?: string } | null;
+  },
+): {
+  id: string;
+  nodeId: string;
+  ok: boolean;
+  payload?: unknown;
+  payloadJSON?: string;
+  error?: { code?: string; message?: string };
+} {
+  const params: {
+    id: string;
+    nodeId: string;
+    ok: boolean;
+    payload?: unknown;
+    payloadJSON?: string;
+    error?: { code?: string; message?: string };
+  } = {
+    id: frame.id,
+    nodeId: frame.nodeId,
+    ok: result.ok,
+  };
+  if (result.payload !== undefined) {
+    params.payload = result.payload;
+  }
+  if (typeof result.payloadJSON === "string") {
+    params.payloadJSON = result.payloadJSON;
+  }
+  if (result.error) {
+    params.error = result.error;
+  }
+  return params;
+}
+
+async function sendNodeEvent(client: GatewayClient, event: string, payload: unknown) {
+  try {
+    await client.request("node.event", {
+      event,
+      payloadJSON: payload ? JSON.stringify(payload) : null,
+    });
+  } catch {
+    // ignore: node events are best-effort
+  }
 }

--- a/src/process/spawn-utils.ts
+++ b/src/process/spawn-utils.ts
@@ -64,6 +64,8 @@ async function spawnAndWaitForSpawn(
   argv: string[],
   options: SpawnOptions,
 ): Promise<ChildProcess> {
+  // closeOnExec removed - it closes stdio fds and causes EBADF
+  // FD leak prevention is now handled by disabling PTY on macOS
   const child = spawnImpl(argv[0], argv.slice(1), options);
 
   return await new Promise((resolve, reject) => {

--- a/src/routing/session-key.test.ts
+++ b/src/routing/session-key.test.ts
@@ -1,5 +1,375 @@
 import { describe, expect, it } from "vitest";
-import { classifySessionKeyShape } from "./session-key.js";
+import {
+  buildAgentMainSessionKey,
+  classifySessionKeyShape,
+  buildAgentPeerSessionKey,
+  buildGroupHistoryKey,
+  DEFAULT_ACCOUNT_ID,
+  DEFAULT_AGENT_ID,
+  DEFAULT_MAIN_KEY,
+  normalizeAccountId,
+  normalizeAgentId,
+  normalizeMainKey,
+  resolveAgentIdFromSessionKey,
+  resolveThreadSessionKeys,
+  sanitizeAgentId,
+  toAgentRequestSessionKey,
+  toAgentStoreSessionKey,
+} from "./session-key.js";
+
+// ---------------------------------------------------------------------------
+// normalizeAgentId
+// ---------------------------------------------------------------------------
+
+describe("normalizeAgentId", () => {
+  it("returns DEFAULT_AGENT_ID for empty/null/undefined", () => {
+    expect(normalizeAgentId("")).toBe(DEFAULT_AGENT_ID);
+    expect(normalizeAgentId(null)).toBe(DEFAULT_AGENT_ID);
+    expect(normalizeAgentId(undefined)).toBe(DEFAULT_AGENT_ID);
+  });
+
+  it("lowercases valid ids", () => {
+    expect(normalizeAgentId("MyAgent")).toBe("myagent");
+    expect(normalizeAgentId("dofu")).toBe("dofu");
+  });
+
+  it("keeps hyphens and underscores", () => {
+    expect(normalizeAgentId("my-agent_1")).toBe("my-agent_1");
+  });
+
+  it("replaces invalid characters with hyphens", () => {
+    expect(normalizeAgentId("my agent!")).toBe("my-agent");
+  });
+
+  it("strips leading/trailing hyphens after normalization", () => {
+    expect(normalizeAgentId("---agent---")).toBe("agent");
+  });
+
+  it("truncates to 64 characters", () => {
+    const longId = "a".repeat(100);
+    expect(normalizeAgentId(longId).length).toBeLessThanOrEqual(64);
+  });
+
+  it("trims whitespace", () => {
+    expect(normalizeAgentId("  dofu  ")).toBe("dofu");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sanitizeAgentId
+// ---------------------------------------------------------------------------
+
+describe("sanitizeAgentId", () => {
+  it("returns DEFAULT_AGENT_ID for empty", () => {
+    expect(sanitizeAgentId("")).toBe(DEFAULT_AGENT_ID);
+    expect(sanitizeAgentId(null)).toBe(DEFAULT_AGENT_ID);
+  });
+
+  it("lowercases valid ids", () => {
+    expect(sanitizeAgentId("MyBot")).toBe("mybot");
+  });
+
+  it("replaces invalid characters", () => {
+    expect(sanitizeAgentId("bot@home!")).toBe("bot-home");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeAccountId
+// ---------------------------------------------------------------------------
+
+describe("normalizeAccountId", () => {
+  it("returns DEFAULT_ACCOUNT_ID for empty/null/undefined", () => {
+    expect(normalizeAccountId("")).toBe(DEFAULT_ACCOUNT_ID);
+    expect(normalizeAccountId(null)).toBe(DEFAULT_ACCOUNT_ID);
+    expect(normalizeAccountId(undefined)).toBe(DEFAULT_ACCOUNT_ID);
+  });
+
+  it("lowercases valid ids", () => {
+    expect(normalizeAccountId("Business")).toBe("business");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeMainKey
+// ---------------------------------------------------------------------------
+
+describe("normalizeMainKey", () => {
+  it("returns DEFAULT_MAIN_KEY for empty/null/undefined", () => {
+    expect(normalizeMainKey("")).toBe(DEFAULT_MAIN_KEY);
+    expect(normalizeMainKey(null)).toBe(DEFAULT_MAIN_KEY);
+    expect(normalizeMainKey(undefined)).toBe(DEFAULT_MAIN_KEY);
+  });
+
+  it("lowercases provided key", () => {
+    expect(normalizeMainKey("Session1")).toBe("session1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildAgentMainSessionKey
+// ---------------------------------------------------------------------------
+
+describe("buildAgentMainSessionKey", () => {
+  it("builds default key", () => {
+    expect(buildAgentMainSessionKey({ agentId: "dofu" })).toBe("agent:dofu:main");
+  });
+
+  it("builds with custom mainKey", () => {
+    expect(buildAgentMainSessionKey({ agentId: "dofu", mainKey: "custom" })).toBe(
+      "agent:dofu:custom",
+    );
+  });
+
+  it("normalizes agent id", () => {
+    expect(buildAgentMainSessionKey({ agentId: "My Agent" })).toBe("agent:my-agent:main");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildAgentPeerSessionKey
+// ---------------------------------------------------------------------------
+
+describe("buildAgentPeerSessionKey", () => {
+  it("returns main key for DM with scope=main", () => {
+    const key = buildAgentPeerSessionKey({
+      agentId: "dofu",
+      channel: "telegram",
+      peerKind: "dm",
+      peerId: "user123",
+      dmScope: "main",
+    });
+    expect(key).toBe("agent:dofu:main");
+  });
+
+  it("includes peer for DM with scope=per-peer", () => {
+    const key = buildAgentPeerSessionKey({
+      agentId: "dofu",
+      channel: "telegram",
+      peerKind: "dm",
+      peerId: "user123",
+      dmScope: "per-peer",
+    });
+    expect(key).toBe("agent:dofu:dm:user123");
+  });
+
+  it("includes channel for DM with scope=per-channel-peer", () => {
+    const key = buildAgentPeerSessionKey({
+      agentId: "dofu",
+      channel: "telegram",
+      peerKind: "dm",
+      peerId: "user123",
+      dmScope: "per-channel-peer",
+    });
+    expect(key).toBe("agent:dofu:telegram:dm:user123");
+  });
+
+  it("includes account for DM with scope=per-account-channel-peer", () => {
+    const key = buildAgentPeerSessionKey({
+      agentId: "dofu",
+      channel: "telegram",
+      accountId: "biz",
+      peerKind: "dm",
+      peerId: "user123",
+      dmScope: "per-account-channel-peer",
+    });
+    expect(key).toBe("agent:dofu:telegram:biz:dm:user123");
+  });
+
+  it("builds group session key", () => {
+    const key = buildAgentPeerSessionKey({
+      agentId: "dofu",
+      channel: "telegram",
+      peerKind: "group",
+      peerId: "-100123",
+    });
+    expect(key).toBe("agent:dofu:telegram:group:-100123");
+  });
+
+  it("builds channel session key", () => {
+    const key = buildAgentPeerSessionKey({
+      agentId: "dofu",
+      channel: "discord",
+      peerKind: "channel",
+      peerId: "ch-456",
+    });
+    expect(key).toBe("agent:dofu:discord:channel:ch-456");
+  });
+
+  it("uses 'unknown' for missing channel in group/channel mode", () => {
+    const key = buildAgentPeerSessionKey({
+      agentId: "dofu",
+      channel: "",
+      peerKind: "group",
+      peerId: "grp1",
+    });
+    expect(key).toBe("agent:dofu:unknown:group:grp1");
+  });
+
+  it("uses 'unknown' for missing peerId in group mode", () => {
+    const key = buildAgentPeerSessionKey({
+      agentId: "dofu",
+      channel: "telegram",
+      peerKind: "group",
+      peerId: "",
+    });
+    expect(key).toBe("agent:dofu:telegram:group:unknown");
+  });
+
+  it("resolves identity links for per-peer scope", () => {
+    const key = buildAgentPeerSessionKey({
+      agentId: "dofu",
+      channel: "telegram",
+      peerKind: "dm",
+      peerId: "111111111",
+      dmScope: "per-peer",
+      identityLinks: {
+        alice: ["telegram:111111111", "discord:222222222222222222"],
+      },
+    });
+    expect(key).toBe("agent:dofu:dm:alice");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// toAgentStoreSessionKey
+// ---------------------------------------------------------------------------
+
+describe("toAgentStoreSessionKey", () => {
+  it("returns main key for empty requestKey", () => {
+    const key = toAgentStoreSessionKey({ agentId: "dofu", requestKey: "" });
+    expect(key).toBe("agent:dofu:main");
+  });
+
+  it("returns main key for 'main' requestKey", () => {
+    const key = toAgentStoreSessionKey({ agentId: "dofu", requestKey: "main" });
+    expect(key).toBe("agent:dofu:main");
+  });
+
+  it("preserves agent: prefix", () => {
+    const key = toAgentStoreSessionKey({ agentId: "dofu", requestKey: "agent:other:session" });
+    expect(key).toBe("agent:other:session");
+  });
+
+  it("prefixes subagent: with agent:", () => {
+    const key = toAgentStoreSessionKey({ agentId: "dofu", requestKey: "subagent:task1" });
+    expect(key).toBe("agent:dofu:subagent:task1");
+  });
+
+  it("prefixes arbitrary key with agent:", () => {
+    const key = toAgentStoreSessionKey({ agentId: "dofu", requestKey: "telegram:dm:user1" });
+    expect(key).toBe("agent:dofu:telegram:dm:user1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// toAgentRequestSessionKey
+// ---------------------------------------------------------------------------
+
+describe("toAgentRequestSessionKey", () => {
+  it("returns undefined for empty key", () => {
+    expect(toAgentRequestSessionKey("")).toBeUndefined();
+    expect(toAgentRequestSessionKey(null)).toBeUndefined();
+  });
+
+  it("strips agent: prefix and returns rest", () => {
+    const result = toAgentRequestSessionKey("agent:dofu:telegram:dm:user1");
+    expect(result).toBe("telegram:dm:user1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveAgentIdFromSessionKey
+// ---------------------------------------------------------------------------
+
+describe("resolveAgentIdFromSessionKey", () => {
+  it("extracts agent id from session key", () => {
+    expect(resolveAgentIdFromSessionKey("agent:dofu:main")).toBe("dofu");
+  });
+
+  it("returns DEFAULT_AGENT_ID for non-parseable key", () => {
+    expect(resolveAgentIdFromSessionKey("invalid")).toBe(DEFAULT_AGENT_ID);
+  });
+
+  it("returns DEFAULT_AGENT_ID for null/undefined", () => {
+    expect(resolveAgentIdFromSessionKey(null)).toBe(DEFAULT_AGENT_ID);
+    expect(resolveAgentIdFromSessionKey(undefined)).toBe(DEFAULT_AGENT_ID);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildGroupHistoryKey
+// ---------------------------------------------------------------------------
+
+describe("buildGroupHistoryKey", () => {
+  it("builds key with all parts", () => {
+    const key = buildGroupHistoryKey({
+      channel: "telegram",
+      accountId: "default",
+      peerKind: "group",
+      peerId: "-100123",
+    });
+    expect(key).toBe("telegram:default:group:-100123");
+  });
+
+  it("uses default account when not provided", () => {
+    const key = buildGroupHistoryKey({
+      channel: "discord",
+      peerKind: "channel",
+      peerId: "ch-1",
+    });
+    expect(key).toBe("discord:default:channel:ch-1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveThreadSessionKeys
+// ---------------------------------------------------------------------------
+
+describe("resolveThreadSessionKeys", () => {
+  it("returns base key when no threadId", () => {
+    const result = resolveThreadSessionKeys({
+      baseSessionKey: "agent:dofu:main",
+      threadId: null,
+    });
+    expect(result.sessionKey).toBe("agent:dofu:main");
+    expect(result.parentSessionKey).toBeUndefined();
+  });
+
+  it("appends thread suffix by default", () => {
+    const result = resolveThreadSessionKeys({
+      baseSessionKey: "agent:dofu:discord:channel:ch1",
+      threadId: "thread-123",
+    });
+    expect(result.sessionKey).toBe("agent:dofu:discord:channel:ch1:thread:thread-123");
+  });
+
+  it("skips thread suffix when useSuffix=false", () => {
+    const result = resolveThreadSessionKeys({
+      baseSessionKey: "agent:dofu:main",
+      threadId: "thread-123",
+      useSuffix: false,
+    });
+    expect(result.sessionKey).toBe("agent:dofu:main");
+  });
+
+  it("passes parentSessionKey through", () => {
+    const result = resolveThreadSessionKeys({
+      baseSessionKey: "agent:dofu:main",
+      threadId: "thread-123",
+      parentSessionKey: "agent:dofu:discord:channel:parent",
+    });
+    expect(result.parentSessionKey).toBe("agent:dofu:discord:channel:parent");
+  });
+
+  it("lowercases threadId", () => {
+    const result = resolveThreadSessionKeys({
+      baseSessionKey: "agent:dofu:main",
+      threadId: "THREAD-ABC",
+    });
+    expect(result.sessionKey).toBe("agent:dofu:main:thread:thread-abc");
+  });
+});
 
 describe("classifySessionKeyShape", () => {
   it("classifies empty keys as missing", () => {

--- a/src/sessions/session-key-utils.test.ts
+++ b/src/sessions/session-key-utils.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import {
+  isAcpSessionKey,
+  isSubagentSessionKey,
+  parseAgentSessionKey,
+  resolveThreadParentSessionKey,
+} from "./session-key-utils.js";
+
+// ---------------------------------------------------------------------------
+// parseAgentSessionKey
+// ---------------------------------------------------------------------------
+
+describe("parseAgentSessionKey", () => {
+  it("returns null for empty/null/undefined", () => {
+    expect(parseAgentSessionKey("")).toBeNull();
+    expect(parseAgentSessionKey(null)).toBeNull();
+    expect(parseAgentSessionKey(undefined)).toBeNull();
+  });
+
+  it("returns null for keys with < 3 parts", () => {
+    expect(parseAgentSessionKey("agent:dofu")).toBeNull();
+    expect(parseAgentSessionKey("agent")).toBeNull();
+  });
+
+  it("returns null for non-agent prefix", () => {
+    expect(parseAgentSessionKey("user:dofu:main")).toBeNull();
+  });
+
+  it("parses valid agent session key", () => {
+    const result = parseAgentSessionKey("agent:dofu:main");
+    expect(result).toEqual({ agentId: "dofu", rest: "main" });
+  });
+
+  it("parses complex session key with multiple colons", () => {
+    const result = parseAgentSessionKey("agent:dofu:telegram:dm:user123");
+    expect(result).toEqual({ agentId: "dofu", rest: "telegram:dm:user123" });
+  });
+
+  it("trims whitespace", () => {
+    const result = parseAgentSessionKey("  agent:dofu:main  ");
+    expect(result).toEqual({ agentId: "dofu", rest: "main" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isSubagentSessionKey
+// ---------------------------------------------------------------------------
+
+describe("isSubagentSessionKey", () => {
+  it("returns false for empty", () => {
+    expect(isSubagentSessionKey("")).toBe(false);
+    expect(isSubagentSessionKey(null)).toBe(false);
+  });
+
+  it("returns true for direct subagent: prefix", () => {
+    expect(isSubagentSessionKey("subagent:task1")).toBe(true);
+  });
+
+  it("returns true for agent-wrapped subagent key", () => {
+    expect(isSubagentSessionKey("agent:dofu:subagent:task1")).toBe(true);
+  });
+
+  it("returns false for regular session key", () => {
+    expect(isSubagentSessionKey("agent:dofu:main")).toBe(false);
+  });
+
+  it("is case-insensitive", () => {
+    expect(isSubagentSessionKey("SUBAGENT:task")).toBe(true);
+    expect(isSubagentSessionKey("agent:dofu:SUBAGENT:task")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isAcpSessionKey
+// ---------------------------------------------------------------------------
+
+describe("isAcpSessionKey", () => {
+  it("returns false for empty", () => {
+    expect(isAcpSessionKey("")).toBe(false);
+    expect(isAcpSessionKey(null)).toBe(false);
+  });
+
+  it("returns true for direct acp: prefix", () => {
+    expect(isAcpSessionKey("acp:session1")).toBe(true);
+  });
+
+  it("returns true for agent-wrapped acp key", () => {
+    expect(isAcpSessionKey("agent:dofu:acp:session1")).toBe(true);
+  });
+
+  it("returns false for regular session key", () => {
+    expect(isAcpSessionKey("agent:dofu:main")).toBe(false);
+  });
+
+  it("is case-insensitive", () => {
+    expect(isAcpSessionKey("ACP:session")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveThreadParentSessionKey
+// ---------------------------------------------------------------------------
+
+describe("resolveThreadParentSessionKey", () => {
+  it("returns null for empty/null/undefined", () => {
+    expect(resolveThreadParentSessionKey("")).toBeNull();
+    expect(resolveThreadParentSessionKey(null)).toBeNull();
+    expect(resolveThreadParentSessionKey(undefined)).toBeNull();
+  });
+
+  it("returns null for non-thread session key", () => {
+    expect(resolveThreadParentSessionKey("agent:dofu:main")).toBeNull();
+  });
+
+  it("extracts parent from :thread: marker", () => {
+    const result = resolveThreadParentSessionKey(
+      "agent:dofu:discord:channel:ch1:thread:thread-123",
+    );
+    expect(result).toBe("agent:dofu:discord:channel:ch1");
+  });
+
+  it("extracts parent from :topic: marker", () => {
+    const result = resolveThreadParentSessionKey("agent:dofu:slack:channel:ch1:topic:topic-1");
+    expect(result).toBe("agent:dofu:slack:channel:ch1");
+  });
+
+  it("uses last marker when multiple exist", () => {
+    const result = resolveThreadParentSessionKey("agent:dofu:thread:old:thread:new");
+    // lastIndexOf finds the last :thread: marker
+    expect(result).toBe("agent:dofu:thread:old");
+  });
+
+  it("returns null when marker is at position 0", () => {
+    expect(resolveThreadParentSessionKey(":thread:123")).toBeNull();
+  });
+});

--- a/src/sessions/session-label.test.ts
+++ b/src/sessions/session-label.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { parseSessionLabel, SESSION_LABEL_MAX_LENGTH } from "./session-label.js";
+
+describe("parseSessionLabel", () => {
+  it("returns ok for valid label", () => {
+    const result = parseSessionLabel("my-session");
+    expect(result).toEqual({ ok: true, label: "my-session" });
+  });
+
+  it("trims whitespace", () => {
+    const result = parseSessionLabel("  trimmed  ");
+    expect(result).toEqual({ ok: true, label: "trimmed" });
+  });
+
+  it("rejects non-string input", () => {
+    expect(parseSessionLabel(123).ok).toBe(false);
+    expect(parseSessionLabel(null).ok).toBe(false);
+    expect(parseSessionLabel(undefined).ok).toBe(false);
+    expect(parseSessionLabel({}).ok).toBe(false);
+  });
+
+  it("rejects empty string", () => {
+    expect(parseSessionLabel("").ok).toBe(false);
+    expect(parseSessionLabel("   ").ok).toBe(false);
+  });
+
+  it("rejects labels exceeding max length", () => {
+    const tooLong = "a".repeat(SESSION_LABEL_MAX_LENGTH + 1);
+    const result = parseSessionLabel(tooLong);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("too long");
+    }
+  });
+
+  it("accepts labels at exactly max length", () => {
+    const exact = "a".repeat(SESSION_LABEL_MAX_LENGTH);
+    const result = parseSessionLabel(exact);
+    expect(result.ok).toBe(true);
+  });
+});

--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -350,7 +350,15 @@ export async function runOnboardingWizard(
           initialValue: baseConfig.agents?.defaults?.workspace ?? DEFAULT_WORKSPACE,
         }));
 
-  const workspaceDir = resolveUserPath(workspaceInput.trim() || DEFAULT_WORKSPACE);
+  let workspaceDir = resolveUserPath(workspaceInput.trim() || DEFAULT_WORKSPACE);
+
+  // Docker container safety: if the workspace path looks like a macOS/host path
+  // but we're in a Linux container, fall back to the container-native default.
+  if (process.platform === "linux" && workspaceDir.startsWith("/Users/")) {
+    const containerDefault = resolveUserPath(DEFAULT_WORKSPACE);
+    runtime.log(`Docker/container detected: using ${containerDefault} instead of ${workspaceDir}`);
+    workspaceDir = containerDefault;
+  }
 
   let nextConfig: OpenClawConfig = {
     ...baseConfig,


### PR DESCRIPTION
## Summary

Foundational infrastructure layer adding several interconnected systems. Grouped as a single PR because these modules share type dependencies.

### Hook lifecycle system
- `src/hooks/internal-hooks.ts`: event bus emitting `message:received`, `message:sent`, `model:request`, `model:response`, `session:updated`, etc.
- `src/plugins/hooks.ts` + `types.ts`: plugin hook bridge + `on_model_failover` interface
- Integration points in gateway startup, server channels, node events, outbound delivery, Telegram dispatch

### Model failover + task classifier
- `src/agents/model-fallback.ts`: multi-tier failover with configurable fallback chains, synthetic model routing, provider-aware retry
- `src/agents/task-classifier.ts`: classifies tasks for optimal model selection
- `src/agents/agent-scope.ts`: scope-aware model selection

### Embedded runner improvements
- `background-optimization.ts`: background task optimization for embedded sessions
- Enhanced `history.ts`, `pi-settings.ts`, `run.ts` with structured context integration

### In-flight tracker + graceful shutdown
- `src/infra/in-flight-tracker.ts`: tracks pending HTTP/WebSocket requests
- `src/cli/gateway-cli/run-loop.ts`: waits for in-flight completion before shutdown

### Session store enhancements
- TTL-based cache, path mapping (host↔container), session maintenance (prune/cap/rotate)
- `src/agents/path-map.ts`: bidirectional path translation

### Config & plumbing
- Extended types (`types.agents.ts`, `types.openclaw.ts`) and schemas
- Various integration points: memory tool, dispatch, commands, onboarding

## Test plan

- [ ] Type check passes (`tsgo`)
- [ ] Lint passes (`oxlint`)
- [ ] Unit tests pass for model-fallback, pi-settings, background-optimization, in-flight-tracker, session keys, cache utils
- [ ] Gateway shutdown gracefully waits for in-flight requests
- [ ] Hook events fire correctly on message/model lifecycle
- [ ] Session store cache invalidates on write

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces a foundational infrastructure layer encompassing hook lifecycle, model failover with smart routing, session management, embedded runner optimization, and graceful shutdown. The changes are well-structured with comprehensive test coverage. Previous thread concerns about hook type safety and in-flight tracker cleanup have been addressed.

Key additions:
- **Hook system**: `internal-hooks.ts` provides event-driven hooks (`message:received`, `model:select`, `model:failover`) with plugin bridge integration
- **Model failover**: Multi-tier failback with task classification, auth profile cooldown awareness, and hook-based smart routing
- **Embedded runner**: Background optimization triggers compaction proactively based on turn count and time thresholds
- **In-flight tracker**: Tracks pending requests and ensures graceful shutdown with configurable timeout (previous cleanup issues resolved)
- **Session store**: TTL-based caching, path mapping for container environments, and maintenance utilities
- **Spawn patch**: Global `closeOnExec: true` injection to prevent fd leaks across all spawn calls

The implementation follows project conventions with colocated tests, proper error handling, and clear separation of concerns.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor considerations
- Score reflects solid implementation with comprehensive tests, proper error handling, and resolved previous concerns. The infrastructural changes are well-integrated across multiple subsystems. Minor points to verify: spawn-patch global mutation impact, path-map edge cases with Windows paths, and task classifier pattern effectiveness in production.
- Pay close attention to `src/infra/spawn-patch.ts` (global mutation), `src/agents/path-map.ts` (cross-platform path handling), and `src/agents/task-classifier.ts` (pattern effectiveness)

<sub>Last reviewed commit: a1ac166</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->