### PR TITLE
Warn when config contains numeric IDs that lost precision during JSON parsing

### DIFF
--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -1,12 +1,12 @@
 import type { OpenClawConfig } from "../config/config.js";
-import type { GatewayMessageChannel } from "../utils/message-channel.js";
-import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
-import type { AnyAgentTool } from "./tools/common.js";
 import { resolvePluginTools } from "../plugins/tools.js";
+import type { GatewayMessageChannel } from "../utils/message-channel.js";
 import { resolveSessionAgentId } from "./agent-scope.js";
+import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
 import { createAgentsListTool } from "./tools/agents-list-tool.js";
 import { createBrowserTool } from "./tools/browser-tool.js";
 import { createCanvasTool } from "./tools/canvas-tool.js";
+import type { AnyAgentTool } from "./tools/common.js";
 import { createCronTool } from "./tools/cron-tool.js";
 import { createGatewayTool } from "./tools/gateway-tool.js";
 import { createImageTool } from "./tools/image-tool.js";

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -1,9 +1,9 @@
 import type { ReasoningLevel, ThinkLevel } from "../auto-reply/thinking.js";
+import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import type { MemoryCitationsMode } from "../config/types.memory.js";
+import { listDeliverableMessageChannels } from "../utils/message-channel.js";
 import type { ResolvedTimeFormat } from "./date-time.js";
 import type { EmbeddedContextFile } from "./pi-embedded-helpers.js";
