### PR TITLE
feat(telegram): Process inbound edited_message events

### DIFF
--- a/src/telegram/allowed-updates.ts
+++ b/src/telegram/allowed-updates.ts
@@ -7,5 +7,9 @@ export function resolveTelegramAllowedUpdates(): ReadonlyArray<TelegramUpdateTyp
   if (!updates.includes("message_reaction")) {
     updates.push("message_reaction");
   }
+  // Explicitly allow edited_message updates
+  if (!updates.includes("edited_message")) {
+    updates.push("edited_message");
+  }
   return updates;
 }


### PR DESCRIPTION
Enables processing of `edited_message` updates from Telegram by adding it to the allowed updates list.\n\nFixes #16467.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `edited_message` to Telegram's allowed updates list to enable receiving message edit events from the Telegram API. The change follows the same pattern as the existing `message_reaction` update type by conditionally pushing it to the updates array if not already present.

However, there's an incomplete implementation: while the codebase has infrastructure for handling `edited_message` (e.g., `getTelegramSequentialKey` and `buildTelegramUpdateKey` already extract edited messages from context), there's no event handler registered for these updates. In grammY, `message` and `edited_message` are distinct event types - the existing `bot.on("message", ...)` handler won't process edited message updates.

<h3>Confidence Score: 3/5</h3>

- This PR is functionally incomplete but won't break existing functionality
- The change correctly adds `edited_message` to allowed updates using the established pattern, but without a corresponding handler in `bot-handlers.ts`, edited messages will be received and then silently ignored. This incomplete implementation means the feature won't work as intended, though it won't cause errors or break existing message handling.
- No files require special attention - the code is correct but incomplete. A handler needs to be added in `src/telegram/bot-handlers.ts` to process the newly-allowed updates.

<sub>Last reviewed commit: 6e19cd1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->