### PR TITLE
fix: suppress NO_REPLY silent token in webchat TUI

### DIFF
--- a/src/tui/components/chat-log.ts
+++ b/src/tui/components/chat-log.ts
@@ -45,6 +45,15 @@ export class ChatLog extends Container {
     existing.setText(text);
   }
 
+  removeAssistant(runId?: string) {
+    const effectiveRunId = this.resolveRunId(runId);
+    const existing = this.streamingRuns.get(effectiveRunId);
+    if (existing) {
+      this.removeChild(existing);
+      this.streamingRuns.delete(effectiveRunId);
+    }
+  }
+
   finalizeAssistant(text: string, runId?: string) {
     const effectiveRunId = this.resolveRunId(runId);
     const existing = this.streamingRuns.get(effectiveRunId);

--- a/src/tui/tui-types.ts
+++ b/src/tui/tui-types.ts
@@ -16,6 +16,8 @@ export type ChatEvent = {
   state: "delta" | "final" | "aborted" | "error";
   message?: unknown;
   errorMessage?: string;
+  /** When true, the assistant reply was a silent token (NO_REPLY) and should not be displayed. */
+  silent?: boolean;
 };
 
 export type AgentEvent = {


### PR DESCRIPTION
## Summary

The webchat TUI renders raw model output without checking for the `NO_REPLY` silent reply token, causing it to appear as a visible assistant message.

## Changes

- **`src/tui/tui-event-handlers.ts`**: Added `isSilentReplyText` check in the finalize path. When the final text is a silent token, the streamed message bubble is removed instead of being finalized.
- **`src/tui/components/chat-log.ts`**: Added `removeAssistant()` method to clean up a streaming assistant message component.

## Testing

- Build passes (`npm run build`)
- Linter passes (0 warnings, 0 errors)

Fixes #3340

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixes webchat TUI rendering `NO_REPLY` silent token as visible message. When the final text is a silent reply token, the streamed message bubble is now removed instead of finalized.

- Added `removeAssistant()` method to `ChatLog` to clean up streaming assistant message components
- Added `isSilentReplyText()` check in the finalize path of `tui-event-handlers.ts`
- Test mock type needs updating to include `removeAssistant` method

<h3>Confidence Score: 4/5</h3>

- Safe to merge after fixing the test mock type to prevent potential test failures
- The implementation correctly addresses the issue of silent tokens appearing in the TUI. The logic follows existing patterns used throughout the codebase for handling `isSilentReplyText()`. The new `removeAssistant()` method is simple and mirrors the structure of `finalizeAssistant()`. However, the test mock type is missing the new `removeAssistant` method which could cause tests to fail.
- src/tui/tui-event-handlers.test.ts needs the mock type updated to include `removeAssistant`

<sub>Last reviewed commit: 210a38a</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->