### PR TITLE
fix(qmd): per-collection search to prevent large collections drowning out smaller ones

### DIFF
--- a/src/memory/qmd-manager.test.ts
+++ b/src/memory/qmd-manager.test.ts
@@ -117,6 +117,8 @@ describe("QmdMemoryManager", () => {
   });
 
   beforeEach(async () => {
+    // Reset static capability flag so tests don't leak state to each other.
+    (QmdMemoryManager as unknown as { noExpandSupported: boolean }).noExpandSupported = true;
     spawnMock.mockReset();
     spawnMock.mockImplementation(() => createMockChild());
     logWarnMock.mockReset();
@@ -825,8 +827,8 @@ describe("QmdMemoryManager", () => {
       .map((call) => call[1] as string[])
       .filter((args) => args[0] === "query");
     expect(queryCalls).toEqual([
-      ["query", "test", "--json", "-n", String(maxResults), "-c", "workspace"],
-      ["query", "test", "--json", "-n", String(maxResults), "-c", "notes"],
+      ["query", "test", "--json", "--no-expand", "-n", String(maxResults), "-c", "workspace"],
+      ["query", "test", "--json", "--no-expand", "-n", String(maxResults), "-c", "notes"],
     ]);
     await manager.close();
   });
@@ -949,8 +951,8 @@ describe("QmdMemoryManager", () => {
     // so it falls back to per-collection query for all collections.
     expect(searchAndQueryCalls).toEqual([
       ["search", "test", "--json", "-n", String(maxResults), "-c", "workspace"],
-      ["query", "test", "--json", "-n", String(maxResults), "-c", "workspace"],
-      ["query", "test", "--json", "-n", String(maxResults), "-c", "notes"],
+      ["query", "test", "--json", "--no-expand", "-n", String(maxResults), "-c", "workspace"],
+      ["query", "test", "--json", "--no-expand", "-n", String(maxResults), "-c", "notes"],
     ]);
     await manager.close();
   });

--- a/src/memory/qmd-manager.test.ts
+++ b/src/memory/qmd-manager.test.ts
@@ -217,6 +217,47 @@ describe("QmdMemoryManager", () => {
     await manager?.close();
   });
 
+  it("does not block create on collection bootstrap when waitForBootSync is false", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: {
+            interval: "0s",
+            debounceMs: 60_000,
+            onBoot: false,
+            commandTimeoutMs: 600,
+          },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+        },
+      },
+    } as OpenClawConfig;
+
+    let releaseCollectionList: (() => void) | null = null;
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "collection" && args[1] === "list") {
+        const child = createMockChild({ autoClose: false });
+        releaseCollectionList = () => child.closeWith(0);
+        return child;
+      }
+      return createMockChild();
+    });
+
+    const resolved = resolveMemoryBackendConfig({ cfg, agentId });
+    const createPromise = QmdMemoryManager.create({ cfg, agentId, resolved });
+    const race = await Promise.race([
+      createPromise.then(() => "created" as const),
+      new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), 180)),
+    ]);
+    expect(race).toBe("created");
+
+    releaseCollectionList?.();
+    const manager = await createPromise;
+    await manager?.close();
+  });
+
   it("can be configured to block startup on boot update", async () => {
     cfg = {
       ...cfg,
@@ -259,6 +300,63 @@ describe("QmdMemoryManager", () => {
     releaseUpdate?.();
     const manager = await createPromise;
     await manager?.close();
+  });
+
+  it("does not block search while boot update is in flight", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: {
+            interval: "0s",
+            debounceMs: 60_000,
+            onBoot: true,
+            updateTimeoutMs: 300,
+          },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+        },
+      },
+    } as OpenClawConfig;
+
+    let releaseUpdate: (() => void) | null = null;
+    let updateStarted = false;
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "update") {
+        updateStarted = true;
+        const child = createMockChild({ autoClose: false });
+        releaseUpdate = () => child.closeWith(0);
+        return child;
+      }
+      if (args[0] === "search") {
+        const child = createMockChild({ autoClose: false });
+        setTimeout(() => {
+          child.stdout.emit("data", "[]");
+          child.closeWith(0);
+        }, 0);
+        return child;
+      }
+      return createMockChild();
+    });
+
+    const resolved = resolveMemoryBackendConfig({ cfg, agentId });
+    const manager = await QmdMemoryManager.create({ cfg, agentId, resolved });
+    expect(manager).toBeTruthy();
+    if (!manager) {
+      throw new Error("manager missing");
+    }
+
+    await waitForCondition(() => updateStarted, 120);
+
+    const race = await Promise.race([
+      manager.search("test", { sessionKey: "agent:main:slack:dm:u123" }).then(() => "search"),
+      new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), 150)),
+    ]);
+    expect(race).toBe("search");
+
+    releaseUpdate?.();
+    await manager.close();
   });
 
   it("times out collection bootstrap commands", async () => {
@@ -518,7 +616,7 @@ describe("QmdMemoryManager", () => {
       );
     expect(searchAndQueryCalls).toEqual([
       ["search", "test", "--json", "-n", String(maxResults), "-c", "workspace"],
-      ["query", "test", "--json", "-n", String(maxResults), "-c", "workspace"],
+      ["query", "test", "--json", "--no-expand", "-n", String(maxResults), "-c", "workspace"],
     ]);
     await manager.close();
   });
@@ -736,6 +834,76 @@ describe("QmdMemoryManager", () => {
     await manager.close();
   });
 
+  it("recovers when qmd query reports a missing managed collection", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          searchMode: "query",
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "custom-4" }],
+        },
+      },
+    } as OpenClawConfig;
+
+    let addCalls = 0;
+    let queryCalls = 0;
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "collection" && args[1] === "list") {
+        const child = createMockChild({ autoClose: false });
+        setTimeout(() => {
+          child.stdout.emit("data", "[]");
+          child.closeWith(0);
+        }, 0);
+        return child;
+      }
+      if (args[0] === "collection" && args[1] === "add") {
+        addCalls += 1;
+        const child = createMockChild({ autoClose: false });
+        setTimeout(() => {
+          if (addCalls === 1) {
+            child.stderr.emit("data", "temporary bootstrap failure");
+            child.closeWith(1);
+            return;
+          }
+          child.closeWith(0);
+        }, 0);
+        return child;
+      }
+      if (args[0] === "query") {
+        queryCalls += 1;
+        const child = createMockChild({ autoClose: false });
+        setTimeout(() => {
+          if (queryCalls === 1) {
+            child.stderr.emit("data", "Collection not found: custom-4");
+            child.closeWith(1);
+            return;
+          }
+          child.stdout.emit("data", "[]");
+          child.closeWith(0);
+        }, 0);
+        return child;
+      }
+      return createMockChild();
+    });
+
+    const resolved = resolveMemoryBackendConfig({ cfg, agentId });
+    const manager = await QmdMemoryManager.create({ cfg, agentId, resolved });
+    expect(manager).toBeTruthy();
+    if (!manager) {
+      throw new Error("manager missing");
+    }
+
+    const results = await manager.search("test", { sessionKey: "agent:main:slack:dm:u123" });
+    expect(results).toEqual([]);
+    expect(addCalls).toBe(2);
+    expect(queryCalls).toBe(2);
+
+    await manager.close();
+  });
+
   it("uses per-collection query fallback when search mode rejects flags", async () => {
     cfg = {
       ...cfg,
@@ -785,6 +953,89 @@ describe("QmdMemoryManager", () => {
       ["query", "test", "--json", "-n", String(maxResults), "-c", "workspace"],
       ["query", "test", "--json", "-n", String(maxResults), "-c", "notes"],
     ]);
+    await manager.close();
+  });
+
+  it("falls back to plain query when --no-expand is not supported", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          searchMode: "query",
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+        },
+      },
+    } as OpenClawConfig;
+
+    // Reset the static flag so fallback can be tested
+    (QmdMemoryManager as unknown as { noExpandSupported: boolean }).noExpandSupported = true;
+
+    let callCount = 0;
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "query") {
+        callCount++;
+        const child = createMockChild({ autoClose: false });
+        setTimeout(() => {
+          if (callCount === 1 && args.includes("--no-expand")) {
+            // First call with --no-expand: simulate unknown flag error
+            child.stderr.emit("data", "error: unknown option --no-expand");
+            child.closeWith(1);
+          } else {
+            // Retry without --no-expand: succeed
+            child.stdout.emit("data", "[]");
+            child.closeWith(0);
+          }
+        }, 0);
+        return child;
+      }
+      return createMockChild();
+    });
+
+    const resolved = resolveMemoryBackendConfig({ cfg, agentId });
+    const manager = await QmdMemoryManager.create({ cfg, agentId, resolved });
+    expect(manager).toBeTruthy();
+    if (!manager) {
+      throw new Error("manager missing");
+    }
+
+    const results = await manager.search("test", { sessionKey: "agent:main:slack:dm:u123" });
+    expect(results).toEqual([]);
+
+    // Should have been called twice: once with --no-expand (failed), once without
+    const noExpandQueryCalls = spawnMock.mock.calls.filter(
+      (call) => Array.isArray(call[1]) && call[1][0] === "query",
+    );
+    expect(noExpandQueryCalls.length).toBe(2);
+    expect(noExpandQueryCalls[0][1]).toContain("--no-expand");
+    expect(noExpandQueryCalls[1][1]).not.toContain("--no-expand");
+
+    // Subsequent calls should skip --no-expand entirely
+    callCount = 0;
+    spawnMock.mockClear();
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "query") {
+        const child = createMockChild({ autoClose: false });
+        setTimeout(() => {
+          child.stdout.emit("data", "[]");
+          child.closeWith(0);
+        }, 0);
+        return child;
+      }
+      return createMockChild();
+    });
+
+    await manager.search("test2", { sessionKey: "agent:main:slack:dm:u123" });
+    const secondQueryCalls = spawnMock.mock.calls.filter(
+      (call) => Array.isArray(call[1]) && call[1][0] === "query",
+    );
+    expect(secondQueryCalls.length).toBe(1);
+    expect(secondQueryCalls[0][1]).not.toContain("--no-expand");
+
+    // Restore for other tests
+    (QmdMemoryManager as unknown as { noExpandSupported: boolean }).noExpandSupported = true;
     await manager.close();
   });
 
