### PR TITLE
fix: strip tool_use blocks from aborted/errored assistant messages

### DIFF
--- a/src/agents/session-transcript-repair.e2e.test.ts
+++ b/src/agents/session-transcript-repair.e2e.test.ts
@@ -114,10 +114,11 @@ describe("sanitizeToolUseResultPairing", () => {
     expect(out.map((m) => m.role)).toEqual(["user", "assistant"]);
   });
 
-  it("skips tool call extraction for assistant messages with stopReason 'error'", () => {
+  it("strips tool_use blocks from assistant messages with stopReason 'error'", () => {
     // When an assistant message has stopReason: "error", its tool_use blocks may be
-    // incomplete/malformed. We should NOT create synthetic tool_results for them,
-    // as this causes API 400 errors: "unexpected tool_use_id found in tool_result blocks"
+    // incomplete/malformed. They are stripped to prevent API 400 errors like
+    // "unexpected tool_use_id found in tool_result blocks" (#4597, #16823).
+    // If no content remains after stripping, the message is dropped entirely.
     const input = [
       {
         role: "assistant",
@@ -131,15 +132,15 @@ describe("sanitizeToolUseResultPairing", () => {
 
     // Should NOT add synthetic tool results for errored messages
     expect(result.added).toHaveLength(0);
-    // The assistant message should be passed through unchanged
-    expect(result.messages[0]?.role).toBe("assistant");
-    expect(result.messages[1]?.role).toBe("user");
-    expect(result.messages).toHaveLength(2);
+    // The assistant message had only tool_use content, so it's dropped
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0]?.role).toBe("user");
   });
 
-  it("skips tool call extraction for assistant messages with stopReason 'aborted'", () => {
+  it("strips tool_use blocks from assistant messages with stopReason 'aborted'", () => {
     // When a request is aborted mid-stream, the assistant message may have incomplete
-    // tool_use blocks (with partialJson). We should NOT create synthetic tool_results.
+    // tool_use blocks (with partialJson). These are stripped, and if no content remains,
+    // the entire message is dropped.
     const input = [
       {
         role: "assistant",
@@ -153,10 +154,9 @@ describe("sanitizeToolUseResultPairing", () => {
 
     // Should NOT add synthetic tool results for aborted messages
     expect(result.added).toHaveLength(0);
-    // Messages should be passed through without synthetic insertions
-    expect(result.messages).toHaveLength(2);
-    expect(result.messages[0]?.role).toBe("assistant");
-    expect(result.messages[1]?.role).toBe("user");
+    // The assistant message had only tool_use content, so it's dropped
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0]?.role).toBe("user");
   });
 
   it("still repairs tool results for normal assistant messages with stopReason 'toolUse'", () => {
@@ -199,11 +199,11 @@ describe("sanitizeToolUseResultPairing", () => {
 
     const result = repairToolUseResultPairing(input);
 
-    // The orphan tool result should be dropped
+    // The orphan tool result should be dropped, and the aborted assistant message
+    // (which only contained tool_use blocks) is also dropped
     expect(result.droppedOrphanCount).toBe(1);
-    expect(result.messages).toHaveLength(2);
-    expect(result.messages[0]?.role).toBe("assistant");
-    expect(result.messages[1]?.role).toBe("user");
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0]?.role).toBe("user");
     // No synthetic results should be added
     expect(result.added).toHaveLength(0);
   });

--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -7,7 +7,7 @@ function assistantToolCall(id: string, opts?: { stopReason?: string }): AgentMes
     role: "assistant",
     content: [{ type: "toolCall", id, name: "exec", arguments: { command: "ls" } }],
     stopReason: opts?.stopReason,
-  } as AgentMessage;
+  } as unknown as AgentMessage;
 }
 
 function toolResult(id: string): AgentMessage {
@@ -16,14 +16,14 @@ function toolResult(id: string): AgentMessage {
     toolCallId: id,
     toolName: "exec",
     content: [{ type: "text", text: "result" }],
-  } as AgentMessage;
+  } as unknown as AgentMessage;
 }
 
 function textAssistant(text: string): AgentMessage {
   return {
     role: "assistant",
     content: [{ type: "text", text }],
-  } as AgentMessage;
+  } as unknown as AgentMessage;
 }
 
 describe("repairToolUseResultPairing — aborted message tool_use stripping (#16823)", () => {
@@ -89,7 +89,7 @@ describe("repairToolUseResultPairing — aborted message tool_use stripping (#16
         { type: "toolCall", id: "call_1", name: "exec", arguments: {} },
       ],
       stopReason: "aborted",
-    } as AgentMessage;
+    } as unknown as AgentMessage;
     const messages: AgentMessage[] = [abortedMsg, textAssistant("retry")];
     const report = repairToolUseResultPairing(messages);
     // Should keep the text content from the aborted message

--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -1,0 +1,101 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { describe, expect, it } from "vitest";
+import { repairToolUseResultPairing } from "./session-transcript-repair.js";
+
+function assistantToolCall(id: string, opts?: { stopReason?: string }): AgentMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "toolCall", id, name: "exec", arguments: { command: "ls" } }],
+    stopReason: opts?.stopReason,
+  } as AgentMessage;
+}
+
+function toolResult(id: string): AgentMessage {
+  return {
+    role: "toolResult",
+    toolCallId: id,
+    toolName: "exec",
+    content: [{ type: "text", text: "result" }],
+  } as AgentMessage;
+}
+
+function textAssistant(text: string): AgentMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text }],
+  } as AgentMessage;
+}
+
+describe("repairToolUseResultPairing — aborted message tool_use stripping (#16823)", () => {
+  it("strips tool_use blocks from aborted assistant messages", () => {
+    const messages: AgentMessage[] = [
+      assistantToolCall("call_1", { stopReason: "aborted" }),
+      textAssistant("follow-up"),
+    ];
+    const report = repairToolUseResultPairing(messages);
+    // The aborted message's tool_use should be stripped
+    const roles = report.messages.map((m) => m.role);
+    expect(roles).not.toContain("toolResult"); // no synthetic results
+    // The aborted assistant message should either be gone or have no tool_use
+    for (const msg of report.messages) {
+      if (msg.role === "assistant" && Array.isArray(msg.content)) {
+        const hasToolCall = msg.content.some(
+          (b: unknown) =>
+            b &&
+            typeof b === "object" &&
+            ((b as { type?: string }).type === "toolCall" ||
+              (b as { type?: string }).type === "toolUse"),
+        );
+        if ((msg as { stopReason?: string }).stopReason === "aborted") {
+          expect(hasToolCall).toBe(false);
+        }
+      }
+    }
+  });
+
+  it("strips tool_use blocks from errored assistant messages", () => {
+    const messages: AgentMessage[] = [
+      assistantToolCall("call_1", { stopReason: "error" }),
+      textAssistant("recovery"),
+    ];
+    const report = repairToolUseResultPairing(messages);
+    const roles = report.messages.map((m) => m.role);
+    expect(roles).not.toContain("toolResult");
+  });
+
+  it("preserves normal assistant tool_use/result pairing", () => {
+    const messages: AgentMessage[] = [
+      assistantToolCall("call_1"),
+      toolResult("call_1"),
+      textAssistant("done"),
+    ];
+    const report = repairToolUseResultPairing(messages);
+    expect(report.messages.map((m) => m.role)).toEqual(["assistant", "toolResult", "assistant"]);
+    expect(report.added).toHaveLength(0);
+  });
+
+  it("inserts synthetic result for normal missing tool_result", () => {
+    const messages: AgentMessage[] = [assistantToolCall("call_1"), textAssistant("next")];
+    const report = repairToolUseResultPairing(messages);
+    expect(report.added).toHaveLength(1);
+    expect(report.messages.map((m) => m.role)).toEqual(["assistant", "toolResult", "assistant"]);
+  });
+
+  it("keeps aborted message text content when stripping tool_use", () => {
+    const abortedMsg = {
+      role: "assistant",
+      content: [
+        { type: "text", text: "starting..." },
+        { type: "toolCall", id: "call_1", name: "exec", arguments: {} },
+      ],
+      stopReason: "aborted",
+    } as AgentMessage;
+    const messages: AgentMessage[] = [abortedMsg, textAssistant("retry")];
+    const report = repairToolUseResultPairing(messages);
+    // Should keep the text content from the aborted message
+    const firstMsg = report.messages[0] as { content?: Array<{ type: string; text?: string }> };
+    expect(firstMsg.content).toHaveLength(1);
+    expect(firstMsg.content?.[0].type).toBe("text");
+    expect(firstMsg.content?.[0].text).toBe("starting...");
+  });
+});


