### PR TITLE
fix(plugins): prefer config/workspace/global over bundled for same plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - macOS: hard-limit unkeyed `openclaw://agent` deep links and ignore `deliver` / `to` / `channel` unless a valid unattended key is provided. Thanks @Cillian-Collins.
+- Plugins: suppress false duplicate plugin id warnings when the same extension is discovered via multiple paths (config/workspace/global vs bundled), while still warning on genuine duplicates. (#16222) Thanks @shadril238.
 
 ## 2026.2.14
 


### PR DESCRIPTION
Follow-up to #16222.

When the same physical plugin directory is discovered multiple ways (symlink / path normalization), suppress the duplicate warning and ensure the manifest registry consistently prefers higher-precedence origins:

config > workspace > global > bundled

Adds regression coverage.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Follow-up to #16222. When the same physical plugin directory is discovered via multiple paths (symlinks, path normalization), this PR ensures the manifest registry consistently prefers higher-precedence origins (config > workspace > global > bundled) instead of keeping whichever was encountered first. False-positive duplicate warnings remain suppressed for same-directory candidates.

- Introduced `pluginOriginRank()` helper with explicit precedence ordering and a `SeenIdEntry` type to track both the candidate and its position in the records array
- When a same-physical-directory duplicate is detected with higher precedence, the existing record is replaced in-place via array index assignment
- Moved `configSchema`/`schemaCacheKey` computation earlier so it is available for the replacement code path
- Added regression test covering bundled-vs-config precedence using equivalent-but-different path representations
- Updated `CHANGELOG.md` with fix description

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a focused, well-tested bug fix with no risk to existing behavior.
- The change is narrowly scoped to the duplicate-detection branch in `loadPluginManifestRegistry`. The new `pluginOriginRank` function exhaustively covers all `PluginOrigin` values. The in-place replacement via `recordIndex` is correct and handles edge cases (multiple duplicates, equal precedence). Pre-existing behavior for genuine duplicates (different physical dirs) is completely unchanged. A regression test covers the new path. No security implications.
- No files require special attention.

<sub>Last reviewed commit: fd0dca8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->