### PR TITLE
fix(gateway): truncate oversized message content in chat.history response

### DIFF
--- a/src/gateway/chat-sanitize.ts
+++ b/src/gateway/chat-sanitize.ts
@@ -121,3 +121,71 @@ export function stripEnvelopeFromMessages(messages: unknown[]): unknown[] {
   });
   return changed ? next : messages;
 }
+
+const MAX_CONTENT_CHARS = 50_000;
+const TRUNCATION_SUFFIX = "\n\n… [content truncated for display]";
+
+function truncateString(text: string): string {
+  if (text.length <= MAX_CONTENT_CHARS) {
+    return text;
+  }
+  return text.slice(0, MAX_CONTENT_CHARS) + TRUNCATION_SUFFIX;
+}
+
+function truncateContentArray(content: unknown[]): { content: unknown[]; changed: boolean } {
+  let changed = false;
+  const next = content.map((item) => {
+    if (!item || typeof item !== "object") {
+      return item;
+    }
+    const entry = item as Record<string, unknown>;
+    if (typeof entry.text !== "string" || entry.text.length <= MAX_CONTENT_CHARS) {
+      return item;
+    }
+    changed = true;
+    return { ...entry, text: truncateString(entry.text) };
+  });
+  return { content: next, changed };
+}
+
+function truncateMessageContent(message: unknown): unknown {
+  if (!message || typeof message !== "object") {
+    return message;
+  }
+  const entry = message as Record<string, unknown>;
+  let changed = false;
+  const next: Record<string, unknown> = { ...entry };
+
+  if (typeof entry.content === "string" && entry.content.length > MAX_CONTENT_CHARS) {
+    next.content = truncateString(entry.content);
+    changed = true;
+  } else if (Array.isArray(entry.content)) {
+    const updated = truncateContentArray(entry.content);
+    if (updated.changed) {
+      next.content = updated.content;
+      changed = true;
+    }
+  }
+
+  if (typeof entry.text === "string" && entry.text.length > MAX_CONTENT_CHARS) {
+    next.text = truncateString(entry.text);
+    changed = true;
+  }
+
+  return changed ? next : message;
+}
+
+export function truncateMessagesForChatHistory(messages: unknown[]): unknown[] {
+  if (messages.length === 0) {
+    return messages;
+  }
+  let changed = false;
+  const next = messages.map((message) => {
+    const truncated = truncateMessageContent(message);
+    if (truncated !== message) {
+      changed = true;
+    }
+    return truncated;
+  });
+  return changed ? next : messages;
+}

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -19,7 +19,7 @@ import {
   resolveChatRunExpiresAtMs,
 } from "../chat-abort.js";
 import { type ChatImageContent, parseMessageWithAttachments } from "../chat-attachments.js";
-import { stripEnvelopeFromMessages } from "../chat-sanitize.js";
+import { stripEnvelopeFromMessages, truncateMessagesForChatHistory } from "../chat-sanitize.js";
 import { GATEWAY_CLIENT_CAPS, hasGatewayClientCap } from "../protocol/client-info.js";
 import {
   ErrorCodes,
@@ -233,7 +233,8 @@ export const chatHandlers: GatewayRequestHandlers = {
     const max = Math.min(hardMax, requested);
     const sliced = rawMessages.length > max ? rawMessages.slice(-max) : rawMessages;
     const sanitized = stripEnvelopeFromMessages(sliced);
-    const capped = capArrayByJsonBytes(sanitized, getMaxChatHistoryMessagesBytes()).items;
+    const truncated = truncateMessagesForChatHistory(sanitized);
+    const capped = capArrayByJsonBytes(truncated, getMaxChatHistoryMessagesBytes()).items;
     let thinkingLevel = entry?.thinkingLevel;
     if (!thinkingLevel) {
       const configured = cfg.agents?.defaults?.thinkingDefault;


### PR DESCRIPTION
## Summary
- Add `truncateMessagesForChatHistory()` that caps each message's content fields to 50K chars before the response is byte-capped
- A single message with huge thinking output or tool response can dominate the entire `chat.history` payload, causing the Control UI to freeze
- Runs in the existing pipeline: `stripEnvelopeFromMessages → truncateMessagesForChatHistory → capArrayByJsonBytes`
- Truncated content ends with `… [content truncated for display]` so users know data was trimmed

## Test plan
- [x] 5 new tests in `chat-sanitize.test.ts` covering string content, content arrays, text field, no-op passthrough, and empty array
- [x] Build + lint clean

Ref #15992

lobster-biscuit

> 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Added `truncateMessagesForChatHistory()` to cap message content fields at 50K characters before the response is byte-capped, preventing the Control UI from freezing when a single message with huge thinking output or tool response dominates the entire `chat.history` payload. The function runs in the existing sanitization pipeline: `stripEnvelopeFromMessages → truncateMessagesForChatHistory → capArrayByJsonBytes`. Truncated content includes `… [content truncated for display]` suffix to inform users of trimming.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation follows existing patterns in the codebase, has comprehensive test coverage with 5 new tests covering various edge cases (string content, content arrays, text field, no-op passthrough, empty array), and the changes are well-isolated to a specific utility function. The truncation logic is straightforward and defensive, handling null/undefined cases properly. The function integrates seamlessly into the existing pipeline without disrupting other functionality.
- No files require special attention

<sub>Last reviewed commit: 185379a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->