### PR TITLE
fix(completion): avoid rc=1 for optionless zsh leaf commands

### DIFF
--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -365,7 +365,7 @@ export async function installCompletion(shell: string, yes: boolean, binName = "
   }
 }
 
-function generateZshCompletion(program: Command): string {
+export function generateZshCompletion(program: Command): string {
   const rootCmd = program.name();
   const script = `
 #compdef ${rootCmd}
@@ -440,15 +440,16 @@ function generateZshSubcommands(program: Command, prefix: string): string {
     script += generateZshSubcommands(cmd, `${prefix}_${cmdName.replace(/-/g, "_")}`);
 
     const subCommands = cmd.commands;
+    const zshArgs = generateZshArgs(cmd);
     if (subCommands.length > 0) {
+      const argsLine = zshArgs ? `${zshArgs} \\\n    ` : "";
       script += `
 ${funcName}() {
   local -a commands
   local -a options
   
   _arguments -C \\
-    ${generateZshArgs(cmd)} \\
-    ${generateZshSubcmdList(cmd)} \\
+    ${argsLine}${generateZshSubcmdList(cmd)} \\
     "*::arg:->args"
 
   case $state in
@@ -460,11 +461,17 @@ ${funcName}() {
   esac
 }
 `;
-    } else {
+    } else if (zshArgs) {
       script += `
 ${funcName}() {
   _arguments -C \\
-    ${generateZshArgs(cmd)}
+    ${zshArgs}
+}
+`;
+    } else {
+      script += `
+${funcName}() {
+  return 0
 }
 `;
     }

--- a/src/wizard/onboarding.completion.test.ts
+++ b/src/wizard/onboarding.completion.test.ts
@@ -1,4 +1,6 @@
+import { Command } from "commander";
 import { describe, expect, it, vi } from "vitest";
+import { generateZshCompletion } from "../cli/completion-cli.js";
 import { setupOnboardingShellCompletion } from "./onboarding.completion.js";
 
 describe("setupOnboardingShellCompletion", () => {
@@ -54,5 +56,17 @@ describe("setupOnboardingShellCompletion", () => {
     expect(deps.ensureCompletionCacheExists).not.toHaveBeenCalled();
     expect(deps.installCompletion).not.toHaveBeenCalled();
     expect(prompter.note).not.toHaveBeenCalled();
+  });
+});
+
+describe("generateZshCompletion", () => {
+  it("emits a no-op leaf function for commands without options", () => {
+    const program = new Command();
+    program.name("openclaw");
+    program.command("empty").description("No options");
+
+    const script = generateZshCompletion(program);
+
+    expect(script).toMatch(/_openclaw_empty\(\) \{\n  return 0\n\}/);
   });
 });


### PR DESCRIPTION
## Summary
- fix zsh completion generation for leaf commands that have no options
- avoid emitting an empty `_arguments -C` block for those leaves
- emit a no-op leaf function (`return 0`) instead
- add a regression test in `src/wizard/onboarding.completion.test.ts`

## Why
Some generated zsh leaf functions ended up with an empty `_arguments -C` body, which returned non-zero (rc=1) when invoked. This makes completion behavior brittle for optionless leaf commands.

## Verification
- `npx pnpm vitest src/wizard/onboarding.completion.test.ts` ✅
- `npx pnpm exec oxfmt --check src/cli/completion-cli.ts src/wizard/onboarding.completion.test.ts` ✅
- `npx pnpm exec oxlint --type-aware src/cli/completion-cli.ts src/wizard/onboarding.completion.test.ts` ✅
- manual repro with generated mini zsh completion: `_openclaw_config_unset` returns `rc:0` ✅

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed zsh completion generation for leaf commands without options by emitting a no-op function (`return 0`) instead of an empty `_arguments -C` block that would fail with rc=1.

- Refactored `generateZshSubcommands` to handle three cases: commands with subcommands, leaf commands with options, and leaf commands without options
- Added regression test to verify no-op function generation for optionless commands
- Optimized argument line generation to avoid trailing backslash when no args exist

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is surgical and well-targeted: it addresses a specific bug in zsh completion generation for optionless leaf commands, includes a regression test, and follows the existing code patterns. The logic flow is correct across all three cases (commands with subcommands, leaf with options, leaf without options).
- No files require special attention

<sub>Last reviewed commit: e949bf7</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->