### PR TITLE
feat(feishu): add create_from_markdown import action

### DIFF
--- a/extensions/feishu/src/doc-schema.ts
+++ b/extensions/feishu/src/doc-schema.ts
@@ -23,6 +23,12 @@ export const FeishuDocSchema = Type.Union([
     folder_token: Type.Optional(Type.String({ description: "Target folder token (optional)" })),
   }),
   Type.Object({
+    action: Type.Literal("create_from_markdown"),
+    title: Type.String({ description: "Document title" }),
+    content: Type.String({ description: "Markdown content for initial document body" }),
+    folder_token: Type.String({ description: "Target folder token" }),
+  }),
+  Type.Object({
     action: Type.Literal("list_blocks"),
     doc_token: Type.String({ description: "Document token" }),
   }),

--- a/extensions/feishu/src/docx.test.ts
+++ b/extensions/feishu/src/docx.test.ts
@@ -20,10 +20,14 @@ vi.mock("./runtime.js", () => ({
 import { registerFeishuDocTools } from "./docx.js";
 
 describe("feishu_doc image fetch hardening", () => {
+  const createDocMock = vi.hoisted(() => vi.fn());
   const convertMock = vi.hoisted(() => vi.fn());
   const blockListMock = vi.hoisted(() => vi.fn());
   const blockChildrenCreateMock = vi.hoisted(() => vi.fn());
   const driveUploadAllMock = vi.hoisted(() => vi.fn());
+  const importTaskCreateMock = vi.hoisted(() => vi.fn());
+  const importTaskGetMock = vi.hoisted(() => vi.fn());
+  const driveFileDeleteMock = vi.hoisted(() => vi.fn());
   const blockPatchMock = vi.hoisted(() => vi.fn());
   const scopeListMock = vi.hoisted(() => vi.fn());
 
@@ -33,6 +37,7 @@ describe("feishu_doc image fetch hardening", () => {
     createFeishuClientMock.mockReturnValue({
       docx: {
         document: {
+          create: createDocMock,
           convert: convertMock,
         },
         documentBlock: {
@@ -44,6 +49,13 @@ describe("feishu_doc image fetch hardening", () => {
         },
       },
       drive: {
+        file: {
+          delete: driveFileDeleteMock,
+        },
+        importTask: {
+          create: importTaskCreateMock,
+          get: importTaskGetMock,
+        },
         media: {
           uploadAll: driveUploadAllMock,
         },
@@ -77,7 +89,17 @@ describe("feishu_doc image fetch hardening", () => {
       },
     });
 
+    createDocMock.mockResolvedValue({
+      code: 0,
+      data: { document: { document_id: "tmp_doc_1", title: "tmp" } },
+    });
     driveUploadAllMock.mockResolvedValue({ file_token: "token_1" });
+    importTaskCreateMock.mockResolvedValue({ code: 0, data: { ticket: "ticket_1" } });
+    importTaskGetMock.mockResolvedValue({
+      code: 0,
+      data: { result: { job_status: 0, token: "new_doc_1", url: "https://feishu.cn/docx/new_doc_1" } },
+    });
+    driveFileDeleteMock.mockResolvedValue({ code: 0, data: { task_id: "task_cleanup" } });
     blockPatchMock.mockResolvedValue({ code: 0 });
     scopeListMock.mockResolvedValue({ code: 0, data: { scopes: [] } });
   });
@@ -119,5 +141,61 @@ describe("feishu_doc image fetch hardening", () => {
     expect(result.details.images_processed).toBe(0);
     expect(consoleErrorSpy).toHaveBeenCalled();
     consoleErrorSpy.mockRestore();
+  });
+
+  it("creates a new doc from markdown via import task", async () => {
+    vi.useFakeTimers();
+    try {
+      importTaskGetMock
+        .mockResolvedValueOnce({
+          code: 0,
+          data: { result: { job_status: 1 } },
+        })
+        .mockResolvedValueOnce({
+          code: 0,
+          data: {
+            result: { job_status: 0, token: "new_doc_imported", url: "https://feishu.cn/docx/new_doc_imported" },
+          },
+        });
+
+      const registerTool = vi.fn();
+      registerFeishuDocTools({
+        config: {
+          channels: {
+            feishu: {
+              appId: "app_id",
+              appSecret: "app_secret",
+            },
+          },
+        } as any,
+        logger: { debug: vi.fn(), info: vi.fn() } as any,
+        registerTool,
+      } as any);
+
+      const feishuDocTool = registerTool.mock.calls
+        .map((call) => call[0])
+        .find((tool) => tool.name === "feishu_doc");
+      expect(feishuDocTool).toBeDefined();
+
+      const pending = feishuDocTool.execute("tool-call", {
+        action: "create_from_markdown",
+        title: "Imported Doc",
+        content: "# Hello\n\nworld",
+        folder_token: "folder_123",
+      });
+      await vi.runAllTimersAsync();
+      const result = await pending;
+
+      expect(createDocMock).toHaveBeenCalledTimes(1);
+      expect(driveUploadAllMock).toHaveBeenCalledTimes(1);
+      expect(importTaskCreateMock).toHaveBeenCalledTimes(1);
+      expect(importTaskGetMock).toHaveBeenCalled();
+      expect(driveFileDeleteMock).toHaveBeenCalledTimes(1);
+      expect(result.details.success).toBe(true);
+      expect(result.details.document_id).toBe("new_doc_imported");
+      expect(result.details.method).toBe("import_task");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- feat(feishu): add create_from_markdown import action
- Split from our `v2026.2.13` patch train as a single-purpose change for easier review.

## Why
- Keep the diff focused and low-risk so it can be merged or reverted independently.

## Scope
- Branch: `feat/feishu-doc-import-create-from-markdown-en`
- Files changed: 3
- Key files:
  - `extensions/feishu/src/doc-schema.ts`
  - `extensions/feishu/src/docx.test.ts`
  - `extensions/feishu/src/docx.ts`

## Test Plan
- Suggested local command:
  - `./node_modules/.bin/vitest run extensions/feishu/src/docx.test.ts`
- Validation status:
  - [ ] CI checks pass
  - [ ] Maintainer re-ran local tests

## Risk & Rollback
- Risk: low to medium; impact limited to touched module(s).
- Rollback: revert this PR commit(s) cleanly.

## Co-authorship
- Co-authored by @ciberponk and Codex (GPT-5).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `create_from_markdown` action to the `feishu_doc` tool, enabling direct document creation from markdown content via Feishu's import task API. The implementation creates a temporary document, uploads the markdown file, initiates an import task, polls for completion (60s timeout with 2s intervals), and cleans up the temporary document.

**Key changes:**
- New schema entry for `create_from_markdown` action with required `title`, `content`, and `folder_token` parameters
- `createDocFromMarkdownViaImport` function handles the import workflow with polling logic
- Test coverage for the happy path with simulated polling
- Tool description updated to list the new action

**Notes:**
- The cleanup (deletion of temporary document) runs in the `finally` block immediately after import completion, which could potentially race with Feishu's read operations on the temporary file
- Polling logic uses a 60-second timeout with 2-second intervals

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk
- The change adds a focused new feature (markdown import) with reasonable implementation. The polling logic has a known issue already documented in previous threads. The main uncertainty is around the timing of the temporary file cleanup which could theoretically race with Feishu's import process, but this is marked as best-effort cleanup. The test coverage validates the happy path. Overall risk is low since this is a new optional action that doesn't modify existing behavior.
- No files require special attention

<sub>Last reviewed commit: 5411e1a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->