### PR TITLE
Fix/agent session key normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 - Auto-reply/WhatsApp/TUI/Web: when a final assistant message is `NO_REPLY` and a messaging tool send succeeded, mirror the delivered messaging-tool text into session-visible assistant output so TUI/Web no longer show `NO_REPLY` placeholders. (#7010) Thanks @Morrowind-Xie.
 - Gateway/Chat: harden `chat.send` inbound message handling by rejecting null bytes, stripping unsafe control characters, and normalizing Unicode to NFC before dispatch. (#8593) Thanks @fr33d3m0n.
 - Gateway/Send: return an actionable error when `send` targets internal-only `webchat`, guiding callers to use `chat.send` or a deliverable channel. (#15703) Thanks @rodrigouroz.
+- Gateway/Agent: reject malformed `agent:`-prefixed session keys (for example, `agent:main`) in `agent` and `agent.identity.get` instead of silently resolving them to the default agent, preventing accidental cross-session routing. (#15707) Thanks @rodrigouroz.
 - Gateway/Security: redact sensitive session/path details from `status` responses for non-admin clients; full details remain available to `operator.admin`. (#8590) Thanks @fr33d3m0n.
 - Agents: return an explicit timeout error reply when an embedded run times out before producing any payloads, preventing silent dropped turns during slow cache-refresh transitions. (#16659) Thanks @liaosvcaf and @vignesh07.
 - Agents/OpenAI: force `store=true` for direct OpenAI Responses/Codex runs to preserve multi-turn server-side conversation state, while leaving proxy/non-OpenAI endpoints unchanged. (#16803) Thanks @mark9232 and @vignesh07.

--- a/src/gateway/server.agent.gateway-server-agent-a.e2e.test.ts
+++ b/src/gateway/server.agent.gateway-server-agent-a.e2e.test.ts
@@ -285,6 +285,20 @@ describe("gateway server agent", () => {
     expect(spy).not.toHaveBeenCalled();
   });
 
+  test("agent rejects malformed agent-prefixed session keys", async () => {
+    setRegistry(defaultRegistry);
+    const res = await rpcReq(ws, "agent", {
+      message: "hi",
+      sessionKey: "agent:main",
+      idempotencyKey: "idem-agent-malformed-key",
+    });
+    expect(res.ok).toBe(false);
+    expect(res.error?.message).toContain("malformed session key");
+
+    const spy = vi.mocked(agentCommand);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
   test("agent forwards accountId to agentCommand", async () => {
     setRegistry(defaultRegistry);
     testState.allowFrom = ["+1555"];


### PR DESCRIPTION
## Summary

  This PR hardens gateway agent session-key validation so malformed agent-prefixed keys are rejected early and consistently.

  ## Problem

  Malformed values like `agent:main` were not being rejected up front in some agent paths.
  Instead, they could flow deeper into runtime/workspace resolution and fail later with `UNAVAILABLE`-style errors, which made the issue look like infra/runtime instability
  instead of request validation.

  ## Why this matters

  - `agent:*` keys have a strict shape and malformed values are client input errors.
  - Returning `INVALID_REQUEST` early gives clients a stable, actionable contract.
  - It prevents noisy downstream failures and reduces misleading error signals.

  ## Root Cause / Context

  - `agent` handler accepted `sessionKey` strings and trimmed them, but did not explicitly reject malformed `agent:*` shapes before execution.
  - `agent.identity.get` similarly derived agent identity from `sessionKey` without an explicit malformed-shape guard.
  - Main already contains a separate sessions-path compatibility fix (`fix(sessions): normalize absolute sessionFile paths for v2026.2.12 compatibility`), but that does not cover
  malformed `agent:*` request validation in these handlers.

  ## Fix

  ### `src/gateway/server-methods/agent.ts`

  - In `agent`:
    - added early guard using `classifySessionKeyShape(...)`
    - if shape is `malformed_agent`, return:
      - `INVALID_REQUEST`
      - message: `invalid agent params: malformed session key "<key>"`

  - In `agent.identity.get`:
    - added equivalent malformed-shape guard
    - returns:
      - `INVALID_REQUEST`
      - message: `invalid agent.identity.get params: malformed session key "<key>"`

  ## Tests

  ### `src/gateway/server-methods/agent.test.ts`

  - added unit test: rejects malformed agent session keys early in `agent`
  - added unit test: rejects malformed session keys in `agent.identity.get`

  ### `src/gateway/server.agent.gateway-server-agent-a.e2e.test.ts`

  - added e2e test: `agent` rejects malformed agent-prefixed session keys
  - verifies:
    - request fails
    - error mentions malformed session key
    - command dispatch is not executed

  ## Verification run

  - `pnpm test src/gateway/server-methods/agent.test.ts`
  - `pnpm vitest run --config vitest.e2e.config.ts src/gateway/server.agent.gateway-server-agent-a.e2e.test.ts -t "agent rejects malformed agent-prefixed session keys"`

  ## Risk / Compatibility

  Low risk:
  - only affects malformed `agent:*` inputs
  - valid session keys and existing behavior remain unchanged
  - change is additive validation + tests

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds early validation to the gateway `agent` and `agent.identity.get` handlers to reject malformed `agent:*` session keys using `classifySessionKeyShape(...)`, returning `INVALID_REQUEST` instead of allowing downstream failures.

It also adds unit + e2e coverage to ensure malformed `agent:`-prefixed keys (e.g. `agent:main`) fail fast and do not dispatch `agentCommand`.

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge, with one correctness edge case around session-key prefix casing.
- The change is small and well-covered by tests for the malformed `agent:main` case. However, session-key shape classification relies on `parseAgentSessionKey`, which currently treats the `agent` prefix as case-sensitive, so keys like `Agent:...` will be rejected as malformed by the new guards even though they are structurally valid elsewhere in the codebase that lowercases agent keys.
- src/sessions/session-key-utils.ts (parseAgentSessionKey casing)

<sub>Last reviewed commit: dc3a0fa</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->