### PR TITLE
fix(line): accept webhook verification requests without signature (#16425)

### DIFF
--- a/src/line/webhook.test.ts
+++ b/src/line/webhook.test.ts
@@ -118,4 +118,43 @@ describe("createLineWebhookMiddleware", () => {
     expect(res.status).toHaveBeenCalledWith(401);
     expect(onEvents).not.toHaveBeenCalled();
   });
+
+  it("responds 200 to LINE verification requests (empty events, no signature)", async () => {
+    const onEvents = vi.fn(async () => {});
+    const middleware = createLineWebhookMiddleware({ channelSecret: "secret", onEvents });
+
+    const rawBody = JSON.stringify({ events: [] });
+    const req = {
+      headers: {},
+      body: rawBody,
+      // oxlint-disable-next-line typescript/no-explicit-any
+    } as any;
+    const res = createRes();
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await middleware(req, res, {} as any);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ status: "ok" });
+    expect(onEvents).not.toHaveBeenCalled();
+  });
+
+  it("still rejects missing signature when events are present", async () => {
+    const onEvents = vi.fn(async () => {});
+    const middleware = createLineWebhookMiddleware({ channelSecret: "secret", onEvents });
+
+    const rawBody = JSON.stringify({ events: [{ type: "message" }] });
+    const req = {
+      headers: {},
+      body: rawBody,
+      // oxlint-disable-next-line typescript/no-explicit-any
+    } as any;
+    const res = createRes();
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await middleware(req, res, {} as any);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(onEvents).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #16425 — LINE's webhook verification sends `{"events":[]}` without an `X-Line-Signature` header. The middleware rejected these with 400 ("Missing X-Line-Signature header"), causing the LINE Developers Console "Verify" button to fail.

## Changes

**`src/line/webhook.ts`**
- Before checking for a missing signature, parse the body and check if `events` is an empty array
- If so, respond 200 immediately (verification handshake)
- Non-empty event payloads without a signature still get rejected with 400

**`src/line/webhook.test.ts`**
- Test: verification request (empty events, no signature) → 200
- Test: real events without signature → still 400

## Context

Per [LINE's webhook documentation](https://developers.line.biz/en/docs/messaging-api/receiving-messages/#verifying-signatures), the verification request is a POST with an empty events array and no signature. The server should return HTTP 200 to confirm the endpoint is reachable.

---

*AI-assisted (Claude). Reviewed by human.*

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes LINE webhook verification by allowing requests with `{"events":[]}` and no `X-Line-Signature` header to return HTTP 200. This is required by LINE's Messaging API, which sends such a request when the "Verify" button is clicked in the LINE Developers Console. Non-empty event payloads without a signature are still correctly rejected with 400.

- Adds an early-return check in `createLineWebhookMiddleware` that parses the body before rejecting missing signatures, and responds 200 if events is an empty array
- Has a **TypeScript type error** on line 46 of `src/line/webhook.ts`: `readRawBody(req)` returns `string | null` but is passed to `parseWebhookBody` which expects `string` — this should fail `pnpm tsgo` with strict null checks enabled
- Two new tests cover both the verification handshake (200) and the continued rejection of unsigned non-empty events (400)

<h3>Confidence Score: 3/5</h3>

- Functionally correct at runtime for the tested scenarios, but has a TypeScript type error that likely breaks CI type checking
- The logic is sound — empty-events verification requests are allowed through while non-empty unsigned requests are still rejected. However, the `readRawBody(req)` call passes a `string | null` value where `string` is expected, which is a type error under the project's strict TypeScript config. This will likely cause CI failures with `pnpm tsgo`.
- `src/line/webhook.ts` line 46 — type mismatch when calling `parseWebhookBody` with potentially null `rawBody`

<sub>Last reviewed commit: ba2d88d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->