### PR TITLE
docs(docker): add prerequisite note about cloning the repo

### DIFF
--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -28,6 +28,15 @@ Sandboxing details: [Sandboxing](/gateway/sandboxing)
 - Docker Desktop (or Docker Engine) + Docker Compose v2
 - Enough disk for images + logs
 
+> **No pre-built images.** OpenClaw does not publish Docker images to a
+> registry. You build them locally from the source repository. Clone the repo
+> first, then run the setup script from the repo root:
+>
+> ```bash
+> git clone https://github.com/openclaw/openclaw.git
+> cd openclaw
+> ```
+
 ## Containerized Gateway (Docker Compose)
 
 ### Quick start (recommended)


### PR DESCRIPTION
The Docker docs jumped straight into `docker-setup.sh` without explaining that OpenClaw doesn't publish pre-built images. Users need to clone the repository first and build locally.

Add a callout in the Requirements section with the clone command.

Fixes #15655

Includes zh-CN translation.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a Requirements callout to the Docker install docs clarifying that OpenClaw doesn’t publish pre-built Docker images and that users must clone the repo before running `docker-setup.sh`. Also includes the same note in the zh-CN Docker doc.

This fits the docs set by improving onboarding for the Docker Compose gateway path, preventing users from expecting a published image/registry flow.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but the zh-CN docs change conflicts with the repo’s i18n workflow guidance.
- The English doc addition is straightforward and improves correctness of the Docker setup instructions. The only must-fix concern is that `docs/zh-CN/**` is described as generated content in repo guidelines, so manual edits are likely to diverge from or be overwritten by the translation pipeline.
- docs/zh-CN/install/docker.md

<sub>Last reviewed commit: 051d932</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->