### PR TITLE
fix: Android production build permits cleartext traffic globally

### DIFF
--- a/apps/android/app/src/debug/res/xml/network_security_config.xml
+++ b/apps/android/app/src/debug/res/xml/network_security_config.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config xmlns:tools="http://schemas.android.com/tools">
+  <!-- Debug-only policy for local/tailnet development endpoints, including IP-based hosts. -->
+  <base-config cleartextTrafficPermitted="true" tools:ignore="InsecureBaseConfiguration" />
+  <domain-config cleartextTrafficPermitted="true">
+    <domain includeSubdomains="true">openclaw.local</domain>
+  </domain-config>
+  <domain-config cleartextTrafficPermitted="true">
+    <domain includeSubdomains="true">ts.net</domain>
+  </domain-config>
+</network-security-config>

--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -26,6 +26,7 @@
     <application
         android:name=".NodeApp"
         android:allowBackup="true"
+        android:usesCleartextTraffic="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"

--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -23,6 +23,7 @@
         android:name="android.hardware.telephony"
         android:required="false" />
 
+    <!-- Production network policy: cleartext disabled; config wired via networkSecurityConfig. -->
     <application
         android:name=".NodeApp"
         android:allowBackup="true"

--- a/apps/android/app/src/main/res/xml/network_security_config.xml
+++ b/apps/android/app/src/main/res/xml/network_security_config.xml
@@ -1,12 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<network-security-config xmlns:tools="http://schemas.android.com/tools">
-  <!-- This app is primarily used on a trusted tailnet; allow cleartext for IP-based endpoints too. -->
-  <base-config cleartextTrafficPermitted="true" tools:ignore="InsecureBaseConfiguration" />
-  <!-- Allow HTTP for tailnet/local dev endpoints (e.g. canvas/background web). -->
-  <domain-config cleartextTrafficPermitted="true">
-    <domain includeSubdomains="true">openclaw.local</domain>
-  </domain-config>
-  <domain-config cleartextTrafficPermitted="true">
-    <domain includeSubdomains="true">ts.net</domain>
-  </domain-config>
+<network-security-config>
+  <!-- Release policy: deny cleartext by default. -->
+  <base-config cleartextTrafficPermitted="false" />
 </network-security-config>

--- a/apps/android/app/src/main/res/xml/network_security_config.xml
+++ b/apps/android/app/src/main/res/xml/network_security_config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-  <!-- Release policy: deny cleartext by default. -->
+  <!-- Release policy: deny cleartext by default in production builds. -->
   <base-config cleartextTrafficPermitted="false" />
 </network-security-config>

--- a/apps/android/app/src/test/java/ai/openclaw/android/NetworkSecurityPolicyTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/android/NetworkSecurityPolicyTest.kt
@@ -1,0 +1,44 @@
+package ai.openclaw.android
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NetworkSecurityPolicyTest {
+  @Test
+  fun releaseManifestDisablesGlobalCleartextTraffic() {
+    val manifest = readAppFile("src/main/AndroidManifest.xml")
+    assertTrue(manifest.contains("android:networkSecurityConfig=\"@xml/network_security_config\""))
+    assertTrue(manifest.contains("android:usesCleartextTraffic=\"false\""))
+  }
+
+  @Test
+  fun mainNetworkSecurityConfigDeniesCleartextByDefault() {
+    val config = readAppFile("src/main/res/xml/network_security_config.xml")
+    assertTrue(config.contains("<base-config cleartextTrafficPermitted=\"false\""))
+  }
+
+  @Test
+  fun debugNetworkSecurityConfigAllowsDevelopmentCleartextOverrides() {
+    val debugConfig = readAppFile("src/debug/res/xml/network_security_config.xml")
+    assertTrue(debugConfig.contains("<base-config cleartextTrafficPermitted=\"true\""))
+  }
+
+  private fun readAppFile(relativePath: String): String {
+    val candidates = listOf(
+      Paths.get(relativePath),
+      Paths.get("app", relativePath),
+      Paths.get("apps/android/app", relativePath),
+    )
+
+    val file =
+      candidates
+        .map(Path::normalize)
+        .firstOrNull(Files::exists)
+        ?: error("Unable to locate app file: $relativePath")
+
+    return Files.readString(file)
+  }
+}

