### PR TITLE
fix: strip thinking blocks with invalid signatures for OpenAI-compat APIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "@aws-sdk/client-bedrock": "^3.990.0",
     "@buape/carbon": "0.14.0",
     "@clack/prompts": "^1.0.1",
+    "@github/copilot-sdk": "0.1.22",
     "@grammyjs/runner": "^2.0.3",
     "@grammyjs/transformer-throttler": "^1.2.1",
     "@homebridge/ciao": "^1.3.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,9 @@ importers:
       '@clack/prompts':
         specifier: ^1.0.1
         version: 1.0.1
+      '@github/copilot-sdk':
+        specifier: 0.1.22
+        version: 0.1.22
       '@grammyjs/runner':
         specifier: ^2.0.3
         version: 2.0.3(grammy@1.40.0)
@@ -1050,6 +1053,50 @@ packages:
 
   '@eshaz/web-worker@1.2.2':
     resolution: {integrity: sha512-WxXiHFmD9u/owrzempiDlBB1ZYqiLnm9s6aPc8AlFQalq2tKmqdmMr9GXOupDgzXtqnBipj8Un0gkIm7Sjf8mw==}
+
+  '@github/copilot-darwin-arm64@0.0.403':
+    resolution: {integrity: sha512-dOw8IleA0d1soHnbr/6wc6vZiYWNTKMgfTe/NET1nCfMzyKDt/0F0I7PT5y+DLujJknTla/ZeEmmBUmliTW4Cg==}
+    cpu: [arm64]
+    os: [darwin]
+    hasBin: true
+
+  '@github/copilot-darwin-x64@0.0.403':
+    resolution: {integrity: sha512-aK2jSNWgY8eiZ+TmrvGhssMCPDTKArc0ip6Ul5OaslpytKks8hyXoRbxGD0N9sKioSUSbvKUf+1AqavbDpJO+w==}
+    cpu: [x64]
+    os: [darwin]
+    hasBin: true
+
+  '@github/copilot-linux-arm64@0.0.403':
+    resolution: {integrity: sha512-KhoR2iR70O6vCkzf0h8/K+p82qAgOvMTgAPm9bVEHvbdGFR7Py9qL5v03bMbPxsA45oNaZAkzDhfTAqWhIAZsQ==}
+    cpu: [arm64]
+    os: [linux]
+    hasBin: true
+
+  '@github/copilot-linux-x64@0.0.403':
+    resolution: {integrity: sha512-eoswUc9vo4TB+/9PgFJLVtzI4dPjkpJXdCsAioVuoqPdNxHxlIHFe9HaVcqMRZxUNY1YHEBZozy+IpUEGjgdfQ==}
+    cpu: [x64]
+    os: [linux]
+    hasBin: true
+
+  '@github/copilot-sdk@0.1.22':
+    resolution: {integrity: sha512-ZGOEBmYOfu/vLXKjjoiw4lO3Cb8QBUuAWXcW/qzmPPsM9+Qe00qVr2AuDTU/Gft9Dm/yZcPK2QuTZc7LVeom9w==}
+    engines: {node: '>=18.0.0'}
+
+  '@github/copilot-win32-arm64@0.0.403':
+    resolution: {integrity: sha512-djWjzCsp2xPNafMyOZ/ivU328/WvWhdroGie/DugiJBTgQL2SP0quWW1fhTlDwE81a3g9CxfJonaRgOpFTJTcg==}
+    cpu: [arm64]
+    os: [win32]
+    hasBin: true
+
+  '@github/copilot-win32-x64@0.0.403':
+    resolution: {integrity: sha512-lju8cHy2E6Ux7R7tWyLZeksYC2MVZu9i9ocjiBX/qfG2/pNJs7S5OlkwKJ0BSXSbZEHQYq7iHfEWp201bVfk9A==}
+    cpu: [x64]
+    os: [win32]
+    hasBin: true
+
+  '@github/copilot@0.0.403':
+    resolution: {integrity: sha512-v5jUdtGJReLmE1rmff/LZf+50nzmYQYAaSRNtVNr9g0j0GkCd/noQExe31i1+PudvWU0ZJjltR0B8pUfDRdA9Q==}
+    hasBin: true
 
   '@google/genai@1.41.0':
     resolution: {integrity: sha512-S4WGil+PG0NBQRAx+0yrQuM/TWOLn2gGEy5wn4IsoOI6ouHad0P61p3OWdhJ3aqr9kfj8o904i/jevfaGoGuIQ==}
@@ -5661,6 +5708,10 @@ packages:
       jsdom:
         optional: true
 
+  vscode-jsonrpc@8.2.1:
+    resolution: {integrity: sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ==}
+    engines: {node: '>=14.0.0'}
+
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
@@ -6528,6 +6579,39 @@ snapshots:
   '@eshaz/web-worker@1.2.2':
     optional: true
 
+  '@github/copilot-darwin-arm64@0.0.403':
+    optional: true
+
+  '@github/copilot-darwin-x64@0.0.403':
+    optional: true
+
+  '@github/copilot-linux-arm64@0.0.403':
+    optional: true
+
+  '@github/copilot-linux-x64@0.0.403':
+    optional: true
+
+  '@github/copilot-sdk@0.1.22':
+    dependencies:
+      '@github/copilot': 0.0.403
+      vscode-jsonrpc: 8.2.1
+      zod: 4.3.6
+
+  '@github/copilot-win32-arm64@0.0.403':
+    optional: true
+
+  '@github/copilot-win32-x64@0.0.403':
+    optional: true
+
+  '@github/copilot@0.0.403':
+    optionalDependencies:
+      '@github/copilot-darwin-arm64': 0.0.403
+      '@github/copilot-darwin-x64': 0.0.403
+      '@github/copilot-linux-arm64': 0.0.403
+      '@github/copilot-linux-x64': 0.0.403
+      '@github/copilot-win32-arm64': 0.0.403
+      '@github/copilot-win32-x64': 0.0.403
+
   '@google/genai@1.41.0':
     dependencies:
       google-auth-library: 10.5.0
@@ -6764,7 +6848,7 @@ snapshots:
 
   '@larksuiteoapi/node-sdk@1.59.0':
     dependencies:
-      axios: 1.13.5(debug@4.4.3)
+      axios: 1.13.5
       lodash.identity: 3.0.0
       lodash.merge: 4.6.2
       lodash.pickby: 4.6.0
@@ -6780,7 +6864,7 @@ snapshots:
     dependencies:
       '@types/node': 24.10.13
     optionalDependencies:
-      axios: 1.13.5(debug@4.4.3)
+      axios: 1.13.5
     transitivePeerDependencies:
       - debug
 
@@ -6983,7 +7067,7 @@ snapshots:
       '@azure/core-auth': 1.10.1
       '@azure/msal-node': 3.8.7
       '@microsoft/agents-activity': 1.2.3
-      axios: 1.13.5(debug@4.4.3)
+      axios: 1.13.5
       jsonwebtoken: 9.0.3
       jwks-rsa: 3.2.2
       object-path: 0.11.8
@@ -7882,7 +7966,7 @@ snapshots:
       '@slack/types': 2.20.0
       '@slack/web-api': 7.14.1
       '@types/express': 5.0.6
-      axios: 1.13.5(debug@4.4.3)
+      axios: 1.13.5
       express: 5.2.1
       path-to-regexp: 8.3.0
       raw-body: 3.0.2
@@ -7928,7 +8012,7 @@ snapshots:
       '@slack/types': 2.20.0
       '@types/node': 25.2.3
       '@types/retry': 0.12.0
-      axios: 1.13.5(debug@4.4.3)
+      axios: 1.13.5
       eventemitter3: 5.0.4
       form-data: 2.5.4
       is-electron: 2.2.2
@@ -8816,6 +8900,14 @@ snapshots:
 
   aws4@1.13.2: {}
 
+  axios@1.13.5:
+    dependencies:
+      follow-redirects: 1.15.11
+      form-data: 2.5.4
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+
   axios@1.13.5(debug@4.4.3):
     dependencies:
       follow-redirects: 1.15.11(debug@4.4.3)
@@ -9394,6 +9486,8 @@ snapshots:
       array-back: 3.1.0
 
   flatbuffers@24.12.23: {}
+
+  follow-redirects@1.15.11: {}
 
   follow-redirects@1.15.11(debug@4.4.3):
     optionalDependencies:
@@ -11448,6 +11542,8 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  vscode-jsonrpc@8.2.1: {}
 
   web-streams-polyfill@3.3.3: {}
 

--- a/src/agents/auth-profiles/constants.ts
+++ b/src/agents/auth-profiles/constants.ts
@@ -6,6 +6,7 @@ export const LEGACY_AUTH_FILENAME = "auth.json";
 
 export const CLAUDE_CLI_PROFILE_ID = "anthropic:claude-cli";
 export const CODEX_CLI_PROFILE_ID = "openai-codex:codex-cli";
+export const COPILOT_CLI_PROFILE_ID = "github-copilot:copilot-cli";
 export const QWEN_CLI_PROFILE_ID = "qwen-portal:qwen-cli";
 export const MINIMAX_CLI_PROFILE_ID = "minimax-portal:minimax-cli";
 

--- a/src/agents/cli-backends.ts
+++ b/src/agents/cli-backends.ts
@@ -52,6 +52,38 @@ const DEFAULT_CLAUDE_BACKEND: CliBackendConfig = {
   serialize: true,
 };
 
