### PR TITLE
fix(web-fetch): preserve JSON-LD structured data during HTML-to-markdown

### DIFF
--- a/src/agents/tools/web-fetch-utils.test.ts
+++ b/src/agents/tools/web-fetch-utils.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { htmlToMarkdown } from "./web-fetch-utils.js";
+
+describe("htmlToMarkdown JSON-LD extraction (#17137)", () => {
+  it("preserves JSON-LD blocks that would otherwise be stripped with scripts", () => {
+    const html = `<html><head>
+      <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","name":"Test"}</script>
+      <script>console.log("removed")</script>
+    </head><body><p>Hello world</p></body></html>`;
+    const { text } = htmlToMarkdown(html);
+    expect(text).toContain("Structured Data (JSON-LD)");
+    expect(text).toContain('"@type":"Article"');
+    expect(text).not.toContain("console.log");
+  });
+
+  it("handles multiple JSON-LD blocks", () => {
+    const html = `<html><body>
+      <script type="application/ld+json">{"@type":"Organization"}</script>
+      <script type="application/ld+json">{"@type":"WebSite"}</script>
+      <p>Content</p>
+    </body></html>`;
+    const { text } = htmlToMarkdown(html);
+    expect(text).toContain('"@type":"Organization"');
+    expect(text).toContain('"@type":"WebSite"');
+  });
+
+  it("returns normal markdown when no JSON-LD is present", () => {
+    const html = `<html><body><p>No structured data</p></body></html>`;
+    const { text } = htmlToMarkdown(html);
+    expect(text).not.toContain("Structured Data");
+    expect(text).toContain("No structured data");
+  });
+});

--- a/src/agents/tools/web-fetch-utils.ts
+++ b/src/agents/tools/web-fetch-utils.ts
@@ -58,6 +58,16 @@ function normalizeWhitespace(value: string): string {
 export function htmlToMarkdown(html: string): { text: string; title?: string } {
   const titleMatch = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
   const title = titleMatch ? normalizeWhitespace(stripTags(titleMatch[1])) : undefined;
+  // Extract JSON-LD structured data before stripping scripts (#17137)
+  const jsonLdBlocks: string[] = [];
+  const jsonLdRe = /<script[^>]+type\s*=\s*["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi;
+  let jsonLdMatch: RegExpExecArray | null;
+  while ((jsonLdMatch = jsonLdRe.exec(html)) !== null) {
+    const block = jsonLdMatch[1].trim();
+    if (block) {
+      jsonLdBlocks.push(block);
+    }
+  }
   let text = html
     .replace(/<script[\s\S]*?<\/script>/gi, "")
     .replace(/<style[\s\S]*?<\/style>/gi, "")
@@ -83,6 +93,10 @@ export function htmlToMarkdown(html: string): { text: string; title?: string } {
     .replace(/<\/(p|div|section|article|header|footer|table|tr|ul|ol)>/gi, "\n");
   text = stripTags(text);
   text = normalizeWhitespace(text);
+  if (jsonLdBlocks.length > 0) {
+    const jsonLdSection = jsonLdBlocks.map((block) => `\`\`\`json\n${block}\n\`\`\``).join("\n");
+    text = `${text}\n\n## Structured Data (JSON-LD)\n\n${jsonLdSection}`;
+  }
   return { text, title };
 }
 

--- a/src/agents/tools/web-fetch-utils.ts
+++ b/src/agents/tools/web-fetch-utils.ts
@@ -60,7 +60,8 @@ export function htmlToMarkdown(html: string): { text: string; title?: string } {
   const title = titleMatch ? normalizeWhitespace(stripTags(titleMatch[1])) : undefined;
   // Extract JSON-LD structured data before stripping scripts (#17137)
   const jsonLdBlocks: string[] = [];
-  const jsonLdRe = /<script[^>]+type\s*=\s*["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi;
+  const jsonLdRe =
+    /<script[^>]+type\s*=\s*["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi;
   let jsonLdMatch: RegExpExecArray | null;
   while ((jsonLdMatch = jsonLdRe.exec(html)) !== null) {
     const block = jsonLdMatch[1].trim();


### PR DESCRIPTION
## Summary
Preserve JSON-LD structured data during HTML-to-markdown conversion. `htmlToMarkdown` strips all script tags including `<script type="application/ld+json">` blocks containing valuable structured data used by agents for understanding page content. Extract JSON-LD before script removal and append as a formatted section.

Fixes #17137

## Validation
- [x] `pnpm build` — passed
- [x] `pnpm check` (format + tsgo + lint) — passed
- [x] `pnpm test` — 1073 tests passed (105 test files)

## Scope
- Single focused fix — 2 files changed (`src/agents/tools/web-fetch-utils.ts` + test)

## AI-Assistance
- AI-assisted (Claude Code) for implementation
- Human-reviewed: confirmed understanding of changes
- Testing: full local validation suite passed