### PR TITLE
fix(agents): don't force store=true for Codex responses

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.e2e.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.e2e.test.ts
@@ -137,4 +137,27 @@ describe("applyExtraParamsToAgent", () => {
 
     expect(payload.store).toBe(false);
   });
+
+  it("does not force store=true for Codex responses (Codex requires store=false)", () => {
+    const payload = { store: false };
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      options?.onPayload?.(payload);
+      return new AssistantMessageEventStream();
+    };
+    const agent = { streamFn: baseStreamFn };
+
+    applyExtraParamsToAgent(agent, undefined, "openai-codex", "codex-mini-latest");
+
+    const model = {
+      api: "openai-codex-responses",
+      provider: "openai-codex",
+      id: "codex-mini-latest",
+      baseUrl: "https://chatgpt.com/backend-api/codex/responses",
+    } as Model<"openai-codex-responses">;
+    const context: Context = { messages: [] };
+
+    void agent.streamFn?.(model, context, {});
+
+    expect(payload.store).toBe(false);
+  });
 });

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -8,8 +8,10 @@ const OPENROUTER_APP_HEADERS: Record<string, string> = {
   "HTTP-Referer": "https://openclaw.ai",
   "X-Title": "OpenClaw",
 };
-const OPENAI_RESPONSES_APIS = new Set(["openai-responses", "openai-codex-responses"]);
-const OPENAI_RESPONSES_PROVIDERS = new Set(["openai", "openai-codex"]);
+// NOTE: We only force `store=true` for *direct* OpenAI Responses.
+// Codex responses (chatgpt.com/backend-api/codex/responses) require `store=false`.
+const OPENAI_RESPONSES_APIS = new Set(["openai-responses"]);
+const OPENAI_RESPONSES_PROVIDERS = new Set(["openai"]);
 
 /**
  * Resolve provider-specific extra params from model config.

--- a/src/auto-reply/reply/commands.test.ts
+++ b/src/auto-reply/reply/commands.test.ts
@@ -377,7 +377,7 @@ describe("handleCommands subagents", () => {
     const params = buildParams("/subagents list", cfg);
     const result = await handleCommands(params);
     expect(result.shouldContinue).toBe(false);
-    expect(result.reply?.text).toContain("tokens 1k (in 12 / out 1k)");
+    expect(result.reply?.text).toMatch(/tokens 1(\.0)?k \(in 12 \/ out 1(\.0)?k\)/);
     expect(result.reply?.text).toContain("prompt/cache 197k");
     expect(result.reply?.text).not.toContain("1k io");
   });

--- a/src/infra/process-respawn.test.ts
+++ b/src/infra/process-respawn.test.ts
@@ -34,6 +34,14 @@ afterEach(() => {
   spawnMock.mockReset();
 });
 
+function clearSupervisorHints() {
+  delete process.env.LAUNCH_JOB_LABEL;
+  delete process.env.LAUNCH_JOB_NAME;
+  delete process.env.INVOCATION_ID;
+  delete process.env.SYSTEMD_EXEC_PID;
+  delete process.env.JOURNAL_STREAM;
+}
+
 describe("restartGatewayProcessWithFreshPid", () => {
   it("returns disabled when OPENCLAW_NO_RESPAWN is set", () => {
     process.env.OPENCLAW_NO_RESPAWN = "1";
@@ -51,7 +59,7 @@ describe("restartGatewayProcessWithFreshPid", () => {
 
   it("spawns detached child with current exec argv", () => {
     delete process.env.OPENCLAW_NO_RESPAWN;
-    delete process.env.LAUNCH_JOB_LABEL;
+    clearSupervisorHints();
     process.execArgv = ["--import", "tsx"];
     process.argv = ["/usr/local/bin/node", "/repo/dist/index.js", "gateway", "run"];
     spawnMock.mockReturnValue({ pid: 4242, unref: vi.fn() });
@@ -70,6 +78,9 @@ describe("restartGatewayProcessWithFreshPid", () => {
   });
 
   it("returns failed when spawn throws", () => {
+    delete process.env.OPENCLAW_NO_RESPAWN;
+    clearSupervisorHints();
+
     spawnMock.mockImplementation(() => {
       throw new Error("spawn failed");
     });


### PR DESCRIPTION
Codex responses (chatgpt.com/backend-api/codex/responses) reject store=true.\n\nThis narrows the store=true workaround to direct OpenAI Responses only (api=openai-responses, provider=openai), and adds a regression test for Codex.\n\nFixes regression introduced in 909b5411b.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a regression where Codex responses were incorrectly forced to use `store=true`, causing API rejections. The fix narrows the `store=true` workaround to only direct OpenAI Responses (api=openai-responses, provider=openai), excluding Codex which requires `store=false`.

- Removed `openai-codex-responses` and `openai-codex` from the sets that trigger forced `store=true`
- Added comprehensive regression test verifying Codex responses maintain `store=false`
- Updated inline comments to clarify the distinction between OpenAI and Codex endpoints

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is minimal, well-targeted, and includes comprehensive test coverage. It corrects a specific API compatibility issue without affecting other functionality. The change only modifies two constant Sets to exclude Codex-specific values, preventing the incorrect `store=true` override for Codex endpoints.
- No files require special attention

<sub>Last reviewed commit: df7724d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->