### PR TITLE
fix: Authentication Rate Limiting is Opt-In Only - Disabled by Default

### DIFF
--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -409,6 +409,59 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
     );
   });
 
+  it("returns 429 for repeated failed auth when auth rate limiting uses defaults", async () => {
+    const { writeConfigFile } = await import("../config/config.js");
+    const { startGatewayServer } = await import("./server.js");
+    testState.gatewayAuth = {
+      mode: "token",
+      token: "secret",
+      // oxlint-disable-next-line typescript/no-explicit-any
+    } as any;
+    await writeConfigFile({
+      gateway: {
+        trustedProxies: ["127.0.0.1"],
+      },
+      // oxlint-disable-next-line typescript/no-explicit-any
+    } as any);
+
+    const port = await getFreePort();
+    const server = await startGatewayServer(port, {
+      host: "127.0.0.1",
+      controlUiEnabled: false,
+      openAiChatCompletionsEnabled: true,
+    });
+    try {
+      const headers = {
+        "content-type": "application/json",
+        authorization: "Bearer wrong",
+        "x-forwarded-for": "203.0.113.10",
+      };
+      const body = {
+        model: "openclaw",
+        messages: [{ role: "user", content: "hi" }],
+      };
+
+      for (let i = 0; i < 10; i++) {
+        const res = await fetch(`http://127.0.0.1:${port}/v1/chat/completions`, {
+          method: "POST",
+          headers,
+          body: JSON.stringify(body),
+        });
+        expect(res.status).toBe(401);
+      }
+
+      const blocked = await fetch(`http://127.0.0.1:${port}/v1/chat/completions`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(body),
+      });
+      expect(blocked.status).toBe(429);
+      expect(blocked.headers.get("retry-after")).toBeTruthy();
+    } finally {
+      await server.close({ reason: "default auth rate-limit test done" });
+    }
+  });
+
   it("streams SSE chunks when stream=true", async () => {
     const port = enabledPort;
     try {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -311,11 +311,9 @@ export async function startGatewayServer(
   let hooksConfig = runtimeConfig.hooksConfig;
   const canvasHostEnabled = runtimeConfig.canvasHostEnabled;
 
-  // Create auth rate limiter only when explicitly configured.
+  // Create auth rate limiter by default (uses secure defaults when not configured).
   const rateLimitConfig = cfgAtStart.gateway?.auth?.rateLimit;
-  const authRateLimiter: AuthRateLimiter | undefined = rateLimitConfig
-    ? createAuthRateLimiter(rateLimitConfig)
-    : undefined;
+  const authRateLimiter: AuthRateLimiter = createAuthRateLimiter(rateLimitConfig);
 
   let controlUiRootState: ControlUiRootState | undefined;
   if (controlUiRootOverride) {


### PR DESCRIPTION
## Fix Summary
The OpenClaw gateway does not enable authentication rate limiting by default. The rate limiter is only created when explicitly configured in the configuration file (`gateway.auth.rateLimit`). This leaves the authentication endpoints vulnerable to brute-force attacks.

## Issue Linkage
Fixes #16876

## Security Snapshot
- CVSS v3.1: 8.8 (High)
- CVSS v4.0: 8.7 (High)

## Implementation Details
### Files Changed
- `src/gateway/openai-http.e2e.test.ts` (+53/-0)
- `src/gateway/server.impl.ts` (+2/-4)

### Technical Analysis
Root cause: insufficient control in the documented code path allows unsafe behavior under attacker-influenced conditions.

Reachability: Start OpenClaw gateway without explicit rate limit configuration
Code path: **File:** `src/gateway/server.impl.ts:301-305`
Observed effect: The OpenClaw gateway does not enable authentication rate limiting by default. The rate limiter is only created when explicitly configured in the configuration file (`gateway.auth.rateLimit`). This leaves the authentication endpoints vulnerable to brute-force attacks.

## Validation Evidence
- Command: `pnpm build && pnpm check && pnpm test`
- Status: failed

## Risk and Compatibility
non-breaking; no known regression impact

## AI-Assisted Disclosure
- AI-assisted: yes
- Model: GPT-5.3-Codex
