### PR TITLE
Fix LINE webhook verification failing for empty events

### DIFF
--- a/src/line/webhook.test.ts
+++ b/src/line/webhook.test.ts
@@ -58,6 +58,46 @@ describe("createLineWebhookMiddleware", () => {
     expect(onEvents).toHaveBeenCalledWith(expect.objectContaining({ events: expect.any(Array) }));
   });
 
+  it("returns 200 for LINE verification request (empty events, no signature)", async () => {
+    const onEvents = vi.fn(async () => {});
+    const secret = "secret";
+    const middleware = createLineWebhookMiddleware({ channelSecret: secret, onEvents });
+
+    const req = {
+      headers: {},
+      body: JSON.stringify({ events: [] }),
+      // oxlint-disable-next-line typescript/no-explicit-any
+    } as any;
+    const res = createRes();
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await middleware(req, res, {} as any);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ status: "ok" });
+    expect(onEvents).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 for empty events with pre-parsed body object", async () => {
+    const onEvents = vi.fn(async () => {});
+    const secret = "secret";
+    const middleware = createLineWebhookMiddleware({ channelSecret: secret, onEvents });
+
+    const req = {
+      headers: {},
+      body: { events: [] },
+      rawBody: JSON.stringify({ events: [] }),
+      // oxlint-disable-next-line typescript/no-explicit-any
+    } as any;
+    const res = createRes();
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await middleware(req, res, {} as any);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(onEvents).not.toHaveBeenCalled();
+  });
+
   it("rejects invalid JSON payloads", async () => {
     const onEvents = vi.fn(async () => {});
     const secret = "secret";


### PR DESCRIPTION
## What
Skip signature validation for LINE webhook verification requests that send an empty events array.

## Why
Closes #16425

LINE's Developers Console sends `{"events":[]}` **without** an `X-Line-Signature` header to verify the webhook URL. The current code requires the signature header unconditionally, causing verification to fail with a 400 error in the response body.

## How
Parse the request body before checking the signature. If the parsed body has an empty `events` array, return HTTP 200 immediately — this is LINE's documented verification behavior. For all other requests (with actual events), signature validation proceeds as before.

## Test
- Added two new test cases covering the verification flow (empty events with string body and pre-parsed object body)
- All 7 tests in `src/line/webhook.test.ts` pass
- Manual verification: `curl -X POST <webhook_url> -d '{"events":[]}'` now returns `{"status":"ok"}`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds proper support for LINE webhook URL verification by bypassing signature validation for empty events arrays. LINE's Developers Console sends `{"events":[]}` without an `X-Line-Signature` header to verify webhook URLs - the previous implementation rejected these requests because it required the signature header unconditionally.

The fix reorders the validation logic to parse the request body first, then checks if it's a verification request (empty events array) before attempting signature validation. For verification requests, the middleware returns HTTP 200 immediately without checking signatures. For all other requests with actual events, signature validation proceeds as normal.

- Adds two test cases covering both string body and pre-parsed object body scenarios
- All existing security validations remain intact for non-verification requests
- Follows LINE's documented API behavior for webhook verification

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - it implements LINE's documented webhook verification protocol correctly
- The implementation follows LINE's documented API behavior where verification requests send empty events arrays without signatures. The bypass is narrow (only for empty events arrays), security validation remains intact for all actual webhook events, test coverage is comprehensive, and the approach matches LINE's official webhook verification protocol
- No files require special attention

<sub>Last reviewed commit: c1f89d2</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->