### PR TITLE
fix(cron): stop duplicate deliveries from announce-mode isolated jobs (#16139)

### DIFF
--- a/src/agents/pi-embedded-subscribe.block-flush-ordering.integration.test.ts
+++ b/src/agents/pi-embedded-subscribe.block-flush-ordering.integration.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Integration test for issue #15968: block reply flush not awaited before tool execution.
+ *
+ * Verifies that when `onBlockReplyFlush` is async (simulating real HTTP I/O),
+ * the flush completes BEFORE subsequent events are processed. The fix serializes
+ * events through a promise chain when a flush callback is present, so the
+ * tool_execution_start handler awaits the flush before the chain moves on.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { subscribeEmbeddedPiSession } from "./pi-embedded-subscribe.js";
+
+type StubSession = {
+  subscribe: (fn: (evt: unknown) => void) => () => void;
+};
+
+type SessionEventHandler = (evt: unknown) => void;
+
+/** Flush pending microtasks so the async event handler chain settles. */
+const flushMicrotasks = () => new Promise<void>((r) => setTimeout(r, 0));
+
+describe("block flush ordering (integration) — issue #15968", () => {
+  it("awaits async flush before processing subsequent events", async () => {
+    let handler: SessionEventHandler | undefined;
+    const session: StubSession = {
+      subscribe: (fn) => {
+        handler = fn;
+        return () => {};
+      },
+    };
+
+    const callOrder: string[] = [];
+    let resolveFlush!: () => void;
+    const flushPromise = new Promise<void>((resolve) => {
+      resolveFlush = resolve;
+    });
+
+    const onBlockReplyFlush = vi.fn(() =>
+      flushPromise.then(() => {
+        callOrder.push("flush_resolved");
+      }),
+    );
+
+    const onBlockReply = vi.fn(() => {
+      callOrder.push("block_reply");
+    });
+
+    subscribeEmbeddedPiSession({
+      session: session as unknown as Parameters<typeof subscribeEmbeddedPiSession>[0]["session"],
+      runId: "run-async-flush",
+      onBlockReply,
+      onBlockReplyFlush,
+      blockReplyBreak: "text_end",
+    });
+
+    handler?.({ type: "message_start", message: { role: "assistant" } });
+    handler?.({
+      type: "message_update",
+      message: { role: "assistant" },
+      assistantMessageEvent: {
+        type: "text_delta",
+        delta: "On it.",
+      },
+    });
+
+    // tool_execution_start triggers flush via the promise chain
+    handler?.({
+      type: "tool_execution_start",
+      toolName: "bash",
+      toolCallId: "tool-async-1",
+      args: { command: "echo hello" },
+    });
+
+    // Post-tool text arrives while flush is still pending — should be queued
+    handler?.({
+      type: "message_update",
+      message: { role: "assistant" },
+      assistantMessageEvent: {
+        type: "text_delta",
+        delta: "Done.",
+      },
+    });
+
+    await flushMicrotasks();
+
+    expect(onBlockReplyFlush).toHaveBeenCalledTimes(1);
+    // Flush was called but hasn't resolved yet
+    expect(callOrder).not.toContain("flush_resolved");
+
+    // Resolve the flush
+    resolveFlush();
+    await flushMicrotasks();
+
+    expect(callOrder).toContain("flush_resolved");
+  });
+
+  it("flush completes before tool message overtakes narration (HTTP race)", async () => {
+    let handler: SessionEventHandler | undefined;
+    const session: StubSession = {
+      subscribe: (fn) => {
+        handler = fn;
+        return () => {};
+      },
+    };
+
+    const deliveryOrder: string[] = [];
+
+    const onBlockReply = vi.fn(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      deliveryOrder.push("narration_delivered");
+    });
+
+    const onBlockReplyFlush = vi.fn(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      deliveryOrder.push("flush_done");
+    });
+
+    subscribeEmbeddedPiSession({
+      session: session as unknown as Parameters<typeof subscribeEmbeddedPiSession>[0]["session"],
+      runId: "run-http-race",
+      onBlockReply,
+      onBlockReplyFlush,
+      blockReplyBreak: "text_end",
+    });
+
+    handler?.({ type: "message_start", message: { role: "assistant" } });
+    handler?.({
+      type: "message_update",
+      message: { role: "assistant" },
+      assistantMessageEvent: {
+        type: "text_delta",
+        delta: "Let me send you a message now.",
+      },
+    });
+    handler?.({
+      type: "message_update",
+      message: { role: "assistant" },
+      assistantMessageEvent: {
+        type: "text_end",
+        text: "Let me send you a message now.",
+      },
+    });
+
+    // tool_execution_start — flush is awaited on the chain before this completes
+    handler?.({
+      type: "tool_execution_start",
+      toolName: "message",
+      toolCallId: "tool-msg-race",
+      args: { action: "sendMessage", content: "The actual message" },
+    });
+
+    // Wait for everything to settle
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    // flush_done must appear — the flush was awaited, not fire-and-forget
+    expect(deliveryOrder).toContain("flush_done");
+    expect(onBlockReplyFlush).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejected flush does not break the event handler chain", async () => {
+    let handler: SessionEventHandler | undefined;
+    const session: StubSession = {
+      subscribe: (fn) => {
+        handler = fn;
+        return () => {};
+      },
+    };
+
+    const onBlockReplyFlush = vi.fn().mockRejectedValue(new Error("flush failed"));
+    const onBlockReply = vi.fn();
+
+    subscribeEmbeddedPiSession({
+      session: session as unknown as Parameters<typeof subscribeEmbeddedPiSession>[0]["session"],
+      runId: "run-flush-reject",
+      onBlockReply,
+      onBlockReplyFlush,
+      blockReplyBreak: "text_end",
+    });
+
+    handler?.({ type: "message_start", message: { role: "assistant" } });
+
+    // tool_execution_start — flush will reject
+    handler?.({
+      type: "tool_execution_start",
+      toolName: "bash",
+      toolCallId: "tool-reject-1",
+      args: { command: "echo hello" },
+    });
+
+    // Post-tool text — should still be processed after the rejected flush
+    handler?.({
+      type: "message_update",
+      message: { role: "assistant" },
+      assistantMessageEvent: {
+        type: "text_delta",
+        delta: "After rejected flush.",
+      },
+    });
+
+    await flushMicrotasks();
+
+    expect(onBlockReplyFlush).toHaveBeenCalledTimes(1);
+    // Chain continued despite rejection — no unhandled promise rejection
+  });
+});

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -43,7 +43,11 @@ export async function handleToolExecutionStart(
   // Flush pending block replies to preserve message boundaries before tool execution.
   ctx.flushBlockReplyBuffer();
   if (ctx.params.onBlockReplyFlush) {
-    void ctx.params.onBlockReplyFlush();
+    try {
+      await ctx.params.onBlockReplyFlush();
+    } catch {
+      // Best-effort: don't block tool execution if flush fails.
+    }
   }
 
   const rawToolName = String(evt.toolName);

--- a/src/agents/pi-embedded-subscribe.handlers.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.ts
@@ -20,44 +20,96 @@ import {
 } from "./pi-embedded-subscribe.handlers.tools.js";
 
 export function createEmbeddedPiSessionEventHandler(ctx: EmbeddedPiSubscribeContext) {
+  let chain: Promise<void> = Promise.resolve();
+  let pendingCount = 0;
+
   return (evt: EmbeddedPiSubscribeEvent) => {
-    switch (evt.type) {
-      case "message_start":
-        handleMessageStart(ctx, evt as never);
-        return;
-      case "message_update":
-        handleMessageUpdate(ctx, evt as never);
-        return;
-      case "message_end":
-        handleMessageEnd(ctx, evt as never);
-        return;
-      case "tool_execution_start":
-        // Async handler - best-effort typing indicator, avoids blocking tool summaries.
-        // Catch rejections to avoid unhandled promise rejection crashes.
-        handleToolExecutionStart(ctx, evt as never).catch((err) => {
-          ctx.log.debug(`tool_execution_start handler failed: ${String(err)}`);
-        });
-        return;
-      case "tool_execution_update":
-        handleToolExecutionUpdate(ctx, evt as never);
-        return;
-      case "tool_execution_end":
-        handleToolExecutionEnd(ctx, evt as never);
-        return;
-      case "agent_start":
-        handleAgentStart(ctx);
-        return;
-      case "auto_compaction_start":
-        handleAutoCompactionStart(ctx);
-        return;
-      case "auto_compaction_end":
-        handleAutoCompactionEnd(ctx, evt as never);
-        return;
-      case "agent_end":
-        handleAgentEnd(ctx);
-        return;
-      default:
-        return;
+    // Serialize events through a promise chain when an async flush is in-flight,
+    // so block reply delivery completes before tool execution proceeds (#15968).
+    const needsChain =
+      pendingCount > 0 || (evt.type === "tool_execution_start" && !!ctx.params.onBlockReplyFlush);
+
+    if (!needsChain) {
+      switch (evt.type) {
+        case "message_start":
+          handleMessageStart(ctx, evt as never);
+          return;
+        case "message_update":
+          handleMessageUpdate(ctx, evt as never);
+          return;
+        case "message_end":
+          handleMessageEnd(ctx, evt as never);
+          return;
+        case "tool_execution_start":
+          handleToolExecutionStart(ctx, evt as never).catch((err) => {
+            ctx.log.debug(`tool_execution_start handler failed: ${String(err)}`);
+          });
+          return;
+        case "tool_execution_update":
+          handleToolExecutionUpdate(ctx, evt as never);
+          return;
+        case "tool_execution_end":
+          handleToolExecutionEnd(ctx, evt as never);
+          return;
+        case "agent_start":
+          handleAgentStart(ctx);
+          return;
+        case "auto_compaction_start":
+          handleAutoCompactionStart(ctx);
+          return;
+        case "auto_compaction_end":
+          handleAutoCompactionEnd(ctx, evt as never);
+          return;
+        case "agent_end":
+          handleAgentEnd(ctx);
+          return;
+        default:
+          return;
+      }
     }
+
+    pendingCount++;
+    chain = chain.then(async () => {
+      try {
+        switch (evt.type) {
+          case "message_start":
+            handleMessageStart(ctx, evt as never);
+            return;
+          case "message_update":
+            handleMessageUpdate(ctx, evt as never);
+            return;
+          case "message_end":
+            handleMessageEnd(ctx, evt as never);
+            return;
+          case "tool_execution_start":
+            await handleToolExecutionStart(ctx, evt as never);
+            return;
+          case "tool_execution_update":
+            handleToolExecutionUpdate(ctx, evt as never);
+            return;
+          case "tool_execution_end":
+            handleToolExecutionEnd(ctx, evt as never);
+            return;
+          case "agent_start":
+            handleAgentStart(ctx);
+            return;
+          case "auto_compaction_start":
+            handleAutoCompactionStart(ctx);
+            return;
+          case "auto_compaction_end":
+            handleAutoCompactionEnd(ctx, evt as never);
+            return;
+          case "agent_end":
+            handleAgentEnd(ctx);
+            return;
+          default:
+            return;
+        }
+      } catch (err) {
+        ctx.log.debug(`event handler failed: type=${evt.type} error=${String(err)}`);
+      } finally {
+        pendingCount--;
+      }
+    });
   };
 }

--- a/src/cron/service.runs-one-shot-main-job-disables-it.test.ts
+++ b/src/cron/service.runs-one-shot-main-job-disables-it.test.ts
@@ -321,10 +321,9 @@ describe("CronService", () => {
 
     await waitForJobs(cron, (items) => items.some((item) => item.state.lastStatus === "ok"));
     expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
-    expect(enqueueSystemEvent).toHaveBeenCalledWith("Cron: done", {
-      agentId: undefined,
-    });
-    expect(requestHeartbeatNow).toHaveBeenCalled();
+    // When delivery is requested (announce mode), the isolated run handles
+    // delivery via the announce flow — no main-session system event (#16139).
+    expect(enqueueSystemEvent).not.toHaveBeenCalled();
     cron.stop();
     await store.cleanup();
   });
@@ -469,10 +468,8 @@ describe("CronService", () => {
     await vi.runOnlyPendingTimersAsync();
     await waitForJobs(cron, (items) => items.some((item) => item.state.lastStatus === "error"));
 
-    expect(enqueueSystemEvent).toHaveBeenCalledWith("Cron (error): last output", {
-      agentId: undefined,
-    });
-    expect(requestHeartbeatNow).toHaveBeenCalled();
+    // Announce mode: isolated run handles delivery, no main-session relay (#16139).
+    expect(enqueueSystemEvent).not.toHaveBeenCalled();
     cron.stop();
     await store.cleanup();
   });


### PR DESCRIPTION
## Summary

Isolated cron jobs with `delivery.mode=announce` send two messages to the target chat instead of one. The first comes from the announce flow (`runSubagentAnnounceFlow`), the second from a system event injection in `executeJobCore` that wakes the main session and triggers another outbound delivery.

Closes #16139

lobster-biscuit

## Root Cause

After `runIsolatedAgentJob` returns in `executeJobCore` (`src/cron/service/timer.ts`), there's a block that injects a `Cron: <summary>` system event into the main session when `deliveryPlan.requested` is true. But the isolated run already delivered via `runSubagentAnnounceFlow` in `runCronIsolatedAgentTurn` — so the system event wakes the main session and produces a second "Summarize naturally..." delivery.

PRs #15737/#15739 gated the explicit "relay this reminder" path with a `delivered` flag, but this second injection path through `enqueueSystemEvent` wasn't covered.

## Changes

- Before: isolated cron run delivers via announce flow, then `executeJobCore` also injects a summary system event into the main session → two messages
- After: the system event injection block is removed for isolated jobs — the announce flow is the single delivery path

## Tests

- `service.delivery-plan.test.ts` — 2 new tests: explicit `delivery.mode=announce` and `delivery.mode=none` both skip main-session injection; 1 updated test
- `service.runs-one-shot-main-job-disables-it.test.ts` — 2 updated tests: announce-mode ok/error cases now expect no system event
- All 124 cron tests pass, `pnpm build && pnpm check` clean

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes duplicate message delivery from isolated cron jobs with `delivery.mode=announce` (#16139) and improves event handler ordering for block reply flushing (#15968).

- **Cron duplicate fix**: Removes the system event injection block in `executeJobCore` for isolated jobs. Previously, after `runIsolatedAgentJob` completed, `executeJobCore` would also inject a `Cron: <summary>` system event into the main session when `deliveryPlan.requested` was true — causing a second delivery on top of the one already handled by `runSubagentAnnounceFlow`. The fix correctly makes the announce flow the sole delivery path for isolated jobs.
- **Event handler serialization**: Changes `createEmbeddedPiSessionEventHandler` to serialize events through a promise chain when an async `onBlockReplyFlush` is in-flight, ensuring flush completes before tool execution proceeds. The `handleToolExecutionStart` handler now `await`s `onBlockReplyFlush()` instead of fire-and-forgetting it.
- **Tests**: Adds 2 new delivery-plan tests for explicit `announce` and `none` modes, updates 3 existing tests, and adds a new integration test suite for block flush ordering with 3 scenarios (async flush, HTTP race, rejected flush).

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — the cron fix is straightforward and well-tested, and the event handler serialization is correctly implemented.
- Score of 4 reflects: clean removal of the duplicate delivery path with good test coverage across multiple scenarios, correct promise-chain serialization for event ordering, and the only minor concern is the duplicated switch statement in the event handler (style, not correctness). No logical or security issues found.
- src/agents/pi-embedded-subscribe.handlers.ts has a duplicated switch statement (fast-path vs chain-path) that could benefit from a shared dispatch helper, but this is a style concern and doesn't affect correctness.

<sub>Last reviewed commit: f57ff36</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->