### PR TITLE
fix: implement model aliases for /model command

### DIFF
--- a/src/config/legacy.migrations.aliases.test.ts
+++ b/src/config/legacy.migrations.aliases.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { applyLegacyMigrations } from "./legacy.js";
+
+describe("aliases migration", () => {
+  it("migrates top-level aliases to agents.defaults.models.*.alias", () => {
+    const raw = {
+      aliases: {
+        fast: "ollama/minimax-m2.5:cloud",
+        deep: "ollama/kimi-k2.5:cloud",
+      },
+    };
+
+    const { next, changes } = applyLegacyMigrations(raw);
+
+    expect(next).not.toBeNull();
+    expect(next?.aliases).toBeUndefined();
+    expect(next?.agents?.defaults?.models?.["ollama/minimax-m2.5:cloud"]?.alias).toBe("fast");
+    expect(next?.agents?.defaults?.models?.["ollama/kimi-k2.5:cloud"]?.alias).toBe("deep");
+    expect(changes).toContain("Migrated aliases → agents.defaults.models.*.alias.");
+  });
+
+  it("does not overwrite existing alias", () => {
+    const raw = {
+      aliases: {
+        fast: "ollama/minimax-m2.5:cloud",
+      },
+      agents: {
+        defaults: {
+          models: {
+            "ollama/minimax-m2.5:cloud": { alias: "minimax" },
+          },
+        },
+      },
+    };
+
+    const { next } = applyLegacyMigrations(raw);
+
+    expect(next).not.toBeNull();
+    // Existing alias should be preserved
+    expect(next?.agents?.defaults?.models?.["ollama/minimax-m2.5:cloud"]?.alias).toBe("minimax");
+  });
+
+  it("handles empty aliases", () => {
+    const raw = {
+      aliases: {},
+    };
+
+    const { next, changes } = applyLegacyMigrations(raw);
+
+    // No migration should happen for empty aliases
+    expect(next).toBeNull();
+    expect(changes).toHaveLength(0);
+  });
+
+  it("handles aliases with invalid values", () => {
+    const raw = {
+      aliases: {
+        fast: "ollama/minimax-m2.5:cloud",
+        invalid: 123, // Should be skipped
+        empty: "", // Should be skipped
+      },
+    };
+
+    const { next } = applyLegacyMigrations(raw);
+
+    expect(next).not.toBeNull();
+    expect(next?.agents?.defaults?.models?.["ollama/minimax-m2.5:cloud"]?.alias).toBe("fast");
+    // Invalid entries should not create model entries
+    expect(Object.keys(next?.agents?.defaults?.models ?? {})).toHaveLength(1);
+  });
+
+  it("preserves other config when migrating aliases", () => {
+    const raw = {
+      aliases: {
+        opus: "anthropic/claude-opus-4-6",
+      },
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-sonnet-4-5" },
+        },
+      },
+      env: {
+        ANTHROPIC_API_KEY: "sk-test",
+      },
+    };
+
+    const { next } = applyLegacyMigrations(raw);
+
+    expect(next).not.toBeNull();
+    expect(next?.aliases).toBeUndefined();
+    expect(next?.agents?.defaults?.model?.primary).toBe("anthropic/claude-sonnet-4-5");
+    expect(next?.agents?.defaults?.models?.["anthropic/claude-opus-4-6"]?.alias).toBe("opus");
+    expect(next?.env?.ANTHROPIC_API_KEY).toBe("sk-test");
+  });
+});

--- a/src/config/legacy.rules.ts
+++ b/src/config/legacy.rules.ts
@@ -133,4 +133,8 @@ export const LEGACY_CONFIG_RULES: LegacyConfigRule[] = [
     path: ["gateway", "token"],
     message: "gateway.token is ignored; use gateway.auth.token instead (auto-migrated on load).",
   },
+  {
+    path: ["aliases"],
+    message: "aliases was replaced by agents.defaults.models.*.alias (auto-migrated on load).",
+  },
 ];

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -32,6 +32,11 @@ export type OpenClawConfig = {
     /** ISO timestamp when this config was last written. */
     lastTouchedAt?: string;
   };
+  /**
+   * Convenience aliases for model selection (migrated to agents.defaults.models.*.alias).
+   * Example: { "fast": "ollama/minimax-m2.5:cloud" } allows /model fast
+   */
+  aliases?: Record<string, string>;
   auth?: AuthConfig;
   env?: {
     /** Opt-in: import missing secrets from a login shell environment (exec `$SHELL -l -c 'env -0'`). */


### PR DESCRIPTION
## Summary

Adds support for a top-level `aliases` config key as a convenience alternative to `agents.defaults.models.*.alias`. This allows users to define model shortcuts in a more intuitive format.

## Changes

- Added `aliases` property to `OpenClawConfig` type
- Added legacy migration to convert top-level `aliases` to `agents.defaults.models.*.alias`
- Added legacy rule for deprecation warning
- Added unit tests for the new migration

## Testing

- All 382 existing tests pass
- Added 5 new tests specifically for the aliases migration
- Build completes successfully

## Example Usage

Users can now define aliases like:
```json
{
  "aliases": {
    "fast": "ollama/minimax-m2.5:cloud",
    "deep": "ollama/kimi-k2.5:cloud"
  }
}
```

Then use `/model fast` instead of `/model ollama/minimax-m2.5:cloud`.

The aliases are automatically migrated to the internal format on load, so the existing implementation continues to work.

Fixes openclaw/openclaw#16074

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a top-level `aliases` config key as a shorthand for defining model aliases, which are then auto-migrated to the canonical `agents.defaults.models.*.alias` format on config load. The implementation includes a new legacy migration, a deprecation rule, a type definition update, and thorough tests.

- The migration correctly handles existing aliases (no overwrite), invalid values (non-string/empty), and preserves surrounding config.
- One edge case: the migration reports a change and deletes `raw.aliases` even when **all** entries are invalid, causing an unnecessary config rewrite. A `migrated` flag would fix this.
- Test coverage is solid with 5 new cases covering the happy path, conflict preservation, empty input, invalid values, and config preservation.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk; the flagged edge case only causes a spurious no-op config rewrite, not data loss.
- The migration logic is straightforward and follows established patterns in the codebase. The one issue found (reporting a change when all entries are invalid) is a minor correctness bug that won't cause data loss — it just triggers an unnecessary config file rewrite. Tests are thorough but miss this specific edge case.
- `src/config/legacy.migrations.part-2.ts` — the aliases migration has an edge case where all-invalid entries still trigger a config rewrite.

<sub>Last reviewed commit: 7e590eb</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->