### PR TITLE
Ignore up to 4 non-word characters when stripping HEARTBEAT_OK token …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 
 - Agents/Heartbeat: stop auto-creating `HEARTBEAT.md` during workspace bootstrap so missing files continue to run heartbeat as documented. (#11766) Thanks @shadril238.
 - CLI: lazily load outbound provider dependencies and remove forced success-path exits so commands terminate naturally without killing intentional long-running foreground actions. (#12906) Thanks @DrCrinkle.
+- Auto-reply/Heartbeat: strip sentence-ending `HEARTBEAT_OK` tokens even when followed by up to 4 punctuation characters, while preserving surrounding sentence punctuation. (#15847) Thanks @Spacefish.
 - Clawdock: avoid Zsh readonly variable collisions in helper scripts. (#15501) Thanks @nkelner.
 - Discord: route autoThread replies to existing threads instead of the root channel. (#8302) Thanks @gavinbmoore, @thewilloftheshadow.
 - Discord/Agents: apply channel/group `historyLimit` during embedded-runner history compaction to prevent long-running channel sessions from bypassing truncation and overflowing context windows. (#11224) Thanks @shadril238.

--- a/src/auto-reply/heartbeat.test.ts
+++ b/src/auto-reply/heartbeat.test.ts
@@ -127,8 +127,8 @@ describe("stripHeartbeatToken", () => {
     });
   });
 
-  it("does not strip trailing punctuation from unrelated text containing the token", () => {
-    // Token is in the middle — trailing dot belongs to surrounding sentence, not the token
+  it("strips a sentence-ending token and keeps trailing punctuation", () => {
+    // Token appears at sentence end with trailing punctuation.
     expect(
       stripHeartbeatToken(`I should not respond ${HEARTBEAT_TOKEN}.`, {
         mode: "message",
@@ -140,11 +140,24 @@ describe("stripHeartbeatToken", () => {
     });
   });
 
+  it("strips sentence-ending token with emphasis punctuation in heartbeat mode", () => {
+    expect(
+      stripHeartbeatToken(
+        `There is nothing todo, so i should respond with ${HEARTBEAT_TOKEN} !!!`,
+        {
+          mode: "heartbeat",
+        },
+      ),
+    ).toEqual({
+      shouldSkip: true,
+      text: "",
+      didStrip: true,
+    });
+  });
+
   it("preserves trailing punctuation on text before the token", () => {
     // Token at end, preceding text has its own punctuation — only the token is stripped
-    expect(
-      stripHeartbeatToken(`All clear. ${HEARTBEAT_TOKEN}`, { mode: "message" }),
-    ).toEqual({
+    expect(stripHeartbeatToken(`All clear. ${HEARTBEAT_TOKEN}`, { mode: "message" })).toEqual({
       shouldSkip: false,
       text: "All clear.",
       didStrip: true,

--- a/src/auto-reply/heartbeat.test.ts
+++ b/src/auto-reply/heartbeat.test.ts
@@ -107,6 +107,49 @@ describe("stripHeartbeatToken", () => {
       didStrip: true,
     });
   });
+
+  it("strips trailing punctuation only when directly after the token", () => {
+    // Token with trailing dot/exclamation/dashes → should still strip
+    expect(stripHeartbeatToken(`${HEARTBEAT_TOKEN}.`, { mode: "heartbeat" })).toEqual({
+      shouldSkip: true,
+      text: "",
+      didStrip: true,
+    });
+    expect(stripHeartbeatToken(`${HEARTBEAT_TOKEN}!!!`, { mode: "heartbeat" })).toEqual({
+      shouldSkip: true,
+      text: "",
+      didStrip: true,
+    });
+    expect(stripHeartbeatToken(`${HEARTBEAT_TOKEN}---`, { mode: "heartbeat" })).toEqual({
+      shouldSkip: true,
+      text: "",
+      didStrip: true,
+    });
+  });
+
+  it("does not strip trailing punctuation from unrelated text containing the token", () => {
+    // Token is in the middle — trailing dot belongs to surrounding sentence, not the token
+    expect(
+      stripHeartbeatToken(`I should not respond ${HEARTBEAT_TOKEN}.`, {
+        mode: "message",
+      }),
+    ).toEqual({
+      shouldSkip: false,
+      text: `I should not respond ${HEARTBEAT_TOKEN}.`,
+      didStrip: false,
+    });
+  });
+
+  it("preserves trailing punctuation on text before the token", () => {
+    // Token at end, preceding text has its own punctuation — only the token is stripped
+    expect(
+      stripHeartbeatToken(`All clear. ${HEARTBEAT_TOKEN}`, { mode: "message" }),
+    ).toEqual({
+      shouldSkip: false,
+      text: "All clear.",
+      didStrip: true,
+    });
+  });
 });
 
 describe("isHeartbeatContentEffectivelyEmpty", () => {

--- a/src/auto-reply/heartbeat.test.ts
+++ b/src/auto-reply/heartbeat.test.ts
@@ -135,8 +135,8 @@ describe("stripHeartbeatToken", () => {
       }),
     ).toEqual({
       shouldSkip: false,
-      text: `I should not respond ${HEARTBEAT_TOKEN}.`,
-      didStrip: false,
+      text: `I should not respond.`,
+      didStrip: true,
     });
   });
 

--- a/src/auto-reply/heartbeat.ts
+++ b/src/auto-reply/heartbeat.ts
@@ -81,9 +81,14 @@ function stripTokenAtEdges(raw: string): { text: string; didStrip: boolean } {
       changed = true;
       continue;
     }
-    if (next.endsWith(token)) {
-      const before = next.slice(0, Math.max(0, next.length - token.length));
-      text = before.trimEnd();
+    // Strip the token when it appears at the end of the text.
+    // Also strip up to 4 trailing non-word characters the model may have appended
+    // (e.g. ".", "!!!", "---"), but only when the token is the entire remaining text
+    // (^ anchor). This prevents mangling sentences like "I should not respond HEARTBEAT_OK."
+    // where the punctuation belongs to the surrounding text.
+    if (next.endsWith(token) || new RegExp(`^${token}[^\\w]{0,4}$`).test(next)) {
+      const idx = next.lastIndexOf(token);
+      text = next.slice(0, idx).trimEnd();
       didStrip = true;
       changed = true;
     }

--- a/src/auto-reply/heartbeat.ts
+++ b/src/auto-reply/heartbeat.ts
@@ -87,9 +87,9 @@ function stripTokenAtEdges(raw: string): { text: string; didStrip: boolean } {
     // (e.g. ".", "!!!", "---"), but only when the token is the entire remaining text
     // (^ anchor). This prevents mangling sentences like "I should not respond HEARTBEAT_OK."
     // where the punctuation belongs to the surrounding text.
-    if (next.endsWith(token) || new RegExp(`^${escapeRegExp(token)}[^\\w]{0,4}$`).test(next)) {
+    if (new RegExp(`${escapeRegExp(token)}[^\\w]{0,4}$`).test(next)) {
       const idx = next.lastIndexOf(token);
-      text = next.slice(0, idx).trimEnd();
+      text = `${next.slice(0, idx).trimEnd()}${next.slice(idx + token.length)}`.trimEnd();
       didStrip = true;
       changed = true;
     }

--- a/src/auto-reply/heartbeat.ts
+++ b/src/auto-reply/heartbeat.ts
@@ -1,4 +1,5 @@
 import { HEARTBEAT_TOKEN } from "./tokens.js";
+import { escapeRegExp } from "../utils.js";
 
 // Default heartbeat prompt (used when config.agents.defaults.heartbeat.prompt is unset).
 // Keep it tight and avoid encouraging the model to invent/rehash "open loops" from prior chat context.
@@ -86,7 +87,7 @@ function stripTokenAtEdges(raw: string): { text: string; didStrip: boolean } {
     // (e.g. ".", "!!!", "---"), but only when the token is the entire remaining text
     // (^ anchor). This prevents mangling sentences like "I should not respond HEARTBEAT_OK."
     // where the punctuation belongs to the surrounding text.
-    if (next.endsWith(token) || new RegExp(`^${token}[^\\w]{0,4}$`).test(next)) {
+    if (next.endsWith(token) || new RegExp(`^${escapeRegExp(token)}[^\\w]{0,4}$`).test(next)) {
       const idx = next.lastIndexOf(token);
       text = next.slice(0, idx).trimEnd();
       didStrip = true;


### PR DESCRIPTION
Some models often respond to a HEARTBEAT with things like:

`.... of silence, I'll respond with HEARTBEAT_OK.`
or 
`There is nothing todo, so i should respond with HEARTBEAT_OK !!!`

IMHO this is also a HEARTBEAT_TOKEN at the end of the message which should be stripped.
Therefore this PR.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the heartbeat auto-reply stripping logic so `HEARTBEAT_OK` is removed not only when it appears verbatim at the start/end, but also when the model appends up to 4 trailing non-word characters (e.g. `.`, `!!!`, `---`). It also adds focused tests to cover trailing-punctuation stripping and to ensure punctuation in surrounding sentence text is preserved.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge and is covered by targeted tests, but the new stripping logic has a concrete edge case that can remove more than intended when multiple tokens appear.
- The change is small and tested, and it fixes prior review feedback by matching token-at-end with punctuation and escaping the token. However, the use of `lastIndexOf(token)` combined with a regex that matches any occurrence of the token before trailing punctuation can strip from the *last* occurrence even when the token that makes the regex pass is earlier, which can drop additional text in multi-token strings.
- src/auto-reply/heartbeat.ts

<sub>Last reviewed commit: 73a3102</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->