### PR TITLE
security: block apply_patch path traversal outside workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Docs: https://docs.openclaw.ai
 - Security/BlueBubbles: reject ambiguous shared-path webhook routing when multiple webhook targets match the same guid/password.
 - Security/BlueBubbles: harden BlueBubbles webhook auth behind reverse proxies by only accepting passwordless webhooks for direct localhost loopback requests (forwarded/proxied requests now require a password). Thanks @simecek.
 - Security/BlueBubbles: require explicit `mediaLocalRoots` allowlists for local outbound media path reads to prevent local file disclosure. (#16322) Thanks @mbelinky.
+- Security/Agents: enforce workspace-root path bounds for `apply_patch` in non-sandbox mode to block traversal and symlink escape writes. Thanks @p80n-sec.
 - Cron/Slack: preserve agent identity (name and icon) when cron jobs deliver outbound messages. (#16242) Thanks @robbyczgw-cla.
 - Cron: deliver text-only output directly when `delivery.to` is set so cron recipients get full output instead of summaries. (#16360) Thanks @rubyrunsstuff.
 - Cron: repair missing/corrupt `nextRunAtMs` for the updated job without globally recomputing unrelated due jobs during `cron update`. (#15750)


### PR DESCRIPTION
## Summary
- enforce workspace-root path bounds for `apply_patch` even when sandbox mode is not enabled
- reuse sandbox path guard logic for non-sandbox path resolution
- add regression coverage for traversal, absolute-outside, and symlink escape attempts

## Security context
- advisory: https://github.com/openclaw/openclaw/security/advisories/GHSA-r5fq-947m-xm57
- this closes the server-side file path escape primitive by rejecting paths outside the workspace root

## Tests
- `OPENCLAW_E2E_WORKERS=1 pnpm exec vitest run --config vitest.e2e.config.ts src/agents/apply-patch.e2e.test.ts`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR closes a critical path traversal vulnerability in `apply_patch` that allowed writes outside the workspace directory. The fix extends sandbox path enforcement to non-sandbox mode by replacing custom path resolution with the shared `assertSandboxPath` utility, which validates both path boundaries and symlink escapes.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The security fix properly addresses the vulnerability by reusing battle-tested path validation logic from `assertSandboxPath`, comprehensive test coverage validates all attack vectors (relative traversal, absolute paths, symlink escapes), and the CHANGELOG documents the security context appropriately
- No files require special attention

<sub>Last reviewed commit: 43274ac</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->