### PR TITLE
fix(auth-profiles): clear billing disable state in clearAuthProfileCooldown

### DIFF
--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -301,6 +301,9 @@ export async function clearAuthProfileCooldown(params: {
         ...freshStore.usageStats[profileId],
         errorCount: 0,
         cooldownUntil: undefined,
+        disabledUntil: undefined,
+        disabledReason: undefined,
+        failureCounts: undefined,
       };
       return true;
     },
@@ -317,6 +320,9 @@ export async function clearAuthProfileCooldown(params: {
     ...store.usageStats[profileId],
     errorCount: 0,
     cooldownUntil: undefined,
+    disabledUntil: undefined,
+    disabledReason: undefined,
+    failureCounts: undefined,
   };
   saveAuthProfileStore(store, agentDir);
 }


### PR DESCRIPTION
## Summary
- `clearAuthProfileCooldown` only reset `errorCount` and `cooldownUntil`
- Missing: `disabledUntil`, `disabledReason`, `failureCounts`
- `isProfileInCooldown` checks both `cooldownUntil` and `disabledUntil`, so billing-disabled profiles stayed blocked
- Compare with `markAuthProfileUsed` which correctly resets all fields

## Fix
- Reset all five usage stat fields in both the lock-based updater and the fallback path, consistent with `markAuthProfileUsed`

## Test plan
- [x] Existing auth-profiles tests pass

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `clearAuthProfileCooldown` in `src/agents/auth-profiles/usage.ts` to fully clear all usage-related “blocked” state, not just `errorCount`/`cooldownUntil`. Specifically, it now also resets `disabledUntil`, `disabledReason`, and `failureCounts` in both the lock-based updater path and the fallback direct-write path.

This aligns the manual reset behavior with `markAuthProfileUsed`, and fixes the scenario where a profile disabled for billing would remain unusable because `isProfileInCooldown` considers both `cooldownUntil` and `disabledUntil`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is narrowly scoped to resetting additional fields in `clearAuthProfileCooldown` and mirrors existing reset behavior in `markAuthProfileUsed`. No new control flow or external interactions were introduced; both lock-based and fallback paths are updated consistently.
- src/agents/auth-profiles/usage.ts

<sub>Last reviewed commit: 8c1d640</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->