### PR TITLE
fix: use provider-qualified key in MODEL_CACHE for context window lookup

### DIFF
--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -62,7 +62,7 @@ export function applyConfiguredContextWindows(params: {
   if (!providers || typeof providers !== "object") {
     return;
   }
-  for (const [providerId, provider] of Object.entries(providers)) {
+  for (const provider of Object.values(providers)) {
     if (!Array.isArray(provider?.models)) {
       continue;
     }
@@ -73,18 +73,13 @@ export function applyConfiguredContextWindows(params: {
       if (!modelId || !contextWindow || contextWindow <= 0) {
         continue;
       }
-      // Store with provider-qualified key (e.g. "rdsec/claude-4.6-sonnet") so
-      // models that share the same id across providers but differ in context
-      // window are resolved correctly via lookupContextTokens.
-      // Use normalizeProviderId so the key format matches resolveContextTokensForModel
-      // which also normalizes before constructing the qualified lookup key.
-      if (providerId) {
-        params.cache.set(`${normalizeProviderId(providerId)}/${modelId}`, contextWindow);
-      }
-      // Also store by bare model id as a fallback for callers that only have
-      // the model name. When multiple providers define the same id the last
-      // one wins, but a provider-qualified lookup above will always take
-      // precedence when provider info is available.
+      // Only write the bare model id. The provider-qualified key space is
+      // reserved for raw discovery entries (e.g. "google-gemini-cli/gemini-3.1-pro-preview")
+      // and must not be polluted by synthetic config writes that could corrupt
+      // slash-containing model IDs (e.g. OpenRouter's "anthropic/claude-opus-4-6").
+      // Callers with provider info use resolveContextTokensForModel which scans
+      // cfg.models.providers directly and never relies on this cache for the
+      // qualified lookup.
       params.cache.set(modelId, contextWindow);
     }
   }

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -62,7 +62,7 @@ export function applyConfiguredContextWindows(params: {
   if (!providers || typeof providers !== "object") {
     return;
   }
-  for (const provider of Object.values(providers)) {
+  for (const [providerId, provider] of Object.entries(providers)) {
     if (!Array.isArray(provider?.models)) {
       continue;
     }
@@ -73,6 +73,18 @@ export function applyConfiguredContextWindows(params: {
       if (!modelId || !contextWindow || contextWindow <= 0) {
         continue;
       }
+      // Store with provider-qualified key (e.g. "rdsec/claude-4.6-sonnet") so
+      // models that share the same id across providers but differ in context
+      // window are resolved correctly via lookupContextTokens.
+      // Use normalizeProviderId so the key format matches resolveContextTokensForModel
+      // which also normalizes before constructing the qualified lookup key.
+      if (providerId) {
+        params.cache.set(`${normalizeProviderId(providerId)}/${modelId}`, contextWindow);
+      }
+      // Also store by bare model id as a fallback for callers that only have
+      // the model name. When multiple providers define the same id the last
+      // one wins, but a provider-qualified lookup above will always take
+      // precedence when provider info is available.
       params.cache.set(modelId, contextWindow);
     }
   }

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -289,6 +289,7 @@ export async function runMemoryFlushIfNeeded(params: {
     params.sessionEntry ??
     (params.sessionKey ? params.sessionStore?.[params.sessionKey] : undefined);
   const contextWindowTokens = resolveMemoryFlushContextWindowTokens({
+    cfg: params.cfg,
     modelId: params.followupRun.run.model ?? params.defaultModel,
     providerId: params.followupRun.run.provider,
     agentCfgContextTokens: params.agentCfgContextTokens,

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -290,6 +290,7 @@ export async function runMemoryFlushIfNeeded(params: {
     (params.sessionKey ? params.sessionStore?.[params.sessionKey] : undefined);
   const contextWindowTokens = resolveMemoryFlushContextWindowTokens({
     modelId: params.followupRun.run.model ?? params.defaultModel,
+    providerId: params.followupRun.run.provider,
     agentCfgContextTokens: params.agentCfgContextTokens,
   });
 

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs";
-import { lookupContextTokens } from "../../agents/context.js";
+import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { resolveModelAuthMode } from "../../agents/model-auth.js";
 import { isCliProvider } from "../../agents/model-selection.js";
@@ -460,10 +460,13 @@ export async function runReplyAgent(params: {
       ? runResult.meta?.agentMeta?.sessionId?.trim()
       : undefined;
     const contextTokensUsed =
-      agentCfgContextTokens ??
-      lookupContextTokens(modelUsed) ??
-      activeSessionEntry?.contextTokens ??
-      DEFAULT_CONTEXT_TOKENS;
+      resolveContextTokensForModel({
+        cfg,
+        provider: providerUsed,
+        model: modelUsed,
+        contextTokensOverride: agentCfgContextTokens,
+        fallbackContextTokens: activeSessionEntry?.contextTokens ?? DEFAULT_CONTEXT_TOKENS,
+      }) ?? DEFAULT_CONTEXT_TOKENS;
 
     await persistRunSessionUsage({
       storePath,

--- a/src/auto-reply/reply/directive-handling.persist.ts
+++ b/src/auto-reply/reply/directive-handling.persist.ts
@@ -3,7 +3,7 @@ import {
   resolveDefaultAgentId,
   resolveSessionAgentId,
 } from "../../agents/agent-scope.js";
-import { lookupContextTokens } from "../../agents/context.js";
+import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import {
   buildModelAliasIndex,
@@ -213,7 +213,14 @@ export async function persistInlineDirectives(params: {
   return {
     provider,
     model,
-    contextTokens: agentCfg?.contextTokens ?? lookupContextTokens(model) ?? DEFAULT_CONTEXT_TOKENS,
+    contextTokens:
+      resolveContextTokensForModel({
+        cfg,
+        provider,
+        model,
+        contextTokensOverride: agentCfg?.contextTokens,
+        fallbackContextTokens: DEFAULT_CONTEXT_TOKENS,
+      }) ?? DEFAULT_CONTEXT_TOKENS,
   };
 }
 

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -1,7 +1,7 @@
 import crypto from "node:crypto";
 import { resolveRunModelFallbacksOverride } from "../../agents/agent-scope.js";
 import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
-import { lookupContextTokens } from "../../agents/context.js";
+import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { runWithModelFallback } from "../../agents/model-fallback.js";
 import { runEmbeddedPiAgent } from "../../agents/pi-embedded.js";
@@ -244,11 +244,15 @@ export function createFollowupRunner(params: {
       const usage = runResult.meta?.agentMeta?.usage;
       const promptTokens = runResult.meta?.agentMeta?.promptTokens;
       const modelUsed = runResult.meta?.agentMeta?.model ?? fallbackModel ?? defaultModel;
+      const providerUsed = runResult.meta?.agentMeta?.provider ?? fallbackProvider;
       const contextTokensUsed =
-        agentCfgContextTokens ??
-        lookupContextTokens(modelUsed) ??
-        sessionEntry?.contextTokens ??
-        DEFAULT_CONTEXT_TOKENS;
+        resolveContextTokensForModel({
+          cfg: queued.run.config,
+          provider: providerUsed,
+          model: modelUsed,
+          contextTokensOverride: agentCfgContextTokens,
+          fallbackContextTokens: sessionEntry?.contextTokens ?? DEFAULT_CONTEXT_TOKENS,
+        }) ?? DEFAULT_CONTEXT_TOKENS;
 
       if (storePath && sessionKey) {
         await persistRunSessionUsage({
@@ -258,7 +262,7 @@ export function createFollowupRunner(params: {
           lastCallUsage: runResult.meta?.agentMeta?.lastCallUsage,
           promptTokens,
           modelUsed,
-          providerUsed: fallbackProvider,
+          providerUsed,
           contextTokensUsed,
           systemPromptReport: runResult.meta?.systemPromptReport,
           logLabel: "followup",

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -421,6 +421,7 @@ export async function resolveReplyDirectives(params: {
   let contextTokens = resolveContextTokens({
     agentCfg,
     model,
+    provider,
   });
 
   const initialModelLabel = `${provider}/${model}`;

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -1,4 +1,6 @@
 import type { ExecToolDefaults } from "../../agents/bash-tools.js";
+import { resolveContextTokensForModel } from "../../agents/context.js";
+import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { resolveFastModeState } from "../../agents/fast-mode.js";
 import type { ModelAliasIndex } from "../../agents/model-selection.js";
 import { resolveSandboxRuntimeStatus } from "../../agents/sandbox.js";
@@ -17,7 +19,7 @@ import { applyInlineDirectiveOverrides } from "./get-reply-directives-apply.js";
 import { clearExecInlineDirectives, clearInlineDirectives } from "./get-reply-directives-utils.js";
 import { defaultGroupActivation, resolveGroupRequireMention } from "./groups.js";
 import { CURRENT_MESSAGE_MARKER, stripMentions, stripStructuralPrefixes } from "./mentions.js";
-import { createModelSelectionState, resolveContextTokens } from "./model-selection.js";
+import { createModelSelectionState } from "./model-selection.js";
 import { formatElevatedUnavailableMessage, resolveElevatedPermissions } from "./reply-elevated.js";
 import { stripInlineStatus } from "./reply-inline.js";
 import type { TypingController } from "./typing.js";
@@ -418,11 +420,14 @@ export async function resolveReplyDirectives(params: {
     resolvedReasoningLevel = await modelState.resolveDefaultReasoningLevel();
   }
 
-  let contextTokens = resolveContextTokens({
-    agentCfg,
-    model,
-    provider,
-  });
+  let contextTokens =
+    resolveContextTokensForModel({
+      cfg,
+      provider,
+      model,
+      contextTokensOverride: agentCfg?.contextTokens,
+      fallbackContextTokens: DEFAULT_CONTEXT_TOKENS,
+    }) ?? DEFAULT_CONTEXT_TOKENS;
 
   const initialModelLabel = `${provider}/${model}`;
   const formatModelSwitchEvent = (label: string, alias?: string) =>

--- a/src/auto-reply/reply/memory-flush.ts
+++ b/src/auto-reply/reply/memory-flush.ts
@@ -1,7 +1,6 @@
-import { lookupContextTokens } from "../../agents/context.js";
+import { resolveContextTokensForModel } from "../../agents/context.js";
 import { resolveCronStyleNow } from "../../agents/current-time.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
-import { normalizeProviderId } from "../../agents/model-selection.js";
 import { DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR } from "../../agents/pi-settings.js";
 import { parseNonNegativeByteSize } from "../../config/byte-size.js";
 import type { OpenClawConfig } from "../../config/config.js";
@@ -160,19 +159,19 @@ function ensureMemoryFlushSafetyHints(text: string): string {
 }
 
 export function resolveMemoryFlushContextWindowTokens(params: {
+  cfg?: OpenClawConfig;
   modelId?: string;
   providerId?: string;
   agentCfgContextTokens?: number;
 }): number {
-  const qualified =
-    params.providerId && params.modelId
-      ? lookupContextTokens(`${normalizeProviderId(params.providerId)}/${params.modelId}`)
-      : undefined;
   return (
-    qualified ??
-    lookupContextTokens(params.modelId) ??
-    params.agentCfgContextTokens ??
-    DEFAULT_CONTEXT_TOKENS
+    resolveContextTokensForModel({
+      cfg: params.cfg,
+      provider: params.providerId,
+      model: params.modelId,
+      contextTokensOverride: params.agentCfgContextTokens,
+      fallbackContextTokens: DEFAULT_CONTEXT_TOKENS,
+    }) ?? DEFAULT_CONTEXT_TOKENS
   );
 }
 

--- a/src/auto-reply/reply/memory-flush.ts
+++ b/src/auto-reply/reply/memory-flush.ts
@@ -1,6 +1,7 @@
 import { lookupContextTokens } from "../../agents/context.js";
 import { resolveCronStyleNow } from "../../agents/current-time.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
+import { normalizeProviderId } from "../../agents/model-selection.js";
 import { DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR } from "../../agents/pi-settings.js";
 import { parseNonNegativeByteSize } from "../../config/byte-size.js";
 import type { OpenClawConfig } from "../../config/config.js";
@@ -160,10 +161,18 @@ function ensureMemoryFlushSafetyHints(text: string): string {
 
 export function resolveMemoryFlushContextWindowTokens(params: {
   modelId?: string;
+  providerId?: string;
   agentCfgContextTokens?: number;
 }): number {
+  const qualified =
+    params.providerId && params.modelId
+      ? lookupContextTokens(`${normalizeProviderId(params.providerId)}/${params.modelId}`)
+      : undefined;
   return (
-    lookupContextTokens(params.modelId) ?? params.agentCfgContextTokens ?? DEFAULT_CONTEXT_TOKENS
+    qualified ??
+    lookupContextTokens(params.modelId) ??
+    params.agentCfgContextTokens ??
+    DEFAULT_CONTEXT_TOKENS
   );
 }
 

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -603,8 +603,16 @@ export function resolveModelDirectiveSelection(params: {
 export function resolveContextTokens(params: {
   agentCfg: NonNullable<NonNullable<OpenClawConfig["agents"]>["defaults"]> | undefined;
   model: string;
+  provider?: string;
 }): number {
+  const qualified =
+    params.provider
+      ? lookupContextTokens(`${normalizeProviderId(params.provider)}/${params.model}`)
+      : undefined;
   return (
-    params.agentCfg?.contextTokens ?? lookupContextTokens(params.model) ?? DEFAULT_CONTEXT_TOKENS
+    params.agentCfg?.contextTokens ??
+    qualified ??
+    lookupContextTokens(params.model) ??
+    DEFAULT_CONTEXT_TOKENS
   );
 }

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -603,16 +603,8 @@ export function resolveModelDirectiveSelection(params: {
 export function resolveContextTokens(params: {
   agentCfg: NonNullable<NonNullable<OpenClawConfig["agents"]>["defaults"]> | undefined;
   model: string;
-  provider?: string;
 }): number {
-  const qualified =
-    params.provider
-      ? lookupContextTokens(`${normalizeProviderId(params.provider)}/${params.model}`)
-      : undefined;
   return (
-    params.agentCfg?.contextTokens ??
-    qualified ??
-    lookupContextTokens(params.model) ??
-    DEFAULT_CONTEXT_TOKENS
+    params.agentCfg?.contextTokens ?? lookupContextTokens(params.model) ?? DEFAULT_CONTEXT_TOKENS
   );
 }

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -1,5 +1,6 @@
-import { lookupContextTokens } from "../agents/context.js";
-import { DEFAULT_CONTEXT_TOKENS } from "../agents/defaults.js";
+import { resolveContextTokensForModel } from "../agents/context.js";
+import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
+import { resolveConfiguredModelRef } from "../agents/model-selection.js";
 import { loadConfig } from "../config/config.js";
 import { loadSessionStore, resolveFreshSessionTotalTokens } from "../config/sessions.js";
 import { classifySessionKey } from "../gateway/session-utils.js";
@@ -91,10 +92,19 @@ export async function sessionsCommand(
   const aggregateAgents = opts.allAgents === true;
   const cfg = loadConfig();
   const displayDefaults = resolveSessionDisplayDefaults(cfg);
+  const configResolved = resolveConfiguredModelRef({
+    cfg,
+    defaultProvider: DEFAULT_PROVIDER,
+    defaultModel: DEFAULT_MODEL,
+  });
   const configContextTokens =
-    cfg.agents?.defaults?.contextTokens ??
-    lookupContextTokens(displayDefaults.model) ??
-    DEFAULT_CONTEXT_TOKENS;
+    resolveContextTokensForModel({
+      cfg,
+      provider: configResolved.provider,
+      model: configResolved.model,
+      contextTokensOverride: cfg.agents?.defaults?.contextTokens,
+      fallbackContextTokens: DEFAULT_CONTEXT_TOKENS,
+    }) ?? DEFAULT_CONTEXT_TOKENS;
   const targets = resolveSessionStoreTargetsOrExit({
     cfg,
     opts: {
@@ -163,7 +173,14 @@ export async function sessionsCommand(
               totalTokensFresh:
                 typeof r.totalTokens === "number" ? r.totalTokensFresh !== false : false,
               contextTokens:
-                r.contextTokens ?? lookupContextTokens(model) ?? configContextTokens ?? null,
+                r.contextTokens ??
+                resolveContextTokensForModel({
+                  cfg,
+                  provider: r.modelProvider,
+                  model,
+                  fallbackContextTokens: configContextTokens,
+                }) ??
+                null,
               model,
             };
           }),
@@ -207,7 +224,15 @@ export async function sessionsCommand(
 
   for (const row of rows) {
     const model = resolveSessionDisplayModel(cfg, row, displayDefaults);
-    const contextTokens = row.contextTokens ?? lookupContextTokens(model) ?? configContextTokens;
+    const contextTokens =
+      row.contextTokens ??
+      resolveContextTokensForModel({
+        cfg,
+        provider: row.modelProvider,
+        model,
+        fallbackContextTokens: configContextTokens,
+      }) ??
+      configContextTokens;
     const total = resolveFreshSessionTotalTokens(row);
 
     const line = [

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -9,7 +9,7 @@ import { resolveSessionAuthProfileOverride } from "../../agents/auth-profiles/se
 import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
 import { runCliAgent } from "../../agents/cli-runner.js";
 import { getCliSessionId, setCliSessionId } from "../../agents/cli-session.js";
-import { lookupContextTokens } from "../../agents/context.js";
+import { resolveContextTokensForModel } from "../../agents/context.js";
 import { resolveCronStyleNow } from "../../agents/current-time.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../../agents/defaults.js";
 import { resolveFastModeState } from "../../agents/fast-mode.js";
@@ -718,7 +718,13 @@ export async function runCronIsolatedAgentTurn(params: {
     const modelUsed = finalRunResult.meta?.agentMeta?.model ?? fallbackModel ?? model;
     const providerUsed = finalRunResult.meta?.agentMeta?.provider ?? fallbackProvider ?? provider;
     const contextTokens =
-      agentCfg?.contextTokens ?? lookupContextTokens(modelUsed) ?? DEFAULT_CONTEXT_TOKENS;
+      resolveContextTokensForModel({
+        cfg: cfgWithAgentDefaults,
+        provider: providerUsed,
+        model: modelUsed,
+        contextTokensOverride: agentCfg?.contextTokens,
+        fallbackContextTokens: DEFAULT_CONTEXT_TOKENS,
+      }) ?? DEFAULT_CONTEXT_TOKENS;
 
     setSessionRuntimeModel(cronSession.sessionEntry, {
       provider: providerUsed,

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
-import { lookupContextTokens } from "../agents/context.js";
+import { resolveContextTokensForModel } from "../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import {
   inferUniqueProviderFromConfiguredModels,
@@ -717,9 +717,13 @@ export function getSessionDefaults(cfg: OpenClawConfig): GatewaySessionsDefaults
     defaultModel: DEFAULT_MODEL,
   });
   const contextTokens =
-    cfg.agents?.defaults?.contextTokens ??
-    lookupContextTokens(resolved.model) ??
-    DEFAULT_CONTEXT_TOKENS;
+    resolveContextTokensForModel({
+      cfg,
+      provider: resolved.provider,
+      model: resolved.model,
+      contextTokensOverride: cfg.agents?.defaults?.contextTokens,
+      fallbackContextTokens: DEFAULT_CONTEXT_TOKENS,
+    }) ?? DEFAULT_CONTEXT_TOKENS;
   return {
     modelProvider: resolved.provider ?? null,
     model: resolved.model ?? null,


### PR DESCRIPTION
## Summary

- **Problem:** When multiple providers define the same model ID with different context windows, `/status` and compaction logic show/use the wrong context window for the non-last-loaded provider.
- **Why it matters:** Users running e.g. `provider-1/claude-4.6-sonnet` (200k) and `provider-2/claude-4.6-sonnet` (1M) would see both show `1.0m`, causing premature compaction on the 1M provider and incorrect status display on the 200k one.
- **What changed:** `applyConfiguredContextWindows` now writes only bare model-id keys to `MODEL_CACHE`. Call sites with provider info (`get-reply-directives`, `memory-flush`, `agent-runner-memory`) now call `resolveContextTokensForModel` with the full `cfg`, which scans `models.providers` directly to disambiguate same-named models across providers. `resolveContextTokens` in `model-selection.ts` reverted to remove the now-unused `provider` param.
- **What did NOT change:** Discovery cache entries (OpenRouter slash-path keys), overall context resolution priority chain, API contracts, config schema.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Memory / storage

## Linked Issue/PR

- Closes #11629

## User-visible / Behavior Changes

- `/status` now displays the correct context window when the same model ID exists across multiple providers with different limits.
- Compaction threshold is now computed from the actual provider's configured context window instead of the last-written cache entry.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux (Ubuntu 24.04)
- Runtime/container: Node 22, local gateway
- Model/provider: `provider-1/claude-4.6-sonnet` (200k), `provider-2/claude-4.6-sonnet` (1M)
- Relevant config: Two providers sharing `claude-4.6-sonnet` and `claude-4.6-opus` with different `contextWindow` values

### Steps

1. Configure two providers with the same model ID but different `contextWindow` in `openclaw.json`
2. `/model provider-1/claude-4.6-sonnet` → `/status`
3. `/model provider-2/claude-4.6-sonnet` → `/status`

### Expected

- `provider-1/claude-4.6-sonnet` → `tokens xx/200k`
- `provider-2/claude-4.6-sonnet` → `tokens xx/1.0m`

### Actual (after fix)

- `provider-1/claude-4.6-sonnet` → `tokens 19k/200k (9%)` ✅
- `provider-2/claude-4.6-sonnet` → `tokens 18k/1.0m (2%)` ✅

## Evidence

- [x] Trace/log snippets (TUI status bar confirmed above)

## Human Verification (required)

- **Verified scenarios:** Both `claude-4.6-sonnet` and `claude-4.6-opus` tested across two providers via TUI. Context window displayed correctly in status bar for each provider. Messages sent to both providers successfully.
- **Edge cases checked:** Confirmed `MODEL_CACHE` bare-key entries for discovery (OpenRouter slash-path IDs) are not affected by the change; `resolveContextTokensForModel` falls through to bare cache key when config scan finds no match.
- **What I did not verify:** Agents using `contextTokens` global override; OpenRouter provider with slash-containing model IDs in live environment.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

(Both Greptile review threads from the previous commit are resolved. The issues they identified — unguarded `undefined/model` lookup and provider mismatch in `persistRunSessionUsage` — no longer exist in the current code because the qualified-key-in-cache approach has been replaced entirely.)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: `git revert f5dcd2409`
- Files/config to restore: None
- Known bad symptoms: If context windows regress to always showing the last-loaded provider's value, this commit is the first place to check.

## Risks and Mitigations

- Risk: `resolveContextTokensForModel` scans `cfg.models.providers` on every call instead of reading from cache.
  - Mitigation: Config is an in-memory object; scan cost is O(providers × models) and negligible compared to API roundtrip latency.
