### PR TITLE
test: annotate CLI program test mocks to fix TS2742

### DIFF
--- a/src/cli/program.test-mocks.ts
+++ b/src/cli/program.test-mocks.ts
@@ -1,21 +1,22 @@
 import { vi } from "vitest";
+import type { MockFn } from "../test-utils/vitest-mock-fn.js";
 
-export const messageCommand = vi.fn();
-export const statusCommand = vi.fn();
-export const configureCommand = vi.fn();
-export const configureCommandWithSections = vi.fn();
-export const setupCommand = vi.fn();
-export const onboardCommand = vi.fn();
-export const callGateway = vi.fn();
-export const runChannelLogin = vi.fn();
-export const runChannelLogout = vi.fn();
-export const runTui = vi.fn();
+export const messageCommand: MockFn = vi.fn();
+export const statusCommand: MockFn = vi.fn();
+export const configureCommand: MockFn = vi.fn();
+export const configureCommandWithSections: MockFn = vi.fn();
+export const setupCommand: MockFn = vi.fn();
+export const onboardCommand: MockFn = vi.fn();
+export const callGateway: MockFn = vi.fn();
+export const runChannelLogin: MockFn = vi.fn();
+export const runChannelLogout: MockFn = vi.fn();
+export const runTui: MockFn = vi.fn();
 
-export const loadAndMaybeMigrateDoctorConfig = vi.fn();
-export const ensureConfigReady = vi.fn();
-export const ensurePluginRegistryLoaded = vi.fn();
+export const loadAndMaybeMigrateDoctorConfig: MockFn = vi.fn();
+export const ensureConfigReady: MockFn = vi.fn();
+export const ensurePluginRegistryLoaded: MockFn = vi.fn();
 
-export const runtime = {
+export const runtime: { log: MockFn; error: MockFn; exit: MockFn } = {
   log: vi.fn(),
   error: vi.fn(),
   exit: vi.fn(() => {


### PR DESCRIPTION
## Summary
- Add explicit `MockFn` type annotations to exported `vi.fn()` mocks in `src/cli/program.test-mocks.ts`
- Prevents TS2742 errors ("The inferred type of '...' cannot be named without a reference to '@vitest/spy'")
- Follows the same pattern used in 519ffd59d for `monitor-inbox.test-harness.ts`

## Test plan
- [x] `npx tsc --noEmit` reports 0 TS2742 errors (was 14)
- [x] `program.force.test.ts` passes (6 tests)
- [x] `program.smoke.e2e.test.ts` passes (14 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Added explicit `MockFn` type annotations to all exported `vi.fn()` mocks in `src/cli/program.test-mocks.ts` to prevent TS2742 errors ("The inferred type of '...' cannot be named without a reference to '@vitest/spy'"). This follows the same pattern established in commit 519ffd59d for `monitor-inbox.test-harness.ts`.

The changes include:
- Imported `MockFn` type from `../test-utils/vitest-mock-fn.js`
- Annotated 13 individual mock exports with `: MockFn`
- Annotated the `runtime` object with structured type `{ log: MockFn; error: MockFn; exit: MockFn }`

The fix ensures TypeScript can properly infer types without requiring external references, resolving 14 TS2742 errors according to the test plan.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change is purely additive type annotations that don't affect runtime behavior. It follows an established pattern from commit 519ffd59d, resolves TypeScript compilation errors, and the test plan confirms all tests pass with 0 TS2742 errors (down from 14). The type annotations are correct and consistent with the `MockFn` utility type.
- No files require special attention

<sub>Last reviewed commit: 82a5469</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->