### PR TITLE
fix(venice): disable streaming to prevent SDK crash

### DIFF
--- a/src/agents/venice-models.ts
+++ b/src/agents/venice-models.ts
@@ -300,6 +300,11 @@ export function buildVeniceModelDefinition(entry: VeniceCatalogEntry): ModelDefi
     cost: VENICE_DEFAULT_COST,
     contextWindow: entry.contextWindow,
     maxTokens: entry.maxTokens,
+    // Disable streaming by default for Venice to avoid SDK crash with usage-only chunks
+    // See: https://github.com/openclaw/openclaw/issues/15819
+    params: {
+      streaming: false,
+    },
   };
 }
 
@@ -381,6 +386,10 @@ export async function discoverVeniceModels(): Promise<ModelDefinitionConfig[]> {
           cost: VENICE_DEFAULT_COST,
           contextWindow: apiModel.model_spec.availableContextTokens || 128000,
           maxTokens: 8192,
+          // Disable streaming to avoid SDK crash with usage-only chunks (#15819)
+          params: {
+            streaming: false,
+          },
         });
       }
     }

--- a/src/agents/venice-models.ts
+++ b/src/agents/venice-models.ts
@@ -300,10 +300,10 @@ export function buildVeniceModelDefinition(entry: VeniceCatalogEntry): ModelDefi
     cost: VENICE_DEFAULT_COST,
     contextWindow: entry.contextWindow,
     maxTokens: entry.maxTokens,
-    // Disable streaming by default for Venice to avoid SDK crash with usage-only chunks
+    // Avoid usage-only streaming chunks that can break OpenAI-compatible parsers.
     // See: https://github.com/openclaw/openclaw/issues/15819
-    params: {
-      streaming: false,
+    compat: {
+      supportsUsageInStreaming: false,
     },
   };
 }
@@ -386,9 +386,9 @@ export async function discoverVeniceModels(): Promise<ModelDefinitionConfig[]> {
           cost: VENICE_DEFAULT_COST,
           contextWindow: apiModel.model_spec.availableContextTokens || 128000,
           maxTokens: 8192,
-          // Disable streaming to avoid SDK crash with usage-only chunks (#15819)
-          params: {
-            streaming: false,
+          // Avoid usage-only streaming chunks that can break OpenAI-compatible parsers.
+          compat: {
+            supportsUsageInStreaming: false,
           },
         });
       }


### PR DESCRIPTION
## Problem

Venice.ai provider crashes with `TypeError: Cannot read properties of undefined (reading '0')` when streaming responses contain usage-only chunks without a `choices` array (#15819).

## Root Cause

Venice sends SSE chunks like:
```
data: {"id":"...","usage":{...},"model":"..."}
```

These chunks have no `choices` array, but the SDK tries to access `choices[0]`, causing a crash.

## Solution

Disable streaming by default for all Venice models (similar to Ollama workaround for issue #1205):

```typescript
params: {
  streaming: false,
}
```

## Changes

- `buildVeniceModelDefinition()`: Add `streaming: false` to static catalog models
- `discoverVeniceModels()`: Add `streaming: false` to dynamically discovered models

## Workaround

Users can explicitly re-enable streaming in their config if the SDK issue is fixed:
```json
{
  "models": {
    "providers": {
      "venice": {
        "models": [{
          "id": "llama-3.3-70b",
          "params": { "streaming": true }
        }]
      }
    }
  }
}
```

Fixes #15819

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change disables streaming by default for Venice model definitions (both static catalog entries and API-discovered models) to work around an SDK crash when Venice emits usage-only SSE chunks without a `choices` array.

Unrelated to the Venice fix, it also adjusts cron schedule normalization to treat numeric timestamps as either seconds or milliseconds, and adds debug logging to the internal hook triggering path to aid diagnosing missing hook registrations.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but cron normalization has a concrete inconsistency for numeric one-shot schedules.
- Venice streaming disablement is localized and low-risk, and the hook logging is additive. However, the cron normalization change introduces a definite case where `schedule.at` provided as a number yields a schedule missing `kind`, which can cause runtime logic to mis-handle one-shot jobs.
- src/cron/normalize.ts

<sub>Last reviewed commit: 7d1e505</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->