### PR TITLE
fix(agents): prevent agents from using exec for gateway management

### DIFF
--- a/src/agents/system-prompt.e2e.test.ts
+++ b/src/agents/system-prompt.e2e.test.ts
@@ -106,6 +106,7 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("## OpenClaw CLI Quick Reference");
     expect(prompt).toContain("openclaw gateway restart");
     expect(prompt).toContain("Do not invent commands");
+    expect(prompt).toContain("Do not use exec for gateway stop/restart/config");
   });
 
   it("marks system message blocks as internal and not user-visible", () => {
@@ -277,7 +278,9 @@ describe("buildAgentSystemPrompt", () => {
 
     expect(prompt).toContain("## OpenClaw Self-Update");
     expect(prompt).toContain("config.apply");
+    expect(prompt).toContain("config.patch");
     expect(prompt).toContain("update.run");
+    expect(prompt).toContain("never edit config files directly");
   });
 
   it("includes skills guidance when skills prompt is present", () => {

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -444,6 +444,8 @@ export function buildAgentSystemPrompt(params: {
     "- openclaw gateway stop",
     "- openclaw gateway restart",
     "If unsure, ask the user to run `openclaw help` (or `openclaw gateway --help`) and paste the output.",
+    "Do not use exec for gateway stop/restart/config — use the `gateway` tool instead.",
+    "The gateway tool preserves session context across restarts; exec does not.",
     "",
     ...skillsSection,
     ...memorySection,
@@ -453,8 +455,9 @@ export function buildAgentSystemPrompt(params: {
       ? [
           "Get Updates (self-update) is ONLY allowed when the user explicitly asks for it.",
           "Do not run config.apply or update.run unless the user explicitly requests an update or config change; if it's not explicit, ask first.",
-          "Actions: config.get, config.schema, config.apply (validate + write full config, then restart), update.run (update deps or git, then restart).",
+          "Actions: config.get, config.schema, config.apply (validate + write full config, then restart), config.patch (safe partial config updates; merges with existing), update.run (update deps or git, then restart).",
           "After restart, OpenClaw pings the last active session automatically.",
+          "Config changes via config.apply/config.patch are validated before writing and restart automatically — never edit config files directly or restart manually after config changes.",
         ].join("\n")
       : "",
     hasGateway && !isMinimal ? "" : "",


### PR DESCRIPTION
## Summary

- **Problem:** System prompt teaches agents CLI commands for gateway management and implies manual restart is needed after config changes
- **Why it matters:** Agents use `exec openclaw gateway restart` (full process kill, no session preservation) instead of the gateway tool, and manually edit config files when `config.apply` rejects invalid input — breaking their own gateway
- **What changed:** Added warnings against using exec for gateway operations; clarified config changes auto-restart; documented `config.patch`
- **What did NOT change:** CLI reference still lists commands for reference; no runtime logic changed

Closes #17189
Supersedes #13068 (narrower fix — only warned about restart)

## Root Cause

Two system prompt issues combine:
1. CLI Quick Reference lists `openclaw gateway stop/restart` without warning that `exec` bypasses the gateway tool's restart sentinel (session context lost)
2. Self-Update section says `config.apply (validate + write full config, then restart)` — agents misread "then restart" as something they need to do manually

## Changes

**`src/agents/system-prompt.ts`** (+4 lines):
- "Do not use exec for gateway stop/restart/config — use the gateway tool instead"
- "The gateway tool preserves session context across restarts; exec does not"
- Documented `config.patch` as preferred method for partial config updates
- "Config changes via config.apply/config.patch are validated before writing and restart automatically — never edit config files directly"

**`src/agents/system-prompt.e2e.test.ts`** (+3 assertions):
- Verify exec warning present in CLI reference
- Verify `config.patch` and "never edit config files directly" in self-update section

## Testing

All 39 e2e tests pass (`vitest run --config vitest.e2e.config.ts src/agents/system-prompt.e2e.test.ts`).

## Compatibility

Backward compatible — additive prompt text only.

## AI Disclosure
AI-assisted (Claude via OpenClaw). Code reviewed and tested.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds defensive system prompt text to prevent agents from using `exec` for gateway management operations (stop/restart/config), which bypasses the restart sentinel and loses session context. Also documents `config.patch` as the preferred method for partial config updates and clarifies that config changes auto-restart — addressing agent misinterpretation of "then restart" as a manual step.

- Added exec warning in CLI Quick Reference section directing agents to use the `gateway` tool instead
- Documented `config.patch` in the Self-Update section alongside `config.apply`
- Added explicit note that config changes restart automatically — agents should never edit config files directly
- Three new e2e test assertions verify the new prompt content is present

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it only adds additive prompt text with no runtime logic changes.
- The changes are purely additive system prompt text (4 new lines) and 3 new test assertions. No runtime logic, no behavioral changes, no API modifications. The new prompt content is factually accurate: `config.patch` is a real gateway action, the restart sentinel mechanism does preserve session context, and config changes do auto-restart. Tests pass and cover the new content.
- No files require special attention.

<sub>Last reviewed commit: fc438b0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->