### PR TITLE
fix(cron): pass agent identity through delivery path (#16218)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 - Security/Archive: enforce archive extraction entry/size limits to prevent resource exhaustion from high-expansion ZIP/TAR archives. Thanks @vincentkoc.
 - Security/Media: reject oversized base64-backed input media before decoding to avoid large allocations. Thanks @vincentkoc.
 - Security/Gateway: reject oversized base64 chat attachments before decoding to avoid large allocations. Thanks @vincentkoc.
+- Cron/Slack: preserve agent identity (name and icon) when cron jobs deliver outbound messages. (#16242) Thanks @robbyczgw-cla.
 
 ## 2026.2.14
 

--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -127,6 +127,7 @@ openclaw gateway
 - Config tokens override env fallback.
 - `SLACK_BOT_TOKEN` / `SLACK_APP_TOKEN` env fallback applies only to the default account.
 - `userToken` (`xoxp-...`) is config-only (no env fallback) and defaults to read-only behavior (`userTokenReadOnly: true`).
+- Optional: add `chat:write.customize` if you want outgoing messages to use the active agent identity (custom `username` and icon). `icon_emoji` uses `:emoji_name:` syntax.
 
 <Tip>
 For actions/directory reads, user token can be preferred when configured. For writes, bot token remains preferred; user-token writes are only allowed when `userTokenReadOnly: false` and bot token is unavailable.

--- a/src/channels/plugins/outbound/slack.ts
+++ b/src/channels/plugins/outbound/slack.ts
@@ -45,9 +45,9 @@ export const slackOutbound: ChannelOutboundAdapter = {
     const result = await send(to, finalText, {
       threadTs,
       accountId: accountId ?? undefined,
-      username,
-      icon_url,
-      icon_emoji,
+      ...(username ? { username } : {}),
+      ...(icon_url ? { icon_url } : {}),
+      ...(icon_emoji && !icon_url ? { icon_emoji } : {}),
     });
     return { channel: "slack", ...result };
   },
@@ -92,9 +92,9 @@ export const slackOutbound: ChannelOutboundAdapter = {
       mediaUrl,
       threadTs,
       accountId: accountId ?? undefined,
-      username,
-      icon_url,
-      icon_emoji,
+      ...(username ? { username } : {}),
+      ...(icon_url ? { icon_url } : {}),
+      ...(icon_emoji && !icon_url ? { icon_emoji } : {}),
     });
     return { channel: "slack", ...result };
   },

