### PR TITLE
fix(agents): prevent before_tool_call hook double-fire on wrapped tools

### DIFF
--- a/src/agents/pi-tools.before-tool-call.ts
+++ b/src/agents/pi-tools.before-tool-call.ts
@@ -73,6 +73,9 @@ export function wrapToolWithBeforeToolCallHook(
   if (!execute) {
     return tool;
   }
+  if (isToolWrappedWithBeforeToolCallHook(tool)) {
+    return tool;
+  }
   const toolName = tool.name || "tool";
   const wrappedTool: AnyAgentTool = {
     ...tool,
@@ -100,7 +103,7 @@ export function wrapToolWithBeforeToolCallHook(
   };
   Object.defineProperty(wrappedTool, BEFORE_TOOL_CALL_WRAPPED, {
     value: true,
-    enumerable: false,
+    enumerable: true,
   });
   return wrappedTool;
 }


### PR DESCRIPTION
Fixes #16851

## Problem

`BEFORE_TOOL_CALL_WRAPPED` Symbol is defined with `enumerable: false` in `wrapToolWithBeforeToolCallHook()`. When `{...tool}` spread copies the tool object, non-enumerable Symbol properties are lost. This means `isToolWrappedWithBeforeToolCallHook()` returns `false` for already-wrapped tools, allowing them to be double-wrapped — firing the hook twice per tool call.

## Root Cause

In `src/agents/pi-tools.before-tool-call.ts`:
```typescript
Object.defineProperty(wrappedTool, BEFORE_TOOL_CALL_WRAPPED, {
    value: true,
    enumerable: false,  // ← lost on {...tool} spread
});
```

The spread operator only copies enumerable own properties. When another wrapper does `{...wrappedTool}`, the Symbol is dropped, and the next call to `wrapToolWithBeforeToolCallHook` wraps it again.

## Fix

Two changes:
1. Change `enumerable: false` → `enumerable: true` so the Symbol survives object spread
2. Add early-return guard at the top of `wrapToolWithBeforeToolCallHook` to skip already-wrapped tools

```diff
   if (!execute) {
     return tool;
   }
+  if (isToolWrappedWithBeforeToolCallHook(tool)) {
+    return tool;
+  }
   const toolName = tool.name || "tool";
   ...
   Object.defineProperty(wrappedTool, BEFORE_TOOL_CALL_WRAPPED, {
     value: true,
-    enumerable: false,
+    enumerable: true,
   });
```

The guard provides defense-in-depth even if the Symbol is somehow lost again in future refactors.

## Testing

- ✅ Lint: 0 warnings, 0 errors (oxlint type-aware)
- ✅ 4-model independent consensus (Opus 4.6, Kimi K2.5, GPT 5.3 Codex, MiniMax M2.5) — all converged on identical fix
- ℹ️ e2e test file exists (`pi-tools.before-tool-call.e2e.test.ts`) but excluded by vitest config (`**/*.e2e.test.ts`)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed double-firing of `before_tool_call` hook on wrapped tools by making the `BEFORE_TOOL_CALL_WRAPPED` Symbol enumerable and adding an early-return guard.

**Key Changes:**
- Changed Symbol property from `enumerable: false` to `enumerable: true` on line 106, ensuring the marker survives object spread operations (`{...tool}`)
- Added early-return guard (lines 76-78) to prevent double-wrapping when tool is already wrapped
- Both changes provide defense-in-depth: the enumerable Symbol prevents accidental loss during spread, while the guard catches any future edge cases

**Analysis:**
The root cause was that `{...tool}` spread operators (used in line 81 and in `wrapToolWithAbortSignal` at src/agents/pi-tools.abort.ts:58) only copy enumerable properties. Non-enumerable Symbols were silently dropped, breaking the `isToolWrappedWithBeforeToolCallHook()` check and allowing duplicate wrapping.

The fix is correct and minimal - it addresses the issue at both the source (making Symbol enumerable) and adds a failsafe (early-return guard).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is surgical, well-explained, and addresses a clear bug with a two-pronged approach (enumerable Symbol + guard). The changes are minimal (2 lines added, 1 line modified), have clear test coverage via existing e2e tests, and include consensus validation from multiple models. The logic is sound: making the Symbol enumerable ensures it survives spread operations, and the early-return guard provides an additional safety layer.
- No files require special attention

<sub>Last reviewed commit: e099f6b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->