### PR TITLE
[Security]: strip provider apiKey from models.json before prompt serialization

### DIFF
--- a/src/agents/models-config.fills-missing-provider-apikey-from-env-var.e2e.test.ts
+++ b/src/agents/models-config.fills-missing-provider-apikey-from-env-var.e2e.test.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { withTempHome as withTempHomeBase } from "../../test/helpers/temp-home.js";
 import { resolveOpenClawAgentDir } from "./agent-paths.js";
-import { ensureOpenClawModelsJson } from "./models-config.js";
+import { ensureOpenClawModelsJson, REDACTED_PLACEHOLDER } from "./models-config.js";
 
 async function withTempHome<T>(fn: (home: string) => Promise<T>): Promise<T> {
   return withTempHomeBase(fn, { prefix: "openclaw-models-" });
@@ -79,7 +79,7 @@ describe("models-config", () => {
         const parsed = JSON.parse(raw) as {
           providers: Record<string, { apiKey?: string; models?: Array<{ id: string }> }>;
         };
-        expect(parsed.providers.minimax?.apiKey).toBe("MINIMAX_API_KEY");
+        expect(parsed.providers.minimax?.apiKey).toBe(REDACTED_PLACEHOLDER);
         const ids = parsed.providers.minimax?.models?.map((model) => model.id);
         expect(ids).toContain("MiniMax-VL-01");
       } finally {

--- a/src/agents/models-config.skips-writing-models-json-no-env-token.e2e.test.ts
+++ b/src/agents/models-config.skips-writing-models-json-no-env-token.e2e.test.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { withTempHome as withTempHomeBase } from "../../test/helpers/temp-home.js";
 import { resolveOpenClawAgentDir } from "./agent-paths.js";
-import { ensureOpenClawModelsJson } from "./models-config.js";
+import { ensureOpenClawModelsJson, REDACTED_PLACEHOLDER } from "./models-config.js";
 
 async function withTempHome<T>(fn: (home: string) => Promise<T>): Promise<T> {
   return withTempHomeBase(fn, { prefix: "openclaw-models-" });
@@ -159,7 +159,7 @@ describe("models-config", () => {
           >;
         };
         expect(parsed.providers.minimax?.baseUrl).toBe("https://api.minimax.chat/v1");
-        expect(parsed.providers.minimax?.apiKey).toBe("MINIMAX_API_KEY");
+        expect(parsed.providers.minimax?.apiKey).toBe(REDACTED_PLACEHOLDER);
         const ids = parsed.providers.minimax?.models?.map((model) => model.id);
         expect(ids).toContain("MiniMax-M2.1");
         expect(ids).toContain("MiniMax-VL-01");
@@ -192,7 +192,7 @@ describe("models-config", () => {
           >;
         };
         expect(parsed.providers.synthetic?.baseUrl).toBe("https://api.synthetic.new/anthropic");
-        expect(parsed.providers.synthetic?.apiKey).toBe("SYNTHETIC_API_KEY");
+        expect(parsed.providers.synthetic?.apiKey).toBe(REDACTED_PLACEHOLDER);
         const ids = parsed.providers.synthetic?.models?.map((model) => model.id);
         expect(ids).toContain("hf:MiniMaxAI/MiniMax-M2.1");
       } finally {

--- a/src/agents/models-config.strip-secrets.test.ts
+++ b/src/agents/models-config.strip-secrets.test.ts
@@ -1,0 +1,151 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { withTempHome as withTempHomeBase } from "../../test/helpers/temp-home.js";
+import { resolveOpenClawAgentDir } from "./agent-paths.js";
+import { ensureOpenClawModelsJson, REDACTED_PLACEHOLDER } from "./models-config.js";
+
+async function withTempHome<T>(fn: (home: string) => Promise<T>): Promise<T> {
+  return withTempHomeBase(fn, { prefix: "openclaw-strip-secrets-" });
+}
+
+describe("models-config secret stripping", () => {
+  it("replaces apiKey with REDACTED_BY_OPENCLAW in models.json output", async () => {
+    await withTempHome(async () => {
+      const cfg: OpenClawConfig = {
+        models: {
+          providers: {
+            "test-provider": {
+              baseUrl: "https://api.example.com",
+              apiKey: "sk-secret-literal-key-12345",
+              api: "openai-responses",
+              models: [
+                {
+                  id: "test-model",
+                  name: "Test Model",
+                  reasoning: false,
+                  input: ["text"],
+                  cost: { input: 1, output: 2, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 128000,
+                  maxTokens: 4096,
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      await ensureOpenClawModelsJson(cfg);
+
+      const modelPath = path.join(resolveOpenClawAgentDir(), "models.json");
+      const raw = await fs.readFile(modelPath, "utf8");
+      const parsed = JSON.parse(raw) as {
+        providers: Record<string, { apiKey?: string; baseUrl?: string; models?: unknown[] }>;
+      };
+
+      expect(parsed.providers["test-provider"]?.apiKey).toBe(REDACTED_PLACEHOLDER);
+      expect(raw).not.toContain("sk-secret-literal-key-12345");
+
+      // Non-secret fields preserved
+      expect(parsed.providers["test-provider"]?.baseUrl).toBe("https://api.example.com");
+      expect(parsed.providers["test-provider"]?.models).toHaveLength(1);
+    });
+  });
+
+  it("strips apiKey from multiple providers", async () => {
+    await withTempHome(async () => {
+      const cfg: OpenClawConfig = {
+        models: {
+          providers: {
+            "provider-a": {
+              baseUrl: "https://api.a.com",
+              apiKey: "sk-secret-a",
+              api: "anthropic-messages",
+              models: [
+                {
+                  id: "model-a",
+                  name: "Model A",
+                  reasoning: true,
+                  input: ["text", "image"],
+                  cost: { input: 15, output: 75, cacheRead: 2, cacheWrite: 4 },
+                  contextWindow: 200000,
+                  maxTokens: 32000,
+                },
+              ],
+            },
+            "provider-b": {
+              baseUrl: "https://api.b.com",
+              apiKey: "sk-secret-b",
+              api: "openai-responses",
+              models: [
+                {
+                  id: "model-b",
+                  name: "Model B",
+                  reasoning: false,
+                  input: ["text"],
+                  cost: { input: 5, output: 15, cacheRead: 1, cacheWrite: 2 },
+                  contextWindow: 128000,
+                  maxTokens: 16384,
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      await ensureOpenClawModelsJson(cfg);
+
+      const modelPath = path.join(resolveOpenClawAgentDir(), "models.json");
+      const raw = await fs.readFile(modelPath, "utf8");
+      const parsed = JSON.parse(raw) as {
+        providers: Record<string, { apiKey?: string }>;
+      };
+
+      expect(parsed.providers["provider-a"]?.apiKey).toBe(REDACTED_PLACEHOLDER);
+      expect(parsed.providers["provider-b"]?.apiKey).toBe(REDACTED_PLACEHOLDER);
+      expect(raw).not.toContain("sk-secret-a");
+      expect(raw).not.toContain("sk-secret-b");
+    });
+  });
+
+  it("does not add apiKey when provider has none", async () => {
+    await withTempHome(async () => {
+      const agentDir = resolveOpenClawAgentDir();
+      // Pre-seed models.json so ensureOpenClawModelsJson has something to merge with
+      // and doesn't skip due to empty providers.
+      const cfg: OpenClawConfig = {
+        models: {
+          providers: {
+            "no-key-provider": {
+              baseUrl: "https://api.example.com",
+              api: "openai-responses",
+              models: [
+                {
+                  id: "test-model",
+                  name: "Test",
+                  reasoning: false,
+                  input: ["text"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 128000,
+                  maxTokens: 4096,
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      await ensureOpenClawModelsJson(cfg);
+
+      const modelPath = path.join(agentDir, "models.json");
+      const raw = await fs.readFile(modelPath, "utf8");
+      const parsed = JSON.parse(raw) as {
+        providers: Record<string, { apiKey?: string }>;
+      };
+
+      // Provider without apiKey should not get one added
+      expect(parsed.providers["no-key-provider"]?.apiKey).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

  Strip provider `apiKey` values from `models.json` before disk write.
  The agent SDK reads this file and may expose credentials in prompt context.
  Auth resolution is unaffected — `model-auth.ts` injects keys via `authStorage.setRuntimeApiKey()` independently.

  Fixes #11202 · Implements Layer 1 of #11829 · Related: #14411

  ## Security Impact

  **Risk:** Literal API keys from auth profiles leak into `~/.openclaw/agents/<id>/models.json` via `resolveApiKeyFromProfiles()` at `models-config.providers.ts:278`. The pi-coding-agent SDK reads this file, making credentials accessible to agent filesystem tools and potentially
  serializable into LLM prompt context. Every provider sees every other provider's keys, every turn. Confirmed in v2026.2.3-1 through v2026.2.6-3 (#11202).

  **Repro:**
  1. Configure a provider with an auth profile (not env var)
  2. Start an agent session
  3. `cat ~/.openclaw/agents/default/models.json | grep apiKey`
  4. Observe: literal secret visible in plaintext

  **Fix:** Add `stripProviderSecrets()` at the serialization boundary in `ensureOpenClawModelsJson()` (`models-config.ts:152`). Replace credential fields with `"REDACTED_BY_OPENCLAW"` placeholder — SDK still considers custom models "available" (non-empty apiKey).

  **Code path traced:**
  - `models-config.providers.ts:278-283` — `resolveApiKeyFromProfiles()` returns literal secrets
  - `models-config.ts:148-155` — normalization then stripping before `JSON.stringify`
  - `model-auth.ts:135-233` — auth resolution reads from runtime config, env, profiles (NOT models.json)
  - `run.ts:343-345` — `authStorage.setRuntimeApiKey()` injects real auth before session creation

  I searched the codebase for existing functionality — `ModelCatalogEntry` type at `model-catalog.ts:5-12` already excludes `apiKey`, confirming the agent doesn't need it.

  **Known remaining vectors:**
  - `session-status-tool.ts:56-64` — `formatApiKeySnippet()` shows truncated key heads/tails to the agent via `/status` tool output. Lower severity (partial, not full key), separate scope.
  - `models.json` on disk — agent has filesystem tools and could read other config files (`openclaw.config.json`, auth-profiles) that may contain credentials. Process-level isolation (#12839) addresses this vector.
  - Upstream SDK context — `@mariozechner/pi-coding-agent` may include model metadata in internal agent context beyond the system prompt. Layer 3 of #11829 tracks upstream filtering.

  ## Changes

  - **`src/agents/models-config.ts`** — Add `REDACTED_PLACEHOLDER` constant, `stripProviderSecrets()` helper, call before `JSON.stringify` at serialization boundary
  - **`src/agents/models-config.strip-secrets.test.ts`** *(new)* — 3 tests: single provider stripping, multi-provider stripping, no-key graceful handling
  - **`src/agents/models-config.fills-missing-provider-apikey-from-env-var.e2e.test.ts`** — apiKey assertion updated to `REDACTED_PLACEHOLDER`
  - **`src/agents/models-config.skips-writing-models-json-no-env-token.e2e.test.ts`** — 2 apiKey assertions updated to `REDACTED_PLACEHOLDER`

  ## Validation / Test Plan

  **Automated:**
  - `models.json` contains `"REDACTED_BY_OPENCLAW"` for all apiKey fields
  - No `sk-` patterns in serialized output
  - Agent can still make API calls (auth resolves via `model-auth.ts`, not `models.json`)
  - `pnpm check` passes
  - `pnpm build` passes
  - `pnpm test` passes (628 files, 4382 tests — all green)
  - All `model-auth`, `model-catalog`, remaining `models-config` tests unchanged and passing

  **Manual:**
  1. Configure 2+ providers with different auth methods
  2. Start agent, verify API calls succeed for all providers
  3. Inspect `~/.openclaw/agents/default/models.json` — all apiKeys show `REDACTED_BY_OPENCLAW`
  4. Verify `/models` list and model switching still work

  ## Sign-Off

  - **Models used:** Claude Opus 4.6 (architecture analysis, implementation via Claude Code)
  - **Submitter effort:** Manual security research, code path tracing, PR strategy. AI-assisted implementation.
  - **Agent notes:** Auth pipeline independence verified by tracing `model-auth.ts` → `run.ts:345` → `authStorage.setRuntimeApiKey()`. Confirmed `models.json` is not read back for API calls.

  lobster-biscuit

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR prevents provider credentials from being persisted into `~/.openclaw/agents/<id>/models.json` by replacing any `providers[...].apiKey` values with the constant `REDACTED_BY_OPENCLAW` at the serialization boundary (`src/agents/models-config.ts`).

The rest of the agent runtime continues to resolve real credentials via `model-auth` and inject them into the embedded runner’s `AuthStorage` using `authStorage.setRuntimeApiKey(...)` (see `src/agents/pi-embedded-runner/run.ts`), so `models.json` remains a model/metadata registry file rather than an auth source. Tests were updated/added to assert that the redacted placeholder is written and that literals are not present on disk.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is narrowly scoped to the `models.json` write path and replaces secrets with a placeholder while leaving runtime auth resolution unchanged (runtime keys are injected via `authStorage.setRuntimeApiKey(...)`). The added/updated tests cover the intended redaction behavior and reduce regression risk.
- No files require special attention

<sub>Last reviewed commit: ba0e976</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->