### PR TITLE
feat(agents): declarative agent definitions for sessions_spawn

### DIFF
--- a/src/agents/agent-definitions/index.ts
+++ b/src/agents/agent-definitions/index.ts
@@ -1,0 +1,8 @@
+export { parseAgentDefinition, parseAgentDefinitionFrontmatter } from "./loader.js";
+export { loadAgentDefinitions, resolveAgentDefinition } from "./workspace.js";
+export type {
+  AgentDefinition,
+  AgentDefinitionFrontmatter,
+  AgentDefinitionSource,
+  AgentDefinitionToolPolicy,
+} from "./types.js";

--- a/src/agents/agent-definitions/loader.test.ts
+++ b/src/agents/agent-definitions/loader.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest";
+import { parseAgentDefinition, parseAgentDefinitionFrontmatter } from "./loader.js";
+
+describe("parseAgentDefinitionFrontmatter", () => {
+  it("parses a complete frontmatter object", () => {
+    const result = parseAgentDefinitionFrontmatter({
+      name: "explorer",
+      description: "Read-only codebase exploration",
+      model: "google/gemini-2.5-flash",
+      tools: {
+        allow: ["read", "web_search"],
+        deny: ["write", "edit"],
+      },
+    });
+    expect(result).toEqual({
+      name: "explorer",
+      description: "Read-only codebase exploration",
+      model: "google/gemini-2.5-flash",
+      tools: {
+        allow: ["read", "web_search"],
+        deny: ["write", "edit"],
+      },
+    });
+  });
+
+  it("returns null when name is missing", () => {
+    const result = parseAgentDefinitionFrontmatter({
+      description: "No name agent",
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when name is empty string", () => {
+    const result = parseAgentDefinitionFrontmatter({
+      name: "  ",
+    });
+    expect(result).toBeNull();
+  });
+
+  it("handles missing optional fields", () => {
+    const result = parseAgentDefinitionFrontmatter({
+      name: "minimal",
+    });
+    expect(result).toEqual({
+      name: "minimal",
+      description: undefined,
+      model: undefined,
+      tools: undefined,
+    });
+  });
+
+  it("parses comma-separated tool lists", () => {
+    const result = parseAgentDefinitionFrontmatter({
+      name: "test",
+      tools: {
+        allow: "read, write, edit",
+      },
+    });
+    expect(result?.tools?.allow).toEqual(["read", "write", "edit"]);
+  });
+
+  it("ignores empty tools object", () => {
+    const result = parseAgentDefinitionFrontmatter({
+      name: "test",
+      tools: {},
+    });
+    expect(result?.tools).toBeUndefined();
+  });
+});
+
+describe("parseAgentDefinition", () => {
+  it("parses a full agent definition markdown file", () => {
+    const content = [
+      "---",
+      "name: explorer",
+      'description: "Read-only codebase exploration"',
+      "model: google/gemini-2.5-flash",
+      "tools:",
+      "  allow:",
+      "    - read",
+      "    - web_search",
+      "  deny:",
+      "    - write",
+      "    - edit",
+      "---",
+      "",
+      "You are a code explorer. Find and summarize relevant code.",
+    ].join("\n");
+
+    const result = parseAgentDefinition(content, {
+      filePath: "/workspace/agents/explorer.md",
+      source: "workspace",
+    });
+
+    expect(result).toEqual({
+      name: "explorer",
+      description: "Read-only codebase exploration",
+      model: "google/gemini-2.5-flash",
+      tools: {
+        allow: ["read", "web_search"],
+        deny: ["write", "edit"],
+      },
+      systemPrompt: "You are a code explorer. Find and summarize relevant code.",
+      source: "workspace",
+      filePath: "/workspace/agents/explorer.md",
+    });
+  });
+
+  it("falls back to filename-based name when frontmatter has no name", () => {
+    const content = [
+      "---",
+      'description: "A researcher agent"',
+      "---",
+      "",
+      "Research things.",
+    ].join("\n");
+
+    const result = parseAgentDefinition(content, {
+      filePath: "/workspace/agents/researcher.md",
+      source: "workspace",
+      filenameName: "researcher",
+    });
+
+    expect(result?.name).toBe("researcher");
+    expect(result?.description).toBe("A researcher agent");
+    expect(result?.systemPrompt).toBe("Research things.");
+  });
+
+  it("returns null for content without frontmatter", () => {
+    const result = parseAgentDefinition("Just some text.", {
+      filePath: "/workspace/agents/bad.md",
+      source: "workspace",
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null for invalid YAML frontmatter", () => {
+    const content = ["---", "invalid: [unclosed", "---", "", "Body."].join("\n");
+    const result = parseAgentDefinition(content, {
+      filePath: "/workspace/agents/bad.md",
+      source: "workspace",
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when neither name nor filenameName is provided", () => {
+    const content = ["---", 'description: "No name"', "---", "", "Body."].join("\n");
+    const result = parseAgentDefinition(content, {
+      filePath: "/workspace/agents/test.md",
+      source: "workspace",
+    });
+    expect(result).toBeNull();
+  });
+
+  it("handles empty body after frontmatter", () => {
+    const content = ["---", "name: minimal", "---"].join("\n");
+    const result = parseAgentDefinition(content, {
+      filePath: "/workspace/agents/minimal.md",
+      source: "workspace",
+    });
+    expect(result?.name).toBe("minimal");
+    expect(result?.systemPrompt).toBeUndefined();
+  });
+
+  it("preserves multiline system prompt", () => {
+    const content = [
+      "---",
+      "name: writer",
+      "---",
+      "",
+      "You are a writer.",
+      "",
+      "Write clear and concise content.",
+      "",
+      "Follow the style guide.",
+    ].join("\n");
+
+    const result = parseAgentDefinition(content, {
+      filePath: "/workspace/agents/writer.md",
+      source: "workspace",
+    });
+
+    expect(result?.systemPrompt).toContain("You are a writer.");
+    expect(result?.systemPrompt).toContain("Follow the style guide.");
+  });
+});

--- a/src/agents/agent-definitions/loader.ts
+++ b/src/agents/agent-definitions/loader.ts
@@ -1,0 +1,121 @@
+import YAML from "yaml";
+import type {
+  AgentDefinition,
+  AgentDefinitionFrontmatter,
+  AgentDefinitionSource,
+  AgentDefinitionToolPolicy,
+} from "./types.js";
+
+function normalizeStringList(input: unknown): string[] | undefined {
+  if (!input) {
+    return undefined;
+  }
+  if (Array.isArray(input)) {
+    const result = input.map((v) => String(v).trim()).filter(Boolean);
+    return result.length > 0 ? result : undefined;
+  }
+  if (typeof input === "string") {
+    const result = input
+      .split(",")
+      .map((v) => v.trim())
+      .filter(Boolean);
+    return result.length > 0 ? result : undefined;
+  }
+  return undefined;
+}
+
+function parseToolPolicy(raw: unknown): AgentDefinitionToolPolicy | undefined {
+  if (!raw || typeof raw !== "object") {
+    return undefined;
+  }
+  const obj = raw as Record<string, unknown>;
+  const allow = normalizeStringList(obj.allow);
+  const deny = normalizeStringList(obj.deny);
+  if (!allow && !deny) {
+    return undefined;
+  }
+  return { allow, deny };
+}
+
+function parseFrontmatterYaml(block: string): Record<string, unknown> | null {
+  try {
+    const parsed = YAML.parse(block) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return null;
+    }
+    return parsed as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function extractFrontmatterBlock(content: string): { block: string; body: string } | null {
+  const normalized = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  if (!normalized.startsWith("---")) {
+    return null;
+  }
+  const endIndex = normalized.indexOf("\n---", 3);
+  if (endIndex === -1) {
+    return null;
+  }
+  const block = normalized.slice(4, endIndex);
+  const body = normalized.slice(endIndex + 4).trim();
+  return { block, body };
+}
+
+export function parseAgentDefinitionFrontmatter(
+  raw: Record<string, unknown>,
+): AgentDefinitionFrontmatter | null {
+  const name = typeof raw.name === "string" ? raw.name.trim() : undefined;
+  if (!name) {
+    return null;
+  }
+  return {
+    name,
+    description:
+      typeof raw.description === "string" ? raw.description.trim() || undefined : undefined,
+    model: typeof raw.model === "string" ? raw.model.trim() || undefined : undefined,
+    tools: parseToolPolicy(raw.tools),
+  };
+}
+
+export function parseAgentDefinition(
+  content: string,
+  opts: { filePath: string; source: AgentDefinitionSource; filenameName?: string },
+): AgentDefinition | null {
+  const extracted = extractFrontmatterBlock(content);
+  if (!extracted) {
+    return null;
+  }
+  const raw = parseFrontmatterYaml(extracted.block);
+  if (!raw) {
+    return null;
+  }
+  const frontmatter = parseAgentDefinitionFrontmatter(raw);
+  if (!frontmatter) {
+    // Fall back to filename-based name if frontmatter has no name field
+    if (opts.filenameName) {
+      const nameFromFile = opts.filenameName;
+      return {
+        name: nameFromFile,
+        description:
+          typeof raw.description === "string" ? raw.description.trim() || undefined : undefined,
+        model: typeof raw.model === "string" ? raw.model.trim() || undefined : undefined,
+        tools: parseToolPolicy(raw.tools),
+        systemPrompt: extracted.body || undefined,
+        source: opts.source,
+        filePath: opts.filePath,
+      };
+    }
+    return null;
+  }
+  return {
+    name: frontmatter.name,
+    description: frontmatter.description,
+    model: frontmatter.model,
+    tools: frontmatter.tools,
+    systemPrompt: extracted.body || undefined,
+    source: opts.source,
+    filePath: opts.filePath,
+  };
+}

--- a/src/agents/agent-definitions/types.ts
+++ b/src/agents/agent-definitions/types.ts
@@ -1,0 +1,43 @@
+/**
+ * Declarative agent definition types.
+ *
+ * Agent definitions are markdown files with YAML frontmatter that define
+ * specialized sub-agent types with scoped tools, models, and system prompts.
+ */
+
+export type AgentDefinitionToolPolicy = {
+  /** Allowlist of tools (supports group names like "group:fs"). */
+  allow?: string[];
+  /** Denylist of tools. */
+  deny?: string[];
+};
+
+export type AgentDefinitionFrontmatter = {
+  /** Unique agent definition name (must match filename without extension). */
+  name: string;
+  /** Human-readable description of the agent's purpose. */
+  description?: string;
+  /** Default model for this agent type (e.g. "google/gemini-2.5-flash"). */
+  model?: string;
+  /** Tool policy for this agent type. */
+  tools?: AgentDefinitionToolPolicy;
+};
+
+export type AgentDefinitionSource = "workspace" | "bundled";
+
+export type AgentDefinition = {
+  /** Agent definition name (derived from filename). */
+  name: string;
+  /** Human-readable description. */
+  description?: string;
+  /** Default model override. */
+  model?: string;
+  /** Tool policy (allow/deny). */
+  tools?: AgentDefinitionToolPolicy;
+  /** System prompt (markdown body after frontmatter). */
+  systemPrompt?: string;
+  /** Where the definition was loaded from. */
+  source: AgentDefinitionSource;
+  /** Absolute path to the definition file. */
+  filePath: string;
+};

--- a/src/agents/agent-definitions/workspace.test.ts
+++ b/src/agents/agent-definitions/workspace.test.ts
@@ -1,0 +1,161 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { loadAgentDefinitions, resolveAgentDefinition } from "./workspace.js";
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-def-test-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function writeAgentDef(dir: string, filename: string, content: string) {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, filename), content, "utf-8");
+}
+
+const explorerDef = [
+  "---",
+  "name: explorer",
+  'description: "Read-only codebase exploration"',
+  "model: google/gemini-2.5-flash",
+  "tools:",
+  "  allow:",
+  "    - read",
+  "    - web_search",
+  "---",
+  "",
+  "You are a code explorer.",
+].join("\n");
+
+const researcherDef = [
+  "---",
+  "name: researcher",
+  'description: "Research and analysis"',
+  "---",
+  "",
+  "You are a researcher.",
+].join("\n");
+
+describe("loadAgentDefinitions", () => {
+  it("loads definitions from workspace agents/ directory", () => {
+    const agentsDir = path.join(tmpDir, "agents");
+    writeAgentDef(agentsDir, "explorer.md", explorerDef);
+    writeAgentDef(agentsDir, "researcher.md", researcherDef);
+
+    const defs = loadAgentDefinitions(tmpDir);
+    expect(defs).toHaveLength(2);
+
+    const names = defs.map((d) => d.name).toSorted();
+    expect(names).toEqual(["explorer", "researcher"]);
+
+    const explorer = defs.find((d) => d.name === "explorer");
+    expect(explorer?.model).toBe("google/gemini-2.5-flash");
+    expect(explorer?.tools?.allow).toEqual(["read", "web_search"]);
+    expect(explorer?.source).toBe("workspace");
+  });
+
+  it("loads definitions from .agents/agents/ directory", () => {
+    const dotAgentsDir = path.join(tmpDir, ".agents", "agents");
+    writeAgentDef(dotAgentsDir, "explorer.md", explorerDef);
+
+    const defs = loadAgentDefinitions(tmpDir);
+    expect(defs).toHaveLength(1);
+    expect(defs[0].name).toBe("explorer");
+    expect(defs[0].source).toBe("workspace");
+  });
+
+  it("workspace agents/ overrides .agents/agents/", () => {
+    const dotAgentsDir = path.join(tmpDir, ".agents", "agents");
+    const agentsDir = path.join(tmpDir, "agents");
+
+    const overrideDef = [
+      "---",
+      "name: explorer",
+      'description: "Overridden explorer"',
+      "model: openai/gpt-4o",
+      "---",
+      "",
+      "Custom explorer.",
+    ].join("\n");
+
+    writeAgentDef(dotAgentsDir, "explorer.md", explorerDef);
+    writeAgentDef(agentsDir, "explorer.md", overrideDef);
+
+    const defs = loadAgentDefinitions(tmpDir);
+    expect(defs).toHaveLength(1);
+    expect(defs[0].description).toBe("Overridden explorer");
+    expect(defs[0].model).toBe("openai/gpt-4o");
+  });
+
+  it("bundled definitions are overridden by workspace", () => {
+    const bundledDir = path.join(tmpDir, "bundled");
+    const agentsDir = path.join(tmpDir, "workspace", "agents");
+
+    writeAgentDef(bundledDir, "explorer.md", explorerDef);
+
+    const overrideDef = [
+      "---",
+      "name: explorer",
+      'description: "Workspace override"',
+      "---",
+      "",
+      "Custom.",
+    ].join("\n");
+    writeAgentDef(agentsDir, "explorer.md", overrideDef);
+
+    const defs = loadAgentDefinitions(path.join(tmpDir, "workspace"), {
+      bundledDir,
+    });
+    expect(defs).toHaveLength(1);
+    expect(defs[0].description).toBe("Workspace override");
+    expect(defs[0].source).toBe("workspace");
+  });
+
+  it("returns empty array for non-existent directory", () => {
+    const defs = loadAgentDefinitions(path.join(tmpDir, "nonexistent"));
+    expect(defs).toEqual([]);
+  });
+
+  it("ignores non-markdown files", () => {
+    const agentsDir = path.join(tmpDir, "agents");
+    writeAgentDef(agentsDir, "explorer.md", explorerDef);
+    fs.writeFileSync(path.join(agentsDir, "readme.txt"), "Not a definition", "utf-8");
+    fs.writeFileSync(path.join(agentsDir, "config.yaml"), "key: value", "utf-8");
+
+    const defs = loadAgentDefinitions(tmpDir);
+    expect(defs).toHaveLength(1);
+  });
+
+  it("ignores directories inside agents/", () => {
+    const agentsDir = path.join(tmpDir, "agents");
+    writeAgentDef(agentsDir, "explorer.md", explorerDef);
+    fs.mkdirSync(path.join(agentsDir, "subdir"), { recursive: true });
+
+    const defs = loadAgentDefinitions(tmpDir);
+    expect(defs).toHaveLength(1);
+  });
+});
+
+describe("resolveAgentDefinition", () => {
+  it("resolves a definition by name (case-insensitive)", () => {
+    const agentsDir = path.join(tmpDir, "agents");
+    writeAgentDef(agentsDir, "explorer.md", explorerDef);
+
+    const def = resolveAgentDefinition(tmpDir, "Explorer");
+    expect(def?.name).toBe("explorer");
+  });
+
+  it("returns undefined for unknown definition", () => {
+    const agentsDir = path.join(tmpDir, "agents");
+    writeAgentDef(agentsDir, "explorer.md", explorerDef);
+
+    const def = resolveAgentDefinition(tmpDir, "unknown");
+    expect(def).toBeUndefined();
+  });
+});

--- a/src/agents/agent-definitions/workspace.ts
+++ b/src/agents/agent-definitions/workspace.ts
@@ -1,0 +1,95 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { AgentDefinition, AgentDefinitionSource } from "./types.js";
+import { parseAgentDefinition } from "./loader.js";
+
+const AGENT_DEFINITIONS_DIR_NAME = "agents";
+
+function loadDefinitionsFromDir(dir: string, source: AgentDefinitionSource): AgentDefinition[] {
+  if (!fs.existsSync(dir)) {
+    return [];
+  }
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const definitions: AgentDefinition[] = [];
+  for (const entry of entries) {
+    if (!entry.isFile()) {
+      continue;
+    }
+    if (!entry.name.endsWith(".md")) {
+      continue;
+    }
+    const filePath = path.join(dir, entry.name);
+    const filenameName = entry.name.replace(/\.md$/, "");
+    if (!filenameName) {
+      continue;
+    }
+    let content: string;
+    try {
+      content = fs.readFileSync(filePath, "utf-8");
+    } catch {
+      continue;
+    }
+    const definition = parseAgentDefinition(content, {
+      filePath,
+      source,
+      filenameName,
+    });
+    if (definition) {
+      definitions.push(definition);
+    }
+  }
+  return definitions;
+}
+
+/**
+ * Load agent definitions from workspace and optional bundled directories.
+ *
+ * Workspace definitions override bundled ones with the same name.
+ * Scans `{workspaceDir}/agents/` and optionally `{workspaceDir}/.agents/agents/`.
+ */
+export function loadAgentDefinitions(
+  workspaceDir: string,
+  opts?: { bundledDir?: string },
+): AgentDefinition[] {
+  const byName = new Map<string, AgentDefinition>();
+
+  // 1. Load bundled defaults (lowest precedence)
+  if (opts?.bundledDir) {
+    for (const def of loadDefinitionsFromDir(opts.bundledDir, "bundled")) {
+      byName.set(def.name.toLowerCase(), def);
+    }
+  }
+
+  // 2. Load from .agents/agents/ (project-scoped, medium precedence)
+  const dotAgentsDir = path.join(workspaceDir, ".agents", AGENT_DEFINITIONS_DIR_NAME);
+  for (const def of loadDefinitionsFromDir(dotAgentsDir, "workspace")) {
+    byName.set(def.name.toLowerCase(), def);
+  }
+
+  // 3. Load from agents/ (workspace root, highest precedence)
+  const workspaceAgentsDir = path.join(workspaceDir, AGENT_DEFINITIONS_DIR_NAME);
+  for (const def of loadDefinitionsFromDir(workspaceAgentsDir, "workspace")) {
+    byName.set(def.name.toLowerCase(), def);
+  }
+
+  return Array.from(byName.values());
+}
+
+/**
+ * Resolve a single agent definition by name.
+ */
+export function resolveAgentDefinition(
+  workspaceDir: string,
+  name: string,
+  opts?: { bundledDir?: string },
+): AgentDefinition | undefined {
+  const all = loadAgentDefinitions(workspaceDir, opts);
+  const normalized = name.trim().toLowerCase();
+  return all.find((def) => def.name.toLowerCase() === normalized);
+}

--- a/src/agents/openclaw-tools.subagents.sessions-spawn-resolves-agent-definition.e2e.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn-resolves-agent-definition.e2e.test.ts
@@ -1,0 +1,206 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const callGatewayMock = vi.fn();
+vi.mock("../gateway/call.js", () => ({
+  callGateway: (opts: unknown) => callGatewayMock(opts),
+}));
+
+let configOverride: ReturnType<(typeof import("../config/config.js"))["loadConfig"]> = {
+  session: {
+    mainKey: "main",
+    scope: "per-sender",
+  },
+};
+
+vi.mock("../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/config.js")>();
+  return {
+    ...actual,
+    loadConfig: () => configOverride,
+    resolveGatewayPort: () => 18789,
+  };
+});
+
+let agentWorkspaceDirOverride: string | undefined;
+vi.mock("../agents/agent-scope.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../agents/agent-scope.js")>();
+  return {
+    ...actual,
+    resolveAgentWorkspaceDir: (...args: Parameters<typeof actual.resolveAgentWorkspaceDir>) => {
+      if (agentWorkspaceDirOverride) {
+        return agentWorkspaceDirOverride;
+      }
+      return actual.resolveAgentWorkspaceDir(...args);
+    },
+  };
+});
+
+import "./test-helpers/fast-core-tools.js";
+import { createOpenClawTools } from "./openclaw-tools.js";
+import { resetSubagentRegistryForTests } from "./subagent-registry.js";
+
+let tmpDir: string;
+
+describe("openclaw-tools: subagents agent definitions", () => {
+  beforeEach(() => {
+    configOverride = {
+      session: {
+        mainKey: "main",
+        scope: "per-sender",
+      },
+    };
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-def-spawn-"));
+    agentWorkspaceDirOverride = tmpDir;
+  });
+
+  afterEach(() => {
+    agentWorkspaceDirOverride = undefined;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("sessions_spawn resolves agent definition and applies model", async () => {
+    resetSubagentRegistryForTests();
+    callGatewayMock.mockReset();
+
+    // Create agent definition
+    const agentsDir = path.join(tmpDir, "agents");
+    fs.mkdirSync(agentsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(agentsDir, "explorer.md"),
+      [
+        "---",
+        "name: explorer",
+        'description: "Read-only codebase exploration"',
+        "model: google/gemini-2.5-flash",
+        "tools:",
+        "  allow:",
+        "    - read",
+        "    - web_search",
+        "---",
+        "",
+        "You are a code explorer. Find relevant code patterns.",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    let capturedModel: string | undefined;
+    let capturedSystemPrompt: string | undefined;
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: Record<string, unknown> };
+      if (request.method === "sessions.patch") {
+        capturedModel = request.params?.model as string;
+        return {};
+      }
+      if (request.method === "agent") {
+        capturedSystemPrompt = request.params?.extraSystemPrompt as string;
+        return { runId: "run-def-1", status: "accepted", acceptedAt: 6000 };
+      }
+      if (request.method === "agent.wait") {
+        return { status: "timeout" };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools({
+      agentSessionKey: "main",
+      agentChannel: "whatsapp",
+    }).find((c) => c.name === "sessions_spawn");
+    if (!tool) {
+      throw new Error("missing sessions_spawn tool");
+    }
+
+    const result = await tool.execute("call-def-1", {
+      task: "Find error handling patterns",
+      agent: "explorer",
+    });
+
+    expect(result.details).toMatchObject({
+      status: "accepted",
+      agentDefinition: "explorer",
+    });
+    // Model from definition should be applied
+    expect(capturedModel).toBe("google/gemini-2.5-flash");
+    // System prompt should include agent definition content
+    expect(capturedSystemPrompt).toContain("Agent: explorer");
+    expect(capturedSystemPrompt).toContain("code explorer");
+  });
+
+  it("sessions_spawn returns error for unknown agent definition", async () => {
+    resetSubagentRegistryForTests();
+    callGatewayMock.mockReset();
+
+    const tool = createOpenClawTools({
+      agentSessionKey: "main",
+      agentChannel: "whatsapp",
+    }).find((c) => c.name === "sessions_spawn");
+    if (!tool) {
+      throw new Error("missing sessions_spawn tool");
+    }
+
+    const result = await tool.execute("call-def-2", {
+      task: "Do something",
+      agent: "nonexistent",
+    });
+
+    expect(result.details).toMatchObject({
+      status: "error",
+    });
+    expect((result.details as { error?: string }).error).toContain("not found");
+  });
+
+  it("explicit model override takes precedence over agent definition model", async () => {
+    resetSubagentRegistryForTests();
+    callGatewayMock.mockReset();
+
+    const agentsDir = path.join(tmpDir, "agents");
+    fs.mkdirSync(agentsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(agentsDir, "explorer.md"),
+      [
+        "---",
+        "name: explorer",
+        "model: google/gemini-2.5-flash",
+        "---",
+        "",
+        "Explorer agent.",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    let capturedModel: string | undefined;
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: Record<string, unknown> };
+      if (request.method === "sessions.patch") {
+        capturedModel = request.params?.model as string;
+        return {};
+      }
+      if (request.method === "agent") {
+        return { runId: "run-def-3", status: "accepted", acceptedAt: 6100 };
+      }
+      if (request.method === "agent.wait") {
+        return { status: "timeout" };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools({
+      agentSessionKey: "main",
+      agentChannel: "whatsapp",
+    }).find((c) => c.name === "sessions_spawn");
+    if (!tool) {
+      throw new Error("missing sessions_spawn tool");
+    }
+
+    await tool.execute("call-def-3", {
+      task: "Do something",
+      agent: "explorer",
+      model: "anthropic/claude-sonnet-4-20250514",
+    });
+
+    // Explicit model should win
+    expect(capturedModel).toBe("anthropic/claude-sonnet-4-20250514");
+  });
+});

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -321,14 +321,31 @@ export function buildSubagentSystemPrompt(params: {
   childSessionKey: string;
   label?: string;
   task?: string;
+  agentDefinition?: {
+    name: string;
+    systemPrompt?: string;
+  };
 }) {
   const taskText =
     typeof params.task === "string" && params.task.trim()
       ? params.task.replace(/\s+/g, " ").trim()
       : "{{TASK_DESCRIPTION}}";
+
+  // When an agent definition provides a custom system prompt, prepend it
+  const agentDefSection: string[] = [];
+  if (params.agentDefinition?.systemPrompt) {
+    agentDefSection.push(
+      `## Agent: ${params.agentDefinition.name}`,
+      "",
+      params.agentDefinition.systemPrompt,
+      "",
+    );
+  }
+
   const lines = [
     "# Subagent Context",
     "",
+    ...agentDefSection,
     "You are a **subagent** spawned by the main agent for a specific task.",
     "",
     "## Your Role",
@@ -356,6 +373,7 @@ export function buildSubagentSystemPrompt(params: {
     "- Only use the `message` tool when explicitly instructed to contact a specific external recipient; otherwise return plain text and let the main agent deliver it",
     "",
     "## Session Context",
+    params.agentDefinition ? `- Agent type: ${params.agentDefinition.name}` : undefined,
     params.label ? `- Label: ${params.label}` : undefined,
     params.requesterSessionKey ? `- Requester session: ${params.requesterSessionKey}.` : undefined,
     params.requesterOrigin?.channel


### PR DESCRIPTION
## Summary

Adds support for **declarative agent definitions** - markdown files with YAML frontmatter that define specialized sub-agent types with scoped tools, models, and system prompts, spawnable by name via `sessions_spawn`.

Fixes #16128

## Changes

### New: Agent Definition Module (`src/agents/agent-definitions/`)
- **types.ts** - `AgentDefinition`, `AgentDefinitionFrontmatter`, `AgentDefinitionToolPolicy` types
- **loader.ts** - Parses markdown files with YAML frontmatter into structured agent definitions
- **workspace.ts** - Discovers definitions from `agents/` and `.agents/agents/` directories with precedence (workspace > .agents > bundled)
- **index.ts** - Barrel export

### Modified: `sessions_spawn` tool
- New optional `agent` parameter to reference an agent definition by name
- Definition model serves as fallback (explicit `model` override takes precedence over definition)
- Returns `agentDefinition` field in response when an agent definition is used
- Returns clear error when a referenced definition is not found

### Modified: `agents_list` tool
- Response now includes `definitions` array listing available agent definitions (name, description, source)

### Modified: `buildSubagentSystemPrompt`
- Accepts optional `agentDefinition` parameter
- When present, prepends the definition's custom system prompt to the subagent context
- Adds agent type to session context section

### Example Usage

Place a file at `agents/explorer.md`:

```markdown
---
name: explorer
description: "Read-only codebase exploration"
model: google/gemini-2.5-flash
tools:
  allow:
    - read
    - web_search
---

You are a code explorer. Find and summarize relevant code patterns.
```

Then spawn it:
```
sessions_spawn({ agent: "explorer", task: "Find error handling patterns in src/" })
```

## Test Plan

- [x] 22 unit tests for loader and workspace discovery (parsing, precedence, edge cases)
- [x] 3 e2e tests for sessions_spawn with agent definitions (resolution, error handling, model precedence)
- [x] 4 existing agents_list e2e tests still pass
- [x] 15 existing sessions_spawn e2e tests still pass
- [x] Full test suite: 644 files, 4413 tests passed
- [x] Lint: 0 warnings, 0 errors
- [x] Format: all files pass
- [x] Type check: passes
- [x] Build: succeeds

---
🤖 Generated with Claude Code (issue-hunter-pro)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds declarative agent definitions - markdown files with YAML frontmatter that define specialized sub-agent types with scoped tools, models, and system prompts. The implementation includes a complete loader/parser module, workspace directory discovery with precedence rules (workspace > .agents > bundled), and integration with `sessions_spawn` and `agents_list` tools.

**Key Changes:**
- New `agent-definitions/` module with types, loader, and workspace discovery logic
- `sessions_spawn` tool accepts optional `agent` parameter to reference agent definitions by name
- Agent definition model serves as fallback (explicit `model` parameter takes precedence)
- `agents_list` tool now returns available agent definitions in response
- `buildSubagentSystemPrompt` prepends custom system prompts from agent definitions
- 22 unit tests for loader/workspace discovery, 3 e2e tests for sessions_spawn integration

**Implementation Quality:**
- Well-structured with proper separation of concerns (types, loader, workspace)
- Comprehensive test coverage including edge cases (invalid YAML, missing files, precedence)
- Proper error handling for missing agent definitions
- Follows existing patterns for tool parameter handling and model resolution
- Case-insensitive name resolution for better UX

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with very low risk
- The implementation is well-designed with comprehensive test coverage (25 total tests across unit and e2e), proper error handling, and follows established codebase patterns. The feature is additive and opt-in - existing functionality remains unchanged. All tests pass (644 files, 4413 tests) with no lint/format/type errors.
- No files require special attention

<sub>Last reviewed commit: aa2f037</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->