### PR TITLE
perf: skip cache-busting for bundled hooks, use mtime for workspace hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ Docs: https://docs.openclaw.ai
 - Cron/Schedule: for `every` jobs, prefer `lastRunAtMs + everyMs` when still in the future after restarts, then fall back to anchor scheduling for catch-up windows, so NEXT timing matches the last successful cadence. (#22895) Thanks @SidQin-cyber.
 - Agents/Compaction: restore embedded compaction safeguard/context-pruning extension loading in production by wiring bundled extension factories into the resource loader instead of runtime file-path resolution. (#22349) Thanks @Glucksberg.
 - Feishu/Media: for inbound video messages that include both `file_key` (video) and `image_key` (thumbnail), prefer `file_key` when downloading media so video attachments are saved instead of silently failing on thumbnail keys. (#23633)
+- Hooks/Loader: avoid redundant hook-module recompilation on gateway restart by skipping cache-busting for bundled hooks and using stable file metadata keys (`mtime+size`) for mutable workspace/managed/plugin hook imports. (#16953) Thanks @mudrii.
 - Hooks/Cron: suppress duplicate main-session events for delivered hook turns and mark `SILENT_REPLY_TOKEN` (`NO_REPLY`) early exits as delivered to prevent hook context pollution. (#20678) Thanks @JonathanWorks.
 - Providers/OpenRouter: inject `cache_control` on system prompts for OpenRouter Anthropic models to improve prompt-cache reuse. (#17473) Thanks @rrenamed.
 - Installer/Smoke tests: remove legacy `OPENCLAW_USE_GUM` overrides from docker install-smoke runs so tests exercise installer auto TTY detection behavior directly.

--- a/src/hooks/import-url.test.ts
+++ b/src/hooks/import-url.test.ts
@@ -1,0 +1,61 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { buildImportUrl } from "./import-url.js";
+
+describe("buildImportUrl", () => {
+  let tmpDir: string;
+  let tmpFile: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "import-url-test-"));
+    tmpFile = path.join(tmpDir, "handler.js");
+    fs.writeFileSync(tmpFile, "export default () => {};");
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns bare URL for bundled hooks (no query string)", () => {
+    const url = buildImportUrl(tmpFile, "openclaw-bundled");
+    expect(url).not.toContain("?t=");
+    expect(url).toMatch(/^file:\/\//);
+  });
+
+  it("appends mtime-based cache buster for workspace hooks", () => {
+    const url = buildImportUrl(tmpFile, "openclaw-workspace");
+    expect(url).toMatch(/\?t=\d+/);
+
+    const { mtimeMs } = fs.statSync(tmpFile);
+    expect(url).toContain(`?t=${mtimeMs}`);
+  });
+
+  it("appends mtime-based cache buster for managed hooks", () => {
+    const url = buildImportUrl(tmpFile, "openclaw-managed");
+    expect(url).toMatch(/\?t=\d+/);
+  });
+
+  it("appends mtime-based cache buster for plugin hooks", () => {
+    const url = buildImportUrl(tmpFile, "openclaw-plugin");
+    expect(url).toMatch(/\?t=\d+/);
+  });
+
+  it("returns same URL for bundled hooks across calls (cacheable)", () => {
+    const url1 = buildImportUrl(tmpFile, "openclaw-bundled");
+    const url2 = buildImportUrl(tmpFile, "openclaw-bundled");
+    expect(url1).toBe(url2);
+  });
+
+  it("returns same URL for workspace hooks when file is unchanged", () => {
+    const url1 = buildImportUrl(tmpFile, "openclaw-workspace");
+    const url2 = buildImportUrl(tmpFile, "openclaw-workspace");
+    expect(url1).toBe(url2);
+  });
+
+  it("falls back to Date.now() when file does not exist", () => {
+    const url = buildImportUrl("/nonexistent/handler.js", "openclaw-workspace");
+    expect(url).toMatch(/\?t=\d+/);
+  });
+});

--- a/src/hooks/import-url.test.ts
+++ b/src/hooks/import-url.test.ts
@@ -26,20 +26,21 @@ describe("buildImportUrl", () => {
 
   it("appends mtime-based cache buster for workspace hooks", () => {
     const url = buildImportUrl(tmpFile, "openclaw-workspace");
-    expect(url).toMatch(/\?t=\d+/);
+    expect(url).toMatch(/\?t=[\d.]+&s=\d+/);
 
-    const { mtimeMs } = fs.statSync(tmpFile);
+    const { mtimeMs, size } = fs.statSync(tmpFile);
     expect(url).toContain(`?t=${mtimeMs}`);
+    expect(url).toContain(`&s=${size}`);
   });
 
   it("appends mtime-based cache buster for managed hooks", () => {
     const url = buildImportUrl(tmpFile, "openclaw-managed");
-    expect(url).toMatch(/\?t=\d+/);
+    expect(url).toMatch(/\?t=[\d.]+&s=\d+/);
   });
 
   it("appends mtime-based cache buster for plugin hooks", () => {
     const url = buildImportUrl(tmpFile, "openclaw-plugin");
-    expect(url).toMatch(/\?t=\d+/);
+    expect(url).toMatch(/\?t=[\d.]+&s=\d+/);
   });
 
   it("returns same URL for bundled hooks across calls (cacheable)", () => {

--- a/src/hooks/import-url.ts
+++ b/src/hooks/import-url.ts
@@ -1,0 +1,38 @@
+/**
+ * Build an import URL for a hook handler module.
+ *
+ * Bundled hooks (shipped in dist/) are immutable between installs, so they
+ * can be imported without a cache-busting suffix — letting V8 reuse its
+ * module cache across gateway restarts.
+ *
+ * Workspace, managed, and plugin hooks may be edited by the user between
+ * restarts.  For those we append `?t=<mtime>` so the module is only
+ * re-parsed when the file actually changes on disk.
+ */
+
+import fs from "node:fs";
+import { pathToFileURL } from "node:url";
+import type { HookSource } from "./types.js";
+
+/**
+ * Sources whose handler files never change between `npm install` runs.
+ * Imports from these sources skip cache busting entirely.
+ */
+const IMMUTABLE_SOURCES: ReadonlySet<HookSource> = new Set(["openclaw-bundled"]);
+
+export function buildImportUrl(handlerPath: string, source: HookSource): string {
+  const base = pathToFileURL(handlerPath).href;
+
+  if (IMMUTABLE_SOURCES.has(source)) {
+    return base;
+  }
+
+  // Use file mtime so the cache is only invalidated when the file is modified
+  try {
+    const { mtimeMs } = fs.statSync(handlerPath);
+    return `${base}?t=${mtimeMs}`;
+  } catch {
+    // If stat fails (unlikely), fall back to Date.now() to guarantee freshness
+    return `${base}?t=${Date.now()}`;
+  }
+}

--- a/src/hooks/import-url.ts
+++ b/src/hooks/import-url.ts
@@ -6,8 +6,8 @@
  * module cache across gateway restarts.
  *
  * Workspace, managed, and plugin hooks may be edited by the user between
- * restarts.  For those we append `?t=<mtime>` so the module is only
- * re-parsed when the file actually changes on disk.
+ * restarts. For those we append `?t=<mtime>&s=<size>` so the module key
+ * reflects on-disk changes while staying stable for unchanged files.
  */
 
 import fs from "node:fs";
@@ -27,10 +27,10 @@ export function buildImportUrl(handlerPath: string, source: HookSource): string 
     return base;
   }
 
-  // Use file mtime so the cache is only invalidated when the file is modified
+  // Use file metadata so the cache key only changes when the file changes
   try {
-    const { mtimeMs } = fs.statSync(handlerPath);
-    return `${base}?t=${mtimeMs}`;
+    const { mtimeMs, size } = fs.statSync(handlerPath);
+    return `${base}?t=${mtimeMs}&s=${size}`;
   } catch {
     // If stat fails (unlikely), fall back to Date.now() to guarantee freshness
     return `${base}?t=${Date.now()}`;


### PR DESCRIPTION
## Summary

Bundled hooks in `dist/` are immutable between `npm install` runs — there is no reason to append `?t=Date.now()` to their import URLs on every gateway restart. This forced V8 to re-parse and re-compile ~30 transitive module chunks per hook (×4 hooks = ~120 redundant compilations per restart).

## Changes

- **New:** `src/hooks/import-url.ts` — `buildImportUrl(path, source)` helper that decides cache-busting strategy based on hook source:
  - `openclaw-bundled`: bare URL (no query string) → V8 module cache effective across restarts
  - `openclaw-workspace` / `openclaw-managed` / `openclaw-plugin`: `?t=<mtime>` → only re-parsed when file actually changes
  - Falls back to `?t=Date.now()` if `stat()` fails (safety net)
- **Updated:** `src/hooks/loader.ts` — use `buildImportUrl()` for both directory-based and legacy handler imports
- **Updated:** `src/hooks/plugin-hooks.ts` — use `buildImportUrl()` for plugin hook imports
- **New:** `src/hooks/import-url.test.ts` — 7 unit tests covering all source types, cacheability, and fallback behavior

## Observed impact

Cold restart (first of day) — hooks take ~1.3s to load as V8 compiles all modules fresh:
```
07:49:39 → boot-md registered
07:49:40 → bootstrap-extra-files (1.3s gap)
```

With this fix, bundled hook imports will hit V8 module cache on subsequent restarts, eliminating redundant parse+compile cycles for ~30 immutable dist chunks.

## Testing

- `pnpm build` ✅
- `pnpm lint` ✅ (0 warnings, 0 errors)
- `pnpm test -- src/hooks/` ✅ (90 tests, 11 files, all passing)

Fixes #16953

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Eliminates redundant V8 module compilation on gateway restarts by using smart cache-busting strategies: bundled hooks skip cache-busting entirely (immutable between installs), while workspace/managed/plugin hooks use mtime-based invalidation (only re-parsed when files actually change).

- Adds `buildImportUrl()` helper that selects cache strategy based on hook source type
- Updates `loader.ts` and `plugin-hooks.ts` to use the new helper for all hook imports
- Includes 7 unit tests covering all source types, cacheability guarantees, and fallback behavior
- Addresses performance issue where ~120 module chunks were redundantly re-compiled on every restart

<h3>Confidence Score: 5/5</h3>

- Safe to merge - focused performance optimization with proper fallbacks
- Clean implementation with comprehensive test coverage (7 tests covering all source types and edge cases), proper error handling (falls back to Date.now() if stat fails), and minimal surface area for issues. The logic correctly distinguishes between immutable bundled hooks and mutable workspace/plugin hooks.
- No files require special attention

<sub>Last reviewed commit: 10805c4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->