### PR DESCRIPTION
## Summary
- When an assistant message has `stopReason` of "error" or "aborted", its `tool_use` blocks may be incomplete (e.g., `partialJson: true`)
- Previously these blocks were left intact, causing API 400 errors like "unexpected tool_use_id found in tool_result blocks"
- Now strips tool_use blocks from these messages during transcript repair, keeping any text content
- Drops the message entirely if no content remains after stripping

Fixes #16823

## Test plan
- [x] Test aborted messages have tool_use blocks stripped
- [x] Test errored messages have tool_use blocks stripped  
- [x] Test normal tool_use/result pairing preserved
- [x] Test text content retained when tool_use stripped from mixed messages
- [x] Test synthetic results still inserted for normal missing results
- [x] Full test suite passes (`pnpm test:fast`, `pnpm check`)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR strips `tool_use` blocks from assistant messages that have `stopReason` of `"error"` or `"aborted"` during transcript repair, preventing API 400 errors caused by incomplete/partial tool call blocks. If no content remains after stripping, the message is dropped entirely. The filtering logic is correct and the new unit tests cover the main scenarios well.

- **Breaking existing tests**: The existing e2e tests in `session-transcript-repair.e2e.test.ts` (lines 117-160, 180-209) were not updated. These tests assert that errored/aborted assistant messages are preserved intact with 2 messages in output, but the new behavior drops the assistant message when it contains only tool_use blocks, reducing the output to 1 message. These tests will fail.
- **New test file**: `session-transcript-repair.test.ts` adds good coverage for the new stripping logic, including mixed-content retention and synthetic result behavior.

<h3>Confidence Score: 2/5</h3>

- This PR will break existing e2e tests that were not updated to reflect the behavioral change.
- The implementation logic is correct, but existing e2e tests in `session-transcript-repair.e2e.test.ts` (lines 117-160, 180-209) assert the old behavior where errored/aborted assistant messages are preserved intact. The new stripping behavior drops these messages when they contain only tool_use blocks, which will cause at least 3 existing test assertions to fail. The PR description claims "Full test suite passes" but the e2e test file was not updated.
- `src/agents/session-transcript-repair.e2e.test.ts` needs to be updated to match the new behavior. Pay attention to the tests at lines 117-138, 140-160, and 180-209.

<sub>Last reviewed commit: dbaae16</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->