### PR TITLE
fix(agents): prevent rapid-fire duplicate messages during tool execution

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -763,6 +763,8 @@ export async function runEmbeddedPiAgent(
             onAssistantMessageStart: params.onAssistantMessageStart,
             onBlockReply: params.onBlockReply,
             onBlockReplyFlush: params.onBlockReplyFlush,
+            onBlockReplyHold: params.onBlockReplyHold,
+            onBlockReplyResume: params.onBlockReplyResume,
             blockReplyBreak: params.blockReplyBreak,
             blockReplyChunking: params.blockReplyChunking,
             onReasoningStream: params.onReasoningStream,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1241,6 +1241,8 @@ export async function runEmbeddedAttempt(
         onReasoningEnd: params.onReasoningEnd,
         onBlockReply: params.onBlockReply,
         onBlockReplyFlush: params.onBlockReplyFlush,
+        onBlockReplyHold: params.onBlockReplyHold,
+        onBlockReplyResume: params.onBlockReplyResume,
         blockReplyBreak: params.blockReplyBreak,
         blockReplyChunking: params.blockReplyChunking,
         onPartialReply: params.onPartialReply,

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -96,6 +96,8 @@ export type RunEmbeddedPiAgentParams = {
   onAssistantMessageStart?: () => void | Promise<void>;
   onBlockReply?: (payload: BlockReplyPayload) => void | Promise<void>;
   onBlockReplyFlush?: () => void | Promise<void>;
+  onBlockReplyHold?: () => void;
+  onBlockReplyResume?: () => void;
   blockReplyBreak?: "text_end" | "message_end";
   blockReplyChunking?: BlockReplyChunking;
   onReasoningStream?: (payload: { text?: string; mediaUrls?: string[] }) => void | Promise<void>;

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -181,10 +181,18 @@ export async function handleToolExecutionStart(
   ctx: ToolHandlerContext,
   evt: AgentEvent & { toolName: string; toolCallId: string; args: unknown },
 ) {
-  // Flush pending block replies to preserve message boundaries before tool execution.
+  // Hold before draining so pre-tool text can coalesce with post-tool text.
+  const onBlockReplyHold = ctx.params.onBlockReplyHold;
+  const canHoldBlockReplies = typeof onBlockReplyHold === "function";
+  if (canHoldBlockReplies) {
+    onBlockReplyHold();
+  }
+  // Drain pending block chunks into the reply pipeline before tool execution.
   ctx.flushBlockReplyBuffer();
-  if (ctx.params.onBlockReplyFlush) {
-    await ctx.params.onBlockReplyFlush();
+  // Legacy fallback: if hold/resume hooks are unavailable, force flush to preserve
+  // old tool-boundary behavior.
+  if (!canHoldBlockReplies && ctx.params.onBlockReplyFlush) {
+    void ctx.params.onBlockReplyFlush();
   }
 
   const rawToolName = String(evt.toolName);
@@ -310,6 +318,9 @@ export async function handleToolExecutionEnd(
     result?: unknown;
   },
 ) {
+  // Resume coalescer idle timer now that tool execution is complete
+  ctx.params.onBlockReplyResume?.();
+
   const toolName = normalizeToolName(String(evt.toolName));
   const toolCallId = String(evt.toolCallId);
   const runId = ctx.params.runId;

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -134,6 +134,8 @@ export type ToolHandlerParams = Pick<
   SubscribeEmbeddedPiSessionParams,
   | "runId"
   | "onBlockReplyFlush"
+  | "onBlockReplyHold"
+  | "onBlockReplyResume"
   | "onAgentEvent"
   | "onToolResult"
   | "sessionKey"

--- a/src/agents/pi-embedded-subscribe.types.ts
+++ b/src/agents/pi-embedded-subscribe.types.ts
@@ -23,6 +23,8 @@ export type SubscribeEmbeddedPiSessionParams = {
   onBlockReply?: (payload: BlockReplyPayload) => void | Promise<void>;
   /** Flush pending block replies (e.g., before tool execution to preserve message boundaries). */
   onBlockReplyFlush?: () => void | Promise<void>;
+  onBlockReplyHold?: () => void;
+  onBlockReplyResume?: () => void;
   blockReplyBreak?: "text_end" | "message_end";
   blockReplyChunking?: BlockReplyChunking;
   onPartialReply?: (payload: { text?: string; mediaUrls?: string[] }) => void | Promise<void>;

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -393,6 +393,18 @@ export async function runAgentTurnWithFallback(params: {
                     await blockReplyPipeline.flush({ force: true });
                   }
                 : undefined,
+            onBlockReplyHold:
+              params.blockStreamingEnabled && blockReplyPipeline
+                ? () => {
+                    blockReplyPipeline.hold();
+                  }
+                : undefined,
+            onBlockReplyResume:
+              params.blockStreamingEnabled && blockReplyPipeline
+                ? () => {
+                    blockReplyPipeline.resume();
+                  }
+                : undefined,
             shouldEmitToolResult: params.shouldEmitToolResult,
             shouldEmitToolOutput: params.shouldEmitToolOutput,
             onToolResult: onToolResult

--- a/src/auto-reply/reply/block-reply-coalescer.test.ts
+++ b/src/auto-reply/reply/block-reply-coalescer.test.ts
@@ -1,0 +1,266 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createBlockReplyCoalescer } from "./block-reply-coalescer.js";
+
+describe("BlockReplyCoalescer hold/resume behavior", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("does not flush on idle timer when held", async () => {
+    const onFlush = vi.fn();
+    const coalescer = createBlockReplyCoalescer({
+      config: { minChars: 1, maxChars: 1000, idleMs: 1000, joiner: "" },
+      shouldAbort: () => false,
+      onFlush,
+    });
+
+    // Enqueue text (starts idle timer)
+    coalescer.enqueue({ text: "Hello" });
+    expect(onFlush).not.toHaveBeenCalled();
+
+    // Hold the coalescer
+    coalescer.hold();
+
+    // Advance time past idleMs
+    await vi.advanceTimersByTimeAsync(1500);
+
+    // Should NOT have flushed
+    expect(onFlush).not.toHaveBeenCalled();
+  });
+
+  it("resumes idle timer after resume()", async () => {
+    const onFlush = vi.fn();
+    const coalescer = createBlockReplyCoalescer({
+      config: { minChars: 1, maxChars: 1000, idleMs: 1000, joiner: "" },
+      shouldAbort: () => false,
+      onFlush,
+    });
+
+    // Enqueue text
+    coalescer.enqueue({ text: "Hello" });
+
+    // Hold
+    coalescer.hold();
+    await vi.advanceTimersByTimeAsync(1500);
+    expect(onFlush).not.toHaveBeenCalled();
+
+    // Resume (should restart idle timer)
+    coalescer.resume();
+
+    // Advance time past idleMs
+    await vi.advanceTimersByTimeAsync(1100);
+
+    // Should have flushed
+    expect(onFlush).toHaveBeenCalledTimes(1);
+    expect(onFlush).toHaveBeenCalledWith({ text: "Hello" });
+  });
+
+  it("hold clears existing idle timer", async () => {
+    const onFlush = vi.fn();
+    const coalescer = createBlockReplyCoalescer({
+      config: { minChars: 1, maxChars: 1000, idleMs: 1000, joiner: "" },
+      shouldAbort: () => false,
+      onFlush,
+    });
+
+    // Enqueue text (starts idle timer)
+    coalescer.enqueue({ text: "Hello" });
+
+    // Advance partway through idle period
+    await vi.advanceTimersByTimeAsync(500);
+
+    // Hold before timer fires
+    coalescer.hold();
+
+    // Advance past original idleMs
+    await vi.advanceTimersByTimeAsync(600);
+
+    // Should NOT have flushed (timer was cleared)
+    expect(onFlush).not.toHaveBeenCalled();
+  });
+
+  it("resume with no buffered text does not schedule timer", async () => {
+    const onFlush = vi.fn();
+    const coalescer = createBlockReplyCoalescer({
+      config: { minChars: 1, maxChars: 1000, idleMs: 1000, joiner: "" },
+      shouldAbort: () => false,
+      onFlush,
+    });
+
+    // Hold with no text
+    coalescer.hold();
+
+    // Resume with no buffered text
+    coalescer.resume();
+
+    // Advance time
+    await vi.advanceTimersByTimeAsync(1500);
+
+    // Should NOT have flushed (no buffered text)
+    expect(onFlush).not.toHaveBeenCalled();
+  });
+
+  it("flush with force:true works even when held", async () => {
+    const onFlush = vi.fn();
+    const coalescer = createBlockReplyCoalescer({
+      config: { minChars: 1, maxChars: 1000, idleMs: 1000, joiner: "" },
+      shouldAbort: () => false,
+      onFlush,
+    });
+
+    // Enqueue text
+    coalescer.enqueue({ text: "Hello" });
+
+    // Hold
+    coalescer.hold();
+
+    // Force flush
+    await coalescer.flush({ force: true });
+
+    // Should have flushed despite being held
+    expect(onFlush).toHaveBeenCalledTimes(1);
+    expect(onFlush).toHaveBeenCalledWith({ text: "Hello" });
+  });
+
+  it("multiple hold/resume cycles work correctly", async () => {
+    const onFlush = vi.fn();
+    const coalescer = createBlockReplyCoalescer({
+      config: { minChars: 1, maxChars: 1000, idleMs: 1000, joiner: "" },
+      shouldAbort: () => false,
+      onFlush,
+    });
+
+    // First cycle
+    coalescer.enqueue({ text: "First" });
+    coalescer.hold();
+    await vi.advanceTimersByTimeAsync(1500);
+    expect(onFlush).not.toHaveBeenCalled();
+
+    coalescer.resume();
+    await vi.advanceTimersByTimeAsync(1100);
+    expect(onFlush).toHaveBeenCalledTimes(1);
+    expect(onFlush).toHaveBeenCalledWith({ text: "First" });
+
+    // Second cycle
+    onFlush.mockClear();
+    coalescer.enqueue({ text: "Second" });
+    coalescer.hold();
+    await vi.advanceTimersByTimeAsync(1500);
+    expect(onFlush).not.toHaveBeenCalled();
+
+    coalescer.resume();
+    await vi.advanceTimersByTimeAsync(1100);
+    expect(onFlush).toHaveBeenCalledTimes(1);
+    expect(onFlush).toHaveBeenCalledWith({ text: "Second" });
+
+    // Third cycle - enqueue after hold/resume
+    onFlush.mockClear();
+    coalescer.hold();
+    coalescer.resume();
+    coalescer.enqueue({ text: "Third" });
+    await vi.advanceTimersByTimeAsync(1100);
+    expect(onFlush).toHaveBeenCalledTimes(1);
+    expect(onFlush).toHaveBeenCalledWith({ text: "Third" });
+  });
+
+  it("enqueue during hold accumulates text for later flush", async () => {
+    const onFlush = vi.fn();
+    const coalescer = createBlockReplyCoalescer({
+      config: { minChars: 1, maxChars: 1000, idleMs: 1000, joiner: "" },
+      shouldAbort: () => false,
+      onFlush,
+    });
+
+    // Enqueue first text
+    coalescer.enqueue({ text: "text_1" });
+    expect(onFlush).not.toHaveBeenCalled();
+
+    // Hold
+    coalescer.hold();
+
+    // Enqueue second text while held
+    coalescer.enqueue({ text: "text_2" });
+    await vi.advanceTimersByTimeAsync(1500);
+    expect(onFlush).not.toHaveBeenCalled();
+
+    // Resume and wait for flush
+    coalescer.resume();
+    await vi.advanceTimersByTimeAsync(1100);
+
+    // Should have flushed coalesced text
+    expect(onFlush).toHaveBeenCalledTimes(1);
+    expect(onFlush).toHaveBeenCalledWith({ text: "text_1text_2" });
+  });
+
+  it("parallel holds require matching resumes", async () => {
+    const onFlush = vi.fn();
+    const coalescer = createBlockReplyCoalescer({
+      config: { minChars: 1, maxChars: 1000, idleMs: 1000, joiner: "" },
+      shouldAbort: () => false,
+      onFlush,
+    });
+
+    // Enqueue text
+    coalescer.enqueue({ text: "Hello" });
+
+    // Two parallel holds
+    coalescer.hold();
+    coalescer.hold();
+
+    // First resume (holdCount=1, still held)
+    coalescer.resume();
+    await vi.advanceTimersByTimeAsync(1500);
+    expect(onFlush).not.toHaveBeenCalled();
+
+    // Second resume (holdCount=0, no longer held)
+    coalescer.resume();
+    await vi.advanceTimersByTimeAsync(1100);
+
+    // Should have flushed after both resumes
+    expect(onFlush).toHaveBeenCalledTimes(1);
+    expect(onFlush).toHaveBeenCalledWith({ text: "Hello" });
+  });
+
+  it("media enqueue during hold does not reset hold state", async () => {
+    const onFlush = vi.fn();
+    const coalescer = createBlockReplyCoalescer({
+      config: { minChars: 1, maxChars: 1000, idleMs: 1000, joiner: "" },
+      shouldAbort: () => false,
+      onFlush,
+    });
+
+    // Enqueue text
+    coalescer.enqueue({ text: "Hello" });
+    expect(onFlush).not.toHaveBeenCalled();
+
+    // Hold
+    coalescer.hold();
+
+    // Enqueue media (triggers internal force flush)
+    coalescer.enqueue({ mediaUrl: "http://example.com/image.jpg" });
+
+    // Media should have flushed text, then media
+    expect(onFlush).toHaveBeenCalledTimes(2);
+    expect(onFlush).toHaveBeenNthCalledWith(1, { text: "Hello" });
+    expect(onFlush).toHaveBeenNthCalledWith(2, { mediaUrl: "http://example.com/image.jpg" });
+
+    // Enqueue more text after media
+    onFlush.mockClear();
+    coalescer.enqueue({ text: "World" });
+
+    // Advance time - should NOT flush because still held
+    await vi.advanceTimersByTimeAsync(1500);
+    expect(onFlush).not.toHaveBeenCalled();
+
+    // Resume should allow flush
+    coalescer.resume();
+    await vi.advanceTimersByTimeAsync(1100);
+    expect(onFlush).toHaveBeenCalledTimes(1);
+    expect(onFlush).toHaveBeenCalledWith({ text: "World" });
+  });
+});

--- a/src/auto-reply/reply/block-reply-pipeline.test.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from "vitest";
+import { createBlockReplyPipeline } from "./block-reply-pipeline.js";
+
+describe("BlockReplyPipeline hold/resume pass-through", () => {
+  it("hold() and resume() pass through to coalescer", () => {
+    const onBlockReply = vi.fn();
+    const pipeline = createBlockReplyPipeline({
+      onBlockReply,
+      timeoutMs: 5000,
+      coalescing: {
+        minChars: 1,
+        maxChars: 1000,
+        idleMs: 1000,
+        joiner: "",
+      },
+    });
+
+    // Verify hold and resume methods exist and are callable
+    expect(typeof pipeline.hold).toBe("function");
+    expect(typeof pipeline.resume).toBe("function");
+
+    // Should not throw
+    pipeline.hold();
+    pipeline.resume();
+  });
+});

--- a/src/auto-reply/reply/block-reply-pipeline.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.ts
@@ -11,6 +11,8 @@ export type BlockReplyPipeline = {
   didStream: () => boolean;
   isAborted: () => boolean;
   hasSentPayload: (payload: ReplyPayload) => boolean;
+  hold: () => void;
+  resume: () => void;
 };
 
 export type BlockReplyBuffer = {
@@ -241,5 +243,7 @@ export function createBlockReplyPipeline(params: {
       const payloadKey = createBlockReplyPayloadKey(payload);
       return sentKeys.has(payloadKey);
     },
+    hold: () => coalescer?.hold(),
+    resume: () => coalescer?.resume(),
   };
 }


### PR DESCRIPTION
## Summary

Tool-heavy replies were being split into multiple outbound messages because block coalescing could idle-flush while a tool call was still running. This PR pauses idle-based coalescing during tool execution and resumes it when the tool ends, so pre-tool and post-tool text can remain in one coherent streamed reply.

## What Changed

### Block coalescer hold and resume during tool execution

When a tool call takes longer than the coalescer idle timeout, buffered assistant text flushes mid-tool. Subsequent text then arrives as additional messages, which appears as fragmented or duplicate reply behavior across channels.

- `src/auto-reply/reply/block-reply-coalescer.ts`: Added hold/resume semantics to the coalescer with new `hold()` and `resume()` APIs.
- `src/auto-reply/reply/block-reply-coalescer.ts`: Added ref-counted `holdCount` so overlapping holds are handled safely.
- `src/auto-reply/reply/block-reply-coalescer.ts`: `scheduleIdleFlush()` now skips scheduling while held.
- `src/auto-reply/reply/block-reply-coalescer.ts`: `hold()` clears any active idle timer, and `resume()` reschedules only when all holds are released and text is buffered.
- `src/auto-reply/reply/block-reply-pipeline.ts`: Exposed pass-through hold/resume on the pipeline.
- `src/auto-reply/reply/agent-runner-execution.ts`, `src/agents/pi-embedded-runner/run.ts`, `src/agents/pi-embedded-runner/run/attempt.ts`, `src/agents/pi-embedded-runner/run/params.ts`, `src/agents/pi-embedded-subscribe.types.ts`, and `src/agents/pi-embedded-subscribe.handlers.types.ts`: Wired callbacks from auto-reply execution into embedded runner plumbing.
- `src/agents/pi-embedded-subscribe.handlers.tools.ts`: `handleToolExecutionStart(...)` now calls `onBlockReplyHold()` first, then drains buffered block output via `flushBlockReplyBuffer()`. When `onBlockReplyHold` is unavailable, it falls back to the legacy `onBlockReplyFlush()` path.
- `src/agents/pi-embedded-subscribe.handlers.tools.ts`: `handleToolExecutionEnd(...)` now calls `onBlockReplyResume()` before processing results.

## Design Notes

- Ref-counted hold state (instead of a boolean) was chosen so parallel and overlapping tool execution cannot resume coalescing too early.
- The change intentionally pauses only idle-timer flush behavior; force flush paths remain available for explicit boundaries and media payload behavior.
- New callbacks are optional, preserving compatibility for call paths that do not enable block streaming.

## Testing

- Added `src/auto-reply/reply/block-reply-coalescer.test.ts` with coverage for idle suppression while held, timer restart on resume, nested/parallel hold balancing, force flush behavior while held, and media enqueue behavior during hold.
- Added `src/auto-reply/reply/block-reply-pipeline.test.ts` for hold/resume passthrough.
- Updated `src/agents/pi-embedded-subscribe.handlers.tools.test.ts` to validate hold at tool start and resume at tool end.
- Updated `src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.calls-onblockreplyflush-before-tool-execution-start-preserve.test.ts` to assert `onBlockReplyHold` and added fallback test for when hold callback is unavailable.
- Ran: `pnpm test src/auto-reply/reply/block-reply-coalescer.test.ts src/auto-reply/reply/block-reply-pipeline.test.ts src/agents/pi-embedded-subscribe.handlers.tools.test.ts`
- Result: 3 files passed, 20 tests passed.

## AI Disclosure

- [x] AI-assisted
- [x] Fully tested

## Related Issues

- #12659
- #13788
- #20226

---

Closes #3549
Closes #13944
Closes #15022
Closes #15968
Closes #20740
Closes #22258