### PR TITLE
feat(inbound): expose platform_message_id in inbound_meta (#16188)

### DIFF
--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -21,6 +21,7 @@ export function buildInboundMetaSystemPrompt(ctx: TemplateContext): string {
     channel: safeTrim(ctx.OriginatingChannel) ?? safeTrim(ctx.Surface) ?? safeTrim(ctx.Provider),
     provider: safeTrim(ctx.Provider),
     surface: safeTrim(ctx.Surface),
+    platform_message_id: safeTrim(ctx.MessageSidFull) ?? safeTrim(ctx.MessageSid),
     chat_type: chatType ?? (isDirect ? "direct" : undefined),
     flags: {
       is_group_chat: !isDirect ? true : undefined,


### PR DESCRIPTION
## Summary

Fixes #16188 — Agents had no access to the platform-native message ID in inbound context.

## Change

Added `platform_message_id` to inbound metadata in `src/auto-reply/reply/inbound-meta.ts`:

```ts
platform_message_id: safeTrim(ctx.MessageSidFull) ?? safeTrim(ctx.MessageSid)
```

Uses `MessageSidFull` (preferred, fully-qualified) with fallback to `MessageSid`. Omitted when both are absent.

## Use cases
- Targeted reactions to the originating message
- Precise reply threading
- Cross-step agent workflows that need a stable message reference

---

*AI-assisted (Claude). Reviewed by human.*