### PR TITLE
fix: use container workdir in sandbox system prompt instead of host path

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -477,8 +477,9 @@ export async function compactEmbeddedPiSessionDirect(
       moduleUrl: import.meta.url,
     });
     const ttsHint = params.config ? buildTtsSystemPromptHint(params.config) : undefined;
+    const promptWorkspaceDir = sandbox?.enabled ? sandbox.containerWorkdir : effectiveWorkspace;
     const appendPrompt = buildEmbeddedSystemPrompt({
-      workspaceDir: effectiveWorkspace,
+      workspaceDir: promptWorkspaceDir,
       defaultThinkLevel: params.thinkLevel,
       reasoningLevel: params.reasoningLevel ?? "off",
       extraSystemPrompt: params.extraSystemPrompt,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -419,8 +419,9 @@ export async function runEmbeddedAttempt(
     });
     const ttsHint = params.config ? buildTtsSystemPromptHint(params.config) : undefined;
 
+    const promptWorkspaceDir = sandbox?.enabled ? sandbox.containerWorkdir : effectiveWorkspace;
     const appendPrompt = buildEmbeddedSystemPrompt({
-      workspaceDir: effectiveWorkspace,
+      workspaceDir: promptWorkspaceDir,
       defaultThinkLevel: params.thinkLevel,
       reasoningLevel: params.reasoningLevel ?? "off",
       extraSystemPrompt: params.extraSystemPrompt,

--- a/src/agents/pi-embedded-runner/sandbox-info.ts
+++ b/src/agents/pi-embedded-runner/sandbox-info.ts
@@ -12,7 +12,7 @@ export function buildEmbeddedSandboxInfo(
   const elevatedAllowed = Boolean(execElevated?.enabled && execElevated.allowed);
   return {
     enabled: true,
-    workspaceDir: sandbox.workspaceDir,
+    workspaceDir: sandbox.containerWorkdir,
     containerWorkspaceDir: sandbox.containerWorkdir,
     workspaceAccess: sandbox.workspaceAccess,
     agentWorkspaceMount: sandbox.workspaceAccess === "ro" ? "/agent" : undefined,


### PR DESCRIPTION
## Summary

When sandbox is enabled with `workspaceAccess: "rw"`, the `## Workspace` section of the system prompt
injects the host filesystem path (e.g. `/home/user/.openclaw/workspace`) instead of the container's
working directory (`/workspace`). The agent trusts this path and fails with "No such file or directory"
when running exec commands.

`SandboxContext.containerWorkdir` already holds the correct container-side path (`/workspace`) but was
not used for prompt generation. This PR changes `buildEmbeddedSystemPrompt` and `buildEmbeddedSandboxInfo`
to use `containerWorkdir` for prompt-facing paths.

`effectiveWorkspace` itself is unchanged — it must remain the host path for `fs.mkdir`, `process.chdir`,
`loadWorkspaceSkillEntries`, etc.

## Changes

- **`attempt.ts`**: Introduce `promptWorkspaceDir` that resolves to `sandbox.containerWorkdir` when
  sandbox is enabled, passed to `buildEmbeddedSystemPrompt`
- **`sandbox-info.ts`**: Use `sandbox.containerWorkdir` for `EmbeddedSandboxInfo.workspaceDir`

## Related

- Closes #16790
- Related: #4171 (cron isolated agent path issue), #16212 (container path normalization proposal)

✍️ Author: Claude Code with @carrotRakko (AI-written, human-approved)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixed sandbox system prompt path injection by using `containerWorkdir` instead of host filesystem paths when sandbox is enabled with `workspaceAccess: "rw"`. 

**Changes:**
- `attempt.ts`: introduced `promptWorkspaceDir` that resolves to `sandbox.containerWorkdir` when sandbox is enabled
- `sandbox-info.ts`: changed `workspaceDir` field to use `sandbox.containerWorkdir`

**Issue found:**
- `compact.ts` has the identical bug on line 481 where it passes `effectiveWorkspace` (host path) to `buildEmbeddedSystemPrompt`, causing the same "No such file or directory" error during compaction

<h3>Confidence Score: 3/5</h3>

- This PR fixes a critical bug but has incomplete coverage
- The fix correctly addresses the issue in `attempt.ts` and `sandbox-info.ts`, but the identical bug exists in `compact.ts` which was not addressed. The compaction flow would still inject incorrect host paths into the system prompt.
- Pay close attention to `src/agents/pi-embedded-runner/compact.ts` which has the same bug

<sub>Last reviewed commit: c0ad70c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->