### PR TITLE
Gateway: add fs.write RPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Gateway: add `fs.write` RPC method so web clients can write base64-encoded attachments directly into the sandbox workspace over the existing gateway WebSocket connection. (#16709) Thanks @advaitpaliwal.
 - Telegram: add poll sending via `openclaw message poll` (duration seconds, silent delivery, anonymity controls). (#16209) Thanks @robbyczgw-cla.
 - Discord: allow exec approval prompts to target channels or both DM+channel via `channels.discord.execApprovals.target`. (#16051) Thanks @leonnardo.
 - Slack/Discord: add `dmPolicy` + `allowFrom` config aliases for DM access control; legacy `dm.policy` + `dm.allowFrom` keys remain supported and `openclaw doctor --fix` can migrate them.

--- a/src/gateway/protocol/index.ts
+++ b/src/gateway/protocol/index.ts
@@ -120,6 +120,8 @@ import {
   type EventFrame,
   EventFrameSchema,
   errorShape,
+  type FsWriteParams,
+  FsWriteParamsSchema,
   type GatewayFrame,
   GatewayFrameSchema,
   type HelloOk,
@@ -367,6 +369,7 @@ export const validateUpdateRunParams = ajv.compile<UpdateRunParams>(UpdateRunPar
 export const validateWebLoginStartParams =
   ajv.compile<WebLoginStartParams>(WebLoginStartParamsSchema);
 export const validateWebLoginWaitParams = ajv.compile<WebLoginWaitParams>(WebLoginWaitParamsSchema);
+export const validateFsWriteParams = ajv.compile<FsWriteParams>(FsWriteParamsSchema);
 
 export function formatValidationErrors(errors: ErrorObject[] | null | undefined) {
   if (!errors?.length) {
@@ -491,6 +494,7 @@ export {
   ChatHistoryParamsSchema,
   ChatSendParamsSchema,
   ChatInjectParamsSchema,
+  FsWriteParamsSchema,
   UpdateRunParamsSchema,
   TickEventSchema,
   ShutdownEventSchema,
@@ -600,4 +604,5 @@ export type {
   PollParams,
   UpdateRunParams,
   ChatInjectParams,
+  FsWriteParams,
 };

--- a/src/gateway/protocol/schema.ts
+++ b/src/gateway/protocol/schema.ts
@@ -7,6 +7,7 @@ export * from "./schema/error-codes.js";
 export * from "./schema/exec-approvals.js";
 export * from "./schema/devices.js";
 export * from "./schema/frames.js";
+export * from "./schema/fs.js";
 export * from "./schema/logs-chat.js";
 export * from "./schema/nodes.js";
 export * from "./schema/protocol-schemas.js";

--- a/src/gateway/protocol/schema/fs.ts
+++ b/src/gateway/protocol/schema/fs.ts
@@ -1,0 +1,16 @@
+import { Type } from "@sinclair/typebox";
+import { NonEmptyString } from "./primitives.js";
+
+export const FsWriteParamsSchema = Type.Object(
+  {
+    path: NonEmptyString,
+    content: NonEmptyString,
+  },
+  { additionalProperties: false },
+);
+
+export type FsWriteParams = {
+  path: string;
+  /** Base64-encoded bytes to write. */
+  content: string;
+};

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -40,6 +40,7 @@ const BASE_METHODS = [
   "agents.files.list",
   "agents.files.get",
   "agents.files.set",
+  "fs.write",
   "skills.status",
   "skills.bins",
   "skills.install",

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -10,6 +10,7 @@ import { connectHandlers } from "./server-methods/connect.js";
 import { cronHandlers } from "./server-methods/cron.js";
 import { deviceHandlers } from "./server-methods/devices.js";
 import { execApprovalsHandlers } from "./server-methods/exec-approvals.js";
+import { fsHandlers } from "./server-methods/fs.js";
 import { healthHandlers } from "./server-methods/health.js";
 import { logsHandlers } from "./server-methods/logs.js";
 import { modelsHandlers } from "./server-methods/models.js";
@@ -94,6 +95,7 @@ const WRITE_METHODS = new Set([
   "chat.send",
   "chat.abort",
   "browser.request",
+  "fs.write",
 ]);
 
 function authorizeGatewayMethod(method: string, client: GatewayRequestOptions["client"]) {
@@ -170,6 +172,7 @@ function authorizeGatewayMethod(method: string, client: GatewayRequestOptions["c
 
 export const coreGatewayHandlers: GatewayRequestHandlers = {
   ...connectHandlers,
+  ...fsHandlers,
   ...logsHandlers,
   ...voicewakeHandlers,
   ...healthHandlers,

--- a/src/gateway/server-methods/fs.test.ts
+++ b/src/gateway/server-methods/fs.test.ts
@@ -1,0 +1,124 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import type { GatewayRequestContext } from "./types.js";
+import { withTempHome } from "../../../test/helpers/temp-home.js";
+
+describe("fs.write", () => {
+  it("writes base64-decoded bytes within the workspace and creates parent dirs", async () => {
+    await withTempHome(
+      async () => {
+        vi.resetModules();
+
+        const [{ fsHandlers }, { DEFAULT_AGENT_WORKSPACE_DIR }] = await Promise.all([
+          import("./fs.js"),
+          import("../../agents/workspace.js"),
+        ]);
+
+        let captured:
+          | { ok: true; payload: unknown }
+          | { ok: false; error: { code?: string; message?: string } | undefined }
+          | null = null;
+        const respond = (ok: boolean, payload?: unknown, error?: unknown) => {
+          captured = ok
+            ? { ok: true, payload }
+            : {
+                ok: false,
+                error:
+                  error && typeof error === "object"
+                    ? (error as { code?: string; message?: string })
+                    : undefined,
+              };
+        };
+
+        await fsHandlers["fs.write"]({
+          req: { type: "req", id: "t1", method: "fs.write", params: {} } as unknown as never,
+          params: {
+            path: "media/inbound/test.txt",
+            content: "SGVsbG8gV29ybGQ=",
+          },
+          client: null,
+          isWebchatConnect: () => false,
+          respond,
+          context: {} as unknown as GatewayRequestContext,
+        });
+
+        expect(captured).not.toBeNull();
+        expect(captured && captured.ok).toBe(true);
+
+        const outPath = path.join(DEFAULT_AGENT_WORKSPACE_DIR, "media", "inbound", "test.txt");
+        await expect(fs.stat(outPath)).resolves.toBeTruthy();
+        await expect(fs.readFile(outPath, "utf-8")).resolves.toBe("Hello World");
+      },
+      { env: { OPENCLAW_PROFILE: "fs-write-test" } },
+    );
+  });
+
+  it("rejects path traversal attempts", async () => {
+    await withTempHome(
+      async () => {
+        vi.resetModules();
+        const { fsHandlers } = await import("./fs.js");
+
+        let captured: { ok: boolean; error?: { message?: string } } | null = null;
+        const respond = (ok: boolean, _payload?: unknown, error?: unknown) => {
+          captured = {
+            ok,
+            error: error && typeof error === "object" ? (error as { message?: string }) : undefined,
+          };
+        };
+
+        await fsHandlers["fs.write"]({
+          req: { type: "req", id: "t2", method: "fs.write", params: {} } as unknown as never,
+          params: {
+            path: "../../etc/passwd",
+            content: "SGVsbG8=",
+          },
+          client: null,
+          isWebchatConnect: () => false,
+          respond,
+          context: {} as unknown as GatewayRequestContext,
+        });
+
+        expect(captured).not.toBeNull();
+        expect(captured?.ok).toBe(false);
+        expect(captured?.error?.message ?? "").toContain("within workspace");
+      },
+      { env: { OPENCLAW_PROFILE: "fs-write-test" } },
+    );
+  });
+
+  it("rejects invalid base64", async () => {
+    await withTempHome(
+      async () => {
+        vi.resetModules();
+        const { fsHandlers } = await import("./fs.js");
+
+        let captured: { ok: boolean; error?: { message?: string } } | null = null;
+        const respond = (ok: boolean, _payload?: unknown, error?: unknown) => {
+          captured = {
+            ok,
+            error: error && typeof error === "object" ? (error as { message?: string }) : undefined,
+          };
+        };
+
+        await fsHandlers["fs.write"]({
+          req: { type: "req", id: "t3", method: "fs.write", params: {} } as unknown as never,
+          params: {
+            path: "media/inbound/bad.bin",
+            content: "not base64!!!",
+          },
+          client: null,
+          isWebchatConnect: () => false,
+          respond,
+          context: {} as unknown as GatewayRequestContext,
+        });
+
+        expect(captured).not.toBeNull();
+        expect(captured?.ok).toBe(false);
+        expect(captured?.error?.message ?? "").toContain("base64");
+      },
+      { env: { OPENCLAW_PROFILE: "fs-write-test" } },
+    );
+  });
+});

--- a/src/gateway/server-methods/fs.ts
+++ b/src/gateway/server-methods/fs.ts
@@ -1,0 +1,119 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { GatewayRequestHandlers } from "./types.js";
+import { DEFAULT_AGENT_WORKSPACE_DIR } from "../../agents/workspace.js";
+import {
+  ErrorCodes,
+  errorShape,
+  formatValidationErrors,
+  validateFsWriteParams,
+} from "../protocol/index.js";
+
+function isLikelyBase64(input: string): boolean {
+  // Reject obviously-invalid input early so we don't silently write corrupted bytes.
+  // Accept unpadded base64 (we normalize padding below).
+  return /^[A-Za-z0-9+/]+={0,2}$/.test(input) && input.length % 4 !== 1;
+}
+
+function normalizeBase64(input: string): string | null {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return null;
+  }
+  if (!isLikelyBase64(trimmed)) {
+    return null;
+  }
+  const mod = trimmed.length % 4;
+  if (mod === 0) {
+    return trimmed;
+  }
+  if (mod === 2) {
+    return `${trimmed}==`;
+  }
+  if (mod === 3) {
+    return `${trimmed}=`;
+  }
+  return null;
+}
+
+function resolveWorkspacePath(relativePath: string): { ok: true; absPath: string } | { ok: false } {
+  const trimmed = relativePath.trim();
+  if (!trimmed) {
+    return { ok: false };
+  }
+  if (path.isAbsolute(trimmed)) {
+    return { ok: false };
+  }
+
+  const absPath = path.resolve(DEFAULT_AGENT_WORKSPACE_DIR, trimmed);
+  const rel = path.relative(DEFAULT_AGENT_WORKSPACE_DIR, absPath);
+
+  // `path.relative` can return paths like "..\\.." on Windows. It also returns absolute
+  // paths when drives differ, so guard both.
+  if (!rel || rel === "." || rel.startsWith("..") || path.isAbsolute(rel)) {
+    return { ok: false };
+  }
+
+  return { ok: true, absPath };
+}
+
+export const fsHandlers: GatewayRequestHandlers = {
+  "fs.write": async ({ params, respond }) => {
+    if (!validateFsWriteParams(params)) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          `invalid fs.write params: ${formatValidationErrors(validateFsWriteParams.errors)}`,
+        ),
+      );
+      return;
+    }
+
+    const relativePath = params.path;
+    const content = params.content;
+    const normalizedBase64 = normalizeBase64(content);
+    if (!normalizedBase64) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "content must be base64"));
+      return;
+    }
+
+    const resolved = resolveWorkspacePath(relativePath);
+    if (!resolved.ok) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "path must be relative and within workspace"),
+      );
+      return;
+    }
+
+    let buffer: Buffer;
+    try {
+      buffer = Buffer.from(normalizedBase64, "base64");
+    } catch (err) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          err instanceof Error ? err.message : "invalid base64",
+        ),
+      );
+      return;
+    }
+
+    try {
+      await fs.mkdir(path.dirname(resolved.absPath), { recursive: true });
+      await fs.writeFile(resolved.absPath, buffer);
+      respond(true, { ok: true, path: relativePath, size: buffer.length }, undefined);
+    } catch (err) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.UNAVAILABLE, err instanceof Error ? err.message : "write failed"),
+      );
+    }
+  },
+};


