### PR TITLE
feat(mattermost): add native slash command support

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -27,18 +27,27 @@ jobs:
     steps:
       - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         id: app-token
+        if: ${{ secrets.GH_APP_PRIVATE_KEY != '' }}
         with:
           app-id: "2729701"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
+      - name: Resolve token
+        id: token
+        shell: bash
+        run: |
+          # Prefer a GitHub App token when available, otherwise fall back to GITHUB_TOKEN.
+          echo "token=${{ steps.app-token.outputs.token || github.token }}" >> "$GITHUB_OUTPUT"
+
       - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5
         with:
           configuration-path: .github/labeler.yml
-          repo-token: ${{ steps.app-token.outputs.token }}
+          repo-token: ${{ steps.token.outputs.token }}
           sync-labels: true
       - name: Apply PR size label
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
+          github-token: ${{ steps.token.outputs.token }}
           script: |
             const pullRequest = context.payload.pull_request;
             if (!pullRequest) {
@@ -127,7 +136,7 @@ jobs:
       - name: Apply maintainer or trusted-contributor label
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
+          github-token: ${{ steps.token.outputs.token }}
           script: |
             const login = context.payload.pull_request?.user?.login;
             if (!login) {
@@ -149,7 +158,12 @@ jobs:
               });
               isMaintainer = membership?.data?.state === "active";
             } catch (error) {
-              if (error?.status !== 404) {
+              // GITHUB_TOKEN may not have org/team read perms; treat permission errors as non-fatal.
+              if (error?.status === 404) {
+                // ignore
+              } else if (error?.status === 403) {
+                core.warning(`Skipping team membership check for ${login}; missing permissions.`);
+              } else {
                 throw error;
               }
             }
@@ -204,13 +218,21 @@ jobs:
     steps:
       - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         id: app-token
+        if: ${{ secrets.GH_APP_PRIVATE_KEY != '' }}
         with:
           app-id: "2729701"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
+      - name: Resolve token
+        id: token
+        shell: bash
+        run: |
+          echo "token=${{ steps.app-token.outputs.token || github.token }}" >> "$GITHUB_OUTPUT"
+
       - name: Backfill PR labels
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
+          github-token: ${{ steps.token.outputs.token }}
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
@@ -444,13 +466,21 @@ jobs:
     steps:
       - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         id: app-token
+        if: ${{ secrets.GH_APP_PRIVATE_KEY != '' }}
         with:
           app-id: "2729701"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
+      - name: Resolve token
+        id: token
+        shell: bash
+        run: |
+          echo "token=${{ steps.app-token.outputs.token || github.token }}" >> "$GITHUB_OUTPUT"
+
       - name: Apply maintainer or trusted-contributor label
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
+          github-token: ${{ steps.token.outputs.token }}
           script: |
             const login = context.payload.issue?.user?.login;
             if (!login) {
@@ -472,7 +502,12 @@ jobs:
               });
               isMaintainer = membership?.data?.state === "active";
             } catch (error) {
-              if (error?.status !== 404) {
+              // GITHUB_TOKEN may not have org/team read perms; treat permission errors as non-fatal.
+              if (error?.status === 404) {
+                // ignore
+              } else if (error?.status === 403) {
+                core.warning(`Skipping team membership check for ${login}; missing permissions.`);
+              } else {
                 throw error;
               }
             }

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -292,7 +292,12 @@ jobs:
                 });
                 isMaintainer = membership?.data?.state === "active";
               } catch (error) {
-                if (error?.status !== 404) {
+                // GITHUB_TOKEN may not have org/team read perms; treat permission errors as non-fatal.
+                if (error?.status === 404) {
+                  // ignore
+                } else if (error?.status === 403) {
+                  core.warning(`Skipping team membership check for ${login}; missing permissions.`);
+                } else {
                   throw error;
                 }
               }

--- a/extensions/mattermost/index.ts
+++ b/extensions/mattermost/index.ts
@@ -1,6 +1,7 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
 import { mattermostPlugin } from "./src/channel.js";
+import { getSlashCommandState, registerSlashCommandRoute } from "./src/mattermost/slash-state.js";
 import { setMattermostRuntime } from "./src/runtime.js";
 
 const plugin = {
@@ -11,6 +12,11 @@ const plugin = {
   register(api: OpenClawPluginApi) {
     setMattermostRuntime(api.runtime);
     api.registerChannel({ plugin: mattermostPlugin });
+
+    // Register the HTTP route for slash command callbacks.
+    // The actual command registration with MM happens in the monitor
+    // after the bot connects and we know the team ID.
+    registerSlashCommandRoute(api);
   },
 };
 

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -75,6 +75,7 @@ export const mattermostPlugin: ChannelPlugin<ResolvedMattermostAccount> = {
     chatTypes: ["direct", "channel", "group", "thread"],
     threads: true,
     media: true,
+    nativeCommands: true,
   },
   streaming: {
     blockStreamingCoalesceDefaults: { minChars: 1500, idleMs: 1000 },

--- a/extensions/mattermost/src/config-schema.ts
+++ b/extensions/mattermost/src/config-schema.ts
@@ -7,6 +7,20 @@ import {
 } from "openclaw/plugin-sdk";
 import { z } from "zod";
 
+const MattermostSlashCommandsSchema = z
+  .object({
+    /** Enable native slash commands. "auto" resolves to false (opt-in). */
+    native: z.union([z.boolean(), z.literal("auto")]).optional(),
+    /** Also register skill-based commands. */
+    nativeSkills: z.union([z.boolean(), z.literal("auto")]).optional(),
+    /** Path for the callback endpoint on the gateway HTTP server. */
+    callbackPath: z.string().optional(),
+    /** Explicit callback URL (e.g. behind reverse proxy). */
+    callbackUrl: z.string().optional(),
+  })
+  .strict()
+  .optional();
+
 const MattermostAccountSchemaBase = z
   .object({
     name: z.string().optional(),
@@ -28,6 +42,7 @@ const MattermostAccountSchemaBase = z
     blockStreaming: z.boolean().optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
     responsePrefix: z.string().optional(),
+    commands: MattermostSlashCommandsSchema,
   })
   .strict();
 

--- a/extensions/mattermost/src/mattermost/accounts.ts
+++ b/extensions/mattermost/src/mattermost/accounts.ts
@@ -65,7 +65,21 @@ function mergeMattermostAccountConfig(
   const { accounts: _ignored, ...base } = (cfg.channels?.mattermost ??
     {}) as MattermostAccountConfig & { accounts?: unknown };
   const account = resolveAccountConfig(cfg, accountId) ?? {};
-  return { ...base, ...account };
+
+  // Shallow merging is fine for most keys, but `commands` should be merged
+  // so that account-specific overrides (callbackPath/callbackUrl) do not
+  // accidentally reset global settings like `native: true`.
+  const mergedCommands = {
+    ...(base.commands ?? {}),
+    ...(account.commands ?? {}),
+  };
+
+  const merged = { ...base, ...account };
+  if (Object.keys(mergedCommands).length > 0) {
+    merged.commands = mergedCommands;
+  }
+
+  return merged;
 }
 
 function resolveMattermostRequireMention(config: MattermostAccountConfig): boolean | undefined {

--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -180,6 +180,19 @@ export async function createMattermostPost(
   });
 }
 
+export type MattermostTeam = {
+  id: string;
+  name?: string | null;
+  display_name?: string | null;
+};
+
+export async function fetchMattermostUserTeams(
+  client: MattermostClient,
+  userId: string,
+): Promise<MattermostTeam[]> {
+  return await client.request<MattermostTeam[]>(`/users/${userId}/teams`);
+}
+
 export async function uploadMattermostFile(
   client: MattermostClient,
   params: {

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -298,7 +298,15 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
   if (slashEnabled) {
     try {
       const teams = await fetchMattermostUserTeams(client, botUserId);
-      const gatewayPort = cfg.gateway?.port ?? 3015;
+
+      // Use the *runtime* listener port when available (e.g. `openclaw gateway run --port <port>`).
+      // The gateway sets OPENCLAW_GATEWAY_PORT when it boots, but the config file may still contain
+      // a different port.
+      const envPortRaw = process.env.OPENCLAW_GATEWAY_PORT?.trim();
+      const envPort = envPortRaw ? Number.parseInt(envPortRaw, 10) : NaN;
+      const gatewayPort =
+        Number.isFinite(envPort) && envPort > 0 ? envPort : (cfg.gateway?.port ?? 3015);
+
       const callbackUrl = resolveCallbackUrl({
         config: slashConfig,
         gatewayPort,

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1057,10 +1057,10 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
     const onAbortCleanup = () => {
       void cleanupSlashCommands({
         client,
-        commands: getSlashCommandState().registeredCommands,
+        commands: getSlashCommandState(account.accountId)?.registeredCommands ?? [],
         log: (msg) => runtime.log?.(msg),
       })
-        .then(() => deactivateSlashCommands())
+        .then(() => deactivateSlashCommands(account.accountId))
         .catch((err) => runtime.error?.(`mattermost: slash cleanup failed: ${String(err)}`));
     };
     opts.abortSignal?.addEventListener("abort", onAbortCleanup, { once: true });

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -311,15 +311,18 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       try {
         const mmHost = new URL(baseUrl).hostname;
         const callbackHost = new URL(callbackUrl).hostname;
+
+        // NOTE: We cannot infer network reachability from hostnames alone.
+        // Mattermost might be accessed via a public domain while still running on the same
+        // machine as the gateway (where http://localhost:<port> is valid).
+        // So treat loopback callback URLs as an advisory warning only.
         if (isLoopbackHost(callbackHost) && !isLoopbackHost(mmHost)) {
           runtime.error?.(
-            `mattermost: slash commands callbackUrl resolved to ${callbackUrl} (loopback). This is unreachable from Mattermost at ${baseUrl}. Set channels.mattermost.commands.callbackUrl to a reachable URL (e.g. your public reverse proxy URL). Skipping slash command registration.`,
+            `mattermost: slash commands callbackUrl resolved to ${callbackUrl} (loopback) while baseUrl is ${baseUrl}. This MAY be unreachable depending on your deployment. If native slash commands don't work, set channels.mattermost.commands.callbackUrl to a URL reachable from the Mattermost server (e.g. your public reverse proxy URL).`,
           );
-          throw new Error("unreachable callbackUrl (loopback)");
         }
-      } catch (err) {
-        // If URL parsing fails or callback is loopback/unreachable, skip registration.
-        throw err;
+      } catch {
+        // URL parse failed; ignore and continue (we'll fail naturally if registration requests break).
       }
 
       const commandsToRegister: import("./slash-commands.js").MattermostCommandSpec[] = [

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1116,13 +1116,16 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
   // Clean up slash commands on shutdown
   if (slashEnabled) {
     const onAbortCleanup = () => {
+      // Snapshot registered commands before deactivating state
+      const commands = getSlashCommandState(account.accountId)?.registeredCommands ?? [];
+      // Deactivate state immediately to prevent race with re-activation
+      deactivateSlashCommands(account.accountId);
+      // Then clean up remote registrations asynchronously
       void cleanupSlashCommands({
         client,
-        commands: getSlashCommandState(account.accountId)?.registeredCommands ?? [],
+        commands,
         log: (msg) => runtime.log?.(msg),
-      })
-        .then(() => deactivateSlashCommands(account.accountId))
-        .catch((err) => runtime.error?.(`mattermost: slash cleanup failed: ${String(err)}`));
+      }).catch((err) => runtime.error?.(`mattermost: slash cleanup failed: ${String(err)}`));
     };
     opts.abortSignal?.addEventListener("abort", onAbortCleanup, { once: true });
   }

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -26,6 +26,7 @@ import {
   fetchMattermostChannel,
   fetchMattermostMe,
   fetchMattermostUser,
+  fetchMattermostUserTeams,
   normalizeMattermostBaseUrl,
   sendMattermostTyping,
   type MattermostChannel,
@@ -39,6 +40,19 @@ import {
   resolveThreadSessionKeys,
 } from "./monitor-helpers.js";
 import { sendMessageMattermost } from "./send.js";
+import {
+  DEFAULT_COMMAND_SPECS,
+  cleanupSlashCommands,
+  isSlashCommandsEnabled,
+  registerSlashCommands,
+  resolveCallbackUrl,
+  resolveSlashCommandConfig,
+} from "./slash-commands.js";
+import {
+  activateSlashCommands,
+  deactivateSlashCommands,
+  getSlashCommandState,
+} from "./slash-state.js";
 
 export type MonitorMattermostOpts = {
   botToken?: string;
@@ -272,6 +286,52 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
   const botUserId = botUser.id;
   const botUsername = botUser.username?.trim() || undefined;
   runtime.log?.(`mattermost connected as ${botUsername ? `@${botUsername}` : botUserId}`);
+
+  // ─── Slash command registration ──────────────────────────────────────────
+  const commandsRaw = account.config.commands as
+    | Partial<import("./slash-commands.js").MattermostSlashCommandConfig>
+    | undefined;
+  const slashConfig = resolveSlashCommandConfig(commandsRaw);
+  const slashEnabled = isSlashCommandsEnabled(slashConfig);
+
+  if (slashEnabled) {
+    try {
+      const teams = await fetchMattermostUserTeams(client, botUserId);
+      const gatewayPort = cfg.gateway?.port ?? 3015;
+      const callbackUrl = resolveCallbackUrl({
+        config: slashConfig,
+        gatewayPort,
+        gatewayHost: cfg.gateway?.customBindHost ?? undefined,
+      });
+
+      const allRegistered: import("./slash-commands.js").MattermostRegisteredCommand[] = [];
+
+      for (const team of teams) {
+        const registered = await registerSlashCommands({
+          client,
+          teamId: team.id,
+          callbackUrl,
+          commands: DEFAULT_COMMAND_SPECS,
+          log: (msg) => runtime.log?.(msg),
+        });
+        allRegistered.push(...registered);
+      }
+
+      activateSlashCommands({
+        account,
+        commandTokens: allRegistered.map((cmd) => cmd.token).filter(Boolean),
+        registeredCommands: allRegistered,
+        api: { cfg, runtime },
+        log: (msg) => runtime.log?.(msg),
+      });
+
+      runtime.log?.(
+        `mattermost: slash commands registered (${allRegistered.length} commands across ${teams.length} teams, callback=${callbackUrl})`,
+      );
+    } catch (err) {
+      runtime.error?.(`mattermost: failed to register slash commands: ${String(err)}`);
+    }
+  }
 
   const channelCache = new Map<string, { value: MattermostChannel | null; expiresAt: number }>();
   const userCache = new Map<string, { value: MattermostUser | null; expiresAt: number }>();
@@ -991,6 +1051,20 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       });
     });
   };
+
+  // Clean up slash commands on shutdown
+  if (slashEnabled) {
+    const onAbortCleanup = () => {
+      void cleanupSlashCommands({
+        client,
+        commands: getSlashCommandState().registeredCommands,
+        log: (msg) => runtime.log?.(msg),
+      })
+        .then(() => deactivateSlashCommands())
+        .catch((err) => runtime.error?.(`mattermost: slash cleanup failed: ${String(err)}`));
+    };
+    opts.abortSignal?.addEventListener("abort", onAbortCleanup, { once: true });
+  }
 
   while (!opts.abortSignal?.aborted) {
     await connectOnce();

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -369,15 +369,26 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
 
       const allRegistered: import("./slash-commands.js").MattermostRegisteredCommand[] = [];
 
-      for (const team of teams) {
-        const registered = await registerSlashCommands({
+      try {
+        for (const team of teams) {
+          const registered = await registerSlashCommands({
+            client,
+            teamId: team.id,
+            callbackUrl,
+            commands: dedupedCommands,
+            log: (msg) => runtime.log?.(msg),
+          });
+          allRegistered.push(...registered);
+        }
+      } catch (err) {
+        // If we partially succeeded (some teams had commands created) but later failed,
+        // clean up the created commands so we don't strand registrations that will 503.
+        await cleanupSlashCommands({
           client,
-          teamId: team.id,
-          callbackUrl,
-          commands: dedupedCommands,
+          commands: allRegistered,
           log: (msg) => runtime.log?.(msg),
         });
-        allRegistered.push(...registered);
+        throw err;
       }
 
       // Build trigger→originalName map for accurate command name resolution

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -304,6 +304,58 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         gatewayHost: cfg.gateway?.customBindHost ?? undefined,
       });
 
+      const isLoopbackHost = (hostname: string) =>
+        hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+
+      try {
+        const mmHost = new URL(baseUrl).hostname;
+        const callbackHost = new URL(callbackUrl).hostname;
+        if (isLoopbackHost(callbackHost) && !isLoopbackHost(mmHost)) {
+          runtime.error?.(
+            `mattermost: slash commands callbackUrl resolved to ${callbackUrl} (loopback). This is unreachable from Mattermost at ${baseUrl}. Set channels.mattermost.commands.callbackUrl to a reachable URL (e.g. your public reverse proxy URL). Skipping slash command registration.`,
+          );
+          throw new Error("unreachable callbackUrl (loopback)");
+        }
+      } catch (err) {
+        // If URL parsing fails or callback is loopback/unreachable, skip registration.
+        throw err;
+      }
+
+      const commandsToRegister: import("./slash-commands.js").MattermostCommandSpec[] = [
+        ...DEFAULT_COMMAND_SPECS,
+      ];
+
+      if (slashConfig.nativeSkills === true) {
+        try {
+          const { listSkillCommandsForAgents } =
+            await import("../../../../src/auto-reply/skill-commands.js");
+          const skillCommands = listSkillCommandsForAgents({ cfg: cfg as any });
+          for (const spec of skillCommands) {
+            const name = typeof spec.name === "string" ? spec.name.trim() : "";
+            if (!name) continue;
+            const trigger = name.startsWith("oc_") ? name : `oc_${name}`;
+            commandsToRegister.push({
+              trigger,
+              description: spec.description || `Run skill ${name}`,
+              autoComplete: true,
+              autoCompleteHint: "[args]",
+            });
+          }
+        } catch (err) {
+          runtime.error?.(`mattermost: failed to list skill commands: ${String(err)}`);
+        }
+      }
+
+      // Deduplicate by trigger
+      const seen = new Set<string>();
+      const dedupedCommands = commandsToRegister.filter((cmd) => {
+        const key = cmd.trigger.trim();
+        if (!key) return false;
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      });
+
       const allRegistered: import("./slash-commands.js").MattermostRegisteredCommand[] = [];
 
       for (const team of teams) {
@@ -311,7 +363,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           client,
           teamId: team.id,
           callbackUrl,
-          commands: DEFAULT_COMMAND_SPECS,
+          commands: dedupedCommands,
           log: (msg) => runtime.log?.(msg),
         });
         allRegistered.push(...registered);

--- a/extensions/mattermost/src/mattermost/slash-commands.ts
+++ b/extensions/mattermost/src/mattermost/slash-commands.ts
@@ -503,7 +503,13 @@ export function resolveCallbackUrl(params: {
   if (params.config.callbackUrl) {
     return params.config.callbackUrl;
   }
-  const host = params.gatewayHost || "localhost";
+  let host = params.gatewayHost || "localhost";
   const path = normalizeCallbackPath(params.config.callbackPath);
+
+  // Bracket IPv6 literals so the URL is valid: http://[::1]:3015/...
+  if (host.includes(":") && !(host.startsWith("[") && host.endsWith("]"))) {
+    host = `[${host}]`;
+  }
+
   return `http://${host}:${params.gatewayPort}${path}`;
 }

--- a/extensions/mattermost/src/mattermost/slash-commands.ts
+++ b/extensions/mattermost/src/mattermost/slash-commands.ts
@@ -251,6 +251,10 @@ export async function registerSlashCommands(params: {
     existing = await listMattermostCommands(client, teamId);
   } catch (err) {
     log?.(`mattermost: failed to list existing commands: ${String(err)}`);
+    // Fail closed: if we can't list existing commands, we should not attempt to
+    // create/update anything because we may create duplicates and end up with an
+    // empty/partial token set (causing callbacks to be rejected until restart).
+    throw err;
   }
 
   const existingByTrigger = new Map(existing.map((cmd) => [cmd.trigger, cmd]));

--- a/extensions/mattermost/src/mattermost/slash-commands.ts
+++ b/extensions/mattermost/src/mattermost/slash-commands.ts
@@ -35,6 +35,8 @@ export type MattermostCommandSpec = {
   description: string;
   autoComplete: boolean;
   autoCompleteHint?: string;
+  /** Original command name (for skill commands that start with oc_) */
+  originalName?: string;
 };
 
 export type MattermostRegisteredCommand = {
@@ -128,39 +130,46 @@ type MattermostCommandResponse = {
 export const DEFAULT_COMMAND_SPECS: MattermostCommandSpec[] = [
   {
     trigger: "oc_status",
+    originalName: "status",
     description: "Show session status (model, usage, uptime)",
     autoComplete: true,
   },
   {
     trigger: "oc_model",
+    originalName: "model",
     description: "View or change the current model",
     autoComplete: true,
     autoCompleteHint: "[model-name]",
   },
   {
     trigger: "oc_new",
+    originalName: "new",
     description: "Start a new conversation session",
     autoComplete: true,
   },
   {
     trigger: "oc_help",
+    originalName: "help",
     description: "Show available commands",
     autoComplete: true,
   },
   {
     trigger: "oc_think",
+    originalName: "think",
     description: "Set thinking/reasoning level",
     autoComplete: true,
     autoCompleteHint: "[off|low|medium|high]",
   },
   {
     trigger: "oc_reasoning",
+    originalName: "reasoning",
     description: "Toggle reasoning mode",
     autoComplete: true,
     autoCompleteHint: "[on|off]",
   },
   {
     trigger: "oc_verbose",
+    originalName: "verbose",
     description: "Toggle verbose mode",
     autoComplete: true,
     autoCompleteHint: "[on|off]",
@@ -435,9 +444,14 @@ export function parseSlashCommandPayload(
  * Map the trigger word back to the original OpenClaw command name.
  * e.g. "oc_status" -> "/status", "oc_model" -> "/model"
  */
-export function resolveCommandText(trigger: string, text: string): string {
-  // Strip the "oc_" prefix to get the original command name
-  const commandName = trigger.startsWith("oc_") ? trigger.slice(3) : trigger;
+export function resolveCommandText(
+  trigger: string,
+  text: string,
+  triggerMap?: ReadonlyMap<string, string>,
+): string {
+  // Use the trigger map if available for accurate name resolution
+  const commandName =
+    triggerMap?.get(trigger) ?? (trigger.startsWith("oc_") ? trigger.slice(3) : trigger);
   const args = text.trim();
   return args ? `/${commandName} ${args}` : `/${commandName}`;
 }

--- a/extensions/mattermost/src/mattermost/slash-commands.ts
+++ b/extensions/mattermost/src/mattermost/slash-commands.ts
@@ -1,0 +1,381 @@
+/**
+ * Mattermost native slash command support.
+ *
+ * Registers custom slash commands via the Mattermost REST API and handles
+ * incoming command callbacks via an HTTP endpoint on the gateway.
+ *
+ * Architecture:
+ * - On startup, registers commands with MM via POST /api/v4/commands
+ * - MM sends HTTP POST to callbackUrl when a user invokes a command
+ * - The callback handler reconstructs the text as `/<command> <args>` and
+ *   routes it through the standard inbound reply pipeline
+ * - On shutdown, cleans up registered commands via DELETE /api/v4/commands/{id}
+ */
+
+import type { MattermostClient } from "./client.js";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type MattermostSlashCommandConfig = {
+  /** Enable native slash commands. "auto" resolves to false for now (opt-in). */
+  native: boolean | "auto";
+  /** Also register skill-based commands. */
+  nativeSkills: boolean | "auto";
+  /** Path for the callback endpoint on the gateway HTTP server. */
+  callbackPath: string;
+  /**
+   * Explicit callback URL override (e.g. behind a reverse proxy).
+   * If not set, auto-derived from baseUrl + gateway port + callbackPath.
+   */
+  callbackUrl?: string;
+};
+
+export type MattermostCommandSpec = {
+  trigger: string;
+  description: string;
+  autoComplete: boolean;
+  autoCompleteHint?: string;
+};
+
+export type MattermostRegisteredCommand = {
+  id: string;
+  trigger: string;
+  teamId: string;
+  token: string;
+};
+
+/**
+ * Payload sent by Mattermost when a slash command is invoked.
+ * Can arrive as application/x-www-form-urlencoded or application/json.
+ */
+export type MattermostSlashCommandPayload = {
+  token: string;
+  team_id: string;
+  team_domain?: string;
+  channel_id: string;
+  channel_name?: string;
+  user_id: string;
+  user_name?: string;
+  command: string; // e.g. "/status"
+  text: string; // args after the trigger word
+  trigger_id?: string;
+  response_url?: string;
+};
+
+/**
+ * Response format for Mattermost slash command callbacks.
+ */
+export type MattermostSlashCommandResponse = {
+  response_type?: "ephemeral" | "in_channel";
+  text: string;
+  username?: string;
+  icon_url?: string;
+  goto_location?: string;
+  attachments?: unknown[];
+};
+
+// ─── MM API types ────────────────────────────────────────────────────────────
+
+type MattermostCommandCreate = {
+  team_id: string;
+  trigger: string;
+  method: "P" | "G";
+  url: string;
+  description?: string;
+  auto_complete: boolean;
+  auto_complete_desc?: string;
+  auto_complete_hint?: string;
+  token?: string;
+  creator_id?: string;
+};
+
+type MattermostCommandResponse = {
+  id: string;
+  token: string;
+  team_id: string;
+  trigger: string;
+  method: string;
+  url: string;
+  auto_complete: boolean;
+  auto_complete_desc?: string;
+  auto_complete_hint?: string;
+  creator_id?: string;
+  create_at?: number;
+  update_at?: number;
+  delete_at?: number;
+};
+
+// ─── Default commands ────────────────────────────────────────────────────────
+
+/**
+ * Built-in OpenClaw commands to register as native slash commands.
+ * These mirror the text-based commands already handled by the gateway.
+ */
+export const DEFAULT_COMMAND_SPECS: MattermostCommandSpec[] = [
+  {
+    trigger: "oc_status",
+    description: "Show session status (model, usage, uptime)",
+    autoComplete: true,
+  },
+  {
+    trigger: "oc_model",
+    description: "View or change the current model",
+    autoComplete: true,
+    autoCompleteHint: "[model-name]",
+  },
+  {
+    trigger: "oc_new",
+    description: "Start a new conversation session",
+    autoComplete: true,
+  },
+  {
+    trigger: "oc_help",
+    description: "Show available commands",
+    autoComplete: true,
+  },
+  {
+    trigger: "oc_think",
+    description: "Set thinking/reasoning level",
+    autoComplete: true,
+    autoCompleteHint: "[off|low|medium|high]",
+  },
+  {
+    trigger: "oc_reasoning",
+    description: "Toggle reasoning mode",
+    autoComplete: true,
+    autoCompleteHint: "[on|off]",
+  },
+  {
+    trigger: "oc_verbose",
+    description: "Toggle verbose mode",
+    autoComplete: true,
+    autoCompleteHint: "[on|off]",
+  },
+];
+
+// ─── Command registration ────────────────────────────────────────────────────
+
+/**
+ * List existing custom slash commands for a team.
+ */
+export async function listMattermostCommands(
+  client: MattermostClient,
+  teamId: string,
+): Promise<MattermostCommandResponse[]> {
+  return await client.request<MattermostCommandResponse[]>(
+    `/commands?team_id=${encodeURIComponent(teamId)}&custom_only=true`,
+  );
+}
+
+/**
+ * Create a custom slash command on a Mattermost team.
+ */
+export async function createMattermostCommand(
+  client: MattermostClient,
+  params: MattermostCommandCreate,
+): Promise<MattermostCommandResponse> {
+  return await client.request<MattermostCommandResponse>("/commands", {
+    method: "POST",
+    body: JSON.stringify(params),
+  });
+}
+
+/**
+ * Delete a custom slash command.
+ */
+export async function deleteMattermostCommand(
+  client: MattermostClient,
+  commandId: string,
+): Promise<void> {
+  await client.request<Record<string, unknown>>(`/commands/${encodeURIComponent(commandId)}`, {
+    method: "DELETE",
+  });
+}
+
+/**
+ * Register all OpenClaw slash commands for a given team.
+ * Skips commands that are already registered with the same trigger + callback URL.
+ * Returns the list of newly created command IDs.
+ */
+export async function registerSlashCommands(params: {
+  client: MattermostClient;
+  teamId: string;
+  callbackUrl: string;
+  commands: MattermostCommandSpec[];
+  log?: (msg: string) => void;
+}): Promise<MattermostRegisteredCommand[]> {
+  const { client, teamId, callbackUrl, commands, log } = params;
+
+  // Fetch existing commands to avoid duplicates
+  let existing: MattermostCommandResponse[] = [];
+  try {
+    existing = await listMattermostCommands(client, teamId);
+  } catch (err) {
+    log?.(`mattermost: failed to list existing commands: ${String(err)}`);
+  }
+
+  const existingByTrigger = new Map(
+    existing.filter((cmd) => cmd.url === callbackUrl).map((cmd) => [cmd.trigger, cmd]),
+  );
+
+  const registered: MattermostRegisteredCommand[] = [];
+
+  for (const spec of commands) {
+    // Skip if already registered with same callback URL
+    const existingCmd = existingByTrigger.get(spec.trigger);
+    if (existingCmd) {
+      log?.(`mattermost: command /${spec.trigger} already registered (id=${existingCmd.id})`);
+      registered.push({
+        id: existingCmd.id,
+        trigger: spec.trigger,
+        teamId,
+        token: existingCmd.token,
+      });
+      continue;
+    }
+
+    try {
+      const created = await createMattermostCommand(client, {
+        team_id: teamId,
+        trigger: spec.trigger,
+        method: "P",
+        url: callbackUrl,
+        description: spec.description,
+        auto_complete: spec.autoComplete,
+        auto_complete_desc: spec.description,
+        auto_complete_hint: spec.autoCompleteHint,
+      });
+      log?.(`mattermost: registered command /${spec.trigger} (id=${created.id})`);
+      registered.push({
+        id: created.id,
+        trigger: spec.trigger,
+        teamId,
+        token: created.token,
+      });
+    } catch (err) {
+      log?.(`mattermost: failed to register command /${spec.trigger}: ${String(err)}`);
+    }
+  }
+
+  return registered;
+}
+
+/**
+ * Clean up all registered slash commands.
+ */
+export async function cleanupSlashCommands(params: {
+  client: MattermostClient;
+  commands: MattermostRegisteredCommand[];
+  log?: (msg: string) => void;
+}): Promise<void> {
+  const { client, commands, log } = params;
+  for (const cmd of commands) {
+    try {
+      await deleteMattermostCommand(client, cmd.id);
+      log?.(`mattermost: deleted command /${cmd.trigger} (id=${cmd.id})`);
+    } catch (err) {
+      log?.(`mattermost: failed to delete command /${cmd.trigger}: ${String(err)}`);
+    }
+  }
+}
+
+// ─── Callback parsing ────────────────────────────────────────────────────────
+
+/**
+ * Parse a Mattermost slash command callback payload from a URL-encoded or JSON body.
+ */
+export function parseSlashCommandPayload(
+  body: string,
+  contentType?: string,
+): MattermostSlashCommandPayload | null {
+  if (!body) {
+    return null;
+  }
+
+  try {
+    if (contentType?.includes("application/json")) {
+      return JSON.parse(body) as MattermostSlashCommandPayload;
+    }
+
+    // Default: application/x-www-form-urlencoded
+    const params = new URLSearchParams(body);
+    const token = params.get("token");
+    const teamId = params.get("team_id");
+    const channelId = params.get("channel_id");
+    const userId = params.get("user_id");
+    const command = params.get("command");
+
+    if (!token || !teamId || !channelId || !userId || !command) {
+      return null;
+    }
+
+    return {
+      token,
+      team_id: teamId,
+      team_domain: params.get("team_domain") ?? undefined,
+      channel_id: channelId,
+      channel_name: params.get("channel_name") ?? undefined,
+      user_id: userId,
+      user_name: params.get("user_name") ?? undefined,
+      command,
+      text: params.get("text") ?? "",
+      trigger_id: params.get("trigger_id") ?? undefined,
+      response_url: params.get("response_url") ?? undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Map the trigger word back to the original OpenClaw command name.
+ * e.g. "oc_status" -> "/status", "oc_model" -> "/model"
+ */
+export function resolveCommandText(trigger: string, text: string): string {
+  // Strip the "oc_" prefix to get the original command name
+  const commandName = trigger.startsWith("oc_") ? trigger.slice(3) : trigger;
+  const args = text.trim();
+  return args ? `/${commandName} ${args}` : `/${commandName}`;
+}
+
+// ─── Config resolution ───────────────────────────────────────────────────────
+
+const DEFAULT_CALLBACK_PATH = "/api/channels/mattermost/command";
+
+export function resolveSlashCommandConfig(
+  raw?: Partial<MattermostSlashCommandConfig>,
+): MattermostSlashCommandConfig {
+  return {
+    native: raw?.native ?? "auto",
+    nativeSkills: raw?.nativeSkills ?? "auto",
+    callbackPath: raw?.callbackPath?.trim() || DEFAULT_CALLBACK_PATH,
+    callbackUrl: raw?.callbackUrl?.trim() || undefined,
+  };
+}
+
+export function isSlashCommandsEnabled(config: MattermostSlashCommandConfig): boolean {
+  if (config.native === true) {
+    return true;
+  }
+  if (config.native === false) {
+    return false;
+  }
+  // "auto" defaults to false for mattermost (opt-in)
+  return false;
+}
+
+/**
+ * Build the callback URL that Mattermost will POST to when a command is invoked.
+ */
+export function resolveCallbackUrl(params: {
+  config: MattermostSlashCommandConfig;
+  gatewayPort: number;
+  gatewayHost?: string;
+}): string {
+  if (params.config.callbackUrl) {
+    return params.config.callbackUrl;
+  }
+  const host = params.gatewayHost || "localhost";
+  const path = params.config.callbackPath;
+  return `http://${host}:${params.gatewayPort}${path}`;
+}

--- a/extensions/mattermost/src/mattermost/slash-http.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.ts
@@ -108,8 +108,9 @@ export function createSlashCommandHttpHandler(params: SlashHttpHandlerParams) {
       return;
     }
 
-    // Validate token
-    if (commandTokens.size > 0 && !commandTokens.has(payload.token)) {
+    // Validate token — fail closed: reject when no tokens are registered
+    // (e.g. registration failed or startup was partial)
+    if (commandTokens.size === 0 || !commandTokens.has(payload.token)) {
       sendJsonResponse(res, 401, {
         response_type: "ephemeral",
         text: "Unauthorized: invalid command token.",

--- a/extensions/mattermost/src/mattermost/slash-http.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.ts
@@ -146,11 +146,13 @@ async function authorizeSlashInvocation(params: {
 
   const channelType = channelInfo?.type ?? undefined;
   const isDirectMessage = channelType?.toUpperCase() === "D";
-  const kind = isDirectMessage
+  const kind: SlashInvocationAuth["kind"] = isDirectMessage
     ? "direct"
-    : channelType?.toUpperCase() === "G"
-      ? "group"
-      : "channel";
+    : channelInfo
+      ? channelType?.toUpperCase() === "G"
+        ? "group"
+        : "channel"
+      : "direct";
 
   const chatType = kind === "direct" ? "direct" : kind === "group" ? "group" : "channel";
 

--- a/extensions/mattermost/src/mattermost/slash-http.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.ts
@@ -152,7 +152,7 @@ async function authorizeSlashInvocation(params: {
       ? channelType?.toUpperCase() === "G"
         ? "group"
         : "channel"
-      : "direct";
+      : "channel";
 
   const chatType = kind === "direct" ? "direct" : kind === "group" ? "group" : "channel";
 

--- a/extensions/mattermost/src/mattermost/slash-http.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.ts
@@ -36,6 +36,8 @@ type SlashHttpHandlerParams = {
   runtime: RuntimeEnv;
   /** Expected token from registered commands (for validation). */
   commandTokens: Set<string>;
+  /** Map from trigger to original command name (for skill commands that start with oc_). */
+  triggerMap?: ReadonlyMap<string, string>;
   log?: (msg: string) => void;
 };
 
@@ -361,7 +363,7 @@ async function authorizeSlashInvocation(params: {
  * from the Mattermost server when a user invokes a registered slash command.
  */
 export function createSlashCommandHttpHandler(params: SlashHttpHandlerParams) {
-  const { account, cfg, runtime, commandTokens, log } = params;
+  const { account, cfg, runtime, commandTokens, triggerMap, log } = params;
 
   const MAX_BODY_BYTES = 64 * 1024; // 64KB
 
@@ -404,7 +406,7 @@ export function createSlashCommandHttpHandler(params: SlashHttpHandlerParams) {
 
     // Extract command info
     const trigger = payload.command.replace(/^\//, "").trim();
-    const commandText = resolveCommandText(trigger, payload.text);
+    const commandText = resolveCommandText(trigger, payload.text, triggerMap);
     const channelId = payload.channel_id;
     const senderId = payload.user_id;
     const senderName = payload.user_name ?? senderId;

--- a/extensions/mattermost/src/mattermost/slash-http.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.ts
@@ -1,0 +1,338 @@
+/**
+ * HTTP callback handler for Mattermost slash commands.
+ *
+ * Receives POST requests from Mattermost when a slash command is invoked,
+ * validates the token, and routes the command through the standard inbound pipeline.
+ */
+
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { OpenClawConfig, ReplyPayload, RuntimeEnv } from "openclaw/plugin-sdk";
+import {
+  createReplyPrefixOptions,
+  createTypingCallbacks,
+  logTypingFailure,
+} from "openclaw/plugin-sdk";
+import type { ResolvedMattermostAccount } from "../mattermost/accounts.js";
+import { getMattermostRuntime } from "../runtime.js";
+import {
+  createMattermostClient,
+  fetchMattermostChannel,
+  fetchMattermostUser,
+  normalizeMattermostBaseUrl,
+  sendMattermostTyping,
+  type MattermostChannel,
+} from "./client.js";
+import { sendMessageMattermost } from "./send.js";
+import {
+  parseSlashCommandPayload,
+  resolveCommandText,
+  type MattermostSlashCommandResponse,
+} from "./slash-commands.js";
+
+type SlashHttpHandlerParams = {
+  account: ResolvedMattermostAccount;
+  cfg: OpenClawConfig;
+  runtime: RuntimeEnv;
+  /** Expected token from registered commands (for validation). */
+  commandTokens: Set<string>;
+  log?: (msg: string) => void;
+};
+
+/**
+ * Read the full request body as a string.
+ */
+function readBody(req: IncomingMessage, maxBytes: number): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let size = 0;
+    req.on("data", (chunk: Buffer) => {
+      size += chunk.length;
+      if (size > maxBytes) {
+        req.destroy();
+        reject(new Error("Request body too large"));
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    req.on("error", reject);
+  });
+}
+
+function sendJsonResponse(
+  res: ServerResponse,
+  status: number,
+  body: MattermostSlashCommandResponse,
+) {
+  res.statusCode = status;
+  res.setHeader("Content-Type", "application/json; charset=utf-8");
+  res.end(JSON.stringify(body));
+}
+
+/**
+ * Create the HTTP request handler for Mattermost slash command callbacks.
+ *
+ * This handler is registered as a plugin HTTP route and receives POSTs
+ * from the Mattermost server when a user invokes a registered slash command.
+ */
+export function createSlashCommandHttpHandler(params: SlashHttpHandlerParams) {
+  const { account, cfg, runtime, commandTokens, log } = params;
+  const core = getMattermostRuntime();
+
+  const MAX_BODY_BYTES = 64 * 1024; // 64KB
+
+  return async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
+    if (req.method !== "POST") {
+      res.statusCode = 405;
+      res.setHeader("Allow", "POST");
+      res.end("Method Not Allowed");
+      return;
+    }
+
+    let body: string;
+    try {
+      body = await readBody(req, MAX_BODY_BYTES);
+    } catch {
+      res.statusCode = 413;
+      res.end("Payload Too Large");
+      return;
+    }
+
+    const contentType = req.headers["content-type"] ?? "";
+    const payload = parseSlashCommandPayload(body, contentType);
+    if (!payload) {
+      sendJsonResponse(res, 400, {
+        response_type: "ephemeral",
+        text: "Invalid slash command payload.",
+      });
+      return;
+    }
+
+    // Validate token
+    if (commandTokens.size > 0 && !commandTokens.has(payload.token)) {
+      sendJsonResponse(res, 401, {
+        response_type: "ephemeral",
+        text: "Unauthorized: invalid command token.",
+      });
+      return;
+    }
+
+    // Extract command info
+    const trigger = payload.command.replace(/^\//, "").trim();
+    const commandText = resolveCommandText(trigger, payload.text);
+    const channelId = payload.channel_id;
+    const senderId = payload.user_id;
+    const senderName = payload.user_name ?? senderId;
+
+    log?.(`mattermost: slash command /${trigger} from ${senderName} in ${channelId}`);
+
+    // Acknowledge immediately — we'll send the actual reply asynchronously
+    sendJsonResponse(res, 200, {
+      response_type: "ephemeral",
+      text: "Processing...",
+    });
+
+    // Now handle the command asynchronously (post reply as a message)
+    try {
+      await handleSlashCommandAsync({
+        account,
+        cfg,
+        runtime,
+        commandText,
+        channelId,
+        senderId,
+        senderName,
+        teamId: payload.team_id,
+        triggerId: payload.trigger_id,
+        log,
+      });
+    } catch (err) {
+      log?.(`mattermost: slash command handler error: ${String(err)}`);
+      try {
+        const to = `channel:${channelId}`;
+        await sendMessageMattermost(to, "Sorry, something went wrong processing that command.", {
+          accountId: account.accountId,
+        });
+      } catch {
+        // best-effort error reply
+      }
+    }
+  };
+}
+
+async function handleSlashCommandAsync(params: {
+  account: ResolvedMattermostAccount;
+  cfg: OpenClawConfig;
+  runtime: RuntimeEnv;
+  commandText: string;
+  channelId: string;
+  senderId: string;
+  senderName: string;
+  teamId: string;
+  triggerId?: string;
+  log?: (msg: string) => void;
+}) {
+  const { account, cfg, runtime, commandText, channelId, senderId, senderName, teamId, log } =
+    params;
+  const core = getMattermostRuntime();
+
+  // Resolve channel info
+  const client = createMattermostClient({
+    baseUrl: account.baseUrl ?? "",
+    botToken: account.botToken ?? "",
+  });
+
+  let channelInfo: MattermostChannel | null = null;
+  try {
+    channelInfo = await fetchMattermostChannel(client, channelId);
+  } catch {
+    // continue without channel info
+  }
+
+  const channelType = channelInfo?.type ?? undefined;
+  const isDirectMessage = channelType?.toUpperCase() === "D";
+  const kind = isDirectMessage
+    ? "direct"
+    : channelType?.toUpperCase() === "G"
+      ? "group"
+      : "channel";
+  const chatType =
+    kind === "direct"
+      ? ("direct" as const)
+      : kind === "group"
+        ? ("group" as const)
+        : ("channel" as const);
+
+  const channelName = channelInfo?.name ?? "";
+  const channelDisplay = channelInfo?.display_name ?? channelName;
+  const roomLabel = channelName ? `#${channelName}` : channelDisplay || `#${channelId}`;
+
+  const route = core.channel.routing.resolveAgentRoute({
+    cfg,
+    channel: "mattermost",
+    accountId: account.accountId,
+    teamId,
+    peer: {
+      kind,
+      id: kind === "direct" ? senderId : channelId,
+    },
+  });
+
+  const fromLabel =
+    kind === "direct"
+      ? `Mattermost DM from ${senderName}`
+      : `Mattermost message in ${roomLabel} from ${senderName}`;
+
+  const to = kind === "direct" ? `user:${senderId}` : `channel:${channelId}`;
+
+  // Build inbound context — the command text is the body
+  const ctxPayload = core.channel.reply.finalizeInboundContext({
+    Body: commandText,
+    BodyForAgent: commandText,
+    RawBody: commandText,
+    CommandBody: commandText,
+    From:
+      kind === "direct"
+        ? `mattermost:${senderId}`
+        : kind === "group"
+          ? `mattermost:group:${channelId}`
+          : `mattermost:channel:${channelId}`,
+    To: to,
+    SessionKey: route.sessionKey,
+    AccountId: route.accountId,
+    ChatType: chatType,
+    ConversationLabel: fromLabel,
+    GroupSubject: kind !== "direct" ? channelDisplay || roomLabel : undefined,
+    SenderName: senderName,
+    SenderId: senderId,
+    Provider: "mattermost" as const,
+    Surface: "mattermost" as const,
+    MessageSid: params.triggerId ?? `slash-${Date.now()}`,
+    Timestamp: Date.now(),
+    WasMentioned: true,
+    CommandAuthorized: true, // Slash commands bypass mention requirements
+    CommandSource: "native" as const,
+    OriginatingChannel: "mattermost" as const,
+    OriginatingTo: to,
+  });
+
+  const textLimit = core.channel.text.resolveTextChunkLimit(cfg, "mattermost", account.accountId, {
+    fallbackLimit: account.textChunkLimit ?? 4000,
+  });
+  const tableMode = core.channel.text.resolveMarkdownTableMode({
+    cfg,
+    channel: "mattermost",
+    accountId: account.accountId,
+  });
+
+  const { onModelSelected, ...prefixOptions } = createReplyPrefixOptions({
+    cfg,
+    agentId: route.agentId,
+    channel: "mattermost",
+    accountId: account.accountId,
+  });
+
+  const typingCallbacks = createTypingCallbacks({
+    start: () => sendMattermostTyping(client, { channelId }),
+    onStartError: (err) => {
+      logTypingFailure({
+        log: (message) => log?.(message),
+        channel: "mattermost",
+        target: channelId,
+        error: err,
+      });
+    },
+  });
+
+  const { dispatcher, replyOptions, markDispatchIdle } =
+    core.channel.reply.createReplyDispatcherWithTyping({
+      ...prefixOptions,
+      humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, route.agentId),
+      deliver: async (payload: ReplyPayload) => {
+        const mediaUrls = payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
+        const text = core.channel.text.convertMarkdownTables(payload.text ?? "", tableMode);
+        if (mediaUrls.length === 0) {
+          const chunkMode = core.channel.text.resolveChunkMode(
+            cfg,
+            "mattermost",
+            account.accountId,
+          );
+          const chunks = core.channel.text.chunkMarkdownTextWithMode(text, textLimit, chunkMode);
+          for (const chunk of chunks.length > 0 ? chunks : [text]) {
+            if (!chunk) continue;
+            await sendMessageMattermost(to, chunk, {
+              accountId: account.accountId,
+            });
+          }
+        } else {
+          let first = true;
+          for (const mediaUrl of mediaUrls) {
+            const caption = first ? text : "";
+            first = false;
+            await sendMessageMattermost(to, caption, {
+              accountId: account.accountId,
+              mediaUrl,
+            });
+          }
+        }
+        runtime.log?.(`delivered slash reply to ${to}`);
+      },
+      onError: (err, info) => {
+        runtime.error?.(`mattermost slash ${info.kind} reply failed: ${String(err)}`);
+      },
+      onReplyStart: typingCallbacks.onReplyStart,
+    });
+
+  await core.channel.reply.dispatchReplyFromConfig({
+    ctx: ctxPayload,
+    cfg,
+    dispatcher,
+    replyOptions: {
+      ...replyOptions,
+      disableBlockStreaming:
+        typeof account.blockStreaming === "boolean" ? !account.blockStreaming : undefined,
+      onModelSelected,
+    },
+  });
+  markDispatchIdle();
+}

--- a/extensions/mattermost/src/mattermost/slash-state.ts
+++ b/extensions/mattermost/src/mattermost/slash-state.ts
@@ -4,6 +4,9 @@
  * Bridges the plugin registration phase (HTTP route) with the monitor phase
  * (command registration with MM API). The HTTP handler needs to know which
  * tokens are valid, and the monitor needs to store registered command IDs.
+ *
+ * State is kept per-account so that multi-account deployments don't
+ * overwrite each other's tokens, registered commands, or handlers.
  */
 
 import type { IncomingMessage, ServerResponse } from "node:http";
@@ -12,28 +15,34 @@ import type { ResolvedMattermostAccount } from "./accounts.js";
 import { resolveSlashCommandConfig, type MattermostRegisteredCommand } from "./slash-commands.js";
 import { createSlashCommandHttpHandler } from "./slash-http.js";
 
-// ─── Shared mutable state ────────────────────────────────────────────────────
+// ─── Per-account state ───────────────────────────────────────────────────────
 
-type SlashCommandState = {
+type SlashCommandAccountState = {
   /** Tokens from registered commands, used for validation. */
   commandTokens: Set<string>;
   /** Registered command IDs for cleanup on shutdown. */
   registeredCommands: MattermostRegisteredCommand[];
-  /** Current HTTP handler (set when an account activates). */
+  /** Current HTTP handler for this account. */
   handler: ((req: IncomingMessage, res: ServerResponse) => Promise<void>) | null;
   /** The account that activated slash commands. */
-  activeAccount: ResolvedMattermostAccount | null;
+  account: ResolvedMattermostAccount;
 };
 
-const state: SlashCommandState = {
-  commandTokens: new Set(),
-  registeredCommands: [],
-  handler: null,
-  activeAccount: null,
-};
+/** Map from accountId → per-account slash command state. */
+const accountStates = new Map<string, SlashCommandAccountState>();
 
-export function getSlashCommandState(): SlashCommandState {
-  return state;
+/**
+ * Get the slash command state for a specific account, or null if not activated.
+ */
+export function getSlashCommandState(accountId: string): SlashCommandAccountState | null {
+  return accountStates.get(accountId) ?? null;
+}
+
+/**
+ * Get all active slash command account states.
+ */
+export function getAllSlashCommandStates(): ReadonlyMap<string, SlashCommandAccountState> {
+  return accountStates;
 }
 
 /**
@@ -51,35 +60,59 @@ export function activateSlashCommands(params: {
   log?: (msg: string) => void;
 }) {
   const { account, commandTokens, registeredCommands, api, log } = params;
+  const accountId = account.accountId;
 
-  state.commandTokens = new Set(commandTokens);
-  state.registeredCommands = registeredCommands;
-  state.activeAccount = account;
+  const tokenSet = new Set(commandTokens);
 
-  state.handler = createSlashCommandHttpHandler({
+  const handler = createSlashCommandHttpHandler({
     account,
     cfg: api.cfg,
     runtime: api.runtime,
-    commandTokens: state.commandTokens,
+    commandTokens: tokenSet,
     log,
   });
 
-  log?.(`mattermost: slash commands activated (${registeredCommands.length} commands)`);
+  accountStates.set(accountId, {
+    commandTokens: tokenSet,
+    registeredCommands,
+    handler,
+    account,
+  });
+
+  log?.(
+    `mattermost: slash commands activated for account ${accountId} (${registeredCommands.length} commands)`,
+  );
 }
 
 /**
- * Deactivate slash commands (on shutdown/disconnect).
+ * Deactivate slash commands for a specific account (on shutdown/disconnect).
  */
-export function deactivateSlashCommands() {
-  state.commandTokens.clear();
-  state.registeredCommands = [];
-  state.handler = null;
-  state.activeAccount = null;
+export function deactivateSlashCommands(accountId?: string) {
+  if (accountId) {
+    const state = accountStates.get(accountId);
+    if (state) {
+      state.commandTokens.clear();
+      state.registeredCommands = [];
+      state.handler = null;
+      accountStates.delete(accountId);
+    }
+  } else {
+    // Deactivate all accounts (full shutdown)
+    for (const [, state] of accountStates) {
+      state.commandTokens.clear();
+      state.registeredCommands = [];
+      state.handler = null;
+    }
+    accountStates.clear();
+  }
 }
 
 /**
  * Register the HTTP route for slash command callbacks.
  * Called during plugin registration.
+ *
+ * The single HTTP route dispatches to the correct per-account handler
+ * by matching the inbound token against each account's registered tokens.
  */
 export function registerSlashCommandRoute(api: OpenClawPluginApi) {
   const mmConfig = api.config.channels?.mattermost as Record<string, unknown> | undefined;
@@ -92,7 +125,7 @@ export function registerSlashCommandRoute(api: OpenClawPluginApi) {
   api.registerHttpRoute({
     path: callbackPath,
     handler: async (req: IncomingMessage, res: ServerResponse) => {
-      if (!state.handler) {
+      if (accountStates.size === 0) {
         res.statusCode = 503;
         res.setHeader("Content-Type", "application/json; charset=utf-8");
         res.end(
@@ -103,7 +136,103 @@ export function registerSlashCommandRoute(api: OpenClawPluginApi) {
         );
         return;
       }
-      await state.handler(req, res);
+
+      // We need to peek at the token to route to the right account handler.
+      // Since each account handler also validates the token, we find the
+      // account whose token set contains the inbound token and delegate.
+      // If none match, we pick the first handler and let its own validation
+      // reject the request (fail closed).
+
+      // For multi-account routing: the handlers read the body themselves,
+      // so we can't pre-parse here without buffering. Instead, if there's
+      // only one active account (common case), route directly.
+      if (accountStates.size === 1) {
+        const [, state] = [...accountStates.entries()][0]!;
+        if (!state.handler) {
+          res.statusCode = 503;
+          res.setHeader("Content-Type", "application/json; charset=utf-8");
+          res.end(
+            JSON.stringify({
+              response_type: "ephemeral",
+              text: "Slash commands are not yet initialized. Please try again in a moment.",
+            }),
+          );
+          return;
+        }
+        await state.handler(req, res);
+        return;
+      }
+
+      // Multi-account: buffer the body, find the matching account by token,
+      // then replay the request to the correct handler.
+      const chunks: Buffer[] = [];
+      const MAX_BODY = 64 * 1024;
+      let size = 0;
+      for await (const chunk of req) {
+        size += (chunk as Buffer).length;
+        if (size > MAX_BODY) {
+          res.statusCode = 413;
+          res.end("Payload Too Large");
+          return;
+        }
+        chunks.push(chunk as Buffer);
+      }
+      const bodyStr = Buffer.concat(chunks).toString("utf8");
+
+      // Parse just the token to find the right account
+      let token: string | null = null;
+      const ct = req.headers["content-type"] ?? "";
+      try {
+        if (ct.includes("application/json")) {
+          token = (JSON.parse(bodyStr) as { token?: string }).token ?? null;
+        } else {
+          token = new URLSearchParams(bodyStr).get("token");
+        }
+      } catch {
+        // parse failed — will be caught by handler
+      }
+
+      // Find the account whose tokens include this one
+      let matchedHandler: ((req: IncomingMessage, res: ServerResponse) => Promise<void>) | null =
+        null;
+
+      if (token) {
+        for (const [, state] of accountStates) {
+          if (state.commandTokens.has(token) && state.handler) {
+            matchedHandler = state.handler;
+            break;
+          }
+        }
+      }
+
+      if (!matchedHandler) {
+        // No matching account — reject
+        res.statusCode = 401;
+        res.setHeader("Content-Type", "application/json; charset=utf-8");
+        res.end(
+          JSON.stringify({
+            response_type: "ephemeral",
+            text: "Unauthorized: invalid command token.",
+          }),
+        );
+        return;
+      }
+
+      // Replay: create a synthetic readable that re-emits the buffered body
+      const { Readable } = await import("node:stream");
+      const syntheticReq = new Readable({
+        read() {
+          this.push(Buffer.from(bodyStr, "utf8"));
+          this.push(null);
+        },
+      }) as IncomingMessage;
+
+      // Copy necessary IncomingMessage properties
+      syntheticReq.method = req.method;
+      syntheticReq.url = req.url;
+      syntheticReq.headers = req.headers;
+
+      await matchedHandler(syntheticReq, res);
     },
   });
 

--- a/extensions/mattermost/src/mattermost/slash-state.ts
+++ b/extensions/mattermost/src/mattermost/slash-state.ts
@@ -26,6 +26,8 @@ type SlashCommandAccountState = {
   handler: ((req: IncomingMessage, res: ServerResponse) => Promise<void>) | null;
   /** The account that activated slash commands. */
   account: ResolvedMattermostAccount;
+  /** Map from trigger to original command name (for skill commands that start with oc_). */
+  triggerMap: Map<string, string>;
 };
 
 /** Map from accountId → per-account slash command state. */
@@ -53,13 +55,14 @@ export function activateSlashCommands(params: {
   account: ResolvedMattermostAccount;
   commandTokens: string[];
   registeredCommands: MattermostRegisteredCommand[];
+  triggerMap?: Map<string, string>;
   api: {
     cfg: import("openclaw/plugin-sdk").OpenClawConfig;
     runtime: import("openclaw/plugin-sdk").RuntimeEnv;
   };
   log?: (msg: string) => void;
 }) {
-  const { account, commandTokens, registeredCommands, api, log } = params;
+  const { account, commandTokens, registeredCommands, triggerMap, api, log } = params;
   const accountId = account.accountId;
 
   const tokenSet = new Set(commandTokens);
@@ -69,6 +72,7 @@ export function activateSlashCommands(params: {
     cfg: api.cfg,
     runtime: api.runtime,
     commandTokens: tokenSet,
+    triggerMap,
     log,
   });
 
@@ -77,6 +81,7 @@ export function activateSlashCommands(params: {
     registeredCommands,
     handler,
     account,
+    triggerMap: triggerMap ?? new Map(),
   });
 
   log?.(

--- a/extensions/mattermost/src/mattermost/slash-state.ts
+++ b/extensions/mattermost/src/mattermost/slash-state.ts
@@ -1,0 +1,111 @@
+/**
+ * Shared state for Mattermost slash commands.
+ *
+ * Bridges the plugin registration phase (HTTP route) with the monitor phase
+ * (command registration with MM API). The HTTP handler needs to know which
+ * tokens are valid, and the monitor needs to store registered command IDs.
+ */
+
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { ResolvedMattermostAccount } from "./accounts.js";
+import { resolveSlashCommandConfig, type MattermostRegisteredCommand } from "./slash-commands.js";
+import { createSlashCommandHttpHandler } from "./slash-http.js";
+
+// ─── Shared mutable state ────────────────────────────────────────────────────
+
+type SlashCommandState = {
+  /** Tokens from registered commands, used for validation. */
+  commandTokens: Set<string>;
+  /** Registered command IDs for cleanup on shutdown. */
+  registeredCommands: MattermostRegisteredCommand[];
+  /** Current HTTP handler (set when an account activates). */
+  handler: ((req: IncomingMessage, res: ServerResponse) => Promise<void>) | null;
+  /** The account that activated slash commands. */
+  activeAccount: ResolvedMattermostAccount | null;
+};
+
+const state: SlashCommandState = {
+  commandTokens: new Set(),
+  registeredCommands: [],
+  handler: null,
+  activeAccount: null,
+};
+
+export function getSlashCommandState(): SlashCommandState {
+  return state;
+}
+
+/**
+ * Activate slash commands for a specific account.
+ * Called from the monitor after bot connects.
+ */
+export function activateSlashCommands(params: {
+  account: ResolvedMattermostAccount;
+  commandTokens: string[];
+  registeredCommands: MattermostRegisteredCommand[];
+  api: {
+    cfg: import("openclaw/plugin-sdk").OpenClawConfig;
+    runtime: import("openclaw/plugin-sdk").RuntimeEnv;
+  };
+  log?: (msg: string) => void;
+}) {
+  const { account, commandTokens, registeredCommands, api, log } = params;
+
+  state.commandTokens = new Set(commandTokens);
+  state.registeredCommands = registeredCommands;
+  state.activeAccount = account;
+
+  state.handler = createSlashCommandHttpHandler({
+    account,
+    cfg: api.cfg,
+    runtime: api.runtime,
+    commandTokens: state.commandTokens,
+    log,
+  });
+
+  log?.(`mattermost: slash commands activated (${registeredCommands.length} commands)`);
+}
+
+/**
+ * Deactivate slash commands (on shutdown/disconnect).
+ */
+export function deactivateSlashCommands() {
+  state.commandTokens.clear();
+  state.registeredCommands = [];
+  state.handler = null;
+  state.activeAccount = null;
+}
+
+/**
+ * Register the HTTP route for slash command callbacks.
+ * Called during plugin registration.
+ */
+export function registerSlashCommandRoute(api: OpenClawPluginApi) {
+  const mmConfig = api.config.channels?.mattermost as Record<string, unknown> | undefined;
+  const commandsRaw = mmConfig?.commands as
+    | Partial<import("./slash-commands.js").MattermostSlashCommandConfig>
+    | undefined;
+  const slashConfig = resolveSlashCommandConfig(commandsRaw);
+  const callbackPath = slashConfig.callbackPath;
+
+  api.registerHttpRoute({
+    path: callbackPath,
+    handler: async (req: IncomingMessage, res: ServerResponse) => {
+      if (!state.handler) {
+        res.statusCode = 503;
+        res.setHeader("Content-Type", "application/json; charset=utf-8");
+        res.end(
+          JSON.stringify({
+            response_type: "ephemeral",
+            text: "Slash commands are not yet initialized. Please try again in a moment.",
+          }),
+        );
+        return;
+      }
+      await state.handler(req, res);
+    },
+  });
+
+  api.logger.info?.(`mattermost: registered slash command callback at ${callbackPath}`);
+}

--- a/extensions/mattermost/src/mattermost/slash-state.ts
+++ b/extensions/mattermost/src/mattermost/slash-state.ts
@@ -116,16 +116,47 @@ export function deactivateSlashCommands(accountId?: string) {
  */
 export function registerSlashCommandRoute(api: OpenClawPluginApi) {
   const mmConfig = api.config.channels?.mattermost as Record<string, unknown> | undefined;
+
+  // Collect callback paths from both top-level and per-account config.
+  // Command registration uses account.config.commands, so the HTTP route
+  // registration must include any account-specific callbackPath overrides.
+  const callbackPaths = new Set<string>();
+
   const commandsRaw = mmConfig?.commands as
     | Partial<import("./slash-commands.js").MattermostSlashCommandConfig>
     | undefined;
-  const slashConfig = resolveSlashCommandConfig(commandsRaw);
-  const callbackPath = slashConfig.callbackPath;
+  callbackPaths.add(resolveSlashCommandConfig(commandsRaw).callbackPath);
 
-  api.registerHttpRoute({
-    path: callbackPath,
-    handler: async (req: IncomingMessage, res: ServerResponse) => {
-      if (accountStates.size === 0) {
+  const accountsRaw = (mmConfig?.accounts ?? {}) as Record<string, unknown>;
+  for (const accountId of Object.keys(accountsRaw)) {
+    const accountCfg = accountsRaw[accountId] as Record<string, unknown> | undefined;
+    const accountCommandsRaw = accountCfg?.commands as
+      | Partial<import("./slash-commands.js").MattermostSlashCommandConfig>
+      | undefined;
+    callbackPaths.add(resolveSlashCommandConfig(accountCommandsRaw).callbackPath);
+  }
+
+  const routeHandler = async (req: IncomingMessage, res: ServerResponse) => {
+    if (accountStates.size === 0) {
+      res.statusCode = 503;
+      res.setHeader("Content-Type", "application/json; charset=utf-8");
+      res.end(
+        JSON.stringify({
+          response_type: "ephemeral",
+          text: "Slash commands are not yet initialized. Please try again in a moment.",
+        }),
+      );
+      return;
+    }
+
+    // We need to peek at the token to route to the right account handler.
+    // Since each account handler also validates the token, we find the
+    // account whose token set contains the inbound token and delegate.
+
+    // If there's only one active account (common case), route directly.
+    if (accountStates.size === 1) {
+      const [, state] = [...accountStates.entries()][0]!;
+      if (!state.handler) {
         res.statusCode = 503;
         res.setHeader("Content-Type", "application/json; charset=utf-8");
         res.end(
@@ -136,105 +167,87 @@ export function registerSlashCommandRoute(api: OpenClawPluginApi) {
         );
         return;
       }
+      await state.handler(req, res);
+      return;
+    }
 
-      // We need to peek at the token to route to the right account handler.
-      // Since each account handler also validates the token, we find the
-      // account whose token set contains the inbound token and delegate.
-      // If none match, we pick the first handler and let its own validation
-      // reject the request (fail closed).
-
-      // For multi-account routing: the handlers read the body themselves,
-      // so we can't pre-parse here without buffering. Instead, if there's
-      // only one active account (common case), route directly.
-      if (accountStates.size === 1) {
-        const [, state] = [...accountStates.entries()][0]!;
-        if (!state.handler) {
-          res.statusCode = 503;
-          res.setHeader("Content-Type", "application/json; charset=utf-8");
-          res.end(
-            JSON.stringify({
-              response_type: "ephemeral",
-              text: "Slash commands are not yet initialized. Please try again in a moment.",
-            }),
-          );
-          return;
-        }
-        await state.handler(req, res);
+    // Multi-account: buffer the body, find the matching account by token,
+    // then replay the request to the correct handler.
+    const chunks: Buffer[] = [];
+    const MAX_BODY = 64 * 1024;
+    let size = 0;
+    for await (const chunk of req) {
+      size += (chunk as Buffer).length;
+      if (size > MAX_BODY) {
+        res.statusCode = 413;
+        res.end("Payload Too Large");
         return;
       }
+      chunks.push(chunk as Buffer);
+    }
+    const bodyStr = Buffer.concat(chunks).toString("utf8");
 
-      // Multi-account: buffer the body, find the matching account by token,
-      // then replay the request to the correct handler.
-      const chunks: Buffer[] = [];
-      const MAX_BODY = 64 * 1024;
-      let size = 0;
-      for await (const chunk of req) {
-        size += (chunk as Buffer).length;
-        if (size > MAX_BODY) {
-          res.statusCode = 413;
-          res.end("Payload Too Large");
-          return;
-        }
-        chunks.push(chunk as Buffer);
+    // Parse just the token to find the right account
+    let token: string | null = null;
+    const ct = req.headers["content-type"] ?? "";
+    try {
+      if (ct.includes("application/json")) {
+        token = (JSON.parse(bodyStr) as { token?: string }).token ?? null;
+      } else {
+        token = new URLSearchParams(bodyStr).get("token");
       }
-      const bodyStr = Buffer.concat(chunks).toString("utf8");
+    } catch {
+      // parse failed — will be caught by handler
+    }
 
-      // Parse just the token to find the right account
-      let token: string | null = null;
-      const ct = req.headers["content-type"] ?? "";
-      try {
-        if (ct.includes("application/json")) {
-          token = (JSON.parse(bodyStr) as { token?: string }).token ?? null;
-        } else {
-          token = new URLSearchParams(bodyStr).get("token");
-        }
-      } catch {
-        // parse failed — will be caught by handler
-      }
+    // Find the account whose tokens include this one
+    let matchedHandler: ((req: IncomingMessage, res: ServerResponse) => Promise<void>) | null =
+      null;
 
-      // Find the account whose tokens include this one
-      let matchedHandler: ((req: IncomingMessage, res: ServerResponse) => Promise<void>) | null =
-        null;
-
-      if (token) {
-        for (const [, state] of accountStates) {
-          if (state.commandTokens.has(token) && state.handler) {
-            matchedHandler = state.handler;
-            break;
-          }
+    if (token) {
+      for (const [, state] of accountStates) {
+        if (state.commandTokens.has(token) && state.handler) {
+          matchedHandler = state.handler;
+          break;
         }
       }
+    }
 
-      if (!matchedHandler) {
-        // No matching account — reject
-        res.statusCode = 401;
-        res.setHeader("Content-Type", "application/json; charset=utf-8");
-        res.end(
-          JSON.stringify({
-            response_type: "ephemeral",
-            text: "Unauthorized: invalid command token.",
-          }),
-        );
-        return;
-      }
+    if (!matchedHandler) {
+      // No matching account — reject
+      res.statusCode = 401;
+      res.setHeader("Content-Type", "application/json; charset=utf-8");
+      res.end(
+        JSON.stringify({
+          response_type: "ephemeral",
+          text: "Unauthorized: invalid command token.",
+        }),
+      );
+      return;
+    }
 
-      // Replay: create a synthetic readable that re-emits the buffered body
-      const { Readable } = await import("node:stream");
-      const syntheticReq = new Readable({
-        read() {
-          this.push(Buffer.from(bodyStr, "utf8"));
-          this.push(null);
-        },
-      }) as IncomingMessage;
+    // Replay: create a synthetic readable that re-emits the buffered body
+    const { Readable } = await import("node:stream");
+    const syntheticReq = new Readable({
+      read() {
+        this.push(Buffer.from(bodyStr, "utf8"));
+        this.push(null);
+      },
+    }) as IncomingMessage;
 
-      // Copy necessary IncomingMessage properties
-      syntheticReq.method = req.method;
-      syntheticReq.url = req.url;
-      syntheticReq.headers = req.headers;
+    // Copy necessary IncomingMessage properties
+    syntheticReq.method = req.method;
+    syntheticReq.url = req.url;
+    syntheticReq.headers = req.headers;
 
-      await matchedHandler(syntheticReq, res);
-    },
-  });
+    await matchedHandler(syntheticReq, res);
+  };
 
-  api.logger.info?.(`mattermost: registered slash command callback at ${callbackPath}`);
+  for (const callbackPath of callbackPaths) {
+    api.registerHttpRoute({
+      path: callbackPath,
+      handler: routeHandler,
+    });
+    api.logger.info?.(`mattermost: registered slash command callback at ${callbackPath}`);
+  }
 }

--- a/extensions/mattermost/src/types.ts
+++ b/extensions/mattermost/src/types.ts
@@ -44,6 +44,17 @@ export type MattermostAccountConfig = {
   blockStreamingCoalesce?: BlockStreamingCoalesceConfig;
   /** Outbound response prefix override for this channel/account. */
   responsePrefix?: string;
+  /** Native slash command configuration. */
+  commands?: {
+    /** Enable native slash commands. "auto" resolves to false (opt-in). */
+    native?: boolean | "auto";
+    /** Also register skill-based commands. */
+    nativeSkills?: boolean | "auto";
+    /** Path for the callback endpoint on the gateway HTTP server. */
+    callbackPath?: string;
+    /** Explicit callback URL (e.g. behind reverse proxy). */
+    callbackUrl?: string;
+  };
 };
 
 export type MattermostConfig = {

--- a/src/auto-reply/command-auth.ts
+++ b/src/auto-reply/command-auth.ts
@@ -150,7 +150,9 @@ function resolveCommandsAllowFromList(params: {
 
   const rawList = Array.isArray(providerList) ? providerList : globalList;
   if (!Array.isArray(rawList)) {
-    return null; // No applicable list found
+    // commands.allowFrom is configured, but there's no provider-specific list and no "*".
+    // Treat as an explicit deny for this provider (override semantics).
+    return [];
   }
 
   return formatAllowFromList({

--- a/src/auto-reply/command-control.test.ts
+++ b/src/auto-reply/command-control.test.ts
@@ -340,6 +340,33 @@ describe("resolveCommandAuthorization", () => {
       expect(whatsappAuth.isAuthorizedSender).toBe(true);
     });
 
+    it("denies providers not present in commands.allowFrom when no wildcard is set", () => {
+      const cfg = {
+        commands: {
+          allowFrom: {
+            signal: ["user123"],
+          },
+        },
+        // Channel allowFrom would normally allow, but commands.allowFrom should override.
+        channels: { whatsapp: { allowFrom: ["*"] } },
+      } as OpenClawConfig;
+
+      const ctx = {
+        Provider: "whatsapp",
+        Surface: "whatsapp",
+        From: "whatsapp:anyuser",
+        SenderId: "anyuser",
+      } as MsgContext;
+
+      const auth = resolveCommandAuthorization({
+        ctx,
+        cfg,
+        commandAuthorized: true,
+      });
+
+      expect(auth.isAuthorizedSender).toBe(false);
+    });
+
     it("falls back to channel allowFrom when commands.allowFrom not set", () => {
       const cfg = {
         channels: { whatsapp: { allowFrom: ["+15551234567"] } },

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -352,7 +352,8 @@ export function createGatewayHttpServer(opts: {
         // Channel HTTP endpoints are gateway-auth protected by default.
         // Non-channel plugin routes remain plugin-owned and must enforce
         // their own auth when exposing sensitive functionality.
-        if (requestPath.startsWith("/api/channels/")) {
+        const isMattermostSlashCommandCallback = requestPath === "/api/channels/mattermost/command";
+        if (requestPath.startsWith("/api/channels/") && !isMattermostSlashCommandCallback) {
           const token = getBearerToken(req);
           const authResult = await authorizeGatewayConnect({
             auth: resolvedAuth,

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -352,7 +352,50 @@ export function createGatewayHttpServer(opts: {
         // Channel HTTP endpoints are gateway-auth protected by default.
         // Non-channel plugin routes remain plugin-owned and must enforce
         // their own auth when exposing sensitive functionality.
-        const isMattermostSlashCommandCallback = requestPath === "/api/channels/mattermost/command";
+        const mattermostCallbackPaths = new Set<string>();
+        const defaultMmCallbackPath = "/api/channels/mattermost/command";
+
+        const normalizeCallbackPath = (value: unknown): string => {
+          const trimmed = typeof value === "string" ? value.trim() : "";
+          if (!trimmed) {
+            return defaultMmCallbackPath;
+          }
+          return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+        };
+
+        const tryAddCallbackUrlPath = (rawUrl: unknown) => {
+          if (typeof rawUrl !== "string") {
+            return;
+          }
+          const trimmed = rawUrl.trim();
+          if (!trimmed) {
+            return;
+          }
+          try {
+            const pathname = new URL(trimmed).pathname;
+            if (pathname) {
+              mattermostCallbackPaths.add(pathname);
+            }
+          } catch {
+            // ignore
+          }
+        };
+
+        const mmRaw = configSnapshot.channels?.mattermost as Record<string, unknown> | undefined;
+        const addMmCommands = (raw: unknown) => {
+          const commands = raw as Record<string, unknown> | undefined;
+          mattermostCallbackPaths.add(normalizeCallbackPath(commands?.callbackPath));
+          tryAddCallbackUrlPath(commands?.callbackUrl);
+        };
+
+        addMmCommands(mmRaw?.commands);
+        const accountsRaw = (mmRaw?.accounts ?? {}) as Record<string, unknown>;
+        for (const accountId of Object.keys(accountsRaw)) {
+          const accountCfg = accountsRaw[accountId] as Record<string, unknown> | undefined;
+          addMmCommands(accountCfg?.commands);
+        }
+
+        const isMattermostSlashCommandCallback = mattermostCallbackPaths.has(requestPath);
         if (requestPath.startsWith("/api/channels/") && !isMattermostSlashCommandCallback) {
           const token = getBearerToken(req);
           const authResult = await authorizeGatewayConnect({

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -383,7 +383,10 @@ export function createGatewayHttpServer(opts: {
 
         const mmRaw = configSnapshot.channels?.mattermost as Record<string, unknown> | undefined;
         const addMmCommands = (raw: unknown) => {
-          const commands = raw as Record<string, unknown> | undefined;
+          if (raw == null || typeof raw !== "object") {
+            return;
+          }
+          const commands = raw as Record<string, unknown>;
           mattermostCallbackPaths.add(normalizeCallbackPath(commands?.callbackPath));
           tryAddCallbackUrlPath(commands?.callbackUrl);
         };

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -265,6 +265,8 @@ export type {
 } from "../infra/diagnostic-events.js";
 export { detectMime, extensionForMime, getFileExtension } from "../media/mime.js";
 export { extractOriginalFilename } from "../media/store.js";
+export { listSkillCommandsForAgents } from "../auto-reply/skill-commands.js";
+export type { SkillCommandSpec } from "../agents/skills.js";
 
 // Channel: Discord
 export {


### PR DESCRIPTION
## What
Adds **opt-in native Mattermost slash command support** to OpenClaw, including command registration, callback handling, and account-aware routing.

## Why
Mattermost users need first-class slash commands (e.g. `/oc_status`) without relying on external bridges. This keeps UX consistent with other channels while preserving fail-closed auth/token checks.

## Scope
Single theme PR: Mattermost native slash-command support + related hardening needed to safely ship it (auth bypass precision, command registration cleanup, callback URL handling, and labeler fallback robustness required for CI/backfill in this workflow).

## Validation
- ✅ `pnpm build`
- ✅ `pnpm check`
- 🔄 `pnpm test` (full suite in progress during maintainer sweep; no failures observed so far in this run)
- Plus targeted lint/tests were run on touched files during prior review iterations.

## AI assistance transparency
This PR was **heavily assisted by LLMs**.


Closes #16515.

---
Previous context from fork: https://github.com/0mg-cc/openclaw/pull/10

<!-- greptile_comment -->
<h3>Greptile Summary</h3>

This PR adds opt-in native Mattermost slash command support, enabling OpenClaw to register custom slash commands (e.g., `/oc_status`, `/oc_model`) via the Mattermost REST API and handle incoming command callbacks through an HTTP endpoint on the gateway.

<sub>Last reviewed commit: f1c9f43</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->


