### PR TITLE
fix(clawdock): include docker-compose.extra.yml in compose commands

### DIFF
--- a/scripts/shell-helpers/clawdock-helpers.sh
+++ b/scripts/shell-helpers/clawdock-helpers.sh
@@ -136,7 +136,11 @@ _clawdock_ensure_dir() {
 # Wrapper to run docker compose commands
 _clawdock_compose() {
   _clawdock_ensure_dir || return 1
-  command docker compose -f "${CLAWDOCK_DIR}/docker-compose.yml" "$@"
+  local compose_args=("-f" "${CLAWDOCK_DIR}/docker-compose.yml")
+  if [[ -f "${CLAWDOCK_DIR}/docker-compose.extra.yml" ]]; then
+    compose_args+=("-f" "${CLAWDOCK_DIR}/docker-compose.extra.yml")
+  fi
+  command docker compose "${compose_args[@]}" "$@"
 }
 
 _clawdock_read_env_token() {


### PR DESCRIPTION
## Summary
Fixes a bug where \clawdock\ helper commands would ignore the \docker-compose.extra.yml\ file generated by the setup script. This prevented persistent volume configurations (like \OPENCLAW_HOME_VOLUME\) from taking effect.

## Fix
Updated \_clawdock_compose\ in \scripts/shell-helpers/clawdock-helpers.sh\ to checking for the existence of \docker-compose.extra.yml\ and append it to the command arguments if found.

Closes #17083

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes `_clawdock_compose` in `clawdock-helpers.sh` to conditionally include `docker-compose.extra.yml` (generated by `docker-setup.sh` for persistent volume configs like `OPENCLAW_HOME_VOLUME`) when it exists on disk. Previously, all `clawdock-*` helper commands only referenced the base `docker-compose.yml`, causing volume overrides to be silently ignored.

- The fix uses a bash array to build compose arguments, appending `-f docker-compose.extra.yml` only if the file is present, mirroring the approach used in `docker-setup.sh` itself.
- All `clawdock-*` commands route through `_clawdock_compose`, so a single change covers the entire helper surface.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a small, well-scoped bug fix with no risk of regression.
- The change is a 5-line fix to a single shell function. It adds conditional file detection using a standard bash `-f` test, builds compose args with a bash array (correct quoting), and passes them through to `docker compose`. The pattern directly mirrors what `docker-setup.sh` already does. No existing behavior changes when `docker-compose.extra.yml` does not exist.
- No files require special attention.

<sub>Last reviewed commit: cbda63c</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->