### PR TITLE
fix(memory-flush): add softThresholdPercent for context-relative threshold

### DIFF
--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -73,6 +73,7 @@ export async function runMemoryFlushIfNeeded(params: {
       }),
       reserveTokensFloor: memoryFlushSettings.reserveTokensFloor,
       softThresholdTokens: memoryFlushSettings.softThresholdTokens,
+      softThresholdPercent: memoryFlushSettings.softThresholdPercent,
     });
 
   if (!shouldFlushMemory) {

--- a/src/auto-reply/reply/memory-flush.ts
+++ b/src/auto-reply/reply/memory-flush.ts
@@ -22,7 +22,10 @@ export const DEFAULT_MEMORY_FLUSH_SYSTEM_PROMPT = [
 
 export type MemoryFlushSettings = {
   enabled: boolean;
+  /** Absolute soft threshold tokens (fallback if softThresholdPercent not set). */
   softThresholdTokens: number;
+  /** Optional percentage of context window for soft threshold (e.g., 2 = 2%). Overrides softThresholdTokens if set. */
+  softThresholdPercent?: number;
   prompt: string;
   systemPrompt: string;
   reserveTokensFloor: number;
@@ -44,6 +47,7 @@ export function resolveMemoryFlushSettings(cfg?: OpenClawConfig): MemoryFlushSet
   }
   const softThresholdTokens =
     normalizeNonNegativeInt(defaults?.softThresholdTokens) ?? DEFAULT_MEMORY_FLUSH_SOFT_TOKENS;
+  const softThresholdPercent = defaults?.softThresholdPercent;
   const prompt = defaults?.prompt?.trim() || DEFAULT_MEMORY_FLUSH_PROMPT;
   const systemPrompt = defaults?.systemPrompt?.trim() || DEFAULT_MEMORY_FLUSH_SYSTEM_PROMPT;
   const reserveTokensFloor =
@@ -53,6 +57,7 @@ export function resolveMemoryFlushSettings(cfg?: OpenClawConfig): MemoryFlushSet
   return {
     enabled,
     softThresholdTokens,
+    softThresholdPercent,
     prompt: ensureNoReplyHint(prompt),
     systemPrompt: ensureNoReplyHint(systemPrompt),
     reserveTokensFloor,
@@ -83,6 +88,7 @@ export function shouldRunMemoryFlush(params: {
   contextWindowTokens: number;
   reserveTokensFloor: number;
   softThresholdTokens: number;
+  softThresholdPercent?: number;
 }): boolean {
   const totalTokens = resolveFreshSessionTotalTokens(params.entry);
   if (!totalTokens || totalTokens <= 0) {
@@ -90,7 +96,14 @@ export function shouldRunMemoryFlush(params: {
   }
   const contextWindow = Math.max(1, Math.floor(params.contextWindowTokens));
   const reserveTokens = Math.max(0, Math.floor(params.reserveTokensFloor));
-  const softThreshold = Math.max(0, Math.floor(params.softThresholdTokens));
+  // If softThresholdPercent is set, calculate threshold as percentage of context window
+  // Otherwise, use the absolute softThresholdTokens value
+  let softThreshold: number;
+  if (typeof params.softThresholdPercent === "number" && params.softThresholdPercent > 0) {
+    softThreshold = Math.floor(contextWindow * (params.softThresholdPercent / 100));
+  } else {
+    softThreshold = Math.max(0, Math.floor(params.softThresholdTokens));
+  }
   const threshold = Math.max(0, contextWindow - reserveTokens - softThreshold);
   if (threshold <= 0) {
     return false;

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -263,6 +263,8 @@ export type AgentCompactionMemoryFlushConfig = {
   enabled?: boolean;
   /** Run the memory flush when context is within this many tokens of the compaction threshold. */
   softThresholdTokens?: number;
+  /** Percentage of context window for soft threshold (e.g., 2 = 2%%). Overrides softThresholdTokens if set. */
+  softThresholdPercent?: number;
   /** User prompt used for the memory flush turn (NO_REPLY is enforced if missing). */
   prompt?: string;
   /** System prompt appended for the memory flush turn. */


### PR DESCRIPTION
Fixes #17034

## Problem
Memory flush softThresholdTokens is an absolute value (default 4000). On large context models (1M tokens), this threshold is never reached, so memory flush never triggers.

## Solution
Add softThresholdPercent config option that calculates threshold as a percentage of context window:
- Example: softThresholdPercent: 2 = 2%% of context window
- For 1M context: 2%% = 20K tokens (reaches threshold)
- For 200K context: 2%% = 4K tokens (equivalent to default)

## Usage
```yaml
agents:
  defaults:
    compaction:
      memoryFlush:
        softThresholdPercent: 2  # Use 2%% of context window
```

## Impact
- Memory flush now works correctly on all context window sizes
- Backward compatible: existing softThresholdTokens still works

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `softThresholdPercent` config option to calculate memory flush threshold as a percentage of context window, solving the issue where absolute threshold values don't scale with large context models (e.g., 1M tokens). The implementation correctly passes the new parameter through the call chain and applies it in the threshold calculation with proper fallback to `softThresholdTokens`. The change is backward compatible.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor style improvement suggested
- The implementation correctly solves the stated problem with proper logic flow and backward compatibility. The threshold calculation has appropriate safeguards (`Math.max`, type checks). One style suggestion for input validation consistency.
- No files require special attention

<sub>Last reviewed commit: fd0b6da</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->