### PR TITLE
refactor(sandbox): auto-recreate browser container on config changes

### DIFF
--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -7,17 +7,23 @@ import {
   DEFAULT_OPENCLAW_BROWSER_COLOR,
   DEFAULT_OPENCLAW_BROWSER_PROFILE_NAME,
 } from "../../browser/constants.js";
+import { defaultRuntime } from "../../runtime.js";
 import { BROWSER_BRIDGES } from "./browser-bridges.js";
+import { computeSandboxBrowserConfigHash } from "./config-hash.js";
+import { resolveSandboxBrowserDockerCreateConfig } from "./config.js";
 import { DEFAULT_SANDBOX_BROWSER_IMAGE, SANDBOX_AGENT_WORKSPACE_MOUNT } from "./constants.js";
 import {
   buildSandboxCreateArgs,
   dockerContainerState,
   execDocker,
+  readDockerContainerLabel,
   readDockerPort,
 } from "./docker.js";
-import { updateBrowserRegistry } from "./registry.js";
-import { slugifySessionKey } from "./shared.js";
+import { readBrowserRegistry, updateBrowserRegistry } from "./registry.js";
+import { resolveSandboxAgentId, slugifySessionKey } from "./shared.js";
 import { isToolAllowed } from "./tool-policy.js";
+
+const HOT_BROWSER_WINDOW_MS = 5 * 60 * 1000;
 
 async function waitForSandboxCdp(params: { cdpPort: number; timeoutMs: number }): Promise<boolean> {
   const deadline = Date.now() + Math.max(0, params.timeoutMs);
@@ -104,17 +110,74 @@ export async function ensureSandboxBrowser(params: {
   const name = `${params.cfg.browser.containerPrefix}${slug}`;
   const containerName = name.slice(0, 63);
   const state = await dockerContainerState(containerName);
-  if (!state.exists) {
-    await ensureSandboxBrowserImage(params.cfg.browser.image ?? DEFAULT_SANDBOX_BROWSER_IMAGE);
-    const browserDockerCfg =
-      params.cfg.browser.binds !== undefined
-        ? { ...params.cfg.docker, network: "bridge", binds: params.cfg.browser.binds }
-        : { ...params.cfg.docker, network: "bridge" };
+  const browserImage = params.cfg.browser.image ?? DEFAULT_SANDBOX_BROWSER_IMAGE;
+  const browserDockerCfg = resolveSandboxBrowserDockerCreateConfig({
+    docker: params.cfg.docker,
+    browser: { ...params.cfg.browser, image: browserImage },
+  });
+  const expectedHash = computeSandboxBrowserConfigHash({
+    docker: browserDockerCfg,
+    browser: {
+      cdpPort: params.cfg.browser.cdpPort,
+      vncPort: params.cfg.browser.vncPort,
+      noVncPort: params.cfg.browser.noVncPort,
+      headless: params.cfg.browser.headless,
+      enableNoVnc: params.cfg.browser.enableNoVnc,
+    },
+    workspaceAccess: params.cfg.workspaceAccess,
+    workspaceDir: params.workspaceDir,
+    agentWorkspaceDir: params.agentWorkspaceDir,
+  });
+
+  const now = Date.now();
+  let hasContainer = state.exists;
+  let running = state.running;
+  let currentHash: string | null = null;
+  let hashMismatch = false;
+
+  if (hasContainer) {
+    const registry = await readBrowserRegistry();
+    const registryEntry = registry.entries.find((entry) => entry.containerName === containerName);
+    currentHash = await readDockerContainerLabel(containerName, "openclaw.configHash");
+    hashMismatch = !currentHash || currentHash !== expectedHash;
+    if (!currentHash) {
+      currentHash = registryEntry?.configHash ?? null;
+      hashMismatch = !currentHash || currentHash !== expectedHash;
+    }
+    if (hashMismatch) {
+      const lastUsedAtMs = registryEntry?.lastUsedAtMs;
+      const isHot =
+        running && (typeof lastUsedAtMs !== "number" || now - lastUsedAtMs < HOT_BROWSER_WINDOW_MS);
+      if (isHot) {
+        const hint = (() => {
+          if (params.cfg.scope === "session") {
+            return `openclaw sandbox recreate --browser --session ${params.scopeKey}`;
+          }
+          if (params.cfg.scope === "agent") {
+            const agentId = resolveSandboxAgentId(params.scopeKey) ?? "main";
+            return `openclaw sandbox recreate --browser --agent ${agentId}`;
+          }
+          return "openclaw sandbox recreate --browser --all";
+        })();
+        defaultRuntime.log(
+          `Sandbox browser config changed for ${containerName} (recently used). Recreate to apply: ${hint}`,
+        );
+      } else {
+        await execDocker(["rm", "-f", containerName], { allowFailure: true });
+        hasContainer = false;
+        running = false;
+      }
+    }
+  }
+
+  if (!hasContainer) {
+    await ensureSandboxBrowserImage(browserImage);
     const args = buildSandboxCreateArgs({
       name: containerName,
       cfg: browserDockerCfg,
       scopeKey: params.scopeKey,
       labels: { "openclaw.sandboxBrowser": "1" },
+      configHash: expectedHash,
     });
     const mainMountSuffix =
       params.cfg.workspaceAccess === "ro" && params.workspaceDir === params.agentWorkspaceDir
@@ -137,10 +200,10 @@ export async function ensureSandboxBrowser(params: {
     args.push("-e", `OPENCLAW_BROWSER_CDP_PORT=${params.cfg.browser.cdpPort}`);
     args.push("-e", `OPENCLAW_BROWSER_VNC_PORT=${params.cfg.browser.vncPort}`);
     args.push("-e", `OPENCLAW_BROWSER_NOVNC_PORT=${params.cfg.browser.noVncPort}`);
-    args.push(params.cfg.browser.image);
+    args.push(browserImage);
     await execDocker(args);
     await execDocker(["start", containerName]);
-  } else if (!state.running) {
+  } else if (!running) {
     await execDocker(["start", containerName]);
   }
 
@@ -239,13 +302,13 @@ export async function ensureSandboxBrowser(params: {
     });
   }
 
-  const now = Date.now();
   await updateBrowserRegistry({
     containerName,
     sessionKey: params.scopeKey,
     createdAtMs: now,
     lastUsedAtMs: now,
-    image: params.cfg.browser.image,
+    image: browserImage,
+    configHash: hashMismatch && running ? (currentHash ?? undefined) : expectedHash,
     cdpPort: mappedCdp,
     noVncPort: mappedNoVnc ?? undefined,
   });

--- a/src/agents/sandbox/config-hash.ts
+++ b/src/agents/sandbox/config-hash.ts
@@ -1,8 +1,19 @@
 import crypto from "node:crypto";
-import type { SandboxDockerConfig, SandboxWorkspaceAccess } from "./types.js";
+import type { SandboxBrowserConfig, SandboxDockerConfig, SandboxWorkspaceAccess } from "./types.js";
 
 type SandboxHashInput = {
   docker: SandboxDockerConfig;
+  workspaceAccess: SandboxWorkspaceAccess;
+  workspaceDir: string;
+  agentWorkspaceDir: string;
+};
+
+type SandboxBrowserHashInput = {
+  docker: SandboxDockerConfig;
+  browser: Pick<
+    SandboxBrowserConfig,
+    "cdpPort" | "vncPort" | "noVncPort" | "headless" | "enableNoVnc"
+  >;
   workspaceAccess: SandboxWorkspaceAccess;
   workspaceDir: string;
   agentWorkspaceDir: string;
@@ -58,6 +69,14 @@ function primitiveToString(value: unknown): string {
 }
 
 export function computeSandboxConfigHash(input: SandboxHashInput): string {
+  return computeHash(input);
+}
+
+export function computeSandboxBrowserConfigHash(input: SandboxBrowserHashInput): string {
+  return computeHash(input);
+}
+
+function computeHash(input: unknown): string {
   const payload = normalizeForHash(input);
   const raw = JSON.stringify(payload);
   return crypto.createHash("sha1").update(raw).digest("hex");

--- a/src/agents/sandbox/config.ts
+++ b/src/agents/sandbox/config.ts
@@ -23,6 +23,21 @@ import {
 } from "./constants.js";
 import { resolveSandboxToolPolicyForAgent } from "./tool-policy.js";
 
+export function resolveSandboxBrowserDockerCreateConfig(params: {
+  docker: SandboxDockerConfig;
+  browser: SandboxBrowserConfig;
+}): SandboxDockerConfig {
+  const base: SandboxDockerConfig = {
+    ...params.docker,
+    // Browser container needs network access for Chrome, downloads, etc.
+    network: "bridge",
+    // For hashing and consistency, treat browser image as the docker image even though we
+    // pass it separately as the final `docker create` argument.
+    image: params.browser.image,
+  };
+  return params.browser.binds !== undefined ? { ...base, binds: params.browser.binds } : base;
+}
+
 export function resolveSandboxScope(params: {
   scope?: SandboxScope;
   perSession?: boolean;

--- a/src/agents/sandbox/registry.ts
+++ b/src/agents/sandbox/registry.ts
@@ -24,6 +24,7 @@ export type SandboxBrowserRegistryEntry = {
   createdAtMs: number;
   lastUsedAtMs: number;
   image: string;
+  configHash?: string;
   cdpPort: number;
   noVncPort?: number;
 };
@@ -102,6 +103,7 @@ export async function updateBrowserRegistry(entry: SandboxBrowserRegistryEntry) 
     ...entry,
     createdAtMs: existing?.createdAtMs ?? entry.createdAtMs,
     image: existing?.image ?? entry.image,
+    configHash: entry.configHash ?? existing?.configHash,
   });
   await writeBrowserRegistry({ entries: next });
 }


### PR DESCRIPTION
Summary

- Add config-hash + mismatch handling for sandbox browser containers, similar to exec containers.
- Centralize browser container docker create cfg derivation.
- Persist browser registry configHash for list/recreate UX.

Notes

- Hot containers (recently used) are not auto-removed; we print a recreate hint: `openclaw sandbox recreate --browser ...`.
- Container is labeled with `openclaw.configHash` so `sandbox list --browser` can become smarter later.

Tests

- pnpm check
- pnpm test -- src/config/config.sandbox-docker.test.ts

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Extends browser container lifecycle management with config-hash tracking and auto-recreation logic, mirroring the existing exec container implementation. When config changes are detected, cold containers are auto-removed while hot containers (used within 5 minutes) display a helpful recreate command hint. The implementation centralizes browser Docker config derivation and persists `configHash` in both container labels and the registry for improved list/recreate UX.

- Added `computeSandboxBrowserConfigHash` function to compute browser-specific config hashes
- Implemented config mismatch detection with hot/cold container handling (5 min window)
- Created `resolveSandboxBrowserDockerCreateConfig` to centralize browser container config
- Extracted `readDockerContainerLabel` utility for reuse between exec and browser containers
- Added `configHash` field to `SandboxBrowserRegistryEntry` type
- Logical bug in config hash fallback at `browser.ts:141-146` - redundant check prevents registry fallback

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one logical issue that should be fixed
- Implementation mirrors existing exec container pattern well, but has a logical bug in the hash fallback code that could prevent proper config detection from registry in edge cases
- Pay close attention to `src/agents/sandbox/browser.ts` lines 138-146 where the config hash fallback logic has a bug

<sub>Last reviewed commit: ab7187f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->