### PR TITLE
fix(security): block access to sensitive directories from within sandbox

### DIFF
--- a/src/agents/sandbox-paths.sensitive.test.ts
+++ b/src/agents/sandbox-paths.sensitive.test.ts
@@ -1,7 +1,11 @@
+import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { isSensitivePath, resolveSandboxPath } from "./sandbox-paths.js";
+
+// Dynamic import for assertSandboxPath (async version)
+const { assertSandboxPath } = await import("./sandbox-paths.js");
 
 const home = os.homedir();
 
@@ -111,5 +115,63 @@ describe("resolveSandboxPath sensitive path blocking", () => {
         root: home,
       }),
     ).toThrow(/sensitive directory/);
+  });
+});
+
+describe("assertSandboxPath symlink-aware sensitive path blocking", () => {
+  const tmpDir = path.join(os.tmpdir(), `sandbox-sensitive-test-${process.pid}`);
+  const symlinkPath = path.join(tmpDir, "sneaky-link");
+  const openclawDir = path.join(home, ".openclaw");
+
+  beforeAll(async () => {
+    await fs.mkdir(tmpDir, { recursive: true });
+    // Only create symlink if .openclaw exists (it should on most dev machines)
+    try {
+      await fs.stat(openclawDir);
+      await fs.symlink(openclawDir, symlinkPath);
+    } catch {
+      // .openclaw doesn't exist — skip symlink creation, test will be skipped
+    }
+  });
+
+  afterAll(async () => {
+    try {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    } catch {
+      // cleanup best-effort
+    }
+  });
+
+  it("blocks symlinks that resolve to sensitive directories", async () => {
+    try {
+      await fs.lstat(symlinkPath);
+    } catch {
+      return; // skip if symlink wasn't created
+    }
+
+    await expect(
+      assertSandboxPath({
+        filePath: path.join("sneaky-link", "openclaw.json"),
+        cwd: tmpDir,
+        root: tmpDir,
+      }),
+    ).rejects.toThrow(/sensitive directory/);
+  });
+
+  it("allows symlinks to non-sensitive targets", async () => {
+    const safeLinkTarget = tmpDir; // points to itself, not sensitive
+    const safeLinkPath = path.join(tmpDir, "safe-link");
+    try {
+      await fs.symlink(safeLinkTarget, safeLinkPath);
+    } catch {
+      return;
+    }
+
+    // Should not throw — target is not sensitive
+    await assertSandboxPath({
+      filePath: "safe-link",
+      cwd: tmpDir,
+      root: tmpDir,
+    });
   });
 });

