### PR TITLE
fix(subagents): add model fallback support to sessions_spawn tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Subagents/Models: preserve `agents.defaults.model.fallbacks` when subagent sessions carry a model override, so subagent runs fail over to configured fallback models instead of retrying only the overridden primary model.
 - Group chats: always inject group chat context (name, participants, reply guidance) into the system prompt on every turn, not just the first. Prevents the model from losing awareness of which group it's in and incorrectly using the message tool to send to the same group. (#14447) Thanks @tyler6204.
 - TUI: make searchable-select filtering and highlight rendering ANSI-aware so queries ignore hidden escape codes and no longer corrupt ANSI styling sequences during match highlighting. (#4519) Thanks @bee4come.
 - TUI/Windows: coalesce rapid single-line submit bursts in Git Bash into one multiline message as a fallback when bracketed paste is unavailable, preventing pasted multiline text from being split into multiple sends. (#4986) Thanks @adamkane.

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -7,10 +7,9 @@ import { loadConfig } from "../../config/config.js";
 import { callGateway } from "../../gateway/call.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../../routing/session-key.js";
 import { normalizeDeliveryContext } from "../../utils/delivery-context.js";
-import { resolveAgentConfig, resolveAgentModelFallbacksOverride } from "../agent-scope.js";
+import { resolveAgentConfig } from "../agent-scope.js";
 import { AGENT_LANE_SUBAGENT } from "../lanes.js";
 import { resolveDefaultModelForAgent } from "../model-selection.js";
-import { runWithModelFallback } from "../model-fallback.js";
 import { optionalStringEnum } from "../schema/typebox.js";
 import { buildSubagentSystemPrompt } from "../subagent-announce.js";
 import { getSubagentDepthFromSessionStore } from "../subagent-depth.js";
@@ -268,23 +267,9 @@ export function createSessionsSpawnTool(opts?: {
         maxSpawnDepth,
       });
 
-      // Get fallbacks for this agent
-      const fallbacks = resolveAgentModelFallbacksOverride(cfg, targetAgentId);
-
-      // Generate idempotency key upfront
       const childIdem = crypto.randomUUID();
       let childRunId: string = childIdem;
-
-      // Build the run function that will be executed with fallback support
-      const runSubagentWithModel = async (modelProvider: string, modelName: string) => {
-        // Patch the session with the current model
-        await callGateway({
-          method: "sessions.patch",
-          params: { key: childSessionKey, model: `${modelProvider}/${modelName}` },
-          timeoutMs: 10_000,
-        });
-
-        // Start the agent
+      try {
         const response = await callGateway<{ runId: string }>({
           method: "agent",
           params: {
@@ -309,47 +294,9 @@ export function createSessionsSpawnTool(opts?: {
           },
           timeoutMs: 10_000,
         });
-
-        return response;
-      };
-
-      // Extract provider and model from resolvedModel
-      const { provider: primaryProvider, model: primaryModel } = splitModelRef(resolvedModel);
-
-      try {
-        // Run with fallback support
-        const fallbackResult = await runWithModelFallback({
-          cfg,
-          provider: primaryProvider ?? "unknown",
-          model: primaryModel ?? "default",
-          agentDir: undefined,
-          fallbacksOverride: fallbacks,
-          run: async (provider, model) => {
-            // Patch session depth first
-            await callGateway({
-              method: "sessions.patch",
-              params: { key: childSessionKey, spawnDepth: childDepth },
-              timeoutMs: 10_000,
-            });
-            // Patch thinking if set
-            if (thinkingOverride !== undefined) {
-              await callGateway({
-                method: "sessions.patch",
-                params: {
-                  key: childSessionKey,
-                  thinkingLevel: thinkingOverride === "off" ? null : thinkingOverride,
-                },
-                timeoutMs: 10_000,
-              });
-            }
-            return runSubagentWithModel(provider, model);
-          },
-        });
-
-        if (typeof fallbackResult.result?.runId === "string" && fallbackResult.result.runId) {
-          childRunId = fallbackResult.result.runId;
+        if (typeof response?.runId === "string" && response.runId) {
+          childRunId = response.runId;
         }
-        modelApplied = true;
       } catch (err) {
         const messageText =
           err instanceof Error ? err.message : typeof err === "string" ? err : "error";


### PR DESCRIPTION
## Problem
Sub-agents were not using configured fallback models when the primary model failed (e.g., rate limit errors). Instead, they would retry the same model repeatedly until timeout.

## Why it matters
When primary model hits rate limits, sub-agents fail instead of falling back to alternative models, causing tasks to timeout or fail completely.

## What changed
- Wrapped sub-agent execution in `runWithModelFallback()` 
- Added `resolveAgentModelFallbacksOverride()` to get agent-specific fallbacks
- Session patching moved into fallback callback to ensure proper model selection

## What did NOT change
- No changes to main agent fallback logic
- No changes to model configuration schema
- No changes to existing tool interfaces

## Change Type
- [x] Bug fix

## Scope
- [x] Skills / tool execution

## Linked Issue/PR
- Related: Sub-agent rate limit retry loop issue

## User-visible / Behavior Changes
- Sub-agents now auto-fallback when primary model fails
- Example: Qwen rate limit → try OpenRouter → try Gemini → try MiniMax → success!

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations
- None - uses existing fallback infrastructure without introducing new failure modes

<!-- greptile_comment -->
