### PR TITLE
fix(bonjour): stop mDNS flood on multi-NIC same-LAN setups (#17222)

### DIFF
--- a/src/gateway/server-discovery-runtime.test.ts
+++ b/src/gateway/server-discovery-runtime.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  startGatewayBonjourAdvertiser: vi.fn(),
+  pickPrimaryLanIPv4: vi.fn(),
+  resolveTailnetDnsHint: vi.fn(),
+  formatBonjourInstanceName: vi.fn(),
+  resolveBonjourCliPath: vi.fn(),
+}));
+
+vi.mock("../infra/bonjour.js", () => ({
+  startGatewayBonjourAdvertiser: mocks.startGatewayBonjourAdvertiser,
+}));
+
+vi.mock("../infra/tailnet.js", () => ({
+  pickPrimaryTailnetIPv4: vi.fn(),
+  pickPrimaryTailnetIPv6: vi.fn(),
+}));
+
+vi.mock("../infra/widearea-dns.js", () => ({
+  resolveWideAreaDiscoveryDomain: vi.fn(),
+  writeWideAreaGatewayZone: vi.fn(),
+}));
+
+vi.mock("./net.js", () => ({
+  pickPrimaryLanIPv4: mocks.pickPrimaryLanIPv4,
+}));
+
+vi.mock("./server-discovery.js", () => ({
+  formatBonjourInstanceName: mocks.formatBonjourInstanceName,
+  resolveBonjourCliPath: mocks.resolveBonjourCliPath,
+  resolveTailnetDnsHint: mocks.resolveTailnetDnsHint,
+}));
+
+const { startGatewayDiscovery } = await import("./server-discovery-runtime.js");
+
+describe("startGatewayDiscovery", () => {
+  const prevEnv = { ...process.env };
+
+  function baseParams(overrides?: Partial<Parameters<typeof startGatewayDiscovery>[0]>) {
+    return {
+      machineDisplayName: "test-machine",
+      port: 18789,
+      wideAreaDiscoveryEnabled: false,
+      tailscaleMode: "off" as const,
+      mdnsMode: "minimal" as const,
+      logDiscovery: { info: vi.fn(), warn: vi.fn() },
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    // Allow bonjour to be "enabled" in tests.
+    delete process.env.VITEST;
+    delete process.env.OPENCLAW_DISABLE_BONJOUR;
+    process.env.NODE_ENV = "development";
+
+    mocks.formatBonjourInstanceName.mockReturnValue("test-machine (OpenClaw)");
+    mocks.resolveBonjourCliPath.mockReturnValue("/usr/local/bin/openclaw");
+    mocks.resolveTailnetDnsHint.mockResolvedValue(undefined);
+    mocks.startGatewayBonjourAdvertiser.mockResolvedValue({ stop: vi.fn() });
+  });
+
+  afterEach(() => {
+    for (const key of Object.keys(process.env)) {
+      if (!(key in prevEnv)) {
+        delete process.env[key];
+      }
+    }
+    for (const [key, value] of Object.entries(prevEnv)) {
+      process.env[key] = value;
+    }
+    vi.restoreAllMocks();
+    for (const mock of Object.values(mocks)) {
+      mock.mockReset();
+    }
+  });
+
+  it("passes primary LAN IP as networkInterface to bonjour advertiser", async () => {
+    mocks.pickPrimaryLanIPv4.mockReturnValue("192.168.1.130");
+    mocks.startGatewayBonjourAdvertiser.mockResolvedValue({ stop: vi.fn() });
+
+    await startGatewayDiscovery(baseParams());
+
+    expect(mocks.startGatewayBonjourAdvertiser).toHaveBeenCalledTimes(1);
+    const opts = mocks.startGatewayBonjourAdvertiser.mock.calls[0]?.[0];
+    expect(opts.networkInterface).toBe("192.168.1.130");
+  });
+
+  it("passes undefined networkInterface when no LAN IP is available", async () => {
+    mocks.pickPrimaryLanIPv4.mockReturnValue(undefined);
+    mocks.startGatewayBonjourAdvertiser.mockResolvedValue({ stop: vi.fn() });
+
+    await startGatewayDiscovery(baseParams());
+
+    expect(mocks.startGatewayBonjourAdvertiser).toHaveBeenCalledTimes(1);
+    const opts = mocks.startGatewayBonjourAdvertiser.mock.calls[0]?.[0];
+    expect(opts.networkInterface).toBeUndefined();
+  });
+});

