### PR TITLE
fix(gateway): add rateLimit to auth Zod schema

### DIFF
--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -402,6 +402,15 @@ export const OpenClawSchema = z
             token: z.string().optional().register(sensitive),
             password: z.string().optional().register(sensitive),
             allowTailscale: z.boolean().optional(),
+            rateLimit: z
+              .object({
+                maxAttempts: z.number().int().positive().optional(),
+                windowMs: z.number().int().positive().optional(),
+                lockoutMs: z.number().int().positive().optional(),
+                exemptLoopback: z.boolean().optional(),
+              })
+              .strict()
+              .optional(),
           })
           .strict()
           .optional(),

--- a/src/gateway/server.auth.e2e.test.ts
+++ b/src/gateway/server.auth.e2e.test.ts
@@ -665,8 +665,7 @@ describe("gateway server auth/connect", () => {
       mode: "token",
       token: "secret",
       rateLimit: { maxAttempts: 1, windowMs: 60_000, lockoutMs: 60_000, exemptLoopback: false },
-      // oxlint-disable-next-line typescript/no-explicit-any
-    } as any;
+    };
     const prevToken = process.env.OPENCLAW_GATEWAY_TOKEN;
     process.env.OPENCLAW_GATEWAY_TOKEN = "secret";
     const port = await getFreePort();
@@ -721,8 +720,7 @@ describe("gateway server auth/connect", () => {
       mode: "token",
       token: "secret",
       rateLimit: { maxAttempts: 1, windowMs: 60_000, lockoutMs: 60_000, exemptLoopback: false },
-      // oxlint-disable-next-line typescript/no-explicit-any
-    } as any;
+    };
     const prevToken = process.env.OPENCLAW_GATEWAY_TOKEN;
     process.env.OPENCLAW_GATEWAY_TOKEN = "secret";
     const port = await getFreePort();


### PR DESCRIPTION
Fixes #16071.

## Summary

`gateway.auth.rateLimit` is defined in the TypeScript types, used by the runtime, recommended by `openclaw security audit --deep`, and documented — but was never added to the Zod validation schema. Since the schema uses `.strict()`, any config containing this field causes a fatal validation error on startup:

```
gateway.auth: Unrecognized key: "rateLimit"
```

This was introduced in #15035 (merged 2026-02-13), which added the type, runtime code, audit check, and tests but missed the Zod schema.

## Changes

- Add `rateLimit` sub-schema (`maxAttempts`, `windowMs`, `lockoutMs`, `exemptLoopback`) to the `gateway.auth` Zod object in `src/config/zod-schema.ts`, matching `GatewayAuthRateLimitConfig`
- Add 4 Zod validation tests in `src/config/schema.test.ts` that parse configs through `OpenClawSchema.safeParse()` (accepts valid rateLimit, accepts all fields, optional rateLimit, rejects unknown keys)
- Remove 2 `as any` casts and their `oxlint-disable` comments in `src/gateway/server.auth.e2e.test.ts` that are no longer needed

## Tests

- `pnpm vitest run src/config/schema.test.ts` — 9/9 pass (4 new)
- `pnpm format:check` — pass
- `pnpm lint` — 0 warnings, 0 errors
- `tsgo --noEmit` — no new errors

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds the missing `gateway.auth.rateLimit` field to the Zod validation schema, fixing a fatal startup error when this documented and recommended configuration field is used.

- Adds `rateLimit` sub-schema with proper validation (`maxAttempts`, `windowMs`, `lockoutMs` as positive integers, `exemptLoopback` as boolean) to `src/config/zod-schema.ts:405-413`
- Adds 4 comprehensive Zod validation tests that verify valid configs are accepted, optional fields work, and unknown keys are rejected
- Removes 2 `as any` type casts in `src/gateway/server.auth.e2e.test.ts:667-668,722-723` that were workarounds for the missing schema

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The PR adds a missing Zod schema field that perfectly matches the existing TypeScript type definition. The fix is straightforward, well-tested with 4 new validation tests, and removes type-safety workarounds. No logic changes, no breaking changes, and directly addresses a documented bug that causes startup failures.
- No files require special attention

<sub>Last reviewed commit: 7acf2cf</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->