### PR TITLE
fix: convert unsigned thinking blocks to text in OpenAI downgrade

### DIFF
--- a/src/agents/pi-embedded-helpers.downgradeopenai-reasoning.e2e.test.ts
+++ b/src/agents/pi-embedded-helpers.downgradeopenai-reasoning.e2e.test.ts
@@ -75,4 +75,73 @@ describe("downgradeOpenAIReasoningBlocks", () => {
     // oxlint-disable-next-line typescript/no-explicit-any
     expect(downgradeOpenAIReasoningBlocks(input as any)).toEqual(input);
   });
+
+  it("converts unsigned thinking blocks to text", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "thinking",
+            thinking: "proxy stripped the signature",
+          },
+          { type: "text", text: "answer" },
+        ],
+      },
+    ];
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const result = downgradeOpenAIReasoningBlocks(input as any);
+    expect(result).toEqual([
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "proxy stripped the signature" },
+          { type: "text", text: "answer" },
+        ],
+      },
+    ]);
+  });
+
+  it("drops empty unsigned thinking blocks", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "thinking",
+            thinking: "",
+          },
+          { type: "text", text: "answer" },
+        ],
+      },
+    ];
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const result = downgradeOpenAIReasoningBlocks(input as any);
+    expect(result).toEqual([
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "answer" }],
+      },
+    ]);
+  });
+
+  it("drops unsigned thinking blocks without thinking field", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "thinking",
+          },
+        ],
+      },
+      { role: "user", content: "next" },
+    ];
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const result = downgradeOpenAIReasoningBlocks(input as any);
+    expect(result).toEqual([{ role: "user", content: "next" }]);
+  });
 });


### PR DESCRIPTION
## Summary

Closes #15681

When Claude thinking blocks arrive via proxies (e.g. Antigravity/Google Code Assist) that omit `thinkingSignature`, the blocks were kept as `type: "thinking"` and passed to the API which rejects them with `thinking.signature: Field required`.

**Root cause:** `downgradeOpenAIReasoningBlocks()` only drops thinking blocks with valid OpenAI reasoning signatures that lack a following content block. Unsigned thinking blocks (no signature at all) were passed through unchanged.

**Fix:** Convert unsigned thinking blocks to plain `type: "text"` blocks, preserving the thinking content while avoiding API validation errors. Empty thinking blocks are dropped entirely.

## Test plan

- [ ] Thinking blocks without `thinkingSignature` should be converted to text blocks
- [ ] Thinking blocks with valid OpenAI signatures should be unaffected
- [ ] Empty thinking blocks without signatures should be dropped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR has two independent fixes: (1) converting unsigned thinking blocks to text in `downgradeOpenAIReasoningBlocks` to prevent `thinking.signature: Field required` API rejections from proxies that omit signatures, and (2) dropping tool_use blocks with empty `name` fields in `repairToolCallInputs` to prevent similar API errors.

- The `session-transcript-repair.ts` changes (new `hasValidToolCallName` guard, `??` → `||` in `makeMissingToolResult`) are clean and correctly scoped.
- **The `openai.ts` change has a logic bug**: the `!signature` condition is too broad — it fires for *any* block where `parseOpenAIReasoningSignature` returns null, including blocks with valid non-OpenAI `thinkingSignature` values (e.g., Anthropic native formats like `"c2ln"`). The fix should check for `!record.thinkingSignature` (absent/falsy) rather than `!signature` (not-OpenAI-parseable). The existing test "keeps non-reasoning thinking signatures" was not updated and will fail with this change.
- No new tests were added for the new unsigned-thinking-block-to-text conversion or empty-name tool call dropping behaviors.

<h3>Confidence Score: 2/5</h3>

- The openai.ts change has a logic bug that will break existing tests and could degrade thinking content for non-OpenAI providers; session-transcript-repair.ts changes are safe.
- Score of 2 reflects a confirmed logic issue in the openai.ts change: the condition is too broad, converting thinking blocks with valid non-OpenAI signatures (not just unsigned blocks) to plain text. The existing test "keeps non-reasoning thinking signatures" will fail. The session-transcript-repair.ts changes are correct, but the openai.ts issue needs to be fixed before merging.
- Pay close attention to `src/agents/pi-embedded-helpers/openai.ts` — the `!signature` guard needs to be narrowed to `!record.thinkingSignature` to avoid converting non-OpenAI signed thinking blocks.

<sub>Last reviewed commit: f73abbc</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->