### PR TITLE
docs: fix typo p-coding-agent -> pi-coding-agent

### DIFF
--- a/docs/concepts/system-prompt.md
+++ b/docs/concepts/system-prompt.md
@@ -8,7 +8,7 @@ title: "System Prompt"
 
 # System Prompt
 
-OpenClaw builds a custom system prompt for every agent run. The prompt is **OpenClaw-owned** and does not use the p-coding-agent default prompt.
+OpenClaw builds a custom system prompt for every agent run. The prompt is **OpenClaw-owned** and does not use the pi-coding-agent default prompt.
 
 The prompt is assembled by OpenClaw and injected into each agent run.
 

--- a/docs/zh-CN/concepts/system-prompt.md
+++ b/docs/zh-CN/concepts/system-prompt.md
@@ -15,7 +15,7 @@ x-i18n:
 
 # 系统提示词
 
-OpenClaw 为每次智能体运行构建自定义系统提示词。该提示词由 **OpenClaw 拥有**，不使用 p-coding-agent 默认提示词。
+OpenClaw 为每次智能体运行构建自定义系统提示词。该提示词由 **OpenClaw 拥有**，不使用 pi-coding-agent 默认提示词。
 
 该提示词由 OpenClaw 组装并注入到每次智能体运行中。
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: typo in docs

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixes a typo in the system prompt documentation: `p-coding-agent` → `pi-coding-agent`. The change is applied consistently in both the English and Chinese (`zh-CN`) versions of `docs/concepts/system-prompt.md`.

- Corrects a missing letter (`i`) in the `pi-coding-agent` package name reference
- No functional or behavioral changes

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal documentation-only typo fix with no code changes.
- The change fixes a single-character typo (`p-coding-agent` → `pi-coding-agent`) in two documentation files. The correct name `pi-coding-agent` is confirmed by 60+ references throughout the codebase including package.json. There is zero risk of functional regression.
- No files require special attention.

<sub>Last reviewed commit: d1778ce</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->