### PR TITLE
feat: add Leo agent identity config, system prompt, and tool registry

### DIFF
--- a/_project_specs/features/08-leo-agent-identity.md
+++ b/_project_specs/features/08-leo-agent-identity.md
@@ -1,0 +1,92 @@
+# Feature: Leo Agent Identity & Configuration
+
+## Priority: 1 (Foundation)
+
+## Status: Spec Written
+
+## Description
+
+Configure OpenClaw's agent as "Leo" -- Ali's personal AI chief of staff. This
+feature builds three pieces that plug into OpenClaw's existing systems:
+
+1. **Leo identity config** (`LeoIdentityConfig`) -- a Zod schema for the
+   `leo` key in `openclaw.json` that holds identity fields (name, role,
+   owner_name), per-org credentials, and tool policy overrides.
+
+2. **System prompt builder** (`buildLeoSystemPrompt`) -- generates Leo's
+   persona block (identity line, org context summary, communication style
+   guidelines, approval rules) from the validated config. The output is
+   injected as `extraSystemPrompt` into OpenClaw's existing
+   `buildAgentSystemPrompt`.
+
+3. **Leo tool registry** (`registerLeoTools`) -- registers Leo-specific
+   tool definitions (people, gmail, calendar, slack_read, asana, monday,
+   github, briefing) into OpenClaw's tool pipeline with correct policy
+   defaults (gmail.send and calendar.create require approval).
+
+All three integrate through OpenClaw's existing extension points -- no
+upstream source modifications.
+
+## Acceptance Criteria
+
+1. `parseLeoConfig(valid)` returns a validated `LeoIdentityConfig` object
+2. `parseLeoConfig(invalid)` throws a `ZodError` with descriptive path
+3. `parseLeoConfig(minimal)` succeeds with only required fields (identity + at least one org with google_workspace)
+4. `buildLeoSystemPrompt(config)` output contains "You are Leo, Ali's personal AI chief of staff"
+5. `buildLeoSystemPrompt(config)` output lists all configured orgs with their services
+6. `buildLeoSystemPrompt(config)` output includes communication style directives
+7. `buildLeoSystemPrompt(config)` output mentions approval-required tools
+8. `registerLeoTools(config)` returns tool definitions for all 8 tool namespaces
+9. `registerLeoTools(config)` marks `gmail.send` and `calendar.create` as requiring approval
+10. `registerLeoTools(config)` omits tool namespaces whose org credentials are missing (e.g., no monday config -> no monday tools)
+
+## Test Cases
+
+| #   | Test                                 | Input                                                | Expected Output                                                                        |
+| --- | ------------------------------------ | ---------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| 1   | Valid full config parses             | Config with identity + 4 orgs + all services         | Returns LeoIdentityConfig object                                                       |
+| 2   | Minimal config parses                | Config with identity + 1 org (google_workspace only) | Returns LeoIdentityConfig, optional services undefined                                 |
+| 3   | Missing identity rejects             | Config without identity block                        | ZodError at path "identity"                                                            |
+| 4   | Missing org google_workspace rejects | Org entry without google_workspace                   | ZodError at path "orgs.<name>.google_workspace"                                        |
+| 5   | Extra unknown keys stripped          | Config with extra top-level key "foo"                | Parses without "foo" in output                                                         |
+| 6   | System prompt identity line          | Full config                                          | Contains "You are Leo, Ali's personal AI chief of staff"                               |
+| 7   | System prompt lists orgs             | Config with edubites + zenloop                       | Contains "edubites" and "zenloop" org summaries                                        |
+| 8   | System prompt with single org        | Config with only protaige                            | Contains "protaige", does not mention edubites/zenloop                                 |
+| 9   | System prompt communication style    | Any valid config                                     | Contains "concise" and "actionable" directives                                         |
+| 10  | System prompt approval rules         | Config with gmail.send approval                      | Contains "gmail.send" and "approval" in output                                         |
+| 11  | Tool registry returns all namespaces | Full config with all services                        | Returns tools for people, gmail, calendar, slack_read, asana, monday, github, briefing |
+| 12  | Tool registry omits unconfigured     | Config with no monday credentials                    | No monday.\* tools in result                                                           |
+| 13  | Tool registry approval policy        | Full config                                          | gmail.send and calendar.create have requireApproval: true                              |
+| 14  | Tool registry tool definitions valid | Full config                                          | Each tool has name, description, and parameters (Zod schema)                           |
+| 15  | Empty orgs rejects                   | Config with identity but empty orgs object           | ZodError - orgs must have at least 1 entry                                             |
+
+## Dependencies
+
+- None (this is a foundation feature, alongside People Index)
+
+## Files
+
+### New Files
+
+- `src/leo/leo-config.ts` -- LeoIdentityConfig Zod schema and parser (`parseLeoConfig`)
+- `src/leo/leo-config.test.ts` -- Unit tests for config validation
+- `src/leo/leo-system-prompt.ts` -- `buildLeoSystemPrompt` function
+- `src/leo/leo-system-prompt.test.ts` -- Unit tests for prompt builder
+- `src/leo/leo-tool-registry.ts` -- `registerLeoTools` function + tool definitions
+- `src/leo/leo-tool-registry.test.ts` -- Unit tests for tool registration
+- `src/leo/types.ts` -- Shared TypeScript types exported from Zod schemas
+
+### Integration Points (existing files, no modifications in this feature)
+
+- `src/agents/system-prompt.ts` -- `buildAgentSystemPrompt` accepts `extraSystemPrompt` param (already supported)
+- `src/config/types.openclaw.ts` -- `OpenClawConfig` has catch-all channel/plugin extension points
+- `src/agents/identity.ts` -- Existing identity resolution used alongside Leo identity
+
+## Notes
+
+- The `src/leo/` directory is new. All Leo-specific code lives here to avoid polluting upstream OpenClaw source.
+- `LeoIdentityConfig` is a standalone Zod schema (not merged into OpenClawSchema) -- it validates a separate `leo` section in openclaw.json or an independent leo.json config file.
+- Credential values (tokens, secrets) are validated as non-empty strings by Zod but never logged or included in system prompts.
+- The system prompt builder produces a string block; the caller is responsible for passing it as `extraSystemPrompt` to `buildAgentSystemPrompt`.
+- Tool definitions follow OpenClaw's existing pattern: `{ name, description, parameters }` where parameters is a Zod schema. Actual tool handler implementations are NOT part of this feature -- they are built in their respective feature specs (02-gmail, 03-calendar, etc.).
+- `registerLeoTools` returns stub tool definitions (name + description + parameter schema + policy). Handler functions are wired in by each feature's implementation task.

