### PR TITLE
feat(web-search): include Brave structured faq/discussions/infobox results

### DIFF
--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -86,6 +86,35 @@ type BraveSearchResponse = {
   web?: {
     results?: BraveSearchResult[];
   };
+  discussions?: {
+    results?: Array<{
+      title?: string;
+      url?: string;
+      data?: {
+        forum_name?: string;
+        question?: string;
+        top_comment?: string;
+        num_answers?: number;
+        score?: number;
+      };
+    }>;
+  };
+  faq?: {
+    results?: Array<{
+      question?: string;
+      answer?: string;
+      title?: string;
+      url?: string;
+    }>;
+  };
+  infobox?: {
+    results?: Array<{
+      label?: string;
+      long_desc?: string;
+      website_url?: string;
+      attributes?: Array<[string, string]>;
+    }>;
+  };
 };
 
 type PerplexityConfig = {
@@ -685,6 +714,50 @@ async function runWebSearch(params: {
     };
   });
 
+  const formattedDiscussions = Array.isArray(data.discussions?.results)
+    ? data.discussions.results
+        .map((entry) => ({
+          title: entry.title ? wrapWebContent(entry.title, "web_search") : "",
+          url: entry.url ?? "",
+          forum: entry.data?.forum_name ? wrapWebContent(entry.data.forum_name, "web_search") : "",
+          question: entry.data?.question ? wrapWebContent(entry.data.question, "web_search") : "",
+          topComment: entry.data?.top_comment
+            ? wrapWebContent(entry.data.top_comment, "web_search")
+            : "",
+          answers: entry.data?.num_answers ?? 0,
+          score: entry.data?.score ?? undefined,
+        }))
+        .filter((entry) => entry.topComment)
+    : [];
+
+  const formattedFaq = Array.isArray(data.faq?.results)
+    ? data.faq.results
+        .map((entry) => ({
+          question: entry.question ? wrapWebContent(entry.question, "web_search") : "",
+          answer: entry.answer ? wrapWebContent(entry.answer, "web_search") : "",
+          title: entry.title ? wrapWebContent(entry.title, "web_search") : "",
+          url: entry.url ?? "",
+        }))
+        .filter((entry) => entry.answer)
+    : [];
+
+  const infoboxRaw = data.infobox?.results?.[0];
+  const formattedInfobox = infoboxRaw
+    ? {
+        label: infoboxRaw.label ? wrapWebContent(infoboxRaw.label, "web_search") : "",
+        description: infoboxRaw.long_desc
+          ? wrapWebContent(infoboxRaw.long_desc, "web_search")
+          : "",
+        attributes: Array.isArray(infoboxRaw.attributes)
+          ? infoboxRaw.attributes.map(([key, value]) => ({
+              key: wrapWebContent(key, "web_search"),
+              value: wrapWebContent(value, "web_search"),
+            }))
+          : [],
+        url: infoboxRaw.website_url ?? "",
+      }
+    : undefined;
+
   const payload = {
     query: params.query,
     provider: params.provider,
@@ -697,6 +770,9 @@ async function runWebSearch(params: {
       wrapped: true,
     },
     results: mapped,
+    ...(formattedDiscussions.length > 0 ? { discussions: formattedDiscussions } : {}),
+    ...(formattedFaq.length > 0 ? { faq: formattedFaq } : {}),
+    ...(formattedInfobox ? { infobox: formattedInfobox } : {}),
   };
   writeCache(SEARCH_CACHE, cacheKey, payload, params.cacheTtlMs);
   return payload;

--- a/src/agents/tools/web-tools.enabled-defaults.e2e.test.ts
+++ b/src/agents/tools/web-tools.enabled-defaults.e2e.test.ts
@@ -460,6 +460,72 @@ describe("web_search external content wrapping", () => {
     expect(details.results?.[0]?.published).not.toContain("<<<EXTERNAL_UNTRUSTED_CONTENT>>>");
   });
 
+  it("includes Brave structured faq/discussions/infobox results when present", async () => {
+    vi.stubEnv("BRAVE_API_KEY", "test-key");
+    const mockFetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            web: { results: [] },
+            discussions: {
+              results: [
+                {
+                  title: "Forum thread",
+                  url: "https://forum.example.com/t/1",
+                  data: {
+                    forum_name: "Example Forum",
+                    question: "Best setup?",
+                    top_comment: "Use config A",
+                    num_answers: 2,
+                    score: 9,
+                  },
+                },
+              ],
+            },
+            faq: {
+              results: [
+                {
+                  question: "What is X?",
+                  answer: "X is Y",
+                  title: "FAQ Entry",
+                  url: "https://example.com/faq/x",
+                },
+              ],
+            },
+            infobox: {
+              results: [
+                {
+                  label: "Example Label",
+                  long_desc: "Example Description",
+                  website_url: "https://example.com",
+                  attributes: [["Key1", "Value1"]],
+                },
+              ],
+            },
+          }),
+      } as Response),
+    );
+    // @ts-expect-error mock fetch
+    global.fetch = mockFetch;
+
+    const tool = createWebSearchTool({ config: undefined, sandboxed: true });
+    const result = await tool?.execute?.(1, { query: "structured-results-test" });
+    const details = result?.details as {
+      discussions?: Array<{ topComment?: string; url?: string }>;
+      faq?: Array<{ answer?: string; url?: string }>;
+      infobox?: { description?: string; url?: string; attributes?: Array<{ key?: string }> };
+    };
+
+    expect(details.discussions?.[0]?.topComment).toContain("<<<EXTERNAL_UNTRUSTED_CONTENT>>>");
+    expect(details.discussions?.[0]?.url).toBe("https://forum.example.com/t/1");
+    expect(details.faq?.[0]?.answer).toContain("<<<EXTERNAL_UNTRUSTED_CONTENT>>>");
+    expect(details.faq?.[0]?.url).toBe("https://example.com/faq/x");
+    expect(details.infobox?.description).toContain("<<<EXTERNAL_UNTRUSTED_CONTENT>>>");
+    expect(details.infobox?.url).toBe("https://example.com");
+    expect(details.infobox?.attributes?.[0]?.key).toContain("<<<EXTERNAL_UNTRUSTED_CONTENT>>>");
+  });
+
   it("wraps Perplexity content", async () => {
     vi.stubEnv("PERPLEXITY_API_KEY", "pplx-test");
     const mockFetch = vi.fn(() =>


### PR DESCRIPTION
## Summary
- map Brave structured sections into `web_search` payload when present: `discussions`, `faq`, `infobox`
- keep URLs raw for chaining while wrapping untrusted text fields
- add e2e coverage for structured field mapping and wrapping behavior

## Why
Brave responses can include useful structured context beyond `web.results`. Exposing these fields improves downstream answer quality without breaking existing payload shape.

## Tests
- `pnpm test:e2e src/agents/tools/web-tools.enabled-defaults.e2e.test.ts`

## Co-authored
- Co-authored-by: ciberponk <ciberponk@gmail.com>
- Co-authored-by: Codex <codex@openai.com>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Exposes Brave structured search sections (`discussions`, `faq`, `infobox`) in the `web_search` payload while maintaining proper security wrapping.

- Added TypeScript types for `discussions`, `faq`, and `infobox` in `BraveSearchResponse`
- Maps these fields from Brave API responses into the tool payload with proper `wrapWebContent` calls for untrusted text
- Keeps URLs unwrapped to enable tool chaining (e.g., passing to `web_fetch`)
- Conditionally includes structured sections only when present (using spread syntax)
- Added comprehensive e2e test coverage for field mapping and wrapping behavior

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation follows existing patterns for handling external content with proper security wrapping. All untrusted text fields are wrapped with `wrapWebContent` while URLs remain raw for tool chaining. The changes are additive (conditionally spreading new fields), preserving backward compatibility. Comprehensive test coverage validates both field mapping and security wrapping behavior.
- No files require special attention

<sub>Last reviewed commit: aec2512</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->