### PR TITLE
Fix: Preserve case sensitivity for Slack IDs

### DIFF
--- a/src/channels/targets.ts
+++ b/src/channels/targets.ts
@@ -16,7 +16,7 @@ export type MessagingTargetParseOptions = {
 };
 
 export function normalizeTargetId(kind: MessagingTargetKind, id: string): string {
-  return `${kind}:${id}`.toLowerCase();
+  return `${kind}:${id}`;
 }
 
 export function buildMessagingTarget(

--- a/src/slack/targets.test.ts
+++ b/src/slack/targets.test.ts
@@ -7,17 +7,17 @@ describe("parseSlackTarget", () => {
     expect(parseSlackTarget("<@U123>")).toMatchObject({
       kind: "user",
       id: "U123",
-      normalized: "user:u123",
+      normalized: "user:U123",
     });
     expect(parseSlackTarget("user:U456")).toMatchObject({
       kind: "user",
       id: "U456",
-      normalized: "user:u456",
+      normalized: "user:U456",
     });
     expect(parseSlackTarget("slack:U789")).toMatchObject({
       kind: "user",
       id: "U789",
-      normalized: "user:u789",
+      normalized: "user:U789",
     });
   });
 
@@ -25,12 +25,12 @@ describe("parseSlackTarget", () => {
     expect(parseSlackTarget("channel:C123")).toMatchObject({
       kind: "channel",
       id: "C123",
-      normalized: "channel:c123",
+      normalized: "channel:C123",
     });
     expect(parseSlackTarget("#C999")).toMatchObject({
       kind: "channel",
       id: "C999",
-      normalized: "channel:c999",
+      normalized: "channel:C999",
     });
   });
 
@@ -53,6 +53,6 @@ describe("resolveSlackChannelId", () => {
 
 describe("normalizeSlackMessagingTarget", () => {
   it("defaults raw ids to channels", () => {
-    expect(normalizeSlackMessagingTarget("C123")).toBe("channel:c123");
+    expect(normalizeSlackMessagingTarget("C123")).toBe("channel:C123");
   });
 });


### PR DESCRIPTION
## Summary
Fixes #4751 - Preserves case sensitivity for Slack channel IDs

## Changes
- Removed `.toLowerCase()` from `normalizeTargetId()` in `src/channels/targets.ts`
- Slack IDs (format: C0ACC8J786L) are case-sensitive and should not be lowercased

## Before
```typescript
export function normalizeTargetId(kind: MessagingTargetKind, id: string): string {
  return `${kind}:${id}`.toLowerCase();
}
```

## After
```typescript
export function normalizeTargetId(kind: MessagingTargetKind, id: string): string {
  return `${kind}:${id}`;
}
```

## Testing
- ✅ Lint check passed
- ✅ Format check passed

🤖 Generated with Claude Code

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Removed `.toLowerCase()` from `normalizeTargetId()` to preserve case sensitivity for Slack channel IDs.

**Issues Found:**
- The change will break existing tests in `src/slack/targets.test.ts` that expect lowercase normalized IDs
- Creates backwards compatibility concerns: existing stored normalized IDs (in configs/caches) are lowercase, but new ones will preserve case, breaking equality comparisons in target resolution code (`src/infra/outbound/target-resolver.ts:492`)

**Recommendation:**
While Slack IDs are indeed case-sensitive and should be preserved, this change needs:
1. Test updates to reflect the new behavior
2. Migration strategy for existing stored normalized IDs, or case-insensitive comparison logic where normalized IDs are compared

<h3>Confidence Score: 1/5</h3>

- This PR is unsafe to merge - it will break existing tests and may cause runtime issues with target ID comparisons
- Score of 1 (critical issues) because: (1) The change breaks existing unit tests that explicitly check for lowercase normalized IDs, (2) Creates backwards compatibility issues where stored lowercase IDs won't match newly generated case-preserved IDs in equality comparisons, (3) No migration strategy or backwards compatibility handling is included. While the intent to preserve Slack ID case sensitivity is correct, the implementation is incomplete.
- src/channels/targets.ts requires additional changes to handle backwards compatibility before merging

<sub>Last reviewed commit: 993ec1f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->