### PR TITLE
fix(auth-profiles): implement per-model rate limit cooldown tracking

### DIFF
--- a/src/agents/auth-profiles.per-model-cooldown.test.ts
+++ b/src/agents/auth-profiles.per-model-cooldown.test.ts
@@ -1,0 +1,512 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  ensureAuthProfileStore,
+  isProfileInCooldown,
+  markAuthProfileFailure,
+  markAuthProfileUsed,
+  clearAuthProfileCooldown,
+  getModelCooldownUntil,
+} from "./auth-profiles.js";
+
+describe("per-model cooldown tracking", () => {
+  it("rate_limit error with model sets model-specific cooldown, not profile-wide", async () => {
+    const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-auth-"));
+    try {
+      const authPath = path.join(agentDir, "auth-profiles.json");
+      fs.writeFileSync(
+        authPath,
+        JSON.stringify({
+          version: 1,
+          profiles: {
+            "google:default": {
+              type: "api_key",
+              provider: "google",
+              key: "key-default",
+            },
+          },
+        }),
+      );
+
+      const store = ensureAuthProfileStore(agentDir);
+      const startedAt = Date.now();
+
+      // Mark rate limit failure for gemini-3-flash
+      await markAuthProfileFailure({
+        store,
+        profileId: "google:default",
+        reason: "rate_limit",
+        agentDir,
+        model: "gemini-3-flash",
+      });
+
+      // Model-specific cooldown should be set
+      const stats = store.usageStats?.["google:default"];
+      expect(stats?.modelCooldowns?.["gemini-3-flash"]).toBeDefined();
+      expect(stats?.modelCooldowns?.["gemini-3-flash"]).toBeGreaterThan(startedAt);
+
+      // Profile-level cooldown should NOT be set
+      expect(stats?.cooldownUntil).toBeUndefined();
+
+      // Profile should be in cooldown for gemini-3-flash
+      expect(isProfileInCooldown(store, "google:default", "gemini-3-flash")).toBe(true);
+
+      // Profile should NOT be in cooldown for other models
+      expect(isProfileInCooldown(store, "google:default", "gemini-2.5-flash-lite")).toBe(false);
+      expect(isProfileInCooldown(store, "google:default", "gemini-3-pro-preview")).toBe(false);
+
+      // Profile without model specified should NOT be in cooldown
+      expect(isProfileInCooldown(store, "google:default")).toBe(false);
+    } finally {
+      fs.rmSync(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("auth error sets profile-wide cooldown, blocking all models", async () => {
+    const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-auth-"));
+    try {
+      const authPath = path.join(agentDir, "auth-profiles.json");
+      fs.writeFileSync(
+        authPath,
+        JSON.stringify({
+          version: 1,
+          profiles: {
+            "google:default": {
+              type: "api_key",
+              provider: "google",
+              key: "key-default",
+            },
+          },
+        }),
+      );
+
+      const store = ensureAuthProfileStore(agentDir);
+      const startedAt = Date.now();
+
+      // Mark auth failure (should be profile-wide)
+      await markAuthProfileFailure({
+        store,
+        profileId: "google:default",
+        reason: "auth",
+        agentDir,
+      });
+
+      // Profile-level cooldown should be set
+      const stats = store.usageStats?.["google:default"];
+      expect(stats?.cooldownUntil).toBeDefined();
+      expect(stats?.cooldownUntil).toBeGreaterThan(startedAt);
+
+      // Model-specific cooldowns should NOT be set
+      expect(stats?.modelCooldowns).toBeUndefined();
+
+      // Profile should be in cooldown for ALL models
+      expect(isProfileInCooldown(store, "google:default", "gemini-3-flash")).toBe(true);
+      expect(isProfileInCooldown(store, "google:default", "gemini-2.5-flash-lite")).toBe(true);
+      expect(isProfileInCooldown(store, "google:default")).toBe(true);
+    } finally {
+      fs.rmSync(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("billing error sets profile-wide disabled status, blocking all models", async () => {
+    const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-auth-"));
+    try {
+      const authPath = path.join(agentDir, "auth-profiles.json");
+      fs.writeFileSync(
+        authPath,
+        JSON.stringify({
+          version: 1,
+          profiles: {
+            "google:default": {
+              type: "api_key",
+              provider: "google",
+              key: "key-default",
+            },
+          },
+        }),
+      );
+
+      const store = ensureAuthProfileStore(agentDir);
+      const startedAt = Date.now();
+
+      // Mark billing failure (should be profile-wide disabled)
+      await markAuthProfileFailure({
+        store,
+        profileId: "google:default",
+        reason: "billing",
+        agentDir,
+      });
+
+      // Profile should be disabled
+      const stats = store.usageStats?.["google:default"];
+      expect(stats?.disabledUntil).toBeDefined();
+      expect(stats?.disabledUntil).toBeGreaterThan(startedAt);
+      expect(stats?.disabledReason).toBe("billing");
+
+      // Profile should be in cooldown for ALL models
+      expect(isProfileInCooldown(store, "google:default", "gemini-3-flash")).toBe(true);
+      expect(isProfileInCooldown(store, "google:default", "gemini-2.5-flash-lite")).toBe(true);
+      expect(isProfileInCooldown(store, "google:default")).toBe(true);
+    } finally {
+      fs.rmSync(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("multiple models can have independent cooldowns", async () => {
+    const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-auth-"));
+    try {
+      const authPath = path.join(agentDir, "auth-profiles.json");
+      fs.writeFileSync(
+        authPath,
+        JSON.stringify({
+          version: 1,
+          profiles: {
+            "google:default": {
+              type: "api_key",
+              provider: "google",
+              key: "key-default",
+            },
+          },
+        }),
+      );
+
+      const store = ensureAuthProfileStore(agentDir);
+
+      // Mark rate limit for two different models
+      await markAuthProfileFailure({
+        store,
+        profileId: "google:default",
+        reason: "rate_limit",
+        agentDir,
+        model: "gemini-3-flash",
+      });
+      await markAuthProfileFailure({
+        store,
+        profileId: "google:default",
+        reason: "rate_limit",
+        agentDir,
+        model: "gemini-3-pro-preview",
+      });
+
+      // Both models should have cooldowns
+      const stats = store.usageStats?.["google:default"];
+      expect(stats?.modelCooldowns?.["gemini-3-flash"]).toBeDefined();
+      expect(stats?.modelCooldowns?.["gemini-3-pro-preview"]).toBeDefined();
+
+      // Both models should be in cooldown
+      expect(isProfileInCooldown(store, "google:default", "gemini-3-flash")).toBe(true);
+      expect(isProfileInCooldown(store, "google:default", "gemini-3-pro-preview")).toBe(true);
+
+      // Other models should NOT be in cooldown
+      expect(isProfileInCooldown(store, "google:default", "gemini-2.5-flash-lite")).toBe(false);
+    } finally {
+      fs.rmSync(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("markAuthProfileUsed with model clears only that model's cooldown", async () => {
+    const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-auth-"));
+    try {
+      const authPath = path.join(agentDir, "auth-profiles.json");
+      fs.writeFileSync(
+        authPath,
+        JSON.stringify({
+          version: 1,
+          profiles: {
+            "google:default": {
+              type: "api_key",
+              provider: "google",
+              key: "key-default",
+            },
+          },
+        }),
+      );
+
+      const store = ensureAuthProfileStore(agentDir);
+
+      // Mark rate limit for two different models
+      await markAuthProfileFailure({
+        store,
+        profileId: "google:default",
+        reason: "rate_limit",
+        agentDir,
+        model: "gemini-3-flash",
+      });
+      await markAuthProfileFailure({
+        store,
+        profileId: "google:default",
+        reason: "rate_limit",
+        agentDir,
+        model: "gemini-3-pro-preview",
+      });
+
+      // Mark success for gemini-3-flash
+      await markAuthProfileUsed({
+        store,
+        profileId: "google:default",
+        agentDir,
+        model: "gemini-3-flash",
+      });
+
+      // gemini-3-flash cooldown should be cleared
+      expect(isProfileInCooldown(store, "google:default", "gemini-3-flash")).toBe(false);
+
+      // gemini-3-pro-preview should still be in cooldown
+      expect(isProfileInCooldown(store, "google:default", "gemini-3-pro-preview")).toBe(true);
+    } finally {
+      fs.rmSync(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("clearAuthProfileCooldown with model clears only that model's cooldown", async () => {
+    const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-auth-"));
+    try {
+      const authPath = path.join(agentDir, "auth-profiles.json");
+      fs.writeFileSync(
+        authPath,
+        JSON.stringify({
+          version: 1,
+          profiles: {
+            "google:default": {
+              type: "api_key",
+              provider: "google",
+              key: "key-default",
+            },
+          },
+        }),
+      );
+
+      const store = ensureAuthProfileStore(agentDir);
+
+      // Mark rate limit for two different models
+      await markAuthProfileFailure({
+        store,
+        profileId: "google:default",
+        reason: "rate_limit",
+        agentDir,
+        model: "gemini-3-flash",
+      });
+      await markAuthProfileFailure({
+        store,
+        profileId: "google:default",
+        reason: "rate_limit",
+        agentDir,
+        model: "gemini-3-pro-preview",
+      });
+
+      // Clear cooldown for gemini-3-flash only
+      await clearAuthProfileCooldown({
+        store,
+        profileId: "google:default",
+        agentDir,
+        model: "gemini-3-flash",
+      });
+
+      // gemini-3-flash cooldown should be cleared
+      expect(isProfileInCooldown(store, "google:default", "gemini-3-flash")).toBe(false);
+
+      // gemini-3-pro-preview should still be in cooldown
+      expect(isProfileInCooldown(store, "google:default", "gemini-3-pro-preview")).toBe(true);
+    } finally {
+      fs.rmSync(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("clearAuthProfileCooldown without model clears all cooldowns", async () => {
+    const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-auth-"));
+    try {
+      const authPath = path.join(agentDir, "auth-profiles.json");
+      fs.writeFileSync(
+        authPath,
+        JSON.stringify({
+          version: 1,
+          profiles: {
+            "google:default": {
+              type: "api_key",
+              provider: "google",
+              key: "key-default",
+            },
+          },
+        }),
+      );
+
+      const store = ensureAuthProfileStore(agentDir);
+
+      // Mark rate limit for multiple models
+      await markAuthProfileFailure({
+        store,
+        profileId: "google:default",
+        reason: "rate_limit",
+        agentDir,
+        model: "gemini-3-flash",
+      });
+      await markAuthProfileFailure({
+        store,
+        profileId: "google:default",
+        reason: "rate_limit",
+        agentDir,
+        model: "gemini-3-pro-preview",
+      });
+
+      // Clear all cooldowns
+      await clearAuthProfileCooldown({
+        store,
+        profileId: "google:default",
+        agentDir,
+      });
+
+      // All model cooldowns should be cleared
+      expect(isProfileInCooldown(store, "google:default", "gemini-3-flash")).toBe(false);
+      expect(isProfileInCooldown(store, "google:default", "gemini-3-pro-preview")).toBe(false);
+      expect(store.usageStats?.["google:default"]?.modelCooldowns).toBeUndefined();
+    } finally {
+      fs.rmSync(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("getModelCooldownUntil returns correct value for model with cooldown", async () => {
+    const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-auth-"));
+    try {
+      const authPath = path.join(agentDir, "auth-profiles.json");
+      fs.writeFileSync(
+        authPath,
+        JSON.stringify({
+          version: 1,
+          profiles: {
+            "google:default": {
+              type: "api_key",
+              provider: "google",
+              key: "key-default",
+            },
+          },
+        }),
+      );
+
+      const store = ensureAuthProfileStore(agentDir);
+      const startedAt = Date.now();
+
+      // Mark rate limit for gemini-3-flash
+      await markAuthProfileFailure({
+        store,
+        profileId: "google:default",
+        reason: "rate_limit",
+        agentDir,
+        model: "gemini-3-flash",
+      });
+
+      // getModelCooldownUntil should return cooldown time for gemini-3-flash
+      const cooldownUntil = getModelCooldownUntil(store, "google:default", "gemini-3-flash");
+      expect(cooldownUntil).toBeDefined();
+      expect(cooldownUntil).toBeGreaterThan(startedAt);
+
+      // getModelCooldownUntil should return null for models without cooldown
+      expect(getModelCooldownUntil(store, "google:default", "gemini-2.5-flash-lite")).toBeNull();
+    } finally {
+      fs.rmSync(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("model-specific cooldown uses exponential backoff per model", async () => {
+    const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-auth-"));
+    try {
+      const authPath = path.join(agentDir, "auth-profiles.json");
+      fs.writeFileSync(
+        authPath,
+        JSON.stringify({
+          version: 1,
+          profiles: {
+            "google:default": {
+              type: "api_key",
+              provider: "google",
+              key: "key-default",
+            },
+          },
+        }),
+      );
+
+      const store = ensureAuthProfileStore(agentDir);
+
+      // First failure: 1 minute cooldown
+      const startedAt1 = Date.now();
+      await markAuthProfileFailure({
+        store,
+        profileId: "google:default",
+        reason: "rate_limit",
+        agentDir,
+        model: "gemini-3-flash",
+      });
+      const cooldown1 = store.usageStats?.["google:default"]?.modelCooldowns?.["gemini-3-flash"];
+      expect(cooldown1).toBeDefined();
+      const duration1 = (cooldown1 as number) - startedAt1;
+      expect(duration1).toBeGreaterThan(50 * 1000); // ~1 min
+      expect(duration1).toBeLessThan(70 * 1000);
+
+      // Second failure: 5 minute cooldown
+      const startedAt2 = Date.now();
+      await markAuthProfileFailure({
+        store,
+        profileId: "google:default",
+        reason: "rate_limit",
+        agentDir,
+        model: "gemini-3-flash",
+      });
+      const cooldown2 = store.usageStats?.["google:default"]?.modelCooldowns?.["gemini-3-flash"];
+      const duration2 = (cooldown2 as number) - startedAt2;
+      expect(duration2).toBeGreaterThan(4 * 60 * 1000); // ~5 min
+      expect(duration2).toBeLessThan(6 * 60 * 1000);
+
+      // Model error count should be 2
+      expect(store.usageStats?.["google:default"]?.modelErrorCounts?.["gemini-3-flash"]).toBe(2);
+    } finally {
+      fs.rmSync(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rate_limit without model falls back to profile-level cooldown", async () => {
+    const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-auth-"));
+    try {
+      const authPath = path.join(agentDir, "auth-profiles.json");
+      fs.writeFileSync(
+        authPath,
+        JSON.stringify({
+          version: 1,
+          profiles: {
+            "google:default": {
+              type: "api_key",
+              provider: "google",
+              key: "key-default",
+            },
+          },
+        }),
+      );
+
+      const store = ensureAuthProfileStore(agentDir);
+      const startedAt = Date.now();
+
+      // Mark rate limit without model (backwards compatibility)
+      await markAuthProfileFailure({
+        store,
+        profileId: "google:default",
+        reason: "rate_limit",
+        agentDir,
+        // No model specified
+      });
+
+      // Profile-level cooldown should be set
+      const stats = store.usageStats?.["google:default"];
+      expect(stats?.cooldownUntil).toBeDefined();
+      expect(stats?.cooldownUntil).toBeGreaterThan(startedAt);
+
+      // Model-specific cooldowns should NOT be set
+      expect(stats?.modelCooldowns).toBeUndefined();
+
+      // Profile should be in cooldown for all models
+      expect(isProfileInCooldown(store, "google:default")).toBe(true);
+      expect(isProfileInCooldown(store, "google:default", "gemini-3-flash")).toBe(true);
+    } finally {
+      fs.rmSync(agentDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/agents/auth-profiles.ts
+++ b/src/agents/auth-profiles.ts
@@ -33,7 +33,9 @@ export type {
 export {
   calculateAuthProfileCooldownMs,
   clearAuthProfileCooldown,
+  getModelCooldownUntil,
   isProfileInCooldown,
+  isProfileInCooldownForModel,
   markAuthProfileCooldown,
   markAuthProfileFailure,
   markAuthProfileUsed,

--- a/src/agents/auth-profiles/order.ts
+++ b/src/agents/auth-profiles/order.ts
@@ -4,19 +4,6 @@ import { normalizeProviderId } from "../model-selection.js";
 import { listProfilesForProvider } from "./profiles.js";
 import { isProfileInCooldown } from "./usage.js";
 
-function resolveProfileUnusableUntil(stats: {
-  cooldownUntil?: number;
-  disabledUntil?: number;
-}): number | null {
-  const values = [stats.cooldownUntil, stats.disabledUntil]
-    .filter((value): value is number => typeof value === "number")
-    .filter((value) => Number.isFinite(value) && value > 0);
-  if (values.length === 0) {
-    return null;
-  }
-  return Math.max(...values);
-}
-
 /**
  * Resolve when a profile becomes usable for a specific model.
  * Considers both profile-level cooldowns (auth/billing) and model-specific cooldowns (rate_limit).

--- a/src/agents/auth-profiles/order.ts
+++ b/src/agents/auth-profiles/order.ts
@@ -17,13 +17,60 @@ function resolveProfileUnusableUntil(stats: {
   return Math.max(...values);
 }
 
+/**
+ * Resolve when a profile becomes usable for a specific model.
+ * Considers both profile-level cooldowns (auth/billing) and model-specific cooldowns (rate_limit).
+ */
+function resolveProfileUnusableUntilForModel(
+  stats: {
+    cooldownUntil?: number;
+    disabledUntil?: number;
+    modelCooldowns?: Record<string, number>;
+  },
+  model?: string,
+): number | null {
+  // Collect all applicable cooldown timestamps
+  const values: number[] = [];
+
+  // Profile-level cooldowns (auth/billing errors)
+  if (
+    typeof stats.cooldownUntil === "number" &&
+    Number.isFinite(stats.cooldownUntil) &&
+    stats.cooldownUntil > 0
+  ) {
+    values.push(stats.cooldownUntil);
+  }
+  if (
+    typeof stats.disabledUntil === "number" &&
+    Number.isFinite(stats.disabledUntil) &&
+    stats.disabledUntil > 0
+  ) {
+    values.push(stats.disabledUntil);
+  }
+
+  // Model-specific cooldown (rate_limit errors)
+  if (model && stats.modelCooldowns) {
+    const modelCooldown = stats.modelCooldowns[model];
+    if (typeof modelCooldown === "number" && Number.isFinite(modelCooldown) && modelCooldown > 0) {
+      values.push(modelCooldown);
+    }
+  }
+
+  if (values.length === 0) {
+    return null;
+  }
+  return Math.max(...values);
+}
+
 export function resolveAuthProfileOrder(params: {
   cfg?: OpenClawConfig;
   store: AuthProfileStore;
   provider: string;
   preferredProfile?: string;
+  /** Optional model ID for model-specific cooldown checks */
+  model?: string;
 }): string[] {
-  const { cfg, store, provider, preferredProfile } = params;
+  const { cfg, store, provider, preferredProfile, model } = params;
   const providerKey = normalizeProviderId(provider);
   const now = Date.now();
   const storedOrder = (() => {
@@ -118,11 +165,13 @@ export function resolveAuthProfileOrder(params: {
   if (explicitOrder && explicitOrder.length > 0) {
     // ...but still respect cooldown tracking to avoid repeatedly selecting a
     // known-bad/rate-limited key as the first candidate.
+    // Use model-aware cooldown check if model is provided
     const available: string[] = [];
     const inCooldown: Array<{ profileId: string; cooldownUntil: number }> = [];
 
     for (const profileId of deduped) {
-      const cooldownUntil = resolveProfileUnusableUntil(store.usageStats?.[profileId] ?? {}) ?? 0;
+      const cooldownUntil =
+        resolveProfileUnusableUntilForModel(store.usageStats?.[profileId] ?? {}, model) ?? 0;
       if (
         typeof cooldownUntil === "number" &&
         Number.isFinite(cooldownUntil) &&
@@ -151,7 +200,7 @@ export function resolveAuthProfileOrder(params: {
   // Otherwise, use round-robin: sort by lastUsed (oldest first)
   // preferredProfile goes first if specified (for explicit user choice)
   // lastGood is NOT prioritized - that would defeat round-robin
-  const sorted = orderProfilesByMode(deduped, store);
+  const sorted = orderProfilesByMode(deduped, store, model);
 
   if (preferredProfile && sorted.includes(preferredProfile)) {
     return [preferredProfile, ...sorted.filter((e) => e !== preferredProfile)];
@@ -160,15 +209,16 @@ export function resolveAuthProfileOrder(params: {
   return sorted;
 }
 
-function orderProfilesByMode(order: string[], store: AuthProfileStore): string[] {
+function orderProfilesByMode(order: string[], store: AuthProfileStore, model?: string): string[] {
   const now = Date.now();
 
   // Partition into available and in-cooldown
+  // Use model-aware cooldown check if model is provided
   const available: string[] = [];
   const inCooldown: string[] = [];
 
   for (const profileId of order) {
-    if (isProfileInCooldown(store, profileId)) {
+    if (isProfileInCooldown(store, profileId, model)) {
       inCooldown.push(profileId);
     } else {
       available.push(profileId);
@@ -198,10 +248,12 @@ function orderProfilesByMode(order: string[], store: AuthProfileStore): string[]
     .map((entry) => entry.profileId);
 
   // Append cooldown profiles at the end (sorted by cooldown expiry, soonest first)
+  // Use model-aware cooldown expiry if model is provided
   const cooldownSorted = inCooldown
     .map((profileId) => ({
       profileId,
-      cooldownUntil: resolveProfileUnusableUntil(store.usageStats?.[profileId] ?? {}) ?? now,
+      cooldownUntil:
+        resolveProfileUnusableUntilForModel(store.usageStats?.[profileId] ?? {}, model) ?? now,
     }))
     .toSorted((a, b) => a.cooldownUntil - b.cooldownUntil)
     .map((entry) => entry.profileId);

--- a/src/agents/auth-profiles/types.ts
+++ b/src/agents/auth-profiles/types.ts
@@ -43,12 +43,19 @@ export type AuthProfileFailureReason =
 /** Per-profile usage statistics for round-robin and cooldown tracking */
 export type ProfileUsageStats = {
   lastUsed?: number;
+  /** Profile-level cooldown (for auth/billing/unknown errors) */
   cooldownUntil?: number;
   disabledUntil?: number;
   disabledReason?: AuthProfileFailureReason;
   errorCount?: number;
   failureCounts?: Partial<Record<AuthProfileFailureReason, number>>;
   lastFailureAt?: number;
+  /** Per-model cooldown timestamps (model -> cooldownUntil). Used for rate_limit errors. */
+  modelCooldowns?: Record<string, number>;
+  /** Per-model error counts (model -> errorCount). Used for rate_limit backoff calculation. */
+  modelErrorCounts?: Record<string, number>;
+  /** Per-model last failure timestamps (model -> lastFailureAt). */
+  modelLastFailureAt?: Record<string, number>;
 };
 
 export type AuthProfileStore = {

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -15,26 +15,55 @@ function resolveProfileUnusableUntil(stats: ProfileUsageStats): number | null {
 
 /**
  * Check if a profile is currently in cooldown (due to rate limiting or errors).
+ * If `model` is provided, also checks model-specific cooldowns.
+ * A profile is considered in cooldown if:
+ * - Profile-level cooldown is active (auth/billing errors), OR
+ * - The specific model has an active cooldown (rate_limit errors)
  */
-export function isProfileInCooldown(store: AuthProfileStore, profileId: string): boolean {
+export function isProfileInCooldown(
+  store: AuthProfileStore,
+  profileId: string,
+  model?: string,
+): boolean {
   const stats = store.usageStats?.[profileId];
   if (!stats) {
     return false;
   }
-  const unusableUntil = resolveProfileUnusableUntil(stats);
-  return unusableUntil ? Date.now() < unusableUntil : false;
+  // Check profile-level cooldown (auth/billing errors disable entire profile)
+  const profileUnusableUntil = resolveProfileUnusableUntil(stats);
+  if (profileUnusableUntil && Date.now() < profileUnusableUntil) {
+    return true;
+  }
+  // Check model-specific cooldown if model is provided
+  if (model && stats.modelCooldowns) {
+    const modelCooldownUntil = stats.modelCooldowns[model];
+    if (
+      typeof modelCooldownUntil === "number" &&
+      Number.isFinite(modelCooldownUntil) &&
+      modelCooldownUntil > 0 &&
+      Date.now() < modelCooldownUntil
+    ) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /**
  * Mark a profile as successfully used. Resets error count and updates lastUsed.
  * Uses store lock to avoid overwriting concurrent usage updates.
+ *
+ * If `model` is provided, only clears the cooldown for that specific model.
+ * If `model` is not provided, clears all cooldowns (profile-level and model-level).
  */
 export async function markAuthProfileUsed(params: {
   store: AuthProfileStore;
   profileId: string;
   agentDir?: string;
+  /** Optional model ID - if provided, only clears cooldown for this model */
+  model?: string;
 }): Promise<void> {
-  const { store, profileId, agentDir } = params;
+  const { store, profileId, agentDir, model } = params;
   const updated = await updateAuthProfileStoreWithLock({
     agentDir,
     updater: (freshStore) => {
@@ -42,15 +71,40 @@ export async function markAuthProfileUsed(params: {
         return false;
       }
       freshStore.usageStats = freshStore.usageStats ?? {};
-      freshStore.usageStats[profileId] = {
-        ...freshStore.usageStats[profileId],
-        lastUsed: Date.now(),
-        errorCount: 0,
-        cooldownUntil: undefined,
-        disabledUntil: undefined,
-        disabledReason: undefined,
-        failureCounts: undefined,
-      };
+      const existing = freshStore.usageStats[profileId] ?? {};
+
+      if (model) {
+        // Only clear cooldown for the specific model
+        const modelCooldowns = { ...existing.modelCooldowns };
+        const modelErrorCounts = { ...existing.modelErrorCounts };
+        const modelLastFailureAt = { ...existing.modelLastFailureAt };
+        delete modelCooldowns[model];
+        delete modelErrorCounts[model];
+        delete modelLastFailureAt[model];
+
+        freshStore.usageStats[profileId] = {
+          ...existing,
+          lastUsed: Date.now(),
+          modelCooldowns: Object.keys(modelCooldowns).length > 0 ? modelCooldowns : undefined,
+          modelErrorCounts: Object.keys(modelErrorCounts).length > 0 ? modelErrorCounts : undefined,
+          modelLastFailureAt:
+            Object.keys(modelLastFailureAt).length > 0 ? modelLastFailureAt : undefined,
+        };
+      } else {
+        // Clear all cooldowns
+        freshStore.usageStats[profileId] = {
+          ...existing,
+          lastUsed: Date.now(),
+          errorCount: 0,
+          cooldownUntil: undefined,
+          disabledUntil: undefined,
+          disabledReason: undefined,
+          failureCounts: undefined,
+          modelCooldowns: undefined,
+          modelErrorCounts: undefined,
+          modelLastFailureAt: undefined,
+        };
+      }
       return true;
     },
   });
@@ -63,15 +117,40 @@ export async function markAuthProfileUsed(params: {
   }
 
   store.usageStats = store.usageStats ?? {};
-  store.usageStats[profileId] = {
-    ...store.usageStats[profileId],
-    lastUsed: Date.now(),
-    errorCount: 0,
-    cooldownUntil: undefined,
-    disabledUntil: undefined,
-    disabledReason: undefined,
-    failureCounts: undefined,
-  };
+  const existing = store.usageStats[profileId] ?? {};
+
+  if (model) {
+    // Only clear cooldown for the specific model
+    const modelCooldowns = { ...existing.modelCooldowns };
+    const modelErrorCounts = { ...existing.modelErrorCounts };
+    const modelLastFailureAt = { ...existing.modelLastFailureAt };
+    delete modelCooldowns[model];
+    delete modelErrorCounts[model];
+    delete modelLastFailureAt[model];
+
+    store.usageStats[profileId] = {
+      ...existing,
+      lastUsed: Date.now(),
+      modelCooldowns: Object.keys(modelCooldowns).length > 0 ? modelCooldowns : undefined,
+      modelErrorCounts: Object.keys(modelErrorCounts).length > 0 ? modelErrorCounts : undefined,
+      modelLastFailureAt:
+        Object.keys(modelLastFailureAt).length > 0 ? modelLastFailureAt : undefined,
+    };
+  } else {
+    // Clear all cooldowns
+    store.usageStats[profileId] = {
+      ...existing,
+      lastUsed: Date.now(),
+      errorCount: 0,
+      cooldownUntil: undefined,
+      disabledUntil: undefined,
+      disabledReason: undefined,
+      failureCounts: undefined,
+      modelCooldowns: undefined,
+      modelErrorCounts: undefined,
+      modelLastFailureAt: undefined,
+    };
+  }
   saveAuthProfileStore(store, agentDir);
 }
 
@@ -157,13 +236,86 @@ export function resolveProfileUnusableUntilForDisplay(
   return resolveProfileUnusableUntil(stats);
 }
 
+/**
+ * Get the cooldown expiry timestamp for a specific model on a profile.
+ * Returns null if no model-specific cooldown is active.
+ */
+export function getModelCooldownUntil(
+  store: AuthProfileStore,
+  profileId: string,
+  model: string,
+): number | null {
+  const stats = store.usageStats?.[profileId];
+  if (!stats?.modelCooldowns) {
+    return null;
+  }
+  const cooldownUntil = stats.modelCooldowns[model];
+  if (
+    typeof cooldownUntil === "number" &&
+    Number.isFinite(cooldownUntil) &&
+    cooldownUntil > 0 &&
+    Date.now() < cooldownUntil
+  ) {
+    return cooldownUntil;
+  }
+  return null;
+}
+
+/**
+ * Check if a profile is in cooldown for a specific model.
+ * This is a convenience wrapper that combines profile-level and model-level checks.
+ */
+export function isProfileInCooldownForModel(
+  store: AuthProfileStore,
+  profileId: string,
+  model: string,
+): boolean {
+  return isProfileInCooldown(store, profileId, model);
+}
+
 function computeNextProfileUsageStats(params: {
   existing: ProfileUsageStats;
   now: number;
   reason: AuthProfileFailureReason;
   cfgResolved: ResolvedAuthCooldownConfig;
+  /** Optional model ID for model-specific rate_limit cooldowns */
+  model?: string;
 }): ProfileUsageStats {
   const windowMs = params.cfgResolved.failureWindowMs;
+
+  // For rate_limit errors with a specific model, use model-level tracking
+  if (params.reason === "rate_limit" && params.model) {
+    const modelLastFailureAt = params.existing.modelLastFailureAt?.[params.model];
+    const modelWindowExpired =
+      typeof modelLastFailureAt === "number" &&
+      modelLastFailureAt > 0 &&
+      params.now - modelLastFailureAt > windowMs;
+
+    const baseModelErrorCount = modelWindowExpired
+      ? 0
+      : (params.existing.modelErrorCounts?.[params.model] ?? 0);
+    const nextModelErrorCount = baseModelErrorCount + 1;
+    const backoffMs = calculateAuthProfileCooldownMs(nextModelErrorCount);
+
+    const updatedStats: ProfileUsageStats = {
+      ...params.existing,
+      modelCooldowns: {
+        ...params.existing.modelCooldowns,
+        [params.model]: params.now + backoffMs,
+      },
+      modelErrorCounts: {
+        ...params.existing.modelErrorCounts,
+        [params.model]: nextModelErrorCount,
+      },
+      modelLastFailureAt: {
+        ...params.existing.modelLastFailureAt,
+        [params.model]: params.now,
+      },
+    };
+    return updatedStats;
+  }
+
+  // For non-rate_limit errors or rate_limit without model, use profile-level tracking
   const windowExpired =
     typeof params.existing.lastFailureAt === "number" &&
     params.existing.lastFailureAt > 0 &&
@@ -191,6 +343,8 @@ function computeNextProfileUsageStats(params: {
     updatedStats.disabledUntil = params.now + backoffMs;
     updatedStats.disabledReason = "billing";
   } else {
+    // For rate_limit without model info, or auth/format/timeout/unknown errors,
+    // apply profile-level cooldown
     const backoffMs = calculateAuthProfileCooldownMs(nextErrorCount);
     updatedStats.cooldownUntil = params.now + backoffMs;
   }
@@ -201,6 +355,10 @@ function computeNextProfileUsageStats(params: {
 /**
  * Mark a profile as failed for a specific reason. Billing failures are treated
  * as "disabled" (longer backoff) vs the regular cooldown window.
+ *
+ * For rate_limit errors, if `model` is provided, the cooldown is applied to that
+ * specific model only, allowing other models on the same profile to remain usable.
+ * Auth, billing, and other errors always apply profile-wide cooldowns.
  */
 export async function markAuthProfileFailure(params: {
   store: AuthProfileStore;
@@ -208,8 +366,10 @@ export async function markAuthProfileFailure(params: {
   reason: AuthProfileFailureReason;
   cfg?: OpenClawConfig;
   agentDir?: string;
+  /** Optional model ID for model-specific rate_limit cooldowns */
+  model?: string;
 }): Promise<void> {
-  const { store, profileId, reason, agentDir, cfg } = params;
+  const { store, profileId, reason, agentDir, cfg, model } = params;
   const updated = await updateAuthProfileStoreWithLock({
     agentDir,
     updater: (freshStore) => {
@@ -232,6 +392,7 @@ export async function markAuthProfileFailure(params: {
         now,
         reason,
         cfgResolved,
+        model,
       });
       return true;
     },
@@ -258,6 +419,7 @@ export async function markAuthProfileFailure(params: {
     now,
     reason,
     cfgResolved,
+    model,
   });
   saveAuthProfileStore(store, agentDir);
 }
@@ -283,13 +445,18 @@ export async function markAuthProfileCooldown(params: {
 /**
  * Clear cooldown for a profile (e.g., manual reset).
  * Uses store lock to avoid overwriting concurrent usage updates.
+ *
+ * If `model` is provided, only clears the cooldown for that specific model.
+ * If `model` is not provided, clears all cooldowns (profile-level and model-level).
  */
 export async function clearAuthProfileCooldown(params: {
   store: AuthProfileStore;
   profileId: string;
   agentDir?: string;
+  /** Optional model ID - if provided, only clears cooldown for this model */
+  model?: string;
 }): Promise<void> {
-  const { store, profileId, agentDir } = params;
+  const { store, profileId, agentDir, model } = params;
   const updated = await updateAuthProfileStoreWithLock({
     agentDir,
     updater: (freshStore) => {
@@ -297,11 +464,30 @@ export async function clearAuthProfileCooldown(params: {
         return false;
       }
 
-      freshStore.usageStats[profileId] = {
-        ...freshStore.usageStats[profileId],
-        errorCount: 0,
-        cooldownUntil: undefined,
-      };
+      const existing = freshStore.usageStats[profileId];
+      if (model) {
+        // Only clear cooldown for the specific model
+        const modelCooldowns = { ...existing.modelCooldowns };
+        const modelErrorCounts = { ...existing.modelErrorCounts };
+        delete modelCooldowns[model];
+        delete modelErrorCounts[model];
+
+        freshStore.usageStats[profileId] = {
+          ...existing,
+          modelCooldowns: Object.keys(modelCooldowns).length > 0 ? modelCooldowns : undefined,
+          modelErrorCounts: Object.keys(modelErrorCounts).length > 0 ? modelErrorCounts : undefined,
+        };
+      } else {
+        // Clear all cooldowns
+        freshStore.usageStats[profileId] = {
+          ...existing,
+          errorCount: 0,
+          cooldownUntil: undefined,
+          modelCooldowns: undefined,
+          modelErrorCounts: undefined,
+          modelLastFailureAt: undefined,
+        };
+      }
       return true;
     },
   });
@@ -313,10 +499,29 @@ export async function clearAuthProfileCooldown(params: {
     return;
   }
 
-  store.usageStats[profileId] = {
-    ...store.usageStats[profileId],
-    errorCount: 0,
-    cooldownUntil: undefined,
-  };
+  const existing = store.usageStats[profileId];
+  if (model) {
+    // Only clear cooldown for the specific model
+    const modelCooldowns = { ...existing.modelCooldowns };
+    const modelErrorCounts = { ...existing.modelErrorCounts };
+    delete modelCooldowns[model];
+    delete modelErrorCounts[model];
+
+    store.usageStats[profileId] = {
+      ...existing,
+      modelCooldowns: Object.keys(modelCooldowns).length > 0 ? modelCooldowns : undefined,
+      modelErrorCounts: Object.keys(modelErrorCounts).length > 0 ? modelErrorCounts : undefined,
+    };
+  } else {
+    // Clear all cooldowns
+    store.usageStats[profileId] = {
+      ...existing,
+      errorCount: 0,
+      cooldownUntil: undefined,
+      modelCooldowns: undefined,
+      modelErrorCounts: undefined,
+      modelLastFailureAt: undefined,
+    };
+  }
   saveAuthProfileStore(store, agentDir);
 }

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -246,15 +246,20 @@ export async function runWithModelFallback<T>(params: {
         cfg: params.cfg,
         store: authStore,
         provider: candidate.provider,
+        model: candidate.model,
       });
-      const isAnyProfileAvailable = profileIds.some((id) => !isProfileInCooldown(authStore, id));
+      // Check if any profile is available for this specific model
+      // isProfileInCooldown now checks both profile-level (auth/billing) and model-level (rate_limit) cooldowns
+      const isAnyProfileAvailable = profileIds.some(
+        (id) => !isProfileInCooldown(authStore, id, candidate.model),
+      );
 
       if (profileIds.length > 0 && !isAnyProfileAvailable) {
-        // All profiles for this provider are in cooldown; skip without attempting
+        // All profiles for this model are in cooldown; skip without attempting
         attempts.push({
           provider: candidate.provider,
           model: candidate.model,
-          error: `Provider ${candidate.provider} is in cooldown (all profiles unavailable)`,
+          error: `Model ${candidate.provider}/${candidate.model} is in cooldown (all profiles unavailable)`,
           reason: "rate_limit",
         });
         continue;

--- a/src/agents/pi-embedded-helpers.extractratelimitedmodel.test.ts
+++ b/src/agents/pi-embedded-helpers.extractratelimitedmodel.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import { extractRateLimitedModel } from "./pi-embedded-helpers.js";
+
+describe("extractRateLimitedModel", () => {
+  it("extracts model from Google 429 response with quotaDimensions", () => {
+    const googleError = JSON.stringify({
+      error: {
+        code: 429,
+        message: "Resource has been exhausted (e.g. check quota).",
+        status: "RESOURCE_EXHAUSTED",
+        details: [
+          {
+            "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+            reason: "RATE_LIMIT_EXCEEDED",
+            domain: "googleapis.com",
+            metadata: {
+              service: "generativelanguage.googleapis.com",
+              consumer: "projects/12345",
+            },
+          },
+          {
+            "@type": "type.googleapis.com/google.rpc.QuotaFailure",
+            violations: [
+              {
+                subject: "GenerateContent",
+                description: "Rate limit exceeded",
+              },
+            ],
+          },
+          {
+            quotaDimensions: {
+              location: "global",
+              model: "gemini-3-flash",
+            },
+          },
+        ],
+      },
+    });
+
+    expect(extractRateLimitedModel(googleError)).toBe("gemini-3-flash");
+  });
+
+  it("extracts model from Google 429 response with HTTP prefix", () => {
+    const googleErrorWithPrefix = `429 ${JSON.stringify({
+      error: {
+        code: 429,
+        message: "Resource has been exhausted",
+        details: [
+          {
+            quotaDimensions: {
+              location: "us-central1",
+              model: "gemini-2.5-flash-lite",
+            },
+          },
+        ],
+      },
+    })}`;
+
+    expect(extractRateLimitedModel(googleErrorWithPrefix)).toBe("gemini-2.5-flash-lite");
+  });
+
+  it("extracts model from error.model field", () => {
+    const errorWithModelField = JSON.stringify({
+      error: {
+        code: 429,
+        message: "Rate limit exceeded",
+        model: "gpt-4o-mini",
+      },
+    });
+
+    expect(extractRateLimitedModel(errorWithModelField)).toBe("gpt-4o-mini");
+  });
+
+  it("extracts model from root model field", () => {
+    const errorWithRootModel = JSON.stringify({
+      code: 429,
+      message: "Rate limit exceeded",
+      model: "claude-3-5-sonnet",
+    });
+
+    expect(extractRateLimitedModel(errorWithRootModel)).toBe("claude-3-5-sonnet");
+  });
+
+  it("returns null for non-JSON error", () => {
+    expect(extractRateLimitedModel("Rate limit exceeded")).toBeNull();
+  });
+
+  it("returns null for JSON without model info", () => {
+    const errorWithoutModel = JSON.stringify({
+      error: {
+        code: 429,
+        message: "Rate limit exceeded",
+      },
+    });
+
+    expect(extractRateLimitedModel(errorWithoutModel)).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(extractRateLimitedModel("")).toBeNull();
+  });
+
+  it("returns null for whitespace-only string", () => {
+    expect(extractRateLimitedModel("   ")).toBeNull();
+  });
+
+  it("handles multiple details entries, extracting from quotaDimensions", () => {
+    const googleErrorMultipleDetails = JSON.stringify({
+      error: {
+        code: 429,
+        details: [
+          { "@type": "type.googleapis.com/google.rpc.ErrorInfo" },
+          { someOther: "data" },
+          {
+            quotaDimensions: {
+              location: "global",
+              model: "gemini-3-pro-preview",
+            },
+          },
+          { moreData: true },
+        ],
+      },
+    });
+
+    expect(extractRateLimitedModel(googleErrorMultipleDetails)).toBe("gemini-3-pro-preview");
+  });
+
+  it("extracts from root-level details (without error wrapper)", () => {
+    const rootLevelDetails = JSON.stringify({
+      code: 429,
+      details: [
+        {
+          quotaDimensions: {
+            model: "gemini-exp-1206",
+          },
+        },
+      ],
+    });
+
+    expect(extractRateLimitedModel(rootLevelDetails)).toBe("gemini-exp-1206");
+  });
+});

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -11,6 +11,7 @@ export {
   BILLING_ERROR_USER_MESSAGE,
   formatBillingErrorMessage,
   classifyFailoverReason,
+  extractRateLimitedModel,
   formatRawAssistantErrorForUi,
   formatAssistantErrorText,
   getApiErrorPayloadFingerprint,


### PR DESCRIPTION
**FIX ISSUE #5744** 

Previously, when one Google model (e.g., gemini-3-flash) hit HTTP 429 rate limit,OpenClaw would put the ENTIRE provider "google" in cooldown, blocking all other Google models even if they still had available quota.

This change implements per-model cooldown tracking:
- Rate limit (429) errors now apply cooldown to the specific model only
- Other models from the same provider remain usable
- Auth/billing errors still trigger full provider cooldown (as expected)
- Parse Google's quotaDimensions.model from 429 response for accurate tracking

---
PR Summary

## Summary

- Implement per-model rate limit cooldown tracking instead of full provider cooldown
- Add `extractRateLimitedModel()` helper to parse model from Google 429 responses
- Update `isProfileInCooldown()`, `markAuthProfileFailure()`, and related functions to support model-level cooldowns
- Modify model routing to check cooldowns at the model level

## Problem

When one Google model (e.g., `gemini-3-flash`) hits its per-model rate limit (HTTP 429), OpenClaw was putting the **entire provider** in cooldown. This blocked all other Google models(`gemini-2.5-flash-lite`, `gemini-3-pro-preview`, etc.) even though they still had available quota.

## Solution

- **Per-model cooldown tracking**: Added `modelCooldowns`, `modelErrorCounts`, and `modelLastFailureAt` fields to `ProfileUsageStats`
- **Smart 429 parsing**: Extract model info from Google's `quotaDimensions.model` in 429 responses
- **Scoped cooldowns**: Rate limit errors now only affect the specific model that hit its limit
- **Preserved provider-wide cooldowns**: Auth and billing errors still disable the entire profile (correct behavior)

## Changes

| File | Change |
|------|--------|
| `auth-profiles/types.ts` | Add model-level cooldown fields to `ProfileUsageStats` |
| `auth-profiles/usage.ts` | Update cooldown functions to support model parameter |
| `auth-profiles/order.ts` | Add model parameter to profile ordering logic |
| `pi-embedded-helpers/errors.ts` | Add `extractRateLimitedModel()` helper |
| `model-fallback.ts` | Pass model to cooldown checks in fallback routing |
| `pi-embedded-runner/run.ts` | Pass model info when marking failures |

## Test Plan

- [x] Model A rate limit → only Model A in cooldown
- [x] Model B from same provider still accessible
- [x] Auth error → full profile cooldown (all models blocked)
- [x] Billing error → full profile disabled (all models blocked)
- [x] Per-model exponential backoff works correctly
- [x] Backwards compatible: rate_limit without model info falls back to profile-level cooldown

## New Tests

- `auth-profiles.per-model-cooldown.test.ts` (10 test cases)
- `pi-embedded-helpers.extractratelimitedmodel.test.ts` (10 test cases)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements per-model rate limit cooldown tracking so that when one Google model (e.g., `gemini-3-flash`) hits HTTP 429, only that model is put in cooldown — other models on the same provider profile remain usable. Auth/billing errors continue to apply full provider-wide cooldowns.

- Adds `modelCooldowns`, `modelErrorCounts`, and `modelLastFailureAt` fields to `ProfileUsageStats` for model-level tracking
- New `extractRateLimitedModel()` parses Google's `quotaDimensions.model` from 429 responses to identify which model hit its limit
- `model-fallback.ts` correctly passes model to both profile ordering and cooldown checks
- `pi-embedded-runner/run.ts` passes model info when marking failures and successes
- Good test coverage: 10 tests for per-model cooldown behavior, 10 tests for `extractRateLimitedModel`

**Issues found:**
- The `resolveAuthProfileOrder` call in `pi-embedded-runner/run.ts:258` doesn't pass the `model` parameter, so the initial profile selection in the embedded runner doesn't benefit from per-model cooldowns — a rate-limited profile for the current model may still be tried first
- `clearAuthProfileCooldown` with a model parameter doesn't clear `modelLastFailureAt[model]`, unlike `markAuthProfileUsed` which clears all three model-level fields — creating an inconsistency in state cleanup

<h3>Confidence Score: 3/5</h3>

- Generally safe but has an incomplete integration that partially undermines the feature's effectiveness
- The core per-model cooldown logic is well-implemented and well-tested. However, the missing model parameter in the initial resolveAuthProfileOrder call in pi-embedded-runner/run.ts means per-model cooldowns won't be considered when selecting the first profile candidate — the primary code path. The model-fallback.ts integration is correct, but the embedded runner's initial ordering is incomplete. The clearAuthProfileCooldown inconsistency is a secondary concern.
- Pay close attention to `src/agents/pi-embedded-runner/run.ts` (missing model param in resolveAuthProfileOrder) and `src/agents/auth-profiles/usage.ts` (inconsistent state cleanup in clearAuthProfileCooldown)

<sub>Last reviewed commit: 2034fd5</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->