### PR TITLE
refactor(agents): dedupe transient error copy

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -57,7 +57,7 @@ export function handleMessageUpdate(
     return;
   }
 
-  ctx.state.lastAssistant = msg;
+  ctx.noteLastAssistant(msg);
 
   const assistantEvent = evt.assistantMessageEvent;
   const assistantRecord =
@@ -200,7 +200,7 @@ export function handleMessageEnd(
   }
 
   const assistantMessage = msg;
-  ctx.state.lastAssistant = assistantMessage;
+  ctx.noteLastAssistant(assistantMessage);
   ctx.recordAssistantUsage((assistantMessage as { usage?: unknown }).usage);
   promoteThinkingTagsToBlocks(assistantMessage);
 

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -72,6 +72,7 @@ export type EmbeddedPiSubscribeContext = {
   blockChunking?: BlockReplyChunking;
   blockChunker: EmbeddedBlockChunker | null;
   hookRunner?: HookRunner;
+  noteLastAssistant: (msg: AgentMessage) => void;
 
   shouldEmitToolResult: () => boolean;
   shouldEmitToolOutput: () => boolean;

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -1,3 +1,4 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { InlineCodeState } from "../markdown/code-spans.js";
 import type {
   EmbeddedPiSubscribeContext,
@@ -569,6 +570,12 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     resetAssistantMessageState(0);
   };
 
+  const noteLastAssistant = (msg: AgentMessage) => {
+    if (msg?.role === "assistant") {
+      state.lastAssistant = msg;
+    }
+  };
+
   const ctx: EmbeddedPiSubscribeContext = {
     params,
     state,
@@ -576,6 +583,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     blockChunking,
     blockChunker,
     hookRunner: params.hookRunner,
+    noteLastAssistant,
     shouldEmitToolResult,
     shouldEmitToolOutput,
     emitToolSummary,


### PR DESCRIPTION
Follow-up cleanup after #10415.

- Centralize rate-limit and overload user copy in a shared helper.
- Add ctx.noteLastAssistant so last-assistant tracking is consistent.

No behavior change intended beyond reducing drift risk.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR successfully deduplicates rate-limit and overload error copy introduced in #10415 by:

- Extracting duplicate error messages into a shared helper `formatRateLimitOrOverloadedErrorCopy()` in `src/agents/pi-embedded-helpers/errors.ts`
- Centralizing the `OVERLOADED_ERROR_USER_MESSAGE` constant (previously a hardcoded string literal in two locations)
- Adding `ctx.noteLastAssistant()` helper to ensure consistent last-assistant tracking with role validation

The refactoring is clean and maintains identical behavior while reducing code duplication and drift risk. All error message strings remain unchanged, ensuring no user-facing impact.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- This is a straightforward refactoring that extracts duplicated error copy into a shared helper function without changing any logic or user-facing behavior. The changes are minimal, well-scoped, and directly address the stated goal of reducing code duplication and drift risk from PR #10415
- No files require special attention

<sub>Last reviewed commit: 4d94aaa</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->