### PR TITLE
Gateway: sanitize WebSocket log headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 - Security/Canvas: serve A2UI assets via the shared safe-open path (`openFileWithinRoot`) to close traversal/TOCTOU gaps, with traversal and symlink regression coverage. (#10525) Thanks @abdelsfane.
 - Security/Gateway: breaking default-behavior change - canvas IP-based auth fallback now only accepts machine-scoped addresses (RFC1918, link-local, ULA IPv6, CGNAT); public-source IP matches now require bearer token auth. (#14661) Thanks @sumleo.
+- Security/Gateway: sanitize and truncate untrusted WebSocket header values in pre-handshake close logs to reduce log-poisoning risk. Thanks @thewilloftheshadow.
 - Security/WhatsApp: enforce `0o600` on `creds.json` and `creds.json.bak` on save/backup/restore paths to reduce credential file exposure. (#10529) Thanks @abdelsfane.
 - Security/Gateway + ACP: block high-risk tools (`sessions_spawn`, `sessions_send`, `gateway`, `whatsapp_login`) from HTTP `/tools/invoke` by default with `gateway.tools.{allow,deny}` overrides, and harden ACP permission selection to fail closed when tool identity/options are ambiguous while supporting `allow_always`/`reject_always`. (#15390) Thanks @aether-ai-agent.
 - Gateway/Tools Invoke: sanitize `/tools/invoke` execution failures while preserving `400` for tool input errors and returning `500` for unexpected runtime failures, with regression coverage and docs updates. (#13185) Thanks @davidrudduck.

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -7,6 +7,7 @@ import type { GatewayRequestContext, GatewayRequestHandlers } from "../server-me
 import type { GatewayWsClient } from "./ws-types.js";
 import { resolveCanvasHostUrl } from "../../infra/canvas-host-url.js";
 import { listSystemPresence, upsertPresence } from "../../infra/system-presence.js";
+import { truncateUtf16Safe } from "../../utils.js";
 import { isWebchatClient } from "../../utils/message-channel.js";
 import { isLoopbackAddress } from "../net.js";
 import { getHandshakeTimeoutMs } from "../server-constants.js";
@@ -16,6 +17,23 @@ import { getHealthVersion, getPresenceVersion, incrementPresenceVersion } from "
 import { attachGatewayWsMessageHandler } from "./ws-connection/message-handler.js";
 
 type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
+
+const LOG_HEADER_MAX_LEN = 300;
+const LOG_HEADER_CONTROL_REGEX = /[\u0000-\u001f\u007f-\u009f]/g;
+
+const sanitizeLogValue = (value: string | undefined): string | undefined => {
+  if (!value) {
+    return undefined;
+  }
+  const cleaned = value.replace(LOG_HEADER_CONTROL_REGEX, " ").replace(/\s+/g, " ").trim();
+  if (!cleaned) {
+    return undefined;
+  }
+  if (cleaned.length <= LOG_HEADER_MAX_LEN) {
+    return cleaned;
+  }
+  return truncateUtf16Safe(cleaned, LOG_HEADER_MAX_LEN);
+};
 
 export function attachGatewayWsConnectionHandler(params: {
   wss: WebSocketServer;
@@ -156,6 +174,11 @@ export function attachGatewayWsConnectionHandler(params: {
 
     socket.once("close", (code, reason) => {
       const durationMs = Date.now() - openedAt;
+      const logForwardedFor = sanitizeLogValue(forwardedFor);
+      const logOrigin = sanitizeLogValue(requestOrigin);
+      const logHost = sanitizeLogValue(requestHost);
+      const logUserAgent = sanitizeLogValue(requestUserAgent);
+      const logReason = sanitizeLogValue(reason?.toString());
       const closeContext = {
         cause: closeCause,
         handshake: handshakeState,
@@ -163,10 +186,10 @@ export function attachGatewayWsConnectionHandler(params: {
         lastFrameType,
         lastFrameMethod,
         lastFrameId,
-        host: requestHost,
-        origin: requestOrigin,
-        userAgent: requestUserAgent,
-        forwardedFor,
+        host: logHost,
+        origin: logOrigin,
+        userAgent: logUserAgent,
+        forwardedFor: logForwardedFor,
         ...closeMeta,
       };
       if (!client) {
@@ -174,13 +197,13 @@ export function attachGatewayWsConnectionHandler(params: {
           ? logWsControl.debug
           : logWsControl.warn;
         logFn(
-          `closed before connect conn=${connId} remote=${remoteAddr ?? "?"} fwd=${forwardedFor ?? "n/a"} origin=${requestOrigin ?? "n/a"} host=${requestHost ?? "n/a"} ua=${requestUserAgent ?? "n/a"} code=${code ?? "n/a"} reason=${reason?.toString() || "n/a"}`,
+          `closed before connect conn=${connId} remote=${remoteAddr ?? "?"} fwd=${logForwardedFor || "n/a"} origin=${logOrigin || "n/a"} host=${logHost || "n/a"} ua=${logUserAgent || "n/a"} code=${code ?? "n/a"} reason=${logReason || "n/a"}`,
           closeContext,
         );
       }
       if (client && isWebchatClient(client.connect.client)) {
         logWsControl.info(
-          `webchat disconnected code=${code} reason=${reason?.toString() || "n/a"} conn=${connId}`,
+          `webchat disconnected code=${code} reason=${logReason || "n/a"} conn=${connId}`,
         );
       }
       if (client?.presenceKey) {
@@ -208,7 +231,7 @@ export function attachGatewayWsConnectionHandler(params: {
       logWs("out", "close", {
         connId,
         code,
-        reason: reason?.toString(),
+        reason: logReason,
         durationMs,
         cause: closeCause,
         handshake: handshakeState,

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -20,12 +20,17 @@ type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
 
 const LOG_HEADER_MAX_LEN = 300;
 const LOG_HEADER_CONTROL_REGEX = /[\u0000-\u001f\u007f-\u009f]/g;
+const LOG_HEADER_FORMAT_REGEX = /\p{Cf}/gu;
 
 const sanitizeLogValue = (value: string | undefined): string | undefined => {
   if (!value) {
     return undefined;
   }
-  const cleaned = value.replace(LOG_HEADER_CONTROL_REGEX, " ").replace(/\s+/g, " ").trim();
+  const cleaned = value
+    .replace(LOG_HEADER_CONTROL_REGEX, " ")
+    .replace(LOG_HEADER_FORMAT_REGEX, " ")
+    .replace(/\s+/g, " ")
+    .trim();
   if (!cleaned) {
     return undefined;
   }


### PR DESCRIPTION
## Summary
- sanitize and truncate untrusted header values before logging pre-handshake WebSocket closes
- reuse sanitized values for log context, including close reasons
- add changelog entry for the gateway log hardening

## Testing
- Not run (not requested)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens Gateway WebSocket logging by sanitizing and truncating untrusted header values (host/origin/user-agent/x-forwarded-for) and reusing the sanitized values in the “closed before connect” and disconnect log lines, plus a changelog entry documenting the security hardening.

The main remaining gap is that the new sanitization removes C0/C1 control characters but still allows Unicode format/bidi characters to flow into logs; since the logging subsystem doesn’t strip these, an attacker can still generate visually misleading log output via crafted header values or close reasons.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, with one log-sanitization gap to address.
- Changes are localized to log formatting and metadata; however, the sanitization currently doesn’t remove Unicode bidi/format characters, and the logging layer doesn’t compensate, so log-spoofing is still possible via crafted header/reason values.
- src/gateway/server/ws-connection.ts

<sub>Last reviewed commit: 951e962</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->