### PR TITLE
fix(heartbeat): skip delivery when showOk is false

### DIFF
--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -606,7 +606,9 @@ export async function runHeartbeatOnce(opts: {
       normalized.shouldSkip = false;
     }
     const shouldSkipMain = normalized.shouldSkip && !normalized.hasMedia && !hasExecCompletion;
-    if (shouldSkipMain && reasoningPayloads.length === 0) {
+    // Also skip if showOk is false (user doesn't want HEARTBEAT_OK responses)
+    const shouldSkipDueToShowOk = !visibility.showOk;
+    if ((shouldSkipMain || shouldSkipDueToShowOk) && reasoningPayloads.length === 0) {
       await restoreHeartbeatUpdatedAt({
         storePath,
         sessionKey,


### PR DESCRIPTION
Fixes #16974

## Problem
When showOk is set to false, HEARTBEAT_OK responses still leak to the channel instead of being suppressed.

## Solution
Skip main heartbeat delivery when visibility.showOk is false, in addition to existing skip logic for HEARTBEAT_TOKEN responses.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `shouldSkipDueToShowOk` check to skip heartbeat delivery when `visibility.showOk` is `false`. However, the condition `!visibility.showOk` is too broad — since `showOk` defaults to `false` (in `heartbeat-visibility.ts`), this change will suppress **all** heartbeat deliveries (including substantive alert content) under default configuration when no reasoning payloads are present.

- The existing code already correctly suppresses `HEARTBEAT_OK` token delivery via `shouldSkipMain` (based on `normalized.shouldSkip`) and `canAttemptHeartbeatOk` (which checks `visibility.showOk`)
- The new `shouldSkipDueToShowOk = !visibility.showOk` unconditionally blocks the main delivery path, even for real content responses that should be delivered
- Under default settings, this regression would silently drop all heartbeat alert messages to channels

<h3>Confidence Score: 1/5</h3>

- This PR introduces a regression that would silently suppress all heartbeat alert delivery under default configuration.
- The condition `shouldSkipDueToShowOk = !visibility.showOk` evaluates to `true` under default settings (showOk defaults to false). Combined with `reasoningPayloads.length === 0` (the common case), this causes the early-return skip path to trigger for ALL heartbeat responses — not just HEARTBEAT_OK tokens. The existing code already handles HEARTBEAT_OK suppression correctly via `shouldSkipMain` and `canAttemptHeartbeatOk`.
- `src/infra/heartbeat-runner.ts` — the `shouldSkipDueToShowOk` condition on line 610 needs to be scoped more narrowly to avoid suppressing substantive heartbeat content.

<sub>Last reviewed commit: 3a900b2</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->