### PR TITLE
fix: redirect plugin logs to stderr in completion command

### DIFF
--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { resolveStateDir } from "../config/paths.js";
+import { loggingState } from "../logging/state.js";
 import { pathExists } from "../utils.js";
 import { getSubCliEntries, registerSubCliByName } from "./program/register.subclis.js";
 
@@ -236,6 +237,9 @@ export function registerCompletionCli(program: Command) {
     .option("-y, --yes", "Skip confirmation (non-interactive)", false)
     .action(async (options) => {
       const shell = options.shell ?? "zsh";
+      // Force all logs to stderr so completion script goes to stdout only
+      loggingState.forceConsoleToStderr = true;
+
       // Eagerly register all subcommands to build the full tree
       const entries = getSubCliEntries();
       for (const entry of entries) {

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -273,7 +273,8 @@ export function registerCompletionCli(program: Command) {
         throw new Error(`Unsupported shell: ${shell}`);
       }
       const script = getCompletionScript(shell, program);
-      console.log(script);
+      // Use process.stdout directly to bypass forceConsoleToStderr
+      process.stdout.write(script + "\n");
     });
 }
 


### PR DESCRIPTION
## Summary

Fixes #15481

The `openclaw completion --shell zsh` command was outputting plugin registration logs to stdout, polluting the completion script output. This caused "bad pattern" errors when users tried to source the completion with:

```zsh
source <(openclaw completion --shell zsh)
```

## Root Cause

The completion command calls `registerSubCliByName()` which loads plugins. Plugin initialization logs via the logging subsystem, which by default goes to stdout.

## Fix

Set `loggingState.forceConsoleToStderr = true` before loading plugins. This ensures:
- All logs go to stderr
- Completion script output remains clean on stdout
- `source <(...)` works correctly

## Testing

The fix follows the same pattern used in `src/logging/console.ts` where `forceConsoleToStderr` is set for similar purposes.

Manual test:
```bash
# Before fix: logs appear in output
openclaw completion --shell zsh | head -5
[plugins] feishu_doc: Registered feishu_doc...
#compdef openclaw
...

# After fix: only completion script
openclaw completion --shell zsh | head -5
#compdef openclaw
...
```

## Files Changed

- `src/cli/completion-cli.ts`: Import `loggingState` and set `forceConsoleToStderr = true` before loading plugins

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the `completion` CLI command to prevent plugin initialization logs from polluting generated shell completion scripts. It imports the shared `loggingState` and sets `loggingState.forceConsoleToStderr = true` at the start of the `completion` action, before eagerly registering all subcommands (which can trigger plugin loading via `registerSubCliByName`). This matches the repo’s existing pattern for keeping stdout clean for machine-consumable output (e.g., `src/logging/console.ts`’s `routeLogsToStderr()` helper).

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge and should fix stdout pollution for completion generation.
- Change is small and follows an existing logging mechanism (`loggingState.forceConsoleToStderr`) used elsewhere to keep stdout clean. The only meaningful risk is global process state: setting `forceConsoleToStderr` is not reverted, so in-process follow-on code could have its console output redirected to stderr if the same Node process continues beyond completion generation (mostly relevant to tests or embedded/in-process CLI usage).
- src/cli/completion-cli.ts

<sub>Last reviewed commit: 1d80e6b</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->