### PR TITLE
fix(pi-embedded): add aggregate timeout to compaction retry + harden SIGUSR1 restart

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -163,29 +163,6 @@
         "line_number": 15
       }
     ],
-    "appcast.xml": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "appcast.xml",
-        "hashed_secret": "2bc43713edb8f775582c6314953b7c020d691aba",
-        "is_verified": false,
-        "line_number": 141
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "appcast.xml",
-        "hashed_secret": "2fcd83b35235522978c19dbbab2884a09aa64f35",
-        "is_verified": false,
-        "line_number": 209
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "appcast.xml",
-        "hashed_secret": "78b65f0952ed8a557e0f67b2364ff67cb6863bc8",
-        "is_verified": false,
-        "line_number": 310
-      }
-    ],
     "apps/android/app/src/test/java/ai/openclaw/android/node/AppUpdateHandlerTest.kt": [
       {
         "type": "Hex High Entropy String",
@@ -195,22 +172,13 @@
         "line_number": 58
       }
     ],
-    "apps/ios/Sources/Gateway/GatewaySettingsStore.swift": [
-      {
-        "type": "Secret Keyword",
-        "filename": "apps/ios/Sources/Gateway/GatewaySettingsStore.swift",
-        "hashed_secret": "5f7c0c35e552780b67fe1c0ee186764354793be3",
-        "is_verified": false,
-        "line_number": 28
-      }
-    ],
     "apps/ios/Tests/DeepLinkParserTests.swift": [
       {
         "type": "Secret Keyword",
         "filename": "apps/ios/Tests/DeepLinkParserTests.swift",
         "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
         "is_verified": false,
-        "line_number": 89
+        "line_number": 105
       }
     ],
     "apps/macos/Sources/OpenClawProtocol/GatewayModels.swift": [
@@ -219,23 +187,7 @@
         "filename": "apps/macos/Sources/OpenClawProtocol/GatewayModels.swift",
         "hashed_secret": "7990585255d25249fb1e6eac3d2bd6c37429b2cd",
         "is_verified": false,
-        "line_number": 1492
-      }
-    ],
-    "apps/macos/Tests/OpenClawIPCTests/AnthropicAuthResolverTests.swift": [
-      {
-        "type": "Secret Keyword",
-        "filename": "apps/macos/Tests/OpenClawIPCTests/AnthropicAuthResolverTests.swift",
-        "hashed_secret": "e761624445731fcb8b15da94343c6b92e507d190",
-        "is_verified": false,
-        "line_number": 26
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "apps/macos/Tests/OpenClawIPCTests/AnthropicAuthResolverTests.swift",
-        "hashed_secret": "a23c8630c8a5fbaa21f095e0269c135c20d21689",
-        "is_verified": false,
-        "line_number": 42
+        "line_number": 1745
       }
     ],
     "apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift": [
@@ -244,7 +196,7 @@
         "filename": "apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift",
         "hashed_secret": "19dad5cecb110281417d1db56b60e1b006d55bb4",
         "is_verified": false,
-        "line_number": 61
+        "line_number": 66
       }
     ],
     "apps/macos/Tests/OpenClawIPCTests/GatewayLaunchAgentManagerTests.swift": [
@@ -271,7 +223,7 @@
         "filename": "apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 106
+        "line_number": 115
       }
     ],
     "apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift": [
@@ -280,7 +232,7 @@
         "filename": "apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift",
         "hashed_secret": "7990585255d25249fb1e6eac3d2bd6c37429b2cd",
         "is_verified": false,
-        "line_number": 1492
+        "line_number": 1745
       }
     ],
     "docs/.i18n/zh-CN.tm.jsonl": [
@@ -9612,14 +9564,14 @@
         "filename": "docs/channels/feishu.md",
         "hashed_secret": "b60d121b438a380c343d5ec3c2037564b82ffef3",
         "is_verified": false,
-        "line_number": 187
+        "line_number": 189
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/channels/feishu.md",
         "hashed_secret": "186154712b2d5f6791d85b9a0987b98fa231779c",
         "is_verified": false,
-        "line_number": 435
+        "line_number": 501
       }
     ],
     "docs/channels/irc.md": [
@@ -9628,7 +9580,7 @@
         "filename": "docs/channels/irc.md",
         "hashed_secret": "d54831b8e4b461d85e32ea82156d2fb5ce5cb624",
         "is_verified": false,
-        "line_number": 191
+        "line_number": 198
       }
     ],
     "docs/channels/line.md": [
@@ -9637,7 +9589,7 @@
         "filename": "docs/channels/line.md",
         "hashed_secret": "83661b43df128631f891767fbfc5b049af3dce86",
         "is_verified": false,
-        "line_number": 61
+        "line_number": 65
       }
     ],
     "docs/channels/matrix.md": [
@@ -9698,21 +9650,21 @@
         "filename": "docs/concepts/memory.md",
         "hashed_secret": "39d711243bfcee9fec8299b204e1aa9c3430fa12",
         "is_verified": false,
-        "line_number": 281
+        "line_number": 301
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/concepts/memory.md",
         "hashed_secret": "1a8abbf465c52363ab4c9c6ad945b8e857cbea55",
         "is_verified": false,
-        "line_number": 305
+        "line_number": 325
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/concepts/memory.md",
         "hashed_secret": "b9f640d6095b9f6b5a65983f7b76dbbb254e0044",
         "is_verified": false,
-        "line_number": 706
+        "line_number": 726
       }
     ],
     "docs/concepts/model-providers.md": [
@@ -9721,21 +9673,30 @@
         "filename": "docs/concepts/model-providers.md",
         "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
         "is_verified": false,
-        "line_number": 178
+        "line_number": 226
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/concepts/model-providers.md",
         "hashed_secret": "6a4a6c8f2406f4f0843a0a1aae6a320f92f9d6ae",
         "is_verified": false,
-        "line_number": 274
+        "line_number": 386
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/concepts/model-providers.md",
         "hashed_secret": "ef83ad68b9b66e008727b7c417c6a8f618b5177e",
         "is_verified": false,
-        "line_number": 305
+        "line_number": 417
+      }
+    ],
+    "docs/design/kilo-gateway-integration.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/design/kilo-gateway-integration.md",
+        "hashed_secret": "9addbf544119efa4a64223b649750a510f0d463f",
+        "is_verified": false,
+        "line_number": 458
       }
     ],
     "docs/gateway/configuration-examples.md": [
@@ -9758,21 +9719,21 @@
         "filename": "docs/gateway/configuration-examples.md",
         "hashed_secret": "22af290a1a3d5e941193a41a3d3a9e4ca8da5e27",
         "is_verified": false,
-        "line_number": 332
+        "line_number": 336
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-examples.md",
         "hashed_secret": "c1e6ee547fd492df1441ac492e8bb294974712bd",
         "is_verified": false,
-        "line_number": 431
+        "line_number": 439
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-examples.md",
         "hashed_secret": "16c249e04e2be318050cb883c40137361c0c7209",
         "is_verified": false,
-        "line_number": 596
+        "line_number": 613
       }
     ],
     "docs/gateway/configuration-reference.md": [
@@ -9781,70 +9742,70 @@
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 149
+        "line_number": 199
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "1188d5a8ed7edcff5144a9472af960243eacf12e",
         "is_verified": false,
-        "line_number": 1267
+        "line_number": 1611
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "bde4db9b4c3be4049adc3b9a69851d7c35119770",
         "is_verified": false,
-        "line_number": 1283
+        "line_number": 1627
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "7f8aaf142ce0552c260f2e546dda43ddd7c9aef3",
         "is_verified": false,
-        "line_number": 1461
+        "line_number": 1812
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "22af290a1a3d5e941193a41a3d3a9e4ca8da5e27",
         "is_verified": false,
-        "line_number": 1603
+        "line_number": 1985
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
         "is_verified": false,
-        "line_number": 1631
+        "line_number": 2039
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "c1e6ee547fd492df1441ac492e8bb294974712bd",
         "is_verified": false,
-        "line_number": 1862
+        "line_number": 2271
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "45d676e7c6ab44cf4b8fa366ef2d8fccd3e6d6e6",
         "is_verified": false,
-        "line_number": 1966
+        "line_number": 2399
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "a219d7693c25cd2d93313512e200ff3eb374d281",
         "is_verified": false,
-        "line_number": 2202
+        "line_number": 2652
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "b6f56e5e92078ed7c078c46fbfeedcbe5719bc25",
         "is_verified": false,
-        "line_number": 2204
+        "line_number": 2654
       }
     ],
     "docs/gateway/configuration.md": [
@@ -9853,14 +9814,14 @@
         "filename": "docs/gateway/configuration.md",
         "hashed_secret": "a219d7693c25cd2d93313512e200ff3eb374d281",
         "is_verified": false,
-        "line_number": 434
+        "line_number": 461
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration.md",
         "hashed_secret": "b6f56e5e92078ed7c078c46fbfeedcbe5719bc25",
         "is_verified": false,
-        "line_number": 435
+        "line_number": 462
       }
     ],
     "docs/gateway/local-models.md": [
@@ -9879,13 +9840,29 @@
         "line_number": 124
       }
     ],
+    "docs/gateway/remote.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/gateway/remote.md",
+        "hashed_secret": "7d852a6979e11c7a40c35c63a2ee96edb2dc2c69",
+        "is_verified": false,
+        "line_number": 111
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/gateway/remote.md",
+        "hashed_secret": "e1ce9e0c459c8ef30dcadf6fc4e2d50f63a7aa8a",
+        "is_verified": false,
+        "line_number": 114
+      }
+    ],
     "docs/gateway/tailscale.md": [
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/tailscale.md",
         "hashed_secret": "9cb0dc5383312aa15b9dc6745645bde18ff5ade9",
         "is_verified": false,
-        "line_number": 81
+        "line_number": 86
       }
     ],
     "docs/help/environment.md": [
@@ -9910,35 +9887,44 @@
         "filename": "docs/help/faq.md",
         "hashed_secret": "491d458f895b9213facb2ee9375b1b044eaea3ac",
         "is_verified": false,
-        "line_number": 1412
+        "line_number": 1503
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/help/faq.md",
         "hashed_secret": "a219d7693c25cd2d93313512e200ff3eb374d281",
         "is_verified": false,
-        "line_number": 1689
+        "line_number": 1780
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/help/faq.md",
         "hashed_secret": "b6f56e5e92078ed7c078c46fbfeedcbe5719bc25",
         "is_verified": false,
-        "line_number": 1690
+        "line_number": 1781
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/help/faq.md",
         "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
         "is_verified": false,
-        "line_number": 2118
+        "line_number": 2209
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/help/faq.md",
         "hashed_secret": "45d676e7c6ab44cf4b8fa366ef2d8fccd3e6d6e6",
         "is_verified": false,
-        "line_number": 2398
+        "line_number": 2489
+      }
+    ],
+    "docs/help/testing.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/help/testing.md",
+        "hashed_secret": "e008bed242a21b8279c220f84ba16019a67a9dd4",
+        "is_verified": false,
+        "line_number": 94
       }
     ],
     "docs/install/macos-vm.md": [
@@ -9965,7 +9951,7 @@
         "filename": "docs/perplexity.md",
         "hashed_secret": "6b26c117c66a0c030e239eef595c1e18865132a8",
         "is_verified": false,
-        "line_number": 36
+        "line_number": 29
       }
     ],
     "docs/plugins/voice-call.md": [
@@ -9974,7 +9960,7 @@
         "filename": "docs/plugins/voice-call.md",
         "hashed_secret": "cb46980ce5532f18440dff4bbbe097896a8c08c8",
         "is_verified": false,
-        "line_number": 239
+        "line_number": 254
       }
     ],
     "docs/providers/anthropic.md": [
@@ -9992,7 +9978,7 @@
         "filename": "docs/providers/claude-max-api-proxy.md",
         "hashed_secret": "b5c2827eb65bf13b87130e7e3c424ba9ff07cd67",
         "is_verified": false,
-        "line_number": 80
+        "line_number": 86
       }
     ],
     "docs/providers/glm.md": [
@@ -10026,14 +10012,23 @@
         "filename": "docs/providers/minimax.md",
         "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
         "is_verified": false,
-        "line_number": 71
+        "line_number": 70
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/providers/minimax.md",
         "hashed_secret": "16c249e04e2be318050cb883c40137361c0c7209",
         "is_verified": false,
-        "line_number": 140
+        "line_number": 149
+      }
+    ],
+    "docs/providers/mistral.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/providers/mistral.md",
+        "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
+        "is_verified": false,
+        "line_number": 27
       }
     ],
     "docs/providers/moonshot.md": [
@@ -10042,7 +10037,7 @@
         "filename": "docs/providers/moonshot.md",
         "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
         "is_verified": false,
-        "line_number": 43
+        "line_number": 49
       }
     ],
     "docs/providers/nvidia.md": [
@@ -10060,7 +10055,7 @@
         "filename": "docs/providers/ollama.md",
         "hashed_secret": "e774aaeac31c6272107ba89080295e277050fa7c",
         "is_verified": false,
-        "line_number": 33
+        "line_number": 37
       }
     ],
     "docs/providers/openai.md": [
@@ -10069,7 +10064,7 @@
         "filename": "docs/providers/openai.md",
         "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
         "is_verified": false,
-        "line_number": 31
+        "line_number": 32
       }
     ],
     "docs/providers/opencode.md": [
@@ -10112,7 +10107,7 @@
         "filename": "docs/providers/venice.md",
         "hashed_secret": "c179fe46776696372a90218532dc0d67267f2f04",
         "is_verified": false,
-        "line_number": 236
+        "line_number": 251
       }
     ],
     "docs/providers/vllm.md": [
@@ -10149,13 +10144,38 @@
         "line_number": 27
       }
     ],
+    "docs/reference/secretref-user-supplied-credentials-matrix.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/reference/secretref-user-supplied-credentials-matrix.json",
+        "hashed_secret": "d6c8cbcbe34bf0e02cf1a52e27afcf18b59b3f79",
+        "is_verified": false,
+        "line_number": 22
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/reference/secretref-user-supplied-credentials-matrix.json",
+        "hashed_secret": "e9a292f7f4d25b0d861458719c6115de3ec813c3",
+        "is_verified": false,
+        "line_number": 40
+      }
+    ],
+    "docs/start/wizard-cli-automation.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/start/wizard-cli-automation.md",
+        "hashed_secret": "6d9c68c603e465077bdd49c62347fe54717f83a3",
+        "is_verified": false,
+        "line_number": 155
+      }
+    ],
     "docs/tools/browser.md": [
       {
         "type": "Basic Auth Credentials",
         "filename": "docs/tools/browser.md",
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
-        "line_number": 140
+        "line_number": 149
       }
     ],
     "docs/tools/firecrawl.md": [
@@ -10173,7 +10193,7 @@
         "filename": "docs/tools/skills-config.md",
         "hashed_secret": "c1e6ee547fd492df1441ac492e8bb294974712bd",
         "is_verified": false,
-        "line_number": 29
+        "line_number": 31
       }
     ],
     "docs/tools/skills.md": [
@@ -10182,7 +10202,7 @@
         "filename": "docs/tools/skills.md",
         "hashed_secret": "c1e6ee547fd492df1441ac492e8bb294974712bd",
         "is_verified": false,
-        "line_number": 198
+        "line_number": 200
       }
     ],
     "docs/tools/web.md": [
@@ -10191,28 +10211,35 @@
         "filename": "docs/tools/web.md",
         "hashed_secret": "6b26c117c66a0c030e239eef595c1e18865132a8",
         "is_verified": false,
-        "line_number": 62
+        "line_number": 90
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/tools/web.md",
-        "hashed_secret": "96c682c88ed551f22fe76d206c2dfb7df9221ad9",
+        "hashed_secret": "4a9fd550cf205ab06ee932f41a132ff53cb83d83",
         "is_verified": false,
-        "line_number": 113
+        "line_number": 107
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/tools/web.md",
+        "hashed_secret": "1ccebc9638f47c80fc388173e346b2fa51178cca",
+        "is_verified": false,
+        "line_number": 135
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/tools/web.md",
         "hashed_secret": "491d458f895b9213facb2ee9375b1b044eaea3ac",
         "is_verified": false,
-        "line_number": 161
+        "line_number": 179
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/tools/web.md",
         "hashed_secret": "674397e2c0c2faaa85961c708d2a96a7cc7af217",
         "is_verified": false,
-        "line_number": 235
+        "line_number": 277
       }
     ],
     "docs/tts.md": [
@@ -10228,7 +10255,16 @@
         "filename": "docs/tts.md",
         "hashed_secret": "1188d5a8ed7edcff5144a9472af960243eacf12e",
         "is_verified": false,
-        "line_number": 100
+        "line_number": 101
+      }
+    ],
+    "docs/vps.md": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/vps.md",
+        "hashed_secret": "66eba27d45030064a428078cf4d510002a445f27",
+        "is_verified": false,
+        "line_number": 60
       }
     ],
     "docs/zh-CN/brave-search.md": [
@@ -10262,7 +10298,7 @@
         "filename": "docs/zh-CN/channels/feishu.md",
         "hashed_secret": "186154712b2d5f6791d85b9a0987b98fa231779c",
         "is_verified": false,
-        "line_number": 445
+        "line_number": 509
       }
     ],
     "docs/zh-CN/channels/line.md": [
@@ -10807,37 +10843,37 @@
         "filename": "extensions/bluebubbles/src/actions.test.ts",
         "hashed_secret": "789cbe0407840b1c2041cb33452ff60f19bf58cc",
         "is_verified": false,
-        "line_number": 86
+        "line_number": 54
       }
     ],
     "extensions/bluebubbles/src/attachments.test.ts": [
       {
         "type": "Secret Keyword",
         "filename": "extensions/bluebubbles/src/attachments.test.ts",
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "is_verified": false,
+        "line_number": 79
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/bluebubbles/src/attachments.test.ts",
         "hashed_secret": "789cbe0407840b1c2041cb33452ff60f19bf58cc",
         "is_verified": false,
-        "line_number": 21
+        "line_number": 90
       },
       {
         "type": "Secret Keyword",
         "filename": "extensions/bluebubbles/src/attachments.test.ts",
         "hashed_secret": "db1530e1ea43af094d3d75b8dbaf19a4a182a318",
         "is_verified": false,
-        "line_number": 85
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "extensions/bluebubbles/src/attachments.test.ts",
-        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
-        "is_verified": false,
-        "line_number": 103
+        "line_number": 154
       },
       {
         "type": "Secret Keyword",
         "filename": "extensions/bluebubbles/src/attachments.test.ts",
         "hashed_secret": "052f076c732648ab32d2fcde9fe255319bfa0c7b",
         "is_verified": false,
-        "line_number": 215
+        "line_number": 260
       }
     ],
     "extensions/bluebubbles/src/chat.test.ts": [
@@ -10846,42 +10882,42 @@
         "filename": "extensions/bluebubbles/src/chat.test.ts",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 19
+        "line_number": 68
       },
       {
         "type": "Secret Keyword",
         "filename": "extensions/bluebubbles/src/chat.test.ts",
         "hashed_secret": "789cbe0407840b1c2041cb33452ff60f19bf58cc",
         "is_verified": false,
-        "line_number": 54
+        "line_number": 93
       },
       {
         "type": "Secret Keyword",
         "filename": "extensions/bluebubbles/src/chat.test.ts",
         "hashed_secret": "5c5a15a8b0b3e154d77746945e563ba40100681b",
         "is_verified": false,
-        "line_number": 82
+        "line_number": 115
       },
       {
         "type": "Secret Keyword",
         "filename": "extensions/bluebubbles/src/chat.test.ts",
         "hashed_secret": "faacad0ce4ea1c19b46e128fd79679d37d3d331d",
         "is_verified": false,
-        "line_number": 131
+        "line_number": 158
       },
       {
         "type": "Secret Keyword",
         "filename": "extensions/bluebubbles/src/chat.test.ts",
         "hashed_secret": "4dcc26a1d99532846fedf1265df4f40f4e0005b8",
         "is_verified": false,
-        "line_number": 227
+        "line_number": 239
       },
       {
         "type": "Secret Keyword",
         "filename": "extensions/bluebubbles/src/chat.test.ts",
         "hashed_secret": "fd2a721f7be1ee3d691a011affcdb11d0ca365a8",
         "is_verified": false,
-        "line_number": 290
+        "line_number": 302
       }
     ],
     "extensions/bluebubbles/src/monitor.test.ts": [
@@ -10890,14 +10926,37 @@
         "filename": "extensions/bluebubbles/src/monitor.test.ts",
         "hashed_secret": "789cbe0407840b1c2041cb33452ff60f19bf58cc",
         "is_verified": false,
-        "line_number": 278
+        "line_number": 169
       },
       {
         "type": "Secret Keyword",
         "filename": "extensions/bluebubbles/src/monitor.test.ts",
+        "hashed_secret": "891f33ddd2af62f77eab3b7aac8d4874acc093e4",
+        "is_verified": false,
+        "line_number": 2394
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/bluebubbles/src/monitor.test.ts",
+        "hashed_secret": "01ee85f364fd0a345244d10a59d73b9f28b2e8da",
+        "is_verified": false,
+        "line_number": 2398
+      }
+    ],
+    "extensions/bluebubbles/src/monitor.webhook-auth.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/bluebubbles/src/monitor.webhook-auth.test.ts",
+        "hashed_secret": "789cbe0407840b1c2041cb33452ff60f19bf58cc",
+        "is_verified": false,
+        "line_number": 169
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/bluebubbles/src/monitor.webhook-auth.test.ts",
         "hashed_secret": "1ae0af3fe72b3ba394f9fa95a6cffc090d726c23",
         "is_verified": false,
