### PR TITLE
fix(config): transform Discord user/role IDs to strings

### DIFF
--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -226,8 +226,15 @@ export const DiscordGuildChannelSchema = z
     toolsBySender: ToolPolicyBySenderSchema,
     skills: z.array(z.string()).optional(),
     enabled: z.boolean().optional(),
-    users: z.array(z.union([z.string(), z.number()])).optional(),
-    roles: z.array(z.union([z.string(), z.number()])).optional(),
+    // Transform numbers to strings to preserve precision for large Discord IDs
+    users: z
+      .array(z.union([z.string(), z.number()]))
+      .optional()
+      .transform((val) => val?.map((v) => String(v))),
+    roles: z
+      .array(z.union([z.string(), z.number()]))
+      .optional()
+      .transform((val) => val?.map((v) => String(v))),
     systemPrompt: z.string().optional(),
     includeThreadStarter: z.boolean().optional(),
     autoThread: z.boolean().optional(),
@@ -241,8 +248,15 @@ export const DiscordGuildSchema = z
     tools: ToolPolicySchema,
     toolsBySender: ToolPolicyBySenderSchema,
     reactionNotifications: z.enum(["off", "own", "all", "allowlist"]).optional(),
-    users: z.array(z.union([z.string(), z.number()])).optional(),
-    roles: z.array(z.union([z.string(), z.number()])).optional(),
+    // Transform numbers to strings to preserve precision for large Discord IDs
+    users: z
+      .array(z.union([z.string(), z.number()]))
+      .optional()
+      .transform((val) => val?.map((v) => String(v))),
+    roles: z
+      .array(z.union([z.string(), z.number()]))
+      .optional()
+      .transform((val) => val?.map((v) => String(v))),
     channels: z.record(z.string(), DiscordGuildChannelSchema.optional()).optional(),
   })
   .strict();


### PR DESCRIPTION
Fixes #16681

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Transforms Discord user and role IDs from numbers to strings at the schema level to prevent precision loss with large snowflake IDs. The change applies `.transform((val) => val?.map((v) => String(v)))` to `users` and `roles` fields in both `DiscordGuildChannelSchema` and `DiscordGuildSchema`. This ensures that large 64-bit Discord IDs (which can exceed JavaScript's safe integer range) are preserved as strings before being used in allowlist matching, where they're compared via `Set.has()` operations.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified issues
- The transformation is minimal, focused, and solves a real precision issue with large Discord snowflake IDs. The change is backward compatible (strings and numbers both get converted to strings), and the downstream code already handles these values as strings via `String()` conversions. The implementation follows existing patterns in the codebase and correctly uses Zod's transform API with proper null handling.
- No files require special attention

<sub>Last reviewed commit: eeb1b5b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->