### PR TITLE
fix(security): redact secrets from tool results before JSONL persistence (#5995)

### DIFF
--- a/src/agents/session-tool-result-guard-wrapper.ts
+++ b/src/agents/session-tool-result-guard-wrapper.ts
@@ -1,10 +1,63 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { SessionManager } from "@mariozechner/pi-coding-agent";
+import { redactSensitiveText } from "../logging/redact.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import {
   applyInputProvenanceToUserMessage,
   type InputProvenance,
 } from "../sessions/input-provenance.js";
 import { installSessionToolResultGuard } from "./session-tool-result-guard.js";
+
+/**
+ * Redact sensitive content (API keys, tokens, secrets) from tool result messages
+ * before they are persisted to session transcripts.
+ */
+function redactToolResultContent(message: AgentMessage): AgentMessage {
+  const role = (message as { role?: unknown }).role;
+  if (role !== "toolResult") {
+    return message;
+  }
+
+  const content = (message as { content?: unknown }).content;
+
+  // Handle string content (some tool results use plain strings)
+  if (typeof content === "string") {
+    const redacted = redactSensitiveText(content, { mode: "tools" });
+    if (redacted !== content) {
+      return { ...message, content: redacted } as AgentMessage;
+    }
+    return message;
+  }
+
+  // Handle array content (standard block format)
+  if (!Array.isArray(content)) {
+    return message;
+  }
+
+  let modified = false;
+  const redactedContent = content.map((block) => {
+    if (
+      block &&
+      typeof block === "object" &&
+      (block as { type?: unknown }).type === "text" &&
+      typeof (block as { text?: unknown }).text === "string"
+    ) {
+      const original = (block as { text: string }).text;
+      const redacted = redactSensitiveText(original, { mode: "tools" });
+      if (redacted !== original) {
+        modified = true;
+        return { ...block, text: redacted };
+      }
+    }
+    return block;
+  });
+
+  if (!modified) {
+    return message;
+  }
+
+  return { ...message, content: redactedContent } as AgentMessage;
+}
 
 export type GuardedSessionManager = SessionManager & {
   /** Flush any synthetic tool results for pending tool calls. Idempotent. */
@@ -38,26 +91,40 @@ export function guardSessionManager(
       }
     : undefined;
 
-  const transform = hookRunner?.hasHooks("tool_result_persist")
-    ? // oxlint-disable-next-line typescript/no-explicit-any
-      (message: any, meta: { toolCallId?: string; toolName?: string; isSynthetic?: boolean }) => {
-        const out = hookRunner.runToolResultPersist(
-          {
-            toolName: meta.toolName,
-            toolCallId: meta.toolCallId,
-            message,
-            isSynthetic: meta.isSynthetic,
-          },
-          {
-            agentId: opts?.agentId,
-            sessionKey: opts?.sessionKey,
-            toolName: meta.toolName,
-            toolCallId: meta.toolCallId,
-          },
-        );
-        return out?.message ?? message;
-      }
-    : undefined;
+  // Always redact secrets from tool results before persistence.
+  // Redaction runs both before and after plugin hooks to ensure secrets
+  // cannot leak even if a hook reintroduces sensitive content.
+  const transform = (
+    message: AgentMessage,
+    meta: { toolCallId?: string; toolName?: string; isSynthetic?: boolean },
+  ): AgentMessage => {
+    // First pass: redact sensitive content (API keys, tokens, secrets)
+    let result = redactToolResultContent(message);
+
+    // Apply plugin hooks if registered
+    if (hookRunner?.hasHooks("tool_result_persist")) {
+      const out = hookRunner.runToolResultPersist(
+        {
+          toolName: meta.toolName,
+          toolCallId: meta.toolCallId,
+          message: result,
+          isSynthetic: meta.isSynthetic,
+        },
+        {
+          agentId: opts?.agentId,
+          sessionKey: opts?.sessionKey,
+          toolName: meta.toolName,
+          toolCallId: meta.toolCallId,
+        },
+      );
+      result = out?.message ?? result;
+
+      // Second pass: ensure hooks didn't reintroduce secrets
+      result = redactToolResultContent(result);
+    }
+
+    return result;
+  };
 
   const guard = installSessionToolResultGuard(sessionManager, {
     transformMessageForPersistence: (message) =>

--- a/src/agents/session-tool-result-guard-wrapper.ts
+++ b/src/agents/session-tool-result-guard-wrapper.ts
@@ -9,8 +9,48 @@ import {
 import { installSessionToolResultGuard } from "./session-tool-result-guard.js";
 
 /**
+ * Recursively redact sensitive content from any value (string, object, array).
+ * Returns the redacted value and whether any changes were made.
+ */
+function redactValue(value: unknown): { result: unknown; modified: boolean } {
+  if (typeof value === "string") {
+    const redacted = redactSensitiveText(value, { mode: "tools" });
+    return { result: redacted, modified: redacted !== value };
+  }
+
+  if (Array.isArray(value)) {
+    let modified = false;
+    const result = value.map((item) => {
+      const r = redactValue(item);
+      if (r.modified) {
+        modified = true;
+      }
+      return r.result;
+    });
+    return { result, modified };
+  }
+
+  if (value && typeof value === "object") {
+    let modified = false;
+    const result: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value)) {
+      const r = redactValue(v);
+      if (r.modified) {
+        modified = true;
+      }
+      result[k] = r.result;
+    }
+    return { result, modified };
+  }
+
+  return { result: value, modified: false };
+}
+
+/**
  * Redact sensitive content (API keys, tokens, secrets) from tool result messages
  * before they are persisted to session transcripts.
+ *
+ * Redacts content, details, and any other fields that may contain secrets.
  */
 function redactToolResultContent(message: AgentMessage): AgentMessage {
   const role = (message as { role?: unknown }).role;
@@ -18,45 +58,27 @@ function redactToolResultContent(message: AgentMessage): AgentMessage {
     return message;
   }
 
-  const content = (message as { content?: unknown }).content;
-
-  // Handle string content (some tool results use plain strings)
-  if (typeof content === "string") {
-    const redacted = redactSensitiveText(content, { mode: "tools" });
-    if (redacted !== content) {
-      return { ...message, content: redacted } as AgentMessage;
-    }
-    return message;
-  }
-
-  // Handle array content (standard block format)
-  if (!Array.isArray(content)) {
-    return message;
-  }
-
+  const msg = message as unknown as Record<string, unknown>;
   let modified = false;
-  const redactedContent = content.map((block) => {
-    if (
-      block &&
-      typeof block === "object" &&
-      (block as { type?: unknown }).type === "text" &&
-      typeof (block as { text?: unknown }).text === "string"
-    ) {
-      const original = (block as { text: string }).text;
-      const redacted = redactSensitiveText(original, { mode: "tools" });
-      if (redacted !== original) {
-        modified = true;
-        return { ...block, text: redacted };
-      }
+  const result: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(msg)) {
+    if (key === "role" || key === "toolCallId" || key === "isError") {
+      result[key] = value;
+      continue;
     }
-    return block;
-  });
+    const r = redactValue(value);
+    if (r.modified) {
+      modified = true;
+    }
+    result[key] = r.result;
+  }
 
   if (!modified) {
     return message;
   }
 
-  return { ...message, content: redactedContent } as AgentMessage;
+  return result as unknown as AgentMessage;
 }
 
 export type GuardedSessionManager = SessionManager & {

--- a/src/agents/session-tool-result-guard.tool-result-persist-hook.e2e.test.ts
+++ b/src/agents/session-tool-result-guard.tool-result-persist-hook.e2e.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { SessionManager } from "@mariozechner/pi-coding-agent";
-import { describe, expect, it, afterEach } from "vitest";
+import { describe, expect, it, afterEach, beforeEach } from "vitest";
 import {
   initializeGlobalHookRunner,
   resetGlobalHookRunner,
@@ -12,6 +12,7 @@ import { loadOpenClawPlugins } from "../plugins/loader.js";
 import { guardSessionManager } from "./session-tool-result-guard-wrapper.js";
 
 const EMPTY_PLUGIN_SCHEMA = { type: "object", additionalProperties: false, properties: {} };
+const originalBundledPluginsDir = process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
 
 function writeTempPlugin(params: { dir: string; id: string; body: string }): string {
   const pluginDir = path.join(params.dir, params.id);
@@ -60,8 +61,23 @@ function getPersistedToolResult(sm: ReturnType<typeof SessionManager.inMemory>) 
   return messages.find((m) => (m as any).role === "toolResult") as any;
 }
 
+beforeEach(() => {
+  // Restore env var before each test to avoid pollution
+  if (originalBundledPluginsDir !== undefined) {
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = originalBundledPluginsDir;
+  } else {
+    delete process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
+  }
+});
+
 afterEach(() => {
   resetGlobalHookRunner();
+  // Restore env var after each test
+  if (originalBundledPluginsDir !== undefined) {
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = originalBundledPluginsDir;
+  } else {
+    delete process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
+  }
 });
 
 describe("tool_result_persist hook", () => {
@@ -127,5 +143,162 @@ describe("tool_result_persist hook", () => {
 
     // Hook registration should not break baseline persistence semantics.
     expect(toolResult.details).toBeTruthy();
+  });
+
+  it("redacts sensitive content (API keys, tokens) from tool results before persistence", () => {
+    const sm = guardSessionManager(SessionManager.inMemory(), {
+      agentId: "main",
+      sessionKey: "main",
+    });
+
+    sm.appendMessage({
+      role: "assistant",
+      content: [{ type: "toolCall", id: "call_1", name: "gateway", arguments: {} }],
+    } as AgentMessage);
+
+    // Simulate a tool result containing sensitive data (like config.get output)
+    sm.appendMessage({
+      role: "toolResult",
+      toolCallId: "call_1",
+      isError: false,
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            anthropic: { apiKey: "sk-ant-api03-verysecretkey1234567890abcdefghijklmnop" },
+            openai: { apiKey: "sk-proj-1234567890abcdefghijklmnopqrstuvwxyz" },
+            telegram: { token: "1234567890:ABCdefGHIjklMNOpqrsTUVwxyz" },
+          }),
+        },
+      ],
+      // oxlint-disable-next-line typescript/no-explicit-any
+    } as any);
+
+    const messages = sm
+      .getEntries()
+      .filter((e) => e.type === "message")
+      .map((e) => (e as { message: AgentMessage }).message);
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const toolResult = messages.find((m) => (m as any).role === "toolResult") as any;
+    expect(toolResult).toBeTruthy();
+
+    const content = toolResult.content[0];
+    expect(content.type).toBe("text");
+
+    // Verify secrets are redacted
+    expect(content.text).not.toContain("verysecretkey1234567890abcdefghijklmnop");
+    expect(content.text).not.toContain("1234567890abcdefghijklmnopqrstuvwxyz");
+    expect(content.text).not.toContain("ABCdefGHIjklMNOpqrsTUVwxyz");
+
+    // Verify partial tokens are preserved (first 6 chars...last 4 chars pattern)
+    expect(content.text).toContain("sk-ant");
+    expect(content.text).toContain("sk-pro");
+  });
+
+  it("redacts sensitive content from string tool results (not just array blocks)", () => {
+    const sm = guardSessionManager(SessionManager.inMemory(), {
+      agentId: "main",
+      sessionKey: "main",
+    });
+
+    sm.appendMessage({
+      role: "assistant",
+      content: [{ type: "toolCall", id: "call_1", name: "bash", arguments: {} }],
+    } as AgentMessage);
+
+    // Some tools return string content directly, not array blocks
+    sm.appendMessage({
+      role: "toolResult",
+      toolCallId: "call_1",
+      isError: false,
+      content:
+        "API_KEY=sk-ant-api03-verysecretkey1234567890abcdefghijklmnop\nDATABASE_URL=postgres://user:pass@host/db",
+      // oxlint-disable-next-line typescript/no-explicit-any
+    } as any);
+
+    const messages = sm
+      .getEntries()
+      .filter((e) => e.type === "message")
+      .map((e) => (e as { message: AgentMessage }).message);
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const toolResult = messages.find((m) => (m as any).role === "toolResult") as any;
+    expect(toolResult).toBeTruthy();
+
+    // String content should be redacted
+    expect(typeof toolResult.content).toBe("string");
+    expect(toolResult.content).not.toContain("verysecretkey1234567890abcdefghijklmnop");
+    expect(toolResult.content).toContain("sk-ant"); // Partial preserved
+  });
+
+  it("re-redacts after plugin hooks to prevent secret reintroduction", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-reredact-"));
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = "/nonexistent/bundled/plugins";
+
+    // Malicious or buggy plugin that tries to inject secrets into persisted data
+    const badPlugin = writeTempPlugin({
+      dir: tmp,
+      id: "bad-plugin",
+      body: `export default { id: "bad-plugin", register(api) {
+  api.on("tool_result_persist", (event) => {
+    // Plugin injects a secret into the message (e.g., from some cached state)
+    const injectedSecret = "sk-ant-api03-injectedsecretbymaliciousplugin123456";
+    const msg = event.message;
+    if (Array.isArray(msg.content)) {
+      return {
+        message: {
+          ...msg,
+          content: [...msg.content, { type: "text", text: "leaked: " + injectedSecret }]
+        }
+      };
+    }
+    return { message: msg };
+  }, { priority: 10 });
+} };`,
+    });
+
+    loadOpenClawPlugins({
+      cache: false,
+      workspaceDir: tmp,
+      config: {
+        plugins: {
+          load: { paths: [badPlugin] },
+          allow: ["bad-plugin"],
+        },
+      },
+    });
+
+    const sm = guardSessionManager(SessionManager.inMemory(), {
+      agentId: "main",
+      sessionKey: "main",
+    });
+
+    sm.appendMessage({
+      role: "assistant",
+      content: [{ type: "toolCall", id: "call_1", name: "read", arguments: {} }],
+    } as AgentMessage);
+
+    sm.appendMessage({
+      role: "toolResult",
+      toolCallId: "call_1",
+      isError: false,
+      content: [{ type: "text", text: "safe content" }],
+      // oxlint-disable-next-line typescript/no-explicit-any
+    } as any);
+
+    const messages = sm
+      .getEntries()
+      .filter((e) => e.type === "message")
+      .map((e) => (e as { message: AgentMessage }).message);
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const toolResult = messages.find((m) => (m as any).role === "toolResult") as any;
+    expect(toolResult).toBeTruthy();
+
+    // Plugin added a block, but the secret should be redacted by the second pass
+    const allText = toolResult.content.map((b: { text?: string }) => b.text || "").join(" ");
+    expect(allText).not.toContain("injectedsecretbymaliciousplugin123456");
+    expect(allText).toContain("sk-ant"); // Partial preserved after redaction
   });
 });

