### PR TITLE
fix(tui): use available terminal width for session name display (#16109)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 - Security/Discovery: stop treating Bonjour TXT records as authoritative routing (prefer resolved service endpoints) and prevent discovery from overriding stored TLS pins; autoconnect now requires a previously trusted gateway. Thanks @simecek.
 - macOS: hard-limit unkeyed `openclaw://agent` deep links and ignore `deliver` / `to` / `channel` unless a valid unattended key is provided. Thanks @Cillian-Collins.
 - Plugins: suppress false duplicate plugin id warnings when the same extension is discovered via multiple paths (config/workspace/global vs bundled), while still warning on genuine duplicates. (#16222) Thanks @shadril238.
+- TUI: use available terminal width for session name display in searchable select lists. (#16238) Thanks @robbyczgw-cla.
 - Security/Voice Call: require valid Twilio webhook signatures even when ngrok free tier loopback compatibility mode is enabled. Thanks @p80n-sec.
 - Security/Google Chat: deprecate `users/<email>` allowlists (treat `users/...` as immutable user id only); keep raw email allowlists for usability. Thanks @vincentkoc.
 - Security/Google Chat: reject ambiguous shared-path webhook routing when multiple webhook targets verify successfully (prevents cross-account policy-context misrouting). Thanks @vincentkoc.

--- a/src/tui/components/searchable-select-list.test.ts
+++ b/src/tui/components/searchable-select-list.test.ts
@@ -38,6 +38,16 @@ describe("SearchableSelectList", () => {
     expect(output[0]).toContain("search");
   });
 
+  it("does not truncate long labels on wide terminals when description is present", () => {
+    const tail = "__TAIL__";
+    const longLabel = `session-${"x".repeat(40)}${tail}`; // > 30 chars; tail would be lost before PR
+    const items = [{ value: longLabel, label: longLabel, description: "desc" }];
+    const list = new SearchableSelectList(items, 5, mockTheme);
+
+    const output = list.render(120).join("\n");
+    expect(output).toContain(tail);
+  });
+
   it("filters items when typing", () => {
     const list = new SearchableSelectList(testItems, 5, mockTheme);
 

--- a/src/tui/components/searchable-select-list.ts
+++ b/src/tui/components/searchable-select-list.ts
@@ -219,20 +219,28 @@ export class SearchableSelectList implements Component {
     const displayValue = this.getItemLabel(item);
 
     if (item.description && width > 40) {
-      const maxValueWidth = Math.min(30, width - prefixWidth - 4);
-      const truncatedValue = truncateToWidth(displayValue, maxValueWidth, "");
-      const valueText = this.highlightMatch(truncatedValue, query);
-      const spacingWidth = Math.max(1, 32 - visibleWidth(valueText));
-      const spacing = " ".repeat(spacingWidth);
-      const descriptionStart = prefixWidth + visibleWidth(valueText) + spacing.length;
-      const remainingWidth = width - descriptionStart - 2;
-      if (remainingWidth > 10) {
-        const truncatedDesc = truncateToWidth(item.description, remainingWidth, "");
-        // Highlight plain text first, then apply theme styling to avoid corrupting ANSI codes
-        const highlightedDesc = this.highlightMatch(truncatedDesc, query);
-        const descText = isSelected ? highlightedDesc : this.theme.description(highlightedDesc);
-        const line = `${prefix}${valueText}${spacing}${descText}`;
-        return isSelected ? this.theme.selectedText(line) : line;
+      const minDescriptionWidth = 12;
+      const spacingWidth = 2;
+      const availableWidth = Math.max(1, width - prefixWidth - 2);
+
+      if (availableWidth > minDescriptionWidth + spacingWidth + 1) {
+        const maxValueWidth = availableWidth - minDescriptionWidth - spacingWidth;
+        const truncatedValue = truncateToWidth(displayValue, maxValueWidth, "");
+        const valueText = this.highlightMatch(truncatedValue, query);
+
+        const usedByValue = visibleWidth(valueText);
+        const remainingWidth = availableWidth - usedByValue;
+
+        if (remainingWidth > spacingWidth + 1) {
+          const descriptionWidth = remainingWidth - spacingWidth;
+          const spacing = " ".repeat(spacingWidth);
+          const truncatedDesc = truncateToWidth(item.description, descriptionWidth, "");
+          // Highlight plain text first, then apply theme styling to avoid corrupting ANSI codes
+          const highlightedDesc = this.highlightMatch(truncatedDesc, query);
+          const descText = isSelected ? highlightedDesc : this.theme.description(highlightedDesc);
+          const line = `${prefix}${valueText}${spacing}${descText}`;
+          return isSelected ? this.theme.selectedText(line) : line;
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
This PR fixes truncation in the TUI session picker by removing the fixed 30-character cap for session labels and using terminal width dynamically. On wide terminals, longer session names now remain visible instead of being cut early, while narrow terminals continue to render safely.

## Problem
In `src/tui/components/searchable-select-list.ts`, the label width inside the description layout was hard-capped:

```ts
const maxValueWidth = Math.min(30, width - prefixWidth - 4);
```

That meant even when plenty of horizontal space was available, labels still truncated at ~30 chars. This is especially painful when many sessions share similar prefixes (e.g. channel-scoped or agent-scoped names), because distinguishing context appears only after the cutoff.

## Solution
The rendering logic now allocates width based on available terminal space instead of a fixed label cap.

### Before
- Label width: fixed ceiling of 30 chars
- Spacing tied to a fixed label column target (`32`)
- Description shown only after this constrained layout

### After
- Compute available width from terminal width and line prefix
- Reserve only a small minimum description width (12 chars) plus spacing
- Let the label consume the rest (`availableWidth - minDescriptionWidth - spacing`)
- Use remaining width for description dynamically

Key behavior:

```ts
const availableWidth = Math.max(1, width - prefixWidth - 2);
const maxValueWidth = availableWidth - minDescriptionWidth - spacingWidth;
```

This preserves a two-field layout when possible, but no longer wastes half the terminal on wide screens.

## Edge Cases
- **Narrow terminals:** logic keeps minimum guards and falls back cleanly to the existing label-only path when there isn’t enough room.
- **Descriptions absent:** unaffected; existing non-description branch still applies.
- **Selected vs non-selected rows:** highlighting/theming behavior is unchanged.

## Testing
- Ran lint as requested:

```bash
npm run lint
# Found 0 warnings and 0 errors.
```

- Verified changed files:

```bash
git diff main --name-only
# src/tui/components/searchable-select-list.ts
```

So the change is scoped to one file and passes lint cleanly.

## AI Disclosure
This PR was prepared with AI assistance (implementation drafting, diff iteration, and PR text composition), then validated via local linting and repository checks before submission.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Replaces fixed 30-character label width cap with dynamic terminal width calculation in the TUI session picker. The change allows session labels to consume available horizontal space while preserving a minimum 12-character description width. The new layout logic correctly accounts for ANSI highlighting codes, maintains proper spacing, and includes appropriate bounds checking for narrow terminals. The math has been verified to prevent overflow and ensure the total line width stays within terminal bounds.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change is mathematically sound with proper bounds checking, well-scoped to a single rendering function, preserves all fallback paths for narrow terminals, and has passed linting. The logic correctly handles ANSI codes via `visibleWidth()` and maintains layout constraints.
- No files require special attention

<sub>Last reviewed commit: 1a68012</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->