### PR TITLE
fix(sessions): allow WhatsApp-style identifiers in session IDs (#16211)

### DIFF
--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -3,21 +3,23 @@ import fsPromises from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { SessionConfig } from "../types.base.js";
+import type { SessionEntry } from "./types.js";
 import {
   clearSessionStoreCacheForTest,
   loadSessionStore,
   resolveAndPersistSessionFile,
   updateSessionStore,
 } from "../sessions.js";
-import type { SessionConfig } from "../types.base.js";
 import {
   resolveSessionFilePath,
   resolveSessionTranscriptPathInDir,
+  dotQuote,
+  dotUnquote,
   validateSessionId,
 } from "./paths.js";
 import { resolveSessionResetPolicy } from "./reset.js";
 import { appendAssistantMessageToSessionTranscript } from "./transcript.js";
-import type { SessionEntry } from "./types.js";
 
 function useTempSessionsFixture(prefix: string) {
   let tempDir = "";
@@ -268,5 +270,37 @@ describe("resolveAndPersistSessionFile", () => {
     expect(result.sessionEntry.sessionId).toBe(sessionId);
     const saved = loadSessionStore(fixture.storePath(), { skipCache: true });
     expect(saved[sessionKey]?.sessionFile).toBe(fallbackSessionFile);
+  });
+});
+
+describe("validateSessionId with special characters", () => {
+  it("accepts WhatsApp-style IDs with colons and plus signs", () => {
+    expect(validateSessionId("agent:wa-relay:whatsapp:+15551234567")).toBe(
+      "agent:wa-relay:whatsapp:+15551234567",
+    );
+  });
+
+  it("rejects IDs with path traversal characters", () => {
+    expect(() => validateSessionId("../escape")).toThrow("Invalid session ID");
+    expect(() => validateSessionId("foo/bar")).toThrow("Invalid session ID");
+  });
+});
+
+describe("dotQuote / dotUnquote", () => {
+  it("encodes special characters", () => {
+    expect(dotQuote("agent:wa:+1234")).toBe("agent.3Awa.3A.2B1234");
+  });
+
+  it("encodes dots", () => {
+    expect(dotQuote("foo.bar")).toBe("foo.2Ebar");
+  });
+
+  it("roundtrips", () => {
+    const original = "agent:wa-relay:whatsapp:+15551234567";
+    expect(dotUnquote(dotQuote(original))).toBe(original);
+  });
+
+  it("leaves safe characters unchanged", () => {
+    expect(dotQuote("simple-id_123")).toBe("simple-id_123");
   });
 });


### PR DESCRIPTION
## Summary

Fixes #16211 — WhatsApp routing keys contain `:` and `+` (e.g. `agent:wa-relay:whatsapp:+15551234567`) which are rejected by `validateSessionId()`.

## Changes

**`src/config/sessions/paths.ts`**
- Expand `SAFE_SESSION_ID_RE` to accept `:` and `+`
- Add `dotQuote()`/`dotUnquote()` for filesystem-safe transcript filenames (`.` → `.2E`, `+` → `.2B`, `:` → `.3A`)
- Use dot-quoting in `resolveSessionTranscriptPathInDir()`

**`src/config/sessions/paths.test.ts`**
- WhatsApp-style ID validation tests
- Dot-quoting roundtrip and encoding tests
- Path traversal rejection tests

## Why dot-quoting

Per reviewer feedback on the previous attempt: `%`-encoding creates shell/filesystem issues. Dot-quoting (`.XX` hex) is cleaner, avoids `%` escaping, and is fully reversible.

---


## Local Validation

- `pnpm build` ✅
- `pnpm check` (oxlint) ✅
- Relevant test suites pass ✅

## Contribution Checklist

- [x] Focused scope — single fix per PR
- [x] Clear "what" + "why" in description
- [x] AI-assisted (Codex/Claude) — reviewed and tested by human
- [x] Local validation run (`pnpm build && pnpm check`)

*AI-assisted (Claude). Reviewed by human.*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR expands session ID validation to accept WhatsApp-style routing keys containing `:` and `+` (e.g., `agent:wa-relay:whatsapp:+15551234567`). Since these characters are unsafe in filenames, the PR introduces a dot-quoting scheme (`.` → `.2E`, `+` → `.2B`, `:` → `.3A`) applied to session IDs when generating transcript file paths.

- The regex change in `SAFE_SESSION_ID_RE` is correct — the trailing `-` in the character class `[a-z0-9._:+-]` is treated as a literal hyphen by JavaScript's regex engine
- The `dotQuote`/`dotUnquote` encoding scheme is sound and correctly roundtrips, even for edge cases like session IDs containing dot-quote-like sequences (e.g., `a.2E`)
- Backward compatibility is maintained for existing sessions via the stored `sessionFile` field in the session store — only sessions without a stored `sessionFile` that have `.` in their ID would resolve to a different (dot-quoted) path
- Tests cover WhatsApp-style ID acceptance, dot-quoting encoding/decoding, roundtrip correctness, and path traversal rejection

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk — the changes are well-scoped and the encoding scheme is sound.
- The regex change correctly handles the trailing hyphen as a literal character. The dot-quoting scheme is well-designed, roundtrips correctly, and avoids filesystem-unsafe characters. Tests are comprehensive. The only minor concern is backward compatibility for sessions with `.` in the ID that don't have a stored `sessionFile`, which is a narrow edge case. No security issues — path traversal is still correctly rejected.
- No files require special attention

<sub>Last reviewed commit: 36c38fd</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->