### PR TITLE
Fix Groq TPM limits misidentified as context overflow

### DIFF
--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -36,6 +36,12 @@ export function isContextOverflowError(errorMessage?: string): boolean {
     return false;
   }
   const lower = errorMessage.toLowerCase();
+
+  // Groq uses 413 for TPM (tokens per minute) limits, which is a rate limit, not context overflow.
+  if (lower.includes("tpm") || lower.includes("tokens per minute")) {
+    return false;
+  }
+
   const hasRequestSizeExceeds = lower.includes("request size exceeds");
   const hasContextWindow =
     lower.includes("context window") ||
@@ -64,6 +70,13 @@ export function isLikelyContextOverflowError(errorMessage?: string): boolean {
   if (!errorMessage) {
     return false;
   }
+
+  // Groq uses 413 for TPM (tokens per minute) limits, which is a rate limit, not context overflow.
+  const lower = errorMessage.toLowerCase();
+  if (lower.includes("tpm") || lower.includes("tokens per minute")) {
+    return false;
+  }
+
   if (CONTEXT_WINDOW_TOO_SMALL_RE.test(errorMessage)) {
     return false;
   }
@@ -582,6 +595,8 @@ const ERROR_PATTERNS = {
     "quota exceeded",
     "resource_exhausted",
     "usage limit",
+    "tpm",
+    "tokens per minute",
   ],
   overloaded: [/overloaded_error|"type"\s*:\s*"overloaded_error"/i, "overloaded"],
   timeout: [


### PR DESCRIPTION
Groq uses HTTP 413 for TPM (tokens per minute) limit errors. These were being incorrectly identified as context window overflows, causing OpenClaw to try resetting the session in an infinite loop. This fix excludes errors containing 'tpm' or 'tokens per minute' from being identified as context overflows and correctly classifies them as rate limits.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed Groq TPM (tokens per minute) rate limit errors being misidentified as context overflow errors. Groq returns HTTP 413 with "too large" messages for rate limits, which was matching the context overflow pattern `(lower.includes("413") && lower.includes("too large"))` in `isContextOverflowError()`. This caused infinite retry loops as OpenClaw attempted to reset sessions for what it thought were context overflows. The fix adds early exclusion checks for "tpm" and "tokens per minute" strings in both `isContextOverflowError()` and `isLikelyContextOverflowError()`, and adds these patterns to the rate limit classifier.

- Prevented TPM errors from triggering incorrect context overflow handling
- Ensured TPM errors are properly classified as rate limits in `ERROR_PATTERNS.rateLimit`
- Applied consistent exclusion logic across both context overflow detection functions

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is targeted, logical, and solves a specific misidentification bug without introducing new risks. The changes are minimal (adding exclusion checks and updating pattern arrays), the logic is sound (checking for rate-limit-specific terms before general overflow patterns), and the implementation is consistent across related functions. No breaking changes or side effects expected.
- No files require special attention

<sub>Last reviewed commit: fd20686</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->