### PR TITLE
fix: LINE mixed rich reply order is reversed

### DIFF
--- a/extensions/line/src/channel.ts
+++ b/extensions/line/src/channel.ts
@@ -396,6 +396,25 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
           });
         }
 
+        if (lineData.location) {
+          lastResult = await sendLocation(to, lineData.location, {
+            verbose: false,
+            accountId: accountId ?? undefined,
+          });
+        }
+
+        // Send markdown table flex messages BEFORE template/button messages
+        // so users see details before pagination/buttons
+        for (const flexMsg of processed.flexMessages) {
+          // LINE SDK expects FlexContainer but we receive contents as unknown
+          const flexContents = flexMsg.contents as Parameters<typeof sendFlex>[2];
+          lastResult = await sendFlex(to, flexMsg.altText, flexContents, {
+            verbose: false,
+            accountId: accountId ?? undefined,
+          });
+        }
+
+        // Send template/button messages AFTER table flex messages
         if (lineData.templateMessage) {
           const template = buildTemplate(lineData.templateMessage);
           if (template) {
@@ -404,22 +423,6 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
               accountId: accountId ?? undefined,
             });
           }
-        }
-
-        if (lineData.location) {
-          lastResult = await sendLocation(to, lineData.location, {
-            verbose: false,
-            accountId: accountId ?? undefined,
-          });
-        }
-
-        for (const flexMsg of processed.flexMessages) {
-          // LINE SDK expects FlexContainer but we receive contents as unknown
-          const flexContents = flexMsg.contents as Parameters<typeof sendFlex>[2];
-          lastResult = await sendFlex(to, flexMsg.altText, flexContents, {
-            verbose: false,
-            accountId: accountId ?? undefined,
-          });
         }
       }
 


### PR DESCRIPTION
## Summary

When a LINE reply contains both a markdown table and `[[buttons:...]]`, the pagination/template card now appears AFTER the detail table card, instead of before. This fixes user confusion where summary/pagination appeared before details.

## Changes

- Reordered `sendPayload` function in LINE channel to send markdown table flex messages BEFORE template/button messages
- Added comment explaining the ordering rationale

## Testing

- All 7 existing tests in `channel.sendPayload.test.ts` pass
- No changes to test files required as this is a behavior fix for a bug

Fixes openclaw/openclaw#17308

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes the ordering of LINE rich reply messages so that markdown table flex cards are sent before template/button messages, ensuring users see details before pagination/buttons. The fix correctly reorders the non-batched send path.

- Moved the `templateMessage` send block after the `processed.flexMessages` loop in the `!shouldSendQuickRepliesInline` branch
- Added clarifying comments explaining the ordering rationale
- The same ordering issue exists in the `shouldSendQuickRepliesInline` batch path (lines 464-485), where `templateMessage` is still pushed into the array before `processed.flexMessages` — this should also be swapped for consistency

<h3>Confidence Score: 3/5</h3>

- The fix is correct for its targeted code path, but an analogous ordering issue remains unfixed in the quick-reply batch path.
- The reorder in the non-batched path is straightforward and low-risk. However, the same reversed ordering exists in the `shouldSendQuickRepliesInline` branch and was not addressed, meaning the bug can still surface when quick replies are present without text chunks.
- Pay attention to `extensions/line/src/channel.ts` lines 464-485 where the quick-reply batch path has the same ordering issue.

<sub>Last reviewed commit: de3799a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->