### PR TITLE
fix: remove incorrect sandbox file tool guidance

### DIFF
--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -655,7 +655,7 @@ describe("buildAgentSystemPrompt", () => {
 
     expect(prompt).toContain("Your working directory is: /workspace");
     expect(prompt).toContain(
-      "For read/write/edit/apply_patch, file paths resolve against host workspace: /tmp/openclaw. For bash/exec commands, use sandbox container paths under /workspace (or relative paths from that workdir), not host paths.",
+      "Treat this directory as the single global workspace for file operations unless explicitly instructed otherwise.",
     );
     expect(prompt).toContain("Sandbox container workdir: /workspace");
     expect(prompt).toContain(

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -388,9 +388,7 @@ export function buildAgentSystemPrompt(params: {
       ? sanitizedSandboxContainerWorkspace
       : sanitizedWorkspaceDir;
   const workspaceGuidance =
-    params.sandboxInfo?.enabled && sanitizedSandboxContainerWorkspace
-      ? `For read/write/edit/apply_patch, file paths resolve against host workspace: ${sanitizedWorkspaceDir}. For bash/exec commands, use sandbox container paths under ${sanitizedSandboxContainerWorkspace} (or relative paths from that workdir), not host paths. Prefer relative paths so both sandboxed exec and file tools work consistently.`
-      : "Treat this directory as the single global workspace for file operations unless explicitly instructed otherwise.";
+    "Treat this directory as the single global workspace for file operations unless explicitly instructed otherwise.";
   const safetySection = [
     "## Safety",
     "You have no independent goals: do not pursue self-preservation, replication, resource acquisition, or power-seeking; avoid long-term plans beyond the user's request.",


### PR DESCRIPTION
## Summary

Remove incorrect workspace guidance for sandboxed agents. Commit 2bf33077 added guidance stating
file tools (read/write/edit/apply_patch) resolve paths against the host workspace. This is wrong —
all file tools use `SandboxFsBridge` → `docker exec` inside the container.

## Changes

- `src/agents/system-prompt.ts`: Remove sandbox-specific `workspaceGuidance` branch. Use the same
  guidance for both sandbox and non-sandbox modes.

## Evidence

`SandboxFsBridgeImpl.runCommand` in `src/agents/sandbox/fs-bridge.ts` executes all file operations
through `docker exec -i <containerName> sh -c <script>`. Host-side `node:fs` is never used when
sandbox is enabled.

## Related

- Closes #16920
- Related: #16790 (original sandbox path bug, fixed by 2bf33077)

✍️ Author: Claude Code with @carrotRakko (AI-written, human-approved)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes an incorrect sandbox-specific `workspaceGuidance` branch from the system prompt builder. The previous code told sandboxed agents that file tools (read/write/edit/apply_patch) resolve paths against the host workspace, which is wrong — `SandboxFsBridgeImpl.runCommand` in `src/agents/sandbox/fs-bridge.ts` runs all file operations via `docker exec` inside the container.

The fix correctly unifies the guidance to use a single string for both sandbox and non-sandbox modes.

- **Issue found**: The test in `src/agents/system-prompt.e2e.test.ts` (line 450-452) still asserts the old removed text (`"For read/write/edit/apply_patch, file paths resolve against host workspace: /tmp/openclaw."`) and will fail. This test needs to be updated to match the new behavior.

<h3>Confidence Score: 3/5</h3>

- The production code change is correct but the PR will break an existing e2e test.
- The logic fix itself is sound and well-evidenced — sandbox file tools do use docker exec, not host-side node:fs. However, the corresponding e2e test in system-prompt.e2e.test.ts was not updated and will fail, which means CI should catch this. Score of 3 reflects that the code change is correct but incomplete.
- src/agents/system-prompt.e2e.test.ts — contains a stale assertion (line 450-452) that will fail after this change.

<sub>Last reviewed commit: 139c932</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->