### PR TITLE
fix(telegram): apply follow-up transcript substitution from #16789

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 - Agents: return an explicit timeout error reply when an embedded run times out before producing any payloads, preventing silent dropped turns during slow cache-refresh transitions. (#16659) Thanks @liaosvcaf and @vignesh07.
 - Agents/OpenAI: force `store=true` for direct OpenAI Responses/Codex runs to preserve multi-turn server-side conversation state, while leaving proxy/non-OpenAI endpoints unchanged. (#16803) Thanks @mark9232 and @vignesh07.
 - CLI/Build: make legacy daemon CLI compatibility shim generation tolerant of minimal tsdown daemon export sets, while preserving restart/register compatibility aliases and surfacing explicit errors for unavailable legacy daemon commands. Thanks @vignesh07.
+- Telegram: replace inbound `<media:audio>` placeholder with successful preflight voice transcript in message body context, preventing placeholder-only prompt bodies for mention-gated voice messages. (#16789) Thanks @Limitless2023.
 
 ## 2026.2.14
 

--- a/src/telegram/bot-message-context.audio-transcript.test.ts
+++ b/src/telegram/bot-message-context.audio-transcript.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildTelegramMessageContext } from "./bot-message-context.js";
+
+const transcribeFirstAudioMock = vi.fn();
+
+vi.mock("../media-understanding/audio-preflight.js", () => ({
+  transcribeFirstAudio: (...args: unknown[]) => transcribeFirstAudioMock(...args),
+}));
+
+describe("buildTelegramMessageContext audio transcript body", () => {
+  it("uses preflight transcript as BodyForAgent for mention-gated group voice messages", async () => {
+    transcribeFirstAudioMock.mockResolvedValueOnce("hey bot please help");
+
+    const ctx = await buildTelegramMessageContext({
+      primaryCtx: {
+        message: {
+          message_id: 1,
+          chat: { id: -1001234567890, type: "supergroup", title: "Test Group" },
+          date: 1700000000,
+          from: { id: 42, first_name: "Alice" },
+          voice: { file_id: "voice-1" },
+        },
+        me: { id: 7, username: "bot" },
+      } as never,
+      allMedia: [{ path: "/tmp/voice.ogg", contentType: "audio/ogg" }],
+      storeAllowFrom: [],
+      options: { forceWasMentioned: true },
+      bot: {
+        api: {
+          sendChatAction: vi.fn(),
+          setMessageReaction: vi.fn(),
+        },
+      } as never,
+      cfg: {
+        agents: { defaults: { model: "anthropic/claude-opus-4-5", workspace: "/tmp/openclaw" } },
+        channels: { telegram: {} },
+        messages: { groupChat: { mentionPatterns: ["\\bbot\\b"] } },
+      } as never,
+      account: { accountId: "default" } as never,
+      historyLimit: 0,
+      groupHistories: new Map(),
+      dmPolicy: "open",
+      allowFrom: [],
+      groupAllowFrom: [],
+      ackReactionScope: "off",
+      logger: { info: vi.fn() },
+      resolveGroupActivation: () => true,
+      resolveGroupRequireMention: () => true,
+      resolveTelegramGroupConfig: () => ({
+        groupConfig: { requireMention: true },
+        topicConfig: undefined,
+      }),
+    });
+
+    expect(ctx).not.toBeNull();
+    expect(transcribeFirstAudioMock).toHaveBeenCalledTimes(1);
+    expect(ctx?.ctxPayload?.BodyForAgent).toBe("hey bot please help");
+    expect(ctx?.ctxPayload?.Body).toContain("hey bot please help");
+    expect(ctx?.ctxPayload?.Body).not.toContain("<media:audio>");
+  });
+});

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -425,7 +425,12 @@ export const buildTelegramMessageContext = async ({
     }
   }
 
-  // Build bodyText - if there's audio with transcript, use transcript; otherwise use placeholder
+  // Replace audio placeholder with transcript when preflight succeeds.
+  if (hasAudio && bodyText === "<media:audio>" && preflightTranscript) {
+    bodyText = preflightTranscript;
+  }
+
+  // Build bodyText fallback for messages that still have no text.
   if (!bodyText && allMedia.length > 0) {
     if (hasAudio) {
       bodyText = preflightTranscript || "<media:audio>";


### PR DESCRIPTION
## Summary
- recover follow-up fix that was accidentally not included in merged PR #16789
- replace `<media:audio>` placeholder with preflight transcript when transcript exists
- add regression test for mention-gated group voice input to ensure `BodyForAgent` uses transcript
- add changelog entry

## Validation
- pnpm vitest run src/telegram/bot-message-context.audio-transcript.test.ts src/telegram/bot-message-context.dm-threads.test.ts

## Context
PR #16789 merged commit `b65b3c6` only. Follow-up commit `2dfd427` did not land; this PR reapplies that exact change on top of `main`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Applies follow-up fix from PR #16789 that substitutes preflight voice transcript into message body for mention-gated group audio messages. The original PR merged only the first commit which moved preflight transcription logic earlier, but didn't include the substitution logic that replaces the `<media:audio>` placeholder with the actual transcript text. This prevents agents from receiving placeholder-only prompts when processing voice messages in groups that require mentions.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Small, focused fix that applies a missing piece of logic from a previously reviewed PR. The change is well-tested with a regression test that validates the exact scenario, has clear documentation in the changelog, and follows the existing code patterns. The logic is straightforward: substitute the placeholder with the actual transcript when available.
- No files require special attention

<sub>Last reviewed commit: e03ea88</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->