### PR TITLE
Fix applyMergePatch accepting __proto__ and constructor keys

### DIFF
--- a/src/config/merge-patch.proto-pollution.test.ts
+++ b/src/config/merge-patch.proto-pollution.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { applyMergePatch } from "./merge-patch.js";
+
+describe("applyMergePatch prototype pollution guard", () => {
+  it("ignores __proto__ keys in patch", () => {
+    const base = { a: 1 };
+    const patch = JSON.parse('{"__proto__": {"polluted": true}, "b": 2}');
+    const result = applyMergePatch(base, patch) as Record<string, unknown>;
+    expect(result.b).toBe(2);
+    expect(result.a).toBe(1);
+    expect(Object.prototype.hasOwnProperty.call(result, "__proto__")).toBe(false);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  it("ignores constructor key in patch", () => {
+    const base = { a: 1 };
+    const patch = { constructor: { polluted: true }, b: 2 };
+    const result = applyMergePatch(base, patch) as Record<string, unknown>;
+    expect(result.b).toBe(2);
+    expect(Object.prototype.hasOwnProperty.call(result, "constructor")).toBe(false);
+  });
+
+  it("ignores prototype key in patch", () => {
+    const base = { a: 1 };
+    const patch = { prototype: { polluted: true }, b: 2 };
+    const result = applyMergePatch(base, patch) as Record<string, unknown>;
+    expect(result.b).toBe(2);
+    expect(Object.prototype.hasOwnProperty.call(result, "prototype")).toBe(false);
+  });
+
+  it("ignores __proto__ in nested patches", () => {
+    const base = { nested: { x: 1 } };
+    const patch = JSON.parse('{"nested": {"__proto__": {"polluted": true}, "y": 2}}');
+    const result = applyMergePatch(base, patch) as { nested: Record<string, unknown> };
+    expect(result.nested.y).toBe(2);
+    expect(result.nested.x).toBe(1);
+    expect(Object.prototype.hasOwnProperty.call(result.nested, "__proto__")).toBe(false);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+});

--- a/src/config/merge-patch.ts
+++ b/src/config/merge-patch.ts
@@ -2,6 +2,9 @@ import { isPlainObject } from "../utils.js";
 
 type PlainObject = Record<string, unknown>;
 
+/** Keys that must never be merged to prevent prototype-pollution attacks. */
+const BLOCKED_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
 type MergePatchOptions = {
   mergeObjectArraysById?: boolean;
 };
@@ -51,6 +54,9 @@ export function applyMergePatch(
   const result: PlainObject = isPlainObject(base) ? { ...base } : {};
 
   for (const [key, value] of Object.entries(patch)) {
+    if (BLOCKED_KEYS.has(key)) {
+      continue;
+    }
     if (value === null) {
       delete result[key];
       continue;


### PR DESCRIPTION
`applyMergePatch` iterates `Object.entries(patch)` and assigns each key to the result object. When the patch originates from `JSON.parse`, `__proto__` becomes an own enumerable property that `Object.entries` yields. Assigning `result['__proto__']` replaces the object's prototype chain, which can cause unexpected behavior downstream.

```js
const patch = JSON.parse('{"__proto__": {"polluted": true}}');
Object.entries(patch); // [['__proto__', {polluted: true}]]
```

Block `__proto__`, `constructor`, and `prototype` keys from being merged.

**Tests:** 4 new test cases covering direct, nested, constructor, and prototype key injection.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds prototype pollution guard to `applyMergePatch` by blocking `__proto__`, `constructor`, and `prototype` keys.

- Prevents prototype chain manipulation when patches originate from `JSON.parse` 
- Guard placed in main iteration loop to block dangerous keys before assignment
- Recursive nature ensures nested objects are also protected
- No impact on legitimate keys or existing functionality

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk - it's a critical security fix
- The implementation is straightforward, well-tested with 4 comprehensive test cases, and addresses a real security vulnerability. The fix uses a simple blocklist that prevents prototype pollution without affecting legitimate use cases.
- No files require special attention

<sub>Last reviewed commit: 03a7b4a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->