### PR TITLE
fix(bluebubbles): accept webhook message fields at top level

### DIFF
--- a/extensions/bluebubbles/src/monitor-normalize.ts
+++ b/extensions/bluebubbles/src/monitor-normalize.ts
@@ -526,6 +526,26 @@ export function parseTapbackText(params: {
   return null;
 }
 
+// Checks if a record looks like a BlueBubbles message (has typical message fields)
+function looksLikeMessage(record: Record<string, unknown> | null): boolean {
+  if (!record) {
+    return false;
+  }
+  // Check for common message fields that indicate this is a message payload
+  const messageFieldIndicators = [
+    "text",
+    "body",
+    "handle",
+    "sender",
+    "isFromMe",
+    "is_from_me",
+    "chatGuid",
+    "chat_guid",
+    "guid",
+  ];
+  return messageFieldIndicators.some((field) => record[field] !== undefined);
+}
+
 function extractMessagePayload(payload: Record<string, unknown>): Record<string, unknown> | null {
   const dataRaw = payload.data ?? payload.payload ?? payload.event;
   const data =
@@ -535,10 +555,18 @@ function extractMessagePayload(payload: Record<string, unknown>): Record<string,
   const message =
     asRecord(messageRaw) ??
     (typeof messageRaw === "string" ? (asRecord(JSON.parse(messageRaw)) ?? null) : null);
-  if (!message) {
-    return null;
+  if (message) {
+    return message;
   }
-  return message;
+
+  // Fallback: BlueBubbles may send message fields directly at the top level
+  // without a wrapper (data/payload/event/message). Check if the payload itself
+  // looks like a message and use it directly.
+  if (looksLikeMessage(payload)) {
+    return payload;
+  }
+
+  return null;
 }
 
 export function normalizeWebhookMessage(

--- a/extensions/bluebubbles/src/monitor.test.ts
+++ b/extensions/bluebubbles/src/monitor.test.ts
@@ -381,6 +381,41 @@ describe("BlueBubbles webhook monitor", () => {
       expect(res.body).toBe("ok");
     });
 
+    it("accepts POST requests with message fields at top level (BlueBubbles standard format)", async () => {
+      const account = createMockAccount();
+      const config: OpenClawConfig = {};
+      const core = createMockRuntime();
+      setBlueBubblesRuntime(core);
+
+      unregister = registerBlueBubblesWebhookTarget({
+        account,
+        config,
+        runtime: { log: vi.fn(), error: vi.fn() },
+        core,
+        path: "/bluebubbles-webhook",
+      });
+
+      // BlueBubbles may send message fields directly at the top level without a wrapper
+      const payload = {
+        type: "new-message",
+        text: "hello",
+        handle: { address: "+15551234567" },
+        isGroup: false,
+        isFromMe: false,
+        guid: "msg-1",
+        date: Date.now(),
+      };
+
+      const req = createMockRequest("POST", "/bluebubbles-webhook", payload);
+      const res = createMockResponse();
+
+      const handled = await handleBlueBubblesWebhookRequest(req, res);
+
+      expect(handled).toBe(true);
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toBe("ok");
+    });
+
     it("rejects requests with invalid JSON", async () => {
       const account = createMockAccount();
       const config: OpenClawConfig = {};


### PR DESCRIPTION
## Summary

This PR fixes the BlueBubbles webhook compatibility issue where incoming iMessage webhooks were rejected with "invalid payload" error. The fix adds a fallback in `extractMessagePayload()` to handle the case where BlueBubbles sends message fields directly at the top level of the webhook payload without a wrapper (data/payload/event/message).

## Changes

- Added `looksLikeMessage()` helper function to detect if a payload looks like a BlueBubbles message
- Added fallback in `extractMessagePayload()` to use the payload directly as message when no wrapper is found but payload has message-like fields
- Added test case to verify the fix works with top-level message format

## Testing

- All 52 existing tests pass
- New test case "accepts POST requests with message fields at top level (BlueBubbles standard format)" passes
- Tested by running: `npx vitest run extensions/bluebubbles/src/monitor.test.ts`

Fixes openclaw/openclaw#16282

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes BlueBubbles webhook compatibility by adding support for webhooks where message fields are sent directly at the top level instead of nested within a `data` wrapper. The fix adds a fallback in `extractMessagePayload()` that uses the payload directly as a message when no wrapper is found but the payload contains message-like fields (`text`, `body`, `handle`, `sender`, `isFromMe`, `chatGuid`, or `guid`).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are minimal and focused. The fix adds a simple fallback for detecting top-level message payloads without affecting existing wrapped format handling. The new `looksLikeMessage()` helper uses reasonable field indicators to avoid false positives. Test coverage is appropriate with a new test case verifying the fix.
- No files require special attention

<sub>Last reviewed commit: bf4982d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->