### PR TITLE
Fix: Force dashboard command to use localhost URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Docs: https://docs.openclaw.ai
 - Cron/Slack: preserve agent identity (name and icon) when cron jobs deliver outbound messages. (#16242) Thanks @robbyczgw-cla.
 - Cron: deliver text-only output directly when `delivery.to` is set so cron recipients get full output instead of summaries. (#16360) Thanks @thewilloftheshadow.
 - Cron: prevent `cron list`/`cron status` from silently skipping past-due recurring jobs by using maintenance recompute semantics. (#16156) Thanks @zerone0x.
+- CLI/Dashboard: when `gateway.bind=lan`, generate localhost dashboard URLs to satisfy browser secure-context requirements while preserving non-LAN bind behavior. (#16434) Thanks @BinHPdev.
 - Cron: repair missing/corrupt `nextRunAtMs` for the updated job without globally recomputing unrelated due jobs during `cron update`. (#15750)
 - Discord: prefer gateway guild id when logging inbound messages so cached-miss guilds do not appear as `guild=dm`. Thanks @thewilloftheshadow.
 - TUI: refactor searchable select list description layout and add regression coverage for ANSI-highlight width bounds.

--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -436,7 +436,11 @@ public struct PollParams: Codable, Sendable {
     public let question: String
     public let options: [String]
     public let maxselections: Int?
+    public let durationseconds: Int?
     public let durationhours: Int?
+    public let silent: Bool?
+    public let isanonymous: Bool?
+    public let threadid: String?
     public let channel: String?
     public let accountid: String?
     public let idempotencykey: String
@@ -446,7 +450,11 @@ public struct PollParams: Codable, Sendable {
         question: String,
         options: [String],
         maxselections: Int?,
+        durationseconds: Int?,
         durationhours: Int?,
+        silent: Bool?,
+        isanonymous: Bool?,
+        threadid: String?,
         channel: String?,
         accountid: String?,
         idempotencykey: String
@@ -455,7 +463,11 @@ public struct PollParams: Codable, Sendable {
         self.question = question
         self.options = options
         self.maxselections = maxselections
+        self.durationseconds = durationseconds
         self.durationhours = durationhours
+        self.silent = silent
+        self.isanonymous = isanonymous
+        self.threadid = threadid
         self.channel = channel
         self.accountid = accountid
         self.idempotencykey = idempotencykey
@@ -465,7 +477,11 @@ public struct PollParams: Codable, Sendable {
         case question
         case options
         case maxselections = "maxSelections"
+        case durationseconds = "durationSeconds"
         case durationhours = "durationHours"
+        case silent
+        case isanonymous = "isAnonymous"
+        case threadid = "threadId"
         case channel
         case accountid = "accountId"
         case idempotencykey = "idempotencyKey"

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -436,7 +436,11 @@ public struct PollParams: Codable, Sendable {
     public let question: String
     public let options: [String]
     public let maxselections: Int?
+    public let durationseconds: Int?
     public let durationhours: Int?
+    public let silent: Bool?
+    public let isanonymous: Bool?
+    public let threadid: String?
     public let channel: String?
     public let accountid: String?
     public let idempotencykey: String
@@ -446,7 +450,11 @@ public struct PollParams: Codable, Sendable {
         question: String,
         options: [String],
         maxselections: Int?,
+        durationseconds: Int?,
         durationhours: Int?,
+        silent: Bool?,
+        isanonymous: Bool?,
+        threadid: String?,
         channel: String?,
         accountid: String?,
         idempotencykey: String
@@ -455,7 +463,11 @@ public struct PollParams: Codable, Sendable {
         self.question = question
         self.options = options
         self.maxselections = maxselections
+        self.durationseconds = durationseconds
         self.durationhours = durationhours
+        self.silent = silent
+        self.isanonymous = isanonymous
+        self.threadid = threadid
         self.channel = channel
         self.accountid = accountid
         self.idempotencykey = idempotencykey
@@ -465,7 +477,11 @@ public struct PollParams: Codable, Sendable {
         case question
         case options
         case maxselections = "maxSelections"
+        case durationseconds = "durationSeconds"
         case durationhours = "durationHours"
+        case silent
+        case isanonymous = "isAnonymous"
+        case threadid = "threadId"
         case channel
         case accountid = "accountId"
         case idempotencykey = "idempotencyKey"

--- a/src/commands/dashboard.test.ts
+++ b/src/commands/dashboard.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { GatewayBindMode } from "../config/types.gateway.js";
+import { dashboardCommand } from "./dashboard.js";
+
+const mocks = vi.hoisted(() => ({
+  readConfigFileSnapshot: vi.fn(),
+  resolveGatewayPort: vi.fn(),
+  resolveControlUiLinks: vi.fn(),
+  copyToClipboard: vi.fn(),
+}));
+
+vi.mock("../config/config.js", () => ({
+  readConfigFileSnapshot: mocks.readConfigFileSnapshot,
+  resolveGatewayPort: mocks.resolveGatewayPort,
+}));
+
+vi.mock("./onboard-helpers.js", () => ({
+  resolveControlUiLinks: mocks.resolveControlUiLinks,
+  detectBrowserOpenSupport: vi.fn(),
+  openUrl: vi.fn(),
+  formatControlUiSshHint: vi.fn(() => "ssh hint"),
+}));
+
+vi.mock("../infra/clipboard.js", () => ({
+  copyToClipboard: mocks.copyToClipboard,
+}));
+
+const runtime = {
+  log: vi.fn(),
+  error: vi.fn(),
+  exit: vi.fn(),
+};
+
+function mockSnapshot(params?: {
+  token?: string;
+  bind?: GatewayBindMode;
+  customBindHost?: string;
+}) {
+  const token = params?.token ?? "abc123";
+  mocks.readConfigFileSnapshot.mockResolvedValue({
+    path: "/tmp/openclaw.json",
+    exists: true,
+    raw: "{}",
+    parsed: {},
+    valid: true,
+    config: {
+      gateway: {
+        auth: { token },
+        bind: params?.bind,
+        customBindHost: params?.customBindHost,
+      },
+    },
+    issues: [],
+    legacyIssues: [],
+  });
+  mocks.resolveGatewayPort.mockReturnValue(18789);
+  mocks.resolveControlUiLinks.mockReturnValue({
+    httpUrl: "http://127.0.0.1:18789/",
+    wsUrl: "ws://127.0.0.1:18789",
+  });
+  mocks.copyToClipboard.mockResolvedValue(true);
+}
+
+describe("dashboardCommand bind selection", () => {
+  beforeEach(() => {
+    mocks.readConfigFileSnapshot.mockReset();
+    mocks.resolveGatewayPort.mockReset();
+    mocks.resolveControlUiLinks.mockReset();
+    mocks.copyToClipboard.mockReset();
+    runtime.log.mockReset();
+    runtime.error.mockReset();
+    runtime.exit.mockReset();
+  });
+
+  it("maps lan bind to loopback for dashboard URLs", async () => {
+    mockSnapshot({ bind: "lan" });
+
+    await dashboardCommand(runtime, { noOpen: true });
+
+    expect(mocks.resolveControlUiLinks).toHaveBeenCalledWith({
+      port: 18789,
+      bind: "loopback",
+      customBindHost: undefined,
+      basePath: undefined,
+    });
+  });
+
+  it("defaults to loopback when bind is unset", async () => {
+    mockSnapshot();
+
+    await dashboardCommand(runtime, { noOpen: true });
+
+    expect(mocks.resolveControlUiLinks).toHaveBeenCalledWith({
+      port: 18789,
+      bind: "loopback",
+      customBindHost: undefined,
+      basePath: undefined,
+    });
+  });
+
+  it("preserves custom bind mode", async () => {
+    mockSnapshot({ bind: "custom", customBindHost: "10.0.0.5" });
+
+    await dashboardCommand(runtime, { noOpen: true });
+
+    expect(mocks.resolveControlUiLinks).toHaveBeenCalledWith({
+      port: 18789,
+      bind: "custom",
+      customBindHost: "10.0.0.5",
+      basePath: undefined,
+    });
+  });
+
+  it("preserves tailnet bind mode", async () => {
+    mockSnapshot({ bind: "tailnet" });
+
+    await dashboardCommand(runtime, { noOpen: true });
+
+    expect(mocks.resolveControlUiLinks).toHaveBeenCalledWith({
+      port: 18789,
+      bind: "tailnet",
+      customBindHost: undefined,
+      basePath: undefined,
+    });
+  });
+});

--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -20,15 +20,16 @@ export async function dashboardCommand(
   const snapshot = await readConfigFileSnapshot();
   const cfg = snapshot.valid ? snapshot.config : {};
   const port = resolveGatewayPort(cfg);
+  const bind = cfg.gateway?.bind ?? "loopback";
   const basePath = cfg.gateway?.controlUi?.basePath;
   const customBindHost = cfg.gateway?.customBindHost;
   const token = cfg.gateway?.auth?.token ?? process.env.OPENCLAW_GATEWAY_TOKEN ?? "";
 
-  // Dashboard always uses localhost regardless of bind mode to avoid
-  // secure context errors in browsers (which require HTTPS or localhost)
+  // LAN URLs fail secure-context checks in browsers.
+  // Coerce only lan->loopback and preserve other bind modes.
   const links = resolveControlUiLinks({
     port,
-    bind: "loopback",
+    bind: bind === "lan" ? "loopback" : bind,
     customBindHost,
     basePath,
   });

--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -20,14 +20,15 @@ export async function dashboardCommand(
   const snapshot = await readConfigFileSnapshot();
   const cfg = snapshot.valid ? snapshot.config : {};
   const port = resolveGatewayPort(cfg);
-  const bind = cfg.gateway?.bind ?? "loopback";
   const basePath = cfg.gateway?.controlUi?.basePath;
   const customBindHost = cfg.gateway?.customBindHost;
   const token = cfg.gateway?.auth?.token ?? process.env.OPENCLAW_GATEWAY_TOKEN ?? "";
 
+  // Dashboard always uses localhost regardless of bind mode to avoid
+  // secure context errors in browsers (which require HTTPS or localhost)
   const links = resolveControlUiLinks({
     port,
-    bind,
+    bind: "loopback",
     customBindHost,
     basePath,
   });


### PR DESCRIPTION
## Summary
Fixes #16423 - Dashboard now uses localhost URL to avoid browser secure context errors

## Problem
When `gateway.bind="lan"`, the `openclaw dashboard` command generated URLs with LAN IP (e.g., `http://192.168.31.137:18789/`). Browsers rejected WebSocket connections to these URLs due to secure context policy requiring "HTTPS or localhost."

## Solution
Force dashboard command to always use localhost (127.0.0.1) regardless of gateway bind configuration.

## Changes
Modified `src/commands/dashboard.ts`:
- Force `bind: "loopback"` in `resolveControlUiLinks()` call
- Removed unused `bind` variable
- Added explanatory comment

## Rationale
- **Dashboard is local-only**: Always accessed from the same machine as gateway
- **Gateway accepts both**: When bound to `0.0.0.0` or LAN, still accepts localhost connections
- **Browser security**: Localhost satisfies secure context without requiring HTTPS
- **No functionality loss**: All features work identically via localhost

## Before
```typescript
const bind = cfg.gateway?.bind ?? "loopback";
const links = resolveControlUiLinks({
  port,
  bind,  // Uses LAN IP when bind="lan"
  customBindHost,
  basePath,
});
```

## After
```typescript
// Dashboard always uses localhost regardless of bind mode
const links = resolveControlUiLinks({
  port,
  bind: "loopback",  // Always localhost
  customBindHost,
  basePath,
});
```

## Testing
- ✅ Lint check passed
- ✅ Format check passed

🤖 Generated with Claude Code

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Forces dashboard command to always use `localhost` (127.0.0.1) instead of respecting `gateway.bind` configuration. This prevents browser secure context errors when gateway is bound to LAN IP addresses, since browsers require HTTPS or localhost for WebSocket connections. The change is safe because:

- The dashboard is always accessed locally from the same machine as the gateway
- Gateway accepts localhost connections even when bound to `0.0.0.0` or LAN addresses
- The `status` command (src/commands/status.command.ts:199-206) still respects the `bind` configuration for display purposes
- Tests verify the behavior expects `bind: "loopback"` (src/commands/dashboard.e2e.test.ts:80-85)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is minimal, well-justified, and correctly addresses a browser security policy issue. The hardcoded `bind: "loopback"` is appropriate for dashboard command since it's always accessed locally. Tests confirm the expected behavior, and the change doesn't affect other parts of the system (status command still shows actual bind configuration).
- No files require special attention

<sub>Last reviewed commit: dda36bb</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->