### PR TITLE
fix(config): add customBindHost to gateway zod schema (#5435)

### DIFF
--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -37,6 +37,21 @@ describe("config schema regressions", () => {
     expect(res.ok).toBe(true);
   });
 
+  it('accepts gateway.bind="custom" with gateway.customBindHost', () => {
+    const res = validateConfigObject({
+      gateway: {
+        bind: "custom",
+        customBindHost: "192.168.1.100",
+      },
+    });
+
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.config.gateway?.bind).toBe("custom");
+      expect(res.config.gateway?.customBindHost).toBe("192.168.1.100");
+    }
+  });
+
   it("accepts safe iMessage remoteHost", () => {
     const res = validateConfigObject({
       channels: {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -396,6 +396,7 @@ export const OpenClawSchema = z
             z.literal("tailnet"),
           ])
           .optional(),
+        customBindHost: z.string().optional(),
         controlUi: z
           .object({
             enabled: z.boolean().optional(),


### PR DESCRIPTION
## Summary

Fixes #5435

## Problem

Setting `gateway.bind: "custom"` with `gateway.customBindHost` fails config validation:

```
Error: Config validation failed: gateway: Unrecognized key: "customBindHost"
```

## Root Cause

The TypeScript type `GatewayConfig` in `types.gateway.ts` includes `customBindHost?: string`, but the corresponding zod validation schema in `zod-schema.ts` is missing this field. Since the gateway object uses `.strict()`, any unrecognized key is rejected.

## Fix

Add `customBindHost: z.string().optional()` to the gateway zod schema object, adjacent to the `bind` field where it logically belongs.

## Tests

Existing schema regression tests continue to pass (2/2). Config schema tests pass (5/5).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds missing `customBindHost` field to gateway zod schema to fix validation error when using `bind: "custom"` mode.

- Fixed schema validation rejection for `gateway.customBindHost`
- Added `customBindHost: z.string().optional()` to gateway object in `zod-schema.ts:398`
- Placed field adjacent to `bind` field for logical organization
- Added regression test to verify `bind="custom"` with `customBindHost` accepts valid config
- Schema now matches TypeScript type definition in `types.gateway.ts:298`

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Simple, focused fix that adds a single missing field to align zod schema with TypeScript types. The field is already used throughout the codebase (29 files), and this just enables validation to pass. The change is minimal, well-tested with a regression test, and directly addresses the reported issue.
- No files require special attention

<sub>Last reviewed commit: 9f84f78</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->