### PR TITLE
docs(security): comprehensive security audit report

### DIFF
--- a/docs/security/AUDIT-2026-02-13.md
+++ b/docs/security/AUDIT-2026-02-13.md
@@ -10,12 +10,12 @@ A comprehensive security audit of the OpenClaw codebase was conducted using six 
 
 **43 total findings** were identified:
 
-| Severity | Count | Primary Domains |
-|----------|-------|----------------|
-| **CRITICAL** | 7 | Chinese AI data sovereignty (zero controls) |
-| **HIGH** | 10 | Plugin isolation, hooks injection, supply chain, browser automation |
-| **MEDIUM** | 15 | Auth defaults, prototype pollution, sandbox config, CI gaps |
-| **LOW** | 11 | Timing oracles, SSRF edge cases, Unicode bypasses |
+| Severity     | Count | Primary Domains                                                     |
+| ------------ | ----- | ------------------------------------------------------------------- |
+| **CRITICAL** | 7     | Chinese AI data sovereignty (zero controls)                         |
+| **HIGH**     | 10    | Plugin isolation, hooks injection, supply chain, browser automation |
+| **MEDIUM**   | 15    | Auth defaults, prototype pollution, sandbox config, CI gaps         |
+| **LOW**      | 11    | Timing oracles, SSRF edge cases, Unicode bypasses                   |
 
 The codebase demonstrates strong security engineering fundamentals (SSRF protection, timing-safe auth, config redaction, sandbox hardening, exec approval system). The most urgent gaps are in **data sovereignty controls for Chinese AI providers** and **plugin system isolation**.
 
