### PR TITLE
fix: use provider-qualified key in MODEL_CACHE for context window lookup

### DIFF
--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -69,6 +69,7 @@ export async function runMemoryFlushIfNeeded(params: {
         (params.sessionKey ? params.sessionStore?.[params.sessionKey] : undefined),
       contextWindowTokens: resolveMemoryFlushContextWindowTokens({
         modelId: params.followupRun.run.model ?? params.defaultModel,
+        providerId: params.followupRun.run.provider,
         agentCfgContextTokens: params.agentCfgContextTokens,
       }),
       reserveTokensFloor: memoryFlushSettings.reserveTokensFloor,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -380,6 +380,7 @@ export async function runReplyAgent(params: {
       : undefined;
     const contextTokensUsed =
       agentCfgContextTokens ??
+      lookupContextTokens(`${providerUsed}/${modelUsed}`) ??
       lookupContextTokens(modelUsed) ??
       activeSessionEntry?.contextTokens ??
       DEFAULT_CONTEXT_TOKENS;

--- a/src/auto-reply/reply/directive-handling.persist.ts
+++ b/src/auto-reply/reply/directive-handling.persist.ts
@@ -219,7 +219,11 @@ export async function persistInlineDirectives(params: {
   return {
     provider,
     model,
-    contextTokens: agentCfg?.contextTokens ?? lookupContextTokens(model) ?? DEFAULT_CONTEXT_TOKENS,
+    contextTokens:
+      agentCfg?.contextTokens ??
+      (provider ? lookupContextTokens(`${provider}/${model}`) : undefined) ??
+      lookupContextTokens(model) ??
+      DEFAULT_CONTEXT_TOKENS,
   };
 }
 

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -196,8 +196,10 @@ export function createFollowupRunner(params: {
       const usage = runResult.meta.agentMeta?.usage;
       const promptTokens = runResult.meta.agentMeta?.promptTokens;
       const modelUsed = runResult.meta.agentMeta?.model ?? fallbackModel ?? defaultModel;
+      const providerUsed = runResult.meta.agentMeta?.provider ?? fallbackProvider;
       const contextTokensUsed =
         agentCfgContextTokens ??
+        (providerUsed ? lookupContextTokens(`${providerUsed}/${modelUsed}`) : undefined) ??
         lookupContextTokens(modelUsed) ??
         sessionEntry?.contextTokens ??
         DEFAULT_CONTEXT_TOKENS;

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -401,6 +401,7 @@ export async function resolveReplyDirectives(params: {
   let contextTokens = resolveContextTokens({
     agentCfg,
     model,
+    provider,
   });
 
   const initialModelLabel = `${provider}/${model}`;

--- a/src/auto-reply/reply/memory-flush.ts
+++ b/src/auto-reply/reply/memory-flush.ts
@@ -68,10 +68,16 @@ function ensureNoReplyHint(text: string): string {
 
 export function resolveMemoryFlushContextWindowTokens(params: {
   modelId?: string;
+  providerId?: string;
   agentCfgContextTokens?: number;
 }): number {
   return (
-    lookupContextTokens(params.modelId) ?? params.agentCfgContextTokens ?? DEFAULT_CONTEXT_TOKENS
+    (params.providerId && params.modelId
+      ? lookupContextTokens(`${params.providerId}/${params.modelId}`)
+      : undefined) ??
+    lookupContextTokens(params.modelId) ??
+    params.agentCfgContextTokens ??
+    DEFAULT_CONTEXT_TOKENS
   );
 }
 

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -586,11 +586,12 @@ export function resolveContextTokens(params: {
   model: string;
   provider?: string;
 }): number {
+  const qualified = params.provider
+    ? lookupContextTokens(`${params.provider}/${params.model}`)
+    : undefined;
   return (
     params.agentCfg?.contextTokens ??
-    (params.provider
-      ? lookupContextTokens(`${params.provider}/${params.model}`)
-      : undefined) ??
+    qualified ??
     lookupContextTokens(params.model) ??
     DEFAULT_CONTEXT_TOKENS
   );

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -584,8 +584,14 @@ export function resolveModelDirectiveSelection(params: {
 export function resolveContextTokens(params: {
   agentCfg: NonNullable<NonNullable<OpenClawConfig["agents"]>["defaults"]> | undefined;
   model: string;
+  provider?: string;
 }): number {
   return (
-    params.agentCfg?.contextTokens ?? lookupContextTokens(params.model) ?? DEFAULT_CONTEXT_TOKENS
+    params.agentCfg?.contextTokens ??
+    (params.provider
+      ? lookupContextTokens(`${params.provider}/${params.model}`)
+      : undefined) ??
+    lookupContextTokens(params.model) ??
+    DEFAULT_CONTEXT_TOKENS
   );
 }

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -339,8 +339,9 @@ export function buildStatusMessage(args: StatusArgs): string {
   const provider = entry?.providerOverride ?? resolved.provider ?? DEFAULT_PROVIDER;
   let model = entry?.modelOverride ?? resolved.model ?? DEFAULT_MODEL;
   let contextTokens =
-    entry?.contextTokens ??
     args.agent?.contextTokens ??
+    lookupContextTokens(`${provider}/${model}`) ??
+    entry?.contextTokens ??
     lookupContextTokens(model) ??
     DEFAULT_CONTEXT_TOKENS;
 

--- a/src/commands/agent/session-store.ts
+++ b/src/commands/agent/session-store.ts
@@ -42,7 +42,10 @@ export async function updateSessionStoreAfterAgentRun(params: {
   const modelUsed = result.meta.agentMeta?.model ?? fallbackModel ?? defaultModel;
   const providerUsed = result.meta.agentMeta?.provider ?? fallbackProvider ?? defaultProvider;
   const contextTokens =
-    params.contextTokensOverride ?? lookupContextTokens(modelUsed) ?? DEFAULT_CONTEXT_TOKENS;
+    params.contextTokensOverride ??
+    lookupContextTokens(`${providerUsed}/${modelUsed}`) ??
+    lookupContextTokens(modelUsed) ??
+    DEFAULT_CONTEXT_TOKENS;
 
   const entry = sessionStore[sessionKey] ?? {
     sessionId,

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -32,6 +32,7 @@ type SessionRow = {
   totalTokens?: number;
   totalTokensFresh?: boolean;
   model?: string;
+  modelProvider?: string;
   contextTokens?: number;
 };
 
@@ -168,6 +169,7 @@ function toRows(store: Record<string, SessionEntry>): SessionRow[] {
         totalTokens: entry?.totalTokens,
         totalTokensFresh: entry?.totalTokensFresh,
         model: entry?.model,
+        modelProvider: entry?.modelProvider,
         contextTokens: entry?.contextTokens,
       } satisfies SessionRow;
     })

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -184,8 +184,10 @@ export async function sessionsCommand(
     defaultProvider: DEFAULT_PROVIDER,
     defaultModel: DEFAULT_MODEL,
   });
+  const configProvider = resolved.provider ?? DEFAULT_PROVIDER;
   const configContextTokens =
     cfg.agents?.defaults?.contextTokens ??
+    lookupContextTokens(`${configProvider}/${resolved.model}`) ??
     lookupContextTokens(resolved.model) ??
     DEFAULT_CONTEXT_TOKENS;
   const configModel = resolved.model ?? DEFAULT_MODEL;
@@ -226,7 +228,13 @@ export async function sessionsCommand(
             totalTokensFresh:
               typeof r.totalTokens === "number" ? r.totalTokensFresh !== false : false,
             contextTokens:
-              r.contextTokens ?? lookupContextTokens(r.model) ?? configContextTokens ?? null,
+              r.contextTokens ??
+              (r.modelProvider && r.model
+                ? lookupContextTokens(`${r.modelProvider}/${r.model}`)
+                : undefined) ??
+              lookupContextTokens(r.model) ??
+              configContextTokens ??
+              null,
             model: r.model ?? configModel ?? null,
           })),
         },
@@ -261,7 +269,12 @@ export async function sessionsCommand(
 
   for (const row of rows) {
     const model = row.model ?? configModel;
-    const contextTokens = row.contextTokens ?? lookupContextTokens(model) ?? configContextTokens;
+    const rowProvider = row.modelProvider ?? configProvider;
+    const contextTokens =
+      row.contextTokens ??
+      (rowProvider && model ? lookupContextTokens(`${rowProvider}/${model}`) : undefined) ??
+      lookupContextTokens(model) ??
+      configContextTokens;
     const total = resolveFreshSessionTotalTokens(row);
 
     const keyLabel = truncateKey(row.key).padEnd(KEY_PAD);

--- a/src/commands/status.summary.ts
+++ b/src/commands/status.summary.ts
@@ -93,8 +93,10 @@ export async function getStatusSummary(): Promise<StatusSummary> {
     defaultModel: DEFAULT_MODEL,
   });
   const configModel = resolved.model ?? DEFAULT_MODEL;
+  const configProvider = resolved.provider ?? DEFAULT_PROVIDER;
   const configContextTokens =
     cfg.agents?.defaults?.contextTokens ??
+    lookupContextTokens(`${configProvider}/${configModel}`) ??
     lookupContextTokens(configModel) ??
     DEFAULT_CONTEXT_TOKENS;
 
@@ -119,8 +121,13 @@ export async function getStatusSummary(): Promise<StatusSummary> {
         const updatedAt = entry?.updatedAt ?? null;
         const age = updatedAt ? now - updatedAt : null;
         const model = entry?.model ?? configModel ?? null;
+        const entryProvider = entry?.modelProvider ?? configProvider ?? null;
         const contextTokens =
-          entry?.contextTokens ?? lookupContextTokens(model) ?? configContextTokens ?? null;
+          entry?.contextTokens ??
+          (entryProvider && model ? lookupContextTokens(`${entryProvider}/${model}`) : undefined) ??
+          lookupContextTokens(model) ??
+          configContextTokens ??
+          null;
         const total = resolveFreshSessionTotalTokens(entry);
         const totalTokensFresh =
           typeof entry?.totalTokens === "number" ? entry?.totalTokensFresh !== false : false;

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -460,7 +460,10 @@ export async function runCronIsolatedAgentTurn(params: {
     const modelUsed = runResult.meta.agentMeta?.model ?? fallbackModel ?? model;
     const providerUsed = runResult.meta.agentMeta?.provider ?? fallbackProvider ?? provider;
     const contextTokens =
-      agentCfg?.contextTokens ?? lookupContextTokens(modelUsed) ?? DEFAULT_CONTEXT_TOKENS;
+      agentCfg?.contextTokens ??
+      lookupContextTokens(`${providerUsed}/${modelUsed}`) ??
+      lookupContextTokens(modelUsed) ??
+      DEFAULT_CONTEXT_TOKENS;
 
     cronSession.sessionEntry.modelProvider = providerUsed;
     cronSession.sessionEntry.model = modelUsed;

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -515,6 +515,7 @@ export function getSessionDefaults(cfg: OpenClawConfig): GatewaySessionsDefaults
   });
   const contextTokens =
     cfg.agents?.defaults?.contextTokens ??
+    lookupContextTokens(`${resolved.provider ?? DEFAULT_PROVIDER}/${resolved.model}`) ??
     lookupContextTokens(resolved.model) ??
     DEFAULT_CONTEXT_TOKENS;
   return {


### PR DESCRIPTION
## Problem

When multiple providers define the same model id (e.g. `claude-4.6-opus`) with different context windows, `MODEL_CACHE` uses only the bare model id as key. The last-loaded provider overwrites earlier entries, causing:

1. Incorrect context window in `/status` display
2. Wrong compaction timing (smaller context model inherits larger value)
3. Session store caches the wrong value, persisting the error across restarts

## Root Cause

`MODEL_CACHE.set(m.id, m.contextWindow)` in `src/agents/context.ts` — key is `m.id` without provider prefix. Additionally, `entry.contextTokens` (cached in session store) takes priority over fresh lookups in status display.

## Fix

1. **`context.ts`**: Store entries with provider-qualified keys (`provider/model`) in addition to bare model id fallback
2. **All `lookupContextTokens` call sites** (13 files): Prefer qualified key (`provider/model`) when provider info is available
3. **`status.ts`**: Prioritize fresh provider-qualified lookup over cached `entry.contextTokens` to reflect model switches correctly

## How to Reproduce

Configure two providers with the same model id but different context windows in `models.json`, switch between them with `/model`, observe `/status` — both show the same (wrong) context window.

### Example `models.json`

```json
{
  "providers": {
    "provider-1": {
      "baseUrl": "http://provider-1/v1/",
      "apiKey": "",
      "api": "openai-completions",
      "models": [
        {
          "id": "claude-4.6-opus",
          "name": "claude-4.6-opus",
          "reasoning": false,
          "input": ["text", "image"],
          "cost": {
            "input": 5,
            "output": 25,
            "cacheRead": 0.5,
            "cacheWrite": 6.25
          },
          "contextWindow": 200000,
          "maxTokens": 128000,
          "compat": {
            "supportsStore": false
          }
        }
      ]
    },
    "provider-2": {
      "baseUrl": "http://provider-2/",
      "apiKey": "",
      "api": "anthropic-messages",
      "authHeader": true,
      "models": [
        {
          "id": "claude-4.6-opus",
          "name": "claude-4.6-opus (1M)",
          "reasoning": true,
          "input": ["text", "image"],
          "cost": {
            "input": 5,
            "output": 25,
            "cacheRead": 0.5,
            "cacheWrite": 6.25
          },
          "contextWindow": 1000000,
          "maxTokens": 128000,
          "headers": {
            "anthropic-beta": "context-1m-2025-08-07"
          }
        }
      ]
    }
  }
}
```

### Steps

1. Use the config above (same model id `claude-4.6-opus`, 200k via OpenAI-compatible vs 1M via native Anthropic Messages API with `anthropic-beta: context-1m-2025-08-07` header)
2. `/model provider-1/claude-4.6-opus` → `/status` shows `Context: xx/1.0m` ❌ (should be 200k)
3. `/model provider-2/claude-4.6-opus` → `/status` shows `Context: xx/1.0m` ✅

**Expected:** provider-1 shows `200k`, provider-2 shows `1.0m`
**Actual (before fix):** Both show `1.0m`

## Testing

Verified with the above configuration. After fix, `/status` correctly displays:
- `provider-1/claude-4.6-opus` → `Context: xx/200k` ✅
- `provider-2/claude-4.6-opus` → `Context: xx/1.0m` ✅

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates context-window lookups to avoid collisions when different providers expose the same model id. It stores provider-qualified keys in `MODEL_CACHE` (e.g., `provider/model`) and updates many call sites (auto-reply runners, session store updates, `/sessions`, `/status` summary) to prefer qualified lookups when provider info is available. `/status` display is adjusted to prefer fresh qualified lookups over cached `entry.contextTokens` so switching providers/models reflects immediately.

One behavior change to double-check: the bare-model-id fallback cache entry is now only written once, so “first loaded” wins instead of “last loaded”, which can affect any remaining unqualified lookups.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, with one confirmed behavioral change to validate.
- Most changes are straightforward and consistently prefer provider-qualified context-window keys to prevent collisions. The main concern is a confirmed semantics flip for the bare-id fallback cache entry, which could change behavior for remaining unqualified lookups depending on model discovery order.
- src/agents/context.ts

<sub>Last reviewed commit: 07e5467</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->