### PR TITLE
test: add regression tests for sub-agent session path resolution

### DIFF
--- a/src/config/sessions/paths.test.ts
+++ b/src/config/sessions/paths.test.ts
@@ -1,0 +1,229 @@
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  resolveSessionFilePath,
+  resolveSessionFilePathOptions,
+  resolveSessionTranscriptPath,
+  resolveSessionTranscriptPathInDir,
+  resolveStorePath,
+  validateSessionId,
+} from "./paths.js";
+
+describe("resolveStorePath", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("uses OPENCLAW_HOME for tilde expansion", () => {
+    vi.stubEnv("OPENCLAW_HOME", "/srv/openclaw-home");
+    vi.stubEnv("HOME", "/home/other");
+
+    const resolved = resolveStorePath("~/.openclaw/agents/{agentId}/sessions/sessions.json", {
+      agentId: "research",
+    });
+
+    expect(resolved).toBe(
+      path.resolve("/srv/openclaw-home/.openclaw/agents/research/sessions/sessions.json"),
+    );
+  });
+});
+
+describe("session path safety", () => {
+  it("validates safe session IDs", () => {
+    expect(validateSessionId("sess-1")).toBe("sess-1");
+    expect(validateSessionId("ABC_123.hello")).toBe("ABC_123.hello");
+  });
+
+  it("rejects unsafe session IDs", () => {
+    expect(() => validateSessionId("../etc/passwd")).toThrow(/Invalid session ID/);
+    expect(() => validateSessionId("a/b")).toThrow(/Invalid session ID/);
+    expect(() => validateSessionId("a\\b")).toThrow(/Invalid session ID/);
+    expect(() => validateSessionId("/abs")).toThrow(/Invalid session ID/);
+  });
+
+  it("resolves transcript path inside an explicit sessions dir", () => {
+    const sessionsDir = "/tmp/openclaw/agents/main/sessions";
+    const resolved = resolveSessionTranscriptPathInDir("sess-1", sessionsDir, "topic/a+b");
+
+    expect(resolved).toBe(path.resolve(sessionsDir, "sess-1-topic-topic%2Fa%2Bb.jsonl"));
+  });
+
+  it("rejects unsafe sessionFile candidates that escape the sessions dir", () => {
+    const sessionsDir = "/tmp/openclaw/agents/main/sessions";
+
+    expect(() =>
+      resolveSessionFilePath("sess-1", { sessionFile: "../../etc/passwd" }, { sessionsDir }),
+    ).toThrow(/within sessions directory/);
+
+    expect(() =>
+      resolveSessionFilePath("sess-1", { sessionFile: "/etc/passwd" }, { sessionsDir }),
+    ).toThrow(/within sessions directory/);
+  });
+
+  it("accepts sessionFile candidates within the sessions dir", () => {
+    const sessionsDir = "/tmp/openclaw/agents/main/sessions";
+
+    const resolved = resolveSessionFilePath(
+      "sess-1",
+      { sessionFile: "subdir/threaded-session.jsonl" },
+      { sessionsDir },
+    );
+
+    expect(resolved).toBe(path.resolve(sessionsDir, "subdir/threaded-session.jsonl"));
+  });
+
+  it("accepts absolute sessionFile paths that resolve within the sessions dir", () => {
+    const sessionsDir = "/tmp/openclaw/agents/main/sessions";
+
+    const resolved = resolveSessionFilePath(
+      "sess-1",
+      { sessionFile: "/tmp/openclaw/agents/main/sessions/abc-123.jsonl" },
+      { sessionsDir },
+    );
+
+    expect(resolved).toBe(path.resolve(sessionsDir, "abc-123.jsonl"));
+  });
+
+  it("accepts absolute sessionFile with topic suffix within the sessions dir", () => {
+    const sessionsDir = "/tmp/openclaw/agents/main/sessions";
+
+    const resolved = resolveSessionFilePath(
+      "sess-1",
+      { sessionFile: "/tmp/openclaw/agents/main/sessions/abc-123-topic-42.jsonl" },
+      { sessionsDir },
+    );
+
+    expect(resolved).toBe(path.resolve(sessionsDir, "abc-123-topic-42.jsonl"));
+  });
+
+  it("rejects absolute sessionFile paths outside known agent sessions dirs", () => {
+    const sessionsDir = "/tmp/openclaw/agents/main/sessions";
+
+    expect(() =>
+      resolveSessionFilePath(
+        "sess-1",
+        { sessionFile: "/tmp/openclaw/agents/work/not-sessions/abc-123.jsonl" },
+        { sessionsDir },
+      ),
+    ).toThrow(/within sessions directory/);
+  });
+
+  it("uses explicit agentId fallback for absolute sessionFile outside sessionsDir", () => {
+    const mainSessionsDir = path.dirname(resolveStorePath(undefined, { agentId: "main" }));
+    const opsSessionsDir = path.dirname(resolveStorePath(undefined, { agentId: "ops" }));
+    const opsSessionFile = path.join(opsSessionsDir, "abc-123.jsonl");
+
+    const resolved = resolveSessionFilePath(
+      "sess-1",
+      { sessionFile: opsSessionFile },
+      { sessionsDir: mainSessionsDir, agentId: "ops" },
+    );
+
+    expect(resolved).toBe(path.resolve(opsSessionFile));
+  });
+
+  it("uses absolute path fallback when sessionFile includes a different agent dir", () => {
+    const mainSessionsDir = path.dirname(resolveStorePath(undefined, { agentId: "main" }));
+    const opsSessionsDir = path.dirname(resolveStorePath(undefined, { agentId: "ops" }));
+    const opsSessionFile = path.join(opsSessionsDir, "abc-123.jsonl");
+
+    const resolved = resolveSessionFilePath(
+      "sess-1",
+      { sessionFile: opsSessionFile },
+      { sessionsDir: mainSessionsDir },
+    );
+
+    expect(resolved).toBe(path.resolve(opsSessionFile));
+  });
+
+  it("uses sibling fallback for custom per-agent store roots", () => {
+    const mainSessionsDir = "/srv/custom/agents/main/sessions";
+    const opsSessionFile = "/srv/custom/agents/ops/sessions/abc-123.jsonl";
+
+    const resolved = resolveSessionFilePath(
+      "sess-1",
+      { sessionFile: opsSessionFile },
+      { sessionsDir: mainSessionsDir, agentId: "ops" },
+    );
+
+    expect(resolved).toBe(path.resolve(opsSessionFile));
+  });
+
+  it("uses extracted agent fallback for custom per-agent store roots", () => {
+    const mainSessionsDir = "/srv/custom/agents/main/sessions";
+    const opsSessionFile = "/srv/custom/agents/ops/sessions/abc-123.jsonl";
+
+    const resolved = resolveSessionFilePath(
+      "sess-1",
+      { sessionFile: opsSessionFile },
+      { sessionsDir: mainSessionsDir },
+    );
+
+    expect(resolved).toBe(path.resolve(opsSessionFile));
+  });
+
+  it("uses agent sessions dir fallback for transcript path", () => {
+    const resolved = resolveSessionTranscriptPath("sess-1", "main");
+    expect(resolved.endsWith(path.join("agents", "main", "sessions", "sess-1.jsonl"))).toBe(true);
+  });
+
+  it("keeps storePath and agentId when resolving session file options", () => {
+    const opts = resolveSessionFilePathOptions({
+      storePath: "/tmp/custom/agent-store/sessions.json",
+      agentId: "ops",
+    });
+    expect(opts).toEqual({
+      sessionsDir: path.resolve("/tmp/custom/agent-store"),
+      agentId: "ops",
+    });
+  });
+
+  it("keeps custom per-agent store roots when agentId is provided", () => {
+    const opts = resolveSessionFilePathOptions({
+      storePath: "/srv/custom/agents/ops/sessions/sessions.json",
+      agentId: "ops",
+    });
+    expect(opts).toEqual({
+      sessionsDir: path.resolve("/srv/custom/agents/ops/sessions"),
+      agentId: "ops",
+    });
+  });
+
+  it("falls back to agentId when storePath is absent", () => {
+    const opts = resolveSessionFilePathOptions({ agentId: "ops" });
+    expect(opts).toEqual({ agentId: "ops" });
+  });
+
+  // Regression: #16826 — sub-agent sessions must use agentId to resolve correctly
+  it("resolves sub-agent session path when agentId is provided", () => {
+    const resolved = resolveSessionTranscriptPath("sess-42", "research");
+    expect(resolved).toContain(path.join("agents", "research", "sessions", "sess-42.jsonl"));
+  });
+
+  it("resolves main agent session path when agentId is omitted", () => {
+    const resolved = resolveSessionTranscriptPath("sess-42");
+    expect(resolved).toContain(path.join("agents", "main", "sessions", "sess-42.jsonl"));
+  });
+
+  it("sub-agent and main agent resolve to different directories", () => {
+    const mainPath = resolveSessionTranscriptPath("sess-42");
+    const subPath = resolveSessionTranscriptPath("sess-42", "research");
+    expect(mainPath).not.toBe(subPath);
+    expect(mainPath).toContain(path.join("agents", "main"));
+    expect(subPath).toContain(path.join("agents", "research"));
+  });
+
+  it("resolveSessionFilePath with agentId resolves to sub-agent dir", () => {
+    const mainSessionsDir = path.dirname(resolveStorePath(undefined, { agentId: "main" }));
+    const subSessionsDir = path.dirname(resolveStorePath(undefined, { agentId: "research" }));
+    const subSessionFile = path.join(subSessionsDir, "sess-42.jsonl");
+
+    // With agentId, resolves correctly even when sessionsDir points to main agent
+    const resolved = resolveSessionFilePath(
+      "sess-42",
+      { sessionFile: subSessionFile },
+      { sessionsDir: mainSessionsDir, agentId: "research" },
+    );
+    expect(resolved).toBe(path.resolve(subSessionFile));
+  });
+});


### PR DESCRIPTION
## Summary
- Adds regression tests for `resolveSessionFilePath` covering sub-agent scenarios where `agentId` is required
- Verifies main agent and sub-agent paths are distinct and correctly resolved
- The underlying code fix was already applied; these tests prevent regressions

Relates to #16826, #16278

## Test plan
- [x] Tests verify main vs sub-agent paths differ
- [x] Tests verify agentId is properly incorporated into resolved paths
- [x] Full test suite passes (`pnpm test:fast`, `pnpm check`)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added four regression tests for `resolveSessionFilePath` covering sub-agent session path resolution scenarios. Tests verify that main agent sessions default to `agents/main/sessions/` while sub-agent sessions correctly resolve to `agents/{agentId}/sessions/` when `agentId` is provided. The underlying fix was already applied in cab0abf5; these tests prevent future regressions.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Pure test addition covering regression scenarios. Tests are well-structured, follow existing patterns, and correctly verify the distinction between main and sub-agent session path resolution. No production code changes.
- No files require special attention

<sub>Last reviewed commit: 52989f8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->