### PR TITLE
fix(discord): defer component interactions to prevent timeout

### DIFF
--- a/src/discord/monitor/agent-components.test.ts
+++ b/src/discord/monitor/agent-components.test.ts
@@ -24,25 +24,29 @@ const createCfg = (): OpenClawConfig => ({}) as OpenClawConfig;
 
 const createDmButtonInteraction = (overrides: Partial<ButtonInteraction> = {}) => {
   const reply = vi.fn().mockResolvedValue(undefined);
+  const defer = vi.fn().mockResolvedValue(undefined);
   const interaction = {
     rawData: { channel_id: "dm-channel" },
     user: { id: "123456789", username: "Alice", discriminator: "1234" },
+    defer,
     reply,
     ...overrides,
   } as unknown as ButtonInteraction;
-  return { interaction, reply };
+  return { interaction, defer, reply };
 };
 
 const createDmSelectInteraction = (overrides: Partial<StringSelectMenuInteraction> = {}) => {
   const reply = vi.fn().mockResolvedValue(undefined);
+  const defer = vi.fn().mockResolvedValue(undefined);
   const interaction = {
     rawData: { channel_id: "dm-channel" },
     user: { id: "123456789", username: "Alice", discriminator: "1234" },
     values: ["alpha"],
+    defer,
     reply,
     ...overrides,
   } as unknown as StringSelectMenuInteraction;
-  return { interaction, reply };
+  return { interaction, defer, reply };
 };
 
 beforeEach(() => {
@@ -58,10 +62,11 @@ describe("agent components", () => {
       accountId: "default",
       dmPolicy: "pairing",
     });
-    const { interaction, reply } = createDmButtonInteraction();
+    const { interaction, defer, reply } = createDmButtonInteraction();
 
     await button.run(interaction, { componentId: "hello" } as ComponentData);
 
+    expect(defer).toHaveBeenCalledWith({ ephemeral: true });
     expect(reply).toHaveBeenCalledTimes(1);
     expect(reply.mock.calls[0]?.[0]?.content).toContain("Pairing code: PAIRCODE");
     expect(enqueueSystemEventMock).not.toHaveBeenCalled();
@@ -74,10 +79,11 @@ describe("agent components", () => {
       accountId: "default",
       dmPolicy: "allowlist",
     });
-    const { interaction, reply } = createDmButtonInteraction();
+    const { interaction, defer, reply } = createDmButtonInteraction();
 
     await button.run(interaction, { componentId: "hello" } as ComponentData);
 
+    expect(defer).toHaveBeenCalledWith({ ephemeral: true });
     expect(reply).toHaveBeenCalledWith({ content: "✓", ephemeral: true });
     expect(enqueueSystemEventMock).toHaveBeenCalled();
   });
@@ -89,10 +95,11 @@ describe("agent components", () => {
       dmPolicy: "allowlist",
       allowFrom: ["Alice#1234"],
     });
-    const { interaction, reply } = createDmSelectInteraction();
+    const { interaction, defer, reply } = createDmSelectInteraction();
 
     await select.run(interaction, { componentId: "hello" } as ComponentData);
 
+    expect(defer).toHaveBeenCalledWith({ ephemeral: true });
     expect(reply).toHaveBeenCalledWith({ content: "✓", ephemeral: true });
     expect(enqueueSystemEventMock).toHaveBeenCalled();
   });

--- a/src/discord/monitor/agent-components.test.ts
+++ b/src/discord/monitor/agent-components.test.ts
@@ -84,7 +84,7 @@ describe("agent components", () => {
     await button.run(interaction, { componentId: "hello" } as ComponentData);
 
     expect(defer).toHaveBeenCalledWith({ ephemeral: true });
-    expect(reply).toHaveBeenCalledWith({ content: "✓", ephemeral: true });
+    expect(reply).toHaveBeenCalledWith({ content: "✓" });
     expect(enqueueSystemEventMock).toHaveBeenCalled();
   });
 
