### PR TITLE
feat(signal): enhanced inbound handling — rich metadata, polls, edits, styles

### DIFF
--- a/docs/channels/signal.md
+++ b/docs/channels/signal.md
@@ -328,6 +328,66 @@ Related global options:
 - `messages.groupChat.mentionPatterns` (global fallback).
 - `messages.responsePrefix`.
 
+## Inbound Message Features
+
+Signal provides enhanced inbound message metadata that OpenClaw extracts and forwards to your agent.
+
+### Multi-attachment Support
+
+When a message contains multiple attachments, OpenClaw populates both singular fields (backward-compatible) and plural array fields:
+
+| Field                      | Description                              |
+| -------------------------- | ---------------------------------------- |
+| `MediaPath` / `MediaUrl`   | First attachment path (legacy)           |
+| `MediaType`                | First attachment MIME type (legacy)      |
+| `MediaPaths` / `MediaUrls` | Array of all attachment paths            |
+| `MediaTypes`               | Array of all MIME types                  |
+| `MediaCaption`             | First attachment caption                 |
+| `MediaCaptions`            | Array of all captions                    |
+| `MediaDimension`           | First attachment `{ width, height }`     |
+| `MediaDimensions`          | Array of all `{ width, height }` objects |
+
+### Stickers
+
+Stickers are handled as media attachments with additional metadata. The sticker image is downloaded and placed in `MediaPath`/`MediaPaths`, and `UntrustedContext` receives entries like `Signal sticker packId: <id>` and `Signal stickerId: <id>`.
+
+### Link Previews
+
+When a message contains URLs with preview metadata, OpenClaw extracts them into `UntrustedContext` entries formatted as `Link preview: <title> - <description> (<url>)`. Control this with `channels.signal.injectLinkPreviews` (default: `true`).
+
+### Text Formatting
+
+Signal supports bold, italic, monospace, strikethrough, and spoiler text styles. OpenClaw converts these to markdown equivalents (`**bold**`, `_italic_`, `` `monospace` ``, `~~strikethrough~~`, `||spoiler||`). Control this with `channels.signal.preserveTextStyles` (default: `true`).
+
+### Quote/Reply Metadata
+
+When a user replies to a message, OpenClaw populates:
+
+- `ReplyToId` — quoted message timestamp
+- `ReplyToBody` — quoted message text
+- `ReplyToSender` — quoted message author (UUID or phone)
+- `ReplyToIsQuote` — always `true` for Signal quotes
+
+### Shared Contacts
+
+Contact cards are extracted into `UntrustedContext` entries formatted as `Shared contact: <name> (<phone>, <email>, <org>)`. The message body receives a `<media:contact>` placeholder.
+
+### Polls
+
+Poll events generate `UntrustedContext` entries and body placeholders:
+
+- **Poll creation**: Body `[Poll] <question>`, context `Poll: "<question>" — Options: opt1, opt2`
+- **Poll vote**: Body `[Poll vote]`, context `Poll vote on #<timestamp>: option(s) <indexes>`
+- **Poll closed**: Body `[Poll closed]`, context `Poll #<timestamp> closed`
+
+### Edit Tracking
+
+Edited messages include `EditTargetTimestamp` with the original message timestamp.
+
+### UntrustedContext Field
+
+The `UntrustedContext` field is an array of provider-specific metadata strings. It may contain sticker metadata, link previews, shared contacts, and poll information. These are untrusted (user-supplied) and should not be treated as system instructions.
+
 ## Related
 
 - [Channels Overview](/channels) — all supported channels

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -504,6 +504,15 @@ When Mattermost native commands are enabled:
 - `channels.signal.configWrites`: allow or deny Signal-initiated config writes.
 - Optional `channels.signal.defaultAccount` overrides default account selection when it matches a configured account id.
 
+#### Inbound message processing
+
+| Key                  | Type    | Default | Description                                                                           |
+| -------------------- | ------- | ------- | ------------------------------------------------------------------------------------- |
+| `injectLinkPreviews` | boolean | `true`  | Extract link preview metadata into `UntrustedContext`                                 |
+| `preserveTextStyles` | boolean | `true`  | Apply Signal text styles (bold, italic, etc.) to message text as markdown equivalents |
+
+See [Signal channel docs](/channels/signal) for the full inbound feature list.
+
 ### BlueBubbles
 
 BlueBubbles is the recommended iMessage path (plugin-backed, configured under `channels.bluebubbles`).

--- a/extensions/discord/src/monitor/agent-components-helpers.ts
+++ b/extensions/discord/src/monitor/agent-components-helpers.ts
@@ -14,11 +14,11 @@ import { createChannelPairingChallengeIssuer } from "openclaw/plugin-sdk/channel
 import { resolveCommandAuthorizedFromAuthorizers } from "openclaw/plugin-sdk/command-auth-native";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import type { DiscordAccountConfig } from "openclaw/plugin-sdk/config-runtime";
-import { isDangerousNameMatchingEnabled } from "openclaw/plugin-sdk/dangerous-name-runtime";
-import { resolveOpenProviderRuntimeGroupPolicy } from "openclaw/plugin-sdk/runtime-group-policy";
 import * as conversationRuntime from "openclaw/plugin-sdk/conversation-runtime";
+import { isDangerousNameMatchingEnabled } from "openclaw/plugin-sdk/dangerous-name-runtime";
 import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
+import { resolveOpenProviderRuntimeGroupPolicy } from "openclaw/plugin-sdk/runtime-group-policy";
 import * as securityRuntime from "openclaw/plugin-sdk/security-runtime";
 import { logError } from "openclaw/plugin-sdk/text-runtime";
 import {

--- a/extensions/discord/src/monitor/agent-components.ts
+++ b/extensions/discord/src/monitor/agent-components.ts
@@ -25,23 +25,21 @@ import {
 } from "openclaw/plugin-sdk/channel-inbound";
 import { enqueueSystemEvent } from "openclaw/plugin-sdk/channel-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import type { DiscordAccountConfig } from "openclaw/plugin-sdk/config-runtime";
 import { isDangerousNameMatchingEnabled } from "openclaw/plugin-sdk/dangerous-name-runtime";
 import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
-import { resolveOpenProviderRuntimeGroupPolicy } from "openclaw/plugin-sdk/runtime-group-policy";
-import { readSessionUpdatedAt, resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
-import type { DiscordAccountConfig } from "openclaw/plugin-sdk/config-runtime";
 import { getAgentScopedMediaLocalRoots } from "openclaw/plugin-sdk/media-runtime";
-import {
-  type PluginInteractiveDiscordHandlerContext,
-} from "openclaw/plugin-sdk/plugin-runtime";
+import { type PluginInteractiveDiscordHandlerContext } from "openclaw/plugin-sdk/plugin-runtime";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { createNonExitingRuntime, type RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import { resolveOpenProviderRuntimeGroupPolicy } from "openclaw/plugin-sdk/runtime-group-policy";
+import { readSessionUpdatedAt, resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import { logDebug, logError } from "openclaw/plugin-sdk/text-runtime";
+import { resolveDiscordMaxLinesPerMessage } from "../accounts.js";
 import {
   parseDiscordComponentCustomIdForCarbon,
   parseDiscordModalCustomIdForCarbon,
 } from "../component-custom-id.js";
-import { resolveDiscordMaxLinesPerMessage } from "../accounts.js";
 import { resolveDiscordComponentEntry, resolveDiscordModalEntry } from "../components-registry.js";
 import type { DiscordComponentEntry, DiscordModalEntry } from "../components.js";
 import {
@@ -901,7 +899,9 @@ async function handleDiscordModalTrigger(params: {
   }
 
   try {
-    await params.interaction.showModal((await loadComponentsRuntime()).createDiscordFormModal(modalEntry));
+    await params.interaction.showModal(
+      (await loadComponentsRuntime()).createDiscordFormModal(modalEntry),
+    );
   } catch (err) {
     logError(`${params.label}: failed to show modal: ${String(err)}`);
   }

--- a/extensions/discord/src/monitor/message-handler.preflight.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.ts
@@ -289,8 +289,9 @@ export async function preflightDiscordMessage(
   const pluralkitConfig = params.discordConfig?.pluralkit;
   const webhookId = resolveDiscordWebhookId(message);
   const shouldCheckPluralKit = Boolean(pluralkitConfig?.enabled) && !webhookId;
-  let pluralkitInfo: Awaited<ReturnType<typeof import("../pluralkit.js").fetchPluralKitMessageInfo>> =
-    null;
+  let pluralkitInfo: Awaited<
+    ReturnType<typeof import("../pluralkit.js").fetchPluralKitMessageInfo>
+  > = null;
   if (shouldCheckPluralKit) {
     try {
       const { fetchPluralKitMessageInfo } = await loadPluralKitRuntime();

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -20,13 +20,13 @@ import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/config-runtime";
 import { readSessionUpdatedAt, resolveStorePath } from "openclaw/plugin-sdk/config-runtime";
 import { recordInboundSession } from "openclaw/plugin-sdk/conversation-runtime";
 import { getAgentScopedMediaLocalRoots } from "openclaw/plugin-sdk/media-runtime";
+import { resolveChunkMode } from "openclaw/plugin-sdk/reply-chunking";
+import { finalizeInboundContext } from "openclaw/plugin-sdk/reply-dispatch-runtime";
 import {
   buildPendingHistoryContextFromMap,
   clearHistoryEntriesIfEnabled,
 } from "openclaw/plugin-sdk/reply-history";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
-import { resolveChunkMode } from "openclaw/plugin-sdk/reply-chunking";
-import { finalizeInboundContext } from "openclaw/plugin-sdk/reply-dispatch-runtime";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { buildAgentSessionKey } from "openclaw/plugin-sdk/routing";
 import { resolveThreadSessionKeys } from "openclaw/plugin-sdk/routing";

--- a/extensions/discord/src/monitor/native-command.ts
+++ b/extensions/discord/src/monitor/native-command.ts
@@ -17,6 +17,10 @@ import {
   resolveCommandAuthorizedFromAuthorizers,
   resolveNativeCommandSessionTargets,
 } from "openclaw/plugin-sdk/command-auth-native";
+import type { OpenClawConfig, loadConfig } from "openclaw/plugin-sdk/config-runtime";
+import { buildPairingReply } from "openclaw/plugin-sdk/conversation-runtime";
+import { isDangerousNameMatchingEnabled } from "openclaw/plugin-sdk/dangerous-name-runtime";
+import { getAgentScopedMediaLocalRoots } from "openclaw/plugin-sdk/media-runtime";
 import {
   buildCommandTextFromArgs,
   findCommandByNativeName,
@@ -31,11 +35,6 @@ import {
   type CommandArgs,
   type NativeCommandSpec,
 } from "openclaw/plugin-sdk/native-command-registry";
-import type { OpenClawConfig, loadConfig } from "openclaw/plugin-sdk/config-runtime";
-import { isDangerousNameMatchingEnabled } from "openclaw/plugin-sdk/dangerous-name-runtime";
-import { resolveOpenProviderRuntimeGroupPolicy } from "openclaw/plugin-sdk/runtime-group-policy";
-import { buildPairingReply } from "openclaw/plugin-sdk/conversation-runtime";
-import { getAgentScopedMediaLocalRoots } from "openclaw/plugin-sdk/media-runtime";
 import * as pluginRuntime from "openclaw/plugin-sdk/plugin-runtime";
 import {
   resolveSendableOutboundReplyParts,
@@ -46,6 +45,7 @@ import { resolveChunkMode, resolveTextChunkLimit } from "openclaw/plugin-sdk/rep
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
+import { resolveOpenProviderRuntimeGroupPolicy } from "openclaw/plugin-sdk/runtime-group-policy";
 import { loadWebMedia } from "openclaw/plugin-sdk/web-media";
 import { resolveDiscordMaxLinesPerMessage } from "../accounts.js";
 import { chunkDiscordTextWithMode } from "../chunk.js";

--- a/extensions/discord/src/monitor/provider.ts
+++ b/extensions/discord/src/monitor/provider.ts
@@ -20,12 +20,6 @@ import {
 } from "openclaw/plugin-sdk/config-runtime";
 import type { OpenClawConfig, ReplyToMode } from "openclaw/plugin-sdk/config-runtime";
 import { loadConfig } from "openclaw/plugin-sdk/config-runtime";
-import {
-  GROUP_POLICY_BLOCKED_LABEL,
-  resolveOpenProviderRuntimeGroupPolicy,
-  resolveDefaultGroupPolicy,
-  warnMissingProviderGroupPolicyFallbackOnce,
-} from "openclaw/plugin-sdk/runtime-group-policy";
 import { createConnectedChannelStatusPatch } from "openclaw/plugin-sdk/gateway-runtime";
 import { getPluginCommandSpecs } from "openclaw/plugin-sdk/plugin-runtime";
 import { resolveTextChunkLimit } from "openclaw/plugin-sdk/reply-runtime";
@@ -38,6 +32,12 @@ import {
 } from "openclaw/plugin-sdk/runtime-env";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { createNonExitingRuntime, type RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import {
+  GROUP_POLICY_BLOCKED_LABEL,
+  resolveOpenProviderRuntimeGroupPolicy,
+  resolveDefaultGroupPolicy,
+  warnMissingProviderGroupPolicyFallbackOnce,
+} from "openclaw/plugin-sdk/runtime-group-policy";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import { summarizeStringEntries } from "openclaw/plugin-sdk/text-runtime";
 import { resolveDiscordAccount } from "../accounts.js";

--- a/extensions/line/src/bot-message-context.ts
+++ b/extensions/line/src/bot-message-context.ts
@@ -14,8 +14,8 @@ import {
   resolvePinnedMainDmOwnerFromAllowlist,
   resolveConfiguredBindingRoute,
 } from "openclaw/plugin-sdk/conversation-runtime";
-import type { HistoryEntry } from "openclaw/plugin-sdk/reply-history";
 import { finalizeInboundContext } from "openclaw/plugin-sdk/reply-dispatch-runtime";
+import type { HistoryEntry } from "openclaw/plugin-sdk/reply-history";
 import {
   deriveLastRoutePolicy,
   resolveAgentIdFromSessionKey,

--- a/extensions/signal/src/monitor.ts
+++ b/extensions/signal/src/monitor.ts
@@ -380,6 +380,8 @@ export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promi
   const mediaMaxBytes = (opts.mediaMaxMb ?? accountInfo.config.mediaMaxMb ?? 8) * 1024 * 1024;
   const ignoreAttachments = opts.ignoreAttachments ?? accountInfo.config.ignoreAttachments ?? false;
   const sendReadReceipts = Boolean(opts.sendReadReceipts ?? accountInfo.config.sendReadReceipts);
+  const injectLinkPreviews = accountInfo.config.injectLinkPreviews !== false;
+  const preserveTextStyles = accountInfo.config.preserveTextStyles !== false;
   const waitForTransportReadyFn = opts.waitForTransportReady ?? waitForTransportReady;
 
   const autoStart = opts.autoStart ?? accountInfo.config.autoStart ?? !accountInfo.config.httpUrl;
@@ -452,6 +454,8 @@ export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promi
       ignoreAttachments,
       sendReadReceipts,
       readReceiptsViaDaemon,
+      injectLinkPreviews,
+      preserveTextStyles,
       fetchAttachment,
       deliverReplies: (params) => deliverReplies({ ...params, chunkMode }),
       resolveSignalReactionTargets,

--- a/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
+++ b/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
@@ -1,8 +1,11 @@
 import type { MsgContext } from "openclaw/plugin-sdk/reply-runtime";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SignalEventHandlerDeps, SignalReactionMessage } from "./event-handler.types.js";
+
 let expectInboundContextContract: typeof import("openclaw/plugin-sdk/testing").expectChannelInboundContextContract;
 let createBaseSignalEventHandlerDeps: typeof import("./event-handler.test-harness.js").createBaseSignalEventHandlerDeps;
 let createSignalReceiveEvent: typeof import("./event-handler.test-harness.js").createSignalReceiveEvent;
+let capturedCtxs: MsgContext[] = [];
 
 const { sendTypingMock, sendReadReceiptMock, dispatchInboundMessageMock, capture } = vi.hoisted(
   () => {
@@ -16,6 +19,7 @@ const { sendTypingMock, sendReadReceiptMock, dispatchInboundMessageMock, capture
           replyOptions?: { onReplyStart?: () => void | Promise<void> };
         }) => {
           captureState.ctx = params.ctx;
+          capturedCtxs.push(params.ctx);
           await Promise.resolve(params.replyOptions?.onReplyStart?.());
           return { queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } };
         },
@@ -48,18 +52,80 @@ vi.mock("../../../../src/pairing/pairing-store.js", () => ({
 
 let createSignalEventHandler: typeof import("./event-handler.js").createSignalEventHandler;
 
+async function loadSignalEventHandlerModules() {
+  ({ expectChannelInboundContextContract: expectInboundContextContract } =
+    await import("openclaw/plugin-sdk/testing"));
+  ({ createBaseSignalEventHandlerDeps, createSignalReceiveEvent } =
+    await import("./event-handler.test-harness.js"));
+  ({ createSignalEventHandler } = await import("./event-handler.js"));
+}
+
+function createTestHandler(overrides: Partial<SignalEventHandlerDeps> = {}) {
+  return createSignalEventHandler({
+    // oxlint-disable-next-line typescript/no-explicit-any
+    runtime: { log: () => {}, error: () => {} } as any,
+    // oxlint-disable-next-line typescript/no-explicit-any
+    cfg: { messages: { inbound: { debounceMs: 0 } } } as any,
+    baseUrl: "http://localhost",
+    accountId: "default",
+    historyLimit: 0,
+    groupHistories: new Map(),
+    textLimit: 4000,
+    dmPolicy: "open",
+    allowFrom: ["*"],
+    groupAllowFrom: ["*"],
+    groupPolicy: "open",
+    reactionMode: "off",
+    reactionAllowlist: [],
+    mediaMaxBytes: 1024,
+    ignoreAttachments: true,
+    sendReadReceipts: false,
+    readReceiptsViaDaemon: false,
+    injectLinkPreviews: true,
+    preserveTextStyles: true,
+    fetchAttachment: async () => null,
+    deliverReplies: async () => {},
+    resolveSignalReactionTargets: () => [],
+    isSignalReactionMessage: (
+      _reaction: SignalReactionMessage | null | undefined,
+    ): _reaction is SignalReactionMessage => false,
+    shouldEmitSignalReactionNotification: () => false,
+    buildSignalReactionSystemEventText: () => "reaction",
+    ...overrides,
+  });
+}
+
+function makeReceiveEvent(
+  dataMessage: Record<string, unknown>,
+  envelope: Record<string, unknown> = {},
+) {
+  return {
+    event: "receive",
+    data: JSON.stringify({
+      envelope: {
+        sourceNumber: "+15550001111",
+        sourceName: "Alice",
+        timestamp: 1700000000000,
+        dataMessage: {
+          message: "",
+          attachments: [],
+          ...dataMessage,
+        },
+        ...envelope,
+      },
+    }),
+  };
+}
+
 describe("signal createSignalEventHandler inbound context", () => {
   beforeAll(async () => {
     vi.useRealTimers();
-    ({ expectChannelInboundContextContract: expectInboundContextContract } =
-      await import("openclaw/plugin-sdk/testing"));
-    ({ createBaseSignalEventHandlerDeps, createSignalReceiveEvent } =
-      await import("./event-handler.test-harness.js"));
-    ({ createSignalEventHandler } = await import("./event-handler.js"));
+    await loadSignalEventHandlerModules();
   });
 
   beforeEach(() => {
     capture.ctx = undefined;
+    capturedCtxs = [];
     sendTypingMock.mockReset().mockResolvedValue(true);
     sendReadReceiptMock.mockReset().mockResolvedValue(true);
     dispatchInboundMessageMock.mockClear();
@@ -266,5 +332,735 @@ describe("signal createSignalEventHandler inbound context", () => {
 
     expect(capture.ctx).toBeUndefined();
     expect(dispatchInboundMessageMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("signal enhanced inbound contract coverage", () => {
+  beforeAll(async () => {
+    vi.useRealTimers();
+    await loadSignalEventHandlerModules();
+  });
+
+  beforeEach(() => {
+    capture.ctx = undefined;
+    capturedCtxs = [];
+    sendTypingMock.mockReset().mockResolvedValue(true);
+    sendReadReceiptMock.mockReset().mockResolvedValue(true);
+    dispatchInboundMessageMock.mockClear();
+  });
+
+  it("maps all attachments to plural media fields and preserves first-item aliases", async () => {
+    const fetchAttachment = vi.fn(async (params: { attachment?: { id?: string | null } }) => {
+      const id = params.attachment?.id;
+      if (id === "att-1") {
+        return { path: "/tmp/signal-att-1.jpg", contentType: "image/jpeg" };
+      }
+      if (id === "att-2") {
+        return { path: "/tmp/signal-att-2.png", contentType: "image/png" };
+      }
+      return null;
+    });
+
+    const handler = createTestHandler({
+      ignoreAttachments: false,
+      fetchAttachment,
+    });
+
+    await handler(
+      makeReceiveEvent({
+        attachments: [
+          { id: "att-1", contentType: "image/jpeg" },
+          { id: "att-2", contentType: "image/png" },
+        ],
+      }),
+    );
+
+    expect(capture.ctx).toBeTruthy();
+    expectInboundContextContract(capture.ctx!);
+    expect(fetchAttachment).toHaveBeenCalledTimes(2);
+    expect(capture.ctx?.MediaPath).toBe("/tmp/signal-att-1.jpg");
+    expect(capture.ctx?.MediaType).toBe("image/jpeg");
+    expect(capture.ctx?.MediaUrl).toBe("/tmp/signal-att-1.jpg");
+    expect(capture.ctx?.MediaPaths).toEqual(["/tmp/signal-att-1.jpg", "/tmp/signal-att-2.png"]);
+    expect(capture.ctx?.MediaUrls).toEqual(["/tmp/signal-att-1.jpg", "/tmp/signal-att-2.png"]);
+    expect(capture.ctx?.MediaTypes).toEqual(["image/jpeg", "image/png"]);
+  });
+
+  it("keeps media type array aligned with media paths when content type is missing", async () => {
+    const fetchAttachment = vi.fn(async (params: { attachment?: { id?: string | null } }) => {
+      const id = params.attachment?.id;
+      if (id === "att-1") {
+        return { path: "/tmp/signal-att-1.bin" };
+      }
+      if (id === "att-2") {
+        return { path: "/tmp/signal-att-2.png", contentType: "image/png" };
+      }
+      return null;
+    });
+
+    const handler = createTestHandler({
+      ignoreAttachments: false,
+      fetchAttachment,
+    });
+
+    await handler(
+      makeReceiveEvent({
+        attachments: [{ id: "att-1" }, { id: "att-2", contentType: "image/png" }],
+      }),
+    );
+
+    expect(capture.ctx).toBeTruthy();
+    expect(capture.ctx?.MediaPaths).toEqual(["/tmp/signal-att-1.bin", "/tmp/signal-att-2.png"]);
+    expect(capture.ctx?.MediaTypes).toEqual(["application/octet-stream", "image/png"]);
+    expect(capture.ctx?.MediaType).toBe("application/octet-stream");
+  });
+
+  it("keeps successful attachments when one attachment fetch fails", async () => {
+    const fetchAttachment = vi.fn(async (params: { attachment?: { id?: string | null } }) => {
+      const id = params.attachment?.id;
+      if (id === "att-1") {
+        throw new Error("network timeout");
+      }
+      if (id === "att-2") {
+        return { path: "/tmp/signal-att-2.png", contentType: "image/png" };
+      }
+      return null;
+    });
+
+    const handler = createTestHandler({
+      ignoreAttachments: false,
+      fetchAttachment,
+    });
+
+    await handler(
+      makeReceiveEvent({
+        attachments: [
+          { id: "att-1", contentType: "image/jpeg" },
+          { id: "att-2", contentType: "image/png" },
+        ],
+      }),
+    );
+
+    expect(capture.ctx).toBeTruthy();
+    expect(fetchAttachment).toHaveBeenCalledTimes(2);
+    expect(capture.ctx?.MediaPaths).toEqual(["/tmp/signal-att-2.png"]);
+    expect(capture.ctx?.MediaPath).toBe("/tmp/signal-att-2.png");
+    expect(capture.ctx?.MediaType).toBe("image/png");
+  });
+
+  it("maps quote metadata to reply context fields", async () => {
+    const handler = createTestHandler();
+
+    await handler(
+      makeReceiveEvent({
+        message: "reply with quote",
+        quote: {
+          id: 9001,
+          text: "original message",
+          authorUuid: "123e4567-e89b-12d3-a456-426614174000",
+        },
+      }),
+    );
+
+    expect(capture.ctx).toBeTruthy();
+    expectInboundContextContract(capture.ctx!);
+    expect(capture.ctx?.ReplyToId).toBe("9001");
+    expect(capture.ctx?.ReplyToSender).toBe("123e4567-e89b-12d3-a456-426614174000");
+    expect(capture.ctx?.ReplyToBody).toBe("original message");
+    expect(capture.ctx?.ReplyToIsQuote).toBe(true);
+  });
+
+  it("falls back quote reply metadata to timestamp and author number", async () => {
+    const handler = createTestHandler();
+
+    await handler(
+      makeReceiveEvent({
+        message: "reply with quote",
+        quote: {
+          timestamp: 1700000000111,
+          text: "fallback author message",
+          authorNumber: "+15550002222",
+          author: "fallback",
+        },
+      }),
+    );
+
+    expect(capture.ctx).toBeTruthy();
+    expectInboundContextContract(capture.ctx!);
+    expect(capture.ctx?.ReplyToId).toBe("1700000000111");
+    expect(capture.ctx?.ReplyToSender).toBe("+15550002222");
+    expect(capture.ctx?.ReplyToBody).toBe("fallback author message");
+    expect(capture.ctx?.ReplyToIsQuote).toBe(true);
+  });
+
+  it("sets reply body to undefined when quoted text is missing", async () => {
+    const handler = createTestHandler();
+
+    await handler(
+      makeReceiveEvent({
+        message: "reply with empty quote",
+        quote: {
+          id: 9002,
+          text: "   ",
+          authorUuid: "123e4567-e89b-12d3-a456-426614174001",
+        },
+      }),
+    );
+
+    expect(capture.ctx).toBeTruthy();
+    expect(capture.ctx?.ReplyToId).toBe("9002");
+    expect(capture.ctx?.ReplyToSender).toBe("123e4567-e89b-12d3-a456-426614174001");
+    expect(capture.ctx?.ReplyToBody).toBeUndefined();
+    expect(capture.ctx?.ReplyToIsQuote).toBe(true);
+  });
+
+  it("clears quote metadata but preserves untrusted context when debounced entries are merged", async () => {
+    const handler = createTestHandler({
+      // oxlint-disable-next-line typescript/no-explicit-any
+      cfg: { messages: { inbound: { debounceMs: 50 } } } as any,
+    });
+
+    await handler(makeReceiveEvent({ message: "first message" }));
+    await handler(
+      makeReceiveEvent({
+        message: "second message",
+        quote: { id: 42, text: "quoted" },
+        previews: [{ url: "https://example.com", title: "Example", description: "Desc" }],
+      }),
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 90));
+
+    expect(capturedCtxs).toHaveLength(1);
+    expect(capture.ctx?.BodyForCommands).toBe("first message\nsecond message");
+    expect(capture.ctx?.ReplyToId).toBeUndefined();
+    expect(capture.ctx?.ReplyToBody).toBeUndefined();
+    expect(capture.ctx?.ReplyToSender).toBeUndefined();
+    expect(capture.ctx?.ReplyToIsQuote).toBeUndefined();
+    // Untrusted context is merged from all entries (link preview from second message survives)
+    expect(capture.ctx?.UntrustedContext).toBeDefined();
+    expect(capture.ctx?.UntrustedContext).toContain(
+      "Link preview: Example - Desc (https://example.com)",
+    );
+  });
+
+  it("merges untrusted context from multiple debounced poll vote entries", async () => {
+    const handler = createTestHandler({
+      // oxlint-disable-next-line typescript/no-explicit-any
+      cfg: { messages: { inbound: { debounceMs: 50 } } } as any,
+    });
+
+    await handler(
+      makeReceiveEvent({
+        pollVote: {
+          authorNumber: "+15551234567",
+          targetSentTimestamp: 1234567890,
+          optionIndexes: [0],
+          voteCount: 1,
+        },
+      }),
+    );
+    await handler(
+      makeReceiveEvent({
+        pollVote: {
+          authorNumber: "+15551234567",
+          targetSentTimestamp: 1234567890,
+          optionIndexes: [0, 2],
+          voteCount: 1,
+        },
+      }),
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 90));
+
+    expect(capturedCtxs).toHaveLength(1);
+    expect(capture.ctx?.BodyForCommands).toBe("[Poll vote]\n[Poll vote]");
+    // Both poll vote contexts should survive the merge
+    expect(capture.ctx?.UntrustedContext).toBeDefined();
+    expect(capture.ctx?.UntrustedContext).toContain("Poll vote on #1234567890: option(s) 0");
+    expect(capture.ctx?.UntrustedContext).toContain("Poll vote on #1234567890: option(s) 0, 2");
+  });
+
+  it("handles sticker messages with sticker placeholder, downloaded media, and metadata", async () => {
+    const fetchAttachment = vi.fn(async (params: { attachment?: { id?: string | null } }) => {
+      const id = params.attachment?.id;
+      if (id === "sticker-att-1") {
+        return { path: "/tmp/signal-sticker-1.webp", contentType: "image/webp" };
+      }
+      return null;
+    });
+
+    const handler = createTestHandler({
+      ignoreAttachments: false,
+      fetchAttachment,
+    });
+
+    await handler(
+      makeReceiveEvent({
+        sticker: {
+          packId: "signal-pack-1",
+          stickerId: 42,
+          attachment: {
+            id: "sticker-att-1",
+            contentType: "image/webp",
+          },
+        },
+      }),
+    );
+
+    expect(capture.ctx).toBeTruthy();
+    expectInboundContextContract(capture.ctx!);
+    expect(fetchAttachment).toHaveBeenCalledTimes(1);
+    expect(capture.ctx?.BodyForCommands).toBe("<media:sticker>");
+    expect(capture.ctx?.MediaPath).toBe("/tmp/signal-sticker-1.webp");
+    expect(capture.ctx?.MediaType).toBe("image/webp");
+    expect(capture.ctx?.MediaUrl).toBe("/tmp/signal-sticker-1.webp");
+    expect(capture.ctx?.MediaPaths).toEqual(["/tmp/signal-sticker-1.webp"]);
+    expect(capture.ctx?.MediaUrls).toEqual(["/tmp/signal-sticker-1.webp"]);
+    expect(capture.ctx?.MediaTypes).toEqual(["image/webp"]);
+    expect(capture.ctx?.UntrustedContext).toContain("Signal sticker packId: signal-pack-1");
+    expect(capture.ctx?.UntrustedContext).toContain("Signal stickerId: 42");
+  });
+
+  it("passes attachment dimensions into media context fields", async () => {
+    const fetchAttachment = vi.fn(async (params: { attachment?: { id?: string | null } }) => {
+      if (params.attachment?.id === "img-att-1") {
+        return { path: "/tmp/signal-img-1.jpg", contentType: "image/jpeg" };
+      }
+      if (params.attachment?.id === "img-att-2") {
+        return { path: "/tmp/signal-img-2.png", contentType: "image/png" };
+      }
+      return null;
+    });
+
+    const handler = createTestHandler({
+      ignoreAttachments: false,
+      fetchAttachment,
+    });
+
+    await handler(
+      makeReceiveEvent({
+        attachments: [
+          {
+            id: "img-att-1",
+            contentType: "image/jpeg",
+            width: 4000,
+            height: 3000,
+          },
+          {
+            id: "img-att-2",
+            contentType: "image/png",
+            width: 1920,
+            height: 1080,
+          },
+        ],
+      }),
+    );
+
+    expect(capture.ctx).toBeTruthy();
+    expectInboundContextContract(capture.ctx!);
+    expect(capture.ctx?.MediaDimension).toEqual({ width: 4000, height: 3000 });
+    expect(capture.ctx?.MediaDimensions).toEqual([
+      { width: 4000, height: 3000 },
+      { width: 1920, height: 1080 },
+    ]);
+  });
+
+  it("threads attachment captions into media caption context fields", async () => {
+    const fetchAttachment = vi.fn(async (params: { attachment?: { id?: string | null } }) => {
+      if (params.attachment?.id === "img-cap-1") {
+        return { path: "/tmp/signal-cap-1.jpg", contentType: "image/jpeg" };
+      }
+      if (params.attachment?.id === "img-cap-2") {
+        return { path: "/tmp/signal-cap-2.png", contentType: "image/png" };
+      }
+      return null;
+    });
+
+    const handler = createTestHandler({
+      ignoreAttachments: false,
+      fetchAttachment,
+    });
+
+    await handler(
+      makeReceiveEvent({
+        attachments: [
+          {
+            id: "img-cap-1",
+            contentType: "image/jpeg",
+            caption: "sunset",
+          },
+          {
+            id: "img-cap-2",
+            contentType: "image/png",
+            caption: "mountain",
+          },
+        ],
+      }),
+    );
+
+    const ctx = capture.ctx as MsgContext & {
+      MediaCaption?: string;
+      MediaCaptions?: string[];
+    };
+    expect(ctx).toBeTruthy();
+    expect(ctx.MediaCaption).toBe("sunset");
+    expect(ctx.MediaCaptions).toEqual(["sunset", "mountain"]);
+  });
+
+  it("tracks edit target timestamp for edited messages", async () => {
+    const handler = createTestHandler();
+
+    await handler({
+      event: "receive",
+      data: JSON.stringify({
+        envelope: {
+          sourceNumber: "+15550001111",
+          sourceName: "Alice",
+          timestamp: 1700000000999,
+          editMessage: {
+            targetSentTimestamp: 1700000000111,
+            dataMessage: {
+              message: "edited text",
+              attachments: [],
+            },
+          },
+        },
+      }),
+    });
+
+    const ctx = capture.ctx as MsgContext & {
+      EditTargetTimestamp?: number;
+    };
+    expect(ctx).toBeTruthy();
+    expect(ctx.EditTargetTimestamp).toBe(1700000000111);
+    expect(ctx.BodyForCommands).toBe("edited text");
+  });
+
+  it("adds link preview metadata to untrusted context", async () => {
+    const handler = createTestHandler();
+
+    await handler(
+      makeReceiveEvent({
+        message: "check this",
+        previews: [
+          {
+            url: "https://example.com/post",
+            title: "Example Post",
+            description: "A useful summary",
+          },
+        ],
+      }),
+    );
+
+    expect(capture.ctx).toBeTruthy();
+    expect(capture.ctx?.UntrustedContext).toContain(
+      "Link preview: Example Post - A useful summary (https://example.com/post)",
+    );
+  });
+
+  it("formats signal text styles into markdown in the message body", async () => {
+    const handler = createTestHandler();
+
+    await handler(
+      makeReceiveEvent({
+        message: "hello world",
+        textStyles: [
+          { style: "BOLD", start: 0, length: 5 },
+          { style: "ITALIC", start: 6, length: 5 },
+        ],
+      }),
+    );
+
+    expect(capture.ctx).toBeTruthy();
+    expect(capture.ctx?.BodyForCommands).toBe("**hello** _world_");
+  });
+
+  it("skips link preview injection when injectLinkPreviews is false", async () => {
+    const handler = createTestHandler({
+      injectLinkPreviews: false,
+    });
+
+    await handler(
+      makeReceiveEvent({
+        message: "check this",
+        previews: [
+          {
+            url: "https://example.com/post",
+            title: "Example Post",
+            description: "A useful summary",
+          },
+        ],
+      }),
+    );
+
+    expect(capture.ctx).toBeTruthy();
+    const untrusted = capture.ctx?.UntrustedContext?.join("\n") ?? "";
+    expect(untrusted).not.toContain("Link preview");
+    expect(untrusted).not.toContain("https://example.com/post");
+  });
+
+  it("skips text style formatting when preserveTextStyles is false", async () => {
+    const handler = createTestHandler({
+      preserveTextStyles: false,
+    });
+
+    await handler(
+      makeReceiveEvent({
+        message: "hello world",
+        textStyles: [
+          { style: "BOLD", start: 0, length: 5 },
+          { style: "ITALIC", start: 6, length: 5 },
+        ],
+      }),
+    );
+
+    expect(capture.ctx).toBeTruthy();
+    expect(capture.ctx?.BodyForCommands).toBe("hello world");
+    expect(capture.ctx?.BodyForCommands).not.toContain("**");
+    expect(capture.ctx?.BodyForCommands).not.toContain("_");
+  });
+
+  it("applies text styles correctly when message contains mentions", async () => {
+    const handler = createTestHandler();
+
+    await handler(
+      makeReceiveEvent({
+        message: "\uFFFC check this out",
+        mentions: [
+          {
+            uuid: "550e8400-e29b-41d4-a716-446655440000",
+            start: 0,
+            length: 1,
+          },
+        ],
+        textStyles: [
+          { style: "BOLD", start: 2, length: 5 }, // "check" in original message
+        ],
+      }),
+    );
+
+    expect(capture.ctx).toBeTruthy();
+    expect(capture.ctx?.BodyForCommands).toContain("@550e8400-e29b-41d4-a716-446655440000");
+    expect(capture.ctx?.BodyForCommands).toContain("**check**");
+    expect(capture.ctx?.BodyForCommands).toBe(
+      "@550e8400-e29b-41d4-a716-446655440000 **check** this out",
+    );
+  });
+
+  it("keeps a style span aligned when it starts at a mention placeholder", async () => {
+    const handler = createTestHandler();
+
+    await handler(
+      makeReceiveEvent({
+        message: "\uFFFC check",
+        mentions: [
+          {
+            uuid: "550e8400-e29b-41d4-a716-446655440000",
+            start: 0,
+            length: 1,
+          },
+        ],
+        textStyles: [
+          { style: "BOLD", start: 0, length: 7 }, // entire raw message
+        ],
+      }),
+    );
+
+    expect(capture.ctx).toBeTruthy();
+    expect(capture.ctx?.BodyForCommands).toBe("**@550e8400-e29b-41d4-a716-446655440000 check**");
+  });
+
+  it("adds shared contact metadata to untrusted context and uses contact placeholder", async () => {
+    const handler = createTestHandler();
+
+    await handler(
+      makeReceiveEvent({
+        contacts: [
+          {
+            name: {
+              display: "Jane Doe",
+              given: "Jane",
+              family: "Doe",
+            },
+            phone: [{ value: "+15551234567", type: "mobile" }],
+            email: [{ value: "jane@example.com", type: "work" }],
+            organization: "Acme Corp",
+          },
+        ],
+      }),
+    );
+
+    expect(capture.ctx).toBeTruthy();
+    expect(capture.ctx?.UntrustedContext).toContain(
+      "Shared contact: Jane Doe (+15551234567, jane@example.com, Acme Corp)",
+    );
+    expect(capture.ctx?.BodyForCommands).toBe("<media:contact>");
+  });
+
+  it("includes both message text and contact context when contact has message", async () => {
+    const handler = createTestHandler();
+
+    await handler(
+      makeReceiveEvent({
+        message: "Here's John's info",
+        contacts: [
+          {
+            name: {
+              given: "John",
+              family: "Smith",
+            },
+            phone: [{ value: "+15559876543" }],
+            email: [{ value: "john@example.org" }],
+          },
+        ],
+      }),
+    );
+
+    expect(capture.ctx).toBeTruthy();
+    expect(capture.ctx?.BodyForCommands).toBe("Here's John's info");
+    expect(capture.ctx?.UntrustedContext).toContain(
+      "Shared contact: John Smith (+15559876543, john@example.org)",
+    );
+  });
+
+  it("renders poll creation with question and options", async () => {
+    const handler = createTestHandler();
+
+    await handler(
+      makeReceiveEvent({
+        pollCreate: {
+          question: "What's for lunch?",
+          allowMultiple: false,
+          options: ["Pizza", "Sushi", "Tacos"],
+        },
+      }),
+    );
+
+    expect(capture.ctx).toBeTruthy();
+    expectInboundContextContract(capture.ctx!);
+    expect(capture.ctx?.BodyForCommands).toBe("[Poll] What's for lunch?");
+    expect(capture.ctx?.UntrustedContext).toContain(
+      'Poll: "What\'s for lunch?" — Options: Pizza, Sushi, Tacos',
+    );
+  });
+
+  it("renders multi-select poll creation", async () => {
+    const handler = createTestHandler();
+
+    await handler(
+      makeReceiveEvent({
+        pollCreate: {
+          question: "Pick your favorites",
+          allowMultiple: true,
+          options: ["Coffee", "Tea", "Water"],
+        },
+      }),
+    );
+
+    expect(capture.ctx).toBeTruthy();
+    expectInboundContextContract(capture.ctx!);
+    expect(capture.ctx?.BodyForCommands).toBe("[Poll] Pick your favorites");
+    expect(capture.ctx?.UntrustedContext).toContain(
+      'Poll: "Pick your favorites" — Options: Coffee, Tea, Water (multiple selections allowed)',
+    );
+  });
+
+  it("renders poll vote with option indexes", async () => {
+    const handler = createTestHandler();
+
+    await handler(
+      makeReceiveEvent({
+        pollVote: {
+          authorNumber: "+15551234567",
+          targetSentTimestamp: 1234567890,
+          optionIndexes: [1, 3],
+          voteCount: 2,
+        },
+      }),
+    );
+
+    expect(capture.ctx).toBeTruthy();
+    expectInboundContextContract(capture.ctx!);
+    expect(capture.ctx?.BodyForCommands).toBe("[Poll vote]");
+    expect(capture.ctx?.UntrustedContext).toContain("Poll vote on #1234567890: option(s) 1, 3");
+  });
+
+  it("renders poll termination", async () => {
+    const handler = createTestHandler();
+
+    await handler(
+      makeReceiveEvent({
+        pollTerminate: {
+          targetSentTimestamp: 1234567890,
+        },
+      }),
+    );
+
+    expect(capture.ctx).toBeTruthy();
+    expectInboundContextContract(capture.ctx!);
+    expect(capture.ctx?.BodyForCommands).toBe("[Poll closed]");
+    expect(capture.ctx?.UntrustedContext).toContain("Poll #1234567890 closed");
+  });
+
+  it("uses Untitled placeholder for null question with empty options", async () => {
+    const handler = createTestHandler();
+
+    await handler(
+      makeReceiveEvent({
+        pollCreate: {
+          question: null,
+          allowMultiple: false,
+          options: [],
+        },
+      }),
+    );
+
+    expect(capture.ctx).toBeTruthy();
+    expectInboundContextContract(capture.ctx!);
+    expect(capture.ctx?.BodyForCommands).toBe("[Poll] Untitled");
+    expect(capture.ctx?.UntrustedContext).toContain('Poll: "Untitled"');
+  });
+
+  it("does not include poll creator author fields in poll vote context", async () => {
+    const handler = createTestHandler();
+
+    await handler(
+      makeReceiveEvent({
+        pollVote: {
+          authorNumber: null,
+          authorUuid: "abc-123-uuid",
+          targetSentTimestamp: 1234567890,
+          optionIndexes: [0, 2],
+          voteCount: 2,
+        },
+      }),
+    );
+
+    expect(capture.ctx).toBeTruthy();
+    expectInboundContextContract(capture.ctx!);
+    expect(capture.ctx?.BodyForCommands).toBe("[Poll vote]");
+    expect(capture.ctx?.UntrustedContext).toContain("Poll vote on #1234567890: option(s) 0, 2");
+    expect(capture.ctx?.UntrustedContext).not.toContain("abc-123-uuid");
+  });
+
+  it("preserves message body when poll is present", async () => {
+    const handler = createTestHandler();
+
+    await handler(
+      makeReceiveEvent({
+        message: "Check out this poll",
+        pollCreate: {
+          question: "Lunch?",
+          allowMultiple: false,
+          options: ["Pizza", "Sushi"],
+        },
+      }),
+    );
+
+    expect(capture.ctx).toBeTruthy();
+    expectInboundContextContract(capture.ctx!);
+    expect(capture.ctx?.BodyForCommands).toBe("Check out this poll");
+    expect(capture.ctx?.UntrustedContext).toContain('Poll: "Lunch?" — Options: Pizza, Sushi');
   });
 });

--- a/extensions/signal/src/monitor/event-handler.mention-gating.test.ts
+++ b/extensions/signal/src/monitor/event-handler.mention-gating.test.ts
@@ -36,6 +36,11 @@ type GroupEventOpts = {
     start?: number;
     length?: number;
   }> | null;
+  textStyles?: Array<{
+    style: string;
+    start: number;
+    length: number;
+  }>;
 };
 
 function makeGroupEvent(opts: GroupEventOpts) {
@@ -45,6 +50,7 @@ function makeGroupEvent(opts: GroupEventOpts) {
       attachments: opts.attachments ?? [],
       quote: opts.quoteText ? { text: opts.quoteText } : undefined,
       mentions: opts.mentions ?? undefined,
+      textStyles: opts.textStyles ?? undefined,
       groupInfo: { groupId: "g1", groupName: "Test Group" },
     },
   });
@@ -86,6 +92,15 @@ function createSignalConfig(params: { requireMention: boolean; mentionPattern?: 
       },
     },
   } as unknown as OpenClawConfig;
+}
+
+function createGroupHandler() {
+  capturedCtx = undefined;
+  return createMentionHandler({ requireMention: true });
+}
+
+function dispatchCalled() {
+  return capturedCtx !== undefined;
 }
 
 async function expectSkippedGroupHistory(opts: GroupEventOpts, expectedBody: string) {
@@ -258,6 +273,16 @@ describe("signal mention gating", () => {
     expect(String(getCapturedCtx()?.Body ?? "")).toContain("@123e4567");
     expect(getCapturedCtx()?.WasMentioned).toBe(true);
   });
+
+  it("detects control commands even when text style markers wrap the command", async () => {
+    const handler = createGroupHandler();
+    const event = makeGroupEvent({
+      message: "/help",
+      textStyles: [{ style: "BOLD", start: 0, length: 5 }],
+    });
+    await handler(event);
+    expect(dispatchCalled()).toBe(true);
+  });
 });
 
 describe("renderSignalMentions", () => {
@@ -265,35 +290,38 @@ describe("renderSignalMentions", () => {
 
   it("returns the original message when no mentions are provided", () => {
     const message = `${PLACEHOLDER} ping`;
-    expect(renderSignalMentions(message, null)).toBe(message);
-    expect(renderSignalMentions(message, [])).toBe(message);
+    expect(renderSignalMentions(message, null).text).toBe(message);
+    expect(renderSignalMentions(message, []).text).toBe(message);
   });
 
   it("replaces placeholder code points using mention metadata", () => {
     const message = `${PLACEHOLDER} hi ${PLACEHOLDER}!`;
-    const normalized = renderSignalMentions(message, [
+    const result = renderSignalMentions(message, [
       { uuid: "abc-123", start: 0, length: 1 },
       { number: "+15550005555", start: message.lastIndexOf(PLACEHOLDER), length: 1 },
     ]);
 
-    expect(normalized).toBe("@abc-123 hi @+15550005555!");
+    expect(result.text).toBe("@abc-123 hi @+15550005555!");
+    expect(result.offsetShifts.size).toBeGreaterThan(0);
   });
 
   it("skips mentions that lack identifiers or out-of-bounds spans", () => {
     const message = `${PLACEHOLDER} hi`;
-    const normalized = renderSignalMentions(message, [
+    const result = renderSignalMentions(message, [
       { name: "ignored" },
       { uuid: "valid", start: 0, length: 1 },
       { number: "+1555", start: 999, length: 1 },
     ]);
 
-    expect(normalized).toBe("@valid hi");
+    expect(result.text).toBe("@valid hi");
+    expect(result.offsetShifts.size).toBeGreaterThan(0);
   });
 
   it("clamps and truncates fractional mention offsets", () => {
     const message = `${PLACEHOLDER} ping`;
-    const normalized = renderSignalMentions(message, [{ uuid: "valid", start: -0.7, length: 1.9 }]);
+    const result = renderSignalMentions(message, [{ uuid: "valid", start: -0.7, length: 1.9 }]);
 
-    expect(normalized).toBe("@valid ping");
+    expect(result.text).toBe("@valid ping");
+    expect(result.offsetShifts.size).toBeGreaterThan(0);
   });
 });

--- a/extensions/signal/src/monitor/event-handler.test-harness.ts
+++ b/extensions/signal/src/monitor/event-handler.test-harness.ts
@@ -22,6 +22,8 @@ export function createBaseSignalEventHandlerDeps(
     ignoreAttachments: true,
     sendReadReceipts: false,
     readReceiptsViaDaemon: false,
+    injectLinkPreviews: true,
+    preserveTextStyles: true,
     fetchAttachment: async () => null,
     deliverReplies: async () => {},
     resolveSignalReactionTargets: () => [],

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -7,7 +7,6 @@ import {
   formatInboundFromLabel,
   matchesMentionPatterns,
   resolveEnvelopeFormatOptions,
-  shouldDebounceTextInbound,
 } from "openclaw/plugin-sdk/channel-inbound";
 import {
   logInboundDrop,
@@ -55,8 +54,210 @@ import type {
   SignalEventHandlerDeps,
   SignalReactionMessage,
   SignalReceivePayload,
+  SignalTextStyleRange,
 } from "./event-handler.types.js";
 import { renderSignalMentions } from "./mentions.js";
+import { cacheSignalMessage, lookupSignalMessage } from "./message-cache.js";
+
+function normalizeDimensionValue(value?: number | null): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return undefined;
+  }
+  return Math.round(value);
+}
+
+function normalizeCaptionValue(value?: string | null): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const normalized = value.trim();
+  return normalized || undefined;
+}
+
+const SIGNAL_MARKDOWN_STYLE_MARKERS: Record<string, { open: string; close: string }> = {
+  BOLD: { open: "**", close: "**" },
+  ITALIC: { open: "_", close: "_" },
+  MONOSPACE: { open: "`", close: "`" },
+  STRIKETHROUGH: { open: "~~", close: "~~" },
+  SPOILER: { open: "||", close: "||" },
+};
+
+function applySignalTextStyles(text: string, styles?: SignalTextStyleRange[] | null): string {
+  if (!text || !Array.isArray(styles) || styles.length === 0) {
+    return text;
+  }
+
+  const opens = new Map<number, string[]>();
+  const closes = new Map<number, string[]>();
+
+  const normalizedRanges = styles
+    .map((style) => {
+      const marker = style.style ? SIGNAL_MARKDOWN_STYLE_MARKERS[style.style] : undefined;
+      if (!marker) {
+        return null;
+      }
+      if (typeof style.start !== "number" || typeof style.length !== "number") {
+        return null;
+      }
+      if (!Number.isFinite(style.start) || !Number.isFinite(style.length)) {
+        return null;
+      }
+      const start = Math.max(0, Math.trunc(style.start));
+      const length = Math.max(0, Math.trunc(style.length));
+      if (length <= 0 || start >= text.length) {
+        return null;
+      }
+      const end = Math.min(text.length, start + length);
+      if (end <= start) {
+        return null;
+      }
+      return { start, end, marker };
+    })
+    .filter(
+      (range): range is { start: number; end: number; marker: { open: string; close: string } } =>
+        Boolean(range),
+    )
+    .toSorted((a, b) => {
+      if (a.start !== b.start) {
+        return b.start - a.start;
+      }
+      return b.end - a.end;
+    });
+
+  for (const range of normalizedRanges) {
+    const openList = opens.get(range.start) ?? [];
+    openList.push(range.marker.open);
+    opens.set(range.start, openList);
+
+    const closeList = closes.get(range.end) ?? [];
+    closeList.push(range.marker.close);
+    closes.set(range.end, closeList);
+  }
+
+  let output = text;
+  for (let index = text.length; index >= 0; index -= 1) {
+    const closeList = closes.get(index);
+    const openList = opens.get(index);
+    if (!closeList && !openList) {
+      continue;
+    }
+    const insertion = `${(closeList ?? []).join("")}${(openList ?? []).join("")}`;
+    output = `${output.slice(0, index)}${insertion}${output.slice(index)}`;
+  }
+
+  return output;
+}
+
+function buildSignalLinkPreviewContext(
+  previews?: Array<{
+    url?: string | null;
+    title?: string | null;
+    description?: string | null;
+  }> | null,
+): string[] {
+  if (!Array.isArray(previews) || previews.length === 0) {
+    return [];
+  }
+
+  const context: string[] = [];
+  for (const preview of previews) {
+    const url = preview.url?.trim();
+    if (!url) {
+      continue;
+    }
+    const title = preview.title?.trim();
+    const description = preview.description?.trim();
+    const label = title && description ? `${title} - ${description}` : title || description || url;
+    context.push(`Link preview: ${label} (${url})`);
+  }
+  return context;
+}
+
+function buildSignalContactContext(
+  contacts?: Array<{
+    name?: { display?: string | null; given?: string | null; family?: string | null } | null;
+    phone?: Array<{ value?: string | null; type?: string | null }> | null;
+    email?: Array<{ value?: string | null; type?: string | null }> | null;
+    organization?: string | null;
+  }> | null,
+): string[] {
+  if (!Array.isArray(contacts) || contacts.length === 0) {
+    return [];
+  }
+
+  const context: string[] = [];
+  for (const contact of contacts) {
+    const displayName =
+      contact.name?.display?.trim() ||
+      `${contact.name?.given?.trim() ?? ""} ${contact.name?.family?.trim() ?? ""}`.trim() ||
+      "Unknown";
+    const phone = contact.phone?.[0]?.value?.trim();
+    const email = contact.email?.[0]?.value?.trim();
+    const organization = contact.organization?.trim();
+
+    const details = [phone, email, organization].filter(Boolean).join(", ");
+    if (!details && displayName === "Unknown") {
+      continue;
+    }
+
+    const label = details ? `${displayName} (${details})` : displayName;
+    context.push(`Shared contact: ${label}`);
+  }
+  return context;
+}
+
+function buildSignalPollContext(params: {
+  pollCreate?: {
+    question?: string | null;
+    allowMultiple?: boolean | null;
+    options?: string[] | null;
+  } | null;
+  pollVote?: {
+    authorNumber?: string | null;
+    authorUuid?: string | null;
+    targetSentTimestamp?: number | null;
+    optionIndexes?: number[] | null;
+    voteCount?: number | null;
+  } | null;
+  pollTerminate?: { targetSentTimestamp?: number | null } | null;
+}): string[] {
+  const context: string[] = [];
+
+  if (params.pollCreate) {
+    const question = params.pollCreate.question?.trim() || "Untitled";
+    const options =
+      params.pollCreate.options?.filter((opt) => opt?.trim()).map((opt) => opt.trim()) ?? [];
+    const allowMultiple = params.pollCreate.allowMultiple === true;
+
+    if (options.length > 0) {
+      const optionsText = options.join(", ");
+      const suffix = allowMultiple ? " (multiple selections allowed)" : "";
+      context.push(`Poll: "${question}" — Options: ${optionsText}${suffix}`);
+    } else {
+      context.push(`Poll: "${question}"`);
+    }
+  }
+
+  if (params.pollVote) {
+    const targetTimestamp = params.pollVote.targetSentTimestamp;
+    const indexes = params.pollVote.optionIndexes?.filter((idx) => typeof idx === "number") ?? [];
+
+    if (targetTimestamp != null) {
+      const timestampText = `#${targetTimestamp}`;
+      const indexesText = indexes.length > 0 ? indexes.join(", ") : "unknown";
+      context.push(`Poll vote on ${timestampText}: option(s) ${indexesText}`);
+    }
+  }
+
+  if (params.pollTerminate) {
+    const targetTimestamp = params.pollTerminate.targetSentTimestamp;
+    if (targetTimestamp != null) {
+      context.push(`Poll #${targetTimestamp} closed`);
+    }
+  }
+
+  return context;
+}
 
 function formatAttachmentKindCount(kind: string, count: number): string {
   if (kind === "attachment") {
@@ -105,13 +306,26 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     groupName?: string;
     isGroup: boolean;
     bodyText: string;
+    bodyTextPlain: string;
     commandBody: string;
     timestamp?: number;
     messageId?: string;
+    editTargetTimestamp?: number;
+    isEdit?: boolean;
+    editOriginalBody?: string;
     mediaPath?: string;
     mediaType?: string;
+    mediaCaption?: string;
     mediaPaths?: string[];
     mediaTypes?: string[];
+    mediaCaptions?: string[];
+    mediaDimension?: { width?: number; height?: number };
+    mediaDimensions?: Array<{ width?: number; height?: number }>;
+    untrustedContext?: string[];
+    replyToId?: string;
+    replyToBody?: string;
+    replyToSender?: string;
+    replyToIsQuote?: boolean;
     commandAuthorized: boolean;
     wasMentioned?: boolean;
   };
@@ -205,13 +419,24 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       Provider: "signal" as const,
       Surface: "signal" as const,
       MessageSid: entry.messageId,
+      EditTargetTimestamp: entry.editTargetTimestamp,
+      EditOriginalBody: entry.editOriginalBody,
+      ReplyToId: entry.replyToId,
+      ReplyToBody: entry.replyToBody,
+      ReplyToSender: entry.replyToSender,
+      ReplyToIsQuote: entry.replyToIsQuote,
+      UntrustedContext: entry.untrustedContext,
       Timestamp: entry.timestamp ?? undefined,
       MediaPath: entry.mediaPath,
       MediaType: entry.mediaType,
+      MediaCaption: entry.mediaCaption,
       MediaUrl: entry.mediaPath,
       MediaPaths: entry.mediaPaths,
       MediaUrls: entry.mediaPaths,
       MediaTypes: entry.mediaTypes,
+      MediaCaptions: entry.mediaCaptions,
+      MediaDimension: entry.mediaDimension,
+      MediaDimensions: entry.mediaDimensions,
       WasMentioned: entry.isGroup ? entry.wasMentioned === true : undefined,
       CommandAuthorized: entry.commandAuthorized,
       OriginatingChannel: "signal" as const,
@@ -349,11 +574,23 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       return `signal:${deps.accountId}:${conversationId}:${entry.senderPeerId}`;
     },
     shouldDebounce: (entry) => {
-      return shouldDebounceTextInbound({
-        text: entry.bodyText,
-        cfg: deps.cfg,
-        hasMedia: Boolean(entry.mediaPath || entry.mediaType || entry.mediaPaths?.length),
-      });
+      if (!entry.bodyText.trim()) {
+        return false;
+      }
+      if (entry.isEdit) {
+        return false;
+      }
+      if (
+        entry.mediaPath ||
+        entry.mediaType ||
+        entry.mediaCaption ||
+        (Array.isArray(entry.mediaPaths) && entry.mediaPaths.length > 0) ||
+        (Array.isArray(entry.mediaTypes) && entry.mediaTypes.length > 0) ||
+        (Array.isArray(entry.mediaCaptions) && entry.mediaCaptions.length > 0)
+      ) {
+        return false;
+      }
+      return !hasControlCommand(entry.bodyTextPlain, deps.cfg);
     },
     onFlush: async (entries) => {
       const last = entries.at(-1);
@@ -367,17 +604,47 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       const combinedText = entries
         .map((entry) => entry.bodyText)
         .filter(Boolean)
-        .join("\\n");
+        .join("\n");
+      const combinedTextPlain = entries
+        .map((entry) => entry.bodyTextPlain)
+        .filter(Boolean)
+        .join("\n");
+      const combinedCommandBody = entries
+        .map((entry) => entry.commandBody)
+        .filter(Boolean)
+        .join("\n");
       if (!combinedText.trim()) {
         return;
       }
+      // Merge untrustedContext arrays from all entries so poll vote metadata,
+      // link previews, sticker context etc. survive debounce concatenation.
+      const mergedUntrustedContext = entries.reduce<string[]>((acc, entry) => {
+        if (Array.isArray(entry.untrustedContext)) {
+          acc.push(...entry.untrustedContext);
+        }
+        return acc;
+      }, []);
       await handleSignalInboundMessage({
         ...last,
         bodyText: combinedText,
+        bodyTextPlain: combinedTextPlain,
+        commandBody: combinedCommandBody || combinedText,
         mediaPath: undefined,
         mediaType: undefined,
+        mediaCaption: undefined,
         mediaPaths: undefined,
         mediaTypes: undefined,
+        mediaCaptions: undefined,
+        mediaDimension: undefined,
+        mediaDimensions: undefined,
+        untrustedContext: mergedUntrustedContext.length > 0 ? mergedUntrustedContext : undefined,
+        replyToId: undefined,
+        replyToBody: undefined,
+        replyToSender: undefined,
+        replyToIsQuote: undefined,
+        editTargetTimestamp: undefined,
+        isEdit: undefined,
+        editOriginalBody: undefined,
       });
     },
     onError: (err) => {
@@ -508,6 +775,26 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     }
 
     const dataMessage = envelope.dataMessage ?? envelope.editMessage?.dataMessage;
+    const editTargetTimestamp =
+      typeof envelope.editMessage?.targetSentTimestamp === "number" &&
+      Number.isFinite(envelope.editMessage.targetSentTimestamp)
+        ? envelope.editMessage.targetSentTimestamp
+        : undefined;
+    const isEditMessage = Boolean(envelope.editMessage);
+    const signalMessageTimestamp =
+      typeof envelope.timestamp === "number"
+        ? envelope.timestamp
+        : typeof dataMessage?.timestamp === "number"
+          ? dataMessage.timestamp
+          : undefined;
+    const cachedEditedMessage =
+      isEditMessage && typeof editTargetTimestamp === "number"
+        ? lookupSignalMessage(String(editTargetTimestamp))
+        : undefined;
+    const editOriginalBody = cachedEditedMessage?.body;
+    const editOriginalContext = editOriginalBody
+      ? [`Edited message original body: ${editOriginalBody}`]
+      : [];
     const reaction = deps.isSignalReactionMessage(envelope.reactionMessage)
       ? envelope.reactionMessage
       : deps.isSignalReactionMessage(dataMessage?.reaction)
@@ -517,12 +804,106 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     // Replace ￼ (object replacement character) with @uuid or @phone from mentions
     // Signal encodes mentions as the object replacement character; hydrate them from metadata first.
     const rawMessage = dataMessage?.message ?? "";
-    const normalizedMessage = renderSignalMentions(rawMessage, dataMessage?.mentions);
-    const messageText = normalizedMessage.trim();
+    const mentionResult = renderSignalMentions(rawMessage, dataMessage?.mentions);
+    const normalizedMessage = mentionResult.text;
 
-    const quoteText = dataMessage?.quote?.text?.trim() ?? "";
+    // Adjust text style offsets to account for mention expansions.
+    const adjustedTextStyles =
+      dataMessage?.textStyles && mentionResult.offsetShifts.size > 0
+        ? (() => {
+            const sortedShiftPositions = Array.from(mentionResult.offsetShifts.keys()).toSorted(
+              (a, b) => a - b,
+            );
+            const cumulativeShiftAtOffset = (offset: number): number => {
+              let cumulativeShift = 0;
+              for (const shiftPos of sortedShiftPositions) {
+                if (shiftPos <= offset) {
+                  cumulativeShift += mentionResult.offsetShifts.get(shiftPos) ?? 0;
+                } else {
+                  break;
+                }
+              }
+              return cumulativeShift;
+            };
+            return dataMessage.textStyles.map((style) => {
+              if (typeof style.start !== "number") {
+                return style;
+              }
+              const adjustedStart = style.start + cumulativeShiftAtOffset(style.start);
+              if (typeof style.length !== "number") {
+                return {
+                  ...style,
+                  start: adjustedStart,
+                };
+              }
+              const styleEnd = style.start + style.length;
+              const adjustedEnd = styleEnd + cumulativeShiftAtOffset(styleEnd);
+              return {
+                ...style,
+                start: adjustedStart,
+                length: Math.max(0, adjustedEnd - adjustedStart),
+              };
+            });
+          })()
+        : dataMessage?.textStyles;
+
+    const styledMessage =
+      deps.preserveTextStyles !== false
+        ? applySignalTextStyles(normalizedMessage, adjustedTextStyles)
+        : normalizedMessage;
+    const messageTextPlain = normalizedMessage.trim();
+    const messageText = styledMessage.trim();
+
+    const quote = dataMessage?.quote;
+    const quoteText = quote?.text?.trim() ?? "";
+    const quoteReplyId = (() => {
+      const raw = quote?.id ?? quote?.timestamp;
+      if (raw == null) {
+        return undefined;
+      }
+      const value = String(raw).trim();
+      return value || undefined;
+    })();
+    const quoteReplySender = (() => {
+      const raw = quote?.authorUuid ?? quote?.authorNumber ?? quote?.author;
+      if (typeof raw !== "string") {
+        return undefined;
+      }
+      const value = raw.trim();
+      return value || undefined;
+    })();
+    const sticker = dataMessage?.sticker;
+    const stickerPackId = (() => {
+      const raw = sticker?.packId;
+      if (raw == null) {
+        return undefined;
+      }
+      const value = String(raw).trim();
+      return value || undefined;
+    })();
+    const stickerId = (() => {
+      const raw = sticker?.stickerId;
+      if (raw == null) {
+        return undefined;
+      }
+      const value = String(raw).trim();
+      return value || undefined;
+    })();
+    const stickerContext = [
+      stickerPackId ? `Signal sticker packId: ${stickerPackId}` : undefined,
+      stickerId ? `Signal stickerId: ${stickerId}` : undefined,
+    ].filter((entry): entry is string => Boolean(entry));
+    const linkPreviewContext =
+      deps.injectLinkPreviews !== false ? buildSignalLinkPreviewContext(dataMessage?.previews) : [];
+    const contactContext = buildSignalContactContext(dataMessage?.contacts);
+    const pollCreate = dataMessage?.pollCreate ?? null;
+    const pollVote = dataMessage?.pollVote ?? null;
+    const pollTerminate = dataMessage?.pollTerminate ?? null;
+    const pollContext = buildSignalPollContext({ pollCreate, pollVote, pollTerminate });
+    const attachments = dataMessage?.attachments ?? [];
+    const allAttachments = sticker?.attachment ? [...attachments, sticker.attachment] : attachments;
     const hasBodyContent =
-      Boolean(messageText || quoteText) || Boolean(!reaction && dataMessage?.attachments?.length);
+      Boolean(messageText || quoteText) || Boolean(!reaction && allAttachments.length > 0);
     const senderDisplay = formatSignalSenderDisplay(sender);
     const { resolveAccessDecision, dmAccess, effectiveDmAllow, effectiveGroupAllow } =
       await resolveSignalAccessState({
@@ -603,7 +984,8 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     const commandDmAllow = isGroup ? deps.allowFrom : effectiveDmAllow;
     const ownerAllowedForCommands = isSignalSenderAllowed(sender, commandDmAllow);
     const groupAllowedForCommands = isSignalSenderAllowed(sender, effectiveGroupAllow);
-    const hasControlCommandInMessage = hasControlCommand(messageText, deps.cfg);
+    // Use plain text (without style markers) for command detection
+    const hasControlCommandInMessage = hasControlCommand(messageTextPlain, deps.cfg);
     const commandGate = resolveControlCommandGate({
       useAccessGroups,
       authorizers: [
@@ -632,7 +1014,8 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       senderPeerId,
     });
     const mentionRegexes = buildMentionRegexes(deps.cfg, route.agentId);
-    const wasMentioned = isGroup && matchesMentionPatterns(messageText, mentionRegexes);
+    // Use plain text for mention detection so style markers don't interfere
+    const wasMentioned = isGroup && matchesMentionPatterns(messageTextPlain, mentionRegexes);
     const requireMention =
       isGroup &&
       resolveChannelGroupRequireMention({
@@ -661,9 +1044,11 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
         reason: "no mention",
         target: senderDisplay,
       });
-      const quoteText = dataMessage.quote?.text?.trim() || "";
       const pendingPlaceholder = (() => {
-        if (!dataMessage.attachments?.length) {
+        if (sticker) {
+          return "<media:sticker>";
+        }
+        if (!allAttachments.length) {
           return "";
         }
         // When we're skipping a message we intentionally avoid downloading attachments.
@@ -671,17 +1056,24 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
         if (deps.ignoreAttachments) {
           return "<media:attachment>";
         }
-        const attachmentTypes = (dataMessage.attachments ?? []).map((attachment) =>
+        const attachmentTypes = allAttachments.map((attachment) =>
           typeof attachment?.contentType === "string" ? attachment.contentType : undefined,
         );
         if (attachmentTypes.length > 1) {
           return formatAttachmentSummaryPlaceholder(attachmentTypes);
         }
-        const firstContentType = dataMessage.attachments?.[0]?.contentType;
+        const firstContentType = allAttachments[0]?.contentType;
         const pendingKind = kindFromMime(firstContentType ?? undefined);
         return pendingKind ? `<media:${pendingKind}>` : "<media:attachment>";
       })();
       const pendingBodyText = messageText || pendingPlaceholder || quoteText;
+      if (signalMessageTimestamp != null && pendingBodyText) {
+        cacheSignalMessage(
+          String(signalMessageTimestamp),
+          pendingBodyText,
+          envelope.sourceName ?? senderDisplay,
+        );
+      }
       const historyKey = groupId ?? "unknown";
       recordPendingHistoryEntryIfEnabled({
         historyMap: deps.groupHistories,
@@ -700,16 +1092,26 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
 
     let mediaPath: string | undefined;
     let mediaType: string | undefined;
-    const mediaPaths: string[] = [];
-    const mediaTypes: string[] = [];
+    let mediaCaption: string | undefined;
+    let mediaPaths: string[] | undefined;
+    let mediaTypes: string[] | undefined;
+    let mediaCaptions: string[] | undefined;
+    let mediaDimension: { width?: number; height?: number } | undefined;
+    let mediaDimensions: Array<{ width?: number; height?: number }> | undefined;
     let placeholder = "";
-    const attachments = dataMessage.attachments ?? [];
-    if (!deps.ignoreAttachments) {
-      for (const attachment of attachments) {
-        if (!attachment?.id) {
-          continue;
-        }
-        try {
+    if (!deps.ignoreAttachments && allAttachments.length > 0) {
+      const fetchedMedia: Array<{
+        path: string;
+        contentType?: string;
+        caption?: string;
+        width?: number;
+        height?: number;
+      }> = [];
+      const fetchResults = await Promise.allSettled(
+        allAttachments.map(async (attachment) => {
+          if (!attachment?.id) {
+            return null;
+          }
           const fetched = await deps.fetchAttachment({
             baseUrl: deps.baseUrl,
             account: deps.account,
@@ -718,34 +1120,72 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
             groupId,
             maxBytes: deps.mediaMaxBytes,
           });
-          if (fetched) {
-            mediaPaths.push(fetched.path);
-            mediaTypes.push(
-              fetched.contentType ?? attachment.contentType ?? "application/octet-stream",
-            );
-            if (!mediaPath) {
-              mediaPath = fetched.path;
-              mediaType = fetched.contentType ?? attachment.contentType ?? undefined;
-            }
+          if (!fetched) {
+            return null;
           }
-        } catch (err) {
-          deps.runtime.error?.(danger(`attachment fetch failed: ${String(err)}`));
+          return {
+            path: fetched.path,
+            contentType: fetched.contentType ?? attachment.contentType ?? undefined,
+            caption: normalizeCaptionValue(attachment.caption),
+            width: normalizeDimensionValue(attachment.width),
+            height: normalizeDimensionValue(attachment.height),
+          };
+        }),
+      );
+      for (const result of fetchResults) {
+        if (result.status === "rejected") {
+          deps.runtime.error?.(danger(`attachment fetch failed: ${String(result.reason)}`));
+          continue;
+        }
+        if (result.value) {
+          fetchedMedia.push(result.value);
         }
       }
-    }
-
-    if (mediaPaths.length > 1) {
-      placeholder = formatAttachmentSummaryPlaceholder(mediaTypes);
-    } else {
-      const kind = kindFromMime(mediaType ?? undefined);
-      if (kind) {
-        placeholder = `<media:${kind}>`;
-      } else if (attachments.length) {
-        placeholder = "<media:attachment>";
+      mediaPath = fetchedMedia[0]?.path;
+      mediaType =
+        fetchedMedia.length > 0
+          ? (fetchedMedia[0]?.contentType ?? "application/octet-stream")
+          : undefined;
+      mediaCaption = fetchedMedia[0]?.caption;
+      mediaPaths = fetchedMedia.length > 0 ? fetchedMedia.map((entry) => entry.path) : undefined;
+      mediaTypes =
+        fetchedMedia.length > 0
+          ? fetchedMedia.map((entry) => entry.contentType ?? "application/octet-stream")
+          : undefined;
+      mediaCaptions =
+        fetchedMedia.length > 0 ? fetchedMedia.map((entry) => entry.caption ?? "") : undefined;
+      if (mediaCaptions && !mediaCaptions.some((entry) => entry.trim().length > 0)) {
+        mediaCaptions = undefined;
       }
+      const fetchedDimensions = fetchedMedia.map((entry) => ({
+        width: entry.width,
+        height: entry.height,
+      }));
+      const hasAnyDimensions = fetchedDimensions.some((entry) => entry.width || entry.height);
+      mediaDimension = hasAnyDimensions ? fetchedDimensions[0] : undefined;
+      mediaDimensions = hasAnyDimensions ? fetchedDimensions : undefined;
     }
 
-    const bodyText = messageText || placeholder || dataMessage.quote?.text?.trim() || "";
+    const firstAttachmentContentType = allAttachments[0]?.contentType ?? undefined;
+    const kind = kindFromMime(mediaType ?? firstAttachmentContentType);
+    if (sticker) {
+      placeholder = "<media:sticker>";
+    } else if (kind) {
+      placeholder = `<media:${kind}>`;
+    } else if (allAttachments.length) {
+      placeholder = "<media:attachment>";
+    } else if (Array.isArray(dataMessage?.contacts) && dataMessage.contacts.length > 0) {
+      placeholder = "<media:contact>";
+    } else if (pollCreate) {
+      const question = pollCreate.question?.trim() || "Untitled";
+      placeholder = `[Poll] ${question}`;
+    } else if (pollVote) {
+      placeholder = "[Poll vote]";
+    } else if (pollTerminate) {
+      placeholder = "[Poll closed]";
+    }
+
+    const bodyText = messageText || placeholder || quoteText;
     if (!bodyText) {
       return;
     }
@@ -776,6 +1216,9 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     }
 
     const senderName = envelope.sourceName ?? senderDisplay;
+    if (signalMessageTimestamp != null) {
+      cacheSignalMessage(String(signalMessageTimestamp), bodyText, senderName);
+    }
     const messageId =
       typeof envelope.timestamp === "number" ? String(envelope.timestamp) : undefined;
     await inboundDebouncer.enqueue({
@@ -787,13 +1230,39 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       groupName,
       isGroup,
       bodyText,
-      commandBody: messageText,
+      bodyTextPlain: messageTextPlain || bodyText,
+      commandBody: messageText || bodyText,
       timestamp: envelope.timestamp ?? undefined,
       messageId,
+      editTargetTimestamp,
+      isEdit: isEditMessage,
+      editOriginalBody,
       mediaPath,
       mediaType,
-      mediaPaths: mediaPaths.length > 0 ? mediaPaths : undefined,
-      mediaTypes: mediaTypes.length > 0 ? mediaTypes : undefined,
+      mediaCaption,
+      mediaPaths,
+      mediaTypes,
+      mediaCaptions,
+      mediaDimension,
+      mediaDimensions,
+      untrustedContext:
+        stickerContext.length > 0 ||
+        linkPreviewContext.length > 0 ||
+        contactContext.length > 0 ||
+        pollContext.length > 0 ||
+        editOriginalContext.length > 0
+          ? [
+              ...stickerContext,
+              ...linkPreviewContext,
+              ...contactContext,
+              ...pollContext,
+              ...editOriginalContext,
+            ]
+          : undefined,
+      replyToId: quoteReplyId,
+      replyToBody: quoteText || undefined,
+      replyToSender: quoteReplySender,
+      replyToIsQuote: quote ? true : undefined,
       commandAuthorized,
       wasMentioned: effectiveWasMentioned,
     });

--- a/extensions/signal/src/monitor/event-handler.types.ts
+++ b/extensions/signal/src/monitor/event-handler.types.ts
@@ -15,7 +15,10 @@ export type SignalEnvelope = {
   sourceName?: string | null;
   timestamp?: number | null;
   dataMessage?: SignalDataMessage | null;
-  editMessage?: { dataMessage?: SignalDataMessage | null } | null;
+  editMessage?: {
+    targetSentTimestamp?: number | null;
+    dataMessage?: SignalDataMessage | null;
+  } | null;
   syncMessage?: unknown;
   reactionMessage?: SignalReactionMessage | null;
 };
@@ -32,12 +35,26 @@ export type SignalDataMessage = {
   timestamp?: number;
   message?: string | null;
   attachments?: Array<SignalAttachment>;
+  sticker?: SignalSticker | null;
+  previews?: Array<SignalLinkPreview> | null;
+  textStyles?: Array<SignalTextStyleRange> | null;
   mentions?: Array<SignalMention> | null;
+  contacts?: Array<SignalSharedContact> | null;
+  pollCreate?: SignalPollCreate | null;
+  pollVote?: SignalPollVote | null;
+  pollTerminate?: SignalPollTerminate | null;
   groupInfo?: {
     groupId?: string | null;
     groupName?: string | null;
   } | null;
-  quote?: { text?: string | null } | null;
+  quote?: {
+    id?: number | string | null;
+    timestamp?: number | null;
+    text?: string | null;
+    authorUuid?: string | null;
+    authorNumber?: string | null;
+    author?: string | null;
+  } | null;
   reaction?: SignalReactionMessage | null;
 };
 
@@ -57,7 +74,54 @@ export type SignalAttachment = {
   id?: string | null;
   contentType?: string | null;
   filename?: string | null;
+  caption?: string | null;
   size?: number | null;
+  width?: number | null;
+  height?: number | null;
+};
+
+export type SignalSticker = {
+  packId?: string | number | null;
+  stickerId?: string | number | null;
+  attachment?: SignalAttachment | null;
+};
+
+export type SignalLinkPreview = {
+  url?: string | null;
+  title?: string | null;
+  description?: string | null;
+  image?: SignalAttachment | null;
+};
+
+export type SignalTextStyleRange = {
+  style?: string | null;
+  start?: number | null;
+  length?: number | null;
+};
+
+export type SignalSharedContact = {
+  name?: { display?: string | null; given?: string | null; family?: string | null } | null;
+  phone?: Array<{ value?: string | null; type?: string | null }> | null;
+  email?: Array<{ value?: string | null; type?: string | null }> | null;
+  organization?: string | null;
+};
+
+export type SignalPollCreate = {
+  question?: string | null;
+  allowMultiple?: boolean | null;
+  options?: string[] | null;
+};
+
+export type SignalPollVote = {
+  authorNumber?: string | null;
+  authorUuid?: string | null;
+  targetSentTimestamp?: number | null;
+  optionIndexes?: number[] | null;
+  voteCount?: number | null;
+};
+
+export type SignalPollTerminate = {
+  targetSentTimestamp?: number | null;
 };
 
 export type SignalReactionTarget = {
@@ -92,6 +156,8 @@ export type SignalEventHandlerDeps = {
   ignoreAttachments: boolean;
   sendReadReceipts: boolean;
   readReceiptsViaDaemon: boolean;
+  injectLinkPreviews?: boolean;
+  preserveTextStyles?: boolean;
   fetchAttachment: (params: {
     baseUrl: string;
     account?: string;

--- a/extensions/signal/src/monitor/mentions.test.ts
+++ b/extensions/signal/src/monitor/mentions.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { renderSignalMentions } from "./mentions.js";
+
+const PLACEHOLDER = "\uFFFC";
+
+describe("renderSignalMentions", () => {
+  it("returns the original message when no mentions are provided", () => {
+    const message = `${PLACEHOLDER} ping`;
+    expect(renderSignalMentions(message, null).text).toBe(message);
+    expect(renderSignalMentions(message, []).text).toBe(message);
+  });
+
+  it("replaces placeholder code points using mention metadata", () => {
+    const message = `${PLACEHOLDER} hi ${PLACEHOLDER}!`;
+    const result = renderSignalMentions(message, [
+      { uuid: "abc-123", start: 0, length: 1 },
+      { number: "+15550005555", start: message.lastIndexOf(PLACEHOLDER), length: 1 },
+    ]);
+
+    expect(result.text).toBe("@abc-123 hi @+15550005555!");
+    expect(result.offsetShifts.size).toBeGreaterThan(0);
+  });
+
+  it("skips mentions that lack identifiers or out-of-bounds spans", () => {
+    const message = `${PLACEHOLDER} hi`;
+    const result = renderSignalMentions(message, [
+      { name: "ignored" },
+      { uuid: "valid", start: 0, length: 1 },
+      { number: "+1555", start: 999, length: 1 },
+    ]);
+
+    expect(result.text).toBe("@valid hi");
+    expect(result.offsetShifts.size).toBeGreaterThan(0);
+  });
+
+  it("returns shift metadata for downstream style-offset adjustment", () => {
+    const message = `${PLACEHOLDER} ping`;
+    const result = renderSignalMentions(message, [{ uuid: "abc-123", start: 0, length: 1 }]);
+
+    expect(result.text).toBe("@abc-123 ping");
+    expect(result.offsetShifts.size).toBe(1);
+  });
+});

--- a/extensions/signal/src/monitor/mentions.ts
+++ b/extensions/signal/src/monitor/mentions.ts
@@ -25,12 +25,25 @@ function clampBounds(start: number, length: number, textLength: number) {
   return { start: safeStart, end: safeEnd };
 }
 
-export function renderSignalMentions(message: string, mentions?: SignalMention[] | null) {
+export interface MentionRenderResult {
+  text: string;
+  /**
+   * Map from original mention end offset to the shift introduced by mention expansions.
+   * Used to adjust textStyle ranges that reference original message offsets.
+   */
+  offsetShifts: Map<number, number>;
+}
+
+export function renderSignalMentions(
+  message: string,
+  mentions?: SignalMention[] | null,
+): MentionRenderResult {
   if (!message || !mentions?.length) {
-    return message;
+    return { text: message, offsetShifts: new Map() };
   }
 
   let normalized = message;
+  const offsetShifts = new Map<number, number>();
   const candidates = mentions.filter(isValidMention).toSorted((a, b) => b.start! - a.start!);
 
   for (const mention of candidates) {
@@ -49,8 +62,21 @@ export function renderSignalMentions(message: string, mentions?: SignalMention[]
       continue;
     }
 
-    normalized = normalized.slice(0, start) + `@${identifier}` + normalized.slice(end);
+    const replacement = `@${identifier}`;
+    const originalLength = end - start;
+    const newLength = replacement.length;
+    const shift = newLength - originalLength;
+
+    normalized = normalized.slice(0, start) + replacement + normalized.slice(end);
+
+    // Track shift at the original mention end so offsets inside the mention are not shifted.
+    if (shift !== 0) {
+      offsetShifts.set(end, (offsetShifts.get(end) ?? 0) + shift);
+    }
   }
 
-  return normalized;
+  return { text: normalized, offsetShifts };
 }
+
+/** Alias for renderSignalMentions — kept for readability at call sites that need shift data. */
+export const renderSignalMentionsWithShifts = renderSignalMentions;

--- a/extensions/signal/src/monitor/message-cache.test.ts
+++ b/extensions/signal/src/monitor/message-cache.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  cacheSignalMessage,
+  clearSignalMessageCacheForTest,
+  lookupSignalMessage,
+} from "./message-cache.js";
+
+const SIX_HOURS_MS = 6 * 60 * 60 * 1000;
+
+describe("signal message cache", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-02-17T00:00:00.000Z"));
+    clearSignalMessageCacheForTest();
+  });
+
+  afterEach(() => {
+    clearSignalMessageCacheForTest();
+    vi.useRealTimers();
+  });
+
+  it("returns cached entries by timestamp", () => {
+    cacheSignalMessage("1700000000000", "hello world", "Alice");
+
+    const entry = lookupSignalMessage("1700000000000");
+    expect(entry).toBeTruthy();
+    expect(entry?.body).toBe("hello world");
+    expect(entry?.sender).toBe("Alice");
+    expect(entry?.timestamp).toBe(1700000000000);
+    expect(entry?.cachedAt).toBe(Date.now());
+  });
+
+  it("returns undefined for unknown timestamps", () => {
+    expect(lookupSignalMessage("999999")).toBeUndefined();
+  });
+
+  it("expires entries after the TTL window", () => {
+    cacheSignalMessage("1700000000000", "stale soon");
+
+    vi.advanceTimersByTime(SIX_HOURS_MS + 1);
+
+    expect(lookupSignalMessage("1700000000000")).toBeUndefined();
+  });
+
+  it("evicts the oldest entry when cache exceeds max size", () => {
+    for (let index = 0; index <= 2000; index += 1) {
+      cacheSignalMessage(String(1700000000000 + index), `body-${index}`);
+    }
+
+    expect(lookupSignalMessage("1700000000000")).toBeUndefined();
+    expect(lookupSignalMessage("1700000002000")?.body).toBe("body-2000");
+  });
+});

--- a/extensions/signal/src/monitor/message-cache.ts
+++ b/extensions/signal/src/monitor/message-cache.ts
@@ -1,0 +1,90 @@
+const SIGNAL_MESSAGE_CACHE_MAX = 2000;
+const SIGNAL_MESSAGE_CACHE_TTL_MS = 6 * 60 * 60 * 1000;
+
+export type SignalMessageCacheEntry = {
+  body: string;
+  sender?: string;
+  timestamp: number;
+  cachedAt: number;
+};
+
+const signalMessageCacheByTimestamp = new Map<string, SignalMessageCacheEntry>();
+
+function normalizeKey(timestamp: string): string {
+  return timestamp.trim();
+}
+
+function parseTimestamp(timestamp: string): number {
+  const parsed = Number(timestamp);
+  if (Number.isFinite(parsed)) {
+    return parsed;
+  }
+  return Date.now();
+}
+
+function evictExpiredEntries(): void {
+  const cutoff = Date.now() - SIGNAL_MESSAGE_CACHE_TTL_MS;
+  for (const [key, entry] of signalMessageCacheByTimestamp) {
+    if (entry.cachedAt < cutoff) {
+      signalMessageCacheByTimestamp.delete(key);
+      continue;
+    }
+    break;
+  }
+}
+
+function evictOverflowEntries(): void {
+  while (signalMessageCacheByTimestamp.size > SIGNAL_MESSAGE_CACHE_MAX) {
+    const oldest = signalMessageCacheByTimestamp.keys().next().value;
+    if (!oldest) {
+      break;
+    }
+    signalMessageCacheByTimestamp.delete(oldest);
+  }
+}
+
+export function cacheSignalMessage(timestamp: string, body: string, sender?: string): void {
+  const key = normalizeKey(timestamp);
+  if (!key) {
+    return;
+  }
+
+  evictExpiredEntries();
+
+  const now = Date.now();
+  signalMessageCacheByTimestamp.delete(key);
+  signalMessageCacheByTimestamp.set(key, {
+    body,
+    sender: sender?.trim() || undefined,
+    timestamp: parseTimestamp(key),
+    cachedAt: now,
+  });
+
+  evictOverflowEntries();
+}
+
+export function lookupSignalMessage(timestamp: string): SignalMessageCacheEntry | undefined {
+  const key = normalizeKey(timestamp);
+  if (!key) {
+    return undefined;
+  }
+
+  evictExpiredEntries();
+
+  const entry = signalMessageCacheByTimestamp.get(key);
+  if (!entry) {
+    return undefined;
+  }
+
+  const cutoff = Date.now() - SIGNAL_MESSAGE_CACHE_TTL_MS;
+  if (entry.cachedAt < cutoff) {
+    signalMessageCacheByTimestamp.delete(key);
+    return undefined;
+  }
+
+  return entry;
+}
+
+export function clearSignalMessageCacheForTest(): void {
+  signalMessageCacheByTimestamp.clear();
+}

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -15,13 +15,6 @@ import {
 } from "openclaw/plugin-sdk/command-auth-native";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import type { ChannelGroupPolicy } from "openclaw/plugin-sdk/config-runtime";
-import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
-import { getRuntimeConfigSnapshot } from "openclaw/plugin-sdk/runtime-config-snapshot";
-import {
-  normalizeTelegramCommandName,
-  resolveTelegramCustomCommands,
-  TELEGRAM_COMMAND_NAME_PATTERN,
-} from "openclaw/plugin-sdk/telegram-command-config";
 import type {
   ReplyToMode,
   TelegramAccountConfig,
@@ -33,6 +26,7 @@ import {
   ensureConfiguredBindingRouteReady,
   recordInboundSessionMetaSafe,
 } from "openclaw/plugin-sdk/conversation-runtime";
+import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
 import { getAgentScopedMediaLocalRoots } from "openclaw/plugin-sdk/media-runtime";
 import {
   executePluginCommand,
@@ -45,9 +39,15 @@ import {
 } from "openclaw/plugin-sdk/reply-dispatch-runtime";
 import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
 import { resolveThreadSessionKeys } from "openclaw/plugin-sdk/routing";
+import { getRuntimeConfigSnapshot } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { getChildLogger } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import {
+  normalizeTelegramCommandName,
+  resolveTelegramCustomCommands,
+  TELEGRAM_COMMAND_NAME_PATTERN,
+} from "openclaw/plugin-sdk/telegram-command-config";
 import { resolveTelegramAccount } from "./accounts.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { isSenderAllowed, normalizeDmAllowFromWithStore } from "./bot-access.js";

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
@@ -7,8 +7,8 @@ import { formatInboundEnvelope } from "openclaw/plugin-sdk/channel-inbound";
 import { createChannelReplyPipeline } from "openclaw/plugin-sdk/channel-reply-pipeline";
 import { shouldComputeCommandAuthorized } from "openclaw/plugin-sdk/command-detection";
 import type { loadConfig } from "openclaw/plugin-sdk/config-runtime";
-import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
 import { recordSessionMetaFromInbound } from "openclaw/plugin-sdk/config-runtime";
+import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
 import { getAgentScopedMediaLocalRoots } from "openclaw/plugin-sdk/media-runtime";
 import {
   buildHistoryContextFromEntries,

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -130,10 +130,7 @@ function applyWhamCooldownResult(params: {
       : 0;
   return {
     ...params.computed,
-    cooldownUntil: Math.max(
-      existingActiveCooldownUntil,
-      params.now + params.whamResult.cooldownMs,
-    ),
+    cooldownUntil: Math.max(existingActiveCooldownUntil, params.now + params.whamResult.cooldownMs),
   };
 }
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -419,64 +419,64 @@ export async function runEmbeddedAttempt(
       ? []
       : (() => {
           const allTools = createOpenClawCodingTools({
-          agentId: sessionAgentId,
-          trigger: params.trigger,
-          memoryFlushWritePath: params.memoryFlushWritePath,
-          exec: {
-            ...params.execOverrides,
-            elevated: params.bashElevated,
-          },
-          sandbox,
-          messageProvider: params.messageChannel ?? params.messageProvider,
-          agentAccountId: params.agentAccountId,
-          messageTo: params.messageTo,
-          messageThreadId: params.messageThreadId,
-          groupId: params.groupId,
-          groupChannel: params.groupChannel,
-          groupSpace: params.groupSpace,
-          spawnedBy: params.spawnedBy,
-          senderId: params.senderId,
-          senderName: params.senderName,
-          senderUsername: params.senderUsername,
-          senderE164: params.senderE164,
-          senderIsOwner: params.senderIsOwner,
-          allowGatewaySubagentBinding: params.allowGatewaySubagentBinding,
-          sessionKey: sandboxSessionKey,
-          sessionId: params.sessionId,
-          runId: params.runId,
-          agentDir,
-          workspaceDir: effectiveWorkspace,
-          // When sandboxing uses a copied workspace (`ro` or `none`), effectiveWorkspace points
-          // at the sandbox copy. Spawned subagents should inherit the real workspace instead.
-          spawnWorkspaceDir: resolveAttemptSpawnWorkspaceDir({
+            agentId: sessionAgentId,
+            trigger: params.trigger,
+            memoryFlushWritePath: params.memoryFlushWritePath,
+            exec: {
+              ...params.execOverrides,
+              elevated: params.bashElevated,
+            },
             sandbox,
-            resolvedWorkspace,
-          }),
-          config: params.config,
-          abortSignal: runAbortController.signal,
-          modelProvider: params.model.provider,
-          modelId: params.modelId,
-          modelCompat: params.model.compat,
-          modelApi: params.model.api,
-          modelContextWindowTokens: params.model.contextWindow,
-          modelAuthMode: resolveModelAuthMode(params.model.provider, params.config),
-          currentChannelId: params.currentChannelId,
-          currentThreadTs: params.currentThreadTs,
-          currentMessageId: params.currentMessageId,
-          replyToMode: params.replyToMode,
-          hasRepliedRef: params.hasRepliedRef,
-          modelHasVision,
-          requireExplicitMessageTarget:
-            params.requireExplicitMessageTarget ?? isSubagentSessionKey(params.sessionKey),
-          disableMessageTool: params.disableMessageTool,
-          onYield: (message) => {
-            yieldDetected = true;
-            yieldMessage = message;
-            queueYieldInterruptForSession?.();
-            runAbortController.abort("sessions_yield");
-            abortSessionForYield?.();
-          },
-        });
+            messageProvider: params.messageChannel ?? params.messageProvider,
+            agentAccountId: params.agentAccountId,
+            messageTo: params.messageTo,
+            messageThreadId: params.messageThreadId,
+            groupId: params.groupId,
+            groupChannel: params.groupChannel,
+            groupSpace: params.groupSpace,
+            spawnedBy: params.spawnedBy,
+            senderId: params.senderId,
+            senderName: params.senderName,
+            senderUsername: params.senderUsername,
+            senderE164: params.senderE164,
+            senderIsOwner: params.senderIsOwner,
+            allowGatewaySubagentBinding: params.allowGatewaySubagentBinding,
+            sessionKey: sandboxSessionKey,
+            sessionId: params.sessionId,
+            runId: params.runId,
+            agentDir,
+            workspaceDir: effectiveWorkspace,
+            // When sandboxing uses a copied workspace (`ro` or `none`), effectiveWorkspace points
+            // at the sandbox copy. Spawned subagents should inherit the real workspace instead.
+            spawnWorkspaceDir: resolveAttemptSpawnWorkspaceDir({
+              sandbox,
+              resolvedWorkspace,
+            }),
+            config: params.config,
+            abortSignal: runAbortController.signal,
+            modelProvider: params.model.provider,
+            modelId: params.modelId,
+            modelCompat: params.model.compat,
+            modelApi: params.model.api,
+            modelContextWindowTokens: params.model.contextWindow,
+            modelAuthMode: resolveModelAuthMode(params.model.provider, params.config),
+            currentChannelId: params.currentChannelId,
+            currentThreadTs: params.currentThreadTs,
+            currentMessageId: params.currentMessageId,
+            replyToMode: params.replyToMode,
+            hasRepliedRef: params.hasRepliedRef,
+            modelHasVision,
+            requireExplicitMessageTarget:
+              params.requireExplicitMessageTarget ?? isSubagentSessionKey(params.sessionKey),
+            disableMessageTool: params.disableMessageTool,
+            onYield: (message) => {
+              yieldDetected = true;
+              yieldMessage = message;
+              queueYieldInterruptForSession?.();
+              runAbortController.abort("sessions_yield");
+              abortSessionForYield?.();
+            },
+          });
           if (params.toolsAllow && params.toolsAllow.length > 0) {
             const allowSet = new Set(params.toolsAllow);
             return allTools.filter((tool) => allowSet.has(tool.name));
@@ -621,7 +621,7 @@ export async function runEmbeddedAttempt(
     const promptMode = resolvePromptModeForSession(params.sessionKey);
 
     // When toolsAllow is set, use minimal prompt and strip skills catalog
-    const effectivePromptMode = params.toolsAllow?.length ? "minimal" as const : promptMode;
+    const effectivePromptMode = params.toolsAllow?.length ? ("minimal" as const) : promptMode;
     const effectiveSkillsPrompt = params.toolsAllow?.length ? undefined : skillsPrompt;
     const docsPath = await resolveOpenClawDocsPath({
       workspaceDir: effectiveWorkspace,

--- a/src/agents/pi-embedded-runner/run/helpers.ts
+++ b/src/agents/pi-embedded-runner/run/helpers.ts
@@ -38,7 +38,9 @@ export function resolveOverloadProfileRotationLimit(cfg?: OpenClawConfig): numbe
 }
 
 export function resolveRateLimitProfileRotationLimit(cfg?: OpenClawConfig): number {
-  return cfg?.auth?.cooldowns?.rateLimitedProfileRotations ?? DEFAULT_MAX_RATE_LIMIT_PROFILE_ROTATIONS;
+  return (
+    cfg?.auth?.cooldowns?.rateLimitedProfileRotations ?? DEFAULT_MAX_RATE_LIMIT_PROFILE_ROTATIONS
+  );
 }
 
 const ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL = "ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL";

--- a/src/auto-reply/media-note.test.ts
+++ b/src/auto-reply/media-note.test.ts
@@ -176,4 +176,22 @@ describe("buildInboundMediaNote", () => {
     // No transcription = keep audio attachment as fallback
     expect(note).toBe("[media attached: /tmp/voice.ogg (audio/ogg)]");
   });
+
+  it("includes attachment dimensions when available", () => {
+    const note = buildInboundMediaNote({
+      MediaPath: "/tmp/photo.jpg",
+      MediaType: "image/jpeg",
+      MediaDimension: { width: 4000, height: 3000 },
+    });
+    expect(note).toBe("[media attached: /tmp/photo.jpg (image/jpeg, 4000x3000)]");
+  });
+
+  it("includes attachment captions when available", () => {
+    const note = buildInboundMediaNote({
+      MediaPath: "/tmp/photo.jpg",
+      MediaType: "image/jpeg",
+      MediaCaption: "sunset over the ocean",
+    });
+    expect(note).toBe('[media attached: /tmp/photo.jpg (image/jpeg, "sunset over the ocean")]');
+  });
 });

--- a/src/auto-reply/media-note.ts
+++ b/src/auto-reply/media-note.ts
@@ -4,6 +4,9 @@ function formatMediaAttachedLine(params: {
   path: string;
   url?: string;
   type?: string;
+  caption?: string;
+  width?: number;
+  height?: number;
   index?: number;
   total?: number;
 }): string {
@@ -11,7 +14,17 @@ function formatMediaAttachedLine(params: {
     typeof params.index === "number" && typeof params.total === "number"
       ? `[media attached ${params.index}/${params.total}: `
       : "[media attached: ";
-  const typePart = params.type?.trim() ? ` (${params.type.trim()})` : "";
+  const details: string[] = [];
+  if (params.type?.trim()) {
+    details.push(params.type.trim());
+  }
+  if (typeof params.width === "number" && typeof params.height === "number") {
+    details.push(`${params.width}x${params.height}`);
+  }
+  if (params.caption?.trim()) {
+    details.push(JSON.stringify(params.caption.trim()));
+  }
+  const typePart = details.length > 0 ? ` (${details.join(", ")})` : "";
   const urlRaw = params.url?.trim();
   const urlPart = urlRaw ? ` | ${urlRaw}` : "";
   return `${prefix}${params.path}${typePart}${urlPart}]`;
@@ -97,11 +110,23 @@ export function buildInboundMediaNote(ctx: MsgContext): string | undefined {
   // when there is a single attachment to avoid stripping unrelated audio files.
   const canStripSingleAttachmentByTranscript = hasTranscript && paths.length === 1;
 
+  const captions =
+    Array.isArray(ctx.MediaCaptions) && ctx.MediaCaptions.length === paths.length
+      ? ctx.MediaCaptions
+      : undefined;
+  const dimensions =
+    Array.isArray(ctx.MediaDimensions) && ctx.MediaDimensions.length === paths.length
+      ? ctx.MediaDimensions
+      : undefined;
+
   const entries = paths
     .map((entry, index) => ({
       path: entry ?? "",
       type: types?.[index] ?? ctx.MediaType,
       url: urls?.[index] ?? ctx.MediaUrl,
+      caption: captions?.[index] ?? ctx.MediaCaption,
+      width: dimensions?.[index]?.width ?? ctx.MediaDimension?.width,
+      height: dimensions?.[index]?.height ?? ctx.MediaDimension?.height,
       index,
     }))
     .filter((entry) => {
@@ -134,6 +159,9 @@ export function buildInboundMediaNote(ctx: MsgContext): string | undefined {
       path: entries[0]?.path ?? "",
       type: entries[0]?.type,
       url: entries[0]?.url,
+      caption: entries[0]?.caption,
+      width: entries[0]?.width,
+      height: entries[0]?.height,
     });
   }
 
@@ -147,6 +175,9 @@ export function buildInboundMediaNote(ctx: MsgContext): string | undefined {
         total: count,
         type: entry.type,
         url: entry.url,
+        caption: entry.caption,
+        width: entry.width,
+        height: entry.height,
       }),
     );
   }

--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -331,6 +331,29 @@ describe("buildInboundUserContextPrefix", () => {
     expect(conversationInfo["history_count"]).toBe(1);
   });
 
+  it("includes edit_target_id when edit context is provided", () => {
+    const text = buildInboundUserContextPrefix({
+      ChatType: "group",
+      MessageSid: "1700000000999",
+      EditTargetTimestamp: 1700000000111,
+    } as TemplateContext);
+
+    const conversationInfo = parseConversationInfoPayload(text);
+    expect(conversationInfo["edit_target_id"]).toBe("1700000000111");
+    expect(conversationInfo["has_edit_context"]).toBe(true);
+  });
+
+  it("omits edit_target_id when edit context is absent", () => {
+    const text = buildInboundUserContextPrefix({
+      ChatType: "group",
+      MessageSid: "1700000000999",
+    } as TemplateContext);
+
+    const conversationInfo = parseConversationInfoPayload(text);
+    expect(conversationInfo["edit_target_id"]).toBeUndefined();
+    expect(conversationInfo["has_edit_context"]).toBeUndefined();
+  });
+
   it("trims sender_id in conversation info", () => {
     const text = buildInboundUserContextPrefix({
       ChatType: "group",

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -90,9 +90,14 @@ export function buildInboundUserContextPrefix(
   const resolvedMessageId = messageId ?? messageIdFull;
   const timestampStr = formatConversationTimestamp(ctx.Timestamp, envelope);
 
+  const editTargetId =
+    typeof ctx.EditTargetTimestamp === "number" && Number.isFinite(ctx.EditTargetTimestamp)
+      ? String(ctx.EditTargetTimestamp)
+      : undefined;
   const conversationInfo = {
     message_id: shouldIncludeConversationInfo ? resolvedMessageId : undefined,
     reply_to_id: shouldIncludeConversationInfo ? safeTrim(ctx.ReplyToId) : undefined,
+    edit_target_id: shouldIncludeConversationInfo ? editTargetId : undefined,
     sender_id: shouldIncludeConversationInfo ? safeTrim(ctx.SenderId) : undefined,
     conversation_label: isDirect ? undefined : safeTrim(ctx.ConversationLabel),
     sender: shouldIncludeConversationInfo
@@ -111,6 +116,7 @@ export function buildInboundUserContextPrefix(
     is_group_chat: !isDirect ? true : undefined,
     was_mentioned: ctx.WasMentioned === true ? true : undefined,
     has_reply_context: ctx.ReplyToBody ? true : undefined,
+    has_edit_context: editTargetId ? true : undefined,
     has_forwarded_context: ctx.ForwardedFrom ? true : undefined,
     has_thread_starter: safeTrim(ctx.ThreadStarterBody) ? true : undefined,
     history_count:
@@ -157,6 +163,17 @@ export function buildInboundUserContextPrefix(
         "Thread starter (untrusted, for context):",
         "```json",
         JSON.stringify({ body: ctx.ThreadStarterBody }, null, 2),
+        "```",
+      ].join("\n"),
+    );
+  }
+
+  if (ctx.EditOriginalBody) {
+    blocks.push(
+      [
+        "Edited message original body (untrusted, for context):",
+        "```json",
+        JSON.stringify({ body: ctx.EditOriginalBody }, null, 2),
         "```",
       ].join("\n"),
     );

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -108,6 +108,18 @@ export type MsgContext = {
   Sticker?: StickerContextMetadata;
   /** True when current-turn sticker media is present in MediaPaths (false for cached-description path). */
   StickerMediaIncluded?: boolean;
+  /** Provider-specific timestamp/id targeted by an edit message. */
+  EditTargetTimestamp?: number;
+  /** Original body for an edited message, resolved from local inbound cache. */
+  EditOriginalBody?: string;
+  /** Single attachment caption. */
+  MediaCaption?: string;
+  /** Array of all attachment captions. */
+  MediaCaptions?: string[];
+  /** Single attachment dimensions. */
+  MediaDimension?: { width?: number; height?: number };
+  /** Array of all attachment dimensions. */
+  MediaDimensions?: Array<{ width?: number; height?: number }>;
   OutputDir?: string;
   OutputBase?: string;
   /** Remote host for SCP when media lives on a different machine (e.g., openclaw@192.168.64.3). */

--- a/src/config/types.signal.ts
+++ b/src/config/types.signal.ts
@@ -52,6 +52,10 @@ export type SignalAccountConfig = CommonChannelMessagingConfig & {
    * - "extensive": Agent can react liberally
    */
   reactionLevel?: SignalReactionLevel;
+  /** Extract link preview metadata into UntrustedContext (default: true). */
+  injectLinkPreviews?: boolean;
+  /** Apply Signal text styles (bold, italic, etc.) to message text as markdown (default: true). */
+  preserveTextStyles?: boolean;
 };
 
 export type SignalConfig = {

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -1077,6 +1077,8 @@ export const SignalAccountSchemaBase = z
       .strict()
       .optional(),
     reactionLevel: z.enum(["off", "ack", "minimal", "extensive"]).optional(),
+    injectLinkPreviews: z.boolean().optional(),
+    preserveTextStyles: z.boolean().optional(),
     heartbeat: ChannelHeartbeatVisibilitySchema,
     healthMonitor: ChannelHealthMonitorSchema,
     responsePrefix: z.string().optional(),

--- a/src/media/constants.ts
+++ b/src/media/constants.ts
@@ -9,22 +9,27 @@ export function mediaKindFromMime(mime?: string | null): MediaKind | undefined {
   if (!mime) {
     return undefined;
   }
-  if (mime.startsWith("image/")) {
+  // Normalize: trim, lowercase, and strip parameters (e.g. "; charset=utf-8")
+  const normalized = mime.trim().toLowerCase().replace(/;.*$/, "").trim();
+  if (!normalized) {
+    return undefined;
+  }
+  if (normalized.startsWith("image/")) {
     return "image";
   }
-  if (mime.startsWith("audio/")) {
+  if (normalized.startsWith("audio/")) {
     return "audio";
   }
-  if (mime.startsWith("video/")) {
+  if (normalized.startsWith("video/")) {
     return "video";
   }
-  if (mime === "application/pdf") {
+  if (normalized === "application/pdf") {
     return "document";
   }
-  if (mime.startsWith("text/")) {
+  if (normalized.startsWith("text/")) {
     return "document";
   }
-  if (mime.startsWith("application/")) {
+  if (normalized.startsWith("application/")) {
     return "document";
   }
   return undefined;

--- a/src/plugin-sdk/command-surface.ts
+++ b/src/plugin-sdk/command-surface.ts
@@ -1,4 +1,1 @@
-export {
-  normalizeCommandBody,
-  shouldHandleTextCommands,
-} from "../auto-reply/commands-registry.js";
+export { normalizeCommandBody, shouldHandleTextCommands } from "../auto-reply/commands-registry.js";

--- a/src/plugin-sdk/session-store-runtime.ts
+++ b/src/plugin-sdk/session-store-runtime.ts
@@ -1,4 +1,1 @@
-export {
-  readSessionUpdatedAt,
-  resolveStorePath,
-} from "../config/sessions.js";
+export { readSessionUpdatedAt, resolveStorePath } from "../config/sessions.js";

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -109,8 +109,9 @@ function renderCronFilterIcon(hiddenCount: number) {
         <circle cx="12" cy="12" r="10"></circle>
         <polyline points="12 6 12 12 16 14"></polyline>
       </svg>
-      ${hiddenCount > 0
-        ? html`<span
+      ${
+        hiddenCount > 0
+          ? html`<span
             style="
               position: absolute;
               top: -5px;
@@ -125,7 +126,8 @@ function renderCronFilterIcon(hiddenCount: number) {
             "
             >${hiddenCount}</span
           >`
-        : ""}
+          : ""
+      }
     </span>
   `;
 }
@@ -311,11 +313,13 @@ export function renderChatControls(state: AppViewState) {
           state.sessionsHideCron = !hideCron;
         }}
         aria-pressed=${hideCron}
-        title=${hideCron
-          ? hiddenCronCount > 0
-            ? t("chat.showCronSessionsHidden", { count: String(hiddenCronCount) })
-            : t("chat.showCronSessions")
-          : t("chat.hideCronSessions")}
+        title=${
+          hideCron
+            ? hiddenCronCount > 0
+              ? t("chat.showCronSessionsHidden", { count: String(hiddenCronCount) })
+              : t("chat.showCronSessions")
+            : t("chat.hideCronSessions")
+        }
       >
         ${renderCronFilterIcon(hiddenCronCount)}
       </button>
@@ -941,9 +945,9 @@ export function renderTopbarThemeModeToggle(state: AppViewState) {
         (opt) => html`
           <button
             type="button"
-            class="topbar-theme-mode__btn ${opt.id === state.themeMode
-              ? "topbar-theme-mode__btn--active"
-              : ""}"
+            class="topbar-theme-mode__btn ${
+              opt.id === state.themeMode ? "topbar-theme-mode__btn--active" : ""
+            }"
             title=${opt.label}
             aria-label="Color mode: ${opt.label}"
             aria-pressed=${opt.id === state.themeMode}

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -414,11 +414,11 @@ export function renderApp(state: AppViewState) {
       },
     })}
     <div
-      class="shell ${isChat ? "shell--chat" : ""} ${chatFocus
-        ? "shell--chat-focus"
-        : ""} ${navCollapsed ? "shell--nav-collapsed" : ""} ${navDrawerOpen
-        ? "shell--nav-drawer-open"
-        : ""} ${state.onboarding ? "shell--onboarding" : ""}"
+      class="shell ${isChat ? "shell--chat" : ""} ${
+        chatFocus ? "shell--chat-focus" : ""
+      } ${navCollapsed ? "shell--nav-collapsed" : ""} ${
+        navDrawerOpen ? "shell--nav-drawer-open" : ""
+      } ${state.onboarding ? "shell--onboarding" : ""}"
     >
       <button
         type="button"
@@ -469,9 +469,10 @@ export function renderApp(state: AppViewState) {
           <div class="sidebar-shell">
             <div class="sidebar-shell__header">
               <div class="sidebar-brand">
-                ${navCollapsed
-                  ? nothing
-                  : html`
+                ${
+                  navCollapsed
+                    ? nothing
+                    : html`
                       <img
                         class="sidebar-brand__logo"
                         src="${agentLogoUrl(basePath)}"
@@ -481,7 +482,8 @@ export function renderApp(state: AppViewState) {
                         <span class="sidebar-brand__eyebrow">${t("nav.control")}</span>
                         <span class="sidebar-brand__title">OpenClaw</span>
                       </span>
-                    `}
+                    `
+                }
               </div>
               <button
                 type="button"
@@ -508,8 +510,9 @@ export function renderApp(state: AppViewState) {
 
                   return html`
                     <section class="nav-section ${!showItems ? "nav-section--collapsed" : ""}">
-                      ${!navCollapsed
-                        ? html`
+                      ${
+                        !navCollapsed
+                          ? html`
                             <button
                               class="nav-section__label"
                               @click=${() => {
@@ -528,7 +531,8 @@ export function renderApp(state: AppViewState) {
                               <span class="nav-section__chevron"> ${icons.chevronDown} </span>
                             </button>
                           `
-                        : nothing}
+                          : nothing
+                      }
                       <div class="nav-section__items">
                         ${group.tabs.map((tab) =>
                           renderTab(state, tab, { collapsed: navCollapsed }),
@@ -549,12 +553,14 @@ export function renderApp(state: AppViewState) {
                   title="${t("common.docs")} (opens in new tab)"
                 >
                   <span class="nav-item__icon" aria-hidden="true">${icons.book}</span>
-                  ${!navCollapsed
-                    ? html`
+                  ${
+                    !navCollapsed
+                      ? html`
                         <span class="nav-item__text">${t("common.docs")}</span>
                         <span class="nav-item__external-icon">${icons.externalLink}</span>
                       `
-                    : nothing}
+                      : nothing
+                  }
                 </a>
                 <div class="sidebar-mode-switch">${renderTopbarThemeModeToggle(state)}</div>
                 ${(() => {
@@ -562,13 +568,15 @@ export function renderApp(state: AppViewState) {
                   return version
                     ? html`
                         <div class="sidebar-version" title=${`v${version}`}>
-                          ${!navCollapsed
-                            ? html`
+                          ${
+                            !navCollapsed
+                              ? html`
                                 <span class="sidebar-version__label">${t("common.version")}</span>
                                 <span class="sidebar-version__text">v${version}</span>
                                 ${renderSidebarConnectionStatus(state)}
                               `
-                            : html` ${renderSidebarConnectionStatus(state)} `}
+                              : html` ${renderSidebarConnectionStatus(state)} `
+                          }
                         </div>
                       `
                     : nothing;
@@ -579,10 +587,11 @@ export function renderApp(state: AppViewState) {
         </aside>
       </div>
       <main class="content ${isChat ? "content--chat" : ""}">
-        ${state.updateAvailable &&
-        state.updateAvailable.latestVersion !== state.updateAvailable.currentVersion &&
-        !isUpdateBannerDismissed(state.updateAvailable)
-          ? html`<div class="update-banner callout danger" role="alert">
+        ${
+          state.updateAvailable &&
+          state.updateAvailable.latestVersion !== state.updateAvailable.currentVersion &&
+          !isUpdateBannerDismissed(state.updateAvailable)
+            ? html`<div class="update-banner callout danger" role="alert">
               <strong>Update available:</strong> v${state.updateAvailable.latestVersion} (running
               v${state.updateAvailable.currentVersion}).
               <button
@@ -605,1379 +614,1431 @@ export function renderApp(state: AppViewState) {
                 ${icons.x}
               </button>
             </div>`
-          : nothing}
-        ${state.tab === "config"
-          ? nothing
-          : html`<section class="content-header">
+            : nothing
+        }
+        ${
+          state.tab === "config"
+            ? nothing
+            : html`<section class="content-header">
               <div>
-                ${isChat
-                  ? renderChatSessionSelect(state)
-                  : html`<div class="page-title">${titleForTab(state.tab)}</div>`}
+                ${
+                  isChat
+                    ? renderChatSessionSelect(state)
+                    : html`<div class="page-title">${titleForTab(state.tab)}</div>`
+                }
                 ${isChat ? nothing : html`<div class="page-sub">${subtitleForTab(state.tab)}</div>`}
               </div>
               <div class="page-meta">
-                ${state.lastError
-                  ? html`<div class="pill danger">${state.lastError}</div>`
-                  : nothing}
+                ${
+                  state.lastError
+                    ? html`<div class="pill danger">${state.lastError}</div>`
+                    : nothing
+                }
                 ${isChat ? renderChatControls(state) : nothing}
               </div>
-            </section>`}
-        ${state.tab === "overview"
-          ? renderOverview({
-              connected: state.connected,
-              hello: state.hello,
-              settings: state.settings,
-              password: state.password,
-              lastError: state.lastError,
-              lastErrorCode: state.lastErrorCode,
-              presenceCount,
-              sessionsCount,
-              cronEnabled: state.cronStatus?.enabled ?? null,
-              cronNext,
-              lastChannelsRefresh: state.channelsLastSuccess,
-              usageResult: state.usageResult,
-              sessionsResult: state.sessionsResult,
-              skillsReport: state.skillsReport,
-              cronJobs: state.cronJobs,
-              cronStatus: state.cronStatus,
-              attentionItems: state.attentionItems,
-              eventLog: state.eventLog,
-              overviewLogLines: state.overviewLogLines,
-              showGatewayToken: state.overviewShowGatewayToken,
-              showGatewayPassword: state.overviewShowGatewayPassword,
-              onSettingsChange: (next) => state.applySettings(next),
-              onPasswordChange: (next) => (state.password = next),
-              onSessionKeyChange: (next) => {
-                state.sessionKey = next;
-                state.chatMessage = "";
-                state.resetToolStream();
-                state.applySettings({
-                  ...state.settings,
-                  sessionKey: next,
-                  lastActiveSessionKey: next,
-                });
-                void state.loadAssistantIdentity();
-              },
-              onToggleGatewayTokenVisibility: () => {
-                state.overviewShowGatewayToken = !state.overviewShowGatewayToken;
-              },
-              onToggleGatewayPasswordVisibility: () => {
-                state.overviewShowGatewayPassword = !state.overviewShowGatewayPassword;
-              },
-              onConnect: () => state.connect(),
-              onRefresh: () => state.loadOverview(),
-              onNavigate: (tab) => state.setTab(tab as import("./navigation.ts").Tab),
-              onRefreshLogs: () => state.loadOverview(),
-            })
-          : nothing}
-        ${state.tab === "channels"
-          ? lazyRender(lazyChannels, (m) =>
-              m.renderChannels({
+            </section>`
+        }
+        ${
+          state.tab === "overview"
+            ? renderOverview({
                 connected: state.connected,
-                loading: state.channelsLoading,
-                snapshot: state.channelsSnapshot,
-                lastError: state.channelsError,
-                lastSuccessAt: state.channelsLastSuccess,
-                whatsappMessage: state.whatsappLoginMessage,
-                whatsappQrDataUrl: state.whatsappLoginQrDataUrl,
-                whatsappConnected: state.whatsappLoginConnected,
-                whatsappBusy: state.whatsappBusy,
-                configSchema: state.configSchema,
-                configSchemaLoading: state.configSchemaLoading,
-                configForm: state.configForm,
-                configUiHints: state.configUiHints,
-                configSaving: state.configSaving,
-                configFormDirty: state.configFormDirty,
-                nostrProfileFormState: state.nostrProfileFormState,
-                nostrProfileAccountId: state.nostrProfileAccountId,
-                onRefresh: (probe) => loadChannels(state, probe),
-                onWhatsAppStart: (force) => state.handleWhatsAppStart(force),
-                onWhatsAppWait: () => state.handleWhatsAppWait(),
-                onWhatsAppLogout: () => state.handleWhatsAppLogout(),
-                onConfigPatch: (path, value) => updateConfigFormValue(state, path, value),
-                onConfigSave: () => state.handleChannelConfigSave(),
-                onConfigReload: () => state.handleChannelConfigReload(),
-                onNostrProfileEdit: (accountId, profile) =>
-                  state.handleNostrProfileEdit(accountId, profile),
-                onNostrProfileCancel: () => state.handleNostrProfileCancel(),
-                onNostrProfileFieldChange: (field, value) =>
-                  state.handleNostrProfileFieldChange(field, value),
-                onNostrProfileSave: () => state.handleNostrProfileSave(),
-                onNostrProfileImport: () => state.handleNostrProfileImport(),
-                onNostrProfileToggleAdvanced: () => state.handleNostrProfileToggleAdvanced(),
-              }),
-            )
-          : nothing}
-        ${state.tab === "instances"
-          ? lazyRender(lazyInstances, (m) =>
-              m.renderInstances({
-                loading: state.presenceLoading,
-                entries: state.presenceEntries,
-                lastError: state.presenceError,
-                statusMessage: state.presenceStatus,
-                onRefresh: () => loadPresence(state),
-              }),
-            )
-          : nothing}
-        ${state.tab === "sessions"
-          ? lazyRender(lazySessions, (m) =>
-              m.renderSessions({
-                loading: state.sessionsLoading,
-                result: state.sessionsResult,
-                error: state.sessionsError,
-                activeMinutes: state.sessionsFilterActive,
-                limit: state.sessionsFilterLimit,
-                includeGlobal: state.sessionsIncludeGlobal,
-                includeUnknown: state.sessionsIncludeUnknown,
-                basePath: state.basePath,
-                searchQuery: state.sessionsSearchQuery,
-                sortColumn: state.sessionsSortColumn,
-                sortDir: state.sessionsSortDir,
-                page: state.sessionsPage,
-                pageSize: state.sessionsPageSize,
-                selectedKeys: state.sessionsSelectedKeys,
-                onFiltersChange: (next) => {
-                  state.sessionsFilterActive = next.activeMinutes;
-                  state.sessionsFilterLimit = next.limit;
-                  state.sessionsIncludeGlobal = next.includeGlobal;
-                  state.sessionsIncludeUnknown = next.includeUnknown;
+                hello: state.hello,
+                settings: state.settings,
+                password: state.password,
+                lastError: state.lastError,
+                lastErrorCode: state.lastErrorCode,
+                presenceCount,
+                sessionsCount,
+                cronEnabled: state.cronStatus?.enabled ?? null,
+                cronNext,
+                lastChannelsRefresh: state.channelsLastSuccess,
+                usageResult: state.usageResult,
+                sessionsResult: state.sessionsResult,
+                skillsReport: state.skillsReport,
+                cronJobs: state.cronJobs,
+                cronStatus: state.cronStatus,
+                attentionItems: state.attentionItems,
+                eventLog: state.eventLog,
+                overviewLogLines: state.overviewLogLines,
+                showGatewayToken: state.overviewShowGatewayToken,
+                showGatewayPassword: state.overviewShowGatewayPassword,
+                onSettingsChange: (next) => state.applySettings(next),
+                onPasswordChange: (next) => (state.password = next),
+                onSessionKeyChange: (next) => {
+                  state.sessionKey = next;
+                  state.chatMessage = "";
+                  state.resetToolStream();
+                  state.applySettings({
+                    ...state.settings,
+                    sessionKey: next,
+                    lastActiveSessionKey: next,
+                  });
+                  void state.loadAssistantIdentity();
                 },
-                onSearchChange: (q) => {
-                  state.sessionsSearchQuery = q;
-                  state.sessionsPage = 0;
+                onToggleGatewayTokenVisibility: () => {
+                  state.overviewShowGatewayToken = !state.overviewShowGatewayToken;
                 },
-                onSortChange: (col, dir) => {
-                  state.sessionsSortColumn = col;
-                  state.sessionsSortDir = dir;
-                  state.sessionsPage = 0;
+                onToggleGatewayPasswordVisibility: () => {
+                  state.overviewShowGatewayPassword = !state.overviewShowGatewayPassword;
                 },
-                onPageChange: (p) => {
-                  state.sessionsPage = p;
-                },
-                onPageSizeChange: (s) => {
-                  state.sessionsPageSize = s;
-                  state.sessionsPage = 0;
-                },
-                onRefresh: () => loadSessions(state),
-                onPatch: (key, patch) => patchSession(state, key, patch),
-                onToggleSelect: (key) => {
-                  const next = new Set(state.sessionsSelectedKeys);
-                  if (next.has(key)) {
-                    next.delete(key);
-                  } else {
-                    next.add(key);
-                  }
-                  state.sessionsSelectedKeys = next;
-                },
-                onSelectPage: (keys) => {
-                  const next = new Set(state.sessionsSelectedKeys);
-                  for (const k of keys) {
-                    next.add(k);
-                  }
-                  state.sessionsSelectedKeys = next;
-                },
-                onDeselectPage: (keys) => {
-                  const next = new Set(state.sessionsSelectedKeys);
-                  for (const k of keys) {
-                    next.delete(k);
-                  }
-                  state.sessionsSelectedKeys = next;
-                },
-                onDeselectAll: () => {
-                  state.sessionsSelectedKeys = new Set();
-                },
-                onDeleteSelected: async () => {
-                  const keys = [...state.sessionsSelectedKeys];
-                  const deleted = await deleteSessionsAndRefresh(state, keys);
-                  if (deleted.length > 0) {
+                onConnect: () => state.connect(),
+                onRefresh: () => state.loadOverview(),
+                onNavigate: (tab) => state.setTab(tab as import("./navigation.ts").Tab),
+                onRefreshLogs: () => state.loadOverview(),
+              })
+            : nothing
+        }
+        ${
+          state.tab === "channels"
+            ? lazyRender(lazyChannels, (m) =>
+                m.renderChannels({
+                  connected: state.connected,
+                  loading: state.channelsLoading,
+                  snapshot: state.channelsSnapshot,
+                  lastError: state.channelsError,
+                  lastSuccessAt: state.channelsLastSuccess,
+                  whatsappMessage: state.whatsappLoginMessage,
+                  whatsappQrDataUrl: state.whatsappLoginQrDataUrl,
+                  whatsappConnected: state.whatsappLoginConnected,
+                  whatsappBusy: state.whatsappBusy,
+                  configSchema: state.configSchema,
+                  configSchemaLoading: state.configSchemaLoading,
+                  configForm: state.configForm,
+                  configUiHints: state.configUiHints,
+                  configSaving: state.configSaving,
+                  configFormDirty: state.configFormDirty,
+                  nostrProfileFormState: state.nostrProfileFormState,
+                  nostrProfileAccountId: state.nostrProfileAccountId,
+                  onRefresh: (probe) => loadChannels(state, probe),
+                  onWhatsAppStart: (force) => state.handleWhatsAppStart(force),
+                  onWhatsAppWait: () => state.handleWhatsAppWait(),
+                  onWhatsAppLogout: () => state.handleWhatsAppLogout(),
+                  onConfigPatch: (path, value) => updateConfigFormValue(state, path, value),
+                  onConfigSave: () => state.handleChannelConfigSave(),
+                  onConfigReload: () => state.handleChannelConfigReload(),
+                  onNostrProfileEdit: (accountId, profile) =>
+                    state.handleNostrProfileEdit(accountId, profile),
+                  onNostrProfileCancel: () => state.handleNostrProfileCancel(),
+                  onNostrProfileFieldChange: (field, value) =>
+                    state.handleNostrProfileFieldChange(field, value),
+                  onNostrProfileSave: () => state.handleNostrProfileSave(),
+                  onNostrProfileImport: () => state.handleNostrProfileImport(),
+                  onNostrProfileToggleAdvanced: () => state.handleNostrProfileToggleAdvanced(),
+                }),
+              )
+            : nothing
+        }
+        ${
+          state.tab === "instances"
+            ? lazyRender(lazyInstances, (m) =>
+                m.renderInstances({
+                  loading: state.presenceLoading,
+                  entries: state.presenceEntries,
+                  lastError: state.presenceError,
+                  statusMessage: state.presenceStatus,
+                  onRefresh: () => loadPresence(state),
+                }),
+              )
+            : nothing
+        }
+        ${
+          state.tab === "sessions"
+            ? lazyRender(lazySessions, (m) =>
+                m.renderSessions({
+                  loading: state.sessionsLoading,
+                  result: state.sessionsResult,
+                  error: state.sessionsError,
+                  activeMinutes: state.sessionsFilterActive,
+                  limit: state.sessionsFilterLimit,
+                  includeGlobal: state.sessionsIncludeGlobal,
+                  includeUnknown: state.sessionsIncludeUnknown,
+                  basePath: state.basePath,
+                  searchQuery: state.sessionsSearchQuery,
+                  sortColumn: state.sessionsSortColumn,
+                  sortDir: state.sessionsSortDir,
+                  page: state.sessionsPage,
+                  pageSize: state.sessionsPageSize,
+                  selectedKeys: state.sessionsSelectedKeys,
+                  onFiltersChange: (next) => {
+                    state.sessionsFilterActive = next.activeMinutes;
+                    state.sessionsFilterLimit = next.limit;
+                    state.sessionsIncludeGlobal = next.includeGlobal;
+                    state.sessionsIncludeUnknown = next.includeUnknown;
+                  },
+                  onSearchChange: (q) => {
+                    state.sessionsSearchQuery = q;
+                    state.sessionsPage = 0;
+                  },
+                  onSortChange: (col, dir) => {
+                    state.sessionsSortColumn = col;
+                    state.sessionsSortDir = dir;
+                    state.sessionsPage = 0;
+                  },
+                  onPageChange: (p) => {
+                    state.sessionsPage = p;
+                  },
+                  onPageSizeChange: (s) => {
+                    state.sessionsPageSize = s;
+                    state.sessionsPage = 0;
+                  },
+                  onRefresh: () => loadSessions(state),
+                  onPatch: (key, patch) => patchSession(state, key, patch),
+                  onToggleSelect: (key) => {
                     const next = new Set(state.sessionsSelectedKeys);
-                    for (const k of deleted) {
+                    if (next.has(key)) {
+                      next.delete(key);
+                    } else {
+                      next.add(key);
+                    }
+                    state.sessionsSelectedKeys = next;
+                  },
+                  onSelectPage: (keys) => {
+                    const next = new Set(state.sessionsSelectedKeys);
+                    for (const k of keys) {
+                      next.add(k);
+                    }
+                    state.sessionsSelectedKeys = next;
+                  },
+                  onDeselectPage: (keys) => {
+                    const next = new Set(state.sessionsSelectedKeys);
+                    for (const k of keys) {
                       next.delete(k);
                     }
                     state.sessionsSelectedKeys = next;
-                  }
-                },
-                onNavigateToChat: (sessionKey) => {
-                  switchChatSession(state, sessionKey);
-                  state.setTab("chat" as import("./navigation.ts").Tab);
-                },
-              }),
-            )
-          : nothing}
+                  },
+                  onDeselectAll: () => {
+                    state.sessionsSelectedKeys = new Set();
+                  },
+                  onDeleteSelected: async () => {
+                    const keys = [...state.sessionsSelectedKeys];
+                    const deleted = await deleteSessionsAndRefresh(state, keys);
+                    if (deleted.length > 0) {
+                      const next = new Set(state.sessionsSelectedKeys);
+                      for (const k of deleted) {
+                        next.delete(k);
+                      }
+                      state.sessionsSelectedKeys = next;
+                    }
+                  },
+                  onNavigateToChat: (sessionKey) => {
+                    switchChatSession(state, sessionKey);
+                    state.setTab("chat" as import("./navigation.ts").Tab);
+                  },
+                }),
+              )
+            : nothing
+        }
         ${renderUsageTab(state)}
-        ${state.tab === "cron"
-          ? lazyRender(lazyCron, (m) =>
-              m.renderCron({
-                basePath: state.basePath,
-                loading: state.cronLoading,
-                status: state.cronStatus,
-                jobs: visibleCronJobs,
-                jobsLoadingMore: state.cronJobsLoadingMore,
-                jobsTotal: state.cronJobsTotal,
-                jobsHasMore: state.cronJobsHasMore,
-                jobsQuery: state.cronJobsQuery,
-                jobsEnabledFilter: state.cronJobsEnabledFilter,
-                jobsScheduleKindFilter: state.cronJobsScheduleKindFilter,
-                jobsLastStatusFilter: state.cronJobsLastStatusFilter,
-                jobsSortBy: state.cronJobsSortBy,
-                jobsSortDir: state.cronJobsSortDir,
-                editingJobId: state.cronEditingJobId,
-                error: state.cronError,
-                busy: state.cronBusy,
-                form: state.cronForm,
-                channels: state.channelsSnapshot?.channelMeta?.length
-                  ? state.channelsSnapshot.channelMeta.map((entry) => entry.id)
-                  : (state.channelsSnapshot?.channelOrder ?? []),
-                channelLabels: state.channelsSnapshot?.channelLabels ?? {},
-                channelMeta: state.channelsSnapshot?.channelMeta ?? [],
-                runsJobId: state.cronRunsJobId,
-                runs: state.cronRuns,
-                runsTotal: state.cronRunsTotal,
-                runsHasMore: state.cronRunsHasMore,
-                runsLoadingMore: state.cronRunsLoadingMore,
-                runsScope: state.cronRunsScope,
-                runsStatuses: state.cronRunsStatuses,
-                runsDeliveryStatuses: state.cronRunsDeliveryStatuses,
-                runsStatusFilter: state.cronRunsStatusFilter,
-                runsQuery: state.cronRunsQuery,
-                runsSortDir: state.cronRunsSortDir,
-                fieldErrors: state.cronFieldErrors,
-                canSubmit: !hasCronFormErrors(state.cronFieldErrors),
-                agentSuggestions: cronAgentSuggestions,
-                modelSuggestions: cronModelSuggestions,
-                thinkingSuggestions: CRON_THINKING_SUGGESTIONS,
-                timezoneSuggestions: CRON_TIMEZONE_SUGGESTIONS,
-                deliveryToSuggestions,
-                accountSuggestions,
-                onFormChange: (patch) => {
-                  state.cronForm = normalizeCronFormState({ ...state.cronForm, ...patch });
-                  state.cronFieldErrors = validateCronForm(state.cronForm);
-                },
-                onRefresh: () => state.loadCron(),
-                onAdd: () => addCronJob(state),
-                onEdit: (job) => startCronEdit(state, job),
-                onClone: (job) => startCronClone(state, job),
-                onCancelEdit: () => cancelCronEdit(state),
-                onToggle: (job, enabled) => toggleCronJob(state, job, enabled),
-                onRun: (job, mode) => runCronJob(state, job, mode ?? "force"),
-                onRemove: (job) => removeCronJob(state, job),
-                onLoadRuns: async (jobId) => {
-                  updateCronRunsFilter(state, { cronRunsScope: "job" });
-                  await loadCronRuns(state, jobId);
-                },
-                onLoadMoreJobs: () => loadMoreCronJobs(state),
-                onJobsFiltersChange: async (patch) => {
-                  updateCronJobsFilter(state, patch);
-                  const shouldReload =
-                    typeof patch.cronJobsQuery === "string" ||
-                    Boolean(patch.cronJobsEnabledFilter) ||
-                    Boolean(patch.cronJobsSortBy) ||
-                    Boolean(patch.cronJobsSortDir);
-                  if (shouldReload) {
-                    await reloadCronJobs(state);
-                  }
-                },
-                onJobsFiltersReset: async () => {
-                  updateCronJobsFilter(state, {
-                    cronJobsQuery: "",
-                    cronJobsEnabledFilter: "all",
-                    cronJobsScheduleKindFilter: "all",
-                    cronJobsLastStatusFilter: "all",
-                    cronJobsSortBy: "nextRunAtMs",
-                    cronJobsSortDir: "asc",
-                  });
-                  await reloadCronJobs(state);
-                },
-                onLoadMoreRuns: () => loadMoreCronRuns(state),
-                onRunsFiltersChange: async (patch) => {
-                  updateCronRunsFilter(state, patch);
-                  if (state.cronRunsScope === "all") {
-                    await loadCronRuns(state, null);
-                    return;
-                  }
-                  await loadCronRuns(state, state.cronRunsJobId);
-                },
-                onNavigateToChat: (sessionKey) => {
-                  switchChatSession(state, sessionKey);
-                  state.setTab("chat" as import("./navigation.ts").Tab);
-                },
-              }),
-            )
-          : nothing}
-        ${state.tab === "agents"
-          ? lazyRender(lazyAgents, (m) =>
-              m.renderAgents({
-                basePath: state.basePath ?? "",
-                loading: state.agentsLoading,
-                error: state.agentsError,
-                agentsList: state.agentsList,
-                selectedAgentId: resolvedAgentId,
-                activePanel: state.agentsPanel,
-                config: {
-                  form: configValue,
-                  loading: state.configLoading,
-                  saving: state.configSaving,
-                  dirty: state.configFormDirty,
-                },
-                channels: {
-                  snapshot: state.channelsSnapshot,
-                  loading: state.channelsLoading,
-                  error: state.channelsError,
-                  lastSuccess: state.channelsLastSuccess,
-                },
-                cron: {
-                  status: state.cronStatus,
-                  jobs: state.cronJobs,
+        ${
+          state.tab === "cron"
+            ? lazyRender(lazyCron, (m) =>
+                m.renderCron({
+                  basePath: state.basePath,
                   loading: state.cronLoading,
+                  status: state.cronStatus,
+                  jobs: visibleCronJobs,
+                  jobsLoadingMore: state.cronJobsLoadingMore,
+                  jobsTotal: state.cronJobsTotal,
+                  jobsHasMore: state.cronJobsHasMore,
+                  jobsQuery: state.cronJobsQuery,
+                  jobsEnabledFilter: state.cronJobsEnabledFilter,
+                  jobsScheduleKindFilter: state.cronJobsScheduleKindFilter,
+                  jobsLastStatusFilter: state.cronJobsLastStatusFilter,
+                  jobsSortBy: state.cronJobsSortBy,
+                  jobsSortDir: state.cronJobsSortDir,
+                  editingJobId: state.cronEditingJobId,
                   error: state.cronError,
-                },
-                agentFiles: {
-                  list: state.agentFilesList,
-                  loading: state.agentFilesLoading,
-                  error: state.agentFilesError,
-                  active: state.agentFileActive,
-                  contents: state.agentFileContents,
-                  drafts: state.agentFileDrafts,
-                  saving: state.agentFileSaving,
-                },
-                agentIdentityLoading: state.agentIdentityLoading,
-                agentIdentityError: state.agentIdentityError,
-                agentIdentityById: state.agentIdentityById,
-                agentSkills: {
-                  report: state.agentSkillsReport,
-                  loading: state.agentSkillsLoading,
-                  error: state.agentSkillsError,
-                  agentId: state.agentSkillsAgentId,
-                  filter: state.skillsFilter,
-                },
-                toolsCatalog: {
-                  loading: state.toolsCatalogLoading,
-                  error: state.toolsCatalogError,
-                  result: state.toolsCatalogResult,
-                },
-                toolsEffective: {
-                  loading: state.toolsEffectiveLoading,
-                  error: state.toolsEffectiveError,
-                  result: state.toolsEffectiveResult,
-                },
-                runtimeSessionKey: state.sessionKey,
-                runtimeSessionMatchesSelectedAgent: toolsPanelUsesActiveSession,
-                modelCatalog: state.chatModelCatalog ?? [],
-                onRefresh: async () => {
-                  await loadAgents(state);
-                  const agentIds = state.agentsList?.agents?.map((entry) => entry.id) ?? [];
-                  if (agentIds.length > 0) {
-                    void loadAgentIdentities(state, agentIds);
-                  }
-                  const refreshedAgentId =
-                    state.agentsSelectedId ??
-                    state.agentsList?.defaultId ??
-                    state.agentsList?.agents?.[0]?.id ??
-                    null;
-                  if (state.agentsPanel === "files" && refreshedAgentId) {
-                    void loadAgentFiles(state, refreshedAgentId);
-                  }
-                  if (state.agentsPanel === "skills" && refreshedAgentId) {
-                    void loadAgentSkills(state, refreshedAgentId);
-                  }
-                  if (state.agentsPanel === "tools" && refreshedAgentId) {
-                    void loadToolsCatalog(state, refreshedAgentId);
-                    if (refreshedAgentId === resolveAgentIdFromSessionKey(state.sessionKey)) {
-                      void loadToolsEffective(state, {
-                        agentId: refreshedAgentId,
-                        sessionKey: state.sessionKey,
-                      });
+                  busy: state.cronBusy,
+                  form: state.cronForm,
+                  channels: state.channelsSnapshot?.channelMeta?.length
+                    ? state.channelsSnapshot.channelMeta.map((entry) => entry.id)
+                    : (state.channelsSnapshot?.channelOrder ?? []),
+                  channelLabels: state.channelsSnapshot?.channelLabels ?? {},
+                  channelMeta: state.channelsSnapshot?.channelMeta ?? [],
+                  runsJobId: state.cronRunsJobId,
+                  runs: state.cronRuns,
+                  runsTotal: state.cronRunsTotal,
+                  runsHasMore: state.cronRunsHasMore,
+                  runsLoadingMore: state.cronRunsLoadingMore,
+                  runsScope: state.cronRunsScope,
+                  runsStatuses: state.cronRunsStatuses,
+                  runsDeliveryStatuses: state.cronRunsDeliveryStatuses,
+                  runsStatusFilter: state.cronRunsStatusFilter,
+                  runsQuery: state.cronRunsQuery,
+                  runsSortDir: state.cronRunsSortDir,
+                  fieldErrors: state.cronFieldErrors,
+                  canSubmit: !hasCronFormErrors(state.cronFieldErrors),
+                  agentSuggestions: cronAgentSuggestions,
+                  modelSuggestions: cronModelSuggestions,
+                  thinkingSuggestions: CRON_THINKING_SUGGESTIONS,
+                  timezoneSuggestions: CRON_TIMEZONE_SUGGESTIONS,
+                  deliveryToSuggestions,
+                  accountSuggestions,
+                  onFormChange: (patch) => {
+                    state.cronForm = normalizeCronFormState({ ...state.cronForm, ...patch });
+                    state.cronFieldErrors = validateCronForm(state.cronForm);
+                  },
+                  onRefresh: () => state.loadCron(),
+                  onAdd: () => addCronJob(state),
+                  onEdit: (job) => startCronEdit(state, job),
+                  onClone: (job) => startCronClone(state, job),
+                  onCancelEdit: () => cancelCronEdit(state),
+                  onToggle: (job, enabled) => toggleCronJob(state, job, enabled),
+                  onRun: (job, mode) => runCronJob(state, job, mode ?? "force"),
+                  onRemove: (job) => removeCronJob(state, job),
+                  onLoadRuns: async (jobId) => {
+                    updateCronRunsFilter(state, { cronRunsScope: "job" });
+                    await loadCronRuns(state, jobId);
+                  },
+                  onLoadMoreJobs: () => loadMoreCronJobs(state),
+                  onJobsFiltersChange: async (patch) => {
+                    updateCronJobsFilter(state, patch);
+                    const shouldReload =
+                      typeof patch.cronJobsQuery === "string" ||
+                      Boolean(patch.cronJobsEnabledFilter) ||
+                      Boolean(patch.cronJobsSortBy) ||
+                      Boolean(patch.cronJobsSortDir);
+                    if (shouldReload) {
+                      await reloadCronJobs(state);
                     }
-                  }
-                  if (state.agentsPanel === "channels") {
-                    void loadChannels(state, false);
-                  }
-                  if (state.agentsPanel === "cron") {
-                    void state.loadCron();
-                  }
-                },
-                onSelectAgent: (agentId) => {
-                  if (state.agentsSelectedId === agentId) {
-                    return;
-                  }
-                  state.agentsSelectedId = agentId;
-                  state.agentFilesList = null;
-                  state.agentFilesError = null;
-                  state.agentFilesLoading = false;
-                  state.agentFileActive = null;
-                  state.agentFileContents = {};
-                  state.agentFileDrafts = {};
-                  state.agentSkillsReport = null;
-                  state.agentSkillsError = null;
-                  state.agentSkillsAgentId = null;
-                  state.toolsCatalogResult = null;
-                  state.toolsCatalogError = null;
-                  state.toolsCatalogLoading = false;
-                  state.toolsEffectiveResult = null;
-                  state.toolsEffectiveResultKey = null;
-                  state.toolsEffectiveError = null;
-                  state.toolsEffectiveLoading = false;
-                  state.toolsEffectiveLoadingKey = null;
-                  void loadAgentIdentity(state, agentId);
-                  if (state.agentsPanel === "files") {
-                    void loadAgentFiles(state, agentId);
-                  }
-                  if (state.agentsPanel === "tools") {
-                    void loadToolsCatalog(state, agentId);
-                    if (agentId === resolveAgentIdFromSessionKey(state.sessionKey)) {
-                      void loadToolsEffective(state, {
-                        agentId,
-                        sessionKey: state.sessionKey,
-                      });
+                  },
+                  onJobsFiltersReset: async () => {
+                    updateCronJobsFilter(state, {
+                      cronJobsQuery: "",
+                      cronJobsEnabledFilter: "all",
+                      cronJobsScheduleKindFilter: "all",
+                      cronJobsLastStatusFilter: "all",
+                      cronJobsSortBy: "nextRunAtMs",
+                      cronJobsSortDir: "asc",
+                    });
+                    await reloadCronJobs(state);
+                  },
+                  onLoadMoreRuns: () => loadMoreCronRuns(state),
+                  onRunsFiltersChange: async (patch) => {
+                    updateCronRunsFilter(state, patch);
+                    if (state.cronRunsScope === "all") {
+                      await loadCronRuns(state, null);
+                      return;
                     }
-                  }
-                  if (state.agentsPanel === "skills") {
-                    void loadAgentSkills(state, agentId);
-                  }
-                },
-                onSelectPanel: (panel) => {
-                  state.agentsPanel = panel;
-                  if (panel === "files" && resolvedAgentId) {
-                    if (state.agentFilesList?.agentId !== resolvedAgentId) {
-                      state.agentFilesList = null;
-                      state.agentFilesError = null;
-                      state.agentFileActive = null;
-                      state.agentFileContents = {};
-                      state.agentFileDrafts = {};
-                      void loadAgentFiles(state, resolvedAgentId);
+                    await loadCronRuns(state, state.cronRunsJobId);
+                  },
+                  onNavigateToChat: (sessionKey) => {
+                    switchChatSession(state, sessionKey);
+                    state.setTab("chat" as import("./navigation.ts").Tab);
+                  },
+                }),
+              )
+            : nothing
+        }
+        ${
+          state.tab === "agents"
+            ? lazyRender(lazyAgents, (m) =>
+                m.renderAgents({
+                  basePath: state.basePath ?? "",
+                  loading: state.agentsLoading,
+                  error: state.agentsError,
+                  agentsList: state.agentsList,
+                  selectedAgentId: resolvedAgentId,
+                  activePanel: state.agentsPanel,
+                  config: {
+                    form: configValue,
+                    loading: state.configLoading,
+                    saving: state.configSaving,
+                    dirty: state.configFormDirty,
+                  },
+                  channels: {
+                    snapshot: state.channelsSnapshot,
+                    loading: state.channelsLoading,
+                    error: state.channelsError,
+                    lastSuccess: state.channelsLastSuccess,
+                  },
+                  cron: {
+                    status: state.cronStatus,
+                    jobs: state.cronJobs,
+                    loading: state.cronLoading,
+                    error: state.cronError,
+                  },
+                  agentFiles: {
+                    list: state.agentFilesList,
+                    loading: state.agentFilesLoading,
+                    error: state.agentFilesError,
+                    active: state.agentFileActive,
+                    contents: state.agentFileContents,
+                    drafts: state.agentFileDrafts,
+                    saving: state.agentFileSaving,
+                  },
+                  agentIdentityLoading: state.agentIdentityLoading,
+                  agentIdentityError: state.agentIdentityError,
+                  agentIdentityById: state.agentIdentityById,
+                  agentSkills: {
+                    report: state.agentSkillsReport,
+                    loading: state.agentSkillsLoading,
+                    error: state.agentSkillsError,
+                    agentId: state.agentSkillsAgentId,
+                    filter: state.skillsFilter,
+                  },
+                  toolsCatalog: {
+                    loading: state.toolsCatalogLoading,
+                    error: state.toolsCatalogError,
+                    result: state.toolsCatalogResult,
+                  },
+                  toolsEffective: {
+                    loading: state.toolsEffectiveLoading,
+                    error: state.toolsEffectiveError,
+                    result: state.toolsEffectiveResult,
+                  },
+                  runtimeSessionKey: state.sessionKey,
+                  runtimeSessionMatchesSelectedAgent: toolsPanelUsesActiveSession,
+                  modelCatalog: state.chatModelCatalog ?? [],
+                  onRefresh: async () => {
+                    await loadAgents(state);
+                    const agentIds = state.agentsList?.agents?.map((entry) => entry.id) ?? [];
+                    if (agentIds.length > 0) {
+                      void loadAgentIdentities(state, agentIds);
                     }
-                  }
-                  if (panel === "skills") {
-                    if (resolvedAgentId) {
-                      void loadAgentSkills(state, resolvedAgentId);
+                    const refreshedAgentId =
+                      state.agentsSelectedId ??
+                      state.agentsList?.defaultId ??
+                      state.agentsList?.agents?.[0]?.id ??
+                      null;
+                    if (state.agentsPanel === "files" && refreshedAgentId) {
+                      void loadAgentFiles(state, refreshedAgentId);
                     }
-                  }
-                  if (panel === "tools" && resolvedAgentId) {
-                    if (
-                      state.toolsCatalogResult?.agentId !== resolvedAgentId ||
-                      state.toolsCatalogError
-                    ) {
-                      void loadToolsCatalog(state, resolvedAgentId);
+                    if (state.agentsPanel === "skills" && refreshedAgentId) {
+                      void loadAgentSkills(state, refreshedAgentId);
                     }
-                    if (resolvedAgentId === resolveAgentIdFromSessionKey(state.sessionKey)) {
-                      const toolsRequestKey = buildToolsEffectiveRequestKey(state, {
-                        agentId: resolvedAgentId,
-                        sessionKey: state.sessionKey,
-                      });
-                      if (
-                        state.toolsEffectiveResultKey !== toolsRequestKey ||
-                        state.toolsEffectiveError
-                      ) {
+                    if (state.agentsPanel === "tools" && refreshedAgentId) {
+                      void loadToolsCatalog(state, refreshedAgentId);
+                      if (refreshedAgentId === resolveAgentIdFromSessionKey(state.sessionKey)) {
                         void loadToolsEffective(state, {
-                          agentId: resolvedAgentId,
+                          agentId: refreshedAgentId,
                           sessionKey: state.sessionKey,
                         });
                       }
-                    } else {
-                      state.toolsEffectiveResult = null;
-                      state.toolsEffectiveResultKey = null;
-                      state.toolsEffectiveError = null;
-                      state.toolsEffectiveLoading = false;
-                      state.toolsEffectiveLoadingKey = null;
                     }
-                  }
-                  if (panel === "channels") {
-                    void loadChannels(state, false);
-                  }
-                  if (panel === "cron") {
-                    void state.loadCron();
-                  }
-                },
-                onLoadFiles: (agentId) => loadAgentFiles(state, agentId),
-                onSelectFile: (name) => {
-                  state.agentFileActive = name;
-                  if (!resolvedAgentId) {
-                    return;
-                  }
-                  void loadAgentFileContent(state, resolvedAgentId, name);
-                },
-                onFileDraftChange: (name, content) => {
-                  state.agentFileDrafts = { ...state.agentFileDrafts, [name]: content };
-                },
-                onFileReset: (name) => {
-                  const base = state.agentFileContents[name] ?? "";
-                  state.agentFileDrafts = { ...state.agentFileDrafts, [name]: base };
-                },
-                onFileSave: (name) => {
-                  if (!resolvedAgentId) {
-                    return;
-                  }
-                  const content =
-                    state.agentFileDrafts[name] ?? state.agentFileContents[name] ?? "";
-                  void saveAgentFile(state, resolvedAgentId, name, content);
-                },
-                onToolsProfileChange: (agentId, profile, clearAllow) => {
-                  const index =
-                    profile || clearAllow ? ensureAgentIndex(agentId) : findAgentIndex(agentId);
-                  if (index < 0) {
-                    return;
-                  }
-                  const basePath = ["agents", "list", index, "tools"];
-                  if (profile) {
-                    updateConfigFormValue(state, [...basePath, "profile"], profile);
-                  } else {
-                    removeConfigFormValue(state, [...basePath, "profile"]);
-                  }
-                  if (clearAllow) {
-                    removeConfigFormValue(state, [...basePath, "allow"]);
-                  }
-                },
-                onToolsOverridesChange: (agentId, alsoAllow, deny) => {
-                  const index =
-                    alsoAllow.length > 0 || deny.length > 0
-                      ? ensureAgentIndex(agentId)
-                      : findAgentIndex(agentId);
-                  if (index < 0) {
-                    return;
-                  }
-                  const basePath = ["agents", "list", index, "tools"];
-                  if (alsoAllow.length > 0) {
-                    updateConfigFormValue(state, [...basePath, "alsoAllow"], alsoAllow);
-                  } else {
-                    removeConfigFormValue(state, [...basePath, "alsoAllow"]);
-                  }
-                  if (deny.length > 0) {
-                    updateConfigFormValue(state, [...basePath, "deny"], deny);
-                  } else {
-                    removeConfigFormValue(state, [...basePath, "deny"]);
-                  }
-                },
-                onConfigReload: () => loadConfig(state),
-                onConfigSave: () => saveAgentsConfig(state),
-                onChannelsRefresh: () => loadChannels(state, false),
-                onCronRefresh: () => state.loadCron(),
-                onCronRunNow: (jobId) => {
-                  const job = state.cronJobs.find((entry) => entry.id === jobId);
-                  if (!job) {
-                    return;
-                  }
-                  void runCronJob(state, job, "force");
-                },
-                onSkillsFilterChange: (next) => (state.skillsFilter = next),
-                onSkillsRefresh: () => {
-                  if (resolvedAgentId) {
-                    void loadAgentSkills(state, resolvedAgentId);
-                  }
-                },
-                onAgentSkillToggle: (agentId, skillName, enabled) => {
-                  const index = ensureAgentIndex(agentId);
-                  if (index < 0) {
-                    return;
-                  }
-                  const list = (getCurrentConfigValue() as { agents?: { list?: unknown[] } } | null)
-                    ?.agents?.list;
-                  const entry = Array.isArray(list)
-                    ? (list[index] as { skills?: unknown })
-                    : undefined;
-                  const normalizedSkill = skillName.trim();
-                  if (!normalizedSkill) {
-                    return;
-                  }
-                  const allSkills =
-                    state.agentSkillsReport?.skills?.map((skill) => skill.name).filter(Boolean) ??
-                    [];
-                  const existing = Array.isArray(entry?.skills)
-                    ? entry.skills.map((name) => String(name).trim()).filter(Boolean)
-                    : undefined;
-                  const base = existing ?? allSkills;
-                  const next = new Set(base);
-                  if (enabled) {
-                    next.add(normalizedSkill);
-                  } else {
-                    next.delete(normalizedSkill);
-                  }
-                  updateConfigFormValue(state, ["agents", "list", index, "skills"], [...next]);
-                },
-                onAgentSkillsClear: (agentId) => {
-                  const index = findAgentIndex(agentId);
-                  if (index < 0) {
-                    return;
-                  }
-                  removeConfigFormValue(state, ["agents", "list", index, "skills"]);
-                },
-                onAgentSkillsDisableAll: (agentId) => {
-                  const index = ensureAgentIndex(agentId);
-                  if (index < 0) {
-                    return;
-                  }
-                  updateConfigFormValue(state, ["agents", "list", index, "skills"], []);
-                },
-                onModelChange: (agentId, modelId) => {
-                  const index = modelId ? ensureAgentIndex(agentId) : findAgentIndex(agentId);
-                  if (index < 0) {
-                    return;
-                  }
-                  const list = (getCurrentConfigValue() as { agents?: { list?: unknown[] } } | null)
-                    ?.agents?.list;
-                  const basePath = ["agents", "list", index, "model"];
-                  if (!modelId) {
-                    removeConfigFormValue(state, basePath);
-                  } else {
+                    if (state.agentsPanel === "channels") {
+                      void loadChannels(state, false);
+                    }
+                    if (state.agentsPanel === "cron") {
+                      void state.loadCron();
+                    }
+                  },
+                  onSelectAgent: (agentId) => {
+                    if (state.agentsSelectedId === agentId) {
+                      return;
+                    }
+                    state.agentsSelectedId = agentId;
+                    state.agentFilesList = null;
+                    state.agentFilesError = null;
+                    state.agentFilesLoading = false;
+                    state.agentFileActive = null;
+                    state.agentFileContents = {};
+                    state.agentFileDrafts = {};
+                    state.agentSkillsReport = null;
+                    state.agentSkillsError = null;
+                    state.agentSkillsAgentId = null;
+                    state.toolsCatalogResult = null;
+                    state.toolsCatalogError = null;
+                    state.toolsCatalogLoading = false;
+                    state.toolsEffectiveResult = null;
+                    state.toolsEffectiveResultKey = null;
+                    state.toolsEffectiveError = null;
+                    state.toolsEffectiveLoading = false;
+                    state.toolsEffectiveLoadingKey = null;
+                    void loadAgentIdentity(state, agentId);
+                    if (state.agentsPanel === "files") {
+                      void loadAgentFiles(state, agentId);
+                    }
+                    if (state.agentsPanel === "tools") {
+                      void loadToolsCatalog(state, agentId);
+                      if (agentId === resolveAgentIdFromSessionKey(state.sessionKey)) {
+                        void loadToolsEffective(state, {
+                          agentId,
+                          sessionKey: state.sessionKey,
+                        });
+                      }
+                    }
+                    if (state.agentsPanel === "skills") {
+                      void loadAgentSkills(state, agentId);
+                    }
+                  },
+                  onSelectPanel: (panel) => {
+                    state.agentsPanel = panel;
+                    if (panel === "files" && resolvedAgentId) {
+                      if (state.agentFilesList?.agentId !== resolvedAgentId) {
+                        state.agentFilesList = null;
+                        state.agentFilesError = null;
+                        state.agentFileActive = null;
+                        state.agentFileContents = {};
+                        state.agentFileDrafts = {};
+                        void loadAgentFiles(state, resolvedAgentId);
+                      }
+                    }
+                    if (panel === "skills") {
+                      if (resolvedAgentId) {
+                        void loadAgentSkills(state, resolvedAgentId);
+                      }
+                    }
+                    if (panel === "tools" && resolvedAgentId) {
+                      if (
+                        state.toolsCatalogResult?.agentId !== resolvedAgentId ||
+                        state.toolsCatalogError
+                      ) {
+                        void loadToolsCatalog(state, resolvedAgentId);
+                      }
+                      if (resolvedAgentId === resolveAgentIdFromSessionKey(state.sessionKey)) {
+                        const toolsRequestKey = buildToolsEffectiveRequestKey(state, {
+                          agentId: resolvedAgentId,
+                          sessionKey: state.sessionKey,
+                        });
+                        if (
+                          state.toolsEffectiveResultKey !== toolsRequestKey ||
+                          state.toolsEffectiveError
+                        ) {
+                          void loadToolsEffective(state, {
+                            agentId: resolvedAgentId,
+                            sessionKey: state.sessionKey,
+                          });
+                        }
+                      } else {
+                        state.toolsEffectiveResult = null;
+                        state.toolsEffectiveResultKey = null;
+                        state.toolsEffectiveError = null;
+                        state.toolsEffectiveLoading = false;
+                        state.toolsEffectiveLoadingKey = null;
+                      }
+                    }
+                    if (panel === "channels") {
+                      void loadChannels(state, false);
+                    }
+                    if (panel === "cron") {
+                      void state.loadCron();
+                    }
+                  },
+                  onLoadFiles: (agentId) => loadAgentFiles(state, agentId),
+                  onSelectFile: (name) => {
+                    state.agentFileActive = name;
+                    if (!resolvedAgentId) {
+                      return;
+                    }
+                    void loadAgentFileContent(state, resolvedAgentId, name);
+                  },
+                  onFileDraftChange: (name, content) => {
+                    state.agentFileDrafts = { ...state.agentFileDrafts, [name]: content };
+                  },
+                  onFileReset: (name) => {
+                    const base = state.agentFileContents[name] ?? "";
+                    state.agentFileDrafts = { ...state.agentFileDrafts, [name]: base };
+                  },
+                  onFileSave: (name) => {
+                    if (!resolvedAgentId) {
+                      return;
+                    }
+                    const content =
+                      state.agentFileDrafts[name] ?? state.agentFileContents[name] ?? "";
+                    void saveAgentFile(state, resolvedAgentId, name, content);
+                  },
+                  onToolsProfileChange: (agentId, profile, clearAllow) => {
+                    const index =
+                      profile || clearAllow ? ensureAgentIndex(agentId) : findAgentIndex(agentId);
+                    if (index < 0) {
+                      return;
+                    }
+                    const basePath = ["agents", "list", index, "tools"];
+                    if (profile) {
+                      updateConfigFormValue(state, [...basePath, "profile"], profile);
+                    } else {
+                      removeConfigFormValue(state, [...basePath, "profile"]);
+                    }
+                    if (clearAllow) {
+                      removeConfigFormValue(state, [...basePath, "allow"]);
+                    }
+                  },
+                  onToolsOverridesChange: (agentId, alsoAllow, deny) => {
+                    const index =
+                      alsoAllow.length > 0 || deny.length > 0
+                        ? ensureAgentIndex(agentId)
+                        : findAgentIndex(agentId);
+                    if (index < 0) {
+                      return;
+                    }
+                    const basePath = ["agents", "list", index, "tools"];
+                    if (alsoAllow.length > 0) {
+                      updateConfigFormValue(state, [...basePath, "alsoAllow"], alsoAllow);
+                    } else {
+                      removeConfigFormValue(state, [...basePath, "alsoAllow"]);
+                    }
+                    if (deny.length > 0) {
+                      updateConfigFormValue(state, [...basePath, "deny"], deny);
+                    } else {
+                      removeConfigFormValue(state, [...basePath, "deny"]);
+                    }
+                  },
+                  onConfigReload: () => loadConfig(state),
+                  onConfigSave: () => saveAgentsConfig(state),
+                  onChannelsRefresh: () => loadChannels(state, false),
+                  onCronRefresh: () => state.loadCron(),
+                  onCronRunNow: (jobId) => {
+                    const job = state.cronJobs.find((entry) => entry.id === jobId);
+                    if (!job) {
+                      return;
+                    }
+                    void runCronJob(state, job, "force");
+                  },
+                  onSkillsFilterChange: (next) => (state.skillsFilter = next),
+                  onSkillsRefresh: () => {
+                    if (resolvedAgentId) {
+                      void loadAgentSkills(state, resolvedAgentId);
+                    }
+                  },
+                  onAgentSkillToggle: (agentId, skillName, enabled) => {
+                    const index = ensureAgentIndex(agentId);
+                    if (index < 0) {
+                      return;
+                    }
+                    const list = (
+                      getCurrentConfigValue() as { agents?: { list?: unknown[] } } | null
+                    )?.agents?.list;
+                    const entry = Array.isArray(list)
+                      ? (list[index] as { skills?: unknown })
+                      : undefined;
+                    const normalizedSkill = skillName.trim();
+                    if (!normalizedSkill) {
+                      return;
+                    }
+                    const allSkills =
+                      state.agentSkillsReport?.skills?.map((skill) => skill.name).filter(Boolean) ??
+                      [];
+                    const existing = Array.isArray(entry?.skills)
+                      ? entry.skills.map((name) => String(name).trim()).filter(Boolean)
+                      : undefined;
+                    const base = existing ?? allSkills;
+                    const next = new Set(base);
+                    if (enabled) {
+                      next.add(normalizedSkill);
+                    } else {
+                      next.delete(normalizedSkill);
+                    }
+                    updateConfigFormValue(state, ["agents", "list", index, "skills"], [...next]);
+                  },
+                  onAgentSkillsClear: (agentId) => {
+                    const index = findAgentIndex(agentId);
+                    if (index < 0) {
+                      return;
+                    }
+                    removeConfigFormValue(state, ["agents", "list", index, "skills"]);
+                  },
+                  onAgentSkillsDisableAll: (agentId) => {
+                    const index = ensureAgentIndex(agentId);
+                    if (index < 0) {
+                      return;
+                    }
+                    updateConfigFormValue(state, ["agents", "list", index, "skills"], []);
+                  },
+                  onModelChange: (agentId, modelId) => {
+                    const index = modelId ? ensureAgentIndex(agentId) : findAgentIndex(agentId);
+                    if (index < 0) {
+                      return;
+                    }
+                    const list = (
+                      getCurrentConfigValue() as { agents?: { list?: unknown[] } } | null
+                    )?.agents?.list;
+                    const basePath = ["agents", "list", index, "model"];
+                    if (!modelId) {
+                      removeConfigFormValue(state, basePath);
+                    } else {
+                      const entry = Array.isArray(list)
+                        ? (list[index] as { model?: unknown })
+                        : undefined;
+                      const existing = entry?.model;
+                      if (existing && typeof existing === "object" && !Array.isArray(existing)) {
+                        const fallbacks = (existing as { fallbacks?: unknown }).fallbacks;
+                        const next = {
+                          primary: modelId,
+                          ...(Array.isArray(fallbacks) ? { fallbacks } : {}),
+                        };
+                        updateConfigFormValue(state, basePath, next);
+                      } else {
+                        updateConfigFormValue(state, basePath, modelId);
+                      }
+                    }
+                    void refreshVisibleToolsEffectiveForCurrentSession(state);
+                  },
+                  onModelFallbacksChange: (agentId, fallbacks) => {
+                    const normalized = fallbacks.map((name) => name.trim()).filter(Boolean);
+                    const currentConfig = getCurrentConfigValue();
+                    const resolvedConfig = resolveAgentConfig(currentConfig, agentId);
+                    const effectivePrimary =
+                      resolveModelPrimary(resolvedConfig.entry?.model) ??
+                      resolveModelPrimary(resolvedConfig.defaults?.model);
+                    const effectiveFallbacks = resolveEffectiveModelFallbacks(
+                      resolvedConfig.entry?.model,
+                      resolvedConfig.defaults?.model,
+                    );
+                    const index =
+                      normalized.length > 0
+                        ? effectivePrimary
+                          ? ensureAgentIndex(agentId)
+                          : -1
+                        : (effectiveFallbacks?.length ?? 0) > 0 || findAgentIndex(agentId) >= 0
+                          ? ensureAgentIndex(agentId)
+                          : -1;
+                    if (index < 0) {
+                      return;
+                    }
+                    const list = (
+                      getCurrentConfigValue() as { agents?: { list?: unknown[] } } | null
+                    )?.agents?.list;
+                    const basePath = ["agents", "list", index, "model"];
                     const entry = Array.isArray(list)
                       ? (list[index] as { model?: unknown })
                       : undefined;
                     const existing = entry?.model;
-                    if (existing && typeof existing === "object" && !Array.isArray(existing)) {
-                      const fallbacks = (existing as { fallbacks?: unknown }).fallbacks;
-                      const next = {
-                        primary: modelId,
-                        ...(Array.isArray(fallbacks) ? { fallbacks } : {}),
-                      };
-                      updateConfigFormValue(state, basePath, next);
-                    } else {
-                      updateConfigFormValue(state, basePath, modelId);
-                    }
-                  }
-                  void refreshVisibleToolsEffectiveForCurrentSession(state);
-                },
-                onModelFallbacksChange: (agentId, fallbacks) => {
-                  const normalized = fallbacks.map((name) => name.trim()).filter(Boolean);
-                  const currentConfig = getCurrentConfigValue();
-                  const resolvedConfig = resolveAgentConfig(currentConfig, agentId);
-                  const effectivePrimary =
-                    resolveModelPrimary(resolvedConfig.entry?.model) ??
-                    resolveModelPrimary(resolvedConfig.defaults?.model);
-                  const effectiveFallbacks = resolveEffectiveModelFallbacks(
-                    resolvedConfig.entry?.model,
-                    resolvedConfig.defaults?.model,
-                  );
-                  const index =
-                    normalized.length > 0
-                      ? effectivePrimary
-                        ? ensureAgentIndex(agentId)
-                        : -1
-                      : (effectiveFallbacks?.length ?? 0) > 0 || findAgentIndex(agentId) >= 0
-                        ? ensureAgentIndex(agentId)
-                        : -1;
-                  if (index < 0) {
-                    return;
-                  }
-                  const list = (getCurrentConfigValue() as { agents?: { list?: unknown[] } } | null)
-                    ?.agents?.list;
-                  const basePath = ["agents", "list", index, "model"];
-                  const entry = Array.isArray(list)
-                    ? (list[index] as { model?: unknown })
-                    : undefined;
-                  const existing = entry?.model;
-                  const resolvePrimary = () => {
-                    if (typeof existing === "string") {
-                      return existing.trim() || null;
-                    }
-                    if (existing && typeof existing === "object" && !Array.isArray(existing)) {
-                      const primary = (existing as { primary?: unknown }).primary;
-                      if (typeof primary === "string") {
-                        const trimmed = primary.trim();
-                        return trimmed || null;
+                    const resolvePrimary = () => {
+                      if (typeof existing === "string") {
+                        return existing.trim() || null;
                       }
+                      if (existing && typeof existing === "object" && !Array.isArray(existing)) {
+                        const primary = (existing as { primary?: unknown }).primary;
+                        if (typeof primary === "string") {
+                          const trimmed = primary.trim();
+                          return trimmed || null;
+                        }
+                      }
+                      return null;
+                    };
+                    const primary = resolvePrimary() ?? effectivePrimary;
+                    if (normalized.length === 0) {
+                      if (primary) {
+                        updateConfigFormValue(state, basePath, primary);
+                      } else {
+                        removeConfigFormValue(state, basePath);
+                      }
+                      return;
                     }
-                    return null;
-                  };
-                  const primary = resolvePrimary() ?? effectivePrimary;
-                  if (normalized.length === 0) {
-                    if (primary) {
-                      updateConfigFormValue(state, basePath, primary);
+                    if (!primary) {
+                      return;
+                    }
+                    updateConfigFormValue(state, basePath, { primary, fallbacks: normalized });
+                  },
+                  onSetDefault: (agentId) => {
+                    if (!configValue) {
+                      return;
+                    }
+                    updateConfigFormValue(state, ["agents", "defaultId"], agentId);
+                  },
+                }),
+              )
+            : nothing
+        }
+        ${
+          state.tab === "skills"
+            ? lazyRender(lazySkills, (m) =>
+                m.renderSkills({
+                  connected: state.connected,
+                  loading: state.skillsLoading,
+                  report: state.skillsReport,
+                  error: state.skillsError,
+                  filter: state.skillsFilter,
+                  statusFilter: state.skillsStatusFilter,
+                  edits: state.skillEdits,
+                  messages: state.skillMessages,
+                  busyKey: state.skillsBusyKey,
+                  detailKey: state.skillsDetailKey,
+                  onFilterChange: (next) => (state.skillsFilter = next),
+                  onStatusFilterChange: (next) => (state.skillsStatusFilter = next),
+                  onRefresh: () => loadSkills(state, { clearMessages: true }),
+                  onToggle: (key, enabled) => updateSkillEnabled(state, key, enabled),
+                  onEdit: (key, value) => updateSkillEdit(state, key, value),
+                  onSaveKey: (key) => saveSkillApiKey(state, key),
+                  onInstall: (skillKey, name, installId) =>
+                    installSkill(state, skillKey, name, installId),
+                  onDetailOpen: (key) => (state.skillsDetailKey = key),
+                  onDetailClose: () => (state.skillsDetailKey = null),
+                }),
+              )
+            : nothing
+        }
+        ${
+          state.tab === "nodes"
+            ? lazyRender(lazyNodes, (m) =>
+                m.renderNodes({
+                  loading: state.nodesLoading,
+                  nodes: state.nodes,
+                  devicesLoading: state.devicesLoading,
+                  devicesError: state.devicesError,
+                  devicesList: state.devicesList,
+                  configForm:
+                    state.configForm ??
+                    (state.configSnapshot?.config as Record<string, unknown> | null),
+                  configLoading: state.configLoading,
+                  configSaving: state.configSaving,
+                  configDirty: state.configFormDirty,
+                  configFormMode: state.configFormMode,
+                  execApprovalsLoading: state.execApprovalsLoading,
+                  execApprovalsSaving: state.execApprovalsSaving,
+                  execApprovalsDirty: state.execApprovalsDirty,
+                  execApprovalsSnapshot: state.execApprovalsSnapshot,
+                  execApprovalsForm: state.execApprovalsForm,
+                  execApprovalsSelectedAgent: state.execApprovalsSelectedAgent,
+                  execApprovalsTarget: state.execApprovalsTarget,
+                  execApprovalsTargetNodeId: state.execApprovalsTargetNodeId,
+                  onRefresh: () => loadNodes(state),
+                  onDevicesRefresh: () => loadDevices(state),
+                  onDeviceApprove: (requestId) => approveDevicePairing(state, requestId),
+                  onDeviceReject: (requestId) => rejectDevicePairing(state, requestId),
+                  onDeviceRotate: (deviceId, role, scopes) =>
+                    rotateDeviceToken(state, { deviceId, role, scopes }),
+                  onDeviceRevoke: (deviceId, role) => revokeDeviceToken(state, { deviceId, role }),
+                  onLoadConfig: () => loadConfig(state),
+                  onLoadExecApprovals: () => {
+                    const target =
+                      state.execApprovalsTarget === "node" && state.execApprovalsTargetNodeId
+                        ? { kind: "node" as const, nodeId: state.execApprovalsTargetNodeId }
+                        : { kind: "gateway" as const };
+                    return loadExecApprovals(state, target);
+                  },
+                  onBindDefault: (nodeId) => {
+                    if (nodeId) {
+                      updateConfigFormValue(state, ["tools", "exec", "node"], nodeId);
+                    } else {
+                      removeConfigFormValue(state, ["tools", "exec", "node"]);
+                    }
+                  },
+                  onBindAgent: (agentIndex, nodeId) => {
+                    const basePath = ["agents", "list", agentIndex, "tools", "exec", "node"];
+                    if (nodeId) {
+                      updateConfigFormValue(state, basePath, nodeId);
                     } else {
                       removeConfigFormValue(state, basePath);
                     }
-                    return;
-                  }
-                  if (!primary) {
-                    return;
-                  }
-                  updateConfigFormValue(state, basePath, { primary, fallbacks: normalized });
+                  },
+                  onSaveBindings: () => saveConfig(state),
+                  onExecApprovalsTargetChange: (kind, nodeId) => {
+                    state.execApprovalsTarget = kind;
+                    state.execApprovalsTargetNodeId = nodeId;
+                    state.execApprovalsSnapshot = null;
+                    state.execApprovalsForm = null;
+                    state.execApprovalsDirty = false;
+                    state.execApprovalsSelectedAgent = null;
+                  },
+                  onExecApprovalsSelectAgent: (agentId) => {
+                    state.execApprovalsSelectedAgent = agentId;
+                  },
+                  onExecApprovalsPatch: (path, value) =>
+                    updateExecApprovalsFormValue(state, path, value),
+                  onExecApprovalsRemove: (path) => removeExecApprovalsFormValue(state, path),
+                  onSaveExecApprovals: () => {
+                    const target =
+                      state.execApprovalsTarget === "node" && state.execApprovalsTargetNodeId
+                        ? { kind: "node" as const, nodeId: state.execApprovalsTargetNodeId }
+                        : { kind: "gateway" as const };
+                    return saveExecApprovals(state, target);
+                  },
+                }),
+              )
+            : nothing
+        }
+        ${
+          state.tab === "chat"
+            ? renderChat({
+                sessionKey: state.sessionKey,
+                onSessionKeyChange: (next) => {
+                  state.sessionKey = next;
+                  state.chatMessage = "";
+                  state.chatAttachments = [];
+                  state.chatStream = null;
+                  state.chatStreamStartedAt = null;
+                  state.chatRunId = null;
+                  state.chatQueue = [];
+                  state.resetToolStream();
+                  state.resetChatScroll();
+                  state.applySettings({
+                    ...state.settings,
+                    sessionKey: next,
+                    lastActiveSessionKey: next,
+                  });
+                  void state.loadAssistantIdentity();
+                  void loadChatHistory(state);
+                  void refreshChatAvatar(state);
                 },
-                onSetDefault: (agentId) => {
-                  if (!configValue) {
-                    return;
-                  }
-                  updateConfigFormValue(state, ["agents", "defaultId"], agentId);
-                },
-              }),
-            )
-          : nothing}
-        ${state.tab === "skills"
-          ? lazyRender(lazySkills, (m) =>
-              m.renderSkills({
+                thinkingLevel: state.chatThinkingLevel,
+                showThinking,
+                showToolCalls,
+                loading: state.chatLoading,
+                sending: state.chatSending,
+                compactionStatus: state.compactionStatus,
+                fallbackStatus: state.fallbackStatus,
+                assistantAvatarUrl: chatAvatarUrl,
+                messages: state.chatMessages,
+                toolMessages: state.chatToolMessages,
+                streamSegments: state.chatStreamSegments,
+                stream: state.chatStream,
+                streamStartedAt: state.chatStreamStartedAt,
+                draft: state.chatMessage,
+                queue: state.chatQueue,
                 connected: state.connected,
-                loading: state.skillsLoading,
-                report: state.skillsReport,
-                error: state.skillsError,
-                filter: state.skillsFilter,
-                statusFilter: state.skillsStatusFilter,
-                edits: state.skillEdits,
-                messages: state.skillMessages,
-                busyKey: state.skillsBusyKey,
-                detailKey: state.skillsDetailKey,
-                onFilterChange: (next) => (state.skillsFilter = next),
-                onStatusFilterChange: (next) => (state.skillsStatusFilter = next),
-                onRefresh: () => loadSkills(state, { clearMessages: true }),
-                onToggle: (key, enabled) => updateSkillEnabled(state, key, enabled),
-                onEdit: (key, value) => updateSkillEdit(state, key, value),
-                onSaveKey: (key) => saveSkillApiKey(state, key),
-                onInstall: (skillKey, name, installId) =>
-                  installSkill(state, skillKey, name, installId),
-                onDetailOpen: (key) => (state.skillsDetailKey = key),
-                onDetailClose: () => (state.skillsDetailKey = null),
-              }),
-            )
-          : nothing}
-        ${state.tab === "nodes"
-          ? lazyRender(lazyNodes, (m) =>
-              m.renderNodes({
-                loading: state.nodesLoading,
-                nodes: state.nodes,
-                devicesLoading: state.devicesLoading,
-                devicesError: state.devicesError,
-                devicesList: state.devicesList,
-                configForm:
-                  state.configForm ??
-                  (state.configSnapshot?.config as Record<string, unknown> | null),
-                configLoading: state.configLoading,
-                configSaving: state.configSaving,
-                configDirty: state.configFormDirty,
-                configFormMode: state.configFormMode,
-                execApprovalsLoading: state.execApprovalsLoading,
-                execApprovalsSaving: state.execApprovalsSaving,
-                execApprovalsDirty: state.execApprovalsDirty,
-                execApprovalsSnapshot: state.execApprovalsSnapshot,
-                execApprovalsForm: state.execApprovalsForm,
-                execApprovalsSelectedAgent: state.execApprovalsSelectedAgent,
-                execApprovalsTarget: state.execApprovalsTarget,
-                execApprovalsTargetNodeId: state.execApprovalsTargetNodeId,
-                onRefresh: () => loadNodes(state),
-                onDevicesRefresh: () => loadDevices(state),
-                onDeviceApprove: (requestId) => approveDevicePairing(state, requestId),
-                onDeviceReject: (requestId) => rejectDevicePairing(state, requestId),
-                onDeviceRotate: (deviceId, role, scopes) =>
-                  rotateDeviceToken(state, { deviceId, role, scopes }),
-                onDeviceRevoke: (deviceId, role) => revokeDeviceToken(state, { deviceId, role }),
-                onLoadConfig: () => loadConfig(state),
-                onLoadExecApprovals: () => {
-                  const target =
-                    state.execApprovalsTarget === "node" && state.execApprovalsTargetNodeId
-                      ? { kind: "node" as const, nodeId: state.execApprovalsTargetNodeId }
-                      : { kind: "gateway" as const };
-                  return loadExecApprovals(state, target);
+                canSend: state.connected,
+                disabledReason: chatDisabledReason,
+                error: state.lastError,
+                sessions: state.sessionsResult,
+                focusMode: chatFocus,
+                onRefresh: () => {
+                  state.resetToolStream();
+                  return Promise.all([loadChatHistory(state), refreshChatAvatar(state)]);
                 },
-                onBindDefault: (nodeId) => {
-                  if (nodeId) {
-                    updateConfigFormValue(state, ["tools", "exec", "node"], nodeId);
-                  } else {
-                    removeConfigFormValue(state, ["tools", "exec", "node"]);
+                onToggleFocusMode: () => {
+                  if (state.onboarding) {
+                    return;
+                  }
+                  state.applySettings({
+                    ...state.settings,
+                    chatFocusMode: !state.settings.chatFocusMode,
+                  });
+                },
+                onChatScroll: (event) => state.handleChatScroll(event),
+                getDraft: () => state.chatMessage,
+                onDraftChange: (next) => (state.chatMessage = next),
+                onRequestUpdate: requestHostUpdate,
+                attachments: state.chatAttachments,
+                onAttachmentsChange: (next) => (state.chatAttachments = next),
+                onSend: () => state.handleSendChat(),
+                canAbort: Boolean(state.chatRunId),
+                onAbort: () => void state.handleAbortChat(),
+                onQueueRemove: (id) => state.removeQueuedMessage(id),
+                onNewSession: () => state.handleSendChat("/new", { restoreDraft: true }),
+                onClearHistory: async () => {
+                  if (!state.client || !state.connected) {
+                    return;
+                  }
+                  try {
+                    await state.client.request("sessions.reset", { key: state.sessionKey });
+                    state.chatMessages = [];
+                    state.chatStream = null;
+                    state.chatRunId = null;
+                    await loadChatHistory(state);
+                  } catch (err) {
+                    state.lastError = String(err);
                   }
                 },
-                onBindAgent: (agentIndex, nodeId) => {
-                  const basePath = ["agents", "list", agentIndex, "tools", "exec", "node"];
-                  if (nodeId) {
-                    updateConfigFormValue(state, basePath, nodeId);
-                  } else {
-                    removeConfigFormValue(state, basePath);
-                  }
-                },
-                onSaveBindings: () => saveConfig(state),
-                onExecApprovalsTargetChange: (kind, nodeId) => {
-                  state.execApprovalsTarget = kind;
-                  state.execApprovalsTargetNodeId = nodeId;
-                  state.execApprovalsSnapshot = null;
-                  state.execApprovalsForm = null;
-                  state.execApprovalsDirty = false;
-                  state.execApprovalsSelectedAgent = null;
-                },
-                onExecApprovalsSelectAgent: (agentId) => {
-                  state.execApprovalsSelectedAgent = agentId;
-                },
-                onExecApprovalsPatch: (path, value) =>
-                  updateExecApprovalsFormValue(state, path, value),
-                onExecApprovalsRemove: (path) => removeExecApprovalsFormValue(state, path),
-                onSaveExecApprovals: () => {
-                  const target =
-                    state.execApprovalsTarget === "node" && state.execApprovalsTargetNodeId
-                      ? { kind: "node" as const, nodeId: state.execApprovalsTargetNodeId }
-                      : { kind: "gateway" as const };
-                  return saveExecApprovals(state, target);
-                },
-              }),
-            )
-          : nothing}
-        ${state.tab === "chat"
-          ? renderChat({
-              sessionKey: state.sessionKey,
-              onSessionKeyChange: (next) => {
-                state.sessionKey = next;
-                state.chatMessage = "";
-                state.chatAttachments = [];
-                state.chatStream = null;
-                state.chatStreamStartedAt = null;
-                state.chatRunId = null;
-                state.chatQueue = [];
-                state.resetToolStream();
-                state.resetChatScroll();
-                state.applySettings({
-                  ...state.settings,
-                  sessionKey: next,
-                  lastActiveSessionKey: next,
-                });
-                void state.loadAssistantIdentity();
-                void loadChatHistory(state);
-                void refreshChatAvatar(state);
-              },
-              thinkingLevel: state.chatThinkingLevel,
-              showThinking,
-              showToolCalls,
-              loading: state.chatLoading,
-              sending: state.chatSending,
-              compactionStatus: state.compactionStatus,
-              fallbackStatus: state.fallbackStatus,
-              assistantAvatarUrl: chatAvatarUrl,
-              messages: state.chatMessages,
-              toolMessages: state.chatToolMessages,
-              streamSegments: state.chatStreamSegments,
-              stream: state.chatStream,
-              streamStartedAt: state.chatStreamStartedAt,
-              draft: state.chatMessage,
-              queue: state.chatQueue,
-              connected: state.connected,
-              canSend: state.connected,
-              disabledReason: chatDisabledReason,
-              error: state.lastError,
-              sessions: state.sessionsResult,
-              focusMode: chatFocus,
-              onRefresh: () => {
-                state.resetToolStream();
-                return Promise.all([loadChatHistory(state), refreshChatAvatar(state)]);
-              },
-              onToggleFocusMode: () => {
-                if (state.onboarding) {
-                  return;
-                }
-                state.applySettings({
-                  ...state.settings,
-                  chatFocusMode: !state.settings.chatFocusMode,
-                });
-              },
-              onChatScroll: (event) => state.handleChatScroll(event),
-              getDraft: () => state.chatMessage,
-              onDraftChange: (next) => (state.chatMessage = next),
-              onRequestUpdate: requestHostUpdate,
-              attachments: state.chatAttachments,
-              onAttachmentsChange: (next) => (state.chatAttachments = next),
-              onSend: () => state.handleSendChat(),
-              canAbort: Boolean(state.chatRunId),
-              onAbort: () => void state.handleAbortChat(),
-              onQueueRemove: (id) => state.removeQueuedMessage(id),
-              onNewSession: () => state.handleSendChat("/new", { restoreDraft: true }),
-              onClearHistory: async () => {
-                if (!state.client || !state.connected) {
-                  return;
-                }
-                try {
-                  await state.client.request("sessions.reset", { key: state.sessionKey });
+                agentsList: state.agentsList,
+                currentAgentId: resolvedAgentId ?? "main",
+                onAgentChange: (agentId: string) => {
+                  state.sessionKey = buildAgentMainSessionKey({ agentId });
                   state.chatMessages = [];
                   state.chatStream = null;
                   state.chatRunId = null;
-                  await loadChatHistory(state);
-                } catch (err) {
-                  state.lastError = String(err);
-                }
-              },
-              agentsList: state.agentsList,
-              currentAgentId: resolvedAgentId ?? "main",
-              onAgentChange: (agentId: string) => {
-                state.sessionKey = buildAgentMainSessionKey({ agentId });
-                state.chatMessages = [];
-                state.chatStream = null;
-                state.chatRunId = null;
-                state.applySettings({
-                  ...state.settings,
-                  sessionKey: state.sessionKey,
-                  lastActiveSessionKey: state.sessionKey,
-                });
-                void loadChatHistory(state);
-                void state.loadAssistantIdentity();
-              },
-              onNavigateToAgent: () => {
-                state.agentsSelectedId = resolvedAgentId;
-                state.setTab("agents" as import("./navigation.ts").Tab);
-              },
-              onSessionSelect: (key: string) => {
-                switchChatSession(state, key);
-              },
-              showNewMessages: state.chatNewMessagesBelow && !state.chatManualRefreshInFlight,
-              onScrollToBottom: () => state.scrollToBottom(),
-              // Sidebar props for tool output viewing
-              sidebarOpen: state.sidebarOpen,
-              sidebarContent: state.sidebarContent,
-              sidebarError: state.sidebarError,
-              splitRatio: state.splitRatio,
-              onOpenSidebar: (content: string) => state.handleOpenSidebar(content),
-              onCloseSidebar: () => state.handleCloseSidebar(),
-              onSplitRatioChange: (ratio: number) => state.handleSplitRatioChange(ratio),
-              assistantName: state.assistantName,
-              assistantAvatar: state.assistantAvatar,
-              basePath: state.basePath ?? "",
-            })
-          : nothing}
-        ${state.tab === "config"
-          ? renderConfig({
-              raw: state.configRaw,
-              originalRaw: state.configRawOriginal,
-              valid: state.configValid,
-              issues: state.configIssues,
-              loading: state.configLoading,
-              saving: state.configSaving,
-              applying: state.configApplying,
-              updating: state.updateRunning,
-              connected: state.connected,
-              schema: state.configSchema,
-              schemaLoading: state.configSchemaLoading,
-              uiHints: state.configUiHints,
-              formMode: state.configFormMode,
-              showModeToggle: true,
-              formValue: state.configForm,
-              originalValue: state.configFormOriginal,
-              searchQuery: state.configSearchQuery,
-              activeSection:
-                state.configActiveSection &&
-                (COMMUNICATION_SECTION_KEYS.includes(
-                  state.configActiveSection as CommunicationSectionKey,
-                ) ||
-                  APPEARANCE_SECTION_KEYS.includes(
-                    state.configActiveSection as AppearanceSectionKey,
-                  ) ||
-                  AUTOMATION_SECTION_KEYS.includes(
-                    state.configActiveSection as AutomationSectionKey,
-                  ) ||
-                  INFRASTRUCTURE_SECTION_KEYS.includes(
-                    state.configActiveSection as InfrastructureSectionKey,
-                  ) ||
-                  AI_AGENTS_SECTION_KEYS.includes(state.configActiveSection as AiAgentsSectionKey))
-                  ? null
-                  : state.configActiveSection,
-              activeSubsection:
-                state.configActiveSection &&
-                (COMMUNICATION_SECTION_KEYS.includes(
-                  state.configActiveSection as CommunicationSectionKey,
-                ) ||
-                  APPEARANCE_SECTION_KEYS.includes(
-                    state.configActiveSection as AppearanceSectionKey,
-                  ) ||
-                  AUTOMATION_SECTION_KEYS.includes(
-                    state.configActiveSection as AutomationSectionKey,
-                  ) ||
-                  INFRASTRUCTURE_SECTION_KEYS.includes(
-                    state.configActiveSection as InfrastructureSectionKey,
-                  ) ||
-                  AI_AGENTS_SECTION_KEYS.includes(state.configActiveSection as AiAgentsSectionKey))
-                  ? null
-                  : state.configActiveSubsection,
-              onRawChange: (next) => {
-                state.configRaw = next;
-              },
-              onRequestUpdate: requestHostUpdate,
-              onFormModeChange: (mode) => (state.configFormMode = mode),
-              onFormPatch: (path, value) => updateConfigFormValue(state, path, value),
-              onSearchChange: (query) => (state.configSearchQuery = query),
-              onSectionChange: (section) => {
-                state.configActiveSection = section;
-                state.configActiveSubsection = null;
-              },
-              onSubsectionChange: (section) => (state.configActiveSubsection = section),
-              onReload: () => loadConfig(state),
-              onSave: () => saveConfig(state),
-              onApply: () => applyConfig(state),
-              onUpdate: () => runUpdate(state),
-              onOpenFile: () => openConfigFile(state),
-              version: state.hello?.server?.version ?? "",
-              theme: state.theme,
-              themeMode: state.themeMode,
-              setTheme: (t, ctx) => state.setTheme(t, ctx),
-              setThemeMode: (m, ctx) => state.setThemeMode(m, ctx),
-              borderRadius: state.settings.borderRadius,
-              setBorderRadius: (v) => state.setBorderRadius(v),
-              gatewayUrl: state.settings.gatewayUrl,
-              assistantName: state.assistantName,
-              configPath: state.configSnapshot?.path ?? null,
-              rawAvailable: typeof state.configSnapshot?.raw === "string",
-              excludeSections: [
-                ...COMMUNICATION_SECTION_KEYS,
-                ...AUTOMATION_SECTION_KEYS,
-                ...INFRASTRUCTURE_SECTION_KEYS,
-                ...AI_AGENTS_SECTION_KEYS,
-                "ui",
-                "wizard",
-              ],
-              includeVirtualSections: false,
-            })
-          : nothing}
-        ${state.tab === "communications"
-          ? renderConfig({
-              raw: state.configRaw,
-              originalRaw: state.configRawOriginal,
-              valid: state.configValid,
-              issues: state.configIssues,
-              loading: state.configLoading,
-              saving: state.configSaving,
-              applying: state.configApplying,
-              updating: state.updateRunning,
-              connected: state.connected,
-              schema: state.configSchema,
-              schemaLoading: state.configSchemaLoading,
-              uiHints: state.configUiHints,
-              formMode: state.communicationsFormMode,
-              formValue: state.configForm,
-              originalValue: state.configFormOriginal,
-              searchQuery: state.communicationsSearchQuery,
-              activeSection:
-                state.communicationsActiveSection &&
-                !COMMUNICATION_SECTION_KEYS.includes(
-                  state.communicationsActiveSection as CommunicationSectionKey,
-                )
-                  ? null
-                  : state.communicationsActiveSection,
-              activeSubsection:
-                state.communicationsActiveSection &&
-                !COMMUNICATION_SECTION_KEYS.includes(
-                  state.communicationsActiveSection as CommunicationSectionKey,
-                )
-                  ? null
-                  : state.communicationsActiveSubsection,
-              onRawChange: (next) => {
-                state.configRaw = next;
-              },
-              onRequestUpdate: requestHostUpdate,
-              onFormModeChange: (mode) => (state.communicationsFormMode = mode),
-              onFormPatch: (path, value) => updateConfigFormValue(state, path, value),
-              onSearchChange: (query) => (state.communicationsSearchQuery = query),
-              onSectionChange: (section) => {
-                state.communicationsActiveSection = section;
-                state.communicationsActiveSubsection = null;
-              },
-              onSubsectionChange: (section) => (state.communicationsActiveSubsection = section),
-              onReload: () => loadConfig(state),
-              onSave: () => saveConfig(state),
-              onApply: () => applyConfig(state),
-              onUpdate: () => runUpdate(state),
-              onOpenFile: () => openConfigFile(state),
-              version: state.hello?.server?.version ?? "",
-              theme: state.theme,
-              themeMode: state.themeMode,
-              setTheme: (t, ctx) => state.setTheme(t, ctx),
-              setThemeMode: (m, ctx) => state.setThemeMode(m, ctx),
-              borderRadius: state.settings.borderRadius,
-              setBorderRadius: (v) => state.setBorderRadius(v),
-              gatewayUrl: state.settings.gatewayUrl,
-              assistantName: state.assistantName,
-              configPath: state.configSnapshot?.path ?? null,
-              rawAvailable: typeof state.configSnapshot?.raw === "string",
-              navRootLabel: "Communication",
-              includeSections: [...COMMUNICATION_SECTION_KEYS],
-              includeVirtualSections: false,
-            })
-          : nothing}
-        ${state.tab === "appearance"
-          ? renderConfig({
-              raw: state.configRaw,
-              originalRaw: state.configRawOriginal,
-              valid: state.configValid,
-              issues: state.configIssues,
-              loading: state.configLoading,
-              saving: state.configSaving,
-              applying: state.configApplying,
-              updating: state.updateRunning,
-              connected: state.connected,
-              schema: state.configSchema,
-              schemaLoading: state.configSchemaLoading,
-              uiHints: state.configUiHints,
-              formMode: state.appearanceFormMode,
-              formValue: state.configForm,
-              originalValue: state.configFormOriginal,
-              searchQuery: state.appearanceSearchQuery,
-              activeSection:
-                state.appearanceActiveSection &&
-                !APPEARANCE_SECTION_KEYS.includes(
-                  state.appearanceActiveSection as AppearanceSectionKey,
-                )
-                  ? null
-                  : state.appearanceActiveSection,
-              activeSubsection:
-                state.appearanceActiveSection &&
-                !APPEARANCE_SECTION_KEYS.includes(
-                  state.appearanceActiveSection as AppearanceSectionKey,
-                )
-                  ? null
-                  : state.appearanceActiveSubsection,
-              onRawChange: (next) => {
-                state.configRaw = next;
-              },
-              onRequestUpdate: requestHostUpdate,
-              onFormModeChange: (mode) => (state.appearanceFormMode = mode),
-              onFormPatch: (path, value) => updateConfigFormValue(state, path, value),
-              onSearchChange: (query) => (state.appearanceSearchQuery = query),
-              onSectionChange: (section) => {
-                state.appearanceActiveSection = section;
-                state.appearanceActiveSubsection = null;
-              },
-              onSubsectionChange: (section) => (state.appearanceActiveSubsection = section),
-              onReload: () => loadConfig(state),
-              onSave: () => saveConfig(state),
-              onApply: () => applyConfig(state),
-              onUpdate: () => runUpdate(state),
-              onOpenFile: () => openConfigFile(state),
-              version: state.hello?.server?.version ?? "",
-              theme: state.theme,
-              themeMode: state.themeMode,
-              setTheme: (t, ctx) => state.setTheme(t, ctx),
-              setThemeMode: (m, ctx) => state.setThemeMode(m, ctx),
-              borderRadius: state.settings.borderRadius,
-              setBorderRadius: (v) => state.setBorderRadius(v),
-              gatewayUrl: state.settings.gatewayUrl,
-              assistantName: state.assistantName,
-              configPath: state.configSnapshot?.path ?? null,
-              rawAvailable: typeof state.configSnapshot?.raw === "string",
-              navRootLabel: "Appearance",
-              includeSections: [...APPEARANCE_SECTION_KEYS],
-              includeVirtualSections: true,
-            })
-          : nothing}
-        ${state.tab === "automation"
-          ? renderConfig({
-              raw: state.configRaw,
-              originalRaw: state.configRawOriginal,
-              valid: state.configValid,
-              issues: state.configIssues,
-              loading: state.configLoading,
-              saving: state.configSaving,
-              applying: state.configApplying,
-              updating: state.updateRunning,
-              connected: state.connected,
-              schema: state.configSchema,
-              schemaLoading: state.configSchemaLoading,
-              uiHints: state.configUiHints,
-              formMode: state.automationFormMode,
-              formValue: state.configForm,
-              originalValue: state.configFormOriginal,
-              searchQuery: state.automationSearchQuery,
-              activeSection:
-                state.automationActiveSection &&
-                !AUTOMATION_SECTION_KEYS.includes(
-                  state.automationActiveSection as AutomationSectionKey,
-                )
-                  ? null
-                  : state.automationActiveSection,
-              activeSubsection:
-                state.automationActiveSection &&
-                !AUTOMATION_SECTION_KEYS.includes(
-                  state.automationActiveSection as AutomationSectionKey,
-                )
-                  ? null
-                  : state.automationActiveSubsection,
-              onRawChange: (next) => {
-                state.configRaw = next;
-              },
-              onRequestUpdate: requestHostUpdate,
-              onFormModeChange: (mode) => (state.automationFormMode = mode),
-              onFormPatch: (path, value) => updateConfigFormValue(state, path, value),
-              onSearchChange: (query) => (state.automationSearchQuery = query),
-              onSectionChange: (section) => {
-                state.automationActiveSection = section;
-                state.automationActiveSubsection = null;
-              },
-              onSubsectionChange: (section) => (state.automationActiveSubsection = section),
-              onReload: () => loadConfig(state),
-              onSave: () => saveConfig(state),
-              onApply: () => applyConfig(state),
-              onUpdate: () => runUpdate(state),
-              onOpenFile: () => openConfigFile(state),
-              version: state.hello?.server?.version ?? "",
-              theme: state.theme,
-              themeMode: state.themeMode,
-              setTheme: (t, ctx) => state.setTheme(t, ctx),
-              setThemeMode: (m, ctx) => state.setThemeMode(m, ctx),
-              borderRadius: state.settings.borderRadius,
-              setBorderRadius: (v) => state.setBorderRadius(v),
-              gatewayUrl: state.settings.gatewayUrl,
-              assistantName: state.assistantName,
-              configPath: state.configSnapshot?.path ?? null,
-              rawAvailable: typeof state.configSnapshot?.raw === "string",
-              navRootLabel: "Automation",
-              includeSections: [...AUTOMATION_SECTION_KEYS],
-              includeVirtualSections: false,
-            })
-          : nothing}
-        ${state.tab === "infrastructure"
-          ? renderConfig({
-              raw: state.configRaw,
-              originalRaw: state.configRawOriginal,
-              valid: state.configValid,
-              issues: state.configIssues,
-              loading: state.configLoading,
-              saving: state.configSaving,
-              applying: state.configApplying,
-              updating: state.updateRunning,
-              connected: state.connected,
-              schema: state.configSchema,
-              schemaLoading: state.configSchemaLoading,
-              uiHints: state.configUiHints,
-              formMode: state.infrastructureFormMode,
-              formValue: state.configForm,
-              originalValue: state.configFormOriginal,
-              searchQuery: state.infrastructureSearchQuery,
-              activeSection:
-                state.infrastructureActiveSection &&
-                !INFRASTRUCTURE_SECTION_KEYS.includes(
-                  state.infrastructureActiveSection as InfrastructureSectionKey,
-                )
-                  ? null
-                  : state.infrastructureActiveSection,
-              activeSubsection:
-                state.infrastructureActiveSection &&
-                !INFRASTRUCTURE_SECTION_KEYS.includes(
-                  state.infrastructureActiveSection as InfrastructureSectionKey,
-                )
-                  ? null
-                  : state.infrastructureActiveSubsection,
-              onRawChange: (next) => {
-                state.configRaw = next;
-              },
-              onRequestUpdate: requestHostUpdate,
-              onFormModeChange: (mode) => (state.infrastructureFormMode = mode),
-              onFormPatch: (path, value) => updateConfigFormValue(state, path, value),
-              onSearchChange: (query) => (state.infrastructureSearchQuery = query),
-              onSectionChange: (section) => {
-                state.infrastructureActiveSection = section;
-                state.infrastructureActiveSubsection = null;
-              },
-              onSubsectionChange: (section) => (state.infrastructureActiveSubsection = section),
-              onReload: () => loadConfig(state),
-              onSave: () => saveConfig(state),
-              onApply: () => applyConfig(state),
-              onUpdate: () => runUpdate(state),
-              onOpenFile: () => openConfigFile(state),
-              version: state.hello?.server?.version ?? "",
-              theme: state.theme,
-              themeMode: state.themeMode,
-              setTheme: (t, ctx) => state.setTheme(t, ctx),
-              setThemeMode: (m, ctx) => state.setThemeMode(m, ctx),
-              borderRadius: state.settings.borderRadius,
-              setBorderRadius: (v) => state.setBorderRadius(v),
-              gatewayUrl: state.settings.gatewayUrl,
-              assistantName: state.assistantName,
-              configPath: state.configSnapshot?.path ?? null,
-              rawAvailable: typeof state.configSnapshot?.raw === "string",
-              navRootLabel: "Infrastructure",
-              includeSections: [...INFRASTRUCTURE_SECTION_KEYS],
-              includeVirtualSections: false,
-            })
-          : nothing}
-        ${state.tab === "aiAgents"
-          ? renderConfig({
-              raw: state.configRaw,
-              originalRaw: state.configRawOriginal,
-              valid: state.configValid,
-              issues: state.configIssues,
-              loading: state.configLoading,
-              saving: state.configSaving,
-              applying: state.configApplying,
-              updating: state.updateRunning,
-              connected: state.connected,
-              schema: state.configSchema,
-              schemaLoading: state.configSchemaLoading,
-              uiHints: state.configUiHints,
-              formMode: state.aiAgentsFormMode,
-              formValue: state.configForm,
-              originalValue: state.configFormOriginal,
-              searchQuery: state.aiAgentsSearchQuery,
-              activeSection:
-                state.aiAgentsActiveSection &&
-                !AI_AGENTS_SECTION_KEYS.includes(state.aiAgentsActiveSection as AiAgentsSectionKey)
-                  ? null
-                  : state.aiAgentsActiveSection,
-              activeSubsection:
-                state.aiAgentsActiveSection &&
-                !AI_AGENTS_SECTION_KEYS.includes(state.aiAgentsActiveSection as AiAgentsSectionKey)
-                  ? null
-                  : state.aiAgentsActiveSubsection,
-              onRawChange: (next) => {
-                state.configRaw = next;
-              },
-              onRequestUpdate: requestHostUpdate,
-              onFormModeChange: (mode) => (state.aiAgentsFormMode = mode),
-              onFormPatch: (path, value) => updateConfigFormValue(state, path, value),
-              onSearchChange: (query) => (state.aiAgentsSearchQuery = query),
-              onSectionChange: (section) => {
-                state.aiAgentsActiveSection = section;
-                state.aiAgentsActiveSubsection = null;
-              },
-              onSubsectionChange: (section) => (state.aiAgentsActiveSubsection = section),
-              onReload: () => loadConfig(state),
-              onSave: () => saveConfig(state),
-              onApply: () => applyConfig(state),
-              onUpdate: () => runUpdate(state),
-              onOpenFile: () => openConfigFile(state),
-              version: state.hello?.server?.version ?? "",
-              theme: state.theme,
-              themeMode: state.themeMode,
-              setTheme: (t, ctx) => state.setTheme(t, ctx),
-              setThemeMode: (m, ctx) => state.setThemeMode(m, ctx),
-              borderRadius: state.settings.borderRadius,
-              setBorderRadius: (v) => state.setBorderRadius(v),
-              gatewayUrl: state.settings.gatewayUrl,
-              assistantName: state.assistantName,
-              configPath: state.configSnapshot?.path ?? null,
-              rawAvailable: typeof state.configSnapshot?.raw === "string",
-              navRootLabel: "AI & Agents",
-              includeSections: [...AI_AGENTS_SECTION_KEYS],
-              includeVirtualSections: false,
-            })
-          : nothing}
-        ${state.tab === "debug"
-          ? lazyRender(lazyDebug, (m) =>
-              m.renderDebug({
-                loading: state.debugLoading,
-                status: state.debugStatus,
-                health: state.debugHealth,
-                models: state.debugModels,
-                heartbeat: state.debugHeartbeat,
-                eventLog: state.eventLog,
-                methods: (state.hello?.features?.methods ?? []).toSorted(),
-                callMethod: state.debugCallMethod,
-                callParams: state.debugCallParams,
-                callResult: state.debugCallResult,
-                callError: state.debugCallError,
-                onCallMethodChange: (next) => (state.debugCallMethod = next),
-                onCallParamsChange: (next) => (state.debugCallParams = next),
-                onRefresh: () => loadDebug(state),
-                onCall: () => callDebugMethod(state),
-              }),
-            )
-          : nothing}
-        ${state.tab === "logs"
-          ? lazyRender(lazyLogs, (m) =>
-              m.renderLogs({
-                loading: state.logsLoading,
-                error: state.logsError,
-                file: state.logsFile,
-                entries: state.logsEntries,
-                filterText: state.logsFilterText,
-                levelFilters: state.logsLevelFilters,
-                autoFollow: state.logsAutoFollow,
-                truncated: state.logsTruncated,
-                onFilterTextChange: (next) => (state.logsFilterText = next),
-                onLevelToggle: (level, enabled) => {
-                  state.logsLevelFilters = { ...state.logsLevelFilters, [level]: enabled };
+                  state.applySettings({
+                    ...state.settings,
+                    sessionKey: state.sessionKey,
+                    lastActiveSessionKey: state.sessionKey,
+                  });
+                  void loadChatHistory(state);
+                  void state.loadAssistantIdentity();
                 },
-                onToggleAutoFollow: (next) => (state.logsAutoFollow = next),
-                onRefresh: () => loadLogs(state, { reset: true }),
-                onExport: (lines, label) => state.exportLogs(lines, label),
-                onScroll: (event) => state.handleLogsScroll(event),
-              }),
-            )
-          : nothing}
+                onNavigateToAgent: () => {
+                  state.agentsSelectedId = resolvedAgentId;
+                  state.setTab("agents" as import("./navigation.ts").Tab);
+                },
+                onSessionSelect: (key: string) => {
+                  switchChatSession(state, key);
+                },
+                showNewMessages: state.chatNewMessagesBelow && !state.chatManualRefreshInFlight,
+                onScrollToBottom: () => state.scrollToBottom(),
+                // Sidebar props for tool output viewing
+                sidebarOpen: state.sidebarOpen,
+                sidebarContent: state.sidebarContent,
+                sidebarError: state.sidebarError,
+                splitRatio: state.splitRatio,
+                onOpenSidebar: (content: string) => state.handleOpenSidebar(content),
+                onCloseSidebar: () => state.handleCloseSidebar(),
+                onSplitRatioChange: (ratio: number) => state.handleSplitRatioChange(ratio),
+                assistantName: state.assistantName,
+                assistantAvatar: state.assistantAvatar,
+                basePath: state.basePath ?? "",
+              })
+            : nothing
+        }
+        ${
+          state.tab === "config"
+            ? renderConfig({
+                raw: state.configRaw,
+                originalRaw: state.configRawOriginal,
+                valid: state.configValid,
+                issues: state.configIssues,
+                loading: state.configLoading,
+                saving: state.configSaving,
+                applying: state.configApplying,
+                updating: state.updateRunning,
+                connected: state.connected,
+                schema: state.configSchema,
+                schemaLoading: state.configSchemaLoading,
+                uiHints: state.configUiHints,
+                formMode: state.configFormMode,
+                showModeToggle: true,
+                formValue: state.configForm,
+                originalValue: state.configFormOriginal,
+                searchQuery: state.configSearchQuery,
+                activeSection:
+                  state.configActiveSection &&
+                  (COMMUNICATION_SECTION_KEYS.includes(
+                    state.configActiveSection as CommunicationSectionKey,
+                  ) ||
+                    APPEARANCE_SECTION_KEYS.includes(
+                      state.configActiveSection as AppearanceSectionKey,
+                    ) ||
+                    AUTOMATION_SECTION_KEYS.includes(
+                      state.configActiveSection as AutomationSectionKey,
+                    ) ||
+                    INFRASTRUCTURE_SECTION_KEYS.includes(
+                      state.configActiveSection as InfrastructureSectionKey,
+                    ) ||
+                    AI_AGENTS_SECTION_KEYS.includes(
+                      state.configActiveSection as AiAgentsSectionKey,
+                    ))
+                    ? null
+                    : state.configActiveSection,
+                activeSubsection:
+                  state.configActiveSection &&
+                  (COMMUNICATION_SECTION_KEYS.includes(
+                    state.configActiveSection as CommunicationSectionKey,
+                  ) ||
+                    APPEARANCE_SECTION_KEYS.includes(
+                      state.configActiveSection as AppearanceSectionKey,
+                    ) ||
+                    AUTOMATION_SECTION_KEYS.includes(
+                      state.configActiveSection as AutomationSectionKey,
+                    ) ||
+                    INFRASTRUCTURE_SECTION_KEYS.includes(
+                      state.configActiveSection as InfrastructureSectionKey,
+                    ) ||
+                    AI_AGENTS_SECTION_KEYS.includes(
+                      state.configActiveSection as AiAgentsSectionKey,
+                    ))
+                    ? null
+                    : state.configActiveSubsection,
+                onRawChange: (next) => {
+                  state.configRaw = next;
+                },
+                onRequestUpdate: requestHostUpdate,
+                onFormModeChange: (mode) => (state.configFormMode = mode),
+                onFormPatch: (path, value) => updateConfigFormValue(state, path, value),
+                onSearchChange: (query) => (state.configSearchQuery = query),
+                onSectionChange: (section) => {
+                  state.configActiveSection = section;
+                  state.configActiveSubsection = null;
+                },
+                onSubsectionChange: (section) => (state.configActiveSubsection = section),
+                onReload: () => loadConfig(state),
+                onSave: () => saveConfig(state),
+                onApply: () => applyConfig(state),
+                onUpdate: () => runUpdate(state),
+                onOpenFile: () => openConfigFile(state),
+                version: state.hello?.server?.version ?? "",
+                theme: state.theme,
+                themeMode: state.themeMode,
+                setTheme: (t, ctx) => state.setTheme(t, ctx),
+                setThemeMode: (m, ctx) => state.setThemeMode(m, ctx),
+                borderRadius: state.settings.borderRadius,
+                setBorderRadius: (v) => state.setBorderRadius(v),
+                gatewayUrl: state.settings.gatewayUrl,
+                assistantName: state.assistantName,
+                configPath: state.configSnapshot?.path ?? null,
+                rawAvailable: typeof state.configSnapshot?.raw === "string",
+                excludeSections: [
+                  ...COMMUNICATION_SECTION_KEYS,
+                  ...AUTOMATION_SECTION_KEYS,
+                  ...INFRASTRUCTURE_SECTION_KEYS,
+                  ...AI_AGENTS_SECTION_KEYS,
+                  "ui",
+                  "wizard",
+                ],
+                includeVirtualSections: false,
+              })
+            : nothing
+        }
+        ${
+          state.tab === "communications"
+            ? renderConfig({
+                raw: state.configRaw,
+                originalRaw: state.configRawOriginal,
+                valid: state.configValid,
+                issues: state.configIssues,
+                loading: state.configLoading,
+                saving: state.configSaving,
+                applying: state.configApplying,
+                updating: state.updateRunning,
+                connected: state.connected,
+                schema: state.configSchema,
+                schemaLoading: state.configSchemaLoading,
+                uiHints: state.configUiHints,
+                formMode: state.communicationsFormMode,
+                formValue: state.configForm,
+                originalValue: state.configFormOriginal,
+                searchQuery: state.communicationsSearchQuery,
+                activeSection:
+                  state.communicationsActiveSection &&
+                  !COMMUNICATION_SECTION_KEYS.includes(
+                    state.communicationsActiveSection as CommunicationSectionKey,
+                  )
+                    ? null
+                    : state.communicationsActiveSection,
+                activeSubsection:
+                  state.communicationsActiveSection &&
+                  !COMMUNICATION_SECTION_KEYS.includes(
+                    state.communicationsActiveSection as CommunicationSectionKey,
+                  )
+                    ? null
+                    : state.communicationsActiveSubsection,
+                onRawChange: (next) => {
+                  state.configRaw = next;
+                },
+                onRequestUpdate: requestHostUpdate,
+                onFormModeChange: (mode) => (state.communicationsFormMode = mode),
+                onFormPatch: (path, value) => updateConfigFormValue(state, path, value),
+                onSearchChange: (query) => (state.communicationsSearchQuery = query),
+                onSectionChange: (section) => {
+                  state.communicationsActiveSection = section;
+                  state.communicationsActiveSubsection = null;
+                },
+                onSubsectionChange: (section) => (state.communicationsActiveSubsection = section),
+                onReload: () => loadConfig(state),
+                onSave: () => saveConfig(state),
+                onApply: () => applyConfig(state),
+                onUpdate: () => runUpdate(state),
+                onOpenFile: () => openConfigFile(state),
+                version: state.hello?.server?.version ?? "",
+                theme: state.theme,
+                themeMode: state.themeMode,
+                setTheme: (t, ctx) => state.setTheme(t, ctx),
+                setThemeMode: (m, ctx) => state.setThemeMode(m, ctx),
+                borderRadius: state.settings.borderRadius,
+                setBorderRadius: (v) => state.setBorderRadius(v),
+                gatewayUrl: state.settings.gatewayUrl,
+                assistantName: state.assistantName,
+                configPath: state.configSnapshot?.path ?? null,
+                rawAvailable: typeof state.configSnapshot?.raw === "string",
+                navRootLabel: "Communication",
+                includeSections: [...COMMUNICATION_SECTION_KEYS],
+                includeVirtualSections: false,
+              })
+            : nothing
+        }
+        ${
+          state.tab === "appearance"
+            ? renderConfig({
+                raw: state.configRaw,
+                originalRaw: state.configRawOriginal,
+                valid: state.configValid,
+                issues: state.configIssues,
+                loading: state.configLoading,
+                saving: state.configSaving,
+                applying: state.configApplying,
+                updating: state.updateRunning,
+                connected: state.connected,
+                schema: state.configSchema,
+                schemaLoading: state.configSchemaLoading,
+                uiHints: state.configUiHints,
+                formMode: state.appearanceFormMode,
+                formValue: state.configForm,
+                originalValue: state.configFormOriginal,
+                searchQuery: state.appearanceSearchQuery,
+                activeSection:
+                  state.appearanceActiveSection &&
+                  !APPEARANCE_SECTION_KEYS.includes(
+                    state.appearanceActiveSection as AppearanceSectionKey,
+                  )
+                    ? null
+                    : state.appearanceActiveSection,
+                activeSubsection:
+                  state.appearanceActiveSection &&
+                  !APPEARANCE_SECTION_KEYS.includes(
+                    state.appearanceActiveSection as AppearanceSectionKey,
+                  )
+                    ? null
+                    : state.appearanceActiveSubsection,
+                onRawChange: (next) => {
+                  state.configRaw = next;
+                },
+                onRequestUpdate: requestHostUpdate,
+                onFormModeChange: (mode) => (state.appearanceFormMode = mode),
+                onFormPatch: (path, value) => updateConfigFormValue(state, path, value),
+                onSearchChange: (query) => (state.appearanceSearchQuery = query),
+                onSectionChange: (section) => {
+                  state.appearanceActiveSection = section;
+                  state.appearanceActiveSubsection = null;
+                },
+                onSubsectionChange: (section) => (state.appearanceActiveSubsection = section),
+                onReload: () => loadConfig(state),
+                onSave: () => saveConfig(state),
+                onApply: () => applyConfig(state),
+                onUpdate: () => runUpdate(state),
+                onOpenFile: () => openConfigFile(state),
+                version: state.hello?.server?.version ?? "",
+                theme: state.theme,
+                themeMode: state.themeMode,
+                setTheme: (t, ctx) => state.setTheme(t, ctx),
+                setThemeMode: (m, ctx) => state.setThemeMode(m, ctx),
+                borderRadius: state.settings.borderRadius,
+                setBorderRadius: (v) => state.setBorderRadius(v),
+                gatewayUrl: state.settings.gatewayUrl,
+                assistantName: state.assistantName,
+                configPath: state.configSnapshot?.path ?? null,
+                rawAvailable: typeof state.configSnapshot?.raw === "string",
+                navRootLabel: "Appearance",
+                includeSections: [...APPEARANCE_SECTION_KEYS],
+                includeVirtualSections: true,
+              })
+            : nothing
+        }
+        ${
+          state.tab === "automation"
+            ? renderConfig({
+                raw: state.configRaw,
+                originalRaw: state.configRawOriginal,
+                valid: state.configValid,
+                issues: state.configIssues,
+                loading: state.configLoading,
+                saving: state.configSaving,
+                applying: state.configApplying,
+                updating: state.updateRunning,
+                connected: state.connected,
+                schema: state.configSchema,
+                schemaLoading: state.configSchemaLoading,
+                uiHints: state.configUiHints,
+                formMode: state.automationFormMode,
+                formValue: state.configForm,
+                originalValue: state.configFormOriginal,
+                searchQuery: state.automationSearchQuery,
+                activeSection:
+                  state.automationActiveSection &&
+                  !AUTOMATION_SECTION_KEYS.includes(
+                    state.automationActiveSection as AutomationSectionKey,
+                  )
+                    ? null
+                    : state.automationActiveSection,
+                activeSubsection:
+                  state.automationActiveSection &&
+                  !AUTOMATION_SECTION_KEYS.includes(
+                    state.automationActiveSection as AutomationSectionKey,
+                  )
+                    ? null
+                    : state.automationActiveSubsection,
+                onRawChange: (next) => {
+                  state.configRaw = next;
+                },
+                onRequestUpdate: requestHostUpdate,
+                onFormModeChange: (mode) => (state.automationFormMode = mode),
+                onFormPatch: (path, value) => updateConfigFormValue(state, path, value),
+                onSearchChange: (query) => (state.automationSearchQuery = query),
+                onSectionChange: (section) => {
+                  state.automationActiveSection = section;
+                  state.automationActiveSubsection = null;
+                },
+                onSubsectionChange: (section) => (state.automationActiveSubsection = section),
+                onReload: () => loadConfig(state),
+                onSave: () => saveConfig(state),
+                onApply: () => applyConfig(state),
+                onUpdate: () => runUpdate(state),
+                onOpenFile: () => openConfigFile(state),
+                version: state.hello?.server?.version ?? "",
+                theme: state.theme,
+                themeMode: state.themeMode,
+                setTheme: (t, ctx) => state.setTheme(t, ctx),
+                setThemeMode: (m, ctx) => state.setThemeMode(m, ctx),
+                borderRadius: state.settings.borderRadius,
+                setBorderRadius: (v) => state.setBorderRadius(v),
+                gatewayUrl: state.settings.gatewayUrl,
+                assistantName: state.assistantName,
+                configPath: state.configSnapshot?.path ?? null,
+                rawAvailable: typeof state.configSnapshot?.raw === "string",
+                navRootLabel: "Automation",
+                includeSections: [...AUTOMATION_SECTION_KEYS],
+                includeVirtualSections: false,
+              })
+            : nothing
+        }
+        ${
+          state.tab === "infrastructure"
+            ? renderConfig({
+                raw: state.configRaw,
+                originalRaw: state.configRawOriginal,
+                valid: state.configValid,
+                issues: state.configIssues,
+                loading: state.configLoading,
+                saving: state.configSaving,
+                applying: state.configApplying,
+                updating: state.updateRunning,
+                connected: state.connected,
+                schema: state.configSchema,
+                schemaLoading: state.configSchemaLoading,
+                uiHints: state.configUiHints,
+                formMode: state.infrastructureFormMode,
+                formValue: state.configForm,
+                originalValue: state.configFormOriginal,
+                searchQuery: state.infrastructureSearchQuery,
+                activeSection:
+                  state.infrastructureActiveSection &&
+                  !INFRASTRUCTURE_SECTION_KEYS.includes(
+                    state.infrastructureActiveSection as InfrastructureSectionKey,
+                  )
+                    ? null
+                    : state.infrastructureActiveSection,
+                activeSubsection:
+                  state.infrastructureActiveSection &&
+                  !INFRASTRUCTURE_SECTION_KEYS.includes(
+                    state.infrastructureActiveSection as InfrastructureSectionKey,
+                  )
+                    ? null
+                    : state.infrastructureActiveSubsection,
+                onRawChange: (next) => {
+                  state.configRaw = next;
+                },
+                onRequestUpdate: requestHostUpdate,
+                onFormModeChange: (mode) => (state.infrastructureFormMode = mode),
+                onFormPatch: (path, value) => updateConfigFormValue(state, path, value),
+                onSearchChange: (query) => (state.infrastructureSearchQuery = query),
+                onSectionChange: (section) => {
+                  state.infrastructureActiveSection = section;
+                  state.infrastructureActiveSubsection = null;
+                },
+                onSubsectionChange: (section) => (state.infrastructureActiveSubsection = section),
+                onReload: () => loadConfig(state),
+                onSave: () => saveConfig(state),
+                onApply: () => applyConfig(state),
+                onUpdate: () => runUpdate(state),
+                onOpenFile: () => openConfigFile(state),
+                version: state.hello?.server?.version ?? "",
+                theme: state.theme,
+                themeMode: state.themeMode,
+                setTheme: (t, ctx) => state.setTheme(t, ctx),
+                setThemeMode: (m, ctx) => state.setThemeMode(m, ctx),
+                borderRadius: state.settings.borderRadius,
+                setBorderRadius: (v) => state.setBorderRadius(v),
+                gatewayUrl: state.settings.gatewayUrl,
+                assistantName: state.assistantName,
+                configPath: state.configSnapshot?.path ?? null,
+                rawAvailable: typeof state.configSnapshot?.raw === "string",
+                navRootLabel: "Infrastructure",
+                includeSections: [...INFRASTRUCTURE_SECTION_KEYS],
+                includeVirtualSections: false,
+              })
+            : nothing
+        }
+        ${
+          state.tab === "aiAgents"
+            ? renderConfig({
+                raw: state.configRaw,
+                originalRaw: state.configRawOriginal,
+                valid: state.configValid,
+                issues: state.configIssues,
+                loading: state.configLoading,
+                saving: state.configSaving,
+                applying: state.configApplying,
+                updating: state.updateRunning,
+                connected: state.connected,
+                schema: state.configSchema,
+                schemaLoading: state.configSchemaLoading,
+                uiHints: state.configUiHints,
+                formMode: state.aiAgentsFormMode,
+                formValue: state.configForm,
+                originalValue: state.configFormOriginal,
+                searchQuery: state.aiAgentsSearchQuery,
+                activeSection:
+                  state.aiAgentsActiveSection &&
+                  !AI_AGENTS_SECTION_KEYS.includes(
+                    state.aiAgentsActiveSection as AiAgentsSectionKey,
+                  )
+                    ? null
+                    : state.aiAgentsActiveSection,
+                activeSubsection:
+                  state.aiAgentsActiveSection &&
+                  !AI_AGENTS_SECTION_KEYS.includes(
+                    state.aiAgentsActiveSection as AiAgentsSectionKey,
+                  )
+                    ? null
+                    : state.aiAgentsActiveSubsection,
+                onRawChange: (next) => {
+                  state.configRaw = next;
+                },
+                onRequestUpdate: requestHostUpdate,
+                onFormModeChange: (mode) => (state.aiAgentsFormMode = mode),
+                onFormPatch: (path, value) => updateConfigFormValue(state, path, value),
+                onSearchChange: (query) => (state.aiAgentsSearchQuery = query),
+                onSectionChange: (section) => {
+                  state.aiAgentsActiveSection = section;
+                  state.aiAgentsActiveSubsection = null;
+                },
+                onSubsectionChange: (section) => (state.aiAgentsActiveSubsection = section),
+                onReload: () => loadConfig(state),
+                onSave: () => saveConfig(state),
+                onApply: () => applyConfig(state),
+                onUpdate: () => runUpdate(state),
+                onOpenFile: () => openConfigFile(state),
+                version: state.hello?.server?.version ?? "",
+                theme: state.theme,
+                themeMode: state.themeMode,
+                setTheme: (t, ctx) => state.setTheme(t, ctx),
+                setThemeMode: (m, ctx) => state.setThemeMode(m, ctx),
+                borderRadius: state.settings.borderRadius,
+                setBorderRadius: (v) => state.setBorderRadius(v),
+                gatewayUrl: state.settings.gatewayUrl,
+                assistantName: state.assistantName,
+                configPath: state.configSnapshot?.path ?? null,
+                rawAvailable: typeof state.configSnapshot?.raw === "string",
+                navRootLabel: "AI & Agents",
+                includeSections: [...AI_AGENTS_SECTION_KEYS],
+                includeVirtualSections: false,
+              })
+            : nothing
+        }
+        ${
+          state.tab === "debug"
+            ? lazyRender(lazyDebug, (m) =>
+                m.renderDebug({
+                  loading: state.debugLoading,
+                  status: state.debugStatus,
+                  health: state.debugHealth,
+                  models: state.debugModels,
+                  heartbeat: state.debugHeartbeat,
+                  eventLog: state.eventLog,
+                  methods: (state.hello?.features?.methods ?? []).toSorted(),
+                  callMethod: state.debugCallMethod,
+                  callParams: state.debugCallParams,
+                  callResult: state.debugCallResult,
+                  callError: state.debugCallError,
+                  onCallMethodChange: (next) => (state.debugCallMethod = next),
+                  onCallParamsChange: (next) => (state.debugCallParams = next),
+                  onRefresh: () => loadDebug(state),
+                  onCall: () => callDebugMethod(state),
+                }),
+              )
+            : nothing
+        }
+        ${
+          state.tab === "logs"
+            ? lazyRender(lazyLogs, (m) =>
+                m.renderLogs({
+                  loading: state.logsLoading,
+                  error: state.logsError,
+                  file: state.logsFile,
+                  entries: state.logsEntries,
+                  filterText: state.logsFilterText,
+                  levelFilters: state.logsLevelFilters,
+                  autoFollow: state.logsAutoFollow,
+                  truncated: state.logsTruncated,
+                  onFilterTextChange: (next) => (state.logsFilterText = next),
+                  onLevelToggle: (level, enabled) => {
+                    state.logsLevelFilters = { ...state.logsLevelFilters, [level]: enabled };
+                  },
+                  onToggleAutoFollow: (next) => (state.logsAutoFollow = next),
+                  onRefresh: () => loadLogs(state, { reset: true }),
+                  onExport: (lines, label) => state.exportLogs(lines, label),
+                  onScroll: (event) => state.handleLogsScroll(event),
+                }),
+              )
+            : nothing
+        }
       </main>
       ${renderExecApprovalPrompt(state)} ${renderGatewayUrlConfirmation(state)} ${nothing}
     </div>

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -177,9 +177,11 @@ export function renderMessageGroup(
           <span class="chat-group-timestamp">${timestamp}</span>
           ${renderMessageMeta(meta)}
           ${normalizedRole === "assistant" && isTtsSupported() ? renderTtsButton(group) : nothing}
-          ${opts.onDelete
-            ? renderDeleteButton(opts.onDelete, normalizedRole === "user" ? "left" : "right")
-            : nothing}
+          ${
+            opts.onDelete
+              ? renderDeleteButton(opts.onDelete, normalizedRole === "user" ? "left" : "right")
+              : nothing
+          }
         </div>
       </div>
     </div>
@@ -728,70 +730,84 @@ function renderGroupedMessage(
 
   return html`
     <div class="${bubbleClasses}">
-      ${hasActions
-        ? html`<div class="chat-bubble-actions">
+      ${
+        hasActions
+          ? html`<div class="chat-bubble-actions">
             ${canExpand ? renderExpandButton(markdown!, onOpenSidebar!) : nothing}
             ${canCopyMarkdown ? renderCopyAsMarkdownButton(markdown!) : nothing}
           </div>`
-        : nothing}
-      ${isToolMessage
-        ? html`
+          : nothing
+      }
+      ${
+        isToolMessage
+          ? html`
             <details class="chat-tool-msg-collapse">
               <summary class="chat-tool-msg-summary">
                 <span class="chat-tool-msg-summary__icon">${icons.zap}</span>
                 <span class="chat-tool-msg-summary__label">Tool output</span>
-                ${toolSummaryLabel
-                  ? html`<span class="chat-tool-msg-summary__names">${toolSummaryLabel}</span>`
-                  : toolPreview
-                    ? html`<span class="chat-tool-msg-summary__preview">${toolPreview}</span>`
-                    : nothing}
+                ${
+                  toolSummaryLabel
+                    ? html`<span class="chat-tool-msg-summary__names">${toolSummaryLabel}</span>`
+                    : toolPreview
+                      ? html`<span class="chat-tool-msg-summary__preview">${toolPreview}</span>`
+                      : nothing
+                }
               </summary>
               <div class="chat-tool-msg-body">
                 ${renderMessageImages(images)}
-                ${reasoningMarkdown
-                  ? html`<div class="chat-thinking">
+                ${
+                  reasoningMarkdown
+                    ? html`<div class="chat-thinking">
                       ${unsafeHTML(toSanitizedMarkdownHtml(reasoningMarkdown))}
                     </div>`
-                  : nothing}
-                ${jsonResult
-                  ? html`<details class="chat-json-collapse">
+                    : nothing
+                }
+                ${
+                  jsonResult
+                    ? html`<details class="chat-json-collapse">
                       <summary class="chat-json-summary">
                         <span class="chat-json-badge">JSON</span>
                         <span class="chat-json-label">${jsonSummaryLabel(jsonResult.parsed)}</span>
                       </summary>
                       <pre class="chat-json-content"><code>${jsonResult.pretty}</code></pre>
                     </details>`
-                  : markdown
-                    ? html`<div class="chat-text" dir="${detectTextDirection(markdown)}">
+                    : markdown
+                      ? html`<div class="chat-text" dir="${detectTextDirection(markdown)}">
                         ${unsafeHTML(toSanitizedMarkdownHtml(markdown))}
                       </div>`
-                    : nothing}
+                      : nothing
+                }
                 ${hasToolCards ? renderCollapsedToolCards(toolCards, onOpenSidebar) : nothing}
               </div>
             </details>
           `
-        : html`
+          : html`
             ${renderMessageImages(images)}
-            ${reasoningMarkdown
-              ? html`<div class="chat-thinking">
+            ${
+              reasoningMarkdown
+                ? html`<div class="chat-thinking">
                   ${unsafeHTML(toSanitizedMarkdownHtml(reasoningMarkdown))}
                 </div>`
-              : nothing}
-            ${jsonResult
-              ? html`<details class="chat-json-collapse">
+                : nothing
+            }
+            ${
+              jsonResult
+                ? html`<details class="chat-json-collapse">
                   <summary class="chat-json-summary">
                     <span class="chat-json-badge">JSON</span>
                     <span class="chat-json-label">${jsonSummaryLabel(jsonResult.parsed)}</span>
                   </summary>
                   <pre class="chat-json-content"><code>${jsonResult.pretty}</code></pre>
                 </details>`
-              : markdown
-                ? html`<div class="chat-text" dir="${detectTextDirection(markdown)}">
+                : markdown
+                  ? html`<div class="chat-text" dir="${detectTextDirection(markdown)}">
                     ${unsafeHTML(toSanitizedMarkdownHtml(markdown))}
                   </div>`
-                : nothing}
+                  : nothing
+            }
             ${hasToolCards ? renderCollapsedToolCards(toolCards, onOpenSidebar) : nothing}
-          `}
+          `
+      }
     </div>
   `;
 }

--- a/ui/src/ui/chat/tool-cards.ts
+++ b/ui/src/ui/chat/tool-cards.ts
@@ -81,35 +81,49 @@ export function renderToolCardSidebar(card: ToolCard, onOpenSidebar?: (content: 
       @click=${handleClick}
       role=${canClick ? "button" : nothing}
       tabindex=${canClick ? "0" : nothing}
-      @keydown=${canClick
-        ? (e: KeyboardEvent) => {
-            if (e.key !== "Enter" && e.key !== " ") {
-              return;
+      @keydown=${
+        canClick
+          ? (e: KeyboardEvent) => {
+              if (e.key !== "Enter" && e.key !== " ") {
+                return;
+              }
+              e.preventDefault();
+              handleClick?.();
             }
-            e.preventDefault();
-            handleClick?.();
-          }
-        : nothing}
+          : nothing
+      }
     >
       <div class="chat-tool-card__header">
         <div class="chat-tool-card__title">
           <span class="chat-tool-card__icon">${icons[display.icon]}</span>
           <span>${display.label}</span>
         </div>
-        ${canClick
-          ? html`<span class="chat-tool-card__action"
+        ${
+          canClick
+            ? html`<span class="chat-tool-card__action"
               >${hasText ? "View" : ""} ${icons.check}</span
             >`
-          : nothing}
-        ${isEmpty && !canClick
-          ? html`<span class="chat-tool-card__status">${icons.check}</span>`
-          : nothing}
+            : nothing
+        }
+        ${
+          isEmpty && !canClick
+            ? html`<span class="chat-tool-card__status">${icons.check}</span>`
+            : nothing
+        }
       </div>
       ${detail ? html`<div class="chat-tool-card__detail">${detail}</div>` : nothing}
-      ${isEmpty ? html` <div class="chat-tool-card__status-text muted">Completed</div> ` : nothing}
-      ${showCollapsed
-        ? html`<div class="chat-tool-card__preview mono">${getTruncatedPreview(card.text!)}</div>`
-        : nothing}
+      ${
+        isEmpty
+          ? html`
+              <div class="chat-tool-card__status-text muted">Completed</div>
+            `
+          : nothing
+      }
+      ${
+        showCollapsed
+          ? html`<div class="chat-tool-card__preview mono">${getTruncatedPreview(card.text!)}</div>`
+          : nothing
+      }
       ${showInline ? html`<div class="chat-tool-card__inline mono">${card.text}</div>` : nothing}
     </div>
   `;

--- a/ui/src/ui/icons.ts
+++ b/ui/src/ui/icons.ts
@@ -121,7 +121,9 @@ export const icons = {
       <path d="m6 6 12 12" />
     </svg>
   `,
-  check: html` <svg viewBox="0 0 24 24"><path d="M20 6 9 17l-5-5" /></svg> `,
+  check: html`
+    <svg viewBox="0 0 24 24"><path d="M20 6 9 17l-5-5" /></svg>
+  `,
   arrowDown: html`
     <svg viewBox="0 0 24 24">
       <path d="M12 5v14" />
@@ -142,12 +144,8 @@ export const icons = {
   `,
   brain: html`
     <svg viewBox="0 0 24 24">
-      <path
-        d="M12 5a3 3 0 1 0-5.997.125 4 4 0 0 0-2.526 5.77 4 4 0 0 0 .556 6.588A4 4 0 1 0 12 18Z"
-      />
-      <path
-        d="M12 5a3 3 0 1 1 5.997.125 4 4 0 0 1 2.526 5.77 4 4 0 0 1-.556 6.588A4 4 0 1 1 12 18Z"
-      />
+      <path d="M12 5a3 3 0 1 0-5.997.125 4 4 0 0 0-2.526 5.77 4 4 0 0 0 .556 6.588A4 4 0 1 0 12 18Z" />
+      <path d="M12 5a3 3 0 1 1 5.997.125 4 4 0 0 1 2.526 5.77 4 4 0 0 1-.556 6.588A4 4 0 1 1 12 18Z" />
       <path d="M15 13a4.5 4.5 0 0 1-3-4 4.5 4.5 0 0 1-3 4" />
       <path d="M17.599 6.5a3 3 0 0 0 .399-1.375" />
       <path d="M6.003 5.125A3 3 0 0 0 6.401 6.5" />
@@ -238,7 +236,9 @@ export const icons = {
       <path d="M18 8v5a4 4 0 0 1-4 4h-4a4 4 0 0 1-4-4V8Z" />
     </svg>
   `,
-  circle: html` <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10" /></svg> `,
+  circle: html`
+    <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10" /></svg>
+  `,
   puzzle: html`
     <svg viewBox="0 0 24 24">
       <path
@@ -286,7 +286,9 @@ export const icons = {
       <path d="M22 2 11 13" />
     </svg>
   `,
-  stop: html` <svg viewBox="0 0 24 24"><rect width="14" height="14" x="5" y="5" rx="1" /></svg> `,
+  stop: html`
+    <svg viewBox="0 0 24 24"><rect width="14" height="14" x="5" y="5" rx="1" /></svg>
+  `,
   pin: html`
     <svg viewBox="0 0 24 24">
       <line x1="12" x2="12" y1="17" y2="22" />

--- a/ui/src/ui/views/agents-panels-overview.ts
+++ b/ui/src/ui/views/agents-panels-overview.ts
@@ -126,13 +126,13 @@ export function renderAgentOverview(params: {
         </div>
       </div>
 
-      ${configDirty
-        ? html`
-            <div class="callout warn" style="margin-top: 16px">
-              You have unsaved config changes.
-            </div>
-          `
-        : nothing}
+      ${
+        configDirty
+          ? html`
+              <div class="callout warn" style="margin-top: 16px">You have unsaved config changes.</div>
+            `
+          : nothing
+      }
 
       <div class="agent-model-select" style="margin-top: 20px;">
         <div class="label">Model Selection</div>
@@ -145,13 +145,17 @@ export function renderAgentOverview(params: {
               @change=${(e: Event) =>
                 onModelChange(agent.id, (e.target as HTMLSelectElement).value || null)}
             >
-              ${isDefault
-                ? html` <option value="">Not set</option> `
-                : html`
+              ${
+                isDefault
+                  ? html`
+                      <option value="">Not set</option>
+                    `
+                  : html`
                     <option value="">
                       ${defaultPrimary ? `Inherit default (${defaultPrimary})` : "Inherit default"}
                     </option>
-                  `}
+                  `
+              }
               ${buildModelOptions(configForm, effectivePrimary ?? undefined, params.modelCatalog)}
             </select>
           </label>

--- a/ui/src/ui/views/agents-panels-status-files.ts
+++ b/ui/src/ui/views/agents-panels-status-files.ts
@@ -179,19 +179,24 @@ export function renderAgentChannels(params: {
           </button>
         </div>
         <div class="muted" style="margin-top: 8px;">Last refresh: ${lastSuccessLabel}</div>
-        ${params.error
-          ? html`<div class="callout danger" style="margin-top: 12px;">${params.error}</div>`
-          : nothing}
-        ${!params.snapshot
-          ? html`
-              <div class="callout info" style="margin-top: 12px">
-                Load channels to see live status.
-              </div>
-            `
-          : nothing}
-        ${entries.length === 0
-          ? html` <div class="muted" style="margin-top: 16px">No channels found.</div> `
-          : html`
+        ${
+          params.error
+            ? html`<div class="callout danger" style="margin-top: 12px;">${params.error}</div>`
+            : nothing
+        }
+        ${
+          !params.snapshot
+            ? html`
+                <div class="callout info" style="margin-top: 12px">Load channels to see live status.</div>
+              `
+            : nothing
+        }
+        ${
+          entries.length === 0
+            ? html`
+                <div class="muted" style="margin-top: 16px">No channels found.</div>
+              `
+            : html`
               <div class="list" style="margin-top: 16px;">
                 ${entries.map((entry) => {
                   const summary = summarizeChannelAccounts(entry.accounts);
@@ -217,28 +222,33 @@ export function renderAgentChannels(params: {
                         <div>${status}</div>
                         <div>${configLabel}</div>
                         <div>${enabled}</div>
-                        ${summary.configured === 0
-                          ? html`
-                              <div>
-                                <a
-                                  href="https://docs.openclaw.ai/channels"
-                                  target="_blank"
-                                  rel="noopener"
-                                  style="color: var(--accent); font-size: 12px"
-                                  >Setup guide</a
-                                >
-                              </div>
-                            `
-                          : nothing}
-                        ${extras.length > 0
-                          ? extras.map((extra) => html`<div>${extra.label}: ${extra.value}</div>`)
-                          : nothing}
+                        ${
+                          summary.configured === 0
+                            ? html`
+                                <div>
+                                  <a
+                                    href="https://docs.openclaw.ai/channels"
+                                    target="_blank"
+                                    rel="noopener"
+                                    style="color: var(--accent); font-size: 12px"
+                                    >Setup guide</a
+                                  >
+                                </div>
+                              `
+                            : nothing
+                        }
+                        ${
+                          extras.length > 0
+                            ? extras.map((extra) => html`<div>${extra.label}: ${extra.value}</div>`)
+                            : nothing
+                        }
                       </div>
                     </div>
                   `;
                 })}
               </div>
-            `}
+            `
+        }
       </section>
     </section>
   `;
@@ -289,26 +299,33 @@ export function renderAgentCron(params: {
             <div class="stat-value">${formatNextRun(params.status?.nextWakeAtMs ?? null)}</div>
           </div>
         </div>
-        ${params.error
-          ? html`<div class="callout danger" style="margin-top: 12px;">${params.error}</div>`
-          : nothing}
+        ${
+          params.error
+            ? html`<div class="callout danger" style="margin-top: 12px;">${params.error}</div>`
+            : nothing
+        }
       </section>
     </section>
     <section class="card">
       <div class="card-title">Agent Cron Jobs</div>
       <div class="card-sub">Scheduled jobs targeting this agent.</div>
-      ${jobs.length === 0
-        ? html` <div class="muted" style="margin-top: 16px">No jobs assigned.</div> `
-        : html`
+      ${
+        jobs.length === 0
+          ? html`
+              <div class="muted" style="margin-top: 16px">No jobs assigned.</div>
+            `
+          : html`
             <div class="list" style="margin-top: 16px;">
               ${jobs.map(
                 (job) => html`
                   <div class="list-item">
                     <div class="list-main">
                       <div class="list-title">${job.name}</div>
-                      ${job.description
-                        ? html`<div class="list-sub">${job.description}</div>`
-                        : nothing}
+                      ${
+                        job.description
+                          ? html`<div class="list-sub">${job.description}</div>`
+                          : nothing
+                      }
                       <div class="chip-row" style="margin-top: 6px;">
                         <span class="chip">${formatCronSchedule(job)}</span>
                         <span class="chip ${job.enabled ? "chip-ok" : "chip-warn"}">
@@ -333,7 +350,8 @@ export function renderAgentCron(params: {
                 `,
               )}
             </div>
-          `}
+          `
+      }
     </section>
   `;
 }
@@ -376,46 +394,60 @@ export function renderAgentFiles(params: {
           ${params.agentFilesLoading ? "Loading…" : "Refresh"}
         </button>
       </div>
-      ${list
-        ? html`<div class="muted mono" style="margin-top: 8px;">
+      ${
+        list
+          ? html`<div class="muted mono" style="margin-top: 8px;">
             Workspace: <span>${list.workspace}</span>
           </div>`
-        : nothing}
-      ${params.agentFilesError
-        ? html`<div class="callout danger" style="margin-top: 12px;">
+          : nothing
+      }
+      ${
+        params.agentFilesError
+          ? html`<div class="callout danger" style="margin-top: 12px;">
             ${params.agentFilesError}
           </div>`
-        : nothing}
-      ${!list
-        ? html`
-            <div class="callout info" style="margin-top: 12px">
-              Load the agent workspace files to edit core instructions.
-            </div>
-          `
-        : files.length === 0
-          ? html` <div class="muted" style="margin-top: 16px">No files found.</div> `
-          : html`
+          : nothing
+      }
+      ${
+        !list
+          ? html`
+              <div class="callout info" style="margin-top: 12px">
+                Load the agent workspace files to edit core instructions.
+              </div>
+            `
+          : files.length === 0
+            ? html`
+                <div class="muted" style="margin-top: 16px">No files found.</div>
+              `
+            : html`
               <div class="agent-tabs" style="margin-top: 14px;">
                 ${files.map((file) => {
                   const isActive = active === file.name;
                   const label = file.name.replace(/\.md$/i, "");
                   return html`
                     <button
-                      class="agent-tab ${isActive ? "active" : ""} ${file.missing
-                        ? "agent-tab--missing"
-                        : ""}"
+                      class="agent-tab ${isActive ? "active" : ""} ${
+                        file.missing ? "agent-tab--missing" : ""
+                      }"
                       @click=${() => params.onSelectFile(file.name)}
                     >
-                      ${label}${file.missing
-                        ? html` <span class="agent-tab-badge">missing</span> `
-                        : nothing}
+                      ${label}${
+                        file.missing
+                          ? html`
+                              <span class="agent-tab-badge">missing</span>
+                            `
+                          : nothing
+                      }
                     </button>
                   `;
                 })}
               </div>
-              ${!activeEntry
-                ? html` <div class="muted" style="margin-top: 16px">Select a file to edit.</div> `
-                : html`
+              ${
+                !activeEntry
+                  ? html`
+                      <div class="muted" style="margin-top: 16px">Select a file to edit.</div>
+                    `
+                  : html`
                     <div class="agent-file-header" style="margin-top: 14px;">
                       <div>
                         <div class="agent-file-sub mono">${activeEntry.path}</div>
@@ -450,13 +482,15 @@ export function renderAgentFiles(params: {
                         </button>
                       </div>
                     </div>
-                    ${activeEntry.missing
-                      ? html`
-                          <div class="callout info" style="margin-top: 10px">
-                            This file is missing. Saving will create it in the agent workspace.
-                          </div>
-                        `
-                      : nothing}
+                    ${
+                      activeEntry.missing
+                        ? html`
+                            <div class="callout info" style="margin-top: 10px">
+                              This file is missing. Saving will create it in the agent workspace.
+                            </div>
+                          `
+                        : nothing
+                    }
                     <label class="field agent-file-field" style="margin-top: 12px;">
                       <span>Content</span>
                       <textarea
@@ -536,8 +570,10 @@ export function renderAgentFiles(params: {
                         </div>
                       </div>
                     </dialog>
-                  `}
-            `}
+                  `
+              }
+            `
+      }
     </section>
   `;
 }

--- a/ui/src/ui/views/agents-panels-tools-skills.ts
+++ b/ui/src/ui/views/agents-panels-tools-skills.ts
@@ -200,41 +200,49 @@ export function renderAgentTools(params: {
         </div>
       </div>
 
-      ${!params.configForm
-        ? html`
-            <div class="callout info" style="margin-top: 12px">
-              Load the gateway config to adjust tool profiles.
-            </div>
-          `
-        : nothing}
-      ${hasAgentAllow
-        ? html`
-            <div class="callout info" style="margin-top: 12px">
-              This agent is using an explicit allowlist in config. Tool overrides are managed in the
-              Config tab.
-            </div>
-          `
-        : nothing}
-      ${hasGlobalAllow
-        ? html`
-            <div class="callout info" style="margin-top: 12px">
-              Global tools.allow is set. Agent overrides cannot enable tools that are globally
-              blocked.
-            </div>
-          `
-        : nothing}
-      ${params.toolsCatalogLoading && !params.toolsCatalogResult && !params.toolsCatalogError
-        ? html`
-            <div class="callout info" style="margin-top: 12px">Loading runtime tool catalog…</div>
-          `
-        : nothing}
-      ${params.toolsCatalogError
-        ? html`
-            <div class="callout info" style="margin-top: 12px">
-              Could not load runtime tool catalog. Showing built-in fallback list instead.
-            </div>
-          `
-        : nothing}
+      ${
+        !params.configForm
+          ? html`
+              <div class="callout info" style="margin-top: 12px">
+                Load the gateway config to adjust tool profiles.
+              </div>
+            `
+          : nothing
+      }
+      ${
+        hasAgentAllow
+          ? html`
+              <div class="callout info" style="margin-top: 12px">
+                This agent is using an explicit allowlist in config. Tool overrides are managed in the Config tab.
+              </div>
+            `
+          : nothing
+      }
+      ${
+        hasGlobalAllow
+          ? html`
+              <div class="callout info" style="margin-top: 12px">
+                Global tools.allow is set. Agent overrides cannot enable tools that are globally blocked.
+              </div>
+            `
+          : nothing
+      }
+      ${
+        params.toolsCatalogLoading && !params.toolsCatalogResult && !params.toolsCatalogError
+          ? html`
+              <div class="callout info" style="margin-top: 12px">Loading runtime tool catalog…</div>
+            `
+          : nothing
+      }
+      ${
+        params.toolsCatalogError
+          ? html`
+              <div class="callout info" style="margin-top: 12px">
+                Could not load runtime tool catalog. Showing built-in fallback list instead.
+              </div>
+            `
+          : nothing
+      }
 
       <div class="agent-tools-meta" style="margin-top: 16px;">
         <div class="agent-kv">
@@ -245,14 +253,16 @@ export function renderAgentTools(params: {
           <div class="label">Source</div>
           <div>${profileSource}</div>
         </div>
-        ${params.configDirty
-          ? html`
-              <div class="agent-kv">
-                <div class="label">Status</div>
-                <div class="mono">unsaved</div>
-              </div>
-            `
-          : nothing}
+        ${
+          params.configDirty
+            ? html`
+                <div class="agent-kv">
+                  <div class="label">Status</div>
+                  <div class="mono">unsaved</div>
+                </div>
+              `
+            : nothing
+        }
       </div>
 
       <div style="margin-top: 18px;">
@@ -261,31 +271,32 @@ export function renderAgentTools(params: {
           What this agent can use in the current chat session.
           <span class="mono">${params.runtimeSessionKey || "no session"}</span>
         </div>
-        ${!params.runtimeSessionMatchesSelectedAgent
-          ? html`
-              <div class="callout info" style="margin-top: 12px">
-                Switch chat to this agent to view its live runtime tools.
-              </div>
-            `
-          : params.toolsEffectiveLoading &&
-              !params.toolsEffectiveResult &&
-              !params.toolsEffectiveError
+        ${
+          !params.runtimeSessionMatchesSelectedAgent
             ? html`
-                <div class="callout info" style="margin-top: 12px">Loading available tools…</div>
+                <div class="callout info" style="margin-top: 12px">
+                  Switch chat to this agent to view its live runtime tools.
+                </div>
               `
-            : params.toolsEffectiveError
+            : params.toolsEffectiveLoading &&
+                !params.toolsEffectiveResult &&
+                !params.toolsEffectiveError
               ? html`
-                  <div class="callout info" style="margin-top: 12px">
-                    Could not load available tools for this session.
-                  </div>
+                  <div class="callout info" style="margin-top: 12px">Loading available tools…</div>
                 `
-              : (params.toolsEffectiveResult?.groups?.length ?? 0) === 0
+              : params.toolsEffectiveError
                 ? html`
                     <div class="callout info" style="margin-top: 12px">
-                      No tools are available for this session right now.
+                      Could not load available tools for this session.
                     </div>
                   `
-                : html`
+                : (params.toolsEffectiveResult?.groups?.length ?? 0) === 0
+                  ? html`
+                      <div class="callout info" style="margin-top: 12px">
+                        No tools are available for this session right now.
+                      </div>
+                    `
+                  : html`
                     <div class="agent-tools-grid" style="margin-top: 16px;">
                       ${params.toolsEffectiveResult?.groups.map(
                         (group) => html`
@@ -314,7 +325,8 @@ export function renderAgentTools(params: {
                         `,
                       )}
                     </div>
-                  `}
+                  `
+        }
       </div>
 
       <div class="agent-tools-presets" style="margin-top: 16px;">
@@ -347,11 +359,13 @@ export function renderAgentTools(params: {
             <div class="agent-tools-section">
               <div class="agent-tools-header">
                 ${section.label}
-                ${section.source === "plugin" && section.pluginId
-                  ? html`<span class="agent-pill" style="margin-left: 8px;"
+                ${
+                  section.source === "plugin" && section.pluginId
+                    ? html`<span class="agent-pill" style="margin-left: 8px;"
                       >plugin:${section.pluginId}</span
                     >`
-                  : nothing}
+                    : nothing
+                }
               </div>
               <div class="agent-tools-list">
                 ${section.tools.map((tool) => {
@@ -430,9 +444,11 @@ export function renderAgentSkills(params: {
           <div class="card-title">Skills</div>
           <div class="card-sub">
             Per-agent skill allowlist and workspace skills.
-            ${totalCount > 0
-              ? html`<span class="mono">${enabledCount}/${totalCount}</span>`
-              : nothing}
+            ${
+              totalCount > 0
+                ? html`<span class="mono">${enabledCount}/${totalCount}</span>`
+                : nothing
+            }
           </div>
         </div>
         <div class="row" style="gap: 8px; flex-wrap: wrap;">
@@ -483,34 +499,40 @@ export function renderAgentSkills(params: {
         </div>
       </div>
 
-      ${!params.configForm
-        ? html`
-            <div class="callout info" style="margin-top: 12px">
-              Load the gateway config to set per-agent skills.
-            </div>
-          `
-        : nothing}
-      ${usingAllowlist
-        ? html`
-            <div class="callout info" style="margin-top: 12px">
-              This agent uses a custom skill allowlist.
-            </div>
-          `
-        : html`
-            <div class="callout info" style="margin-top: 12px">
-              All skills are enabled. Disabling any skill will create a per-agent allowlist.
-            </div>
-          `}
-      ${!reportReady && !params.loading
-        ? html`
-            <div class="callout info" style="margin-top: 12px">
-              Load skills for this agent to view workspace-specific entries.
-            </div>
-          `
-        : nothing}
-      ${params.error
-        ? html`<div class="callout danger" style="margin-top: 12px;">${params.error}</div>`
-        : nothing}
+      ${
+        !params.configForm
+          ? html`
+              <div class="callout info" style="margin-top: 12px">
+                Load the gateway config to set per-agent skills.
+              </div>
+            `
+          : nothing
+      }
+      ${
+        usingAllowlist
+          ? html`
+              <div class="callout info" style="margin-top: 12px">This agent uses a custom skill allowlist.</div>
+            `
+          : html`
+              <div class="callout info" style="margin-top: 12px">
+                All skills are enabled. Disabling any skill will create a per-agent allowlist.
+              </div>
+            `
+      }
+      ${
+        !reportReady && !params.loading
+          ? html`
+              <div class="callout info" style="margin-top: 12px">
+                Load skills for this agent to view workspace-specific entries.
+              </div>
+            `
+          : nothing
+      }
+      ${
+        params.error
+          ? html`<div class="callout danger" style="margin-top: 12px;">${params.error}</div>`
+          : nothing
+      }
 
       <div class="filters" style="margin-top: 14px;">
         <label class="field" style="flex: 1;">
@@ -526,9 +548,12 @@ export function renderAgentSkills(params: {
         <div class="muted">${filtered.length} shown</div>
       </div>
 
-      ${filtered.length === 0
-        ? html` <div class="muted" style="margin-top: 16px">No skills found.</div> `
-        : html`
+      ${
+        filtered.length === 0
+          ? html`
+              <div class="muted" style="margin-top: 16px">No skills found.</div>
+            `
+          : html`
             <div class="agent-skills-groups" style="margin-top: 16px;">
               ${groups.map((group) =>
                 renderAgentSkillGroup(group, {
@@ -540,7 +565,8 @@ export function renderAgentSkills(params: {
                 }),
               )}
             </div>
-          `}
+          `
+      }
     </section>
   `;
 }
@@ -596,12 +622,16 @@ function renderAgentSkillRow(
         <div class="list-title">${skill.emoji ? `${skill.emoji} ` : ""}${skill.name}</div>
         <div class="list-sub">${skill.description}</div>
         ${renderSkillStatusChips({ skill })}
-        ${missing.length > 0
-          ? html`<div class="muted" style="margin-top: 6px;">Missing: ${missing.join(", ")}</div>`
-          : nothing}
-        ${reasons.length > 0
-          ? html`<div class="muted" style="margin-top: 6px;">Reason: ${reasons.join(", ")}</div>`
-          : nothing}
+        ${
+          missing.length > 0
+            ? html`<div class="muted" style="margin-top: 6px;">Missing: ${missing.join(", ")}</div>`
+            : nothing
+        }
+        ${
+          reasons.length > 0
+            ? html`<div class="muted" style="margin-top: 6px;">Reason: ${reasons.join(", ")}</div>`
+            : nothing
+        }
       </div>
       <div class="list-meta">
         <label class="cfg-toggle">

--- a/ui/src/ui/views/agents.ts
+++ b/ui/src/ui/views/agents.ts
@@ -154,22 +154,29 @@ export function renderAgents(props: AgentsProps) {
               ?disabled=${props.loading || agents.length === 0}
               @change=${(e: Event) => props.onSelectAgent((e.target as HTMLSelectElement).value)}
             >
-              ${agents.length === 0
-                ? html` <option value="">No agents</option> `
-                : agents.map(
-                    (agent) => html`
+              ${
+                agents.length === 0
+                  ? html`
+                      <option value="">No agents</option>
+                    `
+                  : agents.map(
+                      (agent) => html`
                       <option value=${agent.id} ?selected=${agent.id === selectedId}>
-                        ${normalizeAgentLabel(agent)}${agentBadgeText(agent.id, defaultId)
-                          ? ` (${agentBadgeText(agent.id, defaultId)})`
-                          : ""}
+                        ${normalizeAgentLabel(agent)}${
+                          agentBadgeText(agent.id, defaultId)
+                            ? ` (${agentBadgeText(agent.id, defaultId)})`
+                            : ""
+                        }
                       </option>
                     `,
-                  )}
+                    )
+              }
             </select>
           </div>
           <div class="agents-toolbar-actions">
-            ${selectedAgent
-              ? html`
+            ${
+              selectedAgent
+                ? html`
                   <button
                     type="button"
                     class="btn btn--sm btn--ghost"
@@ -183,14 +190,17 @@ export function renderAgents(props: AgentsProps) {
                     class="btn btn--sm btn--ghost"
                     ?disabled=${Boolean(defaultId && selectedAgent.id === defaultId)}
                     @click=${() => props.onSetDefault(selectedAgent.id)}
-                    title=${defaultId && selectedAgent.id === defaultId
-                      ? "Already the default agent"
-                      : "Set as the default agent"}
+                    title=${
+                      defaultId && selectedAgent.id === defaultId
+                        ? "Already the default agent"
+                        : "Set as the default agent"
+                    }
                   >
                     ${defaultId && selectedAgent.id === defaultId ? "Default" : "Set Default"}
                   </button>
                 `
-              : nothing}
+                : nothing
+            }
             <button
               class="btn btn--sm agents-refresh-btn"
               ?disabled=${props.loading}
@@ -200,142 +210,158 @@ export function renderAgents(props: AgentsProps) {
             </button>
           </div>
         </div>
-        ${props.error
-          ? html`<div class="callout danger" style="margin-top: 8px;">${props.error}</div>`
-          : nothing}
+        ${
+          props.error
+            ? html`<div class="callout danger" style="margin-top: 8px;">${props.error}</div>`
+            : nothing
+        }
       </section>
       <section class="agents-main">
-        ${!selectedAgent
-          ? html`
-              <div class="card">
-                <div class="card-title">Select an agent</div>
-                <div class="card-sub">Pick an agent to inspect its workspace and tools.</div>
-              </div>
-            `
-          : html`
+        ${
+          !selectedAgent
+            ? html`
+                <div class="card">
+                  <div class="card-title">Select an agent</div>
+                  <div class="card-sub">Pick an agent to inspect its workspace and tools.</div>
+                </div>
+              `
+            : html`
               ${renderAgentTabs(
                 props.activePanel,
                 (panel) => props.onSelectPanel(panel),
                 tabCounts,
               )}
-              ${props.activePanel === "overview"
-                ? renderAgentOverview({
-                    agent: selectedAgent,
-                    basePath: props.basePath,
-                    defaultId,
-                    configForm: props.config.form,
-                    agentFilesList: props.agentFiles.list,
-                    agentIdentity: props.agentIdentityById[selectedAgent.id] ?? null,
-                    agentIdentityError: props.agentIdentityError,
-                    agentIdentityLoading: props.agentIdentityLoading,
-                    configLoading: props.config.loading,
-                    configSaving: props.config.saving,
-                    configDirty: props.config.dirty,
-                    modelCatalog: props.modelCatalog,
-                    onConfigReload: props.onConfigReload,
-                    onConfigSave: props.onConfigSave,
-                    onModelChange: props.onModelChange,
-                    onModelFallbacksChange: props.onModelFallbacksChange,
-                    onSelectPanel: props.onSelectPanel,
-                  })
-                : nothing}
-              ${props.activePanel === "files"
-                ? renderAgentFiles({
-                    agentId: selectedAgent.id,
-                    agentFilesList: props.agentFiles.list,
-                    agentFilesLoading: props.agentFiles.loading,
-                    agentFilesError: props.agentFiles.error,
-                    agentFileActive: props.agentFiles.active,
-                    agentFileContents: props.agentFiles.contents,
-                    agentFileDrafts: props.agentFiles.drafts,
-                    agentFileSaving: props.agentFiles.saving,
-                    onLoadFiles: props.onLoadFiles,
-                    onSelectFile: props.onSelectFile,
-                    onFileDraftChange: props.onFileDraftChange,
-                    onFileReset: props.onFileReset,
-                    onFileSave: props.onFileSave,
-                  })
-                : nothing}
-              ${props.activePanel === "tools"
-                ? renderAgentTools({
-                    agentId: selectedAgent.id,
-                    configForm: props.config.form,
-                    configLoading: props.config.loading,
-                    configSaving: props.config.saving,
-                    configDirty: props.config.dirty,
-                    toolsCatalogLoading: props.toolsCatalog.loading,
-                    toolsCatalogError: props.toolsCatalog.error,
-                    toolsCatalogResult: props.toolsCatalog.result,
-                    toolsEffectiveLoading: props.toolsEffective.loading,
-                    toolsEffectiveError: props.toolsEffective.error,
-                    toolsEffectiveResult: props.toolsEffective.result,
-                    runtimeSessionKey: props.runtimeSessionKey,
-                    runtimeSessionMatchesSelectedAgent: props.runtimeSessionMatchesSelectedAgent,
-                    onProfileChange: props.onToolsProfileChange,
-                    onOverridesChange: props.onToolsOverridesChange,
-                    onConfigReload: props.onConfigReload,
-                    onConfigSave: props.onConfigSave,
-                  })
-                : nothing}
-              ${props.activePanel === "skills"
-                ? renderAgentSkills({
-                    agentId: selectedAgent.id,
-                    report: props.agentSkills.report,
-                    loading: props.agentSkills.loading,
-                    error: props.agentSkills.error,
-                    activeAgentId: props.agentSkills.agentId,
-                    configForm: props.config.form,
-                    configLoading: props.config.loading,
-                    configSaving: props.config.saving,
-                    configDirty: props.config.dirty,
-                    filter: props.agentSkills.filter,
-                    onFilterChange: props.onSkillsFilterChange,
-                    onRefresh: props.onSkillsRefresh,
-                    onToggle: props.onAgentSkillToggle,
-                    onClear: props.onAgentSkillsClear,
-                    onDisableAll: props.onAgentSkillsDisableAll,
-                    onConfigReload: props.onConfigReload,
-                    onConfigSave: props.onConfigSave,
-                  })
-                : nothing}
-              ${props.activePanel === "channels"
-                ? renderAgentChannels({
-                    context: buildAgentContext(
-                      selectedAgent,
-                      props.config.form,
-                      props.agentFiles.list,
+              ${
+                props.activePanel === "overview"
+                  ? renderAgentOverview({
+                      agent: selectedAgent,
+                      basePath: props.basePath,
                       defaultId,
-                      props.agentIdentityById[selectedAgent.id] ?? null,
-                    ),
-                    configForm: props.config.form,
-                    snapshot: props.channels.snapshot,
-                    loading: props.channels.loading,
-                    error: props.channels.error,
-                    lastSuccess: props.channels.lastSuccess,
-                    onRefresh: props.onChannelsRefresh,
-                    onSelectPanel: props.onSelectPanel,
-                  })
-                : nothing}
-              ${props.activePanel === "cron"
-                ? renderAgentCron({
-                    context: buildAgentContext(
-                      selectedAgent,
-                      props.config.form,
-                      props.agentFiles.list,
-                      defaultId,
-                      props.agentIdentityById[selectedAgent.id] ?? null,
-                    ),
-                    agentId: selectedAgent.id,
-                    jobs: props.cron.jobs,
-                    status: props.cron.status,
-                    loading: props.cron.loading,
-                    error: props.cron.error,
-                    onRefresh: props.onCronRefresh,
-                    onRunNow: props.onCronRunNow,
-                    onSelectPanel: props.onSelectPanel,
-                  })
-                : nothing}
-            `}
+                      configForm: props.config.form,
+                      agentFilesList: props.agentFiles.list,
+                      agentIdentity: props.agentIdentityById[selectedAgent.id] ?? null,
+                      agentIdentityError: props.agentIdentityError,
+                      agentIdentityLoading: props.agentIdentityLoading,
+                      configLoading: props.config.loading,
+                      configSaving: props.config.saving,
+                      configDirty: props.config.dirty,
+                      modelCatalog: props.modelCatalog,
+                      onConfigReload: props.onConfigReload,
+                      onConfigSave: props.onConfigSave,
+                      onModelChange: props.onModelChange,
+                      onModelFallbacksChange: props.onModelFallbacksChange,
+                      onSelectPanel: props.onSelectPanel,
+                    })
+                  : nothing
+              }
+              ${
+                props.activePanel === "files"
+                  ? renderAgentFiles({
+                      agentId: selectedAgent.id,
+                      agentFilesList: props.agentFiles.list,
+                      agentFilesLoading: props.agentFiles.loading,
+                      agentFilesError: props.agentFiles.error,
+                      agentFileActive: props.agentFiles.active,
+                      agentFileContents: props.agentFiles.contents,
+                      agentFileDrafts: props.agentFiles.drafts,
+                      agentFileSaving: props.agentFiles.saving,
+                      onLoadFiles: props.onLoadFiles,
+                      onSelectFile: props.onSelectFile,
+                      onFileDraftChange: props.onFileDraftChange,
+                      onFileReset: props.onFileReset,
+                      onFileSave: props.onFileSave,
+                    })
+                  : nothing
+              }
+              ${
+                props.activePanel === "tools"
+                  ? renderAgentTools({
+                      agentId: selectedAgent.id,
+                      configForm: props.config.form,
+                      configLoading: props.config.loading,
+                      configSaving: props.config.saving,
+                      configDirty: props.config.dirty,
+                      toolsCatalogLoading: props.toolsCatalog.loading,
+                      toolsCatalogError: props.toolsCatalog.error,
+                      toolsCatalogResult: props.toolsCatalog.result,
+                      toolsEffectiveLoading: props.toolsEffective.loading,
+                      toolsEffectiveError: props.toolsEffective.error,
+                      toolsEffectiveResult: props.toolsEffective.result,
+                      runtimeSessionKey: props.runtimeSessionKey,
+                      runtimeSessionMatchesSelectedAgent: props.runtimeSessionMatchesSelectedAgent,
+                      onProfileChange: props.onToolsProfileChange,
+                      onOverridesChange: props.onToolsOverridesChange,
+                      onConfigReload: props.onConfigReload,
+                      onConfigSave: props.onConfigSave,
+                    })
+                  : nothing
+              }
+              ${
+                props.activePanel === "skills"
+                  ? renderAgentSkills({
+                      agentId: selectedAgent.id,
+                      report: props.agentSkills.report,
+                      loading: props.agentSkills.loading,
+                      error: props.agentSkills.error,
+                      activeAgentId: props.agentSkills.agentId,
+                      configForm: props.config.form,
+                      configLoading: props.config.loading,
+                      configSaving: props.config.saving,
+                      configDirty: props.config.dirty,
+                      filter: props.agentSkills.filter,
+                      onFilterChange: props.onSkillsFilterChange,
+                      onRefresh: props.onSkillsRefresh,
+                      onToggle: props.onAgentSkillToggle,
+                      onClear: props.onAgentSkillsClear,
+                      onDisableAll: props.onAgentSkillsDisableAll,
+                      onConfigReload: props.onConfigReload,
+                      onConfigSave: props.onConfigSave,
+                    })
+                  : nothing
+              }
+              ${
+                props.activePanel === "channels"
+                  ? renderAgentChannels({
+                      context: buildAgentContext(
+                        selectedAgent,
+                        props.config.form,
+                        props.agentFiles.list,
+                        defaultId,
+                        props.agentIdentityById[selectedAgent.id] ?? null,
+                      ),
+                      configForm: props.config.form,
+                      snapshot: props.channels.snapshot,
+                      loading: props.channels.loading,
+                      error: props.channels.error,
+                      lastSuccess: props.channels.lastSuccess,
+                      onRefresh: props.onChannelsRefresh,
+                      onSelectPanel: props.onSelectPanel,
+                    })
+                  : nothing
+              }
+              ${
+                props.activePanel === "cron"
+                  ? renderAgentCron({
+                      context: buildAgentContext(
+                        selectedAgent,
+                        props.config.form,
+                        props.agentFiles.list,
+                        defaultId,
+                        props.agentIdentityById[selectedAgent.id] ?? null,
+                      ),
+                      agentId: selectedAgent.id,
+                      jobs: props.cron.jobs,
+                      status: props.cron.status,
+                      loading: props.cron.loading,
+                      error: props.cron.error,
+                      onRefresh: props.onCronRefresh,
+                      onRunNow: props.onCronRunNow,
+                      onSelectPanel: props.onSelectPanel,
+                    })
+                  : nothing
+              }
+            `
+        }
       </section>
     </div>
   `;
@@ -363,9 +389,11 @@ function renderAgentTabs(
             type="button"
             @click=${() => onSelect(tab.id)}
           >
-            ${tab.label}${counts[tab.id] != null
-              ? html`<span class="agent-tab-count">${counts[tab.id]}</span>`
-              : nothing}
+            ${tab.label}${
+              counts[tab.id] != null
+                ? html`<span class="agent-tab-count">${counts[tab.id]}</span>`
+                : nothing
+            }
           </button>
         `,
       )}

--- a/ui/src/ui/views/channels.config.ts
+++ b/ui/src/ui/views/channels.config.ts
@@ -86,11 +86,15 @@ export function renderChannelConfigForm(props: ChannelConfigFormProps) {
   const analysis = analyzeConfigSchema(props.schema);
   const normalized = analysis.schema;
   if (!normalized) {
-    return html` <div class="callout danger">Schema unavailable. Use Raw.</div> `;
+    return html`
+      <div class="callout danger">Schema unavailable. Use Raw.</div>
+    `;
   }
   const node = resolveSchemaNode(normalized, ["channels", props.channelId]);
   if (!node) {
-    return html` <div class="callout danger">Channel config schema unavailable.</div> `;
+    return html`
+      <div class="callout danger">Channel config schema unavailable.</div>
+    `;
   }
   const configValue = props.configValue ?? {};
   const value = resolveChannelValue(configValue, props.channelId);
@@ -116,16 +120,20 @@ export function renderChannelConfigSection(params: { channelId: string; props: C
   const disabled = props.configSaving || props.configSchemaLoading;
   return html`
     <div style="margin-top: 16px;">
-      ${props.configSchemaLoading
-        ? html` <div class="muted">Loading config schema…</div> `
-        : renderChannelConfigForm({
-            channelId,
-            configValue: props.configForm,
-            schema: props.configSchema,
-            uiHints: props.configUiHints,
-            disabled,
-            onPatch: props.onConfigPatch,
-          })}
+      ${
+        props.configSchemaLoading
+          ? html`
+              <div class="muted">Loading config schema…</div>
+            `
+          : renderChannelConfigForm({
+              channelId,
+              configValue: props.configForm,
+              schema: props.configSchema,
+              uiHints: props.configUiHints,
+              disabled,
+              onPatch: props.onConfigPatch,
+            })
+      }
       <div class="row" style="margin-top: 12px;">
         <button
           class="btn primary"

--- a/ui/src/ui/views/channels.nostr-profile-form.ts
+++ b/ui/src/ui/views/channels.nostr-profile-form.ts
@@ -108,16 +108,20 @@ export function renderNostrProfileForm(params: {
             }}
             ?disabled=${state.saving}
           ></textarea>
-          ${help
-            ? html`<div style="font-size: 12px; color: var(--text-muted); margin-top: 2px;">
+          ${
+            help
+              ? html`<div style="font-size: 12px; color: var(--text-muted); margin-top: 2px;">
                 ${help}
               </div>`
-            : nothing}
-          ${error
-            ? html`<div style="font-size: 12px; color: var(--danger-color); margin-top: 2px;">
+              : nothing
+          }
+          ${
+            error
+              ? html`<div style="font-size: 12px; color: var(--danger-color); margin-top: 2px;">
                 ${error}
               </div>`
-            : nothing}
+              : nothing
+          }
         </div>
       `;
     }
@@ -140,16 +144,20 @@ export function renderNostrProfileForm(params: {
           }}
           ?disabled=${state.saving}
         />
-        ${help
-          ? html`<div style="font-size: 12px; color: var(--text-muted); margin-top: 2px;">
+        ${
+          help
+            ? html`<div style="font-size: 12px; color: var(--text-muted); margin-top: 2px;">
               ${help}
             </div>`
-          : nothing}
-        ${error
-          ? html`<div style="font-size: 12px; color: var(--danger-color); margin-top: 2px;">
+            : nothing
+        }
+        ${
+          error
+            ? html`<div style="font-size: 12px; color: var(--danger-color); margin-top: 2px;">
               ${error}
             </div>`
-          : nothing}
+            : nothing
+        }
       </div>
     `;
   };
@@ -191,12 +199,16 @@ export function renderNostrProfileForm(params: {
         <div style="font-size: 12px; color: var(--text-muted);">Account: ${accountId}</div>
       </div>
 
-      ${state.error
-        ? html`<div class="callout danger" style="margin-bottom: 12px;">${state.error}</div>`
-        : nothing}
-      ${state.success
-        ? html`<div class="callout success" style="margin-bottom: 12px;">${state.success}</div>`
-        : nothing}
+      ${
+        state.error
+          ? html`<div class="callout danger" style="margin-bottom: 12px;">${state.error}</div>`
+          : nothing
+      }
+      ${
+        state.success
+          ? html`<div class="callout success" style="margin-bottom: 12px;">${state.success}</div>`
+          : nothing
+      }
       ${renderPicturePreview()}
       ${renderField("name", "Username", {
         placeholder: "satoshi",
@@ -219,8 +231,9 @@ export function renderNostrProfileForm(params: {
         placeholder: "https://example.com/avatar.jpg",
         help: "HTTPS URL to your profile picture",
       })}
-      ${state.showAdvanced
-        ? html`
+      ${
+        state.showAdvanced
+          ? html`
             <div
               style="border-top: 1px solid var(--border-color); padding-top: 12px; margin-top: 12px;"
             >
@@ -248,7 +261,8 @@ export function renderNostrProfileForm(params: {
               })}
             </div>
           `
-        : nothing}
+          : nothing
+      }
 
       <div style="display: flex; gap: 8px; margin-top: 16px; flex-wrap: wrap;">
         <button
@@ -274,13 +288,15 @@ export function renderNostrProfileForm(params: {
         <button class="btn" @click=${callbacks.onCancel} ?disabled=${state.saving}>Cancel</button>
       </div>
 
-      ${isDirty
-        ? html`
-            <div style="font-size: 12px; color: var(--warning-color); margin-top: 8px">
-              You have unsaved changes
-            </div>
-          `
-        : nothing}
+      ${
+        isDirty
+          ? html`
+              <div style="font-size: 12px; color: var(--warning-color); margin-top: 8px">
+                You have unsaved changes
+              </div>
+            `
+          : nothing
+      }
     </div>
   `;
 }

--- a/ui/src/ui/views/channels.nostr.ts
+++ b/ui/src/ui/views/channels.nostr.ts
@@ -80,14 +80,16 @@ export function renderNostrCard(params: {
           <div>
             <span class="label">Last inbound</span>
             <span
-              >${account.lastInboundAt
-                ? formatRelativeTimestamp(account.lastInboundAt)
-                : "n/a"}</span
+              >${
+                account.lastInboundAt ? formatRelativeTimestamp(account.lastInboundAt) : "n/a"
+              }</span
             >
           </div>
-          ${account.lastError
-            ? html` <div class="account-card-error">${account.lastError}</div> `
-            : nothing}
+          ${
+            account.lastError
+              ? html` <div class="account-card-error">${account.lastError}</div> `
+              : nothing
+          }
         </div>
       </div>
     `;
@@ -128,8 +130,9 @@ export function renderNostrCard(params: {
           style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px;"
         >
           <div style="font-weight: 500;">Profile</div>
-          ${summaryConfigured
-            ? html`
+          ${
+            summaryConfigured
+              ? html`
                 <button
                   class="btn btn--sm"
                   @click=${onEditProfile}
@@ -138,13 +141,16 @@ export function renderNostrCard(params: {
                   Edit Profile
                 </button>
               `
-            : nothing}
+              : nothing
+          }
         </div>
-        ${hasAnyProfileData
-          ? html`
+        ${
+          hasAnyProfileData
+            ? html`
               <div class="status-list">
-                ${picture
-                  ? html`
+                ${
+                  picture
+                    ? html`
                       <div style="margin-bottom: 8px;">
                         <img
                           src=${picture}
@@ -156,33 +162,43 @@ export function renderNostrCard(params: {
                         />
                       </div>
                     `
-                  : nothing}
-                ${name
-                  ? html`<div><span class="label">Name</span><span>${name}</span></div>`
-                  : nothing}
-                ${displayName
-                  ? html`<div>
+                    : nothing
+                }
+                ${
+                  name
+                    ? html`<div><span class="label">Name</span><span>${name}</span></div>`
+                    : nothing
+                }
+                ${
+                  displayName
+                    ? html`<div>
                       <span class="label">Display Name</span><span>${displayName}</span>
                     </div>`
-                  : nothing}
-                ${about
-                  ? html`<div>
+                    : nothing
+                }
+                ${
+                  about
+                    ? html`<div>
                       <span class="label">About</span
                       ><span style="max-width: 300px; overflow: hidden; text-overflow: ellipsis;"
                         >${about}</span
                       >
                     </div>`
-                  : nothing}
-                ${nip05
-                  ? html`<div><span class="label">NIP-05</span><span>${nip05}</span></div>`
-                  : nothing}
+                    : nothing
+                }
+                ${
+                  nip05
+                    ? html`<div><span class="label">NIP-05</span><span>${nip05}</span></div>`
+                    : nothing
+                }
               </div>
             `
-          : html`
-              <div style="color: var(--text-muted); font-size: 13px">
-                No profile set. Click "Edit Profile" to add your name, bio, and avatar.
-              </div>
-            `}
+            : html`
+                <div style="color: var(--text-muted); font-size: 13px">
+                  No profile set. Click "Edit Profile" to add your name, bio, and avatar.
+                </div>
+              `
+        }
       </div>
     `;
   };
@@ -192,13 +208,14 @@ export function renderNostrCard(params: {
       <div class="card-title">Nostr</div>
       <div class="card-sub">Decentralized DMs via Nostr relays (NIP-04).</div>
       ${accountCountLabel}
-      ${hasMultipleAccounts
-        ? html`
+      ${
+        hasMultipleAccounts
+          ? html`
             <div class="account-card-list">
               ${nostrAccounts.map((account) => renderAccountCard(account))}
             </div>
           `
-        : html`
+          : html`
             <div class="status-list" style="margin-top: 16px;">
               <div>
                 <span class="label">Configured</span>
@@ -221,10 +238,13 @@ export function renderNostrCard(params: {
                 >
               </div>
             </div>
-          `}
-      ${summaryLastError
-        ? html`<div class="callout danger" style="margin-top: 12px;">${summaryLastError}</div>`
-        : nothing}
+          `
+      }
+      ${
+        summaryLastError
+          ? html`<div class="callout danger" style="margin-top: 12px;">${summaryLastError}</div>`
+          : nothing
+      }
       ${renderProfileSection()} ${renderChannelConfigSection({ channelId: "nostr", props })}
 
       <div class="row" style="margin-top: 12px;">

--- a/ui/src/ui/views/channels.shared.ts
+++ b/ui/src/ui/views/channels.shared.ts
@@ -120,9 +120,11 @@ export function renderSingleAccountChannelCard(params: {
         )}
       </div>
 
-      ${params.lastError
-        ? html`<div class="callout danger" style="margin-top: 12px;">${params.lastError}</div>`
-        : nothing}
+      ${
+        params.lastError
+          ? html`<div class="callout danger" style="margin-top: 12px;">${params.lastError}</div>`
+          : nothing
+      }
       ${params.secondaryCallout ?? nothing} ${params.extraContent ?? nothing}
       ${params.configSection} ${params.footer ?? nothing}
     </div>

--- a/ui/src/ui/views/channels.telegram.ts
+++ b/ui/src/ui/views/channels.telegram.ts
@@ -41,14 +41,16 @@ export function renderTelegramCard(params: {
           <div>
             <span class="label">Last inbound</span>
             <span
-              >${account.lastInboundAt
-                ? formatRelativeTimestamp(account.lastInboundAt)
-                : "n/a"}</span
+              >${
+                account.lastInboundAt ? formatRelativeTimestamp(account.lastInboundAt) : "n/a"
+              }</span
             >
           </div>
-          ${account.lastError
-            ? html` <div class="account-card-error">${account.lastError}</div> `
-            : nothing}
+          ${
+            account.lastError
+              ? html` <div class="account-card-error">${account.lastError}</div> `
+              : nothing
+          }
         </div>
       </div>
     `;
@@ -65,15 +67,19 @@ export function renderTelegramCard(params: {
           ${telegramAccounts.map((account) => renderAccountCard(account))}
         </div>
 
-        ${telegram?.lastError
-          ? html`<div class="callout danger" style="margin-top: 12px;">${telegram.lastError}</div>`
-          : nothing}
-        ${telegram?.probe
-          ? html`<div class="callout" style="margin-top: 12px;">
+        ${
+          telegram?.lastError
+            ? html`<div class="callout danger" style="margin-top: 12px;">${telegram.lastError}</div>`
+            : nothing
+        }
+        ${
+          telegram?.probe
+            ? html`<div class="callout" style="margin-top: 12px;">
               Probe ${telegram.probe.ok ? "ok" : "failed"} · ${telegram.probe.status ?? ""}
               ${telegram.probe.error ?? ""}
             </div>`
-          : nothing}
+            : nothing
+        }
         ${renderChannelConfigSection({ channelId: "telegram", props })}
 
         <div class="row" style="margin-top: 12px;">

--- a/ui/src/ui/views/channels.ts
+++ b/ui/src/ui/views/channels.ts
@@ -82,9 +82,11 @@ export function renderChannels(props: ChannelsProps) {
           ${props.lastSuccessAt ? formatRelativeTimestamp(props.lastSuccessAt) : "n/a"}
         </div>
       </div>
-      ${props.lastError
-        ? html`<div class="callout danger" style="margin-top: 12px;">${props.lastError}</div>`
-        : nothing}
+      ${
+        props.lastError
+          ? html`<div class="callout danger" style="margin-top: 12px;">${props.lastError}</div>`
+          : nothing
+      }
       <pre class="code-block" style="margin-top: 12px;">
 ${props.snapshot ? JSON.stringify(props.snapshot, null, 2) : "No snapshot yet."}
       </pre
@@ -198,13 +200,14 @@ function renderGenericChannelCard(
       <div class="card-title">${label}</div>
       <div class="card-sub">Channel status and configuration.</div>
       ${accountCountLabel}
-      ${accounts.length > 0
-        ? html`
+      ${
+        accounts.length > 0
+          ? html`
             <div class="account-card-list">
               ${accounts.map((account) => renderGenericAccount(account))}
             </div>
           `
-        : html`
+          : html`
             <div class="status-list" style="margin-top: 16px;">
               <div>
                 <span class="label">Configured</span>
@@ -219,10 +222,13 @@ function renderGenericChannelCard(
                 <span>${formatNullableBoolean(displayState.connected)}</span>
               </div>
             </div>
-          `}
-      ${lastError
-        ? html`<div class="callout danger" style="margin-top: 12px;">${lastError}</div>`
-        : nothing}
+          `
+      }
+      ${
+        lastError
+          ? html`<div class="callout danger" style="margin-top: 12px;">${lastError}</div>`
+          : nothing
+      }
       ${renderChannelConfigSection({ channelId: key, props })}
     </div>
   `;
@@ -305,9 +311,11 @@ function renderGenericAccount(account: ChannelAccountSnapshot) {
             >${account.lastInboundAt ? formatRelativeTimestamp(account.lastInboundAt) : "n/a"}</span
           >
         </div>
-        ${account.lastError
-          ? html` <div class="account-card-error">${account.lastError}</div> `
-          : nothing}
+        ${
+          account.lastError
+            ? html` <div class="account-card-error">${account.lastError}</div> `
+            : nothing
+        }
       </div>
     </div>
   `;

--- a/ui/src/ui/views/channels.whatsapp.ts
+++ b/ui/src/ui/views/channels.whatsapp.ts
@@ -43,14 +43,18 @@ export function renderWhatsAppCard(params: {
     ],
     lastError: whatsapp?.lastError,
     extraContent: html`
-      ${props.whatsappMessage
-        ? html`<div class="callout" style="margin-top: 12px;">${props.whatsappMessage}</div>`
-        : nothing}
-      ${props.whatsappQrDataUrl
-        ? html`<div class="qr-wrap">
+      ${
+        props.whatsappMessage
+          ? html`<div class="callout" style="margin-top: 12px;">${props.whatsappMessage}</div>`
+          : nothing
+      }
+      ${
+        props.whatsappQrDataUrl
+          ? html`<div class="qr-wrap">
             <img src=${props.whatsappQrDataUrl} alt="WhatsApp QR" />
           </div>`
-        : nothing}
+          : nothing
+      }
     `,
     configSection: renderChannelConfigSection({ channelId: "whatsapp", props }),
     footer: html`<div class="row" style="margin-top: 14px; flex-wrap: wrap;">

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -642,15 +642,17 @@ function renderWelcomeState(props: ChatProps): TemplateResult {
   return html`
     <div class="agent-chat__welcome" style="--agent-color: var(--accent)">
       <div class="agent-chat__welcome-glow"></div>
-      ${avatar
-        ? html`<img
+      ${
+        avatar
+          ? html`<img
             src=${avatar}
             alt=${name}
             style="width:56px; height:56px; border-radius:50%; object-fit:cover;"
           />`
-        : html`<div class="agent-chat__avatar agent-chat__avatar--logo">
+          : html`<div class="agent-chat__avatar agent-chat__avatar--logo">
             <img src=${logoUrl} alt="OpenClaw" />
-          </div>`}
+          </div>`
+      }
       <h2>${name}</h2>
       <div class="agent-chat__badges">
         <span class="agent-chat__badge"><img src=${logoUrl} alt="" /> Ready to chat</span>
@@ -741,8 +743,9 @@ function renderPinnedSection(
           >${icons.chevronDown}</span
         >
       </button>
-      ${vs.pinnedExpanded
-        ? html`
+      ${
+        vs.pinnedExpanded
+          ? html`
             <div class="agent-chat__pinned-list">
               ${entries.map(
                 ({ index, text, role }) => html`
@@ -768,7 +771,8 @@ function renderPinnedSection(
               )}
             </div>
           `
-        : nothing}
+          : nothing
+      }
     </div>
   `;
 }
@@ -801,9 +805,11 @@ function renderSlashMenu(
                   requestUpdate();
                 }}
               >
-                ${vs.slashMenuCommand?.icon
-                  ? html`<span class="slash-menu-icon">${icons[vs.slashMenuCommand.icon]}</span>`
-                  : nothing}
+                ${
+                  vs.slashMenuCommand?.icon
+                    ? html`<span class="slash-menu-icon">${icons[vs.slashMenuCommand.icon]}</span>`
+                    : nothing
+                }
                 <span class="slash-menu-name">${arg}</span>
                 <span class="slash-menu-desc">/${vs.slashMenuCommand?.name} ${arg}</span>
               </div>
@@ -845,9 +851,9 @@ function renderSlashMenu(
         ${entries.map(
           ({ cmd, globalIdx }) => html`
             <div
-              class="slash-menu-item ${globalIdx === vs.slashMenuIndex
-                ? "slash-menu-item--active"
-                : ""}"
+              class="slash-menu-item ${
+                globalIdx === vs.slashMenuIndex ? "slash-menu-item--active" : ""
+              }"
               role="option"
               aria-selected=${globalIdx === vs.slashMenuIndex}
               @click=${() => selectSlashCommand(cmd, props, requestUpdate)}
@@ -860,11 +866,15 @@ function renderSlashMenu(
               <span class="slash-menu-name">/${cmd.name}</span>
               ${cmd.args ? html`<span class="slash-menu-args">${cmd.args}</span>` : nothing}
               <span class="slash-menu-desc">${cmd.description}</span>
-              ${cmd.argOptions?.length
-                ? html`<span class="slash-menu-badge">${cmd.argOptions.length} options</span>`
-                : cmd.executeLocal && !cmd.args
-                  ? html` <span class="slash-menu-badge">instant</span> `
-                  : nothing}
+              ${
+                cmd.argOptions?.length
+                  ? html`<span class="slash-menu-badge">${cmd.argOptions.length} options</span>`
+                  : cmd.executeLocal && !cmd.args
+                    ? html`
+                        <span class="slash-menu-badge">instant</span>
+                      `
+                    : nothing
+              }
             </div>
           `,
         )}
@@ -944,49 +954,46 @@ export function renderChat(props: ChatProps) {
       @click=${handleCodeBlockCopy}
     >
       <div class="chat-thread-inner">
-        ${props.loading
-          ? html`
-              <div class="chat-loading-skeleton" aria-label="Loading chat">
-                <div class="chat-line assistant">
-                  <div class="chat-msg">
-                    <div class="chat-bubble">
-                      <div
-                        class="skeleton skeleton-line skeleton-line--long"
-                        style="margin-bottom: 8px"
-                      ></div>
-                      <div
-                        class="skeleton skeleton-line skeleton-line--medium"
-                        style="margin-bottom: 8px"
-                      ></div>
-                      <div class="skeleton skeleton-line skeleton-line--short"></div>
+        ${
+          props.loading
+            ? html`
+                <div class="chat-loading-skeleton" aria-label="Loading chat">
+                  <div class="chat-line assistant">
+                    <div class="chat-msg">
+                      <div class="chat-bubble">
+                        <div class="skeleton skeleton-line skeleton-line--long" style="margin-bottom: 8px"></div>
+                        <div class="skeleton skeleton-line skeleton-line--medium" style="margin-bottom: 8px"></div>
+                        <div class="skeleton skeleton-line skeleton-line--short"></div>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="chat-line user" style="margin-top: 12px">
+                    <div class="chat-msg">
+                      <div class="chat-bubble">
+                        <div class="skeleton skeleton-line skeleton-line--medium"></div>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="chat-line assistant" style="margin-top: 12px">
+                    <div class="chat-msg">
+                      <div class="chat-bubble">
+                        <div class="skeleton skeleton-line skeleton-line--long" style="margin-bottom: 8px"></div>
+                        <div class="skeleton skeleton-line skeleton-line--short"></div>
+                      </div>
                     </div>
                   </div>
                 </div>
-                <div class="chat-line user" style="margin-top: 12px">
-                  <div class="chat-msg">
-                    <div class="chat-bubble">
-                      <div class="skeleton skeleton-line skeleton-line--medium"></div>
-                    </div>
-                  </div>
-                </div>
-                <div class="chat-line assistant" style="margin-top: 12px">
-                  <div class="chat-msg">
-                    <div class="chat-bubble">
-                      <div
-                        class="skeleton skeleton-line skeleton-line--long"
-                        style="margin-bottom: 8px"
-                      ></div>
-                      <div class="skeleton skeleton-line skeleton-line--short"></div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            `
-          : nothing}
+              `
+            : nothing
+        }
         ${isEmpty && !vs.searchOpen ? renderWelcomeState(props) : nothing}
-        ${isEmpty && vs.searchOpen
-          ? html` <div class="agent-chat__empty">No matching messages</div> `
-          : nothing}
+        ${
+          isEmpty && vs.searchOpen
+            ? html`
+                <div class="agent-chat__empty">No matching messages</div>
+              `
+            : nothing
+        }
         ${repeat(
           chatItems,
           (item) => item.key,
@@ -1164,8 +1171,9 @@ export function renderChat(props: ChatProps) {
     >
       ${props.disabledReason ? html`<div class="callout">${props.disabledReason}</div>` : nothing}
       ${props.error ? html`<div class="callout danger">${props.error}</div>` : nothing}
-      ${props.focusMode
-        ? html`
+      ${
+        props.focusMode
+          ? html`
             <button
               class="chat-focus-exit"
               type="button"
@@ -1176,7 +1184,8 @@ export function renderChat(props: ChatProps) {
               ${icons.x}
             </button>
           `
-        : nothing}
+          : nothing
+      }
       ${renderSearchBar(requestUpdate)} ${renderPinnedSection(props, pinned, requestUpdate)}
 
       <div class="chat-split-container ${sidebarOpen ? "chat-split-container--open" : ""}">
@@ -1187,8 +1196,9 @@ export function renderChat(props: ChatProps) {
           ${thread}
         </div>
 
-        ${sidebarOpen
-          ? html`
+        ${
+          sidebarOpen
+            ? html`
               <resizable-divider
                 .splitRatio=${splitRatio}
                 @resize=${(e: CustomEvent) => props.onSplitRatioChange?.(e.detail.splitRatio)}
@@ -1207,11 +1217,13 @@ export function renderChat(props: ChatProps) {
                 })}
               </div>
             `
-          : nothing}
+            : nothing
+        }
       </div>
 
-      ${props.queue.length
-        ? html`
+      ${
+        props.queue.length
+          ? html`
             <div class="chat-queue" role="status" aria-live="polite">
               <div class="chat-queue__title">Queued (${props.queue.length})</div>
               <div class="chat-queue__list">
@@ -1219,8 +1231,10 @@ export function renderChat(props: ChatProps) {
                   (item) => html`
                     <div class="chat-queue__item">
                       <div class="chat-queue__text">
-                        ${item.text ||
-                        (item.attachments?.length ? `Image (${item.attachments.length})` : "")}
+                        ${
+                          item.text ||
+                          (item.attachments?.length ? `Image (${item.attachments.length})` : "")
+                        }
                       </div>
                       <button
                         class="btn chat-queue__remove"
@@ -1236,17 +1250,20 @@ export function renderChat(props: ChatProps) {
               </div>
             </div>
           `
-        : nothing}
+          : nothing
+      }
       ${renderFallbackIndicator(props.fallbackStatus)}
       ${renderCompactionIndicator(props.compactionStatus)}
       ${renderContextNotice(activeSession, props.sessions?.defaults?.contextTokens ?? null)}
-      ${props.showNewMessages
-        ? html`
+      ${
+        props.showNewMessages
+          ? html`
             <button class="chat-new-messages" type="button" @click=${props.onScrollToBottom}>
               ${icons.arrowDown} New messages
             </button>
           `
-        : nothing}
+          : nothing
+      }
 
       <!-- Input bar -->
       <div class="agent-chat__input">
@@ -1260,9 +1277,11 @@ export function renderChat(props: ChatProps) {
           @change=${(e: Event) => handleFileSelect(e, props)}
         />
 
-        ${vs.sttRecording && vs.sttInterimText
-          ? html`<div class="agent-chat__stt-interim">${vs.sttInterimText}</div>`
-          : nothing}
+        ${
+          vs.sttRecording && vs.sttInterimText
+            ? html`<div class="agent-chat__stt-interim">${vs.sttInterimText}</div>`
+            : nothing
+        }
 
         <textarea
           ${ref((el) => el && adjustTextareaHeight(el as HTMLTextAreaElement))}
@@ -1290,12 +1309,13 @@ export function renderChat(props: ChatProps) {
               ${icons.paperclip}
             </button>
 
-            ${isSttSupported()
-              ? html`
+            ${
+              isSttSupported()
+                ? html`
                   <button
-                    class="agent-chat__input-btn ${vs.sttRecording
-                      ? "agent-chat__input-btn--recording"
-                      : ""}"
+                    class="agent-chat__input-btn ${
+                      vs.sttRecording ? "agent-chat__input-btn--recording" : ""
+                    }"
                     @click=${() => {
                       if (vs.sttRecording) {
                         stopStt();
@@ -1342,15 +1362,17 @@ export function renderChat(props: ChatProps) {
                     ${vs.sttRecording ? icons.micOff : icons.mic}
                   </button>
                 `
-              : nothing}
+                : nothing
+            }
             ${tokens ? html`<span class="agent-chat__token-count">${tokens}</span>` : nothing}
           </div>
 
           <div class="agent-chat__toolbar-right">
             ${nothing /* search hidden for now */}
-            ${canAbort
-              ? nothing
-              : html`
+            ${
+              canAbort
+                ? nothing
+                : html`
                   <button
                     class="btn btn--ghost"
                     @click=${props.onNewSession}
@@ -1359,7 +1381,8 @@ export function renderChat(props: ChatProps) {
                   >
                     ${icons.plus}
                   </button>
-                `}
+                `
+            }
             <button
               class="btn btn--ghost"
               @click=${() => exportMarkdown(props)}
@@ -1370,8 +1393,9 @@ export function renderChat(props: ChatProps) {
               ${icons.download}
             </button>
 
-            ${canAbort && (isBusy || props.sending)
-              ? html`
+            ${
+              canAbort && (isBusy || props.sending)
+                ? html`
                   <button
                     class="chat-send-btn chat-send-btn--stop"
                     @click=${props.onAbort}
@@ -1381,7 +1405,7 @@ export function renderChat(props: ChatProps) {
                     ${icons.stop}
                   </button>
                 `
-              : html`
+                : html`
                   <button
                     class="chat-send-btn"
                     @click=${() => {
@@ -1396,7 +1420,8 @@ export function renderChat(props: ChatProps) {
                   >
                     ${icons.send}
                   </button>
-                `}
+                `
+            }
           </div>
         </div>
       </div>

--- a/ui/src/ui/views/command-palette.ts
+++ b/ui/src/ui/views/command-palette.ts
@@ -220,15 +220,16 @@ export function renderCommandPalette(props: CommandPaletteProps) {
           }}
         />
         <div class="cmd-palette__results">
-          ${grouped.length === 0
-            ? html`<div class="cmd-palette__empty">
+          ${
+            grouped.length === 0
+              ? html`<div class="cmd-palette__empty">
                 <span class="nav-item__icon" style="opacity:0.3;width:20px;height:20px"
                   >${icons.search}</span
                 >
                 <span>${t("overview.palette.noResults")}</span>
               </div>`
-            : grouped.map(
-                ([category, groupedItems]) => html`
+              : grouped.map(
+                  ([category, groupedItems]) => html`
                   <div class="cmd-palette__group-label">
                     ${CATEGORY_LABELS[category] ?? category}
                   </div>
@@ -246,16 +247,19 @@ export function renderCommandPalette(props: CommandPaletteProps) {
                       >
                         <span class="nav-item__icon">${icons[item.icon]}</span>
                         <span>${item.label}</span>
-                        ${item.description
-                          ? html`<span class="cmd-palette__item-desc muted"
+                        ${
+                          item.description
+                            ? html`<span class="cmd-palette__item-desc muted"
                               >${item.description}</span
                             >`
-                          : nothing}
+                            : nothing
+                        }
                       </div>
                     `;
                   })}
                 `,
-              )}
+                )
+          }
         </div>
         <div class="cmd-palette__footer">
           <span><kbd>↑↓</kbd> navigate</span>

--- a/ui/src/ui/views/config-form.node.ts
+++ b/ui/src/ui/views/config-form.node.ts
@@ -79,9 +79,7 @@ const icons = {
       stroke-linejoin="round"
     >
       <polyline points="3 6 5 6 21 6"></polyline>
-      <path
-        d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"
-      ></path>
+      <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
     </svg>
   `,
   edit: html`
@@ -168,16 +166,20 @@ function renderSensitiveToggleButton(params: {
       type="button"
       class="btn btn--icon ${state.isRevealed ? "active" : ""}"
       style="width:28px;height:28px;padding:0;"
-      title=${state.canReveal
-        ? state.isRevealed
-          ? "Hide value"
-          : "Reveal value"
-        : "Disable stream mode to reveal value"}
-      aria-label=${state.canReveal
-        ? state.isRevealed
-          ? "Hide value"
-          : "Reveal value"
-        : "Disable stream mode to reveal value"}
+      title=${
+        state.canReveal
+          ? state.isRevealed
+            ? "Hide value"
+            : "Reveal value"
+          : "Disable stream mode to reveal value"
+      }
+      aria-label=${
+        state.canReveal
+          ? state.isRevealed
+            ? "Hide value"
+            : "Reveal value"
+          : "Disable stream mode to reveal value"
+      }
       aria-pressed=${state.isRevealed}
       ?disabled=${params.disabled || !state.canReveal}
       @click=${() => params.onToggleSensitivePath?.(params.path)}
@@ -553,10 +555,9 @@ export function renderNode(params: {
               (opt) => html`
                 <button
                   type="button"
-                  class="cfg-segmented__btn ${opt === resolvedValue ||
-                  String(opt) === String(resolvedValue)
-                    ? "active"
-                    : ""}"
+                  class="cfg-segmented__btn ${
+                    opt === resolvedValue || String(opt) === String(resolvedValue) ? "active" : ""
+                  }"
                   ?disabled=${disabled}
                   @click=${() => onPatch(path, opt)}
                 >
@@ -720,16 +721,19 @@ function renderTextInput(params: {
             onPatch(path, raw.trim());
           }}
         />
-        ${isStructuredSecretRef
-          ? nothing
-          : renderSensitiveToggleButton({
-              path,
-              state: sensitiveState,
-              disabled,
-              onToggleSensitivePath: params.onToggleSensitivePath,
-            })}
-        ${schema.default !== undefined
-          ? html`
+        ${
+          isStructuredSecretRef
+            ? nothing
+            : renderSensitiveToggleButton({
+                path,
+                state: sensitiveState,
+                disabled,
+                onToggleSensitivePath: params.onToggleSensitivePath,
+              })
+        }
+        ${
+          schema.default !== undefined
+            ? html`
               <button
                 type="button"
                 class="cfg-input__reset"
@@ -740,7 +744,8 @@ function renderTextInput(params: {
                 ↺
               </button>
             `
-          : nothing}
+            : nothing
+        }
       </div>
     </div>
   `;
@@ -985,23 +990,25 @@ function renderObject(params: {
         onPatch,
       }),
     )}
-    ${allowExtra
-      ? renderMapField({
-          schema: additional,
-          value: obj,
-          path,
-          hints,
-          rawAvailable,
-          unsupported,
-          disabled,
-          reservedKeys: reserved,
-          searchCriteria: childSearchCriteria,
-          revealSensitive,
-          isSensitivePathRevealed,
-          onToggleSensitivePath,
-          onPatch,
-        })
-      : nothing}
+    ${
+      allowExtra
+        ? renderMapField({
+            schema: additional,
+            value: obj,
+            path,
+            hints,
+            rawAvailable,
+            unsupported,
+            disabled,
+            reservedKeys: reserved,
+            searchCriteria: childSearchCriteria,
+            revealSensitive,
+            isSensitivePathRevealed,
+            onToggleSensitivePath,
+            onPatch,
+          })
+        : nothing
+    }
   `;
 
   // For top-level, don't wrap in collapsible
@@ -1100,9 +1107,12 @@ function renderArray(params: {
         </button>
       </div>
       ${help ? html`<div class="cfg-array__help">${help}</div>` : nothing}
-      ${arr.length === 0
-        ? html` <div class="cfg-array__empty">No items yet. Click "Add" to create one.</div> `
-        : html`
+      ${
+        arr.length === 0
+          ? html`
+              <div class="cfg-array__empty">No items yet. Click "Add" to create one.</div>
+            `
+          : html`
             <div class="cfg-array__items">
               ${arr.map(
                 (item, idx) => html`
@@ -1144,7 +1154,8 @@ function renderArray(params: {
                 `,
               )}
             </div>
-          `}
+          `
+      }
     </div>
   `;
 }
@@ -1219,9 +1230,12 @@ function renderMapField(params: {
         </button>
       </div>
 
-      ${visibleEntries.length === 0
-        ? html` <div class="cfg-map__empty">No custom entries.</div> `
-        : html`
+      ${
+        visibleEntries.length === 0
+          ? html`
+              <div class="cfg-map__empty">No custom entries.</div>
+            `
+          : html`
             <div class="cfg-map__items">
               ${visibleEntries.map(([key, entryValue]) => {
                 const valuePath = [...path, key];
@@ -1273,16 +1287,17 @@ function renderMapField(params: {
                       </button>
                     </div>
                     <div class="cfg-map__item-value">
-                      ${anySchema
-                        ? html`
+                      ${
+                        anySchema
+                          ? html`
                             <div class="cfg-input-wrap">
                               <textarea
-                                class="cfg-textarea cfg-textarea--sm${sensitiveState.isRedacted
-                                  ? " cfg-textarea--redacted"
-                                  : ""}"
-                                placeholder=${sensitiveState.isRedacted
-                                  ? REDACTED_PLACEHOLDER
-                                  : "JSON value"}
+                                class="cfg-textarea cfg-textarea--sm${
+                                  sensitiveState.isRedacted ? " cfg-textarea--redacted" : ""
+                                }"
+                                placeholder=${
+                                  sensitiveState.isRedacted ? REDACTED_PLACEHOLDER : "JSON value"
+                                }
                                 rows="2"
                                 .value=${sensitiveState.isRedacted ? "" : fallback}
                                 ?disabled=${disabled}
@@ -1317,27 +1332,29 @@ function renderMapField(params: {
                               })}
                             </div>
                           `
-                        : renderNode({
-                            schema,
-                            value: entryValue,
-                            path: valuePath,
-                            hints,
-                            rawAvailable,
-                            unsupported,
-                            disabled,
-                            searchCriteria,
-                            showLabel: false,
-                            revealSensitive,
-                            isSensitivePathRevealed,
-                            onToggleSensitivePath,
-                            onPatch,
-                          })}
+                          : renderNode({
+                              schema,
+                              value: entryValue,
+                              path: valuePath,
+                              hints,
+                              rawAvailable,
+                              unsupported,
+                              disabled,
+                              searchCriteria,
+                              showLabel: false,
+                              revealSensitive,
+                              isSensitivePathRevealed,
+                              onToggleSensitivePath,
+                              onPatch,
+                            })
+                      }
                     </div>
                   </div>
                 `;
               })}
             </div>
-          `}
+          `
+      }
     </div>
   `;
 }

--- a/ui/src/ui/views/config-form.render.ts
+++ b/ui/src/ui/views/config-form.render.ts
@@ -361,12 +361,16 @@ function matchesSearch(params: {
 
 export function renderConfigForm(props: ConfigFormProps) {
   if (!props.schema) {
-    return html` <div class="muted">Schema unavailable.</div> `;
+    return html`
+      <div class="muted">Schema unavailable.</div>
+    `;
   }
   const schema = props.schema;
   const value = props.value ?? {};
   if (schemaType(schema) !== "object" || !schema.properties) {
-    return html` <div class="callout danger">Unsupported schema. Use Raw.</div> `;
+    return html`
+      <div class="callout danger">Unsupported schema. Use Raw.</div>
+    `;
   }
   const unsupported = new Set(props.unsupportedPaths ?? []);
   const properties = schema.properties;
@@ -446,9 +450,11 @@ export function renderConfigForm(props: ConfigFormProps) {
         <span class="config-section-card__icon">${getSectionIcon(params.sectionKey)}</span>
         <div class="config-section-card__titles">
           <h3 class="config-section-card__title">${params.label}</h3>
-          ${params.description
-            ? html`<p class="config-section-card__desc">${params.description}</p>`
-            : nothing}
+          ${
+            params.description
+              ? html`<p class="config-section-card__desc">${params.description}</p>`
+              : nothing
+          }
         </div>
       </div>
       <div class="config-section-card__content">
@@ -473,43 +479,45 @@ export function renderConfigForm(props: ConfigFormProps) {
 
   return html`
     <div class="config-form config-form--modern">
-      ${subsectionContext
-        ? (() => {
-            const { sectionKey, subsectionKey, schema: node } = subsectionContext;
-            const hint = hintForPath([sectionKey, subsectionKey], props.uiHints);
-            const label = hint?.label ?? node.title ?? humanize(subsectionKey);
-            const description = hint?.help ?? node.description ?? "";
-            const sectionValue = value[sectionKey];
-            const scopedValue =
-              sectionValue && typeof sectionValue === "object"
-                ? (sectionValue as Record<string, unknown>)[subsectionKey]
-                : undefined;
-            return renderSectionCard({
-              id: `config-section-${sectionKey}-${subsectionKey}`,
-              sectionKey,
-              label,
-              description,
-              node,
-              nodeValue: scopedValue,
-              path: [sectionKey, subsectionKey],
-            });
-          })()
-        : filteredEntries.map(([key, node]) => {
-            const meta = SECTION_META[key] ?? {
-              label: key.charAt(0).toUpperCase() + key.slice(1),
-              description: node.description ?? "",
-            };
+      ${
+        subsectionContext
+          ? (() => {
+              const { sectionKey, subsectionKey, schema: node } = subsectionContext;
+              const hint = hintForPath([sectionKey, subsectionKey], props.uiHints);
+              const label = hint?.label ?? node.title ?? humanize(subsectionKey);
+              const description = hint?.help ?? node.description ?? "";
+              const sectionValue = value[sectionKey];
+              const scopedValue =
+                sectionValue && typeof sectionValue === "object"
+                  ? (sectionValue as Record<string, unknown>)[subsectionKey]
+                  : undefined;
+              return renderSectionCard({
+                id: `config-section-${sectionKey}-${subsectionKey}`,
+                sectionKey,
+                label,
+                description,
+                node,
+                nodeValue: scopedValue,
+                path: [sectionKey, subsectionKey],
+              });
+            })()
+          : filteredEntries.map(([key, node]) => {
+              const meta = SECTION_META[key] ?? {
+                label: key.charAt(0).toUpperCase() + key.slice(1),
+                description: node.description ?? "",
+              };
 
-            return renderSectionCard({
-              id: `config-section-${key}`,
-              sectionKey: key,
-              label: meta.label,
-              description: meta.description,
-              node,
-              nodeValue: value[key],
-              path: [key],
-            });
-          })}
+              return renderSectionCard({
+                id: `config-section-${key}`,
+                sectionKey: key,
+                label: meta.label,
+                description: meta.description,
+                node,
+                nodeValue: value[key],
+                path: [key],
+              });
+            })
+      }
     </div>
   `;
 }

--- a/ui/src/ui/views/config.ts
+++ b/ui/src/ui/views/config.ts
@@ -579,9 +579,9 @@ function renderAppearanceSection(props: ConfigProps) {
           ${THEME_OPTIONS.map(
             (opt) => html`
               <button
-                class="settings-theme-card ${opt.id === props.theme
-                  ? "settings-theme-card--active"
-                  : ""}"
+                class="settings-theme-card ${
+                  opt.id === props.theme ? "settings-theme-card--active" : ""
+                }"
                 title=${opt.description}
                 @click=${(e: Event) => {
                   if (opt.id !== props.theme) {
@@ -594,11 +594,13 @@ function renderAppearanceSection(props: ConfigProps) {
               >
                 <span class="settings-theme-card__icon" aria-hidden="true">${opt.icon}</span>
                 <span class="settings-theme-card__label">${opt.label}</span>
-                ${opt.id === props.theme
-                  ? html`<span class="settings-theme-card__check" aria-hidden="true"
+                ${
+                  opt.id === props.theme
+                    ? html`<span class="settings-theme-card__check" aria-hidden="true"
                       >${icons.check}</span
                     >`
-                  : nothing}
+                    : nothing
+                }
               </button>
             `,
           )}
@@ -645,14 +647,16 @@ function renderAppearanceSection(props: ConfigProps) {
               ${props.connected ? "Connected" : "Offline"}
             </span>
           </div>
-          ${props.assistantName
-            ? html`
+          ${
+            props.assistantName
+              ? html`
                 <div class="settings-info-row">
                   <span class="settings-info-row__label">Assistant</span>
                   <span class="settings-info-row__value">${props.assistantName}</span>
                 </div>
               `
-            : nothing}
+              : nothing
+          }
         </div>
       </div>
     </div>
@@ -788,8 +792,9 @@ export function renderConfig(props: ConfigProps) {
       <main class="config-main">
         <div class="config-actions">
           <div class="config-actions__left">
-            ${showModeToggle
-              ? html`
+            ${
+              showModeToggle
+                ? html`
                   <div class="config-mode-toggle">
                     <button
                       class="config-mode-toggle__btn ${formMode === "form" ? "active" : ""}"
@@ -802,36 +807,48 @@ export function renderConfig(props: ConfigProps) {
                     <button
                       class="config-mode-toggle__btn ${formMode === "raw" ? "active" : ""}"
                       ?disabled=${!rawAvailable}
-                      title=${rawAvailable
-                        ? "Edit raw JSON/JSON5 config"
-                        : "Raw mode unavailable for this snapshot"}
+                      title=${
+                        rawAvailable
+                          ? "Edit raw JSON/JSON5 config"
+                          : "Raw mode unavailable for this snapshot"
+                      }
                       @click=${() => props.onFormModeChange("raw")}
                     >
                       Raw
                     </button>
                   </div>
                 `
-              : nothing}
-            ${hasChanges
-              ? html`
+                : nothing
+            }
+            ${
+              hasChanges
+                ? html`
                   <span class="config-changes-badge"
-                    >${formMode === "raw"
-                      ? "Unsaved changes"
-                      : `${diff.length} unsaved change${diff.length !== 1 ? "s" : ""}`}</span
+                    >${
+                      formMode === "raw"
+                        ? "Unsaved changes"
+                        : `${diff.length} unsaved change${diff.length !== 1 ? "s" : ""}`
+                    }</span
                   >
                 `
-              : html` <span class="config-status muted">No changes</span> `}
+                : html`
+                    <span class="config-status muted">No changes</span>
+                  `
+            }
           </div>
           <div class="config-actions__right">
-            ${!rawAvailable
-              ? html`
-                  <span class="config-status muted"
-                    >Raw mode disabled (snapshot cannot safely round-trip raw text).</span
-                  >
-                `
-              : nothing}
-            ${props.onOpenFile
-              ? html`
+            ${
+              !rawAvailable
+                ? html`
+                    <span class="config-status muted"
+                      >Raw mode disabled (snapshot cannot safely round-trip raw text).</span
+                    >
+                  `
+                : nothing
+            }
+            ${
+              props.onOpenFile
+                ? html`
                   <button
                     class="btn btn--sm"
                     title=${props.configPath ? `Open ${props.configPath}` : "Open config file"}
@@ -840,7 +857,8 @@ export function renderConfig(props: ConfigProps) {
                     ${icons.fileText} Open
                   </button>
                 `
-              : nothing}
+                : nothing
+            }
             <button class="btn btn--sm" ?disabled=${props.loading} @click=${props.onReload}>
               ${props.loading ? "Loading…" : "Reload"}
             </button>
@@ -857,8 +875,9 @@ export function renderConfig(props: ConfigProps) {
         </div>
 
         <div class="config-top-tabs">
-          ${formMode === "form"
-            ? html`
+          ${
+            formMode === "form"
+              ? html`
                 <div class="config-search config-search--top">
                   <div class="config-search__input-row">
                     <svg
@@ -880,8 +899,9 @@ export function renderConfig(props: ConfigProps) {
                       @input=${(e: Event) =>
                         props.onSearchChange((e.target as HTMLInputElement).value)}
                     />
-                    ${props.searchQuery
-                      ? html`
+                    ${
+                      props.searchQuery
+                        ? html`
                           <button
                             class="config-search__clear"
                             aria-label="Clear search"
@@ -890,11 +910,13 @@ export function renderConfig(props: ConfigProps) {
                             ×
                           </button>
                         `
-                      : nothing}
+                        : nothing
+                    }
                   </div>
                 </div>
               `
-            : nothing}
+              : nothing
+          }
 
           <div class="config-top-tabs__scroller" role="tablist" aria-label="Settings sections">
             ${topTabs.map(
@@ -913,8 +935,9 @@ export function renderConfig(props: ConfigProps) {
           </div>
         </div>
 
-        ${validity === "invalid" && !cvs.validityDismissed
-          ? html`
+        ${
+          validity === "invalid" && !cvs.validityDismissed
+            ? html`
               <div class="config-validity-warning">
                 <svg
                   class="config-validity-warning__icon"
@@ -947,11 +970,13 @@ export function renderConfig(props: ConfigProps) {
                 </button>
               </div>
             `
-          : nothing}
+            : nothing
+        }
 
         <!-- Diff panel (form mode only - raw mode doesn't have granular diff) -->
-        ${hasChanges && formMode === "form"
-          ? html`
+        ${
+          hasChanges && formMode === "form"
+            ? html`
               <details class="config-diff">
                 <summary class="config-diff__summary">
                   <span>View ${diff.length} pending change${diff.length !== 1 ? "s" : ""}</span>
@@ -985,27 +1010,32 @@ export function renderConfig(props: ConfigProps) {
                 </div>
               </details>
             `
-          : nothing}
-        ${activeSectionMeta && formMode === "form"
-          ? html`
+            : nothing
+        }
+        ${
+          activeSectionMeta && formMode === "form"
+            ? html`
               <div class="config-section-hero">
                 <div class="config-section-hero__icon">
                   ${getSectionIcon(props.activeSection ?? "")}
                 </div>
                 <div class="config-section-hero__text">
                   <div class="config-section-hero__title">${activeSectionMeta.label}</div>
-                  ${activeSectionMeta.description
-                    ? html`<div class="config-section-hero__desc">
+                  ${
+                    activeSectionMeta.description
+                      ? html`<div class="config-section-hero__desc">
                         ${activeSectionMeta.description}
                       </div>`
-                    : nothing}
+                      : nothing
+                  }
                 </div>
-                ${props.activeSection === "env"
-                  ? html`
+                ${
+                  props.activeSection === "env"
+                    ? html`
                       <button
-                        class="config-env-peek-btn ${envSensitiveVisible
-                          ? "config-env-peek-btn--active"
-                          : ""}"
+                        class="config-env-peek-btn ${
+                          envSensitiveVisible ? "config-env-peek-btn--active" : ""
+                        }"
                         title=${envSensitiveVisible ? "Hide env values" : "Reveal env values"}
                         @click=${() => {
                           cvs.envRevealed = !cvs.envRevealed;
@@ -1028,76 +1058,84 @@ export function renderConfig(props: ConfigProps) {
                         Peek
                       </button>
                     `
-                  : nothing}
+                    : nothing
+                }
               </div>
             `
-          : nothing}
+            : nothing
+        }
         <!-- Form content -->
         <div class="config-content">
-          ${props.activeSection === "__appearance__"
-            ? includeVirtualSections
-              ? renderAppearanceSection(props)
-              : nothing
-            : formMode === "form"
-              ? html`
+          ${
+            props.activeSection === "__appearance__"
+              ? includeVirtualSections
+                ? renderAppearanceSection(props)
+                : nothing
+              : formMode === "form"
+                ? html`
                   ${showAppearanceOnRoot ? renderAppearanceSection(props) : nothing}
-                  ${props.schemaLoading
-                    ? html`
-                        <div class="config-loading">
-                          <div class="config-loading__spinner"></div>
-                          <span>Loading schema…</span>
-                        </div>
-                      `
-                    : renderConfigForm({
-                        schema: analysis.schema,
-                        uiHints: props.uiHints,
-                        value: props.formValue,
-                        rawAvailable,
-                        disabled: props.loading || !props.formValue,
-                        unsupportedPaths: analysis.unsupportedPaths,
-                        onPatch: props.onFormPatch,
-                        searchQuery: props.searchQuery,
-                        activeSection: props.activeSection,
-                        activeSubsection: effectiveSubsection,
-                        revealSensitive:
-                          props.activeSection === "env" ? envSensitiveVisible : false,
-                        isSensitivePathRevealed,
-                        onToggleSensitivePath: (path) => {
-                          toggleSensitivePathReveal(path);
-                          requestUpdate();
-                        },
-                      })}
-                `
-              : (() => {
-                  const sensitiveCount = countSensitiveConfigValues(
-                    props.formValue,
-                    [],
-                    props.uiHints,
-                  );
-                  const blurred = sensitiveCount > 0 && !cvs.rawRevealed;
-                  return html`
-                    ${formUnsafe
+                  ${
+                    props.schemaLoading
                       ? html`
-                          <div class="callout info" style="margin-bottom: 12px">
-                            Your config contains fields the form editor can't safely represent. Use
-                            Raw mode to edit those entries.
+                          <div class="config-loading">
+                            <div class="config-loading__spinner"></div>
+                            <span>Loading schema…</span>
                           </div>
                         `
-                      : nothing}
+                      : renderConfigForm({
+                          schema: analysis.schema,
+                          uiHints: props.uiHints,
+                          value: props.formValue,
+                          rawAvailable,
+                          disabled: props.loading || !props.formValue,
+                          unsupportedPaths: analysis.unsupportedPaths,
+                          onPatch: props.onFormPatch,
+                          searchQuery: props.searchQuery,
+                          activeSection: props.activeSection,
+                          activeSubsection: effectiveSubsection,
+                          revealSensitive:
+                            props.activeSection === "env" ? envSensitiveVisible : false,
+                          isSensitivePathRevealed,
+                          onToggleSensitivePath: (path) => {
+                            toggleSensitivePathReveal(path);
+                            requestUpdate();
+                          },
+                        })
+                  }
+                `
+                : (() => {
+                    const sensitiveCount = countSensitiveConfigValues(
+                      props.formValue,
+                      [],
+                      props.uiHints,
+                    );
+                    const blurred = sensitiveCount > 0 && !cvs.rawRevealed;
+                    return html`
+                    ${
+                      formUnsafe
+                        ? html`
+                            <div class="callout info" style="margin-bottom: 12px">
+                              Your config contains fields the form editor can't safely represent. Use Raw mode to edit those
+                              entries.
+                            </div>
+                          `
+                        : nothing
+                    }
                     <div class="field config-raw-field">
                       <span style="display:flex;align-items:center;gap:8px;">
                         Raw config (JSON/JSON5)
-                        ${sensitiveCount > 0
-                          ? html`
+                        ${
+                          sensitiveCount > 0
+                            ? html`
                               <span class="pill pill--sm"
                                 >${sensitiveCount} secret${sensitiveCount === 1 ? "" : "s"}
                                 ${blurred ? "redacted" : "visible"}</span
                               >
                               <button
                                 class="btn btn--icon config-raw-toggle ${blurred ? "" : "active"}"
-                                title=${blurred
-                                  ? "Reveal sensitive values"
-                                  : "Hide sensitive values"}
+                                title=${
+                                  blurred ? "Reveal sensitive values" : "Hide sensitive values"
+                                }
                                 aria-label="Toggle raw config redaction"
                                 aria-pressed=${!blurred}
                                 @click=${() => {
@@ -1108,16 +1146,18 @@ export function renderConfig(props: ConfigProps) {
                                 ${blurred ? icons.eyeOff : icons.eye}
                               </button>
                             `
-                          : nothing}
+                            : nothing
+                        }
                       </span>
-                      ${blurred
-                        ? html`
+                      ${
+                        blurred
+                          ? html`
                             <div class="callout info" style="margin-top: 12px">
                               ${sensitiveCount} sensitive value${sensitiveCount === 1 ? "" : "s"}
                               hidden. Use the reveal button above to edit the raw config.
                             </div>
                           `
-                        : html`
+                          : html`
                             <textarea
                               placeholder="Raw config (JSON/JSON5)"
                               .value=${props.raw}
@@ -1125,17 +1165,21 @@ export function renderConfig(props: ConfigProps) {
                                 props.onRawChange((e.target as HTMLTextAreaElement).value);
                               }}
                             ></textarea>
-                          `}
+                          `
+                      }
                     </div>
                   `;
-                })()}
+                  })()
+          }
         </div>
 
-        ${props.issues.length > 0
-          ? html`<div class="callout danger" style="margin-top: 12px;">
+        ${
+          props.issues.length > 0
+            ? html`<div class="callout danger" style="margin-top: 12px;">
               <pre class="code-block">${JSON.stringify(props.issues, null, 2)}</pre>
             </div>`
-          : nothing}
+            : nothing
+        }
       </main>
     </div>
   `;

--- a/ui/src/ui/views/cron.ts
+++ b/ui/src/ui/views/cron.ts
@@ -341,12 +341,14 @@ function focusFormField(id: string) {
 function renderFieldLabel(text: string, required = false) {
   return html`<span>
     ${text}
-    ${required
-      ? html`
+    ${
+      required
+        ? html`
           <span class="cron-required-marker" aria-hidden="true">*</span>
           <span class="cron-required-sr">${t("cron.form.requiredSr")}</span>
         `
-      : nothing}
+        : nothing
+    }
   </span>`;
 }
 
@@ -400,11 +402,13 @@ export function renderCron(props: CronProps) {
           <div class="cron-summary-label">${t("cron.summary.enabled")}</div>
           <div class="cron-summary-value">
             <span class=${`chip ${props.status?.enabled ? "chip-ok" : "chip-danger"}`}>
-              ${props.status
-                ? props.status.enabled
-                  ? t("cron.summary.yes")
-                  : t("cron.summary.no")
-                : t("common.na")}
+              ${
+                props.status
+                  ? props.status.enabled
+                    ? t("cron.summary.yes")
+                    : t("cron.summary.no")
+                  : t("common.na")
+              }
             </span>
           </div>
         </div>
@@ -543,15 +547,18 @@ export function renderCron(props: CronProps) {
               </button>
             </label>
           </div>
-          ${props.jobs.length === 0
-            ? html` <div class="muted" style="margin-top: 12px">${t("cron.jobs.noMatching")}</div> `
-            : html`
+          ${
+            props.jobs.length === 0
+              ? html` <div class="muted" style="margin-top: 12px">${t("cron.jobs.noMatching")}</div> `
+              : html`
                 <div class="list" style="margin-top: 12px;">
                   ${props.jobs.map((job) => renderJob(job, props))}
                 </div>
-              `}
-          ${props.jobsHasMore
-            ? html`
+              `
+          }
+          ${
+            props.jobsHasMore
+              ? html`
                 <div class="row" style="margin-top: 12px">
                   <button
                     class="btn"
@@ -562,7 +569,8 @@ export function renderCron(props: CronProps) {
                   </button>
                 </div>
               `
-            : nothing}
+              : nothing
+          }
         </section>
 
         <section class="card">
@@ -573,9 +581,11 @@ export function renderCron(props: CronProps) {
             <div>
               <div class="card-title">${t("cron.runs.title")}</div>
               <div class="card-sub">
-                ${props.runsScope === "all"
-                  ? t("cron.runs.subtitleAll")
-                  : t("cron.runs.subtitleJob", { title: selectedRunTitle })}
+                ${
+                  props.runsScope === "all"
+                    ? t("cron.runs.subtitleAll")
+                    : t("cron.runs.subtitleJob", { title: selectedRunTitle })
+                }
               </div>
             </div>
             <div class="muted">
@@ -666,21 +676,24 @@ export function renderCron(props: CronProps) {
               })}
             </div>
           </div>
-          ${props.runsScope === "job" && props.runsJobId == null
-            ? html`
+          ${
+            props.runsScope === "job" && props.runsJobId == null
+              ? html`
                 <div class="muted" style="margin-top: 12px">${t("cron.runs.selectJobHint")}</div>
               `
-            : runs.length === 0
-              ? html`
+              : runs.length === 0
+                ? html`
                   <div class="muted" style="margin-top: 12px">${t("cron.runs.noMatching")}</div>
                 `
-              : html`
+                : html`
                   <div class="list" style="margin-top: 12px;">
                     ${runs.map((entry) => renderRun(entry, props.basePath, props.onNavigateToChat))}
                   </div>
-                `}
-          ${(props.runsScope === "all" || props.runsJobId != null) && props.runsHasMore
-            ? html`
+                `
+          }
+          ${
+            (props.runsScope === "all" || props.runsJobId != null) && props.runsHasMore
+              ? html`
                 <div class="row" style="margin-top: 12px">
                   <button
                     class="btn"
@@ -691,7 +704,8 @@ export function renderCron(props: CronProps) {
                   </button>
                 </div>
               `
-            : nothing}
+              : nothing
+          }
         </section>
       </div>
 
@@ -833,13 +847,16 @@ export function renderCron(props: CronProps) {
                   <option value="agentTurn">${t("cron.form.agentTurn")}</option>
                 </select>
                 <div class="cron-help">
-                  ${props.form.payloadKind === "systemEvent"
-                    ? t("cron.form.systemEventHelp")
-                    : t("cron.form.agentTurnHelp")}
+                  ${
+                    props.form.payloadKind === "systemEvent"
+                      ? t("cron.form.systemEventHelp")
+                      : t("cron.form.agentTurnHelp")
+                  }
                 </div>
               </label>
-              ${isAgentTurn
-                ? html`
+              ${
+                isAgentTurn
+                  ? html`
                     <label class="field">
                       ${renderFieldLabel(t("cron.form.timeoutSeconds"))}
                       <input
@@ -864,7 +881,8 @@ export function renderCron(props: CronProps) {
                       )}
                     </label>
                   `
-                : nothing}
+                  : nothing
+              }
             </div>
             <label class="field cron-span-2">
               ${renderFieldLabel(
@@ -905,16 +923,19 @@ export function renderCron(props: CronProps) {
                         .value as CronFormState["deliveryMode"],
                     })}
                 >
-                  ${supportsAnnounce
-                    ? html` <option value="announce">${t("cron.form.announceDefault")}</option> `
-                    : nothing}
+                  ${
+                    supportsAnnounce
+                      ? html` <option value="announce">${t("cron.form.announceDefault")}</option> `
+                      : nothing
+                  }
                   <option value="webhook">${t("cron.form.webhookPost")}</option>
                   <option value="none">${t("cron.form.noneInternal")}</option>
                 </select>
                 <div class="cron-help">${t("cron.form.deliveryHelp")}</div>
               </label>
-              ${selectedDeliveryMode !== "none"
-                ? html`
+              ${
+                selectedDeliveryMode !== "none"
+                  ? html`
                     <label class="field ${selectedDeliveryMode === "webhook" ? "cron-span-2" : ""}">
                       ${renderFieldLabel(
                         selectedDeliveryMode === "webhook"
@@ -922,8 +943,9 @@ export function renderCron(props: CronProps) {
                           : t("cron.form.channel"),
                         selectedDeliveryMode === "webhook",
                       )}
-                      ${selectedDeliveryMode === "webhook"
-                        ? html`
+                      ${
+                        selectedDeliveryMode === "webhook"
+                          ? html`
                             <input
                               id="cron-delivery-to"
                               .value=${props.form.deliveryTo}
@@ -941,7 +963,7 @@ export function renderCron(props: CronProps) {
                               placeholder=${t("cron.form.webhookPlaceholder")}
                             />
                           `
-                        : html`
+                          : html`
                             <select
                               id="cron-delivery-channel"
                               .value=${props.form.deliveryChannel || "last"}
@@ -957,13 +979,17 @@ export function renderCron(props: CronProps) {
                                   </option>`,
                               )}
                             </select>
-                          `}
-                      ${selectedDeliveryMode === "announce"
-                        ? html` <div class="cron-help">${t("cron.form.channelHelp")}</div> `
-                        : html` <div class="cron-help">${t("cron.form.webhookHelp")}</div> `}
+                          `
+                      }
+                      ${
+                        selectedDeliveryMode === "announce"
+                          ? html` <div class="cron-help">${t("cron.form.channelHelp")}</div> `
+                          : html` <div class="cron-help">${t("cron.form.webhookHelp")}</div> `
+                      }
                     </label>
-                    ${selectedDeliveryMode === "announce"
-                      ? html`
+                    ${
+                      selectedDeliveryMode === "announce"
+                        ? html`
                           <label class="field cron-span-2">
                             ${renderFieldLabel(t("cron.form.to"))}
                             <input
@@ -979,15 +1005,19 @@ export function renderCron(props: CronProps) {
                             <div class="cron-help">${t("cron.form.toHelp")}</div>
                           </label>
                         `
-                      : nothing}
-                    ${selectedDeliveryMode === "webhook"
-                      ? renderFieldError(
-                          props.fieldErrors.deliveryTo,
-                          errorIdForField("deliveryTo"),
-                        )
-                      : nothing}
+                        : nothing
+                    }
+                    ${
+                      selectedDeliveryMode === "webhook"
+                        ? renderFieldError(
+                            props.fieldErrors.deliveryTo,
+                            errorIdForField("deliveryTo"),
+                          )
+                        : nothing
+                    }
                   `
-                : nothing}
+                  : nothing
+              }
             </div>
           </section>
 
@@ -1032,8 +1062,9 @@ export function renderCron(props: CronProps) {
                 />
                 <div class="cron-help">Optional routing key for job delivery and wake routing.</div>
               </label>
-              ${isCronSchedule
-                ? html`
+              ${
+                isCronSchedule
+                  ? html`
                     <label class="field checkbox cron-checkbox cron-span-2">
                       <input
                         type="checkbox"
@@ -1087,9 +1118,11 @@ export function renderCron(props: CronProps) {
                       </label>
                     </div>
                   `
-                : nothing}
-              ${isAgentTurn
-                ? html`
+                  : nothing
+              }
+              ${
+                isAgentTurn
+                  ? html`
                     <label class="field cron-span-2">
                       ${renderFieldLabel("Account ID")}
                       <input
@@ -1150,9 +1183,11 @@ export function renderCron(props: CronProps) {
                       <div class="cron-help">${t("cron.form.thinkingHelp")}</div>
                     </label>
                   `
-                : nothing}
-              ${isAgentTurn
-                ? html`
+                  : nothing
+              }
+              ${
+                isAgentTurn
+                  ? html`
                     <label class="field cron-span-2">
                       ${renderFieldLabel("Failure alerts")}
                       <select
@@ -1171,8 +1206,9 @@ export function renderCron(props: CronProps) {
                         Control when this job sends repeated-failure alerts.
                       </div>
                     </label>
-                    ${props.form.failureAlertMode === "custom"
-                      ? html`
+                    ${
+                      props.form.failureAlertMode === "custom"
+                        ? html`
                           <label class="field">
                             ${renderFieldLabel("Alert after")}
                             <input
@@ -1201,9 +1237,9 @@ export function renderCron(props: CronProps) {
                             <input
                               id="cron-failure-alert-cooldown-seconds"
                               .value=${props.form.failureAlertCooldownSeconds}
-                              aria-invalid=${props.fieldErrors.failureAlertCooldownSeconds
-                                ? "true"
-                                : "false"}
+                              aria-invalid=${
+                                props.fieldErrors.failureAlertCooldownSeconds ? "true" : "false"
+                              }
                               aria-describedby=${ifDefined(
                                 props.fieldErrors.failureAlertCooldownSeconds
                                   ? errorIdForField("failureAlertCooldownSeconds")
@@ -1279,11 +1315,14 @@ export function renderCron(props: CronProps) {
                             />
                           </label>
                         `
-                      : nothing}
+                        : nothing
+                    }
                   `
-                : nothing}
-              ${selectedDeliveryMode !== "none"
-                ? html`
+                  : nothing
+              }
+              ${
+                selectedDeliveryMode !== "none"
+                  ? html`
                     <label class="field checkbox cron-checkbox cron-span-2">
                       <input
                         type="checkbox"
@@ -1299,12 +1338,14 @@ export function renderCron(props: CronProps) {
                       <div class="cron-help">${t("cron.form.bestEffortHelp")}</div>
                     </label>
                   `
-                : nothing}
+                  : nothing
+              }
             </div>
           </details>
         </div>
-        ${blockedByValidation
-          ? html`
+        ${
+          blockedByValidation
+            ? html`
               <div class="cron-form-status" role="status" aria-live="polite">
                 <div class="cron-form-status__title">${t("cron.form.cantAddYet")}</div>
                 <div class="cron-help">${t("cron.form.fillRequired")}</div>
@@ -1325,29 +1366,36 @@ export function renderCron(props: CronProps) {
                 </ul>
               </div>
             `
-          : nothing}
+            : nothing
+        }
         <div class="row cron-form-actions">
           <button
             class="btn primary"
             ?disabled=${props.busy || !props.canSubmit}
             @click=${props.onAdd}
           >
-            ${props.busy
-              ? t("cron.form.saving")
-              : isEditing
-                ? t("cron.form.saveChanges")
-                : t("cron.form.addJob")}
+            ${
+              props.busy
+                ? t("cron.form.saving")
+                : isEditing
+                  ? t("cron.form.saveChanges")
+                  : t("cron.form.addJob")
+            }
           </button>
-          ${submitDisabledReason
-            ? html`<div class="cron-submit-reason" aria-live="polite">${submitDisabledReason}</div>`
-            : nothing}
-          ${isEditing
-            ? html`
+          ${
+            submitDisabledReason
+              ? html`<div class="cron-submit-reason" aria-live="polite">${submitDisabledReason}</div>`
+              : nothing
+          }
+          ${
+            isEditing
+              ? html`
                 <button class="btn" ?disabled=${props.busy} @click=${props.onCancelEdit}>
                   ${t("cron.form.cancel")}
                 </button>
               `
-            : nothing}
+              : nothing
+          }
         </div>
       </section>
     </section>
@@ -1474,11 +1522,13 @@ function renderJob(job: CronJob, props: CronProps) {
         <div class="list-title">${job.name}</div>
         <div class="list-sub">${formatCronSchedule(job)}</div>
         ${renderJobPayload(job)}
-        ${job.agentId
-          ? html`<div class="muted cron-job-agent">
+        ${
+          job.agentId
+            ? html`<div class="muted cron-job-agent">
               ${t("cron.jobDetail.agent")}: ${job.agentId}
             </div>`
-          : nothing}
+            : nothing
+        }
       </div>
       <div class="list-meta">${renderJobState(job)}</div>
       <div class="cron-job-footer">
@@ -1589,12 +1639,14 @@ function renderJobPayload(job: CronJob) {
       <span class="cron-job-detail-label">${t("cron.jobDetail.prompt")}</span>
       <span class="muted cron-job-detail-value">${job.payload.message}</span>
     </div>
-    ${delivery
-      ? html`<div class="cron-job-detail">
+    ${
+      delivery
+        ? html`<div class="cron-job-detail">
           <span class="cron-job-detail-label">${t("cron.jobDetail.delivery")}</span>
           <span class="muted cron-job-detail-value">${delivery.mode}${deliveryTarget}</span>
         </div>`
-      : nothing}
+        : nothing
+    }
   `;
 }
 
@@ -1718,15 +1770,20 @@ function renderRun(
       </div>
       <div class="list-meta cron-run-entry__meta">
         <div>${formatMs(entry.ts)}</div>
-        ${typeof entry.runAtMs === "number"
-          ? html`<div class="muted">${t("cron.runEntry.runAt")} ${formatMs(entry.runAtMs)}</div>`
-          : nothing}
+        ${
+          typeof entry.runAtMs === "number"
+            ? html`<div class="muted">${t("cron.runEntry.runAt")} ${formatMs(entry.runAtMs)}</div>`
+            : nothing
+        }
         <div class="muted">${entry.durationMs ?? 0}ms</div>
-        ${typeof entry.nextRunAtMs === "number"
-          ? html`<div class="muted">${formatRunNextLabel(entry.nextRunAtMs)}</div>`
-          : nothing}
-        ${chatUrl
-          ? html`<div>
+        ${
+          typeof entry.nextRunAtMs === "number"
+            ? html`<div class="muted">${formatRunNextLabel(entry.nextRunAtMs)}</div>`
+            : nothing
+        }
+        ${
+          chatUrl
+            ? html`<div>
               <a
                 class="session-link"
                 href=${chatUrl}
@@ -1749,7 +1806,8 @@ function renderRun(
                 >${t("cron.runEntry.openRunChat")}</a
               >
             </div>`
-          : nothing}
+            : nothing
+        }
         ${entry.error ? html`<div class="muted">${entry.error}</div>` : nothing}
         ${entry.deliveryError ? html`<div class="muted">${entry.deliveryError}</div>` : nothing}
       </div>

--- a/ui/src/ui/views/debug.ts
+++ b/ui/src/ui/views/debug.ts
@@ -48,12 +48,14 @@ export function renderDebug(props: DebugProps) {
         <div class="stack" style="margin-top: 12px;">
           <div>
             <div class="muted">Status</div>
-            ${securitySummary
-              ? html`<div class="callout ${securityTone}" style="margin-top: 8px;">
+            ${
+              securitySummary
+                ? html`<div class="callout ${securityTone}" style="margin-top: 8px;">
                   Security audit: ${securityLabel}${info > 0 ? ` · ${info} info` : ""}. Run
                   <span class="mono">openclaw security audit --deep</span> for details.
                 </div>`
-              : nothing}
+                : nothing
+            }
             <pre class="code-block">${JSON.stringify(props.status ?? {}, null, 2)}</pre>
           </div>
           <div>
@@ -78,9 +80,13 @@ export function renderDebug(props: DebugProps) {
               @change=${(e: Event) =>
                 props.onCallMethodChange((e.target as HTMLSelectElement).value)}
             >
-              ${!props.callMethod
-                ? html` <option value="" disabled>Select a method…</option> `
-                : nothing}
+              ${
+                !props.callMethod
+                  ? html`
+                      <option value="" disabled>Select a method…</option>
+                    `
+                  : nothing
+              }
               ${props.methods.map((m) => html`<option value=${m}>${m}</option>`)}
             </select>
           </label>
@@ -97,12 +103,16 @@ export function renderDebug(props: DebugProps) {
         <div class="row" style="margin-top: 12px;">
           <button class="btn primary" @click=${props.onCall}>Call</button>
         </div>
-        ${props.callError
-          ? html`<div class="callout danger" style="margin-top: 12px;">${props.callError}</div>`
-          : nothing}
-        ${props.callResult
-          ? html`<pre class="code-block" style="margin-top: 12px;">${props.callResult}</pre>`
-          : nothing}
+        ${
+          props.callError
+            ? html`<div class="callout danger" style="margin-top: 12px;">${props.callError}</div>`
+            : nothing
+        }
+        ${
+          props.callResult
+            ? html`<pre class="code-block" style="margin-top: 12px;">${props.callResult}</pre>`
+            : nothing
+        }
       </div>
     </section>
 
@@ -117,9 +127,12 @@ ${JSON.stringify(props.models ?? [], null, 2)}</pre
     <section class="card" style="margin-top: 18px;">
       <div class="card-title">Event Log</div>
       <div class="card-sub">Latest gateway events.</div>
-      ${props.eventLog.length === 0
-        ? html` <div class="muted" style="margin-top: 12px">No events yet.</div> `
-        : html`
+      ${
+        props.eventLog.length === 0
+          ? html`
+              <div class="muted" style="margin-top: 12px">No events yet.</div>
+            `
+          : html`
             <div class="list debug-event-log" style="margin-top: 12px;">
               ${props.eventLog.map(
                 (evt) => html`
@@ -137,7 +150,8 @@ ${formatEventPayload(evt.payload)}</pre
                 `,
               )}
             </div>
-          `}
+          `
+      }
     </section>
   `;
 }

--- a/ui/src/ui/views/exec-approval.ts
+++ b/ui/src/ui/views/exec-approval.ts
@@ -40,11 +40,13 @@ function renderExecBody(request: ExecApprovalRequestPayload) {
 
 function renderPluginBody(active: ExecApprovalRequest) {
   return html`
-    ${active.pluginDescription
-      ? html`<pre class="exec-approval-command mono" style="white-space:pre-wrap">
+    ${
+      active.pluginDescription
+        ? html`<pre class="exec-approval-command mono" style="white-space:pre-wrap">
 ${active.pluginDescription}</pre
         >`
-      : nothing}
+        : nothing
+    }
     <div class="exec-approval-meta">
       ${renderMetaRow("Severity", active.pluginSeverity)}
       ${renderMetaRow("Plugin", active.pluginId)} ${renderMetaRow("Agent", active.request.agentId)}
@@ -74,14 +76,18 @@ export function renderExecApprovalPrompt(state: AppViewState) {
             <div class="exec-approval-title">${title}</div>
             <div class="exec-approval-sub">${remaining}</div>
           </div>
-          ${queueCount > 1
-            ? html`<div class="exec-approval-queue">${queueCount} pending</div>`
-            : nothing}
+          ${
+            queueCount > 1
+              ? html`<div class="exec-approval-queue">${queueCount} pending</div>`
+              : nothing
+          }
         </div>
         ${isPlugin ? renderPluginBody(active) : renderExecBody(request)}
-        ${state.execApprovalError
-          ? html`<div class="exec-approval-error">${state.execApprovalError}</div>`
-          : nothing}
+        ${
+          state.execApprovalError
+            ? html`<div class="exec-approval-error">${state.execApprovalError}</div>`
+            : nothing
+        }
         <div class="exec-approval-actions">
           <button
             class="btn primary"

--- a/ui/src/ui/views/instances.ts
+++ b/ui/src/ui/views/instances.ts
@@ -42,16 +42,24 @@ export function renderInstances(props: InstancesProps) {
           </button>
         </div>
       </div>
-      ${props.lastError
-        ? html`<div class="callout danger" style="margin-top: 12px;">${props.lastError}</div>`
-        : nothing}
-      ${props.statusMessage
-        ? html`<div class="callout" style="margin-top: 12px;">${props.statusMessage}</div>`
-        : nothing}
+      ${
+        props.lastError
+          ? html`<div class="callout danger" style="margin-top: 12px;">${props.lastError}</div>`
+          : nothing
+      }
+      ${
+        props.statusMessage
+          ? html`<div class="callout" style="margin-top: 12px;">${props.statusMessage}</div>`
+          : nothing
+      }
       <div class="list" style="margin-top: 16px;">
-        ${props.entries.length === 0
-          ? html` <div class="muted">No instances reported yet.</div> `
-          : props.entries.map((entry) => renderEntry(entry, masked))}
+        ${
+          props.entries.length === 0
+            ? html`
+                <div class="muted">No instances reported yet.</div>
+              `
+            : props.entries.map((entry) => renderEntry(entry, masked))
+        }
       </div>
     </section>
   `;
@@ -86,9 +94,11 @@ function renderEntry(entry: PresenceEntry, masked: boolean) {
           ${scopesLabel ? html`<span class="chip">${scopesLabel}</span>` : nothing}
           ${entry.platform ? html`<span class="chip">${entry.platform}</span>` : nothing}
           ${entry.deviceFamily ? html`<span class="chip">${entry.deviceFamily}</span>` : nothing}
-          ${entry.modelIdentifier
-            ? html`<span class="chip">${entry.modelIdentifier}</span>`
-            : nothing}
+          ${
+            entry.modelIdentifier
+              ? html`<span class="chip">${entry.modelIdentifier}</span>`
+              : nothing
+          }
           ${entry.version ? html`<span class="chip">${entry.version}</span>` : nothing}
         </div>
       </div>

--- a/ui/src/ui/views/login-gate.ts
+++ b/ui/src/ui/views/login-gate.ts
@@ -100,11 +100,13 @@ export function renderLoginGate(state: AppViewState) {
             ${t("common.connect")}
           </button>
         </div>
-        ${state.lastError
-          ? html`<div class="callout danger" style="margin-top: 14px;">
+        ${
+          state.lastError
+            ? html`<div class="callout danger" style="margin-top: 14px;">
               <div>${state.lastError}</div>
             </div>`
-          : ""}
+            : ""
+        }
         <div class="login-gate__help">
           <div class="login-gate__help-title">${t("overview.connection.title")}</div>
           <ol class="login-gate__steps">

--- a/ui/src/ui/views/logs.ts
+++ b/ui/src/ui/views/logs.ts
@@ -114,25 +114,32 @@ export function renderLogs(props: LogsProps) {
         )}
       </div>
 
-      ${props.file
-        ? html`<div class="muted" style="margin-top: 10px;">File: ${props.file}</div>`
-        : nothing}
-      ${props.truncated
-        ? html`
-            <div class="callout" style="margin-top: 10px">
-              Log output truncated; showing latest chunk.
-            </div>
-          `
-        : nothing}
-      ${props.error
-        ? html`<div class="callout danger" style="margin-top: 10px;">${props.error}</div>`
-        : nothing}
+      ${
+        props.file
+          ? html`<div class="muted" style="margin-top: 10px;">File: ${props.file}</div>`
+          : nothing
+      }
+      ${
+        props.truncated
+          ? html`
+              <div class="callout" style="margin-top: 10px">Log output truncated; showing latest chunk.</div>
+            `
+          : nothing
+      }
+      ${
+        props.error
+          ? html`<div class="callout danger" style="margin-top: 10px;">${props.error}</div>`
+          : nothing
+      }
 
       <div class="log-stream" style="margin-top: 12px;" @scroll=${props.onScroll}>
-        ${filtered.length === 0
-          ? html` <div class="muted" style="padding: 12px">No log entries.</div> `
-          : filtered.map(
-              (entry) => html`
+        ${
+          filtered.length === 0
+            ? html`
+                <div class="muted" style="padding: 12px">No log entries.</div>
+              `
+            : filtered.map(
+                (entry) => html`
                 <div class="log-row">
                   <div class="log-time mono">${formatTime(entry.time)}</div>
                   <div class="log-level ${entry.level ?? ""}">${entry.level ?? ""}</div>
@@ -140,7 +147,8 @@ export function renderLogs(props: LogsProps) {
                   <div class="log-message mono">${entry.message ?? entry.raw}</div>
                 </div>
               `,
-            )}
+              )
+        }
       </div>
     </section>
   `;

--- a/ui/src/ui/views/markdown-sidebar.ts
+++ b/ui/src/ui/views/markdown-sidebar.ts
@@ -18,18 +18,22 @@ export function renderMarkdownSidebar(props: MarkdownSidebarProps) {
         <button @click=${props.onClose} class="btn" title="Close sidebar">${icons.x}</button>
       </div>
       <div class="sidebar-content">
-        ${props.error
-          ? html`
+        ${
+          props.error
+            ? html`
               <div class="callout danger">${props.error}</div>
               <button @click=${props.onViewRawText} class="btn" style="margin-top: 12px;">
                 View Raw Text
               </button>
             `
-          : props.content
-            ? html`<div class="sidebar-markdown">
+            : props.content
+              ? html`<div class="sidebar-markdown">
                 ${unsafeHTML(toSanitizedMarkdownHtml(props.content))}
               </div>`
-            : html` <div class="muted">No content available</div> `}
+              : html`
+                  <div class="muted">No content available</div>
+                `
+        }
       </div>
     </div>
   `;

--- a/ui/src/ui/views/nodes-exec-approvals.ts
+++ b/ui/src/ui/views/nodes-exec-approvals.ts
@@ -211,19 +211,23 @@ export function renderExecApprovals(state: ExecApprovalsState) {
       </div>
 
       ${renderExecApprovalsTarget(state)}
-      ${!ready
-        ? html`<div class="row" style="margin-top: 12px; gap: 12px;">
+      ${
+        !ready
+          ? html`<div class="row" style="margin-top: 12px; gap: 12px;">
             <div class="muted">Load exec approvals to edit allowlists.</div>
             <button class="btn" ?disabled=${state.loading || !targetReady} @click=${state.onLoad}>
               ${state.loading ? "Loading…" : "Load approvals"}
             </button>
           </div>`
-        : html`
+          : html`
             ${renderExecApprovalsTabs(state)} ${renderExecApprovalsPolicy(state)}
-            ${state.selectedScope === EXEC_APPROVALS_DEFAULT_SCOPE
-              ? nothing
-              : renderExecApprovalsAllowlist(state)}
-          `}
+            ${
+              state.selectedScope === EXEC_APPROVALS_DEFAULT_SCOPE
+                ? nothing
+                : renderExecApprovalsAllowlist(state)
+            }
+          `
+      }
     </section>
   `;
 }
@@ -258,8 +262,9 @@ function renderExecApprovalsTarget(state: ExecApprovalsState) {
               <option value="node" ?selected=${state.target === "node"}>Node</option>
             </select>
           </label>
-          ${state.target === "node"
-            ? html`
+          ${
+            state.target === "node"
+              ? html`
                 <label class="field">
                   <span>Node</span>
                   <select
@@ -280,12 +285,17 @@ function renderExecApprovalsTarget(state: ExecApprovalsState) {
                   </select>
                 </label>
               `
-            : nothing}
+              : nothing
+          }
         </div>
       </div>
-      ${state.target === "node" && !hasNodes
-        ? html` <div class="muted">No nodes advertise exec approvals yet.</div> `
-        : nothing}
+      ${
+        state.target === "node" && !hasNodes
+          ? html`
+              <div class="muted">No nodes advertise exec approvals yet.</div>
+            `
+          : nothing
+      }
     </div>
   `;
 }
@@ -296,9 +306,9 @@ function renderExecApprovalsTabs(state: ExecApprovalsState) {
       <span class="label">Scope</span>
       <div class="row" style="gap: 8px; flex-wrap: wrap;">
         <button
-          class="btn btn--sm ${state.selectedScope === EXEC_APPROVALS_DEFAULT_SCOPE
-            ? "active"
-            : ""}"
+          class="btn btn--sm ${
+            state.selectedScope === EXEC_APPROVALS_DEFAULT_SCOPE ? "active" : ""
+          }"
           @click=${() => state.onSelectScope(EXEC_APPROVALS_DEFAULT_SCOPE)}
         >
           Defaults
@@ -359,11 +369,13 @@ function renderExecApprovalsPolicy(state: ExecApprovalsState) {
                 }
               }}
             >
-              ${!isDefaults
-                ? html`<option value="__default__" ?selected=${securityValue === "__default__"}>
+              ${
+                !isDefaults
+                  ? html`<option value="__default__" ?selected=${securityValue === "__default__"}>
                     Use default (${defaults.security})
                   </option>`
-                : nothing}
+                  : nothing
+              }
               ${SECURITY_OPTIONS.map(
                 (option) =>
                   html`<option value=${option.value} ?selected=${securityValue === option.value}>
@@ -397,11 +409,13 @@ function renderExecApprovalsPolicy(state: ExecApprovalsState) {
                 }
               }}
             >
-              ${!isDefaults
-                ? html`<option value="__default__" ?selected=${askValue === "__default__"}>
+              ${
+                !isDefaults
+                  ? html`<option value="__default__" ?selected=${askValue === "__default__"}>
                     Use default (${defaults.ask})
                   </option>`
-                : nothing}
+                  : nothing
+              }
               ${ASK_OPTIONS.map(
                 (option) =>
                   html`<option value=${option.value} ?selected=${askValue === option.value}>
@@ -417,9 +431,11 @@ function renderExecApprovalsPolicy(state: ExecApprovalsState) {
         <div class="list-main">
           <div class="list-title">Ask fallback</div>
           <div class="list-sub">
-            ${isDefaults
-              ? "Applied when the UI prompt is unavailable."
-              : `Default: ${defaults.askFallback}.`}
+            ${
+              isDefaults
+                ? "Applied when the UI prompt is unavailable."
+                : `Default: ${defaults.askFallback}.`
+            }
           </div>
         </div>
         <div class="list-meta">
@@ -437,11 +453,13 @@ function renderExecApprovalsPolicy(state: ExecApprovalsState) {
                 }
               }}
             >
-              ${!isDefaults
-                ? html`<option value="__default__" ?selected=${askFallbackValue === "__default__"}>
+              ${
+                !isDefaults
+                  ? html`<option value="__default__" ?selected=${askFallbackValue === "__default__"}>
                     Use default (${defaults.askFallback})
                   </option>`
-                : nothing}
+                  : nothing
+              }
               ${SECURITY_OPTIONS.map(
                 (option) =>
                   html`<option value=${option.value} ?selected=${askFallbackValue === option.value}>
@@ -457,11 +475,13 @@ function renderExecApprovalsPolicy(state: ExecApprovalsState) {
         <div class="list-main">
           <div class="list-title">Auto-allow skill CLIs</div>
           <div class="list-sub">
-            ${isDefaults
-              ? "Allow skill executables listed by the Gateway."
-              : autoIsDefault
-                ? `Using default (${defaults.autoAllowSkills ? "on" : "off"}).`
-                : `Override (${autoEffective ? "on" : "off"}).`}
+            ${
+              isDefaults
+                ? "Allow skill executables listed by the Gateway."
+                : autoIsDefault
+                  ? `Using default (${defaults.autoAllowSkills ? "on" : "off"}).`
+                  : `Override (${autoEffective ? "on" : "off"}).`
+            }
           </div>
         </div>
         <div class="list-meta">
@@ -477,15 +497,17 @@ function renderExecApprovalsPolicy(state: ExecApprovalsState) {
               }}
             />
           </label>
-          ${!isDefaults && !autoIsDefault
-            ? html`<button
+          ${
+            !isDefaults && !autoIsDefault
+              ? html`<button
                 class="btn btn--sm"
                 ?disabled=${state.disabled}
                 @click=${() => state.onRemove([...basePath, "autoAllowSkills"])}
               >
                 Use default
               </button>`
-            : nothing}
+              : nothing
+          }
         </div>
       </div>
     </div>
@@ -513,9 +535,13 @@ function renderExecApprovalsAllowlist(state: ExecApprovalsState) {
       </button>
     </div>
     <div class="list" style="margin-top: 12px;">
-      ${entries.length === 0
-        ? html` <div class="muted">No allowlist entries yet.</div> `
-        : entries.map((entry, index) => renderAllowlistEntry(state, entry, index))}
+      ${
+        entries.length === 0
+          ? html`
+              <div class="muted">No allowlist entries yet.</div>
+            `
+          : entries.map((entry, index) => renderAllowlistEntry(state, entry, index))
+      }
     </div>
   `;
 }

--- a/ui/src/ui/views/nodes.ts
+++ b/ui/src/ui/views/nodes.ts
@@ -62,9 +62,13 @@ export function renderNodes(props: NodesProps) {
         </button>
       </div>
       <div class="list" style="margin-top: 16px;">
-        ${props.nodes.length === 0
-          ? html` <div class="muted">No nodes found.</div> `
-          : props.nodes.map((n) => renderNode(n))}
+        ${
+          props.nodes.length === 0
+            ? html`
+                <div class="muted">No nodes found.</div>
+              `
+            : props.nodes.map((n) => renderNode(n))
+        }
       </div>
     </section>
   `;
@@ -85,25 +89,35 @@ function renderDevices(props: NodesProps) {
           ${props.devicesLoading ? "Loading…" : "Refresh"}
         </button>
       </div>
-      ${props.devicesError
-        ? html`<div class="callout danger" style="margin-top: 12px;">${props.devicesError}</div>`
-        : nothing}
+      ${
+        props.devicesError
+          ? html`<div class="callout danger" style="margin-top: 12px;">${props.devicesError}</div>`
+          : nothing
+      }
       <div class="list" style="margin-top: 16px;">
-        ${pending.length > 0
-          ? html`
+        ${
+          pending.length > 0
+            ? html`
               <div class="muted" style="margin-bottom: 8px;">Pending</div>
               ${pending.map((req) => renderPendingDevice(req, props))}
             `
-          : nothing}
-        ${paired.length > 0
-          ? html`
+            : nothing
+        }
+        ${
+          paired.length > 0
+            ? html`
               <div class="muted" style="margin-top: 12px; margin-bottom: 8px;">Paired</div>
               ${paired.map((device) => renderPairedDevice(device, props))}
             `
-          : nothing}
-        ${pending.length === 0 && paired.length === 0
-          ? html` <div class="muted">No paired devices.</div> `
-          : nothing}
+            : nothing
+        }
+        ${
+          pending.length === 0 && paired.length === 0
+            ? html`
+                <div class="muted">No paired devices.</div>
+              `
+            : nothing
+        }
       </div>
     </section>
   `;
@@ -151,14 +165,18 @@ function renderPairedDevice(device: PairedDevice, props: NodesProps) {
         <div class="list-title">${name}</div>
         <div class="list-sub">${device.deviceId}${ip}</div>
         <div class="muted" style="margin-top: 6px;">${roles} · ${scopes}</div>
-        ${tokens.length === 0
-          ? html` <div class="muted" style="margin-top: 6px">Tokens: none</div> `
-          : html`
+        ${
+          tokens.length === 0
+            ? html`
+                <div class="muted" style="margin-top: 6px">Tokens: none</div>
+              `
+            : html`
               <div class="muted" style="margin-top: 10px;">Tokens</div>
               <div style="display: flex; flex-direction: column; gap: 8px; margin-top: 6px;">
                 ${tokens.map((token) => renderTokenRow(device.deviceId, token, props))}
               </div>
-            `}
+            `
+        }
       </div>
     </div>
   `;
@@ -180,16 +198,18 @@ function renderTokenRow(deviceId: string, token: DeviceTokenSummary, props: Node
         >
           Rotate
         </button>
-        ${token.revokedAtMs
-          ? nothing
-          : html`
+        ${
+          token.revokedAtMs
+            ? nothing
+            : html`
               <button
                 class="btn btn--sm danger"
                 @click=${() => props.onDeviceRevoke(deviceId, token.role)}
               >
                 Revoke
               </button>
-            `}
+            `
+        }
       </div>
     </div>
   `;
@@ -265,21 +285,24 @@ function renderBindings(state: BindingState) {
         </button>
       </div>
 
-      ${state.formMode === "raw"
-        ? html`
-            <div class="callout warn" style="margin-top: 12px">
-              Switch the Config tab to <strong>Form</strong> mode to edit bindings here.
-            </div>
-          `
-        : nothing}
-      ${!state.ready
-        ? html`<div class="row" style="margin-top: 12px; gap: 12px;">
+      ${
+        state.formMode === "raw"
+          ? html`
+              <div class="callout warn" style="margin-top: 12px">
+                Switch the Config tab to <strong>Form</strong> mode to edit bindings here.
+              </div>
+            `
+          : nothing
+      }
+      ${
+        !state.ready
+          ? html`<div class="row" style="margin-top: 12px; gap: 12px;">
             <div class="muted">Load config to edit bindings.</div>
             <button class="btn" ?disabled=${state.configLoading} @click=${state.onLoadConfig}>
               ${state.configLoading ? "Loading…" : "Load config"}
             </button>
           </div>`
-        : html`
+          : html`
             <div class="list" style="margin-top: 16px;">
               <div class="list-item">
                 <div class="list-main">
@@ -306,17 +329,26 @@ function renderBindings(state: BindingState) {
                       )}
                     </select>
                   </label>
-                  ${!supportsBinding
-                    ? html` <div class="muted">No nodes with system.run available.</div> `
-                    : nothing}
+                  ${
+                    !supportsBinding
+                      ? html`
+                          <div class="muted">No nodes with system.run available.</div>
+                        `
+                      : nothing
+                  }
                 </div>
               </div>
 
-              ${state.agents.length === 0
-                ? html` <div class="muted">No agents found.</div> `
-                : state.agents.map((agent) => renderAgentBinding(agent, state))}
+              ${
+                state.agents.length === 0
+                  ? html`
+                      <div class="muted">No agents found.</div>
+                    `
+                  : state.agents.map((agent) => renderAgentBinding(agent, state))
+              }
             </div>
-          `}
+          `
+      }
     </section>
   `;
 }
@@ -331,9 +363,11 @@ function renderAgentBinding(agent: BindingAgent, state: BindingState) {
         <div class="list-title">${label}</div>
         <div class="list-sub">
           ${agent.isDefault ? "default agent" : "agent"} ·
-          ${bindingValue === "__default__"
-            ? `uses default (${state.defaultBinding ?? "any"})`
-            : `override: ${agent.binding}`}
+          ${
+            bindingValue === "__default__"
+              ? `uses default (${state.defaultBinding ?? "any"})`
+              : `override: ${agent.binding}`
+          }
         </div>
       </div>
       <div class="list-meta">

--- a/ui/src/ui/views/overview-attention.ts
+++ b/ui/src/ui/views/overview-attention.ts
@@ -42,15 +42,17 @@ export function renderOverviewAttention(props: OverviewAttentionProps) {
                 <div class="ov-attention-title">${item.title}</div>
                 <div class="muted">${item.description}</div>
               </div>
-              ${item.href
-                ? html`<a
+              ${
+                item.href
+                  ? html`<a
                     class="ov-attention-link"
                     href=${item.href}
                     target=${item.external ? EXTERNAL_LINK_TARGET : nothing}
                     rel=${item.external ? buildExternalLinkRel() : nothing}
                     >${t("common.docs")}</a
                   >`
-                : nothing}
+                  : nothing
+              }
             </div>
           `,
         )}

--- a/ui/src/ui/views/overview-cards.ts
+++ b/ui/src/ui/views/overview-cards.ts
@@ -136,8 +136,9 @@ export function renderOverviewCards(props: OverviewCardsProps) {
   return html`
     <section class="ov-cards">${cards.map((c) => renderStatCard(c, props.onNavigate))}</section>
 
-    ${sessions.length > 0
-      ? html`
+    ${
+      sessions.length > 0
+        ? html`
           <section class="ov-recent">
             <h3 class="ov-recent__title">${t("overview.cards.recentSessions")}</h3>
             <ul class="ov-recent__list">
@@ -157,6 +158,7 @@ export function renderOverviewCards(props: OverviewCardsProps) {
             </ul>
           </section>
         `
-      : nothing}
+        : nothing
+    }
   `;
 }

--- a/ui/src/ui/views/overview-event-log.ts
+++ b/ui/src/ui/views/overview-event-log.ts
@@ -28,11 +28,13 @@ export function renderOverviewEventLog(props: OverviewEventLogProps) {
             <div class="ov-event-log-entry">
               <span class="ov-event-log-ts">${new Date(entry.ts).toLocaleTimeString()}</span>
               <span class="ov-event-log-name">${entry.event}</span>
-              ${entry.payload
-                ? html`<span class="ov-event-log-payload muted"
+              ${
+                entry.payload
+                  ? html`<span class="ov-event-log-payload muted"
                     >${formatEventPayload(entry.payload).slice(0, 120)}</span
                   >`
-                : nothing}
+                  : nothing
+              }
             </div>
           `,
         )}

--- a/ui/src/ui/views/overview.ts
+++ b/ui/src/ui/views/overview.ts
@@ -216,9 +216,10 @@ export function renderOverview(props: OverviewProps) {
               placeholder="ws://100.x.y.z:18789"
             />
           </label>
-          ${isTrustedProxy
-            ? ""
-            : html`
+          ${
+            isTrustedProxy
+              ? ""
+              : html`
                 <label class="field">
                   <span>${t("overview.access.token")}</span>
                   <div style="display: flex; align-items: center; gap: 8px;">
@@ -273,7 +274,8 @@ export function renderOverview(props: OverviewProps) {
                     </button>
                   </div>
                 </label>
-              `}
+              `
+          }
           <label class="field">
             <span>${t("overview.access.sessionKey")}</span>
             <input
@@ -307,13 +309,14 @@ export function renderOverview(props: OverviewProps) {
           <button class="btn" @click=${() => props.onConnect()}>${t("common.connect")}</button>
           <button class="btn" @click=${() => props.onRefresh()}>${t("common.refresh")}</button>
           <span class="muted"
-            >${isTrustedProxy
-              ? t("overview.access.trustedProxy")
-              : t("overview.access.connectHint")}</span
+            >${
+              isTrustedProxy ? t("overview.access.trustedProxy") : t("overview.access.connectHint")
+            }</span
           >
         </div>
-        ${!props.connected
-          ? html`
+        ${
+          !props.connected
+            ? html`
               <div class="login-gate__help" style="margin-top: 16px;">
                 <div class="login-gate__help-title">${t("overview.connection.title")}</div>
                 <ol class="login-gate__steps">
@@ -343,7 +346,8 @@ export function renderOverview(props: OverviewProps) {
                 </div>
               </div>
             `
-          : nothing}
+            : nothing
+        }
       </div>
 
       <div class="card">
@@ -367,22 +371,26 @@ export function renderOverview(props: OverviewProps) {
           <div class="stat">
             <div class="stat-label">${t("overview.snapshot.lastChannelsRefresh")}</div>
             <div class="stat-value">
-              ${props.lastChannelsRefresh
-                ? formatRelativeTimestamp(props.lastChannelsRefresh)
-                : t("common.na")}
+              ${
+                props.lastChannelsRefresh
+                  ? formatRelativeTimestamp(props.lastChannelsRefresh)
+                  : t("common.na")
+              }
             </div>
           </div>
         </div>
-        ${props.lastError
-          ? html`<div class="callout danger" style="margin-top: 14px;">
+        ${
+          props.lastError
+            ? html`<div class="callout danger" style="margin-top: 14px;">
               <div>${props.lastError}</div>
               ${pairingHint ?? ""} ${authHint ?? ""} ${insecureContextHint ?? ""}
             </div>`
-          : html`
+            : html`
               <div class="callout" style="margin-top: 14px">
                 ${t("overview.snapshot.channelsHint")}
               </div>
-            `}
+            `
+        }
       </div>
     </section>
 

--- a/ui/src/ui/views/sessions.ts
+++ b/ui/src/ui/views/sessions.ts
@@ -216,9 +216,11 @@ export function renderSessions(props: SessionsProps) {
         <div>
           <div class="card-title">Sessions</div>
           <div class="card-sub">
-            ${props.result
-              ? `Store: ${props.result.path}`
-              : "Active session keys and per-session overrides."}
+            ${
+              props.result
+                ? `Store: ${props.result.path}`
+                : "Active session keys and per-session overrides."
+            }
           </div>
         </div>
         <button class="btn" ?disabled=${props.loading} @click=${props.onRefresh}>
@@ -286,9 +288,11 @@ export function renderSessions(props: SessionsProps) {
         </label>
       </div>
 
-      ${props.error
-        ? html`<div class="callout danger" style="margin-bottom: 12px;">${props.error}</div>`
-        : nothing}
+      ${
+        props.error
+          ? html`<div class="callout danger" style="margin-bottom: 12px;">${props.error}</div>`
+          : nothing
+      }
 
       <div class="data-table-wrapper">
         <div class="data-table-toolbar">
@@ -302,8 +306,9 @@ export function renderSessions(props: SessionsProps) {
           </div>
         </div>
 
-        ${props.selectedKeys.size > 0
-          ? html`
+        ${
+          props.selectedKeys.size > 0
+            ? html`
               <div class="data-table-bulk-bar">
                 <span>${props.selectedKeys.size} selected</span>
                 <button class="btn btn--sm" @click=${props.onDeselectAll}>Unselect</button>
@@ -316,20 +321,26 @@ export function renderSessions(props: SessionsProps) {
                 </button>
               </div>
             `
-          : nothing}
+            : nothing
+        }
 
         <div class="data-table-container">
           <table class="data-table">
             <thead>
               <tr>
                 <th class="data-table-checkbox-col">
-                  ${paginated.length > 0
-                    ? html`<input
+                  ${
+                    paginated.length > 0
+                      ? html`<input
                         type="checkbox"
-                        .checked=${paginated.length > 0 &&
-                        paginated.every((r) => props.selectedKeys.has(r.key))}
-                        .indeterminate=${paginated.some((r) => props.selectedKeys.has(r.key)) &&
-                        !paginated.every((r) => props.selectedKeys.has(r.key))}
+                        .checked=${
+                          paginated.length > 0 &&
+                          paginated.every((r) => props.selectedKeys.has(r.key))
+                        }
+                        .indeterminate=${
+                          paginated.some((r) => props.selectedKeys.has(r.key)) &&
+                          !paginated.every((r) => props.selectedKeys.has(r.key))
+                        }
                         @change=${() => {
                           const allSelected = paginated.every((r) => props.selectedKeys.has(r.key));
                           if (allSelected) {
@@ -340,7 +351,8 @@ export function renderSessions(props: SessionsProps) {
                         }}
                         aria-label="Select all on page"
                       />`
-                    : nothing}
+                      : nothing
+                  }
                 </th>
                 ${sortHeader("key", "Key", "data-table-key-col")}
                 <th>Label</th>
@@ -353,34 +365,34 @@ export function renderSessions(props: SessionsProps) {
               </tr>
             </thead>
             <tbody>
-              ${paginated.length === 0
-                ? html`
-                    <tr>
-                      <td
-                        colspan="10"
-                        style="text-align: center; padding: 48px 16px; color: var(--muted)"
-                      >
-                        No sessions found.
-                      </td>
-                    </tr>
-                  `
-                : paginated.map((row) =>
-                    renderRow(
-                      row,
-                      props.basePath,
-                      props.onPatch,
-                      props.selectedKeys.has(row.key),
-                      props.onToggleSelect,
-                      props.loading,
-                      props.onNavigateToChat,
-                    ),
-                  )}
+              ${
+                paginated.length === 0
+                  ? html`
+                      <tr>
+                        <td colspan="10" style="text-align: center; padding: 48px 16px; color: var(--muted)">
+                          No sessions found.
+                        </td>
+                      </tr>
+                    `
+                  : paginated.map((row) =>
+                      renderRow(
+                        row,
+                        props.basePath,
+                        props.onPatch,
+                        props.selectedKeys.has(row.key),
+                        props.onToggleSelect,
+                        props.loading,
+                        props.onNavigateToChat,
+                      ),
+                    )
+              }
             </tbody>
           </table>
         </div>
 
-        ${totalRows > 0
-          ? html`
+        ${
+          totalRows > 0
+            ? html`
               <div class="data-table-pagination">
                 <div class="data-table-pagination__info">
                   ${page * props.pageSize + 1}-${Math.min((page + 1) * props.pageSize, totalRows)}
@@ -407,7 +419,8 @@ export function renderSessions(props: SessionsProps) {
                 </div>
               </div>
             `
-          : nothing}
+            : nothing
+        }
       </div>
     </section>
   `;
@@ -467,8 +480,9 @@ function renderRow(
       </td>
       <td class="data-table-key-col">
         <div class="mono session-key-cell">
-          ${canLink
-            ? html`<a
+          ${
+            canLink
+              ? html`<a
                 href=${chatUrl}
                 class="session-link"
                 @click=${(e: MouseEvent) => {
@@ -489,10 +503,13 @@ function renderRow(
                 }}
                 >${row.key}</a
               >`
-            : row.key}
-          ${showDisplayName
-            ? html`<span class="muted session-key-display-name">${displayName}</span>`
-            : nothing}
+              : row.key
+          }
+          ${
+            showDisplayName
+              ? html`<span class="muted session-key-display-name">${displayName}</span>`
+              : nothing
+          }
         </div>
       </td>
       <td>

--- a/ui/src/ui/views/skills-shared.ts
+++ b/ui/src/ui/views/skills-shared.ts
@@ -30,11 +30,23 @@ export function renderSkillStatusChips(params: {
   return html`
     <div class="chip-row" style="margin-top: 6px;">
       <span class="chip">${skill.source}</span>
-      ${showBundledBadge ? html` <span class="chip">bundled</span> ` : nothing}
+      ${
+        showBundledBadge
+          ? html`
+              <span class="chip">bundled</span>
+            `
+          : nothing
+      }
       <span class="chip ${skill.eligible ? "chip-ok" : "chip-warn"}">
         ${skill.eligible ? "eligible" : "blocked"}
       </span>
-      ${skill.disabled ? html` <span class="chip chip-warn">disabled</span> ` : nothing}
+      ${
+        skill.disabled
+          ? html`
+              <span class="chip chip-warn">disabled</span>
+            `
+          : nothing
+      }
     </div>
   `;
 }

--- a/ui/src/ui/views/skills.ts
+++ b/ui/src/ui/views/skills.ts
@@ -160,18 +160,21 @@ export function renderSkills(props: SkillsProps) {
         <div class="muted">${filtered.length} shown</div>
       </div>
 
-      ${props.error
-        ? html`<div class="callout danger" style="margin-top: 12px;">${props.error}</div>`
-        : nothing}
-      ${filtered.length === 0
-        ? html`
+      ${
+        props.error
+          ? html`<div class="callout danger" style="margin-top: 12px;">${props.error}</div>`
+          : nothing
+      }
+      ${
+        filtered.length === 0
+          ? html`
             <div class="muted" style="margin-top: 16px">
-              ${!props.connected && !props.report
-                ? "Not connected to gateway."
-                : "No skills found."}
+              ${
+                !props.connected && !props.report ? "Not connected to gateway." : "No skills found."
+              }
             </div>
           `
-        : html`
+          : html`
             <div class="agent-skills-groups" style="margin-top: 16px;">
               ${groups.map((group) => {
                 return html`
@@ -187,7 +190,8 @@ export function renderSkills(props: SkillsProps) {
                 `;
               })}
             </div>
-          `}
+          `
+      }
     </section>
 
     ${detailSkill ? renderSkillDetail(detailSkill, props) : nothing}
@@ -283,8 +287,9 @@ function renderSkillDetail(skill: SkillStatusEntry, props: SkillsProps) {
             ${renderSkillStatusChips({ skill, showBundledBadge })}
           </div>
 
-          ${missing.length > 0
-            ? html`
+          ${
+            missing.length > 0
+              ? html`
                 <div
                   class="callout"
                   style="border-color: var(--warn-subtle); background: var(--warn-subtle); color: var(--warn);"
@@ -293,12 +298,15 @@ function renderSkillDetail(skill: SkillStatusEntry, props: SkillsProps) {
                   <div>${missing.join(", ")}</div>
                 </div>
               `
-            : nothing}
-          ${reasons.length > 0
-            ? html`
+              : nothing
+          }
+          ${
+            reasons.length > 0
+              ? html`
                 <div class="muted" style="font-size: 13px;">Reason: ${reasons.join(", ")}</div>
               `
-            : nothing}
+              : nothing
+          }
 
           <div style="display: flex; align-items: center; gap: 12px;">
             <label class="skill-toggle-wrap">
@@ -313,24 +321,29 @@ function renderSkillDetail(skill: SkillStatusEntry, props: SkillsProps) {
             <span style="font-size: 13px; font-weight: 500;">
               ${skill.disabled ? "Disabled" : "Enabled"}
             </span>
-            ${canInstall
-              ? html`<button
+            ${
+              canInstall
+                ? html`<button
                   class="btn"
                   ?disabled=${busy}
                   @click=${() => props.onInstall(skill.skillKey, skill.name, skill.install[0].id)}
                 >
                   ${busy ? "Installing\u2026" : skill.install[0].label}
                 </button>`
-              : nothing}
+                : nothing
+            }
           </div>
 
-          ${message
-            ? html`<div class="callout ${message.kind === "error" ? "danger" : "success"}">
+          ${
+            message
+              ? html`<div class="callout ${message.kind === "error" ? "danger" : "success"}">
                 ${message.message}
               </div>`
-            : nothing}
-          ${skill.primaryEnv
-            ? html`
+              : nothing
+          }
+          ${
+            skill.primaryEnv
+              ? html`
                 <div style="display: grid; gap: 8px;">
                   <div class="field">
                     <span
@@ -366,7 +379,8 @@ function renderSkillDetail(skill: SkillStatusEntry, props: SkillsProps) {
                   </button>
                 </div>
               `
-            : nothing}
+              : nothing
+          }
 
           <div
             style="border-top: 1px solid var(--border); padding-top: 12px; display: grid; gap: 6px; font-size: 12px; color: var(--muted);"

--- a/ui/src/ui/views/usage-render-details.ts
+++ b/ui/src/ui/views/usage-render-details.ts
@@ -114,11 +114,13 @@ function renderSessionSummary(
     })) ?? [];
 
   return html`
-    ${badges.length > 0
-      ? html`<div class="usage-badges">
+    ${
+      badges.length > 0
+        ? html`<div class="usage-badges">
           ${badges.map((b) => html`<span class="usage-badge">${b}</span>`)}
         </div>`
-      : nothing}
+        : nothing
+    }
     <div class="session-summary-grid">
       <div class="stat session-summary-card">
         <div class="session-summary-title">${t("usage.overview.messages")}</div>
@@ -143,8 +145,10 @@ function renderSessionSummary(
       <div class="stat session-summary-card">
         <div class="session-summary-title">${t("usage.details.duration")}</div>
         <div class="stat-value session-summary-value">
-          ${formatDurationCompact(usage.durationMs, { spaced: true }) ??
-          t("usage.common.emptyValue")}
+          ${
+            formatDurationCompact(usage.durationMs, { spaced: true }) ??
+            t("usage.common.emptyValue")
+          }
         </div>
         <div class="session-summary-meta">
           ${formatTs(usage.firstActivity)} → ${formatTs(usage.lastActivity)}
@@ -271,14 +275,17 @@ function renderSessionDetailPanel(
         <div class="session-detail-header-left">
           <div class="session-detail-title">
             ${displayLabel}
-            ${cursorIndicator
-              ? html`<span class="session-detail-indicator">${cursorIndicator}</span>`
-              : nothing}
+            ${
+              cursorIndicator
+                ? html`<span class="session-detail-indicator">${cursorIndicator}</span>`
+                : nothing
+            }
           </div>
         </div>
         <div class="session-detail-stats">
-          ${usage
-            ? html`
+          ${
+            usage
+              ? html`
                 <span
                   ><strong>${formatTokens(headerStats.totalTokens)}</strong> ${t(
                     "usage.metrics.tokens",
@@ -286,7 +293,8 @@ function renderSessionDetailPanel(
                 >
                 <span><strong>${formatCost(headerStats.totalCost)}</strong>${cursorIndicator}</span>
               `
-            : nothing}
+              : nothing
+          }
         </div>
         <button
           class="btn btn--sm btn--ghost"
@@ -480,8 +488,9 @@ function renderTimeSeriesCompact(
       <div class="timeseries-header-row">
         <div class="card-title usage-section-title">${t("usage.details.usageOverTime")}</div>
         <div class="timeseries-controls">
-          ${hasSelection
-            ? html`
+          ${
+            hasSelection
+              ? html`
                 <div class="chart-toggle small">
                   <button
                     class="btn btn--sm toggle-btn active"
@@ -491,7 +500,8 @@ function renderTimeSeriesCompact(
                   </button>
                 </div>
               `
-            : nothing}
+              : nothing
+          }
           <div class="chart-toggle small">
             <button
               class="btn btn--sm toggle-btn ${!isCumulative ? "active" : ""}"
@@ -506,8 +516,9 @@ function renderTimeSeriesCompact(
               ${t("usage.details.cumulative")}
             </button>
           </div>
-          ${!isCumulative
-            ? html`
+          ${
+            !isCumulative
+              ? html`
                 <div class="chart-toggle small">
                   <button
                     class="btn btn--sm toggle-btn ${breakdownMode === "total" ? "active" : ""}"
@@ -523,7 +534,8 @@ function renderTimeSeriesCompact(
                   </button>
                 </div>
               `
-            : nothing}
+              : nothing
+          }
         </div>
       </div>
       <div class="timeseries-chart-wrapper">
@@ -562,12 +574,14 @@ function renderTimeSeriesCompact(
             0
           </text>
           <!-- X axis labels (first and last) -->
-          ${points.length > 0
-            ? svg`
+          ${
+            points.length > 0
+              ? svg`
             <text x="${padding.left}" y="${padding.top + chartHeight + 10}" text-anchor="start" class="ts-axis-label">${new Date(points[0].timestamp).toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" })}</text>
             <text x="${width - padding.right}" y="${padding.top + chartHeight + 10}" text-anchor="end" class="ts-axis-label">${new Date(points[points.length - 1].timestamp).toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" })}</text>
           `
-            : nothing}
+              : nothing
+          }
           <!-- Bars -->
           ${points.map((p, i) => {
             const val = barTotals[i];
@@ -721,8 +735,9 @@ function renderTimeSeriesCompact(
         })()}
       </div>
       <div class="timeseries-summary">
-        ${hasSelection
-          ? html`
+        ${
+          hasSelection
+            ? html`
               <span class="timeseries-summary__range">
                 ${t("usage.details.turnRange", {
                   start: String(rangeStartIdx + 1),
@@ -744,11 +759,13 @@ function renderTimeSeriesCompact(
               )}
               · ${formatCost(filteredPoints.reduce((s, p) => s + (p.cost || 0), 0))}
             `
-          : html`${points.length} ${t("usage.overview.messagesAbbrev")} · ${formatTokens(cumTokens)}
-            · ${formatCost(cumCost)}`}
+            : html`${points.length} ${t("usage.overview.messagesAbbrev")} · ${formatTokens(cumTokens)}
+            · ${formatCost(cumCost)}`
+        }
       </div>
-      ${breakdownByType
-        ? html`
+      ${
+        breakdownByType
+          ? html`
             <div class="timeseries-breakdown">
               <div class="card-title usage-section-title">${t("usage.breakdown.tokensByType")}</div>
               <div class="cost-breakdown-bar cost-breakdown-bar--compact">
@@ -792,7 +809,8 @@ function renderTimeSeriesCompact(
               </div>
             </div>
           `
-        : nothing}
+          : nothing
+      }
     </div>
   `;
 }
@@ -851,11 +869,13 @@ function renderContextPanel(
         <div class="card-title usage-section-title">
           ${t("usage.details.systemPromptBreakdown")}
         </div>
-        ${hasMore
-          ? html`<button class="btn btn--sm" @click=${onToggleExpanded}>
+        ${
+          hasMore
+            ? html`<button class="btn btn--sm" @click=${onToggleExpanded}>
               ${showAll ? t("usage.details.collapse") : t("usage.details.expandAll")}
             </button>`
-          : nothing}
+            : nothing
+        }
       </div>
       <p class="context-weight-desc">${contextPct || t("usage.details.baseContextPerMessage")}</p>
       <div class="context-stacked-bar">
@@ -902,10 +922,11 @@ function renderContextPanel(
         ${t("usage.breakdown.total")}: ~${formatTokens(totalContextTokens)}
       </div>
       <div class="context-breakdown-grid">
-        ${skillsList.length > 0
-          ? (() => {
-              const more = skillsList.length - skillsTop.length;
-              return html`
+        ${
+          skillsList.length > 0
+            ? (() => {
+                const more = skillsList.length - skillsTop.length;
+                return html`
                 <div class="context-breakdown-card">
                   <div class="context-breakdown-title">
                     ${t("usage.details.skills")} (${skillsList.length})
@@ -920,21 +941,25 @@ function renderContextPanel(
                       `,
                     )}
                   </div>
-                  ${more > 0
-                    ? html`
+                  ${
+                    more > 0
+                      ? html`
                         <div class="context-breakdown-more">
                           ${t("usage.sessions.more", { count: String(more) })}
                         </div>
                       `
-                    : nothing}
+                      : nothing
+                  }
                 </div>
               `;
-            })()
-          : nothing}
-        ${toolsList.length > 0
-          ? (() => {
-              const more = toolsList.length - toolsTop.length;
-              return html`
+              })()
+            : nothing
+        }
+        ${
+          toolsList.length > 0
+            ? (() => {
+                const more = toolsList.length - toolsTop.length;
+                return html`
                 <div class="context-breakdown-card">
                   <div class="context-breakdown-title">
                     ${t("usage.details.tools")} (${toolsList.length})
@@ -951,21 +976,25 @@ function renderContextPanel(
                       `,
                     )}
                   </div>
-                  ${more > 0
-                    ? html`
+                  ${
+                    more > 0
+                      ? html`
                         <div class="context-breakdown-more">
                           ${t("usage.sessions.more", { count: String(more) })}
                         </div>
                       `
-                    : nothing}
+                      : nothing
+                  }
                 </div>
               `;
-            })()
-          : nothing}
-        ${filesList.length > 0
-          ? (() => {
-              const more = filesList.length - filesTop.length;
-              return html`
+              })()
+            : nothing
+        }
+        ${
+          filesList.length > 0
+            ? (() => {
+                const more = filesList.length - filesTop.length;
+                return html`
                 <div class="context-breakdown-card">
                   <div class="context-breakdown-title">
                     ${t("usage.details.files")} (${filesList.length})
@@ -982,17 +1011,20 @@ function renderContextPanel(
                       `,
                     )}
                   </div>
-                  ${more > 0
-                    ? html`
+                  ${
+                    more > 0
+                      ? html`
                         <div class="context-breakdown-more">
                           ${t("usage.sessions.more", { count: String(more) })}
                         </div>
                       `
-                    : nothing}
+                      : nothing
+                  }
                 </div>
               `;
-            })()
-          : nothing}
+              })()
+            : nothing
+        }
       </div>
     </div>
   `;
@@ -1177,8 +1209,9 @@ function renderSessionLogsCompact(
                 ${log.tokens ? html`<span>${formatTokens(log.tokens)}</span>` : nothing}
               </div>
               <div class="session-log-content">${cleanContent}</div>
-              ${toolInfo.tools.length > 0
-                ? html`
+              ${
+                toolInfo.tools.length > 0
+                  ? html`
                     <details class="session-log-tools" ?open=${expandedAll}>
                       <summary>${toolInfo.summary}</summary>
                       <div class="session-log-tools-list">
@@ -1190,17 +1223,20 @@ function renderSessionLogsCompact(
                       </div>
                     </details>
                   `
-                : nothing}
+                  : nothing
+              }
             </div>
           `;
         })}
-        ${filteredEntries.length === 0
-          ? html`
+        ${
+          filteredEntries.length === 0
+            ? html`
               <div class="usage-empty-block usage-empty-block--compact">
                 ${t("usage.details.noMessagesMatch")}
               </div>
             `
-          : nothing}
+            : nothing
+        }
       </div>
     </div>
   `;

--- a/ui/src/ui/views/usage-render-overview.ts
+++ b/ui/src/ui/views/usage-render-overview.ts
@@ -93,8 +93,9 @@ function renderFilterChips(
 
   return html`
     <div class="active-filters">
-      ${selectedDays.length > 0
-        ? html`
+      ${
+        selectedDays.length > 0
+          ? html`
             <div class="filter-chip">
               <span class="filter-chip-label">${t("usage.filters.days")}: ${daysLabel}</span>
               <button
@@ -107,9 +108,11 @@ function renderFilterChips(
               </button>
             </div>
           `
-        : nothing}
-      ${selectedHours.length > 0
-        ? html`
+          : nothing
+      }
+      ${
+        selectedHours.length > 0
+          ? html`
             <div class="filter-chip">
               <span class="filter-chip-label">${t("usage.filters.hours")}: ${hoursLabel}</span>
               <button
@@ -122,9 +125,11 @@ function renderFilterChips(
               </button>
             </div>
           `
-        : nothing}
-      ${selectedSessions.length > 0
-        ? html`
+          : nothing
+      }
+      ${
+        selectedSessions.length > 0
+          ? html`
             <div class="filter-chip" title="${sessionsFullName}">
               <span class="filter-chip-label">${t("usage.filters.session")}: ${sessionsLabel}</span>
               <button
@@ -137,14 +142,17 @@ function renderFilterChips(
               </button>
             </div>
           `
-        : nothing}
-      ${(selectedDays.length > 0 || selectedHours.length > 0) && selectedSessions.length > 0
-        ? html`
+          : nothing
+      }
+      ${
+        (selectedDays.length > 0 || selectedHours.length > 0) && selectedSessions.length > 0
+          ? html`
             <button class="btn btn--sm" @click=${onClearFilters}>
               ${t("usage.filters.clearAll")}
             </button>
           `
-        : nothing}
+          : nothing
+      }
     </div>
   `;
 }
@@ -259,8 +267,9 @@ function renderDailyChartCompact(
                 class="daily-bar-wrapper ${isSelected ? "selected" : ""}"
                 @click=${(e: MouseEvent) => onSelectDay(d.date, e.shiftKey)}
               >
-                ${dailyChartMode === "by-type"
-                  ? html`
+                ${
+                  dailyChartMode === "by-type"
+                    ? html`
                       <div
                         class="daily-bar daily-bar--stacked"
                         style="height: ${heightPx.toFixed(0)}px;"
@@ -278,16 +287,19 @@ function renderDailyChartCompact(
                         })()}
                       </div>
                     `
-                  : html` <div class="daily-bar" style="height: ${heightPx.toFixed(0)}px"></div> `}
+                    : html` <div class="daily-bar" style="height: ${heightPx.toFixed(0)}px"></div> `
+                }
                 ${showTotals ? html`<div class="daily-bar-total">${totalLabel}</div>` : nothing}
                 <div class="${labelClass}">${shortLabel}</div>
                 <div class="daily-bar-tooltip">
                   <strong>${formatFullDate(d.date)}</strong><br />
                   ${formatTokens(d.totalTokens)} ${t("usage.metrics.tokens").toLowerCase()}<br />
                   ${formatCost(d.totalCost)}
-                  ${breakdownLines.length
-                    ? html`${breakdownLines.map((line) => html`<div>${line}</div>`)}`
-                    : nothing}
+                  ${
+                    breakdownLines.length
+                      ? html`${breakdownLines.map((line) => html`<div>${line}</div>`)}`
+                      : nothing
+                  }
                 </div>
               </div>
             `;
@@ -318,34 +330,34 @@ function renderCostBreakdownCompact(totals: UsageTotals, mode: "tokens" | "cost"
         <div
           class="cost-segment output"
           style="width: ${(isTokenMode ? tokenPcts.output : breakdown.output.pct).toFixed(1)}%"
-          title="${t("usage.breakdown.output")}: ${isTokenMode
-            ? formatTokens(totals.output)
-            : formatCost(breakdown.output.cost)}"
+          title="${t("usage.breakdown.output")}: ${
+            isTokenMode ? formatTokens(totals.output) : formatCost(breakdown.output.cost)
+          }"
         ></div>
         <div
           class="cost-segment input"
           style="width: ${(isTokenMode ? tokenPcts.input : breakdown.input.pct).toFixed(1)}%"
-          title="${t("usage.breakdown.input")}: ${isTokenMode
-            ? formatTokens(totals.input)
-            : formatCost(breakdown.input.cost)}"
+          title="${t("usage.breakdown.input")}: ${
+            isTokenMode ? formatTokens(totals.input) : formatCost(breakdown.input.cost)
+          }"
         ></div>
         <div
           class="cost-segment cache-write"
           style="width: ${(isTokenMode ? tokenPcts.cacheWrite : breakdown.cacheWrite.pct).toFixed(
             1,
           )}%"
-          title="${t("usage.breakdown.cacheWrite")}: ${isTokenMode
-            ? formatTokens(totals.cacheWrite)
-            : formatCost(breakdown.cacheWrite.cost)}"
+          title="${t("usage.breakdown.cacheWrite")}: ${
+            isTokenMode ? formatTokens(totals.cacheWrite) : formatCost(breakdown.cacheWrite.cost)
+          }"
         ></div>
         <div
           class="cost-segment cache-read"
           style="width: ${(isTokenMode ? tokenPcts.cacheRead : breakdown.cacheRead.pct).toFixed(
             1,
           )}%"
-          title="${t("usage.breakdown.cacheRead")}: ${isTokenMode
-            ? formatTokens(totals.cacheRead)
-            : formatCost(breakdown.cacheRead.cost)}"
+          title="${t("usage.breakdown.cacheRead")}: ${
+            isTokenMode ? formatTokens(totals.cacheRead) : formatCost(breakdown.cacheRead.cost)
+          }"
         ></div>
       </div>
       <div class="cost-breakdown-legend">
@@ -359,15 +371,15 @@ function renderCostBreakdownCompact(totals: UsageTotals, mode: "tokens" | "cost"
         >
         <span class="legend-item"
           ><span class="legend-dot cache-write"></span>${t("usage.breakdown.cacheWrite")}
-          ${isTokenMode
-            ? formatTokens(totals.cacheWrite)
-            : formatCost(breakdown.cacheWrite.cost)}</span
+          ${
+            isTokenMode ? formatTokens(totals.cacheWrite) : formatCost(breakdown.cacheWrite.cost)
+          }</span
         >
         <span class="legend-item"
           ><span class="legend-dot cache-read"></span>${t("usage.breakdown.cacheRead")}
-          ${isTokenMode
-            ? formatTokens(totals.cacheRead)
-            : formatCost(breakdown.cacheRead.cost)}</span
+          ${
+            isTokenMode ? formatTokens(totals.cacheRead) : formatCost(breakdown.cacheRead.cost)
+          }</span
         >
       </div>
       <div class="cost-breakdown-total">
@@ -386,9 +398,10 @@ function renderInsightList(
   return html`
     <div class="usage-insight-card">
       <div class="usage-insight-title">${title}</div>
-      ${items.length === 0
-        ? html`<div class="muted">${emptyLabel}</div>`
-        : html`
+      ${
+        items.length === 0
+          ? html`<div class="muted">${emptyLabel}</div>`
+          : html`
             <div class="usage-list">
               ${items.map(
                 (item) => html`
@@ -402,7 +415,8 @@ function renderInsightList(
                 `,
               )}
             </div>
-          `}
+          `
+      }
     </div>
   `;
 }
@@ -421,9 +435,10 @@ function renderPeakErrorList(
   return html`
     <div class=${cardClass}>
       <div class="usage-insight-title">${title}</div>
-      ${items.length === 0
-        ? html`<div class="muted">${emptyLabel}</div>`
-        : html`
+      ${
+        items.length === 0
+          ? html`<div class="muted">${emptyLabel}</div>`
+          : html`
             <div class=${listClass}>
               ${items.map(
                 (item) => html`
@@ -435,7 +450,8 @@ function renderPeakErrorList(
                 `,
               )}
             </div>
-          `}
+          `
+      }
     </div>
   `;
 }
@@ -800,9 +816,11 @@ function renderSessionsCard(
       >
         <div class="session-bar-label">
           <div class="session-bar-title">${displayLabel}</div>
-          ${meta.length > 0
-            ? html`<div class="session-bar-meta">${meta.join(" · ")}</div>`
-            : nothing}
+          ${
+            meta.length > 0
+              ? html`<div class="session-bar-meta">${meta.join(" · ")}</div>`
+              : nothing
+          }
         </div>
         <div class="session-bar-actions">
           <button
@@ -837,9 +855,11 @@ function renderSessionsCard(
         <div class="card-title">${t("usage.sessions.title")}</div>
         <div class="sessions-card-count">
           ${t("usage.sessions.shown", { count: String(sessions.length) })}
-          ${totalSessions !== sessions.length
-            ? ` · ${t("usage.sessions.total", { count: String(totalSessions) })}`
-            : ""}
+          ${
+            totalSessions !== sessions.length
+              ? ` · ${t("usage.sessions.total", { count: String(totalSessions) })}`
+              : ""
+          }
         </div>
       </div>
       <div class="sessions-card-meta">
@@ -890,46 +910,55 @@ function renderSessionsCard(
         <button
           class="btn btn--sm"
           @click=${() => onSessionSortDirChange(sessionSortDir === "desc" ? "asc" : "desc")}
-          title=${sessionSortDir === "desc"
-            ? t("usage.sessions.descending")
-            : t("usage.sessions.ascending")}
+          title=${
+            sessionSortDir === "desc"
+              ? t("usage.sessions.descending")
+              : t("usage.sessions.ascending")
+          }
         >
           ${sessionSortDir === "desc" ? "↓" : "↑"}
         </button>
-        ${selectedCount > 0
-          ? html`
+        ${
+          selectedCount > 0
+            ? html`
               <button class="btn btn--sm" @click=${onClearSessions}>
                 ${t("usage.sessions.clearSelection")}
               </button>
             `
-          : nothing}
+            : nothing
+        }
       </div>
-      ${sessionsTab === "recent"
-        ? recentEntries.length === 0
-          ? html` <div class="usage-empty-block">${t("usage.sessions.noRecent")}</div> `
-          : html`
+      ${
+        sessionsTab === "recent"
+          ? recentEntries.length === 0
+            ? html` <div class="usage-empty-block">${t("usage.sessions.noRecent")}</div> `
+            : html`
               <div class="session-bars session-bars--recent">
                 ${recentEntries.map((s) => renderSessionBarRow(s, selectedSet.has(s.key)))}
               </div>
             `
-        : sessions.length === 0
-          ? html` <div class="usage-empty-block">${t("usage.sessions.noneInRange")}</div> `
-          : html`
+          : sessions.length === 0
+            ? html` <div class="usage-empty-block">${t("usage.sessions.noneInRange")}</div> `
+            : html`
               <div class="session-bars">
                 ${sortedWithDir
                   .slice(0, 50)
                   .map((s) => renderSessionBarRow(s, selectedSet.has(s.key)))}
-                ${sessions.length > 50
-                  ? html`
+                ${
+                  sessions.length > 50
+                    ? html`
                       <div class="usage-more-sessions">
                         ${t("usage.sessions.more", { count: String(sessions.length - 50) })}
                       </div>
                     `
-                  : nothing}
+                    : nothing
+                }
               </div>
-            `}
-      ${selectedCount > 1
-        ? html`
+            `
+      }
+      ${
+        selectedCount > 1
+          ? html`
             <div class="sessions-selected-group">
               <div class="sessions-card-count">
                 ${t("usage.sessions.selected", { count: String(selectedCount) })}
@@ -939,7 +968,8 @@ function renderSessionsCard(
               </div>
             </div>
           `
-        : nothing}
+          : nothing
+      }
     </div>
   `;
 }

--- a/ui/src/ui/views/usage.ts
+++ b/ui/src/ui/views/usage.ts
@@ -376,9 +376,11 @@ export function renderUsage(props: UsageProps) {
       >
         <summary>
           <span>${label}</span>
-          ${selectedCount > 0
-            ? html`<span class="usage-filter-badge">${selectedCount}</span>`
-            : html` <span class="usage-filter-badge">${t("usage.filters.all")}</span> `}
+          ${
+            selectedCount > 0
+              ? html`<span class="usage-filter-badge">${selectedCount}</span>`
+              : html` <span class="usage-filter-badge">${t("usage.filters.all")}</span> `
+          }
         </summary>
         <div class="usage-filter-popover">
           <div class="usage-filter-actions">
@@ -447,16 +449,21 @@ export function renderUsage(props: UsageProps) {
         <div class="usage-header-row">
           <div class="usage-header-title">
             <div class="card-title usage-section-title">${t("usage.filters.title")}</div>
-            ${data.loading
-              ? html`<span class="usage-refresh-indicator">${t("usage.loading.badge")}</span>`
-              : nothing}
-            ${isEmpty
-              ? html`<span class="usage-query-hint">${t("usage.empty.hint")}</span>`
-              : nothing}
+            ${
+              data.loading
+                ? html`<span class="usage-refresh-indicator">${t("usage.loading.badge")}</span>`
+                : nothing
+            }
+            ${
+              isEmpty
+                ? html`<span class="usage-query-hint">${t("usage.empty.hint")}</span>`
+                : nothing
+            }
           </div>
           <div class="usage-header-metrics">
-            ${displayTotals
-              ? html`
+            ${
+              displayTotals
+                ? html`
                   <span class="usage-metric-badge">
                     <strong>${formatTokens(displayTotals.totalTokens)}</strong>
                     ${t("usage.metrics.tokens")}
@@ -467,12 +474,15 @@ export function renderUsage(props: UsageProps) {
                   </span>
                   <span class="usage-metric-badge">
                     <strong>${displaySessionCount}</strong>
-                    ${displaySessionCount === 1
-                      ? t("usage.metrics.session")
-                      : t("usage.metrics.sessions")}
+                    ${
+                      displaySessionCount === 1
+                        ? t("usage.metrics.session")
+                        : t("usage.metrics.sessions")
+                    }
                   </span>
                 `
-              : nothing}
+                : nothing
+            }
             <button
               class="btn btn--sm usage-pin-btn ${display.headerPinned ? "active" : ""}"
               title=${display.headerPinned ? t("usage.filters.unpin") : t("usage.filters.pin")}
@@ -654,20 +664,24 @@ export function renderUsage(props: UsageProps) {
               >
                 ${t("usage.query.apply")}
               </button>
-              ${hasDraftQuery || hasQuery
-                ? html`
+              ${
+                hasDraftQuery || hasQuery
+                  ? html`
                     <button class="btn btn--sm" @click=${filterActions.onClearQuery}>
                       ${t("usage.filters.clear")}
                     </button>
                   `
-                : nothing}
+                  : nothing
+              }
               <span class="usage-query-hint">
-                ${hasQuery
-                  ? t("usage.query.matching", {
-                      shown: String(filteredSessions.length),
-                      total: String(totalSessions),
-                    })
-                  : t("usage.query.inRange", { total: String(totalSessions) })}
+                ${
+                  hasQuery
+                    ? t("usage.query.matching", {
+                        shown: String(filteredSessions.length),
+                        total: String(totalSessions),
+                      })
+                    : t("usage.query.inRange", { total: String(totalSessions) })
+                }
               </span>
             </div>
           </div>
@@ -679,8 +693,9 @@ export function renderUsage(props: UsageProps) {
             ${renderFilterSelect("tool", t("usage.filters.tool"), toolOptions)}
             <span class="usage-query-hint">${t("usage.query.tip")}</span>
           </div>
-          ${queryTerms.length > 0
-            ? html`
+          ${
+            queryTerms.length > 0
+              ? html`
                 <div class="usage-query-chips">
                   ${queryTerms.map((term) => {
                     const label = term.raw;
@@ -701,9 +716,11 @@ export function renderUsage(props: UsageProps) {
                   })}
                 </div>
               `
-            : nothing}
-          ${querySuggestions.length > 0
-            ? html`
+              : nothing
+          }
+          ${
+            querySuggestions.length > 0
+              ? html`
                 <div class="usage-query-suggestions">
                   ${querySuggestions.map(
                     (suggestion) => html`
@@ -720,29 +737,35 @@ export function renderUsage(props: UsageProps) {
                   )}
                 </div>
               `
-            : nothing}
-          ${queryWarnings.length > 0
-            ? html`
+              : nothing
+          }
+          ${
+            queryWarnings.length > 0
+              ? html`
                 <div class="callout warning usage-callout usage-callout--tight">
                   ${queryWarnings.join(" · ")}
                 </div>
               `
-            : nothing}
+              : nothing
+          }
         </div>
 
-        ${data.error
-          ? html`<div class="callout danger usage-callout">${data.error}</div>`
-          : nothing}
-        ${data.sessionsLimitReached
-          ? html`
+        ${
+          data.error ? html`<div class="callout danger usage-callout">${data.error}</div>` : nothing
+        }
+        ${
+          data.sessionsLimitReached
+            ? html`
               <div class="callout warning usage-callout">${t("usage.sessions.limitReached")}</div>
             `
-          : nothing}
+            : nothing
+        }
       </section>
 
-      ${isEmpty
-        ? renderUsageEmptyState(filterActions.onRefresh)
-        : html`
+      ${
+        isEmpty
+          ? renderUsageEmptyState(filterActions.onRefresh)
+          : html`
             ${renderUsageInsights(
               displayTotals,
               activeAggregates,
@@ -770,9 +793,11 @@ export function renderUsage(props: UsageProps) {
                     displayActions.onDailyChartModeChange,
                     filterActions.onSelectDay,
                   )}
-                  ${displayTotals
-                    ? renderCostBreakdownCompact(displayTotals, display.chartMode)
-                    : nothing}
+                  ${
+                    displayTotals
+                      ? renderCostBreakdownCompact(displayTotals, display.chartMode)
+                      : nothing
+                  }
                 </div>
                 ${renderSessionsCard(
                   filteredSessions,
@@ -792,8 +817,9 @@ export function renderUsage(props: UsageProps) {
                   filterActions.onClearSessions,
                 )}
               </div>
-              ${primarySelectedEntry
-                ? html`<div class="usage-grid-column">
+              ${
+                primarySelectedEntry
+                  ? html`<div class="usage-grid-column">
                     ${renderSessionDetailPanel(
                       primarySelectedEntry,
                       detail.timeSeries,
@@ -823,9 +849,11 @@ export function renderUsage(props: UsageProps) {
                       filterActions.onClearSessions,
                     )}
                   </div>`
-                : nothing}
+                  : nothing
+              }
             </div>
-          `}
+          `
+      }
     </div>
   `;
 }


### PR DESCRIPTION
## Summary

- Problem: Signal inbound normalization only extracted a narrow subset of signal-cli payloads — flattening media to the first attachment, dropping quote identifiers/authors, edit targets, stickers, polls, contacts, link previews, text style metadata, and attachment captions/dimensions before `MsgContext` / conversation-info generation. Additionally, mention/command gating operated on style-rendered text, and the debounce join used an escaped `\\n` literal instead of a real newline.
- Why it matters: Downstream hooks, templates, and agents lose reply/edit context and multi-attachment detail; styled text can interfere with mention or control-command detection; debounce concatenation produced literal `\n` in message bodies instead of actual line breaks.
- What changed:
  - Expanded `extensions/signal/src/monitor/event-handler.ts` to extract and normalize: multi-attachment arrays with captions/dimensions, quote/reply metadata (`ReplyToId`/`ReplyToBody`/`ReplyToSender`/`ReplyToIsQuote`), edit tracking (`EditTargetTimestamp`/`EditOriginalBody`), sticker handling, shared contacts, polls (create/vote/terminate), link previews, and Signal text styles (bold/italic/monospace/strikethrough/spoiler → markdown).
  - Added `extensions/signal/src/monitor/message-cache.ts` — an in-memory LRU cache (max 2000, 6h TTL) used to resolve original body text when an edited message arrives.
  - Updated `extensions/signal/src/monitor/mentions.ts` to return offset shift metadata so text style ranges can be adjusted after mention placeholder expansion.
  - Added `channels.signal.injectLinkPreviews` and `channels.signal.preserveTextStyles` config toggles (both default `true`).
  - Enriched `src/auto-reply/media-note.ts` to include captions and dimensions in media-attached notes.
  - Threaded `edit_target_id` / `has_edit_context` into conversation-info via `src/auto-reply/reply/inbound-meta.ts`.
  - Normalized MIME classification in `src/media/constants.ts` to tolerate whitespace, mixed casing, and parameters (e.g. `IMAGE/JPEG; charset=utf-8`).
  - Added `MsgContext` fields: `EditTargetTimestamp`, `EditOriginalBody`, `MediaCaption`, `MediaCaptions`, `MediaDimension`, `MediaDimensions`.
  - Fixed debounce join from escaped `\\n` to real `\n`.
  - Switched command/mention gating to use plain text (pre-style-render) to prevent markdown markers from interfering with detection.
  - Attachment fetching now uses `Promise.allSettled` so one failed download doesn't block the rest.
  - Edits are excluded from debounce; media/reply/edit fields are cleared on merge; `UntrustedContext` arrays are merged across debounced entries.
- What did NOT change (scope boundary): No outbound Signal actions, no unsend/delete support, no new attachment-timeout/retry config, and no non-Signal channel behavior changes beyond the shared media-note/MIME/inbound-meta plumbing needed to surface the new Signal context.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #21958
- Related #10637, #13106, #18552
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `extensions/signal/src/monitor/event-handler.types.ts` and `extensions/signal/src/monitor/event-handler.ts` only modeled/extracted `message`, `attachments`, `mentions`, `quote.text`, and reactions. The handler flattened attachments to singular fields, ignored richer signal-cli payload fields (stickers, contacts, polls, link previews, text styles, edit targets, attachment dimensions/captions), and ran mention/command gating on the post-rendered body.
- Missing detection / guardrail: No Signal handler coverage for multi-attachment arrays, quote ids/authors, edit targets, stickers, polls, contacts, link previews, mention/style offset alignment, debounce metadata preservation, or MIME strings with whitespace/casing/parameters. The debounce join string was `"\\n"` (two characters) instead of `"\n"` (newline).
- Prior context (`git blame`, prior PR, issue, or refactor if known): The narrow normalization surface traces back to `4540c6b3bc` (`refactor(signal): move Signal channel code to extensions/signal/src/`), which carried forward the older limited payload mapping.
- Why this regressed now: Longstanding fidelity gap rather than a fresh regression — became more visible once users started relying on richer Signal inbound events and grouped/edited traffic (see #21958).
- If unknown, what was ruled out: N/A — root cause is clear.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `extensions/signal/src/monitor/event-handler.inbound-context.test.ts` (27 new tests)
  - `extensions/signal/src/monitor/event-handler.mention-gating.test.ts` (1 new test)
  - `extensions/signal/src/monitor/mentions.test.ts` (4 new tests)
  - `extensions/signal/src/monitor/message-cache.test.ts` (4 new tests)
  - `src/auto-reply/media-note.test.ts` (2 new tests)
  - `src/auto-reply/reply/inbound-meta.test.ts` (2 new tests)
- Scenario the test should lock in: Multi-attachment arrays plus first-item aliases; partial attachment fetch survival (`Promise.allSettled`); quote/edit/sticker/contact/poll/link-preview mapping; style/mention offset alignment; debounce merge boundaries (edits excluded, metadata cleared, `UntrustedContext` merged); edit-target conversation-info threading; MIME normalization with whitespace/casing/parameters; caption/dimension propagation; config toggles for `injectLinkPreviews` and `preserveTextStyles`.
- Why this is the smallest reliable guardrail: The Signal handler tests exercise the actual inbound normalization path without a live daemon, while the shared helper unit tests lock the downstream formatting/metadata behavior.
- Existing test that already covers this (if any): Preexisting inbound context contract assertions covered the base `MsgContext` shape but not the richer Signal-specific payload fields or the plain-text gating path.
- If no new test is added, why not: N/A — ~40 new tests added.

## User-visible / Behavior Changes

- Signal inbound `MsgContext` now preserves `MediaPaths` / `MediaTypes` / `MediaCaptions` / `MediaDimensions` arrays, with first-item aliases (`MediaPath` / `MediaType` / `MediaCaption` / `MediaDimension`) for backward compatibility.
- Quote/reply messages now forward `ReplyToId`, `ReplyToBody`, `ReplyToSender`, and `ReplyToIsQuote`.
- Edited messages forward `EditTargetTimestamp`; downstream conversation-info exposes `edit_target_id` / `has_edit_context`. Original body resolved via in-memory cache appears as `EditOriginalBody`.
- Stickers download as media attachments with `UntrustedContext` entries: `Signal sticker packId: <id>`, `Signal stickerId: <id>`. Body receives `<media:sticker>` placeholder.
- Shared contacts produce `UntrustedContext` entries (`Shared contact: <name> (<details>)`) and `<media:contact>` placeholder.
- Polls: creation → `[Poll] <question>` body + context; vote → `[Poll vote]` body + context; close → `[Poll closed]` body + context.
- Link previews extracted into `UntrustedContext` as `Link preview: <title> - <description> (<url>)`. Controlled by `channels.signal.injectLinkPreviews` (default: `true`).
- Signal text styles (bold, italic, monospace, strikethrough, spoiler) rendered as markdown. Controlled by `channels.signal.preserveTextStyles` (default: `true`).
- Mention detection and control-command gating now run on plain text (pre-style-render) to prevent false negatives from markdown markers.
- Debounce join now produces real newlines instead of literal `\n` strings.
- Media notes now include attachment captions and dimensions when present.
- MIME classification now tolerates whitespace, mixed casing, and parameterized content types.

## Diagram (if applicable)

```text
Before:
signal-cli payload -> event-handler -> flatten to first attachment, drop quote/edit/sticker/poll/contact/preview -> MsgContext

After:
signal-cli payload -> event-handler -> extract all attachments, quotes, edits, stickers, polls,
                                        contacts, link previews, text styles -> message-cache (for edits)
                                     -> mention expansion with offset shifts -> style rendering
                                     -> plain-text gating for commands/mentions
                                     -> MsgContext with full metadata arrays + UntrustedContext
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) `No`
- Secrets/tokens handling changed? (`Yes/No`) `No`
- New/changed network calls? (`Yes/No`) `No`
- Command/tool execution surface changed? (`Yes/No`) `No`
- Data access scope changed? (`Yes/No`) `Yes`
- If any `Yes`, explain risk + mitigation: This PR exposes more already-received Signal message metadata to agents/hooks/templates (quotes, edit targets, contact cards, polls, link previews, captions, dimensions, sticker metadata). The data remains user-supplied; provider-specific strings are routed into `UntrustedContext` (documented as untrusted), mention/command gating now uses plain text to avoid markdown-induced false negatives, and both link-preview injection and style preservation can be disabled per account via config toggles.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+, pnpm
- Model/provider: N/A (inbound normalization, no model calls)
- Integration/channel (if any): Signal (`extensions/signal`)
- Relevant config (redacted): Default test harness; targeted debounce cases used `messages.inbound.debounceMs: 50`; media cases set `ignoreAttachments: false`

### Steps

1. Feed Signal receive payloads containing multiple attachments, quotes, edits, stickers, contacts, polls, link previews, and text styles into `createSignalEventHandler`.
2. Inspect the finalized `MsgContext` / inbound conversation-info payload for plural media fields, reply/edit metadata, `UntrustedContext`, and plain-text gating.
3. Run targeted tests.

### Expected

- Rich Signal payload fields survive inbound normalization without breaking mention or command gating; edit metadata stays bound to the edited message; multi-attachment/media metadata remains aligned.

### Actual

- Before: handler collapsed media to first attachment, only kept `quote.text`, dropped sticker/contact/poll/link-preview/style/edit-target fields, used styled text for command gating, debounce join produced literal `\n`.
- After: all fields preserved and tested.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Local validation:

- `pnpm test -- extensions/signal/src/monitor/event-handler.inbound-context.test.ts extensions/signal/src/monitor/event-handler.mention-gating.test.ts extensions/signal/src/monitor/mentions.test.ts extensions/signal/src/monitor/message-cache.test.ts src/auto-reply/media-note.test.ts src/auto-reply/reply/inbound-meta.test.ts` — all tests pass
- `pnpm build` — passed
- `pnpm config:docs:check` — passed

## Human Verification (required)

- Verified scenarios: Audited all 20 changed files in the diff, reviewed test coverage for each new code path, confirmed config schema additions match type definitions.
- Edge cases checked: Partial attachment download failure with `Promise.allSettled`; mention replacement offset shifts for styled text; control commands wrapped by style markers; debounce merge behavior for quote/edit/media vs. `UntrustedContext`; caption/dimension propagation with missing values; MIME strings with casing/parameters; null/empty poll questions; poll vote without creator fields; empty quote body trimmed to undefined.
- What you did **not** verify: Live Signal daemon/device roundtrip; full `pnpm check`; full `pnpm test` across the whole repo. Also note: `injectLinkPreviews` and `preserveTextStyles` were added to `TelegramAccountSchemaBase` in `src/config/zod-schema.providers-core.ts` (line ~289) in addition to `SignalAccountSchemaBase` — this may be intentional (shared schema shape) or a copy-paste error that should be reviewed.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) `Yes`
- Config/env changes? (`Yes/No`) `Yes` — two new optional booleans: `channels.signal.injectLinkPreviews` (default `true`), `channels.signal.preserveTextStyles` (default `true`)
- Migration needed? (`Yes/No`) `No`
- If yes, exact upgrade steps: N/A (opt-out only: set `channels.signal.injectLinkPreviews: false` and/or `channels.signal.preserveTextStyles: false`)

## Risks and Mitigations

- Risk: Style rendering changes the agent-visible body text and could misalign spans when mentions expand placeholders.
  - Mitigation: `renderSignalMentions` now returns offset shift metadata; `applySignalTextStyles` operates on the post-mention text with adjusted offsets; command/mention gating uses plain text. Alignment cases covered in tests.
- Risk: Richer per-message metadata could bleed across debounced batches.
  - Mitigation: Edits are excluded from debounce; media/reply/edit fields are cleared on merge; only `UntrustedContext` intentionally aggregates across merged entries. Debounce merge tests verify this.
- Risk: `injectLinkPreviews` / `preserveTextStyles` accidentally added to `TelegramAccountSchemaBase` zod schema (line ~289 in `src/config/zod-schema.providers-core.ts`).
  - Mitigation: Reviewer should confirm whether this is intentional or a copy-paste error. The TypeScript types only add these fields to `SignalAccountConfig`.
- Risk: In-memory message cache (`message-cache.ts`) grows unbounded on high-traffic instances.
  - Mitigation: LRU eviction at 2000 entries + 6-hour TTL; cache is process-local and cleared on restart.
- Risk: Forwarding more Signal metadata increases untrusted context visible to agents.
  - Mitigation: Provider-specific strings stored in `UntrustedContext` (documented as untrusted); per-account opt-outs exist for link previews and style rendering.