### PR TITLE
fix: preserve Google Chat space ID case for API replies

### DIFF
--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -658,6 +658,10 @@ async function processMessageWithPipeline(params: {
     OriginatingTo: `googlechat:${spaceId}`,
   });
 
+  // Record session meta and update delivery context with the original-case space ID.
+  // Google Chat space IDs are case-sensitive; the session key is lowercased, so we must
+  // persist the original-case target via updateLastRoute to ensure outbound replies use
+  // the correct casing (fixes #15790).
   void core.channel.session
     .recordSessionMetaFromInbound({
       storePath,
@@ -666,6 +670,22 @@ async function processMessageWithPipeline(params: {
     })
     .catch((err) => {
       runtime.error?.(`googlechat: failed updating session meta: ${String(err)}`);
+    });
+
+  void core.channel.session
+    .updateLastRoute({
+      storePath,
+      sessionKey: route.sessionKey,
+      deliveryContext: {
+        channel: "googlechat",
+        to: `googlechat:${spaceId}`,
+        accountId: route.accountId,
+        threadId: message.thread?.name,
+      },
+      ctx: ctxPayload,
+    })
+    .catch((err) => {
+      runtime.error?.(`googlechat: failed updating last route: ${String(err)}`);
     });
 
   // Typing indicator setup


### PR DESCRIPTION
Fixes #15790

## Problem

When receiving messages from Google Chat, the space ID (e.g. `spaces/ABCxyz`) is lowercased during session key generation (`buildAgentPeerSessionKey` in `session-key.ts` and `resolveAgentRoute` in `resolve-route.ts` both call `.toLowerCase()`). This is fine for session key normalization, but becomes a problem when the system later derives the outbound delivery target from the session.

Google Chat's API is case-sensitive for space resource names. When the lowercased space ID (`spaces/abcxyz`) is used in API calls, Google returns a 403 Forbidden error.

## Root Cause

Unlike Telegram and Discord, the Google Chat monitor in `extensions/googlechat/src/monitor.ts` was only calling `recordSessionMetaFromInbound` (which stores session origin metadata) but never calling `updateLastRoute` to persist the delivery context with the original-case space ID. When outbound delivery needed to resolve the target (e.g. for agent tool sends, cron replies, or subagent replies), the delivery context was missing, and the system fell back to deriving the target from the lowercased session key.

## Fix

Added an `updateLastRoute` call in the Google Chat monitor's `processMessageWithPipeline` function, storing the original-case space ID in the session's delivery context. This ensures that outbound replies resolve the correct case-sensitive space ID for Google Chat API calls.

This follows the same pattern used by Telegram (`bot-message-context.ts`) and other channel plugins that persist delivery context via `updateLastRoute`.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds `updateLastRoute` call to persist the original-case Google Chat space ID in the session's delivery context, fixing 403 errors when the system tries to use lowercased space IDs in API calls.

- Follows the same pattern used by Telegram (`bot-message-context.ts:681`), Discord (`message-handler.process.ts:321`), Slack (`dispatch.ts:26`), and Matrix (`handler.ts:556`)
- The session key generation correctly lowercases the space ID for normalization (`session-key.ts:184`), but Google Chat's API requires case-sensitive space resource names
- Without this fix, outbound deliveries (agent tool sends, cron replies, subagent replies) fall back to deriving the target from the lowercased session key, causing API failures

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - it's a targeted fix that aligns with established patterns across other channel plugins
- The implementation correctly follows the existing pattern used by Telegram, Discord, Slack, and Matrix for persisting delivery context. The fix directly addresses the root cause (lowercased space IDs causing 403 errors) by storing the original-case space ID via `updateLastRoute`, which is then used by `resolveGoogleChatOutboundSpace` for outbound API calls.
- No files require special attention

<sub>Last reviewed commit: 91ad961</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->