### PR TITLE
feat: bridge message lifecycle hooks to workspace hook system

### DIFF
--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -259,6 +259,7 @@ Triggered when messages are received or sent:
 
 - **`message`**: All message events (general listener)
 - **`message:received`**: When an inbound message is received from any channel
+- **`message:before`** (modifying): Fires just before the agent prompt is sent. Handlers can return `prependContext` and/or `systemPrompt` to modify the agent's input.
 - **`message:sent`**: When an outbound message is successfully sent
 
 #### Message Event Context
@@ -287,6 +288,15 @@ Message events include rich context about the message:
   }
 }
 
+// message:before context
+{
+  prompt: string,         // The effective prompt about to be sent
+  messages: AgentMessage[], // Current conversation history
+  agentId?: string,       // Resolved agent ID
+  sessionId?: string,     // Session identifier
+  commandSource?: string, // Message provider/channel
+}
+
 // message:sent context
 {
   to: string,             // Recipient identifier
@@ -300,6 +310,19 @@ Message events include rich context about the message:
 }
 ```
 
+#### Return Values (`message:before` only)
+
+Handlers registered for `message:before` can return an `InternalHookResult`:
+
+```typescript
+interface InternalHookResult {
+  prependContext?: string; // Prepended to the prompt
+  systemPrompt?: string; // Overrides the system prompt
+}
+```
+
+Multiple handlers are merged: `prependContext` values are concatenated with `\n\n`, and the last non-undefined `systemPrompt` wins. Returning `undefined` or `void` is a no-op.
+
 #### Example: Message Logger Hook
 
 ```typescript
@@ -312,7 +335,7 @@ const handler = async (event) => {
   if (isMessageReceivedEvent(event as { type: string; action: string })) {
     console.log(`[message-logger] Received from ${event.context.from}: ${event.context.content}`);
   } else if (isMessageSentEvent(event as { type: string; action: string })) {
-    console.log(`[message-logger] Sent to ${event.context.to}: ${event.context.content}`);
+    console.log(`[message-logger] Sent to ${event.context.to}: ${event.context.content}`)
   }
 };
 

--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -335,7 +335,7 @@ const handler = async (event) => {
   if (isMessageReceivedEvent(event as { type: string; action: string })) {
     console.log(`[message-logger] Received from ${event.context.from}: ${event.context.content}`);
   } else if (isMessageSentEvent(event as { type: string; action: string })) {
-    console.log(`[message-logger] Sent to ${event.context.to}: ${event.context.content}`)
+    console.log(`[message-logger] Sent to ${event.context.to}: ${event.context.content}`);
   }
 };
 

