### PR TITLE
feat(security): add hardening gap audit checks

### DIFF
--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -43,12 +43,30 @@ Start with the smallest access that still works, then widen it as you gain confi
 - **Tool blast radius** (elevated tools + open rooms): could prompt injection turn into shell/file/network actions?
 - **Network exposure** (Gateway bind/auth, Tailscale Serve/Funnel, weak/short auth tokens).
 - **Browser control exposure** (remote nodes, relay ports, remote CDP endpoints).
-- **Local disk hygiene** (permissions, symlinks, config includes, “synced folder” paths).
+- **Local disk hygiene** (permissions, symlinks, config includes, "synced folder" paths).
 - **Plugins** (extensions exist without an explicit allowlist).
 - **Policy drift/misconfig** (sandbox docker settings configured but sandbox mode off; ineffective `gateway.nodes.denyCommands` patterns; global `tools.profile="minimal"` overridden by per-agent profiles; extension plugin tools reachable under permissive tool policy).
 - **Model hygiene** (warn when configured models look legacy; not a hard block).
+- **Hardening gaps** (sandbox mode, network isolation, TLS, dangerous tools not denied).
 
 If you run `--deep`, OpenClaw also attempts a best-effort live Gateway probe.
+
+### Hardening gap checks
+
+Based on [EarlyCore security research](https://www.earlycore.ai/security) findings, the audit includes checks for common hardening gaps:
+
+| Check ID                                       | Severity      | Description                                                        |
+| ---------------------------------------------- | ------------- | ------------------------------------------------------------------ |
+| `sandbox.mode_not_all`                         | Critical/Warn | Sandbox mode not set to "all" (critical if web/exec tools enabled) |
+| `sandbox.docker.network_not_isolated`          | Critical      | Sandbox network allows SSRF (not set to "none")                    |
+| `tools.dangerous_not_denied`                   | Warn          | Dangerous tools (exec, write, browser, etc.) not in deny list      |
+| `tools.elevated_enabled`                       | Info          | Elevated mode is enabled (bypasses sandbox)                        |
+| `tools.elevated_enabled_no_allowlist`          | Warn          | Elevated mode enabled without allowFrom configured                 |
+| `gateway.tls_disabled`                         | Warn/Critical | TLS not enabled (critical for non-loopback)                        |
+| `tools.agent_to_agent_enabled`                 | Info          | Agent-to-agent messaging enabled                                   |
+| `sandbox.docker.writable_root`                 | Info          | Sandbox root filesystem writable                                   |
+| `sandbox.docker.capabilities_not_dropped`      | Info          | Linux capabilities not dropped in sandbox                          |
+| `gateway.nodes.deny_commands_missing_defaults` | Info          | Default dangerous commands not blocked                             |
 
 ## Credential storage map
 

--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -55,18 +55,18 @@ If you run `--deep`, OpenClaw also attempts a best-effort live Gateway probe.
 
 Based on [EarlyCore security research](https://www.earlycore.ai/security) findings, the audit includes checks for common hardening gaps:
 
-| Check ID                                       | Severity      | Description                                                        |
-| ---------------------------------------------- | ------------- | ------------------------------------------------------------------ |
-| `sandbox.mode_not_all`                         | Critical/Warn | Sandbox mode not set to "all" (critical if web/exec tools enabled) |
-| `sandbox.docker.network_not_isolated`          | Critical      | Sandbox network allows SSRF (not set to "none")                    |
-| `tools.dangerous_not_denied`                   | Warn          | Dangerous tools (exec, write, browser, etc.) not in deny list      |
-| `tools.elevated_enabled`                       | Info          | Elevated mode is enabled (bypasses sandbox)                        |
-| `tools.elevated_enabled_no_allowlist`          | Warn          | Elevated mode enabled without allowFrom configured                 |
-| `gateway.tls_disabled`                         | Warn/Critical | TLS not enabled (critical for non-loopback)                        |
-| `tools.agent_to_agent_enabled`                 | Info          | Agent-to-agent messaging enabled                                   |
-| `sandbox.docker.writable_root`                 | Info          | Sandbox root filesystem writable                                   |
-| `sandbox.docker.capabilities_not_dropped`      | Info          | Linux capabilities not dropped in sandbox                          |
-| `gateway.nodes.deny_commands_missing_defaults` | Info          | Default dangerous commands not blocked                             |
+| Check ID                                   | Severity      | Description                                                        |
+| ------------------------------------------ | ------------- | ------------------------------------------------------------------ |
+| `sandbox.mode_not_all`                     | Critical/Warn | Sandbox mode not set to "all" (critical if web/exec tools enabled) |
+| `sandbox.docker.network_not_isolated`      | Critical      | Sandbox network allows SSRF (not set to "none")                    |
+| `tools.dangerous_not_denied`               | Warn          | Dangerous tools (exec, write, browser, etc.) not in deny list      |
+| `tools.elevated_enabled`                   | Info          | Elevated mode is enabled (bypasses sandbox)                        |
+| `tools.elevated_enabled_no_allowlist`      | Warn          | Elevated mode enabled without allowFrom configured                 |
+| `gateway.tls_disabled`                     | Warn/Critical | TLS not enabled (critical for non-loopback)                        |
+| `tools.agent_to_agent_enabled`             | Info          | Agent-to-agent messaging enabled                                   |
+| `sandbox.docker.writable_root`             | Info          | Sandbox root filesystem writable                                   |
+| `sandbox.docker.capabilities_not_dropped`  | Info          | Linux capabilities not dropped in sandbox                          |
+| `gateway.nodes.dangerous_commands_allowed` | Warn          | Dangerous node commands explicitly allowed                         |
 
 ## Credential storage map
 

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -6,7 +6,7 @@
 import type { SandboxToolPolicy } from "../agents/sandbox/types.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type { AgentToolsConfig } from "../config/types.tools.js";
-import { isToolAllowedByPolicies, isToolAllowedByPolicyName } from "../agents/pi-tools.policy.js";
+import { isToolAllowedByPolicies } from "../agents/pi-tools.policy.js";
 import {
   resolveSandboxConfigForAgent,
   resolveSandboxToolPolicyForAgent,

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -891,35 +891,12 @@ export function collectExposureMatrixFindings(cfg: OpenClawConfig): SecurityAudi
 // --------------------------------------------------------------------------
 
 /**
- * Build a combined tool policy from profile + config allow/deny.
- * Uses the existing tool-policy resolution to get profile defaults.
- */
-function buildAuditToolPolicy(cfg: OpenClawConfig): SandboxToolPolicy | undefined {
-  const profilePolicy = resolveToolProfilePolicy(cfg.tools?.profile);
-  const configAllow = cfg.tools?.allow;
-  const configDeny = cfg.tools?.deny;
-
-  // Merge profile policy with config overrides
-  // Config allow extends profile allow; config deny extends profile deny
-  const allow = configAllow?.length
-    ? [...(profilePolicy?.allow ?? []), ...configAllow]
-    : profilePolicy?.allow;
-  const deny = configDeny?.length
-    ? [...(profilePolicy?.deny ?? []), ...configDeny]
-    : profilePolicy?.deny;
-
-  if (!allow && !deny) {
-    return undefined;
-  }
-  return { allow, deny };
-}
-
-/**
  * Check if a tool is available using the proper tool-policy resolution.
+ * Uses the same pickToolPolicy/resolveToolPolicies logic as runtime.
  */
 function isToolAvailable(cfg: OpenClawConfig, toolName: string): boolean {
-  const policy = buildAuditToolPolicy(cfg);
-  return isToolAllowedByPolicyName(toolName, policy);
+  const policies = resolveToolPolicies({ cfg });
+  return isToolAllowedByPolicies(toolName, policies);
 }
 
 /**

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -921,7 +921,7 @@ export function collectSandboxModeFindings(params: {
       isToolAllowedByPolicies("web_search", policies)) ||
     (isWebFetchEnabled(params.cfg) && isToolAllowedByPolicies("web_fetch", policies)) ||
     (isBrowserEnabled(params.cfg) && isToolAllowedByPolicies("browser", policies));
-  const hasExecTools = isToolAvailable(params.cfg, "exec");
+  const hasExecTools = isToolAllowedByPolicies("exec", policies);
 
   findings.push({
     checkId: "sandbox.mode_not_all",

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -893,10 +893,15 @@ export function collectExposureMatrixFindings(cfg: OpenClawConfig): SecurityAudi
 /**
  * Check if a tool is available using the proper tool-policy resolution.
  * Uses the same pickToolPolicy/resolveToolPolicies logic as runtime.
+ * Accepts optional pre-resolved policies to avoid redundant resolution.
  */
-function isToolAvailable(cfg: OpenClawConfig, toolName: string): boolean {
-  const policies = resolveToolPolicies({ cfg });
-  return isToolAllowedByPolicies(toolName, policies);
+function isToolAvailable(
+  cfg: OpenClawConfig,
+  toolName: string,
+  policies?: SandboxToolPolicy[],
+): boolean {
+  const resolved = policies ?? resolveToolPolicies({ cfg });
+  return isToolAllowedByPolicies(toolName, resolved);
 }
 
 /**
@@ -990,7 +995,8 @@ export function collectDangerousToolsFindings(cfg: OpenClawConfig): SecurityAudi
   const findings: SecurityAuditFinding[] = [];
 
   // Check which dangerous tools are actually available based on profile + allow/deny
-  const availableDangerous = DANGEROUS_TOOLS.filter((tool) => isToolAvailable(cfg, tool));
+  const policies = resolveToolPolicies({ cfg });
+  const availableDangerous = DANGEROUS_TOOLS.filter((tool) => isToolAvailable(cfg, tool, policies));
 
   if (availableDangerous.length === 0) {
     return findings; // All dangerous tools restricted by profile or deny list

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -1189,9 +1189,7 @@ export function collectDenyCommandsDefaultsFindings(cfg: OpenClawConfig): Securi
   const findings: SecurityAuditFinding[] = [];
   const denyCommands = cfg.gateway?.nodes?.denyCommands ?? [];
 
-  const missing = HARDENED_DENY_COMMANDS.filter(
-    (cmd) => !denyCommands.some((denied) => denied.includes(cmd) || cmd.includes(denied)),
-  );
+  const missing = HARDENED_DENY_COMMANDS.filter((cmd) => !denyCommands.includes(cmd));
 
   if (missing.length === 0) {
     return findings;

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -1075,21 +1075,20 @@ export function collectElevatedModeFindings(cfg: OpenClawConfig): SecurityAuditF
 export function collectGatewayTlsFindings(cfg: OpenClawConfig): SecurityAuditFinding[] {
   const findings: SecurityAuditFinding[] = [];
   const tlsEnabled = cfg.gateway?.tls?.enabled;
-  const bind = cfg.gateway?.bind ?? "loopback";
 
   if (tlsEnabled === true) {
     return findings; // OK
   }
 
-  const isLoopback = bind === "loopback";
+  const remotelyExposed = isGatewayRemotelyExposed(cfg);
 
   findings.push({
     checkId: "gateway.tls_disabled",
-    severity: isLoopback ? "warn" : "critical",
+    severity: remotelyExposed ? "critical" : "warn",
     title: "Gateway TLS is not enabled",
-    detail: isLoopback
-      ? "TLS is disabled on loopback gateway. Local traffic is unencrypted but contained to this machine."
-      : `TLS is disabled with bind="${bind}". Gateway traffic including auth tokens is unencrypted.`,
+    detail: remotelyExposed
+      ? "TLS is disabled on a remotely-exposed gateway. Traffic including auth tokens is unencrypted."
+      : "TLS is disabled on loopback gateway. Local traffic is unencrypted but contained to this machine.",
     remediation: "Set gateway.tls.enabled=true and gateway.tls.autoGenerate=true.",
   });
 

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -935,10 +935,12 @@ export function collectSandboxModeFindings(params: {
   }
 
   // Check if dangerous tools are available using proper tool policy resolution
+  const policies = resolveToolPolicies({ cfg: params.cfg, sandboxMode });
   const hasWebTools =
-    isWebSearchEnabled(params.cfg, params.env) ||
-    isWebFetchEnabled(params.cfg) ||
-    isBrowserEnabled(params.cfg);
+    (isWebSearchEnabled(params.cfg, params.env) &&
+      isToolAllowedByPolicies("web_search", policies)) ||
+    (isWebFetchEnabled(params.cfg) && isToolAllowedByPolicies("web_fetch", policies)) ||
+    (isBrowserEnabled(params.cfg) && isToolAllowedByPolicies("browser", policies));
   const hasExecTools = isToolAvailable(params.cfg, "exec");
 
   findings.push({

--- a/src/security/audit-extra.ts
+++ b/src/security/audit-extra.ts
@@ -9,13 +9,21 @@
 
 // Sync collectors
 export {
+  collectAgentToAgentFindings,
   collectAttackSurfaceSummaryFindings,
+  collectDangerousToolsFindings,
+  collectDenyCommandsDefaultsFindings,
+  collectElevatedModeFindings,
   collectExposureMatrixFindings,
+  collectGatewayTlsFindings,
   collectHooksHardeningFindings,
   collectMinimalProfileOverrideFindings,
   collectModelHygieneFindings,
   collectNodeDenyCommandPatternFindings,
   collectSandboxDockerNoopFindings,
+  collectSandboxFilesystemFindings,
+  collectSandboxModeFindings,
+  collectSandboxNetworkFindings,
   collectSecretsInConfigFindings,
   collectSmallModelRiskFindings,
   collectSyncedFolderFindings,

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -1588,6 +1588,48 @@ description: test skill
     expect(finding?.severity).toBe("warn");
   });
 
+  it("flags sandbox mode not all as warning when profile is minimal (exec not available)", async () => {
+    const cfg: OpenClawConfig = {
+      agents: { defaults: { sandbox: { mode: "off" } } },
+      tools: {
+        profile: "minimal", // minimal profile only allows session_status, not exec
+        web: { search: { enabled: false }, fetch: { enabled: false } },
+      },
+      browser: { enabled: false },
+    };
+
+    const res = await runSecurityAudit({
+      config: cfg,
+      env: {},
+      includeFilesystem: false,
+      includeChannelSecurity: false,
+    });
+
+    const finding = res.findings.find((f) => f.checkId === "sandbox.mode_not_all");
+    expect(finding?.severity).toBe("warn");
+  });
+
+  it("flags sandbox mode not all as critical when profile is coding (exec available)", async () => {
+    const cfg: OpenClawConfig = {
+      agents: { defaults: { sandbox: { mode: "off" } } },
+      tools: {
+        profile: "coding", // coding profile includes group:runtime which has exec
+        web: { search: { enabled: false }, fetch: { enabled: false } },
+      },
+      browser: { enabled: false },
+    };
+
+    const res = await runSecurityAudit({
+      config: cfg,
+      env: {},
+      includeFilesystem: false,
+      includeChannelSecurity: false,
+    });
+
+    const finding = res.findings.find((f) => f.checkId === "sandbox.mode_not_all");
+    expect(finding?.severity).toBe("critical");
+  });
+
   it("does not flag sandbox mode when set to all", async () => {
     const cfg: OpenClawConfig = {
       agents: { defaults: { sandbox: { mode: "all" } } },

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -1541,6 +1541,399 @@ description: test skill
     );
   });
 
+  // --------------------------------------------------------------------------
+  // Hardening gap checks (EarlyCore findings)
+  // --------------------------------------------------------------------------
+
+  it("flags sandbox mode not all as critical when web tools enabled", async () => {
+    const cfg: OpenClawConfig = {
+      agents: { defaults: { sandbox: { mode: "off" } } },
+      tools: { web: { search: { enabled: true } } },
+    };
+
+    const res = await runSecurityAudit({
+      config: cfg,
+      includeFilesystem: false,
+      includeChannelSecurity: false,
+    });
+
+    expect(res.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "sandbox.mode_not_all",
+          severity: "critical",
+        }),
+      ]),
+    );
+  });
+
+  it("flags sandbox mode not all as warning when no dangerous tools", async () => {
+    const cfg: OpenClawConfig = {
+      agents: { defaults: { sandbox: { mode: "off" } } },
+      tools: {
+        deny: ["exec"],
+        web: { search: { enabled: false }, fetch: { enabled: false } },
+      },
+      browser: { enabled: false },
+    };
+
+    const res = await runSecurityAudit({
+      config: cfg,
+      env: {},
+      includeFilesystem: false,
+      includeChannelSecurity: false,
+    });
+
+    const finding = res.findings.find((f) => f.checkId === "sandbox.mode_not_all");
+    expect(finding?.severity).toBe("warn");
+  });
+
+  it("does not flag sandbox mode when set to all", async () => {
+    const cfg: OpenClawConfig = {
+      agents: { defaults: { sandbox: { mode: "all" } } },
+    };
+
+    const res = await runSecurityAudit({
+      config: cfg,
+      includeFilesystem: false,
+      includeChannelSecurity: false,
+    });
+
+    expect(res.findings.some((f) => f.checkId === "sandbox.mode_not_all")).toBe(false);
+  });
+
+  it("flags sandbox network not isolated when sandbox enabled", async () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          sandbox: { mode: "all", docker: { network: "bridge" } },
+        },
+      },
+    };
+
+    const res = await runSecurityAudit({
+      config: cfg,
+      includeFilesystem: false,
+      includeChannelSecurity: false,
+    });
+
+    expect(res.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "sandbox.docker.network_not_isolated",
+          severity: "critical",
+        }),
+      ]),
+    );
+  });
+
+  it("does not flag sandbox network when set to none", async () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          sandbox: { mode: "all", docker: { network: "none" } },
+        },
+      },
+    };
+
+    const res = await runSecurityAudit({
+      config: cfg,
+      includeFilesystem: false,
+      includeChannelSecurity: false,
+    });
+
+    expect(res.findings.some((f) => f.checkId === "sandbox.docker.network_not_isolated")).toBe(
+      false,
+    );
+  });
+
+  it("does not flag sandbox network when sandbox mode is off", async () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          sandbox: { mode: "off", docker: { network: "bridge" } },
+        },
+      },
+    };
+
+    const res = await runSecurityAudit({
+      config: cfg,
+      includeFilesystem: false,
+      includeChannelSecurity: false,
+    });
+
+    expect(res.findings.some((f) => f.checkId === "sandbox.docker.network_not_isolated")).toBe(
+      false,
+    );
+  });
+
+  it("flags dangerous tools not denied", async () => {
+    const cfg: OpenClawConfig = {
+      tools: { deny: [] },
+    };
+
+    const res = await runSecurityAudit({
+      config: cfg,
+      includeFilesystem: false,
+      includeChannelSecurity: false,
+    });
+
+    expect(res.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "tools.dangerous_not_denied",
+          severity: "warn",
+        }),
+      ]),
+    );
+  });
+
+  it("does not flag dangerous tools when all are denied", async () => {
+    const cfg: OpenClawConfig = {
+      tools: {
+        deny: [
+          "exec",
+          "process",
+          "write",
+          "edit",
+          "apply_patch",
+          "gateway",
+          "cron",
+          "nodes",
+          "browser",
+          "canvas",
+        ],
+      },
+    };
+
+    const res = await runSecurityAudit({
+      config: cfg,
+      includeFilesystem: false,
+      includeChannelSecurity: false,
+    });
+
+    expect(res.findings.some((f) => f.checkId === "tools.dangerous_not_denied")).toBe(false);
+  });
+
+  it("flags elevated mode enabled without allowlist", async () => {
+    const cfg: OpenClawConfig = {
+      tools: { elevated: { enabled: true } },
+    };
+
+    const res = await runSecurityAudit({
+      config: cfg,
+      includeFilesystem: false,
+      includeChannelSecurity: false,
+    });
+
+    expect(res.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "tools.elevated_enabled_no_allowlist",
+          severity: "warn",
+        }),
+      ]),
+    );
+  });
+
+  it("reports info when elevated mode is enabled with allowlist", async () => {
+    const cfg: OpenClawConfig = {
+      tools: { elevated: { enabled: true, allowFrom: { whatsapp: ["+1"] } } },
+    };
+
+    const res = await runSecurityAudit({
+      config: cfg,
+      includeFilesystem: false,
+      includeChannelSecurity: false,
+    });
+
+    expect(res.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "tools.elevated_enabled",
+          severity: "info",
+        }),
+      ]),
+    );
+  });
+
+  it("flags gateway TLS disabled on non-loopback as critical", async () => {
+    const cfg: OpenClawConfig = {
+      gateway: { bind: "lan", tls: { enabled: false }, auth: { token: "test" } },
+    };
+
+    const res = await runSecurityAudit({
+      config: cfg,
+      includeFilesystem: false,
+      includeChannelSecurity: false,
+    });
+
+    expect(res.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "gateway.tls_disabled",
+          severity: "critical",
+        }),
+      ]),
+    );
+  });
+
+  it("flags gateway TLS disabled on loopback as warning", async () => {
+    const cfg: OpenClawConfig = {
+      gateway: { bind: "loopback", tls: { enabled: false } },
+    };
+
+    const res = await runSecurityAudit({
+      config: cfg,
+      includeFilesystem: false,
+      includeChannelSecurity: false,
+    });
+
+    const finding = res.findings.find((f) => f.checkId === "gateway.tls_disabled");
+    expect(finding?.severity).toBe("warn");
+  });
+
+  it("does not flag gateway TLS when enabled", async () => {
+    const cfg: OpenClawConfig = {
+      gateway: { tls: { enabled: true } },
+    };
+
+    const res = await runSecurityAudit({
+      config: cfg,
+      includeFilesystem: false,
+      includeChannelSecurity: false,
+    });
+
+    expect(res.findings.some((f) => f.checkId === "gateway.tls_disabled")).toBe(false);
+  });
+
+  it("reports info when agent-to-agent messaging is enabled", async () => {
+    const cfg: OpenClawConfig = {
+      tools: { agentToAgent: { enabled: true } },
+    };
+
+    const res = await runSecurityAudit({
+      config: cfg,
+      includeFilesystem: false,
+      includeChannelSecurity: false,
+    });
+
+    expect(res.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "tools.agent_to_agent_enabled",
+          severity: "info",
+        }),
+      ]),
+    );
+  });
+
+  it("does not flag agent-to-agent when disabled", async () => {
+    const cfg: OpenClawConfig = {
+      tools: { agentToAgent: { enabled: false } },
+    };
+
+    const res = await runSecurityAudit({
+      config: cfg,
+      includeFilesystem: false,
+      includeChannelSecurity: false,
+    });
+
+    expect(res.findings.some((f) => f.checkId === "tools.agent_to_agent_enabled")).toBe(false);
+  });
+
+  it("flags sandbox writable root when sandbox enabled", async () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          sandbox: { mode: "all", docker: { readOnlyRoot: false } },
+        },
+      },
+    };
+
+    const res = await runSecurityAudit({
+      config: cfg,
+      includeFilesystem: false,
+      includeChannelSecurity: false,
+    });
+
+    expect(res.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "sandbox.docker.writable_root",
+          severity: "info",
+        }),
+      ]),
+    );
+  });
+
+  it("flags sandbox capabilities not dropped when sandbox enabled", async () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          sandbox: { mode: "all", docker: { capDrop: [] } },
+        },
+      },
+    };
+
+    const res = await runSecurityAudit({
+      config: cfg,
+      includeFilesystem: false,
+      includeChannelSecurity: false,
+    });
+
+    expect(res.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "sandbox.docker.capabilities_not_dropped",
+          severity: "info",
+        }),
+      ]),
+    );
+  });
+
+  it("does not flag sandbox filesystem when properly configured", async () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          sandbox: { mode: "all", docker: { readOnlyRoot: true, capDrop: ["ALL"] } },
+        },
+      },
+    };
+
+    const res = await runSecurityAudit({
+      config: cfg,
+      includeFilesystem: false,
+      includeChannelSecurity: false,
+    });
+
+    expect(res.findings.some((f) => f.checkId === "sandbox.docker.writable_root")).toBe(false);
+    expect(res.findings.some((f) => f.checkId === "sandbox.docker.capabilities_not_dropped")).toBe(
+      false,
+    );
+  });
+
+  it("flags missing default deny commands when most are missing", async () => {
+    const cfg: OpenClawConfig = {
+      gateway: { nodes: { denyCommands: [] } },
+    };
+
+    const res = await runSecurityAudit({
+      config: cfg,
+      includeFilesystem: false,
+      includeChannelSecurity: false,
+    });
+
+    expect(res.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "gateway.nodes.deny_commands_missing_defaults",
+          severity: "info",
+        }),
+      ]),
+    );
+  });
+
   describe("maybeProbeGateway auth selection", () => {
     const originalEnvToken = process.env.OPENCLAW_GATEWAY_TOKEN;
     const originalEnvPassword = process.env.OPENCLAW_GATEWAY_PASSWORD;

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -10,19 +10,27 @@ import { buildGatewayConnectionDetails } from "../gateway/call.js";
 import { probeGateway } from "../gateway/probe.js";
 import { collectChannelSecurityFindings } from "./audit-channel.js";
 import {
+  collectAgentToAgentFindings,
   collectAttackSurfaceSummaryFindings,
+  collectDangerousToolsFindings,
+  collectDenyCommandsDefaultsFindings,
+  collectElevatedModeFindings,
   collectExposureMatrixFindings,
+  collectGatewayTlsFindings,
   collectHooksHardeningFindings,
   collectIncludeFilePermFindings,
   collectInstalledSkillsCodeSafetyFindings,
   collectMinimalProfileOverrideFindings,
   collectModelHygieneFindings,
   collectNodeDenyCommandPatternFindings,
-  collectSmallModelRiskFindings,
-  collectSandboxDockerNoopFindings,
-  collectPluginsTrustFindings,
-  collectSecretsInConfigFindings,
   collectPluginsCodeSafetyFindings,
+  collectPluginsTrustFindings,
+  collectSandboxDockerNoopFindings,
+  collectSandboxFilesystemFindings,
+  collectSandboxModeFindings,
+  collectSandboxNetworkFindings,
+  collectSecretsInConfigFindings,
+  collectSmallModelRiskFindings,
   collectStateDeepFilesystemFindings,
   collectSyncedFolderFindings,
   readConfigSnapshotForAudit,
@@ -578,6 +586,16 @@ export async function runSecurityAudit(opts: SecurityAuditOptions): Promise<Secu
   findings.push(...collectModelHygieneFindings(cfg));
   findings.push(...collectSmallModelRiskFindings({ cfg, env }));
   findings.push(...collectExposureMatrixFindings(cfg));
+
+  // Hardening gap checks (EarlyCore findings)
+  findings.push(...collectSandboxModeFindings({ cfg, env }));
+  findings.push(...collectSandboxNetworkFindings(cfg));
+  findings.push(...collectSandboxFilesystemFindings(cfg));
+  findings.push(...collectDangerousToolsFindings(cfg));
+  findings.push(...collectElevatedModeFindings(cfg));
+  findings.push(...collectGatewayTlsFindings(cfg));
+  findings.push(...collectAgentToAgentFindings(cfg));
+  findings.push(...collectDenyCommandsDefaultsFindings(cfg));
 
   const configSnapshot =
     opts.includeFilesystem !== false


### PR DESCRIPTION
## Summary

- Add new security audit checks to detect when hardened configuration options are not enabled
- Based on gap analysis from `harden-config.ts` enforcement patterns
- Includes 10 new check IDs covering sandbox, tools, gateway TLS, and command blocking

### New Audit Checks

| Check ID | Severity | Description |
|----------|----------|-------------|
| `sandbox.mode_not_all` | Critical/Warn | Sandbox mode not set to "all" |
| `sandbox.docker.network_not_isolated` | Critical | Sandbox network allows SSRF |
| `tools.dangerous_not_denied` | Warn | Dangerous tools not in deny list |
| `tools.elevated_enabled` | Info | Elevated mode is enabled |
| `tools.elevated_enabled_no_allowlist` | Warn | Elevated mode without allowlist |
| `gateway.tls_disabled` | Warn/Critical | TLS not enabled |
| `tools.agent_to_agent_enabled` | Info | Agent-to-agent messaging enabled |
| `sandbox.docker.writable_root` | Info | Sandbox root filesystem writable |
| `sandbox.docker.capabilities_not_dropped` | Info | Linux capabilities not dropped |
| `gateway.nodes.deny_commands_missing_defaults` | Info | Default dangerous commands not blocked |

## Why This Is Needed

**The problem:** Users deploying OpenClaw with default configuration have zero isolation. There's no way to **audit** whether a deployment has these protections enabled.

**Related issues requesting this:**

- **#7139** - [Critical: Default configuration provides zero isolation](https://github.com/openclaw/openclaw/issues/7139)
  > "A user who downloads OpenClaw and runs it with default settings is giving an AI agent full filesystem access, credentials stored where any malware can read them, direct shell execution with no sandboxing, no network isolation."

- **#11591** - [Infosec Audit: 65+ P0/P1 Vulnerabilities](https://github.com/openclaw/openclaw/issues/11591)
  > Documents 50+ P0 critical vulnerabilities including shell command injection, plaintext secrets, and authorization bypass.

- **#12506** - [Unified Security Profile System with Preset Scenario Templates](https://github.com/openclaw/openclaw/issues/12506)
  > "OpenClaw deployments run with effectively zero security configuration despite the platform having partial security mechanisms available."

- **#8093** - [RFC: Security Hardening Architecture & Vulnerability Report](https://github.com/openclaw/openclaw/issues/8093)

- **#7604** - [Security Hardening: Request Timeouts, Credential Encryption, Skill Signing, and Prompt Injection Defense](https://github.com/openclaw/openclaw/issues/7604)

**This PR addresses the gap** by making `openclaw security audit` proactively warn users when their configuration lacks hardening protections. Previously, users had to manually compare their config against `harden-config.ts` to know if they were protected.

## Test Plan

- [x] All 77 unit tests pass (19 new tests added)
- [x] Linter passes with no errors
- [x] Manual verification: `openclaw security audit` shows new findings

**Before this PR:**
```
Summary: 0 critical · 3 warn · 1 info
```

**After this PR:**
```
Summary: 1 critical · 5 warn · 1 info

CRITICAL
sandbox.mode_not_all Sandbox mode is "off"
  Sandbox is disabled. All tool execution runs on the host without isolation.
  Fix: Set agents.defaults.sandbox.mode="all" to isolate all tool execution.
```

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Implements 10 new security audit checks to detect hardening configuration gaps based on EarlyCore security research findings. The implementation correctly uses the existing tool policy resolution system (`resolveToolPolicies`, `isToolAllowedByPolicies`) to determine tool availability, properly handles Tailscale exposure detection, and uses authoritative node command lists from `node-command-policy.ts`.

**Key changes:**
- Adds checks for sandbox mode, network isolation, dangerous tools, elevated mode, TLS configuration, and node commands
- Severity levels escalate based on actual risk (e.g., `sandbox.mode_not_all` is critical when exec/web tools are available, warn otherwise)
- All previously reported issues from review threads have been addressed
- 19 new unit tests provide comprehensive coverage (77 total tests passing)

**One minor issue found:**
- Documentation table has incorrect check ID (`gateway.nodes.deny_commands_missing_defaults` should be `gateway.nodes.dangerous_commands_allowed`)

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one minor documentation fix needed
- The implementation is technically sound with proper use of existing policy resolution helpers, comprehensive test coverage (19 new tests), and all previously identified issues resolved. The only issue is a documentation typo for one check ID name. The security checks themselves are well-designed with appropriate severity levels based on actual risk assessment.
- docs/gateway/security/index.md requires a one-line fix to correct the check ID name. All other files are production-ready.

<sub>Last reviewed commit: 7fbdd21</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->