### PR TITLE
fix(sessions): allow cross-agent session paths in multi-agent bindings

### DIFF
--- a/src/config/sessions/paths.test.ts
+++ b/src/config/sessions/paths.test.ts
@@ -96,13 +96,29 @@ describe("session path safety", () => {
     expect(resolved).toBe(path.resolve(sessionsDir, "abc-123-topic-42.jsonl"));
   });
 
-  it("rejects absolute sessionFile paths outside the sessions dir", () => {
+  it("accepts absolute sessionFile paths in another agent's sessions dir (cross-agent binding)", () => {
     const sessionsDir = "/tmp/openclaw/agents/main/sessions";
+
+    const resolved = resolveSessionFilePath(
+      "sess-1",
+      { sessionFile: "/tmp/openclaw/agents/work/sessions/abc-123.jsonl" },
+      { sessionsDir },
+    );
+
+    expect(resolved).toBe(path.resolve("/tmp/openclaw/agents/work/sessions/abc-123.jsonl"));
+  });
+
+  it("rejects absolute paths outside any agent sessions dir", () => {
+    const sessionsDir = "/tmp/openclaw/agents/main/sessions";
+
+    expect(() =>
+      resolveSessionFilePath("sess-1", { sessionFile: "/etc/passwd" }, { sessionsDir }),
+    ).toThrow(/within sessions directory/);
 
     expect(() =>
       resolveSessionFilePath(
         "sess-1",
-        { sessionFile: "/tmp/openclaw/agents/work/sessions/abc-123.jsonl" },
+        { sessionFile: "/tmp/openclaw/agents/work/config/secrets.json" },
         { sessionsDir },
       ),
     ).toThrow(/within sessions directory/);


### PR DESCRIPTION
## Summary

- Fix `resolvePathWithinSessionsDir` rejecting legitimate cross-agent session file paths when using multi-agent bindings
- Extend validation to accept absolute paths under any agent's `sessions/` directory within the same state root
- Add tests for cross-agent path acceptance and out-of-scope path rejection

## Problem

When a binding routes a message to a secondary agent, the gateway crashes with:

```
Session file path must be within sessions directory
```

**Root cause**: `resolvePathWithinSessionsDir` computes `path.relative(agentA/sessions, agentB/sessions/file)` → `../../agentB/sessions/file`. The `..` prefix triggers the security check, rejecting a perfectly valid cross-agent path.

This affects **all** multi-agent + binding setups across all platforms (Telegram, Discord, Slack, WhatsApp, etc.).

Related: #16211 (same root cause for WhatsApp DM session keys)

## Fix

When the existing containment check fails for an absolute path, verify whether the candidate falls under `<stateRoot>/agents/<agentId>/sessions/` — i.e. any agent's sessions directory within the same state root. This preserves the original security guarantee (no path traversal outside agent session directories) while allowing legitimate cross-agent routing.

## Test plan

- [x] Existing tests pass (13/13)
- [x] New test: accepts absolute paths in another agent's sessions dir (cross-agent binding)
- [x] New test: rejects `/etc/passwd` (completely outside state root)
- [x] New test: rejects paths to non-session agent subdirectories (`agents/work/config/secrets.json`)
- [x] Lint (`oxlint`) and format (`oxfmt`) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a critical bug where multi-agent bindings crashed with "Session file path must be within sessions directory" when routing messages between agents. The fix extends `resolvePathWithinSessionsDir` to accept absolute paths under any agent's sessions directory within the same state root (structure: `<stateRoot>/agents/<agentId>/sessions/`), preserving path traversal protection while enabling cross-agent routing.

**Key changes:**
- Modified `resolvePathWithinSessionsDir` (paths.ts:85-99) to validate cross-agent session paths by checking they follow the `agents/<agentId>/sessions/<file>` structure
- Added three new test cases covering cross-agent acceptance, out-of-bounds rejection (`/etc/passwd`), and non-session subdirectory rejection (`agents/work/config/secrets.json`)
- Updated existing test description to clarify it now tests cross-agent binding scenarios

**Security analysis:**
The validation logic correctly rejects path traversal attempts and paths outside agent session directories. However, when custom `sessionsDir` paths are used (via `storePath`), the state root calculation may produce unexpected results since it assumes the standard `<stateRoot>/agents/<agentId>/sessions` structure. This is a low-severity edge case for non-standard configurations.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one edge-case consideration for non-standard configurations
- Score of 4 reflects a well-tested fix for a real production bug. The implementation correctly handles the standard use case (multi-agent bindings within default agent directories) with proper path validation. Test coverage includes both positive cases (cross-agent paths) and negative cases (path traversal attempts). The logic comment on state root calculation in non-standard configurations is a valid concern but represents an edge case that likely doesn't affect typical deployments. No critical security issues identified.
- Pay attention to `src/config/sessions/paths.ts:88-99` regarding the state root calculation with custom sessionsDir configurations

<sub>Last reviewed commit: 92ff0a0</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->