### PR TITLE
Claw Loop: add vNext SDK-first bridge driver with retry/dedupe tests

### DIFF
--- a/scripts/claw-loop-vnext-dry-run.ts
+++ b/scripts/claw-loop-vnext-dry-run.ts
@@ -1,0 +1,84 @@
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type {
+  LoopTransport,
+  SendMessageRequest,
+  SendMessageResult,
+} from "../src/claw-loop-vnext/transport/types.js";
+import { nudgeIfStuck, sendCurrentPhasePrompt } from "../src/claw-loop-vnext/orchestrator.js";
+import { RuntimeStore } from "../src/claw-loop-vnext/runtime-store.js";
+
+class DemoPrimary implements LoopTransport {
+  readonly kind = "sdk" as const;
+  async sendMessage(_request: SendMessageRequest): Promise<SendMessageResult> {
+    return { delivered: false, transport: "sdk", outputText: "", reason: "simulated-no-ack" };
+  }
+}
+
+class DemoFallback implements LoopTransport {
+  readonly kind = "tmux" as const;
+  async sendMessage(_request: SendMessageRequest): Promise<SendMessageResult> {
+    return {
+      delivered: true,
+      transport: "tmux",
+      ackId: "demo-ack",
+      outputText: "PHASE_COMPLETE: P1\nPHASE_COMPLETE: P1",
+    };
+  }
+}
+
+async function main() {
+  const goalsDir = await mkdtemp(path.join(os.tmpdir(), "claw-loop-vnext-demo-"));
+  const goalFile = path.join(goalsDir, "goal-demo.json");
+  await writeFile(
+    goalFile,
+    JSON.stringify({
+      title: "Demo goal",
+      workdir: "/tmp",
+      status: "pending",
+      phases: [
+        { id: "P1", name: "Plan", status: "pending" },
+        { id: "P2", name: "Implement", status: "pending" },
+      ],
+      orchestration: { maxRetries: 2, ackTimeoutMs: 100 },
+    }),
+    "utf8",
+  );
+
+  const result = await sendCurrentPhasePrompt(
+    { goalsDir, primaryTransport: new DemoPrimary(), fallbackTransport: new DemoFallback() },
+    goalFile,
+    "demo run",
+  );
+
+  const store = new RuntimeStore(path.join(goalsDir, ".runtime", "goal-demo.state.json"));
+  const state = await store.load("goal-demo");
+  state.lastActivityAt = new Date(Date.now() - 10 * 60_000).toISOString();
+  await store.save(state);
+
+  const nudge1 = await nudgeIfStuck({ goalsDir, primaryTransport: new DemoFallback() }, goalFile, {
+    stuckAfterMs: 1_000,
+    cooldownMs: 60_000,
+  });
+  const nudge2 = await nudgeIfStuck({ goalsDir, primaryTransport: new DemoFallback() }, goalFile, {
+    stuckAfterMs: 1_000,
+    cooldownMs: 60_000,
+  });
+
+  const goalText = await readFile(goalFile, "utf8");
+  const events = await readFile(path.join(goalsDir, ".runtime", "goal-demo.events.jsonl"), "utf8");
+
+  // eslint-disable-next-line no-console
+  console.log("delivery", result.delivered, result.transport, result.ackId);
+  // eslint-disable-next-line no-console
+  console.log("signals", result.signals.map((s) => s.type).join(","));
+  // eslint-disable-next-line no-console
+  console.log("nudge", nudge1, nudge2);
+  // eslint-disable-next-line no-console
+  console.log("goal", goalText.trim());
+  // eslint-disable-next-line no-console
+  console.log("events", events.trim().split("\n").length);
+}
+
+await main();

--- a/scripts/claw-loop-vnext.ts
+++ b/scripts/claw-loop-vnext.ts
@@ -1,0 +1,4 @@
+import { runClawLoopVNext } from "../src/claw-loop-vnext/cli.js";
+
+const result = await runClawLoopVNext(process.argv.slice(2));
+process.exit(result.exitCode);

--- a/skills/claw-loop-vnext/README.md
+++ b/skills/claw-loop-vnext/README.md
@@ -1,0 +1,49 @@
+# Claw-Loop vNext (Bridge -> SDK-first)
+
+This directory contains the incremental vNext implementation that preserves the original claw-loop contract while reducing tmux flakiness.
+
+## Contract
+
+1. Propose phases
+2. User reviews/edits phases
+3. Execute after approval
+4. Track until complete/blocked
+
+## Rollout
+
+1. Bridge mode (`orchestration.mode=bridge`): SDK-first delivery with tmux fallback.
+2. SDK-first mode (`orchestration.mode=sdk-first`): SDK primary path and tmux fallback only on delivery failure.
+3. SDK-only mode (future): remove tmux fallback path after confidence window.
+
+## Demo (dry run)
+
+```bash
+node --import tsx scripts/claw-loop-vnext-dry-run.ts
+```
+
+What it demonstrates:
+
+- ACK loss on primary transport triggers retry
+- fallback delivery succeeds
+- duplicate `PHASE_COMPLETE` does not double-advance
+- stuck detector sends a single nudge and rate-limits repeats
+
+## Tests
+
+```bash
+pnpm exec vitest run \
+  src/claw-loop-vnext/__tests__/goal.test.ts \
+  src/claw-loop-vnext/__tests__/signal-parser.test.ts \
+  src/claw-loop-vnext/__tests__/runtime-store.test.ts \
+  src/claw-loop-vnext/__tests__/send-with-retry.test.ts \
+  src/claw-loop-vnext/__tests__/orchestrator.dedupe.test.ts \
+  src/claw-loop-vnext/__tests__/regression-unknown-delivery.test.ts \
+  src/claw-loop-vnext/__tests__/integration-mocked-driver.test.ts \
+  src/claw-loop-vnext/__tests__/regression-stuck-single-nudge.test.ts
+```
+
+## Known Limitations
+
+- SDK transport currently uses `codex exec --json` as the ACK source; it is a pragmatic bridge, not a dedicated embedded SDK session yet.
+- Runtime store is JSON-backed (not SQLite) in this slice.
+- `check` currently provides listing/status behavior; full autonomous heartbeat/tick scheduling is partially implemented via `nudgeIfStuck` and will be expanded.

--- a/skills/claw-loop-vnext/SKILL.md
+++ b/skills/claw-loop-vnext/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: claw-loop-vnext
+description: "Iterative goal completion with phase review and SDK-first delivery ACK + tmux fallback."
+---
+
+# Claw-Loop vNext
+
+Preserves the original contract:
+
+1. Propose phases
+2. User reviews/edits phases
+3. After approval, execute goal
+4. Track until complete/blocked
+
+## Commands
+
+```bash
+skills/claw-loop-vnext/claw-loop.sh start --goal ~/clawd/goals/goal-feature.json
+skills/claw-loop-vnext/claw-loop.sh check
+skills/claw-loop-vnext/claw-loop.sh status --goal ~/clawd/goals/goal-feature.json
+skills/claw-loop-vnext/claw-loop.sh prompt --goal ~/clawd/goals/goal-feature.json
+skills/claw-loop-vnext/claw-loop.sh direct --goal ~/clawd/goals/goal-feature.json --msg "Focus on tests"
+skills/claw-loop-vnext/claw-loop.sh approve --goal ~/clawd/goals/goal-feature.json
+```
+
+## Goal Schema Compatibility
+
+Canonical per-phase state is `status`.
+Compatibility field `passes` is still accepted and auto-derived.
+
+- Read: accepts either `status` or `passes`
+- Write: emits both (`status` source of truth)
+
+## Runtime Files
+
+For goal `goal-xyz.json` in `~/clawd/goals`:
+
+- Event log: `~/clawd/goals/.runtime/goal-xyz.events.jsonl`
+- Runtime state: `~/clawd/goals/.runtime/goal-xyz.state.json`

--- a/skills/claw-loop-vnext/SKILL.md
+++ b/skills/claw-loop-vnext/SKILL.md
@@ -37,3 +37,29 @@ For goal `goal-xyz.json` in `~/clawd/goals`:
 
 - Event log: `~/clawd/goals/.runtime/goal-xyz.events.jsonl`
 - Runtime state: `~/clawd/goals/.runtime/goal-xyz.state.json`
