### PR TITLE
feat: add messages.suppressToolErrors config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 - Discord: allow exec approval prompts to target channels or both DM+channel via `channels.discord.execApprovals.target`. (#16051) Thanks @leonnardo.
 - Sandbox: add `sandbox.browser.binds` to configure browser-container bind mounts separately from exec containers. (#16230) Thanks @seheepeak.
 - Discord: add debug logging for message routing decisions to improve `--debug` tracing. (#16202) Thanks @jayleekr.
+- Agents: add optional `messages.suppressToolErrors` config to hide non-mutating tool-failure warnings from user-facing chat while still surfacing mutating failures. (#16620) Thanks @vai-oro.
 
 ### Fixes
 

--- a/src/agents/pi-embedded-runner/run/payloads.e2e.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.e2e.test.ts
@@ -278,6 +278,42 @@ describe("buildEmbeddedRunPayloads", () => {
     expect(payloads).toHaveLength(0);
   });
 
+  it("suppresses non-mutating non-recoverable tool errors when messages.suppressToolErrors is enabled", () => {
+    const payloads = buildEmbeddedRunPayloads({
+      assistantTexts: [],
+      toolMetas: [],
+      lastAssistant: undefined,
+      lastToolError: { toolName: "browser", error: "connection timeout" },
+      config: { messages: { suppressToolErrors: true } },
+      sessionKey: "session:telegram",
+      inlineToolResultsAllowed: false,
+      verboseLevel: "off",
+      reasoningLevel: "off",
+      toolResultFormat: "plain",
+    });
+
+    expect(payloads).toHaveLength(0);
+  });
+
+  it("still shows mutating tool errors when messages.suppressToolErrors is enabled", () => {
+    const payloads = buildEmbeddedRunPayloads({
+      assistantTexts: [],
+      toolMetas: [],
+      lastAssistant: undefined,
+      lastToolError: { toolName: "write", error: "connection timeout" },
+      config: { messages: { suppressToolErrors: true } },
+      sessionKey: "session:telegram",
+      inlineToolResultsAllowed: false,
+      verboseLevel: "off",
+      reasoningLevel: "off",
+      toolResultFormat: "plain",
+    });
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.isError).toBe(true);
+    expect(payloads[0]?.text).toContain("connection timeout");
+  });
+
   it("shows recoverable tool errors for mutating tools", () => {
     const payloads = buildEmbeddedRunPayloads({
       assistantTexts: [],

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -233,7 +233,9 @@ export function buildEmbeddedRunPayloads(params: {
     const isMutatingToolError =
       params.lastToolError.mutatingAction ??
       isLikelyMutatingToolName(params.lastToolError.toolName);
-    const shouldShowToolError = isMutatingToolError || (!hasUserFacingReply && !isRecoverableError && !params.config?.messages?.suppressToolErrors);
+    const shouldShowToolError =
+      isMutatingToolError ||
+      (!hasUserFacingReply && !isRecoverableError && !params.config?.messages?.suppressToolErrors);
 
     // Always surface mutating tool failures so we do not silently confirm actions that did not happen.
     // Otherwise, keep the previous behavior and only surface non-recoverable failures when no reply exists.

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -233,7 +233,7 @@ export function buildEmbeddedRunPayloads(params: {
     const isMutatingToolError =
       params.lastToolError.mutatingAction ??
       isLikelyMutatingToolName(params.lastToolError.toolName);
-    const shouldShowToolError = isMutatingToolError || (!hasUserFacingReply && !isRecoverableError);
+    const shouldShowToolError = isMutatingToolError || (!hasUserFacingReply && !isRecoverableError && !params.config?.messages?.suppressToolErrors);
 
     // Always surface mutating tool failures so we do not silently confirm actions that did not happen.
     // Otherwise, keep the previous behavior and only surface non-recoverable failures when no reply exists.

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -325,6 +325,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Max reply-back turns between requester and target (0–5).",
   "channels.telegram.customCommands":
     "Additional Telegram bot menu commands (merged with native; conflicts ignored).",
+  "messages.suppressToolErrors":
+    "When true, suppress ⚠️ tool-error warnings from being shown to the user. The agent already sees errors in context and can retry. Default: false.",
   "messages.ackReaction": "Emoji reaction used to acknowledge inbound messages (empty disables).",
   "messages.ackReactionScope":
     'When to send ack reactions ("group-mentions", "group-all", "direct", "all").',

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -219,6 +219,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "browser.remoteCdpHandshakeTimeoutMs": "Remote CDP Handshake Timeout (ms)",
   "session.dmScope": "DM Session Scope",
   "session.agentToAgent.maxPingPongTurns": "Agent-to-Agent Ping-Pong Turns",
+  "messages.suppressToolErrors": "Suppress Tool Error Warnings",
   "messages.ackReaction": "Ack Reaction Emoji",
   "messages.ackReactionScope": "Ack Reaction Scope",
   "messages.inbound.debounceMs": "Inbound Message Debounce (ms)",

--- a/src/config/types.messages.ts
+++ b/src/config/types.messages.ts
@@ -82,6 +82,8 @@ export type MessagesConfig = {
   ackReactionScope?: "group-mentions" | "group-all" | "direct" | "all";
   /** Remove ack reaction after reply is sent (default: false). */
   removeAckAfterReply?: boolean;
+  /** When true, suppress ⚠️ tool-error warnings from being shown to the user. Default: false. */
+  suppressToolErrors?: boolean;
   /** Text-to-speech settings for outbound replies. */
   tts?: TtsConfig;
 };

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -114,6 +114,7 @@ export const MessagesSchema = z
     ackReaction: z.string().optional(),
     ackReactionScope: z.enum(["group-mentions", "group-all", "direct", "all"]).optional(),
     removeAckAfterReply: z.boolean().optional(),
+    suppressToolErrors: z.boolean().optional(),
     tts: TtsConfigSchema,
   })
   .strict()


### PR DESCRIPTION
## Summary

- **Problem:** When a tool call fails and the agent doesn't produce a text response, OpenClaw surfaces a `⚠️ tool failed: ...` warning to the user. However, the agent already sees these errors in its context and typically handles them by retrying or using alternatives. These warnings clutter the chat and confuse end users.
- **Why it matters:** Power users running agents in production want clean chat output. Tool errors are implementation details the agent should handle silently.
- **What changed:** Added a `messages.suppressToolErrors` boolean config option (default: `false`) that prevents non-mutating tool-error warnings from being sent to the user when enabled. Mutating tool errors are always surfaced regardless of this setting.
- **What did NOT change:** Default behavior is unchanged. Mutating tool errors (e.g., failed writes/deletes) are always shown to prevent silent failures on destructive actions.

## Change Type
- [x] Feature

## Scope
- [x] Gateway / orchestration
- [x] UI / DX

## User-visible / Behavior Changes

New config option:
```yaml
messages:
  suppressToolErrors: true
```
When enabled, non-mutating tool error warnings are suppressed from user-facing chat. Default: `false` (no behavior change).

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Verification
- Dogfooded on a production instance for 3+ days with `suppressToolErrors: true`
- Confirmed tool errors still visible to the agent in context (retries work)
- Confirmed mutating tool errors still surface to users
- Confirmed default behavior (option unset) is unchanged

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? New optional field, no migration needed
- Migration needed? No

## Failure Recovery
- Set `messages.suppressToolErrors: false` (or remove the key) to restore default behavior
- No data changes, purely display logic

## Risks and Mitigations
- **Risk:** Users might miss legitimate tool failures if they enable this globally
- **Mitigation:** Mutating tool errors are always shown regardless of setting; option defaults to false; documented clearly

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds `messages.suppressToolErrors` config option to hide non-mutating tool error warnings from users while keeping them visible to the agent. Implementation correctly preserves existing behavior when disabled (default) and ensures mutating tool errors are always surfaced regardless of the setting.

- Added new optional boolean config field to `MessagesConfig` type with clear documentation
- Updated Zod schema validation to include the new field
- Modified error display logic to check the config flag for non-mutating errors only
- Added help text and UI label for the new configuration option
- All changes follow existing patterns and maintain backward compatibility

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a simple, well-contained feature addition that follows existing code patterns. The logic correctly preserves mutating tool errors (preventing silent failures) while only suppressing non-mutating errors when explicitly configured. Default behavior is unchanged, maintaining backward compatibility. All type definitions, schema validations, and documentation are properly aligned.
- No files require special attention

<sub>Last reviewed commit: 674a320</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->