### PR TITLE
Feat/tts piper language routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "dotenv": "^17.3.1",
     "express": "^5.2.1",
     "file-type": "^21.3.0",
+    "franc-min": "^6.2.0",
     "grammy": "^1.40.0",
     "https-proxy-agent": "^7.0.6",
     "jiti": "^2.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,9 @@ importers:
       file-type:
         specifier: ^21.3.0
         version: 21.3.0
+      franc-min:
+        specifier: ^6.2.0
+        version: 6.2.0
       grammy:
         specifier: ^1.40.0
         version: 1.40.0
@@ -3508,6 +3511,9 @@ packages:
   codec-parser@2.5.0:
     resolution: {integrity: sha512-Ru9t80fV8B0ZiixQl8xhMTLru+dzuis/KQld32/x5T/+3LwZb0/YvQdSKytX9JqCnRdiupvAvyYJINKrXieziQ==}
 
+  collapse-white-space@2.1.0:
+    resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -3915,6 +3921,9 @@ packages:
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
+
+  franc-min@6.2.0:
+    resolution: {integrity: sha512-1uDIEUSlUZgvJa2AKYR/dmJC66v/PvGQ9mWfI9nOr/kPpMFyvswK0gPXOwpYJYiYD008PpHLkGfG58SPjQJFxw==}
 
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
@@ -4625,6 +4634,9 @@ packages:
 
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  n-gram@2.0.2:
+    resolution: {integrity: sha512-S24aGsn+HLBxUGVAUFOwGpKs7LBcG4RudKU//eWzt/mQ97/NMKQxDWHyHx63UNWk/OOdihgmzoETn1tf5nQDzQ==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -5504,6 +5516,9 @@ packages:
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
+
+  trigram-utils@2.0.1:
+    resolution: {integrity: sha512-nfWIXHEaB+HdyslAfMxSqWKDdmqY9I32jS7GnqpdWQnLH89r6A5sdk3fDVYqGAZ0CrT8ovAFSAo6HRiWcWNIGQ==}
 
   ts-algebra@2.0.0:
     resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
@@ -6845,7 +6860,7 @@ snapshots:
 
   '@larksuiteoapi/node-sdk@1.59.0':
     dependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       lodash.identity: 3.0.0
       lodash.merge: 4.6.2
       lodash.pickby: 4.6.0
@@ -6861,7 +6876,7 @@ snapshots:
     dependencies:
       '@types/node': 24.10.13
     optionalDependencies:
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
     transitivePeerDependencies:
       - debug
 
@@ -7064,7 +7079,7 @@ snapshots:
       '@azure/core-auth': 1.10.1
       '@azure/msal-node': 3.8.7
       '@microsoft/agents-activity': 1.2.3
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       jsonwebtoken: 9.0.3
       jwks-rsa: 3.2.2
       object-path: 0.11.8
@@ -8011,7 +8026,7 @@ snapshots:
       '@slack/types': 2.20.0
       '@slack/web-api': 7.14.0
       '@types/express': 5.0.6
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       express: 5.2.1
       path-to-regexp: 8.3.0
       raw-body: 3.0.2
@@ -8057,7 +8072,7 @@ snapshots:
       '@slack/types': 2.20.0
       '@types/node': 25.2.3
       '@types/retry': 0.12.0
-      axios: 1.13.5
+      axios: 1.13.5(debug@4.4.3)
       eventemitter3: 5.0.4
       form-data: 2.5.4
       is-electron: 2.2.2
@@ -8951,14 +8966,6 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  axios@1.13.5:
-    dependencies:
-      follow-redirects: 1.15.11
-      form-data: 2.5.4
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
   axios@1.13.5(debug@4.4.3):
     dependencies:
       follow-redirects: 1.15.11(debug@4.4.3)
@@ -9144,6 +9151,8 @@ snapshots:
 
   codec-parser@2.5.0:
     optional: true
+
+  collapse-white-space@2.1.0: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -9542,8 +9551,6 @@ snapshots:
 
   flatbuffers@24.12.23: {}
 
-  follow-redirects@1.15.11: {}
-
   follow-redirects@1.15.11(debug@4.4.3):
     optionalDependencies:
       debug: 4.4.3
@@ -9569,6 +9576,10 @@ snapshots:
       fetch-blob: 3.2.0
 
   forwarded@0.2.0: {}
+
+  franc-min@6.2.0:
+    dependencies:
+      trigram-utils: 2.0.1
 
   fresh@0.5.2: {}
 
@@ -10306,6 +10317,8 @@ snapshots:
       any-promise: 1.3.0
       object-assign: 4.1.1
       thenify-all: 1.6.0
+
+  n-gram@2.0.2: {}
 
   nanoid@3.3.11: {}
 
@@ -11415,6 +11428,11 @@ snapshots:
   tr46@0.0.3: {}
 
   tree-kill@1.2.2: {}
+
+  trigram-utils@2.0.1:
+    dependencies:
+      collapse-white-space: 2.1.0
+      n-gram: 2.0.2
 
   ts-algebra@2.0.0: {}
 

--- a/src/auto-reply/reply/commands-tts.ts
+++ b/src/auto-reply/reply/commands-tts.ts
@@ -162,6 +162,7 @@ export const handleTtsCommands: CommandHandler = async (params, allowTextCommand
       const hasOpenAI = Boolean(resolveTtsApiKey(config, "openai"));
       const hasElevenLabs = Boolean(resolveTtsApiKey(config, "elevenlabs"));
       const hasEdge = isTtsProviderConfigured(config, "edge");
+      const hasPiper = isTtsProviderConfigured(config, "piper");
       return {
         shouldContinue: false,
         reply: {
@@ -171,13 +172,19 @@ export const handleTtsCommands: CommandHandler = async (params, allowTextCommand
             `OpenAI key: ${hasOpenAI ? "✅" : "❌"}\n` +
             `ElevenLabs key: ${hasElevenLabs ? "✅" : "❌"}\n` +
             `Edge enabled: ${hasEdge ? "✅" : "❌"}\n` +
-            `Usage: /tts provider openai | elevenlabs | edge`,
+            `Piper URL: ${hasPiper ? "✅" : "❌"}\n` +
+            `Usage: /tts provider openai | elevenlabs | edge | piper`,
         },
       };
     }
 
     const requested = args.trim().toLowerCase();
-    if (requested !== "openai" && requested !== "elevenlabs" && requested !== "edge") {
+    if (
+      requested !== "openai" &&
+      requested !== "elevenlabs" &&
+      requested !== "edge" &&
+      requested !== "piper"
+    ) {
       return { shouldContinue: false, reply: ttsUsage() };
     }
 

--- a/src/config/types.tts.ts
+++ b/src/config/types.tts.ts
@@ -1,4 +1,4 @@
-export type TtsProvider = "elevenlabs" | "openai" | "edge";
+export type TtsProvider = "elevenlabs" | "openai" | "edge" | "piper";
 
 export type TtsMode = "final" | "all";
 
@@ -71,6 +71,12 @@ export type TtsConfig = {
     volume?: string;
     saveSubtitles?: boolean;
     proxy?: string;
+    timeoutMs?: number;
+  };
+  /** Piper (Wyoming HTTP sidecar) configuration. */
+  piper?: {
+    baseUrl?: string;
+    voice?: string;
     timeoutMs?: number;
   };
   /** Optional path for local TTS user preferences JSON. */

--- a/src/config/types.tts.ts
+++ b/src/config/types.tts.ts
@@ -76,7 +76,9 @@ export type TtsConfig = {
   /** Piper (Wyoming HTTP sidecar) configuration. */
   piper?: {
     baseUrl?: string;
+    baseUrlByLang?: Record<string, string>;
     voice?: string;
+    voiceByLang?: Record<string, string>;
     timeoutMs?: number;
   };
   /** Optional path for local TTS user preferences JSON. */

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -164,7 +164,7 @@ export const MarkdownConfigSchema = z
   .strict()
   .optional();
 
-export const TtsProviderSchema = z.enum(["elevenlabs", "openai", "edge"]);
+export const TtsProviderSchema = z.enum(["elevenlabs", "openai", "edge", "piper"]);
 export const TtsModeSchema = z.enum(["final", "all"]);
 export const TtsAutoSchema = z.enum(["off", "always", "inbound", "tagged"]);
 export const TtsConfigSchema = z
@@ -228,6 +228,14 @@ export const TtsConfigSchema = z
         volume: z.string().optional(),
         saveSubtitles: z.boolean().optional(),
         proxy: z.string().optional(),
+        timeoutMs: z.number().int().min(1000).max(120000).optional(),
+      })
+      .strict()
+      .optional(),
+    piper: z
+      .object({
+        baseUrl: z.string().optional(),
+        voice: z.string().optional(),
         timeoutMs: z.number().int().min(1000).max(120000).optional(),
       })
       .strict()

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -235,7 +235,9 @@ export const TtsConfigSchema = z
     piper: z
       .object({
         baseUrl: z.string().optional(),
+        baseUrlByLang: z.record(z.string(), z.string()).optional(),
         voice: z.string().optional(),
+        voiceByLang: z.record(z.string(), z.string()).optional(),
         timeoutMs: z.number().int().min(1000).max(120000).optional(),
       })
       .strict()

--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -35,7 +35,14 @@ vi.mock("../agents/model-auth.js", () => ({
   requireApiKey: vi.fn((auth: { apiKey?: string }) => auth.apiKey ?? ""),
 }));
 
-const { _test, resolveTtsConfig, maybeApplyTtsToPayload, getTtsProvider } = tts;
+const {
+  _test,
+  resolveTtsConfig,
+  maybeApplyTtsToPayload,
+  getTtsProvider,
+  resolveTtsProviderOrder,
+  isTtsProviderConfigured,
+} = tts;
 
 const {
   isValidVoiceId,
@@ -181,6 +188,30 @@ describe("tts", () => {
         },
       });
       expect(resolveEdgeOutputFormat(config)).toBe("audio-24khz-96kbitrate-mono-mp3");
+    });
+  });
+
+  describe("piper provider core", () => {
+    it("includes piper in provider fallback order", () => {
+      expect(resolveTtsProviderOrder("piper")).toEqual(["piper", "openai", "elevenlabs", "edge"]);
+    });
+
+    it("resolves piper defaults and marks provider configured", () => {
+      const config = resolveTtsConfig({
+        agents: { defaults: { model: { primary: "openai/gpt-4o-mini" } } },
+        messages: { tts: {} },
+      });
+      expect(config.piper.baseUrl).toBe("http://piper-http:5001");
+      expect(isTtsProviderConfigured(config, "piper")).toBe(true);
+    });
+
+    it("falls back to default piper baseUrl when configured value is blank", () => {
+      const config = resolveTtsConfig({
+        agents: { defaults: { model: { primary: "openai/gpt-4o-mini" } } },
+        messages: { tts: { piper: { baseUrl: "   " } } },
+      });
+      expect(config.piper.baseUrl).toBe("http://piper-http:5001");
+      expect(isTtsProviderConfigured(config, "piper")).toBe(true);
     });
   });
 

