### PR TITLE
agents: cap persisted tool results to protect session context

### DIFF
--- a/src/agents/session-tool-result-guard.e2e.test.ts
+++ b/src/agents/session-tool-result-guard.e2e.test.ts
@@ -235,7 +235,9 @@ describe("installSessionToolResultGuard", () => {
     const textBlock = toolResult.content.find((b: { type: string }) => b.type === "text") as {
       text: string;
     };
+    // Persistence uses a tighter cap than in-memory context trimming.
     expect(textBlock.text.length).toBeLessThan(500_000);
+    expect(textBlock.text.length).toBeLessThan(60_000);
     expect(textBlock.text).toContain("truncated");
   });
 

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -2,12 +2,14 @@ import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { TextContent } from "@mariozechner/pi-ai";
 import type { SessionManager } from "@mariozechner/pi-coding-agent";
 import { emitSessionTranscriptUpdate } from "../sessions/transcript-events.js";
-import { HARD_MAX_TOOL_RESULT_CHARS } from "./pi-embedded-runner/tool-result-truncation.js";
 import { makeMissingToolResult, sanitizeToolCallInputs } from "./session-transcript-repair.js";
 
 const GUARD_TRUNCATION_SUFFIX =
   "\n\n⚠️ [Content truncated during persistence — original exceeded size limit. " +
   "Use offset/limit parameters or request specific sections for large content.]";
+// Keep persisted tool payloads bounded so one large exec result cannot dominate
+// the next LLM turn's context window.
+const PERSISTED_TOOL_RESULT_MAX_CHARS = 50_000;
 
 /**
  * Truncate oversized text content blocks in a tool result message.
@@ -35,7 +37,7 @@ function capToolResultSize(msg: AgentMessage): AgentMessage {
     }
   }
 
-  if (totalTextChars <= HARD_MAX_TOOL_RESULT_CHARS) {
+  if (totalTextChars <= PERSISTED_TOOL_RESULT_MAX_CHARS) {
     return msg;
   }
 
@@ -51,7 +53,7 @@ function capToolResultSize(msg: AgentMessage): AgentMessage {
     const blockShare = textBlock.text.length / totalTextChars;
     const blockBudget = Math.max(
       2_000,
-      Math.floor(HARD_MAX_TOOL_RESULT_CHARS * blockShare) - GUARD_TRUNCATION_SUFFIX.length,
+      Math.floor(PERSISTED_TOOL_RESULT_MAX_CHARS * blockShare) - GUARD_TRUNCATION_SUFFIX.length,
     );
     if (textBlock.text.length <= blockBudget) {
       return block;


### PR DESCRIPTION
## Summary
- apply a stricter hard cap to tool-result text at session-persistence time
- prevent single large exec/tool outputs from dominating transcript size and blowing context on the next turn
- extend guard test expectations to verify the tighter persisted-size bound

## Issue
- Fixes #16574

Made with [Cursor](https://cursor.com)