### PR TITLE
feat(telegram): add poll action support

### DIFF
--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -18,6 +18,8 @@ export type TelegramActionConfig = {
   editMessage?: boolean;
   /** Enable sticker actions (send and search). */
   sticker?: boolean;
+  /** Enable poll actions (create polls). */
+  polls?: boolean;
 };
 
 export type TelegramNetworkConfig = {


### PR DESCRIPTION
## Summary
Wire up `sendPoll` action for Telegram provider using existing `sendPollTelegram` infrastructure.

## Changes
- Add `polls` to `TelegramActionConfig` type (`src/config/types.telegram.ts`)
- Add poll action to telegram actions router - `listActions` + `handleAction` (`src/channels/plugins/actions/telegram.ts`)
- Add `sendPoll` handler to `handleTelegramAction` (`src/agents/tools/telegram-actions.ts`)

## Features
- Question with 2-10 options (Telegram limit)
- Multi-select support (`pollMulti`)
- Duration/timeout
- Anonymous mode
- Forum topic threading
- Silent sends

## Usage
```yaml
channels:
  telegram:
    actions:
      polls: true  # Enable poll support
```

Then use via message tool:
```
message action:poll to:CHAT_ID pollQuestion:"Which option?" pollOption:["A","B","C"]
```

## Testing
Verified TypeScript compiles without poll-related errors (other errors are missing dependencies in dev environment).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Wires up `sendPoll` action for the Telegram provider, reusing the existing `sendPollTelegram` infrastructure from `src/telegram/send.ts`.

- Adds `polls?: boolean` to `TelegramActionConfig` for action gating (enabled by default, consistent with Discord's poll gating pattern)
- Adds `"poll"` to `listActions` and `handleAction` in the Telegram actions router, extracting user-facing params (`pollQuestion`, `pollOption`, `pollMulti`, `pollDurationSeconds`, `pollAnonymous`) and normalizing via `normalizePollInput`
- Adds `"sendPoll"` handler to `handleTelegramAction` that validates the poll object and delegates to `sendPollTelegram`
- Supports Telegram poll features: 2-10 options, multi-select, duration (5-600s), anonymous mode, forum topic threading, and silent sends
- Poll input normalization happens twice (once in the router, once inside `sendPollTelegram`) — redundant but harmless since normalization is idempotent

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it adds a new opt-in feature using established patterns with no changes to existing behavior.
- The implementation follows existing patterns (sticker actions, Discord polls) closely. All three changed files are additive — no existing behavior is modified. The code correctly delegates to the existing well-tested `sendPollTelegram` function. Downstream validation in `normalizePollInput` and `sendPollTelegram` handles edge cases (option count limits, duration bounds). Score is 4 rather than 5 because the existing test file (`telegram.test.ts`) was not updated with poll action coverage.
- No files require special attention. All changes are additive and follow existing patterns.

<sub>Last reviewed commit: a6f2d24</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->