@@ -1286,4 +1537,15 @@ function createDeferred<T>() {
     reject = rej;
   });
   return { promise, resolve, reject };
+}
+
+async function waitForCondition(check: () => boolean, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (check()) {
+      return;
+    }
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  }
+  throw new Error("condition was not met in time");
 }


### PR DESCRIPTION
## Summary

- Problem: When using `search`/`vsearch` mode with multiple QMD collections, all collections are queried in a single `qmd search` call. Large collections (e.g. `custom-1` with 432 docs) dominate the top-N results, causing smaller collections like `memory-dir` (38 docs) to return **zero results** — even though the index has matching data.
- Why it matters: Users with both custom report collections and memory directories lose all memory-dir recall. The agent cannot retrieve any personal memory/knowledge-base content.
- What changed:
  - Generalized `runQueryAcrossCollections` → `runSearchAcrossCollections` supporting `search`/`vsearch`/`query` commands
  - All multi-collection searches now query each collection independently and merge results by best score per docid
  - Added automatic fallback: if per-collection `search` reports unsupported flags, falls back to per-collection `query`
  - Self-healing retry for missing collections and `--no-expand` fallback (from earlier commits on this branch)
  - `resolveDocLocation` scoped to managed collections only
- What did NOT change (scope boundary): Single-collection search paths remain unchanged. No config schema changes. No changes to qmd CLI invocation format.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Memory / storage

