### PR TITLE
fix(feishu): Credentials check bug of Feishu bitable tools when using multiple accounts configuration

### DIFF
--- a/extensions/feishu/src/bitable.ts
+++ b/extensions/feishu/src/bitable.ts
@@ -326,13 +326,16 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
     validCfg = feishuCfg;
   } else {
     // Multiple account mode - check accounts
+  } else {
+    // Multiple account mode - check accounts
     const accounts = listEnabledFeishuAccounts(api.config);
     if (accounts.length === 0) {
       api.logger.debug?.("feishu_bitable: No Feishu accounts with credentials configured, skipping bitable tools");
       return;
     }
-    // Use the first account with credentials
-    validCfg = accounts[0].config;
+    // Use the first account with credentials (include accountId for proper caching)
+    const account = accounts[0];
+    validCfg = { ...account.config, accountId: account.accountId };
   }
 
   const getClient = () => createFeishuClient(validCfg);

--- a/extensions/feishu/src/bitable.ts
+++ b/extensions/feishu/src/bitable.ts
@@ -2,6 +2,7 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { Type } from "@sinclair/typebox";
 import type { FeishuConfig } from "./types.js";
 import { createFeishuClient } from "./client.js";
+import { listEnabledFeishuAccounts } from "./accounts.js";
 
 // ============ Helpers ============
 
@@ -310,13 +311,31 @@ const UpdateRecordSchema = Type.Object({
 // ============ Tool Registration ============
 
 export function registerFeishuBitableTools(api: OpenClawPluginApi) {
-  const feishuCfg = api.config?.channels?.feishu as FeishuConfig | undefined;
-  if (!feishuCfg?.appId || !feishuCfg?.appSecret) {
-    api.logger.debug?.("feishu_bitable: Feishu credentials not configured, skipping bitable tools");
+  if (!api.config) {
+    api.logger.debug?.("feishu_bitable: No config available, skipping bitable tools");
     return;
   }
 
-  const getClient = () => createFeishuClient(feishuCfg);
+  let validCfg: FeishuConfig;
+
+  const feishuCfg = api.config?.channels?.feishu as FeishuConfig | undefined;
+  
+  // Try single account config first (backward compatible)
+  if (feishuCfg?.appId && feishuCfg?.appSecret) {
+    // Single account mode - use top-level config
+    validCfg = feishuCfg;
+  } else {
+    // Multiple account mode - check accounts
+    const accounts = listEnabledFeishuAccounts(api.config);
+    if (accounts.length === 0) {
+      api.logger.debug?.("feishu_bitable: No Feishu accounts with credentials configured, skipping bitable tools");
+      return;
+    }
+    // Use the first account with credentials
+    validCfg = accounts[0].config;
+  }
+
+  const getClient = () => createFeishuClient(validCfg);
 
   // Tool 0: feishu_bitable_get_meta (helper to parse URLs)
   api.registerTool(

--- a/extensions/feishu/src/bitable.ts
+++ b/extensions/feishu/src/bitable.ts
@@ -326,8 +326,6 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
     validCfg = feishuCfg;
   } else {
     // Multiple account mode - check accounts
-  } else {
-    // Multiple account mode - check accounts
     const accounts = listEnabledFeishuAccounts(api.config);
     if (accounts.length === 0) {
       api.logger.debug?.("feishu_bitable: No Feishu accounts with credentials configured, skipping bitable tools");


### PR DESCRIPTION
## Problem

(A cleaner version of https://github.com/openclaw/openclaw/pull/15637)
When using the multiple accounts configuration described in [the documentation](https://docs.openclaw.ai/channels/feishu#multiple-accounts), the appId and appSecret are defined in the nested under accounts.main. Meanwhile, the [registration function of the bitable tools](https://github.com/openclaw/openclaw/blob/45b9aad0f4384ce16f99885f86a5dd7488638c47/extensions/feishu/src/bitable.ts#L314) checks that both feishuCfg?.appId and feishuCfg?.appSecret exist, which won't under the multi-accounts configuration.

This leads to the registration failure of the bitable tools described in extensions/feishu/src/bitable.ts, causing the agent to be unable to operate in any bitable in feishu.

## Fix

This pr fixes this by adding support to both single- and multi-accounts. When using a single-account configuration, the config is directly passed to createFeishuClient. When one of appId and appSecret is not found, it switches to the multi-accounts configuration and filters accounts with appId and appSecret checks, then use the cfg of the first account with credential to create feishu client.

## Related Issues

https://github.com/openclaw/openclaw/issues/15590

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates Feishu bitable tool registration to support both single-account configs (top-level `appId`/`appSecret`) and multi-account configs (credentials nested under `channels.feishu.accounts.*`). It does so by selecting either the top-level Feishu config or the first enabled+configured account returned by `listEnabledFeishuAccounts`, then using that config to create the Feishu client used by the bitable tools.

One issue to address before merge: in multi-account mode the chosen config omits `accountId`, which interacts poorly with `createFeishuClient`'s per-`accountId` cache and can lead to client cache collisions and wrong credentials being used.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but fix the multi-account client cache collision first.
- Changes are localized to Feishu bitable tool registration and correctly add multi-account credential discovery, but multi-account mode currently drops `accountId`, which can cause `createFeishuClient` to reuse/overwrite the cached client under the default cache key and lead to incorrect credentials being used.
- extensions/feishu/src/bitable.ts

<sub>Last reviewed commit: c8675c1</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->