### PR TITLE
Update session-pruning.md - updated agents.defaults config std

### DIFF
--- a/docs/concepts/session-pruning.md
+++ b/docs/concepts/session-pruning.md
@@ -91,8 +91,10 @@ Default (off):
 
 ```json5
 {
-  agent: {
-    contextPruning: { mode: "off" },
+  agents: {
+    defaults: {
+      contextPruning: { mode: "off" },
+    },
   },
 }
 ```
@@ -101,8 +103,10 @@ Enable TTL-aware pruning:
 
 ```json5
 {
-  agent: {
-    contextPruning: { mode: "cache-ttl", ttl: "5m" },
+  agents: {
+    defaults: {
+      contextPruning: { mode: "cache-ttl", ttl: "5m" },
+    },
   },
 }
 ```
@@ -111,10 +115,12 @@ Restrict pruning to specific tools:
 
 ```json5
 {
-  agent: {
-    contextPruning: {
-      mode: "cache-ttl",
-      tools: { allow: ["exec", "read"], deny: ["*image*"] },
+  agents: {
+    defaults: {
+      contextPruning: {
+        mode: "cache-ttl",
+        tools: { allow: ["exec", "read"], deny: ["*image*"] },
+      },
     },
   },
 }


### PR DESCRIPTION
## Summary

Updated documentation to match config standard. agent.* was moved to agents.defaults.

- Problem:
- Why it matters: docs were outdated
- What changed: examples to match current config format
- What did NOT change (scope boundary): descriptions and text outside of the code examples

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

none, docs only

## Security Impact (required)

none

## Repro + Verification

N/A

### Environment

N/A

### Steps

N/A

### Expected

N/A

### Actual

N/A

## Evidence

N/A. Docs

## Human Verification (required)

Docs

## Compatibility / Migration

Docs

## Failure Recovery (if this breaks)

N/A Docs

## Risks and Mitigations

None

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Documentation-only change that updates the three json5 code examples in `docs/concepts/session-pruning.md` from the deprecated `agent:` config key to the current `agents.defaults` structure. The updated examples now match the canonical configuration reference at `docs/gateway/configuration-reference.md` and the source code in `src/config/defaults.ts`. No text or descriptions were changed outside the code blocks.

- Updated `agent:` → `agents: { defaults: { ... } }` in all three code examples (off mode, cache-ttl mode, and tool-scoped pruning)
- Note: the zh-CN translation (`docs/zh-CN/concepts/session-pruning.md`) still uses the old format but is auto-generated and will be updated when the i18n pipeline runs

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it only updates documentation code examples to match the current config format.
- Documentation-only change with no code impact. The updated examples are verified against both the configuration reference doc and source code. The changes are minimal, correct, and well-scoped.
- No files require special attention.

<sub>Last reviewed commit: b2b6f95</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->