### PR TITLE
fix(matrix): send voice messages as native voice bubbles

### DIFF
--- a/extensions/matrix/src/outbound.ts
+++ b/extensions/matrix/src/outbound.ts
@@ -22,7 +22,7 @@ export const matrixOutbound: ChannelOutboundAdapter = {
       roomId: result.roomId,
     };
   },
-  sendMedia: async ({ to, text, mediaUrl, deps, replyToId, threadId, accountId }) => {
+  sendMedia: async ({ to, text, mediaUrl, deps, replyToId, threadId, accountId, audioAsVoice }) => {
     const send = deps?.sendMatrix ?? sendMessageMatrix;
     const resolvedThreadId =
       threadId !== undefined && threadId !== null ? String(threadId) : undefined;
@@ -31,6 +31,7 @@ export const matrixOutbound: ChannelOutboundAdapter = {
       replyToId: replyToId ?? undefined,
       threadId: resolvedThreadId,
       accountId: accountId ?? undefined,
+      audioAsVoice: audioAsVoice ?? undefined,
     });
     return {
       channel: "matrix",

--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -84,6 +84,8 @@ export type ChannelOutboundContext = {
   identity?: OutboundIdentity;
   deps?: OutboundSendDeps;
   silent?: boolean;
+  /** When true, audio should be sent as a voice message bubble (with waveform) instead of a file attachment. */
+  audioAsVoice?: boolean;
 };
 
 export type ChannelOutboundPayloadContext = ChannelOutboundContext & {


### PR DESCRIPTION
## Summary

Voice messages were being sent as generic audio file attachments instead of native voice message bubbles in Matrix clients (Element, FluffyChat, etc.).

## Root Cause

The `audioAsVoice` flag from `ReplyPayload` wasn't being passed through the outbound delivery chain to the Matrix adapter. The underlying `sendMessageMatrix` function already supports `audioAsVoice` and correctly sets `org.matrix.msc3245.voice: {}` when enabled.

## Changes

1. **`types.adapters.ts`**: Added `audioAsVoice?: boolean` to `ChannelOutboundContext`
2. **`deliver.ts`**: 
   - Added `SendMediaOptions` type with `audioAsVoice`
   - Pass `audioAsVoice` in `sendMedia` calls
3. **`extensions/matrix/src/outbound.ts`**: Pass `audioAsVoice` to `sendMessageMatrix`

## Testing

- When TTS is enabled or `asVoice: true` is set in the message tool, audio should now display as native voice message bubbles with waveform in Matrix clients.

Fixes #14225

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Enables voice message bubbles in Matrix clients by threading `audioAsVoice` flag from `ReplyPayload` through the outbound delivery pipeline to the Matrix adapter.

The changes properly add the `audioAsVoice` field to:
- `ChannelOutboundContext` type with clear documentation
- `SendMediaOptions` type for internal routing
- The Matrix adapter's `sendMedia` call chain

The underlying `sendMessageMatrix` function (extensions/matrix/src/matrix/send.ts:96) already supports `audioAsVoice` and correctly applies the MSC3245 voice message spec when enabled. Tests verify the voice message logic works correctly.

One minor consistency improvement: the `sendPayload` handler should also pass `audioAsVoice` explicitly to the context (currently only available via `ctx.payload.audioAsVoice`).

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor style improvement suggested
- The implementation correctly threads the `audioAsVoice` flag through the delivery pipeline. The underlying Matrix send logic already supports voice messages and has test coverage. One non-critical style improvement suggested for consistency in the `sendPayload` handler.
- No files require special attention

<sub>Last reviewed commit: 65c4884</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->