### PR TITLE
Guard notifications on macOS; fix focus issue and build fixes

### DIFF
--- a/apps/macos/Package.swift
+++ b/apps/macos/Package.swift
@@ -5,10 +5,14 @@ import PackageDescription
 
 let package = Package(
     name: "OpenClaw",
-    // This package is macOS-only. Do not build for iOS.
+    // This package targets macOS only and does not produce any iOS builds.
+    // .iOS(.v18) is listed here solely for shared dependency compatibility:
+    // OpenClawKit (../shared/OpenClawKit) supports both platforms, and SPM
+    // requires every platform declared by a dependency to also be declared by
+    // the consuming package.  Removing it causes a build-time diagnostic.
     platforms: [
         .macOS(.v15),
-        .iOS(.v18),
+        .iOS(.v18), // required for OpenClawKit shared-dependency resolution only
     ],
     products: [
         .library(name: "OpenClawIPC", targets: ["OpenClawIPC"]),

--- a/apps/macos/Package.swift
+++ b/apps/macos/Package.swift
@@ -5,8 +5,10 @@ import PackageDescription
 
 let package = Package(
     name: "OpenClaw",
+    // This package is macOS-only. Do not build for iOS.
     platforms: [
         .macOS(.v15),
+        .iOS(.v18),
     ],
     products: [
         .library(name: "OpenClawIPC", targets: ["OpenClawIPC"]),

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
@@ -448,7 +448,9 @@ private struct ChatComposerTextView: NSViewRepresentable {
 
         if self.shouldFocus, let window = scrollView.window {
             window.makeFirstResponder(textView)
-            self.shouldFocus = false
+            DispatchQueue.main.async {
+                self.shouldFocus = false
+            }
         }
 
         let isEditing = scrollView.window?.firstResponder == textView


### PR DESCRIPTION
Fixes https://github.com/openclaw/openclaw/issues/15911

Some build fixes and version updates for a smoother dev setup on macOS

- PermissionManager: add canAccessNotificationCenter() and avoid calling UNUserNotificationCenter when the app has no bundle identifier
- make ensureCapability return boolean results and propagate them; 
- add macOS-specific handling to exclude .ephemeral authorization (accept .authorized/.provisional on macOS) and mirror that behavior in the batch capability checks. 
- ChatComposer: defer clearing shouldFocus with DispatchQueue.main.async to avoid mutating state while making the text view first responder (fixes a focus/race issue). 
- Package.swift: add a macOS-only comment and update the platforms list to include macOS v15 and iOS v18.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Improved macOS notification handling and fixed a SwiftUI state mutation race condition. The PR guards `UNUserNotificationCenter` access with a bundle identifier check (apps without bundle IDs can't use the notification center), excludes `.ephemeral` authorization status on macOS (iOS-only), updates platform requirements to include iOS v18 for shared dependency compatibility, and defers `shouldFocus` state clearing with `DispatchQueue.main.async` to prevent mutating state during view updates.

Key changes:
- Added `canAccessNotificationCenter()` guard to prevent crashes when bundle identifier is nil
- Made `ensureCapability()` return boolean results for proper error propagation
- Platform-specific handling: `.ephemeral` excluded on macOS, only `.authorized` and `.provisional` accepted
- Fixed ChatComposer focus race by deferring state mutation to next run loop
- Updated Package.swift platforms to include iOS v18 (needed for OpenClawKit shared dependency)

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk - the changes are defensive improvements
- The changes are well-scoped defensive improvements (guard clauses, platform-specific handling, async state mutation fix). All changes follow established Swift/SwiftUI patterns and address real edge cases. The only minor issue is a potentially confusing comment in Package.swift where the file states it's macOS-only but includes iOS platform - this is for dependency compatibility but could be clearer.
- No files require special attention

<sub>Last reviewed commit: e3d2b12</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->