### PR TITLE
Gateway: add commands.list method

### DIFF
--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -14,6 +14,7 @@ const BASE_METHODS = [
   "tts.disable",
   "tts.convert",
   "tts.setProvider",
+  "commands.list",
   "config.get",
   "config.set",
   "config.apply",

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -5,6 +5,7 @@ import { agentsHandlers } from "./server-methods/agents.js";
 import { browserHandlers } from "./server-methods/browser.js";
 import { channelsHandlers } from "./server-methods/channels.js";
 import { chatHandlers } from "./server-methods/chat.js";
+import { commandsHandlers } from "./server-methods/commands.js";
 import { configHandlers } from "./server-methods/config.js";
 import { connectHandlers } from "./server-methods/connect.js";
 import { cronHandlers } from "./server-methods/cron.js";
@@ -62,6 +63,7 @@ const READ_METHODS = new Set([
   "tts.status",
   "tts.providers",
   "models.list",
+  "commands.list",
   "agents.list",
   "agent.identity.get",
   "skills.status",
@@ -176,6 +178,7 @@ export const coreGatewayHandlers: GatewayRequestHandlers = {
   ...channelsHandlers,
   ...chatHandlers,
   ...cronHandlers,
+  ...commandsHandlers,
   ...deviceHandlers,
   ...execApprovalsHandlers,
   ...webHandlers,

--- a/src/gateway/server-methods/commands.test.ts
+++ b/src/gateway/server-methods/commands.test.ts
@@ -10,6 +10,18 @@ vi.mock("../../auto-reply/commands-registry.js", () => ({
       description: "Ping the bot",
       category: "utility",
       acceptsArgs: false,
+      args: [
+        {
+          name: "mode",
+          description: "Mode",
+          choices: ["off", { value: "low", label: "Low" }],
+        },
+        {
+          name: "dynamic",
+          description: "Dynamic",
+          choices: () => [],
+        },
+      ],
     },
     {
       key: "dock:telegram",
@@ -59,12 +71,28 @@ describe("gateway commands.list", () => {
         description: "Ping the bot",
         category: "utility",
         acceptsArgs: false,
+        args: [
+          {
+            name: "mode",
+            description: "Mode",
+            choices: [
+              { value: "off", label: "off" },
+              { value: "low", label: "Low" },
+            ],
+          },
+          {
+            name: "dynamic",
+            description: "Dynamic",
+            choices: undefined,
+          },
+        ],
       },
       {
         name: "dock:telegram",
         description: "Dock Telegram",
         category: "general",
         acceptsArgs: true,
+        args: undefined,
       },
     ]);
   });

--- a/src/gateway/server-methods/commands.test.ts
+++ b/src/gateway/server-methods/commands.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+import type { GatewayRequestContext } from "./types.js";
+import { handleGatewayRequest } from "../server-methods.js";
+
+vi.mock("../../auto-reply/commands-registry.js", () => ({
+  listChatCommands: () => [
+    {
+      key: "ping",
+      nativeName: "ping",
+      description: "Ping the bot",
+      category: "utility",
+      acceptsArgs: false,
+    },
+    {
+      key: "dock:telegram",
+      nativeName: undefined,
+      description: "Dock Telegram",
+      category: undefined,
+      acceptsArgs: true,
+    },
+  ],
+}));
+
+const makeContext = (): GatewayRequestContext => ({}) as unknown as GatewayRequestContext;
+
+describe("gateway commands.list", () => {
+  it("requires operator.read", async () => {
+    const respond = vi.fn();
+
+    await handleGatewayRequest({
+      req: { type: "req", id: "1", method: "commands.list" },
+      respond,
+      client: { connect: { role: "operator", scopes: [] } },
+      isWebchatConnect: () => false,
+      context: makeContext(),
+    });
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: "missing scope: operator.read" }),
+    );
+  });
+
+  it("returns mapped command metadata for operator.read", async () => {
+    const respond = vi.fn();
+
+    await handleGatewayRequest({
+      req: { type: "req", id: "1", method: "commands.list" },
+      respond,
+      client: { connect: { role: "operator", scopes: ["operator.read"] } },
+      isWebchatConnect: () => false,
+      context: makeContext(),
+    });
+
+    expect(respond).toHaveBeenCalledWith(true, [
+      {
+        name: "ping",
+        description: "Ping the bot",
+        category: "utility",
+        acceptsArgs: false,
+      },
+      {
+        name: "dock:telegram",
+        description: "Dock Telegram",
+        category: "general",
+        acceptsArgs: true,
+      },
+    ]);
+  });
+});

--- a/src/gateway/server-methods/commands.ts
+++ b/src/gateway/server-methods/commands.ts
@@ -9,6 +9,13 @@ export const commandsHandlers: GatewayRequestHandlers = {
       description: cmd.description,
       category: cmd.category ?? "general",
       acceptsArgs: cmd.acceptsArgs,
+      args: cmd.args?.map((arg) => ({
+        name: arg.name,
+        description: arg.description,
+        choices: Array.isArray(arg.choices)
+          ? arg.choices.map((c) => (typeof c === "string" ? { value: c, label: c } : c))
+          : undefined,
+      })),
     }));
     respond(true, result);
   },