-        "line_number": 552
+        "line_number": 514
       }
     ],
     "extensions/bluebubbles/src/reactions.test.ts": [
@@ -10906,28 +10965,28 @@
         "filename": "extensions/bluebubbles/src/reactions.test.ts",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 37
+        "line_number": 35
       },
       {
         "type": "Secret Keyword",
         "filename": "extensions/bluebubbles/src/reactions.test.ts",
         "hashed_secret": "789cbe0407840b1c2041cb33452ff60f19bf58cc",
         "is_verified": false,
-        "line_number": 178
+        "line_number": 192
       },
       {
         "type": "Secret Keyword",
         "filename": "extensions/bluebubbles/src/reactions.test.ts",
         "hashed_secret": "a4a05c9a6449eb9d6cdac81dd7edc49230e327e6",
         "is_verified": false,
-        "line_number": 209
+        "line_number": 223
       },
       {
         "type": "Secret Keyword",
         "filename": "extensions/bluebubbles/src/reactions.test.ts",
         "hashed_secret": "a2833da9f0a16f09994754d0a31749cecf8c8c77",
         "is_verified": false,
-        "line_number": 315
+        "line_number": 295
       }
     ],
     "extensions/bluebubbles/src/send.test.ts": [
@@ -10936,14 +10995,14 @@
         "filename": "extensions/bluebubbles/src/send.test.ts",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 55
+        "line_number": 79
       },
       {
         "type": "Secret Keyword",
         "filename": "extensions/bluebubbles/src/send.test.ts",
         "hashed_secret": "faacad0ce4ea1c19b46e128fd79679d37d3d331d",
         "is_verified": false,
-        "line_number": 692
+        "line_number": 757
       }
     ],
     "extensions/bluebubbles/src/targets.test.ts": [
@@ -10952,16 +11011,7 @@
         "filename": "extensions/bluebubbles/src/targets.test.ts",
         "hashed_secret": "a3af2fb0c1e2a30bb038049e1e4b401593af6225",
         "is_verified": false,
-        "line_number": 61
-      }
-    ],
-    "extensions/bluebubbles/src/targets.ts": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": "extensions/bluebubbles/src/targets.ts",
-        "hashed_secret": "a3af2fb0c1e2a30bb038049e1e4b401593af6225",
-        "is_verified": false,
-        "line_number": 265
+        "line_number": 62
       }
     ],
     "extensions/copilot-proxy/index.ts": [
@@ -10971,6 +11021,22 @@
         "hashed_secret": "50f013532a9770a2c2cfdc38b7581dd01df69b70",
         "is_verified": false,
         "line_number": 9
+      }
+    ],
+    "extensions/diagnostics-otel/src/service.test.ts": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "extensions/diagnostics-otel/src/service.test.ts",
+        "hashed_secret": "e6aa9dc072fcb9dbe42761f25c976143c39d3deb",
+        "is_verified": false,
+        "line_number": 332
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "extensions/diagnostics-otel/src/service.test.ts",
+        "hashed_secret": "7e634f2e8cbddf340740ee856bf272aaa6d6d770",
+        "is_verified": false,
+        "line_number": 352
       }
     ],
     "extensions/feishu/skills/feishu-doc/SKILL.md": [
@@ -10991,6 +11057,66 @@
         "line_number": 40
       }
     ],
+    "extensions/feishu/src/accounts.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/accounts.test.ts",
+        "hashed_secret": "e066a1720c6745f87bad43d4dc1206a6beaf4298",
+        "is_verified": false,
+        "line_number": 19
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/accounts.test.ts",
+        "hashed_secret": "32db07403e892e96ab02693d38bffb2777e82c94",
+        "is_verified": false,
+        "line_number": 20
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/accounts.test.ts",
+        "hashed_secret": "b72c7c889dbb48caa14157494693a442309d9f08",
+        "is_verified": false,
+        "line_number": 51
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/accounts.test.ts",
+        "hashed_secret": "d15b430d272b72b4149afe9098236dd161888d76",
+        "is_verified": false,
+        "line_number": 167
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/accounts.test.ts",
+        "hashed_secret": "ea45a4958bbb18451e1d48aa90745cb35a508b29",
+        "is_verified": false,
+        "line_number": 239
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/accounts.test.ts",
+        "hashed_secret": "3017efcbcc4d30831b27c2793bac8e7ea61c905a",
+        "is_verified": false,
+        "line_number": 254
+      }
+    ],
+    "extensions/feishu/src/bot.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/bot.test.ts",
+        "hashed_secret": "6ccf7c8dbcc240973f7793b6bbc8f1d5e6efd4b1",
+        "is_verified": false,
+        "line_number": 1091
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/bot.test.ts",
+        "hashed_secret": "1962fc9032fed7c415a657282d617ba80e82f884",
+        "is_verified": false,
+        "line_number": 1154
+      }
+    ],
     "extensions/feishu/src/channel.test.ts": [
       {
         "type": "Secret Keyword",
@@ -11000,13 +11126,140 @@
         "line_number": 21
       }
     ],
+    "extensions/feishu/src/chat.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/chat.test.ts",
+        "hashed_secret": "f49922d511d666848f250663c4fca84074b856a8",
+        "is_verified": false,
+        "line_number": 32
+      }
+    ],
+    "extensions/feishu/src/client.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/client.test.ts",
+        "hashed_secret": "2e8a3d5cbfeb3818c59b66a9f0bf3b80990489f3",
+        "is_verified": false,
+        "line_number": 62
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/client.test.ts",
+        "hashed_secret": "cfc5057763ea7dabd5c6f7325c0d39c9b8d1baf1",
+        "is_verified": false,
+        "line_number": 105
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/client.test.ts",
+        "hashed_secret": "8636f9964c42d12b2d698204e426276c41df66d1",
+        "is_verified": false,
+        "line_number": 113
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/client.test.ts",
+        "hashed_secret": "2e59eff806170ad50c34e3372faef694874fae93",
+        "is_verified": false,
+        "line_number": 135
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/client.test.ts",
+        "hashed_secret": "f4e4e5f8d09c24c2863cceca031e94154a63e138",
+        "is_verified": false,
+        "line_number": 154
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/client.test.ts",
+        "hashed_secret": "e55783e61a4f2ae1efd1d1ccb142c902c473ef86",
+        "is_verified": false,
+        "line_number": 176
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/client.test.ts",
+        "hashed_secret": "67db48d9a41265dfca56d8b198f3e28ee9b6bbcb",
+        "is_verified": false,
+        "line_number": 200
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/client.test.ts",
+        "hashed_secret": "b8d75c4b958af69d9be3c2efa450e7c4a1b41770",
+        "is_verified": false,
+        "line_number": 222
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/client.test.ts",
+        "hashed_secret": "f546848b2bf72fec2651db6b80e5592fda678e2f",
+        "is_verified": false,
+        "line_number": 245
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/client.test.ts",
+        "hashed_secret": "c7c5ddbf5e808a49ef38791caf8563c0bc0da434",
+        "is_verified": false,
+        "line_number": 264
+      }
+    ],
+    "extensions/feishu/src/config-schema.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/config-schema.test.ts",
+        "hashed_secret": "d25db33e5c07ac669f08da0adc2bde73b15ee929",
+        "is_verified": false,
+        "line_number": 39
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/config-schema.test.ts",
+        "hashed_secret": "8437d84cae482d10a2b9fd3f555d45006979e4be",
+        "is_verified": false,
+        "line_number": 67
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/config-schema.test.ts",
+        "hashed_secret": "32db07403e892e96ab02693d38bffb2777e82c94",
+        "is_verified": false,
+        "line_number": 174
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/config-schema.test.ts",
+        "hashed_secret": "2bd27e71d7e14bbd5ac1576290ed6074dc450b5a",
+        "is_verified": false,
+        "line_number": 185
+      }
+    ],
+    "extensions/feishu/src/docx.account-selection.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/docx.account-selection.test.ts",
+        "hashed_secret": "db2b80fd220b75be76e698a9164f989baf731caf",
+        "is_verified": false,
+        "line_number": 30
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/docx.account-selection.test.ts",
+        "hashed_secret": "57cb5f8d57e1a3c1bcf90d73e103af6a775591a6",
+        "is_verified": false,
+        "line_number": 31
+      }
+    ],
     "extensions/feishu/src/docx.test.ts": [
       {
         "type": "Secret Keyword",
         "filename": "extensions/feishu/src/docx.test.ts",
         "hashed_secret": "f49922d511d666848f250663c4fca84074b856a8",
         "is_verified": false,
-        "line_number": 97
+        "line_number": 124
       }
     ],
     "extensions/feishu/src/media.test.ts": [
@@ -11015,7 +11268,83 @@
         "filename": "extensions/feishu/src/media.test.ts",
         "hashed_secret": "f49922d511d666848f250663c4fca84074b856a8",
         "is_verified": false,
-        "line_number": 45
+        "line_number": 76
+      }
+    ],
+    "extensions/feishu/src/monitor.webhook-security.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/monitor.webhook-security.test.ts",
+        "hashed_secret": "cf27add3cb4cb83efe9a48cf7289068fa869c4cd",
+        "is_verified": false,
+        "line_number": 91
+      }
+    ],
+    "extensions/feishu/src/onboarding.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/onboarding.test.ts",
+        "hashed_secret": "2e8a3d5cbfeb3818c59b66a9f0bf3b80990489f3",
+        "is_verified": false,
+        "line_number": 64
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/onboarding.test.ts",
+        "hashed_secret": "d5fc216f56ec5ef58691c854104ba78667d9efad",
+        "is_verified": false,
+        "line_number": 78
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/onboarding.test.ts",
+        "hashed_secret": "d819cf9769641b789fc8f539e0cd8cbe5606e057",
+        "is_verified": false,
+        "line_number": 82
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/onboarding.test.ts",
+        "hashed_secret": "72b6d12b3e7034420015375375466c37ec68be51",
+        "is_verified": false,
+        "line_number": 114
+      }
+    ],
+    "extensions/feishu/src/probe.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/probe.test.ts",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_verified": false,
+        "line_number": 37
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/probe.test.ts",
+        "hashed_secret": "640d87e741e6aa4c669a82a4cd304787960513ab",
+        "is_verified": false,
+        "line_number": 195
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/probe.test.ts",
+        "hashed_secret": "4205714cdfe14ed9e3d030ddf7887781b964f510",
+        "is_verified": false,
+        "line_number": 199
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/probe.test.ts",
+        "hashed_secret": "5a718c07b29bb4cd5fafb4a3ad377efc2dad9a59",
+        "is_verified": false,
+        "line_number": 214
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/probe.test.ts",
+        "hashed_secret": "5da0807f9682b03d10b7906c5d2312d46368500c",
+        "is_verified": false,
+        "line_number": 219
       }
     ],
     "extensions/feishu/src/reply-dispatcher.test.ts": [
@@ -11024,16 +11353,23 @@
         "filename": "extensions/feishu/src/reply-dispatcher.test.ts",
         "hashed_secret": "f49922d511d666848f250663c4fca84074b856a8",
         "is_verified": false,
-        "line_number": 48
+        "line_number": 74
       }
     ],
-    "extensions/google-antigravity-auth/index.ts": [
+    "extensions/feishu/src/tool-account-routing.test.ts": [
       {
-        "type": "Base64 High Entropy String",
-        "filename": "extensions/google-antigravity-auth/index.ts",
-        "hashed_secret": "709d0f232b6ac4f8d24dec3e4fabfdb14257174f",
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/tool-account-routing.test.ts",
+        "hashed_secret": "db2b80fd220b75be76e698a9164f989baf731caf",
         "is_verified": false,
-        "line_number": 14
+        "line_number": 38
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/feishu/src/tool-account-routing.test.ts",
+        "hashed_secret": "57cb5f8d57e1a3c1bcf90d73e103af6a775591a6",
+        "is_verified": false,
+        "line_number": 43
       }
     ],
     "extensions/google-gemini-cli-auth/oauth.test.ts": [
@@ -11042,7 +11378,32 @@
         "filename": "extensions/google-gemini-cli-auth/oauth.test.ts",
         "hashed_secret": "021343c1f561d7bcbc3b513df45cc3a6baf67b43",
         "is_verified": false,
-        "line_number": 30
+        "line_number": 43
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/google-gemini-cli-auth/oauth.test.ts",
+        "hashed_secret": "07d1db7c4a73c573d6d038b3d26194a7957c513c",
+        "is_verified": false,
+        "line_number": 311
+      }
+    ],
+    "extensions/googlechat/src/api.test.ts": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "extensions/googlechat/src/api.test.ts",
+        "hashed_secret": "bc7bd07bb0114ca5928ca561817efc6cd7083966",
+        "is_verified": false,
+        "line_number": 84
+      }
+    ],
+    "extensions/googlechat/src/channel.outbound.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/googlechat/src/channel.outbound.test.ts",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 50
       }
     ],
     "extensions/irc/src/accounts.ts": [
@@ -11051,7 +11412,7 @@
         "filename": "extensions/irc/src/accounts.ts",
         "hashed_secret": "920f8f5815b381ea692e9e7c2f7119f2b1aa620a",
         "is_verified": false,
-        "line_number": 19
+        "line_number": 24
       }
     ],
     "extensions/irc/src/client.test.ts": [
@@ -11076,7 +11437,7 @@
         "filename": "extensions/line/src/channel.startup.test.ts",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 103
+        "line_number": 94
       }
     ],
     "extensions/matrix/src/matrix/accounts.test.ts": [
@@ -11113,13 +11474,36 @@
         "line_number": 8
       }
     ],
+    "extensions/mattermost/src/normalize.test.ts": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "extensions/mattermost/src/normalize.test.ts",
+        "hashed_secret": "713ecccd228f49a6068bedd7a64510b50b4284e5",
+        "is_verified": false,
+        "line_number": 77
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "extensions/mattermost/src/normalize.test.ts",
+        "hashed_secret": "a8e2493e7579ba630d56b2552d5fd2a7198ad943",
+        "is_verified": false,
+        "line_number": 82
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "extensions/mattermost/src/normalize.test.ts",
+        "hashed_secret": "9a33401dd4f9784482d2db77bbe93d99cea1a571",
+        "is_verified": false,
+        "line_number": 94
+      }
+    ],
     "extensions/memory-lancedb/config.ts": [
       {
         "type": "Secret Keyword",
         "filename": "extensions/memory-lancedb/config.ts",
         "hashed_secret": "ecb252044b5ea0f679ee78ec1a12904739e2904d",
         "is_verified": false,
-        "line_number": 101
+        "line_number": 105
       }
     ],
     "extensions/memory-lancedb/index.test.ts": [
@@ -11131,6 +11515,15 @@
         "line_number": 71
       }
     ],
+    "extensions/msteams/src/monitor.lifecycle.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/msteams/src/monitor.lifecycle.test.ts",
+        "hashed_secret": "5a21585c3dfc2797afe4634fa150d996f4ef5b5e",
+        "is_verified": false,
+        "line_number": 143
+      }
+    ],
     "extensions/msteams/src/probe.test.ts": [
       {
         "type": "Secret Keyword",
@@ -11140,20 +11533,45 @@
         "line_number": 35
       }
     ],
+    "extensions/msteams/src/token.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/msteams/src/token.test.ts",
+        "hashed_secret": "5a21585c3dfc2797afe4634fa150d996f4ef5b5e",
+        "is_verified": false,
+        "line_number": 38
+      }
+    ],
     "extensions/nextcloud-talk/src/accounts.ts": [
       {
         "type": "Secret Keyword",
         "filename": "extensions/nextcloud-talk/src/accounts.ts",
         "hashed_secret": "920f8f5815b381ea692e9e7c2f7119f2b1aa620a",
         "is_verified": false,
-        "line_number": 22
+        "line_number": 31
       },
       {
         "type": "Secret Keyword",
         "filename": "extensions/nextcloud-talk/src/accounts.ts",
         "hashed_secret": "71f8e7976e4cbc4561c9d62fb283e7f788202acb",
         "is_verified": false,
-        "line_number": 151
+        "line_number": 169
+      }
+    ],
+    "extensions/nextcloud-talk/src/channel.startup.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/nextcloud-talk/src/channel.startup.test.ts",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_verified": false,
+        "line_number": 24
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/nextcloud-talk/src/channel.startup.test.ts",
+        "hashed_secret": "dfba7aade0868074c2861c98e2a9a92f3178a51b",
+        "is_verified": false,
+        "line_number": 25
       }
     ],
     "extensions/nextcloud-talk/src/channel.ts": [
@@ -11162,7 +11580,16 @@
         "filename": "extensions/nextcloud-talk/src/channel.ts",
         "hashed_secret": "71f8e7976e4cbc4561c9d62fb283e7f788202acb",
         "is_verified": false,
-        "line_number": 396
+        "line_number": 408
+      }
+    ],
+    "extensions/nextcloud-talk/src/send.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/nextcloud-talk/src/send.test.ts",
+        "hashed_secret": "dbdab9be92cacdae6a97e8601332bfaa8545800f",
+        "is_verified": false,
+        "line_number": 11
       }
     ],
     "extensions/nostr/README.md": [
@@ -11172,6 +11599,36 @@
         "hashed_secret": "edeb23e25a619c434d22bb7f1c3ca4841166b4e8",
         "is_verified": false,
         "line_number": 46
+      }
+    ],
+    "extensions/nostr/src/channel.outbound.test.ts": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "extensions/nostr/src/channel.outbound.test.ts",
+        "hashed_secret": "ce4303f6b22257d9c9cf314ef1dee4707c6e1c13",
+        "is_verified": false,
+        "line_number": 54
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/nostr/src/channel.outbound.test.ts",
+        "hashed_secret": "ce4303f6b22257d9c9cf314ef1dee4707c6e1c13",
+        "is_verified": false,
+        "line_number": 54
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "extensions/nostr/src/channel.outbound.test.ts",
+        "hashed_secret": "e8b2cccf31904f5d9c62838922648cfeaa4c07e0",
+        "is_verified": false,
+        "line_number": 55
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/nostr/src/channel.outbound.test.ts",
+        "hashed_secret": "44682b9fe21c229330c1e5cf9c414d4267d97719",
+        "is_verified": false,
+        "line_number": 66
       }
     ],
     "extensions/nostr/src/channel.test.ts": [
@@ -11288,7 +11745,7 @@
         "filename": "extensions/nostr/src/types.test.ts",
         "hashed_secret": "3bee216ebc256d692260fc3adc765050508fef5e",
         "is_verified": false,
-        "line_number": 123
+        "line_number": 141
       }
     ],
     "extensions/open-prose/skills/prose/SKILL.md": [
@@ -11314,6 +11771,38 @@
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
         "line_number": 200
+      }
+    ],
+    "extensions/slack/src/channel.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/slack/src/channel.test.ts",
+        "hashed_secret": "514f52b114ae97e309055b6f419798569dc48a2b",
+        "is_verified": false,
+        "line_number": 147
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/slack/src/channel.test.ts",
+        "hashed_secret": "071d3673192b4b44a84aa73ac9d00c155821303b",
+        "is_verified": false,
+        "line_number": 217
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/slack/src/channel.test.ts",
+        "hashed_secret": "dfba7aade0868074c2861c98e2a9a92f3178a51b",
+        "is_verified": false,
+        "line_number": 219
+      }
+    ],
+    "extensions/telegram/src/channel.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "extensions/telegram/src/channel.test.ts",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_verified": false,
+        "line_number": 136
       }
     ],
     "extensions/twitch/src/onboarding.test.ts": [
@@ -11356,7 +11845,7 @@
         "filename": "extensions/voice-call/src/config.test.ts",
         "hashed_secret": "62207a469ec2fdcfc7d66b04c2980ac1501acbf0",
         "is_verified": false,
-        "line_number": 129
+        "line_number": 79
       }
     ],
     "extensions/voice-call/src/providers/telnyx.test.ts": [
@@ -11375,15 +11864,6 @@
         "hashed_secret": "f51aaee16a4a756d287f126b99c081b73cba7f15",
         "is_verified": false,
         "line_number": 41
-      }
-    ],
-    "extensions/zalo/src/monitor.webhook.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "extensions/zalo/src/monitor.webhook.test.ts",
-        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
-        "is_verified": false,
-        "line_number": 40
       }
     ],
     "skills/1password/references/cli-examples.md": [
@@ -11413,82 +11893,181 @@
         "line_number": 22
       }
     ],
