### PR TITLE
fix: add retry/backoff for Gemini embedding API calls

### DIFF
--- a/src/hooks/config.ts
+++ b/src/hooks/config.ts
@@ -70,12 +70,7 @@ export function hasBinary(bin: string): boolean {
   const parts = pathEnv.split(path.delimiter).filter(Boolean);
   const extensions =
     process.platform === "win32"
-      ? [
-          "",
-          ...(process.env.PATHEXT ?? ".EXE;.CMD;.BAT;.COM")
-            .split(";")
-            .filter(Boolean),
-        ]
+      ? ["", ...(process.env.PATHEXT ?? ".EXE;.CMD;.BAT;.COM").split(";").filter(Boolean)]
       : [""];
   for (const part of parts) {
     for (const ext of extensions) {

--- a/src/memory/batch-gemini.ts
+++ b/src/memory/batch-gemini.ts
@@ -1,5 +1,6 @@
 import type { GeminiEmbeddingClient } from "./embeddings-gemini.js";
 import { isTruthyEnvValue } from "../infra/env.js";
+import { retryAsync } from "../infra/retry.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { hashText } from "./internal.js";
 
@@ -134,18 +135,37 @@ async function submitGeminiBatch(params: {
     baseUrl,
     requests: params.requests.length,
   });
-  const fileRes = await fetch(uploadUrl, {
-    method: "POST",
-    headers: {
-      ...getGeminiHeaders(params.gemini, { json: false }),
-      "Content-Type": uploadPayload.contentType,
+  const fileRes = await retryAsync(
+    async () => {
+      const res = await fetch(uploadUrl, {
+        method: "POST",
+        headers: {
+          ...getGeminiHeaders(params.gemini, { json: false }),
+          "Content-Type": uploadPayload.contentType,
+        },
+        body: uploadPayload.body,
+      });
+      if (!res.ok) {
+        const text = await res.text();
+        const err = new Error(`gemini batch file upload failed: ${res.status} ${text}`) as Error & {
+          status?: number;
+        };
+        err.status = res.status;
+        throw err;
+      }
+      return res;
     },
-    body: uploadPayload.body,
-  });
-  if (!fileRes.ok) {
-    const text = await fileRes.text();
-    throw new Error(`gemini batch file upload failed: ${fileRes.status} ${text}`);
-  }
+    {
+      attempts: 3,
+      minDelayMs: 300,
+      maxDelayMs: 2000,
+      jitter: 0.2,
+      shouldRetry: (err) => {
+        const status = (err as { status?: number }).status;
+        return status === 429 || (typeof status === "number" && status >= 500);
+      },
+    },
+  );
   const filePayload = (await fileRes.json()) as { name?: string; file?: { name?: string } };
   const fileId = filePayload.name ?? filePayload.file?.name;
   if (!fileId) {
@@ -166,21 +186,42 @@ async function submitGeminiBatch(params: {
     batchEndpoint,
     fileId,
   });
-  const batchRes = await fetch(batchEndpoint, {
-    method: "POST",
-    headers: getGeminiHeaders(params.gemini, { json: true }),
-    body: JSON.stringify(batchBody),
-  });
-  if (batchRes.ok) {
-    return (await batchRes.json()) as GeminiBatchStatus;
-  }
-  const text = await batchRes.text();
-  if (batchRes.status === 404) {
-    throw new Error(
-      "gemini batch create failed: 404 (asyncBatchEmbedContent not available for this model/baseUrl). Disable remote.batch.enabled or switch providers.",
-    );
-  }
-  throw new Error(`gemini batch create failed: ${batchRes.status} ${text}`);
+  const batchRes = await retryAsync(
+    async () => {
+      const res = await fetch(batchEndpoint, {
+        method: "POST",
+        headers: getGeminiHeaders(params.gemini, { json: true }),
+        body: JSON.stringify(batchBody),
+      });
+      if (!res.ok) {
+        const text = await res.text();
+        if (res.status === 404) {
+          const err = new Error(
+            "gemini batch create failed: 404 (asyncBatchEmbedContent not available for this model/baseUrl). Disable remote.batch.enabled or switch providers.",
+          ) as Error & { status?: number };
+          err.status = res.status;
+          throw err;
+        }
+        const err = new Error(`gemini batch create failed: ${res.status} ${text}`) as Error & {
+          status?: number;
+        };
+        err.status = res.status;
+        throw err;
+      }
+      return res;
+    },
+    {
+      attempts: 3,
+      minDelayMs: 300,
+      maxDelayMs: 2000,
+      jitter: 0.2,
+      shouldRetry: (err) => {
+        const status = (err as { status?: number }).status;
+        return status === 429 || (typeof status === "number" && status >= 500);
+      },
+    },
+  );
+  return (await batchRes.json()) as GeminiBatchStatus;
 }
 
 async function fetchGeminiBatchStatus(params: {
@@ -193,13 +234,32 @@ async function fetchGeminiBatchStatus(params: {
     : `batches/${params.batchName}`;
   const statusUrl = `${baseUrl}/${name}`;
   debugLog("memory embeddings: gemini batch status", { statusUrl });
-  const res = await fetch(statusUrl, {
-    headers: getGeminiHeaders(params.gemini, { json: true }),
-  });
-  if (!res.ok) {
-    const text = await res.text();
-    throw new Error(`gemini batch status failed: ${res.status} ${text}`);
-  }
+  const res = await retryAsync(
+    async () => {
+      const res = await fetch(statusUrl, {
+        headers: getGeminiHeaders(params.gemini, { json: true }),
+      });
+      if (!res.ok) {
+        const text = await res.text();
+        const err = new Error(`gemini batch status failed: ${res.status} ${text}`) as Error & {
+          status?: number;
+        };
+        err.status = res.status;
+        throw err;
+      }
+      return res;
+    },
+    {
+      attempts: 3,
+      minDelayMs: 300,
+      maxDelayMs: 2000,
+      jitter: 0.2,
+      shouldRetry: (err) => {
+        const status = (err as { status?: number }).status;
+        return status === 429 || (typeof status === "number" && status >= 500);
+      },
+    },
+  );
   return (await res.json()) as GeminiBatchStatus;
 }
 
@@ -211,13 +271,34 @@ async function fetchGeminiFileContent(params: {
   const file = params.fileId.startsWith("files/") ? params.fileId : `files/${params.fileId}`;
   const downloadUrl = `${baseUrl}/${file}:download`;
   debugLog("memory embeddings: gemini batch download", { downloadUrl });
-  const res = await fetch(downloadUrl, {
-    headers: getGeminiHeaders(params.gemini, { json: true }),
-  });
-  if (!res.ok) {
-    const text = await res.text();
-    throw new Error(`gemini batch file content failed: ${res.status} ${text}`);
-  }
+  const res = await retryAsync(
+    async () => {
+      const res = await fetch(downloadUrl, {
+        headers: getGeminiHeaders(params.gemini, { json: true }),
+      });
+      if (!res.ok) {
+        const text = await res.text();
+        const err = new Error(
+          `gemini batch file content failed: ${res.status} ${text}`,
+        ) as Error & {
+          status?: number;
+        };
+        err.status = res.status;
+        throw err;
+      }
+      return res;
+    },
+    {
+      attempts: 3,
+      minDelayMs: 300,
+      maxDelayMs: 2000,
+      jitter: 0.2,
+      shouldRetry: (err) => {
+        const status = (err as { status?: number }).status;
+        return status === 429 || (typeof status === "number" && status >= 500);
+      },
+    },
+  );
   return await res.text();
 }
 

--- a/src/memory/batch-gemini.ts
+++ b/src/memory/batch-gemini.ts
@@ -162,7 +162,8 @@ async function submitGeminiBatch(params: {
       jitter: 0.2,
       shouldRetry: (err) => {
         const status = (err as { status?: number }).status;
-        return status === 429 || (typeof status === "number" && status >= 500);
+        // Retry on network errors (no status), 429, or 5xx
+        return !status || status === 429 || (typeof status === "number" && status >= 500);
       },
     },
   );
@@ -217,7 +218,8 @@ async function submitGeminiBatch(params: {
       jitter: 0.2,
       shouldRetry: (err) => {
         const status = (err as { status?: number }).status;
-        return status === 429 || (typeof status === "number" && status >= 500);
+        // Retry on network errors (no status), 429, or 5xx
+        return !status || status === 429 || (typeof status === "number" && status >= 500);
       },
     },
   );
@@ -256,7 +258,8 @@ async function fetchGeminiBatchStatus(params: {
       jitter: 0.2,
       shouldRetry: (err) => {
         const status = (err as { status?: number }).status;
-        return status === 429 || (typeof status === "number" && status >= 500);
+        // Retry on network errors (no status), 429, or 5xx
+        return !status || status === 429 || (typeof status === "number" && status >= 500);
       },
     },
   );
@@ -295,7 +298,8 @@ async function fetchGeminiFileContent(params: {
       jitter: 0.2,
       shouldRetry: (err) => {
         const status = (err as { status?: number }).status;
-        return status === 429 || (typeof status === "number" && status >= 500);
+        // Retry on network errors (no status), 429, or 5xx
+        return !status || status === 429 || (typeof status === "number" && status >= 500);
       },
     },
   );


### PR DESCRIPTION
Fixes #15546

## Problem

Gemini embedding path (, , ) lacks the retry/backoff handling that OpenAI and Voyage paths already have. When Gemini hits rate limits (429) or server errors (5xx), calls fail immediately with no retry, causing gateway instability.

## Solution

Wrapped all Gemini embedding fetch calls in  with:
- **3 attempts**
- **Exponential backoff** (300ms to 2s)
- **Jitter** (0.2)
- **Retry on 429 and 5xx errors**

## Implementation

Added  wrapper to:
1.  (2 fetch calls: file upload + batch create)
2. 
3. 

Pattern matches existing OpenAI/Voyage implementation for consistency.

## Testing

- ✅ `pnpm build` passing
- ✅ `pnpm check` passing
- ✅ Code follows existing retry pattern from `batch-openai.ts` and `batch-voyage.ts`

## Impact

- Prevents gateway crashes when Gemini hits daily quota (429)
- Handles transient server errors (5xx) gracefully
- Consistent retry behavior across all embedding providers

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds `retryAsync`-based retry/backoff handling to Gemini batch embedding requests to match the existing OpenAI/Voyage patterns. The Gemini batch flow (file upload → batch create → status polling → result download) now wraps the HTTP calls with 3 attempts, exponential backoff (300ms–2s), jitter, and retries for 429/5xx.

The other change is a small formatting-only update in `src/hooks/config.ts` (Windows `PATHEXT` parsing array literal).

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge but has a retry gap for thrown fetch/network errors that can undermine the intended resiliency improvements.
- The retry/backoff logic for HTTP 429/5xx is consistent with existing providers, but the current `shouldRetry` predicates won’t retry when `fetch` throws (no `status`), which is a common transient failure mode and contradicts the PR’s stated goal of preventing instability under transient conditions.
- src/memory/batch-gemini.ts

<sub>Last reviewed commit: a08ffc4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->