### PR TITLE
feat(signal): add unsend, poll create, poll vote, and poll terminate actions

### DIFF
--- a/docs/channels/signal.md
+++ b/docs/channels/signal.md
@@ -241,6 +241,67 @@ Config:
   - `minimal`/`extensive` enables agent reactions and sets the guidance level.
 - Per-account overrides: `channels.signal.accounts.<id>.actions.reactions`, `channels.signal.accounts.<id>.reactionLevel`.
 
+## Unsend (message tool)
+
+- Use `message action=unsend` with `channel=signal` to delete a message you sent.
+- Targets: recipient E.164, UUID, or group (same format as reactions).
+- `messageId` is the Signal timestamp of the message to delete.
+- Works for both DMs and groups.
+
+Examples:
+
+```
+message action=unsend channel=signal target=+15551234567 messageId=1737630212345
+message action=unsend channel=signal target=uuid:123e4567-e89b-12d3-a456-426614174000 messageId=1737630212345
+message action=unsend channel=signal target=signal:group:<groupId> messageId=1737630212345
+```
+
+Config:
+
+- `channels.signal.actions.unsend`: enable/disable unsend actions (default true).
+- Per-account override: `channels.signal.accounts.<id>.actions.unsend`.
+
+## Poll create/vote/close (message tool)
+
+- Use `message action=poll` to create a poll.
+- Use `message action=pollVote` to vote in a poll.
+- Use `message action=pollTerminate` to close a poll (only the poll creator can close).
+
+**Poll create requirements:**
+
+- `pollQuestion`: poll question text.
+- `pollOption`: array of 2+ option strings.
+- `pollMulti` (optional): `true` to allow multiple selections (default true), `false` for single-select.
+
+**Poll vote requirements:**
+
+- `messageId`: poll timestamp (from the poll message).
+- `targetAuthor`: poll creator's E.164 or UUID.
+- `pollOption`: array of 0-indexed option numbers to vote for.
+
+**Poll close requirements:**
+
+- `messageId`: poll timestamp.
+- Only the poll creator can close the poll.
+
+Examples:
+
+```
+message action=poll channel=signal target=+15551234567 pollQuestion="Lunch?" pollOption=["Pizza","Sushi"] pollMulti=true
+message action=poll channel=signal target=signal:group:<groupId> pollQuestion="Where to meet?" pollOption=["Cafe","Office"] pollMulti=false
+message action=pollVote channel=signal target=+15551234567 messageId=1737630212345 targetAuthor=+15559999999 pollOption=[0,2]
+message action=pollVote channel=signal target=signal:group:<groupId> messageId=1737630212345 targetAuthor=uuid:<creator-uuid> pollOption=[1]
+message action=pollTerminate channel=signal target=+15551234567 messageId=1737630212345
+message action=pollTerminate channel=signal target=signal:group:<groupId> messageId=1737630212345
+```
+
+Config:
+
+- `channels.signal.actions.poll`: enable/disable poll create actions (default true).
+- `channels.signal.actions.pollVote`: enable/disable poll vote actions (default true).
+- `channels.signal.actions.pollTerminate`: enable/disable poll close actions (default true).
+- Per-account overrides: `channels.signal.accounts.<id>.actions.poll`, `channels.signal.accounts.<id>.actions.pollVote`, `channels.signal.accounts.<id>.actions.pollTerminate`.
+
 ## Delivery targets (CLI/cron)
 
 - DMs: `signal:+15551234567` (or plain E.164).

--- a/docs/cli/message.md
+++ b/docs/cli/message.md
@@ -64,11 +64,12 @@ Name lookup:
   - WhatsApp only: `--gif-playback`
 
 - `poll`
-  - Channels: WhatsApp/Telegram/Discord/Matrix/MS Teams
+  - Channels: WhatsApp/Telegram/Discord/Matrix/MS Teams/Signal
   - Required: `--target`, `--poll-question`, `--poll-option` (repeat)
   - Optional: `--poll-multi`
   - Discord only: `--poll-duration-hours`, `--silent`, `--message`
   - Telegram only: `--poll-duration-seconds` (5-600), `--silent`, `--poll-anonymous` / `--poll-public`, `--thread-id`
+  - Signal: creates a poll via `sendPollCreate` RPC
 
 - `react`
   - Channels: Discord/Google Chat/Slack/Telegram/WhatsApp/Signal
@@ -96,6 +97,21 @@ Name lookup:
 - `delete`
   - Channels: Discord/Slack/Telegram
   - Required: `--message-id`, `--target`