-    "src/agents/compaction.tool-result-details.e2e.test.ts": [
+    "src/acp/client.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/compaction.tool-result-details.e2e.test.ts",
+        "filename": "src/acp/client.test.ts",
+        "hashed_secret": "d862c48593628a39a76daafde56f16b69eddd7c2",
+        "is_verified": false,
+        "line_number": 69
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/acp/client.test.ts",
+        "hashed_secret": "aac1281207c0f83f113d70cd1200bd86ce30ffcb",
+        "is_verified": false,
+        "line_number": 70
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/acp/client.test.ts",
+        "hashed_secret": "787951939f82ab64286006ce2a430e06c6d54086",
+        "is_verified": false,
+        "line_number": 71
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/acp/client.test.ts",
+        "hashed_secret": "d503c694c0e762d786079a3f8bd6df32de508a9b",
+        "is_verified": false,
+        "line_number": 85
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/acp/client.test.ts",
+        "hashed_secret": "0d8c5e792dc079c912039086e892330076db8129",
+        "is_verified": false,
+        "line_number": 98
+      }
+    ],
+    "src/acp/server.startup.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/acp/server.startup.test.ts",
+        "hashed_secret": "60fe331dc434ac211c53f33da22a384aa0e3fec5",
+        "is_verified": false,
+        "line_number": 178
+      }
+    ],
+    "src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts",
+        "hashed_secret": "02ecb94373bfb3dfe827ca18409f50b016e8302a",
+        "is_verified": false,
+        "line_number": 26
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts",
+        "hashed_secret": "f8ca0d7266886f4b5be9adddc9b66017b3bf1a4b",
+        "is_verified": false,
+        "line_number": 27
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts",
+        "hashed_secret": "0775624b6a8da2aaf29e334372656c1b657c21b7",
+        "is_verified": false,
+        "line_number": 94
+      }
+    ],
+    "src/agents/compaction.tool-result-details.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/compaction.tool-result-details.test.ts",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 50
+        "line_number": 67
       }
     ],
-    "src/agents/memory-search.e2e.test.ts": [
+    "src/agents/memory-search.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/memory-search.e2e.test.ts",
+        "filename": "src/agents/memory-search.test.ts",
         "hashed_secret": "a1b49d68a91fdf9c9217773f3fac988d77fa0f50",
         "is_verified": false,
-        "line_number": 189
+        "line_number": 191
       }
     ],
-    "src/agents/minimax-vlm.normalizes-api-key.e2e.test.ts": [
+    "src/agents/minimax-vlm.normalizes-api-key.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/minimax-vlm.normalizes-api-key.e2e.test.ts",
+        "filename": "src/agents/minimax-vlm.normalizes-api-key.test.ts",
         "hashed_secret": "8a8461b67e3fe515f248ac2610fd7b1f4fc3b412",
         "is_verified": false,
-        "line_number": 28
+        "line_number": 29
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/minimax-vlm.normalizes-api-key.test.ts",
+        "hashed_secret": "bcdec29c5e1ade0fc995c3a18862f0111e51a998",
+        "is_verified": false,
+        "line_number": 56
       }
     ],
-    "src/agents/model-auth.e2e.test.ts": [
+    "src/agents/model-auth-label.test.ts": [
+      {
+        "type": "GitHub Token",
+        "filename": "src/agents/model-auth-label.test.ts",
+        "hashed_secret": "e175c6f5f2a92e8623bd9a4820edb4e8c1b0fd10",
+        "is_verified": false,
+        "line_number": 35
+      },
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
+        "filename": "src/agents/model-auth-label.test.ts",
+        "hashed_secret": "6367c48dd193d56ea7b0baad25b19455e529f5ee",
+        "is_verified": false,
+        "line_number": 55
+      }
+    ],
+    "src/agents/model-auth.profiles.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/model-auth.profiles.test.ts",
         "hashed_secret": "07a6b9cec637c806195e8aa7e5c0851ab03dc35e",
         "is_verified": false,
-        "line_number": 228
+        "line_number": 194
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
+        "filename": "src/agents/model-auth.profiles.test.ts",
         "hashed_secret": "21f296583ccd80c5ab9b3330a8b0d47e4a409fb9",
         "is_verified": false,
-        "line_number": 254
+        "line_number": 208
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
+        "filename": "src/agents/model-auth.profiles.test.ts",
         "hashed_secret": "b65888424ecafcc98bfd803b24817e4dadf821f8",
         "is_verified": false,
-        "line_number": 275
+        "line_number": 219
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
+        "filename": "src/agents/model-auth.profiles.test.ts",
+        "hashed_secret": "b17453920671d0cb8a415b649a066b3df3d36fb0",
+        "is_verified": false,
+        "line_number": 253
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/model-auth.profiles.test.ts",
         "hashed_secret": "77e991e9f56e6fa4ed1a908208048421f1214c07",
         "is_verified": false,
-        "line_number": 296
+        "line_number": 286
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
+        "filename": "src/agents/model-auth.profiles.test.ts",
         "hashed_secret": "dff6d4ff5dc357cf451d1855ab9cbda562645c9f",
         "is_verified": false,
-        "line_number": 319
+        "line_number": 301
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
+        "filename": "src/agents/model-auth.profiles.test.ts",
         "hashed_secret": "b43be360db55d89ec6afd74d6ed8f82002fe4982",
         "is_verified": false,
-        "line_number": 374
+        "line_number": 333
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
+        "filename": "src/agents/model-auth.profiles.test.ts",
         "hashed_secret": "5b850e9dc678446137ff6d905ebd78634d687fdd",
         "is_verified": false,
-        "line_number": 395
+        "line_number": 344
       }
     ],
     "src/agents/model-auth.ts": [
@@ -11500,38 +12079,118 @@
         "line_number": 25
       }
     ],
+    "src/agents/model-fallback.run-embedded.e2e.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/model-fallback.run-embedded.e2e.test.ts",
+        "hashed_secret": "845fa28a5bf5d82cfa91a00ef9cf6cca8aef00db",
+        "is_verified": false,
+        "line_number": 111
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/model-fallback.run-embedded.e2e.test.ts",
+        "hashed_secret": "19e506a6fcda111778646087fb7aad7f00267113",
+        "is_verified": false,
+        "line_number": 127
+      }
+    ],
     "src/agents/models-config.e2e-harness.ts": [
       {
         "type": "Secret Keyword",
         "filename": "src/agents/models-config.e2e-harness.ts",
         "hashed_secret": "7cf31e8b6cda49f70c31f1f25af05d46f924142d",
         "is_verified": false,
-        "line_number": 110
+        "line_number": 130
       }
     ],
-    "src/agents/models-config.fills-missing-provider-apikey-from-env-var.e2e.test.ts": [
+    "src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/models-config.fills-missing-provider-apikey-from-env-var.e2e.test.ts",
-        "hashed_secret": "fcdd655b11f33ba4327695084a347b2ba192976c",
+        "filename": "src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts",
+        "hashed_secret": "2a9da819718779deba96d5aee1d1f4948047c2bd",
         "is_verified": false,
-        "line_number": 19
+        "line_number": 46
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/models-config.fills-missing-provider-apikey-from-env-var.e2e.test.ts",
-        "hashed_secret": "3a81eb091f80c845232225be5663d270e90dacb7",
+        "filename": "src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts",
+        "hashed_secret": "fa9144b340ea7886885669e2e7a808c86ee14a07",
         "is_verified": false,
-        "line_number": 73
-      }
-    ],
-    "src/agents/models-config.normalizes-gemini-3-ids-preview-google-providers.e2e.test.ts": [
+        "line_number": 117
+      },
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/models-config.normalizes-gemini-3-ids-preview-google-providers.e2e.test.ts",
+        "filename": "src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts",
+        "hashed_secret": "3a81eb091f80c845232225be5663d270e90dacb7",
+        "is_verified": false,
+        "line_number": 181
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts",
+        "hashed_secret": "565a8d87240aae631d7a901c1f697d46ee141a7b",
+        "is_verified": false,
+        "line_number": 214
+      }
+    ],
+    "src/agents/models-config.normalizes-gemini-3-ids-preview-google-providers.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/models-config.normalizes-gemini-3-ids-preview-google-providers.test.ts",
         "hashed_secret": "980d02eb9335ae7c9e9984f6c8ad432352a0d2ac",
         "is_verified": false,
-        "line_number": 20
+        "line_number": 17
+      }
+    ],
+    "src/agents/models-config.providers.google-antigravity.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/models-config.providers.google-antigravity.test.ts",
+        "hashed_secret": "65ef0bf81fc443b3e15a494151196f38c8273c96",
+        "is_verified": false,
+        "line_number": 27
+      }
+    ],
+    "src/agents/models-config.providers.kilocode.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/models-config.providers.kilocode.test.ts",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 24
+      }
+    ],
+    "src/agents/models-config.providers.kimi-coding.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/models-config.providers.kimi-coding.test.ts",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 12
+      }
+    ],
+    "src/agents/models-config.providers.normalize-keys.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/models-config.providers.normalize-keys.test.ts",
+        "hashed_secret": "ba4d38e2a7e8c718913887136d2526351d05cd69",
+        "is_verified": false,
+        "line_number": 16
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/models-config.providers.normalize-keys.test.ts",
+        "hashed_secret": "02ecb94373bfb3dfe827ca18409f50b016e8302a",
+        "is_verified": false,
+        "line_number": 46
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/models-config.providers.normalize-keys.test.ts",
+        "hashed_secret": "b9cdfe69a75e4f2491bcbaf1934ab5e4fd69eb6b",
+        "is_verified": false,
+        "line_number": 52
       }
     ],
     "src/agents/models-config.providers.nvidia.test.ts": [
@@ -11547,38 +12206,54 @@
         "filename": "src/agents/models-config.providers.nvidia.test.ts",
         "hashed_secret": "be1a7be9d4d5af417882b267f4db6dddc08507bd",
         "is_verified": false,
-        "line_number": 27
+        "line_number": 22
       }
     ],
-    "src/agents/models-config.providers.ollama.e2e.test.ts": [
+    "src/agents/models-config.providers.ollama.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/models-config.providers.ollama.e2e.test.ts",
+        "filename": "src/agents/models-config.providers.ollama.test.ts",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 37
-      }
-    ],
-    "src/agents/models-config.providers.qianfan.e2e.test.ts": [
+        "line_number": 54
+      },
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/models-config.providers.qianfan.e2e.test.ts",
+        "filename": "src/agents/models-config.providers.ollama.test.ts",
+        "hashed_secret": "3148ad4aafbeefee82355e1cde29b6d77ba4cf21",
+        "is_verified": false,
+        "line_number": 248
+      }
+    ],
+    "src/agents/models-config.providers.qianfan.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/models-config.providers.qianfan.test.ts",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 12
+        "line_number": 11
       }
     ],
-    "src/agents/models-config.skips-writing-models-json-no-env-token.e2e.test.ts": [
+    "src/agents/models-config.providers.volcengine-byteplus.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/models-config.skips-writing-models-json-no-env-token.e2e.test.ts",
+        "filename": "src/agents/models-config.providers.volcengine-byteplus.test.ts",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 13
+      }
+    ],
+    "src/agents/models-config.skips-writing-models-json-no-env-token.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/models-config.skips-writing-models-json-no-env-token.test.ts",
         "hashed_secret": "4c7bac93427c83bcc3beeceebfa54f16f801b78f",
         "is_verified": false,
         "line_number": 100
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/models-config.skips-writing-models-json-no-env-token.e2e.test.ts",
+        "filename": "src/agents/models-config.skips-writing-models-json-no-env-token.test.ts",
         "hashed_secret": "4f2b3ddc953da005a97d825652080fe6eff21520",
         "is_verified": false,
         "line_number": 113
@@ -11590,7 +12265,39 @@
         "filename": "src/agents/openai-responses.reasoning-replay.test.ts",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 55
+        "line_number": 92
+      }
+    ],
+    "src/agents/owner-display.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/owner-display.test.ts",
+        "hashed_secret": "e9dc4e431a9043d0d7d2750af1189e77e2834877",
+        "is_verified": false,
+        "line_number": 16
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/owner-display.test.ts",
+        "hashed_secret": "d9d2f263c630f79c8eb176dbccfef7c3ade3ddcc",
+        "is_verified": false,
+        "line_number": 70
+      }
+    ],
+    "src/agents/pi-embedded-runner-extraparams.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/pi-embedded-runner-extraparams.test.ts",
+        "hashed_secret": "4604122d2d19b953716499c7fade74e3db0ad17f",
+        "is_verified": false,
+        "line_number": 1075
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/pi-embedded-runner-extraparams.test.ts",
+        "hashed_secret": "81181bf462a0965325a629cff91f511e285d59d4",
+        "is_verified": false,
+        "line_number": 1133
       }
     ],
     "src/agents/pi-embedded-runner.e2e.test.ts": [
@@ -11599,14 +12306,16 @@
         "filename": "src/agents/pi-embedded-runner.e2e.test.ts",
         "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
         "is_verified": false,
-        "line_number": 127
-      },
+        "line_number": 122
+      }
+    ],
+    "src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/pi-embedded-runner.e2e.test.ts",
-        "hashed_secret": "fcdd655b11f33ba4327695084a347b2ba192976c",
+        "filename": "src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts",
+        "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
         "is_verified": false,
-        "line_number": 238
+        "line_number": 159
       }
     ],
     "src/agents/pi-embedded-runner/model.ts": [
@@ -11615,7 +12324,7 @@
         "filename": "src/agents/pi-embedded-runner/model.ts",
         "hashed_secret": "e774aaeac31c6272107ba89080295e277050fa7c",
         "is_verified": false,
-        "line_number": 118
+        "line_number": 232
       }
     ],
     "src/agents/pi-embedded-runner/run.overflow-compaction.mocks.shared.ts": [
@@ -11624,16 +12333,55 @@
         "filename": "src/agents/pi-embedded-runner/run.overflow-compaction.mocks.shared.ts",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 86
+        "line_number": 114
       }
     ],
-    "src/agents/pi-tools.safe-bins.e2e.test.ts": [
+    "src/agents/pi-extensions/compaction-safeguard.test.ts": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/agents/pi-extensions/compaction-safeguard.test.ts",
+        "hashed_secret": "0091061a3babbe6f11d48aa0142e22341b3ea446",
+        "is_verified": false,
+        "line_number": 665
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/agents/pi-extensions/compaction-safeguard.test.ts",
+        "hashed_secret": "ef678205593788329ff416ce5c65fa04f33a05bd",
+        "is_verified": false,
+        "line_number": 811
+      },
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/pi-tools.safe-bins.e2e.test.ts",
-        "hashed_secret": "3ea88a727641fd5571b5e126ce87032377be1e7f",
+        "filename": "src/agents/pi-extensions/compaction-safeguard.test.ts",
+        "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
         "is_verified": false,
-        "line_number": 126
+        "line_number": 1490
+      }
+    ],
+    "src/agents/sandbox/browser.novnc-url.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/sandbox/browser.novnc-url.test.ts",
+        "hashed_secret": "16c002d49d19805aa1bfba58e9c90b5476054b07",
+        "is_verified": false,
+        "line_number": 18
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/sandbox/browser.novnc-url.test.ts",
+        "hashed_secret": "7ce0359f12857f2a90c7de465f40a95f01cb5da9",
+        "is_verified": false,
+        "line_number": 27
+      }
+    ],
+    "src/agents/sandbox/sanitize-env-vars.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/sandbox/sanitize-env-vars.test.ts",
+        "hashed_secret": "c747c6b0a7bb9c6337b81875af1a9f9568c740ad",
+        "is_verified": false,
+        "line_number": 8
       }
     ],
     "src/agents/sanitize-for-prompt.test.ts": [
@@ -11645,65 +12393,141 @@
         "line_number": 28
       }
     ],
-    "src/agents/skills.build-workspace-skills-prompt.prefers-workspace-skills-managed-skills.e2e.test.ts": [
+    "src/agents/session-transcript-repair.attachments.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/skills.build-workspace-skills-prompt.prefers-workspace-skills-managed-skills.e2e.test.ts",
-        "hashed_secret": "7a85f4764bbd6daf1c3545efbbf0f279a6dc0beb",
+        "filename": "src/agents/session-transcript-repair.attachments.test.ts",
+        "hashed_secret": "d25df4833026f016b73dcfa20f33bf753daf7593",
         "is_verified": false,
-        "line_number": 103
-      }
-    ],
-    "src/agents/skills.build-workspace-skills-prompt.syncs-merged-skills-into-target-workspace.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/skills.build-workspace-skills-prompt.syncs-merged-skills-into-target-workspace.e2e.test.ts",
-        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
-        "is_verified": false,
-        "line_number": 147
-      }
-    ],
-    "src/agents/skills.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/skills.e2e.test.ts",
-        "hashed_secret": "5df3a673d724e8a1eb673a8baf623e183940804d",
-        "is_verified": false,
-        "line_number": 250
+        "line_number": 32
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/skills.e2e.test.ts",
+        "filename": "src/agents/session-transcript-repair.attachments.test.ts",
+        "hashed_secret": "30b1e9e71b6de9c2d579657e551b95f7eaae406d",
+        "is_verified": false,
+        "line_number": 47
+      }
+    ],
+    "src/agents/skills-install.download.test.ts": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/agents/skills-install.download.test.ts",
+        "hashed_secret": "459acf71d00174faf13cfeee88513702c82d3cb3",
+        "is_verified": false,
+        "line_number": 51
+      }
+    ],
+    "src/agents/skills.build-workspace-skills-prompt.prefers-workspace-skills-managed-skills.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/skills.build-workspace-skills-prompt.prefers-workspace-skills-managed-skills.test.ts",
+        "hashed_secret": "7a85f4764bbd6daf1c3545efbbf0f279a6dc0beb",
+        "is_verified": false,
+        "line_number": 118
+      }
+    ],
+    "src/agents/skills.build-workspace-skills-prompt.syncs-merged-skills-into-target-workspace.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/skills.build-workspace-skills-prompt.syncs-merged-skills-into-target-workspace.test.ts",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 181
+      }
+    ],
+    "src/agents/skills.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/skills.test.ts",
+        "hashed_secret": "5df3a673d724e8a1eb673a8baf623e183940804d",
+        "is_verified": false,
+        "line_number": 255
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/skills.test.ts",
         "hashed_secret": "8921daaa546693e52bc1f9c40bdcf15e816e0448",
         "is_verified": false,
