### PR TITLE
fix(sandbox): align fs-bridge and fs-paths write checks with tool-gating logic

### DIFF
--- a/src/agents/sandbox/fs-bridge.test.ts
+++ b/src/agents/sandbox/fs-bridge.test.ts
@@ -107,6 +107,24 @@ describe("sandbox fs bridge shell compatibility", () => {
     expect(args.at(-1)).toBe("/workspace-two/README.md");
   });
 
+  it("allows writes when workspaceAccess is none", async () => {
+    const sandbox = createSandbox({
+      workspaceAccess: "none",
+      workspaceDir: "/tmp/sandbox-workspace",
+      agentWorkspaceDir: "/tmp/agent-workspace",
+    });
+    const bridge = createSandboxFsBridge({ sandbox });
+
+    await bridge.writeFile({
+      filePath: "/workspace/src/data/content.ts",
+      data: "export default {}",
+    });
+
+    expect(mockedExecDockerRaw).toHaveBeenCalled();
+    const lastArgs = mockedExecDockerRaw.mock.calls.at(-1)?.[0] ?? [];
+    expect(lastArgs.at(-1)).toBe("/workspace/src/data/content.ts");
+  });
+
   it("blocks writes into read-only bind mounts", async () => {
     const sandbox = createSandbox({
       docker: {

--- a/src/agents/sandbox/fs-bridge.ts
+++ b/src/agents/sandbox/fs-bridge.ts
@@ -229,7 +229,7 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
 }
 
 function allowsWrites(access: SandboxWorkspaceAccess): boolean {
-  return access === "rw";
+  return access !== "ro";
 }
 
 function coerceStatType(typeRaw?: string): "file" | "directory" | "other" {

--- a/src/agents/sandbox/fs-paths.test.ts
+++ b/src/agents/sandbox/fs-paths.test.ts
@@ -95,6 +95,36 @@ describe("resolveSandboxFsPathWithMounts", () => {
     expect(resolved.writable).toBe(true);
   });
 
+  it("marks workspace writable when workspaceAccess is none", () => {
+    const sandbox = createSandbox({
+      workspaceAccess: "none",
+      workspaceDir: "/tmp/sandbox-workspace",
+      agentWorkspaceDir: "/tmp/agent-workspace",
+    });
+    const mounts = buildSandboxFsMounts(sandbox);
+    const resolved = resolveSandboxFsPathWithMounts({
+      filePath: "src/data/content.ts",
+      cwd: sandbox.workspaceDir,
+      defaultWorkspaceRoot: sandbox.workspaceDir,
+      defaultContainerRoot: sandbox.containerWorkdir,
+      mounts,
+    });
+    expect(resolved.writable).toBe(true);
+  });
+
+  it("marks workspace read-only when workspaceAccess is ro", () => {
+    const sandbox = createSandbox({ workspaceAccess: "ro" });
+    const mounts = buildSandboxFsMounts(sandbox);
+    const resolved = resolveSandboxFsPathWithMounts({
+      filePath: "src/index.ts",
+      cwd: sandbox.workspaceDir,
+      defaultWorkspaceRoot: sandbox.workspaceDir,
+      defaultContainerRoot: sandbox.containerWorkdir,
+      mounts,
+    });
+    expect(resolved.writable).toBe(false);
+  });
+
   it("preserves legacy sandbox-root error for outside paths", () => {
     const sandbox = createSandbox();
     const mounts = buildSandboxFsMounts(sandbox);

--- a/src/agents/sandbox/fs-paths.ts
+++ b/src/agents/sandbox/fs-paths.ts
@@ -57,7 +57,7 @@ export function buildSandboxFsMounts(sandbox: SandboxContext): SandboxFsMount[] 
     {
       hostRoot: path.resolve(sandbox.workspaceDir),
       containerRoot: normalizeContainerPath(sandbox.containerWorkdir),
-      writable: sandbox.workspaceAccess === "rw",
+      writable: sandbox.workspaceAccess !== "ro",
       source: "workspace",
     },
   ];


### PR DESCRIPTION
## Summary

PR #4026 (merged in 2026.2.13) introduced `SandboxFsBridge` which routes file ops through docker exec.

Two places used `workspaceAccess === "rw"` to determine writability, which incorrectly blocked writes when `workspaceAccess` is `"none"`. The tool-gating logic in `pi-tools.ts:242` uses `!== "ro"`, so `"none"` should permit writes.

**Fixes:**
- `fs-bridge.ts` — `allowsWrites()` used `=== "rw"` → changed to `!== "ro"`
- `fs-paths.ts` — `buildSandboxFsMounts()` workspace mount `writable` flag used `=== "rw"` → changed to `!== "ro"`

Line 72 (agent mount) intentionally keeps `=== "rw"` since the agent workspace is excluded entirely when access is `"none"`.

## Test plan

- [x] fs-bridge: added test "allows writes when workspaceAccess is none"
- [x] fs-paths: added tests "marks workspace writable when workspaceAccess is none" and "marks workspace read-only when workspaceAccess is ro"
- [x] `"none"` allows writes, `"ro"` blocks, `"rw"` allows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed workspace write access checks to align with tool-gating logic. Changed two functions from using `workspaceAccess === "rw"` to `workspaceAccess !== "ro"`, so that `"none"` access mode now correctly permits writes instead of blocking them.

Changes:
- `fs-bridge.ts:232` — `allowsWrites()` helper now uses `!== "ro"` 
- `fs-paths.ts:60` — workspace mount `writable` flag now uses `!== "ro"`
- Line 72 (agent mount) intentionally kept as `=== "rw"` since that block is excluded when access is `"none"`
- Added test coverage for `"none"` allowing writes and `"ro"` blocking writes

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix correctly aligns workspace access checks with the tool-gating logic in `pi-tools.ts:254`. The changes are minimal, targeted, and well-tested. Line 72 is intentionally preserved as `=== "rw"` since the agent workspace mount is excluded entirely when access is `"none"` (guarded by line 66). All three access modes now behave correctly: `"none"` allows writes, `"ro"` blocks writes, `"rw"` allows writes.
- No files require special attention

<sub>Last reviewed commit: ff47dbc</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->