### PR TITLE
Fix config includes deepMerge accepting __proto__ keys

### DIFF
--- a/src/config/includes.deep-merge-proto.test.ts
+++ b/src/config/includes.deep-merge-proto.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { deepMerge } from "./includes.js";
+
+describe("deepMerge prototype pollution guard", () => {
+  it("ignores __proto__ keys in source", () => {
+    const target = { a: 1 };
+    const source = JSON.parse('{"__proto__": {"polluted": true}, "b": 2}');
+    const result = deepMerge(target, source) as Record<string, unknown>;
+    expect(result.b).toBe(2);
+    expect(result.a).toBe(1);
+    expect(Object.prototype.hasOwnProperty.call(result, "__proto__")).toBe(false);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  it("ignores constructor key in source", () => {
+    const target = { a: 1 };
+    const source = { constructor: { polluted: true }, b: 2 };
+    const result = deepMerge(target, source) as Record<string, unknown>;
+    expect(result.b).toBe(2);
+    expect(Object.prototype.hasOwnProperty.call(result, "constructor")).toBe(false);
+  });
+
+  it("ignores __proto__ in nested objects", () => {
+    const target = { nested: { x: 1 } };
+    const source = JSON.parse('{"nested": {"__proto__": {"polluted": true}, "y": 2}}');
+    const result = deepMerge(target, source) as { nested: Record<string, unknown> };
+    expect(result.nested.y).toBe(2);
+    expect(Object.prototype.hasOwnProperty.call(result.nested, "__proto__")).toBe(false);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+});

--- a/src/config/includes.ts
+++ b/src/config/includes.ts
@@ -61,6 +61,9 @@ export function deepMerge(target: unknown, source: unknown): unknown {
   if (isPlainObject(target) && isPlainObject(source)) {
     const result: Record<string, unknown> = { ...target };
     for (const key of Object.keys(source)) {
+      if (key === "__proto__" || key === "constructor" || key === "prototype") {
+        continue;
+      }
       result[key] = key in result ? deepMerge(result[key], source[key]) : source[key];
     }
     return result;


### PR DESCRIPTION
The `deepMerge` helper used for `$include` directive resolution iterates `Object.keys(source)` and assigns each key to the result. When an included JSON file contains `__proto__` as a key (possible via `JSON.parse`), the assignment corrupts the merged object's prototype chain.

Same class of issue as #16902 and #16921, but in the config includes deep-merge path.

Skip `__proto__`, `constructor`, and `prototype` keys during merge.

**Tests:** 3 new test cases covering direct, nested, and constructor key injection.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds prototype pollution protection to the `deepMerge` helper function in `src/config/includes.ts:64-66`. When config files with `$include` directives are merged, malicious JSON containing `__proto__`, `constructor`, or `prototype` keys could corrupt the object prototype chain. The fix skips these dangerous keys during iteration.

- Blocks `__proto__`, `constructor`, and `prototype` keys in merge operations
- Consistent with similar fixes elsewhere in the codebase (`src/config/config-paths.ts:5` uses same blocked keys pattern)
- Three comprehensive test cases verify direct, nested, and constructor key injection are prevented

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The fix is minimal, well-tested, follows established patterns in the codebase (`src/config/config-paths.ts:5` uses identical key blocking), and addresses a clear security vulnerability with comprehensive test coverage
- No files require special attention

<sub>Last reviewed commit: b76d6fd</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->