### PR TITLE
fix(tui): preserve streamed text when final payload regresses (#15452)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/Image tool: cap image-analysis completion `maxTokens` by model capability (`min(4096, model.maxTokens)`) to avoid over-limit provider failures while still preventing truncation. (#11770) Thanks @detecti1.
+- TUI/Streaming: preserve richer streamed assistant text when final payload drops pre-tool-call text blocks, while keeping non-empty final payload authoritative for plain-text updates. (#15452) Thanks @TsekaLuk.
 - Inbound/Web UI: preserve literal `\n` sequences when normalizing inbound text so Windows paths like `C:\\Work\\nxxx\\README.md` are not corrupted. (#11547) Thanks @mcaxtr.
 - Security/Canvas: serve A2UI assets via the shared safe-open path (`openFileWithinRoot`) to close traversal/TOCTOU gaps, with traversal and symlink regression coverage. (#10525) Thanks @abdelsfane.
 - Security/Gateway: breaking default-behavior change - canvas IP-based auth fallback now only accepts machine-scoped addresses (RFC1918, link-local, ULA IPv6, CGNAT); public-source IP matches now require bearer token auth. (#14661) Thanks @sumleo.

--- a/src/tui/tui-stream-assembler.test.ts
+++ b/src/tui/tui-stream-assembler.test.ts
@@ -98,6 +98,7 @@ describe("TuiStreamAssembler", () => {
         role: "assistant",
         content: [
           { type: "text", text: "Before tool call" },
+          { type: "tool_use", name: "search" },
           { type: "text", text: "After tool call" },
         ],
       },
@@ -108,12 +109,41 @@ describe("TuiStreamAssembler", () => {
       "run-5",
       {
         role: "assistant",
-        content: [{ type: "text", text: "After tool call" }],
+        content: [
+          { type: "tool_use", name: "search" },
+          { type: "text", text: "After tool call" },
+        ],
       },
       false,
     );
 
     expect(finalText).toBe("Before tool call\nAfter tool call");
+  });
+
+  it("keeps non-empty final text for plain text prefix/suffix updates", () => {
+    const assembler = new TuiStreamAssembler();
+    assembler.ingestDelta(
+      "run-5b",
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Draft line 1" },
+          { type: "text", text: "Draft line 2" },
+        ],
+      },
+      false,
+    );
+
+    const finalText = assembler.finalize(
+      "run-5b",
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Draft line 1" }],
+      },
+      false,
+    );
+
+    expect(finalText).toBe("Draft line 1");
   });
 
   it("accepts richer final payload when it extends streamed text", () => {

--- a/src/tui/tui-stream-assembler.test.ts
+++ b/src/tui/tui-stream-assembler.test.ts
@@ -141,4 +141,27 @@ describe("TuiStreamAssembler", () => {
 
     expect(finalText).toBe("Before tool call\nAfter tool call");
   });
+
+  it("prefers non-empty final payload when it is not a dropped block regression", () => {
+    const assembler = new TuiStreamAssembler();
+    assembler.ingestDelta(
+      "run-7",
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "NOT OK" }],
+      },
+      false,
+    );
+
+    const finalText = assembler.finalize(
+      "run-7",
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "OK" }],
+      },
+      false,
+    );
+
+    expect(finalText).toBe("OK");
+  });
 });

--- a/src/tui/tui-stream-assembler.test.ts
+++ b/src/tui/tui-stream-assembler.test.ts
@@ -89,4 +89,56 @@ describe("TuiStreamAssembler", () => {
 
     expect(second).toBeNull();
   });
+
+  it("keeps richer streamed text when final payload drops earlier blocks", () => {
+    const assembler = new TuiStreamAssembler();
+    assembler.ingestDelta(
+      "run-5",
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Before tool call" },
+          { type: "text", text: "After tool call" },
+        ],
+      },
+      false,
+    );
+
+    const finalText = assembler.finalize(
+      "run-5",
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "After tool call" }],
+      },
+      false,
+    );
+
+    expect(finalText).toBe("Before tool call\nAfter tool call");
+  });
+
+  it("accepts richer final payload when it extends streamed text", () => {
+    const assembler = new TuiStreamAssembler();
+    assembler.ingestDelta(
+      "run-6",
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Before tool call" }],
+      },
+      false,
+    );
+
+    const finalText = assembler.finalize(
+      "run-6",
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Before tool call" },
+          { type: "text", text: "After tool call" },
+        ],
+      },
+      false,
+    );
+
+    expect(finalText).toBe("Before tool call\nAfter tool call");
+  });
 });

