### PR TITLE
fix(config): add missing defaults to config snapshot path

### DIFF
--- a/src/config/io.snapshot-defaults.test.ts
+++ b/src/config/io.snapshot-defaults.test.ts
@@ -1,0 +1,52 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { withTempHome } from "./home-env.test-harness.js";
+import { createConfigIO } from "./io.js";
+
+describe("config snapshot defaults chain", () => {
+  const silentLogger = {
+    warn: () => {},
+    error: () => {},
+  };
+
+  it("applies compaction defaults when config file exists", async () => {
+    await withTempHome("openclaw-config-snapshot-", async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      // A config with agents.defaults triggers applyAgentDefaults, which
+      // creates the defaults object that applyCompactionDefaults then fills in.
+      await fs.writeFile(
+        configPath,
+        JSON.stringify({ agents: { defaults: {} } }, null, 2),
+        "utf-8",
+      );
+
+      const io = createConfigIO({
+        env: {} as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: silentLogger,
+      });
+
+      const snapshot = await io.readConfigFileSnapshot();
+      expect(snapshot.valid).toBe(true);
+      expect(snapshot.config.agents?.defaults?.compaction?.mode).toBe("safeguard");
+    });
+  });
+
+  it("applies compaction defaults when no config file exists", async () => {
+    await withTempHome("openclaw-config-snapshot-nofile-", async (home) => {
+      const io = createConfigIO({
+        env: {} as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: silentLogger,
+      });
+
+      const snapshot = await io.readConfigFileSnapshot();
+      expect(snapshot.valid).toBe(true);
+      // No config file => applyAgentDefaults creates agents.defaults,
+      // then applyCompactionDefaults sets the mode.
+      expect(snapshot.config.agents?.defaults?.compaction?.mode).toBe("safeguard");
+    });
+  });
+});

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -767,9 +767,13 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
           config: normalizeConfigPaths(
             applyTalkApiKey(
               applyModelDefaults(
-                applyAgentDefaults(
-                  applySessionDefaults(
-                    applyLoggingDefaults(applyMessageDefaults(validated.config)),
+                applyCompactionDefaults(
+                  applyContextPruningDefaults(
+                    applyAgentDefaults(
+                      applySessionDefaults(
+                        applyLoggingDefaults(applyMessageDefaults(validated.config)),
+                      ),
+                    ),
                   ),
                 ),
               ),


### PR DESCRIPTION
## Summary
- The `readConfigFileSnapshotInternal` function's file-exists path was missing `applyCompactionDefaults` and `applyContextPruningDefaults` in its defaults chain, while `loadConfig` and the no-file-exists path both correctly included them. This caused config snapshots read from existing files to lack compaction and context pruning defaults.
- Added the two missing calls in the same nesting order as `loadConfig`, so all three paths now apply a consistent set of defaults.

## Test plan
- Added `src/config/io.snapshot-defaults.test.ts` with two tests:
  - Verifies `compaction.mode` is set to `"safeguard"` when a config file exists with `agents.defaults`
  - Verifies the same default is applied when no config file exists (existing behavior, regression guard)
- Existing `io.write-config.test.ts` tests continue to pass

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an inconsistency in the config defaults chain within `readConfigFileSnapshotInternal` in `src/config/io.ts`. The file-exists path was missing calls to `applyCompactionDefaults` and `applyContextPruningDefaults`, while both `loadConfig` and the no-file-exists path correctly included them. This caused config snapshots read from existing files to lack compaction and context pruning defaults (e.g., `compaction.mode` not being set to `"safeguard"`).

- Adds `applyCompactionDefaults(applyContextPruningDefaults(...))` wrapping in the file-exists path of `readConfigFileSnapshotInternal`, matching the same nesting order as `loadConfig` (lines 582-590)
- Adds a new test file `io.snapshot-defaults.test.ts` with two focused tests covering both the file-exists and no-file-exists paths
- The fix is minimal, correctly ordered, and well-tested

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it adds two missing function calls to align a defaults chain with existing correct patterns.
- The change is a straightforward, low-risk bug fix that adds two missing defaults function calls (`applyCompactionDefaults`, `applyContextPruningDefaults`) to match the already-correct patterns in `loadConfig` and the no-file-exists path. The nesting order is verified to be consistent across all three paths. New tests cover the exact scenario. No behavioral regressions are expected.
- No files require special attention.

<sub>Last reviewed commit: 20b65ad</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->