### PR TITLE
feat(feishu_doc): support optional public_access on create

### DIFF
--- a/extensions/feishu/src/doc-schema.ts
+++ b/extensions/feishu/src/doc-schema.ts
@@ -21,6 +21,11 @@ export const FeishuDocSchema = Type.Union([
     action: Type.Literal("create"),
     title: Type.String({ description: "Document title" }),
     folder_token: Type.Optional(Type.String({ description: "Target folder token (optional)" })),
+    public_access: Type.Optional(
+      Type.Union([Type.Literal("read"), Type.Literal("edit")], {
+        description: "Optional public link access level after create",
+      }),
+    ),
   }),
   Type.Object({
     action: Type.Literal("list_blocks"),


### PR DESCRIPTION
## Summary
- feat(feishu_doc): support optional public_access on create
- Split from our `v2026.2.13` patch train as a single-purpose change for easier review.

## Why
- Keep the diff focused and low-risk so it can be merged or reverted independently.

## Scope
- Branch: `feat/feishu-create-public-access-option-en`
- Files changed: 3
- Key files:
  - `extensions/feishu/src/doc-schema.ts`
  - `extensions/feishu/src/docx.test.ts`
  - `extensions/feishu/src/docx.ts`

## Test Plan
- Suggested local command:
  - `./node_modules/.bin/vitest run extensions/feishu/src/docx.test.ts`
- Validation status:
  - [ ] CI checks pass
  - [ ] Maintainer re-ran local tests

## Risk & Rollback
- Risk: low to medium; impact limited to touched module(s).
- Rollback: revert this PR commit(s) cleanly.

## Co-authorship
- Co-authored by @ciberponk and Codex (GPT-5).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added optional `public_access` parameter to the Feishu document creation API, allowing documents to be created with public read or edit permissions in a single operation. The implementation calls `setDocPublicPermission` after successful document creation when `public_access` is specified.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one known limitation documented in previous review thread
- Clean implementation with proper test coverage and schema validation. The change is focused, follows existing patterns, and includes a comprehensive test. Score of 4 (not 5) due to the known partial-failure mode mentioned in the previous review thread where permission setting can fail after document creation.
- No files require special attention beyond the documented limitation

<sub>Last reviewed commit: 06ec2fb</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->