### PR TITLE
[AI-assisted] fix: preserve channel ID case in session keys for Slack and Matrix

### DIFF
--- a/src/infra/outbound/message-action-runner.threading.test.ts
+++ b/src/infra/outbound/message-action-runner.threading.test.ts
@@ -102,7 +102,7 @@ describe("runMessageAction threading auto-injection", () => {
     });
 
     const call = mocks.executeSendAction.mock.calls[0]?.[0];
-    expect(call?.ctx?.mirror?.sessionKey).toBe("agent:main:slack:channel:c123:thread:111.222");
+    expect(call?.ctx?.mirror?.sessionKey).toBe("agent:main:slack:channel:C123:thread:111.222");
   });
 
   it("matches auto-threading when channel ids differ in case", async () => {
@@ -128,7 +128,7 @@ describe("runMessageAction threading auto-injection", () => {
     });
 
     const call = mocks.executeSendAction.mock.calls[0]?.[0];
-    expect(call?.ctx?.mirror?.sessionKey).toBe("agent:main:slack:channel:c123:thread:333.444");
+    expect(call?.ctx?.mirror?.sessionKey).toBe("agent:main:slack:channel:C123:thread:333.444");
   });
 
   it("auto-injects telegram threadId from toolContext when omitted", async () => {

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -490,6 +490,7 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
           resolvedTarget,
           replyToId,
           threadId: resolvedThreadId,
+          toolContext: input.toolContext,
         })
       : null;
   if (outboundRoute && agentId && !dryRun) {

--- a/src/infra/outbound/outbound-session.test.ts
+++ b/src/infra/outbound/outbound-session.test.ts
@@ -14,7 +14,7 @@ describe("resolveOutboundSessionRoute", () => {
       replyToId: "456",
     });
 
-    expect(route?.sessionKey).toBe("agent:main:slack:channel:c123:thread:456");
+    expect(route?.sessionKey).toBe("agent:main:slack:channel:C123:thread:456");
     expect(route?.from).toBe("slack:channel:C123");
     expect(route?.to).toBe("channel:C123");
     expect(route?.threadId).toBe("456");
@@ -75,7 +75,7 @@ describe("resolveOutboundSessionRoute", () => {
       target: "chat_guid:ABC123",
     });
 
-    expect(route?.sessionKey).toBe("agent:main:bluebubbles:group:abc123");
+    expect(route?.sessionKey).toBe("agent:main:bluebubbles:group:ABC123");
     expect(route?.from).toBe("group:ABC123");
   });
 
@@ -110,7 +110,7 @@ describe("resolveOutboundSessionRoute", () => {
       target: "channel:G123",
     });
 
-    expect(route?.sessionKey).toBe("agent:main:slack:group:g123");
+    expect(route?.sessionKey).toBe("agent:main:slack:group:G123");
     expect(route?.from).toBe("slack:group:G123");
   });
 });

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -309,11 +309,11 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
       peer,
       dmScope,
       identityLinks,
