### PR TITLE
fix(gateway): fall back to lookupContextTokens on model switch

### DIFF
--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -784,7 +784,7 @@ export function listSessionsFromStore(params: {
         responseUsage: entry?.responseUsage,
         modelProvider,
         model,
-        contextTokens: entry?.contextTokens,
+        contextTokens: entry?.contextTokens ?? lookupContextTokens(model),
         deliveryContext: deliveryFields.deliveryContext,
         lastChannel: deliveryFields.lastChannel ?? entry?.lastChannel,
         lastTo: deliveryFields.lastTo ?? entry?.lastTo,


### PR DESCRIPTION
## Summary

- When a TUI session switches models, `listSessionsFromStore` returns `contextTokens` from the stored session entry. If the entry was created before the model switch (or the field was never persisted), `entry.contextTokens` is `undefined` and the UI shows no context window info.
- This adds a `?? lookupContextTokens(model)` fallback so the display always reflects the current model's context window, even if the session entry lacks the field.

## Test plan

- [x] Verified in local TUI: switch model via `/model`, then check session info - context window now shows correct max tokens for the new model.
- [x] `pnpm tsgo` passes cleanly.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Single-line fix in `listSessionsFromStore` that adds a `?? lookupContextTokens(model)` fallback when building session rows. Previously, if `entry.contextTokens` was `undefined` (e.g., after switching models via `/model`, or for session entries that never persisted the field), the TUI would show no context window info. Now, the gateway resolves the context window from the model catalog for the active model before returning it to the UI.

- The fix aligns `listSessionsFromStore` with the same fallback pattern used consistently elsewhere in the codebase (`status.summary.ts`, `sessions.ts`, `auto-reply/status.ts`, etc.)
- `lookupContextTokens` was already imported; no new dependencies introduced
- The `model` variable is always a string (guaranteed by `?? DEFAULT_MODEL` on line 758), so the lookup will always receive a valid model ID

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, well-scoped one-line fix that follows an established pattern in the codebase.
- The change is a single-line addition of a nullish coalescing fallback that mirrors the exact same pattern used in multiple other files across the codebase. The `lookupContextTokens` function was already imported and widely used. The fix correctly addresses the scenario where session entries lack a `contextTokens` field after a model switch. No new code paths, dependencies, or behavioral changes beyond the intended fallback.
- No files require special attention.

<sub>Last reviewed commit: 6648683</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->