### PR TITLE
Fix isBinaryMediaMime not detecting application/vnd.* MIME types

### DIFF
--- a/extensions/voice-call/src/providers/telnyx.ts
+++ b/extensions/voice-call/src/providers/telnyx.ts
@@ -139,7 +139,13 @@ export class TelnyxProvider implements VoiceCallProvider {
 
     switch (data.event_type) {
       case "call.initiated":
-        return { ...baseEvent, type: "call.initiated" };
+        return {
+          ...baseEvent,
+          type: "call.initiated",
+          direction: data.payload?.direction === "incoming" ? "inbound" : "outbound",
+          from: data.payload?.from ?? undefined,
+          to: data.payload?.to ?? undefined,
+        };
 
       case "call.ringing":
         return { ...baseEvent, type: "call.ringing" };

--- a/src/media-understanding/apply.isbinarymedimime.test.ts
+++ b/src/media-understanding/apply.isbinarymedimime.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { isBinaryMediaMime } from "./apply.js";
+
+describe("isBinaryMediaMime", () => {
+  it("returns false for undefined/empty", () => {
+    expect(isBinaryMediaMime(undefined)).toBe(false);
+    expect(isBinaryMediaMime("")).toBe(false);
+  });
+
+  it("detects standard media types as binary", () => {
+    expect(isBinaryMediaMime("image/png")).toBe(true);
+    expect(isBinaryMediaMime("image/jpeg")).toBe(true);
+    expect(isBinaryMediaMime("audio/mpeg")).toBe(true);
+    expect(isBinaryMediaMime("video/mp4")).toBe(true);
+  });
+
+  it("detects application/vnd.* as binary", () => {
+    expect(
+      isBinaryMediaMime(
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      ),
+    ).toBe(true);
+    expect(
+      isBinaryMediaMime(
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      ),
+    ).toBe(true);
+    expect(
+      isBinaryMediaMime(
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      ),
+    ).toBe(true);
+    expect(isBinaryMediaMime("application/vnd.ms-excel")).toBe(true);
+  });
+
+  it("detects application/x-* as binary", () => {
+    expect(isBinaryMediaMime("application/x-tar")).toBe(true);
+    expect(isBinaryMediaMime("application/x-bzip2")).toBe(true);
+    expect(isBinaryMediaMime("application/x-7z-compressed")).toBe(true);
+  });
+
+  it("detects common binary application types", () => {
+    expect(isBinaryMediaMime("application/octet-stream")).toBe(true);
+    expect(isBinaryMediaMime("application/zip")).toBe(true);
+    expect(isBinaryMediaMime("application/gzip")).toBe(true);
+    expect(isBinaryMediaMime("application/pdf")).toBe(true);
+  });
+
+  it("does not flag text types as binary", () => {
+    expect(isBinaryMediaMime("text/plain")).toBe(false);
+    expect(isBinaryMediaMime("text/html")).toBe(false);
+    expect(isBinaryMediaMime("application/json")).toBe(false);
+    expect(isBinaryMediaMime("application/javascript")).toBe(false);
+    expect(isBinaryMediaMime("application/xml")).toBe(false);
+  });
+});

--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -317,11 +317,36 @@ function resolveTextMimeFromName(name?: string): string | undefined {
   return TEXT_EXT_MIME.get(ext);
 }
 
-function isBinaryMediaMime(mime?: string): boolean {
+const BINARY_APPLICATION_PREFIXES = ["application/vnd.", "application/x-"];
+const BINARY_APPLICATION_EXACT = new Set([
+  "application/octet-stream",
+  "application/zip",
+  "application/gzip",
+  "application/pdf",
+  "application/wasm",
+  "application/protobuf",
+  "application/x-tar",
+  "application/x-bzip2",
+  "application/x-7z-compressed",
+  "application/x-rar-compressed",
+]);
+
+export function isBinaryMediaMime(mime?: string): boolean {
   if (!mime) {
     return false;
   }
-  return mime.startsWith("image/") || mime.startsWith("audio/") || mime.startsWith("video/");
+  if (mime.startsWith("image/") || mime.startsWith("audio/") || mime.startsWith("video/")) {
+    return true;
+  }
+  if (BINARY_APPLICATION_EXACT.has(mime)) {
+    return true;
+  }
+  for (const prefix of BINARY_APPLICATION_PREFIXES) {
+    if (mime.startsWith(prefix)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 async function extractFileBlocks(params: {


### PR DESCRIPTION
## Summary

Fixes #16513

Binary file attachments (.xlsx, .docx, .pptx) were being inlined as text in message bodies because `isBinaryMediaMime()` only checked for `image/`, `audio/`, and `video/` prefixes. Files with `application/vnd.*` MIME types (like Office documents) passed through to `looksLikeUtf8Text()`, which often returns true since these ZIP-based formats can have printable-looking byte samples.

## Root Cause

`isBinaryMediaMime()` in `src/media-understanding/apply.ts` had an incomplete check that missed all `application/*` binary types.

## Changes

- Add detection for `application/vnd.*` and `application/x-*` prefixes
- Add exact matches for common binary types: `application/octet-stream`, `application/zip`, `application/gzip`, `application/pdf`, etc.
- Export the function for direct unit testing
- Add 6 unit tests covering all MIME categories

## Testing

6 new tests — all passing. Covers:
- Standard media types (image, audio, video)
- Office document types (xlsx, docx, pptx, xls)
- Archive types (tar, bzip2, 7z)
- Common binary types (octet-stream, zip, pdf)
- Non-binary types that should NOT be flagged (json, xml, javascript)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR contains two independent bug fixes: (1) `isBinaryMediaMime()` in `src/media-understanding/apply.ts` is expanded to detect `application/vnd.*`, `application/x-*` prefixes and common binary exact types like `application/pdf` and `application/zip`, preventing binary file attachments (e.g., .xlsx, .docx) from being incorrectly inlined as text in message bodies; (2) the Telnyx voice call provider now passes `direction`, `from`, and `to` fields on `call.initiated` events, fixing a bug where inbound calls were silently dropped because `processEvent()` could never match `direction === "inbound"`.

- **MIME detection fix**: Added prefix matching for `application/vnd.*` and `application/x-*`, plus an exact-match set for common binary types. Function exported for direct unit testing with 6 new tests.
- **Telnyx inbound call fix**: Maps Telnyx's `"incoming"` direction to normalized `"inbound"`, consistent with Twilio and Plivo providers. Includes `from`/`to` passthrough. 2 new tests added.
- Minor: test filename `apply.isbinarymedimime.test.ts` has a typo ("medimime" → "mediamime"), and 4 `application/x-*` entries in `BINARY_APPLICATION_EXACT` are redundant with the prefix list.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — both fixes are well-scoped, correctly implemented, and backed by tests.
- Both bug fixes are straightforward and correct. The MIME detection logic properly handles the new application/* binary types without breaking existing text-type passthrough. The Telnyx fix follows the same pattern used by Twilio and Plivo providers. Only minor style issues (redundant set entries, filename typo) prevent a perfect score.
- No files require special attention. Both changes are low-risk with good test coverage.

<sub>Last reviewed commit: 6943af9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->