### PR TITLE
fix(pre-commit): fail fast when lint/format tooling is unavailable

### DIFF
--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -1,9 +1,23 @@
-#!/bin/sh
-FILES=$(git diff --cached --name-only --diff-filter=ACMR | sed 's| |\\ |g')
-[ -z "$FILES" ] && exit 0
+#!/usr/bin/env bash
+set -euo pipefail
 
-echo "$FILES" | xargs pnpm lint --fix
-echo "$FILES" | xargs pnpm format --no-error-on-unmatched-pattern
-echo "$FILES" | xargs git add
+ROOT_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+RUN_NODE_TOOL="$ROOT_DIR/scripts/pre-commit/run-node-tool.sh"
 
-exit 0
+if [[ ! -x "$RUN_NODE_TOOL" ]]; then
+  echo "Missing helper: $RUN_NODE_TOOL" >&2
+  exit 1
+fi
+
+declare -a FILES=()
+while IFS= read -r -d '' file; do
+  FILES+=("$file")
+done < <(git diff --cached --name-only --diff-filter=ACMR -z)
+
+if [[ ${#FILES[@]} -eq 0 ]]; then
+  exit 0
+fi
+
+"$RUN_NODE_TOOL" oxlint --type-aware --fix "${FILES[@]}"
+"$RUN_NODE_TOOL" oxfmt --write --no-error-on-unmatched-pattern "${FILES[@]}"
+git add -- "${FILES[@]}"


### PR DESCRIPTION
## Summary
- switch git pre-commit hook to bash fail-fast mode (`set -euo pipefail`)
- route tool execution through `scripts/pre-commit/run-node-tool.sh` so pnpm/bun/npm fallbacks work
- preserve staged-file handling with NUL-delimited paths and safe re-stage via `git add --`

## Why
The previous hook could print errors (for example, missing `pnpm`) and still exit 0, allowing commits to pass without running lint/format.

## Verification
- reproduced old behavior: commit succeeded even when pre-commit printed `xargs: pnpm: No such file or directory`
- verified new behavior with controlled hook fixtures:
  - missing helper -> non-zero exit
  - failing tool runner -> non-zero exit
  - successful runner with spaced filenames -> success and correct arg passing

No runtime product behavior changed; this is repository tooling hardening.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Simplified pre-commit hook by removing file type filtering logic. The hook now passes all staged files to `oxlint` and `oxfmt`, relying on these tools to filter by extension internally. The `--no-error-on-unmatched-pattern` flag on `oxfmt` ensures it doesn't fail on non-code files. Maintains NUL-delimited file handling and package manager fallback routing.

<h3>Confidence Score: 3/5</h3>

- Safe to merge after fixing option injection vulnerability
- The PR correctly adds fail-fast error handling and package manager fallback routing. However, it's missing the `--` separator before file arguments in both oxlint and oxfmt calls, which creates an option injection vulnerability if a file is named like `--all`. The base commit had this protection. Additionally, the PR removes file type filtering logic, now relying on the tools to filter internally - this should work but represents a behavior change that warrants testing with non-code files in the staging area.
- git-hooks/pre-commit needs the `--` separator added to prevent option injection

<sub>Last reviewed commit: 5577a9a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->