### PR TITLE
feat(hooks): add message_persist hook for all transcript messages

### DIFF
--- a/src/agents/session-tool-result-guard-wrapper.ts
+++ b/src/agents/session-tool-result-guard-wrapper.ts
@@ -67,6 +67,11 @@ export function guardSessionManager(
     : undefined;
 
   const guard = installSessionToolResultGuard(sessionManager, {
+    // Note: This callback runs for ALL message roles (user, assistant, system,
+    // toolResult). For toolResult messages, `tool_result_persist` also fires
+    // separately via transformToolResultForPersistence. Plugin authors who
+    // register both hooks should guard against double-processing (e.g. check
+    // if content is already encrypted before encrypting again).
     transformMessageForPersistence: (message) => {
       let msg = applyInputProvenanceToUserMessage(message, opts?.inputProvenance);
       if (messagePersistTransform) {

--- a/src/agents/session-tool-result-guard.message-persist-hook.e2e.test.ts
+++ b/src/agents/session-tool-result-guard.message-persist-hook.e2e.test.ts
@@ -1,0 +1,283 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { SessionManager } from "@mariozechner/pi-coding-agent";
+import { describe, expect, it, afterEach } from "vitest";
+import type { PluginRegistry } from "../plugins/types.js";
+import {
+  initializeGlobalHookRunner,
+  resetGlobalHookRunner,
+} from "../plugins/hook-runner-global.js";
+import { createPluginRegistry } from "../plugins/registry.js";
+import { guardSessionManager } from "./session-tool-result-guard-wrapper.js";
+
+const silentLogger = { debug: () => {}, warn: () => {}, error: () => {} };
+
+/**
+ * Helper: create a fresh registry with typed hooks pre-registered.
+ * Bypasses jiti/plugin-loader (which conflicts with vitest's module system)
+ * and directly populates the registry — giving us precise control over
+ * hook registration for each test case.
+ */
+function createRegistryWithHooks(
+  hooks: Array<{
+    pluginId: string;
+    hookName: string;
+    // oxlint-disable-next-line typescript/no-explicit-any
+    handler: (...args: any[]) => any;
+    priority?: number;
+  }>,
+): PluginRegistry {
+  const { registry } = createPluginRegistry({ logger: silentLogger });
+  for (const h of hooks) {
+    registry.typedHooks.push({
+      pluginId: h.pluginId,
+      hookName: h.hookName,
+      handler: h.handler,
+      priority: h.priority,
+      source: "test",
+      // oxlint-disable-next-line typescript/no-explicit-any
+    } as any);
+  }
+  return registry;
+}
+
+// oxlint-disable-next-line typescript/no-explicit-any
+function getMessages(sm: ReturnType<typeof guardSessionManager>): any[] {
+  return sm
+    .getEntries()
+    .filter((e) => e.type === "message")
+    .map((e) => (e as { message: AgentMessage }).message);
+}
+
+afterEach(() => {
+  resetGlobalHookRunner();
+});
+
+describe("message_persist hook", () => {
+  it("does not modify persisted messages when no hook is registered", () => {
+    const sm = guardSessionManager(SessionManager.inMemory(), {
+      agentId: "main",
+      sessionKey: "main",
+    });
+
+    sm.appendMessage({ role: "user", content: [{ type: "text", text: "hello" }] });
+    sm.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "world" }],
+    } as AgentMessage);
+
+    const messages = getMessages(sm);
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const user = messages.find((m: any) => m.role === "user");
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const assistant = messages.find((m: any) => m.role === "assistant");
+    expect(user.content[0].text).toBe("hello");
+    expect(assistant.content[0].text).toBe("world");
+  });
+
+  it("hook is called for user, assistant, and system messages", () => {
+    const registry = createRegistryWithHooks([
+      {
+        pluginId: "msg-tag",
+        hookName: "message_persist",
+        // oxlint-disable-next-line typescript/no-explicit-any
+        handler: (event: any, ctx: any) => {
+          return {
+            message: {
+              ...event.message,
+              tagged: true,
+              taggedRole: event.role,
+              agentSeen: ctx.agentId ?? null,
+            },
+          };
+        },
+        priority: 10,
+      },
+    ]);
+    initializeGlobalHookRunner(registry);
+
+    const sm = guardSessionManager(SessionManager.inMemory(), {
+      agentId: "main",
+      sessionKey: "main",
+    });
+
+    sm.appendMessage({ role: "user", content: [{ type: "text", text: "hi" }] });
+    sm.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "hey" }],
+    } as AgentMessage);
+    sm.appendMessage({
+      role: "system",
+      content: "sys prompt",
+    } as AgentMessage);
+
+    const messages = getMessages(sm);
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const user = messages.find((m: any) => m.role === "user");
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const assistant = messages.find((m: any) => m.role === "assistant");
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const system = messages.find((m: any) => m.role === "system");
+
+    expect(user.tagged).toBe(true);
+    expect(user.taggedRole).toBe("user");
+    expect(user.agentSeen).toBe("main");
+
+    expect(assistant.tagged).toBe(true);
+    expect(assistant.taggedRole).toBe("assistant");
+
+    expect(system.tagged).toBe(true);
+    expect(system.taggedRole).toBe("system");
+  });
+
+  it("hook can transform/replace message content before persistence", () => {
+    const registry = createRegistryWithHooks([
+      {
+        pluginId: "msg-redact",
+        hookName: "message_persist",
+        // oxlint-disable-next-line typescript/no-explicit-any
+        handler: (event: any) => {
+          const msg = event.message;
+          if (msg.content && Array.isArray(msg.content)) {
+            const newContent = msg.content.map(
+              // oxlint-disable-next-line typescript/no-explicit-any
+              (c: any) => (c.type === "text" ? { ...c, text: "[REDACTED]" } : c),
+            );
+            return { message: { ...msg, content: newContent } };
+          }
+          return { message: msg };
+        },
+        priority: 10,
+      },
+    ]);
+    initializeGlobalHookRunner(registry);
+
+    const sm = guardSessionManager(SessionManager.inMemory(), {
+      agentId: "main",
+      sessionKey: "main",
+    });
+
+    sm.appendMessage({ role: "user", content: [{ type: "text", text: "secret data" }] });
+
+    const messages = getMessages(sm);
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const user = messages.find((m: any) => m.role === "user");
+    expect(user.content[0].text).toBe("[REDACTED]");
+  });
+
+  it("multiple hooks run in priority order (higher first)", () => {
+    const registry = createRegistryWithHooks([
+      {
+        pluginId: "order-a",
+        hookName: "message_persist",
+        // oxlint-disable-next-line typescript/no-explicit-any
+        handler: (event: any) => {
+          const prior = event.message.order || [];
+          return { message: { ...event.message, order: [...prior, "a"] } };
+        },
+        priority: 10,
+      },
+      {
+        pluginId: "order-b",
+        hookName: "message_persist",
+        // oxlint-disable-next-line typescript/no-explicit-any
+        handler: (event: any) => {
+          const prior = event.message.order || [];
+          return { message: { ...event.message, order: [...prior, "b"] } };
+        },
+        priority: 5,
+      },
+    ]);
+    initializeGlobalHookRunner(registry);
+
+    const sm = guardSessionManager(SessionManager.inMemory(), {
+      agentId: "main",
+      sessionKey: "main",
+    });
+
+    sm.appendMessage({ role: "user", content: [{ type: "text", text: "hi" }] });
+
+    const messages = getMessages(sm);
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const user = messages.find((m: any) => m.role === "user");
+    // Priority 10 runs first (a), then priority 5 (b)
+    expect(user.order).toEqual(["a", "b"]);
+  });
+
+  it("async hooks are rejected with a warning (result ignored)", () => {
+    const registry = createRegistryWithHooks([
+      {
+        pluginId: "async-bad",
+        hookName: "message_persist",
+        handler: async (event: { message: Record<string, unknown> }) => {
+          return { message: { ...event.message, asyncDone: true } };
+        },
+        priority: 10,
+      },
+    ]);
+    initializeGlobalHookRunner(registry);
+
+    const sm = guardSessionManager(SessionManager.inMemory(), {
+      agentId: "main",
+      sessionKey: "main",
+    });
+
+    // Should not throw — async result is silently ignored with a warning
+    sm.appendMessage({ role: "user", content: [{ type: "text", text: "hi" }] });
+
+    const messages = getMessages(sm);
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const user = messages.find((m: any) => m.role === "user");
+    // The async handler's transform should NOT have been applied
+    expect(user.asyncDone).toBeUndefined();
+  });
+
+  it("toolResult messages pass through both message_persist and tool_result_persist", () => {
+    const registry = createRegistryWithHooks([
+      {
+        pluginId: "dual-hook",
+        hookName: "message_persist",
+        // oxlint-disable-next-line typescript/no-explicit-any
+        handler: (event: any) => {
+          return { message: { ...event.message, messagePersistSeen: true } };
+        },
+        priority: 10,
+      },
+      {
+        pluginId: "dual-hook",
+        hookName: "tool_result_persist",
+        // oxlint-disable-next-line typescript/no-explicit-any
+        handler: (event: any) => {
+          return { message: { ...event.message, toolResultPersistSeen: true } };
+        },
+        priority: 10,
+      },
+    ]);
+    initializeGlobalHookRunner(registry);
+
+    const sm = guardSessionManager(SessionManager.inMemory(), {
+      agentId: "main",
+      sessionKey: "main",
+    });
+
+    sm.appendMessage({
+      role: "assistant",
+      content: [{ type: "toolCall", id: "call_1", name: "read", arguments: {} }],
+    } as AgentMessage);
+
+    sm.appendMessage({
+      role: "toolResult",
+      toolCallId: "call_1",
+      isError: false,
+      content: [{ type: "text", text: "ok" }],
+      // oxlint-disable-next-line typescript/no-explicit-any
+    } as any);
+
+    const messages = getMessages(sm);
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const toolResult = messages.find((m: any) => m.role === "toolResult");
+
+    // Both hooks should have fired on the toolResult message
+    expect(toolResult.messagePersistSeen).toBe(true);
+    expect(toolResult.toolResultPersistSeen).toBe(true);
+  });
+});

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -307,6 +307,7 @@ export type PluginHookName =
   | "before_tool_call"
   | "after_tool_call"
   | "tool_result_persist"
