### PR TITLE
fix(discord): avoid injecting empty channels in guild merge

### DIFF
--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -236,7 +236,12 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
             );
             const existing = nextGuilds[entry.guildId] ?? {};
             const mergedChannels = { ...sourceGuild.channels, ...existing.channels };
-            const mergedGuild = { ...sourceGuild, ...existing, channels: mergedChannels };
+            const mergedGuild = {
+              ...sourceGuild,
+              ...existing,
+              // Avoid injecting empty channels object which causes all messages to be dropped
+              channels: Object.keys(mergedChannels).length > 0 ? mergedChannels : undefined,
+            };
             nextGuilds[entry.guildId] = mergedGuild;
             if (source.channelKey && entry.channelId) {
               const sourceChannel = sourceGuild.channels?.[source.channelKey];


### PR DESCRIPTION
Fixes #16846

## Problem
When guilds is configured without explicit channels, an empty  is injected during merge, causing  to return , dropping all messages.

## Solution
Only set channels if there are actual entries to merge.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This one-file fix prevents the guild merge loop in `monitorDiscordProvider` from injecting an empty `channels: {}` object onto merged guild entries when neither the source guild nor the existing entry has any configured channels. Instead, `channels` is now set to `undefined` when there are no entries to merge, preserving the semantic meaning of "no channel restrictions configured." All downstream consumers already handle `channels: undefined` safely via optional chaining and `?? {}` fallbacks.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a minimal, defensive fix with no risk of regression.
- The change is a single conditional expression in one file. All downstream consumers already handle `channels: undefined` via optional chaining and nullish coalescing. The subsequent code block (lines 246-260) correctly overrides the `undefined` when there is a real channel to add. No new logic is introduced and no existing behavior paths are altered for cases where channels are already populated.
- No files require special attention.

<sub>Last reviewed commit: 26f5e45</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->