### PR TITLE
fix: strip leading whitespace in block streaming reply path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Docs: https://docs.openclaw.ai
 - Media: accept `MEDIA:`-prefixed paths (lenient whitespace) when loading outbound media to prevent `ENOENT` for tool-returned local media paths. (#13107) Thanks @mcaxtr.
 - Media understanding: treat binary `application/vnd.*`/zip/octet-stream attachments as non-text (while keeping vendor `+json`/`+xml` text-eligible) so Office/ZIP files are not inlined into prompt body text. (#16513) Thanks @rmramsey32.
 - Agents: deliver tool result media (screenshots, images, audio) to channels regardless of verbose level. (#11735) Thanks @strelov1.
+- Auto-reply/Block streaming: strip leading whitespace from streamed block replies so messages starting with blank lines no longer deliver visible leading empty lines. (#16422) Thanks @mcinteerj.
 - Agents/Image tool: allow workspace-local image paths by including the active workspace directory in local media allowlists, and trust sandbox-validated paths in image loaders to prevent false "not under an allowed directory" rejections. (#15541)
 - Agents/Image tool: propagate the effective workspace root into tool wiring so workspace-local image paths are accepted by default when running without an explicit `workspaceDir`. (#16722)
 - BlueBubbles: include sender identity in group chat envelopes and pass clean message text to the agent prompt, aligning with iMessage/Signal formatting. (#16210) Thanks @zerone0x.

--- a/src/auto-reply/reply.block-streaming.test.ts
+++ b/src/auto-reply/reply.block-streaming.test.ts
@@ -211,4 +211,54 @@ describe("block streaming", () => {
       expect(onBlockReplyStreamMode).not.toHaveBeenCalled();
     });
   });
+
+  it("trims leading whitespace in block-streamed replies", async () => {
+    await withTempHome(async (home) => {
+      const seen: string[] = [];
+      const onBlockReply = vi.fn(async (payload) => {
+        seen.push(payload.text ?? "");
+      });
+
+      piEmbeddedMock.runEmbeddedPiAgent.mockImplementation(
+        async (params: RunEmbeddedPiAgentParams) => {
+          void params.onBlockReply?.({ text: "\n\n  Hello from stream" });
+          return {
+            payloads: [{ text: "\n\n  Hello from stream" }],
+            meta: {
+              durationMs: 5,
+              agentMeta: { sessionId: "s", provider: "p", model: "m" },
+            },
+          };
+        },
+      );
+
+      const res = await getReplyFromConfig(
+        {
+          Body: "ping",
+          From: "+1004",
+          To: "+2000",
+          MessageSid: "msg-128",
+          Provider: "telegram",
+        },
+        {
+          onBlockReply,
+          disableBlockStreaming: false,
+        },
+        {
+          agents: {
+            defaults: {
+              model: "anthropic/claude-opus-4-5",
+              workspace: path.join(home, "openclaw"),
+            },
+          },
+          channels: { telegram: { allowFrom: ["*"] } },
+          session: { store: path.join(home, "sessions.json") },
+        },
+      );
+
+      expect(res).toBeUndefined();
+      expect(onBlockReply).toHaveBeenCalledTimes(1);
+      expect(seen).toEqual(["Hello from stream"]);
+    });
+  });
 });

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -414,7 +414,7 @@ export async function runAgentTurnWithFallback(params: {
 
                   const blockPayload: ReplyPayload = params.applyReplyToMode({
                     ...taggedPayload,
-                    text: cleaned,
+                    text: cleaned?.trimStart(),
                     audioAsVoice: Boolean(parsed.audioAsVoice || payload.audioAsVoice),
                     replyToId: taggedPayload.replyToId ?? parsed.replyToId,
                     replyToTag: taggedPayload.replyToTag || parsed.replyToTag,


### PR DESCRIPTION
#### Summary

Follow-up to #16158 and #16280. The `sanitizeUserFacingText` fix for leading whitespace only applies to the non-streaming delivery path. The block streaming path (`onBlockReply` in `agent-runner-execution.ts`) bypasses `sanitizeUserFacingText` entirely, so LLM responses that start with `\n\n` still reach WhatsApp (and other channels) with visible blank lines when `blockStreaming` is enabled — which is the default.

lobster-biscuit

#### Repro Steps

1. Configure agent with `blockStreamingDefault: "on"` and `blockStreamingBreak: "message_end"` (defaults)
2. Send a message that triggers an LLM response beginning with `\n\n`
3. Observe leading blank lines in the delivered message despite #16158/#16280 being merged

#### Root Cause

The block streaming path constructs reply payloads in `agent-runner-execution.ts` via:
```
text → normalizeStreamingText → applyReplyTagsToPayload → parseReplyDirectives → cleaned → blockPayload
```

None of these steps call `sanitizeUserFacingText` or trim leading whitespace. The `cleaned` text from `parseReplyDirectives` preserves leading newlines.

#### Fix

One-line: `cleaned?.trimStart()` when constructing the block reply payload (line 413). This is consistent with the non-streaming path where `sanitizeUserFacingText` now calls `.trimStart()` via #16280.

#### Alternatives Considered

- Calling `sanitizeUserFacingText` in the block streaming path — rejected as too heavy for streaming (error rewrites, duplicate collapse are unnecessary for streamed text)
- Trimming in `normalizeStreamingText` — too early, would affect intermediate chunks
- Trimming in channel plugins (PR #8052 approach) — scattered, harder to maintain

#### Behavior Changes

- Block-streamed replies will have leading whitespace stripped before delivery
- No change to non-streaming path (already fixed by #16280)
- No change to trailing whitespace or internal newlines

#### Codebase and GitHub Search

- #16158: original `sanitizeUserFacingText` fix (merged, ported to #16280)
- #16280: maintainer port of #16158 with refined behavior
- #8052: scattered `trimStart` in delivery paths (open, superseded by this + #16280)
- #10612: first-chunk trimming approach (open)
- Block streaming path confirmed via code trace from `pi-embedded-subscribe.handlers.messages.ts` → `onBlockReply` → `agent-runner-execution.ts`

#### Tests

This is a one-line change in an async callback that is integration-tested via the existing block streaming test suite. The trimming behavior is covered by the `sanitizeUserFacingText` tests added in #16158.

```
pnpm lint   ✅ 0 warnings, 0 errors
pnpm build  ✅ clean
```

**Sign-Off**

- Models used: Claude Opus 4.6 (analysis + implementation)
- Submitter effort: High — traced full block streaming delivery path across 3 files to identify why #16158/#16280 didnt fix the issue for block streaming users. Root cause identified independently by Kev 🦈 (a separate OpenClaw agent), confirmed and fixed by Keith 🪿.
- Agent notes: Credit to Kev (Adam Holts OpenClaw agent) for independently identifying the block streaming bypass while debugging the same symptom.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Applies `trimStart()` to block-streamed replies to strip leading whitespace, completing the fix started in #16158/#16280. The block streaming path (`onBlockReply`) was bypassing the leading-whitespace fix because `parseReplyDirectives` can re-introduce leading spaces when stripping directive tags like `<reply>` or `<audio>` from the start of text.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- One-line fix that applies standard string trimming in the correct location. The change is well-researched, properly scoped, and consistent with the existing `sanitizeUserFacingText` fix. Optional chaining ensures safety if `cleaned` is undefined.
- No files require special attention

<sub>Last reviewed commit: 403fd50</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->