### PR TITLE
fix(plugins): reject async plugin registration instead of silently ignoring

### DIFF
--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -624,12 +624,18 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     try {
       const result = register(api);
       if (result && typeof result.then === "function") {
+        record.status = "error";
+        record.error = "plugin register() must be synchronous; async registration is not supported";
         registry.diagnostics.push({
-          level: "warn",
+          level: "error",
           pluginId: record.id,
           source: record.source,
-          message: "plugin register returned a promise; async registration is ignored",
+          message:
+            "plugin register() returned a promise; async registration is not supported — use synchronous calls only",
         });
+        registry.plugins.push(record);
+        seenIds.set(pluginId, candidate.origin);
+        continue;
       }
       registry.plugins.push(record);
       seenIds.set(pluginId, candidate.origin);


### PR DESCRIPTION
## Summary
- When a plugin's `register()` returned a Promise, only a warn diagnostic was emitted
- The plugin was still pushed to the registry as "loaded" despite incomplete registration
- Any tools, hooks, or channels registered in the async portion were silently lost

## Fix
- Mark async-registering plugins with `status: "error"` instead of marking them as loaded
- Upgrade diagnostic from warn to error level
- Use `continue` to skip the normal registration path

## Test plan
- [x] Existing plugin loader tests pass

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates the plugin loader (`src/plugins/loader.ts`) to treat plugins whose `register()` returns a Promise as a hard error rather than a warning. In that case, the loader now marks the plugin record with `status: "error"`, attaches an error message, emits an `error`-level diagnostic, and `continue`s to skip the normal successful-registration path.

This aligns the registry state (`registry.plugins`) with the system’s actual behavior: async work after `register()` cannot be awaited here, so any tools/hooks/channels registered later would otherwise be silently lost while the plugin still appeared "loaded".

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped to the plugin registration path, preserves existing control flow for synchronous plugins, and improves correctness by preventing async-registering plugins from being reported as loaded. No additional behavior changes were found outside the intended error handling and diagnostic level update.
- No files require special attention

<sub>Last reviewed commit: e4df1d0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->