### PR TITLE
fix(slack): respect replyToMode=off for inline directive reply tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Slack: respect `replyToMode: "off"` for inline directive reply tags (`[[reply_to_current]]`) so replies stay in channel root instead of threading. (#16080)
 - BlueBubbles: gracefully degrade when Private API is disabled by filtering private-only actions, skipping private-only reactions/reply effects, and avoiding private reply markers so non-private flows remain usable. (#16002) Thanks @L-U-C-K-Y.
 - Outbound: add a write-ahead delivery queue with crash-recovery retries to prevent lost outbound messages after gateway restarts. (#15636) Thanks @nabbilkhan, @thewilloftheshadow.
 - Auto-reply/Threading: auto-inject implicit reply threading so `replyToMode` works without requiring model-emitted `[[reply_to_current]]`, while preserving `replyToMode: "off"` behavior for implicit Slack replies and keeping block-streaming chunk coalescing stable under `replyToMode: "first"`. (#14976) Thanks @Diaspar4u.

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -115,6 +115,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         runtime,
         textLimit: ctx.textLimit,
         replyThreadTs,
+        replyToMode: ctx.replyToMode,
       });
       replyPlan.markSent();
     },


### PR DESCRIPTION
## Summary

Fixes #16080

When `replyToMode` is set to `"off"` (the default), agent responses containing `[[reply_to_current]]` tags were still sent as Slack thread replies instead of regular channel messages. This happened because `deliverReplies()` used `payload.replyToId` (from parsed inline directives) unconditionally, bypassing the `replyToMode` check.

## Changes

- **`src/slack/monitor/replies.ts`**: Add optional `replyToMode` param to `deliverReplies()`. When `replyToMode === "off"`, ignore `payload.replyToId` from inline directives, consistent with how the Telegram plugin handles this (line 94 of `src/telegram/bot/delivery.ts`).
- **`src/slack/monitor/message-handler/dispatch.ts`**: Pass `ctx.replyToMode` through to `deliverReplies()`.
- **Test update**: Fixed existing test that was asserting the buggy behavior (`threadTs: "555"` when `replyToMode: "off"`). Now correctly expects `threadTs: undefined`. Added a new test confirming `replyToId` is still honored when `replyToMode: "all"`.

## Test Plan

- [x] All 22 Slack test files pass (144 tests)
- [x] Lint clean (oxlint)
- [x] Build succeeds
- [x] Verified: `replyToId` ignored when `replyToMode: "off"` (new test)
- [x] Verified: `replyToId` honored when `replyToMode: "all"` (new test)
- [x] Verified: existing threading behavior unchanged for `"first"` and `"all"` modes

---
🤖 Generated with Claude Code (issue-hunter-pro)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where inline directive reply tags (`[[reply_to_current]]`) from agent responses were creating Slack thread replies even when `replyToMode` was set to `"off"`. The fix adds a `replyToMode` parameter to `deliverReplies()` and filters out `payload.replyToId` when the mode is `"off"`, aligning Slack's behavior with how Telegram already handles this case.

- Added `replyToMode` parameter to `deliverReplies()` in `src/slack/monitor/replies.ts:20`
- When `replyToMode === "off"`, inline directive `replyToId` is now ignored (line 25)
- Passes `ctx.replyToMode` from dispatch layer (line 118 of `dispatch.ts`)
- Updated test assertion to expect `threadTs: undefined` when mode is `"off"` (previously incorrectly expected `threadTs: "555"`)
- Added new test confirming `replyToId` still works when `replyToMode: "all"`

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are minimal, focused, and well-tested. The fix mirrors the existing pattern used in Telegram (line 101 of `src/telegram/bot/delivery.ts`), ensuring consistency across channels. Test coverage is comprehensive with both the buggy behavior corrected and a new test for the `"all"` mode added. The implementation is a simple conditional check with no complex logic or side effects.
- No files require special attention

<sub>Last reviewed commit: 2b6c139</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->