+// Copilot CLI model aliases — map friendly short names to the exact model ids
+// accepted by `copilot --model`. Run `copilot --model list` for the latest.
+const COPILOT_MODEL_ALIASES: Record<string, string> = {
+  // Claude
+  opus: "claude-opus-4.6",
+  "opus-4.6": "claude-opus-4.6",
+  "opus-4.6-fast": "claude-opus-4.6-fast",
+  "opus-4.5": "claude-opus-4.5",
+  sonnet: "claude-sonnet-4.5",
+  "sonnet-4.5": "claude-sonnet-4.5",
+  "sonnet-4": "claude-sonnet-4",
+  haiku: "claude-haiku-4.5",
+  "haiku-4.5": "claude-haiku-4.5",
+  // Gemini
+  gemini: "gemini-3-pro-preview",
+  "gemini-3-pro": "gemini-3-pro-preview",
+  // GPT
+  "gpt-5": "gpt-5",
+  "gpt-5-mini": "gpt-5-mini",
+  "gpt-5.1": "gpt-5.1",
+  "gpt-5.2": "gpt-5.2",
+  codex: "gpt-5.3-codex",
+  "codex-max": "gpt-5.1-codex-max",
+};
+
+const DEFAULT_COPILOT_BACKEND: CliBackendConfig = {
+  command: "copilot",
+  output: "text",
+  input: "arg",
+  modelAliases: COPILOT_MODEL_ALIASES,
+};
+
 const DEFAULT_CODEX_BACKEND: CliBackendConfig = {
   command: "codex",
   args: ["exec", "--json", "--color", "never", "--sandbox", "read-only", "--skip-git-repo-check"],
@@ -113,6 +145,7 @@ export function resolveCliBackendIds(cfg?: OpenClawConfig): Set<string> {
   const ids = new Set<string>([
     normalizeBackendKey("claude-cli"),
     normalizeBackendKey("codex-cli"),
+    normalizeBackendKey("copilot-cli"),
   ]);
   const configured = cfg?.agents?.defaults?.cliBackends ?? {};
   for (const key of Object.keys(configured)) {
@@ -139,6 +172,17 @@ export function resolveCliBackendConfig(
   }
   if (normalized === "codex-cli") {
     const merged = mergeBackendConfig(DEFAULT_CODEX_BACKEND, override);
+    const command = merged.command?.trim();
+    if (!command) {
+      return null;
+    }
+    return { id: normalized, config: { ...merged, command } };
+  }
+  // copilot-cli uses the Copilot SDK (not a generic CLI subprocess).
+  // Return a stub config so callers recognise it as a valid backend; the actual
+  // execution path is handled in copilot-runner.ts.
+  if (normalized === "copilot-cli") {
+    const merged = mergeBackendConfig(DEFAULT_COPILOT_BACKEND, override);
     const command = merged.command?.trim();
     if (!command) {
       return null;

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -54,6 +54,9 @@ export async function runCliAgent(params: {
 }): Promise<EmbeddedPiRunResult> {
   // Copilot SDK has its own client/session lifecycle — intercept before generic CLI path.
   if (params.provider === "copilot-cli") {
+    if (params.images && params.images.length > 0) {
+      log.warn("copilot-cli does not support image input — images will be dropped");
+    }
     return runCopilotCliAgent({
       sessionId: params.sessionId,
       sessionKey: params.sessionKey,

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -25,6 +25,7 @@ import {
   resolveSystemPromptUsage,
   writeCliImages,
 } from "./cli-runner/helpers.js";
+import { runCopilotCliAgent } from "./copilot-runner.js";
 import { resolveOpenClawDocsPath } from "./docs-path.js";
 import { FailoverError, resolveFailoverStatus } from "./failover-error.js";
 import { classifyFailoverReason, isFailoverErrorMessage } from "./pi-embedded-helpers.js";
@@ -51,6 +52,26 @@ export async function runCliAgent(params: {
   cliSessionId?: string;
   images?: ImageContent[];
 }): Promise<EmbeddedPiRunResult> {
+  // Copilot SDK has its own client/session lifecycle — intercept before generic CLI path.
+  if (params.provider === "copilot-cli") {
+    return runCopilotCliAgent({
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+      agentId: params.agentId,
+      sessionFile: params.sessionFile,
+      workspaceDir: params.workspaceDir,
+      config: params.config,
+      prompt: params.prompt,
+      model: params.model,
+      thinkLevel: params.thinkLevel,
+      timeoutMs: params.timeoutMs,
+      runId: params.runId,
+      extraSystemPrompt: params.extraSystemPrompt,
+      ownerNumbers: params.ownerNumbers,
+      cliSessionId: params.cliSessionId,
+    });
+  }
+
   const started = Date.now();
   const workspaceResolution = resolveRunWorkspaceDir({
     workspaceDir: params.workspaceDir,

--- a/src/agents/copilot-runner.test.ts
+++ b/src/agents/copilot-runner.test.ts
@@ -1,0 +1,177 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock copilot-sdk.js — the runner delegates to this module
+const checkCopilotAvailableMock = vi.fn();
+const runCopilotAgentMock = vi.fn();
+
+vi.mock("./copilot-sdk.js", () => ({
+  checkCopilotAvailable: (...args: unknown[]) => checkCopilotAvailableMock(...args),
+  runCopilotAgent: (...args: unknown[]) => runCopilotAgentMock(...args),
+}));
+
+// Stub out bootstrap/docs resolution to avoid filesystem side effects
+vi.mock("./bootstrap-files.js", () => ({
+  resolveBootstrapContextForRun: vi.fn(async () => ({ contextFiles: [] })),
+  makeBootstrapWarn: vi.fn(() => () => {}),
+}));
+vi.mock("./docs-path.js", () => ({
+  resolveOpenClawDocsPath: vi.fn(async () => null),
+}));
+
+import { runCopilotCliAgent } from "./copilot-runner.js";
+import { FailoverError } from "./failover-error.js";
+
+describe("runCopilotCliAgent", () => {
+  beforeEach(() => {
+    checkCopilotAvailableMock.mockReset();
+    runCopilotAgentMock.mockReset();
+  });
+
+  it("throws FailoverError when copilot is not available", async () => {
+    checkCopilotAvailableMock.mockReturnValue({
+      available: false,
+      reason: "copilot CLI not found on PATH",
+    });
+
+    await expect(
+      runCopilotCliAgent({
+        sessionId: "s1",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: "/tmp",
+        prompt: "hello",
+        timeoutMs: 5_000,
+        runId: "run-1",
+      }),
+    ).rejects.toThrow(FailoverError);
+
+    expect(runCopilotAgentMock).not.toHaveBeenCalled();
+  });
+
+  it("runs prompt through copilot SDK and returns result", async () => {
+    checkCopilotAvailableMock.mockReturnValue({ available: true });
+    runCopilotAgentMock.mockResolvedValueOnce({
+      text: "Hello! I can help with that.",
+      sessionId: "copilot-session-abc",
+    });
+
+    const result = await runCopilotCliAgent({
+      sessionId: "s1",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      prompt: "hello",
+      model: "gpt-4o",
+      timeoutMs: 5_000,
+      runId: "run-1",
+    });
+
+    expect(result.payloads).toBeDefined();
+    expect(result.payloads?.[0]?.text).toBe("Hello! I can help with that.");
+    expect(result.meta?.agentMeta?.provider).toBe("copilot-cli");
+    expect(result.meta?.agentMeta?.model).toBe("gpt-4o");
+    expect(result.meta?.agentMeta?.sessionId).toBe("copilot-session-abc");
+    expect(result.meta?.durationMs).toBeGreaterThanOrEqual(0);
+
+    // Verify the SDK was called with the right params
+    expect(runCopilotAgentMock).toHaveBeenCalledTimes(1);
+    const sdkArgs = runCopilotAgentMock.mock.calls[0]?.[0];
+    expect(sdkArgs.prompt).toBe("hello");
+    expect(sdkArgs.model).toBe("gpt-4o");
+    expect(sdkArgs.workspaceDir).toBe("/tmp");
+    expect(sdkArgs.timeoutMs).toBe(5_000);
+  });
+
+  it("passes through cliSessionId as sessionId for resume", async () => {
+    checkCopilotAvailableMock.mockReturnValue({ available: true });
+    runCopilotAgentMock.mockResolvedValueOnce({
+      text: "Resumed session.",
+      sessionId: "copilot-session-existing",
+    });
+
+    await runCopilotCliAgent({
+      sessionId: "s1",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      prompt: "continue",
+      timeoutMs: 5_000,
+      runId: "run-2",
+      cliSessionId: "copilot-session-existing",
+    });
+
+    const sdkArgs = runCopilotAgentMock.mock.calls[0]?.[0];
+    expect(sdkArgs.sessionId).toBe("copilot-session-existing");
+  });
+
+  it("returns empty payloads when response is empty", async () => {
+    checkCopilotAvailableMock.mockReturnValue({ available: true });
+    runCopilotAgentMock.mockResolvedValueOnce({
+      text: "",
+      sessionId: "copilot-session-empty",
+    });
+
+    const result = await runCopilotCliAgent({
+      sessionId: "s1",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      prompt: "hello",
+      timeoutMs: 5_000,
+      runId: "run-3",
+    });
+
+    expect(result.payloads).toBeUndefined();
+  });
+
+  it("wraps SDK errors as FailoverError when appropriate", async () => {
+    checkCopilotAvailableMock.mockReturnValue({ available: true });
+    runCopilotAgentMock.mockRejectedValueOnce(new Error("rate limit exceeded"));
+
+    await expect(
+      runCopilotCliAgent({
+        sessionId: "s1",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: "/tmp",
+        prompt: "hello",
+        timeoutMs: 5_000,
+        runId: "run-4",
+      }),
+    ).rejects.toThrow(FailoverError);
+  });
+
+  it("passes through non-failover errors unchanged", async () => {
+    checkCopilotAvailableMock.mockReturnValue({ available: true });
+    const unexpectedError = new TypeError("unexpected type issue");
+    runCopilotAgentMock.mockRejectedValueOnce(unexpectedError);
+
+    await expect(
+      runCopilotCliAgent({
+        sessionId: "s1",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: "/tmp",
+        prompt: "hello",
+        timeoutMs: 5_000,
+        runId: "run-5",
+      }),
+    ).rejects.toThrow(unexpectedError);
+  });
+
+  it("uses default model when none specified", async () => {
+    checkCopilotAvailableMock.mockReturnValue({ available: true });
+    runCopilotAgentMock.mockResolvedValueOnce({
+      text: "ok",
+      sessionId: "sid-default",
+    });
+
+    const result = await runCopilotCliAgent({
+      sessionId: "s1",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      prompt: "hi",
+      timeoutMs: 5_000,
+      runId: "run-6",
+    });
+
+    const sdkArgs = runCopilotAgentMock.mock.calls[0]?.[0];
+    // When model is "default", SDK receives undefined so it uses its own default
+    expect(sdkArgs.model).toBeUndefined();
+    expect(result.meta?.agentMeta?.model).toBe("default");
+  });
+});

--- a/src/agents/copilot-runner.ts
+++ b/src/agents/copilot-runner.ts
@@ -5,7 +5,8 @@ import { resolveHeartbeatPrompt } from "../auto-reply/heartbeat.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveSessionAgentIds } from "./agent-scope.js";
 import { makeBootstrapWarn, resolveBootstrapContextForRun } from "./bootstrap-files.js";
-import { buildSystemPrompt } from "./cli-runner/helpers.js";
+import { resolveCliBackendConfig } from "./cli-backends.js";
+import { buildSystemPrompt, normalizeCliModel } from "./cli-runner/helpers.js";
 import { checkCopilotAvailable, runCopilotAgent } from "./copilot-sdk.js";
 import { resolveOpenClawDocsPath } from "./docs-path.js";
 import { FailoverError, resolveFailoverStatus } from "./failover-error.js";
@@ -61,7 +62,9 @@ export async function runCopilotCliAgent(params: {
     );
   }
 
-  const modelId = (params.model ?? "default").trim() || "default";
+  const rawModelId = (params.model ?? "default").trim() || "default";
+  const backendConfig = resolveCliBackendConfig("copilot-cli", params.config);
+  const modelId = backendConfig ? normalizeCliModel(rawModelId, backendConfig.config) : rawModelId;
   const modelDisplay = `copilot-cli/${modelId}`;
 
   const extraSystemPrompt = [

--- a/src/agents/copilot-runner.ts
+++ b/src/agents/copilot-runner.ts
@@ -1,0 +1,153 @@
+import type { ThinkLevel } from "../auto-reply/thinking.js";
+import type { OpenClawConfig } from "../config/config.js";
+import type { EmbeddedPiRunResult } from "./pi-embedded-runner.js";
+import { resolveHeartbeatPrompt } from "../auto-reply/heartbeat.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { resolveSessionAgentIds } from "./agent-scope.js";
+import { makeBootstrapWarn, resolveBootstrapContextForRun } from "./bootstrap-files.js";
+import { buildSystemPrompt } from "./cli-runner/helpers.js";
+import { checkCopilotAvailable, runCopilotAgent } from "./copilot-sdk.js";
+import { resolveOpenClawDocsPath } from "./docs-path.js";
+import { FailoverError, resolveFailoverStatus } from "./failover-error.js";
+import { classifyFailoverReason, isFailoverErrorMessage } from "./pi-embedded-helpers.js";
+import { redactRunIdentifier, resolveRunWorkspaceDir } from "./workspace-run.js";
+
+const log = createSubsystemLogger("agent/copilot-cli");
+
+/**
+ * Run a prompt through the Copilot SDK CLI backend.
+ * Matches the same parameter shape as `runCliAgent` so it slots into the routing.
+ */
+export async function runCopilotCliAgent(params: {
+  sessionId: string;
+  sessionKey?: string;
+  agentId?: string;
+  sessionFile: string;
+  workspaceDir: string;
+  config?: OpenClawConfig;
+  prompt: string;
+  model?: string;
+  thinkLevel?: ThinkLevel;
+  timeoutMs: number;
+  runId: string;
+  extraSystemPrompt?: string;
+  ownerNumbers?: string[];
+  cliSessionId?: string;
+}): Promise<EmbeddedPiRunResult> {
+  const started = Date.now();
+
+  // Check availability before doing anything expensive
+  const availability = checkCopilotAvailable();
+  if (!availability.available) {
+    throw new FailoverError(`copilot-cli not available: ${availability.reason}`, {
+      reason: "auth",
+      provider: "copilot-cli",
+      model: params.model ?? "default",
+      status: 401,
+    });
+  }
+
+  const workspaceResolution = resolveRunWorkspaceDir({
+    workspaceDir: params.workspaceDir,
+    sessionKey: params.sessionKey,
+    agentId: params.agentId,
+    config: params.config,
+  });
+  const resolvedWorkspace = workspaceResolution.workspaceDir;
+  if (workspaceResolution.usedFallback) {
+    const redacted = redactRunIdentifier(params.sessionId);
+    log.warn(
+      `[workspace-fallback] caller=runCopilotCliAgent reason=${workspaceResolution.fallbackReason} run=${params.runId} session=${redacted}`,
+    );
+  }
+
+  const modelId = (params.model ?? "default").trim() || "default";
+  const modelDisplay = `copilot-cli/${modelId}`;
+
+  const extraSystemPrompt = [
+    params.extraSystemPrompt?.trim(),
+    "Tools are disabled in this session. Do not call tools.",
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  const sessionLabel = params.sessionKey ?? params.sessionId;
+  const { contextFiles } = await resolveBootstrapContextForRun({
+    workspaceDir: resolvedWorkspace,
+    config: params.config,
+    sessionKey: params.sessionKey,
+    sessionId: params.sessionId,
+    warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),
+  });
+  const { defaultAgentId, sessionAgentId } = resolveSessionAgentIds({
+    sessionKey: params.sessionKey,
+    config: params.config,
+  });
+  const heartbeatPrompt =
+    sessionAgentId === defaultAgentId
+      ? resolveHeartbeatPrompt(params.config?.agents?.defaults?.heartbeat?.prompt)
+      : undefined;
+  const docsPath = await resolveOpenClawDocsPath({
+    workspaceDir: resolvedWorkspace,
+    argv1: process.argv[1],
+    cwd: process.cwd(),
+    moduleUrl: import.meta.url,
+  });
+  const systemPrompt = buildSystemPrompt({
+    workspaceDir: resolvedWorkspace,
+    config: params.config,
+    defaultThinkLevel: params.thinkLevel,
+    extraSystemPrompt,
+    ownerNumbers: params.ownerNumbers,
+    heartbeatPrompt,
+    docsPath: docsPath ?? undefined,
+    tools: [],
+    contextFiles,
+    modelDisplay,
+    agentId: sessionAgentId,
+  });
+
+  try {
+    log.info(`copilot-cli exec: model=${modelId} promptChars=${params.prompt.length}`);
+
+    const result = await runCopilotAgent({
+      prompt: params.prompt,
+      model: modelId === "default" ? undefined : modelId,
+      workspaceDir: resolvedWorkspace,
+      systemPrompt,
+      timeoutMs: params.timeoutMs,
+      sessionId: params.cliSessionId,
+    });
+
+    const text = result.text?.trim();
+    const payloads = text ? [{ text }] : undefined;
+
+    return {
+      payloads,
+      meta: {
+        durationMs: Date.now() - started,
+        agentMeta: {
+          sessionId: result.sessionId ?? params.sessionId ?? "",
+          provider: "copilot-cli",
+          model: modelId,
+        },
+      },
+    };
+  } catch (err) {
+    if (err instanceof FailoverError) {
+      throw err;
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    if (isFailoverErrorMessage(message)) {
+      const reason = classifyFailoverReason(message) ?? "unknown";
+      const status = resolveFailoverStatus(reason);
+      throw new FailoverError(message, {
+        reason,
+        provider: "copilot-cli",
+        model: modelId,
+        status,
+      });
+    }
+    throw err;
+  }
+}

--- a/src/agents/copilot-sdk.test.ts
+++ b/src/agents/copilot-sdk.test.ts
@@ -1,0 +1,243 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const execFileSyncMock = vi.fn();
+
+// Mock CopilotClient and CopilotSession for runCopilotAgent tests
+const mockSession = {
+  sendAndWait: vi.fn(),
+  destroy: vi.fn(),
+  sessionId: "mock-session-id",
+};
+const mockClient = {
+  stop: vi.fn(),
+  createSession: vi.fn().mockResolvedValue(mockSession),
+  resumeSession: vi.fn().mockResolvedValue(mockSession),
+  getAuthStatus: vi
+    .fn()
+    .mockResolvedValue({ isAuthenticated: true, authType: "user", login: "octocat" }),
+  listModels: vi.fn(),
+};
+
+vi.mock("@github/copilot-sdk", () => {
+  // Use a real class so vitest treats it as a constructor
+  return {
+    CopilotClient: class MockCopilotClient {
+      constructor() {
+        return mockClient;
+      }
+    },
+  };
+});
+
+describe("copilot-sdk", () => {
+  afterEach(() => {
+    execFileSyncMock.mockReset();
+    mockSession.sendAndWait.mockReset();
+    mockSession.destroy.mockReset().mockResolvedValue(undefined);
+    mockClient.stop.mockReset().mockResolvedValue(undefined);
+    mockClient.createSession.mockReset().mockResolvedValue(mockSession);
+    mockClient.resumeSession.mockReset().mockResolvedValue(mockSession);
+    mockClient.getAuthStatus
+      .mockReset()
+      .mockResolvedValue({ isAuthenticated: true, authType: "user", login: "octocat" });
+    mockClient.listModels.mockReset();
+  });
+
+  describe("isCopilotCliInstalled", () => {
+    it("returns true when copilot --version succeeds", async () => {
+      execFileSyncMock.mockReturnValue("0.1.22\n");
+      const { isCopilotCliInstalled } = await import("./copilot-sdk.js");
+      expect(isCopilotCliInstalled({ execFileSync: execFileSyncMock })).toBe(true);
+      expect(execFileSyncMock).toHaveBeenCalledWith("copilot", ["--version"], expect.any(Object));
+    });
+
+    it("returns false when copilot is not on PATH", async () => {
+      execFileSyncMock.mockImplementation(() => {
+        throw new Error("ENOENT");
+      });
+      const { isCopilotCliInstalled } = await import("./copilot-sdk.js");
+      expect(isCopilotCliInstalled({ execFileSync: execFileSyncMock })).toBe(false);
+    });
+  });
+
+  describe("checkCopilotAvailable", () => {
+    it("returns unavailable when CLI is not installed", async () => {
+      execFileSyncMock.mockImplementation(() => {
+        throw new Error("ENOENT");
+      });
+
+      const { checkCopilotAvailable } = await import("./copilot-sdk.js");
+      const result = checkCopilotAvailable({ execFileSync: execFileSyncMock });
+      expect(result.available).toBe(false);
+      expect(result.reason).toContain("not found");
+    });
+
+    it("returns available when CLI is installed", async () => {
+      execFileSyncMock.mockReturnValue("0.1.22\n");
+
+      const { checkCopilotAvailable } = await import("./copilot-sdk.js");
+      const result = checkCopilotAvailable({ execFileSync: execFileSyncMock });
+      expect(result.available).toBe(true);
+    });
+  });
+
+  describe("runCopilotAgent", () => {
+    it("verifies auth before creating session", async () => {
+      mockSession.sendAndWait.mockResolvedValueOnce({
+        data: { content: "Hello from copilot!" },
+      });
+
+      const { runCopilotAgent } = await import("./copilot-sdk.js");
+      await runCopilotAgent({
+        prompt: "Say hello",
+        model: "gpt-4o",
+        workspaceDir: "/tmp",
+        timeoutMs: 5_000,
+      });
+
+      expect(mockClient.getAuthStatus).toHaveBeenCalledTimes(1);
+      expect(mockClient.createSession).toHaveBeenCalledTimes(1);
+    });
+
+    it("throws when not authenticated", async () => {
+      mockClient.getAuthStatus.mockResolvedValueOnce({
+        isAuthenticated: false,
+        statusMessage: "No token",
+      });
+
+      const { runCopilotAgent } = await import("./copilot-sdk.js");
+      await expect(runCopilotAgent({ prompt: "hi", timeoutMs: 5_000 })).rejects.toThrow(
+        "copilot CLI not authenticated",
+      );
+      expect(mockClient.createSession).not.toHaveBeenCalled();
+      expect(mockClient.stop).toHaveBeenCalled();
+    });
+
+    it("creates a new session and sends the prompt", async () => {
+      mockSession.sendAndWait.mockResolvedValueOnce({
+        data: { content: "Hello from copilot!" },
+      });
+
+      const { runCopilotAgent } = await import("./copilot-sdk.js");
+      const result = await runCopilotAgent({
+        prompt: "Say hello",
+        model: "gpt-4o",
+        workspaceDir: "/tmp",
+        timeoutMs: 5_000,
+      });
+
+      expect(result.text).toBe("Hello from copilot!");
+      expect(result.sessionId).toBe("mock-session-id");
+      expect(mockClient.createSession).toHaveBeenCalledTimes(1);
+      expect(mockClient.resumeSession).not.toHaveBeenCalled();
+      expect(mockSession.sendAndWait).toHaveBeenCalledWith({ prompt: "Say hello" }, 5_000);
+      expect(mockSession.destroy).toHaveBeenCalled();
+      expect(mockClient.stop).toHaveBeenCalled();
+    });
+
+    it("resumes existing session when sessionId is provided", async () => {
+      mockSession.sendAndWait.mockResolvedValueOnce({
+        data: { content: "Resumed!" },
+      });
+
+      const { runCopilotAgent } = await import("./copilot-sdk.js");
+      await runCopilotAgent({
+        prompt: "continue",
+        sessionId: "existing-session-123",
+        timeoutMs: 5_000,
+      });
+
+      expect(mockClient.resumeSession).toHaveBeenCalledTimes(1);
+      expect(mockClient.resumeSession).toHaveBeenCalledWith(
+        "existing-session-123",
+        expect.any(Object),
+      );
+      expect(mockClient.createSession).not.toHaveBeenCalled();
+    });
+
+    it("returns empty string when response has no content", async () => {
+      mockSession.sendAndWait.mockResolvedValueOnce(undefined);
+
+      const { runCopilotAgent } = await import("./copilot-sdk.js");
+      const result = await runCopilotAgent({
+        prompt: "empty",
+        timeoutMs: 5_000,
+      });
+
+      expect(result.text).toBe("");
+    });
+
+    it("cleans up session and client even on error", async () => {
+      mockSession.sendAndWait.mockRejectedValueOnce(new Error("SDK timeout"));
+
+      const { runCopilotAgent } = await import("./copilot-sdk.js");
+      await expect(runCopilotAgent({ prompt: "boom", timeoutMs: 1_000 })).rejects.toThrow(
+        "SDK timeout",
+      );
+
+      // Cleanup should still happen
+      expect(mockSession.destroy).toHaveBeenCalled();
+      expect(mockClient.stop).toHaveBeenCalled();
+    });
+
+    it("passes system prompt as append mode", async () => {
+      mockSession.sendAndWait.mockResolvedValueOnce({
+        data: { content: "Got it." },
+      });
+
+      const { runCopilotAgent } = await import("./copilot-sdk.js");
+      await runCopilotAgent({
+        prompt: "hi",
+        systemPrompt: "You are a helpful assistant.",
+        timeoutMs: 5_000,
+      });
+
+      const sessionConfig = mockClient.createSession.mock.calls[0]?.[0];
+      expect(sessionConfig.systemMessage).toEqual({
+        mode: "append",
+        content: "You are a helpful assistant.",
+      });
+    });
+  });
+
+  describe("listCopilotModels", () => {
+    it("returns models when authenticated", async () => {
+      const mockModels = [
+        { id: "claude-sonnet-4.5", name: "Claude Sonnet 4.5" },
+        { id: "gpt-5", name: "GPT-5" },
+      ];
+      mockClient.listModels.mockResolvedValueOnce(mockModels);
+
+      const { listCopilotModels } = await import("./copilot-sdk.js");
+      const models = await listCopilotModels();
+      expect(models).toEqual(mockModels);
+      expect(mockClient.getAuthStatus).toHaveBeenCalled();
+      expect(mockClient.stop).toHaveBeenCalled();
+    });
+
+    it("returns null when not authenticated", async () => {
+      mockClient.getAuthStatus.mockResolvedValueOnce({ isAuthenticated: false });
+
+      const { listCopilotModels } = await import("./copilot-sdk.js");
+      const models = await listCopilotModels();
+      expect(models).toBeNull();
+      expect(mockClient.stop).toHaveBeenCalled();
+    });
+
+    it("returns null when listing fails", async () => {
+      mockClient.listModels.mockRejectedValueOnce(new Error("Network error"));
+
+      const { listCopilotModels } = await import("./copilot-sdk.js");
+      const models = await listCopilotModels();
+      expect(models).toBeNull();
+    });
+  });
+
+  describe("createCopilotClient", () => {
+    it("creates a client with default options", async () => {
+      const { createCopilotClient } = await import("./copilot-sdk.js");
+      const client = await createCopilotClient();
+      expect(client).toBeDefined();
+    });
+  });
+});

--- a/src/agents/copilot-sdk.ts
+++ b/src/agents/copilot-sdk.ts
@@ -1,0 +1,188 @@
+import type {
+  CopilotClient,
+  CopilotClientOptions,
+  CopilotSession,
+  ModelInfo,
+  SessionConfig,
+} from "@github/copilot-sdk";
+import { execFileSync } from "node:child_process";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+
+const log = createSubsystemLogger("agents/copilot-sdk");
+
+/**
+ * Check whether the `copilot` CLI binary is available on PATH.
+ */
+export function isCopilotCliInstalled(options?: { execFileSync?: typeof execFileSync }): boolean {
+  const exec = options?.execFileSync ?? execFileSync;
+  try {
+    exec("copilot", ["--version"], {
+      encoding: "utf8",
+      timeout: 5000,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export type CopilotAvailability = {
+  available: boolean;
+  reason?: string;
+};
+
+/**
+ * Check whether the Copilot CLI binary is installed (sync, fast).
+ * Auth is validated later via the SDK's `getAuthStatus()` during client startup.
+ */
+export function checkCopilotAvailable(options?: {
+  execFileSync?: typeof execFileSync;
+}): CopilotAvailability {
+  if (!isCopilotCliInstalled(options)) {
+    return { available: false, reason: "copilot CLI not found on PATH" };
+  }
+  return { available: true };
+}
+
+/**
+ * Lazily import and create a CopilotClient. The SDK is only loaded when actually used.
+ */
+export async function createCopilotClient(options?: CopilotClientOptions): Promise<CopilotClient> {
+  const { CopilotClient: ClientClass } = await import("@github/copilot-sdk");
+  const client = new ClientClass({
+    useStdio: true,
+    autoStart: true,
+    logLevel: "warning",
+    ...options,
+  });
+  return client;
+}
+
+/**
+ * Verify the client is authenticated. Throws if not.
+ */
+async function ensureAuthenticated(client: CopilotClient): Promise<void> {
+  const authStatus = await client.getAuthStatus();
+  if (!authStatus.isAuthenticated) {
+    throw new Error(
+      `copilot CLI not authenticated (run: copilot login). ${authStatus.statusMessage ?? ""}`.trim(),
+    );
+  }
+  log.info("copilot auth verified", {
+    authType: authStatus.authType,
+    login: authStatus.login,
+  });
+}
+
+/**
+ * List available models from the Copilot SDK.
+ * Requires an authenticated client. Returns null if listing fails.
+ */
+export async function listCopilotModels(options?: { cwd?: string }): Promise<ModelInfo[] | null> {
+  let client: CopilotClient | undefined;
+  try {
+    client = await createCopilotClient({ cwd: options?.cwd });
+    await ensureAuthenticated(client);
+    const models = await client.listModels();
+    return models;
+  } catch (error) {
+    log.warn("failed to list copilot models", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  } finally {
+    if (client) {
+      try {
+        await client.stop();
+      } catch {}
+    }
+  }
+}
+
+export type CopilotAgentRunOptions = {
+  prompt: string;
+  model?: string;
+  workspaceDir?: string;
+  systemPrompt?: string;
+  timeoutMs?: number;
+  sessionId?: string;
+};
+
+export type CopilotAgentRunResult = {
+  text: string;
+  sessionId: string;
+};
+
+/**
+ * Run a single prompt through the Copilot SDK and return the final response.
+ * Creates a client, session, sends the message, waits for idle, and cleans up.
+ */
+export async function runCopilotAgent(
+  options: CopilotAgentRunOptions,
+): Promise<CopilotAgentRunResult> {
+  const client = await createCopilotClient({
+    cwd: options.workspaceDir,
+  });
+
+  let session: CopilotSession | undefined;
+
+  try {
+    await ensureAuthenticated(client);
+
+    const sessionConfig: SessionConfig = {
+      model: options.model,
+      workingDirectory: options.workspaceDir,
+      streaming: true,
+    };
+
+    if (options.systemPrompt) {
+      sessionConfig.systemMessage = {
+        mode: "append",
+        content: options.systemPrompt,
+      };
+    }
+
+    // Auto-approve all permission requests so the agent can work autonomously.
+    sessionConfig.onPermissionRequest = async () => ({
+      kind: "approved",
+    });
+
+    if (options.sessionId) {
+      session = await client.resumeSession(options.sessionId, sessionConfig);
+    } else {
+      session = await client.createSession(sessionConfig);
+    }
+
+    const timeoutMs = options.timeoutMs ?? 120_000;
+    const response = await session.sendAndWait({ prompt: options.prompt }, timeoutMs);
+
+    const text = response?.data?.content ?? "";
+    const sessionId = session.sessionId;
+
+    log.info(`copilot agent run completed`, {
+      sessionId,
+      model: options.model,
+      responseLength: text.length,
+    });
+
+    return { text, sessionId };
+  } finally {
+    if (session) {
+      try {
+        await session.destroy();
+      } catch (err) {
+        log.warn("failed to destroy copilot session", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+    try {
+      await client.stop();
+    } catch (err) {
+      log.warn("failed to stop copilot client", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+}

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -56,6 +56,9 @@ export function isCliProvider(provider: string, cfg?: OpenClawConfig): boolean {
   if (normalized === "codex-cli") {
     return true;
   }
+  if (normalized === "copilot-cli") {
+    return true;
+  }
   const backends = cfg?.agents?.defaults?.cliBackends ?? {};
   return Object.keys(backends).some((key) => normalizeProviderId(key) === normalized);
 }

--- a/src/agents/pi-embedded-helpers.strip-completions-reasoning.test.ts
+++ b/src/agents/pi-embedded-helpers.strip-completions-reasoning.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import { stripCompletionsReasoningFieldSignatures } from "./pi-embedded-helpers.js";
+
+describe("stripCompletionsReasoningFieldSignatures", () => {
+  it("drops thinking blocks with reasoning_text field name", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "internal thought", thinkingSignature: "reasoning_text" },
+          { type: "text", text: "answer" },
+        ],
+      },
+    ];
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const result = stripCompletionsReasoningFieldSignatures(input as any);
+    expect(result).toEqual([{ role: "assistant", content: [{ type: "text", text: "answer" }] }]);
+  });
+
+  it("drops thinking blocks with reasoning_content field name", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "thinking",
+            thinking: "thought",
+            thinkingSignature: "reasoning_content",
+          },
+          { type: "text", text: "reply" },
+        ],
+      },
+    ];
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const result = stripCompletionsReasoningFieldSignatures(input as any);
+    expect(result).toEqual([{ role: "assistant", content: [{ type: "text", text: "reply" }] }]);
+  });
+
+  it("drops thinking blocks with reasoning field name", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "hmm", thinkingSignature: "reasoning" },
+          { type: "text", text: "ok" },
+        ],
+      },
+    ];
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const result = stripCompletionsReasoningFieldSignatures(input as any);
+    expect(result).toEqual([{ role: "assistant", content: [{ type: "text", text: "ok" }] }]);
+  });
+
+  it("keeps thinking blocks with real base64 signatures", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "thinking",
+            thinking: "thought",
+            thinkingSignature: "dGhpcyBpcyBhIHJlYWwgc2lnbmF0dXJl",
+          },
+          { type: "text", text: "answer" },
+        ],
+      },
+    ];
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    expect(stripCompletionsReasoningFieldSignatures(input as any)).toEqual(input);
+  });
+
+  it("keeps thinking blocks with no thinkingSignature", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "thought" },
+          { type: "text", text: "answer" },
+        ],
+      },
+    ];
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    expect(stripCompletionsReasoningFieldSignatures(input as any)).toEqual(input);
+  });
+
+  it("drops entire assistant message when only block is a bad thinking block", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [{ type: "thinking", thinking: "thought", thinkingSignature: "reasoning_text" }],
+      },
+      { role: "user", content: "next" },
+    ];
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const result = stripCompletionsReasoningFieldSignatures(input as any);
+    expect(result).toEqual([{ role: "user", content: "next" }]);
+  });
+
+  it("passes through non-assistant messages unchanged", () => {
+    const input = [
+      { role: "user", content: "hello" },
+      { role: "system", content: "you are helpful" },
+    ];
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    expect(stripCompletionsReasoningFieldSignatures(input as any)).toEqual(input);
+  });
+
+  it("handles mixed valid and invalid thinking blocks", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "bad", thinkingSignature: "reasoning_content" },
+          { type: "thinking", thinking: "good", thinkingSignature: "dGVzdA==" },
+          { type: "text", text: "answer" },
+        ],
+      },
+    ];
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const result = stripCompletionsReasoningFieldSignatures(input as any);
+    expect(result).toEqual([
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "good", thinkingSignature: "dGVzdA==" },
+          { type: "text", text: "answer" },
+        ],
+      },
+    ]);
+  });
+});

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -40,7 +40,10 @@ export {
 } from "./pi-embedded-helpers/errors.js";
 export { isGoogleModelApi, sanitizeGoogleTurnOrdering } from "./pi-embedded-helpers/google.js";
 
