### PR TITLE
cron: infer payload kind for model-only update patches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 - Telegram: replace inbound `<media:audio>` placeholder with successful preflight voice transcript in message body context, preventing placeholder-only prompt bodies for mention-gated voice messages. (#16789) Thanks @Limitless2023.
 - Telegram: retry inbound media `getFile` calls (3 attempts with backoff) and gracefully fall back to placeholder-only processing when retries fail, preventing dropped voice/media messages on transient Telegram network errors. (#16154) Thanks @yinghaosang.
 - Telegram: finalize streaming preview replies in place instead of sending a second final message, preventing duplicate Telegram assistant outputs at stream completion. (#17218) Thanks @obviyus.
+- Cron: infer `payload.kind="agentTurn"` for model-only `cron.update` payload patches, so partial agent-turn updates do not fail validation when `kind` is omitted. (#15664) Thanks @rodrigouroz.
 
 ## 2026.2.14
 

--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+import { handleToolExecutionStart } from "./pi-embedded-subscribe.handlers.tools.js";
+
+function createTestContext() {
+  const onBlockReplyFlush = vi.fn();
+  const warn = vi.fn();
+  const ctx = {
+    params: {
+      runId: "run-test",
+      onBlockReplyFlush,
+      onAgentEvent: undefined,
+      onToolResult: undefined,
+    },
+    flushBlockReplyBuffer: vi.fn(),
+    hookRunner: undefined,
+    log: {
+      debug: vi.fn(),
+      warn,
+    },
+    state: {
+      toolMetaById: new Map<string, string | undefined>(),
+      toolSummaryById: new Set<string>(),
+      pendingMessagingTargets: new Map<string, unknown>(),
+      pendingMessagingTexts: new Map<string, string>(),
+      messagingToolSentTexts: [],
+      messagingToolSentTextsNormalized: [],
+      messagingToolSentTargets: [],
+    },
+    shouldEmitToolResult: () => false,
+    emitToolSummary: vi.fn(),
+    trimMessagingToolSent: vi.fn(),
+  } as const;
+
+  return { ctx, warn, onBlockReplyFlush };
+}
+
+describe("handleToolExecutionStart read path checks", () => {
+  it("does not warn when read tool uses file_path alias", async () => {
+    const { ctx, warn, onBlockReplyFlush } = createTestContext();
+
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "read",
+        toolCallId: "tool-1",
+        args: { file_path: "/tmp/example.txt" },
+      } as never,
+    );
+
+    expect(onBlockReplyFlush).toHaveBeenCalledTimes(1);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("warns when read tool has neither path nor file_path", async () => {
+    const { ctx, warn } = createTestContext();
+
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "read",
+        toolCallId: "tool-2",
+        args: {},
+      } as never,
+    );
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0]?.[0] ?? "")).toContain("read tool called without path");
+  });
+});

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -75,12 +75,13 @@ export async function handleToolExecutionStart(
 
   if (toolName === "read") {
     const record = args && typeof args === "object" ? (args as Record<string, unknown>) : {};
-    const filePath =
+    const filePathValue =
       typeof record.path === "string"
-        ? record.path.trim()
+        ? record.path
         : typeof record.file_path === "string"
-          ? record.file_path.trim()
+          ? record.file_path
           : "";
+    const filePath = filePathValue.trim();
     if (!filePath) {
       const argsPreview = typeof args === "string" ? args.slice(0, 200) : undefined;
       ctx.log.warn(

--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { normalizeCronJobCreate } from "./normalize.js";
+import { normalizeCronJobCreate, normalizeCronJobPatch } from "./normalize.js";
 
 describe("normalizeCronJobCreate", () => {
   it("maps legacy payload.provider to payload.channel and strips provider", () => {
@@ -291,5 +291,19 @@ describe("normalizeCronJobCreate", () => {
     const delivery = normalized.delivery as Record<string, unknown>;
     expect(delivery.mode).toBeUndefined();
     expect(delivery.to).toBe("123");
+  });
+});
+
+describe("normalizeCronJobPatch", () => {
+  it("infers agentTurn kind for model-only payload patches", () => {
+    const normalized = normalizeCronJobPatch({
+      payload: {
+        model: "anthropic/claude-sonnet-4-5",
+      },
+    }) as unknown as Record<string, unknown>;
+
+    const payload = normalized.payload as Record<string, unknown>;
+    expect(payload.kind).toBe("agentTurn");
+    expect(payload.model).toBe("anthropic/claude-sonnet-4-5");
   });
 });

--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -306,4 +306,18 @@ describe("normalizeCronJobPatch", () => {
     expect(payload.kind).toBe("agentTurn");
     expect(payload.model).toBe("anthropic/claude-sonnet-4-5");
   });
+
+  it("does not infer agentTurn kind for delivery-only legacy hints", () => {
+    const normalized = normalizeCronJobPatch({
+      payload: {
+        channel: "telegram",
+        to: "+15550001111",
+      },
+    }) as unknown as Record<string, unknown>;
+
+    const payload = normalized.payload as Record<string, unknown>;
+    expect(payload.kind).toBeUndefined();
+    expect(payload.channel).toBe("telegram");
+    expect(payload.to).toBe("+15550001111");
+  });
 });

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -74,10 +74,22 @@ function coercePayload(payload: UnknownRecord) {
   if (!next.kind) {
     const hasMessage = typeof next.message === "string" && next.message.trim().length > 0;
     const hasText = typeof next.text === "string" && next.text.trim().length > 0;
+    const hasAgentTurnHint =
+      typeof next.model === "string" ||
+      typeof next.thinking === "string" ||
+      typeof next.timeoutSeconds === "number" ||
+      typeof next.allowUnsafeExternalContent === "boolean" ||
+      typeof next.deliver === "boolean" ||
+      typeof next.channel === "string" ||
+      typeof next.to === "string" ||
+      typeof next.bestEffortDeliver === "boolean";
     if (hasMessage) {
       next.kind = "agentTurn";
     } else if (hasText) {
       next.kind = "systemEvent";
+    } else if (hasAgentTurnHint) {
+      // Accept legacy/partial agentTurn payload patches that only tweak model/delivery fields.
+      next.kind = "agentTurn";
     }
   }
   if (typeof next.message === "string") {

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -78,17 +78,13 @@ function coercePayload(payload: UnknownRecord) {
       typeof next.model === "string" ||
       typeof next.thinking === "string" ||
       typeof next.timeoutSeconds === "number" ||
-      typeof next.allowUnsafeExternalContent === "boolean" ||
-      typeof next.deliver === "boolean" ||
-      typeof next.channel === "string" ||
-      typeof next.to === "string" ||
-      typeof next.bestEffortDeliver === "boolean";
+      typeof next.allowUnsafeExternalContent === "boolean";
     if (hasMessage) {
       next.kind = "agentTurn";
     } else if (hasText) {
       next.kind = "systemEvent";
     } else if (hasAgentTurnHint) {
-      // Accept legacy/partial agentTurn payload patches that only tweak model/delivery fields.
+      // Accept partial agentTurn payload patches that only tweak agent-turn-only fields.
       next.kind = "agentTurn";
     }
   }

--- a/src/gateway/server.cron.e2e.test.ts
+++ b/src/gateway/server.cron.e2e.test.ts
@@ -181,6 +181,28 @@ describe("gateway server cron", () => {
       expect(merged?.delivery?.channel).toBe("telegram");
       expect(merged?.delivery?.to).toBe("19098680");
 
+      const modelOnlyPatchRes = await rpcReq(ws, "cron.update", {
+        id: mergeJobId,
+        patch: {
+          payload: {
+            model: "anthropic/claude-sonnet-4-5",
+          },
+        },
+      });
+      expect(modelOnlyPatchRes.ok).toBe(true);
+      const modelOnlyPatched = modelOnlyPatchRes.payload as
+        | {
+            payload?: {
+              kind?: unknown;
+              message?: unknown;
+              model?: unknown;
+            };
+          }
+        | undefined;
+      expect(modelOnlyPatched?.payload?.kind).toBe("agentTurn");
+      expect(modelOnlyPatched?.payload?.message).toBe("hello");
+      expect(modelOnlyPatched?.payload?.model).toBe("anthropic/claude-sonnet-4-5");
+
       const legacyDeliveryPatchRes = await rpcReq(ws, "cron.update", {
         id: mergeJobId,
         patch: {


### PR DESCRIPTION
## Summary
  - fix `cron.update` compatibility for payload patches that include agent-turn fields (for example `payload.model`) without an explicit `payload.kind`
  - infer `payload.kind = "agentTurn"` during cron patch normalization when agent-turn-only hints are present
  - add regression coverage in both normalization unit tests and gateway cron e2e flow

  ## Problem
  `cron.update` can receive partial payload patches from clients/tools. When a patch contains only agent-turn fields (like `model`) and omits `kind`, request validation rejects
  it because `payload.kind` is required by schema.

  ## Root Cause
  Cron patch normalization inferred payload kind for message/text cases, but did not infer kind for model/thinking/timeout/delivery-only agent-turn patches.

  ## Fix
  - extend `normalizeCronJobPatch` path (`normalizeCronJobInput` -> `coercePayload`) to infer `kind: "agentTurn"` when kind is missing and payload contains agent-turn-specific
  fields
  - preserve existing behavior for requests that already include `kind`

  ## Changes
  - `src/cron/normalize.ts`
    - infer agent-turn kind for payload patches containing agent-turn hints
  - `src/cron/normalize.test.ts`
    - add unit regression: model-only payload patch infers `kind: "agentTurn"`
  - `src/gateway/server.cron.e2e.test.ts`
    - add e2e regression: `cron.update` accepts model-only payload patch, keeps existing message, updates model

  ## Safety
  - inference is applied only when `payload.kind` is missing
  - no behavior change for valid explicit-kind requests
  - strict schema validation remains unchanged

  ## Testing
  - `pnpm test src/cron/normalize.test.ts`
  - `pnpm vitest run --config vitest.e2e.config.ts src/gateway/server.cron.e2e.test.ts`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends cron patch normalization so `cron.update` can accept payload patches that only include agent-turn fields (e.g. `payload.model`) without explicitly providing `payload.kind`. The core change is in `src/cron/normalize.ts` where `coercePayload` infers `kind: "agentTurn"` when certain agent-turn “hints” are present, and new unit + e2e tests cover the model-only patch scenario through the gateway handler.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but kind inference logic may be too permissive for delivery-only payload patches.
- Change is small and covered by new unit + e2e tests, but the new agentTurn inference triggers on legacy delivery fields (`channel`/`to`/`deliver`/`bestEffortDeliver`) which can unintentionally coerce otherwise-invalid/ambiguous patches into agentTurn payloads. If that broadening is unintended, it should be tightened before merging.
- src/cron/normalize.ts

<sub>Last reviewed commit: bc3d639</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->