### PR TITLE
feat(ui/chat): chat UX overhaul

### DIFF
--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -92,8 +92,8 @@
   font-weight: 600;
   font-size: 14px;
   flex-shrink: 0;
-  align-self: flex-end; /* Align with last message in group */
-  margin-bottom: 4px; /* Optical alignment */
+  align-self: flex-start; /* Top-align with first message */
+  margin-top: 0;
 }
 
 .chat-avatar.user {

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -415,39 +415,44 @@
 
 /* Queue tab and panel - compact collapsible queue */
 .chat-queue-tab {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 4px 12px;
-  font-size: 11px;
-  font-weight: 500;
+  gap: 4px;
+  padding: 3px 10px;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
   color: var(--muted);
-  background: var(--bg-elevated);
+  background: var(--card);
   border: 1px solid var(--border);
   border-bottom: none;
-  border-radius: var(--radius-md) var(--radius-md) 0 0;
+  border-radius: 6px 6px 0 0;
   cursor: pointer;
   align-self: flex-start;
   margin-left: 14px;
-  transition: color 0.15s ease;
+  margin-bottom: -1px;
+  position: relative;
+  z-index: 1;
+  transition: color 0.15s ease, background 0.15s ease;
 }
 
 .chat-queue-tab:hover {
   color: var(--text);
+  background: var(--bg-elevated);
 }
 
 .chat-queue-panel {
   border: 1px solid var(--border);
-  border-radius: 0 var(--radius-md) 0 0;
-  background: var(--bg-elevated);
+  border-radius: 0 6px 0 0;
+  background: var(--card);
   margin: 0 14px;
-  padding: 8px;
+  margin-bottom: 4px;
+  padding: 6px;
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  max-height: 120px;
+  gap: 3px;
+  max-height: 100px;
   overflow-y: auto;
-  animation: rise 0.15s ease backwards;
 }
 
 .chat-queue-item {

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -417,52 +417,71 @@
 .chat-queue-tab {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 4px;
-  padding: 3px 10px;
+  padding: 8px 14px;
   font-size: 10px;
   font-weight: 600;
-  letter-spacing: 0.02em;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
   color: var(--muted);
-  background: var(--card);
-  border: 1px solid var(--border);
-  border-bottom: none;
-  border-radius: 6px 6px 0 0;
+  background: #000;
+  border: none;
+  border-radius: 8px 8px 0 0;
   cursor: pointer;
   align-self: flex-start;
   margin-left: 14px;
-  margin-bottom: -1px;
+  margin-bottom: 0;
   position: relative;
-  z-index: 1;
-  transition: color 0.15s ease, background 0.15s ease;
+  z-index: 2;
+  transition: color 0.15s ease;
+  /* Extend touch target */
+  min-height: 28px;
+}
+
+:root[data-theme="light"] .chat-queue-tab {
+  background: #e5e5e5;
+  color: #555;
 }
 
 .chat-queue-tab:hover {
   color: var(--text);
-  background: var(--bg-elevated);
 }
 
 .chat-queue-panel {
-  border: 1px solid var(--border);
-  border-radius: 0 6px 0 0;
-  background: var(--card);
+  background: #000;
+  border-radius: 0 8px 0 0;
   margin: 0 14px;
-  margin-bottom: 4px;
-  padding: 6px;
+  margin-bottom: 0;
+  padding: 8px;
   display: flex;
   flex-direction: column;
   gap: 3px;
-  max-height: 100px;
+  max-height: 120px;
   overflow-y: auto;
+  border: none;
+  /* Drawer effect: overlaps input area at bottom */
+  position: relative;
+  z-index: 1;
+  padding-bottom: 12px;
+}
+
+:root[data-theme="light"] .chat-queue-panel {
+  background: #e5e5e5;
 }
 
 .chat-queue-item {
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 4px 8px;
+  padding: 6px 10px;
   font-size: 12px;
   border-radius: var(--radius-sm);
-  background: var(--card);
+  background: rgba(255, 255, 255, 0.06);
+}
+
+:root[data-theme="light"] .chat-queue-item {
+  background: rgba(0, 0, 0, 0.05);
 }
 
 .chat-queue-text {

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -329,10 +329,21 @@
 /* Session tabs - chip bar */
 .chat-session-tabs {
   display: flex;
+  align-items: center;
   gap: 6px;
   padding: 8px 14px;
   overflow-x: auto;
   border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.chat-session-tabs__label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted);
+  margin-right: 4px;
   flex-shrink: 0;
 }
 
@@ -349,6 +360,7 @@
   cursor: pointer;
   white-space: nowrap;
   transition: all 0.15s ease;
+  flex-shrink: 0;
 }
 
 .chat-session-chip:hover {

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -413,6 +413,60 @@
   margin-top: 2px;
 }
 
+/* Queue tab and panel - compact collapsible queue */
+.chat-queue-tab {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--muted);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-bottom: none;
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
+  cursor: pointer;
+  align-self: flex-start;
+  margin-left: 14px;
+  transition: color 0.15s ease;
+}
+
+.chat-queue-tab:hover {
+  color: var(--text);
+}
+
+.chat-queue-panel {
+  border: 1px solid var(--border);
+  border-radius: 0 var(--radius-md) 0 0;
+  background: var(--bg-elevated);
+  margin: 0 14px;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 120px;
+  overflow-y: auto;
+  animation: rise 0.15s ease backwards;
+}
+
+.chat-queue-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 8px;
+  font-size: 12px;
+  border-radius: var(--radius-sm);
+  background: var(--card);
+}
+
+.chat-queue-text {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 /* Chat controls - moved to content-header area, left aligned */
 .chat-controls {
   display: flex;

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -262,8 +262,8 @@
 /* Compose input row - horizontal layout */
 .chat-compose__row {
   display: flex;
+  gap: 8px;
   align-items: stretch;
-  gap: 12px;
   flex: 1;
 }
 
@@ -272,6 +272,7 @@
 }
 
 .chat-compose__field {
+  position: relative;
   flex: 1 1 auto;
   min-width: 0;
   display: flex;
@@ -304,22 +305,100 @@
   cursor: not-allowed;
 }
 
+/* Stacked buttons - vertical layout beside input */
 .chat-compose__actions {
-  flex-shrink: 0;
   display: flex;
-  align-items: stretch;
-  gap: 8px;
+  flex-direction: column;
+  gap: 4px;
+  flex-shrink: 0;
+  width: 80px;
 }
 
 .chat-compose .chat-compose__actions .btn {
-  padding: 0 16px;
-  font-size: 13px;
-  height: 40px;
-  min-height: 40px;
-  max-height: 40px;
-  line-height: 1;
+  width: 100%;
+  font-size: 12px;
+  padding: 6px 8px;
+  height: auto;
+  min-height: unset;
+  max-height: unset;
+  line-height: 1.2;
   white-space: nowrap;
   box-sizing: border-box;
+}
+
+/* Session tabs - chip bar */
+.chat-session-tabs {
+  display: flex;
+  gap: 6px;
+  padding: 8px 14px;
+  overflow-x: auto;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.chat-session-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 12px;
+  font-size: 11px;
+  font-weight: 500;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--secondary);
+  color: var(--muted);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: all 0.15s ease;
+}
+
+.chat-session-chip:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
+.chat-session-chip.active {
+  background: rgba(59, 130, 246, 0.12);
+  border-color: var(--info);
+  color: var(--info);
+  box-shadow: 0 0 0 1px rgba(59, 130, 246, 0.3);
+}
+
+/* Autosuggest menu - positioned above textarea */
+.chat-compose__field .rpc-suggestions {
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  right: 0;
+  margin-bottom: 4px;
+  max-height: 200px;
+  overflow-y: auto;
+  background: var(--panel-strong);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+  z-index: 100;
+}
+
+.rpc-suggestion {
+  padding: 8px 12px;
+  cursor: pointer;
+  transition: background 150ms ease-out;
+}
+
+.rpc-suggestion:hover {
+  background: var(--bg-hover);
+}
+
+.rpc-suggestion__name {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text);
+}
+
+.rpc-suggestion__desc {
+  font-size: 11px;
+  color: var(--muted);
+  margin-top: 2px;
 }
 
 /* Chat controls - moved to content-header area, left aligned */

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -254,8 +254,16 @@ function renderGroupedMessage(
     .join(" ");
 
   // Tool results: show only the compact card, full output via sidebar "View"
-  if (isToolResult && hasToolCards) {
-    return html`${toolCards.map((card) => renderToolCardSidebar(card, onOpenSidebar))}`;
+  if (isToolResult) {
+    // If no cards extracted, synthesise one from the message text
+    const cards = hasToolCards
+      ? toolCards
+      : [{
+          kind: "result" as const,
+          name: (typeof m.toolName === "string" && m.toolName) || (typeof m.tool_name === "string" && m.tool_name as string) || "tool",
+          text: extractedText ?? undefined,
+        }];
+    return html`${cards.map((card) => renderToolCardSidebar(card, onOpenSidebar))}`;
   }
 
   if (!markdown && hasToolCards) {

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -253,7 +253,12 @@ function renderGroupedMessage(
     .filter(Boolean)
     .join(" ");
 
-  if (!markdown && hasToolCards && isToolResult) {
+  // Tool results: show only the compact card, full output via sidebar "View"
+  if (isToolResult && hasToolCards) {
+    return html`${toolCards.map((card) => renderToolCardSidebar(card, onOpenSidebar))}`;
+  }
+
+  if (!markdown && hasToolCards) {
     return html`${toolCards.map((card) => renderToolCardSidebar(card, onOpenSidebar))}`;
   }
 

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -12,6 +12,7 @@ import {
 } from "./message-extract.ts";
 import { isToolResultMessage, normalizeRoleForGrouping } from "./message-normalizer.ts";
 import { extractToolCards, renderToolCardSidebar } from "./tool-cards.ts";
+import { icons } from "../icons.ts";
 
 type ImageBlock = {
   url: string;
@@ -164,7 +165,7 @@ function renderAvatar(role: string, assistant?: Pick<AssistantIdentity, "name" |
       : normalized === "assistant"
         ? assistantName.charAt(0).toUpperCase() || "A"
         : normalized === "tool"
-          ? "⚙"
+          ? html`<span class="icon-sm" style="width:14px;height:14px;">${icons.wrench}</span>`
           : "?";
   const className =
     normalized === "user"

--- a/ui/src/ui/chat/tool-cards.ts
+++ b/ui/src/ui/chat/tool-cards.ts
@@ -2,10 +2,9 @@ import { html, nothing } from "lit";
 import type { ToolCard } from "../types/chat-types.ts";
 import { icons } from "../icons.ts";
 import { formatToolDetail, resolveToolDisplay } from "../tool-display.ts";
-import { TOOL_INLINE_THRESHOLD } from "./constants.ts";
 import { extractTextCached } from "./message-extract.ts";
 import { isToolResultMessage } from "./message-normalizer.ts";
-import { formatToolOutputForSidebar, getTruncatedPreview } from "./tool-helpers.ts";
+import { formatToolOutputForSidebar } from "./tool-helpers.ts";
 
 export function extractToolCards(message: unknown): ToolCard[] {
   const m = message as Record<string, unknown>;
@@ -67,9 +66,6 @@ export function renderToolCardSidebar(card: ToolCard, onOpenSidebar?: (content: 
       }
     : undefined;
 
-  const isShort = hasText && (card.text?.length ?? 0) <= TOOL_INLINE_THRESHOLD;
-  const showCollapsed = hasText && !isShort;
-  const showInline = hasText && isShort;
   const isEmpty = !hasText;
 
   return html`
@@ -110,12 +106,6 @@ export function renderToolCardSidebar(card: ToolCard, onOpenSidebar?: (content: 
             `
           : nothing
       }
-      ${
-        showCollapsed
-          ? html`<div class="chat-tool-card__preview mono">${getTruncatedPreview(card.text!)}</div>`
-          : nothing
-      }
-      ${showInline ? html`<div class="chat-tool-card__inline mono">${card.text}</div>` : nothing}
     </div>
   `;
 }

--- a/ui/src/ui/views/channels.discord.ts
+++ b/ui/src/ui/views/channels.discord.ts
@@ -2,7 +2,9 @@ import { html, nothing } from "lit";
 import type { DiscordStatus } from "../types.ts";
 import type { ChannelsProps } from "./channels.types.ts";
 import { formatRelativeTimestamp } from "../format.ts";
+import { icons } from "../icons.ts";
 import { renderChannelConfigSection } from "./channels.config.ts";
+import { statusChip } from "./channels.shared.ts";
 
 export function renderDiscordCard(params: {
   props: ChannelsProps;
@@ -12,53 +14,60 @@ export function renderDiscordCard(params: {
   const { props, discord, accountCountLabel } = params;
 
   return html`
-    <div class="card">
-      <div class="card-title">Discord</div>
-      <div class="card-sub">Bot status and channel configuration.</div>
-      ${accountCountLabel}
-
-      <div class="status-list" style="margin-top: 16px;">
-        <div>
-          <span class="label">Configured</span>
-          <span>${discord?.configured ? "Yes" : "No"}</span>
+    <div class="card" style="padding: 0;">
+      <div style="padding: 12px 14px; border-bottom: 1px solid var(--border);">
+        <div class="card-title" style="margin: 0; display: flex; align-items: center; gap: 8px;">
+          <span class="icon" style="width: 16px; height: 16px;">${icons.messageSquare}</span>
+          Discord
         </div>
-        <div>
-          <span class="label">Running</span>
-          <span>${discord?.running ? "Yes" : "No"}</span>
-        </div>
-        <div>
-          <span class="label">Last start</span>
-          <span>${discord?.lastStartAt ? formatRelativeTimestamp(discord.lastStartAt) : "n/a"}</span>
-        </div>
-        <div>
-          <span class="label">Last probe</span>
-          <span>${discord?.lastProbeAt ? formatRelativeTimestamp(discord.lastProbeAt) : "n/a"}</span>
-        </div>
+        <div class="card-sub" style="margin: 0;">Bot status and channel configuration.</div>
+        ${accountCountLabel}
       </div>
 
-      ${
-        discord?.lastError
-          ? html`<div class="callout danger" style="margin-top: 12px;">
-            ${discord.lastError}
-          </div>`
-          : nothing
-      }
+      <div style="padding: 12px 14px;">
+        <div class="status-list">
+          <div>
+            <span class="label">Configured</span>
+            ${statusChip(discord?.configured)}
+          </div>
+          <div>
+            <span class="label">Running</span>
+            ${statusChip(discord?.running)}
+          </div>
+          <div>
+            <span class="label">Last start</span>
+            <span>${discord?.lastStartAt ? formatRelativeTimestamp(discord.lastStartAt) : "n/a"}</span>
+          </div>
+          <div>
+            <span class="label">Last probe</span>
+            <span>${discord?.lastProbeAt ? formatRelativeTimestamp(discord.lastProbeAt) : "n/a"}</span>
+          </div>
+        </div>
 
-      ${
-        discord?.probe
-          ? html`<div class="callout" style="margin-top: 12px;">
-            Probe ${discord.probe.ok ? "ok" : "failed"} ·
-            ${discord.probe.status ?? ""} ${discord.probe.error ?? ""}
-          </div>`
-          : nothing
-      }
+        ${
+          discord?.lastError
+            ? html`<div class="callout danger" style="margin-top: 12px;">
+              ${discord.lastError}
+            </div>`
+            : nothing
+        }
 
-      ${renderChannelConfigSection({ channelId: "discord", props })}
+        ${
+          discord?.probe
+            ? html`<div class="callout" style="margin-top: 12px;">
+              Probe ${discord.probe.ok ? "ok" : "failed"} ·
+              ${discord.probe.status ?? ""} ${discord.probe.error ?? ""}
+            </div>`
+            : nothing
+        }
 
-      <div class="row" style="margin-top: 12px;">
-        <button class="btn" @click=${() => props.onRefresh(true)}>
-          Probe
-        </button>
+        ${renderChannelConfigSection({ channelId: "discord", props })}
+
+        <div class="row" style="margin-top: 12px;">
+          <button class="btn" @click=${() => props.onRefresh(true)}>
+            Probe
+          </button>
+        </div>
       </div>
     </div>
   `;

--- a/ui/src/ui/views/channels.shared.ts
+++ b/ui/src/ui/views/channels.shared.ts
@@ -36,3 +36,12 @@ export function renderChannelAccountCount(
   }
   return html`<div class="account-count">Accounts (${count})</div>`;
 }
+
+export function statusChip(value: boolean | null | undefined, yesLabel = "YES", noLabel = "NO", naLabel = "N/A") {
+  if (value === null || value === undefined) {
+    return html`<span class="log-level" style="width: 54px; text-align: center;">${naLabel}</span>`;
+  }
+  return value
+    ? html`<span class="log-level info" style="width: 54px; text-align: center;">${yesLabel}</span>`
+    : html`<span class="log-level warn" style="width: 54px; text-align: center;">${noLabel}</span>`;
+}

--- a/ui/src/ui/views/channels.signal.ts
+++ b/ui/src/ui/views/channels.signal.ts
@@ -2,7 +2,9 @@ import { html, nothing } from "lit";
 import type { SignalStatus } from "../types.ts";
 import type { ChannelsProps } from "./channels.types.ts";
 import { formatRelativeTimestamp } from "../format.ts";
+import { icons } from "../icons.ts";
 import { renderChannelConfigSection } from "./channels.config.ts";
+import { statusChip } from "./channels.shared.ts";
 
 export function renderSignalCard(params: {
   props: ChannelsProps;
@@ -12,57 +14,64 @@ export function renderSignalCard(params: {
   const { props, signal, accountCountLabel } = params;
 
   return html`
-    <div class="card">
-      <div class="card-title">Signal</div>
-      <div class="card-sub">signal-cli status and channel configuration.</div>
-      ${accountCountLabel}
-
-      <div class="status-list" style="margin-top: 16px;">
-        <div>
-          <span class="label">Configured</span>
-          <span>${signal?.configured ? "Yes" : "No"}</span>
+    <div class="card" style="padding: 0;">
+      <div style="padding: 12px 14px; border-bottom: 1px solid var(--border);">
+        <div class="card-title" style="margin: 0; display: flex; align-items: center; gap: 8px;">
+          <span class="icon" style="width: 16px; height: 16px;">${icons.messageSquare}</span>
+          Signal
         </div>
-        <div>
-          <span class="label">Running</span>
-          <span>${signal?.running ? "Yes" : "No"}</span>
-        </div>
-        <div>
-          <span class="label">Base URL</span>
-          <span>${signal?.baseUrl ?? "n/a"}</span>
-        </div>
-        <div>
-          <span class="label">Last start</span>
-          <span>${signal?.lastStartAt ? formatRelativeTimestamp(signal.lastStartAt) : "n/a"}</span>
-        </div>
-        <div>
-          <span class="label">Last probe</span>
-          <span>${signal?.lastProbeAt ? formatRelativeTimestamp(signal.lastProbeAt) : "n/a"}</span>
-        </div>
+        <div class="card-sub" style="margin: 0;">signal-cli status and channel configuration.</div>
+        ${accountCountLabel}
       </div>
 
-      ${
-        signal?.lastError
-          ? html`<div class="callout danger" style="margin-top: 12px;">
-            ${signal.lastError}
-          </div>`
-          : nothing
-      }
+      <div style="padding: 12px 14px;">
+        <div class="status-list">
+          <div>
+            <span class="label">Configured</span>
+            ${statusChip(signal?.configured)}
+          </div>
+          <div>
+            <span class="label">Running</span>
+            ${statusChip(signal?.running)}
+          </div>
+          <div>
+            <span class="label">Base URL</span>
+            <span>${signal?.baseUrl ?? "n/a"}</span>
+          </div>
+          <div>
+            <span class="label">Last start</span>
+            <span>${signal?.lastStartAt ? formatRelativeTimestamp(signal.lastStartAt) : "n/a"}</span>
+          </div>
+          <div>
+            <span class="label">Last probe</span>
+            <span>${signal?.lastProbeAt ? formatRelativeTimestamp(signal.lastProbeAt) : "n/a"}</span>
+          </div>
+        </div>
 
-      ${
-        signal?.probe
-          ? html`<div class="callout" style="margin-top: 12px;">
-            Probe ${signal.probe.ok ? "ok" : "failed"} ·
-            ${signal.probe.status ?? ""} ${signal.probe.error ?? ""}
-          </div>`
-          : nothing
-      }
+        ${
+          signal?.lastError
+            ? html`<div class="callout danger" style="margin-top: 12px;">
+              ${signal.lastError}
+            </div>`
+            : nothing
+        }
 
-      ${renderChannelConfigSection({ channelId: "signal", props })}
+        ${
+          signal?.probe
+            ? html`<div class="callout" style="margin-top: 12px;">
+              Probe ${signal.probe.ok ? "ok" : "failed"} ·
+              ${signal.probe.status ?? ""} ${signal.probe.error ?? ""}
+            </div>`
+            : nothing
+        }
 
-      <div class="row" style="margin-top: 12px;">
-        <button class="btn" @click=${() => props.onRefresh(true)}>
-          Probe
-        </button>
+        ${renderChannelConfigSection({ channelId: "signal", props })}
+
+        <div class="row" style="margin-top: 12px;">
+          <button class="btn" @click=${() => props.onRefresh(true)}>
+            Probe
+          </button>
+        </div>
       </div>
     </div>
   `;

--- a/ui/src/ui/views/channels.slack.ts
+++ b/ui/src/ui/views/channels.slack.ts
@@ -2,7 +2,9 @@ import { html, nothing } from "lit";
 import type { SlackStatus } from "../types.ts";
 import type { ChannelsProps } from "./channels.types.ts";
 import { formatRelativeTimestamp } from "../format.ts";
+import { icons } from "../icons.ts";
 import { renderChannelConfigSection } from "./channels.config.ts";
+import { statusChip } from "./channels.shared.ts";
 
 export function renderSlackCard(params: {
   props: ChannelsProps;
@@ -12,53 +14,60 @@ export function renderSlackCard(params: {
   const { props, slack, accountCountLabel } = params;
 
   return html`
-    <div class="card">
-      <div class="card-title">Slack</div>
-      <div class="card-sub">Socket mode status and channel configuration.</div>
-      ${accountCountLabel}
-
-      <div class="status-list" style="margin-top: 16px;">
-        <div>
-          <span class="label">Configured</span>
-          <span>${slack?.configured ? "Yes" : "No"}</span>
+    <div class="card" style="padding: 0;">
+      <div style="padding: 12px 14px; border-bottom: 1px solid var(--border);">
+        <div class="card-title" style="margin: 0; display: flex; align-items: center; gap: 8px;">
+          <span class="icon" style="width: 16px; height: 16px;">${icons.messageSquare}</span>
+          Slack
         </div>
-        <div>
-          <span class="label">Running</span>
-          <span>${slack?.running ? "Yes" : "No"}</span>
-        </div>
-        <div>
-          <span class="label">Last start</span>
-          <span>${slack?.lastStartAt ? formatRelativeTimestamp(slack.lastStartAt) : "n/a"}</span>
-        </div>
-        <div>
-          <span class="label">Last probe</span>
-          <span>${slack?.lastProbeAt ? formatRelativeTimestamp(slack.lastProbeAt) : "n/a"}</span>
-        </div>
+        <div class="card-sub" style="margin: 0;">Socket mode status and channel configuration.</div>
+        ${accountCountLabel}
       </div>
 
-      ${
-        slack?.lastError
-          ? html`<div class="callout danger" style="margin-top: 12px;">
-            ${slack.lastError}
-          </div>`
-          : nothing
-      }
+      <div style="padding: 12px 14px;">
+        <div class="status-list">
+          <div>
+            <span class="label">Configured</span>
+            ${statusChip(slack?.configured)}
+          </div>
+          <div>
+            <span class="label">Running</span>
+            ${statusChip(slack?.running)}
+          </div>
+          <div>
+            <span class="label">Last start</span>
+            <span>${slack?.lastStartAt ? formatRelativeTimestamp(slack.lastStartAt) : "n/a"}</span>
+          </div>
+          <div>
+            <span class="label">Last probe</span>
+            <span>${slack?.lastProbeAt ? formatRelativeTimestamp(slack.lastProbeAt) : "n/a"}</span>
+          </div>
+        </div>
 
-      ${
-        slack?.probe
-          ? html`<div class="callout" style="margin-top: 12px;">
-            Probe ${slack.probe.ok ? "ok" : "failed"} ·
-            ${slack.probe.status ?? ""} ${slack.probe.error ?? ""}
-          </div>`
-          : nothing
-      }
+        ${
+          slack?.lastError
+            ? html`<div class="callout danger" style="margin-top: 12px;">
+              ${slack.lastError}
+            </div>`
+            : nothing
+        }
 
-      ${renderChannelConfigSection({ channelId: "slack", props })}
+        ${
+          slack?.probe
+            ? html`<div class="callout" style="margin-top: 12px;">
+              Probe ${slack.probe.ok ? "ok" : "failed"} ·
+              ${slack.probe.status ?? ""} ${slack.probe.error ?? ""}
+            </div>`
+            : nothing
+        }
 
-      <div class="row" style="margin-top: 12px;">
-        <button class="btn" @click=${() => props.onRefresh(true)}>
-          Probe
-        </button>
+        ${renderChannelConfigSection({ channelId: "slack", props })}
+
+        <div class="row" style="margin-top: 12px;">
+          <button class="btn" @click=${() => props.onRefresh(true)}>
+            Probe
+          </button>
+        </div>
       </div>
     </div>
   `;

--- a/ui/src/ui/views/channels.telegram.ts
+++ b/ui/src/ui/views/channels.telegram.ts
@@ -2,7 +2,9 @@ import { html, nothing } from "lit";
 import type { ChannelAccountSnapshot, TelegramStatus } from "../types.ts";
 import type { ChannelsProps } from "./channels.types.ts";
 import { formatRelativeTimestamp } from "../format.ts";
+import { icons } from "../icons.ts";
 import { renderChannelConfigSection } from "./channels.config.ts";
+import { statusChip } from "./channels.shared.ts";
 
 export function renderTelegramCard(params: {
   props: ChannelsProps;
@@ -28,11 +30,11 @@ export function renderTelegramCard(params: {
         <div class="status-list account-card-status">
           <div>
             <span class="label">Running</span>
-            <span>${account.running ? "Yes" : "No"}</span>
+            ${statusChip(account.running)}
           </div>
           <div>
             <span class="label">Configured</span>
-            <span>${account.configured ? "Yes" : "No"}</span>
+            ${statusChip(account.configured)}
           </div>
           <div>
             <span class="label">Last inbound</span>
@@ -53,67 +55,76 @@ export function renderTelegramCard(params: {
   };
 
   return html`
-    <div class="card">
-      <div class="card-title">Telegram</div>
-      <div class="card-sub">Bot status and channel configuration.</div>
-      ${accountCountLabel}
+    <div class="card" style="padding: 0;">
+      <div style="padding: 12px 14px; border-bottom: 1px solid var(--border);">
+        <div class="card-title" style="margin: 0; display: flex; align-items: center; gap: 8px;">
+          <span class="icon" style="width: 16px; height: 16px;">${icons.messageSquare}</span>
+          Telegram
+        </div>
+        <div class="card-sub" style="margin: 0;">Bot status and channel configuration.</div>
+        ${accountCountLabel}
+      </div>
 
-      ${
-        hasMultipleAccounts
-          ? html`
-            <div class="account-card-list">
-              ${telegramAccounts.map((account) => renderAccountCard(account))}
-            </div>
-          `
-          : html`
-            <div class="status-list" style="margin-top: 16px;">
-              <div>
-                <span class="label">Configured</span>
-                <span>${telegram?.configured ? "Yes" : "No"}</span>
+      <div style="padding: 12px 14px;">
+        ${
+          hasMultipleAccounts
+            ? html`
+              <div class="account-card-list">
+                ${telegramAccounts.map((account) => renderAccountCard(account))}
               </div>
-              <div>
-                <span class="label">Running</span>
-                <span>${telegram?.running ? "Yes" : "No"}</span>
+            `
+            : html`
+              <div class="status-list">
+                <div>
+                  <span class="label">Configured</span>
+                  <span>${telegram?.configured ? "Yes" : "No"}</span>
+                </div>
+                <div>
+                  <span class="label">Running</span>
+                  <span class="log-level ${telegram?.running ? "info" : "warn"}">
+                    ${telegram?.running ? "Yes" : "No"}
+                  </span>
+                </div>
+                <div>
+                  <span class="label">Mode</span>
+                  <span>${telegram?.mode ?? "n/a"}</span>
+                </div>
+                <div>
+                  <span class="label">Last start</span>
+                  <span>${telegram?.lastStartAt ? formatRelativeTimestamp(telegram.lastStartAt) : "n/a"}</span>
+                </div>
+                <div>
+                  <span class="label">Last probe</span>
+                  <span>${telegram?.lastProbeAt ? formatRelativeTimestamp(telegram.lastProbeAt) : "n/a"}</span>
+                </div>
               </div>
-              <div>
-                <span class="label">Mode</span>
-                <span>${telegram?.mode ?? "n/a"}</span>
-              </div>
-              <div>
-                <span class="label">Last start</span>
-                <span>${telegram?.lastStartAt ? formatRelativeTimestamp(telegram.lastStartAt) : "n/a"}</span>
-              </div>
-              <div>
-                <span class="label">Last probe</span>
-                <span>${telegram?.lastProbeAt ? formatRelativeTimestamp(telegram.lastProbeAt) : "n/a"}</span>
-              </div>
-            </div>
-          `
-      }
+            `
+        }
 
-      ${
-        telegram?.lastError
-          ? html`<div class="callout danger" style="margin-top: 12px;">
-            ${telegram.lastError}
-          </div>`
-          : nothing
-      }
+        ${
+          telegram?.lastError
+            ? html`<div class="callout danger" style="margin-top: 12px;">
+              ${telegram.lastError}
+            </div>`
+            : nothing
+        }
 
-      ${
-        telegram?.probe
-          ? html`<div class="callout" style="margin-top: 12px;">
-            Probe ${telegram.probe.ok ? "ok" : "failed"} ·
-            ${telegram.probe.status ?? ""} ${telegram.probe.error ?? ""}
-          </div>`
-          : nothing
-      }
+        ${
+          telegram?.probe
+            ? html`<div class="callout" style="margin-top: 12px;">
+              Probe ${telegram.probe.ok ? "ok" : "failed"} ·
+              ${telegram.probe.status ?? ""} ${telegram.probe.error ?? ""}
+            </div>`
+            : nothing
+        }
 
-      ${renderChannelConfigSection({ channelId: "telegram", props })}
+        ${renderChannelConfigSection({ channelId: "telegram", props })}
 
-      <div class="row" style="margin-top: 12px;">
-        <button class="btn" @click=${() => props.onRefresh(true)}>
-          Probe
-        </button>
+        <div class="row" style="margin-top: 12px;">
+          <button class="btn" @click=${() => props.onRefresh(true)}>
+            Probe
+          </button>
+        </div>
       </div>
     </div>
   `;

--- a/ui/src/ui/views/channels.telegram.ts
+++ b/ui/src/ui/views/channels.telegram.ts
@@ -77,13 +77,11 @@ export function renderTelegramCard(params: {
               <div class="status-list">
                 <div>
                   <span class="label">Configured</span>
-                  <span>${telegram?.configured ? "Yes" : "No"}</span>
+                  ${statusChip(telegram?.configured)}
                 </div>
                 <div>
                   <span class="label">Running</span>
-                  <span class="log-level ${telegram?.running ? "info" : "warn"}">
-                    ${telegram?.running ? "Yes" : "No"}
-                  </span>
+                  ${statusChip(telegram?.running)}
                 </div>
                 <div>
                   <span class="label">Mode</span>

--- a/ui/src/ui/views/channels.whatsapp.ts
+++ b/ui/src/ui/views/channels.whatsapp.ts
@@ -2,7 +2,9 @@ import { html, nothing } from "lit";
 import type { WhatsAppStatus } from "../types.ts";
 import type { ChannelsProps } from "./channels.types.ts";
 import { formatRelativeTimestamp, formatDurationHuman } from "../format.ts";
+import { icons } from "../icons.ts";
 import { renderChannelConfigSection } from "./channels.config.ts";
+import { statusChip } from "./channels.shared.ts";
 
 export function renderWhatsAppCard(params: {
   props: ChannelsProps;
@@ -12,107 +14,114 @@ export function renderWhatsAppCard(params: {
   const { props, whatsapp, accountCountLabel } = params;
 
   return html`
-    <div class="card">
-      <div class="card-title">WhatsApp</div>
-      <div class="card-sub">Link WhatsApp Web and monitor connection health.</div>
-      ${accountCountLabel}
-
-      <div class="status-list" style="margin-top: 16px;">
-        <div>
-          <span class="label">Configured</span>
-          <span>${whatsapp?.configured ? "Yes" : "No"}</span>
+    <div class="card" style="padding: 0;">
+      <div style="padding: 12px 14px; border-bottom: 1px solid var(--border);">
+        <div class="card-title" style="margin: 0; display: flex; align-items: center; gap: 8px;">
+          <span class="icon" style="width: 16px; height: 16px;">${icons.smartphone}</span>
+          WhatsApp
         </div>
-        <div>
-          <span class="label">Linked</span>
-          <span>${whatsapp?.linked ? "Yes" : "No"}</span>
-        </div>
-        <div>
-          <span class="label">Running</span>
-          <span>${whatsapp?.running ? "Yes" : "No"}</span>
-        </div>
-        <div>
-          <span class="label">Connected</span>
-          <span>${whatsapp?.connected ? "Yes" : "No"}</span>
-        </div>
-        <div>
-          <span class="label">Last connect</span>
-          <span>
-            ${whatsapp?.lastConnectedAt ? formatRelativeTimestamp(whatsapp.lastConnectedAt) : "n/a"}
-          </span>
-        </div>
-        <div>
-          <span class="label">Last message</span>
-          <span>
-            ${whatsapp?.lastMessageAt ? formatRelativeTimestamp(whatsapp.lastMessageAt) : "n/a"}
-          </span>
-        </div>
-        <div>
-          <span class="label">Auth age</span>
-          <span>
-            ${whatsapp?.authAgeMs != null ? formatDurationHuman(whatsapp.authAgeMs) : "n/a"}
-          </span>
-        </div>
+        <div class="card-sub" style="margin: 0;">Link WhatsApp Web and monitor connection health.</div>
+        ${accountCountLabel}
       </div>
 
-      ${
-        whatsapp?.lastError
-          ? html`<div class="callout danger" style="margin-top: 12px;">
-            ${whatsapp.lastError}
-          </div>`
-          : nothing
-      }
+      <div style="padding: 12px 14px;">
+        <div class="status-list">
+          <div>
+            <span class="label">Configured</span>
+            ${statusChip(whatsapp?.configured)}
+          </div>
+          <div>
+            <span class="label">Linked</span>
+            ${statusChip(whatsapp?.linked)}
+          </div>
+          <div>
+            <span class="label">Running</span>
+            ${statusChip(whatsapp?.running)}
+          </div>
+          <div>
+            <span class="label">Connected</span>
+            ${statusChip(whatsapp?.connected)}
+          </div>
+          <div>
+            <span class="label">Last connect</span>
+            <span>
+              ${whatsapp?.lastConnectedAt ? formatRelativeTimestamp(whatsapp.lastConnectedAt) : "n/a"}
+            </span>
+          </div>
+          <div>
+            <span class="label">Last message</span>
+            <span>
+              ${whatsapp?.lastMessageAt ? formatRelativeTimestamp(whatsapp.lastMessageAt) : "n/a"}
+            </span>
+          </div>
+          <div>
+            <span class="label">Auth age</span>
+            <span>
+              ${whatsapp?.authAgeMs != null ? formatDurationHuman(whatsapp.authAgeMs) : "n/a"}
+            </span>
+          </div>
+        </div>
 
-      ${
-        props.whatsappMessage
-          ? html`<div class="callout" style="margin-top: 12px;">
-            ${props.whatsappMessage}
-          </div>`
-          : nothing
-      }
+        ${
+          whatsapp?.lastError
+            ? html`<div class="callout danger" style="margin-top: 12px;">
+              ${whatsapp.lastError}
+            </div>`
+            : nothing
+        }
 
-      ${
-        props.whatsappQrDataUrl
-          ? html`<div class="qr-wrap">
-            <img src=${props.whatsappQrDataUrl} alt="WhatsApp QR" />
-          </div>`
-          : nothing
-      }
+        ${
+          props.whatsappMessage
+            ? html`<div class="callout" style="margin-top: 12px;">
+              ${props.whatsappMessage}
+            </div>`
+            : nothing
+        }
 
-      <div class="row" style="margin-top: 14px; flex-wrap: wrap;">
-        <button
-          class="btn primary"
-          ?disabled=${props.whatsappBusy}
-          @click=${() => props.onWhatsAppStart(false)}
-        >
-          ${props.whatsappBusy ? "Working…" : "Show QR"}
-        </button>
-        <button
-          class="btn"
-          ?disabled=${props.whatsappBusy}
-          @click=${() => props.onWhatsAppStart(true)}
-        >
-          Relink
-        </button>
-        <button
-          class="btn"
-          ?disabled=${props.whatsappBusy}
-          @click=${() => props.onWhatsAppWait()}
-        >
-          Wait for scan
-        </button>
-        <button
-          class="btn danger"
-          ?disabled=${props.whatsappBusy}
-          @click=${() => props.onWhatsAppLogout()}
-        >
-          Logout
-        </button>
-        <button class="btn" @click=${() => props.onRefresh(true)}>
-          Refresh
-        </button>
+        ${
+          props.whatsappQrDataUrl
+            ? html`<div class="qr-wrap">
+              <img src=${props.whatsappQrDataUrl} alt="WhatsApp QR" />
+            </div>`
+            : nothing
+        }
+
+        <div class="row" style="margin-top: 14px; flex-wrap: wrap;">
+          <button
+            class="btn primary"
+            ?disabled=${props.whatsappBusy}
+            @click=${() => props.onWhatsAppStart(false)}
+          >
+            ${props.whatsappBusy ? "Working…" : "Show QR"}
+          </button>
+          <button
+            class="btn"
+            ?disabled=${props.whatsappBusy}
+            @click=${() => props.onWhatsAppStart(true)}
+          >
+            Relink
+          </button>
+          <button
+            class="btn"
+            ?disabled=${props.whatsappBusy}
+            @click=${() => props.onWhatsAppWait()}
+          >
+            Wait for scan
+          </button>
+          <button
+            class="btn danger"
+            ?disabled=${props.whatsappBusy}
+            @click=${() => props.onWhatsAppLogout()}
+          >
+            Logout
+          </button>
+          <button class="btn" @click=${() => props.onRefresh(true)}>
+            Refresh
+          </button>
+        </div>
+
+        ${renderChannelConfigSection({ channelId: "whatsapp", props })}
       </div>
-
-      ${renderChannelConfigSection({ channelId: "whatsapp", props })}
     </div>
   `;
 }

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -542,7 +542,7 @@ export function renderChat(props: ChatProps) {
               queueExpanded = !queueExpanded;
             }}>
               <span>Queued (${props.queue.length})</span>
-              <span class="icon-sm" style="width:10px;height:10px;">${queueExpanded ? icons.arrowDown : icons.arrowDown}</span>
+              <span class="icon-sm" style="width:10px;height:10px;${queueExpanded ? '' : 'transform:rotate(180deg)'}">${icons.arrowDown}</span>
             </div>
             ${
               queueExpanded


### PR DESCRIPTION
## Summary
Describe the problem and fix in 2–5 bullets:
- Problem: Chat interface cluttered with large queue blocks, inconsistent layouts, and verbose tool output
- Why it matters: Poor UX hinders productivity and makes chat harder to scan
- What changed: Stacked buttons, collapsible queue drawer, compact tool cards, session tabs, system event dividers
- What did NOT change (scope boundary): No backend changes, no message processing logic changes, only UI presentation

## Change Type (select all)
- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes: None
- Related: None

## User-visible / Behavior Changes
- Chat input area now has stacked buttons instead of inline
- Queue moved to collapsible drawer tab (flush to input area)
- Tool results always render as compact cards (no inline output)
- "View" button on tool cards opens sidebar with full output
- Session tabs show recent sessions sorted by last activity
- System events (new session, heartbeat, model change) shown as dividers
- Avatar alignment changed to top-align with first message in group
- Queue drawer has black background, taller clickable tab
- Slash commands for quick actions

## Security Impact (required)
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Environment
- OS: macOS
- Runtime: Node v22
- Model/provider: n/a (UI only)

### Steps
1. Open Control UI chat view
2. Send messages and observe grouped layout
3. Execute tools and observe compact cards
4. Click "View" on tool card to see sidebar output
5. Click queue tab to expand/collapse drawer
6. Switch between recent sessions in session tabs
7. Test across different channel types (Discord, Telegram, Signal, WhatsApp, Slack)

## Evidence
- Screenshots to follow — testing on dev gateway

## Human Verification (required)
- Verified scenarios:
  - Queue drawer expands/collapses correctly
  - Tool cards render compactly with "View" button
  - Session tabs display recent sessions
  - System event dividers appear correctly
  - Message grouping and avatar alignment works
- Edge cases checked:
  - Long tool output truncates properly
  - Queue drawer with many items
  - Switching sessions preserves scroll position
- What you did not verify:
  - RTL language layouts
  - Extremely long session names
  - Performance with 1000+ messages in history

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to revert: revert the commits
- Known bad symptoms: Tool output not showing, queue drawer not appearing, layout broken

## Risks and Mitigations
- Risk: Tool output hidden by default might confuse users
  - Mitigation: Clear "View" button on every tool card; sidebar opens automatically for errors
- Risk: Queue drawer collapsed by default might be overlooked
  - Mitigation: Tab is prominent and clickable; badge shows item count
- Risk: CSS changes might conflict with custom themes
  - Mitigation: Used CSS custom properties and scoped classes

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR delivers a substantial UX overhaul for the chat interface with improved layout, session management, and tool card rendering. The changes successfully implement stacked action buttons, collapsible queue drawer, session tabs, system event dividers, and compact tool cards.

Key improvements implemented:
- Compact tool results now render as cards with sidebar "View" button for detailed output
- Queue drawer with collapsible black-background tab positioned flush to input area
- Session tabs bar showing recent sessions for easier navigation
- Avatar alignment changed from bottom-align to top-align for cleaner grouping
- Autosuggest menus for slash commands and `@`-mentions
- System event dividers for session changes, heartbeats, and model changes
- Consistent styling updates across all channel views (Discord, Telegram, Signal, Slack, WhatsApp)

Minor issues found:
- Module-level state variables could cause issues if multiple chat instances exist simultaneously (rare edge case)
- Cursor position capture timing in `@`-mention autocomplete may insert at wrong position if user moves cursor
- Direct DOM query for textarea ref instead of using the stored ref from the callback

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk — the UX improvements are well-implemented and the issues found are edge cases that won't affect typical usage.
- Score reflects solid implementation of a complex UX overhaul with multiple moving parts. The logical issues identified (module-level state, cursor position capture, DOM queries) are real but unlikely to manifest in production since the application typically runs a single chat instance. The changes are primarily additive and don't modify core business logic. The consistent styling updates across all channel types show thorough implementation. Testing was documented for all channel types.
- Pay closer attention to `ui/src/ui/views/chat.ts` if you plan to support multiple simultaneous chat instances — the module-level state will need refactoring.

<sub>Last reviewed commit: 162d919</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->