### PR TITLE
fix(onboard): remove duplicate description causing auth/model prompts to be skipped

### DIFF
--- a/src/cli/program/register.onboard.ts
+++ b/src/cli/program/register.onboard.ts
@@ -58,7 +58,7 @@ export function registerOnboardCommand(program: Command) {
     .option("--mode <mode>", "Wizard mode: local|remote")
     .option(
       "--auth-choice <choice>",
-      "Auth: setup-token|token|chutes|openai-codex|openai-api-key|xai-api-key|qianfan-api-key|openrouter-api-key|litellm-api-key|ai-gateway-api-key|cloudflare-ai-gateway-api-key|moonshot-api-key|moonshot-api-key-cn|kimi-code-api-key|synthetic-api-key|venice-api-key|gemini-api-key|zai-api-key|zai-coding-global|zai-coding-cn|zai-global|zai-cn|xiaomi-api-key|apiKey|minimax-api|minimax-api-lightning|opencode-zen|custom-api-key|skip|together-api-key|huggingface-api-key",
+      "Auth: setup-token|token|chutes|vllm|openai-codex|openai-api-key|xai-api-key|qianfan-api-key|openrouter-api-key|litellm-api-key|ai-gateway-api-key|cloudflare-ai-gateway-api-key|moonshot-api-key|moonshot-api-key-cn|kimi-code-api-key|synthetic-api-key|venice-api-key|gemini-api-key|zai-api-key|zai-coding-global|zai-coding-cn|zai-global|zai-cn|xiaomi-api-key|apiKey|minimax-api|minimax-api-lightning|opencode-zen|custom-api-key|skip|together-api-key|huggingface-api-key",
     )
     .option(
       "--token-provider <id>",

--- a/src/cli/program/register.onboard.ts
+++ b/src/cli/program/register.onboard.ts
@@ -59,7 +59,6 @@ export function registerOnboardCommand(program: Command) {
     .option(
       "--auth-choice <choice>",
       "Auth: setup-token|token|chutes|openai-codex|openai-api-key|xai-api-key|qianfan-api-key|openrouter-api-key|litellm-api-key|ai-gateway-api-key|cloudflare-ai-gateway-api-key|moonshot-api-key|moonshot-api-key-cn|kimi-code-api-key|synthetic-api-key|venice-api-key|gemini-api-key|zai-api-key|zai-coding-global|zai-coding-cn|zai-global|zai-cn|xiaomi-api-key|apiKey|minimax-api|minimax-api-lightning|opencode-zen|custom-api-key|skip|together-api-key|huggingface-api-key",
-      "Auth: setup-token|token|chutes|vllm|openai-codex|openai-api-key|xai-api-key|qianfan-api-key|openrouter-api-key|litellm-api-key|ai-gateway-api-key|cloudflare-ai-gateway-api-key|moonshot-api-key|moonshot-api-key-cn|kimi-code-api-key|synthetic-api-key|venice-api-key|gemini-api-key|zai-api-key|zai-coding-global|zai-coding-cn|zai-global|zai-cn|xiaomi-api-key|apiKey|minimax-api|minimax-api-lightning|opencode-zen|custom-api-key|skip|together-api-key|huggingface-api-key",
     )
     .option(
       "--token-provider <id>",


### PR DESCRIPTION
## Problem

Running `openclaw onboard` skips the authentication selection and model selection prompts, jumping directly to gateway configuration.

## Root Cause

The `--auth-choice` option incorrectly has two identical description strings. Commander.js interprets the third parameter as a default value, causing `opts.authChoice` to always be set to the description string instead of `undefined`.

## Solution

Remove the duplicate description string (line 62), keeping only the proper description parameter.

## Testing

- ✅ Build completes successfully
- ✅ Passes lint and format checks
- ✅ The option now correctly has no default value

## Impact

**Before:** Auth and model prompts are skipped
**After:** Users are properly prompted during onboarding

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change fixes `openclaw onboard` option parsing by removing a duplicated third argument in the `--auth-choice` Commander `.option()` call, which was being treated as a default value and could cause onboarding to skip interactive auth/model prompts.

The update is localized to the CLI command registration (`src/cli/program/register.onboard.ts`) and affects how onboarding options are passed into `onboardCommand`.

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge, but the CLI help text for `--auth-choice` appears to be inaccurate after the change.
- The functional fix (removing the unintended default value) is straightforward and should restore interactive prompting. The remaining concern is user-facing correctness: `vllm` is a supported AuthChoice in the codebase but is not listed in the `--auth-choice` help string, which can mislead users.
- src/cli/program/register.onboard.ts

<sub>Last reviewed commit: d371c1d</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->