### PR TITLE
fix: auto-reattach browser relay debugger after navigation

### DIFF
--- a/assets/chrome-extension/background-logic.js
+++ b/assets/chrome-extension/background-logic.js
@@ -1,0 +1,111 @@
+/**
+ * Extracted, testable logic for the Chrome extension background service worker.
+ *
+ * All Chrome API dependencies are injected via the `deps` parameter so
+ * this module can be tested with vitest alone (no browser required).
+ */
+
+/**
+ * @typedef {Object} ReattachDeps
+ * @property {Map<number, {state: string, sessionId?: string, targetId?: string, attachOrder?: number}>} tabs
+ * @property {Map<number, () => void>} pendingReattach
+ * @property {(tabId: number, kind: string) => void} setBadge
+ * @property {(tabId: number, reason: string) => void|Promise<void>} detachTab
+ * @property {() => Promise<void>} ensureRelayConnection
+ * @property {(tabId: number, opts?: {skipAttachedEvent?: boolean}) => Promise<{sessionId: string, targetId: string}>} attachTab
+ * @property {{ onUpdated: { addListener: Function, removeListener: Function }, onRemoved: { addListener: Function, removeListener: Function } }} tabEvents
+ * @property {(fn: Function, ms: number) => ReturnType<typeof setTimeout>} setTimeout
+ * @property {(id: ReturnType<typeof setTimeout>) => void} clearTimeout
+ */
+
+/** Detach reasons where auto-reattach should NOT be attempted. */
+const PERMANENT_DETACH_REASONS = new Set([
+  'canceled_by_user',
+  'replaced_with_devtools',
+])
+
+/**
+ * Handle a Chrome debugger detach event.
+ *
+ * For user-initiated detaches (cancel / DevTools takeover), permanently
+ * detaches the tab. For transient detaches (navigation, crash), waits
+ * for the page to finish loading and attempts to re-attach.
+ *
+ * @param {{ tabId?: number }} source
+ * @param {string} reason
+ * @param {ReattachDeps} deps
+ */
+export function handleDebuggerDetach(source, reason, deps) {
+  const tabId = source.tabId
+  if (!tabId) return
+  if (!deps.tabs.has(tabId)) return
+
+  if (PERMANENT_DETACH_REASONS.has(reason)) {
+    void deps.detachTab(tabId, reason)
+    return
+  }
+
+  // Cancel any previous pending reattach for this tab (rapid navigation guard)
+  const prevCleanup = deps.pendingReattach.get(tabId)
+  if (prevCleanup) prevCleanup()
+
+  // Transient detach — wait for page load, then reattach
+  deps.setBadge(tabId, 'connecting')
+
+  const cleanup = () => {
+    deps.tabEvents.onUpdated.removeListener(onUpdated)
+    deps.tabEvents.onRemoved.removeListener(onRemoved)
+    deps.clearTimeout(timeout)
+    deps.pendingReattach.delete(tabId)
+  }
+
+  const onUpdated = async (updatedTabId, changeInfo) => {
+    if (updatedTabId !== tabId || changeInfo.status !== 'complete') return
+    cleanup()
+    // Clean up the old session before reattaching: sends detachedFromTarget
+    // to the relay and removes stale entries from tabBySession / tabs.
+    // The Chrome debugger is already detached so the detach call inside is a no-op.
+    try {
+      await deps.detachTab(tabId, reason)
+    } catch {
+      return
+    }
+    // detachTab resets badge to 'off'; restore 'connecting' while we reattach.
+    deps.setBadge(tabId, 'connecting')
+    try {
+      await deps.ensureRelayConnection()
+      await deps.attachTab(tabId)
+    } catch {
+      void deps.detachTab(tabId, reason)
+    }
+  }
+
+  const onRemoved = (removedTabId) => {
+    if (removedTabId !== tabId) return
+    cleanup()
+    void deps.detachTab(tabId, 'tab_closed')
+  }
+
+  deps.tabEvents.onUpdated.addListener(onUpdated)
+  deps.tabEvents.onRemoved.addListener(onRemoved)
+  deps.pendingReattach.set(tabId, cleanup)
+
+  // Give up after 10 seconds
+  const timeout = deps.setTimeout(() => {
+    cleanup()
+    void deps.detachTab(tabId, reason)
+  }, 10_000)
+}
+
+/**
+ * Cancel all pending reattach attempts.
+ * Called when the relay connection closes.
+ *
+ * @param {Map<number, () => void>} pendingReattach
+ */
+export function cancelAllPendingReattach(pendingReattach) {
+  for (const cleanup of pendingReattach.values()) {
+    cleanup()
+  }
+  pendingReattach.clear()
+}

