### PR TITLE
fix(config): align default pipelines across loadConfig and readConfigFileSnapshot

### DIFF
--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -635,7 +635,9 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
         applyModelDefaults(
           applyCompactionDefaults(
             applyContextPruningDefaults(
-              applyAgentDefaults(applySessionDefaults(applyMessageDefaults({}))),
+              applyAgentDefaults(
+                applySessionDefaults(applyLoggingDefaults(applyMessageDefaults({}))),
+              ),
             ),
           ),
         ),
@@ -767,9 +769,13 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
           config: normalizeConfigPaths(
             applyTalkApiKey(
               applyModelDefaults(
-                applyAgentDefaults(
-                  applySessionDefaults(
-                    applyLoggingDefaults(applyMessageDefaults(validated.config)),
+                applyCompactionDefaults(
+                  applyContextPruningDefaults(
+                    applyAgentDefaults(
+                      applySessionDefaults(
+                        applyLoggingDefaults(applyMessageDefaults(validated.config)),
+                      ),
+                    ),
                   ),
                 ),
               ),


### PR DESCRIPTION
## Summary
Three code paths in `src/config/io.ts` apply different subsets of defaults:

| Default function | loadConfig | snapshot (file exists) | snapshot (no file) |
|---|---|---|---|
| applyCompactionDefaults | Yes | **No** | Yes |
| applyContextPruningDefaults | Yes | **No** | Yes |
| applyLoggingDefaults | Yes | Yes | **No** |

This causes the config editor UI to compute incorrect diffs.

## Fix
- Add missing `applyCompactionDefaults` and `applyContextPruningDefaults` to the snapshot file-exists path
- Add missing `applyLoggingDefaults` to the snapshot no-file path

## Test plan
- [x] Existing config IO tests pass

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates `src/config/io.ts` so `readConfigFileSnapshot()` applies the same runtime default pipeline regardless of whether a config file exists (adds `applyCompactionDefaults`/`applyContextPruningDefaults` on the file-exists path, and adds `applyLoggingDefaults` on the no-file path). This aligns snapshot behavior with `loadConfig()`, reducing UI diffs caused by inconsistent default application.

Main behavior change is limited to which defaults are applied in the snapshot config object; parsing/validation/include resolution remains unchanged.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge, with one behavioral concern around mutation/aliasing in the snapshot pipeline to double-check.
- Changes are narrowly scoped to applying missing default functions in `readConfigFileSnapshot`, matching existing `loadConfig` behavior. The main risk is that snapshot objects are mutated in-place via `normalizeConfigPaths`, which can create reference aliasing if other steps reuse object graphs, potentially impacting diff/patch computation.
- src/config/io.ts

<sub>Last reviewed commit: d604095</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->