### PR TITLE
Feishu: harden media URL fetching against SSRF and local file disclosure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Feishu/Security: harden media URL fetching against SSRF and local file disclosure. (#16285) Thanks @mbelinky.
 - Telegram/Security: require numeric Telegram sender IDs for allowlist authorization (reject `@username` principals) and warn in `openclaw security audit` when legacy configs contain usernames. Thanks @vincentkoc.
 - Security/Skills: harden archive extraction for download-installed skills to prevent path traversal outside the target directory. Thanks @markmusson.
 - Security/Media: stream and bound URL-backed input media fetches to prevent memory exhaustion from oversized responses. Thanks @vincentkoc.

--- a/extensions/feishu/src/docx.test.ts
+++ b/extensions/feishu/src/docx.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const createFeishuClientMock = vi.hoisted(() => vi.fn());
+const fetchRemoteMediaMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./client.js", () => ({
+  createFeishuClient: createFeishuClientMock,
+}));
+
+vi.mock("./runtime.js", () => ({
+  getFeishuRuntime: () => ({
+    channel: {
+      media: {
+        fetchRemoteMedia: fetchRemoteMediaMock,
+      },
+    },
+  }),
+}));
+
+import { registerFeishuDocTools } from "./docx.js";
+
+describe("feishu_doc image fetch hardening", () => {
+  const convertMock = vi.hoisted(() => vi.fn());
+  const blockListMock = vi.hoisted(() => vi.fn());
+  const blockChildrenCreateMock = vi.hoisted(() => vi.fn());
+  const driveUploadAllMock = vi.hoisted(() => vi.fn());
+  const blockPatchMock = vi.hoisted(() => vi.fn());
+  const scopeListMock = vi.hoisted(() => vi.fn());
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    createFeishuClientMock.mockReturnValue({
+      docx: {
+        document: {
+          convert: convertMock,
+        },
+        documentBlock: {
+          list: blockListMock,
+          patch: blockPatchMock,
+        },
+        documentBlockChildren: {
+          create: blockChildrenCreateMock,
+        },
+      },
+      drive: {
+        media: {
+          uploadAll: driveUploadAllMock,
+        },
+      },
+      application: {
+        scope: {
+          list: scopeListMock,
+        },
+      },
+    });
+
+    convertMock.mockResolvedValue({
+      code: 0,
+      data: {
+        blocks: [{ block_type: 27 }],
+        first_level_block_ids: [],
+      },
+    });
+
+    blockListMock.mockResolvedValue({
+      code: 0,
+      data: {
+        items: [],
+      },
+    });
+
+    blockChildrenCreateMock.mockResolvedValue({
+      code: 0,
+      data: {
+        children: [{ block_type: 27, block_id: "img_block_1" }],
+      },
+    });
+
+    driveUploadAllMock.mockResolvedValue({ file_token: "token_1" });
+    blockPatchMock.mockResolvedValue({ code: 0 });
+    scopeListMock.mockResolvedValue({ code: 0, data: { scopes: [] } });
+  });
+
+  it("skips image upload when markdown image URL is blocked", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    fetchRemoteMediaMock.mockRejectedValueOnce(
+      new Error("Blocked: resolves to private/internal IP address"),
+    );
+
+    const registerTool = vi.fn();
+    registerFeishuDocTools({
+      config: {
+        channels: {
+          feishu: {
+            appId: "app_id",
+            appSecret: "app_secret",
+          },
+        },
+      } as any,
+      logger: { debug: vi.fn(), info: vi.fn() } as any,
+      registerTool,
+    } as any);
+
+    const feishuDocTool = registerTool.mock.calls
+      .map((call) => call[0])
+      .find((tool) => tool.name === "feishu_doc");
+    expect(feishuDocTool).toBeDefined();
+
+    const result = await feishuDocTool.execute("tool-call", {
+      action: "write",
+      doc_token: "doc_1",
+      content: "![x](https://x.test/image.png)",
+    });
+
+    expect(fetchRemoteMediaMock).toHaveBeenCalled();
+    expect(driveUploadAllMock).not.toHaveBeenCalled();
+    expect(blockPatchMock).not.toHaveBeenCalled();
+    expect(result.details.images_processed).toBe(0);
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    consoleErrorSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
Security fix for Feishu extension media loading.

Closes:
- GHSA-x22m-j5qq-j49m
- GHSA-8jpq-5h99-ff5r

Changes:
- Route Feishu mediaUrl loading through hardened runtime helpers (SSRF guard, local-root enforcement) with size caps.
- Route DocX markdown image fetching through hardened remote media fetch helper.
- Add regression tests (fail-closed on blocked fetch).

Gate (local):
- pnpm check
- pnpm exec vitest run extensions/feishu/src/media.test.ts extensions/feishu/src/docx.test.ts --maxWorkers 1

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR hardens Feishu extension media URL fetching to prevent SSRF (Server-Side Request Forgery) and local file disclosure vulnerabilities by routing all media URL loading through centralized security helpers.

**Key changes:**
- `extensions/feishu/src/media.ts`: Replaced direct `fetch()` calls and local file reads with `getFeishuRuntime().media.loadWebMedia()`, which enforces SSRF guards, local-root enforcement, and size caps
- `extensions/feishu/src/docx.ts`: Routed markdown image URL fetching through `getFeishuRuntime().channel.media.fetchRemoteMedia()` with `maxBytes` limits
- Both test files verify fail-closed behavior when blocked URLs are detected

**Security improvements:**
- SSRF protection: All remote URLs now pass through `fetchWithSsrFGuard()` which validates against private/internal IP addresses (10.0.0.0/8, 127.0.0.0/8, 169.254.0.0/16, 172.16.0.0/12, 192.168.0.0/16, link-local IPv6) and blocked hostnames (`localhost`, `*.local`, `*.internal`, `metadata.google.internal`)
- Local file disclosure protection: `loadWebMedia()` enforces allowed directory roots (tmpdir, `~/.openclaw/media`, `~/.openclaw/agents`) with symlink resolution to prevent path traversal
- Size enforcement: Respects `mediaMaxMb` configuration (default 30MB) to prevent resource exhaustion

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it's a focused security hardening change that properly addresses SSRF and LFI vulnerabilities
- The security fixes are well-implemented with proper fail-closed behavior verified by tests. The changes route all media URL fetching through established hardened helpers (`fetchWithSsrFGuard`, `loadWebMedia`) that enforce comprehensive SSRF protections (private IP blocking, hostname filtering) and local file access controls (directory root restrictions with symlink resolution). Tests confirm blocked URLs prevent any file operations from proceeding.
- No files require special attention

<sub>Last reviewed commit: b117e2a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->