### PR TITLE
fix: resolve session store race condition and contextTokens updates

### DIFF
--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -1,6 +1,4 @@
 import { Type } from "@sinclair/typebox";
-import type { OpenClawConfig } from "../../config/config.js";
-import type { AnyAgentTool } from "./common.js";
 import { BLUEBUBBLES_GROUP_ACTIONS } from "../../channels/plugins/bluebubbles-actions.js";
 import {
   listChannelMessageActions,
@@ -13,6 +11,7 @@ import {
   CHANNEL_MESSAGE_ACTION_NAMES,
   type ChannelMessageActionName,
 } from "../../channels/plugins/types.js";
+import type { OpenClawConfig } from "../../config/config.js";
 import { loadConfig } from "../../config/config.js";
 import { GATEWAY_CLIENT_IDS, GATEWAY_CLIENT_MODES } from "../../gateway/protocol/client-info.js";
 import { getToolResult, runMessageAction } from "../../infra/outbound/message-action-runner.js";
@@ -23,6 +22,7 @@ import { normalizeMessageChannel } from "../../utils/message-channel.js";
 import { resolveSessionAgentId } from "../agent-scope.js";
 import { listChannelSupportedActions } from "../channel-tools.js";
 import { channelTargetSchema, channelTargetsSchema, stringEnum } from "../schema/typebox.js";
+import type { AnyAgentTool } from "./common.js";
 import { jsonResult, readNumberParam, readStringParam } from "./common.js";
 import { resolveGatewayOptions } from "./gateway.js";
 

--- a/src/agents/tools/telegram-actions.ts
+++ b/src/agents/tools/telegram-actions.ts
@@ -1,7 +1,7 @@
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import type { OpenClawConfig } from "../../config/config.js";
-import type { TelegramButtonStyle, TelegramInlineButtons } from "../../telegram/button-types.js";
 import { createTelegramActionGate } from "../../telegram/accounts.js";
+import type { TelegramButtonStyle, TelegramInlineButtons } from "../../telegram/button-types.js";
 import {
   resolveTelegramInlineButtonsScope,
   resolveTelegramTargetChatType,

--- a/src/channels/plugins/actions/telegram.ts
+++ b/src/channels/plugins/actions/telegram.ts
@@ -1,5 +1,3 @@
-import type { TelegramActionConfig } from "../../../config/types.telegram.js";
-import type { ChannelMessageActionAdapter, ChannelMessageActionName } from "../types.js";
 import {
   readNumberParam,
   readStringArrayParam,
@@ -7,12 +5,14 @@ import {
   readStringParam,
 } from "../../../agents/tools/common.js";
 import { handleTelegramAction } from "../../../agents/tools/telegram-actions.js";
+import type { TelegramActionConfig } from "../../../config/types.telegram.js";
 import { extractToolSend } from "../../../plugin-sdk/tool-send.js";
 import {
   createTelegramActionGate,
   listEnabledTelegramAccounts,
 } from "../../../telegram/accounts.js";
 import { isTelegramInlineButtonsEnabled } from "../../../telegram/inline-buttons.js";
+import type { ChannelMessageActionAdapter, ChannelMessageActionName } from "../types.js";
 
 const providerId = "telegram";
 

--- a/src/commands/agent/session-store.ts
+++ b/src/commands/agent/session-store.ts
@@ -44,44 +44,47 @@ export async function updateSessionStoreAfterAgentRun(params: {
   const contextTokens =
     params.contextTokensOverride ?? lookupContextTokens(modelUsed) ?? DEFAULT_CONTEXT_TOKENS;
 
-  const entry = sessionStore[sessionKey] ?? {
-    sessionId,
-    updatedAt: Date.now(),
-  };
-  const next: SessionEntry = {
-    ...entry,
-    sessionId,
-    updatedAt: Date.now(),
-    modelProvider: providerUsed,
-    model: modelUsed,
-    contextTokens,
-  };
-  if (isCliProvider(providerUsed, cfg)) {
-    const cliSessionId = result.meta.agentMeta?.sessionId?.trim();
-    if (cliSessionId) {
-      setCliSessionId(next, providerUsed, cliSessionId);
-    }
-  }
-  next.abortedLastRun = result.meta.aborted ?? false;
-  if (hasNonzeroUsage(usage)) {
-    const input = usage.input ?? 0;
-    const output = usage.output ?? 0;
-    const totalTokens =
-      deriveSessionTotalTokens({
-        usage,
-        contextTokens,
-        promptTokens,
-      }) ?? input;
-    next.inputTokens = input;
-    next.outputTokens = output;
-    next.totalTokens = totalTokens;
-    next.totalTokensFresh = true;
-  }
-  if (compactionsThisRun > 0) {
-    next.compactionCount = (entry.compactionCount ?? 0) + compactionsThisRun;
-  }
-  sessionStore[sessionKey] = next;
+  // Build the session entry inside the lock callback to read fresh data
+  // from disk, avoiding races where compaction or another agent run
+  // modifies the entry between our read and write.
   await updateSessionStore(storePath, (store) => {
+    const entry = store[sessionKey] ?? {
+      sessionId,
+      updatedAt: Date.now(),
+    };
+    const next: SessionEntry = {
+      ...entry,
+      sessionId,
+      updatedAt: Date.now(),
+      modelProvider: providerUsed,
+      model: modelUsed,
+      contextTokens,
+    };
+    if (isCliProvider(providerUsed, cfg)) {
+      const cliSessionId = result.meta.agentMeta?.sessionId?.trim();
+      if (cliSessionId) {
+        setCliSessionId(next, providerUsed, cliSessionId);
+      }
+    }
+    next.abortedLastRun = result.meta.aborted ?? false;
+    if (hasNonzeroUsage(usage)) {
+      const input = usage.input ?? 0;
+      const output = usage.output ?? 0;
+      const totalTokens =
+        deriveSessionTotalTokens({
+          usage,
+          contextTokens,
+          promptTokens,
+        }) ?? input;
+      next.inputTokens = input;
+      next.outputTokens = output;
+      next.totalTokens = totalTokens;
+      next.totalTokensFresh = true;
+    }
+    if (compactionsThisRun > 0) {
+      next.compactionCount = (entry.compactionCount ?? 0) + compactionsThisRun;
+    }
     store[sessionKey] = next;
+    sessionStore[sessionKey] = next;
   });
 }

--- a/src/sessions/model-overrides.ts
+++ b/src/sessions/model-overrides.ts
@@ -1,3 +1,5 @@
+import { lookupContextTokens } from "../agents/context.js";
+import { DEFAULT_CONTEXT_TOKENS } from "../agents/defaults.js";
 import type { SessionEntry } from "../config/sessions.js";
 
 export type ModelOverrideSelection = {
@@ -34,6 +36,13 @@ export function applyModelOverrideToSessionEntry(params: {
       entry.modelOverride = selection.model;
       updated = true;
     }
+  }
+
+  // Update contextTokens to match the selected model's context window
+  const modelContextTokens = lookupContextTokens(selection.model) ?? DEFAULT_CONTEXT_TOKENS;
+  if (entry.contextTokens !== modelContextTokens) {
+    entry.contextTokens = modelContextTokens;
+    updated = true;
   }
 
   if (profileOverride) {

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -1,7 +1,4 @@
 import type { Message, ReactionTypeEmoji } from "@grammyjs/types";
-import type { TelegramGroupConfig, TelegramTopicConfig } from "../config/types.js";
-import type { TelegramMediaRef } from "./bot-message-context.js";
-import type { TelegramContext } from "./bot/types.js";
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { hasControlCommand } from "../auto-reply/command-detection.js";
 import {
@@ -17,6 +14,7 @@ import { resolveChannelConfigWrites } from "../channels/plugins/config-writes.js
 import { loadConfig } from "../config/config.js";
 import { writeConfigFile } from "../config/io.js";
 import { loadSessionStore, resolveStorePath } from "../config/sessions.js";
+import type { TelegramGroupConfig, TelegramTopicConfig } from "../config/types.js";
 import { danger, logVerbose, warn } from "../globals.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { readChannelAllowFromStore } from "../pairing/pairing-store.js";
@@ -28,6 +26,7 @@ import {
   normalizeAllowFromWithStore,
   type NormalizedAllowFrom,
 } from "./bot-access.js";
+import type { TelegramMediaRef } from "./bot-message-context.js";
 import { RegisterTelegramHandlerParams } from "./bot-native-commands.js";
 import { MEDIA_GROUP_TIMEOUT_MS, type MediaGroupEntry } from "./bot-updates.js";
 import { resolveMedia } from "./bot/delivery.js";
@@ -37,6 +36,7 @@ import {
   resolveTelegramForumThreadId,
   resolveTelegramGroupAllowFromContext,
 } from "./bot/helpers.js";
+import type { TelegramContext } from "./bot/types.js";
 import {
   evaluateTelegramGroupBaseAccess,
   evaluateTelegramGroupPolicyAccess,

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -5,8 +5,6 @@ import type {
   ReactionTypeEmoji,
 } from "@grammyjs/types";
 import { type ApiClientOptions, Bot, HttpError, InputFile } from "grammy";
-import type { RetryConfig } from "../infra/retry.js";
-import type { TelegramInlineButtons } from "./button-types.js";
 import { loadConfig } from "../config/config.js";
 import { resolveMarkdownTableMode } from "../config/markdown-tables.js";
 import { logVerbose } from "../globals.js";
@@ -14,6 +12,7 @@ import { recordChannelActivity } from "../infra/channel-activity.js";
 import { isDiagnosticFlagEnabled } from "../infra/diagnostic-flags.js";
 import { formatErrorMessage, formatUncaughtError } from "../infra/errors.js";
 import { createTelegramRetryRunner } from "../infra/retry-policy.js";
+import type { RetryConfig } from "../infra/retry.js";
 import { redactSensitiveText } from "../logging/redact.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { mediaKindFromMime } from "../media/constants.js";
@@ -23,6 +22,7 @@ import { loadWebMedia } from "../web/media.js";
 import { type ResolvedTelegramAccount, resolveTelegramAccount } from "./accounts.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { buildTelegramThreadParams } from "./bot/helpers.js";
+import type { TelegramInlineButtons } from "./button-types.js";
 import { splitTelegramCaption } from "./caption.js";
 import { resolveTelegramFetch } from "./fetch.js";
 import { renderTelegramHtmlText } from "./format.js";


### PR DESCRIPTION
## Summary

Two focused fixes for session state correctness:

- **Session store race condition (#14979):** Moved session entry construction inside the `updateSessionStore` lock callback so it reads fresh data from disk, preventing compaction or concurrent agent runs from silently overwriting updates.

- **contextTokens not updated on model override (#14969):** `applyModelOverrideToSessionEntry` now calls `lookupContextTokens` for the selected model, keeping `entry.contextTokens` in sync when the user switches models via `/model`.

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm lint` clean
- [x] Existing session-store and model-override tests pass

Closes #14979
Closes #14969

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes two session state correctness issues: prevents race conditions during concurrent session updates by moving entry construction inside the lock callback, and ensures `contextTokens` stays in sync when users override the model via `/model` command. Both changes are minimal, focused, and follow existing patterns in the codebase.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Both fixes are minimal, focused, and correct. The race condition fix properly moves the entry construction inside the lock callback to read fresh data from disk. The contextTokens fix ensures consistency when models are overridden. The changes follow existing patterns, existing tests cover the locking mechanism well, and the test plan shows build and lint passing.
- No files require special attention

<sub>Last reviewed commit: 710d093</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->