### PR TITLE
Fix isBinaryMediaMime not detecting Office and archive MIME types

### DIFF
--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -317,11 +317,26 @@ function resolveTextMimeFromName(name?: string): string | undefined {
   return TEXT_EXT_MIME.get(ext);
 }
 
-function isBinaryMediaMime(mime?: string): boolean {
+/** Known binary MIME prefixes and exact types that should never be inlined as text. */
+const BINARY_MIME_PREFIXES = ["image/", "audio/", "video/", "application/vnd.", "application/x-"];
+const BINARY_MIME_EXACT = new Set([
+  "application/zip",
+  "application/gzip",
+  "application/octet-stream",
+  "application/pdf",
+  "application/wasm",
+  "application/protobuf",
+  "application/x-tar",
+]);
+
+export function isBinaryMediaMime(mime?: string): boolean {
   if (!mime) {
     return false;
   }
-  return mime.startsWith("image/") || mime.startsWith("audio/") || mime.startsWith("video/");
+  if (BINARY_MIME_PREFIXES.some((prefix) => mime.startsWith(prefix))) {
+    return true;
+  }
+  return BINARY_MIME_EXACT.has(mime);
 }
 
 async function extractFileBlocks(params: {

--- a/src/media-understanding/binary-mime.test.ts
+++ b/src/media-understanding/binary-mime.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { isBinaryMediaMime } from "./apply.js";
+
+describe("isBinaryMediaMime", () => {
+  it("returns false for undefined/empty", () => {
+    expect(isBinaryMediaMime(undefined)).toBe(false);
+    expect(isBinaryMediaMime("")).toBe(false);
+  });
+
+  it("detects image/audio/video as binary", () => {
+    expect(isBinaryMediaMime("image/png")).toBe(true);
+    expect(isBinaryMediaMime("audio/mpeg")).toBe(true);
+    expect(isBinaryMediaMime("video/mp4")).toBe(true);
+  });
+
+  it("detects application/vnd.* as binary (Office formats)", () => {
+    expect(
+      isBinaryMediaMime(
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      ),
+    ).toBe(true);
+    expect(
+      isBinaryMediaMime(
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      ),
+    ).toBe(true);
+    expect(isBinaryMediaMime("application/vnd.ms-excel")).toBe(true);
+  });
+
+  it("detects application/x-* as binary", () => {
+    expect(isBinaryMediaMime("application/x-tar")).toBe(true);
+    expect(isBinaryMediaMime("application/x-7z-compressed")).toBe(true);
+  });
+
+  it("detects exact binary MIME types", () => {
+    expect(isBinaryMediaMime("application/zip")).toBe(true);
+    expect(isBinaryMediaMime("application/gzip")).toBe(true);
+    expect(isBinaryMediaMime("application/octet-stream")).toBe(true);
+    expect(isBinaryMediaMime("application/pdf")).toBe(true);
+    expect(isBinaryMediaMime("application/wasm")).toBe(true);
+  });
+
+  it("allows text types through", () => {
+    expect(isBinaryMediaMime("text/plain")).toBe(false);
+    expect(isBinaryMediaMime("text/html")).toBe(false);
+    expect(isBinaryMediaMime("application/json")).toBe(false);
+    expect(isBinaryMediaMime("application/javascript")).toBe(false);
+    expect(isBinaryMediaMime("application/xml")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #16513

`isBinaryMediaMime()` only checked `image/`, `audio/`, and `video/` prefixes. Binary files with `application/vnd.*` MIME types (xlsx, docx, pptx) passed through to `extractFileBlocks()` where the `looksLikeUtf8Text()` heuristic could match ZIP-based Office formats, causing entire binary files to be decoded as UTF-8 and inlined in the message body.

A single xlsx upload consumed ~250K tokens, exceeded the context limit, and permanently stuck the agent session.

## Changes

- **`apply.ts`**: Expand `isBinaryMediaMime()` to detect `application/vnd.*`, `application/x-*` prefixes and common exact binary types (`application/zip`, `application/gzip`, `application/octet-stream`, `application/pdf`, `application/wasm`, `application/protobuf`, `application/x-tar`).
- **`binary-mime.test.ts`**: 6 unit tests covering all new patterns plus verification that text types (`application/json`, `application/xml`, `text/*`) still pass through.

## Testing

All 6 tests passing. Text-based MIME types like `application/json` and `application/javascript` are correctly not flagged as binary.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixes binary MIME detection to prevent Office/archive files from being incorrectly inlined as UTF-8 text, resolving a context limit overflow issue. However, the implementation has a critical bug: the blanket `application/x-*` prefix incorrectly flags text-based formats (`application/x-yaml`, `application/x-www-form-urlencoded`, `application/x-ndjson`) as binary. The prefix approach should be replaced with an explicit allowlist of binary `application/x-*` types in `BINARY_MIME_EXACT`.

The fix correctly:
- Adds `application/vnd.*` detection for Office formats (xlsx, docx, pptx)
- Adds exact binary types (zip, gzip, pdf, wasm, etc.)
- Includes comprehensive test coverage

The bug will cause YAML files with `application/x-yaml` MIME type (explicitly listed as text in `EXTRA_TEXT_MIMES` at line 54) to be skipped from text extraction, breaking existing functionality.

<h3>Confidence Score: 1/5</h3>

- Critical bug will break text file processing for application/x-yaml and other text-based application/x-* formats
- The blanket `application/x-*` prefix creates a regression by incorrectly classifying text formats as binary. `application/x-yaml` is explicitly defined as a text MIME type in the codebase (line 54) but would be flagged as binary and skipped. This breaks existing functionality and contradicts the codebase's own MIME type definitions. While the PR correctly solves the Office file issue, the overly broad prefix approach introduces a new critical bug.
- src/media-understanding/apply.ts requires immediate fix to replace `application/x-*` prefix with explicit binary types

<sub>Last reviewed commit: 301f6a2</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->