### PR TITLE
voice-call: hang up rejected inbounds, idempotency and logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/Compaction: centralize exec default resolution in the shared tool factory so per-agent `tools.exec` overrides (host/security/ask/node and related defaults) persist across compaction retries. (#15833) Thanks @napetrov.
+- Voice Call: route webhook runtime event handling through shared manager event logic so rejected inbound hangups are idempotent in production, with regression tests for duplicate reject events and provider-call-ID remapping parity. (#15892) Thanks @dcantu96.
 - CLI/Completion: route plugin-load logs to stderr and write generated completion scripts directly to stdout to avoid `source <(openclaw completion ...)` corruption. (#15481) Thanks @arosstale.
 - Gateway/Agents: stop injecting a phantom `main` agent into gateway agent listings when `agents.list` explicitly excludes it. (#11450) Thanks @arosstale.
 - Agents/Heartbeat: stop auto-creating `HEARTBEAT.md` during workspace bootstrap so missing files continue to run heartbeat as documented. (#11766) Thanks @shadril238.

--- a/extensions/voice-call/src/manager.ts
+++ b/extensions/voice-call/src/manager.ts
@@ -4,13 +4,13 @@ import fsp from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import type { CallMode, VoiceCallConfig } from "./config.js";
+import type { CallManagerContext } from "./manager/context.js";
 import type { VoiceCallProvider } from "./providers/base.js";
-import { isAllowlistedCaller, normalizePhoneNumber } from "./allowlist.js";
+import { processEvent as processManagerEvent } from "./manager/events.js";
 import {
   type CallId,
   type CallRecord,
   CallRecordSchema,
-  type CallState,
   type NormalizedEvent,
   type OutboundCallOptions,
   TerminalStates,
@@ -284,35 +284,6 @@ export class CallManager {
   }
 
   /**
-   * Start max duration timer for a call.
-   * Auto-hangup when maxDurationSeconds is reached.
-   */
-  private startMaxDurationTimer(callId: CallId): void {
-    // Clear any existing timer
-    this.clearMaxDurationTimer(callId);
-
-    const maxDurationMs = this.config.maxDurationSeconds * 1000;
-    console.log(
-      `[voice-call] Starting max duration timer (${this.config.maxDurationSeconds}s) for call ${callId}`,
-    );
-
-    const timer = setTimeout(async () => {
-      this.maxDurationTimers.delete(callId);
-      const call = this.getCall(callId);
-      if (call && !TerminalStates.has(call.state)) {
-        console.log(
-          `[voice-call] Max duration reached (${this.config.maxDurationSeconds}s), ending call ${callId}`,
-        );
-        call.endReason = "timeout";
-        this.persistCallRecord(call);
-        await this.endCall(callId);
-      }
-    }, maxDurationMs);
-
-    this.maxDurationTimers.set(callId, timer);
-  }
-
-  /**
    * Clear max duration timer for a call.
    */
   private clearMaxDurationTimer(callId: CallId): void {
@@ -339,15 +310,6 @@ export class CallManager {
     }
     this.clearTranscriptWaiter(callId);
     waiter.reject(new Error(reason));
-  }
-
-  private resolveTranscriptWaiter(callId: CallId, transcript: string): void {
-    const waiter = this.transcriptWaiters.get(callId);
-    if (!waiter) {
-      return;
-    }
-    this.clearTranscriptWaiter(callId);
-    waiter.resolve(transcript);
   }
 
   private waitForFinalTranscript(callId: CallId): Promise<string> {
@@ -459,225 +421,29 @@ export class CallManager {
     }
   }
 
-  /**
-   * Check if an inbound call should be accepted based on policy.
-   */
-  private shouldAcceptInbound(from: string | undefined): boolean {
-    const { inboundPolicy: policy, allowFrom } = this.config;
-
-    switch (policy) {
-      case "disabled":
-        console.log("[voice-call] Inbound call rejected: policy is disabled");
-        return false;
-
-      case "open":
-        console.log("[voice-call] Inbound call accepted: policy is open");
-        return true;
-
-      case "allowlist":
-      case "pairing": {
-        const normalized = normalizePhoneNumber(from);
-        if (!normalized) {
-          console.log("[voice-call] Inbound call rejected: missing caller ID");
-          return false;
-        }
-        const allowed = isAllowlistedCaller(normalized, allowFrom);
-        const status = allowed ? "accepted" : "rejected";
-        console.log(
-          `[voice-call] Inbound call ${status}: ${from} ${allowed ? "is in" : "not in"} allowlist`,
-        );
-        return allowed;
-      }
-
-      default:
-        return false;
-    }
-  }
-
-  /**
-   * Create a call record for an inbound call.
-   */
-  private createInboundCall(providerCallId: string, from: string, to: string): CallRecord {
-    const callId = crypto.randomUUID();
-
-    const callRecord: CallRecord = {
-      callId,
-      providerCallId,
-      provider: this.provider?.name || "twilio",
-      direction: "inbound",
-      state: "ringing",
-      from,
-      to,
-      startedAt: Date.now(),
-      transcript: [],
-      processedEventIds: [],
-      metadata: {
-        initialMessage: this.config.inboundGreeting || "Hello! How can I help you today?",
+  private getContext(): CallManagerContext {
+    return {
+      activeCalls: this.activeCalls,
+      providerCallIdMap: this.providerCallIdMap,
+      processedEventIds: this.processedEventIds,
+      rejectedProviderCallIds: this.rejectedProviderCallIds,
+      onCallAnswered: (call) => {
+        this.maybeSpeakInitialMessageOnAnswered(call);
       },
+      provider: this.provider,
+      config: this.config,
+      storePath: this.storePath,
+      webhookUrl: this.webhookUrl,
+      transcriptWaiters: this.transcriptWaiters,
+      maxDurationTimers: this.maxDurationTimers,
     };
-
-    this.activeCalls.set(callId, callRecord);
-    this.providerCallIdMap.set(providerCallId, callId); // Map providerCallId to internal callId
-    this.persistCallRecord(callRecord);
-
-    console.log(`[voice-call] Created inbound call record: ${callId} from ${from}`);
-    return callRecord;
-  }
-
-  /**
-   * Look up a call by either internal callId or providerCallId.
-   */
-  private findCall(callIdOrProviderCallId: string): CallRecord | undefined {
-    // Try direct lookup by internal callId
-    const directCall = this.activeCalls.get(callIdOrProviderCallId);
-    if (directCall) {
-      return directCall;
-    }
-
-    // Try lookup by providerCallId
-    return this.getCallByProviderCallId(callIdOrProviderCallId);
   }
 
   /**
    * Process a webhook event.
    */
   processEvent(event: NormalizedEvent): void {
-    // Idempotency check
-    if (this.processedEventIds.has(event.id)) {
-      return;
-    }
-    this.processedEventIds.add(event.id);
-
-    let call = this.findCall(event.callId);
-
-    // Handle inbound calls - create record if it doesn't exist
-    if (!call && event.direction === "inbound" && event.providerCallId) {
-      // Check if we should accept this inbound call
-      if (!this.shouldAcceptInbound(event.from)) {
-        void this.rejectInboundCall(event);
-        return;
-      }
-
-      // Create a new call record for this inbound call
-      call = this.createInboundCall(
-        event.providerCallId,
-        event.from || "unknown",
-        event.to || this.config.fromNumber || "unknown",
-      );
-
-      // Update the event's callId to use our internal ID
-      event.callId = call.callId;
-    }
-
-    if (!call) {
-      // Still no call record - ignore event
-      return;
-    }
-
-    // Update provider call ID if we got it
-    if (event.providerCallId && event.providerCallId !== call.providerCallId) {
-      const previousProviderCallId = call.providerCallId;
-      call.providerCallId = event.providerCallId;
-      this.providerCallIdMap.set(event.providerCallId, call.callId);
-      if (previousProviderCallId) {
-        const mapped = this.providerCallIdMap.get(previousProviderCallId);
-        if (mapped === call.callId) {
-          this.providerCallIdMap.delete(previousProviderCallId);
-        }
-      }
-    }
-
-    // Track processed event
-    call.processedEventIds.push(event.id);
-
-    // Process event based on type
-    switch (event.type) {
-      case "call.initiated":
-        this.transitionState(call, "initiated");
-        break;
-
-      case "call.ringing":
-        this.transitionState(call, "ringing");
-        break;
-
-      case "call.answered":
-        call.answeredAt = event.timestamp;
-        this.transitionState(call, "answered");
-        // Start max duration timer when call is answered
-        this.startMaxDurationTimer(call.callId);
-        // Best-effort: speak initial message (for inbound greetings and outbound
-        // conversation mode) once the call is answered.
-        this.maybeSpeakInitialMessageOnAnswered(call);
-        break;
-
-      case "call.active":
-        this.transitionState(call, "active");
-        break;
-
-      case "call.speaking":
-        this.transitionState(call, "speaking");
-        break;
-
-      case "call.speech":
-        if (event.isFinal) {
-          this.addTranscriptEntry(call, "user", event.transcript);
-          this.resolveTranscriptWaiter(call.callId, event.transcript);
-        }
-        this.transitionState(call, "listening");
-        break;
-
-      case "call.ended":
-        call.endedAt = event.timestamp;
-        call.endReason = event.reason;
-        this.transitionState(call, event.reason as CallState);
-        this.clearMaxDurationTimer(call.callId);
-        this.rejectTranscriptWaiter(call.callId, `Call ended: ${event.reason}`);
-        this.activeCalls.delete(call.callId);
-        if (call.providerCallId) {
-          this.providerCallIdMap.delete(call.providerCallId);
-        }
-        break;
-
-      case "call.error":
-        if (!event.retryable) {
-          call.endedAt = event.timestamp;
-          call.endReason = "error";
-          this.transitionState(call, "error");
-          this.clearMaxDurationTimer(call.callId);
-          this.rejectTranscriptWaiter(call.callId, `Call error: ${event.error}`);
-          this.activeCalls.delete(call.callId);
-          if (call.providerCallId) {
-            this.providerCallIdMap.delete(call.providerCallId);
-          }
-        }
-        break;
-    }
-
-    this.persistCallRecord(call);
-  }
-
-  private async rejectInboundCall(event: NormalizedEvent): Promise<void> {
-    if (!this.provider || !event.providerCallId) {
-      return;
-    }
-    const pid = event.providerCallId;
-    if (this.rejectedProviderCallIds.has(pid)) {
-      return;
-    }
-    this.rejectedProviderCallIds.add(pid);
-    const callId = event.callId || pid;
-    try {
-      await this.provider.hangupCall({
-        callId,
-        providerCallId: pid,
-        reason: "hangup-bot",
-      });
-    } catch (err) {
-      console.warn(
-        `[voice-call] Failed to reject inbound call ${pid}:`,
-        err instanceof Error ? err.message : err,
-      );
-    }
+    processManagerEvent(this.getContext(), event);
   }
 
   private maybeSpeakInitialMessageOnAnswered(call: CallRecord): void {
@@ -762,52 +528,6 @@ export class CallManager {
     }
 
     return calls;
-  }
-
-  // States that can cycle during multi-turn conversations
-  private static readonly ConversationStates = new Set<CallState>(["speaking", "listening"]);
-
-  // Non-terminal state order for monotonic transitions
-  private static readonly StateOrder: readonly CallState[] = [
-    "initiated",
-    "ringing",
-    "answered",
-    "active",
-    "speaking",
-    "listening",
-  ];
-
-  /**
-   * Transition call state with monotonic enforcement.
-   */
-  private transitionState(call: CallRecord, newState: CallState): void {
-    // No-op for same state or already terminal
-    if (call.state === newState || TerminalStates.has(call.state)) {
-      return;
-    }
-
-    // Terminal states can always be reached from non-terminal
-    if (TerminalStates.has(newState)) {
-      call.state = newState;
-      return;
-    }
-
-    // Allow cycling between speaking and listening (multi-turn conversations)
-    if (
-      CallManager.ConversationStates.has(call.state) &&
-      CallManager.ConversationStates.has(newState)
-    ) {
-      call.state = newState;
-      return;
-    }
-
-    // Only allow forward transitions in state order
-    const currentIndex = CallManager.StateOrder.indexOf(call.state);
-    const newIndex = CallManager.StateOrder.indexOf(newState);
-
-    if (newIndex > currentIndex) {
-      call.state = newState;
-    }
   }
 
   /**

--- a/extensions/voice-call/src/manager/context.ts
+++ b/extensions/voice-call/src/manager/context.ts
@@ -12,6 +12,8 @@ export type CallManagerContext = {
   activeCalls: Map<CallId, CallRecord>;
   providerCallIdMap: Map<string, CallId>;
   processedEventIds: Set<string>;
+  /** Provider call IDs we already sent a reject hangup for; avoids duplicate hangup calls. */
+  rejectedProviderCallIds: Set<string>;
   provider: VoiceCallProvider | null;
   config: VoiceCallConfig;
   storePath: string;

--- a/extensions/voice-call/src/manager/context.ts
+++ b/extensions/voice-call/src/manager/context.ts
@@ -12,7 +12,10 @@ export type CallManagerContext = {
   activeCalls: Map<CallId, CallRecord>;
   providerCallIdMap: Map<string, CallId>;
   processedEventIds: Set<string>;
+  /** Provider call IDs we already sent a reject hangup for; avoids duplicate hangup calls. */
   rejectedProviderCallIds: Set<string>;
+  /** Optional runtime hook invoked after an event transitions a call into answered state. */
+  onCallAnswered?: (call: CallRecord) => void;
   provider: VoiceCallProvider | null;
   config: VoiceCallConfig;
   storePath: string;

--- a/extensions/voice-call/src/manager/context.ts
+++ b/extensions/voice-call/src/manager/context.ts
@@ -12,7 +12,6 @@ export type CallManagerContext = {
   activeCalls: Map<CallId, CallRecord>;
   providerCallIdMap: Map<string, CallId>;
   processedEventIds: Set<string>;
-  /** Provider call IDs we already sent a reject hangup for; avoids duplicate hangup calls. */
   rejectedProviderCallIds: Set<string>;
   provider: VoiceCallProvider | null;
   config: VoiceCallConfig;

--- a/extensions/voice-call/src/manager/events.test.ts
+++ b/extensions/voice-call/src/manager/events.test.ts
@@ -1,0 +1,172 @@
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import type { CallManagerContext } from "./context.js";
+import { processEvent } from "./events.js";
+import type { HangupCallInput, NormalizedEvent } from "../types.js";
+import { VoiceCallConfigSchema } from "../config.js";
+
+function createContext(overrides: Partial<CallManagerContext> = {}): CallManagerContext {
+  return {
+    activeCalls: new Map(),
+    providerCallIdMap: new Map(),
+    processedEventIds: new Set(),
+    rejectedProviderCallIds: new Set(),
+    provider: null,
+    config: VoiceCallConfigSchema.parse({
+      enabled: true,
+      provider: "plivo",
+      fromNumber: "+15550000000",
+    }),
+    storePath: path.join(os.tmpdir(), `openclaw-voice-call-events-test-${Date.now()}`),
+    webhookUrl: null,
+    transcriptWaiters: new Map(),
+    maxDurationTimers: new Map(),
+    ...overrides,
+  };
+}
+
+describe("processEvent (functional)", () => {
+  it("calls provider hangup when rejecting inbound call", () => {
+    const hangupCalls: HangupCallInput[] = [];
+    const provider = {
+      name: "plivo" as const,
+      async hangupCall(input: HangupCallInput): Promise<void> {
+        hangupCalls.push(input);
+      },
+    };
+
+    const ctx = createContext({
+      config: VoiceCallConfigSchema.parse({
+        enabled: true,
+        provider: "plivo",
+        fromNumber: "+15550000000",
+        inboundPolicy: "disabled",
+      }),
+      provider,
+    });
+    const event: NormalizedEvent = {
+      id: "evt-1",
+      type: "call.initiated",
+      callId: "prov-1",
+      providerCallId: "prov-1",
+      timestamp: Date.now(),
+      direction: "inbound",
+      from: "+15559999999",
+      to: "+15550000000",
+    };
+
+    processEvent(ctx, event);
+
+    expect(ctx.activeCalls.size).toBe(0);
+    expect(hangupCalls).toHaveLength(1);
+    expect(hangupCalls[0]).toEqual({
+      callId: "prov-1",
+      providerCallId: "prov-1",
+      reason: "hangup-bot",
+    });
+  });
+
+  it("does not call hangup when provider is null", () => {
+    const ctx = createContext({
+      config: VoiceCallConfigSchema.parse({
+        enabled: true,
+        provider: "plivo",
+        fromNumber: "+15550000000",
+        inboundPolicy: "disabled",
+      }),
+      provider: null,
+    });
+    const event: NormalizedEvent = {
+      id: "evt-2",
+      type: "call.initiated",
+      callId: "prov-2",
+      providerCallId: "prov-2",
+      timestamp: Date.now(),
+      direction: "inbound",
+      from: "+15551111111",
+      to: "+15550000000",
+    };
+
+    processEvent(ctx, event);
+
+    expect(ctx.activeCalls.size).toBe(0);
+  });
+
+  it("calls hangup only once for duplicate events for same rejected call", () => {
+    const hangupCalls: HangupCallInput[] = [];
+    const provider = {
+      name: "plivo" as const,
+      async hangupCall(input: HangupCallInput): Promise<void> {
+        hangupCalls.push(input);
+      },
+    };
+    const ctx = createContext({
+      config: VoiceCallConfigSchema.parse({
+        enabled: true,
+        provider: "plivo",
+        fromNumber: "+15550000000",
+        inboundPolicy: "disabled",
+      }),
+      provider,
+    });
+    const event1: NormalizedEvent = {
+      id: "evt-init",
+      type: "call.initiated",
+      callId: "prov-dup",
+      providerCallId: "prov-dup",
+      timestamp: Date.now(),
+      direction: "inbound",
+      from: "+15552222222",
+      to: "+15550000000",
+    };
+    const event2: NormalizedEvent = {
+      id: "evt-ring",
+      type: "call.ringing",
+      callId: "prov-dup",
+      providerCallId: "prov-dup",
+      timestamp: Date.now(),
+      direction: "inbound",
+      from: "+15552222222",
+      to: "+15550000000",
+    };
+
+    processEvent(ctx, event1);
+    processEvent(ctx, event2);
+
+    expect(ctx.activeCalls.size).toBe(0);
+    expect(hangupCalls).toHaveLength(1);
+    expect(hangupCalls[0]?.providerCallId).toBe("prov-dup");
+  });
+
+  it("when hangup throws, logs and does not throw", () => {
+    const provider = {
+      name: "plivo" as const,
+      async hangupCall(): Promise<void> {
+        throw new Error("provider down");
+      },
+    };
+    const ctx = createContext({
+      config: VoiceCallConfigSchema.parse({
+        enabled: true,
+        provider: "plivo",
+        fromNumber: "+15550000000",
+        inboundPolicy: "disabled",
+      }),
+      provider,
+    });
+    const event: NormalizedEvent = {
+      id: "evt-fail",
+      type: "call.initiated",
+      callId: "prov-fail",
+      providerCallId: "prov-fail",
+      timestamp: Date.now(),
+      direction: "inbound",
+      from: "+15553333333",
+      to: "+15550000000",
+    };
+
+    expect(() => processEvent(ctx, event)).not.toThrow();
+    expect(ctx.activeCalls.size).toBe(0);
+  });
+});

--- a/extensions/voice-call/src/manager/events.test.ts
+++ b/extensions/voice-call/src/manager/events.test.ts
@@ -1,10 +1,10 @@
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import type { CallManagerContext } from "./context.js";
-import { processEvent } from "./events.js";
 import type { HangupCallInput, NormalizedEvent } from "../types.js";
+import type { CallManagerContext } from "./context.js";
 import { VoiceCallConfigSchema } from "../config.js";
+import { processEvent } from "./events.js";
 
 function createContext(overrides: Partial<CallManagerContext> = {}): CallManagerContext {
   return {

--- a/extensions/voice-call/src/manager/events.ts
+++ b/extensions/voice-call/src/manager/events.ts
@@ -94,7 +94,29 @@ export function processEvent(ctx: CallManagerContext, event: NormalizedEvent): v
 
   if (!call && event.direction === "inbound" && event.providerCallId) {
     if (!shouldAcceptInbound(ctx.config, event.from)) {
-      // TODO: Could hang up the call here.
+      const pid = event.providerCallId;
+      if (!ctx.provider) {
+        console.warn(
+          `[voice-call] Inbound call rejected by policy but no provider to hang up (providerCallId: ${pid}, from: ${event.from}); call will time out on provider side.`,
+        );
+        return;
+      }
+      if (ctx.rejectedProviderCallIds.has(pid)) {
+        return;
+      }
+      ctx.rejectedProviderCallIds.add(pid);
+      const callId = event.callId ?? pid;
+      console.log(`[voice-call] Rejecting inbound call by policy: ${pid}`);
+      void ctx.provider
+        .hangupCall({
+          callId,
+          providerCallId: pid,
+          reason: "hangup-bot",
+        })
+        .catch((err) => {
+          const message = err instanceof Error ? err.message : String(err);
+          console.warn(`[voice-call] Failed to reject inbound call ${pid}:`, message);
+        });
       return;
     }
 

--- a/extensions/voice-call/src/manager/events.ts
+++ b/extensions/voice-call/src/manager/events.ts
@@ -135,9 +135,16 @@ export function processEvent(ctx: CallManagerContext, event: NormalizedEvent): v
     return;
   }
 
-  if (event.providerCallId && !call.providerCallId) {
+  if (event.providerCallId && event.providerCallId !== call.providerCallId) {
+    const previousProviderCallId = call.providerCallId;
     call.providerCallId = event.providerCallId;
     ctx.providerCallIdMap.set(event.providerCallId, call.callId);
+    if (previousProviderCallId) {
+      const mapped = ctx.providerCallIdMap.get(previousProviderCallId);
+      if (mapped === call.callId) {
+        ctx.providerCallIdMap.delete(previousProviderCallId);
+      }
+    }
   }
 
   call.processedEventIds.push(event.id);
@@ -161,6 +168,7 @@ export function processEvent(ctx: CallManagerContext, event: NormalizedEvent): v
           await endCall(ctx, callId);
         },
       });
+      ctx.onCallAnswered?.(call);
       break;
 
     case "call.active":

--- a/extensions/voice-call/src/manager/store.ts
+++ b/extensions/voice-call/src/manager/store.ts
@@ -16,6 +16,7 @@ export function loadActiveCallsFromStore(storePath: string): {
   activeCalls: Map<CallId, CallRecord>;
   providerCallIdMap: Map<string, CallId>;
   processedEventIds: Set<string>;
+  rejectedProviderCallIds: Set<string>;
 } {
   const logPath = path.join(storePath, "calls.jsonl");
   if (!fs.existsSync(logPath)) {
@@ -23,6 +24,7 @@ export function loadActiveCallsFromStore(storePath: string): {
       activeCalls: new Map(),
       providerCallIdMap: new Map(),
       processedEventIds: new Set(),
+      rejectedProviderCallIds: new Set(),
     };
   }
 
@@ -45,6 +47,7 @@ export function loadActiveCallsFromStore(storePath: string): {
   const activeCalls = new Map<CallId, CallRecord>();
   const providerCallIdMap = new Map<string, CallId>();
   const processedEventIds = new Set<string>();
+  const rejectedProviderCallIds = new Set<string>();
 
   for (const [callId, call] of callMap) {
     if (TerminalStates.has(call.state)) {
@@ -59,7 +62,7 @@ export function loadActiveCallsFromStore(storePath: string): {
     }
   }
 
-  return { activeCalls, providerCallIdMap, processedEventIds };
+  return { activeCalls, providerCallIdMap, processedEventIds, rejectedProviderCallIds };
 }
 
 export async function getCallHistoryFromStore(


### PR DESCRIPTION
#### Summary

When inbound policy rejects a call (disabled or not allowlisted), we now call the provider’s hangup API so the call ends immediately instead of ringing until timeout. Added idempotency (one hangup per rejected call), a log when there’s no provider to hang up, and tests.

#### Behavior changes

- On reject: call `provider.hangupCall()` when provider is set; otherwise log and return.
- Track rejected `providerCallId`s so duplicate events don’t trigger multiple hangups.
- Logging uses existing `[voice-call]` string style.

#### Tests

`extensions/voice-call/src/manager/events.test.ts`: reject path calls hangup once; no hangup when provider is null; duplicate events for same call only one hangup; hangup throw is caught and does not throw.

lobster-biscuit

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds hangup functionality for rejected inbound voice calls with idempotency tracking and improved logging. When inbound policy rejects a call (disabled or not allowlisted), the system now calls the provider's hangup API to end the call immediately instead of letting it ring until timeout.

Key changes:
- Added `rejectedProviderCallIds` Set to `CallManagerContext` to track rejected calls and prevent duplicate hangup attempts
- Implemented hangup logic in the functional `events.ts` with proper error handling and logging
- Added comprehensive test coverage for reject scenarios including idempotency and error cases

Critical issue: The `CallManager` class (used in production via `webhook.ts:118`) wasn't updated with the idempotency protection, so it can still make duplicate hangup calls for rejected inbound calls. The new idempotency logic only exists in the functional `events.ts` implementation which isn't integrated yet.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge - critical logic missing from production code path
- The PR adds idempotency protection and hangup logic to the functional `events.ts` implementation, but the `CallManager` class actually used in production (`webhook.ts:118`) lacks these improvements. This creates an inconsistency where the tested code path differs from production, and the main issue (duplicate hangup calls) remains unfixed in the active code.
- extensions/voice-call/src/manager.ts needs the same idempotency protection added to events.ts, or the codebase should migrate to use the functional implementation

<sub>Last reviewed commit: 8182ed3</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->