### PR TITLE
fix(models): generic opus-4-6 forward-compat for all providers

### DIFF
--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -314,6 +314,71 @@ describe("resolveModel", () => {
     expectUnknownModelError("openai-codex", "gpt-4.1-mini");
   });
 
+  it("builds a generic forward-compat fallback for opus-4-6 on arbitrary providers", () => {
+    mockDiscoveredModel({
+      provider: "bedrock",
+      modelId: "claude-opus-4-5",
+      templateModel: {
+        id: "claude-opus-4-5",
+        name: "Claude Opus 4.5",
+        provider: "bedrock",
+        api: "bedrock-converse",
+        baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+        reasoning: true,
+        input: ["text", "image"] as const,
+        cost: { input: 3, output: 15, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 64000,
+      },
+    });
+
+    const result = resolveModel("bedrock", "claude-opus-4-6", "/tmp/agent");
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "bedrock",
+      id: "claude-opus-4-6",
+      api: "bedrock-converse",
+      baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+      reasoning: true,
+    });
+  });
+
+  it("builds a generic forward-compat fallback for opus-4-6-thinking on arbitrary providers", () => {
+    mockDiscoveredModel({
+      provider: "my-proxy",
+      modelId: "claude-opus-4-5-thinking",
+      templateModel: {
+        id: "claude-opus-4-5-thinking",
+        name: "Claude Opus 4.5 Thinking",
+        provider: "my-proxy",
+        api: "anthropic-messages",
+        baseUrl: "https://proxy.example.com",
+        reasoning: true,
+        input: ["text"] as const,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 64000,
+      },
+    });
+
+    const result = resolveModel("my-proxy", "claude-opus-4-6-thinking", "/tmp/agent");
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "my-proxy",
+      id: "claude-opus-4-6-thinking",
+      api: "anthropic-messages",
+      baseUrl: "https://proxy.example.com",
+    });
+  });
+
+  it("generic forward-compat does not fire for non-opus-4-6 models", () => {
+    const result = resolveModel("bedrock", "claude-sonnet-4-5", "/tmp/agent");
+    expect(result.model).toBeUndefined();
+    expect(result.error).toBe("Unknown model: bedrock/claude-sonnet-4-5");
+  });
+
   it("uses codex fallback even when openai-codex provider is configured", () => {
     // This test verifies the ordering: codex fallback must fire BEFORE the generic providerCfg fallback.
     // If ordering is wrong, the generic fallback would use api: "openai-responses" (the default)

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -1,6 +1,4 @@
 import { Type } from "@sinclair/typebox";
-import type { OpenClawConfig } from "../../config/config.js";
-import type { AnyAgentTool } from "./common.js";
 import { BLUEBUBBLES_GROUP_ACTIONS } from "../../channels/plugins/bluebubbles-actions.js";
 import {
   listChannelMessageActions,
@@ -13,6 +11,7 @@ import {
   CHANNEL_MESSAGE_ACTION_NAMES,
   type ChannelMessageActionName,
 } from "../../channels/plugins/types.js";
+import type { OpenClawConfig } from "../../config/config.js";
 import { loadConfig } from "../../config/config.js";
 import { GATEWAY_CLIENT_IDS, GATEWAY_CLIENT_MODES } from "../../gateway/protocol/client-info.js";
 import { getToolResult, runMessageAction } from "../../infra/outbound/message-action-runner.js";
@@ -23,6 +22,7 @@ import { normalizeMessageChannel } from "../../utils/message-channel.js";
 import { resolveSessionAgentId } from "../agent-scope.js";
 import { listChannelSupportedActions } from "../channel-tools.js";
 import { channelTargetSchema, channelTargetsSchema, stringEnum } from "../schema/typebox.js";
+import type { AnyAgentTool } from "./common.js";
 import { jsonResult, readNumberParam, readStringParam } from "./common.js";
 import { resolveGatewayOptions } from "./gateway.js";
 

--- a/src/agents/tools/telegram-actions.ts
+++ b/src/agents/tools/telegram-actions.ts
@@ -1,7 +1,7 @@
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import type { OpenClawConfig } from "../../config/config.js";
-import type { TelegramButtonStyle, TelegramInlineButtons } from "../../telegram/button-types.js";
 import { createTelegramActionGate } from "../../telegram/accounts.js";
+import type { TelegramButtonStyle, TelegramInlineButtons } from "../../telegram/button-types.js";
 import {
   resolveTelegramInlineButtonsScope,
   resolveTelegramTargetChatType,

--- a/src/channels/plugins/actions/telegram.ts
+++ b/src/channels/plugins/actions/telegram.ts
@@ -1,5 +1,3 @@
-import type { TelegramActionConfig } from "../../../config/types.telegram.js";
-import type { ChannelMessageActionAdapter, ChannelMessageActionName } from "../types.js";
 import {
   readNumberParam,
   readStringArrayParam,
@@ -7,12 +5,14 @@ import {
   readStringParam,
 } from "../../../agents/tools/common.js";
 import { handleTelegramAction } from "../../../agents/tools/telegram-actions.js";
+import type { TelegramActionConfig } from "../../../config/types.telegram.js";
 import { extractToolSend } from "../../../plugin-sdk/tool-send.js";
 import {
   createTelegramActionGate,
   listEnabledTelegramAccounts,
 } from "../../../telegram/accounts.js";
 import { isTelegramInlineButtonsEnabled } from "../../../telegram/inline-buttons.js";
+import type { ChannelMessageActionAdapter, ChannelMessageActionName } from "../types.js";
 
 const providerId = "telegram";
 

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -1,7 +1,4 @@
 import type { Message, ReactionTypeEmoji } from "@grammyjs/types";
-import type { TelegramGroupConfig, TelegramTopicConfig } from "../config/types.js";
-import type { TelegramMediaRef } from "./bot-message-context.js";
-import type { TelegramContext } from "./bot/types.js";
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { hasControlCommand } from "../auto-reply/command-detection.js";
 import {
@@ -17,6 +14,7 @@ import { resolveChannelConfigWrites } from "../channels/plugins/config-writes.js
 import { loadConfig } from "../config/config.js";
 import { writeConfigFile } from "../config/io.js";
 import { loadSessionStore, resolveStorePath } from "../config/sessions.js";
+import type { TelegramGroupConfig, TelegramTopicConfig } from "../config/types.js";
 import { danger, logVerbose, warn } from "../globals.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { readChannelAllowFromStore } from "../pairing/pairing-store.js";
@@ -28,6 +26,7 @@ import {
   normalizeAllowFromWithStore,
   type NormalizedAllowFrom,
 } from "./bot-access.js";
+import type { TelegramMediaRef } from "./bot-message-context.js";
 import { RegisterTelegramHandlerParams } from "./bot-native-commands.js";
 import { MEDIA_GROUP_TIMEOUT_MS, type MediaGroupEntry } from "./bot-updates.js";
 import { resolveMedia } from "./bot/delivery.js";
@@ -37,6 +36,7 @@ import {
   resolveTelegramForumThreadId,
   resolveTelegramGroupAllowFromContext,
 } from "./bot/helpers.js";
+import type { TelegramContext } from "./bot/types.js";
 import {
   evaluateTelegramGroupBaseAccess,
   evaluateTelegramGroupPolicyAccess,

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -5,8 +5,6 @@ import type {
   ReactionTypeEmoji,
 } from "@grammyjs/types";
 import { type ApiClientOptions, Bot, HttpError, InputFile } from "grammy";
-import type { RetryConfig } from "../infra/retry.js";
-import type { TelegramInlineButtons } from "./button-types.js";
 import { loadConfig } from "../config/config.js";
 import { resolveMarkdownTableMode } from "../config/markdown-tables.js";
 import { logVerbose } from "../globals.js";
@@ -14,6 +12,7 @@ import { recordChannelActivity } from "../infra/channel-activity.js";
 import { isDiagnosticFlagEnabled } from "../infra/diagnostic-flags.js";
 import { formatErrorMessage, formatUncaughtError } from "../infra/errors.js";
 import { createTelegramRetryRunner } from "../infra/retry-policy.js";
+import type { RetryConfig } from "../infra/retry.js";
 import { redactSensitiveText } from "../logging/redact.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { mediaKindFromMime } from "../media/constants.js";
@@ -23,6 +22,7 @@ import { loadWebMedia } from "../web/media.js";
 import { type ResolvedTelegramAccount, resolveTelegramAccount } from "./accounts.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { buildTelegramThreadParams } from "./bot/helpers.js";
+import type { TelegramInlineButtons } from "./button-types.js";
 import { splitTelegramCaption } from "./caption.js";
 import { resolveTelegramFetch } from "./fetch.js";
 import { renderTelegramHtmlText } from "./format.js";


### PR DESCRIPTION
## Summary

Fixes #13281

The existing opus-4-6 forward-compat only works for `anthropic` and `google-antigravity` providers. Any other provider whose pi-ai catalog has `claude-opus-4-5` but not yet `claude-opus-4-6` (e.g. bedrock, vertex, custom Anthropic proxies) gets `Unknown model`.

- Adds a generic catch-all `resolveGenericOpus46ForwardCompatModel` that runs after the provider-specific handlers
- Works for any provider by searching the template under the actual provider name (not hardcoded)
- Handles all opus-4-6 variants including `-thinking` suffixes
- Provider-specific handlers (anthropic, antigravity) take priority and remain unchanged

## Test plan

- [x] Added 3 tests: bedrock opus-4-6, custom proxy opus-4-6-thinking, non-opus model unaffected
- [x] All 18 model tests pass (`pnpm test -- src/agents/pi-embedded-runner/model.test.ts`)
- [x] Existing provider-specific handlers unchanged — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds generic opus-4-6 forward compatibility for all providers (bedrock, vertex, custom proxies) by falling back to opus-4-5 templates when opus-4-6 models aren't in the catalog. Provider-specific handlers (anthropic, antigravity) take precedence.

**Key changes:**
- New `resolveGenericOpus46ForwardCompatModel` function handles any provider
- Supports both dash (`claude-opus-4-6`) and dot (`claude-opus-4.6`) version formats
- Handles `-thinking` suffix variants  
- Added 3 test cases covering bedrock, custom proxy, and non-opus models
- Chain order ensures provider-specific handlers run first

**Issue found:**
- Dot-versioned models (`claude-opus-4.6-*`) incorrectly match dash stem first due to `startsWith` crossing version format boundaries (src/agents/model-forward-compat.ts:257)

<h3>Confidence Score: 3/5</h3>

- Safe to merge with awareness of template matching issue
- Score reflects well-tested functionality with comprehensive test coverage, but the dot/dash version boundary bug (line 257) causes inefficient template lookups and could select wrong templates if both formats exist in registry. Fix would be straightforward but not critical since fallback chain eventually finds correct template.
- src/agents/model-forward-compat.ts line 257 needs the version format boundary fix

<sub>Last reviewed commit: 0466335</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->