### PR TITLE
fix(sessions): infer agent sessions dir for legacy absolute sessionFile

### DIFF
--- a/src/config/sessions/paths.test.ts
+++ b/src/config/sessions/paths.test.ts
@@ -29,6 +29,10 @@ describe("resolveStorePath", () => {
 });
 
 describe("session path safety", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it("validates safe session IDs", () => {
     expect(validateSessionId("sess-1")).toBe("sess-1");
     expect(validateSessionId("ABC_123.hello")).toBe("ABC_123.hello");
@@ -106,6 +110,18 @@ describe("session path safety", () => {
         { sessionsDir },
       ),
     ).toThrow(/within sessions directory/);
+  });
+
+  it("infers sessionsDir for absolute legacy agent paths when opts are omitted", () => {
+    vi.stubEnv("OPENCLAW_HOME", "/tmp/openclaw");
+
+    const resolved = resolveSessionFilePath("sess-1", {
+      sessionFile: "/tmp/openclaw/.openclaw/agents/polymarket/sessions/abc-123.jsonl",
+    });
+
+    expect(resolved).toBe(
+      path.resolve("/tmp/openclaw/.openclaw/agents/polymarket/sessions/abc-123.jsonl"),
+    );
   });
 
   it("uses agent sessions dir fallback for transcript path", () => {


### PR DESCRIPTION
## Summary

Fix a regression where legacy absolute `sessionFile` entries for non-default agents can fail path validation when callers omit `resolveSessionFilePath` options.

This mainly impacts slash-command execution paths that still reach `resolveSessionFilePath(sessionId, entry)` without passing `{ agentId }` or `{ sessionsDir }`, while `sessions.json` contains absolute transcript paths such as:

`/Users/openclaw/.openclaw/agents/polymarket/sessions/<id>.jsonl`

## Problem

Recent session-path hardening requires `sessionFile` to stay inside an expected sessions directory. That is correct for security, but legacy data + legacy call signatures can still collide:

1. The store may persist an **absolute** per-agent transcript path.
2. A caller may invoke `resolveSessionFilePath` **without** options.
3. The function then defaults to the main-agent sessions directory.
4. Validation compares the non-main absolute path against the wrong base and throws:
   - `Session file path must be within sessions directory`

## Root Cause

The validation itself is correct; the mismatch comes from missing context (`agentId` / `sessionsDir`) in some legacy call paths and older dist bundles.

So the bug is not "validation too strict"; it is "validation runs against the wrong base dir when options are omitted".

## Fix Details

### 1) Add legacy sessions-dir inference for absolute candidate paths

In `src/config/sessions/paths.ts`, add:

- `resolveLegacySessionsDirFromAbsolutePath(candidate)`

Behavior:

- Runs only for absolute candidates.
- Resolves state root via `resolveStateDir()`.
- Detects paths matching:
  - `<state>/agents/<agentId>/sessions/...`
- Returns inferred sessions dir:
  - `<state>/agents/<agentId>/sessions`

### 2) Add a guarded fallback in `resolveSessionFilePath`

Current flow remains unchanged first:

- Resolve base sessions dir from options/default.
- Validate candidate with `resolvePathWithinSessionsDir`.

New fallback only if all conditions hold:

- candidate exists,
- first validation threw,
- `opts` were omitted.

Then:

- infer legacy sessions dir from absolute path,
- re-run the same containment validation against inferred dir.

If inference fails or containment still fails, original error is re-thrown.

## Security / Safety

This change does **not** relax traversal checks:

- `../../...` still rejected.
- absolute paths outside inferred sessions dir still rejected.
- unrelated absolute targets (`/etc/passwd`) still rejected.

The fallback is tightly scoped to legacy absolute paths that already live under the OpenClaw state tree in `agents/<id>/sessions`.

## Why this approach

- Fixes production behavior for non-main agents immediately, even if a legacy call site omits options.
- Keeps the security boundary and existing hardening model intact.
- Avoids broad acceptance of arbitrary absolute paths.
- Maintains backward compatibility with older stored session metadata.

## Tests

Updated `src/config/sessions/paths.test.ts`:

- added cleanup in `session path safety` suite (`vi.unstubAllEnvs()`)
- added case:
  - infers sessions dir for omitted-opts legacy absolute agent paths

## Validation notes

`pnpm test src/config/sessions/paths.test.ts --runInBand` could not run in this environment because dependencies are not installed (`node_modules` missing / `vitest` not found).

I did manually verify behavior with direct function calls:

- legacy agent absolute path resolves successfully when options are omitted
- non-sessions absolute paths remain rejected
- `/etc/passwd` remains rejected

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a backward-compatibility fallback in `resolveSessionFilePath` to handle legacy *absolute* `sessionFile` entries for non-default agents when callers omit `{ agentId }` / `{ sessionsDir }`. It does this by inferring an agent-specific sessions directory from absolute paths under `<state>/agents/<agentId>/sessions/...` and re-running the existing containment validation.

Tests are updated to cover the inferred sessions-dir behavior and to clean up env stubs between tests.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but the new test likely depends on host filesystem state and should be made deterministic.
- Core logic keeps the existing containment check and scopes the fallback to omitted-opts + inferred state-root agent sessions paths. The main concern is the added test’s reliance on `resolveStateDir()` heuristics (`fs.existsSync`), which can vary across environments and cause CI flakiness.
- src/config/sessions/paths.test.ts

<sub>Last reviewed commit: e2dd9aa</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->