### PR TITLE
fix(config): align tools.web.fetch schema with firecrawl/readability settings

### DIFF
--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -36,4 +36,26 @@ describe("config schema regressions", () => {
 
     expect(res.ok).toBe(true);
   });
+
+  it("accepts tools.web.fetch readability and firecrawl config", () => {
+    const res = validateConfigObject({
+      tools: {
+        web: {
+          fetch: {
+            readability: true,
+            firecrawl: {
+              enabled: true,
+              apiKey: "firecrawl-test-key",
+              baseUrl: "https://api.firecrawl.dev",
+              onlyMainContent: true,
+              maxAgeMs: 60_000,
+              timeoutSeconds: 30,
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
 });

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -207,6 +207,18 @@ export const ToolsWebFetchSchema = z
     cacheTtlMinutes: z.number().nonnegative().optional(),
     maxRedirects: z.number().int().nonnegative().optional(),
     userAgent: z.string().optional(),
+    readability: z.boolean().optional(),
+    firecrawl: z
+      .object({
+        enabled: z.boolean().optional(),
+        apiKey: z.string().optional().register(sensitive),
+        baseUrl: z.string().optional(),
+        onlyMainContent: z.boolean().optional(),
+        maxAgeMs: z.number().int().nonnegative().optional(),
+        timeoutSeconds: z.number().int().positive().optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict()
   .optional();


### PR DESCRIPTION
## Summary
- add missing `tools.web.fetch.readability` to config schema
- add missing `tools.web.fetch.firecrawl` nested config schema (enabled/apiKey/baseUrl/onlyMainContent/maxAgeMs/timeoutSeconds)
- keep strict validation while aligning schema with runtime + type definitions
- add regression test proving config validation accepts these keys

## Why
`web_fetch` runtime and `types.tools.ts` already support these fields, but `ToolsWebFetchSchema` previously rejected them. This causes config validation failures for valid fetch settings.

## Tests
- `pnpm vitest run src/config/config.schema-regressions.test.ts`

## Co-authored
- Co-authored-by: ciberponk <ciberponk@gmail.com>
- Co-authored-by: Codex <codex@openai.com>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds missing `readability` and `firecrawl` config schema fields to `ToolsWebFetchSchema` that were already supported in runtime code (`src/agents/tools/web-fetch.ts:93-175`) and type definitions (`src/config/types.tools.ts:383-398`). The schema now accepts these previously-rejected valid configuration fields:

- `readability`: boolean flag for extracting main content
- `firecrawl.*`: nested object with `enabled`, `apiKey` (marked sensitive), `baseUrl`, `onlyMainContent`, `maxAgeMs`, and `timeoutSeconds`

All fields are optional and maintain strict validation via `.strict()`. The `apiKey` field is properly marked as sensitive using `.register(sensitive)`. Includes regression test proving validation accepts these keys.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are straightforward schema additions that align perfectly with existing runtime code and type definitions. All new fields are optional, properly typed, and include appropriate validation (`.strict()` for nested objects, `.register(sensitive)` for API keys). The regression test confirms validation works correctly. No breaking changes or logical issues detected.
- No files require special attention

<sub>Last reviewed commit: e10f1b7</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->