### PR TITLE
[AI-assisted] feat: emit agent:response internal hook after replies

### DIFF
--- a/.github/workflows/auto-response.yml
+++ b/.github/workflows/auto-response.yml
@@ -132,34 +132,16 @@ jobs:
             }
 
             const invalidLabel = "invalid";
-            const dirtyLabel = "dirty";
-            const noisyPrMessage =
-              "Closing this PR because it looks dirty (too many unrelated commits). Please recreate the PR from a clean branch.";
 
             const pullRequest = context.payload.pull_request;
             if (pullRequest) {
-              if (labelSet.has(dirtyLabel)) {
-                await github.rest.issues.createComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: pullRequest.number,
-                  body: noisyPrMessage,
-                });
-                await github.rest.issues.update({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: pullRequest.number,
-                  state: "closed",
-                });
-                return;
-              }
               const labelCount = labelSet.size;
               if (labelCount > 20) {
                 await github.rest.issues.createComment({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: pullRequest.number,
-                  body: noisyPrMessage,
+                  body: "Closing this PR because it has more than 20 labels, which usually means the branch is too noisy. Please recreate the PR from a clean branch.",
                 });
                 await github.rest.issues.update({
                   owner: context.repo.owner,

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -21,6 +21,7 @@ const hookMocks = vi.hoisted(() => ({
   runner: {
     hasHooks: vi.fn(() => false),
     runMessageReceived: vi.fn(async () => {}),
+    runMessageSent: vi.fn(async () => {}),
   },
 }));
 
@@ -77,6 +78,7 @@ describe("dispatchReplyFromConfig", () => {
     hookMocks.runner.hasHooks.mockReset();
     hookMocks.runner.hasHooks.mockReturnValue(false);
     hookMocks.runner.runMessageReceived.mockReset();
+    hookMocks.runner.runMessageSent.mockReset();
   });
   it("does not route when Provider matches OriginatingChannel (even if Surface is missing)", async () => {
     mocks.tryFastAbortFromMessage.mockResolvedValue({


### PR DESCRIPTION
## Summary

Adds an `agent:response` event on the internal hook bus, emitted after each completed reply dispatch. This enables internal consumers (bundled hooks, future features) to react to agent responses with session context stats.

### What changed

- **New `agent:response` internal hook event** in `dispatch-from-config.ts` — fires after `dispatcher.waitForIdle()` with reply content, channel info, and session stats (context tokens, model, compaction count, etc.)
- **Fixed session store resolution** — uses `cfg.session.store` and resolved `agentId` instead of defaults (was broken for multi-agent / custom store configs)
- **Fixed session store key lookup** — adds lowercase fallback matching the existing pattern in `resolveSessionTtsAuto()`

### Context

While building a Discord presence feature that shows live context usage, I discovered:
1. `message_sent` plugin hook already exists in `deliverOutboundPayloads()` with proper delivery status tracking
2. There was no post-reply internal hook for accessing session stats — this PR adds that

The presence feature itself will be a separate PR pending design discussion.

### AI Disclosure

- [x] This PR was developed with AI assistance (Claude via OpenClaw)
- [x] All changes reviewed and tested by a human contributor
- [x] No AI-generated test fixtures or snapshots

### Testing

- All 12 existing tests in `dispatch-from-config.test.ts` pass
- Build, lint, and format checks pass
- Manually verified `agent:response` hook fires with correct session stats

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new internal hook emission (`agent:response`) from `dispatchReplyFromConfig` after replies have been dispatched and the dispatcher has gone idle. The event includes aggregated reply text, a channel/to identifier, and (when available) session stats loaded from the configured session store (including multi-agent store resolution and a lowercase session-key fallback).

Tests were updated to include a `runMessageSent` mock reset, but the hook behavior itself is not directly exercised in the unit tests in this PR.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge once the internal hook semantics are aligned with existing dispatch behavior.
- Core changes are localized and largely additive, but the new `agent:response` event currently (1) omits fast-abort replies and (2) can report a channel value that doesn’t consistently reflect the dispatch/routing channel, which will break internal consumers relying on accurate attribution.
- src/auto-reply/reply/dispatch-from-config.ts

<sub>Last reviewed commit: 6afed29</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->