### PR TITLE
fix: add model configuration step to onboard command

### DIFF
--- a/src/cli/program/register.onboard.ts
+++ b/src/cli/program/register.onboard.ts
@@ -65,6 +65,10 @@ export function registerOnboardCommand(program: Command) {
     .option("--mode <mode>", "Wizard mode: local|remote")
     .option("--auth-choice <choice>", `Auth: ${AUTH_CHOICE_HELP}`)
     .option(
+      "--model <model>",
+      "Default model (non-interactive; e.g., anthropic/claude-3-5-sonnet-20241022)",
+    )
+    .option(
       "--token-provider <id>",
       "Token provider id (non-interactive; used with --auth-choice token)",
     )
@@ -124,6 +128,7 @@ export function registerOnboardCommand(program: Command) {
           acceptRisk: Boolean(opts.acceptRisk),
           flow: opts.flow as "quickstart" | "advanced" | "manual" | undefined,
           mode: opts.mode as "local" | "remote" | undefined,
+          model: opts.model as string | undefined,
           authChoice: opts.authChoice as AuthChoice | undefined,
           tokenProvider: opts.tokenProvider as string | undefined,
           token: opts.token as string | undefined,

--- a/src/commands/onboard-non-interactive/local.ts
+++ b/src/commands/onboard-non-interactive/local.ts
@@ -6,6 +6,7 @@ import { resolveGatewayPort, writeConfigFile } from "../../config/config.js";
 import { logConfigUpdated } from "../../config/logging.js";
 import { DEFAULT_GATEWAY_DAEMON_RUNTIME } from "../daemon-runtime.js";
 import { healthCommand } from "../health.js";
+import { applyPrimaryModel } from "../model-picker.js";
 import {
   applyWizardMetadata,
   DEFAULT_WORKSPACE,
@@ -75,6 +76,12 @@ export async function runNonInteractiveOnboardingLocal(params: {
   }
   nextConfig = nextConfigAfterAuth;
 
+  // Apply model configuration if provided
+  const modelRaw = opts.model?.trim();
+  if (modelRaw) {
+    nextConfig = applyPrimaryModel(nextConfig, modelRaw);
+  }
+
   const gatewayBasePort = resolveGatewayPort(baseConfig);
   const gatewayResult = applyNonInteractiveGatewayConfig({
     nextConfig,
@@ -127,6 +134,7 @@ export async function runNonInteractiveOnboardingLocal(params: {
     mode,
     workspaceDir,
     authChoice,
+    model: modelRaw,
     gateway: {
       port: gatewayResult.port,
       bind: gatewayResult.bind,

--- a/src/commands/onboard-non-interactive/local/output.ts
+++ b/src/commands/onboard-non-interactive/local/output.ts
@@ -7,6 +7,7 @@ export function logNonInteractiveOnboardingJson(params: {
   mode: "local" | "remote";
   workspaceDir?: string;
   authChoice?: string;
+  model?: string;
   gateway?: {
     port: number;
     bind: string;
@@ -27,6 +28,7 @@ export function logNonInteractiveOnboardingJson(params: {
         mode: params.mode,
         workspace: params.workspaceDir,
         authChoice: params.authChoice,
+        model: params.model,
         gateway: params.gateway,
         installDaemon: Boolean(params.installDaemon),
         daemonRuntime: params.daemonRuntime,

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -89,6 +89,8 @@ export type OnboardOptions = {
   /** Required for non-interactive onboarding; skips the interactive risk prompt when true. */
   acceptRisk?: boolean;
   reset?: boolean;
+  /** Default model for non-interactive onboarding (e.g., "anthropic/claude-3-5-sonnet-20241022"). */
+  model?: string;
   authChoice?: AuthChoice;
   /** Used when `authChoice=token` in non-interactive mode. */
   tokenProvider?: string;


### PR DESCRIPTION
## Summary

This PR adds a `--model` CLI option to the non-interactive onboarding flow, allowing users to configure the default model during `openclaw onboard --non-interactive --install-daemon`. Previously, model configuration was only available in the interactive onboarding wizard, which caused confusion for users running non-interactive onboarding.

## Changes

- Added `model?: string` option to `OnboardOptions` type in `onboard-types.ts`
- Added `--model <model>` CLI option in `register.onboard.ts` (e.g., `--model anthropic/claude-3-5-sonnet-20241022`)
- Added model configuration step in `runNonInteractiveOnboardingLocal()` that applies the model using `applyPrimaryModel()`
- Added model to JSON output in `logNonInteractiveOnboardingJson()` for non-interactive mode

## Testing

- Lint passes with 0 errors
- Existing onboard-helpers e2e tests pass

## Usage Example

```bash
openclaw onboard --non-interactive --accept-risk --install-daemon \
  --auth-choice openai-api-key --openai-api-key sk-xxx \
  --model openai/gpt-4.1
```

Fixes openclaw/openclaw#16013

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `--model` CLI option support to non-interactive onboarding, allowing users to configure the default model when running `openclaw onboard --non-interactive`. The implementation reuses the existing `applyPrimaryModel` function from the interactive wizard, properly trims input, and includes the model in JSON output.

- Added `--model <model>` CLI option in `register.onboard.ts` with example usage
- Extended `OnboardOptions` type to include optional `model` field
- Applied model configuration in `runNonInteractiveOnboardingLocal` after auth setup
- Included model in JSON output for programmatic consumption

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation follows established patterns, reuses existing tested utilities (`applyPrimaryModel`), properly handles edge cases (trimming, optional values), and maintains consistency with the interactive onboarding flow. The changes are minimal, focused, and the PR description indicates existing tests pass.
- No files require special attention

<sub>Last reviewed commit: 593fc22</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->