### PR TITLE
fix(tts): enable voice for BlueBubbles auto-TTS replies

### DIFF
--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -907,7 +907,8 @@ export async function maybeApplyTtsToPayload(params: {
     };
 
     const channelId = resolveChannelId(params.channel);
-    const shouldVoice = channelId === "telegram" && result.voiceCompatible === true;
+    // Enable voice for Telegram and BlueBubbles (both support native voice messages)
+    const shouldVoice = (channelId === "telegram" || channelId === "bluebubbles") && result.voiceCompatible === true;
     const finalPayload = {
       ...nextPayload,
       mediaUrl: result.audioPath,


### PR DESCRIPTION
Fixes #16848

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added BlueBubbles to the `shouldVoice` condition check on line 911 to enable native voice message support for BlueBubbles auto-TTS replies, matching existing Telegram behavior.

However, as noted in the previous thread, this is only a partial fix. The change enables voice messages when `result.voiceCompatible === true`, but `resolveOutputFormat` (line 481) only returns voice-compatible output (`TELEGRAM_OUTPUT` with `voiceCompatible: true`) for Telegram, not BlueBubbles. For BlueBubbles, it returns `DEFAULT_OUTPUT` where `voiceCompatible` is hardcoded to `false` (line 79).

This means the condition on line 911 will still evaluate to `false` for BlueBubbles when using OpenAI or ElevenLabs providers, since those providers use `output.voiceCompatible` from the resolved format (line 675). The fix only works with the Edge provider because Edge dynamically computes `voiceCompatible` via `isVoiceCompatibleAudio` on the generated file (line 607).

BlueBubbles supports MP3 and CAF formats for voice memos (verified in `extensions/bluebubbles/src/attachments.ts:137-147`). To fully enable voice messages for all providers, `resolveOutputFormat` should also return a voice-compatible output config for BlueBubbles.

<h3>Confidence Score: 3/5</h3>

- Safe to merge but only partially resolves the issue
- The change is syntactically correct and improves the situation for Edge provider users, but doesn't fully solve the underlying problem. BlueBubbles voice messages will only work with Edge TTS, not OpenAI or ElevenLabs, due to the `voiceCompatible: false` flag in `DEFAULT_OUTPUT`. This is a partial fix that helps some users but doesn't achieve the full intended behavior described in issue #16848.
- The `resolveOutputFormat` function (line 481) needs attention to add BlueBubbles voice-compatible output configuration

<sub>Last reviewed commit: 2959098</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->