### PR TITLE
fix: store relative session file paths instead of absolute

### DIFF
--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
+import path from "node:path";
 import type { TypingMode } from "../../config/types.js";
 import type { OriginatingChannelType, TemplateContext } from "../templating.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
@@ -258,7 +259,8 @@ export async function runReplyAgent(params: {
       agentId,
       sessionCtx.MessageThreadId,
     );
-    nextEntry.sessionFile = nextSessionFile;
+    // Store relative path (basename) instead of absolute path to avoid validation errors
+    nextEntry.sessionFile = path.basename(nextSessionFile);
     activeSessionStore[sessionKey] = nextEntry;
     try {
       await updateSessionStore(storePath, (store) => {


### PR DESCRIPTION
## Problem

The auto-reply agent runner was storing absolute session file paths in `sessions.json`, which caused validation errors when those paths were later read and validated by `resolvePathWithinSessionsDir()`.

The validation logic in `src/config/sessions/paths.ts` expects session file paths to be relative to the sessions directory, but the agent runner was storing the full absolute path returned by `resolveSessionTranscriptPath()`.

This resulted in the error: `Session file path must be within sessions directory`

## Root Cause

In `src/auto-reply/reply/agent-runner.ts` (line 261), the code was:
```typescript
nextEntry.sessionFile = nextSessionFile;
```

Where `nextSessionFile` is the return value of `resolveSessionTranscriptPath()`, which returns an absolute path like:
`/home/user/.openclaw/agents/agentId/sessions/sessionId.jsonl`

## Solution

Store only the basename (relative path) instead of the absolute path:
```typescript
nextEntry.sessionFile = path.basename(nextSessionFile);
```

This ensures the stored path is just `sessionId.jsonl`, which passes the validation check in `resolvePathWithinSessionsDir()`.

## Testing

- Verified that Telegram bots using OpenClaw gateway now successfully create and access session files without validation errors
- Confirmed that existing absolute paths in `sessions.json` are normalized correctly by the existing logic in `resolvePathWithinSessionsDir()`
- All session file operations work correctly with relative paths

## Notes

The validation code in `paths.ts` already has logic to handle legacy absolute paths by converting them to relative paths:
```typescript
const normalized = path.isAbsolute(trimmed) ? path.relative(resolvedBase, trimmed) : trimmed;
```

However, this doesn't work when the absolute path points to a different sessions directory than expected. By storing relative paths from the start, we avoid this edge case entirely.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixes a bug where `resetSession()` in `agent-runner.ts` stored the full absolute path from `resolveSessionTranscriptPath()` into `sessionEntry.sessionFile`, which then failed validation in `resolvePathWithinSessionsDir()` when the absolute path pointed to a different sessions directory than expected.

- Stores `path.basename(nextSessionFile)` (e.g., `sessionId.jsonl`) instead of the full absolute path, which passes the containment check in `resolvePathWithinSessionsDir()`
- The in-memory `followupRun.run.sessionFile` correctly retains the full absolute path for runtime use
- A similar absolute-path-to-`sessionFile` pattern exists in `src/auto-reply/reply/session.ts:347` (session initialization) and `src/auto-reply/reply/session.ts:342` (fork), which may warrant the same treatment for full consistency

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it's a small, targeted fix that aligns persisted session file paths with the expected validation contract.
- Single-line change that correctly converts an absolute path to a basename before persisting. The fix is well-justified by the validation logic in `resolvePathWithinSessionsDir()`. The only concern is that the same pattern exists in other code paths (`session.ts`) and wasn't addressed, but that doesn't affect the correctness of this change. No tests were added, but the change is straightforward and low-risk.
- Consider also reviewing `src/auto-reply/reply/session.ts` lines 342 and 347 for the same absolute-path storage pattern.

<sub>Last reviewed commit: 03069fc</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->