### PR TITLE
LLM Task: add explicit thinking level wiring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/node pending work: add narrow in-memory pending-work queue primitives (`node.pending.enqueue` / `node.pending.drain`) and wake-helper reuse as a foundation for dormant-node work delivery. (#41409) Thanks @mbelinky.
 - Git/runtime state: ignore the gateway-generated `.dev-state` file so local runtime state does not show up as untracked repo noise. (#41848) Thanks @smysle.
 - Exec/child commands: mark child command environments with `OPENCLAW_CLI` so subprocesses can detect when they were launched from the OpenClaw CLI. (#41411) Thanks @vincentkoc.
+- LLM Task/Lobster: add an optional `thinking` override so workflow calls can explicitly set embedded reasoning level with shared validation for invalid values and unsupported `xhigh` modes. (#15606) Thanks @xadenryan and @ImLukeF.
 
 ### Breaking
 

--- a/docs/tools/llm-task.md
+++ b/docs/tools/llm-task.md
@@ -75,6 +75,7 @@ outside the list is rejected.
 - `schema` (object, optional JSON Schema)
 - `provider` (string, optional)
 - `model` (string, optional)
+- `thinking` (string, optional)
 - `authProfileId` (string, optional)
 - `temperature` (number, optional)
 - `maxTokens` (number, optional)
@@ -90,6 +91,7 @@ Returns `details.json` containing the parsed JSON (and validates against
 ```lobster
 openclaw.invoke --tool llm-task --action json --args-json '{
   "prompt": "Given the input email, return intent and draft.",
+  "thinking": "low",
   "input": {
     "subject": "Hello",
     "body": "Can you help?"

--- a/docs/tools/lobster.md
+++ b/docs/tools/lobster.md
@@ -106,6 +106,7 @@ Use it in a pipeline:
 ```lobster
 openclaw.invoke --tool llm-task --action json --args-json '{
   "prompt": "Given the input email, return intent and draft.",
+  "thinking": "low",
   "input": { "subject": "Hello", "body": "Can you help?" },
   "schema": {
     "type": "object",

--- a/extensions/llm-task/README.md
+++ b/extensions/llm-task/README.md
@@ -69,6 +69,7 @@ outside the list is rejected.
 - `schema` (object, optional JSON Schema)
 - `provider` (string, optional)
 - `model` (string, optional)
+- `thinking` (string, optional)
 - `authProfileId` (string, optional)
 - `temperature` (number, optional)
 - `maxTokens` (number, optional)

--- a/extensions/llm-task/src/llm-task-tool.test.ts
+++ b/extensions/llm-task/src/llm-task-tool.test.ts
@@ -109,6 +109,59 @@ describe("llm-task tool (json-only)", () => {
     expect(call.model).toBe("claude-4-sonnet");
   });
 
+  it("passes thinking override to embedded runner", async () => {
+    // oxlint-disable-next-line typescript/no-explicit-any
+    (runEmbeddedPiAgent as any).mockResolvedValueOnce({
+      meta: {},
+      payloads: [{ text: JSON.stringify({ ok: true }) }],
+    });
+    const tool = createLlmTaskTool(fakeApi());
+    await tool.execute("id", { prompt: "x", thinking: "high" });
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const call = (runEmbeddedPiAgent as any).mock.calls[0]?.[0];
+    expect(call.thinkLevel).toBe("high");
+  });
+
+  it("normalizes thinking aliases", async () => {
+    // oxlint-disable-next-line typescript/no-explicit-any
+    (runEmbeddedPiAgent as any).mockResolvedValueOnce({
+      meta: {},
+      payloads: [{ text: JSON.stringify({ ok: true }) }],
+    });
+    const tool = createLlmTaskTool(fakeApi());
+    await tool.execute("id", { prompt: "x", thinking: "on" });
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const call = (runEmbeddedPiAgent as any).mock.calls[0]?.[0];
+    expect(call.thinkLevel).toBe("low");
+  });
+
+  it("throws on invalid thinking level", async () => {
+    const tool = createLlmTaskTool(fakeApi());
+    await expect(tool.execute("id", { prompt: "x", thinking: "banana" })).rejects.toThrow(
+      /invalid thinking level/i,
+    );
+  });
+
+  it("throws on unsupported xhigh thinking level", async () => {
+    const tool = createLlmTaskTool(fakeApi());
+    await expect(tool.execute("id", { prompt: "x", thinking: "xhigh" })).rejects.toThrow(
+      /only supported/i,
+    );
+  });
+
+  it("does not pass thinkLevel when thinking is omitted", async () => {
+    // oxlint-disable-next-line typescript/no-explicit-any
+    (runEmbeddedPiAgent as any).mockResolvedValueOnce({
+      meta: {},
+      payloads: [{ text: JSON.stringify({ ok: true }) }],
+    });
+    const tool = createLlmTaskTool(fakeApi());
+    await tool.execute("id", { prompt: "x" });
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const call = (runEmbeddedPiAgent as any).mock.calls[0]?.[0];
+    expect(call.thinkLevel).toBeUndefined();
+  });
+
   it("enforces allowedModels", async () => {
     // oxlint-disable-next-line typescript/no-explicit-any
     (runEmbeddedPiAgent as any).mockResolvedValueOnce({

--- a/extensions/llm-task/src/llm-task-tool.ts
+++ b/extensions/llm-task/src/llm-task-tool.ts
@@ -2,7 +2,13 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { Type } from "@sinclair/typebox";
 import Ajv from "ajv";
-import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/llm-task";
+import {
+  formatThinkingLevels,
+  formatXHighModelHint,
+  normalizeThinkLevel,
+  resolvePreferredOpenClawTmpDir,
+  supportsXHighThinking,
+} from "openclaw/plugin-sdk/llm-task";
 // NOTE: This extension is intended to be bundled with OpenClaw.
 // When running from source (tests/dev), OpenClaw internals live under src/.
 // When running from a built install, internals live under dist/ (no src/ tree).
@@ -86,6 +92,7 @@ export function createLlmTaskTool(api: OpenClawPluginApi) {
         Type.String({ description: "Provider override (e.g. openai-codex, anthropic)." }),
       ),
       model: Type.Optional(Type.String({ description: "Model id override." })),
+      thinking: Type.Optional(Type.String({ description: "Thinking level override." })),
       authProfileId: Type.Optional(Type.String({ description: "Auth profile override." })),
       temperature: Type.Optional(Type.Number({ description: "Best-effort temperature override." })),
       maxTokens: Type.Optional(Type.Number({ description: "Best-effort maxTokens override." })),
@@ -142,6 +149,18 @@ export function createLlmTaskTool(api: OpenClawPluginApi) {
         throw new Error(
           `Model not allowed by llm-task plugin config: ${modelKey}. Allowed models: ${allowed.join(", ")}`,
         );
+      }
+
+      const thinkingRaw =
+        typeof params.thinking === "string" && params.thinking.trim() ? params.thinking : undefined;
+      const thinkLevel = thinkingRaw ? normalizeThinkLevel(thinkingRaw) : undefined;
+      if (thinkingRaw && !thinkLevel) {
+        throw new Error(
+          `Invalid thinking level "${thinkingRaw}". Use one of: ${formatThinkingLevels(provider, model)}.`,
+        );
+      }
+      if (thinkLevel === "xhigh" && !supportsXHighThinking(provider, model)) {
+        throw new Error(`Thinking level "xhigh" is only supported for ${formatXHighModelHint()}.`);
       }
 
       const timeoutMs =
@@ -204,6 +223,7 @@ export function createLlmTaskTool(api: OpenClawPluginApi) {
           model,
           authProfileId,
           authProfileIdSource: authProfileId ? "user" : "auto",
+          thinkLevel,
           streamParams,
           disableTools: true,
         });

--- a/src/plugin-sdk/llm-task.ts
+++ b/src/plugin-sdk/llm-task.ts
@@ -2,4 +2,10 @@
 // Keep this list additive and scoped to symbols used under extensions/llm-task.
 
 export { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
+export {
+  formatThinkingLevels,
+  formatXHighModelHint,
+  normalizeThinkLevel,
+  supportsXHighThinking,
+} from "../auto-reply/thinking.js";
 export type { AnyAgentTool, OpenClawPluginApi } from "../plugins/types.js";


### PR DESCRIPTION
## Problem

`llm-task` could resolve and pass `provider/model`, but it had no explicit `thinking` input and did not forward a thinking level to embedded runs.

As a result, workflow users could not intentionally set thinking behavior per `llm-task` call, and runs implicitly fell back to runner defaults.

## Summary of Solution

This PR adds explicit thinking-level support to `llm-task` and aligns validation behavior with existing OpenClaw patterns.

### What changed

- Added optional `thinking` parameter to `llm-task` tool input schema.
- Normalized and validated `thinking` values using shared thinking helpers.
- Added model-aware validation errors for invalid values.
- Added explicit `xhigh` guardrails using existing support checks.
- Passed validated thinking through to embedded runner as `thinkLevel`.
- Updated docs to include the new `thinking` parameter and example usage.

### Implementation details

- `extensions/llm-task/src/llm-task-tool.ts`
  - Added `thinking` to tool parameters.
  - Added normalization/validation:
    - invalid value -> clear error with supported levels hint
    - unsupported `xhigh` -> explicit model-support error
  - Forwarded to runner:
    - `runEmbeddedPiAgent(..., thinkLevel, ...)`
- `extensions/llm-task/src/llm-task-tool.test.ts`
  - Added tests for:
    - passing explicit thinking override
    - alias normalization (`on` -> `low`)
    - invalid thinking rejection
    - unsupported `xhigh` rejection
    - omitted thinking regression (`thinkLevel` not passed)
- Docs updated:
  - `extensions/llm-task/README.md`
  - `docs/tools/llm-task.md`
  - `docs/tools/lobster.md`

## Verification / Tests Performed

### Targeted unit tests

- Command run:
  - `pnpm test extensions/llm-task/src/llm-task-tool.test.ts`
- Result:
  - `1` test file passed
  - `13` tests passed
  - `0` failures
  
  ### Smoke Test Results

1. thinking: "low" path

- Result payload: {"ok":true}
- Gateway logs confirm llm-task sub-run received thinking:
    - provider=openai-codex model=gpt-5.3-codex thinking=low

2. Invalid thinking ("banana")

- Result payload text:
    - Invalid thinking level "banana". Use one of: off, minimal, low, medium, high, xhigh.
- This matches the new validation behavior.

3. Unsupported xhigh for Anthropic model

- Result payload text:
    - Thinking level "xhigh" is only supported for ...
- This matches the new xhigh guardrail behavior.

4. Omitted thinking (backward compatibility)

- Result payload: {"ok":true}
- Gateway logs confirm llm-task sub-run defaulted:
    - provider=openai-codex model=gpt-5.3-codex thinking=off

## Notes

- No plugin config schema changes were introduced in this PR.
- Existing `llm-task` calls without `thinking` remain backward-compatible.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds an optional `thinking` parameter to the `llm-task` extension tool schema, validates/normalizes it using the shared `src/auto-reply/thinking.ts` helpers, rejects unsupported `xhigh`, and forwards the validated level to embedded agent runs via `runEmbeddedPiAgent({ thinkLevel })`. Docs and unit tests were updated to cover the new parameter and basic validation/forwarding behavior.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are localized to the llm-task extension, rely on existing shared thinking normalization/validation helpers, and are covered by targeted unit tests. The forwarded `thinkLevel` matches the embedded runner parameter (`RunEmbeddedPiAgentParams.thinkLevel`).
- No files require special attention

<sub>Last reviewed commit: dad5fd0</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->