-        "line_number": 277
-      }
-    ],
-    "src/agents/tools/web-fetch.firecrawl-api-key-normalization.e2e.test.ts": [
+        "line_number": 313
+      },
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-fetch.firecrawl-api-key-normalization.e2e.test.ts",
-        "hashed_secret": "9da08ab1e27fe0ae2ba6101aea30edcec02d21a4",
+        "filename": "src/agents/skills.test.ts",
+        "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
         "is_verified": false,
-        "line_number": 45
-      }
-    ],
-    "src/agents/tools/web-fetch.ssrf.e2e.test.ts": [
+        "line_number": 352
+      },
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-fetch.ssrf.e2e.test.ts",
+        "filename": "src/agents/skills.test.ts",
+        "hashed_secret": "895900e6b5d30fa84fbff6e4e4c10eb5a63c5f8f",
+        "is_verified": false,
+        "line_number": 427
+      }
+    ],
+    "src/agents/system-prompt.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/system-prompt.test.ts",
+        "hashed_secret": "0a111adae31992afa2873148fdfcaf39e70ec7d8",
+        "is_verified": false,
+        "line_number": 76
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/system-prompt.test.ts",
+        "hashed_secret": "2b3140fdd098f7cb2af72632ac2c0df772b8e90a",
+        "is_verified": false,
+        "line_number": 83
+      }
+    ],
+    "src/agents/tools/pdf-tool.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/tools/pdf-tool.test.ts",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 74
+      }
+    ],
+    "src/agents/tools/web-fetch.ssrf.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/tools/web-fetch.ssrf.test.ts",
         "hashed_secret": "5ce8e9d54c77266fff990194d2219a708c59b76c",
         "is_verified": false,
-        "line_number": 73
+        "line_number": 84
       }
     ],
-    "src/agents/tools/web-search.e2e.test.ts": [
+    "src/agents/tools/web-search.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-search.e2e.test.ts",
+        "filename": "src/agents/tools/web-search.test.ts",
         "hashed_secret": "c8d313eac6d38274ccfc0fa7935c68bd61d5bc2f",
         "is_verified": false,
-        "line_number": 129
+        "line_number": 105
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/tools/web-search.test.ts",
+        "hashed_secret": "1561970702b4bf5bb10266b292e545ec14fc602e",
+        "is_verified": false,
+        "line_number": 224
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/tools/web-search.test.ts",
+        "hashed_secret": "c930e4d402a279c3feea98578f716d5665c8cc5d",
+        "is_verified": false,
+        "line_number": 228
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/tools/web-search.test.ts",
+        "hashed_secret": "5c1a5088b7790a73e236f21d65a5e4384a742af0",
+        "is_verified": false,
+        "line_number": 231
       }
     ],
     "src/agents/tools/web-search.ts": [
@@ -11712,85 +12536,85 @@
         "filename": "src/agents/tools/web-search.ts",
         "hashed_secret": "dfba7aade0868074c2861c98e2a9a92f3178a51b",
         "is_verified": false,
-        "line_number": 97
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-search.ts",
-        "hashed_secret": "71f8e7976e4cbc4561c9d62fb283e7f788202acb",
-        "is_verified": false,
-        "line_number": 285
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-search.ts",
-        "hashed_secret": "c4865ff9250aca23b0d98eb079dad70ebec1cced",
-        "is_verified": false,
-        "line_number": 295
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-search.ts",
-        "hashed_secret": "527ee41f36386e85fa932ef09471ca017f3c95c8",
-        "is_verified": false,
-        "line_number": 298
+        "line_number": 254
       }
     ],
-    "src/agents/tools/web-tools.enabled-defaults.e2e.test.ts": [
+    "src/agents/tools/web-tools.enabled-defaults.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-tools.enabled-defaults.e2e.test.ts",
-        "hashed_secret": "47b249a75ca78fdb578d0f28c33685e27ea82684",
+        "filename": "src/agents/tools/web-tools.enabled-defaults.test.ts",
+        "hashed_secret": "f6558c30641dd2d38c6e8e7389dd724327c9627e",
         "is_verified": false,
-        "line_number": 181
+        "line_number": 53
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-tools.enabled-defaults.e2e.test.ts",
-        "hashed_secret": "d0ffd81d6d7ad1bc3c365660fe8882480c9a986e",
+        "filename": "src/agents/tools/web-tools.enabled-defaults.test.ts",
+        "hashed_secret": "59fa0cc80b21eb4ea49590dc887b95f5ae7e0bf5",
         "is_verified": false,
-        "line_number": 187
-      }
-    ],
-    "src/agents/tools/web-tools.fetch.e2e.test.ts": [
+        "line_number": 55
+      },
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-tools.fetch.e2e.test.ts",
+        "filename": "src/agents/tools/web-tools.enabled-defaults.test.ts",
+        "hashed_secret": "354a920b3d519d11b737695308dab1bfcf77dbb3",
+        "is_verified": false,
+        "line_number": 57
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/tools/web-tools.enabled-defaults.test.ts",
+        "hashed_secret": "7ec282d2630c12bf9241ef44db50f1f780cdaa79",
+        "is_verified": false,
+        "line_number": 59
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/tools/web-tools.enabled-defaults.test.ts",
+        "hashed_secret": "8ba65d9239fd59ffc16e202cb480d15e35bce964",
+        "is_verified": false,
+        "line_number": 60
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/tools/web-tools.enabled-defaults.test.ts",
+        "hashed_secret": "fb724421f6f4a53c0a73101ea88e4090cabb7b1a",
+        "is_verified": false,
+        "line_number": 461
+      }
+    ],
+    "src/agents/tools/web-tools.fetch.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/agents/tools/web-tools.fetch.test.ts",
         "hashed_secret": "5ce8e9d54c77266fff990194d2219a708c59b76c",
         "is_verified": false,
-        "line_number": 246
+        "line_number": 133
       }
     ],
-    "src/auto-reply/reply.directive.directive-behavior.prefers-alias-matches-fuzzy-selection-is-ambiguous.e2e.test.ts": [
+    "src/auto-reply/reply.directive.directive-behavior.prefers-alias-matches-fuzzy-selection-is-ambiguous.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/auto-reply/reply.directive.directive-behavior.prefers-alias-matches-fuzzy-selection-is-ambiguous.e2e.test.ts",
+        "filename": "src/auto-reply/reply.directive.directive-behavior.prefers-alias-matches-fuzzy-selection-is-ambiguous.test.ts",
         "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
         "is_verified": false,
-        "line_number": 56
+        "line_number": 60
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/auto-reply/reply.directive.directive-behavior.prefers-alias-matches-fuzzy-selection-is-ambiguous.e2e.test.ts",
+        "filename": "src/auto-reply/reply.directive.directive-behavior.prefers-alias-matches-fuzzy-selection-is-ambiguous.test.ts",
         "hashed_secret": "16c249e04e2be318050cb883c40137361c0c7209",
         "is_verified": false,
-        "line_number": 62
+        "line_number": 142
       }
     ],
-    "src/auto-reply/reply.directive.directive-behavior.supports-fuzzy-model-matches-model-directive.e2e.test.ts": [
+    "src/auto-reply/reply.triggers.trigger-handling.filters-usage-summary-current-model-provider.cases.ts": [
       {
-        "type": "Secret Keyword",
-        "filename": "src/auto-reply/reply.directive.directive-behavior.supports-fuzzy-model-matches-model-directive.e2e.test.ts",
-        "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
+        "type": "Hex High Entropy String",
+        "filename": "src/auto-reply/reply.triggers.trigger-handling.filters-usage-summary-current-model-provider.cases.ts",
+        "hashed_secret": "ff998abc1ce6d8f01a675fa197368e44c8916e9c",
         "is_verified": false,
-        "line_number": 42
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/auto-reply/reply.directive.directive-behavior.supports-fuzzy-model-matches-model-directive.e2e.test.ts",
-        "hashed_secret": "16c249e04e2be318050cb883c40137361c0c7209",
-        "is_verified": false,
-        "line_number": 149
+        "line_number": 216
       }
     ],
     "src/auto-reply/status.test.ts": [
@@ -11808,7 +12632,14 @@
         "filename": "src/browser/bridge-server.auth.test.ts",
         "hashed_secret": "6af3c121ed4a752936c297cddfb7b00394eabf10",
         "is_verified": false,
-        "line_number": 66
+        "line_number": 72
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/browser/bridge-server.auth.test.ts",
+        "hashed_secret": "26aaf463d1d85670b71c6a84a2f644ad5995efc8",
+        "is_verified": false,
+        "line_number": 93
       }
     ],
     "src/browser/browser-utils.test.ts": [
@@ -11817,14 +12648,14 @@
         "filename": "src/browser/browser-utils.test.ts",
         "hashed_secret": "4e126c049580d66ca1549fa534d95a7263f27f46",
         "is_verified": false,
-        "line_number": 38
+        "line_number": 43
       },
       {
         "type": "Basic Auth Credentials",
         "filename": "src/browser/browser-utils.test.ts",
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
-        "line_number": 159
+        "line_number": 164
       }
     ],
     "src/browser/cdp.test.ts": [
@@ -11833,7 +12664,23 @@
         "filename": "src/browser/cdp.test.ts",
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
-        "line_number": 186
+        "line_number": 243
+      }
+    ],
+    "src/channels/account-snapshot-fields.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/channels/account-snapshot-fields.test.ts",
+        "hashed_secret": "dfba7aade0868074c2861c98e2a9a92f3178a51b",
+        "is_verified": false,
+        "line_number": 10
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/channels/account-snapshot-fields.test.ts",
+        "hashed_secret": "071d3673192b4b44a84aa73ac9d00c155821303b",
+        "is_verified": false,
+        "line_number": 11
       }
     ],
     "src/channels/plugins/plugins-channel.test.ts": [
@@ -11842,16 +12689,98 @@
         "filename": "src/channels/plugins/plugins-channel.test.ts",
         "hashed_secret": "99c962e8c62296bdc9a17f5caf91ce9bb4c7e0e6",
         "is_verified": false,
-        "line_number": 46
+        "line_number": 64
       }
     ],
-    "src/cli/program.smoke.e2e.test.ts": [
+    "src/cli/acp-cli.option-collisions.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/cli/program.smoke.e2e.test.ts",
-        "hashed_secret": "8689a958b58e4a6f7da6211e666da8e17651697c",
+        "filename": "src/cli/acp-cli.option-collisions.test.ts",
+        "hashed_secret": "e5d0d3f3697f96d69545f36ab2eaf1f9d4e2a8f8",
         "is_verified": false,
-        "line_number": 215
+        "line_number": 94
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/cli/acp-cli.option-collisions.test.ts",
+        "hashed_secret": "8eac0f7ffe62469bf88ebdb208115f1ce3567d07",
+        "is_verified": false,
+        "line_number": 106
+      }
+    ],
+    "src/cli/command-secret-gateway.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/cli/command-secret-gateway.test.ts",
+        "hashed_secret": "68c46e84d76d2e7e686e5158bf598909abd4e45b",
+        "is_verified": false,
+        "line_number": 16
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/cli/command-secret-gateway.test.ts",
+        "hashed_secret": "3a20a67d6535d75cf0852a72a37e9c5a8fdb9976",
+        "is_verified": false,
+        "line_number": 120
+      }
+    ],
+    "src/cli/config-cli.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/cli/config-cli.test.ts",
+        "hashed_secret": "e774aaeac31c6272107ba89080295e277050fa7c",
+        "is_verified": false,
+        "line_number": 200
+      }
+    ],
+    "src/cli/daemon-cli/register-service-commands.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/cli/daemon-cli/register-service-commands.test.ts",
+        "hashed_secret": "d717176567cedb0012b6b5f4653f688bbb9ccb8b",
+        "is_verified": false,
+        "line_number": 67
+      }
+    ],
+    "src/cli/daemon-cli/status.gather.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/cli/daemon-cli/status.gather.test.ts",
+        "hashed_secret": "c09520299bf32111c9f2ebafaf5a9981ec51a91d",
+        "is_verified": false,
+        "line_number": 208
+      }
+    ],
+    "src/cli/program/register.onboard.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/cli/program/register.onboard.test.ts",
+        "hashed_secret": "5da1c2e689ee66cf379bc74d3eafd0460db70ca0",
+        "is_verified": false,
+        "line_number": 126
+      }
+    ],
+    "src/cli/qr-cli.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/cli/qr-cli.test.ts",
+        "hashed_secret": "8fc5be300f480d027174b514b563e77548b636f2",
+        "is_verified": false,
+        "line_number": 207
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/cli/qr-cli.test.ts",
+        "hashed_secret": "f1355ae408e2068355dad8f3a503c2eaedefc0c6",
+        "is_verified": false,
+        "line_number": 235
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/cli/qr-cli.test.ts",
+        "hashed_secret": "4316c1b21634c0e3f4d53bfb3ca2f48dde69bc4e",
+        "is_verified": false,
+        "line_number": 290
       }
     ],
     "src/cli/update-cli.test.ts": [
@@ -11860,51 +12789,64 @@
         "filename": "src/cli/update-cli.test.ts",
         "hashed_secret": "e4f91dd323bac5bfc4f60a6e433787671dc2421d",
         "is_verified": false,
-        "line_number": 239
+        "line_number": 277
       }
     ],
-    "src/commands/auth-choice.e2e.test.ts": [
+    "src/commands/auth-choice.apply-helpers.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "2480500ff391183070fe22ba8665a8be19350833",
+        "filename": "src/commands/auth-choice.apply-helpers.test.ts",
+        "hashed_secret": "69449f994d55805535b9e8fab16f6c39934e9ba4",
         "is_verified": false,
-        "line_number": 454
+        "line_number": 105
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "844ae5308654406d80db6f2b3d0beb07d616f9e1",
+        "filename": "src/commands/auth-choice.apply-helpers.test.ts",
+        "hashed_secret": "bea2f7b64fab8d1d414d0449530b1e088d36d5b1",
         "is_verified": false,
-        "line_number": 487
+        "line_number": 111
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "77e991e9f56e6fa4ed1a908208048421f1214c07",
+        "filename": "src/commands/auth-choice.apply-helpers.test.ts",
+        "hashed_secret": "d23a3625f8598b9cd747e74c1f1676f5ba7be530",
         "is_verified": false,
-        "line_number": 549
+        "line_number": 330
+      }
+    ],
+    "src/commands/auth-choice.apply.minimax.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/auth-choice.apply.minimax.test.ts",
+        "hashed_secret": "69449f994d55805535b9e8fab16f6c39934e9ba4",
+        "is_verified": false,
+        "line_number": 162
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "266e955b27b5fc2c2f532e446f2e71c3667a4cd9",
+        "filename": "src/commands/auth-choice.apply.minimax.test.ts",
+        "hashed_secret": "c090713b544ae4cabb48f2153079955947c6e013",
         "is_verified": false,
-        "line_number": 584
-      },
+        "line_number": 175
+      }
+    ],
+    "src/commands/auth-choice.apply.openai.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "1b4d8423b11d32dd0c466428ac81de84a4a9442b",
+        "filename": "src/commands/auth-choice.apply.openai.test.ts",
+        "hashed_secret": "c5831e54ef6edcf968300daf4a9a84580bc2ed37",
         "is_verified": false,
-        "line_number": 726
-      },
+        "line_number": 31
+      }
+    ],
+    "src/commands/auth-choice.apply.volcengine-byteplus.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "c24e00b94c972ed497d5961212ac96f0dffb4f7a",
+        "filename": "src/commands/auth-choice.apply.volcengine-byteplus.test.ts",
+        "hashed_secret": "69449f994d55805535b9e8fab16f6c39934e9ba4",
         "is_verified": false,
-        "line_number": 798
+        "line_number": 55
       }
     ],
     "src/commands/auth-choice.preferred-provider.ts": [
@@ -11916,29 +12858,105 @@
         "line_number": 8
       }
     ],
-    "src/commands/configure.gateway-auth.e2e.test.ts": [
+    "src/commands/auth-choice.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/commands/configure.gateway-auth.e2e.test.ts",
-        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "filename": "src/commands/auth-choice.test.ts",
+        "hashed_secret": "69449f994d55805535b9e8fab16f6c39934e9ba4",
         "is_verified": false,
-        "line_number": 21
+        "line_number": 679
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/commands/configure.gateway-auth.e2e.test.ts",
-        "hashed_secret": "d5d4cd07616a542891b7ec2d0257b3a24b69856e",
+        "filename": "src/commands/auth-choice.test.ts",
+        "hashed_secret": "c5831e54ef6edcf968300daf4a9a84580bc2ed37",
         "is_verified": false,
-        "line_number": 62
-      }
-    ],
-    "src/commands/daemon-install-helpers.e2e.test.ts": [
+        "line_number": 745
+      },
       {
         "type": "Secret Keyword",
-        "filename": "src/commands/daemon-install-helpers.e2e.test.ts",
+        "filename": "src/commands/auth-choice.test.ts",
+        "hashed_secret": "844ae5308654406d80db6f2b3d0beb07d616f9e1",
+        "is_verified": false,
+        "line_number": 955
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/auth-choice.test.ts",
+        "hashed_secret": "1c62e8a666fb3e1b8c9b0c1cab8e1d6bbb136580",
+        "is_verified": false,
+        "line_number": 1065
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/auth-choice.test.ts",
+        "hashed_secret": "1b4d8423b11d32dd0c466428ac81de84a4a9442b",
+        "is_verified": false,
+        "line_number": 1222
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/auth-choice.test.ts",
+        "hashed_secret": "c24e00b94c972ed497d5961212ac96f0dffb4f7a",
+        "is_verified": false,
+        "line_number": 1234
+      }
+    ],
+    "src/commands/channels.config-only-status-output.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/channels.config-only-status-output.test.ts",
+        "hashed_secret": "dfba7aade0868074c2861c98e2a9a92f3178a51b",
+        "is_verified": false,
+        "line_number": 149
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/channels.config-only-status-output.test.ts",
+        "hashed_secret": "071d3673192b4b44a84aa73ac9d00c155821303b",
+        "is_verified": false,
+        "line_number": 150
+      }
+    ],
+    "src/commands/configure.gateway-auth.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/configure.gateway-auth.test.ts",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_verified": false,
+        "line_number": 24
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/configure.gateway-auth.test.ts",
+        "hashed_secret": "d5d4cd07616a542891b7ec2d0257b3a24b69856e",
+        "is_verified": false,
+        "line_number": 65
+      }
+    ],
+    "src/commands/daemon-install-helpers.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/daemon-install-helpers.test.ts",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
         "line_number": 128
