### PR TITLE
fix(googlechat): DM's works, but groups don't - return add-on action envelope for webhook acks

### DIFF
--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -186,6 +186,7 @@ export async function handleGoogleChatWebhookRequest(
   }
 
   let raw = body.value;
+  let isWorkspaceAddonPayload = false;
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
     res.statusCode = 400;
     res.end("invalid payload");
@@ -204,6 +205,7 @@ export async function handleGoogleChatWebhookRequest(
   };
 
   if (rawObj.commonEventObject?.hostApp === "CHAT" && rawObj.chat?.messagePayload) {
+    isWorkspaceAddonPayload = true;
     const chat = rawObj.chat;
     const messagePayload = chat.messagePayload;
     raw = {
@@ -279,7 +281,19 @@ export async function handleGoogleChatWebhookRequest(
 
   res.statusCode = 200;
   res.setHeader("Content-Type", "application/json");
-  res.end("{}");
+  if (isWorkspaceAddonPayload) {
+    // Google Workspace add-ons require hostAppDataAction response shape.
+    // Without this, Chat can display "not responding" despite successful processing.
+    res.end(
+      JSON.stringify({
+        hostAppDataAction: {
+          chatDataAction: {},
+        },
+      }),
+    );
+  } else {
+    res.end("{}");
+  }
   return true;
 }
 


### PR DESCRIPTION
I couldn't make Google Chat works with groups/spaces (in DM's it worked ok). Creating sample server confirmed json key is working ok for both DM and groups.

## Summary

Google Chat add-on interaction payloads (`commonEventObject.hostApp = "CHAT"`) were being accepted and processed, but the webhook ACK response used a bare `{}` body.

For add-on flows, Chat expects an action envelope (`hostAppDataAction.chatDataAction`). Returning `{}` can cause the UI to show "Tik not responding" even when the event is processed correctly.

This change:
- detects add-on payloads in the Google Chat webhook handler
- returns a valid add-on ACK envelope:
  - `{"hostAppDataAction":{"chatDataAction":{}}}`
- keeps existing behavior for non-add-on payloads (`{}`)

## Why

This avoids false "not responding" errors in Google Chat add-on mode while preserving async processing in OpenClaw.

## Scope

- File: `extensions/googlechat/src/monitor.ts`
- No config/schema changes
- No changes to outbound message logic

## Test Plan

- [x] Reproduced issue path with Google Chat add-on payloads (DM + space mention)
- [x] Confirmed payloads are delivered to webhook
- [x] Confirmed OpenClaw processes events asynchronously after ACK
- [x] Verified handler now returns add-on envelope for add-on payloads
- [x] Verified non-add-on path still returns `{}`

## Notes

This is a compatibility fix for Google Workspace add-on webhook response shape and should be safe for existing Chat API interaction flows.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates the Google Chat webhook handler to return the `hostAppDataAction.chatDataAction` envelope when the incoming request is a Google Workspace Add-on–formatted Chat event (`commonEventObject.hostApp === "CHAT"` with `chat.messagePayload`). For non–Add-on payloads, it continues to return an empty JSON object.

This fits the existing design where the webhook acks immediately (HTTP 200) while `processGoogleChatEvent(...)` continues asynchronously in the background, and aligns with the repo’s existing add-on token/issuer support in `extensions/googlechat/src/auth.ts`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is small, localized to the webhook ack response, preserves prior behavior for non–Workspace Add-on payloads, and is consistent with existing add-on request parsing and auth verification patterns. No correctness or runtime issues were found in the updated logic.
- No files require special attention

<sub>Last reviewed commit: 1389179</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->