### PR TITLE
tools: allow extra roots for workspace-only fs tools

### DIFF
--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -581,6 +581,7 @@ Additional hardening options:
 
 - `tools.exec.applyPatch.workspaceOnly: true` (default): ensures `apply_patch` cannot write/delete outside the workspace directory even when sandboxing is off. Set to `false` only if you intentionally want `apply_patch` to touch files outside the workspace.
 - `tools.fs.workspaceOnly: true` (optional): restricts `read`/`write`/`edit`/`apply_patch` paths to the workspace directory (useful if you allow absolute paths today and want a single guardrail).
+- `tools.fs.allowRoots: ["..."]` (optional): when `tools.fs.workspaceOnly` is enabled, also allow filesystem tool access inside these extra roots (absolute paths or paths relative to the workspace directory). This is useful if you need a dedicated output/temp directory outside the workspace without granting full filesystem access.
 
 ### 5) Secure baseline (copy/paste)
 

--- a/src/agents/pi-tools.fs-allowroots.test.ts
+++ b/src/agents/pi-tools.fs-allowroots.test.ts
@@ -1,0 +1,109 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { createOpenClawCodingTools } from "./pi-tools.js";
+
+vi.mock("../infra/shell-env.js", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("../infra/shell-env.js")>();
+  return { ...mod, getShellPathFromLoginShell: () => null };
+});
+
+async function withTempDir<T>(prefix: string, fn: (dir: string) => Promise<T>) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  try {
+    return await fn(dir);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+function getTextContent(result?: { content?: Array<{ type: string; text?: string }> }) {
+  const textBlock = result?.content?.find((block) => block.type === "text");
+  return textBlock?.text ?? "";
+}
+
+describe("tools.fs.allowRoots", () => {
+  it("allows absolute paths inside allowRoots when workspaceOnly is enabled", async () => {
+    await withTempDir("openclaw-ws-", async (workspaceDir) => {
+      await withTempDir("openclaw-allow-", async (allowRoot) => {
+        const cfg = {
+          tools: {
+            fs: { workspaceOnly: true, allowRoots: [allowRoot] },
+            exec: { applyPatch: { enabled: true } },
+          },
+        } as unknown as OpenClawConfig;
+
+        const tools = createOpenClawCodingTools({
+          workspaceDir,
+          config: cfg,
+          modelProvider: "openai",
+          modelId: "gpt-5.2",
+        });
+        const readTool = tools.find((tool) => tool.name === "read");
+        const writeTool = tools.find((tool) => tool.name === "write");
+        const editTool = tools.find((tool) => tool.name === "edit");
+        const applyPatchTool = tools.find((tool) => tool.name === "apply_patch");
+        expect(readTool).toBeDefined();
+        expect(writeTool).toBeDefined();
+        expect(editTool).toBeDefined();
+        expect(applyPatchTool).toBeDefined();
+
+        const allowedFile = path.join(allowRoot, "allowed.txt");
+        await writeTool?.execute("t-allow-write", {
+          path: allowedFile,
+          content: "allow write ok",
+        });
+        expect(await fs.readFile(allowedFile, "utf8")).toBe("allow write ok");
+
+        const editFile = path.join(allowRoot, "edit.txt");
+        await fs.writeFile(editFile, "hello world", "utf8");
+        await editTool?.execute("t-allow-edit", {
+          path: editFile,
+          oldText: "world",
+          newText: "openclaw",
+        });
+        expect(await fs.readFile(editFile, "utf8")).toBe("hello openclaw");
+
+        const readResult = await readTool?.execute("t-allow-read", { path: editFile });
+        expect(getTextContent(readResult)).toContain("hello openclaw");
+
+        const patchFile = path.join(allowRoot, "patch.txt");
+        const patch = `*** Begin Patch
+*** Add File: ${patchFile}
++patched
+*** End Patch`;
+        await applyPatchTool?.execute("t-allow-apply", { input: patch });
+        expect(await fs.readFile(patchFile, "utf8")).toBe("patched\n");
+      });
+    });
+  });
+
+  it("rejects paths outside workspace and allowRoots when workspaceOnly is enabled", async () => {
+    await withTempDir("openclaw-ws-", async (workspaceDir) => {
+      await withTempDir("openclaw-allow-", async (allowRoot) => {
+        await withTempDir("openclaw-outside-", async (outsideRoot) => {
+          const cfg = {
+            tools: {
+              fs: { workspaceOnly: true, allowRoots: [allowRoot] },
+            },
+          } as unknown as OpenClawConfig;
+
+          const tools = createOpenClawCodingTools({ workspaceDir, config: cfg });
+          const writeTool = tools.find((tool) => tool.name === "write");
+          expect(writeTool).toBeDefined();
+
+          const outsideFile = path.join(outsideRoot, "nope.txt");
+          await expect(
+            writeTool?.execute("t-outside-write", {
+              path: outsideFile,
+              content: "nope",
+            }),
+          ).rejects.toThrow(/allowed roots/i);
+          await expect(fs.stat(outsideFile)).rejects.toMatchObject({ code: "ENOENT" });
+        });
+      });
+    });
+  });
+});

--- a/src/agents/sandbox-paths.ts
+++ b/src/agents/sandbox-paths.ts
@@ -85,7 +85,6 @@ export async function assertSandboxPathInRoots(params: {
     });
   }
 