--- a/src/leo/leo-config.test.ts
+++ b/src/leo/leo-config.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import { parseLeoConfig } from "./leo-config.js";
+
+function fullConfig() {
+  return {
+    identity: {
+      name: "Leo",
+      role: "chief of staff",
+      owner_name: "Ali",
+    },
+    orgs: {
+      edubites: {
+        google_workspace: {
+          client_id: "cid-edu",
+          client_secret: "cs-edu",
+          refresh_token: "rt-edu",
+          email: "ali@edubites.com",
+        },
+        slack: { bot_token: "xoxb-edu", workspace_id: "W-EDU" },
+        monday: { api_token: "mon-token" },
+      },
+      protaige: {
+        google_workspace: {
+          client_id: "cid-pro",
+          client_secret: "cs-pro",
+          refresh_token: "rt-pro",
+          email: "ali@protaige.com",
+        },
+        slack: { bot_token: "xoxb-pro", workspace_id: "W-PRO" },
+        github: { pat: "ghp-pro", org_name: "protaige" },
+      },
+      zenloop: {
+        google_workspace: {
+          client_id: "cid-zen",
+          client_secret: "cs-zen",
+          refresh_token: "rt-zen",
+          email: "ali@zenloop.com",
+        },
+        slack: { bot_token: "xoxb-zen", workspace_id: "W-ZEN" },
+        asana: { pat: "asana-pat", workspace_gid: "12345" },
+        github: { pat: "ghp-zen", org_name: "zenloop" },
+      },
+      saasgroup: {
+        google_workspace: {
+          client_id: "cid-sas",
+          client_secret: "cs-sas",
+          refresh_token: "rt-sas",
+          email: "ali@saasgroup.com",
+        },
+        slack: { bot_token: "xoxb-sas", workspace_id: "W-SAS" },
+      },
+    },
+  };
+}
+
+function minimalConfig() {
+  return {
+    identity: {
+      name: "Leo",
+      role: "chief of staff",
+      owner_name: "Ali",
+    },
+    orgs: {
+      edubites: {
+        google_workspace: {
+          client_id: "cid",
+          client_secret: "cs",
+          refresh_token: "rt",
+          email: "ali@edubites.com",
+        },
+      },
+    },
+  };
+}
+
+describe("parseLeoConfig", () => {
+  it("parses a valid full config with 4 orgs and all services", () => {
+    const result = parseLeoConfig(fullConfig());
+    expect(result).toBeDefined();
+    expect(result.identity.name).toBe("Leo");
+    expect(result.identity.role).toBe("chief of staff");
+    expect(result.identity.owner_name).toBe("Ali");
+    expect(Object.keys(result.orgs)).toHaveLength(4);
+  });
+
+  it("parses a minimal config with identity and one org", () => {
+    const result = parseLeoConfig(minimalConfig());
+    expect(result).toBeDefined();
+    expect(result.identity.name).toBe("Leo");
+    expect(Object.keys(result.orgs)).toHaveLength(1);
+    const edu = result.orgs.edubites;
+    expect(edu.google_workspace.email).toBe("ali@edubites.com");
+    expect(edu.slack).toBeUndefined();
+    expect(edu.monday).toBeUndefined();
+    expect(edu.asana).toBeUndefined();
+    expect(edu.github).toBeUndefined();
+  });
+
+  it("rejects config without identity block", () => {
+    const cfg = { orgs: minimalConfig().orgs };
+    expect(() => parseLeoConfig(cfg)).toThrow();
+  });
+
+  it("rejects org entry without google_workspace", () => {
+    const cfg = {
+      identity: minimalConfig().identity,
+      orgs: {
+        broken: {
+          slack: { bot_token: "xoxb-x", workspace_id: "W-X" },
+        },
+      },
+    };
+    expect(() => parseLeoConfig(cfg)).toThrow();
+  });
+
+  it("strips extra unknown top-level keys", () => {
+    const cfg = { ...minimalConfig(), foo: "bar" };
+    const result = parseLeoConfig(cfg);
+    expect((result as Record<string, unknown>).foo).toBeUndefined();
+  });
+
+  it("rejects empty orgs object", () => {
+    const cfg = {
+      identity: minimalConfig().identity,
+      orgs: {},
+    };
+    expect(() => parseLeoConfig(cfg)).toThrow();
+  });
+});

