### PR TITLE
fix(discord): prevent empty channels injection when merging guild entries

### DIFF
--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -241,7 +241,11 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
             );
             const existing = nextGuilds[entry.guildId] ?? {};
             const mergedChannels = { ...sourceGuild.channels, ...existing.channels };
-            const mergedGuild = { ...sourceGuild, ...existing, channels: mergedChannels };
+            const mergedGuild = {
+              ...sourceGuild,
+              ...existing,
+              channels: Object.keys(mergedChannels).length > 0 ? mergedChannels : undefined,
+            };
             nextGuilds[entry.guildId] = mergedGuild;
             if (source.channelKey && entry.channelId) {
               const sourceChannel = sourceGuild.channels?.[source.channelKey];


### PR DESCRIPTION
## Problem

When `guilds` is configured without an explicit `channels` property, the guild entry merging logic in `provider.ts` spreads two undefined values:

```ts
const mergedChannels = { ...sourceGuild.channels, ...existing.channels };
// both undefined → mergedChannels = {}
```

This produces an empty object `{}` that gets assigned to `channels`. Downstream, `resolveDiscordChannelConfigWithFallback` sees a configured (but empty) channel allowlist and returns `{ allowed: false }`, silently dropping **all** guild messages.

## Fix

Check if `mergedChannels` has any keys before assigning. When empty, use `undefined` so downstream treats it as "no channel config" → allow all.

```ts
channels: Object.keys(mergedChannels).length > 0 ? mergedChannels : undefined,
```

## Testing

- All 48 existing Discord monitor tests pass
- `pnpm build` + `pnpm check` clean

Fixes #16846

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a critical bug where guilds without explicit `channels` configuration were incorrectly treated as having an empty channel allowlist, silently blocking all messages. The fix ensures that when merging guild entries with no channel configurations, the result is `undefined` (no config = allow all) rather than `{}` (empty allowlist = block all).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The fix is surgical, well-tested (48 existing tests pass), and addresses a clear logical bug. The change correctly distinguishes between "no channel config" (undefined) and "empty channel allowlist" ({}), which have different downstream behaviors. The implementation follows the existing pattern used elsewhere in the codebase.
- No files require special attention

<sub>Last reviewed commit: 1170278</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->