### PR TITLE
perf(cli): lazy-load core command infrastructure

### DIFF
--- a/src/channels/defaults.ts
+++ b/src/channels/defaults.ts
@@ -1,0 +1,3 @@
+// Extracted to a standalone module so CLI registration files can reference
+// the default channel without importing the full channel registry + plugin system.
+export const DEFAULT_CHAT_CHANNEL = "whatsapp" as const;

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -19,7 +19,7 @@ export type ChatChannelId = (typeof CHAT_CHANNEL_ORDER)[number];
 
 export const CHANNEL_IDS = [...CHAT_CHANNEL_ORDER] as const;
 
-export const DEFAULT_CHAT_CHANNEL: ChatChannelId = "whatsapp";
+export { DEFAULT_CHAT_CHANNEL } from "./defaults.js";
 
 export type ChatChannelMeta = ChannelMeta;
 

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { resolveStateDir } from "../config/paths.js";
 import { routeLogsToStderr } from "../logging/console.js";
 import { pathExists } from "../utils.js";
-import { getCoreCliCommandNames, registerCoreCliByName } from "./program/command-registry.js";
+import { registerProgramCommands } from "./program/command-registry.js";
 import { getProgramContext } from "./program/program-context.js";
 import { getSubCliEntries, registerSubCliByName } from "./program/register.subclis.js";
 
