### PR TITLE
docs: fix self-referencing link in compaction.md

### DIFF
--- a/docs/concepts/compaction.md
+++ b/docs/concepts/compaction.md
@@ -21,7 +21,7 @@ Compaction **persists** in the session’s JSONL history.
 
 ## Configuration
 
-See [Compaction config & modes](/concepts/compaction) for the `agents.defaults.compaction` settings.
+See [Compaction config](/gateway/configuration-reference#agentsdefaultscompaction) for the `agents.defaults.compaction` settings.
 
 ## Auto-compaction (default on)
 


### PR DESCRIPTION
## Summary
Fixes #15773

The compaction documentation linked to itself with the text 'See [Compaction config & modes](/concepts/compaction)' — not very useful.

## Changes
- Updated the link to point to the actual configuration reference: `/gateway/configuration-reference#agentsdefaultscompaction`
- Fixed both EN and zh-CN versions

## Testing
- Verified the anchor exists in configuration-reference.md (line 723)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes a self-referential link in the compaction concept doc by pointing readers to the relevant section of the Gateway configuration reference (`/gateway/configuration-reference#agentsdefaultscompaction`). The same link adjustment was applied to the zh-CN translated version.

The change fits the docs structure by routing “concepts” content to the “gateway configuration reference” for field-level settings, consistent with other docs that link to `/gateway/configuration-reference` anchors.

<h3>Confidence Score: 4/5</h3>

- Safe to merge once the zh-CN docs update policy is addressed.
- Changes are minimal and limited to documentation links; the only concrete issue is that the PR edits `docs/zh-CN/**`, which repo guidelines treat as generated content requiring the i18n pipeline or an explicit exception.
- docs/zh-CN/concepts/compaction.md

<sub>Last reviewed commit: ae9504d</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->