### PR TITLE
fix(ollama): remove Ollama from isReasoningTagProvider (#2279)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 - Security/Hooks: restrict hook transform modules to `~/.openclaw/hooks/transforms` (prevents path traversal/escape module loads via config). Config note: `hooks.transformsDir` must now be within that directory. Thanks @akhmittra.
 - Security/Hooks: ignore hook package manifest entries that point outside the package directory (prevents out-of-tree handler loads during hook discovery).
+- Ollama/Agents: avoid forcing `<final>` tag enforcement for Ollama models, which could suppress all output as `(no output)`. (#16191) Thanks @Glucksberg.
 
 ## 2026.2.13
 

--- a/src/utils/provider-utils.test.ts
+++ b/src/utils/provider-utils.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { isReasoningTagProvider } from "./provider-utils.js";
+
+describe("isReasoningTagProvider", () => {
+  it("returns false for ollama — native reasoning field, no tags needed (#2279)", () => {
+    expect(isReasoningTagProvider("ollama")).toBe(false);
+    expect(isReasoningTagProvider("Ollama")).toBe(false);
+  });
+
+  it("returns true for google-gemini-cli", () => {
+    expect(isReasoningTagProvider("google-gemini-cli")).toBe(true);
+  });
+
+  it("returns true for google-generative-ai", () => {
+    expect(isReasoningTagProvider("google-generative-ai")).toBe(true);
+  });
+
+  it("returns true for google-antigravity", () => {
+    expect(isReasoningTagProvider("google-antigravity")).toBe(true);
+    expect(isReasoningTagProvider("google-antigravity/gemini-3")).toBe(true);
+  });
+
+  it("returns true for minimax", () => {
+    expect(isReasoningTagProvider("minimax")).toBe(true);
+    expect(isReasoningTagProvider("minimax-cn")).toBe(true);
+  });
+
+  it("returns false for null/undefined/empty", () => {
+    expect(isReasoningTagProvider(null)).toBe(false);
+    expect(isReasoningTagProvider(undefined)).toBe(false);
+    expect(isReasoningTagProvider("")).toBe(false);
+  });
+
+  it("returns false for standard providers", () => {
+    expect(isReasoningTagProvider("anthropic")).toBe(false);
+    expect(isReasoningTagProvider("openai")).toBe(false);
+    expect(isReasoningTagProvider("openrouter")).toBe(false);
+  });
+});

--- a/src/utils/provider-utils.test.ts
+++ b/src/utils/provider-utils.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { isReasoningTagProvider } from "./provider-utils.js";
 
 describe("isReasoningTagProvider", () => {
-  it("returns false for ollama — native reasoning field, no tags needed (#2279)", () => {
+  it("returns false for ollama - native reasoning field, no tags needed (#2279)", () => {
     expect(isReasoningTagProvider("ollama")).toBe(false);
     expect(isReasoningTagProvider("Ollama")).toBe(false);
   });

--- a/src/utils/provider-utils.ts
+++ b/src/utils/provider-utils.ts
@@ -14,7 +14,7 @@ export function isReasoningTagProvider(provider: string | undefined | null): boo
   const normalized = provider.trim().toLowerCase();
 
   // Check for exact matches or known prefixes/substrings for reasoning providers.
-  // Note: Ollama is intentionally excluded — its OpenAI-compatible endpoint
+  // Note: Ollama is intentionally excluded - its OpenAI-compatible endpoint
   // handles reasoning natively via the `reasoning` field in streaming chunks,
   // so tag-based enforcement is unnecessary and causes all output to be
   // discarded as "(no output)" (#2279).

--- a/src/utils/provider-utils.ts
+++ b/src/utils/provider-utils.ts
@@ -13,12 +13,12 @@ export function isReasoningTagProvider(provider: string | undefined | null): boo
   }
   const normalized = provider.trim().toLowerCase();
 
-  // Check for exact matches or known prefixes/substrings for reasoning providers
-  if (
-    normalized === "ollama" ||
-    normalized === "google-gemini-cli" ||
-    normalized === "google-generative-ai"
-  ) {
+  // Check for exact matches or known prefixes/substrings for reasoning providers.
+  // Note: Ollama is intentionally excluded — its OpenAI-compatible endpoint
+  // handles reasoning natively via the `reasoning` field in streaming chunks,
+  // so tag-based enforcement is unnecessary and causes all output to be
+  // discarded as "(no output)" (#2279).
+  if (normalized === "google-gemini-cli" || normalized === "google-generative-ai") {
     return true;
   }
 


### PR DESCRIPTION
## Summary

Fixes #2279

## Problem

All Ollama models return `(no output)` when used through OpenClaw. The TUI and messaging channels show no response even though the models produce valid output via direct API calls.

## Root Cause

`isReasoningTagProvider()` in `src/utils/provider-utils.ts` returns `true` for Ollama, which causes:

1. **`enforceFinalTag: true`** — `stripBlockTags()` enforces strict `<final>` tag extraction. Since Ollama models don't emit `<final>` tags, all text content is discarded.

2. **System prompt injection** — `<think>/<final>` format instructions are injected, which most Ollama models don't follow reliably.

## Why Ollama Doesn't Need Tag Enforcement

Ollama's OpenAI-compatible endpoint already handles reasoning natively via the `reasoning` field in streaming chunks:

```json
{"choices":[{"delta":{"content":"","reasoning":"The user said hello"}}]}
{"choices":[{"delta":{"content":"Hello! How can I help?"}}]}
```

The pi-ai library correctly maps `reasoning` → thinking blocks and `content` → text blocks. Tag-based enforcement is unnecessary and actively harmful.

## Fix

Remove `"ollama"` from the `isReasoningTagProvider()` check.

## Tests

Added comprehensive test suite for `isReasoningTagProvider()` covering all providers.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Removes `"ollama"` from `isReasoningTagProvider()` in `src/utils/provider-utils.ts` to fix #2279, where all Ollama models returned `(no output)`. The root cause was that `isReasoningTagProvider("ollama")` returned `true`, which triggered `enforceFinalTag: true` and injected `<think>/<final>` format instructions. Since Ollama models don't emit `<final>` tags, `stripBlockTags()` discarded all text content. Ollama's OpenAI-compatible endpoint already handles reasoning natively via the `reasoning` field in streaming chunks, making tag-based enforcement both unnecessary and harmful.

- Removed `"ollama"` from the provider list in `isReasoningTagProvider()` with a clear explanatory comment
- Added comprehensive test suite for `isReasoningTagProvider()` covering all provider branches (Ollama, Google variants, Minimax, null/undefined/empty, and standard providers)
- Impact is well-scoped: the function is consumed in 5 files (`get-reply-run.ts`, `compact.ts`, `attempt.ts`, `agent-runner-utils.ts`, and indirectly via the test), and removing Ollama from the check correctly prevents both `enforceFinalTag` and reasoning tag system prompt injection for Ollama sessions

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, well-targeted bug fix with comprehensive tests.
- The change is a single-line removal in a pure function with no side effects beyond its return value. The fix is well-justified: Ollama handles reasoning natively via its `reasoning` field, making tag enforcement both unnecessary and actively harmful (causing all output to be discarded). The new test file covers all code paths in the function. I traced all 5 downstream consumers and confirmed the change correctly prevents both `enforceFinalTag: true` and `reasoningTagHint: true` for Ollama sessions without affecting other providers.
- No files require special attention.

<sub>Last reviewed commit: 45de9e8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->