### PR TITLE
fix: Add operator.read/write scopes to Dashboard auto-pairing

### DIFF
--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -140,7 +140,13 @@ export class GatewayBrowserClient {
     // Gateways may reject this unless gateway.controlUi.allowInsecureAuth is enabled.
     const isSecureContext = typeof crypto !== "undefined" && !!crypto.subtle;
 
-    const scopes = ["operator.admin", "operator.approvals", "operator.pairing"];
+    const scopes = [
+      "operator.admin",
+      "operator.approvals",
+      "operator.pairing",
+      "operator.read",
+      "operator.write",
+    ];
     const role = "operator";
     let deviceIdentity: Awaited<ReturnType<typeof loadOrCreateDeviceIdentity>> | null = null;
     let canFallbackToShared = false;


### PR DESCRIPTION
## Summary

The Dashboard webchat UI was missing `operator.read` and `operator.write` scopes during device auto-pairing, causing "missing scope: operator.read" errors on pages like `sessions.list` and `chat.history` after gateway restarts.

## Changes

- Added `operator.read` and `operator.write` to the default scopes requested by the Dashboard UI during device auto-pairing in `ui/src/ui/gateway.ts`

## Testing

- Ran existing e2e tests in `src/gateway/server.auth.e2e.test.ts` - all 26 tests passed

Fixes openclaw/openclaw#17187

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `operator.read` and `operator.write` to the Dashboard UI's default scopes during device auto-pairing in `ui/src/ui/gateway.ts`. Previously, the Dashboard only requested `["operator.admin", "operator.approvals", "operator.pairing"]`, which meant the issued device token lacked read/write scopes. After gateway restarts, when the Dashboard reconnects using only the stored device token (without the original shared token fallback), calls to read/write-gated methods like `sessions.list` and `chat.history` would fail with "missing scope: operator.read" errors.

- The fix is consistent with iOS and Android apps, which already request `["operator.read", "operator.write"]` during their device connections.
- The scope names are valid, matching constants defined in `src/gateway/server-methods.ts` and validated by `authorizeGatewayMethod()`.
- Note: The CLI (`src/gateway/call.ts:272`) and macOS `ConnectCommand.swift` still use the original three scopes without `operator.read`/`operator.write`, but this may be intentional since those clients may always have the shared token available or handle auth differently.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, well-scoped fix adding two valid scope strings to an array literal.
- The change is a single-file, 4-line addition of two well-established scope strings to an existing array. Both scope names (`operator.read`, `operator.write`) are valid constants used throughout the codebase and validated by the gateway's `authorizeGatewayMethod()`. The fix aligns the Dashboard UI with the iOS/Android apps and directly addresses the reported bug. No new logic, no behavioral regressions, and existing e2e tests pass.
- No files require special attention.

<sub>Last reviewed commit: 651602f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->