### PR TITLE
agents: accept file_path alias in read-path warning check

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+import { handleToolExecutionStart } from "./pi-embedded-subscribe.handlers.tools.js";
+
+function createTestContext() {
+  const onBlockReplyFlush = vi.fn();
+  const warn = vi.fn();
+  const ctx = {
+    params: {
+      runId: "run-test",
+      onBlockReplyFlush,
+      onAgentEvent: undefined,
+      onToolResult: undefined,
+    },
+    flushBlockReplyBuffer: vi.fn(),
+    hookRunner: undefined,
+    log: {
+      debug: vi.fn(),
+      warn,
+    },
+    state: {
+      toolMetaById: new Map<string, string | undefined>(),
+      toolSummaryById: new Set<string>(),
+      pendingMessagingTargets: new Map<string, unknown>(),
+      pendingMessagingTexts: new Map<string, string>(),
+      messagingToolSentTexts: [],
+      messagingToolSentTextsNormalized: [],
+      messagingToolSentTargets: [],
+    },
+    shouldEmitToolResult: () => false,
+    emitToolSummary: vi.fn(),
+    trimMessagingToolSent: vi.fn(),
+  } as const;
+
+  return { ctx, warn, onBlockReplyFlush };
+}
+
+describe("handleToolExecutionStart read path checks", () => {
+  it("does not warn when read tool uses file_path alias", async () => {
+    const { ctx, warn, onBlockReplyFlush } = createTestContext();
+
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "read",
+        toolCallId: "tool-1",
+        args: { file_path: "/tmp/example.txt" },
+      } as never,
+    );
+
+    expect(onBlockReplyFlush).toHaveBeenCalledTimes(1);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("warns when read tool has neither path nor file_path", async () => {
+    const { ctx, warn } = createTestContext();
+
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "read",
+        toolCallId: "tool-2",
+        args: {},
+      } as never,
+    );
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0]?.[0] ?? "")).toContain("read tool called without path");
+  });
+});

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -75,12 +75,13 @@ export async function handleToolExecutionStart(
 
   if (toolName === "read") {
     const record = args && typeof args === "object" ? (args as Record<string, unknown>) : {};
-    const filePath =
+    const filePathValue =
       typeof record.path === "string"
-        ? record.path.trim()
+        ? record.path
         : typeof record.file_path === "string"
-          ? record.file_path.trim()
+          ? record.file_path
           : "";
+    const filePath = filePathValue.trim();
     if (!filePath) {
       const argsPreview = typeof args === "string" ? args.slice(0, 200) : undefined;
       ctx.log.warn(


### PR DESCRIPTION
## Summary
  Reduce false-positive embedded-agent warnings for read tool calls by recognizing `file_path` as a valid alias at warning time.

  ## Problem
  Logs showed frequent warnings:

  `[agent/embedded] read tool called without path ...`

  Even when read-tool calls were valid and used `file_path` (Claude-style alias), these warnings were emitted because the warning check only inspected `args.path`.

  ## Root Cause
  There was a mismatch between:
  - read-tool argument normalization, which supports `file_path -> path`
  - tool-start warning logic, which only checked `path`

  So valid alias-based calls could produce noisy false warnings.

  ## Fix
  In `handleToolExecutionStart` for `read`:
  - treat both `path` and `file_path` as valid path sources before deciding to warn

  ## Changes
  - `src/agents/pi-embedded-subscribe.handlers.tools.ts`
    - warning guard now accepts `record.file_path` alias
  - `src/agents/pi-embedded-subscribe.handlers.tools.test.ts` (new)
    - does not warn when `file_path` is provided
    - still warns when neither `path` nor `file_path` is provided

  ## Why this is safe
  - logging-only behavior adjustment
  - does not change read tool execution behavior
  - preserves warnings for truly missing path arguments

  ## Testing
  - `pnpm test src/agents/pi-embedded-subscribe.handlers.tools.test.ts`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the embedded-agent `handleToolExecutionStart` warning guard for the `read` tool to treat `args.file_path` as a valid alias for `args.path`, reducing false-positive warnings (`read tool called without path`). It also adds a Vitest regression test covering both the alias case (no warning) and the missing-path case (still warns).

The change is isolated to logging behavior at tool-start time and doesn’t alter read tool execution or argument normalization elsewhere.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The code change is a small, well-scoped adjustment to a warning guard (logging-only) and the added test covers the intended behavior without affecting tool execution semantics.
- No files require special attention

<sub>Last reviewed commit: 2d9e56e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->