### PR TITLE
fix(line): allow signatureless empty-events webhook verification

### DIFF
--- a/src/line/signature.test.ts
+++ b/src/line/signature.test.ts
@@ -1,6 +1,6 @@
 import crypto from "node:crypto";
 import { describe, expect, it } from "vitest";
-import { validateLineSignature } from "./signature.js";
+import { hasLineSignatureHeader, validateLineSignature } from "./signature.js";
 
 const sign = (body: string, secret: string) =>
   crypto.createHmac("SHA256", secret).update(body).digest("base64");
@@ -23,5 +23,17 @@ describe("validateLineSignature", () => {
     const rawBody = JSON.stringify({ events: [{ type: "message" }] });
 
     expect(validateLineSignature(rawBody, "short", "secret")).toBe(false);
+  });
+});
+
+describe("hasLineSignatureHeader", () => {
+  it("accepts non-empty string signature headers", () => {
+    expect(hasLineSignatureHeader("abc123")).toBe(true);
+  });
+
+  it("rejects missing or non-string signature headers", () => {
+    expect(hasLineSignatureHeader(undefined)).toBe(false);
+    expect(hasLineSignatureHeader(["abc"])).toBe(false);
+    expect(hasLineSignatureHeader("")).toBe(false);
   });
 });

--- a/src/line/signature.ts
+++ b/src/line/signature.ts
@@ -1,5 +1,11 @@
 import crypto from "node:crypto";
 
