### PR TITLE
fix(web-search): normalize Brave language codes for search_lang/ui_lang

### DIFF
--- a/src/agents/tools/web-tools.enabled-defaults.e2e.test.ts
+++ b/src/agents/tools/web-tools.enabled-defaults.e2e.test.ts
@@ -71,6 +71,23 @@ describe("web_search country and language parameters", () => {
     expect(url.searchParams.get("search_lang")).toBe("de");
   });
 
+  it("normalizes search_lang zh to zh-hans for Brave API", async () => {
+    const mockFetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ web: { results: [] } }),
+      } as Response),
+    );
+    // @ts-expect-error mock fetch
+    global.fetch = mockFetch;
+
+    const tool = createWebSearchTool({ config: undefined, sandboxed: true });
+    await tool?.execute?.(1, { query: "test", search_lang: "zh" });
+
+    const url = new URL(mockFetch.mock.calls[0][0] as string);
+    expect(url.searchParams.get("search_lang")).toBe("zh-hans");
+  });
+
   it("should pass ui_lang parameter to Brave API", async () => {
     const mockFetch = vi.fn(() =>
       Promise.resolve({
@@ -86,6 +103,23 @@ describe("web_search country and language parameters", () => {
 
     const url = new URL(mockFetch.mock.calls[0][0] as string);
     expect(url.searchParams.get("ui_lang")).toBe("de");
+  });
+
+  it("normalizes ui_lang zh-hans to zh-CN for Brave API", async () => {
+    const mockFetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ web: { results: [] } }),
+      } as Response),
+    );
+    // @ts-expect-error mock fetch
+    global.fetch = mockFetch;
+
+    const tool = createWebSearchTool({ config: undefined, sandboxed: true });
+    await tool?.execute?.(1, { query: "test", ui_lang: "zh-hans" });
+
+    const url = new URL(mockFetch.mock.calls[0][0] as string);
+    expect(url.searchParams.get("ui_lang")).toBe("zh-CN");
   });
 
   it("should pass freshness parameter to Brave API", async () => {


### PR DESCRIPTION
## Summary
- normalize Brave `search_lang` values to the provider-supported locale set (e.g. `zh` -> `zh-hans`)
- normalize Brave `ui_lang` values to region-based codes (e.g. `zh-hans` -> `zh-CN`)
- keep unknown values unchanged to avoid breaking custom usage

## Why
Brave search rejects some language variants used by clients and can silently degrade result relevance. This patch makes language handling robust and backward-compatible.

## Tests
- `pnpm test:e2e src/agents/tools/web-tools.enabled-defaults.e2e.test.ts`
- added coverage for `search_lang` and `ui_lang` normalization

## Co-authored
- Co-authored-by: ciberponk <ciberponk@gmail.com>
- Co-authored-by: Codex <codex@openai.com>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds normalization for Brave Search API language parameters to map generic codes (`zh`) to provider-specific formats (`zh-hans` for `search_lang`, `zh-CN` for `ui_lang`). Includes test coverage for the new normalization logic.

- normalized `search_lang` values: `zh` → `zh-hans`
- normalized `ui_lang` values: `zh` → `zh-CN`, `zh-hans` → `zh-CN`, `zh-hant` → `zh-TW`
- preserved unknown values unchanged (backward-compatible)
- added two e2e tests covering the normalization paths

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one minor logic issue that should be fixed
- The change is well-tested and backward-compatible, but has a minor edge case where whitespace-only strings become empty strings instead of undefined, which may cause unexpected API behavior
- src/agents/tools/web-search.ts:423-424 needs attention for the empty string handling

<sub>Last reviewed commit: 7088ad0</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->