### PR TITLE
fix: normalize command names to lowercase in denyCommands matching

### DIFF
--- a/src/gateway/node-command-policy.ts
+++ b/src/gateway/node-command-policy.ts
@@ -140,9 +140,9 @@ export function resolveNodeCommandAllowlist(
   const base = PLATFORM_DEFAULTS[platformId] ?? PLATFORM_DEFAULTS.unknown;
   const extra = cfg.gateway?.nodes?.allowCommands ?? [];
   const deny = new Set(cfg.gateway?.nodes?.denyCommands ?? []);
-  const allow = new Set([...base, ...extra].map((cmd) => cmd.trim()).filter(Boolean));
+  const allow = new Set([...base, ...extra].map((cmd) => cmd.trim().toLowerCase()).filter(Boolean));
   for (const blocked of deny) {
-    const trimmed = blocked.trim();
+    const trimmed = blocked.trim().toLowerCase();
     if (trimmed) {
       allow.delete(trimmed);
     }
@@ -155,7 +155,7 @@ export function isNodeCommandAllowed(params: {
   declaredCommands?: string[];
   allowlist: Set<string>;
 }): { ok: true } | { ok: false; reason: string } {
-  const command = params.command.trim();
+  const command = params.command.trim().toLowerCase();
   if (!command) {
     return { ok: false, reason: "command required" };
   }
@@ -163,7 +163,7 @@ export function isNodeCommandAllowed(params: {
     return { ok: false, reason: "command not allowlisted" };
   }
   if (Array.isArray(params.declaredCommands) && params.declaredCommands.length > 0) {
-    if (!params.declaredCommands.includes(command)) {
+    if (!params.declaredCommands.some((cmd) => cmd.toLowerCase() === command)) {
       return { ok: false, reason: "command not declared by node" };
     }
   } else {


### PR DESCRIPTION
## Summary
Command names like `Device.Info` vs `device.info` should match case-insensitively in the `denyCommands` allowlist check. Without normalization, users could bypass deny rules by using different casing. Normalize all command names to lowercase in `resolveNodeCommandAllowlist()` and `isNodeCommandAllowed()`, including the `declaredCommands` comparison.

Fixes #16508

## Validation
- [x] `pnpm build` — passed
- [x] `pnpm check` (format + tsgo + lint) — passed
- [x] `pnpm test` — 1073 tests passed (105 test files)

## Scope
- Single focused fix — 2 files changed (node-command-policy.ts + gateway-misc.test.ts)

## AI-Assistance
- AI-assisted (Claude Code) for implementation
- Human-reviewed: confirmed understanding of changes
- Testing: full local validation suite passed

Note: Tests adapted to `gateway-misc.test.ts` after upstream consolidated test files.