### PR TITLE
fix: deliver tool result media when verbose is off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents: deliver tool result media (screenshots, images, audio) to channels regardless of verbose level. (#11735) Thanks @strelov1.
 - Telegram: when `channels.telegram.commands.native` is `false`, exclude plugin commands from `setMyCommands` menu registration while keeping plugin slash handlers callable. (#15132) Thanks @Glucksberg.
 - LINE: return 200 OK for Developers Console "Verify" requests (`{"events":[]}`) without `X-Line-Signature`, while still requiring signatures for real deliveries. (#16582) Thanks @arosstale.
 - Cron: deliver text-only output directly when `delivery.to` is set so cron recipients get full output instead of summaries. (#16360) Thanks @thewilloftheshadow.

--- a/src/agents/pi-embedded-subscribe.handlers.tools.media.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.media.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it, vi } from "vitest";
+import type { EmbeddedPiSubscribeContext } from "./pi-embedded-subscribe.handlers.types.js";
+import { handleToolExecutionEnd } from "./pi-embedded-subscribe.handlers.tools.js";
+
+// Minimal mock context factory. Only the fields needed for the media emission path.
+function createMockContext(overrides?: {
+  shouldEmitToolOutput?: boolean;
+  onToolResult?: ReturnType<typeof vi.fn>;
+}): EmbeddedPiSubscribeContext {
+  const onToolResult = overrides?.onToolResult ?? vi.fn();
+  return {
+    params: {
+      runId: "test-run",
+      onToolResult,
+      onAgentEvent: vi.fn(),
+    },
+    state: {
+      toolMetaById: new Map(),
+      toolMetas: [],
+      toolSummaryById: new Set(),
+      pendingMessagingTexts: new Map(),
+      pendingMessagingTargets: new Map(),
+      messagingToolSentTexts: [],
+      messagingToolSentTextsNormalized: [],
+      messagingToolSentTargets: [],
+    },
+    log: { debug: vi.fn(), warn: vi.fn() },
+    shouldEmitToolResult: vi.fn(() => false),
+    shouldEmitToolOutput: vi.fn(() => overrides?.shouldEmitToolOutput ?? false),
+    emitToolSummary: vi.fn(),
+    emitToolOutput: vi.fn(),
+    trimMessagingToolSent: vi.fn(),
+    hookRunner: undefined,
+    // Fill in remaining required fields with no-ops.
+    blockChunker: null,
+    noteLastAssistant: vi.fn(),
+    stripBlockTags: vi.fn((t: string) => t),
+    emitBlockChunk: vi.fn(),
+    flushBlockReplyBuffer: vi.fn(),
+    emitReasoningStream: vi.fn(),
+    consumeReplyDirectives: vi.fn(() => null),
+    consumePartialReplyDirectives: vi.fn(() => null),
+    resetAssistantMessageState: vi.fn(),
+    resetForCompactionRetry: vi.fn(),
+    finalizeAssistantTexts: vi.fn(),
+    ensureCompactionPromise: vi.fn(),
+    noteCompactionRetry: vi.fn(),
+    resolveCompactionRetry: vi.fn(),
+    maybeResolveCompactionWait: vi.fn(),
+    recordAssistantUsage: vi.fn(),
+    incrementCompactionCount: vi.fn(),
+    getUsageTotals: vi.fn(() => undefined),
+    getCompactionCount: vi.fn(() => 0),
+  } as unknown as EmbeddedPiSubscribeContext;
+}
+
+describe("handleToolExecutionEnd media emission", () => {
+  it("emits media when verbose is off and tool result has MEDIA: path", async () => {
+    const onToolResult = vi.fn();
+    const ctx = createMockContext({ shouldEmitToolOutput: false, onToolResult });
+
+    await handleToolExecutionEnd(ctx, {
+      type: "tool_execution_end",
+      toolName: "browser",
+      toolCallId: "tc-1",
+      isError: false,
+      result: {
+        content: [
+          { type: "text", text: "MEDIA:/tmp/screenshot.png" },
+          { type: "image", data: "base64", mimeType: "image/png" },
+        ],
+        details: { path: "/tmp/screenshot.png" },
+      },
+    });
+
+    expect(onToolResult).toHaveBeenCalledWith({
+      mediaUrls: ["/tmp/screenshot.png"],
+    });
+  });
+
+  it("does NOT emit media when verbose is full (emitToolOutput handles it)", async () => {
+    const onToolResult = vi.fn();
+    const ctx = createMockContext({ shouldEmitToolOutput: true, onToolResult });
+
+    await handleToolExecutionEnd(ctx, {
+      type: "tool_execution_end",
+      toolName: "browser",
+      toolCallId: "tc-1",
+      isError: false,
+      result: {
+        content: [
+          { type: "text", text: "MEDIA:/tmp/screenshot.png" },
+          { type: "image", data: "base64", mimeType: "image/png" },
+        ],
+        details: { path: "/tmp/screenshot.png" },
+      },
+    });
+
+    // onToolResult should NOT be called by the new media path (emitToolOutput handles it).
+    // It may be called by emitToolOutput, but the new block should not fire.
+    // Verify emitToolOutput was called instead.
+    expect(ctx.emitToolOutput).toHaveBeenCalled();
+    // The direct media emission should not have been called with just mediaUrls.
+    const directMediaCalls = onToolResult.mock.calls.filter(
+      (call: unknown[]) =>
+        call[0] &&
+        typeof call[0] === "object" &&
+        "mediaUrls" in (call[0] as Record<string, unknown>) &&
+        !("text" in (call[0] as Record<string, unknown>)),
+    );
+    expect(directMediaCalls).toHaveLength(0);
+  });
+
+  it("does NOT emit media for error results", async () => {
+    const onToolResult = vi.fn();
+    const ctx = createMockContext({ shouldEmitToolOutput: false, onToolResult });
+
+    await handleToolExecutionEnd(ctx, {
+      type: "tool_execution_end",
+      toolName: "browser",
+      toolCallId: "tc-1",
+      isError: true,
+      result: {
+        content: [
+          { type: "text", text: "MEDIA:/tmp/screenshot.png" },
+          { type: "image", data: "base64", mimeType: "image/png" },
+        ],
+        details: { path: "/tmp/screenshot.png" },
+      },
+    });
+
+    expect(onToolResult).not.toHaveBeenCalled();
+  });
+
+  it("does NOT emit when tool result has no media", async () => {
+    const onToolResult = vi.fn();
+    const ctx = createMockContext({ shouldEmitToolOutput: false, onToolResult });
+
+    await handleToolExecutionEnd(ctx, {
+      type: "tool_execution_end",
+      toolName: "bash",
+      toolCallId: "tc-1",
+      isError: false,
+      result: {
+        content: [{ type: "text", text: "Command executed successfully" }],
+      },
+    });
+
+    expect(onToolResult).not.toHaveBeenCalled();
+  });
+
+  it("emits media from details.path fallback when no MEDIA: text", async () => {
+    const onToolResult = vi.fn();
+    const ctx = createMockContext({ shouldEmitToolOutput: false, onToolResult });
+
+    await handleToolExecutionEnd(ctx, {
+      type: "tool_execution_end",
+      toolName: "canvas",
+      toolCallId: "tc-1",
+      isError: false,
+      result: {
+        content: [
+          { type: "text", text: "Rendered canvas" },
+          { type: "image", data: "base64", mimeType: "image/png" },
+        ],
+        details: { path: "/tmp/canvas-output.png" },
+      },
+    });
+
+    expect(onToolResult).toHaveBeenCalledWith({
+      mediaUrls: ["/tmp/canvas-output.png"],
+    });
+  });
+});

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -10,6 +10,7 @@ import { normalizeTextForComparison } from "./pi-embedded-helpers.js";
 import { isMessagingTool, isMessagingToolSendAction } from "./pi-embedded-messaging.js";
 import {
   extractToolErrorMessage,
+  extractToolResultMediaPaths,
   extractToolResultText,
   extractMessagingToolSend,
   isToolResultError,
@@ -263,6 +264,20 @@ export async function handleToolExecutionEnd(
     const outputText = extractToolResultText(sanitizedResult);
     if (outputText) {
       ctx.emitToolOutput(toolName, meta, outputText);
+    }
+  }
+
+  // Deliver media from tool results when the verbose emitToolOutput path is off.
+  // When shouldEmitToolOutput() is true, emitToolOutput already delivers media
+  // via parseReplyDirectives (MEDIA: text extraction), so skip to avoid duplicates.
+  if (ctx.params.onToolResult && !isToolError && !ctx.shouldEmitToolOutput()) {
+    const mediaPaths = extractToolResultMediaPaths(result);
+    if (mediaPaths.length > 0) {
+      try {
+        void ctx.params.onToolResult({ mediaUrls: mediaPaths });
+      } catch {
+        // ignore delivery failures
+      }
     }
   }
 

--- a/src/agents/pi-embedded-subscribe.tools.media.test.ts
+++ b/src/agents/pi-embedded-subscribe.tools.media.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import { extractToolResultMediaPaths } from "./pi-embedded-subscribe.tools.js";
+
+describe("extractToolResultMediaPaths", () => {
+  it("returns empty array for null/undefined", () => {
+    expect(extractToolResultMediaPaths(null)).toEqual([]);
+    expect(extractToolResultMediaPaths(undefined)).toEqual([]);
+  });
+
+  it("returns empty array for non-object", () => {
+    expect(extractToolResultMediaPaths("hello")).toEqual([]);
+    expect(extractToolResultMediaPaths(42)).toEqual([]);
+  });
+
+  it("returns empty array when content is missing", () => {
+    expect(extractToolResultMediaPaths({ details: { path: "/tmp/img.png" } })).toEqual([]);
+  });
+
+  it("returns empty array when content has no text or image blocks", () => {
+    expect(extractToolResultMediaPaths({ content: [{ type: "other" }] })).toEqual([]);
+  });
+
+  it("extracts MEDIA: path from text content block", () => {
+    const result = {
+      content: [
+        { type: "text", text: "MEDIA:/tmp/screenshot.png" },
+        { type: "image", data: "base64data", mimeType: "image/png" },
+      ],
+      details: { path: "/tmp/screenshot.png" },
+    };
+    expect(extractToolResultMediaPaths(result)).toEqual(["/tmp/screenshot.png"]);
+  });
+
+  it("extracts MEDIA: path with extra text in the block", () => {
+    const result = {
+      content: [{ type: "text", text: "Here is the image\nMEDIA:/tmp/output.jpg\nDone" }],
+    };
+    expect(extractToolResultMediaPaths(result)).toEqual(["/tmp/output.jpg"]);
+  });
+
+  it("extracts multiple MEDIA: paths from different text blocks", () => {
+    const result = {
+      content: [
+        { type: "text", text: "MEDIA:/tmp/page1.png" },
+        { type: "text", text: "MEDIA:/tmp/page2.png" },
+      ],
+    };
+    expect(extractToolResultMediaPaths(result)).toEqual(["/tmp/page1.png", "/tmp/page2.png"]);
+  });
+
+  it("falls back to details.path when image content exists but no MEDIA: text", () => {
+    // Pi SDK read tool doesn't include MEDIA: but OpenClaw imageResult
+    // sets details.path as fallback.
+    const result = {
+      content: [
+        { type: "text", text: "Read image file [image/png]" },
+        { type: "image", data: "base64data", mimeType: "image/png" },
+      ],
+      details: { path: "/tmp/generated.png" },
+    };
+    expect(extractToolResultMediaPaths(result)).toEqual(["/tmp/generated.png"]);
+  });
+
+  it("returns empty array when image content exists but no MEDIA: and no details.path", () => {
+    // Pi SDK read tool: has image content but no path anywhere in the result.
+    const result = {
+      content: [
+        { type: "text", text: "Read image file [image/png]" },
+        { type: "image", data: "base64data", mimeType: "image/png" },
+      ],
+    };
+    expect(extractToolResultMediaPaths(result)).toEqual([]);
+  });
+
+  it("does not fall back to details.path when MEDIA: paths are found", () => {
+    const result = {
+      content: [
+        { type: "text", text: "MEDIA:/tmp/from-text.png" },
+        { type: "image", data: "base64data", mimeType: "image/png" },
+      ],
+      details: { path: "/tmp/from-details.png" },
+    };
+    // MEDIA: text takes priority; details.path is NOT also included.
+    expect(extractToolResultMediaPaths(result)).toEqual(["/tmp/from-text.png"]);
+  });
+
+  it("handles backtick-wrapped MEDIA: paths", () => {
+    const result = {
+      content: [{ type: "text", text: "MEDIA: `/tmp/screenshot.png`" }],
+    };
+    expect(extractToolResultMediaPaths(result)).toEqual(["/tmp/screenshot.png"]);
+  });
+
+  it("ignores null/undefined items in content array", () => {
+    const result = {
+      content: [null, undefined, { type: "text", text: "MEDIA:/tmp/ok.png" }],
+    };
+    expect(extractToolResultMediaPaths(result)).toEqual(["/tmp/ok.png"]);
+  });
+
+  it("returns empty array for text-only results without MEDIA:", () => {
+    const result = {
+      content: [{ type: "text", text: "Command executed successfully" }],
+    };
+    expect(extractToolResultMediaPaths(result)).toEqual([]);
+  });
+
+  it("ignores details.path when no image content exists", () => {
+    // details.path without image content is not media.
+    const result = {
+      content: [{ type: "text", text: "File saved" }],
+      details: { path: "/tmp/data.json" },
+    };
+    expect(extractToolResultMediaPaths(result)).toEqual([]);
+  });
+
+  it("handles details.path with whitespace", () => {
+    const result = {
+      content: [{ type: "image", data: "base64", mimeType: "image/png" }],
+      details: { path: "  /tmp/image.png  " },
+    };
+    expect(extractToolResultMediaPaths(result)).toEqual(["/tmp/image.png"]);
+  });
+
+  it("skips empty details.path", () => {
+    const result = {
+      content: [{ type: "image", data: "base64", mimeType: "image/png" }],
+      details: { path: "   " },
+    };
+    expect(extractToolResultMediaPaths(result)).toEqual([]);
+  });
+});

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -128,6 +128,10 @@ export async function runAgentTurnWithFallback(params: {
           return { skip: true };
         }
         if (!text) {
+          // Allow media-only payloads (e.g. tool result screenshots) through.
+          if ((payload.mediaUrls?.length ?? 0) > 0) {
+            return { text: undefined, skip: false };
+          }
           return { skip: true };
         }
         const sanitized = sanitizeUserFacingText(text, {


### PR DESCRIPTION
## Summary

Tool result media (screenshots, generated images, audio) from OpenClaw tools (browser, canvas, image, TTS) was only delivered to channels when `verboseLevel === "full"`. Most users run on default verbose level, so media from tool results was silently dropped.

### Root cause

Media delivery flows through `emitToolOutput` which calls `parseReplyDirectives` to extract `MEDIA:` paths. But `emitToolOutput` is gated behind `shouldEmitToolOutput()`, which requires `verboseLevel === "full"`. The agent's final response also can't deliver the image because the system prompt discourages absolute `MEDIA:` paths, and the tool results use absolute paths.

### Changes

1. **New `extractToolResultMediaPaths()` function** (`pi-embedded-subscribe.tools.ts`): extracts media file paths from tool results using two strategies:
   - Parse `MEDIA:` tokens from text content blocks (primary, all OpenClaw tools)
   - Fall back to `details.path` when image content exists but no `MEDIA:` text

2. **Media emission in `handleToolExecutionEnd`** (`pi-embedded-subscribe.handlers.tools.ts`): emits extracted media via `onToolResult` when the verbose `emitToolOutput` path is off. Skips when `shouldEmitToolOutput()` is true to avoid duplicate delivery. Skips error results.

3. **Media-only payload passthrough** (`agent-runner-execution.ts`): `normalizeStreamingText` now allows payloads with `mediaUrls` but no text through instead of skipping them.

### What this does NOT fix

Pi SDK's `read` tool returns base64 image data in content blocks but no file path in the result (`details.path` is undefined, no `MEDIA:` text). Fixing that is a separate concern (see #11754).

## Change Type

- [x] Bug fix

## Scope

- [x] Core

## Linked Issue/PR

- Ref #11735
- Related: #15987 (same root cause analysis, different extraction approach)
- Related: #11754 (fixes the Pi SDK `read` tool gap, complementary to this PR)

## User-visible / Behavior Changes

- Tool result media (browser screenshots, canvas renders, generated images, TTS audio) is now delivered to messaging channels regardless of verbose level.

## Security Impact

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Evidence

- 16 unit tests for `extractToolResultMediaPaths` (MEDIA: extraction, fallback, edge cases)
- 5 integration tests for `handleToolExecutionEnd` media emission (verbose-off delivery, verbose-full skip, error skip, no-media skip, fallback)
- All existing agent-runner and tool subscribe tests pass (49 tests)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Credits

Based on the root cause analysis and fix approach in #15987 by @strelov1. Original issue reported by @khanhbkqt.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes media delivery from tool results (screenshots, generated images, audio) to messaging channels when verbose level is not set to "full". 

The fix correctly identifies the root cause: media was only delivered through `emitToolOutput`, which is gated behind `shouldEmitToolOutput()` requiring `verboseLevel === "full"`. Most users run on default verbose level, causing media to be silently dropped.

**Key changes:**
- Added `extractToolResultMediaPaths()` function that extracts media file paths from tool results using two strategies: parsing `MEDIA:` tokens from text content blocks (primary), and falling back to `details.path` when image content exists but no `MEDIA:` text
- Modified `handleToolExecutionEnd` to emit extracted media via `onToolResult` when verbose mode is off, while avoiding duplicate delivery when verbose mode is on
- Updated `normalizeStreamingText` in agent-runner-execution to allow media-only payloads through instead of skipping them

**Implementation quality:**
- Comprehensive test coverage with 16 unit tests for extraction logic and 5 integration tests for handler behavior
- Correctly uses unsanitized `result` instead of `sanitizedResult` to avoid losing `MEDIA:` tokens that may be truncated at >8000 chars
- Proper handling of edge cases (null/undefined, missing content, no media, error results)
- Clean separation of concerns between extraction logic and delivery logic

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-tested with 21 total tests covering both unit and integration scenarios. The code correctly handles the identified bug without introducing new issues. The fix is narrowly scoped to media delivery, properly avoids duplicate emissions when verbose mode is on, and maintains backward compatibility. The use of unsanitized result data for media extraction is intentionally correct to preserve MEDIA: tokens that might be truncated.
- No files require special attention

<sub>Last reviewed commit: f9e5746</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->