### PR TITLE
fix(telegram): catch getFile network failures to prevent gateway crash (#17227)

### DIFF
--- a/src/auto-reply/inbound-debounce.ts
+++ b/src/auto-reply/inbound-debounce.ts
@@ -90,7 +90,11 @@ export function createInboundDebouncer<T>(params: {
       if (key && buffers.has(key)) {
         await flushKey(key);
       }
-      await params.onFlush([item]);
+      try {
+        await params.onFlush([item]);
+      } catch (err) {
+        params.onError?.(err, [item]);
+      }
       return;
     }
 


### PR DESCRIPTION
## Problem

When Telegram's `getFile` API call fails due to network issues (timeout, DNS failure), the gateway crashes with an unhandled promise rejection. The error chain is: `processMessage` → `resolveMedia` → `ctx.getFile()` → unhandled rejection → crash.

Fixes #17227

## Solution

Add error handling to the unguarded `onFlush` promise path in `src/auto-reply/inbound-debounce.ts`:

The `enqueue` function's immediate-flush path (`await params.onFlush([item])`) had no try/catch — wrapped with error routing to `params.onError`, following the existing callback pattern used by the batched flush path.

## Changes

- `src/auto-reply/inbound-debounce.ts` — 5 insertions, 1 deletion

## Testing

Existing tests pass.

---


## Local Validation

- `pnpm build` ✅
- `pnpm check` (oxlint) ✅
- Relevant test suites pass ✅

## Contribution Checklist

- [x] Focused scope — single fix per PR
- [x] Clear "what" + "why" in description
- [x] AI-assisted (Codex/Claude) — reviewed and tested by human
- [x] Local validation run (`pnpm build && pnpm check`)

*AI-assisted (Claude). Reviewed by human.*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Wraps the unguarded `params.onFlush([item])` call in the immediate-flush path of `createInboundDebouncer.enqueue` with a try/catch that routes errors to `params.onError`. This aligns the non-debounce path with the existing error handling in `flushBuffer` (lines 60-64), preventing unhandled promise rejections from crashing the gateway when callers lack their own outer try/catch (e.g., the Slack message handler).

- **`src/auto-reply/inbound-debounce.ts`**: 5-line change adds try/catch around the immediate-flush `onFlush` call, consistent with the batched-flush error pattern

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a minimal, well-scoped defensive fix that follows an established pattern.
- The change is a 5-line addition that wraps an existing `onFlush` call with the same try/catch + `onError` pattern already used by `flushBuffer`. It introduces no new behavior, no API changes, and no risk of regression. The fix is correct and addresses a real gap in error handling.
- No files require special attention.

<sub>Last reviewed commit: 6960057</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->