### PR TITLE
fix(cron): prevent control-plane starvation during startup catch-up and manual runs

### DIFF
--- a/.github/workflows/formal-conformance.yml
+++ b/.github/workflows/formal-conformance.yml
@@ -107,7 +107,7 @@ jobs:
           path: formal-models-drift.diff
 
       - name: Comment on PR (informational)
-        if: steps.drift.outputs.drift == 'true'
+        if: steps.drift.outputs.drift == 'true' && github.event.pull_request.head.repo.fork == false
         uses: actions/github-script@v7
         with:
           script: |

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -45,7 +45,7 @@ function errorBackoffMs(consecutiveErrors: number): number {
  * Handles consecutive error tracking, exponential backoff, one-shot disable,
  * and nextRunAtMs computation. Returns `true` if the job should be deleted.
  */
-function applyJobResult(
+export function applyJobResult(
   state: CronServiceState,
   job: CronJob,
   result: {
@@ -423,7 +423,7 @@ export async function runDueJobs(state: CronServiceState) {
   }
 }
 
-async function executeJobCore(
+export async function executeJobCore(
   state: CronServiceState,
   job: CronJob,
 ): Promise<{


### PR DESCRIPTION
## Bug fix: prevent cron control-plane starvation during startup catch-up and manual runs

This re-raises the cron starvation fix in a fresh PR.

### Root cause
Control-plane cron RPCs (`cron.status/list/run/runs`) were competing with long-running cron job execution while sharing lock-heavy paths in:
- startup catch-up replay (`runMissedJobs` from `start()`)
- manual runs (`run()`)

### Fixes in this PR
1. **Startup path de-starvation**
   - Keep startup lock scope short.
   - Move missed-job replay outside the startup lock.
   - Persist/reload safely around replay.

2. **Manual run de-starvation + race hardening**
   - Split `run()` into:
     - prepare (locked)
     - execute (unlocked)
     - finalize (locked)
   - Execute from a locked snapshot and re-find by id during finalize to avoid stale unlocked store reads.

3. **Startup replay persistence correctness**
   - Catch-up runs now reserve/persist/finalize through locked phases (same shape as manual run safety pattern).

4. **Test stabilization**
   - Updated wakeMode tests to assert persisted post-run job state via `cron.list`.

5. **CI reliability for fork PRs (informational check only)**
   - `Formal models (informational conformance)` now skips the PR comment step on fork-based PRs to avoid token-permission 403 noise.
   - This keeps the check informational instead of failing due to integration write scope.

## Review feedback addressed
- Addressed race concern about unlocked `state.store` reads between prepare and execute.
- Removed redundant startup set reassignment.

## Local verification run
- `corepack pnpm exec vitest run src/cron/**/*.test.ts` (24 files / 106 tests passed)
- `corepack pnpm tsgo`
- `corepack pnpm format:check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors the cron `start()`, `run()`, and `runMissedJobs()` paths to prevent control-plane starvation by splitting long-running job execution out of lock-held sections. The core pattern is prepare (locked) → execute (unlocked, using a deep-cloned job snapshot) → finalize (locked, re-finding job by ID). This mirrors the existing `onTimer` design and allows concurrent control-plane RPCs (`status`, `list`, `run`, `runs`) to proceed while jobs execute.

- `start()` now releases the lock between clearing stale running markers and replaying missed jobs, then re-acquires to recompute schedules and arm the timer.
- `run()` is split into a locked prepare phase (reserves the run), an unlocked execute phase (runs `executeJobCore` on a snapshot), and a locked finalize phase (applies result, persists, re-arms timer).
- `runMissedJobs()` adopts the same prepare/execute/finalize structure per missed job, each phase acquiring its own short-lived lock.
- Tests are updated to assert post-run state via `cron.list()` instead of reading the original in-memory `job` reference, which is correct since the finalize phase re-finds the job from the store.
- CI: the formal-conformance workflow now skips the PR comment step on fork-based PRs to avoid 403 permission errors.
- `applyJobResult` and `executeJobCore` are now exported from `timer.ts` to support the inlined prepare/execute/finalize logic in `ops.ts`.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it applies a well-established concurrency pattern consistently across the cron execution paths.
- The prepare/execute/finalize pattern is sound and mirrors the existing onTimer design. Each phase properly re-acquires the lock and re-finds the job by ID, guarding against concurrent mutations. The deep-clone via JSON.parse(JSON.stringify) for the execution snapshot prevents stale-reference bugs. Test updates correctly adapt to the new execution model. The only minor concern is some unreachable defensive guards in run() that add unnecessary complexity.
- `src/cron/service/ops.ts` has unreachable type-narrowing guards (lines 247-255) that could be simplified.

<sub>Last reviewed commit: 0563e2b</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->