### PR TITLE
feat: Add audit logging, response verification, and task accountability plugins

### DIFF
--- a/GETLATEST-README.md
+++ b/GETLATEST-README.md
@@ -1,0 +1,104 @@
+# GetLatest OpenClaw Fork
+
+This is GetLatest's fork of [OpenClaw](https://github.com/openclaw/openclaw) with additional plugins for **audit logging**, **response verification**, and **task accountability**.
+
+## Why This Fork?
+
+We built these plugins to solve a real problem: agents sometimes claim they completed work without actually doing it. This fork adds:
+
+1. **Independent audit trail** — Every tool call logged, verifiable
+2. **Completion verification** — Claims checked against actual actions before delivery
+3. **Task accountability** — Enforces workflows (e.g., GitHub issues) with custom instructions
+
+## Added Plugins
+
+| Plugin                 | Description                                           |
+| ---------------------- | ----------------------------------------------------- |
+| `audit-logger`         | Logs all tool calls to `~/.openclaw/logs/audit.jsonl` |
+| `response-verifier`    | Verifies completion claims against audit log          |
+| `task-accountability`  | Injects custom instructions + verifies compliance     |
+| `instruction-injector` | Generic plugin for custom instruction injection       |
+
+## Core Changes
+
+- Added `before_response` hook — fires before responses are delivered, enables verification
+
+## Quick Start
+
+```bash
+# Clone and build
+cd ~/dev
+git clone https://github.com/get-latest/openclaw.git openclaw-getlatest
+cd openclaw-getlatest
+npm install
+npm run build
+
+# Switch to this version
+openclaw gateway stop
+npm link
+openclaw gateway start
+
+# Verify
+openclaw --version  # Should show 2026.2.13+
+```
+
+## Enable Plugins
+
+Add to `~/.openclaw/openclaw.json`:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "audit-logger": { "enabled": true },
+      "response-verifier": { "enabled": true },
+      "task-accountability": { "enabled": true }
+    }
+  }
+}
+```
+
+Then restart: `openclaw gateway restart`
+
+## Custom Instructions
+
+The `task-accountability` plugin looks for custom workflow instructions at:
+
+```
+~/.openclaw/protocols/github-workflow.md
+```
+
+If this file exists, those instructions are injected into every session. Each bot can have different instructions tailored to their workflow.
+
+Example: require GitHub issues for all work, enforce specific repos/projects, control issue lifecycle.
+
+## Modes
+
+- **Warning mode (default)** — Prepends warnings to responses that fail verification
+- **Strict mode** — Blocks responses entirely (`"strictMode": true` in plugin config)
+
+## Rolling Back
+
+If something breaks:
+
+```bash
+openclaw gateway stop
+npm install -g openclaw@latest
+openclaw gateway start
+```
+
+Takes ~30 seconds.
+
+## Full Documentation
+
+See the complete usage guide: [openclaw-fork-usage.md](https://github.com/get-latest/company/blob/main/guides/openclaw-fork-usage.md)
+
+## Upstream PR
+
+These changes are submitted upstream: [openclaw/openclaw#16359](https://github.com/openclaw/openclaw/pull/16359)
+
+If merged, you can switch back to stock OpenClaw and keep the plugins.
+
+---
+
+_Fork maintained by GetLatest AI_

--- a/docs/adr/ADR-001-task-verification.md
+++ b/docs/adr/ADR-001-task-verification.md
@@ -1,0 +1,151 @@
+# ADR-001: Task Verification & Accountability System
+
+**Date:** 2026-02-14  
+**Status:** Implemented  
+**Authors:** @higginsvott, @justinhenriksen
+
+## Context
+
+AI agents can claim to have performed actions without actually doing them. There's no independent verification mechanism — self-reporting is honor-system.
+
+**Problem Statement:** How do we verify that an agent actually did what it claims to have done, before that claim reaches the user?
+
+**Extended Goal:** Enable accountability by tying tasks to external systems (e.g., GitHub issues) with mechanical enforcement.
+
+## Decision
+
+Implement a two-layer verification system using plugin hooks:
+
+1. **`before_agent_start` hook** — Inject mandatory instructions/protocols into system prompt
+2. **`before_response` hook** — Verify completion claims against audit log before delivery
+
+### Why Two Layers?
+
+| Layer        | Purpose                             | Mechanism                 |
+| ------------ | ----------------------------------- | ------------------------- |
+| Instructions | Guide agent toward correct behavior | System prompt injection   |
+| Verification | Enforce compliance mechanically     | Audit log cross-reference |
+
+Instructions alone can be ignored. Verification alone doesn't guide behavior. Together: belt and suspenders.
+
+## Alternatives Considered
+
+### 1. Instruction Injection Only (`before_agent_start`)
+
+Inject requirements into system prompt.
+
+```typescript
+api.on("before_agent_start", () => ({
+  prependContext: "MANDATORY: Create GitHub issue before starting work...",
+}));
+```
+
+✅ Simple, uses existing hook  
+❌ No enforcement — agent can ignore  
+**Verdict:** Necessary but not sufficient
+
+### 2. Mandatory Skills Config
+
+Add config option to always load certain skills.
+
+```json
+{ "skills": { "mandatory": ["github-issue-gate"] } }
+```
+
+✅ Leverages skill system  
+❌ Requires core changes, still just guidance  
+**Verdict:** Good enhancement, doesn't solve verification
+
+### 3. Response Verification Only (`before_response`)
+
+Check audit log before allowing completion claims.
+
+✅ Hard enforcement  
+❌ Doesn't guide agent toward correct behavior  
+**Verdict:** Necessary but needs guidance layer
+
+### 4. Message Wrapping (`message_received`)
+
+Transform incoming messages to include protocol.
+
+```typescript
+api.on("message_received", (event) => ({
+  content: `[PROTOCOL: Create issue first]\n\n${event.content}`,
+}));
+```
+
+✅ Every message gets protocol  
+❌ Pollutes history, feels hacky  
+**Verdict:** Fallback if 1+3 fails
+
+### 5. Tool Gating (`before_tool_call`)
+
+Block tools unless prerequisites met.
+
+```typescript
+api.on("before_tool_call", (event, ctx) => {
+  if (!hasGitHubIssue(ctx)) return { block: true };
+});
+```
+
+✅ Prevents work without accountability  
+❌ Requires session state, may be too restrictive  
+**Verdict:** Consider if 1+3 too loose
+
+## Implementation
+
+### New Plugin Hooks
+
+- **`before_response`** — Fires before assistant response delivery
+  - Event: `{ text, toolCalls, mediaUrls }`
+  - Result: `{ text?, block?, blockReason?, prependWarning? }`
+
+### Plugins
+
+1. **audit-logger** — Logs all tool calls to `~/.openclaw/logs/audit.jsonl`
+2. **response-verifier** — Verifies claims against audit log
+   - Warning mode: Prepends `⚠️ VERIFICATION WARNING`
+   - Strict mode: Blocks unverified responses
+
+### Files Changed
+
+- `src/plugins/types.ts` — Added hook types
+- `src/plugins/hooks.ts` — Added `runBeforeResponse`
+- `src/agents/pi-embedded-subscribe.handlers.messages.ts` — Wired hook
+- `extensions/audit-logger/` — New plugin
+- `extensions/response-verifier/` — New plugin
+
+## Consequences
+
+### Positive
+
+- Independent audit trail of all agent actions
+- Mechanical verification of completion claims
+- Extensible pattern for other accountability requirements
+- Warning mode allows gradual rollout
+
+### Negative
+
+- Additional latency (audit log reads)
+- False positives possible with pattern matching
+- Requires both plugins enabled to work
+
+### Risks
+
+- **Warning fatigue:** Too many false positives → ignored
+- **Performance:** Log parsing may be slow at scale
+- **Bypass:** Clever phrasing might evade detection
+
+## Revisit Triggers
+
+Switch approaches if:
+
+1. Warning fatigue → Tune patterns or enable strict mode
+2. Still missing issues → Add tool gating (Alternative 5)
+3. Instructions ignored → Try mandatory skills (Alternative 2)
+4. Performance issues → In-memory state vs log parsing
+
+## Related
+
+- GitHub Issues: #13131, #12563, #16026
+- Plugins: `extensions/audit-logger/`, `extensions/response-verifier/`

--- a/extensions/audit-logger/README.md
+++ b/extensions/audit-logger/README.md
@@ -1,0 +1,156 @@
+# Audit Logger Plugin
+
+Creates a tamper-evident audit trail of all agent actions for independent verification.
+
+## Why This Exists
+
+When an AI agent claims it did something ("I sent that message", "I created that file"), how do you verify it actually happened? The audit logger creates an **independent record** of all tool calls and messages that:
+
+1. **Cannot be manipulated by the agent** — logs at the gateway level, not agent level
+2. **Captures everything** — every tool call, every message, across all sessions
+3. **Enables verification** — compare agent claims against actual recorded actions
+
+## Installation
+
+The plugin is bundled with OpenClaw. Enable it in your config:
+
+```json
+{
+  "plugins": {
+    "audit-logger": {
+      "enabled": true
+    }
+  }
+}
+```
+
+## What It Logs
+
+### Tool Calls (`type: "tool_call"`)
+
+Every tool invocation (exec, read, write, message, etc.):
+
+```json
+{
+  "ts": "2026-02-14T14:30:05.000Z",
+  "type": "tool_call",
+  "tool": "exec",
+  "params": { "command": "git status" },
+  "success": true,
+  "durationMs": 150,
+  "sessionKey": "agent:main:main"
+}
+```
+
+### Messages Sent (`type: "message_sent"`)
+
+Every outbound message to any channel:
+
+```json
+{
+  "ts": "2026-02-14T14:30:10.000Z",
+  "type": "message_sent",
+  "channelId": "telegram",
+  "to": "+1234567890",
+  "success": true,
+  "contentLength": 42
+}
+```
+
+### Session Events
+
+Markers for session boundaries:
+
+```json
+{"ts": "...", "type": "session_start", "sessionId": "...", "agentId": "main"}
+{"ts": "...", "type": "session_end", "sessionId": "...", "messageCount": 15}
+```
+
+## Log Location
+
+Default: `~/.openclaw/logs/audit.jsonl`
+
+Override via config:
+
+```json
+{
+  "plugins": {
+    "audit-logger": {
+      "enabled": true,
+      "logPath": "/custom/path/audit.jsonl"
+    }
+  }
+}
+```
+
+## Security Features
+
+### Sensitive Data Redaction
+
+Passwords, tokens, API keys, and other sensitive parameters are automatically redacted:
+
+```json
+{ "tool": "exec", "params": { "command": "curl -H 'Authorization: [REDACTED]' ..." } }
+```
+
+Default redacted keys: `password`, `token`, `secret`, `apikey`, `auth`, `credential`, `private`, `bearer`
+
+Add custom patterns:
+
+```json
+{
+  "plugins": {
+    "audit-logger": {
+      "enabled": true,
+      "redactPatterns": ["ssn", "creditcard"]
+    }
+  }
+}
+```
+
+### Append-Only Format
+
+Logs are written in JSONL (JSON Lines) format — each line is a complete JSON object. This makes tampering detectable (modifying a line changes its structure).
+
+## Verification Use Cases
+
+### Check if a command was actually run
+
+```bash
+grep '"tool":"exec"' ~/.openclaw/logs/audit.jsonl | grep 'git push'
+```
+
+### Check if a message was actually sent
+
+```bash
+grep '"type":"message_sent"' ~/.openclaw/logs/audit.jsonl | jq .
+```
+
+### List all tool calls in a session
+
+```bash
+grep '"sessionKey":"agent:main:main"' ~/.openclaw/logs/audit.jsonl | jq -r '.tool' | sort | uniq -c
+```
+
+### View recent activity
+
+```bash
+tail -20 ~/.openclaw/logs/audit.jsonl | jq .
+```
+
+## Related Issues
+
+- [#13131](https://github.com/openclaw/openclaw/issues/13131) — Gateway-level audit logging feature request
+- [#12563](https://github.com/openclaw/openclaw/issues/12563) — Messaging operations without audit (security issue)
+- [#16026](https://github.com/openclaw/openclaw/issues/16026) — Immune system improvements
+
+## Future: Pre-Completion Verification
+
+This plugin handles **Part 1** (audit logging). **Part 2** (pre-completion verification) requires a new `before_response` hook that would:
+
+1. Intercept agent responses before they're sent
+2. Parse completion claims ("done", "created", "sent")
+3. Verify claims against the audit log
+4. Block or warn if verification fails
+
+See the PR for the `before_response` hook for progress on this.

--- a/extensions/audit-logger/index.ts
+++ b/extensions/audit-logger/index.ts
@@ -1,0 +1,163 @@
+/**
+ * Audit Logger Plugin
+ *
+ * Creates a tamper-evident audit trail of all agent actions for independent verification.
+ * Logs to ~/.openclaw/logs/audit.jsonl (or custom path via config).
+ *
+ * Hooks:
+ * - after_tool_call: Logs every tool invocation with params, success, duration
+ * - message_sent: Logs every outbound message with recipient and delivery status
+ * - session_start: Marks session boundaries in the audit trail
+ */
+
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+type AuditLoggerConfig = {
+  redactPatterns?: string[];
+  logPath?: string;
+};
+
+// Sensitive keys to redact by default
+const DEFAULT_SENSITIVE_KEYS = [
+  "password",
+  "token",
+  "secret",
+  "apikey",
+  "api_key",
+  "auth",
+  "credential",
+  "private",
+  "bearer",
+];
+
+function resolveLogPath(config?: AuditLoggerConfig): string {
+  if (config?.logPath) {
+    return config.logPath;
+  }
+  const stateDir = process.env.OPENCLAW_STATE_DIR ?? path.join(os.homedir(), ".openclaw");
+  return path.join(stateDir, "logs", "audit.jsonl");
+}
+
+async function ensureLogDir(logPath: string): Promise<void> {
+  const dir = path.dirname(logPath);
+  await fs.mkdir(dir, { recursive: true });
+}
+
+async function appendLog(logPath: string, entry: Record<string, unknown>): Promise<void> {
+  await ensureLogDir(logPath);
+  const line =
+    JSON.stringify({
+      ts: new Date().toISOString(),
+      ...entry,
+    }) + "\n";
+  await fs.appendFile(logPath, line, "utf-8");
+}
+
+function redactSensitiveParams(
+  params: Record<string, unknown>,
+  extraPatterns: string[] = [],
+): Record<string, unknown> {
+  const sensitiveKeys = [...DEFAULT_SENSITIVE_KEYS, ...extraPatterns.map((p) => p.toLowerCase())];
+
+  const redacted: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(params)) {
+    const lowerKey = key.toLowerCase();
+    if (sensitiveKeys.some((s) => lowerKey.includes(s))) {
+      redacted[key] = "[REDACTED]";
+    } else if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+      redacted[key] = redactSensitiveParams(value as Record<string, unknown>, extraPatterns);
+    } else {
+      redacted[key] = value;
+    }
+  }
+
+  return redacted;
+}
+
+const plugin = {
+  id: "audit-logger",
+  name: "Audit Logger",
+  description: "Logs all tool calls and messages to an audit trail for verification",
+
+  register(api: OpenClawPluginApi) {
+    const config = api.pluginConfig as AuditLoggerConfig | undefined;
+    const logPath = resolveLogPath(config);
+    const extraPatterns = config?.redactPatterns ?? [];
+
+    api.logger.info(`Audit logger enabled, writing to: ${logPath}`);
+
+    // Log session starts
+    api.on("session_start", async (event, ctx) => {
+      try {
+        await appendLog(logPath, {
+          type: "session_start",
+          sessionId: ctx.sessionId,
+          agentId: ctx.agentId,
+          resumedFrom: event.resumedFrom,
+        });
+      } catch (err) {
+        api.logger.error(`Failed to log session_start: ${String(err)}`);
+      }
+    });
+
+    // Log every tool call
+    api.on(
+      "after_tool_call",
+      async (event, ctx) => {
+        try {
+          const redactedParams = redactSensitiveParams(event.params, extraPatterns);
+          await appendLog(logPath, {
+            type: "tool_call",
+            tool: event.toolName,
+            params: redactedParams,
+            success: !event.error,
+            error: event.error,
+            durationMs: event.durationMs,
+            sessionKey: ctx.sessionKey,
+          });
+        } catch (err) {
+          api.logger.error(`Failed to log tool_call: ${String(err)}`);
+        }
+      },
+      { priority: 100 }, // High priority to ensure we log before other hooks
+    );
+
+    // Log every outbound message
+    api.on("message_sent", async (event, ctx) => {
+      try {
+        await appendLog(logPath, {
+          type: "message_sent",
+          channelId: ctx.channelId,
+          to: event.to,
+          success: event.success,
+          error: event.error,
+          // Don't log content for privacy, just that it was sent
+          contentLength: event.content?.length,
+        });
+      } catch (err) {
+        api.logger.error(`Failed to log message_sent: ${String(err)}`);
+      }
+    });
+
+    // Log session ends
+    api.on("session_end", async (event, ctx) => {
+      try {
+        await appendLog(logPath, {
+          type: "session_end",
+          sessionId: ctx.sessionId,
+          agentId: ctx.agentId,
+          messageCount: event.messageCount,
+          durationMs: event.durationMs,
+        });
+      } catch (err) {
+        api.logger.error(`Failed to log session_end: ${String(err)}`);
+      }
+    });
+  },
+};
+
+export default plugin;

--- a/extensions/audit-logger/openclaw.plugin.json
+++ b/extensions/audit-logger/openclaw.plugin.json
@@ -1,0 +1,21 @@
+{
+  "id": "audit-logger",
+  "name": "Audit Logger",
+  "version": "1.0.0",
+  "description": "Logs all tool calls and messages to an audit trail for independent verification",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "redactPatterns": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Additional patterns to redact from logs (besides default sensitive keys)"
+      },
+      "logPath": {
+        "type": "string",
+        "description": "Custom path for audit log (default: ~/.openclaw/logs/audit.jsonl)"
+      }
+    }
+  }
+}

--- a/extensions/audit-logger/package.json
+++ b/extensions/audit-logger/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@openclaw/audit-logger",
+  "version": "1.0.0",
+  "description": "Audit trail plugin for tool calls and messages",
+  "type": "module",
+  "exports": {
+    ".": "./index.ts"
+  },
+  "dependencies": {}
+}

--- a/extensions/compaction-guard/index.ts
+++ b/extensions/compaction-guard/index.ts
@@ -1,0 +1,268 @@
+/**
+ * Compaction Guard Plugin
+ *
+ * Preserves task context across memory compaction events.
+ *
+ * Problem: When Pi auto-compaction runs mid-task, the agent loses working
+ * context and doesn't know what it was doing ("stroke" effect).
+ *
+ * Solution:
+ * 1. `before_compaction` — Extract and save current task state
+ * 2. `after_compaction` — Mark that recovery is needed
+ * 3. `before_agent_start` — Inject recovery context if compaction just happened
+ */
+
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+type CompactionGuardConfig = {
+  contextFile?: string;
+  recoveryPrompt?: boolean;
+  minMessagesForSnapshot?: number;
+};
+
+// State tracking
+const state = {
+  compactionJustHappened: false,
+  lastCompactionTime: 0,
+  compactionCount: 0,
+  savedContext: null as string | null,
+};
+
+function resolveContextPath(config: CompactionGuardConfig): string {
+  const workspace =
+    process.env.OPENCLAW_WORKSPACE ?? path.join(os.homedir(), ".openclaw/workspace");
+  const defaultPath = path.join(workspace, "memory", "compaction-context.md");
+
+  if (!config.contextFile) {
+    return defaultPath;
+  }
+
+  if (config.contextFile.startsWith("~/")) {
+    return path.join(os.homedir(), config.contextFile.slice(2));
+  }
+
+  if (path.isAbsolute(config.contextFile)) {
+    return config.contextFile;
+  }
+
+  return path.join(workspace, config.contextFile);
+}
+
+async function extractTaskContext(messages: unknown[]): Promise<string | null> {
+  if (!Array.isArray(messages) || messages.length === 0) {
+    return null;
+  }
+
+  // Look at recent messages to understand current task
+  const recentMessages = messages.slice(-20);
+  const contextParts: string[] = [];
+
+  for (const msg of recentMessages) {
+    if (!msg || typeof msg !== "object") continue;
+
+    const role = (msg as { role?: string }).role;
+    const content = (msg as { content?: unknown }).content;
+
+    if (role === "user" && typeof content === "string") {
+      // User messages often contain the task
+      const truncated = content.length > 500 ? content.slice(0, 500) + "..." : content;
+      contextParts.push(`User: ${truncated}`);
+    } else if (role === "assistant") {
+      // Look for task indicators in assistant messages
+      const text = extractTextContent(content);
+      if (text) {
+        // Check for task-related patterns
+        if (/working on|creating|building|fixing|implementing|investigating/i.test(text)) {
+          const truncated = text.length > 300 ? text.slice(0, 300) + "..." : text;
+          contextParts.push(`Assistant: ${truncated}`);
+        }
+      }
+    }
+  }
+
+  if (contextParts.length === 0) {
+    return null;
+  }
+
+  return contextParts.slice(-5).join("\n\n");
+}
+
+function extractTextContent(content: unknown): string | null {
+  if (typeof content === "string") {
+    return content;
+  }
+
+  if (Array.isArray(content)) {
+    const textParts: string[] = [];
+    for (const block of content) {
+      if (block && typeof block === "object") {
+        const rec = block as { type?: string; text?: string };
+        if (rec.type === "text" && typeof rec.text === "string") {
+          textParts.push(rec.text);
+        }
+      }
+    }
+    return textParts.join("\n") || null;
+  }
+
+  return null;
+}
+
+async function saveContext(
+  contextPath: string,
+  context: string,
+  compactionCount: number,
+): Promise<void> {
+  const content = `# Compaction Recovery Context
+
+*Auto-saved at: ${new Date().toISOString()}*
+*Compaction #${compactionCount}*
+
+## Recent Activity
+
+${context}
+
+---
+
+**Note:** This context was automatically saved before memory compaction.
+If you're reading this, compaction just ran. Review the above to understand
+what was happening before context was compressed.
+`;
+
+  await fs.mkdir(path.dirname(contextPath), { recursive: true });
+  await fs.writeFile(contextPath, content, "utf-8");
+}
+
+async function loadContext(contextPath: string): Promise<string | null> {
+  try {
+    const content = await fs.readFile(contextPath, "utf-8");
+    return content;
+  } catch {
+    return null;
+  }
+}
+
+async function clearContext(contextPath: string): Promise<void> {
+  try {
+    await fs.unlink(contextPath);
+  } catch {
+    // File may not exist, that's fine
+  }
+}
+
+const RECOVERY_PROMPT = `
+## ⚠️ COMPACTION RECOVERY
+
+Memory compaction just ran. Your previous context was compressed.
+
+**What to do:**
+1. Check \`memory/compaction-context.md\` for saved task state
+2. Check \`memory/session-context.md\` for current task info
+3. If mid-task, review what you were doing and continue
+4. If unclear, ask: "I think compaction just ran. What were we working on?"
+
+**Do not** pretend you know what was happening if context is unclear.
+`.trim();
+
+const plugin = {
+  id: "compaction-guard",
+  name: "Compaction Guard",
+  description: "Preserves task context across memory compaction",
+
+  register(api: OpenClawPluginApi) {
+    const config = (api.pluginConfig ?? {}) as CompactionGuardConfig;
+    const contextPath = resolveContextPath(config);
+    const minMessages = config.minMessagesForSnapshot ?? 10;
+    const injectRecovery = config.recoveryPrompt !== false;
+
+    api.logger.info(`Compaction guard enabled (contextPath: ${contextPath})`);
+
+    // Track sessions that need recovery
+    const needsRecovery = new Set<string>();
+
+    // Before compaction: save current task context
+    api.on("before_compaction", async (event) => {
+      const messageCount = event.messageCount ?? 0;
+
+      if (messageCount < minMessages) {
+        api.logger.debug?.(
+          `[compaction-guard] Skipping snapshot (${messageCount} < ${minMessages} messages)`,
+        );
+        return;
+      }
+
+      state.compactionCount++;
+      state.compactionJustHappened = true;
+      state.lastCompactionTime = Date.now();
+
+      api.logger.info(
+        `[compaction-guard] Compaction #${state.compactionCount} starting (${messageCount} messages)`,
+      );
+
+      // Extract and save context from messages if available
+      const messages = event.messages;
+      if (Array.isArray(messages) && messages.length > 0) {
+        const context = await extractTaskContext(messages);
+        if (context) {
+          try {
+            await saveContext(contextPath, context, state.compactionCount);
+            state.savedContext = context;
+            api.logger.info(`[compaction-guard] Saved task context to ${contextPath}`);
+          } catch (err) {
+            api.logger.warn(`[compaction-guard] Failed to save context: ${String(err)}`);
+          }
+        }
+      }
+    });
+
+    // After compaction: mark recovery needed
+    api.on("after_compaction", async (event) => {
+      const sessionKey = (event as { sessionKey?: string }).sessionKey ?? "default";
+
+      api.logger.info(
+        `[compaction-guard] Compaction complete, marking recovery for session: ${sessionKey}`,
+      );
+      needsRecovery.add(sessionKey);
+    });
+
+    // Before agent start: inject recovery if needed
+    api.on("before_agent_start", async (event) => {
+      const sessionKey = event.sessionKey ?? "default";
+
+      // Check if this session needs recovery
+      if (!needsRecovery.has(sessionKey)) {
+        // Also check time-based (in case of restart)
+        const timeSinceCompaction = Date.now() - state.lastCompactionTime;
+        if (timeSinceCompaction > 60000 || !state.compactionJustHappened) {
+          return undefined;
+        }
+      }
+
+      // Clear the flag
+      needsRecovery.delete(sessionKey);
+      state.compactionJustHappened = false;
+
+      if (!injectRecovery) {
+        return undefined;
+      }
+
+      api.logger.info(`[compaction-guard] Injecting recovery context for session: ${sessionKey}`);
+
+      // Load saved context if available
+      let recoveryContent = RECOVERY_PROMPT;
+      const savedContext = await loadContext(contextPath);
+      if (savedContext) {
+        recoveryContent += `\n\n---\n\n**Saved Context:**\n\n${savedContext}`;
+      }
+
+      return {
+        prependContext: recoveryContent,
+      };
+    });
+  },
+};
+
+export default plugin;

