### PR TITLE
fix(gateway): reduce chat.history byte cap from 6 MB to 2 MB

### DIFF
--- a/src/gateway/server-constants.ts
+++ b/src/gateway/server-constants.ts
@@ -1,7 +1,7 @@
 export const MAX_PAYLOAD_BYTES = 8 * 1024 * 1024; // cap incoming frame size (~8 MiB; fits ~5,000,000 decoded bytes as base64 + JSON overhead)
 export const MAX_BUFFERED_BYTES = 16 * 1024 * 1024; // per-connection send buffer limit (2x max payload)
 
-const DEFAULT_MAX_CHAT_HISTORY_MESSAGES_BYTES = 6 * 1024 * 1024; // keep history responses comfortably under client WS limits
+const DEFAULT_MAX_CHAT_HISTORY_MESSAGES_BYTES = 2 * 1024 * 1024; // keep history responses small enough for browsers to parse without freezing
 let maxChatHistoryMessagesBytes = DEFAULT_MAX_CHAT_HISTORY_MESSAGES_BYTES;
 
 export const getMaxChatHistoryMessagesBytes = () => maxChatHistoryMessagesBytes;


### PR DESCRIPTION
## Summary
- Lower `DEFAULT_MAX_CHAT_HISTORY_MESSAGES_BYTES` from 6 MiB to 2 MiB
- Sessions with large transcripts (~6 MB+) crash the browser tab because `chat.history` sends the full capped payload in a single WebSocket frame
- 2 MiB is still plenty for ~200 messages of normal conversation while staying within what browsers can comfortably parse and render

## Test plan
- [x] `session-utils.test.ts` (34 tests) — all pass, `capArrayByJsonBytes` uses custom limits unaffected by default change
- [x] Build + lint clean

Fixes #15992

lobster-biscuit

> 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Reduced `DEFAULT_MAX_CHAT_HISTORY_MESSAGES_BYTES` from 6 MiB to 2 MiB to prevent browser tab crashes when sending large chat history transcripts via WebSocket. The change addresses sessions with ~6 MB+ transcripts that were causing browser tabs to freeze when `chat.history` sent the full payload in a single WebSocket frame. 2 MiB still provides capacity for approximately 200 messages while staying within browser parsing limits.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a simple constant value reduction that addresses a real browser performance issue. The new value (2 MiB) is still generous for typical use cases (~200 messages), and the `capArrayByJsonBytes` function already handles byte capping correctly. Tests pass and the change is well-justified in both the PR description and issue reference.
- No files require special attention

<sub>Last reviewed commit: 4d3bcde</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->