### PR TITLE
Fix Zalo webhook secret comparison vulnerable to timing attacks

### DIFF
--- a/extensions/zalo/src/monitor.ts
+++ b/extensions/zalo/src/monitor.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { OpenClawConfig, MarkdownTableMode } from "openclaw/plugin-sdk";
 import {
@@ -47,6 +48,18 @@ export type ZaloMonitorOptions = {
 export type ZaloMonitorResult = {
   stop: () => void;
 };
+
+/**
+ * Constant-time string comparison to prevent timing attacks on webhook secrets.
+ */
+function safeEqualSecret(a: string, b: string): boolean {
+  const bufA = Buffer.from(a, "utf-8");
+  const bufB = Buffer.from(b, "utf-8");
+  if (bufA.length !== bufB.length) {
+    return false;
+  }
+  return timingSafeEqual(bufA, bufB);
+}
 
 const ZALO_TEXT_LIMIT = 2000;
 const DEFAULT_MEDIA_MAX_MB = 5;
@@ -104,7 +117,7 @@ export async function handleZaloWebhookRequest(
   }
 
   const headerToken = String(req.headers["x-bot-api-secret-token"] ?? "");
-  const matching = targets.filter((entry) => entry.secret === headerToken);
+  const matching = targets.filter((entry) => safeEqualSecret(entry.secret, headerToken));
   if (matching.length === 0) {
     res.statusCode = 401;
     res.end("unauthorized");

--- a/extensions/zalo/src/monitor.webhook-auth.test.ts
+++ b/extensions/zalo/src/monitor.webhook-auth.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { timingSafeEqual } from "node:crypto";
+
+/**
+ * Mirror of the safeEqualSecret helper added to monitor.ts.
+ * Tests the logic in isolation since the monitor handler is not easily
+ * unit-callable without full runtime wiring.
+ */
+function safeEqualSecret(a: string, b: string): boolean {
+  const bufA = Buffer.from(a, "utf-8");
+  const bufB = Buffer.from(b, "utf-8");
+  if (bufA.length !== bufB.length) {
+    return false;
+  }
+  return timingSafeEqual(bufA, bufB);
+}
+
+describe("Zalo webhook secret comparison", () => {
+  it("returns true for matching secrets", () => {
+    expect(safeEqualSecret("my-secret-token", "my-secret-token")).toBe(true);
+  });
+
+  it("returns false for mismatched secrets", () => {
+    expect(safeEqualSecret("my-secret-token", "wrong-token-here")).toBe(false);
+  });
+
+  it("returns false for different lengths", () => {
+    expect(safeEqualSecret("short", "a-much-longer-secret")).toBe(false);
+  });
+
+  it("handles empty strings", () => {
+    expect(safeEqualSecret("", "")).toBe(true);
+    expect(safeEqualSecret("", "non-empty")).toBe(false);
+  });
+
+  it("handles unicode secrets", () => {
+    expect(safeEqualSecret("密码🔑", "密码🔑")).toBe(true);
+    expect(safeEqualSecret("密码🔑", "密码🔒")).toBe(false);
+  });
+});


### PR DESCRIPTION
The Zalo monitor webhook handler compares the incoming `x-bot-api-secret-token` header against the configured secret using plain `===` equality. This is susceptible to timing side-channel attacks that can incrementally recover the secret.

Other extensions already use constant-time comparison for webhook secrets:
- BlueBubbles → `timingSafeEqual`
- LINE → `crypto.timingSafeEqual`  
- Browser HTTP auth → `safeEqualSecret`

This PR adds a local `safeEqualSecret` helper using `crypto.timingSafeEqual` and wires it into the webhook target matching.

**Tests:** 5 new test cases covering matching, mismatched, different-length, empty, and unicode secrets. Existing webhook tests continue to pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces the plain `===` webhook secret comparison in the Zalo extension with a constant-time `safeEqualSecret` helper using `crypto.timingSafeEqual`, mitigating timing side-channel attacks. The implementation follows the same pattern used by BlueBubbles and the shared `src/security/secret-equal.ts` utility. Since that utility isn't exported via the plugin SDK, the local duplication is justified.

- Security fix in `monitor.ts`: webhook secret comparison now uses `timingSafeEqual` instead of `===`
- New test file tests a duplicated copy of the helper rather than the production code; existing integration tests in `monitor.webhook.test.ts` already exercise the real path

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it's a straightforward, well-scoped security hardening change.
- The core change (replacing `===` with `timingSafeEqual`) is correct, follows established codebase patterns, and is minimal in scope. The only concern is the test file testing a copy rather than the production code, which is a minor quality issue but doesn't affect correctness.
- The test file `extensions/zalo/src/monitor.webhook-auth.test.ts` tests a duplicated copy of the function rather than the actual production code.

<sub>Last reviewed commit: f20bbf4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->