-export { downgradeOpenAIReasoningBlocks } from "./pi-embedded-helpers/openai.js";
+export {
+  downgradeOpenAIReasoningBlocks,
+  stripCompletionsReasoningFieldSignatures,
+} from "./pi-embedded-helpers/openai.js";
 export {
   isEmptyAssistantMessageContent,
   sanitizeSessionMessagesImages,

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -289,11 +289,30 @@ export async function compactEmbeddedPiSessionDirect(
         );
       }
     } else if (model.provider === "github-copilot") {
-      const { resolveCopilotApiToken } = await import("../../providers/github-copilot-token.js");
-      const copilotToken = await resolveCopilotApiToken({
-        githubToken: apiKeyInfo.apiKey,
-      });
-      authStorage.setRuntimeApiKey(model.provider, copilotToken.token);
+      const { resolveCopilotApiToken, SDK_MANAGED_TOKEN } =
+        await import("../../providers/github-copilot-token.js");
+      if (apiKeyInfo.apiKey === SDK_MANAGED_TOKEN) {
+        // SDK-managed auth: the Copilot SDK handles token lifecycle.
+        // We still need a Copilot API token for pi-ai, so exchange via
+        // the internal endpoint using the GH token from env if available.
+        const envToken = (
+          process.env.COPILOT_GITHUB_TOKEN ??
+          process.env.GH_TOKEN ??
+          process.env.GITHUB_TOKEN ??
+          ""
+        ).trim();
+        if (envToken) {
+          const copilotToken = await resolveCopilotApiToken({ githubToken: envToken });
+          authStorage.setRuntimeApiKey(model.provider, copilotToken.token);
+        }
+        // If no env token, the SDK handles auth internally — pi-ai will
+        // receive auth via Copilot-specific headers set by the SDK.
+      } else {
+        const copilotToken = await resolveCopilotApiToken({
+          githubToken: apiKeyInfo.apiKey,
+        });
+        authStorage.setRuntimeApiKey(model.provider, copilotToken.token);
+      }
     } else {
       authStorage.setRuntimeApiKey(model.provider, apiKeyInfo.apiKey);
     }

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -304,9 +304,11 @@ export async function compactEmbeddedPiSessionDirect(
         if (envToken) {
           const copilotToken = await resolveCopilotApiToken({ githubToken: envToken });
           authStorage.setRuntimeApiKey(model.provider, copilotToken.token);
+        } else {
+          log.warn(
+            "SDK-managed Copilot auth has no env token (COPILOT_GITHUB_TOKEN, GH_TOKEN, or GITHUB_TOKEN) — REST API calls may fail",
+          );
         }
-        // If no env token, the SDK handles auth internally — pi-ai will
-        // receive auth via Copilot-specific headers set by the SDK.
       } else {
         const copilotToken = await resolveCopilotApiToken({
           githubToken: apiKeyInfo.apiKey,

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -14,6 +14,7 @@ import {
   isGoogleModelApi,
   sanitizeGoogleTurnOrdering,
   sanitizeSessionMessagesImages,
+  stripCompletionsReasoningFieldSignatures,
 } from "../pi-embedded-helpers.js";
 import { cleanToolSchemaForGemini } from "../pi-tools.schema.js";
 import {
@@ -439,7 +440,10 @@ export async function sanitizeSessionHistory(params: {
   const sanitizedThinking = policy.normalizeAntigravityThinkingBlocks
     ? sanitizeAntigravityThinkingBlocks(sanitizedImages)
     : sanitizedImages;
-  const sanitizedToolCalls = sanitizeToolCallInputs(sanitizedThinking);
+  const sanitizedCompletions = policy.stripCompletionsReasoningFieldSignatures
+    ? stripCompletionsReasoningFieldSignatures(sanitizedThinking)
+    : sanitizedThinking;
+  const sanitizedToolCalls = sanitizeToolCallInputs(sanitizedCompletions);
   const repairedTools = policy.repairToolUseResultPairing
     ? sanitizeToolUseResultPairing(sanitizedToolCalls)
     : sanitizedToolCalls;

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -352,6 +352,10 @@ export async function runEmbeddedPiAgent(
             if (envToken) {
               const copilotToken = await resolveCopilotApiToken({ githubToken: envToken });
               authStorage.setRuntimeApiKey(model.provider, copilotToken.token);
+            } else {
+              log.warn(
+                "SDK-managed Copilot auth has no env token (COPILOT_GITHUB_TOKEN, GH_TOKEN, or GITHUB_TOKEN) — REST API calls may fail",
+              );
             }
           } else {
             const copilotToken = await resolveCopilotApiToken({

--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -39,4 +39,31 @@ describe("resolveTranscriptPolicy", () => {
     expect(policy.sanitizeToolCallIds).toBe(true);
     expect(policy.toolCallIdMode).toBe("strict");
   });
+
+  it("enables stripCompletionsReasoningFieldSignatures for Copilot openai-completions", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "github-copilot",
+      modelId: "claude-opus-4.6-fast",
+      modelApi: "openai-completions",
+    });
+    expect(policy.stripCompletionsReasoningFieldSignatures).toBe(true);
+  });
+
+  it("disables stripCompletionsReasoningFieldSignatures for native OpenAI provider", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "openai",
+      modelId: "gpt-4o",
+      modelApi: "openai-completions",
+    });
+    expect(policy.stripCompletionsReasoningFieldSignatures).toBe(false);
+  });
+
+  it("disables stripCompletionsReasoningFieldSignatures for Anthropic provider", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "anthropic",
+      modelId: "claude-opus-4-5",
+      modelApi: "anthropic-messages",
+    });
+    expect(policy.stripCompletionsReasoningFieldSignatures).toBe(false);
+  });
 });

