### PR TITLE
fix: close child process PIPEs on exit to prevent EBADF (#16008)

### DIFF
--- a/src/node-host/invoke.ts
+++ b/src/node-host/invoke.ts
@@ -300,8 +300,19 @@ async function runCommand(
 
     child.on("error", (err) => {
       finalize(undefined, err.message);
+      // Destroy stdio streams to release pipe FDs on spawn failure
+      try {
+        child.stdout?.destroy();
+      } catch {
+        /* ignore */
+      }
+      try {
+        child.stderr?.destroy();
+      } catch {
+        /* ignore */
+      }
     });
-    child.on("exit", (code) => {
+    child.on("close", (code) => {
       finalize(code === null ? undefined : code, null);
     });
   });

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -154,6 +154,10 @@ export async function runCommandWithTimeout(
       }
       settled = true;
       clearTimeout(timer);
+      // Destroy stdio streams to release pipe FDs on spawn failure
+      child.stdout?.destroy();
+      child.stderr?.destroy();
+      child.stdin?.destroy();
       reject(err);
     });
     child.on("close", (code, signal) => {

--- a/src/process/spawn-utils.test.ts
+++ b/src/process/spawn-utils.test.ts
@@ -2,7 +2,7 @@ import type { ChildProcess } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { PassThrough } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
-import { spawnWithFallback } from "./spawn-utils.js";
+import { destroyChildStreams, spawnWithFallback } from "./spawn-utils.js";
 
 function createStubChild() {
   const child = new EventEmitter() as ChildProcess;
@@ -59,5 +59,147 @@ describe("spawnWithFallback", () => {
       }),
     ).rejects.toThrow(/ENOENT/);
     expect(spawnMock).toHaveBeenCalledTimes(1);
+  });
+  it("destroys stdio streams when spawn emits an error asynchronously", async () => {
+    const stdinDestroy = vi.fn();
+    const stdoutDestroy = vi.fn();
+    const stderrDestroy = vi.fn();
+
+    const spawnMock = vi
+      .fn()
+      .mockImplementationOnce(() => {
+        const child = new EventEmitter() as ChildProcess;
+        child.stdin = Object.assign(new PassThrough(), {
+          destroy: stdinDestroy,
+        }) as ChildProcess["stdin"];
+        child.stdout = Object.assign(new PassThrough(), {
+          destroy: stdoutDestroy,
+        }) as ChildProcess["stdout"];
+        child.stderr = Object.assign(new PassThrough(), {
+          destroy: stderrDestroy,
+        }) as ChildProcess["stderr"];
+        child.pid = undefined as unknown as number;
+        child.killed = false;
+        child.kill = vi.fn(() => true) as ChildProcess["kill"];
+        // Emit error asynchronously to simulate a failed spawn
+        queueMicrotask(() => {
+          const err = new Error("spawn EBADF");
+          (err as NodeJS.ErrnoException).code = "EBADF";
+          child.emit("error", err);
+        });
+        return child;
+      })
+      .mockImplementationOnce(() => createStubChild());
+
+    const result = await spawnWithFallback({
+      argv: ["echo", "ok"],
+      options: { stdio: ["pipe", "pipe", "pipe"] },
+      fallbacks: [{ label: "no-detach", options: { detached: false } }],
+      spawnImpl: spawnMock,
+    });
+
+    expect(result.usedFallback).toBe(true);
+    // Verify that the failed child's streams were destroyed
+    expect(stdinDestroy).toHaveBeenCalled();
+    expect(stdoutDestroy).toHaveBeenCalled();
+    expect(stderrDestroy).toHaveBeenCalled();
+  });
+
+  it("destroys stdio streams when spawn fails without fallback", async () => {
+    const stdinDestroy = vi.fn();
+    const stdoutDestroy = vi.fn();
+    const stderrDestroy = vi.fn();
+
+    const spawnMock = vi.fn().mockImplementationOnce(() => {
+      const child = new EventEmitter() as ChildProcess;
+      child.stdin = Object.assign(new PassThrough(), {
+        destroy: stdinDestroy,
+      }) as ChildProcess["stdin"];
+      child.stdout = Object.assign(new PassThrough(), {
+        destroy: stdoutDestroy,
+      }) as ChildProcess["stdout"];
+      child.stderr = Object.assign(new PassThrough(), {
+        destroy: stderrDestroy,
+      }) as ChildProcess["stderr"];
+      child.pid = undefined as unknown as number;
+      child.killed = false;
+      child.kill = vi.fn(() => true) as ChildProcess["kill"];
+      queueMicrotask(() => {
+        const err = new Error("spawn ENOENT");
+        (err as NodeJS.ErrnoException).code = "ENOENT";
+        child.emit("error", err);
+      });
+      return child;
+    });
+
+    await expect(
+      spawnWithFallback({
+        argv: ["missing"],
+        options: { stdio: ["pipe", "pipe", "pipe"] },
+        spawnImpl: spawnMock,
+      }),
+    ).rejects.toThrow(/ENOENT/);
+
+    // Streams should be destroyed even without fallback
+    expect(stdinDestroy).toHaveBeenCalled();
+    expect(stdoutDestroy).toHaveBeenCalled();
+    expect(stderrDestroy).toHaveBeenCalled();
+  });
+});
+
+describe("destroyChildStreams", () => {
+  it("destroys all stdio streams on a child process", () => {
+    const child = new EventEmitter() as ChildProcess;
+    child.stdin = new PassThrough() as ChildProcess["stdin"];
+    child.stdout = new PassThrough() as ChildProcess["stdout"];
+    child.stderr = new PassThrough() as ChildProcess["stderr"];
+    child.pid = 1234;
+    child.killed = false;
+    child.kill = vi.fn(() => true) as ChildProcess["kill"];
+
+    expect(child.stdin!.destroyed).toBe(false);
+    expect(child.stdout!.destroyed).toBe(false);
+    expect(child.stderr!.destroyed).toBe(false);
+
+    destroyChildStreams(child);
+
+    expect(child.stdin!.destroyed).toBe(true);
+    expect(child.stdout!.destroyed).toBe(true);
+    expect(child.stderr!.destroyed).toBe(true);
+  });
+
+  it("handles missing streams gracefully", () => {
+    const child = new EventEmitter() as ChildProcess;
+    child.stdin = null as ChildProcess["stdin"];
+    child.stdout = null as ChildProcess["stdout"];
+    child.stderr = null as ChildProcess["stderr"];
+    child.pid = 1234;
+    child.killed = false;
+    child.kill = vi.fn(() => true) as ChildProcess["kill"];
+
+    // Should not throw
+    expect(() => destroyChildStreams(child)).not.toThrow();
+  });
+
+  it("skips already-destroyed streams", () => {
+    const child = new EventEmitter() as ChildProcess;
+    const stdin = new PassThrough() as ChildProcess["stdin"];
+    stdin!.destroy();
+    child.stdin = stdin;
+    child.stdout = new PassThrough() as ChildProcess["stdout"];
+    child.stderr = new PassThrough() as ChildProcess["stderr"];
+    child.pid = 1234;
+    child.killed = false;
+    child.kill = vi.fn(() => true) as ChildProcess["kill"];
+
+    const destroySpy = vi.spyOn(stdin!, "destroy");
+
+    destroyChildStreams(child);
+
+    // stdin was already destroyed, should not be called again
+    expect(destroySpy).not.toHaveBeenCalled();
+    // stdout and stderr should be destroyed
+    expect(child.stdout!.destroyed).toBe(true);
+    expect(child.stderr!.destroyed).toBe(true);
   });
 });


