### PR TITLE
fix(shell): stop rejecting newlines in double-quoted args (#16470)

### DIFF
--- a/src/infra/exec-approvals-analysis.ts
+++ b/src/infra/exec-approvals-analysis.ts
@@ -410,9 +410,6 @@ function splitShellPipeline(command: string): { ok: boolean; reason?: string; se
       if (ch === "`") {
         return { ok: false, reason: "unsupported shell token: `", segments: [] };
       }
-      if (ch === "\n" || ch === "\r") {
-        return { ok: false, reason: "unsupported shell token: newline", segments: [] };
-      }
       if (ch === '"') {
         inDouble = false;
       }

--- a/src/infra/exec-approvals.test.ts
+++ b/src/infra/exec-approvals.test.ts
@@ -247,6 +247,22 @@ describe("exec approvals shell parsing", () => {
     expect(res.segments[0]?.argv[0]).toBe("/usr/bin/cat");
   });
 
+  it("allows literal newlines inside double-quoted strings", () => {
+    const res = analyzeShellCommand({
+      command: 'gh issue create --body "## Heading\n\nSome text"',
+    });
+    expect(res.ok).toBe(true);
+    expect(res.segments[0]?.argv[0]).toBe("gh");
+  });
+
+  it("allows carriage-return-newline inside double-quoted strings", () => {
+    const res = analyzeShellCommand({
+      command: 'echo "line one\r\nline two"',
+    });
+    expect(res.ok).toBe(true);
+    expect(res.segments[0]?.argv[0]).toBe("echo");
+  });
+
   it("rejects multiline commands without heredoc", () => {
     const res = analyzeShellCommand({
       command: "/usr/bin/echo first line\n/usr/bin/echo second line",

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -15,7 +15,10 @@ import { resolveToolProfilePolicy } from "../agents/tool-policy.js";
 import { resolveBrowserConfig } from "../browser/config.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { resolveGatewayAuth } from "../gateway/auth.js";
-import { resolveNodeCommandAllowlist } from "../gateway/node-command-policy.js";
+import {
+  DEFAULT_DANGEROUS_NODE_COMMANDS,
+  resolveNodeCommandAllowlist,
+} from "../gateway/node-command-policy.js";
 
 export type SecurityAuditFinding = {
   checkId: string;
@@ -249,6 +252,10 @@ function listKnownNodeCommands(cfg: OpenClawConfig): Set<string> {
         out.add(normalized);
       }
     }
+  }
+  // Dangerous commands are valid names even though they're not in platform defaults.
+  for (const cmd of DEFAULT_DANGEROUS_NODE_COMMANDS) {
+    out.add(cmd);
   }
   return out;
 }

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -489,6 +489,35 @@ describe("security audit", () => {
     expect(finding?.detail).toContain("system.runx");
   });
 
+  it("does not flag dangerous commands as unknown in denyCommands", async () => {
+    const cfg: OpenClawConfig = {
+      gateway: {
+        nodes: {
+          denyCommands: [
+            "camera.snap",
+            "camera.clip",
+            "screen.record",
+            "calendar.add",
+            "contacts.add",
+            "reminders.add",
+            "sms.send",
+          ],
+        },
+      },
+    };
+
+    const res = await runSecurityAudit({
+      config: cfg,
+      includeFilesystem: false,
+      includeChannelSecurity: false,
+    });
+
+    const finding = res.findings.find(
+      (f) => f.checkId === "gateway.nodes.deny_commands_ineffective",
+    );
+    expect(finding).toBeUndefined();
+  });
+
   it("flags agent profile overrides when global tools.profile is minimal", async () => {
     const cfg: OpenClawConfig = {
       tools: {


### PR DESCRIPTION
## Summary

`splitShellPipeline` rejects literal newlines inside double-quoted strings, which blocks auto-approval for commands like `gh issue create --body "## Heading\n\ntext"`. The analysis bails with `ok: false` before safeBin or allowlist checks run, so there's no workaround short of `--body-file`.

Closes #16470

lobster-biscuit

## Root Cause

`iterateQuoteAware` in `exec-approvals-analysis.ts` has a `\n`/`\r` check in the `inDouble` block that treats literal newlines as unsupported tokens. But POSIX shells allow newlines inside double-quoted strings — they're just part of the string value. The `$()` and backtick checks already guard against command substitution, so the newline check isn't doing any security work.

## Changes

- Before: any command with a newline inside double quotes gets `ok: false`, skipping all approval checks
- After: newlines inside double quotes are treated as string content (same as single quotes already do)

Unquoted newlines are still rejected via `DISALLOWED_PIPELINE_TOKENS`.

## Tests

- `exec-approvals.test.ts` — 2 new tests (literal `\n` and `\r\n` inside double quotes), both fail before fix, pass after
- All 56 existing tests pass
- `pnpm build && pnpm check` pass (pre-existing format issue in unrelated `.agents/skills/submit-pr/SKILL.md`)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes overly restrictive newline check from double-quoted string parsing, allowing commands like `gh issue create --body "## Heading\n\ntext"` to pass approval checks. Also fixes security audit to recognize dangerous node commands as valid when used in `denyCommands`.

**Main changes:**
- Removed newline/carriage-return rejection inside double-quoted strings in `splitShellPipeline`
- Added `DEFAULT_DANGEROUS_NODE_COMMANDS` to known commands list in security audit
- Added test coverage for literal newlines and `\r\n` inside double quotes
- Added test to verify dangerous commands aren't flagged as unknown in audit

**Security validation:**
- Command substitution (`$()` and backticks) still blocked inside double quotes
- Unquoted newlines still rejected via `DISALLOWED_PIPELINE_TOKENS`
- Aligns behavior with POSIX shell semantics and existing single-quote handling

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no security risks
- The fix is minimal, well-tested, and addresses a legitimate bug. Security checks for command substitution remain intact, unquoted newlines are still blocked, and the change aligns with POSIX shell behavior. The audit fix correctly adds dangerous commands to the known commands list without compromising security.
- No files require special attention

<sub>Last reviewed commit: 7510c6b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->