### PR TITLE
chore(protocol): regenerate Swift GatewayModels for PollParams changes

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -436,7 +436,11 @@ public struct PollParams: Codable, Sendable {
     public let question: String
     public let options: [String]
     public let maxselections: Int?
+    public let durationseconds: Int?
     public let durationhours: Int?
+    public let silent: Bool?
+    public let isanonymous: Bool?
+    public let threadid: String?
     public let channel: String?
     public let accountid: String?
     public let idempotencykey: String
@@ -446,7 +450,11 @@ public struct PollParams: Codable, Sendable {
         question: String,
         options: [String],
         maxselections: Int?,
+        durationseconds: Int?,
         durationhours: Int?,
+        silent: Bool?,
+        isanonymous: Bool?,
+        threadid: String?,
         channel: String?,
         accountid: String?,
         idempotencykey: String
@@ -455,7 +463,11 @@ public struct PollParams: Codable, Sendable {
         self.question = question
         self.options = options
         self.maxselections = maxselections
+        self.durationseconds = durationseconds
         self.durationhours = durationhours
+        self.silent = silent
+        self.isanonymous = isanonymous
+        self.threadid = threadid
         self.channel = channel
         self.accountid = accountid
         self.idempotencykey = idempotencykey
@@ -465,7 +477,11 @@ public struct PollParams: Codable, Sendable {
         case question
         case options
         case maxselections = "maxSelections"
+        case durationseconds = "durationSeconds"
         case durationhours = "durationHours"
+        case silent
+        case isanonymous = "isAnonymous"
+        case threadid = "threadId"
         case channel
         case accountid = "accountId"
         case idempotencykey = "idempotencyKey"

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -436,7 +436,11 @@ public struct PollParams: Codable, Sendable {
     public let question: String
     public let options: [String]
     public let maxselections: Int?
+    public let durationseconds: Int?
     public let durationhours: Int?
+    public let silent: Bool?
+    public let isanonymous: Bool?
+    public let threadid: String?
     public let channel: String?
     public let accountid: String?
     public let idempotencykey: String
@@ -446,7 +450,11 @@ public struct PollParams: Codable, Sendable {
         question: String,
         options: [String],
         maxselections: Int?,
+        durationseconds: Int?,
         durationhours: Int?,
+        silent: Bool?,
+        isanonymous: Bool?,
+        threadid: String?,
         channel: String?,
         accountid: String?,
         idempotencykey: String
@@ -455,7 +463,11 @@ public struct PollParams: Codable, Sendable {
         self.question = question
         self.options = options
         self.maxselections = maxselections
+        self.durationseconds = durationseconds
         self.durationhours = durationhours
+        self.silent = silent
+        self.isanonymous = isanonymous
+        self.threadid = threadid
         self.channel = channel
         self.accountid = accountid
         self.idempotencykey = idempotencykey
@@ -465,7 +477,11 @@ public struct PollParams: Codable, Sendable {
         case question
         case options
         case maxselections = "maxSelections"
+        case durationseconds = "durationSeconds"
         case durationhours = "durationHours"
+        case silent
+        case isanonymous = "isAnonymous"
+        case threadid = "threadId"
         case channel
         case accountid = "accountId"
         case idempotencykey = "idempotencyKey"


### PR DESCRIPTION
## Summary
- Regenerate Swift `GatewayModels.swift` files to match current TypeScript `PollParams` definition
- Adds missing fields: `durationseconds`, `silent`, `isanonymous`, `threadid`
- These were added to the TS protocol but the Swift codegen was not re-run, causing `protocol:check` failures on PRs whose CI scope includes native files

## Test plan
- [x] `pnpm protocol:check` passes locally after regeneration

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Regenerated Swift `GatewayModels.swift` protocol definitions to match current TypeScript `PollParamsSchema`. Added four missing optional fields to `PollParams`:
- `durationseconds` (`durationSeconds`) - poll duration in seconds
- `silent` - send without notification 
- `isanonymous` (`isAnonymous`) - poll anonymity setting
- `threadid` (`threadId`) - channel-specific thread identifier

The changes are identical across both target files (`apps/macos/Sources/OpenClawProtocol/GatewayModels.swift` and `apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift`). All field names, types, CodingKeys, and initializer parameters correctly match the TypeScript schema definition in `src/gateway/protocol/schema/agent.ts`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- This is a pure codegen sync that adds missing protocol fields to Swift models. The changes are mechanical, correctly match the TypeScript source definition, and the PR author confirmed `pnpm protocol:check` passes locally.
- No files require special attention

<sub>Last reviewed commit: 79b8cae</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->