### PR TITLE
fix(memory-lancedb): classify important statements as preference

### DIFF
--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -146,6 +146,7 @@ describe("memory plugin e2e", () => {
     const { detectCategory } = await import("./index.js");
 
     expect(detectCategory("I prefer dark mode")).toBe("preference");
+    expect(detectCategory("This is important for me")).toBe("preference");
     expect(detectCategory("We decided to use React")).toBe("decision");
     expect(detectCategory("My email is test@example.com")).toBe("entity");
     expect(detectCategory("The server is running on port 3000")).toBe("fact");

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -222,7 +222,7 @@ export function shouldCapture(text: string, options?: { maxChars?: number }): bo
 
 export function detectCategory(text: string): MemoryCategory {
   const lower = text.toLowerCase();
-  if (/prefer|radši|like|love|hate|want/i.test(lower)) {
+  if (/prefer|radši|like|love|hate|want|important/i.test(lower)) {
     return "preference";
   }
   if (/rozhodli|decided|will use|budeme/i.test(lower)) {


### PR DESCRIPTION
## Summary
- fix(memory-lancedb): classify important statements as preference
- Split from our `v2026.2.13` patch train as a single-purpose change for easier review.

## Why
- Keep the diff focused and low-risk so it can be merged or reverted independently.

## Scope
- Branch: `fix/memory-lancedb-classify-important-preference-en`
- Files changed: 2
- Key files:
  - `extensions/memory-lancedb/index.test.ts`
  - `extensions/memory-lancedb/index.ts`

## Test Plan
- Suggested local command:
  - `./node_modules/.bin/vitest run extensions/memory-lancedb/index.test.ts`
- Validation status:
  - [ ] CI checks pass
  - [ ] Maintainer re-ran local tests

## Risk & Rollback
- Risk: low to medium; impact limited to touched module(s).
- Rollback: revert this PR commit(s) cleanly.

## Co-authorship
- Co-authored by @ciberponk and Codex (GPT-5).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the keyword `important` to the preference-detection regex in `detectCategory()` within the memory-lancedb extension. Previously, statements like "This is important for me" would fall through to the "fact" category (matching on the word "is"), despite the word "important" already being recognized as a memory capture trigger in `MEMORY_TRIGGERS`. This fix aligns the category classification with the capture eligibility logic.

- Added `important` to the preference regex in `detectCategory()` (`extensions/memory-lancedb/index.ts:225`)
- Added a corresponding test case verifying the new classification (`extensions/memory-lancedb/index.test.ts:149`)
- No issues found: the change is minimal, focused, and consistent with existing patterns

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — a single keyword addition to a regex with a matching test.
- The change is a one-word addition to an existing regex pattern in a rule-based text classifier, with a corresponding test. The keyword `important` was already recognized as a capture trigger in `MEMORY_TRIGGERS`, so this simply aligns the category classification. No new code paths, no API changes, no risk of regression.
- No files require special attention.

<sub>Last reviewed commit: 389bddd</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->