### PR TITLE
fix(matrix): detect mentions in formatted_body matrix.to links

### DIFF
--- a/extensions/matrix/src/matrix/monitor/mentions.test.ts
+++ b/extensions/matrix/src/matrix/monitor/mentions.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Mock the runtime before importing resolveMentions
+vi.mock("../../runtime.js", () => ({
+  getMatrixRuntime: () => ({
+    channel: {
+      mentions: {
+        matchesMentionPatterns: (text: string, patterns: RegExp[]) =>
+          patterns.some((p) => p.test(text)),
+      },
+    },
+  }),
+}));
+
+import { resolveMentions } from "./mentions.js";
+
+describe("resolveMentions", () => {
+  const userId = "@bot:matrix.org";
+  const mentionRegexes = [/@bot/i];
+
+  describe("m.mentions field", () => {
+    it("detects mention via m.mentions.user_ids", () => {
+      const result = resolveMentions({
+        content: {
+          msgtype: "m.text",
+          body: "hello",
+          "m.mentions": { user_ids: ["@bot:matrix.org"] },
+        },
+        userId,
+        text: "hello",
+        mentionRegexes,
+      });
+      expect(result.wasMentioned).toBe(true);
+      expect(result.hasExplicitMention).toBe(true);
+    });
+
+    it("detects room mention via m.mentions.room", () => {
+      const result = resolveMentions({
+        content: {
+          msgtype: "m.text",
+          body: "hello everyone",
+          "m.mentions": { room: true },
+        },
+        userId,
+        text: "hello everyone",
+        mentionRegexes,
+      });
+      expect(result.wasMentioned).toBe(true);
+    });
+  });
+
+  describe("formatted_body matrix.to links", () => {
+    it("detects mention in formatted_body with plain user ID", () => {
+      const result = resolveMentions({
+        content: {
+          msgtype: "m.text",
+          body: "Bot: hello",
+          formatted_body: '<a href="https://matrix.to/#/@bot:matrix.org">Bot</a>: hello',
+        },
+        userId,
+        text: "Bot: hello",
+        mentionRegexes: [],
+      });
+      expect(result.wasMentioned).toBe(true);
+    });
+
+    it("detects mention in formatted_body with URL-encoded user ID", () => {
+      const result = resolveMentions({
+        content: {
+          msgtype: "m.text",
+          body: "Bot: hello",
+          formatted_body: '<a href="https://matrix.to/#/%40bot%3Amatrix.org">Bot</a>: hello',
+        },
+        userId,
+        text: "Bot: hello",
+        mentionRegexes: [],
+      });
+      expect(result.wasMentioned).toBe(true);
+    });
+
+    it("detects mention with single quotes in href", () => {
+      const result = resolveMentions({
+        content: {
+          msgtype: "m.text",
+          body: "Bot: hello",
+          formatted_body: "<a href='https://matrix.to/#/@bot:matrix.org'>Bot</a>: hello",
+        },
+        userId,
+        text: "Bot: hello",
+        mentionRegexes: [],
+      });
+      expect(result.wasMentioned).toBe(true);
+    });
+
+    it("does not detect mention for different user ID", () => {
+      const result = resolveMentions({
+        content: {
+          msgtype: "m.text",
+          body: "Other: hello",
+          formatted_body: '<a href="https://matrix.to/#/@other:matrix.org">Other</a>: hello',
+        },
+        userId,
+        text: "Other: hello",
+        mentionRegexes: [],
+      });
+      expect(result.wasMentioned).toBe(false);
+    });
+
+    it("does not false-positive on partial user ID match", () => {
+      const result = resolveMentions({
+        content: {
+          msgtype: "m.text",
+          body: "Bot2: hello",
+          formatted_body: '<a href="https://matrix.to/#/@bot2:matrix.org">Bot2</a>: hello',
+        },
+        userId: "@bot:matrix.org",
+        text: "Bot2: hello",
+        mentionRegexes: [],
+      });
+      expect(result.wasMentioned).toBe(false);
+    });
+  });
+
+  describe("regex patterns", () => {
+    it("detects mention via regex pattern in body text", () => {
+      const result = resolveMentions({
+        content: {
+          msgtype: "m.text",
+          body: "hey @bot can you help?",
+        },
+        userId,
+        text: "hey @bot can you help?",
+        mentionRegexes,
+      });
+      expect(result.wasMentioned).toBe(true);
+    });
+  });
+
+  describe("no mention", () => {
+    it("returns false when no mention is present", () => {
+      const result = resolveMentions({
+        content: {
+          msgtype: "m.text",
+          body: "hello world",
+        },
+        userId,
+        text: "hello world",
+        mentionRegexes,
+      });
+      expect(result.wasMentioned).toBe(false);
+      expect(result.hasExplicitMention).toBe(false);
+    });
+  });
+});

--- a/extensions/matrix/src/matrix/monitor/mentions.ts
+++ b/extensions/matrix/src/matrix/monitor/mentions.ts
@@ -4,11 +4,35 @@ import { getMatrixRuntime } from "../../runtime.js";
 type MessageContentWithMentions = {
   msgtype: string;
   body: string;
+  formatted_body?: string;
   "m.mentions"?: {
     user_ids?: string[];
     room?: boolean;
   };
 };
