### PR TITLE
fix(session): preserve responseUsage across /new and /reset

### DIFF
--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -140,6 +140,7 @@ export async function initSessionState(params: {
   let persistedTtsAuto: TtsAutoMode | undefined;
   let persistedModelOverride: string | undefined;
   let persistedProviderOverride: string | undefined;
+  let persistedResponseUsage: "on" | "off" | "tokens" | "full" | undefined;
 
   const normalizedChatType = normalizeChatType(ctx.ChatType);
   const isGroup =
@@ -237,6 +238,7 @@ export async function initSessionState(params: {
     persistedTtsAuto = entry.ttsAuto;
     persistedModelOverride = entry.modelOverride;
     persistedProviderOverride = entry.providerOverride;
+    persistedResponseUsage = entry.responseUsage;
   } else {
     sessionId = crypto.randomUUID();
     isNewSession = true;
@@ -250,6 +252,7 @@ export async function initSessionState(params: {
       persistedVerbose = entry.verboseLevel;
       persistedReasoning = entry.reasoningLevel;
       persistedTtsAuto = entry.ttsAuto;
+      persistedResponseUsage = entry.responseUsage;
     }
   }
 
@@ -282,7 +285,7 @@ export async function initSessionState(params: {
     verboseLevel: persistedVerbose ?? baseEntry?.verboseLevel,
     reasoningLevel: persistedReasoning ?? baseEntry?.reasoningLevel,
     ttsAuto: persistedTtsAuto ?? baseEntry?.ttsAuto,
-    responseUsage: baseEntry?.responseUsage,
+    responseUsage: persistedResponseUsage ?? baseEntry?.responseUsage,
     modelOverride: persistedModelOverride ?? baseEntry?.modelOverride,
     providerOverride: persistedProviderOverride ?? baseEntry?.providerOverride,
     sendPolicy: baseEntry?.sendPolicy,


### PR DESCRIPTION
## Summary
Preserve user-set `responseUsage` across `/new` and `/reset` session resets. The carry-over path only persisted thinking/verbose/tts/model/provider overrides, dropping `responseUsage` and forcing users to re-set it after every reset. Added `persistedResponseUsage` to the carry-over path.

Fixes #17102

## Validation
- [x] `pnpm build` — passed
- [x] `pnpm check` (format + tsgo + lint) — passed
- [x] `pnpm test` — 1073 tests passed (105 test files)

## Scope
- Single focused fix — single file changed (`src/auto-reply/reply/session.ts`)

## AI-Assistance
- AI-assisted (Claude Code) for implementation
- Human-reviewed: confirmed understanding of changes
- Testing: full local validation suite passed