### PR TITLE
perf(ui): virtualize chat message list for large conversations

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -578,6 +578,9 @@ importers:
 
   ui:
     dependencies:
+      '@lit-labs/virtualizer':
+        specifier: ^2.1.1
+        version: 2.1.1
       '@noble/ed25519':
         specifier: 3.0.0
         version: 3.0.0
@@ -1364,6 +1367,9 @@ packages:
 
   '@lit-labs/ssr-dom-shim@1.5.1':
     resolution: {integrity: sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==}
+
+  '@lit-labs/virtualizer@2.1.1':
+    resolution: {integrity: sha512-JWxMwnlouLdwpw8spLTuax53WMnSP3xt0dCyxAS7GJr5Otda9MGgR/ghAdfwhSY75TmjbE1T2TqChwoGCw3ggw==}
 
   '@lit/context@1.1.6':
     resolution: {integrity: sha512-M26qDE6UkQbZA2mQ3RjJ3Gzd8TxP+/0obMgE5HfkfLhEEyYE3Bui4A5XHiGPjy0MUGAyxB3QgVuw2ciS0kHn6A==}
@@ -6845,7 +6851,7 @@ snapshots:
 
   '@larksuiteoapi/node-sdk@1.59.0':
     dependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       lodash.identity: 3.0.0
       lodash.merge: 4.6.2
       lodash.pickby: 4.6.0
@@ -6861,7 +6867,7 @@ snapshots:
     dependencies:
       '@types/node': 24.10.13
     optionalDependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
     transitivePeerDependencies:
       - debug
 
@@ -6871,6 +6877,11 @@ snapshots:
       signal-polyfill: 0.2.2
 
   '@lit-labs/ssr-dom-shim@1.5.1': {}
+
+  '@lit-labs/virtualizer@2.1.1':
+    dependencies:
+      lit: 3.3.2
+      tslib: 2.8.1
 
   '@lit/context@1.1.6':
     dependencies:
@@ -7064,7 +7075,7 @@ snapshots:
       '@azure/core-auth': 1.10.1
       '@azure/msal-node': 3.8.7
       '@microsoft/agents-activity': 1.2.3
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       jsonwebtoken: 9.0.3
       jwks-rsa: 3.2.2
       object-path: 0.11.8
@@ -7963,7 +7974,7 @@ snapshots:
       '@slack/types': 2.20.0
       '@slack/web-api': 7.14.1
       '@types/express': 5.0.6
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       express: 5.2.1
       path-to-regexp: 8.3.0
       raw-body: 3.0.2
@@ -8009,7 +8020,7 @@ snapshots:
       '@slack/types': 2.20.0
       '@types/node': 25.2.3
       '@types/retry': 0.12.0
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       eventemitter3: 5.0.4
       form-data: 2.5.4
       is-electron: 2.2.2
@@ -8897,14 +8908,6 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  axios@1.13.5:
-    dependencies:
-      follow-redirects: 1.15.11
-      form-data: 2.5.4
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
   axios@1.13.5(debug@4.4.3):
     dependencies:
       follow-redirects: 1.15.11(debug@4.4.3)
@@ -9483,8 +9486,6 @@ snapshots:
       array-back: 3.1.0
 
   flatbuffers@24.12.23: {}
-
-  follow-redirects@1.15.11: {}
 
   follow-redirects@1.15.11(debug@4.4.3):
     optionalDependencies:

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,6 +9,7 @@
     "test": "vitest run --config vitest.config.ts"
   },
   "dependencies": {
+    "@lit-labs/virtualizer": "^2.1.1",
     "@noble/ed25519": "3.0.0",
     "dompurify": "^3.3.1",
     "lit": "^3.3.2",

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -1,6 +1,6 @@
+import { virtualize } from "@lit-labs/virtualizer/virtualize.js";
 import { html, nothing } from "lit";
 import { ref } from "lit/directives/ref.js";
-import { repeat } from "lit/directives/repeat.js";
 import {
   renderMessageGroup,
   renderReadingIndicatorGroup,
@@ -221,10 +221,11 @@ export function renderChat(props: ChatProps) {
             `
           : nothing
       }
-      ${repeat(
-        buildChatItems(props),
-        (item) => item.key,
-        (item) => {
+      ${virtualize({
+        items: buildChatItems(props),
+        keyFunction: (item) => item.key,
+        scroller: true,
+        renderItem: (item) => {
           if (item.kind === "divider") {
             return html`
               <div class="chat-divider" role="separator" data-ts=${String(item.timestamp)}>
@@ -259,7 +260,7 @@ export function renderChat(props: ChatProps) {
 
           return nothing;
         },
-      )}
+      })}
     </div>
   `;
 
@@ -427,8 +428,6 @@ export function renderChat(props: ChatProps) {
   `;
 }
 
