### PR TITLE
fix(clawdock): include docker-compose.extra.yml in compose commands

### DIFF
--- a/scripts/shell-helpers/clawdock-helpers.sh
+++ b/scripts/shell-helpers/clawdock-helpers.sh
@@ -136,7 +136,13 @@ _clawdock_ensure_dir() {
 # Wrapper to run docker compose commands
 _clawdock_compose() {
   _clawdock_ensure_dir || return 1
-  command docker compose -f "${CLAWDOCK_DIR}/docker-compose.yml" "$@"
+  # Include extra compose file if it exists (e.g., for OPENCLAW_HOME_VOLUME)
+  local extra_file="${CLAWDOCK_DIR}/docker-compose.extra.yml"
+  local compose_args="-f ${CLAWDOCK_DIR}/docker-compose.yml"
+  if [[ -f "$extra_file" ]]; then
+    compose_args="$compose_args -f $extra_file"
+  fi
+  command docker compose $compose_args "$@"
 }
 
 _clawdock_read_env_token() {


### PR DESCRIPTION
Fixes #17083

## Problem
The `_clawdock_compose` function only loads `docker-compose.yml`, missing `docker-compose.extra.yml` which contains `OPENCLAW_HOME_VOLUME` configuration.

## Solution
Include the extra compose file if it exists:
```bash
local extra_file="${CLAWDOCK_DIR}/docker-compose.extra.yml"
if [[ -f "$extra_file" ]]; then
  compose_args="$compose_args -f $extra_file"
fi
```

## Impact
- Users can now use `OPENCLAW_HOME_VOLUME` environment variable with clawdock
- Docker volumes will be properly mounted when using custom home directories

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes `_clawdock_compose` to include `docker-compose.extra.yml` when present, which enables features like `OPENCLAW_HOME_VOLUME` for users of the clawdock shell helpers. The fix is conceptually correct and aligns with how `docker-setup.sh` and the docs recommend running compose with both files.

- The compose arguments are stored in a plain string variable and expanded unquoted, which will break if `CLAWDOCK_DIR` contains spaces. An array (like `docker-setup.sh` uses) should be used instead to preserve proper quoting.

<h3>Confidence Score: 3/5</h3>

- The fix is logically correct but introduces a quoting regression that breaks paths with spaces
- The intent and conditional logic are sound, but the switch from a quoted variable to an unquoted string expansion is a regression from the original code's space-safe handling. This will fail for users whose CLAWDOCK_DIR path contains spaces.
- `scripts/shell-helpers/clawdock-helpers.sh` — the `_clawdock_compose` function needs to use an array instead of a plain string for compose arguments

<sub>Last reviewed commit: 6347dfc</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->