### PR TITLE
fix: correct Moonshot kimi-k2.5 model ID to resolve 401 auth error

### DIFF
--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -58,7 +58,9 @@ const XIAOMI_DEFAULT_COST = {
 };
 
 const MOONSHOT_BASE_URL = "https://api.moonshot.ai/v1";
-const MOONSHOT_DEFAULT_MODEL_ID = "kimi-k2.5";
+// Fix for issue #15730: Use correct model ID format
+// Moonshot API expects "kimi-k2-0905-preview" not "kimi-k2.5"
+const MOONSHOT_DEFAULT_MODEL_ID = "kimi-k2-0905-preview";
 const MOONSHOT_DEFAULT_CONTEXT_WINDOW = 256000;
 const MOONSHOT_DEFAULT_MAX_TOKENS = 8192;
 const MOONSHOT_DEFAULT_COST = {
@@ -465,8 +467,35 @@ function buildMoonshotProvider(): ProviderConfig {
     models: [
       {
         id: MOONSHOT_DEFAULT_MODEL_ID,
-        name: "Kimi K2.5",
+        name: "Kimi K2 (0905 Preview)",
         reasoning: false,
+        input: ["text"],
+        cost: MOONSHOT_DEFAULT_COST,
+        contextWindow: MOONSHOT_DEFAULT_CONTEXT_WINDOW,
+        maxTokens: MOONSHOT_DEFAULT_MAX_TOKENS,
+      },
+      {
+        id: "kimi-k2-turbo-preview",
+        name: "Kimi K2 Turbo",
+        reasoning: false,
+        input: ["text"],
+        cost: MOONSHOT_DEFAULT_COST,
+        contextWindow: MOONSHOT_DEFAULT_CONTEXT_WINDOW,
+        maxTokens: MOONSHOT_DEFAULT_MAX_TOKENS,
+      },
+      {
+        id: "kimi-k2-thinking",
+        name: "Kimi K2 Thinking",
+        reasoning: true,
+        input: ["text"],
+        cost: MOONSHOT_DEFAULT_COST,
+        contextWindow: MOONSHOT_DEFAULT_CONTEXT_WINDOW,
+        maxTokens: MOONSHOT_DEFAULT_MAX_TOKENS,
+      },
+      {
+        id: "kimi-k2-thinking-turbo",
+        name: "Kimi K2 Thinking Turbo",
+        reasoning: true,
         input: ["text"],
         cost: MOONSHOT_DEFAULT_COST,
         contextWindow: MOONSHOT_DEFAULT_CONTEXT_WINDOW,


### PR DESCRIPTION
## Problem

The Moonshot API returns HTTP 401 authentication errors when using the `kimi-k2.5` model, while `moonshot-v1-8k` works correctly with the same API key.

## Root Cause

The model ID `kimi-k2.5` was incorrect. Moonshot API expects `kimi-k2-0905-preview` as the valid model identifier.

## Changes

- **Fixed**: Updated `MOONSHOT_DEFAULT_MODEL_ID` from `"kimi-k2.5"` to `"kimi-k2-0905-preview"`
- **Added**: Additional Kimi K2 model variants (turbo, thinking, thinking-turbo)
- **Updated**: Model name from "Kimi K2.5" to "Kimi K2 (0905 Preview)" for clarity

## Testing

This fix aligns the model ID with the official Moonshot API documentation and the existing UI model definitions in `ui/src/ui/data/moonshot-kimi-k2.ts`.

## Related Issue

Fixes #15730

---

**Contributor**: Shuai-DaiDai 🦞

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Moonshot provider’s implicit model catalog to use `kimi-k2-0905-preview` as the default (instead of `kimi-k2.5`) and adds additional Kimi K2 variants (turbo / thinking / thinking-turbo) in `src/agents/models-config.providers.ts`.

Key integration note: the repository also has onboarding/auth codepaths that set defaults and generate configs for Moonshot. Those currently still reference `kimi-k2.5`, so the PR’s fix is not applied consistently across entrypoints and can leave users configured with the old model ID.

<h3>Confidence Score: 3/5</h3>

- This PR is close, but the fix is incomplete due to inconsistent Moonshot defaults across codepaths.
- The change in the implicit provider config is straightforward, but onboarding/auth flows and tests still hardcode the old Moonshot model ID (`kimi-k2.5`), so users can still be configured with the broken default and the PR may not actually resolve the reported 401s in common setups.
- src/commands/onboard-auth.models.ts, src/commands/auth-choice.moonshot.e2e.test.ts, and any docs/config examples that set moonshot/kimi-k2.5

<sub>Last reviewed commit: a7ed17d</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->