### PR TITLE
feat(feishu): add write mode import for markdown documents

### DIFF
--- a/extensions/feishu/src/doc-schema.ts
+++ b/extensions/feishu/src/doc-schema.ts
@@ -11,6 +11,15 @@ export const FeishuDocSchema = Type.Union([
     content: Type.String({
       description: "Markdown content to write (replaces entire document content)",
     }),
+    mode: Type.Optional(
+      Type.Union([Type.Literal("blocks"), Type.Literal("import")], {
+        description: "Write mode. `blocks` keeps current behavior; `import` creates a new doc via Import Task.",
+      }),
+    ),
+    title: Type.Optional(Type.String({ description: "Document title (required when mode=import)" })),
+    folder_token: Type.Optional(
+      Type.String({ description: "Target folder token (required when mode=import)" }),
+    ),
   }),
   Type.Object({
     action: Type.Literal("append"),

--- a/extensions/feishu/src/docx.test.ts
+++ b/extensions/feishu/src/docx.test.ts
@@ -20,10 +20,14 @@ vi.mock("./runtime.js", () => ({
 import { registerFeishuDocTools } from "./docx.js";
 
 describe("feishu_doc image fetch hardening", () => {
+  const createDocMock = vi.hoisted(() => vi.fn());
   const convertMock = vi.hoisted(() => vi.fn());
   const blockListMock = vi.hoisted(() => vi.fn());
   const blockChildrenCreateMock = vi.hoisted(() => vi.fn());
   const driveUploadAllMock = vi.hoisted(() => vi.fn());
+  const importTaskCreateMock = vi.hoisted(() => vi.fn());
+  const importTaskGetMock = vi.hoisted(() => vi.fn());
+  const driveFileDeleteMock = vi.hoisted(() => vi.fn());
   const blockPatchMock = vi.hoisted(() => vi.fn());
   const scopeListMock = vi.hoisted(() => vi.fn());
 
@@ -33,6 +37,7 @@ describe("feishu_doc image fetch hardening", () => {
     createFeishuClientMock.mockReturnValue({
       docx: {
         document: {
+          create: createDocMock,
           convert: convertMock,
         },
         documentBlock: {
@@ -44,6 +49,13 @@ describe("feishu_doc image fetch hardening", () => {
         },
       },
       drive: {
+        file: {
+          delete: driveFileDeleteMock,
+        },
+        importTask: {
+          create: importTaskCreateMock,
+          get: importTaskGetMock,
+        },
         media: {
           uploadAll: driveUploadAllMock,
         },
@@ -77,7 +89,23 @@ describe("feishu_doc image fetch hardening", () => {
       },
     });
 
+    createDocMock.mockResolvedValue({
+      code: 0,
+      data: { document: { document_id: "tmp_doc_1", title: "tmp" } },
+    });
     driveUploadAllMock.mockResolvedValue({ file_token: "token_1" });
+    importTaskCreateMock.mockResolvedValue({ code: 0, data: { ticket: "ticket_1" } });
+    importTaskGetMock.mockResolvedValue({
+      code: 0,
+      data: {
+        result: {
+          job_status: 0,
+          token: "imported_doc_1",
+          url: "https://feishu.cn/docx/imported_doc_1",
+        },
+      },
+    });
+    driveFileDeleteMock.mockResolvedValue({ code: 0, data: { task_id: "cleanup_task_1" } });
     blockPatchMock.mockResolvedValue({ code: 0 });
     scopeListMock.mockResolvedValue({ code: 0, data: { scopes: [] } });
   });
@@ -119,5 +147,73 @@ describe("feishu_doc image fetch hardening", () => {
     expect(result.details.images_processed).toBe(0);
     expect(consoleErrorSpy).toHaveBeenCalled();
     consoleErrorSpy.mockRestore();
+  });
+
+  it("uses import path when write mode=import", async () => {
+    const registerTool = vi.fn();
+    registerFeishuDocTools({
+      config: {
+        channels: {
+          feishu: {
+            appId: "app_id",
+            appSecret: "app_secret",
+          },
+        },
+      } as any,
+      logger: { debug: vi.fn(), info: vi.fn() } as any,
+      registerTool,
+    } as any);
+
+    const feishuDocTool = registerTool.mock.calls
+      .map((call) => call[0])
+      .find((tool) => tool.name === "feishu_doc");
+    expect(feishuDocTool).toBeDefined();
+
+    const result = await feishuDocTool.execute("tool-call", {
+      action: "write",
+      mode: "import",
+      doc_token: "old_doc_1",
+      title: "Imported by write mode",
+      folder_token: "folder_1",
+      content: "# Hello",
+    });
+
+    expect(importTaskCreateMock).toHaveBeenCalledTimes(1);
+    expect(importTaskGetMock).toHaveBeenCalledTimes(1);
+    expect(driveFileDeleteMock).toHaveBeenCalledTimes(1);
+    expect(result.details.method).toBe("import_task");
+    expect(result.details.old_doc_token).toBe("old_doc_1");
+  });
+
+  it("returns validation error when write mode=import misses required fields", async () => {
+    const registerTool = vi.fn();
+    registerFeishuDocTools({
+      config: {
+        channels: {
+          feishu: {
+            appId: "app_id",
+            appSecret: "app_secret",
+          },
+        },
+      } as any,
+      logger: { debug: vi.fn(), info: vi.fn() } as any,
+      registerTool,
+    } as any);
+
+    const feishuDocTool = registerTool.mock.calls
+      .map((call) => call[0])
+      .find((tool) => tool.name === "feishu_doc");
+    expect(feishuDocTool).toBeDefined();
+
+    const result = await feishuDocTool.execute("tool-call", {
+      action: "write",
+      mode: "import",
+      doc_token: "old_doc_1",
+      content: "# Hello",
+    });
+
+    expect(String(result.details.error)).toContain(
+      "write mode=import requires both title and folder_token",
+    );
   });
 });


### PR DESCRIPTION
## Summary
- feat(feishu): add write mode import for markdown documents
- Split from our `v2026.2.13` patch train as a single-purpose change for easier review.

## Why
- Keep the diff focused and low-risk so it can be merged or reverted independently.

## Scope
- Branch: `feat/feishu-write-mode-import-en`
- Files changed: 3
- Key files:
  - `extensions/feishu/src/doc-schema.ts`
  - `extensions/feishu/src/docx.test.ts`
  - `extensions/feishu/src/docx.ts`

## Test Plan
- Suggested local command:
  - `./node_modules/.bin/vitest run extensions/feishu/src/docx.test.ts`
- Validation status:
  - [ ] CI checks pass
  - [ ] Maintainer re-ran local tests

## Risk & Rollback
- Risk: low to medium; impact limited to touched module(s).
- Rollback: revert this PR commit(s) cleanly.

## Co-authorship
- Co-authored by @ciberponk and Codex (GPT-5).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new `import` mode to the `feishu_doc` write action, allowing markdown documents to be imported via Feishu's Import Task API rather than the existing blocks-based approach. The change introduces optional parameters (`mode`, `title`, `folder_token`) to the write action schema, implements `createDocFromMarkdownViaImport()` function that creates a temporary document, uploads the markdown file, triggers the import task, polls for completion, and cleans up the temporary document.

Key changes:
- Added `mode` parameter to write action schema with values `"blocks"` (default) or `"import"`
- New `createDocFromMarkdownViaImport()` function handles the import workflow
- Tests cover both success and validation error scenarios
- Import mode requires `title` and `folder_token` parameters for proper operation

Two issues were previously identified and remain unresolved:
- Schema uses `Type.Union` which violates the repository's tool schema guidelines (should use `optionalStringEnum` from `openclaw/plugin-sdk`)
- Polling loop has no delay between API retries, which will hammer the Feishu API unnecessarily

<h3>Confidence Score: 2/5</h3>

- This PR has two unresolved issues that should be fixed before merging
- Score reflects two previously-reported but still-unfixed issues: schema guideline violation and missing retry delay in polling loop. Both issues are straightforward to fix but impact code quality and API behavior.
- `extensions/feishu/src/doc-schema.ts` (schema guideline violation) and `extensions/feishu/src/docx.ts` (missing polling delay)

<sub>Last reviewed commit: c923500</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->