### PR TITLE
fix(lint): suppress no-control-regex for intentional sanitization pattern

### DIFF
--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -19,6 +19,7 @@ import { attachGatewayWsMessageHandler } from "./ws-connection/message-handler.j
 type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
 
 const LOG_HEADER_MAX_LEN = 300;
+// eslint-disable-next-line no-control-regex -- Intentionally matching control characters for sanitization
 const LOG_HEADER_CONTROL_REGEX = /[\u0000-\u001f\u007f-\u009f]/g;
 const LOG_HEADER_FORMAT_REGEX = /\p{Cf}/gu;
 


### PR DESCRIPTION
## Summary
Fixes ESLint `no-control-regex` warning in `ws-connection.ts` introduced by #15592 (Gateway: sanitize WebSocket log headers).

## Details
The `LOG_HEADER_CONTROL_REGEX` pattern intentionally matches control characters (U+0000-U+001F, U+007F-U+009F) to sanitize WebSocket header values before logging. This prevents log injection attacks and terminal corruption.

The ESLint `no-control-regex` rule warns about control characters in regex patterns as they're usually mistakes, but in this case it's the security feature's purpose. Added an appropriate disable comment with explanation.

## Changes
- Added `eslint-disable-next-line no-control-regex` with explanation comment

## Test plan
- [x] `npm run lint` passes without errors
- [x] Sanitization logic unchanged (only comment added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change suppresses ESLint’s `no-control-regex` warning for `LOG_HEADER_CONTROL_REGEX` in `src/gateway/server/ws-connection.ts`, documenting that the regex intentionally matches control characters as part of WebSocket header sanitization before logging.

The change is localized to a single disable-next-line comment and does not modify runtime behavior; the sanitization logic and regex remain unchanged.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The only functional change in the head commit is an ESLint disable-next-line comment with an explanation; runtime code and regex behavior are unchanged. Reviewed the touched file and confirmed no additional side effects.
- No files require special attention

<sub>Last reviewed commit: bd3826d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->