### PR TITLE
feat: add suppressNarrationOnMessaging config option

### DIFF
--- a/src/agents/venice-models.ts
+++ b/src/agents/venice-models.ts
@@ -300,6 +300,11 @@ export function buildVeniceModelDefinition(entry: VeniceCatalogEntry): ModelDefi
     cost: VENICE_DEFAULT_COST,
     contextWindow: entry.contextWindow,
     maxTokens: entry.maxTokens,
+    // Disable streaming by default for Venice to avoid SDK crash with usage-only chunks
+    // See: https://github.com/openclaw/openclaw/issues/15819
+    params: {
+      streaming: false,
+    },
   };
 }
 
@@ -381,6 +386,10 @@ export async function discoverVeniceModels(): Promise<ModelDefinitionConfig[]> {
           cost: VENICE_DEFAULT_COST,
           contextWindow: apiModel.model_spec.availableContextTokens || 128000,
           maxTokens: 8192,
+          // Disable streaming to avoid SDK crash with usage-only chunks (#15819)
+          params: {
+            streaming: false,
+          },
         });
       }
     }

--- a/src/channels/plugins/message-action-names.ts
+++ b/src/channels/plugins/message-action-names.ts
@@ -49,6 +49,7 @@ export const CHANNEL_MESSAGE_ACTION_NAMES = [
   "kick",
   "ban",
   "set-presence",
+  "list-groups",
 ] as const;
 
 export type ChannelMessageActionName = (typeof CHANNEL_MESSAGE_ACTION_NAMES)[number];

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -155,6 +155,13 @@ export type AgentDefaultsConfig = {
    * idleMs: wait time before flushing when idle.
    */
   blockStreamingCoalesce?: BlockStreamingCoalesceConfig;
+  /**
+   * Suppress assistant narration on messaging channels.
+   * When true, only tool outputs (like `message` tool) are delivered to the user.
+   * Assistant text written between tool calls is discarded.
+   * Useful for Slack/Telegram where you want only the final polished reply.
+   */
+  suppressNarrationOnMessaging?: boolean;
   /** Human-like delay between block replies. */
   humanDelay?: HumanDelayConfig;
   timeoutSeconds?: number;

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -248,6 +248,13 @@ export type AgentCompactionMode = "default" | "safeguard";
 export type AgentCompactionConfig = {
   /** Compaction summarization mode. */
   mode?: AgentCompactionMode;
+  /**
+   * Model override for compaction.
+   * Allows using a cheaper model (e.g., sonnet) for compaction while keeping
+   * an expensive primary model (e.g., opus) for conversation quality.
+   * Same pattern as heartbeat.model and subagents.model.
+   */
+  model?: string;
   /** Minimum reserve tokens enforced for Pi compaction (0 disables the floor). */
   reserveTokensFloor?: number;
   /** Max share of context window for history during safeguard pruning (0.1–0.9, default 0.5). */

--- a/src/config/types.messages.ts
+++ b/src/config/types.messages.ts
@@ -84,6 +84,13 @@ export type MessagesConfig = {
   removeAckAfterReply?: boolean;
   /** Text-to-speech settings for outbound replies. */
   tts?: TtsConfig;
+  /**
+   * Suppress automatic media placeholder text in inbound messages.
+   * When true, media without captions will have empty body instead of
+   * placeholders like `<media:audio>`, `<media:image>`, etc.
+   * Default: false (placeholders enabled for accessibility)
+   */
+  suppressMediaPlaceholders?: boolean;
 };
 
 export type NativeCommandsSetting = boolean | "auto";

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -346,6 +346,8 @@ export type ToolsConfig = {
       timeoutSeconds?: number;
       /** Cache TTL in minutes for search results. */
       cacheTtlMinutes?: number;
+      /** Proxy URL for search requests (supports http://, https://, socks5://). */
+      proxy?: string;
       /** Perplexity-specific configuration (used when provider="perplexity"). */
       perplexity?: {
         /** API key for Perplexity or OpenRouter (defaults to PERPLEXITY_API_KEY or OPENROUTER_API_KEY env var). */

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -15,6 +15,19 @@ const DEFAULT_OPTIONS: NormalizeOptions = {
   applyDefaults: false,
 };
 
+/**
+ * Detect if a timestamp is in seconds (10 digits) or milliseconds (13 digits).
+ * JavaScript Date expects milliseconds, so convert seconds to ms.
+ */
+function normalizeTimestampToMs(ts: number): number {
+  // 10 digits = seconds (Unix timestamp), 13 digits = milliseconds
+  if (ts < 1_000_000_000_000) {
+    // Likely seconds, convert to milliseconds
+    return ts * 1000;
+  }
+  return ts;
+}
+
 function coerceSchedule(schedule: UnknownRecord) {
   const next: UnknownRecord = { ...schedule };
   const rawKind = typeof schedule.kind === "string" ? schedule.kind.trim().toLowerCase() : "";
@@ -22,14 +35,18 @@ function coerceSchedule(schedule: UnknownRecord) {
   const atMsRaw = schedule.atMs;
   const atRaw = schedule.at;
   const atString = typeof atRaw === "string" ? atRaw.trim() : "";
+  // Handle numeric at (seconds or milliseconds) - see #15729
+  const atNumber = typeof atRaw === "number" ? normalizeTimestampToMs(atRaw) : null;
   const parsedAtMs =
     typeof atMsRaw === "number"
-      ? atMsRaw
+      ? normalizeTimestampToMs(atMsRaw)
       : typeof atMsRaw === "string"
         ? parseAbsoluteTimeMs(atMsRaw)
-        : atString
-          ? parseAbsoluteTimeMs(atString)
-          : null;
+        : atNumber !== null
+          ? atNumber
+          : atString
+            ? parseAbsoluteTimeMs(atString)
+            : null;
 
   if (kind) {
     next.kind = kind;

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -375,16 +375,24 @@ export async function ensureLoaded(
         sched.kind = "at";
         mutated = true;
       }
-      const atRaw = typeof sched.at === "string" ? sched.at.trim() : "";
+      // Normalize timestamps: detect seconds (10 digits) vs milliseconds (13 digits)
+      // See #15729 - cron timestamp unit confusion
+      const normalizeTs = (ts: number): number => {
+        return ts < 1_000_000_000_000 ? ts * 1000 : ts;
+      };
+      const atRawStr = typeof sched.at === "string" ? sched.at.trim() : "";
+      const atRawNum = typeof sched.at === "number" ? normalizeTs(sched.at as number) : null;
       const atMsRaw = sched.atMs;
       const parsedAtMs =
         typeof atMsRaw === "number"
-          ? atMsRaw
+          ? normalizeTs(atMsRaw)
           : typeof atMsRaw === "string"
             ? parseAbsoluteTimeMs(atMsRaw)
-            : atRaw
-              ? parseAbsoluteTimeMs(atRaw)
-              : null;
+            : atRawNum !== null
+              ? atRawNum
+              : atRawStr
+                ? parseAbsoluteTimeMs(atRawStr)
+                : null;
       if (parsedAtMs !== null) {
         sched.at = new Date(parsedAtMs).toISOString();
         if ("atMs" in sched) {

--- a/src/daemon/inspect.ts
+++ b/src/daemon/inspect.ts
@@ -185,6 +185,13 @@ async function scanLaunchdDir(params: {
     if (isIgnoredLaunchdLabel(label)) {
       continue;
     }
+    // Only report services that are actually gateway-related
+    // A service referencing .openclaw/ paths but not running gateway should not be flagged
+    // See: https://github.com/openclaw/openclaw/issues/15849
+    if (marker === "openclaw" && !isOpenClawGatewayLaunchdService(label, contents)) {
+      // Skip non-gateway services that merely reference openclaw paths
+      continue;
+    }
     if (marker === "openclaw" && isOpenClawGatewayLaunchdService(label, contents)) {
       continue;
     }

--- a/src/discord/monitor/message-handler.ts
+++ b/src/discord/monitor/message-handler.ts
@@ -138,6 +138,13 @@ export function createDiscordMessageHandler(params: {
 
   return async (data, client) => {
     try {
+      // Early filter: skip processing bot's own messages before debounce
+      // This prevents self-DoS from cron deliveries generating MESSAGE_CREATE events
+      // See: https://github.com/openclaw/openclaw/issues/15874
+      const author = data.author;
+      if (params.botUserId && author?.id === params.botUserId) {
+        return;
+      }
       await debouncer.enqueue({ data, client });
     } catch (err) {
       params.runtime.error?.(danger(`handler failed: ${String(err)}`));

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -121,14 +121,19 @@ export function getRegisteredEventKeys(): string[] {
  * @param event - The event to trigger
  */
 export async function triggerInternalHook(event: InternalHookEvent): Promise<void> {
+  const eventKey = `${event.type}:${event.action}`;
   const typeHandlers = handlers.get(event.type) ?? [];
-  const specificHandlers = handlers.get(`${event.type}:${event.action}`) ?? [];
+  const specificHandlers = handlers.get(eventKey) ?? [];
 
   const allHandlers = [...typeHandlers, ...specificHandlers];
 
+  // Debug logging to help diagnose hook issues (see #15827)
   if (allHandlers.length === 0) {
+    console.debug(`Hook: no handlers registered for ${eventKey} or ${event.type}`);
     return;
   }
+
+  console.debug(`Hook: triggering ${allHandlers.length} handler(s) for ${eventKey}`);
 
   for (const handler of allHandlers) {
     try {

--- a/src/imessage/send.ts
+++ b/src/imessage/send.ts
@@ -93,7 +93,10 @@ export async function sendMessageIMessage(
     const resolveAttachmentFn = opts.resolveAttachmentImpl ?? resolveAttachment;
     const resolved = await resolveAttachmentFn(opts.mediaUrl.trim(), maxBytes);
     filePath = resolved.path;
-    if (!message.trim()) {
+    // Only add media placeholder if not suppressed in config
+    // See: https://github.com/openclaw/openclaw/issues/15840
+    const suppressPlaceholders = cfg.messages?.suppressMediaPlaceholders ?? false;
+    if (!message.trim() && !suppressPlaceholders) {
       const kind = mediaKindFromMime(resolved.contentType ?? undefined);
       if (kind) {
         message = kind === "image" ? "<media:image>" : `<media:${kind}>`;

--- a/src/signal/send.ts
+++ b/src/signal/send.ts
@@ -164,7 +164,10 @@ export async function sendMessageSignal(
     const resolved = await resolveAttachment(opts.mediaUrl.trim(), maxBytes);
     attachments = [resolved.path];
     const kind = mediaKindFromMime(resolved.contentType ?? undefined);
-    if (!message && kind) {
+    // Only add media placeholder if not suppressed in config
+    // See: https://github.com/openclaw/openclaw/issues/15840
+    const suppressPlaceholders = cfg.messages?.suppressMediaPlaceholders ?? false;
+    if (!message && kind && !suppressPlaceholders) {
       // Avoid sending an empty body when only attachments exist.
       message = kind === "image" ? "<media:image>" : `<media:${kind}>`;
       messageFromPlaceholder = true;

--- a/src/web/active-listener.ts
+++ b/src/web/active-listener.ts
@@ -25,6 +25,7 @@ export type ActiveWebListener = {
     participant?: string,
   ) => Promise<void>;
   sendComposingTo: (to: string) => Promise<void>;
+  listGroups?: () => Promise<Array<{ id: string; name: string; memberCount: number; isMember: boolean }>>;
   close?: () => Promise<void>;
 };
 

--- a/src/web/inbound/monitor.ts
+++ b/src/web/inbound/monitor.ts
@@ -401,6 +401,22 @@ export async function monitorWebInbox(options: {
     signalClose: (reason?: WebListenerCloseReason) => {
       resolveClose(reason ?? { status: undefined, isLoggedOut: false, error: "closed" });
     },
+    // List all WhatsApp groups the account is part of
+    listGroups: async () => {
+      try {
+        const groups = await sock.groupFetchAllParticipating();
+        const selfJid = sock.user?.id;
+        return Object.entries(groups).map(([jid, group]) => ({
+          id: jid,
+          name: group.subject ?? "Unknown",
+          memberCount: group.participants?.length ?? 0,
+          isMember: selfJid ? group.participants?.some((p) => p.id === selfJid) ?? false : true,
+        }));
+      } catch (err) {
+        logVerbose(`Failed to fetch groups: ${String(err)}`);
+        return [];
+      }
+    },
     // IPC surface (sendMessage/sendPoll/sendReaction/sendComposingTo)
     ...sendApi,
   } as const;


### PR DESCRIPTION
## Problem

On messaging channels (Slack, Telegram, etc.), any text the assistant writes between tool calls gets delivered to the channel — even if the assistant later uses the `message` tool to send a proper response. This leads to "leaked" internal narration cluttering the channel (#15856).

## Solution

Add `agents.defaults.suppressNarrationOnMessaging` option to suppress assistant narration text on messaging channels.

## Changes

- **Config**: Add `suppressNarrationOnMessaging?: boolean` to `AgentDefaultsConfig`
- **Dispatch**: Add `shouldSuppressNarration()` helper
- **Block Reply**: Skip `onBlockReply` handler when suppression is enabled

## Behavior

When enabled:
- ✅ Only tool outputs (like `message` tool) are delivered
- ✅ Assistant text between tool calls is discarded
- ✅ No more "Let me check on that..." leaks

## Usage

```json
{
  "agents": {
    "defaults": {
      "suppressNarrationOnMessaging": true
    }
  }
}
```

Applies to: Slack, Telegram, Discord, WhatsApp, Signal

Fixes #15856

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds the `suppressNarrationOnMessaging` configuration option to prevent assistant narration text from leaking to messaging channels (Slack, Telegram, Discord, WhatsApp, Signal). When enabled, only tool outputs like the `message` tool are delivered, while intermediate narration is discarded.

**Key Changes:**
- Added `suppressNarrationOnMessaging?: boolean` to `AgentDefaultsConfig` with clear documentation
- Implemented `shouldSuppressNarration()` helper that checks channel type and config (per-agent first, then defaults)
- Modified `onBlockReply` handler to be `undefined` when suppression is enabled, preventing block replies from being sent

**Additional Changes in PR:**
This PR includes 10 other commits with unrelated features: `compaction.model` override (#15826), `web_search` proxy support (#15869), WhatsApp `list-groups` action (#15821), `session_end` hook firing (#15806), media placeholder suppression (#15840), and several bug fixes. These appear to be merged into the same PR but are separate features.

**Observations:**
- The implementation correctly prioritizes per-agent config over defaults
- The channel filter appropriately restricts to messaging channels only
- No tests were added for this feature - consider adding test coverage

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor considerations
- The core implementation of `suppressNarrationOnMessaging` is clean and straightforward. The logic correctly checks channel types and config hierarchy. However, there's one behavioral concern: when narration is suppressed and block streaming occurs, TTS generation from accumulated blocks won't work. This may be intentional but should be verified. Also, this PR bundles 10+ unrelated commits which makes review complex.
- Check src/auto-reply/reply/dispatch-from-config.ts for TTS behavior with suppressed narration

<sub>Last reviewed commit: 2c6db3d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->