### PR TITLE
fix(discord): role-based allowlist never matches (Carbon Role objects stringify to mentions)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Docs: https://docs.openclaw.ai
 - Telegram: finalize streaming preview replies in place instead of sending a second final message, preventing duplicate Telegram assistant outputs at stream completion. (#17218) Thanks @obviyus.
 - Cron: infer `payload.kind="agentTurn"` for model-only `cron.update` payload patches, so partial agent-turn updates do not fail validation when `kind` is omitted. (#15664) Thanks @rodrigouroz.
 - Subagents: use child-run-based deterministic announce idempotency keys across direct and queued delivery paths (with legacy queued-item fallback) to prevent duplicate announce retries without collapsing distinct same-millisecond announces. (#17150) Thanks @widingmarcus-cyber.
+- Discord: ensure role allowlist matching uses raw role IDs for message routing authorization. Thanks @xinhuagu.
 
 ## 2026.2.14
 

--- a/src/discord/monitor/listeners.ts
+++ b/src/discord/monitor/listeners.ts
@@ -272,8 +272,8 @@ async function handleDiscordReactionEvent(params: {
     const authorLabel = message?.author ? formatDiscordUserTag(message.author) : undefined;
     const baseText = `Discord reaction ${action}: ${emojiLabel} by ${actorLabel} on ${guildSlug} ${channelLabel} msg ${data.message_id}`;
     const text = authorLabel ? `${baseText} from ${authorLabel}` : baseText;
-    const memberRoleIds = Array.isArray(data.member?.roles)
-      ? data.member.roles.map((roleId: string) => String(roleId))
+    const memberRoleIds = Array.isArray(data.rawMember?.roles)
+      ? data.rawMember.roles.map((roleId: string) => String(roleId))
       : [];
     const route = resolveAgentRoute({
       cfg: params.cfg,

--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -224,8 +224,8 @@ export async function preflightDiscordMessage(
   }
 
   // Fresh config for bindings lookup; other routing inputs are payload-derived.
-  const memberRoleIds = Array.isArray(params.data.member?.roles)
-    ? params.data.member.roles.map((roleId: string) => String(roleId))
+  const memberRoleIds = Array.isArray(params.data.rawMember?.roles)
+    ? params.data.rawMember.roles.map((roleId: string) => String(roleId))
     : [];
   const route = resolveAgentRoute({
     cfg: loadConfig(),


### PR DESCRIPTION
## Problem

Discord role-based guild allowlist (`guilds.<id>.roles`) silently fails — users with the correct role are ignored by the bot.

**Root cause:** `data.member.roles` returns Carbon `Role[]` objects (via `GuildMember.roles` getter), not raw ID strings. `String(Role)` calls `Role.toString()` which produces `"<@&123456>"` — a Discord mention format that never matches the plain role IDs in the allowlist config.

The same pattern in `agent-components.ts` correctly uses `interaction.rawData.member?.roles` (raw Discord API data), but the message handler and reaction listener used the Carbon-wrapped version.

## Fix

Use `data.rawMember?.roles` (raw Discord API string array provided by Carbon's `parseRawData`) instead of `data.member?.roles` (Carbon `Role[]` objects).

**2 files changed, 4 insertions, 4 deletions.**

## Affected files
- `src/discord/monitor/message-handler.preflight.ts` — message routing
- `src/discord/monitor/listeners.ts` — reaction event routing

Fixes #16207

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixes a critical bug where Discord role-based allowlists (`guilds.<id>.roles`) silently failed to match users with the correct roles.

**Root cause:** The code was using `data.member?.roles` which returns Carbon SDK `Role[]` objects. When these are stringified via `String(Role)`, they call `Role.toString()` producing Discord mention format `<@&123456>` instead of the plain role ID `123456` needed for allowlist matching.

**Fix:** Changed to use `data.rawMember?.roles` in both `listeners.ts` and `message-handler.preflight.ts`, which provides the raw Discord API string array of role IDs. This matches the existing correct pattern already used in `agent-components.ts` (line 249) and `native-command.ts` (line 543).

**Impact:** Users with roles specified in guild allowlists will now be correctly authorized to interact with the bot. This was a silent failure where valid users were being ignored.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a straightforward correction that aligns two locations with the existing correct pattern used elsewhere in the codebase. The change is minimal (4 lines), well-documented in the PR description, targets a specific bug with clear root cause analysis, and follows the established pattern from `agent-components.ts:249` and `native-command.ts:543`. No new logic is introduced, only switching from the Carbon wrapper object to the raw API data.
- No files require special attention

<sub>Last reviewed commit: 3914483</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->