### PR TITLE
fix: timestamp parsing should convert seconds to milliseconds

### DIFF
--- a/src/cron/parse.test.ts
+++ b/src/cron/parse.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import { parseAbsoluteTimeMs } from "./parse.js";
+
+describe("parseAbsoluteTimeMs", () => {
+  describe("Unix timestamp (seconds)", () => {
+    it("converts Unix timestamp to milliseconds (#15724)", () => {
+      // 2026-02-13T18:00:00.000Z in seconds
+      const unixSeconds = 1771005600;
+      const result = parseAbsoluteTimeMs(String(unixSeconds));
+      
+      // Should convert seconds to milliseconds
+      expect(result).toBe(unixSeconds * 1000);
+      
+      // Verify the date is correct
+      expect(new Date(result!).toISOString()).toBe("2026-02-13T18:00:00.000Z");
+    });
+
+    it("handles recent timestamps correctly", () => {
+      // 2024-01-01T00:00:00.000Z in seconds
+      const unixSeconds = 1704067200;
+      const result = parseAbsoluteTimeMs(String(unixSeconds));
+      
+      expect(result).toBe(unixSeconds * 1000);
+      expect(new Date(result!).toISOString()).toBe("2024-01-01T00:00:00.000Z");
+    });
+
+    it("handles future timestamps correctly", () => {
+      // 2030-01-01T00:00:00.000Z in seconds
+      const unixSeconds = 1893456000;
+      const result = parseAbsoluteTimeMs(String(unixSeconds));
+      
+      expect(result).toBe(unixSeconds * 1000);
+      expect(new Date(result!).toISOString()).toBe("2030-01-01T00:00:00.000Z");
+    });
+  });
+
+  describe("ISO 8601 format", () => {
+    it("parses full ISO timestamp", () => {
+      const iso = "2026-02-13T18:00:00.000Z";
+      const result = parseAbsoluteTimeMs(iso);
+      
+      expect(result).toBe(Date.parse(iso));
+      expect(result).toBe(1771005600000);
+    });
+
+    it("parses ISO timestamp without milliseconds", () => {
+      const iso = "2026-02-13T18:00:00Z";
+      const result = parseAbsoluteTimeMs(iso);
+      
+      expect(result).toBe(Date.parse(iso));
+    });
+
+    it("parses ISO date without time (assumes 00:00:00Z)", () => {
+      const iso = "2026-02-13";
+      const result = parseAbsoluteTimeMs(iso);
+      
+      expect(result).toBe(Date.parse("2026-02-13T00:00:00Z"));
+    });
+
+    it("parses ISO timestamp without timezone (assumes Z)", () => {
+      const iso = "2026-02-13T18:00:00";
+      const result = parseAbsoluteTimeMs(iso);
+      
+      expect(result).toBe(Date.parse("2026-02-13T18:00:00Z"));
+    });
+
+    it("parses ISO timestamp with timezone offset", () => {
+      const iso = "2026-02-13T18:00:00+09:00";
+      const result = parseAbsoluteTimeMs(iso);
+      
+      // +09:00 is 9 hours ahead of UTC
+      expect(result).toBe(Date.parse("2026-02-13T09:00:00Z"));
+    });
+  });
+
+  describe("edge cases", () => {
+    it("returns null for empty string", () => {
+      expect(parseAbsoluteTimeMs("")).toBe(null);
+    });
+
+    it("returns null for whitespace", () => {
+      expect(parseAbsoluteTimeMs("   ")).toBe(null);
+    });
+
+    it("returns null for zero", () => {
+      expect(parseAbsoluteTimeMs("0")).toBe(null);
+    });
+
+    it("returns null for negative number", () => {
+      expect(parseAbsoluteTimeMs("-1234567890")).toBe(null);
+    });
+
+    it("returns null for invalid ISO string", () => {
+      expect(parseAbsoluteTimeMs("not-a-date")).toBe(null);
+    });
+
+    it("returns null for malformed timestamp", () => {
+      expect(parseAbsoluteTimeMs("12345abc")).toBe(null);
+    });
+
+    it("handles very large Unix timestamps", () => {
+      // 2099-12-31T23:59:59Z in seconds
+      const unixSeconds = 4102444799;
+      const result = parseAbsoluteTimeMs(String(unixSeconds));
+      
+      expect(result).toBe(unixSeconds * 1000);
+    });
+
+    it("trims whitespace around Unix timestamp", () => {
+      const unixSeconds = 1771005600;
+      const result = parseAbsoluteTimeMs(`  ${unixSeconds}  `);
+      
+      expect(result).toBe(unixSeconds * 1000);
+    });
+
+    it("trims whitespace around ISO string", () => {
+      const iso = "  2026-02-13T18:00:00Z  ";
+      const result = parseAbsoluteTimeMs(iso);
+      
+      expect(result).toBe(Date.parse("2026-02-13T18:00:00Z"));
+    });
+  });
+
+  describe("regression: issue #15724", () => {
+    it("Unix timestamp should not be treated as milliseconds", () => {
+      // Before fix: returned 1771005600 (treated as ms -> 1970-01-21)
+      // After fix: returns 1771005600000 (treated as s -> 2026-02-13)
+      const unixSeconds = 1771005600;
+      const result = parseAbsoluteTimeMs(String(unixSeconds));
+      const date = new Date(result!);
+      
+      // Should be in 2026, not 1970
+      expect(date.getFullYear()).toBe(2026);
+      expect(date.getFullYear()).not.toBe(1970);
+      
+      // Exact timestamp
+      expect(result).toBe(1771005600000);
+      expect(date.toISOString()).toBe("2026-02-13T18:00:00.000Z");
+    });
+  });
+});

