### PR TITLE
fix(i18n): use Unicode-aware word boundaries for non-ASCII language support

### DIFF
--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -1,4 +1,5 @@
 import { escapeRegExp } from "../utils.js";
+import { UNICODE_NON_WORD, UNICODE_WORD_END, UNICODE_WORD_START } from "./unicode-boundaries.js";
 
 export const HEARTBEAT_TOKEN = "HEARTBEAT_OK";
 export const SILENT_REPLY_TOKEN = "NO_REPLY";
@@ -11,10 +12,10 @@ export function isSilentReplyText(
     return false;
   }
   const escaped = escapeRegExp(token);
-  const prefix = new RegExp(`^\\s*${escaped}(?=$|\\W)`);
+  const prefix = new RegExp(`^\\s*${escaped}(?=$|${UNICODE_NON_WORD})`, "u");
   if (prefix.test(text)) {
     return true;
   }
-  const suffix = new RegExp(`\\b${escaped}\\b\\W*$`);
+  const suffix = new RegExp(`${UNICODE_WORD_START}${escaped}${UNICODE_WORD_END}${UNICODE_NON_WORD}*$`, "u");
   return suffix.test(text);
 }

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -16,6 +16,9 @@ export function isSilentReplyText(
   if (prefix.test(text)) {
     return true;
   }
-  const suffix = new RegExp(`${UNICODE_WORD_START}${escaped}${UNICODE_WORD_END}${UNICODE_NON_WORD}*$`, "u");
+  const suffix = new RegExp(
+    `${UNICODE_WORD_START}${escaped}${UNICODE_WORD_END}${UNICODE_NON_WORD}*$`,
+    "u",
+  );
   return suffix.test(text);
 }

