### PR TITLE
feat(discord/voice): add voice transcription and auto-summarization

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -373,7 +373,7 @@ See [Slash commands](/tools/slash-commands) for command catalog and behavior.
 
 ## Voice transcription
 
-OpenClaw can auto-join Discord voice channels, transcribe speech via Groq Whisper, and produce a session summary when everyone leaves.
+OpenClaw can auto-join Discord voice channels, transcribe speech via Groq Whisper, and produce a session summary (using the agent's configured LLM) when everyone leaves.
 
 ### How it works
 
@@ -398,7 +398,6 @@ OpenClaw can auto-join Discord voice channels, transcribe speech via Groq Whispe
             transcriptionChannelId: "987654321098765432",
             groqApiKey: "gsk_...", // or use GROQ_API_KEY env var
             whisperModel: "whisper-large-v3-turbo",
-            summarizationModel: "llama-3.3-70b-versatile",
           },
         },
       },
@@ -416,7 +415,7 @@ OpenClaw can auto-join Discord voice channels, transcribe speech via Groq Whispe
 
 ### Requirements
 
-- **Groq API key**: Set via `voice.groqApiKey` config or `GROQ_API_KEY` environment variable. Required for both transcription (Whisper) and summarization (LLM).
+- **Groq API key**: Set via `voice.groqApiKey` config or `GROQ_API_KEY` environment variable. Required for Whisper speech-to-text transcription. Summarization uses the agent's configured LLM.
 - **Transcription channel**: A text channel ID where threads and summaries will be posted.
 - **Voice States intent**: Must be enabled so the gateway receives `VOICE_STATE_UPDATE` events.
 - **Bot permissions**: Connect and Speak in voice channels; Send Messages and Create Public Threads in the transcription channel.

--- a/extensions/discord/index.ts
+++ b/extensions/discord/index.ts
@@ -1,16 +1,160 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
-import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
+import { z } from "zod";
 import { discordPlugin } from "./src/channel.js";
-import { setDiscordRuntime } from "./src/runtime.js";
+import {
+  setDiscordRuntime,
+  setDiscordVoiceProvider,
+  getDiscordVoiceProvider,
+  setDiscordVoiceStateListener,
+} from "./src/runtime.js";
+import {
+  DiscordVoiceProvider,
+  DiscordVoiceConfigSchema,
+  resolveVoiceConfigFromPluginConfig,
+  resolveGroqApiKey,
+  DiscordVoiceStateListener,
+  VoiceSessionOrchestrator,
+} from "./src/voice/index.js";
+
+const DiscordPluginConfigSchema = z
+  .object({
+    voice: DiscordVoiceConfigSchema.optional(),
+  })
+  .passthrough();
+// registerDiscordListener is called from src/discord/monitor/provider.ts
+// where the Carbon client is available.
 
 const plugin = {
   id: "discord",
   name: "Discord",
-  description: "Discord channel plugin",
-  configSchema: emptyPluginConfigSchema(),
+  description: "Discord channel plugin with voice support",
+  configSchema: DiscordPluginConfigSchema,
   register(api: OpenClawPluginApi) {
     setDiscordRuntime(api.runtime);
     api.registerChannel({ plugin: discordPlugin });
+
+    // Initialize voice provider from plugin config
+    const voiceConfig = resolveVoiceConfigFromPluginConfig(api.pluginConfig);
+    if (voiceConfig.enabled) {
+      const voiceProvider = new DiscordVoiceProvider(voiceConfig);
+      setDiscordVoiceProvider(voiceProvider);
+
+      voiceProvider.on("error", (session, error) => {
+        api.logger.error(`[voice] Error in guild ${session.guildId}: ${error.message}`);
+      });
+
+      // Register voice commands
+      api.registerCommand({
+        name: "voice-join",
+        description: "Join a Discord voice channel",
+        acceptsArgs: true,
+        handler: async (ctx) => {
+          const provider = getDiscordVoiceProvider();
+          if (!provider) {
+            return { text: "Voice provider is not enabled." };
+          }
+          const args = ctx.args?.trim() ?? "";
+          const [guildId, channelId] = args.split(/\s+/);
+          if (!guildId || !channelId) {
+            return { text: "Usage: /voice-join <guildId> <channelId>" };
+          }
+          try {
+            const session = await provider.joinChannel({ guildId, channelId });
+            await provider.startListening(guildId);
+            return {
+              text: `Joined voice channel ${session.channelId} in guild ${session.guildId} (session: ${session.sessionId})`,
+            };
+          } catch (err) {
+            return { text: `Failed to join: ${err instanceof Error ? err.message : String(err)}` };
+          }
+        },
+      });
+
+      api.registerCommand({
+        name: "voice-leave",
+        description: "Leave the current Discord voice channel",
+        acceptsArgs: true,
+        handler: async (ctx) => {
+          const provider = getDiscordVoiceProvider();
+          if (!provider) {
+            return { text: "Voice provider is not enabled." };
+          }
+          const guildId = ctx.args?.trim();
+          if (!guildId) {
+            return { text: "Usage: /voice-leave <guildId>" };
+          }
+          try {
+            await provider.leaveChannel({ guildId, reason: "user" });
+            return { text: `Left voice channel in guild ${guildId}.` };
+          } catch (err) {
+            return { text: `Failed to leave: ${err instanceof Error ? err.message : String(err)}` };
+          }
+        },
+      });
+
+      api.registerCommand({
+        name: "voice-status",
+        description: "Show voice channel status",
+        acceptsArgs: true,
+        handler: (ctx) => {
+          const provider = getDiscordVoiceProvider();
+          if (!provider) {
+            return { text: "Voice provider is not enabled." };
+          }
+          const guildId = ctx.args?.trim() || undefined;
+          const status = provider.getStatus(guildId);
+          return { text: JSON.stringify(status, null, 2) };
+        },
+      });
+
+      // Initialize voice transcription orchestrator if Groq API key is available
+      const groqApiKey = resolveGroqApiKey(voiceConfig);
+      let orchestrator: VoiceSessionOrchestrator | undefined;
+      let voiceStateListener: DiscordVoiceStateListener | undefined;
+
+      if (groqApiKey && voiceConfig.autoJoin) {
+        voiceStateListener = new DiscordVoiceStateListener({
+          callbacks: {
+            onUserJoined: (guildId, userId, channelId) => {
+              void orchestrator?.onUserJoined(guildId, userId, channelId);
+            },
+            onUserLeft: (guildId, userId, channelId) => {
+              void orchestrator?.onUserLeft(guildId, userId, channelId);
+            },
+          },
+        });
+
+        orchestrator = new VoiceSessionOrchestrator({
+          voiceConfig,
+          provider: voiceProvider,
+          voiceStateListener,
+        });
+
+        // Store the listener so src/discord/monitor/provider.ts can register
+        // it with the Carbon client (where registerDiscordListener is called).
+        setDiscordVoiceStateListener(voiceStateListener);
+
+        api.logger.info(
+          `[voice] Auto-join transcription enabled${voiceConfig.transcriptionChannelId ? ` (thread channel: ${voiceConfig.transcriptionChannelId})` : ""}`,
+        );
+      } else if (!groqApiKey && voiceConfig.autoJoin) {
+        api.logger.warn(
+          "[voice] autoJoin is enabled but GROQ_API_KEY is missing — transcription disabled",
+        );
+      }
+
+      // Clean up voice provider when the gateway stops
+      api.on("gateway_stop", () => {
+        orchestrator?.destroy();
+        voiceStateListener?.destroy();
+        setDiscordVoiceStateListener(null);
+        const provider = getDiscordVoiceProvider();
+        if (provider) {
+          provider.destroy();
+          setDiscordVoiceProvider(null);
+        }
+      });
+    }
   },
 };
 

--- a/extensions/discord/index.ts
+++ b/extensions/discord/index.ts
@@ -128,6 +128,7 @@ const plugin = {
           voiceConfig,
           provider: voiceProvider,
           voiceStateListener,
+          coreConfig: api.config as Record<string, unknown> | undefined,
         });
 
         // Store the listener so src/discord/monitor/provider.ts can register

