### PR TITLE
fix: replace workspace:* with peerDependencies in extensions (#14042)

### DIFF
--- a/extensions/bluebubbles/package.json
+++ b/extensions/bluebubbles/package.json
@@ -3,8 +3,8 @@
   "version": "2026.2.13",
   "description": "OpenClaw BlueBubbles channel plugin",
   "type": "module",
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/copilot-proxy/package.json
+++ b/extensions/copilot-proxy/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "description": "OpenClaw Copilot Proxy provider plugin",
   "type": "module",
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/diagnostics-otel/package.json
+++ b/extensions/diagnostics-otel/package.json
@@ -16,8 +16,8 @@
     "@opentelemetry/sdk-trace-base": "^2.5.1",
     "@opentelemetry/semantic-conventions": "^1.39.0"
   },
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/discord/package.json
+++ b/extensions/discord/package.json
@@ -3,8 +3,8 @@
   "version": "2026.2.13",
   "description": "OpenClaw Discord channel plugin",
   "type": "module",
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/google-antigravity-auth/package.json
+++ b/extensions/google-antigravity-auth/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "description": "OpenClaw Google Antigravity OAuth provider plugin",
   "type": "module",
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/google-gemini-cli-auth/package.json
+++ b/extensions/google-gemini-cli-auth/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "description": "OpenClaw Gemini CLI OAuth provider plugin",
   "type": "module",
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/googlechat/package.json
+++ b/extensions/googlechat/package.json
@@ -7,8 +7,8 @@
   "dependencies": {
     "google-auth-library": "^10.5.0"
   },
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "peerDependencies": {
     "openclaw": ">=2026.1.26"

--- a/extensions/googlechat/package.json
+++ b/extensions/googlechat/package.json
@@ -8,9 +8,6 @@
     "google-auth-library": "^10.5.0"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.0.0"
-  },
-  "peerDependencies": {
     "openclaw": ">=2026.1.26"
   },
   "openclaw": {

--- a/extensions/imessage/package.json
+++ b/extensions/imessage/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "description": "OpenClaw iMessage channel plugin",
   "type": "module",
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/line/package.json
+++ b/extensions/line/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "description": "OpenClaw LINE channel plugin",
   "type": "module",
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/llm-task/package.json
+++ b/extensions/llm-task/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "description": "OpenClaw JSON-only LLM task plugin",
   "type": "module",
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/lobster/package.json
+++ b/extensions/lobster/package.json
@@ -3,8 +3,8 @@
   "version": "2026.2.13",
   "description": "Lobster workflow tool plugin (typed pipelines + resumable approvals)",
   "type": "module",
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/matrix/package.json
+++ b/extensions/matrix/package.json
@@ -10,8 +10,8 @@
     "music-metadata": "^11.12.0",
     "zod": "^4.3.6"
   },
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/mattermost/package.json
+++ b/extensions/mattermost/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "description": "OpenClaw Mattermost channel plugin",
   "type": "module",
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/memory-core/package.json
+++ b/extensions/memory-core/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "description": "OpenClaw core memory search plugin",
   "type": "module",
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "peerDependencies": {
     "openclaw": ">=2026.1.26"

--- a/extensions/memory-core/package.json
+++ b/extensions/memory-core/package.json
@@ -5,9 +5,6 @@
   "description": "OpenClaw core memory search plugin",
   "type": "module",
   "peerDependencies": {
-    "openclaw": ">=2026.0.0"
-  },
-  "peerDependencies": {
     "openclaw": ">=2026.1.26"
   },
   "openclaw": {

--- a/extensions/memory-lancedb/package.json
+++ b/extensions/memory-lancedb/package.json
@@ -9,8 +9,8 @@
     "@sinclair/typebox": "0.34.48",
     "openai": "^6.21.0"
   },
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/minimax-portal-auth/package.json
+++ b/extensions/minimax-portal-auth/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "description": "OpenClaw MiniMax Portal OAuth provider plugin",
   "type": "module",
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/msteams/package.json
+++ b/extensions/msteams/package.json
@@ -10,8 +10,8 @@
     "express": "^5.2.1",
     "proper-lockfile": "^4.1.2"
   },
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/nextcloud-talk/package.json
+++ b/extensions/nextcloud-talk/package.json
@@ -3,8 +3,8 @@
   "version": "2026.2.13",
   "description": "OpenClaw Nextcloud Talk channel plugin",
   "type": "module",
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/nostr/package.json
+++ b/extensions/nostr/package.json
@@ -7,8 +7,8 @@
     "nostr-tools": "^2.23.1",
     "zod": "^4.3.6"
   },
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/open-prose/package.json
+++ b/extensions/open-prose/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "description": "OpenProse VM skill pack plugin (slash command + telemetry).",
   "type": "module",
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/signal/package.json
+++ b/extensions/signal/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "description": "OpenClaw Signal channel plugin",
   "type": "module",
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/slack/package.json
+++ b/extensions/slack/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "description": "OpenClaw Slack channel plugin",
   "type": "module",
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/telegram/package.json
+++ b/extensions/telegram/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "description": "OpenClaw Telegram channel plugin",
   "type": "module",
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/tlon/package.json
+++ b/extensions/tlon/package.json
@@ -8,8 +8,8 @@
     "@urbit/aura": "^3.0.0",
     "@urbit/http-api": "^3.0.0"
   },
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/twitch/package.json
+++ b/extensions/twitch/package.json
@@ -10,8 +10,8 @@
     "@twurple/chat": "^8.0.3",
     "zod": "^4.3.6"
   },
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/voice-call/package.json
+++ b/extensions/voice-call/package.json
@@ -8,8 +8,8 @@
     "ws": "^8.19.0",
     "zod": "^4.3.6"
   },
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/whatsapp/package.json
+++ b/extensions/whatsapp/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "description": "OpenClaw WhatsApp channel plugin",
   "type": "module",
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/zalo/package.json
+++ b/extensions/zalo/package.json
@@ -6,8 +6,8 @@
   "dependencies": {
     "undici": "7.21.0"
   },
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/zalouser/package.json
+++ b/extensions/zalouser/package.json
@@ -6,8 +6,8 @@
   "dependencies": {
     "@sinclair/typebox": "0.34.48"
   },
