### PR TITLE
docs: fix self-referencing link in compaction page

### DIFF
--- a/docs/concepts/compaction.md
+++ b/docs/concepts/compaction.md
@@ -21,7 +21,7 @@ Compaction **persists** in the session’s JSONL history.
 
 ## Configuration
 
-Use the `agents.defaults.compaction` setting in your `openclaw.json` to configure compaction behavior (mode, target tokens, etc.).
+Use the `agents.defaults.compaction` setting in your `openclaw.json` to configure compaction behavior (mode, target tokens, etc.). See [Session Management & Compaction (Deep Dive)](/reference/session-management-compaction) for full details.
 
 ## Auto-compaction (default on)
 

--- a/docs/zh-CN/concepts/compaction.md
+++ b/docs/zh-CN/concepts/compaction.md
@@ -28,7 +28,7 @@ x-i18n:
 
 ## 配置
 
-有关 `agents.defaults.compaction` 设置，请参阅[压缩配置与模式](/concepts/compaction)。
+有关 `agents.defaults.compaction` 设置，请参阅[会话管理与压缩深入解析](/reference/session-management-compaction)。
 
 ## 自动压缩（默认开启）
 


### PR DESCRIPTION
Fixes #15773

The zh-CN compaction concepts page (`/concepts/compaction`) had a "See Compaction config & modes" link that pointed back to itself. Fixed it to point to `/reference/session-management-compaction` which documents the actual `agents.defaults.compaction` settings.

Also added a link in the English version's Configuration section to the same reference page, since it was missing a cross-reference entirely.

### Changes
- `docs/zh-CN/concepts/compaction.md`: fix self-referencing link → `/reference/session-management-compaction`
- `docs/concepts/compaction.md`: add link to the deep-dive reference page

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixed self-referencing documentation link in the Chinese version (`docs/zh-CN/concepts/compaction.md`) that incorrectly pointed back to itself instead of the configuration reference page. Also added a missing cross-reference link in the English version (`docs/concepts/compaction.md`) to the deep-dive session management documentation.

- Fixed zh-CN link from `/concepts/compaction` → `/reference/session-management-compaction`
- Added cross-reference link in English docs to `/reference/session-management-compaction`

The target reference page exists and the links follow Mintlify documentation conventions (root-relative paths without `.md` extension).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Documentation-only change that fixes a broken self-referencing link and adds a helpful cross-reference. Both changes follow the repository's Mintlify documentation linking conventions (root-relative paths without file extensions). The target reference page exists at the expected location. No code changes, no logic changes, no risk.
- No files require special attention

<sub>Last reviewed commit: fb44da8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->