### PR TITLE
Slack: add channel create for message tool

### DIFF
--- a/src/agents/tool-display.json
+++ b/src/agents/tool-display.json
@@ -226,6 +226,7 @@
         },
         "channel-info": { "label": "channel", "detailKeys": ["provider", "channelId"] },
         "channel-list": { "label": "channels", "detailKeys": ["provider", "guildId"] },
+        "channel-create": { "label": "channel create", "detailKeys": ["provider", "name", "guildId"] },
         "voice-status": { "label": "voice", "detailKeys": ["provider", "guildId", "userId"] },
         "event-list": { "label": "events", "detailKeys": ["provider", "guildId"] },
         "event-create": {

--- a/src/agents/tool-display.json
+++ b/src/agents/tool-display.json
@@ -226,7 +226,10 @@
         },
         "channel-info": { "label": "channel", "detailKeys": ["provider", "channelId"] },
         "channel-list": { "label": "channels", "detailKeys": ["provider", "guildId"] },
-        "channel-create": { "label": "channel create", "detailKeys": ["provider", "name", "guildId"] },
+        "channel-create": {
+          "label": "channel create",
+          "detailKeys": ["provider", "name", "guildId"]
+        },
         "voice-status": { "label": "voice", "detailKeys": ["provider", "guildId", "userId"] },
         "event-list": { "label": "events", "detailKeys": ["provider", "guildId"] },
         "event-create": {

--- a/src/agents/tools/common.ts
+++ b/src/agents/tools/common.ts
@@ -147,7 +147,7 @@ export function readBooleanParam(
     }
   }
   if (required) {
-    throw new Error(`${label} required`);
+    throw new ToolInputError(`${label} required`);
   }
   return undefined;
 }

--- a/src/agents/tools/common.ts
+++ b/src/agents/tools/common.ts
@@ -127,6 +127,31 @@ export function readNumberParam(
   return integer ? Math.trunc(value) : value;
 }
 
