### PR TITLE
docs(gateway): link trusted-proxy auth

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -786,6 +786,10 @@
     {
       "source": "/platforms/northflank",
       "destination": "/install/northflank"
+    },
+    {
+      "source": "/gateway/trusted-proxy",
+      "destination": "/gateway/trusted-proxy-auth"
     }
   ],
   "navigation": {
@@ -1106,6 +1110,7 @@
                       "gateway/configuration-reference",
                       "gateway/configuration-examples",
                       "gateway/authentication",
+                      "gateway/trusted-proxy-auth",
                       "gateway/health",
                       "gateway/heartbeat",
                       "gateway/doctor",

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1889,9 +1889,10 @@ See [Plugins](/tools/plugin).
     port: 18789,
     bind: "loopback",
     auth: {
-      mode: "token", // token | password
+      mode: "token", // token | password | trusted-proxy
       token: "your-token",
       // password: "your-password", // or OPENCLAW_GATEWAY_PASSWORD
+      // trustedProxy: { userHeader: "x-forwarded-user" }, // for mode=trusted-proxy; see /gateway/trusted-proxy-auth
       allowTailscale: true,
       rateLimit: {
         maxAttempts: 10,
@@ -1934,6 +1935,7 @@ See [Plugins](/tools/plugin).
 - `port`: single multiplexed port for WS + HTTP. Precedence: `--port` > `OPENCLAW_GATEWAY_PORT` > `gateway.port` > `18789`.
 - `bind`: `auto`, `loopback` (default), `lan` (`0.0.0.0`), `tailnet` (Tailscale IP only), or `custom`.
 - **Auth**: required by default. Non-loopback binds require a shared token/password. Onboarding wizard generates a token by default.
+- `auth.mode: "trusted-proxy"`: delegate auth to an identity-aware reverse proxy and trust identity headers from `gateway.trustedProxies` (see [Trusted Proxy Auth](/gateway/trusted-proxy-auth)).
 - `auth.allowTailscale`: when `true`, Tailscale Serve identity headers satisfy auth (verified via `tailscale whois`). Defaults to `true` when `tailscale.mode = "serve"`.
 - `auth.rateLimit`: optional failed-auth limiter. Applies per client IP and per auth scope (shared-secret and device-token are tracked independently). Blocked attempts return `429` + `Retry-After`.
   - `auth.rateLimit.exemptLoopback` defaults to `true`; set `false` when you intentionally want localhost traffic rate-limited too (for test setups or strict proxy deployments).

--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -439,6 +439,7 @@ Auth modes:
 
 - `gateway.auth.mode: "token"`: shared bearer token (recommended for most setups).
 - `gateway.auth.mode: "password"`: password auth (prefer setting via env: `OPENCLAW_GATEWAY_PASSWORD`).
+- `gateway.auth.mode: "trusted-proxy"`: trust an identity-aware reverse proxy to authenticate users and pass identity via headers (see [Trusted Proxy Auth](/gateway/trusted-proxy-auth)).
 
 Rotation checklist (token/password):
 
@@ -459,7 +460,7 @@ injected by Tailscale.
 
 **Security rule:** do not forward these headers from your own reverse proxy. If
 you terminate TLS or proxy in front of the gateway, disable
-`gateway.auth.allowTailscale` and use token/password auth instead.
+`gateway.auth.allowTailscale` and use token/password auth (or [Trusted Proxy Auth](/gateway/trusted-proxy-auth)) instead.
 
 Trusted proxies:
 

--- a/docs/web/webchat.md
+++ b/docs/web/webchat.md
@@ -44,6 +44,7 @@ Channel options:
 Related global options:
 
 - `gateway.port`, `gateway.bind`: WebSocket host/port.
-- `gateway.auth.mode`, `gateway.auth.token`, `gateway.auth.password`: WebSocket auth.
+- `gateway.auth.mode`, `gateway.auth.token`, `gateway.auth.password`: WebSocket auth (token/password).
+- `gateway.auth.mode: "trusted-proxy"`: reverse-proxy auth for browser clients (see [Trusted Proxy Auth](/gateway/trusted-proxy-auth)).
 - `gateway.remote.url`, `gateway.remote.token`, `gateway.remote.password`: remote gateway target.
 - `session.*`: session storage and main key defaults.


### PR DESCRIPTION
Add Trusted Proxy Auth discoverability + correct guidance.

- Add nav entry for `/gateway/trusted-proxy-auth`
- Add redirect `/gateway/trusted-proxy` -> `/gateway/trusted-proxy-auth`
- Link + mention `gateway.auth.mode="trusted-proxy"` in Gateway security + configuration reference
- Mention trusted-proxy option in WebChat docs

Gates: `pnpm check:docs`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Improves discoverability and documentation linking for the `trusted-proxy` auth mode by adding navigation entries, redirects, and cross-references across gateway documentation.

- Added redirect from `/gateway/trusted-proxy` to `/gateway/trusted-proxy-auth` in `docs.json`
- Added `gateway/trusted-proxy-auth` to navigation menu under "Configuration and operations"
- Updated `gateway.auth.mode` comments in configuration reference to include `trusted-proxy` option
- Added `trusted-proxy` auth mode to security documentation with proper cross-linking
- Added `trusted-proxy` mention in WebChat documentation for browser client authentication
- All links follow correct Mintlify format (root-relative, no `.md` extension)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Documentation-only changes that improve discoverability and follow all repository guidelines. All links use correct Mintlify format, the redirect is properly configured, and the navigation placement is logical. The trusted-proxy-auth.md file exists at the expected location, and all cross-references are consistent and accurate.
- No files require special attention

<sub>Last reviewed commit: bfef748</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->