### PR TITLE
fix(discord): accept @everyone/@role mentions when requireMention is enabled

### DIFF
--- a/src/auto-reply/reply/mentions.test.ts
+++ b/src/auto-reply/reply/mentions.test.ts
@@ -55,4 +55,18 @@ describe("matchesMentionWithExplicit", () => {
     });
     expect(result).toBe(true);
   });
+
+  it("can treat any mention as explicit for channel-specific behavior", () => {
+    const result = matchesMentionWithExplicit({
+      text: "@everyone wake up",
+      mentionRegexes: [],
+      explicit: {
+        hasAnyMention: true,
+        isExplicitlyMentioned: false,
+        canResolveExplicit: true,
+        acceptAnyMentionAsExplicit: true,
+      },
+    });
+    expect(result).toBe(true);
+  });
 });

--- a/src/auto-reply/reply/mentions.ts
+++ b/src/auto-reply/reply/mentions.ts
@@ -84,6 +84,11 @@ export type ExplicitMentionSignal = {
   hasAnyMention: boolean;
   isExplicitlyMentioned: boolean;
   canResolveExplicit: boolean;
+  /**
+   * Some channels (e.g., Discord) treat @everyone / @role as valid mention triggers
+   * even when they are not direct user mentions.
+   */
+  acceptAnyMentionAsExplicit?: boolean;
 };
 
 export function matchesMentionWithExplicit(params: {
@@ -96,12 +101,16 @@ export function matchesMentionWithExplicit(params: {
   const explicit = params.explicit?.isExplicitlyMentioned === true;
   const explicitAvailable = params.explicit?.canResolveExplicit === true;
   const hasAnyMention = params.explicit?.hasAnyMention === true;
+  const acceptAnyMentionAsExplicit = params.explicit?.acceptAnyMentionAsExplicit === true;
 
   // Check transcript if text is empty and transcript is provided
   const transcriptCleaned = params.transcript ? normalizeMentionText(params.transcript) : "";
   const textToCheck = cleaned || transcriptCleaned;
 
   if (hasAnyMention && explicitAvailable) {
+    if (acceptAnyMentionAsExplicit) {
+      return true;
+    }
     return explicit || params.mentionRegexes.some((re) => re.test(textToCheck));
   }
   if (!textToCheck) {

--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -435,6 +435,7 @@ export async function preflightDiscordMessage(
         hasAnyMention,
         isExplicitlyMentioned: explicitlyMentioned,
         canResolveExplicit: Boolean(botId),
+        acceptAnyMentionAsExplicit: isGuildMessage,
       },
       transcript: preflightTranscript,
     });


### PR DESCRIPTION
Closes #16221

## Summary
- allow Discord guild mention-gating to treat `@everyone` and role mentions as explicit mention triggers
- keep existing direct bot mention + mention pattern behavior unchanged
- add unit test coverage in `mentions.test.ts` for the new explicit-any-mention channel behavior

## Why
With `requireMention: true`, Discord messages that mention `@everyone` or a role were being dropped even though they are valid mention events in guild channels.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds support for treating `@everyone` and `@role` mentions as valid mention triggers in Discord guild channels when `requireMention` is enabled. It introduces a new `acceptAnyMentionAsExplicit` flag on the `ExplicitMentionSignal` type, which short-circuits `matchesMentionWithExplicit` to return `true` whenever any mention is present.

- Adds `acceptAnyMentionAsExplicit` optional field to `ExplicitMentionSignal` in `mentions.ts`
- Sets `acceptAnyMentionAsExplicit: isGuildMessage` in the Discord preflight handler
- Adds one unit test covering the `@everyone` happy path
- **Issue**: The flag is set to `isGuildMessage` unconditionally, but `hasAnyMention` includes `mentionedUsers?.length > 0`. This means the bot will also respond when *any other user* is mentioned (e.g., `@someOtherUser hello`), not just for `@everyone`/`@role` as described in the PR. The flag should be narrowed to only fire for everyone/role mentions.

<h3>Confidence Score: 2/5</h3>

- This PR has a logic issue that could cause unintended bot responses in guild channels whenever any user is mentioned.
- The core change (`acceptAnyMentionAsExplicit: isGuildMessage`) is too broad because `hasAnyMention` already includes any user mention, not just `@everyone`/`@role`. A guild message like `@someOtherUser hello` would incorrectly pass the mention gate and trigger a bot response. The fix is straightforward (narrow the flag to everyone/role cases only), but as written this would change behavior for all guild messages with any mention.
- `src/discord/monitor/message-handler.preflight.ts` — the `acceptAnyMentionAsExplicit: isGuildMessage` assignment needs to be scoped to `@everyone`/`@role` mentions only.

<sub>Last reviewed commit: 3e417cc</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->