### PR TITLE
fix(gateway): prune expired entries instead of clearing all hook auth failure state

### DIFF
--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -228,6 +228,11 @@ export function createHooksRequestHandler(
     const next: HookAuthFailure = expired
       ? { count: 1, windowStartedAtMs: nowMs }
       : { count: current.count + 1, windowStartedAtMs: current.windowStartedAtMs };
+    // Delete-before-set refreshes Map insertion order so recently-active
+    // clients are not evicted before dormant ones during oldest-half eviction.
+    if (hookAuthFailures.has(clientKey)) {
+      hookAuthFailures.delete(clientKey);
+    }
     hookAuthFailures.set(clientKey, next);
     if (next.count <= HOOK_AUTH_FAILURE_LIMIT) {
       return { throttled: false };

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -217,7 +217,9 @@ export function createHooksRequestHandler(
       if (hookAuthFailures.size >= HOOK_AUTH_FAILURE_TRACK_MAX) {
         let toRemove = Math.floor(hookAuthFailures.size / 2);
         for (const key of hookAuthFailures.keys()) {
-          if (toRemove <= 0) break;
+          if (toRemove <= 0) {
+            break;
+          }
           hookAuthFailures.delete(key);
           toRemove--;
         }


### PR DESCRIPTION
## Summary
- Hook auth failure tracking map used `hookAuthFailures.clear()` when at capacity (2048 entries)
- This reset ALL rate limiting state, allowing previously-throttled clients to bypass limits

## Fix
- First prune entries whose time window has expired
- If still at capacity, evict the oldest half (Map iterates in insertion order)
- Preserves rate limiting for active clients while preventing unbounded growth

## Test plan
- [x] Existing gateway tests pass

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes hook auth-failure tracking in `createHooksRequestHandler` (src/gateway/server-http.ts) so that when the failure map reaches its max size, it prunes expired entries and—if still at capacity—evicts entries instead of clearing the entire map. This is intended to prevent a full `clear()` from resetting rate-limiting state for all clients.

One issue to address: the eviction step currently relies on `Map` insertion order, but failures for an existing client update the value without moving the key, so “oldest” does not correspond to least-recently-seen. Under sustained traffic, this can evict currently-active/throttled clients and reset their rate-limit state.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but the current eviction strategy can still reset throttling for active clients under load.
- Core change is small and targeted, but the eviction mechanism uses Map insertion order which doesn’t reflect recent activity for existing keys, so it can drop active/throttled entries and partially reintroduce the bypass behavior the PR is meant to eliminate.
- src/gateway/server-http.ts

<sub>Last reviewed commit: 449ea71</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->