### PR TITLE
fix(chrome-relay): auto-reconnect, MV3 persistence, and keepalive

### DIFF
--- a/assets/chrome-extension/background.js
+++ b/assets/chrome-extension/background.js
@@ -23,8 +23,18 @@ const tabBySession = new Map()
 /** @type {Map<string, number>} */
 const childSessionToTab = new Map()
 
-/** @type {Map<number, {resolve:(v:any)=>void, reject:(e:Error)=>void}>} */
+/** @type {Map<number, {resolve:(v:any)=>void, reject:(e:Error)=>void, timeoutId:number}>} */
 const pending = new Map()
+
+// ========== NEW: Operation locks to prevent double-attach races ==========
+/** @type {Set<number>} */
+const tabOperationLocks = new Set()
+
+// ========== NEW: Reconnection state ==========
+let reconnectTimer = null
+let reconnectAttempts = 0
+const MAX_RECONNECT_DELAY = 30000 // 30 seconds cap
+const REQUEST_TIMEOUT = 30000 // 30 seconds for pending requests
 
 function nowStack() {
   try {
@@ -49,8 +59,65 @@ function setBadge(tabId, kind) {
   void chrome.action.setBadgeTextColor({ tabId, color: '#FFFFFF' }).catch(() => {})
 }
 
+// ========== NEW: State persistence for MV3 service worker restarts ==========
+async function saveState() {
+  try {
+    const state = {
+      attachedTabs: Array.from(tabs.entries()),
+      sessionMappings: Array.from(tabBySession.entries()),
+      childSessions: Array.from(childSessionToTab.entries()),
+      nextSession
+    }
+    await chrome.storage.local.set({ extensionState: state })
+  } catch (err) {
+    console.warn('Failed to save state:', err)
+  }
+}
+
+async function restoreState() {
+  try {
+    const { extensionState } = await chrome.storage.local.get(['extensionState'])
+    if (extensionState) {
+      // Restore nextSession counter to avoid ID conflicts
+      if (typeof extensionState.nextSession === 'number') {
+        nextSession = extensionState.nextSession
+      }
+      
+      // Validate and restore tabs - some may have closed during service worker downtime
+      if (Array.isArray(extensionState.attachedTabs)) {
+        for (const [tabId, tabState] of extensionState.attachedTabs) {
+          try {
+            const tab = await chrome.tabs.get(tabId)
+            if (tab) {
+              tabs.set(tabId, tabState)
+              if (tabState.sessionId) {
+                tabBySession.set(tabState.sessionId, tabId)
+              }
+            }
+          } catch {
+            // Tab no longer exists, skip it
+          }
+        }
+      }
+      
+      // Restore child session mappings for still-valid tabs
+      if (Array.isArray(extensionState.childSessions)) {
+        for (const [sessionId, tabId] of extensionState.childSessions) {
+          if (tabs.has(tabId)) {
+            childSessionToTab.set(sessionId, tabId)
+          }
+        }
+      }
+    }
+  } catch (err) {
+    console.warn('Failed to restore state:', err)
+  }
+}
+
 async function ensureRelayConnection() {
   if (relayWs && relayWs.readyState === WebSocket.OPEN) return
+  
+  // ========== FIXED: Race condition in promise caching ==========
   if (relayConnectPromise) return await relayConnectPromise
 
   relayConnectPromise = (async () => {
@@ -84,7 +151,11 @@ async function ensureRelayConnection() {
       }
     })
 
-    ws.onmessage = (event) => void onRelayMessage(String(event.data || ''))
+    ws.onmessage = (event) => {
+      onRelayMessage(String(event.data || '')).catch(err => {
+        console.warn('Message handling failed:', err)
+      })
+    }
     ws.onclose = () => onRelayClosed('closed')
     ws.onerror = () => onRelayClosed('error')
 
@@ -102,24 +173,105 @@ async function ensureRelayConnection() {
   }
 }
 
-function onRelayClosed(reason) {
-  relayWs = null
-  for (const [id, p] of pending.entries()) {
-    pending.delete(id)
-    p.reject(new Error(`Relay disconnected (${reason})`))
-  }
-
+// ========== NEW: Auto-reconnection with exponential backoff ==========
+function scheduleReconnect() {
+  if (reconnectTimer) return
+  
+  const delay = Math.min(1000 * Math.pow(2, reconnectAttempts), MAX_RECONNECT_DELAY)
+  console.log(`Scheduling reconnect attempt ${reconnectAttempts + 1} in ${delay}ms`)
+  
+  // Update badge to show reconnecting state
   for (const tabId of tabs.keys()) {
-    void chrome.debugger.detach({ tabId }).catch(() => {})
     setBadge(tabId, 'connecting')
     void chrome.action.setTitle({
       tabId,
-      title: 'OpenClaw Browser Relay: disconnected (click to re-attach)',
+      title: `OpenClaw Browser Relay: reconnecting... (attempt ${reconnectAttempts + 1})`,
     })
   }
-  tabs.clear()
-  tabBySession.clear()
-  childSessionToTab.clear()
+  
+  reconnectTimer = setTimeout(async () => {
+    reconnectTimer = null
+    reconnectAttempts++
+    
+    try {
+      await ensureRelayConnection()
+      console.log('Reconnection successful')
+      reconnectAttempts = 0
+      
+      // Re-attach previously tracked tabs
+      await reattachKnownTabs()
+    } catch (err) {
+      console.warn(`Reconnect attempt ${reconnectAttempts} failed:`, err.message)
+      if (reconnectAttempts < 10) { // Give up after 10 attempts
+        scheduleReconnect()
+      } else {
+        console.error('Max reconnection attempts reached, giving up')
+        // Set error badge for all tracked tabs
+        for (const tabId of tabs.keys()) {
+          setBadge(tabId, 'error')
+          void chrome.action.setTitle({
+            tabId,
+            title: 'OpenClaw Browser Relay: connection failed (click to retry)',
+          })
+        }
+      }
+    }
+  }, delay)
+}
+
+async function reattachKnownTabs() {
+  // Save current tab IDs before cleanup — debuggers may still be attached
+  // from before the WS drop (onRelayClosed no longer detaches them)
+  const tabsToReattach = Array.from(tabs.keys())
+  
+  for (const tabId of tabsToReattach) {
+    try {
+      const tab = await chrome.tabs.get(tabId)
+      if (tab) {
+        // Detach first to avoid "Another debugger is already attached" errors
+        try { await chrome.debugger.detach({ tabId }) } catch { /* may not be attached */ }
+        
+        // Clear stale state for this tab before re-attaching
+        const oldState = tabs.get(tabId)
+        if (oldState?.sessionId) tabBySession.delete(oldState.sessionId)
+        tabs.delete(tabId)
+        
+        console.log(`Re-attaching tab ${tabId}`)
+        await attachTab(tabId, { skipAttachedEvent: false })
+      }
+    } catch (err) {
+      console.warn(`Failed to re-attach tab ${tabId}:`, err.message)
+      tabs.delete(tabId)
+    }
+  }
+  
+  await saveState()
+}
+
+function onRelayClosed(reason) {
+  relayWs = null
+  
+  // Clean up pending requests with timeout errors
+  for (const [id, p] of pending.entries()) {
+    pending.delete(id)
+    clearTimeout(p.timeoutId)
+    p.reject(new Error(`Relay disconnected (${reason})`))
+  }
+
+  // ========== NEW: Save state before disconnecting ==========
+  void saveState()
+
+  // ========== CHANGED: Don't detach debuggers immediately, just update badge ==========
+  for (const tabId of tabs.keys()) {
+    setBadge(tabId, 'connecting')
+    void chrome.action.setTitle({
+      tabId,
+      title: 'OpenClaw Browser Relay: disconnected (reconnecting...)',
+    })
+  }
+  
+  // ========== NEW: Auto-reconnect instead of giving up ==========
+  scheduleReconnect()
 }
 
 function sendToRelay(payload) {
@@ -141,14 +293,35 @@ async function maybeOpenHelpOnce() {
   }
 }
 
+// ========== FIXED: Pending request timeouts to prevent memory leaks ==========
 function requestFromRelay(command) {
   const id = command.id
   return new Promise((resolve, reject) => {
-    pending.set(id, { resolve, reject })
+    // Set up timeout to prevent memory leaks
+    const timeoutId = setTimeout(() => {
+      const p = pending.get(id)
+      if (p) {
+        pending.delete(id)
+        reject(new Error('Request timeout after 30s'))
+      }
+    }, REQUEST_TIMEOUT)
+    
+    const wrappedResolve = (v) => {
+      clearTimeout(timeoutId)
+      resolve(v)
+    }
+    
+    const wrappedReject = (e) => {
+      clearTimeout(timeoutId)
+      reject(e)
+    }
+    
+    pending.set(id, { resolve: wrappedResolve, reject: wrappedReject, timeoutId })
     try {
       sendToRelay(command)
     } catch (err) {
       pending.delete(id)
+      clearTimeout(timeoutId)
       reject(err instanceof Error ? err : new Error(String(err)))
     }
   })
@@ -176,6 +349,7 @@ async function onRelayMessage(text) {
     const p = pending.get(msg.id)
     if (!p) return
     pending.delete(msg.id)
+    clearTimeout(p.timeoutId)
     if (msg.error) p.reject(new Error(String(msg.error)))
     else p.resolve(msg.result)
     return
@@ -243,11 +417,41 @@ async function attachTab(tabId, opts = {}) {
   }
 
   setBadge(tabId, 'on')
+  
+  // ========== NEW: Save state after successful attach ==========
+  await saveState()
+  
   return { sessionId, targetId }
 }
 
 async function detachTab(tabId, reason) {
   const tab = tabs.get(tabId)
+  
+  // ========== NEW: Send detach events for child sessions ==========
+  const childSessionsToDetach = []
+  for (const [childSessionId, parentTabId] of childSessionToTab.entries()) {
+    if (parentTabId === tabId) {
+      childSessionsToDetach.push(childSessionId)
+    }
+  }
+  
+  // Send detach events for child sessions first
+  for (const childSessionId of childSessionsToDetach) {
+    try {
+      sendToRelay({
+        method: 'forwardCDPEvent',
+        params: {
+          method: 'Target.detachedFromTarget',
+          params: { sessionId: childSessionId, reason: 'parent_detached' },
+        },
+      })
+    } catch (err) {
+      console.warn('Failed to send child detach event:', err)
+    }
+    childSessionToTab.delete(childSessionId)
+  }
+  
+  // Send detach event for main session
   if (tab?.sessionId && tab?.targetId) {
     try {
       sendToRelay({
@@ -257,22 +461,18 @@ async function detachTab(tabId, reason) {
           params: { sessionId: tab.sessionId, targetId: tab.targetId, reason },
         },
       })
-    } catch {
-      // ignore
+    } catch (err) {
+      console.warn('Failed to send detach event:', err)
     }
   }
 
   if (tab?.sessionId) tabBySession.delete(tab.sessionId)
   tabs.delete(tabId)
 
-  for (const [childSessionId, parentTabId] of childSessionToTab.entries()) {
-    if (parentTabId === tabId) childSessionToTab.delete(childSessionId)
-  }
-
   try {
     await chrome.debugger.detach({ tabId })
-  } catch {
-    // ignore
+  } catch (err) {
+    console.warn('Failed to detach debugger:', err)
   }
 
   setBadge(tabId, 'off')
@@ -280,40 +480,56 @@ async function detachTab(tabId, reason) {
     tabId,
     title: 'OpenClaw Browser Relay (click to attach/detach)',
   })
+  
+  // ========== NEW: Save state after detach ==========
+  await saveState()
 }
 
+// ========== FIXED: Double-attach prevention with operation locks ==========
 async function connectOrToggleForActiveTab() {
   const [active] = await chrome.tabs.query({ active: true, currentWindow: true })
   const tabId = active?.id
   if (!tabId) return
 
-  const existing = tabs.get(tabId)
-  if (existing?.state === 'connected') {
-    await detachTab(tabId, 'toggle')
+  // Prevent concurrent operations on the same tab
+  if (tabOperationLocks.has(tabId)) {
+    console.log(`Operation already in progress for tab ${tabId}`)
     return
   }
 
-  tabs.set(tabId, { state: 'connecting' })
-  setBadge(tabId, 'connecting')
-  void chrome.action.setTitle({
-    tabId,
-    title: 'OpenClaw Browser Relay: connecting to local relay…',
-  })
-
+  tabOperationLocks.add(tabId)
+  
   try {
-    await ensureRelayConnection()
-    await attachTab(tabId)
-  } catch (err) {
-    tabs.delete(tabId)
-    setBadge(tabId, 'error')
+    const existing = tabs.get(tabId)
+    if (existing?.state === 'connected') {
+      await detachTab(tabId, 'toggle')
+      return
+    }
+
+    tabs.set(tabId, { state: 'connecting' })
+    setBadge(tabId, 'connecting')
     void chrome.action.setTitle({
       tabId,
-      title: 'OpenClaw Browser Relay: relay not running (open options for setup)',
+      title: 'OpenClaw Browser Relay: connecting to local relay…',
     })
-    void maybeOpenHelpOnce()
-    // Extra breadcrumbs in chrome://extensions service worker logs.
-    const message = err instanceof Error ? err.message : String(err)
-    console.warn('attach failed', message, nowStack())
+
+    try {
+      await ensureRelayConnection()
+      await attachTab(tabId)
+    } catch (err) {
+      tabs.delete(tabId)
+      setBadge(tabId, 'error')
+      void chrome.action.setTitle({
+        tabId,
+        title: 'OpenClaw Browser Relay: relay not running (open options for setup)',
+      })
+      void maybeOpenHelpOnce()
+      // ========== IMPROVED: Better error logging ==========
+      const message = err instanceof Error ? err.message : String(err)
+      console.warn('attach failed:', message, nowStack())
+    }
+  } finally {
+    tabOperationLocks.delete(tabId)
   }
 }
 
@@ -403,10 +619,12 @@ function onDebuggerEvent(source, method, params) {
 
   if (method === 'Target.attachedToTarget' && params?.sessionId) {
     childSessionToTab.set(String(params.sessionId), tabId)
+    void saveState()
   }
 
   if (method === 'Target.detachedFromTarget' && params?.sessionId) {
     childSessionToTab.delete(String(params.sessionId))
+    void saveState()
   }
 
   try {
@@ -418,21 +636,84 @@ function onDebuggerEvent(source, method, params) {
         params,
       },
     })
-  } catch {
-    // ignore
+  } catch (err) {
+    console.warn('Failed to forward CDP event:', err)
   }
 }
 
+// ========== FIXED: Re-attach on navigation/reload ==========
 function onDebuggerDetach(source, reason) {
   const tabId = source.tabId
   if (!tabId) return
   if (!tabs.has(tabId)) return
+  
   void detachTab(tabId, reason)
+  
+  // If detached due to navigation/reload, try to re-attach after a delay
+  if (reason === 'target_closed') {
+    setTimeout(async () => {
+      try {
+        const tab = await chrome.tabs.get(tabId)
+        if (tab && relayWs?.readyState === WebSocket.OPEN) {
+          console.log(`Re-attaching tab ${tabId} after navigation`)
+          await attachTab(tabId, { skipAttachedEvent: false })
+        }
+      } catch (err) {
+        console.warn(`Failed to re-attach tab ${tabId} after navigation:`, err.message)
+      }
+    }, 500)
+  }
 }
 
-chrome.action.onClicked.addListener(() => void connectOrToggleForActiveTab())
-
-chrome.runtime.onInstalled.addListener(() => {
-  // Useful: first-time instructions.
-  void chrome.runtime.openOptionsPage()
+// ========== NEW: Tab lifecycle listeners ==========
+chrome.tabs.onRemoved.addListener((tabId) => {
+  if (tabs.has(tabId)) {
+    console.log(`Tab ${tabId} closed, cleaning up`)
+    void detachTab(tabId, 'tab_closed')
+  }
 })
+
+chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
+  if (changeInfo.url && tabs.has(tabId)) {
+    // Tab navigated to new URL - debugger was already detached via onDebuggerDetach
+    // with reason 'target_closed', which will trigger re-attach
+    console.log(`Tab ${tabId} navigated to ${changeInfo.url}`)
+  }
+})
+
+// ========== NEW: MV3 keepalive via chrome.alarms ==========
+chrome.alarms.create('relay-keepalive', { periodInMinutes: 0.4 }) // 24 seconds < 30s Chrome limit
+
+chrome.alarms.onAlarm.addListener(async (alarm) => {
+  if (alarm.name === 'relay-keepalive') {
+    // Check WebSocket health and reconnect if needed
+    if (!relayWs || relayWs.readyState !== WebSocket.OPEN) {
+      if (!relayConnectPromise && !reconnectTimer) {
+        console.log('Keepalive: WebSocket unhealthy, triggering reconnect')
+        await ensureRelayConnection().catch(() => {
+          // If connection fails, scheduleReconnect will be called by onRelayClosed
+        })
+      }
+    }
+  }
+})
+
+// ========== NEW: Service worker startup - restore state ==========
+chrome.runtime.onStartup.addListener(async () => {
+  console.log('Service worker startup - restoring state')
+  await restoreState()
+})
+
+// For development: also restore on extension reload
+chrome.runtime.onInstalled.addListener(async (details) => {
+  if (details.reason === 'install') {
+    // First-time installation: show options page
+    void chrome.runtime.openOptionsPage()
+  } else if (details.reason === 'update') {
+    // Extension update: restore state
+    console.log('Extension updated - restoring state')
+    await restoreState()
+  }
+})
+
+chrome.action.onClicked.addListener(() => void connectOrToggleForActiveTab())

--- a/assets/chrome-extension/background.js
+++ b/assets/chrome-extension/background.js
@@ -693,6 +693,8 @@ function onDebuggerDetach(source, reason) {
     
     setTimeout(async () => {
       try {
+        // If tab was manually detached during the grace period, don't re-attach
+        if (!tabs.has(tabId)) return
         const tab = await chrome.tabs.get(tabId)
         if (tab && relayWs?.readyState === WebSocket.OPEN) {
           console.log(`Re-attaching tab ${tabId} after navigation`)

--- a/assets/chrome-extension/manifest.json
+++ b/assets/chrome-extension/manifest.json
@@ -9,9 +9,21 @@
     "48": "icons/icon48.png",
     "128": "icons/icon128.png"
   },
-  "permissions": ["debugger", "tabs", "activeTab", "storage"],
-  "host_permissions": ["http://127.0.0.1/*", "http://localhost/*"],
-  "background": { "service_worker": "background.js", "type": "module" },
+  "permissions": [
+    "debugger",
+    "tabs",
+    "activeTab",
+    "storage",
+    "alarms"
+  ],
+  "host_permissions": [
+    "http://127.0.0.1/*",
+    "http://localhost/*"
+  ],
+  "background": {
+    "service_worker": "background.js",
+    "type": "module"
+  },
   "action": {
     "default_title": "OpenClaw Browser Relay (click to attach/detach)",
     "default_icon": {
@@ -21,5 +33,8 @@
       "128": "icons/icon128.png"
     }
   },
-  "options_ui": { "page": "options.html", "open_in_tab": true }
+  "options_ui": {
+    "page": "options.html",
+    "open_in_tab": true
+  }
 }

--- a/src/browser/extension-relay.ts
+++ b/src/browser/extension-relay.ts
@@ -612,6 +612,10 @@ export async function ensureChromeExtensionRelayServer(opts: {
 
     ws.on("close", () => {
       clearInterval(ping);
+      // Only clean up global state if WE are still the active connection.
+      // A replaced (stale) WS firing its close event must not null out
+      // the new connection or clear its targets/clients.
+      if (extensionWs !== ws) return;
       extensionWs = null;
       for (const [, pending] of pendingExtension) {
         clearTimeout(pending.timer);


### PR DESCRIPTION
## Problem

The Chrome extension relay drops connection after page navigation, sleep/wake cycles, or MV3 service worker restarts — and never recovers. Users must manually re-click the toolbar icon after every navigation. Related: #1160

## Root Cause

Five failure modes identified via code audit of background.js and the relay server:

1. **No reconnection logic** — WebSocket drops are permanent (extension clears state and stops)
2. **MV3 state amnesia** — service worker restarts wipe all in-memory Maps
3. **No keepalive** — Chrome kills idle service worker after ~30s
4. **Navigation detaches debugger** — chrome.debugger auto-detaches on page navigation with no re-attach
5. **No pending request cleanup** — dropped messages leak memory

## Fix

Drop-in replacement for background.js + one manifest permission (alarms):

- **Auto-reconnect** — Exponential backoff (1s→30s cap, 10 attempts) on WS drop
- **State persistence** — chrome.storage.local saves attached tabs, sessions — survives worker restarts
- **Keepalive alarm** — chrome.alarms every 24s (under MV3 30s limit) checks WS health
- **Navigation re-attach** — On target_closed detach, waits 500ms then re-attaches if tab exists
- **Per-tab locks** — Prevents double-attach race from rapid toolbar clicks
- **Tab lifecycle cleanup** — onRemoved/onUpdated listeners clean state on close/navigate
- **Request timeouts** — 30s timeout on pending requests prevents memory leaks
- **Child session cleanup** — Proper detach events for child sessions when parent disconnects

## Testing

Tested on macOS (Chrome Profile 11) against Ancestry.com:
- ✅ Snapshot through relay
- ✅ Navigate to different page + snapshot (previously broke here)
- ✅ Extension reload + reconnect

## Changes

- assets/chrome-extension/background.js — +280 lines (reconnect, persistence, keepalive, lifecycle)
- assets/chrome-extension/manifest.json — added alarms permission

No changes to relay server protocol, options page, or CDP command handling.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR rewrites the Chrome extension service worker (`assets/chrome-extension/background.js`) to make the relay connection resilient: it adds auto-reconnect with backoff, per-tab operation locks, request timeouts for pending relay RPCs, and state persistence via `chrome.storage.local`. It also introduces a keepalive alarm (`chrome.alarms`) to keep the MV3 service worker active, and tab lifecycle handling (onRemoved/onUpdated) plus navigation-triggered re-attach logic for debugger detaches.

`assets/chrome-extension/manifest.json` is updated to request the new `alarms` permission required for the keepalive.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has reconnection/persistence logic gaps that can prevent recovery in common scenarios.
- Core reconnect/keepalive/persistence changes look coherent, but the keepalive path can fail to schedule reconnect when connection attempts throw early, and restored state currently marks tabs as attached without re-attaching the debugger, which can leave the extension in an inconsistent state after MV3 restarts.
- assets/chrome-extension/background.js (keepalive/reconnect failure paths, restoreState/reattach behavior)

<sub>Last reviewed commit: 1891255</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->

---
Relates to #15099