### PR TITLE
feat(hooks): add message:preprocessed hook event

### DIFF
--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -10,8 +10,11 @@ import { resolveModelRefFromString } from "../../agents/model-selection.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { DEFAULT_AGENT_WORKSPACE_DIR, ensureAgentWorkspace } from "../../agents/workspace.js";
 import { type OpenClawConfig, loadConfig } from "../../config/config.js";
+import { logVerbose } from "../../globals.js";
+import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
 import { applyLinkUnderstanding } from "../../link-understanding/apply.js";
 import { applyMediaUnderstanding } from "../../media-understanding/apply.js";
+import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { defaultRuntime } from "../../runtime.js";
 import { resolveCommandAuthorization } from "../command-auth.js";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
@@ -132,6 +135,81 @@ export async function getReplyFromConfig(
       ctx: finalized,
       cfg,
     });
+
+    // Fire message:preprocessed hooks (after media + link understanding, before agent)
+    {
+      const preprocessedHookRunner = getGlobalHookRunner();
+      const processedContent = finalized.Body ?? finalized.RawBody ?? "";
+      const rawContent = ctx.Body ?? ctx.RawBody ?? "";
+      const channelId = (
+        finalized.OriginatingChannel ??
+        finalized.Surface ??
+        finalized.Provider ??
+        ""
+      ).toLowerCase();
+
+      if (preprocessedHookRunner?.hasHooks("message_preprocessed")) {
+        void preprocessedHookRunner
+          .runMessagePreprocessed(
+            {
+              from: finalized.From ?? "",
+              content: processedContent,
+              rawContent,
+              timestamp: finalized.Timestamp ? new Date(finalized.Timestamp).getTime() : Date.now(),
+              metadata: {
+                to: finalized.To,
+                provider: finalized.Provider,
+                surface: finalized.Surface,
+                threadId: finalized.MessageThreadId,
+                originatingChannel: finalized.OriginatingChannel,
+                senderId: finalized.SenderId,
+                senderName: finalized.SenderName,
+                messageId: finalized.MessageSidFull ?? finalized.MessageSid,
+              },
+            },
+            {
+              channelId,
+              accountId: finalized.AccountId,
+              conversationId:
+                finalized.OriginatingTo ?? finalized.To ?? finalized.From ?? undefined,
+            },
+          )
+          .catch((err) => {
+            logVerbose(`get-reply: message_preprocessed hook failed: ${String(err)}`);
+          });
+      }
+
+      const hookEvent = createInternalHookEvent(
+        "message",
+        "preprocessed",
+        finalized.SessionKey ?? "",
+        {
+          text: processedContent,
+          rawText: rawContent,
+          channel: channelId,
+          chatType: finalized.ChatType,
+          from: finalized.From,
+          to: finalized.To,
+          senderId: finalized.SenderId,
+          senderName: finalized.SenderName,
+          senderUsername: finalized.SenderUsername,
+          messageId:
+            finalized.MessageSidFull ??
+            finalized.MessageSid ??
+            finalized.MessageSidFirst ??
+            finalized.MessageSidLast,
+          threadId: finalized.MessageThreadId,
+          timestamp: finalized.Timestamp,
+          accountId: finalized.AccountId,
+          mediaUrls: finalized.MediaUrls,
+          mediaTypes: finalized.MediaTypes,
+          groupId: finalized.OriginatingTo,
+        },
+      );
+      void triggerInternalHook(hookEvent).catch((err) => {
+        logVerbose(`get-reply: message:preprocessed hook failed: ${String(err)}`);
+      });
+    }
   }
 
   const commandAuthorized = finalized.CommandAuthorized;

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -139,8 +139,9 @@ export async function getReplyFromConfig(
     // Fire message:preprocessed hooks (after media + link understanding, before agent)
     {
       const preprocessedHookRunner = getGlobalHookRunner();
-      const processedContent = finalized.Body ?? finalized.RawBody ?? "";
-      const rawContent = ctx.Body ?? ctx.RawBody ?? "";
+      const processedContent =
+        finalized.BodyForCommands ?? finalized.Body ?? finalized.RawBody ?? "";
+      const rawContent = ctx.RawBody ?? ctx.Body ?? "";
       const channelId = (
         finalized.OriginatingChannel ??
         finalized.Surface ??
@@ -155,7 +156,10 @@ export async function getReplyFromConfig(
               from: finalized.From ?? "",
               content: processedContent,
               rawContent,
-              timestamp: finalized.Timestamp ? new Date(finalized.Timestamp).getTime() : Date.now(),
+              timestamp: (() => {
+                const t = new Date(finalized.Timestamp).getTime();
+                return Number.isFinite(t) ? t : Date.now();
+              })(),
               metadata: {
                 to: finalized.To,
                 provider: finalized.Provider,

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -20,6 +20,7 @@ import type {
   PluginHookGatewayStartEvent,
   PluginHookGatewayStopEvent,
   PluginHookMessageContext,
+  PluginHookMessagePreprocessedEvent,
   PluginHookMessageReceivedEvent,
   PluginHookMessageSendingEvent,
   PluginHookMessageSendingResult,
@@ -44,6 +45,7 @@ export type {
   PluginHookBeforeCompactionEvent,
   PluginHookAfterCompactionEvent,
   PluginHookMessageContext,
+  PluginHookMessagePreprocessedEvent,
   PluginHookMessageReceivedEvent,
   PluginHookMessageSendingEvent,
   PluginHookMessageSendingResult,
@@ -243,6 +245,18 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     ctx: PluginHookMessageContext,
   ): Promise<void> {
     return runVoidHook("message_received", event, ctx);
+  }
+
+  /**
+   * Run message_preprocessed hook.
+   * Fires after media/link understanding, before agent processing.
+   * Runs in parallel (fire-and-forget).
+   */
+  async function runMessagePreprocessed(
+    event: PluginHookMessagePreprocessedEvent,
+    ctx: PluginHookMessageContext,
+  ): Promise<void> {
+    return runVoidHook("message_preprocessed", event, ctx);
   }
 
   /**
@@ -449,6 +463,7 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     runAfterCompaction,
     // Message hooks
     runMessageReceived,
+    runMessagePreprocessed,
     runMessageSending,
     runMessageSent,
     // Tool hooks

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -301,6 +301,7 @@ export type PluginHookName =
   | "before_compaction"
   | "after_compaction"
   | "message_received"
+  | "message_preprocessed"
   | "message_sending"
   | "message_sent"
   | "before_tool_call"
@@ -361,6 +362,16 @@ export type PluginHookMessageContext = {
 export type PluginHookMessageReceivedEvent = {
   from: string;
   content: string;
+  timestamp?: number;
+  metadata?: Record<string, unknown>;
+};
+
+// message_preprocessed hook (after media/link understanding, before agent)
+export type PluginHookMessagePreprocessedEvent = {
+  from: string;
+  content: string;
+  rawContent?: string;
+  transcript?: string;
   timestamp?: number;
   metadata?: Record<string, unknown>;
 };
@@ -488,6 +499,10 @@ export type PluginHookHandlerMap = {
   ) => Promise<void> | void;
   message_received: (
     event: PluginHookMessageReceivedEvent,
+    ctx: PluginHookMessageContext,
+  ) => Promise<void> | void;
+  message_preprocessed: (
+    event: PluginHookMessagePreprocessedEvent,
     ctx: PluginHookMessageContext,
   ) => Promise<void> | void;
   message_sending: (


### PR DESCRIPTION
## Summary

Adds a `message_preprocessed` plugin hook event that fires **after** media understanding (transcription, image descriptions) and link understanding (summaries, previews), but **before** agent processing begins.

This completes the three-event message lifecycle:
1. `message:received` — raw inbound message
2. **`message:preprocessed`** — enriched with transcripts, media descriptions, link summaries *(this PR)*
3. `message:sent` — outbound reply

### Why?

Plugins that need enriched content (e.g., memory systems, analytics, logging) currently have to either re-process media themselves or hook into `message:received` which only has raw content. The `message:preprocessed` hook gives plugins access to the fully enriched message context with zero extra work.

### What's included

- `PluginHookMessagePreprocessedEvent` type with `content`, `rawContent`, `transcript`, and metadata
- `runMessagePreprocessed()` on the hook runner
- Internal hook event (`message:preprocessed`) for extension systems
- Hook fires in `getReplyFromConfig()` after `applyMediaUnderstanding()` and `applyLinkUnderstanding()`

### Builds on

PR #14196 which added `message:received` and `message:sent` hooks (shipped in 2026.2.12).

Addresses discussion #14539 (three-event lifecycle proposal).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces a new plugin hook event, `message_preprocessed`, intended to fire after media/link understanding but before agent processing. It updates the plugin hook type map (`src/plugins/types.ts`) and exposes a runner method (`src/plugins/hooks.ts`), then triggers the hook from `getReplyFromConfig` in `src/auto-reply/reply/get-reply.ts` (alongside an internal `message:preprocessed` hook event).

The main integration point is `getReplyFromConfig`, which now constructs a `PluginHookMessagePreprocessedEvent` and dispatches it via the global hook runner before continuing to command authorization/session/agent logic.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but plugin hook payload correctness should be fixed to avoid breaking plugin expectations.
- The change is localized and adds a new hook without altering core agent behavior, but the emitted `message_preprocessed` payload currently has inconsistencies vs existing message hooks (content/rawContent source/normalization) and can produce invalid timestamps (NaN / mishandling 0). These are user-facing API contract issues for plugin authors and should be corrected before merging.
- src/auto-reply/reply/get-reply.ts

<sub>Last reviewed commit: aab320b</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->