### PR TITLE
fix: respect HTTP_PROXY/HTTPS_PROXY in SSRF-protected fetch (#2102)

### DIFF
--- a/src/infra/net/fetch-guard.proxy.test.ts
+++ b/src/infra/net/fetch-guard.proxy.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveProxyUrl, shouldBypassProxy } from "./fetch-guard.js";
+
+describe("shouldBypassProxy", () => {
+  afterEach(() => {
+    delete process.env.NO_PROXY;
+    delete process.env.no_proxy;
+  });
+
+  it("returns false when NO_PROXY is not set", () => {
+    expect(shouldBypassProxy("example.com")).toBe(false);
+  });
+
+  it("matches exact hostname", () => {
+    process.env.NO_PROXY = "example.com";
+    expect(shouldBypassProxy("example.com")).toBe(true);
+    expect(shouldBypassProxy("other.com")).toBe(false);
+  });
+
+  it("matches case-insensitively", () => {
+    process.env.NO_PROXY = "Example.COM";
+    expect(shouldBypassProxy("example.com")).toBe(true);
+    expect(shouldBypassProxy("EXAMPLE.COM")).toBe(true);
+  });
+
+  it("matches dot-prefixed suffix (.example.com)", () => {
+    process.env.NO_PROXY = ".example.com";
+    expect(shouldBypassProxy("sub.example.com")).toBe(true);
+    expect(shouldBypassProxy("deep.sub.example.com")).toBe(true);
+    expect(shouldBypassProxy("example.com")).toBe(false);
+    expect(shouldBypassProxy("notexample.com")).toBe(false);
+  });
+
+  it("matches bare suffix (example.com matches sub.example.com)", () => {
+    process.env.NO_PROXY = "example.com";
+    expect(shouldBypassProxy("sub.example.com")).toBe(true);
+    expect(shouldBypassProxy("notexample.com")).toBe(false);
+  });
+
+  it("matches wildcard *", () => {
+    process.env.NO_PROXY = "*";
+    expect(shouldBypassProxy("anything.example.com")).toBe(true);
+  });
+
+  it("handles comma-separated entries", () => {
+    process.env.NO_PROXY = "localhost, .internal.corp, api.example.com";
+    expect(shouldBypassProxy("localhost")).toBe(true);
+    expect(shouldBypassProxy("svc.internal.corp")).toBe(true);
+    expect(shouldBypassProxy("api.example.com")).toBe(true);
+    expect(shouldBypassProxy("external.com")).toBe(false);
+  });
+
+  it("ignores empty entries", () => {
+    process.env.NO_PROXY = "localhost,,example.com,";
+    expect(shouldBypassProxy("localhost")).toBe(true);
+    expect(shouldBypassProxy("example.com")).toBe(true);
+    expect(shouldBypassProxy("other.com")).toBe(false);
+  });
+
+  it("reads no_proxy (lowercase) as fallback", () => {
+    process.env.no_proxy = "example.com";
+    expect(shouldBypassProxy("example.com")).toBe(true);
+  });
+
+  it("prefers NO_PROXY over no_proxy", () => {
+    process.env.NO_PROXY = "preferred.com";
+    process.env.no_proxy = "fallback.com";
+    expect(shouldBypassProxy("preferred.com")).toBe(true);
+    expect(shouldBypassProxy("fallback.com")).toBe(false);
+  });
+});
+
+describe("resolveProxyUrl", () => {
+  afterEach(() => {
+    delete process.env.HTTP_PROXY;
+    delete process.env.http_proxy;
+    delete process.env.HTTPS_PROXY;
+    delete process.env.https_proxy;
+    delete process.env.NO_PROXY;
+    delete process.env.no_proxy;
+  });
+
+  it("returns undefined when skipProxy is true", () => {
+    process.env.HTTPS_PROXY = "http://proxy:8080";
+    expect(resolveProxyUrl({ skipProxy: true, protocol: "https:" })).toBeUndefined();
+  });
+
+  it("returns explicit proxyUrl regardless of env", () => {
+    process.env.HTTPS_PROXY = "http://env-proxy:8080";
+    expect(resolveProxyUrl({ proxyUrl: "http://explicit:9090", protocol: "https:" })).toBe(
+      "http://explicit:9090",
+    );
+  });
+
+  it("explicit proxyUrl bypasses NO_PROXY", () => {
+    process.env.NO_PROXY = "*";
+    expect(
+      resolveProxyUrl({
+        proxyUrl: "http://explicit:9090",
+        protocol: "https:",
+        hostname: "anything.com",
+      }),
+    ).toBe("http://explicit:9090");
+  });
+
+  it("returns undefined when hostname matches NO_PROXY", () => {
+    process.env.HTTPS_PROXY = "http://proxy:8080";
+    process.env.NO_PROXY = "example.com";
+    expect(resolveProxyUrl({ protocol: "https:", hostname: "example.com" })).toBeUndefined();
+  });
+
+  it("returns HTTPS_PROXY for https: protocol", () => {
+    process.env.HTTPS_PROXY = "http://https-proxy:8080";
+    expect(resolveProxyUrl({ protocol: "https:" })).toBe("http://https-proxy:8080");
+  });
+
+  it("falls back from HTTPS_PROXY to HTTP_PROXY for https:", () => {
+    process.env.HTTP_PROXY = "http://http-proxy:8080";
+    expect(resolveProxyUrl({ protocol: "https:" })).toBe("http://http-proxy:8080");
+  });
+
+  it("returns HTTP_PROXY for http: protocol", () => {
+    process.env.HTTP_PROXY = "http://http-proxy:8080";
+    expect(resolveProxyUrl({ protocol: "http:" })).toBe("http://http-proxy:8080");
+  });
+
+  it("falls back from HTTP_PROXY to HTTPS_PROXY for http:", () => {
+    process.env.HTTPS_PROXY = "http://https-proxy:8080";
+    expect(resolveProxyUrl({ protocol: "http:" })).toBe("http://https-proxy:8080");
+  });
+
+  it("reads lowercase env vars", () => {
+    process.env.https_proxy = "http://lower:8080";
+    expect(resolveProxyUrl({ protocol: "https:" })).toBe("http://lower:8080");
+  });
+
+  it("prefers uppercase over lowercase env vars", () => {
+    process.env.HTTPS_PROXY = "http://upper:8080";
+    process.env.https_proxy = "http://lower:8080";
+    expect(resolveProxyUrl({ protocol: "https:" })).toBe("http://upper:8080");
+  });
+
+  it("returns undefined when no proxy is configured", () => {
+    expect(resolveProxyUrl({ protocol: "https:" })).toBeUndefined();
+  });
+});

