### PR TITLE
fix: ensure cron jobs run even when HEARTBEAT.md is empty

### DIFF
--- a/scripts/shell-helpers/clawdock-helpers.sh
+++ b/scripts/shell-helpers/clawdock-helpers.sh
@@ -136,7 +136,13 @@ _clawdock_ensure_dir() {
 # Wrapper to run docker compose commands
 _clawdock_compose() {
   _clawdock_ensure_dir || return 1
-  command docker compose -f "${CLAWDOCK_DIR}/docker-compose.yml" "$@"
+  # Include extra compose file if it exists (e.g., for OPENCLAW_HOME_VOLUME)
+  local extra_file="${CLAWDOCK_DIR}/docker-compose.extra.yml"
+  local compose_args="-f ${CLAWDOCK_DIR}/docker-compose.yml"
+  if [[ -f "$extra_file" ]]; then
+    compose_args="$compose_args -f $extra_file"
+  fi
+  command docker compose $compose_args "$@"
 }
 
 _clawdock_read_env_token() {

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -302,6 +302,7 @@ type MessageToolOptions = {
   replyToMode?: "off" | "first" | "all";
   hasRepliedRef?: { value: boolean };
   sandboxRoot?: string;
+  workspaceDir?: string;
   requireExplicitTarget?: boolean;
 };
 
@@ -485,6 +486,7 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
           ? resolveSessionAgentId({ sessionKey: options.agentSessionKey, config: cfg })
           : undefined,
         sandboxRoot: options?.sandboxRoot,
+        workspaceDir: options?.workspaceDir,
         abortSignal: signal,
       });
 

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -84,6 +84,7 @@ export function buildInboundUserContextPrefix(ctx: TemplateContext): string {
         username: safeTrim(ctx.SenderUsername),
         tag: safeTrim(ctx.SenderTag),
         e164: safeTrim(ctx.SenderE164),
+        id: safeTrim(ctx.SenderId),
       };
   if (senderInfo?.label) {
     blocks.push(

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -138,6 +138,7 @@ export async function initSessionState(params: {
   let persistedVerbose: string | undefined;
   let persistedReasoning: string | undefined;
   let persistedTtsAuto: TtsAutoMode | undefined;
+  let persistedResponseUsage: "on" | "off" | "tokens" | "full" | undefined;
   let persistedModelOverride: string | undefined;
   let persistedProviderOverride: string | undefined;
 
@@ -235,6 +236,7 @@ export async function initSessionState(params: {
     persistedVerbose = entry.verboseLevel;
     persistedReasoning = entry.reasoningLevel;
     persistedTtsAuto = entry.ttsAuto;
+    persistedResponseUsage = entry.responseUsage;
     persistedModelOverride = entry.modelOverride;
     persistedProviderOverride = entry.providerOverride;
   } else {
@@ -243,13 +245,14 @@ export async function initSessionState(params: {
     systemSent = false;
     abortedLastRun = false;
     // When a reset trigger (/new, /reset) starts a new session, carry over
-    // user-set behavior overrides (verbose, thinking, reasoning, ttsAuto)
+    // user-set behavior overrides (verbose, thinking, reasoning, ttsAuto, responseUsage)
     // so the user doesn't have to re-enable them every time.
     if (resetTriggered && entry) {
       persistedThinking = entry.thinkingLevel;
       persistedVerbose = entry.verboseLevel;
       persistedReasoning = entry.reasoningLevel;
       persistedTtsAuto = entry.ttsAuto;
+      persistedResponseUsage = entry.responseUsage;
     }
   }
 
@@ -282,7 +285,7 @@ export async function initSessionState(params: {
     verboseLevel: persistedVerbose ?? baseEntry?.verboseLevel,
     reasoningLevel: persistedReasoning ?? baseEntry?.reasoningLevel,
     ttsAuto: persistedTtsAuto ?? baseEntry?.ttsAuto,
-    responseUsage: baseEntry?.responseUsage,
+    responseUsage: persistedResponseUsage ?? baseEntry?.responseUsage,
     modelOverride: persistedModelOverride ?? baseEntry?.modelOverride,
     providerOverride: persistedProviderOverride ?? baseEntry?.providerOverride,
     sendPolicy: baseEntry?.sendPolicy,

--- a/src/commands/agent/session.ts
+++ b/src/commands/agent/session.ts
@@ -31,6 +31,7 @@ export type SessionResolution = {
   isNewSession: boolean;
   persistedThinking?: ThinkLevel;
   persistedVerbose?: VerboseLevel;
+  persistedResponseUsage?: "on" | "off" | "tokens" | "full";
 };
 
 type SessionKeyResolution = {
@@ -152,6 +153,8 @@ export function resolveSession(opts: {
     fresh && sessionEntry?.verboseLevel
       ? normalizeVerboseLevel(sessionEntry.verboseLevel)
       : undefined;
+  const persistedResponseUsage =
+    fresh && sessionEntry?.responseUsage ? sessionEntry.responseUsage : undefined;
 
   return {
     sessionId,
@@ -162,5 +165,6 @@ export function resolveSession(opts: {
     isNewSession,
     persistedThinking,
     persistedVerbose,
+    persistedResponseUsage,
   };
 }

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -118,7 +118,7 @@ export async function statusCommand(
             method: "health",
             params: { probe: true },
             timeoutMs: opts.timeoutMs,
-          }),
+          }).catch(() => undefined),
       )
     : undefined;
   const lastHeartbeat =

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -70,9 +70,11 @@ export function buildGatewayCronService(params: {
     runHeartbeatOnce: async (opts) => {
       const runtimeConfig = loadConfig();
       const agentId = opts?.agentId ? resolveCronAgent(opts.agentId).agentId : undefined;
+      // Use a cron:-prefixed reason to ensure heartbeat isn't skipped when HEARTBEAT.md is empty
+      const cronReason = opts?.reason ? `cron:${opts.reason}` : "cron:triggered";
       return await runHeartbeatOnce({
         cfg: runtimeConfig,
-        reason: opts?.reason,
+        reason: cronReason,
         agentId,
         deps: { ...params.deps, runtime: defaultRuntime },
       });

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -301,11 +301,16 @@ export function attachGatewayWsMessageHandler(params: {
         // Note: If the client does not present a device identity, we can't bind scopes to a paired
         // device/token, so we will clear scopes after auth to avoid self-declared permissions.
         let scopes = Array.isArray(connectParams.scopes) ? connectParams.scopes : [];
+        const isControlUi = connectParams.client.id === GATEWAY_CLIENT_IDS.CONTROL_UI;
+        const isWebchat = isWebchatConnect(connectParams);
+        // For Control UI and webchat, default to operator.read scope if no scopes provided.
+        // This fixes token-only auth where scopes would be empty, breaking the dashboard.
+        if ((isControlUi || isWebchat) && scopes.length === 0) {
+          scopes = ["operator.read"];
+        }
         connectParams.role = role;
         connectParams.scopes = scopes;
 
-        const isControlUi = connectParams.client.id === GATEWAY_CLIENT_IDS.CONTROL_UI;
-        const isWebchat = isWebchatConnect(connectParams);
         if (isControlUi || isWebchat) {
           const originCheck = checkBrowserOrigin({
             requestHost,

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -98,6 +98,7 @@ export type RunMessageActionParams = {
   sessionKey?: string;
   agentId?: string;
   sandboxRoot?: string;
+  workspaceDir?: string;
   dryRun?: boolean;
   abortSignal?: AbortSignal;
 };
@@ -749,6 +750,7 @@ export async function runMessageAction(
   await normalizeSandboxMediaParams({
     args: params,
     sandboxRoot: input.sandboxRoot,
+    workspaceDir: input.workspaceDir,
   });
 
   await hydrateSendAttachmentParams({


### PR DESCRIPTION
Fixes #17096

## Problem
Scheduled cron jobs are silently skipped when the HEARTBEAT.md file is empty. The job run log shows the status as "skipped" with the error "empty-heartbeat-file".

## Root Cause
The heartbeat runner checks if HEARTBEAT.md content is effectively empty and skips unless the reason is cron-related (starts with "cron:"). However, the reason passed from `server-cron.ts` to `runHeartbeatOnce` was not prefixed with "cron:", so the empty file check was triggered.

## Solution
Prefix the reason with "cron:" when calling runHeartbeatNow for cron jobs:

```typescript
// Before
reason: opts?.reason

// After  
reason: opts?.reason ? `cron:${opts.reason}` : "cron:triggered"
```

## Impact
- Cron jobs now run correctly even when HEARTBEAT.md is empty
- Consistent with the existing behavior for exec events and wake reasons

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes scheduled cron jobs being skipped when `HEARTBEAT.md` is empty by prefixing the reason with `cron:` in `server-cron.ts`, which bypasses the empty-file check in `heartbeat-runner.ts:432-442`. The fix correctly identifies that the heartbeat runner checks for `reason?.startsWith("cron:")` to determine whether to skip empty heartbeat files.

**Issues found:**
- The fix double-prefixes reasons that already start with `cron:`, resulting in reasons like `cron:cron:job-id` instead of `cron:job-id` (see inline comment on `server-cron.ts:74`)

**Note:** This PR includes 14 changed files spanning many commits in the range, but only one commit (8ae4dae57) is directly related to the stated fix. The other 13 files contain changes from previous commits between the base and head.

<h3>Confidence Score: 3/5</h3>

- Safe to merge with minor fix - the main cron fix is correct but has a double-prefixing edge case
- The core fix correctly identifies the issue and solves it by prefixing the reason with `cron:` to bypass empty-file checks. However, the implementation has a logic bug where reasons already prefixed with `cron:` (like from `timer.ts:453`) will be double-prefixed to `cron:cron:...`. While this won't break functionality since `startsWith("cron:")` still matches, it results in malformed reason strings in logs and telemetry. Additionally, there's an unrelated critical bug in `bot-message-context.ts:401` where `preflightTranscript` is referenced before declaration (already flagged in previous threads).
- Focus on `src/gateway/server-cron.ts:74` for the double-prefix fix, and `src/telegram/bot-message-context.ts:401` for the TDZ bug (already reported in previous threads)

<sub>Last reviewed commit: 8ae4dae</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->