### PR TITLE
docs: clarify Docker image must be built locally

### DIFF
--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -28,6 +28,34 @@ Sandboxing details: [Sandboxing](/gateway/sandboxing)
 - Docker Desktop (or Docker Engine) + Docker Compose v2
 - Enough disk for images + logs
 
+## Getting the Image
+
+### Option 1: Pre-built image (recommended)
+
+Pull the official image from GitHub Container Registry:
+
+```bash
+docker pull ghcr.io/openclaw/openclaw:latest
+```
+
+To use with docker-compose, set the image in your environment:
+
+```bash
+export OPENCLAW_IMAGE=ghcr.io/openclaw/openclaw:latest
+```
+
+### Option 2: Build locally
+
+Clone the repository and build:
+
+```bash
+git clone https://github.com/openclaw/openclaw.git
+cd openclaw
+docker build -t openclaw:local -f Dockerfile .
+```
+
+The `docker-setup.sh` script (below) handles building automatically if no image is specified.
+
 ## Containerized Gateway (Docker Compose)
 
 ### Quick start (recommended)


### PR DESCRIPTION
## Summary
Fixes #15655

The Docker documentation jumped directly into setup steps without explaining that there are no pre-built Docker images available. Users must clone the repository and build locally.

## Changes
Added a **Getting the Image** section before the Containerized Gateway section that:

- Explicitly states no pre-built images are published
- Provides the git clone command
- References `docker-setup.sh` for automatic builds
- Shows the manual `docker build` command for those who prefer it
- Updated Requirements to mention cloning the repo

## Before
User reads 'Quick start' → runs `./docker-setup.sh` → fails because they don't have the repo cloned

## After
User reads 'Getting the Image' → clones repo → runs setup → succeeds

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `docs/install/docker.md` to add a new “Getting the Image” section and adjusts requirements so users understand that OpenClaw does not publish pre-built Docker images. It instructs readers to clone the repository, and notes that `./docker-setup.sh` will build the image (or provides a manual `docker build -t openclaw:local -f Dockerfile .` alternative). This aligns with the existing Docker flow in the repo, where `docker-compose.yml` defaults to `openclaw:local`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are documentation-only, and the new instructions were verified against repository contents (repo-root Dockerfile, docker-compose.yml default image name, and docker-setup.sh build behavior). No broken references or misleading commands were found in the updated section.
- docs/install/docker.md

<sub>Last reviewed commit: a417019</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->