### PR TITLE
fix: convert unsigned thinking blocks to text to prevent signature error

### DIFF
--- a/package.json
+++ b/package.json
@@ -213,6 +213,9 @@
       "node-llama-cpp",
       "protobufjs",
       "sharp"
-    ]
+    ],
+    "patchedDependencies": {
+      "@mariozechner/pi-ai@0.52.10": "patches/@mariozechner__pi-ai@0.52.10.patch"
+    }
   }
 }

--- a/patches/@mariozechner__pi-ai@0.52.10.patch
+++ b/patches/@mariozechner__pi-ai@0.52.10.patch
@@ -1,0 +1,48 @@
+diff --git a/dist/providers/google-shared.js b/dist/providers/google-shared.js
+index 8886935a1258586a4ccd06ff6a9e0587d4aa4c11..e79d1eaff7de2a1deacf1e372b3a4d847119dd6e 100644
+--- a/dist/providers/google-shared.js
++++ b/dist/providers/google-shared.js
+@@ -118,15 +118,23 @@ export function convertMessages(model, context) {
+                     // Skip empty thinking blocks
+                     if (!block.thinking || block.thinking.trim() === "")
+                         continue;
+-                    // Only keep as thinking block if same provider AND same model
+-                    // Otherwise convert to plain text (no tags to avoid model mimicking them)
++                    // Only keep as thinking block if same provider AND same model AND has valid signature.
++                    // Without a valid signature, convert to plain text to prevent API errors
++                    // (e.g. Anthropic requires 'signature' field on thinking blocks via Antigravity proxy).
+                     if (isSameProviderAndModel) {
+                         const thoughtSignature = resolveThoughtSignature(isSameProviderAndModel, block.thinkingSignature);
+-                        parts.push({
+-                            thought: true,
+-                            text: sanitizeSurrogates(block.thinking),
+-                            ...(thoughtSignature && { thoughtSignature }),
+-                        });
++                        if (thoughtSignature) {
++                            parts.push({
++                                thought: true,
++                                text: sanitizeSurrogates(block.thinking),
++                                thoughtSignature,
++                            });
++                        }
++                        else {
++                            parts.push({
++                                text: sanitizeSurrogates(block.thinking),
++                            });
++                        }
+                     }
+                     else {
+                         parts.push({
+diff --git a/dist/providers/transform-messages.js b/dist/providers/transform-messages.js
+index 3d29acb1eea69db48ab6f60517b738087697b3d4..d59fc6cd3dc50fc2ad64ed32578b413a7d2bf741 100644
+--- a/dist/providers/transform-messages.js
++++ b/dist/providers/transform-messages.js
+@@ -35,8 +35,6 @@ export function transformMessages(messages, model, normalizeToolCallId) {
+                     // Skip empty thinking blocks, convert others to plain text
+                     if (!block.thinking || block.thinking.trim() === "")
+                         return [];
+-                    if (isSameModel)
+-                        return block;
+                     return {
+                         type: "text",
+                         text: block.thinking,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,11 @@ overrides:
   tar: 7.5.7
   tough-cookie: 4.1.3
 
+patchedDependencies:
+  '@mariozechner/pi-ai@0.52.10':
+    hash: e5895eac1ab4c0d6ff67e16ff366ba19a255e400832f277b48a5e095acb96ee5
+    path: patches/@mariozechner__pi-ai@0.52.10.patch
+
 importers:
 
   .:
@@ -51,7 +56,7 @@ importers:
         version: 0.52.10(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-ai':
         specifier: 0.52.10
-        version: 0.52.10(ws@8.19.0)(zod@4.3.6)
+        version: 0.52.10(patch_hash=e5895eac1ab4c0d6ff67e16ff366ba19a255e400832f277b48a5e095acb96ee5)(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-coding-agent':
         specifier: 0.52.10
         version: 0.52.10(ws@8.19.0)(zod@4.3.6)
@@ -6845,7 +6850,7 @@ snapshots:
 
   '@larksuiteoapi/node-sdk@1.59.0':
     dependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       lodash.identity: 3.0.0
       lodash.merge: 4.6.2
       lodash.pickby: 4.6.0
@@ -6861,7 +6866,7 @@ snapshots:
     dependencies:
       '@types/node': 24.10.13
     optionalDependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
     transitivePeerDependencies:
       - debug
 
@@ -6958,7 +6963,7 @@ snapshots:
 
   '@mariozechner/pi-agent-core@0.52.10(ws@8.19.0)(zod@4.3.6)':
     dependencies:
-      '@mariozechner/pi-ai': 0.52.10(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.52.10(patch_hash=e5895eac1ab4c0d6ff67e16ff366ba19a255e400832f277b48a5e095acb96ee5)(ws@8.19.0)(zod@4.3.6)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -6968,7 +6973,7 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-ai@0.52.10(ws@8.19.0)(zod@4.3.6)':
+  '@mariozechner/pi-ai@0.52.10(patch_hash=e5895eac1ab4c0d6ff67e16ff366ba19a255e400832f277b48a5e095acb96ee5)(ws@8.19.0)(zod@4.3.6)':
     dependencies:
       '@anthropic-ai/sdk': 0.73.0(zod@4.3.6)
       '@aws-sdk/client-bedrock-runtime': 3.989.0
@@ -6996,7 +7001,7 @@ snapshots:
     dependencies:
       '@mariozechner/jiti': 2.6.5
       '@mariozechner/pi-agent-core': 0.52.10(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.52.10(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.52.10(patch_hash=e5895eac1ab4c0d6ff67e16ff366ba19a255e400832f277b48a5e095acb96ee5)(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-tui': 0.52.10
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
@@ -7064,7 +7069,7 @@ snapshots:
       '@azure/core-auth': 1.10.1
       '@azure/msal-node': 3.8.7
       '@microsoft/agents-activity': 1.2.3
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       jsonwebtoken: 9.0.3
       jwks-rsa: 3.2.2
       object-path: 0.11.8
@@ -8011,7 +8016,7 @@ snapshots:
       '@slack/types': 2.20.0
       '@slack/web-api': 7.14.0
       '@types/express': 5.0.6
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       express: 5.2.1
       path-to-regexp: 8.3.0
       raw-body: 3.0.2
@@ -8057,7 +8062,7 @@ snapshots:
       '@slack/types': 2.20.0
       '@types/node': 25.2.3
       '@types/retry': 0.12.0
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       eventemitter3: 5.0.4
       form-data: 2.5.4
       is-electron: 2.2.2
@@ -8951,14 +8956,6 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  axios@1.13.5:
-    dependencies:
-      follow-redirects: 1.15.11
-      form-data: 2.5.4
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
   axios@1.13.5(debug@4.4.3):
     dependencies:
       follow-redirects: 1.15.11(debug@4.4.3)
@@ -9541,8 +9538,6 @@ snapshots:
       array-back: 3.1.0
 
   flatbuffers@24.12.23: {}
-
-  follow-redirects@1.15.11: {}
 
   follow-redirects@1.15.11(debug@4.4.3):
     optionalDependencies:

--- a/src/providers/google-shared.unsigned-thinking-blocks.test.ts
+++ b/src/providers/google-shared.unsigned-thinking-blocks.test.ts
@@ -1,0 +1,213 @@
+import type { Context, Model } from "@mariozechner/pi-ai/dist/types.js";
+import { convertMessages } from "@mariozechner/pi-ai/dist/providers/google-shared.js";
+import { describe, expect, it } from "vitest";
+
+type GeminiPart = {
+  text?: string;
+  thought?: boolean;
+  thoughtSignature?: string;
+  functionCall?: { name: string; args?: Record<string, unknown> };
+};
+
+const makeModel = (id: string, provider = "google-antigravity"): Model<"google-generative-ai"> =>
+  ({
+    id,
+    name: id,
+    api: "google-generative-ai",
+    provider,
+    baseUrl: "https://example.invalid",
+    reasoning: false,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 1,
+    maxTokens: 1,
+  }) as Model<"google-generative-ai">;
+
+const makeAssistantMessage = (
+  content: Array<Record<string, unknown>>,
+  overrides: Record<string, unknown> = {},
+) => ({
+  role: "assistant",
+  content,
+  api: "google-generative-ai",
+  provider: "google-antigravity",
+  model: "claude-opus-4-6-thinking",
+  usage: {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 0,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  },
+  stopReason: "stop",
+  timestamp: 0,
+  ...overrides,
+});
+
+describe("google-shared convertMessages unsigned thinking blocks (#15681)", () => {
+  it("converts unsigned thinking blocks to plain text for same provider/model", () => {
+    const model = makeModel("claude-opus-4-6-thinking");
+    const context = {
+      messages: [
+        { role: "user", content: "Hello" },
+        makeAssistantMessage([
+          { type: "thinking", thinking: "Let me reason about this..." },
+          { type: "text", text: "Here is my response" },
+        ]),
+      ],
+    } as unknown as Context;
+
+    const contents = convertMessages(model, context);
+    const modelTurn = contents.find((c) => c.role === "model");
+    expect(modelTurn).toBeTruthy();
+
+    const parts = modelTurn!.parts as GeminiPart[];
+
+    // No parts should have thought: true without a valid signature
+    const thoughtParts = parts.filter((p) => p.thought === true);
+    expect(thoughtParts).toHaveLength(0);
+
+    // The thinking content should appear as plain text
+    const textParts = parts.filter((p) => p.text && !p.thought);
+    expect(textParts.some((p) => p.text === "Let me reason about this...")).toBe(true);
+    expect(textParts.some((p) => p.text === "Here is my response")).toBe(true);
+  });
+
+  it("keeps signed thinking blocks as thought:true with signature", () => {
+    const model = makeModel("claude-opus-4-6-thinking");
+    // Valid base64 signature (must be divisible by 4 and match base64 pattern)
+    const validSignature = "dGVzdHNpZ25hdHVyZQ==";
+    const context = {
+      messages: [
+        { role: "user", content: "Hello" },
+        makeAssistantMessage([
+          {
+            type: "thinking",
+            thinking: "Signed reasoning",
+            thinkingSignature: validSignature,
+          },
+          { type: "text", text: "Response" },
+        ]),
+      ],
+    } as unknown as Context;
+
+    const contents = convertMessages(model, context);
+    const modelTurn = contents.find((c) => c.role === "model");
+    const parts = modelTurn!.parts as GeminiPart[];
+
+    // Signed thinking block should be kept with thought: true
+    const thoughtParts = parts.filter((p) => p.thought === true);
+    expect(thoughtParts).toHaveLength(1);
+    expect(thoughtParts[0].text).toBe("Signed reasoning");
+    expect(thoughtParts[0].thoughtSignature).toBe(validSignature);
+  });
+
+  it("converts thinking blocks with invalid signatures to text", () => {
+    const model = makeModel("claude-opus-4-6-thinking");
+    const context = {
+      messages: [
+        { role: "user", content: "Hello" },
+        makeAssistantMessage([
+          {
+            type: "thinking",
+            thinking: "Reasoning with bad sig",
+            // Not valid base64 (odd length)
+            thinkingSignature: "not-valid-base64!",
+          },
+          { type: "text", text: "Response" },
+        ]),
+      ],
+    } as unknown as Context;
+
+    const contents = convertMessages(model, context);
+    const modelTurn = contents.find((c) => c.role === "model");
+    const parts = modelTurn!.parts as GeminiPart[];
+
+    // Invalid signature should cause conversion to plain text
+    const thoughtParts = parts.filter((p) => p.thought === true);
+    expect(thoughtParts).toHaveLength(0);
+
+    const textParts = parts.filter((p) => p.text && !p.thought);
+    expect(textParts.some((p) => p.text === "Reasoning with bad sig")).toBe(true);
+  });
+
+  it("skips empty thinking blocks", () => {
+    const model = makeModel("claude-opus-4-6-thinking");
+    const context = {
+      messages: [
+        { role: "user", content: "Hello" },
+        makeAssistantMessage([
+          { type: "thinking", thinking: "" },
+          { type: "thinking", thinking: "   " },
+          { type: "text", text: "Response" },
+        ]),
+      ],
+    } as unknown as Context;
+
+    const contents = convertMessages(model, context);
+    const modelTurn = contents.find((c) => c.role === "model");
+    const parts = modelTurn!.parts as GeminiPart[];
+
+    // Empty thinking blocks should be skipped entirely
+    expect(parts).toHaveLength(1);
+    expect(parts[0].text).toBe("Response");
+  });
+
+  it("handles multiple unsigned thinking blocks across turns", () => {
+    const model = makeModel("claude-opus-4-6-thinking");
+    const context = {
+      messages: [
+        { role: "user", content: "First question" },
+        makeAssistantMessage([
+          { type: "thinking", thinking: "First reasoning" },
+          { type: "text", text: "First answer" },
+        ]),
+        { role: "user", content: "Second question" },
+        makeAssistantMessage([
+          { type: "thinking", thinking: "Second reasoning" },
+          { type: "text", text: "Second answer" },
+        ]),
+      ],
+    } as unknown as Context;
+
+    const contents = convertMessages(model, context);
+
+    // No thought:true parts anywhere
+    const allParts = contents.flatMap((c) => (c.parts ?? []) as GeminiPart[]);
+    const thoughtParts = allParts.filter((p) => p.thought === true);
+    expect(thoughtParts).toHaveLength(0);
+
+    // All thinking content should be plain text
+    const textParts = allParts.filter((p) => typeof p.text === "string" && !p.thought);
+    expect(textParts.some((p) => p.text === "First reasoning")).toBe(true);
+    expect(textParts.some((p) => p.text === "Second reasoning")).toBe(true);
+  });
+
+  it("converts unsigned thinking from different provider to text", () => {
+    const model = makeModel("gemini-2.0-flash", "google");
+    const context = {
+      messages: [
+        { role: "user", content: "Hello" },
+        makeAssistantMessage(
+          [
+            { type: "thinking", thinking: "Claude reasoning" },
+            { type: "text", text: "Claude response" },
+          ],
+          {
+            provider: "google-antigravity",
+            model: "claude-opus-4-6-thinking",
+          },
+        ),
+      ],
+    } as unknown as Context;
+
+    const contents = convertMessages(model, context);
+    const modelTurn = contents.find((c) => c.role === "model");
+    const parts = modelTurn!.parts as GeminiPart[];
+
+    // Different model: should always convert to text
+    const thoughtParts = parts.filter((p) => p.thought === true);
+    expect(thoughtParts).toHaveLength(0);
+  });
+});

--- a/src/providers/transform-messages.unsigned-thinking.test.ts
+++ b/src/providers/transform-messages.unsigned-thinking.test.ts
@@ -1,0 +1,193 @@
+import type { Api, Message, Model } from "@mariozechner/pi-ai/dist/types.js";
+import { transformMessages } from "@mariozechner/pi-ai/dist/providers/transform-messages.js";
+import { describe, expect, it } from "vitest";
+
+const makeModel = <T extends Api>(api: T, provider: string, id: string): Model<T> =>
+  ({
+    id,
+    name: id,
+    api,
+    provider,
+    baseUrl: "https://example.invalid",
+    reasoning: false,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 1,
+    maxTokens: 1,
+  }) as Model<T>;
+
+describe("transformMessages unsigned thinking blocks (#15681)", () => {
+  it("converts unsigned thinking blocks to text even when isSameModel", () => {
+    const model = makeModel(
+      "google-generative-ai",
+      "google-antigravity",
+      "claude-opus-4-6-thinking",
+    );
+    const messages: Message[] = [
+      { role: "user", content: "Hello" },
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "Let me think about this..." },
+          { type: "text", text: "Hi there!" },
+        ],
+        api: "google-generative-ai",
+        provider: "google-antigravity",
+        model: "claude-opus-4-6-thinking",
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: "stop",
+        timestamp: 0,
+      } as unknown as Message,
+    ];
+
+    const result = transformMessages(messages, model);
+    const assistant = result.find((m) => m.role === "assistant") as Extract<
+      Message,
+      { role: "assistant" }
+    >;
+
+    // Unsigned thinking block should be converted to text, not kept as type "thinking"
+    const thinkingBlocks = assistant.content.filter((b: { type: string }) => b.type === "thinking");
+    expect(thinkingBlocks).toHaveLength(0);
+
+    const textBlocks = assistant.content.filter((b: { type: string }) => b.type === "text");
+    expect(textBlocks).toHaveLength(2);
+    expect((textBlocks[0] as { text: string }).text).toBe("Let me think about this...");
+    expect((textBlocks[1] as { text: string }).text).toBe("Hi there!");
+  });
+
+  it("keeps signed thinking blocks for same model", () => {
+    const model = makeModel(
+      "google-generative-ai",
+      "google-antigravity",
+      "claude-opus-4-6-thinking",
+    );
+    const messages: Message[] = [
+      { role: "user", content: "Hello" },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "thinking",
+            thinking: "Let me think...",
+            thinkingSignature: "dGVzdHNpZw==",
+          },
+          { type: "text", text: "Hi!" },
+        ],
+        api: "google-generative-ai",
+        provider: "google-antigravity",
+        model: "claude-opus-4-6-thinking",
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: "stop",
+        timestamp: 0,
+      } as unknown as Message,
+    ];
+
+    const result = transformMessages(messages, model);
+    const assistant = result.find((m) => m.role === "assistant") as Extract<
+      Message,
+      { role: "assistant" }
+    >;
+
+    // Signed thinking blocks should be preserved
+    const thinkingBlocks = assistant.content.filter((b: { type: string }) => b.type === "thinking");
+    expect(thinkingBlocks).toHaveLength(1);
+    expect((thinkingBlocks[0] as { thinking: string }).thinking).toBe("Let me think...");
+  });
+
+  it("skips empty unsigned thinking blocks for same model", () => {
+    const model = makeModel(
+      "google-generative-ai",
+      "google-antigravity",
+      "claude-opus-4-6-thinking",
+    );
+    const messages: Message[] = [
+      { role: "user", content: "Hello" },
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "   " },
+          { type: "text", text: "Hi!" },
+        ],
+        api: "google-generative-ai",
+        provider: "google-antigravity",
+        model: "claude-opus-4-6-thinking",
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: "stop",
+        timestamp: 0,
+      } as unknown as Message,
+    ];
+
+    const result = transformMessages(messages, model);
+    const assistant = result.find((m) => m.role === "assistant") as Extract<
+      Message,
+      { role: "assistant" }
+    >;
+
+    // Empty thinking blocks should be skipped entirely
+    expect(assistant.content).toHaveLength(1);
+    expect((assistant.content[0] as { type: string }).type).toBe("text");
+  });
+
+  it("converts unsigned thinking blocks to text for different model", () => {
+    const model = makeModel("google-generative-ai", "google", "gemini-2.0-flash");
+    const messages: Message[] = [
+      { role: "user", content: "Hello" },
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "Some reasoning" },
+          { type: "text", text: "Response" },
+        ],
+        api: "google-generative-ai",
+        provider: "google-antigravity",
+        model: "claude-opus-4-6-thinking",
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: "stop",
+        timestamp: 0,
+      } as unknown as Message,
+    ];
+
+    const result = transformMessages(messages, model);
+    const assistant = result.find((m) => m.role === "assistant") as Extract<
+      Message,
+      { role: "assistant" }
+    >;
+
+    // Different model: unsigned thinking blocks should still be converted to text
+    const thinkingBlocks = assistant.content.filter((b: { type: string }) => b.type === "thinking");
+    expect(thinkingBlocks).toHaveLength(0);
+
+    const textBlocks = assistant.content.filter((b: { type: string }) => b.type === "text");
+    expect(textBlocks).toHaveLength(2);
+    expect((textBlocks[0] as { text: string }).text).toBe("Some reasoning");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #15681

When using Claude thinking models via the `google-antigravity` provider, accumulated thinking blocks in session history cause API failures with `thinking.signature: Field required`. This happens because:

1. **`transform-messages.ts`**: When `isSameModel` is true, thinking blocks without `thinkingSignature` are kept as `type: "thinking"` instead of being converted to plain text.
2. **`google-shared.ts` `convertMessages()`**: Sends `thought: true` without `thoughtSignature` to the Google Cloud Code Assist API. The Antigravity proxy does not map the missing `thoughtSignature` to Anthropic's required `signature` field, causing rejection.

## Changes

Patches `@mariozechner/pi-ai@0.52.10` (via `pnpm patch`):

### `transform-messages.js`
- Remove the fallback that keeps unsigned thinking blocks as `type: "thinking"` when `isSameModel` is true
- Unsigned thinking blocks are now always converted to `type: "text"`, regardless of model match
- Signed thinking blocks (with `thinkingSignature`) are still preserved for replay

### `google-shared.js` `convertMessages()`
- When `isSameProviderAndModel` is true but `resolveThoughtSignature()` returns no valid signature, convert the thinking block to plain text instead of sending `thought: true` without `thoughtSignature`
- This prevents the Antigravity proxy from forwarding unsigned thinking blocks to Anthropic

### Tests
- `transform-messages.unsigned-thinking.test.ts` — 4 tests covering unsigned/signed/empty thinking block handling
- `google-shared.unsigned-thinking-blocks.test.ts` — 6 tests covering `convertMessages` behavior for unsigned, signed, invalid-signature, empty, multi-turn, and cross-provider scenarios

All 10 new tests pass. All 31 existing provider tests still pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes API failures when using Claude thinking models via the `google-antigravity` provider (#15681). The root cause was that unsigned thinking blocks (without `thinkingSignature`) were being sent to the Anthropic API via the Antigravity proxy, which requires the `signature` field on all thinking blocks.

The fix is applied as a `pnpm patch` to `@mariozechner/pi-ai@0.52.10`, modifying two files:

- **`transform-messages.js`**: Removes the `if (isSameModel) return block;` fallback that preserved unsigned thinking blocks as `type: "thinking"`. Signed blocks (with `thinkingSignature`) are still preserved via the earlier guard at line 32. Unsigned blocks now always convert to `type: "text"`.
- **`google-shared.js`**: Adds an explicit check — when `resolveThoughtSignature()` returns no valid signature, the thinking block is converted to plain text instead of being sent with `thought: true` but without `thoughtSignature`.

- 10 new tests cover unsigned, signed, invalid-signature, empty, multi-turn, and cross-provider scenarios across both patched functions
- The lockfile includes minor `axios`/`follow-redirects` deduplication changes as a side effect of running `pnpm install`

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — the patch correctly addresses a targeted API compatibility bug with defensive changes and thorough test coverage.
- Score of 4 reflects: (1) the patch logic is correct — signed blocks are still preserved by existing guards while unsigned blocks are safely converted to text, (2) 10 new tests cover the key scenarios comprehensively, (3) the change is narrowly scoped to a specific bug fix with no functional regression risk to other providers. Deducted 1 point because patching a dependency introduces maintenance overhead — this fix should ideally be upstreamed.
- The `patches/@mariozechner__pi-ai@0.52.10.patch` file should be tracked as a maintenance item — this patch will need to be verified or removed when `@mariozechner/pi-ai` is upgraded.

<sub>Last reviewed commit: c2bd83c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->