### PR TITLE
fix: Telegram stream preview finalizes in place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 - CLI/Build: make legacy daemon CLI compatibility shim generation tolerant of minimal tsdown daemon export sets, while preserving restart/register compatibility aliases and surfacing explicit errors for unavailable legacy daemon commands. Thanks @vignesh07.
 - Telegram: replace inbound `<media:audio>` placeholder with successful preflight voice transcript in message body context, preventing placeholder-only prompt bodies for mention-gated voice messages. (#16789) Thanks @Limitless2023.
 - Telegram: retry inbound media `getFile` calls (3 attempts with backoff) and gracefully fall back to placeholder-only processing when retries fail, preventing dropped voice/media messages on transient Telegram network errors. (#16154) Thanks @yinghaosang.
+- Telegram: finalize streaming preview replies in place instead of sending a second final message, preventing duplicate Telegram assistant outputs at stream completion. (#17218) Thanks @obviyus.
 
 ## 2026.2.14
 

--- a/docs/channels/grammy.md
+++ b/docs/channels/grammy.md
@@ -21,7 +21,7 @@ title: grammY
 - **Webhook support:** `webhook-set.ts` wraps `setWebhook/deleteWebhook`; `webhook.ts` hosts the callback with health + graceful shutdown. Gateway enables webhook mode when `channels.telegram.webhookUrl` + `channels.telegram.webhookSecret` are set (otherwise it long-polls).
 - **Sessions:** direct chats collapse into the agent main session (`agent:<agentId>:<mainKey>`); groups use `agent:<agentId>:telegram:group:<chatId>`; replies route back to the same channel.
 - **Config knobs:** `channels.telegram.botToken`, `channels.telegram.dmPolicy`, `channels.telegram.groups` (allowlist + mention defaults), `channels.telegram.allowFrom`, `channels.telegram.groupAllowFrom`, `channels.telegram.groupPolicy`, `channels.telegram.mediaMaxMb`, `channels.telegram.linkPreview`, `channels.telegram.proxy`, `channels.telegram.webhookSecret`, `channels.telegram.webhookUrl`, `channels.telegram.webhookHost`.
-- **Draft streaming:** optional `channels.telegram.streamMode` uses `sendMessageDraft` in private topic chats (Bot API 9.3+). This is separate from channel block streaming.
+- **Live stream preview:** optional `channels.telegram.streamMode` sends a temporary message and updates it with `editMessageText`. This is separate from channel block streaming.
 - **Tests:** grammy mocks cover DM + group mention gating and outbound send; more media/webhook fixtures still welcome.
 
 Open questions

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -155,7 +155,7 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
 
 - Bot token: `channels.telegram.botToken` or `channels.telegram.tokenFile`, with `TELEGRAM_BOT_TOKEN` as fallback for the default account.
 - `configWrites: false` blocks Telegram-initiated config writes (supergroup ID migrations, `/config set|unset`).
-- Draft streaming uses Telegram `sendMessageDraft` (requires private chat topics).
+- Telegram stream previews use `sendMessage` + `editMessageText` (works in direct and group chats).
 - Retry policy: see [Retry policy](/concepts/retry).
 
 ### Discord

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -335,11 +335,11 @@ export const FIELD_HELP: Record<string, string> = {
   "channels.telegram.dmPolicy":
     'Direct message access control ("pairing" recommended). "open" requires channels.telegram.allowFrom=["*"].',
   "channels.telegram.streamMode":
-    "Draft streaming mode for Telegram replies (off | partial | block). Separate from block streaming; requires private topics + sendMessageDraft.",
+    "Live stream preview mode for Telegram replies (off | partial | block). Separate from block streaming; uses sendMessage + editMessageText.",
   "channels.telegram.draftChunk.minChars":
-    'Minimum chars before emitting a Telegram draft update when channels.telegram.streamMode="block" (default: 200).',
+    'Minimum chars before emitting a Telegram stream preview update when channels.telegram.streamMode="block" (default: 200).',
   "channels.telegram.draftChunk.maxChars":
-    'Target max size for a Telegram draft update chunk when channels.telegram.streamMode="block" (default: 800; clamped to channels.telegram.textChunkLimit).',
+    'Target max size for a Telegram stream preview chunk when channels.telegram.streamMode="block" (default: 800; clamped to channels.telegram.textChunkLimit).',
   "channels.telegram.draftChunk.breakPreference":
     "Preferred breakpoints for Telegram draft chunks (paragraph | newline | sentence). Default: paragraph.",
   "channels.telegram.retry.attempts":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -237,7 +237,7 @@ export const FIELD_LABELS: Record<string, string> = {
   ...IRC_FIELD_LABELS,
   "channels.telegram.botToken": "Telegram Bot Token",
   "channels.telegram.dmPolicy": "Telegram DM Policy",
-  "channels.telegram.streamMode": "Telegram Draft Stream Mode",
+  "channels.telegram.streamMode": "Telegram Stream Mode",
   "channels.telegram.draftChunk.minChars": "Telegram Draft Chunk Min Chars",
   "channels.telegram.draftChunk.maxChars": "Telegram Draft Chunk Max Chars",
   "channels.telegram.draftChunk.breakPreference": "Telegram Draft Chunk Break Preference",

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -93,11 +93,11 @@ export type TelegramAccountConfig = {
   chunkMode?: "length" | "newline";
   /** Disable block streaming for this account. */
   blockStreaming?: boolean;
-  /** Chunking config for draft streaming in `streamMode: "block"`. */
+  /** Chunking config for Telegram stream previews in `streamMode: "block"`. */
   draftChunk?: BlockStreamingChunkConfig;
   /** Merge streamed block replies before sending. */
   blockStreamingCoalesce?: BlockStreamingCoalesceConfig;
-  /** Draft streaming mode for Telegram (off|partial|block). Default: partial. */
+  /** Telegram stream preview mode (off|partial|block). Default: partial. */
   streamMode?: "off" | "partial" | "block";
   mediaMaxMb?: number;
   /** Telegram API client timeout in seconds (grammY ApiClientOptions). */

--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const createTelegramDraftStream = vi.hoisted(() => vi.fn());
 const dispatchReplyWithBufferedBlockDispatcher = vi.hoisted(() => vi.fn());
 const deliverReplies = vi.hoisted(() => vi.fn());
+const editMessageTelegram = vi.hoisted(() => vi.fn());
 
 vi.mock("./draft-stream.js", () => ({
   createTelegramDraftStream,
@@ -15,6 +16,10 @@ vi.mock("../auto-reply/reply/provider-dispatcher.js", () => ({
 
 vi.mock("./bot/delivery.js", () => ({
   deliverReplies,
+}));
+
+vi.mock("./send.js", () => ({
+  editMessageTelegram,
 }));
 
 vi.mock("./sticker-cache.js", () => ({
@@ -29,12 +34,15 @@ describe("dispatchTelegramMessage draft streaming", () => {
     createTelegramDraftStream.mockReset();
     dispatchReplyWithBufferedBlockDispatcher.mockReset();
     deliverReplies.mockReset();
+    editMessageTelegram.mockReset();
   });
 
   it("streams drafts in private threads and forwards thread id", async () => {
     const draftStream = {
       update: vi.fn(),
       flush: vi.fn().mockResolvedValue(undefined),
+      messageId: vi.fn().mockReturnValue(undefined),
+      clear: vi.fn().mockResolvedValue(undefined),
       stop: vi.fn(),
     };
     createTelegramDraftStream.mockReturnValue(draftStream);
@@ -47,7 +55,6 @@ describe("dispatchTelegramMessage draft streaming", () => {
     );
     deliverReplies.mockResolvedValue({ delivered: true });
 
-    const resolveBotTopicsEnabled = vi.fn().mockResolvedValue(true);
     const context = {
       ctxPayload: {},
       primaryCtx: { message: { chat: { id: 123, type: "private" } } },
@@ -73,7 +80,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
       removeAckAfterReply: false,
     };
 
-    const bot = { api: { sendMessageDraft: vi.fn() } } as unknown as Bot;
+    const bot = { api: { sendMessage: vi.fn(), editMessageText: vi.fn() } } as unknown as Bot;
     const runtime = {
       log: vi.fn(),
       error: vi.fn(),
@@ -92,10 +99,8 @@ describe("dispatchTelegramMessage draft streaming", () => {
       textLimit: 4096,
       telegramCfg: {},
       opts: { token: "token" },
-      resolveBotTopicsEnabled,
     });
 
-    expect(resolveBotTopicsEnabled).toHaveBeenCalledWith(context.primaryCtx);
     expect(createTelegramDraftStream).toHaveBeenCalledWith(
       expect.objectContaining({
         chatId: 123,
@@ -108,5 +113,221 @@ describe("dispatchTelegramMessage draft streaming", () => {
         thread: { id: 777, scope: "dm" },
       }),
     );
+    expect(dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replyOptions: expect.objectContaining({
+          disableBlockStreaming: true,
+        }),
+      }),
+    );
+    expect(editMessageTelegram).not.toHaveBeenCalled();
+    expect(draftStream.clear).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps block streaming enabled when account config enables it", async () => {
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: "Hello" }, { kind: "final" });
+      return { queuedFinal: true };
+    });
+    deliverReplies.mockResolvedValue({ delivered: true });
+
+    const context = {
+      ctxPayload: {},
+      primaryCtx: { message: { chat: { id: 123, type: "private" } } },
+      msg: {
+        chat: { id: 123, type: "private" },
+        message_id: 456,
+        message_thread_id: 777,
+      },
+      chatId: 123,
+      isGroup: false,
+      resolvedThreadId: undefined,
+      replyThreadId: 777,
+      threadSpec: { id: 777, scope: "dm" },
+      historyKey: undefined,
+      historyLimit: 0,
+      groupHistories: new Map(),
+      route: { agentId: "default", accountId: "default" },
+      skillFilter: undefined,
+      sendTyping: vi.fn(),
+      sendRecordVoice: vi.fn(),
+      ackReactionPromise: null,
+      reactionApi: null,
+      removeAckAfterReply: false,
+    };
+    const bot = { api: { sendMessage: vi.fn(), editMessageText: vi.fn() } } as unknown as Bot;
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: () => {
+        throw new Error("exit");
+      },
+    };
+
+    await dispatchTelegramMessage({
+      context,
+      bot,
+      cfg: {},
+      runtime,
+      replyToMode: "first",
+      streamMode: "partial",
+      textLimit: 4096,
+      telegramCfg: { blockStreaming: true },
+      opts: { token: "token" },
+    });
+
+    expect(createTelegramDraftStream).not.toHaveBeenCalled();
+    expect(dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replyOptions: expect.objectContaining({
+          disableBlockStreaming: false,
+          onPartialReply: undefined,
+        }),
+      }),
+    );
+  });
+
+  it("finalizes text-only replies by editing the preview message in place", async () => {
+    const draftStream = {
+      update: vi.fn(),
+      flush: vi.fn().mockResolvedValue(undefined),
+      messageId: vi.fn().mockReturnValue(999),
+      clear: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn(),
+    };
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "Hel" });
+        await dispatcherOptions.deliver({ text: "Hello final" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+    deliverReplies.mockResolvedValue({ delivered: true });
+    editMessageTelegram.mockResolvedValue({ ok: true, chatId: "123", messageId: "999" });
+
+    const context = {
+      ctxPayload: {},
+      primaryCtx: { message: { chat: { id: 123, type: "private" } } },
+      msg: {
+        chat: { id: 123, type: "private" },
+        message_id: 456,
+        message_thread_id: 777,
+      },
+      chatId: 123,
+      isGroup: false,
+      resolvedThreadId: undefined,
+      replyThreadId: 777,
+      threadSpec: { id: 777, scope: "dm" },
+      historyKey: undefined,
+      historyLimit: 0,
+      groupHistories: new Map(),
+      route: { agentId: "default", accountId: "default" },
+      skillFilter: undefined,
+      sendTyping: vi.fn(),
+      sendRecordVoice: vi.fn(),
+      ackReactionPromise: null,
+      reactionApi: null,
+      removeAckAfterReply: false,
+    };
+
+    const bot = { api: { sendMessage: vi.fn(), editMessageText: vi.fn() } } as unknown as Bot;
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: () => {
+        throw new Error("exit");
+      },
+    };
+
+    await dispatchTelegramMessage({
+      context,
+      bot,
+      cfg: {},
+      runtime,
+      replyToMode: "first",
+      streamMode: "partial",
+      textLimit: 4096,
+      telegramCfg: {},
+      opts: { token: "token" },
+    });
+
+    expect(editMessageTelegram).toHaveBeenCalledWith(123, 999, "Hello final", expect.any(Object));
+    expect(deliverReplies).not.toHaveBeenCalled();
+    expect(draftStream.clear).not.toHaveBeenCalled();
+    expect(draftStream.stop).toHaveBeenCalled();
+  });
+
+  it("falls back to normal delivery when preview final is too long to edit", async () => {
+    const draftStream = {
+      update: vi.fn(),
+      flush: vi.fn().mockResolvedValue(undefined),
+      messageId: vi.fn().mockReturnValue(999),
+      clear: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn(),
+    };
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    const longText = "x".repeat(5000);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: longText }, { kind: "final" });
+      return { queuedFinal: true };
+    });
+    deliverReplies.mockResolvedValue({ delivered: true });
+    editMessageTelegram.mockResolvedValue({ ok: true, chatId: "123", messageId: "999" });
+
+    const context = {
+      ctxPayload: {},
+      primaryCtx: { message: { chat: { id: 123, type: "private" } } },
+      msg: {
+        chat: { id: 123, type: "private" },
+        message_id: 456,
+        message_thread_id: 777,
+      },
+      chatId: 123,
+      isGroup: false,
+      resolvedThreadId: undefined,
+      replyThreadId: 777,
+      threadSpec: { id: 777, scope: "dm" },
+      historyKey: undefined,
+      historyLimit: 0,
+      groupHistories: new Map(),
+      route: { agentId: "default", accountId: "default" },
+      skillFilter: undefined,
+      sendTyping: vi.fn(),
+      sendRecordVoice: vi.fn(),
+      ackReactionPromise: null,
+      reactionApi: null,
+      removeAckAfterReply: false,
+    };
+
+    const bot = { api: { sendMessage: vi.fn(), editMessageText: vi.fn() } } as unknown as Bot;
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: () => {
+        throw new Error("exit");
+      },
+    };
+
+    await dispatchTelegramMessage({
+      context,
+      bot,
+      cfg: {},
+      runtime,
+      replyToMode: "first",
+      streamMode: "partial",
+      textLimit: 4096,
+      telegramCfg: {},
+      opts: { token: "token" },
+    });
+
+    expect(editMessageTelegram).not.toHaveBeenCalled();
+    expect(deliverReplies).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replies: [expect.objectContaining({ text: longText })],
+      }),
+    );
+    expect(draftStream.clear).toHaveBeenCalledTimes(1);
+    expect(draftStream.stop).toHaveBeenCalled();
   });
 });

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -3,7 +3,7 @@ import type { OpenClawConfig, ReplyToMode, TelegramAccountConfig } from "../conf
 import type { RuntimeEnv } from "../runtime.js";
 import type { TelegramMessageContext } from "./bot-message-context.js";
 import type { TelegramBotOptions } from "./bot.js";
