### PR TITLE
fix: harden OpenAI reasoning replay sanitization

### DIFF
--- a/.github/workflows/formal-conformance.yml
+++ b/.github/workflows/formal-conformance.yml
@@ -107,7 +107,10 @@ jobs:
           path: formal-models-drift.diff
 
       - name: Comment on PR (informational)
-        if: steps.drift.outputs.drift == 'true'
+        if: |
+          steps.drift.outputs.drift == 'true' &&
+          github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -457,10 +457,9 @@ export async function sanitizeSessionHistory(params: {
         modelId: params.modelId,
       })
     : false;
-  const sanitizedOpenAI =
-    isOpenAIResponsesApi && modelChanged
-      ? downgradeOpenAIReasoningBlocks(sanitizedToolResults)
-      : sanitizedToolResults;
+  const sanitizedOpenAI = isOpenAIResponsesApi
+    ? downgradeOpenAIReasoningBlocks(sanitizedToolResults)
+    : sanitizedToolResults;
 
   if (hasSnapshot && (!priorSnapshot || modelChanged)) {
     appendModelSnapshot(params.sessionManager, {


### PR DESCRIPTION
- Problem:
  - OpenAI Responses can fail with `404 Item with id 'rs_*' not found ... store=false` when replaying incomplete reasoning signatures after tool turns.
- Root cause:
  - Transcript reasoning blocks were retained/replayed even when signature payload lacked encrypted replay content.
  - Sanitization previously depended on model-change logic and missed same-model failure paths.
- Changes:
  - Treat OpenAI reasoning signatures as replay-safe only if encrypted content is present (`encrypted_content` or `encryptedContent`).
  - Drop unsafe reasoning signatures while preserving user/tool content.
  - Apply OpenAI reasoning replay sanitization on all OpenAI Responses session-history sanitization passes.
  - Keep upstream pipeline ordering and sanitation stages intact.
- Tests:
  - Added coverage for keeping encrypted signatures and dropping non-encrypted signatures.
  - Added same-model regression coverage to ensure unsafe reasoning is removed even without model changes.
- Impact:
  - Reduces brittle `store=false` replay failures without changing non-OpenAI transcript behavior.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Hardens OpenAI reasoning replay sanitization by checking for `encrypted_content` presence. Previously, reasoning signatures were retained during transcript replay based solely on model-change detection, which missed same-model failure paths where OpenAI would reject incomplete reasoning blocks with `404 Item with id 'rs_*' not found`. Now treats reasoning signatures as replay-safe only if they contain encrypted content (`encrypted_content` or `encryptedContent` field), and applies this sanitization on all OpenAI Responses session-history passes rather than only on model changes.

**Key changes:**
- Added `hasEncryptedContent` field to `OpenAIReasoningSignature` type
- Parse both snake_case (`encrypted_content`) and camelCase (`encryptedContent`) variants for compatibility
- Drop reasoning blocks without encrypted content even when followed by other content
- Apply `downgradeOpenAIReasoningBlocks` on all OpenAI sanitization passes (removed `modelChanged` condition in `google.ts:460-462`)
- Added workflow fork-safety check to prevent comment failures on PRs from forks

<h3>Confidence Score: 5/5</h3>

- Safe to merge - defensive fix with comprehensive test coverage
- The changes are well-designed defensive improvements: (1) adds encrypted content validation to prevent replay failures, (2) comprehensive test coverage including edge cases for both encrypted and non-encrypted scenarios, (3) applies sanitization consistently on all OpenAI passes rather than conditionally, (4) preserves backward compatibility by checking both field name variants, and (5) includes an unrelated but sensible workflow fix for fork safety
- No files require special attention

<sub>Last reviewed commit: 35cad45</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->