### PR TITLE
feat(feishu_doc): allow optional initial content on create

### DIFF
--- a/extensions/feishu/src/doc-schema.ts
+++ b/extensions/feishu/src/doc-schema.ts
@@ -21,6 +21,11 @@ export const FeishuDocSchema = Type.Union([
     action: Type.Literal("create"),
     title: Type.String({ description: "Document title" }),
     folder_token: Type.Optional(Type.String({ description: "Target folder token (optional)" })),
+    content: Type.Optional(
+      Type.String({
+        description: "Optional markdown content to write right after document creation",
+      }),
+    ),
   }),
   Type.Object({
     action: Type.Literal("list_blocks"),

--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -483,8 +483,19 @@ export function registerFeishuDocTools(api: OpenClawPluginApi) {
                 return json(await writeDoc(client, p.doc_token, p.content, mediaMaxBytes));
               case "append":
                 return json(await appendDoc(client, p.doc_token, p.content, mediaMaxBytes));
-              case "create":
-                return json(await createDoc(client, p.title, p.folder_token));
+              case "create": {
+                const created = await createDoc(client, p.title, p.folder_token);
+                if (p.content && created.document_id) {
+                  const writeResult = await writeDoc(
+                    client,
+                    created.document_id,
+                    p.content,
+                    mediaMaxBytes,
+                  );
+                  return json({ ...created, write_result: writeResult });
+                }
+                return json(created);
+              }
               case "list_blocks":
                 return json(await listBlocks(client, p.doc_token));
               case "get_block":


### PR DESCRIPTION
## Summary
- feat(feishu_doc): allow optional initial content on create
- Split from our `v2026.2.13` patch train as a single-purpose change for easier review.

## Why
- Keep the diff focused and low-risk so it can be merged or reverted independently.

## Scope
- Branch: `feat/feishu-create-with-content-en`
- Files changed: 3
- Key files:
  - `extensions/feishu/src/doc-schema.ts`
  - `extensions/feishu/src/docx.test.ts`
  - `extensions/feishu/src/docx.ts`

## Test Plan
- Suggested local command:
  - `./node_modules/.bin/vitest run extensions/feishu/src/docx.test.ts`
- Validation status:
  - [ ] CI checks pass
  - [ ] Maintainer re-ran local tests

## Risk & Rollback
- Risk: low to medium; impact limited to touched module(s).
- Rollback: revert this PR commit(s) cleanly.

## Co-authorship
- Co-authored by @ciberponk and Codex (GPT-5).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added optional `content` parameter to the `create` action in `feishu_doc` tool, allowing users to create a document and write initial content in a single operation. When `content` is provided, the implementation creates the document via `createDoc`, then immediately calls `writeDoc` to populate it.

- Added `content: Type.Optional(Type.String(...))` to the create action schema
- Modified create case handler to conditionally call `writeDoc` and merge results  
- Added test coverage for the happy path scenario

Critical issue: if `writeDoc` throws after `createDoc` succeeds, the error propagates to the outer catch block which returns only `{ error: "..." }`, losing the `document_id` of the already-created document. This makes recovery difficult.

<h3>Confidence Score: 3/5</h3>

- Safe to merge with known limitation in error handling
- The feature implementation is straightforward and the happy path works correctly. However, the error handling issue where `document_id` is lost when `writeDoc` fails after successful `createDoc` is a functional defect that could make debugging and recovery difficult. The PR is low-risk for breaking existing functionality since it only adds an optional parameter, but the error handling gap prevents a higher score.
- extensions/feishu/src/docx.ts requires error handling improvement for the create-with-content flow

<sub>Last reviewed commit: 70aa36a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->