### PR TITLE
fix(test): annotate vitest mock return types to resolve TS2742 portability errors

### DIFF
--- a/src/auto-reply/reply.triggers.trigger-handling.test-harness.ts
+++ b/src/auto-reply/reply.triggers.trigger-handling.test-harness.ts
@@ -1,5 +1,5 @@
 import { join } from "node:path";
-import { afterEach, vi } from "vitest";
+import { type Mock, afterEach, vi } from "vitest";
 import { withTempHome as withTempHomeBase } from "../../test/helpers/temp-home.js";
 
 const piEmbeddedMocks = vi.hoisted(() => ({
@@ -11,19 +11,19 @@ const piEmbeddedMocks = vi.hoisted(() => ({
   isEmbeddedPiRunStreaming: vi.fn().mockReturnValue(false),
 }));
 
-export function getAbortEmbeddedPiRunMock() {
+export function getAbortEmbeddedPiRunMock(): Mock {
   return piEmbeddedMocks.abortEmbeddedPiRun;
 }
 
-export function getCompactEmbeddedPiSessionMock() {
+export function getCompactEmbeddedPiSessionMock(): Mock {
   return piEmbeddedMocks.compactEmbeddedPiSession;
 }
 
-export function getRunEmbeddedPiAgentMock() {
+export function getRunEmbeddedPiAgentMock(): Mock {
   return piEmbeddedMocks.runEmbeddedPiAgent;
 }
 
-export function getQueueEmbeddedPiMessageMock() {
+export function getQueueEmbeddedPiMessageMock(): Mock {
   return piEmbeddedMocks.queueEmbeddedPiMessage;
 }
 
@@ -49,7 +49,12 @@ const providerUsageMocks = vi.hoisted(() => ({
   resolveUsageProviderId: vi.fn((provider: string) => provider.split("/")[0]),
 }));
 
-export function getProviderUsageMocks() {
+export function getProviderUsageMocks(): {
+  loadProviderUsageSummary: Mock;
+  formatUsageSummaryLine: Mock;
+  formatUsageWindowSummary: Mock;
+  resolveUsageProviderId: Mock;
+} {
   return providerUsageMocks;
 }
 
@@ -77,7 +82,10 @@ const modelCatalogMocks = vi.hoisted(() => ({
   resetModelCatalogCacheForTest: vi.fn(),
 }));
 
-export function getModelCatalogMocks() {
+export function getModelCatalogMocks(): {
+  loadModelCatalog: Mock;
+  resetModelCatalogCacheForTest: Mock;
+} {
   return modelCatalogMocks;
 }
 
@@ -89,7 +97,11 @@ const webSessionMocks = vi.hoisted(() => ({
   readWebSelfId: vi.fn().mockReturnValue({ e164: "+1999" }),
 }));
 
-export function getWebSessionMocks() {
+export function getWebSessionMocks(): {
+  webAuthExists: Mock;
+  getWebAuthAgeMs: Mock;
+  readWebSelfId: Mock;
+} {
   return webSessionMocks;
 }
 

--- a/src/auto-reply/reply/agent-runner.heartbeat-typing.test-harness.ts
+++ b/src/auto-reply/reply/agent-runner.heartbeat-typing.test-harness.ts
@@ -1,4 +1,4 @@
-import { beforeEach, vi } from "vitest";
+import { type Mock, beforeEach, vi } from "vitest";
 import type { SessionEntry } from "../../config/sessions.js";
 import type { TypingMode } from "../../config/types.js";
 import type { TemplateContext } from "../templating.js";
@@ -10,7 +10,7 @@ const state = vi.hoisted(() => ({
   runEmbeddedPiAgentMock: vi.fn(),
 }));
 
-export function getRunEmbeddedPiAgentMock() {
+export function getRunEmbeddedPiAgentMock(): Mock {
   return state.runEmbeddedPiAgentMock;
 }
 

--- a/src/auto-reply/reply/agent-runner.memory-flush.test-harness.ts
+++ b/src/auto-reply/reply/agent-runner.memory-flush.test-harness.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { vi } from "vitest";
+import { type Mock, vi } from "vitest";
 import type { TemplateContext } from "../templating.js";
 import type { FollowupRun, QueueSettings } from "./queue.js";
 import { createMockTypingController } from "./test-helpers.js";
@@ -16,11 +16,11 @@ const state = vi.hoisted(() => ({
   runCliAgentMock: vi.fn(),
 }));
 
-export function getRunEmbeddedPiAgentMock() {
+export function getRunEmbeddedPiAgentMock(): Mock {
   return state.runEmbeddedPiAgentMock;
 }
 
-export function getRunCliAgentMock() {
+export function getRunCliAgentMock(): Mock {
   return state.runCliAgentMock;
 }
 

--- a/src/imessage/monitor.test-harness.ts
+++ b/src/imessage/monitor.test-harness.ts
@@ -1,4 +1,4 @@
-import { beforeEach, vi } from "vitest";
+import { type Mock, beforeEach, vi } from "vitest";
 
 type NotificationHandler = (msg: { method: string; params?: unknown }) => void;
 
@@ -15,31 +15,31 @@ const state = vi.hoisted(() => ({
   closeResolve: undefined as (() => void) | undefined,
 }));
 
-export function getRequestMock() {
+export function getRequestMock(): Mock {
   return state.requestMock;
 }
 
-export function getStopMock() {
+export function getStopMock(): Mock {
   return state.stopMock;
 }
 
-export function getSendMock() {
+export function getSendMock(): Mock {
   return state.sendMock;
 }
 
-export function getReplyMock() {
+export function getReplyMock(): Mock {
   return state.replyMock;
 }
 
-export function getUpdateLastRouteMock() {
+export function getUpdateLastRouteMock(): Mock {
   return state.updateLastRouteMock;
 }
 
-export function getReadAllowFromStoreMock() {
+export function getReadAllowFromStoreMock(): Mock {
   return state.readAllowFromStoreMock;
 }
 
-export function getUpsertPairingRequestMock() {
+export function getUpsertPairingRequestMock(): Mock {
   return state.upsertPairingRequestMock;
 }
 


### PR DESCRIPTION
## Summary

- Several shared test harnesses (`monitor.test-harness.ts`, `agent-runner.heartbeat-typing.test-harness.ts`, `agent-runner.memory-flush.test-harness.ts`, `reply.triggers.trigger-handling.test-harness.ts`) export getter functions that return `vi.fn()` mocks without explicit type annotations.
- TypeScript infers the return type via the internal `@vitest/spy` path, producing `TS2742: The inferred type cannot be named without a reference to .pnpm/@vitest+spy@...`. This is non-portable and breaks strict type-checking in some environments.
- Fix: import `type Mock` from `vitest` and explicitly annotate all affected return types.

## Test plan

- [x] `pnpm tsgo` passes cleanly - all TS2742 errors resolved.
- [x] No behavioral changes - annotations only.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds explicit `Mock` type annotations (imported from `vitest`) to exported getter functions across four shared test harness files. This resolves TS2742 portability errors where TypeScript inferred return types via the internal `@vitest/spy` path, which is non-portable across different `node_modules` layouts.

- All four harness files (`reply.triggers.trigger-handling.test-harness.ts`, `agent-runner.heartbeat-typing.test-harness.ts`, `agent-runner.memory-flush.test-harness.ts`, `monitor.test-harness.ts`) receive the same treatment: `import { type Mock } from "vitest"` and explicit `: Mock` return type annotations on exported getter functions.
- For getters returning objects with multiple mock properties, inline object types with `Mock`-typed fields are used.
- No behavioral or runtime changes — annotations only.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it contains only type annotations with zero runtime impact.
- All changes are type-only annotations on test harness files. No logic, runtime behavior, or test assertions are modified. The `Mock` type from vitest correctly matches the return type of `vi.fn()`. The PR resolves legitimate TS2742 errors as confirmed by the test plan.
- No files require special attention.

<sub>Last reviewed commit: 80aca37</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->