### PR TITLE
fix: filter Discord bot-own MESSAGE_CREATE events at listener entry point

### DIFF
--- a/src/discord/monitor/listeners.ts
+++ b/src/discord/monitor/listeners.ts
@@ -70,11 +70,16 @@ export class DiscordMessageListener extends MessageCreateListener {
   constructor(
     private handler: DiscordMessageHandler,
     private logger?: Logger,
+    private botUserId?: string,
   ) {
     super();
   }
 
   async handle(data: DiscordMessageEvent, client: Client) {
+    // Filter bot-own messages immediately to avoid unnecessary pipeline processing (#15874)
+    if (this.botUserId && data.author?.id === this.botUserId) {
+      return;
+    }
     const startedAt = Date.now();
     const task = Promise.resolve(this.handler(data, client));
     void task

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -563,7 +563,10 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
     guildEntries,
   });
 
-  registerDiscordListener(client.listeners, new DiscordMessageListener(messageHandler, logger));
+  registerDiscordListener(
+    client.listeners,
+    new DiscordMessageListener(messageHandler, logger, botUserId),
+  );
   registerDiscordListener(
     client.listeners,
     new DiscordReactionListener({


### PR DESCRIPTION
Fixes #15874

## Problem

When OpenClaw sends messages to Discord (e.g., cron job delivery), each outbound message generates a MESSAGE_CREATE event that the bot receives back. The current architecture processes these bot-own messages through the full pipeline — debouncing, preflight, session creation — before discarding them. This causes:

- **83 'Slow listener' warnings in 24 hours** on a single-user server
- **7 WebSocket disconnections** (codes 1005/1006) correlating with slow listener periods
- **28 'No reply from agent'** events — the bot effectively DDoS-ing itself

## Fix

Add an early `author.id === botUserId` check at the top of `DiscordMessageListener.handle()`, before any pipeline processing begins. This is a single comparison that short-circuits immediately for self-messages.

### Changes

- `src/discord/monitor/listeners.ts`: Add `botUserId` parameter to `DiscordMessageListener` constructor; check `data.author.id === botUserId` at the start of `handle()`
- `src/discord/monitor/provider.ts`: Pass `botUserId` when instantiating `DiscordMessageListener`

### Notes

- Only filters the bot's OWN messages — other bots can still interact (controlled by `allowBots` config)
- The existing check in `preflightDiscordMessage` is preserved as a safety net
- Zero risk of breaking existing behavior — this is purely an optimization

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Moves bot-own message filtering from deep in the Discord message pipeline (`preflightDiscordMessage`) to the top of `DiscordMessageListener.handle()`, short-circuiting before debouncing, preflight, and session creation. This addresses performance degradation (slow listener warnings, WebSocket disconnections, "no reply from agent" events) caused by the bot processing its own outbound MESSAGE_CREATE events through the full pipeline.

- `listeners.ts`: Added `botUserId` constructor parameter and early `author.id === botUserId` check in `handle()`
- `provider.ts`: Passes existing `botUserId` to `DiscordMessageListener` constructor
- Existing preflight filter preserved as a defense-in-depth safety net
- Only filters the bot's own messages; other bots remain unaffected (controlled by `allowBots` config)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it adds a single-comparison early return that is already backed by the existing preflight check.
- The change is minimal (a new optional constructor parameter and a 3-line guard), purely additive, and has zero impact on existing behavior. The early filter mirrors the existing check in `preflightDiscordMessage` (which is preserved). Optional chaining handles the edge case where `author` is absent, and the `botUserId &&` guard ensures the check is safely skipped if the bot identity wasn't resolved. No new dependencies, no type changes, no behavioral changes for non-bot messages.
- No files require special attention.

<sub>Last reviewed commit: f9ad7d9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->