### PR TITLE
fix(hooks): use configured model for llm slug generation (#15510)

### DIFF
--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -19,7 +19,7 @@ import { attachGatewayWsMessageHandler } from "./ws-connection/message-handler.j
 type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
 
 const LOG_HEADER_MAX_LEN = 300;
-const LOG_HEADER_CONTROL_REGEX = /[\u0000-\u001f\u007f-\u009f]/g;
+const LOG_HEADER_CONTROL_REGEX = /\p{Cc}/gu;
 const LOG_HEADER_FORMAT_REGEX = /\p{Cf}/gu;
 
 const sanitizeLogValue = (value: string | undefined): string | undefined => {

--- a/src/hooks/llm-slug-generator.test.ts
+++ b/src/hooks/llm-slug-generator.test.ts
@@ -27,15 +27,13 @@ describe("generateSlugViaLLM", () => {
       payloads: [{ text: "Roadmap Plan" }],
     });
 
-    const cfg: OpenClawConfig = {
+    const cfg = {
       agents: {
         defaults: {
-          model: {
-            primary: "minimax/MiniMax-M2.5",
-          },
+          model: "minimax/MiniMax-M2.5",
         },
       },
-    };
+    } satisfies OpenClawConfig;
 
     const slug = await generateSlugViaLLM({
       sessionContent: "User asked for a roadmap plan",

--- a/src/hooks/llm-slug-generator.test.ts
+++ b/src/hooks/llm-slug-generator.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+
+const { runEmbeddedPiAgent } = vi.hoisted(() => ({
+  runEmbeddedPiAgent: vi.fn(),
+}));
+
+vi.mock("../agents/pi-embedded.js", () => ({
+  runEmbeddedPiAgent,
+}));
+
+vi.mock("../agents/agent-scope.js", () => ({
+  resolveDefaultAgentId: vi.fn().mockReturnValue("main"),
+  resolveAgentWorkspaceDir: vi.fn().mockReturnValue("/tmp/workspace"),
+  resolveAgentDir: vi.fn().mockReturnValue("/tmp/agent"),
+}));
+
+import { generateSlugViaLLM } from "./llm-slug-generator.js";
+
+describe("generateSlugViaLLM", () => {
+  beforeEach(() => {
+    runEmbeddedPiAgent.mockReset();
+  });
+
+  it("uses configured default provider/model for the slug generation run", async () => {
+    runEmbeddedPiAgent.mockResolvedValue({
+      payloads: [{ text: "Roadmap Plan" }],
+    });
+
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "minimax/MiniMax-M2.5",
+          },
+        },
+      },
+    };
+
+    const slug = await generateSlugViaLLM({
+      sessionContent: "User asked for a roadmap plan",
+      cfg,
+    });
+
+    expect(slug).toBe("roadmap-plan");
+    expect(runEmbeddedPiAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "minimax",
+        model: "MiniMax-M2.5",
+      }),
+    );
+  });
+
+  it("falls back to built-in defaults when no model is configured", async () => {
+    runEmbeddedPiAgent.mockResolvedValue({
+      payloads: [{ text: "bug-fix" }],
+    });
+
+    const slug = await generateSlugViaLLM({
+      sessionContent: "Fix the bug",
+      cfg: {},
+    });
+
+    expect(slug).toBe("bug-fix");
+    expect(runEmbeddedPiAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      }),
+    );
+  });
+});

--- a/src/hooks/llm-slug-generator.ts
+++ b/src/hooks/llm-slug-generator.ts
@@ -11,6 +11,7 @@ import {
   resolveAgentWorkspaceDir,
   resolveAgentDir,
 } from "../agents/agent-scope.js";
+import { resolveDefaultModelForAgent } from "../agents/model-selection.js";
 import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
 
 /**
@@ -24,6 +25,7 @@ export async function generateSlugViaLLM(params: {
 
   try {
     const agentId = resolveDefaultAgentId(params.cfg);
+    const modelRef = resolveDefaultModelForAgent({ cfg: params.cfg, agentId });
     const workspaceDir = resolveAgentWorkspaceDir(params.cfg, agentId);
     const agentDir = resolveAgentDir(params.cfg, agentId);
 
@@ -46,6 +48,8 @@ Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", 
       workspaceDir,
       agentDir,
       config: params.cfg,
+      provider: modelRef.provider,
+      model: modelRef.model,
       prompt,
       timeoutMs: 15_000, // 15 second timeout
       runId: `slug-gen-${Date.now()}`,


### PR DESCRIPTION
## Summary
Fixes `session-memory` / `llm-slug-generator` using hardcoded Anthropic defaults by explicitly inheriting the configured agent default model.

Closes #15510.

## Problem
`generateSlugViaLLM()` called `runEmbeddedPiAgent()` without provider/model, which falls back to global defaults (`anthropic/claude-opus-4-6`).
In setups without Anthropic auth, this causes slug generation to fail despite a valid configured primary model/provider.

## Root Cause
The slug generator resolved agent/workspace context but did not resolve and pass the configured default model reference.

## Changes
- `src/hooks/llm-slug-generator.ts`
  - Resolve default model via `resolveDefaultModelForAgent({ cfg, agentId })`.
  - Pass `provider` + `model` explicitly into `runEmbeddedPiAgent()`.
- `src/hooks/llm-slug-generator.test.ts` (new)
  - Verifies configured model (`minimax/MiniMax-M2.5`) is used for slug generation calls.
  - Verifies fallback to built-in defaults when no model is configured.

## Tests
- `pnpm vitest run src/hooks/llm-slug-generator.test.ts src/hooks/bundled/session-memory/handler.test.ts`
  - Passed (12/12).
- `pnpm vitest run src/hooks/bundled/session-memory/handler.test.ts src/infra/heartbeat-runner.returns-default-unset.test.ts`
  - Passed (43/43).

## Sign-Off
lobster-biscuit

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the LLM slug generator hook to explicitly inherit the configured default model (via `resolveDefaultModelForAgent`) and pass `provider`/`model` into `runEmbeddedPiAgent`, preventing fallback to the hardcoded Anthropic defaults when a non‑Anthropic primary model is configured.

It also adds a focused unit test that mocks the embedded agent runner and agent scope resolution to assert:
- a configured default model (e.g. `minimax/MiniMax-M2.5`) is propagated into the embedded run
- the built-in defaults (`anthropic/claude-opus-4-6`) are used when no model is configured

Overall, the change fits cleanly into existing model-selection infrastructure (`src/agents/model-selection.ts`) and leverages the same default constants used by the embedded runner (`src/agents/defaults.ts`).

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, with one test-shape issue to address.
- The runtime change is small and uses the existing model-resolution helper to avoid unintended Anthropic fallbacks; the main remaining concern is that the new test may be using a config shape that doesn’t match what `OpenClawConfig` actually supports in practice, which can lead to brittle or misleading coverage.
- src/hooks/llm-slug-generator.test.ts

<sub>Last reviewed commit: 4faff63</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->