### PR TITLE
feat(skill): add GraphQL guidance to GitHub skill

### DIFF
--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -68,6 +68,54 @@ Get PR with specific fields:
 gh api repos/owner/repo/pulls/55 --jq '.title, .state, .user.login'
 ```
 
+## GraphQL API
+
+For GitHub Projects V2, Discussions, and other features not exposed via REST, use `gh api graphql`:
+
+```bash
+gh api graphql -f query='{ viewer { login } }'
+```
+
+### Schema Introspection
+
+**Always introspect before using unfamiliar mutations.** Do not guess mutation names — they differ from training data (e.g., `updateProjectV2Field` not `updateProjectV2SingleSelectField`).
+
+List available mutations matching a pattern:
+
+```bash
+gh api graphql -f query='{ __schema { mutationType { fields { name } } } }' \
+  --jq '.data.__schema.mutationType.fields[].name | select(test("ProjectV2"))'
+```
+
+Get a mutation's input fields:
+
+```bash
+gh api graphql -f query='{ __type(name: "UpdateProjectV2FieldInput") { inputFields { name type { name ofType { name } } } } }'
+```
+
+### Projects V2 Example
+
+Add a status option to a project field:
+
+```bash
+gh api graphql -f query='
+  mutation($fieldId: ID!, $options: [ProjectV2SingleSelectFieldOptionInput!]!) {
+    updateProjectV2Field(input: { fieldId: $fieldId, singleSelectOptions: $options }) {
+      projectV2Field { ... on ProjectV2SingleSelectField { options { name } } }
+    }
+  }' -f fieldId="PVTSSF_..." -f options='[{"name":"Ready","color":"GREEN"}]'
+```
+
+### Error Recovery
+
+If you get `undefinedField`, introspect the schema to find the correct name:
+
+```bash
+# Find mutations containing "Field"
+gh api graphql -f query='{ __schema { mutationType { fields { name } } } }' \
+  --jq '.data.__schema.mutationType.fields[].name | select(contains("Field"))'
+```
+
 ## JSON Output
 
 Most commands support `--json` for structured output. You can use `--jq` to filter:


### PR DESCRIPTION
## Summary
Fixes #15796

The GitHub skill only documented REST usage for `gh api`, with no mention of GraphQL. This caused agents to hallucinate mutation names when working with GitHub Projects V2 and other GraphQL-only features.

## Changes
Added a new **GraphQL API** section with:

- Basic `gh api graphql` usage
- **Schema introspection** examples — agents should introspect before using unfamiliar mutations
- **Projects V2** mutation example (the specific use case from the issue)
- **Error recovery** guidance for `undefinedField` errors

## Before/After

| Scenario | Before | After |
|----------|--------|-------|
| Agent needs Projects V2 mutation | Hallucinates `updateProjectV2SingleSelectField`, fails, tells user to use UI | Introspects schema, finds `updateProjectV2Field`, succeeds |

## Testing
Verified the introspection commands work with `gh api graphql`.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `skills/github/SKILL.md` to add a dedicated GraphQL section for the GitHub skill. It documents basic `gh api graphql` usage, recommends schema introspection before using unfamiliar mutations, provides a Projects V2 mutation example, and adds guidance for recovering from `undefinedField` errors by introspecting available mutations.

This fits the repo’s skill docs by expanding the existing `gh api` guidance (previously REST-focused) to cover GitHub GraphQL-only surfaces like Projects V2, reducing the likelihood that agents guess/hallucinate mutation names.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is isolated to skill documentation and adds guidance without modifying runtime code paths; no concrete correctness issues were found in the updated content based on repository patterns.
- No files require special attention

<sub>Last reviewed commit: 67edcc6</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->