### PR TITLE
[AI-assisted] feat(usage): support cache-hit differentiated pricing

### DIFF
--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -238,7 +238,12 @@ async function scanTranscriptFile(params: {
           model: entry.model,
           config: params.config,
         });
-        entry.costTotal = estimateUsageCost({ usage: entry.usage, cost });
+        entry.costTotal = estimateUsageCost({
+          usage: entry.usage,
+          cost,
+          provider: entry.provider,
+          model: entry.model
+        });
       }
 
       params.onEntry(entry);
@@ -951,7 +956,12 @@ export async function loadSessionLogs(params: {
               model: message.model as string | undefined,
               config: params.config,
             });
-            cost = estimateUsageCost({ usage, cost: costConfig });
+            cost = estimateUsageCost({
+              usage,
+              cost: costConfig,
+              provider: message.provider as string | undefined,
+              model: message.model as string | undefined
+            });
           }
         }
       }

--- a/src/utils/usage-format.ts
+++ b/src/utils/usage-format.ts
@@ -64,9 +64,14 @@ const toNumber = (value: number | undefined): number =>
 export function estimateUsageCost(params: {
   usage?: NormalizedUsage | UsageTotals | null;
   cost?: ModelCostConfig;
+  provider?: string;
+  model?: string;
 }): number | undefined {
   const usage = params.usage;
   const cost = params.cost;
+  const provider = params.provider?.trim().toLowerCase();
+  const model = params.model?.trim().toLowerCase();
+  
   if (!usage || !cost) {
     return undefined;
   }
@@ -74,11 +79,34 @@ export function estimateUsageCost(params: {
   const output = toNumber(usage.output);
   const cacheRead = toNumber(usage.cacheRead);
   const cacheWrite = toNumber(usage.cacheWrite);
-  const total =
-    input * cost.input +
-    output * cost.output +
-    cacheRead * cost.cacheRead +
-    cacheWrite * cost.cacheWrite;
+
+  // Calculate input cost with cache hit pricing
+  let inputCost = input * cost.input;
+  if (cacheRead > 0 && input > 0) {
+    const cacheMissInput = Math.max(0, input - cacheRead);
+    const cacheHitInput = cacheRead;
+    
+    // Get cache hit price based on provider
+    let cacheHitPrice = cost.cacheRead || cost.input * 0.1; // Default to 10% of input price
+    
+    // Provider-specific cache hit pricing
+    if (provider === "deepseek") {
+      cacheHitPrice = 0.028; // DeepSeek cache hit price
+    } else if (provider === "moonshot") {
+      cacheHitPrice = 0.10; // Kimi cache hit price for kimi-k2.5
+    } else if (provider === "minimax") {
+      cacheHitPrice = cost.cacheRead || 0.03; // MiniMax cache read price
+    }
+    
+    inputCost = cacheMissInput * cost.input + cacheHitInput * cacheHitPrice;
+  }
+  
+  const outputCost = output * cost.output;
+  const cacheReadCost = cacheRead * (cost.cacheRead || 0);
+  const cacheWriteCost = cacheWrite * (cost.cacheWrite || 0);
+  
+  const total = inputCost + outputCost + cacheReadCost + cacheWriteCost;
+  
   if (!Number.isFinite(total)) {
     return undefined;
   }


### PR DESCRIPTION
## Summary
Add support for cache-hit differentiated pricing in usage calculation.

## Problem
- DeepSeek: cache hit price is $0.028/M vs $0.28/M (cache miss)
- Kimi: cache hit price is $0.10/M vs $0.60/M  
- MiniMax: cache write cost was missing

## Solution
Modified `estimateUsageCost()` to calculate:
- cacheMissInput * inputPrice + cacheHitInput * cacheHitPrice

## Files Changed
- `src/utils/usage-format.ts` - Core calculation logic
- `src/infra/session-cost-usage.ts` - Pass provider/model to cost function

## Testing
- [x] Gateway restarted successfully
- [ ] Need to verify with actual usage data

## Notes
- AI-assisted: Yes (ShadowAI)
- Testing: Lightly tested (needs real usage data verification)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR modifies `estimateUsageCost()` in `src/utils/usage-format.ts` to apply provider-specific cache-hit pricing for DeepSeek, Moonshot (Kimi), and MiniMax, and updates two call sites in `src/infra/session-cost-usage.ts` to pass `provider` and `model` to the function.

- **Provider key mismatch**: The hardcoded `provider === "deepseek"` check will not match any built-in provider, since DeepSeek models are served under provider keys like `"qianfan"`, `"venice"`, `"together"`, etc. Users of DeepSeek via built-in providers won't receive the intended cache-hit pricing.
- **Inverted moonshot pricing**: Since Moonshot's default `cost.input` is `0`, the cache-hit logic charges $0.10/M for cache hits while cache-miss tokens are free — the opposite of the intended behavior.
- **Double-counting** (flagged in prior review): Cache read tokens are counted both in `inputCost` (line 101) and `cacheReadCost` (line 105), leading to overcharging.
- **No tests**: The existing test passes by coincidence but no new tests cover the provider-specific pricing paths.
- The `model` parameter is accepted but unused in the function body.

Consider using the existing `ModelCostConfig.cacheRead` field for cache-hit pricing (which is already configured per-model) rather than hardcoding per-provider prices in the calculation function.

<h3>Confidence Score: 1/5</h3>

- This PR has correctness issues that will produce incorrect cost calculations for users
- Score of 1 reflects multiple logic issues: provider key mismatches that make the new code unreachable for built-in providers, inverted pricing for moonshot, double-counting of cache read tokens (flagged in prior review), and no test coverage for the new paths. The cost calculation directly affects user billing visibility.
- src/utils/usage-format.ts requires significant rework to address the double-counting and provider key matching issues

<sub>Last reviewed commit: 5183ebb</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->