### PR TITLE
fix(whatsapp): pass fileName to document sends instead of hardcoding 'file'

### DIFF
--- a/src/web/active-listener.ts
+++ b/src/web/active-listener.ts
@@ -5,6 +5,7 @@ import { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
 export type ActiveWebSendOptions = {
   gifPlayback?: boolean;
   accountId?: string;
+  fileName?: string;
 };
 
 export type ActiveWebListener = {

--- a/src/web/inbound/send-api.ts
+++ b/src/web/inbound/send-api.ts
@@ -40,7 +40,7 @@ export function createWebSendApi(params: {
         } else {
           payload = {
             document: mediaBuffer,
-            fileName: "file",
+            fileName: sendOptions?.fileName || "file",
             caption: text || undefined,
             mimetype: mediaType,
           };

--- a/src/web/outbound.test.ts
+++ b/src/web/outbound.test.ts
@@ -130,7 +130,10 @@ describe("web outbound", () => {
       verbose: false,
       mediaUrl: "/tmp/file.pdf",
     });
-    expect(sendMessage).toHaveBeenLastCalledWith("+1555", "doc", buf, "application/pdf");
+    expect(sendMessage).toHaveBeenLastCalledWith("+1555", "doc", buf, "application/pdf", {
+      fileName: "file.pdf",
+      accountId: undefined,
+    });
   });
 
   it("sends polls via active listener", async () => {

--- a/src/web/outbound.ts
+++ b/src/web/outbound.ts
@@ -45,11 +45,13 @@ export async function sendMessageWhatsApp(
     const jid = toWhatsappJid(to);
     let mediaBuffer: Buffer | undefined;
     let mediaType: string | undefined;
+    let mediaFileName: string | undefined;
     if (options.mediaUrl) {
       const media = await loadWebMedia(options.mediaUrl);
       const caption = text || undefined;
       mediaBuffer = media.buffer;
       mediaType = media.contentType;
+      mediaFileName = media.fileName;
       if (media.kind === "audio") {
         // WhatsApp expects explicit opus codec for PTT voice notes.
         mediaType =
@@ -70,9 +72,10 @@ export async function sendMessageWhatsApp(
     const hasExplicitAccountId = Boolean(options.accountId?.trim());
     const accountId = hasExplicitAccountId ? resolvedAccountId : undefined;
     const sendOptions: ActiveWebSendOptions | undefined =
-      options.gifPlayback || accountId
+      options.gifPlayback || accountId || mediaFileName
         ? {
             ...(options.gifPlayback ? { gifPlayback: true } : {}),
+            ...(mediaFileName ? { fileName: mediaFileName } : {}),
             accountId,
           }
         : undefined;


### PR DESCRIPTION
#### Summary

Fix WhatsApp outbound documents always showing as "file" — the fileName from `loadWebMedia()` is now passed through to the Baileys `sendMessage` handler.

Fixes #15560

#### Behavior Changes

- Documents sent via WhatsApp now display their actual filename (e.g., `report.pdf`) instead of generic `file`
- No breaking changes — falls back to `"file"` if fileName is undefined

#### Codebase and GitHub Search

- Searched for existing fileName handling: found `loadWebMedia()` already returns `fileName` but it was not passed through
- Verified no other code paths affected

#### Tests

- Updated `src/web/outbound.test.ts` to expect the new sendOptions with fileName
- `pnpm test -- --run src/web/outbound.test.ts` passes (9/9)
- `pnpm build` passes

#### Manual Testing (omit if N/A)

Not tested on live WhatsApp — requires paired device. Fix is straightforward pass-through.

lobster-biscuit

**Sign-Off**

- Models used: Claude Opus 4.5
- Submitter effort (self-reported): AI-assisted, human-reviewed
- Agent notes: Code change is minimal (3 files, ~10 lines). The fix adds `fileName?: string` to `ActiveWebSendOptions`, captures `media.fileName` in `outbound.ts`, and uses `sendOptions?.fileName || "file"` in `send-api.ts`.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR threads the `fileName` returned by `loadWebMedia()` through WhatsApp outbound sending so Baileys document messages use the real filename instead of a hardcoded `"file"`. Concretely, it adds `fileName?: string` to `ActiveWebSendOptions`, captures `media.fileName` in `src/web/outbound.ts`, and uses `sendOptions?.fileName || "file"` when constructing the Baileys document payload in `src/web/inbound/send-api.ts`. Tests were updated to assert the new send options object.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge after addressing one small behavioral consistency issue in outbound sendOptions construction.
- Changes are narrowly scoped and covered by a unit test, but `sendOptions` now sometimes includes `accountId: undefined` when the options object exists solely to pass `fileName`, which can be behaviorally different from omitting the field if downstream logic checks for property presence rather than value.
- src/web/outbound.ts

<sub>Last reviewed commit: 7740fbd</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->