### PR TITLE
feat(discord): add configurable ephemeral option for slash commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 - iOS/Gateway: stabilize background wake and reconnect behavior with background reconnect suppression/lease windows, BGAppRefresh wake fallback, location wake hook throttling, and APNs wake retry+nudge instrumentation. (#21226) thanks @mbelinky.
 - Auto-reply/UI: add model fallback lifecycle visibility in verbose logs, /status active-model context with fallback reason, and cohesive WebUI fallback indicators. (#20704) Thanks @joshavant.
 - Discord/Streaming: add stream preview mode for live draft replies with partial/block options and configurable chunking. Thanks @thewilloftheshadow. Inspiration @neoagentic-ship-it.
+- Discord: add configurable ephemeral defaults for slash-command responses. (#16563) Thanks @wei.
 - Discord/Telegram: add configurable lifecycle status reactions for queued/thinking/tool/done/error phases with a shared controller and emoji/timing overrides. Thanks @wolly-tundracube and @thewilloftheshadow.
 - Discord/Voice: add voice channel join/leave/status via `/vc`, plus auto-join configuration for realtime voice conversations. Thanks @thewilloftheshadow.
 - Channels: allow per-channel model overrides via `channels.modelByChannel` and note them in /status. Thanks @thewilloftheshadow.

--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -534,6 +534,10 @@ Use `bindings[].match.roles` to route Discord guild members to different agents 
 
 See [Slash commands](/tools/slash-commands) for command catalog and behavior.
 
+Default slash command settings:
+
+- `ephemeral: true`
+
 ## Feature details
 
 <AccordionGroup>
@@ -969,7 +973,7 @@ High-signal Discord fields:
 
 - startup/auth: `enabled`, `token`, `accounts.*`, `allowBots`
 - policy: `groupPolicy`, `dm.*`, `guilds.*`, `guilds.*.channels.*`
-- command: `commands.native`, `commands.useAccessGroups`, `configWrites`
+- command: `commands.native`, `commands.useAccessGroups`, `configWrites`, `slashCommand.*`
 - reply/history: `replyToMode`, `historyLimit`, `dmHistoryLimit`, `dms.*.historyLimit`
 - delivery: `textChunkLimit`, `chunkMode`, `maxLinesPerMessage`
 - streaming: `streamMode`, `draftChunk`, `blockStreaming`, `blockStreamingCoalesce`

--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -142,6 +142,11 @@ export type DiscordUiConfig = {
   components?: DiscordUiComponentsConfig;
 };
 
+export type DiscordSlashCommandConfig = {
+  /** Reply ephemerally (default: true). */
+  ephemeral?: boolean;
+};
+
 export type DiscordAccountConfig = {
   /** Optional display name for this account (used in CLI/UI lists). */
   name?: string;
@@ -226,6 +231,8 @@ export type DiscordAccountConfig = {
   agentComponents?: DiscordAgentComponentsConfig;
   /** Discord UI customization (components, modals, etc.). */
   ui?: DiscordUiConfig;
+  /** Slash command configuration. */
+  slashCommand?: DiscordSlashCommandConfig;
   /** Privileged Gateway Intents (must also be enabled in Discord Developer Portal). */
   intents?: DiscordIntentsConfig;
   /** Voice channel conversation settings. */

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -357,6 +357,12 @@ export const DiscordAccountSchema = z
       .strict()
       .optional(),
     ui: DiscordUiSchema,
+    slashCommand: z
+      .object({
+        ephemeral: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
     intents: z
       .object({
         presence: z.boolean().optional(),

--- a/src/discord/monitor/commands.test.ts
+++ b/src/discord/monitor/commands.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { resolveDiscordSlashCommandConfig } from "./commands.js";
+
+describe("resolveDiscordSlashCommandConfig", () => {
+  it("defaults ephemeral to true when undefined", () => {
+    const result = resolveDiscordSlashCommandConfig(undefined);
+    expect(result.ephemeral).toBe(true);
+  });
+
+  it("defaults ephemeral to true when not explicitly false", () => {
+    const result = resolveDiscordSlashCommandConfig({});
+    expect(result.ephemeral).toBe(true);
+  });
+
+  it("sets ephemeral to false when explicitly false", () => {
+    const result = resolveDiscordSlashCommandConfig({ ephemeral: false });
+    expect(result.ephemeral).toBe(false);
+  });
+
+  it("keeps ephemeral true when explicitly true", () => {
+    const result = resolveDiscordSlashCommandConfig({ ephemeral: true });
+    expect(result.ephemeral).toBe(true);
+  });
+});

--- a/src/discord/monitor/commands.ts
+++ b/src/discord/monitor/commands.ts
@@ -1,0 +1,9 @@
+import type { DiscordSlashCommandConfig } from "../../config/types.discord.js";
+
+export function resolveDiscordSlashCommandConfig(
+  raw?: DiscordSlashCommandConfig,
+): Required<DiscordSlashCommandConfig> {
+  return {
+    ephemeral: raw?.ephemeral !== false,
+  };
+}

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -54,6 +54,7 @@ import {
   createDiscordComponentStringSelect,
   createDiscordComponentUserSelect,
 } from "./agent-components.js";
+import { resolveDiscordSlashCommandConfig } from "./commands.js";
 import { createExecApprovalButton, DiscordExecApprovalHandler } from "./exec-approvals.js";
 import { createDiscordGatewayPlugin } from "./gateway-plugin.js";
 import { registerGateway, unregisterGateway } from "./gateway-registry.js";
@@ -246,8 +247,9 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
     globalSetting: cfg.commands?.native,
   });
   const useAccessGroups = cfg.commands?.useAccessGroups !== false;
+  const slashCommand = resolveDiscordSlashCommandConfig(discordCfg.slashCommand);
   const sessionPrefix = "discord:slash";
-  const ephemeralDefault = true;
+  const ephemeralDefault = slashCommand.ephemeral;
   const voiceEnabled = discordCfg.voice?.enabled !== false;
 
   if (token) {


### PR DESCRIPTION
## Summary

- **Problem:** Discord slash command responses are hardcoded as ephemeral (only visible to the command sender), with no way to change this. When running `/new <question`, the reply is only being displayed to the sender temporarily, and there is no way to persist message and reply in the channel). Meanwhile Slack integration has this as a configurable  slash command setting to turn off ephemeral.
- **Why it matters:** Some users want slash command output visible to all channel members in shared workspaces or to themselves to refer back to at a later time or from a different device. This is already a supported feature in Slack, so this PR brings Discord to parity. Existing Slack type `SlackSlashCommandConfig`: https://github.com/openclaw/openclaw/blob/b97191b81afb0f858ff1c2daf71b3642ec6ce83e/src/config/types.slack.ts#L67-L68
- **What changed:** Following the convention from Slack, added the new `DiscordSlashCommandConfig` and `channels.discord.slashCommand.ephemeral` config option (default: true for backwards compatibility).
- **What did NOT change (scope boundary):** Other slash command options like `sessionPrefix` are not part of the scope of this pull request. If approved & needed, I can work on a follow-up PR to add sessionPrefix to slash command config options.

This pull request was AI-assisted with careful human steering and verifications as outlined below.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

N/A

## User-visible / Behavior Changes

- New config path: `channels.discord.slashCommand.ephemeral` (boolean, default: true, backwards compatible)

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: Linux / Debian 13 (Trixie)
- Runtime/container: Node v25.5.0
- Integration/channel: Discord

### Steps

1. Set `channels.discord.slashCommand.ephemeral: false` in config
2. Run a slash command in a Discord channel
3. Response is visible to all channel members and persisted in the channel

### Expected

- With `ephemeral: true` (default, and backwards compatible): response only visible to command issuer and is deleted after some time.
- With `ephemeral: false`: response visible to everyone and is persisted indefinitely.

### Actual

- Matches expected

## Evidence

Attach at least one:

- [x] Screenshot/recording

**Behavior with `ephemeral: true`:**
<img width="732" height="556" alt="image" src="https://github.com/user-attachments/assets/e5eab76f-fa56-41b5-ac52-b8a7837a6796" />

**Behavior with `ephemeral: false`:**
<img width="687" height="490" alt="image" src="https://github.com/user-attachments/assets/294a13f2-6397-4d63-aed3-e6f08329639a" />

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Verified behavior with `ephemeral: true`, `ephemeral: false`, empty slashCommand (`{}`), and without slashCommand option key. Verified in channels and dms.
- Edge cases checked: Verified behavior without ephemeral setting or a blank setting object, confirmed backwards compatibility.
- What you did **not** verify: Multiple discord account scenarios.

## Compatibility / Migration

- Backward compatible? `Yes` — existing configs without `channels.discord.slashCommand` default to `ephemeral: true`
- Config/env changes? `Yes` — new optional `channels.discord.slashCommand.ephemeral` boolean field
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Remove `channels.discord.slashCommand` from config; defaults back to ephemeral
- Files/config to restore: `channels.discord` section in config
- Known bad symptoms reviewers should watch for: None

## Risks and Mitigations

None

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a configurable `ephemeral` option for Discord slash command responses via `channels.discord.slashCommand.ephemeral` (default: `true`), bringing Discord to parity with the existing Slack `slashCommand.ephemeral` setting.

- Adds `DiscordSlashCommandConfig` type and Zod schema with an optional `ephemeral` boolean field
- Introduces `resolveDiscordSlashCommandConfig()` resolver that defaults to `ephemeral: true` for backwards compatibility
- Replaces the hardcoded `ephemeralDefault = true` in `provider.ts` with the resolved config value
- Includes unit tests covering all edge cases (`undefined`, empty object, explicit `true`, explicit `false`)
- Updates Discord docs with default slash command settings and adds `slashCommand.*` to the config reference list
- Multi-account configs work correctly since `slashCommand` participates in the existing shallow merge via `resolveDiscordAccount`

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, backwards-compatible feature addition with proper defaults and test coverage.
- The change is small and well-scoped: a new optional config field with a safe default (`true`) that preserves existing behavior. The implementation follows established patterns from the Slack integration. Type definitions, Zod validation schema, resolver function, and usage site are all consistent. Unit tests cover the key edge cases. The config participates correctly in multi-account shallow merges. No security surface is changed — the option only controls message visibility. Documentation is updated appropriately.
- No files require special attention

<sub>Last reviewed commit: 88a482e</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->