### PR TITLE
docs: add GraphQL and schema introspection guidance to GitHub skill

### DIFF
--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -68,6 +68,34 @@ Get PR with specific fields:
 gh api repos/owner/repo/pulls/55 --jq '.title, .state, .user.login'
 ```
 
+## GraphQL API
+
+Use `gh api graphql` for GitHub's GraphQL API (required for Projects V2, Discussions, etc.):
+
+Query example:
+```bash
+gh api graphql -f query='query { viewer { login } }'
+```
+
+Mutation example:
+```bash
+gh api graphql -f query='mutation($input: AddProjectV2ItemByIdInput!) { addProjectV2ItemById(input: $input) { item { id } } }' -f input='{"projectId":"...","contentId":"..."}'
+```
+
+### Schema Introspection
+
+When unsure about field or mutation names, introspect the schema first:
+
+```bash
+# List available fields on a type
+gh api graphql -f query='{ __type(name: "Mutation") { fields { name description } } }' --jq '.data.__type.fields[] | "\(.name): \(.description)"' | grep -i project
+
+# Get input fields for a mutation
+gh api graphql -f query='{ __type(name: "UpdateProjectV2FieldInput") { inputFields { name type { name } } } }'
+```
+
+Always introspect before using unfamiliar mutations — do not guess mutation or field names.
+
 ## JSON Output
 
 Most commands support `--json` for structured output. You can use `--jq` to filter:


### PR DESCRIPTION
Fixes #15796

The bundled GitHub skill only documented REST usage for `gh api`, with no mention of GraphQL. When agents need GitHub Projects V2 operations (which require GraphQL), they hallucinate mutation names and fail.

This adds a new **GraphQL API** section to the GitHub skill covering:
- Basic query and mutation examples using `gh api graphql`
- Schema introspection commands to discover fields and mutation inputs
- A clear directive to always introspect before using unfamiliar mutations

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds comprehensive GraphQL documentation to the GitHub skill, filling a critical gap that was causing agents to hallucinate mutation names when working with GitHub Projects V2. The new section includes basic query and mutation examples using `gh api graphql`, schema introspection commands for discovering available fields and mutations, and clear guidance to always introspect before using unfamiliar mutations. This documentation follows the existing skill format and provides practical examples that agents can use immediately.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it only adds documentation without changing any code
- The changes are purely additive documentation that enhances the GitHub skill. The GraphQL syntax and command examples are correct, the jq filters are valid, and the guidance aligns with best practices for preventing hallucination. No code changes, no breaking changes, and it directly addresses the issue described in #15796.
- No files require special attention

<sub>Last reviewed commit: d1111ec</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->