### PR TITLE
fix(feishu): route tool credentials by account parameter

### DIFF
--- a/docs/start/onboarding.md
+++ b/docs/start/onboarding.md
@@ -29,6 +29,12 @@ For a general overview of onboarding paths, see [Onboarding Overview](/start/onb
 <Frame caption="Read the security notice displayed and decide accordingly">
 <img src="/assets/macos-onboarding/03-security-notice.png" alt="" />
 </Frame>
+
+Security trust model:
+
+- By default, OpenClaw is a personal agent: one trusted operator boundary.
+- Shared/multi-user setups require lock-down (split trust boundaries, keep tool access minimal, and follow [Security](/gateway/security)).
+
 </Step>
 <Step title="Local vs Remote">
 <Frame>
@@ -37,17 +43,19 @@ For a general overview of onboarding paths, see [Onboarding Overview](/start/onb
 
 Where does the **Gateway** run?
 
-- **This Mac (Local only):** onboarding can run OAuth flows and write credentials
+- **This Mac (Local only):** onboarding can configure auth and write credentials
   locally.
-- **Remote (over SSH/Tailnet):** onboarding does **not** run OAuth locally;
+- **Remote (over SSH/Tailnet):** onboarding does **not** configure local auth;
   credentials must exist on the gateway host.
 - **Configure later:** skip setup and leave the app unconfigured.
 
 <Tip>
 **Gateway auth tip:**
+
 - The wizard now generates a **token** even for loopback, so local WS clients must authenticate.
 - If you disable auth, any local process can connect; use that only on fully trusted machines.
 - Use a **token** for multi‑machine access or non‑loopback binds.
+
 </Tip>
 </Step>
 <Step title="Permissions">

--- a/extensions/feishu/src/accounts.ts
+++ b/extensions/feishu/src/accounts.ts
@@ -149,20 +149,29 @@ export function listEnabledFeishuAccounts(cfg: ClawdbotConfig): ResolvedFeishuAc
  * If accountId is provided, resolves that specific account.
  * Otherwise falls back to the first enabled account (preserving current behavior).
  */
-export function resolveToolClient(cfg: ClawdbotConfig, accountId?: string) {
-  if (accountId) {
-    const account = resolveFeishuAccount({ cfg, accountId });
+export function resolveToolClient(
+  cfg: ClawdbotConfig,
+  accountId?: string,
+  preferredAccountId?: string,
+) {
+  const requested = accountId || preferredAccountId;
+  if (requested) {
+    const account = resolveFeishuAccount({ cfg, accountId: requested });
     if (!account.configured) {
-      throw new Error(`Feishu account "${accountId}" is not configured`);
+      throw new Error(`Feishu account "${requested}" is not configured`);
     }
     if (!account.enabled) {
-      throw new Error(`Feishu account "${accountId}" is disabled`);
+      throw new Error(`Feishu account "${requested}" is disabled`);
     }
-    return { client: createFeishuClient(account), accountId: account.accountId };
+    return { client: createFeishuClient(account), accountId: account.accountId, account };
   }
   const accounts = listEnabledFeishuAccounts(cfg);
   if (accounts.length === 0) {
     throw new Error("No Feishu accounts configured");
   }
-  return { client: createFeishuClient(accounts[0]), accountId: accounts[0].accountId };
+  return {
+    client: createFeishuClient(accounts[0]),
+    accountId: accounts[0].accountId,
+    account: accounts[0],
+  };
 }

--- a/extensions/feishu/src/accounts.ts
+++ b/extensions/feishu/src/accounts.ts
@@ -6,6 +6,7 @@ import type {
   FeishuDomain,
   ResolvedFeishuAccount,
 } from "./types.js";
+import { createFeishuClient } from "./client.js";
 
 /**
  * List all configured account IDs from the accounts field.
@@ -141,4 +142,27 @@ export function listEnabledFeishuAccounts(cfg: ClawdbotConfig): ResolvedFeishuAc
   return listFeishuAccountIds(cfg)
     .map((accountId) => resolveFeishuAccount({ cfg, accountId }))
     .filter((account) => account.enabled && account.configured);
+}
+
+/**
+ * Resolve a Feishu client for tool execution.
+ * If accountId is provided, resolves that specific account.
+ * Otherwise falls back to the first enabled account (preserving current behavior).
+ */
+export function resolveToolClient(cfg: ClawdbotConfig, accountId?: string) {
+  if (accountId) {
+    const account = resolveFeishuAccount({ cfg, accountId });
+    if (!account.configured) {
+      throw new Error(`Feishu account "${accountId}" is not configured`);
+    }
+    if (!account.enabled) {
+      throw new Error(`Feishu account "${accountId}" is disabled`);
+    }
+    return { client: createFeishuClient(account), accountId: account.accountId };
+  }
+  const accounts = listEnabledFeishuAccounts(cfg);
+  if (accounts.length === 0) {
+    throw new Error("No Feishu accounts configured");
+  }
+  return { client: createFeishuClient(accounts[0]), accountId: accounts[0].accountId };
 }

--- a/extensions/feishu/src/accounts.ts
+++ b/extensions/feishu/src/accounts.ts
@@ -1,12 +1,12 @@
 import type { ClawdbotConfig } from "openclaw/plugin-sdk";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-id";
+import { createFeishuClient } from "./client.js";
 import type {
   FeishuConfig,
   FeishuAccountConfig,
   FeishuDomain,
   ResolvedFeishuAccount,
 } from "./types.js";
-import { createFeishuClient } from "./client.js";
 
 /**
  * List all configured account IDs from the accounts field.

--- a/extensions/feishu/src/bitable.ts
+++ b/extensions/feishu/src/bitable.ts
@@ -1,7 +1,8 @@
-import { Type } from "@sinclair/typebox";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
-import { createFeishuClient } from "./client.js";
+import { Type } from "@sinclair/typebox";
 import type { FeishuConfig } from "./types.js";
+import { listEnabledFeishuAccounts, resolveToolClient } from "./accounts.js";
+import { createFeishuClient } from "./client.js";
 
 // ============ Helpers ============
 
@@ -439,10 +440,15 @@ async function updateRecord(
 
 // ============ Schemas ============
 
+const AccountField = Type.Optional(
+  Type.String({ description: "Feishu account ID. Omit to use the default account." }),
+);
+
 const GetMetaSchema = Type.Object({
   url: Type.String({
     description: "Bitable URL. Supports both formats: /base/XXX?table=YYY or /wiki/XXX?table=YYY",
   }),
+  account: AccountField,
 });
 
 const ListFieldsSchema = Type.Object({
@@ -450,6 +456,7 @@ const ListFieldsSchema = Type.Object({
     description: "Bitable app token (use feishu_bitable_get_meta to get from URL)",
   }),
   table_id: Type.String({ description: "Table ID (from URL: ?table=YYY)" }),
+  account: AccountField,
 });
 
 const ListRecordsSchema = Type.Object({
@@ -467,6 +474,7 @@ const ListRecordsSchema = Type.Object({
   page_token: Type.Optional(
     Type.String({ description: "Pagination token from previous response" }),
   ),
+  account: AccountField,
 });
 
 const GetRecordSchema = Type.Object({
@@ -475,6 +483,7 @@ const GetRecordSchema = Type.Object({
   }),
   table_id: Type.String({ description: "Table ID (from URL: ?table=YYY)" }),
   record_id: Type.String({ description: "Record ID to retrieve" }),
+  account: AccountField,
 });
 
 const CreateRecordSchema = Type.Object({
@@ -486,6 +495,7 @@ const CreateRecordSchema = Type.Object({
     description:
       "Field values keyed by field name. Format by type: Text='string', Number=123, SingleSelect='Option', MultiSelect=['A','B'], DateTime=timestamp_ms, User=[{id:'ou_xxx'}], URL={text:'Display',link:'https://...'}",
   }),
+  account: AccountField,
 });
 
 const CreateAppSchema = Type.Object({
@@ -527,18 +537,22 @@ const UpdateRecordSchema = Type.Object({
   fields: Type.Record(Type.String(), Type.Any(), {
     description: "Field values to update (same format as create_record)",
   }),
+  account: AccountField,
 });
 
 // ============ Tool Registration ============
 
 export function registerFeishuBitableTools(api: OpenClawPluginApi) {
-  const feishuCfg = api.config?.channels?.feishu as FeishuConfig | undefined;
-  if (!feishuCfg?.appId || !feishuCfg?.appSecret) {
-    api.logger.debug?.("feishu_bitable: Feishu credentials not configured, skipping bitable tools");
+  if (!api.config) {
+    api.logger.debug?.("feishu_bitable: No config available, skipping bitable tools");
     return;
   }
 
-  const getClient = () => createFeishuClient(feishuCfg);
+  const accounts = listEnabledFeishuAccounts(api.config);
+  if (accounts.length === 0) {
+    api.logger.debug?.("feishu_bitable: No Feishu accounts configured, skipping bitable tools");
+    return;
+  }
 
   // Tool 0: feishu_bitable_get_meta (helper to parse URLs)
   api.registerTool(
@@ -549,9 +563,10 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
         "Parse a Bitable URL and get app_token, table_id, and table list. Use this first when given a /wiki/ or /base/ URL.",
       parameters: GetMetaSchema,
       async execute(_toolCallId, params) {
-        const { url } = params as { url: string };
+        const { url, account } = params as { url: string; account?: string };
         try {
-          const result = await getBitableMeta(getClient(), url);
+          const { client } = resolveToolClient(api.config!, account);
+          const result = await getBitableMeta(client, url);
           return json(result);
         } catch (err) {
           return json({ error: err instanceof Error ? err.message : String(err) });
@@ -569,9 +584,14 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
       description: "List all fields (columns) in a Bitable table with their types and properties",
       parameters: ListFieldsSchema,
       async execute(_toolCallId, params) {
-        const { app_token, table_id } = params as { app_token: string; table_id: string };
+        const { app_token, table_id, account } = params as {
+          app_token: string;
+          table_id: string;
+          account?: string;
+        };
         try {
-          const result = await listFields(getClient(), app_token, table_id);
+          const { client } = resolveToolClient(api.config!, account);
+          const result = await listFields(client, app_token, table_id);
           return json(result);
         } catch (err) {
           return json({ error: err instanceof Error ? err.message : String(err) });
@@ -589,14 +609,16 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
       description: "List records (rows) from a Bitable table with pagination support",
       parameters: ListRecordsSchema,
       async execute(_toolCallId, params) {
-        const { app_token, table_id, page_size, page_token } = params as {
+        const { app_token, table_id, page_size, page_token, account } = params as {
           app_token: string;
           table_id: string;
           page_size?: number;
           page_token?: string;
+          account?: string;
         };
         try {
-          const result = await listRecords(getClient(), app_token, table_id, page_size, page_token);
+          const { client } = resolveToolClient(api.config!, account);
+          const result = await listRecords(client, app_token, table_id, page_size, page_token);
           return json(result);
         } catch (err) {
           return json({ error: err instanceof Error ? err.message : String(err) });
@@ -614,13 +636,15 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
       description: "Get a single record by ID from a Bitable table",
       parameters: GetRecordSchema,
       async execute(_toolCallId, params) {
-        const { app_token, table_id, record_id } = params as {
+        const { app_token, table_id, record_id, account } = params as {
           app_token: string;
           table_id: string;
           record_id: string;
+          account?: string;
         };
         try {
-          const result = await getRecord(getClient(), app_token, table_id, record_id);
+          const { client } = resolveToolClient(api.config!, account);
+          const result = await getRecord(client, app_token, table_id, record_id);
           return json(result);
         } catch (err) {
           return json({ error: err instanceof Error ? err.message : String(err) });
@@ -638,13 +662,15 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
       description: "Create a new record (row) in a Bitable table",
       parameters: CreateRecordSchema,
       async execute(_toolCallId, params) {
-        const { app_token, table_id, fields } = params as {
+        const { app_token, table_id, fields, account } = params as {
           app_token: string;
           table_id: string;
           fields: Record<string, unknown>;
+          account?: string;
         };
         try {
-          const result = await createRecord(getClient(), app_token, table_id, fields);
+          const { client } = resolveToolClient(api.config!, account);
+          const result = await createRecord(client, app_token, table_id, fields);
           return json(result);
         } catch (err) {
           return json({ error: err instanceof Error ? err.message : String(err) });
@@ -662,14 +688,16 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
       description: "Update an existing record (row) in a Bitable table",
       parameters: UpdateRecordSchema,
       async execute(_toolCallId, params) {
-        const { app_token, table_id, record_id, fields } = params as {
+        const { app_token, table_id, record_id, fields, account } = params as {
           app_token: string;
           table_id: string;
           record_id: string;
           fields: Record<string, unknown>;
+          account?: string;
         };
         try {
-          const result = await updateRecord(getClient(), app_token, table_id, record_id, fields);
+          const { client } = resolveToolClient(api.config!, account);
+          const result = await updateRecord(client, app_token, table_id, record_id, fields);
           return json(result);
         } catch (err) {
           return json({ error: err instanceof Error ? err.message : String(err) });

--- a/extensions/feishu/src/bitable.ts
+++ b/extensions/feishu/src/bitable.ts
@@ -556,153 +556,176 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
 
   // Tool 0: feishu_bitable_get_meta (helper to parse URLs)
   api.registerTool(
-    {
-      name: "feishu_bitable_get_meta",
-      label: "Feishu Bitable Get Meta",
-      description:
-        "Parse a Bitable URL and get app_token, table_id, and table list. Use this first when given a /wiki/ or /base/ URL.",
-      parameters: GetMetaSchema,
-      async execute(_toolCallId, params) {
-        const { url, account } = params as { url: string; account?: string };
-        try {
-          const { client } = resolveToolClient(api.config!, account);
-          const result = await getBitableMeta(client, url);
-          return json(result);
-        } catch (err) {
-          return json({ error: err instanceof Error ? err.message : String(err) });
-        }
-      },
+    (ctx) => {
+      const preferredAccountId = ctx.agentAccountId;
+      return {
+        name: "feishu_bitable_get_meta",
+        label: "Feishu Bitable Get Meta",
+        description:
+          "Parse a Bitable URL and get app_token, table_id, and table list. Use this first when given a /wiki/ or /base/ URL. Auto-selects the bot that received the message when available.",
+        parameters: GetMetaSchema,
+        async execute(_toolCallId, params) {
+          const { url, account } = params as { url: string; account?: string };
+          try {
+            const { client } = resolveToolClient(api.config!, account, preferredAccountId);
+            const result = await getBitableMeta(client, url);
+            return json(result);
+          } catch (err) {
+            return json({ error: err instanceof Error ? err.message : String(err) });
+          }
+        },
+      };
     },
     { name: "feishu_bitable_get_meta" },
   );
 
   // Tool 1: feishu_bitable_list_fields
   api.registerTool(
-    {
-      name: "feishu_bitable_list_fields",
-      label: "Feishu Bitable List Fields",
-      description: "List all fields (columns) in a Bitable table with their types and properties",
-      parameters: ListFieldsSchema,
-      async execute(_toolCallId, params) {
-        const { app_token, table_id, account } = params as {
-          app_token: string;
-          table_id: string;
-          account?: string;
-        };
-        try {
-          const { client } = resolveToolClient(api.config!, account);
-          const result = await listFields(client, app_token, table_id);
-          return json(result);
-        } catch (err) {
-          return json({ error: err instanceof Error ? err.message : String(err) });
-        }
-      },
+    (ctx) => {
+      const preferredAccountId = ctx.agentAccountId;
+      return {
+        name: "feishu_bitable_list_fields",
+        label: "Feishu Bitable List Fields",
+        description:
+          "List all fields (columns) in a Bitable table with their types and properties. Auto-selects the bot that received the message when available.",
+        parameters: ListFieldsSchema,
+        async execute(_toolCallId, params) {
+          const { app_token, table_id, account } = params as {
+            app_token: string;
+            table_id: string;
+            account?: string;
+          };
+          try {
+            const { client } = resolveToolClient(api.config!, account, preferredAccountId);
+            const result = await listFields(client, app_token, table_id);
+            return json(result);
+          } catch (err) {
+            return json({ error: err instanceof Error ? err.message : String(err) });
+          }
+        },
+      };
     },
     { name: "feishu_bitable_list_fields" },
   );
 
   // Tool 2: feishu_bitable_list_records
   api.registerTool(
-    {
-      name: "feishu_bitable_list_records",
-      label: "Feishu Bitable List Records",
-      description: "List records (rows) from a Bitable table with pagination support",
-      parameters: ListRecordsSchema,
-      async execute(_toolCallId, params) {
-        const { app_token, table_id, page_size, page_token, account } = params as {
-          app_token: string;
-          table_id: string;
-          page_size?: number;
-          page_token?: string;
-          account?: string;
-        };
-        try {
-          const { client } = resolveToolClient(api.config!, account);
-          const result = await listRecords(client, app_token, table_id, page_size, page_token);
-          return json(result);
-        } catch (err) {
-          return json({ error: err instanceof Error ? err.message : String(err) });
-        }
-      },
+    (ctx) => {
+      const preferredAccountId = ctx.agentAccountId;
+      return {
+        name: "feishu_bitable_list_records",
+        label: "Feishu Bitable List Records",
+        description:
+          "List records (rows) from a Bitable table with pagination support. Auto-selects the bot that received the message when available.",
+        parameters: ListRecordsSchema,
+        async execute(_toolCallId, params) {
+          const { app_token, table_id, page_size, page_token, account } = params as {
+            app_token: string;
+            table_id: string;
+            page_size?: number;
+            page_token?: string;
+            account?: string;
+          };
+          try {
+            const { client } = resolveToolClient(api.config!, account, preferredAccountId);
+            const result = await listRecords(client, app_token, table_id, page_size, page_token);
+            return json(result);
+          } catch (err) {
+            return json({ error: err instanceof Error ? err.message : String(err) });
+          }
+        },
+      };
     },
     { name: "feishu_bitable_list_records" },
   );
 
   // Tool 3: feishu_bitable_get_record
   api.registerTool(
-    {
-      name: "feishu_bitable_get_record",
-      label: "Feishu Bitable Get Record",
-      description: "Get a single record by ID from a Bitable table",
-      parameters: GetRecordSchema,
-      async execute(_toolCallId, params) {
-        const { app_token, table_id, record_id, account } = params as {
-          app_token: string;
-          table_id: string;
-          record_id: string;
-          account?: string;
-        };
-        try {
-          const { client } = resolveToolClient(api.config!, account);
-          const result = await getRecord(client, app_token, table_id, record_id);
-          return json(result);
-        } catch (err) {
-          return json({ error: err instanceof Error ? err.message : String(err) });
-        }
-      },
+    (ctx) => {
+      const preferredAccountId = ctx.agentAccountId;
+      return {
+        name: "feishu_bitable_get_record",
+        label: "Feishu Bitable Get Record",
+        description:
+          "Get a single record by ID from a Bitable table. Auto-selects the bot that received the message when available.",
+        parameters: GetRecordSchema,
+        async execute(_toolCallId, params) {
+          const { app_token, table_id, record_id, account } = params as {
+            app_token: string;
+            table_id: string;
+            record_id: string;
+            account?: string;
+          };
+          try {
+            const { client } = resolveToolClient(api.config!, account, preferredAccountId);
+            const result = await getRecord(client, app_token, table_id, record_id);
+            return json(result);
+          } catch (err) {
+            return json({ error: err instanceof Error ? err.message : String(err) });
+          }
+        },
+      };
     },
     { name: "feishu_bitable_get_record" },
   );
 
   // Tool 4: feishu_bitable_create_record
   api.registerTool(
-    {
-      name: "feishu_bitable_create_record",
-      label: "Feishu Bitable Create Record",
-      description: "Create a new record (row) in a Bitable table",
-      parameters: CreateRecordSchema,
-      async execute(_toolCallId, params) {
-        const { app_token, table_id, fields, account } = params as {
-          app_token: string;
-          table_id: string;
-          fields: Record<string, unknown>;
-          account?: string;
-        };
-        try {
-          const { client } = resolveToolClient(api.config!, account);
-          const result = await createRecord(client, app_token, table_id, fields);
-          return json(result);
-        } catch (err) {
-          return json({ error: err instanceof Error ? err.message : String(err) });
-        }
-      },
+    (ctx) => {
+      const preferredAccountId = ctx.agentAccountId;
+      return {
+        name: "feishu_bitable_create_record",
+        label: "Feishu Bitable Create Record",
+        description:
+          "Create a new record (row) in a Bitable table. Auto-selects the bot that received the message when available.",
+        parameters: CreateRecordSchema,
+        async execute(_toolCallId, params) {
+          const { app_token, table_id, fields, account } = params as {
+            app_token: string;
+            table_id: string;
+            fields: Record<string, unknown>;
+            account?: string;
+          };
+          try {
+            const { client } = resolveToolClient(api.config!, account, preferredAccountId);
+            const result = await createRecord(client, app_token, table_id, fields);
+            return json(result);
+          } catch (err) {
+            return json({ error: err instanceof Error ? err.message : String(err) });
+          }
+        },
+      };
     },
     { name: "feishu_bitable_create_record" },
   );
 
   // Tool 5: feishu_bitable_update_record
   api.registerTool(
-    {
-      name: "feishu_bitable_update_record",
-      label: "Feishu Bitable Update Record",
-      description: "Update an existing record (row) in a Bitable table",
-      parameters: UpdateRecordSchema,
-      async execute(_toolCallId, params) {
-        const { app_token, table_id, record_id, fields, account } = params as {
-          app_token: string;
-          table_id: string;
-          record_id: string;
-          fields: Record<string, unknown>;
-          account?: string;
-        };
-        try {
-          const { client } = resolveToolClient(api.config!, account);
-          const result = await updateRecord(client, app_token, table_id, record_id, fields);
-          return json(result);
-        } catch (err) {
-          return json({ error: err instanceof Error ? err.message : String(err) });
-        }
-      },
+    (ctx) => {
+      const preferredAccountId = ctx.agentAccountId;
+      return {
+        name: "feishu_bitable_update_record",
+        label: "Feishu Bitable Update Record",
+        description:
+          "Update an existing record (row) in a Bitable table. Auto-selects the bot that received the message when available.",
+        parameters: UpdateRecordSchema,
+        async execute(_toolCallId, params) {
+          const { app_token, table_id, record_id, fields, account } = params as {
+            app_token: string;
+            table_id: string;
+            record_id: string;
+            fields: Record<string, unknown>;
+            account?: string;
+          };
+          try {
+            const { client } = resolveToolClient(api.config!, account, preferredAccountId);
+            const result = await updateRecord(client, app_token, table_id, record_id, fields);
+            return json(result);
+          } catch (err) {
+            return json({ error: err instanceof Error ? err.message : String(err) });
+          }
+        },
+      };
     },
     { name: "feishu_bitable_update_record" },
   );

--- a/extensions/feishu/src/bitable.ts
+++ b/extensions/feishu/src/bitable.ts
@@ -1,8 +1,8 @@
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { Type } from "@sinclair/typebox";
-import type { FeishuConfig } from "./types.js";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { listEnabledFeishuAccounts, resolveToolClient } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
+import type { FeishuConfig } from "./types.js";
 
 // ============ Helpers ============
 

--- a/extensions/feishu/src/doc-schema.ts
+++ b/extensions/feishu/src/doc-schema.ts
@@ -1,9 +1,14 @@
 import { Type, type Static } from "@sinclair/typebox";
 
+const AccountField = Type.Optional(
+  Type.String({ description: "Feishu account ID. Omit to use the default account." }),
+);
+
 export const FeishuDocSchema = Type.Union([
   Type.Object({
     action: Type.Literal("read"),
     doc_token: Type.String({ description: "Document token (extract from URL /docx/XXX)" }),
+    account: AccountField,
   }),
   Type.Object({
     action: Type.Literal("write"),
@@ -11,36 +16,43 @@ export const FeishuDocSchema = Type.Union([
     content: Type.String({
       description: "Markdown content to write (replaces entire document content)",
     }),
+    account: AccountField,
   }),
   Type.Object({
     action: Type.Literal("append"),
     doc_token: Type.String({ description: "Document token" }),
     content: Type.String({ description: "Markdown content to append to end of document" }),
+    account: AccountField,
   }),
   Type.Object({
     action: Type.Literal("create"),
     title: Type.String({ description: "Document title" }),
     folder_token: Type.Optional(Type.String({ description: "Target folder token (optional)" })),
+    account: AccountField,
   }),
   Type.Object({
     action: Type.Literal("list_blocks"),
     doc_token: Type.String({ description: "Document token" }),
+    account: AccountField,
   }),
   Type.Object({
     action: Type.Literal("get_block"),
     doc_token: Type.String({ description: "Document token" }),
     block_id: Type.String({ description: "Block ID (from list_blocks)" }),
+    account: AccountField,
   }),
   Type.Object({
     action: Type.Literal("update_block"),
     doc_token: Type.String({ description: "Document token" }),
     block_id: Type.String({ description: "Block ID (from list_blocks)" }),
     content: Type.String({ description: "New text content" }),
+    account: AccountField,
   }),
   Type.Object({
     action: Type.Literal("delete_block"),
     doc_token: Type.String({ description: "Document token" }),
     block_id: Type.String({ description: "Block ID" }),
+    account: AccountField,
   }),
 ]);
 

--- a/extensions/feishu/src/docx.test.ts
+++ b/extensions/feishu/src/docx.test.ts
@@ -102,12 +102,15 @@ describe("feishu_doc image fetch hardening", () => {
       registerTool,
     } as any);
 
-    const feishuDocTool = registerTool.mock.calls
-      .map((call) => call[0])
-      .find((tool) => tool.name === "feishu_doc");
+    const feishuDocFactory = registerTool.mock.calls.find(
+      (call) => call[1]?.name === "feishu_doc",
+    )?.[0];
+    expect(feishuDocFactory).toBeDefined();
+
+    const feishuDocTool = feishuDocFactory?.({ agentAccountId: undefined });
     expect(feishuDocTool).toBeDefined();
 
-    const result = await feishuDocTool.execute("tool-call", {
+    const result = await feishuDocTool!.execute("tool-call", {
       action: "write",
       doc_token: "doc_1",
       content: "![x](https://x.test/image.png)",

--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -1,7 +1,7 @@
-import type * as Lark from "@larksuiteoapi/node-sdk";
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
-import { Type } from "@sinclair/typebox";
 import { Readable } from "stream";
+import type * as Lark from "@larksuiteoapi/node-sdk";
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { listEnabledFeishuAccounts, resolveToolClient } from "./accounts.js";
 import { FeishuDocSchema, type FeishuDocParams } from "./doc-schema.js";
 import { getFeishuRuntime } from "./runtime.js";

--- a/extensions/feishu/src/drive-schema.ts
+++ b/extensions/feishu/src/drive-schema.ts
@@ -11,17 +11,23 @@ const FileType = Type.Union([
   Type.Literal("shortcut"),
 ]);
 
+const AccountField = Type.Optional(
+  Type.String({ description: "Feishu account ID. Omit to use the default account." }),
+);
+
 export const FeishuDriveSchema = Type.Union([
   Type.Object({
     action: Type.Literal("list"),
     folder_token: Type.Optional(
       Type.String({ description: "Folder token (optional, omit for root directory)" }),
     ),
+    account: AccountField,
   }),
   Type.Object({
     action: Type.Literal("info"),
     file_token: Type.String({ description: "File or folder token" }),
     type: FileType,
+    account: AccountField,
   }),
   Type.Object({
     action: Type.Literal("create_folder"),
@@ -29,17 +35,20 @@ export const FeishuDriveSchema = Type.Union([
     folder_token: Type.Optional(
       Type.String({ description: "Parent folder token (optional, omit for root)" }),
     ),
+    account: AccountField,
   }),
   Type.Object({
     action: Type.Literal("move"),
     file_token: Type.String({ description: "File token to move" }),
     type: FileType,
     folder_token: Type.String({ description: "Target folder token" }),
+    account: AccountField,
   }),
   Type.Object({
     action: Type.Literal("delete"),
     file_token: Type.String({ description: "File token to delete" }),
     type: FileType,
+    account: AccountField,
   }),
 ]);
 

--- a/extensions/feishu/src/drive.ts
+++ b/extensions/feishu/src/drive.ts
@@ -187,35 +187,38 @@ export function registerFeishuDriveTools(api: OpenClawPluginApi) {
   }
 
   api.registerTool(
-    {
-      name: "feishu_drive",
-      label: "Feishu Drive",
-      description:
-        "Feishu cloud storage operations. Actions: list, info, create_folder, move, delete",
-      parameters: FeishuDriveSchema,
-      async execute(_toolCallId, params) {
-        const p = params as FeishuDriveParams;
-        try {
-          const { client } = resolveToolClient(api.config!, p.account);
-          switch (p.action) {
-            case "list":
-              return json(await listFolder(client, p.folder_token));
-            case "info":
-              return json(await getFileInfo(client, p.file_token));
-            case "create_folder":
-              return json(await createFolder(client, p.name, p.folder_token));
-            case "move":
-              return json(await moveFile(client, p.file_token, p.type, p.folder_token));
-            case "delete":
-              return json(await deleteFile(client, p.file_token, p.type));
-            default:
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any -- exhaustive check fallback
-              return json({ error: `Unknown action: ${(p as any).action}` });
+    (ctx) => {
+      const preferredAccountId = ctx.agentAccountId;
+      return {
+        name: "feishu_drive",
+        label: "Feishu Drive",
+        description:
+          "Feishu cloud storage operations. Actions: list, info, create_folder, move, delete. In multi-account setups, this tool auto-selects the bot that received the message when available.",
+        parameters: FeishuDriveSchema,
+        async execute(_toolCallId, params) {
+          const p = params as FeishuDriveParams;
+          try {
+            const { client } = resolveToolClient(api.config!, p.account, preferredAccountId);
+            switch (p.action) {
+              case "list":
+                return json(await listFolder(client, p.folder_token));
+              case "info":
+                return json(await getFileInfo(client, p.file_token));
+              case "create_folder":
+                return json(await createFolder(client, p.name, p.folder_token));
+              case "move":
+                return json(await moveFile(client, p.file_token, p.type, p.folder_token));
+              case "delete":
+                return json(await deleteFile(client, p.file_token, p.type));
+              default:
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any -- exhaustive check fallback
+                return json({ error: `Unknown action: ${(p as any).action}` });
+            }
+          } catch (err) {
+            return json({ error: err instanceof Error ? err.message : String(err) });
           }
-        } catch (err) {
-          return json({ error: err instanceof Error ? err.message : String(err) });
-        }
-      },
+        },
+      };
     },
     { name: "feishu_drive" },
   );

--- a/extensions/feishu/src/drive.ts
+++ b/extensions/feishu/src/drive.ts
@@ -1,7 +1,6 @@
 import type * as Lark from "@larksuiteoapi/node-sdk";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
-import { listEnabledFeishuAccounts } from "./accounts.js";
-import { createFeishuClient } from "./client.js";
+import { listEnabledFeishuAccounts, resolveToolClient } from "./accounts.js";
 import { FeishuDriveSchema, type FeishuDriveParams } from "./drive-schema.js";
 import { resolveToolsConfig } from "./tools-config.js";
 
@@ -187,8 +186,6 @@ export function registerFeishuDriveTools(api: OpenClawPluginApi) {
     return;
   }
 
-  const getClient = () => createFeishuClient(firstAccount);
-
   api.registerTool(
     {
       name: "feishu_drive",
@@ -199,7 +196,7 @@ export function registerFeishuDriveTools(api: OpenClawPluginApi) {
       async execute(_toolCallId, params) {
         const p = params as FeishuDriveParams;
         try {
-          const client = getClient();
+          const { client } = resolveToolClient(api.config!, p.account);
           switch (p.action) {
             case "list":
               return json(await listFolder(client, p.folder_token));

--- a/extensions/feishu/src/perm-schema.ts
+++ b/extensions/feishu/src/perm-schema.ts
@@ -26,11 +26,16 @@ const Permission = Type.Union([
   Type.Literal("full_access"),
 ]);
 
+const AccountField = Type.Optional(
+  Type.String({ description: "Feishu account ID. Omit to use the default account." }),
+);
+
 export const FeishuPermSchema = Type.Union([
   Type.Object({
     action: Type.Literal("list"),
     token: Type.String({ description: "File token" }),
     type: TokenType,
+    account: AccountField,
   }),
   Type.Object({
     action: Type.Literal("add"),
@@ -39,6 +44,7 @@ export const FeishuPermSchema = Type.Union([
     member_type: MemberType,
     member_id: Type.String({ description: "Member ID (email, open_id, user_id, etc.)" }),
     perm: Permission,
+    account: AccountField,
   }),
   Type.Object({
     action: Type.Literal("remove"),
@@ -46,6 +52,7 @@ export const FeishuPermSchema = Type.Union([
     type: TokenType,
     member_type: MemberType,
     member_id: Type.String({ description: "Member ID to remove" }),
+    account: AccountField,
   }),
 ]);
 

--- a/extensions/feishu/src/perm.ts
+++ b/extensions/feishu/src/perm.ts
@@ -1,7 +1,6 @@
 import type * as Lark from "@larksuiteoapi/node-sdk";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
-import { listEnabledFeishuAccounts } from "./accounts.js";
-import { createFeishuClient } from "./client.js";
+import { listEnabledFeishuAccounts, resolveToolClient } from "./accounts.js";
 import { FeishuPermSchema, type FeishuPermParams } from "./perm-schema.js";
 import { resolveToolsConfig } from "./tools-config.js";
 
@@ -136,8 +135,6 @@ export function registerFeishuPermTools(api: OpenClawPluginApi) {
     return;
   }
 
-  const getClient = () => createFeishuClient(firstAccount);
-
   api.registerTool(
     {
       name: "feishu_perm",
@@ -147,7 +144,7 @@ export function registerFeishuPermTools(api: OpenClawPluginApi) {
       async execute(_toolCallId, params) {
         const p = params as FeishuPermParams;
         try {
-          const client = getClient();
+          const { client } = resolveToolClient(api.config!, p.account);
           switch (p.action) {
             case "list":
               return json(await listMembers(client, p.token, p.type));

--- a/extensions/feishu/src/tools-account.test.ts
+++ b/extensions/feishu/src/tools-account.test.ts
@@ -1,0 +1,130 @@
+import type { ClawdbotConfig } from "openclaw/plugin-sdk";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { resolveToolClient } from "./accounts.js";
+import { createFeishuClient } from "./client.js";
+import { FeishuDocSchema } from "./doc-schema.js";
+import { FeishuDriveSchema } from "./drive-schema.js";
+import { FeishuPermSchema } from "./perm-schema.js";
+import { FeishuWikiSchema } from "./wiki-schema.js";
+
+vi.mock("./client.js", () => ({
+  createFeishuClient: vi.fn(() => ({ __mocked: true })),
+}));
+
+function makeConfig(feishu: Record<string, unknown>): ClawdbotConfig {
+  return { channels: { feishu } } as unknown as ClawdbotConfig;
+}
+
+describe("resolveToolClient", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("resolves explicit account credentials", () => {
+    const cfg = makeConfig({
+      domain: "feishu",
+      accounts: {
+        secondary: {
+          appId: "secondary_id",
+          appSecret: "secondary_secret",
+        },
+      },
+    });
+
+    const result = resolveToolClient(cfg, "secondary");
+    expect(result.accountId).toBe("secondary");
+    expect(createFeishuClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: "secondary",
+        appId: "secondary_id",
+        appSecret: "secondary_secret",
+      }),
+    );
+  });
+
+  it("falls back to first enabled account when account is omitted", () => {
+    const cfg = makeConfig({
+      appId: "default_id",
+      appSecret: "default_secret",
+      domain: "feishu",
+    });
+
+    const result = resolveToolClient(cfg);
+    expect(result.accountId).toBe("default");
+    expect(result.client).toBeDefined();
+  });
+
+  it("uses default account when no accounts field is configured", () => {
+    const cfg = makeConfig({
+      appId: "top_level_id",
+      appSecret: "top_level_secret",
+      domain: "feishu",
+    });
+
+    const result = resolveToolClient(cfg);
+    expect(result.accountId).toBe("default");
+    expect(createFeishuClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: "default",
+        appId: "top_level_id",
+        appSecret: "top_level_secret",
+      }),
+    );
+  });
+
+  it("throws for unconfigured account", () => {
+    const cfg = makeConfig({
+      domain: "feishu",
+      accounts: {
+        primary: {
+          appId: "primary_id",
+          appSecret: "primary_secret",
+        },
+      },
+    });
+
+    expect(() => resolveToolClient(cfg, "nonexistent")).toThrow(
+      'Feishu account "nonexistent" is not configured',
+    );
+  });
+
+  it("throws for disabled account", () => {
+    const cfg = makeConfig({
+      domain: "feishu",
+      accounts: {
+        disabled_acct: {
+          appId: "disabled_id",
+          appSecret: "disabled_secret",
+          enabled: false,
+        },
+      },
+    });
+
+    expect(() => resolveToolClient(cfg, "disabled_acct")).toThrow(
+      'Feishu account "disabled_acct" is disabled',
+    );
+  });
+
+  it("throws when no accounts are configured", () => {
+    const cfg = makeConfig({});
+    expect(() => resolveToolClient(cfg)).toThrow("No Feishu accounts configured");
+  });
+});
+
+describe("tool schemas include optional account field", () => {
+  const schemas = [
+    { name: "FeishuDocSchema", schema: FeishuDocSchema },
+    { name: "FeishuWikiSchema", schema: FeishuWikiSchema },
+    { name: "FeishuDriveSchema", schema: FeishuDriveSchema },
+    { name: "FeishuPermSchema", schema: FeishuPermSchema },
+  ];
+
+  for (const { name, schema } of schemas) {
+    it(`${name}: all variants include optional account field`, () => {
+      for (const variant of schema.anyOf) {
+        expect(variant.properties).toHaveProperty("account");
+        expect((variant.required ?? []) as string[]).not.toContain("account");
+      }
+    });
+  }
+});

--- a/extensions/feishu/src/tools-account.test.ts
+++ b/extensions/feishu/src/tools-account.test.ts
@@ -33,6 +33,7 @@ describe("resolveToolClient", () => {
 
     const result = resolveToolClient(cfg, "secondary");
     expect(result.accountId).toBe("secondary");
+    expect(result.account).toBeDefined();
     expect(createFeishuClient).toHaveBeenCalledWith(
       expect.objectContaining({
         accountId: "secondary",
@@ -51,6 +52,7 @@ describe("resolveToolClient", () => {
 
     const result = resolveToolClient(cfg);
     expect(result.accountId).toBe("default");
+    expect(result.account).toBeDefined();
     expect(result.client).toBeDefined();
   });
 
@@ -63,6 +65,7 @@ describe("resolveToolClient", () => {
 
     const result = resolveToolClient(cfg);
     expect(result.accountId).toBe("default");
+    expect(result.account).toBeDefined();
     expect(createFeishuClient).toHaveBeenCalledWith(
       expect.objectContaining({
         accountId: "default",
@@ -70,6 +73,19 @@ describe("resolveToolClient", () => {
         appSecret: "top_level_secret",
       }),
     );
+  });
+
+  it("uses preferred account when account param is omitted", () => {
+    const cfg = makeConfig({
+      domain: "feishu",
+      accounts: {
+        app2: { appId: "app2_id", appSecret: "app2_secret" },
+        shixiaoheng: { appId: "sxh_id", appSecret: "sxh_secret" },
+      },
+    });
+
+    const result = resolveToolClient(cfg, undefined, "shixiaoheng");
+    expect(result.accountId).toBe("shixiaoheng");
   });
 
   it("throws for unconfigured account", () => {

--- a/extensions/feishu/src/wiki-schema.ts
+++ b/extensions/feishu/src/wiki-schema.ts
@@ -1,8 +1,13 @@
 import { Type, type Static } from "@sinclair/typebox";
 
+const AccountField = Type.Optional(
+  Type.String({ description: "Feishu account ID. Omit to use the default account." }),
+);
+
 export const FeishuWikiSchema = Type.Union([
   Type.Object({
     action: Type.Literal("spaces"),
+    account: AccountField,
   }),
   Type.Object({
     action: Type.Literal("nodes"),
@@ -10,15 +15,18 @@ export const FeishuWikiSchema = Type.Union([
     parent_node_token: Type.Optional(
       Type.String({ description: "Parent node token (optional, omit for root)" }),
     ),
+    account: AccountField,
   }),
   Type.Object({
     action: Type.Literal("get"),
     token: Type.String({ description: "Wiki node token (from URL /wiki/XXX)" }),
+    account: AccountField,
   }),
   Type.Object({
     action: Type.Literal("search"),
     query: Type.String({ description: "Search query" }),
     space_id: Type.Optional(Type.String({ description: "Limit search to this space (optional)" })),
+    account: AccountField,
   }),
   Type.Object({
     action: Type.Literal("create"),
@@ -32,6 +40,7 @@ export const FeishuWikiSchema = Type.Union([
     parent_node_token: Type.Optional(
       Type.String({ description: "Parent node token (optional, omit for root)" }),
     ),
+    account: AccountField,
   }),
   Type.Object({
     action: Type.Literal("move"),
@@ -43,12 +52,14 @@ export const FeishuWikiSchema = Type.Union([
     target_parent_token: Type.Optional(
       Type.String({ description: "Target parent node token (optional, root if omitted)" }),
     ),
+    account: AccountField,
   }),
   Type.Object({
     action: Type.Literal("rename"),
     space_id: Type.String({ description: "Knowledge space ID" }),
     node_token: Type.String({ description: "Node token to rename" }),
     title: Type.String({ description: "New title" }),
+    account: AccountField,
   }),
 ]);
 

--- a/extensions/feishu/src/wiki.ts
+++ b/extensions/feishu/src/wiki.ts
@@ -175,52 +175,55 @@ export function registerFeishuWikiTools(api: OpenClawPluginApi) {
   }
 
   api.registerTool(
-    {
-      name: "feishu_wiki",
-      label: "Feishu Wiki",
-      description:
-        "Feishu knowledge base operations. Actions: spaces, nodes, get, create, move, rename",
-      parameters: FeishuWikiSchema,
-      async execute(_toolCallId, params) {
-        const p = params as FeishuWikiParams;
-        try {
-          const { client } = resolveToolClient(api.config!, p.account);
-          switch (p.action) {
-            case "spaces":
-              return json(await listSpaces(client));
-            case "nodes":
-              return json(await listNodes(client, p.space_id, p.parent_node_token));
-            case "get":
-              return json(await getNode(client, p.token));
-            case "search":
-              return json({
-                error:
-                  "Search is not available. Use feishu_wiki with action: 'nodes' to browse or action: 'get' to lookup by token.",
-              });
-            case "create":
-              return json(
-                await createNode(client, p.space_id, p.title, p.obj_type, p.parent_node_token),
-              );
-            case "move":
-              return json(
-                await moveNode(
-                  client,
-                  p.space_id,
-                  p.node_token,
-                  p.target_space_id,
-                  p.target_parent_token,
-                ),
-              );
-            case "rename":
-              return json(await renameNode(client, p.space_id, p.node_token, p.title));
-            default:
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any -- exhaustive check fallback
-              return json({ error: `Unknown action: ${(p as any).action}` });
+    (ctx) => {
+      const preferredAccountId = ctx.agentAccountId;
+      return {
+        name: "feishu_wiki",
+        label: "Feishu Wiki",
+        description:
+          "Feishu knowledge base operations. Actions: spaces, nodes, get, create, move, rename. In multi-account setups, this tool auto-selects the bot that received the message when available.",
+        parameters: FeishuWikiSchema,
+        async execute(_toolCallId, params) {
+          const p = params as FeishuWikiParams;
+          try {
+            const { client } = resolveToolClient(api.config!, p.account, preferredAccountId);
+            switch (p.action) {
+              case "spaces":
+                return json(await listSpaces(client));
+              case "nodes":
+                return json(await listNodes(client, p.space_id, p.parent_node_token));
+              case "get":
+                return json(await getNode(client, p.token));
+              case "search":
+                return json({
+                  error:
+                    "Search is not available. Use feishu_wiki with action: 'nodes' to browse or action: 'get' to lookup by token.",
+                });
+              case "create":
+                return json(
+                  await createNode(client, p.space_id, p.title, p.obj_type, p.parent_node_token),
+                );
+              case "move":
+                return json(
+                  await moveNode(
+                    client,
+                    p.space_id,
+                    p.node_token,
+                    p.target_space_id,
+                    p.target_parent_token,
+                  ),
+                );
+              case "rename":
+                return json(await renameNode(client, p.space_id, p.node_token, p.title));
+              default:
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any -- exhaustive check fallback
+                return json({ error: `Unknown action: ${(p as any).action}` });
+            }
+          } catch (err) {
+            return json({ error: err instanceof Error ? err.message : String(err) });
           }
-        } catch (err) {
-          return json({ error: err instanceof Error ? err.message : String(err) });
-        }
-      },
+        },
+      };
     },
     { name: "feishu_wiki" },
   );

--- a/extensions/feishu/src/wiki.ts
+++ b/extensions/feishu/src/wiki.ts
@@ -1,7 +1,6 @@
 import type * as Lark from "@larksuiteoapi/node-sdk";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
-import { listEnabledFeishuAccounts } from "./accounts.js";
-import { createFeishuClient } from "./client.js";
+import { listEnabledFeishuAccounts, resolveToolClient } from "./accounts.js";
 import { resolveToolsConfig } from "./tools-config.js";
 import { FeishuWikiSchema, type FeishuWikiParams } from "./wiki-schema.js";
 
@@ -175,8 +174,6 @@ export function registerFeishuWikiTools(api: OpenClawPluginApi) {
     return;
   }
 
-  const getClient = () => createFeishuClient(firstAccount);
-
   api.registerTool(
     {
       name: "feishu_wiki",
@@ -187,7 +184,7 @@ export function registerFeishuWikiTools(api: OpenClawPluginApi) {
       async execute(_toolCallId, params) {
         const p = params as FeishuWikiParams;
         try {
-          const client = getClient();
+          const { client } = resolveToolClient(api.config!, p.account);
           switch (p.action) {
             case "spaces":
               return json(await listSpaces(client));


### PR DESCRIPTION
## Summary
This PR fixes multi-account credential isolation for the official Feishu extension by allowing callers to explicitly select which Feishu account to use per tool invocation.

## Problem
In multi-account setups, Feishu tools previously resolved a single client at registration time (effectively locking to the first enabled account). This caused cross-account operations and permission issues.

## Solution
- Add optional `account?: string` to all Feishu tool schemas (doc/wiki/drive/perm/bitable)
- Introduce `resolveToolClient(cfg, accountId?)` to resolve the Feishu client at execution time:
- If `account` is provided: use that configured + enabled account
- If omitted: fall back to the first enabled account (preserves prior behavior)
- Update tool handlers to use `resolveToolClient()` instead of a closure-captured client
- Migrate bitable tool registration away from legacy direct config access to the standard `listEnabledFeishuAccounts()` pattern

Replaces #15241 (closed due to deleted fork).

## Reviewer notes
- Additive & backward-compatible: omitting `account` keeps existing behavior
- Clear error messages for unconfigured / disabled `account` IDs
- Changes are scoped to `extensions/feishu/**` only

## Test plan
- [x] CI is green
- [x] New `extensions/feishu/src/tools-account.test.ts` covers: explicit account routing, fallback behavior, unconfigured/disabled errors, schema validation

_Reviewer focus: schema additions + account resolution logic in `resolveToolClient()`._


## Greptile Overview
### Greptile Summary
Added optional account parameter to all Feishu tool schemas (doc, wiki, drive, perm, bitable) to enable multi-account credential routing. Introduced shared resolveToolClient() helper in accounts.ts that resolves the correct client from the named account with clear error handling. When the account parameter is omitted, tools fall back to using the first enabled account, preserving backward compatibility.

### Key changes:

- New resolveToolClient() function in accounts.ts:152 centralizes account resolution logic with proper error messages for unconfigured/disabled accounts
- All tool schemas updated with consistent AccountField definition (optional string parameter)
- Bitable tools migrated from legacy direct config access to standard listEnabledFeishuAccounts() pattern
- Comprehensive test coverage in tools-account.test.ts validates explicit account resolution, fallback behavior, and error cases

## Confidence Score: 5/5
- This PR is safe to merge with minimal risk
- The implementation is well-structured with proper error handling, comprehensive test coverage (130 lines of tests covering all critical paths), and maintains backward compatibility. The resolveToolClient() helper provides clear error messages for edge cases. All changes follow consistent patterns across tool files. The only minor concern is the inclusion of unrelated web-fetch commits, but these are also well-tested and don't affect the core Feishu functionality.
- No files require special attention

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds optional `account` parameter to all Feishu tool schemas (doc, wiki, drive, perm, bitable) and introduces a shared `resolveToolClient()` helper in `accounts.ts` to route tool invocations to the correct Feishu account at execution time. When `account` is omitted, the tool falls back to the invoking bot's account (via `ctx.agentAccountId`) then to the first enabled account, preserving backward compatibility. Bitable tools are also migrated from legacy direct config access to the standard `listEnabledFeishuAccounts()` registration pattern.

- New `resolveToolClient()` centralizes account resolution with clear error messages for unconfigured/disabled accounts
- All tool registrations migrated from static `getClient()` closures to dynamic per-invocation resolution via the `(ctx) => { ... }` factory pattern
- `mediaMaxBytes` in `docx.ts` now resolves from the per-invocation account config rather than being fixed to the first account at registration time
- Comprehensive tests cover explicit account routing, preferred account fallback, error cases, and schema validation

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk; the changes are additive, backward-compatible, and well-tested.
- The implementation is well-structured with proper error handling, comprehensive test coverage, and maintains backward compatibility. The `resolveToolClient()` helper provides clear error messages for edge cases and all tool files follow a consistent pattern. One minor style concern around repeated `AccountField` definitions is non-blocking. No logical errors found.
- No files require special attention

<sub>Last reviewed commit: e2cb790</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->