### PR TITLE
fix: /status shows stale thinking level after directive change

### DIFF
--- a/src/auto-reply/reply/get-reply-directives-apply.ts
+++ b/src/auto-reply/reply/get-reply-directives-apply.ts
@@ -164,6 +164,17 @@ export async function applyInlineDirectiveOverrides(params: {
     });
     let statusReply: ReplyPayload | undefined;
     if (directives.hasStatusDirective && allowTextCommands && command.isAuthorizedSender) {
+      // Re-resolve levels after handleDirectiveOnly may have mutated sessionEntry
+      const postDirectiveThinkLevel =
+        (sessionEntry?.thinkingLevel as ThinkLevel | undefined) ?? resolvedDefaultThinkLevel;
+      const postDirectiveVerboseLevel =
+        (sessionEntry?.verboseLevel as VerboseLevel | undefined) ?? currentVerboseLevel ?? "off";
+      const postDirectiveReasoningLevel =
+        (sessionEntry?.reasoningLevel as ReasoningLevel | undefined) ??
+        currentReasoningLevel ??
+        "off";
+      const postDirectiveElevatedLevel =
+        (sessionEntry?.elevatedLevel as ElevatedLevel | undefined) ?? resolvedElevatedLevel;
       statusReply = await buildStatusReply({
         cfg,
         command,
@@ -173,11 +184,11 @@ export async function applyInlineDirectiveOverrides(params: {
         provider,
         model,
         contextTokens,
-        resolvedThinkLevel: resolvedDefaultThinkLevel,
-        resolvedVerboseLevel: currentVerboseLevel ?? "off",
-        resolvedReasoningLevel: currentReasoningLevel ?? "off",
-        resolvedElevatedLevel,
-        resolveDefaultThinkingLevel: async () => resolvedDefaultThinkLevel,
+        resolvedThinkLevel: postDirectiveThinkLevel,
+        resolvedVerboseLevel: postDirectiveVerboseLevel,
+        resolvedReasoningLevel: postDirectiveReasoningLevel,
+        resolvedElevatedLevel: postDirectiveElevatedLevel,
+        resolveDefaultThinkingLevel: async () => postDirectiveThinkLevel,
         isGroup,
         defaultGroupActivation: defaultActivation,
         mediaDecisions: ctx.MediaUnderstandingDecisions,

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -87,6 +87,81 @@ describe("buildStatusMessage", () => {
     expect(normalized).toContain("Queue: collect");
   });
 
+  it("falls back to sessionEntry.thinkingLevel when resolvedThink is omitted", () => {
+    const text = buildStatusMessage({
+      agent: { model: "anthropic/claude-opus-4-6", thinkingDefault: "low" },
+      sessionEntry: {
+        sessionId: "think-fallback",
+        updatedAt: 0,
+        thinkingLevel: "high",
+      },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+    });
+    expect(normalizeTestText(text)).toContain("Think: high");
+  });
+
+  it("falls back to sessionEntry.verboseLevel when resolvedVerbose is omitted", () => {
+    const text = buildStatusMessage({
+      agent: { model: "anthropic/claude-opus-4-6", verboseDefault: "off" },
+      sessionEntry: {
+        sessionId: "verbose-fallback",
+        updatedAt: 0,
+        verboseLevel: "full",
+      },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+    });
+    expect(normalizeTestText(text)).toContain("verbose:full");
+  });
+
+  it("falls back to sessionEntry.reasoningLevel when resolvedReasoning is omitted", () => {
+    const text = buildStatusMessage({
+      agent: { model: "anthropic/claude-opus-4-6" },
+      sessionEntry: {
+        sessionId: "reasoning-fallback",
+        updatedAt: 0,
+        reasoningLevel: "medium",
+      },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+    });
+    expect(normalizeTestText(text)).toContain("Reasoning: medium");
+  });
+
+  it("prefers resolvedThink over sessionEntry.thinkingLevel", () => {
+    const text = buildStatusMessage({
+      agent: { model: "anthropic/claude-opus-4-6" },
+      sessionEntry: {
+        sessionId: "think-prefer",
+        updatedAt: 0,
+        thinkingLevel: "low",
+      },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      resolvedThink: "high",
+      queue: { mode: "collect", depth: 0 },
+    });
+    expect(normalizeTestText(text)).toContain("Think: high");
+  });
+
+  it("falls back to thinkingDefault when neither resolvedThink nor sessionEntry.thinkingLevel is set", () => {
+    const text = buildStatusMessage({
+      agent: { model: "anthropic/claude-opus-4-6", thinkingDefault: "medium" },
+      sessionEntry: {
+        sessionId: "think-default",
+        updatedAt: 0,
+      },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+    });
+    expect(normalizeTestText(text)).toContain("Think: medium");
+  });
+
   it("uses per-agent sandbox config when config and session key are provided", () => {
     const text = buildStatusMessage({
       config: {

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -123,13 +123,13 @@ describe("buildStatusMessage", () => {
       sessionEntry: {
         sessionId: "reasoning-fallback",
         updatedAt: 0,
-        reasoningLevel: "medium",
+        reasoningLevel: "on",
       },
       sessionKey: "agent:main:main",
       sessionScope: "per-sender",
       queue: { mode: "collect", depth: 0 },
     });
-    expect(normalizeTestText(text)).toContain("Reasoning: medium");
+    expect(normalizeTestText(text)).toContain("Reasoning: on");
   });
 
   it("prefers resolvedThink over sessionEntry.thinkingLevel", () => {

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -378,9 +378,20 @@ export function buildStatusMessage(args: StatusArgs): string {
     }
   }
 
-  const thinkLevel = args.resolvedThink ?? args.agent?.thinkingDefault ?? "off";
-  const verboseLevel = args.resolvedVerbose ?? args.agent?.verboseDefault ?? "off";
-  const reasoningLevel = args.resolvedReasoning ?? "off";
+  const thinkLevel: ThinkLevel =
+    args.resolvedThink ??
+    (args.sessionEntry?.thinkingLevel as ThinkLevel | undefined) ??
+    args.agent?.thinkingDefault ??
+    "off";
+  const verboseLevel: VerboseLevel =
+    args.resolvedVerbose ??
+    (args.sessionEntry?.verboseLevel as VerboseLevel | undefined) ??
+    args.agent?.verboseDefault ??
+    "off";
+  const reasoningLevel: ReasoningLevel =
+    args.resolvedReasoning ??
+    (args.sessionEntry?.reasoningLevel as ReasoningLevel | undefined) ??
+    "off";
   const elevatedLevel =
     args.resolvedElevated ??
     args.sessionEntry?.elevatedLevel ??


### PR DESCRIPTION
## Problem
When `/think high /status` (or any `/think X /status` combo) is sent as a directive-only message, the `Think:` field in the status reply shows the **old** thinking level rather than the just-applied one.

### Root cause
In `get-reply-directives-apply.ts`, `resolvedDefaultThinkLevel` is computed **before** `handleDirectiveOnly` runs. `handleDirectiveOnly` mutates `sessionEntry.thinkingLevel` to the new value, but the status reply still receives the stale pre-directive value.

## Fix
After `handleDirectiveOnly` returns, re-resolve all directive levels from `sessionEntry` before passing them to `buildStatusReply`. This ensures the status output reflects the just-applied changes.

The same pattern is applied to verbose, reasoning, and elevated levels for consistency.

## Tests
Added two regression tests to `status.test.ts`:
- Verifies `resolvedThink` matching the updated `sessionEntry.thinkingLevel` shows correctly
- Verifies `sessionEntry.thinkingLevel` fallback works when `resolvedThink` is omitted

All 28 tests pass.

Closes #10867

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a stale status display bug where `/think high /status` (or any `/directive /status` combo) showed the old thinking level instead of the just-applied one. The fix re-resolves all directive levels (`thinkingLevel`, `verboseLevel`, `reasoningLevel`, `elevatedLevel`) from `sessionEntry` after `handleDirectiveOnly` mutates them, ensuring the status output reflects the current state.

Key changes:
- `get-reply-directives-apply.ts`: Re-reads directive levels from `sessionEntry` after `handleDirectiveOnly` completes before passing to `buildStatusReply`
- `status.ts`: Updated fallback chain to check `sessionEntry` levels when `resolved*` params are omitted
- `session-status-tool.ts`: Now explicitly resolves and passes all directive levels to `buildStatusMessage`
- Added comprehensive regression tests covering fallback behavior and the specific bug scenario
- Unrelated fix: `gateway-lock.test.ts` switched from fake timers to real timers to avoid intermittent CI hangs

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix correctly addresses the root cause by re-resolving directive levels after mutation. The implementation follows existing patterns, includes comprehensive regression tests (8 new test cases covering fallback chains and the bug scenario), and all 28 tests pass. The logic is straightforward with no edge cases or security concerns.
- No files require special attention

<sub>Last reviewed commit: 1516698</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->