### PR TITLE
fix: await compaction hooks with timeout to prevent cross-session data bleed

### DIFF
--- a/src/agents/compaction-hook-utils.ts
+++ b/src/agents/compaction-hook-utils.ts
@@ -1,0 +1,70 @@
+/**
+ * Shared helpers for compaction hook execution.
+ *
+ * Used by both `pi-embedded-runner/compact.ts` (manual/overflow compaction)
+ * and `pi-embedded-subscribe.handlers.compaction.ts` (auto-compaction during
+ * a live agent run) to avoid duplication.
+ */
+
+export const COMPACTION_HOOK_TIMEOUT_MS = 10_000;
+
+export async function waitForHookWithTimeout(
+  hookPromise: Promise<void>,
+  opts: {
+    timeoutMs?: number;
+    onTimeout: (timeoutMs: number) => void;
+  },
+): Promise<void> {
+  const timeoutMs = Math.max(0, opts.timeoutMs ?? COMPACTION_HOOK_TIMEOUT_MS);
+  if (timeoutMs <= 0) {
+    await hookPromise;
+    return;
+  }
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  let timedOut = false;
+  try {
+    await Promise.race([
+      hookPromise,
+      new Promise<void>((resolve) => {
+        timeoutHandle = setTimeout(() => {
+          timedOut = true;
+          resolve();
+        }, timeoutMs);
+        timeoutHandle.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timeoutHandle) {
+      clearTimeout(timeoutHandle);
+    }
+  }
+  if (timedOut) {
+    opts.onTimeout(timeoutMs);
+  }
+}
+
+export const cloneMessageForHook = (value: unknown): unknown => {
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => cloneMessageForHook(item));
+  }
+  if (value instanceof Date || value instanceof RegExp) {
+    return structuredClone(value);
+  }
+  const source = value as Record<string, unknown>;
+  const clone: Record<string, unknown> = {};
+  for (const [key, nested] of Object.entries(source)) {
+    clone[key] = cloneMessageForHook(nested);
+  }
+  return clone;
+};
+
+export const cloneMessagesForHook = (messages: readonly unknown[]): unknown[] => {
+  try {
+    return structuredClone(Array.from(messages));
+  } catch {
+    return messages.map((message) => cloneMessageForHook(message));
+  }
+};

--- a/src/agents/pi-embedded-subscribe.handlers.compaction.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.compaction.ts
@@ -1,9 +1,10 @@
 import type { AgentEvent } from "@mariozechner/pi-agent-core";
+import type { EmbeddedPiSubscribeContext } from "./pi-embedded-subscribe.handlers.types.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
-import type { EmbeddedPiSubscribeContext } from "./pi-embedded-subscribe.handlers.types.js";
+import { cloneMessagesForHook, waitForHookWithTimeout } from "./compaction-hook-utils.js";
 
-export function handleAutoCompactionStart(ctx: EmbeddedPiSubscribeContext) {
+export async function handleAutoCompactionStart(ctx: EmbeddedPiSubscribeContext) {
   ctx.state.compactionInFlight = true;
   ctx.incrementCompactionCount();
   ctx.ensureCompactionPromise();
@@ -18,26 +19,36 @@ export function handleAutoCompactionStart(ctx: EmbeddedPiSubscribeContext) {
     data: { phase: "start" },
   });
 
-  // Run before_compaction plugin hook (fire-and-forget)
+  // Run before_compaction plugin hook (best effort).
   const hookRunner = getGlobalHookRunner();
   if (hookRunner?.hasHooks("before_compaction")) {
-    void hookRunner
-      .runBeforeCompaction(
+    const hookPromises: Array<Promise<unknown>> = [];
+    hookPromises.push(
+      waitForHookWithTimeout(
+        hookRunner.runBeforeCompaction(
+          {
+            messageCount: ctx.params.session.messages?.length ?? 0,
+            messages: cloneMessagesForHook(ctx.params.session.messages ?? []),
+          },
+          {},
+        ),
         {
-          messageCount: ctx.params.session.messages?.length ?? 0,
+          onTimeout: (timeoutMs) => {
+            ctx.log.warn(`before_compaction hook timed out after ${timeoutMs}ms`);
+          },
         },
-        {},
-      )
-      .catch((err) => {
+      ).catch((err) => {
         ctx.log.warn(`before_compaction hook failed: ${String(err)}`);
-      });
+      }),
+    );
+    await Promise.allSettled(hookPromises);
   }
 }
 
-export function handleAutoCompactionEnd(
+export async function handleAutoCompactionEnd(
   ctx: EmbeddedPiSubscribeContext,
   evt: AgentEvent & { willRetry?: unknown },
-) {
+): Promise<void> {
   ctx.state.compactionInFlight = false;
   const willRetry = Boolean(evt.willRetry);
   if (willRetry) {
@@ -57,21 +68,31 @@ export function handleAutoCompactionEnd(
     data: { phase: "end", willRetry },
   });
 
-  // Run after_compaction plugin hook (fire-and-forget)
+  // Run after_compaction plugin hook (best effort).
   if (!willRetry) {
     const hookRunnerEnd = getGlobalHookRunner();
     if (hookRunnerEnd?.hasHooks("after_compaction")) {
-      void hookRunnerEnd
-        .runAfterCompaction(
+      const hookPromises: Array<Promise<unknown>> = [];
+      hookPromises.push(
+        waitForHookWithTimeout(
+          hookRunnerEnd.runAfterCompaction(
+            {
+              messageCount: ctx.params.session.messages?.length ?? 0,
+              compactedCount: ctx.getCompactionCount(),
+              messages: cloneMessagesForHook(ctx.params.session.messages ?? []),
+            },
+            {},
+          ),
           {
-            messageCount: ctx.params.session.messages?.length ?? 0,
-            compactedCount: ctx.getCompactionCount(),
+            onTimeout: (timeoutMs) => {
+              ctx.log.warn(`after_compaction hook timed out after ${timeoutMs}ms`);
+            },
           },
-          {},
-        )
-        .catch((err) => {
+        ).catch((err) => {
           ctx.log.warn(`after_compaction hook failed: ${String(err)}`);
-        });
+        }),
+      );
+      await Promise.allSettled(hookPromises);
     }
   }
 }

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
@@ -1,9 +1,10 @@
+import type { EmbeddedPiSubscribeContext } from "./pi-embedded-subscribe.handlers.types.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { createInlineCodeState } from "../markdown/code-spans.js";
 import { formatAssistantErrorText } from "./pi-embedded-helpers.js";
-import type { EmbeddedPiSubscribeContext } from "./pi-embedded-subscribe.handlers.types.js";
 import { isAssistantMessage } from "./pi-embedded-utils.js";
 
+export { COMPACTION_HOOK_TIMEOUT_MS } from "./compaction-hook-utils.js";
 export {
   handleAutoCompactionEnd,
   handleAutoCompactionStart,


### PR DESCRIPTION
## Problem

Compaction hooks (before_compaction / after_compaction) were fire-and-forget:
- `process.chdir` was restored before hooks finished, so hooks ran in the wrong working directory
- Message arrays were passed by reference, allowing hooks to mutate session state
- No timeout meant a stuck hook could hang lane cleanup indefinitely

This is especially dangerous in multi-agent setups where multiple sessions compact concurrently.

Fixes #15990

## Solution

1. **Deep-clone messages** passed to hooks using `structuredClone` (with manual fallback for non-cloneable objects)
2. **Await hook promises** via `Promise.allSettled()` in `finally` before restoring `process.chdir`/env
3. **Add 10s timeout** (`waitForHookWithTimeout`) so stuck hooks log a warning and release the lane
4. Apply the same pattern to both code paths:
   - `compactEmbeddedPiSessionDirect` (direct compaction)
   - `handleAutoCompactionStart` / `handleAutoCompactionEnd` (auto-compaction lifecycle)

## Tests

- New `compact.test.ts`: verifies hooks are awaited before `process.chdir` restore, and messages are deep-cloned (mutations don't leak back)
- Extended `wired-hooks-compaction.test.ts`: verifies await behavior and clone isolation in auto-compaction handlers

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a real concurrency issue where compaction hooks were fire-and-forget, causing `process.chdir` to be restored before hooks finished (so hooks ran in the wrong working directory) and allowing hooks to mutate session state via shared message references.

The fix is well-structured:
- Deep-clone messages via `structuredClone` (with manual fallback) before passing to hooks
- Await hook promises in `finally` blocks via `Promise.allSettled` before restoring `process.chdir`/env
- Add a 10s timeout (`waitForHookWithTimeout`) to prevent stuck hooks from hanging lane cleanup
- Apply the same pattern to both direct compaction and auto-compaction lifecycle handlers

Key observations:
- The `void` prefix on the now-async auto-compaction handlers in `pi-embedded-subscribe.handlers.ts` is correct — the event handler is synchronous by design, and internal error handling (`.catch`) prevents unhandled promise rejections
- The type change to `PluginHookAfterCompactionEvent` (adding `messages?: unknown[]`) correctly aligns the type with runtime behavior
- ~63 lines of helper code (`waitForHookWithTimeout`, `cloneMessageForHook`, `cloneMessagesForHook`) are duplicated across `compact.ts` and `pi-embedded-subscribe.handlers.compaction.ts` — extracting to a shared module would reduce maintenance burden
- Tests are thorough: they verify hooks are awaited before cwd restore, messages are deep-cloned (mutations don't leak), and stuck hooks time out correctly

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it fixes a real concurrency bug with correct timeout/cleanup semantics and thorough tests.
- The core logic changes are sound: hooks are properly awaited before cwd/env restoration, messages are deep-cloned to prevent mutation leaks, and timeouts prevent indefinite hangs. The only concern is code duplication of ~63 lines of helper functions across two files, which is a maintainability issue rather than a correctness issue. Tests cover the key scenarios well.
- No files have correctness issues. `src/agents/pi-embedded-subscribe.handlers.compaction.ts` and `src/agents/pi-embedded-runner/compact.ts` share duplicated helper code that could be extracted to a shared module.

<sub>Last reviewed commit: de0c4eb</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->