--- a/docs/zh-CN/automation/hooks.md
+++ b/docs/zh-CN/automation/hooks.md
@@ -206,7 +206,7 @@ export default myHandler;
 
 ```typescript
 {
-  type: 'command' | 'session' | 'agent' | 'gateway',
+  type: 'command' | 'session' | 'agent' | 'gateway' | 'message',
   action: string,              // e.g., 'new', 'reset', 'stop'
   sessionKey: string,          // Session identifier
   timestamp: Date,             // When the event occurred
@@ -245,6 +245,130 @@ export default myHandler;
 
 - **`gateway:startup`**：在渠道启动和 hooks 加载之后
 
+### 消息事件
+
+在消息生命周期中触发。这些事件桥接到工作区 hook 系统，使 hooks 可以观察和修改智能体对话。
+
+- **`message:received`**（即发即弃）：当入站消息到达时触发，在任何处理之前。适用于日志记录、分析或触发副作用。
+- **`message:before`**（可修改）：在智能体提示发送之前触发。处理器可以返回 `prependContext` 和/或 `systemPrompt` 来修改智能体的输入。多个 `prependContext` 值用双换行符合并；最后一个 `systemPrompt` 生效。
+- **`message:sent`**（即发即弃）：在智能体完成响应后触发。适用于后处理、日志记录或触发后续操作。
+
+#### 上下文字段
+
+**`message:received`**：
+
+| 字段            | 类型                  | 描述                         |
+| --------------- | --------------------- | ---------------------------- |
+| `from`          | `string`              | 发送者标识（电话号码、邮箱） |
+| `content`       | `string`              | 消息正文                     |
+| `channel`       | `string`              | 来源渠道（如 `"telegram"`）  |
+| `senderId`      | `string \| undefined` | 平台特定的发送者 ID          |
+| `senderName`    | `string \| undefined` | 发送者显示名称               |
+| `commandSource` | `string`              | 接收消息的表面/提供者        |
+
+**`message:before`**：
+
+| 字段            | 类型                  | 描述               |
+| --------------- | --------------------- | ------------------ |
+| `prompt`        | `string`              | 即将发送的有效提示 |
+| `messages`      | `AgentMessage[]`      | 当前对话历史       |
+| `agentId`       | `string`              | 解析后的智能体 ID  |
+| `sessionId`     | `string`              | 会话标识符         |
+| `commandSource` | `string \| undefined` | 消息提供者/渠道    |
+
+**`message:sent`**：
+
+| 字段        | 类型             | 描述                     |
+| ----------- | ---------------- | ------------------------ |
+| `messages`  | `AgentMessage[]` | 最终对话快照（包含回复） |
+| `sessionId` | `string`         | 会话标识符               |
+| `success`   | `boolean`        | 智能体是否无错误完成     |
+
+#### 返回值（仅 `message:before`）
+
+为 `message:before` 注册的处理器可以返回 `InternalHookResult`：
+
+```typescript
+interface InternalHookResult {
+  prependContext?: string; // 前置到提示中
+  systemPrompt?: string; // 覆盖系统提示
+}
+```
+
+多个处理器会被合并：`prependContext` 值用 `\n\n` 连接，最后一个非 undefined 的 `systemPrompt` 生效。返回 `undefined` 或 `void` 为无操作。
+
+#### HOOK.md 示例
+
+```markdown
+---
+name: message-context-injector
+description: "Inject extra context before each agent turn"
+metadata: { "openclaw": { "emoji": "💉", "events": ["message:before"] } }
+---
+
+# Message Context Injector
+
+为每次智能体提示添加额外上下文。
+```
+
+#### 处理器示例
+
+**即发即弃日志记录（`message:received`）**：
+
+```typescript
+import type { HookHandler } from "../../src/hooks/hooks.js";
+
+const handler: HookHandler = async (event) => {
+  if (event.type !== "message" || event.action !== "received") {
+    return;
+  }
+
+  console.log(`[msg-log] from=${event.context.from} channel=${event.context.channel}`);
+};
+
+export default handler;
+```
+
+**可修改 hook（`message:before`）**：
+
+```typescript
+import type { HookHandler } from "../../src/hooks/hooks.js";
+
+const handler: HookHandler = async (event) => {
+  if (event.type !== "message" || event.action !== "before") {
+    return;
+  }
+
+  return {
+    prependContext: `Current user timezone: America/New_York`,
+  };
+};
+
+export default handler;
+```
+
+**响应后 hook（`message:sent`）**：
+
+```typescript
+import type { HookHandler } from "../../src/hooks/hooks.js";
+
+const handler: HookHandler = async (event) => {
+  if (event.type !== "message" || event.action !== "sent") {
+    return;
+  }
+
+  const { success, sessionId } = event.context as {
+    success: boolean;
+    sessionId: string;
+  };
+  if (!success) {
+    console.warn(`[msg-sent] Agent failed for session ${sessionId}`);
+  }
+};
+
+export default handler;
+```
+
 ### 工具结果 Hooks（插件 API）
 
 这些 hooks 不是事件流监听器；它们让插件在 OpenClaw 持久化工具结果之前同步调整它们。
@@ -258,8 +382,6 @@ export default myHandler;
 - **`session:start`**：当新会话开始时
 - **`session:end`**：当会话结束时
 - **`agent:error`**：当智能体遇到错误时
-- **`message:sent`**：当消息被发送时
-- **`message:received`**：当消息被接收时
 
 ## 创建自定义 Hooks
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1019,11 +1019,11 @@ export async function runEmbeddedAttempt(
             "received",
             params.sessionKey || params.sessionId || "",
             {
-              from: "",
+              from: params.messageTo ?? "",
               content: typeof params.prompt === "string" ? params.prompt : "",
               channel: (params.messageChannel ?? params.messageProvider ?? "").toLowerCase(),
-              senderId: undefined,
-              senderName: undefined,
+              senderId: params.senderId,
+              senderName: params.senderName,
               commandSource: (params.messageChannel ?? params.messageProvider ?? "").toLowerCase(),
             },
           ),
@@ -1092,6 +1092,12 @@ export async function runEmbeddedAttempt(
             effectivePrompt = `${messageBeforeResult.prependContext}\n\n${effectivePrompt}`;
             log.debug(
               `message:before hook prepended context (${messageBeforeResult.prependContext.length} chars)`,
+            );
+          }
+          if (messageBeforeResult?.systemPrompt) {
+            applySystemPromptOverrideToSession(activeSession, messageBeforeResult.systemPrompt);
+            log.debug(
+              `message:before hook overrode system prompt (${messageBeforeResult.systemPrompt.length} chars)`,
             );
           }
         } catch (err) {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -11,6 +11,7 @@ import {
 } from "@mariozechner/pi-coding-agent";
 import { resolveHeartbeatPrompt } from "../../../auto-reply/heartbeat.js";
 import { resolveChannelCapabilities } from "../../../config/channel-capabilities.js";
+import { createInternalHookEvent, triggerInternalHook } from "../../../hooks/internal-hooks.js";
 import { getMachineDisplayName } from "../../../infra/machine-name.js";
 import { MAX_IMAGE_BYTES } from "../../../media/constants.js";
 import { getGlobalHookRunner } from "../../../plugins/hook-runner-global.js";
@@ -1010,6 +1011,29 @@ export async function runEmbeddedAttempt(
       // Hook runner was already obtained earlier before tool creation
       const hookAgentId = sessionAgentId;
 
+      // Bridge message:received to internal (workspace) hooks
+      try {
+        await triggerInternalHook(
+          createInternalHookEvent(
+            "message",
+            "received",
+            params.sessionKey || params.sessionId || "",
+            {
+              from: "",
+              content: typeof params.prompt === "string" ? params.prompt : "",
+              channel: (params.messageChannel ?? params.messageProvider ?? "").toLowerCase(),
+              senderId: undefined,
+              senderName: undefined,
+              commandSource: (params.messageChannel ?? params.messageProvider ?? "").toLowerCase(),
+            },
+          ),
+        );
+      } catch (err) {
+        log.warn(
+          `message:received hook failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+
       let promptError: unknown = null;
       let promptErrorSource: "prompt" | "compaction" | null = null;
       try {
@@ -1046,6 +1070,34 @@ export async function runEmbeddedAttempt(
             systemPromptText = legacySystemPrompt;
             log.debug(`hooks: applied systemPrompt override (${legacySystemPrompt.length} chars)`);
           }
+        }
+
+        // Bridge message:before to internal (workspace) hooks
+        try {
+          const messageBeforeResult = await triggerInternalHook(
+            createInternalHookEvent(
+              "message",
+              "before",
+              params.sessionKey || params.sessionId || "",
+              {
+                prompt: effectivePrompt,
+                messages: activeSession.messages,
+                agentId: hookAgentId,
+                sessionId: params.sessionId,
+                commandSource: params.messageProvider ?? undefined,
+              },
+            ),
+          );
+          if (messageBeforeResult?.prependContext) {
+            effectivePrompt = `${messageBeforeResult.prependContext}\n\n${effectivePrompt}`;
+            log.debug(
+              `message:before hook prepended context (${messageBeforeResult.prependContext.length} chars)`,
+            );
+          }
+        } catch (err) {
+          log.warn(
+            `message:before hook failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
         }
 
         log.debug(`embedded run prompt start: runId=${params.runId} sessionId=${params.sessionId}`);
@@ -1284,6 +1336,17 @@ export async function runEmbeddedAttempt(
               log.warn(`agent_end hook failed: ${err}`);
             });
         }
+
+        // Bridge message:sent to internal (workspace) hooks
+        void triggerInternalHook(
+          createInternalHookEvent("message", "sent", params.sessionKey || params.sessionId || "", {
+            messages: messagesSnapshot,
+            sessionId: params.sessionId,
+            success: !aborted && !promptError,
+          }),
+        ).catch((err) => {
+          log.warn(`message:sent hook failed: ${err}`);
+        });
       } finally {
         clearTimeout(abortTimer);
         if (abortWarnTimer) {

--- a/src/hooks/internal-hooks.test.ts
+++ b/src/hooks/internal-hooks.test.ts
@@ -490,6 +490,146 @@ describe("hooks", () => {
     });
   });
 
+  describe("message lifecycle hooks", () => {
+    describe("message:received", () => {
+      it("fires with correct event shape", async () => {
+        const handler = vi.fn();
+        registerInternalHook("message:received", handler);
+
+        const event = createInternalHookEvent("message", "received", "sess-1", {
+          from: "+1234567890",
+          content: "hello world",
+          channel: "telegram",
+          senderId: "user-123",
+          senderName: "Alice",
+          commandSource: "telegram",
+        });
+        await triggerInternalHook(event);
+
+        expect(handler).toHaveBeenCalledOnce();
+        const calledEvent = handler.mock.calls[0][0] as InternalHookEvent;
+        expect(calledEvent.type).toBe("message");
+        expect(calledEvent.action).toBe("received");
+        expect(calledEvent.sessionKey).toBe("sess-1");
+        expect(calledEvent.context).toEqual({
+          from: "+1234567890",
+          content: "hello world",
+          channel: "telegram",
+          senderId: "user-123",
+          senderName: "Alice",
+          commandSource: "telegram",
+        });
+        expect(calledEvent.timestamp).toBeInstanceOf(Date);
+      });
+
+      it("does not fire when no hooks are registered for message:received", async () => {
+        const handler = vi.fn();
+        registerInternalHook("command:new", handler);
+
+        const event = createInternalHookEvent("message", "received", "sess-1", {
+          from: "user",
+          content: "hello",
+        });
+        await triggerInternalHook(event);
+
+        expect(handler).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("message:before", () => {
+      it("returns and merges prependContext and systemPrompt", async () => {
+        registerInternalHook("message:before", () => ({
+          prependContext: "context from hook A",
+          systemPrompt: "system prompt A",
+        }));
+        registerInternalHook("message:before", () => ({
+          prependContext: "context from hook B",
+          systemPrompt: "system prompt B",
+        }));
+
+        const event = createInternalHookEvent("message", "before", "sess-1", {
+          prompt: "user message",
+          messages: [],
+          agentId: "agent-main",
+          sessionId: "sid-1",
+          commandSource: "telegram",
+        });
+        const result = await triggerInternalHook(event);
+
+        expect(result?.prependContext).toBe("context from hook A\n\ncontext from hook B");
+        expect(result?.systemPrompt).toBe("system prompt B");
+      });
+
+      it("returns undefined when no hooks are registered (no-op)", async () => {
+        const event = createInternalHookEvent("message", "before", "sess-1", {
+          prompt: "user message",
+          messages: [],
+        });
+        const result = await triggerInternalHook(event);
+
+        expect(result).toBeUndefined();
+      });
+
+      it("does not fire when no hooks are registered for message:before", async () => {
+        const handler = vi.fn();
+        registerInternalHook("message:received", handler);
+
+        const event = createInternalHookEvent("message", "before", "sess-1", {
+          prompt: "user message",
+        });
+        await triggerInternalHook(event);
+
+        expect(handler).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("message:sent", () => {
+      it("fires with correct event shape", async () => {
+        const handler = vi.fn();
+        registerInternalHook("message:sent", handler);
+
+        const event = createInternalHookEvent("message", "sent", "sess-1", {
+          messages: [
+            { role: "user", content: "hi" },
+            { role: "assistant", content: "hello" },
+          ],
+          sessionId: "sid-1",
+          success: true,
+        });
+        await triggerInternalHook(event);
+
+        expect(handler).toHaveBeenCalledOnce();
+        const calledEvent = handler.mock.calls[0][0] as InternalHookEvent;
+        expect(calledEvent.type).toBe("message");
+        expect(calledEvent.action).toBe("sent");
+        expect(calledEvent.sessionKey).toBe("sess-1");
+        expect(calledEvent.context).toEqual({
+          messages: [
+            { role: "user", content: "hi" },
+            { role: "assistant", content: "hello" },
+          ],
+          sessionId: "sid-1",
+          success: true,
+        });
+        expect(calledEvent.timestamp).toBeInstanceOf(Date);
+      });
+
+      it("does not fire when no hooks are registered for message:sent", async () => {
+        const handler = vi.fn();
+        registerInternalHook("message:received", handler);
+
+        const event = createInternalHookEvent("message", "sent", "sess-1", {
+          messages: [],
+          sessionId: "sid-1",
+          success: true,
+        });
+        await triggerInternalHook(event);
+
+        expect(handler).not.toHaveBeenCalled();
+      });
+    });
+  });
+
   describe("triggerInternalHook result merging", () => {
     it("returns undefined when no handlers are registered", async () => {
       const event = createInternalHookEvent("message", "before", "sess-1");

--- a/src/hooks/internal-hooks.test.ts
+++ b/src/hooks/internal-hooks.test.ts
@@ -13,6 +13,7 @@ import {
   type AgentBootstrapHookContext,
   type GatewayStartupHookContext,
   type MessageReceivedHookContext,
+  type InternalHookEvent,
   type MessageSentHookContext,
 } from "./internal-hooks.js";
 
@@ -453,6 +454,106 @@ describe("hooks", () => {
 
       const keys = getRegisteredEventKeys();
       expect(keys).toEqual([]);
+    });
+  });
+
+  describe("integration", () => {
+    it("should handle a complete hook lifecycle", async () => {
+      const results: InternalHookEvent[] = [];
+      const handler = vi.fn((event: InternalHookEvent) => {
+        results.push(event);
+      });
+
+      // Register
+      registerInternalHook("command:new", handler);
+
+      // Trigger
+      const event1 = createInternalHookEvent("command", "new", "session-1");
+      await triggerInternalHook(event1);
+
+      const event2 = createInternalHookEvent("command", "new", "session-2");
+      await triggerInternalHook(event2);
+
+      // Verify
+      expect(results).toHaveLength(2);
+      expect(results[0].sessionKey).toBe("session-1");
+      expect(results[1].sessionKey).toBe("session-2");
+
+      // Unregister
+      unregisterInternalHook("command:new", handler);
+
+      // Trigger again - should not call handler
+      const event3 = createInternalHookEvent("command", "new", "session-3");
+      await triggerInternalHook(event3);
+
+      expect(results).toHaveLength(2);
+    });
+  });
+
+  describe("triggerInternalHook result merging", () => {
+    it("returns undefined when no handlers are registered", async () => {
+      const event = createInternalHookEvent("message", "before", "sess-1");
+      const result = await triggerInternalHook(event);
+      expect(result).toBeUndefined();
+    });
+
+    it("returns result when handler returns prependContext", async () => {
+      registerInternalHook("message:before", () => ({
+        prependContext: "extra context",
+      }));
+      const event = createInternalHookEvent("message", "before", "sess-1");
+      const result = await triggerInternalHook(event);
+      expect(result).toEqual({ prependContext: "extra context" });
+    });
+
+    it("merges multiple prependContext values with newlines", async () => {
+      registerInternalHook("message:before", () => ({
+        prependContext: "first",
+      }));
+      registerInternalHook("message:before", () => ({
+        prependContext: "second",
+      }));
+      const event = createInternalHookEvent("message", "before", "sess-1");
+      const result = await triggerInternalHook(event);
+      expect(result?.prependContext).toBe("first\n\nsecond");
+    });
+
+    it("last systemPrompt wins", async () => {
+      registerInternalHook("message:before", () => ({
+        systemPrompt: "prompt-a",
+      }));
+      registerInternalHook("message:before", () => ({
+        systemPrompt: "prompt-b",
+      }));
+      const event = createInternalHookEvent("message", "before", "sess-1");
+      const result = await triggerInternalHook(event);
+      expect(result?.systemPrompt).toBe("prompt-b");
+    });
+
+    it("ignores void/undefined returns from handlers", async () => {
+      registerInternalHook("message:before", () => undefined);
+      registerInternalHook("message:before", () => ({
+        prependContext: "only this",
+      }));
+      registerInternalHook("message:before", () => {});
+      const event = createInternalHookEvent("message", "before", "sess-1");
+      const result = await triggerInternalHook(event);
+      expect(result).toEqual({ prependContext: "only this" });
+    });
+
+    it("works with message event type across type and action handlers", async () => {
+      registerInternalHook("message", async () => ({
+        prependContext: "from type handler",
+      }));
+      registerInternalHook("message:received", async () => ({
+        prependContext: "from action handler",
+      }));
+      const event = createInternalHookEvent("message", "received", "sess-1", {
+        from: "user",
+        content: "hello",
+      });
+      const result = await triggerInternalHook(event);
+      expect(result?.prependContext).toBe("from type handler\n\nfrom action handler");
     });
   });
 });

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -108,7 +108,14 @@ export interface InternalHookEvent {
   messages: string[];
 }
 
-export type InternalHookHandler = (event: InternalHookEvent) => Promise<void> | void;
+export interface InternalHookResult {
+  prependContext?: string;
+  systemPrompt?: string;
+}
+
+export type InternalHookHandler = (
+  event: InternalHookEvent,
+) => Promise<InternalHookResult | void> | InternalHookResult | void;
 
 /** Registry of hook handlers by event key */
 const handlers = new Map<string, InternalHookHandler[]>();
@@ -189,24 +196,43 @@ export function getRegisteredEventKeys(): string[] {
  *
  * @param event - The event to trigger
  */
-export async function triggerInternalHook(event: InternalHookEvent): Promise<void> {
+export async function triggerInternalHook(
+  event: InternalHookEvent,
+): Promise<InternalHookResult | undefined> {
   const typeHandlers = handlers.get(event.type) ?? [];
   const specificHandlers = handlers.get(`${event.type}:${event.action}`) ?? [];
 
   const allHandlers = [...typeHandlers, ...specificHandlers];
 
   if (allHandlers.length === 0) {
-    return;
+    return undefined;
   }
+
+  let merged: InternalHookResult | undefined;
 
   for (const handler of allHandlers) {
     try {
-      await handler(event);
+      const result = await handler(event);
+      if (result) {
+        if (!merged) {
+          merged = {};
+        }
+        if (result.prependContext) {
+          merged.prependContext = merged.prependContext
+            ? `${merged.prependContext}\n\n${result.prependContext}`
+            : result.prependContext;
+        }
+        if (result.systemPrompt !== undefined) {
+          merged.systemPrompt = result.systemPrompt;
+        }
+      }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       log.error(`Hook error [${event.type}:${event.action}]: ${message}`);
     }
   }
+
+  return merged;
 }
 
 /**


### PR DESCRIPTION
## Summary
Bridges three message lifecycle events to the internal workspace hook system via `triggerInternalHook`, enabling workspace hooks (HOOK.md-based) to receive per-message events.

## Events Added
| Event | When | Modifying |
|-------|------|-----------|
| `message:received` | Inbound message parsed | No |
| `message:before` | Before agent processes | Yes (prependContext, systemPrompt) |
| `message:sent` | After response sent | No |

## Motivation
Workspace hooks currently only receive `command:new`, `command:stop`, and `gateway:startup`. Per-message events are dispatched through the plugin hook runner but never bridged to workspace hooks, making them inaccessible without building a full plugin.

This enables use cases like:
- Real-time transcript publishing to NATS/message buses
- Context injection from external knowledge stores
- Sentiment detection and adaptive prompting
- Slack thread context injection (eliminates tool call round-trip)

## Implementation
- Added `"message"` to `InternalHookEventType` union
- Added `InternalHookResult` interface with `prependContext` and `systemPrompt` fields
- Modified `triggerInternalHook` to collect and merge handler results (`prependContext` concatenated with `\n\n`, `systemPrompt` last-wins)
- Three `triggerInternalHook` calls added to the inbound message handling path:
  - `dispatch-from-config.ts`: fire-and-forget `message:received` for channel messages
  - `attempt.ts`: awaited `message:received`, modifying `message:before`, fire-and-forget `message:sent` for agent runner
- `message:before` follows the same modifying pattern as `before_agent_start` in the embedded runner
- No loader changes needed — `src/hooks/loader.ts` already registers handlers for arbitrary event strings from HOOK.md metadata

## Test Plan
- [x] Added 6 new unit tests for result-merging behavior in `internal-hooks.test.ts`
- [x] `pnpm build` passes (pre-existing type errors in discord/memory modules unchanged)
- [x] `pnpm test:fast` — all 4247 tests pass, 0 regressions
- [x] Linter: 0 warnings, 0 errors

Closes #7067, #15442, #14735, #12914, #12867, #8807
Partially addresses #7724, #11485, #10502

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bridges three message lifecycle events (`message:received`, `message:before`, `message:sent`) from the agent runtime into the workspace hook system, enabling HOOK.md-based workspace hooks to observe and modify per-message events. The implementation adds result-merging capabilities to `triggerInternalHook` for modifying hooks, properly handles `prependContext` concatenation and last-wins `systemPrompt` merging, and includes comprehensive test coverage.

The core changes are well-structured and follow existing patterns from the plugin hook system. The `message:before` hook correctly applies both `prependContext` and `systemPrompt` modifications to the session. Test coverage is thorough with 6 new tests covering result merging behavior.

One issue was previously flagged but has since been resolved - the `systemPrompt` field from `message:before` is now properly applied via `applySystemPromptOverrideToSession` (attempt.ts:916-921).

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one minor data mapping issue in the embedded runner path
- The implementation is solid with proper type safety, comprehensive tests (all 4247 passing), and follows existing patterns. The main concern is the incorrect `from` field mapping in attempt.ts which uses `messageTo` instead of sender info, though this doesn't affect core functionality since the field is only used for hook context. The `systemPrompt` application that was previously flagged has been correctly implemented.
- src/agents/pi-embedded-runner/run/attempt.ts requires attention for sender info mapping

<sub>Last reviewed commit: 1a6da0d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->