### PR TITLE
fix: expose messageId of triggering message in agent prompt (#17207)

### DIFF
--- a/src/auto-reply/envelope.test.ts
+++ b/src/auto-reply/envelope.test.ts
@@ -170,4 +170,27 @@ describe("formatInboundEnvelope", () => {
       userTimezone: "Europe/Vienna",
     });
   });
+
+  it("appends messageId when provided", () => {
+    const body = formatInboundEnvelope({
+      channel: "Discord",
+      from: "Guild #general",
+      body: "hi",
+      chatType: "channel",
+      senderLabel: "Alice",
+      messageId: "msg123",
+    });
+    expect(body).toBe("[Discord Guild #general] Alice: hi [id:msg123]");
+  });
+
+  it("does not append messageId when not provided", () => {
+    const body = formatInboundEnvelope({
+      channel: "Discord",
+      from: "Guild #general",
+      body: "hi",
+      chatType: "channel",
+      senderLabel: "Alice",
+    });
+    expect(body).toBe("[Discord Guild #general] Alice: hi");
+  });
 });

--- a/src/auto-reply/envelope.ts
+++ b/src/auto-reply/envelope.ts
@@ -197,12 +197,17 @@ export function formatInboundEnvelope(params: {
   sender?: SenderLabelParams;
   previousTimestamp?: number | Date;
   envelope?: EnvelopeFormatOptions;
+  messageId?: string;
 }): string {
   const chatType = normalizeChatType(params.chatType);
   const isDirect = !chatType || chatType === "direct";
   const resolvedSenderRaw = params.senderLabel?.trim() || resolveSenderLabel(params.sender ?? {});
   const resolvedSender = resolvedSenderRaw ? sanitizeEnvelopeHeaderPart(resolvedSenderRaw) : "";
-  const body = !isDirect && resolvedSender ? `${resolvedSender}: ${params.body}` : params.body;
+  let body = !isDirect && resolvedSender ? `${resolvedSender}: ${params.body}` : params.body;
+  if (params.messageId) {
+    const sanitizedId = params.messageId.replace(/[\[\]]/g, '');
+    body += ` [id:${sanitizedId}]`;
+  }
   return formatAgentEnvelope({
     channel: params.channel,
     from: params.from,

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -175,6 +175,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     senderLabel,
     previousTimestamp,
     envelope: envelopeOptions,
+    messageId: message.id,
   });
   const shouldIncludeChannelHistory =
     !isDirectMessage && !(isGuildMessage && channelConfig?.autoThread && !threadChannel);

--- a/src/imessage/monitor/monitor-provider.ts
+++ b/src/imessage/monitor/monitor-provider.ts
@@ -530,6 +530,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       sender: { name: senderNormalized, id: sender },
       previousTimestamp,
       envelope: envelopeOptions,
+      messageId: message.id ? String(message.id) : undefined,
     });
     let combinedBody = body;
     if (isGroup && historyKey) {

--- a/src/line/bot-message-context.ts
+++ b/src/line/bot-message-context.ts
@@ -261,6 +261,7 @@ async function finalizeLineInboundContext(params: {
     },
     previousTimestamp,
     envelope: envelopeOptions,
+    messageId: params.messageSid,
   });
 
   const ctxPayload = finalizeInboundContext({

--- a/src/signal/monitor/event-handler.ts
+++ b/src/signal/monitor/event-handler.ts
@@ -103,6 +103,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       sender: { name: entry.senderName, id: entry.senderDisplay },
       previousTimestamp,
       envelope: envelopeOptions,
+      messageId: entry.messageId,
     });
     let combinedBody = body;
     const historyKey = entry.isGroup ? String(entry.groupId ?? "unknown") : undefined;

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -583,6 +583,7 @@ export const buildTelegramMessageContext = async ({
     },
     previousTimestamp,
     envelope: envelopeOptions,
+    messageId: String(msg.message_id),
   });
   let combinedBody = body;
   if (isGroup && historyKey && historyLimit > 0) {

--- a/src/web/auto-reply/monitor/message-line.ts
+++ b/src/web/auto-reply/monitor/message-line.ts
@@ -43,5 +43,6 @@ export function buildInboundLine(params: {
     },
     previousTimestamp,
     envelope,
+    messageId: msg.id,
   });
 }


### PR DESCRIPTION
## Problem

When a channel message triggers an agent, the agent has no way to know the `messageId` of the triggering message. This makes `action: "react"` impossible on the current message. History entries already include messageId as `[id:... channel:...]`, but the triggering message does not.

Fixes #17207

## Solution

Add an optional `messageId` parameter to `formatInboundEnvelope()` that appends `[id:...]` to the message body — matching the existing pattern used by history entries.

## Changes

- `src/auto-reply/envelope.ts` — Added optional `messageId` param, appends `[id:...]` suffix (+5/−1)
- `src/auto-reply/envelope.test.ts` — 2 new tests: messageId present + omitted (+23)
- 6 channel handlers updated to pass messageId:
  - `src/telegram/bot-message-context.ts` — `msg.message_id`
  - `src/discord/monitor/message-handler.process.ts` — `message.id`
  - `src/signal/monitor/event-handler.ts` — `entry.messageId`
  - `src/line/bot-message-context.ts` — `params.messageSid`
  - `src/imessage/monitor/monitor-provider.ts` — `message.id`
  - `src/web/auto-reply/monitor/message-line.ts` — WhatsApp `msg.id`
- Slack skipped (already embeds message ID in body)

## Testing

All existing tests pass + 2 new envelope tests added.

> 🤖 AI-assisted: code changes generated with AI assistance, manually reviewed and verified.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `messageId` parameter to `formatInboundEnvelope()` to expose the triggering message ID in agent prompts using the `[id:...]` format, enabling agents to react to the current message. Updated 6 channel handlers (Telegram, Discord, Signal, LINE, iMessage, WhatsApp) to pass message IDs.

**Key changes:**
- Core function enhanced with optional `messageId` param that appends `[id:...]` suffix to message body
- Pattern matches existing history entry format for consistency
- Tests added covering both presence and omission of messageId
- All major channel integrations updated except Slack (which already embeds message ID)

**Issue found:**
- messageId values are not sanitized before being appended to the body. Brackets in message IDs could break the `[id:...]` format and potentially confuse parsing logic.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor risk of bracket injection in messageId values
- The implementation is straightforward, well-tested, and follows existing patterns. However, messageId values are not sanitized before being appended in the `[id:...]` format. While message IDs from major platforms (Discord, Telegram, Signal) typically don't contain brackets, the lack of sanitization could allow malformed IDs to break the format or confuse parsing logic. The issue is low severity since message IDs are usually platform-controlled, but sanitization would make the code more robust.
- src/auto-reply/envelope.ts requires sanitization of messageId to prevent bracket injection

<sub>Last reviewed commit: 75c38d4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->