### PR TITLE
fix: use a single asterisk to wrap the bold text in whatsapp

### DIFF
--- a/docs/reference/templates/AGENTS.md
+++ b/docs/reference/templates/AGENTS.md
@@ -129,7 +129,7 @@ Skills provide your tools. When you need one, check its `SKILL.md`. Keep local n
 
 - **Discord/WhatsApp:** No markdown tables! Use bullet lists instead
 - **Discord links:** Wrap multiple links in `<>` to suppress embeds: `<https://example.com>`
-- **WhatsApp:** No headers — use *bold* (wrapping in single asterisk) or CAPS for emphasis
+- **WhatsApp:** No headers — use `*bold*` (wrapping in single asterisk) or CAPS for emphasis
 
 ## 💓 Heartbeats - Be Proactive!
 

--- a/docs/reference/templates/AGENTS.md
+++ b/docs/reference/templates/AGENTS.md
@@ -129,7 +129,7 @@ Skills provide your tools. When you need one, check its `SKILL.md`. Keep local n
 
 - **Discord/WhatsApp:** No markdown tables! Use bullet lists instead
 - **Discord links:** Wrap multiple links in `<>` to suppress embeds: `<https://example.com>`
-- **WhatsApp:** No headers — use **bold** or CAPS for emphasis
+- **WhatsApp:** No headers — use *bold* (wrapping in single asterisk) or CAPS for emphasis
 
 ## 💓 Heartbeats - Be Proactive!
 


### PR DESCRIPTION
### Problem

When the agent uses whatsapp and what to emphatise some content it uses an extra asterisk (*) that wraps the whole bold text. As shown below:

<img width="507" height="279" alt="image" src="https://github.com/user-attachments/assets/3aed0b69-c353-4c52-b3b4-4b8d61fe19ba" />


### Root cause

The AGENTS.md contains the instruction that tells to use double asterisks (**) to emphatise some content:

```text
- **WhatsApp:** No headers — use **bold** or CAPS for emphasis
```

This behavior is wrong with whatsapp, because whatsapp do not follow the same markdown rules and it uses a single asterisk (*) for bold text. The whatsapp formatting is described [here](https://faq.whatsapp.com/539178204879377/).

### Fix

Simply define to use a single asterisk in the AGENTS.md for the specific channel whatsapp.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes the WhatsApp formatting instruction in the workspace AGENTS.md template. WhatsApp uses single asterisks (`*text*`) for bold, not double asterisks (`**text**`) like standard markdown. The old instruction caused the agent to produce `**bold text**` on WhatsApp, which rendered with visible extra asterisks instead of bold formatting. The fix also wraps the `*bold*` example in backticks so it displays literally rather than being interpreted as italic in markdown renderers.

- Corrected WhatsApp bold syntax from `**bold**` to `*bold*` with explanatory parenthetical
- Wrapped syntax example in backticks to prevent markdown rendering of the asterisks

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a small, correct documentation fix with no code changes.
- The change is a one-line documentation fix in a template file. It corrects an objectively wrong instruction (WhatsApp uses single asterisks for bold, not double). The fix is accurate per WhatsApp's documented formatting rules. No code, tests, or build artifacts are affected.
- No files require special attention.

<sub>Last reviewed commit: 906ef9e</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - docs/reference/templates/AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=ef691cbd-a005-4c3e-998b-6fcd72f2d312))

<!-- /greptile_comment -->