### PR TITLE
docs: update message send example to use --target instead of deprecated --to

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ openclaw onboard --install-daemon
 openclaw gateway --port 18789 --verbose
 
 # Send a message
-openclaw message send --to +1234567890 --message "Hello from OpenClaw"
+openclaw message send --target +1234567890 --message "Hello from OpenClaw"
 
 # Talk to the assistant (optionally deliver back to any connected channel: WhatsApp/Telegram/Slack/Discord/Google Chat/Signal/iMessage/BlueBubbles/Microsoft Teams/Matrix/Zalo/Zalo Personal/WebChat)
 openclaw agent --message "Ship checklist" --thinking high


### PR DESCRIPTION
## Summary
The README message send example used the deprecated `--to` flag. Updated to use `--target` which is the current supported flag.

Fixes #10458

## Validation
- [x] `pnpm build` — passed
- [x] `pnpm check` (format + tsgo + lint) — passed
- [x] `pnpm test` — 1073 tests passed (105 test files)

## Scope
- Single focused fix — documentation update only

## AI-Assistance
- AI-assisted (Claude Code) for implementation
- Human-reviewed: confirmed understanding of changes
- Testing: full local validation suite passed