### PR TITLE
fix: Slack reply tags bypass replyToMode=off (#16080)

### DIFF
--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -177,7 +177,7 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
   threading: {
     resolveReplyToMode: ({ cfg, accountId, chatType }) =>
       resolveSlackReplyToMode(resolveSlackAccount({ cfg, accountId }), chatType),
-    allowTagsWhenOff: true,
+    allowTagsWhenOff: false,
     buildToolContext: (params) => buildSlackThreadingToolContext(params),
   },
   messaging: {

--- a/src/channels/dock.ts
+++ b/src/channels/dock.ts
@@ -369,7 +369,7 @@ const DOCKS: Record<ChatChannelId, ChannelDock> = {
     threading: {
       resolveReplyToMode: ({ cfg, accountId, chatType }) =>
         resolveSlackReplyToMode(resolveSlackAccount({ cfg, accountId }), chatType),
-      allowTagsWhenOff: true,
+      allowTagsWhenOff: false,
       buildToolContext: (params) => buildSlackThreadingToolContext(params),
     },
   },


### PR DESCRIPTION
## Problem

When `channels.slack.replyToMode` is set to `"off"` (the default), agent responses containing `[[reply_to_current]]` tags still get sent as Slack thread replies instead of regular channel messages.

Since the system prompt always injects a Reply Tags section instructing the model to use `[[reply_to_current]]`, the model uses it on nearly every response — making `replyToMode=off` completely ineffective for Slack.

## Root Cause

The Slack channel dock had `allowTagsWhenOff: true` in its threading config:

```typescript
threading: {
  resolveReplyToMode: ...,
  allowTagsWhenOff: true,  // ← bypasses replyToMode=off for tagged replies
  buildToolContext: ...,
},
```

The `createReplyToModeFilter` respects this flag — when `replyToMode === "off"` but `allowTagsWhenOff` is true and `payload.replyToTag` is set, the `replyToId` is preserved instead of being cleared.

## Fix

Set `allowTagsWhenOff: false` for Slack so that `replyToMode=off` fully disables all threading, including tag-triggered replies. This makes the behavior consistent with user expectations: off means off.

Users who want tag-based threading can set `replyToMode: "all"` or `"first"`.

Closes #16080

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where `replyToMode=off` was ineffective for Slack because the Slack dock had `allowTagsWhenOff: true`, which preserved threading for any response containing `[[reply_to_current]]` tags — tags that the system prompt always injects. The fix sets `allowTagsWhenOff: false` so that `off` truly means off.

- One-line config change in `src/channels/dock.ts`: `allowTagsWhenOff: true` → `false` for the Slack channel dock
- Test refactored to test `createReplyToModeFilter` directly instead of relying on Slack extension dock registration, which is more robust since core docks take priority for built-in channels
- Minor inconsistency: `extensions/slack/src/channel.ts:180` still has `allowTagsWhenOff: true` — this is dead code at runtime (core dock takes priority) but could confuse maintainers

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, well-scoped configuration change with matching test updates.
- The change is a single boolean flip from `true` to `false` in a config object, with clear intent and correct test coverage. The `createReplyToModeFilter` logic is well-tested and the behavior change is exactly what the issue describes. No risk of regressions since this only affects Slack threading when `replyToMode=off`.
- The Slack extension at `extensions/slack/src/channel.ts` still has the old `allowTagsWhenOff: true` value, which is dead code but could be updated for consistency.

<sub>Last reviewed commit: 50d551d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->