### PR TITLE
fix(discord): dedupe native skill commands by skillName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 - Security/Logging: redact Telegram bot tokens from error messages and uncaught stack traces to prevent accidental secret leakage into logs. Thanks @aether-ai-agent.
 - Telegram: omit `message_thread_id` for DM sends/draft previews and keep forum-topic handling (`id=1` general omitted, non-general kept), preventing DM failures with `400 Bad Request: message thread not found`. (#10942) Thanks @garnetlyx.
 - Dev tooling: harden git `pre-commit` hook against option injection from malicious filenames (for example `--force`), preventing accidental staging of ignored files. Thanks @mrthankyou.
+- Discord: dedupe native skill commands by skill name in multi-agent setups to prevent duplicated slash commands with `_2` suffixes. (#17365) Thanks @seewhyme.
 - Subagents/Models: preserve `agents.defaults.model.fallbacks` when subagent sessions carry a model override, so subagent runs fail over to configured fallback models instead of retrying only the overridden primary model.
 - Config/Gateway: make sensitive-key whitelist suffix matching case-insensitive while preserving `passwordFile` path exemptions, preventing accidental redaction of non-secret config values like `maxTokens` and IRC password-file paths. (#16042) Thanks @akramcodez.
 - Group chats: always inject group chat context (name, participants, reply guidance) into the system prompt on every turn, not just the first. Prevents the model from losing awareness of which group it's in and incorrectly using the message tool to send to the same group. (#14447) Thanks @tyler6204.

--- a/src/discord/monitor/provider.skill-dedupe.test.ts
+++ b/src/discord/monitor/provider.skill-dedupe.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { __testing } from "./provider.js";
+
+describe("dedupeSkillCommandsForDiscord", () => {
+  it("keeps first command per skillName and drops suffix duplicates", () => {
+    const input = [
+      { name: "github", skillName: "github", description: "GitHub" },
+      { name: "github_2", skillName: "github", description: "GitHub" },
+      { name: "weather", skillName: "weather", description: "Weather" },
+      { name: "weather_2", skillName: "weather", description: "Weather" },
+    ];
+
+    const output = __testing.dedupeSkillCommandsForDiscord(input);
+    expect(output.map((entry) => entry.name)).toEqual(["github", "weather"]);
+  });
+
+  it("treats skillName case-insensitively", () => {
+    const input = [
+      { name: "ClawHub", skillName: "ClawHub", description: "ClawHub" },
+      { name: "clawhub_2", skillName: "clawhub", description: "ClawHub" },
+    ];
+    const output = __testing.dedupeSkillCommandsForDiscord(input);
+    expect(output).toHaveLength(1);
+    expect(output[0]?.name).toBe("ClawHub");
+  });
+});

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -81,6 +81,26 @@ function summarizeGuilds(entries?: Record<string, unknown>) {
   return `${sample.join(", ")}${suffix}`;
 }
 
+function dedupeSkillCommandsForDiscord(
+  skillCommands: ReturnType<typeof listSkillCommandsForAgents>,
+) {
+  const seen = new Set<string>();
+  const deduped: ReturnType<typeof listSkillCommandsForAgents> = [];
+  for (const command of skillCommands) {
+    const key = command.skillName.trim().toLowerCase();
+    if (!key) {
+      deduped.push(command);
+      continue;
+    }
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    deduped.push(command);
+  }
+  return deduped;
+}
+
 async function deployDiscordCommands(params: {
   client: Client;
   runtime: RuntimeEnv;
@@ -355,7 +375,9 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
 
   const maxDiscordCommands = 100;
   let skillCommands =
-    nativeEnabled && nativeSkillsEnabled ? listSkillCommandsForAgents({ cfg }) : [];
+    nativeEnabled && nativeSkillsEnabled
+      ? dedupeSkillCommandsForDiscord(listSkillCommandsForAgents({ cfg }))
+      : [];
   let commandSpecs = nativeEnabled
     ? listNativeCommandSpecsForConfig(cfg, { skillCommands, provider: "discord" })
     : [];
@@ -648,4 +670,5 @@ async function clearDiscordNativeCommands(params: {
 
 export const __testing = {
   createDiscordGatewayPlugin,
+  dedupeSkillCommandsForDiscord,
 };


### PR DESCRIPTION
## Summary
Fixes duplicate Discord native skill commands with `_2` suffix in multi-agent setups where agents expose the same skills from different workspaces.

## What changed
- In Discord provider, dedupe `listSkillCommandsForAgents()` output by normalized `skillName` before building native command specs.
- Keep first command per skill name to avoid registering `github` + `github_2` for the same skill.
- Added unit tests for the dedupe behavior.

## Why
Issue #17358 reports Discord command duplication after restart/reload even on latest version. This is similar to #5717 (Telegram), but on Discord path.

## Scope
Focused PR: one change/theme only (Discord native skill command dedupe).

## Local validation
Completed locally on this branch:
- `pnpm build` ✅
- `pnpm check` ✅
- `pnpm exec vitest run src/discord/monitor/provider.skill-dedupe.test.ts` ✅
- `pnpm exec vitest run src/commands/cleanup-utils.test.ts` ✅

Additional context:
- Full `pnpm test` is being re-run locally due to a prior unrelated CI failure in `src/commands/cleanup-utils.test.ts` on Windows path separators (`/tmp/...` vs `C:\tmp\...`).

## AI-assistance transparency
AI-assisted contribution:
- Assistance used for code drafting/refactoring and test scaffolding.
- Human-reviewed and validated with the commands listed above.
- Testing level: targeted tests + local build/check.

## Notes
This is intentionally scoped to Discord path; no behavior change for Telegram/Slack in this PR.


Fixes #17358 