--- a/assets/chrome-extension/background.js
+++ b/assets/chrome-extension/background.js
@@ -1,3 +1,5 @@
+import { handleDebuggerDetach, cancelAllPendingReattach } from './background-logic.js'
+
 const DEFAULT_PORT = 18792
 
 const BADGE = {
@@ -25,6 +27,9 @@ const childSessionToTab = new Map()
 
 /** @type {Map<number, {resolve:(v:any)=>void, reject:(e:Error)=>void}>} */
 const pending = new Map()
+
+/** @type {Map<number, () => void>} */
+const pendingReattach = new Map()
 
 function nowStack() {
   try {
@@ -135,6 +140,7 @@ function onRelayClosed(reason) {
   tabs.clear()
   tabBySession.clear()
   childSessionToTab.clear()
+  cancelAllPendingReattach(pendingReattach)
 }
 
 function sendToRelay(payload) {
@@ -262,6 +268,10 @@ async function attachTab(tabId, opts = {}) {
 }
 
 async function detachTab(tabId, reason) {
+  // Cancel any pending reattach
+  const cleanup = pendingReattach.get(tabId)
+  if (cleanup) cleanup()
+
   const tab = tabs.get(tabId)
   if (tab?.sessionId && tab?.targetId) {
     try {
@@ -439,10 +449,17 @@ function onDebuggerEvent(source, method, params) {
 }
 
 function onDebuggerDetach(source, reason) {
-  const tabId = source.tabId
-  if (!tabId) return
-  if (!tabs.has(tabId)) return
-  void detachTab(tabId, reason)
+  handleDebuggerDetach(source, reason, {
+    tabs,
+    pendingReattach,
+    setBadge,
+    detachTab,
+    ensureRelayConnection,
+    attachTab,
+    tabEvents: { onUpdated: chrome.tabs.onUpdated, onRemoved: chrome.tabs.onRemoved },
+    setTimeout,
+    clearTimeout,
+  })
 }
 
 chrome.action.onClicked.addListener(() => void connectOrToggleForActiveTab())

--- a/src/browser/extension-background-detach.test.ts
+++ b/src/browser/extension-background-detach.test.ts
@@ -1,0 +1,291 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+// @ts-expect-error TS7016 — untyped JS module in assets/
+import * as bgLogic from "../../assets/chrome-extension/background-logic.js";
+
+const { cancelAllPendingReattach, handleDebuggerDetach } = bgLogic;
+
+interface EventBus {
+  addListener: ReturnType<typeof vi.fn>;
+  removeListener: ReturnType<typeof vi.fn>;
+  fire(...args: unknown[]): void;
+  readonly listenerCount: number;
+}
+
+function createEventBus(): EventBus {
+  const listeners: Array<(...args: unknown[]) => void> = [];
+  return {
+    addListener: vi.fn((fn: (...args: unknown[]) => void) => listeners.push(fn)),
+    removeListener: vi.fn((fn: (...args: unknown[]) => void) => {
+      const i = listeners.indexOf(fn);
+      if (i >= 0) {
+        listeners.splice(i, 1);
+      }
+    }),
+    fire(...args: unknown[]) {
+      const snapshot = listeners.slice();
+      for (const fn of snapshot) {
+        fn(...args);
+      }
+    },
+    get listenerCount() {
+      return listeners.length;
+    },
+  };
+}
+
+function makeDeps(overrides: Record<string, unknown> = {}) {
+  return {
+    tabs: new Map(),
+    pendingReattach: new Map(),
+    setBadge: vi.fn(),
+    detachTab: vi.fn().mockResolvedValue(undefined),
+    ensureRelayConnection: vi.fn().mockResolvedValue(undefined),
+    attachTab: vi.fn().mockResolvedValue({ sessionId: "s1", targetId: "t1" }),
+    tabEvents: {
+      onUpdated: createEventBus(),
+      onRemoved: createEventBus(),
+    },
+    setTimeout: vi.fn((fn: () => void, ms: number) => setTimeout(fn, ms)),
+    clearTimeout: vi.fn((id: ReturnType<typeof setTimeout>) => clearTimeout(id)),
+    ...overrides,
+  };
+}
+
+describe("handleDebuggerDetach", () => {
+  let deps: ReturnType<typeof makeDeps>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    deps = makeDeps();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // --- guards ---
+
+  it("does nothing if source has no tabId", () => {
+    handleDebuggerDetach({}, "target_crashed", deps);
+    expect(deps.detachTab).not.toHaveBeenCalled();
+    expect(deps.setBadge).not.toHaveBeenCalled();
+  });
+
+  it("does nothing if tabId is not in the tabs map", () => {
+    handleDebuggerDetach({ tabId: 42 }, "target_crashed", deps);
+    expect(deps.detachTab).not.toHaveBeenCalled();
+  });
+
+  // --- permanent detach ---
+
+  it("permanently detaches on canceled_by_user without registering listeners", () => {
+    deps.tabs.set(42, { state: "connected", sessionId: "s1" });
+    handleDebuggerDetach({ tabId: 42 }, "canceled_by_user", deps);
+
+    expect(deps.detachTab).toHaveBeenCalledWith(42, "canceled_by_user");
+    expect(deps.tabEvents.onUpdated.addListener).not.toHaveBeenCalled();
+    expect(deps.pendingReattach.size).toBe(0);
+  });
+
+  it("permanently detaches on replaced_with_devtools", () => {
+    deps.tabs.set(42, { state: "connected", sessionId: "s1" });
+    handleDebuggerDetach({ tabId: 42 }, "replaced_with_devtools", deps);
+
+    expect(deps.detachTab).toHaveBeenCalledWith(42, "replaced_with_devtools");
+    expect(deps.tabEvents.onUpdated.addListener).not.toHaveBeenCalled();
+  });
+
+  // --- transient detach (reattach path) ---
+
+  it("sets badge to connecting and registers both listeners", () => {
+    deps.tabs.set(42, { state: "connected", sessionId: "s1" });
+    handleDebuggerDetach({ tabId: 42 }, "target_crashed", deps);
+
+    expect(deps.setBadge).toHaveBeenCalledWith(42, "connecting");
+    expect(deps.tabEvents.onUpdated.addListener).toHaveBeenCalledOnce();
+    expect(deps.tabEvents.onRemoved.addListener).toHaveBeenCalledOnce();
+    expect(deps.pendingReattach.has(42)).toBe(true);
+  });
+
+  it("reattaches when tab finishes loading", async () => {
+    deps.tabs.set(42, { state: "connected", sessionId: "s1" });
+    handleDebuggerDetach({ tabId: 42 }, "target_crashed", deps);
+
+    deps.tabEvents.onUpdated.fire(42, { status: "complete" });
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Old session must be cleaned up before reattach to avoid orphaned
+    // entries in tabBySession and missing detachedFromTarget relay events.
+    expect(deps.detachTab).toHaveBeenCalledWith(42, "target_crashed");
+    expect(deps.ensureRelayConnection).toHaveBeenCalledOnce();
+    expect(deps.attachTab).toHaveBeenCalledWith(42);
+
+    // Badge restored to 'connecting' after cleanup detach (which resets to 'off')
+    expect(deps.setBadge).toHaveBeenCalledTimes(2);
+    expect(deps.setBadge).toHaveBeenNthCalledWith(1, 42, "connecting");
+    expect(deps.setBadge).toHaveBeenNthCalledWith(2, 42, "connecting");
+
+    // Verify ordering: detachTab → ensureRelayConnection → attachTab
+    const detachOrder = deps.detachTab.mock.invocationCallOrder[0];
+    const relayOrder = deps.ensureRelayConnection.mock.invocationCallOrder[0];
+    const attachOrder = deps.attachTab.mock.invocationCallOrder[0];
+    expect(detachOrder).toBeLessThan(relayOrder);
+    expect(relayOrder).toBeLessThan(attachOrder);
+
+    expect(deps.tabEvents.onUpdated.listenerCount).toBe(0);
+    expect(deps.tabEvents.onRemoved.listenerCount).toBe(0);
+    expect(deps.pendingReattach.has(42)).toBe(false);
+  });
+
+  it("ignores onUpdated for wrong tab", async () => {
+    deps.tabs.set(42, { state: "connected", sessionId: "s1" });
+    handleDebuggerDetach({ tabId: 42 }, "target_crashed", deps);
+
+    deps.tabEvents.onUpdated.fire(99, { status: "complete" });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(deps.attachTab).not.toHaveBeenCalled();
+    expect(deps.tabEvents.onUpdated.listenerCount).toBe(1);
+  });
+
+  it("ignores onUpdated for non-complete status", async () => {
+    deps.tabs.set(42, { state: "connected", sessionId: "s1" });
+    handleDebuggerDetach({ tabId: 42 }, "target_crashed", deps);
+
+    deps.tabEvents.onUpdated.fire(42, { status: "loading" });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(deps.attachTab).not.toHaveBeenCalled();
+    expect(deps.tabEvents.onUpdated.listenerCount).toBe(1);
+  });
+
+  it("detaches with tab_closed when tab is removed during reattach", () => {
+    deps.tabs.set(42, { state: "connected", sessionId: "s1" });
+    handleDebuggerDetach({ tabId: 42 }, "target_crashed", deps);
+
+    deps.tabEvents.onRemoved.fire(42);
+
+    expect(deps.detachTab).toHaveBeenCalledWith(42, "tab_closed");
+    expect(deps.tabEvents.onUpdated.listenerCount).toBe(0);
+    expect(deps.tabEvents.onRemoved.listenerCount).toBe(0);
+    expect(deps.pendingReattach.has(42)).toBe(false);
+  });
+
+  it("ignores onRemoved for wrong tab", () => {
+    deps.tabs.set(42, { state: "connected", sessionId: "s1" });
+    handleDebuggerDetach({ tabId: 42 }, "target_crashed", deps);
+
+    deps.tabEvents.onRemoved.fire(99);
+
+    expect(deps.detachTab).not.toHaveBeenCalled();
+    expect(deps.tabEvents.onUpdated.listenerCount).toBe(1);
+  });
+
+  it("times out after 10s and detaches with original reason", async () => {
+    deps.tabs.set(42, { state: "connected", sessionId: "s1" });
+    handleDebuggerDetach({ tabId: 42 }, "target_crashed", deps);
+
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(deps.detachTab).toHaveBeenCalledWith(42, "target_crashed");
+    expect(deps.tabEvents.onUpdated.listenerCount).toBe(0);
+    expect(deps.tabEvents.onRemoved.listenerCount).toBe(0);
+    expect(deps.pendingReattach.has(42)).toBe(false);
+  });
+
+  it("falls back to detachTab when reattach fails", async () => {
+    deps.tabs.set(42, { state: "connected", sessionId: "s1" });
+    deps.attachTab.mockRejectedValueOnce(new Error("attach failed"));
+    handleDebuggerDetach({ tabId: 42 }, "target_crashed", deps);
+
+    deps.tabEvents.onUpdated.fire(42, { status: "complete" });
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Called twice: first to clean up old session, then as fallback on attach failure.
+    expect(deps.detachTab).toHaveBeenCalledTimes(2);
+    expect(deps.detachTab).toHaveBeenNthCalledWith(1, 42, "target_crashed");
+    expect(deps.detachTab).toHaveBeenNthCalledWith(2, 42, "target_crashed");
+  });
+
+  it("falls back to detachTab when relay connection fails", async () => {
+    deps.tabs.set(42, { state: "connected", sessionId: "s1" });
+    deps.ensureRelayConnection.mockRejectedValueOnce(new Error("relay down"));
+    handleDebuggerDetach({ tabId: 42 }, "target_crashed", deps);
+
+    deps.tabEvents.onUpdated.fire(42, { status: "complete" });
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Called twice: first to clean up old session, then as fallback on relay failure.
+    expect(deps.detachTab).toHaveBeenCalledTimes(2);
+    expect(deps.attachTab).not.toHaveBeenCalled();
+  });
+
+  it("does not double-detach when initial cleanup rejects", async () => {
+    deps.tabs.set(42, { state: "connected", sessionId: "s1" });
+    deps.detachTab.mockRejectedValueOnce(new Error("cleanup failed"));
+    handleDebuggerDetach({ tabId: 42 }, "target_crashed", deps);
+
+    deps.tabEvents.onUpdated.fire(42, { status: "complete" });
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Initial cleanup detachTab rejects — returns early without attempting reattach.
+    // detachTab is NOT called a second time (separate try blocks prevent the
+    // reattach catch from re-invoking detachTab for cleanup failures).
+    expect(deps.detachTab).toHaveBeenCalledTimes(1);
+    expect(deps.ensureRelayConnection).not.toHaveBeenCalled();
+    expect(deps.attachTab).not.toHaveBeenCalled();
+  });
+
+  // --- rapid navigation guard ---
+
+  it("cancels previous pending reattach on rapid re-detach", () => {
+    deps.tabs.set(42, { state: "connected", sessionId: "s1" });
+
+    handleDebuggerDetach({ tabId: 42 }, "target_crashed", deps);
+    expect(deps.tabEvents.onUpdated.listenerCount).toBe(1);
+    expect(deps.tabEvents.onRemoved.listenerCount).toBe(1);
+
+    handleDebuggerDetach({ tabId: 42 }, "target_crashed", deps);
+
+    expect(deps.tabEvents.onUpdated.listenerCount).toBe(1);
+    expect(deps.tabEvents.onRemoved.listenerCount).toBe(1);
+    expect(deps.clearTimeout).toHaveBeenCalled();
+    expect(deps.pendingReattach.size).toBe(1);
+  });
+
+  it("does not leak listeners across three rapid detaches", () => {
+    deps.tabs.set(42, { state: "connected", sessionId: "s1" });
+
+    handleDebuggerDetach({ tabId: 42 }, "nav1", deps);
+    handleDebuggerDetach({ tabId: 42 }, "nav2", deps);
+    handleDebuggerDetach({ tabId: 42 }, "nav3", deps);
+
+    expect(deps.tabEvents.onUpdated.listenerCount).toBe(1);
+    expect(deps.tabEvents.onRemoved.listenerCount).toBe(1);
+    expect(deps.pendingReattach.size).toBe(1);
+  });
+});
+
+describe("cancelAllPendingReattach", () => {
+  it("calls all cleanup functions and clears the map", () => {
+    const cleanups = [vi.fn(), vi.fn(), vi.fn()];
+    const map = new Map<number, () => void>([
+      [1, cleanups[0]],
+      [2, cleanups[1]],
+      [3, cleanups[2]],
+    ]);
+
+    cancelAllPendingReattach(map);
+
+    for (const fn of cleanups) {
+      expect(fn).toHaveBeenCalledOnce();
+    }
+    expect(map.size).toBe(0);
+  });
+
+  it("handles empty map", () => {
+    const map = new Map<number, () => void>();
+    cancelAllPendingReattach(map);
+    expect(map.size).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Auto-reattach the Chrome extension debugger when Chrome detaches it during page navigation (cross-origin redirects, OAuth flows, SPA navigation)
- Previously, any navigation that triggered a debugger detach permanently lost the tab connection, requiring manual re-click of the extension icon
- User-initiated cancellation (clicking "Cancel" on the debugging infobar) is still respected

## Problem

When using the browser relay extension, navigating a tab through a redirect chain (e.g. OAuth/Clerk auth flow) causes Chrome to detach the debugger. The `onDebuggerDetach` handler unconditionally removed the tab from tracking, making all subsequent browser actions fail with `"tab not found"`. There was no recovery path — the user had to manually re-click the extension icon.

## Fix

In `onDebuggerDetach`, instead of immediately detaching:

1. Check if the reason is `canceled_by_user` — if so, respect it and detach as before
2. Otherwise, set the badge to "connecting" and listen for the tab to finish loading (`chrome.tabs.onUpdated` with `status === 'complete'`)
3. Re-attach the debugger via `attachTab()`, which sends a fresh `Target.attachedToTarget` event to the relay
4. Give up after 10 seconds if the tab never finishes loading

No server-side relay changes needed — `attachTab()` already sends the correct events.

## Test plan

- [ ] Navigate a relay-attached tab to a different origin — badge should briefly show "…" then return to "ON"
- [ ] OAuth redirect flow (e.g. Clerk, Google OAuth) — relay should survive the redirect chain
- [ ] Click "Cancel" on Chrome's debugging infobar — should still properly detach
- [ ] Close a relay-attached tab — should clean up without errors
- [ ] Tab that fails to load within 10 seconds — should gracefully detach

Fixes #11675

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds auto-reattach logic for the Chrome extension's browser relay debugger after transient navigation events (cross-origin redirects, OAuth flows, SPA navigation). Previously, any debugger detach permanently lost the tab connection.

- Extracts `handleDebuggerDetach` into a new `background-logic.js` module with dependency injection for testability
- On transient detach: sets badge to "connecting", waits for tab load (`status === 'complete'`), cleans up the old session, then re-attaches via `attachTab()`
- Respects permanent detach reasons (`canceled_by_user`, `replaced_with_devtools`) — these still fully detach
- Guards against rapid navigation with a `pendingReattach` map that cancels previous in-flight reattach attempts
- Cleans up listeners (`onUpdated`, `onRemoved`) and timeouts on all resolution paths (success, failure, tab close, timeout)
- Cancels all pending reattaches when the relay connection closes
- Adds `cancelAllPendingReattach` call in `detachTab` to prevent stale reattach attempts
- Comprehensive test suite (291 lines) covering guards, permanent/transient detach, rapid navigation, timeout, and error fallback paths
- Unrelated: documents Slack `assistant:write` scope requirement for typing status indicators

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — well-tested reattach logic with proper cleanup on all paths and no server-side changes needed.
- Score of 4 reflects clean, well-structured code with comprehensive test coverage (15 test cases), proper resource cleanup, and no identified logic bugs. All previous review issues have been addressed. Slight deduction because this is browser extension code that handles complex async state transitions which are inherently tricky to verify without integration testing in a real Chrome environment.
- No files require special attention. All changes are well-tested and follow established patterns in the codebase.

<sub>Last reviewed commit: d713eb9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->