### PR TITLE
fix(delivery): keep route fields paired to channel during context merge

### DIFF
--- a/src/utils/delivery-context.test.ts
+++ b/src/utils/delivery-context.test.ts
@@ -24,16 +24,45 @@ describe("delivery context helpers", () => {
     expect(normalizeDeliveryContext({ channel: "  " })).toBeUndefined();
   });
 
-  it("merges primary values over fallback", () => {
+  it("does not inherit route fields from fallback when channels conflict", () => {
     const merged = mergeDeliveryContext(
-      { channel: "whatsapp", to: "channel:abc" },
-      { channel: "slack", to: "channel:def", accountId: "acct" },
+      { channel: "telegram" },
+      { channel: "discord", to: "channel:def", accountId: "acct", threadId: "99" },
     );
 
     expect(merged).toEqual({
-      channel: "whatsapp",
-      to: "channel:abc",
+      channel: "telegram",
+      to: undefined,
+      accountId: undefined,
+    });
+    expect(merged?.threadId).toBeUndefined();
+  });
+
+  it("inherits missing route fields when channels match", () => {
+    const merged = mergeDeliveryContext(
+      { channel: "telegram" },
+      { channel: "telegram", to: "123", accountId: "acct", threadId: "99" },
+    );
+
+    expect(merged).toEqual({
+      channel: "telegram",
+      to: "123",
       accountId: "acct",
+      threadId: "99",
+    });
+  });
+
+  it("uses normal fallback merge when either side has no channel", () => {
+    const merged = mergeDeliveryContext(
+      { channel: "telegram" },
+      { to: "123", accountId: "acct", threadId: "99" },
+    );
+
+    expect(merged).toEqual({
+      channel: "telegram",
+      to: "123",
+      accountId: "acct",
+      threadId: "99",
     });
   });
 
@@ -103,7 +132,7 @@ describe("delivery context helpers", () => {
     });
   });
 
-  it("normalizes delivery fields and mirrors them on session entries", () => {
+  it("normalizes delivery fields, mirrors session fields, and avoids cross-channel carryover", () => {
     const normalized = normalizeSessionDeliveryFields({
       deliveryContext: {
         channel: " Slack ",
@@ -118,12 +147,11 @@ describe("delivery context helpers", () => {
     expect(normalized.deliveryContext).toEqual({
       channel: "whatsapp",
       to: "+1555",
-      accountId: "acct-2",
-      threadId: "444",
+      accountId: undefined,
     });
     expect(normalized.lastChannel).toBe("whatsapp");
     expect(normalized.lastTo).toBe("+1555");
-    expect(normalized.lastAccountId).toBe("acct-2");
-    expect(normalized.lastThreadId).toBe("444");
+    expect(normalized.lastAccountId).toBeUndefined();
+    expect(normalized.lastThreadId).toBeUndefined();
   });
 });

--- a/src/utils/delivery-context.ts
+++ b/src/utils/delivery-context.ts
@@ -121,11 +121,23 @@ export function mergeDeliveryContext(
   if (!normalizedPrimary && !normalizedFallback) {
     return undefined;
   }
+  const channelsConflict =
+    normalizedPrimary?.channel &&
+    normalizedFallback?.channel &&
+    normalizedPrimary.channel !== normalizedFallback.channel;
   return normalizeDeliveryContext({
     channel: normalizedPrimary?.channel ?? normalizedFallback?.channel,
-    to: normalizedPrimary?.to ?? normalizedFallback?.to,
-    accountId: normalizedPrimary?.accountId ?? normalizedFallback?.accountId,
-    threadId: normalizedPrimary?.threadId ?? normalizedFallback?.threadId,
+    // Keep route fields paired to the selected channel. If both inputs name
+    // different channels, do not inherit target/account/thread from fallback.
+    to: channelsConflict
+      ? normalizedPrimary?.to
+      : (normalizedPrimary?.to ?? normalizedFallback?.to),
+    accountId: channelsConflict
+      ? normalizedPrimary?.accountId
+      : (normalizedPrimary?.accountId ?? normalizedFallback?.accountId),
+    threadId: channelsConflict
+      ? normalizedPrimary?.threadId
+      : (normalizedPrimary?.threadId ?? normalizedFallback?.threadId),
   });
 }
 


### PR DESCRIPTION
Fixes #13332

## Problem

When Telegram and webchat share the same session (`agent:main:main`), `mergeDeliveryContext()` would inherit route fields (`to`, `accountId`, `threadId`) from the fallback context even when the primary and fallback contexts named **different channels**. This caused a Telegram-originated reply to pick up webchat's `to`/`accountId` values, mis-routing the response to the webchat UI instead of back to Telegram.

## Fix

Added a `channelsConflict` guard in `mergeDeliveryContext()` — when both primary and fallback specify different channel names, route fields (`to`, `accountId`, `threadId`) are **not** inherited from the fallback. They remain paired to the selected channel.

This is a 13-line logic change in `src/utils/delivery-context.ts`.

## Changed files

- **`src/utils/delivery-context.ts`** — added channel-conflict check before fallback inheritance
- **`src/utils/delivery-context.test.ts`** — 3 new test cases:
  - Cross-channel fields are NOT inherited (telegram vs discord)
  - Same-channel fields ARE inherited normally
  - Missing channel in fallback still merges normally
  - Updated `normalizeSessionDeliveryFields` test to verify cross-channel carryover is blocked

## Tests

All 3 new unit tests pass. Existing delivery-context tests updated and passing.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds cross-channel conflict detection to `mergeDeliveryContext()` to prevent route field mis-pairing when Telegram and webchat share the same session. When primary and fallback contexts specify different channels, route fields (`to`, `accountId`, `threadId`) are not inherited from fallback, keeping them paired to the selected channel.

- Fixes mis-routing issue where Telegram replies inherited webchat's route fields
- Logic change is minimal (13 lines) and well-tested with 3 new test cases
- Preserves existing behavior when channels match or when either context lacks a channel
- Updated integration test verifies cross-channel carryover is blocked

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is targeted, well-tested, and solves a specific cross-channel routing bug. The logic is sound: it only blocks route field inheritance when both contexts explicitly specify different channels, preserving all existing behavior for same-channel and missing-channel scenarios. Three new unit tests directly validate the fix, and an integration test confirms the end-to-end behavior.
- No files require special attention

<sub>Last reviewed commit: 4248f11</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->