-    }).toLowerCase();
+    });
     const mainSessionKey = buildAgentMainSessionKey({
       agentId: resolvedAgentId,
       mainKey: DEFAULT_MAIN_KEY,
-    }).toLowerCase();
+    });
     return {
       agentId: resolvedAgentId,
       channel,

--- a/src/routing/session-key.ts
+++ b/src/routing/session-key.ts
@@ -164,7 +164,6 @@ export function buildAgentPeerSessionKey(params: {
     if (linkedPeerId) {
       peerId = linkedPeerId;
     }
-    peerId = peerId.toLowerCase();
     if (dmScope === "per-account-channel-peer" && peerId) {
       const channel = (params.channel ?? "").trim().toLowerCase() || "unknown";
       const accountId = normalizeAccountId(params.accountId);
@@ -183,7 +182,7 @@ export function buildAgentPeerSessionKey(params: {
     });
   }
   const channel = (params.channel ?? "").trim().toLowerCase() || "unknown";
-  const peerId = ((params.peerId ?? "").trim() || "unknown").toLowerCase();
+  const peerId = (params.peerId ?? "").trim() || "unknown";
   return `agent:${normalizeAgentId(params.agentId)}:${channel}:${peerKind}:${peerId}`;
 }
 
@@ -241,7 +240,7 @@ export function buildGroupHistoryKey(params: {
 }): string {
   const channel = normalizeToken(params.channel) || "unknown";
   const accountId = normalizeAccountId(params.accountId);
-  const peerId = params.peerId.trim().toLowerCase() || "unknown";
+  const peerId = params.peerId.trim() || "unknown";
   return `${channel}:${accountId}:${params.peerKind}:${peerId}`;
 }
 

--- a/src/slack/monitor.tool-result.threads-top-level-replies-replytomode-is-all.test.ts
+++ b/src/slack/monitor.tool-result.threads-top-level-replies-replytomode-is-all.test.ts
@@ -106,8 +106,8 @@ describe("monitorSlackProvider tool results", () => {
       SessionKey?: string;
       ParentSessionKey?: string;
     };
-    expect(ctx.SessionKey).toBe("agent:main:slack:channel:c1:thread:111.222");
-    expect(ctx.ParentSessionKey).toBe("agent:main:slack:channel:c1");
+    expect(ctx.SessionKey).toBe("agent:main:slack:channel:C1:thread:111.222");
+    expect(ctx.ParentSessionKey).toBe("agent:main:slack:channel:C1");
   });
 
   it("injects starter context for thread replies", async () => {
@@ -154,7 +154,7 @@ describe("monitorSlackProvider tool results", () => {
       ThreadStarterBody?: string;
       ThreadLabel?: string;
     };
-    expect(ctx.SessionKey).toBe("agent:main:slack:channel:c1:thread:111.222");
+    expect(ctx.SessionKey).toBe("agent:main:slack:channel:C1:thread:111.222");
     expect(ctx.ParentSessionKey).toBeUndefined();
     expect(ctx.ThreadStarterBody).toContain("starter message");
     expect(ctx.ThreadLabel).toContain("Slack thread #general");
@@ -203,7 +203,7 @@ describe("monitorSlackProvider tool results", () => {
       SessionKey?: string;
       ParentSessionKey?: string;
     };
-    expect(ctx.SessionKey).toBe("agent:support:slack:channel:c1:thread:111.222");
+    expect(ctx.SessionKey).toBe("agent:support:slack:channel:C1:thread:111.222");
     expect(ctx.ParentSessionKey).toBeUndefined();
   });
 


### PR DESCRIPTION
## Summary

Fixes case sensitivity issues in session key generation for Slack and Matrix channels.

## Background

### Why preserve case?

Different messaging platforms have different case sensitivity requirements for their identifiers:

- **Matrix**: Room IDs are case-sensitive (e.g., `!AbCdEf:matrix.org` is different from `!abcdef:matrix.org`)
- **Slack**: Channel IDs are case-insensitive for matching, but the canonical form preserves case (e.g., `C123` vs `c123`)

When OpenClaw generates session keys for outbound messages, it was lowercasing all peer IDs (channel/room IDs). This caused issues when:
1. An inbound message arrives with a specific case (e.g., `C123`)
2. The agent sends an outbound message to the same channel but with different case (e.g., `c123`)
3. The session keys don't match, creating duplicate sessions for the same conversation

## Changes

### 1. Removed `.toLowerCase()` from peer ID normalization

**Files:** `src/routing/session-key.ts`

- `buildAgentPeerSessionKey()`: Removed `.toLowerCase()` from peer ID
- `buildGroupHistoryKey()`: Removed `.toLowerCase()` from peer ID

This ensures that channel/room IDs are preserved in their original case when constructing session keys.

### 2. Slack auto-threading case preservation

**Files:** `src/infra/outbound/outbound-session.ts`, `src/infra/outbound/message-action-runner.ts`

When auto-threading matches a target channel ID case-insensitively with the `currentChannelId` from `toolContext`, the code now uses the original case from `currentChannelId` to ensure session keys remain consistent with inbound sessions.

Example:
- Inbound session: `agent:main:slack:channel:C123:thread:333.444`
- Outbound target: `channel:c123` (lowercase from user input)
- Before fix: Session key becomes `agent:main:slack:channel:c123:thread:333.444` ❌
- After fix: Session key becomes `agent:main:slack:channel:C123:thread:333.444` ✅

### 3. Test updates

Updated tests to expect the correct case-preserved session keys.

## Test Results

All tests pass, including:
- `message-action-runner.threading.test.ts`: 7 tests pass
- `outbound-session.test.ts`: All tests pass
- `session-key.test.ts`: All tests pass

## Related Issues

Fixes CI failure in PR #16007 where the test "matches auto-threading when channel ids differ in case" was failing due to case mismatch in session keys.