### PR TITLE
fix: add path traversal protection for non-sandboxed media file access

### DIFF
--- a/extensions/bluebubbles/src/media-send.ts
+++ b/extensions/bluebubbles/src/media-send.ts
@@ -17,7 +17,7 @@ async function assertSafeMediaPath(localPath: string): Promise<string> {
   const resolved = path.resolve(localPath);
   const root = process.cwd();
   const relative = path.relative(root, resolved);
-  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+  if (relative.startsWith("..")) {
     throw new Error(`Media path outside working directory: ${path.basename(localPath)}`);
   }
   // Resolve symlinks and re-check to prevent symlink escapes.

--- a/extensions/bluebubbles/src/media-send.ts
+++ b/extensions/bluebubbles/src/media-send.ts
@@ -31,7 +31,7 @@ async function assertSafeMediaPath(localPath: string): Promise<string> {
     throw err;
   }
   const realRelative = path.relative(root, realPath);
-  if (realRelative.startsWith("..") || path.isAbsolute(realRelative)) {
+  if (realRelative.startsWith("..")) {
     throw new Error(`Media path resolves outside working directory: ${path.basename(localPath)}`);
   }
   return realPath;


### PR DESCRIPTION
Vulnerability identified and fix provided by [Kolega.dev](https://kolega.dev/)


## Summary

- **Problem:** When the BlueBubbles extension reads local media files in non-sandboxed (gateway) execution, `normalizeSandboxMediaList` only validates media paths when `sandboxRoot` is present — in gateway mode it passes paths through raw. A prompt-injected agent can read arbitrary files on the host via `file://` URLs and exfiltrate them as message attachments.
- **Why it matters:** Non-technical users may run in gateway mode on LLM advice. Once there, a compromised agent can exfiltrate SSH keys, API credentials, config files, and personal data as message attachments.
- **What changed:** Added `assertSafeMediaPath()` boundary check in `media-send.ts` using the same `path.resolve` + `path.relative` pattern as `resolveSandboxPath`. Preserved `fs.stat` pre-read size check. Moved `fs` import to top-level.
- **What did NOT change (scope boundary):** Sandboxed (Docker) execution is unaffected — its existing validation via `resolveSandboxedMediaSource` continues to apply. The MEDIA: token path in agent text output is already safe (rejects `file://` URLs).

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Local media file access in gateway mode is now constrained to the working directory. Attempts to access files outside this boundary will be rejected.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `Yes`
- If any `Yes`, explain risk + mitigation: Media file access is now restricted to the working directory in non-sandboxed mode. Symlinks are resolved via `fs.realpath` and re-checked to prevent symlink escape.

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime/container: Node.js (gateway host execution, no sandbox)
- Model/provider: Any
- Integration/channel (if any): BlueBubbles
- Relevant config (redacted): Gateway execution mode (no sandboxRoot)

### Steps

1. Run in gateway mode without sandbox
2. Agent calls `send_message --media file:///etc/passwd`
3. Observe that the path is rejected by `assertSafeMediaPath()`

### Expected

- Path traversal outside working directory is blocked

### Actual

- Previously: arbitrary file read and exfiltration as message attachment

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

All 230 BlueBubbles extension tests pass. Media parsing tests (9 tests) pass. No test changes required.

## Human Verification (required)

- **Verified scenarios:** Path traversal blocked for `file://` URLs outside working directory, legitimate media within working directory still loads correctly
- **Edge cases checked:** Symlink escape via `fs.realpath`, absolute paths, relative paths with `../`
- **What you did not verify:** Windows path separators

## Compatibility / Migration

- Backward compatible? `Yes` — only restricts previously unvalidated paths in gateway mode
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Remove the `assertSafeMediaPath()` call in `media-send.ts`
- Files/config to restore: `extensions/bluebubbles/src/media-send.ts`
- Known bad symptoms reviewers should watch for: Legitimate local media files being rejected because they fall outside the working directory

## Risks and Mitigations

- **Risk:** Operators with media files stored outside the agent's working directory may see rejections
  - **Mitigation:** The boundary check uses the same pattern as the existing sandbox validation. Operators can place media files within the working directory.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a path traversal vulnerability in the BlueBubbles extension's non-sandboxed (gateway) media file handling. When `sandboxRoot` is absent, `normalizeSandboxMediaList` in `message-action-runner.ts:381` passes paths through raw without validation. The new `assertSafeMediaPath()` function in `media-send.ts:16` constrains local file access to `process.cwd()` using the same `path.resolve` + `path.relative` pattern as `resolveSandboxPath` in `sandbox-paths.ts:33`. It also resolves symlinks via `fs.realpath` and re-validates to prevent symlink escapes. The fix preserves the existing `fs.stat` size check and moves the `fs` import to top-level for consistency.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - it's a well-implemented security hardening fix with no user-facing breakage for legitimate use cases
- The implementation correctly addresses a real path traversal vulnerability using established patterns from the codebase. The approach mirrors `resolveSandboxPath`, includes symlink escape prevention, and preserves existing functionality. All 230 BlueBubbles tests pass with no changes required. The redundant `path.isAbsolute()` checks noted in previous review threads have been removed.
- No files require special attention

<sub>Last reviewed commit: 18646ca</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->