### PR TITLE
ci(formal): use step summary instead of PR comment for drift notification

### DIFF
--- a/.github/workflows/formal-conformance.yml
+++ b/.github/workflows/formal-conformance.yml
@@ -13,7 +13,6 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: read
-      pull-requests: write
 
     steps:
       - name: Checkout openclaw (PR)
@@ -106,33 +105,20 @@ jobs:
           name: formal-models-conformance-drift
           path: formal-models-drift.diff
 
-      - name: Comment on PR (informational)
-        if: steps.drift.outputs.drift == 'true'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const body = [
-              '⚠️ **Formal models conformance drift detected**',
-              '',
-              'The formal models extracted constants (`generated/*`) do not match this openclaw PR.',
-              '',
-              'This check is **informational** (not blocking merges yet).',
-              'See the `formal-models-conformance-drift` artifact for the diff.',
-              '',
-              'If this change is intentional, follow up by updating the formal models repo or regenerating the extracted artifacts there.',
-            ].join('\n');
-
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              body,
-            });
-
       - name: Summary
         run: |
           if [ "${{ steps.drift.outputs.drift }}" = "true" ]; then
-            echo "Formal conformance drift detected (informational)."
+            cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ## ⚠️ Formal models conformance drift detected
+
+          The formal models extracted constants (`generated/*`) do not match this PR.
+
+          This check is **informational** (not blocking merges yet).
+          See the `formal-models-conformance-drift` artifact for the diff.
+
+          If this change is intentional, follow up by updating the formal models
+          repo or regenerating the extracted artifacts there.
+          EOF
           else
-            echo "Formal conformance: no drift."
+            echo "Formal conformance: no drift." >> "$GITHUB_STEP_SUMMARY"
           fi


### PR DESCRIPTION
## Problem

The `formal_conformance` CI workflow fails on fork PRs when drift is detected. The "Comment on PR (informational)" step calls `github.rest.issues.createComment()`, which requires write permissions. Although the workflow declares `pull-requests: write`, GitHub restricts `GITHUB_TOKEN` permissions on fork PRs by design — fork PRs cannot get write access to the target repo.

The step fails with `403 Resource not accessible by integration`, and since it's not marked `continue-on-error`, it marks the entire job as failed. This makes an informational check look like a real failure on every fork PR that triggers drift.

**Reproduction:**
1. Fork the repo and create a PR that triggers tool-group drift
2. The `formal_conformance` check runs, detects drift
3. The "Comment on PR" step gets 403
4. The entire check shows as failed

**Current trigger:** PR #14447 (subagent orchestration) added the `subagents` tool to multiple tool groups. The `clawdbot-formal-models` repo hasn't regenerated `generated/tool-groups.json` yet, so every PR now shows drift — and every fork PR fails this check.

**Note for maintainers:** the drift itself is a separate issue — `clawdbot-formal-models` needs to regenerate its `generated/tool-groups.json` after #14447 landed. This PR only fixes the workflow so that drift detection doesn't falsely fail on fork PRs.

## Root Cause

`.github/workflows/formal-conformance.yml`, line 109-130: the "Comment on PR (informational)" step uses `actions/github-script@v7` to post a PR comment via `github.rest.issues.createComment()`. GitHub's security model prevents fork PR workflow runs from getting write tokens to the target repo, regardless of the `permissions` block declared in the workflow file.

## Fix

Replace the PR comment step with `$GITHUB_STEP_SUMMARY`, which requires no write permissions and works identically for both fork and same-repo PRs. The drift notification appears in the check's Summary tab alongside the existing artifact link.

Also removes the now-unnecessary `pull-requests: write` permission from the job, since no step requires write access anymore.

## Testing

- CI-only change (YAML workflow file) — no TypeScript modified, no `pnpm build`/`pnpm check` needed
- Verified YAML heredoc indentation is correct (YAML base indent stripped by block scalar, `EOF` terminator at column 0 in bash)
- Verified `$GITHUB_STEP_SUMMARY` is the standard GitHub Actions mechanism for job summaries (no permissions required)

## AI Disclosure

This PR was written with AI assistance. Testing level: manually reviewed (CI workflow change).

- **Analysis + implementation:** Claude Opus 4.6 (root cause investigation of #17020, workflow fix)

We understand the code — this is a straightforward replacement of a PR comment mechanism with step summary to avoid the well-documented GitHub fork PR permission restriction.

## Agent Prompt

The `formal_conformance` CI workflow marks fork PRs as failed when drift is detected, even though the check is meant to be informational. The failure comes from the "Comment on PR" step — it tries to post a PR comment but gets a 403 because GitHub doesn't grant write tokens to fork PR workflows. The drift notification should still be visible to contributors on fork PRs, but through a mechanism that doesn't require write permissions to the target repo.

Fixes #17020

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces the `actions/github-script` PR comment step in the `formal_conformance` workflow with `$GITHUB_STEP_SUMMARY`, which requires no write permissions and works for both fork and same-repo PRs. Also removes the now-unnecessary `pull-requests: write` permission scope.

- Drift notification now appears in the check's Summary tab via `$GITHUB_STEP_SUMMARY` heredoc instead of as a PR comment via `github.rest.issues.createComment()`
- `pull-requests: write` permission removed since no step requires write access anymore
- YAML heredoc indentation is correct: the `EOF` terminator and content lines are properly aligned for bash after YAML block scalar processing
- **Note:** The PR description states the original step was "not marked `continue-on-error`," but the original step did include `continue-on-error: true`. The fix is still valid — even with `continue-on-error`, a 403 failure still shows as a failed (orange) step in the Actions UI, and the step summary approach is cleaner with fewer permissions.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal CI workflow change that reduces permissions and uses a standard GitHub Actions mechanism.
- Single-file change to a CI workflow with no TypeScript or runtime code modified. The change reduces permissions (removes `pull-requests: write`), replaces a PR comment with the standard `$GITHUB_STEP_SUMMARY` mechanism, and the heredoc YAML indentation is verified correct. No logic issues, no security concerns — the change actually improves the security posture by requesting fewer permissions.
- No files require special attention.

<sub>Last reviewed commit: a9e54e1</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->