### PR TITLE
fix(telnyx): add direction field to call.initiated events

### DIFF
--- a/extensions/voice-call/src/providers/telnyx.ts
+++ b/extensions/voice-call/src/providers/telnyx.ts
@@ -139,7 +139,9 @@ export class TelnyxProvider implements VoiceCallProvider {
 
     switch (data.event_type) {
       case "call.initiated":
-        return { ...baseEvent, type: "call.initiated" };
+        // Inbound calls have a to.number, outbound have from.number
+        const direction = data.payload?.to?.number ? "inbound" : "outbound";
+        return { ...baseEvent, type: "call.initiated", direction, from: data.payload?.from?.number, to: data.payload?.to?.number };
 
       case "call.ringing":
         return { ...baseEvent, type: "call.ringing" };

--- a/extensions/voice-call/src/providers/telnyx.ts
+++ b/extensions/voice-call/src/providers/telnyx.ts
@@ -140,8 +140,10 @@ export class TelnyxProvider implements VoiceCallProvider {
     switch (data.event_type) {
       case "call.initiated":
         // Inbound calls have a to.number, outbound have from.number
-        const direction = data.payload?.to?.number ? "inbound" : "outbound";
-        return { ...baseEvent, type: "call.initiated", direction, from: data.payload?.from?.number, to: data.payload?.to?.number };
+        const direction: "inbound" | "outbound" = data.payload?.to?.number ? "inbound" : "outbound";
+        const from: string | undefined = data.payload?.from?.number;
+        const to: string | undefined = data.payload?.to?.number;
+        return { ...baseEvent, type: "call.initiated", direction, from, to };
 
       case "call.ringing":
         return { ...baseEvent, type: "call.ringing" };


### PR DESCRIPTION
Fixes #16601

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `direction`, `from`, and `to` fields to Telnyx `call.initiated` events. The `direction` field is required for inbound call routing and policy enforcement in the call manager.

- Previously, `call.initiated` events lacked the direction field, preventing proper inbound/outbound call handling
- Adds explicit type annotations for `direction`, `from`, and `to` fields
- Direction detection uses presence of `to.number` to distinguish inbound from outbound calls

<h3>Confidence Score: 1/5</h3>

- This PR has a critical logic error that will misclassify outbound calls as inbound
- The direction detection logic assumes outbound calls lack `to.number`, but both call types typically populate this field. This will cause all calls to be classified as inbound, breaking outbound call handling and potentially triggering incorrect policy enforcement that rejects legitimate outbound calls
- Pay close attention to `extensions/voice-call/src/providers/telnyx.ts` - the direction detection must be fixed before merging

<sub>Last reviewed commit: f00d7b3</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->