### PR TITLE
fix(agents): apply config contextWindow overrides to MODEL_CACHE

### DIFF
--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -25,6 +25,21 @@ const loadPromise = (async () => {
         MODEL_CACHE.set(m.id, m.contextWindow);
       }
     }
+
+    // Override MODEL_CACHE with contextWindow values from config. Operator-set
+    // values take precedence over API-discovered values (e.g., correcting a
+    // provider that reports the wrong context window).
+    const providers = cfg.models?.providers;
+    if (providers) {
+      for (const provider of Object.values(providers)) {
+        if (!provider?.models) continue;
+        for (const model of provider.models) {
+          if (model?.id && typeof model.contextWindow === "number" && model.contextWindow > 0) {
+            MODEL_CACHE.set(model.id, model.contextWindow);
+          }
+        }
+      }
+    }
   } catch {
     // If pi-ai isn't available, leave cache empty; lookup will fall back.
   }


### PR DESCRIPTION
## Summary
- `lookupContextTokens()` returns API-discovered context windows, ignoring
  operator-configured `contextWindow` overrides in `openclaw.json`
- Fix: after the API discovery loop populates `MODEL_CACHE`, do a second
  pass over `cfg.models.providers` and overwrite cache entries where the
  operator has set `contextWindow`
- This affects 16 callsites across 12 files that resolve context limits
  through this function

## Problem
When a provider reports an incorrect context window (e.g., OpenRouter
reporting 2M for a model with a 200K actual limit), operators set
`contextWindow` in their config to correct it. This override is read by
`resolveContextWindowInfo()` (display/guard path) but never written into
`MODEL_CACHE`, so `lookupContextTokens()` — used by compaction, memory
flush, session persistence, cron agents, and 12 other callsites — returns
the wrong value.

## Root Cause
`MODEL_CACHE` is populated in `src/agents/context.ts` from
`modelRegistry.getAll()` only. The `cfg` object is loaded but never
consulted for `contextWindow` overrides:

```ts
const cfg = loadConfig();
await ensureOpenClawModelsJson(cfg);
// ...
const models = modelRegistry.getAll();
for (const m of models) {
  MODEL_CACHE.set(m.id, m.contextWindow); // API value only
}
// cfg.models.providers[].models[].contextWindow is never read
```

## Fix
Add a second pass after the discovery loop that reads config model
definitions and overwrites cache values where the operator has set
`contextWindow`. Since it runs after the discovery loop, operator config
always wins:

```ts
const providers = cfg.models?.providers;
if (providers) {
  for (const provider of Object.values(providers)) {
    if (!provider?.models) continue;
    for (const model of provider.models) {
      if (model?.id && typeof model.contextWindow === "number" && model.contextWindow > 0) {
        MODEL_CACHE.set(model.id, model.contextWindow);
      }
    }
  }
}
```

Fixes #17404

## Related Issues
- **#16083** — Different code path (pi-agent internal compaction reads
  `model.contextWindow` from `ModelRegistry`, not `MODEL_CACHE`)
- **#11629** — Different trigger (inter-provider conflicts during
  discovery, not missing config overrides)
- **#10168** — Orthogonal (async race condition in cache population timing)
- **#8506**, **#4965** — Report the symptom (inflated context windows);
  this PR fixes the root cause

## Testing
- Verified that `lookupContextTokens()` returns the config-defined value
  when both API and config specify `contextWindow` for the same model
- Verified that models without a config override still use the
  API-discovered value
- Existing tests pass

## AI Disclosure
This PR was authored with AI assistance.
Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a bug where `lookupContextTokens()` returned only API-discovered context windows from `MODEL_CACHE`, ignoring operator-configured `contextWindow` overrides in `openclaw.json`. The fix adds a second pass after the API discovery loop that reads `cfg.models.providers` and overwrites `MODEL_CACHE` entries where the operator has explicitly set `contextWindow`. This ensures all 16 callsites (compaction, memory flush, session persistence, cron agents, etc.) that resolve context limits through `lookupContextTokens()` now respect config overrides.

- Adds a post-discovery loop in `src/agents/context.ts` that iterates over config provider models and overwrites cache entries with operator-specified `contextWindow` values
- Guard conditions match the existing pattern (null-check on id, type-check on contextWindow, positive value check)
- No test coverage added for the new code path

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it's a small, well-guarded fix to an existing cache-population path with no behavioral changes for models without config overrides.
- Score of 4 reflects a clean, minimal fix that correctly addresses the documented bug. The guard conditions are consistent with existing patterns, the config object is read-only (not mutated by the preceding call), and the change only affects models where operators have explicitly set contextWindow. Deducted one point because there are no unit tests for the new code path — the existing test file for context-window-guard does not cover MODEL_CACHE population.
- No files require special attention — the single changed file (`src/agents/context.ts`) is a straightforward addition.

<sub>Last reviewed commit: 0cd9d83</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->