### PR TITLE
fix: retry sub-agent announcements with backoff instead of silently dropping on timeout

### DIFF
--- a/src/agents/subagent-announce-queue.ts
+++ b/src/agents/subagent-announce-queue.ts
@@ -23,6 +23,8 @@ export type AnnounceQueueItem = {
   sessionKey: string;
   origin?: DeliveryContext;
   originKey?: string;
+  /** Stable idempotency key for delivery — reused across retries to prevent duplicate announces. */
+  idempotencyKey?: string;
 };
 
 export type AnnounceQueueSettings = {

--- a/src/agents/subagent-announce-queue.ts
+++ b/src/agents/subagent-announce-queue.ts
@@ -23,8 +23,6 @@ export type AnnounceQueueItem = {
   sessionKey: string;
   origin?: DeliveryContext;
   originKey?: string;
-  /** Stable idempotency key for delivery — reused across retries to prevent duplicate announces. */
-  idempotencyKey?: string;
 };
 
 export type AnnounceQueueSettings = {

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -289,6 +289,58 @@ function resolveAnnounceOrigin(
   return mergeDeliveryContext(normalizedRequester, normalizedEntry);
 }
 
+/** Default timeout for announce delivery calls. */
+const DEFAULT_ANNOUNCE_TIMEOUT_MS = 30_000;
+
+/** Maximum number of retry attempts for announce delivery. */
+const ANNOUNCE_MAX_RETRIES = 3;
+
+/** Base delay (ms) for exponential backoff between retries. */
+const ANNOUNCE_RETRY_BASE_MS = 2_000;
+
+function resolveAnnounceTimeoutMs(): number {
+  try {
+    const cfg = loadConfig();
+    const cfgTimeout = (cfg as Record<string, unknown>).agents as
+      | { defaults?: { subagents?: { announceTimeoutMs?: number } } }
+      | undefined;
+    const value = cfgTimeout?.defaults?.subagents?.announceTimeoutMs;
+    if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+      return Math.min(Math.max(Math.floor(value), 5_000), 300_000);
+    }
+  } catch {
+    // Fallback to default on config load error.
+  }
+  return DEFAULT_ANNOUNCE_TIMEOUT_MS;
+}
+
+async function callGatewayWithRetry(opts: Parameters<typeof callGateway>[0]): Promise<void> {
+  const maxRetries = ANNOUNCE_MAX_RETRIES;
+  let lastError: Error | undefined;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      await callGateway(opts);
+      return;
+    } catch (err) {
+      lastError = err instanceof Error ? err : new Error(String(err));
+      const isTimeout = lastError.message.includes("timeout");
+      const isCloseError = lastError.message.includes("gateway closed");
+      if (!isTimeout && !isCloseError) {
+        // Non-retryable error — surface immediately.
+        throw lastError;
+      }
+      if (attempt < maxRetries) {
+        const delayMs = ANNOUNCE_RETRY_BASE_MS * 2 ** attempt;
+        defaultRuntime.error?.(
+          `Announce delivery attempt ${attempt + 1}/${maxRetries + 1} failed (${isTimeout ? "timeout" : "closed"}), retrying in ${delayMs}ms...`,
+        );
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+      }
+    }
+  }
+  throw lastError ?? new Error("announce delivery failed after retries");
+}
+
 async function sendAnnounce(item: AnnounceQueueItem) {
   const requesterDepth = getSubagentDepthFromSessionStore(item.sessionKey);
   const requesterIsSubagent = requesterDepth >= 1;
@@ -304,7 +356,7 @@ async function sendAnnounce(item: AnnounceQueueItem) {
       enqueuedAt: item.enqueuedAt,
     }),
   );