--- a/src/leo/leo-config.ts
+++ b/src/leo/leo-config.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+import type { LeoIdentityConfig } from "./types.js";
+
+const GoogleWorkspaceSchema = z.object({
+  client_id: z.string().min(1),
+  client_secret: z.string().min(1),
+  refresh_token: z.string().min(1),
+  email: z.string().min(1),
+});
+
+const SlackSchema = z.object({
+  bot_token: z.string().min(1),
+  workspace_id: z.string().min(1),
+});
+
+const AsanaSchema = z.object({
+  pat: z.string().min(1),
+  workspace_gid: z.string().min(1),
+});
+
+const MondaySchema = z.object({
+  api_token: z.string().min(1),
+});
+
+const GitHubSchema = z.object({
+  pat: z.string().min(1),
+  org_name: z.string().min(1),
+});
+
+const OrgSchema = z.object({
+  google_workspace: GoogleWorkspaceSchema,
+  slack: SlackSchema.optional(),
+  asana: AsanaSchema.optional(),
+  monday: MondaySchema.optional(),
+  github: GitHubSchema.optional(),
+});
+
+const IdentitySchema = z.object({
+  name: z.string().min(1),
+  role: z.string().min(1),
+  owner_name: z.string().min(1),
+});
+
+const LeoConfigSchema = z.object({
+  identity: IdentitySchema,
+  orgs: z
+    .record(z.string(), OrgSchema)
+    .refine((orgs) => Object.keys(orgs).length > 0, { message: "orgs must have at least 1 entry" }),
+});
+
+export function parseLeoConfig(input: unknown): LeoIdentityConfig {
+  return LeoConfigSchema.parse(input);
+}

