### PR TITLE
feat(xai): switch grok-4-1-fast variants by thinking level

### DIFF
--- a/src/agents/model-families.ts
+++ b/src/agents/model-families.ts
@@ -1,0 +1,49 @@
+import { modelKey, normalizeProviderId } from "./model-selection.js";
+
+export type ReasoningModelFamily = {
+  provider: string;
+  members: string[];
+  reasoningModel: string;
+  nonReasoningModel: string;
+};
+
+const REASONING_MODEL_FAMILIES: ReasoningModelFamily[] = [
+  {
+    provider: "xai",
+    members: ["grok-4-1-fast", "grok-4-1-fast-reasoning", "grok-4-1-fast-non-reasoning"],
+    reasoningModel: "grok-4-1-fast-reasoning",
+    nonReasoningModel: "grok-4-1-fast-non-reasoning",
+  },
+];
+
+export function findReasoningModelFamily(
+  provider: string,
+  model: string,
+): ReasoningModelFamily | undefined {
+  const providerKey = normalizeProviderId(provider);
+  const modelKeyLower = model.trim().toLowerCase();
+  if (!providerKey || !modelKeyLower) {
+    return undefined;
+  }
+  return REASONING_MODEL_FAMILIES.find(
+    (family) =>
+      normalizeProviderId(family.provider) === providerKey &&
+      family.members.some((entry) => entry.toLowerCase() === modelKeyLower),
+  );
+}
+
+export function isReasoningFamilyAllowed(params: {
+  provider: string;
+  baseModel: string;
+  candidateModel: string;
+  allowedModelKeys?: Set<string>;
+}): boolean {
+  const allowed = params.allowedModelKeys;
+  if (!allowed || allowed.size === 0) {
+    return true;
+  }
+
+  const base = modelKey(params.provider, params.baseModel);
+  const candidate = modelKey(params.provider, params.candidateModel);
+  return allowed.has(candidate) || allowed.has(base);
+}

--- a/src/agents/model-selection-thinking.test.ts
+++ b/src/agents/model-selection-thinking.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { findReasoningModelFamily } from "./model-families.js";
+import { resolveThinkingAwareModelRef } from "./model-selection-thinking.js";
+
+describe("model-families", () => {
+  it("detects xai grok-4-1-fast family members", () => {
+    expect(findReasoningModelFamily("xai", "grok-4-1-fast")?.reasoningModel).toBe(
+      "grok-4-1-fast-reasoning",
+    );
+    expect(findReasoningModelFamily("xai", "grok-4-1-fast-reasoning")?.nonReasoningModel).toBe(
+      "grok-4-1-fast-non-reasoning",
+    );
+    expect(findReasoningModelFamily("xai", "grok-4-1-fast-non-reasoning")?.reasoningModel).toBe(
+      "grok-4-1-fast-reasoning",
+    );
+  });
+});
+
+describe("resolveThinkingAwareModelRef", () => {
+  it("switches xai fast model to reasoning variant when thinking is enabled", () => {
+    const resolved = resolveThinkingAwareModelRef({
+      provider: "xai",
+      model: "grok-4-1-fast",
+      thinkingLevel: "high",
+    });
+    expect(resolved).toEqual({
+      provider: "xai",
+      model: "grok-4-1-fast-reasoning",
+    });
+  });
+
+  it("switches xai fast model to non-reasoning variant when thinking is off", () => {
+    const resolved = resolveThinkingAwareModelRef({
+      provider: "xai",
+      model: "grok-4-1-fast-reasoning",
+      thinkingLevel: "off",
+    });
+    expect(resolved).toEqual({
+      provider: "xai",
+      model: "grok-4-1-fast-non-reasoning",
+    });
+  });
+
+  it("does not switch when thinking level is unknown", () => {
+    const resolved = resolveThinkingAwareModelRef({
+      provider: "xai",
+      model: "grok-4-1-fast",
+    });
+    expect(resolved).toEqual({
+      provider: "xai",
+      model: "grok-4-1-fast",
+    });
+  });
+
+  it("respects allowlist and does not switch to disallowed variants", () => {
+    const resolved = resolveThinkingAwareModelRef({
+      provider: "xai",
+      model: "grok-4-1-fast",
+      thinkingLevel: "high",
+      allowedModelKeys: new Set(["openai/gpt-5.2"]),
+    });
+    expect(resolved).toEqual({
+      provider: "xai",
+      model: "grok-4-1-fast",
+    });
+  });
+
+  it("allows switching when allowlist includes only base model", () => {
+    const resolved = resolveThinkingAwareModelRef({
+      provider: "xai",
+      model: "grok-4-1-fast",
+      thinkingLevel: "high",
+      allowedModelKeys: new Set(["xai/grok-4-1-fast"]),
+    });
+    expect(resolved).toEqual({
+      provider: "xai",
+      model: "grok-4-1-fast-reasoning",
+    });
+  });
+});

