### PR TITLE
feat(memory-lancedb): increase auto-capture max length to 1500

### DIFF
--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -104,6 +104,10 @@ describe("memory plugin e2e", () => {
     expect(shouldCapture("<relevant-memories>injected</relevant-memories>")).toBe(false);
     expect(shouldCapture("<system>status</system>")).toBe(false);
     expect(shouldCapture("Here is a short **summary**\n- bullet")).toBe(false);
+    const nearLimit = `I always prefer this setting. ${"x".repeat(1450)}`;
+    const overLimit = `I always prefer this setting. ${"x".repeat(1505)}`;
+    expect(shouldCapture(nearLimit)).toBe(true);
+    expect(shouldCapture(overLimit)).toBe(false);
   });
 
   test("detectCategory classifies using production logic", async () => {

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -195,7 +195,7 @@ const MEMORY_TRIGGERS = [
 ];
 
 export function shouldCapture(text: string): boolean {
-  if (text.length < 10 || text.length > 500) {
+  if (text.length < 10 || text.length > 1500) {
     return false;
   }
   // Skip injected context from memory recall


### PR DESCRIPTION
## Summary
- feat(memory-lancedb): increase auto-capture max length to 1500
- Split from our `v2026.2.13` patch train as a single-purpose change for easier review.

## Why
- Keep the diff focused and low-risk so it can be merged or reverted independently.

## Scope
- Branch: `feat/memory-lancedb-capture-limit-1500-en`
- Files changed: 2
- Key files:
  - `extensions/memory-lancedb/index.test.ts`
  - `extensions/memory-lancedb/index.ts`

## Test Plan
- Suggested local command:
  - `./node_modules/.bin/vitest run extensions/memory-lancedb/index.test.ts`
- Validation status:
  - [ ] CI checks pass
  - [ ] Maintainer re-ran local tests

## Risk & Rollback
- Risk: low to medium; impact limited to touched module(s).
- Rollback: revert this PR commit(s) cleanly.

## Co-authorship
- Co-authored by @ciberponk and Codex (GPT-5).
