### PR TITLE
fix(media): anchor MEDIA_TOKEN_RE to line start to prevent false triggers

### DIFF
--- a/src/agents/pi-embedded-subscribe.tools.media.test.ts
+++ b/src/agents/pi-embedded-subscribe.tools.media.test.ts
@@ -129,4 +129,16 @@ describe("extractToolResultMediaPaths", () => {
     };
     expect(extractToolResultMediaPaths(result)).toEqual([]);
   });
+
+  it("ignores MEDIA: mid-line in prose text (#16935)", () => {
+    const result = {
+      content: [
+        {
+          type: "text",
+          text: "accept `MEDIA:`-prefixed paths (lenient whitespace) when loading outbound media to prevent `ENOENT`",
+        },
+      ],
+    };
+    expect(extractToolResultMediaPaths(result)).toEqual([]);
+  });
 });

--- a/src/media/parse.test.ts
+++ b/src/media/parse.test.ts
@@ -87,4 +87,18 @@ describe("splitMediaFromOutput", () => {
     const result = splitMediaFromOutput("MEDIA:screenshot");
     expect(result.mediaUrls).toBeUndefined();
   });
+
+  it("ignores MEDIA: inside changelog prose (#16935)", () => {
+    const input = "accept `MEDIA:`-prefixed paths (lenient whitespace) when loading outbound media";
+    const result = splitMediaFromOutput(input);
+    expect(result.mediaUrls).toBeUndefined();
+    expect(result.text).toBe(input);
+  });
+
+  it("ignores MEDIA: mid-line in markdown list items (#16935)", () => {
+    const input = "- Fixed `MEDIA:` prefix handling for outbound files";
+    const result = splitMediaFromOutput(input);
+    expect(result.mediaUrls).toBeUndefined();
+    expect(result.text).toBe(input);
+  });
 });

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -4,7 +4,7 @@ import { parseFenceSpans } from "../markdown/fences.js";
 import { parseAudioTag } from "./audio-tags.js";
 
 // Allow optional wrapping backticks and punctuation after the token; capture the core token.
-export const MEDIA_TOKEN_RE = /\bMEDIA:\s*`?([^\n]+)`?/gi;
+export const MEDIA_TOKEN_RE = /^[ \t]*\bMEDIA:\s*`?([^\n]+)`?/gim;
 
 export function normalizeMediaSource(src: string) {
   return src.startsWith("file://") ? src.replace("file://", "") : src;


### PR DESCRIPTION
## Summary
Anchor `MEDIA_TOKEN_RE` to line start with the multiline flag to prevent false triggers when `MEDIA:` appears mid-line in prose text. Previously the regex matched `MEDIA:` anywhere in a line, causing changelogs and docs mentioning `MEDIA:` mid-line to incorrectly trigger media processing.

Fixes #16935

## Validation
- [x] `pnpm build` — passed
- [x] `pnpm check` (format + tsgo + lint) — passed
- [x] `pnpm test` — 1073 tests passed (105 test files)

## Scope
- Single focused fix — 3 files changed (parse.ts + 2 test files)

## AI-Assistance
- AI-assisted (Claude Code) for implementation
- Human-reviewed: confirmed understanding of changes
- Testing: full local validation suite passed