### PR TITLE
fix(image): propagate workspace root for image allowlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Docs: https://docs.openclaw.ai
 - WhatsApp: honor per-account `dmPolicy` overrides (account-level settings now take precedence over channel defaults for inbound DMs). (#10082) Thanks @mcaxtr.
 - Media: accept `MEDIA:`-prefixed paths (lenient whitespace) when loading outbound media to prevent `ENOENT` for tool-returned local media paths. (#13107) Thanks @mcaxtr.
 - Agents/Image tool: allow workspace-local image paths by including the active workspace directory in local media allowlists, and trust sandbox-validated paths in image loaders to prevent false "not under an allowed directory" rejections. (#15541)
+- Agents/Image tool: propagate the effective workspace root into tool wiring so workspace-local image paths are accepted by default when running without an explicit `workspaceDir`. (#16722)
 - Cron/Slack: preserve agent identity (name and icon) when cron jobs deliver outbound messages. (#16242) Thanks @robbyczgw-cla.
 - Cron: prevent `cron list`/`cron status` from silently skipping past-due recurring jobs by using maintenance recompute semantics. (#16156) Thanks @zerone0x.
 - Cron: repair missing/corrupt `nextRunAtMs` for the updated job without globally recomputing unrelated due jobs during `cron update`. (#15750)

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -60,11 +60,12 @@ export function createOpenClawTools(options?: {
   /** If true, omit the message tool from the tool list. */
   disableMessageTool?: boolean;
 }): AnyAgentTool[] {
+  const workspaceDir = options?.workspaceDir?.trim() || process.cwd();
   const imageTool = options?.agentDir?.trim()
     ? createImageTool({
         config: options?.config,
         agentDir: options.agentDir,
-        workspaceDir: options?.workspaceDir,
+        workspaceDir,
         sandbox:
           options?.sandboxRoot && options?.sandboxFsBridge
             ? { root: options.sandboxRoot, bridge: options.sandboxFsBridge }
@@ -157,7 +158,7 @@ export function createOpenClawTools(options?: {
   const pluginTools = resolvePluginTools({
     context: {
       config: options?.config,
-      workspaceDir: options?.workspaceDir,
+      workspaceDir,
       agentDir: options?.agentDir,
       agentId: resolveSessionAgentId({
         sessionKey: options?.agentSessionKey,

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -321,7 +321,7 @@ export function createOpenClawCodingTools(options?: {
     pathPrepend: options?.exec?.pathPrepend ?? execConfig.pathPrepend,
     safeBins: options?.exec?.safeBins ?? execConfig.safeBins,
     agentId,
-    cwd: options?.workspaceDir,
+    cwd: workspaceRoot,
     allowBackground,
     scopeKey,
     sessionKey: options?.sessionKey,
@@ -386,7 +386,7 @@ export function createOpenClawCodingTools(options?: {
       agentDir: options?.agentDir,
       sandboxRoot,
       sandboxFsBridge,
-      workspaceDir: options?.workspaceDir,
+      workspaceDir: workspaceRoot,
       sandboxed: !!sandbox,
       config: options?.config,
       pluginToolAllowlist: collectExplicitAllowlist([

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -358,9 +358,14 @@ export function createImageTool(options?: {
     if (!workspaceDir) {
       return roots;
     }
-    const normalized = workspaceDir.startsWith("~") ? resolveUserPath(workspaceDir) : workspaceDir;
-    if (!roots.includes(normalized)) {
-      roots.push(normalized);
+    const expanded = workspaceDir.startsWith("~") ? resolveUserPath(workspaceDir) : workspaceDir;
+    const resolved = path.resolve(expanded);
+    // Defensive: never allow "/" as an implicit media root.
+    if (resolved === path.parse(resolved).root) {
+      return roots;
+    }
+    if (!roots.includes(resolved)) {
+      roots.push(resolved);
     }
     return roots;
   })();


### PR DESCRIPTION
Fix follow-up to #16697.

- Pass effective workspace root into tool wiring so workspace-local image paths are accepted.
- Normalize workspaceDir before adding to local media roots; refuse "/".
- Add e2e coverage via createOpenClawCodingTools path.

Tests:
- pnpm vitest run --config vitest.e2e.config.ts src/agents/tools/image-tool.e2e.test.ts --maxWorkers 1 --no-file-parallelism

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes workspace-local image path allowlisting by propagating the effective workspace root to tool initialization. The fix ensures that when tools are created via `createOpenClawCodingTools` or `createOpenClawTools`, the workspace directory is normalized (trimmed and resolved) before being added to the image tool's allowed local roots. A defensive check now prevents "/" from being added as an implicit media root, which is good security practice.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified issues
- The changes are focused, well-tested, and include proper security hardening. The fix correctly normalizes workspace paths and adds defensive root directory checks. The new e2e test validates the complete flow through `createOpenClawCodingTools`.
- No files require special attention

<sub>Last reviewed commit: 503aa34</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->