### PR TITLE
fix: improve sessions_spawn error message when agentId allowlist is empty

### DIFF
--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -159,9 +159,13 @@ export function createSessionsSpawnTool(opts?: {
             : allowSet.size > 0
               ? Array.from(allowSet).join(", ")
               : "none";
+          const configHint =
+            allowSet.size === 0
+              ? ` Configure agents.defaults.subagents.allowAgents: ["${targetAgentId}"] or allowAgents: ["*"] to enable.`
+              : "";
           return jsonResult({
             status: "forbidden",
-            error: `agentId is not allowed for sessions_spawn (allowed: ${allowedText})`,
+            error: `agentId is not allowed for sessions_spawn (allowed: ${allowedText}).${configHint}`,
           });
         }
       }


### PR DESCRIPTION
Fixes #17330

## Problem

When users configure custom agents in `agents.list` but forget to set `subagents.allowAgents`, attempting to spawn those agents via `sessions_spawn` with `agentId` returns a **cryptic error**:

```json
{
  "status": "forbidden",
  "error": "agentId is not allowed for sessions_spawn (allowed: none)"
}
```

**User confusion:**
- "I configured 8 agents in `agents.list`"
- "They appear in `gateway.config.get`"
- "Why does the error say 'allowed: none'?"
- **No guidance on how to fix it**

**User experience:**
1. User configures `agents.list: [main, coding, windows, security, ...]`
2. Runs `agents_list` → only sees "main"
3. Tries `sessions_spawn agentId=coding` → "allowed: none" error
4. Searches docs/issues for hours trying to understand
5. Eventually finds they need `subagents.allowAgents` config (undocumented)

---

## Root Cause

The error message correctly identifies the problem (agentId not in allowlist), but provides **zero actionable guidance** on how to fix it when the allowlist is empty (`allowed: none`).

**Missing context:**
- What config controls the allowlist?
- Where to add it (`agents.defaults.subagents.allowAgents` or per-agent)?
- Example syntax

**Current message:**
```
agentId is not allowed for sessions_spawn (allowed: none)
```

**User needs:**
```
agentId is not allowed for sessions_spawn (allowed: none). 
Configure agents.defaults.subagents.allowAgents: ["coding"] or allowAgents: ["*"] to enable.
```

---

## Solution

**Add config hint when allowlist is empty:**

```typescript
const configHint =
  allowSet.size === 0
    ? ` Configure agents.defaults.subagents.allowAgents: ["${targetAgentId}"] or allowAgents: ["*"] to enable.`
    : "";
return jsonResult({
  status: "forbidden",
  error: `agentId is not allowed for sessions_spawn (allowed: ${allowedText}).${configHint}`,
});
```

**Before:**
```json
{
  "error": "agentId is not allowed for sessions_spawn (allowed: none)"
}
```

**After:**
```json
{
  "error": "agentId is not allowed for sessions_spawn (allowed: none). Configure agents.defaults.subagents.allowAgents: [\"coding\"] or allowAgents: [\"*\"] to enable."
}
```

**Why only when empty:**
- If allowlist is not empty (e.g., `allowed: main, assistant`), the error is self-explanatory (user knows which agents are allowed)
- When empty (`allowed: none`), the error is confusing ("I configured agents, why none?")
- Config hint is most valuable when user is completely stuck

---

## Impact

- ✅ **Self-service troubleshooting** (users fix config themselves)
- ✅ **Reduced support burden** (fewer "how do I enable custom agents?" issues)
- ✅ **Improved DX** (actionable error messages)
- ✅ **Faster onboarding** (multi-agent users discover allowlist requirement immediately)
- 📝 Error message includes exact config path and example syntax

---

## Testing

**Before fix:**
```bash
# Config: agents.list has "coding" but no allowAgents
sessions_spawn agentId=coding task="test"
# Error: "agentId is not allowed for sessions_spawn (allowed: none)"
# User: "?? How do I fix this?"
```

**After fix:**
```bash
sessions_spawn agentId=coding task="test"
# Error: "agentId is not allowed for sessions_spawn (allowed: none). 
#         Configure agents.defaults.subagents.allowAgents: [\"coding\"] or allowAgents: [\"*\"] to enable."
# User: "Ah! I need to add allowAgents config." ✅
```

---

## Alternative Considered

**Auto-populate allowlist from agents.list:**
- When `allowAgents` is not set, default to all agents in `agents.list`
- Pro: Zero config required
- Con: Security risk (unintended agent access), breaks explicit allowlist design

**Rejected:** The allowlist is intentionally explicit for security. Improving error messages is the right fix.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves the `sessions_spawn` error message when a user attempts to spawn a sub-agent with an `agentId` but no agents are in the allowlist. Instead of the unhelpful `"allowed: none"`, it now appends a configuration hint pointing users to the `allowAgents` setting. The change is small and well-intentioned — it addresses a real DX pain point described in issue #17330.

- The config hint is only shown when the allowlist is empty, which is the right design choice — non-empty allowlists are already self-explanatory.
- The critical issue (incorrect config path in the hint text) was flagged in a previous review thread and still needs to be addressed before merging.
- No tests were added to verify the new hint text, though the existing allowlist tests do cover the forbidden status path.

<h3>Confidence Score: 2/5</h3>

- The PR has an unresolved issue (incorrect config path in the hint) that would actively mislead users — the opposite of its stated goal.
- Score of 2 reflects that the code change is small and low-risk structurally (only error message text), but the incorrectly suggested config path (`agents.defaults.subagents.allowAgents` does not exist) would send users on a wild goose chase. This was flagged in a prior review thread and needs to be fixed before merge.
- `src/agents/tools/sessions-spawn-tool.ts` — the config hint on line 164 references a non-existent config path that needs to be corrected to `agents.list[].subagents.allowAgents`.

<sub>Last reviewed commit: 07a6e6f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->