### PR TITLE
iOS: stabilize QR onboarding + gateway pairing

### DIFF
--- a/apps/ios/Sources/Gateway/GatewayTrustPromptAlert.swift
+++ b/apps/ios/Sources/Gateway/GatewayTrustPromptAlert.swift
@@ -6,10 +6,10 @@ struct GatewayTrustPromptAlert: ViewModifier {
     private var promptBinding: Binding<GatewayConnectionController.TrustPrompt?> {
         Binding(
             get: { self.gatewayController.pendingTrustPrompt },
-            set: { newValue in
-                if newValue == nil {
-                    self.gatewayController.clearPendingTrustPrompt()
-                }
+            set: { _ in
+                // Keep pending trust state until explicit user action.
+                // `alert(item:)` may set the binding to nil during dismissal, which can race with
+                // the button handler and cause accept to no-op.
             })
     }
 
@@ -39,4 +39,3 @@ extension View {
         self.modifier(GatewayTrustPromptAlert())
     }
 }
-

--- a/apps/ios/Sources/Onboarding/OnboardingStateStore.swift
+++ b/apps/ios/Sources/Onboarding/OnboardingStateStore.swift
@@ -25,6 +25,9 @@ enum OnboardingStateStore {
     @MainActor
     static func shouldPresentOnLaunch(appModel: NodeAppModel, defaults: UserDefaults = .standard) -> Bool {
         if defaults.bool(forKey: Self.completedDefaultsKey) { return false }
+        // If we have a last-known connection config, don't force onboarding on launch. Auto-connect
+        // should handle reconnecting, and users can always open onboarding manually if needed.
+        if GatewaySettingsStore.loadLastGatewayConnection() != nil { return false }
         return appModel.gatewayServerName == nil
     }
 

--- a/apps/ios/Sources/Onboarding/OnboardingWizardView.swift
+++ b/apps/ios/Sources/Onboarding/OnboardingWizardView.swift
@@ -661,6 +661,7 @@ struct OnboardingWizardView: View {
     private func resumeAfterPairingApproval() {
         // We intentionally stop reconnect churn while unpaired to avoid generating multiple pending requests.
         self.appModel.gatewayAutoReconnectEnabled = true
+        self.appModel.gatewayPairingPaused = false
         self.connectMessage = "Retrying after approval…"
         self.statusLine = "Retrying after approval…"
         Task { await self.retryLastAttempt() }

--- a/apps/ios/Sources/RootCanvas.swift
+++ b/apps/ios/Sources/RootCanvas.swift
@@ -86,10 +86,10 @@ struct RootCanvas: View {
                 .environment(self.gatewayController)
         }
         .onAppear { self.updateIdleTimer() }
+        .onAppear { self.evaluateOnboardingPresentation(force: false) }
         .onAppear { self.maybeAutoOpenSettings() }
         .onChange(of: self.preventSleep) { _, _ in self.updateIdleTimer() }
         .onChange(of: self.scenePhase) { _, _ in self.updateIdleTimer() }
-        .onAppear { self.evaluateOnboardingPresentation(force: false) }
         .onAppear { self.maybeShowQuickSetup() }
         .onChange(of: self.gatewayController.gateways.count) { _, _ in self.maybeShowQuickSetup() }
         .onAppear { self.updateCanvasDebugStatus() }
@@ -196,6 +196,7 @@ struct RootCanvas: View {
 
     private func maybeAutoOpenSettings() {
         guard !self.didAutoOpenSettings else { return }
+        guard !self.showOnboarding else { return }
         guard self.shouldAutoOpenSettings() else { return }
         self.didAutoOpenSettings = true
         self.presentedSheet = .settings

--- a/apps/ios/Tests/DeepLinkParserTests.swift
+++ b/apps/ios/Tests/DeepLinkParserTests.swift
@@ -106,4 +106,22 @@ import Testing
     @Test func parseGatewaySetupCodeRejectsInvalidInput() {
         #expect(GatewayConnectDeepLink.fromSetupCode("not-a-valid-setup-code") == nil)
     }
+
+    @Test func parseGatewaySetupCodeDefaultsTo443ForWssWithoutPort() {
+        let payload = #"{"url":"wss://gateway.example.com","token":"tok"}"#
+        let encoded = Data(payload.utf8)
+            .base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+
+        let link = GatewayConnectDeepLink.fromSetupCode(encoded)
+
+        #expect(link == .init(
+            host: "gateway.example.com",
+            port: 443,
+            tls: true,
+            token: "tok",
+            password: nil))
+    }
 }

--- a/apps/ios/Tests/GatewayConnectionControllerTests.swift
+++ b/apps/ios/Tests/GatewayConnectionControllerTests.swift
@@ -97,24 +97,26 @@ private func withUserDefaults<T>(_ updates: [String: Any?], _ body: () throws ->
 
     @Test @MainActor func loadLastConnectionReadsSavedValues() {
         withUserDefaults([
-            "gateway.lastHost": "gateway.example.com",
-            "gateway.lastPort": 443,
-            "gateway.lastTls": true,
+            "gateway.last.kind": "manual",
+            "gateway.last.host": "gateway.example.com",
+            "gateway.last.port": 443,
+            "gateway.last.tls": true,
+            "gateway.last.stableID": "manual|gateway.example.com|443",
         ]) {
-            let loaded = GatewayConnectionController.loadLastConnection(defaults: .standard)
-            #expect(loaded?.host == "gateway.example.com")
-            #expect(loaded?.port == 443)
-            #expect(loaded?.useTLS == true)
+            let loaded = GatewaySettingsStore.loadLastGatewayConnection()
+            #expect(loaded == .manual(host: "gateway.example.com", port: 443, useTLS: true, stableID: "manual|gateway.example.com|443"))
         }
     }
 
     @Test @MainActor func loadLastConnectionReturnsNilForInvalidData() {
         withUserDefaults([
-            "gateway.lastHost": "",
-            "gateway.lastPort": 0,
-            "gateway.lastTls": false,
+            "gateway.last.kind": "manual",
+            "gateway.last.host": "",
+            "gateway.last.port": 0,
+            "gateway.last.tls": false,
+            "gateway.last.stableID": "manual|invalid|0",
         ]) {
-            let loaded = GatewayConnectionController.loadLastConnection(defaults: .standard)
+            let loaded = GatewaySettingsStore.loadLastGatewayConnection()
             #expect(loaded == nil)
         }
     }

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/DeepLinks.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/DeepLinks.swift
@@ -34,9 +34,9 @@ public struct GatewayConnectDeepLink: Codable, Sendable, Equatable {
               let hostname = parsed.host, !hostname.isEmpty
         else { return nil }
 
-        let scheme = parsed.scheme ?? "ws"
+        let scheme = (parsed.scheme ?? "ws").lowercased()
         let tls = scheme == "wss"
-        let port = parsed.port ?? 18789
+        let port = parsed.port ?? (tls ? 443 : 18789)
         let token = json["token"] as? String
         let password = json["password"] as? String
         return GatewayConnectDeepLink(host: hostname, port: port, tls: tls, token: token, password: password)

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
@@ -133,10 +133,16 @@ public actor GatewayChannelActor {
     private var lastAuthSource: GatewayAuthSource = .none
     private let decoder = JSONDecoder()
     private let encoder = JSONEncoder()
-    private let connectTimeoutSeconds: Double = 6
-    private let connectChallengeTimeoutSeconds: Double = 3.0
+    // Remote gateways (tailscale/wan) can take a bit longer to deliver the connect.challenge event,
+    // and we must include the nonce once the gateway requires v2 signing.
+    private let connectTimeoutSeconds: Double = 12
+    private let connectChallengeTimeoutSeconds: Double = 6.0
+    // Some networks will silently drop idle TCP/TLS flows around ~30s. The gateway tick is server->client,
+    // but NATs/proxies often require outbound traffic to keep the connection alive.
+    private let keepaliveIntervalSeconds: Double = 15.0
     private var watchdogTask: Task<Void, Never>?
     private var tickTask: Task<Void, Never>?
+    private var keepaliveTask: Task<Void, Never>?
     private let defaultRequestTimeoutMs: Double = 15000
     private let pushHandler: (@Sendable (GatewayPush) async -> Void)?
     private let connectOptions: GatewayConnectOptions?
@@ -174,6 +180,9 @@ public actor GatewayChannelActor {
 
         self.tickTask?.cancel()
         self.tickTask = nil
+
+        self.keepaliveTask?.cancel()
+        self.keepaliveTask = nil
 
         self.task?.cancel(with: .goingAway, reason: nil)
         self.task = nil
@@ -257,11 +266,35 @@ public actor GatewayChannelActor {
         self.connected = true
         self.backoffMs = 500
         self.lastSeq = nil
+        self.startKeepalive()
 
         let waiters = self.connectWaiters
         self.connectWaiters.removeAll()
         for waiter in waiters {
             waiter.resume(returning: ())
+        }
+    }
+
+    private func startKeepalive() {
+        self.keepaliveTask?.cancel()
+        self.keepaliveTask = Task { [weak self] in
+            guard let self else { return }
+            await self.keepaliveLoop()
+        }
+    }
+
+    private func keepaliveLoop() async {
+        while self.shouldReconnect {
+            try? await Task.sleep(nanoseconds: UInt64(self.keepaliveIntervalSeconds * 1_000_000_000))
+            guard self.shouldReconnect else { return }
+            guard self.connected else { continue }
+            // Best-effort outbound message to keep intermediate NAT/proxy state alive.
+            // We intentionally ignore the response.
+            do {
+                try await self.send(method: "health", params: nil)
+            } catch {
+                // Avoid spamming logs; the reconnect paths will surface meaningful errors.
+            }
         }
     }
 
@@ -490,6 +523,8 @@ public actor GatewayChannelActor {
         let wrapped = self.wrap(err, context: "gateway receive")
         self.logger.error("gateway ws receive failed \(wrapped.localizedDescription, privacy: .public)")
         self.connected = false
+        self.keepaliveTask?.cancel()
+        self.keepaliveTask = nil
         await self.disconnectHandler?("receive failed: \(wrapped.localizedDescription)")
         await self.failPending(wrapped)
         await self.scheduleReconnect()

--- a/docs/platforms/index.md
+++ b/docs/platforms/index.md
@@ -12,6 +12,7 @@ OpenClaw core is written in TypeScript. **Node is the recommended runtime**.
 Bun is not recommended for the Gateway (WhatsApp/Telegram bugs).
 
 **Companion apps:**
+
 - **macOS menu bar app:** Available for development builds (build from source)
 - **iOS/Android apps:** Currently in internal preview; not publicly distributed
 - **Windows/Linux companion apps:** Planned

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -32,7 +32,6 @@ const WRITE_SCOPE = "operator.write";
 const APPROVALS_SCOPE = "operator.approvals";
 const PAIRING_SCOPE = "operator.pairing";
 
-<<<<<<< HEAD
 const APPROVAL_METHODS = new Set([
   "exec.approval.request",
   "exec.approval.waitDecision",


### PR DESCRIPTION
This brings the iOS onboarding + QR pairing flow back to a stable, non-flakey path.

What changed
- iOS onboarding: auto-open QR scanner when there's no saved pairing info; status line; avoid settings auto-opening over onboarding; port entry normalized.
- Pairing UX: stop reconnect churn while NOT_PAIRED; keep pairing requestId sticky; add "Resume After Approval" and "Scan QR Code Again".
- Trust prompt: avoid SwiftUI alert binding races that could drop the pending trust prompt before accept.
- OpenClawKit: add best-effort outbound keepalive + slightly longer connect/challenge timeouts to reduce idle disconnects.

Also includes
- Fix stray merge marker in src/gateway/server-methods.ts (build breaker).
- Harden request body guard to avoid req.destroy crash in tests.
- Docs formatting only.

Testing
- Local: pnpm check
- Local: pnpm build
- iOS: manual pairing flow tested on a real device (QR scan, trust prompt, pairing approval prompt)

Follow-ups (not in this PR)
- More robust end-to-end pairing stress test harness for iOS + gateway.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Stabilizes iOS onboarding and gateway pairing by preventing reconnect churn during pairing approval, fixing SwiftUI alert binding races in trust prompts, and adding keepalive messages to prevent idle disconnects.

Key changes:
- Pairing UX improvements: stopped reconnect loops when NOT_PAIRED (via `gatewayPairingPaused` flag), added sticky `requestId` tracking, added "Resume After Approval" and "Scan QR Code Again" buttons
- Onboarding improvements: auto-opens QR scanner when no saved pairing exists, normalized port entry to digits only, added status line tracking, prevents settings from auto-opening over onboarding
- Trust prompt fix: avoided SwiftUI `alert(item:)` binding race by keeping pending state until explicit user action
- OpenClawKit: added 15s outbound keepalive messages, increased connect/challenge timeouts to 12s/6s (from 6s/3s) for slower remote gateways
- Build fix: removed stray merge marker in `server-methods.ts`
- Infrastructure hardening: added `safeDestroyRequest()` guard in `http-body.ts` to handle test stubs without real `.destroy()`

One critical logic bug found: `resumeAfterPairingApproval()` doesn't clear the `gatewayPairingPaused` flag, so reconnect attempts will sleep indefinitely.

<h3>Confidence Score: 3/5</h3>

- This PR has a critical logic bug that prevents the "Resume After Approval" feature from working
- Score reflects one critical bug in the pairing resume flow: `resumeAfterPairingApproval()` sets `gatewayAutoReconnectEnabled = true` but doesn't clear `gatewayPairingPaused`, causing reconnect loops to sleep indefinitely at `NodeAppModel.swift:1617` and `1699`. The rest of the changes appear well-structured with defensive guards (SwiftUI binding race fix, safe destroy pattern), comprehensive testing coverage, and clear incremental improvements to the pairing UX. Once the pairing flag bug is fixed, this should be safe to merge.
- Pay close attention to `apps/ios/Sources/Onboarding/OnboardingWizardView.swift` (critical pairing resume bug)

<sub>Last reviewed commit: 4b25e03</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->