+export function hasLineSignatureHeader(
+  signature: string | string[] | undefined,
+): signature is string {
+  return typeof signature === "string" && signature.trim().length > 0;
+}
+
 export function validateLineSignature(
   body: string,
   signature: string,

--- a/src/line/types.ts
+++ b/src/line/types.ts
@@ -81,6 +81,12 @@ export interface LineWebhookContext {
   roomId?: string;
 }
 
+export type LineWebhookEnvelope = {
+  events?: unknown[];
+  destination?: string;
+  [key: string]: unknown;
+};
+
 export interface LineSendResult {
   messageId: string;
   chatId: string;

--- a/src/line/webhook-verification.test.ts
+++ b/src/line/webhook-verification.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { isLineVerificationProbe, parseLineWebhookBody } from "./webhook-verification.js";
+
+describe("parseLineWebhookBody", () => {
+  it("parses valid JSON payloads", () => {
+    const parsed = parseLineWebhookBody(JSON.stringify({ events: [{ type: "message" }] }));
+    expect(parsed).toBeTruthy();
+    expect(parsed?.events?.length).toBe(1);
+  });
+
+  it("returns null for invalid payloads", () => {
+    expect(parseLineWebhookBody("not-json")).toBeNull();
+  });
+});
+
+describe("isLineVerificationProbe", () => {
+  it("returns true for empty events arrays", () => {
+    expect(isLineVerificationProbe({ events: [] })).toBe(true);
+  });
+
+  it("returns false for non-empty events", () => {
+    expect(isLineVerificationProbe({ events: [{ type: "message" }] })).toBe(false);
+  });
+});

--- a/src/line/webhook-verification.ts
+++ b/src/line/webhook-verification.ts
@@ -1,0 +1,16 @@
+import type { WebhookRequestBody } from "@line/bot-sdk";
+import type { LineWebhookEnvelope } from "./types.js";
+
+export function parseLineWebhookBody(rawBody: string): WebhookRequestBody | null {
+  try {
+    return JSON.parse(rawBody) as WebhookRequestBody;
+  } catch {
+    return null;
+  }
+}
+
+export function isLineVerificationProbe(
+  body: WebhookRequestBody | LineWebhookEnvelope | null | undefined,
+): boolean {
+  return Boolean(body && Array.isArray(body.events) && body.events.length === 0);
+}

--- a/src/line/webhook.test.ts
+++ b/src/line/webhook.test.ts
@@ -18,6 +18,26 @@ const createRes = () => {
 };
 
 describe("createLineWebhookMiddleware", () => {
+  it("accepts LINE verification probes with empty events and no signature", async () => {
+    const onEvents = vi.fn(async () => {});
+    const secret = "secret";
+    const rawBody = JSON.stringify({ events: [] });
+    const middleware = createLineWebhookMiddleware({ channelSecret: secret, onEvents });
+
+    const req = {
+      headers: {},
+      body: rawBody,
+      // oxlint-disable-next-line typescript/no-explicit-any
+    } as any;
+    const res = createRes();
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await middleware(req, res, {} as any);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(onEvents).not.toHaveBeenCalled();
+  });
+
   it("parses JSON from raw string body", async () => {
     const onEvents = vi.fn(async () => {});
     const secret = "secret";
@@ -95,6 +115,26 @@ describe("createLineWebhookMiddleware", () => {
     await middleware(req, res, {} as any);
 
     expect(res.status).toHaveBeenCalledWith(401);
+    expect(onEvents).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-empty events payloads when signature is missing", async () => {
+    const onEvents = vi.fn(async () => {});
+    const secret = "secret";
+    const rawBody = JSON.stringify({ events: [{ type: "message" }] });
+    const middleware = createLineWebhookMiddleware({ channelSecret: secret, onEvents });
+
+    const req = {
+      headers: {},
+      body: rawBody,
+      // oxlint-disable-next-line typescript/no-explicit-any
+    } as any;
+    const res = createRes();
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await middleware(req, res, {} as any);
+
+    expect(res.status).toHaveBeenCalledWith(400);
     expect(onEvents).not.toHaveBeenCalled();
   });
 

--- a/src/line/webhook.ts
+++ b/src/line/webhook.ts
@@ -2,7 +2,8 @@ import type { WebhookRequestBody } from "@line/bot-sdk";
 import type { Request, Response, NextFunction } from "express";
 import type { RuntimeEnv } from "../runtime.js";
 import { logVerbose, danger } from "../globals.js";
-import { validateLineSignature } from "./signature.js";
+import { hasLineSignatureHeader, validateLineSignature } from "./signature.js";
+import { isLineVerificationProbe, parseLineWebhookBody } from "./webhook-verification.js";
 
 export interface LineWebhookOptions {
   channelSecret: string;
@@ -20,15 +21,14 @@ function readRawBody(req: Request): string | null {
   return Buffer.isBuffer(rawBody) ? rawBody.toString("utf-8") : rawBody;
 }
 
-function parseWebhookBody(req: Request, rawBody: string): WebhookRequestBody | null {
+function parseWebhookBody(req: Request, rawBody?: string | null): WebhookRequestBody | null {
   if (req.body && typeof req.body === "object" && !Buffer.isBuffer(req.body)) {
     return req.body as WebhookRequestBody;
   }
-  try {
-    return JSON.parse(rawBody) as WebhookRequestBody;
-  } catch {
+  if (!rawBody) {
     return null;
   }
+  return parseLineWebhookBody(rawBody);
 }
 
 export function createLineWebhookMiddleware(
@@ -38,14 +38,24 @@ export function createLineWebhookMiddleware(
 
   return async (req: Request, res: Response, _next: NextFunction): Promise<void> => {
     try {
-      const signature = req.headers["x-line-signature"];
+      const rawBody = readRawBody(req);
+      const body = parseWebhookBody(req, rawBody);
+      if (!body) {
+        res.status(400).json({ error: "Invalid webhook payload" });
+        return;
+      }
 
-      if (!signature || typeof signature !== "string") {
+      if (isLineVerificationProbe(body)) {
+        res.status(200).json({ status: "ok" });
+        return;
+      }
+
+      const signature = req.headers["x-line-signature"];
+      if (!hasLineSignatureHeader(signature)) {
         res.status(400).json({ error: "Missing X-Line-Signature header" });
         return;
       }
 
-      const rawBody = readRawBody(req);
       if (!rawBody) {
         res.status(400).json({ error: "Missing raw request body for signature verification" });
         return;
@@ -54,12 +64,6 @@ export function createLineWebhookMiddleware(
       if (!validateLineSignature(rawBody, signature, channelSecret)) {
         logVerbose("line: webhook signature validation failed");
         res.status(401).json({ error: "Invalid signature" });
-        return;
-      }
-
-      const body = parseWebhookBody(req, rawBody);
-      if (!body) {
-        res.status(400).json({ error: "Invalid webhook payload" });
         return;
       }
 


### PR DESCRIPTION
## Describe your changes
- Classify LINE webhook payloads before signature checks so `events: []` verification probes are handled correctly.
- Bypass signature validation only for empty-events verification probes, while preserving strict signature enforcement for actual event deliveries.
- Reuse shared webhook payload classification helpers across both LINE webhook entrypoints (`monitor` and Express middleware) to keep behavior consistent.

## Screenshot or video (only for visual changes)
- N/A

## GitHub Issue Link (if applicable)
- https://github.com/openclaw/openclaw/issues/16425

## Testing Plan
- Explanation of why no additional tests are needed:
  - Added focused unit tests for verification probe classification and signature-header validation behavior.
- Unit Tests (JS and/or Python):
  - `pnpm test -- src/line/webhook.test.ts src/line/signature.test.ts src/line/webhook-verification.test.ts src/line/monitor.read-body.test.ts`
- E2E Tests:
  - Not run (requires live LINE webhook callbacks).
- Any manual testing needed?:
  - Optional: use LINE Developers Console webhook "Verify" and confirm a clean HTTP 200 response without signature errors.

---
**Contribution License Agreement**
By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
