### PR TITLE
feat(memory-lancedb): improve Chinese auto-capture and category detection

### DIFF
--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -100,6 +100,8 @@ describe("memory plugin e2e", () => {
     expect(shouldCapture("My email is test@example.com")).toBe(true);
     expect(shouldCapture("Call me at +1234567890123")).toBe(true);
     expect(shouldCapture("I always want verbose output")).toBe(true);
+    expect(shouldCapture("请记住我喜欢深色模式")).toBe(true);
+    expect(shouldCapture("我决定以后都用 TypeScript")).toBe(true);
     expect(shouldCapture("x")).toBe(false);
     expect(shouldCapture("<relevant-memories>injected</relevant-memories>")).toBe(false);
     expect(shouldCapture("<system>status</system>")).toBe(false);
@@ -113,6 +115,10 @@ describe("memory plugin e2e", () => {
     expect(detectCategory("We decided to use React")).toBe("decision");
     expect(detectCategory("My email is test@example.com")).toBe("entity");
     expect(detectCategory("The server is running on port 3000")).toBe("fact");
+    expect(detectCategory("我喜欢深色模式")).toBe("preference");
+    expect(detectCategory("我们决定以后都用 React")).toBe("decision");
+    expect(detectCategory("我叫小明")).toBe("entity");
+    expect(detectCategory("服务器状态是正常")).toBe("fact");
     expect(detectCategory("Random note")).toBe("other");
   });
 });

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -186,6 +186,11 @@ const MEMORY_TRIGGERS = [
   /zapamatuj si|pamatuj|remember/i,
   /preferuji|radši|nechci|prefer/i,
   /rozhodli jsme|budeme používat/i,
+  /记住|记得|请记|别忘|不要忘/,
+  /我喜欢|我偏好|我讨厌|我不喜欢|我爱|我想要|我需要/,
+  /我决定|我们决定|就这么定|以后都|以后用/,
+  /我的.+是|是我的|我叫|我是/,
+  /重要|总是|从不|一定要|必须|千万/,
   /\+\d{10,}/,
   /[\w.-]+@[\w.-]+\.\w+/,
   /můj\s+\w+\s+je|je\s+můj/i,
@@ -220,16 +225,16 @@ export function shouldCapture(text: string): boolean {
 
 export function detectCategory(text: string): MemoryCategory {
   const lower = text.toLowerCase();
-  if (/prefer|radši|like|love|hate|want/i.test(lower)) {
+  if (/prefer|radši|like|love|hate|want|喜欢|偏好|讨厌|爱|想要|需要/i.test(lower)) {
     return "preference";
   }
-  if (/rozhodli|decided|will use|budeme/i.test(lower)) {
+  if (/rozhodli|decided|will use|budeme|决定|以后用|就这么定/i.test(lower)) {
     return "decision";
   }
-  if (/\+\d{10,}|@[\w.-]+\.\w+|is called|jmenuje se/i.test(lower)) {
+  if (/\+\d{10,}|@[\w.-]+\.\w+|is called|jmenuje se|我叫|名字是/i.test(lower)) {
     return "entity";
   }
-  if (/is|are|has|have|je|má|jsou/i.test(lower)) {
+  if (/is|are|has|have|je|má|jsou|是|有/i.test(lower)) {
     return "fact";
   }
   return "other";


### PR DESCRIPTION
## Summary
- feat(memory-lancedb): improve Chinese auto-capture and category detection
- Split from our `v2026.2.13` patch train as a single-purpose change for easier review.

## Why
- Keep the diff focused and low-risk so it can be merged or reverted independently.

## Scope
- Branch: `feat/memory-lancedb-chinese-triggers-en`
- Files changed: 2
- Key files:
  - `extensions/memory-lancedb/index.test.ts`
  - `extensions/memory-lancedb/index.ts`

## Test Plan
- Suggested local command:
  - `./node_modules/.bin/vitest run extensions/memory-lancedb/index.test.ts`
- Validation status:
  - [ ] CI checks pass
  - [ ] Maintainer re-ran local tests

## Risk & Rollback
- Risk: low to medium; impact limited to touched module(s).
- Rollback: revert this PR commit(s) cleanly.

## Co-authorship
- Co-authored by @ciberponk and Codex (GPT-5).
