### PR TITLE
feat(exec): support env field in tools.exec config

### DIFF
--- a/src/agents/bash-tools.exec-types.ts
+++ b/src/agents/bash-tools.exec-types.ts
@@ -21,6 +21,7 @@ export type ExecToolDefaults = {
   notifyOnExit?: boolean;
   notifyOnExitEmptySuccess?: boolean;
   cwd?: string;
+  env?: Record<string, string>;
 };
 
 export type ExecElevatedDefaults = {

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -332,11 +332,12 @@ export function createExecTool(
       }
 
       const mergedEnv = { ...baseEnv, ...defaultsEnv, ...params.env };
+      const mergedSandboxEnv = { ...defaultsEnv, ...params.env };
 
       const env = sandbox
         ? buildSandboxEnv({
             defaultPath: DEFAULT_PATH,
-            paramsEnv: params.env,
+            paramsEnv: mergedSandboxEnv,
             sandboxEnv: sandbox.env,
             containerWorkdir: containerWorkdir ?? sandbox.containerWorkdir,
           })
@@ -365,7 +366,7 @@ export function createExecTool(
           command: params.command,
           workdir,
           env,
-          requestedEnv: params.env,
+          requestedEnv: { ...defaultsEnv, ...params.env },
           requestedNode: params.node?.trim(),
           boundNode: defaults?.node?.trim(),
           sessionKey: defaults?.sessionKey,

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -323,6 +323,7 @@ export function createExecTool(
       }
 
       const baseEnv = coerceEnv(process.env);
+      const defaultsEnv = defaults?.env;
 
       // Logic: Sandbox gets raw env. Host (gateway/node) must pass validation.
       // We validate BEFORE merging to prevent any dangerous vars from entering the stream.
@@ -330,7 +331,7 @@ export function createExecTool(
         validateHostEnv(params.env);
       }
 
-      const mergedEnv = params.env ? { ...baseEnv, ...params.env } : baseEnv;
+      const mergedEnv = { ...baseEnv, ...defaultsEnv, ...params.env };
 
       const env = sandbox
         ? buildSandboxEnv({

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -113,6 +113,7 @@ function resolveExecConfig(params: { cfg?: OpenClawConfig; agentId?: string }) {
     notifyOnExitEmptySuccess:
       agentExec?.notifyOnExitEmptySuccess ?? globalExec?.notifyOnExitEmptySuccess,
     applyPatch: agentExec?.applyPatch ?? globalExec?.applyPatch,
+    env: agentExec?.env ?? globalExec?.env,
   };
 }
 
@@ -370,6 +371,7 @@ export function createOpenClawCodingTools(options?: {
     notifyOnExit: options?.exec?.notifyOnExit ?? execConfig.notifyOnExit,
     notifyOnExitEmptySuccess:
       options?.exec?.notifyOnExitEmptySuccess ?? execConfig.notifyOnExitEmptySuccess,
+    env: options?.exec?.env ?? execConfig.env,
     sandbox: sandbox
       ? {
           containerName: sandbox.containerName,

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -205,6 +205,8 @@ export type ExecToolConfig = {
    * Default false to reduce context noise.
    */
   notifyOnExitEmptySuccess?: boolean;
+  /** Environment variables to inject into exec commands (merged with process.env; tool-call env takes precedence). */
+  env?: Record<string, string>;
   /** apply_patch subtool configuration (experimental). */
   applyPatch?: {
     /** Enable apply_patch for OpenAI models (default: false). */


### PR DESCRIPTION
## Summary

- Add `env?: Record<string, string>` to `ExecToolConfig` so users can configure default environment variables for exec commands in `openclaw.json`
- Wire the config through `resolveExecConfig` → `createExecTool` → environment merge chain
- Config-level env is merged between `process.env` and tool-call `params.env` (tool-call takes highest precedence)

Closes #15974

## Changes

- `src/config/types.tools.ts`: Add `env` field to `ExecToolConfig`
- `src/agents/bash-tools.exec.ts`: Add `env` to `ExecToolDefaults`, merge `defaults.env` into exec environment
- `src/agents/pi-tools.ts`: Wire `env` through `resolveExecConfig` and `createExecTool` call

## Usage

```json
"tools": {
  "exec": {
    "env": {
      "ANTHROPIC_AUTH_TOKEN": "sk-ant-...",
      "ANTHROPIC_BASE_URL": "https://..."
    }
  }
}
```

## Test plan

- [ ] Verify TypeScript compilation passes
- [ ] Verify exec commands receive configured env vars
- [ ] Verify tool-call level `env` params override config-level values
- [ ] Verify backward compatibility when `env` is not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds `env?: Record<string, string>` to `ExecToolConfig` so operators can set default environment variables for exec commands via `openclaw.json`. The config wiring through `resolveExecConfig` → `createExecTool` in `pi-tools.ts` follows existing patterns correctly.

However, the env merge in `bash-tools.exec.ts` has two gaps:

- **Sandbox path (default host)**: `defaults.env` is not passed to `buildSandboxEnv`, so config-level env vars are silently dropped when `host=sandbox` (the default). The feature effectively doesn't work for the most common configuration.
- **Node host path**: `nodeEnv` is built from `params.env` only, so config-level env vars are not forwarded to remote nodes either.

The gateway host path works correctly with the precedence chain: `process.env` < `defaults.env` < `params.env`.

<h3>Confidence Score: 2/5</h3>

- The feature works for gateway hosts but is silently broken for sandbox (default) and node hosts
- Score of 2 because the config-level env vars are not applied in the sandbox path (default host) or node host path, meaning the feature doesn't work for the majority of use cases. The type definitions and config wiring are correct, but the core merge logic has two missing code paths.
- Pay close attention to `src/agents/bash-tools.exec.ts` — the sandbox env build (line 302) and node env build (line 363) both need to incorporate `defaults.env`

<sub>Last reviewed commit: bac4e8a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->