### PR TITLE
fix: BlueBubbles reply action falls back gracefully without Private API

### DIFF
--- a/extensions/bluebubbles/src/actions.ts
+++ b/extensions/bluebubbles/src/actions.ts
@@ -280,8 +280,11 @@ export const bluebubblesMessageActions: ChannelMessageActionAdapter = {
     }
 
     // Handle reply action
+    // Note: do NOT assertPrivateApiEnabled() here — sendMessageBlueBubbles
+    // gracefully downgrades to a plain send when Private API is unavailable,
+    // stripping reply threading fields. This is preferable to silently
+    // dropping the message entirely (#16429).
     if (action === "reply") {
-      assertPrivateApiEnabled();
       const rawMessageId = readStringParam(params, "messageId");
       const text = readMessageText(params);
       const to = readStringParam(params, "to") ?? readStringParam(params, "target");

--- a/extensions/bluebubbles/src/actions.ts
+++ b/extensions/bluebubbles/src/actions.ts
@@ -75,7 +75,6 @@ const PRIVATE_API_ACTIONS = new Set<ChannelMessageActionName>([
   "react",
   "edit",
   "unsend",
-  "reply",
   "sendWithEffect",
   "renameGroup",
   "setGroupIcon",

--- a/extensions/bluebubbles/src/actions.ts
+++ b/extensions/bluebubbles/src/actions.ts
@@ -73,6 +73,7 @@ function readBooleanParam(params: Record<string, unknown>, key: string): boolean
 const SUPPORTED_ACTIONS = new Set<ChannelMessageActionName>(BLUEBUBBLES_ACTION_NAMES);
 const PRIVATE_API_ACTIONS = new Set<ChannelMessageActionName>([
   "react",
+  "reply",
   "edit",
   "unsend",
   "sendWithEffect",


### PR DESCRIPTION
## Summary
The BlueBubbles reply action called `assertPrivateApiEnabled()` which threw before `sendMessageBlueBubbles` could apply its built-in fallback — meaning users without Private API couldn't reply at all, even though a graceful plain-send fallback existed. Removed the assertion so the send function's fallback logic can work as intended.

Fixes #16429

## Validation
- [x] `pnpm build` — passed
- [x] `pnpm check` (format + tsgo + lint) — passed
- [x] `pnpm test` — 1073 tests passed (105 test files)

## Scope
- Single focused fix — single file changed (`extensions/bluebubbles/src/actions.ts`)

## AI-Assistance
- AI-assisted (Claude Code) for implementation
- Human-reviewed: confirmed understanding of changes
- Testing: full local validation suite passed