### PR TITLE
fix: doctor falsely flags non-gateway services as 'gateway-like'

### DIFF
--- a/src/daemon/inspect.ts
+++ b/src/daemon/inspect.ts
@@ -188,6 +188,12 @@ async function scanLaunchdDir(params: {
     if (marker === "openclaw" && isOpenClawGatewayLaunchdService(label, contents)) {
       continue;
     }
+    // Skip plists that merely reference .openclaw/ paths (e.g., workspace scripts)
+    // but don't actually run the gateway. Only flag services that look like gateway
+    // processes — their ProgramArguments should contain "gateway". (#15849)
+    if (marker === "openclaw" && !contents.toLowerCase().includes("gateway")) {
+      continue;
+    }
     results.push({
       platform: "darwin",
       label,
@@ -233,6 +239,10 @@ async function scanSystemdDir(params: {
       continue;
     }
     if (marker === "openclaw" && isOpenClawGatewaySystemdService(name, contents)) {
+      continue;
+    }
+    // Skip units that merely reference .openclaw/ paths but don't run the gateway (#15849)
+    if (marker === "openclaw" && !contents.toLowerCase().includes("gateway")) {
       continue;
     }
     results.push({


### PR DESCRIPTION
Fixes #15849

## Problem

`openclaw doctor` detects any launchd plist or systemd unit that references `.openclaw/` paths as a 'gateway-like service,' even if the service has nothing to do with the gateway (e.g., a git auto-commit script in `~/.openclaw/workspace/scripts/`). It then emits cleanup hints to remove the **actual running gateway plist**, which kills the gateway.

## Root Cause

`detectMarker()` matches the string 'openclaw' anywhere in the plist/unit contents. A service referencing `~/.openclaw/workspace/scripts/foo.sh` triggers the match even though it's not a gateway process.

## Fix

After detecting the 'openclaw' marker, check if the service contents also contain 'gateway'. Services that reference `.openclaw/` paths but don't mention 'gateway' are clearly not gateway processes and are now skipped.

Applied to both launchd (macOS) and systemd (Linux) scanners.

### Changes

- `src/daemon/inspect.ts`: Skip services with 'openclaw' marker but no 'gateway' reference in both `scanLaunchdDir` and `scanSystemdDir`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes `openclaw doctor` falsely flagging non-gateway launchd/systemd services as "gateway-like" when they merely reference `.openclaw/` paths (e.g., workspace scripts). The fix adds a check in both `scanLaunchdDir` and `scanSystemdDir` to skip services where `marker === "openclaw"` but the contents don't contain "gateway".

- The fix correctly addresses the reported issue for macOS (launchd) and Linux (systemd) platforms
- The same false-positive bug exists in the Windows `schtasks` scanning path (`findExtraGatewayServices`, win32 block) but was not addressed — a scheduled task whose command references `.openclaw/` paths will still be incorrectly flagged
- No unit tests were added for this change; `inspect.ts` has no existing test file

<h3>Confidence Score: 3/5</h3>

- The macOS/Linux fix is correct but the same bug remains unfixed in the Windows code path.
- The fix is logically sound for the two platforms it targets and directly addresses the reported issue. However, the identical false-positive bug in the Windows schtasks path was overlooked, meaning the fix is incomplete across all platforms. No tests were added.
- src/daemon/inspect.ts — the Windows (win32) schtasks scanning block needs the same gateway-keyword guard.

<sub>Last reviewed commit: f8cb80e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->