### PR TITLE
fix: transcribe all Telegram voice messages, not just mention-gated groups

### DIFF
--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -398,11 +398,10 @@ export const buildTelegramMessageContext = async ({
   let bodyText = rawBody;
   const hasAudio = allMedia.some((media) => media.contentType?.startsWith("audio/"));
 
-  // Preflight audio transcription for mention detection in groups
-  // This allows voice notes to be checked for mentions before being dropped
+  // Preflight audio transcription for voice messages
+  // This ensures voice notes are transcribed regardless of chat type or mention settings
   let preflightTranscript: string | undefined;
-  const needsPreflightTranscription =
-    isGroup && requireMention && hasAudio && !hasUserText && mentionRegexes.length > 0;
+  const needsPreflightTranscription = hasAudio && !hasUserText;
 
   if (needsPreflightTranscription) {
     try {


### PR DESCRIPTION
## Summary

Extends preflight transcription to work for ALL voice messages, not just group messages with mention requirements. This ensures Telegram voice messages in DMs and other non-mention-gated contexts are transcribed before being processed by the agent.

Previously, transcription only ran for group messages where mentions were required (fix #16789). For DMs and non-mention-gated groups, transcription relied on `applyMediaUnderstanding` which may not have been triggered in all cases.

## Changes

- Modified `needsPreflightTranscription` condition in `bot-message-context.ts` to run for all voice messages with no user text, not just group messages with mention requirements
- Added test for direct message voice transcription

## Testing

- All 437 telegram tests pass
- Added new test case for DM voice messages to verify transcription is triggered

Fixes openclaw/openclaw#17101

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extends preflight audio transcription to all voice messages regardless of chat type or mention settings.

Previously, transcription only ran for mention-gated group messages. The change simplifies the condition from `isGroup && requireMention && hasAudio && !hasUserText && mentionRegexes.length > 0` to just `hasAudio && !hasUserText`, ensuring all audio content (voice messages and audio files) without accompanying text gets transcribed upfront.

- Simplified preflight transcription logic in `bot-message-context.ts:404`
- Added test coverage for DM voice message transcription
- Test suite passes (437 telegram tests)
- Maintains existing behavior: audio with captions is not transcribed during preflight

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a straightforward simplification that removes unnecessary conditions from the preflight transcription check. The logic is sound: transcribe audio when there's no user text, regardless of chat type. Test coverage is comprehensive (437 tests passing + new DM test), and the change follows the existing pattern established in previous fixes (#16789). The simplified condition is easier to understand and maintains backward compatibility.
- No files require special attention

<sub>Last reviewed commit: f791bbe</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->