### PR TITLE
feat: add AI PR triage GitHub Action for duplicate detection

### DIFF
--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           sparse-checkout: |
             scripts/pr-triage.mjs
+            scripts/pr-triage-github.mjs
             CONTRIBUTING.md
           sparse-checkout-cone-mode: false
 

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -1,0 +1,42 @@
+name: PR Triage
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Triage a specific PR number (0 = latest)"
+        required: false
+        default: "0"
+
+permissions: {}
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            scripts/pr-triage.mjs
+            CONTRIBUTING.md
+          sparse-checkout-cone-mode: false
+
+      - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        id: app-token
+        with:
+          app-id: "2729701"
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
+      - name: Triage PR
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr_number || '0' }}
+          REPO: ${{ github.repository }}
+        run: node scripts/pr-triage.mjs

--- a/scripts/pr-triage-github.mjs
+++ b/scripts/pr-triage-github.mjs
@@ -1,0 +1,135 @@
+/**
+ * GitHub API helpers for PR triage.
+ * Handles data fetching, pagination, and PR summary generation.
+ */
+
+const GITHUB_API = "https://api.github.com";
+
+export function createGitHubClient(token) {
+  async function gh(path, opts = {}) {
+    const url = path.startsWith("http") ? path : `${GITHUB_API}${path}`;
+    const res = await fetch(url, {
+      headers: {
+        Authorization: `token ${token}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        ...opts.headers,
+      },
+      ...opts,
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      throw new Error(`GitHub API ${res.status}: ${path} — ${body.slice(0, 200)}`);
+    }
+    return res.json();
+  }
+
+  async function ghPaginate(path, maxItems = 100) {
+    const items = [];
+    let page = 1;
+    while (items.length < maxItems) {
+      const perPage = Math.min(100, maxItems - items.length);
+      const sep = path.includes("?") ? "&" : "?";
+      const data = await gh(`${path}${sep}per_page=${perPage}&page=${page}`);
+      if (!Array.isArray(data) || data.length === 0) { break; }
+      items.push(...data);
+      if (data.length < perPage) { break; }
+      page++;
+    }
+    return items;
+  }
+
+  return { gh, ghPaginate };
+}
+
+export function extractIssueRefs(text) {
+  if (!text) { return []; }
+  const matches = text.match(/#(\d{3,6})/g) || [];
+  return [...new Set(matches)];
+}
+
+export function computeFileOverlap(filesA, filesB) {
+  if (!filesA.length || !filesB.length) { return 0; }
+  const setA = new Set(filesA);
+  const intersection = filesB.filter((f) => setA.has(f));
+  const union = new Set([...filesA, ...filesB]);
+  return intersection.length / union.size;
+}
+
+function summarizePR(pr) {
+  const issueRefs = extractIssueRefs(pr.title + " " + (pr.body || ""));
+  return [
+    `#${pr.number}: ${pr.title}`,
+    `  author:${pr.user?.login || pr.author} +${pr.additions}/-${pr.deletions} ${pr.changed_files ?? pr.files?.length ?? "?"} files`,
+    pr.files?.length
+      ? `  files: ${pr.files.slice(0, 8).join(", ")}${pr.files.length > 8 ? ` (+${pr.files.length - 8} more)` : ""}`
+      : "",
+    issueRefs.length ? `  refs: ${issueRefs.join(", ")}` : "",
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+export async function getTargetPR(gh, repo, prNumber, maxDiffChars, token) {
+  const pr = await gh(`/repos/${repo}/pulls/${prNumber}`);
+  let diff = "";
+  try {
+    const res = await fetch(`${GITHUB_API}/repos/${repo}/pulls/${prNumber}`, {
+      headers: {
+        Authorization: `token ${token}`,
+        Accept: "application/vnd.github.v3.diff",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    });
+    if (res.ok) {
+      diff = await res.text();
+      if (diff.length > maxDiffChars) {
+        diff = diff.slice(0, maxDiffChars) + "\n... (truncated)";
+      }
+    }
+  } catch {}
+
+  const files = await gh(`/repos/${repo}/pulls/${prNumber}/files?per_page=100`);
+  return {
+    number: pr.number,
+    title: pr.title,
+    body: (pr.body || "").slice(0, 2000),
+    author: pr.user?.login,
+    branch: pr.head?.ref,
+    additions: pr.additions,
+    deletions: pr.deletions,
+    changed_files: pr.changed_files,
+    created_at: pr.created_at,
+    files: files.map((f) => f.filename),
+    diff,
+  };
+}
+
+export async function getOpenPRSummaries(gh, ghPaginate, repo, maxOpenPRs) {
+  const prs = await ghPaginate(`/repos/${repo}/pulls?state=open&sort=created&direction=desc`, maxOpenPRs);
+  const summaries = [];
+  for (const pr of prs) {
+    let files = [];
+    try {
+      files = (await gh(`/repos/${repo}/pulls/${pr.number}/files?per_page=30`)).map((f) => f.filename);
+    } catch {}
+    summaries.push(summarizePR({ ...pr, author: pr.user?.login, files }));
+  }
+  return summaries;
+}
+
+export async function getRecentDecisions(ghPaginate, repo, maxHistory) {
+  const merged = await ghPaginate(
+    `/repos/${repo}/pulls?state=closed&sort=updated&direction=desc`,
+    maxHistory * 2,
+  );
+  const mergedPRs = merged
+    .filter((pr) => pr.merged_at)
+    .slice(0, maxHistory)
+    .map((pr) => `MERGED #${pr.number}: ${pr.title} (by ${pr.user?.login}, +${pr.additions}/-${pr.deletions})`);
+  const rejectedPRs = merged
+    .filter((pr) => !pr.merged_at)
+    .slice(0, maxHistory)
+    .map((pr) => `CLOSED #${pr.number}: ${pr.title} (by ${pr.user?.login}, +${pr.additions}/-${pr.deletions})`);
+  return { mergedPRs, rejectedPRs };
+}

--- a/scripts/pr-triage.mjs
+++ b/scripts/pr-triage.mjs
@@ -1,0 +1,547 @@
+#!/usr/bin/env node
+/**
+ * PR Triage — AI-powered duplicate detection and categorization.
+ *
+ * Single Claude Haiku call per PR with cached context of all open PRs
+ * and recent merge/close decisions. Outputs silent labels only — no
+ * public bot comments (political risk: matplotlib/crabby-rathbun Feb 2026).
+ *
+ * Cost: ~$0.005/call with prompt caching. ~$15-20/month at 50 PRs/day.
+ */
+
+const REPO = process.env.REPO;
+const PR_NUMBER = Number(process.env.PR_NUMBER) || 0;
+const ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY;
+const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+
+if (!ANTHROPIC_API_KEY) {
+  console.error("ANTHROPIC_API_KEY is required");
+  process.exit(1);
+}
+if (!GITHUB_TOKEN) {
+  console.error("GITHUB_TOKEN is required");
+  process.exit(1);
+}
+
+const GITHUB_API = "https://api.github.com";
+const ANTHROPIC_API = "https://api.anthropic.com/v1/messages";
+const MODEL = "claude-haiku-4-5-20251001";
+const MAX_OPEN_PRS = 200;
+const MAX_HISTORY = 50;
+const MAX_DIFF_CHARS = 4000;
+
+// ---------------------------------------------------------------------------
+// GitHub helpers
+// ---------------------------------------------------------------------------
+
+async function gh(path, opts = {}) {
+  const url = path.startsWith("http") ? path : `${GITHUB_API}${path}`;
+  const res = await fetch(url, {
+    headers: {
+      Authorization: `token ${GITHUB_TOKEN}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      ...opts.headers,
+    },
+    ...opts,
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`GitHub API ${res.status}: ${path} — ${body.slice(0, 200)}`);
+  }
+  return res.json();
+}
+
+async function ghPaginate(path, maxItems = 100) {
+  const items = [];
+  let page = 1;
+  while (items.length < maxItems) {
+    const perPage = Math.min(100, maxItems - items.length);
+    const sep = path.includes("?") ? "&" : "?";
+    const data = await gh(`${path}${sep}per_page=${perPage}&page=${page}`);
+    if (!Array.isArray(data) || data.length === 0) break;
+    items.push(...data);
+    if (data.length < perPage) break;
+    page++;
+  }
+  return items;
+}
+
+// ---------------------------------------------------------------------------
+// Data collection
+// ---------------------------------------------------------------------------
+
+async function getTargetPR(prNumber) {
+  const pr = await gh(`/repos/${REPO}/pulls/${prNumber}`);
+  let diff = "";
+  try {
+    const res = await fetch(`${GITHUB_API}/repos/${REPO}/pulls/${prNumber}`, {
+      headers: {
+        Authorization: `token ${GITHUB_TOKEN}`,
+        Accept: "application/vnd.github.v3.diff",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    });
+    if (res.ok) {
+      diff = await res.text();
+      if (diff.length > MAX_DIFF_CHARS) {
+        diff = diff.slice(0, MAX_DIFF_CHARS) + "\n... (truncated)";
+      }
+    }
+  } catch {}
+
+  const files = await gh(`/repos/${REPO}/pulls/${prNumber}/files?per_page=100`);
+  return {
+    number: pr.number,
+    title: pr.title,
+    body: (pr.body || "").slice(0, 2000),
+    author: pr.user?.login,
+    branch: pr.head?.ref,
+    additions: pr.additions,
+    deletions: pr.deletions,
+    changed_files: pr.changed_files,
+    created_at: pr.created_at,
+    files: files.map((f) => f.filename),
+    diff,
+  };
+}
+
+function summarizePR(pr) {
+  const issueRefs = extractIssueRefs(pr.title + " " + (pr.body || ""));
+  return [
+    `#${pr.number}: ${pr.title}`,
+    `  author:${pr.user?.login || pr.author} +${pr.additions}/-${pr.deletions} ${pr.changed_files ?? pr.files?.length ?? "?"} files`,
+    pr.files?.length
+      ? `  files: ${pr.files.slice(0, 8).join(", ")}${pr.files.length > 8 ? ` (+${pr.files.length - 8} more)` : ""}`
+      : "",
+    issueRefs.length ? `  refs: ${issueRefs.join(", ")}` : "",
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+async function getOpenPRSummaries() {
+  const prs = await ghPaginate(`/repos/${REPO}/pulls?state=open&sort=created&direction=desc`, MAX_OPEN_PRS);
+  const summaries = [];
+  for (const pr of prs) {
+    let files = [];
+    try {
+      files = (await gh(`/repos/${REPO}/pulls/${pr.number}/files?per_page=30`)).map((f) => f.filename);
+    } catch {}
+    summaries.push(
+      summarizePR({
+        ...pr,
+        author: pr.user?.login,
+        files,
+      }),
+    );
+  }
+  return summaries;
+}
+
+async function getRecentDecisions() {
+  // Last N merged PRs
+  const merged = await ghPaginate(
+    `/repos/${REPO}/pulls?state=closed&sort=updated&direction=desc`,
+    MAX_HISTORY * 2,
+  );
+
+  const mergedPRs = merged
+    .filter((pr) => pr.merged_at)
+    .slice(0, MAX_HISTORY)
+    .map((pr) => `MERGED #${pr.number}: ${pr.title} (by ${pr.user?.login}, +${pr.additions}/-${pr.deletions})`);
+
+  const rejectedPRs = merged
+    .filter((pr) => !pr.merged_at)
+    .slice(0, MAX_HISTORY)
+    .map((pr) => `CLOSED #${pr.number}: ${pr.title} (by ${pr.user?.login}, +${pr.additions}/-${pr.deletions})`);
+
+  return { mergedPRs, rejectedPRs };
+}
+
+// ---------------------------------------------------------------------------
+// Issue reference extraction
+// ---------------------------------------------------------------------------
+
+function extractIssueRefs(text) {
+  if (!text) return [];
+  const matches = text.match(/#(\d{3,6})/g) || [];
+  return [...new Set(matches)];
+}
+
+function computeFileOverlap(filesA, filesB) {
+  if (!filesA.length || !filesB.length) return 0;
+  const setA = new Set(filesA);
+  const intersection = filesB.filter((f) => setA.has(f));
+  const union = new Set([...filesA, ...filesB]);
+  return intersection.length / union.size; // Jaccard
+}
+
+// ---------------------------------------------------------------------------
+// Deterministic pre-enrichment
+// ---------------------------------------------------------------------------
+
+function deterministicSignals(targetPR, openPRSummaries) {
+  const targetRefs = extractIssueRefs(targetPR.title + " " + targetPR.body);
+  const targetFiles = targetPR.files || [];
+
+  const signals = [];
+
+  // Parse open PR summaries back into structured data for comparison
+  for (const summary of openPRSummaries) {
+    const numMatch = summary.match(/^#(\d+):/);
+    if (!numMatch) continue;
+    const num = Number(numMatch[1]);
+    if (num === targetPR.number) continue;
+
+    const refsMatch = summary.match(/refs: (.+)/);
+    const prRefs = refsMatch ? refsMatch[1].split(", ") : [];
+    const filesMatch = summary.match(/files: (.+)/);
+    const prFiles = filesMatch
+      ? filesMatch[1]
+          .replace(/ \(\+\d+ more\)/, "")
+          .split(", ")
+      : [];
+
+    // Shared issue references
+    const sharedRefs = targetRefs.filter((r) => prRefs.includes(r));
+
+    // File overlap
+    const jaccard = computeFileOverlap(targetFiles, prFiles);
+
+    if (sharedRefs.length > 0 || jaccard > 0.3) {
+      signals.push({
+        pr: num,
+        sharedRefs,
+        jaccard: Math.round(jaccard * 100) / 100,
+        summary: summary.split("\n")[0],
+      });
+    }
+  }
+
+  return signals;
+}
+
+// ---------------------------------------------------------------------------
+// LLM triage call
+// ---------------------------------------------------------------------------
+
+async function triagePR(targetPR, openPRSummaries, decisions, deterministicHints) {
+  const contributingMd = await loadContributing();
+
+  const systemPrompt = `You are an AI PR triage assistant for the ${REPO} open-source project.
+Your job: analyze the NEW PR below and detect duplicates, overlaps, and categorize it.
+
+## All Open PRs (${openPRSummaries.length} total)
+${openPRSummaries.join("\n\n")}
+
+## Recent Maintainer Decisions (implicit preferences — learn from these)
+### Merged (approved):
+${decisions.mergedPRs.slice(0, 25).join("\n")}
+
+### Closed without merge (rejected):
+${decisions.rejectedPRs.slice(0, 25).join("\n")}
+
+## Project Focus (from CONTRIBUTING.md)
+${contributingMd}
+
+## Rules
+- Compare the NEW PR against ALL open PRs above
+- Detect: exact duplicates, partial overlaps, related work, superset/subset relationships
+- Categorize: bug, feature, refactor, test, docs, chore
+- Assess quality signals: size appropriateness, test inclusion, focused scope
+- Learn from the merged/closed decisions above — what does this maintainer value?
+- Be conservative: only flag duplicates at HIGH confidence
+- Output valid JSON only, no markdown fences`;
+
+  const deterministicContext =
+    deterministicHints.length > 0
+      ? `\n\nDeterministic pre-analysis found these potential overlaps:\n${deterministicHints.map((h) => `- PR #${h.pr}: shared refs=${h.sharedRefs.join(",") || "none"}, file overlap=${h.jaccard}`).join("\n")}`
+      : "";
+
+  const userPrompt = `## NEW PR to triage
+
+Title: ${targetPR.title}
+Author: ${targetPR.author}
+Branch: ${targetPR.branch}
+Size: +${targetPR.additions}/-${targetPR.deletions}, ${targetPR.changed_files} files changed
+Created: ${targetPR.created_at}
+Files: ${targetPR.files.join(", ")}
+
+Description:
+${targetPR.body || "(no description)"}
+
+Diff (excerpt):
+${targetPR.diff || "(diff unavailable)"}
+${deterministicContext}
+
+Respond with a single JSON object:
+{
+  "duplicate_of": [list of PR numbers this is a duplicate of, or empty],
+  "related_to": [list of PR numbers this is related to but not duplicate, or empty],
+  "category": "bug" | "feature" | "refactor" | "test" | "docs" | "chore",
+  "confidence": "high" | "medium" | "low",
+  "quality_signals": {
+    "focused_scope": true/false,
+    "has_tests": true/false,
+    "appropriate_size": true/false,
+    "references_issue": true/false
+  },
+  "suggested_action": "needs-review" | "likely-duplicate" | "needs-discussion" | "auto-label-only",
+  "reasoning": "one sentence explaining the triage decision"
+}`;
+
+  const res = await fetch(ANTHROPIC_API, {
+    method: "POST",
+    headers: {
+      "x-api-key": ANTHROPIC_API_KEY,
+      "anthropic-version": "2023-06-01",
+      "content-type": "application/json",
+      "anthropic-beta": "prompt-caching-2024-07-31",
+    },
+    body: JSON.stringify({
+      model: MODEL,
+      max_tokens: 1024,
+      system: [
+        {
+          type: "text",
+          text: systemPrompt,
+          cache_control: { type: "ephemeral" },
+        },
+      ],
+      messages: [{ role: "user", content: userPrompt }],
+    }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Anthropic API ${res.status}: ${body.slice(0, 300)}`);
+  }
+
+  const data = await res.json();
+  const text = data.content?.[0]?.text || "";
+
+  // Parse JSON from response (handle potential markdown fences)
+  const jsonStr = text.replace(/^```json?\n?/, "").replace(/\n?```$/, "").trim();
+  try {
+    return JSON.parse(jsonStr);
+  } catch {
+    console.error("Failed to parse LLM response:", text.slice(0, 500));
+    return null;
+  }
+}
+
+async function loadContributing() {
+  try {
+    const { readFile } = await import("node:fs/promises");
+    const content = await readFile("CONTRIBUTING.md", "utf-8");
+    // Extract just the focus/roadmap section
+    const focusMatch = content.match(/## Current Focus.*?\n([\s\S]*?)(?=\n## |$)/);
+    return focusMatch ? focusMatch[1].trim() : content.slice(0, 1000);
+  } catch {
+    return "Priorities: Stability, UX, Skills (ClawHub), Performance";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Label application
+// ---------------------------------------------------------------------------
+
+const CATEGORY_LABELS = {
+  bug: "auto:bug",
+  feature: "auto:feature",
+  refactor: "auto:refactor",
+  test: "auto:test",
+  docs: "auto:docs",
+  chore: "auto:chore",
+};
+
+const TRIAGE_LABEL_COLOR = "c2e0c6";
+const CATEGORY_LABEL_COLOR = "d4c5f9";
+const OVERLAP_LABEL_COLOR = "fbca04";
+
+async function ensureLabel(name, color) {
+  try {
+    await gh(`/repos/${REPO}/labels/${encodeURIComponent(name)}`);
+  } catch {
+    try {
+      await gh(`/repos/${REPO}/labels`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name, color }),
+      });
+    } catch {}
+  }
+}
+
+async function applyLabels(prNumber, triage) {
+  if (!triage) return;
+
+  const labels = [];
+
+  // Category label
+  const catLabel = CATEGORY_LABELS[triage.category];
+  if (catLabel) {
+    await ensureLabel(catLabel, CATEGORY_LABEL_COLOR);
+    labels.push(catLabel);
+  }
+
+  // Duplicate/overlap labels — only at high confidence
+  if (triage.confidence === "high" && triage.duplicate_of?.length > 0) {
+    const label = "possible-overlap";
+    await ensureLabel(label, OVERLAP_LABEL_COLOR);
+    labels.push(label);
+
+    // Add cluster labels for each referenced issue
+    for (const dupNum of triage.duplicate_of) {
+      const clusterLabel = `cluster:#${dupNum}`;
+      await ensureLabel(clusterLabel, OVERLAP_LABEL_COLOR);
+      labels.push(clusterLabel);
+    }
+  }
+
+  // Triage action label
+  if (triage.suggested_action === "likely-duplicate") {
+    await ensureLabel("triage:likely-duplicate", OVERLAP_LABEL_COLOR);
+    labels.push("triage:likely-duplicate");
+  } else if (triage.suggested_action === "needs-discussion") {
+    await ensureLabel("triage:needs-discussion", TRIAGE_LABEL_COLOR);
+    labels.push("triage:needs-discussion");
+  }
+
+  // Quality signal labels
+  if (triage.quality_signals) {
+    if (!triage.quality_signals.references_issue) {
+      await ensureLabel("triage:no-issue-ref", TRIAGE_LABEL_COLOR);
+      labels.push("triage:no-issue-ref");
+    }
+    if (!triage.quality_signals.has_tests && triage.category !== "docs") {
+      await ensureLabel("triage:no-tests", TRIAGE_LABEL_COLOR);
+      labels.push("triage:no-tests");
+    }
+  }
+
+  if (labels.length > 0) {
+    await gh(`/repos/${REPO}/issues/${prNumber}/labels`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ labels }),
+    });
+    console.log(`Applied labels to #${prNumber}: ${labels.join(", ")}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Summary output (GitHub Actions step summary)
+// ---------------------------------------------------------------------------
+
+function writeSummary(prNumber, triage, deterministicHints) {
+  if (!triage) return;
+
+  const lines = [
+    `## PR #${prNumber} Triage`,
+    "",
+    `**Category:** ${triage.category} | **Confidence:** ${triage.confidence} | **Action:** ${triage.suggested_action}`,
+    "",
+    `**Reasoning:** ${triage.reasoning}`,
+    "",
+  ];
+
+  if (triage.duplicate_of?.length > 0) {
+    lines.push(`**Possible duplicates:** ${triage.duplicate_of.map((n) => `#${n}`).join(", ")}`);
+  }
+  if (triage.related_to?.length > 0) {
+    lines.push(`**Related PRs:** ${triage.related_to.map((n) => `#${n}`).join(", ")}`);
+  }
+
+  if (deterministicHints.length > 0) {
+    lines.push("", "**Deterministic signals:**");
+    for (const h of deterministicHints) {
+      lines.push(`- #${h.pr}: refs=${h.sharedRefs.join(",") || "none"}, file overlap=${h.jaccard}`);
+    }
+  }
+
+  const qs = triage.quality_signals || {};
+  lines.push(
+    "",
+    "**Quality:**",
+    `- Focused scope: ${qs.focused_scope ? "yes" : "no"}`,
+    `- Has tests: ${qs.has_tests ? "yes" : "no"}`,
+    `- Appropriate size: ${qs.appropriate_size ? "yes" : "no"}`,
+    `- References issue: ${qs.references_issue ? "yes" : "no"}`,
+  );
+
+  const summary = lines.join("\n");
+  console.log(summary);
+
+  // Write to GitHub Actions step summary if available
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    const { writeFileSync, appendFileSync } = require("node:fs");
+    try {
+      appendFileSync(process.env.GITHUB_STEP_SUMMARY, summary + "\n");
+    } catch {}
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const prNumber = PR_NUMBER || 0;
+  if (!prNumber) {
+    console.error("No PR number provided (set PR_NUMBER env var)");
+    process.exit(1);
+  }
+
+  console.log(`Triaging PR #${prNumber} on ${REPO}...`);
+
+  // 1. Fetch target PR details
+  console.log("Fetching target PR...");
+  const targetPR = await getTargetPR(prNumber);
+  console.log(`Target: "${targetPR.title}" by ${targetPR.author}, ${targetPR.files.length} files`);
+
+  // 2. Fetch all open PR summaries (cached in LLM system prompt)
+  console.log("Fetching open PRs for context...");
+  const openPRSummaries = await getOpenPRSummaries();
+  console.log(`Loaded ${openPRSummaries.length} open PRs as context`);
+
+  // 3. Fetch recent merge/close decisions (implicit preferences)
+  console.log("Fetching recent decisions...");
+  const decisions = await getRecentDecisions();
+  console.log(`Loaded ${decisions.mergedPRs.length} merged + ${decisions.rejectedPRs.length} rejected PRs`);
+
+  // 4. Run deterministic pre-analysis
+  const deterministicHints = deterministicSignals(targetPR, openPRSummaries);
+  if (deterministicHints.length > 0) {
+    console.log(`Deterministic: found ${deterministicHints.length} potential overlaps`);
+  }
+
+  // 5. Single LLM call with cached context
+  console.log("Calling Claude Haiku for triage...");
+  const triage = await triagePR(targetPR, openPRSummaries, decisions, deterministicHints);
+
+  if (!triage) {
+    console.error("LLM triage failed — no valid response");
+    process.exit(1);
+  }
+
+  console.log(`Result: ${triage.category} | ${triage.confidence} | ${triage.suggested_action}`);
+  if (triage.duplicate_of?.length) {
+    console.log(`Duplicates: ${triage.duplicate_of.map((n) => `#${n}`).join(", ")}`);
+  }
+
+  // 6. Apply labels (silent — no public comments)
+  console.log("Applying labels...");
+  await applyLabels(prNumber, triage);
+
+  // 7. Write summary (visible only in Actions run log)
+  writeSummary(prNumber, triage, deterministicHints);
+
+  console.log("Done.");
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err.message);
+  process.exit(1);
+});

--- a/scripts/pr-triage.mjs
+++ b/scripts/pr-triage.mjs
@@ -11,6 +11,15 @@
  */
 
 import { appendFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import {
+  createGitHubClient,
+  extractIssueRefs,
+  computeFileOverlap,
+  getTargetPR,
+  getOpenPRSummaries,
+  getRecentDecisions,
+} from "./pr-triage-github.mjs";
 
 const REPO = process.env.REPO;
 const PR_NUMBER = Number(process.env.PR_NUMBER) || 0;
@@ -26,179 +35,28 @@ if (!GITHUB_TOKEN) {
   process.exit(1);
 }
 
-const GITHUB_API = "https://api.github.com";
 const ANTHROPIC_API = "https://api.anthropic.com/v1/messages";
 const MODEL = process.env.TRIAGE_MODEL || "claude-opus-4-6";
 const MAX_OPEN_PRS = Number(process.env.MAX_OPEN_PRS) || 500;
 const MAX_HISTORY = Number(process.env.MAX_HISTORY) || 100;
 const MAX_DIFF_CHARS = Number(process.env.MAX_DIFF_CHARS) || 8000;
 
-// Cost tracking (per 1M tokens, as of Feb 2026)
 const PRICING = {
-  "claude-opus-4-6":          { input: 15.00, cache_read: 1.50, output: 75.00 },
+  "claude-opus-4-6":            { input: 15.00, cache_read: 1.50, output: 75.00 },
   "claude-sonnet-4-5-20250929": { input: 3.00, cache_read: 0.30, output: 15.00 },
   "claude-haiku-4-5-20251001":  { input: 1.00, cache_read: 0.10, output: 5.00 },
 };
 let totalCost = 0;
 
-// ---------------------------------------------------------------------------
-// GitHub helpers
-// ---------------------------------------------------------------------------
+const { gh, ghPaginate } = createGitHubClient(GITHUB_TOKEN);
 
-async function gh(path, opts = {}) {
-  const url = path.startsWith("http") ? path : `${GITHUB_API}${path}`;
-  const res = await fetch(url, {
-    headers: {
-      Authorization: `token ${GITHUB_TOKEN}`,
-      Accept: "application/vnd.github+json",
-      "X-GitHub-Api-Version": "2022-11-28",
-      ...opts.headers,
-    },
-    ...opts,
-  });
-  if (!res.ok) {
-    const body = await res.text().catch(() => "");
-    throw new Error(`GitHub API ${res.status}: ${path} — ${body.slice(0, 200)}`);
-  }
-  return res.json();
-}
-
-async function ghPaginate(path, maxItems = 100) {
-  const items = [];
-  let page = 1;
-  while (items.length < maxItems) {
-    const perPage = Math.min(100, maxItems - items.length);
-    const sep = path.includes("?") ? "&" : "?";
-    const data = await gh(`${path}${sep}per_page=${perPage}&page=${page}`);
-    if (!Array.isArray(data) || data.length === 0) { break; }
-    items.push(...data);
-    if (data.length < perPage) { break; }
-    page++;
-  }
-  return items;
-}
-
-// ---------------------------------------------------------------------------
-// Data collection
-// ---------------------------------------------------------------------------
-
-async function getTargetPR(prNumber) {
-  const pr = await gh(`/repos/${REPO}/pulls/${prNumber}`);
-  let diff = "";
-  try {
-    const res = await fetch(`${GITHUB_API}/repos/${REPO}/pulls/${prNumber}`, {
-      headers: {
-        Authorization: `token ${GITHUB_TOKEN}`,
-        Accept: "application/vnd.github.v3.diff",
-        "X-GitHub-Api-Version": "2022-11-28",
-      },
-    });
-    if (res.ok) {
-      diff = await res.text();
-      if (diff.length > MAX_DIFF_CHARS) {
-        diff = diff.slice(0, MAX_DIFF_CHARS) + "\n... (truncated)";
-      }
-    }
-  } catch {}
-
-  const files = await gh(`/repos/${REPO}/pulls/${prNumber}/files?per_page=100`);
-  return {
-    number: pr.number,
-    title: pr.title,
-    body: (pr.body || "").slice(0, 2000),
-    author: pr.user?.login,
-    branch: pr.head?.ref,
-    additions: pr.additions,
-    deletions: pr.deletions,
-    changed_files: pr.changed_files,
-    created_at: pr.created_at,
-    files: files.map((f) => f.filename),
-    diff,
-  };
-}
-
-function summarizePR(pr) {
-  const issueRefs = extractIssueRefs(pr.title + " " + (pr.body || ""));
-  return [
-    `#${pr.number}: ${pr.title}`,
-    `  author:${pr.user?.login || pr.author} +${pr.additions}/-${pr.deletions} ${pr.changed_files ?? pr.files?.length ?? "?"} files`,
-    pr.files?.length
-      ? `  files: ${pr.files.slice(0, 8).join(", ")}${pr.files.length > 8 ? ` (+${pr.files.length - 8} more)` : ""}`
-      : "",
-    issueRefs.length ? `  refs: ${issueRefs.join(", ")}` : "",
-  ]
-    .filter(Boolean)
-    .join("\n");
-}
-
-async function getOpenPRSummaries() {
-  const prs = await ghPaginate(`/repos/${REPO}/pulls?state=open&sort=created&direction=desc`, MAX_OPEN_PRS);
-  const summaries = [];
-  for (const pr of prs) {
-    let files = [];
-    try {
-      files = (await gh(`/repos/${REPO}/pulls/${pr.number}/files?per_page=30`)).map((f) => f.filename);
-    } catch {}
-    summaries.push(
-      summarizePR({
-        ...pr,
-        author: pr.user?.login,
-        files,
-      }),
-    );
-  }
-  return summaries;
-}
-
-async function getRecentDecisions() {
-  // Last N merged PRs
-  const merged = await ghPaginate(
-    `/repos/${REPO}/pulls?state=closed&sort=updated&direction=desc`,
-    MAX_HISTORY * 2,
-  );
-
-  const mergedPRs = merged
-    .filter((pr) => pr.merged_at)
-    .slice(0, MAX_HISTORY)
-    .map((pr) => `MERGED #${pr.number}: ${pr.title} (by ${pr.user?.login}, +${pr.additions}/-${pr.deletions})`);
-
-  const rejectedPRs = merged
-    .filter((pr) => !pr.merged_at)
-    .slice(0, MAX_HISTORY)
-    .map((pr) => `CLOSED #${pr.number}: ${pr.title} (by ${pr.user?.login}, +${pr.additions}/-${pr.deletions})`);
-
-  return { mergedPRs, rejectedPRs };
-}
-
-// ---------------------------------------------------------------------------
-// Issue reference extraction
-// ---------------------------------------------------------------------------
-
-function extractIssueRefs(text) {
-  if (!text) { return []; }
-  const matches = text.match(/#(\d{3,6})/g) || [];
-  return [...new Set(matches)];
-}
-
-function computeFileOverlap(filesA, filesB) {
-  if (!filesA.length || !filesB.length) { return 0; }
-  const setA = new Set(filesA);
-  const intersection = filesB.filter((f) => setA.has(f));
-  const union = new Set([...filesA, ...filesB]);
-  return intersection.length / union.size; // Jaccard
-}
-
-// ---------------------------------------------------------------------------
-// Deterministic pre-enrichment
-// ---------------------------------------------------------------------------
+// --- Deterministic pre-enrichment ---
 
 function deterministicSignals(targetPR, openPRSummaries) {
   const targetRefs = extractIssueRefs(targetPR.title + " " + targetPR.body);
   const targetFiles = targetPR.files || [];
-
   const signals = [];
 
-  // Parse open PR summaries back into structured data for comparison
   for (const summary of openPRSummaries) {
     const numMatch = summary.match(/^#(\d+):/);
     if (!numMatch) { continue; }
@@ -209,15 +67,10 @@ function deterministicSignals(targetPR, openPRSummaries) {
     const prRefs = refsMatch ? refsMatch[1].split(", ") : [];
     const filesMatch = summary.match(/files: (.+)/);
     const prFiles = filesMatch
-      ? filesMatch[1]
-          .replace(/ \(\+\d+ more\)/, "")
-          .split(", ")
+      ? filesMatch[1].replace(/ \(\+\d+ more\)/, "").split(", ")
       : [];
 
-    // Shared issue references
     const sharedRefs = targetRefs.filter((r) => prRefs.includes(r));
-
-    // File overlap
     const jaccard = computeFileOverlap(targetFiles, prFiles);
 
     if (sharedRefs.length > 0 || jaccard > 0.3) {
@@ -229,13 +82,20 @@ function deterministicSignals(targetPR, openPRSummaries) {
       });
     }
   }
-
   return signals;
 }
 
-// ---------------------------------------------------------------------------
-// LLM triage call
-// ---------------------------------------------------------------------------
+// --- LLM triage call ---
+
+async function loadContributing() {
+  try {
+    const content = await readFile("CONTRIBUTING.md", "utf-8");
+    const focusMatch = content.match(/## Current Focus.*?\n([\s\S]*?)(?=\n## |$)/);
+    return focusMatch ? focusMatch[1].trim() : content.slice(0, 1000);
+  } catch {
+    return "Priorities: Stability, UX, Skills (ClawHub), Performance";
+  }
+}
 
 async function triagePR(targetPR, openPRSummaries, decisions, deterministicHints) {
   const contributingMd = await loadContributing();
@@ -313,13 +173,7 @@ Respond with a single JSON object:
     body: JSON.stringify({
       model: MODEL,
       max_tokens: 1024,
-      system: [
-        {
-          type: "text",
-          text: systemPrompt,
-          cache_control: { type: "ephemeral" },
-        },
-      ],
+      system: [{ type: "text", text: systemPrompt, cache_control: { type: "ephemeral" } }],
       messages: [{ role: "user", content: userPrompt }],
     }),
   });
@@ -330,8 +184,6 @@ Respond with a single JSON object:
   }
 
   const data = await res.json();
-
-  // Cost tracking
   const usage = data.usage || {};
   const prices = PRICING[MODEL] || PRICING["claude-haiku-4-5-20251001"];
   const inputCost = ((usage.input_tokens || 0) / 1_000_000) * prices.input;
@@ -345,8 +197,6 @@ Respond with a single JSON object:
   console.log(`Cost: $${callCost.toFixed(4)} this call | $${totalCost.toFixed(4)} total`);
 
   const text = data.content?.[0]?.text || "";
-
-  // Parse JSON from response (handle potential markdown fences)
   const jsonStr = text.replace(/^```json?\n?/, "").replace(/\n?```$/, "").trim();
   try {
     return JSON.parse(jsonStr);
@@ -356,34 +206,12 @@ Respond with a single JSON object:
   }
 }
 
-async function loadContributing() {
-  try {
-    const { readFile } = await import("node:fs/promises");
-    const content = await readFile("CONTRIBUTING.md", "utf-8");
-    // Extract just the focus/roadmap section
-    const focusMatch = content.match(/## Current Focus.*?\n([\s\S]*?)(?=\n## |$)/);
-    return focusMatch ? focusMatch[1].trim() : content.slice(0, 1000);
-  } catch {
-    return "Priorities: Stability, UX, Skills (ClawHub), Performance";
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Label application
-// ---------------------------------------------------------------------------
+// --- Label application ---
 
 const CATEGORY_LABELS = {
-  bug: "auto:bug",
-  feature: "auto:feature",
-  refactor: "auto:refactor",
-  test: "auto:test",
-  docs: "auto:docs",
-  chore: "auto:chore",
+  bug: "auto:bug", feature: "auto:feature", refactor: "auto:refactor",
+  test: "auto:test", docs: "auto:docs", chore: "auto:chore",
 };
-
-const TRIAGE_LABEL_COLOR = "c2e0c6";
-const CATEGORY_LABEL_COLOR = "d4c5f9";
-const OVERLAP_LABEL_COLOR = "fbca04";
 
 async function ensureLabel(name, color) {
   try {
@@ -401,47 +229,38 @@ async function ensureLabel(name, color) {
 
 async function applyLabels(prNumber, triage) {
   if (!triage) { return; }
-
   const labels = [];
-
-  // Category label
   const catLabel = CATEGORY_LABELS[triage.category];
   if (catLabel) {
-    await ensureLabel(catLabel, CATEGORY_LABEL_COLOR);
+    await ensureLabel(catLabel, "d4c5f9");
     labels.push(catLabel);
   }
 
-  // Duplicate/overlap labels — only at high confidence
   if (triage.confidence === "high" && triage.duplicate_of?.length > 0) {
-    const label = "possible-overlap";
-    await ensureLabel(label, OVERLAP_LABEL_COLOR);
-    labels.push(label);
-
-    // Add cluster labels for each referenced issue
+    await ensureLabel("possible-overlap", "fbca04");
+    labels.push("possible-overlap");
     for (const dupNum of triage.duplicate_of) {
       const clusterLabel = `cluster:#${dupNum}`;
-      await ensureLabel(clusterLabel, OVERLAP_LABEL_COLOR);
+      await ensureLabel(clusterLabel, "fbca04");
       labels.push(clusterLabel);
     }
   }
 
-  // Triage action label
   if (triage.suggested_action === "likely-duplicate") {
-    await ensureLabel("triage:likely-duplicate", OVERLAP_LABEL_COLOR);
+    await ensureLabel("triage:likely-duplicate", "fbca04");
     labels.push("triage:likely-duplicate");
   } else if (triage.suggested_action === "needs-discussion") {
-    await ensureLabel("triage:needs-discussion", TRIAGE_LABEL_COLOR);
+    await ensureLabel("triage:needs-discussion", "c2e0c6");
     labels.push("triage:needs-discussion");
   }
 
-  // Quality signal labels
   if (triage.quality_signals) {
     if (!triage.quality_signals.references_issue) {
-      await ensureLabel("triage:no-issue-ref", TRIAGE_LABEL_COLOR);
+      await ensureLabel("triage:no-issue-ref", "c2e0c6");
       labels.push("triage:no-issue-ref");
     }
     if (!triage.quality_signals.has_tests && triage.category !== "docs") {
-      await ensureLabel("triage:no-tests", TRIAGE_LABEL_COLOR);
+      await ensureLabel("triage:no-tests", "c2e0c6");
       labels.push("triage:no-tests");
     }
   }
@@ -461,64 +280,45 @@ async function applyLabels(prNumber, triage) {
   }
 }
 
-// ---------------------------------------------------------------------------
-// Summary output (GitHub Actions step summary)
-// ---------------------------------------------------------------------------
+// --- Summary output ---
 
 function writeSummary(prNumber, triage, deterministicHints, costInfo) {
   if (!triage) { return; }
-
   const lines = [
-    `## PR #${prNumber} Triage`,
-    "",
-    `**Category:** ${triage.category} | **Confidence:** ${triage.confidence} | **Action:** ${triage.suggested_action}`,
-    "",
-    `**Reasoning:** ${triage.reasoning}`,
-    "",
+    `## PR #${prNumber} Triage`, "",
+    `**Category:** ${triage.category} | **Confidence:** ${triage.confidence} | **Action:** ${triage.suggested_action}`, "",
+    `**Reasoning:** ${triage.reasoning}`, "",
   ];
-
   if (triage.duplicate_of?.length > 0) {
     lines.push(`**Possible duplicates:** ${triage.duplicate_of.map((n) => `#${n}`).join(", ")}`);
   }
   if (triage.related_to?.length > 0) {
     lines.push(`**Related PRs:** ${triage.related_to.map((n) => `#${n}`).join(", ")}`);
   }
-
   if (deterministicHints.length > 0) {
     lines.push("", "**Deterministic signals:**");
     for (const h of deterministicHints) {
       lines.push(`- #${h.pr}: refs=${h.sharedRefs.join(",") || "none"}, file overlap=${h.jaccard}`);
     }
   }
-
   const qs = triage.quality_signals || {};
-  lines.push(
-    "",
-    "**Quality:**",
+  lines.push("", "**Quality:**",
     `- Focused scope: ${qs.focused_scope ? "yes" : "no"}`,
     `- Has tests: ${qs.has_tests ? "yes" : "no"}`,
     `- Appropriate size: ${qs.appropriate_size ? "yes" : "no"}`,
     `- References issue: ${qs.references_issue ? "yes" : "no"}`,
   );
-
   if (costInfo) {
     lines.push("", `**Model:** ${costInfo.model} | **Cost:** $${costInfo.totalCost.toFixed(4)}`);
   }
-
   const summary = lines.join("\n");
   console.log(summary);
-
-  // Write to GitHub Actions step summary if available
   if (process.env.GITHUB_STEP_SUMMARY) {
-    try {
-      appendFileSync(process.env.GITHUB_STEP_SUMMARY, summary + "\n");
-    } catch {}
+    try { appendFileSync(process.env.GITHUB_STEP_SUMMARY, summary + "\n"); } catch {}
   }
 }
 
-// ---------------------------------------------------------------------------
-// Main
-// ---------------------------------------------------------------------------
+// --- Main ---
 
 async function main() {
   const prNumber = PR_NUMBER || 0;
@@ -529,28 +329,23 @@ async function main() {
 
   console.log(`Triaging PR #${prNumber} on ${REPO}...`);
 
-  // 1. Fetch target PR details
   console.log("Fetching target PR...");
-  const targetPR = await getTargetPR(prNumber);
+  const targetPR = await getTargetPR(gh, REPO, prNumber, MAX_DIFF_CHARS, GITHUB_TOKEN);
   console.log(`Target: "${targetPR.title}" by ${targetPR.author}, ${targetPR.files.length} files`);
 
-  // 2. Fetch all open PR summaries (cached in LLM system prompt)
   console.log("Fetching open PRs for context...");
-  const openPRSummaries = await getOpenPRSummaries();
+  const openPRSummaries = await getOpenPRSummaries(gh, ghPaginate, REPO, MAX_OPEN_PRS);
   console.log(`Loaded ${openPRSummaries.length} open PRs as context`);
 
-  // 3. Fetch recent merge/close decisions (implicit preferences)
   console.log("Fetching recent decisions...");
-  const decisions = await getRecentDecisions();
+  const decisions = await getRecentDecisions(ghPaginate, REPO, MAX_HISTORY);
   console.log(`Loaded ${decisions.mergedPRs.length} merged + ${decisions.rejectedPRs.length} rejected PRs`);
 
-  // 4. Run deterministic pre-analysis
   const deterministicHints = deterministicSignals(targetPR, openPRSummaries);
   if (deterministicHints.length > 0) {
     console.log(`Deterministic: found ${deterministicHints.length} potential overlaps`);
   }
 
-  // 5. Single LLM call with cached context
   let triage;
   if (DRY_RUN) {
     console.log("\n=== DRY RUN — LLM call skipped ===");
@@ -561,8 +356,7 @@ async function main() {
     triage = {
       duplicate_of: deterministicHints.filter((h) => h.sharedRefs.length > 0 || h.jaccard > 0.5).map((h) => h.pr),
       related_to: deterministicHints.filter((h) => h.sharedRefs.length === 0 && h.jaccard <= 0.5).map((h) => h.pr),
-      category: "unknown",
-      confidence: "dry-run",
+      category: "unknown", confidence: "dry-run",
       quality_signals: { focused_scope: true, has_tests: false, appropriate_size: true, references_issue: extractIssueRefs(targetPR.title + " " + targetPR.body).length > 0 },
       suggested_action: "auto-label-only",
       reasoning: "DRY RUN — deterministic signals only",
@@ -582,7 +376,6 @@ async function main() {
     console.log(`Duplicates: ${triage.duplicate_of.map((n) => `#${n}`).join(", ")}`);
   }
 
-  // 6. Apply labels (silent — no public comments)
   if (!DRY_RUN) {
     console.log("Applying labels...");
     await applyLabels(prNumber, triage);
@@ -590,9 +383,7 @@ async function main() {
     console.log("DRY RUN — skipping label application");
   }
 
-  // 7. Write summary (visible only in Actions run log)
   writeSummary(prNumber, triage, deterministicHints, { model: MODEL, totalCost });
-
   console.log("Done.");
 }
 

--- a/scripts/pr-triage.mjs
+++ b/scripts/pr-triage.mjs
@@ -70,9 +70,9 @@ async function ghPaginate(path, maxItems = 100) {
     const perPage = Math.min(100, maxItems - items.length);
     const sep = path.includes("?") ? "&" : "?";
     const data = await gh(`${path}${sep}per_page=${perPage}&page=${page}`);
-    if (!Array.isArray(data) || data.length === 0) break;
+    if (!Array.isArray(data) || data.length === 0) { break; }
     items.push(...data);
-    if (data.length < perPage) break;
+    if (data.length < perPage) { break; }
     page++;
   }
   return items;
@@ -175,13 +175,13 @@ async function getRecentDecisions() {
 // ---------------------------------------------------------------------------
 
 function extractIssueRefs(text) {
-  if (!text) return [];
+  if (!text) { return []; }
   const matches = text.match(/#(\d{3,6})/g) || [];
   return [...new Set(matches)];
 }
 
 function computeFileOverlap(filesA, filesB) {
-  if (!filesA.length || !filesB.length) return 0;
+  if (!filesA.length || !filesB.length) { return 0; }
   const setA = new Set(filesA);
   const intersection = filesB.filter((f) => setA.has(f));
   const union = new Set([...filesA, ...filesB]);
@@ -201,9 +201,9 @@ function deterministicSignals(targetPR, openPRSummaries) {
   // Parse open PR summaries back into structured data for comparison
   for (const summary of openPRSummaries) {
     const numMatch = summary.match(/^#(\d+):/);
-    if (!numMatch) continue;
+    if (!numMatch) { continue; }
     const num = Number(numMatch[1]);
-    if (num === targetPR.number) continue;
+    if (num === targetPR.number) { continue; }
 
     const refsMatch = summary.match(/refs: (.+)/);
     const prRefs = refsMatch ? refsMatch[1].split(", ") : [];
@@ -400,7 +400,7 @@ async function ensureLabel(name, color) {
 }
 
 async function applyLabels(prNumber, triage) {
-  if (!triage) return;
+  if (!triage) { return; }
 
   const labels = [];
 
@@ -466,7 +466,7 @@ async function applyLabels(prNumber, triage) {
 // ---------------------------------------------------------------------------
 
 function writeSummary(prNumber, triage, deterministicHints, costInfo) {
-  if (!triage) return;
+  if (!triage) { return; }
 
   const lines = [
     `## PR #${prNumber} Triage`,


### PR DESCRIPTION
## Summary

Adds an AI-powered PR triage system that automatically detects duplicate/overlapping PRs, categorizes contributions, and applies silent labels. Uses a single Claude API call per PR with cached context of all open PRs and recent merge/close decisions to learn maintainer preferences implicitly.

## Architecture

**3 files** (2 JS + 1 workflow):
- `.github/workflows/pr-triage.yml` — Triggered on `pull_request_target: [opened, reopened]` + manual `workflow_dispatch`
- `scripts/pr-triage.mjs` — Main triage logic, LLM call, label application (393 lines)
- `scripts/pr-triage-github.mjs` — GitHub API helpers, data collection (135 lines)

**Single LLM call per PR:**
- System prompt (cached): summaries of all 500 open PRs + last 100 merge/close decisions + CONTRIBUTING.md focus areas
- User message (fresh): new PR title, description, files changed, diff excerpt + deterministic overlap hints
- Output: structured JSON with `duplicate_of`, `related_to`, `category`, `quality_signals`, `confidence`, `suggested_action`

**Deterministic pre-enrichment** before LLM call:
- Issue reference extraction from PR title/body/branch
- File-path Jaccard overlap detection against all open PRs
- Results passed as hints to the LLM for confirmation

## UX — Invisible to contributors

- **Silent labels only**: `auto:bug`, `auto:feature`, `possible-overlap`, `cluster:#N`, `triage:likely-duplicate`, `triage:needs-discussion`, `triage:no-tests`, `triage:no-issue-ref`
- **NO public bot comments** (political risk avoidance — matplotlib/crabby-rathbun Feb 2026)
- Private summary in GitHub Actions step summary (visible only to maintainers)

## Cost tracking

Built-in per-call and cumulative cost tracking with pricing for Opus 4.6, Sonnet 4.5, Haiku 4.5. Default model configurable via `TRIAGE_MODEL` env var.

## Tested against real PRs

| PR | Result | Notes |
|----|--------|-------|
| #17296 (24-file kitchen-sink) | `bug \| high \| needs-discussion` | Correctly identified unfocused scope, found focused alternative #17279 |
| #17295 (2-file focused fix) | `bug \| high \| likely-duplicate` | Correctly identified as duplicate of #17291 (same issue #17263, same file) |
| #17294 (docs PR) | DRY_RUN verified | Deterministic signals + 500 PR context loading works |

## Configuration

| Env var | Default | Description |
|---------|---------|-------------|
| `TRIAGE_MODEL` | `claude-opus-4-6` | Claude model to use |
| `MAX_OPEN_PRS` | `500` | Number of open PRs to load as context |
| `MAX_HISTORY` | `100` | Number of recent merge/close decisions |
| `MAX_DIFF_CHARS` | `8000` | Max diff characters per PR |
| `DRY_RUN` | `0` | Skip LLM call and label application |

## Requirements

- `ANTHROPIC_API_KEY` secret
- `GH_APP_PRIVATE_KEY` secret (reuses existing labeler app)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an AI-powered PR triage system that uses a single Claude API call per PR to detect duplicate/overlapping PRs, categorize contributions, and apply silent labels. The implementation includes deterministic pre-enrichment (issue reference matching and file-path Jaccard overlap) before the LLM call, cost tracking, and a clean separation between the GitHub API client and the triage logic.

- **Critical bug**: The `gh()` helper in `pr-triage-github.mjs` spreads `...opts` after the merged `headers` object, which overwrites `Authorization` and other required headers whenever callers pass `opts.headers`. This breaks all label creation and application calls (`ensureLabel`, `applyLabels`), causing them to fail silently due to `try/catch` wrappers. Labels will never actually be applied.
- **`workflow_dispatch` behavior mismatch**: The workflow input describes `"0 = latest"` but the script exits with an error when `PR_NUMBER` is 0, making manual dispatch without a specific PR number always fail.
- **Performance concern**: `getOpenPRSummaries` makes one sequential API call per open PR to fetch file lists (up to 500 calls), which will be slow and consume a significant portion of the hourly rate limit.

<h3>Confidence Score: 2/5</h3>

- The header-override bug prevents the core labeling functionality from working; merging this would deploy a non-functional triage system.
- Score of 2 reflects a critical logic bug in the GitHub API client that silently breaks all write operations (label creation and application), combined with a workflow_dispatch UX mismatch. The workflow is safe from a security perspective (correct pull_request_target + base-branch checkout pattern), but its primary feature — applying labels — does not work as written.
- Pay close attention to `scripts/pr-triage-github.mjs` — the `gh()` function's header handling needs to be fixed before any write operations (label creation/application) will succeed.

<sub>Last reviewed commit: bc9a8dc</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->