### PR TITLE
fix: enable auth rate limiting by default

### DIFF
--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -150,6 +150,8 @@ export type GatewayAuthConfig = {
 };
 
 export type GatewayAuthRateLimitConfig = {
+  /** Whether auth rate limiting is enabled.  @default true */
+  enabled?: boolean;
   /** Maximum failed attempts per IP before blocking.  @default 10 */
   maxAttempts?: number;
   /** Sliding window duration in milliseconds.  @default 60000 (1 min) */

--- a/src/gateway/auth-rate-limit.test.ts
+++ b/src/gateway/auth-rate-limit.test.ts
@@ -207,6 +207,28 @@ describe("auth rate limiter", () => {
     expect(limiter.check("").allowed).toBe(false);
   });
 
+  // ---------- default config (regression: #16876) ----------
+
+  it("creates a working limiter with no config (sensible defaults)", () => {
+    limiter = createAuthRateLimiter();
+    // Should use defaults: 10 maxAttempts, 60s window, 5min lockout
+    const result = limiter.check("10.0.0.50");
+    expect(result.allowed).toBe(true);
+    expect(result.remaining).toBe(10);
+    // Record 10 failures to trigger lockout
+    for (let i = 0; i < 10; i++) {
+      limiter.recordFailure("10.0.0.50");
+    }
+    expect(limiter.check("10.0.0.50").allowed).toBe(false);
+  });
+
+  it("creates a working limiter with empty object config", () => {
+    limiter = createAuthRateLimiter({});
+    const result = limiter.check("10.0.0.51");
+    expect(result.allowed).toBe(true);
+    expect(result.remaining).toBe(10);
+  });
+
   // ---------- dispose ----------
 
   it("dispose clears all entries", () => {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -20,6 +20,7 @@ import {
 } from "../config/config.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import { resolveMainSessionKey } from "../config/sessions.js";
+import type { GatewayAuthRateLimitConfig } from "../config/types.gateway.js";
 import { clearAgentRunContext, onAgentEvent } from "../infra/agent-events.js";
 import {
   ensureControlUiAssetsBuilt,
@@ -122,13 +123,12 @@ const logSecrets = log.child("secrets");
 const gatewayRuntime = runtimeForLogger(log);
 const canvasRuntime = runtimeForLogger(logCanvas);
 
-type AuthRateLimitConfig = Parameters<typeof createAuthRateLimiter>[0];
-
-function createGatewayAuthRateLimiters(rateLimitConfig: AuthRateLimitConfig | undefined): {
+function createGatewayAuthRateLimiters(rateLimitConfig: GatewayAuthRateLimitConfig | undefined): {
   rateLimiter?: AuthRateLimiter;
   browserRateLimiter: AuthRateLimiter;
 } {
-  const rateLimiter = rateLimitConfig?.enabled === false ? undefined : createAuthRateLimiter(rateLimitConfig);
+  const rateLimiter =
+    rateLimitConfig?.enabled === false ? undefined : createAuthRateLimiter(rateLimitConfig);
   // Browser-origin WS auth attempts always use loopback-non-exempt throttling.
   const browserRateLimiter = createAuthRateLimiter({
     ...rateLimitConfig,

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -128,7 +128,7 @@ function createGatewayAuthRateLimiters(rateLimitConfig: AuthRateLimitConfig | un
   rateLimiter?: AuthRateLimiter;
   browserRateLimiter: AuthRateLimiter;
 } {
-  const rateLimiter = rateLimitConfig ? createAuthRateLimiter(rateLimitConfig) : undefined;
+  const rateLimiter = rateLimitConfig?.enabled === false ? undefined : createAuthRateLimiter(rateLimitConfig);
   // Browser-origin WS auth attempts always use loopback-non-exempt throttling.
   const browserRateLimiter = createAuthRateLimiter({
     ...rateLimitConfig,
@@ -436,7 +436,7 @@ export async function startGatewayServer(
   let hooksConfig = runtimeConfig.hooksConfig;
   const canvasHostEnabled = runtimeConfig.canvasHostEnabled;
 
-  // Create auth rate limiters used by connect/auth flows.
+  // Create auth rate limiters by default; only skip when explicitly disabled.
   const rateLimitConfig = cfgAtStart.gateway?.auth?.rateLimit;
   const { rateLimiter: authRateLimiter, browserRateLimiter: browserAuthRateLimiter } =
     createGatewayAuthRateLimiters(rateLimitConfig);


### PR DESCRIPTION
## Summary
- Auth rate limiter was only created when explicitly configured, leaving the gateway unprotected by default
- Changed to always create a rate limiter with sensible defaults unless explicitly set to `enabled: false`
- Added `enabled` boolean to `GatewayAuthRateLimitConfig` type for explicit opt-out
- Added tests for default and empty config scenarios

Fixes #16876

## Test plan
- [x] Test rate limiter created with no config (default protection)
- [x] Test rate limiter created with empty config object
- [x] Existing rate limiter tests still pass
- [x] Full test suite passes (`pnpm test:fast`, `pnpm check`)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a security gap (#16876) where the gateway auth rate limiter was only created when `gateway.auth.rateLimit` was explicitly configured, leaving gateways unprotected by default against brute-force auth attempts.

- **`src/gateway/server.impl.ts`**: Inverts the rate limiter creation logic from opt-in to opt-out. The limiter is now always created with sensible defaults (10 attempts, 60s window, 5min lockout) unless `rateLimit.enabled` is explicitly set to `false`. Passing `undefined` config to `createAuthRateLimiter()` correctly triggers all default values.
- **`src/config/types.gateway.ts`**: Adds `enabled?: boolean` to `GatewayAuthRateLimitConfig` for explicit opt-out.
- **`src/gateway/auth-rate-limit.test.ts`**: Adds two regression tests covering no-config and empty-config scenarios.

The change is minimal and well-targeted. All downstream consumers already handle `rateLimiter` as optional (`AuthRateLimiter | undefined`), so the behavioral change is safe.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it closes a security gap with minimal, well-tested changes.
- The change is a 3-file, 27-line addition that flips rate limiter creation from opt-in to opt-out. The logic is straightforward (`=== false` check), the `createAuthRateLimiter` function already handles `undefined` config with sensible defaults, all downstream consumers handle the limiter as optional, and regression tests cover the key scenarios. No risk of breakage for existing configurations.
- No files require special attention.

<sub>Last reviewed commit: 92a9a99</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->