### PR TITLE
feat: add image support to /v1/chat/completions endpoint

### DIFF
--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -1,10 +1,10 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { randomUUID } from "node:crypto";
+import type { ImageContent } from "../commands/agent/types.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import { buildHistoryContextFromEntries, type HistoryEntry } from "../auto-reply/reply/history.js";
 import { createDefaultDeps } from "../cli/deps.js";
 import { agentCommand } from "../commands/agent.js";
-import type { ImageContent } from "../commands/agent/types.js";
 import { emitAgentEvent, onAgentEvent } from "../infra/agent-events.js";
 import { logWarn } from "../logger.js";
 import {
@@ -226,10 +226,7 @@ async function extractImagesFromOpenAiMessages(
       images.push({ type: "image", data: dataUriMatch[2]!, mimeType: dataUriMatch[1]! });
     } else if (url.startsWith("http://") || url.startsWith("https://")) {
       try {
-        const image = await extractImageContentFromSource(
-          { type: "url", url },
-          IMAGE_LIMITS,
-        );
+        const image = await extractImageContentFromSource({ type: "url", url }, IMAGE_LIMITS);
         images.push(image);
       } catch {
         // Skip images that fail to fetch — don't block the request.

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -223,7 +223,7 @@ async function extractImagesFromOpenAiMessages(
 
     const dataUriMatch = url.match(/^data:(image\/[a-zA-Z0-9.+-]+);base64,(.+)$/s);
     if (dataUriMatch) {
-      images.push({ type: "image", data: dataUriMatch[2]!, mimeType: dataUriMatch[1]! });
+      images.push({ type: "image", data: dataUriMatch[2], mimeType: dataUriMatch[1] });
     } else if (url.startsWith("http://") || url.startsWith("https://")) {
       try {
         const image = await extractImageContentFromSource({ type: "url", url }, IMAGE_LIMITS);


### PR DESCRIPTION
## Summary

The OpenAI-compatible `/v1/chat/completions` endpoint silently drops `image_url` content parts and has a 1MB body size limit that blocks base64-encoded images. Meanwhile, the `/v1/responses` endpoint and WebSocket handlers already support images correctly.

This PR wires image support into the chat completions endpoint:

- **New `extractImagesFromOpenAiMessages()` function** — parses `image_url` content parts from the last user message, handling both `data:image/...;base64,...` URIs (inline extraction) and `https://` URLs (via the existing `extractImageContentFromSource` helper with default image limits)
- **Body size limit bumped from 1MB to 20MB** — matches `/v1/responses` default, allows base64-encoded images through
- **Images passed to `agentCommand`** in both streaming and non-streaming code paths

Only images from the last user message are extracted, consistent with how `buildAgentPrompt` only uses the last user entry for the current prompt.

## Test plan

- [ ] Send a text-only message via `/v1/chat/completions` — should work as before (regression check)
- [ ] Send a message with `image_url` content part using a `data:` URI — agent should describe/respond to the image
- [ ] Send a message with `image_url` content part using an `https://` URL — image should be fetched and forwarded
- [ ] Send a large base64 image (>1MB) — should succeed with the new 20MB limit
- [ ] Streaming mode with images — verify images are passed through in the streaming path too

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds image support to the OpenAI-compatible `/v1/chat/completions` endpoint by extracting `image_url` content parts from the last user message. The implementation handles both base64 data URIs (inline extraction) and HTTPS URLs (via the existing `extractImageContentFromSource` helper with SSRF protection). The body size limit is increased from 1MB to 20MB to accommodate base64-encoded images, matching the `/v1/responses` endpoint's default limit.

Key changes:
- New `extractImagesFromOpenAiMessages()` function extracts images from the last user message only (consistent with how `buildAgentPrompt` works)
- Images are passed to `agentCommand` in both streaming and non-streaming paths
- Failed image fetches are silently skipped to avoid blocking the request
- Proper type guards and validation throughout

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk
- The implementation reuses existing, battle-tested image extraction helpers with proper SSRF protection. The changes are focused and follow the same patterns as the `/v1/responses` endpoint. Error handling is appropriate (failed images don't block requests). The 20MB body limit increase is justified and matches other endpoints.
- No files require special attention

<sub>Last reviewed commit: 9969867</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->