### PR TITLE
fix(telegram): preserve entities during text fragment reassembly

### DIFF
--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -50,6 +50,7 @@ import {
 } from "./group-access.js";
 import { migrateTelegramGroupConfig } from "./group-migration.js";
 import { resolveTelegramInlineButtonsScope } from "./inline-buttons.js";
+import { mergeFragmentEntities } from "./merge-entities.js";
 import {
   buildModelsKeyboard,
   buildProviderKeyboard,
@@ -158,18 +159,27 @@ export const registerTelegramHandlers = ({
         await processMessage(last.ctx, last.allMedia, last.storeAllowFrom);
         return;
       }
-      const combinedText = entries
-        .map((entry) => entry.msg.text ?? entry.msg.caption ?? "")
+      const fragments = entries.map((entry) => ({
+        text: entry.msg.text ?? entry.msg.caption ?? "",
+        entities: entry.msg.entities ?? entry.msg.caption_entities,
+      }));
+      const combinedText = fragments
+        .map((f) => f.text)
         .filter(Boolean)
         .join("\n");
       if (!combinedText.trim()) {
         return;
       }
       const first = entries[0];
+
+      const nonEmptyFragments = fragments.filter((f) => f.text);
       const baseCtx = first.ctx;
       const syntheticMessage = buildSyntheticTextMessage({
         base: first.msg,
         text: combinedText,
+        caption: undefined,
+        caption_entities: undefined,
+        entities: mergeFragmentEntities(nonEmptyFragments, "\n"),
         date: last.msg.date ?? first.msg.date,
       });
       const messageIdOverride = last.msg.message_id ? String(last.msg.message_id) : undefined;
@@ -297,7 +307,11 @@ export const registerTelegramHandlers = ({
         return;
       }
 
-      const combinedText = entry.messages.map((m) => m.msg.text ?? "").join("");
+      const fragments = entry.messages.map((m) => ({
+        text: m.msg.text ?? "",
+        entities: m.msg.entities,
+      }));
+      const combinedText = fragments.map((f) => f.text).join("");
       if (!combinedText.trim()) {
         return;
       }
@@ -305,6 +319,9 @@ export const registerTelegramHandlers = ({
       const syntheticMessage = buildSyntheticTextMessage({
         base: first.msg,
         text: combinedText,
+        caption: undefined,
+        caption_entities: undefined,
+        entities: mergeFragmentEntities(fragments),
         date: last.msg.date ?? first.msg.date,
       });
 

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -118,15 +118,21 @@ export const registerTelegramHandlers = ({
     text: string;
     date?: number;
     from?: Message["from"];
-  }): Message => ({
-    ...params.base,
-    ...(params.from ? { from: params.from } : {}),
-    text: params.text,
-    caption: undefined,
-    caption_entities: undefined,
-    entities: undefined,
-    ...(params.date != null ? { date: params.date } : {}),
-  });
+    caption?: Message["caption"];
+    caption_entities?: Message["caption_entities"];
+    entities?: Message["entities"];
+  }): Message => {
+    const msg: Message = {
+      ...params.base,
+      ...(params.from ? { from: params.from } : {}),
+      text: params.text,
+      ...(params.date != null ? { date: params.date } : {}),
+    };
+    msg.caption = params.caption;
+    msg.caption_entities = params.caption_entities;
+    msg.entities = params.entities;
+    return msg;
+  };
   const buildSyntheticContext = (
     ctx: Pick<TelegramContext, "me"> & { getFile?: unknown },
     message: Message,

--- a/src/telegram/merge-entities.test.ts
+++ b/src/telegram/merge-entities.test.ts
@@ -1,0 +1,168 @@
+import type { MessageEntity } from "@grammyjs/types";
+import { describe, expect, it } from "vitest";
+import { mergeFragmentEntities } from "./merge-entities.js";
+
+describe("mergeFragmentEntities", () => {
+  it("returns undefined when no fragments have entities", () => {
+    const result = mergeFragmentEntities([{ text: "hello " }, { text: "world" }]);
+    expect(result).toBeUndefined();
+  });
+
+  it("preserves entities from a single fragment", () => {
+    const entities: MessageEntity[] = [{ type: "bold", offset: 0, length: 5 }];
+    const result = mergeFragmentEntities([{ text: "hello", entities }]);
+    expect(result).toEqual([{ type: "bold", offset: 0, length: 5 }]);
+  });
+
+  it("adjusts offsets for entities in subsequent fragments (no separator)", () => {
+    const result = mergeFragmentEntities([
+      {
+        text: "Hello ",
+        entities: [{ type: "bold", offset: 0, length: 5 }],
+      },
+      {
+        text: "world!",
+        entities: [{ type: "italic", offset: 0, length: 5 }],
+      },
+    ]);
+    expect(result).toEqual([
+      { type: "bold", offset: 0, length: 5 },
+      { type: "italic", offset: 6, length: 5 },
+    ]);
+  });
+
+  it("adjusts offsets accounting for newline separator", () => {
+    const result = mergeFragmentEntities(
+      [
+        {
+          text: "line one",
+          entities: [{ type: "bold", offset: 0, length: 4 }],
+        },
+        {
+          text: "line two",
+          entities: [{ type: "italic", offset: 5, length: 3 }],
+        },
+      ],
+      "\n",
+    );
+    // "line one\nline two" - fragment B offset 0 maps to global offset 9
+    expect(result).toEqual([
+      { type: "bold", offset: 0, length: 4 },
+      { type: "italic", offset: 14, length: 3 }, // 8 (len "line one") + 1 ("\n") + 5
+    ]);
+  });
+
+  it("preserves bot_mention entities across fragments", () => {
+    const result = mergeFragmentEntities([
+      {
+        text: "Hey ",
+        entities: [],
+      },
+      {
+        text: "@mybot do something",
+        entities: [
+          {
+            type: "mention",
+            offset: 0,
+            length: 6,
+          },
+        ],
+      },
+    ]);
+    expect(result).toEqual([{ type: "mention", offset: 4, length: 6 }]);
+  });
+
+  it("handles fragments with no entities interspersed", () => {
+    const result = mergeFragmentEntities([
+      {
+        text: "aaa",
+        entities: [{ type: "bold", offset: 0, length: 3 }],
+      },
+      { text: "bbb" },
+      {
+        text: "ccc",
+        entities: [{ type: "code", offset: 0, length: 3 }],
+      },
+    ]);
+    expect(result).toEqual([
+      { type: "bold", offset: 0, length: 3 },
+      { type: "code", offset: 6, length: 3 },
+    ]);
+  });
+
+  it("handles empty text fragments without breaking offsets", () => {
+    const result = mergeFragmentEntities([
+      { text: "abc", entities: [{ type: "bold", offset: 0, length: 3 }] },
+      { text: "" },
+      { text: "def", entities: [{ type: "italic", offset: 0, length: 3 }] },
+    ]);
+    expect(result).toEqual([
+      { type: "bold", offset: 0, length: 3 },
+      { type: "italic", offset: 3, length: 3 },
+    ]);
+  });
+
+  it("does not add separator for empty text fragments", () => {
+    const result = mergeFragmentEntities(
+      [
+        { text: "abc", entities: [{ type: "bold", offset: 0, length: 3 }] },
+        { text: "" },
+        { text: "def", entities: [{ type: "italic", offset: 0, length: 3 }] },
+      ],
+      "\n",
+    );
+    // empty fragment is skipped for separator, so: "abc" + "\n" + "def"
+    // "def" starts at offset 4 (3 + 1)
+    expect(result).toEqual([
+      { type: "bold", offset: 0, length: 3 },
+      { type: "italic", offset: 4, length: 3 },
+    ]);
+  });
+
+  it("returns undefined for empty fragment list", () => {
+    expect(mergeFragmentEntities([])).toBeUndefined();
+  });
+
+  it("preserves extra entity fields like url and user", () => {
+    const user = { id: 123, is_bot: true, first_name: "Bot" };
+    const result = mergeFragmentEntities([
+      { text: "check " },
+      {
+        text: "this link",
+        entities: [
+          {
+            type: "text_link",
+            offset: 0,
+            length: 9,
+            url: "https://example.com",
+          } as MessageEntity,
+        ],
+      },
+      {
+        text: " from @bot",
+        entities: [
+          {
+            type: "text_mention",
+            offset: 6,
+            length: 4,
+            user,
+          } as MessageEntity,
+        ],
+      },
+    ]);
+    expect(result).toEqual([
+      {
+        type: "text_link",
+        offset: 6,
+        length: 9,
+        url: "https://example.com",
+      },
+      {
+        type: "text_mention",
+        offset: 21,
+        length: 4,
+        user,
+      },
+    ]);
+  });
+});

--- a/src/telegram/merge-entities.ts
+++ b/src/telegram/merge-entities.ts
@@ -1,0 +1,30 @@
+import type { MessageEntity } from "@grammyjs/types";
+
+/**
+ * Merge Telegram message entities from multiple text fragments,
+ * adjusting offsets so they remain correct in the concatenated text.
+ *
+ * @param fragments - Array of `{ text, entities }` in order.
+ * @param separator - The string used to join fragment texts (e.g. "" or "\n").
+ * @returns Merged entity array, or `undefined` if there are none.
+ */
+export function mergeFragmentEntities(
+  fragments: ReadonlyArray<{ text: string; entities?: MessageEntity[] }>,
+  separator = "",
+): MessageEntity[] | undefined {
+  const merged: MessageEntity[] = [];
+  let offset = 0;
+  for (let i = 0; i < fragments.length; i++) {
+    const { text, entities } = fragments[i];
+    if (separator && i > 0 && text) {
+      offset += separator.length;
+    }
+    if (entities) {
+      for (const e of entities) {
+        merged.push({ ...e, offset: e.offset + offset });
+      }
+    }
+    offset += text.length;
+  }
+  return merged.length > 0 ? merged : undefined;
+}


### PR DESCRIPTION
## Summary
- When long Telegram messages are split into fragments and reassembled, all formatting entities (bold, italic, code blocks, links, mentions) were explicitly discarded by setting `entities: undefined` on the synthetic message. This could cause bot mentions in entities to be lost, potentially causing messages to be ignored in mention-gated groups.
- Extracted a `mergeFragmentEntities()` utility that merges entities from all fragments with correctly adjusted `offset` values, accounting for concatenated text positions and optional separators.
- Fixed both the text fragment reassembly path (no separator) and the inbound debounce flush path (`"\n"` separator).

## Test plan
- [x] Added unit tests for `mergeFragmentEntities()` covering: single fragments, multi-fragment offset adjustment, newline separator handling, bot mention preservation, interspersed empty-entity fragments, empty text fragments, empty input, and extra entity fields (url, user)
- [x] All 10 tests pass
- [x] TypeScript type-check passes with no errors
- [x] Linter and formatter pass with no issues

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a bug where Telegram message entities (bold, italic, mentions, links, etc.) were discarded during text fragment reassembly and inbound debounce flushing. Previously, the synthetic merged message set `entities: undefined`, which caused `hasBotMention()` and `expandTextLinks()` to lose formatting and mention data — potentially causing the bot to ignore messages in mention-gated groups.

- Extracts a new `mergeFragmentEntities()` utility in `src/telegram/merge-entities.ts` that correctly accumulates UTF-16 offsets across concatenated fragments, accounting for optional separators and empty fragments.
- Both call sites in `bot-handlers.ts` (debounce flush with `"\n"` separator, and text fragment flush with no separator) are updated consistently, with the debounce path correctly pre-filtering to non-empty fragments.
- Comprehensive test suite covers offset adjustment, separator handling, empty fragments, extra entity fields, and bot mention preservation.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it fixes a real entity-loss bug with correct offset math and thorough tests.
- The change is well-scoped: a single new utility with clean offset arithmetic, two consistent call sites, and 10 unit tests covering edge cases. The merging logic correctly uses JavaScript string.length (UTF-16 code units) which matches Telegram's entity offset convention. Both call sites maintain consistency between how combinedText is built and how entities are merged. No regressions are introduced — the previous behavior was strictly worse (discarding all entities).
- No files require special attention.

<sub>Last reviewed commit: 04a039b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->