### PR TITLE
fix(docs): update outdated hooks documentation URLs

### DIFF
--- a/.agents/skills/PR_WORKFLOW.md
+++ b/.agents/skills/PR_WORKFLOW.md
@@ -136,7 +136,7 @@ Use this for GHSA-linked fixes and private reports.
 4. In GitHub advisory UI, set package ranges in the structured fields:
    - `Affected versions`: `< fixed_version`
    - `Patched versions`: `>= fixed_version`
-   Do not rely on description text alone.
+     Do not rely on description text alone.
 5. If collaborator can edit text but cannot change advisory state, hand off to a Publisher to move triage -> accepted draft -> publish.
 6. Advisory comments are posted manually in UI when required by policy. Do not rely on `gh api` automation for advisory comments.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Gateway/Auth: add trusted-proxy mode hardening follow-ups by keeping `OPENCLAW_GATEWAY_*` env compatibility, auto-normalizing invalid setup combinations in interactive `gateway configure` (trusted-proxy forces `bind=lan` and disables Tailscale serve/funnel), and suppressing shared-secret/rate-limit audit findings that do not apply to trusted-proxy deployments. (#15940) Thanks @nickytonline.
+- Docs/Hooks: update hooks documentation URLs to the new `/automation/hooks` location. (#16165) Thanks @nicholascyh.
 - Security/Audit: warn when `gateway.tools.allow` re-enables default-denied tools over HTTP `POST /tools/invoke`, since this can increase RCE blast radius if the gateway is reachable.
 - Feishu: stop persistent Typing reaction on NO_REPLY/suppressed runs by wiring reply-dispatcher cleanup to remove typing indicators. (#15464) Thanks @arosstale.
 - BlueBubbles: gracefully degrade when Private API is disabled by filtering private-only actions, skipping private-only reactions/reply effects, and avoiding private reply markers so non-private flows remain usable. (#16002) Thanks @L-U-C-K-Y.

--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -128,7 +128,7 @@ The `HOOK.md` file contains metadata in YAML frontmatter plus Markdown documenta
 ---
 name: my-hook
 description: "Short description of what this hook does"
-homepage: https://docs.openclaw.ai/hooks#my-hook
+homepage: https://docs.openclaw.ai/automation/hooks#my-hook
 metadata:
   { "openclaw": { "emoji": "🔗", "events": ["command:new"], "requires": { "bins": ["node"] } } }
 ---

--- a/docs/cli/hooks.md
+++ b/docs/cli/hooks.md
@@ -90,7 +90,7 @@ Details:
   Source: openclaw-bundled
   Path: /path/to/openclaw/hooks/bundled/session-memory/HOOK.md
   Handler: /path/to/openclaw/hooks/bundled/session-memory/handler.ts
-  Homepage: https://docs.openclaw.ai/hooks#session-memory
+  Homepage: https://docs.openclaw.ai/automation/hooks#session-memory
   Events: command:new
 
 Requirements:

--- a/docs/zh-CN/automation/hooks.md
+++ b/docs/zh-CN/automation/hooks.md
@@ -133,7 +133,7 @@ Hook 包可以附带依赖；它们将安装在 `~/.openclaw/hooks/<id>` 下。
 ---
 name: my-hook
 description: "Short description of what this hook does"
-homepage: https://docs.openclaw.ai/hooks#my-hook
+homepage: https://docs.openclaw.ai/automation/hooks#my-hook
 metadata:
   { "openclaw": { "emoji": "🔗", "events": ["command:new"], "requires": { "bins": ["node"] } } }
 ---

--- a/docs/zh-CN/cli/hooks.md
+++ b/docs/zh-CN/cli/hooks.md
@@ -96,7 +96,7 @@ Details:
   Source: openclaw-bundled
   Path: /path/to/openclaw/hooks/bundled/session-memory/HOOK.md
   Handler: /path/to/openclaw/hooks/bundled/session-memory/handler.ts
-  Homepage: https://docs.openclaw.ai/hooks#session-memory
+  Homepage: https://docs.openclaw.ai/automation/hooks#session-memory
   Events: command:new
 
 Requirements:

--- a/src/cli/hooks-cli.test.ts
+++ b/src/cli/hooks-cli.test.ts
@@ -16,7 +16,7 @@ const report: HookStatusReport = {
       handlerPath: "/tmp/hooks/session-memory/handler.js",
       hookKey: "session-memory",
       emoji: "💾",
-      homepage: "https://docs.openclaw.ai/hooks#session-memory",
+      homepage: "https://docs.openclaw.ai/automation/hooks#session-memory",
       events: ["command:new"],
       always: false,
       disabled: false,

--- a/src/commands/onboard-hooks.ts
+++ b/src/commands/onboard-hooks.ts
@@ -15,7 +15,7 @@ export async function setupInternalHooks(
       "Hooks let you automate actions when agent commands are issued.",
       "Example: Save session context to memory when you issue /new.",
       "",
-      "Learn more: https://docs.openclaw.ai/hooks",
+      "Learn more: https://docs.openclaw.ai/automation/hooks",
     ].join("\n"),
     "Hooks",
   );

--- a/src/hooks/bundled/README.md
+++ b/src/hooks/bundled/README.md
@@ -81,7 +81,7 @@ session-memory/
 ---
 name: my-hook
 description: "Short description"
-homepage: https://docs.openclaw.ai/hooks#my-hook
+homepage: https://docs.openclaw.ai/automation/hooks#my-hook
 metadata:
   { "openclaw": { "emoji": "🔗", "events": ["command:new"], "requires": { "bins": ["node"] } } }
 ---
@@ -220,4 +220,4 @@ Test your hooks by:
 
 ## Documentation
 
-Full documentation: https://docs.openclaw.ai/hooks
+Full documentation: https://docs.openclaw.ai/automation/hooks

--- a/src/hooks/bundled/boot-md/HOOK.md
+++ b/src/hooks/bundled/boot-md/HOOK.md
@@ -1,7 +1,7 @@
 ---
 name: boot-md
 description: "Run BOOT.md on gateway startup"
-homepage: https://docs.openclaw.ai/hooks#boot-md
+homepage: https://docs.openclaw.ai/automation/hooks#boot-md
 metadata:
   {
     "openclaw":

--- a/src/hooks/bundled/command-logger/HOOK.md
+++ b/src/hooks/bundled/command-logger/HOOK.md
@@ -1,7 +1,7 @@
 ---
 name: command-logger
 description: "Log all command events to a centralized audit file"
-homepage: https://docs.openclaw.ai/hooks#command-logger
+homepage: https://docs.openclaw.ai/automation/hooks#command-logger
 metadata:
   {
     "openclaw":

--- a/src/hooks/bundled/session-memory/HOOK.md
+++ b/src/hooks/bundled/session-memory/HOOK.md
@@ -1,7 +1,7 @@
 ---
 name: session-memory
 description: "Save session context to memory when /new command is issued"
-homepage: https://docs.openclaw.ai/hooks#session-memory
+homepage: https://docs.openclaw.ai/automation/hooks#session-memory
 metadata:
   {
     "openclaw":

--- a/src/hooks/frontmatter.test.ts
+++ b/src/hooks/frontmatter.test.ts
@@ -233,7 +233,7 @@ describe("resolveOpenClawMetadata", () => {
     const content = `---
 name: session-memory
 description: "Save session context to memory when /new command is issued"
-homepage: https://docs.openclaw.ai/hooks#session-memory
+homepage: https://docs.openclaw.ai/automation/hooks#session-memory
 metadata:
   {
     "openclaw":


### PR DESCRIPTION
## Description

This PR updates outdated hooks documentation links. The hooks docs have moved from `https://docs.openclaw.ai/hooks` to `https://docs.openclaw.ai/automation/hooks`, but several references still pointed to the old URL.

## Changes

- Updated hooks documentation links from `https://docs.openclaw.ai/hooks` to `https://docs.openclaw.ai/automation/hooks`.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updates all hooks documentation URLs from `https://docs.openclaw.ai/hooks` to `https://docs.openclaw.ai/automation/hooks` across 11 files — English and Chinese docs, bundled hook `HOOK.md` frontmatter, onboarding source code, and test fixtures. The changes are consistent and complete for all active references; the sole remaining old URL in `CHANGELOG.md` is a historical entry and appropriately left unchanged.

- Updated `homepage` frontmatter in all 3 bundled hooks (`session-memory`, `boot-md`, `command-logger`)
- Updated example URLs in documentation (`docs/automation/hooks.md`, `docs/cli/hooks.md`) and their zh-CN translations
- Updated the "Learn more" link in `src/commands/onboard-hooks.ts` shown during onboarding
- Updated `src/hooks/bundled/README.md` documentation and example HOOK.md template
- Updated test fixtures in `src/cli/hooks-cli.test.ts` and `src/hooks/frontmatter.test.ts` to match

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it contains only URL string replacements with no logic changes.
- All changes are mechanical find-and-replace of a documentation URL. No logic, behavior, or code structure is altered. The replacement is consistent across all 11 files, and tests have been updated to match. No remaining stale URLs exist in active code (the one in CHANGELOG.md is a historical record).
- No files require special attention.

<sub>Last reviewed commit: 9883fbf</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->