+      }
+    ],
+    "src/commands/doctor-gateway-auth-token.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/doctor-gateway-auth-token.test.ts",
+        "hashed_secret": "f1355ae408e2068355dad8f3a503c2eaedefc0c6",
+        "is_verified": false,
+        "line_number": 166
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/doctor-gateway-auth-token.test.ts",
+        "hashed_secret": "0b75f28abf6b39a10d1398ce5a95e93a5cebbbda",
+        "is_verified": false,
+        "line_number": 206
       }
     ],
     "src/commands/doctor-memory-search.test.ts": [
@@ -11947,53 +12965,75 @@
         "filename": "src/commands/doctor-memory-search.test.ts",
         "hashed_secret": "2e07956ffc9bc4fd624064c40b7495c85d5f1467",
         "is_verified": false,
-        "line_number": 38
-      }
-    ],
-    "src/commands/model-picker.e2e.test.ts": [
+        "line_number": 43
+      },
       {
         "type": "Secret Keyword",
-        "filename": "src/commands/model-picker.e2e.test.ts",
+        "filename": "src/commands/doctor-memory-search.test.ts",
+        "hashed_secret": "e774aaeac31c6272107ba89080295e277050fa7c",
+        "is_verified": false,
+        "line_number": 278
+      }
+    ],
+    "src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts",
+        "hashed_secret": "f3c7399f056377fc3dae16a9854fe636b720d3d0",
+        "is_verified": false,
+        "line_number": 98
+      }
+    ],
+    "src/commands/gateway-install-token.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/gateway-install-token.test.ts",
+        "hashed_secret": "f3c7399f056377fc3dae16a9854fe636b720d3d0",
+        "is_verified": false,
+        "line_number": 143
+      }
+    ],
+    "src/commands/gateway-status/helpers.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/gateway-status/helpers.test.ts",
+        "hashed_secret": "1e1ff291f3b48b7e5b54828396f264ba43379076",
+        "is_verified": false,
+        "line_number": 183
+      }
+    ],
+    "src/commands/message.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/message.test.ts",
+        "hashed_secret": "3bb1ec510d35ab2af7d05d8bbd5f0820333f1a0d",
+        "is_verified": false,
+        "line_number": 194
+      }
+    ],
+    "src/commands/model-picker.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/model-picker.test.ts",
         "hashed_secret": "5b924ca5330ede58702a5b0e414207b90fb1aef3",
         "is_verified": false,
-        "line_number": 127
+        "line_number": 105
       }
     ],
-    "src/commands/models/list.status.e2e.test.ts": [
+    "src/commands/onboard-auth.config-core.kilocode.test.ts": [
       {
-        "type": "Base64 High Entropy String",
-        "filename": "src/commands/models/list.status.e2e.test.ts",
-        "hashed_secret": "d6ae2508a78a232d5378ef24b85ce40cbb4d7ff0",
+        "type": "Secret Keyword",
+        "filename": "src/commands/onboard-auth.config-core.kilocode.test.ts",
+        "hashed_secret": "01800a0712a2a1aa928b95c4745e9ee06673925b",
         "is_verified": false,
-        "line_number": 12
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "src/commands/models/list.status.e2e.test.ts",
-        "hashed_secret": "2d8012102440ea97852b3152239218f00579bafa",
-        "is_verified": false,
-        "line_number": 19
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "src/commands/models/list.status.e2e.test.ts",
-        "hashed_secret": "51848e2be4b461a549218d3167f19c01be6b98b8",
-        "is_verified": false,
-        "line_number": 51
+        "line_number": 163
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/commands/models/list.status.e2e.test.ts",
-        "hashed_secret": "51848e2be4b461a549218d3167f19c01be6b98b8",
+        "filename": "src/commands/onboard-auth.config-core.kilocode.test.ts",
+        "hashed_secret": "8d2ce71c6723bf46f6c166984b4ddb597f92322a",
         "is_verified": false,
-        "line_number": 51
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/models/list.status.e2e.test.ts",
-        "hashed_secret": "1c1e381bfb72d3b7bfca9437053d9875356680f0",
-        "is_verified": false,
-        "line_number": 57
+        "line_number": 190
       }
     ],
     "src/commands/onboard-auth.config-minimax.ts": [
@@ -12002,104 +13042,53 @@
         "filename": "src/commands/onboard-auth.config-minimax.ts",
         "hashed_secret": "16c249e04e2be318050cb883c40137361c0c7209",
         "is_verified": false,
-        "line_number": 36
+        "line_number": 37
       },
       {
         "type": "Secret Keyword",
         "filename": "src/commands/onboard-auth.config-minimax.ts",
         "hashed_secret": "ddcb713196b974770575a9bea5a4e7d46361f8e9",
         "is_verified": false,
-        "line_number": 78
+        "line_number": 79
       }
     ],
-    "src/commands/onboard-auth.e2e.test.ts": [
+    "src/commands/onboard-auth.credentials.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/commands/onboard-auth.e2e.test.ts",
-        "hashed_secret": "e184b402822abc549b37689c84e8e0e33c39a1f1",
+        "filename": "src/commands/onboard-auth.credentials.test.ts",
+        "hashed_secret": "69449f994d55805535b9e8fab16f6c39934e9ba4",
         "is_verified": false,
-        "line_number": 272
-      }
-    ],
-    "src/commands/onboard-custom.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-custom.e2e.test.ts",
-        "hashed_secret": "62e6748c6bb4c4a0f785a28cdd7d41ef212c0091",
-        "is_verified": false,
-        "line_number": 238
-      }
-    ],
-    "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "fcdd655b11f33ba4327695084a347b2ba192976c",
-        "is_verified": false,
-        "line_number": 153
+        "line_number": 97
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "07a6b9cec637c806195e8aa7e5c0851ab03dc35e",
+        "filename": "src/commands/onboard-auth.credentials.test.ts",
+        "hashed_secret": "3fabe94b84be76552a40fab6d3284697b136ea23",
+        "is_verified": false,
+        "line_number": 139
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/onboard-auth.credentials.test.ts",
+        "hashed_secret": "aec738f7a0d1056bee31567d522e7191a13ce31a",
+        "is_verified": false,
+        "line_number": 190
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/onboard-auth.credentials.test.ts",
+        "hashed_secret": "9705dbfd5f922106b199746632af2b66b02c3f0a",
         "is_verified": false,
         "line_number": 191
-      },
+      }
+    ],
+    "src/commands/onboard-auth.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "77e991e9f56e6fa4ed1a908208048421f1214c07",
+        "filename": "src/commands/onboard-auth.test.ts",
+        "hashed_secret": "e184b402822abc549b37689c84e8e0e33c39a1f1",
         "is_verified": false,
-        "line_number": 234
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "65547299f940eca3dc839f3eac85e8a78a6deb05",
-        "is_verified": false,
-        "line_number": 282
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "2833d098c110602e4c8d577fbfdb423a9ffd58e9",
-        "is_verified": false,
-        "line_number": 304
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "266e955b27b5fc2c2f532e446f2e71c3667a4cd9",
-        "is_verified": false,
-        "line_number": 338
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "995b80728ee01edb90ddfed07870bbab405df19f",
-        "is_verified": false,
-        "line_number": 366
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "b65888424ecafcc98bfd803b24817e4dadf821f8",
-        "is_verified": false,
-        "line_number": 383
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "62e6748c6bb4c4a0f785a28cdd7d41ef212c0091",
-        "is_verified": false,
-        "line_number": 402
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "8818d3b7c102fd6775af9e1390e5ed3a128473fb",
-        "is_verified": false,
-        "line_number": 447
+        "line_number": 423
       }
     ],
     "src/commands/onboard-non-interactive/api-keys.ts": [
@@ -12108,7 +13097,7 @@
         "filename": "src/commands/onboard-non-interactive/api-keys.ts",
         "hashed_secret": "112f3a99b283a4e1788dedd8e0e5d35375c33747",
         "is_verified": false,
-        "line_number": 11
+        "line_number": 12
       }
     ],
     "src/commands/status.update.test.ts": [
@@ -12129,13 +13118,13 @@
         "line_number": 60
       }
     ],
-    "src/commands/zai-endpoint-detect.e2e.test.ts": [
+    "src/commands/zai-endpoint-detect.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/commands/zai-endpoint-detect.e2e.test.ts",
+        "filename": "src/commands/zai-endpoint-detect.test.ts",
         "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
         "is_verified": false,
-        "line_number": 24
+        "line_number": 61
       }
     ],
     "src/config/config-misc.test.ts": [
@@ -12144,7 +13133,7 @@
         "filename": "src/config/config-misc.test.ts",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 62
+        "line_number": 102
       }
     ],
     "src/config/config.env-vars.test.ts": [
@@ -12188,20 +13177,71 @@
         "line_number": 33
       }
     ],
+    "src/config/config.web-search-provider.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/config.web-search-provider.test.ts",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 19
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/config.web-search-provider.test.ts",
+        "hashed_secret": "a704b0feaf024ae73cda6859104dd323bc36b451",
+        "is_verified": false,
+        "line_number": 78
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/config.web-search-provider.test.ts",
+        "hashed_secret": "6984b2d1edb45c9ba5de8d29e9cd9a2613c6a170",
+        "is_verified": false,
+        "line_number": 83
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/config.web-search-provider.test.ts",
+        "hashed_secret": "bfe8fe037d4fe1aa6c0aeecf94efe2ebc265c6f8",
+        "is_verified": false,
+        "line_number": 88
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/config.web-search-provider.test.ts",
+        "hashed_secret": "4ee210c6480582752ad7f74c74bd63a3d4531e51",
+        "is_verified": false,
+        "line_number": 93
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/config.web-search-provider.test.ts",
+        "hashed_secret": "6d166fccc1c1a5193f7f7397705c84a184d68c0e",
+        "is_verified": false,
+        "line_number": 98
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/config.web-search-provider.test.ts",
+        "hashed_secret": "0f7f0fad47a1470a44be65dac2b848a99e28302c",
+        "is_verified": false,
+        "line_number": 108
+      }
+    ],
     "src/config/env-preserve-io.test.ts": [
       {
         "type": "Secret Keyword",
         "filename": "src/config/env-preserve-io.test.ts",
         "hashed_secret": "85639f0560fd9bf8704f52e01c5e764c9ed5a6aa",
         "is_verified": false,
-        "line_number": 59
+        "line_number": 31
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/env-preserve-io.test.ts",
         "hashed_secret": "996650087ab48bdb1ca80f0842c97d4fbb6f1c71",
         "is_verified": false,
-        "line_number": 86
+        "line_number": 75
       }
     ],
     "src/config/env-preserve.test.ts": [
@@ -12240,28 +13280,37 @@
         "filename": "src/config/env-substitution.test.ts",
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_verified": false,
-        "line_number": 37
+        "line_number": 80
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/env-substitution.test.ts",
         "hashed_secret": "ec417f567082612f8fd6afafe1abcab831fca840",
         "is_verified": false,
-        "line_number": 68
+        "line_number": 100
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/env-substitution.test.ts",
         "hashed_secret": "520bd69c3eb1646d9a78181ecb4c90c51fdf428d",
         "is_verified": false,
-        "line_number": 69
+        "line_number": 101
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/env-substitution.test.ts",
         "hashed_secret": "f136444bf9b3d01a9f9b772b80ac6bf7b6a43ef0",
         "is_verified": false,
-        "line_number": 227
+        "line_number": 282
+      }
+    ],
+    "src/config/io.runtime-snapshot-write.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/io.runtime-snapshot-write.test.ts",
+        "hashed_secret": "c7106700045d8a274b6702325ecf9bcb60d42318",
+        "is_verified": false,
+        "line_number": 34
       }
     ],
     "src/config/io.write-config.test.ts": [
@@ -12270,7 +13319,7 @@
         "filename": "src/config/io.write-config.test.ts",
         "hashed_secret": "13951588fd3325e25ed1e3b116d7009fb221c85e",
         "is_verified": false,
-        "line_number": 65
+        "line_number": 289
       }
     ],
     "src/config/model-alias-defaults.test.ts": [
@@ -12279,107 +13328,163 @@
         "filename": "src/config/model-alias-defaults.test.ts",
         "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
         "is_verified": false,
-        "line_number": 66
-      }
-    ],
-    "src/config/redact-snapshot.test.ts": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "src/config/redact-snapshot.test.ts",
-        "hashed_secret": "3732e17b2d11ed6c64fef02c341958007af154e7",
-        "is_verified": false,
-        "line_number": 77
+        "line_number": 13
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/config/redact-snapshot.test.ts",
-        "hashed_secret": "3732e17b2d11ed6c64fef02c341958007af154e7",
+        "filename": "src/config/model-alias-defaults.test.ts",
+        "hashed_secret": "fa9144b340ea7886885669e2e7a808c86ee14a07",
         "is_verified": false,
-        "line_number": 77
-      },
+        "line_number": 114
+      }
+    ],
+    "src/config/redact-snapshot.test.ts": [
       {
         "type": "Secret Keyword",
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "7f413afd37447cd321d79286be0f58d7a9875d9b",
         "is_verified": false,
-        "line_number": 89
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/config/redact-snapshot.test.ts",
-        "hashed_secret": "c21afa950dee2a70f3e0f6ffdfbc87f8edb90262",
-        "is_verified": false,
-        "line_number": 99
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/config/redact-snapshot.test.ts",
-        "hashed_secret": "83a9937c6de261ffda22304834f30fe6c8f97926",
-        "is_verified": false,
-        "line_number": 110
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/config/redact-snapshot.test.ts",
-        "hashed_secret": "87ac76dfc9cba93bead43c191e31bd099a97cc11",
-        "is_verified": false,
-        "line_number": 198
+        "line_number": 78
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "abb1aabcd0e49019c2873944a40671a80ccd64c7",
         "is_verified": false,
-        "line_number": 309
+        "line_number": 84
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/redact-snapshot.test.ts",
+        "hashed_secret": "83a9937c6de261ffda22304834f30fe6c8f97926",
+        "is_verified": false,
+        "line_number": 88
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/redact-snapshot.test.ts",
+        "hashed_secret": "c21afa950dee2a70f3e0f6ffdfbc87f8edb90262",
+        "is_verified": false,
+        "line_number": 91
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/config/redact-snapshot.test.ts",
+        "hashed_secret": "3732e17b2d11ed6c64fef02c341958007af154e7",
+        "is_verified": false,
+        "line_number": 95
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/redact-snapshot.test.ts",
+        "hashed_secret": "3732e17b2d11ed6c64fef02c341958007af154e7",
+        "is_verified": false,
+        "line_number": 95
+      },
+      {
+        "type": "Private Key",
+        "filename": "src/config/redact-snapshot.test.ts",
+        "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
+        "is_verified": false,
+        "line_number": 123
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/redact-snapshot.test.ts",
+        "hashed_secret": "87ac76dfc9cba93bead43c191e31bd099a97cc11",
+        "is_verified": false,
+        "line_number": 227
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/redact-snapshot.test.ts",
+        "hashed_secret": "939bb46a04c3640c8c427e92b1b557e882e2d2a0",
+        "is_verified": false,
+        "line_number": 262
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/redact-snapshot.test.ts",
+        "hashed_secret": "7505d64a54e061b7acd54ccd58b49dc43500b635",
+        "is_verified": false,
+        "line_number": 302
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "8e22880b4e96bab354e1da6c91d2f58dabde3555",
         "is_verified": false,
-        "line_number": 321
+        "line_number": 397
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "8e22880b4e96bab354e1da6c91d2f58dabde3555",
         "is_verified": false,
-        "line_number": 321
+        "line_number": 397
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "a9c732e05044a08c760cce7f6d142cd0d35a19e5",
         "is_verified": false,
-        "line_number": 375
+        "line_number": 455
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "50843dd5651cfafbe7c5611c1eed195c63e6e3fd",
         "is_verified": false,
-        "line_number": 691
+        "line_number": 771
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/redact-snapshot.test.ts",
+        "hashed_secret": "22edfa62d61f01fead87e40562f8c8a51caa2806",
+        "is_verified": false,
+        "line_number": 783
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/redact-snapshot.test.ts",
+        "hashed_secret": "33e65bb7ffff7e05b434318409b212f8724bc961",
+        "is_verified": false,
+        "line_number": 806
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/redact-snapshot.test.ts",
+        "hashed_secret": "dc2e131fd7ef4cf84345ad7f6c92c3d656051ede",
+        "is_verified": false,
+        "line_number": 831
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/redact-snapshot.test.ts",
+        "hashed_secret": "0834708d0ed84f1d023353afc867fb0a4e5ebfea",
+        "is_verified": false,
+        "line_number": 838
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "927e7cdedcb8f71af399a49fb90a381df8b8df28",
         "is_verified": false,
-        "line_number": 808
+        "line_number": 1007
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "1996cc327bd39dad69cd8feb24250dafd51e7c08",
         "is_verified": false,
-        "line_number": 814
+        "line_number": 1013
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "a5c0a65a4fa8874a486aa5072671927ceba82a90",
         "is_verified": false,
-        "line_number": 838
+        "line_number": 1037
       }
     ],
     "src/config/schema.help.ts": [
@@ -12388,14 +13493,14 @@
         "filename": "src/config/schema.help.ts",
         "hashed_secret": "9f4cda226d3868676ac7f86f59e4190eb94bd208",
         "is_verified": false,
-        "line_number": 647
+        "line_number": 649
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/schema.help.ts",
         "hashed_secret": "01822c8bbf6a8b136944b14182cb885100ec2eae",
         "is_verified": false,
-        "line_number": 678
+        "line_number": 680
       }
     ],
     "src/config/schema.irc.ts": [
@@ -12434,20 +13539,45 @@
         "filename": "src/config/schema.labels.ts",
         "hashed_secret": "e73c9fcad85cd4eecc74181ec4bdb31064d68439",
         "is_verified": false,
-        "line_number": 104
+        "line_number": 216
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/schema.labels.ts",
         "hashed_secret": "2eda7cd978f39eebec3bf03e4410a40e14167fff",
         "is_verified": false,
-        "line_number": 145
+        "line_number": 324
       }
     ],
     "src/config/slack-http-config.test.ts": [
       {
         "type": "Secret Keyword",
         "filename": "src/config/slack-http-config.test.ts",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_verified": false,
+        "line_number": 10
+      }
+    ],
+    "src/config/talk.normalize.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/talk.normalize.test.ts",
+        "hashed_secret": "dff6d4ff5dc357cf451d1855ab9cbda562645c9f",
+        "is_verified": false,
+        "line_number": 30
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/talk.normalize.test.ts",
+        "hashed_secret": "653d2545f6d16efa76ad7740bab466e175c4efd3",
+        "is_verified": false,
+        "line_number": 101
+      }
+    ],
+    "src/config/telegram-webhook-port.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/config/telegram-webhook-port.test.ts",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
         "line_number": 10
@@ -12462,13 +13592,20 @@
         "line_number": 10
       }
     ],