--- a/src/agents/sandbox-paths.sensitive.test.ts
+++ b/src/agents/sandbox-paths.sensitive.test.ts
@@ -1,0 +1,115 @@
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { isSensitivePath, resolveSandboxPath } from "./sandbox-paths.js";
+
+const home = os.homedir();
+
+describe("isSensitivePath", () => {
+  it("blocks ~/.openclaw/openclaw.json", () => {
+    const result = isSensitivePath(path.join(home, ".openclaw", "openclaw.json"));
+    expect(result.sensitive).toBe(true);
+  });
+
+  it("blocks ~/.openclaw/credentials/", () => {
+    const result = isSensitivePath(path.join(home, ".openclaw", "credentials", "token.json"));
+    expect(result.sensitive).toBe(true);
+  });
+
+  it("blocks ~/.openclaw/ itself", () => {
+    const result = isSensitivePath(path.join(home, ".openclaw"));
+    expect(result.sensitive).toBe(true);
+  });
+
+  it("blocks ~/.ssh/id_rsa", () => {
+    const result = isSensitivePath(path.join(home, ".ssh", "id_rsa"));
+    expect(result.sensitive).toBe(true);
+  });
+
+  it("blocks ~/.gnupg/", () => {
+    const result = isSensitivePath(path.join(home, ".gnupg", "secring.gpg"));
+    expect(result.sensitive).toBe(true);
+  });
+
+  it("blocks ~/.aws/credentials", () => {
+    const result = isSensitivePath(path.join(home, ".aws", "credentials"));
+    expect(result.sensitive).toBe(true);
+  });
+
+  it("allows normal workspace paths", () => {
+    const result = isSensitivePath(path.join(home, "workspace", "project", "index.ts"));
+    expect(result.sensitive).toBe(false);
+  });
+
+  it("allows paths outside home", () => {
+    const result = isSensitivePath("/tmp/test.txt");
+    expect(result.sensitive).toBe(false);
+  });
+
+  it("allows home directory root files", () => {
+    const result = isSensitivePath(path.join(home, ".bashrc"));
+    expect(result.sensitive).toBe(false);
+  });
+});
+
+describe("resolveSandboxPath sensitive path blocking", () => {
+  it("throws when accessing ~/.openclaw/ within sandbox", () => {
+    expect(() =>
+      resolveSandboxPath({
+        filePath: ".openclaw/openclaw.json",
+        cwd: home,
+        root: home,
+      }),
+    ).toThrow(/sensitive directory/);
+  });
+
+  it("throws when accessing ~/.ssh/ within sandbox", () => {
+    expect(() =>
+      resolveSandboxPath({
+        filePath: ".ssh/id_rsa",
+        cwd: home,
+        root: home,
+      }),
+    ).toThrow(/sensitive directory/);
+  });
+
+  it("allows normal paths within sandbox", () => {
+    const result = resolveSandboxPath({
+      filePath: "workspace/file.ts",
+      cwd: home,
+      root: home,
+    });
+    expect(result.resolved).toContain("workspace/file.ts");
+  });
+
+  it("allows skipping sensitive check when flag is set", () => {
+    // Should not throw
+    const result = resolveSandboxPath({
+      filePath: ".openclaw/openclaw.json",
+      cwd: home,
+      root: home,
+      skipSensitiveCheck: true,
+    });
+    expect(result.resolved).toContain(".openclaw/openclaw.json");
+  });
+
+  it("blocks absolute paths targeting sensitive dirs", () => {
+    expect(() =>
+      resolveSandboxPath({
+        filePath: path.join(home, ".openclaw", "credentials", "key.json"),
+        cwd: home,
+        root: home,
+      }),
+    ).toThrow(/sensitive directory/);
+  });
+
+  it("blocks tilde-expanded paths targeting sensitive dirs", () => {
+    expect(() =>
+      resolveSandboxPath({
+        filePath: "~/.openclaw/openclaw.json",
+        cwd: "/tmp",
+        root: home,
+      }),
+    ).toThrow(/sensitive directory/);
+  });
+});

--- a/src/agents/sandbox-paths.ts
+++ b/src/agents/sandbox-paths.ts
@@ -15,9 +15,17 @@ const DATA_URL_RE = /^data:/i;
  *
  * Paths are resolved at call time so environment overrides are respected.
  */
