### PR TITLE
fix: allow empty message content for Discord voice-only sends

### DIFF
--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -395,10 +395,11 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
     readStringParam(params, "path", { trim: false }) ??
     readStringParam(params, "filePath", { trim: false });
   const hasCard = params.card != null && typeof params.card === "object";
+  const asVoice = params.asVoice === true;
   const caption = readStringParam(params, "caption", { allowEmpty: true }) ?? "";
   let message =
     readStringParam(params, "message", {
-      required: !mediaHint && !hasCard,
+      required: !mediaHint && !hasCard && !asVoice,
       allowEmpty: true,
     }) ?? "";
   if (message.includes("\\n")) {


### PR DESCRIPTION
## Summary
`handleSendAction` required a non-empty message parameter even for voice-only sends on Discord. This caused voice-only sends (e.g., TTS without text content) to fail validation unnecessarily. Relaxed the validation to allow empty message content when the send is voice-only.

Fixes #16688

## Validation
- [x] `pnpm build` — passed
- [x] `pnpm check` (format + tsgo + lint) — passed
- [x] `pnpm test` — 1073 tests passed (105 test files)

## Scope
- Single focused fix — relax message content validation in `src/infra/outbound/message-action-runner.ts`

## AI-Assistance
- AI-assisted (Claude Code) for implementation
- Human-reviewed: confirmed understanding of changes
- Testing: full local validation suite passed