### PR TITLE
fix: expose messageId in trusted inbound metadata (#17207)

### DIFF
--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -22,6 +22,7 @@ export function buildInboundMetaSystemPrompt(ctx: TemplateContext): string {
     provider: safeTrim(ctx.Provider),
     surface: safeTrim(ctx.Surface),
     chat_type: chatType ?? (isDirect ? "direct" : undefined),
+    message_id: safeTrim(ctx.MessageSidFull) ?? safeTrim(ctx.MessageSid),
     flags: {
       is_group_chat: !isDirect ? true : undefined,
       was_mentioned: ctx.WasMentioned === true ? true : undefined,


### PR DESCRIPTION
## Problem

Agents have no way to know the `messageId` of the triggering message, making `action: "react"` on the current message impossible.

Fixes #17207

## Previous approach (closed #17245)

The previous PR appended `[id:...]` to user text in `formatInboundEnvelope`. Per @thewilloftheshadow's [feedback](https://github.com/openclaw/openclaw/pull/17245#issuecomment-2836283946), this was wrong:
- Injected IDs into untrusted user prompt, conflicting with trusted metadata design
- Added token noise to every message
- Weak sanitization

## New approach

Add `message_id` to the **trusted inbound_meta JSON** in `buildInboundMetaSystemPrompt`:

```ts
message_id: safeTrim(ctx.MessageSidFull) ?? safeTrim(ctx.MessageSid),
```

One file, one line. The ID now lives in the system-role trusted metadata block alongside `channel`, `provider`, `chat_type` — exactly where it belongs.

## Changes

- `src/auto-reply/reply/inbound-meta.ts` — 1 insertion

---


## Local Validation

- `pnpm build` ✅
- `pnpm check` (oxlint) ✅
- Relevant test suites pass ✅

## Contribution Checklist

- [x] Focused scope — single fix per PR
- [x] Clear "what" + "why" in description
- [x] AI-assisted (Codex/Claude) — reviewed and tested by human
- [x] Local validation run (`pnpm build && pnpm check`)

*AI-assisted (Claude). Reviewed by human.*