### PR TITLE
fix(discord): normalize DM session keys for multi-agent setups 🤖

### DIFF
--- a/src/config/sessions/session-key.test.ts
+++ b/src/config/sessions/session-key.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { resolveSessionKey } from "./session-key.js";
+import type { MsgContext } from "../../auto-reply/templating.js";
+
+function makeCtx(overrides: Partial<MsgContext>): MsgContext {
+  return {
+    Body: "",
+    From: "",
+    To: "",
+    ...overrides,
+  } as MsgContext;
+}
+
+describe("resolveSessionKey", () => {
+  describe("Discord DM session key normalization", () => {
+    it("should pass through correct discord:direct keys unchanged", () => {
+      const ctx = makeCtx({
+        SessionKey: "agent:fina:discord:direct:123456",
+        ChatType: "direct",
+        From: "discord:123456",
+        SenderId: "123456",
+      });
+      expect(resolveSessionKey("per-sender", ctx)).toBe("agent:fina:discord:direct:123456");
+    });
+
+    it("should migrate legacy discord:dm: to discord:direct:", () => {
+      const ctx = makeCtx({
+        SessionKey: "agent:fina:discord:dm:123456",
+        ChatType: "direct",
+        From: "discord:123456",
+        SenderId: "123456",
+      });
+      expect(resolveSessionKey("per-sender", ctx)).toBe("agent:fina:discord:direct:123456");
+    });
+
+    it("should fix phantom discord:channel:USERID to discord:direct:USERID when sender matches", () => {
+      const ctx = makeCtx({
+        SessionKey: "agent:fina:discord:channel:123456",
+        ChatType: "direct",
+        From: "discord:123456",
+        SenderId: "123456",
+      });
+      expect(resolveSessionKey("per-sender", ctx)).toBe("agent:fina:discord:direct:123456");
+    });
+
+    it("should NOT fix discord:channel: when chatType is not direct", () => {
+      const ctx = makeCtx({
+        SessionKey: "agent:fina:discord:channel:123456",
+        ChatType: "channel",
+        From: "discord:channel:123456",
+        SenderId: "789",
+      });
+      expect(resolveSessionKey("per-sender", ctx)).toBe("agent:fina:discord:channel:123456");
+    });
+
+    it("should NOT fix discord:channel: when sender ID does not match", () => {
+      const ctx = makeCtx({
+        SessionKey: "agent:fina:discord:channel:123456",
+        ChatType: "direct",
+        From: "discord:789",
+        SenderId: "789",
+      });
+      // sender 789 != channel id 123456, so don't rewrite
+      expect(resolveSessionKey("per-sender", ctx)).toBe("agent:fina:discord:channel:123456");
+    });
+
+    it("should handle keys without agent: prefix", () => {
+      const ctx = makeCtx({
+        SessionKey: "discord:channel:123456",
+        ChatType: "direct",
+        From: "discord:123456",
+        SenderId: "123456",
+      });
+      expect(resolveSessionKey("per-sender", ctx)).toBe("discord:direct:123456");
+    });
+  });
+});

--- a/src/config/sessions/session-key.test.ts
+++ b/src/config/sessions/session-key.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { resolveSessionKey } from "./session-key.js";
 import type { MsgContext } from "../../auto-reply/templating.js";
