### PR TITLE
fix(macos): respect gateway.controlUi.basePath in Dashboard URL

### DIFF
--- a/apps/macos/Sources/OpenClaw/GatewayEndpointStore.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayEndpointStore.swift
@@ -619,7 +619,29 @@ actor GatewayEndpointStore {
 }
 
 extension GatewayEndpointStore {
-    static func dashboardURL(for config: GatewayConnection.Config) throws -> URL {
+    private static func normalizeDashboardPath(_ rawPath: String?) -> String {
+        let trimmed = (rawPath ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "/" }
+        let withLeadingSlash = trimmed.hasPrefix("/") ? trimmed : "/" + trimmed
+        guard withLeadingSlash != "/" else { return "/" }
+        return withLeadingSlash.hasSuffix("/") ? withLeadingSlash : withLeadingSlash + "/"
+    }
+
+    private static func localControlUiBasePath() -> String {
+        let root = OpenClawConfigFile.loadDict()
+        guard let gateway = root["gateway"] as? [String: Any],
+              let controlUi = gateway["controlUi"] as? [String: Any]
+        else {
+            return "/"
+        }
+        return self.normalizeDashboardPath(controlUi["basePath"] as? String)
+    }
+
+    static func dashboardURL(
+        for config: GatewayConnection.Config,
+        mode: AppState.ConnectionMode,
+        localBasePath: String? = nil) throws -> URL
+    {
         guard var components = URLComponents(url: config.url, resolvingAgainstBaseURL: false) else {
             throw NSError(domain: "Dashboard", code: 1, userInfo: [
                 NSLocalizedDescriptionKey: "Invalid gateway URL",
@@ -633,7 +655,17 @@ extension GatewayEndpointStore {
         default:
             components.scheme = "http"
         }
-        components.path = "/"
+
+        let urlPath = self.normalizeDashboardPath(components.path)
+        if urlPath != "/" {
+            components.path = urlPath
+        } else if mode == .local {
+            let fallbackPath = localBasePath ?? self.localControlUiBasePath()
+            components.path = self.normalizeDashboardPath(fallbackPath)
+        } else {
+            components.path = "/"
+        }
+
         var queryItems: [URLQueryItem] = []
         if let token = config.token?.trimmingCharacters(in: .whitespacesAndNewlines),
            !token.isEmpty

--- a/apps/macos/Sources/OpenClaw/MenuContentView.swift
+++ b/apps/macos/Sources/OpenClaw/MenuContentView.swift
@@ -337,7 +337,7 @@ struct MenuContent: View {
     private func openDashboard() async {
         do {
             let config = try await GatewayEndpointStore.shared.requireConfig()
-            let url = try GatewayEndpointStore.dashboardURL(for: config)
+            let url = try GatewayEndpointStore.dashboardURL(for: config, mode: self.state.connectionMode)
             NSWorkspace.shared.open(url)
         } catch {
             let alert = NSAlert()

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift
@@ -176,6 +176,48 @@ import Testing
         #expect(host == "192.168.1.10")
     }
 
+    @Test func dashboardURLUsesLocalBasePathInLocalMode() throws {
+        let config: GatewayConnection.Config = (
+            url: try #require(URL(string: "ws://127.0.0.1:18789")),
+            token: nil,
+            password: nil
+        )
+
+        let url = try GatewayEndpointStore.dashboardURL(
+            for: config,
+            mode: .local,
+            localBasePath: " control ")
+        #expect(url.absoluteString == "http://127.0.0.1:18789/control/")
+    }
+
+    @Test func dashboardURLSkipsLocalBasePathInRemoteMode() throws {
+        let config: GatewayConnection.Config = (
+            url: try #require(URL(string: "ws://gateway.example:18789")),
+            token: nil,
+            password: nil
+        )
+
+        let url = try GatewayEndpointStore.dashboardURL(
+            for: config,
+            mode: .remote,
+            localBasePath: "/local-ui")
+        #expect(url.absoluteString == "http://gateway.example:18789/")
+    }
+
+    @Test func dashboardURLPrefersPathFromConfigURL() throws {
+        let config: GatewayConnection.Config = (
+            url: try #require(URL(string: "wss://gateway.example:443/remote-ui")),
+            token: nil,
+            password: nil
+        )
+
+        let url = try GatewayEndpointStore.dashboardURL(
+            for: config,
+            mode: .remote,
+            localBasePath: "/local-ui")
+        #expect(url.absoluteString == "https://gateway.example:443/remote-ui/")
+    }
+
     @Test func normalizeGatewayUrlAddsDefaultPortForWs() {
         let url = GatewayRemoteConfig.normalizeGatewayUrl("ws://gateway")
         #expect(url?.port == 18789)


### PR DESCRIPTION
## Problem

The macOS app ignores the configured gateway.controlUi.basePath when opening the Dashboard, always using '/' which results in 404 when a custom basePath is set.

## Solution

- Added gatewayControlUiBasePath() method to read the config
- Updated dashboardURL() to use the configured basePath
- Properly formats path with leading/trailing slashes

Fixes #15743

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes the macOS menu bar app’s “Open Dashboard” URL generation to respect `gateway.controlUi.basePath` instead of always opening `/`, by adding a config reader (`OpenClawConfigFile.gatewayControlUiBasePath()`) and wiring it into `GatewayEndpointStore.dashboardURL()`.

It also includes unrelated documentation tweaks (compaction config text and GitHub skill GraphQL guidance) and expands Moonshot model provider defaults (correcting the default model id and adding additional model variants).

<h3>Confidence Score: 3/5</h3>

- This PR is mostly safe, but has at least one behavior issue that can break remote dashboard URLs and one doc inconsistency.
- The macOS basePath fix is straightforward for local gateways, but `dashboardURL()` now reads basePath exclusively from the local config file even when connected to a remote gateway URL, which can produce incorrect links in remote/direct modes. Additionally, the compaction doc change appears to reference a different config filename than the rest of the repo, which will mislead users.
- apps/macos/Sources/OpenClaw/GatewayEndpointStore.swift, docs/concepts/compaction.md

<sub>Last reviewed commit: 28d7741</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->