### PR TITLE
fix(telegram): record update ID before processing to prevent crash replay

### DIFF
--- a/src/telegram/bot.create-telegram-bot.records-update-id-before-processing.test.ts
+++ b/src/telegram/bot.create-telegram-bot.records-update-id-before-processing.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest";
+import { getLoadConfigMock, middlewareUseSpy } from "./bot.create-telegram-bot.test-harness.js";
+import { createTelegramBot } from "./bot.js";
+
+const loadConfig = getLoadConfigMock();
+
+describe("createTelegramBot", () => {
+  it("records update id before processing (before next())", async () => {
+    middlewareUseSpy.mockReset();
+
+    const onUpdateId = vi.fn();
+
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: { dmPolicy: "open", allowFrom: ["*"] },
+      },
+    });
+
+    createTelegramBot({
+      token: "tok",
+      updateOffset: { onUpdateId },
+    });
+
+    // Find the middleware that calls recordUpdateId.
+    // It is the middleware registered via bot.use that accepts (ctx, next).
+    const middlewares = middlewareUseSpy.mock.calls
+      .map((call) => call[0])
+      .filter((fn) => typeof fn === "function" && fn.length === 2);
+
+    // Track the order of operations
+    const order: string[] = [];
+
+    const ctx = {
+      update: { update_id: 500 },
+      message: {
+        chat: { id: 1, type: "private" },
+        from: { id: 1, username: "testuser" },
+        text: "hello",
+        date: 1736380800,
+        message_id: 1,
+      },
+    };
+
+    const mockNext = vi.fn(async () => {
+      order.push("next");
+    });
+
+    onUpdateId.mockImplementation(() => {
+      order.push("onUpdateId");
+    });
+
+    // Invoke each two-arg middleware; the one that triggers onUpdateId
+    // is the logging/recordUpdateId middleware.
+    for (const mw of middlewares) {
+      onUpdateId.mockClear();
+      order.length = 0;
+      mockNext.mockClear();
+      await mw(ctx, mockNext);
+      if (onUpdateId.mock.calls.length > 0) {
+        break;
+      }
+    }
+
+    expect(onUpdateId).toHaveBeenCalledWith(500);
+    expect(order).toEqual(["onUpdateId", "next"]);
+  });
+});

--- a/src/telegram/bot.create-telegram-bot.records-update-id-before-processing.test.ts
+++ b/src/telegram/bot.create-telegram-bot.records-update-id-before-processing.test.ts
@@ -23,9 +23,10 @@ describe("createTelegramBot", () => {
 
     // Find the middleware that calls recordUpdateId.
     // It is the middleware registered via bot.use that accepts (ctx, next).
+    type MiddlewareFn = (ctx: unknown, next: () => Promise<void>) => Promise<void>;
     const middlewares = middlewareUseSpy.mock.calls
       .map((call) => call[0])
-      .filter((fn) => typeof fn === "function" && fn.length === 2);
+      .filter((fn): fn is MiddlewareFn => typeof fn === "function" && fn.length === 2);
 
     // Track the order of operations
     const order: string[] = [];

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -222,8 +222,8 @@ export function createTelegramBot(opts: TelegramBotOptions) {
         rawUpdateLogger.debug(`telegram update log failed: ${String(err)}`);
       }
     }
-    await next();
     recordUpdateId(ctx);
+    await next();
   });
 
   const historyLimit = Math.max(


### PR DESCRIPTION
## Summary
- **Bug:** `recordUpdateId(ctx)` was called after `await next()` in the logging middleware (`src/telegram/bot.ts:215-228`). If the process crashed during `next()` (while processing the message), the update offset was never persisted. On restart, Telegram would redeliver the same update, causing duplicate message processing.
- **Fix:** Move `recordUpdateId(ctx)` to before `await next()` so the offset is recorded before the handler runs. `recordUpdateId` has no dependency on the result of `next()` — it only reads `ctx.update.update_id` and persists it via `onUpdateId`.
- Added a test that verifies `onUpdateId` is called before `next()` completes.

## Test plan
- [x] New test `bot.create-telegram-bot.records-update-id-before-processing.test.ts` asserts `onUpdateId` fires before `next()`
- [x] Existing dedupe and update-offset-store tests pass unchanged

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Moved `recordUpdateId(ctx)` before `await next()` in the Telegram logging middleware to prevent duplicate message processing after crashes. Previously, if the process crashed during message handling, the update offset wasn't persisted, causing Telegram to redeliver the same update on restart. The fix is correct because `recordUpdateId` only reads `ctx.update.update_id` and has no dependency on the result of `next()`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - it fixes a critical duplicate message bug with a minimal, well-tested change
- The fix is a simple two-line swap with clear logic: recording the update ID before processing ensures it's persisted even if the process crashes. The recordUpdateId function has no dependencies on the result of next(), making the reordering safe. The new test directly validates the execution order, and existing tests remain unchanged, confirming no regressions
- No files require special attention

<sub>Last reviewed commit: 6a72472</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->