### PR TITLE
fix(sessions): use model contextWindow instead of agent contextTokens in session listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Clawdock: avoid Zsh readonly variable collisions in helper scripts. (#15501) Thanks @nkelner.
+- Sessions: use model context window instead of agent buffer setting for context token display in session listing. (#15705)
 - Discord: route autoThread replies to existing threads instead of the root channel. (#8302) Thanks @gavinbmoore, @thewilloftheshadow.
 - Agents/Image tool: cap image-analysis completion `maxTokens` by model capability (`min(4096, model.maxTokens)`) to avoid over-limit provider failures while still preventing truncation. (#11770) Thanks @detecti1.
 - TUI/Streaming: preserve richer streamed assistant text when final payload drops pre-tool-call text blocks, while keeping non-empty final payload authoritative for plain-text updates. (#15452) Thanks @TsekaLuk.

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -184,10 +184,7 @@ export async function sessionsCommand(
     defaultProvider: DEFAULT_PROVIDER,
     defaultModel: DEFAULT_MODEL,
   });
-  const configContextTokens =
-    cfg.agents?.defaults?.contextTokens ??
-    lookupContextTokens(resolved.model) ??
-    DEFAULT_CONTEXT_TOKENS;
+  const configContextTokens = lookupContextTokens(resolved.model) ?? DEFAULT_CONTEXT_TOKENS;
   const configModel = resolved.model ?? DEFAULT_MODEL;
   const storePath = resolveStorePath(opts.store ?? cfg.session?.store);
   const store = loadSessionStore(storePath);


### PR DESCRIPTION
## Summary

Fixes #15705. Also addresses #15697.

The `sessionsCommand` fallback chain for `configContextTokens` incorrectly prioritized `cfg.agents.defaults.contextTokens` (the agent max buffer setting) over the model's actual context window. When users set a large buffer value (e.g. 1M), session listings showed inflated context windows and misleading token percentages.\n\n## Root Cause\n\nIn `src/commands/sessions.ts`, the fallback chain was:\n\n```typescript\nconst configContextTokens =\n  cfg.agents?.defaults?.contextTokens ??   // agent buffer (e.g. 1M)\n  lookupContextTokens(resolved.model) ??   // model's actual contextWindow\n  DEFAULT_CONTEXT_TOKENS;                  // 200k\n```\n\n`cfg.agents.defaults.contextTokens` is the agent's max buffer setting, not the model's context window. Because `??` only falls through on `null`/`undefined`, a configured value (e.g. `1_000_000`) always wins, even when the model's actual context window is known.\n\n## Fix\n\nRemove `cfg.agents.defaults.contextTokens` from the fallback chain:\n\n```typescript\nconst configContextTokens =\n  lookupContextTokens(resolved.model) ?? DEFAULT_CONTEXT_TOKENS;\n```\n\n## Before / After\n\n**Before** (agent buffer = 1M, model = MiniMax-M2.5-Omni with 204k context):\n```\ndirect +15555550123  30m ago  MiniMax-M2.5-Omni 60k/1000k (6%)\n```\n\n**After:**\n```\ndirect +15555550123  30m ago  MiniMax-M2.5-Omni 60k/200k (30%)\n```\n\n## Test Plan\n\n- Updated existing e2e test assertions to reflect correct fallback behavior\n- Added regression test verifying `agents.defaults.contextTokens` does not leak into display\n- All 4 tests pass: `pnpm vitest run src/commands/sessions.e2e.test.ts --config vitest.e2e.config.ts`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `sessionsCommand` to derive the displayed context window from model metadata (`lookupContextTokens(resolved.model)`) and fall back to `DEFAULT_CONTEXT_TOKENS`, rather than incorrectly preferring `cfg.agents.defaults.contextTokens` (agent buffer size). The sessions e2e tests are updated accordingly and add a regression assertion to ensure `agents.defaults.contextTokens` does not affect the JSON/table display when the model context window is unknown.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped to a single fallback chain in `sessionsCommand` and aligns the displayed context window with model metadata, preventing misleading token percentages. Test updates and an explicit regression test cover the behavior change for both table and JSON outputs.
- No files require special attention

<sub>Last reviewed commit: 058ef3f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->