### PR TITLE
fix: improve context overflow error with diagnostic details

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -601,12 +601,24 @@ export async function runEmbeddedPiAgent(
               }
             }
             const kind = isCompactionFailure ? "compaction_failure" : "context_overflow";
+            const contextLimit = ctxInfo.tokens;
+            const sessionLabel = params.sessionKey ?? params.sessionId;
+            const overflowDetails = [
+              `Context overflow (${provider}/${modelId}, limit: ${contextLimit.toLocaleString()} tokens)`,
+              sessionLabel ? `  Session: ${sessionLabel}` : null,
+              `  Messages: ${msgCount}`,
+              "",
+              "Actions:",
+              "  \u2022 Run /reset to clear context and start fresh",
+              "  \u2022 Or switch to a model with a larger context window",
+              "  \u2022 Consider lowering contextTokens in config to trigger earlier compaction",
+            ]
+              .filter((line) => line !== null)
+              .join("\n");
             return {
               payloads: [
                 {
-                  text:
-                    "Context overflow: prompt too large for the model. " +
-                    "Try /reset (or /new) to start a fresh session, or use a larger-context model.",
+                  text: overflowDetails,
                   isError: true,
                 },
               ],

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -601,11 +601,11 @@ export async function runEmbeddedPiAgent(
               }
             }
             const kind = isCompactionFailure ? "compaction_failure" : "context_overflow";
-            const contextLimit = typeof ctxInfo.tokens === "number" ? ctxInfo.tokens : 0;
+            const contextLimit = ctxInfo.tokens ?? "unknown";
 
             const header = isCompactionFailure
               ? `Compaction failure (${provider}/${modelId})`
-              : `Context overflow (${provider}/${modelId}, limit: ${contextLimit ? contextLimit.toLocaleString() : "unknown"} tokens)`;
+              : `Context overflow (${provider}/${modelId}, limit: ${typeof contextLimit === "number" ? contextLimit.toLocaleString() : contextLimit} tokens)`;
 
             const actions = isCompactionFailure
               ? [


### PR DESCRIPTION
## Summary

- Replaces the generic "Context overflow: prompt too large" message with diagnostic details
- Now includes provider/model name, context window limit, session identifier, and message count
- Adds actionable recovery steps (run /reset, switch model, adjust contextTokens)

**Before:**
```
Context overflow: prompt too large for the model. Try /reset (or /new) to start a fresh session, or use a larger-context model.
```

**After:**
```
Context overflow (anthropic/claude-opus-4-5, limit: 200,000 tokens)
  Session: discord:channel:123456789
  Messages: 47

Actions:
  • Run /reset to clear context and start fresh
  • Or switch to a model with a larger context window
  • Consider lowering contextTokens in config to trigger earlier compaction
```

Closes #9409

## Test plan

- [x] Lint passes (oxlint, no warnings/errors)
- [x] Existing e2e tests check `isError: true` and `error.kind`, not exact text — unchanged
- [ ] Manual test: trigger a context overflow and verify the new message format

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates the embedded PI agent’s context-overflow handling to return a multi-line error message with diagnostics (provider/model, context-window limit, session label, message count) and suggested recovery actions instead of the previous generic one-liner.

The behavior lives in `src/agents/pi-embedded-runner/run.ts` inside the overflow/compaction recovery branch, and affects what end users see when the runner detects a context overflow and can’t recover via auto-compaction/tool-result truncation.

<h3>Confidence Score: 3/5</h3>

- This PR is close to safe to merge but has a couple of user-facing error-handling edge cases to fix first.
- Core change is localized and straightforward, but the new formatting can throw if the context limit isn’t a number, and it may expose sensitive session identifiers and mislabel compaction failures as context overflows.
- src/agents/pi-embedded-runner/run.ts

<sub>Last reviewed commit: 281f021</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->