### PR TITLE
fix(gateway): correct malformed HTTP 429 response on WebSocket upgrade

### DIFF
--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -186,23 +186,21 @@ function writeUpgradeAuthFailure(
   if (auth.rateLimited) {
     const retryAfterSeconds =
       auth.retryAfterMs && auth.retryAfterMs > 0 ? Math.ceil(auth.retryAfterMs / 1000) : undefined;
-    socket.write(
-      [
-        "HTTP/1.1 429 Too Many Requests",
-        retryAfterSeconds ? `Retry-After: ${retryAfterSeconds}` : undefined,
-        "Content-Type: application/json; charset=utf-8",
-        "Connection: close",
-        "",
-        JSON.stringify({
-          error: {
-            message: "Too many failed authentication attempts. Please try again later.",
-            type: "rate_limited",
-          },
-        }),
-      ]
-        .filter(Boolean)
-        .join("\r\n"),
-    );
+    const headers = [
+      "HTTP/1.1 429 Too Many Requests",
+      retryAfterSeconds ? `Retry-After: ${retryAfterSeconds}` : undefined,
+      "Content-Type: application/json; charset=utf-8",
+      "Connection: close",
+    ]
+      .filter(Boolean)
+      .join("\r\n");
+    const body = JSON.stringify({
+      error: {
+        message: "Too many failed authentication attempts. Please try again later.",
+        type: "rate_limited",
+      },
+    });
+    socket.write(`${headers}\r\n\r\n${body}`);
     return;
   }
   socket.write("HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n");


### PR DESCRIPTION
## Summary
- `writeUpgradeAuthFailure` built the 429 response as an array joined by `\r\n`, with an empty string `""` as the header/body separator
- `.filter(Boolean)` removed the empty string since `Boolean("") === false`, producing a malformed HTTP response with no blank line between headers and body
- The 401 path on line 185 correctly used hardcoded `\r\n\r\n`

## Fix
- Build headers array separately (with `filter(Boolean)` for optional Retry-After), then join headers and body with the required `\r\n\r\n` separator

## Test plan
- [x] Existing gateway tests pass
- [x] Manual inspection confirms well-formed HTTP response structure

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes the HTTP response written directly to the raw socket when rejecting a WebSocket upgrade due to rate limiting.

Previously, the 429 response was assembled as an array joined by `\r\n`, relying on an empty string element as the required header/body separator. Because the array was then passed through `.filter(Boolean)`, the empty string separator was removed, producing a malformed HTTP response without the required blank line between headers and body.

The change builds the header block separately (still filtering out the optional `Retry-After` line), then concatenates headers and JSON body using the correct `\r\n\r\n` delimiter, matching the existing 401 upgrade-failure path.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped to constructing a raw HTTP 429 response for WebSocket upgrade rejection and corrects a definite protocol formatting bug (missing CRLF-CRLF) without altering authentication or rate-limit logic. No additional code paths or dependencies were introduced.
- No files require special attention

<sub>Last reviewed commit: 6875525</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->