### PR TITLE
fix: Windows CI safeBins tests fail because isSafeBinUsage unconditionally returns false

### DIFF
--- a/src/infra/exec-approvals.test.ts
+++ b/src/infra/exec-approvals.test.ts
@@ -439,28 +439,34 @@ describe("exec approvals allowlist evaluation", () => {
   });
 
   it("satisfies allowlist via safe bins", () => {
-    const analysis = {
-      ok: true,
-      segments: [
-        {
-          raw: "jq .foo",
-          argv: ["jq", ".foo"],
-          resolution: {
-            rawExecutable: "jq",
-            resolvedPath: "/usr/bin/jq",
-            executableName: "jq",
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "linux" });
+    try {
+      const analysis = {
+        ok: true,
+        segments: [
+          {
+            raw: "jq .foo",
+            argv: ["jq", ".foo"],
+            resolution: {
+              rawExecutable: "jq",
+              resolvedPath: "/usr/bin/jq",
+              executableName: "jq",
+            },
           },
-        },
-      ],
-    };
-    const result = evaluateExecAllowlist({
-      analysis,
-      allowlist: [],
-      safeBins: normalizeSafeBins(["jq"]),
-      cwd: "/tmp",
-    });
-    expect(result.allowlistSatisfied).toBe(true);
-    expect(result.allowlistMatches).toEqual([]);
+        ],
+      };
+      const result = evaluateExecAllowlist({
+        analysis,
+        allowlist: [],
+        safeBins: normalizeSafeBins(["jq"]),
+        cwd: "/tmp",
+      });
+      expect(result.allowlistSatisfied).toBe(true);
+      expect(result.allowlistMatches).toEqual([]);
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    }
   });
 
   it("satisfies allowlist via auto-allow skills", () => {
@@ -634,24 +640,30 @@ describe("exec approvals node host allowlist check", () => {
   });
 
   it("satisfies via safeBins even when not in allowlist", () => {
-    const resolution = {
-      rawExecutable: "jq",
-      resolvedPath: "/usr/bin/jq",
-      executableName: "jq",
-    };
-    // Not in allowlist
-    const entries: ExecAllowlistEntry[] = [{ pattern: "/usr/bin/python3" }];
-    const match = matchAllowlist(entries, resolution);
-    expect(match).toBeNull();
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "linux" });
+    try {
+      const resolution = {
+        rawExecutable: "jq",
+        resolvedPath: "/usr/bin/jq",
+        executableName: "jq",
+      };
+      // Not in allowlist
+      const entries: ExecAllowlistEntry[] = [{ pattern: "/usr/bin/python3" }];
+      const match = matchAllowlist(entries, resolution);
+      expect(match).toBeNull();
 
-    // But is a safe bin with non-file args
-    const safe = isSafeBinUsage({
-      argv: ["jq", ".foo"],
-      resolution,
-      safeBins: normalizeSafeBins(["jq"]),
-      cwd: "/tmp",
-    });
-    expect(safe).toBe(true);
+      // But is a safe bin with non-file args
+      const safe = isSafeBinUsage({
+        argv: ["jq", ".foo"],
+        resolution,
+        safeBins: normalizeSafeBins(["jq"]),
+        cwd: "/tmp",
+      });
+      expect(safe).toBe(true);
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    }
   });
 });
 


### PR DESCRIPTION
## Problem

Two tests in `src/infra/exec-approvals.test.ts` fail on Windows CI:
- "satisfies allowlist via safe bins"
- "satisfies via safeBins even when not in allowlist"

`isSafeBinUsage()` calls `isWindowsPlatform(process.platform)` and returns `false` early on Windows. The tests use hardcoded Unix-style resolution objects and expect `true`.

## Fix

Mock `process.platform` to `"linux"` in these two tests so the safe-bin logic is actually exercised regardless of the host OS.

Fixes #16695

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixed two Windows CI test failures by mocking `process.platform` to `"linux"` in tests that validate safe-bin allowlist logic. The tests use Unix-style paths and were failing because `isSafeBinUsage()` unconditionally returns false on Windows platforms (intentional behavior due to different PowerShell parsing rules). The mock ensures the safe-bin validation logic is properly exercised across all CI platforms.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix correctly addresses Windows CI test failures using an established mocking pattern already present in the codebase. The changes are test-only, properly scoped with try-finally cleanup, and follow existing conventions. No logic or security issues found.
- No files require special attention

<sub>Last reviewed commit: 70296eb</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->