@@ -247,9 +247,7 @@ export function registerCompletionCli(program: Command) {
       // Our CLI defaults to lazy registration for perf; force-register core commands here.
       const ctx = getProgramContext(program);
       if (ctx) {
-        for (const name of getCoreCliCommandNames()) {
-          await registerCoreCliByName(program, ctx, name);
-        }
+        registerProgramCommands(program, ctx, process.argv);
       }
 
       // Eagerly register all subcommands to build the full tree

--- a/src/cli/program/build-program-shell.ts
+++ b/src/cli/program/build-program-shell.ts
@@ -1,0 +1,13 @@
+import { Command } from "commander";
+import type { ProgramContext } from "./context.js";
+import { createProgramContext } from "./context.js";
+import { configureProgramHelp } from "./help.js";
+import { registerPreActionHooks } from "./preaction.js";
+
+export function buildProgramShell(): { program: Command; ctx: ProgramContext } {
+  const program = new Command();
+  const ctx = createProgramContext();
+  configureProgramHelp(program, ctx);
+  registerPreActionHooks(program, ctx.programVersion);
+  return { program, ctx };
+}

--- a/src/cli/program/build-program-shell.ts
+++ b/src/cli/program/build-program-shell.ts
@@ -1,13 +1,26 @@
 import { Command } from "commander";
-import type { ProgramContext } from "./context.js";
+import type { ChannelOptionsProvider, ProgramContext } from "./context.js";
 import { createProgramContext } from "./context.js";
 import { configureProgramHelp } from "./help.js";
 import { registerPreActionHooks } from "./preaction.js";
 
-export function buildProgramShell(): { program: Command; ctx: ProgramContext } {
+export type ProgramShell = {
+  program: Command;
+  ctx: ProgramContext;
+  provideChannelOptions: (fn: ChannelOptionsProvider) => void;
+};
+
+export function buildProgramShell(): ProgramShell {
   const program = new Command();
-  const ctx = createProgramContext();
+  let channelOptionsProvider: ChannelOptionsProvider | undefined;
+  const ctx = createProgramContext(() => channelOptionsProvider?.() ?? []);
   configureProgramHelp(program, ctx);
   registerPreActionHooks(program, ctx.programVersion);
-  return { program, ctx };
+  return {
+    program,
+    ctx,
+    provideChannelOptions(fn: ChannelOptionsProvider) {
+      channelOptionsProvider = fn;
+    },
+  };
 }

--- a/src/cli/program/build-program.ts
+++ b/src/cli/program/build-program.ts
@@ -1,8 +1,10 @@
+import { resolveCliChannelOptions } from "../channel-options.js";
 import { buildProgramShell } from "./build-program-shell.js";
 import { registerProgramCommands } from "./command-registry.js";
 
 export function buildProgram() {
-  const { program, ctx } = buildProgramShell();
+  const { program, ctx, provideChannelOptions } = buildProgramShell();
+  provideChannelOptions(resolveCliChannelOptions);
   registerProgramCommands(program, ctx, process.argv);
   return program;
 }

--- a/src/cli/program/build-program.ts
+++ b/src/cli/program/build-program.ts
@@ -1,20 +1,8 @@
-import { Command } from "commander";
+import { buildProgramShell } from "./build-program-shell.js";
 import { registerProgramCommands } from "./command-registry.js";
-import { createProgramContext } from "./context.js";
-import { configureProgramHelp } from "./help.js";
-import { registerPreActionHooks } from "./preaction.js";
-import { setProgramContext } from "./program-context.js";
 
 export function buildProgram() {
-  const program = new Command();
-  const ctx = createProgramContext();
-  const argv = process.argv;
-
-  setProgramContext(program, ctx);
-  configureProgramHelp(program, ctx);
-  registerPreActionHooks(program, ctx.programVersion);
-
-  registerProgramCommands(program, ctx, argv);
-
+  const { program, ctx } = buildProgramShell();
+  registerProgramCommands(program, ctx, process.argv);
   return program;
 }

--- a/src/cli/program/command-registry.test.ts
+++ b/src/cli/program/command-registry.test.ts
@@ -2,8 +2,6 @@ import { Command } from "commander";
 import { describe, expect, it, vi } from "vitest";
 import type { ProgramContext } from "./context.js";
 
-// Perf: `registerCoreCliByName(...)` dynamically imports registrar modules.
-// Mock the heavy registrars so this suite stays focused on command-registry wiring.
 vi.mock("./register.agent.js", () => ({
   registerAgentCommands: (program: Command) => {
     program.command("agent");
@@ -20,9 +18,6 @@ vi.mock("./register.maintenance.js", () => ({
   },
 }));
 
-const { getCoreCliCommandNames, registerCoreCliByName, registerCoreCliCommands } =
-  await import("./command-registry.js");
-
 vi.mock("./register.status-health-sessions.js", () => ({
   registerStatusHealthSessionsCommands: (program: Command) => {
     program.command("status");
@@ -30,6 +25,40 @@ vi.mock("./register.status-health-sessions.js", () => ({
     program.command("sessions");
   },
 }));
+
+vi.mock("./register.setup.js", () => ({
+  registerSetupCommand: (program: Command) => program.command("setup"),
+}));
+
+vi.mock("./register.onboard.js", () => ({
+  registerOnboardCommand: (program: Command) => program.command("onboard"),
+}));
+
+vi.mock("./register.configure.js", () => ({
+  registerConfigureCommand: (program: Command) => program.command("configure"),
+}));
+
+vi.mock("./register.message.js", () => ({
+  registerMessageCommands: (program: Command) => program.command("message"),
+}));
+
+vi.mock("../../browser-cli.js", () => ({
+  registerBrowserCli: (program: Command) => program.command("browser"),
+}));
+
+vi.mock("../../config-cli.js", () => ({
+  registerConfigCli: (program: Command) => program.command("config"),
+}));
+
+vi.mock("../../memory-cli.js", () => ({
+  registerMemoryCli: (program: Command) => program.command("memory"),
+}));
+
+vi.mock("./register.subclis.js", () => ({
+  registerSubCliCommands: (program: Command) => program.command("subclis"),
+}));
+
+const { registerProgramCommands } = await import("./command-registry.js");
 
 const testProgramContext: ProgramContext = {
   programVersion: "0.0.0-test",
@@ -39,65 +68,27 @@ const testProgramContext: ProgramContext = {
 };
 
 describe("command-registry", () => {
-  it("includes both agent and agents in core CLI command names", () => {
-    const names = getCoreCliCommandNames();
+  it("registerProgramCommands registers all core commands", () => {
+    const program = new Command();
+    registerProgramCommands(program, testProgramContext);
+
+    const names = program.commands.map((c) => c.name());
     expect(names).toContain("agent");
     expect(names).toContain("agents");
-  });
-
-  it("registerCoreCliByName resolves agents to the agent entry", async () => {
-    const program = new Command();
-    const found = await registerCoreCliByName(program, testProgramContext, "agents");
-    expect(found).toBe(true);
-    const agentsCmd = program.commands.find((c) => c.name() === "agents");
-    expect(agentsCmd).toBeDefined();
-    // The registrar also installs the singular "agent" command from the same entry.
-    const agentCmd = program.commands.find((c) => c.name() === "agent");
-    expect(agentCmd).toBeDefined();
-  });
-
-  it("registerCoreCliByName returns false for unknown commands", async () => {
-    const program = new Command();
-    const found = await registerCoreCliByName(program, testProgramContext, "nonexistent");
-    expect(found).toBe(false);
-  });
-
-  it("registers doctor placeholder for doctor primary command", () => {
-    const program = new Command();
-    registerCoreCliCommands(program, testProgramContext, ["node", "openclaw", "doctor"]);
-
-    expect(program.commands.map((command) => command.name())).toEqual(["doctor"]);
-  });
-
-  it("treats maintenance commands as top-level builtins", async () => {
-    const program = new Command();
-
-    expect(await registerCoreCliByName(program, testProgramContext, "doctor")).toBe(true);
-
-    const names = getCoreCliCommandNames();
-    expect(names).toContain("doctor");
-    expect(names).toContain("dashboard");
-    expect(names).toContain("reset");
-    expect(names).toContain("uninstall");
-    expect(names).not.toContain("maintenance");
-  });
-
-  it("registers grouped core entry placeholders without duplicate command errors", async () => {
-    const program = new Command();
-    registerCoreCliCommands(program, testProgramContext, ["node", "openclaw", "vitest"]);
-
-    const prevArgv = process.argv;
-    process.argv = ["node", "openclaw", "status"];
-    try {
-      program.exitOverride();
-      await program.parseAsync(["node", "openclaw", "status"]);
-    } finally {
-      process.argv = prevArgv;
-    }
-
-    const names = program.commands.map((command) => command.name());
     expect(names).toContain("status");
-    expect(names).toContain("health");
-    expect(names).toContain("sessions");
+    expect(names).toContain("doctor");
+    expect(names).toContain("setup");
+    expect(names).toContain("message");
+    expect(names).toContain("config");
+    expect(names).toContain("memory");
+  });
+
+  it("does not register duplicate commands", () => {
+    const program = new Command();
+    registerProgramCommands(program, testProgramContext);
+
+    const names = program.commands.map((c) => c.name());
+    const unique = new Set(names);
+    expect(names.length).toBe(unique.size);
   });
 });

--- a/src/cli/program/command-registry.ts
+++ b/src/cli/program/command-registry.ts
@@ -1,7 +1,15 @@
 import type { Command } from "commander";
 import type { ProgramContext } from "./context.js";
-import { buildParseArgv, getPrimaryCommand, hasHelpOrVersion } from "../argv.js";
-import { resolveActionArgs } from "./helpers.js";
+import { registerBrowserCli } from "../browser-cli.js";
+import { registerConfigCli } from "../config-cli.js";
+import { registerMemoryCli } from "../memory-cli.js";
+import { registerAgentCommands } from "./register.agent.js";
+import { registerConfigureCommand } from "./register.configure.js";
+import { registerMaintenanceCommands } from "./register.maintenance.js";
+import { registerMessageCommands } from "./register.message.js";
+import { registerOnboardCommand } from "./register.onboard.js";
+import { registerSetupCommand } from "./register.setup.js";
+import { registerStatusHealthSessionsCommands } from "./register.status-health-sessions.js";
 import { registerSubCliCommands } from "./register.subclis.js";
 
 type CommandRegisterParams = {
@@ -10,221 +18,65 @@ type CommandRegisterParams = {
   argv: string[];
 };
 
-export type CommandRegistration = {
+type CommandRegistration = {
   id: string;
   register: (params: CommandRegisterParams) => void;
 };
 
-type CoreCliEntry = {
-  commands: Array<{ name: string; description: string }>;
-  register: (params: CommandRegisterParams) => Promise<void> | void;
-};
-
-const shouldRegisterCorePrimaryOnly = (argv: string[]) => {
-  if (hasHelpOrVersion(argv)) {
-    return false;
-  }
-  return true;
-};
-
-const coreEntries: CoreCliEntry[] = [
+const commandRegistry: CommandRegistration[] = [
   {
-    commands: [{ name: "setup", description: "Setup helpers" }],
-    register: async ({ program }) => {
-      const mod = await import("./register.setup.js");
-      mod.registerSetupCommand(program);
-    },
+    id: "setup",
+    register: ({ program }) => registerSetupCommand(program),
   },
   {
-    commands: [{ name: "onboard", description: "Onboarding helpers" }],
-    register: async ({ program }) => {
-      const mod = await import("./register.onboard.js");
-      mod.registerOnboardCommand(program);
-    },
+    id: "onboard",
+    register: ({ program }) => registerOnboardCommand(program),
   },
   {
-    commands: [{ name: "configure", description: "Configure wizard" }],
-    register: async ({ program }) => {
-      const mod = await import("./register.configure.js");
-      mod.registerConfigureCommand(program);
-    },
+    id: "configure",
+    register: ({ program }) => registerConfigureCommand(program),
   },
   {
-    commands: [{ name: "config", description: "Config helpers" }],
-    register: async ({ program }) => {
-      const mod = await import("../config-cli.js");
-      mod.registerConfigCli(program);
-    },
+    id: "config",
+    register: ({ program }) => registerConfigCli(program),
   },
   {
-    commands: [
-      { name: "doctor", description: "Health checks + quick fixes for the gateway and channels" },
-      { name: "dashboard", description: "Open the Control UI with your current token" },
-      { name: "reset", description: "Reset local config/state (keeps the CLI installed)" },
-      {
-        name: "uninstall",
-        description: "Uninstall the gateway service + local data (CLI remains)",
-      },
-    ],
-    register: async ({ program }) => {
-      const mod = await import("./register.maintenance.js");
-      mod.registerMaintenanceCommands(program);
-    },
+    id: "maintenance",
+    register: ({ program }) => registerMaintenanceCommands(program),
   },
   {
-    commands: [{ name: "message", description: "Send, read, and manage messages" }],
-    register: async ({ program, ctx }) => {
-      const mod = await import("./register.message.js");
-      mod.registerMessageCommands(program, ctx);
-    },
+    id: "message",
+    register: ({ program, ctx }) => registerMessageCommands(program, ctx),
   },
   {
-    commands: [{ name: "memory", description: "Memory commands" }],
-    register: async ({ program }) => {
-      const mod = await import("../memory-cli.js");
-      mod.registerMemoryCli(program);
-    },
+    id: "memory",
+    register: ({ program }) => registerMemoryCli(program),
   },
   {
-    commands: [
-      { name: "agent", description: "Agent commands" },
-      { name: "agents", description: "Manage isolated agents" },
-    ],
-    register: async ({ program, ctx }) => {
-      const mod = await import("./register.agent.js");
-      mod.registerAgentCommands(program, { agentChannelOptions: ctx.agentChannelOptions });
-    },
+    id: "agent",
+    register: ({ program, ctx }) =>
+      registerAgentCommands(program, { agentChannelOptions: ctx.agentChannelOptions }),
   },
   {
-    commands: [
-      { name: "status", description: "Gateway status" },
-      { name: "health", description: "Gateway health" },
-      { name: "sessions", description: "Session management" },
-    ],
-    register: async ({ program }) => {
-      const mod = await import("./register.status-health-sessions.js");
-      mod.registerStatusHealthSessionsCommands(program);
-    },
+    id: "subclis",
+    register: ({ program, argv }) => registerSubCliCommands(program, argv),
   },
   {
-    commands: [{ name: "browser", description: "Browser tools" }],
-    register: async ({ program }) => {
-      const mod = await import("../browser-cli.js");
-      mod.registerBrowserCli(program);
-    },
+    id: "status-health-sessions",
+    register: ({ program }) => registerStatusHealthSessionsCommands(program),
+  },
+  {
+    id: "browser",
+    register: ({ program }) => registerBrowserCli(program),
   },
 ];
-
-export function getCoreCliCommandNames(): string[] {
-  const seen = new Set<string>();
-  const names: string[] = [];
-  for (const entry of coreEntries) {
-    for (const cmd of entry.commands) {
-      if (seen.has(cmd.name)) {
-        continue;
-      }
-      seen.add(cmd.name);
-      names.push(cmd.name);
-    }
-  }
-  return names;
-}
-
-function removeCommand(program: Command, command: Command) {
-  const commands = program.commands as Command[];
-  const index = commands.indexOf(command);
-  if (index >= 0) {
-    commands.splice(index, 1);
-  }
-}
-
-function registerLazyCoreCommand(
-  program: Command,
-  ctx: ProgramContext,
-  entry: CoreCliEntry,
-  command: { name: string; description: string },
-) {
-  const placeholder = program.command(command.name).description(command.description);
-  placeholder.allowUnknownOption(true);
-  placeholder.allowExcessArguments(true);
-  placeholder.action(async (...actionArgs) => {
-    // Some registrars install multiple top-level commands (e.g. status/health/sessions).
-    // Remove placeholders/old registrations for all names in the entry before re-registering.
-    for (const cmd of entry.commands) {
-      const existing = program.commands.find((c) => c.name() === cmd.name);
-      if (existing) {
-        removeCommand(program, existing);
-      }
-    }
-    await entry.register({ program, ctx, argv: process.argv });
-    const actionCommand = actionArgs.at(-1) as Command | undefined;
-    const root = actionCommand?.parent ?? program;
-    const rawArgs = (root as Command & { rawArgs?: string[] }).rawArgs;
-    const actionArgsList = resolveActionArgs(actionCommand);
-    const fallbackArgv = actionCommand?.name()
-      ? [actionCommand.name(), ...actionArgsList]
-      : actionArgsList;
-    const parseArgv = buildParseArgv({
-      programName: program.name(),
-      rawArgs,
-      fallbackArgv,
-    });
-    await program.parseAsync(parseArgv);
-  });
-}
-
-export async function registerCoreCliByName(
-  program: Command,
-  ctx: ProgramContext,
-  name: string,
-  argv: string[] = process.argv,
-): Promise<boolean> {
-  const entry = coreEntries.find((candidate) =>
-    candidate.commands.some((cmd) => cmd.name === name),
-  );
-  if (!entry) {
-    return false;
-  }
-
-  // Some registrars install multiple top-level commands (e.g. status/health/sessions).
-  // Remove placeholders/old registrations for all names in the entry before re-registering.
-  for (const cmd of entry.commands) {
-    const existing = program.commands.find((c) => c.name() === cmd.name);
-    if (existing) {
-      removeCommand(program, existing);
-    }
-  }
-  await entry.register({ program, ctx, argv });
-  return true;
-}
-
-export function registerCoreCliCommands(program: Command, ctx: ProgramContext, argv: string[]) {
-  const primary = getPrimaryCommand(argv);
-  if (primary && shouldRegisterCorePrimaryOnly(argv)) {
-    const entry = coreEntries.find((candidate) =>
-      candidate.commands.some((cmd) => cmd.name === primary),
-    );
-    if (entry) {
-      const cmd = entry.commands.find((c) => c.name === primary);
-      if (cmd) {
-        registerLazyCoreCommand(program, ctx, entry, cmd);
-      }
-      return;
-    }
-  }
-
-  for (const entry of coreEntries) {
-    for (const cmd of entry.commands) {
-      registerLazyCoreCommand(program, ctx, entry, cmd);
-    }
-  }
-}
 
 export function registerProgramCommands(
   program: Command,
   ctx: ProgramContext,
   argv: string[] = process.argv,
 ) {
-  registerCoreCliCommands(program, ctx, argv);
-  registerSubCliCommands(program, argv);
+  for (const entry of commandRegistry) {
+    entry.register({ program, ctx, argv });
+  }
 }

--- a/src/cli/program/preaction.ts
+++ b/src/cli/program/preaction.ts
@@ -1,7 +1,5 @@
 import type { Command } from "commander";
-import { setVerbose } from "../../globals.js";
 import { isTruthyEnvValue } from "../../infra/env.js";
-import { defaultRuntime } from "../../runtime.js";
 import { getCommandPath, getVerboseFlag, hasHelpOrVersion } from "../argv.js";
 import { emitCliBanner } from "../banner.js";
 import { resolveCliName } from "../cli-name.js";
@@ -38,6 +36,7 @@ export function registerPreActionHooks(program: Command, programVersion: string)
     if (!hideBanner) {
       emitCliBanner(programVersion);
     }
+    const { setVerbose } = await import("../../globals.js");
     const verbose = getVerboseFlag(argv, { includeDebug: true });
     setVerbose(verbose);
     if (!verbose) {
@@ -46,6 +45,7 @@ export function registerPreActionHooks(program: Command, programVersion: string)
     if (commandPath[0] === "doctor" || commandPath[0] === "completion") {
       return;
     }
+    const { defaultRuntime } = await import("../../runtime.js");
     const { ensureConfigReady } = await import("./config-guard.js");
     await ensureConfigReady({ runtime: defaultRuntime, commandPath });
     // Load plugins for commands that need channel access

--- a/src/cli/program/register.agent.ts
+++ b/src/cli/program/register.agent.ts
@@ -1,19 +1,7 @@
 import type { Command } from "commander";
-import { DEFAULT_CHAT_CHANNEL } from "../../channels/registry.js";
-import { agentCliCommand } from "../../commands/agent-via-gateway.js";
-import {
-  agentsAddCommand,
-  agentsDeleteCommand,
-  agentsListCommand,
-  agentsSetIdentityCommand,
-} from "../../commands/agents.js";
-import { setVerbose } from "../../globals.js";
-import { defaultRuntime } from "../../runtime.js";
 import { formatDocsLink } from "../../terminal/links.js";
 import { theme } from "../../terminal/theme.js";
-import { runCommandWithRuntime } from "../cli-utils.js";
 import { hasExplicitOptions } from "../command-options.js";
-import { createDefaultDeps } from "../deps.js";
 import { formatHelpExamples } from "../help-format.js";
 import { collectOption } from "./helpers.js";
 
@@ -29,7 +17,7 @@ export function registerAgentCommands(program: Command, args: { agentChannelOpti
     .option("--verbose <on|off>", "Persist agent verbose level for the session")
     .option(
       "--channel <channel>",
-      `Delivery channel: ${args.agentChannelOptions} (default: ${DEFAULT_CHAT_CHANNEL})`,
+      `Delivery channel: ${args.agentChannelOptions} (default: whatsapp)`,
     )
     .option("--reply-to <target>", "Delivery target override (separate from session routing)")
     .option("--reply-channel <channel>", "Delivery channel override (separate from routing)")
@@ -71,10 +59,14 @@ ${formatHelpExamples([
 ${theme.muted("Docs:")} ${formatDocsLink("/cli/agent", "docs.openclaw.ai/cli/agent")}`,
     )
     .action(async (opts) => {
+      const { setVerbose } = await import("../../globals.js");
       const verboseLevel = typeof opts.verbose === "string" ? opts.verbose.toLowerCase() : "";
       setVerbose(verboseLevel === "on");
-      // Build default deps (keeps parity with other commands; future-proofing).
+      const { createDefaultDeps } = await import("../deps.js");
       const deps = createDefaultDeps();
+      const { defaultRuntime } = await import("../../runtime.js");
+      const { runCommandWithRuntime } = await import("../cli-utils.js");
+      const { agentCliCommand } = await import("../../commands/agent-via-gateway.js");
       await runCommandWithRuntime(defaultRuntime, async () => {
         await agentCliCommand(opts, defaultRuntime, deps);
       });
@@ -95,6 +87,9 @@ ${theme.muted("Docs:")} ${formatDocsLink("/cli/agent", "docs.openclaw.ai/cli/age
     .option("--json", "Output JSON instead of text", false)
     .option("--bindings", "Include routing bindings", false)
     .action(async (opts) => {
+      const { defaultRuntime } = await import("../../runtime.js");
+      const { runCommandWithRuntime } = await import("../cli-utils.js");
+      const { agentsListCommand } = await import("../../commands/agents.js");
       await runCommandWithRuntime(defaultRuntime, async () => {
         await agentsListCommand(
           { json: Boolean(opts.json), bindings: Boolean(opts.bindings) },
@@ -113,6 +108,9 @@ ${theme.muted("Docs:")} ${formatDocsLink("/cli/agent", "docs.openclaw.ai/cli/age
     .option("--non-interactive", "Disable prompts; requires --workspace", false)
     .option("--json", "Output JSON summary", false)
     .action(async (name, opts, command) => {
+      const { defaultRuntime } = await import("../../runtime.js");
+      const { runCommandWithRuntime } = await import("../cli-utils.js");
+      const { agentsAddCommand } = await import("../../commands/agents.js");
       await runCommandWithRuntime(defaultRuntime, async () => {
         const hasFlags = hasExplicitOptions(command, [
           "workspace",
@@ -169,6 +167,9 @@ ${formatHelpExamples([
 `,
     )
     .action(async (opts) => {
+      const { defaultRuntime } = await import("../../runtime.js");
+      const { runCommandWithRuntime } = await import("../cli-utils.js");
+      const { agentsSetIdentityCommand } = await import("../../commands/agents.js");
       await runCommandWithRuntime(defaultRuntime, async () => {
         await agentsSetIdentityCommand(
           {
@@ -193,6 +194,9 @@ ${formatHelpExamples([
     .option("--force", "Skip confirmation", false)
     .option("--json", "Output JSON summary", false)
     .action(async (id, opts) => {
+      const { defaultRuntime } = await import("../../runtime.js");
+      const { runCommandWithRuntime } = await import("../cli-utils.js");
+      const { agentsDeleteCommand } = await import("../../commands/agents.js");
       await runCommandWithRuntime(defaultRuntime, async () => {
         await agentsDeleteCommand(
           {
@@ -206,6 +210,9 @@ ${formatHelpExamples([
     });
 
   agents.action(async () => {
+    const { defaultRuntime } = await import("../../runtime.js");
+    const { runCommandWithRuntime } = await import("../cli-utils.js");
+    const { agentsListCommand } = await import("../../commands/agents.js");
     await runCommandWithRuntime(defaultRuntime, async () => {
       await agentsListCommand({}, defaultRuntime);
     });

--- a/src/cli/program/register.agent.ts
+++ b/src/cli/program/register.agent.ts
@@ -1,4 +1,5 @@
 import type { Command } from "commander";
+import { DEFAULT_CHAT_CHANNEL } from "../../channels/defaults.js";
 import { formatDocsLink } from "../../terminal/links.js";
 import { theme } from "../../terminal/theme.js";
 import { hasExplicitOptions } from "../command-options.js";
@@ -17,7 +18,7 @@ export function registerAgentCommands(program: Command, args: { agentChannelOpti
     .option("--verbose <on|off>", "Persist agent verbose level for the session")
     .option(
       "--channel <channel>",
-      `Delivery channel: ${args.agentChannelOptions} (default: whatsapp)`,
+      `Delivery channel: ${args.agentChannelOptions} (default: ${DEFAULT_CHAT_CHANNEL})`,
     )
     .option("--reply-to <target>", "Delivery target override (separate from session routing)")
     .option("--reply-channel <channel>", "Delivery channel override (separate from routing)")

--- a/src/cli/program/register.configure.ts
+++ b/src/cli/program/register.configure.ts
@@ -1,19 +1,7 @@
 import type { Command } from "commander";
+import { CONFIGURE_WIZARD_SECTIONS } from "../../commands/configure-sections.js";
 import { formatDocsLink } from "../../terminal/links.js";
 import { theme } from "../../terminal/theme.js";
-
-// Inlined from configure.shared.ts to avoid pulling in @clack/prompts for --help text.
-// The canonical list lives in commands/configure.shared.ts; keep in sync.
-const CONFIGURE_WIZARD_SECTIONS = [
-  "workspace",
-  "model",
-  "web",
-  "gateway",
-  "daemon",
-  "channels",
-  "skills",
-  "health",
-] as const;
 
 export function registerConfigureCommand(program: Command) {
   program

--- a/src/cli/program/register.configure.ts
+++ b/src/cli/program/register.configure.ts
@@ -1,14 +1,19 @@
 import type { Command } from "commander";
-import {
-  CONFIGURE_WIZARD_SECTIONS,
-  configureCommand,
-  configureCommandWithSections,
-  parseConfigureWizardSections,
-} from "../../commands/configure.js";
-import { defaultRuntime } from "../../runtime.js";
 import { formatDocsLink } from "../../terminal/links.js";
 import { theme } from "../../terminal/theme.js";
-import { runCommandWithRuntime } from "../cli-utils.js";
+
+// Inlined from configure.shared.ts to avoid pulling in @clack/prompts for --help text.
+// The canonical list lives in commands/configure.shared.ts; keep in sync.
+const CONFIGURE_WIZARD_SECTIONS = [
+  "workspace",
+  "model",
+  "web",
+  "gateway",
+  "daemon",
+  "channels",
+  "skills",
+  "health",
+] as const;
 
 export function registerConfigureCommand(program: Command) {
   program
@@ -26,6 +31,10 @@ export function registerConfigureCommand(program: Command) {
       [] as string[],
     )
     .action(async (opts) => {
+      const { defaultRuntime } = await import("../../runtime.js");
+      const { runCommandWithRuntime } = await import("../cli-utils.js");
+      const { configureCommand, configureCommandWithSections, parseConfigureWizardSections } =
+        await import("../../commands/configure.js");
       await runCommandWithRuntime(defaultRuntime, async () => {
         const { sections, invalid } = parseConfigureWizardSections(opts.section);
         if (sections.length === 0) {

--- a/src/cli/program/register.core-lazy.ts
+++ b/src/cli/program/register.core-lazy.ts
@@ -1,0 +1,113 @@
+import type { Command } from "commander";
+import type { ProgramContext } from "./context.js";
+
+type CoreCommandRegisterParams = {
+  program: Command;
+  ctx: ProgramContext;
+  argv: string[];
+};
+
+type LazyCoreEntry = {
+  id: string;
+  register: (params: CoreCommandRegisterParams) => Promise<void>;
+};
+
+/**
+ * Lazy-loadable core command registrations. Each entry dynamically imports only
+ * its own command module, avoiding the static import cascade in command-registry.ts
+ * that pulls in ~2.8MB of transitive dependencies.
+ *
+ * Used by run-main.ts when a specific primary command is known, so we skip loading
+ * all 11 command groups for a single command invocation.
+ */
+const lazyCoreEntries: LazyCoreEntry[] = [
+  {
+    id: "setup",
+    register: async ({ program }) => {
+      const { registerSetupCommand } = await import("./register.setup.js");
+      registerSetupCommand(program);
+    },
+  },
+  {
+    id: "onboard",
+    register: async ({ program }) => {
+      const { registerOnboardCommand } = await import("./register.onboard.js");
+      registerOnboardCommand(program);
+    },
+  },
+  {
+    id: "configure",
+    register: async ({ program }) => {
+      const { registerConfigureCommand } = await import("./register.configure.js");
+      registerConfigureCommand(program);
+    },
+  },
+  {
+    id: "config",
+    register: async ({ program }) => {
+      const { registerConfigCli } = await import("../config-cli.js");
+      registerConfigCli(program);
+    },
+  },
+  {
+    id: "maintenance",
+    register: async ({ program }) => {
+      const { registerMaintenanceCommands } = await import("./register.maintenance.js");
+      registerMaintenanceCommands(program);
+    },
+  },
+  {
+    id: "message",
+    register: async ({ program, ctx }) => {
+      const { registerMessageCommands } = await import("./register.message.js");
+      registerMessageCommands(program, ctx);
+    },
+  },
+  {
+    id: "memory",
+    register: async ({ program }) => {
+      const { registerMemoryCli } = await import("../memory-cli.js");
+      registerMemoryCli(program);
+    },
+  },
+  {
+    id: "agent",
+    register: async ({ program, ctx }) => {
+      const { registerAgentCommands } = await import("./register.agent.js");
+      registerAgentCommands(program, { agentChannelOptions: ctx.agentChannelOptions });
+    },
+  },
+  {
+    id: "browser",
+    register: async ({ program }) => {
+      const { registerBrowserCli } = await import("../browser-cli.js");
+      registerBrowserCli(program);
+    },
+  },
+  {
+    id: "status-health-sessions",
+    register: async ({ program }) => {
+      const { registerStatusHealthSessionsCommands } =
+        await import("./register.status-health-sessions.js");
+      registerStatusHealthSessionsCommands(program);
+    },
+  },
+];
+
+export async function registerCoreCommandByName(
+  program: Command,
+  ctx: ProgramContext,
+  name: string,
+  argv: string[],
+): Promise<boolean> {
+  const entry = lazyCoreEntries.find((e) => e.id === name);
+  if (!entry) {
+    return false;
+  }
+  await entry.register({ program, ctx, argv });
+  return true;
+}
+
+export function getLazyCoreEntries(): readonly LazyCoreEntry[] {
+  return lazyCoreEntries;
+}

--- a/src/cli/program/register.core-lazy.ts
+++ b/src/cli/program/register.core-lazy.ts
@@ -50,7 +50,28 @@ const lazyCoreEntries: LazyCoreEntry[] = [
     },
   },
   {
-    id: "maintenance",
+    id: "doctor",
+    register: async ({ program }) => {
+      const { registerMaintenanceCommands } = await import("./register.maintenance.js");
+      registerMaintenanceCommands(program);
+    },
+  },
+  {
+    id: "dashboard",
+    register: async ({ program }) => {
+      const { registerMaintenanceCommands } = await import("./register.maintenance.js");
+      registerMaintenanceCommands(program);
+    },
+  },
+  {
+    id: "reset",
+    register: async ({ program }) => {
+      const { registerMaintenanceCommands } = await import("./register.maintenance.js");
+      registerMaintenanceCommands(program);
+    },
+  },
+  {
+    id: "uninstall",
     register: async ({ program }) => {
       const { registerMaintenanceCommands } = await import("./register.maintenance.js");
       registerMaintenanceCommands(program);
@@ -78,6 +99,13 @@ const lazyCoreEntries: LazyCoreEntry[] = [
     },
   },
   {
+    id: "agents",
+    register: async ({ program, ctx }) => {
+      const { registerAgentCommands } = await import("./register.agent.js");
+      registerAgentCommands(program, { agentChannelOptions: ctx.agentChannelOptions });
+    },
+  },
+  {
     id: "browser",
     register: async ({ program }) => {
       const { registerBrowserCli } = await import("../browser-cli.js");
@@ -85,7 +113,23 @@ const lazyCoreEntries: LazyCoreEntry[] = [
     },
   },
   {
-    id: "status-health-sessions",
+    id: "status",
+    register: async ({ program }) => {
+      const { registerStatusHealthSessionsCommands } =
+        await import("./register.status-health-sessions.js");
+      registerStatusHealthSessionsCommands(program);
+    },
+  },
+  {
+    id: "health",
+    register: async ({ program }) => {
+      const { registerStatusHealthSessionsCommands } =
+        await import("./register.status-health-sessions.js");
+      registerStatusHealthSessionsCommands(program);
+    },
+  },
+  {
+    id: "sessions",
     register: async ({ program }) => {
       const { registerStatusHealthSessionsCommands } =
         await import("./register.status-health-sessions.js");

--- a/src/cli/program/register.maintenance.ts
+++ b/src/cli/program/register.maintenance.ts
@@ -1,12 +1,6 @@
 import type { Command } from "commander";
-import { dashboardCommand } from "../../commands/dashboard.js";
-import { doctorCommand } from "../../commands/doctor.js";
-import { resetCommand } from "../../commands/reset.js";
-import { uninstallCommand } from "../../commands/uninstall.js";
-import { defaultRuntime } from "../../runtime.js";
 import { formatDocsLink } from "../../terminal/links.js";
 import { theme } from "../../terminal/theme.js";
-import { runCommandWithRuntime } from "../cli-utils.js";
 
 export function registerMaintenanceCommands(program: Command) {
   program
@@ -26,6 +20,9 @@ export function registerMaintenanceCommands(program: Command) {
     .option("--generate-gateway-token", "Generate and configure a gateway token", false)
     .option("--deep", "Scan system services for extra gateway installs", false)
     .action(async (opts) => {
+      const { defaultRuntime } = await import("../../runtime.js");
+      const { runCommandWithRuntime } = await import("../cli-utils.js");
+      const { doctorCommand } = await import("../../commands/doctor.js");
       await runCommandWithRuntime(defaultRuntime, async () => {
         await doctorCommand(defaultRuntime, {
           workspaceSuggestions: opts.workspaceSuggestions,
@@ -49,6 +46,9 @@ export function registerMaintenanceCommands(program: Command) {
     )
     .option("--no-open", "Print URL but do not launch a browser", false)
     .action(async (opts) => {
+      const { defaultRuntime } = await import("../../runtime.js");
+      const { runCommandWithRuntime } = await import("../cli-utils.js");
+      const { dashboardCommand } = await import("../../commands/dashboard.js");
       await runCommandWithRuntime(defaultRuntime, async () => {
         await dashboardCommand(defaultRuntime, {
           noOpen: Boolean(opts.noOpen),
@@ -69,6 +69,9 @@ export function registerMaintenanceCommands(program: Command) {
     .option("--non-interactive", "Disable prompts (requires --scope + --yes)", false)
     .option("--dry-run", "Print actions without removing files", false)
     .action(async (opts) => {
+      const { defaultRuntime } = await import("../../runtime.js");
+      const { runCommandWithRuntime } = await import("../cli-utils.js");
+      const { resetCommand } = await import("../../commands/reset.js");
       await runCommandWithRuntime(defaultRuntime, async () => {
         await resetCommand(defaultRuntime, {
           scope: opts.scope,
@@ -96,6 +99,9 @@ export function registerMaintenanceCommands(program: Command) {
     .option("--non-interactive", "Disable prompts (requires --yes)", false)
     .option("--dry-run", "Print actions without removing files", false)
     .action(async (opts) => {
+      const { defaultRuntime } = await import("../../runtime.js");
+      const { runCommandWithRuntime } = await import("../cli-utils.js");
+      const { uninstallCommand } = await import("../../commands/uninstall.js");
       await runCommandWithRuntime(defaultRuntime, async () => {
         await uninstallCommand(defaultRuntime, {
           service: Boolean(opts.service),

--- a/src/cli/program/register.onboard.ts
+++ b/src/cli/program/register.onboard.ts
@@ -55,7 +55,6 @@ export function registerOnboardCommand(program: Command) {
     .option("--mode <mode>", "Wizard mode: local|remote")
     .option(
       "--auth-choice <choice>",
-      "Auth: setup-token|token|chutes|openai-codex|openai-api-key|xai-api-key|qianfan-api-key|openrouter-api-key|litellm-api-key|ai-gateway-api-key|cloudflare-ai-gateway-api-key|moonshot-api-key|moonshot-api-key-cn|kimi-code-api-key|synthetic-api-key|venice-api-key|gemini-api-key|zai-api-key|zai-coding-global|zai-coding-cn|zai-global|zai-cn|xiaomi-api-key|apiKey|minimax-api|minimax-api-lightning|opencode-zen|custom-api-key|skip|together-api-key|huggingface-api-key",
       "Auth: setup-token|token|chutes|vllm|openai-codex|openai-api-key|xai-api-key|qianfan-api-key|openrouter-api-key|litellm-api-key|ai-gateway-api-key|cloudflare-ai-gateway-api-key|moonshot-api-key|moonshot-api-key-cn|kimi-code-api-key|synthetic-api-key|venice-api-key|gemini-api-key|zai-api-key|zai-coding-global|zai-coding-cn|zai-global|zai-cn|xiaomi-api-key|apiKey|minimax-api|minimax-api-lightning|opencode-zen|custom-api-key|skip|together-api-key|huggingface-api-key",
     )
     .option(

--- a/src/cli/program/register.onboard.ts
+++ b/src/cli/program/register.onboard.ts
@@ -7,13 +7,8 @@ import type {
   NodeManagerChoice,
   TailscaleMode,
 } from "../../commands/onboard-types.js";
-import { formatAuthChoiceChoicesForCli } from "../../commands/auth-choice-options.js";
-import { ONBOARD_PROVIDER_AUTH_FLAGS } from "../../commands/onboard-provider-auth-flags.js";
-import { onboardCommand } from "../../commands/onboard.js";
-import { defaultRuntime } from "../../runtime.js";
 import { formatDocsLink } from "../../terminal/links.js";
 import { theme } from "../../terminal/theme.js";
-import { runCommandWithRuntime } from "../cli-utils.js";
 
 function resolveInstallDaemonFlag(
   command: unknown,
@@ -39,13 +34,8 @@ function resolveInstallDaemonFlag(
   return undefined;
 }
 
-const AUTH_CHOICE_HELP = formatAuthChoiceChoicesForCli({
-  includeLegacyAliases: true,
-  includeSkip: true,
-});
-
 export function registerOnboardCommand(program: Command) {
-  const command = program
+  program
     .command("onboard")
     .description("Interactive wizard to set up the gateway, workspace, and skills")
     .addHelpText(
@@ -63,7 +53,11 @@ export function registerOnboardCommand(program: Command) {
     )
     .option("--flow <flow>", "Wizard flow: quickstart|advanced|manual")
     .option("--mode <mode>", "Wizard mode: local|remote")
-    .option("--auth-choice <choice>", `Auth: ${AUTH_CHOICE_HELP}`)
+    .option(
+      "--auth-choice <choice>",
+      "Auth: setup-token|token|chutes|openai-codex|openai-api-key|xai-api-key|qianfan-api-key|openrouter-api-key|litellm-api-key|ai-gateway-api-key|cloudflare-ai-gateway-api-key|moonshot-api-key|moonshot-api-key-cn|kimi-code-api-key|synthetic-api-key|venice-api-key|gemini-api-key|zai-api-key|zai-coding-global|zai-coding-cn|zai-global|zai-cn|xiaomi-api-key|apiKey|minimax-api|minimax-api-lightning|opencode-zen|custom-api-key|skip|together-api-key|huggingface-api-key",
+      "Auth: setup-token|token|chutes|vllm|openai-codex|openai-api-key|xai-api-key|qianfan-api-key|openrouter-api-key|litellm-api-key|ai-gateway-api-key|cloudflare-ai-gateway-api-key|moonshot-api-key|moonshot-api-key-cn|kimi-code-api-key|synthetic-api-key|venice-api-key|gemini-api-key|zai-api-key|zai-coding-global|zai-coding-cn|zai-global|zai-cn|xiaomi-api-key|apiKey|minimax-api|minimax-api-lightning|opencode-zen|custom-api-key|skip|together-api-key|huggingface-api-key",
+    )
     .option(
       "--token-provider <id>",
       "Token provider id (non-interactive; used with --auth-choice token)",
@@ -74,14 +68,27 @@ export function registerOnboardCommand(program: Command) {
       "Auth profile id (non-interactive; default: <provider>:manual)",
     )
     .option("--token-expires-in <duration>", "Optional token expiry duration (e.g. 365d, 12h)")
+    .option("--anthropic-api-key <key>", "Anthropic API key")
+    .option("--openai-api-key <key>", "OpenAI API key")
+    .option("--openrouter-api-key <key>", "OpenRouter API key")
+    .option("--ai-gateway-api-key <key>", "Vercel AI Gateway API key")
     .option("--cloudflare-ai-gateway-account-id <id>", "Cloudflare Account ID")
-    .option("--cloudflare-ai-gateway-gateway-id <id>", "Cloudflare AI Gateway ID");
-
-  for (const providerFlag of ONBOARD_PROVIDER_AUTH_FLAGS) {
-    command.option(providerFlag.cliOption, providerFlag.description);
-  }
-
-  command
+    .option("--cloudflare-ai-gateway-gateway-id <id>", "Cloudflare AI Gateway ID")
+    .option("--cloudflare-ai-gateway-api-key <key>", "Cloudflare AI Gateway API key")
+    .option("--moonshot-api-key <key>", "Moonshot API key")
+    .option("--kimi-code-api-key <key>", "Kimi Coding API key")
+    .option("--gemini-api-key <key>", "Gemini API key")
+    .option("--zai-api-key <key>", "Z.AI API key")
+    .option("--xiaomi-api-key <key>", "Xiaomi API key")
+    .option("--minimax-api-key <key>", "MiniMax API key")
+    .option("--synthetic-api-key <key>", "Synthetic API key")
+    .option("--venice-api-key <key>", "Venice API key")
+    .option("--together-api-key <key>", "Together AI API key")
+    .option("--huggingface-api-key <key>", "Hugging Face API key (HF token)")
+    .option("--opencode-zen-api-key <key>", "OpenCode Zen API key")
+    .option("--xai-api-key <key>", "xAI API key")
+    .option("--litellm-api-key <key>", "LiteLLM API key")
+    .option("--qianfan-api-key <key>", "QIANFAN API key")
     .option("--custom-base-url <url>", "Custom provider base URL")
     .option("--custom-api-key <key>", "Custom provider API key (optional)")
     .option("--custom-model-id <id>", "Custom provider model ID")
@@ -108,77 +115,79 @@ export function registerOnboardCommand(program: Command) {
     .option("--skip-health", "Skip health check")
     .option("--skip-ui", "Skip Control UI/TUI prompts")
     .option("--node-manager <name>", "Node manager for skills: npm|pnpm|bun")
-    .option("--json", "Output JSON summary", false);
-
-  command.action(async (opts, commandRuntime) => {
-    await runCommandWithRuntime(defaultRuntime, async () => {
-      const installDaemon = resolveInstallDaemonFlag(commandRuntime, {
-        installDaemon: Boolean(opts.installDaemon),
+    .option("--json", "Output JSON summary", false)
+    .action(async (opts, command) => {
+      const { defaultRuntime } = await import("../../runtime.js");
+      const { runCommandWithRuntime } = await import("../cli-utils.js");
+      const { onboardCommand } = await import("../../commands/onboard.js");
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        const installDaemon = resolveInstallDaemonFlag(command, {
+          installDaemon: Boolean(opts.installDaemon),
+        });
+        const gatewayPort =
+          typeof opts.gatewayPort === "string" ? Number.parseInt(opts.gatewayPort, 10) : undefined;
+        await onboardCommand(
+          {
+            workspace: opts.workspace as string | undefined,
+            nonInteractive: Boolean(opts.nonInteractive),
+            acceptRisk: Boolean(opts.acceptRisk),
+            flow: opts.flow as "quickstart" | "advanced" | "manual" | undefined,
+            mode: opts.mode as "local" | "remote" | undefined,
+            authChoice: opts.authChoice as AuthChoice | undefined,
+            tokenProvider: opts.tokenProvider as string | undefined,
+            token: opts.token as string | undefined,
+            tokenProfileId: opts.tokenProfileId as string | undefined,
+            tokenExpiresIn: opts.tokenExpiresIn as string | undefined,
+            anthropicApiKey: opts.anthropicApiKey as string | undefined,
+            openaiApiKey: opts.openaiApiKey as string | undefined,
+            openrouterApiKey: opts.openrouterApiKey as string | undefined,
+            aiGatewayApiKey: opts.aiGatewayApiKey as string | undefined,
+            cloudflareAiGatewayAccountId: opts.cloudflareAiGatewayAccountId as string | undefined,
+            cloudflareAiGatewayGatewayId: opts.cloudflareAiGatewayGatewayId as string | undefined,
+            cloudflareAiGatewayApiKey: opts.cloudflareAiGatewayApiKey as string | undefined,
+            moonshotApiKey: opts.moonshotApiKey as string | undefined,
+            kimiCodeApiKey: opts.kimiCodeApiKey as string | undefined,
+            geminiApiKey: opts.geminiApiKey as string | undefined,
+            zaiApiKey: opts.zaiApiKey as string | undefined,
+            xiaomiApiKey: opts.xiaomiApiKey as string | undefined,
+            qianfanApiKey: opts.qianfanApiKey as string | undefined,
+            minimaxApiKey: opts.minimaxApiKey as string | undefined,
+            syntheticApiKey: opts.syntheticApiKey as string | undefined,
+            veniceApiKey: opts.veniceApiKey as string | undefined,
+            togetherApiKey: opts.togetherApiKey as string | undefined,
+            huggingfaceApiKey: opts.huggingfaceApiKey as string | undefined,
+            opencodeZenApiKey: opts.opencodeZenApiKey as string | undefined,
+            xaiApiKey: opts.xaiApiKey as string | undefined,
+            litellmApiKey: opts.litellmApiKey as string | undefined,
+            customBaseUrl: opts.customBaseUrl as string | undefined,
+            customApiKey: opts.customApiKey as string | undefined,
+            customModelId: opts.customModelId as string | undefined,
+            customProviderId: opts.customProviderId as string | undefined,
+            customCompatibility: opts.customCompatibility as "openai" | "anthropic" | undefined,
+            gatewayPort:
+              typeof gatewayPort === "number" && Number.isFinite(gatewayPort)
+                ? gatewayPort
+                : undefined,
+            gatewayBind: opts.gatewayBind as GatewayBind | undefined,
+            gatewayAuth: opts.gatewayAuth as GatewayAuthChoice | undefined,
+            gatewayToken: opts.gatewayToken as string | undefined,
+            gatewayPassword: opts.gatewayPassword as string | undefined,
+            remoteUrl: opts.remoteUrl as string | undefined,
+            remoteToken: opts.remoteToken as string | undefined,
+            tailscale: opts.tailscale as TailscaleMode | undefined,
+            tailscaleResetOnExit: Boolean(opts.tailscaleResetOnExit),
+            reset: Boolean(opts.reset),
+            installDaemon,
+            daemonRuntime: opts.daemonRuntime as GatewayDaemonRuntime | undefined,
+            skipChannels: Boolean(opts.skipChannels),
+            skipSkills: Boolean(opts.skipSkills),
+            skipHealth: Boolean(opts.skipHealth),
+            skipUi: Boolean(opts.skipUi),
+            nodeManager: opts.nodeManager as NodeManagerChoice | undefined,
+            json: Boolean(opts.json),
+          },
+          defaultRuntime,
+        );
       });
-      const gatewayPort =
-        typeof opts.gatewayPort === "string" ? Number.parseInt(opts.gatewayPort, 10) : undefined;
-      await onboardCommand(
-        {
-          workspace: opts.workspace as string | undefined,
-          nonInteractive: Boolean(opts.nonInteractive),
-          acceptRisk: Boolean(opts.acceptRisk),
-          flow: opts.flow as "quickstart" | "advanced" | "manual" | undefined,
-          mode: opts.mode as "local" | "remote" | undefined,
-          authChoice: opts.authChoice as AuthChoice | undefined,
-          tokenProvider: opts.tokenProvider as string | undefined,
-          token: opts.token as string | undefined,
-          tokenProfileId: opts.tokenProfileId as string | undefined,
-          tokenExpiresIn: opts.tokenExpiresIn as string | undefined,
-          anthropicApiKey: opts.anthropicApiKey as string | undefined,
-          openaiApiKey: opts.openaiApiKey as string | undefined,
-          openrouterApiKey: opts.openrouterApiKey as string | undefined,
-          aiGatewayApiKey: opts.aiGatewayApiKey as string | undefined,
-          cloudflareAiGatewayAccountId: opts.cloudflareAiGatewayAccountId as string | undefined,
-          cloudflareAiGatewayGatewayId: opts.cloudflareAiGatewayGatewayId as string | undefined,
-          cloudflareAiGatewayApiKey: opts.cloudflareAiGatewayApiKey as string | undefined,
-          moonshotApiKey: opts.moonshotApiKey as string | undefined,
-          kimiCodeApiKey: opts.kimiCodeApiKey as string | undefined,
-          geminiApiKey: opts.geminiApiKey as string | undefined,
-          zaiApiKey: opts.zaiApiKey as string | undefined,
-          xiaomiApiKey: opts.xiaomiApiKey as string | undefined,
-          qianfanApiKey: opts.qianfanApiKey as string | undefined,
-          minimaxApiKey: opts.minimaxApiKey as string | undefined,
-          syntheticApiKey: opts.syntheticApiKey as string | undefined,
-          veniceApiKey: opts.veniceApiKey as string | undefined,
-          togetherApiKey: opts.togetherApiKey as string | undefined,
-          huggingfaceApiKey: opts.huggingfaceApiKey as string | undefined,
-          opencodeZenApiKey: opts.opencodeZenApiKey as string | undefined,
-          xaiApiKey: opts.xaiApiKey as string | undefined,
-          litellmApiKey: opts.litellmApiKey as string | undefined,
-          customBaseUrl: opts.customBaseUrl as string | undefined,
-          customApiKey: opts.customApiKey as string | undefined,
-          customModelId: opts.customModelId as string | undefined,
-          customProviderId: opts.customProviderId as string | undefined,
-          customCompatibility: opts.customCompatibility as "openai" | "anthropic" | undefined,
-          gatewayPort:
-            typeof gatewayPort === "number" && Number.isFinite(gatewayPort)
-              ? gatewayPort
-              : undefined,
-          gatewayBind: opts.gatewayBind as GatewayBind | undefined,
-          gatewayAuth: opts.gatewayAuth as GatewayAuthChoice | undefined,
-          gatewayToken: opts.gatewayToken as string | undefined,
-          gatewayPassword: opts.gatewayPassword as string | undefined,
-          remoteUrl: opts.remoteUrl as string | undefined,
-          remoteToken: opts.remoteToken as string | undefined,
-          tailscale: opts.tailscale as TailscaleMode | undefined,
-          tailscaleResetOnExit: Boolean(opts.tailscaleResetOnExit),
-          reset: Boolean(opts.reset),
-          installDaemon,
-          daemonRuntime: opts.daemonRuntime as GatewayDaemonRuntime | undefined,
-          skipChannels: Boolean(opts.skipChannels),
-          skipSkills: Boolean(opts.skipSkills),
-          skipHealth: Boolean(opts.skipHealth),
-          skipUi: Boolean(opts.skipUi),
-          nodeManager: opts.nodeManager as NodeManagerChoice | undefined,
-          json: Boolean(opts.json),
-        },
-        defaultRuntime,
-      );
     });
-  });
 }

--- a/src/cli/program/register.setup.ts
+++ b/src/cli/program/register.setup.ts
@@ -1,10 +1,6 @@
 import type { Command } from "commander";
-import { onboardCommand } from "../../commands/onboard.js";
-import { setupCommand } from "../../commands/setup.js";
-import { defaultRuntime } from "../../runtime.js";
 import { formatDocsLink } from "../../terminal/links.js";
 import { theme } from "../../terminal/theme.js";
-import { runCommandWithRuntime } from "../cli-utils.js";
 import { hasExplicitOptions } from "../command-options.js";
 
 export function registerSetupCommand(program: Command) {
@@ -26,6 +22,8 @@ export function registerSetupCommand(program: Command) {
     .option("--remote-url <url>", "Remote Gateway WebSocket URL")
     .option("--remote-token <token>", "Remote Gateway token (optional)")
     .action(async (opts, command) => {
+      const { defaultRuntime } = await import("../../runtime.js");
+      const { runCommandWithRuntime } = await import("../cli-utils.js");
       await runCommandWithRuntime(defaultRuntime, async () => {
         const hasWizardFlags = hasExplicitOptions(command, [
           "wizard",
@@ -35,6 +33,7 @@ export function registerSetupCommand(program: Command) {
           "remoteToken",
         ]);
         if (opts.wizard || hasWizardFlags) {
+          const { onboardCommand } = await import("../../commands/onboard.js");
           await onboardCommand(
             {
               workspace: opts.workspace as string | undefined,
@@ -47,6 +46,7 @@ export function registerSetupCommand(program: Command) {
           );
           return;
         }
+        const { setupCommand } = await import("../../commands/setup.js");
         await setupCommand({ workspace: opts.workspace as string | undefined }, defaultRuntime);
       });
     });

--- a/src/cli/program/register.status-health-sessions.ts
+++ b/src/cli/program/register.status-health-sessions.ts
@@ -1,12 +1,6 @@
 import type { Command } from "commander";
-import { healthCommand } from "../../commands/health.js";
-import { sessionsCommand } from "../../commands/sessions.js";
-import { statusCommand } from "../../commands/status.js";
-import { setVerbose } from "../../globals.js";
-import { defaultRuntime } from "../../runtime.js";
 import { formatDocsLink } from "../../terminal/links.js";
 import { theme } from "../../terminal/theme.js";
-import { runCommandWithRuntime } from "../cli-utils.js";
 import { formatHelpExamples } from "../help-format.js";
 import { parsePositiveIntOrUndefined } from "./helpers.js";
 
@@ -14,9 +8,10 @@ function resolveVerbose(opts: { verbose?: boolean; debug?: boolean }): boolean {
   return Boolean(opts.verbose || opts.debug);
 }
 
-function parseTimeoutMs(timeout: unknown): number | null | undefined {
+async function parseTimeoutMs(timeout: unknown): Promise<number | null | undefined> {
   const parsed = parsePositiveIntOrUndefined(timeout);
   if (timeout !== undefined && parsed === undefined) {
+    const { defaultRuntime } = await import("../../runtime.js");
     defaultRuntime.error("--timeout must be a positive integer (milliseconds)");
     defaultRuntime.exit(1);
     return null;
@@ -56,12 +51,16 @@ export function registerStatusHealthSessionsCommands(program: Command) {
         `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/status", "docs.openclaw.ai/cli/status")}\n`,
     )
     .action(async (opts) => {
+      const { setVerbose } = await import("../../globals.js");
       const verbose = resolveVerbose(opts);
       setVerbose(verbose);
-      const timeout = parseTimeoutMs(opts.timeout);
+      const timeout = await parseTimeoutMs(opts.timeout);
       if (timeout === null) {
         return;
       }
+      const { defaultRuntime } = await import("../../runtime.js");
+      const { runCommandWithRuntime } = await import("../cli-utils.js");
+      const { statusCommand } = await import("../../commands/status.js");
       await runCommandWithRuntime(defaultRuntime, async () => {
         await statusCommand(
           {
@@ -90,12 +89,16 @@ export function registerStatusHealthSessionsCommands(program: Command) {
         `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/health", "docs.openclaw.ai/cli/health")}\n`,
     )
     .action(async (opts) => {
+      const { setVerbose } = await import("../../globals.js");
       const verbose = resolveVerbose(opts);
       setVerbose(verbose);
-      const timeout = parseTimeoutMs(opts.timeout);
+      const timeout = await parseTimeoutMs(opts.timeout);
       if (timeout === null) {
         return;
       }
+      const { defaultRuntime } = await import("../../runtime.js");
+      const { runCommandWithRuntime } = await import("../cli-utils.js");
+      const { healthCommand } = await import("../../commands/health.js");
       await runCommandWithRuntime(defaultRuntime, async () => {
         await healthCommand(
           {
@@ -133,7 +136,10 @@ export function registerStatusHealthSessionsCommands(program: Command) {
         `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/sessions", "docs.openclaw.ai/cli/sessions")}\n`,
     )
     .action(async (opts) => {
+      const { setVerbose } = await import("../../globals.js");
       setVerbose(Boolean(opts.verbose));
+      const { defaultRuntime } = await import("../../runtime.js");
+      const { sessionsCommand } = await import("../../commands/sessions.js");
       await sessionsCommand(
         {
           json: Boolean(opts.json),

--- a/src/cli/route.ts
+++ b/src/cli/route.ts
@@ -1,10 +1,7 @@
 import { isTruthyEnvValue } from "../infra/env.js";
-import { defaultRuntime } from "../runtime.js";
 import { VERSION } from "../version.js";
 import { getCommandPath, hasHelpOrVersion } from "./argv.js";
 import { emitCliBanner } from "./banner.js";
-import { ensurePluginRegistryLoaded } from "./plugin-registry.js";
-import { ensureConfigReady } from "./program/config-guard.js";
 import { findRoutedCommand } from "./program/routes.js";
 
 async function prepareRoutedCommand(params: {
@@ -13,8 +10,11 @@ async function prepareRoutedCommand(params: {
   loadPlugins?: boolean;
 }) {
   emitCliBanner(VERSION, { argv: params.argv });
+  const { defaultRuntime } = await import("../runtime.js");
+  const { ensureConfigReady } = await import("./program/config-guard.js");
   await ensureConfigReady({ runtime: defaultRuntime, commandPath: params.commandPath });
   if (params.loadPlugins) {
+    const { ensurePluginRegistryLoaded } = await import("./plugin-registry.js");
     ensurePluginRegistryLoaded();
   }
 }

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -9,7 +9,6 @@ import { assertSupportedRuntime } from "../infra/runtime-guard.js";
 import { installUnhandledRejectionHandler } from "../infra/unhandled-rejections.js";
 import { enableConsoleCapture } from "../logging.js";
 import { getCommandPath, getPrimaryCommand, hasHelpOrVersion } from "./argv.js";
-import { tryRouteCli } from "./route.js";
 import { normalizeWindowsArgv } from "./windows-argv.js";
 
 export function rewriteUpdateFlagArgv(argv: string[]): string[] {
@@ -72,15 +71,18 @@ export async function runCli(argv: string[] = process.argv) {
   // Enforce the minimum supported runtime before doing any work.
   assertSupportedRuntime();
 
-  if (await tryRouteCli(normalizedArgv)) {
-    return;
+  if (!hasHelpOrVersion(normalizedArgv)) {
+    const { tryRouteCli } = await import("./route.js");
+    if (await tryRouteCli(normalizedArgv)) {
+      return;
+    }
   }
 
   // Capture all console output into structured logs while keeping stdout/stderr behavior.
   enableConsoleCapture();
 
   const { buildProgramShell } = await import("./program/build-program-shell.js");
-  const { program, ctx } = buildProgramShell();
+  const { program, ctx, provideChannelOptions } = buildProgramShell();
 
   // Global error handlers to prevent silent crashes from unhandled rejections/exceptions.
   // These log the error and exit gracefully instead of crashing without trace.
@@ -108,6 +110,8 @@ export async function runCli(argv: string[] = process.argv) {
   }
 
   if (!commandRegistered) {
+    const { resolveCliChannelOptions } = await import("./channel-options.js");
+    provideChannelOptions(resolveCliChannelOptions);
     const { registerProgramCommands } = await import("./program/command-registry.js");
     registerProgramCommands(program, ctx, parseArgv);
   }

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -104,6 +104,12 @@ export async function runCli(argv: string[] = process.argv) {
     commandRegistered = await registerSubCliByName(program, primary);
 
     if (!commandRegistered) {
+      // Commands that use channel options in their help text need the provider
+      // set before registration, otherwise --channel shows incomplete choices.
+      if (primary === "agent" || primary === "agents" || primary === "message") {
+        const { resolveCliChannelOptions } = await import("./channel-options.js");
+        provideChannelOptions(resolveCliChannelOptions);
+      }
       const { registerCoreCommandByName } = await import("./program/register.core-lazy.js");
       commandRegistered = await registerCoreCommandByName(program, ctx, primary, parseArgv);
     }

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -79,8 +79,8 @@ export async function runCli(argv: string[] = process.argv) {
   // Capture all console output into structured logs while keeping stdout/stderr behavior.
   enableConsoleCapture();
 
-  const { buildProgram } = await import("./program.js");
-  const program = buildProgram();
+  const { buildProgramShell } = await import("./program/build-program-shell.js");
+  const { program, ctx } = buildProgramShell();
 
   // Global error handlers to prevent silent crashes from unhandled rejections/exceptions.
   // These log the error and exit gracefully instead of crashing without trace.
@@ -92,26 +92,30 @@ export async function runCli(argv: string[] = process.argv) {
   });
 
   const parseArgv = rewriteUpdateFlagArgv(normalizedArgv);
-  // Register the primary command (builtin or subcli) so help and command parsing
-  // are correct even with lazy command registration.
+  // Try to register only the specific command needed instead of all 11 groups.
+  // Falls back to full registration for unknown commands or bare `openclaw --help`.
   const primary = getPrimaryCommand(parseArgv);
-  if (primary) {
-    const { getProgramContext } = await import("./program/program-context.js");
-    const ctx = getProgramContext(program);
-    if (ctx) {
-      const { registerCoreCliByName } = await import("./program/command-registry.js");
-      await registerCoreCliByName(program, ctx, primary, parseArgv);
-    }
+
+  let commandRegistered = false;
+  if (primary && shouldRegisterPrimarySubcommand(parseArgv)) {
     const { registerSubCliByName } = await import("./program/register.subclis.js");
-    await registerSubCliByName(program, primary);
+    commandRegistered = await registerSubCliByName(program, primary);
+
+    if (!commandRegistered) {
+      const { registerCoreCommandByName } = await import("./program/register.core-lazy.js");
+      commandRegistered = await registerCoreCommandByName(program, ctx, primary, parseArgv);
+    }
   }
 
-  const hasBuiltinPrimary =
-    primary !== null && program.commands.some((command) => command.name() === primary);
+  if (!commandRegistered) {
+    const { registerProgramCommands } = await import("./program/command-registry.js");
+    registerProgramCommands(program, ctx, parseArgv);
+  }
+
   const shouldSkipPluginRegistration = shouldSkipPluginCommandRegistration({
     argv: parseArgv,
     primary,
-    hasBuiltinPrimary,
+    hasBuiltinPrimary: commandRegistered,
   });
   if (!shouldSkipPluginRegistration) {
     // Register plugin CLI commands before parsing

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -29,10 +29,14 @@ vi.mock("../infra/openclaw-root.js", () => ({
   resolveOpenClawPackageRoot: vi.fn(),
 }));
 
-vi.mock("../config/config.js", () => ({
-  readConfigFileSnapshot: vi.fn(),
-  writeConfigFile: vi.fn(),
-}));
+vi.mock("../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/config.js")>();
+  return {
+    ...actual,
+    readConfigFileSnapshot: vi.fn(),
+    writeConfigFile: vi.fn(),
+  };
+});
 
 vi.mock("../infra/update-check.js", () => {
   const parseSemver = (

--- a/src/commands/configure-sections.ts
+++ b/src/commands/configure-sections.ts
@@ -1,0 +1,14 @@
+// Extracted to a standalone module so the CLI registration file can import
+// the section list without pulling in @clack/prompts (which configure.shared.ts uses).
+export const CONFIGURE_WIZARD_SECTIONS = [
+  "workspace",
+  "model",
+  "web",
+  "gateway",
+  "daemon",
+  "channels",
+  "skills",
+  "health",
+] as const;
+
+export type WizardSection = (typeof CONFIGURE_WIZARD_SECTIONS)[number];

--- a/src/commands/configure.shared.ts
+++ b/src/commands/configure.shared.ts
@@ -7,18 +7,8 @@ import {
 } from "@clack/prompts";
 import { stylePromptHint, stylePromptMessage, stylePromptTitle } from "../terminal/prompt-style.js";
 
-export const CONFIGURE_WIZARD_SECTIONS = [
-  "workspace",
-  "model",
-  "web",
-  "gateway",
-  "daemon",
-  "channels",
-  "skills",
-  "health",
-] as const;
-
-export type WizardSection = (typeof CONFIGURE_WIZARD_SECTIONS)[number];
+export { CONFIGURE_WIZARD_SECTIONS } from "./configure-sections.js";
+export type { WizardSection } from "./configure-sections.js";
 
 export function parseConfigureWizardSections(raw: unknown): {
   sections: WizardSection[];

--- a/src/commands/configure.shared.ts
+++ b/src/commands/configure.shared.ts
@@ -7,6 +7,8 @@ import {
 } from "@clack/prompts";
 import { stylePromptHint, stylePromptMessage, stylePromptTitle } from "../terminal/prompt-style.js";
 
+import type { WizardSection } from "./configure-sections.js";
+
 export { CONFIGURE_WIZARD_SECTIONS } from "./configure-sections.js";
 export type { WizardSection } from "./configure-sections.js";
 

--- a/src/commands/configure.shared.ts
+++ b/src/commands/configure.shared.ts
@@ -5,8 +5,8 @@ import {
   select as clackSelect,
   text as clackText,
 } from "@clack/prompts";
-import type { WizardSection } from "./configure-sections.js";
 import { stylePromptHint, stylePromptMessage, stylePromptTitle } from "../terminal/prompt-style.js";
+import { CONFIGURE_WIZARD_SECTIONS, type WizardSection } from "./configure-sections.js";
 
 export { CONFIGURE_WIZARD_SECTIONS } from "./configure-sections.js";
 export type { WizardSection } from "./configure-sections.js";

--- a/src/commands/configure.shared.ts
+++ b/src/commands/configure.shared.ts
@@ -5,9 +5,8 @@ import {
   select as clackSelect,
   text as clackText,
 } from "@clack/prompts";
-import { stylePromptHint, stylePromptMessage, stylePromptTitle } from "../terminal/prompt-style.js";
-
 import type { WizardSection } from "./configure-sections.js";
+import { stylePromptHint, stylePromptMessage, stylePromptTitle } from "../terminal/prompt-style.js";
 
 export { CONFIGURE_WIZARD_SECTIONS } from "./configure-sections.js";
 export type { WizardSection } from "./configure-sections.js";


### PR DESCRIPTION
## Summary

Introduces per-command lazy loading for the CLI startup path. Instead of importing the full command registry (which pulls in every sub-CLI and their transitive dependencies), each command is resolved at parse time and only its registration module is loaded.

- Adds `register.core-lazy.ts` with a lightweight per-command dispatch table
- Extracts route specs from `command-registry.ts` to break the static import chain
- Defers heavy imports in `run-main.ts`, `route.ts`, `preaction.ts`, `context.ts`, and `config-cli.ts` to after command resolution
- Defers `dotenv`, `console-capture`, and env normalization
- Lazy-loads action dependencies in all core register files

This is **part 1 of 4** in a series optimizing CLI cold-start performance. This PR sets up the lazy-loading infrastructure that subsequent PRs build on:
- Part 2: Browser-cli and status command deferred imports
- Part 3: Sub-CLI lazy loading and help stubs
- Part 4: Bundle-level import chain breaking

## Test plan

- [x] `pnpm build && pnpm check` pass locally
- [x] Full test suite passes on the complete stack (parts 1-4)
- [ ] CI passes

## AI disclosure

Built with Claude Code (AI-assisted). Fully tested locally. I understand and can explain every change — the core idea is deferring `await import()` calls from module scope to inside action handlers so they only load when a specific command is invoked.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces lazy-loading infrastructure for CLI commands to improve cold-start performance. Instead of eagerly importing all 11 command groups and their dependencies at startup, it resolves commands at parse time and dynamically imports only the needed modules.

**Key changes:**
- Added `register.core-lazy.ts` with per-command dispatch table for lazy registration
- Extracted constants (`DEFAULT_CHAT_CHANNEL`, `CONFIGURE_WIZARD_SECTIONS`) into standalone modules to break import chains
- Deferred heavy imports (`dotenv`, `console-capture`, `runtime`, command handlers) to after command resolution in `run-main.ts`, `route.ts`, `preaction.ts`, and registration files
- Made channel options lazily resolvable via getters in `createProgramContext`
- Created `buildProgramShell()` to separate program shell creation from full command registration

The implementation correctly handles channel options for commands that need them (`agent`, `agents`, `message`) by providing the resolver before registration. The lazy getter pattern in `context.ts` ensures channel options are only resolved when actually accessed.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk - the changes are well-structured performance optimizations that preserve existing behavior through lazy loading
- The lazy-loading implementation is clean and follows good patterns (async/await, lazy getters, proper import deferral). The constant extractions prevent duplication by re-exporting from canonical sources. However, as part 1 of 4, full validation of the performance benefits requires testing the complete series. The code changes are non-invasive and maintain backward compatibility.
- No files require special attention - the implementation is consistent across all modified files

<sub>Last reviewed commit: 871d509</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->