@@ -38,16 +38,16 @@ The codebase demonstrates strong security engineering fundamentals (SSRF protect
 
 ### Provider Inventory
 
-| ID | Provider | HQ | Endpoints | Data at Risk |
-|----|----------|-----|-----------|-------------|
-| C1 | MiniMax | Beijing | `api.minimax.io`, `api.minimaxi.com` | Conversations, images, code, OAuth tokens |
-| C2 | Moonshot/Kimi | Beijing | `api.moonshot.ai`, `api.moonshot.cn` | Conversations, code |
-| C3 | Z.AI/ZhipuAI | Beijing | `api.z.ai`, `open.bigmodel.cn` | Conversations, code, API keys (probe) |
-| C4 | Qwen/Alibaba | Hangzhou | `portal.qwen.ai`, `chat.qwen.ai` | Conversations, code, OAuth, images |
-| C5 | Qianfan/Baidu | Beijing | `qianfan.baidubce.com` | Conversations, code |
-| C6 | Xiaomi | Beijing | `api.xiaomimimo.com` | Conversations, code |
-| C7 | DeepSeek | Hangzhou | Via Together/Synthetic (indirect) | Model provenance concern |
-| C8 | Feishu/ByteDance | Beijing | Lark SDK (`@larksuiteoapi`) | Messages, docs, media, user info |
+| ID  | Provider         | HQ       | Endpoints                            | Data at Risk                              |
+| --- | ---------------- | -------- | ------------------------------------ | ----------------------------------------- |
+| C1  | MiniMax          | Beijing  | `api.minimax.io`, `api.minimaxi.com` | Conversations, images, code, OAuth tokens |
+| C2  | Moonshot/Kimi    | Beijing  | `api.moonshot.ai`, `api.moonshot.cn` | Conversations, code                       |
+| C3  | Z.AI/ZhipuAI     | Beijing  | `api.z.ai`, `open.bigmodel.cn`       | Conversations, code, API keys (probe)     |
+| C4  | Qwen/Alibaba     | Hangzhou | `portal.qwen.ai`, `chat.qwen.ai`     | Conversations, code, OAuth, images        |
+| C5  | Qianfan/Baidu    | Beijing  | `qianfan.baidubce.com`               | Conversations, code                       |
+| C6  | Xiaomi           | Beijing  | `api.xiaomimimo.com`                 | Conversations, code                       |
+| C7  | DeepSeek         | Hangzhou | Via Together/Synthetic (indirect)    | Model provenance concern                  |
+| C8  | Feishu/ByteDance | Beijing  | Lark SDK (`@larksuiteoapi`)          | Messages, docs, media, user info          |
 
 ### Key Concerns
 
@@ -77,15 +77,15 @@ The codebase demonstrates strong security engineering fundamentals (SSRF protect
 
 ### .cn Domain Inventory
 
-| Domain | File | Purpose |
-|--------|------|---------|
-| `api.minimaxi.com` | `extensions/minimax-portal-auth/index.ts:12` | MiniMax CN API |
-| `api.minimaxi.com` | `extensions/minimax-portal-auth/oauth.ts:7` | MiniMax CN OAuth |
-| `api.minimaxi.com` | `src/infra/provider-usage.fetch.minimax.ts:313` | Usage tracking |
-| `api.moonshot.cn` | `src/commands/onboard-auth.models.ts:12` | Moonshot CN |
-| `open.bigmodel.cn` | `src/commands/onboard-auth.models.ts:24,26` | Z.AI CN |
-| `qianfan.baidubce.com` | `src/agents/models-config.providers.ts:103` | Baidu Qianfan |
-| `api.xiaomimimo.com` | `src/agents/models-config.providers.ts:49` | Xiaomi |
+| Domain                 | File                                            | Purpose          |
+| ---------------------- | ----------------------------------------------- | ---------------- |
+| `api.minimaxi.com`     | `extensions/minimax-portal-auth/index.ts:12`    | MiniMax CN API   |
+| `api.minimaxi.com`     | `extensions/minimax-portal-auth/oauth.ts:7`     | MiniMax CN OAuth |
+| `api.minimaxi.com`     | `src/infra/provider-usage.fetch.minimax.ts:313` | Usage tracking   |
+| `api.moonshot.cn`      | `src/commands/onboard-auth.models.ts:12`        | Moonshot CN      |
+| `open.bigmodel.cn`     | `src/commands/onboard-auth.models.ts:24,26`     | Z.AI CN          |
+| `qianfan.baidubce.com` | `src/agents/models-config.providers.ts:103`     | Baidu Qianfan    |
+| `api.xiaomimimo.com`   | `src/agents/models-config.providers.ts:49`      | Xiaomi           |
 
 ---
 
@@ -250,19 +250,19 @@ The codebase demonstrates strong security engineering fundamentals (SSRF protect
 
 ## Low Severity Findings
 
-| ID | Finding | File |
-|----|---------|------|
-| L1 | Timing side-channel leaks secret length in `safeEqualSecret` | `src/security/secret-equal.ts:12-13` |
-| L2 | Token in URL fragment for dashboard (browser history exposure) | `src/commands/dashboard.e2e.test.ts:86` |
-| L3 | WebSocket origin check only for browser clients | `src/gateway/server/ws-connection/message-handler.ts:305-335` |
-| L4 | Browser SSRF via navigation to internal networks | `src/browser/pw-tools-core.interactions.ts:427-430` |
-| L5 | Shell environment loading executes user's login shell | `src/infra/shell-env.ts:69-84` |
-| L6 | External content marker bypass via uncovered Unicode homoglyphs | `src/security/external-content.ts:87-167` |
-| L7 | Webhook hook body not hard-limited before JSON parsing | `src/gateway/server-http.ts:288` |
-| L8 | Global plugin registry uses `Symbol.for()` (accessible by any in-process code) | `src/plugins/runtime.ts:19-37` |
-| L9 | `pull_request_target` in 2 workflows (mitigated with App tokens) | `.github/workflows/auto-response.yml`, `labeler.yml` |
-| L10 | `git-hooks/pre-commit` lacks secret scanning | `git-hooks/pre-commit` |
-| L11 | Link understanding CLI URL injection (mitigated by `execFile`) | `src/link-understanding/runner.ts:56-73` |
+| ID  | Finding                                                                        | File                                                          |
+| --- | ------------------------------------------------------------------------------ | ------------------------------------------------------------- |
+| L1  | Timing side-channel leaks secret length in `safeEqualSecret`                   | `src/security/secret-equal.ts:12-13`                          |
+| L2  | Token in URL fragment for dashboard (browser history exposure)                 | `src/commands/dashboard.e2e.test.ts:86`                       |
+| L3  | WebSocket origin check only for browser clients                                | `src/gateway/server/ws-connection/message-handler.ts:305-335` |
+| L4  | Browser SSRF via navigation to internal networks                               | `src/browser/pw-tools-core.interactions.ts:427-430`           |
+| L5  | Shell environment loading executes user's login shell                          | `src/infra/shell-env.ts:69-84`                                |
+| L6  | External content marker bypass via uncovered Unicode homoglyphs                | `src/security/external-content.ts:87-167`                     |
+| L7  | Webhook hook body not hard-limited before JSON parsing                         | `src/gateway/server-http.ts:288`                              |
+| L8  | Global plugin registry uses `Symbol.for()` (accessible by any in-process code) | `src/plugins/runtime.ts:19-37`                                |
+| L9  | `pull_request_target` in 2 workflows (mitigated with App tokens)               | `.github/workflows/auto-response.yml`, `labeler.yml`          |
+| L10 | `git-hooks/pre-commit` lacks secret scanning                                   | `git-hooks/pre-commit`                                        |
+| L11 | Link understanding CLI URL injection (mitigated by `execFile`)                 | `src/link-understanding/runner.ts:56-73`                      |
 
 ---
 
@@ -270,24 +270,24 @@ The codebase demonstrates strong security engineering fundamentals (SSRF protect
 
 The codebase demonstrates strong security engineering in these areas:
 
-| Area | Implementation | File(s) |
-|------|---------------|---------|
-| **SSRF Protection** | DNS pinning, private IP blocking, redirect validation, hostname blocklist | `src/infra/net/ssrf.ts` |
-| **Timing-Safe Auth** | `crypto.timingSafeEqual` for all secret comparisons | `src/security/secret-equal.ts` |
-| **External Content Wrapping** | Boundary markers with Unicode homoglyph detection for prompt injection defense | `src/security/external-content.ts` |
-| **Config Redaction** | Sentinel-based redaction with round-trip safety | `src/config/redact-snapshot.ts` |
-| **Atomic Config Writes** | Temp file + rename pattern prevents corruption | `src/config/io.ts:742-780` |
-| **Pairing Store** | `0o600` permissions, file locking, crypto-secure codes, auto-expiry | `src/pairing/pairing-store.ts` |
-| **Device Auth** | Nonce/replay protection, timestamp skew enforcement, crypto signatures | `src/gateway/server/ws-connection/message-handler.ts` |
-| **Proxy Header Detection** | Refuses untrusted `X-Forwarded-For` / `X-Real-IP` | `src/gateway/server/ws-connection/message-handler.ts:143-164` |
-| **Exec Approval System** | Per-agent allowlists, approval workflow, timeout | `src/agents/bash-tools.exec.ts` |
-| **Docker Sandbox** | Drops all caps, read-only root, no network, `no-new-privileges` | `src/agents/sandbox/config.ts`, `docker.ts` |
-| **Pre-Commit Hooks** | detect-secrets, shellcheck, zizmor (GHA security), actionlint | `.pre-commit-config.yaml` |
-| **Prototype Pollution Guards** | `BLOCKED_KEYS` set in config path operations | `src/config/config-paths.ts:5` |
-| **Path Traversal Protection** | `isSafeRelativePath` + startsWith check for Control UI | `src/gateway/control-ui.ts:225-237` |
-| **Non-Root Docker** | Drops to `USER node` after build | `Dockerfile:43` |
-| **Dependency Supply Chain** | `minimumReleaseAge: 2880` (48h) prevents typosquatting, 6 CVE overrides | `package.json`, `pnpm-workspace.yaml` |
-| **Media Sanitization** | Cross-platform filename sanitization with Unicode support | `src/media/store.ts:42-49` |
+| Area                           | Implementation                                                                 | File(s)                                                       |
+| ------------------------------ | ------------------------------------------------------------------------------ | ------------------------------------------------------------- |
+| **SSRF Protection**            | DNS pinning, private IP blocking, redirect validation, hostname blocklist      | `src/infra/net/ssrf.ts`                                       |
+| **Timing-Safe Auth**           | `crypto.timingSafeEqual` for all secret comparisons                            | `src/security/secret-equal.ts`                                |
+| **External Content Wrapping**  | Boundary markers with Unicode homoglyph detection for prompt injection defense | `src/security/external-content.ts`                            |
+| **Config Redaction**           | Sentinel-based redaction with round-trip safety                                | `src/config/redact-snapshot.ts`                               |
+| **Atomic Config Writes**       | Temp file + rename pattern prevents corruption                                 | `src/config/io.ts:742-780`                                    |
+| **Pairing Store**              | `0o600` permissions, file locking, crypto-secure codes, auto-expiry            | `src/pairing/pairing-store.ts`                                |
+| **Device Auth**                | Nonce/replay protection, timestamp skew enforcement, crypto signatures         | `src/gateway/server/ws-connection/message-handler.ts`         |
+| **Proxy Header Detection**     | Refuses untrusted `X-Forwarded-For` / `X-Real-IP`                              | `src/gateway/server/ws-connection/message-handler.ts:143-164` |
+| **Exec Approval System**       | Per-agent allowlists, approval workflow, timeout                               | `src/agents/bash-tools.exec.ts`                               |
+| **Docker Sandbox**             | Drops all caps, read-only root, no network, `no-new-privileges`                | `src/agents/sandbox/config.ts`, `docker.ts`                   |
+| **Pre-Commit Hooks**           | detect-secrets, shellcheck, zizmor (GHA security), actionlint                  | `.pre-commit-config.yaml`                                     |
+| **Prototype Pollution Guards** | `BLOCKED_KEYS` set in config path operations                                   | `src/config/config-paths.ts:5`                                |
+| **Path Traversal Protection**  | `isSafeRelativePath` + startsWith check for Control UI                         | `src/gateway/control-ui.ts:225-237`                           |
+| **Non-Root Docker**            | Drops to `USER node` after build                                               | `Dockerfile:43`                                               |
+| **Dependency Supply Chain**    | `minimumReleaseAge: 2880` (48h) prevents typosquatting, 6 CVE overrides        | `package.json`, `pnpm-workspace.yaml`                         |
+| **Media Sanitization**         | Cross-platform filename sanitization with Unicode support                      | `src/media/store.ts:42-49`                                    |
 
 ---
 
@@ -296,6 +296,7 @@ The codebase demonstrates strong security engineering in these areas:
 ### Priority 1 — Data Sovereignty Controls (Eliminates 7 CRITICAL)
 
 1. Add `dataSovereignty` config section:
+
    ```typescript
    dataSovereignty: {
      blockChineseProviders: boolean;     // default: false
@@ -303,6 +304,7 @@ The codebase demonstrates strong security engineering in these areas:
      allowedJurisdictions: string[];     // e.g. ["us", "eu"]
    }
    ```
+
 2. Add `jurisdiction` metadata to every provider definition
 3. Add `DATA SOVEREIGNTY WARNING` to all Chinese provider documentation
 4. Add consent prompt during onboarding when Chinese provider is selected
@@ -343,17 +345,17 @@ The codebase demonstrates strong security engineering in these areas:
 
 This audit was conducted using six specialized agents running in parallel:
 
-| Agent | Focus | Findings |
-|-------|-------|----------|
-| Security Auditor #1 | Gateway auth, secrets, pairing, config reload | 13 |
-| Compliance Auditor | Chinese AI provider data sovereignty | 10 |
-| Penetration Tester #1 | Input validation, injection surfaces, SSRF | 12 |
-| Code Reviewer | Security bugs in core subsystems | 5 |
-| Security Auditor #2 | Dependencies, supply chain, CI/CD, Docker | 18 |
-| Penetration Tester #2 | Plugin sandbox, hooks, cross-channel isolation | 19 |
+| Agent                 | Focus                                          | Findings |
+| --------------------- | ---------------------------------------------- | -------- |
+| Security Auditor #1   | Gateway auth, secrets, pairing, config reload  | 13       |
+| Compliance Auditor    | Chinese AI provider data sovereignty           | 10       |
+| Penetration Tester #1 | Input validation, injection surfaces, SSRF     | 12       |
+| Code Reviewer         | Security bugs in core subsystems               | 5        |
+| Security Auditor #2   | Dependencies, supply chain, CI/CD, Docker      | 18       |
+| Penetration Tester #2 | Plugin sandbox, hooks, cross-channel isolation | 19       |
 
 All findings were deduplicated and consolidated. Source files were read directly; no tests were run against live systems.
 
 ---
 
-*Generated by automated security audit agents on 2026-02-13.*
+_Generated by automated security audit agents on 2026-02-13._

--- a/docs/security/AUDIT-2026-02-13.md
+++ b/docs/security/AUDIT-2026-02-13.md
@@ -113,7 +113,7 @@ The codebase demonstrates strong security engineering fundamentals (SSRF protect
 ### H4: Cross-Channel Data Leakage via Shared DM Session
 
 - **File**: `src/security/audit-channel.ts:110-122`
-- **Issue**: `session.dmScope` defaults to `"main"` — ALL DM senders across ALL channels share the same session context.
+- **Issue**: `session.dmScope` falls back to `"main"` when unset — ALL DM senders across ALL channels share the same session context.
 - **Fix**: Default `dmScope` to `"per-channel-peer"` for new installations.
 
 ### H5: Plugin Runtime Exposes ALL Channel Send Functions

--- a/docs/security/AUDIT-2026-02-13.md
+++ b/docs/security/AUDIT-2026-02-13.md
@@ -1,0 +1,359 @@
+# Security Audit Report — 2026-02-13
+
+**Branch**: `main` (`caebe70e9`) | **Scope**: Full codebase | **Method**: 6 parallel automated security agents
+
+---
+
+## Executive Summary
+
+A comprehensive security audit of the OpenClaw codebase was conducted using six specialized agents covering gateway authentication, data sovereignty compliance, penetration testing, code review, dependency analysis, and plugin/sandbox isolation.
+
+**43 total findings** were identified:
+
+| Severity | Count | Primary Domains |
+|----------|-------|----------------|
+| **CRITICAL** | 7 | Chinese AI data sovereignty (zero controls) |
+| **HIGH** | 10 | Plugin isolation, hooks injection, supply chain, browser automation |
+| **MEDIUM** | 15 | Auth defaults, prototype pollution, sandbox config, CI gaps |
+| **LOW** | 11 | Timing oracles, SSRF edge cases, Unicode bypasses |
+
+The codebase demonstrates strong security engineering fundamentals (SSRF protection, timing-safe auth, config redaction, sandbox hardening, exec approval system). The most urgent gaps are in **data sovereignty controls for Chinese AI providers** and **plugin system isolation**.
+
+---
+
+## Table of Contents
+
+- [Critical — Chinese AI Data Sovereignty](#critical--chinese-ai-data-sovereignty)
+- [High Severity Findings](#high-severity-findings)
+- [Medium Severity Findings](#medium-severity-findings)
+- [Low Severity Findings](#low-severity-findings)
+- [Positive Security Findings](#positive-security-findings)
+- [Remediation Priorities](#remediation-priorities)
+
+---
+
+## Critical — Chinese AI Data Sovereignty
+
+**8 Chinese AI providers are integrated with zero data sovereignty warnings, zero opt-out controls, and zero jurisdiction disclosures.**
+
+### Provider Inventory
+
+| ID | Provider | HQ | Endpoints | Data at Risk |
+|----|----------|-----|-----------|-------------|
+| C1 | MiniMax | Beijing | `api.minimax.io`, `api.minimaxi.com` | Conversations, images, code, OAuth tokens |
+| C2 | Moonshot/Kimi | Beijing | `api.moonshot.ai`, `api.moonshot.cn` | Conversations, code |
+| C3 | Z.AI/ZhipuAI | Beijing | `api.z.ai`, `open.bigmodel.cn` | Conversations, code, API keys (probe) |
+| C4 | Qwen/Alibaba | Hangzhou | `portal.qwen.ai`, `chat.qwen.ai` | Conversations, code, OAuth, images |
+| C5 | Qianfan/Baidu | Beijing | `qianfan.baidubce.com` | Conversations, code |
+| C6 | Xiaomi | Beijing | `api.xiaomimimo.com` | Conversations, code |
+| C7 | DeepSeek | Hangzhou | Via Together/Synthetic (indirect) | Model provenance concern |
+| C8 | Feishu/ByteDance | Beijing | Lark SDK (`@larksuiteoapi`) | Messages, docs, media, user info |
+
+### Key Concerns
+
+1. **MiniMax labeled "recommended"** in auth choice with no jurisdiction caveat
+   - File: `src/commands/auth-choice-options.ts:45`
+
+2. **Z.AI endpoint detection probes Chinese servers** with user API keys
+   - File: `src/commands/zai-endpoint-detect.ts`
+
+3. **MiniMax VLM sends base64-encoded user images** directly to Chinese infrastructure
+   - File: `src/agents/minimax-vlm.ts:39-113`
+
+4. **12 environment variables** for Chinese providers in `.env.example` with no sovereignty comments:
+   `ZAI_API_KEY`, `Z_AI_API_KEY`, `MINIMAX_API_KEY`, `MINIMAX_OAUTH_TOKEN`, `MINIMAX_API_HOST`, `MOONSHOT_API_KEY`, `KIMI_API_KEY`, `KIMICODE_API_KEY`, `QWEN_OAUTH_TOKEN`, `QWEN_PORTAL_API_KEY`, `XIAOMI_API_KEY`, `QIANFAN_API_KEY`
+
+5. **Provider ID normalization hides origin**: `z.ai` and `z-ai` normalized to `zai`
+   - File: `src/agents/model-selection.ts:35-37`
+
+### Missing Controls
+
+- No `dataSovereignty` configuration option
+- No provider jurisdiction metadata on provider definitions
+- No data sovereignty warnings in onboarding or docs
+- No opt-in/opt-out mechanism for Chinese providers
+- No audit logging for data routed to Chinese infrastructure
+- No consent prompt when selecting a Chinese provider
+
+### .cn Domain Inventory
+
+| Domain | File | Purpose |
+|--------|------|---------|
+| `api.minimaxi.com` | `extensions/minimax-portal-auth/index.ts:12` | MiniMax CN API |
+| `api.minimaxi.com` | `extensions/minimax-portal-auth/oauth.ts:7` | MiniMax CN OAuth |
+| `api.minimaxi.com` | `src/infra/provider-usage.fetch.minimax.ts:313` | Usage tracking |
+| `api.moonshot.cn` | `src/commands/onboard-auth.models.ts:12` | Moonshot CN |
+| `open.bigmodel.cn` | `src/commands/onboard-auth.models.ts:24,26` | Z.AI CN |
+| `qianfan.baidubce.com` | `src/agents/models-config.providers.ts:103` | Baidu Qianfan |
+| `api.xiaomimimo.com` | `src/agents/models-config.providers.ts:49` | Xiaomi |
+
+---
+
+## High Severity Findings
+
+### H1: Plugins Execute In-Process with Full Host Access
+
+- **Files**: `src/plugins/loader.ts:299`, `src/plugins/runtime/types.ts:178-362`
+- **Issue**: `jiti()` loads arbitrary TypeScript with no VM/worker isolation. Full `PluginRuntime` API exposed including config write, shell exec, and all channel send functions.
+- **Impact**: A malicious plugin achieves complete system compromise.
+- **Fix**: Implement capability-based permission model; run untrusted plugins in worker threads with IPC.
+
+### H2: `before_agent_start` Hook Can Replace System Prompt
+
+- **File**: `src/plugins/hooks.ts:183-199`
+- **Issue**: Last plugin to return `systemPrompt` wins completely, enabling system-level prompt injection.
+- **Fix**: Restrict `systemPrompt` replacement to trusted/bundled plugins only; audit log all modifications.
+
+### H3: `before_tool_call` Hook Can Modify Tool Parameters
+
+- **File**: `src/plugins/hooks.ts:288-302`
+- **Issue**: Hook can change `exec` commands, file paths, and bypass approvals by modifying tool params.
+- **Fix**: Validate parameters after hook execution for security-critical tools.
+
+### H4: Cross-Channel Data Leakage via Shared DM Session
+
+- **File**: `src/security/audit-channel.ts:110-122`
+- **Issue**: `session.dmScope` defaults to `"main"` — ALL DM senders across ALL channels share the same session context.
+- **Fix**: Default `dmScope` to `"per-channel-peer"` for new installations.
+
+### H5: Plugin Runtime Exposes ALL Channel Send Functions
+
+- **File**: `src/plugins/runtime/index.ts:239-432`
+- **Issue**: Every plugin receives `sendMessageTelegram`, `sendMessageDiscord`, `sendMessageSlack`, etc. No channel scoping.
+- **Fix**: Scope runtime API per-plugin based on registered channel.
+
+### H6: Configurable `binds` Allow Arbitrary Host Mounts
+
+- **Files**: `src/agents/sandbox/docker.ts:296-300`, `src/agents/sandbox/types.docker.ts:21`
+- **Issue**: `binds` config accepts arbitrary Docker bind mount strings with no path validation. `binds: ["/:/host"]` defeats sandbox entirely.
+- **Fix**: Validate bind paths against a denylist (`/`, `/etc`, `/var`, `~/.ssh`).
+
+### H7: Browser `evaluate` Executes Arbitrary JavaScript
+
+- **File**: `src/browser/pw-tools-core.interactions.ts:220-368`
+- **Issue**: When `evaluateEnabled` is true, arbitrary JS runs in browser context with full DOM/cookie access. Exploitable via prompt injection directing AI agents.
+- **Fix**: Keep default off; add function allowlist, audit logging, and CSP layer when enabled.
+
+### H8: Unpinned Bun Install via `curl | bash` in Dockerfile
+
+- **File**: `Dockerfile:4`
+- **Issue**: `curl -fsSL https://bun.sh/install | bash` — no version pin, no checksum verification.
+- **Fix**: Pin version and verify checksum: `curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_VERSION}"`.
+
+### H9: 30+ GitHub Actions Pinned by Mutable Tag
+
+- **Files**: `.github/workflows/ci.yml`, `docker-release.yml`, `install-smoke.yml`, others
+- **Issue**: Actions use `@v4`/`@v5` tags instead of SHA hashes. Workflows with write permissions and secret access are at risk.
+- **Fix**: Pin all actions to full commit SHA, especially in workflows with `packages: write` or secret access.
+
+### H10: Plugin Discovery Loads from Uncontrolled Workspace Paths
+
+- **File**: `src/plugins/discovery.ts:301-364`
+- **Issue**: `.openclaw/extensions/` in cloned repositories auto-loads plugins at startup without approval.
+- **Fix**: Implement trust-on-first-use (TOFU) requiring explicit approval before loading workspace plugins.
+
+---
+
+## Medium Severity Findings
+
+### M1: Rate Limiter Not Enabled by Default
+
+- **File**: `src/gateway/server.impl.ts:275-278`
+- **Issue**: Auth rate limiter is only created when `gateway.auth.rateLimit` is explicitly configured.
+- **Fix**: Enable with sensible defaults (10 attempts / 60s window / 300s lockout).
+
+### M2: Loopback Exemption Bypasses All Rate Limiting
+
+- **File**: `src/gateway/auth-rate-limit.ts:119-133`
+- **Issue**: Loopback connections exempt from all rate limiting. Local attacker gets unlimited attempts.
+- **Fix**: Add configurable option; implement higher threshold for loopback rather than full exemption.
+
+### M3: Prototype Pollution in `getByPath`
+
+- **File**: `src/gateway/hooks-mapping.ts:411-443`
+- **Issue**: No `__proto__`/`constructor`/`prototype` blocking in hook template path resolution against attacker-controlled payloads.
+- **Fix**: Add `BLOCKED_KEYS` check: `if (BLOCKED_KEYS.has(part)) return undefined;`
+
+### M4: Command Injection on Windows via `shell: true`
+
+- **File**: `src/process/exec.ts:121-128`
+- **Issue**: On Windows, non-.exe commands use `shell: true`, passing unsanitized arguments through `cmd.exe`.
+- **Fix**: Always use `windowsVerbatimArguments: true` or sanitize for cmd.exe metacharacters.
+
+### M5: Arbitrary Module Loading from Config-Controlled Path
+
+- **File**: `src/gateway/hooks-mapping.ts:321-331`
+- **Issue**: `loadTransform` does dynamic import on config-controlled `modulePath` with no path restriction. Config write access leads to code execution.
+- **Fix**: Restrict `modulePath` to designated transforms directory with path containment check.
+
+### M6: SQL Table Name Injection in Memory Schema
+
+- **Files**: `src/memory/memory-schema.ts:39,51,59`, `src/memory/manager-search.ts:40,158-160`
+- **Issue**: Table names interpolated into SQL via template literals without validation.
+- **Fix**: Validate against strict regex: `/^[a-z_][a-z0-9_]*$/`.
+
+### M7: Config `$include` Path Traversal
+
+- **File**: `src/config/includes.ts:157-173`
+- **Issue**: No restriction on path resolution — config can include any file readable by the process.
+- **Fix**: Restrict to config directory tree or explicit allowlist.
+
+### M8: `allowUnsafeExternalContent` Bypasses Prompt Injection Defense
+
+- **File**: `src/cron/isolated-agent/run.ts:320-323`
+- **Issue**: When true, raw webhook/email content flows to LLM without injection protection.
+- **Fix**: Add prominent warnings; run `detectSuspiciousPatterns()` even when flag is true.
+
+### M9: Plugin HTTP Routes Lack Default Authentication
+
+- **File**: `src/gateway/server-http.ts:480-501`
+- **Issue**: Non-channel plugin routes have no gateway auth by default.
+- **Fix**: Default to requiring auth; add `requireAuth: false` opt-out for public routes.
+
+### M10: Sandbox Mode Defaults to "off"
+
+- **File**: `src/agents/sandbox/config.ts:147`
+- **Issue**: Commands execute on host unless sandbox explicitly configured.
+- **Fix**: Default to `"non-main"` for new installations; log warning when off.
+
+### M11: No `pnpm audit` in CI Pipeline
+
+- **File**: `.github/workflows/ci.yml`
+- **Issue**: CI includes lint, test, build, secrets — but no dependency vulnerability scanning.
+- **Fix**: Add `pnpm audit --audit-level=high` step.
+
+### M12: Unpinned Docker Base Image Tag
+
+- **File**: `Dockerfile:1`
+- **Issue**: `node:22-bookworm` is a rolling tag — builds are not reproducible.
+- **Fix**: Pin to specific digest: `FROM node:22-bookworm@sha256:<digest>`.
+
+### M13: No Security-Level Logging for Auth Config Changes
+
+- **File**: `src/gateway/config-reload.ts:310`
+- **Issue**: Auth-related config changes logged at `info` level, not `warn`.
+- **Fix**: Detect `gateway.auth.*` path changes and log at `warn` level.
+
+### M14: Pre-Release Native Dependencies in Production
+
+- **Files**: `package.json`
+- **Issue**: `@lydell/node-pty` 1.2.0-beta.3, `sqlite-vec` 0.1.7-alpha.2, `@whiskeysockets/baileys` 7.0.0-rc.9.
+- **Fix**: Track stable releases; document accepted risk.
+
+### M15: `applyMergePatch` Doesn't Block Prototype Pollution Keys
+
+- **File**: `src/config/merge-patch.ts:5-26`
+- **Issue**: Iterates `Object.entries(patch)` without filtering `__proto__`/`constructor`/`prototype`.
+- **Fix**: Add key blocklist check matching `config-paths.ts` pattern.
+
+---
+
+## Low Severity Findings
+
+| ID | Finding | File |
+|----|---------|------|
+| L1 | Timing side-channel leaks secret length in `safeEqualSecret` | `src/security/secret-equal.ts:12-13` |
+| L2 | Token in URL fragment for dashboard (browser history exposure) | `src/commands/dashboard.e2e.test.ts:86` |
+| L3 | WebSocket origin check only for browser clients | `src/gateway/server/ws-connection/message-handler.ts:305-335` |
+| L4 | Browser SSRF via navigation to internal networks | `src/browser/pw-tools-core.interactions.ts:427-430` |
+| L5 | Shell environment loading executes user's login shell | `src/infra/shell-env.ts:69-84` |
+| L6 | External content marker bypass via uncovered Unicode homoglyphs | `src/security/external-content.ts:87-167` |
+| L7 | Webhook hook body not hard-limited before JSON parsing | `src/gateway/server-http.ts:288` |
+| L8 | Global plugin registry uses `Symbol.for()` (accessible by any in-process code) | `src/plugins/runtime.ts:19-37` |
+| L9 | `pull_request_target` in 2 workflows (mitigated with App tokens) | `.github/workflows/auto-response.yml`, `labeler.yml` |
+| L10 | `git-hooks/pre-commit` lacks secret scanning | `git-hooks/pre-commit` |
+| L11 | Link understanding CLI URL injection (mitigated by `execFile`) | `src/link-understanding/runner.ts:56-73` |
+
+---
+
+## Positive Security Findings
+
+The codebase demonstrates strong security engineering in these areas:
+
+| Area | Implementation | File(s) |
+|------|---------------|---------|
+| **SSRF Protection** | DNS pinning, private IP blocking, redirect validation, hostname blocklist | `src/infra/net/ssrf.ts` |
+| **Timing-Safe Auth** | `crypto.timingSafeEqual` for all secret comparisons | `src/security/secret-equal.ts` |
+| **External Content Wrapping** | Boundary markers with Unicode homoglyph detection for prompt injection defense | `src/security/external-content.ts` |
+| **Config Redaction** | Sentinel-based redaction with round-trip safety | `src/config/redact-snapshot.ts` |
+| **Atomic Config Writes** | Temp file + rename pattern prevents corruption | `src/config/io.ts:742-780` |
+| **Pairing Store** | `0o600` permissions, file locking, crypto-secure codes, auto-expiry | `src/pairing/pairing-store.ts` |
+| **Device Auth** | Nonce/replay protection, timestamp skew enforcement, crypto signatures | `src/gateway/server/ws-connection/message-handler.ts` |
+| **Proxy Header Detection** | Refuses untrusted `X-Forwarded-For` / `X-Real-IP` | `src/gateway/server/ws-connection/message-handler.ts:143-164` |
+| **Exec Approval System** | Per-agent allowlists, approval workflow, timeout | `src/agents/bash-tools.exec.ts` |
+| **Docker Sandbox** | Drops all caps, read-only root, no network, `no-new-privileges` | `src/agents/sandbox/config.ts`, `docker.ts` |
+| **Pre-Commit Hooks** | detect-secrets, shellcheck, zizmor (GHA security), actionlint | `.pre-commit-config.yaml` |
+| **Prototype Pollution Guards** | `BLOCKED_KEYS` set in config path operations | `src/config/config-paths.ts:5` |
+| **Path Traversal Protection** | `isSafeRelativePath` + startsWith check for Control UI | `src/gateway/control-ui.ts:225-237` |
+| **Non-Root Docker** | Drops to `USER node` after build | `Dockerfile:43` |
+| **Dependency Supply Chain** | `minimumReleaseAge: 2880` (48h) prevents typosquatting, 6 CVE overrides | `package.json`, `pnpm-workspace.yaml` |
+| **Media Sanitization** | Cross-platform filename sanitization with Unicode support | `src/media/store.ts:42-49` |
+
+---
+
+## Remediation Priorities
+
+### Priority 1 — Data Sovereignty Controls (Eliminates 7 CRITICAL)
+
+1. Add `dataSovereignty` config section:
+   ```typescript
+   dataSovereignty: {
+     blockChineseProviders: boolean;     // default: false
+     auditChineseProviders: boolean;     // default: true
+     allowedJurisdictions: string[];     // e.g. ["us", "eu"]
+   }
+   ```
+2. Add `jurisdiction` metadata to every provider definition
+3. Add `DATA SOVEREIGNTY WARNING` to all Chinese provider documentation
+4. Add consent prompt during onboarding when Chinese provider is selected
+5. Remove "recommended" label from MiniMax or add jurisdiction disclosure
+6. Add audit logging for data sent to Chinese-controlled infrastructure
+
+### Priority 2 — Plugin Capability Model (Addresses H1, H2, H3, H5, H10)
+
+1. Implement permission declarations in plugin manifests
+2. Wrap `PluginRuntime` in a proxy exposing only declared capabilities
+3. Scope channel send functions per-plugin based on registered channel
+4. Add TOFU approval for workspace-origin plugins
+5. Validate tool parameters after hook execution for security-critical tools
+6. Consider worker-thread isolation for non-bundled plugins
+
+### Priority 3 — Cross-Channel Isolation (Fixes H4)
+
+1. Default `session.dmScope` to `"per-channel-peer"`
+2. Escalate existing audit warning to a blocking prompt for multi-user setups
+
+### Priority 4 — Supply Chain Hardening (Fixes H8, H9, M11, M12)
+
+1. Pin all GitHub Actions by SHA hash
+2. Pin Bun installation in Dockerfile with checksum verification
+3. Pin Docker base image to specific digest
+4. Add `pnpm audit --audit-level=high` to CI pipeline
+
+### Priority 5 — Auth and Sandbox Defaults (Fixes M1, M2, H6, M10)
+
+1. Enable rate limiting by default with sensible thresholds
+2. Validate sandbox `binds` against a denylist of dangerous paths
+3. Default sandbox mode to `"non-main"` for new installations
+4. Add higher rate limit threshold for loopback instead of full exemption
+
+---
+
+## Methodology
+
+This audit was conducted using six specialized agents running in parallel:
+
+| Agent | Focus | Findings |
+|-------|-------|----------|
+| Security Auditor #1 | Gateway auth, secrets, pairing, config reload | 13 |
+| Compliance Auditor | Chinese AI provider data sovereignty | 10 |
+| Penetration Tester #1 | Input validation, injection surfaces, SSRF | 12 |
+| Code Reviewer | Security bugs in core subsystems | 5 |
+| Security Auditor #2 | Dependencies, supply chain, CI/CD, Docker | 18 |
+| Penetration Tester #2 | Plugin sandbox, hooks, cross-channel isolation | 19 |
+
+All findings were deduplicated and consolidated. Source files were read directly; no tests were run against live systems.
+
+---
+
+*Generated by automated security audit agents on 2026-02-13.*

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -4,6 +4,7 @@
 
 ## Documents
 
+- [Security Audit 2026-02-13](./AUDIT-2026-02-13.md) - Comprehensive security audit (43 findings across 6 domains)
 - [Threat Model](./THREAT-MODEL-ATLAS.md) - MITRE ATLAS-based threat model for the OpenClaw ecosystem
 - [Contributing to the Threat Model](./CONTRIBUTING-THREAT-MODEL.md) - How to add threats, mitigations, and attack chains
 


### PR DESCRIPTION
## Summary

- Adds a full security audit report (`docs/security/AUDIT-2026-02-13.md`) produced by 6 specialized agents scanning in parallel
- Links the report from `docs/security/README.md`

### Findings: 43 total

| Severity | Count | Primary Domains |
|----------|-------|----------------|
| **CRITICAL** | 7 | Chinese AI data sovereignty — 8 providers with zero warnings/opt-out/controls |
| **HIGH** | 10 | Plugin in-process execution, hook injection, supply chain (GH Actions pinning), browser eval |
| **MEDIUM** | 15 | Rate limiter off by default, prototype pollution, sandbox defaults, no `pnpm audit` in CI |
| **LOW** | 11 | Timing oracles, SSRF edge cases, Unicode bypasses |

### Top 5 Remediation Priorities

1. **Data sovereignty controls** — provider jurisdiction metadata, `blockChineseProviders` config, consent prompts, doc warnings
2. **Plugin capability model** — permission declarations, scoped runtime API, TOFU for workspace plugins
3. **Cross-channel isolation** — default `dmScope` to `per-channel-peer`
4. **Supply chain hardening** — pin GH Actions by SHA, pin Bun/Docker base image, add `pnpm audit` to CI
5. **Auth & sandbox defaults** — enable rate limiting by default, validate sandbox bind mounts

### Positive Findings

Strong security engineering in SSRF protection, timing-safe auth, external content wrapping, config redaction, exec approval system, Docker sandbox hardening, and pre-commit hooks.

## Test plan

- [ ] Verify report renders correctly on GitHub and Mintlify docs
- [ ] Verify `docs/security/README.md` link resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new security audit report (`docs/security/AUDIT-2026-02-13.md`) and links it from `docs/security/README.md`.

The docs link looks correct, and the audit report is generally well-structured (TOC, tables, remediation sections). One merge-blocking issue: the report states that `session.dmScope` “defaults to `"main"`”, but the referenced code indicates a fallback when config is unset, not necessarily a defined default. This should be reworded or backed by a source for the default value so the report remains accurate.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge after fixing a small documentation accuracy issue.
- Changes are docs-only and the README link is correct. The main risk is factual correctness: at least one claim (dmScope “defaults to main”) is misleading based on the referenced source and should be corrected to avoid spreading incorrect security guidance.
- docs/security/AUDIT-2026-02-13.md

<sub>Last reviewed commit: a1ee766</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->