### PR TITLE
fix(security): escape user input in HTML gallery to prevent stored XSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/Compaction: count auto-compactions only after a non-retry `auto_compaction_end`, keeping session `compactionCount` aligned to completed compactions.
+- Security/Skills: escape user-controlled prompt, filename, and output-path values in `openai-image-gen` HTML gallery generation to prevent stored XSS in generated `index.html` output. (#12538) Thanks @CornBrother0x.
 - Security/CLI: redact sensitive values in `openclaw config get` output before printing config paths, preventing credential leakage to terminal output/history. (#13683) Thanks @SleuthCo.
 - Install/Discord Voice: make `@discordjs/opus` an optional dependency so `openclaw` install/update no longer hard-fails when native Opus builds fail, while keeping `opusscript` as the runtime fallback decoder for Discord voice flows. (#23737, #23733, #23703) Thanks @jeadland, @Sheetaa, and @Breakyman.
 - Docker/Setup: precreate `$OPENCLAW_CONFIG_DIR/identity` during `docker-setup.sh` so CLI commands that need device identity (for example `devices list`) avoid `EACCES ... /home/node/.openclaw/identity` failures on restrictive bind mounts. (#23948) Thanks @ackson-beep.

--- a/skills/openai-image-gen/scripts/gen.py
+++ b/skills/openai-image-gen/scripts/gen.py
@@ -9,6 +9,7 @@ import re
 import sys
 import urllib.error
 import urllib.request
+from html import escape as html_escape
 from pathlib import Path
 
 
@@ -131,8 +132,8 @@ def write_gallery(out_dir: Path, items: list[dict]) -> None:
         [
             f"""
 <figure>
-  <a href="{it["file"]}"><img src="{it["file"]}" loading="lazy" /></a>
-  <figcaption>{it["prompt"]}</figcaption>
+  <a href="{html_escape(it["file"], quote=True)}"><img src="{html_escape(it["file"], quote=True)}" loading="lazy" /></a>
+  <figcaption>{html_escape(it["prompt"])}</figcaption>
 </figure>
 """.strip()
             for it in items
@@ -152,7 +153,7 @@ def write_gallery(out_dir: Path, items: list[dict]) -> None:
   code {{ color: #9cd1ff; }}
 </style>
 <h1>openai-image-gen</h1>
-<p>Output: <code>{out_dir.as_posix()}</code></p>
+<p>Output: <code>{html_escape(out_dir.as_posix())}</code></p>
 <div class="grid">
 {thumbs}
 </div>

--- a/skills/openai-image-gen/scripts/test_gen.py
+++ b/skills/openai-image-gen/scripts/test_gen.py
@@ -1,0 +1,50 @@
+"""Tests for write_gallery HTML escaping (fixes #12538 - stored XSS)."""
+
+import tempfile
+from pathlib import Path
+
+from gen import write_gallery
+
+
+def test_write_gallery_escapes_prompt_xss():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out = Path(tmpdir)
+        items = [{"prompt": '<script>alert("xss")</script>', "file": "001-test.png"}]
+        write_gallery(out, items)
+        html = (out / "index.html").read_text()
+        assert "<script>" not in html
+        assert "&lt;script&gt;" in html
+
+
+def test_write_gallery_escapes_filename():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out = Path(tmpdir)
+        items = [{"prompt": "safe prompt", "file": '" onload="alert(1)'}]
+        write_gallery(out, items)
+        html = (out / "index.html").read_text()
+        assert 'onload="alert(1)"' not in html
+        assert "&quot;" in html
+
+
+def test_write_gallery_escapes_ampersand():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out = Path(tmpdir)
+        items = [{"prompt": "cats & dogs <3", "file": "001-test.png"}]
+        write_gallery(out, items)
+        html = (out / "index.html").read_text()
+        assert "cats &amp; dogs &lt;3" in html
+
+
+def test_write_gallery_normal_output():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out = Path(tmpdir)
+        items = [
+            {"prompt": "a lobster astronaut, golden hour", "file": "001-lobster.png"},
+            {"prompt": "a cozy reading nook", "file": "002-nook.png"},
+        ]
+        write_gallery(out, items)
+        html = (out / "index.html").read_text()
+        assert "a lobster astronaut, golden hour" in html
+        assert 'src="001-lobster.png"' in html
+        assert "002-nook.png" in html
+


### PR DESCRIPTION
## Summary

- **Problem:** `write_gallery()` in the OpenAI image gen skill embeds user-provided prompt text, filenames, and output paths directly into HTML without escaping
- **Why it matters:** Stored XSS — an attacker injects `<script>` tags via image prompts that execute when anyone opens the gallery (CVSS 7.5, CWE-79)
- **What changed:** Applied `html.escape()` (Python stdlib) to all three user-controlled values before HTML embedding
- **What did NOT change:** Gallery layout, image generation, file structure unchanged

Closes #12538

## Changes

**`skills/openai-image-gen/scripts/gen.py`**:
- Added `from html import escape as html_escape`
- Escaped prompt text in `<figcaption>`, filename in `href`/`src` attributes, output path in `<code>` tag

**`skills/openai-image-gen/scripts/test_gen.py`** (new):
- 4 tests: XSS payloads, attribute injection, special characters, normal operation

## Security Impact

- No new permissions, network calls, or execution surface changes
- Fixes stored XSS vulnerability in generated HTML output

## Testing

All 4 tests pass. Verified `<script>alert("xss")</script>` in prompt renders as escaped text, not executable JS.

## Compatibility

Backward compatible. Special characters in prompts now display as HTML entities — no visual difference for normal text.

## AI Disclosure
AI-assisted (Claude via OpenClaw). Code reviewed and tested.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two security vulnerabilities across two skill scripts:

- **Stored XSS in `gen.py`**: Applied `html.escape()` to user-controlled prompt text, filenames, and output paths before embedding them in the generated HTML gallery, preventing script injection via crafted image prompts (CWE-79).
- **Symlink/path traversal in `package_skill.py`**: Added symlink rejection and resolved-path boundary checks during `.skill` file creation, preventing sensitive file exfiltration via symlink attacks or crafted path traversal (zip-slip).

Both fixes are minimal, targeted, and backward compatible. New test files cover the security scenarios for each fix.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it adds targeted security hardening with no functional behavior changes.
- Both security fixes are correct and well-scoped. The HTML escaping uses Python's stdlib `html.escape()` with appropriate `quote=True` for attribute contexts. The symlink/path traversal protection uses a defense-in-depth approach (symlink check + resolved path boundary check). New tests cover the key attack vectors. Only minor style issues (unused imports in test files) were found.
- No files require special attention. Both fixes are straightforward and well-tested.

<sub>Last reviewed commit: 055d8de</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->