### PR TITLE
fix(security): OC-31 scope process cleanup to owned PIDs 

### DIFF
--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -8,7 +8,8 @@ import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { CliBackendConfig } from "../../config/types.js";
 import { buildTtsSystemPromptHint } from "../../tts/tts.js";
-import { isRecord } from "../../utils.js";
+import { runExec } from "../../process/exec.js";
+import { escapeRegExp, isRecord } from "../../utils.js";
 import { buildModelAliasLines } from "../model-alias-lines.js";
 import { resolveDefaultModelForAgent } from "../model-selection.js";
 import type { EmbeddedContextFile } from "../pi-embedded-helpers.js";
@@ -18,6 +19,174 @@ import { buildAgentSystemPrompt } from "../system-prompt.js";
 export { buildCliSupervisorScopeKey, resolveCliNoOutputTimeoutMs } from "./reliability.js";
 
 const CLI_RUN_QUEUE = new Map<string, Promise<unknown>>();
+
+
+export async function cleanupResumeProcesses(
+  backend: CliBackendConfig,
+  sessionId: string,
+): Promise<void> {
+  if (process.platform === "win32") {
+    return;
+  }
+  const resumeArgs = backend.resumeArgs ?? [];
+  if (resumeArgs.length === 0) {
+    return;
+  }
+  if (!resumeArgs.some((arg) => arg.includes("{sessionId}"))) {
+    return;
+  }
+  const commandToken = path.basename(backend.command ?? "").trim();
+  if (!commandToken) {
+    return;
+  }
+
+  const resumeTokens = resumeArgs.map((arg) => arg.replaceAll("{sessionId}", sessionId));
+  const pattern = [commandToken, ...resumeTokens]
+    .filter(Boolean)
+    .map((token) => escapeRegExp(token))
+    .join(".*");
+  if (!pattern) {
+    return;
+  }
+
+  try {
+    const { stdout } = await runExec("ps", ["-ax", "-o", "pid=,ppid=,command="]);
+    const patternRegex = new RegExp(pattern);
+    const toKill: number[] = [];
+
+    for (const line of stdout.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) {
+        continue;
+      }
+      const match = /^(\d+)\s+(\d+)\s+(.*)$/.exec(trimmed);
+      if (!match) {
+        continue;
+      }
+      const pid = Number(match[1]);
+      const ppid = Number(match[2]);
+      const cmd = match[3] ?? "";
+      if (!Number.isFinite(pid)) {
+        continue;
+      }
+      if (ppid !== process.pid) {
+        continue;
+      }
+      if (!patternRegex.test(cmd)) {
+        continue;
+      }
+      toKill.push(pid);
+    }
+
+    if (toKill.length > 0) {
+      await runExec("kill", ["-9", ...toKill.map((pid) => String(pid))]);
+    }
+  } catch {
+    // ignore errors - best effort cleanup
+  }
+}
+
+function buildSessionMatchers(backend: CliBackendConfig): RegExp[] {
+  const commandToken = path.basename(backend.command ?? "").trim();
+  if (!commandToken) {
+    return [];
+  }
+  const matchers: RegExp[] = [];
+  const sessionArg = backend.sessionArg?.trim();
+  const sessionArgs = backend.sessionArgs ?? [];
+  const resumeArgs = backend.resumeArgs ?? [];
+
+  const addMatcher = (args: string[]) => {
+    if (args.length === 0) {
+      return;
+    }
+    const tokens = [commandToken, ...args];
+    const pattern = tokens
+      .map((token, index) => {
+        const tokenPattern = tokenToRegex(token);
+        return index === 0 ? `(?:^|\\s)${tokenPattern}` : `\\s+${tokenPattern}`;
+      })
+      .join("");
+    matchers.push(new RegExp(pattern));
+  };
+
+  if (sessionArgs.some((arg) => arg.includes("{sessionId}"))) {
+    addMatcher(sessionArgs);
+  } else if (sessionArg) {
+    addMatcher([sessionArg, "{sessionId}"]);
+  }
+
+  if (resumeArgs.some((arg) => arg.includes("{sessionId}"))) {
+    addMatcher(resumeArgs);
+  }
+
+  return matchers;
+}
+
+function tokenToRegex(token: string): string {
+  if (!token.includes("{sessionId}")) {
+    return escapeRegExp(token);
+  }
+  const parts = token.split("{sessionId}").map((part) => escapeRegExp(part));
+  return parts.join("\\S+");
+}
+
+/**
+ * Cleanup suspended OpenClaw CLI processes that have accumulated.
+ * Only cleans up if there are more than the threshold (default: 10).
+ */
+export async function cleanupSuspendedCliProcesses(
+  backend: CliBackendConfig,
+  threshold = 10,
+): Promise<void> {
+  if (process.platform === "win32") {
+    return;
+  }
+  const matchers = buildSessionMatchers(backend);
+  if (matchers.length === 0) {
+    return;
+  }
+
+  try {
+    const { stdout } = await runExec("ps", ["-ax", "-o", "pid=,ppid=,stat=,command="]);
+    const suspended: number[] = [];
+    for (const line of stdout.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) {
+        continue;
+      }
+      const match = /^(\d+)\s+(\d+)\s+(\S+)\s+(.*)$/.exec(trimmed);
+      if (!match) {
+        continue;
+      }
+      const pid = Number(match[1]);
+      const ppid = Number(match[2]);
+      const stat = match[3] ?? "";
+      const command = match[4] ?? "";
+      if (!Number.isFinite(pid)) {
+        continue;
+      }
+      if (ppid !== process.pid) {
+        continue;
+      }
+      if (!stat.includes("T")) {
+        continue;
+      }
+      if (!matchers.some((matcher) => matcher.test(command))) {
+        continue;
+      }
+      suspended.push(pid);
+    }
+
+    if (suspended.length > threshold) {
+      // Verified locally: stopped (T) processes ignore SIGTERM, so use SIGKILL.
+      await runExec("kill", ["-9", ...suspended.map((pid) => String(pid))]);
+    }
+  } catch {
+    // ignore errors - best effort cleanup
+  }
+}
+
 export function enqueueCliRun<T>(key: string, task: () => Promise<T>): Promise<T> {
   const prior = CLI_RUN_QUEUE.get(key) ?? Promise.resolve();
   const chained = prior.catch(() => undefined).then(task);


### PR DESCRIPTION
## Summary

Add parent PID (ppid) filtering to `cleanupSuspendedCliProcesses` and `cleanupResumeProcesses` in `src/agents/cli-runner/helpers.ts` to prevent accidentally killing unrelated processes on shared hosts.

**Suggested by Aether AI Agent** — Process Safety Improvement (OC-31)
**Severity**: Low
**CWE**: CWE-283 (Unverified Ownership)

## Problem

Both cleanup functions enumerate system processes and send SIGKILL to pattern-matched PIDs without verifying they belong to the current OpenClaw process tree. On shared hosts, unrelated processes could incidentally match the cleanup regex and be terminated.

## Solution

- **`cleanupSuspendedCliProcesses`**: Added ppid column to `ps` output, parse ppid from regex, filter `ppid !== process.pid` before kill — only direct children of the current process are targeted
- **`cleanupResumeProcesses`**: Replaced `pkill -f pattern` with `ps -ax -o pid=,ppid=,command=` + ppid validation + explicit `kill` — eliminates system-wide blind pattern matching

## Changes

- **`src/agents/cli-runner/helpers.ts`**: ppid validation added to both cleanup functions
- **`src/agents/cli-runner.e2e.test.ts`**:
  - Updated existing test mocks for new ppid column format
  - Updated resume cleanup test for ps+kill flow (was pkill)
  - Added: "only kills child processes of current process" test
  - Added: "skips all processes when none are children" test
  - Added: "only kills resume processes owned by current process" test
  - Added: "skips kill when no resume processes match ppid" test

## Test Plan

- [x] All existing tests updated and passing (10/10)
- [x] New ppid ownership validation tests for `cleanupSuspendedCliProcesses`
- [x] New ppid ownership validation tests for `cleanupResumeProcesses`
- [x] `npx vitest run --config vitest.e2e.config.ts src/agents/cli-runner.e2e.test.ts` — 10/10 pass

Co-authored-by: Aether AI Agent <github@tryaether.ai>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added parent PID validation to process cleanup functions to prevent accidentally killing unrelated processes on shared hosts. Both `cleanupSuspendedCliProcesses` and `cleanupResumeProcesses` now verify `ppid === process.pid` before sending SIGKILL, ensuring only direct child processes are targeted.

- `cleanupResumeProcesses` now uses `ps` + explicit `kill` instead of `pkill -f` for precise ppid validation
- `cleanupSuspendedCliProcesses` adds ppid column to `ps` output and filters by parent ownership
- Test coverage expanded with 4 new ppid ownership validation tests
- All existing tests updated for new ps output format

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are narrowly scoped security improvements with comprehensive test coverage. The ppid validation logic is straightforward and correctly implemented in both cleanup functions. All 10 tests pass, including 4 new tests specifically validating ppid ownership. The fallback error handling ensures graceful degradation if process enumeration fails.
- No files require special attention

<sub>Last reviewed commit: 895125c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->