### PR TITLE
Support for forwarded messages and file_shared messages in slack

### DIFF
--- a/src/slack/monitor/events.ts
+++ b/src/slack/monitor/events.ts
@@ -2,6 +2,7 @@ import type { ResolvedSlackAccount } from "../accounts.js";
 import type { SlackMonitorContext } from "./context.js";
 import type { SlackMessageHandler } from "./message-handler.js";
 import { registerSlackChannelEvents } from "./events/channels.js";
+import { registerSlackFileSharedEvents } from "./events/file-shared.js";
 import { registerSlackMemberEvents } from "./events/members.js";
 import { registerSlackMessageEvents } from "./events/messages.js";
 import { registerSlackPinEvents } from "./events/pins.js";
@@ -20,4 +21,8 @@ export function registerSlackMonitorEvents(params: {
   registerSlackMemberEvents({ ctx: params.ctx });
   registerSlackChannelEvents({ ctx: params.ctx });
   registerSlackPinEvents({ ctx: params.ctx });
+  registerSlackFileSharedEvents({
+    ctx: params.ctx,
+    handleSlackMessage: params.handleSlackMessage,
+  });
 }

--- a/src/slack/monitor/events/file-shared.ts
+++ b/src/slack/monitor/events/file-shared.ts
@@ -1,0 +1,139 @@
+import type { SlackMessageEvent } from "../../types.js";
+import type { SlackMonitorContext } from "../context.js";
+import type { SlackMessageHandler } from "../message-handler.js";
+import { danger } from "../../../globals.js";
+
+/**
+ * Shared dedup set: the `message` event handler should call
+ * `markMessageHandled(ts)` for every message with files so the
+ * `file_shared` fallback handler skips them.
+ */
+const handledMessageTimestamps = new Set<string>();
+const DEDUP_TTL_MS = 30_000;
+
+export function markMessageHandled(ts: string) {
+  handledMessageTimestamps.add(ts);
+  setTimeout(() => handledMessageTimestamps.delete(ts), DEDUP_TTL_MS);
+}
+
+interface FileSharedEvent {
+  file_id?: string;
+  channel_id?: string;
+  user_id?: string;
+  event_ts?: string;
+}
+
+/**
+ * Handle `file_shared` events — Slack's fallback for large file uploads.
+ *
+ * When a user sends a message with a large file (e.g. PDF > ~20MB), Slack
+ * may NOT deliver the normal `message` event via Socket Mode. Instead it
+ * only sends a `file_shared` event with { file_id, channel_id, user_id }.
+ *
+ * This handler catches those events, fetches the actual message from
+ * conversations.history, and feeds it into the normal message pipeline.
+ */
+export function registerSlackFileSharedEvents(params: {
+  ctx: SlackMonitorContext;
+  handleSlackMessage: SlackMessageHandler;
+}) {
+  const { ctx, handleSlackMessage } = params;
+
+  // Bolt doesn't type `file_shared` as a known event, so we register via
+  // the generic receiver and cast the callback arguments ourselves.
+  (
+    ctx.app as unknown as {
+      event: (name: string, cb: (args: { event: unknown; body: unknown }) => Promise<void>) => void;
+    }
+  ).event("file_shared", async ({ event, body }) => {
+    try {
+      if (ctx.shouldDropMismatchedSlackEvent(body)) {
+        return;
+      }
+
+      const fileEvent = event as FileSharedEvent;
+
+      const channelId = fileEvent.channel_id;
+      const fileId = fileEvent.file_id;
+      if (!channelId || !fileId) {
+        return;
+      }
+
+      // Skip if the bot itself shared the file
+      if (fileEvent.user_id === ctx.botUserId) {
+        return;
+      }
+
+      // Small delay — give Slack time to settle the message so
+      // conversations.history returns it with the full files array.
+      await new Promise((r) => setTimeout(r, 2000));
+
+      // Fetch the most recent messages in the channel
+      const result = await ctx.app.client.conversations.history({
+        channel: channelId,
+        limit: 5,
+      });
+
+      if (!result.ok || !result.messages?.length) {
+        return;
+      }
+
+      // Find the message that contains our file_id
+      const matchingMessage = result.messages.find((msg) =>
+        (msg as Record<string, unknown>).files
+          ? ((msg as Record<string, unknown>).files as Array<{ id?: string }>)?.some(
+              (f) => f.id === fileId,
+            )
+          : false,
+      );
+
+      if (!matchingMessage) {
+        return;
+      }
+
+      // Dedup: skip if we already handled this message via the normal
+      // `message` event (small files get both events).
+      const msgTs = matchingMessage.ts;
+      if (msgTs && handledMessageTimestamps.has(msgTs)) {
+        return;
+      }
+
+      // Skip bot messages
+      if (matchingMessage.bot_id || matchingMessage.user === ctx.botUserId) {
+        return;
+      }
+
+      // Mark as handled (prevent future duplicates within this handler)
+      if (msgTs) {
+        markMessageHandled(msgTs);
+      }
+
+      // Resolve channel type for the message event
+      const channelInfo = await ctx.resolveChannelName(channelId);
+
+      // Build a SlackMessageEvent from the history response
+      const files = (matchingMessage as Record<string, unknown>)
+        .files as SlackMessageEvent["files"];
+      const message: SlackMessageEvent = {
+        type: "message",
+        user: matchingMessage.user,
+        text: matchingMessage.text ?? "",
+        ts: matchingMessage.ts,
+        thread_ts: matchingMessage.thread_ts,
+        event_ts: fileEvent.event_ts,
+        channel: channelId,
+        channel_type: channelInfo?.type,
+        files,
+        subtype: "file_share",
+      };
+
+      ctx.runtime.log?.(
+        `file_shared fallback: processing message ${msgTs} in ${channelId} (file ${fileId})`,
+      );
+
+      await handleSlackMessage(message, { source: "message" });
+    } catch (err) {
+      ctx.runtime.error?.(danger(`slack file_shared handler failed: ${String(err)}`));
+    }
+  });
+}

--- a/src/slack/monitor/events/messages.ts
+++ b/src/slack/monitor/events/messages.ts
@@ -10,6 +10,7 @@ import type {
 import { danger } from "../../../globals.js";
 import { enqueueSystemEvent } from "../../../infra/system-events.js";
 import { resolveSlackChannelLabel } from "../channel-config.js";
+import { markMessageHandled } from "./file-shared.js";
 
 export function registerSlackMessageEvents(params: {
   ctx: SlackMonitorContext;
@@ -111,6 +112,9 @@ export function registerSlackMessageEvents(params: {
         return;
       }
 
+      if (message.files?.length && message.ts) {
+        markMessageHandled(message.ts);
+      }
       await handleSlackMessage(message, { source: "message" });
     } catch (err) {
       ctx.runtime.error?.(danger(`slack handler failed: ${String(err)}`));

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -49,6 +49,7 @@ import {
   resolveSlackThreadHistory,
   resolveSlackThreadStarter,
 } from "../media.js";
+import { getAttachmentNote } from "../../overrides/attachment-helper.js";
 
 export async function prepareSlackMessage(params: {
   ctx: SlackMonitorContext;
@@ -342,7 +343,11 @@ export async function prepareSlackMessage(params: {
     token: ctx.botToken,
     maxBytes: ctx.mediaMaxBytes,
   });
-  const rawBody = (message.text ?? "").trim() || media?.placeholder || "";
+  const attachmentNote = getAttachmentNote(message.attachments);
+  const textWithAttachmentNote = attachmentNote
+    ? `${(message.text ?? "").trim()}\n\n${attachmentNote}`
+    : (message.text ?? "").trim();
+  const rawBody = textWithAttachmentNote || media?.placeholder || "";
   if (!rawBody) {
     return null;
   }

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -37,6 +37,7 @@ import { resolveAgentRoute } from "../../../routing/resolve-route.js";
 import { resolveThreadSessionKeys } from "../../../routing/session-key.js";
 import { buildUntrustedChannelMetadata } from "../../../security/channel-metadata.js";
 import { reactSlackMessage } from "../../actions.js";
+import { getAttachmentNote } from "../../overrides/attachment-helper.js";
 import { sendMessageSlack } from "../../send.js";
 import { resolveSlackThreadContext } from "../../threading.js";
 import { resolveSlackAllowListMatch, resolveSlackUserAllowed } from "../allow-list.js";
@@ -49,7 +50,6 @@ import {
   resolveSlackThreadHistory,
   resolveSlackThreadStarter,
 } from "../media.js";
-import { getAttachmentNote } from "../../overrides/attachment-helper.js";
 
 export async function prepareSlackMessage(params: {
   ctx: SlackMonitorContext;

--- a/src/slack/overrides/attachment-helper.ts
+++ b/src/slack/overrides/attachment-helper.ts
@@ -1,0 +1,22 @@
+import type { SlackAttachment } from "../types.js";
+
+/**
+ * Check if message has forwarded content in attachments.
+ * Returns a note for the agent to retrieve it if needed.
+ */
+export function getAttachmentNote(attachments?: SlackAttachment[]): string | null {
+  if (!attachments || attachments.length === 0) {
+    return null;
+  }
+
+  // Check if this looks like a forwarded message
+  const hasForwardedContent = attachments.some(
+    (att) => att.text || att.title || att.pretext
+  );
+
+  if (hasForwardedContent) {
+    return "[Note: This message contains forwarded/attached content. Use Slack API to retrieve full content: conversations.history with the channel and message ts from above]";
+  }
+
+  return null;
+}

--- a/src/slack/overrides/attachment-helper.ts
+++ b/src/slack/overrides/attachment-helper.ts
@@ -10,9 +10,7 @@ export function getAttachmentNote(attachments?: SlackAttachment[]): string | nul
   }
 
   // Check if this looks like a forwarded message
-  const hasForwardedContent = attachments.some(
-    (att) => att.text || att.title || att.pretext
-  );
+  const hasForwardedContent = attachments.some((att) => att.text || att.title || att.pretext);
 
   if (hasForwardedContent) {
     return "[Note: This message contains forwarded/attached content. Use Slack API to retrieve full content: conversations.history with the channel and message ts from above]";

--- a/src/slack/overrides/extract-attachments.ts
+++ b/src/slack/overrides/extract-attachments.ts
@@ -1,0 +1,54 @@
+import type { SlackAttachment } from "./types.js";
+
+/**
+ * Extract forwarded message content from Slack attachments.
+ * Forwarded messages appear in the attachments field with text content.
+ */
+export function extractAttachmentText(attachments?: SlackAttachment[]): string | null {
+  if (!attachments || attachments.length === 0) {
+    return null;
+  }
+
+  const parts: string[] = [];
+
+  for (const attachment of attachments) {
+    // Collect all text-like fields from the attachment
+    const textParts: string[] = [];
+
+    if (attachment.pretext) {
+      textParts.push(attachment.pretext);
+    }
+
+    if (attachment.title) {
+      textParts.push(attachment.title);
+    }
+
+    if (attachment.text) {
+      textParts.push(attachment.text);
+    }
+
+    if (attachment.author_name) {
+      textParts.push(`— ${attachment.author_name}`);
+    }
+
+    if (attachment.fields && attachment.fields.length > 0) {
+      for (const field of attachment.fields) {
+        if (field.title && field.value) {
+          textParts.push(`${field.title}: ${field.value}`);
+        } else if (field.value) {
+          textParts.push(field.value);
+        }
+      }
+    }
+
+    if (attachment.footer) {
+      textParts.push(attachment.footer);
+    }
+
+    if (textParts.length > 0) {
+      parts.push(textParts.join("\n"));
+    }
+  }
+
+  return parts.length > 0 ? parts.join("\n\n---\n\n") : null;
+}

--- a/src/slack/overrides/types.ts
+++ b/src/slack/overrides/types.ts
@@ -2,12 +2,12 @@ export type SlackFile = {
   id?: string;
   name?: string;
   mimetype?: string;
-  subtype?: string;
   size?: number;
   url_private?: string;
   url_private_download?: string;
 };
 
+// Slack attachment for forwarded messages
 export type SlackAttachment = {
   text?: string;
   fallback?: string;


### PR DESCRIPTION
Summary
Forwarded message support: Extracts and surfaces attachment notes from Slack forwarded messages so the agent can see forwarded content (adds attachments field to SlackMessageEvent type and a helper to detect forwarded messages).
Large file upload fallback: When a user sends a message with a large file (>~20MB) in an MPDM, Slack Socket Mode may not deliver the normal message event — instead only a file_shared event is emitted. This adds a fallback handler that catches file_shared events, fetches the actual message from conversations.history, and feeds it into the normal message pipeline.
Dedup logic: For small files that produce both message and file_shared events, a shared timestamp set prevents double-processing.
Background
Slack has a platform-level behavior where large file uploads in MPDMs via Socket Mode do not deliver the expected message event. Instead, only a non-message file_shared event is sent (containing file_id and channel_id but no message text or files array). This was confirmed by testing with a raw WebSocket listener — small files (~1KB) produce normal message events with subtype: "file_share", while large files (~35MB PDF) only produce file_shared events.
Changes
src/slack/overrides/types.ts — Extended SlackMessageEvent with attachments field
src/slack/overrides/attachment-helper.ts — Helper to detect forwarded message content
src/slack/overrides/extract-attachments.ts — Full attachment text extractor
src/slack/monitor/message-handler/prepare.ts — Integrates attachment note into message body
src/slack/monitor/events/file-shared.ts — New file_shared event handler with dedup
src/slack/monitor/events.ts — Registers the new handler
src/slack/monitor/events/messages.ts — Marks file messages as handled for dedup
How the fallback works
Slack sends file_shared event with { file_id, channel_id, user_id }
Handler waits 2s for Slack to settle the message
Fetches last 5 messages from conversations.history
Finds the message containing the matching file_id
Checks dedup set — skips if already handled via normal message event
Constructs a SlackMessageEvent and passes it to handleSlackMessage
Test plan
[ ] Send a text-only message — bot responds normally (no regression)
[ ] Send a message with a small file (<5MB) — bot responds, file is processed
[ ] Send a message with a large file (>20MB) — bot responds via file_shared fallback
[ ] Send a small file message — verify it's not processed twice (dedup)
[ ] Forward a message in Slack — agent sees forwarded content note

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends Slack message handling in two directions:

- Adds support for surfacing forwarded/attached message context by threading an `attachments` field into `SlackMessageEvent` and appending an attachment note during message preparation.
- Adds a new `file_shared` Socket Mode event handler that backfills large file uploads by fetching the corresponding message from `conversations.history`, with timestamp-based deduping to avoid double-processing when both events are emitted.

These changes integrate into the existing Slack monitor event registration (`registerSlackMonitorEvents`) and reuse the normal `handleSlackMessage` pipeline so downstream behaviors (policy checks, mention gating, media handling, etc.) remain centralized.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable, but has a couple correctness issues that can break the new Slack behaviors in production.
- Main risk is the new `file_shared` fallback calling `conversations.history` without an explicit token, which may prevent message backfill entirely depending on client configuration. There’s also an apparently unused duplicate Slack type module that is likely accidental and could cause future drift/confusion.
- src/slack/monitor/events/file-shared.ts; src/slack/overrides/types.ts

<sub>Last reviewed commit: a9fd42b</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->