--- a/extensions/compaction-guard/openclaw.plugin.json
+++ b/extensions/compaction-guard/openclaw.plugin.json
@@ -1,0 +1,25 @@
+{
+  "id": "compaction-guard",
+  "name": "Compaction Guard",
+  "version": "0.1.0",
+  "description": "Preserves task context across memory compaction events",
+  "main": "index.ts",
+  "hooks": ["before_compaction", "after_compaction", "before_agent_start"],
+  "configSchema": {
+    "type": "object",
+    "properties": {
+      "contextFile": {
+        "type": "string",
+        "description": "Path to save/restore context (default: memory/compaction-context.md)"
+      },
+      "recoveryPrompt": {
+        "type": "boolean",
+        "description": "Inject recovery prompt after compaction (default: true)"
+      },
+      "minMessagesForSnapshot": {
+        "type": "number",
+        "description": "Minimum messages to trigger snapshot (default: 10)"
+      }
+    }
+  }
+}

--- a/extensions/compaction-guard/package.json
+++ b/extensions/compaction-guard/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@openclaw/plugin-compaction-guard",
+  "version": "0.1.0",
+  "description": "Preserves task context across memory compaction events",
+  "type": "module",
+  "main": "index.ts",
+  "dependencies": {}
+}

--- a/extensions/instruction-injector/README.md
+++ b/extensions/instruction-injector/README.md
@@ -1,0 +1,127 @@
+# Instruction Injector Plugin
+
+Inject custom instructions into every agent session via the system prompt.
+
+## Use Cases
+
+- **Custom protocols** — Task tracking, code review requirements, etc.
+- **Team guidelines** — Company-specific rules and processes
+- **Project context** — Ongoing project information
+- **Safety/compliance** — Required disclaimers or restrictions
+
+## Installation
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "instruction-injector": {
+        "enabled": true,
+        "instructions": "Your custom instructions here..."
+      }
+    }
+  }
+}
+```
+
+## Configuration
+
+### Inline Instructions
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "instruction-injector": {
+        "enabled": true,
+        "instructions": "## My Protocol\n\nAlways do X before Y.\nNever do Z without approval."
+      }
+    }
+  }
+}
+```
+
+### File-Based Instructions
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "instruction-injector": {
+        "enabled": true,
+        "file": "~/.openclaw/my-instructions.md"
+      }
+    }
+  }
+}
+```
+
+File takes precedence over inline if both are specified.
+
+### Options
+
+| Option           | Type                      | Default                 | Description                           |
+| ---------------- | ------------------------- | ----------------------- | ------------------------------------- |
+| `instructions`   | string                    | —                       | Inline instructions to inject         |
+| `file`           | string                    | —                       | Path to markdown file (supports `~/`) |
+| `position`       | `"prepend"` \| `"append"` | `"prepend"`             | Where to inject (prepend currently)   |
+| `wrapWithHeader` | boolean                   | `true`                  | Wrap with `## Header`                 |
+| `headerTitle`    | string                    | `"Custom Instructions"` | Header title if wrapping              |
+
+## Example: Team Guidelines
+
+**~/.openclaw/team-guidelines.md:**
+
+```markdown
+## Team Guidelines
+
+1. All code changes require PR review
+2. Use conventional commits (feat:, fix:, docs:, etc.)
+3. Update tests when modifying behavior
+4. No direct commits to main branch
+```
+
+**Config:**
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "instruction-injector": {
+        "enabled": true,
+        "file": "~/.openclaw/team-guidelines.md",
+        "wrapWithHeader": false
+      }
+    }
+  }
+}
+```
+
+## Combining with Other Plugins
+
+Use alongside other plugins for layered enforcement:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "instruction-injector": {
+        "enabled": true,
+        "file": "~/.openclaw/my-protocol.md"
+      },
+      "audit-logger": { "enabled": true },
+      "response-verifier": { "enabled": true }
+    }
+  }
+}
+```
+
+- **instruction-injector** — Tells the agent what to do
+- **audit-logger** — Records what it actually did
+- **response-verifier** — Verifies claims before delivery
+
+## Related
+
+- **task-accountability** — GitHub issue enforcement (includes its own instruction injection)
+- **audit-logger** — Audit trail for verification
+- **response-verifier** — Completion claim verification