+
+## Rollout
+
+1. Bridge mode (`orchestration.mode=bridge`): SDK-first with tmux fallback.
+2. SDK-first mode (`orchestration.mode=sdk-first`): SDK primary path with fallback.
+3. SDK-only mode (future): remove tmux fallback after migration confidence.
+
+## Demo
+
+```bash
+node --import tsx scripts/claw-loop-vnext-dry-run.ts
+```
+
+## Test Command
+
+```bash
+pnpm exec vitest run \
+  src/claw-loop-vnext/__tests__/goal.test.ts \
+  src/claw-loop-vnext/__tests__/signal-parser.test.ts \
+  src/claw-loop-vnext/__tests__/runtime-store.test.ts \
+  src/claw-loop-vnext/__tests__/send-with-retry.test.ts \
+  src/claw-loop-vnext/__tests__/orchestrator.dedupe.test.ts \
+  src/claw-loop-vnext/__tests__/regression-unknown-delivery.test.ts \
+  src/claw-loop-vnext/__tests__/integration-mocked-driver.test.ts \
+  src/claw-loop-vnext/__tests__/regression-stuck-single-nudge.test.ts
+```

--- a/skills/claw-loop-vnext/claw-loop.sh
+++ b/skills/claw-loop-vnext/claw-loop.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+exec node --import tsx "$ROOT_DIR/scripts/claw-loop-vnext.ts" "$@"

--- a/skills/claw-loop-vnext/goal.json.example
+++ b/skills/claw-loop-vnext/goal.json.example
@@ -1,0 +1,38 @@
+{
+  "title": "Example Feature",
+  "workdir": "/path/to/repo/or/worktree",
+  "tool": "codex",
+  "status": "pending",
+  "phases": [
+    {
+      "id": "P1",
+      "name": "Plan",
+      "status": "pending",
+      "passes": false
+    },
+    {
+      "id": "P2",
+      "name": "Implement",
+      "status": "pending",
+      "passes": false,
+      "requiresApproval": true
+    },
+    {
+      "id": "P3",
+      "name": "Test",
+      "status": "pending",
+      "passes": false
+    },
+    {
+      "id": "P4",
+      "name": "PR",
+      "status": "pending",
+      "passes": false
+    }
+  ],
+  "orchestration": {
+    "mode": "sdk-first",
+    "ackTimeoutMs": 15000,
+    "maxRetries": 2
+  }
+}

--- a/src/claw-loop-vnext/__tests__/goal.test.ts
+++ b/src/claw-loop-vnext/__tests__/goal.test.ts
@@ -1,0 +1,72 @@
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { loadGoalFile, saveGoalFile, updatePhaseStatus } from "../goal.js";
+
+describe("goal schema compatibility", () => {
+  it("loads legacy passes-only phases", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "claw-loop-vnext-goal-"));
+    const file = path.join(dir, "goal.json");
+    await writeFile(
+      file,
+      JSON.stringify({
+        title: "x",
+        workdir: "/tmp",
+        status: "pending",
+        phases: [
+          { id: "P1", name: "Plan", passes: true },
+          { id: "P2", name: "Implement", passes: false },
+        ],
+      }),
+      "utf8",
+    );
+
+    const goal = await loadGoalFile(file);
+    expect(goal.phases[0].status).toBe("complete");
+    expect(goal.phases[1].status).toBe("pending");
+  });
+
+  it("prefers status when status and passes conflict", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "claw-loop-vnext-goal-"));
+    const file = path.join(dir, "goal.json");
+    await writeFile(
+      file,
+      JSON.stringify({
+        title: "x",
+        workdir: "/tmp",
+        status: "pending",
+        phases: [{ id: "P1", name: "Plan", status: "pending", passes: true }],
+      }),
+      "utf8",
+    );
+
+    const goal = await loadGoalFile(file);
+    expect(goal.phases[0].status).toBe("pending");
+    expect(goal.phases[0].passes).toBe(false);
+  });
+
+  it("writes status and passes together", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "claw-loop-vnext-goal-"));
+    const file = path.join(dir, "goal.json");
+    await writeFile(
+      file,
+      JSON.stringify({
+        title: "x",
+        workdir: "/tmp",
+        status: "pending",
+        phases: [{ id: "P1", name: "Plan", status: "pending" }],
+      }),
+      "utf8",
+    );
+
+    const goal = await loadGoalFile(file);
+    const next = updatePhaseStatus(goal, "P1", "complete");
+    await saveGoalFile(file, next);
+    const saved = JSON.parse(await readFile(file, "utf8")) as {
+      phases: Array<{ status: string; passes: boolean }>;
+    };
+    expect(saved.phases[0].status).toBe("complete");
+    expect(saved.phases[0].passes).toBe(true);
+  });
+});

--- a/src/claw-loop-vnext/__tests__/integration-mocked-driver.test.ts
+++ b/src/claw-loop-vnext/__tests__/integration-mocked-driver.test.ts
@@ -1,0 +1,78 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import type { LoopTransport, SendMessageRequest, SendMessageResult } from "../transport/types.js";
+import { sendCurrentPhasePrompt } from "../orchestrator.js";
+
+class MockDriver implements LoopTransport {
+  readonly kind: "sdk" | "tmux";
+  readonly requests: SendMessageRequest[] = [];
+  private readonly results: SendMessageResult[];
+
+  constructor(kind: "sdk" | "tmux", results: SendMessageResult[]) {
+    this.kind = kind;
+    this.results = [...results];
+  }
+
+  async sendMessage(request: SendMessageRequest): Promise<SendMessageResult> {
+    this.requests.push(request);
+    return this.results.shift() as SendMessageResult;
+  }
+}
+
+describe("integration: mocked driver bridge", () => {
+  it("falls back after ACK loss and advances phase exactly once with duplicate output", async () => {
+    const goalsDir = await mkdtemp(path.join(os.tmpdir(), "claw-loop-vnext-int-"));
+    const goalFile = path.join(goalsDir, "goal-int.json");
+    await writeFile(
+      goalFile,
+      JSON.stringify({
+        title: "goal",
+        workdir: "/tmp",
+        status: "pending",
+        phases: [
+          { id: "P1", name: "Plan", status: "pending" },
+          { id: "P2", name: "Implement", status: "pending" },
+        ],
+        orchestration: { maxRetries: 2, ackTimeoutMs: 100 },
+      }),
+      "utf8",
+    );
+
+    const primary = new MockDriver("sdk", [
+      { delivered: false, transport: "sdk", outputText: "", reason: "timeout" },
+      { delivered: false, transport: "sdk", outputText: "", reason: "timeout" },
+    ]);
+    const fallback = new MockDriver("tmux", [
+      {
+        delivered: true,
+        transport: "tmux",
+        ackId: "ack-tmux",
+        outputText: "PHASE_COMPLETE: P1\nPHASE_COMPLETE: P1",
+      },
+    ]);
+
+    const result = await sendCurrentPhasePrompt(
+      {
+        goalsDir,
+        primaryTransport: primary,
+        fallbackTransport: fallback,
+      },
+      goalFile,
+      "execute",
+    );
+
+    expect(result.delivered).toBe(true);
+    expect(result.transport).toBe("tmux");
+    expect(primary.requests).toHaveLength(2);
+    expect(fallback.requests).toHaveLength(1);
+    expect(primary.requests[0].idempotencyKey).toBe(primary.requests[1].idempotencyKey);
+    expect(fallback.requests[0].idempotencyKey).toBe(primary.requests[0].idempotencyKey);
+
+    const p1 = result.goal.phases.find((p) => p.id === "P1");
+    const p2 = result.goal.phases.find((p) => p.id === "P2");
+    expect(p1?.status).toBe("complete");
+    expect(p2?.status).toBe("pending");
+  });
+});

--- a/src/claw-loop-vnext/__tests__/orchestrator.dedupe.test.ts
+++ b/src/claw-loop-vnext/__tests__/orchestrator.dedupe.test.ts
@@ -1,0 +1,69 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import type { LoopTransport, SendMessageRequest, SendMessageResult } from "../transport/types.js";
+import { sendCurrentPhasePrompt } from "../orchestrator.js";
+
+class FixedTransport implements LoopTransport {
+  readonly kind = "sdk" as const;
+  private readonly outputText: string;
+
+  constructor(outputText: string) {
+    this.outputText = outputText;
+  }
+
+  async sendMessage(_request: SendMessageRequest): Promise<SendMessageResult> {
+    return {
+      delivered: true,
+      transport: "sdk",
+      ackId: "ack-1",
+      outputText: this.outputText,
+    };
+  }
+}
+
+describe("orchestrator dedupe", () => {
+  it("does not advance same phase twice across repeated outputs", async () => {
+    const goalsDir = await mkdtemp(path.join(os.tmpdir(), "claw-loop-vnext-orch-"));
+    const goalFile = path.join(goalsDir, "goal-1.json");
+    await writeFile(
+      goalFile,
+      JSON.stringify({
+        title: "x",
+        workdir: "/tmp",
+        status: "pending",
+        phases: [
+          { id: "P1", name: "Plan", status: "pending" },
+          { id: "P2", name: "Implement", status: "pending" },
+        ],
+      }),
+      "utf8",
+    );
+
+    const output = ["PHASE_COMPLETE: P1", "PHASE_COMPLETE: P1"].join("\n");
+
+    await sendCurrentPhasePrompt(
+      {
+        goalsDir,
+        primaryTransport: new FixedTransport(output),
+      },
+      goalFile,
+      "run",
+    );
+
+    const result2 = await sendCurrentPhasePrompt(
+      {
+        goalsDir,
+        primaryTransport: new FixedTransport(output),
+      },
+      goalFile,
+      "run again",
+    );
+
+    const p1 = result2.goal.phases.find((p) => p.id === "P1");
+    const p2 = result2.goal.phases.find((p) => p.id === "P2");
+    expect(p1?.status).toBe("complete");
+    expect(p2?.status).toBe("pending");
+  });
+});