-import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
-import { listDeliverableMessageChannels } from "../utils/message-channel.js";
 import { sanitizeForPromptLiteral } from "./sanitize-for-prompt.js";
 
 /**

--- a/src/auto-reply/reply/commands-export-session.ts
+++ b/src/auto-reply/reply/commands-export-session.ts
@@ -1,17 +1,17 @@
-import type { SessionEntry as PiSessionEntry, SessionHeader } from "@mariozechner/pi-coding-agent";
-import { SessionManager } from "@mariozechner/pi-coding-agent";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import type { SessionEntry } from "../../config/sessions/types.js";
-import type { ReplyPayload } from "../types.js";
-import type { HandleCommandsParams } from "./commands-types.js";
+import type { SessionEntry as PiSessionEntry, SessionHeader } from "@mariozechner/pi-coding-agent";
+import { SessionManager } from "@mariozechner/pi-coding-agent";
 import {
   resolveDefaultSessionStorePath,
   resolveSessionFilePath,
 } from "../../config/sessions/paths.js";
 import { loadSessionStore } from "../../config/sessions/store.js";
+import type { SessionEntry } from "../../config/sessions/types.js";
+import type { ReplyPayload } from "../types.js";
 import { resolveCommandsSystemPromptBundle } from "./commands-system-prompt.js";
+import type { HandleCommandsParams } from "./commands-types.js";
 
 // Export HTML templates are bundled with this module
 const EXPORT_HTML_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), "export-html");

--- a/src/channels/dock.ts
+++ b/src/channels/dock.ts
@@ -1,17 +1,4 @@
 import type { OpenClawConfig } from "../config/config.js";
-import type {
-  ChannelCapabilities,
-  ChannelCommandAdapter,
-  ChannelElevatedAdapter,
-  ChannelGroupAdapter,
-  ChannelId,
-  ChannelAgentPromptAdapter,
-  ChannelMentionAdapter,
-  ChannelPlugin,
-  ChannelThreadingContext,
-  ChannelThreadingAdapter,
-  ChannelThreadingToolContext,
-} from "./plugins/types.js";
 import {
   resolveChannelGroupRequireMention,
   resolveChannelGroupToolsPolicy,
@@ -41,6 +28,19 @@ import {
   resolveWhatsAppGroupRequireMention,
   resolveWhatsAppGroupToolPolicy,
 } from "./plugins/group-mentions.js";
+import type {
+  ChannelCapabilities,
+  ChannelCommandAdapter,
+  ChannelElevatedAdapter,
+  ChannelGroupAdapter,
+  ChannelId,
+  ChannelAgentPromptAdapter,
+  ChannelMentionAdapter,
+  ChannelPlugin,
+  ChannelThreadingContext,
+  ChannelThreadingAdapter,
+  ChannelThreadingToolContext,
+} from "./plugins/types.js";
 import { CHAT_CHANNEL_ORDER, type ChatChannelId, getChatChannelMeta } from "./registry.js";
 
 export type ChannelDock = {

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -1,6 +1,6 @@
+import { requireActivePluginRegistry } from "../plugins/runtime.js";
 import type { ChannelMeta } from "./plugins/types.js";
 import type { ChannelId } from "./plugins/types.js";
-import { requireActivePluginRegistry } from "../plugins/runtime.js";
 
 // Channel docking: add new core channels here (order + meta + aliases), then
 // register the plugin in its extension entrypoint and keep protocol IDs in sync.

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -1,12 +1,10 @@
-import { cancel, isCancel } from "@clack/prompts";
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { inspect } from "node:util";
-import type { OpenClawConfig } from "../config/config.js";
-import type { RuntimeEnv } from "../runtime.js";
-import type { NodeManagerChoice, OnboardMode, ResetScope } from "./onboard-types.js";
+import { cancel, isCancel } from "@clack/prompts";
 import { DEFAULT_AGENT_WORKSPACE_DIR, ensureAgentWorkspace } from "../agents/workspace.js";
+import type { OpenClawConfig } from "../config/config.js";
 import { CONFIG_PATH } from "../config/config.js";
 import { resolveSessionTranscriptsDirForAgent } from "../config/sessions.js";
 import { callGateway } from "../gateway/call.js";
@@ -16,6 +14,7 @@ import { isSafeExecutableValue } from "../infra/exec-safety.js";
 import { pickPrimaryTailnetIPv4 } from "../infra/tailnet.js";
 import { isWSL } from "../infra/wsl.js";
 import { runCommandWithTimeout } from "../process/exec.js";
+import type { RuntimeEnv } from "../runtime.js";
 import { stylePromptTitle } from "../terminal/prompt-style.js";
 import {
   CONFIG_DIR,
@@ -26,6 +25,7 @@ import {
 } from "../utils.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import { VERSION } from "../version.js";
+import type { NodeManagerChoice, OnboardMode, ResetScope } from "./onboard-types.js";
 
 export function guardCancel<T>(value: T | symbol, runtime: RuntimeEnv): T {
   if (isCancel(value)) {

--- a/src/config/validation-numeric-ids.test.ts
+++ b/src/config/validation-numeric-ids.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { warnUnsafeNumericIds } from "./validation-numeric-ids.js";
+
+describe("warnUnsafeNumericIds", () => {
+  it("returns no warnings for safe integers", () => {
+    const raw = { channels: { discord: { guilds: { test: { users: [123, "456"] } } } } };
+    expect(warnUnsafeNumericIds(raw)).toEqual([]);
+  });
+
+  it("warns about numeric values exceeding MAX_SAFE_INTEGER", () => {
+    // Simulate what JSON.parse does to large unquoted numbers
+    const raw = JSON.parse(
+      '{"channels":{"discord":{"guilds":{"s":{"users":[233734246190153728]}}}}}',
+    );
+    const warnings = warnUnsafeNumericIds(raw);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].path).toBe("channels.discord.guilds.s.users[0]");
+    expect(warnings[0].message).toContain("MAX_SAFE_INTEGER");
+    expect(warnings[0].message).toContain("quotes");
+  });
+
+  it("warns about multiple unsafe IDs", () => {
+    const raw = JSON.parse('{"users":[233734246190153728, 804620549493620756]}');
+    const warnings = warnUnsafeNumericIds(raw);
+    expect(warnings).toHaveLength(2);
+  });
+
+  it("ignores strings, booleans, and null", () => {
+    const raw = { a: "big number 99999999999999999", b: true, c: null };
+    expect(warnUnsafeNumericIds(raw)).toEqual([]);
+  });
+
+  it("ignores NaN and Infinity", () => {
+    const raw = { a: NaN, b: Infinity, c: -Infinity };
+    expect(warnUnsafeNumericIds(raw)).toEqual([]);
+  });
+
+  it("handles deeply nested structures", () => {
+    const raw = JSON.parse('{"a":{"b":{"c":{"d":233734246190153728}}}}');
+    const warnings = warnUnsafeNumericIds(raw);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].path).toBe("a.b.c.d");
+  });
+});

--- a/src/config/validation-numeric-ids.ts
+++ b/src/config/validation-numeric-ids.ts
@@ -1,0 +1,39 @@
+import type { ConfigValidationIssue } from "./types.js";
+
+/**
+ * Scan the raw (pre-Zod) config for numeric values that exceed
+ * Number.MAX_SAFE_INTEGER. These are almost always Discord/Slack/Telegram
+ * snowflake IDs that lost precision during JSON.parse because they were
+ * written without quotes.
+ *
+ * Example: `"users": [233734246190153728]` silently becomes
+ *          `233734246190153730` after parsing.
+ */
+export function warnUnsafeNumericIds(raw: unknown): ConfigValidationIssue[] {
+  const warnings: ConfigValidationIssue[] = [];
+  walk(raw, "", warnings);
+  return warnings;
+}
+
+function walk(value: unknown, path: string, out: ConfigValidationIssue[]): void {
+  if (typeof value === "number" && !Number.isSafeInteger(value) && Number.isFinite(value)) {
+    out.push({
+      path: path || "(root)",
+      message:
+        `Numeric value ${value} exceeds Number.MAX_SAFE_INTEGER and lost precision during JSON parsing. ` +
+        `Wrap it in quotes (e.g. "${value}") to preserve the exact value.`,
+    });
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i++) {
+      walk(value[i], path ? `${path}[${i}]` : `[${i}]`, out);
+    }
+    return;
+  }
+  if (value && typeof value === "object") {
+    for (const [key, child] of Object.entries(value)) {
+      walk(child, path ? `${path}.${key}` : key, out);
+    }
+  }
+}

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -13,6 +13,7 @@ import { findDuplicateAgentDirs, formatDuplicateAgentDirError } from "./agent-di
 import { applyAgentDefaults, applyModelDefaults, applySessionDefaults } from "./defaults.js";
 import { findLegacyConfigIssues } from "./legacy.js";
 import type { OpenClawConfig, ConfigValidationIssue } from "./types.js";
