### PR TITLE
fix: add rateLimit to gateway.auth Zod schema (#16071)

### DIFF
--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -23,6 +23,37 @@ describe("config schema regressions", () => {
     expect(res.ok).toBe(true);
   });
 
+  it("accepts gateway.auth.rateLimit config (#16071)", () => {
+    const res = validateConfigObject({
+      gateway: {
+        auth: {
+          mode: "token",
+          rateLimit: {
+            maxAttempts: 10,
+            windowMs: 60000,
+            lockoutMs: 300000,
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("accepts gateway.auth.rateLimit with exemptLoopback (#16071)", () => {
+    const res = validateConfigObject({
+      gateway: {
+        auth: {
+          rateLimit: {
+            exemptLoopback: false,
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
   it('accepts memorySearch fallback "voyage"', () => {
     const res = validateConfigObject({
       agents: {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -402,6 +402,15 @@ export const OpenClawSchema = z
             token: z.string().optional().register(sensitive),
             password: z.string().optional().register(sensitive),
             allowTailscale: z.boolean().optional(),
+            rateLimit: z
+              .object({
+                maxAttempts: z.number().optional(),
+                windowMs: z.number().optional(),
+                lockoutMs: z.number().optional(),
+                exemptLoopback: z.boolean().optional(),
+              })
+              .strict()
+              .optional(),
           })
           .strict()
           .optional(),

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -404,9 +404,9 @@ export const OpenClawSchema = z
             allowTailscale: z.boolean().optional(),
             rateLimit: z
               .object({
-                maxAttempts: z.number().optional(),
-                windowMs: z.number().optional(),
-                lockoutMs: z.number().optional(),
+                maxAttempts: z.number().int().positive().optional(),
+                windowMs: z.number().positive().optional(),
+                lockoutMs: z.number().positive().optional(),
                 exemptLoopback: z.boolean().optional(),
               })
               .strict()


### PR DESCRIPTION
## Problem

The `gateway.auth` Zod schema uses `.strict()` but was missing the `rateLimit` field introduced in #15035. This means any config containing `gateway.auth.rateLimit` — as recommended by `openclaw security audit --deep` — is rejected on startup with:

```
gateway.auth: Unrecognized key: "rateLimit"
```

The gateway crashes and enters a restart loop. Running `openclaw doctor --fix` silently strips the user's security configuration.

## Root Cause

The `rateLimit` field is:
- ✅ Defined in `GatewayAuthConfig` (types.gateway.ts)
- ✅ Used by the runtime (`auth-rate-limit.ts`)
- ✅ Recommended by `openclaw security audit --deep`
- ✅ Documented in the config reference
- ❌ **Missing from the Zod validation schema** (`zod-schema.ts`)

## Fix

Add the `rateLimit` object (`maxAttempts`, `windowMs`, `lockoutMs`, `exemptLoopback`) to the `gateway.auth` Zod schema, matching the `GatewayAuthRateLimitConfig` type.

## Tests

Added two regression tests in `config.schema-regressions.test.ts`:
- Accepts full `rateLimit` config (maxAttempts + windowMs + lockoutMs)
- Accepts `rateLimit` with `exemptLoopback` only

Closes #16071

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a schema validation gap where `gateway.auth.rateLimit` — defined in the TypeScript types, consumed at runtime, and recommended by `openclaw security audit --deep` — was missing from the Zod validation schema. Since the `gateway.auth` schema uses `.strict()`, any config including `rateLimit` would be rejected on startup, crashing the gateway.

- Adds `rateLimit` object (`maxAttempts`, `windowMs`, `lockoutMs`, `exemptLoopback`) to the `gateway.auth` Zod schema in `zod-schema.ts`, matching the `GatewayAuthRateLimitConfig` type
- Adds two regression tests in `config.schema-regressions.test.ts` covering full and partial `rateLimit` configurations
- Minor observation: the numeric fields lack `.positive()` / `.int()` constraints that similar fields elsewhere in the schema use

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it's a straightforward fix that adds missing schema fields to match an existing type definition.
- The Zod schema fields exactly match the GatewayAuthRateLimitConfig type definition and the runtime RateLimitConfig interface. The change is small, focused, and includes regression tests. The only minor gap is the lack of numeric constraints (e.g., .positive(), .int()) on the new fields, which is a style/hardening concern rather than a correctness issue.
- No files require special attention — both changes are straightforward and well-aligned with existing patterns.

<sub>Last reviewed commit: c3d5371</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->