### PR TITLE
fix: add error handler to memory file watcher to prevent crashes

### DIFF
--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -293,6 +293,9 @@ class MemoryManagerSyncOps {
     this.watcher.on("add", markDirty);
     this.watcher.on("change", markDirty);
     this.watcher.on("unlink", markDirty);
+    this.watcher.on("error", (err) => {
+      log.warn(`memory watcher error: ${String(err)}`);
+    });
   }
 
   private ensureSessionListener() {


### PR DESCRIPTION
## Summary

The chokidar file watcher in `ensureWatcher()` was missing an error handler, which could cause unhandled errors when filesystem race conditions occur (e.g., when folders are created during active conversations). This fix adds a proper error handler that logs the error instead of crashing.

## Changes

- Added `watcher.on("error", ...)` handler to the memory file watcher in `src/memory/manager-sync-ops.ts`

## Testing

- All 91 memory-related unit tests pass
- The fix follows the same pattern used in `config-reload.ts` and `refresh.ts`

Fixes openclaw/openclaw#16070

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added error handler to memory file watcher in `ensureWatcher()` method to prevent unhandled promise rejections when filesystem race conditions occur. The fix follows established patterns from `config-reload.ts:361-368` and `refresh.ts:179-181` where similar chokidar watchers log errors rather than crashing the application.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a defensive programming fix that adds proper error handling to prevent crashes. It follows the exact same pattern used consistently throughout the codebase for chokidar watchers, uses appropriate logging, and has no logical flaws or breaking changes
- No files require special attention

<sub>Last reviewed commit: 4ef851a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->