### PR TITLE
feat(web-search): enable Brave text_decorations by default

### DIFF
--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -654,6 +654,7 @@ async function runWebSearch(params: {
   if (params.freshness) {
     url.searchParams.set("freshness", params.freshness);
   }
+  url.searchParams.set("text_decorations", "1");
 
   const res = await fetch(url.toString(), {
     method: "GET",

--- a/src/agents/tools/web-tools.enabled-defaults.e2e.test.ts
+++ b/src/agents/tools/web-tools.enabled-defaults.e2e.test.ts
@@ -105,6 +105,23 @@ describe("web_search country and language parameters", () => {
     expect(url.searchParams.get("freshness")).toBe("pw");
   });
 
+  it("should enable Brave text_decorations by default", async () => {
+    const mockFetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ web: { results: [] } }),
+      } as Response),
+    );
+    // @ts-expect-error mock fetch
+    global.fetch = mockFetch;
+
+    const tool = createWebSearchTool({ config: undefined, sandboxed: true });
+    await tool?.execute?.(1, { query: "test-text-decorations" });
+
+    const url = new URL(mockFetch.mock.calls[0][0] as string);
+    expect(url.searchParams.get("text_decorations")).toBe("1");
+  });
+
   it("rejects invalid freshness values", async () => {
     const mockFetch = vi.fn(() =>
       Promise.resolve({


### PR DESCRIPTION
## Summary
- enable Brave `text_decorations=1` by default in web_search requests
- add e2e coverage ensuring the query param is always set

## Why
`text_decorations` enriches Brave snippets with better formatting/context and is a safe request-side enhancement with no contract changes.

## Tests
- `pnpm test:e2e src/agents/tools/web-tools.enabled-defaults.e2e.test.ts`

## Co-authored
- Co-authored-by: ciberponk <ciberponk@gmail.com>
- Co-authored-by: Codex <codex@openai.com>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Enables Brave Search `text_decorations=1` query parameter by default for all Brave web search requests. This enriches search result snippets with better formatting (bold/italic markup) from Brave's API. The change is a single-line addition to the URL construction in `runWebSearch`, accompanied by a well-structured e2e test that validates the parameter is always present.

- Adds `url.searchParams.set("text_decorations", "1")` unconditionally for Brave search requests in `web-search.ts`
- New e2e test in `web-tools.enabled-defaults.e2e.test.ts` follows existing test patterns and verifies the query param is set
- No cache key changes needed since the value is a constant default (always `"1"`)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk — it adds a single hardcoded query parameter to Brave search requests.
- The change is a one-line, additive-only modification that sets a constant query parameter on Brave search API requests. No existing behavior is altered, no new code paths are introduced, and the test coverage is adequate. The `text_decorations` parameter is a well-documented Brave Search API option that enriches snippet formatting.
- No files require special attention.

<sub>Last reviewed commit: 5d2ba7d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->