### PR TITLE
feat/memory lancedb configurable capture limit en

### DIFF
--- a/.github/workflows/sandbox-common-smoke.yml
+++ b/.github/workflows/sandbox-common-smoke.yml
@@ -1,0 +1,56 @@
+name: Sandbox Common Smoke
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - Dockerfile.sandbox
+      - Dockerfile.sandbox-common
+      - scripts/sandbox-common-setup.sh
+  pull_request:
+    paths:
+      - Dockerfile.sandbox
+      - Dockerfile.sandbox-common
+      - scripts/sandbox-common-setup.sh
+
+concurrency:
+  group: sandbox-common-smoke-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  sandbox-common-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: Build minimal sandbox base (USER sandbox)
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          docker build -t openclaw-sandbox-smoke-base:bookworm-slim - <<'EOF'
+          FROM debian:bookworm-slim
+          RUN useradd --create-home --shell /bin/bash sandbox
+          USER sandbox
+          WORKDIR /home/sandbox
+          EOF
+
+      - name: Build sandbox-common image (root for installs, sandbox at runtime)
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          BASE_IMAGE="openclaw-sandbox-smoke-base:bookworm-slim" \
+            TARGET_IMAGE="openclaw-sandbox-common-smoke:bookworm-slim" \
+            PACKAGES="ca-certificates" \
+            INSTALL_PNPM=0 \
+            INSTALL_BUN=0 \
+            INSTALL_BREW=0 \
+            FINAL_USER=sandbox \
+            scripts/sandbox-common-setup.sh
+
+          u="$(docker run --rm openclaw-sandbox-common-smoke:bookworm-slim sh -lc 'id -un')"
+          test "$u" = "sandbox"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,7 @@ Docs: https://docs.openclaw.ai
 - Telegram: scope skill commands to the resolved agent for default accounts so `setMyCommands` no longer triggers `BOT_COMMANDS_TOO_MUCH` when multiple agents are configured. (#15599)
 - Discord: avoid misrouting numeric guild allowlist entries to `/channels/<guildId>` by prefixing guild-only inputs with `guild:` during resolution. (#12326) Thanks @headswim.
 - Memory/QMD: default `memory.qmd.searchMode` to `search` for faster CPU-only recall and always scope `search`/`vsearch` requests to managed collections (auto-falling back to `query` when required). (#16047) Thanks @togotago.
+- Memory/LanceDB: add configurable `captureMaxChars` for auto-capture while keeping the legacy 500-char default. (#16641) Thanks @ciberponk.
 - MS Teams: preserve parsed mention entities/text when appending OneDrive fallback file links, and accept broader real-world Teams mention ID formats (`29:...`, `8:orgid:...`) while still rejecting placeholder patterns. (#15436) Thanks @hyojin.
 - Media: classify `text/*` MIME types as documents in media-kind routing so text attachments are no longer treated as unknown. (#12237) Thanks @arosstale.
 - Inbound/Web UI: preserve literal `\n` sequences when normalizing inbound text so Windows paths like `C:\\Work\\nxxx\\README.md` are not corrupted. (#11547) Thanks @mcaxtr.

--- a/Dockerfile.sandbox-common
+++ b/Dockerfile.sandbox-common
@@ -1,0 +1,45 @@
+ARG BASE_IMAGE=openclaw-sandbox:bookworm-slim
+FROM ${BASE_IMAGE}
+
+USER root
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+ARG PACKAGES="curl wget jq coreutils grep nodejs npm python3 git ca-certificates golang-go rustc cargo unzip pkg-config libasound2-dev build-essential file"
+ARG INSTALL_PNPM=1
+ARG INSTALL_BUN=1
+ARG BUN_INSTALL_DIR=/opt/bun
+ARG INSTALL_BREW=1
+ARG BREW_INSTALL_DIR=/home/linuxbrew/.linuxbrew
+ARG FINAL_USER=sandbox
+
+ENV BUN_INSTALL=${BUN_INSTALL_DIR}
+ENV HOMEBREW_PREFIX=${BREW_INSTALL_DIR}
+ENV HOMEBREW_CELLAR=${BREW_INSTALL_DIR}/Cellar
+ENV HOMEBREW_REPOSITORY=${BREW_INSTALL_DIR}/Homebrew
+ENV PATH=${BUN_INSTALL_DIR}/bin:${BREW_INSTALL_DIR}/bin:${BREW_INSTALL_DIR}/sbin:${PATH}
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ${PACKAGES} \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN if [ "${INSTALL_PNPM}" = "1" ]; then npm install -g pnpm; fi
+
+RUN if [ "${INSTALL_BUN}" = "1" ]; then \
+  curl -fsSL https://bun.sh/install | bash; \
+  ln -sf "${BUN_INSTALL_DIR}/bin/bun" /usr/local/bin/bun; \
+fi
+
+RUN if [ "${INSTALL_BREW}" = "1" ]; then \
+  if ! id -u linuxbrew >/dev/null 2>&1; then useradd -m -s /bin/bash linuxbrew; fi; \
+  mkdir -p "${BREW_INSTALL_DIR}"; \
+  chown -R linuxbrew:linuxbrew "$(dirname "${BREW_INSTALL_DIR}")"; \
+  su - linuxbrew -c "NONINTERACTIVE=1 CI=1 /bin/bash -c '$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)'"; \
+  if [ ! -e "${BREW_INSTALL_DIR}/Library" ]; then ln -s "${BREW_INSTALL_DIR}/Homebrew/Library" "${BREW_INSTALL_DIR}/Library"; fi; \
+  if [ ! -x "${BREW_INSTALL_DIR}/bin/brew" ]; then echo \"brew install failed\"; exit 1; fi; \
+  ln -sf "${BREW_INSTALL_DIR}/bin/brew" /usr/local/bin/brew; \
+fi
+
+# Default is sandbox, but allow BASE_IMAGE overrides to select another final user.
+USER ${FINAL_USER}
+

--- a/extensions/memory-lancedb/config.ts
+++ b/extensions/memory-lancedb/config.ts
@@ -11,12 +11,14 @@ export type MemoryConfig = {
   dbPath?: string;
   autoCapture?: boolean;
   autoRecall?: boolean;
+  captureMaxChars?: number;
 };
 
 export const MEMORY_CATEGORIES = ["preference", "fact", "decision", "entity", "other"] as const;
 export type MemoryCategory = (typeof MEMORY_CATEGORIES)[number];
 
 const DEFAULT_MODEL = "text-embedding-3-small";
+const DEFAULT_CAPTURE_MAX_CHARS = 1500;
 const LEGACY_STATE_DIRS: string[] = [];
 
 function resolveDefaultDbPath(): string {
@@ -89,7 +91,11 @@ export const memoryConfigSchema = {
       throw new Error("memory config required");
     }
     const cfg = value as Record<string, unknown>;
-    assertAllowedKeys(cfg, ["embedding", "dbPath", "autoCapture", "autoRecall"], "memory config");
+    assertAllowedKeys(
+      cfg,
+      ["embedding", "dbPath", "autoCapture", "autoRecall", "captureMaxChars"],
+      "memory config",
+    );
 
     const embedding = cfg.embedding as Record<string, unknown> | undefined;
     if (!embedding || typeof embedding.apiKey !== "string") {
@@ -98,6 +104,15 @@ export const memoryConfigSchema = {
     assertAllowedKeys(embedding, ["apiKey", "model"], "embedding config");
 
     const model = resolveEmbeddingModel(embedding);
+
+    const captureMaxChars =
+      typeof cfg.captureMaxChars === "number" ? Math.floor(cfg.captureMaxChars) : undefined;
+    if (
+      typeof captureMaxChars === "number" &&
+      (captureMaxChars < 100 || captureMaxChars > 10_000)
+    ) {
+      throw new Error("captureMaxChars must be between 100 and 10000");
+    }
 
     return {
       embedding: {
@@ -108,6 +123,7 @@ export const memoryConfigSchema = {
       dbPath: typeof cfg.dbPath === "string" ? cfg.dbPath : DEFAULT_DB_PATH,
       autoCapture: cfg.autoCapture !== false,
       autoRecall: cfg.autoRecall !== false,
+      captureMaxChars: captureMaxChars ?? DEFAULT_CAPTURE_MAX_CHARS,
     };
   },
   uiHints: {
@@ -134,6 +150,12 @@ export const memoryConfigSchema = {
     autoRecall: {
       label: "Auto-Recall",
       help: "Automatically inject relevant memories into context",
+    },
+    captureMaxChars: {
+      label: "Capture Max Chars",
+      help: "Maximum message length eligible for auto-capture",
+      advanced: true,
+      placeholder: String(DEFAULT_CAPTURE_MAX_CHARS),
     },
   },
 };

--- a/extensions/memory-lancedb/config.ts
+++ b/extensions/memory-lancedb/config.ts
@@ -18,7 +18,7 @@ export const MEMORY_CATEGORIES = ["preference", "fact", "decision", "entity", "o
 export type MemoryCategory = (typeof MEMORY_CATEGORIES)[number];
 
 const DEFAULT_MODEL = "text-embedding-3-small";
-const DEFAULT_CAPTURE_MAX_CHARS = 1500;
+export const DEFAULT_CAPTURE_MAX_CHARS = 500;
 const LEGACY_STATE_DIRS: string[] = [];
 
 function resolveDefaultDbPath(): string {

--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -61,7 +61,7 @@ describe("memory plugin e2e", () => {
     expect(config).toBeDefined();
     expect(config?.embedding?.apiKey).toBe(OPENAI_API_KEY);
     expect(config?.dbPath).toBe(dbPath);
-    expect(config?.captureMaxChars).toBe(1500);
+    expect(config?.captureMaxChars).toBe(500);
   });
 
   test("config schema resolves env vars", async () => {
@@ -105,6 +105,21 @@ describe("memory plugin e2e", () => {
     }).toThrow("captureMaxChars must be between 100 and 10000");
   });
 
+  test("config schema accepts captureMaxChars override", async () => {
+    const { default: memoryPlugin } = await import("./index.js");
+
+    const config = memoryPlugin.configSchema?.parse?.({
+      embedding: {
+        apiKey: OPENAI_API_KEY,
+        model: "text-embedding-3-small",
+      },
+      dbPath,
+      captureMaxChars: 1800,
+    });
+
+    expect(config?.captureMaxChars).toBe(1800);
+  });
+
   test("shouldCapture applies real capture rules", async () => {
     const { shouldCapture } = await import("./index.js");
 
@@ -117,10 +132,14 @@ describe("memory plugin e2e", () => {
     expect(shouldCapture("<relevant-memories>injected</relevant-memories>")).toBe(false);
     expect(shouldCapture("<system>status</system>")).toBe(false);
     expect(shouldCapture("Here is a short **summary**\n- bullet")).toBe(false);
-    const longButAllowed = `I always prefer this style. ${"x".repeat(1200)}`;
-    const tooLong = `I always prefer this style. ${"x".repeat(1600)}`;
-    expect(shouldCapture(longButAllowed, { maxChars: 1500 })).toBe(true);
-    expect(shouldCapture(tooLong, { maxChars: 1500 })).toBe(false);
+    const defaultAllowed = `I always prefer this style. ${"x".repeat(400)}`;
+    const defaultTooLong = `I always prefer this style. ${"x".repeat(600)}`;
+    expect(shouldCapture(defaultAllowed)).toBe(true);
+    expect(shouldCapture(defaultTooLong)).toBe(false);
+    const customAllowed = `I always prefer this style. ${"x".repeat(1200)}`;
+    const customTooLong = `I always prefer this style. ${"x".repeat(1600)}`;
+    expect(shouldCapture(customAllowed, { maxChars: 1500 })).toBe(true);
+    expect(shouldCapture(customTooLong, { maxChars: 1500 })).toBe(false);
   });
 
   test("detectCategory classifies using production logic", async () => {

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -194,8 +194,9 @@ const MEMORY_TRIGGERS = [
   /always|never|important/i,
 ];
 
-export function shouldCapture(text: string): boolean {
-  if (text.length < 10 || text.length > 500) {
+export function shouldCapture(text: string, options?: { maxChars?: number }): boolean {
+  const maxChars = options?.maxChars ?? 1500;
+  if (text.length < 10 || text.length > maxChars) {
     return false;
   }
   // Skip injected context from memory recall
@@ -570,7 +571,9 @@ const memoryPlugin = {
           }
 
           // Filter for capturable content
-          const toCapture = texts.filter((text) => text && shouldCapture(text));
+          const toCapture = texts.filter(
+            (text) => text && shouldCapture(text, { maxChars: cfg.captureMaxChars }),
+          );
           if (toCapture.length === 0) {
             return;
           }

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -12,6 +12,7 @@ import { Type } from "@sinclair/typebox";
 import { randomUUID } from "node:crypto";
 import OpenAI from "openai";
 import {
+  DEFAULT_CAPTURE_MAX_CHARS,
   MEMORY_CATEGORIES,
   type MemoryCategory,
   memoryConfigSchema,
@@ -195,7 +196,7 @@ const MEMORY_TRIGGERS = [
 ];
 
 export function shouldCapture(text: string, options?: { maxChars?: number }): boolean {
-  const maxChars = options?.maxChars ?? 1500;
+  const maxChars = options?.maxChars ?? DEFAULT_CAPTURE_MAX_CHARS;
   if (text.length < 10 || text.length > maxChars) {
     return false;
   }

--- a/extensions/memory-lancedb/openclaw.plugin.json
+++ b/extensions/memory-lancedb/openclaw.plugin.json
@@ -25,6 +25,12 @@
     "autoRecall": {
       "label": "Auto-Recall",
       "help": "Automatically inject relevant memories into context"
+    },
+    "captureMaxChars": {
+      "label": "Capture Max Chars",
+      "help": "Maximum message length eligible for auto-capture",
+      "advanced": true,
+      "placeholder": "1500"
     }
   },
   "configSchema": {
@@ -53,6 +59,11 @@
       },
       "autoRecall": {
         "type": "boolean"
+      },
+      "captureMaxChars": {
+        "type": "number",
+        "minimum": 100,
+        "maximum": 10000
       }
     },
     "required": ["embedding"]

--- a/extensions/memory-lancedb/openclaw.plugin.json
+++ b/extensions/memory-lancedb/openclaw.plugin.json
@@ -30,7 +30,7 @@
       "label": "Capture Max Chars",
       "help": "Maximum message length eligible for auto-capture",
       "advanced": true,
-      "placeholder": "1500"
+      "placeholder": "500"
     }
   },
   "configSchema": {

--- a/scripts/sandbox-common-setup.sh
+++ b/scripts/sandbox-common-setup.sh
@@ -9,6 +9,7 @@ INSTALL_BUN="${INSTALL_BUN:-1}"
 BUN_INSTALL_DIR="${BUN_INSTALL_DIR:-/opt/bun}"
 INSTALL_BREW="${INSTALL_BREW:-1}"
 BREW_INSTALL_DIR="${BREW_INSTALL_DIR:-/home/linuxbrew/.linuxbrew}"
+FINAL_USER="${FINAL_USER:-sandbox}"
 
 if ! docker image inspect "${BASE_IMAGE}" >/dev/null 2>&1; then
   echo "Base image missing: ${BASE_IMAGE}"
@@ -20,44 +21,16 @@ echo "Building ${TARGET_IMAGE} with: ${PACKAGES}"
 
 docker build \
   -t "${TARGET_IMAGE}" \
+  -f Dockerfile.sandbox-common \
+  --build-arg BASE_IMAGE="${BASE_IMAGE}" \
+  --build-arg PACKAGES="${PACKAGES}" \
   --build-arg INSTALL_PNPM="${INSTALL_PNPM}" \
   --build-arg INSTALL_BUN="${INSTALL_BUN}" \
   --build-arg BUN_INSTALL_DIR="${BUN_INSTALL_DIR}" \
   --build-arg INSTALL_BREW="${INSTALL_BREW}" \
   --build-arg BREW_INSTALL_DIR="${BREW_INSTALL_DIR}" \
-  - <<EOF
-FROM ${BASE_IMAGE}
-USER root
-ENV DEBIAN_FRONTEND=noninteractive
-ARG INSTALL_PNPM=1
-ARG INSTALL_BUN=1
-ARG BUN_INSTALL_DIR=/opt/bun
-ARG INSTALL_BREW=1
-ARG BREW_INSTALL_DIR=/home/linuxbrew/.linuxbrew
-ENV BUN_INSTALL=\${BUN_INSTALL_DIR}
-ENV HOMEBREW_PREFIX="\${BREW_INSTALL_DIR}"
-ENV HOMEBREW_CELLAR="\${BREW_INSTALL_DIR}/Cellar"
-ENV HOMEBREW_REPOSITORY="\${BREW_INSTALL_DIR}/Homebrew"
-ENV PATH="\${BUN_INSTALL_DIR}/bin:\${BREW_INSTALL_DIR}/bin:\${BREW_INSTALL_DIR}/sbin:\${PATH}"
-RUN apt-get update \\
-  && apt-get install -y --no-install-recommends ${PACKAGES} \\
-  && rm -rf /var/lib/apt/lists/*
-RUN if [ "\${INSTALL_PNPM}" = "1" ]; then npm install -g pnpm; fi
-RUN if [ "\${INSTALL_BUN}" = "1" ]; then \\
-  curl -fsSL https://bun.sh/install | bash; \\
-  ln -sf "\${BUN_INSTALL_DIR}/bin/bun" /usr/local/bin/bun; \\
-fi
-RUN if [ "\${INSTALL_BREW}" = "1" ]; then \\
-  if ! id -u linuxbrew >/dev/null 2>&1; then useradd -m -s /bin/bash linuxbrew; fi; \\
-  mkdir -p "\${BREW_INSTALL_DIR}"; \\
-  chown -R linuxbrew:linuxbrew "\$(dirname "\${BREW_INSTALL_DIR}")"; \\
-  su - linuxbrew -c "NONINTERACTIVE=1 CI=1 /bin/bash -c '\$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)'"; \\
-  if [ ! -e "\${BREW_INSTALL_DIR}/Library" ]; then ln -s "\${BREW_INSTALL_DIR}/Homebrew/Library" "\${BREW_INSTALL_DIR}/Library"; fi; \\
-  if [ ! -x "\${BREW_INSTALL_DIR}/bin/brew" ]; then echo "brew install failed"; exit 1; fi; \\
-  ln -sf "\${BREW_INSTALL_DIR}/bin/brew" /usr/local/bin/brew; \\
-fi
-USER sandbox
-EOF
+  --build-arg FINAL_USER="${FINAL_USER}" \
+  .
 
 cat <<NOTE
 Built ${TARGET_IMAGE}.


### PR DESCRIPTION
- **feat(memory-lancedb): make auto-capture max length configurable**
- **Memory-lancedb: configurable capture limit (#16624) (thanks @ciberponk)**

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Added configurable `captureMaxChars` parameter to control the maximum message length eligible for auto-capture in the memory-lancedb plugin. The implementation adds validation (100-10,000 range), defaults to 500 characters, and properly threads the configuration through the config schema, plugin JSON schema, and the `shouldCapture` function. Tests cover default behavior, validation, and custom values.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is clean, well-tested, and follows existing patterns. All changes are additive (no breaking changes), validation is properly implemented, and comprehensive test coverage has been added for the new functionality.
- No files require special attention

<sub>Last reviewed commit: f393026</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->