--- a/extensions/instruction-injector/index.ts
+++ b/extensions/instruction-injector/index.ts
@@ -1,0 +1,119 @@
+/**
+ * Instruction Injector Plugin
+ *
+ * Injects custom instructions into every agent session via the system prompt.
+ * Instructions can be provided inline via config or loaded from a file.
+ *
+ * Use cases:
+ * - Custom protocols (task tracking, code review requirements, etc.)
+ * - Team-specific guidelines
+ * - Project-specific context
+ * - Safety/compliance instructions
+ */
+
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+type InstructionInjectorConfig = {
+  instructions?: string;
+  file?: string;
+  position?: "prepend" | "append";
+  wrapWithHeader?: boolean;
+  headerTitle?: string;
+};
+
+function expandPath(filePath: string): string {
+  if (filePath.startsWith("~/")) {
+    return path.join(os.homedir(), filePath.slice(2));
+  }
+  return filePath;
+}
+
+async function loadInstructions(config: InstructionInjectorConfig): Promise<string | null> {
+  // File takes precedence over inline
+  if (config.file) {
+    try {
+      const filePath = expandPath(config.file);
+      const content = await fs.readFile(filePath, "utf-8");
+      return content.trim();
+    } catch (err) {
+      console.error(`[instruction-injector] Failed to load file: ${config.file}`, err);
+      return null;
+    }
+  }
+
+  if (config.instructions) {
+    return config.instructions.trim();
+  }
+
+  return null;
+}
+
+function wrapInstructions(instructions: string, wrap: boolean, title: string): string {
+  if (!wrap) {
+    return instructions;
+  }
+
+  return `## ${title}
+
+${instructions}`;
+}
+
+const plugin = {
+  id: "instruction-injector",
+  name: "Instruction Injector",
+  description: "Inject custom instructions into agent system prompt",
+
+  register(api: OpenClawPluginApi) {
+    const config = api.pluginConfig as InstructionInjectorConfig | undefined;
+
+    if (!config?.instructions && !config?.file) {
+      api.logger.warn(
+        "[instruction-injector] No instructions configured. Set 'instructions' or 'file' in plugin config.",
+      );
+      return;
+    }
+
+    const position = config.position ?? "prepend";
+    const wrapWithHeader = config.wrapWithHeader ?? true;
+    const headerTitle = config.headerTitle ?? "Custom Instructions";
+
+    api.logger.info(
+      `Instruction injector enabled (source: ${config.file ? "file" : "inline"}, position: ${position})`,
+    );
+
+    // Cache loaded instructions to avoid file reads on every request
+    let cachedInstructions: string | null = null;
+    let instructionsLoaded = false;
+
+    api.on("before_agent_start", async () => {
+      // Load instructions on first use
+      if (!instructionsLoaded) {
+        cachedInstructions = await loadInstructions(config);
+        instructionsLoaded = true;
+
+        if (!cachedInstructions) {
+          api.logger.warn("[instruction-injector] No instructions loaded");
+        }
+      }
+
+      if (!cachedInstructions) {
+        return undefined;
+      }
+
+      const formatted = wrapInstructions(cachedInstructions, wrapWithHeader, headerTitle);
+
+      if (position === "append") {
+        // Note: prependContext is the only option currently available
+        // For true append, would need systemPrompt modification
+        return { prependContext: formatted };
+      }
+
+      return { prependContext: formatted };
+    });
+  },
+};
+
+export default plugin;

