### PR TITLE
fix(whatsapp): add typingIndicator config to avoid rate limits

### DIFF
--- a/src/config/types.whatsapp.ts
+++ b/src/config/types.whatsapp.ts
@@ -35,6 +35,13 @@ export type WhatsAppAckReactionConfig = {
   group?: "always" | "mentions" | "never";
 };
 
+/**
+ * Controls typing indicator sent before outbound messages.
+ * - "none": do not send typing indicator
+ * - "composing": send "is typing" indicator before each message (default)
+ */
+export type WhatsAppTypingIndicatorConfig = "none" | "composing";
+
 export type WhatsAppConfig = {
   /** Optional per-account WhatsApp configuration (multi-account). */
   accounts?: Record<string, WhatsAppAccountConfig>;
@@ -46,6 +53,8 @@ export type WhatsAppConfig = {
   configWrites?: boolean;
   /** Send read receipts for incoming messages (default true). */
   sendReadReceipts?: boolean;
+  /** Typing indicator sent before outbound messages. Set to "none" to disable (helps avoid rate limits with new accounts). Default: "composing". */
+  typingIndicator?: WhatsAppTypingIndicatorConfig;
   /**
    * Inbound message prefix (WhatsApp only).
    * Default: `[{agents.list[].identity.name}]` (or `[openclaw]`) when allowFrom is empty, else `""`.
@@ -116,6 +125,8 @@ export type WhatsAppAccountConfig = {
   enabled?: boolean;
   /** Send read receipts for incoming messages (default true). */
   sendReadReceipts?: boolean;
+  /** Typing indicator sent before outbound messages. Set to "none" to disable (helps avoid rate limits with new accounts). Default: "composing". */
+  typingIndicator?: WhatsAppTypingIndicatorConfig;
   /** Inbound message prefix override for this account (WhatsApp only). */
   messagePrefix?: string;
   /** Per-account outbound response prefix override (takes precedence over channel and global). */

--- a/src/config/zod-schema.providers-whatsapp.ts
+++ b/src/config/zod-schema.providers-whatsapp.ts
@@ -36,6 +36,7 @@ const WhatsAppSharedSchema = z.object({
   markdown: MarkdownConfigSchema,
   configWrites: z.boolean().optional(),
   sendReadReceipts: z.boolean().optional(),
+  typingIndicator: z.enum(["none", "composing"]).optional(),
   messagePrefix: z.string().optional(),
   responsePrefix: z.string().optional(),
   dmPolicy: DmPolicySchema.optional().default("pairing"),

--- a/src/web/accounts.ts
+++ b/src/web/accounts.ts
@@ -12,6 +12,7 @@ export type ResolvedWhatsAppAccount = {
   name?: string;
   enabled: boolean;
   sendReadReceipts: boolean;
+  typingIndicator?: "none" | "composing";
   messagePrefix?: string;
   authDir: string;
   isLegacyAuthDir: boolean;
@@ -150,6 +151,7 @@ export function resolveWhatsAppAccount(params: {
     name: accountCfg?.name?.trim() || undefined,
     enabled,
     sendReadReceipts: accountCfg?.sendReadReceipts ?? rootCfg?.sendReadReceipts ?? true,
+    typingIndicator: accountCfg?.typingIndicator ?? rootCfg?.typingIndicator,
     messagePrefix:
       accountCfg?.messagePrefix ?? rootCfg?.messagePrefix ?? params.cfg.messages?.messagePrefix,
     authDir,

--- a/src/web/outbound.ts
+++ b/src/web/outbound.ts
@@ -7,6 +7,7 @@ import { convertMarkdownTables } from "../markdown/tables.js";
 import { markdownToWhatsApp } from "../markdown/whatsapp.js";
 import { normalizePollInput, type PollInput } from "../polls.js";
 import { toWhatsappJid } from "../utils.js";
+import { resolveWhatsAppAccount } from "./accounts.js";
 import { type ActiveWebSendOptions, requireActiveWebListener } from "./active-listener.js";
 import { loadWebMedia } from "./media.js";
 
@@ -68,7 +69,13 @@ export async function sendMessageWhatsApp(
     }
     outboundLog.info(`Sending message -> ${jid}${options.mediaUrl ? " (media)" : ""}`);
     logger.info({ jid, hasMedia: Boolean(options.mediaUrl) }, "sending message");
-    await active.sendComposingTo(to);
+    const whatsappAccount = resolveWhatsAppAccount({
+      cfg,
+      accountId: resolvedAccountId ?? options.accountId,
+    });
+    if (whatsappAccount.typingIndicator !== "none") {
+      await active.sendComposingTo(to);
+    }
     const hasExplicitAccountId = Boolean(options.accountId?.trim());
     const accountId = hasExplicitAccountId ? resolvedAccountId : undefined;
     const sendOptions: ActiveWebSendOptions | undefined =


### PR DESCRIPTION
## Summary

Add a new `typingIndicator` configuration option for the WhatsApp channel. When set to `"none"`, it disables the typing indicator (composing presence) sent before each outbound message. This helps avoid WhatsApp rate limits that can trigger `"restricted"` status on new accounts with few contacts.

## Changes

- Add `typingIndicator` type (`"none" | "composing"`) to WhatsApp config schema
- Add `typingIndicator` to `ResolvedWhatsAppAccount` type
- Modify outbound message sending to check config before sending typing indicator
- Default behavior unchanged (sends typing indicator as before)

## Testing

- Build passes successfully
- Existing outbound tests pass
- Manual testing: Set `typingIndicator: "none"` in config to disable typing indicator

Fixes openclaw/openclaw#16912

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a `typingIndicator` configuration option (`"none" | "composing"`) for WhatsApp to allow disabling the composing presence indicator sent before outbound messages. This addresses rate-limiting issues on new WhatsApp accounts with few contacts (openclaw/openclaw#16912).

- Added `WhatsAppTypingIndicatorConfig` type and `typingIndicator` field to both root-level `WhatsAppConfig` and per-account `WhatsAppAccountConfig`
- Added Zod validation in the shared schema (`z.enum(["none", "composing"]).optional()`)
- Added `typingIndicator` to `ResolvedWhatsAppAccount` with proper fallback chain (account → root config → `undefined`)
- Modified `sendMessageWhatsApp` in `outbound.ts` to conditionally skip `sendComposingTo` when `typingIndicator` is `"none"`
- Default behavior is preserved: when `typingIndicator` is unset (`undefined`), typing indicator is still sent
- No new tests were added for the `typingIndicator: "none"` code path, though existing tests pass since the default behavior is unchanged

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk — it's an additive, opt-in configuration change with backward-compatible defaults.
- The changes are focused and well-structured. Type definitions, Zod schema, account resolution, and outbound logic are all consistent. The `!== "none"` check correctly preserves default behavior when the config is unset. The only minor concern is the new `resolveWhatsAppAccount` call in the hot outbound path, which includes synchronous filesystem I/O for legacy auth detection, though this pattern is used elsewhere. No new tests cover the "none" path specifically, but existing tests verify the default behavior still works.
- `src/web/outbound.ts` — new `resolveWhatsAppAccount` call adds synchronous filesystem I/O to the outbound message path

<sub>Last reviewed commit: 0a583a1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->