### PR TITLE
fix(memory): close stale SQLite connection after QMD update

### DIFF
--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -620,6 +620,10 @@ export class QmdMemoryManager implements MemorySearchManager {
         }
       }
       this.lastUpdateAt = Date.now();
+      if (this.db) {
+        this.db.close();
+        this.db = null;
+      }
       this.docPathCache.clear();
     };
     this.pendingUpdate = run().finally(() => {


### PR DESCRIPTION
Fixes #16844

## Problem

`QmdMemoryManager.runUpdate()` clears `docPathCache` after QMD update but keeps a stale read-only SQLite connection cached in `this.db`. In WAL journal mode (the default), this cached connection gets stuck on a pre-write WAL snapshot and cannot see rows committed by the `qmd update` subprocess.

**Result:** `resolveDocLocation()` cannot find newly indexed document hashes → search results are silently dropped (`if (!doc) continue`). Approximately 50% of queries lose valid results over time until the gateway is restarted.

## Root Cause

In `qmd-manager.ts`:
- `ensureDb()` caches `this.db` with `readOnly: true` — opened once, reused forever
- `runUpdate()` calls `this.docPathCache.clear()` after update but does NOT close/reopen the SQLite connection
- In WAL mode, the stale read-only connection cannot see rows committed by the `qmd update` subprocess

## Fix

Close and null `this.db` before clearing `docPathCache` in `runUpdate()`. This forces `ensureDb()` to open a fresh connection on the next query, which will see the latest WAL checkpoint.

```diff
       this.lastUpdateAt = Date.now();
+      if (this.db) {
+        this.db.close();
+        this.db = null;
+      }
       this.docPathCache.clear();
```

## Testing

- ✅ `qmd-manager.test.ts`: 33/33 passed
- ✅ Lint: 0 warnings, 0 errors (oxlint type-aware)
- ✅ 4-model independent consensus (Opus 4.6, Kimi K2.5, GPT 5.3 Codex, MiniMax M2.5) — all converged on identical fix