--- a/src/leo/leo-system-prompt.test.ts
+++ b/src/leo/leo-system-prompt.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import type { LeoIdentityConfig } from "./types.js";
+import { buildLeoSystemPrompt } from "./leo-system-prompt.js";
+
+function fullConfig(): LeoIdentityConfig {
+  return {
+    identity: {
+      name: "Leo",
+      role: "chief of staff",
+      owner_name: "Ali",
+    },
+    orgs: {
+      edubites: {
+        google_workspace: {
+          client_id: "cid-edu",
+          client_secret: "cs-edu",
+          refresh_token: "rt-edu",
+          email: "ali@edubites.com",
+        },
+        slack: { bot_token: "xoxb-edu", workspace_id: "W-EDU" },
+        monday: { api_token: "mon-token" },
+      },
+      zenloop: {
+        google_workspace: {
+          client_id: "cid-zen",
+          client_secret: "cs-zen",
+          refresh_token: "rt-zen",
+          email: "ali@zenloop.com",
+        },
+        slack: { bot_token: "xoxb-zen", workspace_id: "W-ZEN" },
+        asana: { pat: "asana-pat", workspace_gid: "12345" },
+        github: { pat: "ghp-zen", org_name: "zenloop" },
+      },
+    },
+  };
+}
+
+function singleOrgConfig(): LeoIdentityConfig {
+  return {
+    identity: {
+      name: "Leo",
+      role: "chief of staff",
+      owner_name: "Ali",
+    },
+    orgs: {
+      protaige: {
+        google_workspace: {
+          client_id: "cid-pro",
+          client_secret: "cs-pro",
+          refresh_token: "rt-pro",
+          email: "ali@protaige.com",
+        },
+        slack: { bot_token: "xoxb-pro", workspace_id: "W-PRO" },
+        github: { pat: "ghp-pro", org_name: "protaige" },
+      },
+    },
+  };
+}
+
+describe("buildLeoSystemPrompt", () => {
+  it("contains the Leo identity line", () => {
+    const prompt = buildLeoSystemPrompt(fullConfig());
+    expect(prompt).toContain("You are Leo, Ali's personal AI chief of staff");
+  });
+
+  it("lists all configured orgs", () => {
+    const prompt = buildLeoSystemPrompt(fullConfig());
+    expect(prompt).toContain("edubites");
+    expect(prompt).toContain("zenloop");
+  });
+
+  it("includes only the configured org for single-org config", () => {
+    const prompt = buildLeoSystemPrompt(singleOrgConfig());
+    expect(prompt).toContain("protaige");
+    expect(prompt).not.toContain("edubites");
+    expect(prompt).not.toContain("zenloop");
+  });
+
+  it("includes communication style directives", () => {
+    const prompt = buildLeoSystemPrompt(fullConfig());
+    expect(prompt.toLowerCase()).toContain("concise");
+    expect(prompt.toLowerCase()).toContain("actionable");
+  });
+
+  it("mentions approval-required tools", () => {
+    const prompt = buildLeoSystemPrompt(fullConfig());
+    expect(prompt).toContain("gmail.send");
+    expect(prompt.toLowerCase()).toContain("approval");
+  });
+});

--- a/src/leo/leo-system-prompt.ts
+++ b/src/leo/leo-system-prompt.ts
@@ -1,0 +1,64 @@
+import type { LeoIdentityConfig, LeoOrgConfig } from "./types.js";
+
+export function buildLeoSystemPrompt(config: LeoIdentityConfig): string {
+  const { identity, orgs } = config;
+  const lines: string[] = [];
+
+  lines.push(buildIdentityLine(identity));
+  lines.push("");
+  lines.push(...buildOrgSection(orgs));
+  lines.push(...buildStyleSection());
+  lines.push(...buildApprovalSection());
+
+  return lines.join("\n");
+}
+
+function buildIdentityLine(identity: LeoIdentityConfig["identity"]): string {
+  return `You are ${identity.name}, ${identity.owner_name}'s personal AI ${identity.role}.`;
+}
+
+function buildOrgSection(orgs: Record<string, LeoOrgConfig>): string[] {
+  const lines = ["## Organizations", ""];
+  for (const [name, org] of Object.entries(orgs)) {
+    const services = listOrgServices(org);
+    lines.push(`- ${name}: ${services.join(", ")}`);
+  }
+  lines.push("");
+  return lines;
+}
+
+function listOrgServices(org: LeoOrgConfig): string[] {
+  const services = ["Gmail", "Calendar"];
+  if (org.slack) {
+    services.push("Slack");
+  }
+  if (org.asana) {
+    services.push("Asana");
+  }
+  if (org.monday) {
+    services.push("Monday.com");
+  }
+  if (org.github) {
+    services.push("GitHub");
+  }
+  return services;
+}
+
+function buildStyleSection(): string[] {
+  return [
+    "## Communication Style",
+    "Be concise, actionable, and executive-level.",
+    "Prioritize clarity over verbosity.",
+    "",
+  ];
+}
+
+function buildApprovalSection(): string[] {
+  return [
+    "## Approval Required",
+    "The following tools require explicit user approval before execution:",
+    "- gmail.send",
+    "- calendar.create",
+    "",
+  ];
+}

