### PR TITLE
test: fix TS2742 portable type errors in cli program test mocks

### DIFF
--- a/src/cli/program.test-mocks.ts
+++ b/src/cli/program.test-mocks.ts
@@ -1,21 +1,21 @@
-import { vi } from "vitest";
+import { type Mock, vi } from "vitest";
 
-export const messageCommand = vi.fn();
-export const statusCommand = vi.fn();
-export const configureCommand = vi.fn();
-export const configureCommandWithSections = vi.fn();
-export const setupCommand = vi.fn();
-export const onboardCommand = vi.fn();
-export const callGateway = vi.fn();
-export const runChannelLogin = vi.fn();
-export const runChannelLogout = vi.fn();
-export const runTui = vi.fn();
+export const messageCommand: Mock = vi.fn();
+export const statusCommand: Mock = vi.fn();
+export const configureCommand: Mock = vi.fn();
+export const configureCommandWithSections: Mock = vi.fn();
+export const setupCommand: Mock = vi.fn();
+export const onboardCommand: Mock = vi.fn();
+export const callGateway: Mock = vi.fn();
+export const runChannelLogin: Mock = vi.fn();
+export const runChannelLogout: Mock = vi.fn();
+export const runTui: Mock = vi.fn();
 
-export const loadAndMaybeMigrateDoctorConfig = vi.fn();
-export const ensureConfigReady = vi.fn();
-export const ensurePluginRegistryLoaded = vi.fn();
+export const loadAndMaybeMigrateDoctorConfig: Mock = vi.fn();
+export const ensureConfigReady: Mock = vi.fn();
+export const ensurePluginRegistryLoaded: Mock = vi.fn();
 
-export const runtime = {
+export const runtime: { log: Mock; error: Mock; exit: Mock } = {
   log: vi.fn(),
   error: vi.fn(),
   exit: vi.fn(() => {


### PR DESCRIPTION
## Summary
- Add explicit `Mock` type annotations to exported `vi.fn()` mocks in `src/cli/program.test-mocks.ts`
- Follows the same pattern applied to other test harness files (e.g. 519ffd59d, 5b7a33272)
- Fixes TS2742 "cannot be named without a reference to @vitest/spy" errors that currently break `pnpm check` on main

## Test plan
- `pnpm check` passes (format + types + lint)
- Both e2e test files using this mock pass (22 tests)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds explicit `Mock` type annotations to all exported `vi.fn()` mocks in `src/cli/program.test-mocks.ts` to fix TS2742 errors that break `pnpm check`. The change imports `Mock` from vitest and applies type annotations to 13 exported mock functions and the runtime object, following the same pattern used in `src/gateway/test-helpers.mocks.ts` (lines 204-205).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change is a straightforward type annotation fix that addresses a TypeScript compilation error (TS2742). The pattern matches existing usage in the codebase, all exported mocks maintain the same runtime behavior, and the PR author has verified that tests pass and `pnpm check` succeeds
- No files require special attention

<sub>Last reviewed commit: 131fb3a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->