--- a/extensions/instruction-injector/openclaw.plugin.json
+++ b/extensions/instruction-injector/openclaw.plugin.json
@@ -1,0 +1,36 @@
+{
+  "id": "instruction-injector",
+  "name": "Instruction Injector",
+  "version": "1.0.0",
+  "description": "Inject custom instructions into every agent session via system prompt",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "instructions": {
+        "type": "string",
+        "description": "Instructions to inject (inline string)"
+      },
+      "file": {
+        "type": "string",
+        "description": "Path to markdown file containing instructions (overrides inline)"
+      },
+      "position": {
+        "type": "string",
+        "enum": ["prepend", "append"],
+        "description": "Where to inject instructions",
+        "default": "prepend"
+      },
+      "wrapWithHeader": {
+        "type": "boolean",
+        "description": "Wrap instructions with a header comment",
+        "default": true
+      },
+      "headerTitle": {
+        "type": "string",
+        "description": "Title for the header wrapper",
+        "default": "Custom Instructions"
+      }
+    }
+  }
+}

--- a/extensions/instruction-injector/package.json
+++ b/extensions/instruction-injector/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@openclaw/instruction-injector",
+  "version": "1.0.0",
+  "description": "Inject custom instructions into every agent session",
+  "type": "module",
+  "exports": {
+    ".": "./index.ts"
+  },
+  "dependencies": {}
+}

