### PR TITLE
fix(signal): enable agent-initiated emoji reactions

### DIFF
--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -31,7 +31,6 @@ export function buildInboundMetaSystemPrompt(ctx: TemplateContext): string {
     provider: safeTrim(ctx.Provider),
     surface: safeTrim(ctx.Surface),
     chat_type: chatType ?? (isDirect ? "direct" : undefined),
-    message_id: safeTrim(ctx.MessageSid),
     flags: {
       is_group_chat: !isDirect ? true : undefined,
       was_mentioned: ctx.WasMentioned === true ? true : undefined,

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -31,6 +31,7 @@ export function buildInboundMetaSystemPrompt(ctx: TemplateContext): string {
     provider: safeTrim(ctx.Provider),
     surface: safeTrim(ctx.Surface),
     chat_type: chatType ?? (isDirect ? "direct" : undefined),
+    message_id: safeTrim(ctx.MessageSid),
     flags: {
       is_group_chat: !isDirect ? true : undefined,
       was_mentioned: ctx.WasMentioned === true ? true : undefined,

--- a/src/channels/plugins/normalize/signal.ts
+++ b/src/channels/plugins/normalize/signal.ts
@@ -40,22 +40,25 @@ export function looksLikeSignalTargetId(raw: string): boolean {
   if (!trimmed) {
     return false;
   }
-  if (/^(signal:)?(group:|username:|u:)/i.test(trimmed)) {
+  // Strip optional signal: provider prefix so that signal:<bare-uuid> and
+  // signal:+E.164 are recognised in the same way as their unprefixed forms.
+  const withoutProvider = trimmed.replace(/^signal:/i, "").trim();
+  if (!withoutProvider) {
+    return false;
+  }
+  if (/^(group:|username:|u:)/i.test(withoutProvider)) {
     return true;
   }
-  if (/^(signal:)?uuid:/i.test(trimmed)) {
-    const stripped = trimmed
-      .replace(/^signal:/i, "")
-      .replace(/^uuid:/i, "")
-      .trim();
+  if (/^uuid:/i.test(withoutProvider)) {
+    const stripped = withoutProvider.replace(/^uuid:/i, "").trim();
     if (!stripped) {
       return false;
     }
     return UUID_PATTERN.test(stripped) || UUID_COMPACT_PATTERN.test(stripped);
   }
   // Accept UUIDs (used by signal-cli for reactions)
-  if (UUID_PATTERN.test(trimmed) || UUID_COMPACT_PATTERN.test(trimmed)) {
+  if (UUID_PATTERN.test(withoutProvider) || UUID_COMPACT_PATTERN.test(withoutProvider)) {
     return true;
   }
-  return /^\+?\d{3,}$/.test(trimmed);
+  return /^\+?\d{3,}$/.test(withoutProvider);
 }

--- a/src/channels/plugins/plugins-channel.test.ts
+++ b/src/channels/plugins/plugins-channel.test.ts
@@ -47,6 +47,15 @@ describe("signal target normalization", () => {
     expect(looksLikeSignalTargetId("uuid:123e4567e89b12d3a456426614174000")).toBe(true);
   });
 
+  it("accepts signal:<bare-uuid> (inferred from currentChannelId)", () => {
+    expect(looksLikeSignalTargetId("signal:da2f7ce5-3545-4597-bc4a-04dc5340c2af")).toBe(true);
+    expect(looksLikeSignalTargetId("signal:123e4567e89b12d3a456426614174000")).toBe(true);
+  });
+
+  it("accepts signal:<phone> targets", () => {
+    expect(looksLikeSignalTargetId("signal:+4915114438023")).toBe(true);
+  });
+
   it("rejects invalid uuid prefixes", () => {
     expect(looksLikeSignalTargetId("uuid:")).toBe(false);
     expect(looksLikeSignalTargetId("uuid:not-a-uuid")).toBe(false);


### PR DESCRIPTION
## Summary

Signal agent-initiated emoji reactions (the `react` message action) silently fail for two independent reasons. This PR fixes both.

## Problem

When an agent calls the `message` tool with `action: "react"` on a Signal channel:

1. **Missing `message_id` in inbound metadata** — `buildInboundMetaSystemPrompt` did not include `ctx.MessageSid` in the trusted metadata payload. Without the numeric Signal timestamp the agent has no valid value for the react tool's required `messageId` parameter.

2. **Target resolver rejects `signal:<bare-uuid>`** — When the agent omits the `to` parameter (as expected for reacting to the current conversation), `runMessageAction` auto-fills the target from `currentChannelId`, which has the format `signal:<uuid>`. However, `looksLikeSignalTargetId` only handled `signal:uuid:<uuid>`, `signal:group:<id>`, and bare UUIDs — not `signal:<bare-uuid>`. This caused `resolveMessagingTarget` to fall through to a directory lookup, fail, and throw `Unknown target "signal:<uuid>" for Signal`.

## Changes

- **`src/auto-reply/reply/inbound-meta.ts`** — Add `message_id: safeTrim(ctx.MessageSid)` to the trusted metadata JSON payload so the agent can reference the current message's Signal timestamp.
- **`src/channels/plugins/normalize/signal.ts`** — Strip the `signal:` provider prefix early in `looksLikeSignalTargetId` so that `signal:<bare-uuid>` and `signal:+E.164` are recognised the same way as their unprefixed forms.
- **`src/channels/plugins/normalize/signal.test.ts`** — Add test cases for `signal:<bare-uuid>` and `signal:<phone>` targets.

## Testing

- Tested end-to-end on a self-hosted OpenClaw instance with Signal (signal-cli 0.13.24)
- Confirmed agent-initiated `❤️` reaction arrives on the recipient's Signal client
- Existing normalisation test cases still pass

## AI-Assisted Contribution

- [x] This PR was authored with AI assistance (Claude Code / Claude Opus 4.6)
- [x] Tested end-to-end on a live Signal setup
- [x] No human has reviewed the code yet — reviewer attention appreciated
- [x] I understand what the code does

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes two independent bugs that caused agent-initiated emoji reactions on Signal to silently fail. First, `message_id` (the Signal message timestamp) is now included in the trusted inbound metadata so the agent has a valid `messageId` for the react tool. Second, `looksLikeSignalTargetId` is updated to strip the `signal:` provider prefix early, so that `signal:<bare-uuid>` (as auto-filled from `currentChannelId`) is correctly recognized as a direct target ID instead of falling through to a failed directory lookup.

- Added `message_id: safeTrim(ctx.MessageSid)` to trusted metadata in `inbound-meta.ts` — the value comes from `envelope.timestamp` (system-generated), consistent with the "no attacker-controlled strings" policy for this payload
- Refactored `looksLikeSignalTargetId` to strip the optional `signal:` prefix before matching, aligning it with the existing `normalizeSignalMessagingTarget` function which already handled this prefix
- Added test coverage for `signal:<bare-uuid>` and `signal:<phone>` target formats

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it fixes two clear bugs with minimal, well-scoped changes.
- The changes are small, focused, and logically correct. The `looksLikeSignalTargetId` refactoring is consistent with the existing `normalizeSignalMessagingTarget` function. The `message_id` addition uses a system-generated value (Signal message timestamp) that is not attacker-controlled. New test cases cover the added behavior. No regressions are introduced for existing patterns.
- No files require special attention.

<sub>Last reviewed commit: 46e70e2</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->