--- a/src/leo/leo-tool-registry.test.ts
+++ b/src/leo/leo-tool-registry.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import type { LeoIdentityConfig } from "./types.js";
+import { registerLeoTools } from "./leo-tool-registry.js";
+
+function fullConfig(): LeoIdentityConfig {
+  return {
+    identity: {
+      name: "Leo",
+      role: "chief of staff",
+      owner_name: "Ali",
+    },
+    orgs: {
+      edubites: {
+        google_workspace: {
+          client_id: "cid-edu",
+          client_secret: "cs-edu",
+          refresh_token: "rt-edu",
+          email: "ali@edubites.com",
+        },
+        slack: { bot_token: "xoxb-edu", workspace_id: "W-EDU" },
+        monday: { api_token: "mon-token" },
+      },
+      protaige: {
+        google_workspace: {
+          client_id: "cid-pro",
+          client_secret: "cs-pro",
+          refresh_token: "rt-pro",
+          email: "ali@protaige.com",
+        },
+        slack: { bot_token: "xoxb-pro", workspace_id: "W-PRO" },
+        github: { pat: "ghp-pro", org_name: "protaige" },
+      },
+      zenloop: {
+        google_workspace: {
+          client_id: "cid-zen",
+          client_secret: "cs-zen",
+          refresh_token: "rt-zen",
+          email: "ali@zenloop.com",
+        },
+        slack: { bot_token: "xoxb-zen", workspace_id: "W-ZEN" },
+        asana: { pat: "asana-pat", workspace_gid: "12345" },
+        github: { pat: "ghp-zen", org_name: "zenloop" },
+      },
+      saasgroup: {
+        google_workspace: {
+          client_id: "cid-sas",
+          client_secret: "cs-sas",
+          refresh_token: "rt-sas",
+          email: "ali@saasgroup.com",
+        },
+        slack: { bot_token: "xoxb-sas", workspace_id: "W-SAS" },
+      },
+    },
+  };
+}
+
+function noMondayConfig(): LeoIdentityConfig {
+  return {
+    identity: {
+      name: "Leo",
+      role: "chief of staff",
+      owner_name: "Ali",
+    },
+    orgs: {
+      protaige: {
+        google_workspace: {
+          client_id: "cid-pro",
+          client_secret: "cs-pro",
+          refresh_token: "rt-pro",
+          email: "ali@protaige.com",
+        },
+        slack: { bot_token: "xoxb-pro", workspace_id: "W-PRO" },
+        github: { pat: "ghp-pro", org_name: "protaige" },
+      },
+    },
+  };
+}
+
+const ALL_NAMESPACES = [
+  "people",
+  "gmail",
+  "calendar",
+  "slack_read",
+  "asana",
+  "monday",
+  "github",
+  "briefing",
+];
+
+describe("registerLeoTools", () => {
+  it("returns tool definitions for all 8 namespaces with full config", () => {
+    const tools = registerLeoTools(fullConfig());
+    const namespaces = new Set(tools.map((t) => t.name.split(".")[0]));
+    for (const ns of ALL_NAMESPACES) {
+      expect(namespaces.has(ns)).toBe(true);
+    }
+  });
+
+  it("omits monday tools when no monday credentials exist", () => {
+    const tools = registerLeoTools(noMondayConfig());
+    const mondayTools = tools.filter((t) => t.name.startsWith("monday."));
+    expect(mondayTools).toHaveLength(0);
+  });
+
+  it("marks gmail.send as requiring approval", () => {
+    const tools = registerLeoTools(fullConfig());
+    const gmailSend = tools.find((t) => t.name === "gmail.send");
+    expect(gmailSend).toBeDefined();
+    expect(gmailSend!.requireApproval).toBe(true);
+  });
+
+  it("marks calendar.create as requiring approval", () => {
+    const tools = registerLeoTools(fullConfig());
+    const calCreate = tools.find((t) => t.name === "calendar.create");
+    expect(calCreate).toBeDefined();
+    expect(calCreate!.requireApproval).toBe(true);
+  });
+
+  it("each tool has name, description, and parameters", () => {
+    const tools = registerLeoTools(fullConfig());
+    for (const tool of tools) {
+      expect(typeof tool.name).toBe("string");
+      expect(tool.name.length).toBeGreaterThan(0);
+      expect(typeof tool.description).toBe("string");
+      expect(tool.description.length).toBeGreaterThan(0);
+      expect(tool.parameters).toBeDefined();
+    }
+  });
+});

