### PR TITLE
feat(hooks): emit compaction lifecycle hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/hook policy: add `plugins.entries.<id>.hooks.allowPromptInjection`, validate unknown typed hook names at runtime, and preserve legacy `before_agent_start` model/provider overrides while stripping prompt-mutating fields when prompt injection is disabled. (#36567) thanks @gumadeiras.
 - Tools/Diffs guidance: restore a short system-prompt hint for enabled diffs while keeping the detailed instructions in the companion skill, so diffs usage guidance stays out of user-prompt space. (#36904) thanks @gumadeiras.
 - Telegram/ACP topic bindings: accept Telegram Mac Unicode dash option prefixes in `/acp spawn`, support Telegram topic thread binding (`--thread here|auto`), route bound-topic follow-ups to ACP sessions, add actionable Telegram approval buttons with prefixed approval-id resolution, and pin successful bind confirmations in-topic. (#36683) Thanks @huntharo.
+- Hooks/Compaction lifecycle: emit `session:compact:before` and `session:compact:after` internal events plus plugin compaction callbacks with session/count metadata, so automations can react to compaction runs consistently. (#16788) thanks @vincentkoc.
 
 ### Breaking
 

--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -250,6 +250,7 @@ Triggered when agent commands are issued:
 
 Internal hook payloads emit these as `type: "session"` with `action: "compact:before"` / `action: "compact:after"`; listeners subscribe with the combined keys above.
 Specific handler registration uses the literal key format `${type}:${action}`. For these events, register `session:compact:before` and `session:compact:after`.
+Specific handler registration uses the literal key format `${type}:${action}`. For these events, register `session:compact:before` and `session:compact:after`.
 
 ### Agent Events
 

--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -248,6 +248,8 @@ Triggered when agent commands are issued:
 - **`session:compact:before`**: Right before compaction summarizes history
 - **`session:compact:after`**: After compaction completes with summary metadata
 
+Internal hook payloads emit these as `type: "session"` with `action: "compact:before"` / `action: "compact:after"`; listeners subscribe with the combined keys above.
+
 ### Agent Events
 
 - **`agent:bootstrap`**: Before workspace bootstrap files are injected (hooks may mutate `context.bootstrapFiles`)

--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -250,6 +250,7 @@ Triggered when agent commands are issued:
 
 Internal hook payloads emit these as `type: "session"` with `action: "compact:before"` / `action: "compact:after"`; listeners subscribe with the combined keys above.
 Specific handler registration uses the literal key format `${type}:${action}`. For these events, register `session:compact:before` and `session:compact:after`.
+
 ### Agent Events
 
 - **`agent:bootstrap`**: Before workspace bootstrap files are injected (hooks may mutate `context.bootstrapFiles`)

--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -250,7 +250,6 @@ Triggered when agent commands are issued:
 
 Internal hook payloads emit these as `type: "session"` with `action: "compact:before"` / `action: "compact:after"`; listeners subscribe with the combined keys above.
 Specific handler registration uses the literal key format `${type}:${action}`. For these events, register `session:compact:before` and `session:compact:after`.
-
 ### Agent Events
 
 - **`agent:bootstrap`**: Before workspace bootstrap files are injected (hooks may mutate `context.bootstrapFiles`)

--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -243,6 +243,11 @@ Triggered when agent commands are issued:
 - **`command:reset`**: When `/reset` command is issued
 - **`command:stop`**: When `/stop` command is issued
 
+### Session Events
+
+- **`session:compact:before`**: Right before compaction summarizes history
+- **`session:compact:after`**: After compaction completes with summary metadata
+
 ### Agent Events
 
 - **`agent:bootstrap`**: Before workspace bootstrap files are injected (hooks may mutate `context.bootstrapFiles`)
@@ -350,6 +355,13 @@ export default handler;
 These hooks are not event-stream listeners; they let plugins synchronously adjust tool results before OpenClaw persists them.
 
 - **`tool_result_persist`**: transform tool results before they are written to the session transcript. Must be synchronous; return the updated tool result payload or `undefined` to keep it as-is. See [Agent Loop](/concepts/agent-loop).
+
+### Plugin Hook Events
+
+Compaction lifecycle hooks exposed through the plugin hook runner:
+
+- **`before_compaction`**: Runs before compaction with count/token metadata
+- **`after_compaction`**: Runs after compaction with compaction summary metadata
 
 ### Future Events
 

--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -249,6 +249,7 @@ Triggered when agent commands are issued:
 - **`session:compact:after`**: After compaction completes with summary metadata
 
 Internal hook payloads emit these as `type: "session"` with `action: "compact:before"` / `action: "compact:after"`; listeners subscribe with the combined keys above.
+Specific handler registration uses the literal key format `${type}:${action}`. For these events, register `session:compact:before` and `session:compact:after`.
 
 ### Agent Events
 

--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -250,7 +250,6 @@ Triggered when agent commands are issued:
 
 Internal hook payloads emit these as `type: "session"` with `action: "compact:before"` / `action: "compact:after"`; listeners subscribe with the combined keys above.
 Specific handler registration uses the literal key format `${type}:${action}`. For these events, register `session:compact:before` and `session:compact:after`.
-Specific handler registration uses the literal key format `${type}:${action}`. For these events, register `session:compact:before` and `session:compact:after`.
 
 ### Agent Events
 

--- a/src/agents/pi-embedded-runner/compact.hooks.test.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.test.ts
@@ -254,8 +254,6 @@ describe("compactEmbeddedPiSessionDirect hooks", () => {
       expect.objectContaining({
         messageCount: 3,
         tokenCount: 30,
-        messageCountOriginal: 3,
-        tokenCountOriginal: 30,
       }),
       expect.objectContaining({ sessionKey: "agent:main:session-1" }),
     );

--- a/src/agents/pi-embedded-runner/compact.hooks.test.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.test.ts
@@ -250,16 +250,22 @@ describe("compactEmbeddedPiSessionDirect hooks", () => {
       type: "session",
       action: "compact:before",
     });
-    expect(sessionHook("compact:before")?.context).toMatchObject({
+    const beforeContext = sessionHook("compact:before")?.context;
+    const afterContext = sessionHook("compact:after")?.context;
+
+    expect(beforeContext).toMatchObject({
       messageCount: 2,
       tokenCount: 20,
       messageCountOriginal: 3,
       tokenCountOriginal: 30,
     });
-    expect(sessionHook("compact:after")?.context).toMatchObject({
+    expect(afterContext).toMatchObject({
       messageCount: 1,
       compactedCount: 2,
     });
+    expect(afterContext?.compactedCount).toBe(
+      (beforeContext?.messageCountOriginal as number) - (afterContext?.messageCount as number),
+    );
 
     expect(hookRunner.runBeforeCompaction).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/agents/pi-embedded-runner/compact.hooks.test.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.test.ts
@@ -258,7 +258,7 @@ describe("compactEmbeddedPiSessionDirect hooks", () => {
     });
     expect(sessionHook("compact:after")?.context).toMatchObject({
       messageCount: 1,
-      compactedCount: 1,
+      compactedCount: 2,
     });
 
     expect(hookRunner.runBeforeCompaction).toHaveBeenCalledWith(
@@ -272,7 +272,7 @@ describe("compactEmbeddedPiSessionDirect hooks", () => {
       {
         messageCount: 1,
         tokenCount: 10,
-        compactedCount: 1,
+        compactedCount: 2,
       },
       expect.objectContaining({ sessionKey: "agent:main:session-1" }),
     );

--- a/src/agents/pi-embedded-runner/compact.hooks.test.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.test.ts
@@ -1,0 +1,271 @@
+import { describe, expect, it, vi } from "vitest";
+
+const { hookRunner, triggerInternalHook } = vi.hoisted(() => ({
+  hookRunner: {
+    hasHooks: vi.fn(),
+    runBeforeCompaction: vi.fn(),
+    runAfterCompaction: vi.fn(),
+  },
+  triggerInternalHook: vi.fn(),
+}));
+
+vi.mock("../../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: () => hookRunner,
+}));
+
+vi.mock("../../hooks/internal-hooks.js", async () => {
+  const actual = await vi.importActual<typeof import("../../hooks/internal-hooks.js")>(
+    "../../hooks/internal-hooks.js",
+  );
+  return {
+    ...actual,
+    triggerInternalHook,
+  };
+});
+
+vi.mock("@mariozechner/pi-coding-agent", () => {
+  return {
+    createAgentSession: vi.fn(async () => {
+      const session = {
+        sessionId: "session-1",
+        messages: [
+          { role: "user", content: "hello", timestamp: 1 },
+          { role: "assistant", content: [{ type: "text", text: "hi" }], timestamp: 2 },
+          {
+            role: "toolResult",
+            toolCallId: "t1",
+            toolName: "exec",
+            content: [{ type: "text", text: "output" }],
+            isError: false,
+            timestamp: 3,
+          },
+        ],
+        agent: { replaceMessages: vi.fn(), streamFn: vi.fn() },
+        compact: vi.fn(async () => {
+          // simulate compaction trimming to a single message
+          session.messages.splice(1);
+          return {
+            summary: "summary",
+            firstKeptEntryId: "entry-1",
+            tokensBefore: 120,
+            details: { ok: true },
+          };
+        }),
+        dispose: vi.fn(),
+      };
+      return { session };
+    }),
+    SessionManager: {
+      open: vi.fn(() => ({})),
+    },
+    SettingsManager: {
+      create: vi.fn(() => ({})),
+    },
+    estimateTokens: vi.fn(() => 10),
+  };
+});
+
+vi.mock("../session-tool-result-guard-wrapper.js", () => ({
+  guardSessionManager: vi.fn(() => ({
+    flushPendingToolResults: vi.fn(),
+  })),
+}));
+
+vi.mock("../pi-settings.js", () => ({
+  ensurePiCompactionReserveTokens: vi.fn(),
+  resolveCompactionReserveTokensFloor: vi.fn(() => 0),
+}));
+
+vi.mock("../models-config.js", () => ({
+  ensureOpenClawModelsJson: vi.fn(async () => {}),
+}));
+
+vi.mock("../model-auth.js", () => ({
+  getApiKeyForModel: vi.fn(async () => ({ apiKey: "test", mode: "env" })),
+  resolveModelAuthMode: vi.fn(() => "env"),
+}));
+
+vi.mock("../sandbox.js", () => ({
+  resolveSandboxContext: vi.fn(async () => null),
+}));
+
+vi.mock("../session-file-repair.js", () => ({
+  repairSessionFileIfNeeded: vi.fn(async () => {}),
+}));
+
+vi.mock("../session-write-lock.js", () => ({
+  acquireSessionWriteLock: vi.fn(async () => ({ release: vi.fn(async () => {}) })),
+}));
+
+vi.mock("../bootstrap-files.js", () => ({
+  makeBootstrapWarn: vi.fn(() => () => {}),
+  resolveBootstrapContextForRun: vi.fn(async () => ({ contextFiles: [] })),
+}));
+
+vi.mock("../docs-path.js", () => ({
+  resolveOpenClawDocsPath: vi.fn(async () => undefined),
+}));
+
+vi.mock("../channel-tools.js", () => ({
+  listChannelSupportedActions: vi.fn(() => undefined),
+  resolveChannelMessageToolHints: vi.fn(() => undefined),
+}));
+
+vi.mock("../pi-tools.js", () => ({
+  createOpenClawCodingTools: vi.fn(() => []),
+}));
+
+vi.mock("./google.js", () => ({
+  logToolSchemasForGoogle: vi.fn(),
+  sanitizeSessionHistory: vi.fn(async (params: { messages: unknown[] }) => params.messages),
+  sanitizeToolsForGoogle: vi.fn(({ tools }: { tools: unknown[] }) => tools),
+}));
+
+vi.mock("./tool-split.js", () => ({
+  splitSdkTools: vi.fn(() => ({ builtInTools: [], customTools: [] })),
+}));
+
+vi.mock("../transcript-policy.js", () => ({
+  resolveTranscriptPolicy: vi.fn(() => ({
+    allowSyntheticToolResults: false,
+    validateGeminiTurns: false,
+    validateAnthropicTurns: false,
+  })),
+}));
+
+vi.mock("./extensions.js", () => ({
+  buildEmbeddedExtensionPaths: vi.fn(),
+}));
+
+vi.mock("./history.js", () => ({
+  getDmHistoryLimitFromSessionKey: vi.fn(() => undefined),
+  limitHistoryTurns: vi.fn((msgs: unknown[]) => msgs),
+}));
+
+vi.mock("../skills.js", () => ({
+  applySkillEnvOverrides: vi.fn(() => () => {}),
+  applySkillEnvOverridesFromSnapshot: vi.fn(() => () => {}),
+  loadWorkspaceSkillEntries: vi.fn(() => []),
+  resolveSkillsPromptForRun: vi.fn(() => undefined),
+}));
+
+vi.mock("../agent-paths.js", () => ({
+  resolveOpenClawAgentDir: vi.fn(() => "/tmp"),
+}));
+
+vi.mock("../agent-scope.js", () => ({
+  resolveSessionAgentIds: vi.fn(() => ({ defaultAgentId: "main", sessionAgentId: "main" })),
+}));
+
+vi.mock("../date-time.js", () => ({
+  formatUserTime: vi.fn(() => ""),
+  resolveUserTimeFormat: vi.fn(() => ""),
+  resolveUserTimezone: vi.fn(() => ""),
+}));
+
+vi.mock("../defaults.js", () => ({
+  DEFAULT_MODEL: "fake-model",
+  DEFAULT_PROVIDER: "openai",
+}));
+
+vi.mock("../utils.js", () => ({
+  resolveUserPath: vi.fn((p: string) => p),
+}));
+
+vi.mock("../../infra/machine-name.js", () => ({
+  getMachineDisplayName: vi.fn(async () => "machine"),
+}));
+
+vi.mock("../../config/channel-capabilities.js", () => ({
+  resolveChannelCapabilities: vi.fn(() => undefined),
+}));
+
+vi.mock("../../utils/message-channel.js", () => ({
+  normalizeMessageChannel: vi.fn(() => undefined),
+}));
+
+vi.mock("../pi-embedded-helpers.js", () => ({
+  ensureSessionHeader: vi.fn(async () => {}),
+  validateAnthropicTurns: vi.fn((m: unknown[]) => m),
+  validateGeminiTurns: vi.fn((m: unknown[]) => m),
+}));
+
+vi.mock("./sandbox-info.js", () => ({
+  buildEmbeddedSandboxInfo: vi.fn(() => undefined),
+}));
+
+vi.mock("./model.js", () => ({
+  buildModelAliasLines: vi.fn(() => []),
+  resolveModel: vi.fn(() => ({
+    model: { provider: "openai", api: "responses", id: "fake", input: [] },
+    error: null,
+    authStorage: { setRuntimeApiKey: vi.fn() },
+    modelRegistry: {},
+  })),
+}));
+
+vi.mock("./session-manager-cache.js", () => ({
+  prewarmSessionFile: vi.fn(async () => {}),
+  trackSessionManagerAccess: vi.fn(),
+}));
+
+vi.mock("./system-prompt.js", () => ({
+  applySystemPromptOverrideToSession: vi.fn(),
+  buildEmbeddedSystemPrompt: vi.fn(() => ""),
+  createSystemPromptOverride: vi.fn(() => () => ""),
+}));
+
+vi.mock("./utils.js", () => ({
+  describeUnknownError: vi.fn((err: unknown) => String(err)),
+  mapThinkingLevel: vi.fn(() => "off"),
+  resolveExecToolDefaults: vi.fn(() => undefined),
+}));
+
+import { compactEmbeddedPiSessionDirect } from "./compact.js";
+
+const sessionHook = (action: string) =>
+  triggerInternalHook.mock.calls.find(
+    (call) => call[0]?.type === "session" && call[0]?.action === action,
+  )?.[0];
+
+describe("compactEmbeddedPiSessionDirect hooks", () => {
+  it("emits internal + plugin compaction hooks with counts", async () => {
+    hookRunner.hasHooks.mockReturnValue(true);
+
+    const result = await compactEmbeddedPiSessionDirect({
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      customInstructions: "focus on decisions",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(sessionHook("compact:before")).toMatchObject({
+      type: "session",
+      action: "compact:before",
+    });
+    expect(sessionHook("compact:after")?.context).toMatchObject({
+      messageCount: 1,
+      compactedCount: 2,
+    });
+
+    expect(hookRunner.runBeforeCompaction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageCount: 3,
+        tokenCount: 30,
+        messageCountOriginal: 3,
+        tokenCountOriginal: 30,
+      }),
+      expect.objectContaining({ sessionKey: "agent:main:session-1" }),
+    );
+    expect(hookRunner.runAfterCompaction).toHaveBeenCalledWith(
+      {
+        messageCount: 1,
+        tokenCount: 10,
+        compactedCount: 2,
+      },
+      expect.objectContaining({ sessionKey: "agent:main:session-1" }),
+    );
+  });
+});

--- a/src/agents/pi-embedded-runner/compact.hooks.test.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.test.ts
@@ -325,4 +325,26 @@ describe("compactEmbeddedPiSessionDirect hooks", () => {
       expect.objectContaining({ sessionKey: "session-1" }),
     );
   });
+
+  it("applies validated transcript before hooks even when it becomes empty", async () => {
+    hookRunner.hasHooks.mockReturnValue(true);
+    sanitizeSessionHistoryMock.mockResolvedValue([]);
+
+    const result = await compactEmbeddedPiSessionDirect({
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      customInstructions: "focus on decisions",
+    });
+
+    expect(result.ok).toBe(true);
+    const beforeContext = sessionHook("compact:before")?.context;
+    expect(beforeContext).toMatchObject({
+      messageCountOriginal: 0,
+      tokenCountOriginal: 0,
+      messageCount: 0,
+      tokenCount: 0,
+    });
+  });
 });

--- a/src/agents/pi-embedded-runner/compact.hooks.test.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.test.ts
@@ -101,6 +101,7 @@ vi.mock("../session-file-repair.js", () => ({
 
 vi.mock("../session-write-lock.js", () => ({
   acquireSessionWriteLock: vi.fn(async () => ({ release: vi.fn(async () => {}) })),
+  resolveSessionLockMaxHoldFromTimeout: vi.fn(() => 0),
 }));
 
 vi.mock("../bootstrap-files.js", () => ({
@@ -140,7 +141,7 @@ vi.mock("../transcript-policy.js", () => ({
 }));
 
 vi.mock("./extensions.js", () => ({
-  buildEmbeddedExtensionPaths: vi.fn(),
+  buildEmbeddedExtensionFactories: vi.fn(() => []),
 }));
 
 vi.mock("./history.js", () => ({
@@ -194,6 +195,12 @@ vi.mock("../pi-embedded-helpers.js", () => ({
   ensureSessionHeader: vi.fn(async () => {}),
   validateAnthropicTurns: vi.fn((m: unknown[]) => m),
   validateGeminiTurns: vi.fn((m: unknown[]) => m),
+}));
+
+vi.mock("../pi-project-settings.js", () => ({
+  createPreparedEmbeddedPiSettingsManager: vi.fn(() => ({
+    getGlobalSettings: vi.fn(() => ({})),
+  })),
 }));
 
 vi.mock("./sandbox-info.js", () => ({

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -12,7 +12,6 @@ import type { ReasoningLevel, ThinkLevel } from "../../auto-reply/thinking.js";
 import { resolveChannelCapabilities } from "../../config/channel-capabilities.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
-import type { OpenClawConfig } from "../../config/config.js";
 import { getMachineDisplayName } from "../../infra/machine-name.js";
 import { generateSecureToken } from "../../infra/secure-random.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -11,6 +11,8 @@ import { resolveHeartbeatPrompt } from "../../auto-reply/heartbeat.js";
 import type { ReasoningLevel, ThinkLevel } from "../../auto-reply/thinking.js";
 import { resolveChannelCapabilities } from "../../config/channel-capabilities.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
+import type { OpenClawConfig } from "../../config/config.js";
 import { getMachineDisplayName } from "../../infra/machine-name.js";
 import { generateSecureToken } from "../../infra/secure-random.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
@@ -609,10 +611,12 @@ export async function compactEmbeddedPiSessionDirect(
         const validated = transcriptPolicy.validateAnthropicTurns
           ? validateAnthropicTurns(validatedGemini)
           : validatedGemini;
-        // Capture full message history BEFORE limiting — plugins need the complete conversation
-        const preCompactionMessages = [...session.messages];
+        // Keep compaction hooks aligned with the validated transcript that actually enters
+        // truncation/repair and compaction.
+        session.agent.replaceMessages(validated);
+        const originalMessages = session.messages.slice();
         const truncated = limitHistoryTurns(
-          validated,
+          session.messages,
           getDmHistoryLimitFromSessionKey(params.sessionKey, params.config),
         );
         // Re-run tool_use/tool_result pairing repair after truncation, since
@@ -624,32 +628,63 @@ export async function compactEmbeddedPiSessionDirect(
         if (limited.length > 0) {
           session.agent.replaceMessages(limited);
         }
-        // Run before_compaction hooks (fire-and-forget).
-        // The session JSONL already contains all messages on disk, so plugins
-        // can read sessionFile asynchronously and process in parallel with
-        // the compaction LLM call — no need to block or wait for after_compaction.
+        const missingSessionKey = !params.sessionKey || !params.sessionKey.trim();
+        const hookSessionKey = params.sessionKey?.trim() || `compact:${params.sessionId}`;
         const hookRunner = getGlobalHookRunner();
-        const hookCtx = {
-          agentId: params.sessionKey?.split(":")[0] ?? "main",
-          sessionKey: params.sessionKey,
-          sessionId: params.sessionId,
-          workspaceDir: params.workspaceDir,
-          messageProvider: params.messageChannel ?? params.messageProvider,
-        };
+        const messageCountOriginal = originalMessages.length;
+        const messageCountBefore = session.messages.length;
+        let tokenCountOriginal: number | undefined;
+        let tokenCountBefore: number | undefined;
+        try {
+          tokenCountOriginal = 0;
+          for (const message of originalMessages) {
+            tokenCountOriginal += estimateTokens(message);
+          }
+        } catch {
+          tokenCountOriginal = undefined;
+        }
+        try {
+          tokenCountBefore = 0;
+          for (const message of session.messages) {
+            tokenCountBefore += estimateTokens(message);
+          }
+        } catch {
+          tokenCountBefore = undefined;
+        }
+        // TODO(#7175): Consider exposing full message snapshots or pre-compaction injection
+        // hooks; current events only report counts/metadata.
+        try {
+          const hookEvent = createInternalHookEvent("session", "compact:before", hookSessionKey, {
+            sessionId: params.sessionId,
+            missingSessionKey,
+            messageCount: messageCountBefore,
+            tokenCount: tokenCountBefore,
+            messageCountOriginal,
+            tokenCountOriginal,
+          });
+          await triggerInternalHook(hookEvent);
+        } catch (err) {
+          log.warn(`session:compact:before hook failed: ${String(err)}`);
+        }
         if (hookRunner?.hasHooks("before_compaction")) {
-          hookRunner
-            .runBeforeCompaction(
+          try {
+            await hookRunner.runBeforeCompaction(
               {
-                messageCount: preCompactionMessages.length,
-                compactingCount: limited.length,
-                messages: preCompactionMessages,
-                sessionFile: params.sessionFile,
+                messageCount: messageCountBefore,
+                tokenCount: tokenCountBefore,
+                messageCountOriginal,
+                tokenCountOriginal,
               },
-              hookCtx,
-            )
-            .catch((hookErr: unknown) => {
-              log.warn(`before_compaction hook failed: ${String(hookErr)}`);
-            });
+              {
+                agentId: sessionAgentId,
+                sessionKey: params.sessionKey,
+                workspaceDir: params.workspaceDir,
+                messageProvider: params.messageProvider,
+              },
+            );
+          } catch (err) {
+              log.warn(`before_compaction hook failed: ${String(err)}`);
+            }
         }
 
         const diagEnabled = log.isEnabled("debug");
@@ -697,25 +732,8 @@ export async function compactEmbeddedPiSessionDirect(
           // If estimation fails, leave tokensAfter undefined
           tokensAfter = undefined;
         }
-        // Run after_compaction hooks (fire-and-forget).
-        // Also includes sessionFile for plugins that only need to act after
-        // compaction completes (e.g. analytics, cleanup).
-        if (hookRunner?.hasHooks("after_compaction")) {
-          hookRunner
-            .runAfterCompaction(
-              {
-                messageCount: session.messages.length,
-                tokenCount: tokensAfter,
-                compactedCount: limited.length - session.messages.length,
-                sessionFile: params.sessionFile,
-              },
-              hookCtx,
-            )
-            .catch((hookErr) => {
-              log.warn(`after_compaction hook failed: ${hookErr}`);
-            });
-        }
-
+        const messageCountAfter = session.messages.length;
+        const compactedCount = Math.max(0, messageCountBefore - messageCountAfter);
         const postMetrics = diagEnabled ? summarizeCompactionMessages(session.messages) : undefined;
         if (diagEnabled && preMetrics && postMetrics) {
           log.debug(
@@ -730,6 +748,43 @@ export async function compactEmbeddedPiSessionDirect(
               `delta.toolResultChars=${postMetrics.toolResultChars - preMetrics.toolResultChars} ` +
               `delta.estTokens=${typeof preMetrics.estTokens === "number" && typeof postMetrics.estTokens === "number" ? postMetrics.estTokens - preMetrics.estTokens : "unknown"}`,
           );
+        }
+        // TODO(#9611): Consider exposing compaction summaries or post-compaction injection;
+        // current events only report summary metadata.
+        try {
+          const hookEvent = createInternalHookEvent("session", "compact:after", hookSessionKey, {
+            sessionId: params.sessionId,
+            missingSessionKey,
+            messageCount: messageCountAfter,
+            tokenCount: tokensAfter,
+            compactedCount,
+            summaryLength: typeof result.summary === "string" ? result.summary.length : undefined,
+            tokensBefore: result.tokensBefore,
+            tokensAfter,
+            firstKeptEntryId: result.firstKeptEntryId,
+          });
+          await triggerInternalHook(hookEvent);
+        } catch (err) {
+          log.warn(`session:compact:after hook failed: ${String(err)}`);
+        }
+        if (hookRunner?.hasHooks("after_compaction")) {
+          try {
+            await hookRunner.runAfterCompaction(
+              {
+                messageCount: messageCountAfter,
+                tokenCount: tokensAfter,
+                compactedCount,
+              },
+              {
+                agentId: sessionAgentId,
+                sessionKey: params.sessionKey,
+                workspaceDir: params.workspaceDir,
+                messageProvider: params.messageProvider,
+              },
+            );
+          } catch (err) {
+            log.warn(`after_compaction hook failed: ${String(err)}`);
+          }
         }
         return {
           ok: true,

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -675,7 +675,7 @@ export async function compactEmbeddedPiSessionDirect(
               },
               {
                 agentId: sessionAgentId,
-                sessionKey: params.sessionKey,
+                sessionKey: hookSessionKey,
                 workspaceDir: effectiveWorkspace,
                 messageProvider: params.messageProvider,
               },
@@ -775,7 +775,7 @@ export async function compactEmbeddedPiSessionDirect(
               },
               {
                 agentId: sessionAgentId,
-                sessionKey: params.sessionKey,
+                sessionKey: hookSessionKey,
                 workspaceDir: effectiveWorkspace,
                 messageProvider: params.messageProvider,
               },

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -680,6 +680,7 @@ export async function compactEmbeddedPiSessionDirect(
                 tokenCount: tokenCountBefore,
               },
               {
+                sessionId: params.sessionId,
                 agentId: sessionAgentId,
                 sessionKey: hookSessionKey,
                 workspaceDir: effectiveWorkspace,
@@ -788,6 +789,7 @@ export async function compactEmbeddedPiSessionDirect(
                 compactedCount,
               },
               {
+                sessionId: params.sessionId,
                 agentId: sessionAgentId,
                 sessionKey: hookSessionKey,
                 workspaceDir: effectiveWorkspace,

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -672,8 +672,6 @@ export async function compactEmbeddedPiSessionDirect(
               {
                 messageCount: messageCountBefore,
                 tokenCount: tokenCountBefore,
-                messageCountOriginal,
-                tokenCountOriginal,
               },
               {
                 agentId: sessionAgentId,

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -632,7 +632,7 @@ export async function compactEmbeddedPiSessionDirect(
           session.agent.replaceMessages(limited);
         }
         const missingSessionKey = !params.sessionKey || !params.sessionKey.trim();
-        const hookSessionKey = params.sessionKey?.trim() || `compact:${params.sessionId}`;
+        const hookSessionKey = params.sessionKey?.trim() || params.sessionId;
         const hookRunner = getGlobalHookRunner();
         const messageCountOriginal = originalMessages.length;
         let tokenCountOriginal: number | undefined;

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -361,6 +361,7 @@ export async function compactEmbeddedPiSessionDirect(
     });
 
     const sessionLabel = params.sessionKey ?? params.sessionId;
+    const resolvedMessageProvider = params.messageChannel ?? params.messageProvider;
     const { contextFiles } = await resolveBootstrapContextForRun({
       workspaceDir: effectiveWorkspace,
       config: params.config,
@@ -374,7 +375,7 @@ export async function compactEmbeddedPiSessionDirect(
         elevated: params.bashElevated,
       },
       sandbox,
-      messageProvider: params.messageChannel ?? params.messageProvider,
+      messageProvider: resolvedMessageProvider,
       agentAccountId: params.agentAccountId,
       sessionKey: sandboxSessionKey,
       sessionId: params.sessionId,
@@ -614,7 +615,9 @@ export async function compactEmbeddedPiSessionDirect(
         // Keep compaction hooks aligned with the validated transcript that actually enters
         // truncation/repair and compaction.
         session.agent.replaceMessages(validated);
-        const originalMessages = session.messages.slice();
+        // "Original" compaction metrics should describe the validated transcript that enters
+        // limiting/compaction, not the raw on-disk session snapshot.
+        const originalMessages = validated.slice();
         const truncated = limitHistoryTurns(
           session.messages,
           getDmHistoryLimitFromSessionKey(params.sessionKey, params.config),
@@ -680,7 +683,7 @@ export async function compactEmbeddedPiSessionDirect(
                 agentId: sessionAgentId,
                 sessionKey: hookSessionKey,
                 workspaceDir: effectiveWorkspace,
-                messageProvider: params.messageProvider,
+                messageProvider: resolvedMessageProvider,
               },
             );
           } catch (err) {
@@ -788,7 +791,7 @@ export async function compactEmbeddedPiSessionDirect(
                 agentId: sessionAgentId,
                 sessionKey: hookSessionKey,
                 workspaceDir: effectiveWorkspace,
-                messageProvider: params.messageProvider,
+                messageProvider: resolvedMessageProvider,
               },
             );
           } catch (err) {

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -632,9 +632,7 @@ export async function compactEmbeddedPiSessionDirect(
         const hookSessionKey = params.sessionKey?.trim() || `compact:${params.sessionId}`;
         const hookRunner = getGlobalHookRunner();
         const messageCountOriginal = originalMessages.length;
-        const messageCountBefore = session.messages.length;
         let tokenCountOriginal: number | undefined;
-        let tokenCountBefore: number | undefined;
         try {
           tokenCountOriginal = 0;
           for (const message of originalMessages) {
@@ -643,6 +641,8 @@ export async function compactEmbeddedPiSessionDirect(
         } catch {
           tokenCountOriginal = undefined;
         }
+        const messageCountBefore = session.messages.length;
+        let tokenCountBefore: number | undefined;
         try {
           tokenCountBefore = 0;
           for (const message of session.messages) {

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -676,15 +676,14 @@ export async function compactEmbeddedPiSessionDirect(
               {
                 agentId: sessionAgentId,
                 sessionKey: params.sessionKey,
-                workspaceDir: params.workspaceDir,
+                workspaceDir: effectiveWorkspace,
                 messageProvider: params.messageProvider,
               },
             );
           } catch (err) {
-              log.warn(`before_compaction hook failed: ${String(err)}`);
-            }
+            log.warn(`before_compaction hook failed: ${String(err)}`);
+          }
         }
-
         const diagEnabled = log.isEnabled("debug");
         const preMetrics = diagEnabled ? summarizeCompactionMessages(session.messages) : undefined;
         if (diagEnabled && preMetrics) {
@@ -712,6 +711,7 @@ export async function compactEmbeddedPiSessionDirect(
         }
 
         const compactStartedAt = Date.now();
+        const messageCountCompactionInput = session.messages.length;
         const result = await compactWithSafetyTimeout(() =>
           session.compact(params.customInstructions),
         );
@@ -731,7 +731,7 @@ export async function compactEmbeddedPiSessionDirect(
           tokensAfter = undefined;
         }
         const messageCountAfter = session.messages.length;
-        const compactedCount = Math.max(0, messageCountBefore - messageCountAfter);
+        const compactedCount = Math.max(0, messageCountCompactionInput - messageCountAfter);
         const postMetrics = diagEnabled ? summarizeCompactionMessages(session.messages) : undefined;
         if (diagEnabled && preMetrics && postMetrics) {
           log.debug(
@@ -776,7 +776,7 @@ export async function compactEmbeddedPiSessionDirect(
               {
                 agentId: sessionAgentId,
                 sessionKey: params.sessionKey,
-                workspaceDir: params.workspaceDir,
+                workspaceDir: effectiveWorkspace,
                 messageProvider: params.messageProvider,
               },
             );

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -579,7 +579,7 @@ export async function compactEmbeddedPiSessionDirect(
       });
 
       const { session } = await createAgentSession({
-        cwd: resolvedWorkspace,
+        cwd: effectiveWorkspace,
         agentDir,
         authStorage,
         modelRegistry,

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -664,7 +664,10 @@ export async function compactEmbeddedPiSessionDirect(
           });
           await triggerInternalHook(hookEvent);
         } catch (err) {
-          log.warn(`session:compact:before hook failed: ${String(err)}`);
+          log.warn("session:compact:before hook failed", {
+            errorMessage: err instanceof Error ? err.message : String(err),
+            errorStack: err instanceof Error ? err.stack : undefined,
+          });
         }
         if (hookRunner?.hasHooks("before_compaction")) {
           try {
@@ -681,7 +684,10 @@ export async function compactEmbeddedPiSessionDirect(
               },
             );
           } catch (err) {
-            log.warn(`before_compaction hook failed: ${String(err)}`);
+            log.warn("before_compaction hook failed", {
+              errorMessage: err instanceof Error ? err.message : String(err),
+              errorStack: err instanceof Error ? err.stack : undefined,
+            });
           }
         }
         const diagEnabled = log.isEnabled("debug");
@@ -765,7 +771,10 @@ export async function compactEmbeddedPiSessionDirect(
           });
           await triggerInternalHook(hookEvent);
         } catch (err) {
-          log.warn(`session:compact:after hook failed: ${String(err)}`);
+          log.warn("session:compact:after hook failed", {
+            errorMessage: err instanceof Error ? err.message : String(err),
+            errorStack: err instanceof Error ? err.stack : undefined,
+          });
         }
         if (hookRunner?.hasHooks("after_compaction")) {
           try {
@@ -783,7 +792,10 @@ export async function compactEmbeddedPiSessionDirect(
               },
             );
           } catch (err) {
-            log.warn(`after_compaction hook failed: ${String(err)}`);
+            log.warn("after_compaction hook failed", {
+              errorMessage: err instanceof Error ? err.message : String(err),
+              errorStack: err instanceof Error ? err.stack : undefined,
+            });
           }
         }
         return {

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -711,7 +711,9 @@ export async function compactEmbeddedPiSessionDirect(
         }
 
         const compactStartedAt = Date.now();
-        const messageCountCompactionInput = session.messages.length;
+        // Measure compactedCount from the original pre-limiting transcript so compaction
+        // lifecycle metrics represent total reduction through the compaction pipeline.
+        const messageCountCompactionInput = messageCountOriginal;
         const result = await compactWithSafetyTimeout(() =>
           session.compact(params.customInstructions),
         );

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -612,12 +612,12 @@ export async function compactEmbeddedPiSessionDirect(
         const validated = transcriptPolicy.validateAnthropicTurns
           ? validateAnthropicTurns(validatedGemini)
           : validatedGemini;
-        // Keep compaction hooks aligned with the validated transcript that actually enters
-        // truncation/repair and compaction.
+        // Apply validated transcript to the live session even when no history limit is configured,
+        // so compaction and hook metrics are based on the same message set.
         session.agent.replaceMessages(validated);
         // "Original" compaction metrics should describe the validated transcript that enters
         // limiting/compaction, not the raw on-disk session snapshot.
-        const originalMessages = validated.slice();
+        const originalMessages = session.messages.slice();
         const truncated = limitHistoryTurns(
           session.messages,
           getDmHistoryLimitFromSessionKey(params.sessionKey, params.config),


### PR DESCRIPTION
## Why
Compaction is a critical lifecycle boundary for observability and guardrails, but runtime hook visibility was incomplete. This PR adds explicit compaction lifecycle emissions so operators and plugins can reliably track pre/post compaction state. lobster-biscuit

## Split Context
This PR was split from closed umbrella PR #9761: https://github.com/openclaw/openclaw/pull/9761.

## Detailed Changes
- Internal hook emissions added in compaction flow:
  - `session:compact:before`
  - `session:compact:after`
- Plugin hook wiring added in compaction flow:
  - `before_compaction`
  - `after_compaction`
- Hook metadata now includes counts/token-oriented context (without full message snapshots)
- Added focused test coverage for compaction hook emission and payload shape

## Related Links, Issues and Resolutions
- Closed source PR: #9761
- Related issues: 
  - Closes #7175
  - Closes #9611
  - #7420 
  - Closes #9527
  - Closes #11617

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds internal (`session:compact:before`, `session:compact:after`) and plugin (`before_compaction`, `after_compaction`) hook emissions to the compaction flow with count/token metadata. The implementation correctly passes context including `sessionId`, `agentId`, `sessionKey`, `workspaceDir`, and `messageProvider` to plugin hooks, addressing previous concerns about missing `sessionId`. The PR also includes a subtle bug fix changing `cwd: resolvedWorkspace` to `cwd: effectiveWorkspace` to properly respect sandbox settings.

- Internal hooks emit structured events with message counts and token estimates before/after compaction
- Plugin hooks receive metadata without full message snapshots (by design per TODOs #7175, #9611)
- Test coverage validates hook emission, payload structure, and edge cases (empty transcripts, missing sessionKey)
- `compactedCount` correctly measures total reduction from validated transcript through both history limiting and compaction
- Previous thread concerns about missing `sessionId` in plugin context have been resolved

<h3>Confidence Score: 4/5</h3>

- Safe to merge with high confidence - well-tested hook implementation with proper error handling
- The implementation is solid with comprehensive test coverage and proper error handling. Previous concerns about missing `sessionId` have been addressed. The change from `resolvedWorkspace` to `effectiveWorkspace` is a legitimate bug fix. Hook payloads intentionally omit full message snapshots per design decisions documented in TODOs. Loses one point only due to the documentation formatting issue already flagged in previous threads (missing blank line before heading).
- No files require special attention - all changes are well-structured and tested

<sub>Last reviewed commit: 85d9ced</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->