### PR TITLE
fix: add preferSessionLookupForAnnounceTarget to channel plugins

### DIFF
--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -48,6 +48,7 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
   id: "discord",
   meta: {
     ...meta,
+    preferSessionLookupForAnnounceTarget: true,
   },
   onboarding: discordOnboardingAdapter,
   pairing: {

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -62,6 +62,7 @@ export const mattermostPlugin: ChannelPlugin<ResolvedMattermostAccount> = {
   id: "mattermost",
   meta: {
     ...meta,
+    preferSessionLookupForAnnounceTarget: true,
   },
   onboarding: mattermostOnboardingAdapter,
   pairing: {

--- a/extensions/msteams/src/channel.ts
+++ b/extensions/msteams/src/channel.ts
@@ -45,6 +45,7 @@ export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount> = {
   meta: {
     ...meta,
     aliases: [...meta.aliases],
+    preferSessionLookupForAnnounceTarget: true,
   },
   onboarding: msteamsOnboardingAdapter,
   pairing: {

--- a/extensions/signal/src/channel.ts
+++ b/extensions/signal/src/channel.ts
@@ -46,6 +46,7 @@ export const signalPlugin: ChannelPlugin<ResolvedSignalAccount> = {
   id: "signal",
   meta: {
     ...meta,
+    preferSessionLookupForAnnounceTarget: true,
   },
   onboarding: signalOnboardingAdapter,
   pairing: {

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -54,6 +54,7 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
   id: "slack",
   meta: {
     ...meta,
+    preferSessionLookupForAnnounceTarget: true,
   },
   onboarding: slackOnboardingAdapter,
   pairing: {

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -52,6 +52,7 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
   meta: {
     ...meta,
     quickstartAllowFrom: true,
+    preferSessionLookupForAnnounceTarget: true,
   },
   onboarding: telegramOnboardingAdapter,
   pairing: {


### PR DESCRIPTION
## Summary
The `sessions_send` action was failing for most channel plugins because they were missing the `preferSessionLookupForAnnounceTarget` flag. Without this flag, the announce-target resolution skipped session lookup, causing sends to fail when no explicit target was provided. Added the flag to all affected channel plugins so session-based sends work correctly.

Fixes #16660

## Validation
- [x] `pnpm build` — passed
- [x] `pnpm check` (format + tsgo + lint) — passed
- [x] `pnpm test` — 1073 tests passed (105 test files)

## Scope
- Single focused fix — add `preferSessionLookupForAnnounceTarget` to 6 channel plugin files (discord, mattermost, msteams, signal, slack, telegram)

## AI-Assistance
- AI-assisted (Claude Code) for implementation
- Human-reviewed: confirmed understanding of changes
- Testing: full local validation suite passed