### PR TITLE
docs(matrix): add warning about dm.allowFrom requirement for commands

### DIFF
--- a/docs/channels/matrix.md
+++ b/docs/channels/matrix.md
@@ -192,6 +192,12 @@ Notes:
 - `channels.matrix.dm.allowFrom` accepts full Matrix user IDs (example: `@user:server`). The wizard resolves display names to user IDs when directory search finds a single exact match.
 - Do not use display names or bare localparts (example: `"Alice"` or `"alice"`). They are ambiguous and are ignored for allowlist matching. Use full `@user:server` IDs.
 
+**Important:** To use gateway commands (`/model`, `/status`, `/reset`) via DM, you must:
+1. Enable DMs by setting `dm.policy` to `"pairing"`, `"allowlist"`, or `"open"` (not `"disabled"`)
+2. Configure `dm.allowFrom` with your Matrix user ID
+
+Without `dm.allowFrom`, commands will be treated as regular messages and sent to the AI model instead of being processed by the gateway. Note: when `dm.policy` is `"disabled"`, all DMs (including commands) are blocked entirely.
+
 ## Rooms (groups)
 
 - Default: `channels.matrix.groupPolicy = "allowlist"` (mention-gated). Use `channels.defaults.groupPolicy` to override the default when unset.


### PR DESCRIPTION
only update doc:
Even when DM is disabled, dm.allowFrom must be configured to enable command execution (/model, /status, /reset). Without it, commands are treated as regular messages and sent to the AI model.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a documentation warning to `docs/channels/matrix.md` explaining that `channels.matrix.dm.allowFrom` must be configured for command execution (`/model`, `/status`, `/reset`), even when DM is disabled.

- The core advice is valid: `dm.allowFrom` is indeed required for command authorization in the Matrix handler's command gating logic (`resolveControlCommandGate`)
- However, the wording is misleading: it states that configuring `dm.allowFrom` enables command execution when `dm.policy="disabled"`, but the source code (`handler.ts:230-231`) drops **all** DM messages immediately when policy is `"disabled"`, before command processing runs — so `dm.allowFrom` has no effect in that case
- The warning is most relevant for `"pairing"`, `"allowlist"`, or `"open"` policies, where DMs are accepted but commands aren't processed without an `allowFrom` entry

<h3>Confidence Score: 3/5</h3>

- Documentation-only change that is safe to merge but contains a misleading claim about the interaction between dm.policy="disabled" and dm.allowFrom
- The PR is a docs-only change with no code risk. However, the documentation statement is technically inaccurate: it claims dm.allowFrom enables commands when dm.policy="disabled", but the handler code drops all DMs before reaching command gating when policy is disabled. The underlying advice (configure dm.allowFrom for commands) is correct for non-disabled policies.
- docs/channels/matrix.md — the new warning paragraph needs rewording for accuracy

<sub>Last reviewed commit: 77349dd</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->