### PR TITLE
fix(memory-lancedb): classify need statements as preference

### DIFF
--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -146,6 +146,7 @@ describe("memory plugin e2e", () => {
     const { detectCategory } = await import("./index.js");
 
     expect(detectCategory("I prefer dark mode")).toBe("preference");
+    expect(detectCategory("I need concise answers")).toBe("preference");
     expect(detectCategory("We decided to use React")).toBe("decision");
     expect(detectCategory("My email is test@example.com")).toBe("entity");
     expect(detectCategory("The server is running on port 3000")).toBe("fact");

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -222,7 +222,7 @@ export function shouldCapture(text: string, options?: { maxChars?: number }): bo
 
 export function detectCategory(text: string): MemoryCategory {
   const lower = text.toLowerCase();
-  if (/prefer|radši|like|love|hate|want/i.test(lower)) {
+  if (/prefer|radši|like|love|hate|want|need/i.test(lower)) {
     return "preference";
   }
   if (/rozhodli|decided|will use|budeme/i.test(lower)) {


### PR DESCRIPTION
## Summary
- fix(memory-lancedb): classify need statements as preference
- Split from our `v2026.2.13` patch train as a single-purpose change for easier review.

## Why
- Keep the diff focused and low-risk so it can be merged or reverted independently.

## Scope
- Branch: `fix/memory-lancedb-detect-need-preference-en`
- Files changed: 2
- Key files:
  - `extensions/memory-lancedb/index.test.ts`
  - `extensions/memory-lancedb/index.ts`

## Test Plan
- Suggested local command:
  - `./node_modules/.bin/vitest run extensions/memory-lancedb/index.test.ts`
- Validation status:
  - [ ] CI checks pass
  - [ ] Maintainer re-ran local tests

## Risk & Rollback
- Risk: low to medium; impact limited to touched module(s).
- Rollback: revert this PR commit(s) cleanly.

## Co-authorship
- Co-authored by @ciberponk and Codex (GPT-5).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `need` to the preference-detection regex in `detectCategory()`, so statements like "I need concise answers" are classified as `"preference"` instead of falling through to `"other"`. A matching test case is added.

- The `need` keyword was already present in `MEMORY_TRIGGERS` (used by `shouldCapture`) but was missing from `detectCategory`, causing a classification gap where captured "need" statements would be categorized as `"other"` instead of `"preference"`.
- The fix is consistent with the existing pattern — other similar intent words (`want`, `like`, `love`, `hate`) are already in the preference regex.
- No issues found. The change is minimal, well-scoped, and correctly tested.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it adds a single keyword to an existing regex and includes a corresponding test.
- The change is a one-word addition to a regex alternation in `detectCategory()` with a matching test case. There are no logic errors, no risk of breaking existing behavior, and the classification of "need" as a preference is consistent with the existing keywords (`want`, `like`, `love`, `hate`). The `need` keyword was already recognized in `MEMORY_TRIGGERS` for capture, so this just aligns the classification step.
- No files require special attention.

<sub>Last reviewed commit: 4991720</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->