### PR TITLE
fix: capture initial CWD for Control UI path resolution

### DIFF
--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -165,6 +165,12 @@ export async function startGatewayServer(
   const minimalTestGateway =
     process.env.VITEST === "1" && process.env.OPENCLAW_TEST_MINIMAL_GATEWAY === "1";
 
+  // Capture initial CWD immediately before any async operations that might
+  // change it (e.g., agent runs calling process.chdir to workspace directories).
+  // This ensures Control UI path resolution finds assets correctly even after
+  // the working directory changes. See issue #8325.
+  const initialCwd = process.cwd();
+
   // Ensure all default port derivations (browser/canvas) see the actual runtime port.
   process.env.OPENCLAW_GATEWAY_PORT = String(port);
   logAcceptedEnvOption({
@@ -318,7 +324,7 @@ export async function startGatewayServer(
     let resolvedRoot = resolveControlUiRootSync({
       moduleUrl: import.meta.url,
       argv1: process.argv[1],
-      cwd: process.cwd(),
+      cwd: initialCwd,
     });
     if (!resolvedRoot) {
       const ensureResult = await ensureControlUiAssetsBuilt(gatewayRuntime);
@@ -328,7 +334,7 @@ export async function startGatewayServer(
       resolvedRoot = resolveControlUiRootSync({
         moduleUrl: import.meta.url,
         argv1: process.argv[1],
-        cwd: process.cwd(),
+        cwd: initialCwd,
       });
     }
     controlUiRootState = resolvedRoot

--- a/src/infra/control-ui-assets.test.ts
+++ b/src/infra/control-ui-assets.test.ts
@@ -296,4 +296,29 @@ describe("control UI assets helpers", () => {
       );
     });
   });
+
+  it("resolves control-ui root using explicit cwd even after process.chdir (issue #8325)", async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ui-cwd-"));
+    const prevCwd = process.cwd();
+    try {
+      const appDir = path.join(tmp, "app");
+      const workspaceDir = path.join(tmp, "workspace");
+      await fs.mkdir(path.join(appDir, "dist", "control-ui"), { recursive: true });
+      await fs.mkdir(workspaceDir, { recursive: true });
+      await fs.writeFile(path.join(appDir, "package.json"), JSON.stringify({ name: "openclaw" }));
+      await fs.writeFile(path.join(appDir, "dist", "control-ui", "index.html"), "<html></html>\n");
+
+      const initialCwd = appDir;
+      process.chdir(workspaceDir);
+
+      expect(resolveControlUiRootSync({ cwd: initialCwd })).toBe(
+        path.join(appDir, "dist", "control-ui"),
+      );
+
+      expect(resolveControlUiRootSync({ cwd: process.cwd() })).toBeNull();
+    } finally {
+      process.chdir(prevCwd);
+      await fs.rm(tmp, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/memory/qmd-scope.ts
+++ b/src/memory/qmd-scope.ts
@@ -63,7 +63,10 @@ export function deriveQmdScopeChatType(key?: string): "channel" | "group" | "dir
   return "direct";
 }
 
-function normalizeQmdSessionKey(key: string): string | undefined {
+function normalizeQmdSessionKey(key?: string): string | undefined {
+  if (!key) {
+    return undefined;
+  }
   const trimmed = key.trim();
   if (!trimmed) {
     return undefined;


### PR DESCRIPTION
## Summary
- Capture `process.cwd()` at gateway startup before async operations can change it
- Prevents Control UI asset resolution failures when agent runs call `process.chdir`

Replaces #8413 (clean branch from upstream/main to fix CI).

Closes #8325

## Test plan
- [x] Existing tests pass (`pnpm test`)
- [x] Cherry-picked with conflict resolution from verified commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Captures `process.cwd()` at gateway startup (line 172) and passes it to Control UI path resolution instead of calling `process.cwd()` at resolution time (lines 327, 337). This prevents asset resolution failures when agent runs call `process.chdir` to workspace directories.

The fix is clean and targeted:
- Stores initial CWD before any async operations
- Passes `initialCwd` to `resolveControlUiRootSync` calls
- Adds comprehensive test coverage for the `process.chdir` scenario (lines 300-323)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The fix is minimal (3 lines changed in production code), addresses a clear bug (issue #8325), and includes excellent test coverage. The logic is sound: capturing CWD before async operations is the correct approach since `process.chdir` can change it later. No side effects or edge cases identified.
- No files require special attention

<sub>Last reviewed commit: 2a74cbd</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->