### PR TITLE
fix(doctor): skip embedding provider check when memory backend is QMD

### DIFF
--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -4,6 +4,7 @@ import { resolveAgentDir, resolveDefaultAgentId } from "../agents/agent-scope.js
 import { resolveMemorySearchConfig } from "../agents/memory-search.js";
 import { resolveApiKeyForProvider } from "../agents/model-auth.js";
 import { formatCliCommand } from "../cli/command-format.js";
+import { resolveMemoryBackendConfig } from "../memory/backend-config.js";
 import { note } from "../terminal/note.js";
 import { resolveUserPath } from "../utils.js";
 
@@ -19,6 +20,14 @@ export async function noteMemorySearchHealth(cfg: OpenClawConfig): Promise<void>
 
   if (!resolved) {
     note("Memory search is explicitly disabled (enabled: false).", "Memory search");
+    return;
+  }
+
+  // When the memory backend is QMD, embeddings are handled internally by the
+  // QMD engine (e.g. embeddinggemma). OpenClaw does not need its own embedding
+  // provider, so skip the provider check to avoid a false-positive warning.
+  const backendConfig = resolveMemoryBackendConfig({ cfg, agentId });
+  if (backendConfig.backend === "qmd") {
     return;
   }
 


### PR DESCRIPTION
## Summary

- **Problem:** `openclaw doctor` falsely warns "no embedding provider configured" when using QMD as the memory backend, even though QMD handles embeddings internally (e.g. embeddinggemma)
- **Fix:** Added an early return in `noteMemorySearchHealth()` that detects the QMD backend via `resolveMemoryBackendConfig()` and skips the embedding provider check
- **Test:** Added a regression test covering the QMD backend scenario

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #17263

## User-visible / Behavior Changes

`openclaw doctor` no longer shows a false warning about missing embedding providers when the memory backend is set to `qmd`.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS (arm64)
- Runtime: Node v22.22.0
- OpenClaw: v2026.2.14+

### Steps

1. Set `memory.backend: "qmd"` in `openclaw.json`
2. Configure QMD with local embeddings (e.g. embeddinggemma)
3. Run `openclaw doctor`

### Expected

No warning about embedding providers.

### Actual (before fix)

Shows "Memory search is enabled but no embedding provider is configured."

## Evidence

- [x] Failing test/log before + passing after

All 4 tests pass (3 existing + 1 new regression test):

```
 ✓ src/commands/doctor-memory-search.test.ts (4 tests) 3ms
   ✓ does not warn when remote apiKey is configured for explicit provider
   ✓ does not warn in auto mode when remote apiKey is configured
   ✓ does not warn when memory backend is qmd (#17263)
   ✓ resolves provider auth from the default agent directory
```

## Human Verification (required)

- Verified: QMD backend path returns early without emitting a note
- Verified: Existing tests still pass (non-QMD flows unaffected)
- Not verified: Live `openclaw doctor` on a system with QMD installed

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## AI-Assisted 🤖

This PR was AI-assisted (Claude). The fix and test were manually reviewed and verified against the codebase.

lobster-biscuit

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds early return in `noteMemorySearchHealth()` to skip embedding provider validation when QMD backend is configured, since QMD handles embeddings internally. The fix is well-positioned in the control flow and includes proper test coverage.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a simple, focused early return that addresses a specific false-positive warning. The logic is sound, the function being called always returns valid data, and comprehensive test coverage verifies the behavior. No edge cases or error paths exist that could cause issues.
- No files require special attention

<sub>Last reviewed commit: faa219b</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->