### PR TITLE
fix: preserve scopes when dangerouslyDisableDeviceAuth is enabled

### DIFF
--- a/scripts/shell-helpers/clawdock-helpers.sh
+++ b/scripts/shell-helpers/clawdock-helpers.sh
@@ -136,7 +136,13 @@ _clawdock_ensure_dir() {
 # Wrapper to run docker compose commands
 _clawdock_compose() {
   _clawdock_ensure_dir || return 1
-  command docker compose -f "${CLAWDOCK_DIR}/docker-compose.yml" "$@"
+  # Include extra compose file if it exists (e.g., for OPENCLAW_HOME_VOLUME)
+  local extra_file="${CLAWDOCK_DIR}/docker-compose.extra.yml"
+  local compose_args="-f ${CLAWDOCK_DIR}/docker-compose.yml"
+  if [[ -f "$extra_file" ]]; then
+    compose_args="$compose_args -f $extra_file"
+  fi
+  command docker compose $compose_args "$@"
 }
 
 _clawdock_read_env_token() {

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -302,6 +302,7 @@ type MessageToolOptions = {
   replyToMode?: "off" | "first" | "all";
   hasRepliedRef?: { value: boolean };
   sandboxRoot?: string;
+  workspaceDir?: string;
   requireExplicitTarget?: boolean;
 };
 
@@ -485,6 +486,7 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
           ? resolveSessionAgentId({ sessionKey: options.agentSessionKey, config: cfg })
           : undefined,
         sandboxRoot: options?.sandboxRoot,
+        workspaceDir: options?.workspaceDir,
         abortSignal: signal,
       });
 

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -84,6 +84,7 @@ export function buildInboundUserContextPrefix(ctx: TemplateContext): string {
         username: safeTrim(ctx.SenderUsername),
         tag: safeTrim(ctx.SenderTag),
         e164: safeTrim(ctx.SenderE164),
+        id: safeTrim(ctx.SenderId),
       };
   if (senderInfo?.label) {
     blocks.push(

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -138,6 +138,7 @@ export async function initSessionState(params: {
   let persistedVerbose: string | undefined;
   let persistedReasoning: string | undefined;
   let persistedTtsAuto: TtsAutoMode | undefined;
+  let persistedResponseUsage: "on" | "off" | "tokens" | "full" | undefined;
   let persistedModelOverride: string | undefined;
   let persistedProviderOverride: string | undefined;
 
@@ -235,6 +236,7 @@ export async function initSessionState(params: {
     persistedVerbose = entry.verboseLevel;
     persistedReasoning = entry.reasoningLevel;
     persistedTtsAuto = entry.ttsAuto;
+    persistedResponseUsage = entry.responseUsage;
     persistedModelOverride = entry.modelOverride;
     persistedProviderOverride = entry.providerOverride;
   } else {
@@ -243,13 +245,14 @@ export async function initSessionState(params: {
     systemSent = false;
     abortedLastRun = false;
     // When a reset trigger (/new, /reset) starts a new session, carry over
-    // user-set behavior overrides (verbose, thinking, reasoning, ttsAuto)
+    // user-set behavior overrides (verbose, thinking, reasoning, ttsAuto, responseUsage)
     // so the user doesn't have to re-enable them every time.
     if (resetTriggered && entry) {
       persistedThinking = entry.thinkingLevel;
       persistedVerbose = entry.verboseLevel;
       persistedReasoning = entry.reasoningLevel;
       persistedTtsAuto = entry.ttsAuto;
+      persistedResponseUsage = entry.responseUsage;
     }
   }
 
@@ -282,7 +285,7 @@ export async function initSessionState(params: {
     verboseLevel: persistedVerbose ?? baseEntry?.verboseLevel,
     reasoningLevel: persistedReasoning ?? baseEntry?.reasoningLevel,
     ttsAuto: persistedTtsAuto ?? baseEntry?.ttsAuto,
-    responseUsage: baseEntry?.responseUsage,
+    responseUsage: persistedResponseUsage ?? baseEntry?.responseUsage,
     modelOverride: persistedModelOverride ?? baseEntry?.modelOverride,
     providerOverride: persistedProviderOverride ?? baseEntry?.providerOverride,
     sendPolicy: baseEntry?.sendPolicy,

--- a/src/commands/agent/session.ts
+++ b/src/commands/agent/session.ts
@@ -31,6 +31,7 @@ export type SessionResolution = {
   isNewSession: boolean;
   persistedThinking?: ThinkLevel;
   persistedVerbose?: VerboseLevel;
+  persistedResponseUsage?: "on" | "off" | "tokens" | "full";
 };
 
 type SessionKeyResolution = {
@@ -152,6 +153,8 @@ export function resolveSession(opts: {
     fresh && sessionEntry?.verboseLevel
       ? normalizeVerboseLevel(sessionEntry.verboseLevel)
       : undefined;
+  const persistedResponseUsage =
+    fresh && sessionEntry?.responseUsage ? sessionEntry.responseUsage : undefined;
 
   return {
     sessionId,
@@ -162,5 +165,6 @@ export function resolveSession(opts: {
     isNewSession,
     persistedThinking,
     persistedVerbose,
+    persistedResponseUsage,
   };
 }

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -118,7 +118,7 @@ export async function statusCommand(
             method: "health",
             params: { probe: true },
             timeoutMs: opts.timeoutMs,
-          }),
+          }).catch(() => undefined),
       )
     : undefined;
   const lastHeartbeat =

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -70,9 +70,11 @@ export function buildGatewayCronService(params: {
     runHeartbeatOnce: async (opts) => {
       const runtimeConfig = loadConfig();
       const agentId = opts?.agentId ? resolveCronAgent(opts.agentId).agentId : undefined;
+      // Use a cron:-prefixed reason to ensure heartbeat isn't skipped when HEARTBEAT.md is empty
+      const cronReason = opts?.reason ? `cron:${opts.reason}` : "cron:triggered";
       return await runHeartbeatOnce({
         cfg: runtimeConfig,
-        reason: opts?.reason,
+        reason: cronReason,
         agentId,
         deps: { ...params.deps, runtime: defaultRuntime },
       });

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -1,6 +1,7 @@
 import type { Server as HttpServer } from "node:http";
 import { WebSocketServer } from "ws";
 import type { CliDeps } from "../cli/deps.js";
+import { onDiagnosticEvent } from "../infra/diagnostic-events.js";
 import type { createSubsystemLogger } from "../logging/subsystem.js";
 import type { PluginRegistry } from "../plugins/registry.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -112,6 +113,11 @@ export async function createGatewayRuntimeState(params: {
 
   const clients = new Set<GatewayWsClient>();
   const { broadcast, broadcastToConnIds } = createGatewayBroadcaster({ clients });
+
+  // Subscribe to diagnostic events and broadcast them to WebSocket clients
+  onDiagnosticEvent((evt) => {
+    broadcast("diagnostic", evt);
+  });
 
   const handleHooksRequest = createGatewayHooksRequestHandler({
     deps: params.deps,

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -435,7 +435,7 @@ export function attachGatewayWsMessageHandler(params: {
           close(1008, truncateCloseReason(authMessage));
         };
         if (!device) {
-          if (scopes.length > 0) {
+          if (scopes.length > 0 && !allowControlUiBypass) {
             scopes = [];
             connectParams.scopes = scopes;
           }

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -301,11 +301,16 @@ export function attachGatewayWsMessageHandler(params: {
         // Note: If the client does not present a device identity, we can't bind scopes to a paired
         // device/token, so we will clear scopes after auth to avoid self-declared permissions.
         let scopes = Array.isArray(connectParams.scopes) ? connectParams.scopes : [];
+        const isControlUi = connectParams.client.id === GATEWAY_CLIENT_IDS.CONTROL_UI;
+        const isWebchat = isWebchatConnect(connectParams);
+        // For Control UI and webchat, default to operator.read scope if no scopes provided.
+        // This fixes token-only auth where scopes would be empty, breaking the dashboard.
+        if ((isControlUi || isWebchat) && scopes.length === 0) {
+          scopes = ["operator.read"];
+        }
         connectParams.role = role;
         connectParams.scopes = scopes;
 
-        const isControlUi = connectParams.client.id === GATEWAY_CLIENT_IDS.CONTROL_UI;
-        const isWebchat = isWebchatConnect(connectParams);
         if (isControlUi || isWebchat) {
           const originCheck = checkBrowserOrigin({
             requestHost,

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -98,6 +98,7 @@ export type RunMessageActionParams = {
   sessionKey?: string;
   agentId?: string;
   sandboxRoot?: string;
+  workspaceDir?: string;
   dryRun?: boolean;
   abortSignal?: AbortSignal;
 };
@@ -749,6 +750,7 @@ export async function runMessageAction(
   await normalizeSandboxMediaParams({
     args: params,
     sandboxRoot: input.sandboxRoot,
+    workspaceDir: input.workspaceDir,
   });
 
   await hydrateSendAttachmentParams({


### PR DESCRIPTION
Fixes #17153

## Problem
When `gateway.controlUi.dangerouslyDisableDeviceAuth: true` is set, the dashboard connects successfully but becomes completely unusable because all scopes are stripped to `[]`, resulting in "missing scope: operator.read" errors for every operation.

## Root Cause
In the WebSocket handshake code, when `!device` (which happens when `dangerouslyDisableDeviceAuth` is true), scopes were unconditionally cleared:

```typescript
if (!device) {
  if (scopes.length > 0) {
    scopes = [];  // ❌ Always clears scopes
    connectParams.scopes = scopes;
  }
```

This ignored the `allowControlUiBypass` flag which should permit scope preservation for local/bypass connections.

## Solution
Only clear scopes when `allowControlUiBypass` is false:

```typescript
if (!device) {
  if (scopes.length > 0 && !allowControlUiBypass) {
    scopes = [];  // ✅ Only clear when not bypassed
    connectParams.scopes = scopes;
  }
```

## Impact
- Dashboard now works correctly when `dangerouslyDisableDeviceAuth` is enabled
- Scopes (including `operator.read`) are preserved for local/bypass connections
- Security unchanged for normal device auth flow
- Fixes the regression introduced when device auth bypass was added

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a regression where the Control UI dashboard became unusable when `gateway.controlUi.dangerouslyDisableDeviceAuth` is enabled. The fix adds a single condition check (`!allowControlUiBypass`) to preserve scopes for local/bypass connections instead of unconditionally clearing them.

**Key Changes:**
- Modified scope-clearing logic in WebSocket authentication to respect the `allowControlUiBypass` flag
- When device auth is bypassed, scopes are now preserved, allowing the dashboard to function with `operator.read` permissions
- Security is maintained: scopes are still cleared when bypass is not enabled

**Note:** The PR includes 16 files in the changeset, but only 1 file (`src/gateway/server/ws-connection/message-handler.ts`) contains the actual fix. The other 15 files represent commits that occurred between the base and head SHA, and are not part of this specific fix.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a minimal, surgical change (single condition added) that correctly addresses the reported issue. The logic preserves scopes only when bypass is explicitly enabled via configuration flags, maintaining security for normal auth flows. The change is well-scoped and doesn't introduce new attack vectors.
- No files require special attention - the fix is straightforward and correctly implements the intended behavior

<sub>Last reviewed commit: 9d62ab8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->