+import { warnUnsafeNumericIds } from "./validation-numeric-ids.js";
 import { OpenClawSchema } from "./zod-schema.js";
 
 const AVATAR_SCHEME_RE = /^[a-z][a-z0-9+.-]*:/i;
@@ -261,6 +262,9 @@ function validateConfigObjectWithPluginsBase(
       }
     }
   }
+
+  // Warn about numeric IDs that lose precision after JSON.parse (e.g. Discord snowflakes).
+  warnings.push(...warnUnsafeNumericIds(raw));
 
   const heartbeatChannelIds = new Set<string>();
   for (const channelId of CHANNEL_IDS) {

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -1,5 +1,4 @@
 import { createRequire } from "node:module";
-import type { PluginRuntime } from "./types.js";
 import { resolveEffectiveMessagesConfig, resolveHumanDelayConfig } from "../../agents/identity.js";
 import { createMemoryGetTool, createMemorySearchTool } from "../../agents/tools/memory-tool.js";
 import { handleSlackAction } from "../../agents/tools/slack-actions.js";
@@ -139,6 +138,7 @@ import {
 } from "../../web/auth-store.js";
 import { loadWebMedia } from "../../web/media.js";
 import { formatNativeDependencyHint } from "./native-deps.js";
+import type { PluginRuntime } from "./types.js";
 
 let cachedVersion: string | null = null;
 

--- a/src/wizard/onboarding.finalize.ts
+++ b/src/wizard/onboarding.finalize.ts
@@ -1,10 +1,5 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import type { OnboardOptions } from "../commands/onboard-types.js";
-import type { OpenClawConfig } from "../config/config.js";
-import type { RuntimeEnv } from "../runtime.js";
-import type { GatewayWizardSettings, WizardFlow } from "./onboarding.types.js";
-import type { WizardPrompter } from "./prompts.js";
 import { DEFAULT_BOOTSTRAP_FILENAME } from "../agents/workspace.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import {
@@ -25,13 +20,18 @@ import {
   waitForGatewayReachable,
   resolveControlUiLinks,
 } from "../commands/onboard-helpers.js";
+import type { OnboardOptions } from "../commands/onboard-types.js";
+import type { OpenClawConfig } from "../config/config.js";
 import { resolveGatewayService } from "../daemon/service.js";
 import { isSystemdUserServiceAvailable } from "../daemon/systemd.js";
 import { ensureControlUiAssetsBuilt } from "../infra/control-ui-assets.js";
+import type { RuntimeEnv } from "../runtime.js";
 import { restoreTerminalState } from "../terminal/restore.js";
 import { runTui } from "../tui/tui.js";
 import { resolveUserPath } from "../utils.js";
 import { setupOnboardingShellCompletion } from "./onboarding.completion.js";
+import type { GatewayWizardSettings, WizardFlow } from "./onboarding.types.js";
+import type { WizardPrompter } from "./prompts.js";
 
 type FinalizeOnboardingOptions = {
   flow: WizardFlow;


### PR DESCRIPTION
Fixes #16681

Discord, Slack, and Telegram use snowflake IDs that exceed `Number.MAX_SAFE_INTEGER` (2^53 - 1). When these are written as bare numbers in `openclaw.json` (without quotes), `JSON.parse` silently rounds them to the nearest representable float:

```jsonc
// What you wrote:
"users": [233734246190153728]
// What JS sees after JSON.parse:
"users": [233734246190153730]  // ← different ID!
```

This is hard to catch because the numbers look almost identical.

**Fix:** Add a config validation pass that walks the raw parsed config object and emits a warning for any numeric value exceeding `MAX_SAFE_INTEGER`, advising the user to wrap it in quotes. The warning surfaces through `openclaw doctor` and gateway startup diagnostics.

**Tests:** 6 test cases covering safe integers, unsafe IDs, multiple IDs, deeply nested structures, and edge cases (NaN, Infinity).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a config validation pass that detects numeric values exceeding `Number.MAX_SAFE_INTEGER` in the raw parsed config, targeting Discord/Slack/Telegram snowflake IDs that silently lose precision during `JSON.parse`. The new `warnUnsafeNumericIds` function recursively walks the config tree and emits warnings for affected values, which are surfaced through `openclaw doctor` and gateway startup diagnostics via the existing warnings pipeline.

- New `validation-numeric-ids.ts` module with recursive object walker and 6 unit tests
- Clean integration into `validateConfigObjectWithPluginsBase` in `validation.ts`
- Both previously flagged issues (false positives on fractional config values like `sampleRate: 0.5`, and warning message displaying the already-rounded value) remain unaddressed in this revision

<h3>Confidence Score: 3/5</h3>

- Warning-only change with no runtime behavior impact, but the false-positive issue on fractional values should be fixed before merge
- The core idea is sound and the integration is clean, but the detection condition (`!Number.isSafeInteger`) will produce false positive warnings for legitimate fractional config values (e.g. `sampleRate: 0.5`, `jitter: 0.3`). Since this is a warning-only change it won't break anything, but it will confuse users who have fractional values in their config. The fix is straightforward (`Math.abs(value) > Number.MAX_SAFE_INTEGER`) and was already suggested in a previous review thread.
- `src/config/validation-numeric-ids.ts` — the detection condition on line 19 needs adjustment to avoid false positives on fractional numbers

<sub>Last reviewed commit: fe2184a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->