### PR TITLE
feat: pass through OpenRouter provider routing params

### DIFF
--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -89,18 +89,43 @@ function createStreamFnWithExtraParams(
     streamParams.cacheRetention = cacheRetention;
   }
 
-  if (Object.keys(streamParams).length === 0) {
+  // Extract OpenRouter provider routing preferences from extraParams.provider.
+  // Injected into model.compat.openRouterRouting so pi-ai's buildParams sets
+  // params.provider in the API request body (openai-completions.js L359-362).
+  // pi-ai's OpenRouterRouting type only declares { only?, order? }, but at
+  // runtime the full object is forwarded — enabling allow_fallbacks,
+  // data_collection, ignore, sort, quantizations, etc.
+  const providerRouting =
+    provider === "openrouter" &&
+    extraParams.provider != null &&
+    typeof extraParams.provider === "object"
+      ? (extraParams.provider as Record<string, unknown>)
+      : undefined;
+
+  if (Object.keys(streamParams).length === 0 && !providerRouting) {
     return undefined;
   }
 
   log.debug(`creating streamFn wrapper with params: ${JSON.stringify(streamParams)}`);
+  if (providerRouting) {
+    log.debug(`OpenRouter provider routing: ${JSON.stringify(providerRouting)}`);
+  }
 
   const underlying = baseStreamFn ?? streamSimple;
-  const wrappedStreamFn: StreamFn = (model, context, options) =>
-    underlying(model, context, {
+  const wrappedStreamFn: StreamFn = (model, context, options) => {
+    // When provider routing is configured, inject it into model.compat so
+    // pi-ai picks it up via model.compat.openRouterRouting.
+    const effectiveModel = providerRouting
+      ? ({
+          ...model,
+          compat: { ...model.compat, openRouterRouting: providerRouting },
+        } as unknown as typeof model)
+      : model;
+    return underlying(effectiveModel, context, {
       ...streamParams,
       ...options,
     });
+  };
 
   return wrappedStreamFn;
 }


### PR DESCRIPTION
## Summary

`createStreamFnWithExtraParams()` silently drops `extraParams.provider`, making it impossible to use OpenRouter's provider routing options (only, order, allow_fallbacks, data_collection, ignore, sort, quantizations) via model config.

This change extracts `extraParams.provider` when the provider is `openrouter` and injects it into `model.compat.openRouterRouting`, which pi-ai's `buildParams` already picks up and includes in the API request body.

## Design decision

An earlier PR (#3971) proposed adding `openRouterRouting` directly to `compat` in the model config schema. This PR takes a different approach: it keeps provider routing in `params.provider` (matching OpenRouter's own API schema) and bridges it to `model.compat.openRouterRouting` at runtime. This avoids schema changes and keeps the config format consistent with the upstream API.

## Config example

```jsonc
"openrouter/anthropic/claude-sonnet-4.5": {
  "params": {
    "provider": {
      "only": ["anthropic"],
      "allow_fallbacks": false
    }
  }
}
```

## Test plan

- [ ] Verify `pnpm check` passes (format + tsgo + lint)
- [ ] Deploy with provider routing config and confirm params appear in OpenRouter API requests

Closes #10869

✍️ Author: Claude Code with @carrotRakko (AI-written, human-approved)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Enables OpenRouter provider routing by extracting `extraParams.provider` and injecting it into `model.compat.openRouterRouting`, which pi-ai's `buildParams` already picks up. This allows users to configure OpenRouter routing options (`only`, `order`, `allow_fallbacks`, etc.) via model config `params.provider` instead of requiring schema changes. The implementation properly guards the extraction with provider and type checks, adds debug logging, and integrates cleanly with the existing wrapper chain.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minimal risk - straightforward feature addition with proper guards
- The change is well-contained, adds proper type/provider checks, includes helpful debug logging, and follows existing patterns. Minor consideration: spreading `model.compat` when it could be undefined, but this is handled safely by the spread operator which treats undefined as an empty object.
- No files require special attention

<sub>Last reviewed commit: 57187f8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->