### PR TITLE
fix(voice-call): pass direction, from, to fields in Telnyx call.initiated events

### DIFF
--- a/extensions/voice-call/src/providers/telnyx.test.ts
+++ b/extensions/voice-call/src/providers/telnyx.test.ts
@@ -22,6 +22,66 @@ function decodeBase64Url(input: string): Buffer {
   return Buffer.from(padded, "base64");
 }
 
+describe("TelnyxProvider.parseWebhookEvent", () => {
+  it("includes direction, from, and to fields for call.initiated events", () => {
+    const provider = new TelnyxProvider(
+      { apiKey: "KEY123", connectionId: "CONN456", publicKey: undefined },
+      { skipVerification: true },
+    );
+
+    const rawBody = JSON.stringify({
+      data: {
+        id: "evt_123",
+        event_type: "call.initiated",
+        payload: {
+          call_control_id: "call_abc",
+          direction: "incoming",
+          from: "+15551234567",
+          to: "+15559876543",
+          client_state: "",
+        },
+      },
+    });
+
+    const result = provider.parseWebhookEvent(createCtx({ rawBody }));
+
+    expect(result.events).toHaveLength(1);
+    const event = result.events[0];
+    expect(event?.type).toBe("call.initiated");
+    // Telnyx sends "incoming" which should be normalized to "inbound"
+    expect(event?.direction).toBe("inbound");
+    expect(event?.from).toBe("+15551234567");
+    expect(event?.to).toBe("+15559876543");
+  });
+
+  it("normalizes outgoing direction to outbound", () => {
+    const provider = new TelnyxProvider(
+      { apiKey: "KEY123", connectionId: "CONN456", publicKey: undefined },
+      { skipVerification: true },
+    );
+
+    const rawBody = JSON.stringify({
+      data: {
+        id: "evt_456",
+        event_type: "call.initiated",
+        payload: {
+          call_control_id: "call_def",
+          direction: "outgoing",
+          from: "+15559876543",
+          to: "+15551234567",
+          client_state: "",
+        },
+      },
+    });
+
+    const result = provider.parseWebhookEvent(createCtx({ rawBody }));
+
+    expect(result.events).toHaveLength(1);
+    const event = result.events[0];
+    expect(event?.direction).toBe("outbound");
+  });
+});
+
 describe("TelnyxProvider.verifyWebhook", () => {
   it("fails closed when public key is missing and skipVerification is false", () => {
     const provider = new TelnyxProvider(

--- a/extensions/voice-call/src/providers/telnyx.ts
+++ b/extensions/voice-call/src/providers/telnyx.ts
@@ -139,7 +139,18 @@ export class TelnyxProvider implements VoiceCallProvider {
 
     switch (data.event_type) {
       case "call.initiated":
-        return { ...baseEvent, type: "call.initiated" };
+        return {
+          ...baseEvent,
+          type: "call.initiated",
+          direction:
+            data.payload?.direction === "incoming"
+              ? "inbound"
+              : data.payload?.direction === "outgoing"
+                ? "outbound"
+                : undefined,
+          from: data.payload?.from,
+          to: data.payload?.to,
+        };
 
       case "call.ringing":
         return { ...baseEvent, type: "call.ringing" };

--- a/extensions/voice-call/src/providers/telnyx.ts
+++ b/extensions/voice-call/src/providers/telnyx.ts
@@ -148,8 +148,8 @@ export class TelnyxProvider implements VoiceCallProvider {
               : data.payload?.direction === "outgoing"
                 ? "outbound"
                 : undefined,
-          from: data.payload?.from,
-          to: data.payload?.to,
+          from: data.payload?.from as string | undefined,
+          to: data.payload?.to as string | undefined,
         };
 
       case "call.ringing":


### PR DESCRIPTION
## Summary

Fixes #16601 - Inbound voice calls via Telnyx were being silently dropped.

## Problem

The `normalizeEvent` method for `call.initiated` events was not passing through the `direction`, `from`, and `to` fields from the Telnyx webhook payload. Without `direction: "inbound"`, `processEvent` could not identify inbound calls and silently discarded them.

Additionally, Telnyx sends `direction` as `"incoming"`/`"outgoing"` while the normalized schema expects `"inbound"`/`"outbound"`, requiring a mapping.

## Solution

1. Pass `direction`, `from`, and `to` from `data.payload` in the `call.initiated` event
2. Map Telnyx's `"incoming"` → `"inbound"` and `"outgoing"` → `"outbound"`

## Testing

- Added test for inbound direction normalization
- Added test for outbound direction normalization
- All existing tests pass

## Checklist

- [x] Tests added
- [x] Lint passes
- [x] Types check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed critical bug where inbound Telnyx voice calls were silently dropped due to missing `direction`, `from`, and `to` fields in `call.initiated` events. The fix maps Telnyx's `"incoming"`/`"outgoing"` direction values to the normalized `"inbound"`/`"outbound"` format expected by the event processor.

- Added `direction`, `from`, and `to` field extraction from Telnyx webhook payload
- Implemented direction mapping: `"incoming"` → `"inbound"`, `"outgoing"` → `"outbound"`
- Added comprehensive tests for both inbound and outbound direction normalization
- Used type casts for TypeScript compatibility with the generic payload interface

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified risks
- The fix correctly addresses the root cause of inbound calls being dropped by ensuring required fields are passed through and properly normalized. The implementation handles all edge cases, includes comprehensive test coverage for both inbound and outbound scenarios, and follows the same patterns used by other providers (Twilio, Plivo). The type casts are appropriate given the generic payload interface structure.
- No files require special attention

<sub>Last reviewed commit: 48ff138</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->