### PR TITLE
feat(browser): add browser.args config field for custom Chrome launch flags (#14803)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Docs: https://docs.openclaw.ai
 - Skills: remove duplicate `local-places` Google Places skill/proxy and keep `goplaces` as the single supported Google Places path.
 - Discord: send voice messages with waveform previews from local audio files (including silent delivery). (#7253) Thanks @nyanjou.
 - Discord: add configurable presence status/activity/type/url (custom status defaults to activity text). (#10855) Thanks @h0tp-ftw.
+- Browser: add `browser.args` config field for custom Chrome launch flags (e.g. `--use-angle=vulkan`). (#14803)
 
 ### Fixes
 

--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -62,6 +62,7 @@ function buildSandboxBrowserResolvedConfig(params: {
     headless: params.headless,
     noSandbox: false,
     attachOnly: true,
+    args: [],
     defaultProfile: DEFAULT_OPENCLAW_BROWSER_PROFILE_NAME,
     profiles: {
       [DEFAULT_OPENCLAW_BROWSER_PROFILE_NAME]: {

--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -217,6 +217,11 @@ export async function launchOpenClawChrome(
     // Stealth: hide navigator.webdriver from automation detection (#80)
     args.push("--disable-blink-features=AutomationControlled");
 
+    // Append user-supplied extra Chrome flags (#14803).
+    for (const extra of resolved.args) {
+      args.push(extra);
+    }
+
     // Always open a blank tab to ensure a target exists.
     args.push("about:blank");
 

--- a/src/browser/config.test.ts
+++ b/src/browser/config.test.ts
@@ -140,6 +140,25 @@ describe("browser config", () => {
     expect(() => resolveBrowserConfig({ cdpUrl: "ws://127.0.0.1:18791" })).toThrow(/must be http/i);
   });
 
+  it("passes extra args through to resolved config (#14803)", () => {
+    const resolved = resolveBrowserConfig({
+      args: ["--use-angle=vulkan", "--enable-features=Vulkan"],
+    });
+    expect(resolved.args).toEqual(["--use-angle=vulkan", "--enable-features=Vulkan"]);
+  });
+
+  it("defaults args to empty array when omitted", () => {
+    const resolved = resolveBrowserConfig(undefined);
+    expect(resolved.args).toEqual([]);
+  });
+
+  it("filters out non-string and empty args entries", () => {
+    const resolved = resolveBrowserConfig({
+      args: ["--valid", "", 42, null, "--also-valid"] as unknown as string[],
+    });
+    expect(resolved.args).toEqual(["--valid", "--also-valid"]);
+  });
+
   it("does not add the built-in chrome extension profile if the derived relay port is already used", () => {
     const resolved = resolveBrowserConfig({
       profiles: {

--- a/src/browser/config.ts
+++ b/src/browser/config.ts
@@ -29,6 +29,7 @@ export type ResolvedBrowserConfig = {
   headless: boolean;
   noSandbox: boolean;
   attachOnly: boolean;
+  args: string[];
   defaultProfile: string;
   profiles: Record<string, BrowserProfileConfig>;
 };
@@ -210,6 +211,7 @@ export function resolveBrowserConfig(
     headless,
     noSandbox,
     attachOnly,
+    args: Array.isArray(cfg?.args) ? cfg.args.filter((a) => typeof a === "string" && a.trim()) : [],
     defaultProfile,
     profiles,
   };

--- a/src/config/types.browser.ts
+++ b/src/config/types.browser.ts
@@ -36,6 +36,8 @@ export type BrowserConfig = {
   defaultProfile?: string;
   /** Named browser profiles with explicit CDP ports or URLs. */
   profiles?: Record<string, BrowserProfileConfig>;
+  /** Extra Chrome launch arguments appended to the built-in flags. */
+  args?: string[];
   /** Default snapshot options (applied by the browser tool/CLI when unset). */
   snapshotDefaults?: BrowserSnapshotDefaults;
 };


### PR DESCRIPTION
## Summary

Add a `browser.args` config field that lets users append custom Chrome launch flags to the built-in set. This enables hardware-accelerated WebGL, custom ANGLE backends, and other Chrome flags without patching source code.

**Example config:**

```json
{
  "browser": {
    "enabled": true,
    "headless": true,
    "args": ["--use-angle=vulkan", "--enable-features=Vulkan"]
  }
}
```

## Problem

Chrome launch arguments in `launchOpenClawChrome` are entirely hardcoded. Users with GPU-capable servers (e.g. AMD Radeon iGPU with Vulkan 1.4) cannot enable hardware-accelerated WebGL because `--headless=new --disable-gpu` is always passed and there is no way to add `--use-angle=vulkan`.

## Before (on main — real environment)

### Config level

Called the real `resolveBrowserConfig` with `args: ["--use-angle=vulkan", "--enable-features=Vulkan"]`:

```
resolved config keys: enabled, evaluateEnabled, controlPort, cdpProtocol, cdpHost, cdpIsLoopback,
  remoteCdpTimeoutMs, remoteCdpHandshakeTimeoutMs, color, executablePath, headless, noSandbox,
  attachOnly, defaultProfile, profiles
has "args" in resolved: false
❌ FEATURE GAP CONFIRMED (config): browser.args is silently dropped by resolveBrowserConfig
```

### Launch level

Called the real `launchOpenClawChrome` → real `spawnOnce()`, captured the full Chrome args array:

```
Chrome spawn args (15): --remote-debugging-port=19999 --user-data-dir=...
  --no-first-run --no-default-browser-check --disable-sync
  --disable-background-networking --disable-component-update
  --disable-features=Translate,MediaRouter --disable-session-crashed-bubble
  --hide-crash-restore-bubble --password-store=basic --headless=new
  --disable-gpu --disable-blink-features=AutomationControlled about:blank
Contains --use-angle=vulkan: false
❌ FEATURE GAP CONFIRMED (launch): no mechanism to pass custom flags to Chrome
```

## After (on fix branch)

```
✓ passes extra args through to resolved config (#14803)
✓ defaults args to empty array when omitted
✓ filters out non-string and empty args entries

Test Files  1 passed (1)
     Tests  15 passed (15)
```

## Changes

- `src/config/types.browser.ts`: add `args?: string[]` to `BrowserConfig`
- `src/browser/config.ts`: add `args: string[]` to `ResolvedBrowserConfig`, parse and filter in `resolveBrowserConfig`
- `src/browser/chrome.ts`: append `resolved.args` to Chrome launch arguments in `spawnOnce()` (before the final `about:blank` positional arg)
- `src/browser/config.test.ts`: add 3 regression tests (passthrough, default empty, filter invalid entries)
- `CHANGELOG.md`: add entry

Closes #14803
