### PR TITLE
fix: preserve responseUsage across session resets

### DIFF
--- a/scripts/shell-helpers/clawdock-helpers.sh
+++ b/scripts/shell-helpers/clawdock-helpers.sh
@@ -136,7 +136,13 @@ _clawdock_ensure_dir() {
 # Wrapper to run docker compose commands
 _clawdock_compose() {
   _clawdock_ensure_dir || return 1
-  command docker compose -f "${CLAWDOCK_DIR}/docker-compose.yml" "$@"
+  # Include extra compose file if it exists (e.g., for OPENCLAW_HOME_VOLUME)
+  local extra_file="${CLAWDOCK_DIR}/docker-compose.extra.yml"
+  local compose_args="-f ${CLAWDOCK_DIR}/docker-compose.yml"
+  if [[ -f "$extra_file" ]]; then
+    compose_args="$compose_args -f $extra_file"
+  fi
+  command docker compose $compose_args "$@"
 }
 
 _clawdock_read_env_token() {

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -138,6 +138,7 @@ export async function initSessionState(params: {
   let persistedVerbose: string | undefined;
   let persistedReasoning: string | undefined;
   let persistedTtsAuto: TtsAutoMode | undefined;
+  let persistedResponseUsage: "on" | "off" | "tokens" | "full" | undefined;
   let persistedModelOverride: string | undefined;
   let persistedProviderOverride: string | undefined;
 
@@ -235,6 +236,7 @@ export async function initSessionState(params: {
     persistedVerbose = entry.verboseLevel;
     persistedReasoning = entry.reasoningLevel;
     persistedTtsAuto = entry.ttsAuto;
+    persistedResponseUsage = entry.responseUsage;
     persistedModelOverride = entry.modelOverride;
     persistedProviderOverride = entry.providerOverride;
   } else {
@@ -243,13 +245,14 @@ export async function initSessionState(params: {
     systemSent = false;
     abortedLastRun = false;
     // When a reset trigger (/new, /reset) starts a new session, carry over
-    // user-set behavior overrides (verbose, thinking, reasoning, ttsAuto)
+    // user-set behavior overrides (verbose, thinking, reasoning, ttsAuto, responseUsage)
     // so the user doesn't have to re-enable them every time.
     if (resetTriggered && entry) {
       persistedThinking = entry.thinkingLevel;
       persistedVerbose = entry.verboseLevel;
       persistedReasoning = entry.reasoningLevel;
       persistedTtsAuto = entry.ttsAuto;
+      persistedResponseUsage = entry.responseUsage;
     }
   }
 
@@ -282,7 +285,7 @@ export async function initSessionState(params: {
     verboseLevel: persistedVerbose ?? baseEntry?.verboseLevel,
     reasoningLevel: persistedReasoning ?? baseEntry?.reasoningLevel,
     ttsAuto: persistedTtsAuto ?? baseEntry?.ttsAuto,
-    responseUsage: baseEntry?.responseUsage,
+    responseUsage: persistedResponseUsage ?? baseEntry?.responseUsage,
     modelOverride: persistedModelOverride ?? baseEntry?.modelOverride,
     providerOverride: persistedProviderOverride ?? baseEntry?.providerOverride,
     sendPolicy: baseEntry?.sendPolicy,

--- a/src/commands/agent/session.ts
+++ b/src/commands/agent/session.ts
@@ -31,6 +31,7 @@ export type SessionResolution = {
   isNewSession: boolean;
   persistedThinking?: ThinkLevel;
   persistedVerbose?: VerboseLevel;
+  persistedResponseUsage?: "on" | "off" | "tokens" | "full";
 };
 
 type SessionKeyResolution = {
@@ -152,6 +153,8 @@ export function resolveSession(opts: {
     fresh && sessionEntry?.verboseLevel
       ? normalizeVerboseLevel(sessionEntry.verboseLevel)
       : undefined;
+  const persistedResponseUsage =
+    fresh && sessionEntry?.responseUsage ? sessionEntry.responseUsage : undefined;
 
   return {
     sessionId,
@@ -162,5 +165,6 @@ export function resolveSession(opts: {
     isNewSession,
     persistedThinking,
     persistedVerbose,
+    persistedResponseUsage,
   };
 }


### PR DESCRIPTION
Fixes #17102

## Problem
The `/usage` command setting (`responseUsage`) was lost on session resets (daily/idle), while other preferences (`thinkingLevel`, `verboseLevel`, `reasoningLevel`, `ttsAuto`) were preserved. Users had to re-type `/usage full` after each reset.

## Root Cause
In `src/auto-reply/reply/session.ts`, `responseUsage` was only set from `baseEntry` (which is undefined on reset), while other settings used persisted fallbacks:
```ts
responseUsage: baseEntry?.responseUsage,  // ❌ Lost on reset
```

## Solution
Added `persistedResponseUsage` handling to match other preferences:
1. Added `persistedResponseUsage` to `SessionResolution` type
2. Persist value when session is fresh or reset triggered  
3. Use persisted value as fallback in session entry initialization

```ts
responseUsage: persistedResponseUsage ?? baseEntry?.responseUsage,  // ✅ Preserved
```

## Impact
- `/usage` setting now persists across session resets
- Consistent behavior with other per-session preferences
- Users don't need to re-enable `/usage` after `/new`, `/reset`, or daily resets

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where the `/usage` command setting (`responseUsage`) was lost during session resets (triggered by `/new`, `/reset`, or idle/daily timeouts), requiring users to re-enable it after each reset. The fix adds `persistedResponseUsage` handling to match the existing pattern used for other per-session preferences like `thinkingLevel`, `verboseLevel`, `reasoningLevel`, and `ttsAuto`. The implementation correctly persists the value when a session is fresh or when a reset is triggered, and uses the persisted value as a fallback during session initialization.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified risks
- The fix follows the exact same pattern already established for other session preferences (`ttsAuto`, `thinkingLevel`, `verboseLevel`, `reasoningLevel`). The implementation is minimal, focused, and consistent across both files. Type definitions are correct, and the changes align with the existing codebase architecture. No logical errors, security issues, or unintended side effects detected.
- No files require special attention

<sub>Last reviewed commit: f7a45f0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->