### PR TITLE
fix(skills): use subsystem logger instead of console.log for debug output

### DIFF
--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -54,12 +54,12 @@ function filterSkillEntries(
   if (skillFilter !== undefined) {
     const normalized = skillFilter.map((entry) => String(entry).trim()).filter(Boolean);
     const label = normalized.length > 0 ? normalized.join(", ") : "(none)";
-    console.log(`[skills] Applying skill filter: ${label}`);
+    skillsLogger.verbose(`Applying skill filter: ${label}`);
     filtered =
       normalized.length > 0
         ? filtered.filter((entry) => normalized.includes(entry.skill.name))
         : [];
-    console.log(`[skills] After filter: ${filtered.map((entry) => entry.skill.name).join(", ")}`);
+    skillsLogger.verbose(`After filter: ${filtered.map((entry) => entry.skill.name).join(", ")}`);
   }
   return filtered;
 }


### PR DESCRIPTION
Fixes #16661

## Problem
src/agents/skills/workspace.ts uses raw console.log for debug output (lines 57, 62), polluting stdout on every message when skill filters are configured, regardless of log level settings.

## Solution
Replace console.log with skillsLogger.verbose to respect configured log levels.

## Changes
- Line 57: console.log → skillsLogger.verbose
- Line 62: console.log → skillsLogger.verbose

## Impact
- Debug output now respects log level configuration
- No more stdout pollution in production
- Messages only appear when verbose logging is enabled

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces raw `console.log` calls in `filterSkillEntries()` with `skillsLogger.verbose()` to respect configured log levels. However, the `SubsystemLogger` type does not expose a `verbose` method — its available methods are `trace`, `debug`, `info`, `warn`, `error`, `fatal`, and `raw`. This will throw a `TypeError` at runtime when skill filters are configured. As noted in previous review comments, `skillsLogger.debug()` should be used instead.

<h3>Confidence Score: 1/5</h3>

- This PR will crash at runtime — do not merge without fixing the method name.
- The `SubsystemLogger` type defines `trace`, `debug`, `info`, `warn`, `error`, `fatal`, and `raw` methods — there is no `verbose` method. Both changed lines (57 and 62) call `skillsLogger.verbose()`, which will throw `TypeError: skillsLogger.verbose is not a function` at runtime whenever skill filters are configured. The fix is straightforward (use `debug` instead of `verbose`), but as-is this PR introduces a regression.
- `src/agents/skills/workspace.ts` — both changed lines use a non-existent method

<sub>Last reviewed commit: 4a99799</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->