### PR TITLE
fix: Read tool handler checks both path and file_path params

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -74,7 +74,9 @@ export async function handleToolExecutionStart(
 
   if (toolName === "read") {
     const record = args && typeof args === "object" ? (args as Record<string, unknown>) : {};
-    const filePath = typeof record.path === "string" ? record.path.trim() : "";
+    const filePath =
+      (typeof record.path === "string" ? record.path.trim() : "") ||
+      (typeof record.file_path === "string" ? record.file_path.trim() : "");
     if (!filePath) {
       const argsPreview = typeof args === "string" ? args.slice(0, 200) : undefined;
       ctx.log.warn(


### PR DESCRIPTION
## Summary
- Fixes #16717
- The Read tool handler in `pi-embedded-subscribe.handlers.tools.ts` only checked `record.path` for the warning log, missing `record.file_path` (the parameter name used by some clients)
- Now checks both `record.path` and `record.file_path` with a fallback chain

## Test plan
- [x] Verified handler logs correct path when `file_path` is used instead of `path`
- [x] Existing pi-embedded-subscribe tests pass
- [x] Linting and formatting pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

The Read tool handler now checks both `path` and `file_path` parameters when logging warnings about missing paths. This aligns with the codebase's existing Claude Code compatibility layer that supports both parameter naming conventions (`file_path` for Claude Code, `path` for pi-coding-agent).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a straightforward fix that adds a fallback check for the `file_path` parameter in a warning log statement. It's consistent with the existing parameter normalization pattern used throughout the codebase (see `pi-tools.read.ts` lines 110-123). The logic uses the OR operator correctly to check `record.path` first, then fall back to `record.file_path`, which matches the precedence order in the normalization layer.
- No files require special attention

<sub>Last reviewed commit: 6b639a8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->