### PR TITLE
fix(cli): spawn new process for daemon restart after update

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -128,6 +128,7 @@ vi.mock("../runtime.js", () => ({
   },
 }));
 
+const { spawnSync } = await import("node:child_process");
 const { runGatewayUpdate } = await import("../infra/update-runner.js");
 const { resolveOpenClawPackageRoot } = await import("../infra/openclaw-root.js");
 const { readConfigFileSnapshot, writeConfigFile } = await import("../config/config.js");
@@ -222,6 +223,15 @@ describe("update-cli", () => {
     vi.mocked(resolveNpmChannelTag).mockReset();
     vi.mocked(runCommandWithTimeout).mockReset();
     vi.mocked(runDaemonRestart).mockReset();
+    vi.mocked(spawnSync).mockReset();
+    vi.mocked(spawnSync).mockReturnValue({
+      pid: 0,
+      output: [],
+      stdout: "",
+      stderr: "",
+      status: 0,
+      signal: null,
+    });
     vi.mocked(defaultRuntime.log).mockReset();
     vi.mocked(defaultRuntime.error).mockReset();
     vi.mocked(defaultRuntime.exit).mockReset();
@@ -483,7 +493,7 @@ describe("update-cli", () => {
     expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
   });
 
-  it("updateCommand restarts daemon by default", async () => {
+  it("updateCommand restarts daemon via subprocess by default", async () => {
     const mockResult: UpdateRunResult = {
       status: "ok",
       mode: "git",
@@ -492,11 +502,18 @@ describe("update-cli", () => {
     };
 
     vi.mocked(runGatewayUpdate).mockResolvedValue(mockResult);
-    vi.mocked(runDaemonRestart).mockResolvedValue(true);
 
     await updateCommand({});
 
-    expect(runDaemonRestart).toHaveBeenCalled();
+    // After update, daemon restart should be spawned as a subprocess
+    // (not called in-process) to avoid stale content-hashed module references.
+    expect(spawnSync).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.arrayContaining(["gateway", "restart"]),
+      expect.objectContaining({ stdio: "inherit" }),
+    );
+    // The in-process runDaemonRestart should NOT be called
+    expect(runDaemonRestart).not.toHaveBeenCalled();
   });
 
   it("updateCommand skips restart when --no-restart is set", async () => {
@@ -508,13 +525,20 @@ describe("update-cli", () => {
     };
 
     vi.mocked(runGatewayUpdate).mockResolvedValue(mockResult);
+    vi.mocked(spawnSync).mockClear();
 
     await updateCommand({ restart: false });
 
-    expect(runDaemonRestart).not.toHaveBeenCalled();
+    // spawnSync may be called for other reasons (e.g. completion cache),
+    // but should NOT be called with gateway restart args
+    const restartCalls = vi.mocked(spawnSync).mock.calls.filter((call) => {
+      const args = call[1] as string[] | undefined;
+      return args?.includes("gateway") && args?.includes("restart");
+    });
+    expect(restartCalls).toHaveLength(0);
   });
 
-  it("updateCommand skips success message when restart does not run", async () => {
+  it("updateCommand skips success message when restart subprocess fails", async () => {
     const mockResult: UpdateRunResult = {
       status: "ok",
       mode: "git",
@@ -523,7 +547,14 @@ describe("update-cli", () => {
     };
 
     vi.mocked(runGatewayUpdate).mockResolvedValue(mockResult);
-    vi.mocked(runDaemonRestart).mockResolvedValue(false);
+    vi.mocked(spawnSync).mockReturnValue({
+      pid: 0,
+      output: [],
+      stdout: "",
+      stderr: "",
+      status: 1,
+      signal: null,
+    });
     vi.mocked(defaultRuntime.log).mockClear();
 
     await updateCommand({ restart: true });

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -405,7 +405,15 @@ async function maybeRestartService(params: {
         stdio: "inherit",
         timeout: 30_000,
       });
-      const restarted = restartResult.status === 0;
+      if (restartResult.error) {
+        defaultRuntime.log(
+          theme.warn(`Daemon restart failed to spawn: ${restartResult.error.message}`),
+        );
+        defaultRuntime.log(
+          "You may need to restart the service manually: openclaw gateway restart",
+        );
+      }
+      const restarted = restartResult.status === 0 && !restartResult.error;
 
       if (!params.opts.json && restarted) {
         defaultRuntime.log(theme.success("Daemon restarted successfully."));


### PR DESCRIPTION
## Summary

- **Problem:** After `openclaw update` replaces dist/ files, the running process tries to call `runDaemonRestart()` which resolves lazy-loaded chunks with stale content hashes — crashes with `ERR_MODULE_NOT_FOUND`
- **Why it matters:** Every user running `openclaw update` with a system service sees a crash that looks like a broken installation (though it's actually fine)
- **What changed:** `maybeRestartService()` now spawns `openclaw gateway restart` as a child process using the newly installed binary instead of calling the function in-process. The post-update `doctor` command is also spawned as a subprocess for the same reason.
- **What did NOT change:** The update flow itself, plugin updates, and all other post-update steps are unchanged

Closes #17225

## Root Cause

The bundler (tsdown) produces content-hashed filenames (e.g., `daemon-cli-yMu4ZGat.js`). Even though the source has static `import` statements, code-splitting turns barrel re-exports into lazy chunks resolved at call time. After npm replaces dist/, the old hashes are gone but the running process still references them.

## Changes

- **`src/cli/update-cli/update-command.ts`**: Replaced in-process `runDaemonRestart()` call with `spawnSync(node, [entryPath, "gateway", "restart"])` using the newly installed binary. Also replaced in-process `doctorCommand()` call with a subprocess spawn for the same stale-module reason. Removed unused `doctorCommand` and `runDaemonRestart` imports; added `spawnSync` from `node:child_process`.
- **`src/cli/update-cli.test.ts`**: Updated tests to verify daemon restart uses `spawnSync` with `["gateway", "restart"]` args instead of calling `runDaemonRestart()` in-process. Added test for failed subprocess case.

## Testing

- Updated existing tests to verify subprocess spawning behavior
- Test: restart spawns subprocess with correct args (`gateway restart`)
- Test: `--no-restart` skips the subprocess spawn  
- Test: failed subprocess (exit code 1) skips success message
- All 20 tests pass, typecheck clean

## Compatibility

Backward compatible. Same restart behavior, just executed via subprocess instead of in-process function call.

## Failure Recovery

Revert commit. If subprocess spawn fails, the error message tells users to restart manually (same as current behavior).

## AI Disclosure
AI-assisted (Claude via OpenClaw). Code reviewed and tested.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces in-process `runDaemonRestart()` and `doctorCommand()` calls with `spawnSync` subprocesses in the post-update flow. This fixes `ERR_MODULE_NOT_FOUND` crashes caused by stale content-hashed chunk references after `openclaw update` replaces `dist/` files. The approach is well-motivated and the core logic is correct.

- The daemon restart and doctor commands are now spawned as child processes using the freshly installed binary, avoiding stale module references in the running process
- Unused `runDaemonRestart` and `doctorCommand` imports are cleaned up
- Tests are updated to verify subprocess spawning with correct args, `--no-restart` behavior, and failed subprocess handling
- **Issue**: The spawn error handling (lines 408-415) produces duplicate error messages when `spawnSync` fails (e.g., `ENOENT`) because the `else if` branch at line 438 also fires, and the error block doesn't respect `--json` mode

<h3>Confidence Score: 3/5</h3>

- The core change is sound and fixes a real crash, but has a minor error-handling bug that produces duplicate messages on spawn failure.
- The approach of spawning subprocesses to avoid stale module references is correct and well-reasoned. The main deduction is for the duplicate error message bug in the spawn failure path, which affects user experience but not functionality. Tests cover the key scenarios adequately.
- `src/cli/update-cli/update-command.ts` — the spawn error handling at lines 408-415 needs adjustment to avoid duplicate messages and respect JSON mode.

<sub>Last reviewed commit: 804ce67</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->