### PR TITLE
fix(telegram): persist relative session transcript paths

### DIFF
--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -338,16 +338,18 @@ export async function initSessionState(params: {
     if (forked) {
       sessionId = forked.sessionId;
       sessionEntry.sessionId = forked.sessionId;
-      sessionEntry.sessionFile = forked.sessionFile;
+      // Persist relative transcript filenames in session store.
+      // Absolute paths are rejected by resolveSessionFilePath() strict checks.
+      sessionEntry.sessionFile = path.basename(forked.sessionFile);
       console.warn(`[session-init] forked session created: file=${forked.sessionFile}`);
     }
   }
   if (!sessionEntry.sessionFile) {
-    sessionEntry.sessionFile = resolveSessionTranscriptPath(
+    sessionEntry.sessionFile = path.basename(resolveSessionTranscriptPath(
       sessionEntry.sessionId,
       agentId,
       ctx.MessageThreadId,
-    );
+    ));
   }
   if (isNewSession) {
     sessionEntry.compactionCount = 0;


### PR DESCRIPTION
## Summary
- fix session-state persistence to store `sessionFile` as a relative filename instead of an absolute path
- normalize both normal and forked-session transcript path assignment via `path.basename(...)`
- prevents Telegram inbound handler failures caused by strict sessions-dir validation rejecting absolute `sessionFile` values

## Verification
- reproduced failure locally with logs showing `Session file path must be within sessions directory` on inbound Telegram messages
- applied equivalent runtime patch and confirmed Telegram responses resumed
- ported fix to source in `src/auto-reply/reply/session.ts`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts session-state persistence in `src/auto-reply/reply/session.ts` so `sessionEntry.sessionFile` is stored as a relative filename (via `path.basename(...)`) for both newly created sessions and forked sessions. This aligns persisted state with `resolveSessionFilePath(...)` strict containment checks in `src/config/sessions/paths.ts`, avoiding failures when absolute paths would be rejected as “not within sessions directory.”

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is narrowly scoped to session-file persistence and is consistent with the existing path-validation logic (which expects a within-sessions-dir relative path). Repository code confirms transcript paths are simple filenames, so using `path.basename` will not drop required subdirectory information.
- src/auto-reply/reply/session.ts

<sub>Last reviewed commit: 3bd7b82</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->