### PR TITLE
docs(telegram): add poll CLI example and constraints

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -628,6 +628,22 @@ openclaw message send --channel telegram --target 123456789 --message "hi"
 openclaw message send --channel telegram --target @name --message "hi"
 ```
 
+    CLI poll send (Telegram):
+
+```bash
+openclaw message poll --channel telegram --target 123456789 \
+  --poll-question "Deploy tonight?" \
+  --poll-option "Yes" --poll-option "No" \
+  --poll-duration-seconds 300 \
+  --poll-anonymous --silent
+```
+
+    Poll constraints (Telegram):
+
+    - `--poll-option` supports 2-12 options
+    - `--poll-duration-seconds` supports 5-600
+    - use `--poll-public` to make the poll non-anonymous
+
   </Accordion>
 </AccordionGroup>
 

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -640,7 +640,7 @@ openclaw message poll --channel telegram --target 123456789 \
 
     Poll constraints (Telegram):
 
-    - `--poll-option` supports 2-12 options
+    - `--poll-option` supports 2-10 options
     - `--poll-duration-seconds` supports 5-600
     - use `--poll-public` to make the poll non-anonymous
 


### PR DESCRIPTION
## Summary
- add a telegram-specific `openclaw message poll` example to channel docs
- document telegram poll constraints: 2-12 options, 5-600 seconds, and `--poll-public`
- keep scope docs-only (no runtime changes)

## Verification
- checked flags via `openclaw message poll --help`
- validated placement in the existing "Limits, retry, and CLI targets" section

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added Telegram-specific CLI poll example and documented poll constraints (2-10 options, 5-600 seconds, `--poll-public` flag). The documentation accurately reflects the implementation with the corrected option limit from the previous review thread.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk - docs-only change that accurately documents existing functionality
- Documentation-only PR that accurately reflects implementation details verified in source code (`src/telegram/send.ts:979` for maxOptions:10, lines 1049-1050 for 5-600 duration, `src/cli/program/message/register.poll.ts:21` for --poll-public flag). The previously identified issue with 2-12 options has been corrected to 2-10.
- No files require special attention

<sub>Last reviewed commit: c068328</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->