### PR TITLE
docs(raspberry-pi): Add SSH linger troubleshooting

### DIFF
--- a/docs/platforms/raspberry-pi.md
+++ b/docs/platforms/raspberry-pi.md
@@ -312,6 +312,37 @@ npm run build
 sudo systemctl restart openclaw
 ```
 
+### Service Dies When SSH Session Closes
+
+**Symptom:** The OpenClaw service stops every time you log out of SSH.
+
+**Root cause:** systemd's default `KillUserProcesses=yes` kills all user processes (including systemd user services) when a user logs out.
+
+**Solution:** Enable linger for your user to persist the session:
+
+```bash
+# Enable linger (keeps user services running after logout)
+sudo loginctl enable-linger $USER
+
+# Verify it's enabled
+loginctl show-user $USER | grep Linger
+# Should show: Linger=yes
+
+# Restart the service
+sudo systemctl restart openclaw
+```
+
+**Why this happens:** When you SSH into the Pi and start the service, it runs under your user session. By default, systemd terminates all processes in that session when you log out. Enabling linger tells systemd to keep your user services running permanently, even when you're not logged in.
+
+**Check if you need this:**
+
+```bash
+# If this shows "Linger=no", you need to enable it
+loginctl show-user $USER | grep Linger
+```
+
+This is **critical for headless Pi setups accessed via SSH** — without linger, your Gateway will stop whenever you disconnect.
+
 ### ARM Binary Issues
 
 If a skill fails with "exec format error":

--- a/docs/platforms/raspberry-pi.md
+++ b/docs/platforms/raspberry-pi.md
@@ -321,25 +321,17 @@ sudo systemctl restart openclaw
 **Solution:** Enable linger for your user to persist the session:
 
 ```bash
+# Check if you need linger (if this shows "Linger=no", you need it)
+loginctl show-user $USER | grep Linger
+
 # Enable linger (keeps user services running after logout)
 sudo loginctl enable-linger $USER
 
-# Verify it's enabled
-loginctl show-user $USER | grep Linger
-# Should show: Linger=yes
-
-# Restart the service
-sudo systemctl restart openclaw
+# Restart the user service
+systemctl --user restart openclaw-gateway
 ```
 
 **Why this happens:** When you SSH into the Pi and start the service, it runs under your user session. By default, systemd terminates all processes in that session when you log out. Enabling linger tells systemd to keep your user services running permanently, even when you're not logged in.
-
-**Check if you need this:**
-
-```bash
-# If this shows "Linger=no", you need to enable it
-loginctl show-user $USER | grep Linger
-```
 
 This is **critical for headless Pi setups accessed via SSH** — without linger, your Gateway will stop whenever you disconnect.
 


### PR DESCRIPTION
## Problem

Addresses #17069 - OpenClaw Gateway service dies when SSH session closes on Raspberry Pi setups.

## Solution

Added troubleshooting section to  explaining:

- **Root cause**: systemd's  kills user services on logout
- **Fix**:  to persist user session
- **Verification**: How to check if linger is needed
- **Context**: Critical for headless Pi deployments accessed via SSH

## Impact

This is a common pain point for SSH-based Pi deployments. Without linger enabled, the Gateway service stops unexpectedly every time the user disconnects from SSH, breaking the "always-on" nature of the deployment.

## Testing

Tested on Raspberry Pi 5 (ARM64) running Debian Linux, accessed via SSH. Verified that:
1. Service stops on logout without linger
2. Service persists after enabling linger
3. Instructions are clear and work as documented

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a troubleshooting section to the Raspberry Pi docs explaining why the OpenClaw Gateway service dies when SSH sessions close and how to fix it with `loginctl enable-linger`. The new section correctly uses `systemctl --user restart openclaw-gateway`, consistent with how the codebase installs the service (as a systemd user unit via `src/daemon/systemd.ts`).

- The root cause explanation (`KillUserProcesses=yes`) is accurate and well-articulated
- The diagnostic command (`loginctl show-user $USER | grep Linger`) and fix (`sudo loginctl enable-linger $USER`) are correct
- The restart command in the new section correctly targets `openclaw-gateway` via `systemctl --user`, matching the actual service name in `src/daemon/constants.ts`
- No issues found in the new content

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it adds a well-written, technically accurate documentation section with no code changes.
- This is a docs-only change adding a single troubleshooting section. The commands are correct and match the codebase's actual systemd user service implementation. The linger mechanism is accurately described, and the section fills a genuine gap in the documentation for headless Pi deployments.
- No files require special attention.

<sub>Last reviewed commit: b1ff6b5</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->