### PR TITLE
Fix mergeConfigSection accepting __proto__ and constructor keys

### DIFF
--- a/src/config/merge-config.proto-pollution.test.ts
+++ b/src/config/merge-config.proto-pollution.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { mergeConfigSection } from "./merge-config.js";
+
+describe("mergeConfigSection prototype pollution guard", () => {
+  it("ignores __proto__ keys in patch", () => {
+    const base = { a: "1" } as Record<string, unknown>;
+    const patch = JSON.parse('{"__proto__": {"polluted": true}, "b": "2"}');
+    const result = mergeConfigSection(base, patch);
+    expect(result.b).toBe("2");
+    expect(result.a).toBe("1");
+    expect(Object.prototype.hasOwnProperty.call(result, "__proto__")).toBe(false);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  it("ignores constructor key in patch", () => {
+    const base = { a: "1" } as Record<string, unknown>;
+    const patch = { constructor: { polluted: true }, b: "2" } as Record<string, unknown>;
+    const result = mergeConfigSection(base, patch);
+    expect(result.b).toBe("2");
+    expect(Object.prototype.hasOwnProperty.call(result, "constructor")).toBe(false);
+  });
+});

--- a/src/config/merge-config.ts
+++ b/src/config/merge-config.ts
@@ -1,6 +1,9 @@
 import type { OpenClawConfig } from "./config.js";
 import type { WhatsAppConfig } from "./types.js";
 
+/** Keys that must never be merged to prevent prototype-pollution attacks. */
+const BLOCKED_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
 export type MergeSectionOptions<T> = {
   unsetOnUndefined?: Array<keyof T>;
 };
@@ -12,6 +15,9 @@ export function mergeConfigSection<T extends Record<string, unknown>>(
 ): T {
   const next: Record<string, unknown> = { ...(base ?? undefined) };
   for (const [key, value] of Object.entries(patch) as [keyof T, T[keyof T]][]) {
+    if (BLOCKED_KEYS.has(key as string)) {
+      continue;
+    }
     if (value === undefined) {
       if (options.unsetOnUndefined?.includes(key)) {
         delete next[key as string];


### PR DESCRIPTION
`mergeConfigSection` uses `Object.entries` to iterate patch keys and assigns them to the result object. When a patch from parsed JSON contains `__proto__` as an own property, the assignment corrupts the result's prototype chain.

This is the same class of issue as #16902 but in the config section merge helper used by `mergeWhatsAppConfig` and other internal callers.

Block `__proto__`, `constructor`, and `prototype` keys from being merged.

**Tests:** 2 new test cases covering `__proto__` and `constructor` key injection.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds prototype pollution protection to `mergeConfigSection` by blocking `__proto__`, `constructor`, and `prototype` keys from being merged into result objects. This follows the same pattern already established in `config-paths.ts` (which uses an identical `BLOCKED_KEYS` set) and addresses the same class of vulnerability as #16902.

- Blocked keys (`__proto__`, `constructor`, `prototype`) are skipped via a `Set` check during the `Object.entries` iteration loop in `mergeConfigSection`
- Two new test cases verify `__proto__` (via `JSON.parse`) and `constructor` key injection are correctly blocked
- No changes to the public API or behavior for legitimate config keys

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, well-scoped security fix with tests.
- The change is small (3 lines of logic + a constant), follows an established pattern already in the codebase (`config-paths.ts`), and is covered by 2 new test cases. The fix correctly addresses the prototype pollution vector without affecting any legitimate config merging behavior.
- No files require special attention.

<sub>Last reviewed commit: 1683669</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->