--- a/src/auto-reply/unicode-boundaries.test.ts
+++ b/src/auto-reply/unicode-boundaries.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { wrapWordBoundary, UNICODE_WORD_START, UNICODE_WORD_END, UNICODE_NON_WORD } from "./unicode-boundaries.js";
+
+function escapeRegExp(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+describe("Unicode word boundaries", () => {
+  describe("wrapWordBoundary", () => {
+    it("matches ASCII name in ASCII context", () => {
+      const re = new RegExp(wrapWordBoundary(escapeRegExp("Puck")), "iu");
+      expect(re.test("Hej Puck!")).toBe(true);
+      expect(re.test("Puck")).toBe(true);
+      expect(re.test("@Puck hello")).toBe(true);
+    });
+
+    it("does not match partial ASCII words", () => {
+      const re = new RegExp(wrapWordBoundary(escapeRegExp("Puck")), "iu");
+      expect(re.test("Pucky")).toBe(false);
+      expect(re.test("unpuck")).toBe(false);
+    });
+
+    it("matches Swedish name with åäö", () => {
+      const re = new RegExp(wrapWordBoundary(escapeRegExp("Björk")), "iu");
+      expect(re.test("Hej Björk!")).toBe(true);
+      expect(re.test("Björk sa hej")).toBe(true);
+      expect(re.test("sa Björk")).toBe(true);
+    });
+
+    it("does not match partial Swedish words", () => {
+      const re = new RegExp(wrapWordBoundary(escapeRegExp("Björk")), "iu");
+      expect(re.test("Björken")).toBe(false);
+    });
+
+    it("matches German name with ü", () => {
+      const re = new RegExp(wrapWordBoundary(escapeRegExp("Pück")), "iu");
+      expect(re.test("Hej Pück!")).toBe(true);
+    });
+
+    it("matches French name with accents", () => {
+      const re = new RegExp(wrapWordBoundary(escapeRegExp("François")), "iu");
+      expect(re.test("Bonjour François!")).toBe(true);
+      expect(re.test("François est là")).toBe(true);
+    });
+
+    it("matches Spanish name with ñ", () => {
+      const re = new RegExp(wrapWordBoundary(escapeRegExp("José")), "iu");
+      expect(re.test("Hola José!")).toBe(true);
+    });
+
+    it("treats café as one word", () => {
+      const re = new RegExp(wrapWordBoundary(escapeRegExp("café")), "iu");
+      expect(re.test("I love café!")).toBe(true);
+      expect(re.test("caféine")).toBe(false);
+    });
+
+    it("treats über as one word", () => {
+      const re = new RegExp(wrapWordBoundary(escapeRegExp("über")), "iu");
+      expect(re.test("Das ist über cool")).toBe(true);
+      expect(re.test("überall")).toBe(false);
+    });
+
+    it("works with CJK characters", () => {
+      const re = new RegExp(wrapWordBoundary(escapeRegExp("太郎")), "iu");
+      expect(re.test("こんにちは 太郎 さん")).toBe(true);
+    });
+
+    it("matches at string boundaries", () => {
+      const re = new RegExp(wrapWordBoundary(escapeRegExp("Ärlig")), "iu");
+      expect(re.test("Ärlig")).toBe(true);
+      expect(re.test("Ärlig!")).toBe(true);
+      expect(re.test("!Ärlig")).toBe(true);
+    });
+  });
+
+  describe("UNICODE_NON_WORD", () => {
+    it("matches spaces and punctuation", () => {
+      const re = new RegExp(UNICODE_NON_WORD, "u");
+      expect(re.test(" ")).toBe(true);
+      expect(re.test("!")).toBe(true);
+      expect(re.test(".")).toBe(true);
+    });
+
+    it("does not match letters or digits", () => {
+      const re = new RegExp(UNICODE_NON_WORD, "u");
+      expect(re.test("a")).toBe(false);
+      expect(re.test("å")).toBe(false);
+      expect(re.test("é")).toBe(false);
+      expect(re.test("9")).toBe(false);
+      expect(re.test("_")).toBe(false);
+    });
+  });
+
+  describe("regression: \\b fails with non-ASCII (before fix)", () => {
+    it("ASCII \\b breaks Swedish word boundary", () => {
+      // This demonstrates the problem: \b treats ö as non-word
+      const broken = /\bBjörk\b/i;
+      // \b sees the ö→k transition as already a boundary, so "Björken" matches!
+      // This is the bug we're fixing.
+      expect(broken.test("Björken")).toBe(true); // BUG: should be false
+
+      // Our fix:
+      const fixed = new RegExp(wrapWordBoundary(escapeRegExp("Björk")), "iu");
+      expect(fixed.test("Björken")).toBe(false); // CORRECT
+    });
+  });
+});

--- a/src/auto-reply/unicode-boundaries.test.ts
+++ b/src/auto-reply/unicode-boundaries.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { wrapWordBoundary, UNICODE_WORD_START, UNICODE_WORD_END, UNICODE_NON_WORD } from "./unicode-boundaries.js";
+import {
+  wrapWordBoundary,
+  UNICODE_WORD_START,
+  UNICODE_WORD_END,
+  UNICODE_NON_WORD,
+} from "./unicode-boundaries.js";
 
 function escapeRegExp(text: string): string {
   return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");

--- a/src/auto-reply/unicode-boundaries.ts
+++ b/src/auto-reply/unicode-boundaries.ts
@@ -1,0 +1,43 @@
+/**
+ * Unicode-aware word boundary helpers.
+ *
+ * JavaScript's built-in `\b` word boundary only recognises ASCII word characters
+ * (`[a-zA-Z0-9_]`). Characters like å, ä, ö, é, ñ, ü — and all non-Latin scripts —
+ * are treated as non-word characters, which breaks mention detection, token matching,
+ * and text processing for non-English languages.
+ *
+ * These helpers use Unicode property escapes (`\p{L}`, `\p{N}`) so that **any**
+ * letter or digit in any script is considered a "word character".
+ *
+ * All RegExp instances built with these helpers **must** use the `u` flag.
+ */
+
+/**
+ * Zero-width assertion matching the start of a word (Unicode-aware).
+ * Matches at the start of the string or after a character that is NOT a Unicode
+ * letter, digit, or underscore.
+ */
+export const UNICODE_WORD_START = String.raw`(?:(?<=^)|(?<=(?:[^\p{L}\p{N}_])))`;
+
+/**
+ * Zero-width assertion matching the end of a word (Unicode-aware).
+ * Matches at the end of the string or before a character that is NOT a Unicode
+ * letter, digit, or underscore.
+ */
+export const UNICODE_WORD_END = String.raw`(?:(?=$)|(?=(?:[^\p{L}\p{N}_])))`;
+
+/** Character class matching a single non-word character (Unicode-aware). */
+export const UNICODE_NON_WORD = String.raw`[^\p{L}\p{N}_]`;
+
+/**
+ * Wrap a pattern string with Unicode-aware word boundaries.
+ *
+ * Usage:
+ * ```ts
+ * const re = new RegExp(wrapWordBoundary(escapeRegExp("Pück")), "iu");
+ * re.test("Hej Pück!"); // true
+ * ```
+ */
+export function wrapWordBoundary(pattern: string): string {
+  return `${UNICODE_WORD_START}${pattern}${UNICODE_WORD_END}`;
+}


### PR DESCRIPTION
## Summary

Replaces ASCII-only `\b` word boundaries with Unicode property escapes (`\p{L}`, `\p{N}`) so that mention detection, token matching, and text processing work correctly for **all non-ASCII languages** — Swedish (åäö), French (é), German (ü), Spanish (ñ), Japanese, Chinese, Korean, and more.

## Problem

JavaScript `\b` only recognizes `[a-zA-Z0-9_]` as "word characters". Any letter outside ASCII is treated as a non-word character, which causes:

- **False positives**: `\bÅsa\b` matches inside `HejÅsa` (because `j→Å` is seen as a word→non-word boundary)
- **False positives**: `\början\b` matches inside `Hejörjan`
- **Broken mention detection** for agent names containing non-ASCII characters
- **Broken structural prefix stripping** for non-Latin text (only `[A-Za-z0-9]` was matched)

This affects **any language** that uses characters outside the ASCII range.

## Solution

### New shared utility: `src/auto-reply/unicode-boundaries.ts`

Provides Unicode-aware word boundary helpers using `\p{L}` (any Unicode letter) and `\p{N}` (any Unicode digit) with the `u` flag:

```typescript
// Zero-width assertions (like \b but Unicode-aware)
UNICODE_WORD_START  // (?:(?<=^)|(?<=(?:[^\p{L}\p{N}_])))
UNICODE_WORD_END    // (?:(?=$)|(?=(?:[^\p{L}\p{N}_])))
UNICODE_NON_WORD    // [^\p{L}\p{N}_]

// Helper to wrap a pattern
wrapWordBoundary(pattern)  // adds start + end boundaries
```

### Updated files

| File | Change |
|------|--------|
| `src/auto-reply/reply/mentions.ts` | `deriveMentionPatterns` uses `wrapWordBoundary()` instead of `\b` |
| `src/auto-reply/reply/mentions.ts` | `buildMentionRegexes` tries `"iu"` flag first (falls back to `"i"` for user patterns) |
| `src/auto-reply/reply/mentions.ts` | `stripStructuralPrefixes` uses `\p{L}\p{N}` instead of `[A-Za-z0-9]` |
| `src/auto-reply/reply/mentions.ts` | `stripMentions` tries `"giu"` flag first |
| `src/auto-reply/tokens.ts` | `isSilentReplyText` uses Unicode-aware patterns |

### Backward compatibility

All changes try the Unicode `u` flag first and gracefully fall back to the non-Unicode version for user-supplied patterns that may not be `u`-compatible. This ensures no regressions for existing configurations.

## Tests

Comprehensive test suite in `src/auto-reply/unicode-boundaries.test.ts` covering:
- ASCII names (baseline)
- Swedish: Björk, Ärlig, Åsa
- French: François, café
- German: Pück, über
- Spanish: José
- CJK characters: 太郎
- False positive regression test demonstrating the `\b` bug

## Verification

```
// The bug (before fix):
/\bÅsa\b/.test("HejÅsa")  // true — WRONG (false positive)

// After fix:
new RegExp(wrapWordBoundary("Åsa"), "iu").test("HejÅsa")   // false — CORRECT
new RegExp(wrapWordBoundary("Åsa"), "iu").test("Hej Åsa!")  // true  — CORRECT
```

Refs: #3460

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces ASCII-only `\b` word boundaries with Unicode property escapes (`\p{L}`, `\p{N}`) across mention detection, token matching, and structural prefix stripping. This fixes false positives and broken matching for non-ASCII languages (Swedish, French, German, Spanish, CJK, etc.).

- Adds new shared utility `src/auto-reply/unicode-boundaries.ts` with `UNICODE_WORD_START`, `UNICODE_WORD_END`, `UNICODE_NON_WORD`, and `wrapWordBoundary()` helper
- Updates `deriveMentionPatterns` to use `wrapWordBoundary()` instead of `\b`
- Updates `buildMentionRegexes` and `stripMentions` to try `"iu"` flag first with graceful fallback for user-supplied patterns
- Updates `stripStructuralPrefixes` to use `[\p{L}\p{N}...]` instead of `[A-Za-z0-9...]` so non-ASCII sender prefixes are correctly stripped
- Updates `isSilentReplyText` to use Unicode-aware boundary and non-word patterns
- Includes comprehensive test suite covering multiple languages and a regression test demonstrating the original `\b` bug

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — the changes are well-scoped, backward-compatible, and thoroughly tested.
- Score of 4 reflects a well-implemented fix with comprehensive tests. The Unicode boundary patterns are correct and verified against multiple languages. The try/catch fallback pattern ensures backward compatibility for user-supplied patterns. One minor point: CJK names embedded without whitespace separators won't match (same as before this PR for practical purposes since \b also couldn't match them), but this is a known limitation of word-boundary-based matching for CJK text and not a regression. Unused imports in the test file were already flagged in a prior review.
- No files require special attention. All changes are straightforward regex replacements with proper fallback handling.

<sub>Last reviewed commit: e87ef6c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->