### PR TITLE
fix: narrow heartbeat filter in compactSystemEvent to preserve user cron payloads

### DIFF
--- a/src/gateway/server-methods/system.ts
+++ b/src/gateway/server-methods/system.ts
@@ -121,7 +121,13 @@ export const systemHandlers: GatewayRequestHandlers = {
         }
       }
     } else {
-      enqueueSystemEvent(text, { sessionKey });
+      const normalizedReason = (reason ?? "").toLowerCase();
+      const isHeartbeatOrigin =
+        normalizedReason.startsWith("periodic") || normalizedReason === "heartbeat";
+      enqueueSystemEvent(text, {
+        sessionKey,
+        ...(isHeartbeatOrigin ? { source: "heartbeat" } : {}),
+      });
     }
     const nextPresenceVersion = context.incrementPresenceVersion();
     context.broadcast(


### PR DESCRIPTION
## Summary
- Adds an optional `source` field to `SystemEvent` so events can be tagged with their origin (e.g. `"heartbeat"`)
- Updates `enqueueSystemEvent()` to accept and store the `source` tag
- Replaces fragile text-based heartbeat filtering in `compactSystemEvent()` with source-tag filtering (`event.source === "heartbeat"`)
- Heartbeat prompts are user-configurable, so filtering by content is unreliable — this approach correctly identifies heartbeat events regardless of prompt text

Fixes #15399

## Test plan
- [x] Updated tests to use source tagging instead of text matching
- [x] Verified non-heartbeat events mentioning "heartbeat" are preserved
- [x] Verified heartbeat-tagged events are filtered regardless of text content
- [x] All existing session-resets tests pass (17/17)

🤖 Generated with [Claude Code](https://claude.com/claude-code)