### PR TITLE
Plugins: fix llm-task module resolution fallback for built installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Plugins: fix llm-task plugin module resolution by adding extensionAPI and dist/ fallback paths so the plugin works in built/global installs where src/ does not exist. (#16182)
 - BlueBubbles: gracefully degrade when Private API is disabled by filtering private-only actions, skipping private-only reactions/reply effects, and avoiding private reply markers so non-private flows remain usable. (#16002) Thanks @L-U-C-K-Y.
 - Outbound: add a write-ahead delivery queue with crash-recovery retries to prevent lost outbound messages after gateway restarts. (#15636) Thanks @nabbilkhan, @thewilloftheshadow.
 - Auto-reply/Threading: auto-inject implicit reply threading so `replyToMode` works without requiring model-emitted `[[reply_to_current]]`, while preserving `replyToMode: "off"` behavior for implicit Slack replies and keeping block-streaming chunk coalescing stable under `replyToMode: "first"`. (#14976) Thanks @Diaspar4u.


### PR DESCRIPTION
Fixes #16182

## Problem

`loadRunEmbeddedPiAgent()` in `extensions/llm-task/src/llm-task-tool.ts` had identical import paths for both the source checkout and the "bundled install fallback" — both pointed to `../../../src/agents/pi-embedded-runner.js`. In npm global installs, `src/` does not exist (only `dist/`), so both imports fail with `Cannot find module`.

## Root Cause

The comment says "Source checkout (tests/dev)" and "Bundled install (built)" but both branches used the exact same path `../../../src/agents/pi-embedded-runner.js`. The "fallback" was not a real fallback.

## Fix

Replace the duplicate path with a proper fallback chain:
1. `../../../src/agents/pi-embedded-runner.js` — source checkout (dev/tests)
2. `../../../src/extensionAPI.ts` — jiti-transpiled intermediate fallback
3. `../../../dist/extensionAPI.js` — built install (npm global)

`extensionAPI` is a dedicated build entry-point that exports `runEmbeddedPiAgent` and survives the tsdown bundle as `dist/extensionAPI.js`.

## Tests

- All 9 tests pass (8 existing + 1 regression)
- Regression test verifies all import paths are unique and include `dist/` fallback

```
 ✓ llm-task tool (json-only) > returns parsed json
 ✓ llm-task tool (json-only) > strips fenced json
 ✓ llm-task tool (json-only) > validates schema
 ✓ llm-task tool (json-only) > throws on invalid json
 ✓ llm-task tool (json-only) > throws on schema mismatch
 ✓ llm-task tool (json-only) > passes provider/model overrides to embedded runner
 ✓ llm-task tool (json-only) > enforces allowedModels
 ✓ llm-task tool (json-only) > disables tools for embedded run
 ✓ loadRunEmbeddedPiAgent fallback chain (#16182) > import paths in source include distinct fallback to extensionAPI

 Test Files  1 passed (1)
      Tests  9 passed (9)
```

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixes a clear bug in `loadRunEmbeddedPiAgent()` where the "bundled install fallback" used the exact same import path as the "source checkout" path (`../../../src/agents/pi-embedded-runner.js`), meaning the fallback never actually fell back to anything different. This caused `Cannot find module` errors in npm global installs where `src/` does not exist.

- Replaces the duplicate import path with a proper 3-step fallback chain: direct `src/` import → `src/extensionAPI.ts` (jiti-transpiled) → `dist/extensionAPI.js` (built install)
- The approach is consistent with how `extensions/voice-call/src/core-bridge.ts` resolves core dependencies via `dist/extensionAPI.js`
- `src/extensionAPI.ts` is confirmed as a tsdown build entry point that produces `dist/extensionAPI.js` and exports `runEmbeddedPiAgent`
- Adds a regression test that reads the source file and verifies all dynamic import paths are unique and include the required `dist/` and `extensionAPI` fallbacks
- Adds a changelog entry

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it fixes an obvious bug with a well-structured fallback chain.
- The original bug was a clear copy-paste error where both branches of a fallback used the identical import path. The fix introduces a proper 3-step fallback chain that mirrors the established pattern in voice-call/core-bridge.ts. The build configuration confirms extensionAPI.ts is a tsdown entry point. All imports are wrapped in try/catch. A regression test prevents the duplicate-path bug from recurring. No functional logic outside the module resolution was changed.
- No files require special attention.

<sub>Last reviewed commit: f0c960d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->