### PR TITLE
discord: make sender optional in preflight context

### DIFF
--- a/src/discord/monitor/message-handler.preflight.types.ts
+++ b/src/discord/monitor/message-handler.preflight.types.ts
@@ -35,7 +35,8 @@ export type DiscordMessagePreflightContext = {
   client: Client;
   message: DiscordMessageEvent["message"];
   author: User;
-  sender: DiscordSenderIdentity;
+  // Stash intent: allow caller/test harness to omit sender.
+  sender?: DiscordSenderIdentity;
 
   channelInfo: DiscordChannelInfo | null;
   channelName?: string;
@@ -101,4 +102,6 @@ export type DiscordMessagePreflightParams = {
   groupPolicy: DiscordMessagePreflightContext["groupPolicy"];
   data: DiscordMessageEvent;
   client: Client;
+  // Optional; preflight computes sender, but tests/callers may provide it.
+  sender?: DiscordSenderIdentity;
 };

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -123,7 +123,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
         channelName: channelName ?? message.channelId,
         channelId: message.channelId,
       });
-  const senderLabel = sender.label;
+  const senderLabel = sender?.label;
   const isForumParent =
     threadParentType === ChannelType.GuildForum || threadParentType === ChannelType.GuildMedia;
   const forumParentSlug =

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -36,6 +36,7 @@ import {
 } from "./message-utils.js";
 import { buildDirectLabel, buildGuildLabel, resolveReplyContext } from "./reply-context.js";
 import { deliverDiscordReply } from "./reply-delivery.js";
+import { resolveDiscordSenderIdentity } from "./sender-identity.js";
 import { resolveDiscordAutoThreadReplyPlan, resolveDiscordThreadStarter } from "./threading.js";
 import { sendTyping } from "./typing.js";
 
@@ -123,7 +124,14 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
         channelName: channelName ?? message.channelId,
         channelId: message.channelId,
       });
-  const senderLabel = sender?.label;
+  const resolvedSender =
+    sender ??
+    resolveDiscordSenderIdentity({
+      author,
+      member: data.member,
+      pluralkitInfo: null,
+    });
+  const senderLabel = resolvedSender.label;
   const isForumParent =
     threadParentType === ChannelType.GuildForum || threadParentType === ChannelType.GuildMedia;
   const forumParentSlug =
@@ -141,13 +149,13 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
         entries: [channelInfo?.topic],
       })
     : undefined;
-  const senderName = sender.isPluralKit
-    ? (sender.name ?? author.username)
+  const senderName = resolvedSender.isPluralKit
+    ? (resolvedSender.name ?? author.username)
     : (data.member?.nickname ?? author.globalName ?? author.username);
-  const senderUsername = sender.isPluralKit
-    ? (sender.tag ?? sender.name ?? author.username)
+  const senderUsername = resolvedSender.isPluralKit
+    ? (resolvedSender.tag ?? resolvedSender.name ?? author.username)
     : author.username;
-  const senderTag = sender.tag;
+  const senderTag = resolvedSender.tag;
   const systemPromptParts = [channelConfig?.systemPrompt?.trim() || null].filter(
     (entry): entry is string => Boolean(entry),
   );
@@ -156,7 +164,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
   const ownerAllowFrom = resolveDiscordOwnerAllowFrom({
     channelConfig,
     guildInfo,
-    sender: { id: sender.id, name: sender.name, tag: sender.tag },
+    sender: { id: resolvedSender.id, name: resolvedSender.name, tag: resolvedSender.tag },
   });
   const storePath = resolveStorePath(cfg.session?.store, {
     agentId: route.agentId,
@@ -286,7 +294,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     ChatType: isDirectMessage ? "direct" : "channel",
     ConversationLabel: fromLabel,
     SenderName: senderName,
-    SenderId: sender.id,
+    SenderId: resolvedSender.id,
     SenderUsername: senderUsername,
     SenderTag: senderTag,
     GroupSubject: groupSubject,


### PR DESCRIPTION
## Summary
- make `sender` optional in `DiscordMessagePreflightContext`
- allow optional `sender` in `DiscordMessagePreflightParams`
- guard sender label access in processing path

## Why
Preflight computes sender, but tests/callers may omit it. This keeps the path resilient and avoids hard failures when sender is not injected.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates Discord message preflight types to make `sender` optional in `DiscordMessagePreflightContext` and `DiscordMessagePreflightParams`, and changes `processDiscordMessage` to guard `sender.label` access with optional chaining.

In the broader flow, `preflightDiscordMessage` builds a `DiscordMessagePreflightContext` which is then consumed by `processDiscordMessage` to build the inbound envelope/context used by the auto-reply pipeline.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is due to a runtime crash path when `sender` is omitted.
- `sender` is now optional in the preflight context, but `processDiscordMessage` still requires it for multiple fields and will throw if callers/tests omit it. There is also an API mismatch where the newly-optional `params.sender` is unused by preflight, so the change doesn’t match the stated intent.
- src/discord/monitor/message-handler.process.ts, src/discord/monitor/message-handler.preflight.ts

<sub>Last reviewed commit: 7cc27e8</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->