### PR TITLE
Config: preserve env var references on write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Docs: https://docs.openclaw.ai
 - Sessions/Agents: pass `agentId` through status and usage transcript-resolution paths (auto-reply, gateway usage APIs, and session cost/log loaders) so non-default agents can resolve absolute session files without path-validation failures. (#15103) Thanks @jalehman.
 - Signal/Install: auto-install `signal-cli` via Homebrew on non-x64 Linux architectures, avoiding x86_64 native binary `Exec format error` failures on arm64/arm hosts. (#15443) Thanks @jogvan-k.
 - Discord: avoid misrouting numeric guild allowlist entries to `/channels/<guildId>` by prefixing guild-only inputs with `guild:` during resolution. (#12326) Thanks @headswim.
+- Config: preserve `${VAR}` env references when writing config files so `openclaw config set/apply/patch` does not persist secrets to disk. Thanks @thewilloftheshadow.
 - Web tools/web_fetch: prefer `text/markdown` responses for Cloudflare Markdown for Agents, add `cf-markdown` extraction for markdown bodies, and redact fetched URLs in `x-markdown-tokens` debug logs to avoid leaking raw paths/query params. (#15376) Thanks @Yaxuan42.
 - Config: keep legacy audio transcription migration strict by rejecting non-string/unsafe command tokens while still migrating valid custom script executables. (#5042) Thanks @shayan919293.
 

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -44,4 +44,61 @@ describe("config io write", () => {
       expect(persisted).not.toHaveProperty("sessions.persistence");
     });
   });
+
+  it("preserves env var references when writing", async () => {
+    await withTempHome(async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.writeFile(
+        configPath,
+        JSON.stringify(
+          {
+            agents: {
+              defaults: {
+                cliBackends: {
+                  codex: {
+                    env: {
+                      OPENAI_API_KEY: "${OPENAI_API_KEY}",
+                    },
+                  },
+                },
+              },
+            },
+            gateway: { port: 18789 },
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+
+      const io = createConfigIO({
+        env: { OPENAI_API_KEY: "sk-secret" } as NodeJS.ProcessEnv,
+        homedir: () => home,
+      });
+
+      const snapshot = await io.readConfigFileSnapshot();
+      expect(snapshot.valid).toBe(true);
+
+      const next = structuredClone(snapshot.config);
+      next.gateway = {
+        ...next.gateway,
+        auth: { mode: "token" },
+      };
+
+      await io.writeConfigFile(next);
+
+      const persisted = JSON.parse(await fs.readFile(configPath, "utf-8")) as {
+        agents: { defaults: { cliBackends: { codex: { env: { OPENAI_API_KEY: string } } } } };
+        gateway: { port: number; auth: { mode: string } };
+      };
+      expect(persisted.agents.defaults.cliBackends.codex.env.OPENAI_API_KEY).toBe(
+        "${OPENAI_API_KEY}",
+      );
+      expect(persisted.gateway).toEqual({
+        port: 18789,
+        auth: { mode: "token" },
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- preserve `${VAR}` env references when writing config files so `config set/apply/patch` does not persist secrets
- restore original env references for unchanged paths after merge-patch writes
- add regression test coverage

## Testing
- not run (not requested)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes config writing behavior to avoid persisting secrets by preserving `${VAR}` env references when writing config files. It does this by:

- Adding `containsEnvVarReference()` to detect env substitution patterns.
- During `writeConfigFile()`, computing a merge-patch against the existing snapshot and then restoring original env-reference strings for paths not modified by the patch.
- Adding a regression test to ensure `${OPENAI_API_KEY}` remains in the persisted config when unrelated config fields are updated.

The overall approach fits into the existing `readConfigFileSnapshot()` flow (which resolves `$include` and substitutes `${VAR}` for runtime use) by using the parsed+included config to map original env-reference locations, then applying that mapping back onto the validated config object that will be written.

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe to merge but has a correctness issue around env-ref restoration for arrays.
- Core behavior (preserving `${VAR}` strings for unchanged fields) is covered by a regression test and the logic is localized to config write. However, the path-based changed-set logic does not align for arrays, which can cause stale env references to be restored after array modifications.
- src/config/io.ts

<sub>Last reviewed commit: b49493e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->