### PR TITLE
fix(discord): use guild_id from gateway params for logging (#16207)

### DIFF
--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -446,7 +446,7 @@ export async function preflightDiscordMessage(
   );
   if (shouldLogVerbose()) {
     logVerbose(
-      `discord: inbound id=${message.id} guild=${message.guild?.id ?? "dm"} channel=${message.channelId} mention=${wasMentioned ? "yes" : "no"} type=${isDirectMessage ? "dm" : isGroupDm ? "group-dm" : "guild"} content=${messageText ? "yes" : "no"}`,
+      `discord: inbound id=${message.id} guild=${params.data.guild_id ?? message.guild?.id ?? "dm"} channel=${message.channelId} mention=${wasMentioned ? "yes" : "no"} type=${isDirectMessage ? "dm" : isGroupDm ? "group-dm" : "guild"} content=${messageText ? "yes" : "no"}`,
     );
   }
 


### PR DESCRIPTION
## Summary

Fixes #16207 — Discord message handler logged `guild=dm` for messages in non-cached guilds, even though the actual security logic (`params.data.guild_id`) was correct.

### Problem
When a guild wasn't in the Discord cache, `resolveGuild()` returned `null`, causing the log line to fall through to `'dm'`. This was a **logging-only bug** — all security-critical paths (role allowlists, mention gating) already used the correct `params.data.guild_id`.

### Fix
Use `params.data.guild_id` for the log line as well, falling back to `'dm'` only when guild_id is genuinely absent.

### Changed files
- `src/discord/monitor/message-handler.preflight.ts` — 1 line fix

*This PR was crafted with AI assistance (Claude). All changes reviewed and verified by a human.*