### PR TITLE
fix: strip device suffix from selfJid in WhatsApp mention matching

### DIFF
--- a/src/web/auto-reply/mentions.ts
+++ b/src/web/auto-reply/mentions.ts
@@ -28,7 +28,7 @@ export function resolveMentionTargets(msg: WebInboundMsg, authDir?: string): Men
     ? msg.mentionedJids.map((jid) => jidToE164(jid, jidOptions) ?? jid).filter(Boolean)
     : [];
   const selfE164 = msg.selfE164 ?? (msg.selfJid ? jidToE164(msg.selfJid, jidOptions) : null);
-  const selfJid = msg.selfJid ? msg.selfJid.replace(/:\\d+/, "") : null;
+  const selfJid = msg.selfJid ? msg.selfJid.replace(/:\d+/, "") : null;
   return { normalizedMentions, selfE164, selfJid };
 }
 

--- a/src/web/auto-reply/monitor/group-gating.ts
+++ b/src/web/auto-reply/monitor/group-gating.ts
@@ -104,8 +104,8 @@ export function applyGroupGating(params: {
     conversationId: params.conversationId,
   });
   const requireMention = activation !== "always";
-  const selfJid = params.msg.selfJid?.replace(/:\\d+/, "");
-  const replySenderJid = params.msg.replyToSenderJid?.replace(/:\\d+/, "");
+  const selfJid = params.msg.selfJid?.replace(/:\d+/, "");
+  const replySenderJid = params.msg.replyToSenderJid?.replace(/:\d+/, "");
   const selfE164 = params.msg.selfE164 ? normalizeE164(params.msg.selfE164) : null;
   const replySenderE164 = params.msg.replyToSenderE164
     ? normalizeE164(params.msg.replyToSenderE164)


### PR DESCRIPTION
## Problem

When WhatsApp runs as a linked device, the `selfJid` has a device suffix (e.g., `6580835862:2@s.whatsapp.net`). The regex intended to strip this suffix used `/:\\d+/` (escaped backslash + literal 'd') instead of `/:\d+/` (colon + digits), so the suffix was never removed.

This caused `wasMentioned` to always be `false` in group chats because the `normalizedMentionedJids` (E.164 format like `+6580835862`) could never match the unstripped `selfJid`.

## Fix

Changed the regex from `/:\\d+/` to `/:\d+/` in three places:
- `src/web/auto-reply/mentions.ts` — `resolveMentionTargets`
- `src/web/auto-reply/monitor/group-gating.ts` — `applyGroupGating` (selfJid + replySenderJid)

Fixes #15783

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes WhatsApp mention matching on linked devices by correcting the regex used to strip the `:<device>` suffix from JIDs. Specifically, it updates `/:\\d+/` (which matches a literal `\d`) to `/:\d+/` in `resolveMentionTargets` and in group gating’s implicit-mention comparison, so `selfJid` / `replyToSenderJid` normalize from e.g. `6580…:2@s.whatsapp.net` to `6580…@s.whatsapp.net` and can match expected mention targets.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are small, localized, and correct a plainly broken regex that previously could not match WhatsApp linked-device JID suffixes. The updated regex aligns with existing JID parsing elsewhere in the repo and does not alter control flow beyond intended normalization.
- No files require special attention

<sub>Last reviewed commit: b80085d</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->