### PR TITLE
fix(memory-lancedb): classify nechci statements as preference

### DIFF
--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -187,6 +187,7 @@ describe("memory plugin e2e", () => {
     const { detectCategory } = await import("./index.js");
 
     expect(detectCategory("I prefer dark mode")).toBe("preference");
+    expect(detectCategory("Nechci používat světlý režim")).toBe("preference");
     expect(detectCategory("We decided to use React")).toBe("decision");
     expect(detectCategory("My email is test@example.com")).toBe("entity");
     expect(detectCategory("The server is running on port 3000")).toBe("fact");

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -264,7 +264,7 @@ export function shouldCapture(text: string, options?: { maxChars?: number }): bo
 
 export function detectCategory(text: string): MemoryCategory {
   const lower = text.toLowerCase();
-  if (/prefer|radši|like|love|hate|want/i.test(lower)) {
+  if (/prefer|radši|nechci|like|love|hate|want/i.test(lower)) {
     return "preference";
   }
   if (/rozhodli|decided|will use|budeme/i.test(lower)) {


### PR DESCRIPTION
## Summary
- fix(memory-lancedb): classify `nechci` statements as `preference`.
- Split from our `v2026.2.13` patch train as a single-purpose consistency fix.

## Why
- `shouldCapture` already treats Czech `nechci` phrases as memory-worthy, but `detectCategory` did not classify them as `preference`.
- This mismatch can reduce retrieval quality by assigning `other` instead of `preference`.

## Scope
- Branch: `fix/memory-lancedb-classify-nechci-preference-en`
- Files changed: 2
- Key files:
  - `extensions/memory-lancedb/index.ts`
  - `extensions/memory-lancedb/index.test.ts`

## Test Plan
- Executed locally:
  - `./node_modules/.bin/vitest run extensions/memory-lancedb/index.test.ts`
- Result:
  - 1 test file passed, 11 tests passed, 1 skipped

## Risk & Rollback
- Risk: low; change is limited to category regex and one regression assertion.
- Rollback: revert this PR commit cleanly.

## Co-authorship
- Co-authored by @ciberponk and Codex (GPT-5).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds the Czech keyword `nechci` ("I don't want") to the `detectCategory` preference regex in the memory-lancedb plugin. This aligns `detectCategory` with `shouldCapture`, which already recognized `nechci` as memory-worthy. Without this fix, Czech "nechci" statements would bypass the preference category and incorrectly classify as "fact" (due to the broad `/je/i` pattern matching substrings like "režim").

- Added `nechci` to the preference regex in `detectCategory` (`extensions/memory-lancedb/index.ts`)
- Added a regression test asserting `detectCategory("Nechci používat světlý režim")` returns `"preference"` (`extensions/memory-lancedb/index.test.ts`)
- No issues found; the change is minimal, well-scoped, and correctly addresses the mismatch

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk — it adds a single keyword to an existing regex and a corresponding test assertion.
- The change is a one-word addition to a regex pattern, aligning detectCategory with the already-existing shouldCapture behavior. The test covers the new case. No logic changes, no new dependencies, no risk of regressions.
- No files require special attention.

<sub>Last reviewed commit: e15b801</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->