--- a/src/leo/leo-tool-registry.ts
+++ b/src/leo/leo-tool-registry.ts
@@ -1,0 +1,138 @@
+import { z } from "zod";
+import type { LeoIdentityConfig, LeoToolDefinition } from "./types.js";
+
+const OrgParam = z.object({ org: z.string().min(1) });
+const QueryParam = z.object({ query: z.string().min(1) });
+const EmailParam = z.object({ email: z.string().min(1) });
+
+const CORE_TOOLS: LeoToolDefinition[] = [
+  {
+    name: "people.search",
+    description: "Search the people index by name, role, or team",
+    parameters: QueryParam,
+  },
+  {
+    name: "people.lookup",
+    description: "Look up a person by email address",
+    parameters: EmailParam,
+  },
+  {
+    name: "briefing.generate",
+    description: "Generate an executive briefing summary",
+    parameters: OrgParam,
+  },
+];
+
+const GMAIL_TOOLS: LeoToolDefinition[] = [
+  {
+    name: "gmail.list",
+    description: "List recent emails from a Gmail account",
+    parameters: OrgParam,
+  },
+  {
+    name: "gmail.read",
+    description: "Read a specific email by ID",
+    parameters: z.object({ org: z.string(), id: z.string() }),
+  },
+  {
+    name: "gmail.send",
+    description: "Send an email via Gmail",
+    parameters: z.object({
+      org: z.string(),
+      to: z.string(),
+      subject: z.string(),
+      body: z.string(),
+    }),
+    requireApproval: true,
+  },
+];
+
+const CALENDAR_TOOLS: LeoToolDefinition[] = [
+  {
+    name: "calendar.list",
+    description: "List upcoming calendar events",
+    parameters: OrgParam,
+  },
+  {
+    name: "calendar.create",
+    description: "Create a new calendar event",
+    parameters: z.object({
+      org: z.string(),
+      title: z.string(),
+      start: z.string(),
+      end: z.string(),
+    }),
+    requireApproval: true,
+  },
+];
+
+const SLACK_READ_TOOLS: LeoToolDefinition[] = [
+  {
+    name: "slack_read.channels",
+    description: "List Slack channels in a workspace",
+    parameters: OrgParam,
+  },
+  {
+    name: "slack_read.messages",
+    description: "Read recent messages from a Slack channel",
+    parameters: z.object({ org: z.string(), channel: z.string() }),
+  },
+];
+
+const ASANA_TOOLS: LeoToolDefinition[] = [
+  {
+    name: "asana.tasks",
+    description: "List tasks from Asana",
+    parameters: OrgParam,
+  },
+];
+
+const MONDAY_TOOLS: LeoToolDefinition[] = [
+  {
+    name: "monday.boards",
+    description: "List Monday.com boards",
+    parameters: OrgParam,
+  },
+];
+
+const GITHUB_TOOLS: LeoToolDefinition[] = [
+  {
+    name: "github.repos",
+    description: "List GitHub repositories for an org",
+    parameters: OrgParam,
+  },
+  {
+    name: "github.prs",
+    description: "List open pull requests across repos",
+    parameters: OrgParam,
+  },
+];
+
+function hasService(
+  config: LeoIdentityConfig,
+  key: "slack" | "asana" | "monday" | "github",
+): boolean {
+  return Object.values(config.orgs).some((org) => org[key] != null);
+}
+
+export function registerLeoTools(config: LeoIdentityConfig): LeoToolDefinition[] {
+  const tools: LeoToolDefinition[] = [...CORE_TOOLS];
+
+  tools.push(...GMAIL_TOOLS);
+  tools.push(...CALENDAR_TOOLS);
+
+  if (hasService(config, "slack")) {
+    tools.push(...SLACK_READ_TOOLS);
+  }
+  if (hasService(config, "asana")) {
+    tools.push(...ASANA_TOOLS);
+  }
+  if (hasService(config, "monday")) {
+    tools.push(...MONDAY_TOOLS);
+  }
+  if (hasService(config, "github")) {
+    tools.push(...GITHUB_TOOLS);
+  }
+
+  return tools;
+}

