### PR TITLE
fix: resolve session path from absolute path when agentId is implicit

### DIFF
--- a/src/gateway/server-methods/types.ts
+++ b/src/gateway/server-methods/types.ts
@@ -30,7 +30,7 @@ export type GatewayRequestContext = {
   cron: CronService;
   cronStorePath: string;
   execApprovalManager?: ExecApprovalManager;
-  loadGatewayModelCatalog: () => Promise<ModelCatalogEntry[]>;
+  loadGatewayModelCatalog: (agentId?: string) => Promise<ModelCatalogEntry[]>;
   getHealthCache: () => HealthSummary | null;
   refreshHealthSnapshot: (opts?: { probe?: boolean }) => Promise<HealthSummary>;
   logHealth: { error: (message: string) => void };

--- a/src/gateway/server-model-catalog.ts
+++ b/src/gateway/server-model-catalog.ts
@@ -4,6 +4,7 @@ import {
   resetModelCatalogCacheForTest,
 } from "../agents/model-catalog.js";
 import { loadConfig } from "../config/config.js";
+import { resolveAgentDir } from "../agents/agent-scope.js";
 
 export type GatewayModelChoice = ModelCatalogEntry;
 
@@ -14,6 +15,11 @@ export function __resetModelCatalogCacheForTest() {
   resetModelCatalogCacheForTest();
 }
 
-export async function loadGatewayModelCatalog(): Promise<GatewayModelChoice[]> {
-  return await loadModelCatalog({ config: loadConfig() });
+export async function loadGatewayModelCatalog(agentId?: string): Promise<GatewayModelChoice[]> {
+  const cfg = loadConfig();
+  
+  // If agentId is provided, use the agent-specific directory for model discovery
+  const agentDir = agentId ? resolveAgentDir(cfg, agentId) : undefined;
+  
+  return await loadModelCatalog({ config: cfg, agentDir });
 }

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -63,7 +63,7 @@ export async function applySessionsPatchToStore(params: {
   store: Record<string, SessionEntry>;
   storeKey: string;
   patch: SessionsPatchParams;
-  loadGatewayModelCatalog?: () => Promise<ModelCatalogEntry[]>;
+  loadGatewayModelCatalog?: (agentId?: string) => Promise<ModelCatalogEntry[]>;
 }): Promise<{ ok: true; entry: SessionEntry } | { ok: false; error: ErrorShape }> {
   const { cfg, store, storeKey, patch } = params;
   const now = Date.now();
@@ -270,7 +270,7 @@ export async function applySessionsPatchToStore(params: {
           error: errorShape(ErrorCodes.UNAVAILABLE, "model catalog unavailable"),
         };
       }
-      const catalog = await params.loadGatewayModelCatalog();
+      const catalog = await params.loadGatewayModelCatalog(sessionAgentId);
       const resolved = resolveAllowedModelRef({
         cfg,
         catalog,


### PR DESCRIPTION
## Summary

Fixes #16271 - Sessions fail with "Session file path must be within sessions directory" when main agent is not explicitly listed in `agents.list`.

## Problem

When `agents.list` defines custom agents but does NOT explicitly include the implicit `main` agent, all channel messages fail with:


This happens because:
1. Session entries store absolute paths like `~/.openclaw/agents/host-cron/sessions/abc.jsonl`
2. When `agentId` is not passed to `resolveSessionFilePath`, it defaults to "main"
3. The path validation rejects paths that escape the main agent's sessions directory

## Solution

When path resolution fails (relative path starts with `..`), extract the agentId from the absolute path and retry resolution with the correct agent's sessions directory.

## Changes

Modified `resolvePathWithinSessionsDir()` in `src/config/sessions/paths.ts`:
- Extract potential agentId from absolute sessionFile path (e.g., `agents/host-cron/sessions/`)
- Retry resolution with the detected agent's sessions directory
- Falls back to original error if detection fails

## Impact

- ✅ Fixes all channel failures (Telegram, Slack, WhatsApp, Discord) when main is implicit
- ✅ Works with existing session entries (no migration needed)
- ✅ Backward compatible - only affects the edge case

Fixes #16271

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixes session path resolution when the main agent is implicit in `agents.list`. The PR addresses a path escaping issue where session files stored with absolute paths for custom agents (like `~/.openclaw/agents/host-cron/sessions/abc.jsonl`) were incorrectly validated against the "main" agent's sessions directory, causing all channel operations to fail with "Session file path must be within sessions directory".

Key changes:
- Modified `resolvePathWithinSessionsDir()` to extract agent ID from absolute paths when validation fails
- Updated model catalog loading to accept agent-specific directories for proper agent isolation
- Changes are backward compatible and only activate when path resolution would otherwise fail

The fix is elegant and maintains security by re-validating extracted paths through the same containment checks.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor considerations around test coverage
- The fix correctly addresses the reported issue with a targeted fallback mechanism. The security model is preserved through re-validation of extracted paths. However, the score is 4 instead of 5 due to missing test coverage for the new code path, which handles a critical edge case that previously caused complete channel failures.
- Consider adding test coverage for `src/config/sessions/paths.ts` to validate the agent ID extraction logic

<sub>Last reviewed commit: 29975b3</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->