### PR TITLE
fix: add 'does not support tools' to format error patterns for failover

### DIFF
--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -593,6 +593,7 @@ const ERROR_PATTERNS = {
     "tool_use_id",
     "messages.1.content.1.tool_use.id",
     "invalid request format",
+    "does not support tools", // Ollama 400 error for models that lack tool support
   ],
 } as const;
 


### PR DESCRIPTION
This PR adds the error string "does not support tools" to the format error patterns. This is commonly returned by Ollama (400 Bad Request) when a model does not support tool use. Recognizing this error allows OpenClaw to correctly trigger a model fallback instead of stopping with an unhandled error.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds the `"does not support tools"` string to `ERROR_PATTERNS.format` in `src/agents/pi-embedded-helpers/errors.ts`, enabling OpenClaw to recognize Ollama's 400 Bad Request error when a model lacks tool support and trigger model failover instead of surfacing an unhandled error.

- The new pattern is a single string addition to the existing `format` error patterns array, consistent with how other format errors (e.g., `"invalid request format"`) are already handled.
- `matchesErrorPatterns` lowercases input before comparison, so the match is case-insensitive.
- No test cases were added for the new pattern — consider adding a test in `pi-embedded-helpers.iscloudcodeassistformaterror.e2e.test.ts` and `pi-embedded-helpers.classifyfailoverreason.e2e.test.ts` to cover the Ollama-specific error string.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, additive change to an error pattern list with no risk of breaking existing behavior.
- The change adds a single string to an existing error pattern array, following the exact same convention as all other entries. The matching logic in matchesErrorPatterns is well-tested and case-insensitive. The new pattern correctly enables failover for Ollama models that don't support tools. No logical, security, or syntax issues.
- No files require special attention.

<sub>Last reviewed commit: e143b4b</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->