+  | "message_persist"
   | "session_start"
   | "session_end"
   | "gateway_start"
@@ -458,6 +459,27 @@ export type PluginHookToolResultPersistResult = {
   message?: AgentMessage;
 };
 
+// message_persist hook
+export type PluginHookMessagePersistContext = {
+  agentId?: string;
+  sessionKey?: string;
+};
+
+export type PluginHookMessagePersistEvent = {
+  /**
+   * The message about to be written to the session transcript.
+   * Handlers may return a modified message (e.g. encrypt content).
+   * Applies to all message roles (user, assistant, system, toolResult, etc.).
+   */
+  message: AgentMessage;
+  /** The role of the message being persisted. */
+  role?: string;
+};
+
+export type PluginHookMessagePersistResult = {
+  message?: AgentMessage;
+};
+
 // Session context
 export type PluginHookSessionContext = {
   agentId?: string;
@@ -535,6 +557,10 @@ export type PluginHookHandlerMap = {
     event: PluginHookToolResultPersistEvent,
     ctx: PluginHookToolResultPersistContext,
   ) => PluginHookToolResultPersistResult | void;
+  message_persist: (
+    event: PluginHookMessagePersistEvent,
+    ctx: PluginHookMessagePersistContext,
+  ) => PluginHookMessagePersistResult | void;
   session_start: (
     event: PluginHookSessionStartEvent,
     ctx: PluginHookSessionContext,


### PR DESCRIPTION
## Summary

Adds a new synchronous plugin hook `message_persist` that is called for **all messages** (user, assistant, system, toolResult) before they are written to the session transcript on disk.

## Why This Hook Matters

OpenClaw's plugin system lets agents extend the platform without forking core. But there's a gap: **there's no way for a plugin to intercept user, assistant, or system messages before they're written to disk.**

The existing `tool_result_persist` hook only covers tool results. If you want to build:
- 🔒 **At-rest encryption** — encrypt ALL transcript content, not just tool results
- 🔇 **PII redaction** — strip sensitive data from every message type
- 📝 **Audit logging** — complete conversation capture for compliance
- 🏷️ **Metadata injection** — tag messages with provenance, timestamps, or labels

...you're stuck. You'd have to fork OpenClaw core.

This hook closes that gap. A plugin registers `message_persist`, and every message flows through it before hitting disk — same pattern plugin authors already know from `tool_result_persist`.

## How We Built This (Development Process)

This PR was developed by an AI agent (Clawee 🐾) working through OpenClaw's own plugin system. Here's the process — useful as a template for agent-contributed PRs:

1. **Identified the need**: Building an `@openclaw/vault` encryption plugin. Discovered `tool_result_persist` existed but couldn't intercept user/assistant/system messages.
2. **Read the source**: Traced the persistence path — `SessionManager._persist()` → `appendFileSync()` → found `transformMessageForPersistence` callback in `session-tool-result-guard.ts` already intercepted ALL messages but wasn't exposed as a hook.
3. **Mirrored the existing pattern**: Copied the `tool_result_persist` implementation exactly — same synchronous execution, same priority ordering, same async rejection, same zero-overhead guard when no hooks registered.
4. **Wired it in**: Connected the new hook to the existing `transformMessageForPersistence` callback, running after input provenance tagging.
5. **Validated**: TypeScript compiles, linting clean, formatting clean.

## Design

The hook follows the exact same synchronous, sequential pattern as `tool_result_persist`:
- Handlers run in priority order (higher first)
- Each handler may return `{ message }` to replace the message for the next handler
- Async handlers are rejected with a warning (hot path, same as `tool_result_persist`)
- When no hooks are registered, zero overhead (guard check skipped entirely)

### ⚠️ Double-hook note for `toolResult` messages

`toolResult` messages pass through **both** `message_persist` (via `transformMessageForPersistence`) and `tool_result_persist` (via `transformToolResultForPersistence`). This is by design — most plugins only need `message_persist` to cover everything. But if you register both hooks, guard against double-processing:

```ts
// Example: skip if already encrypted
api.registerHook('message_persist', (event) => {
  if (isAlreadyEncrypted(event.message)) return; // guard
  return { message: encrypt(event.message) };
});
```

## Changes

| File | Change |
|------|--------|
| `src/plugins/types.ts` | Add `message_persist` to `PluginHookName`, event/result/context types, handler map entry |
| `src/plugins/hooks.ts` | Add `runMessagePersist()` — mirrors `runToolResultPersist()` exactly |
| `src/agents/session-tool-result-guard-wrapper.ts` | Wire hook into `transformMessageForPersistence` callback with inline docs |

## Usage Example

```ts
// Plugin: encrypt all messages before they hit disk
export default function (api) {
  api.registerHook('message_persist', (event, ctx) => {
    // event.message — the raw message object (any role)
    // event.role    — 'user' | 'assistant' | 'system' | 'toolResult'
    // ctx.agentId   — which agent's session this belongs to
    // ctx.sessionKey — the session identifier
    
    const encrypted = encrypt(event.message);
    return { message: encrypted }; // returned message replaces original on disk
  }, { name: 'vault-encrypt', priority: 100 });
}
```

## Backward Compatibility

No breaking changes. Existing behavior is fully preserved when no `message_persist` hooks are registered — the `transformMessageForPersistence` path still applies input provenance as before, with the hook transform applied afterward.

## Testing

- TypeScript compiles cleanly
- Linting passes (oxlint: 0 warnings, 0 errors)
- Formatting passes (oxfmt)
- E2e test to follow (mirroring existing `tool_result_persist` test)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `message_persist` hook that intercepts all messages (user, assistant, system, toolResult) before persistence to disk, enabling plugins to implement at-rest encryption, PII redaction, audit logging, and metadata injection without forking core.

- **Design**: Mirrors `tool_result_persist` exactly — synchronous, priority-ordered execution, async handler rejection, zero overhead when no hooks registered
- **Integration**: Wired into existing `transformMessageForPersistence` callback in session-tool-result-guard-wrapper.ts, running after input provenance tagging
- **Testing**: Comprehensive e2e test coverage validates all message roles, transformation chaining, priority ordering, async rejection, and double-hook interaction for toolResult messages
- **Documentation**: Inline comment at src/agents/session-tool-result-guard-wrapper.ts:70 warns plugin authors that toolResult messages pass through both `message_persist` and `tool_result_persist` hooks

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no risk — implementation follows established patterns exactly
- Clean implementation that mirrors the existing `tool_result_persist` hook pattern exactly. Comprehensive e2e tests validate all edge cases including async rejection, priority ordering, and the double-hook interaction for toolResult messages. The inline documentation at the integration point is clear and warns plugin authors about the potential for double-processing. No breaking changes, zero overhead when hooks aren't registered, and fully backward compatible.
- No files require special attention

<sub>Last reviewed commit: cd7047d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->