### PR TITLE
plugin-sdk: export PluginLogger type for plugin use

### DIFF
--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -65,6 +65,7 @@ export type {
   OpenClawPluginServiceContext,
   ProviderAuthContext,
   ProviderAuthResult,
+  PluginLogger,
 } from "../plugins/types.js";
 export type {
   GatewayRequestHandler,

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -63,9 +63,9 @@ export type {
   OpenClawPluginApi,
   OpenClawPluginService,
   OpenClawPluginServiceContext,
+  PluginLogger,
   ProviderAuthContext,
   ProviderAuthResult,
-  PluginLogger,
 } from "../plugins/types.js";
 export type {
   GatewayRequestHandler,

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -63,9 +63,9 @@ export type {
   OpenClawPluginApi,
   OpenClawPluginService,
   OpenClawPluginServiceContext,
-  PluginLogger,
   ProviderAuthContext,
   ProviderAuthResult,
+  PluginLogger,
 } from "../plugins/types.js";
 export type {
   GatewayRequestHandler,


### PR DESCRIPTION
# PR Description: plugin-sdk export PluginLogger type

## Summary

- **Problem:** Plugins cannot reference the `PluginLogger` type from the SDK; they have to declare it locally or source the type elsewhere.
- **Why it matters:** Plugin authors need the correct type for logger parameters/variables for type safety and IDE support.
- **What changed:** Re-exported `PluginLogger` in `src/plugin-sdk/index.ts` from `../plugins/types.js` so plugins can import it from `openclaw/plugin-sdk`.
- **What did NOT change (scope boundary):** No change to logger implementation, plugin runtime behavior, or other APIs.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

None. Only adds a type re-export; runtime behavior is unchanged.

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**
- If any **Yes**, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: any
- Runtime/container: Node 22+ / Bun
- Model/provider: N/A
- Integration/channel: N/A
- Relevant config: N/A

### Steps

1. In any extension, add `import type { PluginLogger } from 'openclaw/plugin-sdk'` (or the project’s jiti alias).
2. Use the type to annotate a logger parameter or variable; confirm type-check passes and IDE shows completion.

### Expected

- Type imports and resolves; no type errors.

### Actual

- (Same as expected.)

## Evidence

- [x] Type re-export added in `plugin-sdk/index.ts` alongside existing exports (e.g. `OpenClawPluginServiceContext`). Verified by importing the type in an extension.

## Human Verification (required)

- **Verified scenarios:** Imported `PluginLogger` in a plugin/extension and confirmed the type is available.
- **Edge cases checked:** Type-only re-export; no new runtime code paths.
- **What you did not verify:** Did not run full test suite across all extensions (no runtime logic change).

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- **How to disable/revert:** Remove `PluginLogger` from the `export type { ... }` list in `src/plugin-sdk/index.ts` and release/deploy.
- **Files/config to restore:** `src/plugin-sdk/index.ts` (single export line).
- **Known bad symptoms:** If a plugin depends on this type and the export is reverted, only type errors; runtime is unaffected.

## Risks and Mitigations

**None.** Pure type re-export; no implementation or behavior change.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Re-exports `PluginLogger` type from `src/plugin-sdk/index.ts`, enabling plugins to import the logger type directly from `openclaw/plugin-sdk` for proper type annotations.

- Added `PluginLogger` to the type re-export list from `../plugins/types.js` in alphabetical order (line 66)
- Type was already defined in `src/plugins/types.ts` (lines 22-27) and used internally
- No runtime behavior changes, pure type-level addition
- Improves plugin developer experience by providing proper TypeScript type definitions

<h3>Confidence Score: 5/5</h3>

- Safe to merge - pure type re-export with no runtime changes
- This is a straightforward type re-export that adds no new implementation. The `PluginLogger` type already exists and is used throughout the codebase. The change is minimal (one line), properly alphabetized, and the multiple follow-up commits show careful attention to code organization.
- No files require special attention

<sub>Last reviewed commit: c49d90c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->