### PR TITLE
fix: preserve bootstrap paths and expose failed mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents: keep unresolved mutating tool failures visible until the same action retry succeeds, scope mutation-error surfacing to mutating calls (including `session_status` model changes), and dedupe duplicate failure warnings in outbound replies. (#16131) Thanks @Swader.
 - Agents: classify external timeout aborts during compaction the same as internal timeouts, preventing unnecessary auth-profile rotation and preserving compaction-timeout snapshot fallback behavior. (#9855) Thanks @mverrilli.
 - Sessions/Agents: harden transcript path resolution for mismatched agent context by preserving explicit store roots and adding safe absolute-path fallback to the correct agent sessions directory. (#16288) Thanks @robbyczgw-cla.
 - BlueBubbles: include sender identity in group chat envelopes and pass clean message text to the agent prompt, aligning with iMessage/Signal formatting. (#16210) Thanks @zerone0x.

--- a/src/agents/bootstrap-files.e2e.test.ts
+++ b/src/agents/bootstrap-files.e2e.test.ts
@@ -53,7 +53,9 @@ describe("resolveBootstrapContextForRun", () => {
 
     const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-");
     const result = await resolveBootstrapContextForRun({ workspaceDir });
-    const extra = result.contextFiles.find((file) => file.path === "EXTRA.md");
+    const extra = result.contextFiles.find(
+      (file) => file.path === path.join(workspaceDir, "EXTRA.md"),
+    );
 
     expect(extra?.content).toBe("extra");
   });

--- a/src/agents/pi-embedded-helpers.buildbootstrapcontextfiles.e2e.test.ts
+++ b/src/agents/pi-embedded-helpers.buildbootstrapcontextfiles.e2e.test.ts
@@ -14,7 +14,7 @@ describe("buildBootstrapContextFiles", () => {
     const files = [makeFile({ missing: true, content: undefined })];
     expect(buildBootstrapContextFiles(files)).toEqual([
       {
-        path: DEFAULT_AGENTS_FILENAME,
+        path: "/tmp/AGENTS.md",
         content: "[MISSING] Expected at: /tmp/AGENTS.md",
       },
     ]);

--- a/src/agents/pi-embedded-helpers/bootstrap.ts
+++ b/src/agents/pi-embedded-helpers/bootstrap.ts
@@ -168,7 +168,7 @@ export function buildBootstrapContextFiles(
   for (const file of files) {
     if (file.missing) {
       result.push({
-        path: file.name,
+        path: file.path,
         content: `[MISSING] Expected at: ${file.path}`,
       });
       continue;
@@ -183,7 +183,7 @@ export function buildBootstrapContextFiles(
       );
     }
     result.push({
-      path: file.name,
+      path: file.path,
       content: trimmed.content,
     });
   }

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -18,37 +18,9 @@ import {
   extractAssistantThinking,
   formatReasoningMessage,
 } from "../../pi-embedded-utils.js";
+import { isLikelyMutatingToolName } from "../../tool-mutation.js";
 
 type ToolMetaEntry = { toolName: string; meta?: string };
-
-const MUTATING_TOOL_NAMES = new Set([
-  "write",
-  "edit",
-  "apply_patch",
-  "exec",
-  "bash",
-  "process",
-  "message",
-  "sessions_send",
-  "cron",
-  "gateway",
-  "canvas",
-  "nodes",
-  "session_status",
-]);
-
-function isLikelyMutatingTool(toolName: string): boolean {
-  const normalized = toolName.trim().toLowerCase();
-  if (!normalized) {
-    return false;
-  }
-  return (
-    MUTATING_TOOL_NAMES.has(normalized) ||
-    normalized.endsWith("_actions") ||
-    normalized.startsWith("message_") ||
-    normalized.includes("send")
-  );
-}
 
 export function buildEmbeddedRunPayloads(params: {
   assistantTexts: string[];
@@ -259,7 +231,8 @@ export function buildEmbeddedRunPayloads(params: {
       errorLower.includes("needs") ||
       errorLower.includes("requires");
     const isMutatingToolError =
-      params.lastToolError.mutatingAction ?? isLikelyMutatingTool(params.lastToolError.toolName);
+      params.lastToolError.mutatingAction ??
+      isLikelyMutatingToolName(params.lastToolError.toolName);
     const shouldShowToolError = isMutatingToolError || (!hasUserFacingReply && !isRecoverableError);
 
     // Always surface mutating tool failures so we do not silently confirm actions that did not happen.

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -33,7 +33,13 @@ export type EmbeddedRunAttemptResult = {
   assistantTexts: string[];
   toolMetas: Array<{ toolName: string; meta?: string }>;
   lastAssistant: AssistantMessage | undefined;
-  lastToolError?: { toolName: string; meta?: string; error?: string };
+  lastToolError?: {
+    toolName: string;
+    meta?: string;
+    error?: string;
+    mutatingAction?: boolean;
+    actionFingerprint?: string;
+  };
   didSendViaMessagingTool: boolean;
   messagingToolSentTexts: string[];
   messagingToolSentTargets: MessagingToolSend[];

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -16,168 +16,19 @@ import {
   sanitizeToolResult,
 } from "./pi-embedded-subscribe.tools.js";
 import { inferToolMetaFromArgs } from "./pi-embedded-utils.js";
+import { buildToolMutationState, isSameToolMutationAction } from "./tool-mutation.js";
 import { normalizeToolName } from "./tool-policy.js";
 
 /** Track tool execution start times and args for after_tool_call hook */
 const toolStartData = new Map<string, { startTime: number; args: unknown }>();
 
-const READ_ONLY_ACTIONS = new Set([
-  "get",
-  "list",
-  "read",
-  "status",
-  "show",
-  "fetch",
-  "search",
-  "query",
-  "view",
-  "poll",
-  "log",
-  "inspect",
-  "check",
-  "probe",
-]);
-const PROCESS_MUTATING_ACTIONS = new Set(["write", "send_keys", "submit", "paste", "kill"]);
-const MESSAGE_MUTATING_ACTIONS = new Set([
-  "send",
-  "reply",
-  "thread_reply",
-  "threadreply",
-  "edit",
-  "delete",
-  "react",
-  "pin",
-  "unpin",
-]);
-
-function asRecord(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === "object" ? (value as Record<string, unknown>) : undefined;
-}
-
-function normalizeActionName(value: unknown): string | undefined {
-  if (typeof value !== "string") {
-    return undefined;
-  }
-  const normalized = value
-    .trim()
-    .toLowerCase()
-    .replace(/[\s-]+/g, "_");
-  return normalized || undefined;
-}
-
-function normalizeFingerprintValue(value: unknown): string | undefined {
-  if (typeof value !== "string") {
-    return undefined;
-  }
-  const normalized = value.trim();
-  return normalized ? normalized.toLowerCase() : undefined;
-}
-
-function isMutatingToolCall(toolName: string, args: unknown): boolean {
-  const normalized = toolName.trim().toLowerCase();
-  const record = asRecord(args);
-  const action = normalizeActionName(record?.action);
-
-  switch (normalized) {
-    case "write":
-    case "edit":
-    case "apply_patch":
-    case "exec":
-    case "bash":
-    case "sessions_send":
-      return true;
-    case "process":
-      return action != null && PROCESS_MUTATING_ACTIONS.has(action);
-    case "message":
-      return (
-        (action != null && MESSAGE_MUTATING_ACTIONS.has(action)) ||
-        typeof record?.content === "string" ||
-        typeof record?.message === "string"
-      );
-    case "session_status":
-      return typeof record?.model === "string" && record.model.trim().length > 0;
-    default: {
-      if (normalized === "cron" || normalized === "gateway" || normalized === "canvas") {
-        return action == null || !READ_ONLY_ACTIONS.has(action);
-      }
-      if (normalized === "nodes") {
-        return action == null || action !== "list";
-      }
-      if (normalized.endsWith("_actions")) {
-        return action == null || !READ_ONLY_ACTIONS.has(action);
-      }
-      if (normalized.startsWith("message_") || normalized.includes("send")) {
-        return true;
-      }
-      return false;
-    }
-  }
-}
-
-function buildActionFingerprint(
-  toolName: string,
-  args: unknown,
-  meta?: string,
-): string | undefined {
-  if (!isMutatingToolCall(toolName, args)) {
-    return undefined;
-  }
-  const normalizedTool = toolName.trim().toLowerCase();
-  const record = asRecord(args);
-  const action = normalizeActionName(record?.action);
-  const parts = [`tool=${normalizedTool}`];
-  if (action) {
-    parts.push(`action=${action}`);
-  }
-  for (const key of [
-    "path",
-    "filePath",
-    "oldPath",
-    "newPath",
-    "to",
-    "target",
-    "messageId",
-    "sessionKey",
-    "jobId",
-    "id",
-    "model",
-  ]) {
-    const value = normalizeFingerprintValue(record?.[key]);
-    if (value) {
-      parts.push(`${key.toLowerCase()}=${value}`);
-    }
-  }
-  const normalizedMeta = meta?.trim().replace(/\s+/g, " ").toLowerCase();
-  if (normalizedMeta) {
-    parts.push(`meta=${normalizedMeta}`);
-  }
-  return parts.join("|");
-}
-
 function buildToolCallSummary(toolName: string, args: unknown, meta?: string): ToolCallSummary {
-  const actionFingerprint = buildActionFingerprint(toolName, args, meta);
+  const mutation = buildToolMutationState(toolName, args, meta);
   return {
     meta,
-    mutatingAction: actionFingerprint != null,
-    actionFingerprint,
+    mutatingAction: mutation.mutatingAction,
+    actionFingerprint: mutation.actionFingerprint,
   };
-}
-
-function sameToolAction(
-  existing: { toolName: string; meta?: string; actionFingerprint?: string },
-  toolName: string,
-  meta?: string,
-  actionFingerprint?: string,
-): boolean {
-  if (existing.actionFingerprint != null || actionFingerprint != null) {
-    // For mutating flows, fail closed: only clear when both fingerprints exist and match.
-    return (
-      existing.actionFingerprint != null &&
-      actionFingerprint != null &&
-      existing.actionFingerprint === actionFingerprint
-    );
-  }
-  return existing.toolName === toolName && (existing.meta ?? "") === (meta ?? "");
 }
 
 function extendExecMeta(toolName: string, args: unknown, meta?: string): string | undefined {
@@ -347,7 +198,13 @@ export async function handleToolExecutionEnd(
   } else if (ctx.state.lastToolError) {
     // Keep unresolved mutating failures until the same action succeeds.
     if (ctx.state.lastToolError.mutatingAction) {
-      if (sameToolAction(ctx.state.lastToolError, toolName, meta, callSummary?.actionFingerprint)) {
+      if (
+        isSameToolMutationAction(ctx.state.lastToolError, {
+          toolName,
+          meta,
+          actionFingerprint: callSummary?.actionFingerprint,
+        })
+      ) {
         ctx.state.lastToolError = undefined;
       }
     } else {

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -178,6 +178,9 @@ export async function handleToolExecutionEnd(
       meta,
       error: errorMessage,
     };
+  } else {
+    // Keep the latest tool outcome authoritative; successful retries should clear prior failures.
+    ctx.state.lastToolError = undefined;
   }
 
   // Commit messaging tool text on success, discard on error.

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -169,8 +169,13 @@ function sameToolAction(
   meta?: string,
   actionFingerprint?: string,
 ): boolean {
-  if (existing.actionFingerprint && actionFingerprint) {
-    return existing.actionFingerprint === actionFingerprint;
+  if (existing.actionFingerprint != null || actionFingerprint != null) {
+    // For mutating flows, fail closed: only clear when both fingerprints exist and match.
+    return (
+      existing.actionFingerprint != null &&
+      actionFingerprint != null &&
+      existing.actionFingerprint === actionFingerprint
+    );
   }
   return existing.toolName === toolName && (existing.meta ?? "") === (meta ?? "");
 }

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -20,12 +20,20 @@ export type ToolErrorSummary = {
   toolName: string;
   meta?: string;
   error?: string;
+  mutatingAction?: boolean;
+  actionFingerprint?: string;
+};
+
+export type ToolCallSummary = {
+  meta?: string;
+  mutatingAction: boolean;
+  actionFingerprint?: string;
 };
 
 export type EmbeddedPiSubscribeState = {
   assistantTexts: string[];
   toolMetas: Array<{ toolName?: string; meta?: string }>;
-  toolMetaById: Map<string, string | undefined>;
+  toolMetaById: Map<string, ToolCallSummary>;
   toolSummaryById: Set<string>;
   lastToolError?: ToolErrorSummary;
 

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.e2e.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.e2e.test.ts
@@ -318,6 +318,100 @@ describe("subscribeEmbeddedPiSession", () => {
     expect(payloads[0]?.mediaUrls).toEqual(["https://example.com/a.png"]);
   });
 
+  it("keeps unresolved mutating failure when an unrelated tool succeeds", () => {
+    let handler: ((evt: unknown) => void) | undefined;
+    const session: StubSession = {
+      subscribe: (fn) => {
+        handler = fn;
+        return () => {};
+      },
+    };
+
+    const subscription = subscribeEmbeddedPiSession({
+      session: session as unknown as Parameters<typeof subscribeEmbeddedPiSession>[0]["session"],
+      runId: "run-tools-1",
+      sessionKey: "test-session",
+    });
+
+    handler?.({
+      type: "tool_execution_start",
+      toolName: "write",
+      toolCallId: "w1",
+      args: { path: "/tmp/demo.txt", content: "next" },
+    });
+    handler?.({
+      type: "tool_execution_end",
+      toolName: "write",
+      toolCallId: "w1",
+      isError: true,
+      result: { error: "disk full" },
+    });
+    expect(subscription.getLastToolError()?.toolName).toBe("write");
+
+    handler?.({
+      type: "tool_execution_start",
+      toolName: "read",
+      toolCallId: "r1",
+      args: { path: "/tmp/demo.txt" },
+    });
+    handler?.({
+      type: "tool_execution_end",
+      toolName: "read",
+      toolCallId: "r1",
+      isError: false,
+      result: { text: "ok" },
+    });
+
+    expect(subscription.getLastToolError()?.toolName).toBe("write");
+  });
+
+  it("clears unresolved mutating failure when the same action succeeds", () => {
+    let handler: ((evt: unknown) => void) | undefined;
+    const session: StubSession = {
+      subscribe: (fn) => {
+        handler = fn;
+        return () => {};
+      },
+    };
+
+    const subscription = subscribeEmbeddedPiSession({
+      session: session as unknown as Parameters<typeof subscribeEmbeddedPiSession>[0]["session"],
+      runId: "run-tools-2",
+      sessionKey: "test-session",
+    });
+
+    handler?.({
+      type: "tool_execution_start",
+      toolName: "write",
+      toolCallId: "w1",
+      args: { path: "/tmp/demo.txt", content: "next" },
+    });
+    handler?.({
+      type: "tool_execution_end",
+      toolName: "write",
+      toolCallId: "w1",
+      isError: true,
+      result: { error: "disk full" },
+    });
+    expect(subscription.getLastToolError()?.toolName).toBe("write");
+
+    handler?.({
+      type: "tool_execution_start",
+      toolName: "write",
+      toolCallId: "w2",
+      args: { path: "/tmp/demo.txt", content: "retry" },
+    });
+    handler?.({
+      type: "tool_execution_end",
+      toolName: "write",
+      toolCallId: "w2",
+      isError: false,
+      result: { ok: true },
+    });
+
+    expect(subscription.getLastToolError()).toBeUndefined();
+  });
+
   it("emits lifecycle:error event on agent_end when last assistant message was an error", async () => {
     let handler: ((evt: unknown) => void) | undefined;
     const session: StubSession = {

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.e2e.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.e2e.test.ts
@@ -412,6 +412,98 @@ describe("subscribeEmbeddedPiSession", () => {
     expect(subscription.getLastToolError()).toBeUndefined();
   });
 
+  it("keeps unresolved mutating failure when same tool succeeds on a different target", () => {
+    let handler: ((evt: unknown) => void) | undefined;
+    const session: StubSession = {
+      subscribe: (fn) => {
+        handler = fn;
+        return () => {};
+      },
+    };
+
+    const subscription = subscribeEmbeddedPiSession({
+      session: session as unknown as Parameters<typeof subscribeEmbeddedPiSession>[0]["session"],
+      runId: "run-tools-3",
+      sessionKey: "test-session",
+    });
+
+    handler?.({
+      type: "tool_execution_start",
+      toolName: "write",
+      toolCallId: "w1",
+      args: { path: "/tmp/a.txt", content: "first" },
+    });
+    handler?.({
+      type: "tool_execution_end",
+      toolName: "write",
+      toolCallId: "w1",
+      isError: true,
+      result: { error: "disk full" },
+    });
+
+    handler?.({
+      type: "tool_execution_start",
+      toolName: "write",
+      toolCallId: "w2",
+      args: { path: "/tmp/b.txt", content: "second" },
+    });
+    handler?.({
+      type: "tool_execution_end",
+      toolName: "write",
+      toolCallId: "w2",
+      isError: false,
+      result: { ok: true },
+    });
+
+    expect(subscription.getLastToolError()?.toolName).toBe("write");
+  });
+
+  it("keeps unresolved session_status model-mutation failure on later read-only status success", () => {
+    let handler: ((evt: unknown) => void) | undefined;
+    const session: StubSession = {
+      subscribe: (fn) => {
+        handler = fn;
+        return () => {};
+      },
+    };
+
+    const subscription = subscribeEmbeddedPiSession({
+      session: session as unknown as Parameters<typeof subscribeEmbeddedPiSession>[0]["session"],
+      runId: "run-tools-4",
+      sessionKey: "test-session",
+    });
+
+    handler?.({
+      type: "tool_execution_start",
+      toolName: "session_status",
+      toolCallId: "s1",
+      args: { sessionKey: "agent:main:main", model: "openai/gpt-4o" },
+    });
+    handler?.({
+      type: "tool_execution_end",
+      toolName: "session_status",
+      toolCallId: "s1",
+      isError: true,
+      result: { error: "Model not allowed." },
+    });
+
+    handler?.({
+      type: "tool_execution_start",
+      toolName: "session_status",
+      toolCallId: "s2",
+      args: { sessionKey: "agent:main:main" },
+    });
+    handler?.({
+      type: "tool_execution_end",
+      toolName: "session_status",
+      toolCallId: "s2",
+      isError: false,
+      result: { ok: true },
+    });
+
+    expect(subscription.getLastToolError()?.toolName).toBe("session_status");
+  });
+
   it("emits lifecycle:error event on agent_end when last assistant message was an error", async () => {
     let handler: ((evt: unknown) => void) | undefined;
     const session: StubSession = {

--- a/src/agents/tool-mutation.test.ts
+++ b/src/agents/tool-mutation.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildToolActionFingerprint,
+  buildToolMutationState,
+  isLikelyMutatingToolName,
+  isMutatingToolCall,
+  isSameToolMutationAction,
+} from "./tool-mutation.js";
+
+describe("tool mutation helpers", () => {
+  it("treats session_status as mutating only when model override is provided", () => {
+    expect(isMutatingToolCall("session_status", { sessionKey: "agent:main:main" })).toBe(false);
+    expect(
+      isMutatingToolCall("session_status", {
+        sessionKey: "agent:main:main",
+        model: "openai/gpt-4o",
+      }),
+    ).toBe(true);
+  });
+
+  it("builds stable fingerprints for mutating calls and omits read-only calls", () => {
+    const writeFingerprint = buildToolActionFingerprint(
+      "write",
+      { path: "/tmp/demo.txt", id: 42 },
+      "write /tmp/demo.txt",
+    );
+    expect(writeFingerprint).toContain("tool=write");
+    expect(writeFingerprint).toContain("path=/tmp/demo.txt");
+    expect(writeFingerprint).toContain("id=42");
+    expect(writeFingerprint).toContain("meta=write /tmp/demo.txt");
+
+    const readFingerprint = buildToolActionFingerprint("read", { path: "/tmp/demo.txt" });
+    expect(readFingerprint).toBeUndefined();
+  });
+
+  it("exposes mutation state for downstream payload rendering", () => {
+    expect(
+      buildToolMutationState("message", { action: "send", to: "telegram:1" }).mutatingAction,
+    ).toBe(true);
+    expect(buildToolMutationState("browser", { action: "list" }).mutatingAction).toBe(false);
+  });
+
+  it("matches tool actions by fingerprint and fails closed on asymmetric data", () => {
+    expect(
+      isSameToolMutationAction(
+        { toolName: "write", actionFingerprint: "tool=write|path=/tmp/a" },
+        { toolName: "write", actionFingerprint: "tool=write|path=/tmp/a" },
+      ),
+    ).toBe(true);
+    expect(
+      isSameToolMutationAction(
+        { toolName: "write", actionFingerprint: "tool=write|path=/tmp/a" },
+        { toolName: "write", actionFingerprint: "tool=write|path=/tmp/b" },
+      ),
+    ).toBe(false);
+    expect(
+      isSameToolMutationAction(
+        { toolName: "write", actionFingerprint: "tool=write|path=/tmp/a" },
+        { toolName: "write" },
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps legacy name-only mutating heuristics for payload fallback", () => {
+    expect(isLikelyMutatingToolName("sessions_send")).toBe(true);
+    expect(isLikelyMutatingToolName("browser_actions")).toBe(true);
+    expect(isLikelyMutatingToolName("message_slack")).toBe(true);
+    expect(isLikelyMutatingToolName("browser")).toBe(false);
+  });
+});

--- a/src/agents/tool-mutation.ts
+++ b/src/agents/tool-mutation.ts
@@ -1,0 +1,201 @@
+const MUTATING_TOOL_NAMES = new Set([
+  "write",
+  "edit",
+  "apply_patch",
+  "exec",
+  "bash",
+  "process",
+  "message",
+  "sessions_send",
+  "cron",
+  "gateway",
+  "canvas",
+  "nodes",
+  "session_status",
+]);
+
+const READ_ONLY_ACTIONS = new Set([
+  "get",
+  "list",
+  "read",
+  "status",
+  "show",
+  "fetch",
+  "search",
+  "query",
+  "view",
+  "poll",
+  "log",
+  "inspect",
+  "check",
+  "probe",
+]);
+
+const PROCESS_MUTATING_ACTIONS = new Set(["write", "send_keys", "submit", "paste", "kill"]);
+
+const MESSAGE_MUTATING_ACTIONS = new Set([
+  "send",
+  "reply",
+  "thread_reply",
+  "threadreply",
+  "edit",
+  "delete",
+  "react",
+  "pin",
+  "unpin",
+]);
+
+export type ToolMutationState = {
+  mutatingAction: boolean;
+  actionFingerprint?: string;
+};
+
+export type ToolActionRef = {
+  toolName: string;
+  meta?: string;
+  actionFingerprint?: string;
+};
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : undefined;
+}
+
+function normalizeActionName(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, "_");
+  return normalized || undefined;
+}
+
+function normalizeFingerprintValue(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    const normalized = value.trim();
+    return normalized ? normalized.toLowerCase() : undefined;
+  }
+  if (typeof value === "number" || typeof value === "bigint" || typeof value === "boolean") {
+    return String(value).toLowerCase();
+  }
+  return undefined;
+}
+
+export function isLikelyMutatingToolName(toolName: string): boolean {
+  const normalized = toolName.trim().toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+  return (
+    MUTATING_TOOL_NAMES.has(normalized) ||
+    normalized.endsWith("_actions") ||
+    normalized.startsWith("message_") ||
+    normalized.includes("send")
+  );
+}
+
+export function isMutatingToolCall(toolName: string, args: unknown): boolean {
+  const normalized = toolName.trim().toLowerCase();
+  const record = asRecord(args);
+  const action = normalizeActionName(record?.action);
+
+  switch (normalized) {
+    case "write":
+    case "edit":
+    case "apply_patch":
+    case "exec":
+    case "bash":
+    case "sessions_send":
+      return true;
+    case "process":
+      return action != null && PROCESS_MUTATING_ACTIONS.has(action);
+    case "message":
+      return (
+        (action != null && MESSAGE_MUTATING_ACTIONS.has(action)) ||
+        typeof record?.content === "string" ||
+        typeof record?.message === "string"
+      );
+    case "session_status":
+      return typeof record?.model === "string" && record.model.trim().length > 0;
+    default: {
+      if (normalized === "cron" || normalized === "gateway" || normalized === "canvas") {
+        return action == null || !READ_ONLY_ACTIONS.has(action);
+      }
+      if (normalized === "nodes") {
+        return action == null || action !== "list";
+      }
+      if (normalized.endsWith("_actions")) {
+        return action == null || !READ_ONLY_ACTIONS.has(action);
+      }
+      if (normalized.startsWith("message_") || normalized.includes("send")) {
+        return true;
+      }
+      return false;
+    }
+  }
+}
+
+export function buildToolActionFingerprint(
+  toolName: string,
+  args: unknown,
+  meta?: string,
+): string | undefined {
+  if (!isMutatingToolCall(toolName, args)) {
+    return undefined;
+  }
+  const normalizedTool = toolName.trim().toLowerCase();
+  const record = asRecord(args);
+  const action = normalizeActionName(record?.action);
+  const parts = [`tool=${normalizedTool}`];
+  if (action) {
+    parts.push(`action=${action}`);
+  }
+  for (const key of [
+    "path",
+    "filePath",
+    "oldPath",
+    "newPath",
+    "to",
+    "target",
+    "messageId",
+    "sessionKey",
+    "jobId",
+    "id",
+    "model",
+  ]) {
+    const value = normalizeFingerprintValue(record?.[key]);
+    if (value) {
+      parts.push(`${key.toLowerCase()}=${value}`);
+    }
+  }
+  const normalizedMeta = meta?.trim().replace(/\s+/g, " ").toLowerCase();
+  if (normalizedMeta) {
+    parts.push(`meta=${normalizedMeta}`);
+  }
+  return parts.join("|");
+}
+
+export function buildToolMutationState(
+  toolName: string,
+  args: unknown,
+  meta?: string,
+): ToolMutationState {
+  const actionFingerprint = buildToolActionFingerprint(toolName, args, meta);
+  return {
+    mutatingAction: actionFingerprint != null,
+    actionFingerprint,
+  };
+}
+
+export function isSameToolMutationAction(existing: ToolActionRef, next: ToolActionRef): boolean {
+  if (existing.actionFingerprint != null || next.actionFingerprint != null) {
+    // For mutating flows, fail closed: only clear when both fingerprints exist and match.
+    return (
+      existing.actionFingerprint != null &&
+      next.actionFingerprint != null &&
+      existing.actionFingerprint === next.actionFingerprint
+    );
+  }
+  return existing.toolName === next.toolName && (existing.meta ?? "") === (next.meta ?? "");
+}


### PR DESCRIPTION
This PR is a safety and accuracy fix for agent behavior.

1. It fixes file targeting:
- Bootstrap context now keeps the real file path (not just filename), so the agent points tools at the correct file.

2. It fixes “false success” messaging:
- If a mutating tool (`write`, `edit`, `message`, `exec`, etc.) fails, the failure is now surfaced to the user even if the model also produced normal text.
- This prevents “I changed it” claims when the change actually failed.

3. It fixes stale error state:
- After a successful retry, prior tool error state is cleared so old failures don’t leak into later replies.

4. It adds regression tests

Net effect: fewer hallucinated “done” confirmations

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixes three agent behavior issues: preserves absolute file paths in bootstrap context (not just filenames), surfaces failed mutating tool operations to prevent false success messages, and clears stale error state after successful retries.

- Bootstrap context now uses `file.path` instead of `file.name`, ensuring agents target the correct absolute file paths
- Mutating tools (`write`, `edit`, `message`, `exec`, etc.) now always surface failures even when the model produces text output, preventing "I changed it" claims when actions failed
- Successful tool retries now clear `lastToolError` state to prevent old failures from appearing in later replies
- New tests validate all three fixes including regression coverage

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk
- Changes are focused, well-tested, and fix real agent behavior bugs. The bootstrap path fix is straightforward (using full paths instead of basenames). The mutating tool error surfacing logic is sound with explicit allowlist and heuristics. Error state clearing prevents stale failures. Comprehensive test coverage validates all three fixes. Minor deduction for the heuristic-based mutating tool detection which could theoretically miss edge cases.
- No files require special attention

<sub>Last reviewed commit: 08ee3b2</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->