--- a/src/claw-loop-vnext/__tests__/regression-stuck-single-nudge.test.ts
+++ b/src/claw-loop-vnext/__tests__/regression-stuck-single-nudge.test.ts
@@ -1,0 +1,64 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import type { LoopTransport, SendMessageRequest, SendMessageResult } from "../transport/types.js";
+import { nudgeIfStuck } from "../orchestrator.js";
+import { RuntimeStore } from "../runtime-store.js";
+
+class NudgeTransport implements LoopTransport {
+  readonly kind = "sdk" as const;
+  readonly sent: SendMessageRequest[] = [];
+
+  async sendMessage(request: SendMessageRequest): Promise<SendMessageResult> {
+    this.sent.push(request);
+    return {
+      delivered: true,
+      transport: "sdk",
+      ackId: "ack-nudge",
+      outputText: "Working...",
+    };
+  }
+}
+
+describe("regression: stuck detection single nudge", () => {
+  it("sends one nudge then respects cooldown", async () => {
+    const goalsDir = await mkdtemp(path.join(os.tmpdir(), "claw-loop-vnext-stuck-"));
+    const goalFile = path.join(goalsDir, "goal-stuck.json");
+    await writeFile(
+      goalFile,
+      JSON.stringify({
+        title: "goal",
+        workdir: "/tmp",
+        status: "in_progress",
+        phases: [{ id: "P1", name: "Plan", status: "pending" }],
+      }),
+      "utf8",
+    );
+
+    const store = new RuntimeStore(path.join(goalsDir, ".runtime", "goal-stuck.state.json"));
+    await store.save({
+      goalId: "goal-stuck",
+      lastDeliveryByIdempotencyKey: {},
+      seenSignalKeys: {},
+      lastActivityAt: new Date(Date.now() - 10 * 60_000).toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const transport = new NudgeTransport();
+    const first = await nudgeIfStuck({ goalsDir, primaryTransport: transport }, goalFile, {
+      stuckAfterMs: 1_000,
+      cooldownMs: 60_000,
+    });
+    const second = await nudgeIfStuck({ goalsDir, primaryTransport: transport }, goalFile, {
+      stuckAfterMs: 1_000,
+      cooldownMs: 60_000,
+    });
+
+    expect(first.nudged).toBe(true);
+    expect(first.reason).toBe("sent");
+    expect(second.nudged).toBe(false);
+    expect(second.reason).toBe("within_cooldown");
+    expect(transport.sent).toHaveLength(1);
+  });
+});

--- a/src/claw-loop-vnext/__tests__/regression-unknown-delivery.test.ts
+++ b/src/claw-loop-vnext/__tests__/regression-unknown-delivery.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import type { LoopTransport, SendMessageRequest, SendMessageResult } from "../transport/types.js";
+import { sendWithRetry } from "../transport/send-with-retry.js";
+
+class CaptureTransport implements LoopTransport {
+  readonly kind: "sdk" | "tmux";
+  readonly requests: SendMessageRequest[] = [];
+  private readonly results: SendMessageResult[];
+
+  constructor(kind: "sdk" | "tmux", results: SendMessageResult[]) {
+    this.kind = kind;
+    this.results = [...results];
+  }
+
+  async sendMessage(request: SendMessageRequest): Promise<SendMessageResult> {
+    this.requests.push(request);
+    return (
+      this.results.shift() ?? {
+        delivered: false,
+        transport: this.kind,
+        outputText: "",
+        reason: "exhausted",
+      }
+    );
+  }
+}
+
+describe("regression: unknown delivery / no ACK", () => {
+  it("retries with the same idempotency key and reports failure when ACK never arrives", async () => {
+    const primary = new CaptureTransport("sdk", [
+      { delivered: false, transport: "sdk", outputText: "", reason: "no-ack" },
+      { delivered: false, transport: "sdk", outputText: "", reason: "no-ack" },
+    ]);
+
+    const result = await sendWithRetry({
+      primary,
+      request: {
+        goalId: "goal-1",
+        workdir: "/tmp",
+        message: "phase prompt",
+        idempotencyKey: "idem-fixed",
+        ackTimeoutMs: 50,
+      },
+      maxRetries: 2,
+      onEvent: async () => {},
+    });
+
+    expect(result.delivered).toBe(false);
+    expect(primary.requests).toHaveLength(2);
+    expect(primary.requests[0].idempotencyKey).toBe("idem-fixed");
+    expect(primary.requests[1].idempotencyKey).toBe("idem-fixed");
+  });
+});

--- a/src/claw-loop-vnext/__tests__/runtime-store.test.ts
+++ b/src/claw-loop-vnext/__tests__/runtime-store.test.ts
@@ -1,0 +1,26 @@
+import { mkdtemp } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { RuntimeStore } from "../runtime-store.js";
+
+describe("RuntimeStore", () => {
+  it("tracks seen signal keys", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "claw-loop-vnext-state-"));
+    const store = new RuntimeStore(path.join(dir, "state.json"));
+
+    expect(await store.hasSeenSignal("goal-1", "phase_complete:P1")).toBe(false);
+    await store.markSignalSeen("goal-1", "phase_complete:P1");
+    expect(await store.hasSeenSignal("goal-1", "phase_complete:P1")).toBe(true);
+  });
+
+  it("records delivery by idempotency key", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "claw-loop-vnext-state-"));
+    const store = new RuntimeStore(path.join(dir, "state.json"));
+
+    await store.recordDelivery("goal-2", "idem-1", true, "sdk");
+    const state = await store.load("goal-2");
+    expect(state.lastDeliveryByIdempotencyKey["idem-1"]?.delivered).toBe(true);
+    expect(state.lastDeliveryByIdempotencyKey["idem-1"]?.transport).toBe("sdk");
+  });
+});

--- a/src/claw-loop-vnext/__tests__/send-with-retry.test.ts
+++ b/src/claw-loop-vnext/__tests__/send-with-retry.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import type { LoopTransport, SendMessageResult } from "../transport/types.js";
+import { sendWithRetry } from "../transport/send-with-retry.js";
+
+class StubTransport implements LoopTransport {
+  readonly kind: "sdk" | "tmux";
+  private readonly results: SendMessageResult[];
+
+  constructor(kind: "sdk" | "tmux", results: SendMessageResult[]) {
+    this.kind = kind;
+    this.results = [...results];
+  }
+
+  async sendMessage(): Promise<SendMessageResult> {
+    const next = this.results.shift();
+    if (!next) {
+      return { delivered: false, transport: this.kind, outputText: "", reason: "exhausted" };
+    }
+    return next;
+  }
+}
+
+describe("sendWithRetry", () => {
+  it("retries primary then falls back", async () => {
+    const events: string[] = [];
+    const primary = new StubTransport("sdk", [
+      { delivered: false, transport: "sdk", outputText: "", reason: "no ack" },
+      { delivered: false, transport: "sdk", outputText: "", reason: "no ack" },
+    ]);
+    const fallback = new StubTransport("tmux", [
+      { delivered: true, transport: "tmux", outputText: "PHASE_COMPLETE: P1", ackId: "a" },
+    ]);
+
+    const result = await sendWithRetry({
+      primary,
+      fallback,
+      request: {
+        goalId: "goal-1",
+        workdir: "/tmp",
+        message: "x",
+        idempotencyKey: "idem",
+        ackTimeoutMs: 100,
+      },
+      maxRetries: 2,
+      onEvent: async (event) => {
+        events.push(event.type);
+      },
+    });
+
+    expect(result.delivered).toBe(true);
+    expect(result.transport).toBe("tmux");
+    expect(events).toContain("transport_fallback");
+  });
+});

--- a/src/claw-loop-vnext/__tests__/signal-parser.test.ts
+++ b/src/claw-loop-vnext/__tests__/signal-parser.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { extractSignals } from "../signal-parser.js";
+
+describe("extractSignals", () => {
+  it("parses explicit signal lines only", () => {
+    const text = [
+      "some text",
+      "PHASE_COMPLETE: P2",
+      "PHASE_BLOCKED: missing env var",
+      "GOAL_COMPLETE",
+      "<promise>DONE: shipped</promise>",
+    ].join("\n");
+
+    const signals = extractSignals(text);
+    expect(signals.map((s) => s.type)).toEqual([
+      "phase_complete",
+      "phase_blocked",
+      "goal_complete",
+      "promise_done",
+    ]);
+  });
+
+  it("ignores instructional text", () => {
+    const text = "output exactly PHASE_COMPLETE: P1";
+    const signals = extractSignals(text);
+    expect(signals).toHaveLength(0);
+  });
+});

