### PR TITLE
fix(whatsapp): group composing indicator, echo prevention, and presence subscription

### DIFF
--- a/src/web/inbound/monitor.ts
+++ b/src/web/inbound/monitor.ts
@@ -11,7 +11,6 @@ import { jidToE164, resolveJidToE164 } from "../../utils.js";
 import { createWaSocket, getStatusCode, waitForWaConnection } from "../session.js";
 import { checkInboundAccessControl } from "./access-control.js";
 import { isRecentInboundMessage } from "./dedupe.js";
-import { isSentByUs } from "./sent-ids.js";
 import {
   describeReplyContext,
   extractLocationData,
@@ -21,6 +20,7 @@ import {
 } from "./extract.js";
 import { downloadInboundMedia } from "./media.js";
 import { createWebSendApi } from "./send-api.js";
+import { isSentByUs } from "./sent-ids.js";
 import type { WebInboundMessage, WebListenerCloseReason } from "./types.js";
 
 export async function monitorWebInbox(options: {

--- a/src/web/inbound/monitor.ts
+++ b/src/web/inbound/monitor.ts
@@ -11,6 +11,7 @@ import { jidToE164, resolveJidToE164 } from "../../utils.js";
 import { createWaSocket, getStatusCode, waitForWaConnection } from "../session.js";
 import { checkInboundAccessControl } from "./access-control.js";
 import { isRecentInboundMessage } from "./dedupe.js";
+import { isSentByUs } from "./sent-ids.js";
 import {
   describeReplyContext,
   extractLocationData,
@@ -176,6 +177,11 @@ export async function monitorWebInbox(options: {
         if (isRecentInboundMessage(dedupeKey)) {
           continue;
         }
+      }
+      // Skip messages we sent ourselves — prevents echo loops where the bot
+      // re-ingests its own voice notes or media as new inbound messages.
+      if (id && isSentByUs(id)) {
+        continue;
       }
       const participantJid = msg.key?.participant ?? undefined;
       const from = group ? remoteJid : await resolveInboundJid(remoteJid);
@@ -368,6 +374,7 @@ export async function monitorWebInbox(options: {
     sock: {
       sendMessage: (jid: string, content: AnyMessageContent) => sock.sendMessage(jid, content),
       sendPresenceUpdate: (presence, jid?: string) => sock.sendPresenceUpdate(presence, jid),
+      presenceSubscribe: (jid: string) => sock.presenceSubscribe(jid),
     },
     defaultAccountId: options.accountId,
   });

--- a/src/web/inbound/send-api.test.ts
+++ b/src/web/inbound/send-api.test.ts
@@ -10,8 +10,9 @@ import { createWebSendApi } from "./send-api.js";
 describe("createWebSendApi", () => {
   const sendMessage = vi.fn(async () => ({ key: { id: "msg-1" } }));
   const sendPresenceUpdate = vi.fn(async () => {});
+  const presenceSubscribe = vi.fn(async () => {});
   const api = createWebSendApi({
-    sock: { sendMessage, sendPresenceUpdate },
+    sock: { sendMessage, sendPresenceUpdate, presenceSubscribe },
     defaultAccountId: "main",
   });
 

--- a/src/web/inbound/send-api.ts
+++ b/src/web/inbound/send-api.ts
@@ -2,6 +2,7 @@ import type { AnyMessageContent, WAPresence } from "@whiskeysockets/baileys";
 import { recordChannelActivity } from "../../infra/channel-activity.js";
 import { toWhatsappJid } from "../../utils.js";
 import type { ActiveWebSendOptions } from "../active-listener.js";
+import { trackSentMessageId } from "./sent-ids.js";
 
 function recordWhatsAppOutbound(accountId: string) {
   recordChannelActivity({
@@ -21,6 +22,7 @@ export function createWebSendApi(params: {
   sock: {
     sendMessage: (jid: string, content: AnyMessageContent) => Promise<unknown>;
     sendPresenceUpdate: (presence: WAPresence, jid?: string) => Promise<unknown>;
+    presenceSubscribe: (jid: string) => Promise<void>;
   };
   defaultAccountId: string;
 }) {
@@ -67,6 +69,9 @@ export function createWebSendApi(params: {
       const accountId = sendOptions?.accountId ?? params.defaultAccountId;
       recordWhatsAppOutbound(accountId);
       const messageId = resolveOutboundMessageId(result);
+      if (messageId !== "unknown") {
+        trackSentMessageId(messageId);
+      }
       return { messageId };
     },
     sendPoll: async (
@@ -107,6 +112,15 @@ export function createWebSendApi(params: {
     },
     sendComposingTo: async (to: string): Promise<void> => {
       const jid = toWhatsappJid(to);
+      // WhatsApp requires presence subscription before composing works in groups.
+      // Without this, sendPresenceUpdate("composing") silently fails for group JIDs.
+      if (jid.endsWith("@g.us")) {
+        try {
+          await params.sock.presenceSubscribe(jid);
+        } catch {
+          // Non-fatal: composing may still work in some cases
+        }
+      }
       await params.sock.sendPresenceUpdate("composing", jid);
     },
   } as const;

--- a/src/web/inbound/sent-ids.ts
+++ b/src/web/inbound/sent-ids.ts
@@ -1,0 +1,26 @@
+/**
+ * Track message IDs sent by the bot to prevent re-ingestion.
+ * WhatsApp sometimes delivers our own sent messages back to us
+ * (especially voice notes and media), causing echo loops.
+ */
+
+const SENT_IDS = new Set<string>();
+const MAX_SENT_IDS = 500;
+const CLEANUP_THRESHOLD = 600;
+
+export function trackSentMessageId(id: string): void {
+  SENT_IDS.add(id);
+  // Prevent unbounded growth — trim oldest when threshold exceeded.
+  // Sets iterate in insertion order, so deleting first entries is FIFO.
+  if (SENT_IDS.size > CLEANUP_THRESHOLD) {
+    const iter = SENT_IDS.values();
+    const excess = SENT_IDS.size - MAX_SENT_IDS;
+    for (let i = 0; i < excess; i++) {
+      SENT_IDS.delete(iter.next().value!);
+    }
+  }
+}
+
+export function isSentByUs(id: string): boolean {
+  return SENT_IDS.has(id);
+}


### PR DESCRIPTION
## Problem

Three independent but related WhatsApp reliability issues discovered while running a 24/7 OpenClaw agent on WhatsApp:

### 1. Typing indicator silently fails in groups
`sendPresenceUpdate("composing", groupJid)` does nothing in groups because Baileys requires `presenceSubscribe(jid)` first for group JIDs. This is a known Baileys behavior — without subscribing, presence updates are silently dropped.

### 2. Bot re-ingests its own voice notes / media
WhatsApp sometimes delivers the bot's own sent messages back as inbound `messages.upsert` events (especially voice notes and media). Without tracking, these get processed as new user messages, causing echo loops.

## Fix

### Group composing (`send-api.ts`)
- Add `presenceSubscribe` to the sock type interface
- Call `presenceSubscribe(jid)` before `sendPresenceUpdate("composing")` when the target is a group JID (`@g.us`)
- Non-fatal: if subscribe fails, composing is still attempted

### Echo prevention (`sent-ids.ts` + `send-api.ts` + `monitor.ts`)
- New `sent-ids.ts` module: simple in-memory `Set<string>` with FIFO cleanup (max 500 entries)
- `send-api.ts`: track message IDs after successful sends via `trackSentMessageId()`
- `monitor.ts`: skip inbound messages whose ID matches a recently sent message via `isSentByUs()`

### Monitor passthrough (`monitor.ts`)
- Expose `presenceSubscribe` from the Baileys socket to the send API

## Files Changed

| File | Change |
|------|--------|
| `src/web/inbound/send-api.ts` | Add presenceSubscribe to sock type, track sent IDs, subscribe before composing in groups |
| `src/web/inbound/monitor.ts` | Pass presenceSubscribe to send API, skip self-sent messages on inbound |
| `src/web/inbound/sent-ids.ts` | **New** — sent message ID tracking with bounded FIFO cleanup |

**3 files, 47 insertions, 0 deletions.**

## Testing

- Build passes (`pnpm build`)
- Manual testing: 24/7 WhatsApp agent with voice notes in groups — no more echo loops, typing indicator now visible in groups

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds group typing indicator support and echo prevention for WhatsApp messages. The implementation correctly subscribes to presence before sending composing indicators in groups, and tracks sent message IDs to filter out echo loops.

- Fixed typing indicator in groups by calling `presenceSubscribe` before `sendPresenceUpdate` for group JIDs
- Added in-memory tracking of sent message IDs with bounded FIFO cleanup (max 500 entries)
- Filters out self-sent messages in the inbound handler to prevent echo loops
- One issue found: `sendPoll` doesn't track its message ID, which could cause poll messages to echo back

<h3>Confidence Score: 4/5</h3>

- Safe to merge after addressing the sendPoll message ID tracking gap
- The implementation correctly solves the stated problems with sound architectural choices. The typing indicator fix is straightforward and properly handles failure. The echo prevention mechanism uses an appropriate bounded in-memory Set with FIFO cleanup. However, `sendPoll` has the same echo vulnerability as `sendMessage` had before this fix - it returns a messageId but doesn't track it, which could cause poll messages to be re-ingested. This is a logical gap in the implementation that should be addressed to fully prevent echo loops.
- src/web/inbound/send-api.ts requires attention for the sendPoll message ID tracking issue

<sub>Last reviewed commit: 218de1b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->