### PR TITLE
feat(web-search): request and merge Brave extra_snippets

### DIFF
--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -80,6 +80,7 @@ type BraveSearchResult = {
   url?: string;
   description?: string;
   age?: string;
+  extra_snippets?: string[];
 };
 
 type BraveSearchResponse = {
@@ -654,6 +655,7 @@ async function runWebSearch(params: {
   if (params.freshness) {
     url.searchParams.set("freshness", params.freshness);
   }
+  url.searchParams.set("extra_snippets", "true");
 
   const res = await fetch(url.toString(), {
     method: "GET",
@@ -673,13 +675,20 @@ async function runWebSearch(params: {
   const results = Array.isArray(data.web?.results) ? (data.web?.results ?? []) : [];
   const mapped = results.map((entry) => {
     const description = entry.description ?? "";
+    const extraSnippets = Array.isArray(entry.extra_snippets)
+      ? entry.extra_snippets.filter((snippet): snippet is string => typeof snippet === "string")
+      : [];
+    const combinedDescription = [description, ...extraSnippets]
+      .map((snippet) => snippet.trim())
+      .filter((snippet) => snippet.length > 0)
+      .join("\n");
     const title = entry.title ?? "";
     const url = entry.url ?? "";
     const rawSiteName = resolveSiteName(url);
     return {
       title: title ? wrapWebContent(title, "web_search") : "",
       url, // Keep raw for tool chaining
-      description: description ? wrapWebContent(description, "web_search") : "",
+      description: combinedDescription ? wrapWebContent(combinedDescription, "web_search") : "",
       published: entry.age || undefined,
       siteName: rawSiteName || undefined,
     };

--- a/src/agents/tools/web-tools.enabled-defaults.e2e.test.ts
+++ b/src/agents/tools/web-tools.enabled-defaults.e2e.test.ts
@@ -105,6 +105,23 @@ describe("web_search country and language parameters", () => {
     expect(url.searchParams.get("freshness")).toBe("pw");
   });
 
+  it("should request Brave extra snippets by default", async () => {
+    const mockFetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ web: { results: [] } }),
+      } as Response),
+    );
+    // @ts-expect-error mock fetch
+    global.fetch = mockFetch;
+
+    const tool = createWebSearchTool({ config: undefined, sandboxed: true });
+    await tool?.execute?.(1, { query: "test-extra-snippets" });
+
+    const url = new URL(mockFetch.mock.calls[0][0] as string);
+    expect(url.searchParams.get("extra_snippets")).toBe("true");
+  });
+
   it("rejects invalid freshness values", async () => {
     const mockFetch = vi.fn(() =>
       Promise.resolve({
@@ -365,6 +382,40 @@ describe("web_search external content wrapping", () => {
       source: "web_search",
       wrapped: true,
     });
+  });
+
+  it("appends Brave extra_snippets into wrapped description", async () => {
+    vi.stubEnv("BRAVE_API_KEY", "test-key");
+    const mockFetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            web: {
+              results: [
+                {
+                  title: "Example",
+                  url: "https://example.com",
+                  description: "Base description",
+                  extra_snippets: ["Snippet one", "Snippet two"],
+                },
+              ],
+            },
+          }),
+      } as Response),
+    );
+    // @ts-expect-error mock fetch
+    global.fetch = mockFetch;
+
+    const tool = createWebSearchTool({ config: undefined, sandboxed: true });
+    const result = await tool?.execute?.(1, { query: "test-extra-snippet-merge" });
+    const details = result?.details as { results?: Array<{ description?: string }> };
+    const description = details.results?.[0]?.description ?? "";
+
+    expect(description).toContain("<<<EXTERNAL_UNTRUSTED_CONTENT>>>");
+    expect(description).toContain("Base description");
+    expect(description).toContain("Snippet one");
+    expect(description).toContain("Snippet two");
   });
 
   it("does not wrap Brave result urls (raw for tool chaining)", async () => {


### PR DESCRIPTION
## Summary
- always request Brave `extra_snippets` for richer snippet payloads
- append `entry.extra_snippets` into the mapped result `description`
- preserve existing URL/siteName/raw-field behavior for tool chaining
- add e2e coverage for request param and merged wrapped description

## Why
Brave can return additional snippet context via `extra_snippets`, which improves downstream relevance without changing tool contract shape.

## Tests
- `pnpm test:e2e src/agents/tools/web-tools.enabled-defaults.e2e.test.ts`

## Co-authored
- Co-authored-by: ciberponk <ciberponk@gmail.com>
- Co-authored-by: Codex <codex@openai.com>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR enhances Brave Search integration by requesting and merging `extra_snippets` into search result descriptions. The implementation correctly adds the `extra_snippets=true` parameter to all Brave API requests and appends the additional snippet context to the base description using newline separators. The combined description is properly wrapped with security markers via `wrapWebContent`. URL and metadata fields remain unwrapped for tool chaining compatibility. The changes include appropriate e2e test coverage verifying both the request parameter and the merged output.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-contained, follow existing patterns in the codebase, maintain security by wrapping external content, preserve backward compatibility by keeping URLs and metadata fields unwrapped for tool chaining, and include thorough test coverage for both the request parameter and response merging logic
- No files require special attention

<sub>Last reviewed commit: 933c90e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->