### PR TITLE
fix: sanitize tool_use/tool_result pairing before every API call

### DIFF
--- a/src/agents/session-transcript-repair-stream-guard.test.ts
+++ b/src/agents/session-transcript-repair-stream-guard.test.ts
@@ -1,0 +1,128 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { describe, expect, it, vi } from "vitest";
+import { sanitizeToolUseResultPairing } from "./session-transcript-repair.js";
+
+/**
+ * Validates the defense-in-depth stream guard logic introduced in #16693.
+ *
+ * During multi-turn tool execution the SDK can append messages that create
+ * orphaned tool_result blocks.  The stream guard runs
+ * `sanitizeToolUseResultPairing` on the messages passed to `streamFn` before
+ * each API call, so even mid-loop orphans are caught.
+ */
+describe("stream guard: tool pairing sanitization before API call (#16693)", () => {
+  it("drops orphaned tool_result that follows a user turn after provider switch", () => {
+    const messages: AgentMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Let me look that up." },
+          { type: "toolCall", id: "call_openai_abc123", name: "search", arguments: "{}" },
+        ],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_openai_abc123",
+        toolName: "search",
+        content: [{ type: "text", text: "result from search" }],
+        isError: false,
+      },
+      { role: "user", content: "Now summarize that." },
+      {
+        role: "assistant",
+        content: [
+          { type: "toolCall", id: "toolu_01XYZ", name: "read", arguments: '{"path":"a.txt"}' },
+        ],
+      },
+      // Orphaned tool_result — leftover from a stale OpenAI call not in context
+      {
+        role: "toolResult",
+        toolCallId: "call_openai_stale999",
+        toolName: "exec",
+        content: [{ type: "text", text: "stale openai result" }],
+        isError: false,
+      },
+      {
+        role: "toolResult",
+        toolCallId: "toolu_01XYZ",
+        toolName: "read",
+        content: [{ type: "text", text: "file content" }],
+        isError: false,
+      },
+    ];
+
+    const sanitized = sanitizeToolUseResultPairing(messages);
+
+    const toolResultIds = sanitized
+      .filter((m) => m.role === "toolResult")
+      .map((m) => (m as { toolCallId?: string }).toolCallId);
+
+    expect(toolResultIds).not.toContain("call_openai_stale999");
+    expect(toolResultIds).toContain("call_openai_abc123");
+    expect(toolResultIds).toContain("toolu_01XYZ");
+  });
+
+  it("returns same reference for a clean transcript with no tool calls", () => {
+    const messages: AgentMessage[] = [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi there" },
+    ];
+
+    const sanitized = sanitizeToolUseResultPairing(messages);
+    expect(sanitized).toBe(messages);
+  });
+
+  it("simulates the full stream guard wrapper flow", () => {
+    const innerStreamFn = vi.fn();
+    const wrapStreamFn = (streamFn: typeof innerStreamFn) => {
+      return (model: unknown, context: unknown, options: unknown) => {
+        const ctx = context as { messages?: AgentMessage[] };
+        if (Array.isArray(ctx.messages) && ctx.messages.length > 0) {
+          const sanitized = sanitizeToolUseResultPairing(ctx.messages);
+          if (sanitized !== ctx.messages) {
+            return streamFn(model, { ...context, messages: sanitized }, options);
+          }
+        }
+        return streamFn(model, context, options);
+      };
+    };
+
+    const wrappedStreamFn = wrapStreamFn(innerStreamFn);
+
+    const messagesWithOrphan: AgentMessage[] = [
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "toolu_01B", name: "exec", arguments: '{"cmd":"ls"}' }],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_stale",
+        toolName: "unknown",
+        content: [{ type: "text", text: "stale" }],
+        isError: false,
+      },
+      {
+        role: "toolResult",
+        toolCallId: "toolu_01B",
+        toolName: "exec",
+        content: [{ type: "text", text: "file list" }],
+        isError: false,
+      },
+    ];
+
+    const model = { id: "claude-opus-4-6", provider: "anthropic", api: "anthropic-messages" };
+    const context = { system: "You are helpful.", messages: messagesWithOrphan };
+    const options = {};
+
+    wrappedStreamFn(model, context, options);
+
+    expect(innerStreamFn).toHaveBeenCalledTimes(1);
+    const passedContext = innerStreamFn.mock.calls[0][1] as { messages: AgentMessage[] };
+    const resultIds = passedContext.messages
+      .filter((m) => m.role === "toolResult")
+      .map((m) => (m as { toolCallId?: string }).toolCallId);
+
+    expect(resultIds).toEqual(["toolu_01B"]);
+    expect(resultIds).not.toContain("call_stale");
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes #16693
- During multi-turn tool execution, the SDK can append messages that create orphaned tool_result blocks — especially after mid-session provider switches (e.g. OpenAI → Anthropic)
- The existing sanitization only ran at session load; added a defense-in-depth streamFn wrapper that re-runs `repairToolUseResultPairing` on `context.messages` before each API call
- Only activates when `transcriptPolicy.repairToolUseResultPairing` is true (Anthropic-compatible providers)

## Test plan
- [x] All 35 pi-embedded-runner tests pass
- [x] New unit tests validate provider-switch orphan scenario, idempotency, and full wrapper flow
- [x] Linting and formatting pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds defense-in-depth sanitization of tool_use/tool_result pairing by wrapping `streamFn` to run `sanitizeToolUseResultPairing` on context messages before every API call, fixing orphaned tool_result blocks that can appear during multi-turn tool execution, especially after mid-session provider switches.

- Wraps `activeSession.agent.streamFn` with a guard that sanitizes messages only when `transcriptPolicy.repairToolUseResultPairing` is true (Anthropic-compatible providers)
- Positioned as the outermost wrapper (after cacheTrace and anthropicPayloadLogger), ensuring sanitization runs first
- Uses identity check to avoid unnecessary object creation when messages are already clean
- Comprehensive test coverage validates orphan removal, idempotency, and full wrapper flow

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is well-designed and follows established patterns in the codebase. The wrapper approach is defensive and only modifies messages when necessary (identity check optimization). Tests comprehensively validate the core scenarios including orphan removal and idempotency. The change is scoped to only affect providers that require tool pairing repair (Anthropic-compatible), minimizing impact. The implementation correctly positions the wrapper in the chain and includes clear documentation
- No files require special attention

<sub>Last reviewed commit: ff49afa</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->