--- a/src/agents/model-selection-thinking.ts
+++ b/src/agents/model-selection-thinking.ts
@@ -1,0 +1,37 @@
+import type { ThinkLevel } from "../auto-reply/thinking.js";
+import { findReasoningModelFamily, isReasoningFamilyAllowed } from "./model-families.js";
+
+export type ThinkingAwareModelRef = {
+  provider: string;
+  model: string;
+};
+
+export function resolveThinkingAwareModelRef(params: {
+  provider: string;
+  model: string;
+  thinkingLevel?: ThinkLevel;
+  allowedModelKeys?: Set<string>;
+}): ThinkingAwareModelRef {
+  const family = findReasoningModelFamily(params.provider, params.model);
+  if (!family || !params.thinkingLevel) {
+    return { provider: params.provider, model: params.model };
+  }
+
+  const candidateModel =
+    params.thinkingLevel === "off" ? family.nonReasoningModel : family.reasoningModel;
+  if (
+    !isReasoningFamilyAllowed({
+      provider: params.provider,
+      baseModel: params.model,
+      candidateModel,
+      allowedModelKeys: params.allowedModelKeys,
+    })
+  ) {
+    return { provider: params.provider, model: params.model };
+  }
+
+  return {
+    provider: params.provider,
+    model: candidateModel,
+  };
+}

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -392,6 +392,7 @@ export async function resolveReplyDirectives(params: {
     defaultModel,
     provider,
     model,
+    thinkingLevel: resolvedThinkLevel,
     hasModelDirective: directives.hasModelDirective,
     hasResolvedHeartbeatModelOverride,
   });

--- a/src/auto-reply/reply/model-selection.override-respected.test.ts
+++ b/src/auto-reply/reply/model-selection.override-respected.test.ts
@@ -7,6 +7,13 @@ vi.mock("../../agents/model-catalog.js", () => ({
     { provider: "inferencer", id: "deepseek-v3-4bit-mlx", name: "DeepSeek V3" },
     { provider: "kimi-coding", id: "k2p5", name: "Kimi K2.5" },
     { provider: "anthropic", id: "claude-opus-4-5", name: "Claude Opus 4.5" },
+    { provider: "xai", id: "grok-4-1-fast", name: "Grok 4.1 Fast" },
+    { provider: "xai", id: "grok-4-1-fast-reasoning", name: "Grok 4.1 Fast Reasoning" },
+    {
+      provider: "xai",
+      id: "grok-4-1-fast-non-reasoning",
+      name: "Grok 4.1 Fast Non-Reasoning",
+    },
   ]),
 }));
 
@@ -128,5 +135,41 @@ describe("createModelSelectionState respects session model override", () => {
 
     expect(state.provider).toBe(defaultProvider);
     expect(state.model).toBe("deepseek-v3-4bit-mlx");
+  });
+
+  it("maps xai fast model to reasoning variant when thinking is enabled", async () => {
+    const cfg = {} as OpenClawConfig;
+
+    const state = await createModelSelectionState({
+      cfg,
+      agentCfg: undefined,
+      defaultProvider: "xai",
+      defaultModel: "grok-4-1-fast",
+      provider: "xai",
+      model: "grok-4-1-fast",
+      thinkingLevel: "high",
+      hasModelDirective: false,
+    });
+
+    expect(state.provider).toBe("xai");
+    expect(state.model).toBe("grok-4-1-fast-reasoning");
+  });
+
+  it("maps xai fast model to non-reasoning variant when thinking is off", async () => {
+    const cfg = {} as OpenClawConfig;
+
+    const state = await createModelSelectionState({
+      cfg,
+      agentCfg: undefined,
+      defaultProvider: "xai",
+      defaultModel: "grok-4-1-fast",
+      provider: "xai",
+      model: "grok-4-1-fast",
+      thinkingLevel: "off",
+      hasModelDirective: false,
+    });
+
+    expect(state.provider).toBe("xai");
+    expect(state.model).toBe("grok-4-1-fast-non-reasoning");
   });
 });

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -4,6 +4,7 @@ import { clearSessionAuthProfileOverride } from "../../agents/auth-profiles/sess
 import { lookupContextTokens } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { loadModelCatalog } from "../../agents/model-catalog.js";
