### PR TITLE
feat(sandbox): separate bind mounts for browser containers

### DIFF
--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -106,9 +106,12 @@ export async function ensureSandboxBrowser(params: {
   const state = await dockerContainerState(containerName);
   if (!state.exists) {
     await ensureSandboxBrowserImage(params.cfg.browser.image ?? DEFAULT_SANDBOX_BROWSER_IMAGE);
+    const browserDockerCfg = params.cfg.browser.binds
+      ? { ...params.cfg.docker, network: "bridge", binds: params.cfg.browser.binds }
+      : { ...params.cfg.docker, network: "bridge" };
     const args = buildSandboxCreateArgs({
       name: containerName,
-      cfg: { ...params.cfg.docker, network: "bridge" },
+      cfg: browserDockerCfg,
       scopeKey: params.scopeKey,
       labels: { "openclaw.sandboxBrowser": "1" },
     });

--- a/src/agents/sandbox/config.ts
+++ b/src/agents/sandbox/config.ts
@@ -88,6 +88,7 @@ export function resolveSandboxBrowserConfig(params: {
 }): SandboxBrowserConfig {
   const agentBrowser = params.scope === "shared" ? undefined : params.agentBrowser;
   const globalBrowser = params.globalBrowser;
+  const binds = [...(globalBrowser?.binds ?? []), ...(agentBrowser?.binds ?? [])];
   return {
     enabled: agentBrowser?.enabled ?? globalBrowser?.enabled ?? false,
     image: agentBrowser?.image ?? globalBrowser?.image ?? DEFAULT_SANDBOX_BROWSER_IMAGE,
@@ -107,6 +108,7 @@ export function resolveSandboxBrowserConfig(params: {
       agentBrowser?.autoStartTimeoutMs ??
       globalBrowser?.autoStartTimeoutMs ??
       DEFAULT_SANDBOX_BROWSER_AUTOSTART_TIMEOUT_MS,
+    binds: binds.length ? binds : undefined,
   };
 }
 

--- a/src/agents/sandbox/types.ts
+++ b/src/agents/sandbox/types.ts
@@ -40,6 +40,7 @@ export type SandboxBrowserConfig = {
   allowHostControl: boolean;
   autoStart: boolean;
   autoStartTimeoutMs: number;
+  binds?: string[];
 };
 
 export type SandboxPruneConfig = {

--- a/src/config/config.sandbox-docker.test.ts
+++ b/src/config/config.sandbox-docker.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { resolveSandboxBrowserConfig } from "../agents/sandbox/config.js";
 import { validateConfigObject } from "./config.js";
 
 describe("sandbox docker config", () => {
@@ -50,5 +51,60 @@ describe("sandbox docker config", () => {
       },
     });
     expect(res.ok).toBe(false);
+  });
+});
+
+describe("sandbox browser binds config", () => {
+  it("accepts binds array in sandbox.browser config", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: {
+            browser: {
+              binds: ["/home/user/.chrome-profile:/data/chrome:rw"],
+            },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.config.agents?.defaults?.sandbox?.browser?.binds).toEqual([
+        "/home/user/.chrome-profile:/data/chrome:rw",
+      ]);
+    }
+  });
+
+  it("rejects non-string values in browser binds array", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: {
+            browser: {
+              binds: [123],
+            },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  it("merges global and agent browser binds", () => {
+    const resolved = resolveSandboxBrowserConfig({
+      scope: "agent",
+      globalBrowser: { binds: ["/global:/global:ro"] },
+      agentBrowser: { binds: ["/agent:/agent:rw"] },
+    });
+    expect(resolved.binds).toEqual(["/global:/global:ro", "/agent:/agent:rw"]);
+  });
+
+  it("returns undefined binds when none configured", () => {
+    const resolved = resolveSandboxBrowserConfig({
+      scope: "agent",
+      globalBrowser: {},
+      agentBrowser: {},
+    });
+    expect(resolved.binds).toBeUndefined();
   });
 });

--- a/src/config/types.sandbox.ts
+++ b/src/config/types.sandbox.ts
@@ -65,6 +65,8 @@ export type SandboxBrowserSettings = {
   autoStart?: boolean;
   /** Max time to wait for CDP to become reachable after auto-start (ms). */
   autoStartTimeoutMs?: number;
+  /** Additional bind mounts for the browser container only. When set, replaces docker.binds for the browser container. */
+  binds?: string[];
 };
 
 export type SandboxPruneSettings = {

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -139,6 +139,7 @@ export const SandboxBrowserSchema = z
     allowHostControl: z.boolean().optional(),
     autoStart: z.boolean().optional(),
     autoStartTimeoutMs: z.number().int().positive().optional(),
+    binds: z.array(z.string()).optional(),
   })
   .strict()
   .optional();


### PR DESCRIPTION
## Summary

- Add `sandbox.browser.binds` config to allow browser-specific bind mounts
- When `browser.binds` is set, browser containers use those instead of `docker.binds`
- Falls back to `docker.binds` when `browser.binds` is not configured (backwards compatible)

Closes #14614

## Example

```json5
{
  sandbox: {
    docker: {
      binds: ["/home/user/.ssh:/root/.ssh:ro"]        // exec container only
    },
    browser: {
      binds: ["/home/user/.chrome:/data/chrome:rw"]    // browser container only
    }
  }
}
```

## Test plan

- [x] Config validation accepts `browser.binds` string array
- [x] Config validation rejects non-string values
- [x] Global and agent-level browser binds merge correctly
- [x] Undefined when no browser binds configured
- [x] Type check passes
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds `sandbox.browser.binds` configuration to enable browser-specific bind mounts, addressing issue #14614. When configured, browser containers use these binds instead of inheriting from `docker.binds`, with backwards-compatible fallback behavior.

**Core Changes:**
- Added `binds?: string[]` field to `SandboxBrowserConfig` and `SandboxBrowserSettings` types
- Implemented merging logic in `resolveSandboxBrowserConfig` (global + agent-level binds)
- Updated browser container creation in `ensureSandboxBrowser` to use browser-specific binds when available
- Added comprehensive test coverage for config validation and merge behavior

**Unrelated Changes Included:**
This PR includes several unrelated commits that should be in separate PRs:
- Dockerfile.sandbox changes (python packages, gh CLI)
- Pi-ai patch for Gemini-3 unsigned tool calls
- Cron isolated-agent sandbox exclusion fix
- Browser entrypoint script improvements

**Implementation Quality:**
The core feature is well-implemented with proper type safety, test coverage, and follows the codebase's existing patterns for config resolution and merging.

<h3>Confidence Score: 3/5</h3>

- This PR mixes a solid core feature with several unrelated changes that should be separated.
- The browser binds feature implementation itself is well-designed with proper types, config merging, backwards compatibility, and test coverage. However, the PR bundles unrelated changes (Dockerfile packages, pi-ai patch, cron fix, entrypoint improvements) that complicate review and violate single-responsibility principle. The core feature is safe to merge, but the PR structure needs cleanup.
- Check that Dockerfile.sandbox, package.json, patches/@mariozechner__pi-ai.patch, scripts/sandbox-browser-entrypoint.sh, and src/cron/isolated-agent/run.ts changes are intentionally bundled or should be split into separate PRs

<sub>Last reviewed commit: 7d76182</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->