### PR TITLE
fix: strip leading empty lines in sanitizeUserFacingText

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ Docs: https://docs.openclaw.ai
 - Security/Audit: warn when `gateway.tools.allow` re-enables default-denied tools over HTTP `POST /tools/invoke`, since this can increase RCE blast radius if the gateway is reachable.
 - Security/Plugins/Hooks: harden npm-based installs by restricting specs to registry packages only, passing `--ignore-scripts` to `npm pack`, and cleaning up temp install directories.
 - Feishu: stop persistent Typing reaction on NO_REPLY/suppressed runs by wiring reply-dispatcher cleanup to remove typing indicators. (#15464) Thanks @arosstale.
-- Agents: strip leading whitespace/newlines from `sanitizeUserFacingText` output and normalize whitespace-only outputs to empty text. (#16158) Thanks @mcinteerj.
+- Agents: strip leading empty lines from `sanitizeUserFacingText` output and normalize whitespace-only outputs to empty text. (#16158) Thanks @mcinteerj.
 - BlueBubbles: gracefully degrade when Private API is disabled by filtering private-only actions, skipping private-only reactions/reply effects, and avoiding private reply markers so non-private flows remain usable. (#16002) Thanks @L-U-C-K-Y.
 - Outbound: add a write-ahead delivery queue with crash-recovery retries to prevent lost outbound messages after gateway restarts. (#15636) Thanks @nabbilkhan, @thewilloftheshadow.
 - Auto-reply/Threading: auto-inject implicit reply threading so `replyToMode` works without requiring model-emitted `[[reply_to_current]]`, while preserving `replyToMode: "off"` behavior for implicit Slack replies and keeping block-streaming chunk coalescing stable under `replyToMode: "first"`. (#14976) Thanks @Diaspar4u.

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.e2e.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.e2e.test.ts
@@ -77,7 +77,7 @@ describe("sanitizeUserFacingText", () => {
   });
 
   it("strips leading whitespace and newlines combined", () => {
-    expect(sanitizeUserFacingText("\n \n Hello")).toBe("Hello");
+    expect(sanitizeUserFacingText("\n \nHello")).toBe("Hello");
     expect(sanitizeUserFacingText("  \n\nHello")).toBe("Hello");
   });
 

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -527,7 +527,10 @@ export function sanitizeUserFacingText(text: string, opts?: { errorContext?: boo
     }
   }
 
-  return collapseConsecutiveDuplicateBlocks(stripped).trimStart();
+  // Strip leading blank lines (including whitespace-only lines) without clobbering indentation on
+  // the first content line (e.g. markdown/code blocks).
+  const withoutLeadingEmptyLines = stripped.replace(/^(?:[ \t]*\r?\n)+/, "");
+  return collapseConsecutiveDuplicateBlocks(withoutLeadingEmptyLines);
 }
 
 export function isRateLimitAssistantError(msg: AssistantMessage | undefined): boolean {


### PR DESCRIPTION
Ports #16158 to a maintainer branch, strips leading empty lines (not full trimStart) and normalizes whitespace-only outputs to empty.

Thanks @mcinteerj.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Refines `sanitizeUserFacingText` to strip only leading blank lines instead of all leading whitespace. This preserves indentation on the first content line (important for markdown/code blocks) while still removing spurious empty lines from LLM output.

- **`src/agents/pi-embedded-helpers/errors.ts`**: Replaces `.trimStart()` with a regex (`/^(?:[ \t]*\r?\n)+/`) that removes leading blank/whitespace-only lines without clobbering first-line indentation. Also reorders the operation to strip leading lines before passing to `collapseConsecutiveDuplicateBlocks`.
- **Test update**: Adjusts one test case to reflect that leading spaces on the first content line are now intentionally preserved.
- **CHANGELOG**: Updates wording from "strip leading whitespace/newlines" to "strip leading empty lines" to match the actual behavior.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a focused, well-scoped behavior refinement with correct regex logic and updated tests.
- The change is minimal and targeted: a single regex replacement that is more precise than the previous `.trimStart()`. The regex is correct, the test was updated to reflect the new behavior, and the CHANGELOG accurately describes the change. No callers are affected negatively — the only observable difference is that leading indentation on the first content line is now preserved, which is the intended improvement.
- No files require special attention.

<sub>Last reviewed commit: 5d29c8f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->