### PR TITLE
fix(security): audit falsely flags dangerous commands in denyCommands (#16508)

### DIFF
--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -15,7 +15,10 @@ import { resolveToolProfilePolicy } from "../agents/tool-policy.js";
 import { resolveBrowserConfig } from "../browser/config.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { resolveGatewayAuth } from "../gateway/auth.js";
-import { resolveNodeCommandAllowlist } from "../gateway/node-command-policy.js";
+import {
+  DEFAULT_DANGEROUS_NODE_COMMANDS,
+  resolveNodeCommandAllowlist,
+} from "../gateway/node-command-policy.js";
 
 export type SecurityAuditFinding = {
   checkId: string;
@@ -249,6 +252,10 @@ function listKnownNodeCommands(cfg: OpenClawConfig): Set<string> {
         out.add(normalized);
       }
     }
+  }
+  // Dangerous commands are valid names even though they're not in platform defaults.
+  for (const cmd of DEFAULT_DANGEROUS_NODE_COMMANDS) {
+    out.add(cmd);
   }
   return out;
 }

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -489,6 +489,35 @@ describe("security audit", () => {
     expect(finding?.detail).toContain("system.runx");
   });
 
+  it("does not flag dangerous commands as unknown in denyCommands", async () => {
+    const cfg: OpenClawConfig = {
+      gateway: {
+        nodes: {
+          denyCommands: [
+            "camera.snap",
+            "camera.clip",
+            "screen.record",
+            "calendar.add",
+            "contacts.add",
+            "reminders.add",
+            "sms.send",
+          ],
+        },
+      },
+    };
+
+    const res = await runSecurityAudit({
+      config: cfg,
+      includeFilesystem: false,
+      includeChannelSecurity: false,
+    });
+
+    const finding = res.findings.find(
+      (f) => f.checkId === "gateway.nodes.deny_commands_ineffective",
+    );
+    expect(finding).toBeUndefined();
+  });
+
   it("flags agent profile overrides when global tools.profile is minimal", async () => {
     const cfg: OpenClawConfig = {
       tools: {


### PR DESCRIPTION
## Summary

`security audit --deep` flags entries like `camera.snap`, `screen.record`, `sms.send` in `gateway.nodes.denyCommands` as "unknown command names" — but these are real commands defined in `DEFAULT_DANGEROUS_NODE_COMMANDS`. Users adding them to their deny list get a false warning that creates confusion about whether their config is actually working.

Closes #16508

lobster-biscuit

## Root Cause

`listKnownNodeCommands` in `audit-extra.sync.ts` builds the known command set by iterating platform default allowlists via `resolveNodeCommandAllowlist`. But dangerous commands (`camera.snap`, `camera.clip`, `screen.record`, `calendar.add`, `contacts.add`, `reminders.add`, `sms.send`) aren't in any platform's defaults — they're opt-in via `allowCommands`. So the audit doesn't recognize them as valid names.

## Changes

- Before: denying `camera.snap` triggers `gateway.nodes.deny_commands_ineffective` warning
- After: dangerous commands are recognized as valid, only truly unknown names get flagged

## Tests

- `audit.test.ts` — new test with all 7 dangerous commands in `denyCommands`, confirms no false warning. Fails before fix, passes after.
- All 158 tests in `src/security/` pass
- `pnpm build && pnpm check` pass

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed false positive audit warnings when denying dangerous commands like `camera.snap`, `screen.record`, and `sms.send`. The audit's `listKnownNodeCommands` function now recognizes `DEFAULT_DANGEROUS_NODE_COMMANDS` as valid command names, eliminating confusion about whether deny list configurations are working correctly.

Changes:
- Added `DEFAULT_DANGEROUS_NODE_COMMANDS` to the known command set in `listKnownNodeCommands`
- Added comprehensive test covering all 7 dangerous commands to verify they're recognized as valid

<h3>Confidence Score: 5/5</h3>

- Safe to merge - surgical fix that correctly addresses the root cause with appropriate test coverage
- The fix is minimal and precisely targets the issue: dangerous commands weren't included in the audit's known command set despite being valid. The solution simply adds them to the set after iterating platform defaults. Test coverage includes all 7 dangerous commands and verifies the warning is not triggered.
- No files require special attention

<sub>Last reviewed commit: 8aef653</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->