### PR TITLE
feat(telegram): add Business Mode for personal chat access

### DIFF
--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -17,6 +17,7 @@ import { createSessionsHistoryTool } from "./tools/sessions-history-tool.js";
 import { createSessionsListTool } from "./tools/sessions-list-tool.js";
 import { createSessionsSendTool } from "./tools/sessions-send-tool.js";
 import { createSessionsSpawnTool } from "./tools/sessions-spawn-tool.js";
+import { createTelegramBusinessTool } from "./tools/telegram-business-tool.js";
 import { createTtsTool } from "./tools/tts-tool.js";
 import { createWebFetchTool, createWebSearchTool } from "./tools/web-tools.js";
 
@@ -152,6 +153,11 @@ export function createOpenClawTools(options?: {
     ...(webFetchTool ? [webFetchTool] : []),
     ...(imageTool ? [imageTool] : []),
   ];
+
+  const telegramBusinessTool = createTelegramBusinessTool({ config: options?.config });
+  if (telegramBusinessTool) {
+    tools.push(telegramBusinessTool);
+  }
 
   const pluginTools = resolvePluginTools({
     context: {

--- a/src/agents/tools/telegram-business-tool.ts
+++ b/src/agents/tools/telegram-business-tool.ts
@@ -1,0 +1,198 @@
+import { Type } from "@sinclair/typebox";
+import { Bot } from "grammy";
+import type { OpenClawConfig } from "../../config/config.js";
+import { loadConfig } from "../../config/config.js";
+import {
+  getActiveBusinessConnectionId,
+  listBusinessChats,
+  loadChatMessages,
+  resolveBusinessStorageDir,
+  searchBusinessMessages,
+} from "../../telegram/business/index.js";
+import { resolveTelegramToken } from "../../telegram/token.js";
+import { stringEnum } from "../schema/typebox.js";
+import { type AnyAgentTool, jsonResult, readNumberParam, readStringParam } from "./common.js";
+
+const TELEGRAM_BUSINESS_ACTIONS = ["list_chats", "get_messages", "search", "send"] as const;
+
+const TelegramBusinessToolSchema = Type.Object({
+  action: stringEnum(TELEGRAM_BUSINESS_ACTIONS, {
+    description:
+      "list_chats: list all accessible chats. get_messages: fetch messages from a chat. search: search messages across chats. send: send a message as the operator (only when explicitly instructed).",
+  }),
+  chatId: Type.Optional(
+    Type.Number({
+      description: "Chat ID (required for get_messages, search in specific chat, send).",
+    }),
+  ),
+  limit: Type.Optional(
+    Type.Number({
+      description: "Max messages to return (default 50 for get_messages, 20 for search).",
+    }),
+  ),
+  before: Type.Optional(
+    Type.Number({ description: "Return messages before this message ID (for pagination)." }),
+  ),
+  after: Type.Optional(
+    Type.Number({ description: "Return messages after this message ID (for pagination)." }),
+  ),
+  query: Type.Optional(Type.String({ description: "Search query text (for search action)." })),
+  content: Type.Optional(Type.String({ description: "Message text to send (for send action)." })),
+  replyToMessageId: Type.Optional(
+    Type.Number({ description: "Message ID to reply to (for send action)." }),
+  ),
+  accountId: Type.Optional(
+    Type.String({ description: "Telegram account ID (for multi-account setups)." }),
+  ),
+});
+
+function resolveBusinessToolEnabled(cfg: OpenClawConfig): boolean {
+  const biz = cfg.channels?.telegram?.business;
+  if (!biz?.enabled) {
+    return false;
+  }
+  return biz.tool !== false;
+}
+
+function formatTimestamp(unix: number): string {
+  return new Date(unix * 1000)
+    .toISOString()
+    .replace("T", " ")
+    .replace(/\.\d{3}Z$/, " UTC");
+}
+
+export function createTelegramBusinessTool(opts?: {
+  config?: OpenClawConfig;
+}): AnyAgentTool | null {
+  const cfg = opts?.config ?? loadConfig();
+  if (!resolveBusinessToolEnabled(cfg)) {
+    return null;
+  }
+
+  return {
+    label: "Telegram Business",
+    name: "telegram_business",
+    description:
+      "Read the operator's personal Telegram chats via Business Mode. " +
+      "Actions: list_chats (list all chats), get_messages (fetch chat history), " +
+      "search (text search across chats), send (send a message as the operator — only when explicitly instructed).",
+    parameters: TelegramBusinessToolSchema,
+    execute: async (_toolCallId, args) => {
+      const params = args as Record<string, unknown>;
+      const action = readStringParam(params, "action", { required: true });
+      const accountId = readStringParam(params, "accountId");
+      const currentCfg = loadConfig();
+      const baseDir = resolveBusinessStorageDir(currentCfg, accountId);
+
+      if (action === "list_chats") {
+        const chats = listBusinessChats(baseDir);
+        if (chats.length === 0) {
+          return jsonResult({
+            chats: [],
+            note: "No business chats found. Ensure business mode is connected and messages have been received.",
+          });
+        }
+        return jsonResult({
+          chats: chats.map((c) => ({
+            chatId: c.chatId,
+            name: [c.firstName, c.lastName].filter(Boolean).join(" "),
+            username: c.username,
+            lastActivity: new Date(c.lastMessageAt).toISOString(),
+            messageCount: c.messageCount,
+          })),
+        });
+      }
+
+      if (action === "get_messages") {
+        const chatId = readNumberParam(params, "chatId", { required: true, integer: true })!;
+        const limit = readNumberParam(params, "limit", { integer: true });
+        const before = readNumberParam(params, "before", { integer: true });
+        const after = readNumberParam(params, "after", { integer: true });
+
+        const messages = loadChatMessages(baseDir, chatId, {
+          limit: limit ?? 50,
+          before: before ?? undefined,
+          after: after ?? undefined,
+        });
+
+        if (messages.length === 0) {
+          return jsonResult({ messages: [], note: "No messages found for this chat." });
+        }
+
+        return jsonResult({
+          chatId,
+          messages: messages.map((m) => ({
+            messageId: m.messageId,
+            date: formatTimestamp(m.date),
+            from:
+              [m.fromFirstName, m.fromLastName].filter(Boolean).join(" ") +
+              (m.fromUsername ? ` (@${m.fromUsername})` : ""),
+            direction: m.direction,
+            text: m.text ?? m.caption ?? "",
+            ...(m.replyToMessageId ? { replyTo: m.replyToMessageId } : {}),
+          })),
+        });
+      }
+
+      if (action === "search") {
+        const query = readStringParam(params, "query", { required: true });
+        const chatId = readNumberParam(params, "chatId", { integer: true });
+        const limit = readNumberParam(params, "limit", { integer: true });
+
+        const results = searchBusinessMessages(baseDir, query, {
+          chatId: chatId ?? undefined,
+          limit: limit ?? 20,
+        });
+
+        if (results.length === 0) {
+          return jsonResult({ results: [], note: `No messages matching "${query}".` });
+        }
+
+        return jsonResult({
+          query,
+          results: results.map((m) => ({
+            chatId: m.chatId,
+            messageId: m.messageId,
+            date: formatTimestamp(m.date),
+            from:
+              [m.fromFirstName, m.fromLastName].filter(Boolean).join(" ") +
+              (m.fromUsername ? ` (@${m.fromUsername})` : ""),
+            direction: m.direction,
+            text: m.text ?? m.caption ?? "",
+          })),
+        });
+      }
+
+      if (action === "send") {
+        const chatId = readNumberParam(params, "chatId", { required: true, integer: true })!;
+        const content = readStringParam(params, "content", { required: true });
+        const replyToMessageId = readNumberParam(params, "replyToMessageId", { integer: true });
+
+        const connectionId = getActiveBusinessConnectionId(baseDir);
+        if (!connectionId) {
+          throw new Error(
+            "No active business connection found. The operator must connect the bot via Telegram Business settings.",
+          );
+        }
+
+        const tokenRes = resolveTelegramToken(currentCfg, { accountId });
+        if (tokenRes.source === "none" || !tokenRes.token) {
+          throw new Error("Telegram bot token not found. Check configuration.");
+        }
+
+        const bot = new Bot(tokenRes.token);
+        const result = await bot.api.sendMessage(chatId, content, {
+          business_connection_id: connectionId,
+          ...(replyToMessageId ? { reply_parameters: { message_id: replyToMessageId } } : {}),
+        });
+        return jsonResult({
+          sent: true,
+          messageId: result.message_id,
+          chatId,
+        });
+      }
+
+      throw new Error(`Unknown action: ${action}`);
+    },
+  };
+}

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -41,6 +41,28 @@ export type TelegramCustomCommand = {
   description: string;
 };
 
+/**
+ * Telegram Business Mode configuration.
+ * Grants the agent read access to the operator's personal Telegram chats
+ * via Telegram's Business API. This is a data-source integration, not a
+ * real-time channel — messages are passively stored and queried on demand.
+ */
+export type TelegramBusinessConfig = {
+  /** Enable business mode message ingestion. Default: false. */
+  enabled?: boolean;
+  /**
+   * Storage directory for business messages.
+   * Default: {stateDir}/telegram-business/{accountId}
+   */
+  storageDir?: string;
+  /** Maximum messages to retain per chat (0 = unlimited). Default: 10000. */
+  maxMessagesPerChat?: number;
+  /** Maximum age in days for stored messages (0 = unlimited). Default: 90. */
+  maxAgeDays?: number;
+  /** If true, expose the telegram_business agent tool. Default: true when business.enabled. */
+  tool?: boolean;
+};
+
 export type TelegramAccountConfig = {
   /** Optional display name for this account (used in CLI/UI lists). */
   name?: string;
@@ -140,6 +162,8 @@ export type TelegramAccountConfig = {
    * Use `"auto"` to derive `[{identity.name}]` from the routed agent.
    */
   responsePrefix?: string;
+  /** Telegram Business Mode configuration (personal chat access). */
+  business?: TelegramBusinessConfig;
 };
 
 export type TelegramTopicConfig = {

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -142,6 +142,16 @@ export const TelegramAccountSchemaBase = z
     heartbeat: ChannelHeartbeatVisibilitySchema,
     linkPreview: z.boolean().optional(),
     responsePrefix: z.string().optional(),
+    business: z
+      .object({
+        enabled: z.boolean().optional(),
+        storageDir: z.string().optional(),
+        maxMessagesPerChat: z.number().int().min(0).optional(),
+        maxAgeDays: z.number().int().min(0).optional(),
+        tool: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict();
 

--- a/src/telegram/business/connection-store.ts
+++ b/src/telegram/business/connection-store.ts
@@ -1,0 +1,63 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { OpenClawConfig } from "../../config/config.js";
+import type { BusinessConnectionStore, StoredBusinessConnection } from "./types.js";
+import { resolveStateDir } from "../../config/paths.js";
+
+const CONNECTIONS_FILE = "connections.json";
+
+/** Resolve the base storage directory for Telegram business mode data. */
+export function resolveBusinessStorageDir(cfg: OpenClawConfig, accountId?: string): string {
+  const customDir = cfg.channels?.telegram?.business?.storageDir;
+  if (customDir) {
+    return accountId ? path.join(customDir, accountId) : customDir;
+  }
+  const stateDir = resolveStateDir();
+  const base = path.join(stateDir, "telegram-business");
+  return path.join(base, accountId ?? "default");
+}
+
+function ensureDir(dir: string): void {
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+function connectionsPath(baseDir: string): string {
+  return path.join(baseDir, CONNECTIONS_FILE);
+}
+
+export function loadBusinessConnections(baseDir: string): BusinessConnectionStore {
+  const filePath = connectionsPath(baseDir);
+  try {
+    const raw = fs.readFileSync(filePath, "utf-8");
+    const parsed = JSON.parse(raw) as BusinessConnectionStore;
+    if (parsed.version === 1 && parsed.connections) {
+      return parsed;
+    }
+  } catch {
+    // File doesn't exist or is corrupt — return empty store.
+  }
+  return { version: 1, connections: {} };
+}
+
+export function saveBusinessConnection(baseDir: string, conn: StoredBusinessConnection): void {
+  ensureDir(baseDir);
+  const store = loadBusinessConnections(baseDir);
+  store.connections[conn.id] = conn;
+  const filePath = connectionsPath(baseDir);
+  fs.writeFileSync(filePath, JSON.stringify(store, null, 2), "utf-8");
+}
+
+/** Returns the most recently updated active (enabled) connection ID, or undefined. */
+export function getActiveBusinessConnectionId(baseDir: string): string | undefined {
+  const store = loadBusinessConnections(baseDir);
+  let best: StoredBusinessConnection | undefined;
+  for (const conn of Object.values(store.connections)) {
+    if (!conn.isEnabled) {
+      continue;
+    }
+    if (!best || conn.updatedAt > best.updatedAt) {
+      best = conn;
+    }
+  }
+  return best?.id;
+}

--- a/src/telegram/business/handlers.ts
+++ b/src/telegram/business/handlers.ts
@@ -1,0 +1,188 @@
+import type { Message } from "@grammyjs/types";
+import type { Bot } from "grammy";
+import type { OpenClawConfig } from "../../config/config.js";
+import type { RuntimeEnv } from "../../runtime.js";
+import type { StoredBusinessConnection, StoredBusinessMessage } from "./types.js";
+import { danger, logVerbose } from "../../globals.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { resolveBusinessStorageDir, saveBusinessConnection } from "./connection-store.js";
+import { appendBusinessMessage, appendDeletionMarker, updateChatMeta } from "./message-store.js";
+
+const log = createSubsystemLogger("telegram/business");
+
+function resolveBusinessEnabled(cfg: OpenClawConfig): boolean {
+  return cfg.channels?.telegram?.business?.enabled === true;
+}
+
+/**
+ * Determine message direction by comparing `from.id` with `chat.id`.
+ * In business mode private chats, `chat.id` is the contact's user ID.
+ * If the sender matches the chat, it's incoming (contact sent it).
+ * Otherwise it's outgoing (operator sent it).
+ */
+function resolveDirection(msg: Message): "incoming" | "outgoing" {
+  const fromId = msg.from?.id;
+  const chatId = msg.chat?.id;
+  if (fromId != null && chatId != null && fromId !== chatId) {
+    return "outgoing";
+  }
+  return "incoming";
+}
+
+function extractStoredMessage(
+  msg: Message,
+  businessConnectionId: string,
+  event: "new" | "edited",
+): StoredBusinessMessage {
+  return {
+    messageId: msg.message_id,
+    date: msg.date,
+    storedAt: Date.now(),
+    fromId: msg.from?.id ?? 0,
+    fromFirstName: msg.from?.first_name ?? "",
+    fromLastName: msg.from?.last_name,
+    fromUsername: msg.from?.username,
+    text: msg.text,
+    caption: msg.caption,
+    direction: resolveDirection(msg),
+    replyToMessageId: msg.reply_to_message?.message_id,
+    businessConnectionId,
+    event,
+  };
+}
+
+export function registerTelegramBusinessHandlers(params: {
+  bot: Bot;
+  cfg: OpenClawConfig;
+  accountId: string;
+  runtime: RuntimeEnv;
+  shouldSkipUpdate: (ctx: { update?: { update_id?: number } }) => boolean;
+}): void {
+  const { bot, cfg, accountId, runtime } = params;
+  const baseDir = resolveBusinessStorageDir(cfg, accountId);
+
+  // ---- BusinessConnection: operator connects/disconnects the bot ----
+  bot.on("business_connection", (ctx) => {
+    try {
+      const conn = ctx.businessConnection;
+      if (!conn) {
+        return;
+      }
+
+      const stored: StoredBusinessConnection = {
+        id: conn.id,
+        userId: conn.user.id,
+        userChatId: conn.user_chat_id,
+        firstName: conn.user.first_name,
+        lastName: conn.user.last_name,
+        username: conn.user.username,
+        date: conn.date,
+        isEnabled: conn.is_enabled,
+        rights: conn.rights
+          ? {
+              canReply: conn.rights.can_reply ?? false,
+              canReadMessages: conn.rights.can_read_messages ?? false,
+              canDeleteOutgoingMessages: conn.rights.can_delete_outgoing_messages ?? false,
+              canDeleteAllMessages: conn.rights.can_delete_all_messages ?? false,
+            }
+          : undefined,
+        updatedAt: Date.now(),
+      };
+      saveBusinessConnection(baseDir, stored);
+      log.info(
+        `business connection ${conn.is_enabled ? "connected" : "disconnected"}: ${conn.user.first_name} (${conn.user.id})`,
+      );
+    } catch (err) {
+      runtime.error?.(danger(`business_connection handler failed: ${String(err)}`));
+    }
+  });
+
+  // ---- business_message: new message in operator's personal chat ----
+  bot.on("business_message", (ctx) => {
+    try {
+      if (!resolveBusinessEnabled(cfg)) {
+        return;
+      }
+
+      const msg = ctx.update.business_message;
+      if (!msg) {
+        return;
+      }
+
+      const businessConnectionId = msg.business_connection_id;
+      if (!businessConnectionId) {
+        return;
+      }
+
+      const chatId = msg.chat.id;
+      const stored = extractStoredMessage(msg, businessConnectionId, "new");
+      appendBusinessMessage(baseDir, chatId, stored);
+
+      updateChatMeta(baseDir, chatId, {
+        firstName: msg.chat.first_name ?? "",
+        lastName: msg.chat.last_name,
+        username: msg.chat.username,
+        lastMessageAt: Date.now(),
+        incrementCount: true,
+      });
+
+      logVerbose(
+        `telegram business: stored ${stored.direction} message in chat ${chatId} (msg ${msg.message_id})`,
+      );
+    } catch (err) {
+      runtime.error?.(danger(`business_message handler failed: ${String(err)}`));
+    }
+  });
+
+  // ---- edited_business_message: message edited in operator's chat ----
+  bot.on("edited_business_message", (ctx) => {
+    try {
+      if (!resolveBusinessEnabled(cfg)) {
+        return;
+      }
+
+      const msg = ctx.update.edited_business_message;
+      if (!msg) {
+        return;
+      }
+
+      const businessConnectionId = msg.business_connection_id;
+      if (!businessConnectionId) {
+        return;
+      }
+
+      const chatId = msg.chat.id;
+      const stored = extractStoredMessage(msg, businessConnectionId, "edited");
+      appendBusinessMessage(baseDir, chatId, stored);
+
+      logVerbose(
+        `telegram business: stored edited message in chat ${chatId} (msg ${msg.message_id})`,
+      );
+    } catch (err) {
+      runtime.error?.(danger(`edited_business_message handler failed: ${String(err)}`));
+    }
+  });
+
+  // ---- deleted_business_messages: messages deleted in operator's chat ----
+  bot.on("deleted_business_messages", (ctx) => {
+    try {
+      if (!resolveBusinessEnabled(cfg)) {
+        return;
+      }
+
+      const deleted = ctx.update.deleted_business_messages;
+      if (!deleted) {
+        return;
+      }
+
+      const chatId = deleted.chat.id;
+      appendDeletionMarker(baseDir, chatId, deleted.message_ids, deleted.business_connection_id);
+
+      logVerbose(
+        `telegram business: marked ${deleted.message_ids.length} message(s) deleted in chat ${chatId}`,
+      );
+    } catch (err) {
+      runtime.error?.(danger(`deleted_business_messages handler failed: ${String(err)}`));
+    }
+  });
+}

--- a/src/telegram/business/index.ts
+++ b/src/telegram/business/index.ts
@@ -1,0 +1,20 @@
+export type {
+  BusinessConnectionStore,
+  StoredBusinessConnection,
+  StoredBusinessMessage,
+  StoredChatMeta,
+} from "./types.js";
+export {
+  getActiveBusinessConnectionId,
+  loadBusinessConnections,
+  resolveBusinessStorageDir,
+  saveBusinessConnection,
+} from "./connection-store.js";
+export {
+  appendBusinessMessage,
+  appendDeletionMarker,
+  listBusinessChats,
+  loadChatMessages,
+  searchBusinessMessages,
+  updateChatMeta,
+} from "./message-store.js";

--- a/src/telegram/business/index.ts
+++ b/src/telegram/business/index.ts
@@ -15,6 +15,7 @@ export {
   appendDeletionMarker,
   listBusinessChats,
   loadChatMessages,
+  maybePruneChatMessages,
   searchBusinessMessages,
   updateChatMeta,
 } from "./message-store.js";

--- a/src/telegram/business/message-store.ts
+++ b/src/telegram/business/message-store.ts
@@ -1,0 +1,235 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { StoredBusinessMessage, StoredChatMeta } from "./types.js";
+
+const MESSAGES_FILE = "messages.jsonl";
+const META_FILE = "meta.json";
+const CHATS_DIR = "chats";
+
+function chatDir(baseDir: string, chatId: number): string {
+  return path.join(baseDir, CHATS_DIR, String(chatId));
+}
+
+function ensureDir(dir: string): void {
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+// ---------------------------------------------------------------------------
+// Append
+// ---------------------------------------------------------------------------
+
+export function appendBusinessMessage(
+  baseDir: string,
+  chatId: number,
+  msg: StoredBusinessMessage,
+): void {
+  const dir = chatDir(baseDir, chatId);
+  ensureDir(dir);
+  const filePath = path.join(dir, MESSAGES_FILE);
+  fs.appendFileSync(filePath, JSON.stringify(msg) + "\n", "utf-8");
+}
+
+export function appendDeletionMarker(
+  baseDir: string,
+  chatId: number,
+  messageIds: number[],
+  businessConnectionId: string,
+): void {
+  const marker: StoredBusinessMessage = {
+    messageId: 0,
+    date: Math.floor(Date.now() / 1000),
+    storedAt: Date.now(),
+    fromId: 0,
+    fromFirstName: "",
+    direction: "incoming",
+    businessConnectionId,
+    event: "deleted",
+    deletedMessageIds: messageIds,
+  };
+  appendBusinessMessage(baseDir, chatId, marker);
+}
+
+// ---------------------------------------------------------------------------
+// Read
+// ---------------------------------------------------------------------------
+
+function readJsonl(filePath: string): StoredBusinessMessage[] {
+  try {
+    const raw = fs.readFileSync(filePath, "utf-8");
+    const lines = raw.split("\n").filter((l) => l.trim());
+    const records: StoredBusinessMessage[] = [];
+    for (const line of lines) {
+      try {
+        records.push(JSON.parse(line) as StoredBusinessMessage);
+      } catch {
+        // Skip corrupt lines.
+      }
+    }
+    return records;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Deduplicate and filter messages:
+ * - For edits, keep only the latest version per messageId.
+ * - Remove messages that have been marked as deleted.
+ */
+function deduplicateMessages(records: StoredBusinessMessage[]): StoredBusinessMessage[] {
+  const deletedIds = new Set<number>();
+  for (const r of records) {
+    if (r.event === "deleted" && r.deletedMessageIds) {
+      for (const id of r.deletedMessageIds) {
+        deletedIds.add(id);
+      }
+    }
+  }
+
+  // Keep the latest version of each messageId (edits replace originals).
+  const byId = new Map<number, StoredBusinessMessage>();
+  for (const r of records) {
+    if (r.event === "deleted") {
+      continue;
+    }
+    if (deletedIds.has(r.messageId)) {
+      continue;
+    }
+    byId.set(r.messageId, r);
+  }
+
+  return [...byId.values()].toSorted((a, b) => a.date - b.date || a.messageId - b.messageId);
+}
+
+export function loadChatMessages(
+  baseDir: string,
+  chatId: number,
+  opts?: { limit?: number; before?: number; after?: number },
+): StoredBusinessMessage[] {
+  const filePath = path.join(chatDir(baseDir, chatId), MESSAGES_FILE);
+  const raw = readJsonl(filePath);
+  let messages = deduplicateMessages(raw);
+
+  if (opts?.after != null) {
+    messages = messages.filter((m) => m.messageId > opts.after!);
+  }
+  if (opts?.before != null) {
+    messages = messages.filter((m) => m.messageId < opts.before!);
+  }
+
+  const limit = opts?.limit ?? 50;
+  if (limit > 0 && messages.length > limit) {
+    // Return the most recent N messages.
+    messages = messages.slice(-limit);
+  }
+
+  return messages;
+}
+
+// ---------------------------------------------------------------------------
+// Chat listing
+// ---------------------------------------------------------------------------
+
+export function updateChatMeta(
+  baseDir: string,
+  chatId: number,
+  partial: Partial<Omit<StoredChatMeta, "messageCount">> & { incrementCount?: boolean },
+): void {
+  const dir = chatDir(baseDir, chatId);
+  ensureDir(dir);
+  const filePath = path.join(dir, META_FILE);
+  let existing: StoredChatMeta = {
+    chatId,
+    firstName: "",
+    lastMessageAt: 0,
+    messageCount: 0,
+  };
+  try {
+    const raw = fs.readFileSync(filePath, "utf-8");
+    existing = JSON.parse(raw) as StoredChatMeta;
+  } catch {
+    // New chat.
+  }
+  const { incrementCount, ...rest } = partial;
+  const updated: StoredChatMeta = {
+    ...existing,
+    ...rest,
+    chatId,
+    messageCount: incrementCount ? existing.messageCount + 1 : existing.messageCount,
+  };
+  fs.writeFileSync(filePath, JSON.stringify(updated, null, 2), "utf-8");
+}
+
+export function listBusinessChats(baseDir: string): StoredChatMeta[] {
+  const chatsPath = path.join(baseDir, CHATS_DIR);
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(chatsPath);
+  } catch {
+    return [];
+  }
+
+  const metas: StoredChatMeta[] = [];
+  for (const entry of entries) {
+    const metaPath = path.join(chatsPath, entry, META_FILE);
+    try {
+      const raw = fs.readFileSync(metaPath, "utf-8");
+      metas.push(JSON.parse(raw) as StoredChatMeta);
+    } catch {
+      // Skip directories without valid meta.
+    }
+  }
+
+  return metas.toSorted((a, b) => b.lastMessageAt - a.lastMessageAt);
+}
+
+// ---------------------------------------------------------------------------
+// Search
+// ---------------------------------------------------------------------------
+
+export function searchBusinessMessages(
+  baseDir: string,
+  query: string,
+  opts?: { chatId?: number; limit?: number },
+): Array<StoredBusinessMessage & { chatId: number }> {
+  const lowerQuery = query.toLowerCase();
+  const limit = opts?.limit ?? 20;
+  const results: Array<StoredBusinessMessage & { chatId: number }> = [];
+
+  const chatIds: number[] = [];
+  if (opts?.chatId != null) {
+    chatIds.push(opts.chatId);
+  } else {
+    const chatsPath = path.join(baseDir, CHATS_DIR);
+    try {
+      const entries = fs.readdirSync(chatsPath);
+      for (const e of entries) {
+        const parsed = Number(e);
+        if (Number.isFinite(parsed)) {
+          chatIds.push(parsed);
+        }
+      }
+    } catch {
+      return [];
+    }
+  }
+
+  for (const cid of chatIds) {
+    if (results.length >= limit) {
+      break;
+    }
+    const filePath = path.join(chatDir(baseDir, cid), MESSAGES_FILE);
+    const messages = deduplicateMessages(readJsonl(filePath));
+    for (const m of messages) {
+      if (results.length >= limit) {
+        break;
+      }
+      const text = (m.text ?? m.caption ?? "").toLowerCase();
+      if (text.includes(lowerQuery)) {
+        results.push({ ...m, chatId: cid });
+      }
+    }
+  }
+
+  return results;
+}

--- a/src/telegram/business/types.ts
+++ b/src/telegram/business/types.ts
@@ -1,0 +1,66 @@
+/** Persisted snapshot of a Telegram BusinessConnection. */
+export type StoredBusinessConnection = {
+  /** Unique identifier of the business connection. */
+  id: string;
+  /** Business account user ID. */
+  userId: number;
+  /** Private chat ID with the user who created the connection. */
+  userChatId: number;
+  firstName: string;
+  lastName?: string;
+  username?: string;
+  /** Unix timestamp when the connection was established. */
+  date: number;
+  /** Whether the connection is currently active. */
+  isEnabled: boolean;
+  rights?: {
+    canReply?: boolean;
+    canReadMessages?: boolean;
+    canDeleteOutgoingMessages?: boolean;
+    canDeleteAllMessages?: boolean;
+  };
+  /** Epoch ms when this record was last written. */
+  updatedAt: number;
+};
+
+/** Versioned store for business connections. */
+export type BusinessConnectionStore = {
+  version: 1;
+  /** Keyed by connection ID. */
+  connections: Record<string, StoredBusinessConnection>;
+};
+
+/** A single business message record stored in JSONL. */
+export type StoredBusinessMessage = {
+  messageId: number;
+  /** Unix timestamp from Telegram. */
+  date: number;
+  /** Epoch ms when this record was stored. */
+  storedAt: number;
+  fromId: number;
+  fromFirstName: string;
+  fromLastName?: string;
+  fromUsername?: string;
+  text?: string;
+  caption?: string;
+  /** 'incoming' = someone wrote to operator, 'outgoing' = operator sent. */
+  direction: "incoming" | "outgoing";
+  replyToMessageId?: number;
+  businessConnectionId: string;
+  /** 'new' = new message, 'edited' = edit of existing, 'deleted' = deletion marker. */
+  event: "new" | "edited" | "deleted";
+  /** For 'deleted' events: the message IDs that were deleted. */
+  deletedMessageIds?: number[];
+};
+
+/** Per-chat metadata stored alongside the JSONL message log. */
+export type StoredChatMeta = {
+  chatId: number;
+  firstName: string;
+  lastName?: string;
+  username?: string;
+  /** Epoch ms of the most recent message. */
+  lastMessageAt: number;
+  /** Total stored message records (including edits/deletions). */
+  messageCount: number;
+};


### PR DESCRIPTION
## Summary

- Adds Telegram Business Mode integration — passive ingestion of the operator's personal Telegram chats via the Business API
- Messages stored locally in JSONL (`{stateDir}/telegram-business/{accountId}/chats/{chatId}/messages.jsonl`)
- New `telegram_business` agent tool with `list_chats`, `get_messages`, `search`, and `send` actions
- Handles `business_connection`, `business_message`, `edited_business_message`, and `deleted_business_messages` update types
- Config: `channels.telegram.business.enabled: true` to activate

This is a data-source integration (like gog for Gmail), not a real-time channel. Messages are passively stored and queried on demand. The agent is NOT woken on incoming business messages.

## Test plan

- [x] Enable Business Mode in @BotFather
- [x] Connect bot in Telegram app → Settings → Telegram Business → Chatbots
- [x] Verify `business_connection` stored to `connections.json`
- [x] Send messages in personal chat → verify JSONL ingestion with correct direction detection
- [x] Test `telegram_business action=list_chats` via agent
- [x] Test `telegram_business action=get_messages` via agent
- [x] Test `telegram_business action=search` via agent
- [x] Test incoming message direction detection (contact sends to operator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds Telegram Business Mode integration allowing passive ingestion of operator's personal Telegram chats via the Business API. Messages are stored locally in JSONL format under `{stateDir}/telegram-business/{accountId}/chats/{chatId}/messages.jsonl` and accessed on-demand through a new `telegram_business` agent tool.

**Key changes:**
- Created new business integration module in `src/telegram/business/` with connection store, message store, and event handlers
- Handles `business_connection`, `business_message`, `edited_business_message`, and `deleted_business_messages` update types
- New agent tool supports `list_chats`, `get_messages`, `search`, and `send` actions
- Config: enable with `channels.telegram.business.enabled: true`
- Includes pre-reset hook feature from merged branch (allows agent wrap-up before session reset)

**Implementation quality:**
- Direction detection logic correctly identifies incoming vs outgoing messages by comparing `from.id` with `chat.id`
- Message deduplication properly handles edits and deletions
- Error handling uses try-catch with graceful fallbacks
- Sequential processing ensured via `getTelegramSequentialKey` updates

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor considerations around testing and potential file system growth
- The implementation is well-structured with proper error handling, sequential processing guarantees, and clean separation of concerns. Message deduplication and direction detection logic are sound. The code follows project conventions (TypeScript strict typing, proper error handling). However, the score is not a perfect 5 due to: (1) no test coverage for the new business integration, (2) no built-in limits on JSONL file growth despite config options for `maxMessagesPerChat` and `maxAgeDays` being defined but unused, and (3) the feature merges pre-reset hook changes that were already in main, making the diff slightly larger than the feature alone.
- Pay attention to `src/telegram/business/message-store.ts` regarding potential file growth - the config defines retention limits but they're not enforced in the append operations

<sub>Last reviewed commit: e93ccd3</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->