### PR TITLE
fix: Slack reactions pass explicit bot token for DM channels

### DIFF
--- a/src/slack/actions.ts
+++ b/src/slack/actions.ts
@@ -73,8 +73,10 @@ export async function reactSlackMessage(
   emoji: string,
   opts: SlackActionClientOpts = {},
 ) {
-  const client = await getClient(opts);
+  const token = resolveToken(opts.token, opts.accountId);
+  const client = opts.client ?? createSlackWebClient(token);
   await client.reactions.add({
+    token,
     channel: channelId,
     timestamp: messageId,
     name: normalizeEmoji(emoji),
@@ -87,8 +89,10 @@ export async function removeSlackReaction(
   emoji: string,
   opts: SlackActionClientOpts = {},
 ) {
-  const client = await getClient(opts);
+  const token = resolveToken(opts.token, opts.accountId);
+  const client = opts.client ?? createSlackWebClient(token);
   await client.reactions.remove({
+    token,
     channel: channelId,
     timestamp: messageId,
     name: normalizeEmoji(emoji),
@@ -100,7 +104,8 @@ export async function removeOwnSlackReactions(
   messageId: string,
   opts: SlackActionClientOpts = {},
 ): Promise<string[]> {
-  const client = await getClient(opts);
+  const token = resolveToken(opts.token, opts.accountId);
+  const client = opts.client ?? createSlackWebClient(token);
   const userId = await resolveBotUserId(client);
   const reactions = await listSlackReactions(channelId, messageId, { client });
   const toRemove = new Set<string>();
@@ -120,6 +125,7 @@ export async function removeOwnSlackReactions(
   await Promise.all(
     Array.from(toRemove, (name) =>
       client.reactions.remove({
+        token,
         channel: channelId,
         timestamp: messageId,
         name,


### PR DESCRIPTION
## Summary
`reactSlackMessage` and `removeSlackReaction` used `getClient()` which could return the wrong token for DM channels, causing reaction API calls to fail. Fixed by passing an explicit bot token when operating on DM channels, ensuring the correct authentication is used.

Fixes #16588

## Validation
- [x] `pnpm build` — passed
- [x] `pnpm check` (format + tsgo + lint) — passed
- [x] `pnpm test` — 1073 tests passed (105 test files)

## Scope
- Single focused fix — pass explicit bot token for DM channels in `src/slack/actions.ts`

## AI-Assistance
- AI-assisted (Claude Code) for implementation
- Human-reviewed: confirmed understanding of changes
- Testing: full local validation suite passed