### PR TITLE
CLI: enable plugin loading for configure and onboard commands

### DIFF
--- a/extensions/openclaw-channel-dingtalk/.eslintrc.json
+++ b/extensions/openclaw-channel-dingtalk/.eslintrc.json
@@ -1,0 +1,40 @@
+{
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:@typescript-eslint/recommended-requiring-type-checking",
+    "prettier"
+  ],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 2020,
+    "sourceType": "module",
+    "project": "./tsconfig.json"
+  },
+  "plugins": ["@typescript-eslint"],
+  "rules": {
+    "@typescript-eslint/explicit-module-boundary-types": "warn",
+    "@typescript-eslint/no-explicit-any": "warn",
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      {
+        "argsIgnorePattern": "^_",
+        "varsIgnorePattern": "^_"
+      }
+    ],
+    "no-console": [
+      "warn",
+      {
+        "allow": ["warn", "error"]
+      }
+    ],
+    "no-empty": "off",
+    "@typescript-eslint/no-unsafe-member-access": "off",
+    "@typescript-eslint/no-unsafe-assignment": "off",
+    "@typescript-eslint/no-unsafe-call": "off",
+    "@typescript-eslint/no-unsafe-return": "off",
+    "@typescript-eslint/no-unsafe-argument": "off",
+    "@typescript-eslint/no-misused-promises": "off"
+  },
+  "ignorePatterns": ["node_modules", "dist"]
+}

--- a/extensions/openclaw-channel-dingtalk/.gitignore
+++ b/extensions/openclaw-channel-dingtalk/.gitignore
@@ -1,0 +1,23 @@
+# Dependency files
+node_modules/
+package-lock.json
+
+# Build files
+dist/
+*.js.map
+
+# Logs
+logs
+*.log
+npm-debug.log*
+
+# OS files
+.DS_Store
+
+# Credentials (IMPORTANT: DO NOT PUBLISH YOUR APP KEYS)
+credentials.json
+.env
+
+# Opencode directories
+.opencode/
+.vscode/

--- a/extensions/openclaw-channel-dingtalk/.prettierrc.json
+++ b/extensions/openclaw-channel-dingtalk/.prettierrc.json
@@ -1,0 +1,9 @@
+{
+  "semi": true,
+  "trailingComma": "es5",
+  "singleQuote": true,
+  "printWidth": 120,
+  "tabWidth": 2,
+  "useTabs": false,
+  "arrowParens": "always"
+}

--- a/extensions/openclaw-channel-dingtalk/AGENTS.md
+++ b/extensions/openclaw-channel-dingtalk/AGENTS.md
@@ -1,0 +1,188 @@
+# PROJECT KNOWLEDGE BASE
+
+**Generated:** 2026-01-31
+**Type:** OpenClaw DingTalk Channel Plugin
+
+## OVERVIEW
+
+DingTalk (钉钉) enterprise bot channel plugin using Stream mode (WebSocket, no public IP required). Part of OpenClaw ecosystem.
+
+## STRUCTURE
+
+```
+./
+├── src/
+│   ├── channel.ts        # Main plugin logic (API, messaging, AI Card) - 1076 lines
+│   ├── types.ts          # 30+ type definitions - 493 lines
+│   ├── runtime.ts        # Runtime getter/setter - 14 lines
+│   └── config-schema.ts  # Zod validation schema - 58 lines
+├── index.ts            # Plugin registration entry point - 18 lines
+├── utils.ts            # Utilities (retry, masking, temp cleanup) - 107 lines
+└── [config files]     # package.json, tsconfig.json, .eslintrc.json
+```
+
+## WHERE TO LOOK
+
+| Task                   | Location               | Notes                         |
+| ---------------------- | ---------------------- | ----------------------------- |
+| Plugin registration    | `index.ts`             | Exports default plugin object |
+| Channel implementation | `src/channel.ts`       | All DingTalk-specific logic   |
+| Type definitions       | `src/types.ts`         | 30+ interfaces, AI Card types |
+| Configuration schema   | `src/config-schema.ts` | Zod validation                |
+| Utilities              | `utils.ts`             | Retry, data masking, cleanup  |
+| Runtime access         | `src/runtime.ts`       | Getter/setter pattern         |
+
+## CODE MAP
+
+| Symbol                 | Type      | Location               | Role                            |
+| ---------------------- | --------- | ---------------------- | ------------------------------- |
+| dingtalkPlugin         | const     | src/channel.ts:862     | Main channel plugin definition  |
+| createAICard           | function  | src/channel.ts:374     | Create AI Card instance         |
+| streamAICard           | function  | src/channel.ts:475     | Stream AI Card content          |
+| finishAICard           | function  | src/channel.ts:556     | Finalize AI Card                |
+| handleDingTalkMessage  | function  | src/channel.ts:643     | Process inbound messages        |
+| sendBySession          | function  | src/channel.ts:333     | Send via session webhook        |
+| sendMessage            | function  | src/channel.ts:610     | Auto send (card/text/markdown)  |
+| getAccessToken         | function  | src/channel.ts:156     | Get/cached DingTalk token       |
+| downloadMedia          | function  | src/channel.ts:253     | Download media files            |
+| DingTalkConfig         | interface | src/types.ts:17        | Plugin configuration            |
+| DingTalkInboundMessage | interface | src/types.ts:100       | Inbound message from Stream API |
+| AICardInstance         | interface | src/types.ts:424       | AI Card cache entry             |
+| AICardStatus           | const     | src/types.ts:408       | Card state constants            |
+| DingTalkConfigSchema   | const     | src/config-schema.ts:7 | Zod validation schema           |
+
+## CONVENTIONS
+
+**Code Style:**
+
+- TypeScript strict mode enabled
+- ES2020 target, ESNext modules
+- 4-space indentation (Prettier)
+- Export public API from `src/channel.ts` (sendBySession, createAICard, streamAICard, finishAICard, sendMessage, getAccessToken)
+
+**Naming:**
+
+- Private functions: camelCase (e.g., `normalizeAllowFrom`, `detectMarkdownAndExtractTitle`)
+- Exported functions: camelCase
+- Type interfaces: PascalCase (e.g., `DingTalkConfig`, `AICardInstance`)
+- Constants: UPPER_SNAKE_CASE (e.g., `AICardStatus`, `CARD_CACHE_TTL`)
+
+**Error Handling:**
+
+- Use `try/catch` for all async API calls
+- Log errors with structured format: `[DingTalk][Context] message`
+- Return `{ ok: boolean, error?: string }` for send operations
+- Retry with exponential backoff (max 3 retries) for 401/429/5xx errors
+
+**State Management:**
+
+- Access token cached in module-level variable with expiry
+- AI Card instances cached in `Map<string, AICardInstance>`
+- Card cache cleanup runs every 30 minutes (TTL: 1 hour for terminal states)
+- Runtime stored via getter/setter pattern in `src/runtime.ts`
+
+**Monorepo Structure:**
+
+- Extends `../../tsconfig.json` (parent repo)
+- Path mapping: `openclaw/plugin-sdk` → `../../src/plugin-sdk/index.ts`
+- Dev dependency: `openclaw: workspace:*`
+
+## ANTI-PATTERNS (THIS PROJECT)
+
+**Prohibited:**
+
+- Sending messages without access token (must call `getAccessToken()` first)
+- Creating multiple AI Cards for same conversation (use cached instance)
+- Hardcoding credentials (use config from `channels.dingtalk`)
+- Suppressing type errors with `@ts-ignore` (use proper typing)
+- Using `console.log` (use logger: `log?.info`, `log?.error`, etc.)
+- Leaving temp files in OS temp directory (call `cleanupOrphanedTempFiles()`)
+- Not masking sensitive data in logs (use `maskSensitiveData()`)
+
+**Security:**
+
+- Never log raw access tokens (masked to 3 chars)
+- Validate `dmPolicy` before allowing DM messages
+- Check `allowFrom` list for allowlist mode
+- Normalize sender IDs (remove `dingtalk:`, `dd:`, `ding:` prefixes)
+
+## UNIQUE STYLES
+
+**AI Card Flow:**
+
+1. Create card instance → cache with state=PROCESSING
+2. Switch to INPUTING state on first stream update
+3. Stream content via `/v1.0/card/streaming` API
+4. Finalize with FINISHED state + isFinalize=true
+
+**Message Processing Pipeline:**
+
+1. Filter self-messages (senderId === chatbotUserId)
+2. Extract content (text/richText/media)
+3. Download media to temp dir if present
+4. Check authorization (dmPolicy + allowFrom)
+5. Route to agent via OpenClaw runtime
+6. Create AI Card if messageType=card
+7. Send "thinking..." message
+8. Stream AI response via dispatcher
+
+**Media Handling:**
+
+- Download to `/tmp/dingtalk_<timestamp>.<ext>`
+- Auto-delete temp files after use
+- Clean up orphaned files (>24h old) on startup
+
+**Markdown Detection:**
+
+- Auto-detect: checks for `#`, `*`, `>`, `-`, `[`, `\n`
+- Extract title from first line (strip `#*` prefix, limit to 20 chars)
+- Fallback title: "Clawdbot 消息"
+
+## COMMANDS
+
+```bash
+# Type check
+npm run type-check
+
+# Lint
+npm run lint
+
+# Lint + fix
+npm run lint:fix
+```
+
+**Note:** No build script - plugin runs directly via OpenClaw runtime.
+
+## NOTES
+
+**OpenClaw Plugin Architecture:**
+
+- Entry point: `index.ts` exports default plugin object
+- Plugin register: `register(api: OpenClawPluginApi)` called by runtime
+- Channel registration: `api.registerChannel({ plugin: dingtalkPlugin })`
+- Configuration: Read from `cfg.channels.dingtalk`
+- Multiple accounts supported via `accounts` object in config
+
+**DingTalk API:**
+
+- Base URL: `https://api.dingtalk.com`
+- Token endpoint: `/v1.0/oauth2/accessToken`
+- Media download: `/v1.0/robot/messageFiles/download`
+- AI Card create: `/v1.0/card/instances`
+- AI Card deliver: `/v1.0/card/instances/deliver`
+- AI Card stream: `/v1.0/card/streaming`
+
+**Package.json Issue:**
+
+- `openclaw` configuration object duplicated (lines 37-63 and 64-90)
+
+**Dependencies:**
+
+- `dingtalk-stream` (v2.1.4) - WebSocket Stream client
+- `axios` (v1.6.0) - HTTP client
+- `zod` (v4.3.6) - Schema validation
+
+**No Tests:**
+
+- No test files or test configs present
+- Testing likely done at OpenClaw monorepo root

