### PR TITLE
docs(pi): add loginctl enable-linger instruction for SSH persistence

### DIFF
--- a/docs/platforms/raspberry-pi.md
+++ b/docs/platforms/raspberry-pi.md
@@ -63,6 +63,12 @@ ssh user@gateway-host
 ssh user@192.168.x.x
 ```
 
+> ⚠️ **Important for persistent deployments:** If you're accessing the Pi via SSH and want the gateway to keep running after you disconnect, run:
+> ```bash
+> sudo loginctl enable-linger $USER
+> ```
+> This prevents systemd from killing your processes when the SSH session ends. Without this, the gateway will die every time you log out.
+
 ## 3) System Setup
 
 ```bash


### PR DESCRIPTION
Fixes #17069

## Problem
When running OpenClaw on Raspberry Pi accessed via SSH, the gateway dies when the SSH session closes because systemd-logind's default  kills all user processes.

## Solution
Added a warning note in the Raspberry Pi docs with the workaround:
```bash
sudo loginctl enable-linger $USER
```

This prevents systemd from killing the gateway when the SSH session ends.

## Impact
- Helps users avoid the common pitfall of their Pi gateway dying after disconnecting SSH
- Low-risk documentation fix with clear reproduction steps from the issue

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds helpful SSH persistence documentation for Raspberry Pi users and attempts to optimize hook loading by skipping cache-busting for bundled hooks.

- **Docs change (raspberry-pi.md)**: Clean addition - warns users about systemd killing processes when SSH disconnects and provides the `loginctl enable-linger` fix
- **Loader optimization (loader.ts)**: The optimization logic is sound, but `entry.origin` should be `entry.hook.source` and the comparison value should be `"openclaw-bundled"` not `"bundled"`

The bug makes the optimization a no-op (always applies cache-busting), so it doesn't break existing functionality - it just fails to deliver the performance improvement.

<h3>Confidence Score: 3/5</h3>

- Safe to merge with the logic fix - docs are good, bug doesn't break functionality
- The documentation change is solid and the loader bug doesn't cause runtime errors (just makes the optimization ineffective). However, the bug should be fixed before merging to actually deliver the performance benefit.
- src/hooks/loader.ts needs the property path corrected

<sub>Last reviewed commit: 3b9c17c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->