### PR TITLE
fix: include --profile in systemd service ExecStart

### DIFF
--- a/src/commands/daemon-install-helpers.ts
+++ b/src/commands/daemon-install-helpers.ts
@@ -48,6 +48,7 @@ export async function buildGatewayInstallPlan(params: {
     dev: devMode,
     runtime: params.runtime,
     nodePath,
+    profile: params.env.OPENCLAW_PROFILE,
   });
   if (params.runtime === "node") {
     const systemNode = await resolveSystemNodeInfo({ env: params.env });

--- a/src/daemon/program-args.test.ts
+++ b/src/daemon/program-args.test.ts
@@ -87,4 +87,62 @@ describe("resolveGatewayProgramArguments", () => {
       "18789",
     ]);
   });
+
+  it("includes --profile in program arguments when profile is provided", async () => {
+    const argv1 = path.resolve("/tmp/.npm/_npx/63c3/node_modules/.bin/openclaw");
+    const entryPath = path.resolve("/tmp/.npm/_npx/63c3/node_modules/openclaw/dist/entry.js");
+    process.argv = ["node", argv1];
+    fsMocks.realpath.mockResolvedValue(entryPath);
+    fsMocks.access.mockResolvedValue(undefined);
+
+    const result = await resolveGatewayProgramArguments({ port: 18789, profile: "myprofile" });
+
+    expect(result.programArguments).toEqual([
+      process.execPath,
+      entryPath,
+      "gateway",
+      "--port",
+      "18789",
+      "--profile",
+      "myprofile",
+    ]);
+  });
+
+  it("omits --profile when profile is empty", async () => {
+    const argv1 = path.resolve("/tmp/.npm/_npx/63c3/node_modules/.bin/openclaw");
+    const entryPath = path.resolve("/tmp/.npm/_npx/63c3/node_modules/openclaw/dist/entry.js");
+    process.argv = ["node", argv1];
+    fsMocks.realpath.mockResolvedValue(entryPath);
+    fsMocks.access.mockResolvedValue(undefined);
+
+    const result = await resolveGatewayProgramArguments({ port: 18789, profile: "" });
+
+    expect(result.programArguments).toEqual([
+      process.execPath,
+      entryPath,
+      "gateway",
+      "--port",
+      "18789",
+    ]);
+  });
+
+  it("trims whitespace from profile name", async () => {
+    const argv1 = path.resolve("/tmp/.npm/_npx/63c3/node_modules/.bin/openclaw");
+    const entryPath = path.resolve("/tmp/.npm/_npx/63c3/node_modules/openclaw/dist/entry.js");
+    process.argv = ["node", argv1];
+    fsMocks.realpath.mockResolvedValue(entryPath);
+    fsMocks.access.mockResolvedValue(undefined);
+
+    const result = await resolveGatewayProgramArguments({ port: 18789, profile: "  myprofile  " });
+
+    expect(result.programArguments).toEqual([
+      process.execPath,
+      entryPath,
+      "gateway",
+      "--port",
+      "18789",
+      "--profile",
+      "myprofile",
+    ]);
+  });
 });

--- a/src/daemon/program-args.ts
+++ b/src/daemon/program-args.ts
@@ -244,8 +244,12 @@ export async function resolveGatewayProgramArguments(params: {
   dev?: boolean;
   runtime?: GatewayRuntimePreference;
   nodePath?: string;
+  profile?: string;
 }): Promise<GatewayProgramArgs> {
   const gatewayArgs = ["gateway", "--port", String(params.port)];
+  if (params.profile?.trim()) {
+    gatewayArgs.push("--profile", params.profile.trim());
+  }
   return resolveCliProgramArguments({
     args: gatewayArgs,
     dev: params.dev,


### PR DESCRIPTION
## Summary

Fixes a regression where multi-profile gateways could not start simultaneously after upgrading from v2026.2.6-3 to v2026.2.13.

## Root Cause

The issue occurred because:
1. Systemd service files generated by `openclaw setup` and `openclaw onboard` did not include the `--profile` parameter in the ExecStart line
2. When the gateway process started, the `--profile` flag was not passed on the command line
3. This caused the gateway process detection to not distinguish between different profiles

This caused the error: `gateway already running (pid xxx); lock timeout after 5000ms`

## Changes

- Added `profile` parameter to `resolveGatewayProgramArguments()` function
- Modified `buildGatewayInstallPlan()` to pass `env.OPENCLAW_PROFILE` to the program arguments builder
- The ExecStart line in systemd service files now includes `--profile <name>` when a non-default profile is used

## Testing

- Added new test cases for the profile parameter in `resolveGatewayProgramArguments()`
- All existing daemon-related tests pass (120 tests)
- Verified the program arguments include `--profile` when a profile is provided
- Verified the profile is trimmed of whitespace
- Verified empty profiles are handled correctly

Fixes openclaw/openclaw#15970

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes a regression where multiple profile-based gateways could not start simultaneously. The root cause was that systemd service files lacked the `--profile` parameter in their ExecStart command, causing the gateway lock mechanism to fail at distinguishing between different profile instances.

The fix adds profile support to `resolveGatewayProgramArguments()` in `src/daemon/program-args.ts:242` and threads the `OPENCLAW_PROFILE` environment variable through `buildGatewayInstallPlan()` in `src/commands/daemon-install-helpers.ts:51`. The implementation properly handles edge cases: empty profiles are omitted, whitespace is trimmed, and the profile parameter is only added when non-empty.

Test coverage is comprehensive with three new test cases covering the profile parameter, empty profile handling, and whitespace trimming in `src/daemon/program-args.test.ts:91-147`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is straightforward and follows existing patterns. The profile parameter is properly validated before use (trimmed and checked for emptiness), preventing malformed arguments. The fix is backwards compatible - when no profile is specified, behavior is unchanged. Test coverage is thorough with three new test cases validating the core functionality and edge cases. The change is minimal and focused, touching only the necessary functions to thread the profile parameter from environment to program arguments.
- No files require special attention

<sub>Last reviewed commit: b06c924</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->