### PR TITLE
fix(discord): default dm config for sub-accounts to prevent silent crash

### DIFF
--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -185,6 +185,14 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
   const discordCfg = account.config;
   const discordRestFetch = resolveDiscordRestFetch(discordCfg.proxy, runtime);
   const dmConfig = discordCfg.dm;
+  if (!dmConfig && !discordCfg.dmPolicy) {
+    runtime.log?.(
+      warn(
+        `discord: [${account.accountId}] no dm config found; defaulting to dm.policy="pairing". ` +
+          `Set channels.discord${account.accountId !== "default" ? `.accounts.${account.accountId}` : ""}.dmPolicy (or .dm.policy) to suppress this warning.`,
+      ),
+    );
+  }
   let guildEntries = discordCfg.guilds;
   const defaultGroupPolicy = cfg.channels?.defaults?.groupPolicy;
   const groupPolicy = discordCfg.groupPolicy ?? defaultGroupPolicy ?? "open";

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -136,6 +136,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
 
     await Promise.all(
       accountIds.map(async (id) => {
+        try {
         if (store.tasks.has(id)) {
           return;
         }
@@ -259,6 +260,12 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
             }
           });
         store.tasks.set(id, trackedPromise);
+        } catch (err) {
+          const message = formatErrorMessage(err);
+          setRuntime(channelId, id, { accountId: id, running: false, lastError: message });
+          const log = channelLogs[channelId];
+          log.error?.(`[${id}] account startup failed (isolated): ${message}`);
+        }
       }),
     );
   };

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -136,7 +136,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
 
     await Promise.all(
       accountIds.map(async (id) => {
-        try {
+          try {
         if (store.tasks.has(id)) {
           return;
         }


### PR DESCRIPTION
## Summary

Fixes #17394 — Adding a Discord sub-account without an explicit `dm` block crashes the entire Discord plugin silently, killing all bot connections including the primary account.

## Root Cause

`mergeDiscordAccountConfig()` in `src/discord/accounts.ts` does a shallow merge of base + account config. When a sub-account omits `dm` and the base's `dm` doesn't get inherited, `merged.dm` is `undefined`. Downstream code doesn't guard against this, causing a silent crash.

## Changes

### 1. Default DM config (`src/discord/accounts.ts`)
- Added `DEFAULT_DM_CONFIG` (`{ enabled: true, policy: "pairing" }`) applied when neither base nor account provides a `dm` block
- Safe fallback that doesn't change behavior for existing configs

### 2. Warning log (`src/discord/monitor/provider.ts`)  
- Logs a warning when no DM config is found, pointing operators to the correct config path

### 3. Error isolation (`src/gateway/server-channels.ts`)
- Wrapped per-account startup in try/catch so one failing account cannot take down others
- Failed accounts get `running: false` status with the error message logged

## Testing

Reproduced the crash by configuring a Discord sub-account without a `dm` block. After this fix:
- Sub-account without `dm` starts successfully with default pairing policy
- Warning is logged directing the operator to add explicit config
- If a sub-account fails for any reason, other accounts continue running

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a critical bug where Discord sub-accounts without explicit `dm` configuration would crash the entire Discord plugin, taking down all bot connections. The fix applies a safe default (`dm.policy="pairing"`) when neither base nor account config provides DM settings, adds a helpful warning to guide operators, and wraps per-account startup in try-catch to isolate failures.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix correctly addresses the root cause (undefined dm config in shallow merge), uses a safe default that matches existing behavior (pairing policy), and adds critical error isolation. The changes are well-scoped and backward-compatible.
- No files require special attention

<sub>Last reviewed commit: 3746003</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->