### PR TITLE
fix: register agents command in CLI command registry

### DIFF
--- a/src/cli/program/command-registry.ts
+++ b/src/cli/program/command-registry.ts
@@ -78,7 +78,10 @@ const coreEntries: CoreCliEntry[] = [
     },
   },
   {
-    commands: [{ name: "agent", description: "Agent commands" }],
+    commands: [
+      { name: "agent", description: "Agent commands" },
+      { name: "agents", description: "Manage isolated agents (workspaces + auth + routing)" },
+    ],
     register: async ({ program, ctx }) => {
       const mod = await import("./register.agent.js");
       mod.registerAgentCommands(program, { agentChannelOptions: ctx.agentChannelOptions });


### PR DESCRIPTION
## Summary

Fixes #16267 - `openclaw agents add` and other `agents` subcommands were failing with "unknown command 'agents'" error.

## Problem

The `agents` command group (agents add, agents list, agents delete, agents set-identity) was defined in `register.agent.ts` but not properly registered in `command-registry.ts` coreEntries list. This caused Commander.js to reject `agents` as an unknown command, even though the registration function existed.

## Solution

Added the `agents` command entry to `coreEntries` alongside the existing `agent` command. Both commands share the same `registerAgentCommands()` registration function, which properly registers both command groups.

## Testing

Before fix:
```bash
$ openclaw agents add --help
error: unknown command 'agents'
(Did you mean agent?)
```

After fix:
```bash
$ openclaw agents --help
Usage: openclaw agents [options] [command]

Manage isolated agents (workspaces + auth + routing)

Commands:
  add           Add a new isolated agent
  delete        Delete an agent and prune workspace/state
  list          List configured agents
  set-identity  Update an agent identity (name/theme/emoji/avatar)
```

## Impact

- ✅ Users can now use `openclaw agents add/delete/list/set-identity` commands
- ✅ No breaking changes
- ✅ Minimal code change (3 lines added)
- ✅ Passed oxlint and oxfmt checks

---

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Added the `agents` command entry to the `coreEntries` array in `command-registry.ts`, resolving the "unknown command 'agents'" error. The `agents` command group (with subcommands `add`, `list`, `delete`, `set-identity`) was already implemented in `register.agent.ts` but wasn't discoverable because it wasn't registered in the command registry. The fix follows the existing pattern used by other multi-command registrations (like `status`/`health`/`sessions` on lines 91-95) where multiple command names share the same registration function.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a minimal, surgical change that adds a single missing entry to the command registry array. The implementation follows the exact same pattern already used elsewhere in the file (status/health/sessions commands), and the registration function (`registerAgentCommands`) already exists and correctly registers both `agent` and `agents` commands. The change is purely declarative and doesn't modify any logic.
- No files require special attention

<sub>Last reviewed commit: efcf066</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->