### PR TITLE
feat(sessions): expose isProcessing flag in sessions.list

### DIFF
--- a/src/agents/tools/sessions-helpers.ts
+++ b/src/agents/tools/sessions-helpers.ts
@@ -32,6 +32,7 @@ export type SessionListRow = {
   verboseLevel?: string;
   systemSent?: boolean;
   abortedLastRun?: boolean;
+  isProcessing?: boolean;
   sendPolicy?: string;
   lastChannel?: string;
   lastTo?: string;

--- a/src/agents/tools/sessions-list-tool.ts
+++ b/src/agents/tools/sessions-list-tool.ts
@@ -195,6 +195,7 @@ export function createSessionsListTool(opts?: {
           systemSent: typeof entry.systemSent === "boolean" ? entry.systemSent : undefined,
           abortedLastRun:
             typeof entry.abortedLastRun === "boolean" ? entry.abortedLastRun : undefined,
+          isProcessing: typeof entry.isProcessing === "boolean" ? entry.isProcessing : undefined,
           sendPolicy: typeof entry.sendPolicy === "string" ? entry.sendPolicy : undefined,
           lastChannel,
           lastTo: deliveryTo ?? (typeof entry.lastTo === "string" ? entry.lastTo : undefined),

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -117,7 +117,7 @@ async function ensureSessionRuntimeCleanup(params: {
 }
 
 export const sessionsHandlers: GatewayRequestHandlers = {
-  "sessions.list": ({ params, respond }) => {
+  "sessions.list": ({ params, respond, context }) => {
     if (!validateSessionsListParams(params)) {
       respond(
         false,
@@ -132,11 +132,16 @@ export const sessionsHandlers: GatewayRequestHandlers = {
     const p = params;
     const cfg = loadConfig();
     const { storePath, store } = loadCombinedSessionStoreForGateway(cfg);
+    const activeSessionKeys = new Set<string>();
+    for (const entry of context.chatAbortControllers.values()) {
+      activeSessionKeys.add(entry.sessionKey);
+    }
     const result = listSessionsFromStore({
       cfg,
       storePath,
       store,
       opts: p,
+      activeSessionKeys,
     });
     respond(true, result, undefined);
   },

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -668,8 +668,9 @@ export function listSessionsFromStore(params: {
   storePath: string;
   store: Record<string, SessionEntry>;
   opts: import("./protocol/index.js").SessionsListParams;
+  activeSessionKeys?: ReadonlySet<string>;
 }): SessionsListResult {
-  const { cfg, storePath, store, opts } = params;
+  const { cfg, storePath, store, opts, activeSessionKeys } = params;
   const now = Date.now();
 
   const includeGlobal = opts.includeGlobal === true;
@@ -772,6 +773,7 @@ export function listSessionsFromStore(params: {
         sessionId: entry?.sessionId,
         systemSent: entry?.systemSent,
         abortedLastRun: entry?.abortedLastRun,
+        isProcessing: activeSessionKeys ? activeSessionKeys.has(key) : undefined,
         thinkingLevel: entry?.thinkingLevel,
         verboseLevel: entry?.verboseLevel,
         reasoningLevel: entry?.reasoningLevel,

--- a/src/gateway/session-utils.types.ts
+++ b/src/gateway/session-utils.types.ts
@@ -25,6 +25,7 @@ export type GatewaySessionRow = {
   sessionId?: string;
   systemSent?: boolean;
   abortedLastRun?: boolean;
+  isProcessing?: boolean;
   thinkingLevel?: string;
   verboseLevel?: string;
   reasoningLevel?: string;


### PR DESCRIPTION
## What

Adds an `isProcessing` boolean to the `sessions.list` response, derived from the gateway's in-memory `chatAbortControllers` map.

When a session has an active run tracked in `chatAbortControllers`, `isProcessing` is `true`; otherwise `false`. The field is optional and only populated when the caller goes through the gateway (direct `listSessionsFromStore` calls without the param get `undefined`, preserving backward compat).

## Why

I believe some users may require a flag to mark the current state of a session during multitasking operations, distinguishing whether the agent is currently processing a task or awaiting user input.

## Changes

- `session-utils.types.ts` — added `isProcessing` to `GatewaySessionRow`
- `session-utils.ts` — `listSessionsFromStore` accepts optional `activeSessionKeys` set, populates `isProcessing` per row
- `server-methods/sessions.ts` — `sessions.list` handler now reads `context.chatAbortControllers` and passes active keys
- `sessions-helpers.ts` — added `isProcessing` to `SessionListRow`
- `sessions-list-tool.ts` — passes `isProcessing` through to tool output

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an `isProcessing` boolean field to the `sessions.list` response to indicate whether a session has an active chat run in progress. The flag is derived from the gateway's in-memory `chatAbortControllers` map.

**Key changes:**
- Added `isProcessing` field to type definitions (`GatewaySessionRow`, `SessionListRow`)
- Modified `sessions.list` handler to collect active session keys from `chatAbortControllers`
- Updated `listSessionsFromStore` to accept optional `activeSessionKeys` parameter and populate `isProcessing`
- Propagated the field through the sessions list tool output

**Issue found:**
- The implementation stores raw session keys in `chatAbortControllers` but compares against canonical store keys, which may cause the flag to be incorrect when key normalization occurs (case changes, agent prefix additions, etc.)

<h3>Confidence Score: 2/5</h3>

- This PR has a logical bug that will cause the isProcessing flag to be incorrect in some cases
- The implementation has a key normalization mismatch bug where raw session keys are stored in chatAbortControllers but compared against canonical store keys. This means isProcessing will be false even when a session is actively processing if the keys differ due to case normalization or agent prefix additions. The bug should be fixed before merging.
- Pay close attention to src/gateway/server-methods/sessions.ts where the session key collection logic needs to be fixed

<sub>Last reviewed commit: 014c7db</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->