### PR TITLE
fix(agents): read models from gateway config first

### DIFF
--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -70,49 +70,55 @@ export function resolveModel(
   const resolvedAgentDir = agentDir ?? resolveOpenClawAgentDir();
   const authStorage = discoverAuthStorage(resolvedAgentDir);
   const modelRegistry = discoverModels(authStorage, resolvedAgentDir);
-  const model = modelRegistry.find(provider, modelId) as Model<Api> | null;
-  if (!model) {
-    const providers = cfg?.models?.providers ?? {};
-    const inlineModels = buildInlineProviderModels(providers);
-    const normalizedProvider = normalizeProviderId(provider);
-    const inlineMatch = inlineModels.find(
-      (entry) => normalizeProviderId(entry.provider) === normalizedProvider && entry.id === modelId,
-    );
-    if (inlineMatch) {
-      const normalized = normalizeModelCompat(inlineMatch as Model<Api>);
-      return {
-        model: normalized,
-        authStorage,
-        modelRegistry,
-      };
-    }
-    // Forward-compat fallbacks must be checked BEFORE the generic providerCfg fallback.
-    // Otherwise, configured providers can default to a generic API and break specific transports.
-    const forwardCompat = resolveForwardCompatModel(provider, modelId, modelRegistry);
-    if (forwardCompat) {
-      return { model: forwardCompat, authStorage, modelRegistry };
-    }
-    const providerCfg = providers[provider];
-    if (providerCfg || modelId.startsWith("mock-")) {
-      const fallbackModel: Model<Api> = normalizeModelCompat({
-        id: modelId,
-        name: modelId,
-        api: providerCfg?.api ?? "openai-responses",
-        provider,
-        baseUrl: providerCfg?.baseUrl,
-        reasoning: false,
-        input: ["text"],
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-        contextWindow: providerCfg?.models?.[0]?.contextWindow ?? DEFAULT_CONTEXT_TOKENS,
-        maxTokens: providerCfg?.models?.[0]?.maxTokens ?? DEFAULT_CONTEXT_TOKENS,
-      } as Model<Api>);
-      return { model: fallbackModel, authStorage, modelRegistry };
-    }
+
+  // Always check gateway config FIRST for the model.
+  // The per-agent models.json may be stale and not reflect gateway config changes.
+  // This ensures agents always use the latest models from the gateway config.
+  const providers = cfg?.models?.providers ?? {};
+  const inlineModels = buildInlineProviderModels(providers);
+  const normalizedProvider = normalizeProviderId(provider);
+  const inlineMatch = inlineModels.find(
+    (entry) => normalizeProviderId(entry.provider) === normalizedProvider && entry.id === modelId,
+  );
+  if (inlineMatch) {
+    const normalized = normalizeModelCompat(inlineMatch as Model<Api>);
     return {
-      error: `Unknown model: ${provider}/${modelId}`,
+      model: normalized,
       authStorage,
       modelRegistry,
     };
   }
-  return { model: normalizeModelCompat(model), authStorage, modelRegistry };
+
+  // Fall back to models.json only if not found in gateway config
+  const model = modelRegistry.find(provider, modelId) as Model<Api> | null;
+  if (model) {
+    return { model, authStorage, modelRegistry };
+  }
+  // Forward-compat fallbacks must be checked BEFORE the generic providerCfg fallback.
+  // Otherwise, configured providers can default to a generic API and break specific transports.
+  const forwardCompat = resolveForwardCompatModel(provider, modelId, modelRegistry);
+  if (forwardCompat) {
+    return { model: forwardCompat, authStorage, modelRegistry };
+  }
+  const providerCfg = providers[provider];
+  if (providerCfg || modelId.startsWith("mock-")) {
+    const fallbackModel: Model<Api> = normalizeModelCompat({
+      id: modelId,
+      name: modelId,
+      api: providerCfg?.api ?? "openai-responses",
+      provider,
+      baseUrl: providerCfg?.baseUrl,
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: providerCfg?.models?.[0]?.contextWindow ?? DEFAULT_CONTEXT_TOKENS,
+      maxTokens: providerCfg?.models?.[0]?.maxTokens ?? DEFAULT_CONTEXT_TOKENS,
+    } as Model<Api>);
+    return { model: fallbackModel, authStorage, modelRegistry };
+  }
+  return {
+    error: `Unknown model: ${provider}/${modelId}`,
+    authStorage,
+    modelRegistry,
+  };
 }


### PR DESCRIPTION
Fixes #16976

## Problem
Per-agent models.json is a static snapshot written at agent creation time. When gateway config adds new models (e.g., new Ollama models), agents fall back to default model instead of using the newly configured models.

## Root Cause
resolveModel() checked models.json FIRST before checking the gateway config. The gateway config is always fresh, but the per-agent models.json is stale.

## Solution
Check gateway config (cfg.models.providers) FIRST before falling back to models.json. This ensures agents always use the latest models from the gateway config.

## Impact
- Agents automatically use newly added models without manual models.json updates
- No need to restart gateway or recreate agents after config changes
- Models.json becomes a secondary fallback (for backward compatibility)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Refactors `resolveModel()` to check gateway config (`cfg.models.providers`) before falling back to per-agent `models.json`, ensuring agents always use fresh models from gateway config instead of stale snapshots.

**Major changes:**
- Gateway config now checked first (lines 77-90), so newly added models are immediately available
- `models.json` becomes secondary fallback (lines 93-96)
- Forward-compat and generic provider fallbacks remain in correct order

**Critical issue:**
- Line 95 drops the `normalizeModelCompat()` wrapper from the models.json path (previously line 118 in old code). This breaks ZAI models resolved from models.json—they won't have `supportsDeveloperRole: false` set and will attempt to use the developer role, causing API failures.

<h3>Confidence Score: 2/5</h3>

- This PR contains a critical logical error that will break ZAI models
- The refactor correctly inverts the priority (gateway config first, models.json second), but introduces a regression by dropping `normalizeModelCompat()` on the models.json path. This will cause ZAI `openai-completions` models to fail at runtime when resolved from models.json.
- src/agents/pi-embedded-runner/model.ts line 95 requires immediate attention

<sub>Last reviewed commit: 6ab83b6</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->