### PR TITLE
fix: treat empty channels config as unset instead of blocking all messages

### DIFF
--- a/src/discord/monitor/allow-list.ts
+++ b/src/discord/monitor/allow-list.ts
@@ -333,7 +333,7 @@ export function resolveDiscordChannelConfig(params: {
 }): DiscordChannelConfigResolved | null {
   const { guildInfo, channelId, channelName, channelSlug } = params;
   const channels = guildInfo?.channels;
-  if (!channels) {
+  if (!channels || Object.keys(channels).length === 0) {
     return null;
   }
   const match = resolveDiscordChannelEntryMatch(channels, {
@@ -366,7 +366,7 @@ export function resolveDiscordChannelConfigWithFallback(params: {
     scope,
   } = params;
   const channels = guildInfo?.channels;
-  if (!channels) {
+  if (!channels || Object.keys(channels).length === 0) {
     return null;
   }
   const resolvedParentSlug = parentSlug ?? (parentName ? normalizeDiscordSlug(parentName) : "");


### PR DESCRIPTION
## Summary

- When using `groupPolicy: "open"` without per-channel configs, the channel resolution process injects `channels: {}` into guild config at startup
- `resolveDiscordChannelConfig` and `resolveDiscordChannelConfigWithFallback` treat this empty object as a valid (but empty) channel whitelist
- All guild messages are silently blocked with `{allowed: false}` — the bot appears dead in guild channels

Fix: add `Object.keys(channels).length === 0` check so empty channels object is treated same as `null`/`undefined` (return null → defer to guild-level policy).

Fixes #16714

## Test plan

- [ ] Bot with `groupPolicy: "open"` and no `channels` config responds to guild messages
- [ ] Bot with explicit `channels` config still respects per-channel allow/deny
- [ ] Bot with `channels: {}` explicitly set behaves same as no channels config

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixed bot becoming unresponsive in Discord guilds with `groupPolicy: "open"` when no per-channel configs exist. The channel resolution process was injecting empty `channels: {}` objects at startup, which were incorrectly treated as valid (but empty) channel whitelists, causing all guild messages to be silently blocked with `{allowed: false}`. The fix adds explicit checks for empty objects (`Object.keys(channels).length === 0`) in `resolveDiscordChannelConfig` and `resolveDiscordChannelConfigWithFallback`, treating them the same as `null`/`undefined` to properly defer to guild-level policy.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is minimal, focused, and correctly addresses the root cause. The added checks (`Object.keys(channels).length === 0`) properly treat empty objects as unset configuration, matching the existing pattern used elsewhere in the codebase (see line 347 in message-handler.preflight.ts). The logic is straightforward and preserves backward compatibility - explicit channel configs are still respected, while empty objects now correctly defer to guild-level policy.
- No files require special attention

<sub>Last reviewed commit: 227882e</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->