### PR TITLE
fix(ui): move New Session out of composer and harden reset UX

### DIFF
--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -343,6 +343,10 @@
   font-size: 13px;
 }
 
+.chat-controls__new-session {
+  font-family: var(--font-mono);
+}
+
 /* Icon button style */
 .btn--icon {
   padding: 8px !important;

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -191,6 +191,25 @@ export function renderChatControls(state: AppViewState) {
       >
         ${focusIcon}
       </button>
+      <span class="chat-controls__separator">|</span>
+      <button
+        class="btn btn--sm chat-controls__new-session"
+        tabindex="-1"
+        ?disabled=${!state.connected}
+        @click=${async () => {
+          if (
+            !window.confirm(
+              "Start a new session? This clears active context for this chat, but keeps history on disk.",
+            )
+          ) {
+            return;
+          }
+          await state.handleSendChat("/new", { restoreDraft: true });
+        }}
+        title="Start a new session (same as typing /new)"
+      >
+        New Session
+      </button>
     </div>
   `;
 }

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1114,7 +1114,6 @@ export function renderApp(state: AppViewState) {
                 canAbort: Boolean(state.chatRunId),
                 onAbort: () => void state.handleAbortChat(),
                 onQueueRemove: (id) => state.removeQueuedMessage(id),
-                onNewSession: () => state.handleSendChat("/new", { restoreDraft: true }),
                 showNewMessages: state.chatNewMessagesBelow && !state.chatManualRefreshInFlight,
                 onScrollToBottom: () => state.scrollToBottom(),
                 // Sidebar props for tool output viewing

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -147,8 +147,8 @@ describe("chat view", () => {
       (btn) => btn.textContent?.trim() === "New session",
     );
     const stopButton = Array.from(container.querySelectorAll("button")).find(
-      (btn) => btn.textContent?.trim() === "Stop",
-    ) as HTMLButtonElement | undefined;
+      (btn): btn is HTMLButtonElement => btn.textContent?.trim() === "Stop",
+    );
 
     expect(newSessionButton).toBeUndefined();
     expect(stopButton).not.toBeUndefined();

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -43,7 +43,6 @@ function createProps(overrides: Partial<ChatProps> = {}): ChatProps {
     onDraftChange: () => undefined,
     onSend: () => undefined,
     onQueueRemove: () => undefined,
-    onNewSession: () => undefined,
     ...overrides,
   };
 }
@@ -133,14 +132,12 @@ describe("chat view", () => {
     expect(container.textContent).not.toContain("New session");
   });
 
-  it("shows a new session button when aborting is unavailable", () => {
+  it("keeps only stop/send controls when aborting is unavailable", () => {
     const container = document.createElement("div");
-    const onNewSession = vi.fn();
     render(
       renderChat(
         createProps({
           canAbort: false,
-          onNewSession,
         }),
       ),
       container,
@@ -149,9 +146,12 @@ describe("chat view", () => {
     const newSessionButton = Array.from(container.querySelectorAll("button")).find(
       (btn) => btn.textContent?.trim() === "New session",
     );
-    expect(newSessionButton).not.toBeUndefined();
-    newSessionButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    expect(onNewSession).toHaveBeenCalledTimes(1);
-    expect(container.textContent).not.toContain("Stop");
+    const stopButton = Array.from(container.querySelectorAll("button")).find(
+      (btn) => btn.textContent?.trim() === "Stop",
+    ) as HTMLButtonElement | undefined;
+
+    expect(newSessionButton).toBeUndefined();
+    expect(stopButton).not.toBeUndefined();
+    expect(stopButton?.disabled).toBe(true);
   });
 });

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -64,7 +64,6 @@ export type ChatProps = {
   onSend: () => void;
   onAbort?: () => void;
   onQueueRemove: (id: string) => void;
-  onNewSession: () => void;
   onOpenSidebar?: (content: string) => void;
   onCloseSidebar?: () => void;
   onSplitRatioChange?: (ratio: number) => void;
@@ -408,10 +407,10 @@ export function renderChat(props: ChatProps) {
           <div class="chat-compose__actions">
             <button
               class="btn"
-              ?disabled=${!props.connected || (!canAbort && props.sending)}
-              @click=${canAbort ? props.onAbort : props.onNewSession}
+              ?disabled=${!props.connected || !canAbort}
+              @click=${() => props.onAbort?.()}
             >
-              ${canAbort ? "Stop" : "New session"}
+              Stop
             </button>
             <button
               class="btn primary"


### PR DESCRIPTION
## Summary
- remove the in-composer New session fallback from the Stop button area
- keep composer actions to Stop + Send/Queue only
- add a dedicated **New Session** control in the chat header controls
- make the New Session control `tabindex="-1"` to prevent accidental Tab+Enter activation from the textarea flow
- add a confirmation prompt before sending `/new`

## Why
The previous placement made accidental session resets too easy (keyboard and mouse), especially during rapid chat workflows. This keeps reset as an explicit secondary action while preserving discoverability for new users.

## Validation
- `pnpm build` (ui)
- updated unit tests in `ui/src/ui/views/chat.test.ts` to reflect composer behavior

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR removes the in-composer “New session” fallback from the Stop button area and adds a dedicated **New Session** control to the chat header controls. The new header button is intentionally removed from the normal tab order (`tabindex="-1"`) and now prompts for confirmation before sending `/new`.

Implementation-wise, `renderChat` no longer accepts an `onNewSession` callback; the composer action row is now strictly **Stop** (only when abort is available) plus **Send/Queue**. The reset workflow is centralized in `renderChatControls` (`ui/src/ui/app-render.helpers.ts`) by calling `state.handleSendChat("/new", { restoreDraft: true })` behind a confirm dialog.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are limited to UI control placement/behavior and corresponding unit test updates. I reviewed the modified source files end-to-end and verified the removal of the in-composer `onNewSession` path is consistent with how `canAbort` is derived (`Boolean(state.chatRunId)`), and the new header button uses existing `handleSendChat("/new")` plumbing. No runtime errors or broken prop wiring were found in the reviewed paths.
- No files require special attention

<sub>Last reviewed commit: 380de0d</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->