--- a/src/claw-loop-vnext/cli.ts
+++ b/src/claw-loop-vnext/cli.ts
@@ -1,0 +1,209 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { getCurrentPhase, loadGoalFile, saveGoalFile } from "./goal.js";
+import { sendCurrentPhasePrompt } from "./orchestrator.js";
+import { CodexExecSdkTransport } from "./transport/codex-exec-sdk.js";
+import { TmuxFallbackTransport } from "./transport/tmux-fallback.js";
+
+export type CliRunResult = {
+  exitCode: number;
+};
+
+type Action =
+  | "start"
+  | "check"
+  | "status"
+  | "prompt"
+  | "direct"
+  | "answer"
+  | "remind"
+  | "correct"
+  | "approve"
+  | "list";
+
+type ParsedArgs = {
+  action: Action;
+  goalFile?: string;
+  message?: string;
+  goalsDir: string;
+};
+
+function parseArgs(argv: string[]): ParsedArgs {
+  let action: Action = "check";
+  let goalFile: string | undefined;
+  let message: string | undefined;
+  const goalsDir = process.env.GOALS_DIR ?? path.join(process.env.HOME ?? ".", "clawd", "goals");
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (
+      arg === "start" ||
+      arg === "check" ||
+      arg === "status" ||
+      arg === "prompt" ||
+      arg === "direct" ||
+      arg === "answer" ||
+      arg === "remind" ||
+      arg === "correct" ||
+      arg === "approve" ||
+      arg === "list"
+    ) {
+      action = arg;
+      continue;
+    }
+
+    if (arg === "--goal") {
+      goalFile = argv[i + 1];
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith("--goal=")) {
+      goalFile = arg.slice("--goal=".length);
+      continue;
+    }
+    if (arg === "--msg" || arg === "--message") {
+      message = argv[i + 1];
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith("--msg=") || arg.startsWith("--message=")) {
+      const idx = arg.indexOf("=");
+      message = arg.slice(idx + 1);
+      continue;
+    }
+    if (!arg.startsWith("-")) {
+      message = message ? `${message} ${arg}` : arg;
+    }
+  }
+
+  return { action, goalFile, message, goalsDir };
+}
+
+async function listGoals(goalsDir: string): Promise<void> {
+  const files = await fs.readdir(goalsDir, { withFileTypes: true }).catch(() => []);
+  const goalFiles = files
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
+    .map((entry) => path.join(goalsDir, entry.name));
+
+  if (goalFiles.length === 0) {
+    // eslint-disable-next-line no-console
+    console.log("No goals found.");
+    return;
+  }
+
+  for (const file of goalFiles) {
+    const goal = await loadGoalFile(file).catch(() => null);
+    if (!goal) {
+      continue;
+    }
+    const current = getCurrentPhase(goal);
+    // eslint-disable-next-line no-console
+    console.log(
+      `${path.basename(file)} | ${goal.status} | ${current ? `${current.id}:${current.name}` : "done"} | awaitingApproval=${goal.awaitingApproval ?? "no"}`,
+    );
+  }
+}
+
+async function ensureGoalPath(goalFile: string | undefined): Promise<string> {
+  if (!goalFile) {
+    throw new Error("--goal is required");
+  }
+  await fs.access(goalFile);
+  return goalFile;
+}
+
+function buildDirective(label: string, message?: string): string {
+  return `${label}\n\n${message?.trim() || "Continue with the current phase."}\n\nOutput PHASE_COMPLETE when done.`;
+}
+
+export async function runClawLoopVNext(argv: string[]): Promise<CliRunResult> {
+  const parsed = parseArgs(argv);
+
+  if (parsed.action === "list") {
+    await listGoals(parsed.goalsDir);
+    return { exitCode: 0 };
+  }
+
+  if (parsed.action === "check") {
+    await listGoals(parsed.goalsDir);
+    return { exitCode: 0 };
+  }
+
+  const goalFile = await ensureGoalPath(parsed.goalFile);
+  const goal = await loadGoalFile(goalFile);
+
+  if (parsed.action === "status") {
+    const current = getCurrentPhase(goal);
+    // eslint-disable-next-line no-console
+    console.log(`Goal: ${goal.title}`);
+    // eslint-disable-next-line no-console
+    console.log(`Status: ${goal.status}`);
+    // eslint-disable-next-line no-console
+    console.log(`Current phase: ${current ? `${current.id} - ${current.name}` : "none"}`);
+    // eslint-disable-next-line no-console
+    console.log(`Awaiting approval: ${goal.awaitingApproval ?? "no"}`);
+    return { exitCode: 0 };
+  }
+
+  if (parsed.action === "approve") {
+    const next = { ...goal, awaitingApproval: undefined, status: "in_progress" as const };
+    await saveGoalFile(goalFile, next);
+    const mode = next.orchestration?.mode ?? "sdk-first";
+    const result = await sendCurrentPhasePrompt(
+      {
+        goalsDir: parsed.goalsDir,
+        primaryTransport: new CodexExecSdkTransport(),
+        fallbackTransport:
+          mode === "sdk-first" || mode === "bridge" ? new TmuxFallbackTransport() : undefined,
+      },
+      goalFile,
+    );
+    // eslint-disable-next-line no-console
+    console.log(
+      `approval recorded, delivery=${result.delivered} transport=${result.transport} ack=${result.ackId ?? "none"}`,
+    );
+    return { exitCode: result.delivered ? 0 : 1 };
+  }
+
+  if (goal.awaitingApproval && parsed.action === "prompt") {
+    // eslint-disable-next-line no-console
+    console.log(`Checkpoint pending for ${goal.awaitingApproval}. Run approve first.`);
+    return { exitCode: 2 };
+  }
+
+  if (parsed.action === "start" || parsed.action === "prompt") {
+    const next = { ...goal, status: "in_progress" as const };
+    await saveGoalFile(goalFile, next);
+  }
+
+  const mode = goal.orchestration?.mode ?? "sdk-first";
+  const result = await sendCurrentPhasePrompt(
+    {
+      goalsDir: parsed.goalsDir,
+      primaryTransport: new CodexExecSdkTransport(),
+      fallbackTransport:
+        mode === "sdk-first" || mode === "bridge" ? new TmuxFallbackTransport() : undefined,
+    },
+    goalFile,
+    parsed.action === "direct"
+      ? buildDirective("# Orchestrator Directive", parsed.message)
+      : parsed.action === "answer"
+        ? buildDirective("# Orchestrator Answer", parsed.message)
+        : parsed.action === "remind"
+          ? buildDirective("# Orchestrator Reminder", parsed.message)
+          : parsed.action === "correct"
+            ? buildDirective("# Orchestrator Correction", parsed.message)
+            : undefined,
+  );
+
+  // eslint-disable-next-line no-console
+  console.log(
+    `delivery=${result.delivered} transport=${result.transport} ack=${result.ackId ?? "none"}`,
+  );
+  for (const signal of result.signals) {
+    // eslint-disable-next-line no-console
+    console.log(`signal=${signal.type}`);
+  }
+
+  return { exitCode: result.delivered ? 0 : 1 };
+}

--- a/src/claw-loop-vnext/event-log.ts
+++ b/src/claw-loop-vnext/event-log.ts
@@ -1,0 +1,21 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import type { LoopEvent } from "./types.js";
+
+export async function appendEvent(logFile: string, event: LoopEvent): Promise<void> {
+  await fs.mkdir(path.dirname(logFile), { recursive: true });
+  await fs.appendFile(logFile, `${JSON.stringify(event)}\n`, "utf8");
+}
+
+export function createEvent(
+  goalId: string,
+  type: LoopEvent["type"],
+  data?: LoopEvent["data"],
+): LoopEvent {
+  return {
+    at: new Date().toISOString(),
+    goalId,
+    type,
+    data,
+  };
+}

