### PR TITLE
Feature/k8s openclaw

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,15 @@ pnpm gateway:watch
 
 Note: `pnpm openclaw ...` runs TypeScript directly (via `tsx`). `pnpm build` produces `dist/` for running via Node / the packaged `openclaw` binary.
 
+## Kubernetes / GitOps
+
+Need to run OpenClaw in a cluster? A first-party Helm chart plus Flux/Argo-ready Kustomize
+overlays now live under [`deploy/kubernetes`](deploy/kubernetes). The chart deploys the
+`ghcr.io/openclaw/openclaw` image, PVCs for `/home/node/.openclaw` + `/home/node/.openclaw/workspace`,
+and optional ingress/secret scaffolding. Render it directly with Helm or let Flux/Argo CD
+track the overlays in `deploy/kubernetes/kustomize/overlays/*`. Full docs (with diagrams)
+are available in [`docs/kubernetes.md`](docs/kubernetes.md).
+
 ## Security defaults (DM access)
 
 OpenClaw connects to real messaging surfaces. Treat inbound DMs as **untrusted input**.

--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -1,0 +1,128 @@
+# OpenClaw on Kubernetes
+
+This directory contains everything needed to run the OpenClaw gateway on Kubernetes
+without modifying the upstream core:
+
+- A Helm chart (`deploy/kubernetes/charts/openclaw`) that packages the gateway
+  Deployment, Service, PVCs, optional Ingress, and supporting resources.
+- Kustomize overlays (`deploy/kubernetes/kustomize`) that render the Helm chart so
+  it can be managed by Flux, Argo CD, or raw `kustomize build` workflows.
+
+## Helm chart overview
+
+| Component | Purpose |
+|-----------|---------|
+| `Deployment` | Runs the `ghcr.io/openclaw/openclaw` container. You can override the command/args if you need to pass `gateway` flags. |
+| `Service` | Exposes the gateway (18789) and bridge (18790) ports inside the cluster. |
+| `Ingress` | Optional HTTP ingress for the primary port. |
+| `PVCs` | Two state volumes: `/home/node/.openclaw` (config) and `/home/node/.openclaw/workspace` (project files). Both can be swapped for existing claims or disabled in favor of emptyDir. |
+| `Secret` | Optional helper to materialize `OPENCLAW_GATEWAY_TOKEN` and other credentials. It is referenced via `envFrom`, so you can supply any key/value pairs the gateway expects. |
+
+Key values (see `values.yaml` for the full list):
+
+- `image.repository` / `image.tag` – defaults to the published GitHub Container Registry image. Override the tag to pin a release.
+- `gateway.env`, `gateway.args`, `gateway.extraEnvFrom` – inject tokens, model credentials, or additional CLI flags.
+- `persistence.config` / `persistence.workspace` – size and storage class for your state PVCs. Set `existingClaim` to bind to an already-provisioned volume.
+- `initContainers.enabled` – runs a tiny BusyBox init step to create `/home/node/.openclaw/workspace` and fix ownership (UID 1000). Disable it if your CSI driver already handles permissions.
+- `extraContainers`, `extraVolumes`, `extraVolumeMounts` – attach browser sidecars or debugging tools without touching the upstream image.
+
+Install directly with Helm:
+
+```bash
+helm upgrade --install openclaw \
+  ./deploy/kubernetes/charts/openclaw \
+  --namespace openclaw --create-namespace \
+  --set secret.create=true \
+  --set secret.stringData.OPENCLAW_GATEWAY_TOKEN="REPLACE_ME" \
+  --set image.tag=v2026.2.13
+```
+
+## Kustomize overlays
+
+Flux and Argo CD both understand native Kustomize. Each overlay renders the Helm
+chart with an environment-specific values file.
+
+```
+deploy/kubernetes/kustomize
+├── base            # Namespace definition
+└── overlays
+    ├── dev         # Single replica, smaller PVCs, sample secret
+    └── prod        # Two replicas, Ingress + TLS, external secret reference
+```
+
+Render an overlay locally:
+
+```bash
+kustomize build deploy/kubernetes/kustomize/overlays/dev
+```
+
+### Flux example
+
+```yaml
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: openclaw
+  namespace: flux-system
+spec:
+  interval: 1m
+  url: https://github.com/egkristi/openclaw
+  ref:
+    branch: feature/k8s
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: openclaw
+  namespace: flux-system
+spec:
+  interval: 5m
+  path: ./deploy/kubernetes/kustomize/overlays/prod
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: openclaw
+```
+
+### Argo CD example
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: openclaw
+spec:
+  destination:
+    namespace: openclaw
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    repoURL: https://github.com/egkristi/openclaw.git
+    targetRevision: feature/k8s
+    path: deploy/kubernetes/kustomize/overlays/dev
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+```
+
+## Secrets & security
+
+- **Do not commit real gateway tokens**. For production, set `secret.create=false`
+  and reference a secret managed by your secret store (SOPS, External Secrets,
+  sealed-secrets, etc.).
+- The included ServiceAccount runs without extra permissions. Attach Roles only if
+  you extend OpenClaw with cluster integrations that need them.
+- The Deployment runs as user `node` (UID 1000) with `allowPrivilegeEscalation=false`.
+  Adjust the `securityContext` if you embed privileged sidecars.
+
+## Extending the stack
+
+- Attach a GUI/Chromium sidecar by adding another container via
+  `extraContainers` and wiring shared PVCs through `extraVolumes`. This keeps
+  the upstream OpenClaw image untouched while still satisfying bot-detection
+  requirements.
+- Add monitoring by turning on the annotations under `service.annotations` and
+  scraping the `/healthz` endpoint.
+- Customize ingress, TLS, and network policies via standard Helm/Kustomize
+  patterns without patching the OpenClaw sources.

--- a/deploy/kubernetes/charts/openclaw/Chart.yaml
+++ b/deploy/kubernetes/charts/openclaw/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: openclaw
+version: 0.1.0
+description: Helm chart that deploys the OpenClaw gateway with optional browser sidecars on Kubernetes.
+type: application
+appVersion: "0.1.0"

--- a/deploy/kubernetes/charts/openclaw/templates/NOTES.txt
+++ b/deploy/kubernetes/charts/openclaw/templates/NOTES.txt
@@ -1,0 +1,15 @@
+1. Get the OpenClaw gateway URL by running:
+
+  kubectl get svc {{ include "openclaw.fullname" . }} -n {{ .Release.Namespace }}
+
+2. The gateway exposes two ports:
+   * {{ .Values.service.ports.gateway }} (primary API)
+   * {{ .Values.service.ports.bridge }} (bridge/tunnel)
+
+3. Provide your gateway token and any model credentials via a Secret. You can either:
+   * Supply values under `secret.stringData` and keep them in git-ignored files, or
+   * Reference an existing secret using `secret.name` and disable secret creation.
+
+4. Your workspace and configuration live under `/home/node/.openclaw`. Make sure the
+   associated PersistentVolumeClaims have enough capacity for downloaded skills,
+   memory snapshots, and gateways logs.

--- a/deploy/kubernetes/charts/openclaw/templates/_helpers.tpl
+++ b/deploy/kubernetes/charts/openclaw/templates/_helpers.tpl
@@ -1,0 +1,50 @@
+{{- define "openclaw.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "openclaw.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "openclaw.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" -}}
+{{- end -}}
+
+{{- define "openclaw.labels" -}}
+app.kubernetes.io/name: {{ include "openclaw.name" . }}
+helm.sh/chart: {{ include "openclaw.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.podLabels }}
+{{- range $key, $value := .Values.podLabels }}
+{{ $key }}: {{ $value | quote }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{- define "openclaw.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "openclaw.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "openclaw.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{ default (include "openclaw.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+{{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{- define "openclaw.secretName" -}}
+{{- if .Values.secret.name -}}
+{{ .Values.secret.name }}
+{{- else -}}
+{{ printf "%s-secrets" (include "openclaw.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end -}}
+{{- end -}}

--- a/deploy/kubernetes/charts/openclaw/templates/deployment.yaml
+++ b/deploy/kubernetes/charts/openclaw/templates/deployment.yaml
@@ -1,0 +1,182 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "openclaw.fullname" . }}
+  labels:
+    {{- include "openclaw.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "openclaw.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "openclaw.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "openclaw.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.initContainers.enabled }}
+      initContainers:
+        - name: init-openclaw-state
+          image: {{ .Values.initContainers.image }}
+          {{- with .Values.initContainers.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.initContainers.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            {{- if .Values.persistence.config.enabled }}
+            - name: config
+              mountPath: /config
+            {{- end }}
+            {{- if .Values.persistence.workspace.enabled }}
+            - name: workspace
+              mountPath: /workspace
+            {{- end }}
+        {{- with .Values.initContainers.extra }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      containers:
+        - name: openclaw
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.gateway.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.gateway.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            - name: HOME
+              value: /home/node
+            - name: TERM
+              value: xterm-256color
+            {{- range .Values.gateway.env }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+            {{- end }}
+            {{- range .Values.gateway.extraEnv }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+            {{- end }}
+          {{- if or .Values.gateway.envFrom .Values.gateway.extraEnvFrom (or .Values.secret.create .Values.secret.name) }}
+          envFrom:
+            {{- if or .Values.secret.create .Values.secret.name }}
+            - secretRef:
+                name: {{ include "openclaw.secretName" . }}
+            {{- end }}
+            {{- with .Values.gateway.envFrom }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.gateway.extraEnvFrom }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+          ports:
+            - containerPort: {{ .Values.service.ports.gateway }}
+              name: gateway
+            - containerPort: {{ .Values.service.ports.bridge }}
+              name: bridge
+          {{- if .Values.gateway.livenessProbe.enabled }}
+          livenessProbe:
+            {{- $lp := omit .Values.gateway.livenessProbe "enabled" }}
+            {{- toYaml $lp | nindent 12 }}
+          {{- end }}
+          {{- if .Values.gateway.readinessProbe.enabled }}
+          readinessProbe:
+            {{- $rp := omit .Values.gateway.readinessProbe "enabled" }}
+            {{- toYaml $rp | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- $hasMounts := or .Values.persistence.config.enabled .Values.persistence.workspace.enabled }}
+          {{- if or $hasMounts .Values.extraVolumeMounts }}
+          volumeMounts:
+            {{- if .Values.persistence.config.enabled }}
+            - name: config
+              mountPath: /home/node/.openclaw
+            {{- end }}
+            {{- if .Values.persistence.workspace.enabled }}
+            - name: workspace
+              mountPath: /home/node/.openclaw/workspace
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+        {{- with .Values.extraContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      volumes:
+        {{- if .Values.persistence.config.enabled }}
+        - name: config
+          {{- if .Values.persistence.config.existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.config.existingClaim }}
+          {{- else }}
+          persistentVolumeClaim:
+            claimName: {{ printf "%s-config" (include "openclaw.fullname" .) | trunc 63 | trimSuffix "-" }}
+          {{- end }}
+        {{- else }}
+        - name: config
+          emptyDir: {}
+        {{- end }}
+        {{- if .Values.persistence.workspace.enabled }}
+        - name: workspace
+          {{- if .Values.persistence.workspace.existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.workspace.existingClaim }}
+          {{- else }}
+          persistentVolumeClaim:
+            claimName: {{ printf "%s-workspace" (include "openclaw.fullname" .) | trunc 63 | trimSuffix "-" }}
+          {{- end }}
+        {{- else }}
+        - name: workspace
+          emptyDir: {}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/kubernetes/charts/openclaw/templates/ingress.yaml
+++ b/deploy/kubernetes/charts/openclaw/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "openclaw.fullname" . }}
+  labels:
+    {{- include "openclaw.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ include "openclaw.fullname" $ }}
+                port:
+                  name: {{ .servicePort | default "gateway" }}
+          {{- end }}
+    {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- toYaml .Values.ingress.tls | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/deploy/kubernetes/charts/openclaw/templates/pvc-config.yaml
+++ b/deploy/kubernetes/charts/openclaw/templates/pvc-config.yaml
@@ -1,0 +1,18 @@
+{{- $p := .Values.persistence.config -}}
+{{- if and $p.enabled (not $p.existingClaim) -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ printf "%s-config" (include "openclaw.fullname" .) | trunc 63 | trimSuffix "-" }}
+  labels:
+    {{- include "openclaw.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml $p.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ $p.size }}
+  {{- if $p.storageClass }}
+  storageClassName: {{ $p.storageClass | quote }}
+  {{- end }}
+{{- end -}}

--- a/deploy/kubernetes/charts/openclaw/templates/pvc-workspace.yaml
+++ b/deploy/kubernetes/charts/openclaw/templates/pvc-workspace.yaml
@@ -1,0 +1,18 @@
+{{- $p := .Values.persistence.workspace -}}
+{{- if and $p.enabled (not $p.existingClaim) -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ printf "%s-workspace" (include "openclaw.fullname" .) | trunc 63 | trimSuffix "-" }}
+  labels:
+    {{- include "openclaw.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml $p.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ $p.size }}
+  {{- if $p.storageClass }}
+  storageClassName: {{ $p.storageClass | quote }}
+  {{- end }}
+{{- end -}}

--- a/deploy/kubernetes/charts/openclaw/templates/secret.yaml
+++ b/deploy/kubernetes/charts/openclaw/templates/secret.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.secret.create (not (empty .Values.secret.stringData)) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "openclaw.secretName" . }}
+  labels:
+    {{- include "openclaw.labels" . | nindent 4 }}
+  {{- with .Values.secret.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+type: Opaque
+stringData:
+  {{- toYaml .Values.secret.stringData | nindent 2 }}
+{{- end -}}

--- a/deploy/kubernetes/charts/openclaw/templates/service.yaml
+++ b/deploy/kubernetes/charts/openclaw/templates/service.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "openclaw.fullname" . }}
+  labels:
+    {{- include "openclaw.labels" . | nindent 4 }}
+    {{- with .Values.service.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "openclaw.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: gateway
+      port: {{ .Values.service.ports.gateway }}
+      targetPort: gateway
+      protocol: TCP
+    - name: bridge
+      port: {{ .Values.service.ports.bridge }}
+      targetPort: bridge
+      protocol: TCP

--- a/deploy/kubernetes/charts/openclaw/templates/serviceaccount.yaml
+++ b/deploy/kubernetes/charts/openclaw/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "openclaw.serviceAccountName" . }}
+  labels:
+    {{- include "openclaw.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/deploy/kubernetes/charts/openclaw/values.yaml
+++ b/deploy/kubernetes/charts/openclaw/values.yaml
@@ -1,0 +1,132 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/openclaw/openclaw
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext:
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+  fsGroupChangePolicy: "OnRootMismatch"
+
+securityContext:
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
+  capabilities:
+    drop:
+      - ALL
+
+resources: {}
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+topologySpreadConstraints: []
+
+service:
+  type: ClusterIP
+  annotations: {}
+  additionalLabels: {}
+  ports:
+    gateway: 18789
+    bridge: 18790
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: openclaw.local
+      paths:
+        - path: /
+          pathType: Prefix
+          servicePort: gateway
+  tls: []
+
+secret:
+  create: false
+  name: ""
+  annotations: {}
+  stringData: {}
+
+gateway:
+  command: []
+  args: []
+  env:
+    - name: OPENCLAW_GATEWAY_BIND
+      value: lan
+  envFrom: []
+  extraEnv: []
+  extraEnvFrom: []
+  livenessProbe:
+    enabled: true
+    httpGet:
+      path: /healthz
+      port: gateway
+    initialDelaySeconds: 20
+    periodSeconds: 15
+  readinessProbe:
+    enabled: true
+    httpGet:
+      path: /healthz
+      port: gateway
+    initialDelaySeconds: 10
+    periodSeconds: 10
+
+persistence:
+  config:
+    enabled: true
+    existingClaim: ""
+    accessModes:
+      - ReadWriteOnce
+    storageClass: ""
+    size: 5Gi
+  workspace:
+    enabled: true
+    existingClaim: ""
+    accessModes:
+      - ReadWriteOnce
+    storageClass: ""
+    size: 20Gi
+
+initContainers:
+  enabled: true
+  image: busybox:1.36
+  command:
+    - /bin/sh
+    - -c
+  args:
+    - |
+      set -euo pipefail
+      if [ -d /config ]; then
+        mkdir -p /config/workspace
+        chown -R 1000:1000 /config
+      fi
+      if [ -d /workspace ]; then
+        chown -R 1000:1000 /workspace
+      fi
+  extra: []
+
+extraContainers: []
+
+extraVolumes: []
+
+extraVolumeMounts: []

--- a/deploy/kubernetes/kustomize/base/kustomization.yaml
+++ b/deploy/kubernetes/kustomize/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openclaw
+resources:
+  - namespace.yaml

--- a/deploy/kubernetes/kustomize/base/namespace.yaml
+++ b/deploy/kubernetes/kustomize/base/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openclaw
+  labels:
+    app.kubernetes.io/name: openclaw

--- a/deploy/kubernetes/kustomize/overlays/dev/kustomization.yaml
+++ b/deploy/kubernetes/kustomize/overlays/dev/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openclaw
+resources:
+  - ../base
+helmCharts:
+  - name: openclaw
+    releaseName: openclaw
+    namespace: openclaw
+    path: ../../charts/openclaw
+    valuesFile: values-dev.yaml

--- a/deploy/kubernetes/kustomize/overlays/dev/values-dev.yaml
+++ b/deploy/kubernetes/kustomize/overlays/dev/values-dev.yaml
@@ -1,0 +1,25 @@
+replicaCount: 1
+image:
+  tag: v2026.2.13
+secret:
+  create: true
+  stringData:
+    OPENCLAW_GATEWAY_TOKEN: "REPLACE_ME"
+persistence:
+  config:
+    size: 3Gi
+  workspace:
+    size: 15Gi
+service:
+  type: ClusterIP
+gateway:
+  env:
+    - name: OPENCLAW_GATEWAY_BIND
+      value: lan
+resources:
+  limits:
+    cpu: "1"
+    memory: 2Gi
+  requests:
+    cpu: 200m
+    memory: 512Mi

--- a/deploy/kubernetes/kustomize/overlays/prod/kustomization.yaml
+++ b/deploy/kubernetes/kustomize/overlays/prod/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openclaw
+resources:
+  - ../base
+helmCharts:
+  - name: openclaw
+    releaseName: openclaw
+    namespace: openclaw
+    path: ../../charts/openclaw
+    valuesFile: values-prod.yaml

--- a/deploy/kubernetes/kustomize/overlays/prod/values-prod.yaml
+++ b/deploy/kubernetes/kustomize/overlays/prod/values-prod.yaml
@@ -1,0 +1,40 @@
+replicaCount: 2
+image:
+  tag: v2026.2.13
+service:
+  type: ClusterIP
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "18789"
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+  hosts:
+    - host: openclaw.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+          servicePort: gateway
+  tls:
+    - hosts:
+        - openclaw.example.com
+      secretName: openclaw-tls
+secret:
+  create: false
+  name: openclaw-secrets
+persistence:
+  config:
+    size: 10Gi
+  workspace:
+    size: 50Gi
+resources:
+  limits:
+    cpu: "2"
+    memory: 4Gi
+  requests:
+    cpu: 500m
+    memory: 1Gi
+nodeSelector:
+  kubernetes.io/os: linux

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -26,10 +26,10 @@ graph TD
 
     OC --> PVC1
     OC --> PVC2
-    SB -. "shared volume" .-> PVC2
+    SB -. shared_volume .-> PVC2
     Deploy --> SVC
     SVC -->|18789| Users
-    SVC -->|18790| "Bridges/Tunnels"
+    SVC -->|18790| Bridges_Tunnels
 ```
 
 Flux or Argo CD reconcile the chart via Kustomize overlays, keeping the cluster in sync

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -12,24 +12,24 @@ expose the gateway and bridge ports.
 
 ```mermaid
 graph TD
-    subgraph Cluster[Kubernetes Cluster]
-        subgraph NS[Namespace: openclaw]
-            PVC1[(PVC: config)]
-            PVC2[(PVC: workspace)]
-            subgraph Deploy[Deployment: openclaw]
-                OC[Container: ghcr.io/openclaw/openclaw]
-                SB[Optional sidecar(s)]
+    subgraph Cluster["Kubernetes Cluster"]
+        subgraph NS["Namespace: openclaw"]
+            PVC1[("PVC: config")]
+            PVC2[("PVC: workspace")]
+            subgraph Deploy["Deployment: openclaw"]
+                OC["Container: ghcr.io/openclaw/openclaw"]
+                SB["Optional sidecar"]
             end
-            SVC((Service: gateway/bridge))
+            SVC(("Service: gateway/bridge"))
         end
     end
 
     OC --> PVC1
     OC --> PVC2
-    SB -. shared volume .-> PVC2
+    SB -. "shared volume" .-> PVC2
     Deploy --> SVC
     SVC -->|18789| Users
-    SVC -->|18790| Bridges/Tunnels
+    SVC -->|18790| "Bridges/Tunnels"
 ```
 
 Flux or Argo CD reconcile the chart via Kustomize overlays, keeping the cluster in sync

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -1,0 +1,169 @@
+# OpenClaw on Kubernetes
+
+Running OpenClaw inside Kubernetes keeps the upstream code untouched while letting you
+compose sidecars, declarative secrets, GitOps pipelines, and HA upgrades. This guide
+covers the packaged Helm chart, Kustomize overlays, and GitOps workflows.
+
+## Architecture
+
+Kubernetes hosts the gateway container alongside any helper sidecars (browser, cron,
+model runners). Persistent volumes provide `/home/node/.openclaw` state, while services
+expose the gateway and bridge ports.
+
+```mermaid
+graph TD
+    subgraph Cluster[Kubernetes Cluster]
+        subgraph NS[Namespace: openclaw]
+            PVC1[(PVC: config)]
+            PVC2[(PVC: workspace)]
+            subgraph Deploy[Deployment: openclaw]
+                OC[Container: ghcr.io/openclaw/openclaw]
+                SB[Optional sidecar(s)]
+            end
+            SVC((Service: gateway/bridge))
+        end
+    end
+
+    OC --> PVC1
+    OC --> PVC2
+    SB -. shared volume .-> PVC2
+    Deploy --> SVC
+    SVC -->|18789| Users
+    SVC -->|18790| Bridges/Tunnels
+```
+
+Flux or Argo CD reconcile the chart via Kustomize overlays, keeping the cluster in sync
+with git.
+
+```mermaid
+sequenceDiagram
+    participant Developer
+    participant GitHub
+    participant GitOps as Flux/Argo
+    participant Cluster
+
+    Developer->>GitHub: Commit chart/overlay changes
+    GitOps->>GitHub: Poll repo
+    GitOps-->>GitOps: Render Kustomize (Helm chart)
+    GitOps->>Cluster: Apply manifests (Deployment, Service, PVCs)
+    Cluster-->>GitOps: Status/health
+    GitOps-->>Developer: Sync status (optional UIs/alerts)
+```
+
+## Helm chart (`deploy/kubernetes/charts/openclaw`)
+
+The chart deploys:
+
+- `Deployment` running `ghcr.io/openclaw/openclaw`
+- `Service` exposing ports 18789 (gateway) + 18790 (bridge)
+- Optional `Ingress`
+- PVCs for `/home/node/.openclaw` and `/home/node/.openclaw/workspace`
+- Optional Secret (for `OPENCLAW_GATEWAY_TOKEN`, OAuth creds, etc.)
+- BusyBox init container to fix permissions on shared volumes
+
+Key values (`values.yaml`):
+
+| Value | Purpose |
+|-------|---------|
+| `image.repository/tag/pullPolicy` | Pin the OpenClaw container release. |
+| `gateway.env/args` | Inject CLI flags or env vars (model keys, bind mode). |
+| `secret.create/stringData` | Inline secret creation. Set `secret.create=false` to reference an external secret. |
+| `persistence.{config,workspace}` | Size, accessMode, storageClass, or reuse `existingClaim`. |
+| `extraContainers/extraVolumes` | Attach GUI browsers, proxies, etc., without modifying upstream images. |
+| `ingress.*` | Enable HTTP ingress + TLS. |
+
+Install directly:
+
+```bash
+helm upgrade --install openclaw \
+  ./deploy/kubernetes/charts/openclaw \
+  --namespace openclaw --create-namespace \
+  --set image.tag=v2026.2.13 \
+  --set secret.create=true \
+  --set secret.stringData.OPENCLAW_GATEWAY_TOKEN="REPLACE_ME"
+```
+
+## Kustomize overlays (`deploy/kubernetes/kustomize`)
+
+- `base/` – namespace definition (openclaw)
+- `overlays/dev` – single replica, smaller PVCs, sample secret
+- `overlays/prod` – two replicas, ingress + TLS, references external secret
+
+Render locally:
+
+```bash
+kustomize build deploy/kubernetes/kustomize/overlays/dev
+```
+
+### Flux example
+
+```yaml
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: openclaw
+spec:
+  interval: 1m
+  url: https://github.com/egkristi/openclaw
+  ref:
+    branch: feature/k8s
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: openclaw
+spec:
+  interval: 5m
+  path: ./deploy/kubernetes/kustomize/overlays/prod
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: openclaw
+```
+
+### Argo CD example
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: openclaw
+spec:
+  destination:
+    namespace: openclaw
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    repoURL: https://github.com/egkristi/openclaw.git
+    targetRevision: feature/k8s
+    path: deploy/kubernetes/kustomize/overlays/dev
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+```
+
+## Secrets & security
+
+- **Never commit real tokens.** Use `secret.create=false` and reference a secret from
+  External Secrets, SOPS, or your cloud secret manager.
+- ServiceAccount is minimal by default. Add Roles/Bindings only if sidecars need API
+  access.
+- The Deployment runs as UID 1000 (`node`). Adjust `securityContext` if a sidecar needs
+  elevated privileges.
+
+## Sidecars & extensions
+
+1. Add a browser/GUI container via `extraContainers`. Mount the same workspace PVC to
+   share cookies or session files.
+2. Use `extraVolumes` + `extraVolumeMounts` for shared Unix sockets or cache dirs.
+3. Wire Prometheus scraping by enabling service annotations (`prometheus.io/*`).
+4. Attach NetworkPolicies or ServiceMonitors outside the chart via additional manifests in
+   your overlay.
+
+## Upstream compatibility
+
+All Kubernetes assets live under `deploy/kubernetes/*` plus documentation links, so they
+can track the official upstream repo without touching core code. Regularly merge upstream
+`main` into your branch to stay current; conflicts are unlikely unless upstream eventually
+ships their own Kubernetes package (in which case you can upstream these files or adapt).


### PR DESCRIPTION
Openclaw k8s automated self re-deploy.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds comprehensive Kubernetes deployment support with Helm charts and Kustomize overlays for running OpenClaw in cluster environments. The implementation includes deployment manifests, persistent volume claims for config and workspace storage, optional ingress configuration, and GitOps-ready overlays for dev and prod environments.

- Complete Helm chart with configurable deployment, service, PVCs, ingress, and secrets
- Kustomize overlays for dev (single replica, smaller storage) and prod (HA with 2 replicas, ingress+TLS) environments
- BusyBox init container for permissions setup on persistent volumes
- Security-hardened pod configuration (non-root, capabilities dropped, fsGroup management)
- Comprehensive documentation with architecture diagrams and GitOps workflow examples

The implementation follows Kubernetes best practices with proper security contexts, resource limits, and health checks. Previous thread comments have identified several issues that should be addressed before merging (repository URLs, mount path inconsistencies, and placeholder tokens).

<h3>Confidence Score: 3/5</h3>

- Safe to merge after addressing repository URL references and documentation updates mentioned in previous threads
- The Kubernetes manifests are well-structured and follow best practices. Security contexts are properly configured, and the chart design is flexible. However, several non-critical issues from previous review threads need attention: repository URLs still reference `egkristi/openclaw` instead of `openclaw/openclaw`, branch references point to `feature/k8s` instead of `main`, and the dev overlay contains a `REPLACE_ME` placeholder token. The mount path issues identified in previous threads should also be resolved. These are documentation and configuration concerns rather than functional defects.
- `deploy/kubernetes/README.md` and `docs/kubernetes.md` need repository URL updates before merging

<sub>Last reviewed commit: ee1b922</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->