### PR TITLE
fix(telegram): stop dropping voice messages on getFile network errors (#16136)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 - Agents/OpenAI: force `store=true` for direct OpenAI Responses/Codex runs to preserve multi-turn server-side conversation state, while leaving proxy/non-OpenAI endpoints unchanged. (#16803) Thanks @mark9232 and @vignesh07.
 - CLI/Build: make legacy daemon CLI compatibility shim generation tolerant of minimal tsdown daemon export sets, while preserving restart/register compatibility aliases and surfacing explicit errors for unavailable legacy daemon commands. Thanks @vignesh07.
 - Telegram: replace inbound `<media:audio>` placeholder with successful preflight voice transcript in message body context, preventing placeholder-only prompt bodies for mention-gated voice messages. (#16789) Thanks @Limitless2023.
+- Telegram: retry inbound media `getFile` calls (3 attempts with backoff) and gracefully fall back to placeholder-only processing when retries fail, preventing dropped voice/media messages on transient Telegram network errors. (#16154) Thanks @yinghaosang.
 
 ## 2026.2.14
 

--- a/src/telegram/bot/delivery.resolve-media-retry.test.ts
+++ b/src/telegram/bot/delivery.resolve-media-retry.test.ts
@@ -1,0 +1,137 @@
+import type { Message } from "@grammyjs/types";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { TelegramContext } from "./types.js";
+
+const saveMediaBuffer = vi.fn();
+const fetchRemoteMedia = vi.fn();
+
+vi.mock("../../media/store.js", () => ({
+  saveMediaBuffer: (...args: unknown[]) => saveMediaBuffer(...args),
+}));
+
+vi.mock("../../media/fetch.js", () => ({
+  fetchRemoteMedia: (...args: unknown[]) => fetchRemoteMedia(...args),
+}));
+
+vi.mock("../../globals.js", () => ({
+  danger: (s: string) => s,
+  logVerbose: () => {},
+}));
+
+vi.mock("../sticker-cache.js", () => ({
+  cacheSticker: () => {},
+  getCachedSticker: () => null,
+}));
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+const { resolveMedia } = await import("./delivery.js");
+
+function makeCtx(
+  mediaField: "voice" | "audio" | "photo" | "video",
+  getFile: TelegramContext["getFile"],
+): TelegramContext {
+  const msg: Record<string, unknown> = {
+    message_id: 1,
+    date: 0,
+    chat: { id: 1, type: "private" },
+  };
+  if (mediaField === "voice") {
+    msg.voice = { file_id: "v1", duration: 5, file_unique_id: "u1" };
+  }
+  if (mediaField === "audio") {
+    msg.audio = { file_id: "a1", duration: 5, file_unique_id: "u2" };
+  }
+  if (mediaField === "photo") {
+    msg.photo = [{ file_id: "p1", width: 100, height: 100 }];
+  }
+  if (mediaField === "video") {
+    msg.video = { file_id: "vid1", duration: 10, file_unique_id: "u3" };
+  }
+  return {
+    message: msg as Message,
+    me: { id: 1, is_bot: true, first_name: "bot", username: "bot" },
+    getFile,
+  };
+}
+
+describe("resolveMedia getFile retry", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fetchRemoteMedia.mockReset();
+    saveMediaBuffer.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("retries getFile on transient failure and succeeds on second attempt", async () => {
+    const getFile = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Network request for 'getFile' failed!"))
+      .mockResolvedValueOnce({ file_path: "voice/file_0.oga" });
+
+    fetchRemoteMedia.mockResolvedValueOnce({
+      buffer: Buffer.from("audio"),
+      contentType: "audio/ogg",
+      fileName: "file_0.oga",
+    });
+    saveMediaBuffer.mockResolvedValueOnce({
+      path: "/tmp/file_0.oga",
+      contentType: "audio/ogg",
+    });
+
+    const promise = resolveMedia(makeCtx("voice", getFile), 10_000_000, "tok123");
+    await vi.advanceTimersByTimeAsync(5000);
+    const result = await promise;
+
+    expect(getFile).toHaveBeenCalledTimes(2);
+    expect(result).toEqual(
+      expect.objectContaining({ path: "/tmp/file_0.oga", placeholder: "<media:audio>" }),
+    );
+  });
+
+  it("returns null when all getFile retries fail so message is not dropped", async () => {
+    const getFile = vi.fn().mockRejectedValue(new Error("Network request for 'getFile' failed!"));
+
+    const promise = resolveMedia(makeCtx("voice", getFile), 10_000_000, "tok123");
+    await vi.advanceTimersByTimeAsync(15000);
+    const result = await promise;
+
+    expect(getFile).toHaveBeenCalledTimes(3);
+    expect(result).toBeNull();
+  });
+
+  it("does not catch errors from fetchRemoteMedia (only getFile is retried)", async () => {
+    const getFile = vi.fn().mockResolvedValue({ file_path: "voice/file_0.oga" });
+    fetchRemoteMedia.mockRejectedValueOnce(new Error("download failed"));
+
+    await expect(resolveMedia(makeCtx("voice", getFile), 10_000_000, "tok123")).rejects.toThrow(
+      "download failed",
+    );
+
+    expect(getFile).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns null for photo when getFile exhausts retries", async () => {
+    const getFile = vi.fn().mockRejectedValue(new Error("HttpError: Network error"));
+
+    const promise = resolveMedia(makeCtx("photo", getFile), 10_000_000, "tok123");
+    await vi.advanceTimersByTimeAsync(15000);
+    const result = await promise;
+
+    expect(getFile).toHaveBeenCalledTimes(3);
+    expect(result).toBeNull();
+  });
+
+  it("returns null for video when getFile exhausts retries", async () => {
+    const getFile = vi.fn().mockRejectedValue(new Error("HttpError: Network error"));
+
+    const promise = resolveMedia(makeCtx("video", getFile), 10_000_000, "tok123");
+    await vi.advanceTimersByTimeAsync(15000);
+    const result = await promise;
+
+    expect(getFile).toHaveBeenCalledTimes(3);
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Voice messages (and all non-sticker media) get lost when the Telegram `getFile` API call hits a network error. The sticker path already has a try/catch that returns `null` gracefully, but the non-sticker media path in `resolveMedia` just lets the exception bubble up — it reaches the outer catch in `bot-handlers.ts` which logs and drops the message.

Closes #16136

lobster-biscuit

## Root Cause

`resolveMedia()` in `delivery.ts` calls `ctx.getFile()` with no retry and no error handling for non-sticker media (voice, photo, video, audio, document). On network failure, the error propagates to `bot-handlers.ts:884` where only the "exceeds MB limit" case is caught — everything else gets re-thrown and the outer catch at line 933 swallows it. Message gone, no feedback.

## Changes

- Before: single `getFile()` call, network error → message dropped
- After: 3 retries with exponential backoff (1s/2s/4s) using the existing `retryAsync` from `src/infra/retry.ts`. If all retries fail, returns `null` instead of throwing — the message still reaches the agent with a type-based placeholder (e.g. `<media:audio>`) from `bot-message-context.ts`

Only `delivery.ts` is changed. The retry catch is scoped to `getFile` only — downstream errors from `fetchRemoteMedia`/`saveMediaBuffer` still throw normally.

## Tests

New file: `delivery.resolve-media-retry.test.ts` (5 tests, fake timers):

- getFile fails once then succeeds → media resolved normally (retry works)
- getFile fails all 3 attempts → returns null, message isn't dropped
- getFile succeeds but fetchRemoteMedia throws → error propagates (not swallowed by retry catch)
- photo getFile exhausts retries → returns null
- video getFile exhausts retries → returns null

All 50 telegram test files (419 tests) pass. `pnpm build && pnpm check` clean (pre-existing format issue in `.agents/skills/find-issue/SKILL.md` only).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR contains two separate fixes that improve reliability in different parts of the system. The telegram fix adds retry logic with exponential backoff (3 attempts, 1s/2s/4s delays) for the `getFile` API call when processing non-sticker media (voice, photo, video, audio, document). Previously, network errors would cause messages to be dropped at the outer catch handler in `bot-handlers.ts:933`. Now, if all retries fail, `resolveMedia` returns `null` instead of throwing, allowing the message to reach the agent with a type-based placeholder (e.g., `<media:audio>`). The agents fix addresses a race condition where async `onBlockReplyFlush` callbacks were not awaited before subsequent events were processed, causing tool messages to potentially overtake narration delivery. The fix serializes events through a promise chain when a flush callback is present, ensuring delivery completes before tool execution proceeds.

- Added `retryAsync` wrapper around `ctx.getFile()` in `delivery.ts:406-414` with exponential backoff for non-sticker media
- Returns `null` on retry exhaustion instead of throwing, preventing message loss
- Comprehensive test coverage in `delivery.resolve-media-retry.test.ts` (5 tests with fake timers)
- Modified `pi-embedded-subscribe.handlers.ts` to serialize events through a promise chain when flush is in-flight
- Changed `handleToolExecutionStart` to await `onBlockReplyFlush()` with try-catch for best-effort delivery

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Both fixes are well-implemented with comprehensive test coverage and follow existing patterns in the codebase. The telegram retry logic uses the existing `retryAsync` utility correctly and degrades gracefully on failure. The agents fix properly serializes async operations without breaking the event handler chain. No logic errors, security issues, or breaking changes detected.
- No files require special attention

<sub>Last reviewed commit: 9956dad</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->