### PR TITLE
fix(memory-lancedb): classify always/never statements as preference

### DIFF
--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -146,6 +146,8 @@ describe("memory plugin e2e", () => {
     const { detectCategory } = await import("./index.js");
 
     expect(detectCategory("I prefer dark mode")).toBe("preference");
+    expect(detectCategory("I always use dark mode")).toBe("preference");
+    expect(detectCategory("I never use emojis")).toBe("preference");
     expect(detectCategory("We decided to use React")).toBe("decision");
     expect(detectCategory("My email is test@example.com")).toBe("entity");
     expect(detectCategory("The server is running on port 3000")).toBe("fact");

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -222,7 +222,7 @@ export function shouldCapture(text: string, options?: { maxChars?: number }): bo
 
 export function detectCategory(text: string): MemoryCategory {
   const lower = text.toLowerCase();
-  if (/prefer|radši|like|love|hate|want/i.test(lower)) {
+  if (/prefer|radši|like|love|hate|want|always|never/i.test(lower)) {
     return "preference";
   }
   if (/rozhodli|decided|will use|budeme/i.test(lower)) {


### PR DESCRIPTION
## Summary
- fix(memory-lancedb): classify always/never statements as preference
- Split from our `v2026.2.13` patch train as a single-purpose change for easier review.

## Why
- Keep the diff focused and low-risk so it can be merged or reverted independently.

## Scope
- Branch: `fix/memory-lancedb-classify-always-never-preference-en`
- Files changed: 2
- Key files:
  - `extensions/memory-lancedb/index.test.ts`
  - `extensions/memory-lancedb/index.ts`

## Test Plan
- Suggested local command:
  - `./node_modules/.bin/vitest run extensions/memory-lancedb/index.test.ts`
- Validation status:
  - [ ] CI checks pass
  - [ ] Maintainer re-ran local tests

## Risk & Rollback
- Risk: low to medium; impact limited to touched module(s).
- Rollback: revert this PR commit(s) cleanly.

## Co-authorship
- Co-authored by @ciberponk and Codex (GPT-5).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `always` and `never` to the preference-detection regex in `detectCategory()`, aligning it with `MEMORY_TRIGGERS` which already captures text containing these words. Previously, statements like "I always use dark mode" would pass `shouldCapture` but then get mis-classified as `"fact"` (due to the broad substring-matching fact regex) instead of `"preference"`.

- `extensions/memory-lancedb/index.ts`: Extended the preference regex from `/prefer|radši|like|love|hate|want/i` to include `always|never`
- `extensions/memory-lancedb/index.test.ts`: Added two test assertions covering both new keywords
- No issues found — the change is minimal, logically consistent, and well-tested

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, well-scoped regex fix with matching test coverage.
- The change is a single-line regex addition that aligns `detectCategory` with the existing `MEMORY_TRIGGERS` capture logic. Both new keywords (`always`, `never`) are already recognized by `shouldCapture`, so this just fixes the downstream classification. The test additions directly cover the new behavior. No regressions, no side effects.
- No files require special attention.

<sub>Last reviewed commit: a3d0e20</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->