### PR TITLE
fix: enforce Telegram 100-command limit with warning (#5787)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/Heartbeat: stop auto-creating `HEARTBEAT.md` during workspace bootstrap so missing files continue to run heartbeat as documented. (#11766) Thanks @shadril238.
+- Telegram: cap bot menu registration to Telegram's 100-command limit with an overflow warning while keeping typed hidden commands available. (#15844) Thanks @battman21.
 - CLI: lazily load outbound provider dependencies and remove forced success-path exits so commands terminate naturally without killing intentional long-running foreground actions. (#12906) Thanks @DrCrinkle.
 - Auto-reply/Heartbeat: strip sentence-ending `HEARTBEAT_OK` tokens even when followed by up to 4 punctuation characters, while preserving surrounding sentence punctuation. (#15847) Thanks @Spacefish.
 - Clawdock: avoid Zsh readonly variable collisions in helper scripts. (#15501) Thanks @nkelner.

--- a/src/telegram/bot-native-commands.test.ts
+++ b/src/telegram/bot-native-commands.test.ts
@@ -112,7 +112,7 @@ describe("registerTelegramNativeCommands", () => {
     expect(registeredCommands).toHaveLength(100);
     expect(registeredCommands).toEqual(customCommands.slice(0, 100));
     expect(runtimeLog).toHaveBeenCalledWith(
-      "telegram: truncating 120 commands to 100 (Telegram Bot API limit)",
+      "Telegram limits bots to 100 commands. 120 configured; registering first 100. Use channels.telegram.commands.native: false to disable, or reduce skill/custom commands.",
     );
   });
 });

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -368,7 +368,7 @@ export const registerTelegramNativeCommands = ({
   ];
   const TELEGRAM_MAX_COMMANDS = 100;
   if (allCommandsFull.length > TELEGRAM_MAX_COMMANDS) {
-    runtime.warn?.(
+    runtime.log?.(
       `Telegram limits bots to ${TELEGRAM_MAX_COMMANDS} commands. ` +
         `${allCommandsFull.length} configured; registering first ${TELEGRAM_MAX_COMMANDS}. ` +
         `Use channels.telegram.commands.native: false to disable, or reduce skill/custom commands.`,

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -366,25 +366,26 @@ export const registerTelegramNativeCommands = ({
     ...pluginCommands,
     ...customCommands,
   ];
-  // Telegram Bot API limits commands to 100 per scope.
-  // Truncate with a warning rather than failing with BOT_COMMANDS_TOO_MUCH.
   const TELEGRAM_MAX_COMMANDS = 100;
   if (allCommandsFull.length > TELEGRAM_MAX_COMMANDS) {
-    runtime.log?.(
-      `telegram: truncating ${allCommandsFull.length} commands to ${TELEGRAM_MAX_COMMANDS} (Telegram Bot API limit)`,
+    runtime.warn?.(
+      `Telegram limits bots to ${TELEGRAM_MAX_COMMANDS} commands. ` +
+        `${allCommandsFull.length} configured; registering first ${TELEGRAM_MAX_COMMANDS}. ` +
+        `Use channels.telegram.commands.native: false to disable, or reduce skill/custom commands.`,
     );
   }
-  const allCommands = allCommandsFull.slice(0, TELEGRAM_MAX_COMMANDS);
+  // Telegram only limits the setMyCommands payload (menu entries).
+  const commandsToRegister = allCommandsFull.slice(0, TELEGRAM_MAX_COMMANDS);
 
   // Clear stale commands before registering new ones to prevent
   // leftover commands from deleted skills persisting across restarts (#5717).
   // Chain delete → set so a late-resolving delete cannot wipe newly registered commands.
   const registerCommands = () => {
-    if (allCommands.length > 0) {
+    if (commandsToRegister.length > 0) {
       withTelegramApiErrorLogging({
         operation: "setMyCommands",
         runtime,
-        fn: () => bot.api.setMyCommands(allCommands),
+        fn: () => bot.api.setMyCommands(commandsToRegister),
       }).catch(() => {});
     }
   };
@@ -401,7 +402,7 @@ export const registerTelegramNativeCommands = ({
     registerCommands();
   }
 
-  if (allCommands.length > 0) {
+  if (commandsToRegister.length > 0) {
     if (typeof (bot as unknown as { command?: unknown }).command !== "function") {
       logVerbose("telegram: bot.command unavailable; skipping native handlers");
     } else {


### PR DESCRIPTION
## Summary

- Enforce Telegram's 100-command limit for `setMyCommands` API
- When commands exceed 100, truncate and warn instead of silently failing
- Priority order: native > plugin > custom commands

Fixes #5787

## Test plan

- [ ] Gateway starts without `BOT_COMMANDS_TOO_MUCH` error when >100 commands
- [ ] Warning logged when count exceeds 100
- [ ] No change when under 100 commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change introduces a hard cap of 100 commands when registering Telegram bot commands via `setMyCommands`, and logs a warning when configuration exceeds Telegram’s limit. The command list is built with the intended priority order (native → plugin → custom), then truncated before calling the Telegram API to avoid `BOT_COMMANDS_TOO_MUCH`.

Within the Telegram channel integration, `registerTelegramNativeCommands` is the central place where both the advertised command menu (`setMyCommands`) and the runtime command handlers (`bot.command`) are set up.

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but there is a behavioral inconsistency between advertised commands and registered handlers when over the Telegram limit.
- The PR correctly avoids Telegram API failure by truncating the `setMyCommands` payload and warning. However, it leaves command handlers registered for commands that are no longer advertised, which will produce confusing UX and potentially unexpected exposure of commands beyond the first 100.
- src/telegram/bot-native-commands.ts

<sub>Last reviewed commit: 151796f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->