### PR TITLE
Fix: Handle string input in setConsoleSubsystemFilter

### DIFF
--- a/src/logging/console.ts
+++ b/src/logging/console.ts
@@ -99,12 +99,18 @@ export function routeLogsToStderr(): void {
   loggingState.forceConsoleToStderr = true;
 }
 
-export function setConsoleSubsystemFilter(filters?: string[] | null): void {
-  if (!filters || filters.length === 0) {
+export function setConsoleSubsystemFilter(filters?: string[] | string | null): void {
+  if (!filters) {
     loggingState.consoleSubsystemFilter = null;
     return;
   }
-  const normalized = filters.map((value) => value.trim()).filter((value) => value.length > 0);
+  // Convert string to array by splitting on comma
+  const filterArray = typeof filters === "string" ? filters.split(",") : filters;
+  if (filterArray.length === 0) {
+    loggingState.consoleSubsystemFilter = null;
+    return;
+  }
+  const normalized = filterArray.map((value) => value.trim()).filter((value) => value.length > 0);
   loggingState.consoleSubsystemFilter = normalized.length > 0 ? normalized : null;
 }
 


### PR DESCRIPTION
## Summary
`setConsoleSubsystemFilter` crashed when receiving a string input instead of the expected array type. Added type guard to handle string input gracefully.

## Validation
- [x] `pnpm build` — passed
- [x] `pnpm check` (format + tsgo + lint) — passed
- [x] `pnpm test` — 1073 tests passed (105 test files)

## Scope
- Single focused fix — single file changed

## AI-Assistance
- AI-assisted (Claude Code) for implementation
- Human-reviewed: confirmed understanding of changes
- Testing: full local validation suite passed