### PR TITLE
fix(media): expand isBinaryMediaMime to cover Office and archive formats (#16513)

### DIFF
--- a/src/media-understanding/apply.binary-mime.test.ts
+++ b/src/media-understanding/apply.binary-mime.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { isBinaryMediaMime } from "./apply.js";
+
+describe("isBinaryMediaMime", () => {
+  it.each([
+    "image/png",
+    "image/jpeg",
+    "audio/mpeg",
+    "video/mp4",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "application/vnd.ms-excel",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "application/zip",
+    "application/x-tar",
+    "application/x-7z-compressed",
+    "application/octet-stream",
+    "application/pdf",
+    "application/gzip",
+  ])("returns true for %s", (mime) => {
+    expect(isBinaryMediaMime(mime)).toBe(true);
+  });
+
+  it.each(["text/plain", "text/html", "text/csv", "application/json", "application/xml"])(
+    "returns false for %s",
+    (mime) => {
+      expect(isBinaryMediaMime(mime)).toBe(false);
+    },
+  );
+
+  it("returns false for undefined", () => {
+    expect(isBinaryMediaMime(undefined)).toBe(false);
+  });
+});

--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -317,11 +317,21 @@ function resolveTextMimeFromName(name?: string): string | undefined {
   return TEXT_EXT_MIME.get(ext);
 }
 
-function isBinaryMediaMime(mime?: string): boolean {
+export function isBinaryMediaMime(mime?: string): boolean {
   if (!mime) {
     return false;
   }
-  return mime.startsWith("image/") || mime.startsWith("audio/") || mime.startsWith("video/");
+  return (
+    mime.startsWith("image/") ||
+    mime.startsWith("audio/") ||
+    mime.startsWith("video/") ||
+    mime.startsWith("application/vnd.") ||
+    mime.startsWith("application/x-") ||
+    mime === "application/zip" ||
+    mime === "application/octet-stream" ||
+    mime === "application/pdf" ||
+    mime === "application/gzip"
+  );
 }
 
 async function extractFileBlocks(params: {


### PR DESCRIPTION
## Summary

Fixes #16513 — Office files (.xlsx, .docx, .pptx) pass the `looksLikeUtf8Text()` heuristic because they're ZIP archives containing XML. A single .xlsx upload consumed ~250K tokens and permanently stuck the agent session.

## Changes

**`src/media-understanding/apply.ts`**
- Expand `isBinaryMediaMime()` to also match `application/vnd.*`, `application/x-*`, `application/zip`, `application/octet-stream`, `application/pdf`, and `application/gzip`
- Export the function for testability

**`src/media-understanding/apply.binary-mime.test.ts`**
- 19 test cases covering all binary MIME types and text MIME passthrough

---

*AI-assisted (Claude). Reviewed by human.*

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes a real and important issue where Office files (`.xlsx`, `.docx`, `.pptx`) — which are ZIP archives containing XML — passed the `looksLikeUtf8Text()` heuristic, leading to massive token consumption (~250K) and stuck agent sessions.

The fix expands `isBinaryMediaMime()` to catch these binary formats early, before the text heuristic runs. The function is also exported for direct unit testing.

- The `application/vnd.*`, `application/zip`, `application/octet-stream`, `application/pdf`, and `application/gzip` exact/prefix matches are correct and well-targeted.
- The `application/x-*` prefix match is **overly broad**: it will misclassify `application/x-yaml` as binary. This type is listed in `EXTRA_TEXT_MIMES` in the same file and represents valid text content. Files uploaded without a recognized extension but with `Content-Type: application/x-yaml` would be silently skipped. Consider using explicit matches for known binary `application/x-*` subtypes instead.
- `application/msword` (legacy `.doc`) is not covered by any of the new patterns, though this may be a minor gap since `.doc` files with the correct extension would be handled by `resolveTextMimeFromName`.
- New test file provides good coverage with 19 cases but should also include `application/x-yaml` as a "returns false" case to prevent the identified regression.

<h3>Confidence Score: 3/5</h3>

- The core fix is sound, but the `application/x-*` prefix match introduces a regression for text-based MIME types like `application/x-yaml`.
- Score of 3 reflects that the PR correctly solves the reported Office file issue but introduces an overly broad pattern that could silently skip legitimate text content. The `application/x-yaml` MIME type is explicitly recognized as text in the same file's `EXTRA_TEXT_MIMES` list, making this a concrete conflict rather than a theoretical concern.
- Pay close attention to `src/media-understanding/apply.ts` — the `application/x-*` prefix match at line 329 conflicts with text MIME types recognized elsewhere in the same file.

<sub>Last reviewed commit: 68a6534</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->