-import type { TelegramStreamMode, TelegramContext } from "./bot/types.js";
+import type { TelegramStreamMode } from "./bot/types.js";
 import { resolveAgentDir } from "../agents/agent-scope.js";
 import {
   findModelInCatalog,
@@ -24,6 +24,7 @@ import { danger, logVerbose } from "../globals.js";
 import { deliverReplies } from "./bot/delivery.js";
 import { resolveTelegramDraftStreamingChunking } from "./draft-chunking.js";
 import { createTelegramDraftStream } from "./draft-stream.js";
+import { editMessageTelegram } from "./send.js";
 import { cacheSticker, describeStickerImage } from "./sticker-cache.js";
 
 const EMPTY_RESPONSE_FALLBACK = "No response generated. Please try again.";
@@ -42,8 +43,6 @@ async function resolveStickerVisionSupport(cfg: OpenClawConfig, agentId: string)
   }
 }
 
-type ResolveBotTopicsEnabled = (ctx: TelegramContext) => boolean | Promise<boolean>;
-
 type DispatchTelegramMessageParams = {
   context: TelegramMessageContext;
   bot: Bot;
@@ -54,7 +53,6 @@ type DispatchTelegramMessageParams = {
   textLimit: number;
   telegramCfg: TelegramAccountConfig;
   opts: Pick<TelegramBotOptions, "token">;
-  resolveBotTopicsEnabled: ResolveBotTopicsEnabled;
 };
 
 export const dispatchTelegramMessage = async ({
@@ -67,11 +65,9 @@ export const dispatchTelegramMessage = async ({
   textLimit,
   telegramCfg,
   opts,
-  resolveBotTopicsEnabled,
 }: DispatchTelegramMessageParams) => {
   const {
     ctxPayload,
-    primaryCtx,
     msg,
     chatId,
     isGroup,
@@ -88,19 +84,16 @@ export const dispatchTelegramMessage = async ({
     removeAckAfterReply,
   } = context;
 
-  const isPrivateChat = msg.chat.type === "private";
-  const draftThreadId = threadSpec.id;
   const draftMaxChars = Math.min(textLimit, 4096);
-  const canStreamDraft =
-    streamMode !== "off" &&
-    isPrivateChat &&
-    typeof draftThreadId === "number" &&
-    (await resolveBotTopicsEnabled(primaryCtx));
+  const accountBlockStreamingEnabled =
+    typeof telegramCfg.blockStreaming === "boolean"
+      ? telegramCfg.blockStreaming
+      : cfg.agents?.defaults?.blockStreamingDefault === "on";
+  const canStreamDraft = streamMode !== "off" && !accountBlockStreamingEnabled;
   const draftStream = canStreamDraft
     ? createTelegramDraftStream({
         api: bot.api,
         chatId,
-        draftId: msg.message_id || Date.now(),
         maxChars: draftMaxChars,
         thread: threadSpec,
         log: logVerbose,
@@ -172,8 +165,11 @@ export const dispatchTelegramMessage = async ({
   };
 
   const disableBlockStreaming =
-    Boolean(draftStream) ||
-    (typeof telegramCfg.blockStreaming === "boolean" ? !telegramCfg.blockStreaming : undefined);
+    typeof telegramCfg.blockStreaming === "boolean"
+      ? !telegramCfg.blockStreaming
+      : draftStream
+        ? true
+        : undefined;
 
   const { onModelSelected, ...prefixOptions } = createReplyPrefixOptions({
     cfg,
@@ -250,64 +246,109 @@ export const dispatchTelegramMessage = async ({
     delivered: false,
     skippedNonSilent: 0,
   };
+  let finalizedViaPreviewMessage = false;
 
-  const { queuedFinal } = await dispatchReplyWithBufferedBlockDispatcher({
-    ctx: ctxPayload,
-    cfg,
-    dispatcherOptions: {
-      ...prefixOptions,
-      deliver: async (payload, info) => {
-        if (info.kind === "final") {
-          await flushDraft();
-          draftStream?.stop();
-        }
-        const result = await deliverReplies({
-          replies: [payload],
-          chatId: String(chatId),
-          token: opts.token,
-          runtime,
-          bot,
-          replyToMode,
-          textLimit,
-          thread: threadSpec,
-          tableMode,
-          chunkMode,
-          onVoiceRecording: sendRecordVoice,
-          linkPreview: telegramCfg.linkPreview,
-          replyQuoteText,
-        });
-        if (result.delivered) {
-          deliveryState.delivered = true;
-        }
-      },
-      onSkip: (_payload, info) => {
-        if (info.reason !== "silent") {
-          deliveryState.skippedNonSilent += 1;
-        }
-      },
-      onError: (err, info) => {
-        runtime.error?.(danger(`telegram ${info.kind} reply failed: ${String(err)}`));
-      },
-      onReplyStart: createTypingCallbacks({
-        start: sendTyping,
-        onStartError: (err) => {
-          logTypingFailure({
-            log: logVerbose,
-            channel: "telegram",
-            target: String(chatId),
-            error: err,
+  let queuedFinal = false;
+  try {
+    ({ queuedFinal } = await dispatchReplyWithBufferedBlockDispatcher({
+      ctx: ctxPayload,
+      cfg,
+      dispatcherOptions: {
+        ...prefixOptions,
+        deliver: async (payload, info) => {
+          if (info.kind === "final") {
+            await flushDraft();
+            const hasMedia = Boolean(payload.mediaUrl) || (payload.mediaUrls?.length ?? 0) > 0;
+            const previewMessageId = draftStream?.messageId();
+            const previewButtons = (
+              payload.channelData?.telegram as
+                | { buttons?: Array<Array<{ text: string; callback_data: string }>> }
+                | undefined
+            )?.buttons;
+            let draftStoppedForPreviewEdit = false;
+            if (!hasMedia && payload.text && typeof previewMessageId === "number") {
+              const canFinalizeViaPreviewEdit = payload.text.length <= draftMaxChars;
+              if (canFinalizeViaPreviewEdit) {
+                draftStream?.stop();
+                draftStoppedForPreviewEdit = true;
+                try {
+                  await editMessageTelegram(chatId, previewMessageId, payload.text, {
+                    api: bot.api,
+                    cfg,
+                    accountId: route.accountId,
+                    linkPreview: telegramCfg.linkPreview,
+                    buttons: previewButtons,
+                  });
+                  finalizedViaPreviewMessage = true;
+                  deliveryState.delivered = true;
+                  return;
+                } catch (err) {
+                  logVerbose(
+                    `telegram: preview final edit failed; falling back to standard send (${String(err)})`,
+                  );
+                }
+              } else {
+                logVerbose(
+                  `telegram: preview final too long for edit (${payload.text.length} > ${draftMaxChars}); falling back to standard send`,
+                );
+              }
+            }
+            if (!draftStoppedForPreviewEdit) {
+              draftStream?.stop();
+            }
+          }
+          const result = await deliverReplies({
+            replies: [payload],
+            chatId: String(chatId),
+            token: opts.token,
+            runtime,
+            bot,
+            replyToMode,
+            textLimit,
+            thread: threadSpec,
+            tableMode,
+            chunkMode,
+            onVoiceRecording: sendRecordVoice,
+            linkPreview: telegramCfg.linkPreview,
+            replyQuoteText,
           });
+          if (result.delivered) {
+            deliveryState.delivered = true;
+          }
         },
-      }).onReplyStart,
-    },
-    replyOptions: {
-      skillFilter,
-      disableBlockStreaming,
-      onPartialReply: draftStream ? (payload) => updateDraftFromPartial(payload.text) : undefined,
-      onModelSelected,
-    },
-  });
-  draftStream?.stop();
+        onSkip: (_payload, info) => {
+          if (info.reason !== "silent") {
+            deliveryState.skippedNonSilent += 1;
+          }
+        },
+        onError: (err, info) => {
+          runtime.error?.(danger(`telegram ${info.kind} reply failed: ${String(err)}`));
+        },
+        onReplyStart: createTypingCallbacks({
+          start: sendTyping,
+          onStartError: (err) => {
+            logTypingFailure({
+              log: logVerbose,
+              channel: "telegram",
+              target: String(chatId),
+              error: err,
+            });
+          },
+        }).onReplyStart,
+      },
+      replyOptions: {
+        skillFilter,
+        disableBlockStreaming,
+        onPartialReply: draftStream ? (payload) => updateDraftFromPartial(payload.text) : undefined,
+        onModelSelected,
+      },
+    }));
+  } finally {
+    if (!finalizedViaPreviewMessage) {
+      await draftStream?.clear();
+    }
+    draftStream?.stop();
+  }
   let sentFallback = false;
   if (!deliveryState.delivered && deliveryState.skippedNonSilent > 0) {
     const result = await deliverReplies({

--- a/src/telegram/bot-message.test.ts
+++ b/src/telegram/bot-message.test.ts
@@ -36,10 +36,9 @@ describe("telegram bot message processor", () => {
     resolveTelegramGroupConfig: () => ({}),
     runtime: {},
     replyToMode: "auto",
-    streamMode: "auto",
+    streamMode: "partial",
     textLimit: 4096,
     opts: {},
-    resolveBotTopicsEnabled: () => false,
   };
 
   it("dispatches when context is available", async () => {

--- a/src/telegram/bot-message.ts
+++ b/src/telegram/bot-message.ts
@@ -21,7 +21,6 @@ type TelegramMessageProcessorDeps = Omit<
   streamMode: TelegramStreamMode;
   textLimit: number;
   opts: Pick<TelegramBotOptions, "token">;
-  resolveBotTopicsEnabled: (ctx: TelegramContext) => boolean | Promise<boolean>;
 };
 
 export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDeps) => {
@@ -45,7 +44,6 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
     streamMode,
     textLimit,
     opts,
-    resolveBotTopicsEnabled,
   } = deps;
 
   return async (
@@ -86,7 +84,6 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
       textLimit,
       telegramCfg,
       opts,
-      resolveBotTopicsEnabled,
     });
   };
 };

--- a/src/telegram/bot/types.ts
+++ b/src/telegram/bot/types.ts
@@ -1,6 +1,6 @@
 import type { Message, UserFromGetMe } from "@grammyjs/types";
 
-/** App-specific stream mode for Telegram draft streaming. */
+/** App-specific stream mode for Telegram stream previews. */
 export type TelegramStreamMode = "off" | "partial" | "block";
 
 /**

--- a/src/telegram/draft-stream.test.ts
+++ b/src/telegram/draft-stream.test.ts
@@ -2,52 +2,117 @@ import { describe, expect, it, vi } from "vitest";
 import { createTelegramDraftStream } from "./draft-stream.js";
 
 describe("createTelegramDraftStream", () => {
-  it("passes message_thread_id when provided", () => {
-    const api = { sendMessageDraft: vi.fn().mockResolvedValue(true) };
+  it("sends stream preview message with message_thread_id when provided", async () => {
+    const api = {
+      sendMessage: vi.fn().mockResolvedValue({ message_id: 17 }),
+      editMessageText: vi.fn().mockResolvedValue(true),
+      deleteMessage: vi.fn().mockResolvedValue(true),
+    };
     const stream = createTelegramDraftStream({
       // oxlint-disable-next-line typescript/no-explicit-any
       api: api as any,
       chatId: 123,
-      draftId: 42,
       thread: { id: 99, scope: "forum" },
     });
 
     stream.update("Hello");
 
-    expect(api.sendMessageDraft).toHaveBeenCalledWith(123, 42, "Hello", {
-      message_thread_id: 99,
-    });
+    await vi.waitFor(() =>
+      expect(api.sendMessage).toHaveBeenCalledWith(123, "Hello", { message_thread_id: 99 }),
+    );
   });
 
-  it("omits message_thread_id for general topic id", () => {
-    const api = { sendMessageDraft: vi.fn().mockResolvedValue(true) };
+  it("edits existing stream preview message on subsequent updates", async () => {
+    const api = {
+      sendMessage: vi.fn().mockResolvedValue({ message_id: 17 }),
+      editMessageText: vi.fn().mockResolvedValue(true),
+      deleteMessage: vi.fn().mockResolvedValue(true),
+    };
     const stream = createTelegramDraftStream({
       // oxlint-disable-next-line typescript/no-explicit-any
       api: api as any,
       chatId: 123,
-      draftId: 42,
+      thread: { id: 99, scope: "forum" },
+    });
+
+    stream.update("Hello");
+    await vi.waitFor(() =>
+      expect(api.sendMessage).toHaveBeenCalledWith(123, "Hello", { message_thread_id: 99 }),
+    );
+    await (api.sendMessage.mock.results[0]?.value as Promise<unknown>);
+
+    stream.update("Hello again");
+    await stream.flush();
+
+    expect(api.editMessageText).toHaveBeenCalledWith(123, 17, "Hello again");
+  });
+
+  it("waits for in-flight updates before final flush edit", async () => {
+    let resolveSend: ((value: { message_id: number }) => void) | undefined;
+    const firstSend = new Promise<{ message_id: number }>((resolve) => {
+      resolveSend = resolve;
+    });
+    const api = {
+      sendMessage: vi.fn().mockReturnValue(firstSend),
+      editMessageText: vi.fn().mockResolvedValue(true),
+      deleteMessage: vi.fn().mockResolvedValue(true),
+    };
+    const stream = createTelegramDraftStream({
+      // oxlint-disable-next-line typescript/no-explicit-any
+      api: api as any,
+      chatId: 123,
+      thread: { id: 99, scope: "forum" },
+    });
+
+    stream.update("Hello");
+    await vi.waitFor(() => expect(api.sendMessage).toHaveBeenCalledTimes(1));
+    stream.update("Hello final");
+    const flushPromise = stream.flush();
+    expect(api.editMessageText).not.toHaveBeenCalled();
+
+    resolveSend?.({ message_id: 17 });
+    await flushPromise;
+
+    expect(api.editMessageText).toHaveBeenCalledWith(123, 17, "Hello final");
+  });
+
+  it("omits message_thread_id for general topic id", async () => {
+    const api = {
+      sendMessage: vi.fn().mockResolvedValue({ message_id: 17 }),
+      editMessageText: vi.fn().mockResolvedValue(true),
+      deleteMessage: vi.fn().mockResolvedValue(true),
+    };
+    const stream = createTelegramDraftStream({
+      // oxlint-disable-next-line typescript/no-explicit-any
+      api: api as any,
+      chatId: 123,
       thread: { id: 1, scope: "forum" },
     });
 
     stream.update("Hello");
 
-    expect(api.sendMessageDraft).toHaveBeenCalledWith(123, 42, "Hello", undefined);
+    await vi.waitFor(() => expect(api.sendMessage).toHaveBeenCalledWith(123, "Hello", undefined));
   });
 
-  it("keeps message_thread_id for dm threads", () => {
-    const api = { sendMessageDraft: vi.fn().mockResolvedValue(true) };
+  it("keeps message_thread_id for dm threads and clears preview on cleanup", async () => {
+    const api = {
+      sendMessage: vi.fn().mockResolvedValue({ message_id: 17 }),
+      editMessageText: vi.fn().mockResolvedValue(true),
+      deleteMessage: vi.fn().mockResolvedValue(true),
+    };
     const stream = createTelegramDraftStream({
       // oxlint-disable-next-line typescript/no-explicit-any
       api: api as any,
       chatId: 123,
-      draftId: 42,
       thread: { id: 1, scope: "dm" },
     });
 
     stream.update("Hello");
+    await vi.waitFor(() =>
+      expect(api.sendMessage).toHaveBeenCalledWith(123, "Hello", { message_thread_id: 1 }),
+    );
+    await stream.clear();
 
-    expect(api.sendMessageDraft).toHaveBeenCalledWith(123, 42, "Hello", {
-      message_thread_id: 1,
-    });
+    expect(api.deleteMessage).toHaveBeenCalledWith(123, 17);
   });
 });

--- a/src/telegram/send.edit-message.test.ts
+++ b/src/telegram/send.edit-message.test.ts
@@ -88,4 +88,23 @@ describe("editMessageTelegram", () => {
       }),
     );
   });
+
+  it("disables link previews when linkPreview is false", async () => {
+    botApi.editMessageText.mockResolvedValue({ message_id: 1, chat: { id: "123" } });
+
+    await editMessageTelegram("123", 1, "https://example.com", {
+      token: "tok",
+      cfg: {},
+      linkPreview: false,
+    });
+
+    expect(botApi.editMessageText).toHaveBeenCalledTimes(1);
+    const params = (botApi.editMessageText.mock.calls[0] ?? [])[3] as Record<string, unknown>;
+    expect(params).toEqual(
+      expect.objectContaining({
+        parse_mode: "HTML",
+        link_preview_options: { is_disabled: true },
+      }),
+    );
+  });
 });

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -696,6 +696,8 @@ type TelegramEditOpts = {
   api?: Bot["api"];
   retry?: RetryConfig;
   textMode?: "markdown" | "html";
+  /** Controls whether link previews are shown in the edited message. */
+  linkPreview?: boolean;
   /** Inline keyboard buttons (reply markup). Pass empty array to remove buttons. */
   buttons?: Array<Array<{ text: string; callback_data: string }>>;
   /** Optional config injection to avoid global loadConfig() (improves testability). */
@@ -752,6 +754,9 @@ export async function editMessageTelegram(
   const editParams: Record<string, unknown> = {
     parse_mode: "HTML",
   };
+  if (opts.linkPreview === false) {
+    editParams.link_preview_options = { is_disabled: true };
+  }
   if (replyMarkup !== undefined) {
     editParams.reply_markup = replyMarkup;
   }
@@ -767,6 +772,9 @@ export async function editMessageTelegram(
         console.warn(`telegram HTML parse failed, retrying as plain text: ${errText}`);
       }
       const plainParams: Record<string, unknown> = {};
+      if (opts.linkPreview === false) {
+        plainParams.link_preview_options = { is_disabled: true };
+      }
       if (replyMarkup !== undefined) {
         plainParams.reply_markup = replyMarkup;
       }


### PR DESCRIPTION
## Summary
- switch Telegram stream preview transport from `sendMessageDraft` to `sendMessage` + `editMessageText`
- finalize text-only replies by editing the same preview message in place (no extra final send)
- keep fallback path for non-text/complex finals (normal delivery + preview cleanup)
- fix race where a late in-flight preview update could overwrite the final formatted edit
- decouple preview streaming from forced block-stream disable so Telegram block streaming still works when enabled
- update Telegram streaming docs/config help text to match current behavior

## Testing
- `pnpm test src/telegram/draft-stream.test.ts src/telegram/bot-message-dispatch.test.ts src/telegram/send.edit-message.test.ts src/telegram/bot-message.test.ts src/auto-reply/reply.block-streaming.test.ts`
- `pnpm check`

Fixes #7123

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Switched Telegram stream preview transport from `sendMessageDraft` to `sendMessage` + `editMessageText`, enabling text-only final replies to be delivered by editing the same preview message in place instead of sending a duplicate final message.

Key changes:
- Preview messages now use standard `sendMessage` API (no longer requires private chat with topics enabled)
- Text-only finals edit the preview message in place (prevents duplicate sends)
- Non-text/complex finals fall back to normal delivery with preview cleanup
- Race condition fix: `flush()` now waits for all in-flight preview updates before returning, preventing late updates from overwriting the final formatted edit
- Decoupled preview streaming from block streaming disable (Telegram block streaming works independently when enabled)
- Updated docs and config help text to reflect new behavior

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-tested with comprehensive test coverage including race condition handling, fallback paths, and cleanup logic. The implementation correctly addresses the race condition by ensuring `flush()` waits for in-flight operations before returning. The finally block properly handles cleanup in both success and failure scenarios. Documentation and config help text accurately reflect the new behavior.
- No files require special attention

<sub>Last reviewed commit: 2f6ac9e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->