### PR DESCRIPTION
## Summary

- Problem: web uploads to sandbox currently require proxying through HTTP routes, which can hit body size limits and adds bandwidth/latency.
- Why it matters: large attachments (images, PDFs) should be able to land in the sandbox workspace via the already-authenticated gateway WS connection.
- What changed: added a new gateway WS RPC method `fs.write` that writes base64-decoded bytes to a relative path inside the sandbox workspace (with traversal protection + auto-mkdir), plus protocol schema/validator and tests.
- What did NOT change (scope boundary): no changes to existing chat/media pipelines or HTTP upload routes.
- AI-assisted: Yes (Codex). Verified via `pnpm build`, `pnpm check`, `pnpm test`.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: companion-cloud internal task "fs.write" gateway RPC

## User-visible / Behavior Changes

- New gateway method: `fs.write` (operator.write scoped) writes base64 bytes to `DEFAULT_AGENT_WORKSPACE_DIR/<relative path>`.

## Security Impact (required)

- New permissions/capabilities? (Yes)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (Yes)
- If any Yes, explain risk + mitigation:
  - Risk: remote clients with `operator.write` can write files into the sandbox workspace.
  - Mitigation: strict param validation, base64 validation, absolute/traversal path rejection, workspace bounds enforcement, and existing gateway auth + scope gating.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node 22+

### Steps

1. Connect to gateway WebSocket and authenticate.
2. Send `{ "type":"req", "id":"1", "method":"fs.write", "params": { "path":"media/inbound/test.txt", "content":"SGVsbG8gV29ybGQ=" } }`.

### Expected

- File is written under the sandbox workspace and response payload includes `{ ok: true, path, size }`.

## Evidence

- Added gateway unit tests: `src/gateway/server-methods/fs.test.ts`.

## Human Verification (required)

- Verified scenarios:
  - Writes base64-decoded bytes; creates parent directories.
  - Rejects traversal/absolute paths.
  - Rejects invalid base64.
- What you did not verify:
  - Live browser -> gateway integration (web app change is separate).

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)

## Failure Recovery (if this breaks)

- Disable/revert by removing the handler wiring for `fs.write`.

## Risks and Mitigations

- Risk: unintended file writes if clients pass unexpected paths/content.
  - Mitigation: strict schema validation, path bounds checks, and base64 validation.
