### PR TITLE
fix: patch systemd unit version before service restart

### DIFF
--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -4,6 +4,7 @@ import { isSystemdUserServiceAvailable } from "../../daemon/systemd.js";
 import { renderSystemdUnavailableHints } from "../../daemon/systemd-hints.js";
 import { isWSL } from "../../infra/wsl.js";
 import { defaultRuntime } from "../../runtime.js";
+import { VERSION } from "../../version.js";
 import { buildDaemonServiceSnapshot, createNullWriter, emitDaemonActionJson } from "./response.js";
 import { renderGatewayServiceStartHints } from "./shared.js";
 import type { DaemonLifecycleOptions } from "./types.js";
@@ -276,6 +277,13 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
       }
     }
     return false;
+  }
+  if (service.patchVersion) {
+    try {
+      await service.patchVersion({ env: process.env, version: VERSION });
+    } catch {
+      // Non-fatal: version metadata is cosmetic; don't block restart
+    }
   }
   try {
     await service.restart({ env: process.env, stdout });

--- a/src/commands/doctor-gateway-services.ts
+++ b/src/commands/doctor-gateway-services.ts
@@ -16,6 +16,7 @@ import {
 } from "../daemon/service-audit.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { note } from "../terminal/note.js";
+import { VERSION } from "../version.js";
 import { buildGatewayInstallPlan } from "./daemon-install-helpers.js";
 import { DEFAULT_GATEWAY_DAEMON_RUNTIME, type GatewayDaemonRuntime } from "./daemon-runtime.js";
 import type { DoctorOptions, DoctorPrompter } from "./doctor-prompter.js";
@@ -107,6 +108,7 @@ export async function maybeRepairGatewayServiceConfig(
   const audit = await auditGatewayServiceConfig({
     env: process.env,
     command,
+    currentVersion: VERSION,
   });
   const needsNodeRuntime = needsNodeRuntimeMigration(audit.issues);
   const systemNodeInfo = needsNodeRuntime

--- a/src/daemon/service-audit.test.ts
+++ b/src/daemon/service-audit.test.ts
@@ -41,6 +41,59 @@ describe("auditGatewayServiceConfig", () => {
     ).toBe(true);
   });
 
+  it("detects version mismatch when versions differ", async () => {
+    const audit = await auditGatewayServiceConfig({
+      env: { HOME: "/tmp" },
+      platform: "darwin",
+      currentVersion: "2.0.0",
+      command: {
+        programArguments: ["/usr/bin/node", "gateway"],
+        environment: {
+          PATH: "/usr/bin:/bin",
+          OPENCLAW_SERVICE_VERSION: "1.0.0",
+        },
+      },
+    });
+    expect(
+      audit.issues.some((issue) => issue.code === SERVICE_AUDIT_CODES.serviceVersionMismatch),
+    ).toBe(true);
+  });
+
+  it("no version mismatch issue when versions match", async () => {
+    const audit = await auditGatewayServiceConfig({
+      env: { HOME: "/tmp" },
+      platform: "darwin",
+      currentVersion: "2.0.0",
+      command: {
+        programArguments: ["/usr/bin/node", "gateway"],
+        environment: {
+          PATH: "/usr/bin:/bin",
+          OPENCLAW_SERVICE_VERSION: "2.0.0",
+        },
+      },
+    });
+    expect(
+      audit.issues.some((issue) => issue.code === SERVICE_AUDIT_CODES.serviceVersionMismatch),
+    ).toBe(false);
+  });
+
+  it("no version mismatch issue when OPENCLAW_SERVICE_VERSION is absent", async () => {
+    const audit = await auditGatewayServiceConfig({
+      env: { HOME: "/tmp" },
+      platform: "darwin",
+      currentVersion: "2.0.0",
+      command: {
+        programArguments: ["/usr/bin/node", "gateway"],
+        environment: {
+          PATH: "/usr/bin:/bin",
+        },
+      },
+    });
+    expect(
+      audit.issues.some((issue) => issue.code === SERVICE_AUDIT_CODES.serviceVersionMismatch),
+    ).toBe(false);
+  });
+
   it("accepts Linux minimal PATH with user directories", async () => {
     const env = { HOME: "/home/testuser", PNPM_HOME: "/opt/pnpm" };
     const minimalPath = buildMinimalServicePath({ platform: "linux", env });

--- a/src/daemon/service.ts
+++ b/src/daemon/service.ts
@@ -20,6 +20,7 @@ import type { GatewayServiceRuntime } from "./service-runtime.js";
 import {
   installSystemdService,
   isSystemdServiceEnabled,
+  patchSystemdUnitVersion,
   readSystemdServiceExecStart,
   readSystemdServiceRuntime,
   restartSystemdService,
@@ -61,6 +62,10 @@ export type GatewayService = {
     sourcePath?: string;
   } | null>;
   readRuntime: (env: Record<string, string | undefined>) => Promise<GatewayServiceRuntime>;
+  patchVersion?: (args: {
+    env: Record<string, string | undefined>;
+    version: string;
+  }) => Promise<boolean>;
 };
 
 export function resolveGatewayService(): GatewayService {
@@ -119,6 +124,7 @@ export function resolveGatewayService(): GatewayService {
       isLoaded: async (args) => isSystemdServiceEnabled(args),
       readCommand: readSystemdServiceExecStart,
       readRuntime: async (env) => await readSystemdServiceRuntime(env),
+      patchVersion: async (args) => patchSystemdUnitVersion(args),
     };
   }
 

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from "vitest";
-
-import { parseSystemdShow, resolveSystemdUserUnitPath } from "./systemd.js";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { parseSystemdShow, patchSystemdUnitVersion, resolveSystemdUserUnitPath } from "./systemd.js";
 
 describe("systemd runtime parsing", () => {
   it("parses active state details", () => {
@@ -92,5 +93,91 @@ describe("resolveSystemdUserUnitPath", () => {
     expect(resolveSystemdUserUnitPath(env)).toBe(
       "/home/test/.config/systemd/user/openclaw-gateway-myprofile.service",
     );
+  });
+});
+
+vi.mock("node:child_process", () => ({
+  execFile: vi.fn((_cmd: string, _args: string[], _opts: unknown, cb?: Function) => {
+    if (cb) {
+      cb(null, "", "");
+    }
+  }),
+}));
+
+describe("patchSystemdUnitVersion", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join("/tmp", "systemd-patch-test-"));
+    await fs.mkdir(path.join(tmpDir, ".config", "systemd", "user"), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  const sampleUnit = [
+    "[Unit]",
+    "Description=OpenClaw Gateway (v1.0.0)",
+    "After=network-online.target",
+    "Wants=network-online.target",
+    "",
+    "[Service]",
+    "ExecStart=/usr/bin/node /opt/openclaw/cli.js gateway",
+    "Restart=always",
+    "RestartSec=5",
+    "KillMode=process",
+    "Environment=PATH=/usr/bin:/bin",
+    "Environment=OPENCLAW_SERVICE_VERSION=1.0.0",
+    "Environment=OPENCLAW_GATEWAY_TOKEN=secret",
+    "",
+    "[Install]",
+    "WantedBy=default.target",
+    "",
+  ].join("\n");
+
+  it("patches Description and OPENCLAW_SERVICE_VERSION when version differs", async () => {
+    const unitPath = path.join(tmpDir, ".config", "systemd", "user", "openclaw-gateway.service");
+    await fs.writeFile(unitPath, sampleUnit, "utf8");
+
+    const env = { HOME: tmpDir };
+    const result = await patchSystemdUnitVersion({ env, version: "2.0.0" });
+    expect(result).toBe(true);
+
+    const patched = await fs.readFile(unitPath, "utf8");
+    expect(patched).toContain("Description=OpenClaw Gateway (v2.0.0)");
+    expect(patched).toContain("Environment=OPENCLAW_SERVICE_VERSION=2.0.0");
+  });
+
+  it("returns false when already current", async () => {
+    const unitPath = path.join(tmpDir, ".config", "systemd", "user", "openclaw-gateway.service");
+    await fs.writeFile(unitPath, sampleUnit, "utf8");
+
+    const env = { HOME: tmpDir };
+    const result = await patchSystemdUnitVersion({ env, version: "1.0.0" });
+    expect(result).toBe(false);
+  });
+
+  it("returns false when unit file doesn't exist", async () => {
+    const env = { HOME: tmpDir };
+    const result = await patchSystemdUnitVersion({ env, version: "2.0.0" });
+    expect(result).toBe(false);
+  });
+
+  it("preserves all other lines unchanged", async () => {
+    const unitPath = path.join(tmpDir, ".config", "systemd", "user", "openclaw-gateway.service");
+    await fs.writeFile(unitPath, sampleUnit, "utf8");
+
+    const env = { HOME: tmpDir };
+    await patchSystemdUnitVersion({ env, version: "2.0.0" });
+
+    const patched = await fs.readFile(unitPath, "utf8");
+    expect(patched).toContain("ExecStart=/usr/bin/node /opt/openclaw/cli.js gateway");
+    expect(patched).toContain("Environment=PATH=/usr/bin:/bin");
+    expect(patched).toContain("Environment=OPENCLAW_GATEWAY_TOKEN=secret");
+    expect(patched).toContain("Restart=always");
+    expect(patched).toContain("RestartSec=5");
+    expect(patched).toContain("KillMode=process");
+    expect(patched).toContain("WantedBy=default.target");
   });
 });


### PR DESCRIPTION
## Summary

- After `openclaw update`, the systemd unit file retained the old `OPENCLAW_SERVICE_VERSION` and `Description` because `restartSystemdService()` only ran `systemctl --user restart` without touching the unit file
- Add `patchSystemdUnitVersion()` that surgically patches only the `Description=` and `OPENCLAW_SERVICE_VERSION` env lines before restart, avoiding a full `installSystemdService()` which could clobber env vars from the original install environment
- Add `serviceVersionMismatch` audit check so `openclaw doctor` catches stale versions as a safety net
- Verified end-to-end: unit file updated from `v2026.2.12` → `v2026.2.13` on restart, service running cleanly

Fixes #15513
Fixes #7710

## Test plan

- [x] `pnpm test src/daemon/systemd.test.ts` — 4 new tests for `patchSystemdUnitVersion` (patches version, no-op when current, no-op when missing, preserves other lines)
- [x] `pnpm test src/daemon/service-audit.test.ts` — 3 new tests for version mismatch audit
- [x] Manual: ran `openclaw gateway restart` on live system, confirmed unit file updated and service running

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `patchSystemdUnitVersion()` to surgically update only the version-related fields (`Description=` and `OPENCLAW_SERVICE_VERSION`) in the systemd unit file before restart, avoiding a full reinstall that could overwrite environment variables. Also adds a `serviceVersionMismatch` audit check to `openclaw doctor` for detecting stale service versions.

- New `patchSystemdUnitVersion()` function patches version metadata in systemd unit files
- Added optional `patchVersion` method to `GatewayService` interface, called before restart
- New `serviceVersionMismatch` audit code detects version mismatches in `openclaw doctor`
- Comprehensive test coverage for both patching logic and audit checks
- One logic issue found: whitespace handling bug in line comparison could cause unnecessary rewrites

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one minor logic fix recommended
- Well-tested implementation with clear purpose and comprehensive test coverage. One logical error found in whitespace handling that could cause unnecessary file rewrites, but unlikely to cause issues in practice since OpenClaw-generated files don't have leading whitespace. Non-fatal error handling prevents blocking restarts.
- Check `src/daemon/systemd.ts:316-322` for whitespace comparison logic

<sub>Last reviewed commit: ef94e42</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->