--- a/src/claw-loop-vnext/goal.ts
+++ b/src/claw-loop-vnext/goal.ts
@@ -1,0 +1,169 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import type { GoalFile, GoalPhase, PhaseStatus } from "./types.js";
+
+type GoalPhaseInput = Partial<GoalPhase> & {
+  id?: string;
+  name?: string;
+  status?: PhaseStatus;
+  passes?: boolean;
+};
+
+type GoalInput = Omit<GoalFile, "phases"> & {
+  phases?: GoalPhaseInput[];
+};
+
+function normalizePhaseStatus(input: GoalPhaseInput): PhaseStatus {
+  if (input.status) {
+    return input.status;
+  }
+  if (typeof input.passes === "boolean") {
+    return input.passes ? "complete" : "pending";
+  }
+  return "pending";
+}
+
+function normalizePhase(input: GoalPhaseInput): GoalPhase {
+  const id = String(input.id ?? "").trim();
+  const name = String(input.name ?? "").trim();
+  if (!id || !name) {
+    throw new Error(`invalid phase: id and name are required (id=${id}, name=${name})`);
+  }
+
+  const status = normalizePhaseStatus(input);
+  const passes = status === "complete";
+
+  return {
+    id,
+    name,
+    status,
+    passes,
+    description: input.description,
+    prompt: input.prompt,
+    notes: input.notes,
+    verification: input.verification,
+    artifacts: input.artifacts,
+    requiresApproval: input.requiresApproval,
+  };
+}
+
+function normalizeGoal(input: GoalInput): GoalFile {
+  if (!input.title?.trim()) {
+    throw new Error("goal.title is required");
+  }
+  if (!input.workdir?.trim()) {
+    throw new Error("goal.workdir is required");
+  }
+  const phases = (input.phases ?? []).map(normalizePhase);
+  if (phases.length === 0) {
+    throw new Error("goal.phases must include at least one phase");
+  }
+
+  return {
+    title: input.title,
+    workdir: input.workdir,
+    tool: input.tool ?? "codex",
+    status: input.status ?? "pending",
+    phases,
+    infiniteLoop: Boolean(input.infiniteLoop),
+    session: input.session,
+    awaitingApproval: input.awaitingApproval,
+    orchestration: input.orchestration,
+  };
+}
+
+export async function loadGoalFile(goalFile: string): Promise<GoalFile> {
+  const raw = await fs.readFile(goalFile, "utf8");
+  const parsed = JSON.parse(raw) as GoalInput;
+  return normalizeGoal(parsed);
+}
+
+export async function saveGoalFile(goalFile: string, goal: GoalFile): Promise<void> {
+  const next = {
+    ...goal,
+    phases: goal.phases.map((phase) => ({
+      ...phase,
+      status: phase.status,
+      passes: phase.status === "complete",
+    })),
+  };
+  await fs.mkdir(path.dirname(goalFile), { recursive: true });
+  await fs.writeFile(goalFile, `${JSON.stringify(next, null, 2)}\n`, "utf8");
+}
+
+export function getCurrentPhase(goal: GoalFile): GoalPhase | undefined {
+  return goal.phases.find((phase) => phase.status !== "complete");
+}
+
+export function updatePhaseStatus(goal: GoalFile, phaseId: string, status: PhaseStatus): GoalFile {
+  const phases = goal.phases.map((phase) => {
+    if (phase.id !== phaseId) {
+      return phase;
+    }
+    return {
+      ...phase,
+      status,
+      passes: status === "complete",
+    };
+  });
+
+  const allComplete = phases.every((phase) => phase.status === "complete");
+  return {
+    ...goal,
+    phases,
+    status: allComplete ? "complete" : goal.status,
+  };
+}
+
+export function buildPhasePrompt(goal: GoalFile, phase: GoalPhase): string {
+  const artifacts = phase.artifacts?.length ? phase.artifacts.join(", ") : "(none)";
+  const verification = phase.verification ?? "(none)";
+  const notes = phase.notes?.trim();
+  const instructions = phase.prompt?.trim();
+
+  const lines = [
+    `# Phase: ${phase.id} - ${phase.name}`,
+    "",
+    phase.description?.trim() || "",
+    "",
+    "## Expected Artifacts",
+    artifacts,
+    "",
+    "## Verification Criteria",
+    verification,
+  ];
+
+  if (instructions) {
+    lines.push("", "## Instructions", instructions);
+  }
+  if (notes) {
+    lines.push("", "## Notes from previous phases", notes);
+  }
+
+  lines.push(
+    "",
+    "---",
+    "**Completion signals** (output on its own line when ready):",
+    `- Done: \`PHASE_COMPLETE: ${phase.id}\``,
+    "- Blocked: `PHASE_BLOCKED: your reason here`",
+    "",
+    "Start now.",
+  );
+
+  return lines.join("\n");
+}
+
+export function ensureApprovalGate(goal: GoalFile, completedPhaseId: string): GoalFile {
+  const completed = goal.phases.find((phase) => phase.id === completedPhaseId);
+  if (!completed?.requiresApproval) {
+    return { ...goal, awaitingApproval: undefined };
+  }
+  const next = getCurrentPhase(goal);
+  if (!next) {
+    return goal;
+  }
+  return {
+    ...goal,
+    awaitingApproval: next.id,
+  };
+}

--- a/src/claw-loop-vnext/orchestrator.ts
+++ b/src/claw-loop-vnext/orchestrator.ts
@@ -1,0 +1,181 @@
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+import type { LoopTransport } from "./transport/types.js";
+import type { GoalFile, Signal } from "./types.js";
+import { appendEvent, createEvent } from "./event-log.js";
+import {
+  buildPhasePrompt,
+  ensureApprovalGate,
+  getCurrentPhase,
+  loadGoalFile,
+  saveGoalFile,
+  updatePhaseStatus,
+} from "./goal.js";
+import { RuntimeStore } from "./runtime-store.js";
+import { extractSignals } from "./signal-parser.js";
+import { sendWithRetry } from "./transport/send-with-retry.js";
+
+export type OrchestratorDeps = {
+  primaryTransport: LoopTransport;
+  fallbackTransport?: LoopTransport;
+  goalsDir: string;
+};
+
+export type HandleResult = {
+  goal: GoalFile;
+  delivered: boolean;
+  transport: string;
+  ackId?: string;
+  signals: Signal[];
+  outputText: string;
+};
+
+function goalIdFromFile(goalFile: string): string {
+  return path.basename(goalFile, ".json");
+}
+
+function runtimePaths(goalsDir: string, goalId: string) {
+  return {
+    eventLogFile: path.join(goalsDir, ".runtime", `${goalId}.events.jsonl`),
+    stateFile: path.join(goalsDir, ".runtime", `${goalId}.state.json`),
+  };
+}
+
+async function processSignals(params: {
+  goal: GoalFile;
+  goalFile: string;
+  goalId: string;
+  signals: Signal[];
+  store: RuntimeStore;
+  eventLogFile: string;
+}): Promise<GoalFile> {
+  let goal = params.goal;
+
+  for (const signal of params.signals) {
+    const seen = await params.store.hasSeenSignal(params.goalId, signal.dedupeKey);
+    if (seen) {
+      await appendEvent(
+        params.eventLogFile,
+        createEvent(params.goalId, "signal_deduped", {
+          dedupeKey: signal.dedupeKey,
+          type: signal.type,
+        }),
+      );
+      continue;
+    }
+
+    await params.store.markSignalSeen(params.goalId, signal.dedupeKey);
+    await appendEvent(
+      params.eventLogFile,
+      createEvent(params.goalId, "signal_seen", { dedupeKey: signal.dedupeKey, type: signal.type }),
+    );
+
+    if (signal.type === "phase_complete") {
+      goal = updatePhaseStatus(goal, signal.phaseId, "complete");
+      goal = ensureApprovalGate(goal, signal.phaseId);
+      await appendEvent(
+        params.eventLogFile,
+        createEvent(params.goalId, "phase_advanced", {
+          phaseId: signal.phaseId,
+          status: "complete",
+        }),
+      );
+      continue;
+    }
+
+    if (signal.type === "phase_blocked") {
+      const current = getCurrentPhase(goal);
+      if (current) {
+        goal = updatePhaseStatus(goal, current.id, "blocked");
+      }
+      goal.status = "blocked";
+      continue;
+    }
+
+    if (signal.type === "goal_complete" || signal.type === "promise_done") {
+      goal.status = "complete";
+    }
+  }
+
+  await saveGoalFile(params.goalFile, goal);
+  return goal;
+}
+
+export async function sendCurrentPhasePrompt(
+  deps: OrchestratorDeps,
+  goalFile: string,
+  messageOverride?: string,
+): Promise<HandleResult> {
+  const goalId = goalIdFromFile(goalFile);
+  const goal = await loadGoalFile(goalFile);
+  const { eventLogFile, stateFile } = runtimePaths(deps.goalsDir, goalId);
+  const store = new RuntimeStore(stateFile);
+
+  const current = getCurrentPhase(goal);
+  const message = messageOverride ?? (current ? buildPhasePrompt(goal, current) : "");
+  if (!message.trim()) {
+    return {
+      goal,
+      delivered: false,
+      transport: deps.primaryTransport.kind,
+      signals: [],
+      outputText: "",
+    };
+  }
+
+  const idempotencyKey = randomUUID();
+  const ackTimeoutMs = goal.orchestration?.ackTimeoutMs ?? 15_000;
+  const maxRetries = goal.orchestration?.maxRetries ?? 2;
+
+  const sendResult = await sendWithRetry({
+    primary: deps.primaryTransport,
+    fallback: deps.fallbackTransport,
+    request: {
+      goalId,
+      workdir: goal.workdir,
+      message,
+      idempotencyKey,
+      ackTimeoutMs,
+      sessionName: goal.session,
+    },
+    maxRetries,
+    onEvent: async (event) => appendEvent(eventLogFile, event),
+  });
+
+  await store.recordDelivery(goalId, idempotencyKey, sendResult.delivered, sendResult.transport);
+  await appendEvent(
+    eventLogFile,
+    createEvent(goalId, "goal_updated", {
+      delivery: sendResult.delivered,
+      transport: sendResult.transport,
+      ackId: sendResult.ackId,
+    }),
+  );
+
+  const signals = extractSignals(sendResult.outputText);
+  const nextGoal = await processSignals({
+    goal,
+    goalFile,
+    goalId,
+    signals,
+    store,
+    eventLogFile,
+  });
+
+  return {
+    goal: nextGoal,
+    delivered: sendResult.delivered,
+    transport: sendResult.transport,
+    ackId: sendResult.ackId,
+    signals,
+    outputText: sendResult.outputText,
+  };
+}
+
+export async function approveNextPhase(goalFile: string): Promise<GoalFile> {
+  const goal = await loadGoalFile(goalFile);
+  return {
+    ...goal,
+    awaitingApproval: undefined,
+  };
+}

