### PR TITLE
fix: use runtime context window instead of stale model registry lookup

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -881,6 +881,7 @@ export async function runEmbeddedPiAgent(
             usage,
             lastCallUsage: lastCallUsage ?? undefined,
             promptTokens,
+            contextWindow: ctxInfo.tokens || undefined,
             compactionCount: autoCompactionCount > 0 ? autoCompactionCount : undefined,
           };
 

--- a/src/agents/pi-embedded-runner/types.ts
+++ b/src/agents/pi-embedded-runner/types.ts
@@ -15,6 +15,13 @@ export type EmbeddedPiAgentMeta = {
     total?: number;
   };
   /**
+   * The model's context window size as reported at runtime. This is more
+   * reliable than `lookupContextTokens()` which reads from a static model
+   * registry that may have stale or incorrect values (e.g. Z.ai reports
+   * 400K for glm-5 in the registry but the actual usable window is 200K).
+   */
+  contextWindow?: number;
+  /**
    * Usage from the last individual API call (not accumulated across tool-use
    * loops or compaction retries). Used for context-window utilization display
    * (`totalTokens` in sessions.json) because the accumulated `usage.input`

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -378,8 +378,15 @@ export async function runReplyAgent(params: {
     const cliSessionId = isCliProvider(providerUsed, cfg)
       ? runResult.meta.agentMeta?.sessionId?.trim()
       : undefined;
+    // Prefer the runtime-reported context window from the agent run. The model
+    // registry (`lookupContextTokens`) can return incorrect values — e.g. Z.ai
+    // reports 400K for glm-5 in the registry but the actual usable window is
+    // 200K. The runtime value comes from the resolved model config and is more
+    // reliable. See: https://github.com/openclaw/openclaw/issues/15153
+    const runtimeContextWindow = runResult.meta.agentMeta?.contextWindow;
     const contextTokensUsed =
       agentCfgContextTokens ??
+      runtimeContextWindow ??
       lookupContextTokens(modelUsed) ??
       activeSessionEntry?.contextTokens ??
       DEFAULT_CONTEXT_TOKENS;


### PR DESCRIPTION
## Problem

`persistSessionUsageUpdate` writes `contextTokens` to `sessions.json` using `lookupContextTokens()`, which reads from the static model registry. Some providers report incorrect context window sizes in the registry — e.g. **Z.ai reports 400K for glm-5** while the actual usable context window is **200K** (as reported by the API at runtime).

This causes `/status` to display wrong context utilization percentages (e.g. `149K/400K = 37%` instead of `149K/200K = 75%`), which in turn prevents users from understanding how close they are to the compaction threshold.

Related: #15153

## Fix

Pass the **runtime-resolved context window** (from the model config used during the actual agent run) through `agentMeta`, and prefer it over `lookupContextTokens()` when resolving `contextTokensUsed`.

The resolution order is now:
1. User config override (`agentCfgContextTokens`) — unchanged
2. **Runtime context window from the agent run** ← new
3. Model registry lookup (`lookupContextTokens`) — existing fallback
4. Stored session value — existing fallback
5. Default — existing fallback

## Changes

| File | Change |
|------|--------|
| `src/agents/pi-embedded-runner/types.ts` | Add `contextWindow?: number` to `EmbeddedPiAgentMeta` |
| `src/agents/pi-embedded-runner/run.ts` | Pass `ctxInfo.tokens` through `agentMeta.contextWindow` |
| `src/auto-reply/reply/agent-runner.ts` | Prefer `agentMeta.contextWindow` over `lookupContextTokens()` |

## Testing

- [x] Tested locally with Z.ai/GLM-5 (200K context window)
- [x] `/status` shows correct context window after fix
- [x] Compaction threshold calculated from correct window size
- [x] Fallback chain still works when `contextWindow` is not in agentMeta

## AI-assisted

This PR was developed with AI assistance (Windsurf/Cascade). The fix was identified through runtime debugging of the compaction system with diagnostic logging. Full root cause analysis of 10 interacting compaction bugs is documented in #15153.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed context window reporting to use runtime-resolved values instead of stale model registry lookups. The model registry can report incorrect context window sizes (e.g. Z.ai reports 400K for `glm-5` while the actual usable window is 200K), causing `/status` to display wrong context utilization percentages and preventing users from understanding how close they are to the compaction threshold.

The fix adds a new `contextWindow` field to `EmbeddedPiAgentMeta` that captures the runtime context window from `ctxInfo.tokens` (which is resolved from the model config during the actual agent run). In `agent-runner.ts`, the resolution order is now:
1. User config override (`agentCfgContextTokens`)
2. Runtime context window from agent run (new)
3. Model registry lookup (`lookupContextTokens`)
4. Stored session value
5. Default fallback

Changes are minimal, well-documented, and properly handle the fallback chain when the runtime value is not available.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is straightforward, well-documented, and addresses a clear root cause. It adds a single optional field to pass runtime context window information through the existing metadata pipeline, and updates the resolution logic to prefer this runtime value over the stale registry lookup. The change maintains backward compatibility by making the field optional and preserving the entire fallback chain. The logic is consistent with how other `agentMeta` fields are handled, and there are no breaking changes or edge cases that could cause issues.
- No files require special attention

<sub>Last reviewed commit: 1c11ca0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->