### PR TITLE
fix(memory-flush): only write memoryFlushCompactionCount when compaction succeeds

### DIFF
--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -162,10 +162,7 @@ export async function runMemoryFlushIfNeeded(params: {
         });
       },
     });
-    let memoryFlushCompactionCount =
-      activeSessionEntry?.compactionCount ??
-      (params.sessionKey ? activeSessionStore?.[params.sessionKey]?.compactionCount : 0) ??
-      0;
+    let memoryFlushCompactionCount: number | undefined;
     if (memoryCompactionCompleted) {
       const nextCount = await incrementCompactionCount({
         sessionEntry: activeSessionEntry,
@@ -184,7 +181,7 @@ export async function runMemoryFlushIfNeeded(params: {
           sessionKey: params.sessionKey,
           update: async () => ({
             memoryFlushAt: Date.now(),
-            memoryFlushCompactionCount,
+            ...(memoryFlushCompactionCount !== undefined ? { memoryFlushCompactionCount } : {}),
           }),
         });
         if (updatedEntry) {

--- a/src/auto-reply/reply/agent-runner.memory-flush.runreplyagent-memory-flush.runs-memory-flush-turn-updates-session-metadata.test.ts
+++ b/src/auto-reply/reply/agent-runner.memory-flush.runreplyagent-memory-flush.runs-memory-flush-turn-updates-session-metadata.test.ts
@@ -182,7 +182,8 @@ describe("runReplyAgent memory flush", () => {
 
     const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));
     expect(stored[sessionKey].memoryFlushAt).toBeTypeOf("number");
-    expect(stored[sessionKey].memoryFlushCompactionCount).toBe(1);
+    // memoryFlushCompactionCount should NOT be updated when compaction did not complete
+    expect(stored[sessionKey].memoryFlushCompactionCount).toBeUndefined();
   });
   it("skips memory flush when disabled in config", async () => {
     runEmbeddedPiAgentMock.mockReset();


### PR DESCRIPTION
## Problem

`runMemoryFlushIfNeeded` writes `memoryFlushCompactionCount` to the session store **even when compaction does not complete**. This sets `memoryFlushCompactionCount === compactionCount`, causing `shouldRunMemoryFlush` to return `false` on all future turns — permanently blocking auto-compaction for that session.

Sessions get stuck above the token threshold (e.g., 120k+ tokens with a 60k softThreshold) with no way to recover without manual intervention.

## Fix

Only include `memoryFlushCompactionCount` in the session store update when `memoryCompactionCompleted` is true. When compaction fails or doesn't fire, the field is omitted from the update, preserving whatever value was previously stored.

## Changes

- `agent-runner-memory.ts`: Changed `memoryFlushCompactionCount` to `undefined` by default; conditionally spread into the update object only when compaction completed
- Updated existing test assertion to expect `undefined` when compaction doesn't complete (was incorrectly asserting the buggy behavior)

## Testing

All 8 memory-flush tests pass. All 11 `memory-flush.test.ts` unit tests pass.

Closes #15930

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixed critical bug where `memoryFlushCompactionCount` was written to session store even when compaction didn't complete, permanently blocking future auto-compaction for affected sessions.

- Changed `memoryFlushCompactionCount` initialization from computed value to `undefined`
- Only writes `memoryFlushCompactionCount` when `memoryCompactionCompleted` is true using conditional spread
- Updated test to expect `undefined` when compaction doesn't complete (was incorrectly asserting buggy behavior)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a targeted correction of critical logic error with clear before/after behavior. The change correctly implements conditional field updates using standard TypeScript patterns, existing tests validate both success and failure paths, and the fix directly addresses the root cause described in the issue.
- No files require special attention

<sub>Last reviewed commit: 2912c50</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->