### PR TITLE
fix(cron): remove duplicate main-session relay for isolated jobs with announce delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/Restart: clear stale command-queue and heartbeat wake runtime state after SIGUSR1 in-process restarts to prevent zombie gateway behavior where queued work stops draining. (#15195) Thanks @joeykrug.
 - Onboarding/CLI: restore terminal state without resuming paused `stdin`, so onboarding exits cleanly after choosing Web UI and the installer returns instead of appearing stuck.
 - Auth/OpenAI Codex: share OAuth login handling across onboarding and `models auth login --provider openai-codex`, keep onboarding alive when OAuth fails, and surface a direct OAuth help note instead of terminating the wizard. (#15406, follow-up to #14552) Thanks @zhiluo20.
+- Cron: add regression coverage for announce-mode isolated jobs so runs that already report `delivered: true` do not enqueue duplicate main-session relays, including delivery configs where `mode` is omitted and defaults to announce. (#15737) Thanks @brandonwise.
 - Onboarding/Providers: add vLLM as an onboarding provider with model discovery, auth profile wiring, and non-interactive auth-choice validation. (#12577) Thanks @gejifeng.
 - Onboarding/Providers: preserve Hugging Face auth intent in auth-choice remapping (`tokenProvider=huggingface` with `authChoice=apiKey`) and skip env-override prompts when an explicit token is provided. (#13472) Thanks @Josephrp.
 - OpenAI Codex/Spark: implement end-to-end `gpt-5.3-codex-spark` support across fallback/thinking/model resolution and `models list` forward-compat visibility. (#14990, #15174) Thanks @L-U-C-K-Y, @loiie45e.


### PR DESCRIPTION
## Summary

Fixes #15692

Previously, isolated cron jobs with `delivery.mode=announce` caused duplicate messages:

1. `runIsolatedAgentJob()` calls `runSubagentAnnounceFlow()` which sends a message to the main session
2. `executeJobCore()` ALSO called `enqueueSystemEvent()` + `requestHeartbeatNow()` which triggered another main session run

The second step was redundant since `runSubagentAnnounceFlow` already handles the announce delivery.

## Changes

- Removed the redundant `enqueueSystemEvent` + `requestHeartbeatNow` block from `executeJobCore()` for isolated jobs
- Updated tests to verify no duplicate relay occurs
- Added new test case specifically for #15692

## Testing

- All 95 cron tests pass
- Verified that isolated jobs with announce delivery no longer trigger duplicate messages

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR removes the CronService-level “post summary back to main session” relay from `executeJobCore()` for isolated jobs, based on the rationale that `runIsolatedAgentJob()`’s announce flow already delivers the message (fixing duplicate relays for `delivery.mode=announce`). Tests were updated to assert `enqueueSystemEvent()` / `requestHeartbeatNow()` are not called for isolated jobs.

One behavior risk: `runIsolatedAgentJob` is an injected dependency. If it does *not* itself run the announce flow, isolated jobs with `delivery.requested=true` will no longer be relayed to the main session at all (previously they were, gated by `resolveCronDeliveryPlan(job).requested` and a non-empty `res.summary`). Consider scoping the removal to only the cases where the injected runner is known to already announce, or reintroducing the relay for other runners.


<h3>Confidence Score: 3/5</h3>

- This PR is moderately safe to merge but may change isolated-job delivery behavior depending on the injected runner implementation.
- The code change is small and test-updated, but it removes a relay that previously posted summaries to main for isolated jobs when delivery was requested. Because `runIsolatedAgentJob` is a dependency, this can break consumers that relied on CronService to perform the relay rather than the runner.
- src/cron/service/timer.ts

<sub>Last reviewed commit: 9a6263c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->