### PR TITLE
fix(voice-call): preserve Telnyx inbound event direction metadata

### DIFF
--- a/extensions/voice-call/src/manager/events.test.ts
+++ b/extensions/voice-call/src/manager/events.test.ts
@@ -237,4 +237,57 @@ describe("processEvent (functional)", () => {
     expect(() => processEvent(ctx, event)).not.toThrow();
     expect(ctx.activeCalls.size).toBe(0);
   });
+
+  it("infers inbound direction from endpoints when provider omits direction", () => {
+    const ctx = createContext({
+      config: VoiceCallConfigSchema.parse({
+        enabled: true,
+        provider: "telnyx",
+        fromNumber: "+15550000000",
+        inboundPolicy: "open",
+      }),
+    });
+    const event: NormalizedEvent = {
+      id: "evt-infer-inbound",
+      type: "call.initiated",
+      callId: "prov-infer",
+      providerCallId: "prov-infer",
+      timestamp: Date.now(),
+      from: "+15559999999",
+      to: "+15550000000",
+    };
+
+    processEvent(ctx, event);
+
+    expect(ctx.activeCalls.size).toBe(1);
+    const call = Array.from(ctx.activeCalls.values())[0];
+    expect(call?.direction).toBe("inbound");
+    expect(call?.providerCallId).toBe("prov-infer");
+    expect(event.direction).toBe("inbound");
+  });
+
+  it("does not infer inbound direction when destination does not match configured number", () => {
+    const ctx = createContext({
+      config: VoiceCallConfigSchema.parse({
+        enabled: true,
+        provider: "telnyx",
+        fromNumber: "+15550000000",
+        inboundPolicy: "open",
+      }),
+    });
+    const event: NormalizedEvent = {
+      id: "evt-infer-miss",
+      type: "call.initiated",
+      callId: "prov-miss",
+      providerCallId: "prov-miss",
+      timestamp: Date.now(),
+      from: "+15557777777",
+      to: "+15558888888",
+    };
+
+    processEvent(ctx, event);
+
+    expect(ctx.activeCalls.size).toBe(0);
+    expect(event.direction).not.toBe("inbound");
+  });
 });

--- a/extensions/voice-call/src/providers/direction.ts
+++ b/extensions/voice-call/src/providers/direction.ts
@@ -1,0 +1,58 @@
+export type NormalizedDirection = "inbound" | "outbound";
+
+type EndpointValue = string | null | undefined;
+
+function normalizePhoneLike(value: EndpointValue): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  // Keep leading "+" and digits only so E.164-like comparisons are stable.
+  const normalized = trimmed.replace(/[^\d+]/g, "");
+  return normalized || undefined;
+}
+
+/**
+ * Normalize provider-specific direction values to internal direction.
+ */
+export function parseProviderDirection(direction: string | null | undefined): NormalizedDirection | undefined {
+  const normalized = direction?.trim().toLowerCase();
+  if (!normalized) {
+    return undefined;
+  }
+  if (normalized === "inbound" || normalized === "incoming") {
+    return "inbound";
+  }
+  if (
+    normalized === "outbound" ||
+    normalized === "outgoing" ||
+    normalized === "outbound-api" ||
+    normalized === "outbound-dial"
+  ) {
+    return "outbound";
+  }
+  return undefined;
+}
+
+/**
+ * Infer direction when providers omit a dedicated direction field.
+ */
+export function inferDirectionFromEndpoints(params: {
+  from: EndpointValue;
+  to: EndpointValue;
+  fromNumber: EndpointValue;
+}): NormalizedDirection | undefined {
+  const from = normalizePhoneLike(params.from);
+  const to = normalizePhoneLike(params.to);
+  const configuredFrom = normalizePhoneLike(params.fromNumber);
+  if (!configuredFrom) {
+    return undefined;
+  }
+  if (to === configuredFrom) {
+    return "inbound";
+  }
+  if (from === configuredFrom) {
+    return "outbound";
+  }
+  return undefined;
+}

--- a/extensions/voice-call/src/providers/plivo.ts
+++ b/extensions/voice-call/src/providers/plivo.ts
@@ -15,6 +15,7 @@ import type {
 import type { VoiceCallProvider } from "./base.js";
 import { escapeXml } from "../voice-mapping.js";
 import { reconstructWebhookUrl, verifyPlivoWebhook } from "../webhook-security.js";
+import { parseProviderDirection } from "./direction.js";
 
 export interface PlivoProviderOptions {
   /** Override public URL origin for signature verification */
@@ -204,12 +205,7 @@ export class PlivoProvider implements VoiceCallProvider {
       callId: callIdOverride || callUuid || requestUuid,
       providerCallId: callUuid || requestUuid || undefined,
       timestamp: Date.now(),
-      direction:
-        direction === "inbound"
-          ? ("inbound" as const)
-          : direction === "outbound"
-            ? ("outbound" as const)
-            : undefined,
+      direction: parseProviderDirection(direction),
       from,
       to,
     };

--- a/extensions/voice-call/src/providers/telnyx.test.ts
+++ b/extensions/voice-call/src/providers/telnyx.test.ts
@@ -119,3 +119,69 @@ describe("TelnyxProvider.verifyWebhook", () => {
     expect(result.ok).toBe(true);
   });
 });
