### PR TITLE
refactor: centralize exec approval timeout

### DIFF
--- a/src/cli/nodes-cli/register.invoke.ts
+++ b/src/cli/nodes-cli/register.invoke.ts
@@ -5,6 +5,7 @@ import { resolveAgentConfig, resolveDefaultAgentId } from "../../agents/agent-sc
 import { loadConfig } from "../../config/config.js";
 import { randomIdempotencyKey } from "../../gateway/call.js";
 import {
+  DEFAULT_EXEC_APPROVAL_TIMEOUT_MS,
   type ExecApprovalsFile,
   type ExecAsk,
   type ExecSecurity,
@@ -272,30 +273,33 @@ export function registerNodesInvokeCommands(nodes: Command) {
           let approvalId: string | null = null;
           if (requiresAsk) {
             approvalId = crypto.randomUUID();
-            const approvalTimeoutMs = 120_000;
+            const approvalTimeoutMs = DEFAULT_EXEC_APPROVAL_TIMEOUT_MS;
             // The CLI transport timeout (opts.timeout) must be longer than the
             // gateway-side approval wait so the connection stays alive while the
             // user decides.  Without this override the default 35 s transport
             // timeout races — and always loses — against the 120 s approval
             // timeout, causing "gateway timeout after 35000ms" (#12098).
-            const approvalOpts = {
-              ...opts,
-              timeout: String(
-                Math.max(parseTimeoutMs(opts.timeout) ?? 0, approvalTimeoutMs + 10_000),
-              ),
-            };
-            const decisionResult = (await callGatewayCli("exec.approval.request", approvalOpts, {
-              id: approvalId,
-              command: rawCommand ?? argv.join(" "),
-              cwd: opts.cwd,
-              host: "node",
-              security: hostSecurity,
-              ask: hostAsk,
-              agentId,
-              resolvedPath: undefined,
-              sessionKey: undefined,
-              timeoutMs: approvalTimeoutMs,
-            })) as { decision?: string } | null;
+            const transportTimeoutMs = Math.max(
+              parseTimeoutMs(opts.timeout) ?? 0,
+              approvalTimeoutMs + 10_000,
+            );
+            const decisionResult = (await callGatewayCli(
+              "exec.approval.request",
+              opts,
+              {
+                id: approvalId,
+                command: rawCommand ?? argv.join(" "),
+                cwd: opts.cwd,
+                host: "node",
+                security: hostSecurity,
+                ask: hostAsk,
+                agentId,
+                resolvedPath: undefined,
+                sessionKey: undefined,
+                timeoutMs: approvalTimeoutMs,
+              },
+              { transportTimeoutMs },
+            )) as { decision?: string } | null;
             const decision =
               decisionResult && typeof decisionResult === "object"
                 ? (decisionResult.decision ?? null)

--- a/src/cli/nodes-cli/rpc.ts
+++ b/src/cli/nodes-cli/rpc.ts
@@ -13,7 +13,12 @@ export const nodesCallOpts = (cmd: Command, defaults?: { timeoutMs?: number }) =
     .option("--timeout <ms>", "Timeout in ms", String(defaults?.timeoutMs ?? 10_000))
     .option("--json", "Output JSON", false);
 
-export const callGatewayCli = async (method: string, opts: NodesRpcOpts, params?: unknown) =>
+export const callGatewayCli = async (
+  method: string,
+  opts: NodesRpcOpts,
+  params?: unknown,
+  callOpts?: { transportTimeoutMs?: number },
+) =>
   withProgress(
     {
       label: `Nodes ${method}`,
@@ -26,7 +31,7 @@ export const callGatewayCli = async (method: string, opts: NodesRpcOpts, params?
         token: opts.token,
         method,
         params,
-        timeoutMs: Number(opts.timeout ?? 10_000),
+        timeoutMs: callOpts?.transportTimeoutMs ?? Number(opts.timeout ?? 10_000),
         clientName: GATEWAY_CLIENT_NAMES.CLI,
         mode: GATEWAY_CLIENT_MODES.CLI,
       }),

--- a/src/gateway/server-methods/exec-approval.ts
+++ b/src/gateway/server-methods/exec-approval.ts
@@ -1,7 +1,10 @@
 import type { ExecApprovalForwarder } from "../../infra/exec-approval-forwarder.js";
-import type { ExecApprovalDecision } from "../../infra/exec-approvals.js";
 import type { ExecApprovalManager } from "../exec-approval-manager.js";
 import type { GatewayRequestHandlers } from "./types.js";
+import {
+  DEFAULT_EXEC_APPROVAL_TIMEOUT_MS,
+  type ExecApprovalDecision,
+} from "../../infra/exec-approvals.js";
 import {
   ErrorCodes,
   errorShape,
@@ -43,7 +46,8 @@ export function createExecApprovalHandlers(
         twoPhase?: boolean;
       };
       const twoPhase = p.twoPhase === true;
-      const timeoutMs = typeof p.timeoutMs === "number" ? p.timeoutMs : 120_000;
+      const timeoutMs =
+        typeof p.timeoutMs === "number" ? p.timeoutMs : DEFAULT_EXEC_APPROVAL_TIMEOUT_MS;
       const explicitId = typeof p.id === "string" && p.id.trim().length > 0 ? p.id.trim() : null;
       if (explicitId && manager.getSnapshot(explicitId)) {
         respond(

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -81,6 +81,9 @@ export type ExecApprovalsResolved = {
   file: ExecApprovalsFile;
 };
 
+// Keep CLI + gateway defaults in sync.
+export const DEFAULT_EXEC_APPROVAL_TIMEOUT_MS = 120_000;
+
 const DEFAULT_SECURITY: ExecSecurity = "deny";
 const DEFAULT_ASK: ExecAsk = "on-miss";
 const DEFAULT_ASK_FALLBACK: ExecSecurity = "deny";

--- a/src/memory/sqlite.ts
+++ b/src/memory/sqlite.ts
@@ -5,5 +5,15 @@ const require = createRequire(import.meta.url);
 
 export function requireNodeSqlite(): typeof import("node:sqlite") {
   installProcessWarningFilter();
-  return require("node:sqlite") as typeof import("node:sqlite");
+  try {
+    return require("node:sqlite") as typeof import("node:sqlite");
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    // Node distributions can ship without the experimental builtin SQLite module.
+    // Surface an actionable error instead of the generic "unknown builtin module".
+    throw new Error(
+      `SQLite support is unavailable in this Node runtime (missing node:sqlite). ${message}`,
+      { cause: err },
+    );
+  }
 }


### PR DESCRIPTION
Follow-up cleanup after #12188.

Changes:
- Centralize default exec approval timeout (CLI + gateway).
- Thread transport timeout separately (no opts mutation).
- Improve missing `node:sqlite` runtime error message.

Gate:
- fnm exec --using 22.21.1 -- pnpm check
- fnm exec --using 22.21.1 -- pnpm test

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Refactored exec approval timeout handling to improve code maintainability and clarity.

- Centralized the 120-second default exec approval timeout as `DEFAULT_EXEC_APPROVAL_TIMEOUT_MS` constant, now shared between CLI and gateway
- Replaced opts object mutation pattern with explicit `transportTimeoutMs` parameter to `callGatewayCli`, avoiding spread operator overhead and making intent clearer
- Enhanced `node:sqlite` missing runtime error message to be more actionable for users
- Updated all tests to reflect the new API signature with separate transport timeout parameter

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Clean refactoring with comprehensive test coverage. The changes eliminate object mutation, centralize magic numbers into well-named constants, and maintain functional equivalence with the previous implementation. All tests have been updated to match the new API signature. The SQLite error improvement is a pure developer experience enhancement with no logic changes.
- No files require special attention

<sub>Last reviewed commit: 179ed55</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->