### PR TITLE
fix: filter brew install options when brew is unavailable

### DIFF
--- a/src/agents/skills-status.filters-brew-when-unavailable.e2e.test.ts
+++ b/src/agents/skills-status.filters-brew-when-unavailable.e2e.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from "vitest";
+import type { SkillEntry } from "./skills/types.js";
+import { buildWorkspaceSkillStatus } from "./skills-status.js";
+import { hasBinary } from "./skills/config.js";
+
+vi.mock("./skills/config.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("./skills/config.js")>();
+  return {
+    ...original,
+    hasBinary: vi.fn((bin: string) => {
+      // Simulate an environment where brew is not installed.
+      if (bin === "brew") {
+        return false;
+      }
+      return original.hasBinary(bin);
+    }),
+  };
+});
+
+describe("buildWorkspaceSkillStatus – brew filtering", () => {
+  it("filters out brew install options when brew is not available", () => {
+    const entry: SkillEntry = {
+      skill: {
+        name: "brew-only-skill",
+        description: "Needs brew",
+        source: "test",
+        filePath: "/tmp/brew-only",
+        baseDir: "/tmp",
+      },
+      frontmatter: {},
+      metadata: {
+        requires: { bins: ["fakebin"] },
+        install: [
+          {
+            id: "brew",
+            kind: "brew",
+            formula: "fakebin",
+            bins: ["fakebin"],
+            label: "Install fakebin (brew)",
+          },
+        ],
+      },
+    };
+
+    // Verify mock is active.
+    expect(hasBinary("brew")).toBe(false);
+    const report = buildWorkspaceSkillStatus("/tmp/ws", { entries: [entry] });
+    const skill = report.skills.find((s) => s.name === "brew-only-skill");
+    expect(skill).toBeDefined();
+    expect(skill?.install).toEqual([]);
+  });
+
+  it("prefers non-brew install option when brew is not available", () => {
+    const entry: SkillEntry = {
+      skill: {
+        name: "multi-install-skill",
+        description: "Has brew and node options",
+        source: "test",
+        filePath: "/tmp/multi-install",
+        baseDir: "/tmp",
+      },
+      frontmatter: {},
+      metadata: {
+        requires: { bins: ["fakebin"] },
+        install: [
+          {
+            id: "brew",
+            kind: "brew",
+            formula: "fakebin",
+            bins: ["fakebin"],
+            label: "Install fakebin (brew)",
+          },
+          {
+            id: "node",
+            kind: "node",
+            package: "fakebin",
+            bins: ["fakebin"],
+            label: "Install fakebin (npm)",
+          },
+        ],
+      },
+    };
+
+    const report = buildWorkspaceSkillStatus("/tmp/ws", { entries: [entry] });
+    const skill = report.skills.find((s) => s.name === "multi-install-skill");
+    expect(skill).toBeDefined();
+    expect(skill?.install).toHaveLength(1);
+    expect(skill?.install[0]?.kind).toBe("node");
+  });
+});

--- a/src/agents/skills-status.ts
+++ b/src/agents/skills-status.ts
@@ -125,9 +125,17 @@ function normalizeInstallOptions(
   }
 
   const platform = process.platform;
+  const brewAvailable = hasBinary("brew");
   const filtered = install.filter((spec) => {
     const osList = spec.os ?? [];
-    return osList.length === 0 || osList.includes(platform);
+    if (osList.length > 0 && !osList.includes(platform)) {
+      return false;
+    }
+    // Filter out brew-based install options when brew is not available.
+    if (spec.kind === "brew" && !brewAvailable) {
+      return false;
+    }
+    return true;
   });
   if (filtered.length === 0) {
     return [];


### PR DESCRIPTION
## Summary

- Filters out `brew`-based skill install options when `brew` is not available on the system
- Prevents confusing "brew not installed" errors during onboarding in Docker containers and other environments without Homebrew
- Skills with alternative install methods (npm, uv, go) automatically fall back to those options

Closes #14593

## Changes

**`src/agents/skills-status.ts`** — Extended `normalizeInstallOptions()` to check `hasBinary("brew")` and filter out brew-kind install specs when brew is unavailable. Uses the existing `hasBinary` utility (already imported).

**`src/agents/skills-status.filters-brew-when-unavailable.e2e.test.ts`** — New test file with 2 tests:
1. Brew-only skill gets empty install array when brew unavailable
2. Multi-install skill (brew + node) falls back to node when brew unavailable

## How it works

Before: Skills with `kind: "brew"` install specs passed the OS filter (Linux includes Docker) and appeared selectable, then failed at install time with "brew not installed".

After: Skills with `kind: "brew"` install specs are filtered out at selection time when brew is unavailable. This is environment-agnostic — works in Docker, bare-metal Linux without brew, WSL without brew, etc.

## Test plan

- [x] New e2e tests pass (7/7 across related files)
- [x] Lint: 0 warnings, 0 errors
- [x] Existing skills-status tests unaffected
- [ ] Manual: Run `openclaw onboard` in Docker container, verify brew skills not offered

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Filters out `brew`-based skill install options in `normalizeInstallOptions()` when Homebrew is not available on the system, preventing confusing "brew not installed" errors during onboarding in Docker containers and other environments without Homebrew.

- Extended `normalizeInstallOptions()` in `skills-status.ts` to check `hasBinary("brew")` and exclude brew-kind install specs when brew is unavailable
- Skills with alternative install methods (npm, uv, go) automatically fall back to those options
- Added two well-structured e2e tests covering the brew-only and multi-install fallback scenarios
- Clean, minimal change that integrates well with the existing OS-based filtering pattern

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it adds a straightforward availability check that prevents broken install options from being surfaced.
- The change is minimal, well-scoped, and follows existing patterns in the codebase. It adds a `hasBinary("brew")` check (already used elsewhere in this file at line 93) to the filter pipeline, with no risk of regression. The brew availability result is correctly hoisted outside the filter callback for efficiency. Both new tests are properly structured and cover the key scenarios. No logical errors, security concerns, or edge cases found.
- No files require special attention

<sub>Last reviewed commit: 1636063</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->