### PR TITLE
fix: deliver tool result images (screenshots) to Telegram

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -5,6 +5,7 @@ import { normalizeTextForComparison } from "./pi-embedded-helpers.js";
 import { isMessagingTool, isMessagingToolSendAction } from "./pi-embedded-messaging.js";
 import {
   extractToolErrorMessage,
+  extractToolResultMediaPaths,
   extractToolResultText,
   extractMessagingToolSend,
   isToolResultError,
@@ -224,6 +225,18 @@ export function handleToolExecutionEnd(
     const outputText = extractToolResultText(sanitizedResult);
     if (outputText) {
       ctx.emitToolOutput(toolName, meta, outputText);
+    }
+  }
+
+  // Emit media from tool image results regardless of verbose level.
+  if (ctx.params.onToolResult && !isToolError) {
+    const mediaPaths = extractToolResultMediaPaths(result);
+    if (mediaPaths && mediaPaths.length > 0) {
+      try {
+        void ctx.params.onToolResult({ mediaUrls: mediaPaths });
+      } catch {
+        /* ignore */
+      }
     }
   }
 }

--- a/src/agents/pi-embedded-subscribe.tools.ts
+++ b/src/agents/pi-embedded-subscribe.tools.ts
@@ -118,6 +118,29 @@ export function extractToolResultText(result: unknown): string | undefined {
   return texts.join("\n");
 }
 
+export function extractToolResultMediaPaths(result: unknown): string[] | undefined {
+  if (!result || typeof result !== "object") {
+    return undefined;
+  }
+  const record = result as Record<string, unknown>;
+  const content = Array.isArray(record.content) ? record.content : null;
+  if (!content) {
+    return undefined;
+  }
+
+  const hasImage = content.some(
+    (item) =>
+      item && typeof item === "object" && (item as Record<string, unknown>).type === "image",
+  );
+  if (!hasImage) {
+    return undefined;
+  }
+
+  const details = record.details as Record<string, unknown> | undefined;
+  const path = typeof details?.path === "string" ? details.path.trim() : "";
+  return path ? [path] : undefined;
+}
+
 export function isToolResultError(result: unknown): boolean {
   if (!result || typeof result !== "object") {
     return false;

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -125,7 +125,10 @@ export async function runAgentTurnWithFallback(params: {
           return { skip: true };
         }
         if (!text) {
-          return { skip: true };
+          if ((payload.mediaUrls?.length ?? 0) === 0) {
+            return { skip: true };
+          }
+          return { text: undefined, skip: false };
         }
         const sanitized = sanitizeUserFacingText(text, {
           errorContext: Boolean(payload.isError),


### PR DESCRIPTION
## Summary

- Extract image paths directly from tool result content blocks via `extractToolResultMediaPaths()`, bypassing broken MEDIA: text parsing
- Emit media through `onToolResult` regardless of verbose level (was gated by `verboseLevel === "full"`)
- Allow media-only payloads through `normalizeStreamingText()` (was skipping when text was empty)

Closes #11735

## Test plan

- [x] `npx vitest run src/agents/pi-embedded-subscribe.tools` — 2/2 passed
- [x] `npx vitest run src/auto-reply/reply/agent-runner` — 45/45 passed
- [ ] Manual: ask bot to take a screenshot in Telegram DM, verify image appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixed screenshot delivery to Telegram by bypassing broken MEDIA: text parsing and verbose level restrictions. Introduces `extractToolResultMediaPaths()` to directly extract image paths from tool result content blocks, decouples media emission from the `verboseLevel === "full"` gate in `handleToolExecutionEnd()`, and allows media-only payloads through `normalizeStreamingText()`.

Key changes:
- Tool result images (screenshots) now reach Telegram regardless of verbose level
- Media emission uses structured content block extraction instead of fragile text parsing  
- Media-only messages (no text) are properly delivered

Minor suggestion:
- Consider adding unit tests for `extractToolResultMediaPaths` (src/agents/pi-embedded-subscribe.tools.ts:121)

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor test coverage suggestion
- Changes correctly address the stated problem with a reasonable approach. Integration tests pass. Main suggestion is adding unit tests for the new extraction function, but this is not blocking.
- No files require special attention

<sub>Last reviewed commit: 213a8e4</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->