### PR TITLE
fix(telegram): respect requireMention for file-size error replies

### DIFF
--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -81,6 +81,8 @@ export type TelegramAccountConfig = {
    * - "allowlist": only allow group messages from senders in groupAllowFrom/allowFrom
    */
   groupPolicy?: GroupPolicy;
+  /** Account-level default for requireMention in groups. Per-group/topic overrides take precedence. */
+  requireMention?: boolean;
   /** Max group messages to keep as history context (0 disables). */
   historyLimit?: number;
   /** Max DM turns to keep as history context. */

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -106,6 +106,7 @@ export const TelegramAccountSchemaBase = z
     allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
     groupAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
     groupPolicy: GroupPolicySchema.optional().default("allowlist"),
+    requireMention: z.boolean().optional(),
     historyLimit: z.number().int().min(0).optional(),
     dmHistoryLimit: z.number().int().min(0).optional(),
     dms: z.record(z.string(), DmConfigSchema.optional()).optional(),

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -28,6 +28,7 @@ import { resolveMedia } from "./bot/delivery.js";
 import {
   buildTelegramGroupPeerId,
   buildTelegramParentPeer,
+  hasBotMention,
   resolveTelegramForumThreadId,
   resolveTelegramGroupAllowFromContext,
 } from "./bot/helpers.js";
@@ -896,6 +897,22 @@ export const registerTelegramHandlers = ({
       } catch (mediaErr) {
         const errMsg = String(mediaErr);
         if (errMsg.includes("exceeds") && errMsg.includes("MB limit")) {
+          // Respect requireMention in groups: don't reply to file-size errors
+          // when the bot wasn't mentioned (#17048).
+          if (isGroup) {
+            const fileSizeRequireMention = firstDefined(
+              topicConfig?.requireMention,
+              groupConfig?.requireMention,
+              telegramCfg.requireMention,
+            );
+            if (fileSizeRequireMention) {
+              const botUsername = (ctx.me?.username ?? "").toLowerCase();
+              if (botUsername && !hasBotMention(msg, botUsername)) {
+                logVerbose("telegram: suppressing file-size error (requireMention, not mentioned)");
+                return;
+              }
+            }
+          }
           const limitMb = Math.round(mediaMaxBytes / (1024 * 1024));
           await withTelegramApiErrorLogging({
             operation: "sendMessage",


### PR DESCRIPTION
## Summary
In Telegram groups with `requireMention` enabled, file-size limit error messages were sent even when the bot was not mentioned — creating noise in busy groups since every oversized file triggered an error reply. Added a `requireMention` check inside the file-size error handler using `firstDefined` + `hasBotMention` so the reply is suppressed when the bot is not addressed.

Fixes #17048

## Validation
- [x] `pnpm build` — passed
- [x] `pnpm check` (format + tsgo + lint) — passed
- [x] `pnpm test` — 1073 tests passed (105 test files)

## Scope
- Single focused fix — 3 files changed (bot-handlers.ts, types.telegram.ts, zod-schema.providers-core.ts)

## AI-Assistance
- AI-assisted (Claude Code) for implementation
- Human-reviewed: confirmed understanding of changes
- Testing: full local validation suite passed