### PR TITLE
fix(memory): prioritize live store for compaction count after flush

### DIFF
--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -161,10 +161,13 @@ export async function runMemoryFlushIfNeeded(params: {
         });
       },
     });
+    // Read from the store first (most up-to-date after any compaction in the
+    // preceding reply run), then fall back to the entry snapshot (#16984).
+    const storeCompactionCount = params.sessionKey
+      ? activeSessionStore?.[params.sessionKey]?.compactionCount
+      : undefined;
     let memoryFlushCompactionCount =
-      activeSessionEntry?.compactionCount ??
-      (params.sessionKey ? activeSessionStore?.[params.sessionKey]?.compactionCount : 0) ??
-      0;
+      storeCompactionCount ?? activeSessionEntry?.compactionCount ?? 0;
     if (memoryCompactionCompleted) {
       const nextCount = await incrementCompactionCount({
         sessionEntry: activeSessionEntry,


### PR DESCRIPTION
## Summary
After memory flush with compaction, `memoryFlushCompactionCount` was read from a stale `activeSessionEntry` snapshot where `compactionCount` was 0. Since `0 ?? fallback` returns 0 (nullish coalescing treats 0 as non-nullish), the updated store value was never reached — so compaction count was always reported as 0 after flush. Fixed by reversing the read priority to check the live session store first.

Fixes #16984

## Validation
- [x] `pnpm build` — passed
- [x] `pnpm check` (format + tsgo + lint) — passed
- [x] `pnpm test` — 1073 tests passed (105 test files)

## Scope
- Single focused fix — single file changed (`src/auto-reply/reply/agent-runner-memory.ts`)

## AI-Assistance
- AI-assisted (Claude Code) for implementation
- Human-reviewed: confirmed understanding of changes
- Testing: full local validation suite passed