### PR TITLE
refactor(reply): clarify explicit reply tags in off mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Docs: https://docs.openclaw.ai
 - Outbound: add a write-ahead delivery queue with crash-recovery retries to prevent lost outbound messages after gateway restarts. (#15636) Thanks @nabbilkhan, @thewilloftheshadow.
 - Auto-reply/Threading: auto-inject implicit reply threading so `replyToMode` works without requiring model-emitted `[[reply_to_current]]`, while preserving `replyToMode: "off"` behavior for implicit Slack replies and keeping block-streaming chunk coalescing stable under `replyToMode: "first"`. (#14976) Thanks @Diaspar4u.
 - Auto-reply/Threading: honor explicit `[[reply_to_*]]` tags even when `replyToMode` is `off`. (#16174) Thanks @aldoeliacim.
+- Plugins/Threading: rename `allowTagsWhenOff` to `allowExplicitReplyTagsWhenOff` and keep the old key as a deprecated alias for compatibility. (#16189)
 - Outbound/Threading: pass `replyTo` and `threadId` from `message send` tool actions through the core outbound send path to channel adapters, preserving thread/reply routing. (#14948) Thanks @mcaxtr.
 - Auto-reply/Media: allow image-only inbound messages (no caption) to reach the agent instead of short-circuiting as empty text, and preserve thread context in queued/followup prompt bodies for media-only runs. (#11916) Thanks @arosstale.
 - Discord: route autoThread replies to existing threads instead of the root channel. (#8302) Thanks @gavinbmoore, @thewilloftheshadow.

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -177,7 +177,7 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
   threading: {
     resolveReplyToMode: ({ cfg, accountId, chatType }) =>
       resolveSlackReplyToMode(resolveSlackAccount({ cfg, accountId }), chatType),
-    allowTagsWhenOff: true,
+    allowExplicitReplyTagsWhenOff: true,
     buildToolContext: (params) => buildSlackThreadingToolContext(params),
   },
   messaging: {

--- a/src/auto-reply/reply/reply-payloads.ts
+++ b/src/auto-reply/reply/reply-payloads.ts
@@ -7,41 +7,54 @@ import { normalizeTargetForProvider } from "../../infra/outbound/target-normaliz
 import { extractReplyToTag } from "./reply-tags.js";
 import { createReplyToModeFilterForChannel } from "./reply-threading.js";
 
+function resolveReplyThreadingForPayload(params: {
+  payload: ReplyPayload;
+  implicitReplyToId?: string;
+  currentMessageId?: string;
+}): ReplyPayload {
+  const implicitReplyToId = params.implicitReplyToId?.trim() || undefined;
+  const currentMessageId = params.currentMessageId?.trim() || undefined;
+
+  // 1) Apply implicit reply threading first (replyToMode will strip later if needed).
+  let resolved: ReplyPayload =
+    params.payload.replyToId || params.payload.replyToCurrent === false || !implicitReplyToId
+      ? params.payload
+      : { ...params.payload, replyToId: implicitReplyToId };
+
+  // 2) Parse explicit reply tags from text (if present) and clean them.
+  if (typeof resolved.text === "string" && resolved.text.includes("[[")) {
+    const { cleaned, replyToId, replyToCurrent, hasTag } = extractReplyToTag(
+      resolved.text,
+      currentMessageId,
+    );
+    resolved = {
+      ...resolved,
+      text: cleaned ? cleaned : undefined,
+      replyToId: replyToId ?? resolved.replyToId,
+      replyToTag: hasTag || resolved.replyToTag,
+      replyToCurrent: replyToCurrent || resolved.replyToCurrent,
+    };
+  }
+
+  // 3) If replyToCurrent was set out-of-band (e.g. tags already stripped upstream),
+  // ensure replyToId is set to the current message id when available.
+  if (resolved.replyToCurrent && !resolved.replyToId && currentMessageId) {
+    resolved = {
+      ...resolved,
+      replyToId: currentMessageId,
+    };
+  }
+
+  return resolved;
+}
+
+// Backward-compatible helper: apply explicit reply tags/directives to a single payload.
+// This intentionally does not apply implicit threading.
 export function applyReplyTagsToPayload(
   payload: ReplyPayload,
   currentMessageId?: string,
 ): ReplyPayload {
-  if (typeof payload.text !== "string") {
-    if (!payload.replyToCurrent || payload.replyToId) {
-      return payload;
-    }
-    return {
-      ...payload,
-      replyToId: currentMessageId?.trim() || undefined,
-    };
-  }
-  const shouldParseTags = payload.text.includes("[[");
-  if (!shouldParseTags) {
-    if (!payload.replyToCurrent || payload.replyToId) {
-      return payload;
-    }
-    return {
-      ...payload,
-      replyToId: currentMessageId?.trim() || undefined,
-      replyToTag: payload.replyToTag ?? true,
-    };
-  }
-  const { cleaned, replyToId, replyToCurrent, hasTag } = extractReplyToTag(
-    payload.text,
-    currentMessageId,
-  );
-  return {
-    ...payload,
-    text: cleaned ? cleaned : undefined,
-    replyToId: replyToId ?? payload.replyToId,
-    replyToTag: hasTag || payload.replyToTag,
-    replyToCurrent: replyToCurrent || payload.replyToCurrent,
-  };
+  return resolveReplyThreadingForPayload({ payload, currentMessageId });
 }
 
 export function isRenderablePayload(payload: ReplyPayload): boolean {
@@ -64,13 +77,9 @@ export function applyReplyThreading(params: {
   const applyReplyToMode = createReplyToModeFilterForChannel(replyToMode, replyToChannel);
   const implicitReplyToId = currentMessageId?.trim() || undefined;
   return payloads
-    .map((payload) => {
-      const autoThreaded =
-        payload.replyToId || payload.replyToCurrent === false || !implicitReplyToId
-          ? payload
-          : { ...payload, replyToId: implicitReplyToId };
-      return applyReplyTagsToPayload(autoThreaded, currentMessageId);
-    })
+    .map((payload) =>
+      resolveReplyThreadingForPayload({ payload, implicitReplyToId, currentMessageId }),
+    )
     .filter(isRenderablePayload)
     .map(applyReplyToMode);
 }

--- a/src/auto-reply/reply/reply-routing.test.ts
+++ b/src/auto-reply/reply/reply-routing.test.ts
@@ -232,7 +232,7 @@ describe("createReplyToModeFilter", () => {
   });
 
   it("keeps replyToId when mode is off and reply tags are allowed", () => {
-    const filter = createReplyToModeFilter("off", { allowTagsWhenOff: true });
+    const filter = createReplyToModeFilter("off", { allowExplicitReplyTagsWhenOff: true });
     expect(filter({ text: "hi", replyToId: "1", replyToTag: true }).replyToId).toBe("1");
   });
 

--- a/src/auto-reply/reply/reply-threading.ts
+++ b/src/auto-reply/reply/reply-threading.ts
@@ -25,7 +25,7 @@ export function resolveReplyToMode(
 
 export function createReplyToModeFilter(
   mode: ReplyToMode,
-  opts: { allowTagsWhenOff?: boolean } = {},
+  opts: { allowExplicitReplyTagsWhenOff?: boolean } = {},
 ) {
   let hasThreaded = false;
   return (payload: ReplyPayload): ReplyPayload => {
@@ -33,7 +33,8 @@ export function createReplyToModeFilter(
       return payload;
     }
     if (mode === "off") {
-      if (opts.allowTagsWhenOff && payload.replyToTag) {
+      const isExplicit = Boolean(payload.replyToTag) || Boolean(payload.replyToCurrent);
+      if (opts.allowExplicitReplyTagsWhenOff && isExplicit) {
         return payload;
       }
       return { ...payload, replyToId: undefined };
@@ -54,12 +55,14 @@ export function createReplyToModeFilterForChannel(
   channel?: OriginatingChannelType,
 ) {
   const provider = normalizeChannelId(channel);
-  // Always honour explicit [[reply_to_*]] tags even when replyToMode is "off".
-  // Per-channel opt-out is possible but the safe default is to allow them.
-  const allowTagsWhenOff = provider
-    ? (getChannelDock(provider)?.threading?.allowTagsWhenOff ?? true)
-    : true;
+  const normalized = typeof channel === "string" ? channel.trim().toLowerCase() : undefined;
+  const isWebchat = normalized === "webchat";
+  // Default: allow explicit reply tags/directives even when replyToMode is "off".
+  // Unknown channels fail closed; internal webchat stays allowed.
+  const allowExplicitReplyTagsWhenOff = provider
+    ? (getChannelDock(provider)?.threading?.allowExplicitReplyTagsWhenOff ?? true)
+    : isWebchat;
   return createReplyToModeFilter(mode, {
-    allowTagsWhenOff,
+    allowExplicitReplyTagsWhenOff,
   });
 }

--- a/src/auto-reply/reply/reply-threading.ts
+++ b/src/auto-reply/reply/reply-threading.ts
@@ -59,8 +59,9 @@ export function createReplyToModeFilterForChannel(
   const isWebchat = normalized === "webchat";
   // Default: allow explicit reply tags/directives even when replyToMode is "off".
   // Unknown channels fail closed; internal webchat stays allowed.
+  const dock = provider ? getChannelDock(provider) : undefined;
   const allowExplicitReplyTagsWhenOff = provider
-    ? (getChannelDock(provider)?.threading?.allowExplicitReplyTagsWhenOff ?? true)
+    ? (dock?.threading?.allowExplicitReplyTagsWhenOff ?? dock?.threading?.allowTagsWhenOff ?? true)
     : isWebchat;
   return createReplyToModeFilter(mode, {
     allowExplicitReplyTagsWhenOff,

--- a/src/channels/dock.ts
+++ b/src/channels/dock.ts
@@ -369,7 +369,7 @@ const DOCKS: Record<ChatChannelId, ChannelDock> = {
     threading: {
       resolveReplyToMode: ({ cfg, accountId, chatType }) =>
         resolveSlackReplyToMode(resolveSlackAccount({ cfg, accountId }), chatType),
-      allowTagsWhenOff: true,
+      allowExplicitReplyTagsWhenOff: true,
       buildToolContext: (params) => buildSlackThreadingToolContext(params),
     },
   },

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -223,7 +223,12 @@ export type ChannelThreadingAdapter = {
     accountId?: string | null;
     chatType?: string | null;
   }) => "off" | "first" | "all";
-  allowTagsWhenOff?: boolean;
+  /**
+   * When replyToMode is "off", allow explicit reply tags/directives to keep replyToId.
+   *
+   * Default in shared reply flow: true for known providers; per-channel opt-out supported.
+   */
+  allowExplicitReplyTagsWhenOff?: boolean;
   buildToolContext?: (params: {
     cfg: OpenClawConfig;
     accountId?: string | null;

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -229,6 +229,11 @@ export type ChannelThreadingAdapter = {
    * Default in shared reply flow: true for known providers; per-channel opt-out supported.
    */
   allowExplicitReplyTagsWhenOff?: boolean;
+  /**
+   * Deprecated alias for allowExplicitReplyTagsWhenOff.
+   * Kept for compatibility with older extensions/docks.
+   */
+  allowTagsWhenOff?: boolean;
   buildToolContext?: (params: {
     cfg: OpenClawConfig;
     accountId?: string | null;


### PR DESCRIPTION
Refactor only.

- Rename `allowTagsWhenOff` -> `allowExplicitReplyTagsWhenOff`.
- Fail closed for unknown channels when `replyToMode=off` (keep `webchat` allowed).
- Consolidate reply threading/tag parsing into a single helper.

Tests: pnpm check, pnpm test.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Clean refactoring of the reply threading/tag system with one deliberate behavioral tightening:

- Renames `allowTagsWhenOff` to `allowExplicitReplyTagsWhenOff` across the type, dock, plugin, and filter layers for clarity.
- Consolidates implicit reply threading, tag parsing, and `replyToCurrent` resolution into a single `resolveReplyThreadingForPayload` helper, reducing duplication in `reply-payloads.ts`.
- Broadens the "explicit" check in `createReplyToModeFilter` to include `replyToCurrent` (not just `replyToTag`), which compensates for the removed `replyToTag ?? true` default.
- **Behavioral change**: unknown channels now fail closed when `replyToMode=off` (previously defaulted to allowing tags). Internal `webchat` channel is explicitly exempted. This is a security improvement.
- Tests updated accordingly; existing integration tests confirm no regression.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a well-scoped refactor with one intentional security tightening, backed by passing tests.
- The changes are primarily mechanical renames plus a consolidation of duplicated logic into a single helper. The one behavioral change (fail-closed for unknown channels) is a deliberate security improvement. All existing tests pass, the old property name is fully removed, and the refactored code paths are logically equivalent to the originals.
- No files require special attention.

<sub>Last reviewed commit: e8ebc8e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->