--- a/extensions/openclaw-channel-dingtalk/README.md
+++ b/extensions/openclaw-channel-dingtalk/README.md
@@ -1,0 +1,460 @@
+# DingTalk Channel for OpenClaw
+
+钉钉企业内部机器人 Channel 插件，使用 Stream 模式（无需公网 IP）。
+
+## 功能特性
+
+- ✅ **Stream 模式** — WebSocket 长连接，无需公网 IP 或 Webhook
+- ✅ **私聊支持** — 直接与机器人对话
+- ✅ **群聊支持** — 在群里 @机器人
+- ✅ **多种消息类型** — 文本、图片、语音（自带识别）、视频、文件
+- ✅ **Markdown 回复** — 支持富文本格式回复
+- ✅ **互动卡片** — 支持流式更新，适用于 AI 实时输出
+- ✅ **完整 AI 对话** — 接入 Clawdbot 消息处理管道
+
+## 安装
+
+### 方法 A：通过远程仓库安装 (推荐)
+
+直接运行 openclaw 插件安装命令，openclaw 会自动处理下载、安装依赖和注册：
+
+```bash
+openclaw plugins install https://github.com/soimy/clawdbot-channel-dingtalk.git
+```
+
+### 方法 B：通过本地源码安装
+
+如果你想对插件进行二次开发，可以先克隆仓库：
+
+```bash
+# 1. 克隆仓库
+git clone https://github.com/soimy/openclaw-channel-dingtalk.git
+cd openclaw-channel-dingtalk
+
+# 2. 安装依赖 (必需)
+npm install
+
+# 3. 以链接模式安装 (方便修改代码后实时生效)
+openclaw plugins install -l .
+```
+
+### 方法 C：手动安装
+
+1. 将本目录下载或复制到 `~/.openclaw/extensions/dingtalk`。
+2. 确保包含 `index.ts`, `openclaw.plugin.json` 和 `package.json`。
+3. 运行 `openclaw plugins list` 确认 `dingtalk` 已显示在列表中。
+
+## 更新
+
+```
+openclaw plugins update dingtalk
+```
+
+## 配置
+
+### 1. 创建钉钉应用
+
+1. 访问 [钉钉开发者后台](https://open-dev.dingtalk.com/)
+2. 创建企业内部应用
+3. 添加「机器人」能力
+4. 配置消息接收模式为 **Stream 模式**
+5. 发布应用
+
+### 2. 配置权限管理
+
+在应用的权限管理页面，需要开启以下权限：
+
+- ✅ **Card.Instance.Write** — 创建和投放卡片实例
+- ✅ **Card.Streaming.Write** — 对卡片进行流式更新
+
+**步骤：**
+
+1. 进入应用 → 权限管理
+2. 搜索「Card」相关权限
+3. 勾选上述两个权限
+4. 保存权限配置
+
+### 3. 建立卡片模板
+
+**步骤：**
+
+1. 访问 [钉钉卡片平台](https://open-dev.dingtalk.com/fe/card)
+2. 进入「我的模板」
+3. 点击「创建模板」
+4. 卡片模板场景选择 **「AI 卡片」**
+5. 按需设计卡片排版,点击保存并发布
+6. 记下模板中定义的内容字段名称
+7. 复制模板 ID（格式如：`xxxxx-xxxxx-xxxxx.schema`）
+8. 将 templateId 配置到 `openclaw.json` 的 `cardTemplateId` 字段
+9. 或在OpenClaw控制台的Channel标签->Dingtalk配置面板-> Card Template Id填入
+10. 将记下的内容字段变量名配置到 `openclaw.json` 的 `cardTemplateKey` 字段
+11. 或在OpenClaw控制台的Channel标签->Dingtalk配置面板-> Card Template Key填入
+
+**说明：**
+
+- 使用 DingTalk 官方 AI 卡片模板时，`cardTemplateKey` 默认为 `'msgContent'`，无需修改
+- 如果您创建自定义卡片模板，需要确保模板中包含相应的内容字段，并将 `cardTemplateKey` 配置为该字段名称
+
+**模板配置示例：**
+
+```json
+{
+  "channels": {
+    "dingtalk": {
+      ...
+      "messageType": 'card',
+      "cardTemplateId": '你复制的模板ID',
+      "cardTemplateKey": '你模板的内容变量',
+      ...
+    },
+  },
+}
+```
+
+### 4. 获取凭证
+
+从开发者后台获取：
+
+- **Client ID** (AppKey)
+- **Client Secret** (AppSecret)
+- **Robot Code** (与 Client ID 相同)
+- **Corp ID** (企业 ID)
+- **Agent ID** (应用 ID)
+
+### 5. 配置 OpenClaw
+
+在 `~/.openclaw/openclaw.json` 的 `channels` 下添加：
+
+> 只添加dingtalk部分，内容自己替换
+
+```json5
+{
+  ...
+  "channels": {
+    "telegram": { ... },
+
+    "dingtalk": {
+      "enabled": true,
+      "clientId": "dingxxxxxx",
+      "clientSecret": "your-app-secret",
+      "robotCode": "dingxxxxxx",
+      "corpId": "dingxxxxxx",
+      "agentId": "123456789",
+      "dmPolicy": "open",
+      "groupPolicy": "open",
+      "messageType": "markdown",
+      "debug": false
+    }
+  },
+  ...
+}
+```
+
+### 6. 重启 Gateway
+
+```bash
+openclaw gateway restart
+```
+
+## 配置选项
+
+| 选项                    | 类型     | 默认值       | 说明                                        |
+| ----------------------- | -------- | ------------ | ------------------------------------------- |
+| `enabled`               | boolean  | `true`       | 是否启用                                    |
+| `clientId`              | string   | 必填         | 应用的 AppKey                               |
+| `clientSecret`          | string   | 必填         | 应用的 AppSecret                            |
+| `robotCode`             | string   | -            | 机器人代码（用于下载媒体和发送卡片）        |
+| `corpId`                | string   | -            | 企业 ID                                     |
+| `agentId`               | string   | -            | 应用 ID                                     |
+| `dmPolicy`              | string   | `"open"`     | 私聊策略：open/pairing/allowlist            |
+| `groupPolicy`           | string   | `"open"`     | 群聊策略：open/allowlist                    |
+| `allowFrom`             | string[] | `[]`         | 允许的发送者 ID 列表                        |
+| `messageType`           | string   | `"markdown"` | 消息类型：markdown/card                     |
+| `cardTemplateId`        | string   |              | AI 互动卡片模板 ID（仅当 messageType=card） |
+| `cardTemplateKey`       | string   | `"content"`  | 卡片模板内容字段键（仅当 messageType=card） |
+| `debug`                 | boolean  | `false`      | 是否开启调试日志                            |
+| `maxConnectionAttempts` | number   | `10`         | 最大连接尝试次数                            |
+| `initialReconnectDelay` | number   | `1000`       | 初始重连延迟（毫秒）                        |
+| `maxReconnectDelay`     | number   | `60000`      | 最大重连延迟（毫秒）                        |
+| `reconnectJitter`       | number   | `0.3`        | 重连延迟抖动因子（0-1）                     |
+
+### 连接鲁棒性配置
+
+为提高连接稳定性，插件支持以下高级配置：
+
+- **maxConnectionAttempts**: 连接失败后的最大重试次数，超过后将停止尝试并报警。
+- **initialReconnectDelay**: 第一次重连的初始延迟（毫秒），后续重连会按指数增长。
+- **maxReconnectDelay**: 重连延迟的上限（毫秒），防止等待时间过长。
+- **reconnectJitter**: 延迟抖动因子，在延迟基础上增加随机变化（±30%），避免多个客户端同时重连。
+
+重连延迟计算公式：`delay = min(initialDelay × 2^attempt, maxDelay) × (1 ± jitter)`
+
+示例延迟序列（默认配置）：~1s, ~2s, ~4s, ~8s, ~16s, ~32s, ~60s（达到上限）
+
+更多详情请参阅 [CONNECTION_ROBUSTNESS.md](./CONNECTION_ROBUSTNESS.md)。
+
+## 安全策略
+
+### 私聊策略 (dmPolicy)
+
+- `open` — 任何人都可以私聊机器人
+- `pairing` — 新用户需要通过配对码验证
+- `allowlist` — 只有 allowFrom 列表中的用户可以使用
+
+### 群聊策略 (groupPolicy)
+
+- `open` — 任何群都可以 @机器人
+- `allowlist` — 只有配置的群可以使用
+
+## 消息类型支持
+
+### 接收
+
+| 类型   | 支持 | 说明                 |
+| ------ | ---- | -------------------- |
+| 文本   | ✅   | 完整支持             |
+| 富文本 | ✅   | 提取文本内容         |
+| 图片   | ✅   | 下载并传递给 AI      |
+| 语音   | ✅   | 使用钉钉语音识别结果 |
+| 视频   | ✅   | 下载并传递给 AI      |
+| 文件   | ✅   | 下载并传递给 AI      |
+
+### 发送
+
+| 类型     | 支持 | 说明                             |
+| -------- | ---- | -------------------------------- |
+| 文本     | ✅   | 完整支持                         |
+| Markdown | ✅   | 自动检测或手动指定               |
+| 互动卡片 | ✅   | 支持流式更新，适用于 AI 实时输出 |
+| 图片     | ⏳   | 需要通过媒体上传 API             |
+
+## API 消耗说明
+
+### Text/Markdown 模式
+
+| 操作       | API 调用次数 | 说明                                                                         |
+| ---------- | ------------ | ---------------------------------------------------------------------------- |
+| 获取 Token | 1            | 共享/缓存（60 秒检查过期一次）                                               |
+| 发送消息   | 1            | 使用 `/v1.0/robot/oToMessages/batchSend` 或 `/v1.0/robot/groupMessages/send` |
+| **总计**   | **2**        | 每条回复 1 次                                                                |
+
+### Card（AI 互动卡片）模式
+
+| 阶段         | API 调用               | 说明                                                |
+| ------------ | ---------------------- | --------------------------------------------------- |
+| **创建卡片** | 1                      | `POST /v1.0/card/instances/createAndDeliver`        |
+| **流式更新** | M                      | M = 回复块数量，每块一次 `PUT /v1.0/card/streaming` |
+| **完成卡片** | 包含在最后一次流更新中 | 使用 `isFinalize=true` 标记                         |
+| **总计**     | **1 + M**              | M = Agent 产生的回复块数                            |
+
+### 典型场景成本对比
+
+| 场景             | Text/Markdown | Card | 节省   |
+| ---------------- | ------------- | ---- | ------ |
+| 简短回复（1 块） | 2             | 2    | ✓ 相同 |
+| 中等回复（5 块） | 6             | 6    | ✓ 相同 |
+| 长回复（10 块）  | 12            | 11   | ✓ 1 次 |
+
+### 优化策略
+
+**降低 API 调用的方法：**
+
+1. **合并回复块** — 通过调整 Agent 输出配置，减少块数量
+2. **使用缓存** — Token 自动缓存（60 秒），无需每次都获取
+3. **Buffer 模式** — 使用 `dispatchReplyWithBufferedBlockDispatcher` 合并多个小块
+
+**成本建议：**
+
+- ✅ **推荐** — Card 模式：流式体验更好，成本与 Text/Markdown 相当或更低
+- ⚠️ **谨慎** — 频繁调用需要监测配额，建议使用钉钉开发者后台查看 API 调用量
+
+## 消息类型选择
+
+插件支持两种消息回复类型，可通过 `messageType` 配置：
+
+### 1. markdown（Markdown 格式）**【默认】**
+
+- 支持富文本格式（标题、粗体、列表等）
+- 自动检测消息是否包含 Markdown 语法
+- 适用于大多数场景
+
+### 2. card（AI 互动卡片）
+
+- 支持流式更新（实时显示 AI 生成内容）
+- 更好的视觉呈现和交互体验
+- 支持 Markdown 格式渲染
+- 通过 `cardTemplateId` 指定模板
+- 通过 `cardTemplateKey` 指定内容字段
+- **适用于 AI 对话场景**
+
+**AI Card API 特性：**
+当配置 `messageType: 'card'` 时：
+
+1. 使用 `/v1.0/card/instances/createAndDeliver` 创建并投放卡片
+2. 使用 `/v1.0/card/streaming` 实现真正的流式更新
+3. 自动状态管理（PROCESSING → INPUTING → FINISHED）
+4. 更稳定的流式体验，无需手动节流
+
+**配置示例：**
+
+```json5
+{
+  messageType: "card", // 启用 AI 互动卡片模式
+  cardTemplateId: "382e4302-551d-4880-bf29-a30acfab2e71.schema", // AI 卡片模板 ID（默认值）
+  cardTemplateKey: "msgContent", // 卡片内容字段键（默认值：msgContent）
+}
+```
+
+> **注意**：`cardTemplateKey` 应与您的卡片模板中定义的字段名称一致。默认值为 `'msgContent'`，适用于 DingTalk 官方 AI 卡片模板。如果您使用自定义模板，请根据模板定义的字段名称进行配置。
+
+## 使用示例
+
+配置完成后，直接在钉钉中：
+
+1. **私聊机器人** — 找到机器人，发送消息
+2. **群聊 @机器人** — 在群里 @机器人名称 + 消息
+
+## 故障排除
+
+### 收不到消息
+
+1. 确认应用已发布
+2. 确认消息接收模式是 Stream
+3. 检查 Gateway 日志：`openclaw logs | grep dingtalk`
+
+### 群消息无响应
+
+1. 确认机器人已添加到群
+2. 确认正确 @机器人（使用机器人名称）
+3. 确认群是企业内部群
+
+### 连接失败
+
+1. 检查 clientId 和 clientSecret 是否正确
+2. 确认网络可以访问钉钉 API
+
+## 开发指南
+
+### 首次设置
+
+1. 克隆仓库并安装依赖
+
+```bash
+git clone https://github.com/soimy/openclaw-channel-dingtalk.git
+cd openclaw-channel-dingtalk
+npm install
+```
+
+2. 验证开发环境
+
+```bash
+npm run type-check              # TypeScript 类型检查
+npm run lint                    # ESLint 代码检查
+```
+
+### 常用命令
+
+| 命令                 | 说明                |
+| -------------------- | ------------------- |
+| `npm run type-check` | TypeScript 类型检查 |
+| `npm run lint`       | ESLint 代码检查     |
+| `npm run lint:fix`   | 自动修复格式问题    |
+
+### 项目结构
+
+```
+src/
+  channel.ts           - 插件定义和辅助函数（535 行）
+  runtime.ts           - 运行时管理（14 行）
+  types.ts             - 类型定义（30+ interfaces）
+
+index.ts              - 插件注册（29 行）
+utils.ts              - 工具函数（110 行）
+
+openclaw.plugin.json  - 插件配置
+package.json          - 项目配置
+README.md             - 本文件
+```
+
+### 代码质量
+
+- **TypeScript**: 严格模式，0 错误
+- **ESLint**: 自动检查和修复
+- **Type Safety**: 完整的类型注解（30+ 接口）
+
+### 类型系统
+
+核心类型定义在 `src/types.ts` 中，包括：
+
+```typescript
+// 配置
+DingTalkConfig; // 插件配置
+DingTalkChannelConfig; // 多账户配置
+
+// 消息处理
+DingTalkInboundMessage; // 收到的钉钉消息
+MessageContent; // 解析后的消息内容
+HandleDingTalkMessageParams; // 消息处理参数
+
+// AI 互动卡片
+AICardInstance; // AI 卡片实例
+AICardCreateAndDeliverRequest; // 创建并投放卡片请求
+AICardStreamingRequest; // 流式更新请求
+AICardStatus; // 卡片状态常量
+
+// 工具函数类型
+Logger; // 日志接口
+RetryOptions; // 重试选项
+MediaFile; // 下载的媒体文件
+```
+
+### 公开 API
+
+插件导出以下低级 API 函数，可用于自定义集成：
+
+```typescript
+// 文本/Markdown 消息
+sendBySession(config, sessionWebhook, text, options); // 通过会话发送
+
+// AI 互动卡片
+createAICard(config, conversationId, data, log); // 创建并投放 AI 卡片
+streamAICard(card, content, finished, log); // 流式更新卡片内容
+finishAICard(card, content, log); // 完成并关闭卡片
+
+// 自动模式选择
+sendMessage(config, conversationId, text, options); // 根据配置自动选择（含卡片/文本回退）
+
+// 认证
+getAccessToken(config, log); // 获取访问令牌
+```
+
+**使用示例：**
+
+```typescript
+import { createAICard, streamAICard, finishAICard } from "./src/channel";
+
+// 创建 AI 卡片
+const card = await createAICard(config, conversationId, messageData, log);
+
+// 流式更新内容
+for (const chunk of aiResponseChunks) {
+  await streamAICard(card, currentText + chunk, false, log);
+}
+
+// 完成并关闭卡片
+await finishAICard(card, finalText, log);
+```
+
+### 架构
+
+插件遵循 Telegram 参考实现的架构模式：
+
+- **index.ts**: 最小化插件注册入口
+- **src/channel.ts**: 所有 DingTalk 特定的逻辑（API、消息处理、配置等）
+- **src/runtime.ts**: 运行时管理（getter/setter）
+- **src/types.ts**: 类型定义
+- **utils.ts**: 通用工具函数
+
+## 许可
+
+MIT

--- a/extensions/openclaw-channel-dingtalk/RELEASES.md
+++ b/extensions/openclaw-channel-dingtalk/RELEASES.md
@@ -1,0 +1,1 @@
+Release v2.2.2 created on 2026-02-02.

--- a/extensions/openclaw-channel-dingtalk/TODO.md
+++ b/extensions/openclaw-channel-dingtalk/TODO.md
@@ -1,0 +1,102 @@
+# TODO
+
+> Auto-generated from GitHub Issues (2026-02-14)
+
+## 🐛 Bug Fixes
+
+### Priority: High
+
+- [ ] **[#112](https://github.com/soimy/openclaw-channel-dingtalk/issues/112)** - dingtalk plugins 不能正常链接，request failed with status code 400
+  - 连接尝试 10 次后失败，返回 400 错误
+  - 可能与配置或用户 ID 格式相关
+  - Dup: #63
+
+- [ ] **[#95](https://github.com/soimy/openclaw-channel-dingtalk/issues/95)** - Accounts Unsupported schema node. Use Raw mode
+  - 多帐号配置 UI 显示问题
+  - 不影响主帐号使用
+  - 临时方案：在 openclaw.json 中手动配置多帐号
+
+- [ ] **[#94](https://github.com/soimy/openclaw-channel-dingtalk/issues/94)** - channel is not running
+  - Gateway 启动后 channel 状态不更新
+  - 不影响实际使用，仅状态显示问题
+
+### Priority: Medium
+
+- [ ] **[#63](https://github.com/soimy/openclaw-channel-dingtalk/issues/63)** - 主动发送消息返回 400 错误
+  - 与 agent 提供的 target 格式相关
+  - 需要验证 staffId 格式是否正确
+  - 参考: [钉钉 API Explorer](https://open.dingtalk.com/document/api/explore/explorer-page?api=robot_1.0%23BatchSendOTO&devType=org)
+
+### Priority: Low (Resolved)
+
+- [x] **[#106](https://github.com/soimy/openclaw-channel-dingtalk/issues/106)** - 几个小时不用就报错连不上钉钉
+  - 原因：`dingtalk-stream` SDK 心跳超时 (8秒硬编码)
+  - 修复：PR #96 已合并，增加无限重试循环
+  - 建议：更新到最新版本
+
+---
+
+## ✨ Feature Requests
+
+### Priority: High
+
+- [ ] **[#86](https://github.com/soimy/openclaw-channel-dingtalk/issues/86)** - 支持将图片/媒体消息整合进 AI 流式卡片中
+  - 当前：图片/文件作为独立消息发送，视觉上被切断
+  - 目标：图片直接嵌入 AI 回复卡片，形成统一图文简报
+  - 方案：
+    1. 模板升级：支持图片变量占位符
+    2. 状态追踪：AICardInstance 增加媒体状态
+    3. 逻辑整合：sendMedia 检测活跃卡片并更新
+  - 限制：视频无法直接嵌入，只能做超链接
+
+- [ ] **[#67](https://github.com/soimy/openclaw-channel-dingtalk/issues/67)** - 机器人群聊中支持 @ 某人
+  - 当前：机器人回复不会 @ 群成员
+  - 目标：检测文本中的 "@某某人" 并转换为钉钉格式
+  - 扩展：支持 @ 机器人实现多机器人对话
+
+### Priority: Medium
+
+- [ ] **[#110](https://github.com/soimy/openclaw-channel-dingtalk/issues/110)** - AI Card 模式支持 thinking/tool usage 显示
+  - 当前：thinking 和 tool usage 只显示"处理中"
+  - 限制：每次更新消耗 API 调用（免费版 5000/月）
+  - 方案：需要定制卡片模板
+  - 参考: #111
+
+- [ ] **[#111](https://github.com/soimy/openclaw-channel-dingtalk/issues/111)** - AI Card 模式支持 usage footer
+  - 开启 `/usage full` 后 usage 信息不显示
+  - 需要卡片模板支持
+
+- [ ] **[#76](https://github.com/soimy/openclaw-channel-dingtalk/issues/76)** - 对话打断功能
+  - 当前：AI 处理中无法停止
+  - 目标：支持用户中断正在执行的任务
+  - 场景：AI 执行错误任务时可以及时停止
+
+- [ ] **[#63](https://github.com/soimy/openclaw-channel-dingtalk/issues/63)** - 主动发送消息支持
+  - 目标：支持 agent 主动向用户发送消息
+  - 相关：定时提醒、cron job 等场景
+
+### Priority: Low
+
+- [ ] **[#101](https://github.com/soimy/openclaw-channel-dingtalk/issues/101)** - 钉盘文件访问支持
+  - 当前：不支持钉盘/钉钉文档
+  - 方案：利用钉钉服务端 API，扩展 downloadMedia/uploadMedia
+  - Dup: #107
+
+---
+
+## 📋 Statistics
+
+| Category        | Count  |
+| --------------- | ------ |
+| Bug (Open)      | 4      |
+| Bug (Fixed)     | 1      |
+| Feature Request | 7      |
+| **Total**       | **12** |
+
+---
+
+## 🔗 Quick Links
+
+- [All Issues](https://github.com/soimy/openclaw-channel-dingtalk/issues)
+- [Pull Requests](https://github.com/soimy/openclaw-channel-dingtalk/pulls)
+- [CONNECTION_ROBUSTNESS.md](./CONNECTION_ROBUSTNESS.md) - 连接稳定性说明

--- a/extensions/openclaw-channel-dingtalk/clawbot.plugin.json
+++ b/extensions/openclaw-channel-dingtalk/clawbot.plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "dingtalk",
+  "channels": ["dingtalk"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": true,
+    "properties": {}
+  }
+}

--- a/extensions/openclaw-channel-dingtalk/commitlint.config.js
+++ b/extensions/openclaw-channel-dingtalk/commitlint.config.js
@@ -1,0 +1,35 @@
+/**
+ * Commitlint configuration for conventional commits
+ * Works with cz-git for standardized commit messages
+ */
+
+export default {
+  extends: ["@commitlint/config-conventional"],
+  rules: {
+    "type-enum": [
+      2,
+      "always",
+      [
+        "feat", // A new feature
+        "fix", // A bug fix
+        "docs", // Documentation changes
+        "style", // Code style changes (formatting, etc)
+        "refactor", // Code refactoring
+        "perf", // Performance improvements
+        "test", // Test changes
+        "chore", // Build, dependencies, tooling
+        "ci", // CI/CD changes
+        "build", // Build system changes
+      ],
+    ],
+    "type-case": [2, "always", "lowercase"],
+    "type-empty": [2, "never"],
+    "scope-empty": [0],
+    "scope-case": [2, "always", "lowercase"],
+    "subject-empty": [2, "never"],
+    "subject-full-stop": [2, "never", "."],
+    "subject-case": [0],
+    "subject-exclamation-mark": [0],
+    "header-max-length": [2, "always", 100],
+  },
+};

--- a/extensions/openclaw-channel-dingtalk/docs/plans/2026-02-15-dingtalk-onboarding-design.md
+++ b/extensions/openclaw-channel-dingtalk/docs/plans/2026-02-15-dingtalk-onboarding-design.md
@@ -1,0 +1,252 @@
+# DingTalk Onboarding 设计文档
+
+**日期:** 2026-02-15
+**状态:** 设计完成，待实现
+**参考:** tlon 扩展 (https://github.com/openclaw/openclaw/tree/main/extensions/tlon)
+
+## 概述
+
+为 DingTalk 插件实现交互式 onboarding 功能，允许用户通过命令行向导配置插件参数，而非手动编辑配置文件。
+
+## 目标
+
+1. 提供与 OpenClaw 其他 channel 一致的 onboarding 体验
+2. 支持多账户配置
+3. 分步引导必填和可选配置项
+4. 支持增量配置（后续修改部分参数）
+
+## 文件结构
+
+```
+src/
+├── channel.ts          # 现有：添加 onboarding 属性
+├── onboarding.ts       # 新增：onboarding 适配器实现
+├── types.ts            # 修改：添加 listDingTalkAccountIds, resolveDingTalkAccount
+└── config-schema.ts    # 现有：无修改
+```
+
+## Onboarding 流程
+
+```
+1. 显示帮助说明
+   └── 钉钉开发者后台链接和文档
+
+2. 必填配置（基本连接）
+   ├── clientId (AppKey)
+   └── clientSecret (AppSecret)
+
+3. 可选配置（引导询问）
+   ├── 是否配置完整凭证? (robotCode, corpId, agentId)
+   ├── 是否启用 AI 互动卡片?
+   │   └── 如果是：输入 cardTemplateId + cardTemplateKey
+   ├── 私聊策略 (open/allowlist)
+   │   └── 如果是 allowlist：输入允许的用户 ID
+   └── 群聊策略 (open/allowlist)
+       └── 如果是 allowlist：输入允许的群 ID
+
+4. 生成配置并返回
+```
+
+## 核心组件
+
+### 1. src/onboarding.ts
+
+```typescript
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import {
+  formatDocsLink,
+  promptAccountId,
+  DEFAULT_ACCOUNT_ID,
+  normalizeAccountId,
+  type ChannelOnboardingAdapter,
+  type WizardPrompter,
+} from "openclaw/plugin-sdk";
+import type { DingTalkConfig } from "./types.js";
+import { listDingTalkAccountIds, resolveDingTalkAccount } from "./types.js";
+
+const channel = "dingtalk" as const;
+
+function isConfigured(account: DingTalkConfig): boolean {
+  return Boolean(account.clientId && account.clientSecret);
+}
+
+function applyAccountConfig(params: {
+  cfg: OpenClawConfig;
+  accountId: string;
+  input: Partial<DingTalkConfig>;
+}): OpenClawConfig {
+  // 实现配置合并逻辑
+}
+
+async function noteDingTalkHelp(prompter: WizardPrompter): Promise<void> {
+  await prompter.note(
+    [
+      "You need DingTalk application credentials.",
+      "1. Visit https://open-dev.dingtalk.com/",
+      "2. Create an enterprise internal application",
+      "3. Enable 'Robot' capability",
+      "4. Configure message receiving mode as 'Stream mode'",
+      `Docs: ${formatDocsLink("/channels/dingtalk", "channels/dingtalk")}`,
+    ].join("\n"),
+    "DingTalk setup",
+  );
+}
+
+function parseList(value: string): string[] {
+  return value
+    .split(/[\n,;]+/g)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+export const dingtalkOnboardingAdapter: ChannelOnboardingAdapter = {
+  channel,
+  getStatus: async ({ cfg }) => {
+    const accountIds = listDingTalkAccountIds(cfg);
+    const configured =
+      accountIds.length > 0
+        ? accountIds.some((accountId) => isConfigured(resolveDingTalkAccount(cfg, accountId)))
+        : isConfigured(resolveDingTalkAccount(cfg, DEFAULT_ACCOUNT_ID));
+
+    return {
+      channel,
+      configured,
+      statusLines: [`DingTalk: ${configured ? "configured" : "needs setup"}`],
+      selectionHint: configured ? "configured" : "钉钉企业机器人",
+      quickstartScore: configured ? 1 : 4,
+    };
+  },
+  configure: async ({ cfg, prompter, accountOverrides, shouldPromptAccountIds }) => {
+    // 实现完整配置流程
+  },
+};
+```
+
+### 2. src/types.ts 新增函数
+
+```typescript
+import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk";
+
+export function listDingTalkAccountIds(cfg: OpenClawConfig): string[] {
+  const dingtalk = cfg.channels?.dingtalk as DingTalkChannelConfig | undefined;
+  if (!dingtalk) return [];
+
+  const accountIds: string[] = [];
+
+  if (dingtalk.clientId || dingtalk.clientSecret) {
+    accountIds.push(DEFAULT_ACCOUNT_ID);
+  }
+
+  if (dingtalk.accounts) {
+    accountIds.push(...Object.keys(dingtalk.accounts));
+  }
+
+  return accountIds;
+}
+
+export function resolveDingTalkAccount(
+  cfg: OpenClawConfig,
+  accountId?: string | null,
+): DingTalkConfig & { configured: boolean } {
+  const id = accountId || DEFAULT_ACCOUNT_ID;
+  const dingtalk = cfg.channels?.dingtalk as DingTalkChannelConfig | undefined;
+
+  if (id === DEFAULT_ACCOUNT_ID) {
+    const config: DingTalkConfig = {
+      clientId: dingtalk?.clientId ?? "",
+      clientSecret: dingtalk?.clientSecret ?? "",
+      robotCode: dingtalk?.robotCode,
+      corpId: dingtalk?.corpId,
+      agentId: dingtalk?.agentId,
+      dmPolicy: dingtalk?.dmPolicy,
+      groupPolicy: dingtalk?.groupPolicy,
+      allowFrom: dingtalk?.allowFrom,
+      messageType: dingtalk?.messageType,
+      cardTemplateId: dingtalk?.cardTemplateId,
+      cardTemplateKey: dingtalk?.cardTemplateKey,
+      // ... 其他字段
+    };
+    return {
+      ...config,
+      configured: Boolean(config.clientId && config.clientSecret),
+    };
+  }
+
+  const accountConfig = dingtalk?.accounts?.[id];
+  if (accountConfig) {
+    return {
+      ...accountConfig,
+      configured: Boolean(accountConfig.clientId && accountConfig.clientSecret),
+    };
+  }
+
+  return {
+    clientId: "",
+    clientSecret: "",
+    configured: false,
+  };
+}
+```
+
+### 3. src/channel.ts 修改
+
+```typescript
+import { dingtalkOnboardingAdapter } from "./onboarding.js";
+
+export const dingtalkPlugin: DingTalkChannelPlugin = {
+  id: 'dingtalk',
+  meta: { ... },
+  capabilities: { ... },
+
+  // 添加 onboarding 属性
+  onboarding: dingtalkOnboardingAdapter,
+
+  config: { ... },
+  // ... 其他属性保持不变
+};
+```
+
+## 交互详情
+
+### 必填字段验证
+
+- `clientId`: 非空验证
+- `clientSecret`: 非空验证
+
+### 可选字段
+
+| 字段            | 类型     | 触发条件                                |
+| --------------- | -------- | --------------------------------------- |
+| robotCode       | string   | 用户选择配置完整凭证                    |
+| corpId          | string   | 用户选择配置完整凭证                    |
+| agentId         | string   | 用户选择配置完整凭证                    |
+| cardTemplateId  | string   | 用户选择启用 AI 卡片                    |
+| cardTemplateKey | string   | 用户选择启用 AI 卡片（默认 msgContent） |
+| dmPolicy        | enum     | 始终询问                                |
+| allowFrom       | string[] | dmPolicy = allowlist 时                 |
+| groupPolicy     | enum     | 始终询问                                |
+
+## 测试计划
+
+1. **单元测试**
+   - `listDingTalkAccountIds` 返回正确账户列表
+   - `resolveDingTalkAccount` 正确解析默认账户和命名账户
+   - `isConfigured` 正确判断配置状态
+
+2. **集成测试**
+   - 首次配置流程完整走通
+   - 修改现有配置
+   - 多账户配置
+
+## 风险与缓解
+
+| 风险                  | 影响 | 缓解措施                 |
+| --------------------- | ---- | ------------------------ |
+| OpenClaw SDK API 变更 | 中   | 使用类型导入，编译时报错 |
+| 配置格式不兼容        | 高   | 参考 tlon 实现确保一致性 |
+
+## 参考
+
+- tlon onboarding: https://github.com/openclaw/openclaw/blob/main/extensions/tlon/src/onboarding.ts
+- OpenClaw SDK types: https://github.com/openclaw/openclaw/blob/main/src/plugins/types.ts
+- ChannelPlugin interface: https://github.com/openclaw/openclaw/blob/main/src/channels/plugins/types.plugin.ts

--- a/extensions/openclaw-channel-dingtalk/docs/plans/2026-02-15-dingtalk-onboarding-impl.md
+++ b/extensions/openclaw-channel-dingtalk/docs/plans/2026-02-15-dingtalk-onboarding-impl.md
@@ -1,0 +1,561 @@
+# DingTalk Onboarding Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Implement interactive onboarding wizard for DingTalk channel plugin
+
+**Architecture:** Create `src/onboarding.ts` with `ChannelOnboardingAdapter` implementation, add helper functions to `types.ts`, and register adapter in `channel.ts`. Follow tlon extension pattern exactly.
+
+**Tech Stack:** TypeScript, OpenClaw Plugin SDK (ChannelOnboardingAdapter, WizardPrompter)
+
+---
+
+## Task 1: Add Helper Functions to types.ts
+
+**Files:**
+
+- Modify: `src/types.ts` (append to end of file)
+
+**Step 1: Add DEFAULT_ACCOUNT_ID import**
+
+Add at the beginning of the imports section (after line 11 where OpenClawConfig is imported):
+
+```typescript
+import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk";
+```
+
+**Step 2: Add listDingTalkAccountIds function**
+
+Append to end of file (after line 645):
+
+```typescript
+/**
+ * List all DingTalk account IDs from config
+ */
+export function listDingTalkAccountIds(cfg: OpenClawConfig): string[] {
+  const dingtalk = cfg.channels?.dingtalk as DingTalkChannelConfig | undefined;
+  if (!dingtalk) return [];
+
+  const accountIds: string[] = [];
+
+  // Check for direct configuration (default account)
+  if (dingtalk.clientId || dingtalk.clientSecret) {
+    accountIds.push(DEFAULT_ACCOUNT_ID);
+  }
+
+  // Check accounts object
+  if (dingtalk.accounts) {
+    accountIds.push(...Object.keys(dingtalk.accounts));
+  }
+
+  return accountIds;
+}
+
+/**
+ * Resolve a specific DingTalk account configuration
+ */
+export function resolveDingTalkAccount(
+  cfg: OpenClawConfig,
+  accountId?: string | null,
+): DingTalkConfig & { configured: boolean } {
+  const id = accountId || DEFAULT_ACCOUNT_ID;
+  const dingtalk = cfg.channels?.dingtalk as DingTalkChannelConfig | undefined;
+
+  // For default account, return top-level config
+  if (id === DEFAULT_ACCOUNT_ID) {
+    const config: DingTalkConfig = {
+      clientId: dingtalk?.clientId ?? "",
+      clientSecret: dingtalk?.clientSecret ?? "",
+      robotCode: dingtalk?.robotCode,
+      corpId: dingtalk?.corpId,
+      agentId: dingtalk?.agentId,
+      dmPolicy: dingtalk?.dmPolicy,
+      groupPolicy: dingtalk?.groupPolicy,
+      allowFrom: dingtalk?.allowFrom,
+      showThinking: dingtalk?.showThinking,
+      debug: dingtalk?.debug,
+      messageType: dingtalk?.messageType,
+      cardTemplateId: dingtalk?.cardTemplateId,
+      cardTemplateKey: dingtalk?.cardTemplateKey,
+      groups: dingtalk?.groups,
+      maxConnectionAttempts: dingtalk?.maxConnectionAttempts,
+      initialReconnectDelay: dingtalk?.initialReconnectDelay,
+      maxReconnectDelay: dingtalk?.maxReconnectDelay,
+      reconnectJitter: dingtalk?.reconnectJitter,
+    };
+    return {
+      ...config,
+      configured: Boolean(config.clientId && config.clientSecret),
+    };
+  }
+
+  // For named account, get from accounts object
+  const accountConfig = dingtalk?.accounts?.[id];
+  if (accountConfig) {
+    return {
+      ...accountConfig,
+      configured: Boolean(accountConfig.clientId && accountConfig.clientSecret),
+    };
+  }
+
+  // Account doesn't exist, return empty config
+  return {
+    clientId: "",
+    clientSecret: "",
+    configured: false,
+  };
+}
+```
+
+**Step 3: Run type check**
+
+Run: `npm run type-check`
+Expected: Exit code 0, no errors
+
+**Step 4: Commit**
+
+```bash
+git add src/types.ts
+git commit -m "feat: add listDingTalkAccountIds and resolveDingTalkAccount helpers"
+```
+
+---
+
+## Task 2: Create onboarding.ts
+
+**Files:**
+
+- Create: `src/onboarding.ts`
+
+**Step 1: Create onboarding.ts with full implementation**
+
+```typescript
+/**
+ * DingTalk Channel Onboarding Adapter
+ *
+ * Provides interactive configuration wizard for DingTalk channel setup.
+ * Follows the same pattern as tlon extension.
+ */
+
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import {
+  formatDocsLink,
+  promptAccountId,
+  DEFAULT_ACCOUNT_ID,
+  normalizeAccountId,
+  applyAccountNameToChannelSection,
+  type ChannelOnboardingAdapter,
+  type WizardPrompter,
+} from "openclaw/plugin-sdk";
+import type { DingTalkConfig } from "./types.js";
+import { listDingTalkAccountIds, resolveDingTalkAccount } from "./types.js";
+
+const channel = "dingtalk" as const;
+
+/**
+ * Check if account has required configuration
+ */
+function isConfigured(account: DingTalkConfig): boolean {
+  return Boolean(account.clientId && account.clientSecret);
+}
+
+/**
+ * Apply account configuration to OpenClawConfig
+ */
+function applyAccountConfig(params: {
+  cfg: OpenClawConfig;
+  accountId: string;
+  input: Partial<DingTalkConfig>;
+}): OpenClawConfig {
+  const { cfg, accountId, input } = params;
+  const useDefault = accountId === DEFAULT_ACCOUNT_ID;
+
+  // Apply account name first
+  const namedConfig = applyAccountNameToChannelSection({
+    cfg,
+    channelKey: "dingtalk",
+    accountId,
+    name: input.name,
+  });
+
+  const base = namedConfig.channels?.dingtalk ?? {};
+
+  // Build payload with only provided values
+  const payload: Record<string, unknown> = {};
+
+  if (input.clientId) payload.clientId = input.clientId;
+  if (input.clientSecret) payload.clientSecret = input.clientSecret;
+  if (input.robotCode) payload.robotCode = input.robotCode;
+  if (input.corpId) payload.corpId = input.corpId;
+  if (input.agentId) payload.agentId = input.agentId;
+  if (input.dmPolicy) payload.dmPolicy = input.dmPolicy;
+  if (input.groupPolicy) payload.groupPolicy = input.groupPolicy;
+  if (input.allowFrom && input.allowFrom.length > 0) payload.allowFrom = input.allowFrom;
+  if (input.messageType) payload.messageType = input.messageType;
+  if (input.cardTemplateId) payload.cardTemplateId = input.cardTemplateId;
+  if (input.cardTemplateKey) payload.cardTemplateKey = input.cardTemplateKey;
+
+  if (useDefault) {
+    return {
+      ...namedConfig,
+      channels: {
+        ...namedConfig.channels,
+        dingtalk: {
+          ...base,
+          enabled: true,
+          ...payload,
+        },
+      },
+    };
+  }
+
+  return {
+    ...namedConfig,
+    channels: {
+      ...namedConfig.channels,
+      dingtalk: {
+        ...base,
+        enabled: base.enabled ?? true,
+        accounts: {
+          ...(base as { accounts?: Record<string, unknown> }).accounts,
+          [accountId]: {
+            ...(base as { accounts?: Record<string, Record<string, unknown>> }).accounts?.[
+              accountId
+            ],
+            enabled: true,
+            ...payload,
+          },
+        },
+      },
+    },
+  };
+}
+
+/**
+ * Show DingTalk setup help to user
+ */
+async function noteDingTalkHelp(prompter: WizardPrompter): Promise<void> {
+  await prompter.note(
+    [
+      "You need DingTalk application credentials to proceed.",
+      "",
+      "1. Visit https://open-dev.dingtalk.com/",
+      "2. Create an enterprise internal application",
+      "3. Enable 'Robot' capability",
+      "4. Configure message receiving mode as 'Stream mode'",
+      "5. Copy Client ID (AppKey) and Client Secret (AppSecret)",
+      "",
+      `Docs: ${formatDocsLink("/channels/dingtalk", "channels/dingtalk")}`,
+    ].join("\n"),
+    "DingTalk Setup",
+  );
+}
+
+/**
+ * Parse comma/newline/semicolon separated list
+ */
+function parseList(value: string): string[] {
+  return value
+    .split(/[\n,;]+/g)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+/**
+ * DingTalk onboarding adapter
+ */
+export const dingtalkOnboardingAdapter: ChannelOnboardingAdapter = {
+  channel,
+
+  getStatus: async ({ cfg }) => {
+    const accountIds = listDingTalkAccountIds(cfg);
+    const configured =
+      accountIds.length > 0
+        ? accountIds.some((accountId) => isConfigured(resolveDingTalkAccount(cfg, accountId)))
+        : isConfigured(resolveDingTalkAccount(cfg, DEFAULT_ACCOUNT_ID));
+
+    return {
+      channel,
+      configured,
+      statusLines: [`DingTalk: ${configured ? "configured" : "needs setup"}`],
+      selectionHint: configured ? "configured" : "钉钉企业机器人",
+      quickstartScore: configured ? 1 : 4,
+    };
+  },
+
+  configure: async ({ cfg, prompter, accountOverrides, shouldPromptAccountIds }) => {
+    const override = accountOverrides[channel]?.trim();
+    const defaultAccountId = DEFAULT_ACCOUNT_ID;
+    let accountId = override ? normalizeAccountId(override) : defaultAccountId;
+
+    // Prompt for account ID if needed
+    if (shouldPromptAccountIds && !override) {
+      accountId = await promptAccountId({
+        cfg,
+        prompter,
+        label: "DingTalk",
+        currentId: accountId,
+        listAccountIds: listDingTalkAccountIds,
+        defaultAccountId,
+      });
+    }
+
+    const resolved = resolveDingTalkAccount(cfg, accountId);
+
+    // Show help
+    await noteDingTalkHelp(prompter);
+
+    // === Required fields ===
+    const clientId = await prompter.text({
+      message: "Client ID (AppKey)",
+      placeholder: "dingxxxxxxxx",
+      initialValue: resolved.clientId ?? undefined,
+      validate: (value) => (String(value ?? "").trim() ? undefined : "Required"),
+    });
+
+    const clientSecret = await prompter.text({
+      message: "Client Secret (AppSecret)",
+      placeholder: "xxx-xxx-xxx-xxx",
+      initialValue: resolved.clientSecret ?? undefined,
+      validate: (value) => (String(value ?? "").trim() ? undefined : "Required"),
+    });
+
+    // === Optional: Full credentials ===
+    const wantsFullConfig = await prompter.confirm({
+      message: "Configure robot code, corp ID, and agent ID? (recommended for full features)",
+      initialValue: false,
+    });
+
+    let robotCode: string | undefined;
+    let corpId: string | undefined;
+    let agentId: string | undefined;
+
+    if (wantsFullConfig) {
+      robotCode =
+        String(
+          await prompter.text({
+            message: "Robot Code",
+            placeholder: "dingxxxxxxxx",
+            initialValue: resolved.robotCode ?? undefined,
+          }),
+        ).trim() || undefined;
+
+      corpId =
+        String(
+          await prompter.text({
+            message: "Corp ID",
+            placeholder: "dingxxxxxxxx",
+            initialValue: resolved.corpId ?? undefined,
+          }),
+        ).trim() || undefined;
+
+      agentId =
+        String(
+          await prompter.text({
+            message: "Agent ID",
+            placeholder: "123456789",
+            initialValue: resolved.agentId ? String(resolved.agentId) : undefined,
+          }),
+        ).trim() || undefined;
+    }
+
+    // === Optional: AI Card mode ===
+    const wantsCardMode = await prompter.confirm({
+      message: "Enable AI interactive card mode? (for streaming AI responses)",
+      initialValue: resolved.messageType === "card",
+    });
+
+    let cardTemplateId: string | undefined;
+    let cardTemplateKey: string | undefined;
+
+    if (wantsCardMode) {
+      await prompter.note(
+        [
+          "To use AI cards, create a card template:",
+          "",
+          "1. Visit https://open-dev.dingtalk.com/fe/card",
+          "2. Click 'Create Template'",
+          "3. Select 'AI Card' scenario",
+          "4. Design and publish the template",
+          "5. Copy the template ID",
+        ].join("\n"),
+        "Card Template Setup",
+      );
+
+      cardTemplateId =
+        String(
+          await prompter.text({
+            message: "Card Template ID",
+            placeholder: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx.schema",
+            initialValue: resolved.cardTemplateId ?? undefined,
+          }),
+        ).trim() || undefined;
+
+      cardTemplateKey =
+        String(
+          await prompter.text({
+            message: "Card Template Content Key",
+            placeholder: "msgContent",
+            initialValue: resolved.cardTemplateKey ?? "msgContent",
+          }),
+        ).trim() || "msgContent";
+    }
+
+    // === DM Policy ===
+    const dmPolicy = (await prompter.select({
+      message: "Direct message policy",
+      options: [
+        { label: "Open - anyone can DM", value: "open" },
+        { label: "Allowlist - only approved users", value: "allowlist" },
+      ],
+      initialValue: resolved.dmPolicy ?? "open",
+    })) as "open" | "allowlist";
+
+    let allowFrom: string[] | undefined;
+    if (dmPolicy === "allowlist") {
+      const entry = await prompter.text({
+        message: "Allowed user IDs (comma-separated)",
+        placeholder: "user1, user2, user3",
+      });
+      const parsed = parseList(String(entry ?? ""));
+      allowFrom = parsed.length > 0 ? parsed : undefined;
+    }
+
+    // === Group Policy ===
+    const groupPolicy = (await prompter.select({
+      message: "Group message policy",
+      options: [
+        { label: "Open - any group can mention bot", value: "open" },
+        { label: "Allowlist - only approved groups", value: "allowlist" },
+      ],
+      initialValue: resolved.groupPolicy ?? "open",
+    })) as "open" | "allowlist";
+
+    // Build input object
+    const input: Partial<DingTalkConfig> = {
+      clientId: String(clientId).trim(),
+      clientSecret: String(clientSecret).trim(),
+      robotCode,
+      corpId,
+      agentId,
+      dmPolicy,
+      groupPolicy,
+      allowFrom,
+      messageType: wantsCardMode ? "card" : "markdown",
+      cardTemplateId,
+      cardTemplateKey,
+    };
+
+    // Apply configuration
+    const next = applyAccountConfig({
+      cfg,
+      accountId,
+      input,
+    });
+
+    return { cfg: next, accountId };
+  },
+};
+```
+
+**Step 2: Run type check**
+
+Run: `npm run type-check`
+Expected: Exit code 0, no errors
+
+**Step 3: Run lint**
+
+Run: `npm run lint`
+Expected: Exit code 0, no errors (or run `npm run lint:fix` to auto-fix)
+
+**Step 4: Commit**
+
+```bash
+git add src/onboarding.ts
+git commit -m "feat: add DingTalk onboarding adapter"
+```
+
+---
+
+## Task 3: Register Onboarding in channel.ts
+
+**Files:**
+
+- Modify: `src/channel.ts`
+
+**Step 1: Add import at top of file**
+
+Find line 1-20 where imports are, add after existing imports:
+
+```typescript
+import { dingtalkOnboardingAdapter } from "./onboarding.js";
+```
+
+**Step 2: Add onboarding property to dingtalkPlugin**
+
+Find the `dingtalkPlugin` definition (around line 1352), add `onboarding` property after `capabilities`:
+
+```typescript
+export const dingtalkPlugin: DingTalkChannelPlugin = {
+  id: 'dingtalk',
+  meta: { ... },
+  capabilities: { ... },
+
+  // Add this line:
+  onboarding: dingtalkOnboardingAdapter,
+
+  config: { ... },
+  // ... rest unchanged
+```
+
+**Step 3: Run type check**
+
+Run: `npm run type-check`
+Expected: Exit code 0, no errors
+
+**Step 4: Commit**
+
+```bash
+git add src/channel.ts
+git commit -m "feat: register onboarding adapter in DingTalk plugin"
+```
+
+---
+
+## Task 4: Final Verification
+
+**Step 1: Run full type check**
+
+Run: `npm run type-check`
+Expected: Exit code 0
+
+**Step 2: Run lint**
+
+Run: `npm run lint`
+Expected: Exit code 0
+
+**Step 3: Verify exports**
+
+Run: `grep -n "dingtalkOnboardingAdapter" src/onboarding.ts src/channel.ts`
+Expected:
+
+- `src/onboarding.ts`: export const dingtalkOnboardingAdapter
+- `src/channel.ts`: import { dingtalkOnboardingAdapter } from './onboarding.js'
+
+**Step 4: Final commit (if any fixes)**
+
+```bash
+git add -A
+git commit -m "feat: complete DingTalk onboarding implementation"
+```
+
+---
+
+## Summary
+
+| Task | Files Changed       | Description                                       |
+| ---- | ------------------- | ------------------------------------------------- |
+| 1    | `src/types.ts`      | Add helper functions for account resolution       |
+| 2    | `src/onboarding.ts` | Create onboarding adapter with interactive wizard |
+| 3    | `src/channel.ts`    | Register onboarding adapter in plugin definition  |
+| 4    | -                   | Final verification                                |

--- a/extensions/openclaw-channel-dingtalk/index.ts
+++ b/extensions/openclaw-channel-dingtalk/index.ts
@@ -1,0 +1,17 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
+import { dingtalkPlugin } from "./src/channel.js";
+import { setDingTalkRuntime } from "./src/runtime.js";
+
+const plugin = {
+  id: "dingtalk",
+  name: "DingTalk Channel",
+  description: "DingTalk (钉钉) messaging channel via Stream mode",
+  configSchema: emptyPluginConfigSchema(),
+  register(api: OpenClawPluginApi): void {
+    setDingTalkRuntime(api.runtime);
+    api.registerChannel({ plugin: dingtalkPlugin });
+  },
+};
+
+export default plugin;

--- a/extensions/openclaw-channel-dingtalk/openclaw.plugin.json
+++ b/extensions/openclaw-channel-dingtalk/openclaw.plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "dingtalk",
+  "channels": ["dingtalk"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": true,
+    "properties": {}
+  }
+}

--- a/extensions/openclaw-channel-dingtalk/package.json
+++ b/extensions/openclaw-channel-dingtalk/package.json
@@ -1,0 +1,65 @@
+{
+  "name": "@openclaw/dingtalk",
+  "version": "2.5.1",
+  "description": "DingTalk (钉钉) channel plugin for OpenClaw",
+  "keywords": [
+    "bot",
+    "channel",
+    "clawdbot",
+    "dingtalk",
+    "openclaw",
+    "stream",
+    "钉钉"
+  ],
+  "license": "MIT",
+  "author": "sym",
+  "type": "module",
+  "main": "index.ts",
+  "scripts": {
+    "lint": "eslint index.ts src/",
+    "lint:fix": "eslint --fix index.ts src/ && prettier --write index.ts src/",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "axios": "^1.6.0",
+    "dingtalk-stream": "^2.1.4",
+    "form-data": "^4.0.0",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@types/node": "^25.2.0",
+    "@typescript-eslint/eslint-plugin": "^6.0.0",
+    "@typescript-eslint/parser": "^6.0.0",
+    "eslint": "^8.0.0",
+    "eslint-config-prettier": "^9.0.0",
+    "prettier": "^3.0.0",
+    "typescript": "^5.3.0"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "channels": [
+      "dingtalk"
+    ],
+    "installDependencies": true,
+    "channel": {
+      "id": "dingtalk",
+      "label": "DingTalk",
+      "selectionLabel": "DingTalk (钉钉)",
+      "docsPath": "/channels/dingtalk",
+      "docsLabel": "dingtalk",
+      "blurb": "钉钉企业内部机器人，使用 Stream 模式，无需公网 IP。",
+      "order": 70,
+      "aliases": [
+        "dd",
+        "ding"
+      ]
+    },
+    "install": {
+      "npmSpec": "@openclaw/dingtalk",
+      "localPath": "extensions/dingtalk-channel",
+      "defaultChoice": "local"
+    }
+  }
+}

--- a/extensions/openclaw-channel-dingtalk/src/AGENTS.md
+++ b/extensions/openclaw-channel-dingtalk/src/AGENTS.md
@@ -1,0 +1,63 @@
+# SOURCE DIRECTORY
+
+**Parent:** `./AGENTS.md`
+
+## OVERVIEW
+
+All DingTalk plugin implementation logic.
+
+## STRUCTURE
+
+```
+src/
+├── channel.ts        # Main plugin definition, API calls, message handling, AI Card
+├── types.ts          # Type definitions (30+ interfaces, AI Card types)
+├── runtime.ts        # Runtime getter/setter pattern
+└── config-schema.ts  # Zod validation for configuration
+```
+
+## WHERE TO LOOK
+
+| Task                      | Location               | Notes                                        |
+| ------------------------- | ---------------------- | -------------------------------------------- |
+| Channel plugin definition | `channel.ts:862`       | `dingtalkPlugin` export                      |
+| AI Card operations        | `channel.ts:374-600`   | createAICard, streamAICard, finishAICard     |
+| Message sending           | `channel.ts:520-700`   | sendMessage, sendBySession                   |
+| Token management          | `channel.ts:156-177`   | getAccessToken with cache                    |
+| Message processing        | `channel.ts:643-859`   | handleDingTalkMessage, extractMessageContent |
+| Type exports              | `types.ts`             | All interfaces/constants                     |
+| Public API exports        | `channel.ts:1068-1076` | sendBySession, createAICard, etc.            |
+
+## CONVENTIONS
+
+Same as root. No src-specific deviations.
+
+## ANTI-PATTERNS
+
+**Prohibited:**
+
+- Mutating module-level state outside of initialized functions
+- Creating multiple AI Card instances for same conversationId (use cached)
+- Calling DingTalk APIs without access token
+- Suppressing errors in async handlers
+
+## UNIQUE STYLES
+
+**AI Card State Machine:**
+
+- States: PROCESSING → INPUTING → FINISHED/FAILED
+- Cached in `Map<string, AICardInstance>` with TTL cleanup
+- Terminal states (FINISHED/FAILED) cleaned after 1 hour
+
+**Access Token Caching:**
+
+- Module-level variables: `accessToken`, `accessTokenExpiry`
+- Refresh 60s before expiry
+- Retry logic for 401/429/5xx errors
+
+**Message Type Handling:**
+
+- `text`: Plain text messages
+- `richText`: Extract text + @mentions
+- `picture/audio/video/file`: Download to `/tmp/dingtalk_*`
+- Auto-detect Markdown syntax for auto-formatting

--- a/extensions/openclaw-channel-dingtalk/src/channel.ts
+++ b/extensions/openclaw-channel-dingtalk/src/channel.ts
@@ -1,0 +1,1911 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import axios from "axios";
+import { DWClient, TOPIC_ROBOT } from "dingtalk-stream";
+import { randomUUID } from "node:crypto";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { buildChannelConfigSchema } from "openclaw/plugin-sdk";
+import type {
+  DingTalkConfig,
+  TokenInfo,
+  DingTalkInboundMessage,
+  MessageContent,
+  SendMessageOptions,
+  MediaFile,
+  HandleDingTalkMessageParams,
+  ProactiveMessagePayload,
+  SessionWebhookResponse,
+  AxiosResponse,
+  Logger,
+  ResolvedAccount,
+  GatewayStartContext,
+  GatewayStopResult,
+  AICardInstance,
+  AICardStreamingRequest,
+  ConnectionManagerConfig,
+} from "./types.js";
+import { maskSensitiveData, cleanupOrphanedTempFiles, retryWithBackoff } from "../utils.js";
+import { DingTalkConfigSchema } from "./config-schema.js";
+import { ConnectionManager } from "./connection-manager.js";
+import { detectMediaTypeFromExtension, uploadMedia as uploadMediaUtil } from "./media-utils.js";
+import { dingtalkOnboardingAdapter } from "./onboarding.js";
+import { registerPeerId, resolveOriginalPeerId } from "./peer-id-registry.js";
+import { getDingTalkRuntime } from "./runtime.js";
+import { AICardStatus, ConnectionState } from "./types.js";
+
+/**
+ * Get current timestamp in ISO 8601 format for status tracking
+ */
+function getCurrentTimestamp(): number {
+  return Date.now();
+}
+
+// Access Token cache - keyed by clientId for multi-account support
+interface TokenCache {
+  accessToken: string;
+  expiry: number;
+}
+const accessTokenCache = new Map<string, TokenCache>();
+
+// Global logger reference for use across module methods
+let currentLogger: Logger | undefined;
+
+// AI Card instance cache for streaming updates
+const aiCardInstances = new Map<string, AICardInstance>();
+
+// Target to active AI Card instance ID mapping (accountId:conversationId -> cardInstanceId)
+// Used to quickly lookup existing active cards for a target
+const activeCardsByTarget = new Map<string, string>();
+
+// Card cache TTL (1 hour)
+const CARD_CACHE_TTL = 60 * 60 * 1000; // 1 hour
+
+// DingTalk API base URL
+const DINGTALK_API = "https://api.dingtalk.com";
+
+// ============ Message Deduplication ============
+// Prevents duplicate message processing when DingTalk retries delivery
+// Uses pure in-memory storage with short TTL and lazy cleanup during processing
+
+const processedMessages = new Map<string, number>(); // Map<dedupKey, expiresAt>
+const MESSAGE_DEDUP_TTL = 60000; // 60 seconds
+const MESSAGE_DEDUP_MAX_SIZE = 1000; // Hard cap to prevent memory pressure during bursts
+let messageCounter = 0; // Counter for deterministic cleanup triggering (safe due to Node.js single-threaded event loop)
+
+// Check if message was already processed (with lazy cleanup of expired entries)
+function isMessageProcessed(dedupKey: string): boolean {
+  const now = Date.now();
+  const expiresAt = processedMessages.get(dedupKey);
+
+  if (expiresAt === undefined) {
+    return false;
+  }
+
+  // Lazy cleanup: remove expired entry if found
+  if (now >= expiresAt) {
+    processedMessages.delete(dedupKey);
+    return false;
+  }
+
+  return true;
+}
+
+// Mark message as processed with bot-scoped key
+function markMessageProcessed(dedupKey: string): void {
+  const expiresAt = Date.now() + MESSAGE_DEDUP_TTL;
+  processedMessages.set(dedupKey, expiresAt);
+
+  // Hard cap: if Map exceeds max size, force immediate cleanup
+  if (processedMessages.size > MESSAGE_DEDUP_MAX_SIZE) {
+    const now = Date.now();
+    for (const [key, expiry] of processedMessages.entries()) {
+      if (now >= expiry) {
+        processedMessages.delete(key);
+      }
+    }
+    // If still over limit after cleanup, clear oldest entries (safety valve)
+    // Maps maintain insertion order, so we can delete early entries
+    if (processedMessages.size > MESSAGE_DEDUP_MAX_SIZE) {
+      const removeCount = processedMessages.size - MESSAGE_DEDUP_MAX_SIZE;
+      let removed = 0;
+      for (const key of processedMessages.keys()) {
+        processedMessages.delete(key);
+        if (++removed >= removeCount) break;
+      }
+    }
+    return; // Skip regular cleanup since we just did a full sweep
+  }
+
+  // Lazy cleanup: remove expired entries deterministically every 10 messages
+  // With 60s TTL, Map stays small under normal load, but we avoid cleanup on every message for performance
+  messageCounter++;
+  if (messageCounter >= 10) {
+    messageCounter = 0;
+    const now = Date.now();
+    for (const [key, expiry] of processedMessages.entries()) {
+      if (now >= expiry) {
+        processedMessages.delete(key);
+      }
+    }
+  }
+}
+
+// Authorization helpers
+type NormalizedAllowFrom = {
+  entries: string[];
+  entriesLower: string[];
+  hasWildcard: boolean;
+  hasEntries: boolean;
+};
+
+/**
+ * Normalize allowFrom list to standardized format
+ */
+function normalizeAllowFrom(list?: Array<string>): NormalizedAllowFrom {
+  const entries = (list ?? []).map((value) => String(value).trim()).filter(Boolean);
+  const hasWildcard = entries.includes("*");
+  const normalized = entries
+    .filter((value) => value !== "*")
+    .map((value) => value.replace(/^(dingtalk|dd|ding):/i, ""));
+  const normalizedLower = normalized.map((value) => value.toLowerCase());
+  return {
+    entries: normalized,
+    entriesLower: normalizedLower,
+    hasWildcard,
+    hasEntries: entries.length > 0,
+  };
+}
+
+/**
+ * Check if sender is allowed based on allowFrom list
+ */
+function isSenderAllowed(params: { allow: NormalizedAllowFrom; senderId?: string }): boolean {
+  const { allow, senderId } = params;
+  if (!allow.hasEntries) return true;
+  if (allow.hasWildcard) return true;
+  if (senderId && allow.entriesLower.includes(senderId.toLowerCase())) return true;
+  return false;
+}
+
+// 群组通道授权
+function isSenderGroupAllowed(params: { allow: NormalizedAllowFrom; groupId?: string }): boolean {
+  const { allow, groupId } = params;
+
+  if (groupId && allow.entriesLower.includes(groupId.toLowerCase())) return true;
+  return false;
+}
+
+// Helper function to check if a card is in a terminal state
+function isCardInTerminalState(state: string): boolean {
+  return state === AICardStatus.FINISHED || state === AICardStatus.FAILED;
+}
+
+// Clean up old AI card instances from cache
+function cleanupCardCache() {
+  const now = Date.now();
+
+  // Clean up AI card instances that are in FINISHED or FAILED state
+  // Active cards (PROCESSING, INPUTING) are not cleaned up even if they exceed TTL
+  for (const [cardInstanceId, instance] of aiCardInstances.entries()) {
+    if (isCardInTerminalState(instance.state) && now - instance.lastUpdated > CARD_CACHE_TTL) {
+      // Remove from aiCardInstances
+      aiCardInstances.delete(cardInstanceId);
+
+      // Remove from activeCardsByTarget mapping (break after first match for efficiency)
+      for (const [targetKey, mappedCardId] of activeCardsByTarget.entries()) {
+        if (mappedCardId === cardInstanceId) {
+          activeCardsByTarget.delete(targetKey);
+          break; // Each card should only have one target mapping
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Get the current logger instance
+ * Useful for methods that don't receive log as a parameter
+ */
+function getLogger(): Logger | undefined {
+  return currentLogger;
+}
+
+// Helper function to detect markdown and extract title
+function detectMarkdownAndExtractTitle(
+  text: string,
+  options: SendMessageOptions,
+  defaultTitle: string,
+): { useMarkdown: boolean; title: string } {
+  const hasMarkdown = /^[#*>-]|[*_`#[\]]/.test(text) || text.includes("\n");
+  const useMarkdown = options.useMarkdown !== false && (options.useMarkdown || hasMarkdown);
+
+  const title =
+    options.title ||
+    (useMarkdown
+      ? text
+          .split("\n")[0]
+          .replace(/^[#*\s\->]+/, "")
+          .slice(0, 20) || defaultTitle
+      : defaultTitle);
+
+  return { useMarkdown, title };
+}
+
+// ============ Group Members Persistence ============
+
+function groupMembersFilePath(storePath: string, groupId: string): string {
+  const dir = path.join(path.dirname(storePath), "dingtalk-members");
+  const safeId = groupId.replace(/\+/g, "-").replace(/\//g, "_");
+  return path.join(dir, `${safeId}.json`);
+}
+
+function noteGroupMember(storePath: string, groupId: string, userId: string, name: string): void {
+  if (!userId || !name) return;
+  const filePath = groupMembersFilePath(storePath, groupId);
+  let roster: Record<string, string> = {};
+  try {
+    roster = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+  } catch {}
+  if (roster[userId] === name) return;
+  roster[userId] = name;
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(roster, null, 2));
+}
+
+function formatGroupMembers(storePath: string, groupId: string): string | undefined {
+  const filePath = groupMembersFilePath(storePath, groupId);
+  let roster: Record<string, string> = {};
+  try {
+    roster = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+  } catch {
+    return undefined;
+  }
+  const entries = Object.entries(roster);
+  if (entries.length === 0) return undefined;
+  return entries.map(([id, name]) => `${name} (${id})`).join(", ");
+}
+
+// ============ Group Config Resolution ============
+
+function resolveGroupConfig(
+  cfg: DingTalkConfig,
+  groupId: string,
+): { systemPrompt?: string } | undefined {
+  const groups = cfg.groups;
+  if (!groups) return undefined;
+  return groups[groupId] || groups["*"] || undefined;
+}
+
+// ============ Target Prefix Helpers ============
+
+/**
+ * Strip group: or user: prefix from target ID
+ * Returns the raw targetId and whether it was explicitly marked as a user
+ */
+function stripTargetPrefix(target: string): { targetId: string; isExplicitUser: boolean } {
+  if (target.startsWith("group:")) {
+    return { targetId: target.slice(6), isExplicitUser: false };
+  }
+  if (target.startsWith("user:")) {
+    return { targetId: target.slice(5), isExplicitUser: true };
+  }
+  return { targetId: target, isExplicitUser: false };
+}
+
+// ============ Config Helpers ============
+
+function getConfig(cfg: OpenClawConfig, accountId?: string): DingTalkConfig {
+  const dingtalkCfg = cfg?.channels?.dingtalk as DingTalkConfig | undefined;
+  if (!dingtalkCfg) return {} as DingTalkConfig;
+
+  if (accountId && dingtalkCfg.accounts?.[accountId]) {
+    return dingtalkCfg.accounts[accountId];
+  }
+
+  return dingtalkCfg;
+}
+
+function isConfigured(cfg: OpenClawConfig, accountId?: string): boolean {
+  const config = getConfig(cfg, accountId);
+  return Boolean(config.clientId && config.clientSecret);
+}
+
+const DEFAULT_AGENT_ID = "main";
+const VALID_AGENT_ID_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/i;
+const INVALID_AGENT_ID_CHARS_RE = /[^a-z0-9_-]+/g;
+const LEADING_DASH_RE = /^-+/;
+const TRAILING_DASH_RE = /-+$/;
+
+function normalizeAgentId(value: string | undefined | null): string {
+  const trimmed = (value ?? "").trim();
+  if (!trimmed) return DEFAULT_AGENT_ID;
+  if (VALID_AGENT_ID_RE.test(trimmed)) return trimmed.toLowerCase();
+  return (
+    trimmed
+      .toLowerCase()
+      .replace(INVALID_AGENT_ID_CHARS_RE, "-")
+      .replace(LEADING_DASH_RE, "")
+      .replace(TRAILING_DASH_RE, "")
+      .slice(0, 64) || DEFAULT_AGENT_ID
+  );
+}
+
+function resolveUserPath(input: string): string {
+  const trimmed = input.trim();
+  if (!trimmed) return trimmed;
+  if (trimmed.startsWith("~")) {
+    const expanded = trimmed.replace(/^~(?=$|[\\/])/, os.homedir());
+    return path.resolve(expanded);
+  }
+  return path.resolve(trimmed);
+}
+
+function resolveDefaultAgentWorkspaceDir(): string {
+  const profile = process.env.OPENCLAW_PROFILE?.trim();
+  if (profile && profile.toLowerCase() !== "default") {
+    return path.join(os.homedir(), ".openclaw", `workspace-${profile}`);
+  }
+  return path.join(os.homedir(), ".openclaw", "workspace");
+}
+
+interface AgentConfig {
+  id?: string;
+  default?: boolean;
+  workspace?: string;
+}
+
+function resolveDefaultAgentId(cfg: OpenClawConfig): string {
+  const agents: AgentConfig[] = cfg.agents?.list ?? [];
+  if (agents.length === 0) return DEFAULT_AGENT_ID;
+  const defaults = agents.filter((agent: AgentConfig) => agent?.default);
+  const chosen = (defaults[0] ?? agents[0])?.id?.trim();
+  return normalizeAgentId(chosen || DEFAULT_AGENT_ID);
+}
+
+function resolveAgentWorkspaceDir(cfg: OpenClawConfig, agentId: string): string {
+  const id = normalizeAgentId(agentId);
+  const agents: AgentConfig[] = cfg.agents?.list ?? [];
+  const agent = agents.find((entry: AgentConfig) => normalizeAgentId(entry?.id) === id);
+  const configured = agent?.workspace?.trim();
+  if (configured) return resolveUserPath(configured);
+  const defaultAgentId = resolveDefaultAgentId(cfg);
+  if (id === defaultAgentId) {
+    const fallback = cfg.agents?.defaults?.workspace?.trim();
+    if (fallback) return resolveUserPath(fallback);
+    return resolveDefaultAgentWorkspaceDir();
+  }
+  return path.join(os.homedir(), ".openclaw", `workspace-${id}`);
+}
+
+// Get Access Token with retry logic - uses clientId-based cache for multi-account support
+async function getAccessToken(config: DingTalkConfig, log?: Logger): Promise<string> {
+  const cacheKey = config.clientId;
+  const now = Date.now();
+  const cached = accessTokenCache.get(cacheKey);
+
+  if (cached && cached.expiry > now + 60000) {
+    return cached.accessToken;
+  }
+
+  const token = await retryWithBackoff(
+    async () => {
+      const response = await axios.post<TokenInfo>(
+        "https://api.dingtalk.com/v1.0/oauth2/accessToken",
+        {
+          appKey: config.clientId,
+          appSecret: config.clientSecret,
+        },
+      );
+
+      // Store in cache with clientId as key
+      accessTokenCache.set(cacheKey, {
+        accessToken: response.data.accessToken,
+        expiry: now + response.data.expireIn * 1000,
+      });
+
+      return response.data.accessToken;
+    },
+    { maxRetries: 3, log },
+  );
+
+  return token;
+}
+
+// Wrapper function to upload media via uploadMediaUtil with getAccessToken bound
+async function uploadMedia(
+  config: DingTalkConfig,
+  mediaPath: string,
+  mediaType: "image" | "voice" | "video" | "file",
+  log?: Logger,
+): Promise<string | null> {
+  return uploadMediaUtil(config, mediaPath, mediaType, getAccessToken, log);
+}
+
+// Send text/markdown proactive message via DingTalk OpenAPI
+async function sendProactiveTextOrMarkdown(
+  config: DingTalkConfig,
+  target: string,
+  text: string,
+  options: SendMessageOptions = {},
+): Promise<AxiosResponse> {
+  const token = await getAccessToken(config, options.log);
+  const log = options.log || getLogger();
+
+  // Support group: and user: prefixes, and resolve case-sensitive conversationId
+  const { targetId, isExplicitUser } = stripTargetPrefix(target);
+  const resolvedTarget = resolveOriginalPeerId(targetId);
+  const isGroup = !isExplicitUser && resolvedTarget.startsWith("cid");
+
+  const url = isGroup
+    ? "https://api.dingtalk.com/v1.0/robot/groupMessages/send"
+    : "https://api.dingtalk.com/v1.0/robot/oToMessages/batchSend";
+
+  // Use shared helper function for markdown detection and title extraction
+  const { useMarkdown, title } = detectMarkdownAndExtractTitle(text, options, "OpenClaw 提醒");
+
+  log?.debug?.(
+    `[DingTalk] Sending proactive message to ${isGroup ? "group" : "user"} ${resolvedTarget} with title "${title}"`,
+  );
+
+  // Choose msgKey based on whether we're sending markdown or plain text
+  // Note: DingTalk's proactive message API uses predefined message templates
+  // sampleMarkdown supports markdown formatting, sampleText for plain text
+  const msgKey = useMarkdown ? "sampleMarkdown" : "sampleText";
+  const msgParam = useMarkdown
+    ? JSON.stringify({ title, text })
+    : JSON.stringify({ content: text });
+
+  const payload: ProactiveMessagePayload = {
+    robotCode: config.robotCode || config.clientId,
+    msgKey,
+    msgParam,
+  };
+
+  if (isGroup) {
+    payload.openConversationId = resolvedTarget;
+  } else {
+    payload.userIds = [resolvedTarget];
+  }
+
+  const result = await axios({
+    url,
+    method: "POST",
+    data: payload,
+    headers: { "x-acs-dingtalk-access-token": token, "Content-Type": "application/json" },
+  });
+  return result.data;
+}
+
+// Send proactive media message via DingTalk OpenAPI
+async function sendProactiveMedia(
+  config: DingTalkConfig,
+  target: string,
+  mediaPath: string,
+  mediaType: "image" | "voice" | "video" | "file",
+  options: SendMessageOptions & { accountId?: string } = {},
+): Promise<{ ok: boolean; error?: string; data?: any; messageId?: string }> {
+  const log = options.log || getLogger();
+
+  try {
+    // Upload media first to get media_id
+    const mediaId = await uploadMedia(config, mediaPath, mediaType, log);
+    if (!mediaId) {
+      return { ok: false, error: "Failed to upload media" };
+    }
+
+    const token = await getAccessToken(config, log);
+    const { targetId, isExplicitUser } = stripTargetPrefix(target);
+    const resolvedTarget = resolveOriginalPeerId(targetId);
+    const isGroup = !isExplicitUser && resolvedTarget.startsWith("cid");
+
+    const DINGTALK_API = "https://api.dingtalk.com";
+    const url = isGroup
+      ? `${DINGTALK_API}/v1.0/robot/groupMessages/send`
+      : `${DINGTALK_API}/v1.0/robot/oToMessages/batchSend`;
+
+    // Build payload based on media type
+    // For personal messages (oToMessages), use native media message types
+    // For group messages (groupMessages), use sampleImageMsg/sampleAudio/etc.
+    let msgKey: string;
+    let msgParam: string;
+
+    if (mediaType === "image") {
+      msgKey = "sampleImageMsg";
+      msgParam = JSON.stringify({ photoURL: mediaId });
+    } else if (mediaType === "voice") {
+      msgKey = "sampleAudio";
+      msgParam = JSON.stringify({ mediaId, duration: "0" });
+    } else {
+      // File-like media (including video)
+      // Note: sampleVideo requires a cover image (picMediaId) which we don't have,
+      // so we fall back to sampleFile for video to avoid .octet-stream issues.
+      const filename = path.basename(mediaPath);
+      const defaultExt = mediaType === "video" ? "mp4" : "file";
+      const ext = path.extname(mediaPath).slice(1) || defaultExt;
+      msgKey = "sampleFile";
+      msgParam = JSON.stringify({ mediaId, fileName: filename, fileType: ext });
+    }
+
+    const payload: ProactiveMessagePayload = {
+      robotCode: config.robotCode || config.clientId,
+      msgKey,
+      msgParam,
+    };
+
+    if (isGroup) {
+      payload.openConversationId = resolvedTarget;
+    } else {
+      payload.userIds = [resolvedTarget];
+    }
+
+    log?.debug?.(
+      `[DingTalk] Sending proactive ${mediaType} message to ${isGroup ? "group" : "user"} ${resolvedTarget}`,
+    );
+
+    const result = await axios({
+      url,
+      method: "POST",
+      data: payload,
+      headers: { "x-acs-dingtalk-access-token": token, "Content-Type": "application/json" },
+    });
+
+    const messageId = result.data?.processQueryKey || result.data?.messageId;
+    return { ok: true, data: result.data, messageId };
+  } catch (err: any) {
+    log?.error?.(`[DingTalk] Failed to send proactive media: ${err.message}`);
+    if (axios.isAxiosError(err) && err.response) {
+      log?.error?.(`[DingTalk] Response: ${JSON.stringify(err.response.data)}`);
+    }
+    return { ok: false, error: err.message };
+  }
+}
+
+// Download media file to agent workspace (sandbox-compatible)
+// workspacePath: the agent's workspace directory (e.g., /home/node/.openclaw/workspace)
+async function downloadMedia(
+  config: DingTalkConfig,
+  downloadCode: string,
+  workspacePath: string,
+  log?: Logger,
+): Promise<MediaFile | null> {
+  const formatAxiosErrorData = (value: unknown): string | undefined => {
+    if (value === null || value === undefined) return undefined;
+    if (Buffer.isBuffer(value)) return `<buffer ${value.length} bytes>`;
+    if (value instanceof ArrayBuffer) return `<arraybuffer ${value.byteLength} bytes>`;
+    if (typeof value === "string") return value.length > 500 ? `${value.slice(0, 500)}…` : value;
+    try {
+      return JSON.stringify(maskSensitiveData(value));
+    } catch {
+      return String(value);
+    }
+  };
+
+  if (!downloadCode) {
+    log?.error?.("[DingTalk] downloadMedia requires downloadCode to be provided.");
+    return null;
+  }
+  if (!config.robotCode) {
+    if (log?.error) {
+      log.error("[DingTalk] downloadMedia requires robotCode to be configured.");
+    }
+    return null;
+  }
+  try {
+    const token = await getAccessToken(config, log);
+    const response = await axios.post(
+      "https://api.dingtalk.com/v1.0/robot/messageFiles/download",
+      { downloadCode, robotCode: config.robotCode },
+      { headers: { "x-acs-dingtalk-access-token": token } },
+    );
+    const payload = response.data as Record<string, any>;
+    const downloadUrl = payload?.downloadUrl ?? payload?.data?.downloadUrl;
+    if (!downloadUrl) {
+      const payloadDetail = formatAxiosErrorData(payload);
+      log?.error?.(
+        `[DingTalk] downloadMedia missing downloadUrl. payload=${payloadDetail ?? "unknown"}`,
+      );
+      return null;
+    }
+    const mediaResponse = await axios.get(downloadUrl, { responseType: "arraybuffer" });
+    const contentType = mediaResponse.headers["content-type"] || "application/octet-stream";
+    const buffer = Buffer.from(mediaResponse.data as ArrayBuffer);
+
+    // Save to agent workspace's media/inbound/ directory (sandbox-compatible)
+    // This ensures the file is accessible within the sandbox
+    const mediaDir = path.join(workspacePath, "media", "inbound");
+    fs.mkdirSync(mediaDir, { recursive: true });
+
+    const ext = contentType.split("/")[1]?.split(";")[0] || "bin";
+    const filename = `${Date.now()}_${Math.random().toString(36).slice(2, 8)}.${ext}`;
+    const mediaPath = path.join(mediaDir, filename);
+
+    fs.writeFileSync(mediaPath, buffer);
+    log?.debug?.(`[DingTalk] Media saved to workspace: ${mediaPath}`);
+    return { path: mediaPath, mimeType: contentType };
+  } catch (err: any) {
+    if (log?.error) {
+      if (axios.isAxiosError(err)) {
+        const status = err.response?.status;
+        const statusText = err.response?.statusText;
+        const dataDetail = formatAxiosErrorData(err.response?.data);
+        const code = err.code ? ` code=${err.code}` : "";
+        const statusLabel = status ? ` status=${status}${statusText ? ` ${statusText}` : ""}` : "";
+        log.error(
+          `[DingTalk] Failed to download media:${statusLabel}${code} message=${err.message}`,
+        );
+        if (dataDetail) {
+          log.error(`[DingTalk] downloadMedia response data: ${dataDetail}`);
+        }
+      } else {
+        log.error(`[DingTalk] Failed to download media: ${err.message}`);
+      }
+    }
+    return null;
+  }
+}
+
+function extractMessageContent(data: DingTalkInboundMessage): MessageContent {
+  const msgtype = data.msgtype || "text";
+
+  // Logic for different message types
+  if (msgtype === "text") {
+    return { text: data.text?.content?.trim() || "", messageType: "text" };
+  }
+
+  // Improved richText parsing: join all text/at components and extract first picture
+  if (msgtype === "richText") {
+    const richTextParts = data.content?.richText || [];
+    let text = "";
+    let pictureDownloadCode: string | undefined;
+    for (const part of richTextParts) {
+      // Handle text content: include explicit text type or undefined type field (DingTalk may omit type)
+      if (part.text && (part.type === "text" || part.type === undefined)) text += part.text;
+      if (part.type === "at" && part.atName) text += `@${part.atName} `;
+      // Extract first picture's downloadCode from richText
+      if (part.type === "picture" && part.downloadCode && !pictureDownloadCode) {
+        pictureDownloadCode = part.downloadCode;
+      }
+    }
+    return {
+      text: text.trim() || (pictureDownloadCode ? "<media:image>" : "[富文本消息]"),
+      mediaPath: pictureDownloadCode,
+      mediaType: pictureDownloadCode ? "image" : undefined,
+      messageType: "richText",
+    };
+  }
+
+  if (msgtype === "picture") {
+    return {
+      text: "<media:image>",
+      mediaPath: data.content?.downloadCode,
+      mediaType: "image",
+      messageType: "picture",
+    };
+  }
+
+  if (msgtype === "audio") {
+    return {
+      text: data.content?.recognition || "<media:voice>",
+      mediaPath: data.content?.downloadCode,
+      mediaType: "audio",
+      messageType: "audio",
+    };
+  }
+
+  if (msgtype === "video") {
+    return {
+      text: "<media:video>",
+      mediaPath: data.content?.downloadCode,
+      mediaType: "video",
+      messageType: "video",
+    };
+  }
+
+  if (msgtype === "file") {
+    return {
+      text: `<media:file> (${data.content?.fileName || "文件"})`,
+      mediaPath: data.content?.downloadCode,
+      mediaType: "file",
+      messageType: "file",
+    };
+  }
+
+  // Fallback
+  return { text: data.text?.content?.trim() || `[${msgtype}消息]`, messageType: msgtype };
+}
+
+// Send message via sessionWebhook
+async function sendBySession(
+  config: DingTalkConfig,
+  sessionWebhook: string,
+  text: string,
+  options: SendMessageOptions = {},
+): Promise<AxiosResponse> {
+  const token = await getAccessToken(config, options.log);
+  const log = options.log || getLogger();
+
+  // If mediaPath is provided, upload media and send as native media message
+  if (options.mediaPath && options.mediaType) {
+    const mediaId = await uploadMedia(config, options.mediaPath, options.mediaType, log);
+    if (mediaId) {
+      let body: any;
+
+      // Construct message body based on media type
+      if (options.mediaType === "image") {
+        body = { msgtype: "image", image: { media_id: mediaId } };
+      } else if (options.mediaType === "voice") {
+        body = { msgtype: "voice", voice: { media_id: mediaId } };
+      } else if (options.mediaType === "video") {
+        body = { msgtype: "video", video: { media_id: mediaId } };
+      } else if (options.mediaType === "file") {
+        body = { msgtype: "file", file: { media_id: mediaId } };
+      }
+
+      if (body) {
+        const result = await axios({
+          url: sessionWebhook,
+          method: "POST",
+          data: body,
+          headers: { "x-acs-dingtalk-access-token": token, "Content-Type": "application/json" },
+        });
+        return result.data;
+      }
+    } else {
+      log?.warn?.("[DingTalk] Media upload failed, falling back to text description");
+    }
+  }
+
+  // Use shared helper function for markdown detection and title extraction
+  const { useMarkdown, title } = detectMarkdownAndExtractTitle(text, options, "Clawdbot 消息");
+
+  let body: SessionWebhookResponse;
+  if (useMarkdown) {
+    let finalText = text;
+    if (options.atUserId) finalText = `${finalText} @${options.atUserId}`;
+    body = { msgtype: "markdown", markdown: { title, text: finalText } };
+  } else {
+    body = { msgtype: "text", text: { content: text } };
+  }
+
+  if (options.atUserId) body.at = { atUserIds: [options.atUserId], isAtAll: false };
+
+  const result = await axios({
+    url: sessionWebhook,
+    method: "POST",
+    data: body,
+    headers: { "x-acs-dingtalk-access-token": token, "Content-Type": "application/json" },
+  });
+  return result.data;
+}
+
+// ============ AI Card API Functions ============
+
+/**
+ * Create and deliver an AI Card using the new DingTalk API (createAndDeliver)
+ * @param config DingTalk configuration
+ * @param conversationId Conversation ID (starts with 'cid' for groups, user ID for DM)
+ * @param data Original message data for context
+ * @param accountId Account ID for multi-account support
+ * @param log Logger instance
+ * @returns AI Card instance or null on failure
+ */
+async function createAICard(
+  config: DingTalkConfig,
+  conversationId: string,
+  data: DingTalkInboundMessage,
+  accountId: string,
+  log?: Logger,
+): Promise<AICardInstance | null> {
+  try {
+    const token = await getAccessToken(config, log);
+    // Use crypto.randomUUID() for robust GUID generation instead of Date.now() + random
+    const cardInstanceId = `card_${randomUUID()}`;
+
+    log?.info?.(`[DingTalk][AICard] Creating and delivering card outTrackId=${cardInstanceId}`);
+    log?.debug?.(
+      `[DingTalk][AICard] conversationType=${data.conversationType}, conversationId=${conversationId}`,
+    );
+
+    const isGroup = conversationId.startsWith("cid");
+
+    if (!config.cardTemplateId) {
+      throw new Error("DingTalk cardTemplateId is not configured.");
+    }
+
+    // Build the createAndDeliver request body
+    const createAndDeliverBody = {
+      cardTemplateId: config.cardTemplateId,
+      outTrackId: cardInstanceId,
+      cardData: {
+        cardParamMap: {},
+      },
+      callbackType: "STREAM",
+      imGroupOpenSpaceModel: { supportForward: true },
+      imRobotOpenSpaceModel: { supportForward: true },
+      openSpaceId: isGroup
+        ? `dtv1.card//IM_GROUP.${conversationId}`
+        : `dtv1.card//IM_ROBOT.${conversationId}`,
+      userIdType: 1,
+      imGroupOpenDeliverModel: isGroup
+        ? { robotCode: config.robotCode || config.clientId }
+        : undefined,
+      imRobotOpenDeliverModel: !isGroup ? { spaceType: "IM_ROBOT" } : undefined,
+    };
+
+    if (isGroup && !config.robotCode) {
+      log?.warn?.(
+        "[DingTalk][AICard] robotCode not configured, using clientId as fallback. " +
+          "For best compatibility, set robotCode explicitly in config.",
+      );
+    }
+
+    log?.debug?.(
+      `[DingTalk][AICard] POST /v1.0/card/instances/createAndDeliver body=${JSON.stringify(createAndDeliverBody)}`,
+    );
+    const resp = await axios.post(
+      `${DINGTALK_API}/v1.0/card/instances/createAndDeliver`,
+      createAndDeliverBody,
+      {
+        headers: { "x-acs-dingtalk-access-token": token, "Content-Type": "application/json" },
+      },
+    );
+    log?.debug?.(
+      `[DingTalk][AICard] CreateAndDeliver response: status=${resp.status} data=${JSON.stringify(resp.data)}`,
+    );
+
+    // Cache the AI card instance with config reference for token refresh
+    const aiCardInstance: AICardInstance = {
+      cardInstanceId,
+      accessToken: token,
+      conversationId,
+      createdAt: Date.now(),
+      lastUpdated: Date.now(),
+      state: AICardStatus.PROCESSING, // Initial state after creation
+      config, // Store config reference for token refresh
+    };
+    aiCardInstances.set(cardInstanceId, aiCardInstance);
+
+    // Add mapping from target to active card ID (accountId:conversationId -> cardInstanceId)
+    const targetKey = `${accountId}:${conversationId}`;
+    activeCardsByTarget.set(targetKey, cardInstanceId);
+    log?.debug?.(
+      `[DingTalk][AICard] Registered active card mapping: ${targetKey} -> ${cardInstanceId}`,
+    );
+
+    return aiCardInstance;
+  } catch (err: any) {
+    log?.error?.(`[DingTalk][AICard] Create failed: ${err.message}`);
+    if (err.response) {
+      log?.error?.(
+        `[DingTalk][AICard] Error response: status=${err.response.status} data=${JSON.stringify(err.response.data)}`,
+      );
+    }
+    return null;
+  }
+}
+
+/**
+ * Stream update AI Card content using the new DingTalk API
+ * Always use isFull=true to fully replace the Markdown content
+ * @param card AI Card instance
+ * @param content Content to stream
+ * @param finished Whether this is the final update (isFinalize=true)
+ * @param log Logger instance
+ */
+async function streamAICard(
+  card: AICardInstance,
+  content: string,
+  finished: boolean = false,
+  log?: Logger,
+): Promise<void> {
+  // Refresh token if it's been more than 1.5 hours since card creation (tokens expire after 2 hours)
+  const tokenAge = Date.now() - card.createdAt;
+  const TOKEN_REFRESH_THRESHOLD = 90 * 60 * 1000; // 1.5 hours in milliseconds
+
+  if (tokenAge > TOKEN_REFRESH_THRESHOLD && card.config) {
+    log?.debug?.("[DingTalk][AICard] Token age exceeds threshold, refreshing...");
+    try {
+      card.accessToken = await getAccessToken(card.config, log);
+      log?.debug?.("[DingTalk][AICard] Token refreshed successfully");
+    } catch (err: any) {
+      log?.warn?.(`[DingTalk][AICard] Failed to refresh token: ${err.message}`);
+      // Continue with old token, let the API call fail if token is invalid
+    }
+  }
+
+  // Call streaming API to update content with full replacement
+  const streamBody: AICardStreamingRequest = {
+    outTrackId: card.cardInstanceId,
+    guid: randomUUID(), // Use crypto.randomUUID() for robust GUID generation
+    key: card.config?.cardTemplateKey || "content",
+    content: content,
+    isFull: true, // Always full replacement for Markdown content
+    isFinalize: finished, // Set to true on final update to close the streaming channel
+    isError: false,
+  };
+
+  log?.debug?.(
+    `[DingTalk][AICard] PUT /v1.0/card/streaming contentLen=${content.length} isFull=true isFinalize=${finished} guid=${streamBody.guid} payload=${JSON.stringify(streamBody)}`,
+  );
+
+  try {
+    const streamResp = await axios.put(`${DINGTALK_API}/v1.0/card/streaming`, streamBody, {
+      headers: {
+        "x-acs-dingtalk-access-token": card.accessToken,
+        "Content-Type": "application/json",
+      },
+    });
+    log?.debug?.(
+      `[DingTalk][AICard] Streaming response: status=${streamResp.status}, data=${JSON.stringify(streamResp.data)}`,
+    );
+
+    // Update last updated time and state
+    card.lastUpdated = Date.now();
+    if (finished) {
+      card.state = AICardStatus.FINISHED;
+    } else if (card.state === AICardStatus.PROCESSING) {
+      card.state = AICardStatus.INPUTING;
+    }
+  } catch (err: any) {
+    // Handle 500 unknownError - likely cardTemplateKey mismatch with card template variables
+    if (err.response?.status === 500 && err.response?.data?.code === "unknownError") {
+      const usedKey = streamBody.key;
+      const cardTemplateId = card.config?.cardTemplateId || "(unknown)";
+      const errorMsg =
+        `⚠️ **[DingTalk] AI Card 串流更新失败 (500 unknownError)**\n\n` +
+        `这通常是因为 \`cardTemplateKey\` (当前值: \`${usedKey}\`) 与钉钉卡片模板 \`${cardTemplateId}\` 中定义的正文变量名不匹配。\n\n` +
+        `**建议操作**：\n` +
+        `1. 前往钉钉开发者后台检查该模板的“变量管理”\n` +
+        `2. 确保配置中的 \`cardTemplateKey\` 与模板中用于显示内容的字段变量名完全一致\n\n` +
+        `*注意：当前及后续消息将自动转为 Markdown 发送，直到问题修复。*\n` +
+        `*参考文档: https://github.com/soimy/openclaw-channel-dingtalk/blob/main/README.md#3-%E5%BB%BA%E7%AB%8B%E5%8D%A1%E7%89%87%E6%A8%A1%E6%9D%BF%E5%8F%AF%E9%80%89`;
+
+      log?.error?.(
+        `[DingTalk][AICard] Streaming failed with 500 unknownError. Key: ${usedKey}, Template: ${cardTemplateId}. ` +
+          `Verify that "cardTemplateKey" matches the content field variable name in your card template.`,
+      );
+
+      card.state = AICardStatus.FAILED;
+      card.lastUpdated = Date.now();
+
+      if (card.config) {
+        // Send notification directly to user via Markdown fallback
+        // We don't pass accountId here to ensure it doesn't try to use AI Card recursion
+        try {
+          await sendMessage(card.config, card.conversationId, errorMsg, { log });
+        } catch (sendErr: any) {
+          log?.warn?.(
+            `[DingTalk][AICard] Failed to send error notification to user: ${sendErr.message}`,
+          );
+        }
+      }
+
+      throw err;
+    }
+
+    // Handle 401 errors specifically - try to refresh token once
+    if (err.response?.status === 401 && card.config) {
+      log?.warn?.("[DingTalk][AICard] Received 401 error, attempting token refresh and retry...");
+      try {
+        card.accessToken = await getAccessToken(card.config, log);
+        // Retry the streaming request with refreshed token
+        const retryResp = await axios.put(`${DINGTALK_API}/v1.0/card/streaming`, streamBody, {
+          headers: {
+            "x-acs-dingtalk-access-token": card.accessToken,
+            "Content-Type": "application/json",
+          },
+        });
+        log?.debug?.(
+          `[DingTalk][AICard] Retry after token refresh succeeded: status=${retryResp.status}`,
+        );
+        // Update state on successful retry
+        card.lastUpdated = Date.now();
+        if (finished) {
+          card.state = AICardStatus.FINISHED;
+        } else if (card.state === AICardStatus.PROCESSING) {
+          card.state = AICardStatus.INPUTING;
+        }
+        return; // Success, exit function
+      } catch (retryErr: any) {
+        log?.error?.(`[DingTalk][AICard] Retry after token refresh failed: ${retryErr.message}`);
+        // Fall through to mark as failed and throw
+      }
+    }
+
+    // Ensure card state reflects the failure to prevent retry loops
+    card.state = AICardStatus.FAILED;
+    card.lastUpdated = Date.now();
+    log?.error?.(
+      `[DingTalk][AICard] Streaming update failed: ${err.message}, resp=${JSON.stringify(err.response?.data)}`,
+    );
+    throw err;
+  }
+}
+
+/**
+ * Finalize AI Card: close streaming channel and update to FINISHED state
+ * @param card AI Card instance
+ * @param content Final content
+ * @param log Logger instance
+ */
+async function finishAICard(card: AICardInstance, content: string, log?: Logger): Promise<void> {
+  log?.debug?.(`[DingTalk][AICard] Starting finish, final content length=${content.length}`);
+
+  // Send final content with isFull=true and isFinalize=true to close streaming
+  // No separate state update needed - the streaming API handles everything
+  await streamAICard(card, content, true, log);
+}
+
+// ============ End of New AI Card API Functions ============
+
+// Send message with automatic mode selection (card/markdown)
+// Card mode: if an active AI Card exists for the target, stream updates; otherwise fall back to markdown.
+async function sendMessage(
+  config: DingTalkConfig,
+  conversationId: string,
+  text: string,
+  options: SendMessageOptions & { sessionWebhook?: string; accountId?: string } = {},
+): Promise<{ ok: boolean; error?: string; data?: AxiosResponse }> {
+  try {
+    const messageType = config.messageType || "markdown";
+    const log = options.log || getLogger();
+
+    if (messageType === "card" && options.accountId) {
+      const targetKey = `${options.accountId}:${conversationId}`;
+      const activeCardId = activeCardsByTarget.get(targetKey);
+      if (activeCardId) {
+        const activeCard = aiCardInstances.get(activeCardId);
+        if (activeCard && !isCardInTerminalState(activeCard.state)) {
+          try {
+            await streamAICard(activeCard, text, false, log);
+            return { ok: true };
+          } catch (err: any) {
+            log?.warn?.(
+              `[DingTalk] AI Card streaming failed, fallback to markdown: ${err.message}`,
+            );
+            activeCard.state = AICardStatus.FAILED;
+            activeCard.lastUpdated = Date.now();
+          }
+        } else {
+          activeCardsByTarget.delete(targetKey);
+        }
+      }
+    }
+
+    // Fallback to markdown mode
+    if (options.sessionWebhook) {
+      await sendBySession(config, options.sessionWebhook, text, options);
+      return { ok: true };
+    }
+
+    const result = await sendProactiveTextOrMarkdown(config, conversationId, text, options);
+    return { ok: true, data: result };
+  } catch (err: any) {
+    options.log?.error?.(`[DingTalk] Send message failed: ${err.message}`);
+    return { ok: false, error: err.message };
+  }
+}
+
+// Message handler
+async function handleDingTalkMessage(params: HandleDingTalkMessageParams): Promise<void> {
+  const { cfg, accountId, data, sessionWebhook, log, dingtalkConfig } = params;
+  const rt = getDingTalkRuntime();
+
+  // Save logger reference globally for use by other methods
+  currentLogger = log;
+
+  log?.debug?.("[DingTalk] Full Inbound Data:", JSON.stringify(maskSensitiveData(data)));
+
+  // 0. 清理过期的卡片缓存
+  cleanupCardCache();
+
+  // 1. 过滤机器人自身消息
+  if (data.senderId === data.chatbotUserId || data.senderStaffId === data.chatbotUserId) {
+    log?.debug?.("[DingTalk] Ignoring robot self-message");
+    return;
+  }
+
+  const content = extractMessageContent(data);
+  if (!content.text) return;
+
+  const isDirect = data.conversationType === "1";
+  const senderId = data.senderStaffId || data.senderId;
+  const senderName = data.senderNick || "Unknown";
+  const groupId = data.conversationId;
+  const groupName = data.conversationTitle || "Group";
+
+  // Register original peer IDs to preserve case-sensitive conversationId (base64)
+  if (groupId) registerPeerId(groupId);
+  if (senderId) registerPeerId(senderId);
+
+  // 2. Check authorization for direct messages based on dmPolicy
+  let commandAuthorized = true;
+  if (isDirect) {
+    const dmPolicy = dingtalkConfig.dmPolicy || "open";
+    const allowFrom = dingtalkConfig.allowFrom || [];
+
+    if (dmPolicy === "allowlist") {
+      const normalizedAllowFrom = normalizeAllowFrom(allowFrom);
+      const isAllowed = isSenderAllowed({ allow: normalizedAllowFrom, senderId });
+
+      if (!isAllowed) {
+        log?.debug?.(
+          `[DingTalk] DM blocked: senderId=${senderId} not in allowlist (dmPolicy=allowlist)`,
+        );
+
+        // Notify user with their sender ID so they can request access
+        try {
+          await sendBySession(
+            dingtalkConfig,
+            sessionWebhook,
+            `⛔ 访问受限\n\n您的用户ID：\`${senderId}\`\n\n请联系管理员将此ID添加到允许列表中。`,
+            { log },
+          );
+        } catch (err: any) {
+          log?.debug?.(`[DingTalk] Failed to send access denied message: ${err.message}`);
+        }
+
+        return;
+      }
+
+      log?.debug?.(`[DingTalk] DM authorized: senderId=${senderId} in allowlist`);
+    } else if (dmPolicy === "pairing") {
+      // For pairing mode, SDK will handle the authorization
+      // Set commandAuthorized to true to let SDK check pairing status
+      commandAuthorized = true;
+    } else {
+      // 'open' policy - allow all
+      commandAuthorized = true;
+    }
+  } else {
+    // 群组通道授权
+    const groupPolicy = dingtalkConfig.groupPolicy || "open";
+    const allowFrom = dingtalkConfig.allowFrom || [];
+
+    if (groupPolicy === "allowlist") {
+      const normalizedAllowFrom = normalizeAllowFrom(allowFrom);
+      const isAllowed = isSenderGroupAllowed({ allow: normalizedAllowFrom, groupId });
+
+      if (!isAllowed) {
+        log?.debug?.(
+          `[DingTalk] Group blocked: conversationId=${groupId} senderId=${senderId} not in allowlist (groupPolicy=allowlist)`,
+        );
+
+        try {
+          await sendBySession(
+            dingtalkConfig,
+            sessionWebhook,
+            `⛔ 访问受限\n\n您的群聊ID：\`${groupId}\`\n\n请联系管理员将此ID添加到允许列表中。`,
+            { log, atUserId: senderId },
+          );
+        } catch (err: any) {
+          log?.debug?.(`[DingTalk] Failed to send group access denied message: ${err.message}`);
+        }
+
+        return;
+      }
+
+      log?.debug?.(
+        `[DingTalk] Group authorized: conversationId=${groupId} senderId=${senderId} in allowlist`,
+      );
+    }
+  }
+
+  const route = rt.channel.routing.resolveAgentRoute({
+    cfg,
+    channel: "dingtalk",
+    accountId,
+    // agent权限和openclaw保持一致
+    peer: { kind: isDirect ? "direct" : "group", id: isDirect ? senderId : groupId },
+  });
+
+  const storePath = rt.channel.session.resolveStorePath(cfg.session?.store, {
+    agentId: route.agentId,
+  });
+  const workspacePath = resolveAgentWorkspaceDir(cfg, route.agentId);
+
+  // Download media to agent workspace (must be after route is resolved for correct workspace)
+  let mediaPath: string | undefined;
+  let mediaType: string | undefined;
+  if (content.mediaPath && dingtalkConfig.robotCode) {
+    const media = await downloadMedia(dingtalkConfig, content.mediaPath, workspacePath, log);
+    if (media) {
+      mediaPath = media.path;
+      mediaType = media.mimeType;
+    }
+  }
+  const envelopeOptions = rt.channel.reply.resolveEnvelopeFormatOptions(cfg);
+  const previousTimestamp = rt.channel.session.readSessionUpdatedAt({
+    storePath,
+    sessionKey: route.sessionKey,
+  });
+
+  // Group-specific: resolve config, track members, format member list
+  const groupConfig = !isDirect ? resolveGroupConfig(dingtalkConfig, groupId) : undefined;
+  // GroupSystemPrompt is injected into the system prompt on every turn (unlike
+  // group intro which only fires on the first turn). Embed DingTalk IDs here so
+  // the AI always has access to conversationId.
+  const groupSystemPrompt = !isDirect
+    ? [`DingTalk group context: conversationId=${groupId}`, groupConfig?.systemPrompt?.trim()]
+        .filter(Boolean)
+        .join("\n")
+    : undefined;
+
+  if (!isDirect) {
+    noteGroupMember(storePath, groupId, senderId, senderName);
+  }
+  const groupMembers = !isDirect ? formatGroupMembers(storePath, groupId) : undefined;
+
+  const fromLabel = isDirect ? `${senderName} (${senderId})` : `${groupName} - ${senderName}`;
+  const body = rt.channel.reply.formatInboundEnvelope({
+    channel: "DingTalk",
+    from: fromLabel,
+    timestamp: data.createAt,
+    body: content.text,
+    chatType: isDirect ? "direct" : "group",
+    sender: { name: senderName, id: senderId },
+    previousTimestamp,
+    envelope: envelopeOptions,
+  });
+
+  const to = isDirect ? senderId : groupId;
+  const ctx = rt.channel.reply.finalizeInboundContext({
+    Body: body,
+    RawBody: content.text,
+    CommandBody: content.text,
+    From: to,
+    To: to,
+    SessionKey: route.sessionKey,
+    AccountId: accountId,
+    ChatType: isDirect ? "direct" : "group",
+    ConversationLabel: fromLabel,
+    GroupSubject: isDirect ? undefined : groupName,
+    SenderName: senderName,
+    SenderId: senderId,
+    Provider: "dingtalk",
+    Surface: "dingtalk",
+    MessageSid: data.msgId,
+    Timestamp: data.createAt,
+    MediaPath: mediaPath,
+    MediaType: mediaType,
+    MediaUrl: mediaPath,
+    GroupMembers: groupMembers,
+    GroupSystemPrompt: groupSystemPrompt,
+    GroupChannel: isDirect ? undefined : route.sessionKey,
+    CommandAuthorized: commandAuthorized,
+    OriginatingChannel: "dingtalk",
+    OriginatingTo: to,
+  });
+
+  await rt.channel.session.recordInboundSession({
+    storePath,
+    sessionKey: ctx.SessionKey || route.sessionKey,
+    ctx,
+    updateLastRoute: { sessionKey: route.mainSessionKey, channel: "dingtalk", to, accountId },
+    onRecordError: (err: unknown) => {
+      log?.error?.(`[DingTalk] Failed to record inbound session: ${String(err)}`);
+    },
+  });
+
+  log?.info?.(`[DingTalk] Inbound: from=${senderName} text="${content.text.slice(0, 50)}..."`);
+
+  // Determine if we are in card mode, if so, create or reuse card instance first
+  const useCardMode = dingtalkConfig.messageType === "card";
+  let currentAICard: AICardInstance | undefined;
+  let lastCardContent = "";
+
+  if (useCardMode) {
+    // Try to reuse an existing active AI card for this target, if available
+    const targetKey = `${accountId}:${to}`;
+    const existingCardId = activeCardsByTarget.get(targetKey);
+    const existingCard = existingCardId ? aiCardInstances.get(existingCardId) : undefined;
+
+    // Only reuse cards that are not in terminal states
+    if (existingCard && !isCardInTerminalState(existingCard.state)) {
+      currentAICard = existingCard;
+      log?.debug?.("[DingTalk] Reusing existing active AI card for this conversation.");
+    } else {
+      // Create a new AI card
+      try {
+        const aiCard = await createAICard(dingtalkConfig, to, data, accountId, log);
+        if (aiCard) {
+          currentAICard = aiCard;
+        } else {
+          log?.warn?.(
+            "[DingTalk] Failed to create AI card (returned null), fallback to text/markdown.",
+          );
+        }
+      } catch (err: any) {
+        log?.warn?.(
+          `[DingTalk] Failed to create AI card: ${err.message}, fallback to text/markdown.`,
+        );
+      }
+    }
+  }
+
+  // Feedback: Thinking...
+  if (dingtalkConfig.showThinking !== false) {
+    try {
+      const thinkingText = "🤔 思考中，请稍候...";
+      // AI card already has thinking state visually, so we only send thinking message for non-card modes
+      if (useCardMode && currentAICard) {
+        log?.debug?.("[DingTalk] AI Card in thinking state, skipping thinking message send.");
+      } else {
+        lastCardContent = thinkingText;
+        await sendMessage(dingtalkConfig, to, thinkingText, {
+          sessionWebhook,
+          atUserId: !isDirect ? senderId : null,
+          log,
+          accountId,
+        });
+      }
+    } catch (err: any) {
+      log?.debug?.(`[DingTalk] Thinking message failed: ${err.message}`);
+    }
+  }
+
+  const { queuedFinal } = await rt.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
+    ctx,
+    cfg,
+    dispatcherOptions: {
+      responsePrefix: "",
+      deliver: async (payload: any) => {
+        try {
+          const textToSend = payload.markdown || payload.text;
+          if (!textToSend) return;
+
+          lastCardContent = textToSend;
+          await sendMessage(dingtalkConfig, to, textToSend, {
+            sessionWebhook,
+            atUserId: !isDirect ? senderId : null,
+            log,
+            accountId,
+          });
+        } catch (err: any) {
+          log?.error?.(`[DingTalk] Reply failed: ${err.message}`);
+          throw err;
+        }
+      },
+    },
+  });
+
+  // Finalize AI card
+  if (useCardMode && currentAICard) {
+    try {
+      // Helper function to check if a value is a non-empty string
+      const isNonEmptyString = (value: any): boolean =>
+        typeof value === "string" && value.trim().length > 0;
+
+      // Validate that we have actual content before finalization
+      const hasLastCardContent = isNonEmptyString(lastCardContent);
+      const hasQueuedFinalString = isNonEmptyString(queuedFinal);
+
+      if (hasLastCardContent || hasQueuedFinalString) {
+        const finalContent =
+          hasLastCardContent && typeof lastCardContent === "string"
+            ? lastCardContent
+            : typeof queuedFinal === "string"
+              ? queuedFinal
+              : "";
+        await finishAICard(currentAICard, finalContent, log);
+      } else {
+        // No textual content was produced; skip finalization with empty content
+        log?.debug?.(
+          "[DingTalk] Skipping AI Card finalization because no textual content was produced.",
+        );
+        // Still mark the card as finished to allow cleanup
+        currentAICard.state = AICardStatus.FINISHED;
+        currentAICard.lastUpdated = Date.now();
+      }
+    } catch (err: any) {
+      log?.debug?.(`[DingTalk] AI Card finalization failed: ${err.message}`);
+      // Ensure the AI card transitions to a terminal error state
+      try {
+        if (currentAICard.state !== AICardStatus.FINISHED) {
+          currentAICard.state = AICardStatus.FAILED;
+          currentAICard.lastUpdated = Date.now();
+        }
+      } catch (stateErr: any) {
+        // Log state update failure at debug level to aid production debugging
+        log?.debug?.(`[DingTalk] Failed to update card state to FAILED: ${stateErr.message}`);
+      }
+    }
+  }
+  // Note: Media cleanup is handled by openclaw's media storage mechanism
+  // Files saved via rt.channel.media.saveMediaBuffer are managed automatically
+}
+
+// DingTalk Channel Definition
+export const dingtalkPlugin = {
+  id: "dingtalk",
+  meta: {
+    id: "dingtalk",
+    label: "DingTalk",
+    selectionLabel: "DingTalk (钉钉)",
+    docsPath: "/channels/dingtalk",
+    blurb: "钉钉企业内部机器人，使用 Stream 模式，无需公网 IP。",
+    aliases: ["dd", "ding"],
+  },
+  configSchema: buildChannelConfigSchema(DingTalkConfigSchema),
+  onboarding: dingtalkOnboardingAdapter,
+  capabilities: {
+    chatTypes: ["direct", "group"] as Array<"direct" | "group">,
+    reactions: false,
+    threads: false,
+    media: true,
+    nativeCommands: false,
+    blockStreaming: false,
+    outbound: true,
+  },
+  reload: { configPrefixes: ["channels.dingtalk"] },
+  config: {
+    listAccountIds: (cfg: OpenClawConfig): string[] => {
+      const config = getConfig(cfg);
+      return config.accounts && Object.keys(config.accounts).length > 0
+        ? Object.keys(config.accounts)
+        : isConfigured(cfg)
+          ? ["default"]
+          : [];
+    },
+    resolveAccount: (cfg: OpenClawConfig, accountId?: string | null) => {
+      const config = getConfig(cfg);
+      const id = accountId || "default";
+      const account = config.accounts?.[id];
+      const resolvedConfig = account || config;
+      const configured = Boolean(resolvedConfig.clientId && resolvedConfig.clientSecret);
+      return {
+        accountId: id,
+        config: resolvedConfig,
+        enabled: resolvedConfig.enabled !== false,
+        configured,
+        name: resolvedConfig.name || null,
+      };
+    },
+    defaultAccountId: (): string => "default",
+    isConfigured: (account: ResolvedAccount): boolean =>
+      Boolean(account.config?.clientId && account.config?.clientSecret),
+    describeAccount: (account: ResolvedAccount) => ({
+      accountId: account.accountId,
+      name: account.config?.name || "DingTalk",
+      enabled: account.enabled,
+      configured: Boolean(account.config?.clientId),
+    }),
+  },
+  security: {
+    resolveDmPolicy: ({ account }: any) => ({
+      policy: account.config?.dmPolicy || "open",
+      allowFrom: account.config?.allowFrom || [],
+      policyPath: "channels.dingtalk.dmPolicy",
+      allowFromPath: "channels.dingtalk.allowFrom",
+      approveHint: "使用 /allow dingtalk:<userId> 批准用户",
+      normalizeEntry: (raw: string) => raw.replace(/^(dingtalk|dd|ding):/i, ""),
+    }),
+  },
+  groups: {
+    resolveRequireMention: ({ cfg }: any): boolean => getConfig(cfg).groupPolicy !== "open",
+    resolveGroupIntroHint: ({ groupId, groupChannel }: any): string | undefined => {
+      const parts = [`conversationId=${groupId}`];
+      if (groupChannel) parts.push(`sessionKey=${groupChannel}`);
+      return `DingTalk IDs: ${parts.join(", ")}.`;
+    },
+  },
+  messaging: {
+    normalizeTarget: (raw: string) => (raw ? raw.replace(/^(dingtalk|dd|ding):/i, "") : undefined),
+    targetResolver: {
+      looksLikeId: (id: string): boolean => /^[\w+\-/=]+$/.test(id),
+      hint: "<conversationId>",
+    },
+  },
+  outbound: {
+    deliveryMode: "direct" as const,
+    resolveTarget: ({ to }: any) => {
+      const trimmed = to?.trim();
+      if (!trimmed) {
+        return {
+          ok: false as const,
+          error: new Error("DingTalk message requires --to <conversationId>"),
+        };
+      }
+      // Strip group: or user: prefix and resolve original case-sensitive conversationId
+      const { targetId } = stripTargetPrefix(trimmed);
+      const resolved = resolveOriginalPeerId(targetId);
+      return { ok: true as const, to: resolved };
+    },
+    sendText: async ({ cfg, to, text, accountId, log }: any) => {
+      const config = getConfig(cfg, accountId);
+      try {
+        const result = await sendMessage(config, to, text, { log, accountId });
+        getLogger()?.debug?.(`[DingTalk] sendText: "${text}" result: ${JSON.stringify(result)}`);
+        if (result.ok) {
+          const data = result.data as any;
+          const messageId = String(data?.processQueryKey || data?.messageId || randomUUID());
+          return {
+            channel: "dingtalk",
+            messageId,
+            meta: result.data
+              ? { data: result.data as unknown as Record<string, unknown> }
+              : undefined,
+          };
+        }
+        throw new Error(
+          typeof result.error === "string" ? result.error : JSON.stringify(result.error),
+        );
+      } catch (err: any) {
+        throw new Error(
+          typeof err?.response?.data === "string"
+            ? err.response.data
+            : err?.message || "sendText failed",
+        );
+      }
+    },
+    sendMedia: async ({
+      cfg,
+      to,
+      mediaPath,
+      filePath,
+      mediaUrl,
+      mediaType: providedMediaType,
+      accountId,
+      log,
+    }: any) => {
+      const config = getConfig(cfg, accountId);
+      if (!config.clientId) throw new Error("DingTalk not configured");
+
+      // Support mediaPath, filePath, and mediaUrl parameter names
+      const actualMediaPath = mediaPath || filePath || mediaUrl;
+
+      getLogger()?.debug?.(
+        `[DingTalk] sendMedia called: to=${to}, mediaPath=${mediaPath}, filePath=${filePath}, mediaUrl=${mediaUrl}, actualMediaPath=${actualMediaPath}`,
+      );
+
+      if (!actualMediaPath) {
+        throw new Error(
+          `mediaPath, filePath, or mediaUrl is required. Received: ${JSON.stringify({
+            to,
+            mediaPath,
+            filePath,
+            mediaUrl,
+          })}`,
+        );
+      }
+
+      try {
+        // Detect media type from file extension if not provided
+        const mediaType = providedMediaType || detectMediaTypeFromExtension(actualMediaPath);
+
+        // Send as native media via proactive API
+        const result = await sendProactiveMedia(config, to, actualMediaPath, mediaType, {
+          log,
+          accountId,
+        });
+        getLogger()?.debug?.(
+          `[DingTalk] sendMedia: ${mediaType} file=${actualMediaPath} result: ${JSON.stringify(result)}`,
+        );
+
+        if (result.ok) {
+          // Extract messageId from DingTalk response for CLI display
+          const data = result.data;
+          const messageId = String(
+            result.messageId || data?.processQueryKey || data?.messageId || randomUUID(),
+          );
+          return {
+            channel: "dingtalk",
+            messageId,
+            meta: result.data
+              ? { data: result.data as unknown as Record<string, unknown> }
+              : undefined,
+          };
+        }
+        throw new Error(
+          typeof result.error === "string" ? result.error : JSON.stringify(result.error),
+        );
+      } catch (err: any) {
+        throw new Error(
+          typeof err?.response?.data === "string"
+            ? err.response.data
+            : err?.message || "sendMedia failed",
+        );
+      }
+    },
+  },
+  gateway: {
+    startAccount: async (ctx: GatewayStartContext): Promise<GatewayStopResult> => {
+      const { account, cfg, abortSignal } = ctx;
+      const config = account.config;
+      if (!config.clientId || !config.clientSecret) {
+        throw new Error("DingTalk clientId and clientSecret are required");
+      }
+
+      ctx.log?.info?.(`[${account.accountId}] Initializing DingTalk Stream client...`);
+
+      // Cleanup orphaned temp files from previous sessions
+      cleanupOrphanedTempFiles(ctx.log);
+
+      // Create DWClient with autoReconnect disabled (we'll manage reconnection ourselves)
+      const client = new DWClient({
+        clientId: config.clientId,
+        clientSecret: config.clientSecret,
+        debug: config.debug || false,
+        keepAlive: true,
+      });
+
+      // Disable DWClient's built-in autoReconnect to use our robust ConnectionManager
+      // Access private config to override autoReconnect
+      (client as any).config.autoReconnect = false;
+
+      // Register message callback listener
+      client.registerCallbackListener(TOPIC_ROBOT, async (res: any) => {
+        const messageId = res.headers?.messageId;
+        try {
+          if (messageId) {
+            client.socketCallBackResponse(messageId, { success: true });
+          }
+          const data = JSON.parse(res.data) as DingTalkInboundMessage;
+
+          // Message deduplication: use bot-scoped key (robotKey:msgId) to prevent cross-bot conflicts
+          // robotKey priority: robotCode (DingTalk's bot identifier) > clientId (app key) > accountId (local ID)
+          // This ensures consistent keys per bot instance (config values remain stable during runtime)
+          const robotKey = config.robotCode || config.clientId || account.accountId;
+          const msgId = data.msgId || messageId;
+
+          // Skip dedup if we don't have a message ID (extremely rare edge case)
+          if (!msgId) {
+            ctx.log?.warn?.(`[${account.accountId}] No message ID available for deduplication`);
+          } else {
+            const dedupKey = `${robotKey}:${msgId}`;
+            if (isMessageProcessed(dedupKey)) {
+              ctx.log?.debug?.(`[${account.accountId}] Skipping duplicate message: ${dedupKey}`);
+              return;
+            }
+            markMessageProcessed(dedupKey);
+          }
+
+          await handleDingTalkMessage({
+            cfg,
+            accountId: account.accountId,
+            data,
+            sessionWebhook: data.sessionWebhook,
+            log: ctx.log,
+            dingtalkConfig: config,
+          });
+        } catch (error: any) {
+          ctx.log?.error?.(`[${account.accountId}] Error processing message: ${error.message}`);
+        }
+      });
+
+      // Track stopped state to prevent duplicate stop operations
+      // The 'stopped' flag guards against multiple termination paths (abort signal, explicit stop)
+      // from executing concurrently and ensures each lifecycle transition updates snapshot only once
+      let stopped = false;
+
+      // Create connection manager configuration
+      const connectionConfig: ConnectionManagerConfig = {
+        maxAttempts: config.maxConnectionAttempts ?? 10,
+        initialDelay: config.initialReconnectDelay ?? 1000,
+        maxDelay: config.maxReconnectDelay ?? 60000,
+        jitter: config.reconnectJitter ?? 0.3,
+        onStateChange: (state: ConnectionState, error?: string) => {
+          if (stopped) return;
+          ctx.log?.debug?.(
+            `[${account.accountId}] Connection state changed to: ${state}${error ? ` (${error})` : ""}`,
+          );
+          if (state === ConnectionState.CONNECTED) {
+            ctx.setStatus({
+              ...ctx.getStatus(),
+              running: true,
+              lastStartAt: getCurrentTimestamp(),
+              lastError: null,
+            });
+          } else if (state === ConnectionState.FAILED || state === ConnectionState.DISCONNECTED) {
+            ctx.setStatus({
+              ...ctx.getStatus(),
+              running: false,
+              lastError: error || `Connection ${state.toLowerCase()}`,
+            });
+          }
+        },
+      };
+
+      ctx.log?.debug?.(
+        `[${account.accountId}] Connection config: maxAttempts=${connectionConfig.maxAttempts}, ` +
+          `initialDelay=${connectionConfig.initialDelay}ms, maxDelay=${connectionConfig.maxDelay}ms, ` +
+          `jitter=${connectionConfig.jitter}`,
+      );
+
+      // Create connection manager
+      const connectionManager = new ConnectionManager(
+        client,
+        account.accountId,
+        connectionConfig,
+        ctx.log,
+      );
+
+      // Setup abort signal handler BEFORE connecting
+      // This allows the abort signal to cancel in-flight connection attempts
+      if (abortSignal) {
+        // Check if already aborted before we even start
+        if (abortSignal.aborted) {
+          ctx.log?.warn?.(
+            `[${account.accountId}] Abort signal already active, skipping connection`,
+          );
+
+          // Update snapshot: channel aborted before start
+          ctx.setStatus({
+            ...ctx.getStatus(),
+            running: false,
+            lastStopAt: getCurrentTimestamp(),
+            lastError: "Connection aborted before start",
+          });
+
+          throw new Error("Connection aborted before start");
+        }
+
+        abortSignal.addEventListener("abort", () => {
+          if (stopped) return;
+          stopped = true;
+          ctx.log?.info?.(
+            `[${account.accountId}] Abort signal received, stopping DingTalk Stream client...`,
+          );
+          connectionManager.stop();
+
+          // Update snapshot: channel stopped by abort signal
+          ctx.setStatus({
+            ...ctx.getStatus(),
+            running: false,
+            lastStopAt: getCurrentTimestamp(),
+          });
+        });
+      }
+
+      // Connect with robust retry logic
+      try {
+        await connectionManager.connect();
+
+        // Only mark as running if we weren't stopped and the connection is actually established
+        if (!stopped && connectionManager.isConnected()) {
+          // Update snapshot: connection successful, channel is now running
+          ctx.setStatus({
+            ...ctx.getStatus(),
+            running: true,
+            lastStartAt: getCurrentTimestamp(),
+            lastError: null,
+          });
+          ctx.log?.info?.(`[${account.accountId}] DingTalk Stream client connected successfully`);
+        } else {
+          // Startup was cancelled or connection is not established; do not overwrite stopped snapshot.
+          ctx.log?.info?.(
+            `[${account.accountId}] DingTalk Stream client connect() completed but channel is ` +
+              `not running (stopped=${stopped}, connected=${connectionManager.isConnected()})`,
+          );
+        }
+      } catch (err: any) {
+        ctx.log?.error?.(`[${account.accountId}] Failed to establish connection: ${err.message}`);
+
+        // Update snapshot: connection failed
+        ctx.setStatus({
+          ...ctx.getStatus(),
+          running: false,
+          lastError: err.message || "Connection failed",
+        });
+        throw err;
+      }
+
+      // Return stop handler
+      return {
+        stop: () => {
+          if (stopped) return;
+          stopped = true;
+          ctx.log?.info?.(`[${account.accountId}] Stopping DingTalk Stream client...`);
+          connectionManager.stop();
+
+          // Update snapshot: channel stopped
+          ctx.setStatus({
+            ...ctx.getStatus(),
+            running: false,
+            lastStopAt: getCurrentTimestamp(),
+          });
+
+          ctx.log?.info?.(`[${account.accountId}] DingTalk Stream client stopped`);
+        },
+      };
+    },
+  },
+  status: {
+    defaultRuntime: {
+      accountId: "default",
+      running: false,
+      lastStartAt: null,
+      lastStopAt: null,
+      lastError: null,
+    },
+    collectStatusIssues: (accounts: any[]) => {
+      return accounts.flatMap((account) => {
+        if (!account.configured) {
+          return [
+            {
+              channel: "dingtalk",
+              accountId: account.accountId,
+              kind: "config" as const,
+              message: "Account not configured (missing clientId or clientSecret)",
+            },
+          ];
+        }
+        return [];
+      });
+    },
+    buildChannelSummary: ({ snapshot }: any) => ({
+      configured: snapshot?.configured ?? false,
+      running: snapshot?.running ?? false,
+      lastStartAt: snapshot?.lastStartAt ?? null,
+      lastStopAt: snapshot?.lastStopAt ?? null,
+      lastError: snapshot?.lastError ?? null,
+    }),
+    probeAccount: async ({ account, timeoutMs }: any) => {
+      if (!account.configured || !account.config?.clientId || !account.config?.clientSecret) {
+        return { ok: false, error: "Not configured" };
+      }
+      try {
+        const controller = new AbortController();
+        const timeoutId = timeoutMs ? setTimeout(() => controller.abort(), timeoutMs) : undefined;
+        try {
+          await getAccessToken(account.config);
+          return { ok: true, details: { clientId: account.config.clientId } };
+        } finally {
+          if (timeoutId) clearTimeout(timeoutId);
+        }
+      } catch (error: any) {
+        return { ok: false, error: error.message };
+      }
+    },
+    buildAccountSnapshot: ({ account, runtime, snapshot, probe }: any) => ({
+      accountId: account.accountId,
+      name: account.name,
+      enabled: account.enabled,
+      configured: account.configured,
+      clientId: account.config?.clientId ?? null,
+      running: runtime?.running ?? snapshot?.running ?? false,
+      lastStartAt: runtime?.lastStartAt ?? snapshot?.lastStartAt ?? null,
+      lastStopAt: runtime?.lastStopAt ?? snapshot?.lastStopAt ?? null,
+      lastError: runtime?.lastError ?? snapshot?.lastError ?? null,
+      probe,
+    }),
+  },
+};
+
+/**
+ * Public low-level API exports for the DingTalk channel plugin.
+ *
+ * - {@link sendBySession} sends a message to DingTalk using a session/webhook
+ *   (e.g. replies within an existing conversation).
+ * - {@link createAICard} creates and delivers an AI Card using the DingTalk API
+ *   (returns AICardInstance for streaming updates). Automatically registers the card
+ *   in activeCardsByTarget mapping (accountId:conversationId -> cardInstanceId).
+ * - {@link streamAICard} streams content updates to an AI Card
+ *   (for real-time streaming message updates).
+ * - {@link finishAICard} finalizes an AI Card and sets state to FINISHED
+ *   (closes streaming channel and updates card state).
+ * - {@link sendMessage} sends a message with automatic mode selection
+ *   (text/markdown/card based on config).
+ * - {@link uploadMedia} uploads a local media file to DingTalk media server
+ *   and returns the media_id for use in messages.
+ * - {@link getAccessToken} retrieves (and caches) the DingTalk access token
+ *   for the configured application/runtime.
+ * - {@link getLogger} retrieves the current global logger instance
+ *   (set by handleDingTalkMessage during inbound message processing).
+ *
+ * These exports are intended to be used by external integrations that need
+ * direct programmatic access to DingTalk messaging and authentication.
+ */
+export {
+  sendBySession,
+  createAICard,
+  streamAICard,
+  finishAICard,
+  sendMessage,
+  uploadMedia,
+  sendProactiveMedia,
+  getAccessToken,
+  getLogger,
+};
+export { detectMediaTypeFromExtension } from "./media-utils.js";

--- a/extensions/openclaw-channel-dingtalk/src/config-schema.ts
+++ b/extensions/openclaw-channel-dingtalk/src/config-schema.ts
@@ -1,0 +1,92 @@
+import { z } from "zod";
+
+/**
+ * DingTalk configuration schema using Zod
+ * Mirrors the structure needed for proper control-ui rendering
+ */
+export const DingTalkConfigSchema: z.ZodTypeAny = z.object({
+  /** Account name (optional display name) */
+  name: z.string().optional(),
+
+  /** Whether this channel is enabled */
+  enabled: z.boolean().optional().default(true),
+
+  /** DingTalk App Key (Client ID) - required for authentication */
+  clientId: z.string().optional(),
+
+  /** DingTalk App Secret (Client Secret) - required for authentication */
+  clientSecret: z.string().optional(),
+
+  /** DingTalk Robot Code for media download */
+  robotCode: z.string().optional(),
+
+  /** DingTalk Corporation ID */
+  corpId: z.string().optional(),
+
+  /** DingTalk Application ID (Agent ID) */
+  agentId: z.union([z.string(), z.number()]).optional(),
+
+  /** Direct message policy: open, pairing, or allowlist */
+  dmPolicy: z.enum(["open", "pairing", "allowlist"]).optional().default("open"),
+
+  /** Group message policy: open or allowlist */
+  groupPolicy: z.enum(["open", "allowlist"]).optional().default("open"),
+
+  /** List of allowed user IDs for allowlist policy */
+  allowFrom: z.array(z.string()).optional(),
+
+  /** Show thinking indicator while processing */
+  showThinking: z.boolean().optional().default(true),
+
+  /** Enable debug logging */
+  debug: z.boolean().optional().default(false),
+
+  /** Message type for replies: markdown or card */
+  messageType: z.enum(["markdown", "card"]).optional().default("markdown"),
+
+  /** Card template ID for AI interactive cards
+   * obtain the template ID from DingTalk Developer Console.
+   * ref: https://github.com/soimy/openclaw-channel-dingtalk/blob/main/README.md#3-%E5%BB%BA%E7%AB%8B%E5%8D%A1%E7%89%87%E6%A8%A1%E6%9D%BF%E5%8F%AF%E9%80%89
+   */
+  cardTemplateId: z.string().optional(),
+
+  /** Card template key for streaming updates
+   * Default: 'msgContent' - maps to the content field in the card template
+   * This key is used in the streaming API to update specific fields in the card.
+   */
+  cardTemplateKey: z.string().optional().default("content"),
+
+  /** Per-group configuration, keyed by conversationId (supports "*" wildcard) */
+  groups: z
+    .record(
+      z.string(),
+      z.object({
+        systemPrompt: z.string().optional(),
+      }),
+    )
+    .optional(),
+
+  /** Multi-account configuration */
+  accounts: z
+    .record(
+      z.string(),
+      z.lazy(() => DingTalkConfigSchema),
+    )
+    .optional(),
+
+  /** Connection robustness configuration */
+
+  /** Maximum number of connection attempts before giving up (default: 10) */
+  maxConnectionAttempts: z.number().int().min(1).optional().default(10),
+
+  /** Initial reconnection delay in milliseconds (default: 1000ms) */
+  initialReconnectDelay: z.number().int().min(100).optional().default(1000),
+
+  /** Maximum reconnection delay in milliseconds for exponential backoff (default: 60000ms = 1 minute) */
+  maxReconnectDelay: z.number().int().min(1000).optional().default(60000),
+
+  /** Jitter factor for reconnection delay randomization (0-1, default: 0.3) */
+  reconnectJitter: z.number().min(0).max(1).optional().default(0.3),
+});
+
+export type DingTalkConfig = z.infer<typeof DingTalkConfigSchema>;

--- a/extensions/openclaw-channel-dingtalk/src/connection-manager.ts
+++ b/extensions/openclaw-channel-dingtalk/src/connection-manager.ts
@@ -1,0 +1,463 @@
+/**
+ * Connection Manager for DingTalk Stream Client
+ *
+ * Provides robust connection lifecycle management with:
+ * - Exponential backoff with jitter for reconnection attempts
+ * - Configurable max attempts and delay parameters
+ * - Connection state tracking and event handling
+ * - Proper cleanup of timers and resources
+ * - Structured logging for all connection events
+ */
+
+import type { DWClient } from "dingtalk-stream";
+import type {
+  ConnectionState,
+  ConnectionManagerConfig,
+  ConnectionAttemptResult,
+  Logger,
+} from "./types.js";
+import { ConnectionState as ConnectionStateEnum } from "./types.js";
+
+/**
+ * ConnectionManager handles the robust connection lifecycle for DWClient
+ */
+export class ConnectionManager {
+  private config: ConnectionManagerConfig;
+  private log?: Logger;
+  private accountId: string;
+
+  // Connection state tracking
+  private state: ConnectionState = ConnectionStateEnum.DISCONNECTED;
+  private attemptCount: number = 0;
+  private reconnectTimer?: NodeJS.Timeout;
+  private stopped: boolean = false;
+
+  // Runtime monitoring resources
+  private healthCheckInterval?: NodeJS.Timeout;
+  private socketCloseHandler?: (code: number, reason: string) => void;
+  private socketErrorHandler?: (error: Error) => void;
+  private monitoredSocket?: any; // Store the socket instance we attached listeners to
+
+  // Sleep abort control
+  private sleepTimeout?: NodeJS.Timeout;
+  private sleepResolve?: () => void;
+
+  // Client reference
+  private client: DWClient;
+
+  constructor(client: DWClient, accountId: string, config: ConnectionManagerConfig, log?: Logger) {
+    this.client = client;
+    this.accountId = accountId;
+    this.config = config;
+    this.log = log;
+  }
+
+  private notifyStateChange(error?: string): void {
+    if (this.config.onStateChange) {
+      this.config.onStateChange(this.state, error);
+    }
+  }
+
+  /**
+   * Calculate next reconnection delay with exponential backoff and jitter
+   * Formula: delay = min(initialDelay * 2^attempt, maxDelay) * (1 ± jitter)
+   * @param attempt Zero-based attempt number (0 for first retry, 1 for second, etc.)
+   */
+  private calculateNextDelay(attempt: number): number {
+    const { initialDelay, maxDelay, jitter } = this.config;
+
+    // Exponential backoff: initialDelay * 2^attempt
+    // For attempt=0 (first retry), this gives initialDelay * 1 = initialDelay
+    const exponentialDelay = initialDelay * Math.pow(2, attempt);
+
+    // Cap at maxDelay
+    const cappedDelay = Math.min(exponentialDelay, maxDelay);
+
+    // Apply jitter: randomize ± jitter%
+    const jitterAmount = cappedDelay * jitter;
+    const randomJitter = (Math.random() * 2 - 1) * jitterAmount;
+    const finalDelay = Math.max(100, cappedDelay + randomJitter); // Minimum 100ms
+
+    return Math.floor(finalDelay);
+  }
+
+  /**
+   * Attempt to connect with retry logic
+   */
+  private async attemptConnection(): Promise<ConnectionAttemptResult> {
+    if (this.stopped) {
+      return {
+        success: false,
+        attempt: this.attemptCount,
+        error: new Error("Connection manager stopped"),
+      };
+    }
+
+    this.attemptCount++;
+    this.state = ConnectionStateEnum.CONNECTING;
+    this.notifyStateChange();
+
+    this.log?.info?.(
+      `[${this.accountId}] Connection attempt ${this.attemptCount}/${this.config.maxAttempts}...`,
+    );
+
+    try {
+      // Call DWClient connect method
+      await this.client.connect();
+
+      // Re-check stopped flag after async connect() completes
+      // This prevents race condition where stop() is called during connection
+      if (this.stopped) {
+        this.log?.warn?.(
+          `[${this.accountId}] Connection succeeded but manager was stopped during connect - disconnecting`,
+        );
+        try {
+          this.client.disconnect();
+        } catch (disconnectErr: any) {
+          this.log?.debug?.(
+            `[${this.accountId}] Error during post-connect disconnect: ${disconnectErr.message}`,
+          );
+        }
+        return {
+          success: false,
+          attempt: this.attemptCount,
+          error: new Error("Connection manager stopped during connect"),
+        };
+      }
+
+      // Connection successful
+      this.state = ConnectionStateEnum.CONNECTED;
+      this.notifyStateChange();
+      const successfulAttempt = this.attemptCount;
+      this.attemptCount = 0; // Reset counter on success
+
+      this.log?.info?.(`[${this.accountId}] DingTalk Stream client connected successfully`);
+
+      return { success: true, attempt: successfulAttempt };
+    } catch (err: any) {
+      this.log?.error?.(
+        `[${this.accountId}] Connection attempt ${this.attemptCount} failed: ${err.message}`,
+      );
+
+      // Check if we've exceeded max attempts
+      if (this.attemptCount >= this.config.maxAttempts) {
+        this.state = ConnectionStateEnum.FAILED;
+        this.notifyStateChange("Max connection attempts reached");
+        this.log?.error?.(
+          `[${this.accountId}] Max connection attempts (${this.config.maxAttempts}) reached. Giving up.`,
+        );
+        return { success: false, attempt: this.attemptCount, error: err };
+      }
+
+      // Calculate next retry delay (use attemptCount-1 for zero-based exponent)
+      // This ensures first retry uses 2^0 = 1x initialDelay
+      const nextDelay = this.calculateNextDelay(this.attemptCount - 1);
+
+      this.log?.warn?.(
+        `[${this.accountId}] Will retry connection in ${(nextDelay / 1000).toFixed(2)}s (attempt ${this.attemptCount + 1}/${this.config.maxAttempts})`,
+      );
+
+      return { success: false, attempt: this.attemptCount, error: err, nextDelay };
+    }
+  }
+
+  /**
+   * Connect with robust retry logic
+   */
+  public async connect(): Promise<void> {
+    if (this.stopped) {
+      throw new Error("Cannot connect: connection manager is stopped");
+    }
+
+    // Clear any existing reconnect timer
+    this.clearReconnectTimer();
+
+    this.log?.info?.(
+      `[${this.accountId}] Starting DingTalk Stream client with robust connection...`,
+    );
+
+    // Keep trying until success or max attempts reached
+    while (!this.stopped && this.state !== ConnectionStateEnum.CONNECTED) {
+      const result = await this.attemptConnection();
+
+      if (result.success) {
+        // Connection successful
+        this.setupRuntimeReconnection();
+        return;
+      }
+
+      // Check if connection was stopped during connect
+      if (result.error?.message === "Connection manager stopped during connect") {
+        this.log?.info?.(
+          `[${this.accountId}] Connection cancelled: manager stopped during connect`,
+        );
+        throw new Error("Connection cancelled: connection manager stopped");
+      }
+
+      if (!result.nextDelay || this.attemptCount >= this.config.maxAttempts) {
+        // No more retries
+        throw new Error(`Failed to connect after ${this.attemptCount} attempts`);
+      }
+
+      // Wait before next attempt
+      await this.sleep(result.nextDelay);
+    }
+  }
+
+  /**
+   * Setup runtime reconnection handlers
+   * Monitors DWClient connection state for automatic reconnection
+   */
+  private setupRuntimeReconnection(): void {
+    this.log?.debug?.(`[${this.accountId}] Setting up runtime reconnection monitoring`);
+
+    // Clean up any existing monitoring resources before setting up new ones
+    this.cleanupRuntimeMonitoring();
+
+    // Access DWClient internals to monitor connection state
+    const client = this.client as any;
+
+    // Monitor client's 'connected' property changes
+    // We'll set up an interval to periodically check connection health
+    this.healthCheckInterval = setInterval(() => {
+      if (this.stopped) {
+        if (this.healthCheckInterval) {
+          clearInterval(this.healthCheckInterval);
+        }
+        return;
+      }
+
+      // If we believe we're connected but DWClient disagrees, trigger reconnection
+      if (this.state === ConnectionStateEnum.CONNECTED && !client.connected) {
+        this.log?.warn?.(
+          `[${this.accountId}] Connection health check failed - detected disconnection`,
+        );
+        if (this.healthCheckInterval) {
+          clearInterval(this.healthCheckInterval);
+        }
+        this.handleRuntimeDisconnection();
+      }
+    }, 5000); // Check every 5 seconds
+
+    // Additionally, if we have access to the socket, monitor its events
+    // The DWClient uses 'ws' WebSocket library which extends EventEmitter
+    if (client.socket) {
+      const socket = client.socket;
+      // Store the socket instance we're attaching listeners to
+      this.monitoredSocket = socket;
+
+      // Handler for socket close event
+      this.socketCloseHandler = (code: number, reason: string) => {
+        this.log?.warn?.(
+          `[${this.accountId}] WebSocket closed event (code: ${code}, reason: ${reason || "none"})`,
+        );
+
+        // Only trigger reconnection if we were previously connected and not stopping
+        if (!this.stopped && this.state === ConnectionStateEnum.CONNECTED) {
+          if (this.healthCheckInterval) {
+            clearInterval(this.healthCheckInterval);
+          }
+          this.handleRuntimeDisconnection();
+        }
+      };
+
+      // Handler for socket error event
+      this.socketErrorHandler = (error: Error) => {
+        this.log?.error?.(
+          `[${this.accountId}] WebSocket error event: ${error?.message || "Unknown error"}`,
+        );
+      };
+
+      // Listen to socket events
+      // Use 'once' for close to avoid duplicate reconnection triggers
+      socket.once("close", this.socketCloseHandler);
+      // Use 'once' for error as well to prevent accumulation across reconnects
+      socket.once("error", this.socketErrorHandler);
+    }
+  }
+
+  /**
+   * Clean up runtime monitoring resources (intervals and event listeners)
+   */
+  private cleanupRuntimeMonitoring(): void {
+    // Clear health check interval
+    if (this.healthCheckInterval) {
+      clearInterval(this.healthCheckInterval);
+      this.healthCheckInterval = undefined;
+      this.log?.debug?.(`[${this.accountId}] Health check interval cleared`);
+    }
+
+    // Remove socket event listeners from the stored socket instance
+    if (this.monitoredSocket) {
+      const socket = this.monitoredSocket;
+
+      if (this.socketCloseHandler) {
+        socket.removeListener("close", this.socketCloseHandler);
+        this.socketCloseHandler = undefined;
+      }
+      if (this.socketErrorHandler) {
+        socket.removeListener("error", this.socketErrorHandler);
+        this.socketErrorHandler = undefined;
+      }
+
+      this.log?.debug?.(`[${this.accountId}] Socket event listeners removed from monitored socket`);
+      this.monitoredSocket = undefined;
+    }
+  }
+
+  /**
+   * Handle runtime disconnection and trigger reconnection
+   */
+  private handleRuntimeDisconnection(): void {
+    if (this.stopped) return;
+
+    this.log?.warn?.(
+      `[${this.accountId}] Runtime disconnection detected, initiating reconnection...`,
+    );
+
+    this.state = ConnectionStateEnum.DISCONNECTED;
+    this.notifyStateChange("Runtime disconnection detected");
+    this.attemptCount = 0; // Reset attempt counter for runtime reconnection
+
+    // Clear any existing timer
+    this.clearReconnectTimer();
+
+    // Start reconnection with initial delay
+    const delay = this.calculateNextDelay(0);
+    this.log?.info?.(
+      `[${this.accountId}] Scheduling reconnection in ${(delay / 1000).toFixed(2)}s`,
+    );
+
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnect().catch((err) => {
+        this.log?.error?.(`[${this.accountId}] Reconnection failed: ${err.message}`);
+      });
+    }, delay);
+  }
+
+  /**
+   * Reconnect after runtime disconnection
+   */
+  private async reconnect(): Promise<void> {
+    if (this.stopped) return;
+
+    this.log?.info?.(`[${this.accountId}] Attempting to reconnect...`);
+
+    try {
+      await this.connect();
+      this.log?.info?.(`[${this.accountId}] Reconnection successful`);
+    } catch (err: any) {
+      if (this.stopped) return;
+
+      this.log?.error?.(`[${this.accountId}] Reconnection failed: ${err.message}`);
+      this.state = ConnectionStateEnum.FAILED;
+      this.notifyStateChange(err.message);
+
+      // Continue runtime recovery instead of getting stuck in FAILED.
+      const delay = this.calculateNextDelay(0);
+      this.attemptCount = 0;
+      this.clearReconnectTimer();
+      this.log?.warn?.(
+        `[${this.accountId}] Reconnection cycle failed; scheduling next reconnect in ${(delay / 1000).toFixed(2)}s`,
+      );
+      this.reconnectTimer = setTimeout(() => {
+        void this.reconnect();
+      }, delay);
+    }
+  }
+
+  /**
+   * Stop the connection manager and cleanup resources
+   */
+  public stop(): void {
+    if (this.stopped) return;
+
+    this.log?.info?.(`[${this.accountId}] Stopping connection manager...`);
+
+    this.stopped = true;
+    this.state = ConnectionStateEnum.DISCONNECTING;
+
+    // Clear reconnect timer
+    this.clearReconnectTimer();
+
+    // Cancel any in-flight sleep (retry delay)
+    this.cancelSleep();
+
+    // Clean up runtime monitoring resources
+    this.cleanupRuntimeMonitoring();
+
+    // Disconnect client
+    try {
+      this.client.disconnect();
+    } catch (err: any) {
+      this.log?.warn?.(`[${this.accountId}] Error during disconnect: ${err.message}`);
+    }
+
+    this.state = ConnectionStateEnum.DISCONNECTED;
+    this.log?.info?.(`[${this.accountId}] Connection manager stopped`);
+  }
+
+  /**
+   * Clear reconnection timer
+   */
+  private clearReconnectTimer(): void {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = undefined;
+      this.log?.debug?.(`[${this.accountId}] Reconnect timer cleared`);
+    }
+  }
+
+  /**
+   * Sleep utility for retry delays
+   * Returns a promise that resolves after ms or can be cancelled via cancelSleep()
+   */
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => {
+      this.sleepResolve = resolve;
+      this.sleepTimeout = setTimeout(() => {
+        this.sleepTimeout = undefined;
+        this.sleepResolve = undefined;
+        resolve();
+      }, ms);
+    });
+  }
+
+  /**
+   * Cancel any in-flight sleep operation
+   * Resolves the pending promise immediately so await unblocks
+   */
+  private cancelSleep(): void {
+    if (this.sleepTimeout) {
+      clearTimeout(this.sleepTimeout);
+      this.sleepTimeout = undefined;
+      this.log?.debug?.(`[${this.accountId}] Sleep timeout cancelled`);
+    }
+    // Resolve the pending promise so await unblocks immediately
+    if (this.sleepResolve) {
+      this.sleepResolve();
+      this.sleepResolve = undefined;
+    }
+  }
+
+  /**
+   * Get current connection state
+   */
+  public getState(): ConnectionState {
+    return this.state;
+  }
+
+  /**
+   * Check if connection is active
+   */
+  public isConnected(): boolean {
+    return this.state === ConnectionStateEnum.CONNECTED;
+  }
+
+  /**
+   * Check if connection manager is stopped
+   */
+  public isStopped(): boolean {
+    return this.stopped;
+  }
+}

--- a/extensions/openclaw-channel-dingtalk/src/media-utils.ts
+++ b/extensions/openclaw-channel-dingtalk/src/media-utils.ts
@@ -1,0 +1,136 @@
+// src/media-utils.ts
+
+/**
+ * Media handling utilities for DingTalk channel plugin.
+ * Provides functions for media type detection and file upload to DingTalk media servers.
+ */
+
+import axios from "axios";
+import FormData from "form-data";
+import * as fs from "fs";
+import { promises as fsPromises } from "fs";
+import * as path from "path";
+import type { DingTalkConfig, Logger } from "./types.js";
+
+export type DingTalkMediaType = "image" | "voice" | "video" | "file";
+
+/**
+ * Detect media type from file extension
+ * Matches DingTalk's supported media types:
+ * - image: jpg, gif, png, bmp (max 20MB)
+ * - voice: amr, mp3, wav (max 2MB)
+ * - video: mp4 (max 20MB)
+ * - file: doc, docx, xls, xlsx, ppt, pptx, zip, pdf, rar (max 20MB)
+ *
+ * @param filePath Path to the media file
+ * @returns Detected media type
+ */
+export function detectMediaTypeFromExtension(filePath: string): DingTalkMediaType {
+  const ext = path.extname(filePath).toLowerCase();
+
+  if ([".jpg", ".jpeg", ".png", ".gif", ".bmp"].includes(ext)) {
+    return "image";
+  } else if ([".mp3", ".amr", ".wav"].includes(ext)) {
+    return "voice";
+  } else if ([".mp4", ".avi", ".mov"].includes(ext)) {
+    return "video";
+  }
+
+  return "file";
+}
+
+/**
+ * File size limits for DingTalk media types (in bytes)
+ */
+const FILE_SIZE_LIMITS: Record<DingTalkMediaType, number> = {
+  image: 20 * 1024 * 1024, // 20MB
+  voice: 2 * 1024 * 1024, // 2MB
+  video: 20 * 1024 * 1024, // 20MB
+  file: 20 * 1024 * 1024, // 20MB
+};
+
+/**
+ * Upload media file to DingTalk and get media_id
+ * Uses DingTalk's media upload API: https://oapi.dingtalk.com/media/upload
+ *
+ * Note: Media files are stored temporarily by DingTalk (not in permanent storage).
+ * The media_id can be used in subsequent message sends.
+ *
+ * @param config DingTalk configuration
+ * @param mediaPath Local path to the media file
+ * @param mediaType Type of media: 'image' | 'voice' | 'video' | 'file'
+ * @param getAccessToken Function to get DingTalk access token
+ * @param log Optional logger
+ * @returns media_id on success, null on failure
+ */
+export async function uploadMedia(
+  config: DingTalkConfig,
+  mediaPath: string,
+  mediaType: DingTalkMediaType,
+  getAccessToken: (config: DingTalkConfig, log?: Logger) => Promise<string>,
+  log?: Logger,
+): Promise<string | null> {
+  let fileStream: fs.ReadStream | null = null;
+
+  try {
+    const token = await getAccessToken(config, log);
+
+    // Check file size (stat will throw if file doesn't exist)
+    const stats = await fsPromises.stat(mediaPath);
+    const sizeLimit = FILE_SIZE_LIMITS[mediaType];
+    if (stats.size > sizeLimit) {
+      const sizeMB = (stats.size / (1024 * 1024)).toFixed(2);
+      const limitMB = (sizeLimit / (1024 * 1024)).toFixed(2);
+      log?.error?.(
+        `[DingTalk] Media file too large: ${sizeMB}MB exceeds ${limitMB}MB limit for ${mediaType}`,
+      );
+      return null;
+    }
+
+    // Read file as a stream for better memory efficiency
+    fileStream = fs.createReadStream(mediaPath);
+    const filename = path.basename(mediaPath);
+
+    // Upload to DingTalk's media server using form-data
+    const form = new FormData();
+    form.append("media", fileStream, { filename });
+
+    const uploadUrl = `https://oapi.dingtalk.com/media/upload?access_token=${token}&type=${mediaType}`;
+
+    log?.debug?.(`[DingTalk] Uploading media: ${filename} (${stats.size} bytes) as ${mediaType}`);
+
+    const response = await axios.post(uploadUrl, form, {
+      headers: form.getHeaders(),
+      maxBodyLength: Infinity,
+      maxContentLength: Infinity,
+    });
+
+    if (response.data?.errcode === 0 && response.data?.media_id) {
+      log?.debug?.(
+        `[DingTalk] Media uploaded successfully: ${response.data.media_id} (${stats.size} bytes)`,
+      );
+      return response.data.media_id;
+    } else {
+      log?.error?.(`[DingTalk] Media upload failed: ${JSON.stringify(response.data)}`);
+      return null;
+    }
+  } catch (err: any) {
+    // Handle file system errors (e.g., file not found, permission denied)
+    if (err.code === "ENOENT") {
+      log?.error?.(`[DingTalk] Media file not found: ${mediaPath}`);
+    } else if (err.code === "EACCES") {
+      log?.error?.(`[DingTalk] Permission denied accessing media file: ${mediaPath}`);
+    } else {
+      log?.error?.(`[DingTalk] Failed to upload media: ${err.message}`);
+      if (axios.isAxiosError(err) && err.response) {
+        log?.error?.(`[DingTalk] Upload response: ${JSON.stringify(err.response.data)}`);
+      }
+    }
+    return null;
+  } finally {
+    // Ensure file stream is closed even on error
+    if (fileStream) {
+      fileStream.destroy();
+    }
+  }
+}

--- a/extensions/openclaw-channel-dingtalk/src/onboarding.ts
+++ b/extensions/openclaw-channel-dingtalk/src/onboarding.ts
@@ -1,0 +1,325 @@
+import type { OpenClawConfig, ChannelOnboardingAdapter, WizardPrompter } from "openclaw/plugin-sdk";
+import { DEFAULT_ACCOUNT_ID, normalizeAccountId, formatDocsLink } from "openclaw/plugin-sdk";
+import type { DingTalkConfig, DingTalkChannelConfig } from "./types.js";
+import { listDingTalkAccountIds, resolveDingTalkAccount } from "./types.js";
+
+const channel = "dingtalk" as const;
+
+function isConfigured(account: DingTalkConfig): boolean {
+  return Boolean(account.clientId && account.clientSecret);
+}
+
+function parseList(value: string): string[] {
+  return value
+    .split(/[\n,;]+/g)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function applyAccountNameToChannelSection(params: {
+  cfg: OpenClawConfig;
+  channelKey: string;
+  accountId: string;
+  name?: string;
+}): OpenClawConfig {
+  const { cfg, channelKey, name } = params;
+  if (!name) return cfg;
+  const base = cfg.channels?.[channelKey] as DingTalkChannelConfig | undefined;
+  return {
+    ...cfg,
+    channels: {
+      ...cfg.channels,
+      [channelKey]: { ...base, name },
+    },
+  };
+}
+
+async function promptDingTalkAccountId(options: {
+  cfg: OpenClawConfig;
+  prompter: WizardPrompter;
+  label: string;
+  currentId: string;
+  listAccountIds: (cfg: OpenClawConfig) => string[];
+  defaultAccountId: string;
+}): Promise<string> {
+  const existingIds = options.listAccountIds(options.cfg);
+  if (existingIds.length === 0) {
+    return options.defaultAccountId;
+  }
+  const useExisting = await options.prompter.confirm({
+    message: `Use existing ${options.label} account?`,
+    initialValue: true,
+  });
+  if (useExisting && existingIds.includes(options.currentId)) {
+    return options.currentId;
+  }
+  const newId = await options.prompter.text({
+    message: `New ${options.label} account ID`,
+    placeholder: options.defaultAccountId,
+    initialValue: options.defaultAccountId,
+  });
+  return normalizeAccountId(String(newId));
+}
+
+async function noteDingTalkHelp(prompter: WizardPrompter): Promise<void> {
+  await prompter.note(
+    [
+      "You need DingTalk application credentials.",
+      "1. Visit https://open-dev.dingtalk.com/",
+      "2. Create an enterprise internal application",
+      "3. Enable 'Robot' capability",
+      "4. Configure message receiving mode as 'Stream mode'",
+      "5. Copy Client ID (AppKey) and Client Secret (AppSecret)",
+      `Docs: ${formatDocsLink("/channels/dingtalk", "channels/dingtalk")}`,
+    ].join("\n"),
+    "DingTalk setup",
+  );
+}
+
+function applyAccountConfig(params: {
+  cfg: OpenClawConfig;
+  accountId: string;
+  input: Partial<DingTalkConfig>;
+}): OpenClawConfig {
+  const { cfg, accountId, input } = params;
+  const useDefault = accountId === DEFAULT_ACCOUNT_ID;
+
+  const namedConfig = applyAccountNameToChannelSection({
+    cfg,
+    channelKey: "dingtalk",
+    accountId,
+    name: input.name,
+  });
+  const base = namedConfig.channels?.dingtalk as DingTalkChannelConfig | undefined;
+
+  const payload: Partial<DingTalkConfig> = {
+    ...(input.clientId ? { clientId: input.clientId } : {}),
+    ...(input.clientSecret ? { clientSecret: input.clientSecret } : {}),
+    ...(input.robotCode ? { robotCode: input.robotCode } : {}),
+    ...(input.corpId ? { corpId: input.corpId } : {}),
+    ...(input.agentId ? { agentId: input.agentId } : {}),
+    ...(input.dmPolicy ? { dmPolicy: input.dmPolicy } : {}),
+    ...(input.groupPolicy ? { groupPolicy: input.groupPolicy } : {}),
+    ...(input.allowFrom && input.allowFrom.length > 0 ? { allowFrom: input.allowFrom } : {}),
+    ...(input.messageType ? { messageType: input.messageType } : {}),
+    ...(input.cardTemplateId ? { cardTemplateId: input.cardTemplateId } : {}),
+    ...(input.cardTemplateKey ? { cardTemplateKey: input.cardTemplateKey } : {}),
+  };
+
+  if (useDefault) {
+    return {
+      ...namedConfig,
+      channels: {
+        ...namedConfig.channels,
+        dingtalk: {
+          ...base,
+          enabled: true,
+          ...payload,
+        },
+      },
+    };
+  }
+
+  const accounts = (base as { accounts?: Record<string, unknown> }).accounts ?? {};
+  const existingAccount =
+    (base as { accounts?: Record<string, Record<string, unknown>> }).accounts?.[accountId] ?? {};
+
+  return {
+    ...namedConfig,
+    channels: {
+      ...namedConfig.channels,
+      dingtalk: {
+        ...base,
+        enabled: base?.enabled ?? true,
+        accounts: {
+          ...accounts,
+          [accountId]: {
+            ...existingAccount,
+            enabled: true,
+            ...payload,
+          },
+        },
+      },
+    },
+  };
+}
+
+export const dingtalkOnboardingAdapter: ChannelOnboardingAdapter = {
+  channel,
+  getStatus: ({ cfg }) => {
+    const accountIds = listDingTalkAccountIds(cfg);
+    const configured =
+      accountIds.length > 0
+        ? accountIds.some((accountId) => isConfigured(resolveDingTalkAccount(cfg, accountId)))
+        : isConfigured(resolveDingTalkAccount(cfg, DEFAULT_ACCOUNT_ID));
+
+    return Promise.resolve({
+      channel,
+      configured,
+      statusLines: [`DingTalk: ${configured ? "configured" : "needs setup"}`],
+      selectionHint: configured ? "configured" : "钉钉企业机器人",
+      quickstartScore: configured ? 1 : 4,
+    });
+  },
+  configure: async ({ cfg, prompter, accountOverrides, shouldPromptAccountIds }) => {
+    const override = accountOverrides[channel]?.trim();
+    let accountId = override ? normalizeAccountId(override) : DEFAULT_ACCOUNT_ID;
+
+    if (shouldPromptAccountIds && !override) {
+      accountId = await promptDingTalkAccountId({
+        cfg,
+        prompter,
+        label: "DingTalk",
+        currentId: accountId,
+        listAccountIds: listDingTalkAccountIds,
+        defaultAccountId: DEFAULT_ACCOUNT_ID,
+      });
+    }
+
+    const resolved = resolveDingTalkAccount(cfg, accountId);
+    await noteDingTalkHelp(prompter);
+
+    const clientId = await prompter.text({
+      message: "Client ID (AppKey)",
+      placeholder: "dingxxxxxxxx",
+      initialValue: resolved.clientId ?? undefined,
+      validate: (value) => (String(value ?? "").trim() ? undefined : "Required"),
+    });
+
+    const clientSecret = await prompter.text({
+      message: "Client Secret (AppSecret)",
+      placeholder: "xxx-xxx-xxx-xxx",
+      initialValue: resolved.clientSecret ?? undefined,
+      validate: (value) => (String(value ?? "").trim() ? undefined : "Required"),
+    });
+
+    const wantsFullConfig = await prompter.confirm({
+      message: "Configure robot code, corp ID, and agent ID? (recommended for full features)",
+      initialValue: false,
+    });
+
+    let robotCode: string | undefined;
+    let corpId: string | undefined;
+    let agentId: string | undefined;
+
+    if (wantsFullConfig) {
+      robotCode =
+        String(
+          await prompter.text({
+            message: "Robot Code",
+            placeholder: "dingxxxxxxxx",
+            initialValue: resolved.robotCode ?? undefined,
+          }),
+        ).trim() || undefined;
+
+      corpId =
+        String(
+          await prompter.text({
+            message: "Corp ID",
+            placeholder: "dingxxxxxxxx",
+            initialValue: resolved.corpId ?? undefined,
+          }),
+        ).trim() || undefined;
+
+      agentId =
+        String(
+          await prompter.text({
+            message: "Agent ID",
+            placeholder: "123456789",
+            initialValue: resolved.agentId ? String(resolved.agentId) : undefined,
+          }),
+        ).trim() || undefined;
+    }
+
+    const wantsCardMode = await prompter.confirm({
+      message: "Enable AI interactive card mode? (for streaming AI responses)",
+      initialValue: resolved.messageType === "card",
+    });
+
+    let cardTemplateId: string | undefined;
+    let cardTemplateKey: string | undefined;
+    let messageType: "markdown" | "card" = "markdown";
+
+    if (wantsCardMode) {
+      await prompter.note(
+        [
+          "Create an AI card template in DingTalk Developer Console:",
+          "https://open-dev.dingtalk.com/fe/card",
+          "1. Go to 'My Templates' > 'Create Template'",
+          "2. Select 'AI Card' scenario",
+          "3. Design your card and publish",
+          "4. Copy the Template ID (e.g., xxx.schema)",
+        ].join("\n"),
+        "Card Template Setup",
+      );
+
+      cardTemplateId =
+        String(
+          await prompter.text({
+            message: "Card Template ID",
+            placeholder: "xxxxx-xxxxx-xxxxx.schema",
+            initialValue: resolved.cardTemplateId ?? undefined,
+          }),
+        ).trim() || undefined;
+
+      cardTemplateKey =
+        String(
+          await prompter.text({
+            message: "Card Template Key (content field name)",
+            placeholder: "msgContent",
+            initialValue: resolved.cardTemplateKey ?? "msgContent",
+          }),
+        ).trim() || "msgContent";
+
+      messageType = "card";
+    }
+
+    const dmPolicyValue = await prompter.select({
+      message: "Direct message policy",
+      options: [
+        { label: "Open - anyone can DM", value: "open" },
+        { label: "Allowlist - only allowed users", value: "allowlist" },
+      ],
+      initialValue: resolved.dmPolicy ?? "open",
+    });
+
+    let allowFrom: string[] | undefined;
+    if (dmPolicyValue === "allowlist") {
+      const entry = await prompter.text({
+        message: "Allowed user IDs (comma-separated)",
+        placeholder: "user1, user2",
+      });
+      const parsed = parseList(String(entry ?? ""));
+      allowFrom = parsed.length > 0 ? parsed : undefined;
+    }
+
+    const groupPolicyValue = await prompter.select({
+      message: "Group message policy",
+      options: [
+        { label: "Open - any group can use bot", value: "open" },
+        { label: "Allowlist - only allowed groups", value: "allowlist" },
+      ],
+      initialValue: resolved.groupPolicy ?? "open",
+    });
+
+    const next = applyAccountConfig({
+      cfg,
+      accountId,
+      input: {
+        clientId: String(clientId).trim(),
+        clientSecret: String(clientSecret).trim(),
+        robotCode,
+        corpId,
+        agentId,
+        dmPolicy: dmPolicyValue as "open" | "allowlist",
+        groupPolicy: groupPolicyValue as "open" | "allowlist",
+        allowFrom,
+        messageType,
+        cardTemplateId,
+        cardTemplateKey,
+      },
+    });
+
+    return { cfg: next, accountId };
+  },
+};

--- a/extensions/openclaw-channel-dingtalk/src/peer-id-registry.ts
+++ b/extensions/openclaw-channel-dingtalk/src/peer-id-registry.ts
@@ -1,0 +1,35 @@
+/**
+ * Peer ID Registry
+ *
+ * Maps lowercased peer/session keys back to their original case-sensitive
+ * DingTalk conversationId values. DingTalk conversationIds are base64-encoded
+ * and therefore case-sensitive, but the framework may lowercase session keys
+ * internally. This registry preserves the original casing so outbound messages
+ * can be delivered correctly.
+ */
+
+const peerIdMap = new Map<string, string>();
+
+/**
+ * Register an original peer ID, keyed by its lowercased form.
+ */
+export function registerPeerId(originalId: string): void {
+  if (!originalId) return;
+  peerIdMap.set(originalId.toLowerCase(), originalId);
+}
+
+/**
+ * Resolve a possibly-lowercased peer ID back to its original casing.
+ * Returns the original if found, otherwise returns the input as-is.
+ */
+export function resolveOriginalPeerId(id: string): string {
+  if (!id) return id;
+  return peerIdMap.get(id.toLowerCase()) || id;
+}
+
+/**
+ * Clear the registry (for testing or shutdown).
+ */
+export function clearPeerIdRegistry(): void {
+  peerIdMap.clear();
+}

--- a/extensions/openclaw-channel-dingtalk/src/runtime.ts
+++ b/extensions/openclaw-channel-dingtalk/src/runtime.ts
@@ -1,0 +1,14 @@
+import type { PluginRuntime } from "openclaw/plugin-sdk";
+
+let runtime: PluginRuntime | null = null;
+
+export function setDingTalkRuntime(next: PluginRuntime): void {
+  runtime = next;
+}
+
+export function getDingTalkRuntime(): PluginRuntime {
+  if (!runtime) {
+    throw new Error("DingTalk runtime not initialized");
+  }
+  return runtime;
+}

--- a/extensions/openclaw-channel-dingtalk/src/types.ts
+++ b/extensions/openclaw-channel-dingtalk/src/types.ts
@@ -1,0 +1,543 @@
+/**
+ * Type definitions for DingTalk Channel Plugin
+ *
+ * Provides comprehensive type safety for:
+ * - Configuration objects
+ * - DingTalk API request/response models
+ * - Message content and formats
+ * - Media files and streams
+ * - Session and token management
+ */
+
+import type {
+  OpenClawConfig,
+  ChannelLogSink as SDKChannelLogSink,
+  ChannelAccountSnapshot as SDKChannelAccountSnapshot,
+  ChannelGatewayContext as SDKChannelGatewayContext,
+  ChannelPlugin as SDKChannelPlugin,
+} from "openclaw/plugin-sdk";
+
+/**
+ * DingTalk channel configuration (extends base OpenClaw config)
+ */
+export interface DingTalkConfig extends OpenClawConfig {
+  clientId: string;
+  clientSecret: string;
+  robotCode?: string;
+  corpId?: string;
+  agentId?: string;
+  name?: string;
+  enabled?: boolean;
+  dmPolicy?: "open" | "pairing" | "allowlist";
+  groupPolicy?: "open" | "allowlist";
+  allowFrom?: string[];
+  showThinking?: boolean;
+  debug?: boolean;
+  messageType?: "markdown" | "card";
+  cardTemplateId?: string;
+  cardTemplateKey?: string;
+  groups?: Record<string, { systemPrompt?: string }>;
+  accounts?: Record<string, DingTalkConfig>;
+  // Connection robustness configuration
+  maxConnectionAttempts?: number;
+  initialReconnectDelay?: number;
+  maxReconnectDelay?: number;
+  reconnectJitter?: number;
+}
+
+/**
+ * Multi-account DingTalk configuration wrapper
+ */
+export interface DingTalkChannelConfig {
+  enabled?: boolean;
+  clientId: string;
+  clientSecret: string;
+  robotCode?: string;
+  corpId?: string;
+  agentId?: string;
+  name?: string;
+  dmPolicy?: "open" | "pairing" | "allowlist";
+  groupPolicy?: "open" | "allowlist";
+  allowFrom?: string[];
+  showThinking?: boolean;
+  debug?: boolean;
+  messageType?: "markdown" | "card";
+  cardTemplateId?: string;
+  cardTemplateKey?: string;
+  groups?: Record<string, { systemPrompt?: string }>;
+  accounts?: Record<string, DingTalkConfig>;
+  maxConnectionAttempts?: number;
+  initialReconnectDelay?: number;
+  maxReconnectDelay?: number;
+  reconnectJitter?: number;
+}
+
+/**
+ * DingTalk token info for caching
+ */
+export interface TokenInfo {
+  accessToken: string;
+  expireIn: number;
+}
+
+/**
+ * DingTalk API token response
+ */
+export interface TokenResponse {
+  accessToken: string;
+  expireIn: number;
+}
+
+/**
+ * DingTalk API generic response wrapper
+ */
+export interface DingTalkApiResponse<T = unknown> {
+  data?: T;
+  code?: string;
+  message?: string;
+  success?: boolean;
+}
+
+/**
+ * Media download response from DingTalk API
+ */
+export interface MediaDownloadResponse {
+  downloadUrl?: string;
+  downloadCode?: string;
+}
+
+/**
+ * Media file metadata
+ */
+export interface MediaFile {
+  path: string;
+  mimeType: string;
+}
+
+/**
+ * DingTalk incoming message (Stream mode)
+ */
+export interface DingTalkInboundMessage {
+  msgId: string;
+  msgtype: string;
+  createAt: number;
+  text?: {
+    content: string;
+  };
+  content?: {
+    downloadCode?: string;
+    fileName?: string;
+    recognition?: string;
+    richText?: Array<{
+      type: string;
+      text?: string;
+      atName?: string;
+      downloadCode?: string; // For picture type in richText
+    }>;
+  };
+  conversationType: string;
+  conversationId: string;
+  conversationTitle?: string;
+  senderId: string;
+  senderStaffId?: string;
+  senderNick?: string;
+  chatbotUserId: string;
+  sessionWebhook: string;
+}
+
+/**
+ * Extracted message content for unified processing
+ */
+export interface MessageContent {
+  text: string;
+  mediaPath?: string;
+  mediaType?: string;
+  messageType: string;
+}
+
+/**
+ * Send message options
+ */
+export interface SendMessageOptions {
+  title?: string;
+  useMarkdown?: boolean;
+  atUserId?: string | null;
+  log?: any;
+  mediaPath?: string;
+  filePath?: string;
+  mediaUrl?: string;
+  mediaType?: "image" | "voice" | "video" | "file";
+}
+
+/**
+ * Session webhook response
+ */
+export interface SessionWebhookResponse {
+  msgtype: string;
+  markdown?: {
+    title: string;
+    text: string;
+  };
+  text?: {
+    content: string;
+  };
+  at?: {
+    atUserIds: string[];
+    isAtAll: boolean;
+  };
+}
+
+/**
+ * Message handler parameters
+ */
+export interface HandleDingTalkMessageParams {
+  cfg: OpenClawConfig;
+  accountId: string;
+  data: DingTalkInboundMessage;
+  sessionWebhook: string;
+  log?: any;
+  dingtalkConfig: DingTalkConfig;
+}
+
+/**
+ * Proactive message payload
+ */
+export interface ProactiveMessagePayload {
+  robotCode: string;
+  msgKey: string;
+  msgParam: string;
+  openConversationId?: string;
+  userIds?: string[];
+}
+
+/**
+ * Account descriptor
+ */
+export interface AccountDescriptor {
+  accountId: string;
+  config?: DingTalkConfig;
+  enabled?: boolean;
+  name?: string;
+  configured?: boolean;
+}
+
+/**
+ * Account resolver result
+ */
+export interface ResolvedAccount {
+  accountId: string;
+  config: DingTalkConfig;
+  enabled: boolean;
+}
+
+/**
+ * HTTP request config for axios
+ */
+export interface AxiosRequestConfig {
+  url?: string;
+  method?: string;
+  data?: any;
+  headers?: Record<string, string>;
+  responseType?: "arraybuffer" | "json" | "text";
+}
+
+/**
+ * HTTP response from axios
+ */
+export interface AxiosResponse<T = any> {
+  data: T;
+  status: number;
+  statusText: string;
+  headers: Record<string, string>;
+}
+
+/**
+ * DingTalk Stream callback listener types
+ */
+export interface StreamCallbackResponse {
+  headers?: {
+    messageId?: string;
+  };
+  data: string;
+}
+
+/**
+ * Reply dispatcher context
+ */
+export interface ReplyDispatchContext {
+  responsePrefix?: string;
+  deliver: (payload: any) => Promise<{ ok: boolean; error?: string }>;
+}
+
+/**
+ * Reply dispatcher result
+ */
+export interface ReplyDispatcherResult {
+  dispatcher: any;
+  replyOptions: any;
+  markDispatchIdle: () => void;
+}
+
+/**
+ * Retry options
+ */
+export interface RetryOptions {
+  maxRetries?: number;
+  baseDelayMs?: number;
+  log?: any;
+}
+
+/**
+ * Channel log sink
+ */
+export type ChannelLogSink = SDKChannelLogSink;
+
+/**
+ * @deprecated Use ChannelLogSink instead
+ */
+export type Logger = ChannelLogSink;
+
+/**
+ * Channel account snapshot
+ */
+export type ChannelAccountSnapshot = SDKChannelAccountSnapshot;
+
+/**
+ * @deprecated Use ChannelAccountSnapshot instead
+ */
+export type ChannelSnapshot = ChannelAccountSnapshot;
+
+/**
+ * Plugin gateway start context
+ */
+export type GatewayStartContext = SDKChannelGatewayContext<ResolvedAccount>;
+
+/**
+ * Plugin gateway account stop result
+ */
+export interface GatewayStopResult {
+  stop: () => void;
+}
+
+/**
+ * DingTalk channel plugin definition
+ */
+export type DingTalkChannelPlugin = SDKChannelPlugin<ResolvedAccount & { configured: boolean }>;
+
+/**
+ * Result of target resolution validation
+ */
+export interface TargetResolutionResult {
+  ok: boolean;
+  to?: string;
+  error?: Error;
+}
+
+/**
+ * Parameters for resolveTarget validation
+ */
+export interface ResolveTargetParams {
+  to?: string | null;
+  [key: string]: any;
+}
+
+/**
+ * Parameters for sendText delivery
+ */
+export interface SendTextParams {
+  cfg: DingTalkConfig;
+  to: string;
+  text: string;
+  accountId?: string;
+  [key: string]: any;
+}
+
+/**
+ * Parameters for sendMedia delivery
+ */
+export interface SendMediaParams {
+  cfg: DingTalkConfig;
+  to: string;
+  mediaPath: string;
+  accountId?: string;
+  [key: string]: any;
+}
+
+/**
+ * DingTalk outbound handler configuration
+ */
+export interface DingTalkOutboundHandler {
+  deliveryMode: "direct" | "queued" | "batch";
+  resolveTarget: (params: ResolveTargetParams) => TargetResolutionResult;
+  sendText: (params: SendTextParams) => Promise<{ ok: boolean; data?: any; error?: any }>;
+  sendMedia?: (params: SendMediaParams) => Promise<{ ok: boolean; data?: any; error?: any }>;
+}
+
+/**
+ * AI Card status constants
+ */
+export const AICardStatus = {
+  PROCESSING: "1",
+  INPUTING: "2",
+  FINISHED: "3",
+  FAILED: "5",
+} as const;
+
+/**
+ * AI Card state type
+ */
+export type AICardState = (typeof AICardStatus)[keyof typeof AICardStatus];
+
+/**
+ * AI Card instance
+ */
+export interface AICardInstance {
+  cardInstanceId: string;
+  accessToken: string;
+  conversationId: string;
+  createdAt: number;
+  lastUpdated: number;
+  state: AICardState; // Current card state: PROCESSING, INPUTING, FINISHED, FAILED
+  config?: DingTalkConfig; // Store config reference for token refresh
+}
+
+/**
+ * AI Card streaming update request (new API)
+ */
+export interface AICardStreamingRequest {
+  outTrackId: string;
+  guid: string;
+  key: string;
+  content: string;
+  isFull: boolean;
+  isFinalize: boolean;
+  isError: boolean;
+}
+
+/**
+ * Connection state enum for lifecycle management
+ */
+export enum ConnectionState {
+  DISCONNECTED = "DISCONNECTED",
+  CONNECTING = "CONNECTING",
+  CONNECTED = "CONNECTED",
+  DISCONNECTING = "DISCONNECTING",
+  FAILED = "FAILED",
+}
+
+/**
+ * Connection manager configuration
+ */
+export interface ConnectionManagerConfig {
+  maxAttempts: number;
+  initialDelay: number;
+  maxDelay: number;
+  jitter: number;
+  /** Callback invoked when connection state changes */
+  onStateChange?: (state: ConnectionState, error?: string) => void;
+}
+
+/**
+ * Connection attempt result
+ */
+export interface ConnectionAttemptResult {
+  success: boolean;
+  attempt: number;
+  error?: Error;
+  nextDelay?: number;
+}
+
+// ============ Onboarding Helper Functions ============
+
+const DEFAULT_ACCOUNT_ID = "default";
+
+/**
+ * List all DingTalk account IDs from config
+ */
+export function listDingTalkAccountIds(cfg: OpenClawConfig): string[] {
+  const dingtalk = cfg.channels?.dingtalk as DingTalkChannelConfig | undefined;
+  if (!dingtalk) return [];
+
+  const accountIds: string[] = [];
+
+  // Check for direct configuration (default account)
+  if (dingtalk.clientId || dingtalk.clientSecret) {
+    accountIds.push(DEFAULT_ACCOUNT_ID);
+  }
+
+  // Check accounts object
+  if (dingtalk.accounts) {
+    accountIds.push(...Object.keys(dingtalk.accounts));
+  }
+
+  return accountIds;
+}
+
+/**
+ * Resolved DingTalk account with configuration status
+ */
+export interface ResolvedDingTalkAccount extends DingTalkConfig {
+  accountId: string;
+  configured: boolean;
+}
+
+/**
+ * Resolve a specific DingTalk account configuration
+ */
+export function resolveDingTalkAccount(
+  cfg: OpenClawConfig,
+  accountId?: string | null,
+): ResolvedDingTalkAccount {
+  const id = accountId || DEFAULT_ACCOUNT_ID;
+  const dingtalk = cfg.channels?.dingtalk as DingTalkChannelConfig | undefined;
+
+  // If default account, return top-level config
+  if (id === DEFAULT_ACCOUNT_ID) {
+    const config: DingTalkConfig = {
+      clientId: dingtalk?.clientId ?? "",
+      clientSecret: dingtalk?.clientSecret ?? "",
+      robotCode: dingtalk?.robotCode,
+      corpId: dingtalk?.corpId,
+      agentId: dingtalk?.agentId,
+      name: dingtalk?.name,
+      enabled: dingtalk?.enabled,
+      dmPolicy: dingtalk?.dmPolicy,
+      groupPolicy: dingtalk?.groupPolicy,
+      allowFrom: dingtalk?.allowFrom,
+      showThinking: dingtalk?.showThinking,
+      debug: dingtalk?.debug,
+      messageType: dingtalk?.messageType,
+      cardTemplateId: dingtalk?.cardTemplateId,
+      cardTemplateKey: dingtalk?.cardTemplateKey,
+      groups: dingtalk?.groups,
+      accounts: dingtalk?.accounts,
+      maxConnectionAttempts: dingtalk?.maxConnectionAttempts,
+      initialReconnectDelay: dingtalk?.initialReconnectDelay,
+      maxReconnectDelay: dingtalk?.maxReconnectDelay,
+      reconnectJitter: dingtalk?.reconnectJitter,
+    };
+    return {
+      ...config,
+      accountId: id,
+      configured: Boolean(config.clientId && config.clientSecret),
+    };
+  }
+
+  // If named account, get from accounts object
+  const accountConfig = dingtalk?.accounts?.[id];
+  if (accountConfig) {
+    return {
+      ...accountConfig,
+      accountId: id,
+      configured: Boolean(accountConfig.clientId && accountConfig.clientSecret),
+    };
+  }
+
+  // Account doesn't exist, return empty config
+  return {
+    clientId: "",
+    clientSecret: "",
+    accountId: id,
+    configured: false,
+  };
+}

--- a/extensions/openclaw-channel-dingtalk/tsconfig.json
+++ b/extensions/openclaw-channel-dingtalk/tsconfig.json
@@ -1,0 +1,35 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "lib": ["ES2020"],
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "strictPropertyInitialization": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "rootDir": ".",
+    "types": ["node"],
+    "paths": {
+      "openclaw/plugin-sdk": ["../../dist/plugin-sdk/index.d.ts"],
+      "openclaw/plugin-sdk/*": ["../../dist/plugin-sdk/*.d.ts"]
+    }
+  },
+  "include": ["index.ts", "src/**/*.ts", "utils.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/extensions/openclaw-channel-dingtalk/utils.ts
+++ b/extensions/openclaw-channel-dingtalk/utils.ts
@@ -1,0 +1,110 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { Logger, RetryOptions } from "./src/types.js";
+
+/**
+ * Mask sensitive fields in data for safe logging
+ * Prevents PII leakage in debug logs
+ */
+export function maskSensitiveData(data: unknown): any {
+  if (data === null || data === undefined) {
+    return data;
+  }
+
+  if (typeof data !== "object") {
+    return data as string | number;
+  }
+
+  const masked = JSON.parse(JSON.stringify(data)) as Record<string, any>;
+  const sensitiveFields = ["token", "accessToken"];
+
+  function maskObj(obj: any): void {
+    for (const key in obj) {
+      if (sensitiveFields.includes(key)) {
+        const val = obj[key];
+        if (typeof val === "string" && val.length > 6) {
+          obj[key] = val.slice(0, 3) + "*".repeat(val.length - 6) + val.slice(-3);
+        } else if (typeof val === "string") {
+          obj[key] = "*".repeat(val.length);
+        }
+      } else if (typeof obj[key] === "object" && obj[key] !== null) {
+        maskObj(obj[key]);
+      }
+    }
+  }
+
+  maskObj(masked);
+  return masked;
+}
+
+/**
+ * Cleanup orphaned temp files from dingtalk media
+ * Run at startup to clean up files from crashed processes
+ */
+export function cleanupOrphanedTempFiles(log?: Logger): number {
+  const tempDir = os.tmpdir();
+  const dingtalkPattern = /^dingtalk_\d+\..+$/;
+  let cleaned = 0;
+
+  try {
+    const files = fs.readdirSync(tempDir);
+    const now = Date.now();
+    const maxAge = 24 * 60 * 60 * 1000;
+
+    for (const file of files) {
+      if (!dingtalkPattern.test(file)) continue;
+
+      const filePath = path.join(tempDir, file);
+      try {
+        const stats = fs.statSync(filePath);
+        if (now - stats.mtime.getTime() > maxAge) {
+          fs.unlinkSync(filePath);
+          cleaned++;
+          log?.debug?.(`[DingTalk] Cleaned up orphaned temp file: ${file}`);
+        }
+      } catch (err: any) {
+        log?.debug?.(`[DingTalk] Failed to cleanup temp file ${file}: ${err.message}`);
+      }
+    }
+
+    if (cleaned > 0) {
+      log?.info?.(`[DingTalk] Cleaned up ${cleaned} orphaned temp files`);
+    }
+  } catch (err: any) {
+    log?.debug?.(`[DingTalk] Failed to cleanup temp directory: ${err.message}`);
+  }
+
+  return cleaned;
+}
+
+/**
+ * Retry logic for API calls with exponential backoff
+ * Handles transient failures like 401 token expiry
+ */
+export async function retryWithBackoff<T>(
+  fn: () => Promise<T>,
+  options: RetryOptions = {},
+): Promise<T> {
+  const { maxRetries = 3, baseDelayMs = 100, log } = options;
+
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (err: any) {
+      const statusCode = err.response?.status;
+      const isRetryable =
+        statusCode === 401 || statusCode === 429 || (statusCode && statusCode >= 500);
+
+      if (!isRetryable || attempt === maxRetries) {
+        throw err;
+      }
+
+      const delayMs = baseDelayMs * Math.pow(2, attempt - 1);
+      log?.debug?.(`[DingTalk] Retry attempt ${attempt}/${maxRetries} after ${delayMs}ms`);
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+
+  throw new Error("Retry exhausted without returning");
+}

--- a/src/cli/program/preaction.ts
+++ b/src/cli/program/preaction.ts
@@ -20,7 +20,13 @@ function setProcessTitleForCommand(actionCommand: Command) {
 }
 
 // Commands that need channel plugins loaded
-const PLUGIN_REQUIRED_COMMANDS = new Set(["message", "channels", "directory"]);
+const PLUGIN_REQUIRED_COMMANDS = new Set([
+  "message",
+  "channels",
+  "directory",
+  "configure",
+  "onboard",
+]);
 
 export function registerPreActionHooks(program: Command, programVersion: string) {
   program.hook("preAction", async (_thisCommand, actionCommand) => {


### PR DESCRIPTION
## Problem

External channel plugins (like DingTalk) were not appearing in interactive menus for `openclaw configure --section channels` and `openclaw onboard`, even though the plugins were properly loaded and configured.

## Root Cause

The `PLUGIN_REQUIRED_COMMANDS` whitelist in [src/cli/program/preaction.ts](src/cli/program/preaction.ts) only included `'message'`, `'channels'`, and `'directory'`. This controlled which commands triggered `ensurePluginRegistryLoaded()` in the preAction hook.

Without plugin registry initialization, channel selection menus fell back to core-only channels, excluding external plugins from being visible to users during interactive configuration.

## Solution

Add `'configure'` and `'onboard'` to `PLUGIN_REQUIRED_COMMANDS` to ensure the plugin registry is loaded before these commands display their interactive menus.

## Changes

- Modified `PLUGIN_REQUIRED_COMMANDS` in `src/cli/program/preaction.ts` to include `'configure'` and `'onboard'` commands
- File: [src/cli/program/preaction.ts](src/cli/program/preaction.ts#L23-L29)
- Change: Expanded from 3 to 5 commands in the whitelist

## Impact

✅ **External channel plugins are now discoverable in interactive menus:**
- `openclaw configure --section channels` now shows linked plugins in channel selection
- `openclaw onboard` now shows linked plugins during onboarding flow
- DingTalk channel (and other external plugins) now appear in channel status lists

✅ **No performance impact:**
- These commands already load configuration, so plugin loading adds no new overhead
- Lazy-loading pattern still preserved for other commands

✅ **Backward compatible:**
- Existing commands (`channels`, `message`, `directory`) continue to work unchanged
- Core channels remain visible in all contexts

## Verification

Tested with DingTalk plugin (linked locally via `openclaw plugins install -l .`):

```bash
$ openclaw channels status
Checking channel status…
- Telegram default: enabled, configured, running
- DingTalk default: enabled, configured, stopped  ✅ Now visible!

$ openclaw configure --section channels
# Channel status section shows both Telegram and DingTalk ✅
```

## Related Patterns

This follows the existing pattern used in:
- `channels` command: loads plugins to display channel status
- `message` command: loads plugins for message routing
- `directory` command: loads plugins for provider discovery

The same plugin discovery mechanism is now available to `configure` and `onboard` for interactive user flows.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `'configure'` and `'onboard'` to the `PLUGIN_REQUIRED_COMMANDS` whitelist in `src/cli/program/preaction.ts` to ensure external channel plugins are loaded before these commands display their interactive channel selection menus. Both commands call `listChannelPlugins()` (via `configure.channels.ts:18` and `onboard-channels.ts:116`) to display available channels, so they need the plugin registry initialized to show external plugins like DingTalk alongside core channels.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change is minimal (adding two strings to a Set), follows the existing pattern established for `'message'`, `'channels'`, and `'directory'` commands, and solves a clear bug where external plugins weren't visible in interactive menus. The PR description includes thorough testing and verification with the DingTalk plugin.
- No files require special attention

<sub>Last reviewed commit: 8b6a3df</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->