### PR TITLE
fix(cron): execute missed jobs outside the lock to unblock list/status queries

### DIFF
--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -15,14 +15,13 @@ import { ensureLoaded, persist, warnIfDisabled } from "./store.js";
 import {
   applyJobResult,
   armTimer,
+  DEFAULT_JOB_TIMEOUT_MS,
   emit,
   executeJob,
   executeJobCore,
   stopTimer,
   wake,
 } from "./timer.js";
-
-const DEFAULT_JOB_TIMEOUT_MS = 10 * 60_000;
 
 async function ensureLoadedForRead(state: CronServiceState) {
   await ensureLoaded(state, { skipRecompute: true });

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -12,7 +12,17 @@ import {
 import { locked } from "./locked.js";
 import type { CronServiceState } from "./state.js";
 import { ensureLoaded, persist, warnIfDisabled } from "./store.js";
-import { armTimer, emit, executeJob, runMissedJobs, stopTimer, wake } from "./timer.js";
+import {
+  applyJobResult,
+  armTimer,
+  emit,
+  executeJob,
+  executeJobCore,
+  stopTimer,
+  wake,
+} from "./timer.js";
+
+const DEFAULT_JOB_TIMEOUT_MS = 10 * 60_000;
 
 async function ensureLoadedForRead(state: CronServiceState) {
   await ensureLoaded(state, { skipRecompute: true });
@@ -28,10 +38,15 @@ async function ensureLoadedForRead(state: CronServiceState) {
 }
 
 export async function start(state: CronServiceState) {
-  await locked(state, async () => {
+  // Phase 1: Acquire the lock briefly to load state, identify missed jobs,
+  // and mark them as running.  Missed jobs are collected but NOT executed
+  // while holding the lock — this mirrors the pattern used by `onTimer()`
+  // so that read-only queries (`list`, `status`) are never blocked by
+  // long-running job execution.
+  const missedJobs = await locked(state, async () => {
     if (!state.deps.cronEnabled) {
       state.deps.log.info({ enabled: false }, "cron: disabled");
-      return;
+      return [];
     }
     await ensureLoaded(state, { skipRecompute: true });
     const jobs = state.store?.jobs ?? [];
@@ -46,7 +61,41 @@ export async function start(state: CronServiceState) {
         startupInterruptedJobIds.add(job.id);
       }
     }
-    await runMissedJobs(state, { skipJobIds: startupInterruptedJobIds });
+
+    // Find missed jobs (same logic as runMissedJobs) but do NOT execute
+    // them while holding the lock.
+    const now = state.deps.nowMs();
+    const missed = (state.store?.jobs ?? []).filter((j) => {
+      if (!j.state) {
+        j.state = {};
+      }
+      if (!j.enabled) {
+        return false;
+      }
+      if (startupInterruptedJobIds.has(j.id)) {
+        return false;
+      }
+      if (typeof j.state.runningAtMs === "number") {
+        return false;
+      }
+      const next = j.state.nextRunAtMs;
+      if (j.schedule.kind === "at" && j.state.lastStatus) {
+        return false;
+      }
+      return typeof next === "number" && now >= next;
+    });
+
+    if (missed.length > 0) {
+      state.deps.log.info(
+        { count: missed.length, jobIds: missed.map((j) => j.id) },
+        "cron: running missed jobs after restart",
+      );
+      for (const job of missed) {
+        job.state.runningAtMs = now;
+        job.state.lastError = undefined;
+      }
+    }
+
     recomputeNextRuns(state);
     await persist(state);
     armTimer(state);
@@ -58,6 +107,102 @@ export async function start(state: CronServiceState) {
       },
       "cron: started",
     );
+
+    return missed.map((j) => ({ id: j.id, job: j }));
+  });
+
+  // Phase 2: Execute missed jobs outside the lock (same pattern as onTimer).
+  if (missedJobs.length === 0) {
+    return;
+  }
+
+  const results: Array<{
+    jobId: string;
+    status: "ok" | "error" | "skipped";
+    error?: string;
+    summary?: string;
+    sessionId?: string;
+    sessionKey?: string;
+    startedAt: number;
+    endedAt: number;
+  }> = [];
+
+  for (const { id, job } of missedJobs) {
+    const startedAt = state.deps.nowMs();
+    job.state.runningAtMs = startedAt;
+    emit(state, { jobId: job.id, action: "started", runAtMs: startedAt });
+
+    const jobTimeoutMs =
+      job.payload.kind === "agentTurn" && typeof job.payload.timeoutSeconds === "number"
+        ? job.payload.timeoutSeconds * 1_000
+        : DEFAULT_JOB_TIMEOUT_MS;
+
+    try {
+      let timeoutId: NodeJS.Timeout;
+      const result = await Promise.race([
+        executeJobCore(state, job),
+        new Promise<never>((_, reject) => {
+          timeoutId = setTimeout(
+            () => reject(new Error("cron: job execution timed out")),
+            jobTimeoutMs,
+          );
+        }),
+      ]).finally(() => clearTimeout(timeoutId!));
+      results.push({ jobId: id, ...result, startedAt, endedAt: state.deps.nowMs() });
+    } catch (err) {
+      state.deps.log.warn(
+        { jobId: id, jobName: job.name, timeoutMs: jobTimeoutMs },
+        `cron: missed job failed: ${String(err)}`,
+      );
+      results.push({
+        jobId: id,
+        status: "error",
+        error: String(err),
+        startedAt,
+        endedAt: state.deps.nowMs(),
+      });
+    }
+  }
+
+  // Phase 3: Briefly re-acquire the lock to persist results.
+  await locked(state, async () => {
+    await ensureLoaded(state, { forceReload: true, skipRecompute: true });
+
+    for (const result of results) {
+      const job = state.store?.jobs.find((j) => j.id === result.jobId);
+      if (!job) {
+        continue;
+      }
+
+      const shouldDelete = applyJobResult(state, job, {
+        status: result.status,
+        error: result.error,
+        startedAt: result.startedAt,
+        endedAt: result.endedAt,
+      });
+
+      emit(state, {
+        jobId: job.id,
+        action: "finished",
+        status: result.status,
+        error: result.error,
+        summary: result.summary,
+        sessionId: result.sessionId,
+        sessionKey: result.sessionKey,
+        runAtMs: result.startedAt,
+        durationMs: job.state.lastDurationMs,
+        nextRunAtMs: job.state.nextRunAtMs,
+      });
+
+      if (shouldDelete && state.store) {
+        state.store.jobs = state.store.jobs.filter((j) => j.id !== job.id);
+        emit(state, { jobId: job.id, action: "removed" });
+      }
+    }
+
+    recomputeNextRuns(state);
+    await persist(state);
+    armTimer(state);
   });
 }
 

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -29,7 +29,7 @@ const MIN_REFIRE_GAP_MS = 2_000;
  * on top of the per-provider / per-agent timeouts to prevent one stuck job
  * from wedging the entire cron lane.
  */
-const DEFAULT_JOB_TIMEOUT_MS = 10 * 60_000; // 10 minutes
+export const DEFAULT_JOB_TIMEOUT_MS = 10 * 60_000; // 10 minutes
 
 type TimedCronRunOutcome = CronRunOutcome &
   CronRunTelemetry & {
@@ -400,39 +400,6 @@ function collectRunnableJobs(
       skipAtIfAlreadyRan: opts?.skipAtIfAlreadyRan,
     }),
   );
-}
-
-export async function runMissedJobs(
-  state: CronServiceState,
-  opts?: { skipJobIds?: ReadonlySet<string> },
-) {
-  if (!state.store) {
-    return;
-  }
-  const now = state.deps.nowMs();
-  const skipJobIds = opts?.skipJobIds;
-  const missed = collectRunnableJobs(state, now, { skipJobIds, skipAtIfAlreadyRan: true });
-
-  if (missed.length > 0) {
-    state.deps.log.info(
-      { count: missed.length, jobIds: missed.map((j) => j.id) },
-      "cron: running missed jobs after restart",
-    );
-    for (const job of missed) {
-      await executeJob(state, job, now, { forced: false });
-    }
-  }
-}
-
-export async function runDueJobs(state: CronServiceState) {
-  if (!state.store) {
-    return;
-  }
-  const now = state.deps.nowMs();
-  const due = collectRunnableJobs(state, now);
-  for (const job of due) {
-    await executeJob(state, job, now, { forced: false });
-  }
 }
 
 export async function executeJobCore(

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -60,7 +60,7 @@ function errorBackoffMs(consecutiveErrors: number): number {
  * Handles consecutive error tracking, exponential backoff, one-shot disable,
  * and nextRunAtMs computation. Returns `true` if the job should be deleted.
  */
-function applyJobResult(
+export function applyJobResult(
   state: CronServiceState,
   job: CronJob,
   result: {
@@ -435,7 +435,7 @@ export async function runDueJobs(state: CronServiceState) {
   }
 }
 
-async function executeJobCore(
+export async function executeJobCore(
   state: CronServiceState,
   job: CronJob,
 ): Promise<CronRunOutcome & CronRunTelemetry> {


### PR DESCRIPTION
Fixes #16890

## Problem

When the cron service starts, `start()` calls `runMissedJobs()` **inside** the `locked()` block. Each missed job can take up to its full timeout (default 10 min, typically configured to 2 min) to execute. During this time, every other operation that needs the lock — including `cron.list()` and `cron.status()` used by the WebUI — is blocked waiting for the promise chain to drain.

In practice this means the WebUI shows no cron jobs (or hangs) for minutes after a gateway restart whenever there are past-due jobs.

## Root Cause

`start()` in `ops.ts` acquires the serializing lock via `locked(state, ...)` and then calls `runMissedJobs()`, which iterates over all missed jobs and awaits `executeJob()` for each one — all while still holding the lock.

By contrast, `onTimer()` in `timer.ts` already follows a correct 3-phase pattern:
1. **Lock** briefly to find due jobs and mark them as running
2. **Release** the lock and execute jobs
3. **Lock** briefly again to persist results

`start()` was not following this pattern.

## Fix

Restructure `start()` to use the same 3-phase approach as `onTimer()`:

- **Phase 1 (locked):** Load state, clear stale running markers, identify missed jobs, mark them as `runningAtMs`, persist, arm timer, then release the lock.
- **Phase 2 (unlocked):** Execute each missed job via `executeJobCore()` with a `Promise.race` timeout — identical to how `onTimer()` runs jobs.
- **Phase 3 (locked):** Re-acquire the lock, reload state, apply results via `applyJobResult()`, emit events, handle `deleteAfterRun`, recompute next runs, persist, and re-arm the timer.

To support this, `applyJobResult` and `executeJobCore` are now exported from `timer.ts` (previously module-private).

## Testing

- Verified on a production gateway with 4 cron jobs (each with 120s timeout)
- Before fix: `cron.list` / `cron.status` WebSocket calls blocked for 80-110+ seconds after restart
- After fix: cron service starts in ~1 second, WebUI immediately shows all jobs

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a lock-contention issue where `start()` held the cron serialization lock for the entire duration of missed job execution, blocking `list()` and `status()` queries used by the WebUI. The fix restructures `start()` into the same 3-phase pattern already used by `onTimer()`: (1) lock briefly to identify missed jobs and mark them as running, (2) execute jobs outside the lock, (3) lock briefly to persist results.

- The core fix is sound and mirrors the existing `onTimer()` pattern in `timer.ts`
- `applyJobResult` and `executeJobCore` are exported from `timer.ts` to support the refactored `start()`
- `runMissedJobs` and `runDueJobs` in `timer.ts` are now dead code (no remaining callers) and could be cleaned up
- `DEFAULT_JOB_TIMEOUT_MS` is duplicated between `ops.ts` and `timer.ts`

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it correctly applies an established pattern from the same codebase to fix a real lock-contention issue.
- The 3-phase lock-execute-lock pattern is already proven in `onTimer()`, and the new `start()` closely follows it. The lock serialization via `locked()` ensures Phase 3 sections cannot overlap. Minor style issues (dead code, duplicated constant) don't affect correctness.
- No files require special attention — both changes are straightforward. `src/cron/service/timer.ts` has leftover dead code that can be cleaned up in a follow-up.

<sub>Last reviewed commit: 39cc557</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->