### PR TITLE
refactor(media): normalize inbound MediaType/MediaTypes defaults

### DIFF
--- a/src/auto-reply/inbound.test.ts
+++ b/src/auto-reply/inbound.test.ts
@@ -116,6 +116,43 @@ describe("finalizeInboundContext", () => {
     finalizeInboundContext(ctx, { forceBodyForCommands: true });
     expect(ctx.BodyForCommands).toBe("say hi");
   });
+
+  it("fills MediaType/MediaTypes defaults only when media exists", () => {
+    const withMedia: MsgContext = {
+      Body: "hi",
+      MediaPath: "/tmp/file.bin",
+    };
+    const outWithMedia = finalizeInboundContext(withMedia);
+    expect(outWithMedia.MediaType).toBe("application/octet-stream");
+    expect(outWithMedia.MediaTypes).toEqual(["application/octet-stream"]);
+
+    const withoutMedia: MsgContext = { Body: "hi" };
+    const outWithoutMedia = finalizeInboundContext(withoutMedia);
+    expect(outWithoutMedia.MediaType).toBeUndefined();
+    expect(outWithoutMedia.MediaTypes).toBeUndefined();
+  });
+
+  it("pads MediaTypes to match MediaPaths/MediaUrls length", () => {
+    const ctx: MsgContext = {
+      Body: "hi",
+      MediaPaths: ["/tmp/a", "/tmp/b"],
+      MediaTypes: ["image/png"],
+    };
+    const out = finalizeInboundContext(ctx);
+    expect(out.MediaType).toBe("image/png");
+    expect(out.MediaTypes).toEqual(["image/png", "application/octet-stream"]);
+  });
+
+  it("derives MediaType from MediaTypes when missing", () => {
+    const ctx: MsgContext = {
+      Body: "hi",
+      MediaPath: "/tmp/a",
+      MediaTypes: ["image/jpeg"],
+    };
+    const out = finalizeInboundContext(ctx);
+    expect(out.MediaType).toBe("image/jpeg");
+    expect(out.MediaTypes).toEqual(["image/jpeg"]);
+  });
 });
 
 describe("inbound dedupe", () => {

--- a/src/auto-reply/reply/inbound-context.ts
+++ b/src/auto-reply/reply/inbound-context.ts
@@ -10,11 +10,28 @@ export type FinalizeInboundContextOptions = {
   forceConversationLabel?: boolean;
 };
 
+const DEFAULT_MEDIA_TYPE = "application/octet-stream";
+
 function normalizeTextField(value: unknown): string | undefined {
   if (typeof value !== "string") {
     return undefined;
   }
   return normalizeInboundTextNewlines(value);
+}
+
+function normalizeMediaType(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function countMediaEntries(ctx: MsgContext): number {
+  const pathCount = Array.isArray(ctx.MediaPaths) ? ctx.MediaPaths.length : 0;
+  const urlCount = Array.isArray(ctx.MediaUrls) ? ctx.MediaUrls.length : 0;
+  const single = ctx.MediaPath || ctx.MediaUrl ? 1 : 0;
+  return Math.max(pathCount, urlCount, single);
 }
 
 export function finalizeInboundContext<T extends Record<string, unknown>>(
@@ -72,6 +89,36 @@ export function finalizeInboundContext<T extends Record<string, unknown>>(
 
   // Always set. Default-deny when upstream forgets to populate it.
   normalized.CommandAuthorized = normalized.CommandAuthorized === true;
+
+  // MediaType/MediaTypes alignment:
+  // - No media: do not inject defaults.
+  // - Media present: ensure MediaType is always set, and MediaTypes is padded to match
+  //   MediaPaths/MediaUrls length when possible.
+  const mediaCount = countMediaEntries(normalized);
+  if (mediaCount > 0) {
+    const mediaType = normalizeMediaType(normalized.MediaType);
+    const rawMediaTypes = Array.isArray(normalized.MediaTypes) ? normalized.MediaTypes : undefined;
+    const normalizedMediaTypes = rawMediaTypes?.map((entry) => normalizeMediaType(entry));
+
+    let mediaTypesFinal: string[] | undefined;
+    if (normalizedMediaTypes && normalizedMediaTypes.length > 0) {
+      const filled = normalizedMediaTypes.slice();
+      while (filled.length < mediaCount) {
+        filled.push(undefined);
+      }
+      mediaTypesFinal = filled.map((entry) => entry ?? DEFAULT_MEDIA_TYPE);
+    } else if (mediaType) {
+      mediaTypesFinal = [mediaType];
+      while (mediaTypesFinal.length < mediaCount) {
+        mediaTypesFinal.push(DEFAULT_MEDIA_TYPE);
+      }
+    } else {
+      mediaTypesFinal = Array.from({ length: mediaCount }, () => DEFAULT_MEDIA_TYPE);
+    }
+
+    normalized.MediaTypes = mediaTypesFinal;
+    normalized.MediaType = mediaType ?? mediaTypesFinal[0] ?? DEFAULT_MEDIA_TYPE;
+  }
 
   return normalized as T & FinalizedMsgContext;
 }

--- a/src/browser/server.agent-contract-form-layout-act-commands.test.ts
+++ b/src/browser/server.agent-contract-form-layout-act-commands.test.ts
@@ -421,7 +421,8 @@ describe("browser control server", () => {
     expect(pwMocks.armFileUploadViaPlaywright).toHaveBeenCalledWith({
       cdpUrl: cdpBaseUrl,
       targetId: "abcd1234",
-      paths: [path.join(DEFAULT_UPLOAD_DIR, "a.txt")],
+      // The server resolves paths (which adds a drive letter on Windows for `\\tmp\\...` style roots).
+      paths: [path.resolve(DEFAULT_UPLOAD_DIR, "a.txt")],
       timeoutMs: 1234,
     });
 

--- a/src/slack/monitor/media.ts
+++ b/src/slack/monitor/media.ts
@@ -139,6 +139,33 @@ export type SlackMediaResult = {
 };
 
 const MAX_SLACK_MEDIA_FILES = 8;
+const MAX_SLACK_MEDIA_CONCURRENCY = 3;
+
+async function mapLimit<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  if (items.length === 0) {
+    return [];
+  }
+  const results: R[] = [];
+  results.length = items.length;
+  let nextIndex = 0;
+  const workerCount = Math.max(1, Math.min(limit, items.length));
+  await Promise.all(
+    Array.from({ length: workerCount }, async () => {
+      while (true) {
+        const idx = nextIndex++;
+        if (idx >= items.length) {
+          return;
+        }
+        results[idx] = await fn(items[idx]);
+      }
+    }),
+  );
+  return results;
+}
 
 /**
  * Downloads all files attached to a Slack message and returns them as an array.
@@ -152,43 +179,50 @@ export async function resolveSlackMedia(params: {
   const files = params.files ?? [];
   const limitedFiles =
     files.length > MAX_SLACK_MEDIA_FILES ? files.slice(0, MAX_SLACK_MEDIA_FILES) : files;
-  const results: SlackMediaResult[] = [];
-  for (const file of limitedFiles) {
-    const url = file.url_private_download ?? file.url_private;
-    if (!url) {
-      continue;
-    }
-    try {
-      // Note: fetchRemoteMedia calls fetchImpl(url) with the URL string today and
-      // handles size limits internally. Provide a fetcher that uses auth once, then lets
-      // the redirect chain continue without credentials.
-      const fetchImpl = createSlackMediaFetch(params.token);
-      const fetched = await fetchRemoteMedia({
-        url,
-        fetchImpl,
-        filePathHint: file.name,
-        maxBytes: params.maxBytes,
-      });
-      if (fetched.buffer.byteLength > params.maxBytes) {
-        continue;
+
+  const resolved = await mapLimit<SlackFile, SlackMediaResult | null>(
+    limitedFiles,
+    MAX_SLACK_MEDIA_CONCURRENCY,
+    async (file) => {
+      const url = file.url_private_download ?? file.url_private;
+      if (!url) {
+        return null;
       }
-      const effectiveMime = resolveSlackMediaMimetype(file, fetched.contentType);
-      const saved = await saveMediaBuffer(
-        fetched.buffer,
-        effectiveMime,
-        "inbound",
-        params.maxBytes,
-      );
-      const label = fetched.fileName ?? file.name;
-      results.push({
-        path: saved.path,
-        contentType: effectiveMime ?? saved.contentType,
-        placeholder: label ? `[Slack file: ${label}]` : "[Slack file]",
-      });
-    } catch {
-      // Ignore download failures and try the next file.
-    }
-  }
+      try {
+        // Note: fetchRemoteMedia calls fetchImpl(url) with the URL string today and
+        // handles size limits internally. Provide a fetcher that uses auth once, then lets
+        // the redirect chain continue without credentials.
+        const fetchImpl = createSlackMediaFetch(params.token);
+        const fetched = await fetchRemoteMedia({
+          url,
+          fetchImpl,
+          filePathHint: file.name,
+          maxBytes: params.maxBytes,
+        });
+        if (fetched.buffer.byteLength > params.maxBytes) {
+          return null;
+        }
+        const effectiveMime = resolveSlackMediaMimetype(file, fetched.contentType);
+        const saved = await saveMediaBuffer(
+          fetched.buffer,
+          effectiveMime,
+          "inbound",
+          params.maxBytes,
+        );
+        const label = fetched.fileName ?? file.name;
+        const contentType = effectiveMime ?? saved.contentType;
+        return {
+          path: saved.path,
+          ...(contentType ? { contentType } : {}),
+          placeholder: label ? `[Slack file: ${label}]` : "[Slack file]",
+        };
+      } catch {
+        return null;
+      }
+    },
+  );
+
+  const results = resolved.filter((entry): entry is SlackMediaResult => Boolean(entry));
   return results.length > 0 ? results : null;
 }
 

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -561,9 +561,6 @@ export async function prepareSlackMessage(params: {
   // Use thread starter media if current message has none
   const effectiveMedia = media ?? threadStarterMedia;
   const firstMedia = effectiveMedia?.[0];
-  const firstMediaType = firstMedia
-    ? (firstMedia.contentType ?? "application/octet-stream")
-    : undefined;
 
   const inboundHistory =
     isRoomish && ctx.historyLimit > 0
@@ -606,7 +603,7 @@ export async function prepareSlackMessage(params: {
     Timestamp: message.ts ? Math.round(Number(message.ts) * 1000) : undefined,
     WasMentioned: isRoomish ? effectiveWasMentioned : undefined,
     MediaPath: firstMedia?.path,
-    MediaType: firstMediaType,
+    MediaType: firstMedia?.contentType,
     MediaUrl: firstMedia?.path,
     MediaPaths:
       effectiveMedia && effectiveMedia.length > 0 ? effectiveMedia.map((m) => m.path) : undefined,
@@ -614,7 +611,7 @@ export async function prepareSlackMessage(params: {
       effectiveMedia && effectiveMedia.length > 0 ? effectiveMedia.map((m) => m.path) : undefined,
     MediaTypes:
       effectiveMedia && effectiveMedia.length > 0
-        ? effectiveMedia.map((m) => m.contentType ?? "application/octet-stream")
+        ? effectiveMedia.map((m) => m.contentType ?? "")
         : undefined,
     CommandAuthorized: commandAuthorized,
     OriginatingChannel: "slack" as const,


### PR DESCRIPTION
What
- Centralize MediaType/MediaTypes fallback + padding in finalizeInboundContext (only when media exists).
- Remove Slack-specific application/octet-stream fallbacks; let finalizeInboundContext normalize.
- Add regression tests for media type invariants + Slack cap=8.
- Slack resolveSlackMedia: limited concurrency (3) without changing ordering.
- Fix Windows-only test expectation for file chooser upload paths (path.resolve adds drive).

Why
- Avoid channel-specific duplication and drift.
- Ensure MediaType is consistent with MediaTypes[0] when media exists.

Gates (local)
- pnpm check: PASS
- pnpm test src/auto-reply/inbound.test.ts src/slack/monitor/media.test.ts: PASS
- pnpm test src/browser/server.agent-contract-form-layout-act-commands.test.ts: PASS

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR centralizes `MediaType`/`MediaTypes` fallback logic into `finalizeInboundContext`, removing duplicated `application/octet-stream` fallbacks from the Slack channel handler. The normalization handles three cases: no media (no defaults injected), media with types provided (padded to match array lengths), and media without types (defaults applied). The Slack media downloader is also refactored from a sequential loop to a concurrent `mapLimit(3)` pattern that preserves ordering.

- `finalizeInboundContext` now normalizes `MediaType`/`MediaTypes` when media entries exist, padding arrays and applying `application/octet-stream` defaults
- Slack `prepare.ts` passes `contentType` directly (possibly undefined) and uses empty string `""` for unknown types in the array, relying on the centralizer to normalize
- `resolveSlackMedia` uses a new `mapLimit` helper for bounded concurrency (3 workers) with order-preserving indexed result writes
- Test mocks updated from order-dependent `mockResolvedValueOnce` to content-based `mockImplementation` to handle non-deterministic concurrent call ordering
- Adds regression tests for media type invariants and the 8-file download cap
- Fixes Windows test expectation using `path.resolve` instead of `path.join`

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it centralizes existing fallback logic with well-tested normalization and improves Slack download concurrency without changing behavior.
- The changes are well-structured and focused: moving fallback defaults from channel-specific code into a shared normalizer reduces duplication and drift. The mapLimit concurrency helper is safe under JavaScript's single-threaded model. The data flow from Slack (empty strings for unknown types) through finalizeInboundContext (normalizes to application/octet-stream) is correct and tested. Tests are comprehensive, covering padding, derivation, no-media cases, and the 8-file cap. The browser test fix is a straightforward cross-platform correction.
- No files require special attention

<sub>Last reviewed commit: fe51421</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->