### PR TITLE
fix: retry on transient API errors (overloaded, rate-limit, timeout)

### DIFF
--- a/src/agents/pi-embedded-helpers.istransienthttperror.e2e.test.ts
+++ b/src/agents/pi-embedded-helpers.istransienthttperror.e2e.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isTransientHttpError } from "./pi-embedded-helpers.js";
+import { isRetryableApiError, isTransientHttpError } from "./pi-embedded-helpers.js";
 
 describe("isTransientHttpError", () => {
   it("returns true for retryable 5xx status codes", () => {
@@ -14,5 +14,47 @@ describe("isTransientHttpError", () => {
     expect(isTransientHttpError("504 Gateway Timeout")).toBe(false);
     expect(isTransientHttpError("429 Too Many Requests")).toBe(false);
     expect(isTransientHttpError("network timeout")).toBe(false);
+  });
+});
+
+describe("isRetryableApiError", () => {
+  it("returns true for transient HTTP errors", () => {
+    expect(isRetryableApiError("500 Internal Server Error")).toBe(true);
+    expect(isRetryableApiError("502 Bad Gateway")).toBe(true);
+    expect(isRetryableApiError("503 Service Unavailable")).toBe(true);
+  });
+
+  it("returns true for overloaded errors", () => {
+    expect(
+      isRetryableApiError(
+        '{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
+      ),
+    ).toBe(true);
+    expect(isRetryableApiError("overloaded_error: Overloaded")).toBe(true);
+    expect(isRetryableApiError("Server is overloaded")).toBe(true);
+  });
+
+  it("returns true for rate limit errors", () => {
+    expect(isRetryableApiError("rate_limit: too many requests")).toBe(true);
+    expect(isRetryableApiError("429 Too Many Requests")).toBe(true);
+  });
+
+  it("returns true for timeout errors", () => {
+    expect(isRetryableApiError("request timed out")).toBe(true);
+    expect(isRetryableApiError("deadline exceeded")).toBe(true);
+  });
+
+  it("returns false for auth errors", () => {
+    expect(isRetryableApiError("invalid_api_key")).toBe(false);
+    expect(isRetryableApiError("unauthorized")).toBe(false);
+  });
+
+  it("returns false for billing errors", () => {
+    expect(isRetryableApiError("insufficient credits")).toBe(false);
+    expect(isRetryableApiError("payment required")).toBe(false);
+  });
+
+  it("returns false for empty strings", () => {
+    expect(isRetryableApiError("")).toBe(false);
   });
 });

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -31,6 +31,7 @@ export {
   isRawApiErrorPayload,
   isRateLimitAssistantError,
   isRateLimitErrorMessage,
+  isRetryableApiError,
   isTransientHttpError,
   isTimeoutErrorMessage,
   parseImageDimensionError,

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -643,6 +643,20 @@ export function isOverloadedErrorMessage(raw: string): boolean {
   return matchesErrorPatterns(raw, ERROR_PATTERNS.overloaded);
 }
 
+/**
+ * Returns true for transient provider errors eligible for automatic retry:
+ * HTTP 5xx, overloaded, rate-limited, and timeout errors.
+ * Non-transient errors (auth 401/403, billing 402, format) are excluded.
+ */
+export function isRetryableApiError(raw: string): boolean {
+  return (
+    isTransientHttpError(raw) ||
+    isOverloadedErrorMessage(raw) ||
+    isRateLimitErrorMessage(raw) ||
+    isTimeoutErrorMessage(raw)
+  );
+}
+
 export function parseImageDimensionError(raw: string): {
   maxDimensionPx?: number;
   messageIndex?: number;

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -14,6 +14,7 @@ import {
   isCompactionFailureError,
   isContextOverflowError,
   isLikelyContextOverflowError,
+  isRetryableApiError,
   isTransientHttpError,
   sanitizeUserFacingText,
 } from "../../agents/pi-embedded-helpers.js";
@@ -80,7 +81,8 @@ export async function runAgentTurnWithFallback(params: {
   storePath?: string;
   resolvedVerboseLevel: VerboseLevel;
 }): Promise<AgentRunLoopResult> {
-  const TRANSIENT_HTTP_RETRY_DELAY_MS = 2_500;
+  const API_RETRY_MAX_ATTEMPTS = 3;
+  const API_RETRY_BACKOFF_MS = [2_500, 5_000, 10_000];
   let didLogHeartbeatStrip = false;
   let autoCompactionCompleted = false;
   // Track payloads sent directly (not via pipeline) during tool flush to avoid duplicates.
@@ -99,7 +101,7 @@ export async function runAgentTurnWithFallback(params: {
   let fallbackProvider = params.followupRun.run.provider;
   let fallbackModel = params.followupRun.run.model;
   let didResetAfterCompactionFailure = false;
-  let didRetryTransientHttpError = false;
+  let apiRetryAttempt = 0;
 
   while (true) {
     try {
@@ -583,25 +585,28 @@ export async function runAgentTurnWithFallback(params: {
         };
       }
 
-      if (isTransientHttp && !didRetryTransientHttpError) {
-        didRetryTransientHttpError = true;
-        // Retry the full runWithModelFallback() cycle — transient errors
-        // (502/521/etc.) typically affect the whole provider, so falling
-        // back to an alternate model first would not help. Instead we wait
-        // and retry the complete primary→fallback chain.
+      const isRetryable = isRetryableApiError(message);
+      if (isRetryable && apiRetryAttempt < API_RETRY_MAX_ATTEMPTS) {
+        const delayMs = API_RETRY_BACKOFF_MS[apiRetryAttempt] ?? API_RETRY_BACKOFF_MS.at(-1)!;
+        apiRetryAttempt += 1;
+        // Retry the full runWithModelFallback() cycle — transient/overloaded
+        // errors typically affect the whole provider, so falling back to an
+        // alternate model first would not help. Wait and retry the complete
+        // primary→fallback chain.
         defaultRuntime.error(
-          `Transient HTTP provider error before reply (${message}). Retrying once in ${TRANSIENT_HTTP_RETRY_DELAY_MS}ms.`,
+          `Retryable API error before reply (attempt ${apiRetryAttempt}/${API_RETRY_MAX_ATTEMPTS}): ${message}. Retrying in ${delayMs}ms.`,
         );
         await new Promise<void>((resolve) => {
-          setTimeout(resolve, TRANSIENT_HTTP_RETRY_DELAY_MS);
+          setTimeout(resolve, delayMs);
         });
         continue;
       }
 
       defaultRuntime.error(`Embedded agent failed before reply: ${message}`);
-      const safeMessage = isTransientHttp
-        ? sanitizeUserFacingText(message, { errorContext: true })
-        : message;
+      const safeMessage =
+        isTransientHttp || isRetryable
+          ? sanitizeUserFacingText(message, { errorContext: true })
+          : message;
       const trimmedMessage = safeMessage.replace(/\.\s*$/, "");
       const fallbackText = isContextOverflow
         ? "⚠️ Context overflow — prompt too large for this model. Try a shorter message or a larger-context model."

--- a/src/auto-reply/reply/agent-runner.transient-http-retry.test.ts
+++ b/src/auto-reply/reply/agent-runner.transient-http-retry.test.ts
@@ -46,7 +46,65 @@ vi.mock("./queue.js", async () => {
 
 import { runReplyAgent } from "./agent-runner.js";
 
-describe("runReplyAgent transient HTTP retry", () => {
+function makeFollowupRun(): FollowupRun {
+  return {
+    prompt: "hello",
+    summaryLine: "hello",
+    enqueuedAt: Date.now(),
+    run: {
+      sessionId: "session",
+      sessionKey: "main",
+      messageProvider: "telegram",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      config: {},
+      skillsSnapshot: {},
+      provider: "anthropic",
+      model: "claude",
+      thinkLevel: "low",
+      verboseLevel: "off",
+      elevatedLevel: "off",
+      bashElevated: {
+        enabled: false,
+        allowed: false,
+        defaultLevel: "off",
+      },
+      timeoutMs: 1_000,
+      blockReplyBreak: "message_end",
+    },
+  } as unknown as FollowupRun;
+}
+
+function callRunReplyAgent() {
+  const typing = createMockTypingController();
+  const sessionCtx = {
+    Provider: "telegram",
+    MessageSid: "msg",
+  } as unknown as TemplateContext;
+  const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
+
+  return runReplyAgent({
+    commandBody: "hello",
+    followupRun: makeFollowupRun(),
+    queueKey: "main",
+    resolvedQueue,
+    shouldSteer: false,
+    shouldFollowup: false,
+    isActive: false,
+    isStreaming: false,
+    typing,
+    sessionCtx,
+    defaultModel: "anthropic/claude-opus-4-5",
+    resolvedVerboseLevel: "off",
+    isNewSession: false,
+    blockStreamingEnabled: false,
+    resolvedBlockStreamingBreak: "message_end",
+    shouldInjectGroupIntro: false,
+    typingMode: "instant",
+  });
+}
+
+describe("runReplyAgent API error retry", () => {
   beforeEach(() => {
     runEmbeddedPiAgentMock.mockReset();
     runtimeErrorMock.mockReset();
@@ -69,68 +127,91 @@ describe("runReplyAgent transient HTTP retry", () => {
         meta: {},
       });
 
-    const typing = createMockTypingController();
-    const sessionCtx = {
-      Provider: "telegram",
-      MessageSid: "msg",
-    } as unknown as TemplateContext;
-    const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
-    const followupRun = {
-      prompt: "hello",
-      summaryLine: "hello",
-      enqueuedAt: Date.now(),
-      run: {
-        sessionId: "session",
-        sessionKey: "main",
-        messageProvider: "telegram",
-        sessionFile: "/tmp/session.jsonl",
-        workspaceDir: "/tmp",
-        config: {},
-        skillsSnapshot: {},
-        provider: "anthropic",
-        model: "claude",
-        thinkLevel: "low",
-        verboseLevel: "off",
-        elevatedLevel: "off",
-        bashElevated: {
-          enabled: false,
-          allowed: false,
-          defaultLevel: "off",
-        },
-        timeoutMs: 1_000,
-        blockReplyBreak: "message_end",
-      },
-    } as unknown as FollowupRun;
-
-    const runPromise = runReplyAgent({
-      commandBody: "hello",
-      followupRun,
-      queueKey: "main",
-      resolvedQueue,
-      shouldSteer: false,
-      shouldFollowup: false,
-      isActive: false,
-      isStreaming: false,
-      typing,
-      sessionCtx,
-      defaultModel: "anthropic/claude-opus-4-5",
-      resolvedVerboseLevel: "off",
-      isNewSession: false,
-      blockStreamingEnabled: false,
-      resolvedBlockStreamingBreak: "message_end",
-      shouldInjectGroupIntro: false,
-      typingMode: "instant",
-    });
-
+    const runPromise = callRunReplyAgent();
     await vi.advanceTimersByTimeAsync(2_500);
     const result = await runPromise;
 
     expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(2);
     expect(runtimeErrorMock).toHaveBeenCalledWith(
-      expect.stringContaining("Transient HTTP provider error before reply"),
+      expect.stringContaining("Retryable API error before reply"),
     );
 
     const payload = Array.isArray(result) ? result[0] : result;
     expect(payload?.text).toContain("Recovered response");
+  });
+
+  it("retries on Anthropic overloaded_error and recovers", async () => {
+    runEmbeddedPiAgentMock
+      .mockRejectedValueOnce(
+        new Error('{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}'),
+      )
+      .mockResolvedValueOnce({
+        payloads: [{ text: "Recovered after overload" }],
+        meta: {},
+      });
+
+    const runPromise = callRunReplyAgent();
+    await vi.advanceTimersByTimeAsync(2_500);
+    const result = await runPromise;
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(2);
+    expect(runtimeErrorMock).toHaveBeenCalledWith(
+      expect.stringContaining("Retryable API error before reply (attempt 1/3)"),
+    );
+    const payload = Array.isArray(result) ? result[0] : result;
+    expect(payload?.text).toContain("Recovered after overload");
+  });
+
+  it("retries up to 3 times with increasing backoff then fails", async () => {
+    const overloadedError = new Error("overloaded_error: Overloaded");
+
+    // 1 initial attempt + 3 retries = 4 total attempts, all failing
+    runEmbeddedPiAgentMock
+      .mockRejectedValueOnce(overloadedError)
+      .mockRejectedValueOnce(overloadedError)
+      .mockRejectedValueOnce(overloadedError)
+      .mockRejectedValueOnce(overloadedError);
+
+    const runPromise = callRunReplyAgent();
+    // Advance through all 3 retry delays: 2500 + 5000 + 10000
+    await vi.advanceTimersByTimeAsync(2_500);
+    await vi.advanceTimersByTimeAsync(5_000);
+    await vi.advanceTimersByTimeAsync(10_000);
+    const result = await runPromise;
+
+    // 1 initial + 3 retries = 4 total calls
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(4);
+    // After exhausting retries, the 4th failure falls through to the error response
+    const payload = Array.isArray(result) ? result[0] : result;
+    expect(payload?.text).toContain("Agent failed before reply");
+  });
+
+  it("retries on rate_limit error", async () => {
+    runEmbeddedPiAgentMock
+      .mockRejectedValueOnce(new Error("rate_limit: too many requests"))
+      .mockResolvedValueOnce({
+        payloads: [{ text: "Recovered after rate limit" }],
+        meta: {},
+      });
+
+    const runPromise = callRunReplyAgent();
+    await vi.advanceTimersByTimeAsync(2_500);
+    const result = await runPromise;
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(2);
+    const payload = Array.isArray(result) ? result[0] : result;
+    expect(payload?.text).toContain("Recovered after rate limit");
+  });
+
+  it("does NOT retry on auth errors (401)", async () => {
+    runEmbeddedPiAgentMock.mockRejectedValueOnce(new Error("401 Unauthorized: Invalid API key"));
+
+    const runPromise = callRunReplyAgent();
+    const result = await runPromise;
+
+    // Auth errors are not retryable — should fail immediately
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    const payload = Array.isArray(result) ? result[0] : result;
+    expect(payload?.text).toContain("Agent failed before reply");
   });
 });


### PR DESCRIPTION
## Summary
Fixes #16106

Sub-agent sessions now retry on transient API errors instead of dying immediately. Previously only HTTP 5xx errors triggered a single retry with a 2.5s delay. Now **all retryable provider errors** trigger up to 3 retries with exponential backoff.

## Changes

- **`src/agents/pi-embedded-helpers/errors.ts`**: Add `isRetryableApiError()` — a unified predicate that covers HTTP 5xx, `overloaded_error`, rate-limit, and timeout errors
- **`src/auto-reply/reply/agent-runner-execution.ts`**: Replace single-retry logic with configurable multi-retry (3 attempts, 2.5s → 5s → 10s backoff). Non-transient errors (auth 401/403, billing 402, format) still fail immediately
- **`src/agents/pi-embedded-helpers.ts`**: Export new `isRetryableApiError`

### Error Classification

| Error Type | Example | Retried? |
|---|---|---|
| HTTP 5xx | `502 Bad Gateway`, `521 Cloudflare` | ✅ Yes |
| Overloaded | `overloaded_error` (Anthropic) | ✅ Yes (NEW) |
| Rate limit | `429 Too Many Requests` | ✅ Yes (NEW) |
| Timeout | `deadline exceeded` | ✅ Yes (NEW) |
| Auth | `401 Unauthorized` | ❌ No |
| Billing | `402 Payment Required` | ❌ No |

## Test Plan

- ✅ Existing 521 transient HTTP retry test updated and passing
- ✅ New test: Anthropic `overloaded_error` retries and recovers
- ✅ New test: Exhausts 3 retries then fails gracefully (4 total attempts)
- ✅ New test: Rate-limit error retries and recovers
- ✅ New test: Auth error (401) does NOT retry
- ✅ New test: `isRetryableApiError()` unit tests for all error types
- ✅ Full test suite (4356 tests), lint, and build pass

---
🤖 Generated with Claude Code (issue-hunter-pro)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR upgrades the sub-agent session retry logic from a single-retry mechanism (for HTTP 5xx only) to a multi-retry system with exponential backoff that covers all transient API errors: HTTP 5xx, overloaded (`overloaded_error`), rate-limit (429), and timeout errors.

- **New `isRetryableApiError()` predicate** in `errors.ts` composes existing error classifiers (`isTransientHttpError`, `isOverloadedErrorMessage`, `isRateLimitErrorMessage`, `isTimeoutErrorMessage`) into a single check for retry eligibility
- **Multi-retry with backoff** in `agent-runner-execution.ts`: replaces the boolean `didRetryTransientHttpError` flag with a counter (`apiRetryAttempt`) supporting up to 3 retries with 2.5s → 5s → 10s backoff delays. Non-transient errors (auth, billing, format) still fail immediately
- **Comprehensive test coverage**: unit tests for `isRetryableApiError`, integration tests for overloaded recovery, rate-limit recovery, retry exhaustion, and auth error non-retry behavior
- The retry loop correctly wraps the full `runWithModelFallback()` cycle, so model fallback is re-attempted on each retry — appropriate since transient provider errors typically affect the whole provider

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it extends existing retry logic with well-tested error classification and bounded retries.
- The changes are well-scoped and follow existing patterns. The new `isRetryableApiError` predicate cleanly composes existing classifiers. The retry loop uses proper bounded retries with exponential backoff. Error classification correctly distinguishes retryable (5xx, overloaded, rate-limit, timeout) from non-retryable (auth, billing, format) errors. The interaction with the model fallback system is sound — retries wrap the full fallback chain as intended. Test coverage is comprehensive. Score is 4 rather than 5 due to the inherent complexity of the retry-within-fallback interaction and the existing redundancy in the `isTransientHttp || isRetryable` check (already flagged in a previous thread).
- `src/auto-reply/reply/agent-runner-execution.ts` has the most significant logic changes and should be reviewed carefully for the retry/fallback interaction.

<sub>Last reviewed commit: 02eb3bb</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->