### PR TITLE
fix(cron): prevent control-plane starvation during startup catch-up and manual runs

### DIFF
--- a/.github/workflows/formal-conformance.yml
+++ b/.github/workflows/formal-conformance.yml
@@ -107,7 +107,7 @@ jobs:
           path: formal-models-drift.diff
 
       - name: Comment on PR (informational)
-        if: steps.drift.outputs.drift == 'true'
+        if: steps.drift.outputs.drift == 'true' && github.event.pull_request.head.repo.fork == false
         uses: actions/github-script@v7
         with:
           script: |

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -45,7 +45,7 @@ function errorBackoffMs(consecutiveErrors: number): number {
  * Handles consecutive error tracking, exponential backoff, one-shot disable,
  * and nextRunAtMs computation. Returns `true` if the job should be deleted.
  */
-function applyJobResult(
+export function applyJobResult(
   state: CronServiceState,
   job: CronJob,
   result: {
@@ -361,42 +361,116 @@ export async function runMissedJobs(
   state: CronServiceState,
   opts?: { skipJobIds?: ReadonlySet<string> },
 ) {
-  if (!state.store) {
-    return;
-  }
-  const now = state.deps.nowMs();
   const skipJobIds = opts?.skipJobIds;
-  const missed = state.store.jobs.filter((j) => {
-    if (!j.state) {
-      j.state = {};
+  const missedIds = await locked(state, async () => {
+    if (!state.store) {
+      return [] as string[];
     }
-    if (!j.enabled) {
-      return false;
+    const now = state.deps.nowMs();
+    const missed = state.store.jobs.filter((j) => {
+      if (!j.state) {
+        j.state = {};
+      }
+      if (!j.enabled) {
+        return false;
+      }
+      if (skipJobIds?.has(j.id)) {
+        return false;
+      }
+      if (typeof j.state.runningAtMs === "number") {
+        return false;
+      }
+      const next = j.state.nextRunAtMs;
+      if (j.schedule.kind === "at" && j.state.lastStatus) {
+        return false;
+      }
+      return typeof next === "number" && now >= next;
+    });
+
+    if (missed.length > 0) {
+      state.deps.log.info(
+        { count: missed.length, jobIds: missed.map((j) => j.id) },
+        "cron: running missed jobs after restart",
+      );
     }
-    if (skipJobIds?.has(j.id)) {
-      return false;
-    }
-    if (typeof j.state.runningAtMs === "number") {
-      return false;
-    }
-    const next = j.state.nextRunAtMs;
-    if (j.schedule.kind === "at" && j.state.lastStatus) {
-      // Any terminal status (ok, error, skipped) means the job already
-      // ran at least once.  Don't re-fire it on restart — applyJobResult
-      // disables one-shot jobs, but guard here defensively (#13845).
-      return false;
-    }
-    return typeof next === "number" && now >= next;
+    return missed.map((j) => j.id);
   });
 
-  if (missed.length > 0) {
-    state.deps.log.info(
-      { count: missed.length, jobIds: missed.map((j) => j.id) },
-      "cron: running missed jobs after restart",
-    );
-    for (const job of missed) {
-      await executeJob(state, job, now, { forced: false });
+  for (const jobId of missedIds) {
+    const prepared = await locked(state, async () => {
+      await ensureLoaded(state, { skipRecompute: true });
+      const job = state.store?.jobs.find((j) => j.id === jobId);
+      if (!job) {
+        return null;
+      }
+      if (typeof job.state.runningAtMs === "number") {
+        return null;
+      }
+      const startedAt = state.deps.nowMs();
+      job.state.runningAtMs = startedAt;
+      job.state.lastError = undefined;
+      emit(state, { jobId: job.id, action: "started", runAtMs: startedAt });
+      await persist(state);
+      return {
+        jobId: job.id,
+        startedAt,
+        executionJob: JSON.parse(JSON.stringify(job)) as CronJob,
+      };
+    });
+
+    if (!prepared) {
+      continue;
     }
+
+    let coreResult: {
+      status: "ok" | "error" | "skipped";
+      error?: string;
+      summary?: string;
+      sessionId?: string;
+      sessionKey?: string;
+    };
+    try {
+      coreResult = await executeJobCore(state, prepared.executionJob);
+    } catch (err) {
+      coreResult = { status: "error", error: String(err) };
+    }
+    const endedAt = state.deps.nowMs();
+
+    await locked(state, async () => {
+      await ensureLoaded(state, { forceReload: true, skipRecompute: true });
+      const job = state.store?.jobs.find((j) => j.id === prepared.jobId);
+      if (!job) {
+        return;
+      }
+
+      const shouldDelete = applyJobResult(state, job, {
+        status: coreResult.status,
+        error: coreResult.error,
+        startedAt: prepared.startedAt,
+        endedAt,
+      });
+
+      emit(state, {
+        jobId: job.id,
+        action: "finished",
+        status: coreResult.status,
+        error: coreResult.error,
+        summary: coreResult.summary,
+        sessionId: coreResult.sessionId,
+        sessionKey: coreResult.sessionKey,
+        runAtMs: prepared.startedAt,
+        durationMs: job.state.lastDurationMs,
+        nextRunAtMs: job.state.nextRunAtMs,
+      });
+
+      if (shouldDelete && state.store) {
+        state.store.jobs = state.store.jobs.filter((j) => j.id !== job.id);
+        emit(state, { jobId: job.id, action: "removed" });
+      }
+
+      recomputeNextRuns(state);
+      await persist(state);
+    });
   }
 }
 
@@ -423,7 +497,7 @@ export async function runDueJobs(state: CronServiceState) {
   }
 }
 
-async function executeJobCore(
+export async function executeJobCore(
   state: CronServiceState,
   job: CronJob,
 ): Promise<{


### PR DESCRIPTION
## Bug fix: prevent cron control-plane starvation during startup catch-up and manual runs

This is a **fresh, single-commit** PR (fully squashed) that includes all prior review fixes.

### Fixes included
- Move startup missed-job replay out of startup lock scope.
- Split manual `run()` into locked prepare / unlocked execute / locked finalize.
- Avoid stale unlocked store reads by executing from snapshot + re-find by id under lock in finalize.
- Persist startup catch-up runs safely with locked state transitions.
- Stabilize wakeMode tests to assert persisted post-run job state.
- Prevent fork PR 403 noise in informational formal-conformance workflow by skipping PR-comment step on fork-based PRs.

### Local verification
- `corepack pnpm exec vitest run src/cron/**/*.test.ts` (106 passed)
- `corepack pnpm tsgo`
- `corepack pnpm format:check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Refactored cron job execution to prevent control-plane starvation by moving long-running job execution outside the lock scope. This PR splits the manual `run()` and `runMissedJobs()` operations into three phases: locked prepare (reserves the job), unlocked execute (runs the job core logic), and locked finalize (persists results). This ensures other cron operations like `list()`, `add()`, and `status()` can proceed while jobs execute. The implementation uses `forceReload: true` when re-acquiring the lock to prevent stale reads and safely handle concurrent store modifications. Tests were stabilized to assert against persisted state rather than in-memory snapshots. The workflow change prevents fork PRs from triggering PR comments in the informational formal-conformance workflow.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation follows sound concurrency patterns (lock preparation, unlocked execution, lock finalization) commonly used to prevent deadlocks. The changes are well-tested with 106 passing cron tests. The code correctly handles edge cases like job deletion during execution, stale state by reloading from disk with `forceReload: true`, and error recovery. Test stabilization ensures assertions check persisted state instead of in-memory snapshots, preventing flaky tests. The workflow change is a minor defensive fix with no runtime impact.
- No files require special attention

<sub>Last reviewed commit: 48e2906</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->