### PR TITLE
fix: suppress false duplicate plugin id warning for symlinked extensions

### DIFF
--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -1,0 +1,138 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { PluginCandidate } from "./discovery.js";
+import { loadPluginManifestRegistry } from "./manifest-registry.js";
+
+const tempDirs: string[] = [];
+
+function makeTempDir() {
+  const dir = path.join(os.tmpdir(), `openclaw-manifest-registry-${randomUUID()}`);
+  fs.mkdirSync(dir, { recursive: true });
+  tempDirs.push(dir);
+  return dir;
+}
+
+function writeManifest(dir: string, manifest: Record<string, unknown>) {
+  fs.writeFileSync(path.join(dir, "openclaw.plugin.json"), JSON.stringify(manifest), "utf-8");
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup failures
+    }
+  }
+});
+
+describe("loadPluginManifestRegistry", () => {
+  it("emits duplicate warning for truly distinct plugins with same id", () => {
+    const dirA = makeTempDir();
+    const dirB = makeTempDir();
+    const manifest = { id: "test-plugin", configSchema: { type: "object" } };
+    writeManifest(dirA, manifest);
+    writeManifest(dirB, manifest);
+
+    const candidates: PluginCandidate[] = [
+      {
+        idHint: "test-plugin",
+        source: path.join(dirA, "index.ts"),
+        rootDir: dirA,
+        origin: "bundled",
+      },
+      {
+        idHint: "test-plugin",
+        source: path.join(dirB, "index.ts"),
+        rootDir: dirB,
+        origin: "global",
+      },
+    ];
+
+    const registry = loadPluginManifestRegistry({
+      candidates,
+      cache: false,
+    });
+
+    const duplicateWarnings = registry.diagnostics.filter(
+      (d) => d.level === "warn" && d.message?.includes("duplicate plugin id"),
+    );
+    expect(duplicateWarnings.length).toBe(1);
+  });
+
+  it("suppresses duplicate warning when candidates share the same physical directory via symlink", () => {
+    const realDir = makeTempDir();
+    const manifest = { id: "feishu", configSchema: { type: "object" } };
+    writeManifest(realDir, manifest);
+
+    // Create a symlink pointing to the same directory
+    const symlinkParent = makeTempDir();
+    const symlinkPath = path.join(symlinkParent, "feishu-link");
+    try {
+      fs.symlinkSync(realDir, symlinkPath, "junction");
+    } catch {
+      // On systems where symlinks are not supported (e.g. restricted Windows),
+      // skip this test gracefully.
+      return;
+    }
+
+    const candidates: PluginCandidate[] = [
+      {
+        idHint: "feishu",
+        source: path.join(realDir, "index.ts"),
+        rootDir: realDir,
+        origin: "bundled",
+      },
+      {
+        idHint: "feishu",
+        source: path.join(symlinkPath, "index.ts"),
+        rootDir: symlinkPath,
+        origin: "bundled",
+      },
+    ];
+
+    const registry = loadPluginManifestRegistry({
+      candidates,
+      cache: false,
+    });
+
+    const duplicateWarnings = registry.diagnostics.filter(
+      (d) => d.level === "warn" && d.message?.includes("duplicate plugin id"),
+    );
+    expect(duplicateWarnings.length).toBe(0);
+  });
+
+  it("suppresses duplicate warning when candidates have identical rootDir paths", () => {
+    const dir = makeTempDir();
+    const manifest = { id: "same-path-plugin", configSchema: { type: "object" } };
+    writeManifest(dir, manifest);
+
+    const candidates: PluginCandidate[] = [
+      {
+        idHint: "same-path-plugin",
+        source: path.join(dir, "a.ts"),
+        rootDir: dir,
+        origin: "bundled",
+      },
+      {
+        idHint: "same-path-plugin",
+        source: path.join(dir, "b.ts"),
+        rootDir: dir,
+        origin: "global",
+      },
+    ];
+
+    const registry = loadPluginManifestRegistry({
+      candidates,
+      cache: false,
+    });
+
+    const duplicateWarnings = registry.diagnostics.filter(
+      (d) => d.level === "warn" && d.message?.includes("duplicate plugin id"),
+    );
+    expect(duplicateWarnings.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Problem

`openclaw doctor` warns about duplicate plugin id `feishu` even though only the built-in extension exists, printing the same path twice.

Fixes #16208

## Root Cause

In `manifest-registry.ts`, the registry tracked seen plugin IDs with a `Set<string>`. When two discovery candidates had different `source` path strings but pointed to the same physical directory (via symlinks or differing path representations), the registry falsely warned about a duplicate.

## Solution

- Changed `seenIds` from `Set<string>` to `Map<string, PluginCandidate>` to track the first-seen candidate per manifest ID
- Before emitting a duplicate warning, compare `fs.realpathSync()` of both candidates' `rootDir`
- If they resolve to the same physical directory, silently skip (false positive)
- If they differ, emit the duplicate warning as before

## Tests

Added [manifest-registry.test.ts](cci:7://file:///c:/Users/BS01431/Desktop/openclaw/src/plugins/manifest-registry.test.ts:0:0-0:0) with 3 test cases:
1. **Genuine duplicates** — distinct directories with same manifest id → warning emitted ✅
2. **Symlink duplicates** — same directory via symlink → warning suppressed ✅
3. **Identical path duplicates** — same rootDir string → warning suppressed ✅

All 14 plugin test files pass (83 tests total).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes a false-positive "duplicate plugin id" warning in `openclaw doctor` when the same plugin directory is discovered via both its real path and a symlink (or differing path representation). The fix changes `seenIds` from a `Set<string>` to a `Map<string, PluginCandidate>`, then uses `fs.realpathSync()` to compare physical directories before emitting a duplicate warning.

- The core logic in `manifest-registry.ts` is correct: symlink/same-path duplicates are silently skipped, genuine duplicates still emit warnings, and `realpathSync` failures safely fall through to the warning path.
- Three new test cases cover genuine duplicates, symlink duplicates, and identical-path duplicates — all using real filesystem operations with proper temp directory cleanup.
- Minor style note: the symlink test silently passes (via bare `return`) when symlinks aren't available, rather than logging a skip reason.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a targeted fix with correct logic, proper error handling, and good test coverage.
- The change is minimal and well-scoped: `Set` → `Map` plus a `realpathSync` comparison guard. The error handling is sound (catch falls through to warning). The fix preserves the original behavior for genuine duplicates while correctly suppressing false positives. Three new tests cover the key scenarios.
- No files require special attention.

<sub>Last reviewed commit: 63f1d5e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->