### PR TITLE
fix(memory-lancedb): capture even with injected recall context

### DIFF
--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -104,23 +104,25 @@ describe("memory plugin e2e", () => {
       { text: "Just a random short message", shouldMatch: false },
       { text: "x", shouldMatch: false }, // Too short
       { text: "<relevant-memories>injected</relevant-memories>", shouldMatch: false }, // Skip injected
+      { text: "<relevant-memories>injected</relevant-memories>\nRemember that my name is John", shouldMatch: true }, // Injected prefix should be stripped
     ];
 
     // The shouldCapture function is internal, but we can test via the capture behavior
     // For now, just verify the patterns we expect to match
     for (const { text, shouldMatch } of triggers) {
-      const hasPreference = /prefer|radši|like|love|hate|want/i.test(text);
-      const hasRemember = /zapamatuj|pamatuj|remember/i.test(text);
-      const hasEmail = /[\w.-]+@[\w.-]+\.\w+/.test(text);
-      const hasPhone = /\+\d{10,}/.test(text);
-      const hasDecision = /rozhodli|decided|will use|budeme/i.test(text);
-      const hasAlways = /always|never|important/i.test(text);
-      const isInjected = text.includes("<relevant-memories>");
-      const isTooShort = text.length < 10;
+      const sanitized = text
+        .replace(/<relevant-memories>[\s\S]*?<\/relevant-memories>\s*/g, "")
+        .trim();
+      const hasPreference = /prefer|radši|like|love|hate|want/i.test(sanitized);
+      const hasRemember = /zapamatuj|pamatuj|remember/i.test(sanitized);
+      const hasEmail = /[\w.-]+@[\w.-]+\.\w+/.test(sanitized);
+      const hasPhone = /\+\d{10,}/.test(sanitized);
+      const hasDecision = /rozhodli|decided|will use|budeme/i.test(sanitized);
+      const hasAlways = /always|never|important/i.test(sanitized);
+      const isTooShort = sanitized.length < 10;
 
       const wouldCapture =
         !isTooShort &&
-        !isInjected &&
         (hasPreference || hasRemember || hasEmail || hasPhone || hasDecision || hasAlways);
 
       if (shouldMatch) {

--- a/package.json
+++ b/package.json
@@ -246,5 +246,8 @@
       "apps/macos/.build/**",
       "dist/OpenClaw.app/**"
     ]
+  },
+  "optionalDependencies": {
+    "@lancedb/lancedb-darwin-arm64": "0.24.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -244,6 +244,10 @@ importers:
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.1)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+    optionalDependencies:
+      '@lancedb/lancedb-darwin-arm64':
+        specifier: 0.24.1
+        version: 0.24.1
 
   extensions/bluebubbles:
     devDependencies:
@@ -1285,6 +1289,12 @@ packages:
 
   '@kwsites/promise-deferred@1.1.1':
     resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
+
+  '@lancedb/lancedb-darwin-arm64@0.24.1':
+    resolution: {integrity: sha512-QguwMu3jKEDqe2dtZtbCLNphZA/8hEsEjoS7eTgtx6utGTHIYNYWS6/LtYkNHGJKX6icmul7NzwMbO7cl48i0Q==}
+    engines: {node: '>= 18'}
+    cpu: [arm64]
+    os: [darwin]
 
   '@lancedb/lancedb-linux-arm64-gnu@0.24.1':
     resolution: {integrity: sha512-68T+PVou6NmmNlBpJBXrpa1ITM9Wu/LZ4o1kTi9Kn0TCulb/JhtAGhcmM0gFt4GUTsZQAO9kcDuWN8Mya9lQsw==}
@@ -6555,6 +6565,9 @@ snapshots:
 
   '@kwsites/promise-deferred@1.1.1': {}
 
+  '@lancedb/lancedb-darwin-arm64@0.24.1':
+    optional: true
+
   '@lancedb/lancedb-linux-arm64-gnu@0.24.1':
     optional: true
 
@@ -6587,7 +6600,7 @@ snapshots:
 
   '@larksuiteoapi/node-sdk@1.58.0':
     dependencies:
-      axios: 1.13.4(debug@4.4.3)
+      axios: 1.13.4
       lodash.identity: 3.0.0
       lodash.merge: 4.6.2
       lodash.pickby: 4.6.0
@@ -6603,7 +6616,7 @@ snapshots:
     dependencies:
       '@types/node': 24.10.11
     optionalDependencies:
-      axios: 1.13.4(debug@4.4.3)
+      axios: 1.13.4
     transitivePeerDependencies:
       - debug
 
@@ -6806,7 +6819,7 @@ snapshots:
       '@azure/core-auth': 1.10.1
       '@azure/msal-node': 3.8.6
       '@microsoft/agents-activity': 1.2.3
-      axios: 1.13.4(debug@4.4.3)
+      axios: 1.13.4
       jsonwebtoken: 9.0.3
       jwks-rsa: 3.2.2
       object-path: 0.11.8
@@ -7641,7 +7654,7 @@ snapshots:
       '@slack/types': 2.19.0
       '@slack/web-api': 7.13.0
       '@types/express': 5.0.6
-      axios: 1.13.4(debug@4.4.3)
+      axios: 1.13.4
       express: 5.2.1
       path-to-regexp: 8.3.0
       raw-body: 3.0.2
@@ -7687,7 +7700,7 @@ snapshots:
       '@slack/types': 2.19.0
       '@types/node': 25.2.1
       '@types/retry': 0.12.0
-      axios: 1.13.4(debug@4.4.3)
+      axios: 1.13.4
       eventemitter3: 5.0.4
       form-data: 2.5.4
       is-electron: 2.2.2
@@ -8581,6 +8594,14 @@ snapshots:
 
   aws4@1.13.2: {}
 
+  axios@1.13.4:
+    dependencies:
+      follow-redirects: 1.15.11
+      form-data: 2.5.4
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+
   axios@1.13.4(debug@4.4.3):
     dependencies:
       follow-redirects: 1.15.11(debug@4.4.3)
@@ -9155,6 +9176,8 @@ snapshots:
       array-back: 3.1.0
 
   flatbuffers@24.12.23: {}
+
+  follow-redirects@1.15.11: {}
 
   follow-redirects@1.15.11(debug@4.4.3):
     optionalDependencies:


### PR DESCRIPTION
## Problem\nWhen `autoRecall` is enabled, the plugin prepends a `<relevant-memories>…</relevant-memories>` block into the prompt. OpenClaw persists the *full* prompt string in the message list, so the user message text contained `<relevant-memories>` and auto-capture would silently skip it (`shouldCapture` returned false).\n\nNet: users could tell an agent "remember X" and the agent would reply "Saved", but nothing durable would be written to LanceDB unless the agent explicitly called `memory_store`.\n\n## Fix\n- Strip the injected `<relevant-memories>…</relevant-memories>` block before evaluating capture heuristics and before storing text.\n- Update tests to reflect that an injected prefix should not prevent capture.\n\n## Notes\n- Adds `@lancedb/lancedb-darwin-arm64` as an optional dependency so LanceDB loads cleanly on Apple Silicon macOS runners.\n\n## Tests\n- `pnpm vitest run extensions/memory-lancedb/index.test.ts`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixed auto-capture to work correctly when `autoRecall` is enabled. Previously, the injected `<relevant-memories>` context block prevented any message from being captured to LanceDB, even when the message contained explicit "remember" requests.

The fix strips the injected recall context before evaluating capture heuristics and before storing text, ensuring the actual user content is preserved while the ephemeral context is removed.

- Extracted `stripRelevantMemoriesBlock()` helper that removes injected `<relevant-memories>` blocks using non-greedy regex matching
- Removed the blanket rejection of text containing `<relevant-memories>` from `shouldCapture()`
- Applied sanitization in the capture flow (line 575-577) before filtering and storage
- Updated tests to verify that injected prefixes are stripped correctly
- Added `@lancedb/lancedb-darwin-arm64` as optional dependency for Apple Silicon macOS CI runners

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is well-targeted and addresses a specific bug without changing broader system behavior. The regex pattern for stripping context is correct (non-greedy matching prevents over-removal), sanitization happens before both validation and storage (preventing contaminated data), and tests verify the new behavior. The optional dependency addition is appropriate for CI infrastructure.
- No files require special attention

<sub>Last reviewed commit: e8e9977</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->