--- a/extensions/response-verifier/README.md
+++ b/extensions/response-verifier/README.md
@@ -1,0 +1,138 @@
+# Response Verifier Plugin
+
+Verifies agent completion claims against the audit log **before responses are delivered**.
+
+## The Problem
+
+When an AI agent says "Done! I sent the message" — how do you know it actually did? The agent could:
+
+- Claim completion without taking action
+- Forget to actually execute a tool
+- Have a tool call fail silently
+
+## The Solution
+
+This plugin intercepts responses before delivery and:
+
+1. **Detects completion claims** — "done", "sent", "created", "finished", etc.
+2. **Extracts claimed actions** — what the agent says it did
+3. **Verifies against audit log** — checks if those actions actually occurred
+4. **Blocks or warns** — depending on configuration
+
+## Requirements
+
+This plugin requires the **audit-logger** plugin to be enabled. The audit logger creates the trail that this plugin verifies against.
+
+## Installation
+
+```json
+{
+  "plugins": {
+    "audit-logger": { "enabled": true },
+    "response-verifier": { "enabled": true }
+  }
+}
+```
+
+## Modes
+
+### Warning Mode (default)
+
+When verification fails, the response is delivered with a warning prepended:
+
+```
+⚠️ VERIFICATION WARNING: Unverified claims: message. These actions were not found in the audit log.
+
+Done! I sent the message to the team.
+```
+
+### Strict Mode
+
+When verification fails, the response is **blocked entirely**:
+
+```json
+{
+  "plugins": {
+    "response-verifier": {
+      "enabled": true,
+      "strictMode": true
+    }
+  }
+}
+```
+
+The agent will need to actually perform the action before claiming completion.
+
+## What Gets Verified
+
+| Claimed Action           | Audit Log Check                             |
+| ------------------------ | ------------------------------------------- |
+| "sent the message"       | `message_sent` event or `message` tool call |
+| "created/wrote the file" | `write` tool call                           |
+| "ran the command"        | `exec` tool call                            |
+| "pushed/committed"       | `exec` tool call with git                   |
+| Generic "done/complete"  | Any successful tool call                    |
+
+## Configuration
+
+```json
+{
+  "plugins": {
+    "response-verifier": {
+      "enabled": true,
+      "strictMode": false,
+      "completionPatterns": ["deployed", "shipped"]
+    }
+  }
+}
+```
+
+### Options
+
+- **strictMode** (boolean, default: false) — Block unverified responses instead of warning
+- **completionPatterns** (string[]) — Additional regex patterns that indicate completion claims
+
+## Verification Window
+
+The plugin checks audit log entries from the **last 5 minutes** to verify claims. This prevents false positives from old audit entries and keeps verification relevant to the current conversation.
+
+## Limitations
+
+1. **Pattern-based detection** — Uses regex patterns to detect claims; may miss some phrasing
+2. **Action mapping** — Maps claimed actions to tool names; custom tools may need additional patterns
+3. **Requires audit-logger** — Won't work without audit trail being generated
+
+## Example Scenarios
+
+### ✅ Verified Response
+
+```
+Agent: "I'll send the message now."
+[message tool called, success]
+Agent: "Done! I sent the message."
+→ Audit log shows message_sent event
+→ Response delivered normally
+```
+
+### ⚠️ Unverified Response (Warning Mode)
+
+```
+Agent: "Done! I sent the message."
+→ No message_sent event in audit log
+→ Response delivered with warning prepended
+```
+
+### 🚫 Blocked Response (Strict Mode)
+
+```
+Agent: "Done! I sent the message."
+→ No message_sent event in audit log
+→ Response blocked, not delivered
+→ Agent must actually send message first
+```
+
+## Related
+
+- **audit-logger** plugin — Creates the audit trail this plugin verifies against
+- **before_response** hook — The hook this plugin uses to intercept responses
+- [GitHub Issue #13131](https://github.com/openclaw/openclaw/issues/13131) — Feature request for audit logging

--- a/extensions/response-verifier/index.ts
+++ b/extensions/response-verifier/index.ts
@@ -1,0 +1,242 @@
+/**
+ * Response Verifier Plugin
+ *
+ * Verifies agent completion claims against the audit log before responses are delivered.
+ * Uses the before_response hook to intercept responses and check for verification.
+ *
+ * When the agent claims to have done something (sent a message, created a file, etc.),
+ * this plugin checks the audit log to verify the action actually occurred.
+ *
+ * Modes:
+ * - strictMode: false (default) — Prepend warning if verification fails
+ * - strictMode: true — Block unverified responses entirely
+ */
+
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+type ResponseVerifierConfig = {
+  strictMode?: boolean;
+  completionPatterns?: string[];
+};
+
+// Patterns that indicate the agent is claiming completion
+const DEFAULT_COMPLETION_PATTERNS = [
+  // Direct completion claims
+  /\b(done|completed|finished|created|sent|wrote|saved|updated|deleted|removed|installed|deployed|pushed|committed)\b/i,
+  // Confirmation phrases
+  /\b(i('ve| have)|that('s| is)|it('s| is))\s+(done|complete|finished|sent|created|ready)\b/i,
+  // Action confirmations
+  /\b(successfully|just)\s+(sent|created|wrote|saved|updated|deleted|pushed|committed)\b/i,
+];
+
+// Patterns to extract claimed actions from text
+const ACTION_EXTRACTION_PATTERNS = [
+  // "I sent the message" / "I've sent the message"
+  {
+    pattern: /\bi('ve| have)?\s*(sent|delivered)\s+(the\s+)?(message|email|notification)/i,
+    action: "message",
+  },
+  // "I created the file" / "I wrote to the file"
+  {
+    pattern: /\bi('ve| have)?\s*(created|wrote|saved|updated)\s+(the\s+)?(file|document)/i,
+    action: "write",
+  },
+  // "I ran the command" / "I executed the command"
+  { pattern: /\bi('ve| have)?\s*(ran|executed|run)\s+(the\s+)?(command|script)/i, action: "exec" },
+  // "I pushed the changes" / "I committed the code"
+  {
+    pattern: /\bi('ve| have)?\s*(pushed|committed)\s+(the\s+)?(changes|code|update)/i,
+    action: "exec",
+  },
+  // "Done" / "Complete" / "Finished"
+  { pattern: /^(done|complete|finished)\.?$/i, action: "completion" },
+];
+
+function resolveAuditLogPath(): string {
+  const stateDir = process.env.OPENCLAW_STATE_DIR ?? path.join(os.homedir(), ".openclaw");
+  return path.join(stateDir, "logs", "audit.jsonl");
+}
+
+interface AuditEntry {
+  ts: string;
+  type: string;
+  tool?: string;
+  success?: boolean;
+  sessionKey?: string;
+  [key: string]: unknown;
+}
+
+async function readRecentAuditEntries(
+  logPath: string,
+  sessionKey?: string,
+  maxAge: number = 5 * 60 * 1000, // 5 minutes
+): Promise<AuditEntry[]> {
+  try {
+    const content = await fs.readFile(logPath, "utf-8");
+    const lines = content.trim().split("\n").filter(Boolean);
+    const cutoff = new Date(Date.now() - maxAge).toISOString();
+
+    const entries: AuditEntry[] = [];
+    for (const line of lines) {
+      try {
+        const entry = JSON.parse(line) as AuditEntry;
+        // Filter by time and optionally session
+        if (entry.ts >= cutoff) {
+          if (!sessionKey || entry.sessionKey === sessionKey) {
+            entries.push(entry);
+          }
+        }
+      } catch {
+        // Skip malformed lines
+      }
+    }
+    return entries;
+  } catch {
+    // File doesn't exist or can't be read
+    return [];
+  }
+}
+
+function detectCompletionClaim(text: string, extraPatterns: string[] = []): boolean {
+  const patterns = [
+    ...DEFAULT_COMPLETION_PATTERNS,
+    ...extraPatterns.map((p) => new RegExp(p, "i")),
+  ];
+
+  for (const pattern of patterns) {
+    if (pattern.test(text)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function extractClaimedActions(text: string): string[] {
+  const actions: string[] = [];
+  for (const { pattern, action } of ACTION_EXTRACTION_PATTERNS) {
+    if (pattern.test(text)) {
+      actions.push(action);
+    }
+  }
+  return actions;
+}
+
+function verifyActionsInAuditLog(
+  claimedActions: string[],
+  auditEntries: AuditEntry[],
+): { verified: boolean; missing: string[]; found: string[] } {
+  const found: string[] = [];
+  const missing: string[] = [];
+
+  for (const action of claimedActions) {
+    if (action === "completion") {
+      // Generic completion claim - check if ANY tool was called
+      if (auditEntries.some((e) => e.type === "tool_call" && e.success)) {
+        found.push(action);
+      } else {
+        missing.push(action);
+      }
+    } else if (action === "message") {
+      // Check for message_sent or message tool call
+      if (
+        auditEntries.some(
+          (e) =>
+            e.type === "message_sent" ||
+            (e.type === "tool_call" && e.tool === "message" && e.success),
+        )
+      ) {
+        found.push(action);
+      } else {
+        missing.push(action);
+      }
+    } else {
+      // Check for corresponding tool call
+      if (auditEntries.some((e) => e.type === "tool_call" && e.tool === action && e.success)) {
+        found.push(action);
+      } else {
+        missing.push(action);
+      }
+    }
+  }
+
+  return {
+    verified: missing.length === 0,
+    missing,
+    found,
+  };
+}
+
+const plugin = {
+  id: "response-verifier",
+  name: "Response Verifier",
+  description: "Verifies agent completion claims against audit log",
+
+  register(api: OpenClawPluginApi) {
+    const config = api.pluginConfig as ResponseVerifierConfig | undefined;
+    const strictMode = config?.strictMode ?? false;
+    const extraPatterns = config?.completionPatterns ?? [];
+    const auditLogPath = resolveAuditLogPath();
+
+    api.logger.info(
+      `Response verifier enabled (strictMode: ${strictMode}, auditLog: ${auditLogPath})`,
+    );
+
+    api.on(
+      "before_response",
+      async (event, ctx) => {
+        const { text } = event;
+
+        // Check if response contains completion claims
+        if (!detectCompletionClaim(text, extraPatterns)) {
+          // No completion claim detected, allow response
+          return undefined;
+        }
+
+        // Extract what actions are being claimed
+        const claimedActions = extractClaimedActions(text);
+        if (claimedActions.length === 0) {
+          // Has completion-like language but no specific actions claimed
+          return undefined;
+        }
+
+        // Read recent audit entries
+        const auditEntries = await readRecentAuditEntries(auditLogPath, ctx.sessionKey);
+
+        // Verify claimed actions against audit log
+        const verification = verifyActionsInAuditLog(claimedActions, auditEntries);
+
+        if (verification.verified) {
+          // All claimed actions verified in audit log
+          api.logger.debug?.(`[response-verifier] Verified: ${verification.found.join(", ")}`);
+          return undefined;
+        }
+
+        // Verification failed
+        const warningMsg =
+          `Unverified claims: ${verification.missing.join(", ")}. ` +
+          `These actions were not found in the audit log.`;
+
+        api.logger.warn(`[response-verifier] ${warningMsg}`);
+
+        if (strictMode) {
+          // Block the response entirely
+          return {
+            block: true,
+            blockReason: warningMsg,
+          };
+        } else {
+          // Prepend a warning but allow the response
+          return {
+            prependWarning: `VERIFICATION WARNING: ${warningMsg}`,
+          };
+        }
+      },
+      { priority: 50 }, // Run after other hooks but before delivery
+    );
+  },
+};
+
+export default plugin;

--- a/extensions/response-verifier/openclaw.plugin.json
+++ b/extensions/response-verifier/openclaw.plugin.json
@@ -1,0 +1,22 @@
+{
+  "id": "response-verifier",
+  "name": "Response Verifier",
+  "version": "1.0.0",
+  "description": "Verifies agent completion claims against audit log before delivery",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "strictMode": {
+        "type": "boolean",
+        "description": "If true, block unverified completion claims. If false, just warn.",
+        "default": false
+      },
+      "completionPatterns": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Additional patterns that indicate completion claims"
+      }
+    }
+  }
+}

--- a/extensions/response-verifier/package.json
+++ b/extensions/response-verifier/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@openclaw/response-verifier",
+  "version": "1.0.0",
+  "description": "Verifies agent completion claims against audit log before delivery",
+  "type": "module",
+  "exports": {
+    ".": "./index.ts"
+  },
+  "dependencies": {}
+}

--- a/extensions/task-accountability/README.md
+++ b/extensions/task-accountability/README.md
@@ -1,0 +1,131 @@
+# Task Accountability Plugin
+
+Enforces that all substantive work is tied to a GitHub issue.
+
+## How It Works (ADR-001)
+
+**Two-layer approach:**
+
+1. **`before_agent_start`** — Injects instructions requiring GitHub issue references
+2. **`before_response`** — Verifies issue referenced before allowing completion claims
+
+## What Gets Enforced
+
+When claiming completion ("done", "finished", "created", etc.) after substantive work:
+
+- Response must reference a GitHub issue (GH-123, #45, GET-123, etc.)
+- OR audit log must show `gh issue` commands were run
+
+## What's Exempt
+
+- Simple questions and clarifications
+- Heartbeat responses (HEARTBEAT_OK, NO_REPLY)
+- Quick acknowledgments
+- Responses without completion claims
+- Work taking less than 30 seconds (configurable)
+
+## Installation
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "audit-logger": { "enabled": true },
+      "task-accountability": { "enabled": true }
+    }
+  }
+}
+```
+
+**Requires:** audit-logger plugin for work detection.
+
+## Modes
+
+### Warning Mode (default)
+
+```
+⚠️ ACCOUNTABILITY WARNING: Completion claimed without GitHub issue reference.
+Please reference an issue (e.g., GH-123, #45) or create one with `gh issue create`.
+
+Done! I've implemented the feature.
+```
+
+### Strict Mode
+
+Blocks the response entirely until issue is referenced.
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "task-accountability": {
+        "enabled": true,
+        "strictMode": true
+      }
+    }
+  }
+}
+```
+
+## Configuration
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "task-accountability": {
+        "enabled": true,
+        "strictMode": false,
+        "minTaskDurationSeconds": 30,
+        "issuePatterns": ["PROJ-\\d+"],
+        "exemptPatterns": ["status check"]
+      }
+    }
+  }
+}
+```
+
+| Option                   | Default | Description                                    |
+| ------------------------ | ------- | ---------------------------------------------- |
+| `strictMode`             | `false` | Block vs warn on missing issue                 |
+| `minTaskDurationSeconds` | `30`    | Only require issues for longer tasks           |
+| `issuePatterns`          | `[]`    | Additional regex patterns for issue references |
+| `exemptPatterns`         | `[]`    | Additional patterns for exempt responses       |
+
+## Issue Reference Formats
+
+Recognized automatically:
+
+- `GH-123`, `#123`, `issue #123`
+- `github.com/org/repo/issues/123`
+- `GET-123`, `ABC-123` (Linear-style)
+
+## Injected Instructions
+
+The plugin injects this into every system prompt:
+
+```
+## Task Accountability Protocol
+
+MANDATORY: All substantive work must be tied to a GitHub issue.
+
+Before starting work that involves:
+- Creating or modifying files
+- Running commands that change state
+- Sending messages on behalf of the user
+- Any task expected to take more than 30 seconds
+
+You MUST:
+1. Reference an existing issue (e.g., "Working on GH-123")
+2. OR create a new issue first (`gh issue create`)
+
+When claiming completion:
+- Reference the issue in your response
+- The system will verify this before delivering your response
+```
+
+## Related
+
+- **ADR-001:** `docs/adr/ADR-001-task-verification.md`
+- **audit-logger:** Required for work detection
+- **response-verifier:** Complementary general verification

--- a/extensions/task-accountability/index.ts
+++ b/extensions/task-accountability/index.ts
@@ -184,28 +184,26 @@ function expandPath(filePath: string): string {
   return filePath;
 }
 
+// Well-known path for custom instructions (avoids config schema issues)
+const CUSTOM_INSTRUCTIONS_PATH = "~/.openclaw/protocols/github-workflow.md";
+
 async function loadCustomInstructions(config: TaskAccountabilityConfig): Promise<string | null> {
-  // Explicitly disabled
+  // Explicitly disabled via config
   if (config.instructions === false) {
     return null;
   }
 
-  // File takes precedence
-  if (config.instructionsFile) {
-    try {
-      const filePath = expandPath(config.instructionsFile);
-      const content = await fs.readFile(filePath, "utf-8");
-      return content.trim();
-    } catch (err) {
-      console.error(
-        `[task-accountability] Failed to load instructions file: ${config.instructionsFile}`,
-        err,
-      );
-      return INSTRUCTIONS; // Fall back to default
-    }
+  // Check well-known custom instructions file first
+  try {
+    const customPath = expandPath(CUSTOM_INSTRUCTIONS_PATH);
+    const content = await fs.readFile(customPath, "utf-8");
+    console.log(`[task-accountability] Using custom instructions from ${CUSTOM_INSTRUCTIONS_PATH}`);
+    return content.trim();
+  } catch {
+    // File doesn't exist, continue
   }
 
-  // Inline custom instructions
+  // Inline custom instructions from config
   if (typeof config.instructions === "string") {
     return config.instructions.trim();
   }

--- a/extensions/task-accountability/index.ts
+++ b/extensions/task-accountability/index.ts
@@ -1,0 +1,258 @@
+/**
+ * Task Accountability Plugin
+ *
+ * Enforces that all substantive work is tied to a GitHub issue.
+ *
+ * Two-layer approach (ADR-001):
+ * 1. `before_agent_start` — Injects mandatory instructions
+ * 2. `before_response` — Verifies GitHub issue referenced before completion
+ */
+
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+type TaskAccountabilityConfig = {
+  strictMode?: boolean;
+  issuePatterns?: string[];
+  exemptPatterns?: string[];
+  minTaskDurationSeconds?: number;
+};
+
+// Patterns that indicate a GitHub issue reference
+const DEFAULT_ISSUE_PATTERNS = [
+  // GitHub issue references: GH-123, #123, issue #123
+  /\bGH-\d+\b/i,
+  /\b#\d{1,6}\b/,
+  /\bissue\s*#?\d+\b/i,
+  // GitHub URLs
+  /github\.com\/[\w-]+\/[\w-]+\/issues\/\d+/i,
+  // Linear-style: GET-123, ABC-123
+  /\b[A-Z]{2,5}-\d+\b/,
+];
+
+// Patterns that indicate this is a simple response not requiring an issue
+const DEFAULT_EXEMPT_PATTERNS = [
+  // Questions and clarifications
+  /^(what|how|why|when|where|who|can you|could you|would you|do you|is there|are there)\b/i,
+  // Heartbeat responses
+  /^HEARTBEAT_OK$/,
+  /^NO_REPLY$/,
+  // Simple acknowledgments
+  /^(ok|okay|sure|yes|no|got it|understood|thanks|thank you)\.?$/i,
+];
+
+// Patterns indicating completion/work done
+const COMPLETION_PATTERNS = [
+  /\b(done|completed|finished|created|built|implemented|fixed|resolved|shipped|deployed|pushed|committed)\b/i,
+  /\b(i('ve| have)|that('s| is)|it('s| is))\s+(done|complete|finished|ready)\b/i,
+  /✅|✓|complete/i,
+];
+
+const INSTRUCTIONS = `
+## Task Accountability Protocol
+
+**MANDATORY:** All substantive work must be tied to a GitHub issue.
+
+Before starting work that involves:
+- Creating or modifying files
+- Running commands that change state
+- Sending messages on behalf of the user
+- Any task expected to take more than 30 seconds
+
+You MUST:
+1. Reference an existing issue (e.g., "Working on GH-123" or "This addresses #45")
+2. OR create a new issue first (e.g., \`gh issue create --title "..." --body "..."\`)
+
+When claiming completion:
+- Reference the issue in your response
+- The system will verify this before delivering your response
+
+**Exempt:** Simple questions, clarifications, status checks, and heartbeats do not require issues.
+`.trim();
+
+function resolveAuditLogPath(): string {
+  const stateDir = process.env.OPENCLAW_STATE_DIR ?? path.join(os.homedir(), ".openclaw");
+  return path.join(stateDir, "logs", "audit.jsonl");
+}
+
+interface AuditEntry {
+  ts: string;
+  type: string;
+  tool?: string;
+  params?: Record<string, unknown>;
+  success?: boolean;
+  durationMs?: number;
+  [key: string]: unknown;
+}
+
+async function readRecentAuditEntries(
+  logPath: string,
+  maxAge: number = 10 * 60 * 1000, // 10 minutes
+): Promise<AuditEntry[]> {
+  try {
+    const content = await fs.readFile(logPath, "utf-8");
+    const lines = content.trim().split("\n").filter(Boolean);
+    const cutoff = new Date(Date.now() - maxAge).toISOString();
+
+    const entries: AuditEntry[] = [];
+    // Read from end for efficiency
+    for (let i = lines.length - 1; i >= 0; i--) {
+      try {
+        const entry = JSON.parse(lines[i]) as AuditEntry;
+        if (entry.ts < cutoff) break; // Stop when we hit old entries
+        entries.unshift(entry);
+      } catch {
+        // Skip malformed lines
+      }
+    }
+    return entries;
+  } catch {
+    return [];
+  }
+}
+
+function hasIssueReference(text: string, extraPatterns: string[] = []): boolean {
+  const patterns = [...DEFAULT_ISSUE_PATTERNS, ...extraPatterns.map((p) => new RegExp(p, "i"))];
+
+  for (const pattern of patterns) {
+    if (pattern.test(text)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isExemptResponse(text: string, extraPatterns: string[] = []): boolean {
+  const patterns = [...DEFAULT_EXEMPT_PATTERNS, ...extraPatterns.map((p) => new RegExp(p, "i"))];
+
+  const trimmed = text.trim();
+  for (const pattern of patterns) {
+    if (pattern.test(trimmed)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isCompletionClaim(text: string): boolean {
+  for (const pattern of COMPLETION_PATTERNS) {
+    if (pattern.test(text)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function hasSubstantiveWork(entries: AuditEntry[], minDurationMs: number): boolean {
+  // Check if there were tool calls that indicate real work
+  const workTools = ["exec", "write", "Edit", "message"];
+  let totalDuration = 0;
+
+  for (const entry of entries) {
+    if (entry.type === "tool_call" && entry.success) {
+      if (workTools.includes(entry.tool ?? "")) {
+        totalDuration += entry.durationMs ?? 0;
+      }
+    }
+  }
+
+  return totalDuration >= minDurationMs;
+}
+
+function checkAuditForIssueCommands(entries: AuditEntry[]): boolean {
+  // Check if `gh issue` commands were run
+  for (const entry of entries) {
+    if (entry.type === "tool_call" && entry.tool === "exec" && entry.success) {
+      const command = String(entry.params?.command ?? "");
+      if (/\bgh\s+issue\b/i.test(command)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+const plugin = {
+  id: "task-accountability",
+  name: "Task Accountability",
+  description: "Enforces GitHub issue accountability for all work",
+
+  register(api: OpenClawPluginApi) {
+    const config = api.pluginConfig as TaskAccountabilityConfig | undefined;
+    const strictMode = config?.strictMode ?? false;
+    const extraIssuePatterns = config?.issuePatterns ?? [];
+    const extraExemptPatterns = config?.exemptPatterns ?? [];
+    const minTaskDurationMs = (config?.minTaskDurationSeconds ?? 30) * 1000;
+    const auditLogPath = resolveAuditLogPath();
+
+    api.logger.info(`Task accountability enabled (strictMode: ${strictMode})`);
+
+    // Layer 1: Inject instructions at agent start
+    api.on("before_agent_start", () => {
+      return {
+        prependContext: INSTRUCTIONS,
+      };
+    });
+
+    // Layer 2: Verify issue reference before completion
+    api.on(
+      "before_response",
+      async (event) => {
+        const { text } = event;
+
+        // Skip exempt responses (questions, heartbeats, etc.)
+        if (isExemptResponse(text, extraExemptPatterns)) {
+          return undefined;
+        }
+
+        // Skip if not claiming completion
+        if (!isCompletionClaim(text)) {
+          return undefined;
+        }
+
+        // Check if response already has issue reference
+        if (hasIssueReference(text, extraIssuePatterns)) {
+          api.logger.debug?.("[task-accountability] Issue reference found in response");
+          return undefined;
+        }
+
+        // Read audit log to check for substantive work
+        const auditEntries = await readRecentAuditEntries(auditLogPath);
+
+        // If no substantive work was done, don't require issue
+        if (!hasSubstantiveWork(auditEntries, minTaskDurationMs)) {
+          return undefined;
+        }
+
+        // Check if gh issue commands were run (indicates issue was created/updated)
+        if (checkAuditForIssueCommands(auditEntries)) {
+          api.logger.debug?.("[task-accountability] GitHub issue command found in audit log");
+          return undefined;
+        }
+
+        // Verification failed — work was done but no issue referenced
+        const warningMsg =
+          "Completion claimed without GitHub issue reference. " +
+          "Please reference an issue (e.g., GH-123, #45) or create one with `gh issue create`.";
+
+        api.logger.warn(`[task-accountability] ${warningMsg}`);
+
+        if (strictMode) {
+          return {
+            block: true,
+            blockReason: warningMsg,
+          };
+        } else {
+          return {
+            prependWarning: `ACCOUNTABILITY WARNING: ${warningMsg}`,
+          };
+        }
+      },
+      { priority: 40 }, // Run after audit-logger but before response-verifier
+    );
+  },
+};
+
+export default plugin;

--- a/extensions/task-accountability/openclaw.plugin.json
+++ b/extensions/task-accountability/openclaw.plugin.json
@@ -1,39 +1,63 @@
 {
-  "id": "task-accountability",
-  "name": "Task Accountability",
-  "version": "1.1.0",
-  "description": "Enforces task accountability by requiring GitHub issues for all work",
+  "name": "task-accountability",
+  "version": "1.0.0",
+  "description": "Configurable execution gate - require issue/ticket creation before substantive work",
+  "main": "index.ts",
   "configSchema": {
     "type": "object",
-    "additionalProperties": false,
     "properties": {
       "strictMode": {
         "type": "boolean",
-        "description": "If true, block responses without GitHub issue references. If false, just warn.",
+        "description": "If true, block tool calls. If false, warn only.",
         "default": false
       },
-      "issuePatterns": {
-        "type": "array",
-        "items": { "type": "string" },
-        "description": "Additional patterns that indicate GitHub issue references"
-      },
-      "exemptPatterns": {
-        "type": "array",
-        "items": { "type": "string" },
-        "description": "Patterns for responses that don't require GitHub issues (e.g., simple questions)"
-      },
-      "minTaskDurationSeconds": {
-        "type": "number",
-        "description": "Only require issues for tasks longer than this (based on tool calls)",
-        "default": 30
+      "gate": {
+        "type": "object",
+        "description": "Gate configuration",
+        "properties": {
+          "gatedTools": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Tools that require unlock before execution",
+            "default": ["exec", "write", "edit", "Write", "Edit"]
+          },
+          "unlockPatterns": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Regex patterns that unlock the gate when matched in tool output",
+            "default": [
+              "github\\.com/[\\w-]+/[\\w-]+/issues/\\d+",
+              "gh issue create",
+              "#\\d{1,6}",
+              "GH-\\d+",
+              "[A-Z]{2,5}-\\d+"
+            ]
+          },
+          "exemptPatterns": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Regex patterns for commands always allowed (read-only, etc.)",
+            "default": [
+              "^cat\\s",
+              "^ls\\s",
+              "^grep\\s",
+              "^git\\s+(status|log|diff|show)",
+              "^gh\\s+issue"
+            ]
+          },
+          "unlockDurationMs": {
+            "type": "number",
+            "description": "How long unlock lasts (ms). Omit for session lifetime."
+          }
+        }
       },
       "instructions": {
         "oneOf": [{ "type": "string" }, { "type": "boolean", "const": false }],
-        "description": "Custom instructions to inject (string), or false to disable instruction injection"
+        "description": "Custom instructions to inject, or false to disable"
       },
       "instructionsFile": {
         "type": "string",
-        "description": "Path to markdown file containing custom instructions (overrides inline)"
+        "description": "Path to custom instructions file"
       }
     }
   }

--- a/extensions/task-accountability/openclaw.plugin.json
+++ b/extensions/task-accountability/openclaw.plugin.json
@@ -1,0 +1,32 @@
+{
+  "id": "task-accountability",
+  "name": "Task Accountability",
+  "version": "1.0.0",
+  "description": "Enforces task accountability by requiring GitHub issues for all work",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "strictMode": {
+        "type": "boolean",
+        "description": "If true, block responses without GitHub issue references. If false, just warn.",
+        "default": false
+      },
+      "issuePatterns": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Additional patterns that indicate GitHub issue references"
+      },
+      "exemptPatterns": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Patterns for responses that don't require GitHub issues (e.g., simple questions)"
+      },
+      "minTaskDurationSeconds": {
+        "type": "number",
+        "description": "Only require issues for tasks longer than this (based on tool calls)",
+        "default": 30
+      }
+    }
+  }
+}

--- a/extensions/task-accountability/openclaw.plugin.json
+++ b/extensions/task-accountability/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "task-accountability",
   "name": "Task Accountability",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Enforces task accountability by requiring GitHub issues for all work",
   "configSchema": {
     "type": "object",
@@ -26,6 +26,14 @@
         "type": "number",
         "description": "Only require issues for tasks longer than this (based on tool calls)",
         "default": 30
+      },
+      "instructions": {
+        "oneOf": [{ "type": "string" }, { "type": "boolean", "const": false }],
+        "description": "Custom instructions to inject (string), or false to disable instruction injection"
+      },
+      "instructionsFile": {
+        "type": "string",
+        "description": "Path to markdown file containing custom instructions (overrides inline)"
       }
     }
   }

--- a/extensions/task-accountability/package.json
+++ b/extensions/task-accountability/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@openclaw/task-accountability",
+  "version": "1.0.0",
+  "description": "Enforces task accountability via GitHub issues",
+  "type": "module",
+  "exports": {
+    ".": "./index.ts"
+  },
+  "dependencies": {}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,6 +243,8 @@ importers:
         specifier: ^4.0.18
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
+  extensions/audit-logger: {}
+
   extensions/bluebubbles:
     devDependencies:
       openclaw:
@@ -471,6 +473,8 @@ importers:
       openclaw:
         specifier: workspace:*
         version: link:../..
+
+  extensions/response-verifier: {}
 
   extensions/signal:
     devDependencies:

--- a/src/agents/pi-embedded-subscribe.handlers.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.ts
@@ -29,7 +29,10 @@ export function createEmbeddedPiSessionEventHandler(ctx: EmbeddedPiSubscribeCont
         handleMessageUpdate(ctx, evt as never);
         return;
       case "message_end":
-        handleMessageEnd(ctx, evt as never);
+        // Async handler - supports before_response hook for verification
+        handleMessageEnd(ctx, evt as never).catch((err) => {
+          ctx.log.debug(`message_end handler failed: ${String(err)}`);
+        });
         return;
       case "tool_execution_start":
         // Async handler - best-effort typing indicator, avoids blocking tool summaries.

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -307,6 +307,7 @@ export type PluginHookName =
   | "before_tool_call"
   | "after_tool_call"
   | "tool_result_persist"
+  | "before_response"
   | "session_start"
   | "session_end"
   | "gateway_start"
@@ -458,6 +459,37 @@ export type PluginHookToolResultPersistResult = {
   message?: AgentMessage;
 };
 
+// before_response hook - fires before assistant response is delivered
+export type PluginHookBeforeResponseContext = {
+  agentId?: string;
+  sessionKey?: string;
+};
+
+export type PluginHookBeforeResponseEvent = {
+  /** The response text about to be sent */
+  text: string;
+  /** Tool calls that were made during this response */
+  toolCalls?: Array<{
+    tool: string;
+    params: Record<string, unknown>;
+    success: boolean;
+    error?: string;
+  }>;
+  /** Media URLs included in the response */
+  mediaUrls?: string[];
+};
+
+export type PluginHookBeforeResponseResult = {
+  /** Modified response text (if changed) */
+  text?: string;
+  /** If true, block the response from being sent */
+  block?: boolean;
+  /** Reason for blocking (logged/shown to user) */
+  blockReason?: string;
+  /** Prepend this warning to the response */
+  prependWarning?: string;
+};
+
 // Session context
 export type PluginHookSessionContext = {
   agentId?: string;
@@ -535,6 +567,10 @@ export type PluginHookHandlerMap = {
     event: PluginHookToolResultPersistEvent,
     ctx: PluginHookToolResultPersistContext,
   ) => PluginHookToolResultPersistResult | void;
+  before_response: (
+    event: PluginHookBeforeResponseEvent,
+    ctx: PluginHookBeforeResponseContext,
+  ) => Promise<PluginHookBeforeResponseResult | void> | PluginHookBeforeResponseResult | void;
   session_start: (
     event: PluginHookSessionStartEvent,
     ctx: PluginHookSessionContext,


### PR DESCRIPTION
## Summary

Adds a comprehensive audit and verification system for OpenClaw agents:

### New Plugins

1. **audit-logger** — Logs all tool calls to `~/.openclaw/logs/audit.jsonl`
2. **response-verifier** — Verifies completion claims against audit log before delivery
3. **task-accountability** — Enforces task tracking (e.g., GitHub issues) with custom instructions
4. **instruction-injector** — Generic plugin for injecting custom instructions into system prompt

### Core Changes

- Added `before_response` hook in `src/plugins/hooks.ts` — fires before responses are delivered
- Updated `src/plugins/types.ts` with hook type definitions

### Why

Agents sometimes claim completion without actually doing work. This system:
- Creates an independent audit trail of all actions
- Verifies claims before delivery
- Enforces accountability protocols (configurable per user)

### Configuration

```json
{
  "plugins": {
    "entries": {
      "audit-logger": { "enabled": true },
      "response-verifier": { "enabled": true },
      "task-accountability": { "enabled": true }
    }
  }
}
```

### Custom Instructions

The `task-accountability` plugin looks for custom instructions at:
`~/.openclaw/protocols/github-workflow.md`

If present, uses those instead of default instructions. Each user can define their own workflow.

### Modes

- **Warning mode (default)**: Prepends warnings to responses that fail verification
- **Strict mode**: Blocks responses that fail verification

Closes #16334

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a comprehensive audit and accountability system for OpenClaw agents through a two-layer verification approach: instruction injection via `before_agent_start` hook and response verification via the new `before_response` hook.

**Core Changes:**
- Added `before_response` hook to plugin system (`src/plugins/hooks.ts`, `src/plugins/types.ts`) that fires before assistant responses are delivered, allowing plugins to inspect, modify, or block responses
- Integrated hook into message handler (`src/agents/pi-embedded-subscribe.handlers.messages.ts`) with error handling fallback to original response

**New Plugins:**
- `audit-logger` — logs all tool calls and messages to `~/.openclaw/logs/audit.jsonl` with sensitive data redaction
- `response-verifier` — verifies completion claims against audit log before delivery (warning/strict modes)
- `task-accountability` — enforces GitHub issue references for substantive work, loads custom instructions from `~/.openclaw/protocols/github-workflow.md`
- `instruction-injector` — generic plugin for injecting custom instructions into system prompt

**Architecture:**
The implementation follows ADR-001's belt-and-suspenders approach: instructions guide behavior while verification enforces compliance mechanically. The plugins work independently but are designed to complement each other.

**Issues Found:**
- `toolCalls` parameter in `before_response` hook passes empty params and hardcoded success status (line 328-332 in handlers.messages.ts), which could mislead plugins
- `instruction-injector` position "append" config doesn't actually append (still uses prepend)
- Minor: `console.log` used instead of `api.logger.info` in task-accountability plugin
- Performance consideration: audit log parsing reads entire file on each verification

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor issues that should be addressed
- The implementation is well-architected and follows the documented ADR-001 design. The core hook system changes are solid and the plugins are properly isolated. However, there are two logic issues that reduce confidence: (1) the `toolCalls` parameter in the `before_response` hook passes incomplete/hardcoded data instead of actual tool metadata, which could mislead plugins relying on this field, and (2) the instruction-injector plugin has a non-functional `position: "append"` configuration option. These don't break functionality but should be fixed for correctness. The performance concerns around audit log parsing are optimization opportunities rather than critical issues.
- Pay close attention to `src/agents/pi-embedded-subscribe.handlers.messages.ts` (toolCalls parameter issue) and `extensions/instruction-injector/index.ts` (append config issue)

<sub>Last reviewed commit: 02ab646</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->