### PR TITLE
fix(slack): respect replyToMode=off in statusThreadTs

### DIFF
--- a/src/slack/threading.ts
+++ b/src/slack/threading.ts
@@ -40,6 +40,8 @@ export function resolveSlackThreadTargets(params: {
 }) {
   const { incomingThreadTs, messageTs } = resolveSlackThreadContext(params);
   const replyThreadTs = incomingThreadTs ?? (params.replyToMode === "all" ? messageTs : undefined);
-  const statusThreadTs = replyThreadTs ?? messageTs;
+  // Only set statusThreadTs if we're actually threading (replyToMode is "all" or in existing thread)
+  // Don't fallback to messageTs when replyToMode is "off" or "first"
+  const statusThreadTs = params.replyToMode === "off" ? undefined : (replyThreadTs ?? messageTs);
   return { replyThreadTs, statusThreadTs };
 }


### PR DESCRIPTION
Fixes #16868

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR attempts to fix `statusThreadTs` behavior when `replyToMode="off"` by returning `undefined` instead of falling back to `messageTs`. However, the implementation has a critical issue:

- **Breaks existing tests**: Two tests in `threading.test.ts` will fail — the "threads replies when message is already threaded" test (expects `statusThreadTs` to equal `thread_ts` when in a thread) and the "keeps status threading even when reply threading is off" test (expects `statusThreadTs` to equal `messageTs` for top-level messages).
- **Overly broad condition**: The `replyToMode === "off" ? undefined` check discards `statusThreadTs` even when the message is already in a thread, which means typing indicators won't appear in the correct thread for in-thread messages.
- **Comment/code mismatch**: The comment mentions both `"off"` and `"first"` modes, but the code only handles `"off"`.

A more correct fix would be `replyThreadTs ?? (params.replyToMode === "all" ? messageTs : undefined)`, which preserves threading for in-thread messages while only suppressing the `messageTs` fallback for non-"all" modes.

<h3>Confidence Score: 1/5</h3>

- This PR introduces a regression that breaks existing tests and in-thread status behavior.
- Score of 1 reflects that the change breaks two existing unit tests and introduces incorrect behavior for messages already in a thread. The `statusThreadTs` will be `undefined` even when a thread already exists, causing typing indicators to not appear in the correct thread.
- `src/slack/threading.ts` — the `statusThreadTs` logic needs to be reworked to preserve `replyThreadTs` when the message is already in a thread.

<sub>Last reviewed commit: 4a42013</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->