--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -45,12 +45,15 @@ const {
 } = tts;
 
 const {
+  detectLanguage,
   isValidVoiceId,
   isValidOpenAIVoice,
   isValidOpenAIModel,
   OPENAI_TTS_MODELS,
   OPENAI_TTS_VOICES,
   parseTtsDirectives,
+  resolvePiperBaseUrl,
+  resolvePiperVoice,
   resolveModelOverridePolicy,
   summarizeText,
   resolveOutputFormat,
@@ -212,6 +215,42 @@ describe("tts", () => {
       });
       expect(config.piper.baseUrl).toBe("http://piper-http:5001");
       expect(isTtsProviderConfigured(config, "piper")).toBe(true);
+    });
+  });
+
+  describe("piper language routing", () => {
+    it("detects Hindi text", () => {
+      expect(detectLanguage("यह एक लंबा हिंदी वाक्य है जो भाषा पहचान के लिए पर्याप्त है।")).toBe("hi");
+    });
+
+    it("resolves piper voice by detected language", () => {
+      const voice = resolvePiperVoice({
+        text: "Bonjour tout le monde ceci est une phrase francaise suffisamment longue.",
+        config: {
+          baseUrl: "http://piper-http:5001",
+          voice: "en_US-ryan-medium",
+          voiceByLang: {
+            fr: "fr_FR-siwis-medium",
+          },
+        },
+      });
+      expect(voice).toBe("fr_FR-siwis-medium");
+    });
+
+    it("resolves piper baseUrl by detected language", () => {
+      const baseUrl = resolvePiperBaseUrl({
+        text: "Dies ist ein langer deutscher Satz zur Spracherkennung und Auswahl.",
+        config: {
+          baseUrl: "http://piper-http:5001",
+          baseUrlByLang: {
+            de: "http://piper-http-de:5001",
+          },
+          voiceByLang: {
+            de: "de_DE-thorsten_emotional-medium",
+          },
+        },
+      });
+      expect(baseUrl).toBe("http://piper-http-de:5001");
     });
   });
 