@@ -100,7 +100,7 @@ describe("agent components", () => {
     await select.run(interaction, { componentId: "hello" } as ComponentData);
 
     expect(defer).toHaveBeenCalledWith({ ephemeral: true });
-    expect(reply).toHaveBeenCalledWith({ content: "✓", ephemeral: true });
+    expect(reply).toHaveBeenCalledWith({ content: "✓" });
     expect(enqueueSystemEventMock).toHaveBeenCalled();
   });
 });

--- a/src/discord/monitor/agent-components.ts
+++ b/src/discord/monitor/agent-components.ts
@@ -226,6 +226,15 @@ export class AgentComponentButton extends Button {
       return;
     }
 
+    // Defer immediately to satisfy Discord's 3-second interaction ACK requirement.
+    // We use an ephemeral deferred reply so subsequent interaction.reply() calls
+    // can safely edit the original deferred response.
+    try {
+      await interaction.defer({ ephemeral: true });
+    } catch (err) {
+      logError(`agent button: failed to defer interaction: ${String(err)}`);
+    }
+
     const username = formatUsername(user);
     const userId = user.id;
 
@@ -395,6 +404,15 @@ export class AgentSelectMenu extends StringSelectMenu {
     if (!user) {
       logError("agent select: missing user in interaction");
       return;
+    }
+
+    // Defer immediately to satisfy Discord's 3-second interaction ACK requirement.
+    // We use an ephemeral deferred reply so subsequent interaction.reply() calls
+    // can safely edit the original deferred response.
+    try {
+      await interaction.defer({ ephemeral: true });
+    } catch (err) {
+      logError(`agent select: failed to defer interaction: ${String(err)}`);
     }
 
     const username = formatUsername(user);

--- a/src/discord/monitor/agent-components.ts
+++ b/src/discord/monitor/agent-components.ts
@@ -108,15 +108,16 @@ async function ensureDmComponentAuthorized(params: {
   interaction: AgentComponentInteraction;
   user: DiscordUser;
   componentLabel: string;
+  replyOpts: { ephemeral?: boolean };
 }): Promise<boolean> {
-  const { ctx, interaction, user, componentLabel } = params;
+  const { ctx, interaction, user, componentLabel, replyOpts } = params;
   const dmPolicy = ctx.dmPolicy ?? "pairing";
   if (dmPolicy === "disabled") {
     logVerbose(`agent ${componentLabel}: blocked (DM policy disabled)`);
     try {
       await interaction.reply({
         content: "DM interactions are disabled.",
-        ephemeral: true,
+        ...replyOpts,
       });
     } catch {
       // Interaction may have expired
@@ -162,7 +163,7 @@ async function ensureDmComponentAuthorized(params: {
               code,
             })
           : "Pairing already requested. Ask the bot owner to approve your code.",
-        ephemeral: true,
+        ...replyOpts,
       });
     } catch {
       // Interaction may have expired
@@ -174,7 +175,7 @@ async function ensureDmComponentAuthorized(params: {
   try {
     await interaction.reply({
       content: `You are not authorized to use this ${componentLabel}.`,
-      ephemeral: true,
+      ...replyOpts,
     });
   } catch {
     // Interaction may have expired
@@ -226,14 +227,17 @@ export class AgentComponentButton extends Button {
       return;
     }
 
+    let didDefer = false;
     // Defer immediately to satisfy Discord's 3-second interaction ACK requirement.
     // We use an ephemeral deferred reply so subsequent interaction.reply() calls
     // can safely edit the original deferred response.
     try {
       await interaction.defer({ ephemeral: true });
+      didDefer = true;
     } catch (err) {
       logError(`agent button: failed to defer interaction: ${String(err)}`);
     }
+    const replyOpts = didDefer ? {} : { ephemeral: true };
 
     const username = formatUsername(user);
     const userId = user.id;
@@ -252,6 +256,7 @@ export class AgentComponentButton extends Button {
         interaction,
         user,
         componentLabel: "button",
+        replyOpts,
       });
       if (!authorized) {
         return;
@@ -320,7 +325,7 @@ export class AgentComponentButton extends Button {
         try {
           await interaction.reply({
             content: "You are not authorized to use this button.",
-            ephemeral: true,
+            ...replyOpts,
           });
         } catch {
           // Interaction may have expired
@@ -356,7 +361,7 @@ export class AgentComponentButton extends Button {
     try {
       await interaction.reply({
         content: "✓",
-        ephemeral: true,
+        ...replyOpts,
       });
     } catch (err) {
       logError(`agent button: failed to acknowledge interaction: ${String(err)}`);
@@ -406,14 +411,17 @@ export class AgentSelectMenu extends StringSelectMenu {
       return;
     }
 
+    let didDefer = false;
     // Defer immediately to satisfy Discord's 3-second interaction ACK requirement.
     // We use an ephemeral deferred reply so subsequent interaction.reply() calls
     // can safely edit the original deferred response.
     try {
       await interaction.defer({ ephemeral: true });
+      didDefer = true;
     } catch (err) {
       logError(`agent select: failed to defer interaction: ${String(err)}`);
     }
+    const replyOpts = didDefer ? {} : { ephemeral: true };
 
     const username = formatUsername(user);
     const userId = user.id;
@@ -432,6 +440,7 @@ export class AgentSelectMenu extends StringSelectMenu {
         interaction,
         user,
         componentLabel: "select menu",
+        replyOpts,
       });
       if (!authorized) {
         return;
@@ -496,7 +505,7 @@ export class AgentSelectMenu extends StringSelectMenu {
         try {
           await interaction.reply({
             content: "You are not authorized to use this select menu.",
-            ephemeral: true,
+            ...replyOpts,
           });
         } catch {
           // Interaction may have expired
@@ -536,7 +545,7 @@ export class AgentSelectMenu extends StringSelectMenu {
     try {
       await interaction.reply({
         content: "✓",
-        ephemeral: true,
+        ...replyOpts,
       });
     } catch (err) {
       logError(`agent select: failed to acknowledge interaction: ${String(err)}`);

--- a/src/tui/components/chat-log.ts
+++ b/src/tui/components/chat-log.ts
@@ -56,6 +56,16 @@ export class ChatLog extends Container {
     this.addChild(new AssistantMessageComponent(text));
   }
 
+  dropAssistant(runId?: string) {
+    const effectiveRunId = this.resolveRunId(runId);
+    const existing = this.streamingRuns.get(effectiveRunId);
+    if (!existing) {
+      return;
+    }
+    this.removeChild(existing);
+    this.streamingRuns.delete(effectiveRunId);
+  }
+
   startTool(toolCallId: string, toolName: string, args: unknown) {
     const existing = this.toolById.get(toolCallId);
     if (existing) {

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -109,6 +109,20 @@ export function createEventHandlers(context: EventHandlerContext) {
       setActivityStatus("streaming");
     }
     if (evt.state === "final") {
+      if (!evt.message) {
+        if (isLocalRunId?.(evt.runId)) {
+          forgetLocalRunId?.(evt.runId);
+        } else {
+          void loadHistory?.();
+        }
+        chatLog.dropAssistant(evt.runId);
+        noteFinalizedRun(evt.runId);
+        state.activeChatRunId = null;
+        setActivityStatus("idle");
+        void refreshSessionInfo?.();
+        tui.requestRender();
+        return;
+      }
       if (isCommandMessage(evt.message)) {
         if (isLocalRunId?.(evt.runId)) {
           forgetLocalRunId?.(evt.runId);


### PR DESCRIPTION
## Summary
Discord component interactions (buttons/select menus) must be acknowledged within ~3 seconds. In our Discord monitor component handlers, acknowledgement happened only at the end of the run path (`interaction.reply({ content: "✓", ephemeral: true })`) after authorization and routing work. Under slower conditions, this can exceed Discord’s interaction ACK window and users see **"This interaction failed"**.

This PR changes both component handlers to defer immediately and then continue existing logic.

Fixes #16262.

## Root cause analysis
Code path:
- `src/discord/monitor/agent-components.ts`
  - `AgentComponentButton.run(...)`
  - `AgentSelectMenu.run(...)`

Previously:
1. Parse interaction data
2. Perform policy/allowlist checks (including async store reads in DM pairing flow)
3. Resolve route and enqueue system event
4. Finally call `interaction.reply({ content: "✓", ephemeral: true })`

There was no early defer/ack before async work.

## What changed
### Before
```ts
// ...async checks and routing...
enqueueSystemEvent(...);
await interaction.reply({ content: "✓", ephemeral: true });
```

### After
```ts
await interaction.defer({ ephemeral: true });
// ...existing checks and routing...
enqueueSystemEvent(...);
await interaction.reply({ content: "✓", ephemeral: true });
```

In Carbon (`@buape/carbon`), `reply()` automatically edits the original deferred response once deferred. So the existing response flow remains compatible and no handler restructuring is needed.

## UX and behavior notes
- Chosen approach: **deferred ephemeral reply** (Carbon `defer({ ephemeral: true })`) rather than message-update semantics.
  - Preserves existing ephemeral confirmation/error UX.
  - Avoids mutating the source message state.
- Permission/allowlist failures still return explicit error text; now these are edits to the deferred ephemeral response.
- Parse failures still short-circuit with immediate direct reply (no defer), as they are fast and terminal.

## Timeout / TTL considerations
Discord deferred interaction tokens are finite-lived (~15 minutes). These handlers do not wait for LLM completion; they enqueue an event and respond immediately, so they are comfortably inside the deferred window. This PR still guarantees immediate ACK at interaction receipt time, removing the 3-second failure mode.

## Tests and verification
- Updated tests in `src/discord/monitor/agent-components.test.ts` to assert immediate defer:
  - `expect(defer).toHaveBeenCalledWith({ ephemeral: true })`
- Lint passed: `npm run lint` ✅
- Changed files:
  - `src/discord/monitor/agent-components.ts`
  - `src/discord/monitor/agent-components.test.ts`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR contains two distinct fixes:

**1. Discord component interaction defer** (`agent-components.ts`): Adds an immediate `interaction.defer({ ephemeral: true })` call in both `AgentComponentButton` and `AgentSelectMenu` handlers, placed after fast parse/validation checks but before the heavier async work (allowlist reads, pairing store lookups, route resolution). This ensures Discord's 3-second interaction ACK requirement is met. The defer is wrapped in a try/catch that logs errors but allows execution to continue gracefully. Carbon's `reply()` automatically edits the deferred response, so existing response flows remain compatible.

**2. Webchat NO_REPLY filtering** (`server-chat.ts`): Adds `isSilentReplyText` checks to both `emitChatDelta` (suppresses streaming deltas) and `emitChatFinal` (suppresses the message body in final payloads) when the text matches the `NO_REPLY` token. This prevents the internal silent reply token from leaking to webchat clients. The final lifecycle event is still emitted so clients know the run ended.

- Both changes include appropriate test coverage.
- No issues found during review.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — both changes are straightforward, defensive, and well-tested.
- The Discord defer change is a standard pattern for handling Discord's 3-second interaction ACK window. The defer is placed after fast validation but before any slow async work, and is wrapped in a try/catch for graceful degradation. The NO_REPLY webchat filtering is a clean, defense-in-depth approach that suppresses an internal token at both the streaming delta and final message layers. Both changes have adequate test coverage, and the code follows existing patterns in the codebase.
- No files require special attention.

<sub>Last reviewed commit: 9b41af8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->