### PR TITLE
fix(chrome-relay): resilient reconnect, MV3 persistence, and navigation re-attach

### DIFF
--- a/assets/chrome-extension/background.js
+++ b/assets/chrome-extension/background.js
@@ -12,8 +12,6 @@ let relayWs = null
 /** @type {Promise<void>|null} */
 let relayConnectPromise = null
 
-let debuggerListenersInstalled = false
-
 let nextSession = 1
 
 /** @type {Map<number, {state:'connecting'|'connected', sessionId?:string, targetId?:string, attachOrder?:number}>} */
@@ -25,6 +23,15 @@ const childSessionToTab = new Map()
 
 /** @type {Map<number, {resolve:(v:any)=>void, reject:(e:Error)=>void}>} */
 const pending = new Map()
+
+// Per-tab operation locks prevent double-attach races.
+/** @type {Set<number>} */
+const tabOperationLocks = new Set()
+
+// Reconnect state for exponential backoff.
+let reconnectAttempt = 0
+let reconnectTimer = null
+const RECONNECT_MAX_DELAY = 30000
 
 function nowStack() {
   try {
@@ -47,6 +54,63 @@ function setBadge(tabId, kind) {
   void chrome.action.setBadgeText({ tabId, text: cfg.text })
   void chrome.action.setBadgeBackgroundColor({ tabId, color: cfg.color })
   void chrome.action.setBadgeTextColor({ tabId, color: '#FFFFFF' }).catch(() => {})
+}
+
+// Persist attached tab state to survive MV3 service worker restarts.
+async function persistState() {
+  try {
+    const tabEntries = []
+    for (const [tabId, tab] of tabs.entries()) {
+      if (tab.state === 'connected' && tab.sessionId && tab.targetId) {
+        tabEntries.push({ tabId, sessionId: tab.sessionId, targetId: tab.targetId, attachOrder: tab.attachOrder })
+      }
+    }
+    await chrome.storage.session.set({
+      persistedTabs: tabEntries,
+      nextSession,
+    })
+  } catch {
+    // chrome.storage.session may not be available in all contexts.
+  }
+}
+
+// Rehydrate tab state on service worker startup. Fast path — just restores
+// maps and badges. Relay reconnect happens separately in background.
+async function rehydrateState() {
+  try {
+    const stored = await chrome.storage.session.get(['persistedTabs', 'nextSession'])
+    if (stored.nextSession) {
+      nextSession = Math.max(nextSession, stored.nextSession)
+    }
+    const entries = stored.persistedTabs || []
+    // Phase 1: optimistically restore state and badges.
+    for (const entry of entries) {
+      tabs.set(entry.tabId, {
+        state: 'connected',
+        sessionId: entry.sessionId,
+        targetId: entry.targetId,
+        attachOrder: entry.attachOrder,
+      })
+      tabBySession.set(entry.sessionId, entry.tabId)
+      setBadge(entry.tabId, 'on')
+    }
+    // Phase 2: validate asynchronously, remove dead tabs.
+    for (const entry of entries) {
+      try {
+        await chrome.tabs.get(entry.tabId)
+        await chrome.debugger.sendCommand({ tabId: entry.tabId }, 'Runtime.evaluate', {
+          expression: '1',
+          returnByValue: true,
+        })
+      } catch {
+        tabs.delete(entry.tabId)
+        tabBySession.delete(entry.sessionId)
+        setBadge(entry.tabId, 'off')
+      }
+    }
+  } catch {
+    // Ignore rehydration errors.
+  }
 }
 
 async function ensureRelayConnection() {
@@ -84,42 +148,139 @@ async function ensureRelayConnection() {
       }
     })
 
-    ws.onmessage = (event) => void onRelayMessage(String(event.data || ''))
-    ws.onclose = () => onRelayClosed('closed')
-    ws.onerror = () => onRelayClosed('error')
-
-    if (!debuggerListenersInstalled) {
-      debuggerListenersInstalled = true
-      chrome.debugger.onEvent.addListener(onDebuggerEvent)
-      chrome.debugger.onDetach.addListener(onDebuggerDetach)
+    // Bind permanent handlers. Guard against stale socket: if this WS was
+    // replaced before its close fires, the handler is a no-op.
+    ws.onmessage = (event) => {
+      if (ws !== relayWs) return
+      void whenReady(() => onRelayMessage(String(event.data || '')))
+    }
+    ws.onclose = () => {
+      if (ws !== relayWs) return
+      onRelayClosed('closed')
+    }
+    ws.onerror = () => {
+      if (ws !== relayWs) return
+      onRelayClosed('error')
     }
   })()
 
   try {
     await relayConnectPromise
+    reconnectAttempt = 0
   } finally {
     relayConnectPromise = null
   }
 }
 