--- a/src/channels/plugins/outbound/slack.ts
+++ b/src/channels/plugins/outbound/slack.ts
@@ -6,7 +6,17 @@ export const slackOutbound: ChannelOutboundAdapter = {
   deliveryMode: "direct",
   chunker: null,
   textChunkLimit: 4000,
-  sendText: async ({ to, text, accountId, deps, replyToId, threadId }) => {
+  sendText: async ({
+    to,
+    text,
+    accountId,
+    deps,
+    replyToId,
+    threadId,
+    username,
+    icon_url,
+    icon_emoji,
+  }) => {
     const send = deps?.sendSlack ?? sendMessageSlack;
     // Use threadId fallback so routed tool notifications stay in the Slack thread.
     const threadTs = replyToId ?? (threadId != null ? String(threadId) : undefined);
@@ -35,10 +45,24 @@ export const slackOutbound: ChannelOutboundAdapter = {
     const result = await send(to, finalText, {
       threadTs,
       accountId: accountId ?? undefined,
+      username,
+      icon_url,
+      icon_emoji,
     });
     return { channel: "slack", ...result };
   },
-  sendMedia: async ({ to, text, mediaUrl, accountId, deps, replyToId, threadId }) => {
+  sendMedia: async ({
+    to,
+    text,
+    mediaUrl,
+    accountId,
+    deps,
+    replyToId,
+    threadId,
+    username,
+    icon_url,
+    icon_emoji,
+  }) => {
     const send = deps?.sendSlack ?? sendMessageSlack;
     // Use threadId fallback so routed tool notifications stay in the Slack thread.
     const threadTs = replyToId ?? (threadId != null ? String(threadId) : undefined);
@@ -68,6 +92,9 @@ export const slackOutbound: ChannelOutboundAdapter = {
       mediaUrl,
       threadTs,
       accountId: accountId ?? undefined,
+      username,
+      icon_url,
+      icon_emoji,
     });
     return { channel: "slack", ...result };
   },

--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -79,6 +79,9 @@ export type ChannelOutboundContext = {
   replyToId?: string | null;
   threadId?: string | number | null;
   accountId?: string | null;
+  username?: string;
+  icon_url?: string;
+  icon_emoji?: string;
   deps?: OutboundSendDeps;
   silent?: boolean;
 };

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -14,6 +14,7 @@ import { getCliSessionId, setCliSessionId } from "../../agents/cli-session.js";
 import { lookupContextTokens } from "../../agents/context.js";
 import { resolveCronStyleNow } from "../../agents/current-time.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../../agents/defaults.js";
+import { resolveAgentIdentity } from "../../agents/identity.js";
 import { loadModelCatalog } from "../../agents/model-catalog.js";
 import { runWithModelFallback } from "../../agents/model-fallback.js";
 import {
@@ -555,21 +556,40 @@ export async function runCronIsolatedAgentTurn(params: {
       logWarn(`[cron:${params.job.id}] ${message}`);
       return withRunSession({ status: "ok", summary, outputText });
     }
-    // Shared subagent announce flow is text-based; keep direct outbound delivery
-    // for media/channel payloads so structured content is preserved.
-    if (deliveryPayloadHasStructuredContent) {
+    const agentIdentity = resolveAgentIdentity(cfgWithAgentDefaults, agentId);
+    const identityAvatar = agentIdentity?.avatar?.trim();
+    const username = agentIdentity?.name?.trim() || undefined;
+    const icon_url = identityAvatar?.startsWith("http") ? identityAvatar : undefined;
+    const icon_emoji = !identityAvatar?.startsWith("http")
+      ? agentIdentity?.emoji?.trim() || undefined
+      : undefined;
+
+    // Shared subagent announce flow is text-based. When we have an explicit sender
+    // identity to preserve, prefer direct outbound delivery even for plain-text payloads.
+    if (deliveryPayloadHasStructuredContent || username || icon_url || icon_emoji) {
       try {
-        const deliveryResults = await deliverOutboundPayloads({
-          cfg: cfgWithAgentDefaults,
-          channel: resolvedDelivery.channel,
-          to: resolvedDelivery.to,
-          accountId: resolvedDelivery.accountId,
-          threadId: resolvedDelivery.threadId,
-          payloads: deliveryPayloads,
-          bestEffort: deliveryBestEffort,
-          deps: createOutboundSendDeps(params.deps),
-        });
-        delivered = deliveryResults.length > 0;
+        const payloadsForDelivery =
+          deliveryPayloadHasStructuredContent && deliveryPayloads.length > 0
+            ? deliveryPayloads
+            : synthesizedText
+              ? [{ text: synthesizedText }]
+              : [];
+        if (payloadsForDelivery.length > 0) {
+          const deliveryResults = await deliverOutboundPayloads({
+            cfg: cfgWithAgentDefaults,
+            channel: resolvedDelivery.channel,
+            to: resolvedDelivery.to,
+            accountId: resolvedDelivery.accountId,
+            threadId: resolvedDelivery.threadId,
+            payloads: payloadsForDelivery,
+            username,
+            icon_url,
+            icon_emoji,
+            bestEffort: deliveryBestEffort,
+            deps: createOutboundSendDeps(params.deps),
+          });
+          delivered = deliveryResults.length > 0;
+        }
       } catch (err) {
         if (!deliveryBestEffort) {
           return withRunSession({ status: "error", summary, outputText, error: String(err) });

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -85,6 +85,9 @@ async function createChannelHandler(params: {
   accountId?: string;
   replyToId?: string | null;
   threadId?: string | number | null;
+  username?: string;
+  icon_url?: string;
+  icon_emoji?: string;
   deps?: OutboundSendDeps;
   gifPlayback?: boolean;
   silent?: boolean;
@@ -101,6 +104,9 @@ async function createChannelHandler(params: {
     accountId: params.accountId,
     replyToId: params.replyToId,
     threadId: params.threadId,
+    username: params.username,
+    icon_url: params.icon_url,
+    icon_emoji: params.icon_emoji,
     deps: params.deps,
     gifPlayback: params.gifPlayback,
     silent: params.silent,
@@ -119,6 +125,9 @@ function createPluginHandler(params: {
   accountId?: string;
   replyToId?: string | null;
   threadId?: string | number | null;
+  username?: string;
+  icon_url?: string;
+  icon_emoji?: string;
   deps?: OutboundSendDeps;
   gifPlayback?: boolean;
   silent?: boolean;
@@ -145,6 +154,9 @@ function createPluginHandler(params: {
             accountId: params.accountId,
             replyToId: params.replyToId,
             threadId: params.threadId,
+            username: params.username,
+            icon_url: params.icon_url,
+            icon_emoji: params.icon_emoji,
             gifPlayback: params.gifPlayback,
             deps: params.deps,
             silent: params.silent,
@@ -159,6 +171,9 @@ function createPluginHandler(params: {
         accountId: params.accountId,
         replyToId: params.replyToId,
         threadId: params.threadId,
+        username: params.username,
+        icon_url: params.icon_url,
+        icon_emoji: params.icon_emoji,
         gifPlayback: params.gifPlayback,
         deps: params.deps,
         silent: params.silent,
@@ -172,6 +187,9 @@ function createPluginHandler(params: {
         accountId: params.accountId,
         replyToId: params.replyToId,
         threadId: params.threadId,
+        username: params.username,
+        icon_url: params.icon_url,
+        icon_emoji: params.icon_emoji,
         gifPlayback: params.gifPlayback,
         deps: params.deps,
         silent: params.silent,
@@ -189,6 +207,9 @@ export async function deliverOutboundPayloads(params: {
   payloads: ReplyPayload[];
   replyToId?: string | null;
   threadId?: string | number | null;
+  username?: string;
+  icon_url?: string;
+  icon_emoji?: string;
   deps?: OutboundSendDeps;
   gifPlayback?: boolean;
   abortSignal?: AbortSignal;
@@ -271,6 +292,9 @@ async function deliverOutboundPayloadsCore(params: {
   payloads: ReplyPayload[];
   replyToId?: string | null;
   threadId?: string | number | null;
+  username?: string;
+  icon_url?: string;
+  icon_emoji?: string;
   deps?: OutboundSendDeps;
   gifPlayback?: boolean;
   abortSignal?: AbortSignal;
@@ -299,6 +323,9 @@ async function deliverOutboundPayloadsCore(params: {
     accountId,
     replyToId: params.replyToId,
     threadId: params.threadId,
+    username: params.username,
+    icon_url: params.icon_url,
+    icon_emoji: params.icon_emoji,
     gifPlayback: params.gifPlayback,
     silent: params.silent,
   });

--- a/src/slack/send.ts
+++ b/src/slack/send.ts
@@ -33,7 +33,71 @@ type SlackSendOpts = {
   mediaUrl?: string;
   client?: WebClient;
   threadTs?: string;
+  username?: string;
+  icon_url?: string;
+  icon_emoji?: string;
 };
+
+function hasCustomIdentity(opts: SlackSendOpts): boolean {
+  return Boolean(opts.username || opts.icon_url || opts.icon_emoji);
+}
+
+function isSlackCustomizeScopeError(err: unknown): boolean {
+  if (!(err instanceof Error)) {
+    return false;
+  }
+  const maybeData = err as Error & {
+    data?: {
+      error?: string;
+      needed?: string;
+      response_metadata?: { scopes?: string[]; acceptedScopes?: string[] };
+    };
+  };
+  const code = maybeData.data?.error?.toLowerCase();
+  if (code !== "missing_scope") {
+    return false;
+  }
+  const needed = maybeData.data?.needed?.toLowerCase();
+  if (needed?.includes("chat:write.customize")) {
+    return true;
+  }
+  const scopes = [
+    ...(maybeData.data?.response_metadata?.scopes ?? []),
+    ...(maybeData.data?.response_metadata?.acceptedScopes ?? []),
+  ].map((scope) => scope.toLowerCase());
+  return scopes.includes("chat:write.customize");
+}
+
+async function postSlackMessageBestEffort(params: {
+  client: WebClient;
+  channelId: string;
+  text: string;
+  threadTs?: string;
+  opts: SlackSendOpts;
+}) {
+  const basePayload = {
+    channel: params.channelId,
+    text: params.text,
+    thread_ts: params.threadTs,
+  };
+  const payload = {
+    ...basePayload,
+    ...(params.opts.username ? { username: params.opts.username } : {}),
+    ...(params.opts.icon_url ? { icon_url: params.opts.icon_url } : {}),
+    ...(params.opts.icon_emoji && !params.opts.icon_url
+      ? { icon_emoji: params.opts.icon_emoji }
+      : {}),
+  };
+  try {
+    return await params.client.chat.postMessage(payload);
+  } catch (err) {
+    if (!hasCustomIdentity(params.opts) || !isSlackCustomizeScopeError(err)) {
+      throw err;
+    }
+    logVerbose("slack send: missing chat:write.customize, retrying without custom identity");
+    return params.client.chat.postMessage(basePayload);
+  }
+}
 
 export type SlackSendResult = {
   messageId: string;
@@ -182,19 +246,23 @@ export async function sendMessageSlack(
       maxBytes: mediaMaxBytes,
     });
     for (const chunk of rest) {
-      const response = await client.chat.postMessage({
-        channel: channelId,
+      const response = await postSlackMessageBestEffort({
+        client,
+        channelId,
         text: chunk,
-        thread_ts: opts.threadTs,
+        threadTs: opts.threadTs,
+        opts,
       });
       lastMessageId = response.ts ?? lastMessageId;
     }
   } else {
     for (const chunk of chunks.length ? chunks : [""]) {
-      const response = await client.chat.postMessage({
-        channel: channelId,
+      const response = await postSlackMessageBestEffort({
+        client,
+        channelId,
         text: chunk,
-        thread_ts: opts.threadTs,
+        threadTs: opts.threadTs,
+        opts,
       });
       lastMessageId = response.ts ?? lastMessageId;
     }


### PR DESCRIPTION
## Summary
This PR fixes cron outbound delivery so agent identity is preserved end-to-end when sending through `deliverOutboundPayloads`. Cron-generated messages were being delivered without the configured agent persona (name/avatar/emoji), which caused anonymous/default bot presentation in Slack.

## Problem
Cron delivery for isolated agent runs was successfully producing outbound payloads, but those messages appeared as the default app/bot identity instead of the configured agent identity. In practice, this made scheduled agent reports look like generic system posts rather than messages from the intended agent persona.

## Root cause
Identity fields were not threaded through the outbound delivery plumbing:
- `deliverOutboundPayloads` did not accept/pass `username`, `icon_url`, `icon_emoji`
- `createChannelHandler` / `createPluginHandler` did not forward identity values into channel adapters
- Cron runner (`src/cron/isolated-agent/run.ts`) did not resolve and attach identity for outbound structured delivery

## Solution
I implemented minimal, targeted plumbing across the delivery path:

```ts
// src/infra/outbound/deliver.ts
export async function deliverOutboundPayloads(params: {
  ...
  username?: string;
  icon_url?: string;
  icon_emoji?: string;
})
```

These fields are now forwarded into:
- `createChannelHandler(...)`
- `createPluginHandler(...)`
- `sendPayload`, `sendText`, and `sendMedia` adapter calls

Cron path now resolves and supplies identity:

```ts
const agentIdentity = resolveAgentIdentity(cfgWithAgentDefaults, agentId);
const identityAvatar = agentIdentity?.avatar?.trim();

await deliverOutboundPayloads({
  ...,
  username: agentIdentity?.name?.trim() || undefined,
  icon_url: identityAvatar?.startsWith("http") ? identityAvatar : undefined,
  icon_emoji: !identityAvatar?.startsWith("http")
    ? agentIdentity?.emoji?.trim() || undefined
    : undefined,
});
```

Slack outbound/send was also updated to accept and pass customize fields to `chat.postMessage` when present.

## Before / After
- **Before:** cron outbound messages often appeared as default bot identity (anonymous/generic)
- **After:** cron outbound messages carry configured agent identity (name + avatar/emoji) when available

## Edge cases considered
- Identity fields are optional and only applied when present
- `icon_emoji` is only sent when `icon_url` is absent
- Non-HTTP avatar values do not incorrectly populate `icon_url`
- Non-Slack channels remain unaffected unless they choose to consume the new optional context fields

## Testing
- `npm run lint` passes cleanly
- Scope intentionally minimal (5 files)
- Existing delivery behavior remains unchanged except identity threading

## AI Disclosure
This PR was prepared with AI assistance. I reviewed the code path, implemented the changes, and validated lint locally before opening the PR.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds agent identity threading (name, avatar, emoji) through the outbound delivery pipeline to fix cron-generated messages appearing as the default bot identity instead of the configured agent persona in Slack.

**Key changes:**
- Added optional `username`, `icon_url`, and `icon_emoji` parameters to `ChannelOutboundContext` type
- Threaded these parameters through `deliverOutboundPayloads`, `createChannelHandler`, and `createPluginHandler` in `deliver.ts`
- Updated Slack outbound adapter (`sendText` and `sendMedia`) to accept and forward identity fields to `sendMessageSlack`
- Modified `sendMessageSlack` to conditionally include identity fields in `chat.postMessage` calls
- Cron isolated agent runner now resolves agent identity and supplies it during outbound delivery

**Implementation quality:**
The implementation correctly ensures mutual exclusivity between `icon_url` and `icon_emoji` (Slack only accepts one). The avatar URL validation using `startsWith("http")` is simple but effective. All parameters are optional and only applied when present, maintaining backward compatibility. The changes are minimal and focused, affecting only 5 files.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are minimal, well-scoped, and follow a clear pattern. The identity fields are optional and properly threaded through the delivery pipeline without affecting existing behavior. The mutual exclusivity logic for `icon_url` and `icon_emoji` is correct according to Slack's API requirements. Other channels properly ignore these optional fields. No breaking changes or risky refactoring.
- No files require special attention

<sub>Last reviewed commit: 0bc773b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->