### PR TITLE
fix(infra): use COMSPEC on Windows instead of /bin/sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Infra/Shell: use `COMSPEC` or `cmd.exe` as shell fallback on Windows instead of `/bin/sh`. (#15586)
 - Security/Gateway + ACP: block high-risk tools (`sessions_spawn`, `sessions_send`, `gateway`, `whatsapp_login`) from HTTP `/tools/invoke` by default with `gateway.tools.{allow,deny}` overrides, and harden ACP permission selection to fail closed when tool identity/options are ambiguous while supporting `allow_always`/`reject_always`. (#15390) Thanks @aether-ai-agent.
 - Security/Audit: distinguish external webhooks (`hooks.enabled`) from internal hooks (`hooks.internal.enabled`) in attack-surface summaries to avoid false exposure signals when only internal hooks are enabled. (#13474) Thanks @mcaxtr.
 - Auto-reply/Threading: auto-inject implicit reply threading so `replyToMode` works without requiring model-emitted `[[reply_to_current]]`, while preserving `replyToMode: "off"` behavior for implicit Slack replies and keeping block-streaming chunk coalescing stable under `replyToMode: "first"`. (#14976) Thanks @Diaspar4u.

--- a/src/infra/shell-env.ts
+++ b/src/infra/shell-env.ts
@@ -8,7 +8,13 @@ let cachedShellPath: string | null | undefined;
 
 function resolveShell(env: NodeJS.ProcessEnv): string {
   const shell = env.SHELL?.trim();
-  return shell && shell.length > 0 ? shell : "/bin/sh";
+  if (shell && shell.length > 0) {
+    return shell;
+  }
+  if (process.platform === "win32") {
+    return env.COMSPEC?.trim() || "cmd.exe";
+  }
+  return "/bin/sh";
 }
 
 function parseShellEnv(stdout: Buffer): Map<string, string> {


### PR DESCRIPTION
## Summary

Fix `resolveShell()` to use `COMSPEC` or `cmd.exe` as fallback on Windows instead of `/bin/sh`.

## Why

On Windows, the `$SHELL` environment variable is not set. The current code unconditionally falls back to `/bin/sh`, which does not exist on Windows, causing `spawnSync /bin/sh ENOENT` errors when `loadShellEnvFallback()` or `getShellPathFromLoginShell()` are called.

## Changes

- `src/infra/shell-env.ts`: check `process.platform === "win32"` in `resolveShell()` and use `env.COMSPEC` (typically `C:\Windows\System32\cmd.exe`) or bare `cmd.exe` as fallback.
- `src/infra/shell-env.test.ts`: add 4 regression tests covering COMSPEC usage, cmd.exe fallback, /bin/sh on non-Windows, and SHELL preference over platform fallback.
- `CHANGELOG.md`: add entry.

## Before (on main)

```
❌ BUG CONFIRMED: resolveShell() returned "/bin/sh" instead of a Windows-compatible shell
```

## After (on fix branch)

```
✓ resolveShell Windows fallback (#15586) > uses COMSPEC on win32 when SHELL is absent
✓ resolveShell Windows fallback (#15586) > falls back to cmd.exe on win32 when both SHELL and COMSPEC are absent
✓ resolveShell Windows fallback (#15586) > falls back to /bin/sh on non-Windows when SHELL is absent
✓ resolveShell Windows fallback (#15586) > prefers SHELL over platform fallback

Test Files  1 passed (1)
     Tests  8 passed (8)
```

Closes #15586

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `resolveShell()` to avoid returning `/bin/sh` on Windows when `$SHELL` is unset, instead preferring `COMSPEC` and falling back to `cmd.exe`. It also adds regression tests around that selection logic and includes a changelog entry.

The change fits into the existing “shell env fallback” mechanism (`loadShellEnvFallback()`), which spawns a login shell to capture environment variables (`env -0`) and merge expected keys into the running process env (used during config loading).

<h3>Confidence Score: 2/5</h3>

- This PR is not safe to merge as-is due to a Windows runtime failure in shell env fallback execution.
- Although resolving the shell path fixes the immediate `/bin/sh` ENOENT on Windows, `loadShellEnvFallback()` still invokes the resolved shell with POSIX flags (`-l -c`) and command (`env -0`). Returning `cmd.exe`/`COMSPEC` will make that call fail on Windows when shell env fallback is enabled, replacing one crash with another.
- src/infra/shell-env.ts

<sub>Last reviewed commit: 4bdb791</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->