### PR TITLE
docs(security): propose enforced pre-install guard for skills

### DIFF
--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -6,6 +6,7 @@
 
 - [Threat Model](./THREAT-MODEL-ATLAS.md) - MITRE ATLAS-based threat model for the OpenClaw ecosystem
 - [Contributing to the Threat Model](./CONTRIBUTING-THREAT-MODEL.md) - How to add threats, mitigations, and attack chains
+- [Skill Install Security Guard (Proposal)](./skill-install-guard.md) - Secure-by-default pre-install auditing for marketplace skills
 
 ## Reporting Vulnerabilities
 

--- a/docs/security/skill-install-guard.md
+++ b/docs/security/skill-install-guard.md
@@ -1,0 +1,87 @@
+# Skill Install Security Guard (Proposal)
+
+## Problem
+
+OpenClaw skills can be installed quickly via marketplace tooling (`clawhub install <slug>`), but secure usage currently depends on user discipline (manual pre-install audit).
+
+In practice, this creates a supply-chain gap:
+
+- users skip audits under time pressure
+- assistants may forget process-only rules
+- suspicious packages can be installed before review
+
+## Goal
+
+Make pre-install security auditing the **default path**, not a memory-based workflow.
+
+## Proposed Core Behavior
+
+### 1) Add a built-in guard command
+
+Introduce a first-party command in OpenClaw/ClawHub flow:
+
+```bash
+openclaw skills install-safe <slug>
+```
+
+Behavior:
+
+1. inspect skill files from registry (without install)
+2. run policy-based static scan
+3. optionally run dynamic probe for higher risk categories
+4. block installation unless verdict policy allows it
+5. emit machine-readable audit report + human summary
+
+### 2) Optional hard-enforcement mode
+
+Config option:
+
+```json
+{
+  "skills": {
+    "installGuard": {
+      "enabled": true,
+      "mode": "enforce"
+    }
+  }
+}
+```
+
+When enabled, `clawhub install` from within OpenClaw contexts should route through the guard automatically.
+
+### 3) Verdict model
+
+Keep decisions explicit:
+
+- `APPROVED` → install allowed
+- `CAUTION` → require explicit human confirmation
+- `REJECT` → blocked
+
+### 4) Logs + provenance
+
+Persist report in workspace/logs with:
+
+- slug/version
+- policy profile
+- findings summary
+- verdict
+- timestamp
+
+## Why this helps
+
+- removes fragile “remember to audit” behavior
+- reduces malicious skill blast radius
+- gives consistent policy outcomes across users/agents
+- keeps fast path for trusted installs with explicit approval
+
+## Backwards Compatibility
+
+- default can remain permissive initially (`mode: warn`)
+- teams can opt into `mode: enforce`
+- no breaking changes to existing skill format
+
+## Reference Implementation (community)
+
+A community implementation already exists in the `skill-check` skill as wrapper scripts (`safe_install.sh` + shell guard), proving feasibility with current tools.
+
+This proposal asks to move that behavior into OpenClaw core so all users get secure-by-default installs without custom setup.


### PR DESCRIPTION
## Summary
This PR adds a security proposal for **secure-by-default skill installs**.

- Adds `docs/security/skill-install-guard.md`
- Links it from `docs/security/README.md`

## Why
Skill install safety currently depends on process memory (manual pre-scan), which is fragile. This proposal describes a core enforcement model so users and agents don't need custom wrappers to stay safe.

## Scope
Documentation proposal only (no runtime behavior changes in this PR).

## Follow-up
If maintainers agree, we can submit an implementation PR for:
- `openclaw skills install-safe <slug>`
- optional `skills.installGuard.mode: warn|enforce` routing
- persisted audit reports with verdict gating

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Proposes a secure-by-default pre-install guard for OpenClaw skills to address supply-chain risks documented in the threat model (T-PERSIST-001). The proposal moves post-install scanning (already implemented in `src/agents/skills-install.ts:110` via `scanDirectoryWithSummary`) to pre-install enforcement with configurable verdict policies.

Key improvements suggested:
- Built-in `install-safe` command with policy-based scanning before installation
- Optional hard-enforcement mode to automatically route all installs through the guard
- Explicit verdict model (APPROVED/CAUTION/REJECT) with audit logging
- Backwards compatibility via permissive defaults

Minor clarity issues around command naming conventions and which CLI paths (clawhub vs openclaw skills) would be covered, but otherwise the proposal is technically sound and well-aligned with existing security infrastructure.

<h3>Confidence Score: 4/5</h3>

- This documentation-only PR is safe to merge with minor terminology clarifications recommended
- Well-researched security proposal that builds on existing threat model and scanner infrastructure. Minor terminology inconsistencies around CLI command naming don't affect the core proposal validity. No code changes means no runtime risk.
- No files require special attention

<sub>Last reviewed commit: 76658a7</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->