### PR TITLE
Gateway: suppress NO_REPLY in webchat

### DIFF
--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -112,7 +112,7 @@ describe("agent event handler", () => {
       seq: 1,
       stream: "assistant",
       ts: Date.now(),
-      data: { text: "NO_REPLY" },
+      data: { text: SILENT_REPLY_TOKEN },
     });
     handler({
       runId: "run-2",
@@ -165,55 +165,6 @@ describe("agent event handler", () => {
     expect(broadcast).not.toHaveBeenCalled();
     expect(broadcastToConnIds).toHaveBeenCalledTimes(1);
     resetAgentRunContextForTest();
-  });
-
-  it("skips chat payloads for silent replies", () => {
-    const broadcast = vi.fn();
-    const broadcastToConnIds = vi.fn();
-    const nodeSendToSession = vi.fn();
-    const agentRunSeq = new Map<string, number>();
-    const chatRunState = createChatRunState();
-    const toolEventRecipients = createToolEventRecipientRegistry();
-    chatRunState.registry.add("run-1", { sessionKey: "session-1", clientRunId: "client-1" });
-
-    const handler = createAgentEventHandler({
-      broadcast,
-      broadcastToConnIds,
-      nodeSendToSession,
-      agentRunSeq,
-      chatRunState,
-      resolveSessionKeyForRun: () => undefined,
-      clearAgentRunContext: vi.fn(),
-      toolEventRecipients,
-    });
-
-    handler({
-      runId: "run-1",
-      seq: 1,
-      stream: "assistant",
-      ts: Date.now(),
-      data: { text: SILENT_REPLY_TOKEN },
-    });
-
-    const chatCallsAfterDelta = broadcast.mock.calls.filter(([event]) => event === "chat");
-    expect(chatCallsAfterDelta).toHaveLength(0);
-
-    handler({
-      runId: "run-1",
-      seq: 2,
-      stream: "lifecycle",
-      ts: Date.now(),
-      data: { phase: "end" },
-    });
-
-    const chatCallsAfterFinal = broadcast.mock.calls.filter(([event]) => event === "chat");
-    expect(chatCallsAfterFinal).toHaveLength(1);
-    const payload = chatCallsAfterFinal[0]?.[1] as { state?: string; message?: unknown };
-    expect(payload.state).toBe("final");
-    expect(payload.message).toBeUndefined();
-
-    const sessionChatCalls = nodeSendToSession.mock.calls.filter(([, event]) => event === "chat");
-    expect(sessionChatCalls).toHaveLength(1);
   });
 
   it("broadcasts tool events to WS recipients even when verbose is off, but skips node send", () => {

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
+import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { registerAgentRunContext, resetAgentRunContextForTest } from "../infra/agent-events.js";
 import {
   createAgentEventHandler,
   createChatRunState,
   createToolEventRecipientRegistry,
 } from "./server-chat.js";
-import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 
 describe("agent event handler", () => {
   it("emits chat delta for assistant text-only events", () => {

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -5,6 +5,7 @@ import {
   createChatRunState,
   createToolEventRecipientRegistry,
 } from "./server-chat.js";
+import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 
 describe("agent event handler", () => {
   it("emits chat delta for assistant text-only events", () => {
@@ -82,6 +83,55 @@ describe("agent event handler", () => {
     expect(broadcast).not.toHaveBeenCalled();
     expect(broadcastToConnIds).toHaveBeenCalledTimes(1);
     resetAgentRunContextForTest();
+  });
+
+  it("skips chat payloads for silent replies", () => {
+    const broadcast = vi.fn();
+    const broadcastToConnIds = vi.fn();
+    const nodeSendToSession = vi.fn();
+    const agentRunSeq = new Map<string, number>();
+    const chatRunState = createChatRunState();
+    const toolEventRecipients = createToolEventRecipientRegistry();
+    chatRunState.registry.add("run-1", { sessionKey: "session-1", clientRunId: "client-1" });
+
+    const handler = createAgentEventHandler({
+      broadcast,
+      broadcastToConnIds,
+      nodeSendToSession,
+      agentRunSeq,
+      chatRunState,
+      resolveSessionKeyForRun: () => undefined,
+      clearAgentRunContext: vi.fn(),
+      toolEventRecipients,
+    });
+
+    handler({
+      runId: "run-1",
+      seq: 1,
+      stream: "assistant",
+      ts: Date.now(),
+      data: { text: SILENT_REPLY_TOKEN },
+    });
+
+    const chatCallsAfterDelta = broadcast.mock.calls.filter(([event]) => event === "chat");
+    expect(chatCallsAfterDelta).toHaveLength(0);
+
+    handler({
+      runId: "run-1",
+      seq: 2,
+      stream: "lifecycle",
+      ts: Date.now(),
+      data: { phase: "end" },
+    });
+
+    const chatCallsAfterFinal = broadcast.mock.calls.filter(([event]) => event === "chat");
+    expect(chatCallsAfterFinal).toHaveLength(1);
+    const payload = chatCallsAfterFinal[0]?.[1] as { state?: string; message?: unknown };
+    expect(payload.state).toBe("final");
+    expect(payload.message).toBeUndefined();
+
+    const sessionChatCalls = nodeSendToSession.mock.calls.filter(([, event]) => event === "chat");
+    expect(sessionChatCalls).toHaveLength(1);
   });
 
   it("broadcasts tool events to WS recipients even when verbose is off, but skips node send", () => {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -50,9 +50,7 @@ type TranscriptAppendResult = {
 
 type AppendMessageArg = Parameters<SessionManager["appendMessage"]>[0];
 
-function extractChatTextContent(
-  content: unknown,
-): { text: string | null; hasNonText: boolean } {
+function extractChatTextContent(content: unknown): { text: string | null; hasNonText: boolean } {
   if (typeof content === "string") {
     return { text: content.trim() || null, hasNonText: false };
   }


### PR DESCRIPTION
- Filter NO_REPLY silent tokens from webchat chat deltas and final payloads so they never render in the UI.
- Exclude NO_REPLY-only assistant messages from chat history responses.
- Add gateway test coverage for silent-token suppression.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Filtered `NO_REPLY` silent tokens from webchat responses to prevent them from rendering in the UI. Added helper functions `extractChatTextContent` and `isSilentChatMessage` to detect and filter assistant messages containing only the silent token. Updated streaming logic in `server-chat.ts` to suppress `NO_REPLY` deltas, and modified chat history endpoint to exclude silent messages. Test updated to use `SILENT_REPLY_TOKEN` constant for consistency.

Key implementation details:
- `isSilentChatMessage` only filters assistant-role messages with text-only content (preserves messages with images/tools)
- Falls back to `record.text` field if content array doesn't contain text
- Uses existing `isSilentReplyText` utility for token matching with proper regex handling
- Chat history filtering happens after sanitization but before byte-capping for efficiency

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified issues
- The implementation is clean, well-tested, and follows existing patterns. The logic correctly handles edge cases (non-text content, role filtering, whitespace trimming). The filtering happens at appropriate points in the request flow. Tests verify both streaming suppression and final message filtering. No breaking changes or security concerns identified.
- No files require special attention

<sub>Last reviewed commit: f1dee85</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->