--- a/src/claw-loop-vnext/runtime-store.ts
+++ b/src/claw-loop-vnext/runtime-store.ts
@@ -1,0 +1,73 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import type { RuntimeState } from "./types.js";
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function defaultState(goalId: string): RuntimeState {
+  return {
+    goalId,
+    lastDeliveryByIdempotencyKey: {},
+    seenSignalKeys: {},
+    updatedAt: nowIso(),
+  };
+}
+
+export class RuntimeStore {
+  private readonly stateFile: string;
+
+  constructor(stateFile: string) {
+    this.stateFile = stateFile;
+  }
+
+  async load(goalId: string): Promise<RuntimeState> {
+    try {
+      const raw = await fs.readFile(this.stateFile, "utf8");
+      const parsed = JSON.parse(raw) as RuntimeState;
+      return {
+        ...defaultState(goalId),
+        ...parsed,
+        goalId,
+      };
+    } catch {
+      return defaultState(goalId);
+    }
+  }
+
+  async save(state: RuntimeState): Promise<void> {
+    const next: RuntimeState = {
+      ...state,
+      updatedAt: nowIso(),
+    };
+    await fs.mkdir(path.dirname(this.stateFile), { recursive: true });
+    await fs.writeFile(this.stateFile, `${JSON.stringify(next, null, 2)}\n`, "utf8");
+  }
+
+  async recordDelivery(
+    goalId: string,
+    idempotencyKey: string,
+    delivered: boolean,
+    transport: string,
+  ): Promise<void> {
+    const state = await this.load(goalId);
+    state.lastDeliveryByIdempotencyKey[idempotencyKey] = {
+      delivered,
+      transport,
+      at: nowIso(),
+    };
+    await this.save(state);
+  }
+
+  async hasSeenSignal(goalId: string, dedupeKey: string): Promise<boolean> {
+    const state = await this.load(goalId);
+    return Boolean(state.seenSignalKeys[dedupeKey]);
+  }
+
+  async markSignalSeen(goalId: string, dedupeKey: string): Promise<void> {
+    const state = await this.load(goalId);
+    state.seenSignalKeys[dedupeKey] = nowIso();
+    await this.save(state);
+  }
+}

--- a/src/claw-loop-vnext/runtime-store.ts
+++ b/src/claw-loop-vnext/runtime-store.ts
@@ -57,6 +57,29 @@ export class RuntimeStore {
       transport,
       at: nowIso(),
     };
+    state.lastActivityAt = nowIso();
+    await this.save(state);
+  }
+
+  async touchActivity(goalId: string): Promise<void> {
+    const state = await this.load(goalId);
+    state.lastActivityAt = nowIso();
+    await this.save(state);
+  }
+
+  async getLastActivityAt(goalId: string): Promise<string | undefined> {
+    const state = await this.load(goalId);
+    return state.lastActivityAt;
+  }
+
+  async getLastNudgeAt(goalId: string): Promise<string | undefined> {
+    const state = await this.load(goalId);
+    return state.lastNudgeAt;
+  }
+
+  async markNudgeSent(goalId: string): Promise<void> {
+    const state = await this.load(goalId);
+    state.lastNudgeAt = nowIso();
     await this.save(state);
   }
 

--- a/src/claw-loop-vnext/signal-parser.ts
+++ b/src/claw-loop-vnext/signal-parser.ts
@@ -1,0 +1,61 @@
+import type { Signal } from "./types.js";
+
+function normalizeReason(reason: string): string {
+  return reason.trim().replace(/\s+/g, " ");
+}
+
+function signalKey(type: Signal["type"], value: string): string {
+  return `${type}:${value}`;
+}
+
+export function extractSignals(text: string): Signal[] {
+  const out: Signal[] = [];
+  const lines = text.split(/\r?\n/);
+
+  for (const line of lines) {
+    const phaseComplete = line.match(/^\s*PHASE_COMPLETE:\s*([A-Za-z0-9_\-.]+)\s*$/);
+    if (phaseComplete) {
+      const phaseId = phaseComplete[1];
+      out.push({
+        type: "phase_complete",
+        phaseId,
+        raw: line,
+        dedupeKey: signalKey("phase_complete", phaseId),
+      });
+      continue;
+    }
+
+    const phaseBlocked = line.match(/^\s*PHASE_BLOCKED:\s*(.+)$/);
+    if (phaseBlocked) {
+      const reason = normalizeReason(phaseBlocked[1]);
+      out.push({
+        type: "phase_blocked",
+        reason,
+        raw: line,
+        dedupeKey: signalKey("phase_blocked", reason),
+      });
+      continue;
+    }
+
+    const goalComplete = line.match(/^\s*GOAL_COMPLETE\s*$/);
+    if (goalComplete) {
+      out.push({
+        type: "goal_complete",
+        raw: line,
+        dedupeKey: signalKey("goal_complete", "1"),
+      });
+      continue;
+    }
+
+    const promiseDone = line.match(/^\s*<promise>\s*DONE(?::|\b).*<\/promise>\s*$/i);
+    if (promiseDone) {
+      out.push({
+        type: "promise_done",
+        raw: line,
+        dedupeKey: signalKey("promise_done", "1"),
+      });
+    }
+  }
+
+  return out;
+}

--- a/src/claw-loop-vnext/transport/codex-exec-sdk.ts
+++ b/src/claw-loop-vnext/transport/codex-exec-sdk.ts
@@ -1,0 +1,135 @@
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import type { LoopTransport, SendMessageRequest, SendMessageResult } from "./types.js";
+
+type JsonEvent = Record<string, unknown>;
+
+function toAckId(event: JsonEvent): string {
+  const idCandidate = event.id;
+  if (typeof idCandidate === "string" && idCandidate.trim()) {
+    return idCandidate;
+  }
+  const digest = createHash("sha256").update(JSON.stringify(event)).digest("hex");
+  return digest.slice(0, 16);
+}
+
+function extractTextFromEvent(event: JsonEvent): string | undefined {
+  const text = event.text;
+  if (typeof text === "string") {
+    return text;
+  }
+
+  const message = event.message;
+  if (typeof message === "string") {
+    return message;
+  }
+
+  const content = event.content;
+  if (typeof content === "string") {
+    return content;
+  }
+
+  return undefined;
+}
+
+export class CodexExecSdkTransport implements LoopTransport {
+  readonly kind = "sdk" as const;
+
+  async sendMessage(request: SendMessageRequest): Promise<SendMessageResult> {
+    const args = [
+      "exec",
+      "--json",
+      "--cd",
+      request.workdir,
+      "--sandbox",
+      "danger-full-access",
+      "--ask-for-approval",
+      "never",
+      "-",
+    ];
+
+    const child = spawn("codex", args, {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: {
+        ...process.env,
+        CLAW_LOOP_IDEMPOTENCY_KEY: request.idempotencyKey,
+      },
+    });
+
+    const outputText: string[] = [];
+    const stderrText: string[] = [];
+    let delivered = false;
+    let ackId: string | undefined;
+
+    let stdoutBuffer = "";
+    const ackTimer = setTimeout(() => {
+      if (!delivered) {
+        child.kill("SIGTERM");
+      }
+    }, request.ackTimeoutMs);
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdoutBuffer += chunk.toString("utf8");
+      while (true) {
+        const idx = stdoutBuffer.indexOf("\n");
+        if (idx < 0) {
+          break;
+        }
+        const line = stdoutBuffer.slice(0, idx).trim();
+        stdoutBuffer = stdoutBuffer.slice(idx + 1);
+        if (!line) {
+          continue;
+        }
+        try {
+          const event = JSON.parse(line) as JsonEvent;
+          if (!delivered) {
+            delivered = true;
+            ackId = toAckId(event);
+          }
+          const text = extractTextFromEvent(event);
+          if (text) {
+            outputText.push(text);
+          }
+        } catch {
+          // If codex prints plain text unexpectedly, keep it for downstream parsing.
+          outputText.push(line);
+          if (!delivered) {
+            delivered = true;
+            ackId = createHash("sha1").update(line).digest("hex").slice(0, 16);
+          }
+        }
+      }
+    });
+
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderrText.push(chunk.toString("utf8"));
+    });
+
+    child.stdin.write(request.message);
+    child.stdin.end();
+
+    const exitCode = await new Promise<number | null>((resolve) => {
+      child.on("close", (code) => resolve(code));
+    });
+
+    clearTimeout(ackTimer);
+
+    const stderr = stderrText.join("").trim();
+    if (!delivered) {
+      return {
+        delivered: false,
+        transport: this.kind,
+        outputText: outputText.join("\n"),
+        reason: stderr || `codex exec exited before ACK (code=${String(exitCode)})`,
+      };
+    }
+
+    return {
+      delivered: true,
+      transport: this.kind,
+      ackId,
+      outputText: outputText.join("\n"),
+      reason: exitCode === 0 ? undefined : stderr || `codex exec exit code ${String(exitCode)}`,
+    };
+  }
+}

