### PR TITLE
refactor(sandbox): add Dockerfile.sandbox-common + smoke

### DIFF
--- a/.github/workflows/sandbox-common-smoke.yml
+++ b/.github/workflows/sandbox-common-smoke.yml
@@ -1,0 +1,56 @@
+name: Sandbox Common Smoke
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - Dockerfile.sandbox
+      - Dockerfile.sandbox-common
+      - scripts/sandbox-common-setup.sh
+  pull_request:
+    paths:
+      - Dockerfile.sandbox
+      - Dockerfile.sandbox-common
+      - scripts/sandbox-common-setup.sh
+
+concurrency:
+  group: sandbox-common-smoke-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  sandbox-common-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: Build minimal sandbox base (USER sandbox)
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          docker build -t openclaw-sandbox-smoke-base:bookworm-slim - <<'EOF'
+          FROM debian:bookworm-slim
+          RUN useradd --create-home --shell /bin/bash sandbox
+          USER sandbox
+          WORKDIR /home/sandbox
+          EOF
+
+      - name: Build sandbox-common image (root for installs, sandbox at runtime)
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          BASE_IMAGE="openclaw-sandbox-smoke-base:bookworm-slim" \
+            TARGET_IMAGE="openclaw-sandbox-common-smoke:bookworm-slim" \
+            PACKAGES="ca-certificates" \
+            INSTALL_PNPM=0 \
+            INSTALL_BUN=0 \
+            INSTALL_BREW=0 \
+            FINAL_USER=sandbox \
+            scripts/sandbox-common-setup.sh
+
+          u="$(docker run --rm openclaw-sandbox-common-smoke:bookworm-slim sh -lc 'id -un')"
+          test "$u" = "sandbox"

--- a/Dockerfile.sandbox-common
+++ b/Dockerfile.sandbox-common
@@ -1,0 +1,45 @@
+ARG BASE_IMAGE=openclaw-sandbox:bookworm-slim
+FROM ${BASE_IMAGE}
+
+USER root
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+ARG PACKAGES="curl wget jq coreutils grep nodejs npm python3 git ca-certificates golang-go rustc cargo unzip pkg-config libasound2-dev build-essential file"
+ARG INSTALL_PNPM=1
+ARG INSTALL_BUN=1
+ARG BUN_INSTALL_DIR=/opt/bun
+ARG INSTALL_BREW=1
+ARG BREW_INSTALL_DIR=/home/linuxbrew/.linuxbrew
+ARG FINAL_USER=sandbox
+
+ENV BUN_INSTALL=${BUN_INSTALL_DIR}
+ENV HOMEBREW_PREFIX=${BREW_INSTALL_DIR}
+ENV HOMEBREW_CELLAR=${BREW_INSTALL_DIR}/Cellar
+ENV HOMEBREW_REPOSITORY=${BREW_INSTALL_DIR}/Homebrew
+ENV PATH=${BUN_INSTALL_DIR}/bin:${BREW_INSTALL_DIR}/bin:${BREW_INSTALL_DIR}/sbin:${PATH}
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ${PACKAGES} \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN if [ "${INSTALL_PNPM}" = "1" ]; then npm install -g pnpm; fi
+
+RUN if [ "${INSTALL_BUN}" = "1" ]; then \
+  curl -fsSL https://bun.sh/install | bash; \
+  ln -sf "${BUN_INSTALL_DIR}/bin/bun" /usr/local/bin/bun; \
+fi
+
+RUN if [ "${INSTALL_BREW}" = "1" ]; then \
+  if ! id -u linuxbrew >/dev/null 2>&1; then useradd -m -s /bin/bash linuxbrew; fi; \
+  mkdir -p "${BREW_INSTALL_DIR}"; \
+  chown -R linuxbrew:linuxbrew "$(dirname "${BREW_INSTALL_DIR}")"; \
+  su - linuxbrew -c "NONINTERACTIVE=1 CI=1 /bin/bash -c '$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)'"; \
+  if [ ! -e "${BREW_INSTALL_DIR}/Library" ]; then ln -s "${BREW_INSTALL_DIR}/Homebrew/Library" "${BREW_INSTALL_DIR}/Library"; fi; \
+  if [ ! -x "${BREW_INSTALL_DIR}/bin/brew" ]; then echo \"brew install failed\"; exit 1; fi; \
+  ln -sf "${BREW_INSTALL_DIR}/bin/brew" /usr/local/bin/brew; \
+fi
+
+# Default is sandbox, but allow BASE_IMAGE overrides to select another final user.
+USER ${FINAL_USER}
+

--- a/scripts/sandbox-common-setup.sh
+++ b/scripts/sandbox-common-setup.sh
@@ -9,6 +9,7 @@ INSTALL_BUN="${INSTALL_BUN:-1}"
 BUN_INSTALL_DIR="${BUN_INSTALL_DIR:-/opt/bun}"
 INSTALL_BREW="${INSTALL_BREW:-1}"
 BREW_INSTALL_DIR="${BREW_INSTALL_DIR:-/home/linuxbrew/.linuxbrew}"
