### PR TITLE
fix: retry on transient API errors (overloaded, rate-limit, timeout)

### DIFF
--- a/src/agents/pi-embedded-helpers.istransienthttperror.e2e.test.ts
+++ b/src/agents/pi-embedded-helpers.istransienthttperror.e2e.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { isRetryableApiError, isTransientHttpError } from "./pi-embedded-helpers.js";
+
+describe("isTransientHttpError", () => {
+  it("returns true for retryable 5xx status codes", () => {
+    expect(isTransientHttpError("500 Internal Server Error")).toBe(true);
+    expect(isTransientHttpError("502 Bad Gateway")).toBe(true);
+    expect(isTransientHttpError("503 Service Unavailable")).toBe(true);
+    expect(isTransientHttpError("521 <!DOCTYPE html><html></html>")).toBe(true);
+    expect(isTransientHttpError("529 Overloaded")).toBe(true);
+  });
+
+  it("returns false for non-retryable or non-http text", () => {
+    expect(isTransientHttpError("504 Gateway Timeout")).toBe(false);
+    expect(isTransientHttpError("429 Too Many Requests")).toBe(false);
+    expect(isTransientHttpError("network timeout")).toBe(false);
+  });
+});
+
+describe("isRetryableApiError", () => {
+  it("returns true for transient HTTP errors", () => {
+    expect(isRetryableApiError("500 Internal Server Error")).toBe(true);
+    expect(isRetryableApiError("502 Bad Gateway")).toBe(true);
+    expect(isRetryableApiError("503 Service Unavailable")).toBe(true);
+  });
+
+  it("returns true for overloaded errors", () => {
+    expect(
+      isRetryableApiError(
+        '{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
+      ),
+    ).toBe(true);
+    expect(isRetryableApiError("overloaded_error: Overloaded")).toBe(true);
+    expect(isRetryableApiError("Server is overloaded")).toBe(true);
+  });
+
+  it("returns true for rate limit errors", () => {
+    expect(isRetryableApiError("rate_limit: too many requests")).toBe(true);
+    expect(isRetryableApiError("429 Too Many Requests")).toBe(true);
+  });
+
+  it("returns true for timeout errors", () => {
+    expect(isRetryableApiError("request timed out")).toBe(true);
+    expect(isRetryableApiError("deadline exceeded")).toBe(true);
+  });
+
+  it("returns false for auth errors", () => {
+    expect(isRetryableApiError("invalid_api_key")).toBe(false);
+    expect(isRetryableApiError("unauthorized")).toBe(false);
+  });
+
+  it("returns false for billing errors", () => {
+    expect(isRetryableApiError("insufficient credits")).toBe(false);
+    expect(isRetryableApiError("payment required")).toBe(false);
+  });
+
+  it("returns false for empty strings", () => {
+    expect(isRetryableApiError("")).toBe(false);
+  });
+});

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -34,6 +34,7 @@ export {
   isRawApiErrorPayload,
   isRateLimitAssistantError,
   isRateLimitErrorMessage,
+  isRetryableApiError,
   isTransientHttpError,
   isTimeoutErrorMessage,
   parseImageDimensionError,

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -696,6 +696,20 @@ function isJsonApiInternalServerError(raw: string): boolean {
   return value.includes('"type":"api_error"') && value.includes("internal server error");
 }
 
+/**
+ * Returns true for transient provider errors eligible for automatic retry:
+ * HTTP 5xx, overloaded, rate-limited, and timeout errors.
+ * Non-transient errors (auth 401/403, billing 402, format) are excluded.
+ */
+export function isRetryableApiError(raw: string): boolean {
+  return (
+    isTransientHttpError(raw) ||
+    isOverloadedErrorMessage(raw) ||
+    isRateLimitErrorMessage(raw) ||
+    isTimeoutErrorMessage(raw)
+  );
+}
+
 export function parseImageDimensionError(raw: string): {
   maxDimensionPx?: number;
   messageIndex?: number;

--- a/src/auto-reply/reply/agent-runner.transient-http-retry.test.ts
+++ b/src/auto-reply/reply/agent-runner.transient-http-retry.test.ts
@@ -1,0 +1,217 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { TemplateContext } from "../templating.js";
+import type { FollowupRun, QueueSettings } from "./queue.js";
+import { createMockTypingController } from "./test-helpers.js";
+
+const runEmbeddedPiAgentMock = vi.fn();
+const runtimeErrorMock = vi.fn();
+
+vi.mock("../../agents/model-fallback.js", () => ({
+  runWithModelFallback: async ({
+    provider,
+    model,
+    run,
+  }: {
+    provider: string;
+    model: string;
+    run: (provider: string, model: string) => Promise<unknown>;
+  }) => ({
+    result: await run(provider, model),
+    provider,
+    model,
+  }),
+}));
+
+vi.mock("../../agents/pi-embedded.js", () => ({
+  queueEmbeddedPiMessage: vi.fn().mockReturnValue(false),
+  runEmbeddedPiAgent: (params: unknown) => runEmbeddedPiAgentMock(params),
+}));
+
+vi.mock("../../runtime.js", () => ({
+  defaultRuntime: {
+    log: vi.fn(),
+    error: (...args: unknown[]) => runtimeErrorMock(...args),
+    exit: vi.fn(),
+  },
+}));
+
+vi.mock("./queue.js", async () => {
+  const actual = await vi.importActual<typeof import("./queue.js")>("./queue.js");
+  return {
+    ...actual,
+    enqueueFollowupRun: vi.fn(),
+    scheduleFollowupDrain: vi.fn(),
+  };
+});
+
+import { runReplyAgent } from "./agent-runner.js";
+
+function makeFollowupRun(): FollowupRun {
+  return {
+    prompt: "hello",
+    summaryLine: "hello",
+    enqueuedAt: Date.now(),
+    run: {
+      sessionId: "session",
+      sessionKey: "main",
+      messageProvider: "telegram",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      config: {},
+      skillsSnapshot: {},
+      provider: "anthropic",
+      model: "claude",
+      thinkLevel: "low",
+      verboseLevel: "off",
+      elevatedLevel: "off",
+      bashElevated: {
+        enabled: false,
+        allowed: false,
+        defaultLevel: "off",
+      },
+      timeoutMs: 1_000,
+      blockReplyBreak: "message_end",
+    },
+  } as unknown as FollowupRun;
+}
+
+function callRunReplyAgent() {
+  const typing = createMockTypingController();
+  const sessionCtx = {
+    Provider: "telegram",
+    MessageSid: "msg",
+  } as unknown as TemplateContext;
+  const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
+
+  return runReplyAgent({
+    commandBody: "hello",
+    followupRun: makeFollowupRun(),
+    queueKey: "main",
+    resolvedQueue,
+    shouldSteer: false,
+    shouldFollowup: false,
+    isActive: false,
+    isStreaming: false,
+    typing,
+    sessionCtx,
+    defaultModel: "anthropic/claude-opus-4-5",
+    resolvedVerboseLevel: "off",
+    isNewSession: false,
+    blockStreamingEnabled: false,
+    resolvedBlockStreamingBreak: "message_end",
+    shouldInjectGroupIntro: false,
+    typingMode: "instant",
+  });
+}
+
+describe("runReplyAgent API error retry", () => {
+  beforeEach(() => {
+    runEmbeddedPiAgentMock.mockReset();
+    runtimeErrorMock.mockReset();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("retries once after transient 521 HTML failure and then succeeds", async () => {
+    runEmbeddedPiAgentMock
+      .mockRejectedValueOnce(
+        new Error(
+          `521 <!DOCTYPE html><html lang="en-US"><head><title>Web server is down</title></head><body>Cloudflare</body></html>`,
+        ),
+      )
+      .mockResolvedValueOnce({
+        payloads: [{ text: "Recovered response" }],
+        meta: {},
+      });
+
+    const runPromise = callRunReplyAgent();
+    await vi.advanceTimersByTimeAsync(2_500);
+    const result = await runPromise;
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(2);
+    expect(runtimeErrorMock).toHaveBeenCalledWith(
+      expect.stringContaining("Retryable API error before reply"),
+    );
+
+    const payload = Array.isArray(result) ? result[0] : result;
+    expect(payload?.text).toContain("Recovered response");
+  });
+
+  it("retries on Anthropic overloaded_error and recovers", async () => {
+    runEmbeddedPiAgentMock
+      .mockRejectedValueOnce(
+        new Error('{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}'),
+      )
+      .mockResolvedValueOnce({
+        payloads: [{ text: "Recovered after overload" }],
+        meta: {},
+      });
+
+    const runPromise = callRunReplyAgent();
+    await vi.advanceTimersByTimeAsync(2_500);
+    const result = await runPromise;
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(2);
+    expect(runtimeErrorMock).toHaveBeenCalledWith(
+      expect.stringContaining("Retryable API error before reply (attempt 1/3)"),
+    );
+    const payload = Array.isArray(result) ? result[0] : result;
+    expect(payload?.text).toContain("Recovered after overload");
+  });
+
+  it("retries up to 3 times with increasing backoff then fails", async () => {
+    const overloadedError = new Error("overloaded_error: Overloaded");
+
+    // 1 initial attempt + 3 retries = 4 total attempts, all failing
+    runEmbeddedPiAgentMock
+      .mockRejectedValueOnce(overloadedError)
+      .mockRejectedValueOnce(overloadedError)
+      .mockRejectedValueOnce(overloadedError)
+      .mockRejectedValueOnce(overloadedError);
+
+    const runPromise = callRunReplyAgent();
+    // Advance through all 3 retry delays: 2500 + 5000 + 10000
+    await vi.advanceTimersByTimeAsync(2_500);
+    await vi.advanceTimersByTimeAsync(5_000);
+    await vi.advanceTimersByTimeAsync(10_000);
+    const result = await runPromise;
+
+    // 1 initial + 3 retries = 4 total calls
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(4);
+    // After exhausting retries, the 4th failure falls through to the error response
+    const payload = Array.isArray(result) ? result[0] : result;
+    expect(payload?.text).toContain("Agent failed before reply");
+  });
+
+  it("retries on rate_limit error", async () => {
+    runEmbeddedPiAgentMock
+      .mockRejectedValueOnce(new Error("rate_limit: too many requests"))
+      .mockResolvedValueOnce({
+        payloads: [{ text: "Recovered after rate limit" }],
+        meta: {},
+      });
+
+    const runPromise = callRunReplyAgent();
+    await vi.advanceTimersByTimeAsync(2_500);
+    const result = await runPromise;
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(2);
+    const payload = Array.isArray(result) ? result[0] : result;
+    expect(payload?.text).toContain("Recovered after rate limit");
+  });
+
+  it("does NOT retry on auth errors (401)", async () => {
+    runEmbeddedPiAgentMock.mockRejectedValueOnce(new Error("401 Unauthorized: Invalid API key"));
+
+    const runPromise = callRunReplyAgent();
+    const result = await runPromise;
+
+    // Auth errors are not retryable — should fail immediately
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    const payload = Array.isArray(result) ? result[0] : result;
+    expect(payload?.text).toContain("Agent failed before reply");
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #16106

Sub-agent sessions previously terminated immediately on transient API errors (`overloaded_error`, 5xx, `rate_limit`, timeout) with no retry opportunity. This was especially painful for long-running batch tasks that lost all progress on a single transient failure.

## Changes
- Add `isRetryableApiError()` helper combining transient HTTP (500/502/503/529), overloaded, rate-limit, and timeout detection
- Expand agent runner retry from single attempt (transient HTTP only) to **3 attempts** covering all retryable error types
- Use escalating backoff: **2.5s → 5s → 10s**
- Non-transient errors (auth 401/403, billing 402) continue to fail immediately
- Sanitize user-facing messages for all retryable error types

## Test Plan
- [x] Unit tests for `isRetryableApiError()` covering all error categories
- [x] Integration test: recovers after `overloaded_error`
- [x] Integration test: retries up to 3 times with increasing backoff then fails gracefully
- [x] Integration test: retries on `rate_limit` errors
- [x] Integration test: does NOT retry on auth errors (401)
- [x] All 53 existing agent-runner tests pass (no regressions)

---
🤖 Generated with Claude Code (issue-hunter-pro)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Expands transient error retry logic in the agent runner from a single retry (transient HTTP only) to up to 3 retries with escalating backoff (2.5s → 5s → 10s) covering overloaded, rate-limit, and timeout errors in addition to HTTP 5xx. Non-transient errors (auth, billing) continue to fail immediately.

- Adds `isRetryableApiError()` helper in `errors.ts` composing existing `isTransientHttpError`, `isOverloadedErrorMessage`, `isRateLimitErrorMessage`, and `isTimeoutErrorMessage` detectors
- Replaces boolean `didRetryTransientHttpError` flag with counter-based `apiRetryAttempt` supporting 3 retry attempts in `agent-runner-execution.ts`
- Extends error sanitization to cover all retryable error types in the post-retry failure path
- Comprehensive test coverage: unit tests for the new helper plus integration tests for overloaded recovery, retry exhaustion with backoff, rate-limit retry, and auth error non-retry

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it broadens existing retry behavior with well-bounded retries, correct backoff logic, and thorough test coverage.
- The changes are well-scoped and low-risk: the new `isRetryableApiError` is a straightforward composition of existing, well-tested helpers. The retry logic in `agent-runner-execution.ts` is a clean upgrade from a boolean flag to a bounded counter with escalating backoff. Non-retryable errors (auth, billing) are correctly excluded. All edge cases are covered by tests — unit tests for the helper function and integration tests for the retry behavior including exhaustion, backoff timing, and non-retry paths. The maximum retry count (3) and backoff ceiling (10s) prevent runaway retry loops.
- No files require special attention.

<sub>Last reviewed commit: cdc8daf</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->