### PR TITLE
Fix text truncation splitting surrogate pairs in web-fetch, subagents, and channel metadata

### DIFF
--- a/src/agents/tools/subagents-tool.ts
+++ b/src/agents/tools/subagents-tool.ts
@@ -3,6 +3,7 @@ import crypto from "node:crypto";
 import type { SessionEntry } from "../../config/sessions.js";
 import type { AnyAgentTool } from "./common.js";
 import { clearSessionQueues } from "../../auto-reply/reply/queue.js";
+import { truncateUtf16Safe } from "../../utils.js";
 import { loadConfig } from "../../config/config.js";
 import { loadSessionStore, resolveStorePath, updateSessionStore } from "../../config/sessions.js";
 import { callGateway } from "../../gateway/call.js";
@@ -101,7 +102,7 @@ function truncate(text: string, maxLength: number) {
   if (text.length <= maxLength) {
     return text;
   }
-  return `${text.slice(0, maxLength).trimEnd()}...`;
+  return `${truncateUtf16Safe(text, maxLength).trimEnd()}...`;
 }
 
 function resolveRunLabel(entry: SubagentRunRecord, fallback = "subagent") {

--- a/src/agents/tools/web-fetch-utils.truncate.test.ts
+++ b/src/agents/tools/web-fetch-utils.truncate.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { truncateText } from "./web-fetch-utils.js";
+
+describe("truncateText surrogate safety", () => {
+  it("does not truncate short text", () => {
+    const result = truncateText("hello", 10);
+    expect(result).toEqual({ text: "hello", truncated: false });
+  });
+
+  it("truncates long text", () => {
+    const result = truncateText("hello world", 5);
+    expect(result.truncated).toBe(true);
+    expect(result.text.length).toBeLessThanOrEqual(5);
+  });
+
+  it("does not break surrogate pairs (emoji)", () => {
+    // 🎉 is U+1F389, encoded as 2 UTF-16 code units
+    const text = "ab🎉cd";
+    // text.length is 6 (a, b, \uD83C, \uDF89, c, d)
+    // Truncating at 3 with naive slice would split the emoji
+    const result = truncateText(text, 3);
+    expect(result.truncated).toBe(true);
+    // Must not contain a lone high surrogate
+    expect(result.text).not.toMatch(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/);
+    // Must not contain a lone low surrogate
+    expect(result.text).not.toMatch(/(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/);
+  });
+
+  it("handles CJK + emoji mix", () => {
+    const text = "你好🌍世界test";
+    const result = truncateText(text, 4);
+    expect(result.truncated).toBe(true);
+    expect(result.text).not.toMatch(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/);
+  });
+});

--- a/src/agents/tools/web-fetch-utils.ts
+++ b/src/agents/tools/web-fetch-utils.ts
@@ -1,3 +1,5 @@
+import { truncateUtf16Safe } from "../../utils.js";
+
 export type ExtractMode = "markdown" | "text";
 
 let readabilityDepsPromise:
@@ -104,7 +106,7 @@ export function truncateText(
   if (value.length <= maxChars) {
     return { text: value, truncated: false };
   }
-  return { text: value.slice(0, maxChars), truncated: true };
+  return { text: truncateUtf16Safe(value, maxChars), truncated: true };
 }
 
 export async function extractReadableContent(params: {

--- a/src/security/channel-metadata.truncate.test.ts
+++ b/src/security/channel-metadata.truncate.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { buildUntrustedChannelMetadata } from "./channel-metadata.js";
+
+describe("channel-metadata truncation surrogate safety", () => {
+  it("does not break emoji in metadata entries", () => {
+    // Create an entry with emoji near the truncation boundary
+    const emoji = "🎉";
+    const long = "a".repeat(398) + emoji;
+    const result = buildUntrustedChannelMetadata({
+      source: "test",
+      label: "test",
+      entries: [long],
+    });
+    expect(result).toBeDefined();
+    // Must not contain lone surrogates
+    expect(result).not.toMatch(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/);
+    expect(result).not.toMatch(/(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/);
+  });
+});

--- a/src/security/channel-metadata.ts
+++ b/src/security/channel-metadata.ts
@@ -1,3 +1,4 @@
+import { truncateUtf16Safe } from "../utils.js";
 import { wrapExternalContent } from "./external-content.js";
 
 const DEFAULT_MAX_CHARS = 800;
@@ -14,7 +15,7 @@ function truncateText(value: string, maxChars: number): string {
   if (value.length <= maxChars) {
     return value;
   }
-  const trimmed = value.slice(0, Math.max(0, maxChars - 3)).trimEnd();
+  const trimmed = truncateUtf16Safe(value, Math.max(0, maxChars - 3)).trimEnd();
   return `${trimmed}...`;
 }
 


### PR DESCRIPTION
Several `truncateText` helpers use raw `String.slice()` which can split a surrogate pair (emoji like 🎉, CJK extension B+) and produce lone surrogates in the output. The cron tool and cron normalizer already use `truncateUtf16Safe` for this; this PR aligns the remaining call sites.

**Affected files:**
- `src/agents/tools/web-fetch-utils.ts` — `truncateText` used by `web_fetch` tool output
- `src/agents/tools/subagents-tool.ts` — `truncate` used for subagent result summaries
- `src/security/channel-metadata.ts` — `truncateText` used for untrusted channel metadata

**Fix:** Replace `value.slice(0, n)` with `truncateUtf16Safe(value, n)` from `src/utils.ts`, which already handles surrogate boundary detection.

**Tests:** 5 new test cases across two files verifying emoji and CJK text are not corrupted at truncation boundaries.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces raw `String.slice()` truncation with the existing `truncateUtf16Safe` utility in three call sites (`web-fetch-utils.ts`, `subagents-tool.ts`, `channel-metadata.ts`) to prevent splitting UTF-16 surrogate pairs (emoji, CJK extension B+) during text truncation. This aligns these helpers with the cron tool and cron normalizer, which already use the safe variant.

- **`web-fetch-utils.ts`**: `truncateText` now uses `truncateUtf16Safe` instead of `value.slice(0, maxChars)`
- **`subagents-tool.ts`**: `truncate` helper now uses `truncateUtf16Safe` instead of `text.slice(0, maxLength)`
- **`channel-metadata.ts`**: `truncateText` for untrusted metadata now uses `truncateUtf16Safe` instead of `value.slice(0, ...)`
- Two new test files with 5 test cases verify that emoji and mixed CJK/emoji text are not corrupted at truncation boundaries

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it makes minimal, well-scoped changes that replace unsafe string slicing with an already-proven utility function.
- All three changes are mechanical substitutions of `String.slice()` with the existing `truncateUtf16Safe` utility that is already used elsewhere in the codebase. The utility's behavior is well-defined and tested. The new test files provide adequate coverage of the surrogate pair safety invariant. No behavioral regressions are introduced — the only difference is that truncation now backs off by one character when it would otherwise split a surrogate pair.
- No files require special attention

<sub>Last reviewed commit: b014183</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->