+import { resolveThinkingAwareModelRef } from "../../agents/model-selection-thinking.js";
 import {
   buildAllowedModelSet,
   type ModelAliasIndex,
@@ -271,6 +272,7 @@ export async function createModelSelectionState(params: {
   provider: string;
   model: string;
   hasModelDirective: boolean;
+  thinkingLevel?: ThinkLevel;
   /** True when heartbeat.model was explicitly resolved for this run.
    *  In that case, skip session-stored overrides so the heartbeat selection wins. */
   hasResolvedHeartbeatModelOverride?: boolean;
@@ -358,6 +360,15 @@ export async function createModelSelectionState(params: {
       model = storedOverride.model;
     }
   }
+
+  const thinkingAwareRef = resolveThinkingAwareModelRef({
+    provider,
+    model,
+    thinkingLevel: params.thinkingLevel,
+    allowedModelKeys,
+  });
+  provider = thinkingAwareRef.provider;
+  model = thinkingAwareRef.model;
 
   if (sessionEntry && sessionStore && sessionKey && sessionEntry.authProfileOverride) {
     const { ensureAuthProfileStore } = await import("../../agents/auth-profiles.js");

--- a/src/gateway/session-utils.model-ref.test.ts
+++ b/src/gateway/session-utils.model-ref.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import type { SessionEntry } from "../config/sessions.js";
+import { resolveSessionModelRef } from "./session-utils.js";
+
+describe("resolveSessionModelRef", () => {
+  it("switches xai fast model to reasoning variant for thinking on", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          model: { primary: "xai/grok-4-1-fast" },
+          thinkingDefault: "high",
+        },
+      },
+    } as OpenClawConfig;
+
+    const resolved = resolveSessionModelRef(cfg);
+    expect(resolved).toEqual({
+      provider: "xai",
+      model: "grok-4-1-fast-reasoning",
+    });
+  });
+
+  it("switches xai fast model to non-reasoning variant when session thinking is off", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          model: { primary: "xai/grok-4-1-fast" },
+          thinkingDefault: "high",
+        },
+      },
+    } as OpenClawConfig;
+
+    const entry = {
+      sessionId: "s",
+      updatedAt: Date.now(),
+      thinkingLevel: "off",
+    } as SessionEntry;
+
+    const resolved = resolveSessionModelRef(cfg, entry);
+    expect(resolved).toEqual({
+      provider: "xai",
+      model: "grok-4-1-fast-non-reasoning",
+    });
+  });
+});

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -9,10 +9,12 @@ import type {
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { lookupContextTokens } from "../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
+import { resolveThinkingAwareModelRef } from "../agents/model-selection-thinking.js";
 import {
   resolveConfiguredModelRef,
   resolveDefaultModelForAgent,
 } from "../agents/model-selection.js";
+import { normalizeThinkLevel } from "../auto-reply/thinking.js";
 import { type OpenClawConfig, loadConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
 import {
@@ -660,7 +662,10 @@ export function resolveSessionModelRef(
     provider = entry?.providerOverride?.trim() || provider;
     model = storedModelOverride;
   }
-  return { provider, model };
+  const thinkingLevel = normalizeThinkLevel(
+    entry?.thinkingLevel ?? cfg.agents?.defaults?.thinkingDefault,
+  );
+  return resolveThinkingAwareModelRef({ provider, model, thinkingLevel });
 }
 
 export function listSessionsFromStore(params: {


### PR DESCRIPTION
## Summary
- Add thinking-aware model-family resolution for xAI `grok-4-1-fast` so runtime routing selects `grok-4-1-fast-reasoning` for thinking-on levels and `grok-4-1-fast-non-reasoning` for `/think off`.
- Integrate the resolver into reply/runtime session model resolution and status output so effective model selection is consistent across execution paths.
- Add targeted coverage for family detection, runtime routing behavior, and session model resolution fallbacks.

## Verification
- `pnpm test -- src/agents/model-selection-thinking.test.ts src/auto-reply/reply/model-selection.override-respected.test.ts src/gateway/session-utils.model-ref.test.ts`
- `pnpm tsgo`
- `pnpm build`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added thinking-aware model resolution for xAI `grok-4-1-fast` that automatically switches between `-reasoning` and `-non-reasoning` variants based on thinking level (`/think off` vs thinking-on).

- Introduced `model-families.ts` to define reasoning model families and `isReasoningFamilyAllowed` to check allowlist compatibility
- `resolveThinkingAwareModelRef` in `model-selection-thinking.ts` handles runtime routing
- Integrated into reply execution (`get-reply-run.ts`), model selection state (`model-selection.ts`), session resolution (`session-utils.ts`), and status output (`commands-status.ts`)
- Added comprehensive test coverage across family detection, runtime routing, session model resolution, and allowlist behavior

The implementation follows existing patterns and provides good test coverage. One minor issue: the status command doesn't pass `allowedModelKeys` to `resolveThinkingAwareModelRef`, which could cause it to display a model variant that would be blocked by allowlist restrictions (though this is an edge case).

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one minor edge case to address
- The implementation is well-structured with comprehensive test coverage, follows existing codebase patterns, and correctly handles the core functionality. Score is 4 (not 5) due to the missing `allowedModelKeys` parameter in the status command's thinking-aware resolution, which could cause status output to show an incorrect model variant in edge cases involving allowlists. This is a display-only issue that wouldn't affect actual execution.
- src/auto-reply/reply/commands-status.ts requires attention for allowlist handling

<sub>Last reviewed commit: 07f51c4</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->