### PR TITLE
fix(gateway): avoid no-control-regex lint failure in ws sanitizer

### DIFF
--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -19,7 +19,7 @@ import { attachGatewayWsMessageHandler } from "./ws-connection/message-handler.j
 type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
 
 const LOG_HEADER_MAX_LEN = 300;
-const LOG_HEADER_CONTROL_REGEX = /[\u0000-\u001f\u007f-\u009f]/g;
+const LOG_HEADER_CONTROL_REGEX = /\p{Cc}/gu;
 const LOG_HEADER_FORMAT_REGEX = /\p{Cf}/gu;
 
 const sanitizeLogValue = (value: string | undefined): string | undefined => {


### PR DESCRIPTION
## Summary
Replace the control-character range regex literal with a Unicode property class in gateway websocket header sanitization.

## Why
`oxlint` currently reports:

- `eslint(no-control-regex): Unexpected control characters`
- `src/gateway/server/ws-connection.ts`

This causes `pnpm check` to fail on merge refs and cascades into unrelated PR CI failures.

## Change
- `LOG_HEADER_CONTROL_REGEX`: from `/[\u0000-\u001f\u007f-\u009f]/g`
- to `/\p{Cc}/gu`

Behavior is preserved (control characters are still stripped), while satisfying lint.

## Validation
- `pnpm check`
