### PR TITLE
fix(reply): honour explicit [[reply_to_*]] tags when replyToMode is off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 - BlueBubbles: gracefully degrade when Private API is disabled by filtering private-only actions, skipping private-only reactions/reply effects, and avoiding private reply markers so non-private flows remain usable. (#16002) Thanks @L-U-C-K-Y.
 - Outbound: add a write-ahead delivery queue with crash-recovery retries to prevent lost outbound messages after gateway restarts. (#15636) Thanks @nabbilkhan, @thewilloftheshadow.
 - Auto-reply/Threading: auto-inject implicit reply threading so `replyToMode` works without requiring model-emitted `[[reply_to_current]]`, while preserving `replyToMode: "off"` behavior for implicit Slack replies and keeping block-streaming chunk coalescing stable under `replyToMode: "first"`. (#14976) Thanks @Diaspar4u.
+- Auto-reply/Threading: honor explicit `[[reply_to_*]]` tags even when `replyToMode` is `off`. (#16174) Thanks @aldoeliacim.
 - Outbound/Threading: pass `replyTo` and `threadId` from `message send` tool actions through the core outbound send path to channel adapters, preserving thread/reply routing. (#14948) Thanks @mcaxtr.
 - Auto-reply/Media: allow image-only inbound messages (no caption) to reach the agent instead of short-circuiting as empty text, and preserve thread context in queued/followup prompt bodies for media-only runs. (#11916) Thanks @arosstale.
 - Discord: route autoThread replies to existing threads instead of the root channel. (#8302) Thanks @gavinbmoore, @thewilloftheshadow.

--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -273,6 +273,8 @@ See [Slash commands](/tools/slash-commands) for command catalog and behavior.
     - `first`
     - `all`
 
+    Note: `off` disables implicit reply threading. Explicit `[[reply_to_*]]` tags are still honored.
+
     Message IDs are surfaced in context/history so agents can target specific messages.
 
   </Accordion>

--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -233,6 +233,8 @@ Manual reply tags are supported:
 - `[[reply_to_current]]`
 - `[[reply_to:<id>]]`
 
+Note: `replyToMode="off"` disables implicit reply threading. Explicit `[[reply_to_*]]` tags are still honored.
+
 ## Media, chunking, and delivery
 
 <AccordionGroup>

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -416,6 +416,8 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
     - `first`
     - `all`
 
+    Note: `off` disables implicit reply threading. Explicit `[[reply_to_*]]` tags are still honored.
+
   </Accordion>
 
   <Accordion title="Forum topics and thread behavior">

--- a/src/auto-reply/reply/reply-payloads.auto-threading.test.ts
+++ b/src/auto-reply/reply/reply-payloads.auto-threading.test.ts
@@ -72,4 +72,17 @@ describe("applyReplyThreading auto-threading", () => {
     expect(result[0].replyToId).toBe("42");
     expect(result[0].replyToTag).toBe(true);
   });
+
+  it("keeps explicit tags for Telegram when off mode is enabled", () => {
+    const result = applyReplyThreading({
+      payloads: [{ text: "[[reply_to_current]]A" }],
+      replyToMode: "off",
+      replyToChannel: "telegram",
+      currentMessageId: "42",
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].replyToId).toBe("42");
+    expect(result[0].replyToTag).toBe(true);
+  });
 });

--- a/src/auto-reply/reply/reply-threading.ts
+++ b/src/auto-reply/reply/reply-threading.ts
@@ -54,9 +54,11 @@ export function createReplyToModeFilterForChannel(
   channel?: OriginatingChannelType,
 ) {
   const provider = normalizeChannelId(channel);
+  // Always honour explicit [[reply_to_*]] tags even when replyToMode is "off".
+  // Per-channel opt-out is possible but the safe default is to allow them.
   const allowTagsWhenOff = provider
-    ? Boolean(getChannelDock(provider)?.threading?.allowTagsWhenOff)
-    : false;
+    ? (getChannelDock(provider)?.threading?.allowTagsWhenOff ?? true)
+    : true;
   return createReplyToModeFilter(mode, {
     allowTagsWhenOff,
   });


### PR DESCRIPTION
## Summary

When `replyToMode` is `"off"`, explicit `[[reply_to_current]]` / `[[reply_to:<id>]]` tags from the LLM were being stripped along with auto-injected reply threading. This left users with an all-or-nothing choice: every message is a quoted reply (`"first"`) or no quoted replies ever (`"off"`).

## Changes

Change the default for `allowTagsWhenOff` from `false` to `true` in `createReplyToModeFilterForChannel`. This means explicit LLM tags are now honoured on all channels by default, not just Slack (which already had `allowTagsWhenOff: true` in its dock).

Channels can still opt out by setting `threading.allowTagsWhenOff: false` in their dock definition.

## Testing

- All 355 tests in `src/auto-reply/reply/` pass
- Existing test for `allowTagsWhenOff` behavior at line 235 of `reply-routing.test.ts` covers the core logic

Fixes #16155

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes a usability issue where explicit `[[reply_to_*]]` tags from the LLM were being stripped when `replyToMode` was set to `"off"`. The fix changes the default behavior to honour explicit reply tags across all channels, not just Slack. The change is minimal - it modifies the default value of `allowTagsWhenOff` from `false` to `true` using the nullish coalescing operator (`??`), allowing channels to still opt out by explicitly setting `threading.allowTagsWhenOff: false` in their dock definition. This provides users with more granular control: they can disable auto-reply threading while still allowing the LLM to explicitly request quoted replies when contextually appropriate.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is minimal, well-tested, and backwards compatible. It only changes a default value using proper TypeScript patterns (nullish coalescing). The existing test coverage validates the core logic, and channels can still opt out if needed. The change is also well-documented with a clear comment explaining the rationale.
- No files require special attention

<sub>Last reviewed commit: 6ff506a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->