### PR TITLE
fix: restart service manager after update.run

### DIFF
--- a/.github/workflows/formal-conformance.yml
+++ b/.github/workflows/formal-conformance.yml
@@ -122,12 +122,21 @@ jobs:
               'If this change is intentional, follow up by updating the formal models repo or regenerating the extracted artifacts there.',
             ].join('\n');
 
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              body,
-            });
+            try {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body,
+              });
+            } catch (error) {
+              if (error?.status === 403) {
+                core.warning('Skipping informational PR comment: token cannot write issue comments (common on fork PRs).');
+                return;
+              }
+
+              throw error;
+            }
 
       - name: Summary
         run: |

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -16,10 +16,7 @@ import {
   validateUpdateRunParams,
 } from "../protocol/index.js";
 
-function scheduleGatewayServiceRestart(opts?: {
-  delayMs?: number;
-  reason?: string;
-}): {
+function scheduleGatewayServiceRestart(opts?: { delayMs?: number; reason?: string }): {
   ok: true;
   mode: "service";
   method: "launchctl" | "systemd" | "supervisor";

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -6,7 +6,7 @@ import {
   type RestartSentinelPayload,
   writeRestartSentinel,
 } from "../../infra/restart-sentinel.js";
-import { scheduleGatewaySigusr1Restart } from "../../infra/restart.js";
+import { scheduleGatewaySigusr1Restart, triggerOpenClawRestart } from "../../infra/restart.js";
 import { normalizeUpdateChannel } from "../../infra/update-channels.js";
 import { runGatewayUpdate } from "../../infra/update-runner.js";
 import {
@@ -15,6 +15,55 @@ import {
   formatValidationErrors,
   validateUpdateRunParams,
 } from "../protocol/index.js";
+
+function scheduleGatewayServiceRestart(opts?: {
+  delayMs?: number;
+  reason?: string;
+}): {
+  ok: true;
+  mode: "service";
+  method: "launchctl" | "systemd" | "supervisor";
+  delayMs: number;
+  reason?: string;
+  fallback: "sigusr1";
+} {
+  const delayMsRaw =
+    typeof opts?.delayMs === "number" && Number.isFinite(opts.delayMs)
+      ? Math.floor(opts.delayMs)
+      : 2000;
+  const delayMs = Math.min(Math.max(delayMsRaw, 0), 60_000);
+  const reason =
+    typeof opts?.reason === "string" && opts.reason.trim()
+      ? opts.reason.trim().slice(0, 200)
+      : undefined;
+  const method =
+    process.platform === "darwin"
+      ? "launchctl"
+      : process.platform === "linux"
+        ? "systemd"
+        : "supervisor";
+  setTimeout(() => {
+    const restart = triggerOpenClawRestart();
+    if (restart.ok) {
+      return;
+    }
+    console.warn(
+      `update.run: service restart via ${restart.method} failed (${restart.detail ?? "unknown"}); falling back to in-process SIGUSR1 restart`,
+    );
+    scheduleGatewaySigusr1Restart({
+      delayMs: 0,
+      reason: reason ?? "update.run:fallback",
+    });
+  }, delayMs);
+  return {
+    ok: true,
+    mode: "service",
+    method,
+    delayMs,
+    reason,
+    fallback: "sigusr1",
+  };
+}
 
 export const updateHandlers: GatewayRequestHandlers = {
   "update.run": async ({ params, respond }) => {
@@ -109,7 +158,7 @@ export const updateHandlers: GatewayRequestHandlers = {
       sentinelPath = null;
     }
 
-    const restart = scheduleGatewaySigusr1Restart({
+    const restart = scheduleGatewayServiceRestart({
       delayMs: restartDelayMs,
       reason: "update.run",
     });

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -48,7 +48,7 @@ function scheduleGatewayServiceRestart(opts?: { delayMs?: number; reason?: strin
       `update.run: service restart via ${restart.method} failed (${restart.detail ?? "unknown"}); falling back to in-process SIGUSR1 restart`,
     );
     scheduleGatewaySigusr1Restart({
-      delayMs: 0,
+      // Keep a short grace period so slow service-manager restarts can settle first.
       reason: reason ?? "update.run:fallback",
     });
   }, delayMs);


### PR DESCRIPTION
## Summary
- Update `update.run` to prefer a service-manager restart (`launchctl` on macOS, `systemd` on Linux, `supervisor` otherwise) after update completion.
- Keep the existing SIGUSR1 path as fallback only when service-manager restart fails.
- Add a short grace-period fallback instead of forcing immediate `delayMs: 0`, reducing overlapping restart attempts during transient service-manager latency.
- Keep restart sentinel payload/reporting behavior unchanged.

## Why
- In managed installs, SIGUSR1-only recycle can leave stale runtime/modules loaded right after update.
- Service-manager restart aligns `update.run` with explicit gateway restart behavior and improves update apply reliability.

## AI and Testing
- AI-assisted: yes (Codex).
- Testing degree: fully tested.
- I understand and verified the changed restart flow and fallback behavior.

### Commands run
- `pnpm build`
- `pnpm check`
- `pnpm test`
- `pnpm test:e2e src/gateway/server.roles-allowlist-update.e2e.test.ts -t "falls back to SIGUSR1 when service restart fails"`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes the `update.run` gateway handler to prefer service-manager restarts (`launchctl`/`systemd`/`supervisor`) over in-process SIGUSR1 restarts after an update completes. A new `scheduleGatewayServiceRestart` function wraps `triggerOpenClawRestart` in a `setTimeout`, falling back to `scheduleGatewaySigusr1Restart` (with a default 2000ms grace period) if the service-manager restart fails.

- `src/gateway/server-methods/update.ts`: Introduces `scheduleGatewayServiceRestart` that attempts a service-manager restart first, with SIGUSR1 as a fallback. Replaces the direct `scheduleGatewaySigusr1Restart` call in the handler.
- `src/gateway/server.roles-allowlist-update.e2e.test.ts`: Mocks `triggerOpenClawRestart` and `scheduleGatewaySigusr1Restart` to verify the happy path (service restart succeeds, SIGUSR1 not called) and fallback path (service restart fails, SIGUSR1 invoked with correct reason). Removes direct SIGUSR1 signal handling from tests.
- `.github/workflows/formal-conformance.yml`: Wraps the informational PR comment in a try/catch to tolerate 403 errors on fork PRs where the token lacks write permissions.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk — the restart flow change is well-guarded by a fallback path and tested end-to-end.
- The core logic change (service-manager restart with SIGUSR1 fallback) follows existing patterns in `restart.ts`, has proper clamping/validation, and is covered by new e2e tests for both the happy path and fallback path. The CI change is a straightforward defensive improvement. No issues requiring inline comments were identified beyond the race condition already discussed in a previous thread.
- No files require special attention.

<sub>Last reviewed commit: 1b54efb</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->