### PR TITLE
fix(announce): use deterministic idempotency keys to prevent duplicate subagent announces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Docs: https://docs.openclaw.ai
 - Telegram: retry inbound media `getFile` calls (3 attempts with backoff) and gracefully fall back to placeholder-only processing when retries fail, preventing dropped voice/media messages on transient Telegram network errors. (#16154) Thanks @yinghaosang.
 - Telegram: finalize streaming preview replies in place instead of sending a second final message, preventing duplicate Telegram assistant outputs at stream completion. (#17218) Thanks @obviyus.
 - Cron: infer `payload.kind="agentTurn"` for model-only `cron.update` payload patches, so partial agent-turn updates do not fail validation when `kind` is omitted. (#15664) Thanks @rodrigouroz.
+- Subagents: use child-run-based deterministic announce idempotency keys across direct and queued delivery paths (with legacy queued-item fallback) to prevent duplicate announce retries without collapsing distinct same-millisecond announces. (#17150) Thanks @widingmarcus-cyber.
 
 ## 2026.2.14
 

--- a/src/agents/announce-idempotency.ts
+++ b/src/agents/announce-idempotency.ts
@@ -1,0 +1,25 @@
+export type AnnounceIdFromChildRunParams = {
+  childSessionKey: string;
+  childRunId: string;
+};
+
+export function buildAnnounceIdFromChildRun(params: AnnounceIdFromChildRunParams): string {
+  return `v1:${params.childSessionKey}:${params.childRunId}`;
+}
+
+export function buildAnnounceIdempotencyKey(announceId: string): string {
+  return `announce:${announceId}`;
+}
+
+export function resolveQueueAnnounceId(params: {
+  announceId?: string;
+  sessionKey: string;
+  enqueuedAt: number;
+}): string {
+  const announceId = params.announceId?.trim();
+  if (announceId) {
+    return announceId;
+  }
+  // Backward-compatible fallback for queue items that predate announceId.
+  return `legacy:${params.sessionKey}:${params.enqueuedAt}`;
+}

--- a/src/agents/subagent-announce-queue.ts
+++ b/src/agents/subagent-announce-queue.ts
@@ -14,6 +14,9 @@ import {
 } from "../utils/queue-helpers.js";
 
 export type AnnounceQueueItem = {
+  // Stable announce identity shared by direct + queued delivery paths.
+  // Optional for backward compatibility with previously queued items.
+  announceId?: string;
   prompt: string;
   summaryLine?: string;
   enqueuedAt: number;

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -1,4 +1,3 @@
-import path from "node:path";
 import { resolveQueueSettings } from "../auto-reply/reply/queue.js";
 import { loadConfig } from "../config/config.js";
 import {


### PR DESCRIPTION
## fix(announce): use deterministic idempotency keys to prevent duplicate subagent announces

Fixes #17122

### Problem

When a subagent completes while the main session is busy, the completion announcement is delivered **twice**:

1. The application-level announce queue (`subagent-announce-queue.ts`) drains and calls `sendAnnounce` → `callGateway({ method: "agent" })`
2. If the main session is still busy, the **gateway-level** message queue also captures this `callGateway` call
3. Both queues eventually deliver → **duplicate announcement**

### Root Cause

Both `sendAnnounce` (queue drain path) and the direct announce path in `runSubagentAnnounceFlow` use `crypto.randomUUID()` as the idempotency key:

```typescript
// Before fix:
idempotencyKey: crypto.randomUUID(),  // unique per call → dedup never matches
```

The gateway's dedup cache (`context.dedupe.get(\`agent:${idem}\`)`) can never detect the duplicate because each delivery attempt has a different key.

### Fix

Replace random idempotency keys with **deterministic** ones derived from stable identifiers:

```typescript
// Queue drain path:
idempotencyKey: \`announce:${item.sessionKey}:${item.enqueuedAt}\`

// Direct announce path:
idempotencyKey: \`announce:${params.childSessionKey}:${params.childRunId}\`
```

This allows the gateway dedup cache to recognize the second delivery attempt and return the cached response instead of processing it again.

### Changed Files

| File | Change |
|------|--------|
| `src/agents/subagent-announce.ts` | Replace `crypto.randomUUID()` with deterministic keys in both `sendAnnounce` and direct announce path; remove unused `crypto` import |

### Testing

- All 79 agent tests pass
- All 101 cron tests pass  
- Lint + format pass (oxlint + oxfmt)

### Related

- #15739 (cron duplicate delivery — same pattern, different subsystem)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaced random UUIDs with deterministic idempotency keys derived from stable identifiers to prevent duplicate subagent announcements when both the application-level announce queue and gateway-level message queue deliver the same announcement.

**Key changes:**
- Queue drain path in `sendAnnounce`: uses template with session key and enqueue timestamp instead of random UUID
- Direct announce path in `runSubagentAnnounceFlow`: uses template with child session key and run ID instead of random UUID
- Removed unused crypto import

The fix allows the gateway's deduplication cache to properly recognize and reject duplicate delivery attempts by using the same idempotency key for both delivery paths.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix correctly addresses the root cause of duplicate announcements by replacing non-deterministic random UUIDs with stable, deterministic idempotency keys. The values used (`sessionKey`, `enqueuedAt`, `childRunId`) are all stable identifiers that remain constant across duplicate delivery attempts. The change is minimal, well-tested (79 agent tests + 101 cron tests passing), and follows the same pattern used for cron duplicate delivery in #15739.
- No files require special attention

<sub>Last reviewed commit: 8f695c3</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->