### PR TITLE
fix(doctor): skip embedding provider check when QMD backend is active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Commands/Doctor: skip embedding-provider warnings when `memory.backend` is `qmd`, because QMD manages embeddings internally and does not require `memorySearch` providers. (#17263) Thanks @miloudbelarebia.
 - Security/Webhooks: harden Feishu and Zalo webhook ingress with webhook-mode token preconditions, loopback-default Feishu bind host, JSON content-type enforcement, per-path rate limiting, replay dedupe for Zalo events, constant-time Zalo secret comparison, and anomaly status counters.
 - Security/Plugins: add explicit `plugins.runtime.allowLegacyExec` opt-in to re-enable deprecated `runtime.system.runCommandWithTimeout` for legacy modules while keeping runtime command execution disabled by default. (#20874) Thanks @mbelinky.
 - Gateway/WebChat: block `sessions.patch` and `sessions.delete` for WebChat clients so session-store mutations stay restricted to non-WebChat operator flows. Thanks @allsmog for reporting.

--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -7,6 +7,7 @@ const resolveDefaultAgentId = vi.hoisted(() => vi.fn(() => "agent-default"));
 const resolveAgentDir = vi.hoisted(() => vi.fn(() => "/tmp/agent-default"));
 const resolveMemorySearchConfig = vi.hoisted(() => vi.fn());
 const resolveApiKeyForProvider = vi.hoisted(() => vi.fn());
+const resolveMemoryBackendConfig = vi.hoisted(() => vi.fn());
 
 vi.mock("../terminal/note.js", () => ({
   note,
@@ -23,6 +24,10 @@ vi.mock("../agents/memory-search.js", () => ({
 
 vi.mock("../agents/model-auth.js", () => ({
   resolveApiKeyForProvider,
+}));
+
+vi.mock("../memory/backend-config.js", () => ({
+  resolveMemoryBackendConfig,
 }));
 
 import { noteMemorySearchHealth } from "./doctor-memory-search.js";
@@ -50,6 +55,24 @@ describe("noteMemorySearchHealth", () => {
     resolveAgentDir.mockClear();
     resolveMemorySearchConfig.mockReset();
     resolveApiKeyForProvider.mockReset();
+    resolveMemoryBackendConfig.mockReset();
+    resolveMemoryBackendConfig.mockReturnValue({ backend: "builtin", citations: "auto" });
+  });
+
+  it("does not warn when QMD backend is active", async () => {
+    resolveMemoryBackendConfig.mockReturnValue({
+      backend: "qmd",
+      citations: "auto",
+    });
+    resolveMemorySearchConfig.mockReturnValue({
+      provider: "auto",
+      local: {},
+      remote: {},
+    });
+
+    await noteMemorySearchHealth(cfg);
+
+    expect(note).not.toHaveBeenCalled();
   });
 
   it("does not warn when remote apiKey is configured for explicit provider", async () => {

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -4,6 +4,7 @@ import { resolveMemorySearchConfig } from "../agents/memory-search.js";
 import { resolveApiKeyForProvider } from "../agents/model-auth.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { resolveMemoryBackendConfig } from "../memory/backend-config.js";
 import { note } from "../terminal/note.js";
 import { resolveUserPath } from "../utils.js";
 
@@ -19,6 +20,13 @@ export async function noteMemorySearchHealth(cfg: OpenClawConfig): Promise<void>
 
   if (!resolved) {
     note("Memory search is explicitly disabled (enabled: false).", "Memory search");
+    return;
+  }
+
+  // QMD backend handles embeddings internally (e.g. embeddinggemma) — no
+  // separate embedding provider is needed. Skip the provider check entirely.
+  const backendConfig = resolveMemoryBackendConfig({ cfg, agentId });
+  if (backendConfig.backend === "qmd") {
     return;
   }
 


### PR DESCRIPTION
## Summary

- Fixes false positive warning in `openclaw doctor` when using QMD memory backend with local embeddings (e.g. `embeddinggemma`)
- Adds an early return in `noteMemorySearchHealth()` when `memory.backend === "qmd"`

Fixes #17263

## Problem

When QMD is configured as the memory backend, it handles embeddings internally — no separate embedding provider needs to be configured in OpenClaw's `memorySearch` settings. However, `openclaw doctor` doesn't know this and falsely warns:

```
Memory search is enabled but no embedding provider is configured.
```

## Root cause

`noteMemorySearchHealth()` checks `hasLocalEmbeddings(resolved.local)` which looks for `local.modelPath`. QMD doesn't use this field — it bundles its own embedding model. The function then checks for remote API keys (OpenAI/Gemini/Voyage) and finds none, triggering the false positive.

## Fix

Call `resolveMemoryBackendConfig()` at the top of the check. If `backend === "qmd"`, return early — QMD handles its own embeddings, so no warning is needed.

**1 file changed:** `src/commands/doctor-memory-search.ts`

## Test plan

- [ ] Configure QMD as memory backend with local embeddings
- [ ] Run `openclaw doctor` — verify no false warning about missing embedding provider
- [ ] Configure builtin backend without embedding provider — verify warning still appears
- [ ] Configure builtin backend with OpenAI key — verify no warning

## Local Validation

- `pnpm check` (tsgo): ✅ passes
- `pnpm test`: ✅ passes (existing doctor tests still green)
- Formatting: verified with `oxfmt --check`

## Scope

Single-file fix: `src/commands/doctor-memory-search.ts` — adds early return when QMD backend is detected.

## AI Assistance

AI-assisted (Claude Code) for codebase exploration and root cause analysis. The diagnostic (QMD bundles its own embeddings, so the provider check is unnecessary) and the fix approach are my own work.

Testing level: Fully tested — confirmed `pnpm check` and `pnpm test` pass locally.

## Author

**Miloud Belarebia** — [@miloudbelarebia](https://github.com/miloudbelarebia)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a false positive warning in `openclaw doctor` when using the QMD memory backend. QMD bundles its own embedding model (e.g. `embeddinggemma`), so the existing embedding provider check in `noteMemorySearchHealth()` incorrectly flagged a missing provider. The fix adds an early return when `resolveMemoryBackendConfig()` reports `backend === "qmd"`, skipping the irrelevant provider check entirely.

- Adds `resolveMemoryBackendConfig` call in `noteMemorySearchHealth()` with early return for QMD backend
- Adds properly hoisted mock and test case for the QMD backend path, addressing both items from prior review feedback
- Existing tests continue to pass with a default `{ backend: "builtin" }` mock in `beforeEach`

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it adds a narrow, well-tested early return that only affects QMD backend users.
- The change is minimal (one new import, one early-return guard) with clear intent. The logic is correct: `MemoryBackend` is a union of `"builtin" | "qmd"`, and QMD handles its own embeddings as confirmed by the `backend-config.ts` source and usage in other callers like `search-manager.ts`. The test file properly mocks the new dependency and adds a specific test case. No regressions to existing tests since the default mock returns `{ backend: "builtin" }`. No security concerns.
- No files require special attention

<sub>Last reviewed commit: d970271</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->