### PR TITLE
fix: session store race conditions and contextTokens updates (#14979, #14969, #14970)

### DIFF
--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -3,11 +3,11 @@ import type { WebSocketServer } from "ws";
 import type { CanvasHostHandler, CanvasHostServer } from "../canvas-host/server.js";
 import type { CliDeps } from "../cli/deps.js";
 import type { OpenClawConfig } from "../config/config.js";
-import { type ChannelId, listChannelPlugins } from "../channels/plugins/index.js";
-import { createInternalHookEvent, triggerInternalHook } from "../hooks/internal-hooks.js";
-import { stopGmailWatcher } from "../hooks/gmail-watcher.js";
 import type { HeartbeatRunner } from "../infra/heartbeat-runner.js";
 import type { PluginServicesHandle } from "../plugins/services.js";
+import { type ChannelId, listChannelPlugins } from "../channels/plugins/index.js";
+import { stopGmailWatcher } from "../hooks/gmail-watcher.js";
+import { createInternalHookEvent, triggerInternalHook } from "../hooks/internal-hooks.js";
 
 export function createGatewayCloseHandler(params: {
   cfg: OpenClawConfig;

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -636,6 +636,9 @@ export async function startGatewayServer(
   });
 
   const close = createGatewayCloseHandler({
+    cfg: cfgAtStart,
+    deps,
+    defaultWorkspaceDir,
     bonjourStop,
     tailscaleCleanup,
     canvasHost,

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -259,6 +259,12 @@ export async function applySessionsPatchToStore(params: {
           isDefault: true,
         },
       });
+      // Update contextTokens to match the default model's context window
+      const { lookupContextTokens } = await import("../agents/context.js");
+      const { DEFAULT_CONTEXT_TOKENS } = await import("../agents/defaults.js");
+      const defaultContextTokens =
+        lookupContextTokens(resolvedDefault.model) ?? DEFAULT_CONTEXT_TOKENS;
+      next.contextTokens = defaultContextTokens;
     } else if (raw !== undefined) {
       const trimmed = String(raw).trim();
       if (!trimmed) {
@@ -292,6 +298,11 @@ export async function applySessionsPatchToStore(params: {
           isDefault,
         },
       });
+      // Update contextTokens to match the new model's context window
+      const { lookupContextTokens } = await import("../agents/context.js");
+      const { DEFAULT_CONTEXT_TOKENS } = await import("../agents/defaults.js");
+      const newContextTokens = lookupContextTokens(resolved.ref.model) ?? DEFAULT_CONTEXT_TOKENS;
+      next.contextTokens = newContextTokens;
     }
   }
 

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -259,12 +259,6 @@ export async function applySessionsPatchToStore(params: {
           isDefault: true,
         },
       });
-      // Update contextTokens to match the default model's context window
-      const { lookupContextTokens } = await import("../agents/context.js");
-      const { DEFAULT_CONTEXT_TOKENS } = await import("../agents/defaults.js");
-      const defaultContextTokens =
-        lookupContextTokens(resolvedDefault.model) ?? DEFAULT_CONTEXT_TOKENS;
-      next.contextTokens = defaultContextTokens;
     } else if (raw !== undefined) {
       const trimmed = String(raw).trim();
       if (!trimmed) {
@@ -298,11 +292,6 @@ export async function applySessionsPatchToStore(params: {
           isDefault,
         },
       });
-      // Update contextTokens to match the new model's context window
-      const { lookupContextTokens } = await import("../agents/context.js");
-      const { DEFAULT_CONTEXT_TOKENS } = await import("../agents/defaults.js");
-      const newContextTokens = lookupContextTokens(resolved.ref.model) ?? DEFAULT_CONTEXT_TOKENS;
-      next.contextTokens = newContextTokens;
     }
   }
 

--- a/src/sessions/model-overrides.ts
+++ b/src/sessions/model-overrides.ts
@@ -1,3 +1,5 @@
+import { lookupContextTokens } from "../agents/context.js";
+import { DEFAULT_CONTEXT_TOKENS } from "../agents/defaults.js";
 import type { SessionEntry } from "../config/sessions.js";
 
 export type ModelOverrideSelection = {
@@ -34,6 +36,13 @@ export function applyModelOverrideToSessionEntry(params: {
       entry.modelOverride = selection.model;
       updated = true;
     }
+  }
+
+  // Update contextTokens to match the model's context window
+  const modelContextTokens = lookupContextTokens(selection.model) ?? DEFAULT_CONTEXT_TOKENS;
+  if (entry.contextTokens !== modelContextTokens) {
+    entry.contextTokens = modelContextTokens;
+    updated = true;
   }
 
   if (profileOverride) {

--- a/src/sessions/model-overrides.ts
+++ b/src/sessions/model-overrides.ts
@@ -1,6 +1,6 @@
+import type { SessionEntry } from "../config/sessions.js";
 import { lookupContextTokens } from "../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../agents/defaults.js";
-import type { SessionEntry } from "../config/sessions.js";
 
 export type ModelOverrideSelection = {
   provider: string;


### PR DESCRIPTION
## Summary

- Fix race condition in session store where stale data overwrote compaction changes (#14979)
- Add contextTokens updates when model changes via /model directive (#14969)
- Add gateway:shutdown internal hook event for graceful shutdown handling (#14970)
- Add contextTokens update in applyModelOverrideToSessionEntry

## Test plan

- [ ] `pnpm test` passes
- [ ] Session state consistent after concurrent compaction
- [ ] contextTokens updates when switching models via /model
- [ ] gateway:shutdown event fires on graceful shutdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR addresses three related session/gateway lifecycle issues:

- Updates `updateSessionStoreAfterAgentRun` to read the latest on-disk session store before writing, avoiding overwriting concurrent compaction changes.
- Ensures `contextTokens` stays in sync with the selected model when model overrides are applied (including via `/model`).
- Adds a `gateway:shutdown` internal hook event during gateway close for graceful shutdown handling.

Overall the changes align session persistence with concurrent writers and improve metadata consistency across model switches.

<h3>Confidence Score: 4/5</h3>

- This PR is close to safe to merge, but there is one consistency issue around duplicate contextTokens updates.
- Core changes (session store update with fresh disk state, gateway shutdown hook, and contextTokens updates in applyModelOverrideToSessionEntry) look coherent and verified against existing helper implementations. The main remaining concern is that sessions-patch redundantly overwrites contextTokens after calling the shared override function, which can lead to inconsistent behavior between code paths.
- src/gateway/sessions-patch.ts

<sub>Last reviewed commit: ef61002</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->