--- a/src/gateway/server-discovery-runtime.ts
+++ b/src/gateway/server-discovery-runtime.ts
@@ -1,6 +1,7 @@
 import { startGatewayBonjourAdvertiser } from "../infra/bonjour.js";
 import { pickPrimaryTailnetIPv4, pickPrimaryTailnetIPv6 } from "../infra/tailnet.js";
 import { resolveWideAreaDiscoveryDomain, writeWideAreaGatewayZone } from "../infra/widearea-dns.js";
+import { pickPrimaryLanIPv4 } from "./net.js";
 import {
   formatBonjourInstanceName,
   resolveBonjourCliPath,
@@ -50,6 +51,7 @@ export async function startGatewayDiscovery(params: {
         tailnetDns,
         cliPath,
         minimal: mdnsMinimal,
+        networkInterface: pickPrimaryLanIPv4(),
       });
       bonjourStop = bonjour.stop;
     } catch (err) {

--- a/src/gateway/server-discovery-runtime.ts
+++ b/src/gateway/server-discovery-runtime.ts
@@ -39,6 +39,10 @@ export async function startGatewayDiscovery(params: {
   const sshPort = Number.isFinite(sshPortParsed) && sshPortParsed > 0 ? sshPortParsed : undefined;
   const cliPath = mdnsMinimal ? undefined : resolveBonjourCliPath();
 
+  // Pin mDNS to a single LAN interface to avoid floods on multi-NIC setups.
+  // undefined means "no preference" — ciao will bind all interfaces.
+  const mdnsInterface = pickPrimaryLanIPv4();
+
   if (bonjourEnabled) {
     try {
       const bonjour = await startGatewayBonjourAdvertiser({
@@ -51,7 +55,7 @@ export async function startGatewayDiscovery(params: {
         tailnetDns,
         cliPath,
         minimal: mdnsMinimal,
-        networkInterface: pickPrimaryLanIPv4(),
+        networkInterface: mdnsInterface,
       });
       bonjourStop = bonjour.stop;
     } catch (err) {

--- a/src/infra/bonjour.test.ts
+++ b/src/infra/bonjour.test.ts
@@ -5,11 +5,19 @@ import * as logging from "../logging.js";
 const mocks = vi.hoisted(() => ({
   createService: vi.fn(),
   shutdown: vi.fn(),
+  getResponder: vi.fn(),
   registerUnhandledRejectionHandler: vi.fn(),
   logWarn: vi.fn(),
   logDebug: vi.fn(),
 }));
-const { createService, shutdown, registerUnhandledRejectionHandler, logWarn, logDebug } = mocks;
+const {
+  createService,
+  shutdown,
+  getResponder: getResponderMock,
+  registerUnhandledRejectionHandler,
+  logWarn,
+  logDebug,
+} = mocks;
 
 const asString = (value: unknown, fallback: string) =>
   typeof value === "string" && value.trim() ? value : fallback;
@@ -29,10 +37,13 @@ vi.mock("../logger.js", async () => {
 vi.mock("@homebridge/ciao", () => {
   return {
     Protocol: { TCP: "tcp" },
-    getResponder: () => ({
-      createService,
-      shutdown,
-    }),
+    getResponder: (...args: unknown[]) => {
+      getResponderMock(...args);
+      return {
+        createService,
+        shutdown,
+      };
+    },
   };
 });
 
@@ -73,6 +84,7 @@ describe("gateway bonjour advertiser", () => {
 
     createService.mockReset();
     shutdown.mockReset();
+    getResponderMock.mockReset();
     registerUnhandledRejectionHandler.mockReset();
     logWarn.mockReset();
     logDebug.mockReset();
@@ -374,6 +386,63 @@ describe("gateway bonjour advertiser", () => {
     expect(gatewayCall?.[0]?.domain).toBe("local");
     expect(gatewayCall?.[0]?.hostname).toBe("openclaw");
     expect((gatewayCall?.[0]?.txt as Record<string, string>)?.lanHost).toBe("openclaw.local");
+
+    await started.stop();
+  });
+
+  it("restricts mDNS responder to a single interface when networkInterface is set", async () => {
+    delete process.env.VITEST;
+    process.env.NODE_ENV = "development";
+
+    vi.spyOn(os, "hostname").mockReturnValue("test-host");
+    process.env.OPENCLAW_MDNS_HOSTNAME = "test-host";
+
+    const destroy = vi.fn().mockResolvedValue(undefined);
+    const advertise = vi.fn().mockResolvedValue(undefined);
+    createService.mockImplementation((options: Record<string, unknown>) => ({
+      advertise,
+      destroy,
+      serviceState: "announced",
+      on: vi.fn(),
+      getFQDN: () => `${asString(options.type, "service")}.${asString(options.domain, "local")}.`,
+      getHostname: () => asString(options.hostname, "unknown"),
+      getPort: () => Number(options.port ?? -1),
+    }));
+
+    const started = await startGatewayBonjourAdvertiser({
+      gatewayPort: 18789,
+      networkInterface: "192.168.1.130",
+    });
+
+    expect(getResponderMock).toHaveBeenCalledWith({ interface: "192.168.1.130" });
+
+    await started.stop();
+  });
+
+  it("does not restrict mDNS interface when networkInterface is omitted", async () => {
+    delete process.env.VITEST;
+    process.env.NODE_ENV = "development";
+
+    vi.spyOn(os, "hostname").mockReturnValue("test-host");
+    process.env.OPENCLAW_MDNS_HOSTNAME = "test-host";
+
+    const destroy = vi.fn().mockResolvedValue(undefined);
+    const advertise = vi.fn().mockResolvedValue(undefined);
+    createService.mockImplementation((options: Record<string, unknown>) => ({
+      advertise,
+      destroy,
+      serviceState: "announced",
+      on: vi.fn(),
+      getFQDN: () => `${asString(options.type, "service")}.${asString(options.domain, "local")}.`,
+      getHostname: () => asString(options.hostname, "unknown"),
+      getPort: () => Number(options.port ?? -1),
+    }));
+
+    const started = await startGatewayBonjourAdvertiser({
+      gatewayPort: 18789,
+    });
+
+    expect(getResponderMock).toHaveBeenCalledWith(undefined);
 
     await started.stop();
   });

--- a/src/infra/bonjour.ts
+++ b/src/infra/bonjour.ts
@@ -23,6 +23,11 @@ export type GatewayBonjourAdvertiseOpts = {
    * Reduces information disclosure for better operational security.
    */
   minimal?: boolean;
+  /**
+   * Restrict mDNS to a single network interface (name or IP address).
+   * Prevents mDNS floods on machines with multiple interfaces on the same LAN.
+   */
+  networkInterface?: string;
 };
 
 function isDisabledByEnv() {
@@ -89,7 +94,9 @@ export async function startGatewayBonjourAdvertiser(
   }
 
   const { getResponder, Protocol } = await import("@homebridge/ciao");
-  const responder = getResponder();
+  const responder = getResponder(
+    opts.networkInterface ? { interface: opts.networkInterface } : undefined,
+  );
 
   // mDNS service instance names are single DNS labels; dots in hostnames (like
   // `Mac.localdomain`) can confuse some resolvers/browsers and break discovery.
@@ -169,7 +176,7 @@ export async function startGatewayBonjourAdvertiser(
   logDebug(
     `bonjour: starting (hostname=${hostname}, instance=${JSON.stringify(
       safeServiceName(instanceName),
-    )}, gatewayPort=${opts.gatewayPort}${opts.minimal ? ", minimal=true" : `, sshPort=${opts.sshPort ?? 22}`})`,
+    )}, gatewayPort=${opts.gatewayPort}${opts.networkInterface ? `, interface=${opts.networkInterface}` : ""}${opts.minimal ? ", minimal=true" : `, sshPort=${opts.sshPort ?? 22}`})`,
   );
 
   for (const { label, svc } of services) {


### PR DESCRIPTION
## Summary

Running `openclaw gateway` on a machine with multiple network interfaces on the same LAN (e.g. both ethernet and WiFi) causes an mDNS flood — every device on the network starts continuously querying `openclaw.local` and the machine responds from both IPs, making the LAN unusable.

Closes #17222

lobster-biscuit

## Root Cause

`startGatewayBonjourAdvertiser` calls ciao's `getResponder()` with no options, so the mDNS responder binds to all network interfaces. When two interfaces share the same LAN (like `enp5s0` at 192.168.1.130 and `wlan0` at 192.168.1.118), ciao advertises and responds on both, triggering a flood of conflicting mDNS responses with cache-flush bits set.

## Changes

- Before: mDNS responder binds to all interfaces — multi-NIC same-LAN setups cause mDNS storms
- After: responder is restricted to the primary LAN interface via `pickPrimaryLanIPv4()` (prefers en0/eth0, falls back to first external IPv4)

The fix adds a `networkInterface` option to `GatewayBonjourAdvertiseOpts` and passes it through to ciao's `getResponder({ interface })`. The caller in `server-discovery-runtime.ts` resolves the primary LAN IP using the existing `pickPrimaryLanIPv4()` helper.

## Tests

- `src/infra/bonjour.test.ts` — 2 new tests: verifies `getResponder` receives the `interface` option when `networkInterface` is set, and receives `undefined` when omitted. Both fail before fix, pass after.
- All 9 bonjour tests pass, all 75 infra tests pass, all 44 gateway tests pass
- `pnpm build && pnpm check` pass

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an mDNS flood issue on machines with multiple network interfaces on the same LAN (e.g., both Ethernet and WiFi). The fix pins the ciao mDNS responder to a single primary LAN interface via the existing `pickPrimaryLanIPv4()` helper, rather than binding to all interfaces which caused conflicting mDNS responses.

- Added `networkInterface` option to `GatewayBonjourAdvertiseOpts` and wired it through to ciao's `getResponder({ interface })` in `src/infra/bonjour.ts`
- `server-discovery-runtime.ts` resolves the primary LAN IP via `pickPrimaryLanIPv4()` (prefers `en0`/`eth0`, falls back to first external IPv4) and passes it as `networkInterface`
- The `undefined` case (no LAN IP found) is handled correctly — ciao falls back to binding all interfaces, preserving existing behavior for single-NIC setups
- Well-tested: 3 new unit tests in `bonjour.test.ts` and 2 new integration tests in `server-discovery-runtime.test.ts`

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a targeted, well-tested fix that gracefully falls back to existing behavior when no primary LAN IP is found.
- The change is minimal and focused: a single new option threaded through existing plumbing, with a correct ternary guard that avoids passing `{ interface: undefined }` to ciao. The `undefined` fallback preserves existing behavior for single-NIC setups. All edge cases (set, omitted, explicitly undefined) are covered by tests. No security concerns, no breaking API changes, and no unintended side effects.
- No files require special attention.

<sub>Last reviewed commit: e4e4dfa</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->