### PR TITLE
fix: propagate contextWindow config override to model object (#16083)

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -293,6 +293,13 @@ export async function runEmbeddedPiAgent(
         );
       }
 
+      // Propagate the resolved context window back to the model object so that
+      // downstream consumers (pi-ai's shouldCompact, isContextOverflow, status
+      // display) use the config-overridden value instead of the catalog default.
+      if (ctxInfo.source !== "model" && ctxInfo.tokens !== model.contextWindow) {
+        (model as Record<string, unknown>).contextWindow = ctxInfo.tokens;
+      }
+
       const authStore = ensureAuthProfileStore(agentDir, { allowKeychainPrompt: false });
       const preferredProfileId = params.authProfileId?.trim();
       let lockedProfileId = params.authProfileIdSource === "user" ? preferredProfileId : undefined;

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -297,7 +297,7 @@ export async function runEmbeddedPiAgent(
       // downstream consumers (pi-ai's shouldCompact, isContextOverflow, status
       // display) use the config-overridden value instead of the catalog default.
       if (ctxInfo.source !== "model" && ctxInfo.tokens !== model.contextWindow) {
-        (model as Record<string, unknown>).contextWindow = ctxInfo.tokens;
+        (model as unknown as Record<string, unknown>).contextWindow = ctxInfo.tokens;
       }
 
       const authStore = ensureAuthProfileStore(agentDir, { allowKeychainPrompt: false });


### PR DESCRIPTION
## Problem

When `models.providers[].contextWindow` is configured (e.g. `1000000`), the value is correctly used for:
- ✅ Display (`session_status` shows `Context: 33k/1.0m (3%)`)
- ✅ Guard checks (`resolveContextWindowInfo`)

But **ignored** by pi-ai's internal compaction trigger:
- ❌ `shouldCompact()` reads `this.model.contextWindow` directly (catalog value: 200k)
- ❌ `isContextOverflow()` reads `this.model.contextWindow` directly

This causes compaction to fire at ~180k (200k - 20k reserve) even when the user configured 1M.

## Root Cause

Two separate code paths resolve the context window:

1. **OpenClaw's `resolveContextWindowInfo()`** — checks `models.providers` config first, falls back to catalog. Returns the correct 1M. ✅
2. **pi-ai's `shouldCompact()` / `isContextOverflow()`** — reads `model.contextWindow` directly from the model object, which retains the catalog default (200k). ❌

The resolved value from `resolveContextWindowInfo()` was never written back to the model object before passing it to pi-ai.

## Fix

After `resolveContextWindowInfo()` computes the effective context window, propagate it back to the model object when the source is a config override (not the model catalog itself). This ensures all downstream consumers — including pi-ai's auto-compaction and overflow detection — use the configured value.

```typescript
if (ctxInfo.source !== "model" && ctxInfo.tokens !== model.contextWindow) {
  (model as Record<string, unknown>).contextWindow = ctxInfo.tokens;
}
```

Closes #16083

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Propagates resolved `contextWindow` config override back to the model object to ensure pi-ai's compaction logic uses the configured value instead of the catalog default.

- Fixes context window mismatch where `resolveContextWindowInfo()` correctly resolved overridden values for display/guards, but pi-ai's `shouldCompact()` and `isContextOverflow()` still read the original catalog value (e.g., 200k) from `model.contextWindow`
- Uses double assertion (`as unknown as Record<string, unknown>`) to bypass TypeScript's type system, consistent with codebase patterns
- Only mutates the model object when the source is NOT "model" (i.e., when overridden via config) and the resolved value differs from the catalog value

<h3>Confidence Score: 5/5</h3>

- Safe to merge - targeted fix that resolves a clear bug with minimal risk
- The fix correctly addresses a documented issue where config-overridden context windows weren't being used by pi-ai's compaction logic. The implementation uses defensive conditionals to only mutate when necessary, follows established codebase patterns for type assertions, and has clear justification in both commit message and inline comments.
- No files require special attention

<sub>Last reviewed commit: a02ba4e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->