### PR TITLE
CI: drop trusted label for experienced contributors

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -139,6 +139,21 @@ jobs:
             const experiencedLabel = "experienced-contributor";
             const trustedThreshold = 4;
             const experiencedThreshold = 10;
+            const issueNumber = context.payload.pull_request.number;
+
+            const removeLabelIfPresent = async (name) => {
+              try {
+                await github.rest.issues.removeLabel({
+                  ...context.repo,
+                  issue_number: issueNumber,
+                  name,
+                });
+              } catch (error) {
+                if (error?.status !== 404) {
+                  throw error;
+                }
+              }
+            };
 
             let isMaintainer = false;
             try {
@@ -157,7 +172,7 @@ jobs:
             if (isMaintainer) {
               await github.rest.issues.addLabels({
                 ...context.repo,
-                issue_number: context.payload.pull_request.number,
+                issue_number: issueNumber,
                 labels: ["maintainer"],
               });
               return;
@@ -179,9 +194,10 @@ jobs:
             }
 
             if (mergedCount >= experiencedThreshold) {
+              await removeLabelIfPresent(trustedLabel);
               await github.rest.issues.addLabels({
                 ...context.repo,
-                issue_number: context.payload.pull_request.number,
+                issue_number: issueNumber,
                 labels: [experiencedLabel],
               });
               return;
@@ -190,7 +206,7 @@ jobs:
             if (mergedCount >= trustedThreshold) {
               await github.rest.issues.addLabels({
                 ...context.repo,
-                issue_number: context.payload.pull_request.number,
+                issue_number: issueNumber,
                 labels: [trustedLabel],
               });
             }
@@ -373,6 +389,22 @@ jobs:
                 return;
               }
 
+              if (label === experiencedLabel && labelNames.has(trustedLabel)) {
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner,
+                    repo,
+                    issue_number: pullRequest.number,
+                    name: trustedLabel,
+                  });
+                } catch (error) {
+                  if (error?.status !== 404) {
+                    throw error;
+                  }
+                }
+                labelNames.delete(trustedLabel);
+              }
+
               if (labelNames.has(label)) {
                 return;
               }
@@ -462,6 +494,21 @@ jobs:
             const experiencedLabel = "experienced-contributor";
             const trustedThreshold = 4;
             const experiencedThreshold = 10;
+            const issueNumber = context.payload.issue.number;
+
+            const removeLabelIfPresent = async (name) => {
+              try {
+                await github.rest.issues.removeLabel({
+                  ...context.repo,
+                  issue_number: issueNumber,
+                  name,
+                });
+              } catch (error) {
+                if (error?.status !== 404) {
+                  throw error;
+                }
+              }
+            };
 
             let isMaintainer = false;
             try {
@@ -480,7 +527,7 @@ jobs:
             if (isMaintainer) {
               await github.rest.issues.addLabels({
                 ...context.repo,
-                issue_number: context.payload.issue.number,
+                issue_number: issueNumber,
                 labels: ["maintainer"],
               });
               return;
@@ -502,9 +549,10 @@ jobs:
             }
 
             if (mergedCount >= experiencedThreshold) {
+              await removeLabelIfPresent(trustedLabel);
               await github.rest.issues.addLabels({
                 ...context.repo,
-                issue_number: context.payload.issue.number,
+                issue_number: issueNumber,
                 labels: [experiencedLabel],
               });
               return;
@@ -513,7 +561,7 @@ jobs:
             if (mergedCount >= trustedThreshold) {
               await github.rest.issues.addLabels({
                 ...context.repo,
-                issue_number: context.payload.issue.number,
+                issue_number: issueNumber,
                 labels: [trustedLabel],
               });
             }


### PR DESCRIPTION
## Summary
- remove the trusted-contributor label when the labeler applies experienced-contributor
- keep contributor labels mutually exclusive in the backfill job
- align issue labeling with the experienced-over-trusted rule

## Testing
- Not run (workflow change only)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `.github/workflows/labeler.yml` so that when a contributor qualifies as `experienced-contributor`, any existing `trusted-contributor` label is removed (keeping those contributor labels mutually exclusive). The same rule is applied in three places: the PR labeler job (on `pull_request_target`), the backfill job (`workflow_dispatch`), and the issue labeling job (on new issues).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are small, localized to workflow scripting, and primarily add a 404-tolerant label-removal step before applying `experienced-contributor`. No new permissions or API surface area is introduced beyond calls already present in the workflow, and the logic is consistent across PR, backfill, and issue labeling paths.
- No files require special attention.

<sub>Last reviewed commit: aaf0410</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->