### PR TITLE
fix(skills/github): add GraphQL introspection guidance

### DIFF
--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -60,13 +60,33 @@ gh run view <run-id> --repo owner/repo --log-failed
 
 ## API for Advanced Queries
 
-The `gh api` command is useful for accessing data not available through other subcommands.
+The `gh api` command supports both REST and GraphQL. Use it for anything not available through other `gh` subcommands.
 
-Get PR with specific fields:
+REST example:
 
 ```bash
 gh api repos/owner/repo/pulls/55 --jq '.title, .state, .user.login'
 ```
+
+GraphQL example:
+
+```bash
+gh api graphql -f query='query { organization(login: "owner") { projectsV2(first: 10) { nodes { id title } } } }'
+```
+
+When a `gh` subcommand doesn't support what you need (e.g. `gh project` can't modify field options), use `gh api graphql` with the appropriate mutation. **Do not guess mutation or field names** — introspect the schema first:
+
+```bash
+gh api graphql -f query='{ __schema { mutationType { fields { name } } } }' --jq '.data.__schema.mutationType.fields[].name' | grep -i project
+```
+
+Then inspect the input type for the mutation you need:
+
+```bash
+gh api graphql -f query='{ __type(name: "UpdateProjectV2FieldInput") { inputFields { name type { name kind ofType { name } } } } }'
+```
+
+If a GraphQL call returns an `undefinedField` error, use the introspection queries above to find the correct mutation and field names.
 
 ## JSON Output
 

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -30,7 +30,7 @@ metadata:
 
 # GitHub Skill
 
-Use the `gh` CLI to interact with GitHub. Always specify `--repo owner/repo` when not in a git directory, or use URLs directly.
+Use the `gh` CLI to interact with GitHub. For commands like `gh issue`, `gh pr`, and `gh run`, always specify `--repo owner/repo` when not in a git directory. For `gh api`, include the owner/repo in the URL path or query body.
 
 ## Pull Requests
 


### PR DESCRIPTION
## Summary

The github skill only documents REST usage for `gh api`. When the agent needs
GraphQL (e.g. GitHub Projects V2 mutations), it hallucinates incorrect mutation
names, gets `undefinedField` errors, and tells the user to "use the GitHub UI."

This adds:
- `gh api graphql` examples (query + mutation)
- Schema introspection commands to discover correct mutation/field names
- Guidance to introspect on `undefinedField` errors instead of guessing

## Testing

- Tested on a live OpenClaw instance (MiniMax-M2.1 via Telegram)
- Before: agent hallucinated `updateProjectV2SingleSelectField` (does not exist)
- After: agent used correct `updateProjectV2Field` with proper input fields

## AI Disclosure

- [x] AI-assisted (Claude)
- [x] Tested on live instance
- [x] I understand what the change does

Fixes #15796

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates the GitHub skill documentation to cover `gh api` GraphQL usage in addition to REST, including an example query and schema introspection snippets to avoid guessing mutation/field names when working with GitHub Projects V2.

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge, with one documentation correctness issue to fix.
- Change is doc-only and guidance is generally sound, but the added GraphQL examples omit `--repo` despite the skill’s own requirement to include it outside a git directory, which can cause the documented commands to fail for users.
- skills/github/SKILL.md

<sub>Last reviewed commit: 2f26c92</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->