### PR TITLE
fix(hooks): prevent before_tool_call hook double-fire after abort wrapping

### DIFF
--- a/src/agents/pi-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/pi-tools.before-tool-call.e2e.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { toClientToolDefinitions, toToolDefinitions } from "./pi-tool-definition-adapter.js";
+import { wrapToolWithAbortSignal } from "./pi-tools.abort.js";
 import { wrapToolWithBeforeToolCallHook } from "./pi-tools.before-tool-call.js";
 
 vi.mock("../plugins/hook-runner-global.js");
@@ -141,6 +142,24 @@ describe("before_tool_call hook deduplication (#15502)", () => {
       undefined,
       undefined,
     );
+
+    expect(hookRunner.runBeforeToolCall).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires hook exactly once when tool goes through wrap + abort + toToolDefinitions (#16851)", async () => {
+    const execute = vi.fn().mockResolvedValue({ content: [], details: { ok: true } });
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const baseTool = { name: "Bash", execute, description: "bash", parameters: {} } as any;
+    const abortController = new AbortController();
+
+    const wrapped = wrapToolWithBeforeToolCallHook(baseTool, {
+      agentId: "main",
+      sessionKey: "main",
+    });
+    const withAbort = wrapToolWithAbortSignal(wrapped, abortController.signal);
+    const [def] = toToolDefinitions([withAbort]);
+
+    await def.execute("call-abort-dedup", { command: "echo hi" }, undefined, undefined, undefined);
 
     expect(hookRunner.runBeforeToolCall).toHaveBeenCalledTimes(1);
   });

--- a/src/agents/pi-tools.before-tool-call.ts
+++ b/src/agents/pi-tools.before-tool-call.ts
@@ -100,7 +100,7 @@ export function wrapToolWithBeforeToolCallHook(
   };
   Object.defineProperty(wrappedTool, BEFORE_TOOL_CALL_WRAPPED, {
     value: true,
-    enumerable: false,
+    enumerable: true,
   });
   return wrappedTool;
 }


### PR DESCRIPTION
## Summary
Fix double-firing of the `before_tool_call` hook caused by the `BEFORE_TOOL_CALL_WRAPPED` Symbol marker being defined with `enumerable: false`. When `wrapToolWithAbortSignal` spreads the tool object, non-enumerable properties are dropped, causing `toToolDefinitions` to re-wrap the tool and fire the hook twice. Changed to `enumerable: true` so the marker survives object spread.

Fixes #16851

## Validation
- [x] `pnpm build` — passed
- [x] `pnpm check` (format + tsgo + lint) — passed
- [x] `pnpm test` — 1073 tests passed (105 test files)

## Scope
- Single focused fix — 2 files changed (`src/agents/pi-tools.before-tool-call.ts` + test)

## AI-Assistance
- AI-assisted (Claude Code) for implementation
- Human-reviewed: confirmed understanding of changes
- Testing: full local validation suite passed