-    "src/docker-setup.test.ts": [
+    "src/docker-setup.e2e.test.ts": [
       {
         "type": "Base64 High Entropy String",
-        "filename": "src/docker-setup.test.ts",
+        "filename": "src/docker-setup.e2e.test.ts",
         "hashed_secret": "32ac33b537769e97787f70ef85576cc243fab934",
         "is_verified": false,
-        "line_number": 131
+        "line_number": 178
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/docker-setup.e2e.test.ts",
+        "hashed_secret": "299e5b3d10d301eb479c0b84b16d750cb799e274",
+        "is_verified": false,
+        "line_number": 250
       }
     ],
     "src/gateway/auth-rate-limit.ts": [
@@ -12477,7 +13614,7 @@
         "filename": "src/gateway/auth-rate-limit.ts",
         "hashed_secret": "76ed0a056aa77060de25754586440cff390791d0",
         "is_verified": false,
-        "line_number": 37
+        "line_number": 39
       }
     ],
     "src/gateway/auth.test.ts": [
@@ -12486,88 +13623,241 @@
         "filename": "src/gateway/auth.test.ts",
         "hashed_secret": "db5543cd7440bbdc4c5aaf8aa363715c31dd5a27",
         "is_verified": false,
-        "line_number": 32
+        "line_number": 95
       },
       {
         "type": "Secret Keyword",
         "filename": "src/gateway/auth.test.ts",
         "hashed_secret": "d51f846285cbc6d1dd76677a0fd588c8df44e506",
         "is_verified": false,
-        "line_number": 48
+        "line_number": 112
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/auth.test.ts",
+        "hashed_secret": "052f076c732648ab32d2fcde9fe255319bfa0c7b",
+        "is_verified": false,
+        "line_number": 128
       },
       {
         "type": "Secret Keyword",
         "filename": "src/gateway/auth.test.ts",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 95
+        "line_number": 254
       },
       {
         "type": "Secret Keyword",
         "filename": "src/gateway/auth.test.ts",
         "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
         "is_verified": false,
-        "line_number": 103
+        "line_number": 262
       }
     ],
     "src/gateway/call.test.ts": [
       {
         "type": "Secret Keyword",
         "filename": "src/gateway/call.test.ts",
+        "hashed_secret": "2e07956ffc9bc4fd624064c40b7495c85d5f1467",
+        "is_verified": false,
+        "line_number": 90
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/call.test.ts",
         "hashed_secret": "db5543cd7440bbdc4c5aaf8aa363715c31dd5a27",
         "is_verified": false,
-        "line_number": 357
+        "line_number": 607
       },
       {
         "type": "Secret Keyword",
         "filename": "src/gateway/call.test.ts",
         "hashed_secret": "de1c41e8ece73f5d5c259bb37eccb59a542b91dc",
         "is_verified": false,
-        "line_number": 361
+        "line_number": 611
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/call.test.ts",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 638
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/call.test.ts",
+        "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
+        "is_verified": false,
+        "line_number": 646
       },
       {
         "type": "Secret Keyword",
         "filename": "src/gateway/call.test.ts",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 398
+        "line_number": 683
       },
       {
         "type": "Secret Keyword",
         "filename": "src/gateway/call.test.ts",
         "hashed_secret": "e493f561d90c6638c1f51c5a8a069c3b129b79ed",
         "is_verified": false,
-        "line_number": 408
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/gateway/call.test.ts",
-        "hashed_secret": "2e07956ffc9bc4fd624064c40b7495c85d5f1467",
-        "is_verified": false,
-        "line_number": 413
+        "line_number": 690
       },
       {
         "type": "Secret Keyword",
         "filename": "src/gateway/call.test.ts",
         "hashed_secret": "bddc29032de580fb53b3a9a0357dd409086db800",
         "is_verified": false,
-        "line_number": 426
+        "line_number": 704
       },
       {
         "type": "Secret Keyword",
         "filename": "src/gateway/call.test.ts",
-        "hashed_secret": "6255675480f681df08c1704b7b3cd2c49917f0e2",
+        "hashed_secret": "2e7d14ce1d0b584f112cca09f638557e42a2617b",
         "is_verified": false,
-        "line_number": 463
+        "line_number": 724
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/call.test.ts",
+        "hashed_secret": "802c9dbd2953f682a244abc0ec00ad564ac0eb7d",
+        "is_verified": false,
+        "line_number": 869
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/call.test.ts",
+        "hashed_secret": "1e1ff291f3b48b7e5b54828396f264ba43379076",
+        "is_verified": false,
+        "line_number": 901
       }
     ],
-    "src/gateway/client.e2e.test.ts": [
+    "src/gateway/client.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/client.test.ts",
+        "hashed_secret": "2c35baf5aa803a12df64c64b97df0445c46aeb03",
+        "is_verified": false,
+        "line_number": 126
+      }
+    ],
+    "src/gateway/client.watchdog.test.ts": [
       {
         "type": "Private Key",
-        "filename": "src/gateway/client.e2e.test.ts",
+        "filename": "src/gateway/client.watchdog.test.ts",
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
         "is_verified": false,
-        "line_number": 85
+        "line_number": 89
+      }
+    ],
+    "src/gateway/credential-precedence.parity.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/credential-precedence.parity.test.ts",
+        "hashed_secret": "db5543cd7440bbdc4c5aaf8aa363715c31dd5a27",
+        "is_verified": false,
+        "line_number": 24
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/credential-precedence.parity.test.ts",
+        "hashed_secret": "de1c41e8ece73f5d5c259bb37eccb59a542b91dc",
+        "is_verified": false,
+        "line_number": 34
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/credential-precedence.parity.test.ts",
+        "hashed_secret": "052f076c732648ab32d2fcde9fe255319bfa0c7b",
+        "is_verified": false,
+        "line_number": 80
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/credential-precedence.parity.test.ts",
+        "hashed_secret": "1e1ff291f3b48b7e5b54828396f264ba43379076",
+        "is_verified": false,
+        "line_number": 99
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/credential-precedence.parity.test.ts",
+        "hashed_secret": "d51f846285cbc6d1dd76677a0fd588c8df44e506",
+        "is_verified": false,
+        "line_number": 132
+      }
+    ],
+    "src/gateway/credentials.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/credentials.test.ts",
+        "hashed_secret": "052f076c732648ab32d2fcde9fe255319bfa0c7b",
+        "is_verified": false,
+        "line_number": 15
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/credentials.test.ts",
+        "hashed_secret": "1e1ff291f3b48b7e5b54828396f264ba43379076",
+        "is_verified": false,
+        "line_number": 16
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/credentials.test.ts",
+        "hashed_secret": "db5543cd7440bbdc4c5aaf8aa363715c31dd5a27",
+        "is_verified": false,
+        "line_number": 19
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/credentials.test.ts",
+        "hashed_secret": "6255675480f681df08c1704b7b3cd2c49917f0e2",
+        "is_verified": false,
+        "line_number": 60
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/credentials.test.ts",
+        "hashed_secret": "de1c41e8ece73f5d5c259bb37eccb59a542b91dc",
+        "is_verified": false,
+        "line_number": 240
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/credentials.test.ts",
+        "hashed_secret": "e951da0670d747fb42c25e584913ced2a22df456",
+        "is_verified": false,
+        "line_number": 271
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/credentials.test.ts",
+        "hashed_secret": "c4268595e9bc82fd8385d7f5c31cff96d677e31d",
+        "is_verified": false,
+        "line_number": 282
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/credentials.test.ts",
+        "hashed_secret": "bc5f9ea9a906cf0641cf9e227b6b9ae3cdc9df59",
+        "is_verified": false,
+        "line_number": 298
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/credentials.test.ts",
+        "hashed_secret": "d51f846285cbc6d1dd76677a0fd588c8df44e506",
+        "is_verified": false,
+        "line_number": 468
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/credentials.test.ts",
+        "hashed_secret": "60acdb59369429ffd0729487ec638eb0f7f12976",
+        "is_verified": false,
+        "line_number": 487
       }
     ],
     "src/gateway/gateway-cli-backend.live.test.ts": [
@@ -12576,7 +13866,7 @@
         "filename": "src/gateway/gateway-cli-backend.live.test.ts",
         "hashed_secret": "3e2fd4a90d5afbd27974730c4d6a9592fe300825",
         "is_verified": false,
-        "line_number": 38
+        "line_number": 45
       }
     ],
     "src/gateway/gateway-models.profiles.live.test.ts": [
@@ -12585,7 +13875,16 @@
         "filename": "src/gateway/gateway-models.profiles.live.test.ts",
         "hashed_secret": "3e2fd4a90d5afbd27974730c4d6a9592fe300825",
         "is_verified": false,
-        "line_number": 242
+        "line_number": 384
+      }
+    ],
+    "src/gateway/server-methods/push.test.ts": [
+      {
+        "type": "Private Key",
+        "filename": "src/gateway/server-methods/push.test.ts",
+        "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
+        "is_verified": false,
+        "line_number": 81
       }
     ],
     "src/gateway/server-methods/skills.update.normalizes-api-key.test.ts": [
@@ -12603,41 +13902,34 @@
         "filename": "src/gateway/server-methods/talk.ts",
         "hashed_secret": "e478a5eeba4907d2f12a68761996b9de745d826d",
         "is_verified": false,
-        "line_number": 13
+        "line_number": 14
       }
     ],
-    "src/gateway/server.auth.e2e.test.ts": [
+    "src/gateway/server.auth.control-ui.suite.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/gateway/server.auth.e2e.test.ts",
+        "filename": "src/gateway/server.auth.control-ui.suite.ts",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 460
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/gateway/server.auth.e2e.test.ts",
-        "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
-        "is_verified": false,
-        "line_number": 478
+        "line_number": 239
       }
     ],
-    "src/gateway/server.skills-status.e2e.test.ts": [
+    "src/gateway/server.skills-status.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/gateway/server.skills-status.e2e.test.ts",
+        "filename": "src/gateway/server.skills-status.test.ts",
         "hashed_secret": "1cc6bff0f84efb2d3ff4fa1347f3b2bc173aaff0",
         "is_verified": false,
-        "line_number": 13
+        "line_number": 14
       }
     ],
-    "src/gateway/server.talk-config.e2e.test.ts": [
+    "src/gateway/server.talk-config.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/gateway/server.talk-config.e2e.test.ts",
+        "filename": "src/gateway/server.talk-config.test.ts",
         "hashed_secret": "3c310634864babb081f0b617c14bc34823d7e369",
         "is_verified": false,
-        "line_number": 13
+        "line_number": 70
       }
     ],
     "src/gateway/session-utils.test.ts": [
@@ -12646,7 +13938,37 @@
         "filename": "src/gateway/session-utils.test.ts",
         "hashed_secret": "bb9a5d9483409d2c60b28268a0efcb93324d4cda",
         "is_verified": false,
-        "line_number": 280
+        "line_number": 563
+      }
+    ],
+    "src/gateway/startup-auth.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/startup-auth.test.ts",
+        "hashed_secret": "1951c80555441588e8707fa68a6084a91c8a114a",
+        "is_verified": false,
+        "line_number": 125
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/startup-auth.test.ts",
+        "hashed_secret": "0b75f28abf6b39a10d1398ce5a95e93a5cebbbda",
+        "is_verified": false,
+        "line_number": 255
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/startup-auth.test.ts",
+        "hashed_secret": "f1355ae408e2068355dad8f3a503c2eaedefc0c6",
+        "is_verified": false,
+        "line_number": 282
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/gateway/startup-auth.test.ts",
+        "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
+        "is_verified": false,
+        "line_number": 448
       }
     ],
     "src/gateway/test-openai-responses-model.ts": [
@@ -12673,14 +13995,14 @@
         "filename": "src/infra/env.test.ts",
         "hashed_secret": "df98a117ddabf85991b9fe0e268214dc0e1254dc",
         "is_verified": false,
-        "line_number": 9
+        "line_number": 7
       },
       {
         "type": "Secret Keyword",
         "filename": "src/infra/env.test.ts",
         "hashed_secret": "6d811dc1f59a55ca1a3d38b5042a062b9f79e8ec",
         "is_verified": false,
-        "line_number": 30
+        "line_number": 14
       }
     ],
     "src/infra/outbound/message-action-runner.test.ts": [
@@ -12689,14 +14011,14 @@
         "filename": "src/infra/outbound/message-action-runner.test.ts",
         "hashed_secret": "804ec071803318791b835cffd6e509c8d32239db",
         "is_verified": false,
-        "line_number": 129
+        "line_number": 180
       },
       {
         "type": "Secret Keyword",
         "filename": "src/infra/outbound/message-action-runner.test.ts",
         "hashed_secret": "789cbe0407840b1c2041cb33452ff60f19bf58cc",
         "is_verified": false,
-        "line_number": 435
+        "line_number": 529
       }
     ],
     "src/infra/outbound/outbound.test.ts": [
@@ -12705,7 +14027,7 @@
         "filename": "src/infra/outbound/outbound.test.ts",
         "hashed_secret": "804ec071803318791b835cffd6e509c8d32239db",
         "is_verified": false,
-        "line_number": 631
+        "line_number": 850
       }
     ],
     "src/infra/provider-usage.auth.normalizes-keys.test.ts": [
@@ -12731,27 +14053,36 @@
         "line_number": 125
       }
     ],
+    "src/infra/push-apns.test.ts": [
+      {
+        "type": "Private Key",
+        "filename": "src/infra/push-apns.test.ts",
+        "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
+        "is_verified": false,
+        "line_number": 80
+      }
+    ],
     "src/infra/shell-env.test.ts": [
       {
         "type": "Secret Keyword",
         "filename": "src/infra/shell-env.test.ts",
         "hashed_secret": "65c10dc3549fe07424148a8a4790a3341ecbc253",
         "is_verified": false,
-        "line_number": 26
+        "line_number": 133
       },
       {
         "type": "Secret Keyword",
         "filename": "src/infra/shell-env.test.ts",
         "hashed_secret": "e013ffda590d2178607c16d11b1ea42f75ceb0e7",
         "is_verified": false,
-        "line_number": 58
+        "line_number": 165
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/infra/shell-env.test.ts",
         "hashed_secret": "be6ee9a6bf9f2dad84a5a67d6c0576a5bacc391e",
         "is_verified": false,
-        "line_number": 60
+        "line_number": 167
       }
     ],
     "src/line/accounts.test.ts": [
@@ -12783,7 +14114,14 @@
         "filename": "src/line/bot-handlers.test.ts",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 106
+        "line_number": 107
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/line/bot-handlers.test.ts",
+        "hashed_secret": "d76baddf1b9e3d8e31216f22c73d65d2e91ada7b",
+        "is_verified": false,
+        "line_number": 358
       }
     ],
     "src/line/bot-message-context.test.ts": [
@@ -12793,6 +14131,13 @@
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
         "line_number": 18
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/line/bot-message-context.test.ts",
+        "hashed_secret": "d369d8c413645b43df8ac26be7295cd15a64f9bf",
+        "is_verified": false,
+        "line_number": 179
       }
     ],
     "src/line/monitor.fail-closed.test.ts": [
@@ -12802,6 +14147,15 @@
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
         "line_number": 22
+      }
+    ],
+    "src/line/monitor.lifecycle.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/line/monitor.lifecycle.test.ts",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_verified": false,
+        "line_number": 91
       }
     ],
     "src/line/webhook-node.test.ts": [
@@ -12819,7 +14173,7 @@
         "filename": "src/line/webhook.test.ts",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 23
+        "line_number": 21
       }
     ],
     "src/logging/redact.test.ts": [
@@ -12852,13 +14206,22 @@
         "line_number": 88
       }
     ],
-    "src/media-understanding/apply.e2e.test.ts": [
+    "src/media-understanding/apply.echo-transcript.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/media-understanding/apply.e2e.test.ts",
+        "filename": "src/media-understanding/apply.echo-transcript.test.ts",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 12
+        "line_number": 15
+      }
+    ],
+    "src/media-understanding/apply.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/media-understanding/apply.test.ts",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 17
       }
     ],
     "src/media-understanding/providers/deepgram/audio.test.ts": [
@@ -12867,7 +14230,7 @@
         "filename": "src/media-understanding/providers/deepgram/audio.test.ts",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 27
+        "line_number": 20
       }
     ],
     "src/media-understanding/providers/google/video.test.ts": [
@@ -12876,7 +14239,23 @@
         "filename": "src/media-understanding/providers/google/video.test.ts",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 64
+        "line_number": 56
+      }
+    ],
+    "src/media-understanding/providers/mistral/index.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/media-understanding/providers/mistral/index.test.ts",
+        "hashed_secret": "5b29ef735a0cc9246f2024fe148fa051ddcd9c7b",
+        "is_verified": false,
+        "line_number": 23
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/media-understanding/providers/mistral/index.test.ts",
+        "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
+        "is_verified": false,
+        "line_number": 38
       }
     ],
     "src/media-understanding/providers/openai/audio.test.ts": [
@@ -12885,7 +14264,7 @@
         "filename": "src/media-understanding/providers/openai/audio.test.ts",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 22
+        "line_number": 18
       }
     ],
     "src/media-understanding/runner.auto-audio.test.ts": [
@@ -12903,7 +14282,32 @@
         "filename": "src/media-understanding/runner.deepgram.test.ts",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 44
+        "line_number": 31
+      }
+    ],
+    "src/media-understanding/runner.video.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/media-understanding/runner.video.test.ts",
+        "hashed_secret": "a47110e348a3063541fb1f1f640d635d457181a0",
+        "is_verified": false,
+        "line_number": 17
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/media-understanding/runner.video.test.ts",
+        "hashed_secret": "2568d97e538e07521431c9ea738e5c2df14df7a2",
+        "is_verified": false,
+        "line_number": 88
+      }
+    ],
+    "src/memory/embeddings-ollama.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/memory/embeddings-ollama.test.ts",
+        "hashed_secret": "24ff85e3f39fdc772fc759b161935393b6df7071",
+        "is_verified": false,
+        "line_number": 47
       }
     ],
     "src/memory/embeddings-voyage.test.ts": [
@@ -12912,14 +14316,14 @@
         "filename": "src/memory/embeddings-voyage.test.ts",
         "hashed_secret": "7c2020578bbe5e2e3f78d7f954eb2ad8ab5b0403",
         "is_verified": false,
-        "line_number": 33
+        "line_number": 24
       },
       {
         "type": "Secret Keyword",
         "filename": "src/memory/embeddings-voyage.test.ts",
         "hashed_secret": "8afdb3da9b79c8957ae35978ea8f33fbc3bfdf60",
         "is_verified": false,
-        "line_number": 77
+        "line_number": 88
       }
     ],
     "src/memory/embeddings.test.ts": [
@@ -12951,7 +14355,7 @@
         "filename": "src/pairing/pairing-store.ts",
         "hashed_secret": "f8c6f1ff98c5ee78c27d34a3ca68f35ad79847af",
         "is_verified": false,
-        "line_number": 13
+        "line_number": 14
       }
     ],
     "src/pairing/setup-code.test.ts": [
@@ -12960,30 +14364,207 @@
         "filename": "src/pairing/setup-code.test.ts",
         "hashed_secret": "4914c103484773b5a8e18448b11919bb349cbff8",
         "is_verified": false,
-        "line_number": 22
+        "line_number": 30
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/pairing/setup-code.test.ts",
+        "hashed_secret": "1951c80555441588e8707fa68a6084a91c8a114a",
+        "is_verified": false,
+        "line_number": 74
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/pairing/setup-code.test.ts",
+        "hashed_secret": "f1355ae408e2068355dad8f3a503c2eaedefc0c6",
+        "is_verified": false,
+        "line_number": 106
       },
       {
         "type": "Secret Keyword",
         "filename": "src/pairing/setup-code.test.ts",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 96
+        "line_number": 370
+      }
+    ],
+    "src/secrets/apply.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/apply.test.ts",
+        "hashed_secret": "b933c37f090368dee5ab803d71af8f5551729a9a",
+        "is_verified": false,
+        "line_number": 75
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/secrets/apply.test.ts",
+        "hashed_secret": "b99aa0d13685d4177199dcdb170d90032408b634",
+        "is_verified": false,
+        "line_number": 106
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/apply.test.ts",
+        "hashed_secret": "bb0a04dd3612988998c812bc3ad580ba0fb9d905",
+        "is_verified": false,
+        "line_number": 360
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/apply.test.ts",
+        "hashed_secret": "942c7142a36b069509b957db07321a1cb9b2123a",
+        "is_verified": false,
+        "line_number": 397
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/apply.test.ts",
+        "hashed_secret": "9c0faa509a7c3079f58421307ecbcaceb7cbd545",
+        "is_verified": false,
+        "line_number": 450
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/apply.test.ts",
+        "hashed_secret": "c9a4d024f4386d3a4b044de8cb52226383591481",
+        "is_verified": false,
+        "line_number": 483
+      }
+    ],
+    "src/secrets/command-config.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/command-config.test.ts",
+        "hashed_secret": "e3801068cd8f45226d71fb7ccd94069d0fbba56d",
+        "is_verified": false,
+        "line_number": 14
+      }
+    ],
+    "src/secrets/configure-plan.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/configure-plan.test.ts",
+        "hashed_secret": "68c46e84d76d2e7e686e5158bf598909abd4e45b",
+        "is_verified": false,
+        "line_number": 15
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/configure-plan.test.ts",
+        "hashed_secret": "b340b5722fdf4bae59f23b1b829bad0a50b98c2a",
+        "is_verified": false,
+        "line_number": 142
+      }
+    ],
+    "src/secrets/path-utils.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/path-utils.test.ts",
+        "hashed_secret": "c00dbbc9dadfbe1e232e93a729dd4752fade0abf",
+        "is_verified": false,
+        "line_number": 50
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/path-utils.test.ts",
+        "hashed_secret": "ff3390557335ba88d37755e41514beb03bc499ec",
+        "is_verified": false,
+        "line_number": 68
+      }
+    ],
+    "src/secrets/runtime.coverage.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/secrets/runtime.coverage.test.ts",
+        "hashed_secret": "e9a292f7f4d25b0d861458719c6115de3ec813c3",
+        "is_verified": false,
+        "line_number": 30
       }
     ],
     "src/security/audit.test.ts": [
       {
         "type": "Secret Keyword",
         "filename": "src/security/audit.test.ts",
+        "hashed_secret": "cf27add3cb4cb83efe9a48cf7289068fa869c4cd",
+        "is_verified": false,
+        "line_number": 1493
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/security/audit.test.ts",
+        "hashed_secret": "dfba7aade0868074c2861c98e2a9a92f3178a51b",
+        "is_verified": false,
+        "line_number": 1969
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/security/audit.test.ts",
+        "hashed_secret": "071d3673192b4b44a84aa73ac9d00c155821303b",
+        "is_verified": false,
+        "line_number": 1970
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/security/audit.test.ts",
+        "hashed_secret": "7b231a50a498ef151e291795f46f56bee569eae5",
+        "is_verified": false,
+        "line_number": 1982
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/security/audit.test.ts",
+        "hashed_secret": "5a013c49508291c6816ac388f93a2c11973086ed",
+        "is_verified": false,
+        "line_number": 2058
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/security/audit.test.ts",
         "hashed_secret": "21f688ab56f76a99e5c6ed342291422f4e57e47f",
         "is_verified": false,
-        "line_number": 2063
+        "line_number": 3473
       },
       {
         "type": "Secret Keyword",
         "filename": "src/security/audit.test.ts",
         "hashed_secret": "3dc927d80543dc0f643940b70d066bd4b4c4b78e",
         "is_verified": false,
-        "line_number": 2094
+        "line_number": 3486
+      }
+    ],
+    "src/security/external-content.test.ts": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/security/external-content.test.ts",
+        "hashed_secret": "e8e6c2284ab5bee4de2ee53880c8fc2a4728d3e8",
+        "is_verified": false,
+        "line_number": 148
+      }
+    ],
+    "src/signal/identity.test.ts": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/signal/identity.test.ts",
+        "hashed_secret": "99c962e8c62296bdc9a17f5caf91ce9bb4c7e0e6",
+        "is_verified": false,
+        "line_number": 15
+      }
+    ],
+    "src/slack/monitor/monitor.test.ts": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/slack/monitor/monitor.test.ts",
+        "hashed_secret": "431ef2b335d72ec03c3a5d6393c8ab87012bba48",
+        "is_verified": false,
+        "line_number": 68
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/slack/monitor/monitor.test.ts",
+        "hashed_secret": "6c8fd4b55b7a940cf3d484634cb4f2b9e1a8fe7a",
+        "is_verified": false,
+        "line_number": 78
       }
     ],
     "src/telegram/monitor.test.ts": [
@@ -12992,14 +14573,14 @@
         "filename": "src/telegram/monitor.test.ts",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 205
+        "line_number": 432
       },
       {
         "type": "Secret Keyword",
         "filename": "src/telegram/monitor.test.ts",
         "hashed_secret": "5934c4d4a4fa5d66ddb3d3fc0bba84996c17a5b7",
         "is_verified": false,
-        "line_number": 233
+        "line_number": 479
       }
     ],
     "src/telegram/webhook.test.ts": [
@@ -13008,7 +14589,7 @@
         "filename": "src/telegram/webhook.test.ts",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 42
+        "line_number": 24
       }
     ],
     "src/tts/tts.test.ts": [
@@ -13024,28 +14605,28 @@
         "filename": "src/tts/tts.test.ts",
         "hashed_secret": "b214f706bb602c1cc2adc5c6165e73622305f4bb",
         "is_verified": false,
-        "line_number": 98
+        "line_number": 96
       },
       {
         "type": "Secret Keyword",
         "filename": "src/tts/tts.test.ts",
         "hashed_secret": "75ddfb45216fe09680dfe70eda4f559a910c832c",
         "is_verified": false,
-        "line_number": 397
+        "line_number": 434
       },
       {
         "type": "Secret Keyword",
         "filename": "src/tts/tts.test.ts",
         "hashed_secret": "e29af93630aa18cc3457cb5b13937b7ab7c99c9b",
         "is_verified": false,
-        "line_number": 413
+        "line_number": 444
       },
       {
         "type": "Secret Keyword",
         "filename": "src/tts/tts.test.ts",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 447
+        "line_number": 530
       }
     ],
     "src/tui/gateway-chat.test.ts": [
@@ -13066,13 +14647,54 @@
         "line_number": 60
       }
     ],
