### PR TITLE
fix(whatsapp): pass filename for outbound documents

### DIFF
--- a/src/web/active-listener.ts
+++ b/src/web/active-listener.ts
@@ -5,6 +5,7 @@ import { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
 export type ActiveWebSendOptions = {
   gifPlayback?: boolean;
   accountId?: string;
+  fileName?: string;
 };
 
 export type ActiveWebListener = {

--- a/src/web/inbound/send-api.ts
+++ b/src/web/inbound/send-api.ts
@@ -40,7 +40,7 @@ export function createWebSendApi(params: {
         } else {
           payload = {
             document: mediaBuffer,
-            fileName: "file",
+            fileName: sendOptions?.fileName || "file",
             caption: text || undefined,
             mimetype: mediaType,
           };

--- a/src/web/outbound.ts
+++ b/src/web/outbound.ts
@@ -45,11 +45,13 @@ export async function sendMessageWhatsApp(
     const jid = toWhatsappJid(to);
     let mediaBuffer: Buffer | undefined;
     let mediaType: string | undefined;
+    let mediaFileName: string | undefined;
     if (options.mediaUrl) {
       const media = await loadWebMedia(options.mediaUrl);
       const caption = text || undefined;
       mediaBuffer = media.buffer;
       mediaType = media.contentType;
+      mediaFileName = media.fileName;
       if (media.kind === "audio") {
         // WhatsApp expects explicit opus codec for PTT voice notes.
         mediaType =
@@ -70,9 +72,10 @@ export async function sendMessageWhatsApp(
     const hasExplicitAccountId = Boolean(options.accountId?.trim());
     const accountId = hasExplicitAccountId ? resolvedAccountId : undefined;
     const sendOptions: ActiveWebSendOptions | undefined =
-      options.gifPlayback || accountId
+      options.gifPlayback || accountId || mediaFileName
         ? {
             ...(options.gifPlayback ? { gifPlayback: true } : {}),
+            ...(mediaFileName ? { fileName: mediaFileName } : {}),
             accountId,
           }
         : undefined;


### PR DESCRIPTION
Fixes #15560

## What
Pass actual filename when sending documents via WhatsApp instead of hardcoded `"file"`.

## Why
Documents sent via WhatsApp always appeared as "file" regardless of actual filename, making it hard for recipients to identify files.

## How
1. Added `fileName?: string` to `ActiveWebSendOptions` type
2. Extract `media.fileName` from `loadWebMedia()` result in `sendMessageWhatsApp()`
3. Pass filename via `sendOptions` to `sendMessage()` handler
4. Use `sendOptions?.fileName || "file"` in document payload instead of hardcoded `"file"`

## Testing
- [x] `pnpm check` passes (lint error is pre-existing, unrelated)
- [x] TypeScript compiles cleanly

## AI-Assisted 🤖
This PR was built with AI assistance (Claude via OpenClaw).
- [x] Code reviewed and understood
- [x] Changes are minimal and focused

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR threads an optional `fileName` through the WhatsApp Web outbound send path so document messages use the real media filename instead of a hardcoded `"file"`.

Changes are localized to the WhatsApp web channel:
- `src/web/active-listener.ts` extends `ActiveWebSendOptions` with `fileName?: string`.
- `src/web/outbound.ts` captures `media.fileName` from `loadWebMedia()` and includes it in `sendOptions` when present.
- `src/web/inbound/send-api.ts` uses `sendOptions?.fileName || "file"` when building Baileys document payloads.

Overall, this matches existing patterns (optional send options object) and keeps behavior unchanged when no filename is available.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are small, type-safe, and confined to the WhatsApp web send path. The filename comes from existing media-loading logic (`loadWebMedia`/`fetchRemoteMedia`), and existing behavior is preserved via a default fallback when no filename is available.
- No files require special attention

<sub>Last reviewed commit: 1607c27</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->