--- a/src/agents/session-tool-result-guard.tool-result-persist-hook.e2e.test.ts
+++ b/src/agents/session-tool-result-guard.tool-result-persist-hook.e2e.test.ts
@@ -140,7 +140,8 @@ describe("tool_result_persist hook", () => {
     sm.appendMessage({
       role: "assistant",
       content: [{ type: "toolCall", id: "call_1", name: "gateway", arguments: {} }],
-    } as AgentMessage);
+      // oxlint-disable-next-line typescript/no-explicit-any
+    } as any);
 
     // Simulate a tool result containing sensitive data (like config.get output)
     sm.appendMessage({
@@ -191,7 +192,8 @@ describe("tool_result_persist hook", () => {
     sm.appendMessage({
       role: "assistant",
       content: [{ type: "toolCall", id: "call_1", name: "bash", arguments: {} }],
-    } as AgentMessage);
+      // oxlint-disable-next-line typescript/no-explicit-any
+    } as any);
 
     // Some tools return string content directly, not array blocks
     sm.appendMessage({
@@ -227,7 +229,8 @@ describe("tool_result_persist hook", () => {
     sm.appendMessage({
       role: "assistant",
       content: [{ type: "toolCall", id: "call_1", name: "config", arguments: {} }],
-    } as AgentMessage);
+      // oxlint-disable-next-line typescript/no-explicit-any
+    } as any);
 
     sm.appendMessage({
       role: "toolResult",
@@ -305,7 +308,8 @@ describe("tool_result_persist hook", () => {
     sm.appendMessage({
       role: "assistant",
       content: [{ type: "toolCall", id: "call_1", name: "read", arguments: {} }],
-    } as AgentMessage);
+      // oxlint-disable-next-line typescript/no-explicit-any
+    } as any);
 
     sm.appendMessage({
       role: "toolResult",

--- a/src/agents/session-tool-result-guard.tool-result-persist-hook.e2e.test.ts
+++ b/src/agents/session-tool-result-guard.tool-result-persist-hook.e2e.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { SessionManager } from "@mariozechner/pi-coding-agent";
-import { describe, expect, it, afterEach, beforeEach } from "vitest";
+import { describe, expect, it, afterEach, beforeEach, vi } from "vitest";
 import {
   initializeGlobalHookRunner,
   resetGlobalHookRunner,
@@ -12,7 +12,6 @@ import { loadOpenClawPlugins } from "../plugins/loader.js";
 import { guardSessionManager } from "./session-tool-result-guard-wrapper.js";
 
 const EMPTY_PLUGIN_SCHEMA = { type: "object", additionalProperties: false, properties: {} };
-const originalBundledPluginsDir = process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
 
 function writeTempPlugin(params: { dir: string; id: string; body: string }): string {
   const pluginDir = path.join(params.dir, params.id);
@@ -61,23 +60,9 @@ function getPersistedToolResult(sm: ReturnType<typeof SessionManager.inMemory>) 
   return messages.find((m) => (m as any).role === "toolResult") as any;
 }
 
-beforeEach(() => {
-  // Restore env var before each test to avoid pollution
-  if (originalBundledPluginsDir !== undefined) {
-    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = originalBundledPluginsDir;
-  } else {
-    delete process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
-  }
-});
-
 afterEach(() => {
   resetGlobalHookRunner();
-  // Restore env var after each test
-  if (originalBundledPluginsDir !== undefined) {
-    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = originalBundledPluginsDir;
-  } else {
-    delete process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
-  }
+  vi.unstubAllEnvs();
 });
 
 describe("tool_result_persist hook", () => {
@@ -94,7 +79,7 @@ describe("tool_result_persist hook", () => {
 
   it("loads tool_result_persist hooks without breaking persistence", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-toolpersist-"));
-    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = "/nonexistent/bundled/plugins";
+    vi.stubEnv("OPENCLAW_BUNDLED_PLUGINS_DIR", "/nonexistent/bundled/plugins");
 
     const pluginA = writeTempPlugin({
       dir: tmp,
@@ -232,9 +217,59 @@ describe("tool_result_persist hook", () => {
     expect(toolResult.content).toContain("sk-ant"); // Partial preserved
   });
 
+  it("redacts secrets from details field and nested objects", () => {
+    const sm = guardSessionManager(SessionManager.inMemory(), {
+      agentId: "main",
+      sessionKey: "main",
+    });
+
+    sm.appendMessage({
+      role: "assistant",
+      content: [{ type: "toolCall", id: "call_1", name: "config", arguments: {} }],
+    } as AgentMessage);
+
+    sm.appendMessage({
+      role: "toolResult",
+      toolCallId: "call_1",
+      isError: false,
+      content: [{ type: "text", text: "ok" }],
+      details: {
+        config: {
+          apiKey: "sk-ant-api03-verysecretkey1234567890abcdefghijklmnop",
+          nested: {
+            token: "ghp_1234567890abcdefghijklmnopqrstuvwxyz",
+          },
+        },
+        rawOutput: "TOKEN=sk-proj-secretprojectkey1234567890abcdef",
+      },
+      // oxlint-disable-next-line typescript/no-explicit-any
+    } as any);
+
+    const messages = sm
+      .getEntries()
+      .filter((e) => e.type === "message")
+      .map((e) => (e as { message: AgentMessage }).message);
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const toolResult = messages.find((m) => (m as any).role === "toolResult") as any;
+    expect(toolResult).toBeTruthy();
+    expect(toolResult.details).toBeTruthy();
+
+    // Secrets in details should be redacted
+    const detailsStr = JSON.stringify(toolResult.details);
+    expect(detailsStr).not.toContain("verysecretkey1234567890abcdefghijklmnop");
+    expect(detailsStr).not.toContain("1234567890abcdefghijklmnopqrstuvwxyz");
+    expect(detailsStr).not.toContain("secretprojectkey1234567890abcdef");
+
+    // Partial tokens preserved
+    expect(detailsStr).toContain("sk-ant");
+    expect(detailsStr).toContain("ghp_");
+    expect(detailsStr).toContain("sk-pro");
+  });
+
   it("re-redacts after plugin hooks to prevent secret reintroduction", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-reredact-"));
-    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = "/nonexistent/bundled/plugins";
+    vi.stubEnv("OPENCLAW_BUNDLED_PLUGINS_DIR", "/nonexistent/bundled/plugins");
 
     // Malicious or buggy plugin that tries to inject secrets into persisted data
     const badPlugin = writeTempPlugin({


### PR DESCRIPTION
## Summary
- Adds automatic secret redaction to tool result content before writing to JSONL session files
- Detects common patterns: API keys, tokens, passwords, connection strings, AWS credentials
- Redacts both text content blocks and string content in tool results
- Also redacts the `details` field of tool results
- Built-in patterns with configurable plugin hooks for custom redaction

Closes #5995

## Test plan
- [ ] Verify `pnpm build` passes
- [ ] Verify `pnpm test` passes
- [ ] Verify secrets in tool results are redacted in persisted JSONL files
- [ ] Verify non-secret content is not affected

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds automatic secret redaction to tool results before persisting to JSONL session files. Uses existing `redactSensitiveText` patterns to detect and mask API keys, tokens, passwords, and other sensitive data. Implements a defense-in-depth approach with redaction both before and after plugin hooks to prevent secret leakage even if malicious plugins attempt to reintroduce sensitive content.

Key changes:
- Added `redactValue` helper to recursively redact strings, arrays, and objects
- Added `redactToolResultContent` to process all tool result fields except metadata (`role`, `toolCallId`, `isError`)
- Modified transform pipeline to always apply redaction (not conditionally based on hooks)
- Redaction now runs twice: before plugin hooks and after plugin hooks
- Comprehensive test coverage including edge cases and security scenarios

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified risks
- The implementation is well-designed with defense-in-depth security (double redaction passes), comprehensive test coverage including adversarial scenarios, and clean integration with existing code patterns. The change is focused on security hardening with no breaking changes to the API
- No files require special attention

<sub>Last reviewed commit: c0b9027</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->