### PR TITLE
Fix: Support top-level message fields in BlueBubbles webhook

### DIFF
--- a/extensions/bluebubbles/src/monitor-normalize.ts
+++ b/extensions/bluebubbles/src/monitor-normalize.ts
@@ -638,6 +638,11 @@ function extractMessagePayload(payload: Record<string, unknown>): Record<string,
     asRecord(messageRaw) ??
     (typeof messageRaw === "string" ? (asRecord(JSON.parse(messageRaw)) ?? null) : null);
   if (!message) {
+    // Fallback: Check if payload itself contains message fields (BlueBubbles format)
+    // BlueBubbles sends message data directly at the top level
+    if (payload.guid || payload.text || payload.handle || payload.chatGuid) {
+      return payload;
+    }
     return null;
   }
   return message;


### PR DESCRIPTION
## Summary
BlueBubbles webhook payloads can have message fields at the top level (not nested under a `message` key), causing the handler to miss the data. Fixed by supporting both top-level and nested message field layouts.

## Validation
- [x] `pnpm build` — passed
- [x] `pnpm check` (format + tsgo + lint) — passed
- [x] `pnpm test` — 1073 tests passed (105 test files)

## Scope
- Single focused fix — BlueBubbles webhook payload handling

## AI-Assistance
- AI-assisted (Claude Code) for implementation
- Human-reviewed: confirmed understanding of changes
- Testing: full local validation suite passed