### PR TITLE
refactor(plugins): cache realpath + simplify duplicate checks

### DIFF
--- a/src/browser/csrf.ts
+++ b/src/browser/csrf.ts
@@ -1,4 +1,4 @@
-import type { NextFunction, Request, Response } from "express";
+import type { NextFunction, Request, RequestHandler, Response } from "express";
 import { isLoopbackHost } from "../gateway/net.js";
 
 function firstHeader(value: string | string[] | undefined): string {
@@ -54,7 +54,7 @@ export function shouldRejectBrowserMutation(params: {
   return false;
 }
 
-export function browserMutationGuardMiddleware() {
+export function browserMutationGuardMiddleware(): RequestHandler {
   return (req: Request, res: Response, next: NextFunction) => {
     // OPTIONS is used for CORS preflight. Even if cross-origin, the preflight isn't mutating.
     const method = (req.method || "").trim().toUpperCase();

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -11,17 +11,25 @@ type SeenIdEntry = {
   recordIndex: number;
 };
 
-function pluginOriginRank(origin: PluginOrigin): number {
-  // Precedence: config > workspace > global > bundled
-  switch (origin) {
-    case "config":
-      return 0;
-    case "workspace":
-      return 1;
-    case "global":
-      return 2;
-    case "bundled":
-      return 3;
+// Precedence: config > workspace > global > bundled
+const PLUGIN_ORIGIN_RANK: Readonly<Record<PluginOrigin, number>> = {
+  config: 0,
+  workspace: 1,
+  global: 2,
+  bundled: 3,
+};
+
+function safeRealpathSync(rootDir: string, cache: Map<string, string>): string | null {
+  const cached = cache.get(rootDir);
+  if (cached) {
+    return cached;
+  }
+  try {
+    const resolved = fs.realpathSync(rootDir);
+    cache.set(rootDir, resolved);
+    return resolved;
+  } catch {
+    return null;
   }
 }
 
@@ -158,6 +166,7 @@ export function loadPluginManifestRegistry(params: {
   const candidates: PluginCandidate[] = discovery.candidates;
   const records: PluginManifestRecord[] = [];
   const seenIds = new Map<string, SeenIdEntry>();
+  const realpathCache = new Map<string, string>();
 
   for (const candidate of candidates) {
     const manifestRes = loadPluginManifest(candidate.rootDir);
@@ -191,17 +200,13 @@ export function loadPluginManifestRegistry(params: {
       // Check whether both candidates point to the same physical directory
       // (e.g. via symlinks or different path representations). If so, this
       // is a false-positive duplicate and can be silently skipped.
-      let samePlugin = false;
-      try {
-        samePlugin =
-          fs.realpathSync(existing.candidate.rootDir) === fs.realpathSync(candidate.rootDir);
-      } catch {
-        // If either path is inaccessible, fall through to duplicate warning
-      }
+      const existingReal = safeRealpathSync(existing.candidate.rootDir, realpathCache);
+      const candidateReal = safeRealpathSync(candidate.rootDir, realpathCache);
+      const samePlugin = Boolean(existingReal && candidateReal && existingReal === candidateReal);
       if (samePlugin) {
         // Prefer higher-precedence origins even if candidates are passed in
         // an unexpected order (config > workspace > global > bundled).
-        if (pluginOriginRank(candidate.origin) < pluginOriginRank(existing.candidate.origin)) {
+        if (PLUGIN_ORIGIN_RANK[candidate.origin] < PLUGIN_ORIGIN_RANK[existing.candidate.origin]) {
           records[existing.recordIndex] = buildRecord({
             manifest,
             candidate,


### PR DESCRIPTION
Refactor only.

- Use an origin-rank map instead of a switch
- Cache fs.realpathSync results while processing candidates
- Add explicit return type for browser middleware factory (fixes TS2742 in tsgo)

Gate: pnpm check; pnpm test src/plugins/manifest-registry.test.ts src/browser/csrf.test.ts

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Refactored plugin manifest registry and browser middleware for better maintainability and type safety:
- Replaced `pluginOriginRank` switch statement with a constant map `PLUGIN_ORIGIN_RANK` for cleaner precedence logic
- Added `safeRealpathSync` helper with caching to avoid redundant filesystem calls when checking for duplicate plugins via symlinks
- Added explicit `RequestHandler` return type to `browserMutationGuardMiddleware` to fix TypeScript inference

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Pure refactoring with no behavioral changes. The switch-to-map conversion maintains identical logic, realpath caching is correctly implemented with proper null handling, and the explicit return type fixes a TypeScript issue without affecting runtime behavior
- No files require special attention

<sub>Last reviewed commit: 416f30a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->