### PR TITLE
feat(browser): add browser.profiles.openclaw.userDataDir config

### DIFF
--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -176,8 +176,11 @@ export async function launchOpenClawChrome(
     );
   }
 
-  const userDataDir = resolveOpenClawUserDataDir(profile.name);
-  fs.mkdirSync(userDataDir, { recursive: true });
+  let userDataDir = profile.userDataDir;
+  if (!userDataDir) {
+    userDataDir = resolveOpenClawUserDataDir(profile.name);
+    fs.mkdirSync(userDataDir, { recursive: true });
+  }
 
   const needsDecorate = !isProfileDecorated(
     userDataDir,

--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -179,8 +179,8 @@ export async function launchOpenClawChrome(
   let userDataDir = profile.userDataDir;
   if (!userDataDir) {
     userDataDir = resolveOpenClawUserDataDir(profile.name);
-    fs.mkdirSync(userDataDir, { recursive: true });
   }
+  fs.mkdirSync(userDataDir, { recursive: true });
 
   const needsDecorate = !isProfileDecorated(
     userDataDir,

--- a/src/browser/config.ts
+++ b/src/browser/config.ts
@@ -44,6 +44,7 @@ export type ResolvedBrowserProfile = {
   cdpIsLoopback: boolean;
   color: string;
   driver: "openclaw" | "extension";
+  userDataDir?: string;
 };
 
 function normalizeHexColor(raw: string | undefined) {
@@ -294,6 +295,8 @@ export function resolveProfile(
     throw new Error(`Profile "${profileName}" must define cdpPort or cdpUrl.`);
   }
 
+  const userDataDir = profile.userDataDir?.trim() || undefined;
+
   return {
     name: profileName,
     cdpPort,
@@ -302,6 +305,7 @@ export function resolveProfile(
     cdpIsLoopback: isLoopbackHost(cdpHost),
     color: profile.color,
     driver,
+    userDataDir,
   };
 }
 

--- a/src/browser/profiles-service.test.ts
+++ b/src/browser/profiles-service.test.ts
@@ -171,6 +171,6 @@ describe("BrowserProfilesService", () => {
     const result = await service.deleteProfile("custom");
 
     expect(result.deleted).toBe(true);
-    expect(movePathToTrash).toHaveBeenCalledWith(path.dirname(userDataDir));
+    expect(movePathToTrash).toHaveBeenCalledWith(userDataDir);
   });
 });

--- a/src/browser/profiles-service.test.ts
+++ b/src/browser/profiles-service.test.ts
@@ -144,4 +144,33 @@ describe("BrowserProfilesService", () => {
     expect(result.deleted).toBe(true);
     expect(movePathToTrash).toHaveBeenCalledWith(path.dirname(userDataDir));
   });
+
+  it("deletes profiles with specified userDataDir", async () => {
+    const tempDir = fs.mkdtempSync(path.join("/tmp", "openclaw-profile-"));
+    const userDataDir = path.join(tempDir, "custom", "user-data");
+    const resolved = resolveBrowserConfig({
+      profiles: {
+        custom: { cdpPort: 18801, color: "#0066CC", userDataDir },
+      },
+    });
+    const { ctx } = createCtx(resolved);
+
+    vi.mocked(loadConfig).mockReturnValue({
+      browser: {
+        defaultProfile: "openclaw",
+        profiles: {
+          openclaw: { cdpPort: 18800, color: "#FF4500" },
+          custom: { cdpPort: 18801, color: "#0066CC", userDataDir },
+        },
+      },
+    });
+
+    fs.mkdirSync(path.dirname(userDataDir), { recursive: true });
+
+    const service = createBrowserProfilesService(ctx);
+    const result = await service.deleteProfile("custom");
+
+    expect(result.deleted).toBe(true);
+    expect(movePathToTrash).toHaveBeenCalledWith(path.dirname(userDataDir));
+  });
 });

--- a/src/browser/profiles-service.test.ts
+++ b/src/browser/profiles-service.test.ts
@@ -165,7 +165,7 @@ describe("BrowserProfilesService", () => {
       },
     });
 
-    fs.mkdirSync(path.dirname(userDataDir), { recursive: true });
+    fs.mkdirSync(userDataDir, { recursive: true });
 
     const service = createBrowserProfilesService(ctx);
     const result = await service.deleteProfile("custom");

