### PR TITLE
fix(sessions): allow session file paths from other agents' sessions dirs

### DIFF
--- a/src/config/sessions/paths.test.ts
+++ b/src/config/sessions/paths.test.ts
@@ -96,15 +96,23 @@ describe("session path safety", () => {
     expect(resolved).toBe(path.resolve(sessionsDir, "abc-123-topic-42.jsonl"));
   });
 
-  it("rejects absolute sessionFile paths outside the sessions dir", () => {
+  it("accepts absolute sessionFile paths from another agent's sessions dir", () => {
+    const sessionsDir = "/tmp/openclaw/agents/main/sessions";
+
+    const resolved = resolveSessionFilePath(
+      "sess-1",
+      { sessionFile: "/tmp/openclaw/agents/feishu/sessions/abc-123.jsonl" },
+      { sessionsDir },
+    );
+
+    expect(resolved).toBe(path.resolve("/tmp/openclaw/agents/feishu/sessions/abc-123.jsonl"));
+  });
+
+  it("rejects absolute sessionFile paths outside any agents sessions dir", () => {
     const sessionsDir = "/tmp/openclaw/agents/main/sessions";
 
     expect(() =>
-      resolveSessionFilePath(
-        "sess-1",
-        { sessionFile: "/tmp/openclaw/agents/work/sessions/abc-123.jsonl" },
-        { sessionsDir },
-      ),
+      resolveSessionFilePath("sess-1", { sessionFile: "/etc/passwd" }, { sessionsDir }),
     ).toThrow(/within sessions directory/);
   });
 

--- a/src/config/sessions/paths.ts
+++ b/src/config/sessions/paths.ts
@@ -82,6 +82,14 @@ function resolvePathWithinSessionsDir(sessionsDir: string, candidate: string): s
   // convert them to relative so the containment check passes.
   const normalized = path.isAbsolute(trimmed) ? path.relative(resolvedBase, trimmed) : trimmed;
   if (!normalized || normalized.startsWith("..") || path.isAbsolute(normalized)) {
+    // Allow absolute paths that reside in a valid agents/*/sessions/ directory
+    // to support multi-agent setups where each agent has its own sessions dir.
+    if (path.isAbsolute(trimmed)) {
+      const candidateDir = path.dirname(path.resolve(trimmed));
+      if (candidateDir.includes(path.join("agents")) && candidateDir.endsWith("sessions")) {
+        return path.resolve(trimmed);
+      }
+    }
     throw new Error("Session file path must be within sessions directory");
   }
   return path.resolve(resolvedBase, normalized);


### PR DESCRIPTION
In multi-agent setups, each agent has its own sessions directory. When loading a session file for a non-main agent, the path validation incorrectly rejected absolute paths that belong to another agent's sessions directory. Add a fallback check that allows absolute paths residing in any valid agents/*/sessions/ directory.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds fallback validation to allow absolute session file paths from other agents' sessions directories in multi-agent setups, addressing path rejection issues when loading cross-agent session files.

**Issues found:**
- Path validation logic is overly permissive and vulnerable to path manipulation
- Missing path normalization allows potential directory traversal attacks
- Pattern matching doesn't enforce proper `agents/<agentId>/sessions/` structure

<h3>Confidence Score: 2/5</h3>

- This PR introduces security vulnerabilities through overly permissive path validation
- The path validation logic has critical flaws: it accepts any path containing `agents/` anywhere in the path (not just in proper structure) and lacks path normalization to prevent traversal attacks. These issues could allow unauthorized file access outside intended session directories.
- Pay close attention to `src/config/sessions/paths.ts` - the validation logic needs hardening before merge

<sub>Last reviewed commit: 12741ce</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->