### PR TITLE
fix(telegram): wire poll action into action handler

### DIFF
--- a/src/channels/plugins/actions/telegram.ts
+++ b/src/channels/plugins/actions/telegram.ts
@@ -46,7 +46,7 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
       return [];
     }
     const gate = createActionGate(cfg.channels?.telegram?.actions);
-    const actions = new Set<ChannelMessageActionName>(["send"]);
+    const actions = new Set<ChannelMessageActionName>(["send", "poll"]);
     if (gate("reactions")) {
       actions.add("react");
     }
@@ -193,6 +193,37 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
           action: "searchSticker",
           query,
           limit: limit ?? undefined,
+          accountId: accountId ?? undefined,
+        },
+        cfg,
+      );
+    }
+
+    if (action === "poll") {
+      const to =
+        readStringOrNumberParam(params, "chatId") ??
+        readStringOrNumberParam(params, "channelId") ??
+        readStringParam(params, "to", { required: true });
+      const question = readStringParam(params, "question", { required: true });
+      const options = readStringArrayParam(params, "options");
+      const maxSelections = readNumberParam(params, "maxSelections", { integer: true });
+      const durationSeconds = readNumberParam(params, "durationSeconds", { integer: true });
+      const allowsMultipleAnswers = typeof params.allowsMultipleAnswers === "boolean" ? params.allowsMultipleAnswers : undefined;
+      const anonymous = typeof params.anonymous === "boolean" ? params.anonymous : undefined;
+      const replyToMessageId = readNumberParam(params, "replyTo", { integer: true });
+      const messageThreadId = readNumberParam(params, "threadId", { integer: true });
+      return await handleTelegramAction(
+        {
+          action: "sendPoll",
+          chatId: to,
+          question,
+          options: options ?? [],
+          maxSelections,
+          durationSeconds,
+          allowsMultipleAnswers,
+          anonymous,
+          replyToMessageId: replyToMessageId ?? undefined,
+          messageThreadId: messageThreadId ?? undefined,
           accountId: accountId ?? undefined,
         },
         cfg,


### PR DESCRIPTION
Fixes #16977

## Problem
Telegram polls exist (sendPollTelegram is implemented) but are not wired into the action pipeline, causing "Action poll is not supported for provider telegram" error.

## Solution
- Add 'poll' to telegramMessageActions listActions
- Add poll case in telegram action adapter handler
- Add sendPoll handler in handleTelegramAction

## Testing
Polls can now be sent via message tool with action=poll

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires the existing `sendPollTelegram` function into the Telegram action pipeline by adding a `poll` case to both the channel action adapter (`telegram.ts`) and the direct action handler (`telegram-actions.ts`). It also adds `poll` to the `listActions` set and imports `sendPollTelegram` and `readStringArrayParam`.

- The `poll` action is unconditionally added to the action set in `listActions`, unlike Discord and WhatsApp which gate it behind `gate("polls")`. The `sendPoll` handler in `handleTelegramAction` also lacks the `isActionEnabled` check that every other action handler has.
- Previous review threads noted that `sendPollTelegram` is called with the wrong number of arguments (missing `chatId` as the first parameter) and that `allowsMultipleAnswers` is unused since Telegram derives multi-select from `maxSelections > 1`. These issues appear to still be present in the current code.

<h3>Confidence Score: 1/5</h3>

- This PR has unresolved issues that will cause runtime errors and should not be merged as-is.
- The `sendPollTelegram` call is missing the `chatId` first argument (noted in prior review threads but still present), which will cause a runtime type error or incorrect behavior. Additionally, the poll action is not gated behind configuration, breaking the pattern used by all other actions and providers.
- `src/agents/tools/telegram-actions.ts` needs the `sendPollTelegram` call signature fixed and an action gate added. `src/channels/plugins/actions/telegram.ts` needs the `poll` action gated behind `gate("polls")`.

<sub>Last reviewed commit: dc5ae0b</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))

<!-- /greptile_comment -->