### PR TITLE
fix: pass agentId to resolveSessionFilePath in additional call sites

### DIFF
--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -230,10 +230,12 @@ async function buildSubagentStatsLine(params: {
   });
 
   const sessionId = entry?.sessionId;
+  const agentId = resolveAgentIdFromSessionKey(params.sessionKey);
   let transcriptPath: string | undefined;
   if (sessionId && storePath) {
     try {
       transcriptPath = resolveSessionFilePath(sessionId, entry, {
+        agentId,
         sessionsDir: path.dirname(storePath),
       });
     } catch {

--- a/src/agents/tools/sessions-list-tool.ts
+++ b/src/agents/tools/sessions-list-tool.ts
@@ -161,7 +161,7 @@ export function createSessionsListTool(opts?: {
             transcriptPath = resolveSessionFilePath(
               sessionId,
               sessionFile ? { sessionFile } : undefined,
-              { sessionsDir: path.dirname(storePath) },
+              { agentId: entryAgentId, sessionsDir: path.dirname(storePath) },
             );
           } catch {
             transcriptPath = undefined;

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -106,6 +106,7 @@ export async function appendAssistantMessageToSessionTranscript(params: {
   let sessionFile: string;
   try {
     sessionFile = resolveSessionFilePath(entry.sessionId, entry, {
+      agentId: params.agentId,
       sessionsDir: path.dirname(storePath),
     });
   } catch (err) {


### PR DESCRIPTION
## Summary
This PR fixes additional call sites where `resolveSessionFilePath()` was called without passing `agentId` in the opts parameter, which caused non-default agents to fail with "Session file path must be within sessions directory" error.

## Changes
- `src/config/sessions/transcript.ts`: Pass `agentId` to `resolveSessionFilePath` in `appendAssistantMessageToSessionTranscript`
- `src/agents/tools/sessions-list-tool.ts`: Pass `entryAgentId` to `resolveSessionFilePath` in session list tool
- `src/agents/subagent-announce.ts`: Extract and pass `agentId` from sessionKey to `resolveSessionFilePath` in `buildSubagentStatsLine`
- `src/gateway/server-methods/chat.ts`: Add `agentId` parameter to `resolveTranscriptPath` and `appendAssistantTranscriptMessage`, and pass it through from callers

## Testing
- Verified that the code compiles without errors
- All existing tests should continue to pass
- The fix follows the existing pattern used in other call sites that were already fixed

Fixes openclaw/openclaw#15761

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates several call sites to pass an `agentId` into `resolveSessionFilePath()` so transcripts resolve under the correct per-agent sessions directory (fixing failures for non-default agents).

The main behavioral change is in `src/gateway/server-methods/chat.ts`, where transcript path resolution now optionally threads through an `agentId` derived from the session key before appending injected assistant messages to the session transcript.


<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has one path-resolution bug that can misplace transcripts when storePath is customized.
- Most changes correctly add `agentId` alongside `sessionsDir`, matching how `resolveSessionFilePath` expects to be called. However, `resolveTranscriptPath` in `src/gateway/server-methods/chat.ts` drops `sessionsDir` whenever `agentId` is present, which changes semantics and can resolve to the wrong sessions directory for custom store paths.
- src/gateway/server-methods/chat.ts

<sub>Last reviewed commit: 55385e3</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->