### PR TITLE
revert: undo #12027 heartbeat bootstrap behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,6 @@ Docs: https://docs.openclaw.ai
 - Heartbeat: prevent scheduler silent-death races during runner reloads, preserve retry cooldown backoff under wake bursts, and prioritize user/action wake causes over interval/retry reasons when coalescing. (#15108) Thanks @joeykrug.
 - Heartbeat: allow explicit wake (`wake`) and hook wake (`hook:*`) reasons to run even when `HEARTBEAT.md` is effectively empty so queued system events are processed. (#14527) Thanks @arosstale.
 - Auto-reply/Heartbeat: strip sentence-ending `HEARTBEAT_OK` tokens even when followed by up to 4 punctuation characters, while preserving surrounding sentence punctuation. (#15847) Thanks @Spacefish.
-- Agents/Heartbeat: stop auto-creating `HEARTBEAT.md` during workspace bootstrap so missing files continue to run heartbeat as documented. (#11766) Thanks @shadril238.
 - Sessions/Agents: pass `agentId` when resolving existing transcript paths in reply runs so non-default agents and heartbeat/chat handlers no longer fail with `Session file path must be within sessions directory`. (#15141) Thanks @Goldenmonstew.
 - Sessions/Agents: pass `agentId` through status and usage transcript-resolution paths (auto-reply, gateway usage APIs, and session cost/log loaders) so non-default agents can resolve absolute session files without path-validation failures. (#15103) Thanks @jalehman.
 - Sessions: archive previous transcript files on `/new` and `/reset` session resets (including gateway `sessions.reset`) so stale transcripts do not accumulate on disk. (#14869) Thanks @mcaxtr.

--- a/src/agents/workspace.e2e.test.ts
+++ b/src/agents/workspace.e2e.test.ts
@@ -1,14 +1,9 @@
-import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { makeTempWorkspace, writeWorkspaceFile } from "../test-helpers/workspace.js";
 import {
-  DEFAULT_AGENTS_FILENAME,
-  DEFAULT_BOOTSTRAP_FILENAME,
-  DEFAULT_HEARTBEAT_FILENAME,
   DEFAULT_MEMORY_ALT_FILENAME,
   DEFAULT_MEMORY_FILENAME,
-  ensureAgentWorkspace,
   loadWorkspaceBootstrapFiles,
   resolveDefaultAgentWorkspaceDir,
 } from "./workspace.js";
@@ -21,21 +16,6 @@ describe("resolveDefaultAgentWorkspaceDir", () => {
     } as NodeJS.ProcessEnv);
 
     expect(dir).toBe(path.join(path.resolve("/srv/openclaw-home"), ".openclaw", "workspace"));
-  });
-});
-
-describe("ensureAgentWorkspace", () => {
-  it("does not create HEARTBEAT.md during bootstrap file initialization", async () => {
-    const tempDir = await makeTempWorkspace("openclaw-workspace-init-");
-
-    const result = await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
-
-    await expect(fs.access(path.join(tempDir, DEFAULT_AGENTS_FILENAME))).resolves.toBeUndefined();
-    await expect(
-      fs.access(path.join(tempDir, DEFAULT_BOOTSTRAP_FILENAME)),
-    ).resolves.toBeUndefined();
-    await expect(fs.access(path.join(tempDir, DEFAULT_HEARTBEAT_FILENAME))).rejects.toThrow();
-    expect("heartbeatPath" in result).toBe(false);
   });
 });
 

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -173,6 +173,7 @@ export async function ensureAgentWorkspace(params?: {
   toolsPath?: string;
   identityPath?: string;
   userPath?: string;
+  heartbeatPath?: string;
   bootstrapPath?: string;
 }> {
   const rawDir = params?.dir?.trim() ? params.dir.trim() : DEFAULT_AGENT_WORKSPACE_DIR;
@@ -188,13 +189,11 @@ export async function ensureAgentWorkspace(params?: {
   const toolsPath = path.join(dir, DEFAULT_TOOLS_FILENAME);
   const identityPath = path.join(dir, DEFAULT_IDENTITY_FILENAME);
   const userPath = path.join(dir, DEFAULT_USER_FILENAME);
-  // HEARTBEAT.md is intentionally NOT created from template.
-  // Per docs: "If the file is missing, the heartbeat still runs and the model decides what to do."
-  // Creating it from template (which is effectively empty) would cause heartbeat to be skipped.
+  const heartbeatPath = path.join(dir, DEFAULT_HEARTBEAT_FILENAME);
   const bootstrapPath = path.join(dir, DEFAULT_BOOTSTRAP_FILENAME);
 
   const isBrandNewWorkspace = await (async () => {
-    const paths = [agentsPath, soulPath, toolsPath, identityPath, userPath];
+    const paths = [agentsPath, soulPath, toolsPath, identityPath, userPath, heartbeatPath];
     const existing = await Promise.all(
       paths.map(async (p) => {
         try {
@@ -213,6 +212,7 @@ export async function ensureAgentWorkspace(params?: {
   const toolsTemplate = await loadTemplate(DEFAULT_TOOLS_FILENAME);
   const identityTemplate = await loadTemplate(DEFAULT_IDENTITY_FILENAME);
   const userTemplate = await loadTemplate(DEFAULT_USER_FILENAME);
+  const heartbeatTemplate = await loadTemplate(DEFAULT_HEARTBEAT_FILENAME);
   const bootstrapTemplate = await loadTemplate(DEFAULT_BOOTSTRAP_FILENAME);
 
   await writeFileIfMissing(agentsPath, agentsTemplate);
@@ -220,6 +220,7 @@ export async function ensureAgentWorkspace(params?: {
   await writeFileIfMissing(toolsPath, toolsTemplate);
   await writeFileIfMissing(identityPath, identityTemplate);
   await writeFileIfMissing(userPath, userTemplate);
+  await writeFileIfMissing(heartbeatPath, heartbeatTemplate);
   if (isBrandNewWorkspace) {
     await writeFileIfMissing(bootstrapPath, bootstrapTemplate);
   }
@@ -232,6 +233,7 @@ export async function ensureAgentWorkspace(params?: {
     toolsPath,
     identityPath,
     userPath,
+    heartbeatPath,
     bootstrapPath,
   };
 }


### PR DESCRIPTION
## Summary
- revert commit `386bb0c61806d89b1a8e8fecc78cf42260910c4f` from PR #12027
- restore previous `ensureAgentWorkspace` behavior that writes `HEARTBEAT.md` during workspace init
- keep onboarding behavior consistent: `HEARTBEAT.md` needs to exist on workspace init as part of onboarding
- remove the #12027 changelog entry added by that PR

## Verification
- `pnpm test src/agents/workspace.e2e.test.ts` (fails because repo test config excludes `*.e2e.test.ts`)
- `pnpm check` (currently fails on existing `src/gateway/tools-invoke-http.ts` TypeScript errors on main)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR reverts commit `386bb0c6` from #12027, restoring the original `ensureAgentWorkspace` behavior that auto-creates `HEARTBEAT.md` during workspace initialization.

Key changes:
- Restores `heartbeatPath` parameter in the return type of `ensureAgentWorkspace`
- Re-enables loading and writing the `HEARTBEAT.md` template during bootstrap
- Includes `heartbeatPath` in the `isBrandNewWorkspace` check
- Removes the test that verified `HEARTBEAT.md` was NOT created
- Removes the changelog entry from #12027

The template content (after frontmatter stripping) contains only markdown headers/comments, making it "effectively empty" per `isHeartbeatContentEffectivelyEmpty()`, so heartbeat API calls will still be skipped as intended. This revert appears to restore the correct default behavior where users get a documented template file with instructions.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - it's a clean revert that restores tested, documented behavior
- This is a straightforward revert of a recent commit that restores the previous workspace initialization behavior. The changes are minimal, well-contained, and restore documented functionality. The template that gets written is effectively empty (only contains markdown headers/comments), so the heartbeat will be correctly skipped until users add actual tasks. The revert properly undoes all aspects of the original PR including code changes, tests, and changelog entries.
- No files require special attention

<sub>Last reviewed commit: cd52355</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->