### PR TITLE
feat: add opencode-cli as CLI backend provider

### DIFF
--- a/docs/gateway/cli-backends.md
+++ b/docs/gateway/cli-backends.md
@@ -2,7 +2,7 @@
 summary: "CLI backends: text-only fallback via local AI CLIs"
 read_when:
   - You want a reliable fallback when API providers fail
-  - You are running Claude Code CLI or other local AI CLIs and want to reuse them
+  - You are running Claude Code CLI, OpenCode CLI, or other local AI CLIs and want to reuse them
   - You need a text-only, tool-free path that still supports sessions and images
 title: "CLI Backends"
 ---
@@ -32,6 +32,12 @@ Codex CLI also works out of the box:
 
 ```bash
 openclaw agent --message "hi" --model codex-cli/gpt-5.3-codex
+```
+
+OpenCode CLI is also supported:
+
+```bash
+openclaw agent --message "hi" --model opencode-cli/anthropic/claude-sonnet-4-5
 ```
 
 If your gateway runs under launchd/systemd and PATH is minimal, add just the
@@ -203,6 +209,23 @@ OpenClaw also ships a default for `codex-cli`:
 - `modelArg: "--model"`
 - `imageArg: "--image"`
 - `sessionMode: "existing"`
+
+OpenClaw also ships a default for `opencode-cli`:
+
+- `command: "opencode"`
+- `args: ["run", "--format", "json"]`
+- `resumeArgs: ["run", "--format", "json", "--session", "{sessionId}"]`
+- `output: "jsonl"`
+- `modelArg: "--model"`
+- `sessionArg: "--session"`
+- `sessionMode: "existing"`
+- `imageArg: "--file"`
+- `systemPromptArg: "--prompt"`
+- `systemPromptWhen: "first"`
+
+OpenCode CLI supports multiple providers (Anthropic, OpenAI, Google, DeepSeek, etc.).
+Use the full model path: `opencode-cli/anthropic/claude-sonnet-4-5`, `opencode-cli/openai/gpt-4o`,
+or `opencode-cli/gemini/gemini-2.5-pro`.
 
 Override only if needed (common: absolute `command` path).
 

--- a/src/agents/cli-backends.ts
+++ b/src/agents/cli-backends.ts
@@ -76,6 +76,56 @@ const DEFAULT_CODEX_BACKEND: CliBackendConfig = {
   serialize: true,
 };
 
+const OPENCODE_MODEL_ALIASES: Record<string, string> = {
+  // Anthropic models
+  "claude-sonnet-4": "anthropic/claude-sonnet-4",
+  "claude-sonnet-4-5": "anthropic/claude-sonnet-4-5",
+  "claude-opus-4": "anthropic/claude-opus-4",
+  "claude-opus-4-5": "anthropic/claude-opus-4-5",
+  // OpenAI models
+  "gpt-4o": "openai/gpt-4o",
+  "gpt-4o-mini": "openai/gpt-4o-mini",
+  "gpt-4-turbo": "openai/gpt-4-turbo",
+  // Google models
+  "gemini-2.5-pro": "gemini/gemini-2.5-pro",
+  "gemini-2.0-flash": "gemini/gemini-2.0-flash",
+  // DeepSeek models
+  "deepseek-chat": "deepseek/deepseek-chat",
+  "deepseek-reasoner": "deepseek/deepseek-reasoner",
+};
+
+const DEFAULT_OPENCODE_BACKEND: CliBackendConfig = {
+  command: "opencode",
+  args: ["run", "--format", "json"],
+  resumeArgs: ["run", "--format", "json", "--session", "{sessionId}"],
+  output: "jsonl",
+  input: "arg",
+  modelArg: "--model",
+  modelAliases: OPENCODE_MODEL_ALIASES,
+  sessionArg: "--session",
+  sessionMode: "existing",
+  sessionIdFields: ["sessionID"],
+  systemPromptArg: "--prompt",
+  systemPromptMode: "append",
+  systemPromptWhen: "first",
+  imageArg: "--file",
+  imageMode: "repeat",
+  clearEnv: [
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "GOOGLE_API_KEY",
+    "AZURE_OPENAI_API_KEY",
+    "OPENROUTER_API_KEY",
+    "GROQ_API_KEY",
+    "MISTRAL_API_KEY",
+    "PERPLEXITY_API_KEY",
+    "TOGETHER_API_KEY",
+    "XAI_API_KEY",
+    "DEEPSEEK_API_KEY",
+  ],
+  serialize: true,
+};
+
 function normalizeBackendKey(key: string): string {
   return normalizeProviderId(key);
 }
