### PR TITLE
security: stop false positives for denyCommands IDs

### DIFF
--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -15,7 +15,10 @@ import { resolveToolProfilePolicy } from "../agents/tool-policy.js";
 import { resolveBrowserConfig } from "../browser/config.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { resolveGatewayAuth } from "../gateway/auth.js";
-import { resolveNodeCommandAllowlist } from "../gateway/node-command-policy.js";
+import {
+  DEFAULT_DANGEROUS_NODE_COMMANDS,
+  resolveNodeCommandAllowlist,
+} from "../gateway/node-command-policy.js";
 
 export type SecurityAuditFinding = {
   checkId: string;
@@ -248,6 +251,12 @@ function listKnownNodeCommands(cfg: OpenClawConfig): Set<string> {
       if (normalized) {
         out.add(normalized);
       }
+    }
+  }
+  for (const cmd of DEFAULT_DANGEROUS_NODE_COMMANDS) {
+    const normalized = normalizeNodeCommand(cmd);
+    if (normalized) {
+      out.add(normalized);
     }
   }
   return out;

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -489,6 +489,33 @@ describe("security audit", () => {
     expect(finding?.detail).toContain("system.runx");
   });
 
+  it("does not flag known dangerous node command IDs in denyCommands", async () => {
+    const cfg: OpenClawConfig = {
+      gateway: {
+        nodes: {
+          denyCommands: [
+            "camera.snap",
+            "camera.clip",
+            "screen.record",
+            "calendar.add",
+            "contacts.add",
+            "reminders.add",
+          ],
+        },
+      },
+    };
+
+    const res = await runSecurityAudit({
+      config: cfg,
+      includeFilesystem: false,
+      includeChannelSecurity: false,
+    });
+
+    expect(
+      res.findings.some((f) => f.checkId === "gateway.nodes.deny_commands_ineffective"),
+    ).toBe(false);
+  });
+
   it("flags agent profile overrides when global tools.profile is minimal", async () => {
     const cfg: OpenClawConfig = {
       tools: {


### PR DESCRIPTION
## Summary
- include known high-risk node command IDs in the security audit command index
- keep `gateway.nodes.denyCommands` warnings focused on truly invalid or pattern-based entries
- add regression coverage for onboarding default dangerous command IDs

## Issue
- Fixes #16508
