### PR TITLE
Fix sessions_send failing on Telegram, Discord, Signal, and Slack

### DIFF
--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -48,6 +48,7 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
   id: "discord",
   meta: {
     ...meta,
+    preferSessionLookupForAnnounceTarget: true,
   },
   onboarding: discordOnboardingAdapter,
   pairing: {

--- a/extensions/signal/src/channel.ts
+++ b/extensions/signal/src/channel.ts
@@ -43,6 +43,7 @@ export const signalPlugin: ChannelPlugin<ResolvedSignalAccount> = {
   id: "signal",
   meta: {
     ...meta,
+    preferSessionLookupForAnnounceTarget: true,
   },
   onboarding: signalOnboardingAdapter,
   pairing: {

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -55,6 +55,7 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
   id: "slack",
   meta: {
     ...meta,
+    preferSessionLookupForAnnounceTarget: true,
   },
   onboarding: slackOnboardingAdapter,
   pairing: {

--- a/extensions/telegram/src/channel.meta.test.ts
+++ b/extensions/telegram/src/channel.meta.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import { telegramPlugin } from "./channel.js";
+
+describe("Telegram channel plugin meta", () => {
+  it("enables session lookup for announce targets", () => {
+    expect(telegramPlugin.meta.preferSessionLookupForAnnounceTarget).toBe(true);
+  });
+});

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -72,6 +72,7 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
   meta: {
     ...meta,
     quickstartAllowFrom: true,
+    preferSessionLookupForAnnounceTarget: true,
   },
   onboarding: telegramOnboardingAdapter,
   pairing: {


### PR DESCRIPTION
Cross-channel `sessions_send` silently fails on these four channels because `resolveAnnounceTarget` skips the session lookup when `preferSessionLookupForAnnounceTarget` isn't set. It falls back to parsing the session key string, which gives the channel API a malformed target ID.

WhatsApp already had this flag. LINE was fixed separately (#8539). These four were just missed.

One-liner per plugin — just adding `preferSessionLookupForAnnounceTarget: true` to each channel's meta config.

Fixes #16660

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes `sessions_send` silently failing on Telegram, Discord, Signal, and Slack by enabling session lookup for announce targets. Without `preferSessionLookupForAnnounceTarget`, the `resolveAnnounceTarget` function skips querying the gateway's session list and instead parses the session key string directly, which produces malformed target IDs for these channels. WhatsApp already had this flag set, and this PR brings the other four channels into alignment.

- Added `preferSessionLookupForAnnounceTarget: true` to Discord channel meta config
- Added `preferSessionLookupForAnnounceTarget: true` to Signal channel meta config  
- Added `preferSessionLookupForAnnounceTarget: true` to Slack channel meta config
- Added `preferSessionLookupForAnnounceTarget: true` to Telegram channel meta config
- Added test coverage for Telegram to verify the flag is enabled

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are minimal, well-understood, and follow the exact pattern already used by WhatsApp. Each change is a one-line addition of a boolean flag to channel metadata. The fix addresses a clear bug where session announcements were failing, and test coverage was added for Telegram. The pattern in `sessions-announce-target.ts:18` shows this flag is explicitly checked to determine whether to perform session lookup vs string parsing.
- No files require special attention

<sub>Last reviewed commit: d1a8e3f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->