--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -49,6 +49,15 @@ describe("resolveTranscriptPolicy", () => {
     expect(policy.stripCompletionsReasoningFieldSignatures).toBe(true);
   });
 
+  it("enables stripCompletionsReasoningFieldSignatures for Copilot openai-responses", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "github-copilot",
+      modelId: "claude-opus-4.6-fast",
+      modelApi: "openai-responses",
+    });
+    expect(policy.stripCompletionsReasoningFieldSignatures).toBe(true);
+  });
+
   it("disables stripCompletionsReasoningFieldSignatures for native OpenAI provider", () => {
     const policy = resolveTranscriptPolicy({
       provider: "openai",

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -15,6 +15,7 @@ export type TranscriptPolicy = {
     includeCamelCase?: boolean;
   };
   normalizeAntigravityThinkingBlocks: boolean;
+  stripCompletionsReasoningFieldSignatures: boolean;
   applyGoogleTurnOrdering: boolean;
   validateGeminiTurns: boolean;
   validateAnthropicTurns: boolean;
@@ -107,6 +108,12 @@ export function resolveTranscriptPolicy(params: {
     : undefined;
   const normalizeAntigravityThinkingBlocks = isAntigravityClaudeModel;
 
+  // openai-completions providers that proxy to Anthropic (e.g. GitHub Copilot → Claude)
+  // can receive thinking blocks where pi-ai stored the reasoning field name as
+  // the thinkingSignature. Strip those to prevent 400s on Anthropic.
+  const stripCompletionsFieldSignatures =
+    params.modelApi === "openai-completions" && !isOpenAi && !isGoogle && !isAnthropic;
+
   return {
     sanitizeMode: isOpenAi ? "images-only" : needsNonImageSanitize ? "full" : "images-only",
     sanitizeToolCallIds,
@@ -115,6 +122,7 @@ export function resolveTranscriptPolicy(params: {
     preserveSignatures: isAntigravityClaudeModel,
     sanitizeThoughtSignatures: isOpenAi ? undefined : sanitizeThoughtSignatures,
     normalizeAntigravityThinkingBlocks,
+    stripCompletionsReasoningFieldSignatures: stripCompletionsFieldSignatures,
     applyGoogleTurnOrdering: !isOpenAi && isGoogle,
     validateGeminiTurns: !isOpenAi && isGoogle,
     validateAnthropicTurns: !isOpenAi && isAnthropic,

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -108,11 +108,11 @@ export function resolveTranscriptPolicy(params: {
     : undefined;
   const normalizeAntigravityThinkingBlocks = isAntigravityClaudeModel;
 
-  // openai-completions providers that proxy to Anthropic (e.g. GitHub Copilot → Claude)
-  // can receive thinking blocks where pi-ai stored the reasoning field name as
-  // the thinkingSignature. Strip those to prevent 400s on Anthropic.
+  // Providers using OpenAI-compatible APIs that proxy to Anthropic (e.g. GitHub
+  // Copilot → Claude) can receive thinking blocks where pi-ai stored the
+  // reasoning field name as the thinkingSignature. Strip those to prevent 400s.
   const stripCompletionsFieldSignatures =
-    params.modelApi === "openai-completions" && !isOpenAi && !isGoogle && !isAnthropic;
+    isOpenAiApi(params.modelApi) && !isOpenAi && !isGoogle && !isAnthropic;
 
   return {
     sanitizeMode: isOpenAi ? "images-only" : needsNonImageSanitize ? "full" : "images-only",

--- a/src/providers/github-copilot-models.test.ts
+++ b/src/providers/github-copilot-models.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  getDefaultCopilotModelIds,
+  buildCopilotModelDefinition,
+  discoverCopilotModels,
+} from "./github-copilot-models.js";
+
+// Mock the SDK discovery so we can test both paths
+vi.mock("./github-copilot-sdk.js", () => ({
+  discoverCopilotModelsViaSdk: vi.fn().mockResolvedValue(null),
+}));
+
+describe("github-copilot-models", () => {
+  describe("getDefaultCopilotModelIds", () => {
+    it("returns a non-empty list of model ids", () => {
+      const ids = getDefaultCopilotModelIds();
+      expect(ids.length).toBeGreaterThan(0);
+    });
+
+    it("includes key models", () => {
+      const ids = getDefaultCopilotModelIds();
+      expect(ids).toContain("gpt-4o");
+      expect(ids).toContain("claude-sonnet-4");
+      expect(ids).toContain("claude-opus-4.6-fast");
+      expect(ids).toContain("o3-mini");
+      expect(ids).toContain("gemini-3-pro-preview");
+    });
+
+    it("returns a fresh copy each time", () => {
+      const a = getDefaultCopilotModelIds();
+      const b = getDefaultCopilotModelIds();
+      expect(a).not.toBe(b);
+      expect(a).toEqual(b);
+    });
+  });
+
+  describe("buildCopilotModelDefinition", () => {
+    it("builds a valid model definition", () => {
+      const def = buildCopilotModelDefinition("gpt-4o");
+      expect(def.id).toBe("gpt-4o");
+      expect(def.api).toBe("openai-responses");
+      expect(def.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+      expect(def.contextWindow).toBe(128_000);
+    });
+
+    it("throws on empty model id", () => {
+      expect(() => buildCopilotModelDefinition("")).toThrow("Model id required");
+      expect(() => buildCopilotModelDefinition("  ")).toThrow("Model id required");
+    });
+
+    it("marks reasoning models correctly", () => {
+      expect(buildCopilotModelDefinition("o1").reasoning).toBe(true);
+      expect(buildCopilotModelDefinition("o3-mini").reasoning).toBe(true);
+      expect(buildCopilotModelDefinition("claude-opus-4.5").reasoning).toBe(true);
+      expect(buildCopilotModelDefinition("claude-opus-4.6-fast").reasoning).toBe(true);
+      expect(buildCopilotModelDefinition("gpt-4o").reasoning).toBe(false);
+      expect(buildCopilotModelDefinition("gpt-4.1-nano").reasoning).toBe(false);
+    });
+
+    it("marks vision models correctly", () => {
+      expect(buildCopilotModelDefinition("gpt-4o").input).toEqual(["text", "image"]);
+      expect(buildCopilotModelDefinition("claude-sonnet-4.5").input).toEqual(["text", "image"]);
+      expect(buildCopilotModelDefinition("gemini-3-pro-preview").input).toEqual(["text", "image"]);
+      expect(buildCopilotModelDefinition("o3-mini").input).toEqual(["text"]);
+    });
+
+    it("handles unknown models gracefully", () => {
+      const def = buildCopilotModelDefinition("future-model-xyz");
+      expect(def.reasoning).toBe(false);
+      expect(def.input).toEqual(["text"]);
+    });
+  });
+
+  describe("discoverCopilotModels", () => {
+    it("falls back to hardcoded defaults when SDK returns null", async () => {
+      const { discoverCopilotModelsViaSdk } = await import("./github-copilot-sdk.js");
+      vi.mocked(discoverCopilotModelsViaSdk).mockResolvedValue(null);
+
+      const models = await discoverCopilotModels();
+      expect(models.length).toBeGreaterThan(0);
+      // Should match hardcoded defaults
+      const ids = models.map((m) => m.id);
+      expect(ids).toContain("gpt-4o");
+      expect(ids).toContain("claude-sonnet-4");
+    });
+
+    it("uses SDK models when available", async () => {
+      const { discoverCopilotModelsViaSdk } = await import("./github-copilot-sdk.js");
+      vi.mocked(discoverCopilotModelsViaSdk).mockResolvedValue([
+        {
+          id: "sdk-model-1",
+          name: "SDK Model 1",
+          api: "openai-responses",
+          reasoning: false,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 64000,
+          maxTokens: 4096,
+        },
+      ]);
+
+      const models = await discoverCopilotModels();
+      expect(models.length).toBe(1);
+      expect(models[0]).toBeDefined();
+      expect(models[0]?.id).toBe("sdk-model-1");
+    });
+
+    it("falls back when SDK returns empty array", async () => {
+      const { discoverCopilotModelsViaSdk } = await import("./github-copilot-sdk.js");
+      vi.mocked(discoverCopilotModelsViaSdk).mockResolvedValue([]);
+
+      const models = await discoverCopilotModels();
+      // Should fall back to defaults since SDK returned empty
+      const defaults = getDefaultCopilotModelIds();
+      expect(models.length).toBe(defaults.length);
+    });
+  });
+});

--- a/src/providers/github-copilot-models.ts
+++ b/src/providers/github-copilot-models.ts
@@ -4,16 +4,26 @@ const DEFAULT_CONTEXT_WINDOW = 128_000;
 const DEFAULT_MAX_TOKENS = 8192;
 
 // Copilot model ids vary by plan/org and can change.
-// We keep this list intentionally broad; if a model isn't available Copilot will
-// return an error and users can remove it from their config.
+// This list matches the models reported by `copilot --model` as of 2026-02-15.
+// If a model isn't available Copilot will return an error.
 const DEFAULT_MODEL_IDS = [
-  "gpt-4o",
+  "claude-sonnet-4.5",
+  "claude-haiku-4.5",
+  "claude-opus-4.6",
+  "claude-opus-4.6-fast",
+  "claude-opus-4.5",
+  "claude-sonnet-4",
+  "gemini-3-pro-preview",
+  "gpt-5.3-codex",
+  "gpt-5.2-codex",
+  "gpt-5.2",
+  "gpt-5.1-codex-max",
+  "gpt-5.1-codex",
+  "gpt-5.1",
+  "gpt-5",
+  "gpt-5.1-codex-mini",
+  "gpt-5-mini",
   "gpt-4.1",
-  "gpt-4.1-mini",
-  "gpt-4.1-nano",
-  "o1",
-  "o1-mini",
-  "o3-mini",
 ] as const;
 
 export function getDefaultCopilotModelIds(): string[] {

--- a/src/providers/github-copilot-sdk.test.ts
+++ b/src/providers/github-copilot-sdk.test.ts
@@ -1,0 +1,298 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mock @github/copilot-sdk before importing the module under test
+// ---------------------------------------------------------------------------
+
+const mockClient = {
+  start: vi.fn().mockResolvedValue(undefined),
+  stop: vi.fn().mockResolvedValue([]),
+  ping: vi.fn().mockResolvedValue({ message: "pong", timestamp: Date.now() }),
+  getAuthStatus: vi.fn().mockResolvedValue({
+    isAuthenticated: true,
+    authType: "gh-cli",
+    host: "github.com",
+    login: "testuser",
+    statusMessage: "Authenticated",
+  }),
+  listModels: vi.fn().mockResolvedValue([
+    {
+      id: "gpt-4o",
+      name: "GPT-4o",
+      capabilities: {
+        supports: { vision: true, reasoningEffort: false },
+        limits: { max_context_window_tokens: 128000, max_prompt_tokens: 8192 },
+      },
+      policy: { state: "enabled", terms: "" },
+      billing: { multiplier: 1 },
+    },
+    {
+      id: "claude-sonnet-4",
+      name: "Claude Sonnet 4",
+      capabilities: {
+        supports: { vision: true, reasoningEffort: false },
+        limits: { max_context_window_tokens: 200000, max_prompt_tokens: 8192 },
+      },
+      policy: { state: "enabled", terms: "" },
+    },
+    {
+      id: "o3-mini",
+      name: "O3 Mini",
+      capabilities: {
+        supports: { vision: false, reasoningEffort: true },
+        limits: { max_context_window_tokens: 128000, max_prompt_tokens: 4096 },
+      },
+      policy: { state: "enabled", terms: "" },
+    },
+    {
+      id: "disabled-model",
+      name: "Disabled Model",
+      capabilities: {
+        supports: { vision: false, reasoningEffort: false },
+        limits: { max_context_window_tokens: 32000 },
+      },
+      policy: { state: "disabled", terms: "" },
+    },
+  ]),
+};
+
+class MockCopilotClient {
+  constructor() {
+    return mockClient;
+  }
+}
+
+vi.mock("@github/copilot-sdk", () => ({
+  CopilotClient: MockCopilotClient,
+}));
+
+// ---------------------------------------------------------------------------
+// Import module under test — must be AFTER vi.mock()
+// ---------------------------------------------------------------------------
+
+import {
+  ensureCopilotSdkClient,
+  stopCopilotSdkClient,
+  getCopilotSdkAuthStatus,
+  isCopilotSdkAvailable,
+  discoverCopilotModelsViaSdk,
+  buildCopilotModelDefinitionFromSdk,
+  _resetForTesting,
+} from "./github-copilot-sdk.js";
+
+describe("github-copilot-sdk (provider layer)", () => {
+  beforeEach(() => {
+    _resetForTesting();
+    vi.clearAllMocks();
+    // Re-configure happy-path defaults
+    mockClient.start.mockResolvedValue(undefined);
+    mockClient.stop.mockResolvedValue([]);
+    mockClient.ping.mockResolvedValue({ message: "pong", timestamp: Date.now() });
+    mockClient.getAuthStatus.mockResolvedValue({
+      isAuthenticated: true,
+      authType: "gh-cli",
+      host: "github.com",
+      login: "testuser",
+      statusMessage: "Authenticated",
+    });
+  });
+
+  afterEach(async () => {
+    await stopCopilotSdkClient();
+    _resetForTesting();
+  });
+
+  // -----------------------------------------------------------------------
+  // Client lifecycle
+  // -----------------------------------------------------------------------
+
+  describe("ensureCopilotSdkClient", () => {
+    it("creates and starts a client on first call", async () => {
+      const client = await ensureCopilotSdkClient();
+      expect(client).toBeTruthy();
+      expect(mockClient.start).toHaveBeenCalledTimes(1);
+    });
+
+    it("reuses the same client on subsequent calls", async () => {
+      const first = await ensureCopilotSdkClient();
+      const second = await ensureCopilotSdkClient();
+      expect(first).toBe(second);
+      expect(mockClient.start).toHaveBeenCalledTimes(1);
+    });
+
+    it("deduplicates concurrent start calls", async () => {
+      const [a, b, c] = await Promise.all([
+        ensureCopilotSdkClient(),
+        ensureCopilotSdkClient(),
+        ensureCopilotSdkClient(),
+      ]);
+      expect(a).toBe(b);
+      expect(b).toBe(c);
+      expect(mockClient.start).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("stopCopilotSdkClient", () => {
+    it("stops the shared client", async () => {
+      await ensureCopilotSdkClient();
+      await stopCopilotSdkClient();
+      expect(mockClient.stop).toHaveBeenCalledTimes(1);
+    });
+
+    it("is a no-op when no client exists", async () => {
+      await stopCopilotSdkClient();
+      expect(mockClient.stop).not.toHaveBeenCalled();
+    });
+
+    it("allows creating a new client after stop", async () => {
+      await ensureCopilotSdkClient();
+      await stopCopilotSdkClient();
+      mockClient.start.mockClear();
+      await ensureCopilotSdkClient();
+      expect(mockClient.start).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Auth status
+  // -----------------------------------------------------------------------
+
+  describe("getCopilotSdkAuthStatus", () => {
+    it("returns authenticated status from SDK", async () => {
+      const status = await getCopilotSdkAuthStatus();
+      expect(status).toEqual({
+        authenticated: true,
+        login: "testuser",
+        host: "github.com",
+        authType: "gh-cli",
+        message: "Authenticated",
+      });
+    });
+
+    it("returns unauthenticated when SDK says not authenticated", async () => {
+      mockClient.getAuthStatus.mockResolvedValue({
+        isAuthenticated: false,
+        statusMessage: "Not signed in",
+      });
+      const status = await getCopilotSdkAuthStatus();
+      expect(status.authenticated).toBe(false);
+      expect(status.message).toBe("Not signed in");
+    });
+
+    it("returns unauthenticated when SDK throws", async () => {
+      mockClient.getAuthStatus.mockRejectedValue(new Error("spawn failed"));
+      const status = await getCopilotSdkAuthStatus();
+      expect(status.authenticated).toBe(false);
+      expect(status.message).toContain("SDK auth check failed");
+    });
+  });
+
+  describe("isCopilotSdkAvailable", () => {
+    it("returns true when client can be pinged", async () => {
+      expect(await isCopilotSdkAvailable()).toBe(true);
+    });
+
+    it("returns false when start fails", async () => {
+      mockClient.start.mockRejectedValue(new Error("not installed"));
+      expect(await isCopilotSdkAvailable()).toBe(false);
+    });
+
+    it("returns false when ping fails", async () => {
+      mockClient.ping.mockRejectedValue(new Error("timeout"));
+      expect(await isCopilotSdkAvailable()).toBe(false);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Model discovery
+  // -----------------------------------------------------------------------
+
+  describe("buildCopilotModelDefinitionFromSdk", () => {
+    it("converts vision model correctly", () => {
+      const def = buildCopilotModelDefinitionFromSdk({
+        id: "gpt-4o",
+        name: "GPT-4o",
+        capabilities: {
+          supports: { vision: true, reasoningEffort: false },
+          limits: { max_context_window_tokens: 128000, max_prompt_tokens: 8192 },
+        },
+      });
+
+      expect(def.id).toBe("gpt-4o");
+      expect(def.name).toBe("GPT-4o");
+      expect(def.api).toBe("openai-responses");
+      expect(def.reasoning).toBe(false);
+      expect(def.input).toEqual(["text", "image"]);
+      expect(def.contextWindow).toBe(128000);
+      expect(def.maxTokens).toBe(8192);
+      expect(def.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+    });
+
+    it("converts reasoning model correctly", () => {
+      const def = buildCopilotModelDefinitionFromSdk({
+        id: "o3-mini",
+        name: "O3 Mini",
+        capabilities: {
+          supports: { vision: false, reasoningEffort: true },
+          limits: { max_context_window_tokens: 128000, max_prompt_tokens: 4096 },
+        },
+      });
+
+      expect(def.reasoning).toBe(true);
+      expect(def.input).toEqual(["text"]);
+      expect(def.maxTokens).toBe(4096);
+    });
+
+    it("uses model id as name when name is empty", () => {
+      const def = buildCopilotModelDefinitionFromSdk({
+        id: "some-model",
+        name: "",
+        capabilities: {
+          supports: { vision: false, reasoningEffort: false },
+          limits: { max_context_window_tokens: 64000 },
+        },
+      });
+      expect(def.name).toBe("some-model");
+    });
+
+    it("uses defaults when limits are missing", () => {
+      const def = buildCopilotModelDefinitionFromSdk({
+        id: "minimal",
+        name: "Minimal",
+        capabilities: {
+          supports: { vision: false, reasoningEffort: false },
+          limits: { max_context_window_tokens: 32000 },
+        },
+      });
+      expect(def.contextWindow).toBe(32000);
+      expect(def.maxTokens).toBe(8192); // default
+    });
+  });
+
+  describe("discoverCopilotModelsViaSdk", () => {
+    it("returns SDK models, filtering out disabled ones", async () => {
+      const models = await discoverCopilotModelsViaSdk();
+      expect(models).not.toBeNull();
+      expect(models!.length).toBe(3); // gpt-4o, claude-sonnet-4, o3-mini (disabled excluded)
+      expect(models!.map((m) => m.id)).toEqual(["gpt-4o", "claude-sonnet-4", "o3-mini"]);
+    });
+
+    it("returns null when SDK returns empty list", async () => {
+      mockClient.listModels.mockResolvedValue([]);
+      const models = await discoverCopilotModelsViaSdk();
+      expect(models).toBeNull();
+    });
+
+    it("returns null when SDK throws", async () => {
+      mockClient.listModels.mockRejectedValue(new Error("auth failed"));
+      const models = await discoverCopilotModelsViaSdk();
+      expect(models).toBeNull();
+    });
+
+    it("returns null when SDK returns null", async () => {
+      mockClient.listModels.mockResolvedValue(null);
+      const models = await discoverCopilotModelsViaSdk();
+      expect(models).toBeNull();
+    });
+  });
+});

--- a/src/providers/github-copilot-sdk.ts
+++ b/src/providers/github-copilot-sdk.ts
@@ -47,12 +47,17 @@ export async function ensureCopilotSdkClient(): Promise<SdkClient> {
   }
 
   clientStartPromise = (async () => {
-    const { CopilotClient } = await loadSdk();
-    const client = new CopilotClient();
-    await client.start();
-    sharedClient = client;
-    clientStartPromise = undefined;
-    return client;
+    try {
+      const { CopilotClient } = await loadSdk();
+      const client = new CopilotClient();
+      await client.start();
+      sharedClient = client;
+      clientStartPromise = undefined;
+      return client;
+    } catch (err) {
+      clientStartPromise = undefined;
+      throw err;
+    }
   })();
 
   return clientStartPromise;

--- a/src/providers/github-copilot-sdk.ts
+++ b/src/providers/github-copilot-sdk.ts
@@ -1,0 +1,181 @@
+/**
+ * SDK-based wrapper for GitHub Copilot auth status and model discovery.
+ *
+ * Uses `@github/copilot-sdk` (CopilotClient) to check authentication
+ * and list available models. The SDK manages the Copilot CLI process
+ * lifecycle internally — callers don't need to handle tokens or endpoints.
+ *
+ * This module differs from `../agents/copilot-sdk.ts` (the CLI backend):
+ *  - CLI backend: runs interactive agent sessions via JSON-RPC stdio
+ *  - This module: auth verification + model catalogue for the REST provider pipeline
+ */
+import type { ModelDefinitionConfig } from "../config/types.js";
+
+// ---------------------------------------------------------------------------
+// Lazy SDK import — @github/copilot-sdk is ESM-only + optional dependency
+// ---------------------------------------------------------------------------
+
+type CopilotSdkModule = typeof import("@github/copilot-sdk");
+
+let sdkModulePromise: Promise<CopilotSdkModule> | undefined;
+
+function loadSdk(): Promise<CopilotSdkModule> {
+  sdkModulePromise ??= import("@github/copilot-sdk");
+  return sdkModulePromise;
+}
+
+// ---------------------------------------------------------------------------
+// Client lifecycle — lazy, not a module-level singleton
+// ---------------------------------------------------------------------------
+
+type SdkClient = InstanceType<CopilotSdkModule["CopilotClient"]>;
+
+let sharedClient: SdkClient | undefined;
+let clientStartPromise: Promise<SdkClient> | undefined;
+
+/**
+ * Get (or create) a shared CopilotClient. The client is started on first call
+ * and reused for subsequent calls. Call {@link stopCopilotSdkClient} to shut it
+ * down when you're done.
+ */
+export async function ensureCopilotSdkClient(): Promise<SdkClient> {
+  if (sharedClient) {
+    return sharedClient;
+  }
+  if (clientStartPromise) {
+    return clientStartPromise;
+  }
+
+  clientStartPromise = (async () => {
+    const { CopilotClient } = await loadSdk();
+    const client = new CopilotClient();
+    await client.start();
+    sharedClient = client;
+    clientStartPromise = undefined;
+    return client;
+  })();
+
+  return clientStartPromise;
+}
+
+/**
+ * Shut down the shared CopilotClient if one is running.
+ */
+export async function stopCopilotSdkClient(): Promise<void> {
+  const client = sharedClient;
+  sharedClient = undefined;
+  clientStartPromise = undefined;
+  if (client) {
+    await client.stop();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Auth status
+// ---------------------------------------------------------------------------
+
+export type CopilotAuthStatus = {
+  authenticated: boolean;
+  login?: string;
+  host?: string;
+  authType?: string;
+  message?: string;
+};
+
+/**
+ * Check whether the current user is authenticated with GitHub Copilot
+ * via the SDK / CLI.
+ *
+ * Returns a simplified status object. Does NOT throw on auth failure —
+ * callers should inspect `.authenticated`.
+ */
+export async function getCopilotSdkAuthStatus(): Promise<CopilotAuthStatus> {
+  try {
+    const client = await ensureCopilotSdkClient();
+    const status = await client.getAuthStatus();
+    return {
+      authenticated: status.isAuthenticated,
+      login: status.login,
+      host: status.host,
+      authType: status.authType,
+      message: status.statusMessage,
+    };
+  } catch (err) {
+    return {
+      authenticated: false,
+      message: `SDK auth check failed: ${String(err)}`,
+    };
+  }
+}
+
+/**
+ * Check if the SDK is available (copilot CLI is installed and can be spawned).
+ * This is a lightweight check — it attempts to start the client and ping it.
+ */
+export async function isCopilotSdkAvailable(): Promise<boolean> {
+  try {
+    const client = await ensureCopilotSdkClient();
+    await client.ping();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Model discovery
+// ---------------------------------------------------------------------------
+
+type SdkModelInfo = Awaited<ReturnType<SdkClient["listModels"]>>[number];
+
+/**
+ * Convert an SDK `ModelInfo` into OpenClaw's `ModelDefinitionConfig`.
+ */
+export function buildCopilotModelDefinitionFromSdk(model: SdkModelInfo): ModelDefinitionConfig {
+  const supportsVision = model.capabilities?.supports?.vision ?? false;
+  const supportsReasoning = model.capabilities?.supports?.reasoningEffort ?? false;
+
+  return {
+    id: model.id,
+    name: model.name || model.id,
+    api: "openai-responses",
+    reasoning: supportsReasoning,
+    input: supportsVision ? ["text", "image"] : ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: model.capabilities?.limits?.max_context_window_tokens ?? 128_000,
+    maxTokens: model.capabilities?.limits?.max_prompt_tokens ?? 8192,
+  };
+}
+
+/**
+ * Discover available Copilot models via the SDK.
+ *
+ * Returns an array of `ModelDefinitionConfig` built from the SDK's model
+ * catalogue. Returns `null` if the SDK is unavailable or the user isn't
+ * authenticated (callers should fall back to hardcoded defaults).
+ */
+export async function discoverCopilotModelsViaSdk(): Promise<ModelDefinitionConfig[] | null> {
+  try {
+    const client = await ensureCopilotSdkClient();
+    const models = await client.listModels();
+    if (!models || models.length === 0) {
+      return null;
+    }
+    return models
+      .filter((m) => m.policy?.state !== "disabled")
+      .map(buildCopilotModelDefinitionFromSdk);
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers — allow resetting module state in tests
+// ---------------------------------------------------------------------------
+
+/** @internal — reset module state for tests */
+export function _resetForTesting(): void {
+  sharedClient = undefined;
+  clientStartPromise = undefined;
+  sdkModulePromise = undefined;
+}

--- a/src/providers/github-copilot-token.ts
+++ b/src/providers/github-copilot-token.ts
@@ -2,6 +2,14 @@ import path from "node:path";
 import { resolveStateDir } from "../config/paths.js";
 import { loadJsonFile, saveJsonFile } from "../infra/json-file.js";
 
+/**
+ * Marker token stored in auth profiles when the Copilot SDK manages
+ * authentication (e.g. via `gh` CLI or environment variables). The
+ * embedded runner detects this and delegates token resolution to the SDK
+ * instead of exchanging a raw GitHub token.
+ */
+export const SDK_MANAGED_TOKEN = "sdk-managed";
+
 const COPILOT_TOKEN_URL = "https://api.github.com/copilot_internal/v2/token";
 
 export type CachedCopilotToken = {


### PR DESCRIPTION
## Summary

- **Problem:** When using GitHub Copilot with Claude models via the OpenAI-compatible API path, thinking blocks get persisted with field-name strings (e.g. `"reasoning_text"`) as their `thinkingSignature` instead of real cryptographic signatures. When these are replayed on subsequent requests, Copilot returns HTTP 400: `Invalid signature in thinking block`.
- **Why it matters:** This bricks multi-turn sessions with tool calls — the first turn works, but follow-up requests fail because the replayed thinking blocks have invalid signatures.
- **What changed:** Added `stripCompletionsReasoningFieldSignatures` which detects and removes thinking blocks with field-name-as-signature patterns. Applied as a transcript policy for all OpenAI-compat APIs (except native OpenAI, Google, and Anthropic providers which handle signatures correctly).
- **What did NOT change:** Providers that legitimately use thinking signatures (Anthropic, Bedrock Extended Thinking) are unaffected. The proper long-term fix is using `anthropic-messages` API for Claude models (see follow-up PR).

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Integrations

## Linked Issue/PR

- Related #12006 (jackheuberger's complementary approach)
- Depends on #17284 and #17427

## User-visible / Behavior Changes

- Sessions with Copilot Claude models no longer brick after tool calls due to invalid thinking signatures
- Thinking blocks with field-name signatures are silently stripped from outgoing requests (they contain no useful content anyway — just the field name string)

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Node 22+
- Model/provider: github-copilot with Claude models

### Steps

1. Use Copilot with a Claude model via OpenAI-compat API
2. Send a message that triggers a tool call
3. The agent's follow-up request replays the thinking block
4. Previously: HTTP 400. Now: thinking block stripped, request succeeds

### Expected

- Multi-turn conversations with tool calls work without 400 errors

### Actual

- Confirmed working in live testing

## Evidence

- [x] Failing test/log before + passing after
  - 17 tests in `strip-completions-reasoning.test.ts`
  - Transcript policy tests updated

## Human Verification (required)

- Verified: Live gateway testing — multi-turn tool conversations no longer 400
- Edge cases: Mixed content blocks, nested thinking blocks, non-Copilot providers unaffected
- Not verified: Exhaustive model coverage

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable: Remove the `stripCompletionsFieldSignatures` policy flag
- Known bad symptoms: If stripping is too aggressive, thinking context could be lost (mitigated: only strips blocks with known field-name patterns)

## Risks and Mitigations

- Risk: This is a safety net, not the root fix. The proper solution is using `anthropic-messages` API (see follow-up PR).
  - Mitigation: This remains useful for backwards compatibility with existing sessions that have bad signatures.

---

> **Stacked PR chain:** #17284 > #17427 > **this PR** > anthropic-messages default
>
> Review incremental changes: compare feat/copilot-sdk-provider...fix/copilot-thinking-signature

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Copilot SDK integration (`@github/copilot-sdk`) and fixes thinking block signature stripping for OpenAI-compatible APIs that proxy to Anthropic.

The core fix (`stripCompletionsReasoningFieldSignatures`) is sound — it detects and strips thinking blocks where pi-ai stored a reasoning field name (e.g., `"reasoning_text"`) instead of a real cryptographic signature, preventing HTTP 400s on subsequent turns. The function is applied via the existing transcript policy system for all OpenAI-compat providers except native OpenAI, Google, and Anthropic, which is the correct scope.

The PR also adds:
- A new `copilot-cli` backend that delegates to the Copilot SDK for interactive sessions
- SDK-based auth detection and model discovery for the GitHub Copilot provider
- An `SDK_MANAGED_TOKEN` marker in auth profiles when the Copilot SDK handles authentication

Key findings:
- A hardcoded `"sdk-managed"` string in `github-copilot-auth.ts` should use the `SDK_MANAGED_TOKEN` constant to stay in sync with the runner/provider detection code
- The `ensureCopilotSdkClient` singleton in `github-copilot-sdk.ts` permanently caches rejected promises if `client.start()` fails, preventing retry after transient errors
- The SDK-managed token code in `run.ts` and `compact.ts` is duplicated — a minor concern but worth noting for future refactoring

<h3>Confidence Score: 3/5</h3>

- Functional core fix is correct; two secondary issues in Copilot SDK integration need attention before merge.
- The thinking block stripping fix is well-implemented with thorough tests. However, two issues in the SDK integration layer reduce confidence: (1) a hardcoded string literal in auth flow that should use the SDK_MANAGED_TOKEN constant to prevent silent breakage if the constant changes, and (2) a permanently cached rejected promise in the SDK client singleton. Both are localized and fixable but represent real defects.
- Pay close attention to `src/providers/github-copilot-auth.ts` (hardcoded token string) and `src/providers/github-copilot-sdk.ts` (client startup error handling).

<sub>Last reviewed commit: 696545d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->