### PR TITLE
fix(telegram): prioritize workspace skills over bundled in native command registration

### DIFF
--- a/src/agents/skills/types.ts
+++ b/src/agents/skills/types.ts
@@ -54,6 +54,8 @@ export type SkillCommandSpec = {
   description: string;
   /** Optional deterministic dispatch behavior for this command. */
   dispatch?: SkillCommandDispatchSpec;
+  /** True when this command originates from a bundled skill. */
+  bundled?: boolean;
 };
 
 export type SkillsInstallPreferences = {

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -506,11 +506,13 @@ export function buildWorkspaceSkillCommandSpecs(
       return { kind: "tool", toolName, argMode: "raw" } as const;
     })();
 
+    const isBundled = entry.skill.source === "openclaw-bundled";
     specs.push({
       name: unique,
       skillName: rawName,
       description,
       ...(dispatch ? { dispatch } : {}),
+      ...(isBundled ? { bundled: true } : {}),
     });
   }
   return specs;

--- a/src/telegram/bot-native-commands.test.ts
+++ b/src/telegram/bot-native-commands.test.ts
@@ -115,7 +115,7 @@ describe("registerTelegramNativeCommands", () => {
     expect(registeredCommands).toHaveLength(100);
     expect(registeredCommands).toEqual(customCommands.slice(0, 100));
     expect(runtimeLog).toHaveBeenCalledWith(
-      "Telegram limits bots to 100 commands. 120 configured; registering first 100. Use channels.telegram.commands.native: false to disable, or reduce plugin/skill/custom commands.",
+      "Telegram limits bots to 100 commands. 120 configured; registering first 100 (0 bundled skill commands deprioritized). Use skills.allowBundled to limit which bundled skills register as commands, or channels.telegram.commands.native: false to disable native commands entirely.",
     );
   });
 });


### PR DESCRIPTION
Fixes #17061

## Problem

When `commands.nativeSkills: true`, all eligible skills (bundled + workspace) are registered as Telegram bot commands. With 50+ bundled skills, the 100-command Telegram limit is easily exceeded. The existing truncation logic drops commands from the end of the list, which can silently drop workspace/user skills that the user actually wants.

## Solution

1. **Track skill origin**: Added `bundled?: boolean` flag to `SkillCommandSpec` (set when `skill.source === "openclaw-bundled"`)
2. **Reorder command list**: Bundled skill commands are now placed **after** built-in commands, workspace skills, plugin commands, and custom commands
3. **Better overflow warning**: The truncation message now mentions `skills.allowBundled` as the recommended config to limit bundled skill commands

### Command registration order (new)

1. Built-in OpenClaw commands + workspace skill commands
2. Plugin commands
3. Custom commands  
4. Bundled skill commands ← truncated first when over 100

### Files changed

- `src/agents/skills/types.ts` — added `bundled` field to `SkillCommandSpec`
- `src/agents/skills/workspace.ts` — populate `bundled` flag from `entry.skill.source`
- `src/telegram/bot-native-commands.ts` — partition and reorder commands by origin
- `src/telegram/bot-native-commands.test.ts` — updated test expectation for new warning message

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Prioritizes workspace/user skills over bundled skills when registering Telegram bot commands to prevent user-created skills from being silently dropped when hitting the 100-command limit. The PR adds a `bundled` flag to track skill origin, reorders the command list to place bundled skill commands last, and updates the truncation warning to suggest using `skills.allowBundled` configuration.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is straightforward and correct - it adds a boolean flag to track bundled skills, reorders an array based on that flag, and updates a warning message. The logic properly maps skill command names through the transformation pipeline, and the test has been updated to match the new behavior. No security issues, performance concerns, or breaking changes.
- No files require special attention

<sub>Last reviewed commit: 65c60f4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->