### PR TITLE
fix: hide metadata block when only conversation_label is present

### DIFF
--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -60,7 +60,12 @@ export function buildInboundUserContextPrefix(ctx: TemplateContext): string {
     is_forum: ctx.IsForum === true ? true : undefined,
     was_mentioned: ctx.WasMentioned === true ? true : undefined,
   };
-  if (Object.values(conversationInfo).some((v) => v !== undefined)) {
+  // Only show conversation info block if there's meaningful metadata beyond just conversation_label.
+  // This avoids cluttering TUI and other simple direct chat sessions.
+  const hasUsefulConversationMeta = Object.entries(conversationInfo).some(
+    ([key, value]) => key !== "conversation_label" && value !== undefined,
+  );
+  if (Object.values(conversationInfo).some((v) => v !== undefined) && hasUsefulConversationMeta) {
     blocks.push(
       [
         "Conversation info (untrusted metadata):",

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -65,7 +65,7 @@ export function buildInboundUserContextPrefix(ctx: TemplateContext): string {
   const hasUsefulConversationMeta = Object.entries(conversationInfo).some(
     ([key, value]) => key !== "conversation_label" && value !== undefined,
   );
-  if (Object.values(conversationInfo).some((v) => v !== undefined) && hasUsefulConversationMeta) {
+  if (hasUsefulConversationMeta) {
     blocks.push(
       [
         "Conversation info (untrusted metadata):",


### PR DESCRIPTION
- Avoids cluttering TUI and simple direct chat sessions
- Only shows conversation info block when there's useful metadata beyond just conversation_label
- Fixes issue where TUI shows 'Conversation info (untrusted metadata): { conversation_label: openclaw-tui }' on every message

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Prevents cluttering TUI and direct chat sessions by only displaying the conversation info block when there's meaningful metadata beyond just `conversation_label`.

- Adds new check `hasUsefulConversationMeta` to filter out cases where only `conversation_label` is present
- Fixes issue where TUI shows 'Conversation info (untrusted metadata): { conversation_label: openclaw-tui }' on every message
- Logic is correct but includes a redundant condition (the first `Object.values().some()` check is unnecessary)

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk - it's a focused fix that improves UX without breaking functionality
- Score reflects that the change is well-scoped, logically correct, and addresses a specific UX issue. Minor deduction for the redundant condition that could be simplified, but this doesn't affect correctness
- No files require special attention

<sub>Last reviewed commit: 1b51363</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->