### PR TITLE
fix: surface billing/auth FailoverErrors as user-friendly messages

### DIFF
--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -1,7 +1,9 @@
 import type { AssistantMessage } from "@mariozechner/pi-ai";
 import { describe, expect, it } from "vitest";
 import {
+  AUTH_ERROR_USER_MESSAGE,
   BILLING_ERROR_USER_MESSAGE,
+  formatAuthErrorMessage,
   formatBillingErrorMessage,
   formatAssistantErrorText,
   formatRawAssistantErrorForUi,
@@ -107,6 +109,23 @@ describe("formatAssistantErrorText", () => {
     const result = formatAssistantErrorText(msg);
     expect(result).toContain("API provider");
     expect(result).toBe(BILLING_ERROR_USER_MESSAGE);
+  });
+  it("returns a friendly auth message for invalid API key errors", () => {
+    const msg = makeAssistantError("invalid_api_key");
+    const result = formatAssistantErrorText(msg);
+    expect(result).toBe(AUTH_ERROR_USER_MESSAGE);
+  });
+  it("returns a friendly auth message for HTTP 401 errors", () => {
+    const msg = makeAssistantError("HTTP 401 Unauthorized");
+    const result = formatAssistantErrorText(msg);
+    expect(result).toBe(AUTH_ERROR_USER_MESSAGE);
+  });
+  it("includes provider name in auth message when provider is given", () => {
+    const msg = makeAssistantError("unauthorized");
+    const result = formatAssistantErrorText(msg, { provider: "OpenAI" });
+    expect(result).toBe(formatAuthErrorMessage("OpenAI"));
+    expect(result).toContain("OpenAI");
+    expect(result).not.toContain("API provider");
   });
   it("returns a friendly message for rate limit errors", () => {
     const msg = makeAssistantError("429 rate limit reached");

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -10,7 +10,9 @@ export {
   stripThoughtSignatures,
 } from "./pi-embedded-helpers/bootstrap.js";
 export {
+  AUTH_ERROR_USER_MESSAGE,
   BILLING_ERROR_USER_MESSAGE,
+  formatAuthErrorMessage,
   formatBillingErrorMessage,
   classifyFailoverReason,
   classifyFailoverReasonFromHttpStatus,

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -760,6 +760,10 @@ export function formatAssistantErrorText(
     return formatBillingErrorMessage(opts?.provider, opts?.model ?? msg.model);
   }
 
+  if (isAuthErrorMessage(raw)) {
+    return formatAuthErrorMessage(opts?.provider);
+  }
+
   if (isLikelyHttpErrorText(raw) || isRawApiErrorPayload(raw)) {
     return formatRawAssistantErrorForUi(raw);
   }
@@ -801,6 +805,10 @@ export function sanitizeUserFacingText(text: string, opts?: { errorContext?: boo
 
     if (isBillingErrorMessage(trimmed)) {
       return BILLING_ERROR_USER_MESSAGE;
+    }
+
+    if (isAuthErrorMessage(trimmed)) {
+      return AUTH_ERROR_USER_MESSAGE;
     }
 
     if (isRawApiErrorPayload(trimmed) || isLikelyHttpErrorText(trimmed)) {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -39,6 +39,16 @@ export function formatBillingErrorMessage(provider?: string, model?: string): st
 
 export const BILLING_ERROR_USER_MESSAGE = formatBillingErrorMessage();
 
+export function formatAuthErrorMessage(provider?: string): string {
+  const providerName = provider?.trim();
+  if (providerName) {
+    return `⚠️ ${providerName} returned an authentication error — your API key or credentials were rejected. Verify your API key or re-authenticate with \`openclaw configure\`.`;
+  }
+  return "⚠️ API provider returned an authentication error — your API key or credentials were rejected. Verify your API key or re-authenticate with `openclaw configure`.";
+}
+
+export const AUTH_ERROR_USER_MESSAGE = formatAuthErrorMessage();
+
 const RATE_LIMIT_ERROR_USER_MESSAGE = "⚠️ API rate limit reached. Please try again later.";
 const OVERLOADED_ERROR_USER_MESSAGE =
   "The AI service is temporarily overloaded. Please try again in a moment.";

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -44,6 +44,7 @@ import {
 import { normalizeProviderId } from "../model-selection.js";
 import { ensureOpenClawModelsJson } from "../models-config.js";
 import {
+  formatAuthErrorMessage,
   formatBillingErrorMessage,
   classifyFailoverReason,
   extractObservedOverflowTokenCount,
@@ -1485,7 +1486,7 @@ export async function runEmbeddedPiAgent(
                           activeErrorContext.model,
                         )
                       : authFailure
-                        ? "LLM request unauthorized."
+                        ? formatAuthErrorMessage(provider)
                         : "LLM request failed.");
               const status =
                 resolveFailoverStatus(assistantFailoverReason ?? "unknown") ??

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { FailoverError } from "../../agents/failover-error.js";
+import {
+  formatAuthErrorMessage,
+  formatBillingErrorMessage,
+} from "../../agents/pi-embedded-helpers/errors.js";
+
+// Mock heavy dependencies that runAgentTurnWithFallback imports.
+// runWithModelFallback is the core dependency we control to simulate errors.
+vi.mock("../../agents/model-fallback.js", () => ({
+  runWithModelFallback: vi.fn(),
+}));
+
+vi.mock("../../infra/agent-events.js", () => ({
+  emitAgentEvent: vi.fn(),
+  registerAgentRunContext: vi.fn(),
+}));
+
+vi.mock("../../agents/agent-scope.js", () => ({
+  resolveAgentModelFallbacksOverride: vi.fn().mockReturnValue(undefined),
+  resolveRunModelFallbacksOverride: vi.fn().mockReturnValue(undefined),
+}));
+
+vi.mock("../../runtime.js", () => ({
+  defaultRuntime: { error: vi.fn() },
+}));
+
+import { runWithModelFallback } from "../../agents/model-fallback.js";
+import { runAgentTurnWithFallback } from "./agent-runner-execution.js";
+
+function createStubParams(overrides: Record<string, unknown> = {}) {
+  return {
+    commandBody: "test message",
+    followupRun: {
+      prompt: "test message",
+      enqueuedAt: Date.now(),
+      run: {
+        provider: "anthropic",
+        model: "claude-haiku-4-5",
+        config: {},
+        agentDir: "/tmp/test",
+        sessionId: "test-session",
+        sessionKey: undefined,
+        agentId: "main",
+        sessionFile: "/tmp/session.json",
+        workspaceDir: "/tmp",
+        extraSystemPrompt: undefined,
+        ownerNumbers: [],
+        thinkLevel: undefined,
+        verboseLevel: "off",
+        reasoningLevel: undefined,
+        execOverrides: undefined,
+        skillsSnapshot: undefined,
+        bashElevated: false,
+        timeoutMs: 30000,
+        authProfileId: undefined,
+        authProfileIdSource: undefined,
+        blockReplyBreak: "text_end",
+      },
+    },
+    sessionCtx: {},
+    opts: undefined,
+    typingSignals: {
+      signalTextDelta: vi.fn().mockResolvedValue(undefined),
+      signalMessageStart: vi.fn().mockResolvedValue(undefined),
+      signalReasoningDelta: vi.fn().mockResolvedValue(undefined),
+      signalToolStart: vi.fn().mockResolvedValue(undefined),
+      shouldStartOnReasoning: false,
+    },
+    blockReplyPipeline: null,
+    blockStreamingEnabled: false,
+    resolvedBlockStreamingBreak: "text_end" as const,
+    applyReplyToMode: (p: unknown) => p,
+    shouldEmitToolResult: () => false,
+    shouldEmitToolOutput: () => false,
+    pendingToolTasks: new Set<Promise<void>>(),
+    resetSessionAfterCompactionFailure: vi.fn().mockResolvedValue(false),
+    resetSessionAfterRoleOrderingConflict: vi.fn().mockResolvedValue(false),
+    isHeartbeat: false,
+    getActiveSessionEntry: () => undefined,
+    resolvedVerboseLevel: "off" as const,
+    ...overrides,
+  } as unknown as Parameters<typeof runAgentTurnWithFallback>[0];
+}
+
+describe("runAgentTurnWithFallback - FailoverError handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns user-friendly billing error when FailoverError has billing reason", async () => {
+    const billingError = new FailoverError(
+      "All models failed: your API key has run out of credits",
+      { reason: "billing", provider: "anthropic" },
+    );
+    vi.mocked(runWithModelFallback).mockRejectedValue(billingError);
+
+    const result = await runAgentTurnWithFallback(createStubParams());
+
+    expect(result.kind).toBe("final");
+    if (result.kind === "final") {
+      expect(result.payload.text).toBe(formatBillingErrorMessage("anthropic"));
+      expect(result.payload.text).toContain("billing error");
+      expect(result.payload.text).not.toContain("Agent failed before reply");
+    }
+  });
+
+  it("returns user-friendly auth error when FailoverError has auth reason", async () => {
+    const authError = new FailoverError("All models failed: invalid API key", {
+      reason: "auth",
+      provider: "openai",
+    });
+    vi.mocked(runWithModelFallback).mockRejectedValue(authError);
+
+    const result = await runAgentTurnWithFallback(createStubParams());
+
+    expect(result.kind).toBe("final");
+    if (result.kind === "final") {
+      expect(result.payload.text).toBe(formatAuthErrorMessage("openai"));
+      expect(result.payload.text).toContain("openai");
+      expect(result.payload.text).not.toContain("Agent failed before reply");
+    }
+  });
+
+  it("includes provider name in billing error when available", async () => {
+    const billingError = new FailoverError("billing error", {
+      reason: "billing",
+      provider: "google-ai-studio",
+    });
+    vi.mocked(runWithModelFallback).mockRejectedValue(billingError);
+
+    const result = await runAgentTurnWithFallback(createStubParams());
+
+    expect(result.kind).toBe("final");
+    if (result.kind === "final") {
+      expect(result.payload.text).toBe(formatBillingErrorMessage("google-ai-studio"));
+      expect(result.payload.text).toContain("google-ai-studio");
+    }
+  });
+
+  it("uses generic auth message when provider is not specified", async () => {
+    const authError = new FailoverError("auth error", {
+      reason: "auth",
+    });
+    vi.mocked(runWithModelFallback).mockRejectedValue(authError);
+
+    const result = await runAgentTurnWithFallback(createStubParams());
+
+    expect(result.kind).toBe("final");
+    if (result.kind === "final") {
+      expect(result.payload.text).toBe(formatAuthErrorMessage());
+      expect(result.payload.text).not.toContain("Agent failed before reply");
+    }
+  });
+
+  it("uses generic billing message when provider is not specified", async () => {
+    const billingError = new FailoverError("billing error", {
+      reason: "billing",
+    });
+    vi.mocked(runWithModelFallback).mockRejectedValue(billingError);
+
+    const result = await runAgentTurnWithFallback(createStubParams());
+
+    expect(result.kind).toBe("final");
+    if (result.kind === "final") {
+      expect(result.payload.text).toBe(formatBillingErrorMessage());
+      expect(result.payload.text).toContain("provider's billing dashboard");
+    }
+  });
+});

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -650,7 +650,7 @@ export async function runAgentTurnWithFallback(params: {
         : message;
       const trimmedMessage = safeMessage.replace(/\.\s*$/, "");
       const fallbackText = isBilling
-        ? BILLING_ERROR_USER_MESSAGE
+        ? formatBillingErrorMessage()
         : isContextOverflow
           ? "⚠️ Context overflow — prompt too large for this model. Try a shorter message or a larger-context model."
           : isRoleOrderingError

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -3,10 +3,12 @@ import fs from "node:fs";
 import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
 import { runCliAgent } from "../../agents/cli-runner.js";
 import { getCliSessionId } from "../../agents/cli-session.js";
+import { isFailoverError } from "../../agents/failover-error.js";
 import { runWithModelFallback } from "../../agents/model-fallback.js";
 import { isCliProvider } from "../../agents/model-selection.js";
 import {
-  BILLING_ERROR_USER_MESSAGE,
+  formatAuthErrorMessage,
+  formatBillingErrorMessage,
   isCompactionFailureError,
   isContextOverflowError,
   isBillingErrorMessage,
@@ -617,6 +619,29 @@ export async function runAgentTurnWithFallback(params: {
           setTimeout(resolve, TRANSIENT_HTTP_RETRY_DELAY_MS);
         });
         continue;
+      }
+
+      // Surface billing/auth FailoverErrors as clean user-facing messages
+      // instead of the generic "Agent failed before reply" text.
+      if (isFailoverError(err)) {
+        if (err.reason === "billing") {
+          defaultRuntime.error(`Billing error from ${err.provider ?? "provider"}: ${message}`);
+          return {
+            kind: "final",
+            payload: { text: formatBillingErrorMessage(err.provider) },
+          };
+        }
+        if (err.reason === "auth") {
+          defaultRuntime.error(
+            `Authentication error from ${err.provider ?? "provider"}: ${message}`,
+          );
+          return {
+            kind: "final",
+            payload: {
+              text: formatAuthErrorMessage(err.provider),
+            },
+          };
+        }
       }
 
       defaultRuntime.error(`Embedded agent failed before reply: ${message}`);


### PR DESCRIPTION
Root cause: When `FailoverError` with billing or auth reason is thrown after all models fail, the catch block in `runAgentTurnWithFallback` falls through to the generic "Agent failed before reply" handler instead of producing a clean, actionable error message.

Fix: Add explicit `isFailoverError` check before the generic fallback, routing billing errors to `formatBillingErrorMessage()` and auth errors to a provider-specific authentication failure message.

Test: 5 cases covering billing/auth with and without provider name, verifying clean user-facing messages and absence of generic "Agent failed before reply" text.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Improved error handling for billing and authentication failures by surfacing `FailoverError` instances with specific, user-friendly messages instead of falling through to the generic "Agent failed before reply" handler.

Key changes:
- Added explicit `isFailoverError` check in `agent-runner-execution.ts:548-567` before the generic fallback handler
- Routes billing errors to `formatBillingErrorMessage()` and auth errors to `formatAuthErrorMessage()` with provider-specific context when available
- Updated `pi-embedded-runner/run.ts:881` to use `formatAuthErrorMessage()` instead of generic "LLM request unauthorized." text
- Added comprehensive test coverage with 5 test cases covering both billing and auth scenarios with/without provider names
- Tests verify clean messages and absence of generic error text

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is straightforward, well-tested, and follows existing patterns. The change adds specific error handling for FailoverError cases before falling through to generic handlers, which improves user experience without altering any core logic. Test coverage validates all code paths including with/without provider names for both billing and auth scenarios.
- No files require special attention

<sub>Last reviewed commit: 244a1f7</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->