### PR TITLE
fix(tools): route web_search requests through HTTP proxy env vars

### DIFF
--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -1,6 +1,4 @@
 import { Type } from "@sinclair/typebox";
-import type { OpenClawConfig } from "../../config/config.js";
-import type { AnyAgentTool } from "./common.js";
 import { BLUEBUBBLES_GROUP_ACTIONS } from "../../channels/plugins/bluebubbles-actions.js";
 import {
   listChannelMessageActions,
@@ -13,6 +11,7 @@ import {
   CHANNEL_MESSAGE_ACTION_NAMES,
   type ChannelMessageActionName,
 } from "../../channels/plugins/types.js";
+import type { OpenClawConfig } from "../../config/config.js";
 import { loadConfig } from "../../config/config.js";
 import { GATEWAY_CLIENT_IDS, GATEWAY_CLIENT_MODES } from "../../gateway/protocol/client-info.js";
 import { getToolResult, runMessageAction } from "../../infra/outbound/message-action-runner.js";
@@ -23,6 +22,7 @@ import { normalizeMessageChannel } from "../../utils/message-channel.js";
 import { resolveSessionAgentId } from "../agent-scope.js";
 import { listChannelSupportedActions } from "../channel-tools.js";
 import { channelTargetSchema, channelTargetsSchema, stringEnum } from "../schema/typebox.js";
+import type { AnyAgentTool } from "./common.js";
 import { jsonResult, readNumberParam, readStringParam } from "./common.js";
 import { resolveGatewayOptions } from "./gateway.js";
 

--- a/src/agents/tools/telegram-actions.ts
+++ b/src/agents/tools/telegram-actions.ts
@@ -1,7 +1,7 @@
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import type { OpenClawConfig } from "../../config/config.js";
-import type { TelegramButtonStyle, TelegramInlineButtons } from "../../telegram/button-types.js";
 import { createTelegramActionGate } from "../../telegram/accounts.js";
+import type { TelegramButtonStyle, TelegramInlineButtons } from "../../telegram/button-types.js";
 import {
   resolveTelegramInlineButtonsScope,
   resolveTelegramTargetChatType,

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -1,4 +1,5 @@
 import { Type } from "@sinclair/typebox";
+import { ProxyAgent } from "undici";
 import { formatCliCommand } from "../../cli/command-format.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { wrapWebContent } from "../../security/external-content.js";
@@ -31,6 +32,24 @@ const OPENROUTER_KEY_PREFIXES = ["sk-or-"];
 
 const XAI_API_ENDPOINT = "https://api.x.ai/v1/responses";
 const DEFAULT_GROK_MODEL = "grok-4-1-fast";
+
+function resolveSearchProxyUrl(): string | undefined {
+  return (
+    process.env.HTTPS_PROXY ||
+    process.env.https_proxy ||
+    process.env.HTTP_PROXY ||
+    process.env.http_proxy ||
+    undefined
+  );
+}
+
+function resolveSearchDispatcher(): ProxyAgent | undefined {
+  const proxyUrl = resolveSearchProxyUrl();
+  if (!proxyUrl) {
+    return undefined;
+  }
+  return new ProxyAgent(proxyUrl);
+}
 
 const SEARCH_CACHE = new Map<string, CacheEntry<Record<string, unknown>>>();
 const BRAVE_FRESHNESS_SHORTCUTS = new Set(["pd", "pw", "pm", "py"]);
@@ -473,6 +492,7 @@ async function runPerplexitySearch(params: {
     body.search_recency_filter = recencyFilter;
   }
 
+  const dispatcher = resolveSearchDispatcher();
   const res = await fetch(endpoint, {
     method: "POST",
     headers: {
@@ -483,7 +503,8 @@ async function runPerplexitySearch(params: {
     },
     body: JSON.stringify(body),
     signal: withTimeout(undefined, params.timeoutSeconds * 1000),
-  });
+    ...(dispatcher ? { dispatcher } : {}),
+  } as RequestInit);
 
   if (!res.ok) {
     const detailResult = await readResponseText(res, { maxBytes: 64_000 });
@@ -525,6 +546,7 @@ async function runGrokSearch(params: {
   // citations are returned automatically when available — we just parse
   // them from the response without requesting them explicitly (#12910).
 
+  const dispatcher = resolveSearchDispatcher();
   const res = await fetch(XAI_API_ENDPOINT, {
     method: "POST",
     headers: {
@@ -533,7 +555,8 @@ async function runGrokSearch(params: {
     },
     body: JSON.stringify(body),
     signal: withTimeout(undefined, params.timeoutSeconds * 1000),
-  });
+    ...(dispatcher ? { dispatcher } : {}),
+  } as RequestInit);
 
   if (!res.ok) {
     const detailResult = await readResponseText(res, { maxBytes: 64_000 });
@@ -657,6 +680,7 @@ async function runWebSearch(params: {
     url.searchParams.set("freshness", params.freshness);
   }
 
+  const dispatcher = resolveSearchDispatcher();
   const res = await fetch(url.toString(), {
     method: "GET",
     headers: {
@@ -664,7 +688,8 @@ async function runWebSearch(params: {
       "X-Subscription-Token": params.apiKey,
     },
     signal: withTimeout(undefined, params.timeoutSeconds * 1000),
-  });
+    ...(dispatcher ? { dispatcher } : {}),
+  } as RequestInit);
 
   if (!res.ok) {
     const detailResult = await readResponseText(res, { maxBytes: 64_000 });

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -43,12 +43,20 @@ function resolveSearchProxyUrl(): string | undefined {
   );
 }
 
+let cachedDispatcher: ProxyAgent | undefined;
+let cachedProxyUrl: string | undefined;
+
 function resolveSearchDispatcher(): ProxyAgent | undefined {
   const proxyUrl = resolveSearchProxyUrl();
   if (!proxyUrl) {
     return undefined;
   }
-  return new ProxyAgent(proxyUrl);
+  if (cachedDispatcher && cachedProxyUrl === proxyUrl) {
+    return cachedDispatcher;
+  }
+  cachedProxyUrl = proxyUrl;
+  cachedDispatcher = new ProxyAgent(proxyUrl);
+  return cachedDispatcher;
 }
 
 const SEARCH_CACHE = new Map<string, CacheEntry<Record<string, unknown>>>();

--- a/src/channels/plugins/actions/telegram.ts
+++ b/src/channels/plugins/actions/telegram.ts
@@ -1,5 +1,3 @@
-import type { TelegramActionConfig } from "../../../config/types.telegram.js";
-import type { ChannelMessageActionAdapter, ChannelMessageActionName } from "../types.js";
 import {
   readNumberParam,
   readStringArrayParam,
@@ -7,12 +5,14 @@ import {
   readStringParam,
 } from "../../../agents/tools/common.js";
 import { handleTelegramAction } from "../../../agents/tools/telegram-actions.js";
+import type { TelegramActionConfig } from "../../../config/types.telegram.js";
 import { extractToolSend } from "../../../plugin-sdk/tool-send.js";
 import {
   createTelegramActionGate,
   listEnabledTelegramAccounts,
 } from "../../../telegram/accounts.js";
 import { isTelegramInlineButtonsEnabled } from "../../../telegram/inline-buttons.js";
+import type { ChannelMessageActionAdapter, ChannelMessageActionName } from "../types.js";
 
 const providerId = "telegram";
 

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -1,7 +1,4 @@
 import type { Message, ReactionTypeEmoji } from "@grammyjs/types";
-import type { TelegramGroupConfig, TelegramTopicConfig } from "../config/types.js";
-import type { TelegramMediaRef } from "./bot-message-context.js";
-import type { TelegramContext } from "./bot/types.js";
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { hasControlCommand } from "../auto-reply/command-detection.js";
 import {
@@ -17,6 +14,7 @@ import { resolveChannelConfigWrites } from "../channels/plugins/config-writes.js
 import { loadConfig } from "../config/config.js";
 import { writeConfigFile } from "../config/io.js";
 import { loadSessionStore, resolveStorePath } from "../config/sessions.js";
+import type { TelegramGroupConfig, TelegramTopicConfig } from "../config/types.js";
 import { danger, logVerbose, warn } from "../globals.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { readChannelAllowFromStore } from "../pairing/pairing-store.js";
@@ -28,6 +26,7 @@ import {
   normalizeAllowFromWithStore,
   type NormalizedAllowFrom,
 } from "./bot-access.js";
+import type { TelegramMediaRef } from "./bot-message-context.js";
 import { RegisterTelegramHandlerParams } from "./bot-native-commands.js";
 import { MEDIA_GROUP_TIMEOUT_MS, type MediaGroupEntry } from "./bot-updates.js";
 import { resolveMedia } from "./bot/delivery.js";
@@ -37,6 +36,7 @@ import {
   resolveTelegramForumThreadId,
   resolveTelegramGroupAllowFromContext,
 } from "./bot/helpers.js";
+import type { TelegramContext } from "./bot/types.js";
 import {
   evaluateTelegramGroupBaseAccess,
   evaluateTelegramGroupPolicyAccess,

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -5,8 +5,6 @@ import type {
   ReactionTypeEmoji,
 } from "@grammyjs/types";
 import { type ApiClientOptions, Bot, HttpError, InputFile } from "grammy";
-import type { RetryConfig } from "../infra/retry.js";
-import type { TelegramInlineButtons } from "./button-types.js";
 import { loadConfig } from "../config/config.js";
 import { resolveMarkdownTableMode } from "../config/markdown-tables.js";
 import { logVerbose } from "../globals.js";
@@ -14,6 +12,7 @@ import { recordChannelActivity } from "../infra/channel-activity.js";
 import { isDiagnosticFlagEnabled } from "../infra/diagnostic-flags.js";
 import { formatErrorMessage, formatUncaughtError } from "../infra/errors.js";
 import { createTelegramRetryRunner } from "../infra/retry-policy.js";
+import type { RetryConfig } from "../infra/retry.js";
 import { redactSensitiveText } from "../logging/redact.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { mediaKindFromMime } from "../media/constants.js";
@@ -23,6 +22,7 @@ import { loadWebMedia } from "../web/media.js";
 import { type ResolvedTelegramAccount, resolveTelegramAccount } from "./accounts.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { buildTelegramThreadParams } from "./bot/helpers.js";
+import type { TelegramInlineButtons } from "./button-types.js";
 import { splitTelegramCaption } from "./caption.js";
 import { resolveTelegramFetch } from "./fetch.js";
 import { renderTelegramHtmlText } from "./format.js";


### PR DESCRIPTION
## Summary

Fixes #8534
Related: #15869

The `web_search` tool uses bare `fetch()` which doesn't respect HTTP proxy environment variables (`HTTP_PROXY`, `HTTPS_PROXY`, `http_proxy`, `https_proxy`). This causes "fetch failed" errors in environments behind a proxy (WSL2, corporate networks, China).

Node.js 22's built-in `fetch()` doesn't automatically pick up proxy env vars — it needs an explicit `dispatcher` from undici's `ProxyAgent`.

**Fix:** When proxy env vars are set, create an undici `ProxyAgent` and pass it as the `dispatcher` to all `fetch()` calls (Brave Search, Perplexity, and Grok/xAI).

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm build` succeeds (type-check + bundle)
- [x] All 3 fetch call sites updated: Brave, Perplexity, Grok
- [x] When no proxy env vars set, behavior unchanged (dispatcher is undefined, not passed)
- [x] Follows same pattern as proxy support in other tools (SSRF guard, Discord provider)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds HTTP proxy support to the `web_search` tool by reading `HTTPS_PROXY`/`HTTP_PROXY` environment variables and passing an undici `ProxyAgent` as `dispatcher` to all three fetch call sites (Brave Search, Perplexity, Grok/xAI). Includes a lazy-cached singleton pattern so the `ProxyAgent` is reused across requests.

- All three fetch call sites (`runPerplexitySearch`, `runGrokSearch`, `runWebSearch`) are updated consistently with the same dispatcher pattern
- The `ProxyAgent` is cached at module level and only recreated if the proxy URL changes, avoiding per-request connection pool allocation
- When no proxy env vars are set, the behavior is unchanged (`dispatcher` is `undefined` and not spread into the options)
- Follows the same proxy patterns used elsewhere in the codebase (`src/telegram/proxy.ts`, `extensions/zalo/src/proxy.ts`)

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it adds proxy support with minimal risk and no behavioral change when proxy env vars are absent.
- The change is narrowly scoped to a single file, follows established patterns from other proxy implementations in the codebase (Telegram, Zalo), correctly caches the ProxyAgent, and has no effect when proxy env vars are unset. The `as RequestInit` cast is the standard approach for passing `dispatcher` to Node 22's fetch. No logic or security issues found.
- No files require special attention.

<sub>Last reviewed commit: 49b915d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->