### PR TITLE
CI: run auto-response on label events

### DIFF
--- a/.github/workflows/auto-response.yml
+++ b/.github/workflows/auto-response.yml
@@ -89,7 +89,8 @@ jobs:
               }
             }
 
-            if (!hasTriggerLabel) {
+            const isLabelEvent = context.payload.action === "labeled";
+            if (!hasTriggerLabel && !isLabelEvent) {
               return;
             }
 


### PR DESCRIPTION
## Summary
- run auto-response logic on labeled events without requiring trigger-response
- keep trigger-response as a manual override for non-label events

## Testing
- Not run (workflow change only)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the auto-response GitHub Actions workflow so it executes when an issue/PR is labeled (in addition to the existing `trigger-response` manual override), allowing label-driven responses without adding the trigger label.

The main behavioral risk is that on any `labeled` event the script evaluates against the full existing label set, so a previously-present `r:` rule label can cause duplicate auto-response comments/close/lock actions whenever *any* subsequent label is added.

<h3>Confidence Score: 3/5</h3>

- Mostly safe, but the new label-triggering behavior can cause repeated/duplicate auto-responses on later label changes.
- Change is small and isolated to one workflow, but it alters execution gating in a way that will definitely re-run the auto-response logic on every labeled event and can spam duplicate comments/closures when an `r:` label remains present.
- .github/workflows/auto-response.yml

<sub>Last reviewed commit: 3dced1c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->