### PR TITLE
feat(gateway): add stuck session detection

### DIFF
--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -211,9 +211,20 @@ export type GatewayNodesConfig = {
   denyCommands?: string[];
 };
 
+export type GatewayStuckDetectionConfig = {
+  /** Enable stuck session detection (default: true). */
+  enabled?: boolean;
+  /** Threshold in minutes before a run is considered stuck (default: 5). */
+  thresholdMinutes?: number;
+  /** Action to take when a stuck run is detected (default: 'log'). */
+  action?: "log" | "notify" | "abort";
+};
+
 export type GatewayConfig = {
   /** Single multiplexed port for Gateway WS + HTTP (default: 18789). */
   port?: number;
+  /** Stuck run detection configuration. */
+  stuckDetection?: GatewayStuckDetectionConfig;
   /**
    * Explicit gateway mode. When set to "remote", local gateway start is disabled.
    * When set to "local", the CLI may start the gateway locally.

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -511,6 +511,14 @@ export const OpenClawSchema = z
           })
           .strict()
           .optional(),
+        stuckDetection: z
+          .object({
+            enabled: z.boolean().optional(),
+            thresholdMinutes: z.number().int().positive().optional(),
+            action: z.union([z.literal("log"), z.literal("notify"), z.literal("abort")]).optional(),
+          })
+          .strict()
+          .optional(),
       })
       .strict()
       .optional(),

--- a/src/gateway/chat-abort.ts
+++ b/src/gateway/chat-abort.ts
@@ -88,7 +88,7 @@ export function abortChatRunById(
   ops.chatAbortControllers.delete(runId);
   ops.chatRunBuffers.delete(runId);
   ops.chatDeltaSentAt.delete(runId);
-  ops.removeChatRun(runId, runId, sessionKey);
+  ops.removeChatRun(active.sessionId, runId, sessionKey);
   broadcastChatAborted(ops, { runId, sessionKey, stopReason });
   return { aborted: true };
 }

--- a/src/gateway/server-chat-registry.test.ts
+++ b/src/gateway/server-chat-registry.test.ts
@@ -5,8 +5,8 @@ describe("chat run registry", () => {
   test("queues and removes runs per session", () => {
     const registry = createChatRunRegistry();
 
-    registry.add("s1", { sessionKey: "main", clientRunId: "c1" });
-    registry.add("s1", { sessionKey: "main", clientRunId: "c2" });
+    registry.add("s1", { sessionKey: "main", clientRunId: "c1", startedAt: Date.now() });
+    registry.add("s1", { sessionKey: "main", clientRunId: "c2", startedAt: Date.now() });
 
     expect(registry.peek("s1")?.clientRunId).toBe("c1");
     expect(registry.shift("s1")?.clientRunId).toBe("c1");

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -15,7 +15,11 @@ describe("agent event handler", () => {
     const agentRunSeq = new Map<string, number>();
     const chatRunState = createChatRunState();
     const toolEventRecipients = createToolEventRecipientRegistry();
-    chatRunState.registry.add("run-1", { sessionKey: "session-1", clientRunId: "client-1" });
+    chatRunState.registry.add("run-1", {
+      sessionKey: "session-1",
+      clientRunId: "client-1",
+      startedAt: Date.now(),
+    });
 
     const handler = createAgentEventHandler({
       broadcast,

--- a/src/gateway/server-maintenance.ts
+++ b/src/gateway/server-maintenance.ts
@@ -147,6 +147,22 @@ export function startGatewayMaintenanceTimers(params: {
               );
             }
 
+            if (action === "notify") {
+              params.broadcast("stuck-run", {
+                sessionId,
+                sessionKey: entry.sessionKey,
+                clientRunId: entry.clientRunId,
+                elapsedMinutes: elapsedMin,
+                thresholdMinutes: stuckConfig?.thresholdMinutes ?? DEFAULT_STUCK_THRESHOLD_MINUTES,
+              });
+              if (entry.sessionKey) {
+                params.nodeSendToSession(entry.sessionKey, "stuck-run", {
+                  clientRunId: entry.clientRunId,
+                  elapsedMinutes: elapsedMin,
+                });
+              }
+            }
+
             if (action === "abort") {
               params.logStuck?.warn(
                 `Aborting stuck run: ${entry.clientRunId} (${elapsedMin}m)`,

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -290,6 +290,7 @@ export const agentHandlers: GatewayRequestHandlers = {
         context.addChatRun(idem, {
           sessionKey: requestedSessionKey,
           clientRunId: idem,
+          startedAt: Date.now(),
         });
         bestEffortDeliver = true;
       }

--- a/src/gateway/server-methods/types.ts
+++ b/src/gateway/server-methods/types.ts
@@ -64,7 +64,10 @@ export type GatewayRequestContext = {
   chatAbortedRuns: Map<string, number>;
   chatRunBuffers: Map<string, string>;
   chatDeltaSentAt: Map<string, number>;
-  addChatRun: (sessionId: string, entry: { sessionKey: string; clientRunId: string }) => void;
+  addChatRun: (
+    sessionId: string,
+    entry: { sessionKey: string; clientRunId: string; startedAt: number },
+  ) => void;
   removeChatRun: (
     sessionId: string,
     clientRunId: string,

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -60,6 +60,7 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
       ctx.addChatRun(sessionId, {
         sessionKey,
         clientRunId: `voice-${randomUUID()}`,
+        startedAt: Date.now(),
       });
 
       void agentCommand(

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -430,14 +430,17 @@ export async function startGatewayServer(
     getHealthVersion,
     refreshGatewayHealthSnapshot,
     logHealth,
+    logStuck: { warn: (msg, meta) => logGateway.warn({ ...meta }, msg) },
     dedupe,
     chatAbortControllers,
     chatRunState,
+    chatRunRegistry: chatRunState.registry,
     chatRunBuffers,
     chatDeltaSentAt,
     removeChatRun,
     agentRunSeq,
     nodeSendToSession,
+    stuckDetection: cfgAtStart.gateway?.stuckDetection,
   });
 
   const agentUnsub = onAgentEvent(


### PR DESCRIPTION
## Summary

Adds configurable stuck session detection to the gateway. Sessions that exceed a configurable time threshold are detected and handled according to the configured action.

## Problem

Long-running agent sessions can get stuck due to network issues, API hangs, or infinite loops. Currently there's no mechanism to detect or recover from these situations automatically.

## Solution

- Add `stuckDetection` config to gateway options
- Track `startedAt` timestamp on chat run entries  
- Sweep every 60 seconds checking for sessions exceeding threshold
- Configurable threshold (default 5 minutes) and action (`log`, `notify`, or `abort`)
- Add `entries()` and `size()` methods to ChatRunRegistry for introspection

## Configuration

```json
{
  "gateway": {
    "stuckDetection": {
      "enabled": true,
      "thresholdMinutes": 5,
      "action": "abort"
    }
  }
}
```

## Changes

- `src/config/types.gateway.ts` — Add `GatewayStuckDetectionConfig` type
- `src/config/zod-schema.ts` — Add zod validation schema
- `src/gateway/server-chat.ts` — Track `startedAt`, add registry methods
- `src/gateway/server-maintenance.ts` — Stuck detection sweep logic
- `src/gateway/server.impl.ts` — Wire up config
- Updated test files for new interfaces

## Testing

Existing tests updated to accommodate new interface changes. Stuck detection sweep runs within the existing maintenance timer infrastructure.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds configurable stuck session detection to the gateway, sweeping every 60 seconds and supporting `log`, `notify`, and `abort` actions. Also includes a correct bug fix in `chat-abort.ts` where `removeChatRun` was called with `runId` instead of `sessionId`.

- **Runtime crash**: `server.impl.ts:433` references `logGateway` which is not defined in scope — will throw a `ReferenceError` the first time the stuck detection sweep triggers. Should be `log`.
- **Skipped entries during abort**: `server-maintenance.ts:131-187` iterates over live `Map` and `Array` iterators while the `abort` action mutates them via `removeChatRun`, causing entries to be skipped. Snapshot the iterables before the loop.
- Good bug fix in `chat-abort.ts`: corrects the first argument to `removeChatRun` from `runId` to `active.sessionId`.

<h3>Confidence Score: 2/5</h3>

- This PR has a definite runtime crash (`logGateway` ReferenceError) and a mutation-during-iteration bug that must be fixed before merging.
- Score of 2 reflects two confirmed bugs: (1) an undefined variable reference that will crash at runtime on any stuck detection log, and (2) a collection mutation during iteration that silently skips entries when aborting stuck runs. The overall design and remaining changes are sound.
- `src/gateway/server.impl.ts` (undefined `logGateway` reference) and `src/gateway/server-maintenance.ts` (mutation during iteration in abort path)

<sub>Last reviewed commit: 7cf7f98</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->