### PR TITLE
test: isolate env-dependent gateway/auth fixtures

### DIFF
--- a/src/browser/server.post-tabs-open-profile-unknown-returns-404.test.ts
+++ b/src/browser/server.post-tabs-open-profile-unknown-returns-404.test.ts
@@ -9,6 +9,9 @@ import {
   startBrowserControlServerFromConfig,
 } from "./server.control-server.test-harness.js";
 
+let prevGatewayToken: string | undefined;
+let prevGatewayPassword: string | undefined;
+
 describe("browser control server", () => {
   installBrowserControlServerHooks();
 
@@ -43,6 +46,11 @@ describe("browser control server", () => {
 
 describe("profile CRUD endpoints", () => {
   beforeEach(async () => {
+    prevGatewayToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+    prevGatewayPassword = process.env.OPENCLAW_GATEWAY_PASSWORD;
+    delete process.env.OPENCLAW_GATEWAY_TOKEN;
+    delete process.env.OPENCLAW_GATEWAY_PASSWORD;
+
     await resetBrowserControlServerTestContext();
 
     vi.stubGlobal(
@@ -58,6 +66,17 @@ describe("profile CRUD endpoints", () => {
   });
 
   afterEach(async () => {
+    if (prevGatewayToken === undefined) {
+      delete process.env.OPENCLAW_GATEWAY_TOKEN;
+    } else {
+      process.env.OPENCLAW_GATEWAY_TOKEN = prevGatewayToken;
+    }
+    if (prevGatewayPassword === undefined) {
+      delete process.env.OPENCLAW_GATEWAY_PASSWORD;
+    } else {
+      process.env.OPENCLAW_GATEWAY_PASSWORD = prevGatewayPassword;
+    }
+
     await cleanupBrowserControlServerTestContext();
   });
 

--- a/src/gateway/server-runtime-config.test.ts
+++ b/src/gateway/server-runtime-config.test.ts
@@ -110,10 +110,13 @@ describe("resolveGatewayRuntimeConfig", () => {
 
   describe("token/password auth modes", () => {
     let originalToken: string | undefined;
+    let originalPassword: string | undefined;
 
     beforeEach(() => {
       originalToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+      originalPassword = process.env.OPENCLAW_GATEWAY_PASSWORD;
       delete process.env.OPENCLAW_GATEWAY_TOKEN;
+      delete process.env.OPENCLAW_GATEWAY_PASSWORD;
     });
 
     afterEach(() => {
@@ -121,6 +124,11 @@ describe("resolveGatewayRuntimeConfig", () => {
         process.env.OPENCLAW_GATEWAY_TOKEN = originalToken;
       } else {
         delete process.env.OPENCLAW_GATEWAY_TOKEN;
+      }
+      if (originalPassword !== undefined) {
+        process.env.OPENCLAW_GATEWAY_PASSWORD = originalPassword;
+      } else {
+        delete process.env.OPENCLAW_GATEWAY_PASSWORD;
       }
     });
 

--- a/test/helpers/temp-home.ts
+++ b/test/helpers/temp-home.ts
@@ -11,6 +11,8 @@ type EnvSnapshot = {
   homePath: string | undefined;
   openclawHome: string | undefined;
   stateDir: string | undefined;
+  agentDir: string | undefined;
+  piCodingAgentDir: string | undefined;
 };
 
 type SharedHomeRootState = {
@@ -28,6 +30,8 @@ function snapshotEnv(): EnvSnapshot {
     homePath: process.env.HOMEPATH,
     openclawHome: process.env.OPENCLAW_HOME,
     stateDir: process.env.OPENCLAW_STATE_DIR,
+    agentDir: process.env.OPENCLAW_AGENT_DIR,
+    piCodingAgentDir: process.env.PI_CODING_AGENT_DIR,
   };
 }
 
@@ -45,6 +49,8 @@ function restoreEnv(snapshot: EnvSnapshot) {
   restoreKey("HOMEPATH", snapshot.homePath);
   restoreKey("OPENCLAW_HOME", snapshot.openclawHome);
   restoreKey("OPENCLAW_STATE_DIR", snapshot.stateDir);
+  restoreKey("OPENCLAW_AGENT_DIR", snapshot.agentDir);
+  restoreKey("PI_CODING_AGENT_DIR", snapshot.piCodingAgentDir);
 }
 
 function snapshotExtraEnv(keys: string[]): Record<string, string | undefined> {
@@ -68,8 +74,10 @@ function restoreExtraEnv(snapshot: Record<string, string | undefined>) {
 function setTempHome(base: string) {
   process.env.HOME = base;
   process.env.USERPROFILE = base;
-  // Ensure tests using HOME isolation aren't affected by leaked OPENCLAW_HOME.
+  // Ensure tests using HOME isolation aren't affected by leaked OpenClaw env overrides.
   delete process.env.OPENCLAW_HOME;
+  delete process.env.OPENCLAW_AGENT_DIR;
+  delete process.env.PI_CODING_AGENT_DIR;
   process.env.OPENCLAW_STATE_DIR = path.join(base, ".openclaw");
 
   if (process.platform !== "win32") {


### PR DESCRIPTION
## Summary
- isolate browser profile CRUD tests from host gateway token/password env vars
- isolate runtime auth test from host token/password env vars
- ensure `withTempHome` clears/restores `OPENCLAW_AGENT_DIR` and `PI_CODING_AGENT_DIR` so auth-profile tests use temp home paths

## Why
Several tests were reading host env vars (`OPENCLAW_GATEWAY_TOKEN`, `OPENCLAW_AGENT_DIR`) and became non-deterministic across machines/runners.

## Validation
- `npx vitest run src/browser/server.post-tabs-open-profile-unknown-returns-404.test.ts src/gateway/server-runtime-config.test.ts src/infra/provider-usage.auth.normalizes-keys.test.ts`



## AI-Assisted
Yes — implemented and reviewed with AI assistance.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Properly isolated environment-dependent test fixtures from host environment variables. The changes ensure `OPENCLAW_GATEWAY_TOKEN`, `OPENCLAW_GATEWAY_PASSWORD`, `OPENCLAW_AGENT_DIR`, and `PI_CODING_AGENT_DIR` don't leak into tests, preventing non-deterministic behavior across different machines and CI runners.

- Extended `withTempHome` helper to snapshot/restore `OPENCLAW_AGENT_DIR` and `PI_CODING_AGENT_DIR`
- Added proper cleanup to browser profile CRUD test fixtures
- Wrapped auth test assertions in try-finally to guarantee env restoration

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are straightforward test infrastructure improvements that add proper environment isolation. All modifications follow consistent patterns: snapshot env vars before modification, restore them in cleanup. The code doesn't affect production logic, only test fixtures. The PR includes validation command showing the specific tests that were fixed.
- No files require special attention

<sub>Last reviewed commit: a1bc4f5</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

## Local Validation

```bash
pnpm build && pnpm check && pnpm test
```

Build passes. Lint passes. 4743/4747 tests pass (4 pre-existing env-isolation failures fixed by #16658).

## Local Validation

```bash
pnpm build && pnpm check && pnpm test
```

Build passes. Lint passes. **All tests pass** (including the 4 that were failing without this fix: `provider-usage.auth.normalizes-keys.test.ts`).