+    "src/wizard/onboarding.gateway-config.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/wizard/onboarding.gateway-config.test.ts",
+        "hashed_secret": "358fffeb5cef5e34ae867e1d9edf2ba420ca2bf6",
+        "is_verified": false,
+        "line_number": 148
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/wizard/onboarding.gateway-config.test.ts",
+        "hashed_secret": "69449f994d55805535b9e8fab16f6c39934e9ba4",
+        "is_verified": false,
+        "line_number": 162
+      }
+    ],
+    "src/wizard/onboarding.secret-input.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/wizard/onboarding.secret-input.test.ts",
+        "hashed_secret": "358fffeb5cef5e34ae867e1d9edf2ba420ca2bf6",
+        "is_verified": false,
+        "line_number": 22
+      }
+    ],
+    "src/wizard/onboarding.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/wizard/onboarding.test.ts",
+        "hashed_secret": "9c8c592cc7a339f158262ebc87ee5a0cce39ce83",
+        "is_verified": false,
+        "line_number": 403
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/wizard/onboarding.test.ts",
+        "hashed_secret": "69449f994d55805535b9e8fab16f6c39934e9ba4",
+        "is_verified": false,
+        "line_number": 487
+      }
+    ],
     "ui/src/i18n/locales/en.ts": [
       {
         "type": "Secret Keyword",
         "filename": "ui/src/i18n/locales/en.ts",
         "hashed_secret": "de0ff6b974d6910aca8d6b830e1b761f076d8fe6",
         "is_verified": false,
-        "line_number": 60
+        "line_number": 61
       }
     ],
     "ui/src/i18n/locales/pt-BR.ts": [
@@ -13081,7 +14703,16 @@
         "filename": "ui/src/i18n/locales/pt-BR.ts",
         "hashed_secret": "ef7b6f95faca2d7d3a5aa5a6434c89530c6dd243",
         "is_verified": false,
-        "line_number": 60
+        "line_number": 61
+      }
+    ],
+    "ui/src/ui/config-form.browser.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "ui/src/ui/config-form.browser.test.ts",
+        "hashed_secret": "c00dbbc9dadfbe1e232e93a729dd4752fade0abf",
+        "is_verified": false,
+        "line_number": 368
       }
     ],
     "vendor/a2ui/README.md": [
@@ -13094,5 +14725,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-07T00:11:03Z"
+  "generated_at": "2026-03-07T05:29:53Z"
 }

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -123,6 +123,7 @@ import { installToolResultContextGuard } from "../tool-result-context-guard.js";
 import { splitSdkTools } from "../tool-split.js";
 import { describeUnknownError, mapThinkingLevel } from "../utils.js";
 import { flushPendingToolResultsAfterIdle } from "../wait-for-idle-before-flush.js";
