### PR TITLE
fix(security): OC-100 add rate limiting to pairing code verification

### DIFF
--- a/src/pairing/pairing-store.ts
+++ b/src/pairing/pairing-store.ts
@@ -13,6 +13,57 @@ const PAIRING_CODE_LENGTH = 8;
 const PAIRING_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
 const PAIRING_PENDING_TTL_MS = 60 * 60 * 1000;
 const PAIRING_PENDING_MAX = 3;
+
+// Rate limiting for pairing code attempts (Aether AI Agent — OC-100 remediation)
+const PAIRING_MAX_FAILED_ATTEMPTS = 10;
+const PAIRING_RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000; // 15 minutes
+
+type RateLimitEntry = {
+  failedAttempts: number;
+  firstFailureAt: number;
+};
+
+// In-memory rate limit tracker keyed by channel
+const pairingRateLimitMap = new Map<string, RateLimitEntry>();
+
+/**
+ * Check if a channel is currently rate-limited for pairing code attempts.
+ * Returns true if locked out.
+ */
+function isPairingRateLimited(channelKey: string, nowMs: number): boolean {
+  const entry = pairingRateLimitMap.get(channelKey);
+  if (!entry) {
+    return false;
+  }
+
+  // Window expired — reset and allow
+  if (nowMs - entry.firstFailureAt > PAIRING_RATE_LIMIT_WINDOW_MS) {
+    pairingRateLimitMap.delete(channelKey);
+    return false;
+  }
+
+  return entry.failedAttempts >= PAIRING_MAX_FAILED_ATTEMPTS;
+}
+
+/** Record a failed pairing code attempt for rate limiting. */
+function recordFailedPairingAttempt(channelKey: string, nowMs: number): void {
+  const entry = pairingRateLimitMap.get(channelKey);
+  if (!entry || nowMs - entry.firstFailureAt > PAIRING_RATE_LIMIT_WINDOW_MS) {
+    pairingRateLimitMap.set(channelKey, { failedAttempts: 1, firstFailureAt: nowMs });
+    return;
+  }
+  entry.failedAttempts += 1;
+}
+
+/** Reset rate limit tracking on successful pairing. */
+function resetPairingRateLimit(channelKey: string): void {
+  pairingRateLimitMap.delete(channelKey);
+}
+
+/** Clear all rate limit state (exposed for testing). */
+export function resetAllPairingRateLimits(): void {
+  pairingRateLimitMap.clear();
+}
 const PAIRING_STORE_LOCK_OPTIONS = {
   retries: {
     retries: 10,
@@ -438,6 +489,14 @@ export async function approveChannelPairingCode(params: {
     return null;
   }
 
+  const channelKey = safeChannelKey(params.channel);
+  const nowMs = Date.now();
+
+  // Rate limit check — block brute-force pairing code attempts (OC-100)
+  if (isPairingRateLimited(channelKey, nowMs)) {
+    throw new Error("Too many failed pairing attempts. Try again later.");
+  }
+
   const filePath = resolvePairingPath(params.channel, env);
   return await withFileLock(
     filePath,
@@ -448,10 +507,10 @@ export async function approveChannelPairingCode(params: {
         requests: [],
       });
       const reqs = Array.isArray(value.requests) ? value.requests : [];
-      const nowMs = Date.now();
       const { requests: pruned, removed } = pruneExpiredRequests(reqs, nowMs);
       const idx = pruned.findIndex((r) => String(r.code ?? "").toUpperCase() === code);
       if (idx < 0) {
+        recordFailedPairingAttempt(channelKey, nowMs);
         if (removed) {
           await writeJsonFile(filePath, {
             version: 1,
@@ -464,6 +523,7 @@ export async function approveChannelPairingCode(params: {
       if (!entry) {
         return null;
       }
+      resetPairingRateLimit(channelKey);
       pruned.splice(idx, 1);
       await writeJsonFile(filePath, {
         version: 1,


### PR DESCRIPTION
## Summary
- Add in-memory rate limiter to `approveChannelPairingCode` to block brute-force pairing code attempts
- Lock out channel after 10 failed attempts within a 15-minute sliding window
- Reset rate limit counter on successful pairing approval
- Throw descriptive error (`"Too many failed pairing attempts. Try again later."`) when rate-limited
- Add 4 comprehensive test cases for rate limiting behavior

## Security Impact
**OC-100 Medium (CWE-307, Improper Restriction of Excessive Authentication Attempts)** — Attack vectors:
1. **Brute-force pairing codes**: `approveChannelPairingCode` accepted unlimited attempts with no failed-attempt tracking, no lockout, and no rate limiting. An attacker could automate thousands of code guesses per second against the 8-character pairing code space (31^8 ≈ 852B combinations), significantly reducing the effective security of the pairing mechanism.
2. **Automated enumeration**: Without rate limiting, automated scripts could systematically try every possible code within the 1-hour TTL window.

## Changes
| File | Change |
|------|--------|
| `src/pairing/pairing-store.ts` | Add rate limit constants (`PAIRING_MAX_FAILED_ATTEMPTS=10`, `PAIRING_RATE_LIMIT_WINDOW_MS=15min`), in-memory `Map<string, RateLimitEntry>` tracker, `isPairingRateLimited()`, `recordFailedPairingAttempt()`, `resetPairingRateLimit()` helpers, and rate limit check in `approveChannelPairingCode` |
| `src/pairing/pairing-store.test.ts` | Add `"pairing code rate limiting (OC-100)"` test suite with 4 cases: below-threshold allows, lockout after 10 failures, reset on success, per-channel isolation |

## Test plan
- [x] TypeScript compiles with zero errors (`tsc --noEmit`)
- [x] All 8 tests pass (4 existing + 4 new rate limiting tests)
- [x] Linter passes with 0 warnings and 0 errors (`oxlint --type-aware`)
- [x] Below-threshold attempts (9 failures) return `null` without throwing
- [x] 11th failed attempt throws `"Too many failed pairing attempts"`
- [x] Successful pairing resets the counter, allowing new attempts
- [x] Rate limits are isolated per channel (discord lockout doesn't affect signal)

---
*Created by [Aether AI Agent](https://tryaether.ai) — AI security research and remediation agent.*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added in-memory rate limiting to pairing code verification to prevent brute-force attacks on 8-character pairing codes. The implementation uses a 15-minute sliding window with a 10-attempt limit per channel. The race condition identified in previous review has been fixed by moving the rate limit check inside the file lock (commit `05dd15ba`). Tests thoroughly cover the rate limiting behavior including threshold enforcement, reset on success, and per-channel isolation.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor operational consideration about in-memory state
- The implementation correctly addresses CWE-307 with proper rate limiting inside the file lock to prevent race conditions. Tests are comprehensive. The only consideration is that rate limit state is lost on restart (by design for operational flexibility), which is acceptable for this use case.
- No files require special attention

<sub>Last reviewed commit: 05dd15b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->