### PR TITLE
fix(memory/qmd): default searchMode=search + always scope search/vsearch to collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 - Telegram: cap bot menu registration to Telegram's 100-command limit with an overflow warning while keeping typed hidden commands available. (#15844) Thanks @battman21.
 - Telegram: scope skill commands to the resolved agent for default accounts so `setMyCommands` no longer triggers `BOT_COMMANDS_TOO_MUCH` when multiple agents are configured. (#15599)
 - Discord: avoid misrouting numeric guild allowlist entries to `/channels/<guildId>` by prefixing guild-only inputs with `guild:` during resolution. (#12326) Thanks @headswim.
+- Memory/QMD: default `memory.qmd.searchMode` to `search` for faster CPU-only recall and always scope `search`/`vsearch` requests to managed collections (auto-falling back to `query` when required). (#16047) Thanks @togotago.
 - MS Teams: preserve parsed mention entities/text when appending OneDrive fallback file links, and accept broader real-world Teams mention ID formats (`29:...`, `8:orgid:...`) while still rejecting placeholder patterns. (#15436) Thanks @hyojin.
 - Media: classify `text/*` MIME types as documents in media-kind routing so text attachments are no longer treated as unknown. (#12237) Thanks @arosstale.
 - Inbound/Web UI: preserve literal `\n` sequences when normalizing inbound text so Windows paths like `C:\\Work\\nxxx\\README.md` are not corrupted. (#11547) Thanks @mcaxtr.

--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -139,8 +139,8 @@ out to QMD for retrieval. Key points:
 - Boot refresh now runs in the background by default so chat startup is not
   blocked; set `memory.qmd.update.waitForBootSync = true` to keep the previous
   blocking behavior.
-- Searches run via `memory.qmd.searchMode` (default `qmd query --json`; also
-  supports `search` and `vsearch`). If the selected mode rejects flags on your
+- Searches run via `memory.qmd.searchMode` (default `qmd search --json`; also
+  supports `vsearch` and `query`). If the selected mode rejects flags on your
   QMD build, OpenClaw retries with `qmd query`. If QMD fails or the binary is
   missing, OpenClaw automatically falls back to the builtin SQLite manager so
   memory tools keep working.
@@ -178,8 +178,8 @@ out to QMD for retrieval. Key points:
 **Config surface (`memory.qmd.*`)**
 
 - `command` (default `qmd`): override the executable path.
-- `searchMode` (default `query`): pick which QMD command backs
-  `memory_search` (`query`, `search`, `vsearch`).
+- `searchMode` (default `search`): pick which QMD command backs
+  `memory_search` (`search`, `vsearch`, `query`).
 - `includeDefaultMemory` (default `true`): auto-index `MEMORY.md` + `memory/**/*.md`.
 - `paths[]`: add extra directories/files (`path`, optional `pattern`, optional
   stable `name`).

--- a/src/memory/backend-config.test.ts
+++ b/src/memory/backend-config.test.ts
@@ -25,7 +25,7 @@ describe("resolveMemoryBackendConfig", () => {
     expect(resolved.backend).toBe("qmd");
     expect(resolved.qmd?.collections.length).toBeGreaterThanOrEqual(3);
     expect(resolved.qmd?.command).toBe("qmd");
-    expect(resolved.qmd?.searchMode).toBe("query");
+    expect(resolved.qmd?.searchMode).toBe("search");
     expect(resolved.qmd?.update.intervalMs).toBeGreaterThan(0);
     expect(resolved.qmd?.update.waitForBootSync).toBe(false);
     expect(resolved.qmd?.update.commandTimeoutMs).toBe(30_000);

--- a/src/memory/backend-config.ts
+++ b/src/memory/backend-config.ts
@@ -66,7 +66,9 @@ const DEFAULT_CITATIONS: MemoryCitationsMode = "auto";
 const DEFAULT_QMD_INTERVAL = "5m";
 const DEFAULT_QMD_DEBOUNCE_MS = 15_000;
 const DEFAULT_QMD_TIMEOUT_MS = 4_000;
-const DEFAULT_QMD_SEARCH_MODE: MemoryQmdSearchMode = "query";
+// Defaulting to `query` can be extremely slow on CPU-only systems (query expansion + rerank).
+// Prefer a faster mode for interactive use; users can opt into `query` for best recall.
+const DEFAULT_QMD_SEARCH_MODE: MemoryQmdSearchMode = "search";
 const DEFAULT_QMD_EMBED_INTERVAL = "60m";
 const DEFAULT_QMD_COMMAND_TIMEOUT_MS = 30_000;
 const DEFAULT_QMD_UPDATE_TIMEOUT_MS = 120_000;

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -262,9 +262,10 @@ export class QmdMemoryManager implements MemorySearchManager {
     }
     const qmdSearchCommand = this.qmd.searchMode;
     const args = this.buildSearchArgs(qmdSearchCommand, trimmed, limit);
-    if (qmdSearchCommand === "query") {
-      args.push(...collectionFilterArgs);
-    }
+
+    // Always scope to managed collections (default + custom). Even for `search`/`vsearch`,
+    // pass collection filters; if a given QMD build rejects these flags, we fall back to `query`.
+    args.push(...collectionFilterArgs);
     let stdout: string;
     let stderr: string;
     try {


### PR DESCRIPTION
Fixes openclaw/openclaw#8786.

Changes:
- Default `memory.qmd.searchMode` to `search` (faster on CPU-only systems; users can opt into `query` for best recall).
- Always pass `-c <collection>` filters even for `qmd search`/`vsearch` so searches are scoped to configured collections. If a given qmd build rejects flags, we already fall back to `qmd query`.
- Update docs to reflect new default.

Tests:
- `pnpm lint`
- `pnpm vitest run src/memory/backend-config.test.ts src/memory/qmd-manager.test.ts`

Note: the full `pnpm test` suite currently fails on `main` in unrelated browser/control tests (401/Unauthorized parsing); this PR keeps changes limited to memory/QMD.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Changed default QMD search mode from `query` to `search` for better CPU-only performance, and now scopes all search modes (`search`, `vsearch`, `query`) to configured collections via `-c` flags. Includes automatic fallback to `query` mode if older QMD builds reject collection flags on `search`/`vsearch`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-tested with comprehensive test updates covering the new default, collection scoping, and fallback behavior. The implementation includes proper error handling and maintains backward compatibility through the fallback mechanism. Documentation is updated to reflect the changes. The scope is limited to QMD memory backend configuration and execution, with no breaking changes to the API.
- No files require special attention

<sub>Last reviewed commit: 3b0a4ad</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->