### PR TITLE
fix: sandbox-common build fails after #11289 added USER sandbox

### DIFF
--- a/scripts/sandbox-common-setup.sh
+++ b/scripts/sandbox-common-setup.sh
@@ -27,6 +27,7 @@ docker build \
   --build-arg BREW_INSTALL_DIR="${BREW_INSTALL_DIR}" \
   - <<EOF
 FROM ${BASE_IMAGE}
+USER root
 ENV DEBIAN_FRONTEND=noninteractive
 ARG INSTALL_PNPM=1
 ARG INSTALL_BUN=1
@@ -55,6 +56,8 @@ RUN if [ "\${INSTALL_BREW}" = "1" ]; then \\
   if [ ! -x "\${BREW_INSTALL_DIR}/bin/brew" ]; then echo "brew install failed"; exit 1; fi; \\
   ln -sf "\${BREW_INSTALL_DIR}/bin/brew" /usr/local/bin/brew; \\
 fi
+USER sandbox
+WORKDIR /home/sandbox
 EOF
 
 cat <<NOTE


### PR DESCRIPTION
#### Summary

`scripts/sandbox-common-setup.sh` fails to build after #11289 hardened `Dockerfile.sandbox` to run as non-root `USER sandbox`. The common image derives FROM the base image and runs `apt-get update`, which fails with `Permission denied` because the inherited user cannot write to `/var/lib/apt/lists/`.

#### Repro Steps

1. Build the base sandbox image: `scripts/sandbox-setup.sh`
2. Build the common sandbox image: `scripts/sandbox-common-setup.sh`
3. Step 2 fails:
```
E: List directory /var/lib/apt/lists/partial is missing. - Acquire (13: Permission denied)
```

#### Root Cause

PR #11289 correctly added `USER sandbox` to `Dockerfile.sandbox` as a security hardening measure. However, `sandbox-common-setup.sh` builds an inline Dockerfile that starts `FROM openclaw-sandbox:bookworm-slim` and immediately runs `apt-get` — which now executes as the non-root `sandbox` user inherited from the base image.

#### Behavior Changes

- `sandbox-common-setup.sh` now works when the base image has a non-root USER set
- The resulting common image still runs as `sandbox` (uid 1000) — no change to final image behavior

#### Codebase and GitHub Search

- `Dockerfile.sandbox-browser` is not affected (starts fresh from `debian:bookworm-slim`, not from the base sandbox image)
- Issue #10361 may be related ("[Feature]: Sandbox mode needs a functional default image")

#### Tests

- Built all three sandbox images successfully after fix
- Verified common image runs as `sandbox` (uid 1000): `docker run --rm openclaw-sandbox-common:bookworm-slim whoami` → `sandbox`
- Verified expected binaries present (node, python3, go, rustc, cargo, bun, pnpm, brew)

#### Manual Testing

### Prerequisites

- Docker installed

### Steps

1. `scripts/sandbox-setup.sh` — builds base image
2. `scripts/sandbox-common-setup.sh` — builds common image (fails without fix, succeeds with fix)
3. `docker run --rm openclaw-sandbox-common:bookworm-slim id` — confirms `uid=1000(sandbox)`

#### Evidence

Before fix:
```
E: List directory /var/lib/apt/lists/partial is missing. - Acquire (13: Permission denied)
ERROR: process "/bin/sh -c apt-get update..." did not complete successfully: exit code: 100
```

After fix:
```
$ docker run --rm openclaw-sandbox-common:bookworm-slim id
uid=1000(sandbox) gid=1000(sandbox) groups=1000(sandbox)
```

lobster-biscuit

**Sign-Off**

- Models used: Claude Opus 4.6
- Submitter effort: AI-assisted, manually verified builds and image behavior
- Agent notes: Regression introduced by #11289 (Feb 8). The common setup script predates the USER hardening (created Jan 4) and was never updated to account for it.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a build regression in `scripts/sandbox-common-setup.sh` introduced by PR #11289, which added `USER sandbox` to `Dockerfile.sandbox` as a security hardening measure. The common image derives from the base sandbox image and runs `apt-get update` as root-requiring operations, which failed because the inherited non-root user couldn't write to `/var/lib/apt/lists/`.

- Adds `USER root` at the top of the inline Dockerfile to enable privileged package installation
- Restores `USER sandbox` and `WORKDIR /home/sandbox` at the end, preserving the security hardening from #11289
- Follows the same pattern used in `Dockerfile.sandbox` and `Dockerfile.sandbox-browser`
- No change to final image behavior — the common image still runs as `sandbox` (uid 1000)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, well-scoped fix for a clear build regression with no behavioral changes to the final image.
- The change is a 3-line fix that adds standard Docker USER switching (root for installs, sandbox for runtime). It follows established patterns in the repo's other Dockerfiles, the root cause and fix are well-understood, and the author verified the fix with manual testing. No logic, security, or correctness concerns.
- No files require special attention.

<sub>Last reviewed commit: 76b27a0</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->