### PR TITLE
feat(feishu): add reaction event support (created/deleted)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 - Android/Gateway capability refresh: add live Android capability integration coverage and node canvas capability refresh wiring, plus runtime hardening for A2UI readiness retries, scoped canvas URL normalization, debug diagnostics JSON, and JavaScript MIME delivery. (#28388) Thanks @obviyus.
 - Feishu/Doc permissions: support optional owner permission grant fields on `feishu_doc` create and report permission metadata only when the grant call succeeds, with regression coverage for success/failure/omitted-owner paths. (#28295) Thanks @zhoulongchao77.
 - Feishu/Docx tables + uploads: add `feishu_doc` actions for Docx table creation/cell writing (`create_table`, `write_table_cells`, `create_table_with_values`) and image/file uploads (`upload_image`, `upload_file`) with stricter create/upload error handling for missing `document_id` and placeholder cleanup failures. (#20304) Thanks @xuhao1.
+- Feishu/Reactions: add inbound `im.message.reaction.created_v1` handling, route verified reactions through synthetic inbound turns, and harden verification with timeout + fail-closed filtering so non-bot or unverified reactions are dropped. (#16716) Thanks @schumilin.
 - Memory/LanceDB: support custom OpenAI `baseUrl` and embedding dimensions for LanceDB memory. (#17874) Thanks @rish2jain and @vincentkoc.
 
 ### Fixes

--- a/extensions/feishu/src/monitor.reaction.test.ts
+++ b/extensions/feishu/src/monitor.reaction.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { FeishuMessageEvent } from "./bot.js";
+
+/**
+ * Tests for reaction event handling in monitor.ts.
+ *
+ * Since registerEventHandlers is not exported, we test the reaction handling
+ * logic by extracting and verifying the behavior inline: filtering rules,
+ * synthetic event construction, and dispatch.
+ */
+
+// Mock handleFeishuMessage to capture calls
+const mockHandleFeishuMessage = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("./bot.js", () => ({
+  handleFeishuMessage: (...args: unknown[]) => mockHandleFeishuMessage(...args),
+}));
+
+// Simulate the reaction event filtering and synthetic message construction
+// extracted from monitor.ts registerEventHandlers
+function processReactionEvent(
+  data: {
+    message_id: string;
+    reaction_type: { emoji_type: string };
+    operator_type: string;
+    user_id: { open_id: string };
+    action_time?: string;
+  },
+  botOpenId: string | undefined,
+): FeishuMessageEvent | null {
+  const emoji = data.reaction_type?.emoji_type;
+  const messageId = data.message_id;
+  const senderId = data.user_id?.open_id;
+
+  // Skip bot self-reactions
+  if (data.operator_type === "app" || senderId === botOpenId) {
+    return null;
+  }
+
+  // Skip typing indicator emoji
+  if (emoji === "Typing") {
+    return null;
+  }
+
+  return {
+    sender: {
+      sender_id: { open_id: senderId },
+      sender_type: "user",
+    },
+    message: {
+      message_id: `${messageId}:reaction:${emoji}:test-uuid`,
+      chat_id: `p2p:${senderId}`,
+      chat_type: "p2p",
+      message_type: "text",
+      content: JSON.stringify({
+        text: `[reacted with ${emoji} to message ${messageId}]`,
+      }),
+    },
+  };
+}
+
+describe("reaction event handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("filtering", () => {
+    it("filters out reactions from apps (operator_type === 'app')", () => {
+      const result = processReactionEvent(
+        {
+          message_id: "om_msg1",
+          reaction_type: { emoji_type: "THUMBSUP" },
+          operator_type: "app",
+          user_id: { open_id: "ou_user1" },
+        },
+        "ou_bot123",
+      );
+      expect(result).toBeNull();
+    });
+
+    it("filters out reactions from the bot itself by open_id", () => {
+      const result = processReactionEvent(
+        {
+          message_id: "om_msg1",
+          reaction_type: { emoji_type: "THUMBSUP" },
+          operator_type: "user",
+          user_id: { open_id: "ou_bot123" },
+        },
+        "ou_bot123",
+      );
+      expect(result).toBeNull();
+    });
+
+    it("filters out Typing indicator emoji", () => {
+      const result = processReactionEvent(
+        {
+          message_id: "om_msg1",
+          reaction_type: { emoji_type: "Typing" },
+          operator_type: "user",
+          user_id: { open_id: "ou_user1" },
+        },
+        "ou_bot123",
+      );
+      expect(result).toBeNull();
+    });
+
+    it("allows normal user reactions through", () => {
+      const result = processReactionEvent(
+        {
+          message_id: "om_msg1",
+          reaction_type: { emoji_type: "THUMBSUP" },
+          operator_type: "user",
+          user_id: { open_id: "ou_user1" },
+        },
+        "ou_bot123",
+      );
+      expect(result).not.toBeNull();
+    });
+
+    it("allows reactions when bot open_id is undefined", () => {
+      const result = processReactionEvent(
+        {
+          message_id: "om_msg1",
+          reaction_type: { emoji_type: "HEART" },
+          operator_type: "user",
+          user_id: { open_id: "ou_user1" },
+        },
+        undefined,
+      );
+      expect(result).not.toBeNull();
+    });
+  });
+
+  describe("synthetic event construction", () => {
+    it("creates a valid FeishuMessageEvent with correct structure", () => {
+      const result = processReactionEvent(
+        {
+          message_id: "om_original",
+          reaction_type: { emoji_type: "FINGERHEART" },
+          operator_type: "user",
+          user_id: { open_id: "ou_sender" },
+        },
+        "ou_bot",
+      );
+
+      expect(result).toEqual({
+        sender: {
+          sender_id: { open_id: "ou_sender" },
+          sender_type: "user",
+        },
+        message: {
+          message_id: "om_original:reaction:FINGERHEART:test-uuid",
+          chat_id: "p2p:ou_sender",
+          chat_type: "p2p",
+          message_type: "text",
+          content: JSON.stringify({
+            text: "[reacted with FINGERHEART to message om_original]",
+          }),
+        },
+      });
+    });
+
+    it("routes all reactions as p2p via sender open_id", () => {
+      const result = processReactionEvent(
+        {
+          message_id: "om_group_msg",
+          reaction_type: { emoji_type: "OK" },
+          operator_type: "user",
+          user_id: { open_id: "ou_group_member" },
+        },
+        "ou_bot",
+      );
+
+      expect(result?.message.chat_type).toBe("p2p");
+      expect(result?.message.chat_id).toBe("p2p:ou_group_member");
+    });
+
+    it("includes emoji type and original message_id in synthetic content", () => {
+      const result = processReactionEvent(
+        {
+          message_id: "om_target",
+          reaction_type: { emoji_type: "CLAP" },
+          operator_type: "user",
+          user_id: { open_id: "ou_user" },
+        },
+        "ou_bot",
+      );
+
+      const content = JSON.parse(result!.message.content);
+      expect(content.text).toBe("[reacted with CLAP to message om_target]");
+    });
+
+    it("generates unique message_id with emoji to prevent collisions", () => {
+      // The actual code uses crypto.randomUUID() — here we verify the format
+      // includes the emoji to differentiate reactions on the same message
+      const result1 = processReactionEvent(
+        {
+          message_id: "om_same",
+          reaction_type: { emoji_type: "THUMBSUP" },
+          operator_type: "user",
+          user_id: { open_id: "ou_user" },
+        },
+        "ou_bot",
+      );
+
+      const result2 = processReactionEvent(
+        {
+          message_id: "om_same",
+          reaction_type: { emoji_type: "HEART" },
+          operator_type: "user",
+          user_id: { open_id: "ou_user" },
+        },
+        "ou_bot",
+      );
+
+      // Different emoji → different message_id prefix
+      expect(result1!.message.message_id).toContain(":reaction:THUMBSUP:");
+      expect(result2!.message.message_id).toContain(":reaction:HEART:");
+      expect(result1!.message.message_id).not.toBe(result2!.message.message_id);
+    });
+  });
+});

--- a/extensions/feishu/src/monitor.reaction.test.ts
+++ b/extensions/feishu/src/monitor.reaction.test.ts
@@ -1,281 +1,184 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
-import type { FeishuMessageEvent } from "./bot.js";
-import type { FeishuMessageInfo } from "./send.js";
+import type { ClawdbotConfig } from "openclaw/plugin-sdk";
+import { describe, expect, it, vi } from "vitest";
+import { resolveReactionSyntheticEvent, type FeishuReactionCreatedEvent } from "./monitor.js";
 
-/**
- * Tests for reaction event handling in monitor.ts.
- *
- * Since registerEventHandlers is not exported, we test the reaction handling
- * logic by extracting and verifying the behavior inline: filtering rules,
- * synthetic event construction, and dispatch.
- */
+const cfg = {} as ClawdbotConfig;
 
-// Mock handleFeishuMessage to capture calls
-const mockHandleFeishuMessage = vi.fn().mockResolvedValue(undefined);
-
-vi.mock("./bot.js", () => ({
-  handleFeishuMessage: (...args: unknown[]) => mockHandleFeishuMessage(...args),
-}));
-
-/**
- * Simulate the reaction event filtering and synthetic message construction
- * extracted from monitor.ts registerEventHandlers.
- *
- * The `getReactedMessage` callback simulates getMessageFeishu — it returns
- * the message info for the reacted message, or null if not found.
- */
-function processReactionEvent(
-  data: {
-    message_id: string;
-    reaction_type: { emoji_type: string };
-    operator_type: string;
-    user_id: { open_id: string };
-    action_time?: string;
-  },
-  botOpenId: string | undefined,
-  getReactedMessage?: (messageId: string) => FeishuMessageInfo | null,
-): FeishuMessageEvent | null {
-  const emoji = data.reaction_type?.emoji_type;
-  const messageId = data.message_id;
-  const senderId = data.user_id?.open_id;
-
-  // Skip bot self-reactions
-  if (data.operator_type === "app" || senderId === botOpenId) {
-    return null;
-  }
-
-  // Skip typing indicator emoji
-  if (emoji === "Typing") {
-    return null;
-  }
-
-  // Only process reactions on messages sent by this bot
-  if (botOpenId && getReactedMessage) {
-    const reactedMsg = getReactedMessage(messageId);
-    const isBotMessage = reactedMsg?.senderType === "app" || reactedMsg?.senderOpenId === botOpenId;
-    if (!reactedMsg || !isBotMessage) {
-      return null;
-    }
-  }
-
+function makeReactionEvent(
+  overrides: Partial<FeishuReactionCreatedEvent> = {},
+): FeishuReactionCreatedEvent {
   return {
-    sender: {
-      sender_id: { open_id: senderId },
-      sender_type: "user",
-    },
-    message: {
-      message_id: `${messageId}:reaction:${emoji}:test-uuid`,
-      chat_id: `p2p:${senderId}`,
-      chat_type: "p2p",
-      message_type: "text",
-      content: JSON.stringify({
-        text: `[reacted with ${emoji} to message ${messageId}]`,
-      }),
-    },
-  };
-}
-
-/** Helper to create a mock FeishuMessageInfo */
-function mockMessageInfo(overrides: Partial<FeishuMessageInfo> = {}): FeishuMessageInfo {
-  return {
-    messageId: "om_msg1",
-    chatId: "oc_chat1",
-    content: "hello",
-    contentType: "text",
+    message_id: "om_msg1",
+    reaction_type: { emoji_type: "THUMBSUP" },
+    operator_type: "user",
+    user_id: { open_id: "ou_user1" },
     ...overrides,
   };
 }
 
-describe("reaction event handling", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
+describe("resolveReactionSyntheticEvent", () => {
+  it("filters app self-reactions", async () => {
+    const event = makeReactionEvent({ operator_type: "app" });
+    const result = await resolveReactionSyntheticEvent({
+      cfg,
+      accountId: "default",
+      event,
+      botOpenId: "ou_bot",
+    });
+    expect(result).toBeNull();
   });
 
-  describe("filtering", () => {
-    it("filters out reactions from apps (operator_type === 'app')", () => {
-      const result = processReactionEvent(
-        {
-          message_id: "om_msg1",
-          reaction_type: { emoji_type: "THUMBSUP" },
-          operator_type: "app",
-          user_id: { open_id: "ou_user1" },
-        },
-        "ou_bot123",
-      );
-      expect(result).toBeNull();
+  it("filters Typing reactions", async () => {
+    const event = makeReactionEvent({ reaction_type: { emoji_type: "Typing" } });
+    const result = await resolveReactionSyntheticEvent({
+      cfg,
+      accountId: "default",
+      event,
+      botOpenId: "ou_bot",
+    });
+    expect(result).toBeNull();
+  });
+
+  it("fails closed when bot open_id is unavailable", async () => {
+    const event = makeReactionEvent();
+    const result = await resolveReactionSyntheticEvent({
+      cfg,
+      accountId: "default",
+      event,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("filters reactions on non-bot messages", async () => {
+    const event = makeReactionEvent();
+    const result = await resolveReactionSyntheticEvent({
+      cfg,
+      accountId: "default",
+      event,
+      botOpenId: "ou_bot",
+      fetchMessage: async () => ({
+        messageId: "om_msg1",
+        chatId: "oc_group",
+        senderOpenId: "ou_other",
+        senderType: "user",
+        content: "hello",
+        contentType: "text",
+      }),
+    });
+    expect(result).toBeNull();
+  });
+
+  it("drops unverified reactions when sender verification times out", async () => {
+    const event = makeReactionEvent();
+    const result = await resolveReactionSyntheticEvent({
+      cfg,
+      accountId: "default",
+      event,
+      botOpenId: "ou_bot",
+      verificationTimeoutMs: 1,
+      fetchMessage: async () =>
+        await new Promise<never>(() => {
+          // Never resolves
+        }),
+    });
+    expect(result).toBeNull();
+  });
+
+  it("uses event chat context when provided", async () => {
+    const event = makeReactionEvent({
+      chat_id: "oc_group_from_event",
+      chat_type: "group",
+    });
+    const result = await resolveReactionSyntheticEvent({
+      cfg,
+      accountId: "default",
+      event,
+      botOpenId: "ou_bot",
+      fetchMessage: async () => ({
+        messageId: "om_msg1",
+        chatId: "oc_group_from_lookup",
+        senderOpenId: "ou_bot",
+        content: "hello",
+        contentType: "text",
+      }),
+      uuid: () => "fixed-uuid",
     });
 
-    it("filters out reactions from the bot itself by open_id", () => {
-      const result = processReactionEvent(
-        {
-          message_id: "om_msg1",
-          reaction_type: { emoji_type: "THUMBSUP" },
-          operator_type: "user",
-          user_id: { open_id: "ou_bot123" },
-        },
-        "ou_bot123",
-      );
-      expect(result).toBeNull();
-    });
-
-    it("filters out Typing indicator emoji", () => {
-      const result = processReactionEvent(
-        {
-          message_id: "om_msg1",
-          reaction_type: { emoji_type: "Typing" },
-          operator_type: "user",
-          user_id: { open_id: "ou_user1" },
-        },
-        "ou_bot123",
-      );
-      expect(result).toBeNull();
-    });
-
-    it("allows reactions on bot messages (senderType=app)", () => {
-      const getBotMsg = () => mockMessageInfo({ senderType: "app" });
-      const result = processReactionEvent(
-        {
-          message_id: "om_msg1",
-          reaction_type: { emoji_type: "THUMBSUP" },
-          operator_type: "user",
-          user_id: { open_id: "ou_user1" },
-        },
-        "ou_bot123",
-        getBotMsg,
-      );
-      expect(result).not.toBeNull();
-    });
-
-    it("filters out reactions on non-bot messages", () => {
-      const getNonBotMsg = () => mockMessageInfo({ senderOpenId: "ou_other_user" });
-      const result = processReactionEvent(
-        {
-          message_id: "om_msg1",
-          reaction_type: { emoji_type: "THUMBSUP" },
-          operator_type: "user",
-          user_id: { open_id: "ou_user1" },
-        },
-        "ou_bot123",
-        getNonBotMsg,
-      );
-      expect(result).toBeNull();
-    });
-
-    it("filters out reactions when reacted message is not found", () => {
-      const getNull = () => null;
-      const result = processReactionEvent(
-        {
-          message_id: "om_deleted",
-          reaction_type: { emoji_type: "THUMBSUP" },
-          operator_type: "user",
-          user_id: { open_id: "ou_user1" },
-        },
-        "ou_bot123",
-        getNull,
-      );
-      expect(result).toBeNull();
-    });
-
-    it("allows reactions when bot open_id is undefined (skip sender check)", () => {
-      const result = processReactionEvent(
-        {
-          message_id: "om_msg1",
-          reaction_type: { emoji_type: "HEART" },
-          operator_type: "user",
-          user_id: { open_id: "ou_user1" },
-        },
-        undefined,
-      );
-      expect(result).not.toBeNull();
+    expect(result).toEqual({
+      sender: {
+        sender_id: { open_id: "ou_user1" },
+        sender_type: "user",
+      },
+      message: {
+        message_id: "om_msg1:reaction:THUMBSUP:fixed-uuid",
+        chat_id: "oc_group_from_event",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({
+          text: "[reacted with THUMBSUP to message om_msg1]",
+        }),
+      },
     });
   });
 
-  describe("synthetic event construction", () => {
-    it("creates a valid FeishuMessageEvent with correct structure", () => {
-      const result = processReactionEvent(
-        {
-          message_id: "om_original",
-          reaction_type: { emoji_type: "FINGERHEART" },
-          operator_type: "user",
-          user_id: { open_id: "ou_sender" },
-        },
-        "ou_bot",
-      );
-
-      expect(result).toEqual({
-        sender: {
-          sender_id: { open_id: "ou_sender" },
-          sender_type: "user",
-        },
-        message: {
-          message_id: "om_original:reaction:FINGERHEART:test-uuid",
-          chat_id: "p2p:ou_sender",
-          chat_type: "p2p",
-          message_type: "text",
-          content: JSON.stringify({
-            text: "[reacted with FINGERHEART to message om_original]",
-          }),
-        },
-      });
+  it("falls back to reacted message chat_id when event chat_id is absent", async () => {
+    const event = makeReactionEvent();
+    const result = await resolveReactionSyntheticEvent({
+      cfg,
+      accountId: "default",
+      event,
+      botOpenId: "ou_bot",
+      fetchMessage: async () => ({
+        messageId: "om_msg1",
+        chatId: "oc_group_from_lookup",
+        senderOpenId: "ou_bot",
+        content: "hello",
+        contentType: "text",
+      }),
+      uuid: () => "fixed-uuid",
     });
 
-    it("routes all reactions as p2p via sender open_id", () => {
-      const result = processReactionEvent(
-        {
-          message_id: "om_group_msg",
-          reaction_type: { emoji_type: "OK" },
-          operator_type: "user",
-          user_id: { open_id: "ou_group_member" },
-        },
-        "ou_bot",
-      );
+    expect(result?.message.chat_id).toBe("oc_group_from_lookup");
+    expect(result?.message.chat_type).toBe("p2p");
+  });
 
-      expect(result?.message.chat_type).toBe("p2p");
-      expect(result?.message.chat_id).toBe("p2p:ou_group_member");
+  it("falls back to sender p2p chat when lookup returns empty chat_id", async () => {
+    const event = makeReactionEvent();
+    const result = await resolveReactionSyntheticEvent({
+      cfg,
+      accountId: "default",
+      event,
+      botOpenId: "ou_bot",
+      fetchMessage: async () => ({
+        messageId: "om_msg1",
+        chatId: "",
+        senderOpenId: "ou_bot",
+        content: "hello",
+        contentType: "text",
+      }),
+      uuid: () => "fixed-uuid",
     });
 
-    it("includes emoji type and original message_id in synthetic content", () => {
-      const result = processReactionEvent(
-        {
-          message_id: "om_target",
-          reaction_type: { emoji_type: "CLAP" },
-          operator_type: "user",
-          user_id: { open_id: "ou_user" },
-        },
-        "ou_bot",
-      );
+    expect(result?.message.chat_id).toBe("p2p:ou_user1");
+    expect(result?.message.chat_type).toBe("p2p");
+  });
 
-      const content = JSON.parse(result!.message.content);
-      expect(content.text).toBe("[reacted with CLAP to message om_target]");
+  it("logs and drops reactions when lookup throws", async () => {
+    const log = vi.fn();
+    const event = makeReactionEvent();
+    const result = await resolveReactionSyntheticEvent({
+      cfg,
+      accountId: "acct1",
+      event,
+      botOpenId: "ou_bot",
+      fetchMessage: async () => {
+        throw new Error("boom");
+      },
+      logger: log,
     });
-
-    it("generates unique message_id with emoji to prevent collisions", () => {
-      // The actual code uses crypto.randomUUID() — here we verify the format
-      // includes the emoji to differentiate reactions on the same message
-      const result1 = processReactionEvent(
-        {
-          message_id: "om_same",
-          reaction_type: { emoji_type: "THUMBSUP" },
-          operator_type: "user",
-          user_id: { open_id: "ou_user" },
-        },
-        "ou_bot",
-      );
-
-      const result2 = processReactionEvent(
-        {
-          message_id: "om_same",
-          reaction_type: { emoji_type: "HEART" },
-          operator_type: "user",
-          user_id: { open_id: "ou_user" },
-        },
-        "ou_bot",
-      );
-
-      // Different emoji → different message_id prefix
-      expect(result1!.message.message_id).toContain(":reaction:THUMBSUP:");
-      expect(result2!.message.message_id).toContain(":reaction:HEART:");
-      expect(result1!.message.message_id).not.toBe(result2!.message.message_id);
-    });
+    expect(result).toBeNull();
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining("ignoring reaction on non-bot/unverified message om_msg1"),
+    );
   });
 });

--- a/extensions/feishu/src/monitor.ts
+++ b/extensions/feishu/src/monitor.ts
@@ -11,6 +11,7 @@ import { resolveFeishuAccount, listEnabledFeishuAccounts } from "./accounts.js";
 import { handleFeishuMessage, type FeishuMessageEvent, type FeishuBotAddedEvent } from "./bot.js";
 import { createFeishuWSClient, createEventDispatcher } from "./client.js";
 import { probeFeishu } from "./probe.js";
+import { getMessageFeishu } from "./send.js";
 import type { ResolvedFeishuAccount } from "./types.js";
 
 export type MonitorFeishuOpts = {
@@ -209,6 +210,33 @@ function registerEventHandlers(
         // Skip typing indicator emoji (if used)
         if (emoji === "Typing") {
           return;
+        }
+
+        // Only process reactions on messages sent by this bot.
+        // Without this filter, the agent receives spurious notifications for
+        // reactions the user leaves on *any* message (including other people's
+        // messages in unrelated chats), which is noisy and confusing.
+        if (myBotId) {
+          try {
+            const reactedMsg = await getMessageFeishu({ cfg, messageId, accountId });
+            const isBotMessage =
+              reactedMsg?.senderType === "app" || reactedMsg?.senderOpenId === myBotId;
+            if (!reactedMsg || !isBotMessage) {
+              log(
+                `feishu[${accountId}]: ignoring reaction on non-bot message ${messageId} ` +
+                  `(sender: ${reactedMsg?.senderOpenId ?? "unknown"})`,
+              );
+              return;
+            }
+          } catch (err) {
+            // If we can't verify the message sender (e.g. permission error,
+            // deleted message), skip the reaction rather than routing a
+            // potentially irrelevant event to the agent.
+            log(
+              `feishu[${accountId}]: could not verify reacted message ${messageId}, skipping: ${String(err)}`,
+            );
+            return;
+          }
         }
 
         log(`feishu[${accountId}]: reaction ${emoji} on ${messageId} from ${senderId}`);

--- a/extensions/feishu/src/monitor.ts
+++ b/extensions/feishu/src/monitor.ts
@@ -31,6 +31,29 @@ const FEISHU_WEBHOOK_RATE_LIMIT_WINDOW_MS = 60_000;
 const FEISHU_WEBHOOK_RATE_LIMIT_MAX_REQUESTS = 120;
 const FEISHU_WEBHOOK_RATE_LIMIT_MAX_TRACKED_KEYS = 4_096;
 const FEISHU_WEBHOOK_COUNTER_LOG_EVERY = 25;
+const FEISHU_REACTION_VERIFY_TIMEOUT_MS = 1_500;
+
+export type FeishuReactionCreatedEvent = {
+  message_id: string;
+  chat_id?: string;
+  chat_type?: "p2p" | "group";
+  reaction_type?: { emoji_type?: string };
+  operator_type?: string;
+  user_id?: { open_id?: string };
+  action_time?: string;
+};
+
+type ResolveReactionSyntheticEventParams = {
+  cfg: ClawdbotConfig;
+  accountId: string;
+  event: FeishuReactionCreatedEvent;
+  botOpenId?: string;
+  fetchMessage?: typeof getMessageFeishu;
+  verificationTimeoutMs?: number;
+  logger?: (message: string) => void;
+  uuid?: () => string;
+};
+
 const feishuWebhookRateLimits = new Map<string, { count: number; windowStartMs: number }>();
 const feishuWebhookStatusCounters = new Map<string, number>();
 let lastWebhookRateLimitCleanupMs = 0;
@@ -117,6 +140,95 @@ function recordWebhookStatus(
   }
 }
 
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T | null> {
+  let timeoutId: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race<T | null>([
+      promise,
+      new Promise<null>((resolve) => {
+        timeoutId = setTimeout(() => resolve(null), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
+}
+
+export async function resolveReactionSyntheticEvent(
+  params: ResolveReactionSyntheticEventParams,
+): Promise<FeishuMessageEvent | null> {
+  const {
+    cfg,
+    accountId,
+    event,
+    botOpenId,
+    fetchMessage = getMessageFeishu,
+    verificationTimeoutMs = FEISHU_REACTION_VERIFY_TIMEOUT_MS,
+    logger,
+    uuid = () => crypto.randomUUID(),
+  } = params;
+
+  const emoji = event.reaction_type?.emoji_type;
+  const messageId = event.message_id;
+  const senderId = event.user_id?.open_id;
+  if (!emoji || !messageId || !senderId) {
+    return null;
+  }
+
+  // Skip bot self-reactions
+  if (event.operator_type === "app" || senderId === botOpenId) {
+    return null;
+  }
+
+  // Skip typing indicator emoji
+  if (emoji === "Typing") {
+    return null;
+  }
+
+  // Fail closed if bot identity cannot be resolved; otherwise reactions on any
+  // message can leak into the agent.
+  if (!botOpenId) {
+    logger?.(
+      `feishu[${accountId}]: bot open_id unavailable, skipping reaction ${emoji} on ${messageId}`,
+    );
+    return null;
+  }
+
+  const reactedMsg = await withTimeout(
+    fetchMessage({ cfg, messageId, accountId }),
+    verificationTimeoutMs,
+  ).catch(() => null);
+  const isBotMessage = reactedMsg?.senderType === "app" || reactedMsg?.senderOpenId === botOpenId;
+  if (!reactedMsg || !isBotMessage) {
+    logger?.(
+      `feishu[${accountId}]: ignoring reaction on non-bot/unverified message ${messageId} ` +
+        `(sender: ${reactedMsg?.senderOpenId ?? "unknown"})`,
+    );
+    return null;
+  }
+
+  const syntheticChatIdRaw = event.chat_id ?? reactedMsg.chatId;
+  const syntheticChatId = syntheticChatIdRaw?.trim() ? syntheticChatIdRaw : `p2p:${senderId}`;
+  const syntheticChatType: "p2p" | "group" = event.chat_type ?? "p2p";
+  return {
+    sender: {
+      sender_id: { open_id: senderId },
+      sender_type: "user",
+    },
+    message: {
+      message_id: `${messageId}:reaction:${emoji}:${uuid()}`,
+      chat_id: syntheticChatId,
+      chat_type: syntheticChatType,
+      message_type: "text",
+      content: JSON.stringify({
+        text: `[reacted with ${emoji} to message ${messageId}]`,
+      }),
+    },
+  };
+}
+
 async function fetchBotOpenId(account: ResolvedFeishuAccount): Promise<string | undefined> {
   try {
     const result = await probeFeishu(account);
@@ -188,78 +300,19 @@ function registerEventHandlers(
       }
     },
     "im.message.reaction.created_v1": async (data) => {
-      try {
-        const event = data as unknown as {
-          message_id: string;
-          reaction_type: { emoji_type: string };
-          operator_type: string;
-          user_id: { open_id: string };
-          action_time: string;
-        };
-
-        const emoji = event.reaction_type?.emoji_type;
-        const messageId = event.message_id;
-        const senderId = event.user_id?.open_id;
-
-        // Skip bot self-reactions
+      const processReaction = async () => {
+        const event = data as FeishuReactionCreatedEvent;
         const myBotId = botOpenIds.get(accountId);
-        if (event.operator_type === "app" || senderId === myBotId) {
+        const syntheticEvent = await resolveReactionSyntheticEvent({
+          cfg,
+          accountId,
+          event,
+          botOpenId: myBotId,
+          logger: log,
+        });
+        if (!syntheticEvent) {
           return;
         }
-
-        // Skip typing indicator emoji (if used)
-        if (emoji === "Typing") {
-          return;
-        }
-
-        // Only process reactions on messages sent by this bot.
-        // Without this filter, the agent receives spurious notifications for
-        // reactions the user leaves on *any* message (including other people's
-        // messages in unrelated chats), which is noisy and confusing.
-        if (myBotId) {
-          try {
-            const reactedMsg = await getMessageFeishu({ cfg, messageId, accountId });
-            const isBotMessage =
-              reactedMsg?.senderType === "app" || reactedMsg?.senderOpenId === myBotId;
-            if (!reactedMsg || !isBotMessage) {
-              log(
-                `feishu[${accountId}]: ignoring reaction on non-bot message ${messageId} ` +
-                  `(sender: ${reactedMsg?.senderOpenId ?? "unknown"})`,
-              );
-              return;
-            }
-          } catch (err) {
-            // If we can't verify the message sender (e.g. permission error,
-            // deleted message), skip the reaction rather than routing a
-            // potentially irrelevant event to the agent.
-            log(
-              `feishu[${accountId}]: could not verify reacted message ${messageId}, skipping: ${String(err)}`,
-            );
-            return;
-          }
-        }
-
-        log(`feishu[${accountId}]: reaction ${emoji} on ${messageId} from ${senderId}`);
-
-        // Note: Feishu DM chat_ids also use "oc_" prefix, so we cannot distinguish
-        // group vs DM by prefix alone. For now treat all reactions as DM (p2p)
-        // routing via the sender's open_id.
-        const syntheticEvent: FeishuMessageEvent = {
-          sender: {
-            sender_id: { open_id: senderId },
-            sender_type: "user",
-          },
-          message: {
-            message_id: `${messageId}:reaction:${emoji}:${crypto.randomUUID()}`,
-            chat_id: `p2p:${senderId}`,
-            chat_type: "p2p",
-            message_type: "text",
-            content: JSON.stringify({
-              text: `[reacted with ${emoji} to message ${messageId}]`,
-            }),
-          },
-        };
-
         const promise = handleFeishuMessage({
           cfg,
           event: syntheticEvent,
@@ -268,14 +321,24 @@ function registerEventHandlers(
           chatHistories,
           accountId,
         });
-
         if (fireAndForget) {
           promise.catch((err) => {
             error(`feishu[${accountId}]: error handling reaction: ${String(err)}`);
           });
-        } else {
-          await promise;
+          return;
         }
+        await promise;
+      };
+
+      if (fireAndForget) {
+        void processReaction().catch((err) => {
+          error(`feishu[${accountId}]: error handling reaction event: ${String(err)}`);
+        });
+        return;
+      }
+
+      try {
+        await processReaction();
       } catch (err) {
         error(`feishu[${accountId}]: error handling reaction event: ${String(err)}`);
       }

--- a/extensions/feishu/src/monitor.ts
+++ b/extensions/feishu/src/monitor.ts
@@ -1,3 +1,4 @@
+import * as crypto from "crypto";
 import * as http from "http";
 import * as Lark from "@larksuiteoapi/node-sdk";
 import {
@@ -184,6 +185,75 @@ function registerEventHandlers(
       } catch (err) {
         error(`feishu[${accountId}]: error handling bot removed event: ${String(err)}`);
       }
+    },
+    "im.message.reaction.created_v1": async (data) => {
+      try {
+        const event = data as unknown as {
+          message_id: string;
+          reaction_type: { emoji_type: string };
+          operator_type: string;
+          user_id: { open_id: string };
+          action_time: string;
+        };
+
+        const emoji = event.reaction_type?.emoji_type;
+        const messageId = event.message_id;
+        const senderId = event.user_id?.open_id;
+
+        // Skip bot self-reactions
+        const myBotId = botOpenIds.get(accountId);
+        if (event.operator_type === "app" || senderId === myBotId) {
+          return;
+        }
+
+        // Skip typing indicator emoji (if used)
+        if (emoji === "Typing") {
+          return;
+        }
+
+        log(`feishu[${accountId}]: reaction ${emoji} on ${messageId} from ${senderId}`);
+
+        // Note: Feishu DM chat_ids also use "oc_" prefix, so we cannot distinguish
+        // group vs DM by prefix alone. For now treat all reactions as DM (p2p)
+        // routing via the sender's open_id.
+        const syntheticEvent: FeishuMessageEvent = {
+          sender: {
+            sender_id: { open_id: senderId },
+            sender_type: "user",
+          },
+          message: {
+            message_id: `${messageId}:reaction:${emoji}:${crypto.randomUUID()}`,
+            chat_id: `p2p:${senderId}`,
+            chat_type: "p2p",
+            message_type: "text",
+            content: JSON.stringify({
+              text: `[reacted with ${emoji} to message ${messageId}]`,
+            }),
+          },
+        };
+
+        const promise = handleFeishuMessage({
+          cfg,
+          event: syntheticEvent,
+          botOpenId: myBotId,
+          runtime,
+          chatHistories,
+          accountId,
+        });
+
+        if (fireAndForget) {
+          promise.catch((err) => {
+            error(`feishu[${accountId}]: error handling reaction: ${String(err)}`);
+          });
+        } else {
+          await promise;
+        }
+      } catch (err) {
+        error(`feishu[${accountId}]: error handling reaction event: ${String(err)}`);
+      }
+    },
+    "im.message.reaction.deleted_v1": async () => {
+      // Ignore reaction removals
     },
   });
 }

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -13,6 +13,7 @@ export type FeishuMessageInfo = {
   chatId: string;
   senderId?: string;
   senderOpenId?: string;
+  senderType?: string;
   content: string;
   contentType: string;
   createTime?: number;
@@ -82,6 +83,7 @@ export async function getMessageFeishu(params: {
       chatId: item.chat_id ?? "",
       senderId: item.sender?.id,
       senderOpenId: item.sender?.id_type === "open_id" ? item.sender?.id : undefined,
+      senderType: item.sender?.sender_type,
       content,
       contentType: item.msg_type ?? "text",
       createTime: item.create_time ? parseInt(item.create_time, 10) : undefined,


### PR DESCRIPTION
## Why this matters

In Feishu (and Lark), **emoji reactions are a core part of how people communicate** — they're used constantly to acknowledge messages, express agreement, or give quick feedback without interrupting the conversation flow. This is especially true in Feishu&Lark workplace culture where a 👍 or a +1 (meaning "I agree") carries real conversational weight.

Right now, **OpenClaw's Feishu plugin cannot receive reaction events at all**. When a user reacts to the bot's message, nothing happens — the bot is blind to it. This makes the bot feel unresponsive and disconnected from the natural rhythm of Feishu conversations.

The infrastructure is already 90% there:
- `reactions.ts` has full CRUD (`addReactionFeishu`, `removeReactionFeishu`, `listReactionsFeishu`)
- `typing.ts` uses the reaction API for typing indicators (proving the pipeline works)
- `channel.ts` declares `capabilities.reactions: true`

**The only missing piece is registering the inbound event handler in `monitor.ts`.** This PR closes that gap.

---

## What this does

- Registers `im.message.reaction.created_v1` and `im.message.reaction.deleted_v1` event handlers in the Feishu EventDispatcher
- Routes reaction events as synthetic inbound messages through `handleFeishuMessage`, giving the agent a dedicated turn to process each reaction and respond (e.g., react back)
- Filters out bot self-reactions (by `operator_type`), typing indicator emoji, and reaction-removed events

## Changes

**`extensions/feishu/src/monitor.ts`** (~130 lines added):
- `FeishuReactionEvent` type definition matching the Feishu API schema
- `handleReactionEvent()` — processes reaction events with proper filtering and routing
- Event handler registration in `registerEventHandlers()`

## Design decisions

### Synthetic messages over system events
We initially tried `enqueueSystemEvent()` (matching the Slack plugin pattern), but found that system events are passive — they only surface during the next agent turn and may be merged or delayed. For Feishu's interactive reaction culture, the agent needs a **dedicated turn** to process each reaction and respond in kind. Synthetic messages through `handleFeishuMessage` achieve this.

### DM routing for all reactions
Feishu's DM `chat_id` also uses the `oc_` prefix (unlike most platforms), making it impossible to distinguish DM vs group by prefix alone. To avoid group allowlist issues, all reactions are routed as p2p messages via the sender's `open_id`. This works correctly for single-agent setups. Group-specific session routing can be refined in a follow-up.

### Safety filters
- **Bot self-reactions** filtered by `operator_type === "app"` and `open_id` match
- **Typing indicator** (`Typing` emoji) excluded — used internally
- **Fire-and-forget**: reaction processing never blocks message handling

## Setup required

Users must subscribe to `im.message.reaction.created_v1` in their Feishu Open Platform app console (Events & Callbacks).

## Tested

Dogfooded on a live Feishu bot:
1. ✅ User reacts → bot receives event → agent processes and reacts back
2. ✅ Bot self-reactions correctly filtered (no loops)
3. ✅ Typing indicator reactions ignored
4. ✅ DM reactions route to correct session

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds support for Feishu reaction events (`im.message.reaction.created_v1` and `im.message.reaction.deleted_v1`) by registering handlers in the event dispatcher. Reactions are dispatched as synthetic DM messages through `handleFeishuMessage`, giving the agent a dedicated turn to process and respond to each reaction. The implementation includes proper filtering for bot self-reactions, typing indicator emoji, and reaction-removed events.

**Key changes:**
- Added `FeishuReactionEvent` type definition matching Feishu API schema
- Implemented `handleReactionEvent()` function with filtering logic and synthetic message creation
- Registered reaction event handlers in `registerEventHandlers()`
- Routes all reactions as p2p messages via sender's `open_id` to avoid group allowlist complexity

**Notes:**
- Requires users to subscribe to reaction events in Feishu Open Platform console
- Group reactions currently route to sender's session rather than group session (documented limitation)
- Implementation follows fire-and-forget pattern to avoid blocking message handling

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk - adds well-isolated new functionality with proper error handling
- The implementation is straightforward and follows existing patterns (similar to Slack's reaction handling via system events). The code has good defensive checks (bot self-reactions, typing indicator filtering, error handling). One logical issue exists with message ID collision risk when reactions happen within 1ms, and one style improvement opportunity for unused code cleanup. The synthetic message approach is well-documented and aligns with the stated goal of giving agents dedicated turns for reactions.
- No files require special attention

<sub>Last reviewed commit: 80d4b32</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->