### PR TITLE
fix(cron): prevent control-plane starvation during startup catch-up and manual runs

### DIFF
--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -45,7 +45,7 @@ function errorBackoffMs(consecutiveErrors: number): number {
  * Handles consecutive error tracking, exponential backoff, one-shot disable,
  * and nextRunAtMs computation. Returns `true` if the job should be deleted.
  */
-function applyJobResult(
+export function applyJobResult(
   state: CronServiceState,
   job: CronJob,
   result: {
@@ -423,7 +423,7 @@ export async function runDueJobs(state: CronServiceState) {
   }
 }
 
-async function executeJobCore(
+export async function executeJobCore(
   state: CronServiceState,
   job: CronJob,
 ): Promise<{


### PR DESCRIPTION
## Bug fix: cron control-plane starvation

This PR fixes a scheduler bug where cron control-plane RPCs (`cron.status/list/run/runs`) could stall or time out when startup catch-up or manual runs executed while holding the cron store lock.

## Root cause
Two paths held the cron lock across job execution:
1. Startup catch-up replay (`start()` -> `runMissedJobs()`)
2. Manual runs (`run()`)

Because job execution can be long-running, lock hold time starved control RPCs.

## Fix
### 1) Startup path
- Keep startup lock scope to load/repair/recompute/persist/timer-arm.
- Run missed-job replay **after** lock release.
- Replay is gated by `cronEnabled`.

### 2) Manual run path
- Split into phases:
  - **prepare (locked):** validate due-state, set `runningAtMs`, clear `lastError`, emit `started`, persist, snapshot job
  - **execute (unlocked):** execute payload from snapshot (`executeJobCore`)
  - **finalize (locked):** reload store, re-find job by id, apply result, emit `finished`/`removed`, recompute, persist, arm timer

This preserves behavior while avoiding stale unlocked store mutation and keeping control operations responsive.

## Behavior preserved
- `already-running` / `not-due` return semantics unchanged.
- One-shot disable/remove behavior unchanged.
- Event emissions remain (`started`, `finished`, `removed`).

## Validation
- `pnpm format:check`
- `pnpm tsgo`
