### PR TITLE
fix: suppress leaked heartbeat poll prompts in reply delivery

### DIFF
--- a/src/auto-reply/reply/normalize-reply.ts
+++ b/src/auto-reply/reply/normalize-reply.ts
@@ -1,5 +1,5 @@
 import { sanitizeUserFacingText } from "../../agents/pi-embedded-helpers.js";
-import { stripHeartbeatToken } from "../heartbeat.js";
+import { resolveHeartbeatPrompt, stripHeartbeatToken } from "../heartbeat.js";
 import { HEARTBEAT_TOKEN, isSilentReplyText, SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { ReplyPayload } from "../types.js";
 import { hasLineDirectives, parseLineDirectives } from "./line-directives.js";
@@ -18,6 +18,7 @@ export type NormalizeReplyOptions = {
   stripHeartbeat?: boolean;
   silentToken?: string;
   onSkip?: (reason: NormalizeReplySkipReason) => void;
+  heartbeatPrompt?: string;
 };
 
 export function normalizeReplyPayload(
@@ -46,6 +47,28 @@ export function normalizeReplyPayload(
   if (text && !trimmed) {
     // Keep empty text when media exists so media-only replies still send.
     text = "";
+  }
+
+  const normalizeForCompare = (value: string) => value.replace(/\s+/g, " ").trim().toLowerCase();
+  const resolvedHeartbeatPrompt = normalizeForCompare(resolveHeartbeatPrompt(opts.heartbeatPrompt));
+  const isHeartbeatPollLeak = (value?: string) => {
+    const normalized = value ? normalizeForCompare(value) : "";
+    if (!normalized) {
+      return false;
+    }
+    let rest = normalized;
+    while (rest.startsWith(resolvedHeartbeatPrompt)) {
+      rest = rest.slice(resolvedHeartbeatPrompt.length).trimStart();
+      if (!rest) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  if (isHeartbeatPollLeak(text) && !hasMedia && !hasChannelData) {
+    opts.onSkip?.("heartbeat");
+    return null;
   }
 
   const shouldStripHeartbeat = opts.stripHeartbeat ?? true;

--- a/src/auto-reply/reply/normalize-reply.ts
+++ b/src/auto-reply/reply/normalize-reply.ts
@@ -58,6 +58,8 @@ export function normalizeReplyPayload(
     }
     let rest = normalized;
     while (rest.startsWith(resolvedHeartbeatPrompt)) {
+      // Only suppress payloads that are exactly the heartbeat prompt (possibly repeated/stacked).
+      // Prefix matches with additional content are treated as real replies and must not be dropped.
       rest = rest.slice(resolvedHeartbeatPrompt.length).trimStart();
       if (!rest) {
         return true;

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -1,10 +1,10 @@
 import type { HumanDelayConfig } from "../../config/types.js";
-import type { GetReplyOptions, ReplyPayload } from "../types.js";
-import type { ResponsePrefixContext } from "./response-prefix-template.js";
-import type { TypingController } from "./typing.js";
 import { sleep } from "../../utils.js";
+import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import { registerDispatcher } from "./dispatcher-registry.js";
 import { normalizeReplyPayload, type NormalizeReplySkipReason } from "./normalize-reply.js";
+import type { ResponsePrefixContext } from "./response-prefix-template.js";
+import type { TypingController } from "./typing.js";
 
 export type ReplyDispatchKind = "tool" | "block" | "final";
 

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -1,10 +1,10 @@
 import type { HumanDelayConfig } from "../../config/types.js";
-import { sleep } from "../../utils.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
-import { registerDispatcher } from "./dispatcher-registry.js";
-import { normalizeReplyPayload, type NormalizeReplySkipReason } from "./normalize-reply.js";
 import type { ResponsePrefixContext } from "./response-prefix-template.js";
 import type { TypingController } from "./typing.js";
+import { sleep } from "../../utils.js";
+import { registerDispatcher } from "./dispatcher-registry.js";
+import { normalizeReplyPayload, type NormalizeReplySkipReason } from "./normalize-reply.js";
 
 export type ReplyDispatchKind = "tool" | "block" | "final";
 
@@ -42,6 +42,7 @@ function getHumanDelay(config: HumanDelayConfig | undefined): number {
 export type ReplyDispatcherOptions = {
   deliver: ReplyDispatchDeliverer;
   responsePrefix?: string;
+  heartbeatPrompt?: string;
   /** Static context for response prefix template interpolation. */
   responsePrefixContext?: ResponsePrefixContext;
   /** Dynamic context provider for response prefix template interpolation.
@@ -80,7 +81,11 @@ export type ReplyDispatcher = {
 
 type NormalizeReplyPayloadInternalOptions = Pick<
   ReplyDispatcherOptions,
-  "responsePrefix" | "responsePrefixContext" | "responsePrefixContextProvider" | "onHeartbeatStrip"
+  | "responsePrefix"
+  | "responsePrefixContext"
+  | "responsePrefixContextProvider"
+  | "onHeartbeatStrip"
+  | "heartbeatPrompt"
 > & {
   onSkip?: (reason: NormalizeReplySkipReason) => void;
 };
@@ -95,6 +100,7 @@ function normalizeReplyPayloadInternal(
   return normalizeReplyPayload(payload, {
     responsePrefix: opts.responsePrefix,
     responsePrefixContext: prefixContext,
+    heartbeatPrompt: opts.heartbeatPrompt,
     onHeartbeatStrip: opts.onHeartbeatStrip,
     onSkip: opts.onSkip,
   });
@@ -127,6 +133,7 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
       responsePrefix: options.responsePrefix,
       responsePrefixContext: options.responsePrefixContext,
       responsePrefixContextProvider: options.responsePrefixContextProvider,
+      heartbeatPrompt: options.heartbeatPrompt,
       onHeartbeatStrip: options.onHeartbeatStrip,
       onSkip: (reason) => options.onSkip?.(payload, { kind, reason }),
     });

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { HEARTBEAT_PROMPT, resolveHeartbeatPrompt } from "../heartbeat.js";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import { parseAudioTag } from "./audio-tags.js";
 import { createBlockReplyCoalescer } from "./block-reply-coalescer.js";
@@ -113,6 +114,45 @@ describe("normalizeReplyPayload", () => {
 
     expect(normalized).toBeNull();
     expect(reasons).toEqual(["empty"]);
+  });
+
+  it("suppresses leaked heartbeat poll prompt", () => {
+    const reasons: string[] = [];
+    const normalized = normalizeReplyPayload(
+      { text: HEARTBEAT_PROMPT },
+      { onSkip: (reason) => reasons.push(reason) },
+    );
+
+    expect(normalized).toBeNull();
+    expect(reasons).toEqual(["heartbeat"]);
+  });
+
+  it("suppresses configured custom heartbeat prompts (including stacked)", () => {
+    const customPrompt = resolveHeartbeatPrompt("Check HEARTBEAT.md and reply HEARTBEAT_OK.");
+    const stacked = `${customPrompt}\n\n${customPrompt}`;
+
+    expect(
+      normalizeReplyPayload({ text: customPrompt }, { heartbeatPrompt: customPrompt }),
+    ).toBeNull();
+    expect(normalizeReplyPayload({ text: stacked }, { heartbeatPrompt: customPrompt })).toBeNull();
+  });
+
+  it("does not suppress legitimate messages mentioning heartbeat.md", () => {
+    const normalized = normalizeReplyPayload({
+      text: "Please read heartbeat.md and summarize it.",
+    });
+
+    expect(normalized).not.toBeNull();
+    expect(normalized?.text).toBe("Please read heartbeat.md and summarize it.");
+  });
+
+  it("keeps heartbeat poll text when media is attached", () => {
+    const normalized = normalizeReplyPayload({
+      text: HEARTBEAT_PROMPT,
+      mediaUrl: "https://example.com/image.png",
+    });
+
+    expect(normalized).not.toBeNull();
   });
 });
 

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -137,6 +137,16 @@ describe("normalizeReplyPayload", () => {
     expect(normalizeReplyPayload({ text: stacked }, { heartbeatPrompt: customPrompt })).toBeNull();
   });
 
+  it("does not suppress prompts that include actual reply content", () => {
+    const customPrompt = resolveHeartbeatPrompt("Check HEARTBEAT.md and reply HEARTBEAT_OK.");
+    const text = `${customPrompt} Thanks, done.`;
+
+    const normalized = normalizeReplyPayload({ text }, { heartbeatPrompt: customPrompt });
+
+    expect(normalized).not.toBeNull();
+    expect(normalized?.text).toBe(text);
+  });
+
   it("does not suppress legitimate messages mentioning heartbeat.md", () => {
     const normalized = normalizeReplyPayload({
       text: "Please read heartbeat.md and summarize it.",

--- a/src/auto-reply/reply/route-reply.ts
+++ b/src/auto-reply/reply/route-reply.ts
@@ -7,13 +7,14 @@
  * across multiple providers.
  */
 
+import type { OpenClawConfig } from "../../config/config.js";
+import type { OriginatingChannelType } from "../templating.js";
+import type { ReplyPayload } from "../types.js";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { resolveEffectiveMessagesConfig } from "../../agents/identity.js";
 import { normalizeChannelId } from "../../channels/plugins/index.js";
-import type { OpenClawConfig } from "../../config/config.js";
 import { INTERNAL_MESSAGE_CHANNEL, normalizeMessageChannel } from "../../utils/message-channel.js";
-import type { OriginatingChannelType } from "../templating.js";
-import type { ReplyPayload } from "../types.js";
+import { resolveHeartbeatPrompt } from "../heartbeat.js";
 import { normalizeReplyPayload } from "./normalize-reply.js";
 
 export type RouteReplyParams = {
@@ -76,6 +77,7 @@ export async function routeReply(params: RouteReplyParams): Promise<RouteReplyRe
       : cfg.messages?.responsePrefix;
   const normalized = normalizeReplyPayload(payload, {
     responsePrefix,
+    heartbeatPrompt: resolveHeartbeatPrompt(cfg?.agents?.defaults?.heartbeat?.prompt),
   });
   if (!normalized) {
     return { ok: true };

--- a/src/auto-reply/reply/route-reply.ts
+++ b/src/auto-reply/reply/route-reply.ts
@@ -7,14 +7,14 @@
  * across multiple providers.
  */
 
-import type { OpenClawConfig } from "../../config/config.js";
-import type { OriginatingChannelType } from "../templating.js";
-import type { ReplyPayload } from "../types.js";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { resolveEffectiveMessagesConfig } from "../../agents/identity.js";
 import { normalizeChannelId } from "../../channels/plugins/index.js";
+import type { OpenClawConfig } from "../../config/config.js";
 import { INTERNAL_MESSAGE_CHANNEL, normalizeMessageChannel } from "../../utils/message-channel.js";
 import { resolveHeartbeatPrompt } from "../heartbeat.js";
+import type { OriginatingChannelType } from "../templating.js";
+import type { ReplyPayload } from "../types.js";
 import { normalizeReplyPayload } from "./normalize-reply.js";
 
 export type RouteReplyParams = {

--- a/src/channels/reply-prefix.ts
+++ b/src/channels/reply-prefix.ts
@@ -1,23 +1,25 @@
+import type { GetReplyOptions } from "../auto-reply/types.js";
+import type { OpenClawConfig } from "../config/config.js";
 import { resolveEffectiveMessagesConfig, resolveIdentityName } from "../agents/identity.js";
+import { resolveHeartbeatPrompt } from "../auto-reply/heartbeat.js";
 import {
   extractShortModelName,
   type ResponsePrefixContext,
 } from "../auto-reply/reply/response-prefix-template.js";
-import type { GetReplyOptions } from "../auto-reply/types.js";
-import type { OpenClawConfig } from "../config/config.js";
 
 type ModelSelectionContext = Parameters<NonNullable<GetReplyOptions["onModelSelected"]>>[0];
 
 export type ReplyPrefixContextBundle = {
   prefixContext: ResponsePrefixContext;
   responsePrefix?: string;
+  heartbeatPrompt: string;
   responsePrefixContextProvider: () => ResponsePrefixContext;
   onModelSelected: (ctx: ModelSelectionContext) => void;
 };
 
 export type ReplyPrefixOptions = Pick<
   ReplyPrefixContextBundle,
-  "responsePrefix" | "responsePrefixContextProvider" | "onModelSelected"
+  "responsePrefix" | "heartbeatPrompt" | "responsePrefixContextProvider" | "onModelSelected"
 >;
 
 export function createReplyPrefixContext(params: {
@@ -45,6 +47,7 @@ export function createReplyPrefixContext(params: {
       channel: params.channel,
       accountId: params.accountId,
     }).responsePrefix,
+    heartbeatPrompt: resolveHeartbeatPrompt(cfg.agents?.defaults?.heartbeat?.prompt),
     responsePrefixContextProvider: () => prefixContext,
     onModelSelected,
   };
@@ -56,7 +59,7 @@ export function createReplyPrefixOptions(params: {
   channel?: string;
   accountId?: string;
 }): ReplyPrefixOptions {
-  const { responsePrefix, responsePrefixContextProvider, onModelSelected } =
+  const { responsePrefix, heartbeatPrompt, responsePrefixContextProvider, onModelSelected } =
     createReplyPrefixContext(params);
-  return { responsePrefix, responsePrefixContextProvider, onModelSelected };
+  return { responsePrefix, heartbeatPrompt, responsePrefixContextProvider, onModelSelected };
 }

--- a/src/channels/reply-prefix.ts
+++ b/src/channels/reply-prefix.ts
@@ -1,11 +1,11 @@
-import type { GetReplyOptions } from "../auto-reply/types.js";
-import type { OpenClawConfig } from "../config/config.js";
 import { resolveEffectiveMessagesConfig, resolveIdentityName } from "../agents/identity.js";
 import { resolveHeartbeatPrompt } from "../auto-reply/heartbeat.js";
 import {
   extractShortModelName,
   type ResponsePrefixContext,
 } from "../auto-reply/reply/response-prefix-template.js";
+import type { GetReplyOptions } from "../auto-reply/types.js";
+import type { OpenClawConfig } from "../config/config.js";
 
 type ModelSelectionContext = Parameters<NonNullable<GetReplyOptions["onModelSelected"]>>[0];
 


### PR DESCRIPTION
## Problem

When the agent is busy and a heartbeat poll prompt leaks into the reply pipeline, the raw heartbeat prompt text can be delivered to users.

The original suppression logic only matched hardcoded/default phrasing, so custom prompts from `config.agents.defaults.heartbeat.prompt` could bypass filtering.

Additionally, after `normalizeReplyPayload` gained `heartbeatPrompt`, production callers were not wiring it through, so custom prompts were still not consistently applied in real delivery paths.

## Solution

Make heartbeat-poll leak suppression config-aware in `normalizeReplyPayload` and wire the resolved prompt through production call paths.

- Added `heartbeatPrompt?: string` to `NormalizeReplyOptions`
- Resolve prompt via `resolveHeartbeatPrompt(opts.heartbeatPrompt)`
- Compare using lowercase + whitespace-collapsed full-text matching
- Suppress repeated/stacked prompt leaks
- Preserve media/channel-data payloads
- Threaded heartbeat prompt through dispatcher path via `createReplyPrefixOptions` -> `ReplyDispatcherOptions` -> `normalizeReplyPayload`
- Wired direct `routeReply` normalization call to pass resolved heartbeat prompt from config

## Files changed

- `src/auto-reply/reply/normalize-reply.ts`
- `src/auto-reply/reply/reply-utils.test.ts`
- `src/channels/reply-prefix.ts`
- `src/auto-reply/reply/reply-dispatcher.ts`
- `src/auto-reply/reply/route-reply.ts`

## Validation

- `./node_modules/.bin/tsc --noEmit`

## Notes

- Rebased on latest `main`
- Tests were moved from deleted `normalize-reply.test.ts` into current consolidated `reply-utils.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes heartbeat poll prompt leaks by making suppression config-aware. Previously, only hardcoded default prompts were detected and filtered; custom prompts from `config.agents.defaults.heartbeat.prompt` would leak through to users.

The fix threads the resolved heartbeat prompt through two main delivery paths:
- **Dispatcher path**: `createReplyPrefixOptions` → `ReplyDispatcherOptions` → `normalizeReplyPayload`  
- **Direct routing**: `routeReply` resolves prompt from config and passes to `normalizeReplyPayload`

The suppression logic uses case-insensitive, whitespace-collapsed comparison and handles stacked/repeated prompts. Payloads with media or channel data are preserved even if text matches the prompt. Prompts with additional content (e.g. "PROMPT Thanks, done.") are correctly treated as real replies.

Test coverage is comprehensive, including default prompts, custom prompts, stacked prompts, prompts with extra content, legitimate messages mentioning heartbeat, and media preservation.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is straightforward, well-tested, and addresses a real bug. The heartbeat prompt is threaded through all normalization paths correctly. Type safety ensures all callers must provide the prompt. The logic correctly handles edge cases (stacked prompts, prompts with extra content, media preservation). Previous review concerns have been addressed with clarifying comments and regression tests. No breaking changes or risky refactoring.
- No files require special attention

<sub>Last reviewed commit: ee23af8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->