### PR TITLE
fix(security): use 0o600 permissions for session transcript files

### DIFF
--- a/src/agents/pi-embedded-helpers/bootstrap.ts
+++ b/src/agents/pi-embedded-helpers/bootstrap.ts
@@ -156,7 +156,7 @@ export async function ensureSessionHeader(params: {
     timestamp: new Date().toISOString(),
     cwd: params.cwd,
   };
-  await fs.writeFile(file, `${JSON.stringify(entry)}\n`, "utf-8");
+  await fs.writeFile(file, `${JSON.stringify(entry)}\n`, { encoding: "utf-8", mode: 0o600 });
 }
 
 export function buildBootstrapContextFiles(

--- a/src/agents/pi-embedded-runner/session-manager-init.ts
+++ b/src/agents/pi-embedded-runner/session-manager-init.ts
@@ -43,7 +43,7 @@ export async function prepareSessionManagerForRun(params: {
 
   if (params.hadSessionFile && header && !hasAssistant) {
     // Reset file so the first assistant flush includes header+user+assistant in order.
-    await fs.writeFile(params.sessionFile, "", "utf-8");
+    await fs.writeFile(params.sessionFile, "", { encoding: "utf-8", mode: 0o600 });
     sm.fileEntries = [header];
     sm.byId?.clear?.();
     sm.labelsById?.clear?.();

--- a/src/agents/session-file-repair.ts
+++ b/src/agents/session-file-repair.ts
@@ -73,12 +73,8 @@ export async function repairSessionFileIfNeeded(params: {
   const backupPath = `${sessionFile}.bak-${process.pid}-${Date.now()}`;
   const tmpPath = `${sessionFile}.repair-${process.pid}-${Date.now()}.tmp`;
   try {
-    const stat = await fs.stat(sessionFile).catch(() => null);
-    const mode = stat ? stat.mode : 0o600;
     await fs.writeFile(backupPath, content, { encoding: "utf-8", mode: 0o600 });
-    await fs.chmod(backupPath, mode);
     await fs.writeFile(tmpPath, cleaned, { encoding: "utf-8", mode: 0o600 });
-    await fs.chmod(tmpPath, mode);
     await fs.rename(tmpPath, sessionFile);
   } catch (err) {
     try {

--- a/src/agents/session-file-repair.ts
+++ b/src/agents/session-file-repair.ts
@@ -74,14 +74,11 @@ export async function repairSessionFileIfNeeded(params: {
   const tmpPath = `${sessionFile}.repair-${process.pid}-${Date.now()}.tmp`;
   try {
     const stat = await fs.stat(sessionFile).catch(() => null);
-    await fs.writeFile(backupPath, content, "utf-8");
-    if (stat) {
-      await fs.chmod(backupPath, stat.mode);
-    }
-    await fs.writeFile(tmpPath, cleaned, "utf-8");
-    if (stat) {
-      await fs.chmod(tmpPath, stat.mode);
-    }
+    const mode = stat ? stat.mode : 0o600;
+    await fs.writeFile(backupPath, content, { encoding: "utf-8", mode: 0o600 });
+    await fs.chmod(backupPath, mode);
+    await fs.writeFile(tmpPath, cleaned, { encoding: "utf-8", mode: 0o600 });
+    await fs.chmod(tmpPath, mode);
     await fs.rename(tmpPath, sessionFile);
   } catch (err) {
     try {

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -87,7 +87,10 @@ function forkSessionFromParent(params: {
       cwd: manager.getCwd(),
       parentSession: parentSessionFile,
     };
-    fs.writeFileSync(sessionFile, `${JSON.stringify(header)}\n`, { encoding: "utf-8", mode: 0o600 });
+    fs.writeFileSync(sessionFile, `${JSON.stringify(header)}\n`, {
+      encoding: "utf-8",
+      mode: 0o600,
+    });
     return { sessionId, sessionFile };
   } catch {
     return null;

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -87,7 +87,7 @@ function forkSessionFromParent(params: {
       cwd: manager.getCwd(),
       parentSession: parentSessionFile,
     };
-    fs.writeFileSync(sessionFile, `${JSON.stringify(header)}\n`, "utf-8");
+    fs.writeFileSync(sessionFile, `${JSON.stringify(header)}\n`, { encoding: "utf-8", mode: 0o600 });
     return { sessionId, sessionFile };
   } catch {
     return null;

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -72,7 +72,10 @@ async function ensureSessionHeader(params: {
     timestamp: new Date().toISOString(),
     cwd: process.cwd(),
   };
-  await fs.promises.writeFile(params.sessionFile, `${JSON.stringify(header)}\n`, "utf-8");
+  await fs.promises.writeFile(params.sessionFile, `${JSON.stringify(header)}\n`, {
+    encoding: "utf-8",
+    mode: 0o600,
+  });
 }
 
 export async function appendAssistantMessageToSessionTranscript(params: {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -86,7 +86,10 @@ function ensureTranscriptFile(params: { transcriptPath: string; sessionId: strin
       timestamp: new Date().toISOString(),
       cwd: process.cwd(),
     };
-    fs.writeFileSync(params.transcriptPath, `${JSON.stringify(header)}\n`, "utf-8");
+    fs.writeFileSync(params.transcriptPath, `${JSON.stringify(header)}\n`, {
+      encoding: "utf-8",
+      mode: 0o600,
+    });
     return { ok: true };
   } catch (err) {
     return { ok: false, error: err instanceof Error ? err.message : String(err) };

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -454,7 +454,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
 
     const archived = archiveFileOnDisk(filePath, "bak");
     const keptLines = lines.slice(-maxLines);
-    fs.writeFileSync(filePath, `${keptLines.join("\n")}\n`, "utf-8");
+    fs.writeFileSync(filePath, `${keptLines.join("\n")}\n`, { encoding: "utf-8", mode: 0o600 });
 
     await updateSessionStore(storePath, (store) => {
       const entryKey = compactTarget.primaryKey;


### PR DESCRIPTION
Session transcript .jsonl files contain full conversation history including user messages, tool call arguments, and model responses. Previously created with default 0o644 (world-readable) permissions.

Restrict all session file write paths to 0o600 (owner-only), matching the permission model already used by saveJsonFile() for credential and config files (CWE-732).

Write paths fixed:
- config/sessions/transcript.ts (ensureSessionHeader)
- agents/pi-embedded-helpers/bootstrap.ts (ensureSessionHeader)
- agents/pi-embedded-runner/session-manager-init.ts (reset path)
- auto-reply/reply/session.ts (forkSessionFromParent)
- gateway/server-methods/chat.ts (ensureTranscriptFile)
- gateway/server-methods/sessions.ts (manual compaction)
- agents/session-file-repair.ts (backup + repair writes)

Closes #8751

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR addresses a security vulnerability (CWE-732) where session transcript `.jsonl` files containing sensitive conversation data were being created with default world-readable permissions (`0o644`). The fix restricts all session file write operations to owner-only permissions (`0o600`), matching the pattern already used by `saveJsonFile()` for credentials and config files.

**Changes:**
- Updated 7 file write locations to use `{ encoding: "utf-8", mode: 0o600 }` instead of plain `"utf-8"` encoding
- Files fixed: `config/sessions/transcript.ts`, `agents/pi-embedded-helpers/bootstrap.ts`, `agents/pi-embedded-runner/session-manager-init.ts`, `auto-reply/reply/session.ts`, `gateway/server-methods/chat.ts`, `gateway/server-methods/sessions.ts`, and `agents/session-file-repair.ts`

**Issue identified:**
- `src/agents/session-file-repair.ts:77-81` contains a logic error where backup/temp files are created with `0o600` but then immediately changed back to the original file's permissions via `chmod()`, which could restore insecure permissions if the original file was world-readable

<h3>Confidence Score: 3/5</h3>

- Safe to merge after addressing the permission restoration issue in session-file-repair.ts
- The PR correctly fixes the security vulnerability in 6 out of 7 files, but `session-file-repair.ts` has a logic error where it restores the original (potentially insecure) permissions after creating files with secure permissions. This undermines the security fix for backup and temp files created during repair operations.
- `src/agents/session-file-repair.ts` needs the `chmod` calls removed to maintain secure `0o600` permissions on backup and temp files

<sub>Last reviewed commit: 003a285</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->