### PR TITLE
fix(canvas): resolve A2UI assets from dist + retry resolution

### DIFF
--- a/src/canvas-host/a2ui.test.ts
+++ b/src/canvas-host/a2ui.test.ts
@@ -1,0 +1,83 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  createA2uiRootRealResolver,
+  getA2uiRootCandidates,
+  resolveA2uiRootFromCandidates,
+} from "./a2ui.js";
+
+describe("a2ui asset resolution", () => {
+  it("includes dist/canvas-host/a2ui candidates when running from bundled dist entrypoint", async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-a2ui-"));
+    try {
+      const distDir = path.join(tmp, "dist");
+      const candidates = getA2uiRootCandidates({
+        moduleDir: distDir,
+        cwd: tmp,
+        execPath: process.execPath,
+      });
+
+      expect(candidates).toContain(path.join(distDir, "canvas-host", "a2ui"));
+    } finally {
+      await fs.rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("picks the first candidate with both index.html and a2ui.bundle.js", async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-a2ui-"));
+    try {
+      const missing = path.join(tmp, "missing");
+      const present = path.join(tmp, "present");
+      await fs.mkdir(present, { recursive: true });
+      await fs.writeFile(path.join(present, "index.html"), "<html></html>");
+      await fs.writeFile(path.join(present, "a2ui.bundle.js"), "// bundle");
+
+      await expect(resolveA2uiRootFromCandidates([missing, present])).resolves.toBe(present);
+    } finally {
+      await fs.rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("does not permanently cache null roots (retries on the next call)", async () => {
+    let calls = 0;
+    const resolver = createA2uiRootRealResolver({
+      resolveRoot: async () => {
+        calls += 1;
+        return calls === 1 ? null : "/tmp/a2ui";
+      },
+      realpath: async (p) => p,
+    });
+
+    await expect(resolver()).resolves.toBeNull();
+    await expect(resolver()).resolves.toBe("/tmp/a2ui");
+    expect(calls).toBe(2);
+  });
+
+  it("dedupes inflight resolution work", async () => {
+    let calls = 0;
+    let finish: ((value: string | null) => void) | null = null;
+    const pending = new Promise<string | null>((resolve) => {
+      finish = resolve;
+    });
+
+    const resolver = createA2uiRootRealResolver({
+      resolveRoot: async () => {
+        calls += 1;
+        return pending;
+      },
+      realpath: async (p) => p,
+    });
+
+    const p1 = resolver();
+    const p2 = resolver();
+
+    // Note: resolver() is async, so each call returns a distinct Promise object,
+    // but it should still dedupe the underlying resolution work.
+    expect(calls).toBe(1);
+
+    finish?.("/tmp/a2ui");
+    await expect(Promise.all([p1, p2])).resolves.toEqual(["/tmp/a2ui", "/tmp/a2ui"]);
+  });
+});


### PR DESCRIPTION
Fixes #10497.

## Problem
Some packaged/bundled entrypoint layouts can serve Canvas but A2UI requests return **503** with `A2UI assets not found` even though the bundle exists.

Additionally, if A2UI resolution fails once during startup (transient fs/race), the current implementation can cache `null` for the lifetime of the process (no retry).

## Changes
- Improve A2UI asset root candidate resolution to handle bundled dist entrypoints (e.g. `dist/canvas-host/a2ui`).
- Avoid permanently caching a `null` A2UI root so the next request can recover after transient failures.
- Add unit tests for candidate selection + retry behavior.

## Verification
- `npx pnpm install --frozen-lockfile`
- `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u http_proxy -u https_proxy -u all_proxy npx vitest run --config vitest.unit.config.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Refactors A2UI asset resolution to fix 503 errors in bundled/packaged layouts by adding `dist/canvas-host/a2ui` candidates and prevents permanently caching null results so transient filesystem failures can recover on retry. Extracts resolution logic into testable pure functions (`getA2uiRootCandidates`, `resolveA2uiRootFromCandidates`, `createA2uiRootRealResolver`) and adds unit tests validating candidate selection, null-retry behavior, and inflight deduplication.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The refactoring extracts resolution logic into well-tested pure functions, adds comprehensive unit tests covering the key scenarios (bundled dist paths, null retry, inflight deduplication), and maintains backward compatibility with all existing candidate paths while fixing the reported 503 errors
- No files require special attention

<sub>Last reviewed commit: 14829d5</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->