### PR TITLE
CLI: fix lazy maintenance command registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Security/Node Host: enforce `system.run` rawCommand/argv consistency to prevent allowlist/approval bypass. Thanks @christos-eth.
+- CLI: fix lazy core command registration so top-level maintenance commands (`doctor`, `dashboard`, `reset`, `uninstall`) resolve correctly instead of exposing a non-functional `maintenance` placeholder command.
 - Security/Agents: scope CLI process cleanup to owned child PIDs to avoid killing unrelated processes on shared hosts. Thanks @aether-ai-agent.
 - Security/Agents (macOS): prevent shell injection when writing Claude CLI keychain credentials. (#15924) Thanks @aether-ai-agent.
 - Security: fix Chutes manual OAuth login state validation (thanks @aether-ai-agent). (#16058)

--- a/src/cli/program/command-registry.test.ts
+++ b/src/cli/program/command-registry.test.ts
@@ -1,10 +1,16 @@
 import { Command } from "commander";
 import { describe, expect, it } from "vitest";
 import type { ProgramContext } from "./context.js";
-import { getCoreCliCommandNames, registerCoreCliByName } from "./command-registry.js";
+import {
+  getCoreCliCommandNames,
+  registerCoreCliByName,
+  registerCoreCliCommands,
+} from "./command-registry.js";
 
-const stubCtx: ProgramContext = {
+const testProgramContext: ProgramContext = {
   programVersion: "0.0.0-test",
+  channelOptions: [],
+  messageChannelOptions: "",
   agentChannelOptions: "web",
 };
 
@@ -17,18 +23,38 @@ describe("command-registry", () => {
 
   it("registerCoreCliByName resolves agents to the agent entry", async () => {
     const program = new Command();
-    const found = await registerCoreCliByName(program, stubCtx, "agents");
+    const found = await registerCoreCliByName(program, testProgramContext, "agents");
     expect(found).toBe(true);
     const agentsCmd = program.commands.find((c) => c.name() === "agents");
     expect(agentsCmd).toBeDefined();
-    // The registrar also installs the singular "agent" command from the same entry
+    // The registrar also installs the singular "agent" command from the same entry.
     const agentCmd = program.commands.find((c) => c.name() === "agent");
     expect(agentCmd).toBeDefined();
   });
 
   it("registerCoreCliByName returns false for unknown commands", async () => {
     const program = new Command();
-    const found = await registerCoreCliByName(program, stubCtx, "nonexistent");
+    const found = await registerCoreCliByName(program, testProgramContext, "nonexistent");
     expect(found).toBe(false);
+  });
+
+  it("registers doctor placeholder for doctor primary command", () => {
+    const program = new Command();
+    registerCoreCliCommands(program, testProgramContext, ["node", "openclaw", "doctor"]);
+
+    expect(program.commands.map((command) => command.name())).toEqual(["doctor"]);
+  });
+
+  it("treats maintenance commands as top-level builtins", async () => {
+    const program = new Command();
+
+    expect(await registerCoreCliByName(program, testProgramContext, "doctor")).toBe(true);
+
+    const names = getCoreCliCommandNames();
+    expect(names).toContain("doctor");
+    expect(names).toContain("dashboard");
+    expect(names).toContain("reset");
+    expect(names).toContain("uninstall");
+    expect(names).not.toContain("maintenance");
   });
 });

--- a/src/cli/program/command-registry.ts
+++ b/src/cli/program/command-registry.ts
@@ -57,7 +57,15 @@ const coreEntries: CoreCliEntry[] = [
     },
   },
   {
-    commands: [{ name: "maintenance", description: "Maintenance commands" }],
+    commands: [
+      { name: "doctor", description: "Health checks + quick fixes for the gateway and channels" },
+      { name: "dashboard", description: "Open the Control UI with your current token" },
+      { name: "reset", description: "Reset local config/state (keeps the CLI installed)" },
+      {
+        name: "uninstall",
+        description: "Uninstall the gateway service + local data (CLI remains)",
+      },
+    ],
     register: async ({ program }) => {
       const mod = await import("./register.maintenance.js");
       mod.registerMaintenanceCommands(program);


### PR DESCRIPTION
## Summary

- Problem: `openclaw doctor` failed in lazy-loading mode because core command registration used an internal `maintenance` label as a top-level command name.
- Why it matters: users saw command-not-found style behavior (`doctor` was missing from command resolution/help paths).
- What changed: mapped lazy core registration to actual maintenance top-level commands (`doctor`, `dashboard`, `reset`, `uninstall`) and added a regression test.
- What did NOT change (scope boundary): command behavior/flags for doctor/dashboard/reset/uninstall were not modified.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- `openclaw doctor` and other maintenance commands are now correctly registered/resolved under lazy startup.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22, pnpm
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Run `pnpm openclaw doctor --help` on a build that lazily maps the registrar to `maintenance`.
2. Observe root help output/command mismatch.
3. Apply this fix and rerun `pnpm openclaw doctor --help`.

### Expected

- Doctor help output is shown and command resolves directly.

### Actual

- Verified after fix: doctor help output is shown.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm openclaw doctor --help` resolves to doctor help.
  - `pnpm build` passes.
  - `pnpm check` passes.
  - `pnpm vitest src/cli/program/command-registry.test.ts` passes.
- Edge cases checked:
  - Core lazy registry includes all four maintenance commands.
- What you did **not** verify:
  - Full `pnpm test` suite.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `0b7dbc68b`.
- Files/config to restore:
  - `src/cli/program/command-registry.ts`
- Known bad symptoms reviewers should watch for:
  - `doctor`/`dashboard`/`reset`/`uninstall` missing from top-level command resolution.

## Risks and Mitigations

- Risk:
  - Lazy core registration could drift again if registrar aliases are added but not reflected in the command map.
- Mitigation:
  - Added regression test for maintenance command registration behavior.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixes lazy CLI command registration for maintenance commands (`doctor`, `dashboard`, `reset`, `uninstall`). Previously, the core command registry mapped these four commands under a single `maintenance` label, which meant the lazy loader could never match `openclaw doctor` (or the other three) — the user had to type the non-functional `openclaw maintenance` to hit the entry. The fix expands the `commands` array to list all four actual top-level command names, consistent with the existing pattern used by `status/health/sessions`.

- Replaced the single `{ name: "maintenance" }` entry in `coreEntries` with four individual command entries matching the commands registered by `registerMaintenanceCommands()`
- Descriptions in the registry match the actual command descriptions in `register.maintenance.ts`
- Added a regression test (`command-registry.test.ts`) verifying that lazy registration resolves individual maintenance commands and that `getCoreCliCommandNames()` no longer includes `maintenance`
- CHANGELOG entry added under Unreleased > Fixes

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a straightforward bug fix with no behavioral changes to existing commands.
- The fix correctly aligns the lazy registration command names with the actual commands registered by registerMaintenanceCommands(). The change follows an existing pattern (status/health/sessions), descriptions are consistent with the source of truth in register.maintenance.ts, and a regression test covers the fix. No command behavior, flags, or logic changed.
- No files require special attention.

<sub>Last reviewed commit: 0b7dbc6</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->