--- a/src/claw-loop-vnext/transport/send-with-retry.ts
+++ b/src/claw-loop-vnext/transport/send-with-retry.ts
@@ -1,0 +1,59 @@
+import type { LoopEvent } from "../types.js";
+import type { LoopTransport, SendMessageRequest, SendMessageResult } from "./types.js";
+
+export type SendWithRetryParams = {
+  primary: LoopTransport;
+  fallback?: LoopTransport;
+  request: SendMessageRequest;
+  maxRetries: number;
+  onEvent: (event: LoopEvent) => Promise<void>;
+};
+
+export async function sendWithRetry(params: SendWithRetryParams): Promise<SendMessageResult> {
+  const { primary, fallback, request, maxRetries, onEvent } = params;
+
+  for (let attempt = 1; attempt <= Math.max(1, maxRetries); attempt += 1) {
+    await onEvent({
+      at: new Date().toISOString(),
+      goalId: request.goalId,
+      type: "message_send_attempt",
+      data: { attempt, transport: primary.kind, idempotencyKey: request.idempotencyKey },
+    });
+
+    const primaryResult = await primary.sendMessage(request);
+    if (primaryResult.delivered) {
+      await onEvent({
+        at: new Date().toISOString(),
+        goalId: request.goalId,
+        type: "message_send_ack",
+        data: { transport: primary.kind, ackId: primaryResult.ackId, attempt },
+      });
+      return primaryResult;
+    }
+
+    await onEvent({
+      at: new Date().toISOString(),
+      goalId: request.goalId,
+      type: "message_send_failed",
+      data: { transport: primary.kind, reason: primaryResult.reason, attempt },
+    });
+  }
+
+  if (!fallback) {
+    return {
+      delivered: false,
+      transport: primary.kind,
+      outputText: "",
+      reason: "primary transport failed and no fallback is configured",
+    };
+  }
+
+  await onEvent({
+    at: new Date().toISOString(),
+    goalId: request.goalId,
+    type: "transport_fallback",
+    data: { from: primary.kind, to: fallback.kind },
+  });
+
+  return fallback.sendMessage(request);
+}

--- a/src/claw-loop-vnext/transport/tmux-fallback.ts
+++ b/src/claw-loop-vnext/transport/tmux-fallback.ts
@@ -1,0 +1,71 @@
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import { promisify } from "node:util";
+import type { LoopTransport, SendMessageRequest, SendMessageResult } from "./types.js";
+
+const execFileAsync = promisify(execFile);
+
+async function tmux(...args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync("tmux", args, {
+    maxBuffer: 1024 * 1024,
+  });
+  return stdout;
+}
+
+export class TmuxFallbackTransport implements LoopTransport {
+  readonly kind = "tmux" as const;
+
+  async sendMessage(request: SendMessageRequest): Promise<SendMessageResult> {
+    const sessionName = request.sessionName || `claw-${request.goalId}`;
+
+    try {
+      await tmux("has-session", "-t", sessionName);
+    } catch {
+      try {
+        const payload = [
+          "command -v codex >/dev/null 2>&1 || { echo '[claw-loop-vnext] codex not found'; exec bash; }",
+          "codex -a never -s danger-full-access",
+          "ec=$?",
+          "echo",
+          'echo "[claw-loop-vnext] codex exited with code: ${ec}"',
+          "exec bash",
+        ].join("; ");
+        await tmux(
+          "new-session",
+          "-d",
+          "-s",
+          sessionName,
+          "-c",
+          request.workdir,
+          `bash -lc '${payload}'`,
+        );
+        await new Promise((resolve) => setTimeout(resolve, 1200));
+      } catch (error) {
+        return {
+          delivered: false,
+          transport: this.kind,
+          outputText: "",
+          reason: `failed creating tmux session ${sessionName}: ${String(error)}`,
+        };
+      }
+    }
+
+    const before = await tmux("capture-pane", "-t", sessionName, "-p", "-S", "-120");
+    await tmux("set-buffer", "--", request.message);
+    await tmux("paste-buffer", "-t", sessionName);
+    await tmux("send-keys", "-t", sessionName, "Enter");
+
+    await new Promise((resolve) => setTimeout(resolve, Math.min(request.ackTimeoutMs, 2000)));
+
+    const after = await tmux("capture-pane", "-t", sessionName, "-p", "-S", "-180");
+    const delivered = after !== before;
+
+    return {
+      delivered,
+      transport: this.kind,
+      ackId: delivered ? createHash("sha1").update(after).digest("hex").slice(0, 16) : undefined,
+      outputText: after,
+      reason: delivered ? undefined : "tmux pane output did not change after send",
+    };
+  }
+}

--- a/src/claw-loop-vnext/transport/types.ts
+++ b/src/claw-loop-vnext/transport/types.ts
@@ -1,0 +1,21 @@
+export type SendMessageRequest = {
+  goalId: string;
+  workdir: string;
+  message: string;
+  idempotencyKey: string;
+  ackTimeoutMs: number;
+  sessionName?: string;
+};
+
+export type SendMessageResult = {
+  delivered: boolean;
+  transport: "sdk" | "tmux";
+  ackId?: string;
+  outputText: string;
+  reason?: string;
+};
+
+export interface LoopTransport {
+  readonly kind: "sdk" | "tmux";
+  sendMessage(request: SendMessageRequest): Promise<SendMessageResult>;
+}

--- a/src/claw-loop-vnext/types.ts
+++ b/src/claw-loop-vnext/types.ts
@@ -1,0 +1,62 @@
+export type PhaseStatus = "pending" | "in_progress" | "complete" | "blocked";
+
+export type GoalPhase = {
+  id: string;
+  name: string;
+  status: PhaseStatus;
+  passes: boolean;
+  description?: string;
+  prompt?: string;
+  notes?: string;
+  verification?: string;
+  artifacts?: string[];
+  requiresApproval?: boolean;
+};
+
+export type GoalFile = {
+  title: string;
+  workdir: string;
+  tool?: string;
+  status: "pending" | "in_progress" | "complete" | "blocked";
+  phases: GoalPhase[];
+  infiniteLoop?: boolean;
+  session?: string;
+  awaitingApproval?: string;
+  orchestration?: {
+    mode?: "bridge" | "sdk-first";
+    ackTimeoutMs?: number;
+    maxRetries?: number;
+  };
+};
+
+export type Signal =
+  | { type: "phase_complete"; phaseId: string; raw: string; dedupeKey: string }
+  | { type: "phase_blocked"; reason: string; raw: string; dedupeKey: string }
+  | { type: "goal_complete"; raw: string; dedupeKey: string }
+  | { type: "promise_done"; raw: string; dedupeKey: string };
+
+export type RuntimeState = {
+  goalId: string;
+  lastDeliveryByIdempotencyKey: Record<
+    string,
+    { delivered: boolean; transport: string; at: string }
+  >;
+  seenSignalKeys: Record<string, string>;
+  lastOutputDigest?: string;
+  updatedAt: string;
+};
+
+export type LoopEvent = {
+  at: string;
+  goalId: string;
+  type:
+    | "message_send_attempt"
+    | "message_send_ack"
+    | "message_send_failed"
+    | "transport_fallback"
+    | "signal_seen"
+    | "signal_deduped"
+    | "phase_advanced"
+    | "goal_updated";
+  data?: Record<string, unknown>;
+};

