### PR TITLE
agents: fix missing BOOTSTRAP.md on first-run race

### DIFF
--- a/src/agents/workspace.e2e.test.ts
+++ b/src/agents/workspace.e2e.test.ts
@@ -1,9 +1,18 @@
+import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { makeTempWorkspace, writeWorkspaceFile } from "../test-helpers/workspace.js";
 import {
+  DEFAULT_AGENTS_FILENAME,
+  DEFAULT_BOOTSTRAP_FILENAME,
   DEFAULT_MEMORY_ALT_FILENAME,
   DEFAULT_MEMORY_FILENAME,
+  DEFAULT_SOUL_FILENAME,
+  DEFAULT_TOOLS_FILENAME,
+  DEFAULT_IDENTITY_FILENAME,
+  DEFAULT_USER_FILENAME,
+  DEFAULT_HEARTBEAT_FILENAME,
+  ensureAgentWorkspace,
   loadWorkspaceBootstrapFiles,
   resolveDefaultAgentWorkspaceDir,
 } from "./workspace.js";
@@ -57,5 +66,43 @@ describe("loadWorkspaceBootstrapFiles", () => {
     );
 
     expect(memoryEntries).toHaveLength(0);
+  });
+});
+
+describe("ensureAgentWorkspace", () => {
+  it("creates BOOTSTRAP.md for a brand new workspace", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+
+    await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
+
+    await expect(fs.access(path.join(tempDir, DEFAULT_BOOTSTRAP_FILENAME))).resolves.toBeUndefined();
+  });
+
+  it("does not recreate BOOTSTRAP.md after it was deleted", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+    await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
+    await fs.unlink(path.join(tempDir, DEFAULT_BOOTSTRAP_FILENAME));
+
+    await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
+
+    await expect(fs.access(path.join(tempDir, DEFAULT_BOOTSTRAP_FILENAME))).rejects.toThrow();
+  });
+
+  it("creates BOOTSTRAP.md when core bootstrap files are partially pre-seeded", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+    await writeWorkspaceFile({ dir: tempDir, name: DEFAULT_AGENTS_FILENAME, content: "seeded" });
+
+    await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
+
+    await expect(fs.access(path.join(tempDir, DEFAULT_BOOTSTRAP_FILENAME))).resolves.toBeUndefined();
+    for (const file of [
+      DEFAULT_SOUL_FILENAME,
+      DEFAULT_TOOLS_FILENAME,
+      DEFAULT_IDENTITY_FILENAME,
+      DEFAULT_USER_FILENAME,
+      DEFAULT_HEARTBEAT_FILENAME,
+    ]) {
+      await expect(fs.access(path.join(tempDir, file))).resolves.toBeUndefined();
+    }
   });
 });

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -106,17 +106,19 @@ const VALID_BOOTSTRAP_NAMES: ReadonlySet<string> = new Set([
   DEFAULT_MEMORY_ALT_FILENAME,
 ]);
 
-async function writeFileIfMissing(filePath: string, content: string) {
+async function writeFileIfMissing(filePath: string, content: string): Promise<boolean> {
   try {
     await fs.writeFile(filePath, content, {
       encoding: "utf-8",
       flag: "wx",
     });
+    return true;
   } catch (err) {
     const anyErr = err as { code?: string };
     if (anyErr.code !== "EEXIST") {
       throw err;
     }
+    return false;
   }
 }
 
@@ -215,13 +217,19 @@ export async function ensureAgentWorkspace(params?: {
   const heartbeatTemplate = await loadTemplate(DEFAULT_HEARTBEAT_FILENAME);
   const bootstrapTemplate = await loadTemplate(DEFAULT_BOOTSTRAP_FILENAME);
 
-  await writeFileIfMissing(agentsPath, agentsTemplate);
-  await writeFileIfMissing(soulPath, soulTemplate);
-  await writeFileIfMissing(toolsPath, toolsTemplate);
-  await writeFileIfMissing(identityPath, identityTemplate);
-  await writeFileIfMissing(userPath, userTemplate);
-  await writeFileIfMissing(heartbeatPath, heartbeatTemplate);
-  if (isBrandNewWorkspace) {
+  const wroteAgents = await writeFileIfMissing(agentsPath, agentsTemplate);
+  const wroteSoul = await writeFileIfMissing(soulPath, soulTemplate);
+  const wroteTools = await writeFileIfMissing(toolsPath, toolsTemplate);
+  const wroteIdentity = await writeFileIfMissing(identityPath, identityTemplate);
+  const wroteUser = await writeFileIfMissing(userPath, userTemplate);
+  const wroteHeartbeat = await writeFileIfMissing(heartbeatPath, heartbeatTemplate);
+  const wroteAnyCoreBootstrapFile =
+    wroteAgents || wroteSoul || wroteTools || wroteIdentity || wroteUser || wroteHeartbeat;
+
+  // If another process started workspace initialization first, we may no longer
+  // look "brand new" by the time this call runs. Still seed BOOTSTRAP.md when
+  // we are creating any of the core bootstrap files in this invocation.
+  if (isBrandNewWorkspace || wroteAnyCoreBootstrapFile) {
     await writeFileIfMissing(bootstrapPath, bootstrapTemplate);
   }
   await ensureGitRepo(dir, isBrandNewWorkspace);


### PR DESCRIPTION
## Summary
- make bootstrap seeding resilient to partial first-run initialization ordering/race conditions
- create `BOOTSTRAP.md` when this invocation had to create any core bootstrap workspace file
- add regression tests for brand-new, partially-seeded, and post-delete flows

## Issue
- Fixes #16457

Made with [Cursor](https://cursor.com)