--- a/src/cron/parse.ts
+++ b/src/cron/parse.ts
@@ -23,7 +23,7 @@ export function parseAbsoluteTimeMs(input: string): number | null {
   if (/^\d+$/.test(raw)) {
     const n = Number(raw);
     if (Number.isFinite(n) && n > 0) {
-      return Math.floor(n);
+      return Math.floor(n * 1000); // Convert Unix timestamp (seconds) to milliseconds
     }
   }
   const parsed = Date.parse(normalizeUtcIso(raw));

--- a/src/cron/validate-timestamp.ts
+++ b/src/cron/validate-timestamp.ts
@@ -35,7 +35,7 @@ export function validateScheduleTimestamp(
   if (atMs === null || !Number.isFinite(atMs)) {
     return {
       ok: false,
-      message: `Invalid schedule.at: expected ISO-8601 timestamp (got ${String(schedule.at)})`,
+      message: `Invalid schedule.at: expected ISO-8601 timestamp or Unix seconds (got ${String(schedule.at)})`,
     };
   }
 


### PR DESCRIPTION
## Summary

Fixes #15724

This PR fixes a critical bug in `parseAbsoluteTimeMs()` where Unix timestamps (seconds) were incorrectly treated as milliseconds, causing timestamps to be off by 1000x.

## Root Cause

The `parseAbsoluteTimeMs()` function is supposed to return milliseconds (as its name indicates), but when the input is a pure numeric string (Unix timestamp in seconds), it was returned as-is without conversion.

**Example:**
- Input: `1771005600` (2026-02-13 18:00:00 UTC in seconds)
- Expected: `1771005600000` ms → 2026-02-13
- Actual (before fix): `1771005600` ms → 1970-01-21 ❌

## Solution

Convert numeric input by multiplying by 1000 to convert seconds to milliseconds:

```typescript
// Before
return Math.floor(n);

// After
return Math.floor(n * 1000); // Convert Unix timestamp (seconds) to milliseconds
```

ISO 8601 strings already work correctly because `Date.parse()` returns milliseconds.

## Testing

Added comprehensive test suite in `src/cron/parse.test.ts`:
- ✅ Unix timestamp conversion (seconds → milliseconds)
- ✅ ISO 8601 formats (full, date-only, with/without timezone)
- ✅ Edge cases (empty, whitespace, negative, zero, very large numbers)
- ✅ Regression test for issue #15724

**Key test:**
```typescript
const unixSeconds = 1771005600; // 2026-02-13T18:00:00.000Z
const result = parseAbsoluteTimeMs(String(unixSeconds));
expect(result).toBe(1771005600000); // Milliseconds
expect(new Date(result!).toISOString()).toBe("2026-02-13T18:00:00.000Z");
```

## Impact

**Fixed:**
- Absolute timestamp scheduling with `--at` now works correctly for Unix timestamps

**Unaffected:**
- Relative scheduling (`--every`, `--interval`) continues to work
- ISO 8601 format continues to work (was already correct)

## Breaking Change

⚠️ **Potential breaking change:** If anyone was passing milliseconds as numeric strings (undocumented behavior), they need to either:
- Use ISO 8601 format instead (recommended)
- Divide their input by 1000 to convert to seconds

However, this was never documented, and the function name clearly indicates it expects/returns milliseconds.

## Checklist

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Tests added/updated
- [ ] Documentation updated (if needed)
- [x] Related issue linked (#15724)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates `parseAbsoluteTimeMs()` to treat purely numeric inputs as Unix timestamps in **seconds** and convert them to milliseconds (`n * 1000`). A new Vitest suite (`src/cron/parse.test.ts`) covers Unix timestamps, ISO-8601 variants, trimming/invalid inputs, and a regression for #15724.

`parseAbsoluteTimeMs()` is used throughout the cron CLI and cron schedule normalization/validation paths, so this fix directly affects `--at` absolute scheduling and any schedule fields that flow through that parser.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge with one user-facing validation message inconsistency to fix.
- The parsing change is small and well-targeted, and the added tests align with the new behavior. The main issue found is an existing validation error message that now contradicts the accepted input formats (ISO-only wording), which can mislead users but does not break runtime behavior.
- src/cron/validate-timestamp.ts (error message wording vs accepted formats)

<sub>Last reviewed commit: 5935d40</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->