### PR TITLE
fix(gateway): preserve conversation history on gateway restart

### DIFF
--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -78,10 +78,13 @@ export async function scheduleRestartSentinelWake(_params: { deps: CliDeps }) {
     (origin?.threadId != null ? String(origin.threadId) : undefined);
   // FIX #10018: Write the restart message to the transcript BEFORE delivering.
   if (entry?.sessionId) {
-    await appendAssistantMessageToSessionTranscript({
+    const result = await appendAssistantMessageToSessionTranscript({
       sessionKey,
       text: message,
     });
+    if (!result.ok) {
+      enqueueSystemEvent(`Transcript write failed: ${result.reason}`, { sessionKey });
+    }
   }
 
   try {


### PR DESCRIPTION
Fixes #10018

> Re-submitted from a clean branch. The previous PR #10060 was automatically closed due to a noisy commit history.

## Problem

When the gateway restarts, it sends a notification message (e.g., "Gateway restarted") to external channels via `deliverOutboundPayloads`. However, this message was **not** being written to the session transcript. This caused a gap in the conversation history — the boot message had no `parentId`, effectively creating a new tree root and orphaning all previous conversation history.

## Solution

This PR implements a lightweight fix by calling the existing `appendAssistantMessageToSessionTranscript` function from `src/config/sessions/transcript.ts` right before `deliverOutboundPayloads`. This ensures the restart message is written directly to the session transcript, which automatically handles the `parentId` chain and preserves the conversation history. This approach reuses existing infrastructure, including error handling and real-time UI updates (`emitSessionTranscriptUpdate`), and avoids code duplication.

## Behavior Changes

*   Boot/restart messages are now recorded in the session transcript with a correct `parentId`, preserving the conversation tree.
*   No AI agent run is triggered. No additional token consumption.
*   External notification delivery behavior is completely unchanged.

## Files Changed

| File                                     | Change                                                                              |
| :--------------------------------------- | :---------------------------------------------------------------------------------- |
| `src/gateway/server-restart-sentinel.ts` | **Modified** — calls `appendAssistantMessageToSessionTranscript` before delivering the notification |

*(Self-correction based on Greptile's feedback to reuse existing functions and remove the custom `transcript-writer.ts`)*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `appendAssistantMessageToSessionTranscript` call before `deliverOutboundPayloads` to preserve conversation history on gateway restart by writing the restart message to the session transcript with proper `parentId` chaining.

- The function call is missing error handling—if the transcript write fails, the bug will still occur silently
- Consider wrapping the transcript call in the existing try/catch or checking the return value

<h3>Confidence Score: 2/5</h3>

- This PR has a critical logic error that prevents it from achieving its stated goal
- The transcript write function returns an error result object that is never checked. If the write fails (e.g., missing session, disk error), the conversation history gap will persist silently—exactly the bug this PR aims to fix. The previous review thread mentioned adding error handling, but the implementation doesn't actually check the result
- Pay close attention to `src/gateway/server-restart-sentinel.ts`—the error handling must be added before merge

<sub>Last reviewed commit: 3566274</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->