### PR TITLE
fix(android): require trust before discovery auto-connect

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
@@ -15,6 +15,7 @@ import ai.openclaw.android.gateway.DeviceIdentityStore
 import ai.openclaw.android.gateway.GatewayDiscovery
 import ai.openclaw.android.gateway.GatewayEndpoint
 import ai.openclaw.android.gateway.GatewaySession
+import ai.openclaw.android.gateway.isTrustedForAutoConnect
 import ai.openclaw.android.node.*
 import ai.openclaw.android.protocol.OpenClawCanvasA2UIAction
 import ai.openclaw.android.voice.TalkModeManager
@@ -425,6 +426,9 @@ class NodeRuntime(context: Context) {
         val targetStableId = lastDiscoveredStableId.value.trim()
         if (targetStableId.isEmpty()) return@collect
         val target = list.firstOrNull { it.stableId == targetStableId } ?: return@collect
+        if (!isTrustedForAutoConnect(target, prefs.loadGatewayTlsFingerprint(target.stableId))) {
+          return@collect
+        }
         didAutoConnect = true
         connect(target)
       }

--- a/apps/android/app/src/main/java/ai/openclaw/android/gateway/GatewayTrust.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/gateway/GatewayTrust.kt
@@ -1,0 +1,9 @@
+package ai.openclaw.android.gateway
+
+internal fun isTrustedForAutoConnect(
+  endpoint: GatewayEndpoint,
+  pinnedFingerprintSha256: String?,
+): Boolean {
+  if (endpoint.stableId.startsWith("manual|")) return true
+  return !pinnedFingerprintSha256.isNullOrBlank()
+}

--- a/apps/android/app/src/test/java/ai/openclaw/android/gateway/GatewayTrustTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/android/gateway/GatewayTrustTest.kt
@@ -1,0 +1,40 @@
+package ai.openclaw.android.gateway
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GatewayTrustTest {
+  @Test
+  fun isTrustedForAutoConnect_allowsManualEndpointsWithoutPin() {
+    val endpoint = GatewayEndpoint.manual(host = "gateway.local", port = 18789)
+
+    assertTrue(isTrustedForAutoConnect(endpoint, pinnedFingerprintSha256 = null))
+  }
+
+  @Test
+  fun isTrustedForAutoConnect_rejectsDiscoveredEndpointsWithoutPin() {
+    val endpoint =
+      GatewayEndpoint(
+        stableId = "_openclaw-gw._tcp.|local.|demo",
+        name = "Demo Gateway",
+        host = "192.168.1.25",
+        port = 18789,
+      )
+
+    assertFalse(isTrustedForAutoConnect(endpoint, pinnedFingerprintSha256 = null))
+  }
+
+  @Test
+  fun isTrustedForAutoConnect_allowsDiscoveredEndpointsWithPin() {
+    val endpoint =
+      GatewayEndpoint(
+        stableId = "_openclaw-gw._tcp.|local.|demo",
+        name = "Demo Gateway",
+        host = "192.168.1.25",
+        port = 18789,
+      )
+
+    assertTrue(isTrustedForAutoConnect(endpoint, pinnedFingerprintSha256 = "abc123"))
+  }
+}


### PR DESCRIPTION
## Fix Summary
- Prevent Android auto-connect to discovered gateways unless the gateway identity is already trusted.
- Add `GatewayTrust.isTrustedForAutoConnect(...)` and gate auto-connect in `NodeRuntime`.
- Keep manual endpoints connectable (no discovery spoofing path).
- Add regression tests for trusted/untrusted discovered endpoints.

## Security Snapshot
- Addresses spoofed mDNS/discovery auto-connect path that could let an untrusted discovered gateway become the command source.
- New behavior: discovered endpoints must have a pinned TLS fingerprint before auto-connect is allowed.

## Implementation Details
- `apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt`
- `apps/android/app/src/main/java/ai/openclaw/android/gateway/GatewayTrust.kt`
- `apps/android/app/src/test/java/ai/openclaw/android/gateway/GatewayTrustTest.kt`

## Validation Evidence
- `pnpm build` (pass)
- `pnpm check` (pass)
- Full `pnpm test` runs were executed; unrelated flaky timeouts were observed in `extensions/lobster/src/lobster-tool.test.ts` under heavy parallel load.
- Isolated rerun: `CI=1 pnpm vitest run --config vitest.extensions.config.ts extensions/lobster/src/lobster-tool.test.ts --pool=vmForks --maxWorkers 1` (pass)
- New regression tests in `GatewayTrustTest.kt` pass in branch build/test execution context.

## Risk and Compatibility
- Low/medium behavior change scope: only Android auto-connect gating for discovered endpoints.
- Manual connections are unchanged.

## AI-Assisted Disclosure
Generated with AI assistance (Codex) and manually reviewed.

Refs #15906

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Prevents Android auto-connect to discovered gateways unless they have a pinned TLS fingerprint. Adds `isTrustedForAutoConnect` function that gates discovered endpoint connections while preserving manual connection functionality. The fix addresses mDNS/discovery spoofing attacks where untrusted gateways could become command sources through auto-connect.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The security fix is well-implemented with clear logic, comprehensive test coverage for all code paths, and proper integration with existing fingerprint storage that already handles edge cases like empty strings. The change is narrowly scoped to only the auto-connect path while preserving manual connection functionality
- No files require special attention

<sub>Last reviewed commit: 039587b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->