### PR TITLE
security(line): fail closed when webhook token/secret are missing

### DIFF
--- a/src/line/monitor.auth-guards.test.ts
+++ b/src/line/monitor.auth-guards.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { monitorLineProvider } from "./monitor.js";
+
+const createLineBotMock = vi.fn();
+
+vi.mock("./bot.js", () => ({
+  createLineBot: (...args: unknown[]) => createLineBotMock(...args),
+}));
+
+describe("monitorLineProvider auth guards", () => {
+  const runtime = {
+    log: vi.fn(),
+    error: vi.fn(),
+  } as unknown as RuntimeEnv;
+
+  const cfg = {} as OpenClawConfig;
+
+  it("fails closed when channel secret is empty", async () => {
+    await expect(
+      monitorLineProvider({
+        channelAccessToken: "line-token",
+        channelSecret: "   ",
+        accountId: "default",
+        config: cfg,
+        runtime,
+      }),
+    ).rejects.toThrow(/channel secret missing/i);
+
+    expect(createLineBotMock).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when channel access token is empty", async () => {
+    await expect(
+      monitorLineProvider({
+        channelAccessToken: " ",
+        channelSecret: "line-secret",
+        accountId: "default",
+        config: cfg,
+        runtime,
+      }),
+    ).rejects.toThrow(/access token missing/i);
+
+    expect(createLineBotMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/line/monitor.ts
+++ b/src/line/monitor.ts
@@ -129,6 +129,20 @@ export async function monitorLineProvider(
     webhookPath,
   } = opts;
   const resolvedAccountId = accountId ?? "default";
+  const trimmedToken = channelAccessToken.trim();
+  const trimmedSecret = channelSecret.trim();
+
+  // Fail closed if webhook auth material is missing.
+  if (!trimmedToken) {
+    throw new Error(
+      `LINE channel access token missing for account "${resolvedAccountId}" (set channels.line.channelAccessToken or channels.line.accounts.${resolvedAccountId}.channelAccessToken).`,
+    );
+  }
+  if (!trimmedSecret) {
+    throw new Error(
+      `LINE channel secret missing for account "${resolvedAccountId}" (set channels.line.channelSecret or channels.line.accounts.${resolvedAccountId}.channelSecret).`,
+    );
+  }
 
   // Record starting state
   recordChannelRuntimeState({
@@ -142,8 +156,8 @@ export async function monitorLineProvider(
 
   // Create the bot
   const bot = createLineBot({
-    channelAccessToken,
-    channelSecret,
+    channelAccessToken: trimmedToken,
+    channelSecret: trimmedSecret,
     accountId,
     runtime,
     config,
@@ -281,7 +295,7 @@ export async function monitorLineProvider(
     pluginId: "line",
     accountId: resolvedAccountId,
     log: (msg) => logVerbose(msg),
-    handler: createLineNodeWebhookHandler({ channelSecret, bot, runtime }),
+    handler: createLineNodeWebhookHandler({ channelSecret: trimmedSecret, bot, runtime }),
   });
 
   logVerbose(`line: registered webhook handler at ${normalizedPath}`);


### PR DESCRIPTION
## Problem
LINE webhook startup accepted empty auth inputs, which weakens webhook trust assumptions and risks fail-open behavior.

## What Changed
- Added strict startup guards in `src/line/monitor.ts` to require non-empty `channelAccessToken` and `channelSecret`.
- Trimmed token/secret before wiring bot and webhook handler.
- Added regression tests in `src/line/monitor.auth-guards.test.ts` ensuring startup fails closed and bot creation is not attempted.

## Validation
- `pnpm vitest run src/line/monitor.auth-guards.test.ts`

Fixes #17158

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds startup validation to prevent LINE webhook initialization with empty credentials. Trims `channelAccessToken` and `channelSecret` before checking, and throws descriptive errors (referencing config paths) if either is empty. Test coverage ensures bot creation is never attempted when auth material is missing.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes implement straightforward security hardening with proper fail-closed behavior. The validation logic is correct (trim then check for emptiness), error messages are informative, and the test coverage verifies both edge cases. The guards execute early before any bot initialization or state recording, preventing potential security issues from empty credentials.
- No files require special attention

<sub>Last reviewed commit: 191c5a7</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->