+
+describe("TelnyxProvider.parseWebhookEvent", () => {
+  it("keeps inbound call direction and endpoint numbers on call.initiated", () => {
+    const provider = new TelnyxProvider({
+      apiKey: "KEY123",
+      connectionId: "CONN456",
+      publicKey: "public-key",
+    });
+
+    const rawBody = JSON.stringify({
+      data: {
+        id: "evt_telnyx_1",
+        event_type: "call.initiated",
+        payload: {
+          call_control_id: "call-123",
+          direction: "incoming",
+          from: { phone_number: "+15559990000" },
+          to: { phone_number: "+15550001111" },
+        },
+      },
+    });
+
+    const result = provider.parseWebhookEvent(createCtx({ rawBody }));
+    expect(result.statusCode).toBe(200);
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0]).toMatchObject({
+      type: "call.initiated",
+      providerCallId: "call-123",
+      direction: "inbound",
+      from: "+15559990000",
+      to: "+15550001111",
+    });
+  });
+
+  it("normalizes outgoing direction aliases", () => {
+    const provider = new TelnyxProvider({
+      apiKey: "KEY123",
+      connectionId: "CONN456",
+      publicKey: "public-key",
+    });
+
+    const rawBody = JSON.stringify({
+      data: {
+        id: "evt_telnyx_2",
+        event_type: "call.initiated",
+        payload: {
+          call_control_id: "call-456",
+          direction: "outgoing",
+          from: "+15550001111",
+          to: "+15559990000",
+        },
+      },
+    });
+
+    const result = provider.parseWebhookEvent(createCtx({ rawBody }));
+    expect(result.statusCode).toBe(200);
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0]).toMatchObject({
+      type: "call.initiated",
+      providerCallId: "call-456",
+      direction: "outbound",
+      from: "+15550001111",
+      to: "+15559990000",
+    });
+  });
+});

--- a/extensions/voice-call/src/providers/twilio.ts
+++ b/extensions/voice-call/src/providers/twilio.ts
@@ -19,6 +19,7 @@ import { chunkAudio } from "../telephony-audio.js";
 import { escapeXml, mapVoiceToPolly } from "../voice-mapping.js";
 import { twilioApiRequest } from "./twilio/api.js";
 import { verifyTwilioProviderWebhook } from "./twilio/webhook.js";
+import { parseProviderDirection } from "./direction.js";
 
 /**
  * Twilio Voice API provider implementation.
@@ -230,19 +231,6 @@ export class TwilioProvider implements VoiceCallProvider {
   }
 
   /**
-   * Parse Twilio direction to normalized format.
-   */
-  private static parseDirection(direction: string | null): "inbound" | "outbound" | undefined {
-    if (direction === "inbound") {
-      return "inbound";
-    }
-    if (direction === "outbound-api" || direction === "outbound-dial") {
-      return "outbound";
-    }
-    return undefined;
-  }
-
-  /**
    * Convert Twilio webhook params to normalized event format.
    */
   private normalizeEvent(params: URLSearchParams, callIdOverride?: string): NormalizedEvent | null {
@@ -253,7 +241,7 @@ export class TwilioProvider implements VoiceCallProvider {
       callId: callIdOverride || callSid,
       providerCallId: callSid,
       timestamp: Date.now(),
-      direction: TwilioProvider.parseDirection(params.get("Direction")),
+      direction: parseProviderDirection(params.get("Direction")),
       from: params.get("From") || undefined,
       to: params.get("To") || undefined,
     };


### PR DESCRIPTION
## Describe your changes
- Preserve Telnyx `call.initiated` metadata (`direction`, `from`, `to`) during webhook normalization instead of dropping those fields.
- Normalize provider direction aliases in a shared helper and reuse it across Telnyx, Twilio, and Plivo providers for consistent event semantics.
- Add endpoint-based fallback direction inference in call event processing so inbound calls are still identified when providers omit an explicit direction value.

## Screenshot or video (only for visual changes)
- N/A

## GitHub Issue Link (if applicable)
- https://github.com/openclaw/openclaw/issues/16601

## Testing Plan
- Explanation of why no additional tests are needed:
  - Added focused unit coverage for Telnyx webhook parsing and inbound direction inference paths in the call manager.
- Unit Tests (JS and/or Python):
  - `pnpm test -- extensions/voice-call/src/providers/telnyx.test.ts extensions/voice-call/src/manager/events.test.ts extensions/voice-call/src/providers/twilio.test.ts extensions/voice-call/src/providers/plivo.test.ts`
- E2E Tests:
  - Not run (provider integrations require external telephony services).
- Any manual testing needed?:
  - Optional: place an inbound Telnyx call and confirm `call.initiated` creates an inbound call record.

---
**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
