### PR TITLE
fix(discord): respect gateway TLS config in exec approvals handler

### DIFF
--- a/src/discord/monitor/exec-approvals.ts
+++ b/src/discord/monitor/exec-approvals.ts
@@ -5,6 +5,7 @@ import type { DiscordExecApprovalConfig } from "../../config/types.discord.js";
 import type { EventFrame } from "../../gateway/protocol/index.js";
 import type { ExecApprovalDecision } from "../../infra/exec-approvals.js";
 import type { RuntimeEnv } from "../../runtime.js";
+import { buildGatewayConnectionDetails } from "../../gateway/call.js";
 import { GatewayClient } from "../../gateway/client.js";
 import { logDebug, logError } from "../../logger.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../../utils/message-channel.js";
@@ -266,8 +267,13 @@ export class DiscordExecApprovalHandler {
 
     logDebug("discord exec approvals: starting handler");
 
+    const { url: gatewayUrl } = buildGatewayConnectionDetails({
+      config: this.opts.cfg,
+      url: this.opts.gatewayUrl,
+    });
+
     this.gatewayClient = new GatewayClient({
-      url: this.opts.gatewayUrl ?? "ws://127.0.0.1:18789",
+      url: gatewayUrl,
       clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
       clientDisplayName: "Discord Exec Approvals",
       mode: GATEWAY_CLIENT_MODES.BACKEND,


### PR DESCRIPTION
## Summary

The `DiscordExecApprovalHandler` hardcodes `ws://127.0.0.1:18789` as the gateway
WebSocket URL, ignoring `gateway.tls.enabled` and `gateway.bind`. When TLS is
active the gateway only accepts `wss://` connections, so the handler's connection
is rejected immediately and approval buttons never reach Discord DMs.

This replaces the hardcoded URL with `buildGatewayConnectionDetails()` — the same
utility used by every other gateway client (`status`, `doctor`, `health`, `acp`,
`audit`, `logs`, etc.). This correctly resolves:
- `wss://` vs `ws://` based on TLS config
- The gateway port from config
- The bind address (loopback, LAN IP, or Tailnet IP)
- Explicit `gatewayUrl` override (still takes precedence)

## Reproduction

1. Enable TLS: `gateway.tls.enabled: true`
2. Enable Discord exec approvals: `channels.discord.execApprovals.enabled: true`
3. Configure approval policy in `exec-approvals.json` with non-empty `defaults`
4. Restart gateway — continuous "socket hang up" errors in logs
5. Trigger a command requiring approval — buttons appear in web UI but not Discord DMs

## Change

Single file: `src/discord/monitor/exec-approvals.ts`
- Add import for `buildGatewayConnectionDetails` from `../../gateway/call.js`
- Replace hardcoded URL with resolved URL from config

The `cfg` and `gatewayUrl` parameters are already passed to the handler from
`provider.ts` and typed in `DiscordExecApprovalHandlerOpts`.

## Test plan

- [ ] TLS enabled → handler connects via `wss://`, approval buttons reach Discord DMs
- [ ] TLS disabled → handler connects via `ws://` as before
- [ ] Custom `gatewayUrl` override → still takes precedence
- [ ] Non-default gateway port → respected
- [ ] `bind: "lan"` → handler connects to LAN IP, not just 127.0.0.1

## Environment

- OpenClaw 2026.2.12
- Gateway TLS enabled (CertHub Home CA)
- Confirmed fix works by patching all 4 dist entry points locally

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Replaces hardcoded WebSocket URL with config-aware connection builder in Discord exec approval handler. Previously, the handler always connected via `ws://127.0.0.1:18789`, causing immediate connection failures when gateway TLS was enabled (which requires `wss://` connections). The fix uses `buildGatewayConnectionDetails` - the same utility used by all other gateway clients (`status`, `doctor`, `health`, `acp`, `audit`, `logs`) - to correctly resolve the protocol (`ws://` vs `wss://`), port, and bind address based on the gateway configuration.

The change is minimal, well-tested by existing patterns, and maintains backward compatibility (non-TLS setups continue using `ws://` as before).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a straightforward refactor that aligns with established patterns used throughout the codebase. The change replaces a hardcoded URL with a standard utility function (`buildGatewayConnectionDetails`) that's already used by at least 10 other gateway clients. The implementation is minimal (adds 1 import, replaces 1 line with 5 lines), maintains backward compatibility, and directly addresses a clear bug where TLS-enabled gateways would reject the hardcoded `ws://` connection.
- No files require special attention

<sub>Last reviewed commit: 9e5f2dd</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->