### PR TITLE
fix: textarea size and button layout on iOS

### DIFF
--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -431,6 +431,29 @@
     grid-template-columns: 1fr;
   }
 
+  .chat-compose__row {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 8px;
+  }
+
+  .chat-compose__field {
+    width: 100%;
+  }
+
+  .chat-compose .chat-compose__field textarea {
+    min-height: 80px;
+  }
+
+  .chat-compose__actions {
+    width: 100%;
+    flex-wrap: wrap;
+  }
+
+  .chat-compose .chat-compose__actions .btn {
+    flex: 1 1 0;
+  }
+
   .chat-controls {
     flex-wrap: wrap;
     gap: 8px;


### PR DESCRIPTION
## Summary

This fixes the textarea to be full width at mobile sizes and move the buttons under it. This makes the web chat interface more usable at mobile sizes. 

Fixing this for my own use as a PWA but this is also one piece of the bug(s) reported in issue 16073. This DOES NOT address the other iOS concerns there, only one of them.

- Problem: Text area is too small on an iPhone
- Why it matters: The web chat input box is currently hard to use on iPhone.
- What changed:  It changes the css styles when max-width is under 640px.
- What did NOT change (scope boundary): It does not change desktop sizes or fix existing iOS Safari sizing issues. 

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #16073

## User-visible / Behavior Changes

Textarea gets larger at media sizes under 640px. Buttons move to row under the textarea at this small size.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: iOS 26 on iPhone
- Runtime/container: pnpm ui:dev
- Model/provider: None
- Integration/channel (if any): None
- Relevant config (redacted): None

### Steps

1. Run pnpm ui:dev
2. Open browser on iOS
3. View textarea and buttons

### Expected

- Text typed in textarea to be readable

### Actual

- Only a few characters appear in textarea

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

<img width="603" height="1311" alt="IMG_7518" src="https://github.com/user-attachments/assets/9e87dfb6-beef-4111-9dea-acbb70bf2413" />

<img width="603" height="1311" alt="IMG_7519" src="https://github.com/user-attachments/assets/3c9c77d9-be0d-4fff-9399-11f08a58556d" />

<img width="564" height="1244" alt="CleanShot 2026-02-15 at 10 17 57@2x" src="https://github.com/user-attachments/assets/171da84c-2571-4986-8810-b3556196f3a3" />

<img width="3420" height="2144" alt="CleanShot 2026-02-15 at 11 15 50@2x" src="https://github.com/user-attachments/assets/23f4d806-91b1-4ff1-8085-5825e1cb6be7" />

<img width="3420" height="2144" alt="CleanShot 2026-02-15 at 11 16 02@2x" src="https://github.com/user-attachments/assets/0e439b7c-6497-44f9-af7b-6a0cd6fd5ae3" />

<img width="3420" height="2144" alt="CleanShot 2026-02-15 at 11 16 17@2x" src="https://github.com/user-attachments/assets/b2844c5f-f9ac-4941-b405-55595cec6966" />

<img width="3420" height="2144" alt="CleanShot 2026-02-15 at 11 16 51@2x" src="https://github.com/user-attachments/assets/fe59772f-ed43-4c32-b585-79ab8a8c0d54" />

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Opened in desktop browser (MacOS Safari) at multiple sizes, tried mobile browser as PWA (iOS Safari, Saved to Home Screen).
- Edge cases checked: Larger sizes.
- What you did **not** verify: Did not verify with the control plane enabled. Instead, I enabled only the field itself and verified that it looks correct plus the javascript resizing works correctly. Tested at multiple sizes.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: restore ui/src/styles/chat/layout.css
- Files/config to restore: ui/src/styles/chat/layout.css
- Known bad symptoms reviewers should watch for: n/a

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: None
  - Mitigation: None

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves mobile usability by adding responsive CSS styles for the chat compose area at screen widths under 640px. The changes stack the textarea and action buttons vertically, increase the textarea min-height from 40px to 80px for better visibility, and make buttons flex equally to fill the available width. The implementation correctly uses the existing media query and follows the established CSS patterns in the file.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-scoped CSS-only modifications within a mobile media query. The implementation follows existing patterns, doesn't introduce any logic errors, and addresses a legitimate usability issue on mobile devices. The author has manually tested on both desktop and iOS Safari.
- No files require special attention

<sub>Last reviewed commit: ffb4a32</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->