### PR TITLE
fix(tui): copy-paste inserts spaces into long tokens at wrap points (#17282 #17278)

### DIFF
--- a/src/tui/tui-formatters.ts
+++ b/src/tui/tui-formatters.ts
@@ -7,9 +7,6 @@ const MAX_TOKEN_CHARS = 32;
 const LONG_TOKEN_RE = /\S{33,}/g;
 const LONG_TOKEN_TEST_RE = /\S{33,}/;
 const BINARY_LINE_REPLACEMENT_THRESHOLD = 12;
-const URL_PREFIX_RE = /^(https?:\/\/|file:\/\/)/i;
-const WINDOWS_DRIVE_RE = /^[a-zA-Z]:[\\/]/;
-const FILE_LIKE_RE = /^[a-zA-Z0-9._-]+$/;
 
 function hasControlChars(text: string): boolean {
   for (const char of text) {
@@ -50,33 +47,12 @@ function chunkToken(token: string, maxChars: number): string[] {
   return chunks;
 }
 
-function isCopySensitiveToken(token: string): boolean {
-  if (URL_PREFIX_RE.test(token)) {
-    return true;
-  }
-  if (
-    token.startsWith("/") ||
-    token.startsWith("~/") ||
-    token.startsWith("./") ||
-    token.startsWith("../")
-  ) {
-    return true;
-  }
-  if (WINDOWS_DRIVE_RE.test(token) || token.startsWith("\\\\")) {
-    return true;
-  }
-  if (token.includes("/") || token.includes("\\")) {
-    return true;
-  }
-  return token.includes("_") && FILE_LIKE_RE.test(token);
-}
-
 function normalizeLongTokenForDisplay(token: string): string {
-  // Preserve copy-sensitive tokens exactly (paths/urls/file-like names).
-  if (isCopySensitiveToken(token)) {
-    return token;
-  }
-  return chunkToken(token, MAX_TOKEN_CHARS).join(" ");
+  // Join with empty string so the text buffer stays byte-identical for
+  // copy-paste. Modern terminals wrap at the edge naturally; inserting
+  // any character (space, zero-width space, etc.) corrupts pasted
+  // URLs, paths, and other opaque tokens.
+  return chunkToken(token, MAX_TOKEN_CHARS).join("");
 }
 
 function redactBinaryLikeLine(line: string): string {


### PR DESCRIPTION
## Summary

Copying long paths or URLs from TUI output inserted extra spaces at every 32 characters, breaking pasted commands and file paths.

Closes #17282
#17278

lobster-biscuit

## Root Cause

`normalizeLongTokenForDisplay` in `tui-formatters.ts` chunks any non-whitespace token longer than 32 chars. For non-"copy-sensitive" tokens it joins the pieces with a literal space (`.join(" ")`), which mutates the actual text buffer so copy-paste grabs the corrupted version.

The existing `isCopySensitiveToken` heuristic tried to detect paths/URLs and skip chunking for those, but it can miss edge cases (base64 strings, encoded tokens, unusual path formats, etc.).

## Fix

Changed `normalizeLongTokenForDisplay` to always `.join("")` (empty string). This makes the chunking a no-op for the text buffer: long tokens pass through `chunkToken` but are reassembled unchanged. The text buffer stays byte-identical for copy operations.

This also removes the now-unnecessary `isCopySensitiveToken` heuristic and its associated regex constants (`URL_PREFIX_RE`, `WINDOWS_DRIVE_RE`, `FILE_LIKE_RE`), since all long tokens are now preserved verbatim.

Modern terminals handle long lines gracefully — they wrap at the terminal edge naturally, so explicit break hints are unnecessary.

- Before: `/Users/pia/.openclaw/workspace/s kills/briefing/Briefing-Agenda.m d`
- After: `/Users/pia/.openclaw/workspace/skills/briefing/Briefing-Agenda.md`

URLs and file paths now copy correctly and work when pasted into browsers and terminals.

## Tests

- `tui-formatters.test.ts` — 24 tests total (12 in `sanitizeRenderableText` block):
  - Long tokens pass through unchanged (the issue repro)
  - Moderately long tokens preserved
  - Long filesystem paths preserved verbatim
  - Long URLs preserved verbatim
  - Long file-like underscore tokens preserved
  - Idempotent: calling twice produces the same result
  - Short tokens pass through untouched
  - Mixed content: spaces between normal words preserved alongside long tokens
  - ANSI stripping, control char stripping, binary redaction, empty string
- All tests pass

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a copy-paste bug where long tokens (paths, URLs) had spaces inserted every 32 characters, breaking pasted commands. The fix changes `normalizeLongTokenForDisplay` to join chunks with empty string instead of space, making long tokens pass through unchanged and preserving copy-paste integrity.

The implementation is correct and solves the reported issue. Tests are comprehensive, covering the bug reproduction case, idempotency, and various edge cases (paths, URLs, mixed content, ANSI stripping, binary redaction).

Minor simplification opportunity: since `chunkToken(token, MAX_TOKEN_CHARS).join("")` is now a no-op that returns the input unchanged, the function could be simplified to `return token;` and potentially the `chunkToken` helper could be removed entirely as it's no longer used meaningfully.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — fixes a real bug without introducing regressions
- The fix correctly solves the copy-paste corruption issue by preserving long tokens unchanged. Comprehensive test coverage validates the fix and guards against regressions. The implementation is simple and doesn't introduce new edge cases.
- No files require special attention

<sub>Last reviewed commit: ed2b9f4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->