### PR TITLE
fix(completion): avoid zsh compdef error when compinit is not initialized

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -628,6 +628,22 @@ openclaw message send --channel telegram --target 123456789 --message "hi"
 openclaw message send --channel telegram --target @name --message "hi"
 ```
 
+    CLI poll send (Telegram):
+
+```bash
+openclaw message poll --channel telegram --target 123456789 \
+  --poll-question "Deploy tonight?" \
+  --poll-option "Yes" --poll-option "No" \
+  --poll-duration-seconds 300 \
+  --poll-anonymous --silent
+```
+
+    Poll constraints (Telegram):
+
+    - `--poll-option` supports 2-12 options
+    - `--poll-duration-seconds` supports 5-600
+    - use `--poll-public` to make the poll non-anonymous
+
   </Accordion>
 </AccordionGroup>
 

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -640,7 +640,7 @@ openclaw message poll --channel telegram --target 123456789 \
 
     Poll constraints (Telegram):
 
-    - `--poll-option` supports 2-12 options
+    - `--poll-option` supports 2-10 options
     - `--poll-duration-seconds` supports 5-600
     - use `--poll-public` to make the poll non-anonymous
 

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -628,22 +628,6 @@ openclaw message send --channel telegram --target 123456789 --message "hi"
 openclaw message send --channel telegram --target @name --message "hi"
 ```
 
-    CLI poll send (Telegram):
-
-```bash
-openclaw message poll --channel telegram --target 123456789 \
-  --poll-question "Deploy tonight?" \
-  --poll-option "Yes" --poll-option "No" \
-  --poll-duration-seconds 300 \
-  --poll-anonymous --silent
-```
-
-    Poll constraints (Telegram):
-
-    - `--poll-option` supports 2-10 options
-    - `--poll-duration-seconds` supports 5-600
-    - use `--poll-public` to make the poll non-anonymous
-
   </Accordion>
 </AccordionGroup>
 

--- a/src/cli/completion-cli.test.ts
+++ b/src/cli/completion-cli.test.ts
@@ -1,0 +1,18 @@
+import { Command } from "commander";
+import { describe, expect, it } from "vitest";
+import { generateZshCompletion } from "./completion-cli.js";
+
+describe("generateZshCompletion", () => {
+  it("bootstraps compinit when compdef is unavailable", () => {
+    const program = new Command();
+    program.name("openclaw");
+    program.command("status").description("Show status");
+
+    const script = generateZshCompletion(program);
+
+    expect(script).toContain("if ! command -v compdef >/dev/null 2>&1; then");
+    expect(script).toContain("autoload -Uz compinit");
+    expect(script).toContain("compinit");
+    expect(script).toContain("compdef _openclaw_root_completion openclaw");
+  });
+});

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -365,10 +365,17 @@ export async function installCompletion(shell: string, yes: boolean, binName = "
   }
 }
 
-function generateZshCompletion(program: Command): string {
+export function generateZshCompletion(program: Command): string {
   const rootCmd = program.name();
   const script = `
 #compdef ${rootCmd}
+
+# Ensure completion functions are available when this script is sourced
+# in shells that have not initialized compinit yet.
+if ! command -v compdef >/dev/null 2>&1; then
+  autoload -Uz compinit
+  compinit
+fi
 
 _${rootCmd}_root_completion() {
   local -a commands


### PR DESCRIPTION
## Summary
- update generated zsh completion script to bootstrap `compinit` when `compdef` is unavailable
- prevents `command not found: compdef` for users sourcing completion in shells without prior `compinit` setup
- add unit test coverage for the zsh script bootstrap block

## Validation
- reproduced failure before fix: `zsh -f -c 'source <(openclaw completion --shell zsh)'` -> exit 127 (compdef missing)
- verified after fix: same command exits 0
- `pnpm vitest src/cli/completion-cli.test.ts` passes
- `pnpm build` passes

Closes #14289

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a `compinit` bootstrap guard to the generated zsh completion script so that `source <(openclaw completion --shell zsh)` works in shells where `compinit` has not been initialized (e.g., `zsh -f`). The guard uses `command -v compdef` to detect whether the completion system is loaded, and only runs `autoload -Uz compinit && compinit` when it is not — a well-established pattern used by other CLI tools. The `#compdef` directive is preserved for fpath-based loading, and when `compdef` is already available the guard is a no-op.

- `generateZshCompletion` is now exported (was internal) to enable direct unit testing
- A new test file (`completion-cli.test.ts`) verifies the bootstrap block is present in the generated script
- No changes to bash, fish, or PowerShell completion generators

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it adds a well-known defensive guard to shell script output with no risk to existing functionality.
- The change is minimal and targeted: a 5-line shell guard added to a template string, plus a visibility change (export) and a new test file. The bootstrap pattern (check for compdef, conditionally run compinit) is standard practice in zsh completion scripts. The guard is a no-op when compinit is already loaded, so it cannot break existing setups. The test follows established patterns in the codebase.
- No files require special attention

<sub>Last reviewed commit: f1f6b2d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->