### PR TITLE
feat(feishu): add get_public_permission doc action

### DIFF
--- a/extensions/feishu/src/doc-schema.ts
+++ b/extensions/feishu/src/doc-schema.ts
@@ -23,6 +23,10 @@ export const FeishuDocSchema = Type.Union([
     folder_token: Type.Optional(Type.String({ description: "Target folder token (optional)" })),
   }),
   Type.Object({
+    action: Type.Literal("get_public_permission"),
+    doc_token: Type.String({ description: "Document token" }),
+  }),
+  Type.Object({
     action: Type.Literal("list_blocks"),
     doc_token: Type.String({ description: "Document token" }),
   }),


### PR DESCRIPTION
## Summary
- feat(feishu): add get_public_permission doc action
- Split from our `v2026.2.13` patch train as a single-purpose change for easier review.

## Why
- Keep the diff focused and low-risk so it can be merged or reverted independently.

## Scope
- Branch: `feat/feishu-doc-get-public-permission-en`
- Files changed: 3
- Key files:
  - `extensions/feishu/src/doc-schema.ts`
  - `extensions/feishu/src/docx.test.ts`
  - `extensions/feishu/src/docx.ts`

## Test Plan
- Suggested local command:
  - `./node_modules/.bin/vitest run extensions/feishu/src/docx.test.ts`
- Validation status:
  - [ ] CI checks pass
  - [ ] Maintainer re-ran local tests

## Risk & Rollback
- Risk: low to medium; impact limited to touched module(s).
- Rollback: revert this PR commit(s) cleanly.

## Co-authorship
- Co-authored by @ciberponk and Codex (GPT-5).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a new `get_public_permission` action to the `feishu_doc` tool that retrieves public sharing/permission settings for a Feishu document. The change touches three files: the schema adds a new union variant, the implementation adds a `getDocPublicPermission()` function calling `client.drive.permissionPublic.get()`, and the test validates the new action end-to-end.

- New `getDocPublicPermission()` function follows existing patterns (error check on `res.code`, structured return object)
- Schema, dispatch, and description string all updated consistently
- Test covers correct API call parameters and response shape
- **Design concern**: This permission-reading action is registered under `toolsCfg.doc` (enabled by default) rather than `toolsCfg.perm` (disabled by default, marked "sensitive operation" in `tools-config.ts`). The `perm.ts` module gates all permission operations behind the `perm` flag — this new action bypasses that gate. While it's read-only, it still exposes permission metadata that may warrant the same opt-in gating.

<h3>Confidence Score: 3/5</h3>

- Low-risk code change, but a permission-gating design question should be resolved before merging.
- The implementation is clean and follows existing patterns. The code itself has no bugs. However, the new `get_public_permission` action exposes permission metadata through the `doc` tool gate (enabled by default) rather than the `perm` tool gate (disabled by default as "sensitive"). This access control design question should be intentionally resolved — if the bypass is intentional, score would be 4-5.
- `extensions/feishu/src/docx.ts` — the new action's placement under `toolsCfg.doc` rather than `toolsCfg.perm` needs a deliberate decision.

<sub>Last reviewed commit: 29d466b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->