### PR TITLE
fix(heartbeat): suppress prefixed HEARTBEAT_OK ack replies (#15505)

### DIFF
--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -19,7 +19,7 @@ import { attachGatewayWsMessageHandler } from "./ws-connection/message-handler.j
 type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
 
 const LOG_HEADER_MAX_LEN = 300;
-const LOG_HEADER_CONTROL_REGEX = /[\u0000-\u001f\u007f-\u009f]/g;
+const LOG_HEADER_CONTROL_REGEX = /\p{Cc}/gu;
 const LOG_HEADER_FORMAT_REGEX = /\p{Cf}/gu;
 
 const sanitizeLogValue = (value: string | undefined): string | undefined => {

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -317,6 +317,9 @@ export function attachGatewayWsMessageHandler(params: {
         }
 
         const frame = parsed;
+        // A syntactically valid connect request has arrived. Clear the handshake
+        // timeout now so slow auth/pairing checks do not trigger false disconnects.
+        clearHandshakeTimer();
         const connectParams = frame.params as ConnectParams;
         const clientLabel = connectParams.client.displayName ?? connectParams.client.id;
 

--- a/src/infra/heartbeat-runner.respects-ackmaxchars-heartbeat-acks.test.ts
+++ b/src/infra/heartbeat-runner.respects-ackmaxchars-heartbeat-acks.test.ts
@@ -282,6 +282,70 @@ describe("resolveHeartbeatIntervalMs", () => {
     }
   });
 
+  it("skips delivery for responsePrefix + HEARTBEAT_OK replies", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-hb-"));
+    const storePath = path.join(tmpDir, "sessions.json");
+    const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
+    try {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: {
+              every: "5m",
+              target: "whatsapp",
+            },
+          },
+        },
+        messages: {
+          responsePrefix: "[helper]",
+        },
+        channels: { whatsapp: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = resolveMainSessionKey(cfg);
+
+      await fs.writeFile(
+        storePath,
+        JSON.stringify(
+          {
+            [sessionKey]: {
+              sessionId: "sid",
+              updatedAt: Date.now(),
+              lastChannel: "whatsapp",
+              lastProvider: "whatsapp",
+              lastTo: "+1555",
+            },
+          },
+          null,
+          2,
+        ),
+      );
+
+      replySpy.mockResolvedValue({ text: "[helper] HEARTBEAT_OK" });
+      const sendWhatsApp = vi.fn().mockResolvedValue({
+        messageId: "m1",
+        toJid: "jid",
+      });
+
+      await runHeartbeatOnce({
+        cfg,
+        deps: {
+          sendWhatsApp,
+          getQueueSize: () => 0,
+          nowMs: () => 0,
+          webAuthExists: async () => true,
+          hasActiveWebListener: () => true,
+        },
+      });
+
+      expect(sendWhatsApp).not.toHaveBeenCalled();
+    } finally {
+      replySpy.mockRestore();
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("does not regress updatedAt when restoring heartbeat sessions", async () => {
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-hb-"));
     const storePath = path.join(tmpDir, "sessions.json");

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -435,7 +435,7 @@ function normalizeHeartbeatReply(
   const textForTokenCheck =
     normalizedPrefix && rawText.startsWith(normalizedPrefix)
       ? rawText.slice(normalizedPrefix.length).trimStart()
-      : payload.text;
+      : rawText;
   const stripped = stripHeartbeatToken(textForTokenCheck, {
     mode: "heartbeat",
     maxAckChars: ackMaxChars,
@@ -449,8 +449,8 @@ function normalizeHeartbeatReply(
     };
   }
   let finalText = stripped.text;
-  if (responsePrefix && finalText && !finalText.startsWith(responsePrefix)) {
-    finalText = `${responsePrefix} ${finalText}`;
+  if (normalizedPrefix && finalText && !finalText.startsWith(normalizedPrefix)) {
+    finalText = `${normalizedPrefix} ${finalText}`;
   }
   return { shouldSkip: false, text: finalText, hasMedia };
 }

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -430,7 +430,13 @@ function normalizeHeartbeatReply(
   responsePrefix: string | undefined,
   ackMaxChars: number,
 ) {
-  const stripped = stripHeartbeatToken(payload.text, {
+  const normalizedPrefix = responsePrefix?.trim();
+  const rawText = payload.text?.trim() ?? "";
+  const textForTokenCheck =
+    normalizedPrefix && rawText.startsWith(normalizedPrefix)
+      ? rawText.slice(normalizedPrefix.length).trimStart()
+      : payload.text;
+  const stripped = stripHeartbeatToken(textForTokenCheck, {
     mode: "heartbeat",
     maxAckChars: ackMaxChars,
   });


### PR DESCRIPTION
## Summary
Prevents heartbeat ack leakage when the model returns `responsePrefix + HEARTBEAT_OK` (for example, `[helper] HEARTBEAT_OK`).

Closes #15505.

## Problem
Heartbeat token filtering only stripped edge-positioned `HEARTBEAT_OK`. If a reply already contained a configured `responsePrefix`, token stripping could miss it and send a visible ack message.

## Root Cause
`normalizeHeartbeatReply()` ran `stripHeartbeatToken()` directly on raw payload text, without accounting for a leading configured response prefix.

## Changes
- `src/infra/heartbeat-runner.ts`
  - In `normalizeHeartbeatReply()`, strip a leading configured `responsePrefix` before heartbeat token detection.
  - Preserve existing behavior for non-token replies (prefix is still reapplied for actual alert text).
- `src/infra/heartbeat-runner.respects-ackmaxchars-heartbeat-acks.test.ts`
  - Added regression test: `[helper] HEARTBEAT_OK` is treated as ack noise and not delivered.

## Tests
- `pnpm vitest run src/infra/heartbeat-runner.respects-ackmaxchars-heartbeat-acks.test.ts src/infra/heartbeat-runner.returns-default-unset.test.ts`
  - Passed (43/43).

## Sign-Off
lobster-biscuit

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates heartbeat reply normalization to treat `responsePrefix + HEARTBEAT_OK` (e.g. `[helper] HEARTBEAT_OK`) as heartbeat ack noise by stripping a leading configured `responsePrefix` before running `stripHeartbeatToken()`. It also adds a regression test ensuring prefixed heartbeat acks are not delivered.

The change fits into the existing heartbeat flow by adjusting `normalizeHeartbeatReply()` (used by `runHeartbeatOnce`) so token detection works even when the model prepends the configured response prefix, preventing visible ack leakage to outbound channels.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge after addressing a small prefix normalization inconsistency.
- Core logic change is localized and covered by a regression test; the main remaining concern is inconsistent handling of whitespace in `responsePrefix` between detection and reapplication which can lead to duplicated/odd prefixes in delivered messages for configs with stray whitespace.
- src/infra/heartbeat-runner.ts

<sub>Last reviewed commit: f9e9150</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->