### PR TITLE
fix(cron): prevent duplicate delivery for isolated jobs with announce mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ Docs: https://docs.openclaw.ai
 - Cron: pass `agentId` to `runHeartbeatOnce` for main-session jobs. (#14140) Thanks @ishikawa-pro.
 - Cron: re-arm timers when `onTimer` fires while a job is still executing. (#14233) Thanks @tomron87.
 - Cron: prevent duplicate fires when multiple jobs trigger simultaneously. (#14256) Thanks @xinhuagu.
+- Cron: prevent duplicate announce-mode isolated cron deliveries, and keep main-session fallback active when best-effort structured delivery attempts fail to send any message. (#15739) Thanks @widingmarcus-cyber.
 - Cron: isolate scheduler errors so one bad job does not break all jobs. (#14385) Thanks @MarvinDontPanic.
 - Cron: prevent one-shot `at` jobs from re-firing on restart after skipped/errored runs. (#13878) Thanks @lailoo.
 - Heartbeat: prevent scheduler stalls on unexpected run errors and avoid immediate rerun loops after `requests-in-flight` skips. (#14901) Thanks @joeykrug.

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -46,6 +46,11 @@ export type CronServiceDeps = {
     error?: string;
     sessionId?: string;
     sessionKey?: string;
+    /**
+     * `true` when the isolated run already delivered its output to the target
+     * channel.  See: https://github.com/openclaw/openclaw/issues/15692
+     */
+    delivered?: boolean;
   }>;
   onEvent?: (evt: CronEvent) => void;
 };

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -48,7 +48,8 @@ export type CronServiceDeps = {
     sessionKey?: string;
     /**
      * `true` when the isolated run already delivered its output to the target
-     * channel.  See: https://github.com/openclaw/openclaw/issues/15692
+     * channel (including matching messaging-tool sends). See:
+     * https://github.com/openclaw/openclaw/issues/15692
      */
     delivered?: boolean;
   }>;


### PR DESCRIPTION
## fix(cron): prevent duplicate delivery for isolated jobs with announce mode

Fixes #15692

### Problem

When an isolated cron job runs with `delivery.mode=announce`, the output is delivered **twice** to the target channel with different content:

1. The isolated agent run delivers via `deliverOutboundPayloads` (structured content) or `runSubagentAnnounceFlow` (text-based announce) → **Message #1**
2. `executeJobCore` in `timer.ts` unconditionally calls `enqueueSystemEvent` + `requestHeartbeatNow`, which wakes the main agent. The main agent processes the system event, generates its own response, and delivers it → **Message #2**

Result: two messages with different content for a single cron run.

### Root Cause

In `src/cron/service/timer.ts`, `executeJobCore()` posts a summary to the main agent session after every isolated job, regardless of whether the isolated run already delivered its output:

```typescript
// Before fix:
if (summaryText && deliveryPlan.requested) {
  state.deps.enqueueSystemEvent(label, { agentId: job.agentId });
  if (job.wakeMode === "now") {
    state.deps.requestHeartbeatNow({ reason: \`cron:\${job.id}\` });
  }
}
```

### Fix

Add a `delivered` flag to `RunCronAgentTurnResult` that tracks whether the isolated run already delivered its output. Skip `enqueueSystemEvent` + `requestHeartbeatNow` when `delivered === true`.

**Changed files:** `src/cron/isolated-agent/run.ts`, `src/cron/service/state.ts`, `src/cron/service/timer.ts`

### Testing

- All 128 existing cron tests pass
- Lint + format pass (oxlint + oxfmt)
- TypeScript type-check passes

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a `delivered` flag to the isolated cron job execution result so the cron timer can avoid enqueueing a summary system event (and waking the main agent) when the isolated run has already delivered output to the target channel (via outbound payload delivery or the announce flow). 

Concretely:
- `src/cron/isolated-agent/run.ts` now tracks whether delivery happened and returns it.
- `src/cron/service/state.ts` extends the `runIsolatedAgentJob` dep return type to include `delivered`.
- `src/cron/service/timer.ts` gates `enqueueSystemEvent` + `requestHeartbeatNow` behind `!res.delivered` to prevent duplicate channel messages for `delivery.mode=announce` isolated runs.

Overall, the change is narrowly scoped to the cron isolated-run → main-session handoff logic and matches the stated root cause in #15692.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are small, localized, and type-propagated: `delivered` is only used to suppress a main-session wakeup when isolated delivery already occurred. The new flag is set only on successful delivery paths (outbound payload delivery or announce success) and is otherwise false/undefined, preserving prior behavior. No other call sites are affected beyond the cron service dependency return type and the single gating condition in the timer.
- No files require special attention

<sub>Last reviewed commit: a355115</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->