### PR TITLE
fix(tool errors): suppress compaction-related tool errors

### DIFF
--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -37,6 +37,10 @@ const RECOVERABLE_TOOL_ERROR_KEYWORDS = [
   "must have",
   "needs",
   "requires",
+  // Compaction-related errors - tool call was dropped during compaction, error is not user-actionable
+  "no tool call found",
+  "tool call.*not found",
+  "call_id.*not found",
 ] as const;
 
 function isRecoverableToolError(error: string | undefined): boolean {


### PR DESCRIPTION
Fixes #16948

## Problem
When session is compacted during long-running tool calls, the tool result tries to deliver to a context where the original tool_call ID no longer exists. The error message leaks to user chat.

## Solution
Add compaction-related error keywords to RECOVERABLE_TOOL_ERROR_KEYWORDS:
- "no tool call found"
- "tool call.*not found"
- "call_id.*not found"

These errors are not user-actionable (the tool call was already dropped during compaction), so they should be suppressed from the chat surface.

## Impact
- Users no longer see confusing error messages about missing tool calls
- Tool errors that cannot be recovered are silently suppressed instead of leaking

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added three new keywords to suppress compaction-related tool errors that occur when a tool result tries to deliver to a context where the original tool call ID no longer exists after session compaction.

**Critical issue found:**
- The regex patterns `"tool call.*not found"` and `"call_id.*not found"` won't work as intended because `isRecoverableToolError` uses `.includes()` for literal string matching, not regex matching. The `.*` will be treated as literal characters, preventing these patterns from matching actual error messages.

<h3>Confidence Score: 1/5</h3>

- This PR has a critical bug that prevents the fix from working as intended
- The implementation uses regex-style patterns with `.includes()` which performs literal string matching, not regex matching. The patterns `"tool call.*not found"` and `"call_id.*not found"` will never match actual error messages because the `.*` characters are treated literally. This means the intended fix will not suppress the compaction-related errors it was designed to suppress. The first pattern `"no tool call found"` will work, but the other two will not.
- src/agents/pi-embedded-runner/run/payloads.ts requires correction before merge

<sub>Last reviewed commit: e2dbdd5</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->