### PR TITLE
fix: strip leading whitespace from sanitizeUserFacingText output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Docs: https://docs.openclaw.ai
 - Security/Audit: warn when `gateway.tools.allow` re-enables default-denied tools over HTTP `POST /tools/invoke`, since this can increase RCE blast radius if the gateway is reachable.
 - Security/Plugins/Hooks: harden npm-based installs by restricting specs to registry packages only, passing `--ignore-scripts` to `npm pack`, and cleaning up temp install directories.
 - Feishu: stop persistent Typing reaction on NO_REPLY/suppressed runs by wiring reply-dispatcher cleanup to remove typing indicators. (#15464) Thanks @arosstale.
+- Agents: strip leading whitespace/newlines from `sanitizeUserFacingText` output and normalize whitespace-only outputs to empty text. (#16158) Thanks @mcinteerj.
 - BlueBubbles: gracefully degrade when Private API is disabled by filtering private-only actions, skipping private-only reactions/reply effects, and avoiding private reply markers so non-private flows remain usable. (#16002) Thanks @L-U-C-K-Y.
 - Outbound: add a write-ahead delivery queue with crash-recovery retries to prevent lost outbound messages after gateway restarts. (#15636) Thanks @nabbilkhan, @thewilloftheshadow.
 - Auto-reply/Threading: auto-inject implicit reply threading so `replyToMode` works without requiring model-emitted `[[reply_to_current]]`, while preserving `replyToMode: "off"` behavior for implicit Slack replies and keeping block-streaming chunk coalescing stable under `replyToMode: "first"`. (#14976) Thanks @Diaspar4u.

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.e2e.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.e2e.test.ts
@@ -69,4 +69,25 @@ describe("sanitizeUserFacingText", () => {
     const text = "Hello there!\n\nDifferent line.";
     expect(sanitizeUserFacingText(text)).toBe(text);
   });
+
+  it("strips leading newlines from LLM output", () => {
+    expect(sanitizeUserFacingText("\n\nHello there!")).toBe("Hello there!");
+    expect(sanitizeUserFacingText("\nHello there!")).toBe("Hello there!");
+    expect(sanitizeUserFacingText("\n\n\nMultiple newlines")).toBe("Multiple newlines");
+  });
+
+  it("strips leading whitespace and newlines combined", () => {
+    expect(sanitizeUserFacingText("\n \n Hello")).toBe("Hello");
+    expect(sanitizeUserFacingText("  \n\nHello")).toBe("Hello");
+  });
+
+  it("preserves trailing whitespace and internal newlines", () => {
+    expect(sanitizeUserFacingText("Hello\n\nWorld\n")).toBe("Hello\n\nWorld\n");
+    expect(sanitizeUserFacingText("Line 1\nLine 2")).toBe("Line 1\nLine 2");
+  });
+
+  it("returns empty for whitespace-only input", () => {
+    expect(sanitizeUserFacingText("\n\n")).toBe("");
+    expect(sanitizeUserFacingText("  \n  ")).toBe("");
+  });
 });

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -488,7 +488,7 @@ export function sanitizeUserFacingText(text: string, opts?: { errorContext?: boo
   const stripped = stripFinalTagsFromText(text);
   const trimmed = stripped.trim();
   if (!trimmed) {
-    return stripped;
+    return "";
   }
 
   // Only apply error-pattern rewrites when the caller knows this text is an error payload.
@@ -527,7 +527,7 @@ export function sanitizeUserFacingText(text: string, opts?: { errorContext?: boo
     }
   }
 
-  return collapseConsecutiveDuplicateBlocks(stripped);
+  return collapseConsecutiveDuplicateBlocks(stripped).trimStart();
 }
 
 export function isRateLimitAssistantError(msg: AssistantMessage | undefined): boolean {


### PR DESCRIPTION
#### Summary

LLM responses frequently begin with `\n\n`, causing visible blank lines at the top of messages on WhatsApp (and other channels). This fixes the root cause in `sanitizeUserFacingText` rather than scattering `trimStart()` across multiple delivery paths.

lobster-biscuit

#### Repro Steps

1. Send a message that triggers an LLM response beginning with `\n\n` (common with Claude Opus 4.6)
2. Observe blank lines at the top of the WhatsApp message

#### Root Cause

`sanitizeUserFacingText` in `src/agents/pi-embedded-helpers/errors.ts` uses `trimmed` for empty-checks but returns the untrimmed `stripped` variable:

```typescript
const stripped = stripFinalTagsFromText(text);
const trimmed = stripped.trim();
if (!trimmed) {
  return stripped;  // ← returns whitespace-only string instead of ""
}
// ...
return collapseConsecutiveDuplicateBlocks(stripped);  // ← returns untrimmed
```

#### Fix

Two one-line changes:
1. **Empty input path**: return `""` instead of whitespace-only `stripped`
2. **Final return**: apply `.trimStart()` after `collapseConsecutiveDuplicateBlocks`

This is the single funnel point — all reply paths (auto-reply, heartbeat, outbound) flow through `sanitizeUserFacingText` via `normalizeReplyPayload`, so the fix applies universally without touching delivery code.

#### Behavior Changes

- Messages with leading `\n` or `\n\n` will have that whitespace stripped before delivery
- Whitespace-only text now returns `""` instead of the whitespace string
- No change to trailing whitespace or internal newlines

#### Codebase and GitHub Search

- Supersedes #8052 (same issue, but fixes at 3 delivery paths instead of root cause)
- Supersedes #10612 (same symptom, different approach)
- `normalizeReplyPayload` in `src/auto-reply/reply/normalize-reply.ts` calls `sanitizeUserFacingText` — confirmed single funnel point

#### Tests

4 new test cases added to `pi-embedded-helpers.sanitizeuserfacingtext.e2e.test.ts`:

| Test | Status |
|------|--------|
| strips leading newlines from LLM output | ✅ |
| strips leading whitespace and newlines combined | ✅ |
| preserves trailing whitespace and internal newlines | ✅ |
| returns empty for whitespace-only input | ✅ |

All 15 tests pass (11 existing + 4 new).

```
pnpm lint    ✅ 0 warnings, 0 errors
pnpm build   ✅ clean
pnpm test:e2e (sanitizeuserfacingtext) ✅ 15/15 passed
```

#### Manual Testing

Tested by observing WhatsApp message output before/after the change — leading blank lines no longer appear.

**Sign-Off**

- Models used: Claude Opus 4.6 (analysis + implementation)
- Submitter effort: High — traced through normalize-reply → sanitizeUserFacingText → errors.ts, identified root cause, checked for duplicate PRs, wrote focused fix with tests
- Agent notes: Bug independently discovered by two agents (Keith 🪿 and Kev 🦈) experiencing identical symptoms on the same model. Root cause confirmed by code inspection, not speculation.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixes leading whitespace in LLM responses by modifying `sanitizeUserFacingText` in `src/agents/pi-embedded-helpers/errors.ts`. The function now returns an empty string for whitespace-only input and strips leading whitespace from the final output using `.trimStart()`. This addresses the root cause of blank lines appearing at the top of WhatsApp messages when Claude Opus 4.6 responses begin with `\n\n`.

Changes:
- Returns `""` instead of whitespace-only string when input is empty after trimming
- Applies `.trimStart()` to the final return value after `collapseConsecutiveDuplicateBlocks`
- Adds 4 new test cases covering leading newlines, combined whitespace/newlines, trailing whitespace preservation, and empty input

The fix is well-targeted at the single funnel point where all reply paths flow through `normalizeReplyPayload`, avoiding the need to patch multiple delivery paths.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are minimal (two one-line modifications), well-tested with 4 new test cases, and address a real bug at the correct abstraction level. The fix applies `.trimStart()` uniformly to all non-error output paths without affecting error message formatting. All existing tests continue to pass, and the new tests verify the specific behavior changes.
- No files require special attention

<sub>Last reviewed commit: efdcf74</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->