### PR TITLE
fix(doctor): handle invalid session file paths gracefully

### DIFF
--- a/src/config/sessions/paths.ts
+++ b/src/config/sessions/paths.ts
@@ -195,7 +195,12 @@ export function resolveSessionFilePath(
   const sessionsDir = resolveSessionsDir(opts);
   const candidate = entry?.sessionFile?.trim();
   if (candidate) {
-    return resolvePathWithinSessionsDir(sessionsDir, candidate, { agentId: opts?.agentId });
+    try {
+      return resolvePathWithinSessionsDir(sessionsDir, candidate, { agentId: opts?.agentId });
+    } catch {
+      // Session file path is invalid; fall back to default path
+      // This can happen with stale sessionFile entries in sessions.json
+    }
   }
   return resolveSessionTranscriptPathInDir(sessionId, sessionsDir);
 }


### PR DESCRIPTION
Fixes #16972

## Problem
▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
██░▄▄▄░██░▄▄░██░▄▄▄██░▀██░██░▄▄▀██░████░▄▄▀██░███░██
██░███░██░▀▀░██░▄▄▄██░█░█░██░█████░████░▀▀░██░█░█░██
██░▀▀▀░██░█████░▀▀▀██░██▄░██░▀▀▄██░▀▀░█░██░██▄▀▄▀▄██
▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
                  🦞 OPENCLAW 🦞                    
 
┌  OpenClaw doctor
│
◇  Security ─────────────────────────────────╮
│                                            │
│  - No channel security warnings detected.  │
│  - Run: openclaw security audit --deep     │
│                                            │
├────────────────────────────────────────────╯
│
◇  Skills status ────────────╮
│                            │
│  Eligible: 27              │
│  Missing requirements: 29  │
│  Blocked by allowlist: 0   │
│                            │
├────────────────────────────╯
│
◇  Plugins ──────╮
│                │
│  Loaded: 7     │
│  Disabled: 29  │
│  Errors: 0     │
│                │
├────────────────╯
Telegram: configured
Discord: configured
iMessage: configured
Agents: main (default)
Heartbeat interval: 1h (main)
Session store (main): /Users/limitless/.openclaw/agents/main/sessions/sessions.json (10 entries)
- agent:main:main (3m ago)
- agent:main:cron:be7fcbe9-71b3-408b-bded-efb6450e8f6c (156m ago)
- agent:main:cron:be7fcbe9-71b3-408b-bded-efb6450e8f6c:run:f604fd06-1e91-4c3a-b7e1-38954098510e (156m ago)
- agent:main:cron:1ed51ef3-47a6-44ad-9096-1a9f82a25b61 (546m ago)
- agent:main:cron:1ed51ef3-47a6-44ad-9096-1a9f82a25b61:run:407ef55a-9856-4be2-91f1-08a5d69f3a85 (546m ago)
│
◇  Channel warnings ────────────────────────────╮
│                                               │
│  - imessage default: Channel error: disabled  │
│                                               │
├───────────────────────────────────────────────╯
Run "openclaw doctor --fix" to apply changes.
│
└  Doctor complete. crashes with 'Session file path must be within sessions directory' error. This happens even after config migrations are applied.

## Root Cause
Stale sessionFile entries in sessions.json can contain invalid paths. When doctor tries to resolve the main session path, it throws instead of gracefully falling back.

## Solution
Wrap resolvePathWithinSessionsDir in try-catch and fall back to default session path if invalid.

## Impact
- Doctor no longer crashes on stale session entries
- Graceful degradation to default path instead of hard failure

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wraps `resolvePathWithinSessionsDir` in a try-catch inside `resolveSessionFilePath` to prevent `openclaw doctor` from crashing when stale `sessionFile` entries contain invalid paths. While the intent is sound — the doctor should not crash on corrupt state — the fix is applied at the wrong layer: it changes the shared `resolveSessionFilePath` function used by 20+ callers rather than applying the guard only in the two unprotected call sites in `doctor-state-integrity.ts` (lines 342 and 356).

- Existing tests in `paths.test.ts` (lines 51-61 and 99-108) that assert `resolveSessionFilePath` throws on path-traversal and out-of-bounds `sessionFile` values will now fail
- Several callers in `usage.ts` and `chat.ts` wrap `resolveSessionFilePath` in try-catch to detect invalid session references and return error responses — those catch blocks become unreachable dead code, and invalid references will silently resolve to a wrong default path instead of being reported as errors
- A narrower fix scoped to `doctor-state-integrity.ts` would solve the doctor crash without altering the shared API contract

<h3>Confidence Score: 1/5</h3>

- This PR will break existing tests and silently change error-handling behavior for 20+ callers of a shared utility function.
- Score of 1 reflects that the change breaks existing tests (paths.test.ts lines 51-61 and 99-108 expect .toThrow), turns error-handling catch blocks in multiple callers into dead code, and silently degrades error reporting for invalid session references across the codebase. The fix should be scoped to doctor-state-integrity.ts rather than the shared resolveSessionFilePath function.
- `src/config/sessions/paths.ts` — the only changed file — needs the fix relocated to `src/commands/doctor-state-integrity.ts` instead

<sub>Last reviewed commit: 8a1b428</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->