### PR TITLE
Fix voice-call webhook server crash on EADDRINUSE

### DIFF
--- a/extensions/voice-call/src/webhook-eaddrinuse.test.ts
+++ b/extensions/voice-call/src/webhook-eaddrinuse.test.ts
@@ -1,0 +1,89 @@
+import http from "node:http";
+import { describe, it, expect, afterEach } from "vitest";
+import { VoiceCallWebhookServer } from "./webhook.js";
+
+// Occupy a port so the webhook server hits EADDRINUSE
+function occupyPort(port: number): Promise<http.Server> {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer();
+    server.on("error", reject);
+    server.listen(port, "127.0.0.1", () => resolve(server));
+  });
+}
+
+function closeServer(server: http.Server | null): Promise<void> {
+  return new Promise((resolve) => {
+    if (!server) return resolve();
+    server.close(() => resolve());
+  });
+}
+
+describe("VoiceCallWebhookServer EADDRINUSE retry", () => {
+  const servers: http.Server[] = [];
+  let webhook: VoiceCallWebhookServer | null = null;
+
+  afterEach(async () => {
+    if (webhook) {
+      await webhook.stop();
+      webhook = null;
+    }
+    for (const s of servers) {
+      await closeServer(s);
+    }
+    servers.length = 0;
+  });
+
+  it("falls back to next port when configured port is occupied", async () => {
+    const basePort = 19876;
+    const blocker = await occupyPort(basePort);
+    servers.push(blocker);
+
+    webhook = new VoiceCallWebhookServer({
+      serve: { port: basePort, bind: "127.0.0.1", path: "/voice/webhook" },
+      providers: {},
+    });
+
+    const url = await webhook.start();
+    expect(url).toBe(`http://127.0.0.1:${basePort + 1}/voice/webhook`);
+  });
+
+  it("skips multiple occupied ports", async () => {
+    const basePort = 19877;
+    servers.push(await occupyPort(basePort));
+    servers.push(await occupyPort(basePort + 1));
+
+    webhook = new VoiceCallWebhookServer({
+      serve: { port: basePort, bind: "127.0.0.1", path: "/voice/webhook" },
+      providers: {},
+    });
+
+    const url = await webhook.start();
+    expect(url).toBe(`http://127.0.0.1:${basePort + 2}/voice/webhook`);
+  });
+
+  it("throws after exhausting retries", async () => {
+    const basePort = 19880;
+    for (let i = 0; i <= 3; i++) {
+      servers.push(await occupyPort(basePort + i));
+    }
+
+    webhook = new VoiceCallWebhookServer({
+      serve: { port: basePort, bind: "127.0.0.1", path: "/voice/webhook" },
+      providers: {},
+    });
+
+    await expect(webhook.start()).rejects.toThrow();
+  });
+
+  it("starts on configured port when available", async () => {
+    const basePort = 19884;
+
+    webhook = new VoiceCallWebhookServer({
+      serve: { port: basePort, bind: "127.0.0.1", path: "/voice/webhook" },
+      providers: {},
+    });
+
+    const url = await webhook.start();
+    expect(url).toBe(`http://127.0.0.1:${basePort}/voice/webhook`);
+  });
+});

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -208,7 +208,37 @@ export class VoiceCallWebhookServer {
   async start(): Promise<string> {
     const { port, bind, path: webhookPath } = this.config.serve;
     const streamPath = this.config.streaming?.streamPath || "/voice/stream";
+    const maxRetries = 3;
 
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      const tryPort = port + attempt;
+      try {
+        const url = await this.tryListen(tryPort, bind, webhookPath, streamPath);
+        if (attempt > 0) {
+          console.log(`[voice-call] Port ${port} was in use, fell back to ${tryPort}`);
+        }
+        return url;
+      } catch (err) {
+        const isAddrInUse =
+          err instanceof Error &&
+          "code" in err &&
+          (err as NodeJS.ErrnoException).code === "EADDRINUSE";
+        if (!isAddrInUse || attempt === maxRetries) {
+          throw err;
+        }
+        console.warn(`[voice-call] Port ${tryPort} in use (EADDRINUSE), trying ${tryPort + 1}…`);
+      }
+    }
+    // Unreachable, but satisfies TypeScript
+    throw new Error(`[voice-call] Failed to bind after ${maxRetries + 1} attempts`);
+  }
+
+  private tryListen(
+    port: number,
+    bind: string,
+    webhookPath: string,
+    streamPath: string,
+  ): Promise<string> {
     return new Promise((resolve, reject) => {
       this.server = http.createServer((req, res) => {
         this.handleRequest(req, res, webhookPath).catch((err) => {
@@ -232,7 +262,10 @@ export class VoiceCallWebhookServer {
         });
       }
 
-      this.server.on("error", reject);
+      this.server.on("error", (err) => {
+        this.server = null;
+        reject(err);
+      });
 
       this.server.listen(port, bind, () => {
         const url = `http://${bind}:${port}${webhookPath}`;

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -1,12 +1,12 @@
 import type { OpenClawConfig } from "../config/config.js";
-import type { GatewayMessageChannel } from "../utils/message-channel.js";
-import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
-import type { AnyAgentTool } from "./tools/common.js";
 import { resolvePluginTools } from "../plugins/tools.js";
+import type { GatewayMessageChannel } from "../utils/message-channel.js";
 import { resolveSessionAgentId } from "./agent-scope.js";
+import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
 import { createAgentsListTool } from "./tools/agents-list-tool.js";
 import { createBrowserTool } from "./tools/browser-tool.js";
 import { createCanvasTool } from "./tools/canvas-tool.js";
+import type { AnyAgentTool } from "./tools/common.js";
 import { createCronTool } from "./tools/cron-tool.js";
 import { createGatewayTool } from "./tools/gateway-tool.js";
 import { createImageTool } from "./tools/image-tool.js";

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -1,9 +1,9 @@
 import type { ReasoningLevel, ThinkLevel } from "../auto-reply/thinking.js";
+import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import type { MemoryCitationsMode } from "../config/types.memory.js";
+import { listDeliverableMessageChannels } from "../utils/message-channel.js";
 import type { ResolvedTimeFormat } from "./date-time.js";
 import type { EmbeddedContextFile } from "./pi-embedded-helpers.js";
-import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
-import { listDeliverableMessageChannels } from "../utils/message-channel.js";
 import { sanitizeForPromptLiteral } from "./sanitize-for-prompt.js";
 
 /**

--- a/src/auto-reply/reply/commands-export-session.ts
+++ b/src/auto-reply/reply/commands-export-session.ts
@@ -1,17 +1,17 @@
-import type { SessionEntry as PiSessionEntry, SessionHeader } from "@mariozechner/pi-coding-agent";
-import { SessionManager } from "@mariozechner/pi-coding-agent";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import type { SessionEntry } from "../../config/sessions/types.js";
-import type { ReplyPayload } from "../types.js";
-import type { HandleCommandsParams } from "./commands-types.js";
+import type { SessionEntry as PiSessionEntry, SessionHeader } from "@mariozechner/pi-coding-agent";
+import { SessionManager } from "@mariozechner/pi-coding-agent";
 import {
   resolveDefaultSessionStorePath,
   resolveSessionFilePath,
 } from "../../config/sessions/paths.js";
 import { loadSessionStore } from "../../config/sessions/store.js";
+import type { SessionEntry } from "../../config/sessions/types.js";
+import type { ReplyPayload } from "../types.js";
 import { resolveCommandsSystemPromptBundle } from "./commands-system-prompt.js";
+import type { HandleCommandsParams } from "./commands-types.js";
 
 // Export HTML templates are bundled with this module
 const EXPORT_HTML_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), "export-html");

--- a/src/channels/dock.ts
+++ b/src/channels/dock.ts
@@ -1,17 +1,4 @@
 import type { OpenClawConfig } from "../config/config.js";
-import type {
-  ChannelCapabilities,
-  ChannelCommandAdapter,
-  ChannelElevatedAdapter,
-  ChannelGroupAdapter,
-  ChannelId,
-  ChannelAgentPromptAdapter,
-  ChannelMentionAdapter,
-  ChannelPlugin,
-  ChannelThreadingContext,
-  ChannelThreadingAdapter,
-  ChannelThreadingToolContext,
-} from "./plugins/types.js";
 import {
   resolveChannelGroupRequireMention,
   resolveChannelGroupToolsPolicy,
@@ -41,6 +28,19 @@ import {
   resolveWhatsAppGroupRequireMention,
   resolveWhatsAppGroupToolPolicy,
 } from "./plugins/group-mentions.js";
+import type {
+  ChannelCapabilities,
+  ChannelCommandAdapter,
+  ChannelElevatedAdapter,
+  ChannelGroupAdapter,
+  ChannelId,
+  ChannelAgentPromptAdapter,
+  ChannelMentionAdapter,
+  ChannelPlugin,
+  ChannelThreadingContext,
+  ChannelThreadingAdapter,
+  ChannelThreadingToolContext,
+} from "./plugins/types.js";
 import { CHAT_CHANNEL_ORDER, type ChatChannelId, getChatChannelMeta } from "./registry.js";
 
 export type ChannelDock = {

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -1,6 +1,6 @@
+import { requireActivePluginRegistry } from "../plugins/runtime.js";
 import type { ChannelMeta } from "./plugins/types.js";
 import type { ChannelId } from "./plugins/types.js";
-import { requireActivePluginRegistry } from "../plugins/runtime.js";
 
 // Channel docking: add new core channels here (order + meta + aliases), then
 // register the plugin in its extension entrypoint and keep protocol IDs in sync.

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -1,12 +1,10 @@
-import { cancel, isCancel } from "@clack/prompts";
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { inspect } from "node:util";
-import type { OpenClawConfig } from "../config/config.js";
-import type { RuntimeEnv } from "../runtime.js";
-import type { NodeManagerChoice, OnboardMode, ResetScope } from "./onboard-types.js";
+import { cancel, isCancel } from "@clack/prompts";
 import { DEFAULT_AGENT_WORKSPACE_DIR, ensureAgentWorkspace } from "../agents/workspace.js";
+import type { OpenClawConfig } from "../config/config.js";
 import { CONFIG_PATH } from "../config/config.js";
 import { resolveSessionTranscriptsDirForAgent } from "../config/sessions.js";
 import { callGateway } from "../gateway/call.js";
@@ -16,6 +14,7 @@ import { isSafeExecutableValue } from "../infra/exec-safety.js";
 import { pickPrimaryTailnetIPv4 } from "../infra/tailnet.js";
 import { isWSL } from "../infra/wsl.js";
 import { runCommandWithTimeout } from "../process/exec.js";
+import type { RuntimeEnv } from "../runtime.js";
 import { stylePromptTitle } from "../terminal/prompt-style.js";
 import {
   CONFIG_DIR,
@@ -26,6 +25,7 @@ import {
 } from "../utils.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import { VERSION } from "../version.js";
+import type { NodeManagerChoice, OnboardMode, ResetScope } from "./onboard-types.js";
 
 export function guardCancel<T>(value: T | symbol, runtime: RuntimeEnv): T {
   if (isCancel(value)) {

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -1,5 +1,4 @@
 import { createRequire } from "node:module";
-import type { PluginRuntime } from "./types.js";
 import { resolveEffectiveMessagesConfig, resolveHumanDelayConfig } from "../../agents/identity.js";
 import { createMemoryGetTool, createMemorySearchTool } from "../../agents/tools/memory-tool.js";
 import { handleSlackAction } from "../../agents/tools/slack-actions.js";
@@ -139,6 +138,7 @@ import {
 } from "../../web/auth-store.js";
 import { loadWebMedia } from "../../web/media.js";
 import { formatNativeDependencyHint } from "./native-deps.js";
+import type { PluginRuntime } from "./types.js";
 
 let cachedVersion: string | null = null;
 

--- a/src/wizard/onboarding.finalize.ts
+++ b/src/wizard/onboarding.finalize.ts
@@ -1,10 +1,5 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import type { OnboardOptions } from "../commands/onboard-types.js";
-import type { OpenClawConfig } from "../config/config.js";
-import type { RuntimeEnv } from "../runtime.js";
-import type { GatewayWizardSettings, WizardFlow } from "./onboarding.types.js";
-import type { WizardPrompter } from "./prompts.js";
 import { DEFAULT_BOOTSTRAP_FILENAME } from "../agents/workspace.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import {
@@ -25,13 +20,18 @@ import {
   waitForGatewayReachable,
   resolveControlUiLinks,
 } from "../commands/onboard-helpers.js";
+import type { OnboardOptions } from "../commands/onboard-types.js";
+import type { OpenClawConfig } from "../config/config.js";
 import { resolveGatewayService } from "../daemon/service.js";
 import { isSystemdUserServiceAvailable } from "../daemon/systemd.js";
 import { ensureControlUiAssetsBuilt } from "../infra/control-ui-assets.js";
+import type { RuntimeEnv } from "../runtime.js";
 import { restoreTerminalState } from "../terminal/restore.js";
 import { runTui } from "../tui/tui.js";
 import { resolveUserPath } from "../utils.js";
 import { setupOnboardingShellCompletion } from "./onboarding.completion.js";
+import type { GatewayWizardSettings, WizardFlow } from "./onboarding.types.js";
+import type { WizardPrompter } from "./prompts.js";
 
 type FinalizeOnboardingOptions = {
   flow: WizardFlow;


### PR DESCRIPTION
When the configured webhook port is already in use (e.g. after a quick gateway restart, or another service occupying the port), the voice-call extension throws an unhandled `EADDRINUSE` error and fails to start entirely. This silently breaks inbound voice calls.

**Fix:** Retry up to 3 times with incremented port numbers (`port`, `port+1`, `port+2`, `port+3`) before giving up. Extracted the listen logic into a private `tryListen` method. A warning is logged when falling back so the operator can see which port is actually bound.

The same pattern is used by the browser bridge server (`src/browser/bridge-server.ts`).

**Tests:** 4 test cases — fallback on single/multiple occupied ports, exhausted retries, and clean start.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds retry logic (up to 3 attempts with incremented port numbers) to handle `EADDRINUSE` errors when starting the voice-call webhook server, preventing silent crashes on quick restarts or port conflicts.

- Extracted listen logic into private `tryListen` method
- Added retry loop in `start()` method with fallback ports (`port+1`, `port+2`, `port+3`)
- Logs warning when falling back to non-configured port
- Test coverage includes single/multiple occupied ports, exhausted retries, and clean start

**Note:** Two existing issues already flagged in previous threads remain unaddressed - constructor signature mismatch in tests and potentially incomplete server cleanup in error handler.

<h3>Confidence Score: 2/5</h3>

- This PR has unresolved issues that need to be addressed before merging
- The core retry logic is sound and follows established patterns in the codebase, but two critical issues remain from previous review threads: (1) tests won't compile due to constructor signature mismatch, and (2) incomplete server cleanup in error handler could cause resource leaks in retry scenarios
- Both `extensions/voice-call/src/webhook-eaddrinuse.test.ts` and `extensions/voice-call/src/webhook.ts` need fixes per previous review comments

<sub>Last reviewed commit: ade82f1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->