### PR TITLE
fix(bluebubbles): enforce dmPolicy when allowFrom is empty

### DIFF
--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -253,13 +253,16 @@ export async function processMessage(
       return;
     }
     if (dmPolicy !== "open") {
-      const allowed = isAllowedBlueBubblesSender({
-        allowFrom: effectiveAllowFrom,
-        sender: message.senderId,
-        chatId: message.chatId ?? undefined,
-        chatGuid: message.chatGuid ?? undefined,
-        chatIdentifier: message.chatIdentifier ?? undefined,
-      });
+      const allowed =
+        effectiveAllowFrom.includes("*") ||
+        (effectiveAllowFrom.length > 0 &&
+          isAllowedBlueBubblesSender({
+            allowFrom: effectiveAllowFrom,
+            sender: message.senderId,
+            chatId: message.chatId ?? undefined,
+            chatGuid: message.chatGuid ?? undefined,
+            chatIdentifier: message.chatIdentifier ?? undefined,
+          }));
       if (!allowed) {
         if (dmPolicy === "pairing") {
           const { code, created } = await core.channel.pairing.upsertPairingRequest({
@@ -960,13 +963,16 @@ export async function processReaction(
       return;
     }
     if (dmPolicy !== "open") {
-      const allowed = isAllowedBlueBubblesSender({
-        allowFrom: effectiveAllowFrom,
-        sender: reaction.senderId,
-        chatId: reaction.chatId ?? undefined,
-        chatGuid: reaction.chatGuid ?? undefined,
-        chatIdentifier: reaction.chatIdentifier ?? undefined,
-      });
+      const allowed =
+        effectiveAllowFrom.includes("*") ||
+        (effectiveAllowFrom.length > 0 &&
+          isAllowedBlueBubblesSender({
+            allowFrom: effectiveAllowFrom,
+            sender: reaction.senderId,
+            chatId: reaction.chatId ?? undefined,
+            chatGuid: reaction.chatGuid ?? undefined,
+            chatIdentifier: reaction.chatIdentifier ?? undefined,
+          }));
       if (!allowed) {
         return;
       }


### PR DESCRIPTION
## Summary
When `allowFrom` is empty in BlueBubbles config, `dmPolicy` was not being enforced — all DMs were accepted regardless of the policy setting. Fixed by checking `dmPolicy` independently of the `allowFrom` list.

Fixes #16108

## Validation
- [x] `pnpm build` — passed
- [x] `pnpm check` (format + tsgo + lint) — passed
- [x] `pnpm test` — 1073 tests passed (105 test files)

## Scope
- Single focused fix — single file changed (bluebubbles channel plugin)

## AI-Assistance
- AI-assisted (Claude Code) for implementation
- Human-reviewed: confirmed understanding of changes
- Testing: full local validation suite passed