### PR TITLE
fix(doctor): skip memorySearch provider warning when memory backend is qmd

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -628,6 +628,22 @@ openclaw message send --channel telegram --target 123456789 --message "hi"
 openclaw message send --channel telegram --target @name --message "hi"
 ```
 
+    CLI poll send (Telegram):
+
+```bash
+openclaw message poll --channel telegram --target 123456789 \
+  --poll-question "Deploy tonight?" \
+  --poll-option "Yes" --poll-option "No" \
+  --poll-duration-seconds 300 \
+  --poll-anonymous --silent
+```
+
+    Poll constraints (Telegram):
+
+    - `--poll-option` supports 2-12 options
+    - `--poll-duration-seconds` supports 5-600
+    - use `--poll-public` to make the poll non-anonymous
+
   </Accordion>
 </AccordionGroup>
 

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -640,7 +640,7 @@ openclaw message poll --channel telegram --target 123456789 \
 
     Poll constraints (Telegram):
 
-    - `--poll-option` supports 2-12 options
+    - `--poll-option` supports 2-10 options
     - `--poll-duration-seconds` supports 5-600
     - use `--poll-public` to make the poll non-anonymous
 

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -628,22 +628,6 @@ openclaw message send --channel telegram --target 123456789 --message "hi"
 openclaw message send --channel telegram --target @name --message "hi"
 ```
 
-    CLI poll send (Telegram):
-
-```bash
-openclaw message poll --channel telegram --target 123456789 \
-  --poll-question "Deploy tonight?" \
-  --poll-option "Yes" --poll-option "No" \
-  --poll-duration-seconds 300 \
-  --poll-anonymous --silent
-```
-
-    Poll constraints (Telegram):
-
-    - `--poll-option` supports 2-10 options
-    - `--poll-duration-seconds` supports 5-600
-    - use `--poll-public` to make the poll non-anonymous
-
   </Accordion>
 </AccordionGroup>
 

--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -84,4 +84,19 @@ describe("noteMemorySearchHealth", () => {
     });
     expect(note).not.toHaveBeenCalled();
   });
+
+  it("skips embedding-provider warnings when memory backend is qmd", async () => {
+    const qmdCfg = {
+      memory: {
+        backend: "qmd",
+        qmd: {},
+      },
+    } as OpenClawConfig;
+
+    await noteMemorySearchHealth(qmdCfg);
+
+    expect(note).not.toHaveBeenCalled();
+    expect(resolveDefaultAgentId).not.toHaveBeenCalled();
+    expect(resolveMemorySearchConfig).not.toHaveBeenCalled();
+  });
 });

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -12,6 +12,12 @@ import { resolveUserPath } from "../utils.js";
  * Runs as part of `openclaw doctor` — config-only, no network calls.
  */
 export async function noteMemorySearchHealth(cfg: OpenClawConfig): Promise<void> {
+  // QMD backend manages retrieval/indexing independently and does not require
+  // OpenClaw memorySearch embedding providers.
+  if (cfg.memory?.backend === "qmd") {
+    return;
+  }
+
   const agentId = resolveDefaultAgentId(cfg);
   const agentDir = resolveAgentDir(cfg, agentId);
   const resolved = resolveMemorySearchConfig(cfg, agentId);


### PR DESCRIPTION
## Summary
- return early from doctor memory-search health checks when `memory.backend = "qmd"`
- avoids false warning about missing embedding provider in QMD-only setups
- add unit test coverage for the qmd backend path

## Validation
- `pnpm vitest src/commands/doctor-memory-search.test.ts` (4/4 passing)
- `pnpm build` succeeds
- manual repro: with qmd backend config, patched build no longer emits memory-search embedding warning

Closes #17263

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an early return in `noteMemorySearchHealth` when `memory.backend` is `"qmd"`, preventing false warnings about missing embedding providers in QMD-only setups. QMD manages its own retrieval and indexing independently of OpenClaw's built-in embedding pipeline, so the doctor check is not applicable.

- Early return added in `doctor-memory-search.ts` before any agent/config resolution when backend is `"qmd"`
- New unit test verifies the QMD path exits early without calling downstream resolvers or emitting notes
- Change is consistent with the existing backend handling in `backend-config.ts` which already distinguishes QMD from builtin

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — minimal, well-scoped change with proper test coverage.
- The change is a 3-line early return guard with a single new test. It correctly uses the typed config schema, is consistent with existing QMD handling elsewhere in the codebase, and has no side effects. No logic errors, no security concerns, and the test properly validates the early exit path.
- No files require special attention.

<sub>Last reviewed commit: 31ace25</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->