+let _sensitivePaths: string[] | null = null;
+
+/** @internal Reset the cached sensitive paths (for testing only). */
+export function _resetSensitivePathsCache(): void {
+  _sensitivePaths = null;
+}
+
 function resolveSensitivePaths(): string[] {
+  if (_sensitivePaths) return _sensitivePaths;
   const home = os.homedir();
-  return [
+  _sensitivePaths = [
     // OpenClaw state dir (contains openclaw.json with API keys, credentials/, sessions/)
     resolveStateDir(),
     // Legacy state dirs (.clawdbot, .moldbot, .moltbot)
@@ -31,6 +39,7 @@ function resolveSensitivePaths(): string[] {
     // Google Cloud credentials
     path.join(home, ".config", "gcloud"),
   ].map((p) => path.resolve(p));
+  return _sensitivePaths;
 }
 
 /**

--- a/src/agents/sandbox-paths.ts
+++ b/src/agents/sandbox-paths.ts
@@ -2,10 +2,52 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { resolveStateDir, resolveLegacyStateDirs } from "../config/paths.js";
 
 const UNICODE_SPACES = /[\u00A0\u2000-\u200A\u202F\u205F\u3000]/g;
 const HTTP_URL_RE = /^https?:\/\//i;
 const DATA_URL_RE = /^data:/i;
+
+/**
+ * Well-known directories that contain secrets (API keys, tokens, credentials)
+ * and must never be accessible from within the sandbox, even when they fall
+ * inside the sandbox root.
+ *
+ * Paths are resolved at call time so environment overrides are respected.
+ */
+function resolveSensitivePaths(): string[] {
+  const home = os.homedir();
+  return [
+    // OpenClaw state dir (contains openclaw.json with API keys, credentials/, sessions/)
+    resolveStateDir(),
+    // Legacy state dirs (.clawdbot, .moldbot, .moltbot)
+    ...resolveLegacyStateDirs(),
+    // SSH keys
+    path.join(home, ".ssh"),
+    // GPG keys
+    path.join(home, ".gnupg"),
+    // AWS credentials
+    path.join(home, ".aws"),
+    // Google Cloud credentials
+    path.join(home, ".config", "gcloud"),
+  ].map((p) => path.resolve(p));
+}
+
+/**
+ * Check whether a resolved path falls inside any sensitive directory.
+ * Uses the same `expandPath` normalizer as the sandbox resolver to prevent
+ * normalization mismatches (e.g. Unicode space tricks).
+ */
+export function isSensitivePath(resolvedPath: string): { sensitive: boolean; directory?: string } {
+  const normalized = path.resolve(resolvedPath);
+  for (const dir of resolveSensitivePaths()) {
+    const relative = path.relative(dir, normalized);
+    if (relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative))) {
+      return { sensitive: true, directory: shortPath(dir) };
+    }
+  }
+  return { sensitive: false };
+}
 
 function normalizeUnicodeSpaces(str: string): string {
   return str.replace(UNICODE_SPACES, " ");
@@ -34,7 +76,13 @@ export function resolveSandboxInputPath(filePath: string, cwd: string): string {
   return resolveToCwd(filePath, cwd);
 }
 
-export function resolveSandboxPath(params: { filePath: string; cwd: string; root: string }): {
+export function resolveSandboxPath(params: {
+  filePath: string;
+  cwd: string;
+  root: string;
+  /** Skip the sensitive-path check (e.g. for internal/elevated operations). */
+  skipSensitiveCheck?: boolean;
+}): {
   resolved: string;
   relative: string;
 } {
@@ -47,6 +95,18 @@ export function resolveSandboxPath(params: { filePath: string; cwd: string; root
   if (relative.startsWith("..") || path.isAbsolute(relative)) {
     throw new Error(`Path escapes sandbox root (${shortPath(rootResolved)}): ${params.filePath}`);
   }
+
+  // Block access to sensitive directories (API keys, credentials, SSH keys)
+  // even when they fall within the sandbox root.
+  if (!params.skipSensitiveCheck) {
+    const check = isSensitivePath(resolved);
+    if (check.sensitive) {
+      throw new Error(
+        `Access denied: path targets a sensitive directory (${check.directory}): ${params.filePath}`,
+      );
+    }
+  }
+
   return { resolved, relative };
 }
 


### PR DESCRIPTION
## Summary

- **Problem:** When `sandboxRoot` is the user's home directory (default), `~/.openclaw/` containing API keys and credentials is inside the sandbox and readable by the agent
- **Why it matters:** A prompt-injected LLM can read `~/.openclaw/openclaw.json` and exfiltrate API keys, bot tokens, and auth credentials
- **What changed:** Added `isSensitivePath()` to `resolveSandboxPath()` + post-symlink realpath check in `assertSandboxPath()` to block access to known sensitive directories
- **What did NOT change:** Normal sandbox path resolution, escape detection, and symlink traversal checks are untouched

Closes #8588
Related: #12958 (competing PR with two Greptile-identified bypass vectors — this PR addresses both)

## Why this approach vs PR #12958

PR #12958 implemented the check at the read tool level, but had two bypass vectors:
1. **Parameter aliasing:** `file_path` vs `path` normalization let the check see `""` while the read proceeded
2. **Unicode normalization mismatch:** Separate `expandTilde()` vs `expandPath()` normalizers created a reliable bypass

This PR checks at the `sandbox-paths` level using the **same `expandPath()` normalizer** already used by the sandbox resolver. The async `assertSandboxPath()` also re-checks after `realpath()` to catch symlink bypass (e.g., `~/workspace/link -> ~/.openclaw/`).

## Changes

**`src/agents/sandbox-paths.ts`**:
- Added `isSensitivePath()` — checks resolved path against known sensitive dirs (`~/.openclaw/`, `~/.ssh/`, `~/.gnupg/`, `~/.aws/`, `~/.config/gcloud/`, legacy state dirs)
- Integrated sync check in `resolveSandboxPath()` + async post-symlink check in `assertSandboxPath()`
- `skipSensitiveCheck` escape hatch for elevated/internal operations

**`src/agents/sandbox-paths.sensitive.test.ts`** (new):
- 17 tests: direct paths, absolute paths, tilde expansion, symlink bypass, safe paths allowed, escape hatch

## Security Impact

- Data access scope changed? Yes — restricts agent access to sensitive directories within sandbox
- Only adds restrictions. State dir resolved via `resolveStateDir()` so `$OPENCLAW_STATE_DIR` overrides are respected.

## Testing

All 17 tests pass locally. Symlink bypass test creates real symlinks to verify the post-realpath check works.

## Compatibility

Backward compatible — only adds restrictions. `skipSensitiveCheck: true` available for operations that legitimately need access.

## Failure Recovery

Revert commit or use `skipSensitiveCheck: true` for specific operations. Changes isolated to `sandbox-paths.ts`.

## AI Disclosure
AI-assisted (Claude via OpenClaw). All code reviewed, understood, and tested.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds sensitive directory protection to the sandbox path resolver, preventing agent access to directories containing credentials and secrets (`~/.openclaw/`, `~/.ssh/`, `~/.gnupg/`, `~/.aws/`, `~/.config/gcloud/`, legacy state dirs) even when those directories fall inside the sandbox root.

- Adds `isSensitivePath()` with both a sync check in `resolveSandboxPath()` and an async post-symlink realpath check in `assertSandboxPath()`, correctly closing both direct-access and symlink-bypass vectors
- Uses the same `expandPath()` normalizer as the sandbox resolver, avoiding the normalization mismatch bypass identified in the competing PR #12958
- `skipSensitiveCheck` escape hatch is defined but currently unused by any callers — may want to remove it until needed to reduce API surface
- The symlink bypass test (`"blocks symlinks that resolve to sensitive directories"`) silently skips when `~/.openclaw` doesn't exist (typical in CI), meaning the most security-critical test likely doesn't run in automated testing
- Minor: `resolveSensitivePaths()` re-resolves (including `fs.existsSync`) on every path check; could be memoized for hot-path performance

<h3>Confidence Score: 3/5</h3>

- The security logic is sound and additive-only, but the most critical test (symlink bypass) likely doesn't run in CI.
- The core implementation is well-designed — the dual-layer check (sync string check + async post-realpath check) correctly addresses both direct and symlink bypass vectors. However, the symlink bypass test silently skips in CI environments where ~/.openclaw doesn't exist, leaving the most security-critical behavior unverified in automated testing. The code is additive-only and backward compatible, which limits blast radius.
- Pay close attention to `src/agents/sandbox-paths.sensitive.test.ts` — the symlink bypass test needs to be made CI-deterministic to ensure the security guarantee is actually verified.

<sub>Last reviewed commit: dd0aee6</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->