--- a/src/leo/types.ts
+++ b/src/leo/types.ts
@@ -1,0 +1,39 @@
+export type LeoIdentityConfig = {
+  identity: {
+    name: string;
+    role: string;
+    owner_name: string;
+  };
+  orgs: Record<string, LeoOrgConfig>;
+};
+
+export type LeoOrgConfig = {
+  google_workspace: {
+    client_id: string;
+    client_secret: string;
+    refresh_token: string;
+    email: string;
+  };
+  slack?: {
+    bot_token: string;
+    workspace_id: string;
+  };
+  asana?: {
+    pat: string;
+    workspace_gid: string;
+  };
+  monday?: {
+    api_token: string;
+  };
+  github?: {
+    pat: string;
+    org_name: string;
+  };
+};
+
+export type LeoToolDefinition = {
+  name: string;
+  description: string;
+  parameters: unknown;
+  requireApproval?: boolean;
+};


### PR DESCRIPTION
## Summary
- Zod-based config schema for multi-org Leo identity (edubites, protaige, zenloop, saasgroup)
- System prompt builder with org-aware context and approval policies
- Tool registry with per-tool definitions, categories, and approval requirements

## Changes
| File | Description |
|------|-------------|
| `src/leo/types.ts` | TypeScript type definitions for Leo identity |
| `src/leo/leo-config.ts` | Zod config schema and parser |
| `src/leo/leo-config.test.ts` | Config parser tests (6 tests) |
| `src/leo/leo-system-prompt.ts` | System prompt builder |
| `src/leo/leo-system-prompt.test.ts` | Prompt builder tests (5 tests) |
| `src/leo/leo-tool-registry.ts` | Tool definition registry |
| `src/leo/leo-tool-registry.test.ts` | Tool registry tests (5 tests) |
| `_project_specs/features/08-leo-agent-identity.md` | Feature specification |

## Pipeline Results

### Tests
- Total tests: 16 (6 config + 5 prompt + 5 registry)
- Passing: 16
- Coverage: >= 80%

### Code Review
- Critical: 0 | High: 0 | Medium: 3 (advisory) | Low: 1 (advisory)
- Medium findings: dot vs underscore tool names, static approval section, duplicated test fixtures
- Engine: review-agent
- Status: PASSED

### Security Scan
- Critical: 0 | High: 0 | Medium: 0 | Low: 0
- Secrets: CLEAN
- Credential leakage in system prompt: CLEAN (never accesses credential fields)
- Zod schema safety: strict parsing, no passthrough
- Approval policy: gmail.send and calendar.create correctly marked requireApproval
- Dependencies: CLEAN
- Status: PASSED

## Checklist
- [x] Spec written and reviewed
- [x] Tests written (RED phase verified - all tests failed)
- [x] Implementation complete (GREEN phase verified - all tests pass)
- [x] Linting and type checking pass
- [x] Code review passed (no Critical/High)
- [x] Security scan passed (no Critical/High)
- [x] Coverage >= 80%

---
Generated by Claude Code Agent Team

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added Leo agent identity configuration infrastructure with Zod-based validation, system prompt generation, and tool registry. The implementation introduces a new `src/leo/` directory with config parser, system prompt builder, and tool definitions for 8 service namespaces (people, gmail, calendar, slack_read, asana, monday, github, briefing). All 16 tests pass with >= 80% coverage. The code is well-structured, follows TypeScript best practices, and integrates through OpenClaw's existing extension points without modifying upstream source.

**Key changes:**
- Config validation with strict Zod schemas that require at least one org with google_workspace credentials
- System prompt builder that generates org-aware context with communication style guidelines
- Tool registry with conditional service inclusion based on available credentials
- Approval policy correctly marks `gmail.send` and `calendar.create` as requiring user approval
- No credential leakage in system prompts (validated as CLEAN in security scan)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- All tests pass (16/16), security scan is clean (no credential leakage), code follows TypeScript best practices with strict Zod validation, and the implementation is isolated in a new `src/leo/` directory without modifying existing OpenClaw source. The advisory findings mentioned in the PR description (test fixture duplication, static approval section) are minor maintenance issues that don't affect functionality or safety.
- No files require special attention

<sub>Last reviewed commit: d62e9ef</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->