### PR TITLE
fix(heartbeat): strip HEARTBEAT_OK from streaming path for heartbeat runs

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -110,7 +110,7 @@ export async function runAgentTurnWithFallback(params: {
           return { skip: true };
         }
         let text = payload.text;
-        if (!params.isHeartbeat && text?.includes("HEARTBEAT_OK")) {
+        if (text?.includes("HEARTBEAT_OK")) {
           const stripped = stripHeartbeatToken(text, {
             mode: "message",
           });


### PR DESCRIPTION
Fixes #16974

## Problem

When `showOk: false` is configured, `HEARTBEAT_OK` responses still leak to the channel as visible messages. This happens because `normalizeStreamingText` in `agent-runner-execution.ts` explicitly skips HEARTBEAT_OK stripping for heartbeat runs (`isHeartbeat=true`):

```ts
if (!params.isHeartbeat && text?.includes("HEARTBEAT_OK")) {
```

The streaming delivery sends the raw token to the channel **before** the final `maybeSendHeartbeatOk` suppression logic runs in `heartbeat-runner.ts`.

## Fix

Remove the `!params.isHeartbeat` guard so `HEARTBEAT_OK` is stripped from the streaming path unconditionally. The final heartbeat delivery path still correctly handles `showOk` for non-streaming delivery.

## Change

One-line change in `src/auto-reply/reply/agent-runner-execution.ts`:
```diff
- if (!params.isHeartbeat && text?.includes("HEARTBEAT_OK")) {
+ if (text?.includes("HEARTBEAT_OK")) {
```

## Testing

- All 39 heartbeat-related tests pass
- `pnpm build && pnpm check` clean

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a bug where `HEARTBEAT_OK` tokens leaked into the streaming channel as visible messages when `showOk: false` was configured. The root cause was a `!params.isHeartbeat` guard in `normalizeStreamingText` that paradoxically skipped `HEARTBEAT_OK` stripping for heartbeat runs — the exact scenario where stripping is most needed. The streaming path would deliver the raw token to the channel before the final `maybeSendHeartbeatOk` suppression logic in `heartbeat-runner.ts` could run.

- **Fix**: Removed the `!params.isHeartbeat` condition so `HEARTBEAT_OK` is stripped from the streaming path unconditionally. The final heartbeat delivery path still correctly handles `showOk` visibility for non-streaming delivery.
- **Scope**: Single-line change in `src/auto-reply/reply/agent-runner-execution.ts`; no behavioral side effects — the `stripHeartbeatToken` function with `mode: "message"` already correctly preserves any meaningful text around the token.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a minimal, well-scoped bug fix with no risk of regression.
- The change is a single-line removal of an incorrect guard condition. The stripping logic (`stripHeartbeatToken` with `mode: "message"`) was already battle-tested for non-heartbeat runs and behaves identically for heartbeat runs. The `isHeartbeat` parameter remains used elsewhere (for `registerAgentRunContext`), so no unused code is introduced. The fix aligns the streaming path with the intended behavior of the final delivery path in `heartbeat-runner.ts`.
- No files require special attention

<sub>Last reviewed commit: 585f468</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->