### PR TITLE
fix: preload daemon-cli module before npm update

### DIFF
--- a/src/cli/daemon-cli.ts
+++ b/src/cli/daemon-cli.ts
@@ -1,6 +1,7 @@
 export { registerDaemonCli } from "./daemon-cli/register.js";
 export { addGatewayServiceCommands } from "./daemon-cli/register-service-commands.js";
 export {
+  preloadDaemonCli,
   runDaemonInstall,
   runDaemonRestart,
   runDaemonStart,

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -55,6 +55,8 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
  * that might delete the on-disk files.
  */
 export async function preloadDaemonCli(): Promise<void> {
-  // Import and discard - just ensuring modules are loaded
-  await Promise.resolve();
+  // Import all daemon-cli dependencies to ensure they're cached in memory
+  await import("./lifecycle-core.js");
+  await import("./shared.js");
+  await import("../../daemon/service.js");
 }

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -48,3 +48,13 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
     opts,
   });
 }
+
+/**
+ * Preload daemon-cli module and its dependencies.
+ * This ensures all required modules are loaded into memory before any update process
+ * that might delete the on-disk files.
+ */
+export async function preloadDaemonCli(): Promise<void> {
+  // Import and discard - just ensuring modules are loaded
+  await Promise.resolve();
+}

--- a/src/cli/daemon-cli/runners.ts
+++ b/src/cli/daemon-cli/runners.ts
@@ -1,5 +1,6 @@
 export { runDaemonInstall } from "./install.js";
 export {
+  preloadDaemonCli,
   runDaemonRestart,
   runDaemonStart,
   runDaemonStop,

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -115,6 +115,7 @@ vi.mock("../commands/doctor.js", () => ({
 }));
 // Mock the daemon-cli module
 vi.mock("./daemon-cli.js", () => ({
+  preloadDaemonCli: vi.fn(),
   runDaemonRestart: vi.fn(),
 }));
 

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -32,7 +32,7 @@ import { pathExists } from "../../utils.js";
 import { replaceCliName, resolveCliName } from "../cli-name.js";
 import { formatCliCommand } from "../command-format.js";
 import { installCompletion } from "../completion-cli.js";
-import { runDaemonRestart } from "../daemon-cli.js";
+import { preloadDaemonCli, runDaemonRestart } from "../daemon-cli.js";
 import { createUpdateProgress, printResult } from "./progress.js";
 import {
   DEFAULT_PACKAGE_NAME,
@@ -565,6 +565,11 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
 
   const { progress, stop } = createUpdateProgress(showProgress);
   const startedAt = Date.now();
+
+  // Preload daemon-cli module before the update to ensure all required modules
+  // are loaded into memory. This prevents errors after npm update when the old
+  // on-disk files have been deleted.
+  await preloadDaemonCli();
 
   const result = switchToPackage
     ? await runPackageInstallUpdate({


### PR DESCRIPTION
## Summary

The CLI update command failed after npm update because the old on-disk files were deleted while the running code still referenced them. This fix adds a preload call to ensure all daemon-cli dependencies are loaded into memory before the npm update process begins.

## Changes

- Added `preloadDaemonCli()` function to `src/cli/daemon-cli/lifecycle.ts`
- Exported the new function from `src/cli/daemon-cli/runners.ts` and `src/cli/daemon-cli.ts`
- Added preload call in `src/cli/update-cli/update-command.ts` before the npm update runs
- Updated tests in `src/cli/update-cli.test.ts` to mock the new function

## Testing

- All 20 existing tests in `src/cli/update-cli.test.ts` pass

Fixes openclaw/openclaw#17225

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds preloading to prevent the CLI update command from failing after npm update deletes old files. The `preloadDaemonCli()` function loads key daemon-cli dependencies into memory before npm update runs.

**Key Changes:**
- Added `preloadDaemonCli()` function in `src/cli/daemon-cli/lifecycle.ts`
- Exported function through `src/cli/daemon-cli/runners.ts` and `src/cli/daemon-cli.ts`
- Called preload before npm update in `src/cli/update-cli/update-command.ts:572`
- Tests properly mock the new function

**Critical Issue Found:**
- `./response.js` is not being preloaded, but it's imported by `lifecycle-core.js` and called during `runDaemonRestart()`. This will cause the same failure the PR is trying to fix.

<h3>Confidence Score: 2/5</h3>

- PR is not safe to merge - incomplete preloading will cause runtime failures
- Score reflects a critical missing dependency (`response.js`) that will cause the exact same failure this PR is trying to fix. While the approach is correct and most dependencies are covered, the incomplete implementation means `runDaemonRestart()` will still fail after npm update when it tries to call functions from the unloaded `response.js` module.
- Pay close attention to `src/cli/daemon-cli/lifecycle.ts` - the preload function needs to include `response.js`

<sub>Last reviewed commit: d5d561f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->