### PR TITLE
fix: use localhost for dashboard URL when bind=lan (#16423)

### DIFF
--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -25,9 +25,12 @@ export async function dashboardCommand(
   const customBindHost = cfg.gateway?.customBindHost;
   const token = cfg.gateway?.auth?.token ?? process.env.OPENCLAW_GATEWAY_TOKEN ?? "";
 
+  // The dashboard command is always accessed locally, so use loopback to
+  // satisfy the browser's secure-context requirement (no HTTPS needed).
+  // The gateway with bind=lan (0.0.0.0) still accepts localhost connections.
   const links = resolveControlUiLinks({
     port,
-    bind,
+    bind: bind === "lan" ? "loopback" : bind,
     customBindHost,
     basePath,
   });


### PR DESCRIPTION
## Problem

When `gateway.bind` is set to `"lan"`, `openclaw dashboard` outputs a URL with the LAN IP address (e.g., `http://192.168.31.137:18789/`). Browsers reject this with a secure context error:

```
disconnected (1008): control ui requires HTTPS or localhost (secure context)
```

## Fix

The `dashboardCommand` is always accessed locally, so override `bind=lan` to `loopback` when resolving the dashboard URL. The gateway with `bind=lan` (`0.0.0.0`) still accepts localhost connections, so this is safe.

Other callers of `resolveControlUiLinks()` (status, onboarding) are unaffected — they may legitimately need the LAN IP for remote access hints.

Closes #16423

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixed secure context error when accessing dashboard with `bind=lan` by overriding bind to loopback for the dashboard command URL. The gateway with `bind=lan` (0.0.0.0) still accepts localhost connections, so this change is safe and only affects the URL displayed/opened by the dashboard command.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is minimal, well-commented, and correctly addresses the secure context issue. The change is isolated to the dashboard command and doesn't affect other callers of `resolveControlUiLinks`. The logic is sound - the gateway with `bind=lan` (0.0.0.0) accepts localhost connections, so forcing localhost in the URL is safe.
- No files require special attention

<sub>Last reviewed commit: 2a0dc01</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->