### PR TITLE
fix: handle message_reaction updates in group polling mode

### DIFF
--- a/src/telegram/bot.create-telegram-bot.does-not-skip-group-reactions-due-to-concurrent-update-offset.test.ts
+++ b/src/telegram/bot.create-telegram-bot.does-not-skip-group-reactions-due-to-concurrent-update-offset.test.ts
@@ -1,0 +1,307 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetInboundDedupe } from "../auto-reply/reply/inbound-dedupe.js";
+import { createTelegramBot } from "./bot.js";
+
+const { sessionStorePath } = vi.hoisted(() => ({
+  sessionStorePath: `/tmp/openclaw-telegram-${Math.random().toString(16).slice(2)}.json`,
+}));
+
+const { loadWebMedia } = vi.hoisted(() => ({
+  loadWebMedia: vi.fn(),
+}));
+
+vi.mock("../web/media.js", () => ({
+  loadWebMedia,
+}));
+
+const { loadConfig } = vi.hoisted(() => ({
+  loadConfig: vi.fn(() => ({})),
+}));
+vi.mock("../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/config.js")>();
+  return {
+    ...actual,
+    loadConfig,
+  };
+});
+
+vi.mock("../config/sessions.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/sessions.js")>();
+  return {
+    ...actual,
+    resolveStorePath: vi.fn((storePath) => storePath ?? sessionStorePath),
+  };
+});
+
+const { readChannelAllowFromStore } = vi.hoisted(() => ({
+  readChannelAllowFromStore: vi.fn(async () => [] as string[]),
+}));
+
+vi.mock("../pairing/pairing-store.js", () => ({
+  readChannelAllowFromStore,
+  upsertChannelPairingRequest: vi.fn(async () => ({
+    code: "PAIRCODE",
+    created: true,
+  })),
+}));
+
+const { enqueueSystemEvent } = vi.hoisted(() => ({
+  enqueueSystemEvent: vi.fn(),
+}));
+vi.mock("../infra/system-events.js", () => ({
+  enqueueSystemEvent,
+}));
+
+const { wasSentByBot } = vi.hoisted(() => ({
+  wasSentByBot: vi.fn(() => false),
+}));
+vi.mock("./sent-message-cache.js", () => ({
+  wasSentByBot,
+  recordSentMessage: vi.fn(),
+  clearSentMessageCache: vi.fn(),
+}));
+
+const useSpy = vi.fn();
+const middlewareUseSpy = vi.fn();
+const onSpy = vi.fn();
+const stopSpy = vi.fn();
+const commandSpy = vi.fn();
+const answerCallbackQuerySpy = vi.fn(async () => undefined);
+const sendChatActionSpy = vi.fn();
+const setMessageReactionSpy = vi.fn(async () => undefined);
+const setMyCommandsSpy = vi.fn(async () => undefined);
+const sendMessageSpy = vi.fn(async () => ({ message_id: 77 }));
+const sendAnimationSpy = vi.fn(async () => ({ message_id: 78 }));
+const sendPhotoSpy = vi.fn(async () => ({ message_id: 79 }));
+
+vi.mock("grammy", () => ({
+  Bot: class {
+    api = {
+      config: { use: useSpy },
+      answerCallbackQuery: answerCallbackQuerySpy,
+      sendChatAction: sendChatActionSpy,
+      setMessageReaction: setMessageReactionSpy,
+      setMyCommands: setMyCommandsSpy,
+      sendMessage: sendMessageSpy,
+      sendAnimation: sendAnimationSpy,
+      sendPhoto: sendPhotoSpy,
+    };
+    use = middlewareUseSpy;
+    on = onSpy;
+    stop = stopSpy;
+    command = commandSpy;
+    catch = vi.fn();
+    constructor(
+      public token: string,
+      public options?: { client?: { fetch?: typeof fetch } },
+    ) {}
+  },
+  InputFile: class {},
+  webhookCallback: vi.fn(),
+}));
+
+vi.mock("@grammyjs/runner", () => ({
+  sequentialize: () => vi.fn(),
+}));
+
+vi.mock("@grammyjs/transformer-throttler", () => ({
+  apiThrottler: () => vi.fn(),
+}));
+
+vi.mock("../auto-reply/reply.js", () => {
+  const replySpy = vi.fn(async (_ctx, opts) => {
+    await opts?.onReplyStart?.();
+    return undefined;
+  });
+  return { getReplyFromConfig: replySpy, __replySpy: replySpy };
+});
+
+let replyModule: typeof import("../auto-reply/reply.js");
+
+const getOnHandler = (event: string) => {
+  const handler = onSpy.mock.calls.find((call) => call[0] === event)?.[1];
+  if (!handler) {
+    throw new Error(`Missing handler for event: ${event}`);
+  }
+  return handler as (ctx: Record<string, unknown>) => Promise<void>;
+};
+
+describe("createTelegramBot", () => {
+  beforeAll(async () => {
+    replyModule = await import("../auto-reply/reply.js");
+  });
+
+  beforeEach(() => {
+    resetInboundDedupe();
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: { dmPolicy: "open", reactionNotifications: "all" },
+      },
+    });
+    onSpy.mockReset();
+    enqueueSystemEvent.mockReset();
+    wasSentByBot.mockReset();
+    middlewareUseSpy.mockReset();
+  });
+
+  it("does not skip group reactions due to concurrent update offset advancement", async () => {
+    // Simulate the race condition: bot starts with persisted offset 99.
+    // A message in chat B (update_id 102) would complete before reaction in
+    // chat A (update_id 101) due to concurrent sequentialize keys.
+    // Before the fix, the runtime-advancing lastUpdateId reached 102 and
+    // caused the reaction (101) to be skipped.  After the fix, only the
+    // initial persisted offset (99) is used, so 101 > 99 → not skipped.
+    createTelegramBot({
+      token: "tok",
+      updateOffset: {
+        lastUpdateId: 99,
+        onUpdateId: vi.fn(),
+      },
+    });
+
+    const reactionHandler = getOnHandler("message_reaction");
+    const messageHandler = getOnHandler("message");
+
+    // First: a message from chat B completes (update_id 102 > initial 99)
+    const replySpy = replyModule.__replySpy as unknown as ReturnType<typeof vi.fn>;
+    replySpy.mockReset();
+
+    await messageHandler({
+      update: { update_id: 102 },
+      message: {
+        chat: { id: -200, type: "supergroup", title: "Chat B" },
+        from: { id: 5, username: "user5" },
+        text: "hello from B",
+        date: 1736380800,
+        message_id: 1,
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({}),
+    });
+
+    // Now: the group reaction from chat A (update_id 101) arrives.
+    // Before the fix this would be skipped because 101 <= lastUpdateId (102).
+    await reactionHandler({
+      update: { update_id: 101 },
+      messageReaction: {
+        chat: { id: -100, type: "supergroup" },
+        message_id: 42,
+        user: { id: 9, first_name: "Ada" },
+        date: 1736380800,
+        old_reaction: [],
+        new_reaction: [{ type: "emoji", emoji: "👍" }],
+      },
+    });
+
+    expect(enqueueSystemEvent).toHaveBeenCalledTimes(1);
+    expect(enqueueSystemEvent).toHaveBeenCalledWith(
+      expect.stringContaining("👍"),
+      expect.objectContaining({
+        contextKey: expect.stringContaining("telegram:reaction:add:-100:42:9"),
+      }),
+    );
+  });
+
+  it("still skips updates at or below the persisted initial offset (crash recovery)", async () => {
+    createTelegramBot({
+      token: "tok",
+      updateOffset: {
+        lastUpdateId: 200,
+        onUpdateId: vi.fn(),
+      },
+    });
+
+    const reactionHandler = getOnHandler("message_reaction");
+
+    // Reaction with update_id 200 (equal to persisted offset) should be skipped
+    await reactionHandler({
+      update: { update_id: 200 },
+      messageReaction: {
+        chat: { id: -100, type: "supergroup" },
+        message_id: 50,
+        user: { id: 9, first_name: "Ada" },
+        date: 1736380800,
+        old_reaction: [],
+        new_reaction: [{ type: "emoji", emoji: "🔥" }],
+      },
+    });
+
+    expect(enqueueSystemEvent).not.toHaveBeenCalled();
+
+    // Reaction with update_id 150 (below persisted offset) should also be skipped
+    await reactionHandler({
+      update: { update_id: 150 },
+      messageReaction: {
+        chat: { id: -100, type: "supergroup" },
+        message_id: 51,
+        user: { id: 9, first_name: "Ada" },
+        date: 1736380800,
+        old_reaction: [],
+        new_reaction: [{ type: "emoji", emoji: "❤️" }],
+      },
+    });
+
+    expect(enqueueSystemEvent).not.toHaveBeenCalled();
+  });
+
+  it("does not skip group messages due to concurrent update offset advancement", async () => {
+    // The same race condition also affects regular messages—verify they
+    // are not skipped when a cross-chat update advances the offset.
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: {
+          dmPolicy: "open",
+          reactionNotifications: "all",
+          groupPolicy: "open",
+          groups: { "*": { requireMention: false } },
+        },
+      },
+    });
+
+    createTelegramBot({
+      token: "tok",
+      updateOffset: {
+        lastUpdateId: 99,
+        onUpdateId: vi.fn(),
+      },
+    });
+
+    const messageHandler = getOnHandler("message");
+    const replySpy = replyModule.__replySpy as unknown as ReturnType<typeof vi.fn>;
+    replySpy.mockReset();
+
+    // Chat B message completes first (update_id 102)
+    await messageHandler({
+      update: { update_id: 102 },
+      message: {
+        chat: { id: -200, type: "supergroup", title: "Chat B" },
+        from: { id: 5, username: "user5" },
+        text: "hello from B",
+        date: 1736380800,
+        message_id: 1,
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({}),
+    });
+
+    expect(replySpy).toHaveBeenCalledTimes(1);
+    replySpy.mockReset();
+
+    // Chat A message with lower update_id (101) should NOT be skipped
+    await messageHandler({
+      update: { update_id: 101 },
+      message: {
+        chat: { id: -100, type: "supergroup", title: "Chat A" },
+        from: { id: 3, username: "user3" },
+        text: "hello from A",
+        date: 1736380800,
+        message_id: 2,
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({}),
+    });
+
+    // Before the fix, update 101 would be skipped (101 <= 102).
+    expect(replySpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -156,8 +156,11 @@ export function createTelegramBot(opts: TelegramBotOptions) {
   });
 
   const recentUpdates = createTelegramUpdateDedupe();
-  let lastUpdateId =
+  // The persisted offset from the previous session is safe for crash-recovery
+  // dedup: any update_id <= this value was already processed before this session.
+  const initialLastUpdateId =
     typeof opts.updateOffset?.lastUpdateId === "number" ? opts.updateOffset.lastUpdateId : null;
+  let lastUpdateId = initialLastUpdateId;
 
   const recordUpdateId = (ctx: TelegramUpdateKeyContext) => {
     const updateId = resolveTelegramUpdateId(ctx);
@@ -173,8 +176,14 @@ export function createTelegramBot(opts: TelegramBotOptions) {
 
   const shouldSkipUpdate = (ctx: TelegramUpdateKeyContext) => {
     const updateId = resolveTelegramUpdateId(ctx);
-    if (typeof updateId === "number" && lastUpdateId !== null) {
-      if (updateId <= lastUpdateId) {
+    if (typeof updateId === "number" && initialLastUpdateId !== null) {
+      // Only compare against the persisted offset from before this session.
+      // Using the runtime-advancing `lastUpdateId` is incorrect because
+      // @grammyjs/runner processes updates concurrently across different
+      // sequentialize keys.  A fast-completing update from chat B can advance
+      // the high-water mark past a still-queued serialised update in chat A,
+      // causing that update to be incorrectly skipped.
+      if (updateId <= initialLastUpdateId) {
         return true;
       }
     }


### PR DESCRIPTION
## Problem

Fixes #15753

`message_reaction` updates from groups/supergroups are never delivered to the `bot.on("message_reaction")` handler when using polling mode, while DM reactions work correctly.

## Root Cause

The `shouldSkipUpdate()` function in `bot.ts` compares `updateId <= lastUpdateId` where `lastUpdateId` is a **runtime-advancing high-water mark** that tracks the maximum `update_id` seen across all chats. With `@grammyjs/runner` concurrent processing (via `sequentialize`), updates with different keys (different chats) run in parallel.

This creates a race condition:

1. Updates arrive: `[100: msg in chat A, 101: reaction in chat A, 102: msg in chat B]`
2. `sequentialize` serializes chat A updates `[100, 101]` but processes chat B `[102]` concurrently
3. Chat B's update 102 completes first, advancing `lastUpdateId` to `102`
4. Chat A's update 100 completes, `lastUpdateId` stays at `102`
5. Chat A's reaction (update 101) starts, `shouldSkipUpdate(101)` sees `101 <= 102` and **incorrectly skips it**

DM reactions work because DMs have less concurrent cross-chat activity, making the race condition rare.

## Fix

Change `shouldSkipUpdate()` to compare against `initialLastUpdateId` (the persisted offset from before this session started) instead of the runtime-advancing `lastUpdateId`. This preserves crash-recovery dedup (skip updates already processed in prior sessions) while eliminating the concurrent processing race.

The runtime dedupe cache (`recentUpdates.check()`) already handles within-session deduplication correctly.

## Changes

- `src/telegram/bot.ts`: Split `lastUpdateId` into `initialLastUpdateId` (const, for skip checks) and `lastUpdateId` (mutable, for offset persistence only)
- New test file verifying:
  - Group reactions are not skipped when a cross-chat update has a higher update_id
  - Updates at or below the persisted initial offset are still skipped (crash recovery)
  - Group messages are also protected from the same race condition

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a race condition in the Telegram polling dedup logic where `shouldSkipUpdate()` compared incoming `update_id` values against a runtime-advancing high-water mark (`lastUpdateId`). When `@grammyjs/runner`'s `sequentialize` processes updates from different chats concurrently, a fast-completing update from one chat could advance the offset past a still-queued update from another chat, causing it to be incorrectly skipped. This primarily affected group `message_reaction` updates but could also drop regular messages.

- `src/telegram/bot.ts`: Introduces `initialLastUpdateId` (the persisted offset from before this session) as a `const` used solely by `shouldSkipUpdate()`, while the mutable `lastUpdateId` continues to track the runtime high-water mark for offset persistence via `recordUpdateId`. Within-session dedup remains handled by the existing TTL-based `recentUpdates` cache.
- New test file covering the race condition scenario (group reactions not skipped when cross-chat message advances offset), crash-recovery dedup (updates at/below initial offset still skipped), and the same protection for group messages.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, well-targeted fix with comprehensive test coverage.
- The change is small (splitting one variable into two with clear separation of concerns), the root cause analysis is thorough and correct, and three test cases cover both the fix and the preserved crash-recovery behavior. The mutable `lastUpdateId` continues to serve offset persistence correctly, and within-session dedup is already handled by the TTL-based dedupe cache. No new dependencies or architectural changes are introduced.
- No files require special attention.

<sub>Last reviewed commit: 4310355</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->