### PR TITLE
fix: propagate provider headers to inline model objects

### DIFF
--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -112,6 +112,24 @@ describe("buildInlineProviderModels", () => {
     expect(result[0].headers).toEqual({ "User-Agent": "claude-code/2.1.0", "X-Custom": "value" });
   });
 
+  it("model-level headers take precedence over provider-level headers", () => {
+    const providers = {
+      custom: {
+        baseUrl: "http://localhost:8000",
+        headers: { "User-Agent": "provider-default", "X-Provider": "keep" },
+        models: [{ ...makeModel("custom-model"), headers: { "User-Agent": "model-override" } }],
+      },
+    };
+
+    const result = buildInlineProviderModels(providers);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].headers).toEqual({
+      "User-Agent": "model-override",
+      "X-Provider": "keep",
+    });
+  });
+
   it("inherits both baseUrl and api from provider config", () => {
     const providers = {
       custom: {

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -40,12 +40,14 @@ describe("buildInlineProviderModels", () => {
         provider: "alpha",
         baseUrl: "http://alpha.local",
         api: undefined,
+        headers: undefined,
       },
       {
         ...makeModel("beta-model"),
         provider: "beta",
         baseUrl: "http://beta.local",
         api: undefined,
+        headers: undefined,
       },
     ]);
   });
@@ -92,6 +94,22 @@ describe("buildInlineProviderModels", () => {
 
     expect(result).toHaveLength(1);
     expect(result[0].api).toBe("anthropic-messages");
+  });
+
+  it("inherits headers from provider config", () => {
+    const providers = {
+      custom: {
+        baseUrl: "http://localhost:8000",
+        api: "anthropic-messages",
+        headers: { "User-Agent": "claude-code/2.1.0", "X-Custom": "value" },
+        models: [makeModel("custom-model")],
+      },
+    };
+
+    const result = buildInlineProviderModels(providers);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].headers).toEqual({ "User-Agent": "claude-code/2.1.0", "X-Custom": "value" });
   });
 
   it("inherits both baseUrl and api from provider config", () => {

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -16,6 +16,7 @@ type InlineModelEntry = ModelDefinitionConfig & { provider: string; baseUrl?: st
 type InlineProviderConfig = {
   baseUrl?: string;
   api?: ModelDefinitionConfig["api"];
+  headers?: Record<string, string>;
   models?: ModelDefinitionConfig[];
 };
 

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -214,6 +214,7 @@ export function buildInlineProviderModels(
       provider: trimmed,
       baseUrl: entry?.baseUrl,
       api: model.api ?? entry?.api,
+      headers: entry?.headers,
     }));
   });
 }

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -214,7 +214,9 @@ export function buildInlineProviderModels(
       provider: trimmed,
       baseUrl: entry?.baseUrl,
       api: model.api ?? entry?.api,
-      headers: entry?.headers,
+      headers: entry?.headers || model.headers
+        ? { ...entry?.headers, ...model.headers }
+        : undefined,
     }));
   });
 }

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -214,9 +214,8 @@ export function buildInlineProviderModels(
       provider: trimmed,
       baseUrl: entry?.baseUrl,
       api: model.api ?? entry?.api,
-      headers: entry?.headers || model.headers
-        ? { ...entry?.headers, ...model.headers }
-        : undefined,
+      headers:
+        entry?.headers || model.headers ? { ...entry?.headers, ...model.headers } : undefined,
     }));
   });
 }


### PR DESCRIPTION
## Summary
- `buildInlineProviderModels()` passes `baseUrl` and `api` from provider config to model objects, but omits `headers`
- This causes custom HTTP headers (e.g. `User-Agent` overrides) to be silently ignored for all chat/reply API requests
- One-line fix: add `headers: entry?.headers` to the model spread

## Context
When using a custom provider with an Anthropic-compatible proxy that validates `User-Agent`, the configured headers are never sent. The Anthropic SDK sends its default `User-Agent: Anthropic/JS <version>`, which gets rejected by the proxy (403).

The `pi-ai` Anthropic provider already supports `model.headers` via `mergeHeaders()` in `defaultHeaders`, and the runner entry (`runner-*.js`) already reads `providerConfig?.headers` — only the main reply path was missing it.

This is a follow-up to #2740 which fixed the same class of bug for `baseUrl` but missed `headers`.

Fixes #15682

## Changes
- `src/agents/pi-embedded-runner/model.ts` — add `headers: entry?.headers` to `buildInlineProviderModels()`
- `src/agents/pi-embedded-runner/model.test.ts` — add test for headers propagation, update existing snapshot

## Test plan
- [x] Added unit test: `inherits headers from provider config`
- [x] Updated existing snapshot test to include `headers` field
- [ ] Verify with a custom provider that requires specific `User-Agent`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates `buildInlineProviderModels()` to propagate provider-level HTTP `headers` into the inline model objects, and adds a unit test + snapshot update to validate that propagation.

The code lives in the pi-embedded runner model resolution path (`src/agents/pi-embedded-runner/model.ts`), which builds the inline model entries that `resolveModel()` can normalize and return when a model isn’t found in the registry.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but there is one correctness issue around header precedence that can drop per-model headers for inline models.
- The PR is small and well-tested for provider-level header propagation, but the current implementation unconditionally assigns provider headers and can override existing model-level headers (a supported config field), changing behavior for users relying on per-model header customization.
- src/agents/pi-embedded-runner/model.ts

<sub>Last reviewed commit: 35c99bf</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->