### PR TITLE
fix(telegram): suppress file-size error replies in groups when bot is not mentioned

### DIFF
--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -22,6 +22,7 @@ import { resolveAgentRoute } from "../routing/resolve-route.js";
 import { resolveThreadSessionKeys } from "../routing/session-key.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import {
+  firstDefined,
   isSenderAllowed,
   normalizeAllowFromWithStore,
   type NormalizedAllowFrom,
@@ -33,6 +34,7 @@ import { resolveMedia } from "./bot/delivery.js";
 import {
   buildTelegramGroupPeerId,
   buildTelegramParentPeer,
+  hasBotMention,
   resolveTelegramForumThreadId,
   resolveTelegramGroupAllowFromContext,
 } from "./bot/helpers.js";
@@ -1076,6 +1078,26 @@ export const registerTelegramHandlers = ({
       } catch (mediaErr) {
         const errMsg = String(mediaErr);
         if (errMsg.includes("exceeds") && errMsg.includes("MB limit")) {
+          // In groups with requireMention, suppress the error reply when the bot
+          // was not mentioned — otherwise every agent in the group spams the same
+          // "File too large" message for files they were never asked to process.
+          if (isGroup) {
+            const fileSizeRequireMention = firstDefined(
+              topicConfig?.requireMention,
+              groupConfig?.requireMention,
+              opts.requireMention,
+            );
+            if (fileSizeRequireMention !== false) {
+              const botUser = ctx.me?.username;
+              const mentioned = botUser && hasBotMention(msg, botUser.toLowerCase());
+              if (!mentioned) {
+                logVerbose(
+                  `telegram: suppressing file-size error in group ${chatId} (requireMention, not mentioned)`,
+                );
+                return;
+              }
+            }
+          }
           const limitMb = Math.round(mediaMaxBytes / (1024 * 1024));
           await withTelegramApiErrorLogging({
             operation: "sendMessage",


### PR DESCRIPTION
## Problem

When a user sends a large file (e.g. video > 5MB) in a Telegram group with `requireMention: true`, every bot in the group replies with:

> ⚠️ File too large. Maximum size is 5MB.

This happens because the file-size error is thrown by `resolveMedia()` and caught in a handler that sends the error reply **before** the `requireMention` check runs (which happens later in `processMessage()`).

With multiple agents in the same group, this creates a wall of identical error messages.

## Fix

Added a `requireMention` check inside the file-size error catch block. When all of these are true, the error reply is silently suppressed:

- Message is in a group chat
- `requireMention` is not explicitly `false`
- The bot was not `@mentioned` in the message text/caption

The check uses the same config resolution order as the rest of the codebase: topic → group → channel → global.

## Test

All 53 Telegram test files pass (436 tests).

Fixes #17048

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds logic to suppress "File too large" error replies in Telegram groups when `requireMention` is enabled and the bot was not `@mentioned`. This is a targeted fix for the spam issue where multiple bots reply with identical error messages to large file uploads.

- **Critical: missing `firstDefined` import** — `firstDefined` is used at line 1084 but never imported in `bot-handlers.ts`. This will cause a `ReferenceError` at runtime when the file-size error path is hit in a group chat, crashing the handler instead of suppressing the message.
- The `hasBotMention` import was correctly added from `./bot/helpers.js`, and the mention detection logic is sound.
- The `requireMention` resolution chain (`topicConfig → groupConfig → opts.requireMention`) is a simplified version of the canonical chain in `processMessage`, missing `activationOverride`. This is acceptable since session-level activation state isn't available in the handler context, and the behavior errs safely toward suppression.

<h3>Confidence Score: 2/5</h3>

- This PR has a missing import that will cause a runtime crash on the affected code path — must be fixed before merging.
- The missing `firstDefined` import in `bot-handlers.ts` will cause a `ReferenceError` at runtime when a large file triggers the media-size error in a group chat. Instead of suppressing the error reply, the handler will crash. The logic and approach are otherwise sound.
- `src/telegram/bot-handlers.ts` — missing import for `firstDefined` at line 1084 will cause a runtime error.

<sub>Last reviewed commit: a523588</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->