### PR TITLE
fix(logging): prevent recursive logger/config stack overflow

### DIFF
--- a/src/logging/logger.recursion-guard.test.ts
+++ b/src/logging/logger.recursion-guard.test.ts
@@ -1,0 +1,75 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { enableConsoleCapture } from "./console.js";
+import { resetLogger, setLoggerOverride } from "./logger.js";
+import { loggingState } from "./state.js";
+
+type ConsoleSnapshot = {
+  log: typeof console.log;
+  info: typeof console.info;
+  warn: typeof console.warn;
+  error: typeof console.error;
+  debug: typeof console.debug;
+  trace: typeof console.trace;
+};
+
+let snapshot: ConsoleSnapshot;
+let originalConfigPath: string | undefined;
+
+beforeEach(() => {
+  snapshot = {
+    log: console.log,
+    info: console.info,
+    warn: console.warn,
+    error: console.error,
+    debug: console.debug,
+    trace: console.trace,
+  };
+  originalConfigPath = process.env.OPENCLAW_CONFIG_PATH;
+  loggingState.consolePatched = false;
+  loggingState.forceConsoleToStderr = false;
+  loggingState.consoleTimestampPrefix = false;
+  loggingState.rawConsole = null;
+  resetLogger();
+});
+
+afterEach(() => {
+  console.log = snapshot.log;
+  console.info = snapshot.info;
+  console.warn = snapshot.warn;
+  console.error = snapshot.error;
+  console.debug = snapshot.debug;
+  console.trace = snapshot.trace;
+  loggingState.consolePatched = false;
+  loggingState.forceConsoleToStderr = false;
+  loggingState.consoleTimestampPrefix = false;
+  loggingState.rawConsole = null;
+  resetLogger();
+  setLoggerOverride(null);
+  if (originalConfigPath === undefined) {
+    delete process.env.OPENCLAW_CONFIG_PATH;
+  } else {
+    process.env.OPENCLAW_CONFIG_PATH = originalConfigPath;
+  }
+});
+
+describe("logger recursion guard", () => {
+  it("avoids recursive stack overflow when config loading fails under console capture", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-recursion-"));
+    try {
+      const configPath = path.join(tmpDir, "openclaw.json");
+
+      // Circular include: guaranteed config load failure for exercising error path.
+      await writeFile(configPath, `{ "$include": "./openclaw.json" }\n`, "utf-8");
+      process.env.OPENCLAW_CONFIG_PATH = configPath;
+
+      enableConsoleCapture();
+
+      expect(() => console.error("trigger config load")).not.toThrow();
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -1,7 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
 import { Logger as TsLogger } from "tslog";
-import { getCommandPathWithRootOptions } from "../cli/argv.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { readLoggingConfig } from "./config.js";
@@ -21,6 +20,7 @@ const MAX_LOG_AGE_MS = 24 * 60 * 60 * 1000; // 24h
 const DEFAULT_MAX_LOG_FILE_BYTES = 500 * 1024 * 1024; // 500 MB
 
 const requireConfig = resolveNodeRequireFromMeta(import.meta.url);
+let resolvingSettings = false;
 
 export type LoggerSettings = {
   level?: LogLevel;
@@ -43,9 +43,11 @@ export type LogTransport = (logObj: LogTransportRecord) => void;
 
 const externalTransports = new Set<LogTransport>();
 
-function shouldSkipLoadConfigFallback(argv: string[] = process.argv): boolean {
-  const [primary, secondary] = getCommandPathWithRootOptions(argv, 2);
-  return primary === "config" && secondary === "validate";
+function resolveFallbackSettings(): ResolvedSettings {
+  const override = loggingState.overrideSettings as LoggerSettings | null;
+  const level = normalizeLogLevel(override?.level, "info");
+  const file = override?.file ?? defaultRollingPathForToday();
+  return { level, file };
 }
 
 function attachExternalTransport(logger: TsLogger<LogObj>, transport: LogTransport): void {
@@ -71,38 +73,41 @@ function canUseSilentVitestFileLogFastPath(envLevel: LogLevel | undefined): bool
 }
 
 function resolveSettings(): ResolvedSettings {
-  const envLevel = resolveEnvLogLevelOverride();
-  // Test runs default file logs to silent. Skip config reads and fallback load in the
-  // common case to avoid pulling heavy config/schema stacks on startup.
-  if (canUseSilentVitestFileLogFastPath(envLevel)) {
-    return {
-      level: "silent",
-      file: defaultRollingPathForToday(),
-      maxFileBytes: DEFAULT_MAX_LOG_FILE_BYTES,
-    };
+  // Reentrancy guard: config loading can log errors, and console capture routes
+  // those logs back through getLogger(). In that case, avoid recursive loadConfig().
+  if (resolvingSettings) {
+    return resolveFallbackSettings();
   }
+  resolvingSettings = true;
 
-  let cfg: OpenClawConfig["logging"] | undefined =
-    (loggingState.overrideSettings as LoggerSettings | null) ?? readLoggingConfig();
-  if (!cfg && !shouldSkipLoadConfigFallback()) {
-    try {
-      const loaded = requireConfig?.("../config/config.js") as
-        | {
-            loadConfig?: () => OpenClawConfig;
-          }
-        | undefined;
-      cfg = loaded?.loadConfig?.().logging;
-    } catch {
-      cfg = undefined;
+  try {
+    let cfg: OpenClawConfig["logging"] | undefined =
+      (loggingState.overrideSettings as LoggerSettings | null) ?? readLoggingConfig();
+    if (!cfg) {
+      try {
+        const loaded = requireConfig?.("../config/config.js") as
+          | {
+              loadConfig?: () => OpenClawConfig;
+            }
+          | undefined;
+        cfg = loaded?.loadConfig?.().logging;
+      } catch {
+        cfg = undefined;
+      }
     }
+    const defaultLevel =
+      process.env.VITEST === "true" && process.env.OPENCLAW_TEST_FILE_LOG !== "1"
+        ? "silent"
+        : "info";
+    const fromConfig = normalizeLogLevel(cfg?.level, defaultLevel);
+    const envLevel = resolveEnvLogLevelOverride();
+    const level = envLevel ?? fromConfig;
+    const file = cfg?.file ?? defaultRollingPathForToday();
+    const maxFileBytes = resolveMaxLogFileBytes(cfg?.maxFileBytes);
+    return { level, file, maxFileBytes };
+  } finally {
+    resolvingSettings = false;
   }
-  const defaultLevel =
-    process.env.VITEST === "true" && process.env.OPENCLAW_TEST_FILE_LOG !== "1" ? "silent" : "info";
-  const fromConfig = normalizeLogLevel(cfg?.level, defaultLevel);
-  const level = envLevel ?? fromConfig;
-  const file = cfg?.file ?? defaultRollingPathForToday();
-  const maxFileBytes = resolveMaxLogFileBytes(cfg?.maxFileBytes);
-  return { level, file, maxFileBytes };
 }
 
 function settingsChanged(a: ResolvedSettings | null, b: ResolvedSettings) {
@@ -294,10 +299,6 @@ export function registerLogTransport(transport: LogTransport): () => void {
     externalTransports.delete(transport);
   };
 }
-
-export const __test__ = {
-  shouldSkipLoadConfigFallback,
-};
 
 function formatLocalDate(date: Date): string {
   const year = date.getFullYear();

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -47,7 +47,8 @@ function resolveFallbackSettings(): ResolvedSettings {
   const override = loggingState.overrideSettings as LoggerSettings | null;
   const level = normalizeLogLevel(override?.level, "info");
   const file = override?.file ?? defaultRollingPathForToday();
-  return { level, file };
+  const maxFileBytes = resolveMaxLogFileBytes(undefined);
+  return { level, file, maxFileBytes };
 }
 
 function attachExternalTransport(logger: TsLogger<LogObj>, transport: LogTransport): void {


### PR DESCRIPTION
## Summary
- add reentrancy guard in logger settings resolution to avoid recursive config load when console capture logs during config failures
- ensure guard is always reset with a finally block and preserve Vitest default file-log level behavior
- add regression test that reproduces circular-include config failure under console capture and asserts no stack overflow

## Validation
- bun test src/logging/logger.import-side-effects.test.ts src/logging/logger.recursion-guard.test.ts src/index.test.ts --reporter=dot
- pnpm exec oxlint src/logging/logger.ts src/logging/logger.recursion-guard.test.ts

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Prevents recursive stack overflow in logger settings resolution when config loading fails under console capture.

**Key changes:**
- Added `resolvingSettings` reentrancy guard flag in `logger.ts:20`
- Introduced `resolveFallbackSettings()` helper that returns safe defaults when recursion is detected
- Wrapped `resolveSettings()` in try/finally to ensure guard is always reset
- Added comprehensive regression test that reproduces circular `$include` failure scenario

**How it works:**
When console capture is enabled, console calls route through the file logger. If config loading fails and logs an error, that error would trigger another `getLogger()` call, creating infinite recursion. The guard detects reentry and returns fallback settings instead of recursing.

**Impact:**
This is a critical stability fix that prevents crashes during config loading failures, particularly in test environments with console capture enabled.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - critical bug fix with no breaking changes
- This is a well-implemented fix for a critical stack overflow bug. The reentrancy guard pattern is standard and correct, using try/finally ensures the guard is always reset, and the fallback settings provide safe defaults. The regression test directly reproduces the failure scenario with a circular $include. No logic changes to normal operation - only adds protection for the error path.
- No files require special attention

<sub>Last reviewed commit: 0d8f9f3</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->