### PR TITLE
fix(telegram): ignore messageThreadId for DM chats (#14653)

### DIFF
--- a/src/telegram/bot-message-context.dm-topic-threadid.test.ts
+++ b/src/telegram/bot-message-context.dm-topic-threadid.test.ts
@@ -66,21 +66,21 @@ describe("buildTelegramMessageContext DM topic threadId in deliveryContext (#889
     recordInboundSessionMock.mockClear();
   });
 
-  it("passes threadId to updateLastRoute for DM topics", async () => {
+  it("does not pass threadId for DM even when message_thread_id is present", async () => {
     const ctx = await buildCtx({
       message: {
         chat: { id: 1234, type: "private" },
-        message_thread_id: 42, // DM Topic ID
+        message_thread_id: 42, // DM Topic ID — should be ignored
       },
     });
 
     expect(ctx).not.toBeNull();
     expect(recordInboundSessionMock).toHaveBeenCalled();
 
-    // Check that updateLastRoute includes threadId
+    // DMs should never include threadId, even if message_thread_id is present
     const updateLastRoute = getUpdateLastRoute() as { threadId?: string } | undefined;
     expect(updateLastRoute).toBeDefined();
-    expect(updateLastRoute?.threadId).toBe("42");
+    expect(updateLastRoute?.threadId).toBeUndefined();
   });
 
   it("does not pass threadId for regular DM without topic", async () => {

--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -37,7 +37,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     editMessageTelegram.mockReset();
   });
 
-  it("streams drafts in private threads and forwards thread id", async () => {
+  it("streams drafts in private chats without thread id", async () => {
     const draftStream = {
       update: vi.fn(),
       flush: vi.fn().mockResolvedValue(undefined),
@@ -67,7 +67,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
       isGroup: false,
       resolvedThreadId: undefined,
       replyThreadId: 777,
-      threadSpec: { id: 777, scope: "dm" },
+      threadSpec: { scope: "dm" },
       historyKey: undefined,
       historyLimit: 0,
       groupHistories: new Map(),
@@ -104,13 +104,13 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(createTelegramDraftStream).toHaveBeenCalledWith(
       expect.objectContaining({
         chatId: 123,
-        thread: { id: 777, scope: "dm" },
+        thread: { scope: "dm" },
       }),
     );
     expect(draftStream.update).toHaveBeenCalledWith("Hello");
     expect(deliverReplies).toHaveBeenCalledWith(
       expect.objectContaining({
-        thread: { id: 777, scope: "dm" },
+        thread: { scope: "dm" },
       }),
     );
     expect(dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledWith(
@@ -143,7 +143,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
       isGroup: false,
       resolvedThreadId: undefined,
       replyThreadId: 777,
-      threadSpec: { id: 777, scope: "dm" },
+      threadSpec: { scope: "dm" },
       historyKey: undefined,
       historyLimit: 0,
       groupHistories: new Map(),
@@ -218,7 +218,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
       isGroup: false,
       resolvedThreadId: undefined,
       replyThreadId: 777,
-      threadSpec: { id: 777, scope: "dm" },
+      threadSpec: { scope: "dm" },
       historyKey: undefined,
       historyLimit: 0,
       groupHistories: new Map(),
@@ -287,7 +287,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
       isGroup: false,
       resolvedThreadId: undefined,
       replyThreadId: 777,
-      threadSpec: { id: 777, scope: "dm" },
+      threadSpec: { scope: "dm" },
       historyKey: undefined,
       historyLimit: 0,
       groupHistories: new Map(),

--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -45,13 +45,7 @@ export function resolveTelegramThreadSpec(params: {
       scope: params.isForum ? "forum" : "none",
     };
   }
-  if (params.messageThreadId == null) {
-    return { scope: "dm" };
-  }
-  return {
-    id: params.messageThreadId,
-    scope: "dm",
-  };
+  return { scope: "dm" };
 }
 
 /**


### PR DESCRIPTION
## Problem

In Telegram DM chats (non-forum), `resolveTelegramThreadSpec()` forwards `message_thread_id` as a thread ID in the `threadSpec`. This causes reply routing issues since DMs do not have real threads — Telegram sometimes sends `message_thread_id` in DMs (e.g. when Topics are enabled globally), but it has no semantic meaning there.

Fixes #14653

## Solution

Remove the `messageThreadId` branch from the DM path in `resolveTelegramThreadSpec()`. DMs now always return `{ scope: "dm" }` without an `id` field, regardless of whether `message_thread_id` is present.

## Changes

- `src/telegram/bot/helpers.ts` — Collapsed the DM branch to always return `{ scope: "dm" }` (+1/−7 lines)
- `src/telegram/bot-message-context.dm-topic-threadid.test.ts` — Updated assertions to expect no `threadId` for DMs
- `src/telegram/bot-message-dispatch.test.ts` — Updated 4 test cases: `threadSpec` for DMs no longer includes `id`

## Testing

All existing Telegram tests pass. The updated tests verify the new behavior: DMs never carry a thread ID.

> 🤖 AI-assisted: code changes generated with AI assistance, manually reviewed and verified.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a reply routing issue in Telegram DMs by removing spurious `message_thread_id` handling. Previously, when Telegram sent `message_thread_id` in DM chats (which can happen when Topics are enabled globally), the code incorrectly treated it as a real thread ID, causing session routing problems. The fix ensures DMs always return `{ scope: "dm" }` without an `id` field, since DMs don't have semantic threads. The change correctly propagates through the codebase: `replyThreadId`, `dmThreadId`, and `MessageThreadId` all become `undefined` for DMs, which is the intended behavior. All test updates properly verify that DMs never carry thread IDs, even when `message_thread_id` is present in the Telegram message payload.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change is minimal, well-scoped, and correctly addresses a real bug. The logic change collapses the DM branch to always return `{ scope: "dm" }` without an `id`, which aligns with Telegram's semantics where `message_thread_id` has no meaning in DM chats. All affected code paths handle `undefined` threadSpec.id correctly (e.g., `buildTypingThreadParams`, `dmThreadId` extraction, session key resolution). The test updates comprehensively verify the new behavior across multiple scenarios. No edge cases or potential issues identified.
- No files require special attention

<sub>Last reviewed commit: cd890e1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->