+import { resolveSessionKey } from "./session-key.js";
 
 function makeCtx(overrides: Partial<MsgContext>): MsgContext {
   return {

--- a/src/config/sessions/session-key.ts
+++ b/src/config/sessions/session-key.ts
@@ -7,6 +7,7 @@ import {
 } from "../../routing/session-key.js";
 import { normalizeE164 } from "../../utils.js";
 import { resolveGroupSessionKey } from "./group.js";
+import { normalizeChatType } from "../../channels/chat-type.js";
 
 // Decide which session bucket to use (per-sender vs global).
 export function deriveSessionKey(scope: SessionScope, ctx: MsgContext) {
@@ -28,7 +29,33 @@ export function deriveSessionKey(scope: SessionScope, ctx: MsgContext) {
 export function resolveSessionKey(scope: SessionScope, ctx: MsgContext, mainKey?: string) {
   const explicit = ctx.SessionKey?.trim();
   if (explicit) {
-    return explicit.toLowerCase();
+    let normalized = explicit.toLowerCase();
+
+    // Fix misrouted Discord DM session keys:
+    // When chatType is "direct", the session key should use discord:direct:
+    // instead of discord:dm: (legacy) or discord:channel: (phantom).
+    const chatType = normalizeChatType(ctx.ChatType);
+    if (chatType === "direct") {
+      // Migrate legacy discord:dm: → discord:direct:
+      normalized = normalized.replace(/^(agent:[^:]+:discord:)dm:/, "$1direct:");
+
+      // Fix phantom discord:channel:USERID → discord:direct:USERID
+      // This happens when parseDiscordTarget treats a bare user ID as a channel.
+      const match = normalized.match(/^((?:agent:[^:]+:)?)discord:channel:([^:]+)$/);
+      if (match) {
+        const from = (ctx.From ?? "").trim().toLowerCase();
+        const senderId = (ctx.SenderId ?? "").trim().toLowerCase();
+        const fromDiscordId = from.startsWith("discord:") && !from.includes(":channel:") && !from.includes(":group:")
+          ? from.slice("discord:".length)
+          : "";
+        const directId = senderId || fromDiscordId;
+        if (directId && directId === match[2]) {
+          normalized = `${match[1]}discord:direct:${match[2]}`;
+        }
+      }
+    }
+
+    return normalized;
   }
   const raw = deriveSessionKey(scope, ctx);
   if (scope === "global") {

--- a/src/config/sessions/session-key.ts
+++ b/src/config/sessions/session-key.ts
@@ -1,5 +1,6 @@
 import type { MsgContext } from "../../auto-reply/templating.js";
 import type { SessionScope } from "./types.js";
+import { normalizeChatType } from "../../channels/chat-type.js";
 import {
   buildAgentMainSessionKey,
   DEFAULT_AGENT_ID,
@@ -7,7 +8,6 @@ import {
 } from "../../routing/session-key.js";
 import { normalizeE164 } from "../../utils.js";
 import { resolveGroupSessionKey } from "./group.js";
-import { normalizeChatType } from "../../channels/chat-type.js";
 
 // Decide which session bucket to use (per-sender vs global).
 export function deriveSessionKey(scope: SessionScope, ctx: MsgContext) {
@@ -45,9 +45,10 @@ export function resolveSessionKey(scope: SessionScope, ctx: MsgContext, mainKey?
       if (match) {
         const from = (ctx.From ?? "").trim().toLowerCase();
         const senderId = (ctx.SenderId ?? "").trim().toLowerCase();
-        const fromDiscordId = from.startsWith("discord:") && !from.includes(":channel:") && !from.includes(":group:")
-          ? from.slice("discord:".length)
-          : "";
+        const fromDiscordId =
+          from.startsWith("discord:") && !from.includes(":channel:") && !from.includes(":group:")
+            ? from.slice("discord:".length)
+            : "";
         const directId = senderId || fromDiscordId;
         if (directId && directId === match[2]) {
           normalized = `${match[1]}discord:direct:${match[2]}`;


### PR DESCRIPTION
## Summary

Fixes #15656 — Discord DM messages to non-default agents are silently dropped in multi-agent setups after v2026.2.12.

> **🤖 AI-Assisted PR** — Code written with Claude (AI), reviewed and tested by human on a production multi-agent deployment. Degree of testing: **fully tested in production** with 3 agents (main, work, fina) on separate Discord bot accounts.

## Problem

When using `per-channel-peer` dmScope with multiple agents bound to separate Discord bot accounts, DMs to non-default agents (e.g., `fina`, `work`) create phantom session entries with the wrong key format:

- **Expected**: `agent:fina:discord:direct:USERID`
- **Actual**: `agent:fina:discord:channel:USERID` (no model, no session file → silently dropped)

### Root Cause

`parseDiscordTarget(target, { defaultKind: "channel" })` in `resolveDiscordSession()` treats bare numeric user IDs as channel IDs. When outbound session routing processes a DM reply, it generates `discord:channel:USERID` keys. These phantom session entries get persisted via `ensureOutboundSessionEntry()` with no model and no session file, and subsequent messages get routed to them instead of the correct `discord:direct:USERID` sessions.

Additionally, the session key format changed from `discord:dm:` to `discord:direct:` between versions with no migration path for existing sessions.

## Fix

In `resolveSessionKey()` (`src/config/sessions/session-key.ts`), when `chatType` is `"direct"`, normalize misrouted Discord session keys:

1. **Legacy migration**: `discord:dm:USERID` → `discord:direct:USERID`
2. **Phantom fix**: `discord:channel:USERID` → `discord:direct:USERID` (only when sender ID matches the ID in the key, to avoid accidentally rewriting real channel keys)

This is a targeted, safe fix at the session key resolution layer. The sender ID guard ensures real `discord:channel:` keys for guild channels are never rewritten.

## Testing

- [x] Unit tests added (`session-key.test.ts`) covering all normalization cases and edge cases
- [x] Tested on production instance with 3 agents, 3 Discord bot accounts, `per-channel-peer` dmScope
- [x] Verified: main agent DMs still work, fina/work agent DMs now work, guild channel messages unaffected

## Notes

A more comprehensive upstream fix could also make `parseDiscordTarget` context-aware about DM vs channel targets, but that would be a larger change with wider blast radius. This PR takes the minimal safe approach.