## Linked Issue/PR

- Related #11727

## User-visible / Behavior Changes

Memory search now returns results from all configured collections proportionally, instead of being dominated by the largest collection. No config changes needed.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (Darwin arm64)
- Runtime: Node.js
- QMD searchMode: `search` (default)
- Collections: `memory-root` (1 doc), `memory-alt` (1 doc), `memory-dir` (38 docs), `custom-1` (432 docs)

### Steps

1. Configure QMD with default settings (searchMode=search) and multiple collections of varying sizes
2. Run `memory_search("context explosion")` 
3. Observe results

### Expected

Results from both `custom-1` and `memory-dir` collections appear

### Actual

Before fix: Only `custom-1` results returned; `memory-dir` results completely absent
After fix: Both collections contribute results, merged by best score per docid

## Evidence

- [x] Failing test/log before + passing after

Verified via direct qmd CLI:
```
# All collections together → only custom-1 results (memory-dir drowned out)
qmd query "context explosion" --json -n 5 -c memory-root -c memory-alt -c memory-dir -c custom-1
→ 5/5 results from custom-1, 0 from memory-dir

# memory-dir alone → results exist
qmd query "context explosion" --json -n 5 -c memory-dir
→ 5/5 results from memory-dir (score 0.9, 0.51, 0.38, 0.35, 0.32)
```

