### PR TITLE
feat(memory-lancedb): register memory_search and memory_get compatibility tools

### DIFF
--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -97,6 +97,8 @@ describe("memory plugin e2e", () => {
 
     // oxlint-disable-next-line typescript/no-explicit-any
     const registeredTools: Array<{ tool: any; opts: any }> = [];
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const registeredClis: Array<{ registrar: any; opts: any }> = [];
     const mockSearchTool = { name: "memory_search" };
     const mockGetTool = { name: "memory_get" };
 
@@ -132,7 +134,9 @@ describe("memory plugin e2e", () => {
         registeredTools.push({ tool, opts });
       },
       // oxlint-disable-next-line typescript/no-explicit-any
-      registerCli: () => {},
+      registerCli: (registrar: any, opts: any) => {
+        registeredClis.push({ registrar, opts });
+      },
       // oxlint-disable-next-line typescript/no-explicit-any
       registerService: () => {},
       // oxlint-disable-next-line typescript/no-explicit-any
@@ -157,6 +161,11 @@ describe("memory plugin e2e", () => {
       sessionKey: "session-test",
     });
     expect(created).toEqual([mockSearchTool, mockGetTool]);
+    expect(
+      registeredClis.some(
+        (entry) => Array.isArray(entry.opts?.commands) && entry.opts.commands.includes("memory"),
+      ),
+    ).toBe(true);
   });
 
   test("shouldCapture applies real capture rules", async () => {
@@ -267,7 +276,12 @@ describeLive("memory plugin live tests", () => {
     expect(registeredTools.map((t) => t.opts?.name)).toContain("memory_recall");
     expect(registeredTools.map((t) => t.opts?.name)).toContain("memory_store");
     expect(registeredTools.map((t) => t.opts?.name)).toContain("memory_forget");
-    expect(registeredClis.length).toBe(1);
+    expect(registeredClis.length).toBe(2);
+    expect(
+      registeredClis.some(
+        (entry) => Array.isArray(entry.opts?.commands) && entry.opts.commands.includes("memory"),
+      ),
+    ).toBe(true);
     expect(registeredServices.length).toBe(1);
 
     // Get tool functions

--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -92,6 +92,73 @@ describe("memory plugin e2e", () => {
     }).toThrow("embedding.apiKey is required");
   });
 
+  test("registers memory_search and memory_get compatibility tools", async () => {
+    const { default: memoryPlugin } = await import("./index.js");
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const registeredTools: Array<{ tool: any; opts: any }> = [];
+    const mockSearchTool = { name: "memory_search" };
+    const mockGetTool = { name: "memory_get" };
+
+    const mockApi = {
+      id: "memory-lancedb",
+      name: "Memory (LanceDB)",
+      source: "test",
+      config: {},
+      pluginConfig: {
+        embedding: {
+          apiKey: OPENAI_API_KEY,
+          model: "text-embedding-3-small",
+        },
+        dbPath,
+        autoCapture: false,
+        autoRecall: false,
+      },
+      runtime: {
+        tools: {
+          createMemorySearchTool: () => mockSearchTool,
+          createMemoryGetTool: () => mockGetTool,
+          registerMemoryCli: () => {},
+        },
+      },
+      logger: {
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+        debug: () => {},
+      },
+      // oxlint-disable-next-line typescript/no-explicit-any
+      registerTool: (tool: any, opts: any) => {
+        registeredTools.push({ tool, opts });
+      },
+      // oxlint-disable-next-line typescript/no-explicit-any
+      registerCli: () => {},
+      // oxlint-disable-next-line typescript/no-explicit-any
+      registerService: () => {},
+      // oxlint-disable-next-line typescript/no-explicit-any
+      on: () => {},
+      resolvePath: (p: string) => p,
+    };
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    memoryPlugin.register(mockApi as any);
+
+    const compatibilityRegistration = registeredTools.find(
+      (entry) =>
+        Array.isArray(entry.opts?.names) &&
+        entry.opts.names.includes("memory_search") &&
+        entry.opts.names.includes("memory_get"),
+    );
+    expect(compatibilityRegistration).toBeDefined();
+    expect(typeof compatibilityRegistration?.tool).toBe("function");
+
+    const created = compatibilityRegistration?.tool({
+      config: {},
+      sessionKey: "session-test",
+    });
+    expect(created).toEqual([mockSearchTool, mockGetTool]);
+  });
+
   test("shouldCapture applies real capture rules", async () => {
     const { shouldCapture } = await import("./index.js");
 

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -506,6 +506,13 @@ const memoryPlugin = {
       { commands: ["ltm"] },
     );
 
+    api.registerCli(
+      ({ program }) => {
+        api.runtime.tools.registerMemoryCli(program);
+      },
+      { commands: ["memory"] },
+    );
+
     // ========================================================================
     // Lifecycle Hooks
     // ========================================================================

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -255,6 +255,25 @@ const memoryPlugin = {
 
     api.logger.info(`memory-lancedb: plugin registered (db: ${resolvedDbPath}, lazy init)`);
 
+    // Re-export core file-memory tools for compatibility with shared prompts/tool groups.
+    api.registerTool(
+      (ctx) => {
+        const memorySearchTool = api.runtime.tools.createMemorySearchTool({
+          config: ctx.config,
+          agentSessionKey: ctx.sessionKey,
+        });
+        const memoryGetTool = api.runtime.tools.createMemoryGetTool({
+          config: ctx.config,
+          agentSessionKey: ctx.sessionKey,
+        });
+        if (!memorySearchTool || !memoryGetTool) {
+          return null;
+        }
+        return [memorySearchTool, memoryGetTool];
+      },
+      { names: ["memory_search", "memory_get"] },
+    );
+
     // ========================================================================
     // Tools
     // ========================================================================


### PR DESCRIPTION
## Summary
- feat(memory-lancedb): register memory_search and memory_get compatibility tools
- Split from our `v2026.2.13` patch train as a single-purpose change for easier review.

## Why
- Keep the diff focused and low-risk so it can be merged or reverted independently.

## Scope
- Branch: `feat/memory-lancedb-tool-aliases-en`
- Files changed: 2
- Key files:
  - `extensions/memory-lancedb/index.test.ts`
  - `extensions/memory-lancedb/index.ts`

## Test Plan
- Suggested local command:
  - `./node_modules/.bin/vitest run extensions/memory-lancedb/index.test.ts`
- Validation status:
  - [ ] CI checks pass
  - [ ] Maintainer re-ran local tests

## Risk & Rollback
- Risk: low to medium; impact limited to touched module(s).
- Rollback: revert this PR commit(s) cleanly.

## Co-authorship
- Co-authored by @ciberponk and Codex (GPT-5).