--- a/extensions/discord/openclaw.plugin.json
+++ b/extensions/discord/openclaw.plugin.json
@@ -4,6 +4,38 @@
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
-    "properties": {}
+    "properties": {
+      "voice": {
+        "type": "object",
+        "properties": {
+          "enabled": { "type": "boolean" },
+          "autoJoin": { "type": "boolean" },
+          "autoJoinGuilds": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "transcriptionChannelId": { "type": "string" },
+          "groqApiKey": { "type": "string" },
+          "whisperModel": { "type": "string" },
+          "summarizationModel": { "type": "string" },
+          "silenceTimeoutMs": { "type": "number" },
+          "maxRecordingDurationMs": { "type": "number" },
+          "transcriptionEnabled": { "type": "boolean" },
+          "ttsEnabled": { "type": "boolean" },
+          "autoJoinChannels": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "audioConfig": {
+            "type": "object",
+            "properties": {
+              "sampleRate": { "type": "number" },
+              "channels": { "type": "number" },
+              "bitrate": { "type": "number" }
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/extensions/discord/openclaw.plugin.json
+++ b/extensions/discord/openclaw.plugin.json
@@ -17,7 +17,6 @@
           "transcriptionChannelId": { "type": "string" },
           "groqApiKey": { "type": "string" },
           "whisperModel": { "type": "string" },
-          "summarizationModel": { "type": "string" },
           "silenceTimeoutMs": { "type": "number" },
           "maxRecordingDurationMs": { "type": "number" },
           "transcriptionEnabled": { "type": "boolean" },

--- a/extensions/discord/package.json
+++ b/extensions/discord/package.json
@@ -3,6 +3,13 @@
   "version": "2026.2.13",
   "description": "OpenClaw Discord channel plugin",
   "type": "module",
+  "dependencies": {
+    "@discordjs/opus": "^0.10.0",
+    "@discordjs/voice": "^0.18.0",
+    "libsodium-wrappers": "^0.7.0",
+    "opusscript": "^0.0.8",
+    "prism-media": "^1.3.5"
+  },
   "devDependencies": {
     "openclaw": "workspace:*"
   },

--- a/extensions/discord/src/runtime.ts
+++ b/extensions/discord/src/runtime.ts
@@ -1,4 +1,14 @@
 import type { PluginRuntime } from "openclaw/plugin-sdk";
+import type { DiscordVoiceProvider } from "./voice/provider.js";
+import type { DiscordVoiceStateListener } from "./voice/voice-state-listener.js";
+
+// Voice state listener and voice provider use globalThis because the plugin
+// is loaded via jiti (separate module cache) while provider.ts uses native ESM.
+// Module-level singletons would be invisible across that boundary.
+const G = globalThis as unknown as {
+  __openclawDiscordVoiceStateListener?: DiscordVoiceStateListener | null;
+  __openclawDiscordVoiceProvider?: DiscordVoiceProvider | null;
+};
 
 let runtime: PluginRuntime | null = null;
 
@@ -11,4 +21,20 @@ export function getDiscordRuntime(): PluginRuntime {
     throw new Error("Discord runtime not initialized");
   }
   return runtime;
+}
+
+export function setDiscordVoiceProvider(provider: DiscordVoiceProvider | null) {
+  G.__openclawDiscordVoiceProvider = provider;
+}
+
+export function getDiscordVoiceProvider(): DiscordVoiceProvider | null {
+  return G.__openclawDiscordVoiceProvider ?? null;
+}
+
+export function setDiscordVoiceStateListener(listener: DiscordVoiceStateListener | null) {
+  G.__openclawDiscordVoiceStateListener = listener;
+}
+
+export function getDiscordVoiceStateListener(): DiscordVoiceStateListener | null {
+  return G.__openclawDiscordVoiceStateListener ?? null;
 }

--- a/extensions/discord/src/voice/audio-pipeline.ts
+++ b/extensions/discord/src/voice/audio-pipeline.ts
@@ -50,24 +50,40 @@ export class IncomingAudioHandler extends EventEmitter {
     this.config = { ...DEFAULT_AUDIO_CONFIG, ...config };
   }
 
+  private _decoders?: Map<string, opus.Decoder>;
+  private _chunkCounts: Map<string, number> = new Map();
+  private _pcmCounts: Map<string, number> = new Map();
+
   handleAudioChunk(userId: string, opusChunk: Buffer): void {
+    const count = (this._chunkCounts.get(userId) ?? 0) + 1;
+    this._chunkCounts.set(userId, count);
+    if (count === 1) {
+      console.log(
+        `[audio-pipeline] first opus chunk for user ${userId} (${opusChunk.length} bytes)`,
+      );
+    }
+
     // Get or create a persistent decoder for this user (reuse across packets)
     if (!this._decoders) this._decoders = new Map();
     let decoder = this._decoders.get(userId);
     if (!decoder) {
+      console.log(`[audio-pipeline] creating opus decoder for user ${userId}`);
       decoder = createOpusDecoder();
       this._decoders.set(userId, decoder);
       decoder.on("data", (pcm: Buffer) => {
+        const pcmCount = (this._pcmCounts.get(userId) ?? 0) + 1;
+        this._pcmCounts.set(userId, pcmCount);
+        if (pcmCount === 1) {
+          console.log(`[audio-pipeline] first PCM frame for user ${userId} (${pcm.length} bytes)`);
+        }
         this.processDecodedAudio(userId, pcm);
       });
       decoder.on("error", (err: Error) => {
-        console.error(`[audio] opus decode error for ${userId}:`, err.message);
+        console.error(`[audio-pipeline] opus decode error for ${userId}:`, err.message);
       });
     }
     decoder.write(opusChunk);
   }
-
-  private _decoders?: Map<string, opus.Decoder>;
 
   private processDecodedAudio(userId: string, pcmData: Buffer): void {
     if (!this.buffers.has(userId)) {
@@ -116,10 +132,15 @@ export class IncomingAudioHandler extends EventEmitter {
   flushUserAudio(userId: string): Buffer | null {
     const userBuffers = this.buffers.get(userId);
     if (!userBuffers || userBuffers.length === 0) {
+      console.log(`[audio-pipeline] flushUserAudio(${userId}): no buffers to flush`);
       return null;
     }
 
     const combined = Buffer.concat(userBuffers);
+    const durationS = combined.length / (48000 * 2 * 2);
+    console.log(
+      `[audio-pipeline] flushUserAudio(${userId}): ${userBuffers.length} buffers, ${combined.length} bytes (${durationS.toFixed(1)}s), emitting audioComplete`,
+    );
     userBuffers.length = 0;
 
     this.emit("audioComplete", { userId, data: combined });

--- a/extensions/discord/src/voice/audio-pipeline.ts
+++ b/extensions/discord/src/voice/audio-pipeline.ts
@@ -1,0 +1,225 @@
+import { createAudioResource, StreamType, type AudioResource } from "@discordjs/voice";
+import { EventEmitter } from "node:events";
+import {} from "node:stream";
+import { opus } from "prism-media";
+import type { AudioConfig } from "./types.js";
+
+const DEFAULT_AUDIO_CONFIG: AudioConfig = {
+  sampleRate: 48000,
+  channels: 2,
+  bitrate: 64,
+};
+
+const OPUS_FRAME_SIZE = 960;
+const OPUS_SAMPLE_RATE = 48000;
+const OPUS_CHANNELS = 2;
+
+/** Creates a prism-media Opus decoder Transform stream. */
+function createOpusDecoder(): opus.Decoder {
+  return new opus.Decoder({
+    channels: OPUS_CHANNELS,
+    frameSize: OPUS_FRAME_SIZE,
+    rate: OPUS_SAMPLE_RATE,
+  });
+}
+
+/** Creates a prism-media Opus encoder Transform stream. */
+function createOpusEncoder(): opus.Encoder {
+  return new opus.Encoder({
+    channels: OPUS_CHANNELS,
+    frameSize: OPUS_FRAME_SIZE,
+    rate: OPUS_SAMPLE_RATE,
+  });
+}
+
+export interface AudioBuffer {
+  data: Buffer;
+  timestamp: number;
+  userId?: string;
+}
+
+export class IncomingAudioHandler extends EventEmitter {
+  private buffers: Map<string, Buffer[]> = new Map();
+  private config: AudioConfig;
+  private silenceThreshold: number = 0.01;
+  private silenceTimeoutMs: number = 2000;
+  private silenceTimers: Map<string, NodeJS.Timeout> = new Map();
+
+  constructor(config: Partial<AudioConfig> = {}) {
+    super();
+    this.config = { ...DEFAULT_AUDIO_CONFIG, ...config };
+  }
+
+  handleAudioChunk(userId: string, opusChunk: Buffer): void {
+    // Get or create a persistent decoder for this user (reuse across packets)
+    if (!this._decoders) this._decoders = new Map();
+    let decoder = this._decoders.get(userId);
+    if (!decoder) {
+      decoder = createOpusDecoder();
+      this._decoders.set(userId, decoder);
+      decoder.on("data", (pcm: Buffer) => {
+        this.processDecodedAudio(userId, pcm);
+      });
+      decoder.on("error", (err: Error) => {
+        console.error(`[audio] opus decode error for ${userId}:`, err.message);
+      });
+    }
+    decoder.write(opusChunk);
+  }
+
+  private _decoders?: Map<string, opus.Decoder>;
+
+  private processDecodedAudio(userId: string, pcmData: Buffer): void {
+    if (!this.buffers.has(userId)) {
+      this.buffers.set(userId, []);
+    }
+
+    const userBuffers = this.buffers.get(userId)!;
+    userBuffers.push(pcmData);
+
+    this.resetSilenceTimer(userId);
+
+    if (this.isSilent(pcmData)) {
+      this.emit("silence", { userId, partial: true });
+    } else {
+      this.emit("audio", { userId, data: pcmData });
+    }
+  }
+
+  private resetSilenceTimer(userId: string): void {
+    const existing = this.silenceTimers.get(userId);
+    if (existing) {
+      clearTimeout(existing);
+    }
+
+    const timer = setTimeout(() => {
+      this.flushUserAudio(userId);
+    }, this.silenceTimeoutMs);
+
+    this.silenceTimers.set(userId, timer);
+  }
+
+  private isSilent(pcmData: Buffer): boolean {
+    if (pcmData.length < 2) return true;
+
+    let sum = 0;
+    for (let i = 0; i < pcmData.length; i += 2) {
+      const sample = pcmData.readInt16LE(i);
+      sum += Math.abs(sample);
+    }
+    const avg = sum / (pcmData.length / 2);
+    const normalizedAvg = avg / 32768;
+
+    return normalizedAvg < this.silenceThreshold;
+  }
+
+  flushUserAudio(userId: string): Buffer | null {
+    const userBuffers = this.buffers.get(userId);
+    if (!userBuffers || userBuffers.length === 0) {
+      return null;
+    }
+
+    const combined = Buffer.concat(userBuffers);
+    userBuffers.length = 0;
+
+    this.emit("audioComplete", { userId, data: combined });
+    this.emit("silence", { userId, durationMs: this.silenceTimeoutMs });
+
+    return combined;
+  }
+
+  clearUser(userId: string): void {
+    this.buffers.delete(userId);
+    const timer = this.silenceTimers.get(userId);
+    if (timer) {
+      clearTimeout(timer);
+      this.silenceTimers.delete(userId);
+    }
+    const decoder = this._decoders?.get(userId);
+    if (decoder) {
+      decoder.destroy();
+      this._decoders!.delete(userId);
+    }
+  }
+
+  destroy(): void {
+    for (const timer of this.silenceTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.silenceTimers.clear();
+    this.buffers.clear();
+    if (this._decoders) {
+      for (const d of this._decoders.values()) d.destroy();
+      this._decoders.clear();
+    }
+    this.removeAllListeners();
+  }
+}
+
+export class OutgoingAudioHandler {
+  private encoder: opus.Encoder | null = null;
+  private config: AudioConfig;
+
+  constructor(config: Partial<AudioConfig> = {}) {
+    this.config = { ...DEFAULT_AUDIO_CONFIG, ...config };
+  }
+
+  createAudioResourceFromPcm(pcmStream: NodeJS.ReadableStream): AudioResource {
+    const encoder = createOpusEncoder();
+    const opusStream = pcmStream.pipe(encoder);
+
+    return createAudioResource(opusStream, {
+      inputType: StreamType.Opus,
+    });
+  }
+
+  async encodePcmToOpus(pcmData: Buffer): Promise<Buffer> {
+    return new Promise((resolve, reject) => {
+      const encoder = createOpusEncoder();
+      const chunks: Buffer[] = [];
+
+      encoder.on("data", (chunk: Buffer) => {
+        chunks.push(chunk);
+      });
+
+      encoder.on("end", () => {
+        resolve(Buffer.concat(chunks));
+      });
+
+      encoder.on("error", reject);
+
+      encoder.write(pcmData);
+      encoder.end();
+    });
+  }
+
+  destroy(): void {
+    if (this.encoder) {
+      this.encoder.destroy();
+      this.encoder = null;
+    }
+  }
+}
+
+export class AudioPipeline {
+  private incoming: IncomingAudioHandler;
+  private outgoing: OutgoingAudioHandler;
+
+  constructor(config: Partial<AudioConfig> = {}) {
+    this.incoming = new IncomingAudioHandler(config);
+    this.outgoing = new OutgoingAudioHandler(config);
+  }
+
+  getIncoming(): IncomingAudioHandler {
+    return this.incoming;
+  }
+
+  getOutgoing(): OutgoingAudioHandler {
+    return this.outgoing;
+  }
+
+  destroy(): void {
+    this.incoming.destroy();
+    this.outgoing.destroy();
+  }
+}

--- a/extensions/discord/src/voice/config.ts
+++ b/extensions/discord/src/voice/config.ts
@@ -1,0 +1,70 @@
+import { z } from "zod";
+
+export const DiscordVoiceConfigSchema = z.object({
+  enabled: z.boolean().default(true),
+  autoJoinChannels: z.array(z.string()).optional(),
+  transcriptionEnabled: z.boolean().default(true),
+  ttsEnabled: z.boolean().default(true),
+  silenceTimeoutMs: z.number().min(500).max(30000).default(2000),
+  maxRecordingDurationMs: z.number().min(10000).max(3600000).optional(),
+  audioConfig: z
+    .object({
+      sampleRate: z.number().default(48000),
+      channels: z.number().min(1).max(2).default(2),
+      bitrate: z.number().min(16).max(128).default(64),
+    })
+    .optional(),
+  groqApiKey: z.string().optional(),
+  transcriptionChannelId: z.string().optional(),
+  whisperModel: z.string().default("whisper-large-v3-turbo"),
+  summarizationModel: z.string().default("llama-3.3-70b-versatile"),
+  autoJoin: z.boolean().default(false),
+  autoJoinGuilds: z.array(z.string()).optional(),
+});
+
+export type DiscordVoiceConfig = z.infer<typeof DiscordVoiceConfigSchema>;
+
+export const DEFAULT_DISCORD_VOICE_CONFIG: DiscordVoiceConfig = {
+  enabled: true,
+  transcriptionEnabled: true,
+  ttsEnabled: true,
+  silenceTimeoutMs: 2000,
+  whisperModel: "whisper-large-v3-turbo",
+  summarizationModel: "llama-3.3-70b-versatile",
+  autoJoin: false,
+};
+
+export function parseDiscordVoiceConfig(value: unknown): DiscordVoiceConfig {
+  return DiscordVoiceConfigSchema.parse(value ?? {});
+}
+
+export function mergeVoiceConfig(
+  base: DiscordVoiceConfig,
+  override: Partial<DiscordVoiceConfig>,
+): DiscordVoiceConfig {
+  const merged = {
+    ...base,
+    ...override,
+  };
+  if (base.audioConfig || override.audioConfig) {
+    merged.audioConfig = {
+      ...base.audioConfig,
+      ...override.audioConfig,
+    } as DiscordVoiceConfig["audioConfig"];
+  }
+  return merged;
+}
+
+export function resolveVoiceConfigFromPluginConfig(
+  pluginConfig: Record<string, unknown> | undefined,
+): DiscordVoiceConfig {
+  if (!pluginConfig?.voice || typeof pluginConfig.voice !== "object") {
+    return DEFAULT_DISCORD_VOICE_CONFIG;
+  }
+  return parseDiscordVoiceConfig(pluginConfig.voice);
+}
+
+/** Resolve the Groq API key from config or environment. */
+export function resolveGroqApiKey(config: DiscordVoiceConfig): string | undefined {
+  return config.groqApiKey || process.env.GROQ_API_KEY || undefined;
+}

--- a/extensions/discord/src/voice/config.ts
+++ b/extensions/discord/src/voice/config.ts
@@ -17,7 +17,6 @@ export const DiscordVoiceConfigSchema = z.object({
   groqApiKey: z.string().optional(),
   transcriptionChannelId: z.string().optional(),
   whisperModel: z.string().default("whisper-large-v3-turbo"),
-  summarizationModel: z.string().default("llama-3.3-70b-versatile"),
   autoJoin: z.boolean().default(false),
   autoJoinGuilds: z.array(z.string()).optional(),
 });
@@ -30,7 +29,6 @@ export const DEFAULT_DISCORD_VOICE_CONFIG: DiscordVoiceConfig = {
   ttsEnabled: true,
   silenceTimeoutMs: 2000,
   whisperModel: "whisper-large-v3-turbo",
-  summarizationModel: "llama-3.3-70b-versatile",
   autoJoin: false,
 };
 

--- a/extensions/discord/src/voice/connection.ts
+++ b/extensions/discord/src/voice/connection.ts
@@ -211,14 +211,12 @@ export class DiscordVoiceConnectionManager extends EventEmitter<VoiceConnectionE
     };
 
     speakingMap.on("start", (userId: string) => {
-      console.log(`[voice-conn] user ${userId} started speaking`);
       const user = ensureUser(userId);
       user.speaking = true;
       this.emit("userSpeaking", session, userId, true);
     });
 
     speakingMap.on("end", (userId: string) => {
-      console.log(`[voice-conn] user ${userId} stopped speaking`);
       const user = ensureUser(userId);
       user.speaking = false;
       this.emit("userSpeaking", session, userId, false);
@@ -266,13 +264,9 @@ export class DiscordVoiceConnectionManager extends EventEmitter<VoiceConnectionE
 
     if ("token" in payload && "endpoint" in payload) {
       // VOICE_SERVER_UPDATE — cast through unknown to bridge discord-api-types versions
-      console.log(`[voice-conn] forwarding VOICE_SERVER_UPDATE to adapter for guild ${guildId}`);
       methods.onVoiceServerUpdate(payload as never);
     } else if ("session_id" in payload) {
       // VOICE_STATE_UPDATE
-      console.log(
-        `[voice-conn] forwarding VOICE_STATE_UPDATE to adapter for guild ${guildId} (session_id=${payload.session_id})`,
-      );
       methods.onVoiceStateUpdate(payload as never);
     }
   }
@@ -289,7 +283,6 @@ export class DiscordVoiceConnectionManager extends EventEmitter<VoiceConnectionE
             return false;
           }
           try {
-            console.log(`[voice-conn] sendPayload: sending opcode ${payload.op} to gateway`);
             gateway.send(payload);
             return true;
           } catch (err) {

--- a/extensions/discord/src/voice/connection.ts
+++ b/extensions/discord/src/voice/connection.ts
@@ -1,0 +1,360 @@
+import {
+  joinVoiceChannel,
+  createAudioPlayer,
+  createAudioResource,
+  VoiceConnectionStatus,
+  AudioPlayerStatus,
+  getVoiceConnection,
+  type VoiceConnection,
+  type AudioPlayer,
+  type DiscordGatewayAdapterLibraryMethods,
+} from "@discordjs/voice";
+// Use `unknown` for gateway payloads to avoid discord-api-types version
+// mismatches between root and extension node_modules.
+type VoiceGatewayPayload = Record<string, unknown>;
+import { randomUUID } from "node:crypto";
+import { EventEmitter } from "node:events";
+import type {
+  VoiceChannelSession,
+  VoiceChannelUser,
+  VoiceJoinOptions,
+  VoiceConnectionState,
+} from "./types.js";
+import { getGateway } from "../../../../src/discord/monitor/gateway-registry.js";
+
+type VoiceConnectionEvents = {
+  stateChange: [session: VoiceChannelSession, state: VoiceConnectionState];
+  userJoin: [session: VoiceChannelSession, user: VoiceChannelUser];
+  userLeave: [session: VoiceChannelSession, userId: string];
+  userSpeaking: [session: VoiceChannelSession, userId: string, speaking: boolean];
+  error: [session: VoiceChannelSession, error: Error];
+  destroy: [session: VoiceChannelSession];
+};
+
+export class DiscordVoiceConnectionManager extends EventEmitter<VoiceConnectionEvents> {
+  private sessions: Map<string, VoiceChannelSession> = new Map();
+  private guildSessionIndex: Map<string, string> = new Map();
+  /** Stores @discordjs/voice adapter methods per guild for forwarding gateway events. */
+  private adapterMethods: Map<string, DiscordGatewayAdapterLibraryMethods> = new Map();
+  private accountId: string | undefined;
+
+  constructor(accountId?: string) {
+    super();
+    this.accountId = accountId;
+  }
+
+  async joinChannel(options: VoiceJoinOptions): Promise<VoiceChannelSession> {
+    const existingSessionId = this.guildSessionIndex.get(options.guildId);
+    if (existingSessionId) {
+      const existing = this.sessions.get(existingSessionId);
+      if (existing && existing.channelId === options.channelId) {
+        return existing;
+      }
+      await this.leaveChannel({ guildId: options.guildId });
+    }
+
+    const sessionId = randomUUID();
+    const connection = joinVoiceChannel({
+      guildId: options.guildId,
+      channelId: options.channelId,
+      selfMute: options.selfMute ?? false,
+      selfDeaf: options.selfDeaf ?? false,
+      adapterCreator: this.createAdapterCreator(options.guildId),
+    });
+
+    const player = createAudioPlayer();
+
+    const session: VoiceChannelSession = {
+      sessionId,
+      guildId: options.guildId,
+      channelId: options.channelId,
+      connection,
+      player,
+      state: "idle",
+      users: new Map(),
+      startedAt: Date.now(),
+      transcript: [],
+    };
+
+    this.sessions.set(sessionId, session);
+    this.guildSessionIndex.set(options.guildId, sessionId);
+
+    this.setupConnectionHandlers(session);
+    this.setupPlayerHandlers(session);
+
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        reject(new Error("Voice connection timeout"));
+      }, 30000);
+
+      connection.once(VoiceConnectionStatus.Ready, () => {
+        clearTimeout(timeout);
+        session.state = "listening";
+        this.emit("stateChange", session, "ready");
+        resolve(session);
+      });
+
+      connection.once(VoiceConnectionStatus.Disconnected, () => {
+        clearTimeout(timeout);
+        reject(new Error("Voice connection disconnected"));
+      });
+
+      connection.once(VoiceConnectionStatus.Destroyed, () => {
+        clearTimeout(timeout);
+        reject(new Error("Voice connection destroyed"));
+      });
+    });
+  }
+
+  async leaveChannel(options: { guildId: string; reason?: string }): Promise<void> {
+    const sessionId = this.guildSessionIndex.get(options.guildId);
+    if (!sessionId) {
+      return;
+    }
+
+    const session = this.sessions.get(sessionId);
+    if (!session) {
+      return;
+    }
+
+    if (session.player) {
+      session.player.stop();
+    }
+
+    if (session.connection) {
+      session.connection.destroy();
+    }
+
+    session.endedAt = Date.now();
+    session.state = "idle";
+
+    this.sessions.delete(sessionId);
+    this.guildSessionIndex.delete(options.guildId);
+
+    this.emit("destroy", session);
+  }
+
+  getSession(guildId: string): VoiceChannelSession | undefined {
+    const sessionId = this.guildSessionIndex.get(guildId);
+    if (!sessionId) return undefined;
+    return this.sessions.get(sessionId);
+  }
+
+  getAllSessions(): VoiceChannelSession[] {
+    return Array.from(this.sessions.values());
+  }
+
+  getConnectionState(session: VoiceChannelSession): VoiceConnectionState {
+    if (!session.connection) return "disconnected";
+
+    switch (session.connection.state.status) {
+      case VoiceConnectionStatus.Ready:
+        return "ready";
+      case VoiceConnectionStatus.Connecting:
+      case VoiceConnectionStatus.Signalling:
+        return "connecting";
+      case VoiceConnectionStatus.Connected:
+        return "connected";
+      case VoiceConnectionStatus.Disconnected:
+        return "disconnected";
+      case VoiceConnectionStatus.Destroyed:
+        return "disconnected";
+      default:
+        return "error";
+    }
+  }
+
+  private setupConnectionHandlers(session: VoiceChannelSession): void {
+    if (!session.connection) return;
+
+    session.connection.on(VoiceConnectionStatus.Ready, () => {
+      this.emit("stateChange", session, "ready");
+    });
+
+    session.connection.on(VoiceConnectionStatus.Disconnected, async () => {
+      try {
+        await Promise.race([
+          entersState(session.connection!, VoiceConnectionStatus.Signalling, 5_000),
+          entersState(session.connection!, VoiceConnectionStatus.Connecting, 5_000),
+        ]);
+      } catch {
+        if (session.connection) {
+          session.connection.destroy();
+        }
+        this.emit("stateChange", session, "disconnected");
+      }
+    });
+
+    session.connection.on("error", (error) => {
+      this.emit("error", session, error);
+    });
+
+    // The SpeakingMap on the receiver emits 'start'/'end' when users
+    // begin/stop transmitting audio packets in the voice channel.
+    const speakingMap = session.connection.receiver.speaking;
+
+    const ensureUser = (userId: string) => {
+      let user = session.users.get(userId);
+      if (!user) {
+        user = {
+          userId,
+          username: userId,
+          speaking: false,
+          mute: false,
+          deaf: false,
+          selfMute: false,
+          selfDeaf: false,
+        };
+        session.users.set(userId, user);
+      }
+      return user;
+    };
+
+    speakingMap.on("start", (userId: string) => {
+      console.log(`[voice-conn] user ${userId} started speaking`);
+      const user = ensureUser(userId);
+      user.speaking = true;
+      this.emit("userSpeaking", session, userId, true);
+    });
+
+    speakingMap.on("end", (userId: string) => {
+      console.log(`[voice-conn] user ${userId} stopped speaking`);
+      const user = ensureUser(userId);
+      user.speaking = false;
+      this.emit("userSpeaking", session, userId, false);
+    });
+  }
+
+  private setupPlayerHandlers(session: VoiceChannelSession): void {
+    if (!session.player) return;
+
+    session.player.on(AudioPlayerStatus.Idle, () => {
+      if (session.state === "speaking") {
+        session.state = "listening";
+        this.emit("stateChange", session, "listening");
+      }
+    });
+
+    session.player.on(AudioPlayerStatus.Playing, () => {
+      session.state = "speaking";
+      this.emit("stateChange", session, "speaking");
+    });
+
+    session.player.on("error", (error) => {
+      this.emit("error", session, error);
+    });
+
+    session.connection?.subscribe(session.player);
+  }
+
+  /**
+   * Forward incoming VOICE_STATE_UPDATE and VOICE_SERVER_UPDATE gateway
+   * events to the @discordjs/voice adapter for a specific guild.
+   */
+  /**
+   * Forward incoming VOICE_STATE_UPDATE and VOICE_SERVER_UPDATE gateway
+   * events to the @discordjs/voice adapter for a specific guild.
+   */
+  onGatewayVoicePayload(guildId: string, payload: VoiceGatewayPayload): void {
+    const methods = this.adapterMethods.get(guildId);
+    if (!methods) {
+      console.log(
+        `[voice-conn] onGatewayVoicePayload guildId=${guildId} — no adapter methods stored (adapters: ${[...this.adapterMethods.keys()].join(",")})`,
+      );
+      return;
+    }
+
+    if ("token" in payload && "endpoint" in payload) {
+      // VOICE_SERVER_UPDATE — cast through unknown to bridge discord-api-types versions
+      console.log(`[voice-conn] forwarding VOICE_SERVER_UPDATE to adapter for guild ${guildId}`);
+      methods.onVoiceServerUpdate(payload as never);
+    } else if ("session_id" in payload) {
+      // VOICE_STATE_UPDATE
+      console.log(
+        `[voice-conn] forwarding VOICE_STATE_UPDATE to adapter for guild ${guildId} (session_id=${payload.session_id})`,
+      );
+      methods.onVoiceStateUpdate(payload as never);
+    }
+  }
+
+  private createAdapterCreator(guildId: string) {
+    return (methods: DiscordGatewayAdapterLibraryMethods) => {
+      this.adapterMethods.set(guildId, methods);
+
+      return {
+        sendPayload: (payload: { op: number; d: unknown }) => {
+          const gateway = getGateway(this.accountId);
+          if (!gateway) {
+            console.log(`[voice-conn] sendPayload: no gateway found (accountId=${this.accountId})`);
+            return false;
+          }
+          try {
+            console.log(`[voice-conn] sendPayload: sending opcode ${payload.op} to gateway`);
+            gateway.send(payload);
+            return true;
+          } catch (err) {
+            console.error(`[voice-conn] sendPayload: gateway.send failed:`, err);
+            return false;
+          }
+        },
+        destroy: () => {
+          this.adapterMethods.delete(guildId);
+        },
+      };
+    };
+  }
+
+  destroy(): void {
+    for (const session of this.sessions.values()) {
+      if (session.player) {
+        session.player.stop();
+      }
+      if (session.connection) {
+        session.connection.destroy();
+      }
+    }
+    this.sessions.clear();
+    this.guildSessionIndex.clear();
+    this.adapterMethods.clear();
+  }
+}
+
+function entersState(
+  connection: VoiceConnection,
+  status: VoiceConnectionStatus,
+  timeout: number,
+): Promise<VoiceConnection> {
+  return new Promise((resolve, reject) => {
+    if (connection.state.status === status) {
+      resolve(connection);
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error(`Timeout waiting for state ${status}`));
+    }, timeout);
+
+    const cleanup = () => {
+      clearTimeout(timer);
+      connection.off(VoiceConnectionStatus.Ready, onState);
+      connection.off(VoiceConnectionStatus.Connecting, onState);
+      connection.off(VoiceConnectionStatus.Signalling, onState);
+      connection.off(VoiceConnectionStatus.Disconnected, onState);
+      connection.off(VoiceConnectionStatus.Destroyed, onState);
+    };
+
+    const onState = () => {
+      if (connection.state.status === status) {
+        cleanup();
+        resolve(connection);
+      }
+    };
+
+    connection.on(VoiceConnectionStatus.Ready, onState);
+    connection.on(VoiceConnectionStatus.Connecting, onState);
+    connection.on(VoiceConnectionStatus.Signalling, onState);
+    connection.on(VoiceConnectionStatus.Disconnected, onState);
+    connection.on(VoiceConnectionStatus.Destroyed, onState);
+  });
+}

--- a/extensions/discord/src/voice/core-bridge.ts
+++ b/extensions/discord/src/voice/core-bridge.ts
@@ -1,0 +1,110 @@
+/**
+ * Dynamic import bridge to openclaw core — mirrors extensions/voice-call/src/core-bridge.ts
+ * but only exposes what's needed for one-shot LLM summarization.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+type CoreAgentDeps = {
+  runEmbeddedPiAgent: (params: {
+    sessionId: string;
+    sessionFile: string;
+    workspaceDir: string;
+    config?: Record<string, unknown>;
+    prompt: string;
+    provider?: string;
+    model?: string;
+    timeoutMs: number;
+    runId: string;
+    disableTools?: boolean;
+  }) => Promise<{
+    payloads?: Array<{ text?: string; isError?: boolean }>;
+    meta?: { aborted?: boolean };
+  }>;
+  DEFAULT_MODEL: string;
+  DEFAULT_PROVIDER: string;
+};
+
+let coreRootCache: string | null = null;
+let coreDepsPromise: Promise<CoreAgentDeps> | null = null;
+
+function findPackageRoot(startDir: string, name: string): string | null {
+  let dir = startDir;
+  for (;;) {
+    const pkgPath = path.join(dir, "package.json");
+    try {
+      if (fs.existsSync(pkgPath)) {
+        const raw = fs.readFileSync(pkgPath, "utf8");
+        const pkg = JSON.parse(raw) as { name?: string };
+        if (pkg.name === name) {
+          return dir;
+        }
+      }
+    } catch {
+      // ignore parse errors and keep walking
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+      return null;
+    }
+    dir = parent;
+  }
+}
+
+function resolveOpenClawRoot(): string {
+  if (coreRootCache) {
+    return coreRootCache;
+  }
+  const override = process.env.OPENCLAW_ROOT?.trim();
+  if (override) {
+    coreRootCache = override;
+    return override;
+  }
+
+  const candidates = new Set<string>();
+  if (process.argv[1]) {
+    candidates.add(path.dirname(process.argv[1]));
+  }
+  candidates.add(process.cwd());
+  try {
+    const urlPath = fileURLToPath(import.meta.url);
+    candidates.add(path.dirname(urlPath));
+  } catch {
+    // ignore
+  }
+
+  for (const start of candidates) {
+    for (const name of ["openclaw"]) {
+      const found = findPackageRoot(start, name);
+      if (found) {
+        coreRootCache = found;
+        return found;
+      }
+    }
+  }
+
+  throw new Error("Unable to resolve core root. Set OPENCLAW_ROOT to the package root.");
+}
+
+async function importCoreExtensionAPI(): Promise<CoreAgentDeps> {
+  const distPath = path.join(resolveOpenClawRoot(), "dist", "extensionAPI.js");
+  if (!fs.existsSync(distPath)) {
+    throw new Error(
+      `Missing core module at ${distPath}. Run \`pnpm build\` or install the official package.`,
+    );
+  }
+  return await import(pathToFileURL(distPath).href);
+}
+
+export async function loadCoreAgentDeps(): Promise<CoreAgentDeps> {
+  if (coreDepsPromise) {
+    return coreDepsPromise;
+  }
+
+  coreDepsPromise = (async () => {
+    return await importCoreExtensionAPI();
+  })();
+
+  return coreDepsPromise;
+}

--- a/extensions/discord/src/voice/events.ts
+++ b/extensions/discord/src/voice/events.ts
@@ -1,0 +1,109 @@
+import { randomUUID } from "node:crypto";
+import type { NormalizedEvent } from "../../../voice-call/src/types.js";
+import type { VoiceChannelSession, TranscriptEntry } from "./types.js";
+
+/**
+ * Maps Discord voice channel events into the NormalizedEvent schema used by
+ * the voice-call extension, allowing the rest of the system to treat Discord
+ * voice sessions like any other call provider.
+ *
+ * Discord sessions use the guildId as the "callId" for correlation.
+ */
+
+function baseEvent(session: VoiceChannelSession) {
+  return {
+    id: randomUUID(),
+    callId: session.sessionId,
+    providerCallId: `discord-${session.guildId}-${session.channelId}`,
+    timestamp: Date.now(),
+    direction: "inbound" as const,
+  };
+}
+
+export function createInitiatedEvent(session: VoiceChannelSession): NormalizedEvent {
+  return {
+    ...baseEvent(session),
+    type: "call.initiated",
+    from: `discord:channel:${session.channelId}`,
+    to: `discord:guild:${session.guildId}`,
+  };
+}
+
+export function createActiveEvent(session: VoiceChannelSession): NormalizedEvent {
+  return {
+    ...baseEvent(session),
+    type: "call.active",
+  };
+}
+
+export function createSpeechEvent(
+  session: VoiceChannelSession,
+  transcript: string,
+  isFinal: boolean,
+  confidence?: number,
+): NormalizedEvent {
+  return {
+    ...baseEvent(session),
+    type: "call.speech",
+    transcript,
+    isFinal,
+    confidence,
+  };
+}
+
+export function createSpeakingEvent(session: VoiceChannelSession, text: string): NormalizedEvent {
+  return {
+    ...baseEvent(session),
+    type: "call.speaking",
+    text,
+  };
+}
+
+export function createSilenceEvent(
+  session: VoiceChannelSession,
+  durationMs: number,
+): NormalizedEvent {
+  return {
+    ...baseEvent(session),
+    type: "call.silence",
+    durationMs,
+  };
+}
+
+export function createEndedEvent(
+  session: VoiceChannelSession,
+  reason: "completed" | "hangup-user" | "hangup-bot" | "error" = "completed",
+): NormalizedEvent {
+  return {
+    ...baseEvent(session),
+    type: "call.ended",
+    reason,
+  };
+}
+
+export function createErrorEvent(
+  session: VoiceChannelSession,
+  error: string,
+  retryable?: boolean,
+): NormalizedEvent {
+  return {
+    ...baseEvent(session),
+    type: "call.error",
+    error,
+    retryable,
+  };
+}
+
+/**
+ * Converts a Discord VoiceChannelSession TranscriptEntry into a NormalizedEvent.
+ * Useful for replaying transcripts through the event pipeline.
+ */
+export function transcriptEntryToEvent(
+  session: VoiceChannelSession,
+  entry: TranscriptEntry,
+): NormalizedEvent {
+  if (entry.speaker === "bot") {
+    return createSpeakingEvent(session, entry.text);
+  }
+  return createSpeechEvent(session, entry.text, entry.isFinal);
+}

--- a/extensions/discord/src/voice/index.ts
+++ b/extensions/discord/src/voice/index.ts
@@ -1,0 +1,51 @@
+export { DiscordVoiceProvider } from "./provider.js";
+export { DiscordVoiceConnectionManager } from "./connection.js";
+export {
+  AudioPipeline,
+  IncomingAudioHandler,
+  OutgoingAudioHandler,
+  OpusDecoder,
+  OpusEncoder,
+} from "./audio-pipeline.js";
+export {
+  parseDiscordVoiceConfig,
+  mergeVoiceConfig,
+  resolveVoiceConfigFromPluginConfig,
+  resolveGroqApiKey,
+  DiscordVoiceConfigSchema,
+  DEFAULT_DISCORD_VOICE_CONFIG,
+} from "./config.js";
+export {
+  createInitiatedEvent,
+  createActiveEvent,
+  createSpeechEvent,
+  createSpeakingEvent,
+  createSilenceEvent,
+  createEndedEvent,
+  createErrorEvent,
+  transcriptEntryToEvent,
+} from "./events.js";
+export { wrapPcmInWav } from "./wav.js";
+export { transcribeVoiceAudio } from "./transcription-service.js";
+export { summarizeVoiceSession } from "./summarization-service.js";
+export { VoiceThreadManager } from "./thread-manager.js";
+export { DiscordVoiceStateListener } from "./voice-state-listener.js";
+export { VoiceSessionOrchestrator } from "./session-orchestrator.js";
+export type {
+  VoiceChannelSession,
+  VoiceChannelUser,
+  VoiceConnectionState,
+  VoiceSessionState,
+  VoiceJoinOptions,
+  VoiceLeaveOptions,
+  VoiceSpeakOptions,
+  VoiceStatusResult,
+  VoiceEventManager,
+  VoiceEventCallback,
+  DiscordVoiceConfig,
+  DiscordVoiceRuntime,
+  AudioConfig,
+  TranscriptEntry,
+  SpeakerTranscription,
+  VoiceTranscriptionSession,
+} from "./types.js";

--- a/extensions/discord/src/voice/index.ts
+++ b/extensions/discord/src/voice/index.ts
@@ -28,6 +28,7 @@ export {
 export { wrapPcmInWav } from "./wav.js";
 export { transcribeVoiceAudio } from "./transcription-service.js";
 export { summarizeVoiceSession } from "./summarization-service.js";
+export { loadCoreAgentDeps } from "./core-bridge.js";
 export { VoiceThreadManager } from "./thread-manager.js";
 export { DiscordVoiceStateListener } from "./voice-state-listener.js";
 export { VoiceSessionOrchestrator } from "./session-orchestrator.js";

--- a/extensions/discord/src/voice/provider.ts
+++ b/extensions/discord/src/voice/provider.ts
@@ -1,0 +1,324 @@
+import { EndBehaviorType } from "@discordjs/voice";
+import { EventEmitter } from "node:events";
+import { Readable } from "node:stream";
+import type { NormalizedEvent } from "../../../voice-call/src/types.js";
+import type {
+  VoiceChannelSession,
+  VoiceJoinOptions,
+  VoiceLeaveOptions,
+  VoiceSpeakOptions,
+  VoiceStatusResult,
+  DiscordVoiceConfig,
+  TranscriptEntry,
+} from "./types.js";
+import { AudioPipeline } from "./audio-pipeline.js";
+import { DiscordVoiceConnectionManager } from "./connection.js";
+import {
+  createInitiatedEvent,
+  createActiveEvent,
+  createSpeechEvent,
+  createSpeakingEvent,
+  createSilenceEvent,
+  createEndedEvent,
+  createErrorEvent,
+} from "./events.js";
+
+type DiscordVoiceProviderEvents = {
+  event: [event: NormalizedEvent];
+  transcript: [session: VoiceChannelSession, entry: TranscriptEntry];
+  audioComplete: [session: VoiceChannelSession, userId: string, pcmData: Buffer];
+  error: [session: VoiceChannelSession, error: Error];
+};
+
+/**
+ * Discord voice provider that wraps the connection manager and audio pipeline.
+ *
+ * Emits NormalizedEvent objects for each voice lifecycle event, so the rest of
+ * the system can consume Discord voice sessions alongside telephony calls.
+ */
+export class DiscordVoiceProvider extends EventEmitter<DiscordVoiceProviderEvents> {
+  private connectionManager: DiscordVoiceConnectionManager;
+  private pipelines: Map<string, AudioPipeline> = new Map();
+  private config: DiscordVoiceConfig;
+  private listeningGuilds: Set<string> = new Set();
+
+  constructor(config: DiscordVoiceConfig) {
+    super();
+    this.config = config;
+    this.connectionManager = new DiscordVoiceConnectionManager();
+    this.setupConnectionEvents();
+  }
+
+  /**
+   * Join a Discord voice channel. Creates an audio pipeline for the session
+   * and begins emitting NormalizedEvents.
+   */
+  async joinChannel(options: VoiceJoinOptions): Promise<VoiceChannelSession> {
+    const session = await this.connectionManager.joinChannel(options);
+
+    const pipeline = new AudioPipeline(this.config.audioConfig);
+    this.pipelines.set(session.guildId, pipeline);
+
+    this.emit("event", createInitiatedEvent(session));
+    this.emit("event", createActiveEvent(session));
+
+    if (this.config.transcriptionEnabled) {
+      this.setupIncomingAudio(session, pipeline);
+    }
+
+    return session;
+  }
+
+  /**
+   * Leave a Discord voice channel. Tears down the audio pipeline and emits
+   * an ended event.
+   */
+  async leaveChannel(options: VoiceLeaveOptions): Promise<void> {
+    const session = this.connectionManager.getSession(options.guildId);
+
+    this.listeningGuilds.delete(options.guildId);
+    this.destroyPipeline(options.guildId);
+    await this.connectionManager.leaveChannel(options);
+
+    if (session) {
+      const reason = options.reason === "user" ? "hangup-user" : "hangup-bot";
+      this.emit("event", createEndedEvent(session, reason));
+    }
+  }
+
+  /**
+   * Speak text in a voice channel by converting it to audio via the outgoing
+   * audio pipeline. Records the utterance in the session transcript.
+   */
+  async speak(options: VoiceSpeakOptions & { audioBuffer?: Buffer }): Promise<void> {
+    const session = this.connectionManager.getSession(options.guildId);
+    if (!session) {
+      throw new Error(`No active voice session for guild ${options.guildId}`);
+    }
+
+    if (!session.player || !session.connection) {
+      throw new Error("Voice session is not connected");
+    }
+
+    const pipeline = this.pipelines.get(options.guildId);
+    if (!pipeline) {
+      throw new Error("Audio pipeline not initialized for this session");
+    }
+
+    if (options.interrupt && session.player) {
+      session.player.stop();
+    }
+
+    const entry: TranscriptEntry = {
+      timestamp: Date.now(),
+      speaker: "bot",
+      text: options.text,
+      isFinal: true,
+    };
+    session.transcript.push(entry);
+    this.emit("transcript", session, entry);
+    this.emit("event", createSpeakingEvent(session, options.text));
+
+    // If a pre-rendered audio buffer is provided (from TTS), play it directly
+    if (options.audioBuffer) {
+      const pcmStream = Readable.from(options.audioBuffer);
+      const resource = pipeline.getOutgoing().createAudioResourceFromPcm(pcmStream);
+      session.player.play(resource);
+    }
+  }
+
+  /**
+   * Start listening for user speech in a guild's voice channel.
+   * The incoming audio handler will buffer audio and emit transcript events
+   * when silence is detected.
+   */
+  async startListening(guildId: string): Promise<void> {
+    const session = this.connectionManager.getSession(guildId);
+    if (!session) {
+      throw new Error(`No active voice session for guild ${guildId}`);
+    }
+
+    this.listeningGuilds.add(guildId);
+    session.state = "listening";
+  }
+
+  /**
+   * Stop listening for user speech.
+   */
+  async stopListening(guildId: string): Promise<void> {
+    const session = this.connectionManager.getSession(guildId);
+    if (!session) return;
+
+    this.listeningGuilds.delete(guildId);
+    if (session.state === "listening") {
+      session.state = "idle";
+    }
+
+    const pipeline = this.pipelines.get(guildId);
+    if (pipeline) {
+      // Flush any remaining audio for all tracked users
+      for (const userId of session.users.keys()) {
+        pipeline.getIncoming().flushUserAudio(userId);
+      }
+    }
+  }
+
+  /**
+   * Get the status of a voice session.
+   */
+  getStatus(guildId?: string): VoiceStatusResult | VoiceStatusResult[] {
+    if (guildId) {
+      return this.buildStatus(guildId);
+    }
+    return this.connectionManager.getAllSessions().map((s) => this.buildStatus(s.guildId));
+  }
+
+  /**
+   * Get the active session for a guild.
+   */
+  getSession(guildId: string): VoiceChannelSession | undefined {
+    return this.connectionManager.getSession(guildId);
+  }
+
+  /**
+   * Get all active sessions.
+   */
+  getAllSessions(): VoiceChannelSession[] {
+    return this.connectionManager.getAllSessions();
+  }
+
+  /**
+   * Forward incoming VOICE_STATE_UPDATE / VOICE_SERVER_UPDATE gateway
+   * payloads to the @discordjs/voice adapter so the voice handshake
+   * can complete.
+   */
+  onGatewayVoicePayload(guildId: string, payload: Record<string, unknown>): void {
+    this.connectionManager.onGatewayVoicePayload(guildId, payload);
+  }
+
+  /**
+   * Clean up all sessions and pipelines.
+   */
+  destroy(): void {
+    for (const guildId of this.pipelines.keys()) {
+      this.destroyPipeline(guildId);
+    }
+    this.listeningGuilds.clear();
+    this.connectionManager.destroy();
+    this.removeAllListeners();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private
+  // ---------------------------------------------------------------------------
+
+  private setupConnectionEvents(): void {
+    this.connectionManager.on("error", (session, error) => {
+      this.emit("error", session, error);
+      this.emit("event", createErrorEvent(session, error.message, true));
+    });
+
+    this.connectionManager.on("userSpeaking", (session, userId, speaking) => {
+      if (!speaking || !this.listeningGuilds.has(session.guildId)) return;
+
+      const pipeline = this.pipelines.get(session.guildId);
+      if (!pipeline) return;
+
+      // When a user starts speaking, subscribe to their audio stream
+      this.subscribeToUserAudio(session, userId, pipeline);
+    });
+
+    this.connectionManager.on("destroy", (session) => {
+      this.destroyPipeline(session.guildId);
+      this.listeningGuilds.delete(session.guildId);
+    });
+  }
+
+  private setupIncomingAudio(session: VoiceChannelSession, pipeline: AudioPipeline): void {
+    const incoming = pipeline.getIncoming();
+
+    incoming.on("audioComplete", ({ userId, data }: { userId: string; data: Buffer }) => {
+      if (!this.listeningGuilds.has(session.guildId)) return;
+
+      const user = session.users.get(userId);
+      const entry: TranscriptEntry = {
+        timestamp: Date.now(),
+        speaker: "user",
+        speakerId: userId,
+        speakerName: user?.username,
+        text: `[audio:${data.length} bytes]`,
+        isFinal: false,
+      };
+      session.transcript.push(entry);
+      this.emit("transcript", session, entry);
+      this.emit("audioComplete", session, userId, data);
+      this.emit("event", createSpeechEvent(session, entry.text, false));
+    });
+
+    incoming.on("silence", ({ userId, durationMs }: { userId?: string; durationMs?: number }) => {
+      if (durationMs && durationMs >= this.config.silenceTimeoutMs) {
+        this.emit("event", createSilenceEvent(session, durationMs));
+      }
+    });
+  }
+
+  /**
+   * Subscribe to a specific user's audio stream from the voice connection
+   * receiver. Feeds Opus chunks into the incoming audio handler.
+   */
+  private subscribeToUserAudio(
+    session: VoiceChannelSession,
+    userId: string,
+    pipeline: AudioPipeline,
+  ): void {
+    if (!session.connection) return;
+
+    const receiver = session.connection.receiver;
+    const opusStream = receiver.subscribe(userId, {
+      end: { behavior: EndBehaviorType.AfterSilence, duration: 1000 },
+    });
+
+    opusStream.on("data", (chunk: Buffer) => {
+      pipeline.getIncoming().handleAudioChunk(userId, chunk);
+    });
+
+    opusStream.on("end", () => {
+      pipeline.getIncoming().flushUserAudio(userId);
+    });
+  }
+
+  private destroyPipeline(guildId: string): void {
+    const pipeline = this.pipelines.get(guildId);
+    if (pipeline) {
+      pipeline.destroy();
+      this.pipelines.delete(guildId);
+    }
+  }
+
+  private buildStatus(guildId: string): VoiceStatusResult {
+    const session = this.connectionManager.getSession(guildId);
+    if (!session) {
+      return {
+        connected: false,
+        guildId,
+        state: "disconnected",
+        sessionState: "idle",
+        users: [],
+        transcriptLength: 0,
+      };
+    }
+
+    return {
+      connected: true,
+      guildId: session.guildId,
+      channelId: session.channelId,
+      channelName: session.channelName,
+      guildName: session.guildName,
+      state: this.connectionManager.getConnectionState(session),
+      sessionState: session.state,
+      users: Array.from(session.users.values()),
+      duration: Date.now() - session.startedAt,
+      transcriptLength: session.transcript.length,
+    };
+  }
+}

--- a/extensions/discord/src/voice/session-orchestrator.ts
+++ b/extensions/discord/src/voice/session-orchestrator.ts
@@ -1,0 +1,263 @@
+import { randomUUID } from "node:crypto";
+import type { DiscordVoiceProvider } from "./provider.js";
+import type { SpeakerTranscription, VoiceTranscriptionSession } from "./types.js";
+import type { DiscordVoiceStateListener } from "./voice-state-listener.js";
+/**
+ * Central coordinator wiring voice connection, transcription, thread
+ * posting, and summarization together.
+ *
+ * - On userJoined: auto-join voice channel, start listening
+ * - On audioComplete: transcribe via Groq, post to thread
+ * - On userLeft + only bot remains: summarize, post summary, leave
+ */
+import { fetchMemberInfoDiscord } from "../../../../src/discord/send.guild.js";
+import { resolveGroqApiKey, type DiscordVoiceConfig } from "./config.js";
+import { summarizeVoiceSession } from "./summarization-service.js";
+import { VoiceThreadManager } from "./thread-manager.js";
+import { transcribeVoiceAudio } from "./transcription-service.js";
+
+export interface SessionOrchestratorConfig {
+  voiceConfig: DiscordVoiceConfig;
+  provider: DiscordVoiceProvider;
+  voiceStateListener: DiscordVoiceStateListener;
+  accountId?: string;
+  botUserId?: string;
+}
+
+/** Session key: "guildId:channelId" */
+function sessionKey(guildId: string, channelId: string): string {
+  return `${guildId}:${channelId}`;
+}
+
+export class VoiceSessionOrchestrator {
+  private sessions = new Map<string, VoiceTranscriptionSession>();
+  private threadManagers = new Map<string, VoiceThreadManager>();
+  private config: DiscordVoiceConfig;
+  private provider: DiscordVoiceProvider;
+  private voiceStateListener: DiscordVoiceStateListener;
+  private accountId: string | undefined;
+  private botUserId: string | undefined;
+  private groqApiKey: string | undefined;
+
+  constructor(params: SessionOrchestratorConfig) {
+    this.config = params.voiceConfig;
+    this.provider = params.provider;
+    this.voiceStateListener = params.voiceStateListener;
+    this.accountId = params.accountId;
+    this.botUserId = params.botUserId;
+    this.groqApiKey = resolveGroqApiKey(this.config);
+
+    this.setupEventHandlers();
+  }
+
+  private setupEventHandlers(): void {
+    // Wire audioComplete from provider
+    this.provider.on("audioComplete", (session, userId, pcmData) => {
+      void this.handleAudioComplete(session.guildId, session.channelId, userId, pcmData);
+    });
+  }
+
+  /**
+   * Called by the voice state listener when a user joins a voice channel.
+   */
+  async onUserJoined(guildId: string, userId: string, channelId: string): Promise<void> {
+    console.log(
+      `[orchestrator] onUserJoined guildId=${guildId} userId=${userId} channelId=${channelId} autoJoin=${this.config.autoJoin}`,
+    );
+    if (!this.config.autoJoin) return;
+
+    // Check guild restriction
+    if (
+      this.config.autoJoinGuilds &&
+      this.config.autoJoinGuilds.length > 0 &&
+      !this.config.autoJoinGuilds.includes(guildId)
+    ) {
+      console.log(
+        `[orchestrator] guild ${guildId} not in autoJoinGuilds: ${JSON.stringify(this.config.autoJoinGuilds)}`,
+      );
+      return;
+    }
+
+    const key = sessionKey(guildId, channelId);
+    console.log(`[orchestrator] session key=${key}, existing=${this.sessions.has(key)}`);
+
+    // Resolve the user's display name
+    const userName = await this.resolveUserName(guildId, userId);
+    console.log(`[orchestrator] resolved userName=${userName}`);
+
+    // If we already have a session, just track the user
+    if (this.sessions.has(key)) {
+      const session = this.sessions.get(key)!;
+      session.userNames.set(userId, userName);
+      return;
+    }
+
+    // Create a new transcription session
+    const session: VoiceTranscriptionSession = {
+      sessionId: randomUUID(),
+      guildId,
+      channelId,
+      transcriptions: [],
+      userNames: new Map([[userId, userName]]),
+      startedAt: Date.now(),
+    };
+    this.sessions.set(key, session);
+
+    // Create thread manager (lazy thread creation)
+    if (this.config.transcriptionChannelId) {
+      const threadManager = new VoiceThreadManager({
+        channelId: this.config.transcriptionChannelId,
+        guildId,
+        restOpts: {
+          token: undefined,
+          accountId: this.accountId,
+        },
+      });
+      this.threadManagers.set(key, threadManager);
+    }
+
+    // Join the voice channel
+    console.log(`[orchestrator] joining voice channel ${channelId} in guild ${guildId}`);
+    try {
+      await this.provider.joinChannel({ guildId, channelId, selfDeaf: false });
+      console.log(`[orchestrator] joinChannel succeeded, starting listening`);
+      await this.provider.startListening(guildId);
+      console.log(`[orchestrator] startListening succeeded`);
+    } catch (err) {
+      console.error(`[orchestrator] joinChannel/startListening failed:`, err);
+      // Clean up on failure
+      this.sessions.delete(key);
+      this.threadManagers.delete(key);
+    }
+  }
+
+  /**
+   * Called by the voice state listener when a user leaves a voice channel.
+   */
+  async onUserLeft(guildId: string, userId: string, channelId: string): Promise<void> {
+    const key = sessionKey(guildId, channelId);
+    const session = this.sessions.get(key);
+    if (!session) return;
+
+    // Check if only the bot remains
+    const usersInChannel = this.voiceStateListener.getUsersInChannel(guildId, channelId);
+    if (usersInChannel.length > 0) {
+      // Other humans still present
+      return;
+    }
+
+    // All humans have left — summarize and leave
+    await this.endSession(key);
+  }
+
+  /**
+   * Handle completed audio from a user: transcribe and post to thread.
+   */
+  private async handleAudioComplete(
+    guildId: string,
+    channelId: string,
+    userId: string,
+    pcmData: Buffer,
+  ): Promise<void> {
+    if (!this.groqApiKey) return;
+
+    const key = sessionKey(guildId, channelId);
+    const session = this.sessions.get(key);
+    if (!session) return;
+
+    const userName = session.userNames.get(userId) ?? userId;
+
+    const result = await transcribeVoiceAudio({
+      userId,
+      userName,
+      pcmData,
+      apiKey: this.groqApiKey,
+      model: this.config.whisperModel,
+    });
+
+    if (!result) return;
+
+    const transcription: SpeakerTranscription = {
+      userId: result.userId,
+      userName: result.userName,
+      text: result.text,
+      timestamp: Date.now(),
+    };
+    session.transcriptions.push(transcription);
+
+    // Post to thread
+    const threadManager = this.threadManagers.get(key);
+    if (threadManager) {
+      await threadManager.postTranscription(transcription);
+      // Store the thread ID in the session once created
+      const threadId = threadManager.getThreadId();
+      if (threadId && !session.threadId) {
+        session.threadId = threadId;
+      }
+    }
+  }
+
+  /**
+   * End a session: summarize, post to thread, leave channel.
+   */
+  private async endSession(key: string): Promise<void> {
+    const session = this.sessions.get(key);
+    if (!session) return;
+
+    const threadManager = this.threadManagers.get(key);
+    const durationMs = Date.now() - session.startedAt;
+
+    // Summarize if we have transcriptions
+    if (this.groqApiKey && session.transcriptions.length > 0 && threadManager) {
+      const summaryResult = await summarizeVoiceSession({
+        transcriptions: session.transcriptions,
+        apiKey: this.groqApiKey,
+        model: this.config.summarizationModel,
+      });
+
+      if (summaryResult) {
+        await threadManager.postSummary(summaryResult.formatted);
+      }
+
+      await threadManager.postSessionEnd(durationMs);
+    }
+
+    // Leave the voice channel
+    try {
+      await this.provider.leaveChannel({
+        guildId: session.guildId,
+        reason: "bot",
+      });
+    } catch {
+      // Ignore leave errors
+    }
+
+    // Clean up
+    this.sessions.delete(key);
+    this.threadManagers.delete(key);
+  }
+
+  /**
+   * Resolve a user's display name via the Discord API.
+   */
+  private async resolveUserName(guildId: string, userId: string): Promise<string> {
+    try {
+      const member = await fetchMemberInfoDiscord(guildId, userId, {
+        accountId: this.accountId,
+      });
+      return member.nick ?? member.user?.global_name ?? member.user?.username ?? userId;
+    } catch {
+      return userId;
+    }
+  }
+
+  destroy(): void {
+    // End all active sessions without summarization
+    for (const key of this.sessions.keys()) {
+      const session = this.sessions.get(key)!;
+      void this.provider.leaveChannel({ guildId: session.guildId, reason: "bot" }).catch(() => {});
+    }
+    this.sessions.clear();
+    this.threadManagers.clear();
+  }
+}

--- a/extensions/discord/src/voice/summarization-service.ts
+++ b/extensions/discord/src/voice/summarization-service.ts
@@ -1,0 +1,116 @@
+/**
+ * Voice session summarization via Groq's OpenAI-compatible chat completion API.
+ */
+import type { SpeakerTranscription } from "./types.js";
+
+const GROQ_CHAT_URL = "https://api.groq.com/openai/v1/chat/completions";
+const DEFAULT_SUMMARIZATION_MODEL = "llama-3.3-70b-versatile";
+
+export interface SummarizeVoiceSessionParams {
+  transcriptions: SpeakerTranscription[];
+  apiKey: string;
+  model?: string;
+}
+
+export interface SummarizeVoiceSessionResult {
+  summary: string;
+  actionItems: string;
+  formatted: string;
+}
+
+function buildTranscriptText(transcriptions: SpeakerTranscription[]): string {
+  return transcriptions
+    .map((t) => {
+      const time = new Date(t.timestamp).toLocaleTimeString("en-US", {
+        hour: "2-digit",
+        minute: "2-digit",
+      });
+      return `[${time}] ${t.userName}: ${t.text}`;
+    })
+    .join("\n");
+}
+
+const SYSTEM_PROMPT = `You are a meeting assistant. Given a voice conversation transcript, produce:
+
+1. A concise **Summary** of the discussion (3-5 bullet points)
+2. **Action Items** organized by person, listing what each person committed to or was assigned
+
+Format your response in Discord-compatible markdown exactly like this:
+
+## Summary
+- Point 1
+- Point 2
+- Point 3
+
+## Action Items
+**PersonName**
+- Action item 1
+- Action item 2
+
+**AnotherPerson**
+- Action item 1
+
+If there are no clear action items for a person, omit them.
+If the transcript is too short or unclear, provide a brief summary and note that no clear action items were identified.`;
+
+/**
+ * Summarize a voice session's transcriptions via Groq LLM.
+ * Returns `null` on failure (never throws).
+ */
+export async function summarizeVoiceSession(
+  params: SummarizeVoiceSessionParams,
+): Promise<SummarizeVoiceSessionResult | null> {
+  try {
+    if (params.transcriptions.length === 0) {
+      return null;
+    }
+
+    const model = params.model ?? DEFAULT_SUMMARIZATION_MODEL;
+    const transcript = buildTranscriptText(params.transcriptions);
+
+    const res = await fetch(GROQ_CHAT_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${params.apiKey}`,
+      },
+      body: JSON.stringify({
+        model,
+        messages: [
+          { role: "system", content: SYSTEM_PROMPT },
+          {
+            role: "user",
+            content: `Here is the voice conversation transcript:\n\n${transcript}`,
+          },
+        ],
+        temperature: 0.3,
+        max_tokens: 2048,
+      }),
+    });
+
+    if (!res.ok) {
+      return null;
+    }
+
+    const payload = (await res.json()) as {
+      choices?: Array<{ message?: { content?: string } }>;
+    };
+
+    const content = payload.choices?.[0]?.message?.content?.trim();
+    if (!content) {
+      return null;
+    }
+
+    // Parse the summary and action items sections
+    const summaryMatch = content.match(/## Summary\s*\n([\s\S]*?)(?=\n## Action Items|$)/);
+    const actionItemsMatch = content.match(/## Action Items\s*\n([\s\S]*?)$/);
+
+    return {
+      summary: summaryMatch?.[1]?.trim() ?? content,
+      actionItems: actionItemsMatch?.[1]?.trim() ?? "",
+      formatted: content,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/extensions/discord/src/voice/summarization-service.ts
+++ b/extensions/discord/src/voice/summarization-service.ts
@@ -1,15 +1,17 @@
 /**
- * Voice session summarization via Groq's OpenAI-compatible chat completion API.
+ * Voice session summarization via openclaw's embedded agent runner.
+ * Uses whatever LLM the user has configured (Anthropic, OpenAI, etc.)
+ * instead of calling Groq directly.
  */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import type { SpeakerTranscription } from "./types.js";
-
-const GROQ_CHAT_URL = "https://api.groq.com/openai/v1/chat/completions";
-const DEFAULT_SUMMARIZATION_MODEL = "llama-3.3-70b-versatile";
+import { loadCoreAgentDeps } from "./core-bridge.js";
 
 export interface SummarizeVoiceSessionParams {
   transcriptions: SpeakerTranscription[];
-  apiKey: string;
-  model?: string;
+  coreConfig: Record<string, unknown>;
 }
 
 export interface SummarizeVoiceSessionResult {
@@ -30,80 +32,106 @@ function buildTranscriptText(transcriptions: SpeakerTranscription[]): string {
     .join("\n");
 }
 
-const SYSTEM_PROMPT = `You are a meeting assistant. Given a voice conversation transcript, produce:
+const SYSTEM_PROMPT = `You are a meeting assistant. Given a voice conversation transcript, produce a thorough summary formatted for Discord.
 
-1. A concise **Summary** of the discussion (3-5 bullet points)
-2. **Action Items** organized by person, listing what each person committed to or was assigned
+Rules:
+- Use **bold** for section labels, NOT markdown headings (#, ##). Discord renders # headings too large.
+- Cover ALL important points, decisions, and context from the conversation. Do not artificially limit the number of bullet points — a 30-minute call needs far more detail than a 2-minute one.
+- If there are clear action items, include them organized by person.
+- If there are NO clear action items, omit the action items section entirely.
 
-Format your response in Discord-compatible markdown exactly like this:
+Format like this:
 
-## Summary
-- Point 1
-- Point 2
-- Point 3
+**Summary**
+- Key point or decision
+- Another important topic discussed
+- ...as many points as needed to be thorough...
 
-## Action Items
+**Action Items**
 **PersonName**
 - Action item 1
-- Action item 2
 
-**AnotherPerson**
-- Action item 1
-
-If there are no clear action items for a person, omit them.
-If the transcript is too short or unclear, provide a brief summary and note that no clear action items were identified.`;
+(Omit the Action Items section entirely if none exist.)`;
 
 /**
- * Summarize a voice session's transcriptions via Groq LLM.
+ * Resolve provider/model from coreConfig's agents.defaults.model.primary
+ * (format: "provider/model", e.g. "google/gemini-3-pro-preview").
+ */
+function resolvePrimaryModel(coreConfig: Record<string, unknown>): {
+  provider?: string;
+  model?: string;
+} {
+  const agents = coreConfig.agents as Record<string, unknown> | undefined;
+  const defaults = agents?.defaults as Record<string, unknown> | undefined;
+  const modelCfg = defaults?.model as Record<string, unknown> | undefined;
+  const primary = modelCfg?.primary;
+  if (typeof primary === "string" && primary.includes("/")) {
+    const idx = primary.indexOf("/");
+    return {
+      provider: primary.slice(0, idx),
+      model: primary.slice(idx + 1),
+    };
+  }
+  return {};
+}
+
+function collectText(payloads: Array<{ text?: string; isError?: boolean }> | undefined): string {
+  const texts = (payloads ?? [])
+    .filter((p) => !p.isError && typeof p.text === "string")
+    .map((p) => p.text ?? "");
+  return texts.join("\n").trim();
+}
+
+/**
+ * Summarize a voice session's transcriptions via the user's configured LLM.
  * Returns `null` on failure (never throws).
  */
 export async function summarizeVoiceSession(
   params: SummarizeVoiceSessionParams,
 ): Promise<SummarizeVoiceSessionResult | null> {
+  let tmpDir: string | null = null;
   try {
     if (params.transcriptions.length === 0) {
       return null;
     }
 
-    const model = params.model ?? DEFAULT_SUMMARIZATION_MODEL;
     const transcript = buildTranscriptText(params.transcriptions);
+    const fullPrompt = `${SYSTEM_PROMPT}\n\nHere is the voice conversation transcript:\n\n${transcript}`;
 
-    const res = await fetch(GROQ_CHAT_URL, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${params.apiKey}`,
-      },
-      body: JSON.stringify({
-        model,
-        messages: [
-          { role: "system", content: SYSTEM_PROMPT },
-          {
-            role: "user",
-            content: `Here is the voice conversation transcript:\n\n${transcript}`,
-          },
-        ],
-        temperature: 0.3,
-        max_tokens: 2048,
-      }),
+    const { runEmbeddedPiAgent, DEFAULT_PROVIDER, DEFAULT_MODEL } = await loadCoreAgentDeps();
+    const { provider: cfgProvider, model: cfgModel } = resolvePrimaryModel(params.coreConfig);
+    const provider = cfgProvider || DEFAULT_PROVIDER;
+    const model = cfgModel || DEFAULT_MODEL;
+
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-voice-summary-"));
+    const sessionId = `voice-summary-${Date.now()}`;
+    const sessionFile = path.join(tmpDir, "session.json");
+
+    const result = await runEmbeddedPiAgent({
+      sessionId,
+      sessionFile,
+      workspaceDir: tmpDir,
+      config: params.coreConfig,
+      prompt: fullPrompt,
+      provider,
+      model,
+      timeoutMs: 60_000,
+      runId: `voice-summary-${Date.now()}`,
+      disableTools: true,
     });
 
-    if (!res.ok) {
-      return null;
-    }
-
-    const payload = (await res.json()) as {
-      choices?: Array<{ message?: { content?: string } }>;
-    };
-
-    const content = payload.choices?.[0]?.message?.content?.trim();
+    const content = collectText(result.payloads);
     if (!content) {
       return null;
     }
 
-    // Parse the summary and action items sections
-    const summaryMatch = content.match(/## Summary\s*\n([\s\S]*?)(?=\n## Action Items|$)/);
-    const actionItemsMatch = content.match(/## Action Items\s*\n([\s\S]*?)$/);
+    // Parse the summary and action items sections (supports both **Bold** and ## Heading formats)
+    const summaryMatch = content.match(
+      /(?:\*\*Summary\*\*|## Summary)\s*\n([\s\S]*?)(?=\n(?:\*\*Action Items\*\*|## Action Items)|$)/,
+    );
+    const actionItemsMatch = content.match(
+      /(?:\*\*Action Items\*\*|## Action Items)\s*\n([\s\S]*?)$/,
+    );
 
     return {
       summary: summaryMatch?.[1]?.trim() ?? content,
@@ -112,5 +140,13 @@ export async function summarizeVoiceSession(
     };
   } catch {
     return null;
+  } finally {
+    if (tmpDir) {
+      try {
+        await fs.rm(tmpDir, { recursive: true, force: true });
+      } catch {
+        // ignore
+      }
+    }
   }
 }

--- a/extensions/discord/src/voice/thread-manager.ts
+++ b/extensions/discord/src/voice/thread-manager.ts
@@ -56,6 +56,7 @@ export class VoiceThreadManager {
         day: "numeric",
       });
 
+      console.log(`[thread-manager] creating thread in channel ${this.channelId}`);
       const thread = (await createThreadDiscord(
         this.channelId,
         {
@@ -67,8 +68,10 @@ export class VoiceThreadManager {
       )) as { id: string };
 
       this.threadId = thread.id;
+      console.log(`[thread-manager] thread created: ${this.threadId}`);
       return this.threadId;
-    } catch {
+    } catch (err) {
+      console.error(`[thread-manager] failed to create thread:`, err);
       return undefined;
     }
   }
@@ -94,9 +97,13 @@ export class VoiceThreadManager {
       });
 
       const message = `**${params.userName}** (${time}): ${params.text}`;
-      await sendMessageDiscord(threadId, message, this.restOpts);
-    } catch {
-      // Errors are caught internally, never thrown
+      console.log(
+        `[thread-manager] posting transcription to thread ${threadId}: ${message.substring(0, 80)}...`,
+      );
+      await sendMessageDiscord(`channel:${threadId}`, message, this.restOpts);
+      console.log(`[thread-manager] transcription posted successfully`);
+    } catch (err) {
+      console.error(`[thread-manager] failed to post transcription:`, err);
     }
   }
 
@@ -109,7 +116,7 @@ export class VoiceThreadManager {
       if (!threadId) return;
 
       await sendMessageDiscord(
-        threadId,
+        `channel:${threadId}`,
         `---\n# Voice Session Summary\n\n${markdownText}`,
         this.restOpts,
       );
@@ -131,7 +138,7 @@ export class VoiceThreadManager {
       const durationStr = minutes > 0 ? `${minutes}m ${seconds}s` : `${seconds}s`;
 
       await sendMessageDiscord(
-        threadId,
+        `channel:${threadId}`,
         `---\n*Voice session ended. Duration: ${durationStr}*`,
         this.restOpts,
       );

--- a/extensions/discord/src/voice/thread-manager.ts
+++ b/extensions/discord/src/voice/thread-manager.ts
@@ -97,26 +97,19 @@ export class VoiceThreadManager {
       });
 
       const message = `**${params.userName}** (${time}): ${params.text}`;
-      console.log(
-        `[thread-manager] posting transcription to thread ${threadId}: ${message.substring(0, 80)}...`,
-      );
       await sendMessageDiscord(`channel:${threadId}`, message, this.restOpts);
-      console.log(`[thread-manager] transcription posted successfully`);
     } catch (err) {
       console.error(`[thread-manager] failed to post transcription:`, err);
     }
   }
 
   /**
-   * Post the final session summary to the thread.
+   * Post the final session summary to the parent channel (not the thread).
    */
   async postSummary(markdownText: string): Promise<void> {
     try {
-      const threadId = await this.ensureThread();
-      if (!threadId) return;
-
       await sendMessageDiscord(
-        `channel:${threadId}`,
+        `channel:${this.channelId}`,
         `---\n# Voice Session Summary\n\n${markdownText}`,
         this.restOpts,
       );
@@ -126,19 +119,16 @@ export class VoiceThreadManager {
   }
 
   /**
-   * Post a session-end message with duration info.
+   * Post a session-end message with duration info to the parent channel.
    */
   async postSessionEnd(durationMs: number): Promise<void> {
     try {
-      const threadId = await this.ensureThread();
-      if (!threadId) return;
-
       const minutes = Math.floor(durationMs / 60000);
       const seconds = Math.floor((durationMs % 60000) / 1000);
       const durationStr = minutes > 0 ? `${minutes}m ${seconds}s` : `${seconds}s`;
 
       await sendMessageDiscord(
-        `channel:${threadId}`,
+        `channel:${this.channelId}`,
         `---\n*Voice session ended. Duration: ${durationStr}*`,
         this.restOpts,
       );

--- a/extensions/discord/src/voice/thread-manager.ts
+++ b/extensions/discord/src/voice/thread-manager.ts
@@ -1,0 +1,142 @@
+/**
+ * Manages a Discord thread for a voice transcription session.
+ * Lazily creates the thread on first transcription to avoid empty threads.
+ */
+import { ChannelType } from "discord-api-types/v10";
+import { createThreadDiscord } from "../../../../src/discord/send.messages.js";
+import { sendMessageDiscord } from "../../../../src/discord/send.outbound.js";
+
+export interface ThreadManagerRestOpts {
+  token?: string;
+  accountId?: string;
+}
+
+export interface ThreadManagerConfig {
+  /** Channel ID where threads will be created. */
+  channelId: string;
+  /** Guild ID (used in thread naming). */
+  guildId: string;
+  /** Discord REST opts for API calls. */
+  restOpts: ThreadManagerRestOpts;
+}
+
+export class VoiceThreadManager {
+  private threadId: string | undefined;
+  private channelId: string;
+  private guildId: string;
+  private restOpts: ThreadManagerRestOpts;
+
+  constructor(config: ThreadManagerConfig) {
+    this.channelId = config.channelId;
+    this.guildId = config.guildId;
+    this.restOpts = config.restOpts;
+  }
+
+  getThreadId(): string | undefined {
+    return this.threadId;
+  }
+
+  /**
+   * Ensure the thread exists. Creates it lazily on first call.
+   * Returns the thread ID or undefined if creation fails.
+   */
+  private async ensureThread(): Promise<string | undefined> {
+    if (this.threadId) {
+      return this.threadId;
+    }
+
+    try {
+      const now = new Date();
+      const timeStr = now.toLocaleTimeString("en-US", {
+        hour: "2-digit",
+        minute: "2-digit",
+      });
+      const dateStr = now.toLocaleDateString("en-US", {
+        month: "short",
+        day: "numeric",
+      });
+
+      const thread = (await createThreadDiscord(
+        this.channelId,
+        {
+          name: `Voice Transcript ${dateStr} ${timeStr}`,
+          autoArchiveMinutes: 1440,
+          type: ChannelType.PublicThread,
+        },
+        this.restOpts,
+      )) as { id: string };
+
+      this.threadId = thread.id;
+      return this.threadId;
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
+   * Post a transcription entry to the thread.
+   * Creates the thread if it doesn't exist yet.
+   */
+  async postTranscription(params: {
+    userId: string;
+    userName: string;
+    text: string;
+    timestamp: number;
+  }): Promise<void> {
+    try {
+      const threadId = await this.ensureThread();
+      if (!threadId) return;
+
+      const time = new Date(params.timestamp).toLocaleTimeString("en-US", {
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+      });
+
+      const message = `**${params.userName}** (${time}): ${params.text}`;
+      await sendMessageDiscord(threadId, message, this.restOpts);
+    } catch {
+      // Errors are caught internally, never thrown
+    }
+  }
+
+  /**
+   * Post the final session summary to the thread.
+   */
+  async postSummary(markdownText: string): Promise<void> {
+    try {
+      const threadId = await this.ensureThread();
+      if (!threadId) return;
+
+      await sendMessageDiscord(
+        threadId,
+        `---\n# Voice Session Summary\n\n${markdownText}`,
+        this.restOpts,
+      );
+    } catch {
+      // Errors are caught internally, never thrown
+    }
+  }
+
+  /**
+   * Post a session-end message with duration info.
+   */
+  async postSessionEnd(durationMs: number): Promise<void> {
+    try {
+      const threadId = await this.ensureThread();
+      if (!threadId) return;
+
+      const minutes = Math.floor(durationMs / 60000);
+      const seconds = Math.floor((durationMs % 60000) / 1000);
+      const durationStr = minutes > 0 ? `${minutes}m ${seconds}s` : `${seconds}s`;
+
+      await sendMessageDiscord(
+        threadId,
+        `---\n*Voice session ended. Duration: ${durationStr}*`,
+        this.restOpts,
+      );
+    } catch {
+      // Errors are caught internally, never thrown
+    }
+  }
+}

--- a/extensions/discord/src/voice/thread-manager.ts
+++ b/extensions/discord/src/voice/thread-manager.ts
@@ -104,32 +104,24 @@ export class VoiceThreadManager {
   }
 
   /**
-   * Post the final session summary to the parent channel (not the thread).
+   * Post the final session summary with duration to the parent channel (not the thread).
    */
-  async postSummary(markdownText: string): Promise<void> {
+  async postSummary(markdownText: string, durationMs?: number): Promise<void> {
     try {
-      await sendMessageDiscord(
-        `channel:${this.channelId}`,
-        `---\n# Voice Session Summary\n\n${markdownText}`,
-        this.restOpts,
-      );
-    } catch {
-      // Errors are caught internally, never thrown
-    }
-  }
+      let durationStr = "";
+      if (durationMs != null) {
+        const minutes = Math.floor(durationMs / 60000);
+        const seconds = Math.floor((durationMs % 60000) / 1000);
+        durationStr = minutes > 0 ? `${minutes}m ${seconds}s` : `${seconds}s`;
+      }
 
-  /**
-   * Post a session-end message with duration info to the parent channel.
-   */
-  async postSessionEnd(durationMs: number): Promise<void> {
-    try {
-      const minutes = Math.floor(durationMs / 60000);
-      const seconds = Math.floor((durationMs % 60000) / 1000);
-      const durationStr = minutes > 0 ? `${minutes}m ${seconds}s` : `${seconds}s`;
+      const header = durationStr
+        ? `**Voice Session Summary** *(${durationStr})*`
+        : `**Voice Session Summary**`;
 
       await sendMessageDiscord(
         `channel:${this.channelId}`,
-        `---\n*Voice session ended. Duration: ${durationStr}*`,
+        `${header}\n\n${markdownText}`,
         this.restOpts,
       );
     } catch {

--- a/extensions/discord/src/voice/transcription-service.ts
+++ b/extensions/discord/src/voice/transcription-service.ts
@@ -1,0 +1,71 @@
+/**
+ * Voice transcription service wrapping Groq Whisper via the existing
+ * OpenAI-compatible transcription function.
+ */
+import { transcribeOpenAiCompatibleAudio } from "../../../../src/media-understanding/providers/openai/audio.js";
+import { wrapPcmInWav } from "./wav.js";
+
+const GROQ_BASE_URL = "https://api.groq.com/openai/v1";
+const DEFAULT_WHISPER_MODEL = "whisper-large-v3-turbo";
+/** Minimum audio duration in seconds to attempt transcription. */
+const MIN_AUDIO_DURATION_S = 0.5;
+/** Bytes per second for 48kHz stereo 16-bit PCM. */
+const PCM_BYTES_PER_SECOND = 48000 * 2 * 2;
+
+export interface TranscribeVoiceAudioParams {
+  userId: string;
+  userName: string;
+  pcmData: Buffer;
+  apiKey: string;
+  model?: string;
+  language?: string;
+}
+
+export interface TranscribeVoiceAudioResult {
+  userId: string;
+  userName: string;
+  text: string;
+  model: string;
+}
+
+/**
+ * Transcribe a PCM audio buffer via Groq Whisper.
+ * Returns `null` for short audio or on any failure (never throws).
+ */
+export async function transcribeVoiceAudio(
+  params: TranscribeVoiceAudioParams,
+): Promise<TranscribeVoiceAudioResult | null> {
+  try {
+    const durationS = params.pcmData.length / PCM_BYTES_PER_SECOND;
+    if (durationS < MIN_AUDIO_DURATION_S) {
+      return null;
+    }
+
+    const wavBuffer = wrapPcmInWav(params.pcmData);
+    const model = params.model ?? DEFAULT_WHISPER_MODEL;
+
+    const result = await transcribeOpenAiCompatibleAudio({
+      buffer: wavBuffer,
+      fileName: "voice.wav",
+      mime: "audio/wav",
+      apiKey: params.apiKey,
+      baseUrl: GROQ_BASE_URL,
+      model,
+      language: params.language,
+      timeoutMs: 30_000,
+    });
+
+    if (!result.text?.trim()) {
+      return null;
+    }
+
+    return {
+      userId: params.userId,
+      userName: params.userName,
+      text: result.text.trim(),
+      model: result.model ?? model,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/extensions/discord/src/voice/transcription-service.ts
+++ b/extensions/discord/src/voice/transcription-service.ts
@@ -37,19 +37,12 @@ export async function transcribeVoiceAudio(
 ): Promise<TranscribeVoiceAudioResult | null> {
   try {
     const durationS = params.pcmData.length / PCM_BYTES_PER_SECOND;
-    console.log(
-      `[transcription] pcmLen=${params.pcmData.length} duration=${durationS.toFixed(2)}s minDuration=${MIN_AUDIO_DURATION_S}s`,
-    );
     if (durationS < MIN_AUDIO_DURATION_S) {
-      console.log(
-        `[transcription] audio too short (${durationS.toFixed(2)}s < ${MIN_AUDIO_DURATION_S}s), skipping`,
-      );
       return null;
     }
 
     const wavBuffer = wrapPcmInWav(params.pcmData);
     const model = params.model ?? DEFAULT_WHISPER_MODEL;
-    console.log(`[transcription] sending ${wavBuffer.length} bytes WAV to Groq (model=${model})`);
 
     const result = await transcribeOpenAiCompatibleAudio({
       buffer: wavBuffer,
@@ -62,10 +55,7 @@ export async function transcribeVoiceAudio(
       timeoutMs: 30_000,
     });
 
-    console.log(`[transcription] Groq response: text="${result.text}" model=${result.model}`);
-
     if (!result.text?.trim()) {
-      console.log(`[transcription] empty text response, returning null`);
       return null;
     }
 

--- a/extensions/discord/src/voice/transcription-service.ts
+++ b/extensions/discord/src/voice/transcription-service.ts
@@ -37,12 +37,19 @@ export async function transcribeVoiceAudio(
 ): Promise<TranscribeVoiceAudioResult | null> {
   try {
     const durationS = params.pcmData.length / PCM_BYTES_PER_SECOND;
+    console.log(
+      `[transcription] pcmLen=${params.pcmData.length} duration=${durationS.toFixed(2)}s minDuration=${MIN_AUDIO_DURATION_S}s`,
+    );
     if (durationS < MIN_AUDIO_DURATION_S) {
+      console.log(
+        `[transcription] audio too short (${durationS.toFixed(2)}s < ${MIN_AUDIO_DURATION_S}s), skipping`,
+      );
       return null;
     }
 
     const wavBuffer = wrapPcmInWav(params.pcmData);
     const model = params.model ?? DEFAULT_WHISPER_MODEL;
+    console.log(`[transcription] sending ${wavBuffer.length} bytes WAV to Groq (model=${model})`);
 
     const result = await transcribeOpenAiCompatibleAudio({
       buffer: wavBuffer,
@@ -55,7 +62,10 @@ export async function transcribeVoiceAudio(
       timeoutMs: 30_000,
     });
 
+    console.log(`[transcription] Groq response: text="${result.text}" model=${result.model}`);
+
     if (!result.text?.trim()) {
+      console.log(`[transcription] empty text response, returning null`);
       return null;
     }
 
@@ -65,7 +75,8 @@ export async function transcribeVoiceAudio(
       text: result.text.trim(),
       model: result.model ?? model,
     };
-  } catch {
+  } catch (err) {
+    console.error(`[transcription] error:`, err);
     return null;
   }
 }

--- a/extensions/discord/src/voice/types.ts
+++ b/extensions/discord/src/voice/types.ts
@@ -1,0 +1,161 @@
+import type { VoiceConnection, AudioPlayer } from "@discordjs/voice";
+
+export type VoiceConnectionState = "disconnected" | "connecting" | "connected" | "ready" | "error";
+
+export type VoiceSessionState = "idle" | "listening" | "speaking" | "transcribing";
+
+export interface VoiceChannelUser {
+  userId: string;
+  username?: string;
+  discriminator?: string;
+  avatar?: string;
+  mute: boolean;
+  deaf: boolean;
+  selfMute: boolean;
+  selfDeaf: boolean;
+  speaking: boolean;
+  joinTimestamp: number;
+}
+
+export interface VoiceChannelSession {
+  sessionId: string;
+  guildId: string;
+  channelId: string;
+  channelName?: string;
+  guildName?: string;
+  connection: VoiceConnection | null;
+  player: AudioPlayer | null;
+  state: VoiceSessionState;
+  users: Map<string, VoiceChannelUser>;
+  startedAt: number;
+  endedAt?: number;
+  transcript: TranscriptEntry[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface TranscriptEntry {
+  timestamp: number;
+  speaker: "bot" | "user";
+  speakerId?: string;
+  speakerName?: string;
+  text: string;
+  isFinal: boolean;
+}
+
+export interface VoiceJoinOptions {
+  guildId: string;
+  channelId: string;
+  selfMute?: boolean;
+  selfDeaf?: boolean;
+}
+
+export interface VoiceLeaveOptions {
+  guildId: string;
+  reason?: string;
+}
+
+export interface VoiceSpeakOptions {
+  guildId: string;
+  text: string;
+  interrupt?: boolean;
+}
+
+export interface VoiceStatusResult {
+  connected: boolean;
+  guildId?: string;
+  channelId?: string;
+  channelName?: string;
+  guildName?: string;
+  state: VoiceConnectionState;
+  sessionState: VoiceSessionState;
+  users: VoiceChannelUser[];
+  duration?: number;
+  transcriptLength: number;
+}
+
+export interface AudioConfig {
+  sampleRate: number;
+  channels: number;
+  bitrate: number;
+}
+
+export const DEFAULT_AUDIO_CONFIG: AudioConfig = {
+  sampleRate: 48000,
+  channels: 2,
+  bitrate: 64,
+};
+
+export interface DiscordVoiceConfig {
+  enabled: boolean;
+  autoJoinChannels?: string[];
+  transcriptionEnabled: boolean;
+  ttsEnabled: boolean;
+  silenceTimeoutMs: number;
+  maxRecordingDurationMs?: number;
+  audioConfig?: Partial<AudioConfig>;
+  /** Groq API key for Whisper transcription. Falls back to GROQ_API_KEY env. */
+  groqApiKey?: string;
+  /** Channel ID where transcription threads will be created. */
+  transcriptionChannelId?: string;
+  /** Whisper model to use for transcription. Default: whisper-large-v3-turbo */
+  whisperModel?: string;
+  /** LLM model for session summarization. Default: llama-3.3-70b-versatile */
+  summarizationModel?: string;
+  /** Auto-join voice channels when a user enters. Default: false */
+  autoJoin?: boolean;
+  /** Restrict auto-join to these guild IDs. Omit = all guilds. */
+  autoJoinGuilds?: string[];
+}
+
+export interface VoiceEventManager {
+  onUserJoin: (session: VoiceChannelSession, user: VoiceChannelUser) => void;
+  onUserLeave: (session: VoiceChannelSession, userId: string) => void;
+  onUserSpeaking: (session: VoiceChannelSession, userId: string, speaking: boolean) => void;
+  onTranscript: (session: VoiceChannelSession, entry: TranscriptEntry) => void;
+  onSilence: (session: VoiceChannelSession, durationMs: number) => void;
+  onError: (session: VoiceChannelSession, error: Error) => void;
+  onStateChange: (session: VoiceChannelSession, state: VoiceSessionState) => void;
+}
+
+export type VoiceEventCallback<K extends keyof VoiceEventManager> = Parameters<
+  NonNullable<VoiceEventManager[K]>
+>;
+
+/** A single transcribed speech segment from a voice session. */
+export interface SpeakerTranscription {
+  userId: string;
+  userName: string;
+  text: string;
+  timestamp: number;
+}
+
+/** Tracks the state of a voice transcription session. */
+export interface VoiceTranscriptionSession {
+  sessionId: string;
+  guildId: string;
+  channelId: string;
+  threadId?: string;
+  transcriptions: SpeakerTranscription[];
+  /** Maps userId to display name. */
+  userNames: Map<string, string>;
+  startedAt: number;
+}
+
+export interface DiscordVoiceRuntime {
+  sessions: Map<string, VoiceChannelSession>;
+  getActiveSession: (guildId: string) => VoiceChannelSession | undefined;
+  joinChannel: (options: VoiceJoinOptions) => Promise<VoiceChannelSession>;
+  leaveChannel: (options: VoiceLeaveOptions) => Promise<void>;
+  speak: (options: VoiceSpeakOptions) => Promise<void>;
+  getStatus: (guildId?: string) => VoiceStatusResult | VoiceStatusResult[];
+  startTranscription: (guildId: string) => Promise<void>;
+  stopTranscription: (guildId: string) => Promise<void>;
+  on: <K extends keyof VoiceEventManager>(
+    event: K,
+    callback: (...args: VoiceEventCallback<K>) => void,
+  ) => void;
+  off: <K extends keyof VoiceEventManager>(
+    event: K,
+    callback: (...args: VoiceEventCallback<K>) => void,
+  ) => void;
+}

--- a/extensions/discord/src/voice/types.ts
+++ b/extensions/discord/src/voice/types.ts
@@ -99,8 +99,6 @@ export interface DiscordVoiceConfig {
   transcriptionChannelId?: string;
   /** Whisper model to use for transcription. Default: whisper-large-v3-turbo */
   whisperModel?: string;
-  /** LLM model for session summarization. Default: llama-3.3-70b-versatile */
-  summarizationModel?: string;
   /** Auto-join voice channels when a user enters. Default: false */
   autoJoin?: boolean;
   /** Restrict auto-join to these guild IDs. Omit = all guilds. */

--- a/extensions/discord/src/voice/voice-state-listener.ts
+++ b/extensions/discord/src/voice/voice-state-listener.ts
@@ -1,0 +1,120 @@
+import type { GatewayVoiceStateUpdateDispatchData } from "discord-api-types/v10";
+/**
+ * Gateway listener for VOICE_STATE_UPDATE events.
+ * Tracks voice channel membership and emits join/leave callbacks.
+ *
+ * Extends VoiceStateUpdateListener from @buape/carbon, following the same
+ * pattern as DiscordPresenceListener in src/discord/monitor/listeners.ts.
+ */
+import { VoiceStateUpdateListener, type Client } from "@buape/carbon";
+
+export interface VoiceStateCallbacks {
+  onUserJoined: (guildId: string, userId: string, channelId: string) => void;
+  onUserLeft: (guildId: string, userId: string, channelId: string) => void;
+}
+
+type VoiceStateUpdateEvent = Parameters<VoiceStateUpdateListener["handle"]>[0];
+
+/**
+ * Carbon gateway listener that tracks which users are in which voice channels
+ * per guild and invokes callbacks on join/leave transitions.
+ */
+export class DiscordVoiceStateListener extends VoiceStateUpdateListener {
+  /** guildId -> Map<userId, channelId> */
+  private voiceStates = new Map<string, Map<string, string>>();
+  private botUserId: string | undefined;
+  private callbacks: VoiceStateCallbacks;
+
+  constructor(params: { botUserId?: string; callbacks: VoiceStateCallbacks }) {
+    super();
+    this.botUserId = params.botUserId;
+    this.callbacks = params.callbacks;
+  }
+
+  /** Set the bot user ID after construction (resolved at gateway login time). */
+  setBotUserId(id: string): void {
+    this.botUserId = id;
+  }
+
+  /**
+   * Carbon listener entry point. Called by Carbon's dispatch system
+   * when a VOICE_STATE_UPDATE event is received.
+   */
+  async handle(data: VoiceStateUpdateEvent, _client: Client): Promise<void> {
+    try {
+      console.log(
+        `[voice-listener] handle called, type=${this.type}, data.guild_id=${(data as Record<string, unknown>).guild_id}, data.user_id=${(data as Record<string, unknown>).user_id}, data.channel_id=${(data as Record<string, unknown>).channel_id}`,
+      );
+      this.processVoiceStateUpdate(data as GatewayVoiceStateUpdateDispatchData);
+    } catch (err) {
+      console.error(`[voice-listener] error:`, err);
+    }
+  }
+
+  /**
+   * Process a VOICE_STATE_UPDATE event.
+   * Can also be called directly outside the Carbon listener system.
+   */
+  processVoiceStateUpdate(data: GatewayVoiceStateUpdateDispatchData): void {
+    const guildId = data.guild_id;
+    const userId = data.user_id;
+
+    if (!guildId || !userId) return;
+
+    // Ignore the bot's own state changes
+    if (this.botUserId && userId === this.botUserId) return;
+
+    if (!this.voiceStates.has(guildId)) {
+      this.voiceStates.set(guildId, new Map());
+    }
+    const guildStates = this.voiceStates.get(guildId)!;
+    const previousChannelId = guildStates.get(userId);
+    const newChannelId = data.channel_id ?? undefined;
+
+    if (previousChannelId === newChannelId) return;
+
+    // User left a channel
+    if (previousChannelId && !newChannelId) {
+      guildStates.delete(userId);
+      this.callbacks.onUserLeft(guildId, userId, previousChannelId);
+      return;
+    }
+
+    // User joined a channel (wasn't in one before)
+    if (!previousChannelId && newChannelId) {
+      guildStates.set(userId, newChannelId);
+      this.callbacks.onUserJoined(guildId, userId, newChannelId);
+      return;
+    }
+
+    // User moved channels
+    if (previousChannelId && newChannelId && previousChannelId !== newChannelId) {
+      guildStates.set(userId, newChannelId);
+      this.callbacks.onUserLeft(guildId, userId, previousChannelId);
+      this.callbacks.onUserJoined(guildId, userId, newChannelId);
+    }
+  }
+
+  /** Get all user IDs currently in a specific channel. */
+  getUsersInChannel(guildId: string, channelId: string): string[] {
+    const guildStates = this.voiceStates.get(guildId);
+    if (!guildStates) return [];
+
+    const users: string[] = [];
+    for (const [userId, ch] of guildStates) {
+      if (ch === channelId) {
+        users.push(userId);
+      }
+    }
+    return users;
+  }
+
+  /** Check if no human users are in the channel. */
+  isOnlyBotInChannel(guildId: string, channelId: string): boolean {
+    return this.getUsersInChannel(guildId, channelId).length === 0;
+  }
+
+  destroy(): void {
+    this.voiceStates.clear();
+  }
+}

--- a/extensions/discord/src/voice/voice-state-listener.ts
+++ b/extensions/discord/src/voice/voice-state-listener.ts
@@ -42,9 +42,6 @@ export class DiscordVoiceStateListener extends VoiceStateUpdateListener {
    */
   async handle(data: VoiceStateUpdateEvent, _client: Client): Promise<void> {
     try {
-      console.log(
-        `[voice-listener] handle called, type=${this.type}, data.guild_id=${(data as Record<string, unknown>).guild_id}, data.user_id=${(data as Record<string, unknown>).user_id}, data.channel_id=${(data as Record<string, unknown>).channel_id}`,
-      );
       this.processVoiceStateUpdate(data as GatewayVoiceStateUpdateDispatchData);
     } catch (err) {
       console.error(`[voice-listener] error:`, err);

--- a/extensions/discord/src/voice/wav.ts
+++ b/extensions/discord/src/voice/wav.ts
@@ -1,0 +1,48 @@
+/**
+ * PCM-to-WAV buffer conversion.
+ * Wraps raw PCM audio data in a 44-byte RIFF/WAVE header.
+ */
+
+export interface WavOptions {
+  sampleRate?: number;
+  channels?: number;
+  bitsPerSample?: number;
+}
+
+/**
+ * Wrap raw PCM data in a WAV container.
+ * Defaults to 48kHz stereo 16-bit, matching Discord voice output.
+ */
+export function wrapPcmInWav(pcmData: Buffer, opts?: WavOptions): Buffer {
+  const sampleRate = opts?.sampleRate ?? 48000;
+  const channels = opts?.channels ?? 2;
+  const bitsPerSample = opts?.bitsPerSample ?? 16;
+  const byteRate = sampleRate * channels * (bitsPerSample / 8);
+  const blockAlign = channels * (bitsPerSample / 8);
+  const dataSize = pcmData.length;
+  const headerSize = 44;
+
+  const buffer = Buffer.alloc(headerSize + dataSize);
+
+  // RIFF header
+  buffer.write("RIFF", 0);
+  buffer.writeUInt32LE(36 + dataSize, 4);
+  buffer.write("WAVE", 8);
+
+  // fmt sub-chunk
+  buffer.write("fmt ", 12);
+  buffer.writeUInt32LE(16, 16); // sub-chunk size
+  buffer.writeUInt16LE(1, 20); // audio format (PCM)
+  buffer.writeUInt16LE(channels, 22);
+  buffer.writeUInt32LE(sampleRate, 24);
+  buffer.writeUInt32LE(byteRate, 28);
+  buffer.writeUInt16LE(blockAlign, 32);
+  buffer.writeUInt16LE(bitsPerSample, 34);
+
+  // data sub-chunk
+  buffer.write("data", 36);
+  buffer.writeUInt32LE(dataSize, 40);
+  pcmData.copy(buffer, headerSize);
+
+  return buffer;
+}

--- a/package.json
+++ b/package.json
@@ -202,6 +202,13 @@
       "tar": "7.5.7",
       "tough-cookie": "4.1.3"
     },
+    "packageExtensions": {
+      "prism-media@*": {
+        "dependencies": {
+          "opusscript": "0.0.8"
+        }
+      }
+    },
     "onlyBuiltDependencies": [
       "@lydell/node-pty",
       "@matrix-org/matrix-sdk-crypto-nodejs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,8 @@ overrides:
   tar: 7.5.7
   tough-cookie: 4.1.3
 
+packageExtensionsChecksum: sha256-CsxneYGkM5r1sZQSUvWs5AXNOMqnalS6MwWmLQ8ni9U=
+
 importers:
 
   .:
@@ -24,7 +26,7 @@ importers:
         version: 3.989.0
       '@buape/carbon':
         specifier: 0.14.0
-        version: 0.14.0(hono@4.11.9)
+        version: 0.14.0(@discordjs/opus@0.10.0)(hono@4.11.9)(opusscript@0.0.8)
       '@clack/prompts':
         specifier: ^1.0.1
         version: 1.0.1
@@ -293,6 +295,22 @@ importers:
         version: link:../..
 
   extensions/discord:
+    dependencies:
+      '@discordjs/opus':
+        specifier: ^0.10.0
+        version: 0.10.0
+      '@discordjs/voice':
+        specifier: ^0.18.0
+        version: 0.18.0(@discordjs/opus@0.10.0)(opusscript@0.0.8)
+      libsodium-wrappers:
+        specifier: ^0.7.0
+        version: 0.7.16
+      opusscript:
+        specifier: ^0.0.8
+        version: 0.0.8
+      prism-media:
+        specifier: ^1.3.5
+        version: 1.3.5(@discordjs/opus@0.10.0)(opusscript@0.0.8)
     devDependencies:
       openclaw:
         specifier: workspace:*
@@ -877,6 +895,18 @@ packages:
 
   '@d-fischer/typed-event-emitter@3.3.3':
     resolution: {integrity: sha512-OvSEOa8icfdWDqcRtjSEZtgJTFOFNgTjje7zaL0+nAtu2/kZtRCSK5wUMrI/aXtCH8o0Qz2vA8UqkhWUTARFQQ==}
+
+  '@discordjs/node-pre-gyp@0.4.5':
+    resolution: {integrity: sha512-YJOVVZ545x24mHzANfYoy0BJX5PDyeZlpiJjDkUBM/V/Ao7TFX9lcUvCN4nr0tbr5ubeaXxtEBILUrHtTphVeQ==}
+    hasBin: true
+
+  '@discordjs/opus@0.10.0':
+    resolution: {integrity: sha512-HHEnSNrSPmFEyndRdQBJN2YE6egyXS9JUnJWyP6jficK0Y+qKMEZXyYTgmzpjrxXP1exM/hKaNP7BRBUEWkU5w==}
+    engines: {node: '>=12.0.0'}
+
+  '@discordjs/voice@0.18.0':
+    resolution: {integrity: sha512-BvX6+VJE5/vhD9azV9vrZEt9hL1G+GlOdsQaVl5iv9n87fkXjf3cSwllhR3GdaUC8m6dqT8umXIWtn3yCu4afg==}
+    engines: {node: '>=18'}
 
   '@discordjs/voice@0.19.0':
     resolution: {integrity: sha512-UyX6rGEXzVyPzb1yvjHtPfTlnLvB5jX/stAMdiytHhfoydX+98hfympdOwsnTktzr+IRvphxTbdErgYDJkEsvw==}
@@ -3199,6 +3229,9 @@ packages:
     resolution: {tarball: https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67}
     version: 2.0.1
 
+  abbrev@1.1.1:
+    resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
+
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
@@ -3220,6 +3253,10 @@ packages:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -3275,6 +3312,11 @@ packages:
 
   aproba@2.1.0:
     resolution: {integrity: sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==}
+
+  are-we-there-yet@2.0.0:
+    resolution: {integrity: sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==}
+    engines: {node: '>=10'}
+    deprecated: This package is no longer supported.
 
   are-we-there-yet@3.0.1:
     resolution: {integrity: sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==}
@@ -3401,6 +3443,9 @@ packages:
 
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
+
+  brace-expansion@1.1.12:
+    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
@@ -3536,6 +3581,9 @@ packages:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
 
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
   console-control-strings@1.1.0:
     resolution: {integrity: sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==}
 
@@ -3658,6 +3706,9 @@ packages:
   diff@8.0.3:
     resolution: {integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==}
     engines: {node: '>=0.3.1'}
+
+  discord-api-types@0.37.120:
+    resolution: {integrity: sha512-7xpNK0EiWjjDFp2nAhHXezE4OUWm7s1zhc/UXXN6hnFFU8dfoPHgV0Hx0RPiCa3ILRpdeh152icc68DGCyXYIw==}
 
   discord-api-types@0.38.37:
     resolution: {integrity: sha512-Cv47jzY1jkGkh5sv0bfHYqGgKOWO1peOrGMkDFM4UmaGMOTgOW8QSexhvixa9sVOiz8MnVOBryWYyw/CEVhj7w==}
@@ -3925,6 +3976,9 @@ packages:
     resolution: {integrity: sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==}
     engines: {node: '>=14.14'}
 
+  fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3937,6 +3991,11 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  gauge@3.0.2:
+    resolution: {integrity: sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==}
+    engines: {node: '>=10'}
+    deprecated: This package is no longer supported.
 
   gauge@4.0.4:
     resolution: {integrity: sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==}
@@ -3988,6 +4047,10 @@ packages:
   glob@13.0.3:
     resolution: {integrity: sha512-/g3B0mC+4x724v1TgtBlBtt2hPi/EWptsIAmXUx9Z2rvBYleQcsrmaOzd5LyL50jf/Soi83ZDJmw2+XqvH/EeA==}
     engines: {node: 20 || >=22}
+
+  glob@7.2.3:
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   google-auth-library@10.5.0:
     resolution: {integrity: sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==}
@@ -4099,6 +4162,10 @@ packages:
     resolution: {integrity: sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==}
     engines: {node: '>=0.8', npm: '>=1.3.7'}
 
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
+
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
@@ -4127,6 +4194,10 @@ packages:
   import-without-cache@0.2.5:
     resolution: {integrity: sha512-B6Lc2s6yApwnD2/pMzFh/d5AVjdsDXjgkeJ766FmFuJELIGHNycKRj+l3A39yZPM4CchqNCB4RITEAYB1KUM6A==}
     engines: {node: '>=20.19.0'}
+
+  inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -4305,6 +4376,12 @@ packages:
 
   leac@0.6.0:
     resolution: {integrity: sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==}
+
+  libsodium-wrappers@0.7.16:
+    resolution: {integrity: sha512-Gtr/WBx4dKjvRL1pvfwZqu7gO6AfrQ0u9vFL+kXihtHf6NfkROR8pjYWn98MFDI3jN19Ii1ZUfPR9afGiPyfHg==}
+
+  libsodium@0.7.16:
+    resolution: {integrity: sha512-3HrzSPuzm6Yt9aTYCDxYEG8x8/6C0+ag655Y7rhhWZM9PT4NpdnbqlzXhGZlDnkgR6MeSTnOt/VIyHLs9aSf+Q==}
 
   lie@3.3.0:
     resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
@@ -4497,6 +4574,10 @@ packages:
   magicast@0.5.2:
     resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
 
+  make-dir@3.1.0:
+    resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
+    engines: {node: '>=8'}
+
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
@@ -4575,6 +4656,9 @@ packages:
   minimatch@10.2.0:
     resolution: {integrity: sha512-ugkC31VaVg9cF0DFVoADH12k6061zNZkZON+aX8AWsR9GhPcErkcMBceb6znR8wLERM2AkkOxy2nWRLpT9Jq5w==}
     engines: {node: 20 || >=22}
+
+  minimatch@3.1.2:
+    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
@@ -4696,6 +4780,11 @@ packages:
     resolution: {integrity: sha512-M6Rm/bbG6De/gKGxOpeOobx/dnGuP0dz40adqx38boqHhlWssBJZgLCPBNtb9NkrmnKYiV04xELq+R6PFOnoLA==}
     engines: {node: '>=4.4.0'}
 
+  nopt@5.0.0:
+    resolution: {integrity: sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   nostr-tools@2.23.1:
     resolution: {integrity: sha512-Q5SJ1omrseBFXtLwqDhufpFLA6vX3rS/IuBCc974qaYX6YKGwEPxa/ZsyxruUOr+b+5EpWL2hFmCB5AueYrfBw==}
     peerDependencies:
@@ -4706,6 +4795,10 @@ packages:
 
   nostr-wasm@0.1.0:
     resolution: {integrity: sha512-78BTryCLcLYv96ONU8Ws3Q1JzjlAt+43pWQhIl86xZmWeegYCNLPml7yQ+gG3vR6V5h4XGj+TxO+SS5dsThQIA==}
+
+  npmlog@5.0.1:
+    resolution: {integrity: sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==}
+    deprecated: This package is no longer supported.
 
   npmlog@6.0.2:
     resolution: {integrity: sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==}
@@ -4792,6 +4885,9 @@ packages:
 
   opus-decoder@0.7.11:
     resolution: {integrity: sha512-+e+Jz3vGQLxRTBHs8YJQPRPc1Tr+/aC6coV/DlZylriA29BdHQAYXhvNRKtjftof17OFng0+P4wsFIqQu3a48A==}
+
+  opusscript@0.0.8:
+    resolution: {integrity: sha512-VSTi1aWFuCkRCVq+tx/BQ5q9fMnQ9pVZ3JU4UHKqTkf0ED3fKEPdr+gKAAl3IA2hj9rrP6iyq3hlcJq3HELtNQ==}
 
   ora@8.2.0:
     resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
@@ -4891,6 +4987,10 @@ packages:
 
   partial-json@0.1.7:
     resolution: {integrity: sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==}
+
+  path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -5148,6 +5248,11 @@ packages:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
     engines: {node: '>= 4'}
 
+  rimraf@3.0.2:
+    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
+
   rimraf@5.0.10:
     resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
     hasBin: true
@@ -5208,6 +5313,10 @@ packages:
 
   selderee@0.11.0:
     resolution: {integrity: sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
@@ -6393,13 +6502,13 @@ snapshots:
 
   '@borewit/text-codec@0.2.1': {}
 
-  '@buape/carbon@0.14.0(hono@4.11.9)':
+  '@buape/carbon@0.14.0(@discordjs/opus@0.10.0)(hono@4.11.9)(opusscript@0.0.8)':
     dependencies:
       '@types/node': 25.2.3
       discord-api-types: 0.38.37
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260120.0
-      '@discordjs/voice': 0.19.0
+      '@discordjs/voice': 0.19.0(@discordjs/opus@0.10.0)(opusscript@0.0.8)
       '@hono/node-server': 1.19.9(hono@4.11.9)
       '@types/bun': 1.3.6
       '@types/ws': 8.18.1
@@ -6493,11 +6602,49 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@discordjs/voice@0.19.0':
+  '@discordjs/node-pre-gyp@0.4.5':
+    dependencies:
+      detect-libc: 2.1.2
+      https-proxy-agent: 5.0.1
+      make-dir: 3.1.0
+      node-fetch: 2.7.0
+      nopt: 5.0.0
+      npmlog: 5.0.1
+      rimraf: 3.0.2
+      semver: 7.7.4
+      tar: 7.5.7
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@discordjs/opus@0.10.0':
+    dependencies:
+      '@discordjs/node-pre-gyp': 0.4.5
+      node-addon-api: 8.5.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@discordjs/voice@0.18.0(@discordjs/opus@0.10.0)(opusscript@0.0.8)':
+    dependencies:
+      '@types/ws': 8.18.1
+      discord-api-types: 0.37.120
+      prism-media: 1.3.5(@discordjs/opus@0.10.0)(opusscript@0.0.8)
+      tslib: 2.8.1
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - '@discordjs/opus'
+      - bufferutil
+      - ffmpeg-static
+      - node-opus
+      - opusscript
+      - utf-8-validate
+
+  '@discordjs/voice@0.19.0(@discordjs/opus@0.10.0)(opusscript@0.0.8)':
     dependencies:
       '@types/ws': 8.18.1
       discord-api-types: 0.38.38
-      prism-media: 1.3.5
+      prism-media: 1.3.5(@discordjs/opus@0.10.0)(opusscript@0.0.8)
       tslib: 2.8.1
       ws: 8.19.0
     transitivePeerDependencies:
@@ -6842,7 +6989,7 @@ snapshots:
 
   '@larksuiteoapi/node-sdk@1.59.0':
     dependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       lodash.identity: 3.0.0
       lodash.merge: 4.6.2
       lodash.pickby: 4.6.0
@@ -6858,7 +7005,7 @@ snapshots:
     dependencies:
       '@types/node': 24.10.13
     optionalDependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
     transitivePeerDependencies:
       - debug
 
@@ -7061,7 +7208,7 @@ snapshots:
       '@azure/core-auth': 1.10.1
       '@azure/msal-node': 3.8.7
       '@microsoft/agents-activity': 1.2.3
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       jsonwebtoken: 9.0.3
       jwks-rsa: 3.2.2
       object-path: 0.11.8
@@ -8008,7 +8155,7 @@ snapshots:
       '@slack/types': 2.20.0
       '@slack/web-api': 7.14.0
       '@types/express': 5.0.6
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       express: 5.2.1
       path-to-regexp: 8.3.0
       raw-body: 3.0.2
@@ -8054,7 +8201,7 @@ snapshots:
       '@slack/types': 2.20.0
       '@types/node': 25.2.3
       '@types/retry': 0.12.0
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       eventemitter3: 5.0.4
       form-data: 2.5.4
       is-electron: 2.2.2
@@ -8803,6 +8950,8 @@ snapshots:
       curve25519-js: 0.0.4
       protobufjs: 6.8.8
 
+  abbrev@1.1.1: {}
+
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
@@ -8822,6 +8971,12 @@ snapshots:
       acorn: 8.15.0
 
   acorn@8.15.0: {}
+
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   agent-base@7.1.4: {}
 
@@ -8874,6 +9029,11 @@ snapshots:
       tslib: 2.8.1
 
   aproba@2.1.0: {}
+
+  are-we-there-yet@2.0.0:
+    dependencies:
+      delegates: 1.0.0
+      readable-stream: 3.6.2
 
   are-we-there-yet@3.0.1:
     dependencies:
@@ -8948,14 +9108,6 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  axios@1.13.5:
-    dependencies:
-      follow-redirects: 1.15.11
-      form-data: 2.5.4
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
   axios@1.13.5(debug@4.4.3):
     dependencies:
       follow-redirects: 1.15.11(debug@4.4.3)
@@ -9026,6 +9178,11 @@ snapshots:
   bottleneck@2.19.5: {}
 
   bowser@2.14.1: {}
+
+  brace-expansion@1.1.12:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
 
   brace-expansion@2.0.2:
     dependencies:
@@ -9172,6 +9329,8 @@ snapshots:
 
   commander@14.0.3: {}
 
+  concat-map@0.0.1: {}
+
   console-control-strings@1.1.0: {}
 
   content-disposition@0.5.4:
@@ -9255,6 +9414,8 @@ snapshots:
   detect-libc@2.1.2: {}
 
   diff@8.0.3: {}
+
+  discord-api-types@0.37.120: {}
 
   discord-api-types@0.38.37: {}
 
@@ -9539,8 +9700,6 @@ snapshots:
 
   flatbuffers@24.12.23: {}
 
-  follow-redirects@1.15.11: {}
-
   follow-redirects@1.15.11(debug@4.4.3):
     optionalDependencies:
       debug: 4.4.3
@@ -9577,6 +9736,8 @@ snapshots:
       jsonfile: 6.2.0
       universalify: 2.0.1
 
+  fs.realpath@1.0.0: {}
+
   fsevents@2.3.2:
     optional: true
 
@@ -9584,6 +9745,18 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  gauge@3.0.2:
+    dependencies:
+      aproba: 2.1.0
+      color-support: 1.1.3
+      console-control-strings: 1.1.0
+      has-unicode: 2.0.1
+      object-assign: 4.1.1
+      signal-exit: 3.0.7
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wide-align: 1.1.5
 
   gauge@4.0.4:
     dependencies:
@@ -9667,6 +9840,15 @@ snapshots:
       minimatch: 10.2.0
       minipass: 7.1.2
       path-scurry: 2.0.1
+
+  glob@7.2.3:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.2
+      once: 1.4.0
+      path-is-absolute: 1.0.1
 
   google-auth-library@10.5.0:
     dependencies:
@@ -9797,6 +9979,13 @@ snapshots:
       jsprim: 1.4.2
       sshpk: 1.18.0
 
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
@@ -9826,6 +10015,11 @@ snapshots:
       module-details-from-path: 1.0.4
 
   import-without-cache@0.2.5: {}
+
+  inflight@1.0.6:
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
 
   inherits@2.0.4: {}
 
@@ -10022,6 +10216,12 @@ snapshots:
 
   leac@0.6.0: {}
 
+  libsodium-wrappers@0.7.16:
+    dependencies:
+      libsodium: 0.7.16
+
+  libsodium@0.7.16: {}
+
   lie@3.3.0:
     dependencies:
       immediate: 3.0.6
@@ -10189,6 +10389,10 @@ snapshots:
       '@babel/types': 7.29.0
       source-map-js: 1.2.1
 
+  make-dir@3.1.0:
+    dependencies:
+      semver: 6.3.1
+
   make-dir@4.0.0:
     dependencies:
       semver: 7.7.4
@@ -10245,6 +10449,10 @@ snapshots:
   minimatch@10.2.0:
     dependencies:
       brace-expansion: 5.0.2
+
+  minimatch@3.1.2:
+    dependencies:
+      brace-expansion: 1.1.12
 
   minimatch@9.0.5:
     dependencies:
@@ -10397,6 +10605,10 @@ snapshots:
   node-wav@0.0.2:
     optional: true
 
+  nopt@5.0.0:
+    dependencies:
+      abbrev: 1.1.1
+
   nostr-tools@2.23.1(typescript@5.9.3):
     dependencies:
       '@noble/ciphers': 2.1.1
@@ -10410,6 +10622,13 @@ snapshots:
       typescript: 5.9.3
 
   nostr-wasm@0.1.0: {}
+
+  npmlog@5.0.1:
+    dependencies:
+      are-we-there-yet: 2.0.0
+      console-control-strings: 1.1.0
+      gauge: 3.0.2
+      set-blocking: 2.0.0
 
   npmlog@6.0.2:
     dependencies:
@@ -10492,6 +10711,8 @@ snapshots:
     dependencies:
       '@wasm-audio-decoders/common': 9.0.7
     optional: true
+
+  opusscript@0.0.8: {}
 
   ora@8.2.0:
     dependencies:
@@ -10635,6 +10856,8 @@ snapshots:
 
   partial-json@0.1.7: {}
 
+  path-is-absolute@1.0.1: {}
+
   path-key@3.1.1: {}
 
   path-scurry@1.11.1:
@@ -10720,8 +10943,10 @@ snapshots:
     dependencies:
       parse-ms: 4.0.0
 
-  prism-media@1.3.5:
-    optional: true
+  prism-media@1.3.5(@discordjs/opus@0.10.0)(opusscript@0.0.8):
+    optionalDependencies:
+      '@discordjs/opus': 0.10.0
+      opusscript: 0.0.8
 
   process-nextick-args@2.0.1: {}
 
@@ -10933,6 +11158,10 @@ snapshots:
 
   retry@0.13.1: {}
 
+  rimraf@3.0.2:
+    dependencies:
+      glob: 7.2.3
+
   rimraf@5.0.10:
     dependencies:
       glob: 10.5.0
@@ -11054,6 +11283,8 @@ snapshots:
   selderee@0.11.0:
     dependencies:
       parseley: 0.12.1
+
+  semver@6.3.1: {}
 
   semver@7.7.4: {}
 

--- a/skills/discord/SKILL.md
+++ b/skills/discord/SKILL.md
@@ -413,6 +413,50 @@ Create, edit, delete, and move channels and categories. Enable via `discord.acti
 }
 ```
 
+## Voice Transcription
+
+OpenClaw can automatically join Discord voice channels, transcribe speech in real time, and produce a summary when the session ends.
+
+### What it does
+
+1. **Auto-join**: When a user enters a monitored voice channel, the bot joins automatically.
+2. **Transcribe**: Incoming audio is decoded from Opus, buffered, and sent to Groq Whisper for speech-to-text.
+3. **Thread posting**: Each transcription is posted to a thread (created lazily) in the configured transcription channel.
+4. **Summarize**: When all humans leave, the bot generates a summary (via Groq LLM), posts it to the transcription channel, and leaves.
+
+### Configuration
+
+Voice settings live under `plugins.entries.discord.config.voice`:
+
+```json
+{
+  "enabled": true,
+  "autoJoin": true,
+  "autoJoinGuilds": ["123456789012345678"],
+  "transcriptionChannelId": "987654321098765432",
+  "groqApiKey": "gsk_...",
+  "whisperModel": "whisper-large-v3-turbo",
+  "summarizationModel": "llama-3.3-70b-versatile",
+  "silenceTimeoutMs": 2000,
+  "transcriptionEnabled": true
+}
+```
+
+- **`autoJoin`**: `true` to auto-join when a user enters a voice channel.
+- **`autoJoinGuilds`**: Optional list of guild IDs to restrict auto-join.
+- **`transcriptionChannelId`**: Text channel where transcription threads and summaries are posted.
+- **`groqApiKey`**: Groq API key for Whisper transcription and LLM summarization. Falls back to `GROQ_API_KEY` env var.
+- **`whisperModel`**: Whisper model for transcription (default `whisper-large-v3-turbo`).
+- **`summarizationModel`**: LLM model for session summarization (default `llama-3.3-70b-versatile`).
+- **`silenceTimeoutMs`**: Silence duration before flushing audio buffer (default `2000`).
+
+### Required setup
+
+1. **Groq API key**: Set `groqApiKey` in the voice config or `GROQ_API_KEY` environment variable.
+2. **Transcription channel**: Set `transcriptionChannelId` to a text channel the bot can post in.
+3. **Voice States intent**: Enable `voiceStates` in `channels.discord.intents` so the bot receives voice state updates.
+4. **Bot permissions**: The bot needs Connect + Speak permissions in the voice channel, and Send Messages + Create Public Threads in the transcription channel.
+
 ### Scheduled events
 
 ```json

--- a/skills/discord/SKILL.md
+++ b/skills/discord/SKILL.md
@@ -422,7 +422,7 @@ OpenClaw can automatically join Discord voice channels, transcribe speech in rea
 1. **Auto-join**: When a user enters a monitored voice channel, the bot joins automatically.
 2. **Transcribe**: Incoming audio is decoded from Opus, buffered, and sent to Groq Whisper for speech-to-text.
 3. **Thread posting**: Each transcription is posted to a thread (created lazily) in the configured transcription channel.
-4. **Summarize**: When all humans leave, the bot generates a summary (via Groq LLM), posts it to the transcription channel, and leaves.
+4. **Summarize**: When all humans leave, the bot generates a summary using the agent's configured LLM, posts it to the transcription channel, and leaves.
 
 ### Configuration
 
@@ -436,7 +436,6 @@ Voice settings live under `plugins.entries.discord.config.voice`:
   "transcriptionChannelId": "987654321098765432",
   "groqApiKey": "gsk_...",
   "whisperModel": "whisper-large-v3-turbo",
-  "summarizationModel": "llama-3.3-70b-versatile",
   "silenceTimeoutMs": 2000,
   "transcriptionEnabled": true
 }
@@ -445,14 +444,13 @@ Voice settings live under `plugins.entries.discord.config.voice`:
 - **`autoJoin`**: `true` to auto-join when a user enters a voice channel.
 - **`autoJoinGuilds`**: Optional list of guild IDs to restrict auto-join.
 - **`transcriptionChannelId`**: Text channel where transcription threads and summaries are posted.
-- **`groqApiKey`**: Groq API key for Whisper transcription and LLM summarization. Falls back to `GROQ_API_KEY` env var.
+- **`groqApiKey`**: Groq API key for Whisper speech-to-text transcription. Falls back to `GROQ_API_KEY` env var.
 - **`whisperModel`**: Whisper model for transcription (default `whisper-large-v3-turbo`).
-- **`summarizationModel`**: LLM model for session summarization (default `llama-3.3-70b-versatile`).
 - **`silenceTimeoutMs`**: Silence duration before flushing audio buffer (default `2000`).
 
 ### Required setup
 
-1. **Groq API key**: Set `groqApiKey` in the voice config or `GROQ_API_KEY` environment variable.
+1. **Groq API key**: Set `groqApiKey` in the voice config or `GROQ_API_KEY` environment variable (required for Whisper transcription; summarization uses the agent's configured LLM).
 2. **Transcription channel**: Set `transcriptionChannelId` to a text channel the bot can post in.
 3. **Voice States intent**: Enable `voiceStates` in `channels.discord.intents` so the bot receives voice state updates.
 4. **Bot permissions**: The bot needs Connect + Speak permissions in the voice channel, and Send Messages + Create Public Threads in the transcription channel.

--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -89,6 +89,8 @@ export type DiscordIntentsConfig = {
   presence?: boolean;
   /** Enable Guild Members privileged intent (requires Portal opt-in). Default: false. */
   guildMembers?: boolean;
+  /** Enable Guild Voice States intent (non-privileged). Required for voice transcription. Default: false. */
+  voiceStates?: boolean;
 };
 
 export type DiscordExecApprovalConfig = {

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -318,6 +318,7 @@ export const DiscordAccountSchema = z
       .object({
         presence: z.boolean().optional(),
         guildMembers: z.boolean().optional(),
+        voiceStates: z.boolean().optional(),
       })
       .strict()
       .optional(),

--- a/src/discord/monitor/gateway-registry.ts
+++ b/src/discord/monitor/gateway-registry.ts
@@ -5,8 +5,17 @@ import type { GatewayPlugin } from "@buape/carbon/gateway";
  * Bridges the gap between agent tool handlers (which only have REST access)
  * and the gateway WebSocket (needed for operations like updatePresence).
  * Follows the same pattern as presence-cache.ts.
+ *
+ * Uses globalThis so the registry is shared across jiti (extension) and
+ * native ESM (src/) module boundaries.
  */
-const gatewayRegistry = new Map<string, GatewayPlugin>();
+const G = globalThis as unknown as {
+  __openclawDiscordGatewayRegistry?: Map<string, GatewayPlugin>;
+};
+if (!G.__openclawDiscordGatewayRegistry) {
+  G.__openclawDiscordGatewayRegistry = new Map();
+}
+const gatewayRegistry: Map<string, GatewayPlugin> = G.__openclawDiscordGatewayRegistry;
 
 // Sentinel key for the default (unnamed) account. Uses a prefix that cannot
 // collide with user-configured account IDs.
@@ -26,9 +35,23 @@ export function unregisterGateway(accountId?: string): void {
   gatewayRegistry.delete(resolveAccountKey(accountId));
 }
 
-/** Get the GatewayPlugin for an account. Returns undefined if not registered. */
+/** Get the GatewayPlugin for an account. Returns undefined if not registered.
+ *  When accountId is undefined and the sentinel key has no entry, falls back
+ *  to the first registered gateway (common single-account setup). */
 export function getGateway(accountId?: string): GatewayPlugin | undefined {
-  return gatewayRegistry.get(resolveAccountKey(accountId));
+  const key = resolveAccountKey(accountId);
+  const exact = gatewayRegistry.get(key);
+  if (exact) {
+    return exact;
+  }
+
+  // Fallback: when called without an accountId, return the first (only)
+  // registered gateway. This bridges the gap when the voice extension
+  // doesn't know the concrete account name used at registration time.
+  if (!accountId && gatewayRegistry.size > 0) {
+    return gatewayRegistry.values().next().value;
+  }
+  return undefined;
 }
 
 /** Clear all registered gateways (for testing). */


### PR DESCRIPTION
## Summary
- Adds Discord voice channel transcription pipeline: auto-join, Groq Whisper STT, per-speaker thread posting, and session summarization
- Routes summarization through openclaw's embedded agent runner (`runEmbeddedPiAgent`) instead of hardcoding Groq — uses whatever LLM the user has configured
- Groq API key is only needed for Whisper transcription (speech-to-text)
- Discord-friendly formatting: bold labels instead of oversized headings, combined summary + duration message, no artificial length limits

## Test plan
- [ ] Start gateway, join voice channel, speak — verify transcriptions post to thread
- [ ] Leave voice channel — verify summary is generated using the configured LLM (not Groq)
- [ ] Verify summary appears in the channel (not thread) with clean Discord formatting
- [ ] Confirm existing configs with old `summarizationModel` field don't break (zod passthrough)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds Discord voice-channel support: a transcription pipeline (Groq Whisper STT), per-speaker thread posting, and session summarization routed through OpenClaw’s embedded agent runner (`runEmbeddedPiAgent`) to use the user-configured LLM. It also wires voice state handling into the Discord monitor to support voice gateway events and adds docs/config for enabling voice intents.

Main concern: the Discord monitor now installs a DEBUG gateway listener and monkeypatches the gateway event handler when `intents.voiceStates` is enabled, which makes verbose logging + global behavior changes the default for voice-enabled deployments.

<h3>Confidence Score: 3/5</h3>

- This PR is moderately safe but has a merge-blocking logging/monkeypatch issue in the Discord monitor path when voice is enabled.
- Core feature wiring looks cohesive, but `monitorDiscordProvider` unconditionally installs debug listeners and monkeypatches the gateway event handler when `intents.voiceStates` is enabled, which can flood logs and introduce hard-to-debug global behavior changes in production.
- src/discord/monitor/provider.ts

<sub>Last reviewed commit: 3fcecb8</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->