-const CHAT_HISTORY_RENDER_LIMIT = 200;
-
 function groupMessages(items: ChatItem[]): Array<ChatItem | MessageGroup> {
   const result: Array<ChatItem | MessageGroup> = [];
   let currentGroup: MessageGroup | null = null;
@@ -474,19 +473,7 @@ function buildChatItems(props: ChatProps): Array<ChatItem | MessageGroup> {
   const items: ChatItem[] = [];
   const history = Array.isArray(props.messages) ? props.messages : [];
   const tools = Array.isArray(props.toolMessages) ? props.toolMessages : [];
-  const historyStart = Math.max(0, history.length - CHAT_HISTORY_RENDER_LIMIT);
-  if (historyStart > 0) {
-    items.push({
-      kind: "message",
-      key: "chat:history:notice",
-      message: {
-        role: "system",
-        content: `Showing last ${CHAT_HISTORY_RENDER_LIMIT} messages (${historyStart} hidden).`,
-        timestamp: Date.now(),
-      },
-    });
-  }
-  for (let i = historyStart; i < history.length; i++) {
+  for (let i = 0; i < history.length; i++) {
     const msg = history[i];
     const normalized = normalizeMessage(msg);
     const raw = msg as Record<string, unknown>;

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -258,7 +258,7 @@ export function renderChat(props: ChatProps) {
             });
           }
 
-          return nothing;
+          return html``;
         },
       })}
     </div>

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -224,7 +224,6 @@ export function renderChat(props: ChatProps) {
       ${virtualize({
         items: buildChatItems(props),
         keyFunction: (item) => item.key,
-        scroller: true,
         renderItem: (item) => {
           if (item.kind === "divider") {
             return html`


### PR DESCRIPTION
## Summary
- Replace `repeat()` with `virtualize()` from `@lit-labs/virtualizer` in chat thread rendering
- Only visible messages (+ small buffer) are rendered in the DOM, keeping memory and render time constant regardless of history size
- Remove the previous 200-message render limit — virtualization handles unlimited messages efficiently
- Net -11 lines of code

## Why
The Control UI renders all messages as DOM nodes, which causes the browser tab to freeze or crash with long chat histories (~6 MB+ transcripts). Virtualization solves this at the rendering layer by only mounting elements in or near the viewport.

Prior art: PR #5743 attempted the same approach but went stale.

## Test plan
- [x] Build passes (`pnpm build`)
- [x] Lint clean
- [x] Tested with large conversation histories — smooth scrolling, no freezes

Ref #15992

lobster-biscuit

> 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces Lit's `repeat()` directive with `virtualize()` from `@lit-labs/virtualizer` in the chat thread, so only visible messages (plus a small buffer) are rendered in the DOM. This eliminates the previous 200-message hard cap and keeps rendering performance constant regardless of conversation length.

- **New dependency**: `@lit-labs/virtualizer@^2.1.1` added to `ui/package.json`; compatible with the existing `lit@^3.3.2`.
- **Render limit removed**: The `CHAT_HISTORY_RENDER_LIMIT = 200` constant and the "showing last N messages" system notice are deleted; virtualization handles unlimited messages efficiently.
- **Type fix**: A follow-up commit correctly changes the `renderItem` fallback from `nothing` to `` html`​` `` since `virtualize()` expects a `TemplateResult`, not Lit's `nothing` symbol.
- **Scroll concern**: `virtualize({scroller: true})` takes over scroll management of `.chat-thread`, while `app-scroll.ts` (`scheduleChatScroll`) independently manipulates `scrollTop`/`scrollHeight` on the same element. With variable-height messages (markdown, images, tool cards), the virtualizer's estimated scroll height shifts as items are measured, which could cause the auto-scroll-to-bottom behavior to be unreliable. Worth validating with conversations containing very different message heights.

<h3>Confidence Score: 3/5</h3>

- Likely safe for most cases, but the dual scroll management between the virtualizer and existing auto-scroll logic needs targeted manual testing with variable-height messages.
- The core change (repeat → virtualize) is a well-motivated performance improvement with a clean implementation (-11 lines net). The type compatibility fix is correct. However, the interaction between the virtualizer's internal scroll management and the existing app-scroll.ts scroll-to-bottom logic has not been verified to work reliably with variable-height chat items, and could cause scroll jank or missed auto-scroll in edge cases.
- Pay close attention to `ui/src/ui/views/chat.ts` — specifically the interaction between `virtualize({scroller: true})` and the scroll management in `ui/src/ui/app-scroll.ts`.

<sub>Last reviewed commit: 86328cc</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->