### PR TITLE
feat(memory-lancedb): add memory_search/memory_get compatibility registration

### DIFF
--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -299,6 +299,25 @@ const memoryPlugin = {
 
     api.logger.info(`memory-lancedb: plugin registered (db: ${resolvedDbPath}, lazy init)`);
 
+    // Re-export core file-memory tools for compatibility with shared prompts/tool groups.
+    api.registerTool(
+      (ctx) => {
+        const memorySearchTool = api.runtime.tools.createMemorySearchTool({
+          config: ctx.config,
+          agentSessionKey: ctx.sessionKey,
+        });
+        const memoryGetTool = api.runtime.tools.createMemoryGetTool({
+          config: ctx.config,
+          agentSessionKey: ctx.sessionKey,
+        });
+        if (!memorySearchTool || !memoryGetTool) {
+          return null;
+        }
+        return [memorySearchTool, memoryGetTool];
+      },
+      { names: ["memory_search", "memory_get"] },
+    );
+
     // ========================================================================
     // Tools
     // ========================================================================


### PR DESCRIPTION
## Summary
- feat(memory-lancedb): add memory_search/memory_get compatibility registration
- Split from our `v2026.2.13` patch train as a single-purpose change for easier review.

## Why
- Keep the diff focused and low-risk so it can be merged or reverted independently.

## Scope
- Branch: `feat/memory-lancedb-compat-tools-split-en`
- Files changed: 2
- Key files:
  - `extensions/memory-lancedb/index.test.ts`
  - `extensions/memory-lancedb/index.ts`

## Test Plan
- Suggested local command:
  - `./node_modules/.bin/vitest run extensions/memory-lancedb/index.test.ts`
- Validation status:
  - [ ] CI checks pass
  - [ ] Maintainer re-ran local tests

## Risk & Rollback
- Risk: low to medium; impact limited to touched module(s).
- Rollback: revert this PR commit(s) cleanly.

## Co-authorship
- Co-authored by @ciberponk and Codex (GPT-5).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `memory_search` and `memory_get` compatibility tool registration to the `memory-lancedb` plugin, mirroring the existing pattern from `extensions/memory-core/index.ts`. This ensures that when `memory-lancedb` is used as the memory slot (instead of `memory-core`), the core file-memory tools (`memory_search`, `memory_get`) remain available to shared prompts and tool groups that reference them (e.g., `src/agents/system-prompt.ts` and `src/agents/tool-policy.ts`).

- Adds a `registerTool` factory call that delegates to `api.runtime.tools.createMemorySearchTool` / `createMemoryGetTool`, returning `null` if either tool is unavailable
- The implementation is identical to the established pattern in `extensions/memory-core/index.ts`
- Includes a dedicated unit test verifying the compatibility registration and factory invocation
- Updates the live test tool count assertion from 3 to 4 to reflect the new registration

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it replicates an established pattern with appropriate test coverage and no behavioral risk.
- The implementation is a direct copy of the proven pattern from memory-core/index.ts. The plugin API types (OpenClawPluginToolFactory, OpenClawPluginToolOptions with names[]) explicitly support this usage. The factory gracefully handles null returns. The test verifies registration and invocation. The live test count update is correct. No new dependencies, no security concerns, and no architectural changes.
- No files require special attention.

<sub>Last reviewed commit: da8c37f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->