### PR TITLE
fix(signal): preserve case of base64 group IDs (#11662)

### DIFF
--- a/src/channels/plugins/normalize/signal.test.ts
+++ b/src/channels/plugins/normalize/signal.test.ts
@@ -34,4 +34,22 @@ describe("signal target normalization", () => {
     expect(looksLikeSignalTargetId("uuid:")).toBe(false);
     expect(looksLikeSignalTargetId("uuid:not-a-uuid")).toBe(false);
   });
+
+  it("preserves group ID case (base64 is case-sensitive) (#11662)", () => {
+    expect(normalizeSignalMessagingTarget("group:AbCdEfGh123456789xYz+/aBcDeF==")).toBe(
+      "group:AbCdEfGh123456789xYz+/aBcDeF==",
+    );
+  });
+
+  it("preserves group ID case with signal: prefix (#11662)", () => {
+    expect(normalizeSignalMessagingTarget("signal:group:AbCdEfGh123456789xYz+/aBcDeF==")).toBe(
+      "group:AbCdEfGh123456789xYz+/aBcDeF==",
+    );
+  });
+
+  it("preserves group ID case with uppercase GROUP: prefix (#11662)", () => {
+    expect(normalizeSignalMessagingTarget("GROUP:AbCdEfGh123456789xYz+/aBcDeF==")).toBe(
+      "group:AbCdEfGh123456789xYz+/aBcDeF==",
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #11662

## Problem

`normalizeSignalMessagingTarget()` lowercases the entire group ID when normalizing Signal targets:

```typescript
return id ? \`group:\${id}\`.toLowerCase() : undefined;
```

Signal group IDs are base64-encoded and **case-sensitive**. Lowercasing them causes `signal-cli` to return "Group not found" errors.

## Root Cause

Line 16 in `src/channels/plugins/normalize/signal.ts` applies `.toLowerCase()` to the entire `group:${id}` string, destroying the case of the base64 group ID.

## Fix

Remove `.toLowerCase()` from the group ID branch. The `group:` prefix is already lowercase from the template literal:

```diff
- return id ? \`group:\${id}\`.toLowerCase() : undefined;
+ return id ? \`group:\${id}\` : undefined;
```

## Tests

Added 3 test cases verifying group ID case preservation with various prefix formats.

All 8 tests pass.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixes Signal group ID normalization by removing `.toLowerCase()` from the group ID branch. Signal group IDs are base64-encoded strings that are case-sensitive, so lowercasing them causes `signal-cli` to fail with "Group not found" errors. The fix preserves the case of the base64 ID while keeping the `group:` prefix lowercase. Added 3 test cases verifying case preservation with different input formats (`group:`, `signal:group:`, `GROUP:`).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - it's a simple, well-tested bug fix with no risk
- The fix is minimal (removing one method call), addresses a clear bug where case-sensitive base64 group IDs were being incorrectly lowercased, and includes comprehensive test coverage for the edge cases. The change is isolated to the group ID branch and doesn't affect other normalization paths (username, uuid, etc.). All tests pass and the logic is straightforward.
- No files require special attention

<sub>Last reviewed commit: d515336</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->