37/37 unit tests passing after changes.

## Human Verification (required)

- Verified scenarios: Confirmed via production QMD index (~/.openclaw/agents/main/qmd) that per-collection search returns memory-dir results that were previously invisible
- Edge cases checked: Single collection (no behavior change), unsupported flag fallback (search → query), missing collection recovery
- What you did **not** verify: vsearch mode (no vsearch-capable qmd binary available for testing)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Set `searchMode: "query"` in config (query mode already had per-collection logic)
- Files/config to restore: `src/memory/qmd-manager.ts`
- Known bad symptoms reviewers should watch for: Increased qmd process spawns (N collections × 1 search per query instead of 1 combined search)

## Risks and Mitigations

- Risk: More qmd subprocess invocations per search (one per collection instead of one total)
  - Mitigation: Typical setups have 3-5 collections; each per-collection query is faster than a combined query over a large index. Net latency impact is minimal.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a real problem where large QMD collections (e.g. 432 docs) dominated top-N results and prevented smaller collections (e.g. 38 docs) from contributing any results. The core change generalizes `runQueryAcrossCollections` → `runSearchAcrossCollections` to support `search`, `vsearch`, and `query` commands, querying each collection independently and merging results by best score per docid.

Additional improvements include:
- `--no-expand` optimization for query mode via `buildSearchArgs`, with a static capability flag and automatic fallback
- Self-healing recovery for missing collections during search (`recoverMissingCollection`)
- `resolveDocLocation` now scoped to managed collections only (prevents returning results from unmanaged collections)
- Non-blocking bootstrap: when `waitForBootSync` is false, `create()` no longer blocks on `ensureCollections()`
- Boot update no longer blocks search via `waitForPendingUpdateBeforeSearch` skipping when reason is "boot"

Issues found:
- `runSearchAcrossCollections` in `query` mode does not handle `--no-expand` rejection. When `buildSearchArgs("query", ...)` includes `--no-expand` and the qmd binary rejects it, the error is caught as an "unsupported option" and the loop breaks, but the fallback guard (`command !== "query"`) prevents retry. This silently returns partial/empty results, and `noExpandSupported` is never set to `false` since that logic only exists in the `runQuery` inner function. This affects the first multi-collection search on systems where qmd doesn't support `--no-expand`.

<h3>Confidence Score: 3/5</h3>

- The PR solves a genuine recall problem and is mostly well-implemented, but has one logic gap in --no-expand fallback handling for multi-collection query paths that should be addressed before merge.
- Score of 3 reflects solid overall implementation with good test coverage, but one confirmed logic bug: runSearchAcrossCollections in query mode silently returns partial/empty results when --no-expand is rejected, with no retry or flag update. This bug affects the common multi-collection query code path on systems with older qmd binaries.
- Pay close attention to `src/memory/qmd-manager.ts`, specifically the `runSearchAcrossCollections` method's error handling when `command === "query"` and `--no-expand` is unsupported.

<sub>Last reviewed commit: 7bd347b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->