### PR TITLE
fix(image): allow workspace and sandbox media paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 - BlueBubbles: include sender identity in group chat envelopes and pass clean message text to the agent prompt, aligning with iMessage/Signal formatting. (#16210) Thanks @zerone0x.
 - WhatsApp: honor per-account `dmPolicy` overrides (account-level settings now take precedence over channel defaults for inbound DMs). (#10082) Thanks @mcaxtr.
 - Media: accept `MEDIA:`-prefixed paths (lenient whitespace) when loading outbound media to prevent `ENOENT` for tool-returned local media paths. (#13107) Thanks @mcaxtr.
+- Agents/Image tool: allow workspace-local image paths by including the active workspace directory in local media allowlists, and trust sandbox-validated paths in image loaders to prevent false "not under an allowed directory" rejections. (#15541)
 - Cron/Slack: preserve agent identity (name and icon) when cron jobs deliver outbound messages. (#16242) Thanks @robbyczgw-cla.
 - Cron: prevent `cron list`/`cron status` from silently skipping past-due recurring jobs by using maintenance recompute semantics. (#16156) Thanks @zerone0x.
 - Cron: repair missing/corrupt `nextRunAtMs` for the updated job without globally recomputing unrelated due jobs during `cron update`. (#15750)

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -64,6 +64,7 @@ export function createOpenClawTools(options?: {
     ? createImageTool({
         config: options?.config,
         agentDir: options.agentDir,
+        workspaceDir: options?.workspaceDir,
         sandbox:
           options?.sandboxRoot && options?.sandboxFsBridge
             ? { root: options.sandboxRoot, bridge: options.sandboxFsBridge }

--- a/src/agents/pi-embedded-runner/run/images.ts
+++ b/src/agents/pi-embedded-runner/run/images.ts
@@ -211,6 +211,7 @@ export async function loadImageFromRef(
     const media = options?.sandbox
       ? await loadWebMedia(targetPath, {
           maxBytes: options.maxBytes,
+          localRoots: "any",
           readFile: (filePath) =>
             options.sandbox!.bridge.readFile({ filePath, cwd: options.sandbox!.root }),
         })

--- a/src/agents/tools/image-tool.e2e.test.ts
+++ b/src/agents/tools/image-tool.e2e.test.ts
@@ -150,6 +150,75 @@ describe("image tool implicit imageModel config", () => {
     );
   });
 
+  it("allows workspace images outside default local media roots", async () => {
+    const workspaceParent = await fs.mkdtemp(
+      path.join(process.cwd(), ".openclaw-workspace-image-"),
+    );
+    try {
+      const workspaceDir = path.join(workspaceParent, "workspace");
+      await fs.mkdir(workspaceDir, { recursive: true });
+      const imagePath = path.join(workspaceDir, "photo.png");
+      const pngB64 =
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=";
+      await fs.writeFile(imagePath, Buffer.from(pngB64, "base64"));
+
+      const fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        headers: new Headers(),
+        json: async () => ({
+          content: "ok",
+          base_resp: { status_code: 0, status_msg: "" },
+        }),
+      });
+      // @ts-expect-error partial global
+      global.fetch = fetch;
+      vi.stubEnv("MINIMAX_API_KEY", "minimax-test");
+
+      const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-image-"));
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            model: { primary: "minimax/MiniMax-M2.1" },
+            imageModel: { primary: "minimax/MiniMax-VL-01" },
+          },
+        },
+      };
+
+      const withoutWorkspace = createImageTool({ config: cfg, agentDir });
+      expect(withoutWorkspace).not.toBeNull();
+      if (!withoutWorkspace) {
+        throw new Error("expected image tool");
+      }
+      await expect(
+        withoutWorkspace.execute("t0", {
+          prompt: "Describe the image.",
+          image: imagePath,
+        }),
+      ).rejects.toThrow(/Local media path is not under an allowed directory/i);
+
+      const withWorkspace = createImageTool({ config: cfg, agentDir, workspaceDir });
+      expect(withWorkspace).not.toBeNull();
+      if (!withWorkspace) {
+        throw new Error("expected image tool");
+      }
+
+      await expect(
+        withWorkspace.execute("t1", {
+          prompt: "Describe the image.",
+          image: imagePath,
+        }),
+      ).resolves.toMatchObject({
+        content: [{ type: "text", text: "ok" }],
+      });
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+    } finally {
+      await fs.rm(workspaceParent, { recursive: true, force: true });
+    }
+  });
+
   it("sandboxes image paths like the read tool", async () => {
     const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-image-sandbox-"));
     const agentDir = path.join(stateDir, "agent");

--- a/src/web/media.ts
+++ b/src/web/media.ts
@@ -32,7 +32,6 @@ type WebMediaOptions = {
   readFile?: (filePath: string) => Promise<Buffer>;
 };
 
-<<<<<<< HEAD
 export function getDefaultLocalRoots(): string[] {
   return [
     os.tmpdir(),

--- a/src/web/media.ts
+++ b/src/web/media.ts
@@ -32,7 +32,8 @@ type WebMediaOptions = {
   readFile?: (filePath: string) => Promise<Buffer>;
 };
 
-function getDefaultLocalRoots(): string[] {
+<<<<<<< HEAD
+export function getDefaultLocalRoots(): string[] {
   return [
     os.tmpdir(),
     path.join(STATE_DIR, "media"),


### PR DESCRIPTION
## Summary

Fixes an image tool regression where local file inputs were blocked unless they were inside three hardcoded directories.

### Bug
The image tool path validation only allowed local files from three fixed roots, which incorrectly rejected valid local files in other approved areas (including workspace and sandbox-validated paths).

### Fix
- Wire the workspace directory into the image tool allowlist so workspace local files are accepted.
- Pass `localRoots: "any"` for paths that have already been validated by sandbox path checks, so valid sandbox-local media paths are not re-blocked by the hardcoded root list.

Closes #15541

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixed image tool path validation regression by adding workspace directory to the media allowlist and bypassing redundant checks for sandbox-validated paths. The changes allow local image files in workspace directories and sandbox-approved areas to be processed without being incorrectly rejected by the hardcoded root list.

Key changes:
- Added `workspaceDir` parameter to image tool creation chain (`openclaw-tools.ts` → `image-tool.ts`)
- Modified `getDefaultLocalRoots()` to be exported so workspace paths can be added dynamically
- Set `localRoots: "any"` for sandbox-validated paths in both `image-tool.ts` and `images.ts` to skip redundant validation
- Added comprehensive test coverage for workspace and sandbox scenarios

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is narrowly scoped, well-tested, and follows security best practices by maintaining path validation while fixing false rejections. The sandbox paths are already validated by sandbox checks before passing `localRoots: "any"`, so bypassing redundant checks is safe. New tests verify both workspace and sandbox scenarios work correctly.
- No files require special attention

<sub>Last reviewed commit: fc6682d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->