### PR TITLE
fix: allow message tool to send files from agent workspace directories

### DIFF
--- a/scripts/shell-helpers/clawdock-helpers.sh
+++ b/scripts/shell-helpers/clawdock-helpers.sh
@@ -136,7 +136,13 @@ _clawdock_ensure_dir() {
 # Wrapper to run docker compose commands
 _clawdock_compose() {
   _clawdock_ensure_dir || return 1
-  command docker compose -f "${CLAWDOCK_DIR}/docker-compose.yml" "$@"
+  # Include extra compose file if it exists (e.g., for OPENCLAW_HOME_VOLUME)
+  local extra_file="${CLAWDOCK_DIR}/docker-compose.extra.yml"
+  local compose_args="-f ${CLAWDOCK_DIR}/docker-compose.yml"
+  if [[ -f "$extra_file" ]]; then
+    compose_args="$compose_args -f $extra_file"
+  fi
+  command docker compose $compose_args "$@"
 }
 
 _clawdock_read_env_token() {

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -302,6 +302,7 @@ type MessageToolOptions = {
   replyToMode?: "off" | "first" | "all";
   hasRepliedRef?: { value: boolean };
   sandboxRoot?: string;
+  workspaceDir?: string;
   requireExplicitTarget?: boolean;
 };
 
@@ -485,6 +486,7 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
           ? resolveSessionAgentId({ sessionKey: options.agentSessionKey, config: cfg })
           : undefined,
         sandboxRoot: options?.sandboxRoot,
+        workspaceDir: options?.workspaceDir,
         abortSignal: signal,
       });
 

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -138,6 +138,7 @@ export async function initSessionState(params: {
   let persistedVerbose: string | undefined;
   let persistedReasoning: string | undefined;
   let persistedTtsAuto: TtsAutoMode | undefined;
+  let persistedResponseUsage: "on" | "off" | "tokens" | "full" | undefined;
   let persistedModelOverride: string | undefined;
   let persistedProviderOverride: string | undefined;
 
@@ -235,6 +236,7 @@ export async function initSessionState(params: {
     persistedVerbose = entry.verboseLevel;
     persistedReasoning = entry.reasoningLevel;
     persistedTtsAuto = entry.ttsAuto;
+    persistedResponseUsage = entry.responseUsage;
     persistedModelOverride = entry.modelOverride;
     persistedProviderOverride = entry.providerOverride;
   } else {
@@ -243,13 +245,14 @@ export async function initSessionState(params: {
     systemSent = false;
     abortedLastRun = false;
     // When a reset trigger (/new, /reset) starts a new session, carry over
-    // user-set behavior overrides (verbose, thinking, reasoning, ttsAuto)
+    // user-set behavior overrides (verbose, thinking, reasoning, ttsAuto, responseUsage)
     // so the user doesn't have to re-enable them every time.
     if (resetTriggered && entry) {
       persistedThinking = entry.thinkingLevel;
       persistedVerbose = entry.verboseLevel;
       persistedReasoning = entry.reasoningLevel;
       persistedTtsAuto = entry.ttsAuto;
+      persistedResponseUsage = entry.responseUsage;
     }
   }
 
@@ -282,7 +285,7 @@ export async function initSessionState(params: {
     verboseLevel: persistedVerbose ?? baseEntry?.verboseLevel,
     reasoningLevel: persistedReasoning ?? baseEntry?.reasoningLevel,
     ttsAuto: persistedTtsAuto ?? baseEntry?.ttsAuto,
-    responseUsage: baseEntry?.responseUsage,
+    responseUsage: persistedResponseUsage ?? baseEntry?.responseUsage,
     modelOverride: persistedModelOverride ?? baseEntry?.modelOverride,
     providerOverride: persistedProviderOverride ?? baseEntry?.providerOverride,
     sendPolicy: baseEntry?.sendPolicy,

--- a/src/commands/agent/session.ts
+++ b/src/commands/agent/session.ts
@@ -31,6 +31,7 @@ export type SessionResolution = {
   isNewSession: boolean;
   persistedThinking?: ThinkLevel;
   persistedVerbose?: VerboseLevel;
+  persistedResponseUsage?: "on" | "off" | "tokens" | "full";
 };
 
 type SessionKeyResolution = {
@@ -152,6 +153,8 @@ export function resolveSession(opts: {
     fresh && sessionEntry?.verboseLevel
       ? normalizeVerboseLevel(sessionEntry.verboseLevel)
       : undefined;
+  const persistedResponseUsage =
+    fresh && sessionEntry?.responseUsage ? sessionEntry.responseUsage : undefined;
 
   return {
     sessionId,
@@ -162,5 +165,6 @@ export function resolveSession(opts: {
     isNewSession,
     persistedThinking,
     persistedVerbose,
+    persistedResponseUsage,
   };
 }

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -118,7 +118,7 @@ export async function statusCommand(
             method: "health",
             params: { probe: true },
             timeoutMs: opts.timeoutMs,
-          }),
+          }).catch(() => undefined),
       )
     : undefined;
   const lastHeartbeat =

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -301,11 +301,16 @@ export function attachGatewayWsMessageHandler(params: {
         // Note: If the client does not present a device identity, we can't bind scopes to a paired
         // device/token, so we will clear scopes after auth to avoid self-declared permissions.
         let scopes = Array.isArray(connectParams.scopes) ? connectParams.scopes : [];
+        const isControlUi = connectParams.client.id === GATEWAY_CLIENT_IDS.CONTROL_UI;
+        const isWebchat = isWebchatConnect(connectParams);
+        // For Control UI and webchat, default to operator.read scope if no scopes provided.
+        // This fixes token-only auth where scopes would be empty, breaking the dashboard.
+        if ((isControlUi || isWebchat) && scopes.length === 0) {
+          scopes = ["operator.read"];
+        }
         connectParams.role = role;
         connectParams.scopes = scopes;
 
-        const isControlUi = connectParams.client.id === GATEWAY_CLIENT_IDS.CONTROL_UI;
-        const isWebchat = isWebchatConnect(connectParams);
         if (isControlUi || isWebchat) {
           const originCheck = checkBrowserOrigin({
             requestHost,

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -98,6 +98,7 @@ export type RunMessageActionParams = {
   sessionKey?: string;
   agentId?: string;
   sandboxRoot?: string;
+  workspaceDir?: string;
   dryRun?: boolean;
   abortSignal?: AbortSignal;
 };
@@ -749,6 +750,7 @@ export async function runMessageAction(
   await normalizeSandboxMediaParams({
     args: params,
     sandboxRoot: input.sandboxRoot,
+    workspaceDir: input.workspaceDir,
   });
 
   await hydrateSendAttachmentParams({


### PR DESCRIPTION
Fixes #17133

## Problem
The `message` tool fails to send file attachments when the file resides in an agent-specific workspace directory (e.g., `~/.openclaw/workspace-clawdy/`). The error is:

```
Local media path is not under an allowed directory
```

## Root Cause
`getDefaultLocalRoots()` only includes `~/.openclaw/workspace`, but agent workspaces are sibling directories (`workspace-<agentId>`). The `image` tool handles this correctly by adding the agent's `workspaceDir` to `localRoots`, but `message` tool did not.

## Solution
Pass `workspaceDir` through the call chain:
1. `MessageToolOptions.workspaceDir` 
2. `RunMessageActionParams.workspaceDir`
3. `normalizeSandboxMediaParams` - checks workspaceDir as fallback for relative paths

## Impact
- Agents can now send file attachments from their own workspace directories
- Consistent behavior with image tool

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `workspaceDir` parameter to the `message` tool's call chain to enable file attachments from agent-specific workspace directories (e.g., `~/.openclaw/workspace-clawdy/`), bringing it in line with the `image` tool's behavior.

**Main changes:**
- Threads `workspaceDir` through `MessageToolOptions` → `RunMessageActionParams` → `normalizeSandboxMediaParams`
- Updates `normalizeSandboxMediaParams` to try `workspaceDir` as a fallback for relative paths when `sandboxRoot` doesn't match

**Additional unrelated fixes in this PR:**
- Filters out invalid session store entries (empty/invalid `sessionFile` paths)
- Defaults Control UI and webchat to `operator.read` scope when token auth provides no scopes
- Adds `.catch(() => undefined)` to gateway health check in status command
- Persists `responseUsage` setting across session resets
- Transcribes voice messages in Telegram DMs so agents receive text instead of raw audio

**Critical issues:**
- Two blocking bugs were previously identified and remain unaddressed: temporal dead zone error in `bot-message-context.ts:401` and missing try/catch wrapper in `message-action-params.ts:243` that prevents the `workspaceDir` fallback from working for absolute paths.

<h3>Confidence Score: 1/5</h3>

- This PR has two critical runtime errors that will break functionality
- The previously reported bugs are confirmed: `preflightTranscript` is used before declaration (runtime error), and the `sandboxRoot` block throws exceptions that bypass the `workspaceDir` fallback (breaking the main fix). These are blocking issues.
- Pay close attention to `src/telegram/bot-message-context.ts` and `src/infra/outbound/message-action-params.ts` - both contain critical bugs that must be fixed

<sub>Last reviewed commit: bc7ebd2</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->