### PR TITLE
fix(cron): add minimum delay floor to prevent timer spin loop

### DIFF
--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -443,7 +443,7 @@ describe("Cron issue regressions", () => {
     });
 
     targetJobId = job.id;
-    await vi.advanceTimersByTimeAsync(2);
+    await vi.advanceTimersByTimeAsync(150);
     await started.promise;
     expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
 

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -14,6 +14,7 @@ import {
 import { locked } from "./locked.js";
 import { ensureLoaded, persist } from "./store.js";
 
+const MIN_TIMER_DELAY_MS = 100;
 const MAX_TIMER_DELAY_MS = 60_000;
 
 /**
@@ -143,7 +144,7 @@ export function armTimer(state: CronServiceState) {
   const delay = Math.max(nextAt - now, 0);
   // Wake at least once a minute to avoid schedule drift and recover quickly
   // when the process was paused or wall-clock time jumps.
-  const clampedDelay = Math.min(delay, MAX_TIMER_DELAY_MS);
+  const clampedDelay = Math.min(Math.max(delay, MIN_TIMER_DELAY_MS), MAX_TIMER_DELAY_MS);
   // Intentionally avoid an `async` timer callback:
   // Vitest's fake-timer helpers can await async callbacks, which would block
   // tests that simulate long-running jobs. Runtime behavior is unchanged.


### PR DESCRIPTION
Fixes #16839

## Problem

`armTimer()` computes `Math.max(nextAt - now, 0)` which produces `0` for past-due jobs, then passes it directly to `setTimeout`. This causes a hot loop with ~18ms re-arm cycles after gateway restart, generating thousands of log entries and wasting CPU.

## Root Cause

In `src/cron/service/timer.ts`, `armTimer()`:
```typescript
const delay = Math.max(nextAt - now, 0);
const clampedDelay = Math.min(delay, MAX_TIMER_DELAY_MS);
```
When `nextAt <= now` (past-due), `delay = 0` → `setTimeout(fn, 0)` → immediate re-arm → spin loop.

## Fix

Add `MIN_TIMER_DELAY_MS = 100` constant and clamp the delay to a minimum of 100ms. This prevents zero-delay scheduling while still allowing prompt execution of due jobs.

```diff
+const MIN_TIMER_DELAY_MS = 100;
 const MAX_TIMER_DELAY_MS = 60_000;
 ...
-  const clampedDelay = Math.min(delay, MAX_TIMER_DELAY_MS);
+  const clampedDelay = Math.min(Math.max(delay, MIN_TIMER_DELAY_MS), MAX_TIMER_DELAY_MS);
```

## Testing

- ✅ Cron timer tests: 6/6 passed (rearm, every-jobs-fire, restart-catchup)
- ✅ Lint: 0 warnings, 0 errors (oxlint type-aware)
- ✅ 4-model independent consensus (Opus 4.6, Kimi K2.5, GPT 5.3 Codex, MiniMax M2.5) — all converged on identical fix