-  await callGateway({
+  await callGatewayWithRetry({
     method: "agent",
     params: {
       sessionKey: item.sessionKey,
@@ -316,7 +368,7 @@ async function sendAnnounce(item: AnnounceQueueItem) {
       deliver: !requesterIsSubagent,
       idempotencyKey,
     },
-    timeoutMs: 15_000,
+    timeoutMs: resolveAnnounceTimeoutMs(),
   });
 }
 
@@ -467,7 +519,7 @@ async function sendSubagentAnnounceDirectly(params: {
         completionDirectOrigin?.threadId != null && completionDirectOrigin.threadId !== ""
           ? String(completionDirectOrigin.threadId)
           : undefined;
-      await callGateway({
+      await callGatewayWithRetry({
         method: "send",
         params: {
           channel: completionChannel,
@@ -478,7 +530,7 @@ async function sendSubagentAnnounceDirectly(params: {
           message: params.completionMessage,
           idempotencyKey: params.directIdempotencyKey,
         },
-        timeoutMs: 15_000,
+        timeoutMs: resolveAnnounceTimeoutMs(),
       });
 
       return {
@@ -492,7 +544,7 @@ async function sendSubagentAnnounceDirectly(params: {
       directOrigin?.threadId != null && directOrigin.threadId !== ""
         ? String(directOrigin.threadId)
         : undefined;
-    await callGateway({
+    await callGatewayWithRetry({
       method: "agent",
       params: {
         sessionKey: canonicalRequesterSessionKey,
@@ -505,7 +557,7 @@ async function sendSubagentAnnounceDirectly(params: {
         idempotencyKey: params.directIdempotencyKey,
       },
       expectFinal: true,
-      timeoutMs: 15_000,
+      timeoutMs: resolveAnnounceTimeoutMs(),
     });
 
     return {
@@ -934,9 +986,8 @@ export async function runSubagentAnnounceFlow(params: {
       const { entry } = loadRequesterSessionEntry(targetRequesterSessionKey);
       directOrigin = resolveAnnounceOrigin(entry, targetRequesterOrigin);
     }
-    // Use a deterministic idempotency key so the gateway dedup cache
-    // catches duplicates if this announce is also queued by the gateway-
-    // level message queue while the main session is busy (#17122).
+    // Use a deterministic idempotency key so retries and queue overlap don't
+    // duplicate the same announce event while still allowing distinct events.
     const directIdempotencyKey = buildAnnounceIdempotencyKey(announceId);
     const delivery = await deliverSubagentAnnouncement({
       requesterSessionKey: targetRequesterSessionKey,

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -323,7 +323,7 @@ async function callGatewayWithRetry(opts: Parameters<typeof callGateway>[0]): Pr
       const msg = lastError.message;
       const isRetryable =
         /timeout|timed out|etimedout/i.test(msg) ||
-        /gateway closed|abnormal closure|econnreset|socket hang up/i.test(msg);
+        /gateway closed(?! \(1000)|abnormal closure|econnreset|socket hang up/i.test(msg);
       if (!isRetryable) {
         // Non-retryable error — surface immediately.
         throw lastError;

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -245,6 +245,8 @@ export type AgentDefaultsConfig = {
     maxSpawnDepth?: number;
     /** Maximum active children a single requester session may spawn. Default behavior: 5. */
     maxChildrenPerAgent?: number;
+    /** Timeout in ms for sub-agent announcement delivery (default: 30000). Retries up to 3 times with backoff on timeout/close errors. */
+    announceTimeoutMs?: number;
     /** Auto-archive sub-agent sessions after N minutes (default: 60). */
     archiveAfterMinutes?: number;
     /** Default model selection for spawned sub-agents (string or {primary,fallbacks}). */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -159,6 +159,15 @@ export const AgentDefaultsSchema = z
           .describe(
             "Maximum number of active children a single agent session can spawn (default: 5).",
           ),
+        announceTimeoutMs: z
+          .number()
+          .int()
+          .min(5000)
+          .max(300000)
+          .optional()
+          .describe(
+            "Timeout in milliseconds for sub-agent announcement delivery to the parent session (default: 30000). Announcements retry up to 3 times with exponential backoff on timeout/close errors.",
+          ),
         archiveAfterMinutes: z.number().int().positive().optional(),
         model: AgentModelSchema.optional(),
         thinking: z.string().optional(),


### PR DESCRIPTION
## Summary

Sub-agent announcement delivery could be dropped on transient gateway failures (timeouts / closed connection). This PR preserves the retry-with-backoff behavior while rebasing onto latest `main`.

Closes #17000

## What this PR adds (unique value)

- Retry announce delivery with exponential backoff (2s → 4s → 8s)
- Retry only retryable errors (timeout / gateway closed)
- Keep non-retryable failures immediate
- Keep configurable announce timeout via `agents.defaults.subagents.announceTimeoutMs` (5s–300s, default 30s)

## Rebase alignment with main

- Reused `src/agents/announce-idempotency.ts` (no duplicate idempotency implementation)
- Kept deterministic announce idempotency keys for both queue and direct paths
- Clarified `expectFinal` handling comment in direct announce path (left unset so retries confirm accept/dedupe instead of waiting for terminal run completion)

## Files changed

- `src/agents/subagent-announce.ts`
- `src/config/zod-schema.agent-defaults.ts`
- `src/config/types.agent-defaults.ts`
- `src/agents/subagent-announce-queue.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds retry-with-exponential-backoff for sub-agent announcement delivery to handle transient gateway failures (timeouts, abnormal WebSocket closures, connection resets) instead of silently dropping announcements.

- Introduces `callGatewayWithRetry` wrapper with up to 3 retries and exponential backoff (2s → 4s → 8s), applied to both queued and direct announce delivery paths
- Adds configurable `announceTimeoutMs` setting (5s–300s, default 30s) via `agents.defaults.subagents.announceTimeoutMs`, replacing the previous hardcoded 15s timeout
- Narrows retry classification to exclude normal WebSocket closures (code 1000) using negative lookahead regex
- Removes `expectFinal: true` from the direct announce path so retries only confirm accept/dedupe rather than waiting for terminal run completion
- Correctly reuses deterministic idempotency keys across retries, ensuring gateway-level deduplication works as intended

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — the retry logic is well-bounded, idempotent, and only targets transient failures.
- Score of 4 reflects: clean retry implementation with proper bounds and exponential backoff, correct idempotency key reuse across retries, appropriate error classification with the narrowed regex, consistent type/schema additions. The only minor concern is the lack of unit tests for the new retry logic, though the existing integration test coverage and the defensive coding style mitigate risk. The timeout increase from 15s to 30s default is intentional and documented.
- No files require special attention. The core logic in `src/agents/subagent-announce.ts` was reviewed thoroughly and the retry wrapper is straightforward.

<sub>Last reviewed commit: 69897a0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->