### PR TITLE
feat: add topicId matching to bindings for Telegram forum topics

### DIFF
--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -76,6 +76,8 @@ export type AgentBinding = {
     channel: string;
     accountId?: string;
     peer?: { kind: ChatType; id: string };
+    /** Telegram forum topic ID — routes to a specific topic within a group. */
+    topicId?: string;
     guildId?: string;
     teamId?: string;
     /** Discord role IDs used for role-based routing. */

--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -745,4 +745,93 @@ describe("role-based agent routing", () => {
     expect(route.agentId).toBe("guild-roles");
     expect(route.matchedBy).toBe("binding.guild+roles");
   });
+
+  test("topicId binding matches specific forum topic", () => {
+    const cfg: OpenClawConfig = {
+      bindings: [
+        {
+          agentId: "topic-agent",
+          match: {
+            channel: "telegram",
+            peer: { kind: "group" as ChatType, id: "-1001234567890" },
+            topicId: "315",
+          },
+        },
+        {
+          agentId: "group-agent",
+          match: {
+            channel: "telegram",
+            peer: { kind: "group" as ChatType, id: "-1001234567890" },
+          },
+        },
+      ],
+    };
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "telegram",
+      peer: { kind: "group", id: "-1001234567890" },
+      topicId: "315",
+    });
+    expect(route.agentId).toBe("topic-agent");
+    expect(route.matchedBy).toBe("binding.peer+topic");
+  });
+
+  test("topicId binding does not match different topic", () => {
+    const cfg: OpenClawConfig = {
+      bindings: [
+        {
+          agentId: "topic-agent",
+          match: {
+            channel: "telegram",
+            peer: { kind: "group" as ChatType, id: "-1001234567890" },
+            topicId: "315",
+          },
+        },
+        {
+          agentId: "group-agent",
+          match: {
+            channel: "telegram",
+            peer: { kind: "group" as ChatType, id: "-1001234567890" },
+          },
+        },
+      ],
+    };
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "telegram",
+      peer: { kind: "group", id: "-1001234567890" },
+      topicId: "999",
+    });
+    expect(route.agentId).toBe("group-agent");
+    expect(route.matchedBy).toBe("binding.peer");
+  });
+
+  test("no topicId in input falls back to peer binding without topic constraint", () => {
+    const cfg: OpenClawConfig = {
+      bindings: [
+        {
+          agentId: "topic-agent",
+          match: {
+            channel: "telegram",
+            peer: { kind: "group" as ChatType, id: "-1001234567890" },
+            topicId: "315",
+          },
+        },
+        {
+          agentId: "group-agent",
+          match: {
+            channel: "telegram",
+            peer: { kind: "group" as ChatType, id: "-1001234567890" },
+          },
+        },
+      ],
+    };
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "telegram",
+      peer: { kind: "group", id: "-1001234567890" },
+    });
+    expect(route.agentId).toBe("group-agent");
+    expect(route.matchedBy).toBe("binding.peer");
+  });
 });

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -177,6 +177,7 @@ export const registerTelegramHandlers = ({
         id: peerId,
       },
       parentPeer,
+      topicId: resolvedThreadId != null ? String(resolvedThreadId) : undefined,
     });
     const baseSessionKey = route.sessionKey;
     const dmThreadId = !params.isGroup ? params.messageThreadId : undefined;

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -175,6 +175,7 @@ export const buildTelegramMessageContext = async ({
       id: peerId,
     },
     parentPeer,
+    topicId: resolvedThreadId != null ? String(resolvedThreadId) : undefined,
   });
   const baseSessionKey = route.sessionKey;
   // DMs: use raw messageThreadId for thread sessions (not forum topic ids)

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -464,6 +464,7 @@ export const registerTelegramNativeCommands = ({
               id: isGroup ? buildTelegramGroupPeerId(chatId, resolvedThreadId) : String(chatId),
             },
             parentPeer,
+            topicId: resolvedThreadId != null ? String(resolvedThreadId) : undefined,
           });
           const baseSessionKey = route.sessionKey;
           // DMs: use raw messageThreadId for thread sessions (not resolvedThreadId which is for forums)


### PR DESCRIPTION
## Summary

Add an optional `topicId` field to the binding match schema, enabling per-topic agent routing in Telegram forum groups.

## Use Case

In multi-agent setups, different Telegram forum topics in the same group should route to different agents. Currently, bindings can match on `channel`, `peer`, `guildId`, `teamId`, and `roles` — but not on Telegram forum topic IDs.

## Changes

- **`src/config/types.agents.ts`**: Add optional `topicId: string` to `AgentBinding.match`
- **`src/routing/resolve-route.ts`**: 
  - Add `topicId` to `ResolveAgentRouteInput`, `NormalizedBindingMatch`, and `BindingScope`
  - New `binding.peer+topic` tier ranked above `binding.peer` for higher specificity
  - `matchesBindingScope` checks `topicId` when present on a binding
- **`src/telegram/bot-message-context.ts`**, **`bot-handlers.ts`**, **`bot-native-commands.ts`**: Pass `topicId` (from `resolvedThreadId`) to `resolveAgentRoute`
- **`src/routing/resolve-route.test.ts`**: 3 new tests covering topic match, topic mismatch, and no-topic fallback

## Example Config

```json
{
  "agentId": "cfo",
  "match": {
    "channel": "telegram",
    "peer": { "kind": "group", "id": "-1003888463743" },
    "topicId": "315"
  }
}
```

## Backward Compatibility

When `topicId` is absent from a binding, behavior is unchanged — matches all topics in the group as before.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds optional `topicId`-based routing for Telegram forum topics, enabling per-topic agent binding in multi-agent setups. The routing logic correctly introduces a new `binding.peer+topic` tier above `binding.peer`, and `matchesBindingScope` properly prevents topic-constrained bindings from matching at lower tiers when the topic doesn't match. The Telegram handler files consistently pass `resolvedThreadId` as `topicId`. Tests cover the key scenarios.

- **Critical:** `topicId` is missing from the Zod validation schema in `src/config/zod-schema.agents.ts`. The `match` object uses `.strict()`, so any config with `topicId` in a binding will be **rejected at config load time**, making the feature unusable until the schema is updated.
- **Minor:** Debug log lines in `resolve-route.ts` do not include `topicId`, which will make it harder to troubleshoot topic-based routing issues.

<h3>Confidence Score: 2/5</h3>

- The feature will fail at config validation due to a missing Zod schema update — merging as-is will prevent anyone from using topicId in bindings.
- The routing logic itself is well-implemented and the tests are solid, but the missing `topicId` in the Zod `BindingsSchema` (.strict() mode) means the feature is broken at the config layer. This is a blocking issue that must be fixed before merge.
- `src/config/zod-schema.agents.ts` — needs `topicId: z.string().optional()` added to the binding match schema.

<sub>Last reviewed commit: 210c2f1</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->