+export function readBooleanParam(
+  params: Record<string, unknown>,
+  key: string,
+  options: { required?: boolean; label?: string } = {},
+): boolean | undefined {
+  const { required = false, label = key } = options;
+  const raw = params[key];
+  if (typeof raw === "boolean") {
+    return raw;
+  }
+  if (typeof raw === "string") {
+    const trimmed = raw.trim().toLowerCase();
+    if (trimmed === "true") {
+      return true;
+    }
+    if (trimmed === "false") {
+      return false;
+    }
+  }
+  if (required) {
+    throw new Error(`${label} required`);
+  }
+  return undefined;
+}
+
 export function readStringArrayParam(
   params: Record<string, unknown>,
   key: string,

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -364,6 +364,9 @@ function buildPresenceSchema() {
 function buildChannelManagementSchema() {
   return {
     name: Type.Optional(Type.String()),
+    private: Type.Optional(
+      Type.Boolean({ description: "Create a private channel when supported by the provider." }),
+    ),
     type: Type.Optional(Type.Number()),
     parentId: Type.Optional(Type.String()),
     topic: Type.Optional(Type.String()),

--- a/src/agents/tools/slack-actions.e2e.test.ts
+++ b/src/agents/tools/slack-actions.e2e.test.ts
@@ -33,7 +33,6 @@ vi.mock("../../slack/actions.js", () => ({
   sendSlackMessage,
   unpinSlackMessage,
 }));
-}));
 
 describe("handleSlackAction", () => {
   it("adds reactions", async () => {

--- a/src/agents/tools/slack-actions.e2e.test.ts
+++ b/src/agents/tools/slack-actions.e2e.test.ts
@@ -4,6 +4,7 @@ import { handleSlackAction } from "./slack-actions.js";
 
 const deleteSlackMessage = vi.fn(async (..._args: unknown[]) => ({}));
 const editSlackMessage = vi.fn(async (..._args: unknown[]) => ({}));
+const createSlackChannel = vi.fn(async (..._args: unknown[]) => ({ id: "C_NEW" }));
 const getSlackMemberInfo = vi.fn(async (..._args: unknown[]) => ({}));
 const listSlackEmojis = vi.fn(async (..._args: unknown[]) => ({}));
 const listSlackPins = vi.fn(async (..._args: unknown[]) => ({}));
@@ -17,6 +18,7 @@ const sendSlackMessage = vi.fn(async (..._args: unknown[]) => ({}));
 const unpinSlackMessage = vi.fn(async (..._args: unknown[]) => ({}));
 
 vi.mock("../../slack/actions.js", () => ({
+  createSlackChannel,
   deleteSlackMessage,
   editSlackMessage,
   getSlackMemberInfo,
@@ -30,6 +32,7 @@ vi.mock("../../slack/actions.js", () => ({
   removeSlackReaction,
   sendSlackMessage,
   unpinSlackMessage,
+}));
 }));
 
 describe("handleSlackAction", () => {
@@ -542,6 +545,25 @@ describe("handleSlackAction", () => {
     const expectedMs = Math.round(1735689600.789 * 1000);
     expect(payload.pins[0].message?.timestampMs).toBe(expectedMs);
     expect(payload.pins[0].message?.timestampUtc).toBe(new Date(expectedMs).toISOString());
+  });
+
+  it("creates channels with topic and privacy", async () => {
+    const cfg = { channels: { slack: { botToken: "tok" } } } as OpenClawConfig;
+    createSlackChannel.mockClear();
+    const result = await handleSlackAction(
+      {
+        action: "channelCreate",
+        name: "leads",
+        topic: "Lead Discovery Hub",
+        private: "true",
+      },
+      cfg,
+    );
+    expect(createSlackChannel).toHaveBeenCalledWith("leads", {
+      isPrivate: true,
+      topic: "Lead Discovery Hub",
+    });
+    expect(result.details).toMatchObject({ ok: true, channel: { id: "C_NEW" } });
   });
 
   it("uses user token for reads when available", async () => {

--- a/src/channels/plugins/actions/actions.test.ts
+++ b/src/channels/plugins/actions/actions.test.ts
@@ -775,6 +775,32 @@ describe("slack actions adapter", () => {
     });
   });
 
+  it("forwards channel create params", async () => {
+    const cfg = {
+      channels: { slack: { botToken: "tok", actions: { channels: true } } },
+    } as OpenClawConfig;
+    const actions = createSlackActions("slack");
+
+    await actions.handleAction?.({
+      channel: "slack",
+      action: "channel-create",
+      cfg,
+      params: {
+        name: "leads",
+        topic: "Lead Discovery Hub",
+        private: true,
+      },
+    });
+
+    const [params] = handleSlackAction.mock.calls[0] ?? [];
+    expect(params).toMatchObject({
+      action: "channelCreate",
+      name: "leads",
+      topic: "Lead Discovery Hub",
+      isPrivate: true,
+    });
+  });
+
   it("forwards blocks JSON for send", async () => {
     await runSlackAction("send", {
       to: "channel:C1",

--- a/src/cli/program/message/register.discord-admin.ts
+++ b/src/cli/program/message/register.discord-admin.ts
@@ -57,6 +57,24 @@ export function registerMessageDiscordAdminCommands(message: Command, helpers: M
       await helpers.runMessageAction("channel-list", opts);
     });
 
+  helpers
+    .withMessageBase(
+      channel
+        .command("create")
+        .description("Create a channel")
+        .requiredOption("--name <name>", "Channel name")
+        .option("--guild-id <id>", "Guild id (Discord)"),
+    )
+    .option("--topic <text>", "Channel topic")
+    .option("--type <n>", "Channel type (Discord)")
+    .option("--parent-id <id>", "Parent/category id (Discord)")
+    .option("--position <n>", "Channel position (Discord)")
+    .option("--nsfw", "Mark channel as NSFW (Discord)")
+    .option("--private <bool>", "Create a private channel (Slack)")
+    .action(async (opts) => {
+      await helpers.runMessageAction("channel-create", opts);
+    });
+
   const member = message.command("member").description("Member actions");
   helpers
     .withMessageBase(

--- a/src/config/types.slack.ts
+++ b/src/config/types.slack.ts
@@ -55,6 +55,7 @@ export type SlackActionConfig = {
   permissions?: boolean;
   memberInfo?: boolean;
   channelInfo?: boolean;
+  channels?: boolean;
   emojiList?: boolean;
 };
 

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -593,6 +593,7 @@ export const SlackAccountSchema = z
         permissions: z.boolean().optional(),
         memberInfo: z.boolean().optional(),
         channelInfo: z.boolean().optional(),
+        channels: z.boolean().optional(),
         emojiList: z.boolean().optional(),
       })
       .strict()

--- a/src/plugin-sdk/slack-message-actions.ts
+++ b/src/plugin-sdk/slack-message-actions.ts
@@ -1,5 +1,5 @@
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
-import { readNumberParam, readStringParam } from "../agents/tools/common.js";
+import { readBooleanParam, readNumberParam, readStringParam } from "../agents/tools/common.js";
 import type { ChannelMessageActionContext } from "../channels/plugins/types.js";
 import { parseSlackBlocksInput } from "../slack/blocks-input.js";
 
@@ -160,6 +160,23 @@ export async function handleSlackMessageAction(params: {
         action: action === "pin" ? "pinMessage" : action === "unpin" ? "unpinMessage" : "listPins",
         channelId: resolveChannelId(),
         messageId,
+        accountId,
+      },
+      cfg,
+    );
+  }
+
+  if (action === "channel-create") {
+    const name = readStringParam(actionParams, "name", { required: true });
+    const topic = readStringParam(actionParams, "topic");
+    const isPrivate =
+      readBooleanParam(actionParams, "private") ?? readBooleanParam(actionParams, "isPrivate");
+    return await invoke(
+      {
+        action: "channelCreate",
+        name,
+        topic: topic ?? undefined,
+        isPrivate: isPrivate ?? undefined,
         accountId,
       },
       cfg,

--- a/src/slack/actions.ts
+++ b/src/slack/actions.ts
@@ -245,6 +245,26 @@ export async function listSlackEmojis(opts: SlackActionClientOpts = {}) {
   return await client.emoji.list();
 }
 
+export async function createSlackChannel(
+  name: string,
+  opts: SlackActionClientOpts & { isPrivate?: boolean; topic?: string } = {},
+) {
+  const client = await getClient(opts);
+  const createParams: { name: string; is_private?: boolean } = { name };
+  if (typeof opts.isPrivate === "boolean") {
+    createParams.is_private = opts.isPrivate;
+  }
+  const result = await client.conversations.create(createParams);
+  const channel = result.channel as { id?: string } | undefined;
+  if (opts.topic && channel?.id) {
+    await client.conversations.setTopic({
+      channel: channel.id,
+      topic: opts.topic,
+    });
+  }
+  return channel ?? result;
+}
+
 export async function pinSlackMessage(
   channelId: string,
   messageId: string,

--- a/src/slack/index.ts
+++ b/src/slack/index.ts
@@ -5,6 +5,7 @@ export {
   resolveSlackAccount,
 } from "./accounts.js";
 export {
+  createSlackChannel,
   deleteSlackMessage,
   editSlackMessage,
   getSlackMemberInfo,

--- a/src/slack/message-actions.ts
+++ b/src/slack/message-actions.ts
@@ -44,6 +44,9 @@ export function listSlackMessageActions(cfg: OpenClawConfig): ChannelMessageActi
   if (isActionEnabled("emojiList")) {
     actions.add("emoji-list");
   }
+  if (isActionEnabled("channels")) {
+    actions.add("channel-create");
+  }
   return Array.from(actions);
 }
 


### PR DESCRIPTION
## Summary
- add Slack channel create action for the message tool
- add Discord channel create support
- fix Slack read-token override gating for read-only actions

## Testing
- `pnpm check` (fails on upstream `src/gateway/server/ws-connection.ts` control-regex lint)
- `pnpm build`
- `pnpm test` (fails: missing `@matrix-org/matrix-sdk-crypto-nodejs-darwin-arm64` for Matrix tests on this host)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new channel-create action to the message tool UX/schema, wires Slack to support `channelCreate` (including optional topic + private flag), adds a corresponding CLI command, and adjusts Slack action execution to prefer user tokens for read-only operations.

Most of the integration is consistent across the message tool, Slack adapter, and Slack action handler. One issue remains in shared tool param parsing: boolean required validation errors are thrown as generic errors rather than the project’s `ToolInputError`, which will change how these errors surface to callers.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge once the ToolInputError inconsistency is fixed
- Changes are localized (Slack/Discord channel creation + Slack token gating) and tests added cover the new Slack channelCreate path. The remaining issue is a concrete error-type inconsistency in shared param parsing that can alter API error classification for required boolean params.
- src/agents/tools/common.ts (readBooleanParam error type)

<sub>Last reviewed commit: 61581b1</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->