+FINAL_USER="${FINAL_USER:-sandbox}"
 
 if ! docker image inspect "${BASE_IMAGE}" >/dev/null 2>&1; then
   echo "Base image missing: ${BASE_IMAGE}"
@@ -20,44 +21,16 @@ echo "Building ${TARGET_IMAGE} with: ${PACKAGES}"
 
 docker build \
   -t "${TARGET_IMAGE}" \
+  -f Dockerfile.sandbox-common \
+  --build-arg BASE_IMAGE="${BASE_IMAGE}" \
+  --build-arg PACKAGES="${PACKAGES}" \
   --build-arg INSTALL_PNPM="${INSTALL_PNPM}" \
   --build-arg INSTALL_BUN="${INSTALL_BUN}" \
   --build-arg BUN_INSTALL_DIR="${BUN_INSTALL_DIR}" \
   --build-arg INSTALL_BREW="${INSTALL_BREW}" \
   --build-arg BREW_INSTALL_DIR="${BREW_INSTALL_DIR}" \
-  - <<EOF
-FROM ${BASE_IMAGE}
-USER root
-ENV DEBIAN_FRONTEND=noninteractive
-ARG INSTALL_PNPM=1
-ARG INSTALL_BUN=1
-ARG BUN_INSTALL_DIR=/opt/bun
-ARG INSTALL_BREW=1
-ARG BREW_INSTALL_DIR=/home/linuxbrew/.linuxbrew
-ENV BUN_INSTALL=\${BUN_INSTALL_DIR}
-ENV HOMEBREW_PREFIX="\${BREW_INSTALL_DIR}"
-ENV HOMEBREW_CELLAR="\${BREW_INSTALL_DIR}/Cellar"
-ENV HOMEBREW_REPOSITORY="\${BREW_INSTALL_DIR}/Homebrew"
-ENV PATH="\${BUN_INSTALL_DIR}/bin:\${BREW_INSTALL_DIR}/bin:\${BREW_INSTALL_DIR}/sbin:\${PATH}"
-RUN apt-get update \\
-  && apt-get install -y --no-install-recommends ${PACKAGES} \\
-  && rm -rf /var/lib/apt/lists/*
-RUN if [ "\${INSTALL_PNPM}" = "1" ]; then npm install -g pnpm; fi
-RUN if [ "\${INSTALL_BUN}" = "1" ]; then \\
-  curl -fsSL https://bun.sh/install | bash; \\
-  ln -sf "\${BUN_INSTALL_DIR}/bin/bun" /usr/local/bin/bun; \\
-fi
-RUN if [ "\${INSTALL_BREW}" = "1" ]; then \\
-  if ! id -u linuxbrew >/dev/null 2>&1; then useradd -m -s /bin/bash linuxbrew; fi; \\
-  mkdir -p "\${BREW_INSTALL_DIR}"; \\
-  chown -R linuxbrew:linuxbrew "\$(dirname "\${BREW_INSTALL_DIR}")"; \\
-  su - linuxbrew -c "NONINTERACTIVE=1 CI=1 /bin/bash -c '\$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)'"; \\
-  if [ ! -e "\${BREW_INSTALL_DIR}/Library" ]; then ln -s "\${BREW_INSTALL_DIR}/Homebrew/Library" "\${BREW_INSTALL_DIR}/Library"; fi; \\
-  if [ ! -x "\${BREW_INSTALL_DIR}/bin/brew" ]; then echo "brew install failed"; exit 1; fi; \\
-  ln -sf "\${BREW_INSTALL_DIR}/bin/brew" /usr/local/bin/brew; \\
-fi
-USER sandbox
-EOF
+  --build-arg FINAL_USER="${FINAL_USER}" \
+  .
 
 cat <<NOTE
 Built ${TARGET_IMAGE}.


### PR DESCRIPTION
- Move sandbox-common docker build logic into Dockerfile.sandbox-common (no heredoc).
- Add FINAL_USER build arg/env (default sandbox) for BASE_IMAGE overrides.
- Add CI smoke that builds a minimal USER sandbox base, then builds sandbox-common and asserts runtime user is sandbox.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Refactors sandbox-common Docker build by extracting the inline heredoc Dockerfile into a dedicated `Dockerfile.sandbox-common` file, improving maintainability and allowing better IDE support. Adds `FINAL_USER` build arg (defaults to `sandbox`) to support BASE_IMAGE overrides with different user configurations. Includes comprehensive CI smoke test that validates the build process and asserts the runtime user is correctly set.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Clean refactoring that extracts heredoc Dockerfile logic into a proper file without changing functionality. The CI smoke test validates the build process and runtime user assertion. No breaking changes, security issues, or logical errors detected.
- No files require special attention

<sub>Last reviewed commit: 98d0a8a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->