### PR TITLE
fix(discord): use raw event guild_id in inbound message log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 - Security/Media: reject oversized base64-backed input media before decoding to avoid large allocations. Thanks @vincentkoc.
 - Security/Gateway: reject oversized base64 chat attachments before decoding to avoid large allocations. Thanks @vincentkoc.
 - Cron/Slack: preserve agent identity (name and icon) when cron jobs deliver outbound messages. (#16242) Thanks @robbyczgw-cla.
+- Discord: log inbound guild id from raw event payload to avoid missing guild labels. (#16283) Thanks @jasonftl.
 
 ## 2026.2.14
 

--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -446,7 +446,7 @@ export async function preflightDiscordMessage(
   );
   if (shouldLogVerbose()) {
     logVerbose(
-      `discord: inbound id=${message.id} guild=${message.guild?.id ?? "dm"} channel=${message.channelId} mention=${wasMentioned ? "yes" : "no"} type=${isDirectMessage ? "dm" : isGroupDm ? "group-dm" : "guild"} content=${messageText ? "yes" : "no"}`,
+      `discord: inbound id=${message.id} guild=${params.data.guild_id ?? "dm"} channel=${message.channelId} mention=${wasMentioned ? "yes" : "no"} type=${isDirectMessage ? "dm" : isGroupDm ? "group-dm" : "guild"} content=${messageText ? "yes" : "no"}`,
     );
   }
 


### PR DESCRIPTION
## Summary

- Problem: The verbose inbound message log shows `guild=dm` for guild channel messages when the Discord client hasn't cached the guild object
- Why it matters: Misleading logs make it harder to debug routing issues like role allowlist bypass failures (see #16207)
- What changed: Replaced `message.guild?.id` with `params.data.guild_id` in the log line — uses the raw gateway event field instead of the cached guild object
- What did NOT change (scope boundary): No routing or classification logic changed; only the verbose log label

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #16207

## User-visible / Behavior Changes

Verbose log output changes from `guild=dm` to `guild=<actual_guild_id>` for guild channel messages when the guild isn't cached.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux (WSL2)
- Runtime/container: Node 24.13.1
- Model/provider: N/A
- Integration/channel (if any): Discord
- Relevant config (redacted): N/A

### Steps

1. Start gateway with Discord channel configured
2. Send a message in a guild channel before the guild object is cached
3. Check verbose logs

### Expected

- Log shows `guild=<guild_id>` with the actual guild snowflake ID

### Actual

- Log shows `guild=dm` because `message.guild` is null (not yet cached)

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets — `guild=dm` in log for guild channel messages as reported in #16207
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: Code review confirmed `message.guild?.id` depends on cache while `params.data.guild_id` comes from the raw Discord gateway event
- Edge cases checked: DMs correctly fall through to "dm" since `params.data.guild_id` is undefined for DMs
- What you did **not** verify: Live Discord gateway testing (no Discord bot configured in dev environment)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert single line in message-handler.preflight.ts
- Files/config to restore: `src/discord/monitor/message-handler.preflight.ts`
- Known bad symptoms reviewers should watch for: `guild=undefined` in logs for DMs (would indicate regression, but current code handles this via `?? "dm"` fallback)

## Risks and Mitigations

None — single log-line data source change, no logic affected.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Changed verbose log line to use raw Discord gateway event field (`params.data.guild_id`) instead of cached guild object (`message.guild?.id`) for guild identification. Fixes misleading `guild=dm` log output when guild objects aren't cached yet.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Single-line logging change that replaces a cache-dependent value with a reliable raw event field. The change is consistent with how `guild_id` is used elsewhere in the file (lines 103, 230, 272), and the fallback to "dm" is appropriate since DMs don't have a `guild_id` field. No logic or behavior changes, only affects verbose log output accuracy.
- No files require special attention

<sub>Last reviewed commit: 49d402d</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->