### PR TITLE
test: fix TS2742 portable type errors in web monitor-inbox harness

### DIFF
--- a/src/web/monitor-inbox.test-harness.ts
+++ b/src/web/monitor-inbox.test-harness.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from "node:events";
 import fsSync from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, vi } from "vitest";
+import { afterEach, beforeEach, type Mock, type MockInstance, vi } from "vitest";
 import { resetLogger, setLoggerOverride } from "../logging.js";
 
 export const DEFAULT_ACCOUNT_ID = "default";
@@ -20,16 +20,30 @@ export const DEFAULT_WEB_INBOX_CONFIG = {
   },
 } as const;
 
-export const mockLoadConfig = vi.fn().mockReturnValue(DEFAULT_WEB_INBOX_CONFIG);
+export const mockLoadConfig: Mock = vi.fn().mockReturnValue(DEFAULT_WEB_INBOX_CONFIG);
 
-export const readAllowFromStoreMock = vi.fn().mockResolvedValue([]);
-export const upsertPairingRequestMock = vi
+export const readAllowFromStoreMock: Mock = vi.fn().mockResolvedValue([]);
+export const upsertPairingRequestMock: Mock = vi
   .fn()
   .mockResolvedValue({ code: "PAIRCODE", created: true });
 
-export type MockSock = ReturnType<typeof createMockSock>;
+export interface MockSock {
+  ev: EventEmitter;
+  ws: { close: MockInstance };
+  sendPresenceUpdate: MockInstance;
+  sendMessage: MockInstance;
+  readMessages: MockInstance;
+  updateMediaMessage: MockInstance;
+  logger: Record<string, unknown>;
+  signalRepository: {
+    lidMapping: {
+      getPNForLID: MockInstance;
+    };
+  };
+  user: { id: string };
+}
 
-function createMockSock() {
+function createMockSock(): MockSock {
   const ev = new EventEmitter();
   return {
     ev,


### PR DESCRIPTION
## Summary
- Add explicit `Mock` / `MockInstance` type annotations to exported mocks in `src/web/monitor-inbox.test-harness.ts`
- Convert `MockSock` from `ReturnType<typeof createMockSock>` to an explicit interface
- Follows the same pattern applied to other test harness files in 5b7a33272

Fixes TS2742 "cannot be named without a reference to @vitest/spy" errors that currently break `pnpm check` on main.

## Test plan
- `pnpm check` passes (format + types + lint)
- All 37 web test files pass (165 tests)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixed TS2742 "cannot be named without a reference to `@vitest/spy`" type errors by adding explicit type annotations to the web monitor-inbox test harness. The changes follow the same pattern established in 5b7a33272 for other test harness files, ensuring type portability across module boundaries.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are purely type annotations that fix compiler errors without modifying runtime behavior. The pattern matches the approach used successfully in commit 5b7a3327 for similar test harness files. All type annotations are correct and properly applied.
- No files require special attention

<sub>Last reviewed commit: e230859</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->