+// Relay closed — update badges, reject pending requests, auto-reconnect.
+// Debugger sessions are kept alive so they survive transient WS drops.
 function onRelayClosed(reason) {
   relayWs = null
+
   for (const [id, p] of pending.entries()) {
     pending.delete(id)
     p.reject(new Error(`Relay disconnected (${reason})`))
   }
 
-  for (const tabId of tabs.keys()) {
-    void chrome.debugger.detach({ tabId }).catch(() => {})
-    setBadge(tabId, 'connecting')
-    void chrome.action.setTitle({
-      tabId,
-      title: 'OpenClaw Browser Relay: disconnected (click to re-attach)',
-    })
+  for (const [tabId, tab] of tabs.entries()) {
+    if (tab.state === 'connected') {
+      setBadge(tabId, 'connecting')
+      void chrome.action.setTitle({
+        tabId,
+        title: 'OpenClaw Browser Relay: relay reconnecting…',
+      })
+    }
   }
-  tabs.clear()
-  tabBySession.clear()
-  childSessionToTab.clear()
+
+  scheduleReconnect()
+}
+
+function scheduleReconnect() {
+  if (reconnectTimer) {
+    clearTimeout(reconnectTimer)
+    reconnectTimer = null
+  }
+
+  const delay = Math.min(1000 * Math.pow(2, reconnectAttempt), RECONNECT_MAX_DELAY) + Math.random() * 1000
+  reconnectAttempt++
+
+  console.log(`Scheduling reconnect attempt ${reconnectAttempt} in ${Math.round(delay)}ms`)
+
+  reconnectTimer = setTimeout(async () => {
+    reconnectTimer = null
+    try {
+      await ensureRelayConnection()
+      reconnectAttempt = 0
+      console.log('Reconnected successfully')
+      await reannounceAttachedTabs()
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      console.warn(`Reconnect attempt ${reconnectAttempt} failed: ${message}`)
+      scheduleReconnect()
+    }
+  }, delay)
+}
+
+function cancelReconnect() {
+  if (reconnectTimer) {
+    clearTimeout(reconnectTimer)
+    reconnectTimer = null
+  }
+  reconnectAttempt = 0
+}
+
+// Re-announce all attached tabs to the relay after reconnect.
+async function reannounceAttachedTabs() {
+  for (const [tabId, tab] of tabs.entries()) {
+    if (tab.state !== 'connected' || !tab.sessionId || !tab.targetId) continue
+
+    // Verify debugger is still attached.
+    try {
+      await chrome.debugger.sendCommand({ tabId }, 'Runtime.evaluate', {
+        expression: '1',
+        returnByValue: true,
+      })
+    } catch {
+      tabs.delete(tabId)
+      if (tab.sessionId) tabBySession.delete(tab.sessionId)
+      setBadge(tabId, 'off')
+      void chrome.action.setTitle({
+        tabId,
+        title: 'OpenClaw Browser Relay (click to attach/detach)',
+      })
+      continue
+    }
+
+    // Send fresh attach event to relay.
+    try {
+      const info = /** @type {any} */ (
+        await chrome.debugger.sendCommand({ tabId }, 'Target.getTargetInfo')
+      )
+      const targetInfo = info?.targetInfo
+
+      sendToRelay({
+        method: 'forwardCDPEvent',
+        params: {
+          method: 'Target.attachedToTarget',
+          params: {
+            sessionId: tab.sessionId,
+            targetInfo: { ...targetInfo, attached: true },
+            waitingForDebugger: false,
+          },
+        },
+      })
+
+      setBadge(tabId, 'on')
+      void chrome.action.setTitle({
+        tabId,
+        title: 'OpenClaw Browser Relay: attached (click to detach)',
+      })
+    } catch {
+      setBadge(tabId, 'on')
+    }
+  }
+
+  await persistState()
 }
 
 function sendToRelay(payload) {
@@ -144,10 +305,18 @@ async function maybeOpenHelpOnce() {
 function requestFromRelay(command) {
   const id = command.id
   return new Promise((resolve, reject) => {
-    pending.set(id, { resolve, reject })
+    const timer = setTimeout(() => {
+      pending.delete(id)
+      reject(new Error('Relay request timeout (30s)'))
+    }, 30000)
+    pending.set(id, {
+      resolve: (v) => { clearTimeout(timer); resolve(v) },
+      reject: (e) => { clearTimeout(timer); reject(e) },
+    })
     try {
       sendToRelay(command)
     } catch (err) {
+      clearTimeout(timer)
       pending.delete(id)
       reject(err instanceof Error ? err : new Error(String(err)))
     }
@@ -218,8 +387,9 @@ async function attachTab(tabId, opts = {}) {
     throw new Error('Target.getTargetInfo returned no targetId')
   }
 
-  const sessionId = `cb-tab-${nextSession++}`
-  const attachOrder = nextSession
+  const sid = nextSession++
+  const sessionId = `cb-tab-${sid}`
+  const attachOrder = sid
 
   tabs.set(tabId, { state: 'connected', sessionId, targetId, attachOrder })
   tabBySession.set(sessionId, tabId)
@@ -243,11 +413,33 @@ async function attachTab(tabId, opts = {}) {
   }
 
   setBadge(tabId, 'on')
+  await persistState()
+
   return { sessionId, targetId }
 }
 
 async function detachTab(tabId, reason) {
   const tab = tabs.get(tabId)
+
+  // Send detach events for child sessions first.
+  for (const [childSessionId, parentTabId] of childSessionToTab.entries()) {
+    if (parentTabId === tabId) {
+      try {
+        sendToRelay({
+          method: 'forwardCDPEvent',
+          params: {
+            method: 'Target.detachedFromTarget',
+            params: { sessionId: childSessionId, reason: 'parent_detached' },
+          },
+        })
+      } catch {
+        // Relay may be down.
+      }
+      childSessionToTab.delete(childSessionId)
+    }
+  }
+
+  // Send detach event for main session.
   if (tab?.sessionId && tab?.targetId) {
     try {
       sendToRelay({
@@ -258,21 +450,17 @@ async function detachTab(tabId, reason) {
         },
       })
     } catch {
-      // ignore
+      // Relay may be down.
     }
   }
 
   if (tab?.sessionId) tabBySession.delete(tab.sessionId)
   tabs.delete(tabId)
 
-  for (const [childSessionId, parentTabId] of childSessionToTab.entries()) {
-    if (parentTabId === tabId) childSessionToTab.delete(childSessionId)
-  }
-
   try {
     await chrome.debugger.detach({ tabId })
   } catch {
-    // ignore
+    // May already be detached.
   }
 
   setBadge(tabId, 'off')
@@ -280,6 +468,8 @@ async function detachTab(tabId, reason) {
     tabId,
     title: 'OpenClaw Browser Relay (click to attach/detach)',
   })
+
+  await persistState()
 }
 
 async function connectOrToggleForActiveTab() {
@@ -287,33 +477,43 @@ async function connectOrToggleForActiveTab() {
   const tabId = active?.id
   if (!tabId) return
 
-  const existing = tabs.get(tabId)
-  if (existing?.state === 'connected') {
-    await detachTab(tabId, 'toggle')
-    return
-  }
-
-  tabs.set(tabId, { state: 'connecting' })
-  setBadge(tabId, 'connecting')
-  void chrome.action.setTitle({
-    tabId,
-    title: 'OpenClaw Browser Relay: connecting to local relay…',
-  })
+  // Prevent concurrent operations on the same tab.
+  if (tabOperationLocks.has(tabId)) return
+  tabOperationLocks.add(tabId)
 
   try {
-    await ensureRelayConnection()
-    await attachTab(tabId)
-  } catch (err) {
-    tabs.delete(tabId)
-    setBadge(tabId, 'error')
+    const existing = tabs.get(tabId)
+    if (existing?.state === 'connected') {
+      await detachTab(tabId, 'toggle')
+      return
+    }
+
+    // User is manually connecting — cancel any pending reconnect.
+    cancelReconnect()
+
+    tabs.set(tabId, { state: 'connecting' })
+    setBadge(tabId, 'connecting')
     void chrome.action.setTitle({
       tabId,
-      title: 'OpenClaw Browser Relay: relay not running (open options for setup)',
+      title: 'OpenClaw Browser Relay: connecting to local relay…',
     })
-    void maybeOpenHelpOnce()
-    // Extra breadcrumbs in chrome://extensions service worker logs.
-    const message = err instanceof Error ? err.message : String(err)
-    console.warn('attach failed', message, nowStack())
+
+    try {
+      await ensureRelayConnection()
+      await attachTab(tabId)
+    } catch (err) {
+      tabs.delete(tabId)
+      setBadge(tabId, 'error')
+      void chrome.action.setTitle({
+        tabId,
+        title: 'OpenClaw Browser Relay: relay not running (open options for setup)',
+      })
+      void maybeOpenHelpOnce()
+      const message = err instanceof Error ? err.message : String(err)
+      console.warn('attach failed', message, nowStack())
+    }
+  } finally {
+    tabOperationLocks.delete(tabId)
   }
 }
 
@@ -322,14 +522,12 @@ async function handleForwardCdpCommand(msg) {
   const params = msg?.params?.params || undefined
   const sessionId = typeof msg?.params?.sessionId === 'string' ? msg.params.sessionId : undefined
 
-  // Map command to tab
   const bySession = sessionId ? getTabBySessionId(sessionId) : null
   const targetId = typeof params?.targetId === 'string' ? params.targetId : undefined
   const tabId =
     bySession?.tabId ||
     (targetId ? getTabByTargetId(targetId) : null) ||
     (() => {
-      // No sessionId: pick the first connected tab (stable-ish).
       for (const [id, tab] of tabs.entries()) {
         if (tab.state === 'connected') return id
       }
@@ -419,20 +617,173 @@ function onDebuggerEvent(source, method, params) {
       },
     })
   } catch {
-    // ignore
+    // Relay may be down.
   }
 }
 
+// Navigation/reload fires target_closed but the tab is still alive — Chrome
+// just swaps the renderer process. Suppress the detach event to the relay and
+// seamlessly re-attach after a short grace period.
 function onDebuggerDetach(source, reason) {
   const tabId = source.tabId
   if (!tabId) return
   if (!tabs.has(tabId)) return
+
+  if (reason === 'target_closed') {
+    const oldState = tabs.get(tabId)
+    setBadge(tabId, 'connecting')
+    void chrome.action.setTitle({
+      tabId,
+      title: 'OpenClaw Browser Relay: re-attaching after navigation…',
+    })
+
+    setTimeout(async () => {
+      try {
+        // If user manually detached during the grace period, bail out.
+        if (!tabs.has(tabId)) return
+        const tab = await chrome.tabs.get(tabId)
+        if (tab && relayWs?.readyState === WebSocket.OPEN) {
+          console.log(`Re-attaching tab ${tabId} after navigation`)
+          if (oldState?.sessionId) tabBySession.delete(oldState.sessionId)
+          tabs.delete(tabId)
+          await attachTab(tabId, { skipAttachedEvent: false })
+        } else {
+          // Tab gone or relay down — full cleanup.
+          void detachTab(tabId, reason)
+        }
+      } catch (err) {
+        console.warn(`Failed to re-attach tab ${tabId} after navigation:`, err.message)
+        void detachTab(tabId, reason)
+      }
+    }, 500)
+    return
+  }
+
+  // Non-navigation detach (user action, crash, etc.) — full cleanup.
   void detachTab(tabId, reason)
 }
 
-chrome.action.onClicked.addListener(() => void connectOrToggleForActiveTab())
+// Tab lifecycle listeners — clean up stale entries.
+chrome.tabs.onRemoved.addListener((tabId) => void whenReady(() => {
+  if (!tabs.has(tabId)) return
+  const tab = tabs.get(tabId)
+  if (tab?.sessionId) tabBySession.delete(tab.sessionId)
+  tabs.delete(tabId)
+  for (const [childSessionId, parentTabId] of childSessionToTab.entries()) {
+    if (parentTabId === tabId) childSessionToTab.delete(childSessionId)
+  }
+  if (tab?.sessionId && tab?.targetId) {
+    try {
+      sendToRelay({
+        method: 'forwardCDPEvent',
+        params: {
+          method: 'Target.detachedFromTarget',
+          params: { sessionId: tab.sessionId, targetId: tab.targetId, reason: 'tab_closed' },
+        },
+      })
+    } catch {
+      // Relay may be down.
+    }
+  }
+  void persistState()
+}))
+
+chrome.tabs.onReplaced.addListener((addedTabId, removedTabId) => void whenReady(() => {
+  const tab = tabs.get(removedTabId)
+  if (!tab) return
+  tabs.delete(removedTabId)
+  tabs.set(addedTabId, tab)
+  if (tab.sessionId) {
+    tabBySession.set(tab.sessionId, addedTabId)
+  }
+  for (const [childSessionId, parentTabId] of childSessionToTab.entries()) {
+    if (parentTabId === removedTabId) {
+      childSessionToTab.set(childSessionId, addedTabId)
+    }
+  }
+  setBadge(addedTabId, 'on')
+  void persistState()
+}))
+
+// Register debugger listeners at module scope so detach/event handling works
+// even when the relay WebSocket is down.
+chrome.debugger.onEvent.addListener((...args) => void whenReady(() => onDebuggerEvent(...args)))
+chrome.debugger.onDetach.addListener((...args) => void whenReady(() => onDebuggerDetach(...args)))
+
+chrome.action.onClicked.addListener(() => void whenReady(() => connectOrToggleForActiveTab()))
+
+// Refresh badge after navigation completes — service worker may have restarted
+// during navigation, losing ephemeral badge state.
+chrome.webNavigation.onCompleted.addListener(({ tabId, frameId }) => void whenReady(() => {
+  if (frameId !== 0) return
+  const tab = tabs.get(tabId)
+  if (tab?.state === 'connected') {
+    setBadge(tabId, relayWs && relayWs.readyState === WebSocket.OPEN ? 'on' : 'connecting')
+  }
+}))
+
+// Refresh badge when user switches to an attached tab.
+chrome.tabs.onActivated.addListener(({ tabId }) => void whenReady(() => {
+  const tab = tabs.get(tabId)
+  if (tab?.state === 'connected') {
+    setBadge(tabId, relayWs && relayWs.readyState === WebSocket.OPEN ? 'on' : 'connecting')
+  }
+}))
 
 chrome.runtime.onInstalled.addListener(() => {
-  // Useful: first-time instructions.
   void chrome.runtime.openOptionsPage()
 })
+
+// MV3 keepalive via chrome.alarms — more reliable than setInterval across
+// service worker restarts. Checks relay health and refreshes badges.
+chrome.alarms.create('relay-keepalive', { periodInMinutes: 0.5 })
+
+chrome.alarms.onAlarm.addListener(async (alarm) => {
+  if (alarm.name !== 'relay-keepalive') return
+  await initPromise
+
+  if (tabs.size === 0) return
+
+  // Refresh badges (ephemeral in MV3).
+  for (const [tabId, tab] of tabs.entries()) {
+    if (tab.state === 'connected') {
+      setBadge(tabId, relayWs && relayWs.readyState === WebSocket.OPEN ? 'on' : 'connecting')
+    }
+  }
+
+  // If relay is down and no reconnect is in progress, trigger one.
+  if (!relayWs || relayWs.readyState !== WebSocket.OPEN) {
+    if (!relayConnectPromise && !reconnectTimer) {
+      console.log('Keepalive: WebSocket unhealthy, triggering reconnect')
+      await ensureRelayConnection().catch(() => {
+        // ensureRelayConnection may throw without triggering onRelayClosed
+        // (e.g. preflight fetch fails before WS is created), so ensure
+        // reconnect is always scheduled on failure.
+        if (!reconnectTimer) {
+          scheduleReconnect()
+        }
+      })
+    }
+  }
+})
+
+// Rehydrate state on service worker startup. Split: rehydration is the gate
+// (fast), relay reconnect runs in background (slow, non-blocking).
+const initPromise = rehydrateState()
+
+initPromise.then(() => {
+  if (tabs.size > 0) {
+    ensureRelayConnection().then(() => {
+      reconnectAttempt = 0
+      return reannounceAttachedTabs()
+    }).catch(() => {
+      scheduleReconnect()
+    })
+  }
+})
+
+// Shared gate: all state-dependent handlers await this before accessing maps.
+async function whenReady(fn) {
+  await initPromise
+  return fn()
+}

--- a/assets/chrome-extension/manifest.json
+++ b/assets/chrome-extension/manifest.json
@@ -9,7 +9,7 @@
     "48": "icons/icon48.png",
     "128": "icons/icon128.png"
   },
-  "permissions": ["debugger", "tabs", "activeTab", "storage"],
+  "permissions": ["debugger", "tabs", "activeTab", "storage", "alarms", "webNavigation"],
   "host_permissions": ["http://127.0.0.1/*", "http://localhost/*"],
   "background": { "service_worker": "background.js", "type": "module" },
   "action": {


### PR DESCRIPTION
The Chrome extension relay loses connection after page navigation, sleep/wake cycles, or MV3 service worker restarts and never recovers. Users must manually re-click the toolbar icon after every disconnect.

## Changes

- **Keep debugger sessions alive across WebSocket disconnects** — `onRelayClosed()` no longer detaches debuggers; sessions are preserved with reconnecting badge state
- **Auto-reconnect with exponential backoff and jitter** — unlimited retries (1s → 30s cap), re-announces attached tabs on reconnect
- **Persist state to `chrome.storage.session`** — tab/session state survives MV3 worker restarts; rehydrates on every worker boot via top-level init promise
- **Re-attach debugger after cross-origin navigation** — `target_closed` detach triggers auto re-attach with graduated retry delays; guards against stale session overwrites and restricted URLs
- **Per-tab operation locks** — prevents double-attach races on concurrent toggle/attach operations
- **`chrome.alarms` keepalive** — MV3-correct wake mechanism (`periodInMinutes: 0.5`) alongside existing `setInterval` ping (20s)
- **Safe server-side stale WebSocket replacement** — removes 409 rejection; serializes via promise chain; nulls `extensionWs` before closing old socket so close handler is a no-op; guards on `message`/`close` handlers
- **Child-session detach forwarding** — emits `Target.detachedFromTarget` for child sessions before cleanup
- **Tab lifecycle listeners** — `onRemoved`, `onReplaced` (with child session migration), `onCompleted`
- **Badge refresh** — on navigation complete and tab switch (handles worker restart losing badge state)
- **Pending request timeouts** — 30s timeout prevents memory leaks from dropped relay messages

## Permissions added

- `webNavigation` — badge refresh after navigation
- `alarms` — MV3 keepalive

## Testing

Tested on macOS with Brave (Chromium) across: cross-origin navigation (Amazon → Reddit → YouTube → FAA → Google), WebSocket disconnect/reconnect, service worker restart, manual detach/reattach cycles, and Chrome restart (stale WS replacement).

Reviewed by Codex 5.3 (GPT-5.3) — head-to-head comparison with #15817.

Closes #15099
Relates to #1160