### PR TITLE
fix: treat empty baseUrl as non-direct for OpenAI Responses

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.e2e.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.e2e.test.ts
@@ -140,6 +140,20 @@ describe("applyExtraParamsToAgent", () => {
     expect(payload.store).toBe(false);
   });
 
+  it("does not force store for OpenAI Responses when baseUrl is empty", () => {
+    const payload = runStoreMutationCase({
+      applyProvider: "openai",
+      applyModelId: "gpt-5",
+      model: {
+        api: "openai-responses",
+        provider: "openai",
+        id: "gpt-5",
+        baseUrl: "",
+      } as Model<"openai-responses">,
+    });
+    expect(payload.store).toBe(false);
+  });
+
   it("does not force store=true for Codex responses (Codex requires store=false)", () => {
     const payload = runStoreMutationCase({
       applyProvider: "openai-codex",

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -107,7 +107,7 @@ function createStreamFnWithExtraParams(
 
 function isDirectOpenAIBaseUrl(baseUrl: unknown): boolean {
   if (typeof baseUrl !== "string" || !baseUrl.trim()) {
-    return true;
+    return false;
   }
 
   try {


### PR DESCRIPTION
## Summary

Fixes #16914.

`isDirectOpenAIBaseUrl()` currently treats empty/falsy `baseUrl` as direct OpenAI, which makes the Responses wrapper force `payload.store = true`.

For models routed through non-direct providers with empty `baseUrl` metadata (including the reported `openai-codex/gpt-5.3-codex` path), this is incorrect and triggers upstream errors.

This PR changes empty `baseUrl` handling to return `false` (not direct OpenAI).

## Changes

- `src/agents/pi-embedded-runner/extra-params.ts`
  - `isDirectOpenAIBaseUrl("" | missing)` now returns `false`.
- `src/agents/pi-embedded-runner-extraparams.e2e.test.ts`
  - added regression test that verifies empty `baseUrl` does not force `store=true`.

## Testing

- `pnpm exec vitest run --config vitest.e2e.config.ts src/agents/pi-embedded-runner-extraparams.e2e.test.ts`

## AI-assisted

AI-assisted: yes. I manually reviewed and validated the final patch and tests.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a bug where `isDirectOpenAIBaseUrl()` treated empty/falsy `baseUrl` as direct OpenAI, causing the Responses API wrapper to force `payload.store = true` for models routed through non-direct providers (e.g., `openai-codex/gpt-5.3-codex` paths with empty `baseUrl` metadata). The fix changes the empty `baseUrl` case to return `false`, so only explicitly recognized OpenAI URLs (`api.openai.com`, `chatgpt.com`) trigger the `store=true` override.

- **`src/agents/pi-embedded-runner/extra-params.ts`**: One-line change from `return true` to `return false` in the early-return guard of `isDirectOpenAIBaseUrl`. Models with explicit direct OpenAI `baseUrl` values are unaffected.
- **`src/agents/pi-embedded-runner-extraparams.e2e.test.ts`**: Adds a regression test verifying that empty `baseUrl` does not force `store=true`.
- **`.github/workflows/formal-conformance.yml`**: Adds `continue-on-error: true` to the PR comment step, preventing CI failure when the workflow lacks permissions to post comments (e.g., fork PRs).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, well-scoped bug fix with proper test coverage.
- The change is a single-line fix (`return true` → `return false`) that corrects incorrect behavior for empty `baseUrl` values. The function is only called from one place (`shouldForceResponsesStore`), the change is covered by a new regression test, and the existing test suite confirms that direct OpenAI URLs still correctly force `store=true`. The CI workflow change is similarly low-risk — `continue-on-error: true` only affects an informational comment step.
- No files require special attention.

<sub>Last reviewed commit: 04d8569</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->