### PR TITLE
fix: omit tools param for models without tool support, surface errors (#15702)

### DIFF
--- a/src/agents/pi-embedded-runner.sanitize-antigravity-thinking.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-antigravity-thinking.test.ts
@@ -1,0 +1,147 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { describe, expect, it } from "vitest";
+import { sanitizeAntigravityThinkingBlocks } from "./pi-embedded-runner/google.js";
+
+describe("sanitizeAntigravityThinkingBlocks", () => {
+  it("converts unsigned thinking block to text", () => {
+    const messages: AgentMessage[] = [
+      {
+        role: "assistant",
+        content: [{ type: "thinking", thinking: "deep thought" }],
+      },
+    ];
+
+    const result = sanitizeAntigravityThinkingBlocks(messages);
+    const assistant = result[0] as { content?: Array<{ type?: string; text?: string }> };
+    expect(assistant.content).toHaveLength(1);
+    expect(assistant.content?.[0]?.type).toBe("text");
+    expect(assistant.content?.[0]?.text).toBe("deep thought");
+  });
+
+  it("keeps thinking block with valid base64 signature", () => {
+    const messages: AgentMessage[] = [
+      {
+        role: "assistant",
+        content: [{ type: "thinking", thinking: "signed thought", thinkingSignature: "c2ln" }],
+      },
+    ];
+
+    const result = sanitizeAntigravityThinkingBlocks(messages);
+    const assistant = result[0] as {
+      content?: Array<{ type?: string; thinking?: string; thinkingSignature?: string }>;
+    };
+    expect(assistant.content).toHaveLength(1);
+    expect(assistant.content?.[0]?.type).toBe("thinking");
+    expect(assistant.content?.[0]?.thinking).toBe("signed thought");
+    expect(assistant.content?.[0]?.thinkingSignature).toBe("c2ln");
+  });
+
+  it("normalizes signature key to thinkingSignature", () => {
+    const messages: AgentMessage[] = [
+      {
+        role: "assistant",
+        content: [{ type: "thinking", thinking: "signed", signature: "AQID" }],
+      },
+    ];
+
+    const result = sanitizeAntigravityThinkingBlocks(messages);
+    const assistant = result[0] as {
+      content?: Array<{ type?: string; thinkingSignature?: string }>;
+    };
+    expect(assistant.content?.[0]?.type).toBe("thinking");
+    expect(assistant.content?.[0]?.thinkingSignature).toBe("AQID");
+  });
+
+  it("handles mixed signed and unsigned thinking blocks", () => {
+    const messages: AgentMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "signed", thinkingSignature: "c2ln" },
+          { type: "thinking", thinking: "unsigned thought" },
+          { type: "text", text: "response" },
+        ],
+      },
+    ];
+
+    const result = sanitizeAntigravityThinkingBlocks(messages);
+    const assistant = result[0] as {
+      content?: Array<{ type?: string; text?: string; thinking?: string }>;
+    };
+    expect(assistant.content).toHaveLength(3);
+    expect(assistant.content?.[0]?.type).toBe("thinking");
+    expect(assistant.content?.[0]?.thinking).toBe("signed");
+    expect(assistant.content?.[1]?.type).toBe("text");
+    expect(assistant.content?.[1]?.text).toBe("unsigned thought");
+    expect(assistant.content?.[2]?.type).toBe("text");
+    expect(assistant.content?.[2]?.text).toBe("response");
+  });
+
+  it("drops whitespace-only unsigned thinking blocks", () => {
+    const messages: AgentMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "   " },
+          { type: "text", text: "hello" },
+        ],
+      },
+    ];
+
+    const result = sanitizeAntigravityThinkingBlocks(messages);
+    const assistant = result[0] as { content?: Array<{ type?: string }> };
+    expect(assistant.content).toHaveLength(1);
+    expect(assistant.content?.[0]?.type).toBe("text");
+  });
+
+  it("removes assistant message when all blocks are empty unsigned thinking", () => {
+    const messages: AgentMessage[] = [
+      {
+        role: "user",
+        content: "hi",
+      },
+      {
+        role: "assistant",
+        content: [{ type: "thinking", thinking: "" }],
+      },
+    ];
+
+    const result = sanitizeAntigravityThinkingBlocks(messages);
+    expect(result).toHaveLength(1);
+    expect((result[0] as { role?: string }).role).toBe("user");
+  });
+
+  it("passes through non-assistant messages unchanged", () => {
+    const messages: AgentMessage[] = [{ role: "user", content: "hello" }];
+
+    const result = sanitizeAntigravityThinkingBlocks(messages);
+    expect(result).toBe(messages); // same reference = no changes
+  });
+
+  it("passes through non-thinking blocks unchanged", () => {
+    const messages: AgentMessage[] = [
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "hello" }],
+      },
+    ];
+
+    const result = sanitizeAntigravityThinkingBlocks(messages);
+    expect(result).toBe(messages); // same reference = no changes
+  });
+
+  it("rejects non-base64 signatures and converts to text", () => {
+    const messages: AgentMessage[] = [
+      {
+        role: "assistant",
+        content: [{ type: "thinking", thinking: "thought", thought_signature: "msg_abc123" }],
+      },
+    ];
+
+    const result = sanitizeAntigravityThinkingBlocks(messages);
+    const assistant = result[0] as { content?: Array<{ type?: string; text?: string }> };
+    expect(assistant.content).toHaveLength(1);
+    expect(assistant.content?.[0]?.type).toBe("text");
+    expect(assistant.content?.[0]?.text).toBe("thought");
+  });
+});

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -99,6 +99,16 @@ export function sanitizeAntigravityThinkingBlocks(messages: AgentMessage[]): Age
         rec.thinkingSignature ?? rec.signature ?? rec.thought_signature ?? rec.thoughtSignature;
       if (!isValidAntigravitySignature(candidate)) {
         contentChanged = true;
+        const thinkingText =
+          typeof (block as { thinking?: unknown }).thinking === "string"
+            ? ((block as { thinking?: unknown }).thinking as string)
+            : "";
+        if (thinkingText.trim()) {
+          nextContent.push({
+            type: "text",
+            text: thinkingText,
+          } as AssistantContentBlock);
+        }
         continue;
       }
       if (rec.thinkingSignature !== candidate) {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -273,44 +273,52 @@ export async function runEmbeddedAttempt(
 
     // Check if the model supports native image input
     const modelHasVision = params.model.input?.includes("image") ?? false;
-    const toolsRaw = params.disableTools
-      ? []
-      : createOpenClawCodingTools({
-          exec: {
-            ...params.execOverrides,
-            elevated: params.bashElevated,
-          },
-          sandbox,
-          messageProvider: params.messageChannel ?? params.messageProvider,
-          agentAccountId: params.agentAccountId,
-          messageTo: params.messageTo,
-          messageThreadId: params.messageThreadId,
-          groupId: params.groupId,
-          groupChannel: params.groupChannel,
-          groupSpace: params.groupSpace,
-          spawnedBy: params.spawnedBy,
-          senderId: params.senderId,
-          senderName: params.senderName,
-          senderUsername: params.senderUsername,
-          senderE164: params.senderE164,
-          senderIsOwner: params.senderIsOwner,
-          sessionKey: params.sessionKey ?? params.sessionId,
-          agentDir,
-          workspaceDir: effectiveWorkspace,
-          config: params.config,
-          abortSignal: runAbortController.signal,
-          modelProvider: params.model.provider,
-          modelId: params.modelId,
-          modelAuthMode: resolveModelAuthMode(params.model.provider, params.config),
-          currentChannelId: params.currentChannelId,
-          currentThreadTs: params.currentThreadTs,
-          replyToMode: params.replyToMode,
-          hasRepliedRef: params.hasRepliedRef,
-          modelHasVision,
-          requireExplicitMessageTarget:
-            params.requireExplicitMessageTarget ?? isSubagentSessionKey(params.sessionKey),
-          disableMessageTool: params.disableMessageTool,
-        });
+    const modelSupportsTools =
+      (params.model.compat as Record<string, unknown> | undefined)?.supportsTools !== false;
+    if (!modelSupportsTools) {
+      log.info(
+        `Model ${params.modelId} has compat.supportsTools=false, omitting tools from request`,
+      );
+    }
+    const toolsRaw =
+      params.disableTools || !modelSupportsTools
+        ? []
+        : createOpenClawCodingTools({
+            exec: {
+              ...params.execOverrides,
+              elevated: params.bashElevated,
+            },
+            sandbox,
+            messageProvider: params.messageChannel ?? params.messageProvider,
+            agentAccountId: params.agentAccountId,
+            messageTo: params.messageTo,
+            messageThreadId: params.messageThreadId,
+            groupId: params.groupId,
+            groupChannel: params.groupChannel,
+            groupSpace: params.groupSpace,
+            spawnedBy: params.spawnedBy,
+            senderId: params.senderId,
+            senderName: params.senderName,
+            senderUsername: params.senderUsername,
+            senderE164: params.senderE164,
+            senderIsOwner: params.senderIsOwner,
+            sessionKey: params.sessionKey ?? params.sessionId,
+            agentDir,
+            workspaceDir: effectiveWorkspace,
+            config: params.config,
+            abortSignal: runAbortController.signal,
+            modelProvider: params.model.provider,
+            modelId: params.modelId,
+            modelAuthMode: resolveModelAuthMode(params.model.provider, params.config),
+            currentChannelId: params.currentChannelId,
+            currentThreadTs: params.currentThreadTs,
+            replyToMode: params.replyToMode,
+            hasRepliedRef: params.hasRepliedRef,
+            modelHasVision,
+            requireExplicitMessageTarget:
+              params.requireExplicitMessageTarget ?? isSubagentSessionKey(params.sessionKey),
+            disableMessageTool: params.disableMessageTool,
+          });
     const tools = sanitizeToolsForGoogle({ tools: toolsRaw, provider: params.provider });
     logToolSchemasForGoogle({ tools, provider: params.provider });
 

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -13,6 +13,8 @@ export type ModelCompatConfig = {
   supportsReasoningEffort?: boolean;
   supportsUsageInStreaming?: boolean;
   supportsStrictMode?: boolean;
+  /** Whether the model supports tool/function calling. When false, tools are omitted from API requests. Default: true. */
+  supportsTools?: boolean;
   maxTokensField?: "max_completion_tokens" | "max_tokens";
   thinkingFormat?: "openai" | "zai" | "qwen";
   requiresToolResultName?: boolean;

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -19,6 +19,7 @@ export const ModelCompatSchema = z
     supportsReasoningEffort: z.boolean().optional(),
     supportsUsageInStreaming: z.boolean().optional(),
     supportsStrictMode: z.boolean().optional(),
+    supportsTools: z.boolean().optional(),
     maxTokensField: z
       .union([z.literal("max_completion_tokens"), z.literal("max_tokens")])
       .optional(),


### PR DESCRIPTION
## Problem

When using local Ollama models that don't support tool/function calling, OpenClaw fails silently with `(no output)`. Direct curl to Ollama works fine. The issue is that OpenClaw sends tool definitions to models that can't handle them, and errors are swallowed.

Closes #15702

## Changes

### 1. Add `compat.supportsTools` config flag (`src/config/`)
- Added `supportsTools?: boolean` to `ModelCompatConfig` type and Zod schema
- When set to `false`, tools are omitted from API requests to the model
- Defaults to `true` (existing behavior preserved)

### 2. Skip tools when model lacks support (`src/agents/pi-embedded-runner/run/attempt.ts`)
- Check `model.compat.supportsTools` before creating tool definitions
- When `supportsTools === false`, tools are omitted (same as `disableTools`)
- Logs an info message when tools are skipped for debugging

### 3. Surface Ollama errors (`src/agents/ollama-stream.ts`)
- Detect and surface Ollama-level `error` field in streamed responses (e.g. model doesn't support tools)
- Detect empty responses when tools were sent and surface a helpful error message suggesting `compat.supportsTools=false`
- Added `error?` field to `OllamaChatResponse` interface

### 4. Tests (`src/agents/ollama-stream.test.ts`)
- Test: Ollama error field is surfaced from streamed response
- Test: empty response with tools triggers helpful error message
- Test: empty response without tools does NOT trigger error (normal behavior)

## Usage

For Ollama models that don't support tools, add `supportsTools: false` to the model's compat config:

```json
{
  "models": {
    "providers": {
      "my-ollama": {
        "baseUrl": "http://127.0.0.1:11434",
        "api": "ollama",
        "models": [{
          "id": "tinyllama",
          "name": "TinyLlama",
          "compat": { "supportsTools": false }
        }]
      }
    }
  }
}
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses issue #15702 where Ollama models without tool/function calling support fail silently with `(no output)`. It makes two main changes:

- Adds a `compat.supportsTools` config flag that, when set to `false`, omits tools from API requests to the model. This is checked in `attempt.ts` alongside the existing `disableTools` flag, and the type + Zod schema are updated accordingly.
- Surfaces Ollama-level errors that were previously swallowed: (1) detects the `error` field in streamed NDJSON responses, and (2) detects empty responses when tools were sent, providing a helpful error message pointing users to the `compat.supportsTools=false` config.

Additionally, this PR changes `sanitizeAntigravityThinkingBlocks` to convert unsigned thinking blocks to text blocks instead of dropping them entirely, preserving reasoning content. This is a separate behavioral fix bundled into the same commit (from #15681).

Test coverage is thorough across all changes, with both unit tests and e2e integration tests.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk — changes are well-scoped, defensive, and backward-compatible.
- The config flag addition is backward-compatible (defaults to true). The Ollama error surfacing is a clear improvement over silent failures. The antigravity thinking block change preserves content that was previously lost. All changes have thorough test coverage. The `Record<string, unknown>` cast in attempt.ts is pragmatic given the external SDK type. No critical issues found.
- No files require special attention. The `src/agents/ollama-stream.ts` empty-response heuristic has a minor edge case with whitespace-only responses (already discussed in previous review threads), but this is unlikely to matter in practice.

<sub>Last reviewed commit: 3975256</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->