### PR TITLE
feat(web): implement three-tier graduated retry strategy

### DIFF
--- a/src/memory/qmd-scope.ts
+++ b/src/memory/qmd-scope.ts
@@ -44,6 +44,9 @@ export function deriveQmdScopeChatType(key?: string): "channel" | "group" | "dir
 }
 
 function parseQmdSessionScope(key?: string): ParsedQmdSessionScope {
+  if (!key) {
+    return {};
+  }
   const normalized = normalizeQmdSessionKey(key);
   if (!normalized) {
     return {};

--- a/src/web/auto-reply/monitor.ts
+++ b/src/web/auto-reply/monitor.ts
@@ -18,10 +18,12 @@ import { setActiveWebListener } from "../active-listener.js";
 import { monitorWebInbox } from "../inbound.js";
 import {
   computeBackoff,
+  getTierPolicy,
   newConnectionId,
   resolveHeartbeatSeconds,
-  resolveReconnectPolicy,
+  resolveTieredPolicy,
   sleepWithAbort,
+  type TieredReconnectPolicy,
 } from "../reconnect.js";
 import { formatError, getWebAuthAgeMs, readWebSelfId } from "../session.js";
 import { DEFAULT_WEB_MEDIA_BYTES } from "./constants.js";
@@ -93,7 +95,7 @@ export async function monitorWebChannel(
       ? configuredMaxMb * 1024 * 1024
       : DEFAULT_WEB_MEDIA_BYTES;
   const heartbeatSeconds = resolveHeartbeatSeconds(cfg, tuning.heartbeatSeconds);
-  const reconnectPolicy = resolveReconnectPolicy(cfg, tuning.reconnect);
+  const tieredPolicy = resolveTieredPolicy(cfg, tuning.tieredReconnect);
   const baseMentionConfig = buildMentionConfig(cfg);
   const groupHistoryLimit =
     cfg.channels?.whatsapp?.accounts?.[tuning.accountId ?? ""]?.historyLimit ??
@@ -139,6 +141,8 @@ export async function monitorWebChannel(
   process.once("SIGINT", handleSigint);
 
   let reconnectAttempts = 0;
+  let currentTier: 1 | 2 | 3 = 1;
+  let tierAttempts = 0; // Attempts within current tier
 
   while (true) {
     if (stopRequested()) {
@@ -344,7 +348,10 @@ export async function monitorWebChannel(
 
     const uptimeMs = Date.now() - startedAt;
     if (uptimeMs > heartbeatSeconds * 1000) {
-      reconnectAttempts = 0; // Healthy stretch; reset the backoff.
+      // Healthy stretch; reset all retry state.
+      reconnectAttempts = 0;
+      currentTier = 1;
+      tierAttempts = 0;
     }
     status.reconnectAttempts = reconnectAttempts;
     emitStatus();
@@ -401,38 +408,56 @@ export async function monitorWebChannel(
     }
 
     reconnectAttempts += 1;
+    tierAttempts += 1;
     status.reconnectAttempts = reconnectAttempts;
     emitStatus();
-    if (reconnectPolicy.maxAttempts > 0 && reconnectAttempts >= reconnectPolicy.maxAttempts) {
-      reconnectLogger.warn(
-        {
-          connectionId,
-          status: statusCode,
-          reconnectAttempts,
-          maxAttempts: reconnectPolicy.maxAttempts,
-        },
-        "web reconnect: max attempts reached; continuing in degraded mode",
-      );
-      runtime.error(
-        `WhatsApp Web reconnect: max attempts reached (${reconnectAttempts}/${reconnectPolicy.maxAttempts}). Stopping web monitoring.`,
-      );
-      await closeListener();
-      break;
+
+    // Get current tier's policy
+    const currentPolicy = getTierPolicy(tieredPolicy, currentTier);
+
+    // Check if we need to escalate to next tier
+    if (currentPolicy.maxAttempts > 0 && tierAttempts >= currentPolicy.maxAttempts) {
+      if (currentTier < 3) {
+        // Escalate to next tier
+        const previousTier = currentTier;
+        currentTier = (currentTier + 1) as 2 | 3;
+        tierAttempts = 0;
+        const nextPolicy = getTierPolicy(tieredPolicy, currentTier);
+        reconnectLogger.warn(
+          {
+            connectionId,
+            status: statusCode,
+            reconnectAttempts,
+            previousTier,
+            newTier: currentTier,
+            tierMaxAttempts: nextPolicy.maxAttempts || "unlimited",
+          },
+          `web reconnect: escalating from tier ${previousTier} to tier ${currentTier}`,
+        );
+        runtime.error(
+          `WhatsApp Web: tier ${previousTier} exhausted (${currentPolicy.maxAttempts} attempts). Escalating to tier ${currentTier} (${nextPolicy.maxAttempts || "∞"} attempts, ${formatDurationPrecise(nextPolicy.initialMs)}-${formatDurationPrecise(nextPolicy.maxMs)} backoff).`,
+        );
+      }
+      // Tier 3 has unlimited attempts (maxAttempts: 0), so we never break
     }
 
-    const delay = computeBackoff(reconnectPolicy, reconnectAttempts);
+    // Compute delay using current tier's policy
+    const activePolicy = getTierPolicy(tieredPolicy, currentTier);
+    const delay = computeBackoff(activePolicy, tierAttempts);
     reconnectLogger.info(
       {
         connectionId,
         status: statusCode,
         reconnectAttempts,
-        maxAttempts: reconnectPolicy.maxAttempts || "unlimited",
+        tier: currentTier,
+        tierAttempts,
+        maxAttempts: activePolicy.maxAttempts || "unlimited",
         delayMs: delay,
       },
       "web reconnect: scheduling retry",
     );
     runtime.error(
-      `WhatsApp Web connection closed (status ${statusCode}). Retry ${reconnectAttempts}/${reconnectPolicy.maxAttempts || "∞"} in ${formatDurationPrecise(delay)}… (${errorStr})`,
+      `WhatsApp Web connection closed (status ${statusCode}). Tier ${currentTier} retry ${tierAttempts}/${activePolicy.maxAttempts || "∞"} in ${formatDurationPrecise(delay)}… (${errorStr})`,
     );
     await closeListener();
     try {

--- a/src/web/auto-reply/types.ts
+++ b/src/web/auto-reply/types.ts
@@ -1,5 +1,5 @@
 import type { monitorWebInbox } from "../inbound.js";
-import type { ReconnectPolicy } from "../reconnect.js";
+import type { ReconnectPolicy, TieredReconnectPolicy } from "../reconnect.js";
 
 export type WebInboundMsg = Parameters<typeof monitorWebInbox>[0]["onMessage"] extends (
   msg: infer M,
@@ -24,7 +24,10 @@ export type WebChannelStatus = {
 };
 
 export type WebMonitorTuning = {
+  /** @deprecated Use tieredReconnect instead for graduated retry strategy. */
   reconnect?: Partial<ReconnectPolicy>;
+  /** Three-tier graduated retry strategy for resilient connection handling. */
+  tieredReconnect?: Partial<TieredReconnectPolicy>;
   heartbeatSeconds?: number;
   sleep?: (ms: number, signal?: AbortSignal) => Promise<void>;
   statusSink?: (status: WebChannelStatus) => void;

--- a/src/web/reconnect.test.ts
+++ b/src/web/reconnect.test.ts
@@ -4,8 +4,13 @@ import {
   computeBackoff,
   DEFAULT_HEARTBEAT_SECONDS,
   DEFAULT_RECONNECT_POLICY,
+  DEFAULT_TIER1_POLICY,
+  DEFAULT_TIER2_POLICY,
+  DEFAULT_TIER3_POLICY,
+  getTierPolicy,
   resolveHeartbeatSeconds,
   resolveReconnectPolicy,
+  resolveTieredPolicy,
   sleepWithAbort,
 } from "./reconnect.js";
 
@@ -47,5 +52,53 @@ describe("web reconnect helpers", () => {
     const promise = sleepWithAbort(50, controller.signal);
     controller.abort();
     await expect(promise).rejects.toThrow("aborted");
+  });
+
+  describe("tiered reconnect policy", () => {
+    it("returns default tiers when no config provided", () => {
+      const tiered = resolveTieredPolicy(cfg);
+      expect(tiered.tier1.maxAttempts).toBe(DEFAULT_TIER1_POLICY.maxAttempts);
+      expect(tiered.tier2.maxAttempts).toBe(DEFAULT_TIER2_POLICY.maxAttempts);
+      expect(tiered.tier3.maxAttempts).toBe(DEFAULT_TIER3_POLICY.maxAttempts);
+    });
+
+    it("maps legacy reconnect config to tier1", () => {
+      const legacyCfg: OpenClawConfig = {
+        web: { reconnect: { maxAttempts: 5, initialMs: 1000 } },
+      };
+      const tiered = resolveTieredPolicy(legacyCfg);
+      expect(tiered.tier1.maxAttempts).toBe(5);
+      expect(tiered.tier1.initialMs).toBe(1000);
+      // tier2/3 should still have defaults
+      expect(tiered.tier2.maxAttempts).toBe(DEFAULT_TIER2_POLICY.maxAttempts);
+    });
+
+    it("prefers tieredReconnect over legacy reconnect", () => {
+      const mixedCfg: OpenClawConfig = {
+        web: {
+          reconnect: { maxAttempts: 5 },
+          tieredReconnect: { tier1: { maxAttempts: 20 } },
+        } as OpenClawConfig["web"],
+      };
+      const tiered = resolveTieredPolicy(mixedCfg);
+      expect(tiered.tier1.maxAttempts).toBe(20);
+    });
+
+    it("getTierPolicy returns correct tier", () => {
+      const tiered = resolveTieredPolicy(cfg);
+      expect(getTierPolicy(tiered, 1)).toBe(tiered.tier1);
+      expect(getTierPolicy(tiered, 2)).toBe(tiered.tier2);
+      expect(getTierPolicy(tiered, 3)).toBe(tiered.tier3);
+    });
+
+    it("normalizes tier policies with valid bounds", () => {
+      const tiered = resolveTieredPolicy(cfg, {
+        tier1: { initialMs: 50, factor: 0.5, jitter: 5, maxAttempts: -10 },
+      });
+      expect(tiered.tier1.initialMs).toBeGreaterThanOrEqual(250);
+      expect(tiered.tier1.factor).toBeGreaterThanOrEqual(1.1);
+      expect(tiered.tier1.jitter).toBeLessThanOrEqual(1);
+      expect(tiered.tier1.maxAttempts).toBeGreaterThanOrEqual(0);
+    });
   });
 });

--- a/src/web/reconnect.ts
+++ b/src/web/reconnect.ts
@@ -8,13 +8,55 @@ export type ReconnectPolicy = BackoffPolicy & {
   maxAttempts: number;
 };
 
+/**
+ * Three-tier graduated retry strategy for resilient connection handling.
+ *
+ * Tier 1 (Fast): Quick retries for brief network blips (2s-30s)
+ * Tier 2 (Medium): Moderate backoff for extended outages (30s-5min)
+ * Tier 3 (Slow): Patient retries for prolonged issues (5-15min, unlimited)
+ */
+export type TieredReconnectPolicy = {
+  tier1: ReconnectPolicy; // Fast: brief blips
+  tier2: ReconnectPolicy; // Medium: extended outages
+  tier3: ReconnectPolicy; // Slow: prolonged issues (unlimited)
+};
+
 export const DEFAULT_HEARTBEAT_SECONDS = 60;
-export const DEFAULT_RECONNECT_POLICY: ReconnectPolicy = {
+
+// Tier 1: Fast retries for brief network blips
+export const DEFAULT_TIER1_POLICY: ReconnectPolicy = {
   initialMs: 2_000,
   maxMs: 30_000,
   factor: 1.8,
   jitter: 0.25,
   maxAttempts: 12,
+};
+
+// Tier 2: Medium backoff for extended outages
+export const DEFAULT_TIER2_POLICY: ReconnectPolicy = {
+  initialMs: 30_000,
+  maxMs: 300_000, // 5 minutes
+  factor: 1.5,
+  jitter: 0.2,
+  maxAttempts: 10,
+};
+
+// Tier 3: Patient retries for prolonged issues (unlimited attempts)
+export const DEFAULT_TIER3_POLICY: ReconnectPolicy = {
+  initialMs: 300_000, // 5 minutes
+  maxMs: 900_000, // 15 minutes
+  factor: 1.2,
+  jitter: 0.15,
+  maxAttempts: 0, // 0 = unlimited
+};
+
+// Legacy default for backward compatibility
+export const DEFAULT_RECONNECT_POLICY: ReconnectPolicy = DEFAULT_TIER1_POLICY;
+
+export const DEFAULT_TIERED_POLICY: TieredReconnectPolicy = {
+  tier1: DEFAULT_TIER1_POLICY,
+  tier2: DEFAULT_TIER2_POLICY,
+  tier3: DEFAULT_TIER3_POLICY,
 };
 
 export function resolveHeartbeatSeconds(cfg: OpenClawConfig, overrideSeconds?: number): number {
@@ -43,6 +85,49 @@ export function resolveReconnectPolicy(
   merged.jitter = clamp(merged.jitter, 0, 1);
   merged.maxAttempts = Math.max(0, Math.floor(merged.maxAttempts));
   return merged;
+}
+
+/**
+ * Resolve tiered reconnect policy from config with optional overrides.
+ */
+export function resolveTieredPolicy(
+  cfg: OpenClawConfig,
+  overrides?: Partial<TieredReconnectPolicy>,
+): TieredReconnectPolicy {
+  const cfgTiers = (cfg.web as { tieredReconnect?: Partial<TieredReconnectPolicy> })
+    ?.tieredReconnect;
+  return {
+    tier1: normalizePolicy({ ...DEFAULT_TIER1_POLICY, ...cfgTiers?.tier1, ...overrides?.tier1 }),
+    tier2: normalizePolicy({ ...DEFAULT_TIER2_POLICY, ...cfgTiers?.tier2, ...overrides?.tier2 }),
+    tier3: normalizePolicy({ ...DEFAULT_TIER3_POLICY, ...cfgTiers?.tier3, ...overrides?.tier3 }),
+  };
+}
+
+/**
+ * Get the policy for a specific tier (1-3).
+ */
+export function getTierPolicy(tiered: TieredReconnectPolicy, tier: 1 | 2 | 3): ReconnectPolicy {
+  switch (tier) {
+    case 1:
+      return tiered.tier1;
+    case 2:
+      return tiered.tier2;
+    case 3:
+      return tiered.tier3;
+  }
+}
+
+/**
+ * Normalize a reconnect policy to ensure valid values.
+ */
+function normalizePolicy(policy: ReconnectPolicy): ReconnectPolicy {
+  return {
+    initialMs: Math.max(250, policy.initialMs),
+    maxMs: Math.max(policy.initialMs, policy.maxMs),
+    factor: clamp(policy.factor, 1.1, 10),
+    jitter: clamp(policy.jitter, 0, 1),
+    maxAttempts: Math.max(0, Math.floor(policy.maxAttempts)),
+  };
 }
 
 export { computeBackoff, sleepWithAbort };

--- a/src/web/reconnect.ts
+++ b/src/web/reconnect.ts
@@ -96,8 +96,13 @@ export function resolveTieredPolicy(
 ): TieredReconnectPolicy {
   const cfgTiers = (cfg.web as { tieredReconnect?: Partial<TieredReconnectPolicy> })
     ?.tieredReconnect;
+  const legacyReconnect = cfg.web?.reconnect;
+
+  // Map legacy reconnect config to tier1 if tieredReconnect not configured
+  const tier1Base = cfgTiers?.tier1 ?? (cfgTiers ? undefined : legacyReconnect);
+
   return {
-    tier1: normalizePolicy({ ...DEFAULT_TIER1_POLICY, ...cfgTiers?.tier1, ...overrides?.tier1 }),
+    tier1: normalizePolicy({ ...DEFAULT_TIER1_POLICY, ...tier1Base, ...overrides?.tier1 }),
     tier2: normalizePolicy({ ...DEFAULT_TIER2_POLICY, ...cfgTiers?.tier2, ...overrides?.tier2 }),
     tier3: normalizePolicy({ ...DEFAULT_TIER3_POLICY, ...cfgTiers?.tier3, ...overrides?.tier3 }),
   };


### PR DESCRIPTION
## Summary

Implements a three-tier graduated retry strategy for WhatsApp Web connections that prevents the channel from permanently exiting on transient network failures.

**Problem:** When network connectivity is lost (e.g., router reboot, ISP maintenance), the current 12-attempt retry limit is exhausted and the channel exits permanently, requiring manual gateway restart.

**Solution:** Replace single-policy retry with tiered escalation:

| Tier | Attempts | Backoff | Use Case |
|------|----------|---------|----------|
| 1 (Fast) | 12 | 2s → 30s | Brief network blips |
| 2 (Medium) | 10 | 30s → 5min | Extended outages |
| 3 (Slow) | ∞ | 5min → 15min | Prolonged issues |

**Behavior:**
- Escalates to next tier when current tier exhausted
- Resets to Tier 1 after healthy connection (uptime > heartbeat period)
- Channel never permanently exits due to network issues
- Fully backward compatible (legacy config still works)

## Test Plan

- [ ] Unit tests for tiered policy resolution
- [ ] Manual test: disconnect network, verify tier escalation logs
- [ ] Manual test: reconnect after extended outage, verify tier reset
- [ ] Verify backward compatibility with existing `web.reconnect` config

## Related

Also includes a drive-by fix for `qmd-scope.ts` (undefined key handling) that was blocking the build.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements a three-tier graduated retry strategy for WhatsApp Web connections, preventing permanent channel exit on transient network failures. The implementation correctly escalates from fast retries (2-30s, 12 attempts) through medium backoff (30s-5min, 10 attempts) to unlimited patient retries (5-15min). Backward compatibility is properly maintained by mapping legacy `reconnect` config to tier1, and the tier reset after healthy connections ensures the system recovers to fast retries once stable.

Key changes:
- Added `TieredReconnectPolicy` type with three-tier structure in `reconnect.ts`
- Updated `monitor.ts` to track current tier and tier-specific attempt counts
- Implemented tier escalation logic that triggers when tier max attempts are reached
- Added comprehensive unit tests for policy resolution and tier selection
- Drive-by fix: added undefined key guard in `qmd-scope.ts` to prevent build issues

The escalation logic correctly increments counters before checking limits, resets tier attempts to 1 on escalation, and never breaks on tier 3 (unlimited). Previous review concerns about backward compatibility and missing tests have been addressed.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor risk - the logic is sound and well-tested
- Score reflects solid implementation of the tiered retry strategy with proper backward compatibility, comprehensive unit tests, and correct handling of edge cases (unlimited tier 3, tier reset after healthy connection). The logic has been carefully validated through code analysis. Deducted one point because manual testing of tier escalation during actual network failures hasn't been completed yet per the test plan, though the logic itself is correct.
- No files require special attention - all changes are well-structured and follow the existing patterns

<sub>Last reviewed commit: 9346332</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->