### PR TITLE
Fix Telnyx inbound calls silently dropped — normalizeEvent missing direction/from/to

### DIFF
--- a/extensions/voice-call/src/providers/telnyx.ts
+++ b/extensions/voice-call/src/providers/telnyx.ts
@@ -130,11 +130,20 @@ export class TelnyxProvider implements VoiceCallProvider {
       callId = data.payload?.call_control_id || "";
     }
 
+    const direction = TelnyxProvider.parseDirection(data.payload?.direction);
+    const from =
+      typeof data.payload?.from === "string" ? data.payload.from : undefined;
+    const to =
+      typeof data.payload?.to === "string" ? data.payload.to : undefined;
+
     const baseEvent = {
       id: data.id || crypto.randomUUID(),
       callId,
       providerCallId: data.payload?.call_control_id,
       timestamp: Date.now(),
+      direction,
+      from,
+      to,
     };
 
     switch (data.event_type) {
@@ -284,6 +293,22 @@ export class TelnyxProvider implements VoiceCallProvider {
       { command_id: crypto.randomUUID() },
       { allowNotFound: true },
     );
+  }
+
+  /**
+   * Parse Telnyx direction to normalized format.
+   * Telnyx uses "incoming"/"outgoing" while the normalized format uses "inbound"/"outbound".
+   */
+  private static parseDirection(
+    direction: unknown,
+  ): "inbound" | "outbound" | undefined {
+    if (direction === "incoming" || direction === "inbound") {
+      return "inbound";
+    }
+    if (direction === "outgoing" || direction === "outbound") {
+      return "outbound";
+    }
+    return undefined;
   }
 }
 


### PR DESCRIPTION
Stumbled on this while looking at #16601. The Telnyx provider's `normalizeEvent` never passes `direction`, `from`, or `to` from the webhook payload into the normalized event. Without `direction: "inbound"`, `processEvent` can't tell it's an incoming call and just drops it.

Twilio already does this correctly (via `parseDirection`), so I followed the same pattern — added a static `parseDirection` helper that maps Telnyx's `incoming`/`outgoing` to the normalized `inbound`/`outbound` format, and put all three fields on `baseEvent` so every event type gets them.

Tests added for both inbound and outbound direction mapping through `parseWebhookEvent`.

Fixes #16601

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a bug where Telnyx inbound calls were silently dropped because `normalizeEvent` never populated the `direction`, `from`, or `to` fields on the normalized event. Without `direction: "inbound"`, `processEvent` in `events.ts` couldn't identify the call as inbound and would skip creating a call record for it.

- Adds a `parseDirection` static method to `TelnyxProvider` that maps Telnyx's `"incoming"`/`"outgoing"` values to the normalized `"inbound"`/`"outbound"` format (mirrors the existing pattern in the Twilio and Plivo providers)
- Populates `direction`, `from`, and `to` on `baseEvent` so all Telnyx event types carry these fields
- Adds tests covering inbound direction, outbound direction, and missing direction scenarios

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it fixes a clear bug with a well-scoped, pattern-consistent change.
- The change is minimal and targeted: it adds three fields to the base event object and a pure static helper method. It follows the exact same pattern already established by the Twilio and Plivo providers. The fix is necessary — without it, inbound Telnyx calls are silently dropped because processEvent cannot identify them. Tests cover inbound, outbound, and missing direction cases. No security implications, no breaking changes.
- No files require special attention.

<sub>Last reviewed commit: 97e21d2</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->