### PR TITLE
feat(session): add configurable greetingPrompt for /new and /reset

### DIFF
--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -43,7 +43,7 @@ import { buildGroupIntro } from "./groups.js";
 import { buildInboundMetaSystemPrompt, buildInboundUserContextPrefix } from "./inbound-meta.js";
 import { resolveQueueSettings } from "./queue.js";
 import { routeReply } from "./route-reply.js";
-import { BARE_SESSION_RESET_PROMPT } from "./session-reset-prompt.js";
+import { DEFAULT_GREETING_PROMPT } from "./session-reset-prompt.js";
 import { ensureSkillSnapshot, prependSystemEvents } from "./session-updates.js";
 import { resolveTypingMode } from "./typing-mode.js";
 import { appendUntrustedContext } from "./untrusted-context.js";
@@ -204,7 +204,8 @@ export async function runPreparedReply(
   const isBareSessionReset =
     isNewSession &&
     ((baseBodyTrimmedRaw.length === 0 && rawBodyTrimmed.length > 0) || isBareNewOrReset);
-  const baseBodyFinal = isBareSessionReset ? BARE_SESSION_RESET_PROMPT : baseBody;
+  const greetingPrompt = sessionCfg?.greetingPrompt ?? DEFAULT_GREETING_PROMPT;
+  const baseBodyFinal = isBareSessionReset ? greetingPrompt : baseBody;
   const inboundUserContext = buildInboundUserContextPrefix(
     isNewSession
       ? {

--- a/src/auto-reply/reply/session-reset-prompt.ts
+++ b/src/auto-reply/reply/session-reset-prompt.ts
@@ -1,2 +1,5 @@
-export const BARE_SESSION_RESET_PROMPT =
+export const DEFAULT_GREETING_PROMPT =
   "A new session was started via /new or /reset. Greet the user in your configured persona, if one is provided. Be yourself - use your defined voice, mannerisms, and mood. Keep it to 1-3 sentences and ask what they want to do. If the runtime model differs from default_model in the system prompt, mention the default model. Do not mention internal steps, files, tools, or reasoning.";
+
+/** @deprecated Use DEFAULT_GREETING_PROMPT instead. */
+export const BARE_SESSION_RESET_PROMPT = DEFAULT_GREETING_PROMPT;

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -91,6 +91,8 @@ export type SessionConfig = {
   /** Map platform-prefixed identities (e.g. "telegram:123") to canonical DM peers. */
   identityLinks?: Record<string, string[]>;
   resetTriggers?: string[];
+  /** Custom prompt injected when a bare /new or /reset starts a new session. Overrides the built-in greeting prompt. */
+  greetingPrompt?: string;
   idleMinutes?: number;
   reset?: SessionResetConfig;
   resetByType?: SessionResetByTypeConfig;

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -34,6 +34,7 @@ export const SessionSchema = z
       .optional(),
     identityLinks: z.record(z.string(), z.array(z.string())).optional(),
     resetTriggers: z.array(z.string()).optional(),
+    greetingPrompt: z.string().optional(),
     idleMinutes: z.number().int().positive().optional(),
     reset: SessionResetConfigSchema.optional(),
     resetByType: z

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import type { GatewayRequestHandlerOptions, GatewayRequestHandlers } from "./types.js";
 import { listAgentIds } from "../../agents/agent-scope.js";
-import { BARE_SESSION_RESET_PROMPT } from "../../auto-reply/reply/session-reset-prompt.js";
+import { DEFAULT_GREETING_PROMPT } from "../../auto-reply/reply/session-reset-prompt.js";
 import { agentCommand } from "../../commands/agent.js";
 import { loadConfig } from "../../config/config.js";
 import {
@@ -339,7 +339,7 @@ export const agentHandlers: GatewayRequestHandlers = {
       } else {
         // Keep bare /new and /reset behavior aligned with chat.send:
         // reset first, then run a fresh-session greeting prompt in-place.
-        message = BARE_SESSION_RESET_PROMPT;
+        message = cfg.session?.greetingPrompt ?? DEFAULT_GREETING_PROMPT;
         skipTimestampInjection = true;
       }
     }


### PR DESCRIPTION
## Summary

Adds `session.greetingPrompt` config option that overrides the built-in greeting prompt injected when a bare `/new` or `/reset` starts a new session.

## Motivation

The hardcoded greeting prompt tells agents to "not mention internal steps, files, tools, or reasoning" — but agents with custom bootstrap procedures (reading workspace files, loading memory, etc.) can misinterpret this as "don't *do* internal steps" rather than "don't *narrate* them."

Making this configurable lets users tailor the greeting instruction to their agent's workflow without modifying source code.

## Changes

- **`src/config/types.base.ts`**: Added `greetingPrompt?: string` to `SessionConfig`
- **`src/config/zod-schema.session.ts`**: Added zod validation for the new field
- **`src/auto-reply/reply/get-reply-run.ts`**: Reads `sessionCfg.greetingPrompt` with fallback to the existing default

## Usage

```json5
{
  session: {
    greetingPrompt: "A new session was started. Run your bootstrap silently, then greet the user in 1-3 sentences."
  }
}
```

When not configured, behavior is identical to current — zero breaking changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `session.greetingPrompt` config option to override the built-in greeting prompt injected when `/new` or `/reset` starts a session. The implementation is clean and maintains backward compatibility by keeping the original constant as a deprecated export. The change addresses a valid use case where custom bootstrap workflows need different greeting instructions.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is straightforward, maintains full backward compatibility through a deprecated export, uses proper TypeScript typing with Zod validation, and follows the codebase patterns. The fallback to `DEFAULT_GREETING_PROMPT` ensures existing behavior is preserved when the config option is not set. The change is isolated to configuration and auto-reply logic without affecting core functionality.
- No files require special attention

<sub>Last reviewed commit: 2f1d043</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->