### PR TITLE
fix: harden device pairing token generation and verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,6 +192,7 @@ Docs: https://docs.openclaw.ai
 - Clawdock: avoid Zsh readonly variable collisions in helper scripts. (#15501) Thanks @nkelner.
 - Memory: switch default local embedding model to the QAT `embeddinggemma-300m-qat-Q8_0` variant for better quality at the same footprint. (#15429) Thanks @azade-c.
 - Docs/Mermaid: remove hardcoded Mermaid init theme blocks from four docs diagrams so dark mode inherits readable theme defaults. (#15157) Thanks @heytulsiprasad.
+- Security/Device pairing: generate 256-bit base64url device tokens and use byte-safe constant-time verification to avoid token-compare edge-case failures.
 
 ## 2026.2.12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,7 +192,7 @@ Docs: https://docs.openclaw.ai
 - Clawdock: avoid Zsh readonly variable collisions in helper scripts. (#15501) Thanks @nkelner.
 - Memory: switch default local embedding model to the QAT `embeddinggemma-300m-qat-Q8_0` variant for better quality at the same footprint. (#15429) Thanks @azade-c.
 - Docs/Mermaid: remove hardcoded Mermaid init theme blocks from four docs diagrams so dark mode inherits readable theme defaults. (#15157) Thanks @heytulsiprasad.
-- Security/Device pairing: generate 256-bit base64url device tokens and use byte-safe constant-time verification to avoid token-compare edge-case failures. Thanks @FaizanKolega.
+- Security/Pairing: generate 256-bit base64url device and node pairing tokens and use byte-safe constant-time verification to avoid token-compare edge-case failures. Thanks @FaizanKolega, @gumadeiras.
 
 ## 2026.2.12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,7 +192,7 @@ Docs: https://docs.openclaw.ai
 - Clawdock: avoid Zsh readonly variable collisions in helper scripts. (#15501) Thanks @nkelner.
 - Memory: switch default local embedding model to the QAT `embeddinggemma-300m-qat-Q8_0` variant for better quality at the same footprint. (#15429) Thanks @azade-c.
 - Docs/Mermaid: remove hardcoded Mermaid init theme blocks from four docs diagrams so dark mode inherits readable theme defaults. (#15157) Thanks @heytulsiprasad.
-- Security/Device pairing: generate 256-bit base64url device tokens and use byte-safe constant-time verification to avoid token-compare edge-case failures.
+- Security/Device pairing: generate 256-bit base64url device tokens and use byte-safe constant-time verification to avoid token-compare edge-case failures. Thanks @FaizanKolega.
 
 ## 2026.2.12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,7 +192,7 @@ Docs: https://docs.openclaw.ai
 - Clawdock: avoid Zsh readonly variable collisions in helper scripts. (#15501) Thanks @nkelner.
 - Memory: switch default local embedding model to the QAT `embeddinggemma-300m-qat-Q8_0` variant for better quality at the same footprint. (#15429) Thanks @azade-c.
 - Docs/Mermaid: remove hardcoded Mermaid init theme blocks from four docs diagrams so dark mode inherits readable theme defaults. (#15157) Thanks @heytulsiprasad.
-- Security/Pairing: generate 256-bit base64url device and node pairing tokens and use byte-safe constant-time verification to avoid token-compare edge-case failures. Thanks @FaizanKolega, @gumadeiras.
+- Security/Pairing: generate 256-bit base64url device and node pairing tokens and use byte-safe constant-time verification to avoid token-compare edge-case failures. (#16535) Thanks @FaizanKolega, @gumadeiras.
 
 ## 2026.2.12
 

--- a/src/infra/device-pairing.ts
+++ b/src/infra/device-pairing.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { randomUUID, randomBytes } from "node:crypto";
 import { safeEqualSecret } from "../security/secret-equal.js";
 import {
   createAsyncLock,
@@ -176,7 +176,7 @@ function scopesAllow(requested: string[], allowed: string[]): boolean {
 }
 
 function newToken() {
-  return randomUUID().replaceAll("-", "");
+  return randomBytes(32).toString("base64url");
 }
 
 export async function listDevicePairing(baseDir?: string): Promise<DevicePairingList> {

--- a/src/infra/device-pairing.ts
+++ b/src/infra/device-pairing.ts
@@ -1,5 +1,4 @@
-import { randomUUID, randomBytes } from "node:crypto";
-import { safeEqualSecret } from "../security/secret-equal.js";
+import { randomUUID } from "node:crypto";
 import {
   createAsyncLock,
   pruneExpiredPending,
@@ -7,6 +6,7 @@ import {
   resolvePairingPaths,
   writeJsonAtomic,
 } from "./pairing-files.js";
+import { generatePairingToken, verifyPairingToken } from "./pairing-token.js";
 
 export type DevicePairingPendingRequest = {
   requestId: string;
@@ -176,7 +176,7 @@ function scopesAllow(requested: string[], allowed: string[]): boolean {
 }
 
 function newToken() {
-  return randomBytes(32).toString("base64url");
+  return generatePairingToken();
 }
 
 export async function listDevicePairing(baseDir?: string): Promise<DevicePairingList> {
@@ -375,7 +375,7 @@ export async function verifyDeviceToken(params: {
     if (entry.revokedAtMs) {
       return { ok: false, reason: "token-revoked" };
     }
-    if (!safeEqualSecret(params.token, entry.token)) {
+    if (!verifyPairingToken(params.token, entry.token)) {
       return { ok: false, reason: "token-mismatch" };
     }
     const requestedScopes = normalizeScopes(params.scopes);

--- a/src/infra/node-pairing.test.ts
+++ b/src/infra/node-pairing.test.ts
@@ -1,0 +1,60 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+import {
+  approveNodePairing,
+  getPairedNode,
+  requestNodePairing,
+  verifyNodeToken,
+} from "./node-pairing.js";
+
+async function setupPairedNode(baseDir: string): Promise<string> {
+  const request = await requestNodePairing(
+    {
+      nodeId: "node-1",
+      platform: "darwin",
+      commands: ["system.run"],
+    },
+    baseDir,
+  );
+  await approveNodePairing(request.request.requestId, baseDir);
+  const paired = await getPairedNode("node-1", baseDir);
+  expect(paired).not.toBeNull();
+  if (!paired) {
+    throw new Error("expected node to be paired");
+  }
+  return paired.token;
+}
+
+describe("node pairing tokens", () => {
+  test("generates base64url node tokens with 256-bit entropy output length", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-node-pairing-"));
+    const token = await setupPairedNode(baseDir);
+    expect(token).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    expect(Buffer.from(token, "base64url")).toHaveLength(32);
+  });
+
+  test("verifies token and rejects mismatches", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-node-pairing-"));
+    const token = await setupPairedNode(baseDir);
+    await expect(verifyNodeToken("node-1", token, baseDir)).resolves.toEqual({
+      ok: true,
+      node: expect.objectContaining({ nodeId: "node-1" }),
+    });
+    await expect(verifyNodeToken("node-1", "x".repeat(token.length), baseDir)).resolves.toEqual({
+      ok: false,
+    });
+  });
+
+  test("treats multibyte same-length token input as mismatch without throwing", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-node-pairing-"));
+    const token = await setupPairedNode(baseDir);
+    const multibyteToken = "é".repeat(token.length);
+    expect(Buffer.from(multibyteToken).length).not.toBe(Buffer.from(token).length);
+
+    await expect(verifyNodeToken("node-1", multibyteToken, baseDir)).resolves.toEqual({
+      ok: false,
+    });
+  });
+});

--- a/src/infra/node-pairing.ts
+++ b/src/infra/node-pairing.ts
@@ -6,6 +6,7 @@ import {
   resolvePairingPaths,
   writeJsonAtomic,
 } from "./pairing-files.js";
+import { generatePairingToken, verifyPairingToken } from "./pairing-token.js";
 
 export type NodePairingPendingRequest = {
   requestId: string;
@@ -87,7 +88,7 @@ function normalizeNodeId(nodeId: string) {
 }
 
 function newToken() {
-  return randomUUID().replaceAll("-", "");
+  return generatePairingToken();
 }
 
 export async function listNodePairing(baseDir?: string): Promise<NodePairingList> {
@@ -217,7 +218,7 @@ export async function verifyNodeToken(
   if (!node) {
     return { ok: false };
   }
-  return node.token === token ? { ok: true, node } : { ok: false };
+  return verifyPairingToken(token, node.token) ? { ok: true, node } : { ok: false };
 }
 
 export async function updatePairedNodeMetadata(

--- a/src/infra/pairing-token.ts
+++ b/src/infra/pairing-token.ts
@@ -1,0 +1,12 @@
+import { randomBytes } from "node:crypto";
+import { safeEqualSecret } from "../security/secret-equal.js";
+
+export const PAIRING_TOKEN_BYTES = 32;
+
+export function generatePairingToken(): string {
+  return randomBytes(PAIRING_TOKEN_BYTES).toString("base64url");
+}
+
+export function verifyPairingToken(provided: string, expected: string): boolean {
+  return safeEqualSecret(provided, expected);
+}


### PR DESCRIPTION
## Summary

This PR carries forward and finalizes the device-pairing hardening work from the original PR:
- original: https://github.com/openclaw/openclaw/pull/16490

Changes included:
- Switch device token generation from UUID-derived hex to `randomBytes(32).toString("base64url")` (256-bit entropy output)
- Keep verification on the existing byte-safe constant-time helper (`safeEqualSecret`) to avoid multibyte length edge-case throws
- Add targeted regression tests for token format and multibyte mismatch behavior
- Add changelog entry with contributor credit

## Credit

Credit to @FaizanKolega for the original hardening proposal and implementation direction in #16490.

## Why this follow-up PR exists

The original PR branch is on a fork I cannot push to from this account, so this PR ports the fixes and review-driven updates onto a branch in `openclaw/openclaw`.

## Validation

- `pnpm vitest run src/infra/device-pairing.test.ts` (pass)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Hardened device pairing token generation by switching from UUID-based tokens (122 bits) to cryptographically secure `randomBytes(32).toString("base64url")` (256 bits entropy). The existing `safeEqualSecret` constant-time comparison helper correctly handles the new token format and prevents multibyte character edge-case failures.

- Switched `newToken()` from `randomUUID().replaceAll("-", "")` to `randomBytes(32).toString("base64url")` for stronger entropy
- Added test coverage for token format validation (43-character base64url pattern)
- Added regression test for multibyte character mismatch handling
- Updated CHANGELOG with contributor credit

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Security hardening improves token entropy from 122 to 256 bits using Node.js cryptographic primitives. The existing constant-time comparison function correctly handles the new format. Comprehensive test coverage validates the format and multibyte edge case. Changes are well-scoped and thoroughly documented.
- No files require special attention

<sub>Last reviewed commit: d41fbfd</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->