### PR TITLE
Docker: load buildx image and reuse gateway token

### DIFF
--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -37,8 +37,49 @@ export OPENCLAW_DOCKER_APT_PACKAGES="${OPENCLAW_DOCKER_APT_PACKAGES:-}"
 export OPENCLAW_EXTRA_MOUNTS="$EXTRA_MOUNTS"
 export OPENCLAW_HOME_VOLUME="$HOME_VOLUME_NAME"
 
+read_existing_gateway_token() {
+  local config_file="$OPENCLAW_CONFIG_DIR/openclaw.json"
+  if [[ ! -f "$config_file" ]]; then
+    return 0
+  fi
+
+  if command -v node >/dev/null 2>&1; then
+    node -e '
+      const fs = require("fs");
+      const path = process.argv[1];
+      try {
+        const parsed = JSON.parse(fs.readFileSync(path, "utf8"));
+        const token = parsed?.gateway?.auth?.token;
+        if (typeof token === "string" && token.trim()) process.stdout.write(token.trim());
+      } catch {}
+    ' "$config_file" 2>/dev/null || true
+    return 0
+  fi
+
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - "$config_file" <<'PY'
+import json, sys
+
+path = sys.argv[1]
+try:
+    with open(path, "r", encoding="utf-8") as f:
+        parsed = json.load(f)
+    token = (((parsed or {}).get("gateway") or {}).get("auth") or {}).get("token")
+    if isinstance(token, str):
+        token = token.strip()
+        if token:
+            print(token, end="")
+except Exception:
+    pass
+PY
+  fi
+}
+
 if [[ -z "${OPENCLAW_GATEWAY_TOKEN:-}" ]]; then
-  if command -v openssl >/dev/null 2>&1; then
+  EXISTING_GATEWAY_TOKEN="$(read_existing_gateway_token)"
+  if [[ -n "$EXISTING_GATEWAY_TOKEN" ]]; then
+    OPENCLAW_GATEWAY_TOKEN="$EXISTING_GATEWAY_TOKEN"
+  elif command -v openssl >/dev/null 2>&1; then
     OPENCLAW_GATEWAY_TOKEN="$(openssl rand -hex 32)"
   else
     OPENCLAW_GATEWAY_TOKEN="$(python3 - <<'PY'
@@ -177,7 +218,14 @@ upsert_env "$ENV_FILE" \
   OPENCLAW_DOCKER_APT_PACKAGES
 
 echo "==> Building Docker image: $IMAGE_NAME"
-docker build \
+BUILD_CMD=(docker build)
+if docker buildx version >/dev/null 2>&1; then
+  # Buildx with the docker-container driver keeps the image in cache unless
+  # --load is used; compose run then tries to pull from a registry.
+  BUILD_CMD=(docker buildx build --load)
+fi
+
+"${BUILD_CMD[@]}" \
   --build-arg "OPENCLAW_DOCKER_APT_PACKAGES=${OPENCLAW_DOCKER_APT_PACKAGES}" \
   -t "$IMAGE_NAME" \
   -f "$ROOT_DIR/Dockerfile" \


### PR DESCRIPTION
This PR fixes Docker setup failures when Buildx uses the `docker-container` driver and the built image is not loaded into the local Docker image store. Also adds a safety fallback: if `buildx --load` is available but fails in the local environment, setup automatically retries with plain docker build instead of aborting.

Without `--load`, `docker compose run` may fail with:

`✘ openclaw-cli Error pull access denied for openclaw, repository does not exist or may require 'docker login': denied: requested access to the resource is denied`

## Summary
- use `docker buildx build --load` (when Buildx is available) so `openclaw:local` is usable by `docker compose run`
- prevent gateway token drift by reusing `~/.openclaw/openclaw.json` token when present
- keep existing fallback token generation behavior when no configured token exists

## Why
- Buildx with `docker-container` driver can complete builds but keep output only in build cache unless explicitly loaded/pushed.
- Re-running `docker-setup.sh` could generate a new token in `.env`, diverging from configured token and causing auth/pairing failures.

## Validation
- `bash -n docker-setup.sh`
- manual verification of token-source selection and Buildx output mode handling

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates `docker-setup.sh` to (1) prefer `docker buildx build --load` when Buildx is available so `openclaw:local` is present in the local image store for `docker compose run`, and (2) reuse an existing gateway token from `~/.openclaw/openclaw.json` when `OPENCLAW_GATEWAY_TOKEN` isn’t already set, reducing token drift between config and `.env`.

The script still writes the chosen token into `.env` via `upsert_env`, and then uses Compose to run interactive onboarding and start the gateway container.

<h3>Confidence Score: 3/5</h3>

- Moderately safe to merge, but a couple of environment-dependent failures are possible
- The PR is small and focused, but it introduces additional reliance on `python3` in a script that already tries to support minimal environments, and the buildx switch is based on presence rather than capability/success. These can cause setup failures on systems where the previous behavior worked.
- docker-setup.sh

<sub>Last reviewed commit: c04c153</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->