### PR TITLE
fix: load model catalog from agent-specific directory for sub-agents

### DIFF
--- a/src/gateway/server-methods/types.ts
+++ b/src/gateway/server-methods/types.ts
@@ -30,7 +30,7 @@ export type GatewayRequestContext = {
   cron: CronService;
   cronStorePath: string;
   execApprovalManager?: ExecApprovalManager;
-  loadGatewayModelCatalog: () => Promise<ModelCatalogEntry[]>;
+  loadGatewayModelCatalog: (agentId?: string) => Promise<ModelCatalogEntry[]>;
   getHealthCache: () => HealthSummary | null;
   refreshHealthSnapshot: (opts?: { probe?: boolean }) => Promise<HealthSummary>;
   logHealth: { error: (message: string) => void };

--- a/src/gateway/server-model-catalog.ts
+++ b/src/gateway/server-model-catalog.ts
@@ -4,6 +4,7 @@ import {
   resetModelCatalogCacheForTest,
 } from "../agents/model-catalog.js";
 import { loadConfig } from "../config/config.js";
+import { resolveAgentDir } from "../agents/agent-scope.js";
 
 export type GatewayModelChoice = ModelCatalogEntry;
 
@@ -14,6 +15,11 @@ export function __resetModelCatalogCacheForTest() {
   resetModelCatalogCacheForTest();
 }
 
-export async function loadGatewayModelCatalog(): Promise<GatewayModelChoice[]> {
-  return await loadModelCatalog({ config: loadConfig() });
+export async function loadGatewayModelCatalog(agentId?: string): Promise<GatewayModelChoice[]> {
+  const cfg = loadConfig();
+  
+  // If agentId is provided, use the agent-specific directory for model discovery
+  const agentDir = agentId ? resolveAgentDir(cfg, agentId) : undefined;
+  
+  return await loadModelCatalog({ config: cfg, agentDir });
 }

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -63,7 +63,7 @@ export async function applySessionsPatchToStore(params: {
   store: Record<string, SessionEntry>;
   storeKey: string;
   patch: SessionsPatchParams;
-  loadGatewayModelCatalog?: () => Promise<ModelCatalogEntry[]>;
+  loadGatewayModelCatalog?: (agentId?: string) => Promise<ModelCatalogEntry[]>;
 }): Promise<{ ok: true; entry: SessionEntry } | { ok: false; error: ErrorShape }> {
   const { cfg, store, storeKey, patch } = params;
   const now = Date.now();
@@ -270,7 +270,7 @@ export async function applySessionsPatchToStore(params: {
           error: errorShape(ErrorCodes.UNAVAILABLE, "model catalog unavailable"),
         };
       }
-      const catalog = await params.loadGatewayModelCatalog();
+      const catalog = await params.loadGatewayModelCatalog(sessionAgentId);
       const resolved = resolveAllowedModelRef({
         cfg,
         catalog,


### PR DESCRIPTION
## Summary

Fixes #16277 - MiniMax (and other provider models) fail with 'Unknown model' during sub-agent spawns even though they show as 'configured' in `openclaw models list`.

## Root Cause

`loadGatewayModelCatalog()` always loaded the model catalog from the main agent's directory (`~/.openclaw/agents/main/agent/`), regardless of which agent was spawning.

When a sub-agent (e.g., `mephisto`) spawned with a model configured in its own directory (`~/.openclaw/agents/mephisto/agent/`), the model resolution failed because it was looking in the wrong place.

## Changes

1. **src/gateway/server-model-catalog.ts**
   - Add optional `agentId` parameter to `loadGatewayModelCatalog()`
   - Resolve agent-specific directory when agentId is provided
   
2. **src/agents/model-catalog.ts**
   - Add optional `agentDir` parameter to `loadModelCatalog()`
   - Use provided agentDir instead of always defaulting to main agent
   
3. **src/gateway/sessions-patch.ts**
   - Pass `sessionAgentId` to `loadGatewayModelCatalog()` when patching sessions
   - Update function signature to accept agentId parameter
   
4. **src/gateway/server-methods/types.ts**
   - Update `GatewayContext` type to reflect new signature

## Impact

- ✅ Sub-agents can now use models configured in their own agent directories
- ✅ Fixes MiniMax model resolution for sub-agents
- ✅ Fixes any custom provider models configured per-agent
- ✅ Backward compatible - agentId is optional, defaults to main agent

## Testing

Verified that:
- Main agent model resolution still works (agentId not passed)
- Sub-agent spawns now resolve models from correct agent directory
- `openclaw models list` output matches runtime behavior

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes sub-agent model resolution by converting the model catalog cache from a single promise to a per-`agentDir` Map, and threading an optional `agentId` through the gateway model catalog loading path. The core fix is correct: `loadModelCatalog` and `loadGatewayModelCatalog` now accept an agent-specific directory/ID, and `sessions-patch.ts` correctly passes `sessionAgentId` when resolving models.

- **Shadowed variable risk**: In `model-catalog.ts`, `agentDir` is computed identically at two scopes (line 76 and line 99). The inner declaration shadows the outer, creating a maintenance hazard if one is changed without the other.
- **Incomplete fix in `chat.ts`**: `server-methods/chat.ts:245` calls `loadGatewayModelCatalog()` without passing `sessionAgentId` (which is already resolved on line 243), meaning sub-agent chat sessions will still use the main agent's model catalog for thinking-level defaults.
- **Type inconsistency**: `NodeEventContext.loadGatewayModelCatalog` in `server-node-events-types.ts:29` was not updated to accept the optional `agentId` parameter, unlike `GatewayRequestContext` in `server-methods/types.ts`. This doesn't cause a runtime issue (the underlying function still accepts it), but creates a type mismatch between the two context types.

<h3>Confidence Score: 3/5</h3>

- The core fix is sound but the PR has a shadowed variable that could silently diverge and an incomplete fix in the chat model resolution path.
- The approach is correct and backward compatible. However, the shadowed `agentDir` in model-catalog.ts is a maintenance risk, and the chat.ts call site was not updated to pass the agent ID despite having it in scope — this leaves a gap in the fix for sub-agent model resolution. The type inconsistency in server-node-events-types.ts is minor but should be addressed for consistency.
- `src/agents/model-catalog.ts` (shadowed variable), `src/gateway/server-methods/chat.ts` (missing agentId pass-through), `src/gateway/server-node-events-types.ts` (type not updated)

<sub>Last reviewed commit: b03c9d3</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->