### PR TITLE
fix(telegram): scope default account skill commands to resolved agent (#15599)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Docs: https://docs.openclaw.ai
 - Clawdock: avoid Zsh readonly variable collisions in helper scripts. (#15501) Thanks @nkelner.
 - Discord: route autoThread replies to existing threads instead of the root channel. (#8302) Thanks @gavinbmoore, @thewilloftheshadow.
 - Discord/Agents: apply channel/group `historyLimit` during embedded-runner history compaction to prevent long-running channel sessions from bypassing truncation and overflowing context windows. (#11224) Thanks @shadril238.
+- Telegram: scope skill commands to the resolved agent for default accounts so `setMyCommands` no longer triggers `BOT_COMMANDS_TOO_MUCH` when multiple agents are configured. (#15599)
 - Agents/Image tool: cap image-analysis completion `maxTokens` by model capability (`min(4096, model.maxTokens)`) to avoid over-limit provider failures while still preventing truncation. (#11770) Thanks @detecti1.
 - TUI/Streaming: preserve richer streamed assistant text when final payload drops pre-tool-call text blocks, while keeping non-empty final payload authoritative for plain-text updates. (#15452) Thanks @TsekaLuk.
 - Inbound/Web UI: preserve literal `\n` sequences when normalizing inbound text so Windows paths like `C:\\Work\\nxxx\\README.md` are not corrupted. (#11547) Thanks @mcaxtr.

--- a/src/telegram/bot-native-commands.test.ts
+++ b/src/telegram/bot-native-commands.test.ts
@@ -67,7 +67,7 @@ describe("registerTelegramNativeCommands", () => {
     });
   });
 
-  it("keeps skill commands unscoped without a matching binding", () => {
+  it("scopes skill commands to default agent without a matching binding (#15599)", () => {
     const cfg: OpenClawConfig = {
       agents: {
         list: [{ id: "main", default: true }, { id: "butler" }],
@@ -76,7 +76,10 @@ describe("registerTelegramNativeCommands", () => {
 
     registerTelegramNativeCommands(buildParams(cfg, "bot-a"));
 
-    expect(listSkillCommandsForAgents).toHaveBeenCalledWith({ cfg });
+    expect(listSkillCommandsForAgents).toHaveBeenCalledWith({
+      cfg,
+      agentIds: ["main"],
+    });
   });
 
   it("truncates Telegram command registration to 100 commands", () => {

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -295,8 +295,7 @@ export const registerTelegramNativeCommands = ({
     nativeEnabled && nativeSkillsEnabled
       ? resolveAgentRoute({ cfg, channel: "telegram", accountId })
       : null;
-  const boundAgentIds =
-    boundRoute && boundRoute.matchedBy.startsWith("binding.") ? [boundRoute.agentId] : null;
+  const boundAgentIds = boundRoute ? [boundRoute.agentId] : null;
   const skillCommands =
     nativeEnabled && nativeSkillsEnabled
       ? listSkillCommandsForAgents(boundAgentIds ? { cfg, agentIds: boundAgentIds } : { cfg })


### PR DESCRIPTION
## Summary

Scope skill commands to the resolved agent for default Telegram accounts so `setMyCommands` no longer triggers `BOT_COMMANDS_TOO_MUCH` when multiple agents are configured.

## Root Cause

In `registerTelegramNativeCommands`, `boundAgentIds` was only set when the route was matched via a `binding.*` path. For the default account (no binding), `resolveAgentRoute` returns the default agent via `matchedBy: "default"`, but the old code required `matchedBy.startsWith("binding.")`, leaving `boundAgentIds = null`. This caused `listSkillCommandsForAgents({ cfg })` to traverse **all** agents, generating far more commands than needed.

## Fix

Remove the `matchedBy.startsWith("binding.")` guard so `boundAgentIds` always uses the resolved agent ID from `resolveAgentRoute`, whether matched by binding or default.

```diff
- const boundAgentIds =
-     boundRoute && boundRoute.matchedBy.startsWith("binding.") ? [boundRoute.agentId] : null;
+ const boundAgentIds = boundRoute ? [boundRoute.agentId] : null;
```

## Before (on main — real environment, zero mocks)

Created 3 agent workspaces with real `SKILL.md` files on disk, called the real `listSkillCommandsForAgents` (full chain: `buildWorkspaceSkillCommandSpecs` → `loadSkillEntries` → `loadSkillsFromDir`):

```
Scoped to ["main"]: 47 commands
Unscoped (no agentIds): 141 commands
Extra commands from other agents: 94 — butler_skill_1..5, researcher_skill_1..5
❌ BUG CONFIRMED: unscoped returns 141 commands vs scoped 47 — difference of 94 extra commands from other agents
```

## After (on fix branch)

```
✓ scopes skill commands when account binding exists
✓ scopes skill commands to default agent without a matching binding (#15599)
✓ truncates Telegram command registration to 100 commands

Test Files  1 passed (1)
     Tests  3 passed (3)
```

## Changes

- `src/telegram/bot-native-commands.ts`: remove `matchedBy` guard on `boundAgentIds`
- `src/telegram/bot-native-commands.test.ts`: update existing test to verify default account scopes to `["main"]`
- `src/gateway/server/ws-connection.ts`: suppress false-positive `no-control-regex` lint on intentional control-character sanitizer regex
- `CHANGELOG.md`: add entry

Closes #15599