-  let lastErr: unknown = undefined;
   for (const root of roots) {
     try {
       return await assertSandboxPath({
@@ -94,8 +93,8 @@ export async function assertSandboxPathInRoots(params: {
         root,
         allowFinalSymlink: params.allowFinalSymlink,
       });
-    } catch (err) {
-      lastErr = err;
+    } catch {
+      // Keep trying other roots.
     }
   }
 

--- a/src/config/normalize-paths.test.ts
+++ b/src/config/normalize-paths.test.ts
@@ -7,7 +7,7 @@ describe("normalizeConfigPaths", () => {
   it("expands tilde for path-ish keys only", async () => {
     await withTempHome(async (home) => {
       const cfg = normalizeConfigPaths({
-        tools: { exec: { pathPrepend: ["~/bin"] } },
+        tools: { exec: { pathPrepend: ["~/bin"] }, fs: { allowRoots: ["~/tmp-allow"] } },
         plugins: { load: { paths: ["~/plugins/a"] } },
         logging: { file: "~/.openclaw/logs/openclaw.log" },
         hooks: {
@@ -47,6 +47,7 @@ describe("normalizeConfigPaths", () => {
       expect(cfg.hooks?.path).toBe(path.join(home, ".openclaw", "hooks.json5"));
       expect(cfg.hooks?.transformsDir).toBe(path.join(home, "hooks-xform"));
       expect(cfg.tools?.exec?.pathPrepend?.[0]).toBe(path.join(home, "bin"));
+      expect(cfg.tools?.fs?.allowRoots?.[0]).toBe(path.join(home, "tmp-allow"));
       expect(cfg.channels?.telegram?.accounts?.personal?.tokenFile).toBe(
         path.join(home, ".openclaw", "telegram.token"),
       );

--- a/src/config/normalize-paths.ts
+++ b/src/config/normalize-paths.ts
@@ -4,7 +4,7 @@ import { isPlainObject, resolveUserPath } from "../utils.js";
 const PATH_VALUE_RE = /^~(?=$|[\\/])/;
 
 const PATH_KEY_RE = /(dir|path|paths|file|root|workspace)$/i;
-const PATH_LIST_KEYS = new Set(["paths", "pathPrepend"]);
+const PATH_LIST_KEYS = new Set(["paths", "pathPrepend", "allowRoots"]);
 
 function normalizeStringValue(key: string | undefined, value: string): string {
   if (!PATH_VALUE_RE.test(value.trim())) {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -71,6 +71,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Allow stdin-only safe binaries to run without explicit allowlist entries.",
   "tools.fs.workspaceOnly":
     "Restrict filesystem tools (read/write/edit/apply_patch) to the workspace directory (default: false).",
+  "tools.fs.allowRoots":
+    "Additional allowed roots for filesystem tools when tools.fs.workspaceOnly is enabled (array of paths; rejects filesystem roots like '/').",
   "tools.message.allowCrossContextSend":
     "Legacy override: allow cross-context sends across all providers.",
   "tools.message.crossContext.allowWithinProvider":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -74,6 +74,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "tools.exec.applyPatch.workspaceOnly": "apply_patch Workspace-Only",
   "tools.exec.applyPatch.allowModels": "apply_patch Model Allowlist",
   "tools.fs.workspaceOnly": "Workspace-only FS tools",
+  "tools.fs.allowRoots": "FS Allow Roots",
   "tools.exec.notifyOnExit": "Exec Notify On Exit",
   "tools.exec.notifyOnExitEmptySuccess": "Exec Notify On Empty Success",
   "tools.exec.approvalRunningNoticeMs": "Exec Approval Running Notice (ms)",

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -211,6 +211,15 @@ export type FsToolsConfig = {
    * Default: false (unrestricted, matches legacy behavior).
    */
   workspaceOnly?: boolean;
+  /**
+   * Additional allowed filesystem roots when `workspaceOnly` is enabled.
+   *
+   * - This is an escape hatch for operators who want workspace-only semantics but still need
+   *   to allow specific extra directories (e.g. a dedicated temp/output dir).
+   * - Paths may be absolute or relative to the agent workspace directory.
+   * - The filesystem root ("/" on POSIX) is rejected.
+   */
+  allowRoots?: string[];
 };
 
 export type AgentToolsConfig = {

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -283,6 +283,7 @@ const ToolExecSchema = z.object(ToolExecBaseShape).strict().optional();
 const ToolFsSchema = z
   .object({
     workspaceOnly: z.boolean().optional(),
+    allowRoots: z.array(z.string()).optional(),
   })
   .strict()
   .optional();


### PR DESCRIPTION
## What
Adds `tools.fs.allowRoots` to extend `tools.fs.workspaceOnly` with an explicit allowlist of additional filesystem roots.

When `tools.fs.workspaceOnly: true` is enabled:
- `read`/`write`/`edit` are restricted to workspace root, plus any configured `tools.fs.allowRoots`.
- `apply_patch` remains workspace-contained by default, and will also allow `tools.fs.allowRoots` in host mode.

When `tools.fs.workspaceOnly` is unset/false, behavior is unchanged.

## Why
Some deployments want workspace-only guardrails but still need a dedicated output/temp directory outside the workspace. This adds a narrow escape hatch without reverting to full filesystem access.

## Notes
- `allowRoots` accepts absolute paths or paths relative to the workspace directory.
- Filesystem roots like `/` are rejected.
- Sandbox-mounted filesystem tools are unchanged; this only applies to the host-mode path guard.

## Tests
- `pnpm check`
- `pnpm test:fast -- --maxWorkers=1`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extends `tools.fs.workspaceOnly` with an allowlist of additional filesystem roots via `tools.fs.allowRoots`. When workspace-only mode is enabled, filesystem tools (`read`, `write`, `edit`, `apply_patch`) can now access both the workspace directory and any configured extra roots. The implementation properly validates paths, rejects filesystem root directories, normalizes relative paths, removes duplicates, and handles symlink traversal security checks. The feature is well-tested with comprehensive test cases covering both positive and negative scenarios.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-structured with proper security guards, comprehensive test coverage, clear documentation, and follows the repository's coding conventions. The two-commit structure shows iterative improvement with a cleanup commit removing unused variables. Path validation properly prevents filesystem root access, symlink escapes, and path traversal attacks.
- No files require special attention

<sub>Last reviewed commit: 571e0d3</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->