--- a/src/browser/profiles-service.ts
+++ b/src/browser/profiles-service.ts
@@ -155,7 +155,7 @@ export function createBrowserProfilesService(ctx: BrowserRouteContext) {
       }
 
       const userDataDir = resolved.userDataDir ?? resolveOpenClawUserDataDir(name);
-      const profileDir = path.dirname(userDataDir);
+      const profileDir = resolved.userDataDir ? userDataDir : path.dirname(userDataDir);
       if (fs.existsSync(profileDir)) {
         await movePathToTrash(profileDir);
         deleted = true;

--- a/src/browser/profiles-service.ts
+++ b/src/browser/profiles-service.ts
@@ -154,7 +154,7 @@ export function createBrowserProfilesService(ctx: BrowserRouteContext) {
         // ignore
       }
 
-      const userDataDir = resolveOpenClawUserDataDir(name);
+      const userDataDir = resolved.userDataDir ?? resolveOpenClawUserDataDir(name);
       const profileDir = path.dirname(userDataDir);
       if (fs.existsSync(profileDir)) {
         await movePathToTrash(profileDir);

--- a/src/browser/server-context.ts
+++ b/src/browser/server-context.ts
@@ -515,7 +515,7 @@ function createProfileContext(
         `reset-profile is only supported for local profiles (profile "${profile.name}" is remote).`,
       );
     }
-    const userDataDir = resolveOpenClawUserDataDir(profile.name);
+    const userDataDir = profile.userDataDir ?? resolveOpenClawUserDataDir(profile.name);
     const profileState = getProfileState();
 
     const httpReachable = await isHttpReachable(300);

--- a/src/config/types.browser.ts
+++ b/src/config/types.browser.ts
@@ -7,6 +7,8 @@ export type BrowserProfileConfig = {
   driver?: "openclaw" | "extension";
   /** Profile color (hex). Auto-assigned at creation. */
   color: string;
+  /** User Data Directory */
+  userDataDir?: string;
 };
 export type BrowserSnapshotDefaults = {
   /** Default snapshot mode (applies when mode is not provided). */

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -266,7 +266,13 @@ export const OpenClawSchema = z
                 cdpUrl: z.string().optional(),
                 driver: z.union([z.literal("clawd"), z.literal("extension")]).optional(),
                 color: HexColorSchema,
-                userDataDir: z.string().optional(),
+                userDataDir: z
+                  .string()
+                  .regex(
+                    /openclaw/i,
+                    `"userDataDir" path must contain "openclaw" to prevent accidental data loss`,
+                  )
+                  .optional(),
               })
               .strict()
               .refine((value) => value.cdpPort || value.cdpUrl, {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -266,6 +266,7 @@ export const OpenClawSchema = z
                 cdpUrl: z.string().optional(),
                 driver: z.union([z.literal("clawd"), z.literal("extension")]).optional(),
                 color: HexColorSchema,
+                userDataDir: z.string().optional(),
               })
               .strict()
               .refine((value) => value.cdpPort || value.cdpUrl, {


### PR DESCRIPTION
### Summary

This PR aims to add a `browser.profiles.openclaw.userDataDir` config to customize dedicated profile data storage directory.

The usage would be

```json
{
  "browser": {
    "profiles": {
        "openclaw": {
          "userDataDir": "/path/to/user/data/dir"
        }
    }
}
```

### Test

All current test cases passed. And, this new config was tested in a local environment (Windows)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds optional `userDataDir` configuration to browser profiles, allowing users to specify custom storage locations for profile data. The implementation correctly handles both default and custom paths across profile operations (launch, reset, delete). The regex validation requiring "openclaw" in the path provides safety against accidental data loss. Previous critical issues with `deleteProfile` trashing wrong directories have been resolved.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified issues
- All previously flagged critical bugs have been fixed. The implementation correctly handles custom userDataDir across all operations (launch, reset, delete). The code includes proper validation (openclaw path requirement), tests for both default and custom paths, and consistent handling throughout the codebase. No new issues were identified during review.
- No files require special attention

<sub>Last reviewed commit: 4b87e3c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->