### PR TITLE
fix(cli): run plugin gateway_stop hooks before message exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Docs: https://docs.openclaw.ai
 - Cron: prevent `cron list`/`cron status` from silently skipping past-due recurring jobs by using maintenance recompute semantics. (#16156) Thanks @zerone0x.
 - CLI/Dashboard: when `gateway.bind=lan`, generate localhost dashboard URLs to satisfy browser secure-context requirements while preserving non-LAN bind behavior. (#16434) Thanks @BinHPdev.
 - CLI/Plugins: ensure `openclaw message send` exits after successful delivery across plugin-backed channels so one-shot sends do not hang. (#16491) Thanks @yinghaosang.
+- CLI/Plugins: run registered plugin `gateway_stop` hooks before `openclaw message` exits (success and failure paths), so plugin-backed channels can clean up one-shot CLI resources.
 - Cron: repair missing/corrupt `nextRunAtMs` for the updated job without globally recomputing unrelated due jobs during `cron update`. (#15750)
 - Discord: prefer gateway guild id when logging inbound messages so cached-miss guilds do not appear as `guild=dm`. Thanks @thewilloftheshadow.
 - TUI: refactor searchable select list description layout and add regression coverage for ANSI-highlight width bounds.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ Docs: https://docs.openclaw.ai
 - Cron: prevent `cron list`/`cron status` from silently skipping past-due recurring jobs by using maintenance recompute semantics. (#16156) Thanks @zerone0x.
 - CLI/Dashboard: when `gateway.bind=lan`, generate localhost dashboard URLs to satisfy browser secure-context requirements while preserving non-LAN bind behavior. (#16434) Thanks @BinHPdev.
 - CLI/Plugins: ensure `openclaw message send` exits after successful delivery across plugin-backed channels so one-shot sends do not hang. (#16491) Thanks @yinghaosang.
-- CLI/Plugins: run registered plugin `gateway_stop` hooks before `openclaw message` exits (success and failure paths), so plugin-backed channels can clean up one-shot CLI resources.
+- CLI/Plugins: run registered plugin `gateway_stop` hooks before `openclaw message` exits (success and failure paths), so plugin-backed channels can clean up one-shot CLI resources. (#16580) Thanks @gumadeiras.
 - Cron: repair missing/corrupt `nextRunAtMs` for the updated job without globally recomputing unrelated due jobs during `cron update`. (#15750)
 - Discord: prefer gateway guild id when logging inbound messages so cached-miss guilds do not appear as `guild=dm`. Thanks @thewilloftheshadow.
 - TUI: refactor searchable select list description layout and add regression coverage for ANSI-highlight width bounds.

--- a/src/cli/program/message/helpers.test.ts
+++ b/src/cli/program/message/helpers.test.ts
@@ -121,6 +121,22 @@ describe("runMessageAction", () => {
     expect(exitMock).toHaveBeenCalledWith(0);
   });
 
+  it("logs gateway_stop failure and preserves failure exit code when send fails", async () => {
+    hasHooksMock.mockReturnValueOnce(true);
+    messageCommandMock.mockRejectedValueOnce(new Error("send failed"));
+    runGatewayStopMock.mockRejectedValueOnce(new Error("hook failed"));
+    const fakeCommand = { help: vi.fn() } as never;
+    const { runMessageAction } = createMessageCliHelpers(fakeCommand, "discord");
+
+    await expect(
+      runMessageAction("send", { channel: "discord", target: "123", message: "hi" }),
+    ).rejects.toThrow("exit");
+
+    expect(errorMock).toHaveBeenNthCalledWith(1, "Error: send failed");
+    expect(errorMock).toHaveBeenNthCalledWith(2, "gateway_stop hook failed: Error: hook failed");
+    expect(exitMock).toHaveBeenCalledWith(1);
+  });
+
   it("does not call exit(0) when the action throws", async () => {
     messageCommandMock.mockRejectedValueOnce(new Error("boom"));
     const fakeCommand = { help: vi.fn() } as never;

--- a/src/cli/program/message/helpers.test.ts
+++ b/src/cli/program/message/helpers.test.ts
@@ -107,6 +107,20 @@ describe("runMessageAction", () => {
     expect(exitMock).toHaveBeenCalledWith(1);
   });
 
+  it("logs gateway_stop failure and still exits with success code", async () => {
+    hasHooksMock.mockReturnValueOnce(true);
+    runGatewayStopMock.mockRejectedValueOnce(new Error("hook failed"));
+    const fakeCommand = { help: vi.fn() } as never;
+    const { runMessageAction } = createMessageCliHelpers(fakeCommand, "discord");
+
+    await expect(
+      runMessageAction("send", { channel: "discord", target: "123", message: "hi" }),
+    ).rejects.toThrow("exit");
+
+    expect(errorMock).toHaveBeenCalledWith("gateway_stop hook failed: Error: hook failed");
+    expect(exitMock).toHaveBeenCalledWith(0);
+  });
+
   it("does not call exit(0) when the action throws", async () => {
     messageCommandMock.mockRejectedValueOnce(new Error("boom"));
     const fakeCommand = { help: vi.fn() } as never;

--- a/src/cli/program/message/helpers.ts
+++ b/src/cli/program/message/helpers.ts
@@ -2,6 +2,7 @@ import type { Command } from "commander";
 import { messageCommand } from "../../../commands/message.js";
 import { danger, setVerbose } from "../../../globals.js";
 import { CHANNEL_TARGET_DESCRIPTION } from "../../../infra/outbound/channel-target.js";
+import { getGlobalHookRunner } from "../../../plugins/hook-runner-global.js";
 import { defaultRuntime } from "../../../runtime.js";
 import { runCommandWithRuntime } from "../../cli-utils.js";
 import { createDefaultDeps } from "../../deps.js";
@@ -20,6 +21,14 @@ function normalizeMessageOptions(opts: Record<string, unknown>): Record<string, 
     ...rest,
     accountId: typeof account === "string" ? account : undefined,
   };
+}
+
+async function runPluginStopHooks(): Promise<void> {
+  const hookRunner = getGlobalHookRunner();
+  if (!hookRunner?.hasHooks("gateway_stop")) {
+    return;
+  }
+  await hookRunner.runGatewayStop({ reason: "cli message action complete" }, {});
 }
 
 export function createMessageCliHelpers(
@@ -59,13 +68,10 @@ export function createMessageCliHelpers(
       (err) => {
         failed = true;
         defaultRuntime.error(danger(String(err)));
-        defaultRuntime.exit(1);
       },
     );
-    if (failed) {
-      return;
-    }
-    defaultRuntime.exit(0);
+    await runPluginStopHooks();
+    defaultRuntime.exit(failed ? 1 : 0);
   };
 
   // `message` is only used for `message.help({ error: true })`, keep the

--- a/src/cli/program/message/helpers.ts
+++ b/src/cli/program/message/helpers.ts
@@ -28,7 +28,11 @@ async function runPluginStopHooks(): Promise<void> {
   if (!hookRunner?.hasHooks("gateway_stop")) {
     return;
   }
-  await hookRunner.runGatewayStop({ reason: "cli message action complete" }, {});
+  try {
+    await hookRunner.runGatewayStop({ reason: "cli message action complete" }, {});
+  } catch (err) {
+    defaultRuntime.error(danger(`gateway_stop hook failed: ${String(err)}`));
+  }
 }
 
 export function createMessageCliHelpers(

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -44,7 +44,7 @@ import {
 import { scheduleGatewayUpdateCheck } from "../infra/update-startup.js";
 import { startDiagnosticHeartbeat, stopDiagnosticHeartbeat } from "../logging/diagnostic.js";
 import { createSubsystemLogger, runtimeForLogger } from "../logging/subsystem.js";
-import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+import { getGlobalHookRunner, runGlobalGatewayStopSafely } from "../plugins/hook-runner-global.js";
 import { getTotalQueueSize } from "../process/command-queue.js";
 import { runOnboardingWizard } from "../wizard/onboarding.js";
 import { createAuthRateLimiter, type AuthRateLimiter } from "./auth-rate-limit.js";
@@ -720,19 +720,11 @@ export async function startGatewayServer(
   return {
     close: async (opts) => {
       // Run gateway_stop plugin hook before shutdown
-      {
-        const hookRunner = getGlobalHookRunner();
-        if (hookRunner?.hasHooks("gateway_stop")) {
-          try {
-            await hookRunner.runGatewayStop(
-              { reason: opts?.reason ?? "gateway stopping" },
-              { port },
-            );
-          } catch (err) {
-            log.warn(`gateway_stop hook failed: ${String(err)}`);
-          }
-        }
-      }
+      await runGlobalGatewayStopSafely({
+        event: { reason: opts?.reason ?? "gateway stopping" },
+        ctx: { port },
+        onError: (err) => log.warn(`gateway_stop hook failed: ${String(err)}`),
+      });
       if (diagnosticsEnabled) {
         stopDiagnosticHeartbeat();
       }

--- a/src/plugins/hook-runner-global.ts
+++ b/src/plugins/hook-runner-global.ts
@@ -6,6 +6,7 @@
  */
 
 import type { PluginRegistry } from "./registry.js";
+import type { PluginHookGatewayContext, PluginHookGatewayStopEvent } from "./types.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { createHookRunner, type HookRunner } from "./hooks.js";
 
@@ -56,6 +57,26 @@ export function getGlobalPluginRegistry(): PluginRegistry | null {
  */
 export function hasGlobalHooks(hookName: Parameters<HookRunner["hasHooks"]>[0]): boolean {
   return globalHookRunner?.hasHooks(hookName) ?? false;
+}
+
+export async function runGlobalGatewayStopSafely(params: {
+  event: PluginHookGatewayStopEvent;
+  ctx: PluginHookGatewayContext;
+  onError?: (err: unknown) => void;
+}): Promise<void> {
+  const hookRunner = getGlobalHookRunner();
+  if (!hookRunner?.hasHooks("gateway_stop")) {
+    return;
+  }
+  try {
+    await hookRunner.runGatewayStop(params.event, params.ctx);
+  } catch (err) {
+    if (params.onError) {
+      params.onError(err);
+      return;
+    }
+    log.warn(`gateway_stop hook failed: ${String(err)}`);
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Follow-up to #16491 for long-term CLI stability in plugin-backed channels.

This change ensures one-shot `openclaw message` commands run plugin `gateway_stop` hooks before process exit on both success and failure paths.

## Why

`openclaw message` commands intentionally exit after completion. Running `gateway_stop` hooks before exit gives plugins a deterministic cleanup point for short-lived CLI runs.

## Changes

- Add `runPluginStopHooks()` in `src/cli/program/message/helpers.ts`
- Invoke `gateway_stop` hooks (when registered) before final `defaultRuntime.exit(...)`
- Keep existing success/failure exit semantics (`0` on success, `1` on failure)
- Add tests for hook execution on both success and failure paths
- Add changelog entry

## Tests

- `pnpm vitest run src/cli/program/message/helpers.test.ts`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR ensures plugin `gateway_stop` hooks run before `openclaw message` CLI commands exit, providing a deterministic cleanup point for short-lived CLI runs. The change extends PR #16491's fix for hanging message commands by giving plugins proper lifecycle cleanup.

**Key changes:**
- Added `runPluginStopHooks()` helper in `src/cli/program/message/helpers.ts:26-32` that checks for and invokes registered `gateway_stop` hooks
- Modified `runMessageAction` to call `runPluginStopHooks()` before `defaultRuntime.exit()` on both success and failure paths (helpers.ts:73-74)
- Simplified exit logic from separate success/failure paths to unified `defaultRuntime.exit(failed ? 1 : 0)` (helpers.ts:74)
- Added comprehensive test coverage for hook execution on both success and failure paths (helpers.test.ts:69-80, 96-108)
- Updated CHANGELOG.md with clear explanation of the fix

**Issue found:**
- Missing error handling in `runPluginStopHooks()` could prevent `defaultRuntime.exit()` from being called if hooks throw - see inline comment with suggested fix

<h3>Confidence Score: 3/5</h3>

- This PR is mostly safe to merge but has one important issue with error handling that should be fixed first
- The implementation correctly adds plugin lifecycle hooks before CLI exit and has excellent test coverage. However, the missing error handling in `runPluginStopHooks()` could prevent process exit if hooks throw, which is a stability concern. The gateway implementation (server.impl.ts) wraps similar hook calls in try/catch, establishing a pattern this code should follow. Once the error handling is added, this would be a 5/5.
- src/cli/program/message/helpers.ts requires error handling around the `runGatewayStop()` call to prevent uncaught exceptions from blocking process exit

<sub>Last reviewed commit: d144d9d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->