### PR TITLE
Fix debug console.log in skill filter to use subsystem logger

### DIFF
--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -54,12 +54,12 @@ function filterSkillEntries(
   if (skillFilter !== undefined) {
     const normalized = skillFilter.map((entry) => String(entry).trim()).filter(Boolean);
     const label = normalized.length > 0 ? normalized.join(", ") : "(none)";
-    console.log(`[skills] Applying skill filter: ${label}`);
+    skillsLogger.debug(`Applying skill filter: ${label}`);
     filtered =
       normalized.length > 0
         ? filtered.filter((entry) => normalized.includes(entry.skill.name))
         : [];
-    console.log(`[skills] After filter: ${filtered.map((entry) => entry.skill.name).join(", ")}`);
+    skillsLogger.debug(`After filter: ${filtered.map((entry) => entry.skill.name).join(", ")}`);
   }
   return filtered;
 }


### PR DESCRIPTION
## What
Replace two raw `console.log` calls in `filterSkillEntries` with the existing `skillsLogger.debug`.

## Why
The `skills/workspace.ts` module already creates a subsystem logger on line 31, but the skill filter function still uses `console.log` directly. This produces noisy output in production when skill filters are applied.

## How
Changed `console.log(`[skills] ...`)` → `skillsLogger.debug(...)` on lines 57 and 62.

## Test
Verified the module already has `skillsLogger` initialized. The change is a direct substitution with no behavior change beyond routing output through the logging subsystem.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Replaced two raw `console.log` calls in `filterSkillEntries` with the existing `skillsLogger.debug` subsystem logger. The `[skills]` prefix was correctly removed from the log messages since the subsystem logger handles this automatically.

- Changed lines 57 and 62 to use `skillsLogger.debug()` instead of `console.log()`
- Properly routes debug output through the logging subsystem as intended
- No functional changes to logic or behavior

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change is a simple, well-scoped refactor that replaces two debug console.log calls with the existing subsystem logger. The logger is properly defined on line 31, the change is correctly implemented with the [skills] prefix removed (since the subsystem logger handles this automatically), and there are no logic changes. This is exactly the type of cleanup that improves code consistency and logging control.
- No files require special attention

<sub>Last reviewed commit: 3cf6622</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->