### PR TITLE
feat(skills): add guardskills — security scanner for skill installs

### DIFF
--- a/skills/guardskills/SKILL.md
+++ b/skills/guardskills/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: guardskills
+description: Security gate for skill installs. Scans skill content for malicious patterns (credential exfiltration, remote code execution, destructive ops, privilege escalation) before installation. Always run guardskills before installing any skill from ClawHub, GitHub, or local sources.
+homepage: https://github.com/felixondesk/guardskills
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🛡️",
+        "requires": { "bins": ["guardskills"] },
+        "install":
+          [
+            {
+              "id": "node",
+              "kind": "node",
+              "package": "guardskills",
+              "bins": ["guardskills"],
+              "label": "Install guardskills (npm)",
+            },
+          ],
+      },
+  }
+---
+
+# GuardSkills — Security Scanner for Skills
+
+Static analysis security gate. Scans skill files for malicious patterns and produces a risk decision before allowing installation.
+
+## Rule — ALWAYS scan before installing
+
+Before installing any skill (ClawHub, GitHub, local, or skills.sh), you MUST run a guardskills scan first. Never run `clawhub install`, `skills add`, or copy skill files without scanning.
+
+## Scan by source
+
+### 1. ClawHub skills
+
+When the user asks to install a ClawHub skill, scan it first:
+
+```bash
+guardskills scan-clawhub <owner/skill-slug>
+```
+
+Also accepts full URLs:
+
+```bash
+guardskills scan-clawhub https://clawhub.ai/owner/skill-slug
+```
+
+### 2. Local skills
+
+When loading or reviewing a skill folder on disk:
+
+```bash
+guardskills scan-local <path-to-skill-folder>
+```
+
+If the path contains multiple skills:
+
+```bash
+guardskills scan-local <path-to-skills-root> --skill <skill-folder-name>
+```
+
+### 3. GitHub skills
+
+When installing from a GitHub repository:
+
+```bash
+guardskills add owner/repo --skill <skill-name> --dry-run
+```
+
+Also accepts full URLs:
+
+```bash
+guardskills add https://github.com/owner/repo --skill <skill-name> --dry-run
+```
+
+### 4. skills.sh skills
+
+Use the same GitHub flow:
+
+```bash
+guardskills add owner/repo --skill <skill-name> --dry-run
+```
+
+If scan passes:
+
+```bash
+guardskills add owner/repo --skill <skill-name>
+```
+
+## How to interpret results
+
+| Decision       | Action                                                       |
+| -------------- | ------------------------------------------------------------ |
+| `SAFE`         | Proceed with installation.                                   |
+| `WARNING`      | Ask the user for confirmation before proceeding.             |
+| `UNSAFE`       | Block. Tell the user the skill is unsafe and do not install.  |
+| `CRITICAL`     | Block. Do not install under any circumstances.               |
+| `UNVERIFIABLE` | Block. Inform the user the skill could not be verified.      |
+
+## Useful flags
+
+- `--json` — machine-readable JSON output
+- `--dry-run` — scan only, do not install
+- `--ci` — deterministic gate mode (no prompts, no install)
+- `--strict` — use stricter risk thresholds
+- `--yes` — auto-accept WARNING level (only if user explicitly requests)
+- `--force` — override UNSAFE block (only if user explicitly requests)
+- `--allow-unverifiable` — override UNVERIFIABLE block (only if user explicitly requests)
+
+## Exit codes
+
+- `0` — allowed / safe
+- `10` — warning not confirmed
+- `20` — blocked (UNSAFE, CRITICAL, or UNVERIFIABLE)
+- `30` — runtime / internal error
+
+## Recommended workflow
+
+1. User asks to install a skill.
+2. Determine the source (ClawHub, GitHub, local, skills.sh).
+3. Run the appropriate `guardskills` scan command.
+4. Read the decision from the output.
+5. If `SAFE`, proceed with `clawhub install` or equivalent.
+6. If `WARNING`, inform the user and ask for confirmation.
+7. If `UNSAFE`, `CRITICAL`, or `UNVERIFIABLE`, block and explain why.
+8. Never skip the scan step.
+
+## Notes
+
+- guardskills is an additional security layer, not a replacement for manual review.
+- A `SAFE` result means no known high-risk patterns were detected, not a guarantee of safety.
+- The scanner checks for: credential exfiltration, remote code execution chains, destructive filesystem operations, privilege escalation, obfuscated payloads, and suspicious network activity.


### PR DESCRIPTION
## Summary

Adds **guardskills** as a bundled skill that scans skill content for malicious patterns before installation.

### Problem

OpenClaw's security notes advise users to "treat third-party skills as untrusted code" but provide no automated tooling to actually do this. ClawHub's moderation is report-based (reactive), meaning malicious skills can be installed before anyone reports them.

### Solution

[guardskills](https://www.npmjs.com/package/guardskills) is a static analysis security gate that scans skill files and produces a risk decision (**SAFE** / **WARNING** / **UNSAFE** / **CRITICAL** / **UNVERIFIABLE**) before allowing installation.

This PR adds a bundled `guardskills` skill (`skills/guardskills/SKILL.md`) that instructs the agent to always run a guardskills scan before installing any skill from any source.

### Supported scan sources

| Source | Command |
|---|---|
| ClawHub | `guardskills scan-clawhub <owner/slug>` |
| Local folders | `guardskills scan-local <path>` |
| GitHub repos | `guardskills add owner/repo --skill <name> --dry-run` |
| skills.sh | `guardskills add owner/repo --skill <name> --dry-run` |

### What it detects

- Credential exfiltration (read secrets + send outbound)
- Remote code execution chains (download | execute, IEX patterns)
- Destructive filesystem operations (rm -rf /, format)
- Privilege escalation (sudo + dangerous commands)
- Obfuscated/encoded payloads (base64 decode + exec)
- Suspicious network activity (outbound POSTs with payloads)

### Install spec

Uses `kind: node` installer (same pattern as the `clawhub` skill):

```bash
npm i -g guardskills
```

### Links

- **npm**: https://www.npmjs.com/package/guardskills
- **GitHub**: https://github.com/felixondesk/guardskills
- **Security policy**: https://github.com/felixondesk/guardskills/blob/main/SECURITY.md

---

AI-assisted PR (built with Antigravity). Fully tested — guardskills has its own test suite with fixture-based scanner tests, gate behavior tests, and integration tests.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new bundled skill `guardskills` (`skills/guardskills/SKILL.md`) that documents how to use the external `guardskills` CLI as a security gate before installing other skills. The frontmatter follows the same `metadata.openclaw`/installer pattern used by other bundled skills (e.g., `clawhub`, `video-frames`) and declares the required binary plus a node-based installer for `guardskills`.


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change set is limited to adding a single new skill markdown file; it follows existing bundled-skill frontmatter conventions already used throughout `skills/**/SKILL.md` and does not modify runtime code paths.
- No files require special attention

<sub>Last reviewed commit: f26bf86</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->