--- a/src/claw-loop-vnext/types.ts
+++ b/src/claw-loop-vnext/types.ts
@@ -43,6 +43,8 @@ export type RuntimeState = {
   >;
   seenSignalKeys: Record<string, string>;
   lastOutputDigest?: string;
+  lastActivityAt?: string;
+  lastNudgeAt?: string;
   updatedAt: string;
 };
 
@@ -57,6 +59,8 @@ export type LoopEvent = {
     | "signal_seen"
     | "signal_deduped"
     | "phase_advanced"
-    | "goal_updated";
+    | "goal_updated"
+    | "stuck_nudge_sent"
+    | "stuck_nudge_skipped";
   data?: Record<string, unknown>;
 };


### PR DESCRIPTION
## Summary

- Problem: existing claw-loop orchestration depends on tmux keystroke delivery where Enter can be eaten, causing silent non-delivery and flaky phase advancement.
- Why it matters: unreliable prompt delivery breaks deterministic phase progression and operator trust.
- What changed: added `claw-loop-vnext` Bridge implementation with SDK-first delivery (`codex exec --json` ACK), retry, idempotency-key continuity, conservative signal dedupe, structured JSONL event log, runtime state store, tmux fallback, and stuck single-nudge cooldown.
- What did NOT change (scope boundary): original claw-loop contract/UX remains (phases -> review -> execute); no SQLite runtime store yet; no full scheduler-driven heartbeat orchestration yet.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [x] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- New skill path: `skills/claw-loop-vnext/`
- New wrapper command compatible with existing workflow: `skills/claw-loop-vnext/claw-loop.sh ...`
- Goal phase compatibility: supports both `.phases[].status` (canonical) and legacy `.phases[].passes`.
- New runtime artifacts:
  - `~/clawd/goals/.runtime/<goal>.events.jsonl`
  - `~/clawd/goals/.runtime/<goal>.state.json`

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No (uses existing local `codex` CLI invocation path)
- Command/tool execution surface changed? (`Yes/No`): Yes
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:
  - Execution surface changed by adding a new local orchestration command path; mitigated by preserving explicit operator-triggered actions, deterministic retry/fallback behavior, and test coverage for no-ACK/dup/stuck regressions.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+, pnpm
- Model/provider: Codex CLI (`codex exec --json`) for SDK-first bridge
- Integration/channel (if any): N/A
- Relevant config (redacted): default local workspace; optional `orchestration.mode` in goal JSON

### Steps

1. Run dry-run demo:
   - `node --import tsx scripts/claw-loop-vnext-dry-run.ts`
2. Run vNext test suite:
   - `pnpm exec vitest run src/claw-loop-vnext/__tests__/goal.test.ts src/claw-loop-vnext/__tests__/signal-parser.test.ts src/claw-loop-vnext/__tests__/runtime-store.test.ts src/claw-loop-vnext/__tests__/send-with-retry.test.ts src/claw-loop-vnext/__tests__/orchestrator.dedupe.test.ts src/claw-loop-vnext/__tests__/regression-unknown-delivery.test.ts src/claw-loop-vnext/__tests__/integration-mocked-driver.test.ts src/claw-loop-vnext/__tests__/regression-stuck-single-nudge.test.ts`
3. Check command compatibility:
   - `node --import tsx scripts/claw-loop-vnext.ts list`

### Expected

- Demo: fallback delivery succeeds after simulated no-ACK, duplicate `PHASE_COMPLETE` only advances once, stuck nudge is sent once then cooldown suppresses repeat.
- Tests: all pass.

### Actual

- Demo output showed:
  - `delivery true tmux demo-ack`
  - `signals phase_complete,phase_complete`
  - `nudge { nudged: true, reason: 'sent' } { nudged: false, reason: 'within_cooldown' }`
- Tests passed:
  - `Test Files 8 passed (8)`
  - `Tests 12 passed (12)`

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What I personally verified (not just CI), and how:

- Verified scenarios:
  - Unknown delivery/no ACK retries with same idempotency key and safe fallback behavior.
  - Duplicate outputs/repeated `PHASE_COMPLETE` do not double-advance phase.
  - Stuck detection emits one nudge and respects cooldown.
  - Wrapper/list commands run successfully.
- Edge cases checked:
  - Legacy `passes` + canonical `status` compatibility and write-back behavior.
- What you did **not** verify:
  - Full remote CI on this branch before PR merge (local verification only in this run).

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No required changes
- Migration needed? (`Yes/No`): No (optional rollout)
- If yes, exact upgrade steps:
  - Optional rollout:
    1. `orchestration.mode=bridge`
    2. `orchestration.mode=sdk-first`
    3. SDK-only (future, after confidence window)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Use existing legacy claw-loop path (`~/clawd/skills/claw-loop/claw-loop.sh`) and stop invoking vNext wrapper.
- Files/config to restore:
  - Revert `skills/claw-loop-vnext/*`, `scripts/claw-loop-vnext*.ts`, `src/claw-loop-vnext/*`.
- Known bad symptoms reviewers should watch for:
  - Persistent `delivery=false` with no fallback ACK
  - Repeated phase advancement from duplicate signals
  - Excessive nudge spam (cooldown regression)

## Risks and Mitigations

- Risk: `codex exec --json` semantics could drift from expected ACK behavior.
  - Mitigation: transport abstraction + fallback path + explicit tests for no-ACK/fallback.
- Risk: runtime state JSON corruption could impact dedupe/nudge state.
  - Mitigation: conservative defaults and deterministic behavior on missing state.

## What Changed (requested)

- Added `claw-loop-vnext` implementation with:
  - SDK-first send path (`codex exec --json`)
  - ACK/verification + retry + fallback
  - idempotency key propagation across retries/fallback
  - conservative signal dedupe
  - event log + runtime state store
  - stuck single-nudge cooldown
  - docs and demo script

## How To Run Demo (requested)

```bash
node --import tsx scripts/claw-loop-vnext-dry-run.ts
```

## How To Run Tests (requested)

```bash
pnpm exec vitest run \
  src/claw-loop-vnext/__tests__/goal.test.ts \
  src/claw-loop-vnext/__tests__/signal-parser.test.ts \
  src/claw-loop-vnext/__tests__/runtime-store.test.ts \
  src/claw-loop-vnext/__tests__/send-with-retry.test.ts \
  src/claw-loop-vnext/__tests__/orchestrator.dedupe.test.ts \
  src/claw-loop-vnext/__tests__/regression-unknown-delivery.test.ts \
  src/claw-loop-vnext/__tests__/integration-mocked-driver.test.ts \
  src/claw-loop-vnext/__tests__/regression-stuck-single-nudge.test.ts
```

## Known Limitations (requested)

- Bridge uses `codex exec --json` as pragmatic ACK source, not a dedicated embedded SDK session API yet.
- Runtime store is JSON-backed in this slice (SQLite deferred).
- `check` scheduling/tick loop is partial; full autonomous heartbeat orchestration remains future work.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds comprehensive vNext SDK-first orchestration driver with retry, deduplication, and stuck detection to improve reliability over tmux-only approach.

**Key improvements:**
- SDK-first delivery with `codex exec --json` ACK verification prevents silent message loss
- Retry logic with idempotency key continuity across attempts and fallback paths
- Conservative signal deduplication prevents double phase advancement
- Single-nudge stuck detection with cooldown prevents spam
- JSONL event log and runtime state store enable debugging and recovery
- Comprehensive test coverage including regression tests for historical bugs

**Implementation quality:**
- Well-structured transport abstraction with `LoopTransport` interface
- Proper separation of concerns across orchestrator, runtime-store, event-log, signal-parser modules
- Deterministic behavior with proper state management
- Backward compatible with legacy `passes` field while preferring canonical `status`

**Testing:**
- 8 test files with 12 tests covering core functionality, regression scenarios, and integration paths
- Tests verify retry behavior, deduplication, stuck detection cooldown, and fallback switching

<h3>Confidence Score: 5/5</h3>

- Safe to merge - well-architected additive feature with comprehensive test coverage and no breaking changes
- All new code is additive (new directory `src/claw-loop-vnext/`), preserves backward compatibility, has comprehensive test coverage (8 test files, 12 tests including regression tests), follows existing TypeScript patterns, includes proper error handling and fallback paths, and maintains clear separation of concerns. The implementation addresses a real reliability issue (tmux keystroke delivery) with a pragmatic SDK-first approach. No security issues identified - uses standard subprocess execution with proper argument handling and no user input injection paths.
- No files require special attention - all implementation and test files follow consistent patterns

<sub>Last reviewed commit: abe4f00</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->