--- a/src/gateway/server-methods/commands.ts
+++ b/src/gateway/server-methods/commands.ts
@@ -1,0 +1,15 @@
+import type { GatewayRequestHandlers } from "./types.js";
+import { listChatCommands } from "../../auto-reply/commands-registry.js";
+
+export const commandsHandlers: GatewayRequestHandlers = {
+  "commands.list": ({ respond }) => {
+    const commands = listChatCommands();
+    const result = commands.map((cmd) => ({
+      name: cmd.nativeName ?? cmd.key,
+      description: cmd.description,
+      category: cmd.category ?? "general",
+      acceptsArgs: cmd.acceptsArgs,
+    }));
+    respond(true, result);
+  },
+};


### PR DESCRIPTION
## Summary

- Problem: Web hook currently needs to hit an orchestrator HTTP route to list chat commands.
- Why it matters: We want the web hook to call through the gateway WebSocket instead, and delete the HTTP route.
- What changed:
  - Added gateway WS method `commands.list` that returns the chat command registry.
  - The payload now includes `args[]` (when present) and normalizes static `choices` values to `{ value, label }` pairs.
  - Wired it into method discovery + read-scope allowlists.
- What did NOT change (scope boundary): No changes to web hook wiring, no removal of the existing orchestrator HTTP route yet.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: (follow-up PR will remove orchestrator HTTP route)

## User-visible / Behavior Changes

- Adds gateway WS method `commands.list` (read-scoped) and includes it in the gateway method list.
- `commands.list` now returns command `args` and static arg `choices` (dynamic/function choices are omitted).

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+

### Steps

1. Call gateway WS method `commands.list` as an `operator` client with `operator.read`.

### Expected

- Returns an array of command descriptors, including `args` and static `choices`.

## Evidence

- [x] Passing tests: `pnpm build && pnpm check && pnpm test`

## Human Verification (required)

- Verified scenarios: unit test for scope gating + payload mapping (`src/gateway/server-methods/commands.test.ts`).
- Edge cases checked: fallback name to `key`, fallback category to `general`, and normalization of string choices.
- What you did **not** verify: manual web hook integration (done in follow-up).

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

- Revert commit(s) that introduce/extend `commands.list`.

## Risks and Mitigations

- Risk: exposing a method without correct scoping.
  - Mitigation: `commands.list` is in `READ_METHODS` with a unit test verifying `operator.read` is required.

## AI-assisted disclosure

This PR was authored with AI assistance (Codex). Tests were run locally.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added gateway WebSocket method `commands.list` that returns chat command registry metadata. The method is properly scoped to `operator.read`, included in gateway method discovery, and normalizes command args by:
- Using `nativeName` as fallback to `key` for the command name
- Defaulting missing `category` to `"general"`
- Converting static string choices to `{ value, label }` pairs
- Filtering out dynamic/function choices (sets to `undefined`)

The implementation includes comprehensive test coverage verifying scope gating and payload mapping. No changes to web hook wiring or orchestrator HTTP route removal (intentionally deferred to follow-up PR).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is clean, well-tested, and follows existing patterns. Scope gating is correctly implemented, the method is read-only (no side effects), and test coverage verifies both authorization and payload mapping. The changes are additive (no breaking changes) and properly integrate with the existing gateway method registration system.
- No files require special attention

<sub>Last reviewed commit: 2fdbe86</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->