### PR DESCRIPTION
## Summary

  - Problem: Piper core support lacked language-aware routing for voice and endpoint selection.
  - Why it matters: Multilingual setups need automatic mapping to language-specific voices/services without manual
    provider switching.
  - What changed: Added optional language detection and mapping (voiceByLang, baseUrlByLang) for Piper, plus tests and
    dependency updates.
  - What did NOT change (scope boundary): Core Piper provider integration stays in PR2; no docker/infra compose changes
    are included.

  ## Change Type (select all)

  - [ ] Bug fix
  - [x] Feature
  - [ ] Refactor
  - [ ] Docs
  - [ ] Security hardening
  - [ ] Chore/infra

  ## Scope (select all touched areas)

  - [ ] Gateway / orchestration
  - [x] Skills / tool execution
  - [ ] Auth / tokens
  - [ ] Memory / storage
  - [x] Integrations
  - [x] API / contracts
  - [ ] UI / DX
  - [ ] CI/CD / infra

  ## Linked Issue/PR

  - Closes #
  - Related #
  - Depends on: #16569 (feat/tts-piper-provider-core)

  ## User-visible / Behavior Changes

  - Added optional Piper config:
      - messages.tts.piper.voiceByLang
      - messages.tts.piper.baseUrlByLang
  - TTS can now auto-select Piper voice and/or endpoint based on detected text language.
  - Existing single-endpoint/single-voice behavior remains unchanged when mappings are not provided.

  ## Security Impact (required)

  - New permissions/capabilities? (No)
  - Secrets/tokens handling changed? (No)
  - New/changed network calls? (No)
    (same Piper HTTP call path as PR2; only selection logic changed)
  - Command/tool execution surface changed? (No)
  - Data access scope changed? (No)
  - If any Yes, explain risk + mitigation:

  ## Repro + Verification

  ### Environment

  - OS: macOS
  - Runtime/container: local dev
  - Model/provider: TTS with Piper selected
  - Integration/channel (if any): TTS runtime path
  - Relevant config (redacted):
      - messages.tts.provider: "piper"
      - messages.tts.piper.voiceByLang: { "fr": "...", "de": "..." }
      - messages.tts.piper.baseUrlByLang: { "fr": "...", "de": "..." }

  ### Steps

  1. Configure Piper with voiceByLang and/or baseUrlByLang.
  2. Send multilingual TTS text (e.g., French/German/Hindi).
  3. Verify selected voice/base URL follows mapping rules.
  4. Run targeted TTS tests.

  ### Expected

  - Language detection drives mapped Piper voice/base URL where configured.
  - Fallback to default voice/baseUrl when no mapping exists.

  ### Actual

  - Matches expected after this change.

  ## Evidence

  Attach at least one:

  - [x] Failing test/log before + passing after
  - [ ] Trace/log snippets
  - [ ] Screenshot/recording
  - [ ] Perf numbers (if relevant)

  ## Human Verification (required)

  - Verified scenarios:
      - Added tests in src/tts/tts.test.ts for language detection + routing behavior.
      - Ran pnpm test -- src/tts/tts.test.ts (passing).
  - Edge cases checked:
      - Mapping fallback when no language match.
      - Override voice interaction with endpoint mapping path.
  - What you did not verify:
      - Full real-world language quality/accuracy across all languages/channels.

  ## Compatibility / Migration

  - Backward compatible? (Yes)
  - Config/env changes? (Optional)
  - Migration needed? (No)
  - If yes, exact upgrade steps:
      - Optional: define voiceByLang/baseUrlByLang under messages.tts.piper.

  ## Failure Recovery (if this breaks)

  - How to disable/revert this change quickly:
      - Remove voiceByLang/baseUrlByLang from config, or revert this commit.
  - Files/config to restore:
      - src/tts/tts.ts
      - src/tts/tts.test.ts
      - src/config/types.tts.ts
      - src/config/zod-schema.core.ts
      - package.json
      - pnpm-lock.yaml
  - Known bad symptoms reviewers should watch for:
      - Wrong voice/endpoint chosen for multilingual text.
      - Unexpected fallback behavior despite mappings.

  ## Risks and Mitigations

  - Risk: Language detection may misclassify short/ambiguous text.
      - Mitigation: conservative detection thresholds and fallback to default voice/base URL.
  - Risk: Additional dependency (franc-min) increases maintenance surface.
      - Mitigation: small, focused dependency; behavior covered with targeted tests.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds language-aware voice and endpoint routing for the Piper TTS provider. It introduces the `franc-min` dependency for language detection, adds `voiceByLang` and `baseUrlByLang` config maps, and wires Piper into the existing TTS provider infrastructure (config schema, provider ordering, commands, telephony exclusion).

