### PR TITLE
fix(dashboard): control UI broken on LAN bind — browser rejects WebSocket (#16423)

### DIFF
--- a/src/commands/onboard-helpers.e2e.test.ts
+++ b/src/commands/onboard-helpers.e2e.test.ts
@@ -107,6 +107,15 @@ describe("resolveControlUiLinks", () => {
     expect(links.httpUrl).toBe("http://127.0.0.1:18789/");
     expect(links.wsUrl).toBe("ws://127.0.0.1:18789");
   });
+
+  it("returns localhost for lan bind to satisfy browser secure context", () => {
+    const links = resolveControlUiLinks({
+      port: 18789,
+      bind: "lan",
+    });
+    expect(links.httpUrl).toBe("http://127.0.0.1:18789/");
+    expect(links.wsUrl).toBe("ws://127.0.0.1:18789");
+  });
 });
 
 describe("normalizeGatewayTokenInput", () => {

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -11,7 +11,7 @@ import { CONFIG_PATH } from "../config/config.js";
 import { resolveSessionTranscriptsDirForAgent } from "../config/sessions.js";
 import { callGateway } from "../gateway/call.js";
 import { normalizeControlUiBasePath } from "../gateway/control-ui-shared.js";
-import { pickPrimaryLanIPv4, isValidIPv4 } from "../gateway/net.js";
+import { isValidIPv4 } from "../gateway/net.js";
 import { isSafeExecutableValue } from "../infra/exec-safety.js";
 import { pickPrimaryTailnetIPv4 } from "../infra/tailnet.js";
 import { isWSL } from "../infra/wsl.js";
@@ -472,7 +472,9 @@ export function resolveControlUiLinks(params: {
       return tailnetIPv4 ?? "127.0.0.1";
     }
     if (bind === "lan") {
-      return pickPrimaryLanIPv4() ?? "127.0.0.1";
+      // LAN bind (0.0.0.0) accepts localhost connections too.
+      // Always use 127.0.0.1 so browsers satisfy the secure context requirement.
+      return "127.0.0.1";
     }
     return "127.0.0.1";
   })();


### PR DESCRIPTION
## Summary

`openclaw dashboard` outputs a LAN IP URL (e.g. `http://192.168.x.x:18789/`) when `gateway.bind` is set to `"lan"`. Browsers reject the WebSocket connection because a LAN IP doesn't satisfy the secure context requirement — only `localhost` or HTTPS does.

Closes #16423

lobster-biscuit

## Root Cause

`resolveControlUiLinks()` in `onboard-helpers.ts` calls `pickPrimaryLanIPv4()` for the `bind=lan` case and returns the LAN IP. But the control UI is always opened in a local browser, and the gateway bound to `0.0.0.0` accepts localhost connections anyway.

## Changes

- Before: `bind=lan` → URL uses LAN IP → browser rejects WebSocket (secure context)
- After: `bind=lan` → URL uses `127.0.0.1` → works like `loopback`

## Tests

- `onboard-helpers.e2e.test.ts` — new test for `bind=lan` returning localhost, fails before fix, passes after
- All 15 existing tests in the file still pass
- `pnpm build && pnpm check` pass (lint issue is pre-existing in `.agents/` markdown files)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixes the dashboard control UI URL generation for `bind=lan` mode. Previously, `resolveControlUiLinks()` called `pickPrimaryLanIPv4()` to produce a LAN IP URL (e.g. `http://192.168.x.x:18789/`), which browsers rejected for WebSocket connections because a LAN IP over HTTP doesn't satisfy the secure context requirement. Now, `bind=lan` always uses `127.0.0.1`, which works because the gateway binds to `0.0.0.0` in LAN mode and accepts localhost connections.

- Replaced `pickPrimaryLanIPv4()` call with hardcoded `"127.0.0.1"` in the `bind=lan` branch of `resolveControlUiLinks()`
- Removed the now-unused `pickPrimaryLanIPv4` import from `onboard-helpers.ts` (`pickPrimaryLanIPv4` is still exported from `net.ts` and used in 5 other files)
- Added a targeted test case verifying `bind: "lan"` returns localhost URLs

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, well-scoped fix with a clear root cause and targeted test coverage.
- The change is small (3 lines of logic + 1 removed import) and the fix is sound. LAN mode binds to `0.0.0.0` which accepts localhost connections, so using `127.0.0.1` in the UI URL is both correct and necessary for browser secure context. The removed `pickPrimaryLanIPv4` import is still used in 5 other files so the export is retained. A new test validates the fix. No regressions are introduced.
- No files require special attention

<sub>Last reviewed commit: 7b3dc27</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->