### PR TITLE
fix(security): use 0o600 permissions for session transcript files

### DIFF
--- a/src/agents/pi-embedded-helpers/bootstrap.ts
+++ b/src/agents/pi-embedded-helpers/bootstrap.ts
@@ -156,7 +156,7 @@ export async function ensureSessionHeader(params: {
     timestamp: new Date().toISOString(),
     cwd: params.cwd,
   };
-  await fs.writeFile(file, `${JSON.stringify(entry)}\n`, "utf-8");
+  await fs.writeFile(file, `${JSON.stringify(entry)}\n`, { encoding: "utf-8", mode: 0o600 });
 }
 
 export function buildBootstrapContextFiles(

--- a/src/agents/pi-embedded-runner/session-manager-init.ts
+++ b/src/agents/pi-embedded-runner/session-manager-init.ts
@@ -43,7 +43,7 @@ export async function prepareSessionManagerForRun(params: {
 
   if (params.hadSessionFile && header && !hasAssistant) {
     // Reset file so the first assistant flush includes header+user+assistant in order.
-    await fs.writeFile(params.sessionFile, "", "utf-8");
+    await fs.writeFile(params.sessionFile, "", { encoding: "utf-8", mode: 0o600 });
     sm.fileEntries = [header];
     sm.byId?.clear?.();
     sm.labelsById?.clear?.();

--- a/src/agents/session-file-repair.ts
+++ b/src/agents/session-file-repair.ts
@@ -73,15 +73,8 @@ export async function repairSessionFileIfNeeded(params: {
   const backupPath = `${sessionFile}.bak-${process.pid}-${Date.now()}`;
   const tmpPath = `${sessionFile}.repair-${process.pid}-${Date.now()}.tmp`;
   try {
-    const stat = await fs.stat(sessionFile).catch(() => null);
-    await fs.writeFile(backupPath, content, "utf-8");
-    if (stat) {
-      await fs.chmod(backupPath, stat.mode);
-    }
-    await fs.writeFile(tmpPath, cleaned, "utf-8");
-    if (stat) {
-      await fs.chmod(tmpPath, stat.mode);
-    }
+    await fs.writeFile(backupPath, content, { encoding: "utf-8", mode: 0o600 });
+    await fs.writeFile(tmpPath, cleaned, { encoding: "utf-8", mode: 0o600 });
     await fs.rename(tmpPath, sessionFile);
   } catch (err) {
     try {

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -89,7 +89,10 @@ function forkSessionFromParent(params: {
       cwd: manager.getCwd(),
       parentSession: parentSessionFile,
     };
-    fs.writeFileSync(sessionFile, `${JSON.stringify(header)}\n`, "utf-8");
+    fs.writeFileSync(sessionFile, `${JSON.stringify(header)}\n`, {
+      encoding: "utf-8",
+      mode: 0o600,
+    });
     return { sessionId, sessionFile };
   } catch {
     return null;

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -525,7 +525,7 @@ async function saveSessionStoreUnlocked(
   // We serialize writers via the session-store lock instead.
   if (process.platform === "win32") {
     try {
-      await fs.promises.writeFile(storePath, json, "utf-8");
+      await fs.promises.writeFile(storePath, json, { encoding: "utf-8", mode: 0o600 });
     } catch (err) {
       const code =
         err && typeof err === "object" && "code" in err

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -72,7 +72,10 @@ async function ensureSessionHeader(params: {
     timestamp: new Date().toISOString(),
     cwd: process.cwd(),
   };
-  await fs.promises.writeFile(params.sessionFile, `${JSON.stringify(header)}\n`, "utf-8");
+  await fs.promises.writeFile(params.sessionFile, `${JSON.stringify(header)}\n`, {
+    encoding: "utf-8",
+    mode: 0o600,
+  });
 }
 
 export async function appendAssistantMessageToSessionTranscript(params: {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -86,7 +86,10 @@ function ensureTranscriptFile(params: { transcriptPath: string; sessionId: strin
       timestamp: new Date().toISOString(),
       cwd: process.cwd(),
     };
-    fs.writeFileSync(params.transcriptPath, `${JSON.stringify(header)}\n`, "utf-8");
+    fs.writeFileSync(params.transcriptPath, `${JSON.stringify(header)}\n`, {
+      encoding: "utf-8",
+      mode: 0o600,
+    });
     return { ok: true };
   } catch (err) {
     return { ok: false, error: err instanceof Error ? err.message : String(err) };

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -487,7 +487,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
 
     const archived = archiveFileOnDisk(filePath, "bak");
     const keptLines = lines.slice(-maxLines);
-    fs.writeFileSync(filePath, `${keptLines.join("\n")}\n`, "utf-8");
+    fs.writeFileSync(filePath, `${keptLines.join("\n")}\n`, { encoding: "utf-8", mode: 0o600 });
 
     await updateSessionStore(storePath, (store) => {
       const entryKey = compactTarget.primaryKey;


### PR DESCRIPTION
Session transcript .jsonl files contain full conversation history including user messages, tool call arguments, and model responses. Previously created with default 0o644 (world-readable) permissions.

Restrict all session file write paths to 0o600 (owner-only), matching the permission model already used by saveJsonFile() for credential and config files (CWE-732).

Write paths fixed:
- config/sessions/transcript.ts (ensureSessionHeader)
- agents/pi-embedded-helpers/bootstrap.ts (ensureSessionHeader)
- agents/pi-embedded-runner/session-manager-init.ts (reset path)
- auto-reply/reply/session.ts (forkSessionFromParent)
- gateway/server-methods/chat.ts (ensureTranscriptFile)
- gateway/server-methods/sessions.ts (manual compaction)
- agents/session-file-repair.ts (backup + repair writes)

Closes #8751

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Restricts file permissions on session transcript .jsonl files from world-readable (0o644 default) to owner-only (0o600), addressing CWE-732. Session transcripts contain sensitive data including full conversation history, user messages, tool call arguments, and model responses.

The fix systematically updates all write paths that create or reset session transcript files:
- Initial header writes in `ensureSessionHeader()` functions across multiple modules
- Session file resets during session manager initialization
- Session forking in auto-reply
- Backup and repair operations in session-file-repair
- Manual compaction in gateway sessions handler
- Windows-specific write path in session store

The approach matches the existing permission model used by `saveJsonFile()` (src/infra/json-file.ts:22) for credentials and config files. All changes use the consistent pattern of passing `{ encoding: "utf-8", mode: 0o600 }` to `writeFile/writeFileSync` calls.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - it's a focused security fix with no logic changes
- The changes are straightforward permission restrictions on sensitive files with no behavioral changes. All modifications follow the same pattern consistently across 8 files, matching the existing security model used elsewhere in the codebase. The fix is surgical - only affecting initial file creation/reset operations - and doesn't alter any business logic or data flow.
- No files require special attention

<sub>Last reviewed commit: 50b22e0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->