-  "devDependencies": {
-    "openclaw": "workspace:*"
+  "peerDependencies": {
+    "openclaw": ">=2026.0.0"
   },
   "openclaw": {
     "extensions": [


### PR DESCRIPTION
## Summary
- Convert `devDependencies: { "openclaw": "workspace:*" }` to `peerDependencies: { "openclaw": ">=2026.0.0" }` across all extensions
- Remove redundant `devDependencies` where `peerDependencies` already exist (googlechat, memory-core)
- Fixes plugin install failures when `workspace:*` can't resolve outside the monorepo

Closes #14042

## Test plan
- [ ] `pnpm install` succeeds
- [ ] `pnpm build` passes
- [ ] Extension install via npm spec still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Converts `devDependencies: { "openclaw": "workspace:*" }` to `peerDependencies: { "openclaw": ">=2026.0.0" }` across 27 extensions, and removes redundant duplicate `devDependencies` entries where `peerDependencies` already existed (`googlechat`, `memory-core`). This fixes plugin install failures when `workspace:*` cannot resolve outside the monorepo, aligning with the repo's own `AGENTS.md` guidance.

- All 27 changed extensions correctly moved from `devDependencies` to `peerDependencies`
- `googlechat` and `memory-core` correctly preserved their existing `>=2026.1.26` version constraint
- **`extensions/irc/package.json` was missed** — it still has `devDependencies: { "openclaw": "workspace:*" }` and needs the same conversion

<h3>Confidence Score: 4/5</h3>

- Low-risk metadata-only changes to package.json files; safe to merge after addressing the missed extension.
- All changes are straightforward package.json key renames from devDependencies to peerDependencies with a consistent version range. The only issue is a missed extension (irc) that should also be converted. No runtime code is affected.
- `extensions/irc/package.json` was not included in this PR but still contains `workspace:*` in devDependencies and needs the same conversion.

<sub>Last reviewed commit: 663dc11</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->