### PR TITLE
refactor(media): harden localRoots bypass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 - Media: accept `MEDIA:`-prefixed paths (lenient whitespace) when loading outbound media to prevent `ENOENT` for tool-returned local media paths. (#13107) Thanks @mcaxtr.
 - Agents/Image tool: allow workspace-local image paths by including the active workspace directory in local media allowlists, and trust sandbox-validated paths in image loaders to prevent false "not under an allowed directory" rejections. (#15541)
 - Agents/Image tool: propagate the effective workspace root into tool wiring so workspace-local image paths are accepted by default when running without an explicit `workspaceDir`. (#16722)
+- Media/Security: harden local media allowlist bypasses by requiring an explicit `readFile` override when callers mark paths as validated, and reject filesystem-root `localRoots` entries. (#16739)
 - Cron/Slack: preserve agent identity (name and icon) when cron jobs deliver outbound messages. (#16242) Thanks @robbyczgw-cla.
 - Cron: prevent `cron list`/`cron status` from silently skipping past-due recurring jobs by using maintenance recompute semantics. (#16156) Thanks @zerone0x.
 - Cron: repair missing/corrupt `nextRunAtMs` for the updated job without globally recomputing unrelated due jobs during `cron update`. (#15750)

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -19,6 +19,7 @@ import { createSessionsSendTool } from "./tools/sessions-send-tool.js";
 import { createSessionsSpawnTool } from "./tools/sessions-spawn-tool.js";
 import { createTtsTool } from "./tools/tts-tool.js";
 import { createWebFetchTool, createWebSearchTool } from "./tools/web-tools.js";
+import { resolveWorkspaceRoot } from "./workspace-dir.js";
 
 export function createOpenClawTools(options?: {
   sandboxBrowserBridgeUrl?: string;
@@ -60,7 +61,7 @@ export function createOpenClawTools(options?: {
   /** If true, omit the message tool from the tool list. */
   disableMessageTool?: boolean;
 }): AnyAgentTool[] {
-  const workspaceDir = options?.workspaceDir?.trim() || process.cwd();
+  const workspaceDir = resolveWorkspaceRoot(options?.workspaceDir);
   const imageTool = options?.agentDir?.trim()
     ? createImageTool({
         config: options?.config,

--- a/src/agents/pi-embedded-runner/run/images.ts
+++ b/src/agents/pi-embedded-runner/run/images.ts
@@ -211,7 +211,7 @@ export async function loadImageFromRef(
     const media = options?.sandbox
       ? await loadWebMedia(targetPath, {
           maxBytes: options.maxBytes,
-          localRoots: "any",
+          sandboxValidated: true,
           readFile: (filePath) =>
             options.sandbox!.bridge.readFile({ filePath, cwd: options.sandbox!.root }),
         })

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -53,6 +53,7 @@ import {
   collectExplicitAllowlist,
   resolveToolProfilePolicy,
 } from "./tool-policy.js";
+import { resolveWorkspaceRoot } from "./workspace-dir.js";
 
 function isOpenAIProvider(provider?: string) {
   const normalized = provider?.trim().toLowerCase();
@@ -253,7 +254,7 @@ export function createOpenClawCodingTools(options?: {
   const sandboxRoot = sandbox?.workspaceDir;
   const sandboxFsBridge = sandbox?.fsBridge;
   const allowWorkspaceWrites = sandbox?.workspaceAccess !== "ro";
-  const workspaceRoot = options?.workspaceDir ?? process.cwd();
+  const workspaceRoot = resolveWorkspaceRoot(options?.workspaceDir);
   const workspaceOnly = fsConfig.workspaceOnly === true;
   const applyPatchConfig = execConfig.applyPatch;
   // Secure by default: apply_patch is workspace-contained unless explicitly disabled.

--- a/src/agents/workspace-dir.ts
+++ b/src/agents/workspace-dir.ts
@@ -1,0 +1,20 @@
+import path from "node:path";
+import { resolveUserPath } from "../utils.js";
+
+export function normalizeWorkspaceDir(workspaceDir?: string): string | null {
+  const trimmed = workspaceDir?.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const expanded = trimmed.startsWith("~") ? resolveUserPath(trimmed) : trimmed;
+  const resolved = path.resolve(expanded);
+  // Refuse filesystem roots as "workspace" (too broad; almost always a bug).
+  if (resolved === path.parse(resolved).root) {
+    return null;
+  }
+  return resolved;
+}
+
+export function resolveWorkspaceRoot(workspaceDir?: string): string {
+  return normalizeWorkspaceDir(workspaceDir) ?? process.cwd();
+}

--- a/src/infra/outbound/message-action-params.ts
+++ b/src/infra/outbound/message-action-params.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type {
@@ -200,8 +201,12 @@ async function hydrateAttachmentPayload(params: {
       channel: params.channel,
       accountId: params.accountId,
     });
-    // localRoots: "any" — media paths are already validated by normalizeSandboxMediaList above.
-    const media = await loadWebMedia(mediaSource, maxBytes, { localRoots: "any" });
+    // mediaSource already validated by normalizeSandboxMediaList; allow bypass but force explicit readFile.
+    const media = await loadWebMedia(mediaSource, {
+      maxBytes,
+      sandboxValidated: true,
+      readFile: (filePath: string) => fs.readFile(filePath),
+    });
     params.args.buffer = media.buffer.toString("base64");
     if (!contentTypeParam && media.contentType) {
       params.args.contentType = media.contentType;

--- a/src/web/media.test.ts
+++ b/src/web/media.test.ts
@@ -329,8 +329,20 @@ describe("local media root guard", () => {
   });
 
   it("allows any path when localRoots is 'any'", async () => {
-    const result = await loadWebMedia(tinyPngFile, 1024 * 1024, { localRoots: "any" });
+    const result = await loadWebMedia(tinyPngFile, {
+      maxBytes: 1024 * 1024,
+      localRoots: "any",
+      readFile: (filePath) => fs.readFile(filePath),
+    });
     expect(result.kind).toBe("image");
+  });
+
+  it("rejects filesystem root entries in localRoots", async () => {
+    await expect(
+      loadWebMedia(tinyPngFile, 1024 * 1024, {
+        localRoots: [path.parse(tinyPngFile).root],
+      }),
+    ).rejects.toThrow(/refuses filesystem root/i);
   });
 
   it("allows default OpenClaw state workspace and sandbox roots", async () => {


### PR DESCRIPTION
Centralize workspaceDir normalization + reduce localRoots bypass footguns.

Changes:
- Add `src/agents/workspace-dir.ts` helpers.
- Thread normalization through `src/agents/pi-tools.ts` + `src/agents/openclaw-tools.ts`.
- `src/web/media.ts`: add `sandboxValidated` option, require `readFile` when bypassing allowlist, reject filesystem-root entries in `localRoots`, and type `getDefaultLocalRoots()` as readonly.
- Update callsites (image tool, embedded runner, attachment hydration) to use `sandboxValidated`.
- Update `src/web/media.test.ts` to cover new guards.

Tests:
- pnpm check
- pnpm vitest run src/web/media.test.ts
- pnpm vitest run --config vitest.e2e.config.ts src/agents/tools/image-tool.e2e.test.ts --maxWorkers 1 --no-file-parallelism

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Centralized workspace directory normalization and improved security guards for local media file access. The refactoring extracts workspace path handling into a dedicated `workspace-dir.ts` module, replacing ad-hoc path normalization scattered across tools. The new `sandboxValidated` flag in `media.ts` makes the security model more explicit - callers bypassing the `localRoots` allowlist must now provide an explicit `readFile` function, preventing accidental bypass.

Key changes:
- Added `normalizeWorkspaceDir()` and `resolveWorkspaceRoot()` helpers to centralize workspace path resolution and filesystem-root rejection
- Threaded the normalized workspace path through `pi-tools.ts` and `openclaw-tools.ts` 
- Replaced `localRoots: "any"` with `sandboxValidated: true` + explicit `readFile` at sandbox boundaries (image tool, embedded runner, attachment hydration)
- Added runtime validation in `media.ts` that rejects filesystem root entries in `localRoots` and enforces `readFile` when bypassing allowlist
- Made `getDefaultLocalRoots()` return type `readonly` to signal immutability

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The refactoring hardens security by centralizing workspace path validation and making `localRoots` bypass explicit. All callsites are correctly updated to use `sandboxValidated` with explicit `readFile` functions. Test coverage validates both the new filesystem-root rejection guard and the requirement to pair bypass flags with `readFile`. The changes follow defensive programming principles without breaking existing functionality.
- No files require special attention

<sub>Last reviewed commit: 2f45c4b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->