### PR TITLE
feat(feishu): add set_public_permission doc action

### DIFF
--- a/extensions/feishu/src/doc-schema.ts
+++ b/extensions/feishu/src/doc-schema.ts
@@ -23,6 +23,15 @@ export const FeishuDocSchema = Type.Union([
     folder_token: Type.Optional(Type.String({ description: "Target folder token (optional)" })),
   }),
   Type.Object({
+    action: Type.Literal("set_public_permission"),
+    doc_token: Type.String({ description: "Document token" }),
+    access: Type.Optional(
+      Type.Union([Type.Literal("read"), Type.Literal("edit")], {
+        description: "Public link access level (default: read)",
+      }),
+    ),
+  }),
+  Type.Object({
     action: Type.Literal("list_blocks"),
     doc_token: Type.String({ description: "Document token" }),
   }),


### PR DESCRIPTION
## Summary
- feat(feishu): add set_public_permission doc action
- Split from our `v2026.2.13` patch train as a single-purpose change for easier review.

## Why
- Keep the diff focused and low-risk so it can be merged or reverted independently.

## Scope
- Branch: `feat/feishu-doc-set-public-permission-en`
- Files changed: 3
- Key files:
  - `extensions/feishu/src/doc-schema.ts`
  - `extensions/feishu/src/docx.test.ts`
  - `extensions/feishu/src/docx.ts`

## Test Plan
- Suggested local command:
  - `./node_modules/.bin/vitest run extensions/feishu/src/docx.test.ts`
- Validation status:
  - [ ] CI checks pass
  - [ ] Maintainer re-ran local tests

## Risk & Rollback
- Risk: low to medium; impact limited to touched module(s).
- Rollback: revert this PR commit(s) cleanly.

## Co-authorship
- Co-authored by @ciberponk and Codex (GPT-5).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a new `set_public_permission` action to the Feishu document tool, allowing users to set a document's public link sharing permission to either `read` or `edit` access. The implementation calls the Feishu Drive `permissionPublic.patch` API with appropriate `link_share_entity` and `security_entity` values. Changes are well-scoped across the schema, implementation, and tests.

- New `setDocPublicPermission` function in `docx.ts` correctly maps `read`/`edit` access to Feishu API permission entities
- Schema addition in `doc-schema.ts` uses `Type.Union([Type.Literal(...)])` for the `access` field, which conflicts with the repo's tool-schema guardrails recommending `optionalStringEnum` instead
- Test covers the `access: "edit"` path with proper mock setup and assertion of API call parameters

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk; it adds a single new action to an existing tool with no changes to existing behavior.
- The implementation is straightforward and follows existing patterns in the codebase. The only concern is a style issue (Type.Union vs optionalStringEnum) per repo guidelines. No logical errors or security issues found.
- `extensions/feishu/src/doc-schema.ts` has a minor style issue with `Type.Union` usage that should ideally use `optionalStringEnum` per repo guidelines.

<sub>Last reviewed commit: 9fade64</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))

<!-- /greptile_comment -->