### PR TITLE
Fix: Add type safety to models status command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Docs: https://docs.openclaw.ai
 - Cron: repair missing/corrupt `nextRunAtMs` for the updated job without globally recomputing unrelated due jobs during `cron update`. (#15750)
 - Discord: prefer gateway guild id when logging inbound messages so cached-miss guilds do not appear as `guild=dm`. Thanks @thewilloftheshadow.
 - TUI: refactor searchable select list description layout and add regression coverage for ANSI-highlight width bounds.
+- Models/CLI: guard `models status` string trimming paths to prevent crashes from malformed non-string config values. (#16395) Thanks @BinHPdev.
 
 ## 2026.2.14
 

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -107,7 +107,7 @@ export async function modelsStatusCommand(
   const imageFallbacks = typeof imageConfig === "object" ? (imageConfig?.fallbacks ?? []) : [];
   const aliases = Object.entries(cfg.agents?.defaults?.models ?? {}).reduce<Record<string, string>>(
     (acc, [key, entry]) => {
-      const alias = entry?.alias?.trim();
+      const alias = typeof entry?.alias === "string" ? entry.alias.trim() : undefined;
       if (alias) {
         acc[alias] = key;
       }
@@ -127,7 +127,7 @@ export async function modelsStatusCommand(
   );
   const providersFromConfig = new Set(
     Object.keys(cfg.models?.providers ?? {})
-      .map((p) => p.trim())
+      .map((p) => (typeof p === "string" ? p.trim() : ""))
       .filter(Boolean),
   );
   const providersFromModels = new Set<string>();
@@ -176,7 +176,7 @@ export async function modelsStatusCommand(
       ...providersFromEnv,
     ]),
   )
-    .map((p) => p.trim())
+    .map((p) => (typeof p === "string" ? p.trim() : ""))
     .filter(Boolean)
     .toSorted((a, b) => a.localeCompare(b));
 


### PR DESCRIPTION
## Summary
Fixes #7062 - Prevents crashes in `openclaw models status` when config contains non-string values

## Changes
Added type checks before calling `.trim()` on potentially non-string values:
- Line 110: Check `entry.alias` is a string before trimming
- Line 130: Validate provider keys from config
- Line 179: Validate combined provider array elements

## Problem
The command crashed with `TypeError: Cannot read properties of undefined (reading 'trim')` when:
- `agents.defaults.model` is undefined or malformed
- Config contains non-string values in model aliases or provider configs

## Before
```typescript
const alias = entry?.alias?.trim();  // Crashes if alias is not a string
.map((p) => p.trim())  // Crashes if p is not a string
```

## After
```typescript
const alias = typeof entry?.alias === "string" ? entry.alias.trim() : undefined;
.map((p) => (typeof p === "string" ? p.trim() : ""))
```

## Testing
- ✅ Lint check passed
- ✅ Format check passed

🤖 Generated with Claude Code

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Added type safety guards to prevent crashes when config contains non-string values in model configuration. The changes add `typeof` checks before calling `.trim()` on potentially non-string values at three locations: alias handling (line 110), provider keys (line 130), and combined provider arrays (line 179). These guards prevent `TypeError` crashes when the config is malformed or contains unexpected data types.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk - it adds defensive type checking to prevent crashes
- The changes are defensive and improve robustness by preventing runtime crashes. The type guards are appropriate for lines 110 and 179 where data could come from user config. Line 130's guard is technically unnecessary but harmless. All changes are backward-compatible and add safety without altering core logic. Lint and format checks passed.
- No files require special attention

<sub>Last reviewed commit: 025b9a4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->