### PR TITLE
fix: platform-agnostic test paths and flexible timeout matching

### DIFF
--- a/src/commands/cleanup-utils.test.ts
+++ b/src/commands/cleanup-utils.test.ts
@@ -70,11 +70,13 @@ describe("cleanup path removals", () => {
   it("removes state and only linked paths outside state", async () => {
     const runtime = createRuntimeMock();
     const tmpRoot = path.join(path.parse(process.cwd()).root, "tmp", "openclaw-cleanup");
+    const statePath = path.join(tmpRoot, "state");
+    const oauthPath = path.join(tmpRoot, "oauth");
     await removeStateAndLinkedPaths(
       {
-        stateDir: path.join(tmpRoot, "state"),
-        configPath: path.join(tmpRoot, "state", "openclaw.json"),
-        oauthDir: path.join(tmpRoot, "oauth"),
+        stateDir: statePath,
+        configPath: path.join(statePath, "openclaw.json"),
+        oauthDir: oauthPath,
         configInsideState: true,
         oauthInsideState: false,
       },
@@ -82,22 +84,24 @@ describe("cleanup path removals", () => {
       { dryRun: true },
     );
 
-    const joinedLogs = runtime.log.mock.calls
-      .map(([line]) => line.replaceAll("\\", "/"))
-      .join("\n");
-    expect(joinedLogs).toContain("/tmp/openclaw-cleanup/state");
-    expect(joinedLogs).toContain("/tmp/openclaw-cleanup/oauth");
+    const joinedLogs = runtime.log.mock.calls.map(([line]) => line).join("\n");
+    expect(joinedLogs).toContain(`[dry-run] remove ${statePath}`);
+    expect(joinedLogs).toContain(`[dry-run] remove ${oauthPath}`);
     expect(joinedLogs).not.toContain("openclaw.json");
   });
 
   it("removes every workspace directory", async () => {
     const runtime = createRuntimeMock();
-    const workspaces = ["/tmp/openclaw-workspace-1", "/tmp/openclaw-workspace-2"];
+    const tmpRoot = path.join(path.parse(process.cwd()).root, "tmp");
+    const workspaces = [
+      path.join(tmpRoot, "openclaw-workspace-1"),
+      path.join(tmpRoot, "openclaw-workspace-2"),
+    ];
 
     await removeWorkspaceDirs(workspaces, runtime, { dryRun: true });
 
     const logs = runtime.log.mock.calls.map(([line]) => line);
-    expect(logs).toContain("[dry-run] remove /tmp/openclaw-workspace-1");
-    expect(logs).toContain("[dry-run] remove /tmp/openclaw-workspace-2");
+    expect(logs).toContain(`[dry-run] remove ${workspaces[0]}`);
+    expect(logs).toContain(`[dry-run] remove ${workspaces[1]}`);
   });
 });

--- a/src/cron/isolated-agent.delivers-response-has-heartbeat-ok-but-includes.test.ts
+++ b/src/cron/isolated-agent.delivers-response-has-heartbeat-ok-but-includes.test.ts
@@ -280,7 +280,7 @@ describe("runCronIsolatedAgentTurn", () => {
       });
 
       expect(res.status).toBe("error");
-      expect(res.error).toContain("timed out");
+      expect(res.error).toMatch(/timed out|timeout/i);
       expect(deps.sendMessageTelegram).not.toHaveBeenCalled();
       expect(runSubagentAnnounceFlow).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
## Summary

- Replace hardcoded Unix paths in cleanup-utils tests with `path.join` and dynamic root detection for Windows compatibility
- Make timeout error assertion case-insensitive (`/timed out|timeout/i`) to handle varying error message formats

Note: the original `pi-tools.read.ts` URL parsing simplification was superseded by upstream's `trySafeFileURLToPath` refactor and is no longer included.

## Test plan

- [ ] CI passes on all platforms (Linux, macOS, Windows)
- [ ] `cleanup-utils.test.ts` assertions use platform-agnostic paths
- [ ] Timeout test matches both "timed out" and "Timeout" error formats