### PR TITLE
fix(media): reject unsupported URL schemes with clear error message

### DIFF
--- a/src/web/media.test.ts
+++ b/src/web/media.test.ts
@@ -196,6 +196,21 @@ describe("web media loading", () => {
     fetchMock.mockRestore();
   });
 
+  it("rejects unsupported URL schemes with clear error message", async () => {
+    // AI agents sometimes hallucinate invalid URL schemes (e.g., "vector://")
+    await expect(loadWebMedia("vector://localhost/path/to/file.png")).rejects.toThrow(
+      /Unsupported media URL scheme "vector:\/\/"/,
+    );
+
+    await expect(loadWebMedia("ftp://example.com/file.pdf")).rejects.toThrow(
+      /Unsupported media URL scheme "ftp:\/\/"/,
+    );
+
+    await expect(loadWebMedia("magnet://xt=abc")).rejects.toThrow(
+      /Unsupported media URL scheme "magnet:\/\/"/,
+    );
+  });
+
   it("blocks private network URL fetches (SSRF guard)", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch");
 


### PR DESCRIPTION
## Summary

When AI agents hallucinate invalid URL schemes (e.g., `vector://`, `ftp://`), the code previously attempted to read them as local paths, resulting in confusing ENOENT errors like:

```
ENOENT: no such file or directory, open 'vector://vector/home/user/file.xlsx'
```

This change detects unsupported schemes early and throws a clear, actionable error:

```
Unsupported media URL scheme "vector://". Use file:// for local files, http(s):// for remote URLs, or a direct file path.
```

## Changes

- Added URL scheme validation in `loadWebMediaInternal()` before processing
- Supported schemes: `file://`, `http://`, `https://`, and direct paths
- Added test cases for unsupported schemes (`vector://`, `ftp://`, `magnet://`)

## Testing

- Added unit tests in `src/web/media.test.ts`
- Verified existing tests still pass

Fixes #14575

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds early URL scheme validation in `loadWebMediaInternal()` to reject unsupported protocols (e.g., `vector://`, `ftp://`) with a clear, actionable error message instead of letting them fall through to confusing ENOENT errors.

- Validates URL schemes using an RFC 3986-compliant regex, allowing only `file://`, `http://`, `https://`, and direct file paths
- Validation is correctly placed after `MEDIA:` prefix stripping and before scheme-specific handling
- Adds test coverage for three unsupported scheme variants (`vector://`, `ftp://`, `magnet://`)
- No issues found — this is a focused, well-scoped defensive fix

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it only adds an early-rejection guard for invalid URL schemes with no impact on existing valid paths.
- The change is minimal and purely additive: a single validation check with a clear error path. It does not modify any existing logic for supported schemes (file/http/https/local paths). The regex is correct per RFC 3986, and edge cases like Windows drive letters (`C:/`) and `data:` URIs are unaffected since they don't match the `://` pattern. Tests cover the new behavior adequately.
- No files require special attention.

<sub>Last reviewed commit: 9e34875</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->