### PR TITLE
Fix extra newlines in web UI when thinking toggle is off

### DIFF
--- a/ui/src/ui/chat/message-extract.test.ts
+++ b/ui/src/ui/chat/message-extract.test.ts
@@ -25,6 +25,33 @@ describe("extractTextCached", () => {
   });
 });
 
+describe("extractText", () => {
+  it("filters out empty text blocks to avoid extra newlines", () => {
+    const message = {
+      role: "assistant",
+      content: [
+        { type: "text", text: "First part" },
+        { type: "tool_use", id: "t1", name: "read", input: {} },
+        { type: "text", text: "" },
+        { type: "text", text: "Second part" },
+      ],
+    };
+    const result = extractText(message);
+    expect(result).toBe("First part\nSecond part");
+  });
+
+  it("handles content with only empty text blocks", () => {
+    const message = {
+      role: "assistant",
+      content: [
+        { type: "text", text: "" },
+        { type: "tool_use", id: "t1", name: "read", input: {} },
+      ],
+    };
+    expect(extractText(message)).toBeNull();
+  });
+});
+
 describe("extractThinkingCached", () => {
   it("matches extractThinking output", () => {
     const message = {

--- a/ui/src/ui/chat/message-extract.ts
+++ b/ui/src/ui/chat/message-extract.ts
@@ -21,7 +21,7 @@ export function extractText(message: unknown): string | null {
         }
         return null;
       })
-      .filter((v): v is string => typeof v === "string");
+      .filter((v): v is string => typeof v === "string" && v.length > 0);
     if (parts.length > 0) {
       const joined = parts.join("\n");
       const processed = role === "assistant" ? stripThinkingTags(joined) : stripEnvelope(joined);


### PR DESCRIPTION
Hey! I ran into the issue described in #16636 where assistant text gets broken up with extra newlines in the web UI when the thinking/working toggle is turned off.

The root cause is in `message-extract.ts` — when extracting text from content block arrays, empty text blocks (which can appear between tool_use blocks) pass through the string filter and end up as empty entries in the join. Since blocks are joined with `\n`, those empty entries produce visible double-newlines.

The fix adds a length check to filter out empty text blocks before joining. Also added a couple of tests covering this scenario.

Fixes #16636

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes extra newlines in web UI by filtering empty text blocks before joining with newlines. The fix adds a length check (`v.length > 0`) to the filter in `extractText()`, preventing empty strings between tool_use blocks from creating double newlines when the thinking toggle is off. Test coverage includes both the fix scenario and edge case handling.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is surgical and well-tested - it adds a simple length check to filter out empty strings, includes regression tests for both the main scenario and edge cases, and all tests pass. The change only affects display logic and cannot introduce runtime errors or break existing functionality.
- No files require special attention

<sub>Last reviewed commit: 324455b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->