### PR TITLE
gateway: return actionable error for send channel webchat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 - TUI: suppress false `(no output)` placeholders for non-local empty final events during concurrent runs, preventing external-channel replies from showing empty assistant bubbles while a local run is still streaming. (#5782) Thanks @LagWizard and @vignesh07.
 - Auto-reply/WhatsApp/TUI/Web: when a final assistant message is `NO_REPLY` and a messaging tool send succeeded, mirror the delivered messaging-tool text into session-visible assistant output so TUI/Web no longer show `NO_REPLY` placeholders. (#7010) Thanks @Morrowind-Xie.
 - Gateway/Chat: harden `chat.send` inbound message handling by rejecting null bytes, stripping unsafe control characters, and normalizing Unicode to NFC before dispatch. (#8593) Thanks @fr33d3m0n.
+- Gateway/Send: return an actionable error when `send` targets internal-only `webchat`, guiding callers to use `chat.send` or a deliverable channel. (#15703) Thanks @rodrigouroz.
 - Gateway/Security: redact sensitive session/path details from `status` responses for non-admin clients; full details remain available to `operator.admin`. (#8590) Thanks @fr33d3m0n.
 - Agents: return an explicit timeout error reply when an embedded run times out before producing any payloads, preventing silent dropped turns during slow cache-refresh transitions. (#16659) Thanks @liaosvcaf and @vignesh07.
 - Agents/OpenAI: force `store=true` for direct OpenAI Responses/Codex runs to preserve multi-turn server-side conversation state, while leaving proxy/non-OpenAI endpoints unchanged. (#16803) Thanks @mark9232 and @vignesh07.

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -106,6 +106,18 @@ export const sendHandlers: GatewayRequestHandlers = {
     const channelInput = typeof request.channel === "string" ? request.channel : undefined;
     const normalizedChannel = channelInput ? normalizeChannelId(channelInput) : null;
     if (channelInput && !normalizedChannel) {
+      const normalizedInput = channelInput.trim().toLowerCase();
+      if (normalizedInput === "webchat") {
+        respond(
+          false,
+          undefined,
+          errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            "unsupported channel: webchat (internal-only). Use `chat.send` for WebChat UI messages or choose a deliverable channel.",
+          ),
+        );
+        return;
+      }
       respond(
         false,
         undefined,


### PR DESCRIPTION
## Summary
  Improve `send` RPC UX for `channel=webchat` by returning an actionable error instead of a generic unsupported-channel message.

  ## Problem
  Users can pass `channel: "webchat"` to `send`. `webchat` is an internal UI surface, not a deliverable outbound channel, so `send` rejects it.

  Before this change, the error was generic (`unsupported channel: webchat`) and did not explain what to do instead.

  ## Fix
  Add a `webchat`-specific error path in `send` validation:

  - detect `channelInput === "webchat"` (case-insensitive)
  - return an explicit guidance message:
    - webchat is internal-only
    - use `chat.send` for WebChat UI messages
    - otherwise pick a deliverable channel

  ## Changes
  - `src/gateway/server-methods/send.ts`
    - added dedicated `webchat` guidance error branch when channel normalization fails for `webchat`
  - `src/gateway/server-methods/send.test.ts`
    - added regression test:
      - no outbound delivery attempt for `channel=webchat`
      - response contains actionable guidance (`unsupported channel: webchat`, `Use \`chat.send\``)

  ## Why this is safe
  - validation-only change
  - no outbound delivery behavior changes for supported channels
  - preserves existing rejection semantics for unsupported channels, while improving message quality for this known case

  ## Testing
  - `pnpm test src/gateway/server-methods/send.test.ts`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change improves `send` RPC validation by adding a dedicated rejection path when callers pass `channel=webchat` (case-insensitive), returning an actionable message that explains WebChat is internal-only and directs users to `chat.send`.

Test coverage was extended in `send.test.ts` to assert that `channel=webchat` yields the new guidance and that no outbound delivery is attempted in that case.

<h3>Confidence Score: 4/5</h3>

- This PR is close to safe to merge, with one test mock mismatch that can hide the intended case-insensitive behavior.
- Core behavior change is small and isolated to request validation, but the new regression test’s `normalizeChannelId` mock does not mirror production normalization, so it can miss the primary behavior the PR claims to guarantee (case-insensitive detection).
- src/gateway/server-methods/send.test.ts

<sub>Last reviewed commit: 09393d0</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->