### PR TITLE
fix(threads): inject thread starter context on every turn, not just new sessions

### DIFF
--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -169,6 +169,37 @@ describe("runPreparedReply media-only handling", () => {
     expect(call?.followupRun.prompt).toContain("[User sent media without caption]");
   });
 
+  it("injects thread starter context even when isNewSession is false", async () => {
+    const result = await runPreparedReply(
+      baseParams({
+        ctx: {
+          Body: "hello",
+          RawBody: "hello",
+          CommandBody: "hello",
+          ThreadStarterBody: "Original thread message",
+          OriginatingChannel: "slack",
+          OriginatingTo: "C123",
+          ChatType: "group",
+        },
+        sessionCtx: {
+          Body: "hello",
+          BodyStripped: "hello",
+          Provider: "slack",
+          ChatType: "group",
+          OriginatingChannel: "slack",
+          OriginatingTo: "C123",
+        },
+        isNewSession: false,
+      }),
+    );
+    expect(result).toEqual({ text: "ok" });
+
+    const call = vi.mocked(runReplyAgent).mock.calls[0]?.[0];
+    expect(call).toBeTruthy();
+    expect(call?.followupRun.prompt).toContain("[Thread starter - for context]");
+    expect(call?.followupRun.prompt).toContain("Original thread message");
+  });
+
   it("returns the empty-body reply when there is no text and no media", async () => {
     const result = await runPreparedReply(
       baseParams({

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -262,7 +262,7 @@ export async function runPreparedReply(
   const threadContextNote =
     isNewSession && threadHistoryBody
       ? `[Thread history - for context]\n${threadHistoryBody}`
-      : isNewSession && threadStarterBody
+      : threadStarterBody
         ? `[Thread starter - for context]\n${threadStarterBody}`
         : undefined;
   const skillResult = await ensureSkillSnapshot({


### PR DESCRIPTION
## Summary

Fixes #4927

The `ThreadStarterBody` injection in `get-reply-run.ts` was gated by `isNewSession`, which means follow-up messages in a thread lost the parent message context. This caused the bot to have no knowledge of what started the thread after the first reply.

**Root cause:** When the first thread reply creates the session, `isNewSession = true` and the thread starter is injected. But subsequent messages find the session already exists, so `isNewSession = false` and the thread starter body is silently dropped — even though the Slack message handler correctly fetches it for every thread message.

**Fix:** Remove the `isNewSession` gate from the `threadStarterBody` branch. The thread starter is a small context note (just the parent message text) that should be available on every turn. The `threadHistoryBody` (full thread history dump) retains the `isNewSession` gate since it's large and only needed once.

This affects all channels with thread support (Slack, Discord) that use `inheritParent: true`.

## Test plan

- [x] Existing thread tests pass (`pnpm test -- src/auto-reply/reply/get-reply-run.media-only.test.ts src/slack/monitor.tool-result.threads-top-level-replies-replytomode-is-all.test.ts`)
- [x] Verified thread starter is always populated by Slack/Discord prepare handlers for thread messages
- [x] `threadHistoryBody` still gated by `isNewSession` (no change in behavior for large history dumps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removed the `isNewSession` gate from `threadStarterBody` injection so that thread parent context is available on every turn, not just the first reply. Previously, follow-up messages in threads lost context of the parent message that started the thread. The `threadHistoryBody` (full thread history) correctly retains the `isNewSession` gate since it's large and only needed once.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a minimal, well-targeted fix that removes an incorrect conditional gate. The logic is sound: `threadStarterBody` is a small context note (just the parent message text) that should be available on every turn in a thread, while `threadHistoryBody` (full history dump) correctly remains gated by `isNewSession`. The test coverage is good with a new test specifically validating the fix, and the change aligns with how Slack/Discord handlers populate thread starter context for every thread message.
- No files require special attention

<sub>Last reviewed commit: b92b28a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->