### PR TITLE
fix(ci): avoid TS2742 vitest mock export types

### DIFF
--- a/src/agents/openclaw-tools.subagents.sessions-spawn.mocks.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.mocks.ts
@@ -1,8 +1,7 @@
 import { vi } from "vitest";
+import type { MockFn } from "../test-utils/vitest-mock-fn.js";
 
-// Avoid exporting inferred vitest mock types (TS2742 under pnpm + d.ts emit).
-export type CallGatewayMock = ((opts: unknown) => unknown) & ReturnType<typeof vi.fn>;
-export const callGatewayMock: CallGatewayMock = vi.fn() as unknown as CallGatewayMock;
+export const callGatewayMock: MockFn<(opts: unknown) => unknown> = vi.fn();
 vi.mock("../gateway/call.js", () => ({
   callGateway: (opts: unknown) => callGatewayMock(opts),
 }));

--- a/src/cron/service.test-harness.ts
+++ b/src/cron/service.test-harness.ts
@@ -2,13 +2,13 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, vi } from "vitest";
+import type { MockFn } from "../test-utils/vitest-mock-fn.js";
 
-// Avoid exporting inferred vitest mock types (TS2742 under pnpm + d.ts emit).
 export type NoopLogger = {
-  debug: ReturnType<typeof vi.fn>;
-  info: ReturnType<typeof vi.fn>;
-  warn: ReturnType<typeof vi.fn>;
-  error: ReturnType<typeof vi.fn>;
+  debug: MockFn;
+  info: MockFn;
+  warn: MockFn;
+  error: MockFn;
 };
 
 export function createNoopLogger(): NoopLogger {


### PR DESCRIPTION
Fix TS2742 in d.ts emit by using src/test-utils/vitest-mock-fn.ts MockFn for exported vi.fn() mocks.

Touches:
- src/agents/openclaw-tools.subagents.sessions-spawn.mocks.ts
- src/cron/service.test-harness.ts

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Replaces ad-hoc workarounds for TS2742 (`d.ts` emit under pnpm) in two test harness files with the centralized `MockFn` type alias from `src/test-utils/vitest-mock-fn.ts`.

- `openclaw-tools.subagents.sessions-spawn.mocks.ts`: Removes custom `CallGatewayMock` type and double-cast (`as unknown as`) in favor of direct `MockFn<(opts: unknown) => unknown>` annotation.
- `cron/service.test-harness.ts`: Replaces `ReturnType<typeof vi.fn>` references in `NoopLogger` with the `MockFn` default type, which is semantically equivalent but avoids the inferred vitest type export.
- Both changes are consistent with the established pattern used across 6+ other harness/mock files in the codebase.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a minimal, type-only refactor in test harness files with no runtime behavior change.
- Both files are test harnesses only (no production logic). The changes swap type annotations to use an existing centralized type alias, with no runtime code changes. The pattern is already well-established across the codebase. The type assignments are verified compatible without unsafe casts.
- No files require special attention.

<sub>Last reviewed commit: 3aa9e2d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->