### PR TITLE
fix(media): strip auth headers on cross-origin redirect in downloadToFile

### DIFF
--- a/src/media/store.redirect.test.ts
+++ b/src/media/store.redirect.test.ts
@@ -97,17 +97,7 @@ describe("media store redirects", () => {
     mockRequest.mockImplementation((_url, opts, cb) => {
       call += 1;
       capturedHeaders.push(opts?.headers);
-      const res = new PassThrough();
-      const req = {
-        on: (event: string, handler: (...args: unknown[]) => void) => {
-          if (event === "error") {
-            res.on("error", handler);
-          }
-          return req;
-        },
-        end: () => undefined,
-        destroy: () => res.destroy(),
-      } as const;
+      const { req, res } = createMockHttpExchange();
 
       if (call === 1) {
         res.statusCode = 302;
@@ -150,17 +140,7 @@ describe("media store redirects", () => {
     mockRequest.mockImplementation((_url, opts, cb) => {
       call += 1;
       capturedHeaders.push(opts?.headers);
-      const res = new PassThrough();
-      const req = {
-        on: (event: string, handler: (...args: unknown[]) => void) => {
-          if (event === "error") {
-            res.on("error", handler);
-          }
-          return req;
-        },
-        end: () => undefined,
-        destroy: () => res.destroy(),
-      } as const;
+      const { req, res } = createMockHttpExchange();
 
       if (call === 1) {
         res.statusCode = 302;

--- a/src/media/store.redirect.test.ts
+++ b/src/media/store.redirect.test.ts
@@ -91,6 +91,108 @@ describe("media store redirects", () => {
     expect(await fs.readFile(saved.path, "utf8")).toBe("redirected");
   });
 
+  it("strips Authorization header on cross-origin redirect", async () => {
+    let call = 0;
+    const capturedHeaders: Array<Record<string, string> | undefined> = [];
+    mockRequest.mockImplementation((_url, opts, cb) => {
+      call += 1;
+      capturedHeaders.push(opts?.headers);
+      const res = new PassThrough();
+      const req = {
+        on: (event: string, handler: (...args: unknown[]) => void) => {
+          if (event === "error") {
+            res.on("error", handler);
+          }
+          return req;
+        },
+        end: () => undefined,
+        destroy: () => res.destroy(),
+      } as const;
+
+      if (call === 1) {
+        res.statusCode = 302;
+        // Redirect to a different origin
+        res.headers = { location: "https://evil.com/steal" };
+        setImmediate(() => {
+          cb(res as unknown);
+          res.end();
+        });
+      } else {
+        res.statusCode = 200;
+        res.headers = { "content-type": "text/plain" };
+        setImmediate(() => {
+          cb(res as unknown);
+          res.write("ok");
+          res.end();
+        });
+      }
+
+      return req;
+    });
+
+    await saveMediaSource("https://example.com/start", {
+      Authorization: "Bearer secret",
+      "User-Agent": "test-agent",
+    });
+
+    expect(mockRequest).toHaveBeenCalledTimes(2);
+    // First request should include Authorization
+    expect(capturedHeaders[0]).toEqual(expect.objectContaining({ Authorization: "Bearer secret" }));
+    // Second request (cross-origin) should NOT include Authorization
+    expect(capturedHeaders[1]).not.toHaveProperty("Authorization");
+    // But should keep non-sensitive headers
+    expect(capturedHeaders[1]).toEqual(expect.objectContaining({ "User-Agent": "test-agent" }));
+  });
+
+  it("preserves Authorization header on same-origin redirect", async () => {
+    let call = 0;
+    const capturedHeaders: Array<Record<string, string> | undefined> = [];
+    mockRequest.mockImplementation((_url, opts, cb) => {
+      call += 1;
+      capturedHeaders.push(opts?.headers);
+      const res = new PassThrough();
+      const req = {
+        on: (event: string, handler: (...args: unknown[]) => void) => {
+          if (event === "error") {
+            res.on("error", handler);
+          }
+          return req;
+        },
+        end: () => undefined,
+        destroy: () => res.destroy(),
+      } as const;
+
+      if (call === 1) {
+        res.statusCode = 302;
+        // Redirect to the same origin
+        res.headers = { location: "https://example.com/other-path" };
+        setImmediate(() => {
+          cb(res as unknown);
+          res.end();
+        });
+      } else {
+        res.statusCode = 200;
+        res.headers = { "content-type": "text/plain" };
+        setImmediate(() => {
+          cb(res as unknown);
+          res.write("ok");
+          res.end();
+        });
+      }
+
+      return req;
+    });
+
+    await saveMediaSource("https://example.com/start", {
+      Authorization: "Bearer secret",
+    });
+
+    expect(mockRequest).toHaveBeenCalledTimes(2);
+    // Both requests should include Authorization (same origin)
+    expect(capturedHeaders[0]).toEqual(expect.objectContaining({ Authorization: "Bearer secret" }));
+    expect(capturedHeaders[1]).toEqual(expect.objectContaining({ Authorization: "Bearer secret" }));
+  });
+
   it("fails when redirect response omits location header", async () => {
     mockRequest.mockImplementationOnce((_url, _opts, cb) => {
       const { req, res } = createMockHttpExchange();

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -117,15 +117,21 @@ export const registerTelegramHandlers = ({
     text: string;
     date?: number;
     from?: Message["from"];
-  }): Message => ({
-    ...params.base,
-    ...(params.from ? { from: params.from } : {}),
-    text: params.text,
-    caption: undefined,
-    caption_entities: undefined,
-    entities: undefined,
-    ...(params.date != null ? { date: params.date } : {}),
-  });
+    caption?: Message["caption"];
+    caption_entities?: Message["caption_entities"];
+    entities?: Message["entities"];
+  }): Message => {
+    const msg: Message = {
+      ...params.base,
+      ...(params.from ? { from: params.from } : {}),
+      text: params.text,
+      ...(params.date != null ? { date: params.date } : {}),
+    };
+    msg.caption = params.caption;
+    msg.caption_entities = params.caption_entities;
+    msg.entities = params.entities;
+    return msg;
+  };
   const buildSyntheticContext = (
     ctx: Pick<TelegramContext, "me"> & { getFile?: unknown },
     message: Message,


### PR DESCRIPTION
## Summary
- **Security fix**: `downloadToFile` in `src/media/store.ts` forwarded all headers (including `Authorization`, `Cookie`) unchanged when following HTTP redirects to a different origin. An attacker controlling a media URL could redirect to their server and capture leaked credentials.
- Strip `Authorization`, `Cookie`, and `Set-Cookie` headers when the redirect target has a different origin than the original request. Same-origin redirects preserve all headers.
- Follows the same pattern already used by the Slack media handler (`src/slack/monitor/media.ts`), which drops auth on redirect.

## Test plan
- Added test: cross-origin redirect strips `Authorization` but keeps `User-Agent`
- Added test: same-origin redirect preserves `Authorization`
- All existing redirect tests continue to pass (`npx vitest run src/media/store.redirect.test.ts` — 4/4 passing)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Security fix that strips sensitive headers (`Authorization`, `Cookie`, `Set-Cookie`) from HTTP requests when `downloadToFile` follows a redirect to a different origin, preventing credential leakage to attacker-controlled servers.

- Adds origin comparison logic in `src/media/store.ts` to detect cross-origin redirects and filter sensitive headers before the recursive `downloadToFile` call
- Same-origin redirects continue to preserve all headers
- Follows the same defensive pattern already used by the Slack media handler (`src/slack/monitor/media.ts`), which drops auth on redirect
- SSRF protection via `resolvePinnedHostname` is correctly applied to redirect targets since the recursive call goes through the full `downloadToFile` flow
- Two new tests cover the cross-origin stripping and same-origin preservation cases

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a well-scoped security hardening with correct logic and good test coverage.
- The change is minimal and surgical: 13 lines of production code that add a header-stripping guard on cross-origin redirects. The origin comparison uses the standard URL.origin API correctly. The case-insensitive header matching covers the relevant sensitive headers. The recursive nature of downloadToFile ensures multi-hop redirects remain protected. Two targeted tests verify both the cross-origin and same-origin paths. Existing tests continue to pass. No regressions are possible for the no-headers case since the guard short-circuits when headers is undefined.
- No files require special attention.

<sub>Last reviewed commit: bb4a0b6</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->