### PR TITLE
feat(memory-lancedb): improve CJK category detection

### DIFF
--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -187,13 +187,15 @@ describe("memory plugin e2e", () => {
     const { detectCategory } = await import("./index.js");
 
     expect(detectCategory("I prefer dark mode")).toBe("preference");
-    expect(detectCategory("We decided to use React")).toBe("decision");
-    expect(detectCategory("My email is test@example.com")).toBe("entity");
-    expect(detectCategory("The server is running on port 3000")).toBe("fact");
     expect(detectCategory("我喜欢深色模式")).toBe("preference");
+    expect(detectCategory("We decided to use React")).toBe("decision");
     expect(detectCategory("我们决定以后都用 React")).toBe("decision");
+    expect(detectCategory("My email is test@example.com")).toBe("entity");
     expect(detectCategory("我叫小明")).toBe("entity");
+    expect(detectCategory("The server is running on port 3000")).toBe("fact");
     expect(detectCategory("服务器状态是正常")).toBe("fact");
+    expect(detectCategory("我们有 3 台服务器")).toBe("fact");
+    expect(detectCategory("我有问题吗？")).toBe("other");
     expect(detectCategory("Random note")).toBe("other");
   });
 });

--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -190,6 +190,10 @@ describe("memory plugin e2e", () => {
     expect(detectCategory("We decided to use React")).toBe("decision");
     expect(detectCategory("My email is test@example.com")).toBe("entity");
     expect(detectCategory("The server is running on port 3000")).toBe("fact");
+    expect(detectCategory("我喜欢深色模式")).toBe("preference");
+    expect(detectCategory("我们决定以后都用 React")).toBe("decision");
+    expect(detectCategory("我叫小明")).toBe("entity");
+    expect(detectCategory("服务器状态是正常")).toBe("fact");
     expect(detectCategory("Random note")).toBe("other");
   });
 });

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -264,16 +264,29 @@ export function shouldCapture(text: string, options?: { maxChars?: number }): bo
 
 export function detectCategory(text: string): MemoryCategory {
   const lower = text.toLowerCase();
-  if (/prefer|radši|like|love|hate|want|喜欢|偏好|讨厌|爱|想要|需要/i.test(lower)) {
+  if (/prefer|radši|like|love|hate|want/i.test(lower)) {
     return "preference";
   }
-  if (/rozhodli|decided|will use|budeme|决定|以后用|就这么定/i.test(lower)) {
+  if (/我喜欢|我偏好|我讨厌|我不喜欢|我爱|我想要|我需要/.test(text)) {
+    return "preference";
+  }
+  if (/rozhodli|decided|will use|budeme/i.test(lower)) {
     return "decision";
   }
-  if (/\+\d{10,}|@[\w.-]+\.\w+|is called|jmenuje se|我叫|名字是/i.test(lower)) {
+  if (/我决定|我们决定|就这么定|以后都|以后用/.test(text)) {
+    return "decision";
+  }
+  if (/\+\d{10,}|@[\w.-]+\.\w+|is called|jmenuje se/i.test(lower)) {
     return "entity";
   }
-  if (/is|are|has|have|je|má|jsou|是|有/i.test(lower)) {
+  if (/我叫|我是|我的.+是|是我的/.test(text)) {
+    return "entity";
+  }
+  if (/is|are|has|have|je|má|jsou|事实|信息|状态|版本|配置|地址|端口/.test(lower)) {
+    return "fact";
+  }
+  // Avoid broad CJK copulas ("是/有"), which often appear in questions.
+  if (!/[?？]/.test(text) && /我有|我们有|具备|包含|属于/.test(text)) {
     return "fact";
   }
   return "other";

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -264,16 +264,16 @@ export function shouldCapture(text: string, options?: { maxChars?: number }): bo
 
 export function detectCategory(text: string): MemoryCategory {
   const lower = text.toLowerCase();
-  if (/prefer|radši|like|love|hate|want/i.test(lower)) {
+  if (/prefer|radši|like|love|hate|want|喜欢|偏好|讨厌|爱|想要|需要/i.test(lower)) {
     return "preference";
   }
-  if (/rozhodli|decided|will use|budeme/i.test(lower)) {
+  if (/rozhodli|decided|will use|budeme|决定|以后用|就这么定/i.test(lower)) {
     return "decision";
   }
-  if (/\+\d{10,}|@[\w.-]+\.\w+|is called|jmenuje se/i.test(lower)) {
+  if (/\+\d{10,}|@[\w.-]+\.\w+|is called|jmenuje se|我叫|名字是/i.test(lower)) {
     return "entity";
   }
-  if (/is|are|has|have|je|má|jsou/i.test(lower)) {
+  if (/is|are|has|have|je|má|jsou|是|有/i.test(lower)) {
     return "fact";
   }
   return "other";


### PR DESCRIPTION
## Summary
- feat(memory-lancedb): improve CJK category detection
- Split from our `v2026.2.13` patch train as a single-purpose change for easier review.

## Why
- Keep the diff focused and low-risk so it can be merged or reverted independently.

## Scope
- Branch: `feat/memory-lancedb-cjk-category-detection-en`
- Files changed: 2
- Key files:
  - `extensions/memory-lancedb/index.test.ts`
  - `extensions/memory-lancedb/index.ts`

## Test Plan
- Suggested local command:
  - `./node_modules/.bin/vitest run extensions/memory-lancedb/index.test.ts`
- Validation status:
  - [ ] CI checks pass
  - [ ] Maintainer re-ran local tests

## Risk & Rollback
- Risk: low to medium; impact limited to touched module(s).
- Rollback: revert this PR commit(s) cleanly.

## Co-authorship
- Co-authored by @ciberponk and Codex (GPT-5).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added Chinese (CJK) keyword patterns to the `detectCategory` function for better multi-language memory categorization. The change extends the existing English/Czech patterns with Chinese equivalents across all four memory categories (preference, decision, entity, fact), and adds corresponding test cases to validate the Chinese text classification.

Key changes:
- Added Chinese keywords to preference detection: 喜欢, 偏好, 讨厌, 爱, 想要, 需要
- Added Chinese keywords to decision detection: 决定, 以后用, 就这么定
- Added Chinese keywords to entity detection: 我叫, 名字是  
- Added Chinese keywords to fact detection: 是, 有
- Added 4 new test cases covering Chinese text classification

**Issue found**: The Chinese characters in the fact category (`是` and `有`) are extremely common in Chinese text and will cause false positive matches. These characters appear in questions, preferences, and many other contexts beyond factual statements, which could result in incorrect categorization.

<h3>Confidence Score: 3/5</h3>

- This PR has a logical issue that will cause incorrect categorization for Chinese text
- The implementation adds CJK language support with appropriate test coverage, but the Chinese patterns for the fact category use overly broad characters (`是` and `有`) that will match in many non-factual contexts like questions and preferences. This will degrade categorization accuracy for Chinese users.
- extensions/memory-lancedb/index.ts line 276 needs refinement of the Chinese pattern matching logic

<sub>Last reviewed commit: e554e0a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->