### PR TITLE
feat: add GLM-5 model support (#14352)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Agents: add synthetic catalog support for `hf:zai-org/GLM-5`. (#15867) Thanks @battman21.
 - Skills: remove duplicate `local-places` Google Places skill/proxy and keep `goplaces` as the single supported Google Places path.
 - Discord: send voice messages with waveform previews from local audio files (including silent delivery). (#7253) Thanks @nyanjou.
 - Discord: add configurable presence status/activity/type/url (custom status defaults to activity text). (#10855) Thanks @h0tp-ftw.

--- a/src/agents/synthetic-models.ts
+++ b/src/agents/synthetic-models.ts
@@ -156,6 +156,14 @@ export const SYNTHETIC_MODEL_CATALOG = [
     maxTokens: 128000,
   },
   {
+    id: "hf:zai-org/GLM-5",
+    name: "GLM-5",
+    reasoning: true,
+    input: ["text", "image"],
+    contextWindow: 256000,
+    maxTokens: 128000,
+  },
+  {
     id: "hf:deepseek-ai/DeepSeek-V3",
     name: "DeepSeek V3",
     reasoning: false,


### PR DESCRIPTION
## Summary

See commit history for details.

## Test plan

- [ ] `pnpm test` passes
- [ ] No regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new entry (`hf:zai-org/GLM-5`) to the synthetic model catalog (`src/agents/synthetic-models.ts`). The synthetic provider configuration is assembled by mapping `SYNTHETIC_MODEL_CATALOG` through `buildSyntheticModelDefinition`, so this change makes GLM-5 available anywhere synthetic models are enumerated (e.g., implicit provider construction and onboarding config merge paths).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a single, schema-conformant addition to a static model catalog. It does not alter control flow or provider normalization logic, and the new entry matches the existing catalog shape used throughout provider assembly.
- No files require special attention

<sub>Last reviewed commit: b8ccbfb</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->