+
+- `unsend`
+  - Channels: Signal
+  - Required: `--message-id`, `--target` (recipient E.164, UUID, or group)
+  - Note: Deletes a message you sent (remote delete)
+
+- `pollVote`
+  - Channels: Signal
+  - Required: `--message-id`, `--target`, `--target-author` (poll creator's E.164 or UUID), `--poll-option` (repeat; 0-indexed option numbers)
+  - Note: Vote in a Signal poll; `--poll-option` accepts multiple values for multi-select polls
+
+- `pollTerminate`
+  - Channels: Signal
+  - Required: `--message-id`, `--target`
+  - Note: Close a Signal poll (only the poll creator can close)
 
 - `pin` / `unpin`
   - Channels: Discord/Slack
@@ -235,6 +251,16 @@ openclaw message poll --channel msteams \
   --target conversation:19:abc@thread.tacv2 \
   --poll-question "Lunch?" \
   --poll-option Pizza --poll-option Sushi
+```
+
+Create a Signal poll:
+
+```
+openclaw message poll --channel signal \
+  --target +15551234567 \
+  --poll-question "Lunch?" \
+  --poll-option Pizza --poll-option Sushi \
+  --poll-multi
 ```
 
 React in Slack:

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -470,12 +470,21 @@ Chat modes: `oncall` (respond on @-mention, default), `onmessage` (every message
       reactionNotifications: "own", // off | own | all | allowlist
       reactionAllowlist: ["+15551234567", "uuid:123e4567-e89b-12d3-a456-426614174000"],
       historyLimit: 50,
+      actions: {
+        reactions: true, // enable/disable reaction actions (default: true)
+        poll: true, // enable/disable poll creation (default: true)
+        unsend: true, // enable/disable unsend/remote delete (default: true)
+        pollVote: true, // enable/disable poll voting (default: true)
+        pollTerminate: true, // enable/disable poll termination (default: true)
+      },
     },
   },
 }
 ```
 
 **Reaction notification modes:** `off`, `own` (default), `all`, `allowlist` (from `reactionAllowlist`).
+
+**Action toggles:** `actions.reactions`, `actions.poll`, `actions.unsend`, `actions.pollVote`, `actions.pollTerminate` — all default to `true`. Per-account overrides: `channels.signal.accounts.<id>.actions.*`.
 
 - `channels.signal.account`: pin channel startup to a specific Signal account identity.
 - `channels.signal.configWrites`: allow or deny Signal-initiated config writes.

--- a/src/channels/dock.ts
+++ b/src/channels/dock.ts
@@ -505,6 +505,8 @@ const DOCKS: Record<ChatChannelId, ChannelDock> = {
     capabilities: {
       chatTypes: ["direct", "group"],
       reactions: true,
+      unsend: true,
+      polls: true,
       media: true,
     },
     outbound: DEFAULT_OUTBOUND_TEXT_CHUNK_LIMIT_4000,

--- a/src/channels/plugins/actions/actions.test.ts
+++ b/src/channels/plugins/actions/actions.test.ts
@@ -5,6 +5,19 @@ const handleDiscordAction = vi.fn(async (..._args: unknown[]) => ({ details: { o
 const handleTelegramAction = vi.fn(async (..._args: unknown[]) => ({ ok: true }));
 const sendReactionSignal = vi.fn(async (..._args: unknown[]) => ({ ok: true }));
 const removeReactionSignal = vi.fn(async (..._args: unknown[]) => ({ ok: true }));
+const sendRemoteDeleteSignal = vi.fn(async (..._args: unknown[]) => true);
+const sendPollCreateSignal = vi.fn(async (..._args: unknown[]) => ({
+  messageId: "999",
+  timestamp: 999,
+}));
+const sendPollVoteSignal = vi.fn(async (..._args: unknown[]) => ({
+  messageId: "999",
+  timestamp: 999,
+}));
+const sendPollTerminateSignal = vi.fn(async (..._args: unknown[]) => ({
+  messageId: "999",
+  timestamp: 999,
+}));
 const handleSlackAction = vi.fn(async (..._args: unknown[]) => ({ details: { ok: true } }));
 
 vi.mock("../../../agents/tools/discord-actions.js", () => ({
@@ -18,6 +31,13 @@ vi.mock("../../../agents/tools/telegram-actions.js", () => ({
 vi.mock("../../../signal/send-reactions.js", () => ({
   sendReactionSignal,
   removeReactionSignal,
+}));
+
+vi.mock("../../../signal/send.js", () => ({
+  sendRemoteDeleteSignal: (...args: unknown[]) => sendRemoteDeleteSignal(...args),
+  sendPollCreateSignal: (...args: unknown[]) => sendPollCreateSignal(...args),
+  sendPollVoteSignal: (...args: unknown[]) => sendPollVoteSignal(...args),
+  sendPollTerminateSignal: (...args: unknown[]) => sendPollTerminateSignal(...args),
 }));
 
 vi.mock("../../../agents/tools/slack-actions.js", () => ({
@@ -57,6 +77,8 @@ async function runTelegramAction(
 }
 
 type SignalActionInput = Parameters<NonNullable<typeof signalMessageActions.handleAction>>[0];
+const pollVoteAction = "pollVote" as unknown as SignalActionInput["action"];
+const pollTerminateAction = "pollTerminate" as unknown as SignalActionInput["action"];
 
 async function runSignalAction(
   action: SignalActionInput["action"],
@@ -807,12 +829,12 @@ describe("signalMessageActions", () => {
         cfg: {
           channels: { signal: { account: "+15550001111", actions: { reactions: false } } },
         } as OpenClawConfig,
-        expected: ["send"],
+        expected: ["send", "unsend", "poll", "pollVote", "pollTerminate"],
       },
       {
         name: "account-level reactions enabled",
         cfg: createSignalAccountOverrideCfg(),
-        expected: ["send", "react"],
+        expected: ["send", "react", "unsend", "poll", "pollVote", "pollTerminate"],
       },
     ] as const;
 
@@ -930,6 +952,421 @@ describe("signalMessageActions", () => {
       /targetAuthor/,
       cfg,
     );
+  });
+
+  it("handles unsend action", async () => {
+    sendRemoteDeleteSignal.mockClear();
+    const cfg = {
+      channels: { signal: { account: "+15550001111" } },
+    } as OpenClawConfig;
+
+    const result = await signalMessageActions.handleAction!({
+      channel: "signal",
+      action: "unsend",
+      params: {
+        to: "+15551234567",
+        messageId: "1234567890",
+      },
+      cfg,
+      accountId: undefined,
+    });
+
+    expect(sendRemoteDeleteSignal).toHaveBeenCalledWith("+15551234567", 1234567890, {
+      accountId: undefined,
+    });
+    expect(result.details).toMatchObject({
+      ok: true,
+      deleted: "1234567890",
+    });
+  });
+
+  it("handles unsend for group target", async () => {
+    sendRemoteDeleteSignal.mockClear();
+    const cfg = {
+      channels: { signal: { account: "+15550001111" } },
+    } as OpenClawConfig;
+
+    await signalMessageActions.handleAction!({
+      channel: "signal",
+      action: "unsend",
+      params: {
+        to: "signal:group:group-id",
+        messageId: "9876543210",
+      },
+      cfg,
+      accountId: undefined,
+    });
+
+    expect(sendRemoteDeleteSignal).toHaveBeenCalledWith("signal:group:group-id", 9876543210, {
+      accountId: undefined,
+    });
+  });
+
+  it("rejects unsend when action is disabled", async () => {
+    const cfg = {
+      channels: { signal: { account: "+15550001111", actions: { unsend: false } } },
+    } as OpenClawConfig;
+
+    await expect(
+      signalMessageActions.handleAction!({
+        channel: "signal",
+        action: "unsend",
+        params: {
+          to: "+15551234567",
+          messageId: "1234567890",
+        },
+        cfg,
+        accountId: undefined,
+      }),
+    ).rejects.toThrow(/actions\.unsend/);
+  });
+
+  it("rejects unsend with invalid messageId", async () => {
+    const cfg = {
+      channels: { signal: { account: "+15550001111" } },
+    } as OpenClawConfig;
+
+    await expect(
+      signalMessageActions.handleAction!({
+        channel: "signal",
+        action: "unsend",
+        params: {
+          to: "+15551234567",
+          messageId: "0",
+        },
+        cfg,
+        accountId: undefined,
+      }),
+    ).rejects.toThrow(/Invalid messageId/);
+  });
+
+  it("rejects unsend when remote delete fails", async () => {
+    sendRemoteDeleteSignal.mockClear().mockResolvedValueOnce(false);
+    const cfg = {
+      channels: { signal: { account: "+15550001111" } },
+    } as OpenClawConfig;
+
+    await expect(
+      signalMessageActions.handleAction!({
+        channel: "signal",
+        action: "unsend",
+        params: {
+          to: "+15551234567",
+          messageId: "1234567890",
+        },
+        cfg,
+        accountId: undefined,
+      }),
+    ).rejects.toThrow(/Failed to delete/);
+  });
+
+  it("enables poll, pollVote, and pollTerminate by default", () => {
+    const cfg = {
+      channels: { signal: { account: "+15550001111" } },
+    } as OpenClawConfig;
+    const actions = signalMessageActions.listActions?.({ cfg }) ?? [];
+    expect(actions).toContain("poll");
+    expect(actions).toContain("pollVote");
+    expect(actions).toContain("pollTerminate");
+  });
+
+  it("hides poll when disabled", () => {
+    const cfg = {
+      channels: { signal: { account: "+15550001111", actions: { poll: false } } },
+    } as OpenClawConfig;
+    const actions = signalMessageActions.listActions?.({ cfg }) ?? [];
+    expect(actions).not.toContain("poll");
+  });
+
+  it("handles poll action", async () => {
+    sendPollCreateSignal.mockClear();
+    const cfg = {
+      channels: { signal: { account: "+15550001111" } },
+    } as OpenClawConfig;
+
+    const result = await signalMessageActions.handleAction!({
+      channel: "signal",
+      action: "poll",
+      params: {
+        to: "+15551234567",
+        pollQuestion: "Lunch?",
+        pollOption: ["Pizza", "Sushi"],
+        pollMulti: false,
+      },
+      cfg,
+      accountId: undefined,
+    });
+
+    expect(sendPollCreateSignal).toHaveBeenCalledWith("+15551234567", {
+      question: "Lunch?",
+      options: ["Pizza", "Sushi"],
+      allowMultiple: false,
+      accountId: undefined,
+    });
+    expect(result.details).toMatchObject({
+      ok: true,
+      messageId: "999",
+      question: "Lunch?",
+      options: ["Pizza", "Sushi"],
+      allowMultiple: false,
+    });
+  });
+
+  it("defaults poll action to allow multiple selections", async () => {
+    sendPollCreateSignal.mockClear();
+    const cfg = {
+      channels: { signal: { account: "+15550001111" } },
+    } as OpenClawConfig;
+
+    await signalMessageActions.handleAction!({
+      channel: "signal",
+      action: "poll",
+      params: {
+        to: "+15551234567",
+        pollQuestion: "Lunch?",
+        pollOption: ["Pizza", "Sushi"],
+      },
+      cfg,
+      accountId: undefined,
+    });
+
+    expect(sendPollCreateSignal).toHaveBeenCalledWith("+15551234567", {
+      question: "Lunch?",
+      options: ["Pizza", "Sushi"],
+      allowMultiple: true,
+      accountId: undefined,
+    });
+  });
+
+  it("rejects poll when action is disabled", async () => {
+    const cfg = {
+      channels: { signal: { account: "+15550001111", actions: { poll: false } } },
+    } as OpenClawConfig;
+
+    await expect(
+      signalMessageActions.handleAction!({
+        channel: "signal",
+        action: "poll",
+        params: {
+          to: "+15551234567",
+          pollQuestion: "Lunch?",
+          pollOption: ["Pizza", "Sushi"],
+        },
+        cfg,
+        accountId: undefined,
+      }),
+    ).rejects.toThrow(/actions\.poll/);
+  });
+
+  it("hides pollVote when disabled", () => {
+    const cfg = {
+      channels: { signal: { account: "+15550001111", actions: { pollVote: false } } },
+    } as OpenClawConfig;
+    const actions = signalMessageActions.listActions?.({ cfg }) ?? [];
+    expect(actions).not.toContain("pollVote");
+  });
+
+  it("hides pollTerminate when disabled", () => {
+    const cfg = {
+      channels: { signal: { account: "+15550001111", actions: { pollTerminate: false } } },
+    } as OpenClawConfig;
+    const actions = signalMessageActions.listActions?.({ cfg }) ?? [];
+    expect(actions).not.toContain("pollTerminate");
+  });
+
+  it("handles pollVote action", async () => {
+    sendPollVoteSignal.mockClear();
+    const cfg = {
+      channels: { signal: { account: "+15550001111" } },
+    } as OpenClawConfig;
+
+    const result = await signalMessageActions.handleAction!({
+      channel: "signal",
+      action: pollVoteAction,
+      params: {
+        to: "+15551234567",
+        messageId: "1234567890",
+        targetAuthor: "+15559999999",
+        pollOptions: [0, 2],
+      },
+      cfg,
+      accountId: undefined,
+    });
+
+    expect(sendPollVoteSignal).toHaveBeenCalledWith("+15551234567", {
+      pollAuthor: "+15559999999",
+      pollTimestamp: 1234567890,
+      optionIndexes: [0, 2],
+      accountId: undefined,
+    });
+    expect(result.details).toMatchObject({
+      ok: true,
+      voted: [0, 2],
+    });
+  });
+
+  it("handles pollVote for group target", async () => {
+    sendPollVoteSignal.mockClear();
+    const cfg = {
+      channels: { signal: { account: "+15550001111" } },
+    } as OpenClawConfig;
+
+    await signalMessageActions.handleAction!({
+      channel: "signal",
+      action: pollVoteAction,
+      params: {
+        to: "group:abc123",
+        messageId: "9876543210",
+        targetAuthor: "+15559999999",
+        pollOptions: [1],
+      },
+      cfg,
+      accountId: undefined,
+    });
+
+    expect(sendPollVoteSignal).toHaveBeenCalledWith("group:abc123", {
+      pollAuthor: "+15559999999",
+      pollTimestamp: 9876543210,
+      optionIndexes: [1],
+      accountId: undefined,
+    });
+  });
+
+  it("rejects pollVote when action is disabled", async () => {
+    const cfg = {
+      channels: { signal: { account: "+15550001111", actions: { pollVote: false } } },
+    } as OpenClawConfig;
+
+    await expect(
+      signalMessageActions.handleAction!({
+        channel: "signal",
+        action: pollVoteAction,
+        params: {
+          to: "+15551234567",
+          messageId: "1234567890",
+          targetAuthor: "+15559999999",
+          pollOptions: [0],
+        },
+        cfg,
+        accountId: undefined,
+      }),
+    ).rejects.toThrow(/actions\.pollVote/);
+  });
+
+  it("accepts pollOption (singular) for pollVote", async () => {
+    sendPollVoteSignal.mockClear();
+    const cfg = {
+      channels: { signal: { account: "+15550001111" } },
+    } as OpenClawConfig;
+
+    await signalMessageActions.handleAction!({
+      channel: "signal",
+      action: pollVoteAction,
+      params: {
+        to: "+15551234567",
+        messageId: "1234567890",
+        targetAuthor: "+15559999999",
+        pollOption: [1],
+      },
+      cfg,
+      accountId: undefined,
+    });
+
+    expect(sendPollVoteSignal).toHaveBeenCalledWith("+15551234567", {
+      pollAuthor: "+15559999999",
+      pollTimestamp: 1234567890,
+      optionIndexes: [1],
+      accountId: undefined,
+    });
+  });
+
+  it("rejects pollVote without pollOptions", async () => {
+    const cfg = {
+      channels: { signal: { account: "+15550001111" } },
+    } as OpenClawConfig;
+
+    await expect(
+      signalMessageActions.handleAction!({
+        channel: "signal",
+        action: pollVoteAction,
+        params: {
+          to: "+15551234567",
+          messageId: "1234567890",
+          targetAuthor: "+15559999999",
+        },
+        cfg,
+        accountId: undefined,
+      }),
+    ).rejects.toThrow(/pollOptions/);
+  });
+
+  it("handles pollTerminate action", async () => {
+    sendPollTerminateSignal.mockClear();
+    const cfg = {
+      channels: { signal: { account: "+15550001111" } },
+    } as OpenClawConfig;
+
+    const result = await signalMessageActions.handleAction!({
+      channel: "signal",
+      action: pollTerminateAction,
+      params: {
+        to: "+15551234567",
+        messageId: "1234567890",
+      },
+      cfg,
+      accountId: undefined,
+    });
+
+    expect(sendPollTerminateSignal).toHaveBeenCalledWith("+15551234567", {
+      pollTimestamp: 1234567890,
+      accountId: undefined,
+    });
+    expect(result.details).toMatchObject({
+      ok: true,
+      closed: "1234567890",
+    });
+  });
+
+  it("handles pollTerminate for group target", async () => {
+    sendPollTerminateSignal.mockClear();
+    const cfg = {
+      channels: { signal: { account: "+15550001111" } },
+    } as OpenClawConfig;
+
+    await signalMessageActions.handleAction!({
+      channel: "signal",
+      action: pollTerminateAction,
+      params: {
+        to: "group:xyz789",
+        messageId: "9876543210",
+      },
+      cfg,
+      accountId: undefined,
+    });
+
+    expect(sendPollTerminateSignal).toHaveBeenCalledWith("group:xyz789", {
+      pollTimestamp: 9876543210,
+      accountId: undefined,
+    });
+  });
+
+  it("rejects pollTerminate when action is disabled", async () => {
+    const cfg = {
+      channels: { signal: { account: "+15550001111", actions: { pollTerminate: false } } },
+    } as OpenClawConfig;
+
+    await expect(
+      signalMessageActions.handleAction!({
+        channel: "signal",
+        action: pollTerminateAction,
+        params: {
+          to: "+15551234567",
+          messageId: "1234567890",
+        },
+        cfg,
+        accountId: undefined,
+      }),
+    ).rejects.toThrow(/actions\.pollTerminate/);
   });
 });
 

--- a/src/channels/plugins/actions/signal.ts
+++ b/src/channels/plugins/actions/signal.ts
@@ -1,7 +1,18 @@
-import { createActionGate, jsonResult, readStringParam } from "../../../agents/tools/common.js";
+import {
+  createActionGate,
+  jsonResult,
+  readStringArrayParam,
+  readStringParam,
+} from "../../../agents/tools/common.js";
 import { listEnabledSignalAccounts, resolveSignalAccount } from "../../../signal/accounts.js";
 import { resolveSignalReactionLevel } from "../../../signal/reaction-level.js";
 import { sendReactionSignal, removeReactionSignal } from "../../../signal/send-reactions.js";
+import {
+  sendRemoteDeleteSignal,
+  sendPollCreateSignal,
+  sendPollVoteSignal,
+  sendPollTerminateSignal,
+} from "../../../signal/send.js";
 import type { ChannelMessageActionAdapter, ChannelMessageActionName } from "../types.js";
 import { resolveReactionMessageId } from "./reaction-message-id.js";
 
@@ -85,6 +96,34 @@ export const signalMessageActions: ChannelMessageActionAdapter = {
     );
     if (reactionsEnabled) {
       actions.add("react");
+    }
+
+    const unsendEnabled = configuredAccounts.some((account) =>
+      createActionGate(account.config.actions)("unsend"),
+    );
+    if (unsendEnabled) {
+      actions.add("unsend");
+    }
+
+    const pollEnabled = configuredAccounts.some((account) =>
+      createActionGate(account.config.actions)("poll"),
+    );
+    if (pollEnabled) {
+      actions.add("poll");
+    }
+
+    const pollVoteEnabled = configuredAccounts.some((account) =>
+      createActionGate(account.config.actions)("pollVote"),
+    );
+    if (pollVoteEnabled) {
+      actions.add("pollVote");
+    }
+
+    const pollTerminateEnabled = configuredAccounts.some((account) =>
+      createActionGate(account.config.actions)("pollTerminate"),
+    );
+    if (pollTerminateEnabled) {
+      actions.add("pollTerminate");
     }
 
     return Array.from(actions);
@@ -175,6 +214,181 @@ export const signalMessageActions: ChannelMessageActionAdapter = {
         targetAuthor,
         targetAuthorUuid,
       });
+    }
+
+    if (action === "unsend") {
+      const actionConfig = resolveSignalAccount({ cfg, accountId }).config.actions;
+      const isActionEnabled = createActionGate(actionConfig);
+      if (!isActionEnabled("unsend")) {
+        throw new Error("Signal unsend is disabled via actions.unsend.");
+      }
+
+      const recipientRaw =
+        readStringParam(params, "recipient") ??
+        readStringParam(params, "to", {
+          required: true,
+          label: "recipient (UUID, phone number, or group)",
+        });
+      const target = resolveSignalReactionTarget(recipientRaw);
+      if (!target.recipient && !target.groupId) {
+        throw new Error("recipient or group required");
+      }
+
+      const messageId = readStringParam(params, "messageId", {
+        required: true,
+        label: "messageId (timestamp)",
+      });
+
+      const timestamp = parseInt(messageId, 10);
+      if (!Number.isFinite(timestamp) || timestamp <= 0) {
+        throw new Error(`Invalid messageId: ${messageId}. Expected positive numeric timestamp.`);
+      }
+
+      const deleted = await sendRemoteDeleteSignal(recipientRaw, timestamp, {
+        accountId: accountId ?? undefined,
+      });
+      if (!deleted) {
+        throw new Error(`Failed to delete message ${messageId}.`);
+      }
+      return jsonResult({ ok: true, deleted: messageId });
+    }
+
+    if (action === "poll") {
+      const actionConfig = resolveSignalAccount({ cfg, accountId }).config.actions;
+      const isActionEnabled = createActionGate(actionConfig);
+      if (!isActionEnabled("poll")) {
+        throw new Error("Signal poll creation is disabled via actions.poll.");
+      }
+
+      const recipientRaw =
+        readStringParam(params, "recipient") ??
+        readStringParam(params, "to", {
+          required: true,
+          label: "recipient (UUID, phone number, or group)",
+        });
+      const target = resolveSignalReactionTarget(recipientRaw);
+      if (!target.recipient && !target.groupId) {
+        throw new Error("recipient or group required");
+      }
+
+      const question = readStringParam(params, "pollQuestion", {
+        required: true,
+      });
+      const options =
+        readStringArrayParam(params, "pollOption", {
+          required: true,
+        }) ?? [];
+      const allowMultiple = typeof params.pollMulti === "boolean" ? params.pollMulti : true;
+
+      const result = await sendPollCreateSignal(recipientRaw, {
+        question,
+        options,
+        allowMultiple,
+        accountId: accountId ?? undefined,
+      });
+
+      return jsonResult({
+        ok: true,
+        messageId: result.messageId,
+        question,
+        options,
+        allowMultiple,
+      });
+    }
+
+    if (action === "pollVote") {
+      const actionConfig = resolveSignalAccount({ cfg, accountId }).config.actions;
+      const isActionEnabled = createActionGate(actionConfig);
+      if (!isActionEnabled("pollVote")) {
+        throw new Error("Signal poll voting is disabled via actions.pollVote.");
+      }
+
+      const recipientRaw =
+        readStringParam(params, "recipient") ??
+        readStringParam(params, "to", {
+          required: true,
+          label: "recipient (UUID, phone number, or group)",
+        });
+      const target = resolveSignalReactionTarget(recipientRaw);
+      if (!target.recipient && !target.groupId) {
+        throw new Error("recipient or group required");
+      }
+
+      const messageId = readStringParam(params, "messageId", {
+        required: true,
+        label: "messageId (poll timestamp)",
+      });
+
+      const pollAuthor =
+        readStringParam(params, "targetAuthorUuid") ?? readStringParam(params, "targetAuthor");
+      if (!pollAuthor) {
+        throw new Error(
+          "targetAuthor or targetAuthorUuid required for poll voting (poll creator's identifier).",
+        );
+      }
+
+      const pollOptions = params.pollOption ?? params.pollOptions;
+      if (!Array.isArray(pollOptions) || pollOptions.length === 0) {
+        throw new Error("pollOptions (array of option indexes) is required");
+      }
+
+      const optionIndexes = pollOptions.map((opt) => {
+        const idx = typeof opt === "number" ? opt : parseInt(String(opt), 10);
+        if (!Number.isFinite(idx) || idx < 0) {
+          throw new Error(`Invalid poll option index: ${opt}`);
+        }
+        return idx;
+      });
+
+      const timestamp = parseInt(messageId, 10);
+      if (!Number.isFinite(timestamp) || timestamp <= 0) {
+        throw new Error(`Invalid messageId: ${messageId}. Expected positive numeric timestamp.`);
+      }
+
+      const result = await sendPollVoteSignal(recipientRaw, {
+        pollAuthor,
+        pollTimestamp: timestamp,
+        optionIndexes,
+        accountId: accountId ?? undefined,
+      });
+
+      return jsonResult({ ok: true, messageId: result.messageId, voted: optionIndexes });
+    }
+
+    if (action === "pollTerminate") {
+      const actionConfig = resolveSignalAccount({ cfg, accountId }).config.actions;
+      const isActionEnabled = createActionGate(actionConfig);
+      if (!isActionEnabled("pollTerminate")) {
+        throw new Error("Signal poll termination is disabled via actions.pollTerminate.");
+      }
+
+      const recipientRaw =
+        readStringParam(params, "recipient") ??
+        readStringParam(params, "to", {
+          required: true,
+          label: "recipient (UUID, phone number, or group)",
+        });
+      const target = resolveSignalReactionTarget(recipientRaw);
+      if (!target.recipient && !target.groupId) {
+        throw new Error("recipient or group required");
+      }
+
+      const messageId = readStringParam(params, "messageId", {
+        required: true,
+        label: "messageId (poll timestamp)",
+      });
+
+      const timestamp = parseInt(messageId, 10);
+      if (!Number.isFinite(timestamp) || timestamp <= 0) {
+        throw new Error(`Invalid messageId: ${messageId}. Expected positive numeric timestamp.`);
+      }
+
+      const result = await sendPollTerminateSignal(recipientRaw, {
+        pollTimestamp: timestamp,
+        accountId: accountId ?? undefined,
+      });
+
+      return jsonResult({ ok: true, messageId: result.messageId, closed: messageId });
     }
 
     throw new Error(`Action ${action} not supported for ${providerId}.`);

--- a/src/channels/plugins/message-action-names.ts
+++ b/src/channels/plugins/message-action-names.ts
@@ -2,6 +2,8 @@ export const CHANNEL_MESSAGE_ACTION_NAMES = [
   "send",
   "broadcast",
   "poll",
+  "pollVote",
+  "pollTerminate",
   "react",
   "reactions",
   "read",

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -2,6 +2,31 @@ import { describe, expect, it } from "vitest";
 import { validateConfigObject } from "./config.js";
 
 describe("config schema regressions", () => {
+  it("accepts Signal action toggles for unsend and poll lifecycle actions", () => {
+    const res = validateConfigObject({
+      channels: {
+        signal: {
+          actions: {
+            reactions: true,
+            poll: true,
+            unsend: true,
+            pollVote: true,
+            pollTerminate: true,
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+    if (!res.ok) {
+      return;
+    }
+    expect(res.config.channels?.signal?.actions?.poll).toBe(true);
+    expect(res.config.channels?.signal?.actions?.unsend).toBe(true);
+    expect(res.config.channels?.signal?.actions?.pollVote).toBe(true);
+    expect(res.config.channels?.signal?.actions?.pollTerminate).toBe(true);
+  });
+
   it("accepts nested telegram groupPolicy overrides", () => {
     const res = validateConfigObject({
       channels: {

--- a/src/config/types.signal.ts
+++ b/src/config/types.signal.ts
@@ -34,6 +34,14 @@ export type SignalAccountConfig = CommonChannelMessagingConfig & {
   actions?: {
     /** Enable/disable sending reactions via message tool (default: true). */
     reactions?: boolean;
+    /** Enable/disable unsending messages via message tool (default: true). */
+    unsend?: boolean;
+    /** Enable/disable creating polls via message tool (default: true). */
+    poll?: boolean;
+    /** Enable/disable voting on polls via message tool (default: true). */
+    pollVote?: boolean;
+    /** Enable/disable closing polls via message tool (default: true). */
+    pollTerminate?: boolean;
   };
   /**
    * Controls agent reaction behavior:

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -925,6 +925,10 @@ export const SignalAccountSchemaBase = z
     actions: z
       .object({
         reactions: z.boolean().optional(),
+        poll: z.boolean().optional(),
+        unsend: z.boolean().optional(),
+        pollVote: z.boolean().optional(),
+        pollTerminate: z.boolean().optional(),
       })
       .strict()
       .optional(),

--- a/src/infra/outbound/message-action-spec.ts
+++ b/src/infra/outbound/message-action-spec.ts
@@ -7,6 +7,8 @@ export const MESSAGE_ACTION_TARGET_MODE: Record<ChannelMessageActionName, Messag
     send: "to",
     broadcast: "none",
     poll: "to",
+    pollVote: "to",
+    pollTerminate: "to",
     react: "to",
     reactions: "to",
     read: "to",

--- a/src/signal/send.test.ts
+++ b/src/signal/send.test.ts
@@ -1,0 +1,301 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  sendRemoteDeleteSignal,
+  sendPollCreateSignal,
+  sendPollVoteSignal,
+  sendPollTerminateSignal,
+} from "./send.js";
+
+const rpcMock = vi.fn();
+
+vi.mock("../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/config.js")>();
+  return {
+    ...actual,
+    loadConfig: () => ({}),
+  };
+});
+
+vi.mock("./accounts.js", () => ({
+  resolveSignalAccount: () => ({
+    accountId: "default",
+    enabled: true,
+    baseUrl: "http://signal.local",
+    configured: true,
+    config: { account: "+15550001111" },
+  }),
+}));
+
+vi.mock("./client.js", () => ({
+  signalRpcRequest: (...args: unknown[]) => rpcMock(...args),
+}));
+
+describe("sendRemoteDeleteSignal", () => {
+  beforeEach(() => {
+    rpcMock.mockReset().mockResolvedValue({});
+  });
+
+  it("calls remoteDelete RPC with recipient and targetTimestamp", async () => {
+    await sendRemoteDeleteSignal("+15551234567", 1234567890);
+
+    expect(rpcMock).toHaveBeenCalledWith(
+      "remoteDelete",
+      expect.objectContaining({
+        recipient: ["+15551234567"],
+        targetTimestamp: 1234567890,
+        account: "+15550001111",
+      }),
+      expect.objectContaining({
+        baseUrl: "http://signal.local",
+      }),
+    );
+  });
+
+  it("handles group targets", async () => {
+    await sendRemoteDeleteSignal("group:xyz123", 9876543210);
+
+    const params = rpcMock.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(params.groupId).toBe("xyz123");
+    expect(params.targetTimestamp).toBe(9876543210);
+    expect(params.recipient).toBeUndefined();
+  });
+
+  it("handles username targets", async () => {
+    await sendRemoteDeleteSignal("username:alice.123", 1111111111);
+
+    const params = rpcMock.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(params.username).toEqual(["alice.123"]);
+    expect(params.targetTimestamp).toBe(1111111111);
+    expect(params.recipient).toBeUndefined();
+    expect(params.groupId).toBeUndefined();
+  });
+
+  it("returns false for invalid timestamps", async () => {
+    expect(await sendRemoteDeleteSignal("+15551234567", 0)).toBe(false);
+    expect(await sendRemoteDeleteSignal("+15551234567", -1)).toBe(false);
+    expect(await sendRemoteDeleteSignal("+15551234567", NaN)).toBe(false);
+    expect(rpcMock).not.toHaveBeenCalled();
+  });
+
+  it("returns true on successful delete", async () => {
+    const result = await sendRemoteDeleteSignal("+15551234567", 1234567890);
+    expect(result).toBe(true);
+  });
+});
+
+describe("sendPollCreateSignal", () => {
+  beforeEach(() => {
+    rpcMock.mockReset().mockResolvedValue({ timestamp: 9999999999 });
+  });
+
+  it("sends poll create with correct RPC params for recipient target", async () => {
+    await sendPollCreateSignal("+15551234567", {
+      question: "Lunch?",
+      options: ["Pizza", "Sushi"],
+    });
+
+    expect(rpcMock).toHaveBeenCalledWith(
+      "sendPollCreate",
+      expect.objectContaining({
+        recipient: ["+15551234567"],
+        question: "Lunch?",
+        option: ["Pizza", "Sushi"],
+        noMulti: false,
+        account: "+15550001111",
+      }),
+      expect.objectContaining({
+        baseUrl: "http://signal.local",
+      }),
+    );
+  });
+
+  it("sends poll create for group target", async () => {
+    await sendPollCreateSignal("group:abc123", {
+      question: "Lunch?",
+      options: ["Pizza", "Sushi", "Tacos"],
+      allowMultiple: false,
+    });
+
+    const params = rpcMock.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(params.groupId).toBe("abc123");
+    expect(params.question).toBe("Lunch?");
+    expect(params.option).toEqual(["Pizza", "Sushi", "Tacos"]);
+    expect(params.noMulti).toBe(true);
+    expect(params.recipient).toBeUndefined();
+  });
+
+  it("rejects poll create with empty question", async () => {
+    await expect(
+      sendPollCreateSignal("+15551234567", {
+        question: "   ",
+        options: ["Pizza", "Sushi"],
+      }),
+    ).rejects.toThrow("Poll question is required");
+
+    expect(rpcMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects poll create with fewer than two options", async () => {
+    await expect(
+      sendPollCreateSignal("+15551234567", {
+        question: "Lunch?",
+        options: ["Pizza"],
+      }),
+    ).rejects.toThrow("At least two poll options are required");
+
+    expect(rpcMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("sendPollVoteSignal", () => {
+  beforeEach(() => {
+    rpcMock.mockReset().mockResolvedValue({ timestamp: 9999999999 });
+  });
+
+  it("sends poll vote with correct RPC params for recipient target", async () => {
+    await sendPollVoteSignal("+15551234567", {
+      pollAuthor: "+15559999999",
+      pollTimestamp: 1234567890,
+      optionIndexes: [0, 2],
+    });
+
+    expect(rpcMock).toHaveBeenCalledWith(
+      "sendPollVote",
+      expect.objectContaining({
+        recipient: ["+15551234567"],
+        pollAuthor: "+15559999999",
+        pollTimestamp: 1234567890,
+        option: [0, 2],
+        voteCount: 1,
+        account: "+15550001111",
+      }),
+      expect.objectContaining({
+        baseUrl: "http://signal.local",
+      }),
+    );
+  });
+
+  it("sends poll vote for group target", async () => {
+    await sendPollVoteSignal("group:abc123", {
+      pollAuthor: "+15559999999",
+      pollTimestamp: 9876543210,
+      optionIndexes: [1],
+    });
+
+    const params = rpcMock.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(params.groupId).toBe("abc123");
+    expect(params.pollAuthor).toBe("+15559999999");
+    expect(params.pollTimestamp).toBe(9876543210);
+    expect(params.option).toEqual([1]);
+    expect(params.recipient).toBeUndefined();
+  });
+
+  it("rejects poll vote with invalid timestamp", async () => {
+    await expect(
+      sendPollVoteSignal("+15551234567", {
+        pollAuthor: "+15559999999",
+        pollTimestamp: 0,
+        optionIndexes: [0],
+      }),
+    ).rejects.toThrow("Invalid poll timestamp");
+
+    await expect(
+      sendPollVoteSignal("+15551234567", {
+        pollAuthor: "+15559999999",
+        pollTimestamp: -100,
+        optionIndexes: [0],
+      }),
+    ).rejects.toThrow("Invalid poll timestamp");
+
+    expect(rpcMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects poll vote with empty option indexes", async () => {
+    await expect(
+      sendPollVoteSignal("+15551234567", {
+        pollAuthor: "+15559999999",
+        pollTimestamp: 1234567890,
+        optionIndexes: [],
+      }),
+    ).rejects.toThrow("At least one poll option must be selected");
+
+    expect(rpcMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects poll vote with empty poll author", async () => {
+    await expect(
+      sendPollVoteSignal("+15551234567", {
+        pollAuthor: "",
+        pollTimestamp: 1234567890,
+        optionIndexes: [0],
+      }),
+    ).rejects.toThrow("Poll author is required");
+
+    expect(rpcMock).not.toHaveBeenCalled();
+  });
+
+  it("accepts custom voteCount", async () => {
+    await sendPollVoteSignal("+15551234567", {
+      pollAuthor: "+15559999999",
+      pollTimestamp: 1234567890,
+      optionIndexes: [1],
+      voteCount: 3,
+    });
+
+    const params = rpcMock.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(params.voteCount).toBe(3);
+  });
+});
+
+describe("sendPollTerminateSignal", () => {
+  beforeEach(() => {
+    rpcMock.mockReset().mockResolvedValue({ timestamp: 9999999999 });
+  });
+
+  it("sends poll terminate with correct RPC params", async () => {
+    await sendPollTerminateSignal("+15551234567", {
+      pollTimestamp: 1234567890,
+    });
+
+    expect(rpcMock).toHaveBeenCalledWith(
+      "sendPollTerminate",
+      expect.objectContaining({
+        recipient: ["+15551234567"],
+        pollTimestamp: 1234567890,
+        notifySelf: false,
+        account: "+15550001111",
+      }),
+      expect.objectContaining({
+        baseUrl: "http://signal.local",
+      }),
+    );
+  });
+
+  it("sends poll terminate for group target", async () => {
+    await sendPollTerminateSignal("group:xyz789", {
+      pollTimestamp: 9876543210,
+    });
+
+    const params = rpcMock.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(params.groupId).toBe("xyz789");
+    expect(params.pollTimestamp).toBe(9876543210);
+    expect(params.notifySelf).toBe(false);
+    expect(params.recipient).toBeUndefined();
+  });
+
+  it("rejects poll terminate with invalid timestamp", async () => {
+    await expect(
+      sendPollTerminateSignal("+15551234567", {
+        pollTimestamp: 0,
+      }),
+    ).rejects.toThrow("Invalid poll timestamp");
+
+    await expect(
+      sendPollTerminateSignal("+15551234567", {
+        pollTimestamp: -1,
+      }),
+    ).rejects.toThrow("Invalid poll timestamp");
+
+    expect(rpcMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Signal supported `send` and `react` message actions, but lacked `unsend` (remote delete) and poll lifecycle actions (`poll`, `pollVote`, `pollTerminate`), even though signal-cli exposes the underlying `remoteDelete`, `sendPollCreate`, `sendPollVote`, and `sendPollTerminate` RPC methods. This PR adds all four actions end-to-end, with config toggles, comprehensive tests, and documentation.

## What Changed

### Signal remote delete transport

- `src/signal/send.ts`: Added `sendRemoteDeleteSignal(to, targetTimestamp, opts)`.
- Reuses existing Signal target parsing (`parseTarget`, `buildTargetParams`) and account context resolution (`resolveSignalRpcContext`).
- Maps recipient/group/username targets to the `remoteDelete` RPC payload.
- Rejects invalid timestamps (`<= 0`, non-finite) before RPC.

### Signal poll lifecycle transport

- `src/signal/send.ts`: Added `sendPollCreateSignal(to, opts)` — maps to `sendPollCreate` RPC with `question`, `option` (string array), and `noMulti` (inverted `allowMultiple`). Validates non-empty question and at least 2 options.
- `src/signal/send.ts`: Added `sendPollVoteSignal(to, opts)` — maps to `sendPollVote` RPC with `pollAuthor`, `pollTimestamp`, `option` (index array), and `voteCount`. Validates timestamp, author, and non-empty option indexes.
- `src/signal/send.ts`: Added `sendPollTerminateSignal(to, opts)` — maps to `sendPollTerminate` RPC with `pollTimestamp` and `notifySelf: false`. Validates timestamp.

### Action integration and capability surface

- `src/channels/plugins/actions/signal.ts`: `listActions` now includes `unsend`, `poll`, `pollVote`, and `pollTerminate` when the corresponding `actions.*` config toggle is enabled (all default `true`).
- Action handlers for all four new actions with gate enforcement, recipient/group validation, parameter parsing, and dispatch.
- `src/channels/dock.ts`: Marked Signal capabilities with `unsend: true` and `polls: true`.
- `src/channels/plugins/message-action-names.ts`: Registered `pollVote` and `pollTerminate` as global action names.
- `src/infra/outbound/message-action-spec.ts`: Added `pollVote` and `pollTerminate` target mode mappings.

### Config, schema, and types

- `src/config/types.signal.ts`: Added typed `actions.unsend?`, `actions.poll?`, `actions.pollVote?`, `actions.pollTerminate?` (all `boolean`, default `true`).
- `src/config/zod-schema.providers-core.ts`: Added Zod schema fields for the four new action toggles.
- `src/config/config.schema-regressions.test.ts`: Added regression test validating all new action toggles.

### Documentation

- `docs/channels/signal.md`: Added "Unsend" and "Poll create/vote/close" sections with usage examples.
- `docs/cli/message.md`: Added `unsend`, `pollVote`, `pollTerminate` action descriptions and Signal poll CLI example.
- `docs/gateway/configuration-reference.md`: Added `actions` block with all five toggles to the Signal config example.

### Test coverage

- `src/signal/send.test.ts` (new): Comprehensive tests for all four transport functions — RPC parameter mapping, target handling, input validation.
- `src/channels/plugins/actions/actions.test.ts`: Tests for unsend, poll create, pollVote, and pollTerminate actions — happy paths, group targets, disabled gates, param aliases, missing params, RPC failures.

## Design Notes

- All RPC transport functions are in `src/signal/send.ts` to keep Signal transport centralized.
- Each action uses the same `createActionGate` pattern as existing actions, preserving backward-compatible defaults.
- Poll create uses `noMulti` (inverted boolean) to match signal-cli's RPC convention, while the user-facing config uses the more intuitive `allowMultiple`/`pollMulti`.

## AI Disclosure

- [x] AI-assisted
- [x] Fully tested

---

Closes #15536
Closes #22259