### PR TITLE
fix: inject timestamp into channel message context prefix (#16442)

### DIFF
--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -217,6 +217,7 @@ export async function runPreparedReply(
             : {}),
         }
       : { ...sessionCtx, ThreadStarterBody: undefined },
+    { userTimezone: cfg.agents?.defaults?.userTimezone },
   );
   const baseBodyForPrompt = isBareSessionReset
     ? baseBodyFinal

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -1,5 +1,7 @@
+import { resolveUserTimezone } from "../../agents/date-time.js";
 import { normalizeChatType } from "../../channels/chat-type.js";
 import { resolveSenderLabel } from "../../channels/sender-label.js";
+import { formatZonedTimestamp } from "../../infra/format-time/format-datetime.ts";
 import type { TemplateContext } from "../templating.js";
 
 function safeTrim(value: unknown): string | undefined {
@@ -55,10 +57,35 @@ export function buildInboundMetaSystemPrompt(ctx: TemplateContext): string {
   ].join("\n");
 }
 
-export function buildInboundUserContextPrefix(ctx: TemplateContext): string {
+export function buildInboundUserContextPrefix(
+  ctx: TemplateContext,
+  opts?: { userTimezone?: string },
+): string {
   const blocks: string[] = [];
   const chatType = normalizeChatType(ctx.ChatType);
   const isDirect = !chatType || chatType === "direct";
+
+  // Inject a timestamp so the agent knows when the message was sent.
+  // Channel messages skip the gateway injectTimestamp() path, so this is
+  // the only place they get date/time awareness.
+  if (typeof ctx.Timestamp === "number" && ctx.Timestamp > 0) {
+    const date = new Date(ctx.Timestamp);
+    if (!Number.isNaN(date.getTime())) {
+      const timezone = resolveUserTimezone(opts?.userTimezone);
+      const formatted = formatZonedTimestamp(date, { timeZone: timezone });
+      if (formatted) {
+        try {
+          const dow = new Intl.DateTimeFormat("en-US", {
+            timeZone: timezone,
+            weekday: "short",
+          }).format(date);
+          blocks.push(`[${dow} ${formatted}]`);
+        } catch {
+          blocks.push(`[${formatted}]`);
+        }
+      }
+    }
+  }
 
   const conversationInfo = {
     conversation_label: isDirect ? undefined : safeTrim(ctx.ConversationLabel),


### PR DESCRIPTION
## Problem

Channel messages (Telegram, Discord, etc.) lack timestamp prefixes in the agent's context. The `injectTimestamp()` function in `agent-timestamp.ts` explicitly skips channel messages, assuming they get timestamps via envelope formatting. However, the modern code path uses `buildInboundUserContextPrefix()` which produces structured JSON metadata blocks — without any timestamp.

This means the agent has no way to know when a message was sent, breaking time-sensitive requests like "remind me in 30 minutes" or "what time is it".

## Fix

Add timestamp injection in `buildInboundUserContextPrefix()` using the existing `ctx.Timestamp` field. The format matches `injectTimestamp()` (`[DOW YYYY-MM-DD HH:MM TZ]`) for consistency across all agent contexts.

The `userTimezone` config is passed through from `get-reply-run.ts` so the timestamp respects the user's configured timezone.

## What changes

- `src/auto-reply/reply/inbound-meta.ts`: `buildInboundUserContextPrefix()` now accepts an optional `opts.userTimezone` and prepends a formatted timestamp block when `ctx.Timestamp` is available.
- `src/auto-reply/reply/get-reply-run.ts`: passes `cfg.agents.defaults.userTimezone` to the function.

Closes #16442

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds timestamp injection into `buildInboundUserContextPrefix()` so that channel messages (Telegram, Discord, Slack, Signal, iMessage, etc.) include date/time awareness in the agent's context. Previously, `injectTimestamp()` in `agent-timestamp.ts` only stamped messages from TUI/web paths, while channel messages were assumed to get timestamps via envelope formatting — but the modern `buildInboundUserContextPrefix()` code path produces structured JSON metadata without any timestamp.

- `inbound-meta.ts`: `buildInboundUserContextPrefix()` now accepts an optional `opts.userTimezone` and prepends a `[DOW YYYY-MM-DD HH:MM TZ]` block when `ctx.Timestamp` is set, matching the format used by `injectTimestamp()`.
- `get-reply-run.ts`: Passes `cfg.agents?.defaults?.userTimezone` through to the function.
- No double-stamping risk: channel messages set `ctx.Timestamp` but don't go through `injectTimestamp()`; TUI/web messages go through `injectTimestamp()` but don't set `ctx.Timestamp`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a small, well-scoped fix with no risk of double-stamping or behavioral regressions.
- The changes are minimal (two files, ~25 lines of logic). The timestamp injection follows the exact same pattern as the existing `injectTimestamp()` function. No double-stamping risk exists because channel messages and TUI/web messages use completely separate code paths with non-overlapping conditions (`ctx.Timestamp` is only set by channel handlers, never by gateway TUI/web handlers). The timezone resolution uses the same config property and helper as all other timestamp code paths.
- No files require special attention.

<sub>Last reviewed commit: eab81c0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->