### PR TITLE
fix: status display reads session thinking/verbose/reasoning from session entry

### DIFF
--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -87,6 +87,81 @@ describe("buildStatusMessage", () => {
     expect(normalized).toContain("Queue: collect");
   });
 
+  it("falls back to sessionEntry.thinkingLevel when resolvedThink is omitted", () => {
+    const text = buildStatusMessage({
+      agent: { model: "anthropic/claude-opus-4-6", thinkingDefault: "low" },
+      sessionEntry: {
+        sessionId: "think-fallback",
+        updatedAt: 0,
+        thinkingLevel: "high",
+      },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+    });
+    expect(normalizeTestText(text)).toContain("Think: high");
+  });
+
+  it("falls back to sessionEntry.verboseLevel when resolvedVerbose is omitted", () => {
+    const text = buildStatusMessage({
+      agent: { model: "anthropic/claude-opus-4-6", verboseDefault: "off" },
+      sessionEntry: {
+        sessionId: "verbose-fallback",
+        updatedAt: 0,
+        verboseLevel: "full",
+      },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+    });
+    expect(normalizeTestText(text)).toContain("verbose:full");
+  });
+
+  it("falls back to sessionEntry.reasoningLevel when resolvedReasoning is omitted", () => {
+    const text = buildStatusMessage({
+      agent: { model: "anthropic/claude-opus-4-6" },
+      sessionEntry: {
+        sessionId: "reasoning-fallback",
+        updatedAt: 0,
+        reasoningLevel: "medium",
+      },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+    });
+    expect(normalizeTestText(text)).toContain("Reasoning: medium");
+  });
+
+  it("prefers resolvedThink over sessionEntry.thinkingLevel", () => {
+    const text = buildStatusMessage({
+      agent: { model: "anthropic/claude-opus-4-6" },
+      sessionEntry: {
+        sessionId: "think-prefer",
+        updatedAt: 0,
+        thinkingLevel: "low",
+      },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      resolvedThink: "high",
+      queue: { mode: "collect", depth: 0 },
+    });
+    expect(normalizeTestText(text)).toContain("Think: high");
+  });
+
+  it("falls back to thinkingDefault when neither resolvedThink nor sessionEntry.thinkingLevel is set", () => {
+    const text = buildStatusMessage({
+      agent: { model: "anthropic/claude-opus-4-6", thinkingDefault: "medium" },
+      sessionEntry: {
+        sessionId: "think-default",
+        updatedAt: 0,
+      },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+    });
+    expect(normalizeTestText(text)).toContain("Think: medium");
+  });
+
   it("uses per-agent sandbox config when config and session key are provided", () => {
     const text = buildStatusMessage({
       config: {

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -123,13 +123,13 @@ describe("buildStatusMessage", () => {
       sessionEntry: {
         sessionId: "reasoning-fallback",
         updatedAt: 0,
-        reasoningLevel: "medium",
+        reasoningLevel: "on",
       },
       sessionKey: "agent:main:main",
       sessionScope: "per-sender",
       queue: { mode: "collect", depth: 0 },
     });
-    expect(normalizeTestText(text)).toContain("Reasoning: medium");
+    expect(normalizeTestText(text)).toContain("Reasoning: on");
   });
 
   it("prefers resolvedThink over sessionEntry.thinkingLevel", () => {

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -378,9 +378,20 @@ export function buildStatusMessage(args: StatusArgs): string {
     }
   }
 
-  const thinkLevel = args.resolvedThink ?? args.agent?.thinkingDefault ?? "off";
-  const verboseLevel = args.resolvedVerbose ?? args.agent?.verboseDefault ?? "off";
-  const reasoningLevel = args.resolvedReasoning ?? "off";
+  const thinkLevel: ThinkLevel =
+    args.resolvedThink ??
+    (args.sessionEntry?.thinkingLevel as ThinkLevel | undefined) ??
+    args.agent?.thinkingDefault ??
+    "off";
+  const verboseLevel: VerboseLevel =
+    args.resolvedVerbose ??
+    (args.sessionEntry?.verboseLevel as VerboseLevel | undefined) ??
+    args.agent?.verboseDefault ??
+    "off";
+  const reasoningLevel: ReasoningLevel =
+    args.resolvedReasoning ??
+    (args.sessionEntry?.reasoningLevel as ReasoningLevel | undefined) ??
+    "off";
   const elevatedLevel =
     args.resolvedElevated ??
     args.sessionEntry?.elevatedLevel ??


### PR DESCRIPTION
## Problem

The `/status` slash command and `session_status` tool show the wrong thinking level. The runtime header (`thinking=X` in the system prompt) is correct, but the status display shows a stale/default value.

Fixes #10867

## Root Cause

`buildStatusMessage` had an inconsistency in its fallback chain: it checked `sessionEntry.elevatedLevel` as a fallback (when `resolvedElevated` was not provided), but did **not** check `sessionEntry.thinkingLevel`, `sessionEntry.verboseLevel`, or `sessionEntry.reasoningLevel`. This meant:

1. The `session_status` tool (which doesn't pre-resolve thinking levels) always fell through to `agent.thinkingDefault` instead of reading the session's actual level
2. Any caller that omits the pre-resolved values would show stale defaults

Additionally, the `session_status` tool called `buildStatusMessage` without passing `resolvedThink`, `resolvedVerbose`, `resolvedReasoning`, or `resolvedElevated`.

## Fix

### `src/auto-reply/status.ts` — `buildStatusMessage`
Add `sessionEntry` fallback for `thinkLevel`, `verboseLevel`, and `reasoningLevel`, matching the existing `elevatedLevel` pattern:

```ts
// Before:
const thinkLevel = args.resolvedThink ?? args.agent?.thinkingDefault ?? "off";

// After:
const thinkLevel = args.resolvedThink
  ?? args.sessionEntry?.thinkingLevel
  ?? args.agent?.thinkingDefault
  ?? "off";
```

### `src/agents/tools/session-status-tool.ts`
Explicitly resolve and pass all four level parameters (`resolvedThink`, `resolvedVerbose`, `resolvedReasoning`, `resolvedElevated`) to `buildStatusMessage`, mirroring the resolution chain used by the runtime header builder.

### Tests
5 new regression tests in `src/auto-reply/status.test.ts`:
- Falls back to `sessionEntry.thinkingLevel` when `resolvedThink` is omitted
- Falls back to `sessionEntry.verboseLevel` when `resolvedVerbose` is omitted
- Falls back to `sessionEntry.reasoningLevel` when `resolvedReasoning` is omitted
- Prefers `resolvedThink` over `sessionEntry.thinkingLevel`
- Falls back to `thinkingDefault` when neither is set

All 140 existing + new tests pass.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes an inconsistency in `buildStatusMessage` where `/status` and the `session_status` tool showed stale/default thinking, verbose, and reasoning levels instead of the actual session values.

- **`src/auto-reply/status.ts`**: Adds `sessionEntry` fallback for `thinkLevel`, `verboseLevel`, and `reasoningLevel` in the nullish coalescing chains, matching the existing `elevatedLevel` pattern. The fallback order is now: `resolvedX → sessionEntry.xLevel → agent.xDefault → "off"`.
- **`src/agents/tools/session-status-tool.ts`**: Explicitly resolves and passes all four level parameters (`resolvedThink`, `resolvedVerbose`, `resolvedReasoning`, `resolvedElevated`) to `buildStatusMessage`, using `resolveThinkingDefault` for the thinking level and appropriate defaults for the others — mirroring the resolution chain used by the runtime header builder.
- **`src/auto-reply/status.test.ts`**: Adds 5 regression tests covering the new fallback behavior (session entry fallback, precedence of `resolvedThink` over session entry, and final default fallback). Minor note: the reasoning level test uses `"medium"` which is not a valid `ReasoningLevel` value.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it corrects a display-only bug with a clean, well-tested fix.
- The fix is straightforward and consistent with existing patterns in the codebase. Both callers of `buildStatusMessage` are addressed. The fallback chains are correct and the changes are covered by 5 new regression tests. One minor style issue: a test uses an invalid `ReasoningLevel` value, but this doesn't affect correctness.
- No files require special attention.

<sub>Last reviewed commit: a8fadd9</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->