- **Temp directory leak**: The Piper block in `textToSpeech` creates a temp directory before the async `piperTTS()` call but has no cleanup on failure, unlike the edge provider which explicitly removes the temp dir in its catch blocks.
- **Incomplete ISO 639-3 → ISO 639-1 mapping**: `detectLanguage` only maps 4 languages (en, de, fr, hi). For any other language, `franc` returns a 3-letter code that won't match user-configured 2-letter keys in `voiceByLang`/`baseUrlByLang`, causing silent fallback to defaults.
- **Piper always appears as "configured"**: The hardcoded default `baseUrl` means `isTtsProviderConfigured` always returns `true` for Piper, adding it to every user's fallback chain even without a running Piper service.

<h3>Confidence Score: 2/5</h3>

- PR has a resource leak bug and a language detection gap that will cause silent misbehavior for most languages beyond the 4 currently mapped.
- Score of 2 reflects two concrete bugs: (1) temp directory leak when piperTTS fails, which is a resource leak in a production code path, and (2) detectLanguage returning 3-letter ISO codes for unmapped languages, which silently breaks voice/URL routing for any language beyond en/de/fr/hi. The always-configured default URL is a design concern that adds unnecessary fallback latency for users without Piper.
- src/tts/tts.ts requires attention for the temp directory cleanup bug in the piper block (lines 812-843), the incomplete ISO3_TO_1 mapping (line 564-571), and the always-true isTtsProviderConfigured check (lines 675-677).

<sub>Last reviewed commit: c41e208</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->