### PR TITLE
Fix: Gemini REQUIRED_FIELD_MISSING on corrupted toolResults

### DIFF
--- a/src/providers/google-shared.repro-missing-name.test.ts
+++ b/src/providers/google-shared.repro-missing-name.test.ts
@@ -1,0 +1,67 @@
+import type { Context, Model } from "@mariozechner/pi-ai/dist/types.js";
+import { convertMessages } from "@mariozechner/pi-ai/dist/providers/google-shared.js";
+import { describe, expect, it } from "vitest";
+
+const makeGeminiCliModel = (id: string): Model<"google-gemini-cli"> =>
+  ({
+    id,
+    name: id,
+    api: "google-gemini-cli",
+    provider: "google-gemini-cli",
+    baseUrl: "https://example.invalid",
+    reasoning: false,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 1,
+    maxTokens: 1,
+  }) as Model<"google-gemini-cli">;
+
+describe("google-shared REQUIRED_FIELD_MISSING repro", () => {
+  it("shows that toolResult without toolName leads to missing name in functionResponse", () => {
+    const model = makeGeminiCliModel("gemini-3-flash");
+    const context = {
+      messages: [
+        {
+          role: "user",
+          content: "Use a tool",
+        },
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              id: "call_1",
+              name: "myTool",
+              arguments: { arg: "value" },
+            },
+          ],
+          api: "google-gemini-cli",
+          provider: "google-gemini-cli",
+          model: "gemini-3-flash",
+          usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+          stopReason: "stop",
+          timestamp: 0,
+        },
+        {
+          role: "toolResult",
+          toolCallId: "call_1",
+          // toolName: "myTool", // MISSING!
+          content: [{ type: "text", text: "Tool result" }],
+          isError: false,
+          timestamp: 0,
+        },
+      ],
+    } as unknown as Context;
+
+    const contents = convertMessages(model, context);
+    const parts = contents.flatMap((content) => content.parts ?? []);
+    const toolResponsePart = parts.find(
+      (part) => typeof part === "object" && part !== null && "functionResponse" in part,
+    ) as any;
+
+    expect(toolResponsePart).toBeTruthy();
+    // This is the bug: if toolName is missing, name becomes undefined
+    // which Gemini API rejects with REQUIRED_FIELD_MISSING
+    expect(toolResponsePart.functionResponse.name).toBeUndefined();
+  });
+});


### PR DESCRIPTION
...

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new Vitest repro test that constructs a conversation with a `toolResult` missing `toolName` and asserts that `convertMessages()` produces a `functionResponse` with `name: undefined`, matching the Gemini `REQUIRED_FIELD_MISSING` failure mode.

The test follows the existing pattern of `google-shared.*.test.ts` regression checks intended to lock down message/tool conversion behavior for Google/Gemini providers, but it currently imports conversion logic from `@mariozechner/pi-ai/dist/...` rather than from repo-local code.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is; the added test is likely to fail in CI due to an unresolvable module import in a clean checkout.
- Confidence is reduced because the new test imports `@mariozechner/pi-ai/dist/providers/google-shared.js`, which cannot be resolved without installing deps and relies on a dependency’s internal `dist/` layout. In environments where dependencies aren’t present (or the dependency’s packaging changes), this will fail at import time and break the test suite. The remainder of the change is isolated to a new test file.
- src/providers/google-shared.repro-missing-name.test.ts

<sub>Last reviewed commit: 29fe2f0</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->