### PR TITLE
fix(model): apply provider baseUrl/headers override to registry-found models

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -175,6 +175,11 @@
           - "docs/install/docker.md"
           - "docs/multi-agent-sandbox-tools.md"
 
+"k8s":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "k8s/**"
+
 "agents":
   - changed-files:
       - any-glob-to-any-file:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Docs: https://docs.openclaw.ai
 
 ### Added
 
+- Providers: add native Azure OpenAI support (`azure-openai-responses` API type) with provider-level headers merging and documentation. (#14475) Thanks @dzianisv.
+- Ops: add Kubernetes deployment manifests and bootstrap scripts for self-hosted gateway. (#14475) Thanks @dzianisv.
 - Gateway: add `agents.create`, `agents.update`, `agents.delete` RPC methods for web UI agent management. (#11045) Thanks @advaitpaliwal.
 - Gateway: add node command allowlists (default-deny unknown node commands; configurable via `gateway.nodes.allowCommands` / `gateway.nodes.denyCommands`). (#11755) Thanks @mbelinky.
 - Plugins: add `device-pair` (Telegram `/pair` flow) and `phone-control` (iOS/Android node controls). (#11755) Thanks @mbelinky.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1028,6 +1028,7 @@
                 "pages": [
                   "providers/anthropic",
                   "providers/openai",
+                  "providers/azure-openai",
                   "providers/openrouter",
                   "providers/bedrock",
                   "providers/vercel-ai-gateway",

--- a/docs/providers/azure-openai.md
+++ b/docs/providers/azure-openai.md
@@ -1,0 +1,77 @@
+---
+summary: "Use Azure OpenAI models in OpenClaw"
+read_when:
+  - You want to use Azure OpenAI deployments in OpenClaw
+  - You need to configure a custom endpoint and deployment name
+title: "Azure OpenAI"
+---
+
+# Azure OpenAI
+
+OpenClaw supports Azure OpenAI via custom provider configuration. You can connect to your Azure OpenAI resource by specifying the endpoint, API key, and deployment details.
+
+## Configuration
+
+Add the following to your `openclaw.json` (or `config.json`):
+
+```json5
+{
+  models: {
+    providers: {
+      azure: {
+        // Your Azure OpenAI Endpoint
+        baseUrl: "https://YOUR_RESOURCE_NAME.openai.azure.com/openai/deployments/YOUR_DEPLOYMENT_NAME",
+
+        // Use the specialized Azure adapter
+        api: "azure-openai-responses",
+
+        // Your Azure API Key (not the OpenAI 'sk-' key)
+        apiKey: "YOUR_AZURE_API_KEY",
+
+        // Define the models available on this deployment
+        models: [
+          {
+            id: "gpt-4",
+            name: "gpt-4", // or your deployment name if different
+          },
+        ],
+      },
+    },
+  },
+}
+```
+
+### Important Notes on URLs
+
+Azure OpenAI URLs typically follow this pattern:
+`https://{resource}.openai.azure.com/openai/deployments/{deployment}/chat/completions?api-version={version}`
+
+OpenClaw's `azure-openai-responses` adapter expects the `baseUrl` to be the deployment root. It will append `/chat/completions` and the API version parameters automatically, or you can specify the full path if needed depending on your specific setup.
+
+If you need to strictly control the URL or headers:
+
+```json5
+{
+  models: {
+    providers: {
+      "azure-custom": {
+        baseUrl: "https://YOUR_RESOURCE.openai.azure.com/openai/deployments/YOUR_DEPLOYMENT",
+        // Fallback to generic OpenAI if the Azure adapter doesn't match your version needs
+        api: "openai-responses",
+        apiKey: "YOUR_KEY",
+        headers: {
+          "api-key": "YOUR_KEY", // Azure requires this header if not using Bearer
+        },
+      },
+    },
+  },
+}
+```
+
+## Usage
+
+Once configured, you can use the model by referencing `provider/model-id`:
+
+```bash
+openclaw chat --model azure/gpt-4
+```

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -36,6 +36,7 @@ See [Venice AI](/providers/venice).
 ## Provider docs
 
 - [OpenAI (API + Codex)](/providers/openai)
+- [Azure OpenAI](/providers/azure-openai)
 - [Anthropic (API + Claude Code CLI)](/providers/anthropic)
 - [Qwen (OAuth)](/providers/qwen)
 - [OpenRouter](/providers/openrouter)

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,62 @@
+# OpenClaw Kubernetes Deployment
+
+This directory contains standard Kubernetes manifests for deploying OpenClaw Gateway.
+
+## Prerequisites
+
+- A running Kubernetes cluster (k8s or k3s).
+- `kubectl` configured to communicate with your cluster.
+- An OpenClaw Docker image (either pulled from a registry or built locally and imported).
+
+## Setup Instructions
+
+### 1. Configure Secrets
+
+Edit `secret.yaml` to set your secure gateway token.
+
+```bash
+# Generate a token
+openssl rand -hex 32
+
+# Update the file
+nano secret.yaml
+```
+
+### 2. Apply Manifests
+
+Apply the configuration in the following order:
+
+```bash
+kubectl apply -f secret.yaml
+kubectl apply -f pvc.yaml
+kubectl apply -f deployment.yaml
+kubectl apply -f service.yaml
+```
+
+### 3. Verify Deployment
+
+Check the status of the pods:
+
+```bash
+kubectl get pods
+kubectl logs -f deployment/openclaw-gateway
+```
+
+## Accessing the Gateway
+
+By default, the service is of type `ClusterIP`. To access it:
+
+- **Port Forwarding:**
+
+  ```bash
+  kubectl port-forward service/openclaw-service 18789:18789
+  ```
+
+- **NodePort / LoadBalancer:**
+  Edit `service.yaml` and change `type: ClusterIP` to `NodePort` or `LoadBalancer`.
+
+## Customization
+
+- **Image:** Update `deployment.yaml` to point to your specific Docker image tag.
+- **Resources:** Adjust CPU and memory limits in `deployment.yaml` based on your cluster capacity.
+- **Storage:** Check `pvc.yaml` to adjust the storage size (default 10Gi).

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -62,6 +62,28 @@ By default, the service is of type `ClusterIP`. To access it:
 - **NodePort / LoadBalancer:**
   Edit `service.yaml` and change `type: ClusterIP` to `NodePort` or `LoadBalancer`.
 
+### Ingress with TLS (Traefik + cert-manager)
+
+For HTTPS access with automatic Let's Encrypt certificates, apply the ingress manifest:
+
+```bash
+kubectl apply -f ingress.yaml
+```
+
+This creates an Ingress resource that:
+
+- Routes traffic from `openclaw.vibebrowser.app` to the gateway service.
+- Uses Traefik as the ingress controller.
+- Provisions a TLS certificate via cert-manager and the `letsencrypt-prod` ClusterIssuer.
+
+**Prerequisites:**
+
+- Traefik ingress controller running (default on k3s).
+- cert-manager installed with a `letsencrypt-prod` ClusterIssuer.
+- DNS A record for `openclaw.vibebrowser.app` pointing to your cluster's public IP.
+
+**Customization:** Update the `host` field in `ingress.yaml` to use your own domain.
+
 ## Customization
 
 - **Image:** Update `deployment.yaml` to point to your specific Docker image tag.

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -8,6 +8,13 @@ This directory contains standard Kubernetes manifests for deploying OpenClaw Gat
 - `kubectl` configured to communicate with your cluster.
 - An OpenClaw Docker image (either pulled from a registry or built locally and imported).
 
+## Community Helm Charts
+
+If you prefer using Helm, there are community-maintained charts available:
+
+- **[Chrisbattarbee/openclaw-helm](https://github.com/Chrisbattarbee/openclaw-helm)**: A comprehensive chart with support for configuration injection, persistence, and ingress.
+- **[serhanekicii/openclaw-helm](https://github.com/serhanekicii/openclaw-helm)**: Another popular community chart.
+
 ## Setup Instructions
 
 ### 1. Configure Secrets

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: openclaw-gateway
+  labels:
+    app: openclaw
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: openclaw
+  template:
+    metadata:
+      labels:
+        app: openclaw
+    spec:
+      securityContext:
+        fsGroup: 1000 # Ensure 'node' user can write to the volume
+      containers:
+        - name: gateway
+          # Replace with your image registry path or use a local image if configured
+          image: ghcr.io/openclaw/openclaw:latest
+          imagePullPolicy: IfNotPresent
+          command:
+            - node
+            - dist/index.js
+            - gateway
+            - --bind
+            - lan
+            - --port
+            - "18789"
+          ports:
+            - containerPort: 18789
+              name: gateway
+            - containerPort: 18790
+              name: bridge
+          env:
+            - name: HOME
+              value: /home/node
+            - name: OPENCLAW_GATEWAY_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: openclaw-secret
+                  key: OPENCLAW_GATEWAY_TOKEN
+          volumeMounts:
+            - name: config-volume
+              mountPath: /home/node/.openclaw
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "250m"
+            limits:
+              memory: "2Gi"
+              cpu: "1000m"
+      volumes:
+        - name: config-volume
+          persistentVolumeClaim:
+            claimName: openclaw-pvc

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -25,10 +25,12 @@ spec:
             - node
             - dist/index.js
             - gateway
+            - run
             - --bind
             - lan
             - --port
             - "18789"
+            - --allow-unconfigured
           ports:
             - containerPort: 18789
               name: gateway

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -25,7 +25,6 @@ spec:
             - node
             - dist/index.js
             - gateway
-            - run
             - --bind
             - lan
             - --port

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,27 +1,18 @@
-apiVersion: networking.k8s.io/v1
-kind: Ingress
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
 metadata:
-  name: openclaw-ingress
+  name: openclaw-gateway
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
-    external-dns.alpha.kubernetes.io/target: "4.246.58.241"
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
   labels:
-    app: openclaw-gateway
+    app: openclaw
 spec:
-  ingressClassName: traefik
-  rules:
-    - host: openclaw.vibebrowser.app
-      http:
-        paths:
-          - backend:
-              service:
-                name: openclaw-service
-                port:
-                  number: 18789
-            path: /
-            pathType: Prefix
-  tls:
-    - hosts:
-        - openclaw.vibebrowser.app
-      secretName: openclaw-tls
+  entryPoints:
+    - web
+    - websecure
+  routes:
+    - match: Host(`openclaw.vibebrowser.app`)
+      kind: Rule
+      services:
+        - name: openclaw-service
+          port: 18789

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: openclaw-ingress
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
+  labels:
+    app: openclaw-gateway
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: openclaw.vibebrowser.app
+      http:
+        paths:
+          - backend:
+              service:
+                name: openclaw-service
+                port:
+                  number: 18789
+            path: /
+            pathType: Prefix
+  tls:
+    - hosts:
+        - openclaw.vibebrowser.app
+      secretName: openclaw-tls

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
+    external-dns.alpha.kubernetes.io/target: "4.246.58.241"
   labels:
     app: openclaw-gateway
 spec:

--- a/k8s/pvc.yaml
+++ b/k8s/pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: openclaw-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/k8s/secret.yaml
+++ b/k8s/secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openclaw-secret
+type: Opaque
+stringData:
+  # Replace with a generated secure token
+  # You can generate one with: openssl rand -hex 32
+  OPENCLAW_GATEWAY_TOKEN: "replace-me-with-secure-token"

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: openclaw-service
+spec:
+  selector:
+    app: openclaw
+  ports:
+    - protocol: TCP
+      port: 18789
+      targetPort: 18789
+      name: gateway
+    - protocol: TCP
+      port: 18790
+      targetPort: 18790
+      name: bridge
+  type: ClusterIP
+  # Use NodePort or LoadBalancer if you need external access
+  # type: NodePort

--- a/scripts/k8s-deploy.sh
+++ b/scripts/k8s-deploy.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# k8s-deploy.sh
+# Deploys OpenClaw to the current Kubernetes context.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+K8S_DIR="$ROOT_DIR/k8s"
+
+echo "==> OpenClaw Kubernetes Deployer"
+
+if ! command -v kubectl >/dev/null 2>&1; then
+    echo "Error: kubectl is not installed."
+    exit 1
+fi
+
+# Check connection
+if ! kubectl cluster-info >/dev/null 2>&1; then
+    echo "Error: Cannot connect to Kubernetes cluster."
+    exit 1
+fi
+
+echo "==> Cluster: $(kubectl config current-context)"
+
+# Generate Token if not set
+TOKEN="${OPENCLAW_GATEWAY_TOKEN:-}"
+if [[ -z "$TOKEN" ]]; then
+    echo "Generating secure gateway token..."
+    TOKEN="$(openssl rand -hex 32)"
+    echo "Token: $TOKEN"
+fi
+
+echo "==> Applying Secrets..."
+# We use imperative creation to avoid storing the secret in git, 
+# or we render the template.
+# Let's verify if secret exists
+if kubectl get secret openclaw-secret >/dev/null 2>&1; then
+    echo "Secret 'openclaw-secret' already exists. Skipping creation."
+else
+    kubectl create secret generic openclaw-secret \
+        --from-literal=OPENCLAW_GATEWAY_TOKEN="$TOKEN"
+    echo "Secret 'openclaw-secret' created."
+fi
+
+echo "==> Applying Manifests..."
+kubectl apply -f "$K8S_DIR/pvc.yaml"
+kubectl apply -f "$K8S_DIR/deployment.yaml"
+kubectl apply -f "$K8S_DIR/service.yaml"
+
+echo ""
+echo "==> Deployment initiated."
+echo "Check status with: kubectl get pods -l app=openclaw"
+echo "Gateway Token: $TOKEN"

--- a/scripts/vm-bootstrap.sh
+++ b/scripts/vm-bootstrap.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# vm-bootstrap.sh
+# Bootstraps a fresh Ubuntu/Debian VM for OpenClaw deployment.
+# Installs Docker, Git, and runs the main docker-setup.sh script.
+
+echo "==> OpenClaw VM Bootstrap"
+
+if [[ $EUID -ne 0 ]]; then
+   echo "This script must be run as root (or via sudo)"
+   exit 1
+fi
+
+echo "==> Updating package lists..."
+apt-get update
+
+echo "==> Installing prerequisites (git, curl)..."
+apt-get install -y git curl
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "==> Installing Docker..."
+    # Standard installation for Ubuntu/Debian
+    apt-get install -y docker.io
+    # Start and enable docker
+    systemctl start docker
+    systemctl enable docker
+else
+    echo "Docker already installed."
+fi
+
+# Ensure docker compose plugin is available (docker compose v2)
+if ! docker compose version >/dev/null 2>&1; then
+    echo "==> Installing Docker Compose Plugin..."
+    apt-get install -y docker-compose-plugin || {
+        echo "Failed to install docker-compose-plugin via apt. Trying standalone install..."
+        mkdir -p /usr/local/lib/docker/cli-plugins
+        curl -SL https://github.com/docker/compose/releases/download/v2.23.3/docker-compose-linux-$(uname -m) -o /usr/local/lib/docker/cli-plugins/docker-compose
+        chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
+    }
+fi
+
+# Verify docker compose works
+if ! docker compose version >/dev/null 2>&1; then
+    echo "Error: docker compose is still not available."
+    exit 1
+fi
+
+# Directory setup
+INSTALL_DIR="/opt/openclaw"
+if [[ -d .git && -f "package.json" ]]; then
+    echo "Already inside a repository. Using current directory."
+    INSTALL_DIR="$(pwd)"
+else
+    if [[ ! -d "$INSTALL_DIR" ]]; then
+        echo "==> Cloning OpenClaw repository to $INSTALL_DIR..."
+        git clone https://github.com/openclaw/openclaw.git "$INSTALL_DIR"
+    else
+        echo "Directory $INSTALL_DIR exists. Pulling latest changes..."
+        cd "$INSTALL_DIR" && git pull
+    fi
+    cd "$INSTALL_DIR"
+fi
+
+echo "==> Running docker-setup.sh..."
+# Allow running docker setup as current user if possible, but we are root here.
+# If we want to run as a specific user, we might need adjustments, 
+# but for a dedicated VM, running as root/default user is often acceptable 
+# or expected for initial setup. 
+# docker-setup.sh uses local directory binds.
+
+./docker-setup.sh
+
+echo ""
+echo "==> VM Bootstrap Complete!"
+echo "You can manage the service using 'docker compose' in $INSTALL_DIR"

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -355,7 +355,9 @@ export async function sanitizeSessionHistory(params: {
     : sanitizedToolCalls;
 
   const isOpenAIResponsesApi =
-    params.modelApi === "openai-responses" || params.modelApi === "openai-codex-responses";
+    params.modelApi === "openai-responses" ||
+    params.modelApi === "openai-codex-responses" ||
+    params.modelApi === "azure-openai-responses";
   const hasSnapshot = Boolean(params.provider || params.modelApi || params.modelId);
   const priorSnapshot = hasSnapshot ? readLastModelSnapshot(params.sessionManager) : null;
   const modelChanged = priorSnapshot

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -225,5 +225,23 @@ export function resolveModel(
       modelRegistry,
     };
   }
+  // Apply provider-level baseUrl / headers overrides from user config.
+  // Without this, registry-found models (e.g. anthropic/claude-sonnet-4-20250514)
+  // would always use the built-in baseUrl, ignoring any proxy configured via
+  // cfg.models.providers[provider].baseUrl.
+  const providerOverride = cfg?.models?.providers?.[provider];
+  if (providerOverride) {
+    const overridden = { ...model } as Model<Api>;
+    if (providerOverride.baseUrl) {
+      (overridden as Record<string, unknown>).baseUrl = providerOverride.baseUrl;
+    }
+    if (providerOverride.headers) {
+      (overridden as Record<string, unknown>).headers = {
+        ...((model as Record<string, unknown>).headers as Record<string, string> | undefined),
+        ...providerOverride.headers,
+      };
+    }
+    return { model: normalizeModelCompat(overridden), authStorage, modelRegistry };
+  }
   return { model: normalizeModelCompat(model), authStorage, modelRegistry };
 }

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -17,6 +17,7 @@ type InlineProviderConfig = {
   baseUrl?: string;
   api?: ModelDefinitionConfig["api"];
   models?: ModelDefinitionConfig[];
+  headers?: Record<string, string>;
 };
 
 const OPENAI_CODEX_GPT_53_MODEL_ID = "gpt-5.3-codex";
@@ -127,6 +128,8 @@ export function buildInlineProviderModels(
       provider: trimmed,
       baseUrl: entry?.baseUrl,
       api: model.api ?? entry?.api,
+      headers:
+        entry?.headers || model.headers ? { ...entry?.headers, ...model.headers } : undefined,
     }));
   });
 }
@@ -207,6 +210,7 @@ export function resolveModel(
         api: providerCfg?.api ?? "openai-responses",
         provider,
         baseUrl: providerCfg?.baseUrl,
+        headers: providerCfg?.headers,
         reasoning: false,
         input: ["text"],
         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -34,6 +34,7 @@ const OPENAI_MODEL_APIS = new Set([
   "openai",
   "openai-completions",
   "openai-responses",
+  "azure-openai-responses",
   "openai-codex-responses",
 ]);
 const OPENAI_PROVIDERS = new Set(["openai", "openai-codex"]);

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -1,6 +1,7 @@
 export type ModelApi =
   | "openai-completions"
   | "openai-responses"
+  | "azure-openai-responses"
   | "anthropic-messages"
   | "google-generative-ai"
   | "github-copilot"

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -4,6 +4,7 @@ import { isSafeExecutableValue } from "../infra/exec-safety.js";
 export const ModelApiSchema = z.union([
   z.literal("openai-completions"),
   z.literal("openai-responses"),
+  z.literal("azure-openai-responses"),
   z.literal("anthropic-messages"),
   z.literal("google-generative-ai"),
   z.literal("github-copilot"),


### PR DESCRIPTION
## Summary

- Fix `resolveModel()` ignoring `cfg.models.providers[provider].baseUrl` for models found in pi-ai's built-in `ModelRegistry`
- Users configuring a proxy URL for a known provider (e.g. `anthropic`) had it silently ignored — the hardcoded `baseUrl` (e.g. `https://api.anthropic.com`) was always used
- Now applies `baseUrl` and `headers` overrides from provider config after registry lookup

## Changes

**`src/agents/pi-embedded-runner/model.ts`** (18 lines added)
- After registry lookup succeeds (line 228), check `cfg.models.providers[provider]` for overrides
- Apply `baseUrl` override if present (proxy support)
- Merge `headers` from provider config onto the model

**`src/agents/pi-embedded-runner/model.test.ts`** (107 lines added)
- `applies provider baseUrl override to registry-found models` — verifies configured baseUrl replaces built-in
- `applies provider headers override to registry-found models` — verifies custom headers are applied
- `does not override baseUrl when no provider config exists` — verifies no regression

## Test Results

All 31 model-related tests pass (17 in model.test.ts + 14 in model-compat/model-selection):
```
✓ src/agents/pi-embedded-runner/model.test.ts (17 tests)
✓ src/agents/model-compat.test.ts (3 tests)
✓ src/agents/model-selection.test.ts (11 tests)
Test Files: 3 passed (3)
Tests: 31 passed (31)
```

## Checklist

- [x] Tests added covering the fix
- [x] All existing tests pass
- [x] No new type errors introduced (25 pre-existing ui/ rootDir errors unchanged)
- [x] Linter passes (biome: 0 warnings, 0 errors)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes three categories of changes:

**1. Provider baseUrl/headers override for registry models (core fix):** Fixes `resolveModel()` to apply `cfg.models.providers[provider].baseUrl` and `headers` overrides to models found in pi-ai's built-in `ModelRegistry`. Previously, users configuring a proxy URL for a known provider (e.g. Anthropic) had it silently ignored. The fix adds a post-registry-lookup override step that shallow-copies the model and applies the configured overrides. Tests are thorough and cover the key scenarios.

**2. Azure OpenAI support:** Adds `azure-openai-responses` as a new `ModelApi` type in the type system, Zod schema, transcript policy, and session history sanitization. The actual adapter implementation is delegated to the pi-ai library. New documentation is provided but has an issue (see comment).

**3. Kubernetes deployment manifests and scripts:** Adds k8s manifests (`deployment.yaml`, `service.yaml`, `pvc.yaml`, `ingress.yaml`, `secret.yaml`), a deploy script, and a VM bootstrap script for self-hosted deployment.

- The core model override fix is well-implemented with proper test coverage
- The Azure OpenAI documentation references environment variables (`AZURE_OPENAI_RESOURCE_NAME`, etc.) that are not handled by OpenClaw source code, and the "environment-only" config example omits the required `baseUrl` field which will cause Zod validation errors

<h3>Confidence Score: 3/5</h3>

- The core model override fix is correct and well-tested, but the Azure OpenAI documentation has a config validation issue that would affect users.
- Score of 3 reflects that while the core fix (provider baseUrl/headers override) is solid with good test coverage, the Azure OpenAI documentation contains a config example that will fail Zod validation (missing required `baseUrl`) and references environment variables not handled by the codebase. The k8s manifests and scripts are standard and low-risk. No runtime issues in the TypeScript code.
- Pay close attention to `docs/providers/azure-openai.md` — the environment-only config example is missing the required `baseUrl` field and references env vars not implemented in the codebase.

<sub>Last reviewed commit: def5506</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->