### PR TITLE
fix: require explicit allowlisting for loopback cross-origin WebSocket connections

### DIFF
--- a/src/gateway/origin-check.test.ts
+++ b/src/gateway/origin-check.test.ts
@@ -10,10 +10,10 @@ describe("checkBrowserOrigin", () => {
     expect(result.ok).toBe(true);
   });
 
-  it("accepts loopback host mismatches for dev", () => {
+  it("accepts same-origin with HTTPS", () => {
     const result = checkBrowserOrigin({
-      requestHost: "127.0.0.1:18789",
-      origin: "http://localhost:5173",
+      requestHost: "localhost:8443",
+      origin: "https://localhost:8443",
     });
     expect(result.ok).toBe(true);
   });
@@ -27,12 +27,48 @@ describe("checkBrowserOrigin", () => {
     expect(result.ok).toBe(true);
   });
 
+  it("accepts allowlisted local origins", () => {
+    const result = checkBrowserOrigin({
+      requestHost: "127.0.0.1:18789",
+      origin: "http://localhost:5173",
+      allowedOrigins: ["http://localhost:5173"],
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects loopback cross-origin without allowlist", () => {
+    const result = checkBrowserOrigin({
+      requestHost: "127.0.0.1:18789",
+      origin: "http://localhost:5173",
+    });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain("allowedOrigins");
+  });
+
+  it("rejects different loopback ports without allowlist", () => {
+    const result = checkBrowserOrigin({
+      requestHost: "localhost:18789",
+      origin: "http://localhost:3000",
+    });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain("allowedOrigins");
+  });
+
+  it("rejects localhost to 127.0.0.1 cross-origin without allowlist", () => {
+    const result = checkBrowserOrigin({
+      requestHost: "127.0.0.1:18789",
+      origin: "http://localhost:8080",
+    });
+    expect(result.ok).toBe(false);
+  });
+
   it("rejects missing origin", () => {
     const result = checkBrowserOrigin({
       requestHost: "gateway.example.com:18789",
       origin: "",
     });
     expect(result.ok).toBe(false);
+    expect(result.reason).toContain("origin missing or invalid");
   });
 
   it("rejects mismatched origins", () => {
@@ -41,5 +77,45 @@ describe("checkBrowserOrigin", () => {
       origin: "https://attacker.example.com",
     });
     expect(result.ok).toBe(false);
+  });
+
+  it("rejects null origin", () => {
+    const result = checkBrowserOrigin({
+      requestHost: "gateway.example.com:18789",
+      origin: "null",
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("handles case-insensitive host comparison", () => {
+    const result = checkBrowserOrigin({
+      requestHost: "LOCALHOST:8080",
+      origin: "http://localhost:8080",
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("handles IPv6 bracket notation", () => {
+    const result = checkBrowserOrigin({
+      requestHost: "[::1]:8080",
+      origin: "http://[::1]:8080",
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("handles default HTTP port", () => {
+    const result = checkBrowserOrigin({
+      requestHost: "example.com:80",
+      origin: "http://example.com",
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("handles default HTTPS port", () => {
+    const result = checkBrowserOrigin({
+      requestHost: "example.com:443",
+      origin: "https://example.com",
+    });
+    expect(result.ok).toBe(true);
   });
 });

--- a/src/gateway/origin-check.ts
+++ b/src/gateway/origin-check.ts
@@ -57,14 +57,29 @@ export function checkBrowserOrigin(params: {
     return { ok: true };
   }
 
+  // Same-origin check: try both HTTP and HTTPS since the Host header has no protocol.
+  // URL handles default port normalization (80/443) and IPv6 bracket notation.
   const requestHost = normalizeHostHeader(params.requestHost);
-  if (requestHost && parsedOrigin.host === requestHost) {
-    return { ok: true };
+  if (requestHost) {
+    for (const scheme of ["http", "https"]) {
+      try {
+        if (new URL(`${scheme}://${requestHost}`).origin === parsedOrigin.origin) {
+          return { ok: true };
+        }
+      } catch {
+        // malformed host header
+      }
+    }
   }
 
+  // CWE-346: loopback cross-origin requests require explicit allowlisting.
+  // Provide an actionable error message for local dev scenarios.
   const requestHostname = resolveHostName(requestHost);
   if (isLoopbackHost(parsedOrigin.hostname) && isLoopbackHost(requestHostname)) {
-    return { ok: true };
+    return {
+      ok: false,
+      reason: `origin not allowed (add '${parsedOrigin.origin}' to allowedOrigins)`,
+    };
   }
 
   return { ok: false, reason: "origin not allowed" };


### PR DESCRIPTION
Vulnerability identified and fix provided by [Kolega.dev](https://kolega.dev/)

## Summary

- **Problem:** The WebSocket gateway's `checkBrowserOrigin` function allowed any loopback address to connect to any other loopback address without validation. A request from `http://localhost:8080` to `127.0.0.1:18789` was automatically accepted, enabling malicious local applications or browser-based attacks to access the gateway.
- **Why it matters:** Any local application or malicious webpage can connect to the gateway WebSocket without authorization, enabling cross-origin attacks from the same machine.
- **What changed:** Removed the blanket loopback-to-loopback bypass. All cross-origin connections now require explicit allowlisting via `allowedOrigins`. Same-origin requests (exact host:port match) continue to work without configuration. Improved same-origin comparison to use `URL`-based normalization (handles default ports and IPv6). Rejection error messages now include the specific origin to add.
- **What did NOT change (scope boundary):** Same-origin WebSocket connections are unaffected. The `allowedOrigins` configuration mechanism is unchanged. Authentication and authorization flows are untouched.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Loopback cross-origin WebSocket connections (e.g. `localhost:3000` -> `127.0.0.1:18789`) are now rejected unless the origin is in `allowedOrigins`.
- Rejection error messages now include the specific origin to add to `allowedOrigins` for easy configuration.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `Yes`
- If any `Yes`, explain risk + mitigation: WebSocket access from cross-origin loopback addresses is now denied by default. Operators can explicitly allowlist trusted local origins via `allowedOrigins` configuration.

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime/container: Node.js
- Model/provider: Any
- Integration/channel (if any): N/A
- Relevant config (redacted): Default gateway configuration

### Steps

1. Start gateway on `127.0.0.1:18789`
2. Attempt WebSocket connection from `http://localhost:3000`
3. Observe rejection with actionable error message

### Expected

- Cross-origin loopback connection is rejected

### Actual

- Previously: automatically accepted because both are loopback

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

All 14 origin-check tests pass. Full gateway test suite (43 files, 267 tests) passes with no regressions.

## Human Verification (required)

- **Verified scenarios:** Loopback cross-origin rejected, same-origin accepted, allowlisted origins accepted, null origin handled
- **Edge cases checked:** Case-insensitive comparison, IPv6 bracket notation, default port handling (80/443)
- **What you did not verify:** All possible IPv6 loopback representations

## Compatibility / Migration

- Backward compatible? `No` — loopback cross-origin connections that previously worked will now require explicit `allowedOrigins` configuration
- Config/env changes? `No` new config, but operators may need to populate existing `allowedOrigins` field
- Migration needed? `No` — but local development setups using different loopback ports will need to add origins to `allowedOrigins`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Restore the `isLoopbackHost` bypass in `origin-check.ts`
- Files/config to restore: `src/gateway/origin-check.ts`
- Known bad symptoms reviewers should watch for: Local development tools or browser extensions failing to connect to the gateway WebSocket

## Risks and Mitigations

- **Risk:** Local development workflows relying on cross-port loopback connections will break
  - **Mitigation:** Error messages include the exact origin to add to `allowedOrigins`, making configuration straightforward.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes a cross-origin WebSocket vulnerability (CWE-346) in the gateway's `checkBrowserOrigin` function. Previously, any loopback-to-loopback connection was automatically accepted, allowing malicious local applications or browser-based attacks to connect to the gateway without authorization. The fix removes this blanket bypass and requires explicit `allowedOrigins` configuration for cross-origin loopback connections.

- **Security fix**: Removed the automatic loopback-to-loopback origin bypass that allowed any local application to connect to the gateway WebSocket
- **Improved same-origin check**: Replaced string-based host comparison with `URL`-based origin comparison, correctly handling default port normalization (80/443), IPv6 bracket notation, and case-insensitive hostnames
- **Actionable error messages**: Loopback cross-origin rejections now include the specific origin to add to `allowedOrigins`
- **Breaking change**: Loopback cross-origin connections that previously auto-accepted now require explicit `allowedOrigins` configuration; same-origin connections are unaffected
- **Test coverage**: 14 tests covering same-origin, allowlisted, rejected loopback, null/missing origin, case-insensitive, IPv6, and default port edge cases

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a well-scoped security hardening with correct logic and comprehensive test coverage.
- The change is a focused, well-implemented security fix that removes a clear vulnerability (blanket loopback bypass). The new URL-based same-origin comparison is more robust than the previous string comparison. All edge cases (default ports, IPv6, case sensitivity) are handled correctly. Test coverage is thorough with 14 tests. The only risk is the intentional breaking change for local dev workflows, which is well-documented and mitigated by actionable error messages.
- No files require special attention. Both changed files are clean and well-tested.

<sub>Last reviewed commit: cbe5062</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->