### PR TITLE
feat: Memory kernel rebuild with token budgeting, summary sidecar, and outputRef retrieval

### DIFF
--- a/docs/memory-kernel-implementation-2026-02-15.md
+++ b/docs/memory-kernel-implementation-2026-02-15.md
@@ -1,0 +1,226 @@
+# Memory Kernel Rebuild: Design, Implementation, and Test Results (2026-02-15)
+
+## Scope
+
+This document records the implementation and validation of the memory/context rebuild work delivered in PR `openclaw/openclaw#17345` on branch `codex/memory-token-budget-planner`.
+
+Covered commits:
+
+- `84e694680` Runner: add token-budget context planning
+- `520998e5a` Memory: cap injected recall snippets
+- `e22c86b41` Runner: persist incremental session summary state
+- `9642a3a6a` Runner: prevent session-summary prompt feedback loops
+- `b9490e95e` Runner: recover session summary after transcript rewinds
+- `827d3e48c` Runner: inject session summary only under context pressure
+- `f43c5f41f` Session: persist oversized tool payloads as file refs
+
+## Design Goals
+
+- Replace blunt turn-count trimming with deterministic token budgeting.
+- Keep transcript continuity resilient by adding incremental summary state.
+- Prevent summary feedback loops in conversation history.
+- Keep cache prefix stable when context pressure is low.
+- Stop oversized tool outputs from bloating transcript/prompt context by storing references.
+
+## High-Level Architecture
+
+```mermaid
+flowchart TD
+  A["User Prompt"] --> B["Embedded Runner Attempt"]
+  B --> C["Load and Sanitize Session History"]
+  C --> D["Token Budget Planner"]
+  D --> E["Conditional Session Summary Injection"]
+  E --> F["History Limit and Tool Pair Repair"]
+  F --> G["Model Prompt Execution"]
+  G --> H["Transcript Persistence Guard"]
+  H --> I["Session JSONL"]
+  H --> J["Tool Output Ref Files"]
+```
+
+## Implementation Details
+
+### 1) Token-Budget Context Planning
+
+Primary file:
+
+- `src/agents/pi-embedded-runner/context-planner.ts`
+
+Key behavior:
+
+- Computes `historyBudget` from model context window, reserve tokens, static prompt tokens, dynamic reserve, and safety ratio.
+- Trims from oldest messages first.
+- Preserves mandatory tail from latest user turn onward.
+- Handles invalid-budget fallback by preserving at least the last message.
+
+Flow:
+
+```mermaid
+flowchart TD
+  A["Estimate Message Tokens"] --> B["Compute Available History Budget"]
+  B --> C{"History Within Budget"}
+  C -- "Yes" --> D["Keep Full History"]
+  C -- "No" --> E["Compute Mandatory Tail"]
+  E --> F{"Mandatory Tail Exceeds Budget"}
+  F -- "Yes" --> G["Keep Mandatory Tail Only"]
+  F -- "No" --> H["Backfill Older Messages Until Budget Hit"]
+```
+
+### 2) Memory Retrieval Payload Cap
+
+Primary files:
+
+- `src/agents/tools/memory-tool.ts`
+- `src/agents/memory-search.ts`
+- `src/config/types.tools.ts`
+- `src/config/zod-schema.agent-runtime.ts`
+
+Key behavior:
+
+- Introduced injected snippet cap (default `maxInjectedChars=4000`) to bound recall payload size in prompt context.
+- Applied consistently across memory search backends.
+
+### 3) Session Summary Sidecar State
+
+Primary files:
+
+- `src/agents/pi-embedded-runner/session-summary.ts`
+- `src/agents/pi-embedded-runner/run/attempt.ts`
+
+Key behavior:
+
+- Added sidecar summary state path: `<sessionFile>.summary.json`.
+- Tracks `lastProcessedMessageCount`, rolling summary items, and bounded prompt materialization.
+- Persists incrementally each run.
+
+### 4) Summary Loop and Rewind Hardening
+
+Primary files:
+
+- `src/agents/pi-embedded-runner/session-summary.ts`
+- `src/agents/pi-embedded-runner/run/attempt.ts`
+
+Fixes:
+
+- Ignore synthetic `[SESSION_SUMMARY]` content during summary updates.
+- Recover correctly when transcript message count rewinds after repair/compaction.
+- Keep summary text in system context path instead of user prompt path.
+
+### 5) Cache-Aware Summary Injection Policy
+
+Primary file:
+
+- `src/agents/pi-embedded-runner/run/attempt.ts`
+
+Key behavior:
+
+- Added `decideSessionSummaryInjection(...)`.
+- Inject summary into system prompt only when:
+  - history was trimmed, or
+  - context pressure ratio crosses threshold (default `0.72`).
+- If not under pressure, summary state still persists but cached prefix remains more stable.
+
+### 6) Tool Payload Reference Persistence (P5)
+
+Primary file:
+
+- `src/agents/session-tool-result-guard.ts`
+
+Key behavior:
+
+- On tool-result persistence, if payload is oversized:
+  - write full payload to `.../sessions/tool-output/*.json`;
+  - keep compact transcript preview and `details.outputRef` metadata in JSONL.
+- Preserves essential scalar metadata (`status`, `exitCode`, etc.) in transcript.
+
+Flow:
+
+```mermaid
+flowchart TD
+  A["Tool Result Message"] --> B["Guard Size Checks"]
+  B --> C{"Oversized Details or Text"}
+  C -- "No" --> D["Persist Message Inline"]
+  C -- "Yes" --> E["Write Full Payload to tool-output JSON"]
+  E --> F["Add outputRef Metadata to details"]
+  F --> G["Replace Content with Preview and Notice"]
+  G --> H["Persist Compact Message to Session JSONL"]
+```
+
+## Key Files Changed
+
+- `src/agents/pi-embedded-runner/context-planner.ts`
+- `src/agents/pi-embedded-runner/context-planner.test.ts`
+- `src/agents/tools/memory-tool.ts`
+- `src/agents/memory-search.ts`
+- `src/config/types.tools.ts`
+- `src/config/zod-schema.agent-runtime.ts`
+- `src/agents/pi-embedded-runner/session-summary.ts`
+- `src/agents/pi-embedded-runner/session-summary.test.ts`
+- `src/agents/pi-embedded-runner/run/attempt.ts`
+- `src/agents/pi-embedded-runner/run/attempt.e2e.test.ts`
+- `src/agents/session-tool-result-guard.ts`
+- `src/agents/session-tool-result-guard.e2e.test.ts`
+
+## Automated Test Results
+
+Final verification rerun completed on HEAD `f43c5f41f`:
+
+- `pnpm tsgo`
+  - Result: pass
+- `pnpm test src/agents/pi-embedded-runner/context-planner.test.ts src/agents/pi-embedded-runner/session-summary.test.ts`
+  - Result: `2` files, `11` tests passed
+- `pnpm exec vitest run -c vitest.e2e.config.ts src/agents/pi-embedded-runner.limithistoryturns.e2e.test.ts src/agents/pi-embedded-runner/run/attempt.e2e.test.ts src/agents/memory-search.e2e.test.ts src/agents/tools/memory-tool.citations.e2e.test.ts src/agents/session-tool-result-guard.e2e.test.ts src/agents/session-tool-result-guard.tool-result-persist-hook.e2e.test.ts`
+  - Result: `6` files, `46` tests passed
+
+Historical targeted runs during implementation also passed for the same suites when executed incrementally.
+
+## UAT Results
+
+### UAT 1: Summary Sidecar and Loop Prevention
+
+Session:
+
+- `agent:main:uat-summary-fix`
+
+Observed:
+
+- Summary sidecar created under `~/.openclaw/agents/main/sessions/*.jsonl.summary.json`.
+- No synthetic `[SESSION_SUMMARY]` artifacts re-ingested into summary items.
+
+### UAT 2: Tool Output Reference Persistence
+
+Session:
+
+- `agent:main:uat-p5-tool-output-ref`
+
+Input:
+
+- `python - <<'PY'`
+- `print("x"*150000)`
+- `PY`
+
+Observed:
+
+- Transcript `toolResult.details.outputRef` created with:
+  - `kind: "tool_result_payload"`
+  - `path: "tool-output/<timestamp>-exec-...json"`
+  - `bytes` and `sha256`
+  - `contains: { details: true, text: true }`
+- Referenced payload file exists at:
+  - `~/.openclaw/agents/main/sessions/tool-output/...json`
+- Tool-result text in transcript contains:
+  - `[openclaw] Full tool output saved to ...`
+
+## Current Status
+
+Implemented and validated:
+
+- Phase 1: token-budget planning core
+- Phase 2: retrieval injection cap
+- Phase 3: incremental summary sidecar, loop prevention, rewind recovery
+- Phase 4: cache-aware conditional summary injection
+- Phase 5: oversized tool payload reference persistence
+
+Remaining follow-ups:
+
+- Read helper path for `outputRef` payloads (on-demand full retrieval).
+- Benchmark report for token/cost/latency deltas across long sessions.

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -57,6 +57,7 @@ export type ResolvedMemorySearchConfig = {
   query: {
     maxResults: number;
     minScore: number;
+    maxInjectedChars: number;
     hybrid: {
       enabled: boolean;
       vectorWeight: number;
@@ -88,6 +89,7 @@ const DEFAULT_SESSION_DELTA_BYTES = 100_000;
 const DEFAULT_SESSION_DELTA_MESSAGES = 50;
 const DEFAULT_MAX_RESULTS = 6;
 const DEFAULT_MIN_SCORE = 0.35;
+const DEFAULT_MAX_INJECTED_CHARS = 4_000;
 const DEFAULT_HYBRID_ENABLED = true;
 const DEFAULT_HYBRID_VECTOR_WEIGHT = 0.7;
 const DEFAULT_HYBRID_TEXT_WEIGHT = 0.3;
@@ -230,6 +232,10 @@ function mergeConfig(
   const query = {
     maxResults: overrides?.query?.maxResults ?? defaults?.query?.maxResults ?? DEFAULT_MAX_RESULTS,
     minScore: overrides?.query?.minScore ?? defaults?.query?.minScore ?? DEFAULT_MIN_SCORE,
+    maxInjectedChars:
+      overrides?.query?.maxInjectedChars ??
+      defaults?.query?.maxInjectedChars ??
+      DEFAULT_MAX_INJECTED_CHARS,
   };
   const hybrid = {
     enabled:
@@ -290,6 +296,7 @@ function mergeConfig(
         : DEFAULT_TEMPORAL_DECAY_HALF_LIFE_DAYS,
     ),
   );
+  const maxInjectedChars = clampInt(query.maxInjectedChars, 1, Number.MAX_SAFE_INTEGER);
   const deltaBytes = clampInt(sync.sessions.deltaBytes, 0, Number.MAX_SAFE_INTEGER);
   const deltaMessages = clampInt(sync.sessions.deltaMessages, 0, Number.MAX_SAFE_INTEGER);
   return {
@@ -316,6 +323,7 @@ function mergeConfig(
     query: {
       ...query,
       minScore,
+      maxInjectedChars,
       hybrid: {
         enabled: Boolean(hybrid.enabled),
         vectorWeight: normalizedVectorWeight,

--- a/src/agents/pi-embedded-runner/context-planner.test.ts
+++ b/src/agents/pi-embedded-runner/context-planner.test.ts
@@ -3,10 +3,17 @@ import { describe, expect, it } from "vitest";
 import { computeStaticPromptTokens, planContextMessages } from "./context-planner.js";
 
 function makeTextMessage(role: "user" | "assistant", chars: number): AgentMessage {
+  if (role === "user") {
+    return {
+      role: "user",
+      content: [{ type: "text", text: "x".repeat(chars) }],
+      timestamp: Date.now(),
+    } as AgentMessage;
+  }
   return {
-    role,
+    role: "assistant",
     content: [{ type: "text", text: "x".repeat(chars) }],
-  };
+  } as AgentMessage;
 }
 
 describe("context planner", () => {

--- a/src/agents/pi-embedded-runner/context-planner.test.ts
+++ b/src/agents/pi-embedded-runner/context-planner.test.ts
@@ -1,0 +1,106 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { describe, expect, it } from "vitest";
+import { computeStaticPromptTokens, planContextMessages } from "./context-planner.js";
+
+function makeTextMessage(role: "user" | "assistant", chars: number): AgentMessage {
+  return {
+    role,
+    content: [{ type: "text", text: "x".repeat(chars) }],
+  };
+}
+
+describe("context planner", () => {
+  it("keeps history unchanged when already under budget", () => {
+    const messages: AgentMessage[] = [
+      makeTextMessage("user", 200),
+      makeTextMessage("assistant", 200),
+      makeTextMessage("user", 200),
+    ];
+
+    const result = planContextMessages({
+      messages,
+      contextWindowTokens: 32_000,
+      reserveTokens: 4_000,
+      staticPromptTokens: 1_500,
+    });
+
+    expect(result.trimmed).toBe(false);
+    expect(result.reason).toBe("under-budget");
+    expect(result.messages).toBe(messages);
+    expect(result.droppedMessages).toBe(0);
+  });
+
+  it("drops older messages when history exceeds budget", () => {
+    const messages: AgentMessage[] = [
+      makeTextMessage("user", 8_000),
+      makeTextMessage("assistant", 8_000),
+      makeTextMessage("user", 8_000),
+      makeTextMessage("assistant", 8_000),
+      makeTextMessage("user", 8_000),
+      makeTextMessage("assistant", 8_000),
+    ];
+
+    const result = planContextMessages({
+      messages,
+      contextWindowTokens: 16_000,
+      reserveTokens: 4_000,
+      staticPromptTokens: 2_000,
+    });
+
+    expect(result.trimmed).toBe(true);
+    expect(result.reason).toBe("budget-trimmed");
+    expect(result.messages.length).toBeLessThan(messages.length);
+    expect(result.messages[0]).not.toBe(messages[0]);
+    expect(result.droppedMessages).toBeGreaterThan(0);
+    expect(result.estimatedHistoryTokensAfter).toBeLessThan(result.estimatedHistoryTokensBefore);
+  });
+
+  it("always preserves the latest user turn when it alone exceeds budget", () => {
+    const messages: AgentMessage[] = [
+      makeTextMessage("user", 2_000),
+      makeTextMessage("assistant", 2_000),
+      makeTextMessage("user", 40_000),
+      makeTextMessage("assistant", 30_000),
+    ];
+
+    const result = planContextMessages({
+      messages,
+      contextWindowTokens: 8_000,
+      reserveTokens: 2_500,
+      staticPromptTokens: 1_500,
+    });
+
+    expect(result.trimmed).toBe(true);
+    expect(result.reason).toBe("mandatory-tail-only");
+    expect(result.messages[0]?.role).toBe("user");
+    expect(result.messages).toEqual(messages.slice(2));
+  });
+
+  it("falls back to last message when static budget already overflows", () => {
+    const messages: AgentMessage[] = [
+      makeTextMessage("user", 400),
+      makeTextMessage("assistant", 400),
+      makeTextMessage("user", 400),
+    ];
+
+    const result = planContextMessages({
+      messages,
+      contextWindowTokens: 2_000,
+      reserveTokens: 1_700,
+      staticPromptTokens: 1_200,
+    });
+
+    expect(result.trimmed).toBe(true);
+    expect(result.reason).toBe("invalid-budget");
+    expect(result.messages).toEqual(messages.slice(-1));
+  });
+
+  it("estimates static prompt token cost from system + user prompt text", () => {
+    const total = computeStaticPromptTokens({
+      systemPrompt: "System instructions " + "a".repeat(1500),
+      prompt: "User task " + "b".repeat(1200),
+    });
+
+    expect(total).toBeGreaterThan(0);
+  });
+});

--- a/src/agents/pi-embedded-runner/context-planner.ts
+++ b/src/agents/pi-embedded-runner/context-planner.ts
@@ -1,0 +1,221 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { estimateTokens } from "@mariozechner/pi-coding-agent";
+
+const CHARS_PER_TOKEN_FALLBACK = 3.6;
+const ESTIMATE_SAFETY_RATIO = 0.9;
+const DEFAULT_DYNAMIC_RESERVE_RATIO = 0.08;
+const MIN_DYNAMIC_RESERVE_TOKENS = 1200;
+
+function clampFloat(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) {
+    return min;
+  }
+  return Math.min(max, Math.max(min, value));
+}
+
+function normalizePositiveInt(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return null;
+  }
+  const rounded = Math.floor(value);
+  return rounded > 0 ? rounded : null;
+}
+
+function fallbackEstimateTokens(value: unknown): number {
+  const text =
+    typeof value === "string"
+      ? value
+      : (() => {
+          try {
+            return JSON.stringify(value) ?? "";
+          } catch {
+            return "";
+          }
+        })();
+  if (!text) {
+    return 1;
+  }
+  return Math.max(1, Math.ceil(text.length / CHARS_PER_TOKEN_FALLBACK));
+}
+
+export function estimateMessageTokens(message: AgentMessage): number {
+  try {
+    const estimate = estimateTokens(message);
+    const normalized = normalizePositiveInt(estimate);
+    if (normalized) {
+      return normalized;
+    }
+  } catch {
+    // Fall back to a conservative char-based estimate.
+  }
+  return fallbackEstimateTokens(message);
+}
+
+export function estimateTextTokens(text: string): number {
+  if (!text.trim()) {
+    return 0;
+  }
+  try {
+    const estimate = estimateTokens({
+      role: "user",
+      content: [{ type: "text", text }],
+      timestamp: Date.now(),
+    });
+    const normalized = normalizePositiveInt(estimate);
+    if (normalized) {
+      return normalized;
+    }
+  } catch {
+    // Fall through to char-based estimate.
+  }
+  return fallbackEstimateTokens(text);
+}
+
+export function estimateMessagesTokens(messages: AgentMessage[]): number {
+  return messages.reduce((sum, message) => sum + estimateMessageTokens(message), 0);
+}
+
+export function computeStaticPromptTokens(params: {
+  systemPrompt: string;
+  prompt: string;
+}): number {
+  return estimateTextTokens(params.systemPrompt) + estimateTextTokens(params.prompt);
+}
+
+export type ContextPlanResult = {
+  messages: AgentMessage[];
+  trimmed: boolean;
+  reason: "empty" | "invalid-budget" | "under-budget" | "mandatory-tail-only" | "budget-trimmed";
+  estimatedHistoryTokensBefore: number;
+  estimatedHistoryTokensAfter: number;
+  historyBudgetTokens: number;
+  droppedMessages: number;
+  droppedTokens: number;
+};
+
+export function planContextMessages(params: {
+  messages: AgentMessage[];
+  contextWindowTokens: number;
+  reserveTokens: number;
+  staticPromptTokens: number;
+  maxHistoryShare?: number;
+  dynamicReserveRatio?: number;
+  minDynamicReserveTokens?: number;
+}): ContextPlanResult {
+  const totalMessages = params.messages.length;
+  if (totalMessages === 0) {
+    return {
+      messages: params.messages,
+      trimmed: false,
+      reason: "empty",
+      estimatedHistoryTokensBefore: 0,
+      estimatedHistoryTokensAfter: 0,
+      historyBudgetTokens: 0,
+      droppedMessages: 0,
+      droppedTokens: 0,
+    };
+  }
+
+  const tokenByIndex = params.messages.map((message) => estimateMessageTokens(message));
+  const totalHistoryTokens = tokenByIndex.reduce((sum, tokens) => sum + tokens, 0);
+
+  const contextWindowTokens = Math.max(1, Math.floor(params.contextWindowTokens));
+  const reserveTokens = Math.max(0, Math.floor(params.reserveTokens));
+  const staticPromptTokens = Math.max(0, Math.floor(params.staticPromptTokens));
+  const maxHistoryShare = clampFloat(params.maxHistoryShare ?? 1, 0.1, 1);
+  const dynamicReserveRatio = clampFloat(
+    params.dynamicReserveRatio ?? DEFAULT_DYNAMIC_RESERVE_RATIO,
+    0,
+    0.5,
+  );
+  const minDynamicReserveTokens = Math.max(
+    0,
+    Math.floor(params.minDynamicReserveTokens ?? MIN_DYNAMIC_RESERVE_TOKENS),
+  );
+  const dynamicReserveTokens = Math.max(
+    minDynamicReserveTokens,
+    Math.floor(contextWindowTokens * dynamicReserveRatio),
+  );
+
+  const availableForHistory =
+    contextWindowTokens - reserveTokens - staticPromptTokens - dynamicReserveTokens;
+  const historyBudgetTokens = Math.max(
+    1,
+    Math.floor(availableForHistory * ESTIMATE_SAFETY_RATIO * maxHistoryShare),
+  );
+
+  if (availableForHistory <= 0) {
+    const fallbackTail = params.messages.slice(-1);
+    const keptTokens = tokenByIndex[tokenByIndex.length - 1] ?? 0;
+    return {
+      messages: fallbackTail,
+      trimmed: true,
+      reason: "invalid-budget",
+      estimatedHistoryTokensBefore: totalHistoryTokens,
+      estimatedHistoryTokensAfter: keptTokens,
+      historyBudgetTokens,
+      droppedMessages: Math.max(0, totalMessages - fallbackTail.length),
+      droppedTokens: Math.max(0, totalHistoryTokens - keptTokens),
+    };
+  }
+
+  if (totalHistoryTokens <= historyBudgetTokens) {
+    return {
+      messages: params.messages,
+      trimmed: false,
+      reason: "under-budget",
+      estimatedHistoryTokensBefore: totalHistoryTokens,
+      estimatedHistoryTokensAfter: totalHistoryTokens,
+      historyBudgetTokens,
+      droppedMessages: 0,
+      droppedTokens: 0,
+    };
+  }
+
+  let mandatoryStart = totalMessages - 1;
+  for (let i = totalMessages - 1; i >= 0; i -= 1) {
+    if (params.messages[i]?.role === "user") {
+      mandatoryStart = i;
+      break;
+    }
+  }
+  const mandatoryTailTokens = tokenByIndex
+    .slice(mandatoryStart)
+    .reduce((sum, tokens) => sum + tokens, 0);
+  if (mandatoryTailTokens >= historyBudgetTokens) {
+    const kept = params.messages.slice(mandatoryStart);
+    return {
+      messages: kept,
+      trimmed: true,
+      reason: "mandatory-tail-only",
+      estimatedHistoryTokensBefore: totalHistoryTokens,
+      estimatedHistoryTokensAfter: mandatoryTailTokens,
+      historyBudgetTokens,
+      droppedMessages: Math.max(0, totalMessages - kept.length),
+      droppedTokens: Math.max(0, totalHistoryTokens - mandatoryTailTokens),
+    };
+  }
+
+  let startIndex = mandatoryStart;
+  let keptTokens = mandatoryTailTokens;
+  for (let i = mandatoryStart - 1; i >= 0; i -= 1) {
+    const nextTokens = tokenByIndex[i] ?? 0;
+    if (keptTokens + nextTokens > historyBudgetTokens) {
+      break;
+    }
+    keptTokens += nextTokens;
+    startIndex = i;
+  }
+
+  const kept = params.messages.slice(startIndex);
+  return {
+    messages: kept,
+    trimmed: startIndex > 0,
+    reason: "budget-trimmed",
+    estimatedHistoryTokensBefore: totalHistoryTokens,
+    estimatedHistoryTokensAfter: keptTokens,
+    historyBudgetTokens,
+    droppedMessages: Math.max(0, startIndex),
+    droppedTokens: Math.max(0, totalHistoryTokens - keptTokens),
+  };
+}

--- a/src/agents/pi-embedded-runner/run/attempt.e2e.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.e2e.test.ts
@@ -1,7 +1,7 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { ImageContent } from "@mariozechner/pi-ai";
 import { describe, expect, it } from "vitest";
-import { injectHistoryImagesIntoMessages } from "./attempt.js";
+import { decideSessionSummaryInjection, injectHistoryImagesIntoMessages } from "./attempt.js";
 
 describe("injectHistoryImagesIntoMessages", () => {
   const image: ImageContent = { type: "image", data: "abc", mimeType: "image/png" };
@@ -56,5 +56,66 @@ describe("injectHistoryImagesIntoMessages", () => {
     expect(didMutate).toBe(false);
     const firstAssistant = messages[0] as Extract<AgentMessage, { role: "assistant" }> | undefined;
     expect(firstAssistant?.content).toBe("noop");
+  });
+});
+
+describe("decideSessionSummaryInjection", () => {
+  it("injects summary when base plan was trimmed", () => {
+    const decision = decideSessionSummaryInjection({
+      summaryContext: "[SESSION_SUMMARY]\n- x",
+      basePlan: {
+        messages: [],
+        trimmed: true,
+        reason: "budget-trimmed",
+        estimatedHistoryTokensBefore: 8_000,
+        estimatedHistoryTokensAfter: 2_000,
+        historyBudgetTokens: 4_000,
+        droppedMessages: 4,
+        droppedTokens: 6_000,
+      },
+    });
+
+    expect(decision.inject).toBe(true);
+    expect(decision.reason).toBe("trimmed");
+  });
+
+  it("injects summary when pressure ratio exceeds threshold", () => {
+    const decision = decideSessionSummaryInjection({
+      summaryContext: "[SESSION_SUMMARY]\n- x",
+      basePlan: {
+        messages: [],
+        trimmed: false,
+        reason: "under-budget",
+        estimatedHistoryTokensBefore: 7_400,
+        estimatedHistoryTokensAfter: 7_400,
+        historyBudgetTokens: 10_000,
+        droppedMessages: 0,
+        droppedTokens: 0,
+      },
+      pressureThreshold: 0.7,
+    });
+
+    expect(decision.inject).toBe(true);
+    expect(decision.reason).toBe("pressure");
+  });
+
+  it("skips summary when pressure is low and no trimming occurred", () => {
+    const decision = decideSessionSummaryInjection({
+      summaryContext: "[SESSION_SUMMARY]\n- x",
+      basePlan: {
+        messages: [],
+        trimmed: false,
+        reason: "under-budget",
+        estimatedHistoryTokensBefore: 2_000,
+        estimatedHistoryTokensAfter: 2_000,
+        historyBudgetTokens: 10_000,
+        droppedMessages: 0,
+        droppedTokens: 0,
+      },
+      pressureThreshold: 0.7,
+    });
+
+    expect(decision.inject).toBe(false);
+    expect(decision.reason).toBe("none");
   });
 });

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -30,6 +30,7 @@ import {
   listChannelSupportedActions,
   resolveChannelMessageToolHints,
 } from "../../channel-tools.js";
+import { resolveContextWindowInfo } from "../../context-window-guard.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../defaults.js";
 import { resolveOpenClawDocsPath } from "../../docs-path.js";
 import { isTimeoutError } from "../../failover-error.js";
@@ -70,6 +71,7 @@ import { resolveTranscriptPolicy } from "../../transcript-policy.js";
 import { DEFAULT_BOOTSTRAP_FILENAME } from "../../workspace.js";
 import { isRunnerAbortError } from "../abort.js";
 import { appendCacheTtlTimestamp, isCacheTtlEligibleProvider } from "../cache-ttl.js";
+import { computeStaticPromptTokens, planContextMessages } from "../context-planner.js";
 import { buildEmbeddedExtensionPaths } from "../extensions.js";
 import { applyExtraParamsToAgent } from "../extra-params.js";
 import {
@@ -676,17 +678,42 @@ export async function runEmbeddedAttempt(
         const validated = transcriptPolicy.validateAnthropicTurns
           ? validateAnthropicTurns(validatedGemini)
           : validatedGemini;
-        const truncated = limitHistoryTurns(
-          validated,
+
+        const contextWindowTokens = resolveContextWindowInfo({
+          cfg: params.config,
+          provider: params.provider,
+          modelId: params.modelId,
+          modelContextWindow: params.model?.contextWindow,
+          defaultTokens: DEFAULT_CONTEXT_TOKENS,
+        }).tokens;
+        const reserveTokens = resolveCompactionReserveTokensFloor(params.config);
+        const staticPromptTokens = computeStaticPromptTokens({
+          systemPrompt: systemPromptText,
+          prompt: params.prompt,
+        });
+        const budgeted = planContextMessages({
+          messages: validated,
+          contextWindowTokens,
+          reserveTokens,
+          staticPromptTokens,
+        });
+        const turnLimited = limitHistoryTurns(
+          budgeted.messages,
           getDmHistoryLimitFromSessionKey(params.sessionKey, params.config),
         );
-        // Re-run tool_use/tool_result pairing repair after truncation, since
-        // limitHistoryTurns can orphan tool_result blocks by removing the
+        // Re-run tool_use/tool_result pairing repair after trimming, since
+        // token/turn trimming can orphan tool_result blocks by removing the
         // assistant message that contained the matching tool_use.
         const limited = transcriptPolicy.repairToolUseResultPairing
-          ? sanitizeToolUseResultPairing(truncated)
-          : truncated;
-        cacheTrace?.recordStage("session:limited", { messages: limited });
+          ? sanitizeToolUseResultPairing(turnLimited)
+          : turnLimited;
+        cacheTrace?.recordStage("session:limited", {
+          messages: limited,
+          note:
+            `trimmed=${budgeted.trimmed ? "yes" : "no"} ` +
+            `reason=${budgeted.reason} ` +
+            `tokens=${budgeted.estimatedHistoryTokensAfter}/${budgeted.historyBudgetTokens}`,
+        });
         if (limited.length > 0) {
           activeSession.agent.replaceMessages(limited);
         }

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -71,7 +71,11 @@ import { resolveTranscriptPolicy } from "../../transcript-policy.js";
 import { DEFAULT_BOOTSTRAP_FILENAME } from "../../workspace.js";
 import { isRunnerAbortError } from "../abort.js";
 import { appendCacheTtlTimestamp, isCacheTtlEligibleProvider } from "../cache-ttl.js";
-import { computeStaticPromptTokens, planContextMessages } from "../context-planner.js";
+import {
+  computeStaticPromptTokens,
+  planContextMessages,
+  type ContextPlanResult,
+} from "../context-planner.js";
 import { buildEmbeddedExtensionPaths } from "../extensions.js";
 import { applyExtraParamsToAgent } from "../extra-params.js";
 import {
@@ -112,6 +116,37 @@ import {
 } from "./compaction-timeout.js";
 import { detectAndLoadPromptImages } from "./images.js";
 import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./types.js";
+
+const DEFAULT_SUMMARY_INJECTION_PRESSURE_THRESHOLD = 0.72;
+
+export type SessionSummaryInjectionDecision = {
+  inject: boolean;
+  reason: "none" | "trimmed" | "pressure";
+  pressureRatio: number;
+};
+
+export function decideSessionSummaryInjection(params: {
+  summaryContext: string;
+  basePlan: ContextPlanResult;
+  pressureThreshold?: number;
+}): SessionSummaryInjectionDecision {
+  const pressureThreshold = Number.isFinite(params.pressureThreshold)
+    ? Math.max(0, params.pressureThreshold ?? DEFAULT_SUMMARY_INJECTION_PRESSURE_THRESHOLD)
+    : DEFAULT_SUMMARY_INJECTION_PRESSURE_THRESHOLD;
+  const pressureRatio =
+    params.basePlan.estimatedHistoryTokensBefore / Math.max(1, params.basePlan.historyBudgetTokens);
+
+  if (!params.summaryContext.trim()) {
+    return { inject: false, reason: "none", pressureRatio };
+  }
+  if (params.basePlan.trimmed) {
+    return { inject: true, reason: "trimmed", pressureRatio };
+  }
+  if (pressureRatio >= pressureThreshold) {
+    return { inject: true, reason: "pressure", pressureRatio };
+  }
+  return { inject: false, reason: "none", pressureRatio };
+}
 
 export function injectHistoryImagesIntoMessages(
   messages: AgentMessage[],
@@ -709,10 +744,6 @@ export async function runEmbeddedAttempt(
           buildSessionSummaryPrompt({
             state: nextSummaryState,
           }) ?? "";
-        if (sessionSummaryContext) {
-          effectiveSystemPromptText = `${systemPromptText}\n\n${sessionSummaryContext}`;
-          applySystemPromptOverrideToSession(activeSession, effectiveSystemPromptText);
-        }
 
         const contextWindowTokens = resolveContextWindowInfo({
           cfg: params.config,
@@ -722,16 +753,35 @@ export async function runEmbeddedAttempt(
           defaultTokens: DEFAULT_CONTEXT_TOKENS,
         }).tokens;
         const reserveTokens = resolveCompactionReserveTokensFloor(params.config);
-        const staticPromptTokens = computeStaticPromptTokens({
-          systemPrompt: effectiveSystemPromptText,
+        const baseStaticPromptTokens = computeStaticPromptTokens({
+          systemPrompt: systemPromptText,
           prompt: params.prompt,
         });
-        const budgeted = planContextMessages({
+        const basePlan = planContextMessages({
           messages: validated,
           contextWindowTokens,
           reserveTokens,
-          staticPromptTokens,
+          staticPromptTokens: baseStaticPromptTokens,
         });
+        const summaryDecision = decideSessionSummaryInjection({
+          summaryContext: sessionSummaryContext,
+          basePlan,
+        });
+        let budgeted = basePlan;
+        if (summaryDecision.inject) {
+          effectiveSystemPromptText = `${systemPromptText}\n\n${sessionSummaryContext}`;
+          applySystemPromptOverrideToSession(activeSession, effectiveSystemPromptText);
+          const summarizedStaticPromptTokens = computeStaticPromptTokens({
+            systemPrompt: effectiveSystemPromptText,
+            prompt: params.prompt,
+          });
+          budgeted = planContextMessages({
+            messages: validated,
+            contextWindowTokens,
+            reserveTokens,
+            staticPromptTokens: summarizedStaticPromptTokens,
+          });
+        }
         const turnLimited = limitHistoryTurns(
           budgeted.messages,
           getDmHistoryLimitFromSessionKey(params.sessionKey, params.config),
@@ -748,7 +798,9 @@ export async function runEmbeddedAttempt(
             `trimmed=${budgeted.trimmed ? "yes" : "no"} ` +
             `reason=${budgeted.reason} ` +
             `tokens=${budgeted.estimatedHistoryTokensAfter}/${budgeted.historyBudgetTokens} ` +
-            `summary=${sessionSummaryContext ? "on" : "off"}`,
+            `summary=${summaryDecision.inject ? "on" : "off"} ` +
+            `summaryReason=${summaryDecision.reason} ` +
+            `pressure=${summaryDecision.pressureRatio.toFixed(2)}`,
         });
         if (limited.length > 0) {
           activeSession.agent.replaceMessages(limited);

--- a/src/agents/pi-embedded-runner/session-summary.test.ts
+++ b/src/agents/pi-embedded-runner/session-summary.test.ts
@@ -12,10 +12,17 @@ import {
 } from "./session-summary.js";
 
 function makeMessage(role: "user" | "assistant", text: string): AgentMessage {
+  if (role === "user") {
+    return {
+      role: "user",
+      content: [{ type: "text", text }],
+      timestamp: Date.now(),
+    } as AgentMessage;
+  }
   return {
-    role,
+    role: "assistant",
     content: [{ type: "text", text }],
-  };
+  } as AgentMessage;
 }
 
 describe("session summary state", () => {
@@ -37,6 +44,8 @@ describe("session summary state", () => {
         toolCallId: "call_1",
         toolName: "exec",
         content: [{ type: "text", text: "ignored" }],
+        isError: false,
+        timestamp: Date.now(),
       },
       makeMessage("assistant", "third"),
     ];

--- a/src/agents/pi-embedded-runner/session-summary.test.ts
+++ b/src/agents/pi-embedded-runner/session-summary.test.ts
@@ -1,7 +1,7 @@
-import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { describe, expect, it } from "vitest";
 import {
   buildSessionSummaryPrompt,

--- a/src/agents/pi-embedded-runner/session-summary.test.ts
+++ b/src/agents/pi-embedded-runner/session-summary.test.ts
@@ -1,0 +1,103 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  buildSessionSummaryPrompt,
+  getSessionSummaryStatePath,
+  loadSessionSummaryState,
+  persistSessionSummaryState,
+  updateSessionSummaryState,
+} from "./session-summary.js";
+
+function makeMessage(role: "user" | "assistant", text: string): AgentMessage {
+  return {
+    role,
+    content: [{ type: "text", text }],
+  };
+}
+
+describe("session summary state", () => {
+  it("loads empty state when file is missing", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-summary-state-"));
+    const sessionFile = path.join(dir, "session.jsonl");
+
+    const state = await loadSessionSummaryState({ sessionFile });
+    expect(state.items).toEqual([]);
+    expect(state.lastProcessedMessageCount).toBe(0);
+  });
+
+  it("updates state from new user/assistant messages only", () => {
+    const messages: AgentMessage[] = [
+      makeMessage("user", "first"),
+      makeMessage("assistant", "second"),
+      {
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "exec",
+        content: [{ type: "text", text: "ignored" }],
+      },
+      makeMessage("assistant", "third"),
+    ];
+
+    const updated = updateSessionSummaryState({
+      state: {
+        version: 1,
+        lastProcessedMessageCount: 0,
+        items: [],
+        updatedAt: Date.now(),
+      },
+      messages,
+      maxItems: 10,
+    });
+
+    expect(updated.items).toEqual(["User: first", "Assistant: second", "Assistant: third"]);
+    expect(updated.lastProcessedMessageCount).toBe(messages.length);
+  });
+
+  it("builds bounded prompt from most recent summary items", () => {
+    const prompt = buildSessionSummaryPrompt({
+      state: {
+        version: 1,
+        lastProcessedMessageCount: 10,
+        items: [
+          "User: old",
+          "Assistant: old-reply",
+          "User: latest request with details",
+          "Assistant: latest response",
+        ],
+        updatedAt: Date.now(),
+      },
+      maxChars: 170,
+    });
+
+    expect(prompt).toBeTruthy();
+    expect(prompt).toContain("[SESSION_SUMMARY]");
+    expect(prompt).toContain("latest");
+    expect(prompt?.length).toBeLessThanOrEqual(170);
+  });
+
+  it("persists and reloads summary state", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-summary-roundtrip-"));
+    const sessionFile = path.join(dir, "session.jsonl");
+    await fs.writeFile(sessionFile, "", "utf-8");
+
+    await persistSessionSummaryState({
+      sessionFile,
+      state: {
+        version: 1,
+        lastProcessedMessageCount: 7,
+        items: ["User: hello", "Assistant: world"],
+        updatedAt: Date.now(),
+      },
+    });
+
+    const loaded = await loadSessionSummaryState({ sessionFile });
+    expect(loaded.items).toEqual(["User: hello", "Assistant: world"]);
+    expect(loaded.lastProcessedMessageCount).toBe(7);
+
+    const statePath = getSessionSummaryStatePath(sessionFile);
+    await expect(fs.stat(statePath)).resolves.toBeTruthy();
+  });
+});

--- a/src/agents/pi-embedded-runner/session-summary.test.ts
+++ b/src/agents/pi-embedded-runner/session-summary.test.ts
@@ -96,6 +96,22 @@ describe("session summary state", () => {
     expect(prompt?.length).toBeLessThanOrEqual(170);
   });
 
+  it("resets summary tracking when transcript rewinds", () => {
+    const rewound = updateSessionSummaryState({
+      state: {
+        version: 1,
+        lastProcessedMessageCount: 10,
+        items: ["User: stale", "Assistant: stale"],
+        updatedAt: Date.now(),
+      },
+      messages: [makeMessage("user", "fresh start"), makeMessage("assistant", "fresh reply")],
+      maxItems: 10,
+    });
+
+    expect(rewound.lastProcessedMessageCount).toBe(2);
+    expect(rewound.items).toEqual(["User: fresh start", "Assistant: fresh reply"]);
+  });
+
   it("persists and reloads summary state", async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-summary-roundtrip-"));
     const sessionFile = path.join(dir, "session.jsonl");

--- a/src/agents/pi-embedded-runner/session-summary.test.ts
+++ b/src/agents/pi-embedded-runner/session-summary.test.ts
@@ -56,6 +56,24 @@ describe("session summary state", () => {
     expect(updated.lastProcessedMessageCount).toBe(messages.length);
   });
 
+  it("skips synthetic session summary messages", () => {
+    const updated = updateSessionSummaryState({
+      state: {
+        version: 1,
+        lastProcessedMessageCount: 0,
+        items: [],
+        updatedAt: Date.now(),
+      },
+      messages: [
+        makeMessage("user", "[SESSION_SUMMARY]\nUse this as compressed prior context."),
+        makeMessage("assistant", "normal reply"),
+      ],
+      maxItems: 10,
+    });
+
+    expect(updated.items).toEqual(["Assistant: normal reply"]);
+  });
+
   it("builds bounded prompt from most recent summary items", () => {
     const prompt = buildSessionSummaryPrompt({
       state: {

--- a/src/agents/pi-embedded-runner/session-summary.ts
+++ b/src/agents/pi-embedded-runner/session-summary.ts
@@ -1,0 +1,210 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import fs from "node:fs/promises";
+
+const SUMMARY_VERSION = 1;
+const DEFAULT_MAX_ITEMS = 60;
+const DEFAULT_MAX_ITEM_CHARS = 220;
+const DEFAULT_MAX_PROMPT_CHARS = 1200;
+
+export type SessionSummaryState = {
+  version: number;
+  lastProcessedMessageCount: number;
+  items: string[];
+  updatedAt: number;
+};
+
+function createEmptyState(): SessionSummaryState {
+  return {
+    version: SUMMARY_VERSION,
+    lastProcessedMessageCount: 0,
+    items: [],
+    updatedAt: Date.now(),
+  };
+}
+
+function normalizeText(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function truncateText(value: string, maxChars: number): string {
+  if (value.length <= maxChars) {
+    return value;
+  }
+  if (maxChars <= 1) {
+    return value.slice(0, Math.max(0, maxChars));
+  }
+  return `${value.slice(0, maxChars - 1)}…`;
+}
+
+function extractMessageText(message: AgentMessage): string | null {
+  if (message.role !== "user" && message.role !== "assistant") {
+    return null;
+  }
+
+  if (typeof message.content === "string") {
+    const normalized = normalizeText(message.content);
+    return normalized || null;
+  }
+
+  if (!Array.isArray(message.content)) {
+    return null;
+  }
+
+  const textParts: string[] = [];
+  for (const block of message.content) {
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    const typedBlock = block as { type?: unknown; text?: unknown };
+    if (typedBlock.type === "text" && typeof typedBlock.text === "string") {
+      const normalized = normalizeText(typedBlock.text);
+      if (normalized) {
+        textParts.push(normalized);
+      }
+    }
+  }
+
+  if (textParts.length === 0) {
+    return null;
+  }
+  return textParts.join(" ");
+}
+
+function summarizeMessage(message: AgentMessage): string | null {
+  const text = extractMessageText(message);
+  if (!text) {
+    return null;
+  }
+  const prefix = message.role === "user" ? "User" : "Assistant";
+  return `${prefix}: ${truncateText(text, DEFAULT_MAX_ITEM_CHARS)}`;
+}
+
+function normalizeState(raw: unknown): SessionSummaryState {
+  if (!raw || typeof raw !== "object") {
+    return createEmptyState();
+  }
+  const record = raw as Partial<SessionSummaryState>;
+  const items = Array.isArray(record.items)
+    ? record.items.filter((item): item is string => typeof item === "string")
+    : [];
+  const lastProcessedMessageCount =
+    typeof record.lastProcessedMessageCount === "number" &&
+    Number.isFinite(record.lastProcessedMessageCount) &&
+    record.lastProcessedMessageCount >= 0
+      ? Math.floor(record.lastProcessedMessageCount)
+      : 0;
+  const updatedAt =
+    typeof record.updatedAt === "number" && Number.isFinite(record.updatedAt)
+      ? record.updatedAt
+      : Date.now();
+
+  return {
+    version: SUMMARY_VERSION,
+    lastProcessedMessageCount,
+    items,
+    updatedAt,
+  };
+}
+
+export function getSessionSummaryStatePath(sessionFile: string): string {
+  return `${sessionFile}.summary.json`;
+}
+
+export async function loadSessionSummaryState(params: {
+  sessionFile: string;
+}): Promise<SessionSummaryState> {
+  const statePath = getSessionSummaryStatePath(params.sessionFile);
+  try {
+    const raw = await fs.readFile(statePath, "utf-8");
+    return normalizeState(JSON.parse(raw));
+  } catch {
+    return createEmptyState();
+  }
+}
+
+export function updateSessionSummaryState(params: {
+  state: SessionSummaryState;
+  messages: AgentMessage[];
+  maxItems?: number;
+}): SessionSummaryState {
+  const maxItems = Math.max(1, Math.floor(params.maxItems ?? DEFAULT_MAX_ITEMS));
+  const safeStart = Math.max(
+    0,
+    Math.min(params.state.lastProcessedMessageCount, params.messages.length),
+  );
+  if (safeStart >= params.messages.length) {
+    return params.state;
+  }
+
+  const additions: string[] = [];
+  for (const message of params.messages.slice(safeStart)) {
+    const summarized = summarizeMessage(message);
+    if (!summarized) {
+      continue;
+    }
+    if (params.state.items[params.state.items.length - 1] === summarized) {
+      continue;
+    }
+    additions.push(summarized);
+  }
+
+  const merged =
+    additions.length > 0
+      ? [...params.state.items, ...additions].slice(-maxItems)
+      : params.state.items.slice(-maxItems);
+  return {
+    ...params.state,
+    items: merged,
+    lastProcessedMessageCount: params.messages.length,
+    updatedAt: Date.now(),
+  };
+}
+
+export function buildSessionSummaryPrompt(params: {
+  state: SessionSummaryState;
+  maxChars?: number;
+}): string | null {
+  if (params.state.items.length === 0) {
+    return null;
+  }
+  const maxChars = Math.max(1, Math.floor(params.maxChars ?? DEFAULT_MAX_PROMPT_CHARS));
+  const header = [
+    "[SESSION_SUMMARY]",
+    "Use this as compressed prior context; prioritize direct transcript turns when present.",
+  ].join("\n");
+  if (header.length >= maxChars) {
+    return truncateText(header, maxChars);
+  }
+
+  const keptItems: string[] = [];
+  let totalChars = header.length + 1;
+  for (const item of [...params.state.items].toReversed()) {
+    const line = `- ${item}`;
+    const projected = totalChars + line.length + 1;
+    if (projected > maxChars) {
+      break;
+    }
+    keptItems.push(line);
+    totalChars = projected;
+  }
+
+  if (keptItems.length === 0) {
+    return truncateText(header, maxChars);
+  }
+  keptItems.reverse();
+  return `${header}\n${keptItems.join("\n")}`;
+}
+
+export async function persistSessionSummaryState(params: {
+  sessionFile: string;
+  state: SessionSummaryState;
+}): Promise<void> {
+  const statePath = getSessionSummaryStatePath(params.sessionFile);
+  const payload = {
+    version: SUMMARY_VERSION,
+    lastProcessedMessageCount: Math.max(0, Math.floor(params.state.lastProcessedMessageCount)),
+    items: params.state.items.slice(),
+    updatedAt: Date.now(),
+  };
+  await fs.writeFile(statePath, `${JSON.stringify(payload, null, 2)}\n`, "utf-8");
+}

--- a/src/agents/pi-embedded-runner/session-summary.ts
+++ b/src/agents/pi-embedded-runner/session-summary.ts
@@ -1,5 +1,5 @@
-import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import fs from "node:fs/promises";
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
 
 const SUMMARY_VERSION = 1;
 const DEFAULT_MAX_ITEMS = 60;

--- a/src/agents/pi-embedded-runner/session-summary.ts
+++ b/src/agents/pi-embedded-runner/session-summary.ts
@@ -132,10 +132,11 @@ export function updateSessionSummaryState(params: {
   maxItems?: number;
 }): SessionSummaryState {
   const maxItems = Math.max(1, Math.floor(params.maxItems ?? DEFAULT_MAX_ITEMS));
-  const safeStart = Math.max(
-    0,
-    Math.min(params.state.lastProcessedMessageCount, params.messages.length),
-  );
+  const rewoundTranscript = params.state.lastProcessedMessageCount > params.messages.length;
+  const safeStart = rewoundTranscript
+    ? 0
+    : Math.max(0, Math.min(params.state.lastProcessedMessageCount, params.messages.length));
+  const baseItems = rewoundTranscript ? [] : params.state.items;
   if (safeStart >= params.messages.length) {
     return params.state;
   }
@@ -146,7 +147,7 @@ export function updateSessionSummaryState(params: {
     if (!summarized) {
       continue;
     }
-    if (params.state.items[params.state.items.length - 1] === summarized) {
+    if (baseItems[baseItems.length - 1] === summarized) {
       continue;
     }
     additions.push(summarized);
@@ -154,8 +155,8 @@ export function updateSessionSummaryState(params: {
 
   const merged =
     additions.length > 0
-      ? [...params.state.items, ...additions].slice(-maxItems)
-      : params.state.items.slice(-maxItems);
+      ? [...baseItems, ...additions].slice(-maxItems)
+      : baseItems.slice(-maxItems);
   return {
     ...params.state,
     items: merged,

--- a/src/agents/pi-embedded-runner/session-summary.ts
+++ b/src/agents/pi-embedded-runner/session-summary.ts
@@ -5,6 +5,7 @@ const SUMMARY_VERSION = 1;
 const DEFAULT_MAX_ITEMS = 60;
 const DEFAULT_MAX_ITEM_CHARS = 220;
 const DEFAULT_MAX_PROMPT_CHARS = 1200;
+const SESSION_SUMMARY_PREFIX = "[SESSION_SUMMARY]";
 
 export type SessionSummaryState = {
   version: number;
@@ -73,6 +74,9 @@ function extractMessageText(message: AgentMessage): string | null {
 function summarizeMessage(message: AgentMessage): string | null {
   const text = extractMessageText(message);
   if (!text) {
+    return null;
+  }
+  if (text.startsWith(SESSION_SUMMARY_PREFIX)) {
     return null;
   }
   const prefix = message.role === "user" ? "User" : "Assistant";

--- a/src/agents/session-tool-result-guard.e2e.test.ts
+++ b/src/agents/session-tool-result-guard.e2e.test.ts
@@ -1,8 +1,8 @@
-import type { AgentMessage } from "@mariozechner/pi-agent-core";
-import { SessionManager } from "@mariozechner/pi-coding-agent";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { SessionManager } from "@mariozechner/pi-coding-agent";
 import { describe, expect, it } from "vitest";
 import { installSessionToolResultGuard } from "./session-tool-result-guard.js";
 

--- a/src/agents/session-tool-result-guard.tool-result-persist-hook.e2e.test.ts
+++ b/src/agents/session-tool-result-guard.tool-result-persist-hook.e2e.test.ts
@@ -1,8 +1,8 @@
-import type { AgentMessage } from "@mariozechner/pi-agent-core";
-import { SessionManager } from "@mariozechner/pi-coding-agent";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { SessionManager } from "@mariozechner/pi-coding-agent";
 import { describe, expect, it, afterEach } from "vitest";
 import {
   initializeGlobalHookRunner,

--- a/src/agents/session-tool-result-guard.tool-result-persist-hook.e2e.test.ts
+++ b/src/agents/session-tool-result-guard.tool-result-persist-hook.e2e.test.ts
@@ -1,8 +1,8 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { SessionManager } from "@mariozechner/pi-coding-agent";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import type { AgentMessage } from "@mariozechner/pi-agent-core";
-import { SessionManager } from "@mariozechner/pi-coding-agent";
 import { describe, expect, it, afterEach } from "vitest";
 import {
   initializeGlobalHookRunner,

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -1,13 +1,13 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { TextContent } from "@mariozechner/pi-ai";
 import type { SessionManager } from "@mariozechner/pi-coding-agent";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
 import type {
   PluginHookBeforeMessageWriteEvent,
   PluginHookBeforeMessageWriteResult,
 } from "../plugins/types.js";
-import crypto from "node:crypto";
-import fs from "node:fs";
-import path from "node:path";
 import { emitSessionTranscriptUpdate } from "../sessions/transcript-events.js";
 import { HARD_MAX_TOOL_RESULT_CHARS } from "./pi-embedded-runner/tool-result-truncation.js";
 import { makeMissingToolResult, sanitizeToolCallInputs } from "./session-transcript-repair.js";

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -1,9 +1,9 @@
-import type { AgentMessage } from "@mariozechner/pi-agent-core";
-import type { TextContent } from "@mariozechner/pi-ai";
-import type { SessionManager } from "@mariozechner/pi-coding-agent";
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { TextContent } from "@mariozechner/pi-ai";
+import type { SessionManager } from "@mariozechner/pi-coding-agent";
 import type {
   PluginHookBeforeMessageWriteEvent,
   PluginHookBeforeMessageWriteResult,

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -5,6 +5,9 @@ import type {
   PluginHookBeforeMessageWriteEvent,
   PluginHookBeforeMessageWriteResult,
 } from "../plugins/types.js";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
 import { emitSessionTranscriptUpdate } from "../sessions/transcript-events.js";
 import { HARD_MAX_TOOL_RESULT_CHARS } from "./pi-embedded-runner/tool-result-truncation.js";
 import { makeMissingToolResult, sanitizeToolCallInputs } from "./session-transcript-repair.js";
@@ -13,6 +16,11 @@ import { extractToolCallsFromAssistant, extractToolResultId } from "./tool-call-
 const GUARD_TRUNCATION_SUFFIX =
   "\n\n⚠️ [Content truncated during persistence — original exceeded size limit. " +
   "Use offset/limit parameters or request specific sections for large content.]";
+const TOOL_OUTPUT_DIRNAME = "tool-output";
+const TOOL_RESULT_DETAILS_EXTERNALIZE_MIN_CHARS = 24_000;
+const TOOL_RESULT_TEXT_EXTERNALIZE_MIN_CHARS = 120_000;
+const TOOL_RESULT_PREVIEW_MAX_CHARS = 8_000;
+const TOOL_RESULT_EXTERNALIZE_NOTICE_PREFIX = "[openclaw] Full tool output saved to";
 
 /**
  * Truncate oversized text content blocks in a tool result message.
@@ -74,6 +82,177 @@ function capToolResultSize(msg: AgentMessage): AgentMessage {
   });
 
   return { ...msg, content: newContent } as AgentMessage;
+}
+
+function sanitizeFileNamePart(value: string, fallback: string): string {
+  const trimmed = value.trim().toLowerCase();
+  if (!trimmed) {
+    return fallback;
+  }
+  const cleaned = trimmed
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+  return cleaned || fallback;
+}
+
+function truncatePreview(text: string, maxChars: number): string {
+  if (text.length <= maxChars) {
+    return text;
+  }
+  return `${text.slice(0, Math.max(0, maxChars - 1))}…`;
+}
+
+function extractToolResultText(content: unknown): string {
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  const parts: string[] = [];
+  for (const block of content) {
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    const rec = block as { type?: unknown; text?: unknown };
+    if (rec.type === "text" && typeof rec.text === "string") {
+      parts.push(rec.text);
+    }
+  }
+  return parts.join("\n");
+}
+
+function summarizeDetails(details: Record<string, unknown>): Record<string, unknown> {
+  const summary: Record<string, unknown> = {};
+  const preferredKeys = [
+    "status",
+    "exitCode",
+    "error",
+    "path",
+    "sessionId",
+    "runId",
+    "success",
+    "killed",
+    "timedOut",
+  ];
+  for (const key of preferredKeys) {
+    const value = details[key];
+    if (
+      value === null ||
+      typeof value === "boolean" ||
+      typeof value === "number" ||
+      (typeof value === "string" && value.length <= 500)
+    ) {
+      summary[key] = value;
+    }
+  }
+  return summary;
+}
+
+function getSessionFilePath(sessionManager: SessionManager): string | null {
+  return (sessionManager as { getSessionFile?: () => string | null }).getSessionFile?.() ?? null;
+}
+
+function externalizeLargeToolResultPayload(params: {
+  sessionFile: string | null;
+  message: AgentMessage;
+  toolCallId?: string;
+  toolName?: string;
+}): AgentMessage {
+  if (!params.sessionFile) {
+    return params.message;
+  }
+  const role = (params.message as { role?: string }).role;
+  if (role !== "toolResult") {
+    return params.message;
+  }
+
+  const messageRecord = params.message as unknown as Record<string, unknown>;
+  const details =
+    messageRecord.details && typeof messageRecord.details === "object"
+      ? (messageRecord.details as Record<string, unknown>)
+      : undefined;
+  const detailsSerialized = details ? JSON.stringify(details) : "";
+  const detailsTooLarge = detailsSerialized.length > TOOL_RESULT_DETAILS_EXTERNALIZE_MIN_CHARS;
+  const fullText = extractToolResultText(messageRecord.content);
+  const textTooLarge = fullText.length > TOOL_RESULT_TEXT_EXTERNALIZE_MIN_CHARS;
+  if (!detailsTooLarge && !textTooLarge) {
+    return params.message;
+  }
+
+  try {
+    const sessionDir = path.dirname(params.sessionFile);
+    const outputDir = path.join(sessionDir, TOOL_OUTPUT_DIRNAME);
+    fs.mkdirSync(outputDir, { recursive: true });
+
+    const toolName = sanitizeFileNamePart(params.toolName ?? "", "tool");
+    const toolCallId = sanitizeFileNamePart(params.toolCallId ?? "", "call");
+    const fileName = `${Date.now()}-${toolName}-${toolCallId}.json`;
+    const outputPath = path.join(outputDir, fileName);
+
+    const payload = {
+      version: 1,
+      toolCallId: params.toolCallId ?? null,
+      toolName: params.toolName ?? null,
+      savedAt: new Date().toISOString(),
+      ...(detailsTooLarge ? { details } : {}),
+      ...(textTooLarge ? { text: fullText } : {}),
+    };
+    const payloadText = `${JSON.stringify(payload, null, 2)}\n`;
+    fs.writeFileSync(outputPath, payloadText, "utf-8");
+
+    const payloadSha = crypto.createHash("sha256").update(payloadText).digest("hex");
+    const relativePath = path.relative(sessionDir, outputPath) || outputPath;
+    const outputRef = {
+      kind: "tool_result_payload",
+      path: relativePath,
+      bytes: Buffer.byteLength(payloadText, "utf-8"),
+      sha256: payloadSha,
+      contains: {
+        details: detailsTooLarge,
+        text: textTooLarge,
+      },
+    };
+
+    const nextMessage = { ...messageRecord };
+    if (detailsTooLarge) {
+      nextMessage.details = {
+        ...summarizeDetails(details ?? {}),
+        outputRef,
+      };
+    }
+    if (textTooLarge && Array.isArray(nextMessage.content)) {
+      const preview = truncatePreview(fullText, TOOL_RESULT_PREVIEW_MAX_CHARS);
+      const notice =
+        `\n\n${TOOL_RESULT_EXTERNALIZE_NOTICE_PREFIX} ${relativePath} ` +
+        `(sha256: ${payloadSha.slice(0, 12)}..., bytes: ${outputRef.bytes}).`;
+      let injected = false;
+      const compacted = nextMessage.content.flatMap((block) => {
+        if (!block || typeof block !== "object") {
+          return [block];
+        }
+        const rec = block as { type?: unknown; text?: unknown };
+        if (rec.type !== "text") {
+          return [block];
+        }
+        if (injected) {
+          return [];
+        }
+        injected = true;
+        return [
+          {
+            ...(block as Record<string, unknown>),
+            text: `${preview}${notice}`,
+          },
+        ];
+      });
+      if (!injected) {
+        compacted.unshift({ type: "text", text: `${preview}${notice}` });
+      }
+      nextMessage.content = compacted;
+    }
+    return nextMessage as unknown as AgentMessage;
+  } catch {
+    return params.message;
+  }
 }
 
 export function installSessionToolResultGuard(
@@ -191,17 +370,22 @@ export function installSessionToolResultGuard(
       // Apply hard size cap before persistence to prevent oversized tool results
       // from consuming the entire context window on subsequent LLM calls.
       const capped = capToolResultSize(persistMessage(nextMessage));
-      const persisted = applyBeforeWriteHook(
-        persistToolResult(capped, {
-          toolCallId: id ?? undefined,
-          toolName,
-          isSynthetic: false,
-        }),
-      );
+      const transformed = persistToolResult(capped, {
+        toolCallId: id ?? undefined,
+        toolName,
+        isSynthetic: false,
+      });
+      const persisted = applyBeforeWriteHook(transformed);
       if (!persisted) {
         return undefined;
       }
-      return originalAppend(persisted as never);
+      const compactedForTranscript = externalizeLargeToolResultPayload({
+        sessionFile: getSessionFilePath(sessionManager),
+        message: persisted,
+        toolCallId: id ?? undefined,
+        toolName,
+      });
+      return originalAppend(compactedForTranscript as never);
     }
 
     const toolCalls =

--- a/src/agents/tool-display.json
+++ b/src/agents/tool-display.json
@@ -250,7 +250,7 @@
     "sessions_history": {
       "emoji": "🧾",
       "title": "Session History",
-      "detailKeys": ["sessionKey", "limit", "includeTools"]
+      "detailKeys": ["sessionKey", "limit", "includeTools", "outputRefPath", "outputRefMaxChars"]
     },
     "sessions_send": {
       "emoji": "📨",

--- a/src/agents/tools/memory-tool.e2e.test.ts
+++ b/src/agents/tools/memory-tool.e2e.test.ts
@@ -129,7 +129,7 @@ describe("memory search citations", () => {
       },
     ]);
 
-    const cfg = {
+    const cfg = asOpenClawConfig({
       memory: { citations: "off" },
       agents: {
         defaults: {
@@ -139,7 +139,7 @@ describe("memory search citations", () => {
         },
         list: [{ id: "main", default: true }],
       },
-    };
+    });
     const tool = createMemorySearchTool({ config: cfg });
     if (!tool) {
       throw new Error("tool missing");

--- a/src/agents/tools/memory-tool.e2e.test.ts
+++ b/src/agents/tools/memory-tool.e2e.test.ts
@@ -116,6 +116,39 @@ describe("memory search citations", () => {
     expect(details.results[0]?.snippet.length).toBeLessThanOrEqual(20);
   });
 
+  it("clamps builtin snippets to configured memorySearch injected budget", async () => {
+    backend = "builtin";
+    stubManager.search.mockResolvedValueOnce([
+      {
+        path: "MEMORY.md",
+        startLine: 11,
+        endLine: 15,
+        score: 0.91,
+        snippet: "x".repeat(200),
+        source: "memory" as const,
+      },
+    ]);
+
+    const cfg = {
+      memory: { citations: "off" },
+      agents: {
+        defaults: {
+          memorySearch: {
+            query: { maxInjectedChars: 40 },
+          },
+        },
+        list: [{ id: "main", default: true }],
+      },
+    };
+    const tool = createMemorySearchTool({ config: cfg });
+    if (!tool) {
+      throw new Error("tool missing");
+    }
+    const result = await tool.execute("builtin_budget", { query: "notes" });
+    const details = result.details as { results: Array<{ snippet: string; citation?: string }> };
+    expect(details.results[0]?.snippet.length).toBeLessThanOrEqual(40);
+  });
+
   it("honors auto mode for direct chats", async () => {
     backend = "builtin";
     const cfg = asOpenClawConfig({

--- a/src/agents/tools/sessions-history-tool.ts
+++ b/src/agents/tools/sessions-history-tool.ts
@@ -1,9 +1,16 @@
 import { Type } from "@sinclair/typebox";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import type { AnyAgentTool } from "./common.js";
 import { loadConfig } from "../../config/config.js";
 import { callGateway } from "../../gateway/call.js";
-import { capArrayByJsonBytes } from "../../gateway/session-utils.fs.js";
+import {
+  capArrayByJsonBytes,
+  resolveSessionTranscriptCandidates,
+} from "../../gateway/session-utils.fs.js";
+import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { truncateUtf16Safe } from "../../utils.js";
-import type { AnyAgentTool } from "./common.js";
 import { jsonResult, readStringParam } from "./common.js";
 import {
   createSessionVisibilityGuard,
@@ -19,10 +26,26 @@ const SessionsHistoryToolSchema = Type.Object({
   sessionKey: Type.String(),
   limit: Type.Optional(Type.Number({ minimum: 1 })),
   includeTools: Type.Optional(Type.Boolean()),
+  outputRefPath: Type.Optional(Type.String()),
+  outputRefMaxChars: Type.Optional(Type.Number({ minimum: 256 })),
 });
 
 const SESSIONS_HISTORY_MAX_BYTES = 80 * 1024;
 const SESSIONS_HISTORY_TEXT_MAX_CHARS = 4000;
+const SESSIONS_HISTORY_OUTPUT_REF_MAX_CHARS = 20_000;
+const SESSIONS_HISTORY_OUTPUT_REF_MAX_CHARS_HARD_MAX = 120_000;
+const SESSIONS_HISTORY_OUTPUT_REF_DIRNAME = "tool-output";
+
+type ToolResultOutputRef = {
+  kind: "tool_result_payload";
+  path: string;
+  bytes?: number;
+  sha256?: string;
+  contains?: {
+    details?: boolean;
+    text?: boolean;
+  };
+};
 
 // sandbox policy handling is shared with sessions-list-tool via sessions-helpers.ts
 
@@ -86,8 +109,14 @@ function sanitizeHistoryMessage(message: unknown): { message: unknown; truncated
   let truncated = false;
   // Tool result details often contain very large nested payloads.
   if ("details" in entry) {
-    delete entry.details;
-    truncated = true;
+    const outputRef = readToolResultOutputRef(entry);
+    if (outputRef) {
+      entry.details = { outputRef };
+      truncated = true;
+    } else {
+      delete entry.details;
+      truncated = true;
+    }
   }
   if ("usage" in entry) {
     delete entry.usage;
@@ -113,6 +142,124 @@ function sanitizeHistoryMessage(message: unknown): { message: unknown; truncated
     truncated ||= res.truncated;
   }
   return { message: entry, truncated };
+}
+
+function readToolResultOutputRef(
+  message: Record<string, unknown>,
+): ToolResultOutputRef | undefined {
+  const details = message.details;
+  if (!details || typeof details !== "object") {
+    return undefined;
+  }
+  const ref = (details as { outputRef?: unknown }).outputRef;
+  if (!ref || typeof ref !== "object") {
+    return undefined;
+  }
+  const rec = ref as Record<string, unknown>;
+  const kind = typeof rec.kind === "string" ? rec.kind : "";
+  const outputPath = typeof rec.path === "string" ? rec.path.trim() : "";
+  if (kind !== "tool_result_payload" || !outputPath) {
+    return undefined;
+  }
+  const containsRaw = rec.contains;
+  const contains =
+    containsRaw && typeof containsRaw === "object"
+      ? {
+          details:
+            typeof (containsRaw as { details?: unknown }).details === "boolean"
+              ? (containsRaw as { details: boolean }).details
+              : undefined,
+          text:
+            typeof (containsRaw as { text?: unknown }).text === "boolean"
+              ? (containsRaw as { text: boolean }).text
+              : undefined,
+        }
+      : undefined;
+  return {
+    kind: "tool_result_payload",
+    path: outputPath,
+    bytes: typeof rec.bytes === "number" && Number.isFinite(rec.bytes) ? rec.bytes : undefined,
+    sha256: typeof rec.sha256 === "string" ? rec.sha256 : undefined,
+    contains:
+      contains && (contains.details !== undefined || contains.text !== undefined)
+        ? contains
+        : undefined,
+  };
+}
+
+function resolveOutputRefPayloadPath(params: {
+  transcriptPath: string;
+  outputRefPath: string;
+}): string | null {
+  const sessionDir = path.dirname(params.transcriptPath);
+  const baseDir = path.resolve(sessionDir, SESSIONS_HISTORY_OUTPUT_REF_DIRNAME);
+  const resolved = path.resolve(sessionDir, params.outputRefPath);
+  if (resolved !== baseDir && !resolved.startsWith(`${baseDir}${path.sep}`)) {
+    return null;
+  }
+  return resolved;
+}
+
+function resolveOutputRefMaxChars(raw: unknown): number {
+  if (typeof raw !== "number" || !Number.isFinite(raw)) {
+    return SESSIONS_HISTORY_OUTPUT_REF_MAX_CHARS;
+  }
+  const normalized = Math.floor(raw);
+  return Math.max(256, Math.min(SESSIONS_HISTORY_OUTPUT_REF_MAX_CHARS_HARD_MAX, normalized));
+}
+
+function findOutputRefInMessages(
+  messages: unknown[],
+  outputRefPath: string,
+): ToolResultOutputRef | undefined {
+  const needle = outputRefPath.trim();
+  if (!needle) {
+    return undefined;
+  }
+  for (const message of messages) {
+    if (!message || typeof message !== "object") {
+      continue;
+    }
+    const outputRef = readToolResultOutputRef(message as Record<string, unknown>);
+    if (outputRef?.path === needle) {
+      return outputRef;
+    }
+  }
+  return undefined;
+}
+
+async function resolveTranscriptPathForSession(params: {
+  resolvedKey: string;
+  sessionId?: string;
+}): Promise<string | undefined> {
+  const listing = await callGateway<{
+    path?: string;
+    sessions?: Array<{ key?: string; sessionId?: string }>;
+  }>({
+    method: "sessions.list",
+    params: {
+      search: params.resolvedKey,
+      limit: 8,
+      includeGlobal: true,
+      includeUnknown: true,
+    },
+  });
+
+  const sessionId =
+    params.sessionId ??
+    listing?.sessions?.find((entry) => entry?.key === params.resolvedKey)?.sessionId;
+  if (!sessionId || typeof sessionId !== "string") {
+    return undefined;
+  }
+
+  const storePath = typeof listing?.path === "string" ? listing.path : undefined;
+  const candidates = resolveSessionTranscriptCandidates(
+    sessionId,
+    storePath,
+    undefined,
+    resolveAgentIdFromSessionKey(params.resolvedKey),
+  );
+  return candidates.find((candidate) => fs.existsSync(candidate));
 }
 
 function jsonUtf8Bytes(value: unknown): number {
@@ -162,6 +309,8 @@ export function createSessionsHistoryTool(opts?: {
       const sessionKeyParam = readStringParam(params, "sessionKey", {
         required: true,
       });
+      const outputRefPathParam = readStringParam(params, "outputRefPath");
+      const outputRefMaxChars = resolveOutputRefMaxChars(params.outputRefMaxChars);
       const cfg = loadConfig();
       const { mainKey, alias, effectiveRequesterKey, restrictToSpawned } =
         resolveSandboxedSessionToolContext({
@@ -220,11 +369,71 @@ export function createSessionsHistoryTool(opts?: {
           ? Math.max(1, Math.floor(params.limit))
           : undefined;
       const includeTools = Boolean(params.includeTools);
-      const result = await callGateway<{ messages: Array<unknown> }>({
+      const result = await callGateway<{ messages: Array<unknown>; sessionId?: string }>({
         method: "chat.history",
         params: { sessionKey: resolvedKey, limit },
       });
       const rawMessages = Array.isArray(result?.messages) ? result.messages : [];
+
+      let outputRefPayload:
+        | {
+            path: string;
+            bytes: number;
+            sha256?: string;
+            sha256Verified?: boolean;
+            truncated: boolean;
+            text: string;
+          }
+        | undefined;
+
+      if (outputRefPathParam) {
+        const outputRef = findOutputRefInMessages(rawMessages, outputRefPathParam);
+        if (!outputRef) {
+          return jsonResult({
+            status: "error",
+            error: `Output reference not found in session history: ${outputRefPathParam}`,
+            sessionKey: displayKey,
+          });
+        }
+        const transcriptPath = await resolveTranscriptPathForSession({
+          resolvedKey,
+          sessionId: typeof result?.sessionId === "string" ? result.sessionId : undefined,
+        });
+        if (!transcriptPath) {
+          return jsonResult({
+            status: "error",
+            error: `Unable to resolve transcript path for session: ${displayKey}`,
+            sessionKey: displayKey,
+          });
+        }
+        const payloadPath = resolveOutputRefPayloadPath({
+          transcriptPath,
+          outputRefPath: outputRef.path,
+        });
+        if (!payloadPath || !fs.existsSync(payloadPath)) {
+          return jsonResult({
+            status: "error",
+            error: `Output reference file not found: ${outputRef.path}`,
+            sessionKey: displayKey,
+          });
+        }
+        const text = fs.readFileSync(payloadPath, "utf-8");
+        const truncated = text.length > outputRefMaxChars;
+        const textPreview = truncated
+          ? `${truncateUtf16Safe(text, outputRefMaxChars)}\n…(truncated)…`
+          : text;
+        const payloadSha = crypto.createHash("sha256").update(text).digest("hex");
+        outputRefPayload = {
+          path: outputRef.path,
+          bytes: Buffer.byteLength(text, "utf8"),
+          sha256: payloadSha,
+          sha256Verified:
+            typeof outputRef.sha256 === "string" ? outputRef.sha256 === payloadSha : undefined,
+          truncated,
+          text: textPreview,
+        };
+      }
+
       const selectedMessages = includeTools ? rawMessages : stripToolMessages(rawMessages);
       const sanitizedMessages = selectedMessages.map((message) => sanitizeHistoryMessage(message));
       const contentTruncated = sanitizedMessages.some((entry) => entry.truncated);
@@ -245,6 +454,7 @@ export function createSessionsHistoryTool(opts?: {
         droppedMessages: droppedMessages || hardened.hardCapped,
         contentTruncated,
         bytes: hardened.bytes,
+        outputRefPayload,
       });
     },
   };

--- a/src/agents/tools/sessions-history-tool.ts
+++ b/src/agents/tools/sessions-history-tool.ts
@@ -1,8 +1,7 @@
-import { Type } from "@sinclair/typebox";
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
-import type { AnyAgentTool } from "./common.js";
+import { Type } from "@sinclair/typebox";
 import { loadConfig } from "../../config/config.js";
 import { callGateway } from "../../gateway/call.js";
 import {
@@ -11,6 +10,7 @@ import {
 } from "../../gateway/session-utils.fs.js";
 import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { truncateUtf16Safe } from "../../utils.js";
+import type { AnyAgentTool } from "./common.js";
 import { jsonResult, readStringParam } from "./common.js";
 import {
   createSessionVisibilityGuard,

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -209,6 +209,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Optional override path to sqlite-vec extension library (.dylib/.so/.dll).",
   "agents.defaults.memorySearch.query.hybrid.enabled":
     "Enable hybrid BM25 + vector search for memory (default: true).",
+  "agents.defaults.memorySearch.query.maxInjectedChars":
+    "Max total snippet characters returned by memory_search per call (default: 4000).",
   "agents.defaults.memorySearch.query.hybrid.vectorWeight":
     "Weight for vector similarity when merging results (0-1).",
   "agents.defaults.memorySearch.query.hybrid.textWeight":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -161,6 +161,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.memorySearch.sync.sessions.deltaMessages": "Session Delta Messages",
   "agents.defaults.memorySearch.query.maxResults": "Memory Search Max Results",
   "agents.defaults.memorySearch.query.minScore": "Memory Search Min Score",
+  "agents.defaults.memorySearch.query.maxInjectedChars": "Memory Search Max Injected Chars",
   "agents.defaults.memorySearch.query.hybrid.enabled": "Memory Search Hybrid",
   "agents.defaults.memorySearch.query.hybrid.vectorWeight": "Memory Search Vector Weight",
   "agents.defaults.memorySearch.query.hybrid.textWeight": "Memory Search Text Weight",

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -342,6 +342,8 @@ export type MemorySearchConfig = {
   query?: {
     maxResults?: number;
     minScore?: number;
+    /** Max total snippet characters injected per memory_search call. */
+    maxInjectedChars?: number;
     hybrid?: {
       /** Enable hybrid BM25 + vector search (default: true). */
       enabled?: boolean;

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -543,6 +543,7 @@ export const MemorySearchSchema = z
       .object({
         maxResults: z.number().int().positive().optional(),
         minScore: z.number().min(0).max(1).optional(),
+        maxInjectedChars: z.number().int().positive().optional(),
         hybrid: z
           .object({
             enabled: z.boolean().optional(),


### PR DESCRIPTION
## Summary
- Problem: OpenClaw context assembly relied on turn-count slicing and late compaction, which caused context bloat, unstable continuity, and expensive cache write spikes in long sessions.
- Why it matters: This affects reliability (summary loops/orphans), memory quality, and token/cost efficiency in real agent sessions.
- What changed:
  - Added deterministic token-budget history planning in the PI embedded runner.
  - Capped injected memory retrieval payloads (`maxInjectedChars`, default 4000).
  - Added incremental session-summary sidecar state with loop/rewind hardening and context-pressure-based injection.
  - Externalized oversized tool outputs into `tool-output/*.json` with transcript `details.outputRef` pointers.
  - Added on-demand `outputRef` payload retrieval to `sessions_history` (`outputRefPath`, `outputRefMaxChars`) with path scoping and SHA-256 verification.
  - Added technical design + implementation report in docs.
- What did NOT change (scope boundary): No provider/model contract changes, no migration of existing memory stores, and no change to default session storage locations.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [x] Refactor
- [x] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #N/A
- Related #17345

## User-visible / Behavior Changes

- `sessions_history` now preserves `toolResult.details.outputRef` metadata when history is sanitized.
- `sessions_history` now supports optional on-demand payload retrieval:
  - `outputRefPath`
  - `outputRefMaxChars`
- Large tool outputs are persisted as file refs instead of bloating transcript message content.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): Yes
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): Yes
- Data access scope changed? (`Yes/No`): Yes
- If any `Yes`, explain risk + mitigation:
  - Risk: payload file read path traversal via `outputRefPath`.
  - Mitigation: retrieval is constrained to the session-local `tool-output/` subtree and rejects paths outside that directory.

## Repro + Verification

### Environment

- OS: macOS (Apple Silicon)
- Runtime/container: Node v22.22.0, pnpm 10.23.0
- Model/provider: openai-codex/gpt-5.3-codex (local UAT)
- Integration/channel (if any): local gateway + TUI
- Relevant config (redacted): default local `.openclaw` profile

### Steps

1. Run long chat/tool sessions and trigger memory/context pressure.
2. Execute large-output tool command (e.g. `python - <<'PY'\nprint('x'*150000)\nPY`).
3. Verify `toolResult.details.outputRef` appears in transcript and payload is written under `sessions/tool-output/`.
4. Call `sessions_history` with `outputRefPath` to fetch truncated full payload.

### Expected

- History is token-budgeted deterministically.
- Summary sidecar persists without recursive `[SESSION_SUMMARY]` contamination.
- Large tool output is externalized; transcript remains compact.
- `sessions_history` can retrieve referenced payload safely with hash verification.

### Actual

- Matches expected behavior in local UAT and e2e coverage.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [x] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - UAT session `agent:main:uat-summary-fix` confirms sidecar summary behavior and loop fix.
  - UAT session `agent:main:uat-p5-tool-output-ref` confirms output ref persistence for oversized tool output.
  - On-demand retrieval path via `sessions_history outputRefPath` validated with new e2e coverage.
- Edge cases checked:
  - static budget overflow fallback
  - single-turn oversize preservation
  - transcript rewind recovery
  - output ref path containment + missing ref handling
- What you did **not** verify:
  - full cross-provider cost benchmark report (follow-up item)

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No (new tool params are optional)
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commits `312f3401e` and `f43c5f41f` for tool-output ref pathing.
  - Revert commits `827d3e48c`, `b9490e95e`, `9642a3a6a`, `e22c86b41` for summary sidecar path.
  - Revert commit `84e694680` for context planner.
- Files/config to restore:
  - `src/agents/pi-embedded-runner/run/attempt.ts`
  - `src/agents/pi-embedded-runner/context-planner.ts`
  - `src/agents/pi-embedded-runner/session-summary.ts`
  - `src/agents/session-tool-result-guard.ts`
  - `src/agents/tools/sessions-history-tool.ts`
- Known bad symptoms reviewers should watch for:
  - repeated `[SESSION_SUMMARY]` recursion in prompts
  - missing/invalid `toolResult.details.outputRef` for large outputs
  - context overflow regressions in long sessions

## Risks and Mitigations

- Risk: token estimator fallback (`chars/3.6`) can under/over-estimate for some content mixes.
  - Mitigation: planner uses safety ratio and reserve buffers; e2e coverage verifies hard fallback behavior.
- Risk: additional file I/O for output payload retrieval.
  - Mitigation: on-demand path only, hard character cap, and optional usage.

### Validation Commands

- `pnpm tsgo`
- `pnpm test src/agents/pi-embedded-runner/context-planner.test.ts src/agents/pi-embedded-runner/session-summary.test.ts`
- `pnpm exec vitest run -c vitest.e2e.config.ts src/agents/pi-embedded-runner.limithistoryturns.e2e.test.ts src/agents/pi-embedded-runner/run/attempt.e2e.test.ts src/agents/memory-search.e2e.test.ts src/agents/tools/memory-tool.citations.e2e.test.ts src/agents/session-tool-result-guard.e2e.test.ts src/agents/session-tool-result-guard.tool-result-persist-hook.e2e.test.ts`
- `pnpm exec vitest run -c vitest.e2e.config.ts src/agents/openclaw-tools.sessions.e2e.test.ts -t sessions_history`
- `pnpm exec vitest run -c vitest.e2e.config.ts src/agents/tool-display.e2e.test.ts`

### Commit Set

- `84e694680` Runner: add token-budget context planning
- `520998e5a` Memory: cap injected recall snippets
- `e22c86b41` Runner: persist incremental session summary state
- `9642a3a6a` Runner: prevent session-summary prompt feedback loops
- `b9490e95e` Runner: recover session summary after transcript rewinds
- `827d3e48c` Runner: inject session summary only under context pressure
- `f43c5f41f` Session: persist oversized tool payloads as file refs
- `812107d5f` Docs: add memory kernel design and verification report
- `312f3401e` Sessions: add on-demand outputRef payload retrieval
- `d5db9792c` Docs: update memory kernel report for outputRef retrieval

AI-assisted: Yes (Codex); verified locally with targeted UAT and e2e suites.

Agent-Signoff: Creash-the-Lobster

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces turn-count-based context slicing with a deterministic token-budget context planner for the PI embedded runner, adds an incremental session-summary sidecar with loop/rewind hardening, externalizes oversized tool outputs to `tool-output/*.json` files with transcript `outputRef` pointers, and introduces on-demand payload retrieval via `sessions_history`.

- **Token-budget context planner** (`context-planner.ts`): Well-structured module that estimates token costs per message and trims oldest messages to fit within a computed history budget, always preserving the latest user turn. Integrates cleanly with the existing `limitHistoryTurns` and `sanitizeToolUseResultPairing` pipeline.
- **Session summary sidecar** (`session-summary.ts`): Persists incremental summary state alongside session files, with rewind detection and `[SESSION_SUMMARY]` loop prevention. Summary injection is gated on context pressure or trimming, avoiding unnecessary prompt bloat. Minor dedup bug identified (consecutive duplicate detection only checks against prior state, not accumulated additions).
- **Output ref externalization** (`session-tool-result-guard.ts`): Large tool results (>120K chars text or >24K chars details) are written to separate JSON files with SHA-256 hashes. Uses synchronous file I/O within the `appendMessage` hot path due to interface constraints — a deviation from the codebase's async I/O patterns.
- **On-demand retrieval** (`sessions-history-tool.ts`): New `outputRefPath`/`outputRefMaxChars` parameters allow fetching externalized payloads. Path containment is enforced via `path.resolve` prefix check (lexical only — does not resolve symlinks). SHA-256 verification is informational; mismatched hashes don't prevent payload delivery.
- **Memory search cap** (`memory-search.ts`, `memory-tool.ts`): New `maxInjectedChars` config (default 4000) caps total snippet characters injected per `memory_search` call, applied uniformly across backends.
- Config, schema, and display updates are consistent and minimal. Test coverage is solid with both unit and e2e tests for all new features.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor issues flagged; no critical bugs or security vulnerabilities found.
- The implementation is well-structured with thorough test coverage (unit + e2e), defensive error handling, and clear separation of concerns. The issues found are: (1) a minor dedup logic bug in session summary that only affects unlikely consecutive identical messages, (2) a style concern about sync I/O on the hot path with documented constraints, (3) defense-in-depth suggestions for path containment and hash verification. None are blocking.
- `src/agents/tools/sessions-history-tool.ts` (path containment and hash verification behavior), `src/agents/session-tool-result-guard.ts` (sync I/O on hot path), `src/agents/pi-embedded-runner/session-summary.ts` (dedup logic)

<sub>Last reviewed commit: d5db979</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->