+
+/**
+ * Check if the formatted_body contains a matrix.to mention link for the given user ID.
+ * Many Matrix clients (including Element) use HTML links in formatted_body instead of
+ * or in addition to the m.mentions field.
+ */
+function checkFormattedBodyMention(formattedBody: string | undefined, userId: string): boolean {
+  if (!formattedBody || !userId) {
+    return false;
+  }
+  // Escape special regex characters in the user ID (e.g., @user:matrix.org)
+  const escapedUserId = userId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  // Match matrix.to links with the user ID, handling both URL-encoded and plain formats
+  // Example: href="https://matrix.to/#/@user:matrix.org" or href="https://matrix.to/#/%40user%3Amatrix.org"
+  const plainPattern = new RegExp(`href=["']https://matrix\\.to/#/${escapedUserId}["']`, "i");
+  if (plainPattern.test(formattedBody)) {
+    return true;
+  }
+  // Also check URL-encoded version (@ -> %40, : -> %3A)
+  const encodedUserId = encodeURIComponent(userId);
+  const encodedPattern = new RegExp(`href=["']https://matrix\\.to/#/${encodedUserId}["']`, "i");
+  return encodedPattern.test(formattedBody);
+}
 
 export function resolveMentions(params: {
   content: MessageContentWithMentions;
@@ -20,9 +44,16 @@ export function resolveMentions(params: {
   const mentionedUsers = Array.isArray(mentions?.user_ids)
     ? new Set(mentions.user_ids)
     : new Set<string>();
+
+  // Check formatted_body for matrix.to mention links (legacy/alternative mention format)
+  const mentionedInFormattedBody = params.userId
+    ? checkFormattedBodyMention(params.content.formatted_body, params.userId)
+    : false;
+
   const wasMentioned =
     Boolean(mentions?.room) ||
     (params.userId ? mentionedUsers.has(params.userId) : false) ||
+    mentionedInFormattedBody ||
     getMatrixRuntime().channel.mentions.matchesMentionPatterns(
       params.text ?? "",
       params.mentionRegexes,

--- a/extensions/matrix/src/matrix/monitor/mentions.ts
+++ b/extensions/matrix/src/matrix/monitor/mentions.ts
@@ -29,7 +29,7 @@ function checkFormattedBodyMention(formattedBody: string | undefined, userId: st
     return true;
   }
   // Also check URL-encoded version (@ -> %40, : -> %3A)
-  const encodedUserId = encodeURIComponent(userId);
+  const encodedUserId = encodeURIComponent(userId).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const encodedPattern = new RegExp(`href=["']https://matrix\\.to/#/${encodedUserId}["']`, "i");
   return encodedPattern.test(formattedBody);
 }


### PR DESCRIPTION
## Summary

Matrix mention detection was failing when clients use `formatted_body` with `matrix.to` links instead of the newer `m.mentions` field.

## Problem

Many Matrix clients (including Element) send mentions using HTML in `formatted_body`:

```json
{
  "body": "Bot: hello",
  "formatted_body": "<a href=\\"https://matrix.to/#/@bot:matrix.org\\">Bot</a>: hello",
  "m.mentions": null
}
```

The `resolveMentions()` function only checked:
1. `m.mentions.room` - room mention flag
2. `m.mentions.user_ids` - explicit user ID array
3. Regex patterns on plain `body` text

It did NOT check `formatted_body` for `matrix.to` mention links.

## Solution

Added `checkFormattedBodyMention()` helper that:
- Detects `matrix.to` links in `formatted_body`
- Handles both plain and URL-encoded user IDs (`@bot:matrix.org` vs `%40bot%3Amatrix.org`)
- Properly escapes special regex characters in user IDs

## Testing

Added comprehensive test coverage for:
- `m.mentions` field detection
- `formatted_body` link detection (plain and URL-encoded)
- Regex pattern matching
- No false positives on partial matches

Fixes #6982

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes Matrix mention detection when clients use `formatted_body` HTML with `matrix.to` links instead of (or without) the newer `m.mentions` field. A new `checkFormattedBodyMention()` helper is added that parses `formatted_body` for `matrix.to` user links, handling both plain and URL-encoded user IDs. The change integrates cleanly into the existing `resolveMentions()` flow in `handler.ts`.

- Adds `formatted_body` detection for `matrix.to` mention links alongside existing `m.mentions` and regex-based detection
- Handles both plain (`@bot:matrix.org`) and URL-encoded (`%40bot%3Amatrix.org`) user IDs in href attributes
- Comprehensive test file covering all detection paths, including false-positive guards
- Minor bug: the URL-encoded regex path does not escape `.` from `encodeURIComponent`, which could theoretically cause false-positive matches

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one minor regex escaping fix recommended.
- The change is well-scoped, adds a clear feature (formatted_body mention detection) with comprehensive tests. The one issue found — missing regex escaping on the URL-encoded user ID — is unlikely to cause real-world false positives due to the constrained pattern (requires a quote immediately after), but is straightforward to fix. No security concerns, no breaking changes to existing behavior.
- `extensions/matrix/src/matrix/monitor/mentions.ts` — the `encodedUserId` variable on line 32 needs regex-special-character escaping applied.

<sub>Last reviewed commit: f1ccf1e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->