### PR TITLE
fix: preserve scopes when shared-auth succeeds (Web UI LAN access)

### DIFF
--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -430,11 +430,13 @@ export function attachGatewayWsMessageHandler(params: {
           close(1008, truncateCloseReason(authMessage));
         };
         if (!device) {
-          if (scopes.length > 0) {
+          const canSkipDevice = sharedAuthOk;
+          // Only clear self-declared scopes if the client cannot skip device identity.
+          // If shared-auth succeeded (password/token auth), allow the declared scopes to persist.
+          if (!canSkipDevice && scopes.length > 0) {
             scopes = [];
             connectParams.scopes = scopes;
           }
-          const canSkipDevice = sharedAuthOk;
 
           if (isControlUi && !allowControlUiBypass) {
             const errorMessage = "control ui requires HTTPS or localhost (secure context)";


### PR DESCRIPTION
## Summary

When a client authenticates via shared secret (password/token) but has no device identity, the previously declared scopes were incorrectly cleared. This caused the Web UI to lose the `operator.read` scope when accessed via LAN IP, resulting in "missing scope: operator.read" errors.

## Changes

- Modified `src/gateway/server/ws-connection/message-handler.ts` to only clear scopes when shared-auth fails (i.e., when the client cannot skip device identity verification)
- When shared-auth succeeds, the declared scopes are now preserved

## Testing

- TypeScript compilation successful
- Lint check passed
- The fix is a minimal, targeted change that preserves existing behavior for device-authenticated clients while fixing the issue for shared-secret authenticated clients

Fixes openclaw/openclaw#16862

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR modifies the WebSocket connection handshake in `message-handler.ts` to preserve client-declared scopes when shared-secret authentication (password/token) succeeds but no device identity is present. The intent is to fix Web UI LAN access losing `operator.read` scope.

- **Privilege escalation risk**: The original code intentionally cleared self-declared scopes for deviceless connections (lines 300–302 comment: *"we can't bind scopes to a paired device/token, so we will clear scopes after auth to avoid self-declared permissions"*). This PR removes that safeguard for shared-auth clients, allowing any client that knows the shared secret to self-declare arbitrary scopes including `operator.admin` — bypassing the device pairing approval flow entirely. A safer approach would be to assign a fixed, limited set of scopes server-side for shared-auth-only clients rather than trusting client-declared values.
- **Existing tests will break**: At least two e2e tests (`"ignores requested scopes when device identity is omitted"` and `"allows shared token to skip device when tailscale auth is enabled"`) explicitly assert that scopes are cleared when connecting without device identity. These tests will fail with this change. The PR description mentions TypeScript compilation and lint passing but does not mention test results.

<h3>Confidence Score: 1/5</h3>

- This PR introduces a privilege escalation path and will break existing tests — it should not be merged as-is.
- The change removes a deliberate security safeguard that prevented deviceless clients from self-declaring scopes. With this change, knowing the shared secret is sufficient to claim operator.admin, bypassing device pairing. Additionally, at least two existing e2e tests will fail, suggesting the test suite was not run.
- `src/gateway/server/ws-connection/message-handler.ts` — scope-clearing logic change at lines 433–439 introduces privilege escalation and breaks tests

<sub>Last reviewed commit: 3a6f5f8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->