### PR DESCRIPTION
## Problem

After running for several hours/days, the exec tool fails with `spawn EBADF`. The gateway process accumulates orphaned PIPE file descriptors (confirmed via `lsof`) with no corresponding child processes. This is caused by pipe FDs from child process stdio streams not being properly closed in all code paths.

## Root Cause

When `child_process.spawn()` is called with `stdio: ["pipe", "pipe", "pipe"]`, Node.js allocates pipe file descriptors **synchronously** before the actual fork/exec. If the spawn subsequently fails (e.g., EBADF from FD exhaustion, or any other error), the pipe FDs are never cleaned up because:

1. **`spawnAndWaitForSpawn()`** in `spawn-utils.ts` — rejects the promise on error but never destroys the child`s stdio streams. When `spawnWithFallback()` retries with a fallback, the failed child`s pipe FDs leak permanently.
2. **`runCommand()`** in `node-host/invoke.ts` — listened on `exit` instead of `close`, and never destroyed streams on error.
3. **`runCommandWithTimeout()`** in `process/exec.ts` — error handler didn`t destroy child streams.
4. **PTY sessions** in `bash-tools.exec-runtime.ts` — PTY handle captured in closures was never cleaned up on process exit, leaking the master FD.

Over time (hours/days of spawning), these leaked FDs accumulate until the process hits its FD limit, causing all subsequent spawns to fail with `EBADF`.

## Fix

### Core fix: `src/process/spawn-utils.ts`
- Added `destroyChildStreams()` helper that safely destroys stdin/stdout/stderr on a child process
- Call it in `spawnAndWaitForSpawn()``s error handler before rejecting — this is the primary leak source

### Secondary fixes:
- **`src/node-host/invoke.ts`**: Destroy streams on error; changed `exit` → `close` event for proper sequencing
- **`src/process/exec.ts`**: Destroy streams in error handler of `runCommandWithTimeout()`
- **`src/agents/bash-tools.exec-runtime.ts`**: Clean up PTY handle (kill + destroy) on process exit; explicitly destroy child streams on error before `markExited()`

### Tests: `src/process/spawn-utils.test.ts`
- Test that stdio streams are destroyed when spawn emits an async error (with fallback)
- Test that stdio streams are destroyed when spawn fails without fallback
- Unit tests for `destroyChildStreams()`: normal operation, null streams, already-destroyed streams

Closes #16008

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixes a critical file descriptor leak that causes `spawn EBADF` errors after hours/days of operation. The root cause was pipe FDs allocated by `child_process.spawn()` not being destroyed when spawn fails, accumulating until the process hits FD limits.

**Key changes:**
- Added `destroyChildStreams()` helper in `spawn-utils.ts` to safely destroy stdin/stdout/stderr on child processes
- Applied cleanup in `spawnAndWaitForSpawn()` error handler (primary leak source during fallback retries)
- Added stream destruction to error handlers in `invoke.ts`, `exec.ts`, and `bash-tools.exec-runtime.ts`
- Changed `exit` → `close` event in `invoke.ts:315` for proper stream cleanup sequencing
- Added PTY handle cleanup in `bash-tools.exec-runtime.ts` to release master FD on process exit
- Comprehensive test coverage validates stream cleanup in success/failure/fallback scenarios

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with high confidence
- The fix addresses a well-understood resource leak with surgical precision. The implementation follows defensive programming practices (try-catch blocks, null checks, idempotency checks for already-destroyed streams). The changes are isolated to error paths, preserving existing success-path behavior. Comprehensive unit tests validate the core fix and edge cases. The PR description provides clear root cause analysis and the code comments explain the reasoning.
- No files require special attention

<sub>Last reviewed commit: 94e84bd</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->