### PR TITLE
fix: make sensitive field whitelist case-insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Subagents/Models: preserve `agents.defaults.model.fallbacks` when subagent sessions carry a model override, so subagent runs fail over to configured fallback models instead of retrying only the overridden primary model.
+- Config/Gateway: make sensitive-key whitelist suffix matching case-insensitive while preserving `passwordFile` path exemptions, preventing accidental redaction of non-secret config values like `maxTokens` and IRC password-file paths. (#16042) Thanks @akramcodez.
 - Group chats: always inject group chat context (name, participants, reply guidance) into the system prompt on every turn, not just the first. Prevents the model from losing awareness of which group it's in and incorrectly using the message tool to send to the same group. (#14447) Thanks @tyler6204.
 - TUI: make searchable-select filtering and highlight rendering ANSI-aware so queries ignore hidden escape codes and no longer corrupt ANSI styling sequences during match highlighting. (#4519) Thanks @bee4come.
 - TUI/Windows: coalesce rapid single-line submit bursts in Git Bash into one multiline message as a fallback when bracketed paste is unavailable, preventing pasted multiline text from being split into multiple sends. (#4986) Thanks @adamkane.

--- a/src/config/redact-snapshot.test.ts
+++ b/src/config/redact-snapshot.test.ts
@@ -179,6 +179,29 @@ describe("redactConfigSnapshot", () => {
     expect(gw.auth.token).toBe(REDACTED_SENTINEL);
   });
 
+  it("does not redact passwordFile path fields", () => {
+    const snapshot = makeSnapshot({
+      channels: {
+        irc: {
+          passwordFile: "/etc/openclaw/irc-password.txt",
+          nickserv: {
+            passwordFile: "/etc/openclaw/nickserv-password.txt",
+            password: "super-secret-nickserv-password",
+          },
+        },
+      },
+    });
+
+    const result = redactConfigSnapshot(snapshot);
+    const channels = result.config.channels as Record<string, Record<string, unknown>>;
+    const irc = channels.irc;
+    const nickserv = irc.nickserv as Record<string, unknown>;
+
+    expect(irc.passwordFile).toBe("/etc/openclaw/irc-password.txt");
+    expect(nickserv.passwordFile).toBe("/etc/openclaw/nickserv-password.txt");
+    expect(nickserv.password).toBe(REDACTED_SENTINEL);
+  });
+
   it("preserves hash unchanged", () => {
     const snapshot = makeSnapshot({ gateway: { auth: { token: "secret-token-value-here" } } });
     const result = redactConfigSnapshot(snapshot);

--- a/src/config/redact-snapshot.test.ts
+++ b/src/config/redact-snapshot.test.ts
@@ -366,7 +366,9 @@ describe("redactConfigSnapshot", () => {
     });
     const result = redactConfigSnapshot(snapshot, hints);
     const custom = result.config.custom as Record<string, string>;
+    const resolved = result.resolved as Record<string, Record<string, string>>;
     expect(custom.mySecret).toBe(REDACTED_SENTINEL);
+    expect(resolved.custom.mySecret).toBe(REDACTED_SENTINEL);
   });
 
   it("keeps regex fallback for extension keys not covered by uiHints", () => {
@@ -653,7 +655,9 @@ describe("redactConfigSnapshot", () => {
     });
     const result = redactConfigSnapshot(snapshot, hints);
     const gw = result.config.gateway as Record<string, Record<string, string>>;
+    const resolved = result.resolved as Record<string, Record<string, Record<string, string>>>;
     expect(gw.auth.token).toBe("not-actually-secret-value");
+    expect(resolved.gateway.auth.token).toBe("not-actually-secret-value");
   });
 
   it("does not redact paths absent from uiHints (schema is single source of truth)", () => {
@@ -665,7 +669,9 @@ describe("redactConfigSnapshot", () => {
     });
     const result = redactConfigSnapshot(snapshot, hints);
     const gw = result.config.gateway as Record<string, Record<string, string>>;
+    const resolved = result.resolved as Record<string, Record<string, Record<string, string>>>;
     expect(gw.auth.password).toBe("not-in-hints-value");
+    expect(resolved.gateway.auth.password).toBe("not-in-hints-value");
   });
 
   it("uses wildcard hints for array items", () => {

--- a/src/config/redact-snapshot.ts
+++ b/src/config/redact-snapshot.ts
@@ -301,7 +301,7 @@ export function redactConfigSnapshot(
   const redactedRaw = snapshot.raw ? redactRawText(snapshot.raw, snapshot.config, uiHints) : null;
   const redactedParsed = snapshot.parsed ? redactObject(snapshot.parsed, uiHints) : snapshot.parsed;
   // Also redact the resolved config (contains values after ${ENV} substitution)
-  const redactedResolved = redactConfigObject(snapshot.resolved);
+  const redactedResolved = redactConfigObject(snapshot.resolved, uiHints);
 
   return {
     ...snapshot,

--- a/src/config/schema.hints.test.ts
+++ b/src/config/schema.hints.test.ts
@@ -8,10 +8,22 @@ const { mapSensitivePaths } = __test__;
 
 describe("isSensitiveConfigPath", () => {
   it("matches whitelist suffixes case-insensitively", () => {
-    expect(isSensitiveConfigPath("maxTokens")).toBe(false);
-    expect(isSensitiveConfigPath("MAXTOKENS")).toBe(false);
-    expect(isSensitiveConfigPath("channels.irc.nickserv.passwordFile")).toBe(false);
-    expect(isSensitiveConfigPath("channels.irc.nickserv.PASSWORDFILE")).toBe(false);
+    const whitelistedPaths = [
+      "maxTokens",
+      "maxOutputTokens",
+      "maxInputTokens",
+      "maxCompletionTokens",
+      "contextTokens",
+      "totalTokens",
+      "tokenCount",
+      "tokenLimit",
+      "tokenBudget",
+      "channels.irc.nickserv.passwordFile",
+    ];
+    for (const path of whitelistedPaths) {
+      expect(isSensitiveConfigPath(path)).toBe(false);
+      expect(isSensitiveConfigPath(path.toUpperCase())).toBe(false);
+    }
   });
 
   it("keeps true sensitive keys redacted", () => {

--- a/src/config/schema.hints.test.ts
+++ b/src/config/schema.hints.test.ts
@@ -1,10 +1,25 @@
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
-import { __test__ } from "./schema.hints.js";
+import { __test__, isSensitiveConfigPath } from "./schema.hints.js";
 import { OpenClawSchema } from "./zod-schema.js";
 import { sensitive } from "./zod-schema.sensitive.js";
 
 const { mapSensitivePaths } = __test__;
+
+describe("isSensitiveConfigPath", () => {
+  it("matches whitelist suffixes case-insensitively", () => {
+    expect(isSensitiveConfigPath("maxTokens")).toBe(false);
+    expect(isSensitiveConfigPath("MAXTOKENS")).toBe(false);
+    expect(isSensitiveConfigPath("channels.irc.nickserv.passwordFile")).toBe(false);
+    expect(isSensitiveConfigPath("channels.irc.nickserv.PASSWORDFILE")).toBe(false);
+  });
+
+  it("keeps true sensitive keys redacted", () => {
+    expect(isSensitiveConfigPath("channels.slack.token")).toBe(true);
+    expect(isSensitiveConfigPath("models.providers.openai.apiKey")).toBe(true);
+    expect(isSensitiveConfigPath("channels.irc.nickserv.password")).toBe(true);
+  });
+});
 
 describe("mapSensitivePaths", () => {
   it("should detect sensitive fields nested inside all structural Zod types", () => {

--- a/src/config/schema.hints.ts
+++ b/src/config/schema.hints.ts
@@ -109,12 +109,17 @@ const NORMALIZED_SENSITIVE_KEY_WHITELIST_SUFFIXES = SENSITIVE_KEY_WHITELIST_SUFF
 
 const SENSITIVE_PATTERNS = [/token$/i, /password/i, /secret/i, /api.?key/i];
 
-export function isSensitiveConfigPath(path: string): boolean {
+function isWhitelistedSensitivePath(path: string): boolean {
   const lowerPath = path.toLowerCase();
-  const whitelisted = NORMALIZED_SENSITIVE_KEY_WHITELIST_SUFFIXES.some((suffix) =>
-    lowerPath.endsWith(suffix),
-  );
-  return !whitelisted && SENSITIVE_PATTERNS.some((pattern) => pattern.test(path));
+  return NORMALIZED_SENSITIVE_KEY_WHITELIST_SUFFIXES.some((suffix) => lowerPath.endsWith(suffix));
+}
+
+function matchesSensitivePattern(path: string): boolean {
+  return SENSITIVE_PATTERNS.some((pattern) => pattern.test(path));
+}
+
+export function isSensitiveConfigPath(path: string): boolean {
+  return !isWhitelistedSensitivePath(path) && matchesSensitivePattern(path);
 }
 
 export function buildBaseHints(): ConfigUiHints {

--- a/src/config/schema.hints.ts
+++ b/src/config/schema.hints.ts
@@ -107,8 +107,9 @@ const SENSITIVE_KEY_WHITELIST = new Set([
 const SENSITIVE_PATTERNS = [/token$/i, /password/i, /secret/i, /api.?key/i];
 
 export function isSensitiveConfigPath(path: string): boolean {
+  const lowerPath = path.toLowerCase();
   return (
-    !Array.from(SENSITIVE_KEY_WHITELIST).some((suffix) => path.endsWith(suffix)) &&
+    !Array.from(SENSITIVE_KEY_WHITELIST).some((suffix) => lowerPath.endsWith(suffix)) &&
     SENSITIVE_PATTERNS.some((pattern) => pattern.test(path))
   );
 }

--- a/src/config/schema.hints.ts
+++ b/src/config/schema.hints.ts
@@ -101,14 +101,19 @@ const SENSITIVE_KEY_WHITELIST_SUFFIXES = [
   "tokencount",
   "tokenlimit",
   "tokenbudget",
-  "passwordfile",
+  "passwordFile",
 ] as const;
+const NORMALIZED_SENSITIVE_KEY_WHITELIST_SUFFIXES = SENSITIVE_KEY_WHITELIST_SUFFIXES.map((suffix) =>
+  suffix.toLowerCase(),
+);
 
 const SENSITIVE_PATTERNS = [/token$/i, /password/i, /secret/i, /api.?key/i];
 
 export function isSensitiveConfigPath(path: string): boolean {
   const lowerPath = path.toLowerCase();
-  const whitelisted = SENSITIVE_KEY_WHITELIST_SUFFIXES.some((suffix) => lowerPath.endsWith(suffix));
+  const whitelisted = NORMALIZED_SENSITIVE_KEY_WHITELIST_SUFFIXES.some((suffix) =>
+    lowerPath.endsWith(suffix),
+  );
   return !whitelisted && SENSITIVE_PATTERNS.some((pattern) => pattern.test(path));
 }
 

--- a/src/config/schema.hints.ts
+++ b/src/config/schema.hints.ts
@@ -91,7 +91,7 @@ const FIELD_PLACEHOLDERS: Record<string, string> = {
  * These are explicitly excluded from redaction (plugin config) and
  * warnings about not being marked sensitive (base config).
  */
-const SENSITIVE_KEY_WHITELIST = new Set([
+const SENSITIVE_KEY_WHITELIST_SUFFIXES = [
   "maxtokens",
   "maxoutputtokens",
   "maxinputtokens",
@@ -101,17 +101,15 @@ const SENSITIVE_KEY_WHITELIST = new Set([
   "tokencount",
   "tokenlimit",
   "tokenbudget",
-  "passwordFile",
-]);
+  "passwordfile",
+] as const;
 
 const SENSITIVE_PATTERNS = [/token$/i, /password/i, /secret/i, /api.?key/i];
 
 export function isSensitiveConfigPath(path: string): boolean {
   const lowerPath = path.toLowerCase();
-  return (
-    !Array.from(SENSITIVE_KEY_WHITELIST).some((suffix) => lowerPath.endsWith(suffix)) &&
-    SENSITIVE_PATTERNS.some((pattern) => pattern.test(path))
-  );
+  const whitelisted = SENSITIVE_KEY_WHITELIST_SUFFIXES.some((suffix) => lowerPath.endsWith(suffix));
+  return !whitelisted && SENSITIVE_PATTERNS.some((pattern) => pattern.test(path));
 }
 
 export function buildBaseHints(): ConfigUiHints {


### PR DESCRIPTION
### Problem
Config update was redacting `maxTokens` numeric values as `"__OPENCLAW_REDACTED__"`, causing gateway startup failures with `Invalid input: expected number, received string`.

### Root Cause
The whitelist contains `"maxtokens"` (lowercase) but the check used case-sensitive `endsWith()`:
- `"maxTokens".endsWith("maxtokens")` → false 
- Field gets redacted incorrectly

### Solution
Convert path to lowercase before whitelist matching:
- `"maxTokens".toLowerCase().endsWith("maxtokens")` → true 
- Field correctly skips redaction

## Testing
- [x] All existing tests pass (53 tests in schema.hints.test.ts)
- [x] `maxTokens`, `maxOutputTokens`, etc. properly whitelisted
- [x] Actual secrets (`apiKey`, `token`) still redacted

fixes #16042

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixes case-sensitive whitelist matching that was incorrectly redacting numeric fields like `maxTokens`, causing gateway startup failures. The change converts the path to lowercase before checking against the lowercase whitelist entries, ensuring fields like `maxTokens` match the `"maxtokens"` whitelist entry.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a minimal, targeted change that correctly addresses a critical bug. Converting the path to lowercase before whitelist matching is the correct solution since the whitelist contains lowercase entries. The change maintains consistency with the case-insensitive regex patterns already used in `SENSITIVE_PATTERNS`. All existing tests pass, confirming no regressions.
- No files require special attention

<sub>Last reviewed commit: 10b0fe9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->