### PR TITLE
fix: allow text regex fallback when bot JID not in mentionedJids

### DIFF
--- a/src/web/auto-reply/mentions.ts
+++ b/src/web/auto-reply/mentions.ts
@@ -54,8 +54,10 @@ export function isBotMentionedFromTargets(
         return true;
       }
     }
-    // If the message explicitly mentions someone else, do not fall back to regex matches.
-    return false;
+    // JID not found in mentionedJids — fall through to text regex check
+    // rather than returning false. This handles:
+    // 1. Messages where someone else is @mentioned but the bot is addressed by name
+    // 2. WhatsApp LID mismatches where the bot's JID isn't resolved correctly
   } else if (hasMentions && isSelfChat) {
     // Self-chat mode: ignore WhatsApp @mention JIDs, otherwise @mentioning the owner in group chats triggers the bot.
   }

--- a/src/web/auto-reply/web-auto-reply-utils.test.ts
+++ b/src/web/auto-reply/web-auto-reply-utils.test.ts
@@ -41,9 +41,19 @@ describe("isBotMentionedFromTargets", () => {
     expect(isBotMentionedFromTargets(msg, cfg, targets)).toBe(expected);
   }
 
-  it("ignores regex matches when other mentions are present", () => {
+  it("falls through to regex when bot JID not in mentionedJids", () => {
     const msg = makeMsg({
       body: "@OpenClaw please help",
+      mentionedJids: ["19998887777@s.whatsapp.net"],
+      selfE164: "+15551234567",
+      selfJid: "15551234567@s.whatsapp.net",
+    });
+    expectMentioned(msg, mentionCfg, true);
+  });
+
+  it("returns false when neither JID nor regex match with other mentions present", () => {
+    const msg = makeMsg({
+      body: "hey @OtherPerson what's up",
       mentionedJids: ["19998887777@s.whatsapp.net"],
       selfE164: "+15551234567",
       selfJid: "15551234567@s.whatsapp.net",


### PR DESCRIPTION
## Summary

- Remove the early `return false` in `isBotMentionedFromTargets()` that short-circuited text regex matching when `mentionedJids` contained other users' JIDs
- Fix: bot now correctly responds when addressed by name even when someone else is @mentioned in the same message
- Fix: WhatsApp LID mismatches no longer silently suppress mention detection — the function falls through to regex matching instead of returning false

**Bug:** When a WhatsApp group message contained *any* `mentionedJids` and the bot's JID wasn't in the list, the function returned `false` immediately without attempting text-based regex matching. This meant the bot ignored messages where it was addressed by name alongside an @mention of another user, or where WhatsApp's LID→JID resolution failed.

## Test plan

- [x] Updated existing test: "ignores regex matches when other mentions are present" → now expects `true` (renamed to "falls through to regex when bot JID not in mentionedJids")
- [x] Added new test: "returns false when neither JID nor regex match with other mentions present"
- [x] All existing tests pass (JID match, self-chat, no-mention regex fallback, LID mapping)
- [x] Full test suite: 861 passed, 11 failed (all pre-existing — missing optional extension deps)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes early return that prevented text-based mention detection when `mentionedJids` contained other users. The bot now correctly responds when addressed by name even if someone else is `@mentioned`, and gracefully handles WhatsApp LID→JID resolution failures by falling through to regex matching instead of silently returning false.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - simple logic fix with comprehensive test coverage
- The change removes a premature return statement that blocked regex matching fallback, which is exactly what the bug required. The fix is minimal (removes 2 lines, adds 4 comment lines), preserves all existing behavior paths (JID matching, self-chat handling), and adds appropriate test coverage for both the fixed case and the negative case. All existing tests pass according to the PR description.
- No files require special attention

<sub>Last reviewed commit: 91733b0</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->