### PR TITLE
fix(security): use 0o600 permissions for session transcript files

### DIFF
--- a/src/agents/pi-embedded-helpers/bootstrap.ts
+++ b/src/agents/pi-embedded-helpers/bootstrap.ts
@@ -156,7 +156,7 @@ export async function ensureSessionHeader(params: {
     timestamp: new Date().toISOString(),
     cwd: params.cwd,
   };
-  await fs.writeFile(file, `${JSON.stringify(entry)}\n`, "utf-8");
+  await fs.writeFile(file, `${JSON.stringify(entry)}\n`, { encoding: "utf-8", mode: 0o600 });
 }
 
 export function buildBootstrapContextFiles(

--- a/src/agents/pi-embedded-runner/session-manager-init.ts
+++ b/src/agents/pi-embedded-runner/session-manager-init.ts
@@ -43,7 +43,7 @@ export async function prepareSessionManagerForRun(params: {
 
   if (params.hadSessionFile && header && !hasAssistant) {
     // Reset file so the first assistant flush includes header+user+assistant in order.
-    await fs.writeFile(params.sessionFile, "", "utf-8");
+    await fs.writeFile(params.sessionFile, "", { encoding: "utf-8", mode: 0o600 });
     sm.fileEntries = [header];
     sm.byId?.clear?.();
     sm.labelsById?.clear?.();

--- a/src/agents/session-file-repair.ts
+++ b/src/agents/session-file-repair.ts
@@ -73,15 +73,8 @@ export async function repairSessionFileIfNeeded(params: {
   const backupPath = `${sessionFile}.bak-${process.pid}-${Date.now()}`;
   const tmpPath = `${sessionFile}.repair-${process.pid}-${Date.now()}.tmp`;
   try {
-    const stat = await fs.stat(sessionFile).catch(() => null);
-    await fs.writeFile(backupPath, content, "utf-8");
-    if (stat) {
-      await fs.chmod(backupPath, stat.mode);
-    }
-    await fs.writeFile(tmpPath, cleaned, "utf-8");
-    if (stat) {
-      await fs.chmod(tmpPath, stat.mode);
-    }
+    await fs.writeFile(backupPath, content, { encoding: "utf-8", mode: 0o600 });
+    await fs.writeFile(tmpPath, cleaned, { encoding: "utf-8", mode: 0o600 });
     await fs.rename(tmpPath, sessionFile);
   } catch (err) {
     try {

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -89,7 +89,10 @@ function forkSessionFromParent(params: {
       cwd: manager.getCwd(),
       parentSession: parentSessionFile,
     };
-    fs.writeFileSync(sessionFile, `${JSON.stringify(header)}\n`, "utf-8");
+    fs.writeFileSync(sessionFile, `${JSON.stringify(header)}\n`, {
+      encoding: "utf-8",
+      mode: 0o600,
+    });
     return { sessionId, sessionFile };
   } catch {
     return null;

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -72,7 +72,10 @@ async function ensureSessionHeader(params: {
     timestamp: new Date().toISOString(),
     cwd: process.cwd(),
   };
-  await fs.promises.writeFile(params.sessionFile, `${JSON.stringify(header)}\n`, "utf-8");
+  await fs.promises.writeFile(params.sessionFile, `${JSON.stringify(header)}\n`, {
+    encoding: "utf-8",
+    mode: 0o600,
+  });
 }
 
 export async function appendAssistantMessageToSessionTranscript(params: {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -86,7 +86,10 @@ function ensureTranscriptFile(params: { transcriptPath: string; sessionId: strin
       timestamp: new Date().toISOString(),
       cwd: process.cwd(),
     };
-    fs.writeFileSync(params.transcriptPath, `${JSON.stringify(header)}\n`, "utf-8");
+    fs.writeFileSync(params.transcriptPath, `${JSON.stringify(header)}\n`, {
+      encoding: "utf-8",
+      mode: 0o600,
+    });
     return { ok: true };
   } catch (err) {
     return { ok: false, error: err instanceof Error ? err.message : String(err) };

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -487,7 +487,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
 
     const archived = archiveFileOnDisk(filePath, "bak");
     const keptLines = lines.slice(-maxLines);
-    fs.writeFileSync(filePath, `${keptLines.join("\n")}\n`, "utf-8");
+    fs.writeFileSync(filePath, `${keptLines.join("\n")}\n`, { encoding: "utf-8", mode: 0o600 });
 
     await updateSessionStore(storePath, (store) => {
       const entryKey = compactTarget.primaryKey;


### PR DESCRIPTION
Session transcript .jsonl files contain full conversation history including user messages, tool call arguments, and model responses. Previously created with default 0o644 (world-readable) permissions.

Restrict all session file write paths to 0o600 (owner-only), matching the permission model already used by saveJsonFile() for credential and config files (CWE-732).

Write paths fixed:
- config/sessions/transcript.ts (ensureSessionHeader)
- agents/pi-embedded-helpers/bootstrap.ts (ensureSessionHeader)
- agents/pi-embedded-runner/session-manager-init.ts (reset path)
- auto-reply/reply/session.ts (forkSessionFromParent)
- gateway/server-methods/chat.ts (ensureTranscriptFile)
- gateway/server-methods/sessions.ts (manual compaction)
- agents/session-file-repair.ts (backup + repair writes)

Closes #8751

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Restricts session transcript `.jsonl` files to owner-only permissions (0o600) to address CWE-732. Previously these files containing full conversation history, tool arguments, and model responses were created with default world-readable 0o644 permissions.

The PR systematically updates all 7 identified session file write paths by converting from string-only encoding to options objects with `{ encoding: "utf-8", mode: 0o600 }`. All changes follow the same secure pattern already used by `saveJsonFile()` for credentials and config files (src/infra/json-file.ts:22).

**Locations fixed:**
- Session header initialization (3 locations: config/sessions/transcript.ts, agents/pi-embedded-helpers/bootstrap.ts, gateway/server-methods/chat.ts)
- Session reset/fork paths (2 locations: agents/pi-embedded-runner/session-manager-init.ts, auto-reply/reply/session.ts) 
- Session repair/compaction (2 locations: agents/session-file-repair.ts for backup+repair writes, gateway/server-methods/sessions.ts for manual compaction)

**Issue found:**
- Missing mode parameter on Windows code path in `src/config/sessions/store.ts:528` for `sessions.json` metadata file

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one missed write path on Windows that should be fixed
- The PR correctly implements 0o600 permissions across all 7 identified session transcript write paths using a consistent pattern. However, one related write path in `src/config/sessions/store.ts:528` (Windows code path for `sessions.json` metadata) is missing the mode parameter and should be included for complete coverage. The non-Windows paths in the same file already use 0o600 correctly.
- Pay attention to `src/config/sessions/store.ts` - the Windows code path needs the same permission fix

<sub>Last reviewed commit: a3ffcdf</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->