--- a/apps/android/app/src/test/java/ai/openclaw/android/NetworkSecurityPolicyTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/android/NetworkSecurityPolicyTest.kt
@@ -3,6 +3,7 @@ package ai.openclaw.android
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -12,12 +13,14 @@ class NetworkSecurityPolicyTest {
     val manifest = readAppFile("src/main/AndroidManifest.xml")
     assertTrue(manifest.contains("android:networkSecurityConfig=\"@xml/network_security_config\""))
     assertTrue(manifest.contains("android:usesCleartextTraffic=\"false\""))
+    assertFalse(manifest.contains("android:usesCleartextTraffic=\"true\""))
   }
 
   @Test
   fun mainNetworkSecurityConfigDeniesCleartextByDefault() {
     val config = readAppFile("src/main/res/xml/network_security_config.xml")
     assertTrue(config.contains("<base-config cleartextTrafficPermitted=\"false\""))
+    assertFalse(config.contains("cleartextTrafficPermitted=\"true\""))
   }
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/android/NetworkSecurityPolicyTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/android/NetworkSecurityPolicyTest.kt
@@ -19,6 +19,7 @@ class NetworkSecurityPolicyTest {
   @Test
   fun mainNetworkSecurityConfigDeniesCleartextByDefault() {
     val config = readAppFile("src/main/res/xml/network_security_config.xml")
+    assertTrue(config.contains("<network-security-config"))
     assertTrue(config.contains("<base-config cleartextTrafficPermitted=\"false\""))
     assertFalse(config.contains("cleartextTrafficPermitted=\"true\""))
   }

--- a/src/security/android-network-security-config.test.ts
+++ b/src/security/android-network-security-config.test.ts
@@ -1,0 +1,29 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const REPO_ROOT = process.cwd();
+const MAIN_CONFIG_PATH = path.join(
+  REPO_ROOT,
+  "apps/android/app/src/main/res/xml/network_security_config.xml",
+);
+const DEBUG_CONFIG_PATH = path.join(
+  REPO_ROOT,
+  "apps/android/app/src/debug/res/xml/network_security_config.xml",
+);
+
+describe("android network security config", () => {
+  it("disables global cleartext traffic in main (release) config", async () => {
+    const xml = await fs.readFile(MAIN_CONFIG_PATH, "utf-8");
+
+    expect(xml.includes('cleartextTrafficPermitted="true"')).toBe(false);
+    expect(xml).toContain('<base-config cleartextTrafficPermitted="false" />');
+  });
+
+  it("keeps cleartext override scoped to debug config only", async () => {
+    const xml = await fs.readFile(DEBUG_CONFIG_PATH, "utf-8");
+
+    expect(xml).toContain('<base-config cleartextTrafficPermitted="true"');
+    expect(xml).toContain('tools:ignore="InsecureBaseConfiguration"');
+  });
+});


### PR DESCRIPTION
## Fix Summary
The Android app enables cleartext HTTP globally via `network_security_config` base policy (`cleartextTrafficPermitted="true"`). Because the production manifest applies this config, HTTP/WS traffic can be intercepted and modified on hostile adjacent networks, including credential-bearing gateway flows.

## Issue Linkage
Fixes #15950

## Security Snapshot
- CVSS v3.1: 8.3 (High)
- CVSS v4.0: 8.7 (High)

## Implementation Details
### Files Changed
- `apps/android/app/src/debug/res/xml/network_security_config.xml` (+11/-0)
- `apps/android/app/src/main/AndroidManifest.xml` (+2/-0)
- `apps/android/app/src/main/res/xml/network_security_config.xml` (+3/-10)
- `apps/android/app/src/test/java/ai/openclaw/android/NetworkSecurityPolicyTest.kt` (+48/-0)
- `src/security/android-network-security-config.test.ts` (+29/-0)

### Technical Analysis
Root cause: the Android app ships a global base config with `cleartextTrafficPermitted="true"` in `apps/android/app/src/main/res/xml/network_security_config.xml:4`, and the production manifest points to that file via `android:networkSecurityConfig` in `apps/android/app/src/main/AndroidManifest.xml`. This overrides the secure default for modern target SDKs and permits cleartext transport broadly unless explicitly constrained. Fix approach: enforce secure defaults in release (`base-config` false), isolate any cleartext exceptions to debug/dev-only variants, and add regression coverage that prevents production cleartext drift.

## Validation Evidence
- Command: `pnpm build && pnpm check && pnpm test`
- Status: passed

## Risk and Compatibility
non-breaking; no known regression impact

## AI-Assisted Disclosure
- AI-assisted: yes
- Model: GPT-5.3-Codex

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR properly fixes a high-severity security vulnerability where the Android app globally permitted cleartext HTTP traffic in production builds. The fix enforces secure defaults by setting `cleartextTrafficPermitted="false"` in the release network security config, while isolating development-only cleartext exceptions to the debug build variant. The implementation includes comprehensive regression tests in both Kotlin and TypeScript to prevent future drift. The approach correctly leverages Android's source set hierarchy where debug configs completely override main configs for debug builds.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified risks
- The security fix is well-implemented with proper separation between release and debug configurations, comprehensive test coverage prevents regressions, and the changes are focused on the specific vulnerability without introducing new attack surfaces
- No files require special attention

<sub>Last reviewed commit: 080631f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->