### PR TITLE
feat(discord): download attachments from forwarded messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -544,6 +544,7 @@ Docs: https://docs.openclaw.ai
 - Thinking: allow xhigh for `github-copilot/gpt-5.2-codex` and `github-copilot/gpt-5.2`. (#11646) Thanks @LatencyTDH.
 - Thinking: honor `/think off` for reasoning-capable models. (#9564) Thanks @liuy.
 - Discord: support forum/media thread-create starter messages, wire `message thread create --message`, and harden routing. (#10062) Thanks @jarvis89757.
+- Discord: download attachments from forwarded messages. (#17049) Thanks @pip-nomel, @thewilloftheshadow.
 - Paths: structurally resolve `OPENCLAW_HOME`-derived home paths and fix Windows drive-letter handling in tool meta shortening. (#12125) Thanks @mcaxtr.
 - Memory: set Voyage embeddings `input_type` for improved retrieval. (#10818) Thanks @mcinteerj.
 - Memory: disable async batch embeddings by default for memory indexing (opt-in via `agents.defaults.memorySearch.remote.batch.enabled`). (#13069) Thanks @mcinteerj.

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -29,6 +29,7 @@ import { resolveTimestampMs } from "./format.js";
 import {
   buildDiscordMediaPayload,
   resolveDiscordMessageText,
+  resolveForwardedMediaList,
   resolveMediaList,
 } from "./message-utils.js";
 import { buildDirectLabel, buildGuildLabel, resolveReplyContext } from "./reply-context.js";
@@ -315,6 +316,8 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
   } = ctx;
 
   const mediaList = await resolveMediaList(message, mediaMaxBytes);
+  const forwardedMediaList = await resolveForwardedMediaList(message, mediaMaxBytes);
+  mediaList.push(...forwardedMediaList);
   const text = messageText;
   if (!text) {
     logVerbose(`discord: drop message ${message.id} (empty content)`);

--- a/src/discord/monitor/message-utils.test.ts
+++ b/src/discord/monitor/message-utils.test.ts
@@ -1,9 +1,27 @@
 import type { Message } from "@buape/carbon";
-import { describe, expect, it } from "vitest";
-import { resolveDiscordMessageChannelId } from "./message-utils.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const fetchRemoteMedia = vi.fn();
+const saveMediaBuffer = vi.fn();
+
+vi.mock("../../media/fetch.js", () => ({
+  fetchRemoteMedia: (...args: unknown[]) => fetchRemoteMedia(...args),
+}));
+
+vi.mock("../../media/store.js", () => ({
+  saveMediaBuffer: (...args: unknown[]) => saveMediaBuffer(...args),
+}));
+
+vi.mock("../../globals.js", () => ({
+  logVerbose: () => {},
+}));
+
+const { resolveDiscordMessageChannelId, resolveForwardedMediaList } = await import(
+  "./message-utils.js",
+);
 
 function asMessage(payload: Record<string, unknown>): Message {
-  return payload as unknown as Message;
+  return payload as Message;
 }
 
 describe("resolveDiscordMessageChannelId", () => {
@@ -34,5 +52,74 @@ describe("resolveDiscordMessageChannelId", () => {
       eventChannelId: 789,
     });
     expect(channelId).toBe("789");
+  });
+});
+
+describe("resolveForwardedMediaList", () => {
+  beforeEach(() => {
+    fetchRemoteMedia.mockReset();
+    saveMediaBuffer.mockReset();
+  });
+
+  it("downloads forwarded attachments", async () => {
+    const attachment = {
+      id: "att-1",
+      url: "https://cdn.discordapp.com/attachments/1/image.png",
+      filename: "image.png",
+      content_type: "image/png",
+    };
+    fetchRemoteMedia.mockResolvedValueOnce({
+      buffer: Buffer.from("image"),
+      contentType: "image/png",
+    });
+    saveMediaBuffer.mockResolvedValueOnce({
+      path: "/tmp/image.png",
+      contentType: "image/png",
+    });
+
+    const result = await resolveForwardedMediaList(
+      asMessage({
+        rawData: {
+          message_snapshots: [{ message: { attachments: [attachment] } }],
+        },
+      }),
+      512,
+    );
+
+    expect(fetchRemoteMedia).toHaveBeenCalledTimes(1);
+    expect(fetchRemoteMedia).toHaveBeenCalledWith({
+      url: attachment.url,
+      filePathHint: attachment.filename,
+    });
+    expect(saveMediaBuffer).toHaveBeenCalledTimes(1);
+    expect(saveMediaBuffer).toHaveBeenCalledWith(expect.any(Buffer), "image/png", "inbound", 512);
+    expect(result).toEqual([
+      {
+        path: "/tmp/image.png",
+        contentType: "image/png",
+        placeholder: "<media:image>",
+      },
+    ]);
+  });
+
+  it("returns empty when no snapshots are present", async () => {
+    const result = await resolveForwardedMediaList(asMessage({}), 512);
+
+    expect(result).toEqual([]);
+    expect(fetchRemoteMedia).not.toHaveBeenCalled();
+  });
+
+  it("skips snapshots without attachments", async () => {
+    const result = await resolveForwardedMediaList(
+      asMessage({
+        rawData: {
+          message_snapshots: [{ message: { content: "hello" } }],
+        },
+      }),
+      512,
+    );
+
+    expect(result).toEqual([]);
+    expect(fetchRemoteMedia).not.toHaveBeenCalled();
   });
 });

--- a/src/discord/monitor/message-utils.test.ts
+++ b/src/discord/monitor/message-utils.test.ts
@@ -16,9 +16,8 @@ vi.mock("../../globals.js", () => ({
   logVerbose: () => {},
 }));
 
-const { resolveDiscordMessageChannelId, resolveForwardedMediaList } = await import(
-  "./message-utils.js",
-);
+const { resolveDiscordMessageChannelId, resolveForwardedMediaList } =
+  await import("./message-utils.js");
 
 function asMessage(payload: Record<string, unknown>): Message {
   return payload as Message;

--- a/src/discord/monitor/message-utils.ts
+++ b/src/discord/monitor/message-utils.ts
@@ -285,7 +285,7 @@ function resolveDiscordForwardedMessagesText(message: Message): string {
   return forwardedBlocks.join("\n\n");
 }
 
-export function resolveDiscordMessageSnapshots(message: Message): DiscordMessageSnapshot[] {
+function resolveDiscordMessageSnapshots(message: Message): DiscordMessageSnapshot[] {
   const rawData = (message as { rawData?: { message_snapshots?: unknown } }).rawData;
   const snapshots =
     rawData?.message_snapshots ??

--- a/src/discord/monitor/message-utils.ts
+++ b/src/discord/monitor/message-utils.ts
@@ -156,6 +156,46 @@ export async function resolveMediaList(
   return out;
 }
 
+export async function resolveForwardedMediaList(
+  message: Message,
+  maxBytes: number,
+): Promise<DiscordMediaInfo[]> {
+  const snapshots = resolveDiscordMessageSnapshots(message);
+  if (snapshots.length === 0) {
+    return [];
+  }
+  const out: DiscordMediaInfo[] = [];
+  for (const snapshot of snapshots) {
+    const attachments = snapshot.message?.attachments;
+    if (!attachments || attachments.length === 0) {
+      continue;
+    }
+    for (const attachment of attachments) {
+      try {
+        const fetched = await fetchRemoteMedia({
+          url: attachment.url,
+          filePathHint: attachment.filename ?? attachment.url,
+        });
+        const saved = await saveMediaBuffer(
+          fetched.buffer,
+          fetched.contentType ?? attachment.content_type,
+          "inbound",
+          maxBytes,
+        );
+        out.push({
+          path: saved.path,
+          contentType: saved.contentType,
+          placeholder: inferPlaceholder(attachment),
+        });
+      } catch (err) {
+        const id = attachment.id ?? attachment.url;
+        logVerbose(`discord: failed to download forwarded attachment ${id}: ${String(err)}`);
+      }
+    }
+  }
+  return out;
+}
+
 function inferPlaceholder(attachment: APIAttachment): string {
   const mime = attachment.content_type ?? "";
   if (mime.startsWith("image/")) {
@@ -245,7 +285,7 @@ function resolveDiscordForwardedMessagesText(message: Message): string {
   return forwardedBlocks.join("\n\n");
 }
 
-function resolveDiscordMessageSnapshots(message: Message): DiscordMessageSnapshot[] {
+export function resolveDiscordMessageSnapshots(message: Message): DiscordMessageSnapshot[] {
   const rawData = (message as { rawData?: { message_snapshots?: unknown } }).rawData;
   const snapshots =
     rawData?.message_snapshots ??


### PR DESCRIPTION
## Problem

Discord forwarded messages (using the forward/share feature) include their attachments in `message_snapshots`, but OpenClaw only extracted the text content from these snapshots. Attachments like images were rendered as text placeholders (e.g. `[Image: file.png]`) but never actually downloaded.

## Solution

- Added `resolveForwardedMediaList()` in `message-utils.ts` which iterates over `message_snapshots`, extracts attachments, and downloads them using the existing `fetchRemoteMedia`/`saveMediaBuffer` flow
- Called it alongside `resolveMediaList()` in `processDiscordMessage()` and merged the results into the media list
- Exported `resolveDiscordMessageSnapshots()` for reuse

## Notes

- `@buape/carbon` stores the full Discord gateway payload in `Message._rawData`, so `message_snapshots` is accessible via `message.rawData.message_snapshots`
- The fix follows the same pattern as regular attachment downloading
- Tested with real forwarded messages containing image attachments

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements attachment downloading for Discord forwarded messages by extracting attachments from `message_snapshots` and processing them through the existing media pipeline.

- Added `resolveForwardedMediaList()` function that mirrors the existing `resolveMediaList()` pattern
- Exported `resolveDiscordMessageSnapshots()` for reuse
- Integration point calls both functions and merges results into single media list

The implementation correctly follows established patterns for attachment handling, uses existing SSRF-protected fetch utilities, and handles errors gracefully with verbose logging.

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no blocking issues
- The implementation correctly mirrors the existing `resolveMediaList()` pattern, reuses secure media fetching utilities with SSRF protection, handles errors appropriately, and integrates cleanly without modifying existing behavior. The code is straightforward and follows the codebase's established conventions.
- No files require special attention

<sub>Last reviewed commit: 51abf4d</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->