### PR TITLE
fix: session lookup default

### DIFF
--- a/src/agents/tools/sessions-announce-target.ts
+++ b/src/agents/tools/sessions-announce-target.ts
@@ -15,7 +15,9 @@ export async function resolveAnnounceTarget(params: {
   if (fallback) {
     const normalized = normalizeChannelId(fallback.channel);
     const plugin = normalized ? getChannelPlugin(normalized) : null;
-    if (!plugin?.meta?.preferSessionLookupForAnnounceTarget) {
+    // Default to session lookup (more reliable) unless explicitly opted out
+    // Only skip session lookup if preferSessionLookupForAnnounceTarget is explicitly false
+    if (plugin?.meta?.preferSessionLookupForAnnounceTarget === false) {
       return fallback;
     }
   }


### PR DESCRIPTION
Fixes #16660

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changed the default behavior for announce target resolution to prefer session lookup unless explicitly disabled. The condition was inverted from `!plugin?.meta?.preferSessionLookupForAnnounceTarget` to `plugin?.meta?.preferSessionLookupForAnnounceTarget === false`, making session lookup the new default for all channels that don't explicitly opt out.

- This is a **breaking change** for channels like Discord that currently rely on fallback behavior (undefined treated as opt-out)
- The existing test `sessions-announce-target.e2e.test.ts:64-72` expects Discord to skip the gateway call, but will now fail
- Only WhatsApp currently sets `preferSessionLookupForAnnounceTarget: true` explicitly, so it's unaffected
- All other channels (Discord, Telegram, Signal, etc.) will now perform session lookups by default

The change needs either channel plugin metadata updates or test updates to align expectations.

<h3>Confidence Score: 2/5</h3>

- This PR introduces a breaking behavioral change that conflicts with existing test expectations
- The logic change is intentional but breaks the existing test contract for Discord (and potentially other channels). The test explicitly expects Discord NOT to call `callGateway`, but the new logic will cause it to do so. This needs either: (1) Discord's plugin to explicitly set `preferSessionLookupForAnnounceTarget: false`, or (2) the test to be updated to reflect new expected behavior. Without knowing which channels should use session lookup vs fallback, this could cause runtime issues.
- Pay close attention to `src/agents/tools/sessions-announce-target.ts` and the test file - the behavior change needs validation across all channel types

<sub>Last reviewed commit: 2c8da99</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->