### PR TITLE
fix: expose platform_message_id in inbound_meta

### DIFF
--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -22,6 +22,7 @@ export function buildInboundMetaSystemPrompt(ctx: TemplateContext): string {
     provider: safeTrim(ctx.Provider),
     surface: safeTrim(ctx.Surface),
     chat_type: chatType ?? (isDirect ? "direct" : undefined),
+    platform_message_id: safeTrim(ctx.MessageSidFull) ?? safeTrim(ctx.MessageSid),
     flags: {
       is_group_chat: !isDirect ? true : undefined,
       was_mentioned: ctx.WasMentioned === true ? true : undefined,


### PR DESCRIPTION
## Summary
Expose `platform_message_id` in the inbound metadata envelope so agents can reference specific messages (e.g., for deletion or quoting). This field was computed but not included in the metadata passed to the agent context.

Fixes #16188

## Validation
- [x] `pnpm build` — passed
- [x] `pnpm check` (format + tsgo + lint) — passed
- [x] `pnpm test` — 1073 tests passed (105 test files)

## Scope
- Single focused fix — single file changed

## AI-Assistance
- AI-assisted (Claude Code) for implementation
- Human-reviewed: confirmed understanding of changes
- Testing: full local validation suite passed