@@ -113,6 +163,7 @@ export function resolveCliBackendIds(cfg?: OpenClawConfig): Set<string> {
   const ids = new Set<string>([
     normalizeBackendKey("claude-cli"),
     normalizeBackendKey("codex-cli"),
+    normalizeBackendKey("opencode-cli"),
   ]);
   const configured = cfg?.agents?.defaults?.cliBackends ?? {};
   for (const key of Object.keys(configured)) {
@@ -139,6 +190,14 @@ export function resolveCliBackendConfig(
   }
   if (normalized === "codex-cli") {
     const merged = mergeBackendConfig(DEFAULT_CODEX_BACKEND, override);
+    const command = merged.command?.trim();
+    if (!command) {
+      return null;
+    }
+    return { id: normalized, config: { ...merged, command } };
+  }
+  if (normalized === "opencode-cli") {
+    const merged = mergeBackendConfig(DEFAULT_OPENCODE_BACKEND, override);
     const command = merged.command?.trim();
     if (!command) {
       return null;

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -386,6 +386,7 @@ export function parseCliJsonl(raw: string, backend: CliBackendConfig): CliOutput
       const type = typeof item.type === "string" ? item.type.toLowerCase() : "";
       if (!type || type.includes("message")) {
         texts.push(item.text);
+        continue;
       }
     }
     const part = isRecord(parsed.part) ? parsed.part : null;

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -388,6 +388,10 @@ export function parseCliJsonl(raw: string, backend: CliBackendConfig): CliOutput
         texts.push(item.text);
       }
     }
+    const part = isRecord(parsed.part) ? parsed.part : null;
+    if (part && typeof part.text === "string") {
+      texts.push(part.text);
+    }
   }
   const text = texts.join("\n").trim();
   if (!text) {

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -55,6 +55,9 @@ export function isCliProvider(provider: string, cfg?: OpenClawConfig): boolean {
   if (normalized === "codex-cli") {
     return true;
   }
+  if (normalized === "opencode-cli") {
+    return true;
+  }
   const backends = cfg?.agents?.defaults?.cliBackends ?? {};
   return Object.keys(backends).some((key) => normalizeProviderId(key) === normalized);
 }


### PR DESCRIPTION
## Summary

Add OpenCode CLI as a built-in CLI backend provider, enabling users to use OpenCode CLI models directly in OpenClaw.

OpenCode CLI is an open-source AI coding assistant that supports multiple LLM providers (Anthropic, OpenAI, Google, DeepSeek, etc.) with MCP support.

## Changes

### 1. Core Implementation (`src/agents/cli-backends.ts`)

- Added `OPENCODE_MODEL_ALIASES` for common model shortcuts
- Added `DEFAULT_OPENCODE_BACKEND` configuration:
  - Command: `opencode run --format json`
  - Session support: `--session` flag for continuity
  - Model selection: `--model` flag
  - Image support: `--file` flag
  - Output format: JSONL (streaming events)
  - Clears API keys from environment for security

- Updated `resolveCliBackendIds()` to include `opencode-cli`
- Updated `resolveCliBackendConfig()` to handle `opencode-cli` provider

### 2. Model Selection (`src/agents/model-selection.ts`)

- Added `opencode-cli` to `isCliProvider()` function

### 3. Documentation (`docs/gateway/cli-backends.md`)

- Added quick start example for OpenCode CLI
- Added default configuration documentation
- Updated read_when section

## Usage

```bash
# Quick start - no config needed
openclaw agent --message "hi" --model opencode-cli/anthropic/claude-sonnet-4-5

# Different providers
openclaw agent --message "hi" --model opencode-cli/openai/gpt-4o
openclaw agent --message "hi" --model opencode-cli/gemini/gemini-2.5-pro

# As fallback
{
  agents: {
    defaults: {
      model: {
        primary: "anthropic/claude-opus-4-6",
        fallbacks: ["opencode-cli/anthropic/claude-sonnet-4-5"],
      },
    },
  },
}
```

## Technical Details

OpenCode CLI JSON output format (verified):
```json
{"type":"step_start","sessionID":"ses_xxx",...}
{"type":"text","part":{"text":"response text",...}
{"type":"step_finish",...}
```

Session ID is extracted from `step_start.sessionID` field.

## Testing

- Verified OpenCode CLI JSON output format with `opencode run --format json`
- Configuration follows existing patterns from claude-cli and codex-cli backends

---

**Note**: This PR was created with AI assistance.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds OpenCode CLI as a third built-in CLI backend provider (alongside `claude-cli` and `codex-cli`). The implementation follows existing patterns closely: a new `DEFAULT_OPENCODE_BACKEND` config in `cli-backends.ts`, registration in `resolveCliBackendIds()` and `resolveCliBackendConfig()`, provider recognition in `isCliProvider()`, and JSONL parser support for OpenCode's `part.text` response format.

- Model aliases map short names (e.g. `claude-sonnet-4-5`) to OpenCode's `provider/model` format (e.g. `anthropic/claude-sonnet-4-5`), and full paths like `opencode-cli/anthropic/claude-sonnet-4-5` pass through correctly
- Session flow is sound: first call has no session (due to `sessionMode: "existing"`), session ID is extracted from `step_start.sessionID` in the response, subsequent calls use `resumeArgs` with `{sessionId}` substitution
- The `parseCliJsonl` extension correctly handles the previous thread's concern about `part.text` extraction
- `clearEnv` covers a broad set of API keys to prevent credential leakage to the subprocess
- Documentation additions are consistent with existing style

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it follows established patterns and the changes are additive with no modifications to existing behavior.
- The implementation closely follows the existing patterns for claude-cli and codex-cli backends. All four changed files are straightforward additions. The JSONL parser extension for `part.text` is the only shared-code change and it is additive (won't affect existing codex-cli parsing). No tests are broken since no unit tests exist for these modules. The session flow and arg-building logic were verified against the cli-runner code. Score is 4 rather than 5 because this is a new integration that would benefit from runtime verification with actual OpenCode CLI output.
- No files require special attention. The `src/agents/cli-runner/helpers.ts` change is the most impactful since it modifies shared JSONL parsing, but the addition is purely additive.

<sub>Last reviewed commit: 0fa1a34</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->