### PR TITLE
fix: skip embedding provider check in doctor when QMD backend is enabled

### DIFF
--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -14,6 +14,13 @@ import { resolveUserPath } from "../utils.js";
 export async function noteMemorySearchHealth(cfg: OpenClawConfig): Promise<void> {
   const agentId = resolveDefaultAgentId(cfg);
   const agentDir = resolveAgentDir(cfg, agentId);
+  
+  // If QMD backend is enabled, it handles embeddings internally — skip memorySearch validation.
+  const backend = cfg.memory?.backend ?? "builtin";
+  if (backend === "qmd") {
+    return;
+  }
+  
   const resolved = resolveMemorySearchConfig(cfg, agentId);
   const hasRemoteApiKey = Boolean(resolved?.remote?.apiKey?.trim());
 


### PR DESCRIPTION
Fixes #17263

## Problem

`openclaw doctor` falsely warns about **missing embedding provider** when QMD memory backend is configured with local embeddings (e.g., `gemma-300M`).

**User experience:**
1. User configures `memory.backend = "qmd"` with local embeddings
2. Embeddings work correctly (`qmd embed` and `qmd query` succeed)
3. Run `openclaw doctor`
4. See misleading warning:
   ```
   Memory search is enabled but no embedding provider is configured.
   Semantic recall will not work without an embedding provider.
   
   Fix (pick one):
   - Set OPENAI_API_KEY or GEMINI_API_KEY in your environment
   - Add credentials: openclaw auth add --provider openai
   - For local embeddings: configure agents.defaults.memorySearch.provider and local model path
   ```

The warning is incorrect because **QMD handles embeddings internally** and doesn't require `memorySearch` config or API keys.

---

## Root Cause

`noteMemorySearchHealth` in `src/commands/doctor-memory-search.ts` validates the **builtin** memory backend's `memorySearch` config:
- Checks for OpenAI/Gemini/Voyage API keys
- Checks for local node-llama-cpp models
- Used by the **builtin** memory backend

**When `memory.backend = "qmd"`:**
- OpenClaw delegates **all memory operations** (search, indexing, embeddings) to QMD
- `memorySearch` config is **completely ignored** (QMD doesn't use it)
- QMD uses its own embedding configuration (via `qmd embed` command and `qmd.toml`)
- QMD supports local models (gemma, nomic-embed, etc.) **without API keys**

However, `doctor` unconditionally validates `memorySearch` config **even when QMD is enabled**, triggering the false warning.

---

## Solution

**Skip `memorySearch` validation when `memory.backend === "qmd"`:**

```typescript
export async function noteMemorySearchHealth(cfg: OpenClawConfig): Promise<void> {
  const agentId = resolveDefaultAgentId(cfg);
  const agentDir = resolveAgentDir(cfg, agentId);
  
  // If QMD backend is enabled, it handles embeddings internally — skip memorySearch validation.
  const backend = cfg.memory?.backend ?? "builtin";
  if (backend === "qmd") {
    return;  // ✅ QMD manages its own embeddings
  }
  
  // Validate memorySearch config only for builtin backend
  const resolved = resolveMemorySearchConfig(cfg, agentId);
  // ...
}
```

**Why this is correct:**
- `memorySearch` config is **only relevant** for `backend: "builtin"`
- QMD users configure embeddings via `qmd embed` and `qmd.toml`, not `memorySearch`
- Doctor should validate what's actually used by the configured backend

---

## Impact

- ✅ **No false warnings** for QMD users with local embeddings
- ✅ **Validation still runs correctly** for `backend: "builtin"`
- ✅ **Doctor output is accurate** and actionable
- ✅ Users can trust `openclaw doctor` for health checks
- 📝 Aligns doctor behavior with actual memory backend architecture

---

## Alternative Considered

Instead of skipping validation entirely, we could check QMD's embedding config:
- Call `qmd status` or `qmd list models`
- Verify local embeddings are available

However, this would require:
- Shelling out to `qmd` CLI
- Parsing its output (fragile)
- Slowing down `doctor` runs

**The chosen approach is simpler and correct:** If user chose QMD, trust their QMD configuration. If QMD embeddings don't work, `openclaw memory status --deep` will surface the issue.

---

**Note:** This is a clean re-submission of the previously closed PR #17291 (which had unrelated commits). This branch contains only the single targeted fix.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds early return in `noteMemorySearchHealth` to skip `memorySearch` validation when `memory.backend === "qmd"`. QMD backend handles embeddings internally via its own configuration system, making the `memorySearch` config validation irrelevant and misleading for QMD users.

- Prevents false warnings about missing embedding providers for QMD users with local embeddings
- Aligns doctor behavior with actual memory backend architecture
- Simple conditional check that exits early for QMD backend before calling `resolveMemorySearchConfig`

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one test coverage gap
- The logic is correct and well-targeted. The early return is placed appropriately before `resolveMemorySearchConfig` is called, which correctly avoids validation for QMD backend. However, the PR lacks test coverage for the new code path, as previously noted in review threads.
- No files require special attention beyond addressing the test coverage comment

<sub>Last reviewed commit: 991e8a1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->