### PR TITLE
fix: fall back to guild_id when guild object is missing in resolveDiscordGuildEntry

### DIFF
--- a/src/discord/monitor/agent-components.ts
+++ b/src/discord/monitor/agent-components.ts
@@ -369,6 +369,8 @@ export class AgentComponentButton extends Button {
     // This prevents unauthorized users from injecting system events
     const guildInfo = resolveDiscordGuildEntry({
       guild: interaction.guild ?? undefined,
+      guildId: rawGuildId ?? undefined,
+      guildName: interaction.guild?.name ?? undefined,
       guildEntries: this.ctx.guildEntries,
     });
     const channelCtx = resolveDiscordChannelContext(interaction);
@@ -505,6 +507,8 @@ export class AgentSelectMenu extends StringSelectMenu {
     // Check user allowlist before processing component interaction
     const guildInfo = resolveDiscordGuildEntry({
       guild: interaction.guild ?? undefined,
+      guildId: rawGuildId ?? undefined,
+      guildName: interaction.guild?.name ?? undefined,
       guildEntries: this.ctx.guildEntries,
     });
     const channelCtx = resolveDiscordChannelContext(interaction);

--- a/src/discord/monitor/allow-list.ts
+++ b/src/discord/monitor/allow-list.ts
@@ -251,25 +251,31 @@ export function resolveDiscordCommandAuthorized(params: {
 
 export function resolveDiscordGuildEntry(params: {
   guild?: Guild<true> | Guild | null;
+  guildId?: string;
+  guildName?: string;
   guildEntries?: Record<string, DiscordGuildEntryResolved>;
 }): DiscordGuildEntryResolved | null {
   const guild = params.guild;
   const entries = params.guildEntries;
-  if (!guild || !entries) {
+  if (!entries) {
     return null;
   }
-  const byId = entries[guild.id];
-  if (byId) {
-    return { ...byId, id: guild.id };
+  const guildId = guild?.id ?? (params.guildId?.trim() || undefined);
+  if (!guildId) {
+    return null;
   }
-  const slug = normalizeDiscordSlug(guild.name ?? "");
-  const bySlug = entries[slug];
+  const byId = entries[guildId];
+  if (byId) {
+    return { ...byId, id: guildId };
+  }
+  const slug = normalizeDiscordSlug(guild?.name ?? params.guildName ?? "");
+  const bySlug = slug ? entries[slug] : undefined;
   if (bySlug) {
-    return { ...bySlug, id: guild.id, slug: slug || bySlug.slug };
+    return { ...bySlug, id: guildId, slug: slug || bySlug.slug };
   }
   const wildcard = entries["*"];
   if (wildcard) {
-    return { ...wildcard, id: guild.id, slug: slug || wildcard.slug };
+    return { ...wildcard, id: guildId, slug: slug || wildcard.slug };
   }
   return null;
 }

--- a/src/discord/monitor/listeners.ts
+++ b/src/discord/monitor/listeners.ts
@@ -192,6 +192,8 @@ async function handleDiscordReactionEvent(params: {
     const guildInfo = isGuildMessage
       ? resolveDiscordGuildEntry({
           guild: data.guild ?? undefined,
+          guildId: data.guild_id ?? undefined,
+          guildName: data.guild?.name ?? undefined,
           guildEntries,
         })
       : null;

--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -263,6 +263,8 @@ export async function preflightDiscordMessage(
   const guildInfo = isGuildMessage
     ? resolveDiscordGuildEntry({
         guild: params.data.guild ?? undefined,
+        guildId: params.data.guild_id ?? undefined,
+        guildName: params.data.guild?.name ?? undefined,
         guildEntries: params.guildEntries,
       })
     : null;


### PR DESCRIPTION
## Summary

- `resolveDiscordGuildEntry` requires `params.guild` (full guild object) to resolve guild config, but the guild object depends on gateway cache from `GUILD_CREATE` events
- When cache is cold (reconnection, cold start, or Discord-compatible servers like Spacebar), `data.guild` is undefined even though `data.guild_id` is always present
- Guild resolution fails → message silently dropped

Fix: add optional `guildId` and `guildName` fallback parameters. When `guild` is absent, use `guild_id` from the event data to look up guild config by ID. Updated all 4 call sites:
- `message-handler.preflight.ts` — MESSAGE_CREATE preflight
- `listeners.ts` — reaction handler
- `agent-components.ts` — button + select menu handlers (2 sites, already had `rawGuildId` available)

Fixes #16715

## Test plan

- [ ] Bot resolves guild config when `data.guild` is present (no regression)
- [ ] Bot resolves guild config when `data.guild` is absent but `data.guild_id` exists
- [ ] Bot still blocks messages from unconfigured guilds when `guildEntries` is non-empty
- [ ] Component interactions (buttons, select menus) resolve guild from `rawGuildId` fallback

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a cold-cache bug where `resolveDiscordGuildEntry` would fail when the Discord gateway cache doesn't have the full guild object (e.g., after reconnection or cold start). The fix adds optional `guildId` and `guildName` fallback parameters so guild config can be resolved using `guild_id` from the raw event data when the hydrated `guild` object is unavailable.

- Core logic in `allow-list.ts` is clean: falls back to `guildId` param when `guild.id` is missing, guards against empty slug lookups, and preserves existing behavior when `guild` is present.
- All 4 call sites mentioned in the PR description are correctly updated.
- **One call site missed**: `native-command.ts:558` has the same cold-cache vulnerability but was not updated in this PR. Slash commands going through `handleNativeCommand` will still silently fail guild resolution when the cache is cold.

<h3>Confidence Score: 3/5</h3>

- The changes are correct for the 4 updated call sites but miss a 5th call site with the same bug.
- The core logic change in `resolveDiscordGuildEntry` is well-implemented with proper fallback handling and edge case guards. However, the fix is incomplete — `native-command.ts` has an identical call site that was not updated, meaning slash commands will still break under the same cold-cache conditions this PR aims to fix.
- `src/discord/monitor/native-command.ts` — missed call site at line 558 needs the same `guildId`/`guildName` fallback parameters.

<sub>Last reviewed commit: 911d865</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->