### PR TITLE
skills/gog: add attachments documentation

### DIFF
--- a/skills/gog/SKILL.md
+++ b/skills/gog/SKILL.md
@@ -58,6 +58,12 @@ Common commands
 - Docs export: `gog docs export <docId> --format txt --out /tmp/doc.txt`
 - Docs cat: `gog docs cat <docId>`
 
+Attachments
+
+- Get message with attachments: `gog gmail get <messageId> --json` (returns `attachments` array with `filename`, `attachmentId`, `mimeType`, `size`)
+- Download attachment: `gog gmail attachment <messageId> <attachmentId> --out /path/to/file`
+- Download with original name: `gog gmail attachment <messageId> <attachmentId> --name <filename>`
+
 Calendar Colors
 
 - Use `gog calendar colors` to see all available event colors (IDs 1-11)


### PR DESCRIPTION
Add documentation for Gmail attachment retrieval and download commands to the gog skill.

## Changes
- Added `Attachments` section with commands for:
  - Getting message attachments metadata via `gog gmail get <messageId> --json`
  - Downloading attachments via `gog gmail attachment <messageId> <attachmentId> --out /path/to/file`
  - Downloading with original filename via `--name <filename>`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an "Attachments" section to the gog skill documentation (`skills/gog/SKILL.md`) that documents three Gmail attachment-related commands: retrieving attachment metadata via `gog gmail get --json`, downloading attachments to a specified path via `gog gmail attachment --out`, and downloading with the original filename via `--name`.

- New section follows the existing formatting conventions (plain text headers, bullet-pointed commands)
- Placed logically between the "Common commands" and "Calendar Colors" sections
- No code changes; documentation only

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it only adds documentation with no code changes.
- The change is a small, documentation-only addition to a skill file. It follows existing formatting conventions and introduces no code, logic, or configuration changes. No issues were found.
- No files require special attention.

<sub>Last reviewed commit: 14fb96b</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->