+import { waitForCompactionRetryWithAggregateTimeout } from "./compaction-retry-aggregate-timeout.js";
 import {
   selectCompactionTimeoutSnapshot,
   shouldFlagCompactionTimeout,
@@ -1795,6 +1796,7 @@ export async function runEmbeddedAttempt(
         const preCompactionSnapshot = wasCompactingBefore || wasCompactingAfter ? null : snapshot;
         const preCompactionSessionId = activeSession.sessionId;
 
+        const COMPACTION_RETRY_AGGREGATE_TIMEOUT_MS = 60_000;
         try {
           // Flush buffered block replies before waiting for compaction so the
           // user receives the assistant response immediately.  Without this,
@@ -1804,7 +1806,20 @@ export async function runEmbeddedAttempt(
             await params.onBlockReplyFlush();
           }
 
-          await abortable(waitForCompactionRetry());
+          await waitForCompactionRetryWithAggregateTimeout({
+            waitForCompactionRetry,
+            abortable,
+            aggregateTimeoutMs: COMPACTION_RETRY_AGGREGATE_TIMEOUT_MS,
+            onTimeout: () => {
+              timedOutDuringCompaction = true;
+              if (!isProbeSession) {
+                log.warn(
+                  `compaction retry aggregate timeout (${COMPACTION_RETRY_AGGREGATE_TIMEOUT_MS}ms): ` +
+                    `proceeding with pre-compaction state runId=${params.runId} sessionId=${params.sessionId}`,
+                );
+              }
+            },
+          });
         } catch (err) {
           if (isRunnerAbortError(err)) {
             if (!promptError) {

--- a/src/agents/pi-embedded-runner/run/compaction-retry-aggregate-timeout.e2e.test.ts
+++ b/src/agents/pi-embedded-runner/run/compaction-retry-aggregate-timeout.e2e.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from "vitest";
+import { waitForCompactionRetryWithAggregateTimeout } from "./compaction-retry-aggregate-timeout.js";
+
+describe("waitForCompactionRetryWithAggregateTimeout", () => {
+  it("fires an aggregate timeout and proceeds when compaction retry never resolves", async () => {
+    vi.useFakeTimers();
+    try {
+      const onTimeout = vi.fn();
+      const waitForCompactionRetry = vi.fn(async () => await new Promise<void>(() => {}));
+
+      const resultPromise = waitForCompactionRetryWithAggregateTimeout({
+        waitForCompactionRetry,
+        abortable: async (p) => await p,
+        aggregateTimeoutMs: 60_000,
+        onTimeout,
+      });
+
+      await vi.advanceTimersByTimeAsync(60_000);
+      const result = await resultPromise;
+
+      expect(result.timedOut).toBe(true);
+      expect(onTimeout).toHaveBeenCalledTimes(1);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      await vi.runOnlyPendingTimersAsync();
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not time out when compaction retry resolves quickly, and clears the timer", async () => {
+    vi.useFakeTimers();
+    try {
+      const onTimeout = vi.fn();
+      const waitForCompactionRetry = vi.fn(async () => {});
+
+      const result = await waitForCompactionRetryWithAggregateTimeout({
+        waitForCompactionRetry,
+        abortable: async (p) => await p,
+        aggregateTimeoutMs: 60_000,
+        onTimeout,
+      });
+
+      expect(result.timedOut).toBe(false);
+      expect(onTimeout).not.toHaveBeenCalled();
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      await vi.runOnlyPendingTimersAsync();
+      vi.useRealTimers();
+    }
+  });
+
+  it("propagates abort errors from abortable and clears the timer", async () => {
+    vi.useFakeTimers();
+    try {
+      const abortErr = new Error("aborted");
+      abortErr.name = "AbortError";
+
+      const onTimeout = vi.fn();
+      const waitForCompactionRetry = vi.fn(async () => await new Promise<void>(() => {}));
+
+      await expect(
+        waitForCompactionRetryWithAggregateTimeout({
+          waitForCompactionRetry,
+          abortable: async () => {
+            throw abortErr;
+          },
+          aggregateTimeoutMs: 60_000,
+          onTimeout,
+        }),
+      ).rejects.toThrow("aborted");
+
+      expect(onTimeout).not.toHaveBeenCalled();
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      await vi.runOnlyPendingTimersAsync();
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/agents/pi-embedded-runner/run/compaction-retry-aggregate-timeout.ts
+++ b/src/agents/pi-embedded-runner/run/compaction-retry-aggregate-timeout.ts
@@ -9,7 +9,7 @@ export async function waitForCompactionRetryWithAggregateTimeout(params: {
   onTimeout?: () => void;
 }): Promise<{ timedOut: boolean }> {
   const timeoutMsRaw = params.aggregateTimeoutMs;
-  const timeoutMs = Math.max(1, Math.floor(timeoutMsRaw));
+  const timeoutMs = Number.isFinite(timeoutMsRaw) ? Math.max(1, Math.floor(timeoutMsRaw)) : 1;
 
   let timer: ReturnType<typeof setTimeout> | undefined;
   let timedOut = false;
@@ -29,7 +29,7 @@ export async function waitForCompactionRetryWithAggregateTimeout(params: {
       params.onTimeout?.();
     }
   } finally {
-    if (timer) {
+    if (timer !== undefined) {
       clearTimeout(timer);
     }
   }

--- a/src/agents/pi-embedded-runner/run/compaction-retry-aggregate-timeout.ts
+++ b/src/agents/pi-embedded-runner/run/compaction-retry-aggregate-timeout.ts
@@ -1,0 +1,38 @@
+/**
+ * Helpers for waiting on compaction retries without blocking a session lane indefinitely.
+ */
+
+export async function waitForCompactionRetryWithAggregateTimeout(params: {
+  waitForCompactionRetry: () => Promise<void>;
+  abortable: <T>(promise: Promise<T>) => Promise<T>;
+  aggregateTimeoutMs: number;
+  onTimeout?: () => void;
+}): Promise<{ timedOut: boolean }> {
+  const timeoutMsRaw = params.aggregateTimeoutMs;
+  const timeoutMs = Math.max(1, Math.floor(timeoutMsRaw));
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let timedOut = false;
+
+  try {
+    const result = await params.abortable(
+      Promise.race([
+        params.waitForCompactionRetry().then(() => "done" as const),
+        new Promise<"timeout">((resolve) => {
+          timer = setTimeout(() => resolve("timeout"), timeoutMs);
+        }),
+      ]),
+    );
+
+    if (result === "timeout") {
+      timedOut = true;
+      params.onTimeout?.();
+    }
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+
+  return { timedOut };
+}

--- a/src/agents/pi-embedded-runner/runs.e2e.test.ts
+++ b/src/agents/pi-embedded-runner/runs.e2e.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  __testing,
+  abortEmbeddedPiRun,
+  clearActiveEmbeddedRun,
+  setActiveEmbeddedRun,
+  waitForActiveEmbeddedRuns,
+} from "./runs.js";
+
+describe("pi-embedded-runner runs", () => {
+  afterEach(() => {
+    __testing.resetActiveEmbeddedRuns();
+    vi.restoreAllMocks();
+  });
+
+  it("aborts only compacting runs when mode=compacting", () => {
+    const abortA = vi.fn();
+    const abortB = vi.fn();
+
+    setActiveEmbeddedRun("session-a", {
+      queueMessage: async () => {},
+      isStreaming: () => true,
+      isCompacting: () => true,
+      abort: abortA,
+    });
+
+    setActiveEmbeddedRun("session-b", {
+      queueMessage: async () => {},
+      isStreaming: () => true,
+      isCompacting: () => false,
+      abort: abortB,
+    });
+
+    const aborted = abortEmbeddedPiRun(undefined, { mode: "compacting" });
+    expect(aborted).toBe(true);
+    expect(abortA).toHaveBeenCalledTimes(1);
+    expect(abortB).not.toHaveBeenCalled();
+  });
+
+  it("aborts all runs when mode=all", () => {
+    const abortA = vi.fn();
+    const abortB = vi.fn();
+
+    setActiveEmbeddedRun("session-a", {
+      queueMessage: async () => {},
+      isStreaming: () => true,
+      isCompacting: () => true,
+      abort: abortA,
+    });
+
+    setActiveEmbeddedRun("session-b", {
+      queueMessage: async () => {},
+      isStreaming: () => true,
+      isCompacting: () => false,
+      abort: abortB,
+    });
+
+    const aborted = abortEmbeddedPiRun(undefined, { mode: "all" });
+    expect(aborted).toBe(true);
+    expect(abortA).toHaveBeenCalledTimes(1);
+    expect(abortB).toHaveBeenCalledTimes(1);
+  });
+
+  it("waits for active embedded runs to drain", async () => {
+    vi.useFakeTimers();
+    try {
+      const abortA = vi.fn();
+      const handle = {
+        queueMessage: async () => {},
+        isStreaming: () => true,
+        isCompacting: () => false,
+        abort: abortA,
+      };
+      setActiveEmbeddedRun("session-a", handle);
+
+      // Drain after 500ms
+      setTimeout(() => {
+        clearActiveEmbeddedRun("session-a", handle);
+      }, 500);
+
+      const drainPromise = waitForActiveEmbeddedRuns(1000, { pollMs: 100 });
+      await vi.advanceTimersByTimeAsync(500);
+      const out = await drainPromise;
+      expect(out.drained).toBe(true);
+    } finally {
+      await vi.runOnlyPendingTimersAsync();
+      vi.useRealTimers();
+    }
+  });
+
+  it("returns drained=false when timeout elapses", async () => {
+    vi.useFakeTimers();
+    try {
+      setActiveEmbeddedRun("session-a", {
+        queueMessage: async () => {},
+        isStreaming: () => true,
+        isCompacting: () => false,
+        abort: vi.fn(),
+      });
+
+      const drainPromise = waitForActiveEmbeddedRuns(1000, { pollMs: 100 });
+      await vi.advanceTimersByTimeAsync(1000);
+      const out = await drainPromise;
+      expect(out.drained).toBe(false);
+    } finally {
+      await vi.runOnlyPendingTimersAsync();
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/agents/pi-embedded-runner/runs.ts
+++ b/src/agents/pi-embedded-runner/runs.ts
@@ -45,9 +45,10 @@ export function queueEmbeddedPiMessage(sessionId: string, text: string): boolean
  */
 export function abortEmbeddedPiRun(sessionId: string): boolean;
 export function abortEmbeddedPiRun(
-  sessionId?: string,
-  opts?: { mode?: "all" | "compacting" },
+  sessionId: undefined,
+  opts: { mode: "all" | "compacting" },
 ): boolean;
+export function abortEmbeddedPiRun(): boolean;
 export function abortEmbeddedPiRun(
   sessionId?: string,
   opts?: { mode?: "all" | "compacting" },

--- a/src/agents/pi-embedded-runner/runs.ts
+++ b/src/agents/pi-embedded-runner/runs.ts
@@ -59,7 +59,12 @@ export function abortEmbeddedPiRun(
       return false;
     }
     diag.debug(`aborting run: sessionId=${sessionId}`);
-    handle.abort();
+    try {
+      handle.abort();
+    } catch (err) {
+      diag.warn(`abort failed: sessionId=${sessionId} err=${String(err)}`);
+      return false;
+    }
     return true;
   }
 
@@ -71,8 +76,12 @@ export function abortEmbeddedPiRun(
         continue;
       }
       diag.debug(`aborting compacting run: sessionId=${id}`);
-      handle.abort();
-      aborted = true;
+      try {
+        handle.abort();
+        aborted = true;
+      } catch (err) {
+        diag.warn(`abort failed: sessionId=${id} err=${String(err)}`);
+      }
     }
     return aborted;
   }
@@ -81,8 +90,12 @@ export function abortEmbeddedPiRun(
     let aborted = false;
     for (const [id, handle] of ACTIVE_EMBEDDED_RUNS) {
       diag.debug(`aborting run: sessionId=${id}`);
-      handle.abort();
-      aborted = true;
+      try {
+        handle.abort();
+        aborted = true;
+      } catch (err) {
+        diag.warn(`abort failed: sessionId=${id} err=${String(err)}`);
+      }
     }
     return aborted;
   }

--- a/src/agents/pi-embedded-runner/runs.ts
+++ b/src/agents/pi-embedded-runner/runs.ts
@@ -37,15 +37,57 @@ export function queueEmbeddedPiMessage(sessionId: string, text: string): boolean
   return true;
 }
 
-export function abortEmbeddedPiRun(sessionId: string): boolean {
-  const handle = ACTIVE_EMBEDDED_RUNS.get(sessionId);
-  if (!handle) {
-    diag.debug(`abort failed: sessionId=${sessionId} reason=no_active_run`);
-    return false;
+/**
+ * Abort embedded PI runs.
+ *
+ * - With a sessionId, aborts that single run.
+ * - With no sessionId, supports targeted abort modes (e.g. abort only compacting runs).
+ */
+export function abortEmbeddedPiRun(sessionId: string): boolean;
+export function abortEmbeddedPiRun(
+  sessionId?: string,
+  opts?: { mode?: "all" | "compacting" },
+): boolean;
+export function abortEmbeddedPiRun(
+  sessionId?: string,
+  opts?: { mode?: "all" | "compacting" },
+): boolean {
+  if (typeof sessionId === "string" && sessionId) {
+    const handle = ACTIVE_EMBEDDED_RUNS.get(sessionId);
+    if (!handle) {
+      diag.debug(`abort failed: sessionId=${sessionId} reason=no_active_run`);
+      return false;
+    }
+    diag.debug(`aborting run: sessionId=${sessionId}`);
+    handle.abort();
+    return true;
   }
-  diag.debug(`aborting run: sessionId=${sessionId}`);
-  handle.abort();
-  return true;
+
+  const mode = opts?.mode;
+  if (mode === "compacting") {
+    let aborted = false;
+    for (const [id, handle] of ACTIVE_EMBEDDED_RUNS) {
+      if (!handle.isCompacting()) {
+        continue;
+      }
+      diag.debug(`aborting compacting run: sessionId=${id}`);
+      handle.abort();
+      aborted = true;
+    }
+    return aborted;
+  }
+
+  if (mode === "all") {
+    let aborted = false;
+    for (const [id, handle] of ACTIVE_EMBEDDED_RUNS) {
+      diag.debug(`aborting run: sessionId=${id}`);
+      handle.abort();
+      aborted = true;
+    }
+    return aborted;
+  }
+
+  return false;
 }
 
 export function isEmbeddedPiRunActive(sessionId: string): boolean {
@@ -66,6 +108,37 @@ export function isEmbeddedPiRunStreaming(sessionId: string): boolean {
 
 export function getActiveEmbeddedRunCount(): number {
   return ACTIVE_EMBEDDED_RUNS.size;
+}
+
+/**
+ * Wait for ACTIVE_EMBEDDED_RUNS to drain.
+ *
+ * Used by the gateway run loop during SIGUSR1 restarts so in-flight embedded
+ * runs (especially compaction) can release session write locks before the next
+ * lifecycle begins.
+ */
+export async function waitForActiveEmbeddedRuns(
+  timeoutMs = 15_000,
+  opts?: { pollMs?: number },
+): Promise<{ drained: boolean }> {
+  const pollMsRaw = opts?.pollMs ?? 250;
+  const pollMs = Math.max(10, Math.floor(pollMsRaw));
+  const maxWaitMs = Math.max(pollMs, Math.floor(timeoutMs));
+
+  const startedAt = Date.now();
+  while (true) {
+    if (ACTIVE_EMBEDDED_RUNS.size === 0) {
+      return { drained: true };
+    }
+    const elapsedMs = Date.now() - startedAt;
+    if (elapsedMs >= maxWaitMs) {
+      diag.warn(
+        `wait for active embedded runs timed out: activeRuns=${ACTIVE_EMBEDDED_RUNS.size} timeoutMs=${maxWaitMs}`,
+      );
+      return { drained: false };
+    }
+    await new Promise<void>((resolve) => setTimeout(resolve, pollMs));
+  }
 }
 
 export function waitForEmbeddedPiRunEnd(sessionId: string, timeoutMs = 15_000): Promise<boolean> {
@@ -149,5 +222,18 @@ export function clearActiveEmbeddedRun(
     diag.debug(`run clear skipped: sessionId=${sessionId} reason=handle_mismatch`);
   }
 }
+
+export const __testing = {
+  resetActiveEmbeddedRuns() {
+    for (const waiters of EMBEDDED_RUN_WAITERS.values()) {
+      for (const waiter of waiters) {
+        clearTimeout(waiter.timer);
+        waiter.resolve(true);
+      }
+    }
+    EMBEDDED_RUN_WAITERS.clear();
+    ACTIVE_EMBEDDED_RUNS.clear();
+  },
+};
 
 export type { EmbeddedPiQueueHandle };

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -15,7 +15,9 @@ const resetAllLanes = vi.fn();
 const restartGatewayProcessWithFreshPid = vi.fn<
   () => { mode: "spawned" | "supervised" | "disabled" | "failed"; pid?: number; detail?: string }
 >(() => ({ mode: "disabled" }));
-const abortEmbeddedPiRun = vi.fn(() => false);
+const abortEmbeddedPiRun = vi.fn(
+  (_sessionId?: string, _opts?: { mode?: "all" | "compacting" }) => false,
+);
 const getActiveEmbeddedRunCount = vi.fn(() => 0);
 const waitForActiveEmbeddedRuns = vi.fn(async (_timeoutMs: number) => ({ drained: true }));
 const DRAIN_TIMEOUT_LOG = "drain timeout reached; proceeding with restart";

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -15,6 +15,9 @@ const resetAllLanes = vi.fn();
 const restartGatewayProcessWithFreshPid = vi.fn<
   () => { mode: "spawned" | "supervised" | "disabled" | "failed"; pid?: number; detail?: string }
 >(() => ({ mode: "disabled" }));
+const abortEmbeddedPiRun = vi.fn(() => false);
+const getActiveEmbeddedRunCount = vi.fn(() => 0);
+const waitForActiveEmbeddedRuns = vi.fn(async (_timeoutMs: number) => ({ drained: true }));
 const DRAIN_TIMEOUT_LOG = "drain timeout reached; proceeding with restart";
 const gatewayLog = {
   info: vi.fn(),
@@ -41,6 +44,13 @@ vi.mock("../../process/command-queue.js", () => ({
   markGatewayDraining: () => markGatewayDraining(),
   waitForActiveTasks: (timeoutMs: number) => waitForActiveTasks(timeoutMs),
   resetAllLanes: () => resetAllLanes(),
+}));
+
+vi.mock("../../agents/pi-embedded-runner/runs.js", () => ({
+  abortEmbeddedPiRun: (sessionId?: string, opts?: { mode?: "all" | "compacting" }) =>
+    abortEmbeddedPiRun(sessionId, opts),
+  getActiveEmbeddedRunCount: () => getActiveEmbeddedRunCount(),
+  waitForActiveEmbeddedRuns: (timeoutMs: number) => waitForActiveEmbeddedRuns(timeoutMs),
 }));
 
 vi.mock("../../logging/subsystem.js", () => ({
@@ -163,7 +173,9 @@ describe("runGatewayLoop", () => {
 
     await withIsolatedSignals(async () => {
       getActiveTaskCount.mockReturnValueOnce(2).mockReturnValueOnce(0);
+      getActiveEmbeddedRunCount.mockReturnValueOnce(1).mockReturnValueOnce(0);
       waitForActiveTasks.mockResolvedValueOnce({ drained: false });
+      waitForActiveEmbeddedRuns.mockResolvedValueOnce({ drained: true });
 
       type StartServer = () => Promise<{
         close: (opts: { reason: string; restartExpectedMs: number | null }) => Promise<void>;
@@ -214,7 +226,10 @@ describe("runGatewayLoop", () => {
       expect(start).toHaveBeenCalledTimes(2);
       await new Promise<void>((resolve) => setImmediate(resolve));
 
-      expect(waitForActiveTasks).toHaveBeenCalledWith(30_000);
+      expect(abortEmbeddedPiRun).toHaveBeenCalledWith(undefined, { mode: "compacting" });
+      expect(waitForActiveTasks).toHaveBeenCalledWith(90_000);
+      expect(waitForActiveEmbeddedRuns).toHaveBeenCalledWith(90_000);
+      expect(abortEmbeddedPiRun).toHaveBeenCalledWith(undefined, { mode: "all" });
       expect(markGatewayDraining).toHaveBeenCalledTimes(1);
       expect(gatewayLog.warn).toHaveBeenCalledWith(DRAIN_TIMEOUT_LOG);
       expect(closeFirst).toHaveBeenCalledWith({

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -1,4 +1,9 @@
 import type { startGatewayServer } from "../../gateway/server.js";
+import {
+  abortEmbeddedPiRun,
+  getActiveEmbeddedRunCount,
+  waitForActiveEmbeddedRuns,
+} from "../../agents/pi-embedded-runner/runs.js";
 import { acquireGatewayLock } from "../../infra/gateway-lock.js";
 import { restartGatewayProcessWithFreshPid } from "../../infra/process-respawn.js";
 import {
@@ -88,7 +93,7 @@ export async function runGatewayLoop(params: {
     exitProcess(0);
   };
 
-  const DRAIN_TIMEOUT_MS = 30_000;
+  const DRAIN_TIMEOUT_MS = 90_000;
   const SHUTDOWN_TIMEOUT_MS = 5_000;
 
   const request = (action: GatewayRunSignalAction, signal: string) => {
@@ -116,15 +121,35 @@ export async function runGatewayLoop(params: {
           // sessions get an explicit restart error instead of silent task loss.
           markGatewayDraining();
           const activeTasks = getActiveTaskCount();
-          if (activeTasks > 0) {
+          const activeRuns = getActiveEmbeddedRunCount();
+
+          // Abort compacting embedded runs before draining. In-flight compaction can take
+          // 60–90s and holds the session write lock; restarting mid-compaction can leave
+          // the lock held by the previous lifecycle.
+          if (activeRuns > 0) {
+            abortEmbeddedPiRun(undefined, { mode: "compacting" });
+          }
+
+          if (activeTasks > 0 || activeRuns > 0) {
             gatewayLog.info(
-              `draining ${activeTasks} active task(s) before restart (timeout ${DRAIN_TIMEOUT_MS}ms)`,
+              `draining ${activeTasks} active task(s) and ${activeRuns} active embedded run(s) before restart (timeout ${DRAIN_TIMEOUT_MS}ms)`,
             );
-            const { drained } = await waitForActiveTasks(DRAIN_TIMEOUT_MS);
-            if (drained) {
-              gatewayLog.info("all active tasks drained");
+
+            const [tasksDrain, runsDrain] = await Promise.all([
+              activeTasks > 0
+                ? waitForActiveTasks(DRAIN_TIMEOUT_MS)
+                : Promise.resolve({ drained: true }),
+              activeRuns > 0
+                ? waitForActiveEmbeddedRuns(DRAIN_TIMEOUT_MS)
+                : Promise.resolve({ drained: true }),
+            ]);
+
+            if (tasksDrain.drained && runsDrain.drained) {
+              gatewayLog.info("all active work drained");
             } else {
               gatewayLog.warn("drain timeout reached; proceeding with restart");
+              // Best-effort: abort all embedded runs so they release session locks.
+              abortEmbeddedPiRun(undefined, { mode: "all" });
             }
           }
         }

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -124,7 +124,7 @@ export async function runGatewayLoop(params: {
           const activeRuns = getActiveEmbeddedRunCount();
 
           // Abort compacting embedded runs before draining. In-flight compaction can take
-          // 60–90s and holds the session write lock; restarting mid-compaction can leave
+          // 60-90s and holds the session write lock; restarting mid-compaction can leave
           // the lock held by the previous lifecycle.
           if (activeRuns > 0) {
             abortEmbeddedPiRun(undefined, { mode: "compacting" });

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -1,9 +1,9 @@
-import type { startGatewayServer } from "../../gateway/server.js";
 import {
   abortEmbeddedPiRun,
   getActiveEmbeddedRunCount,
   waitForActiveEmbeddedRuns,
 } from "../../agents/pi-embedded-runner/runs.js";
+import type { startGatewayServer } from "../../gateway/server.js";
 import { acquireGatewayLock } from "../../infra/gateway-lock.js";
 import { restartGatewayProcessWithFreshPid } from "../../infra/process-respawn.js";
 import {

--- a/src/infra/infra-runtime.test.ts
+++ b/src/infra/infra-runtime.test.ts
@@ -244,8 +244,8 @@ describe("infra runtime", () => {
         await vi.advanceTimersByTimeAsync(0);
         expect(emitSpy).not.toHaveBeenCalledWith("SIGUSR1");
 
-        // Advance past the 30s max deferral wait
-        await vi.advanceTimersByTimeAsync(30_000);
+        // Advance past the 90s max deferral wait
+        await vi.advanceTimersByTimeAsync(90_000);
         expect(emitSpy).toHaveBeenCalledWith("SIGUSR1");
       } finally {
         process.removeListener("SIGUSR1", handler);

--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -19,7 +19,7 @@ const SPAWN_TIMEOUT_MS = 2000;
 const SIGUSR1_AUTH_GRACE_MS = 5000;
 const DEFAULT_DEFERRAL_POLL_MS = 500;
 // Default deferral max wait should cover the slowest expected embedded compaction
-// (60–90s observed in production) so we don't restart mid-compaction and leave
+// (60-90s observed in production) so we don't restart mid-compaction and leave
 // session write locks held by the previous lifecycle.
 const DEFAULT_DEFERRAL_MAX_WAIT_MS = 90_000;
 const RESTART_COOLDOWN_MS = 30_000;

--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -18,7 +18,10 @@ export type RestartAttempt = {
 const SPAWN_TIMEOUT_MS = 2000;
 const SIGUSR1_AUTH_GRACE_MS = 5000;
 const DEFAULT_DEFERRAL_POLL_MS = 500;
-const DEFAULT_DEFERRAL_MAX_WAIT_MS = 30_000;
+// Default deferral max wait should cover the slowest expected embedded compaction
+// (60–90s observed in production) so we don't restart mid-compaction and leave
+// session write locks held by the previous lifecycle.
+const DEFAULT_DEFERRAL_MAX_WAIT_MS = 90_000;
 const RESTART_COOLDOWN_MS = 30_000;
 
 const restartLog = createSubsystemLogger("restart");


### PR DESCRIPTION
Fixes #17444

## Summary

This PR addresses two related "session looks hung" failure modes in the PI embedded runner:

1. **Compaction retry waits can block the session lane with no aggregate timeout**.
2. **SIGUSR1 in-process restart can proceed while embedded compaction is still in-flight**, leaving session write locks held by the previous lifecycle.

## What changed

### 1) Bound compaction retry waits (aggregate timeout)

- Add `waitForCompactionRetryWithAggregateTimeout()` in `run/compaction-retry-aggregate-timeout.ts`.
- In `run/attempt.ts`, replace the unbounded `await abortable(waitForCompactionRetry())` with a **60s aggregate timeout**.
- On aggregate timeout:
  - set `timedOutDuringCompaction = true`
  - log a warning and proceed using the existing pre-compaction snapshot selection logic
- Defensive normalization: non-finite `aggregateTimeoutMs` values fall back to 1ms rather than producing `NaN` timeouts.
- Timer cleanup uses `timer !== undefined` (not truthiness) to handle fake-timer environments where handle can be `0`.

This prevents long compaction retry waits from freezing the session lane.

### 2) Harden SIGUSR1 restart against in-flight embedded runs/compaction

- Increase default SIGUSR1 deferral budget: `DEFAULT_DEFERRAL_MAX_WAIT_MS` **30s → 90s**.
- Increase gateway run-loop drain budget: `DRAIN_TIMEOUT_MS` **30s → 90s**.
- On SIGUSR1 restart in the gateway run loop:
  1. **Abort compacting embedded runs** (best-effort, surgical — only runs where `handle.isCompacting()` is true)
  2. Drain **both** active command-queue tasks and active embedded runs (up to 90s)
  3. If drain times out, **abort all embedded runs** (best-effort) and proceed

### 3) Exception-safe abort handling

- All three `abortEmbeddedPiRun()` code paths (single session, compacting-only, abort-all) now wrap `handle.abort()` in try/catch.
- A thrown abort handler no longer prevents `server.close()` from executing during SIGUSR1 restart drain.
- Failed aborts are logged at `warn` level with the session ID and error.

## Why this is safe

- The aggregate timeout only affects cases where compaction retry waits would otherwise stall; normal compaction runs are unchanged.
- Restart already implies disruption; aborting compacting runs is a targeted best-effort to ensure session locks are released.
- Exception guards on abort are strictly additive — they only prevent cascading failures.
- Changes are localized to restart/compaction wait paths.

## Tests

New:
- `src/agents/pi-embedded-runner/run/compaction-retry-aggregate-timeout.e2e.test.ts` — aggregate timeout helper
- `src/agents/pi-embedded-runner/runs.e2e.test.ts` — surgical abort + `waitForActiveEmbeddedRuns`

Updated:
- `src/cli/gateway-cli/run-loop.test.ts` — drain timeout constant
- `src/infra/infra-runtime.test.ts` — deferral timeout constant

Note: e2e tests require `-c vitest.e2e.config.ts` (excluded from default config).

```bash
pnpm -s lint
pnpm -s format:check
npx vitest run src/agents/pi-embedded-runner/ src/cli/gateway-cli/run-loop.test.ts src/infra/infra-runtime.test.ts --reporter=verbose
npx vitest run -c vitest.e2e.config.ts src/agents/pi-embedded-runner/runs.e2e.test.ts src/agents/pi-embedded-runner/run/compaction-retry-aggregate-timeout.e2e.test.ts --reporter=verbose
```

## Notes / follow-ups

- This PR does **not** change per-attempt compaction safety timeouts (`EMBEDDED_COMPACTION_TIMEOUT_MS`); if desired, we can follow up with a smaller per-attempt ceiling and/or a compaction re-entry cooldown once we have more production data.
- Refactor commits (`dedupe compaction failure`, `dedupe assistant delta parsing`, `reuse isPidAlive`) are included to reduce code duplication touched during the investigation.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two related "session hung" failure modes in the PI embedded runner:

- **Aggregate timeout for compaction retry waits**: Adds a 60s aggregate timeout to `waitForCompactionRetry()` in the embedded run attempt loop, preventing unbounded blocking of the session lane. On timeout, the run proceeds with the pre-compaction snapshot. The new `waitForCompactionRetryWithAggregateTimeout` helper uses `Promise.race` with proper timer cleanup and defensive normalization for non-finite timeout values.
- **Hardened SIGUSR1 restart against in-flight compaction**: The gateway run loop now surgically aborts compacting embedded runs before draining, waits for both active tasks and embedded runs in parallel (up to 90s), and falls back to aborting all runs if the drain times out. The deferral budget and drain timeout are increased from 30s to 90s to match observed production compaction durations.
- **Exception-safe abort handling**: All `abortEmbeddedPiRun` code paths now wrap `handle.abort()` in try/catch, preventing a thrown abort handler from cascading into the shutdown sequence.

Changes are well-localized to restart/compaction paths, and existing behavior for normal compaction runs is unchanged. Test coverage is thorough with new e2e tests for the aggregate timeout helper and surgical abort modes.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — changes are defensive, well-scoped to restart/compaction paths, and thoroughly tested.
- The changes are strictly additive safety improvements: an aggregate timeout that only fires when compaction would otherwise stall indefinitely, exception guards on abort that only prevent cascading failures, and targeted abort of compacting runs during restart. Normal compaction flows are unaffected. All new behavior paths have dedicated e2e tests, existing tests are updated to match the new timeout constants, and the code follows established patterns in the codebase (polling drain, try/catch abort, Promise.race with cleanup). No logical or security issues found after thorough analysis of all 9 changed files and their related imports.
- No files require special attention

<sub>Last reviewed commit: 6d7ef5a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->