--- a/src/tui/tui-stream-assembler.ts
+++ b/src/tui/tui-stream-assembler.ts
@@ -23,8 +23,17 @@ function mergeTextPreferRicher(currentText: string, nextText: string): string {
   if (next.includes(current)) {
     return next;
   }
-  if (current.includes(next)) {
-    return current;
+  // Keep streamed text only when the newer payload looks like a dropped
+  // leading/trailing block (the known regression shape), not any substring.
+  const currentLines = current.split("\n");
+  const nextLines = next.split("\n");
+  if (currentLines.length > nextLines.length) {
+    const isDroppedLeadingBlock =
+      currentLines.slice(currentLines.length - nextLines.length).join("\n") === next;
+    const isDroppedTrailingBlock = currentLines.slice(0, nextLines.length).join("\n") === next;
+    if (isDroppedLeadingBlock || isDroppedTrailingBlock) {
+      return current;
+    }
   }
   return next;
 }

--- a/src/tui/tui-stream-assembler.ts
+++ b/src/tui/tui-stream-assembler.ts
@@ -64,7 +64,9 @@ function isDroppedBoundaryTextBlockSubset(params: {
     return false;
   }
 
-  const prefixMatches = finalTextBlocks.every((block, index) => streamedTextBlocks[index] === block);
+  const prefixMatches = finalTextBlocks.every(
+    (block, index) => streamedTextBlocks[index] === block,
+  );
   if (prefixMatches) {
     return true;
   }


### PR DESCRIPTION
## Summary
Fixes a TUI regression where the finalized assistant message can overwrite a richer streamed message with a shorter payload.

Closes #15452.

## Problem
When an assistant turn emits text, then tool calls, then more text, the TUI can show the correct full streamed content during `delta` events, but replace it with a shorter text on `final`.

## Root Cause
`TuiStreamAssembler.finalize()` rebuilt display state from the final payload and accepted shorter subsets (e.g. post-tool blocks only), which regressed already-correct streamed content.

## Changes
- `src/tui/tui-stream-assembler.ts`
  - Added `mergeTextPreferRicher()` to prefer richer cumulative text and reject subset regressions.
  - In `finalize()`, pass the pre-final streamed display as `streamedText` fallback.
- `src/tui/tui-stream-assembler.test.ts`
  - Added regression test: keep full streamed text when final payload drops earlier blocks.
  - Added guard test: still accept richer final payload when final extends streamed content.

## Tests
- `pnpm vitest run src/tui/tui-stream-assembler.test.ts src/tui/tui-event-handlers.test.ts src/tui/tui.test.ts`
  - Passed (18/18).

## Broader Validation Notes
I also ran repo-level checks in this environment:
- `pnpm lint` and `pnpm check` fail on pre-existing unrelated files (`src/infra/provider-usage.auth.normalizes-keys.test.ts`, `src/plugins/discovery.test.ts`) due unused `vi` imports.
- `pnpm build` passed.
- `pnpm test` has unrelated pre-existing failures/timeouts in this environment (e.g. `src/security/audit.test.ts`, `src/gateway/tools-invoke-http.test.ts`, `src/browser/pw-session.get-page-for-targetid.extension-fallback.test.ts`, lobster extension timeouts).

No failures were observed in the touched TUI tests.

## Sign-Off
lobster-biscuit

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `TuiStreamAssembler` to avoid a regression where a shorter `final` assistant payload can overwrite the richer text accumulated during `delta` streaming. It introduces `mergeTextPreferRicher()` to retain previously accumulated thinking/content when the next update appears to be a subset, and it changes `finalize()` to pass the pre-final streamed display text as the fallback into `resolveFinalAssistantText()`.

Tests add two new cases covering the reported regression (final drops earlier text blocks) and ensuring richer finals still win when they extend streamed content.

<h3>Confidence Score: 3/5</h3>

- This PR is close, but the new substring-based merge can produce incorrect final text in some realistic cases.
- The targeted regression fix makes sense and tests cover the reported scenario, but `mergeTextPreferRicher()` uses broad `includes` checks that can cause the assembler to ignore a legitimate non-empty final payload whenever it is shorter and happens to be a substring of the streamed text, changing the intended “final wins unless empty” behavior.
- src/tui/tui-stream-assembler.ts

<sub>Last reviewed commit: ffcd96e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->