--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -38,13 +38,51 @@ export type GuardedFetchResult = {
 const DEFAULT_MAX_REDIRECTS = 3;
 
 /**
+ * Check if a hostname should bypass the proxy based on NO_PROXY/no_proxy.
+ * Supports comma-separated hostnames and wildcard prefixes (e.g., ".example.com").
+ */
+function shouldBypassProxy(hostname: string): boolean {
+  const noProxy = process.env.NO_PROXY || process.env.no_proxy;
+  if (!noProxy) {
+    return false;
+  }
+  const entries = noProxy.split(",").map((s) => s.trim().toLowerCase());
+  const lowerHost = hostname.toLowerCase();
+  for (const entry of entries) {
+    if (!entry) {
+      continue;
+    }
+    if (entry === "*") {
+      return true;
+    }
+    if (entry === lowerHost) {
+      return true;
+    }
+    if (entry.startsWith(".") && lowerHost.endsWith(entry)) {
+      return true;
+    }
+    if (lowerHost.endsWith("." + entry)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
  * Resolve proxy URL from options or environment variables.
- * Checks HTTP_PROXY, HTTPS_PROXY, http_proxy, https_proxy in order.
+ *
+ * Precedence:
+ * - If noProxy option is true, returns undefined
+ * - If explicit proxyUrl option is provided, uses that
+ * - Checks NO_PROXY/no_proxy to see if hostname should bypass proxy
+ * - For HTTPS: HTTPS_PROXY → https_proxy → HTTP_PROXY → http_proxy
+ * - For HTTP: HTTP_PROXY → http_proxy → HTTPS_PROXY → https_proxy
  */
 function resolveProxyUrl(params: {
   proxyUrl?: string;
   noProxy?: boolean;
   protocol?: string;
+  hostname?: string;
 }): string | undefined {
   if (params.noProxy) {
     return undefined;
@@ -52,7 +90,11 @@ function resolveProxyUrl(params: {
   if (params.proxyUrl) {
     return params.proxyUrl;
   }
-  // Check environment variables (both uppercase and lowercase conventions)
+  // Check NO_PROXY before using environment proxy
+  if (params.hostname && shouldBypassProxy(params.hostname)) {
+    return undefined;
+  }
+  // Check environment variables (protocol-specific first, then fallback)
   const isHttps = params.protocol === "https:";
   if (isHttps) {
     return (
@@ -162,6 +204,7 @@ export async function fetchWithSsrFGuard(params: GuardedFetchOptions): Promise<G
           proxyUrl: params.proxyUrl,
           noProxy: params.noProxy,
           protocol: parsedUrl.protocol,
+          hostname: parsedUrl.hostname,
         });
         dispatcher = createPinnedDispatcher(pinned, { proxyUrl });
       }

--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -41,7 +41,7 @@ const DEFAULT_MAX_REDIRECTS = 3;
  * Check if a hostname should bypass the proxy based on NO_PROXY/no_proxy.
  * Supports comma-separated hostnames and wildcard prefixes (e.g., ".example.com").
  */
-function shouldBypassProxy(hostname: string): boolean {
+export function shouldBypassProxy(hostname: string): boolean {
   const noProxy = process.env.NO_PROXY || process.env.no_proxy;
   if (!noProxy) {
     return false;
@@ -77,7 +77,7 @@ function shouldBypassProxy(hostname: string): boolean {
  * 3. NO_PROXY/no_proxy match → no proxy
  * 4. HTTPS_PROXY/HTTP_PROXY env vars by protocol
  */
-function resolveProxyUrl(params: {
+export function resolveProxyUrl(params: {
   proxyUrl?: string;
   skipProxy?: boolean;
   protocol?: string;

--- a/src/infra/net/ssrf.ts
+++ b/src/infra/net/ssrf.ts
@@ -1,6 +1,6 @@
 import { lookup as dnsLookupCb, type LookupAddress } from "node:dns";
 import { lookup as dnsLookup } from "node:dns/promises";
-import { Agent, type Dispatcher } from "undici";
+import { Agent, ProxyAgent, type Dispatcher } from "undici";
 
 type LookupCallback = (
   err: NodeJS.ErrnoException | null,
@@ -395,11 +395,41 @@ export async function resolvePinnedHostname(
   return await resolvePinnedHostnameWithPolicy(hostname, { lookupFn });
 }
 
-export function createPinnedDispatcher(pinned: PinnedHostname): Dispatcher {
+export type PinnedDispatcherOptions = {
+  /** HTTP/HTTPS proxy URL (e.g., "http://proxy.example.com:8080") */
+  proxyUrl?: string;
+};
+
+/**
+ * Create a dispatcher with DNS pinning for SSRF protection.
+ * Optionally routes through a proxy while maintaining DNS pinning.
+ *
+ * Note: When using a proxy, DNS pinning is applied via both `connect` (for HTTP)
+ * and `requestTls` (for HTTPS) to ensure SSRF protection regardless of protocol.
+ */
+export function createPinnedDispatcher(
+  pinned: PinnedHostname,
+  options?: PinnedDispatcherOptions,
+): Dispatcher {
+  const connectOptions = {
+    lookup: pinned.lookup,
+  };
+
+  if (options?.proxyUrl) {
+    // ProxyAgent with custom lookup for DNS pinning through proxy.
+    // Apply pinning to both connect (HTTP) and requestTls (HTTPS) to
+    // ensure SSRF protection regardless of target protocol.
+    return new ProxyAgent({
+      uri: options.proxyUrl,
+      connect: connectOptions,
+      requestTls: {
+        lookup: pinned.lookup,
+      },
+    });
+  }
+
   return new Agent({
-    connect: {
-      lookup: pinned.lookup,
-    },
+    connect: connectOptions,
   });
 }
 

--- a/src/infra/net/ssrf.ts
+++ b/src/infra/net/ssrf.ts
@@ -406,6 +406,10 @@ export type PinnedDispatcherOptions = {
  *
  * Note: When using a proxy, DNS pinning is applied via both `connect` (for HTTP)
  * and `requestTls` (for HTTPS) to ensure SSRF protection regardless of protocol.
+ *
+ * ProxyAgent options used here require Undici 5.x+. The `requestTls` option
+ * is used for TLS connection options when connecting to the target through proxy.
+ * See: https://undici.nodejs.org/#/docs/api/ProxyAgent
  */
 export function createPinnedDispatcher(
   pinned: PinnedHostname,
@@ -419,6 +423,7 @@ export function createPinnedDispatcher(
     // ProxyAgent with custom lookup for DNS pinning through proxy.
     // Apply pinning to both connect (HTTP) and requestTls (HTTPS) to
     // ensure SSRF protection regardless of target protocol.
+    // Note: requestTls is documented in Undici 5.x+ for TLS options.
     return new ProxyAgent({
       uri: options.proxyUrl,
       connect: connectOptions,


### PR DESCRIPTION
## Summary
- Adds HTTP/HTTPS proxy support to the SSRF-protected fetch guard (`fetchWithSsrFGuard`)
- Reads `HTTP_PROXY`, `HTTPS_PROXY`, `http_proxy`, `https_proxy` env vars automatically
- Adds `NO_PROXY`/`no_proxy` support with wildcard matching (e.g., `.example.com`, `*`)
- Routes through undici `ProxyAgent` while preserving SSRF hostname pre-validation
- Explicit `proxyUrl`/`skipProxy` options available for programmatic override

### Scope
This PR covers proxy support for SSRF-guarded fetch paths: web-fetch tool, media downloads, skill installation, and plugin SDK fetches. LLM API calls (Anthropic, OpenAI, etc.) already get proxy support via pi-ai's `EnvHttpProxyAgent` global dispatcher — this PR closes the remaining gap.

### Security notes
- SSRF pre-validation (`resolvePinnedHostnameWithPolicy`) still runs before every fetch
- When a proxy is configured, DNS pinning (`connect.lookup`) applies to the proxy hostname, not the target — this is documented in code. The proxy server itself must be trusted.
- `requestTls.lookup` was removed (not a valid undici option)

Closes #2102

## Test plan
- [x] 21 unit tests for `shouldBypassProxy` and `resolveProxyUrl` (NO_PROXY matching, env var precedence, skipProxy, explicit override)
- [x] All existing SSRF tests pass (34 total across 4 test files)
- [x] `pnpm build` passes
- [x] `pnpm lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added HTTP/HTTPS proxy support to SSRF-protected fetch paths with `NO_PROXY` bypass functionality. The implementation reads standard proxy environment variables (`HTTP_PROXY`, `HTTPS_PROXY`, and their lowercase variants) and routes requests through undici's `ProxyAgent` while preserving pre-fetch SSRF validation via `resolvePinnedHostnameWithPolicy`. DNS pinning through proxies is documented as limited (pins proxy hostname, not target). The `skipProxy` option disables all proxy detection, and explicit `proxyUrl` bypasses `NO_PROXY` checks (by design, per JSDoc). All previous thread comments have been addressed in commit 65a25fe92.

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no remaining issues
- The implementation is well-tested (21 new proxy tests + 34 existing SSRF tests pass), addresses all previous review comments, and correctly preserves SSRF pre-validation. The proxy DNS pinning limitation is properly documented, and the design choices (explicit `proxyUrl` bypassing `NO_PROXY`, `skipProxy` for full disable) are intentional and documented. No logical errors, security vulnerabilities, or implementation issues found.
- No files require special attention

<sub>Last reviewed commit: f247fb0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->