### PR TITLE
channels: deduplicate probe and token resolution types with shared base types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Docs: https://docs.openclaw.ai
 - Subagents: nested sub-agents (sub-sub-agents) with configurable depth. Set `agents.defaults.subagents.maxSpawnDepth: 2` to allow sub-agents to spawn their own children. Includes `maxChildrenPerAgent` limit (default 5), depth-aware tool policy, and proper announce chain routing. (#14447) Thanks @tyler6204.
 - Discord: components v2 UI + embeds passthrough + exec approval UX refinements (CV2 containers, button layout, Discord-forwarding skip). Thanks @thewilloftheshadow.
 - Slack/Discord/Telegram: add per-channel ack reaction overrides (account/channel-level) to support platform-specific emoji formats. (#17092) Thanks @zerone0x.
+- Channels: deduplicate probe/token resolution base types across core + extensions while preserving per-channel error typing. (#16986) Thanks @iyoda and @thewilloftheshadow.
 
 ### Fixes
 

--- a/extensions/bluebubbles/src/probe.ts
+++ b/extensions/bluebubbles/src/probe.ts
@@ -1,9 +1,8 @@
+import type { BaseProbeResult } from "openclaw/plugin-sdk";
 import { buildBlueBubblesApiUrl, blueBubblesFetchWithTimeout } from "./types.js";
 
-export type BlueBubblesProbe = {
-  ok: boolean;
+export type BlueBubblesProbe = BaseProbeResult & {
   status?: number | null;
-  error?: string | null;
 };
 
 export type BlueBubblesServerInfo = {

--- a/extensions/feishu/src/types.ts
+++ b/extensions/feishu/src/types.ts
@@ -1,3 +1,4 @@
+import type { BaseProbeResult } from "openclaw/plugin-sdk";
 import type {
   FeishuConfigSchema,
   FeishuGroupSchema,
@@ -52,9 +53,7 @@ export type FeishuSendResult = {
   chatId: string;
 };
 
-export type FeishuProbeResult = {
-  ok: boolean;
-  error?: string;
+export type FeishuProbeResult = BaseProbeResult<string> & {
   appId?: string;
   botName?: string;
   botOpenId?: string;

--- a/extensions/irc/src/types.ts
+++ b/extensions/irc/src/types.ts
@@ -1,3 +1,4 @@
+import type { BaseProbeResult } from "openclaw/plugin-sdk";
 import type {
   BlockStreamingCoalesceConfig,
   DmConfig,
@@ -83,12 +84,10 @@ export type IrcInboundMessage = {
   isGroup: boolean;
 };
 
-export type IrcProbe = {
-  ok: boolean;
+export type IrcProbe = BaseProbeResult<string> & {
   host: string;
   port: number;
   tls: boolean;
   nick: string;
   latencyMs?: number;
-  error?: string;
 };

--- a/extensions/matrix/src/matrix/probe.ts
+++ b/extensions/matrix/src/matrix/probe.ts
@@ -1,9 +1,8 @@
+import type { BaseProbeResult } from "openclaw/plugin-sdk";
 import { createMatrixClient, isBunRuntime } from "./client.js";
 
-export type MatrixProbe = {
-  ok: boolean;
+export type MatrixProbe = BaseProbeResult & {
   status?: number | null;
-  error?: string | null;
   elapsedMs: number;
   userId?: string | null;
 };

--- a/extensions/mattermost/src/mattermost/probe.ts
+++ b/extensions/mattermost/src/mattermost/probe.ts
@@ -1,9 +1,8 @@
+import type { BaseProbeResult } from "openclaw/plugin-sdk";
 import { normalizeMattermostBaseUrl, type MattermostUser } from "./client.js";
 
-export type MattermostProbe = {
-  ok: boolean;
+export type MattermostProbe = BaseProbeResult & {
   status?: number | null;
-  error?: string | null;
   elapsedMs?: number | null;
   bot?: MattermostUser;
 };

--- a/extensions/msteams/src/probe.ts
+++ b/extensions/msteams/src/probe.ts
@@ -1,11 +1,9 @@
-import type { MSTeamsConfig } from "openclaw/plugin-sdk";
+import type { BaseProbeResult, MSTeamsConfig } from "openclaw/plugin-sdk";
 import { formatUnknownError } from "./errors.js";
 import { loadMSTeamsSdkWithAuth } from "./sdk.js";
 import { resolveMSTeamsCredentials } from "./token.js";
 
-export type ProbeMSTeamsResult = {
-  ok: boolean;
-  error?: string;
+export type ProbeMSTeamsResult = BaseProbeResult<string> & {
   appId?: string;
   graph?: {
     ok: boolean;

--- a/extensions/twitch/src/probe.ts
+++ b/extensions/twitch/src/probe.ts
@@ -1,3 +1,4 @@
+import type { BaseProbeResult } from "openclaw/plugin-sdk";
 import { StaticAuthProvider } from "@twurple/auth";
 import { ChatClient } from "@twurple/chat";
 import type { TwitchAccountConfig } from "./types.js";
@@ -6,9 +7,7 @@ import { normalizeToken } from "./utils/twitch.js";
 /**
  * Result of probing a Twitch account
  */
-export type ProbeTwitchResult = {
-  ok: boolean;
-  error?: string;
+export type ProbeTwitchResult = BaseProbeResult<string> & {
   username?: string;
   elapsedMs: number;
   connected?: boolean;

--- a/extensions/zalo/src/probe.ts
+++ b/extensions/zalo/src/probe.ts
@@ -1,9 +1,8 @@
+import type { BaseProbeResult } from "openclaw/plugin-sdk";
 import { getMe, ZaloApiError, type ZaloBotInfo, type ZaloFetch } from "./api.js";
 
-export type ZaloProbeResult = {
-  ok: boolean;
+export type ZaloProbeResult = BaseProbeResult<string> & {
   bot?: ZaloBotInfo;
-  error?: string;
   elapsedMs: number;
 };
 

--- a/extensions/zalo/src/token.ts
+++ b/extensions/zalo/src/token.ts
@@ -1,9 +1,8 @@
 import { readFileSync } from "node:fs";
-import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk";
+import { type BaseTokenResolution, DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk";
 import type { ZaloConfig } from "./types.js";
 
-export type ZaloTokenResolution = {
-  token: string;
+export type ZaloTokenResolution = BaseTokenResolution & {
   source: "env" | "config" | "configFile" | "none";
 };
 

--- a/extensions/zalouser/src/probe.ts
+++ b/extensions/zalouser/src/probe.ts
@@ -1,11 +1,10 @@
+import type { BaseProbeResult } from "openclaw/plugin-sdk";
 import type { ZcaUserInfo } from "./types.js";
 import { runZca, parseJsonOutput } from "./zca.js";
 
-export interface ZalouserProbeResult {
-  ok: boolean;
+export type ZalouserProbeResult = BaseProbeResult<string> & {
   user?: ZcaUserInfo;
-  error?: string;
-}
+};
 
 export async function probeZalouser(
   profile: string,

--- a/src/channels/plugins/base-types-assignability.test.ts
+++ b/src/channels/plugins/base-types-assignability.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expectTypeOf } from "vitest";
+import type { DiscordProbe } from "../../discord/probe.js";
+import type { DiscordTokenResolution } from "../../discord/token.js";
+import type { IMessageProbe } from "../../imessage/probe.js";
+import type { LineProbeResult } from "../../line/types.js";
+import type { SignalProbe } from "../../signal/probe.js";
+import type { SlackProbe } from "../../slack/probe.js";
+import type { TelegramProbe } from "../../telegram/probe.js";
+import type { TelegramTokenResolution } from "../../telegram/token.js";
+import type { BaseProbeResult, BaseTokenResolution } from "./types.js";
+
+describe("BaseProbeResult assignability", () => {
+  it("TelegramProbe satisfies BaseProbeResult", () => {
+    expectTypeOf<TelegramProbe>().toMatchTypeOf<BaseProbeResult>();
+  });
+
+  it("DiscordProbe satisfies BaseProbeResult", () => {
+    expectTypeOf<DiscordProbe>().toMatchTypeOf<BaseProbeResult>();
+  });
+
+  it("SlackProbe satisfies BaseProbeResult", () => {
+    expectTypeOf<SlackProbe>().toMatchTypeOf<BaseProbeResult>();
+  });
+
+  it("SignalProbe satisfies BaseProbeResult", () => {
+    expectTypeOf<SignalProbe>().toMatchTypeOf<BaseProbeResult>();
+  });
+
+  it("IMessageProbe satisfies BaseProbeResult", () => {
+    expectTypeOf<IMessageProbe>().toMatchTypeOf<BaseProbeResult>();
+  });
+
+  it("LineProbeResult satisfies BaseProbeResult", () => {
+    expectTypeOf<LineProbeResult>().toMatchTypeOf<BaseProbeResult>();
+  });
+});
+
+describe("BaseTokenResolution assignability", () => {
+  it("TelegramTokenResolution satisfies BaseTokenResolution", () => {
+    expectTypeOf<TelegramTokenResolution>().toMatchTypeOf<BaseTokenResolution>();
+  });
+
+  it("DiscordTokenResolution satisfies BaseTokenResolution", () => {
+    expectTypeOf<DiscordTokenResolution>().toMatchTypeOf<BaseTokenResolution>();
+  });
+});

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -347,3 +347,15 @@ export type ChannelPollContext = {
   silent?: boolean;
   isAnonymous?: boolean;
 };
+
+/** Minimal base for all channel probe results. Channel-specific probes extend this. */
+export type BaseProbeResult<TError = string | null> = {
+  ok: boolean;
+  error?: TError;
+};
+
+/** Minimal base for token resolution results. */
+export type BaseTokenResolution = {
+  token: string;
+  source: string;
+};

--- a/src/channels/plugins/types.ts
+++ b/src/channels/plugins/types.ts
@@ -58,6 +58,8 @@ export type {
   ChannelThreadingContext,
   ChannelThreadingToolContext,
   ChannelToolSend,
+  BaseProbeResult,
+  BaseTokenResolution,
 } from "./types.core.js";
 
 export type { ChannelPlugin } from "./types.plugin.js";

--- a/src/discord/probe.ts
+++ b/src/discord/probe.ts
@@ -1,13 +1,12 @@
+import type { BaseProbeResult } from "../channels/plugins/types.js";
 import { resolveFetch } from "../infra/fetch.js";
 import { fetchWithTimeout } from "../utils/fetch-timeout.js";
 import { normalizeDiscordToken } from "./token.js";
 
 const DISCORD_API_BASE = "https://discord.com/api/v10";
 
-export type DiscordProbe = {
-  ok: boolean;
+export type DiscordProbe = BaseProbeResult & {
   status?: number | null;
-  error?: string | null;
   elapsedMs: number;
   bot?: { id?: string | null; username?: string | null };
   application?: DiscordApplicationSummary;

--- a/src/discord/token.ts
+++ b/src/discord/token.ts
@@ -1,10 +1,10 @@
+import type { BaseTokenResolution } from "../channels/plugins/types.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../routing/session-key.js";
 
 export type DiscordTokenSource = "env" | "config" | "none";
 
-export type DiscordTokenResolution = {
-  token: string;
+export type DiscordTokenResolution = BaseTokenResolution & {
   source: DiscordTokenSource;
 };
 

--- a/src/imessage/probe.ts
+++ b/src/imessage/probe.ts
@@ -1,3 +1,4 @@
+import type { BaseProbeResult } from "../channels/plugins/types.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { detectBinary } from "../commands/onboard-helpers.js";
 import { loadConfig } from "../config/config.js";
@@ -8,9 +9,7 @@ import { DEFAULT_IMESSAGE_PROBE_TIMEOUT_MS } from "./constants.js";
 // Re-export for backwards compatibility
 export { DEFAULT_IMESSAGE_PROBE_TIMEOUT_MS } from "./constants.js";
 
-export type IMessageProbe = {
-  ok: boolean;
-  error?: string | null;
+export type IMessageProbe = BaseProbeResult & {
   fatal?: boolean;
 };
 

--- a/src/line/types.ts
+++ b/src/line/types.ts
@@ -7,6 +7,7 @@ import type {
   StickerMessage,
   LocationMessage,
 } from "@line/bot-sdk";
+import type { BaseProbeResult } from "../channels/plugins/types.js";
 
 export type LineTokenSource = "config" | "env" | "file" | "none";
 
@@ -86,16 +87,14 @@ export interface LineSendResult {
   chatId: string;
 }
 
-export interface LineProbeResult {
-  ok: boolean;
+export type LineProbeResult = BaseProbeResult<string> & {
   bot?: {
     displayName?: string;
     userId?: string;
     basicId?: string;
     pictureUrl?: string;
   };
-  error?: string;
-}
+};
 
 export type LineFlexMessagePayload = {
   altText: string;

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -56,6 +56,8 @@ export type {
   ChannelThreadingContext,
   ChannelThreadingToolContext,
   ChannelToolSend,
+  BaseProbeResult,
+  BaseTokenResolution,
 } from "../channels/plugins/types.js";
 export type { ChannelConfigSchema, ChannelPlugin } from "../channels/plugins/types.plugin.js";
 export type {

--- a/src/signal/probe.ts
+++ b/src/signal/probe.ts
@@ -1,9 +1,8 @@
+import type { BaseProbeResult } from "../channels/plugins/types.js";
 import { signalCheck, signalRpcRequest } from "./client.js";
 
-export type SignalProbe = {
-  ok: boolean;
+export type SignalProbe = BaseProbeResult & {
   status?: number | null;
-  error?: string | null;
   elapsedMs: number;
   version?: string | null;
 };

--- a/src/slack/probe.ts
+++ b/src/slack/probe.ts
@@ -1,9 +1,8 @@
+import type { BaseProbeResult } from "../channels/plugins/types.js";
 import { createSlackWebClient } from "./client.js";
 
-export type SlackProbe = {
-  ok: boolean;
+export type SlackProbe = BaseProbeResult & {
   status?: number | null;
-  error?: string | null;
   elapsedMs?: number | null;
   bot?: { id?: string; name?: string };
   team?: { id?: string; name?: string };

--- a/src/telegram/probe.ts
+++ b/src/telegram/probe.ts
@@ -1,12 +1,11 @@
+import type { BaseProbeResult } from "../channels/plugins/types.js";
 import { fetchWithTimeout } from "../utils/fetch-timeout.js";
 import { makeProxyFetch } from "./proxy.js";
 
 const TELEGRAM_API_BASE = "https://api.telegram.org";
 
-export type TelegramProbe = {
-  ok: boolean;
+export type TelegramProbe = BaseProbeResult & {
   status?: number | null;
-  error?: string | null;
   elapsedMs: number;
   bot?: {
     id?: number | null;

--- a/src/telegram/token.ts
+++ b/src/telegram/token.ts
@@ -1,12 +1,12 @@
 import fs from "node:fs";
+import type { BaseTokenResolution } from "../channels/plugins/types.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type { TelegramAccountConfig } from "../config/types.telegram.js";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../routing/session-key.js";
 
 export type TelegramTokenSource = "env" | "tokenFile" | "config" | "none";
 
-export type TelegramTokenResolution = {
-  token: string;
+export type TelegramTokenResolution = BaseTokenResolution & {
   source: TelegramTokenSource;
 };
 


### PR DESCRIPTION
## Summary

Introduces `BaseProbeResult` and `BaseTokenResolution` shared base types, then unifies 15 channel probe types and 3 token resolution types to extend them — eliminating repeated `ok: boolean; error?: string | null` and `token: string; source: string` field declarations across core channels and extensions.

## Motivation

Every channel probe type independently declared `ok` and `error` fields with slightly varying signatures (`string` vs `string | null`). Similarly, token resolution types repeated `token` and `source` fields. This made it harder to write generic probe/token handling code and increased maintenance surface.

## Changes

### Commit 1: Foundation types
- Add `BaseProbeResult = { ok: boolean; error?: string | null }` and `BaseTokenResolution = { token: string; source: string }` to `src/channels/plugins/types.core.ts`
- Re-export from `types.ts` and `plugin-sdk/index.ts`
- Add type assignability tests (vitest `expectTypeOf`)

### Commit 2: Core probe unification (6 types)
- `TelegramProbe`, `DiscordProbe`, `SlackProbe`, `SignalProbe`, `IMessageProbe`, `LineProbeResult` → extend `BaseProbeResult`

### Commit 3: Extension probe unification (9 types)
- `BlueBubblesProbe`, `ProbeMSTeamsResult`, `ZaloProbeResult`, `MatrixProbe`, `MattermostProbe`, `ProbeTwitchResult`, `FeishuProbeResult`, `IrcProbe`, `ZalouserProbeResult` → extend `BaseProbeResult`

### Commit 4: Token type unification (3 types)
- `TelegramTokenResolution`, `DiscordTokenResolution`, `ZaloTokenResolution` → extend `BaseTokenResolution`

## Design decisions

- **Intersection types (`&`)** instead of `interface extends` — preserves existing type narrowing (e.g., `error?: string` stays narrower than `string | null`)
- **Type-only change** — no runtime behavior change, no function signature changes
- **Conservative scope** — account resolution was audited (17 implementations) and intentionally left unchanged; each channel's credential system is different by design
- Slack and MSTeams token types excluded (structurally different: Slack has dual tokens, MSTeams has 3 credentials)

## Verification

- `tsc --noEmit`: zero new errors (all errors are pre-existing extension dependency issues)
- `vitest run`: 855 passed, 10 failed (same pre-existing failures), zero regressions
- 8 type assignability tests added verifying compile-time compatibility

## Stats

- 22 files changed, +100 / −54 lines
- Net: −54 lines of duplicated field declarations removed

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR successfully eliminates type duplication across 18 channel implementations by introducing two shared base types. The refactoring is purely type-level with zero runtime changes - all probe and token resolution functions continue to work identically.

**Key changes:**
- Adds `BaseProbeResult` (ok, error) and `BaseTokenResolution` (token, source) to `src/channels/plugins/types.core.ts`
- Unifies 15 probe types (6 core + 9 extensions) to extend `BaseProbeResult`
- Unifies 3 token resolution types to extend `BaseTokenResolution`
- Adds 8 type assignability tests to verify compile-time compatibility
- Net -54 lines of duplicated field declarations removed

**Type safety impact:**
Some types that previously declared `error?: string` now inherit `error?: string | null` from `BaseProbeResult`. This slightly widens the type but better reflects actual runtime behavior where implementations do set `error` to `null`. The change is backward compatible - all existing error checks (`if (result.error)`) continue to work correctly.

**Verification:**
The commit structure is clean and logical (foundation → core → extensions → tokens). The PR's statistics (22 files, +100/-54 lines, 18 types unified) are accurate. Type assignability tests ensure no regressions in type compatibility.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it's a pure type refactoring with no runtime changes
- This is an exemplary refactoring PR: (1) zero runtime behavior changes - only type declarations modified; (2) comprehensive type assignability tests verify backward compatibility; (3) clean commit structure makes changes easy to review; (4) all statistics and claims in PR description verified accurate; (5) the type widening from `string` to `string | null` for some error fields actually improves type accuracy to match runtime behavior
- No files require special attention - all changes follow the same safe pattern of replacing explicit field declarations with base type intersections

<sub>Last reviewed commit: 2b7cd6e</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->