### PR TITLE
fix(signal): make group reactions deterministic from inbound sender metadata

### DIFF
--- a/src/infra/outbound/message-action-runner.threading.test.ts
+++ b/src/infra/outbound/message-action-runner.threading.test.ts
@@ -294,8 +294,9 @@ describe("runMessageAction threading auto-injection", () => {
   });
 
   it("hydrates signal group reaction targetAuthorUuid from inbound cache", async () => {
+    const groupId = "imrDE/AziMTrojCb1ngE9WcREGjKxjRq30krncLOZnM=";
     recordSignalReactionTarget({
-      groupId: "group-id",
+      groupId,
       messageId: "1737630212345",
       senderId: "uuid:123e4567-e89b-12d3-a456-426614174000",
     });
@@ -314,7 +315,7 @@ describe("runMessageAction threading auto-injection", () => {
       action: "react",
       params: {
         channel: "signal",
-        target: "signal:group:group-id",
+        target: `group:${groupId}`,
         messageId: "1737630212345",
         emoji: "✅",
       },

--- a/src/infra/outbound/message-action-runner.threading.test.ts
+++ b/src/infra/outbound/message-action-runner.threading.test.ts
@@ -3,11 +3,16 @@ import type { OpenClawConfig } from "../../config/config.js";
 import { slackPlugin } from "../../../extensions/slack/src/channel.js";
 import { telegramPlugin } from "../../../extensions/telegram/src/channel.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import {
+  __clearSignalReactionTargetCacheForTests,
+  recordSignalReactionTarget,
+} from "../../signal/reaction-target-cache.js";
 import { createTestRegistry } from "../../test-utils/channel-plugins.js";
 
 const mocks = vi.hoisted(() => ({
   executeSendAction: vi.fn(),
   recordSessionMetaFromInbound: vi.fn(async () => ({ ok: true })),
+  dispatchChannelMessageAction: vi.fn(),
 }));
 
 vi.mock("./outbound-send-service.js", async () => {
@@ -27,6 +32,17 @@ vi.mock("../../config/sessions.js", async () => {
   return {
     ...actual,
     recordSessionMetaFromInbound: mocks.recordSessionMetaFromInbound,
+  };
+});
+
+vi.mock("../../channels/plugins/message-actions.js", async () => {
+  const actual = await vi.importActual<typeof import("../../channels/plugins/message-actions.js")>(
+    "../../channels/plugins/message-actions.js",
+  );
+  return {
+    ...actual,
+    dispatchChannelMessageAction: (...args: unknown[]) =>
+      mocks.dispatchChannelMessageAction(...args),
   };
 });
 
@@ -77,6 +93,8 @@ describe("runMessageAction threading auto-injection", () => {
     setActivePluginRegistry(createTestRegistry([]));
     mocks.executeSendAction.mockReset();
     mocks.recordSessionMetaFromInbound.mockReset();
+    mocks.dispatchChannelMessageAction.mockReset();
+    __clearSignalReactionTargetCacheForTests();
   });
 
   it("uses toolContext thread when auto-threading is active", async () => {
@@ -273,5 +291,39 @@ describe("runMessageAction threading auto-injection", () => {
     };
     expect(call?.replyToId).toBe("777");
     expect(call?.ctx?.params?.replyTo).toBe("777");
+  });
+
+  it("hydrates signal group reaction targetAuthorUuid from inbound cache", async () => {
+    recordSignalReactionTarget({
+      groupId: "group-id",
+      messageId: "1737630212345",
+      senderId: "uuid:123e4567-e89b-12d3-a456-426614174000",
+    });
+    mocks.dispatchChannelMessageAction.mockResolvedValue({ ok: true });
+
+    await runMessageAction({
+      cfg: {
+        channels: {
+          signal: {
+            account: "+15550001111",
+            reactionLevel: "minimal",
+            actions: { reactions: true },
+          },
+        },
+      } as OpenClawConfig,
+      action: "react",
+      params: {
+        channel: "signal",
+        target: "signal:group:group-id",
+        messageId: "1737630212345",
+        emoji: "✅",
+      },
+    });
+
+    const call = mocks.dispatchChannelMessageAction.mock.calls[0]?.[0] as
+      | { params?: Record<string, unknown> }
+      | undefined;
+    expect(call?.params?.targetAuthorUuid).toBe("123e4567-e89b-12d3-a456-426614174000");
+    expect(call?.params?.targetAuthor).toBeUndefined();
   });
 });

--- a/src/signal/reaction-target-cache.test.ts
+++ b/src/signal/reaction-target-cache.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  __clearSignalReactionTargetCacheForTests,
+  recordSignalReactionTarget,
+  resolveSignalReactionTarget,
+} from "./reaction-target-cache.js";
+
+describe("signal reaction target cache", () => {
+  beforeEach(() => {
+    __clearSignalReactionTargetCacheForTests();
+  });
+
+  it("records and resolves uuid authors", () => {
+    recordSignalReactionTarget({
+      groupId: "group-id",
+      messageId: "1771181675531",
+      senderId: "uuid:e489bcc7-6a67-429f-8278-a5710dcd8b02",
+    });
+
+    expect(
+      resolveSignalReactionTarget({
+        groupId: "group-id",
+        messageId: "1771181675531",
+      }),
+    ).toEqual({
+      targetAuthorUuid: "e489bcc7-6a67-429f-8278-a5710dcd8b02",
+      targetAuthor: undefined,
+    });
+  });
+
+  it("records and resolves phone authors when uuid is unavailable", () => {
+    recordSignalReactionTarget({
+      groupId: "group-id",
+      messageId: "1771181675531",
+      senderE164: "+15551230000",
+    });
+
+    expect(
+      resolveSignalReactionTarget({
+        groupId: "group-id",
+        messageId: "1771181675531",
+      }),
+    ).toEqual({
+      targetAuthorUuid: undefined,
+      targetAuthor: "+15551230000",
+    });
+  });
+
+  it("normalizes signal/group prefixes", () => {
+    recordSignalReactionTarget({
+      groupId: "signal:group:imrDE/AziMTrojCb1ngE9WcREGjKxjRq30krncLOZnM=",
+      messageId: "1771181675531",
+      senderId: "e489bcc7-6a67-429f-8278-a5710dcd8b02",
+    });
+
+    expect(
+      resolveSignalReactionTarget({
+        groupId: "group:imrDE/AziMTrojCb1ngE9WcREGjKxjRq30krncLOZnM=",
+        messageId: "1771181675531",
+      }),
+    ).toEqual({
+      targetAuthorUuid: "e489bcc7-6a67-429f-8278-a5710dcd8b02",
+      targetAuthor: undefined,
+    });
+  });
+});

--- a/src/signal/reaction-target-cache.ts
+++ b/src/signal/reaction-target-cache.ts
@@ -71,7 +71,7 @@ function pruneIfNeeded(): void {
   const sorted = Array.from(reactionTargetByGroupMessage.entries()).toSorted(
     (a, b) => a[1].recordedAt - b[1].recordedAt,
   );
-  const overflow = sorted.length - MAX_ENTRIES;
+  const overflow = reactionTargetByGroupMessage.size - MAX_ENTRIES;
   for (let i = 0; i < overflow; i += 1) {
     const key = sorted[i]?.[0];
     if (key) {

--- a/src/signal/reaction-target-cache.ts
+++ b/src/signal/reaction-target-cache.ts
@@ -1,0 +1,134 @@
+const SIGNAL_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const PHONE_RE = /^\+?[0-9][0-9\s().-]*$/;
+const MAX_ENTRIES = 5000;
+const TTL_MS = 24 * 60 * 60 * 1000;
+
+type SignalReactionTarget = {
+  groupId: string;
+  messageId: string;
+  targetAuthorUuid?: string;
+  targetAuthor?: string;
+  recordedAt: number;
+};
+
+const reactionTargetByGroupMessage = new Map<string, SignalReactionTarget>();
+
+function normalizeGroupId(raw?: string): string | undefined {
+  const trimmed = raw?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  return (
+    trimmed
+      .replace(/^signal:/i, "")
+      .replace(/^group:/i, "")
+      .trim() || undefined
+  );
+}
+
+function normalizeMessageId(raw?: string): string | undefined {
+  const trimmed = raw?.trim();
+  if (!trimmed || !/^[0-9]+$/.test(trimmed)) {
+    return undefined;
+  }
+  return trimmed;
+}
+
+function normalizeUuid(raw?: string): string | undefined {
+  const trimmed = raw?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const stripped = trimmed
+    .replace(/^signal:/i, "")
+    .replace(/^uuid:/i, "")
+    .trim();
+  return SIGNAL_UUID_RE.test(stripped) ? stripped : undefined;
+}
+
+function normalizePhone(raw?: string): string | undefined {
+  const trimmed = raw?.trim();
+  if (!trimmed || !PHONE_RE.test(trimmed)) {
+    return undefined;
+  }
+  return trimmed;
+}
+
+function makeKey(groupId: string, messageId: string): string {
+  return `${groupId}:${messageId}`;
+}
+
+function pruneIfNeeded(): void {
+  const now = Date.now();
+  for (const [key, value] of reactionTargetByGroupMessage.entries()) {
+    if (now - value.recordedAt > TTL_MS) {
+      reactionTargetByGroupMessage.delete(key);
+    }
+  }
+  if (reactionTargetByGroupMessage.size <= MAX_ENTRIES) {
+    return;
+  }
+  const sorted = Array.from(reactionTargetByGroupMessage.entries()).toSorted(
+    (a, b) => a[1].recordedAt - b[1].recordedAt,
+  );
+  const overflow = sorted.length - MAX_ENTRIES;
+  for (let i = 0; i < overflow; i += 1) {
+    const key = sorted[i]?.[0];
+    if (key) {
+      reactionTargetByGroupMessage.delete(key);
+    }
+  }
+}
+
+export function recordSignalReactionTarget(params: {
+  groupId?: string;
+  messageId?: string;
+  senderId?: string;
+  senderE164?: string;
+}): void {
+  const groupId = normalizeGroupId(params.groupId);
+  const messageId = normalizeMessageId(params.messageId);
+  if (!groupId || !messageId) {
+    return;
+  }
+  const targetAuthorUuid = normalizeUuid(params.senderId);
+  const targetAuthor = normalizePhone(params.senderE164) ?? normalizePhone(params.senderId);
+  if (!targetAuthorUuid && !targetAuthor) {
+    return;
+  }
+  reactionTargetByGroupMessage.set(makeKey(groupId, messageId), {
+    groupId,
+    messageId,
+    targetAuthorUuid,
+    targetAuthor,
+    recordedAt: Date.now(),
+  });
+  pruneIfNeeded();
+}
+
+export function resolveSignalReactionTarget(params: {
+  groupId?: string;
+  messageId?: string;
+}): { targetAuthorUuid?: string; targetAuthor?: string } | undefined {
+  const groupId = normalizeGroupId(params.groupId);
+  const messageId = normalizeMessageId(params.messageId);
+  if (!groupId || !messageId) {
+    return undefined;
+  }
+  const hit = reactionTargetByGroupMessage.get(makeKey(groupId, messageId));
+  if (!hit) {
+    return undefined;
+  }
+  if (Date.now() - hit.recordedAt > TTL_MS) {
+    reactionTargetByGroupMessage.delete(makeKey(groupId, messageId));
+    return undefined;
+  }
+  return {
+    targetAuthorUuid: hit.targetAuthorUuid,
+    targetAuthor: hit.targetAuthor,
+  };
+}
+
+export function __clearSignalReactionTargetCacheForTests(): void {
+  reactionTargetByGroupMessage.clear();
+}

--- a/src/signal/send-reactions.test.ts
+++ b/src/signal/send-reactions.test.ts
@@ -49,9 +49,21 @@ describe("sendReactionSignal", () => {
     });
 
     const params = rpcMock.mock.calls[0]?.[1] as Record<string, unknown>;
-    expect(params.recipients).toBeUndefined();
+    expect(params.recipients).toEqual(["123e4567-e89b-12d3-a456-426614174000"]);
     expect(params.groupIds).toEqual(["group-id"]);
     expect(params.targetAuthor).toBe("123e4567-e89b-12d3-a456-426614174000");
+  });
+
+  it("prefers targetAuthorUuid over targetAuthor when both are provided", async () => {
+    await sendReactionSignal("", 123, "✅", {
+      groupId: "group-id",
+      targetAuthor: "+15551230000",
+      targetAuthorUuid: "uuid:123e4567-e89b-12d3-a456-426614174000",
+    });
+
+    const params = rpcMock.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(params.targetAuthor).toBe("123e4567-e89b-12d3-a456-426614174000");
+    expect(params.recipients).toEqual(["123e4567-e89b-12d3-a456-426614174000"]);
   });
 
   it("defaults targetAuthor to recipient for removals", async () => {
@@ -61,5 +73,17 @@ describe("sendReactionSignal", () => {
     expect(params.recipients).toEqual(["+15551230000"]);
     expect(params.targetAuthor).toBe("+15551230000");
     expect(params.remove).toBe(true);
+  });
+
+  it("uses targetAuthor for group removals when recipient is empty", async () => {
+    await removeReactionSignal("", 456, "❌", {
+      groupId: "group-id",
+      targetAuthorUuid: "uuid:123e4567-e89b-12d3-a456-426614174000",
+    });
+
+    const params = rpcMock.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(params.recipients).toEqual(["123e4567-e89b-12d3-a456-426614174000"]);
+    expect(params.targetAuthor).toBe("123e4567-e89b-12d3-a456-426614174000");
+    expect(params.groupIds).toEqual(["group-id"]);
   });
 });

--- a/src/signal/send-reactions.ts
+++ b/src/signal/send-reactions.ts
@@ -110,8 +110,7 @@ async function sendReactionSignalCore(params: {
     ...targetAuthorParams,
   };
   const recipients =
-    normalizedRecipient ||
-    (groupId ? targetAuthorParams.targetAuthor?.trim() : undefined);
+    normalizedRecipient || (groupId ? targetAuthorParams.targetAuthor?.trim() : undefined);
   if (recipients) {
     requestParams.recipients = [recipients];
   }

--- a/src/signal/send-reactions.ts
+++ b/src/signal/send-reactions.ts
@@ -53,7 +53,7 @@ function resolveTargetAuthorParams(params: {
   targetAuthorUuid?: string;
   fallback?: string;
 }): { targetAuthor?: string } {
-  const candidates = [params.targetAuthor, params.targetAuthorUuid, params.fallback];
+  const candidates = [params.targetAuthorUuid, params.targetAuthor, params.fallback];
   for (const candidate of candidates) {
     const raw = candidate?.trim();
     if (!raw) {
@@ -109,8 +109,11 @@ async function sendReactionSignalCore(params: {
     ...(params.remove ? { remove: true } : {}),
     ...targetAuthorParams,
   };
-  if (normalizedRecipient) {
-    requestParams.recipients = [normalizedRecipient];
+  const recipients =
+    normalizedRecipient ||
+    (groupId ? targetAuthorParams.targetAuthor?.trim() : undefined);
+  if (recipients) {
+    requestParams.recipients = [recipients];
   }
   if (groupId) {
     requestParams.groupIds = [groupId];


### PR DESCRIPTION
## Summary

  Describe the problem and fix in 2–5 bullets:

  - Problem: Signal group reactions were unreliable because targetAuthor/targetAuthorUuid was often missing or model-
    guessed, causing reactions to fail or be accepted without visible UI effect.
  - Why it matters: Group reaction behavior must deterministically target the exact inbound message author; otherwise
    reactions are flaky in real group chats.
  - What changed: Added an inbound reaction-target cache (groupId + messageId -> sender uuid/e164), populated it in
    Signal inbound handling, and used it in outbound react action prep when targetAuthor* is not provided. Also
    tightened reaction payload shaping to prefer UUID and set recipients for group reactions/removals.
  - What did NOT change (scope boundary): No changes to non-Signal channels, no new external services, no schema/API
    contract changes, and no config migration.

  ## Change Type (select all)

  - [x] Bug fix
  - [ ] Feature
  - [ ] Refactor
  - [ ] Docs
  - [ ] Security hardening
  - [ ] Chore/infra

  ## Scope (select all touched areas)

  - [x] Gateway / orchestration
  - [ ] Skills / tool execution
  - [ ] Auth / tokens
  - [x] Memory / storage
  - [x] Integrations
  - [ ] API / contracts
  - [ ] UI / DX
  - [ ] CI/CD / infra

  ## Linked Issue/PR

  - Closes #
  - Related #

  ## User-visible / Behavior Changes

  - Signal group “react to this message” is now more reliable when messageId is known but targetAuthor* is omitted.
  - For group reactions/removals, UUID targeting is preferred and recipient shaping is more consistent.
  - No new user-facing config required.

  ## Security Impact (required)

  - New permissions/capabilities? (No)
  - Secrets/tokens handling changed? (No)
  - New/changed network calls? (No)
  - Command/tool execution surface changed? (No)
  - Data access scope changed? (Yes)
  - If any Yes, explain risk + mitigation:
      - Added a small in-memory cache of inbound group reaction metadata (sender identifier keyed by group/message) with
        TTL and size cap.
      - Mitigations: bounded cache (MAX_ENTRIES), expiration (TTL_MS), no persistence to disk, no secret material.

  ## Repro + Verification

  ### Environment

  - OS: macOS
  - Runtime/container: Docker Compose (openclaw-gateway + signal-cli-daemon)
  - Model/provider: OpenAI Codex (gpt-5.3-codex)
  - Integration/channel (if any): Signal group + direct chat
  - Relevant config (redacted): channels.signal.reactionLevel=minimal, actions.reactions=true

  ### Steps

  1. Receive a Signal group inbound message and ask agent to react to that message.
  2. Trigger message.react without explicitly forcing targetAuthorUuid.
  3. Observe gateway logs and Signal UI behavior.

  ### Expected

  - Group reaction resolves to exact inbound sender and appears in Signal UI.

  ### Actual

  - Before fix: reactions frequently failed (targetAuthor required) or reported success but were not visible.
  - After fix: deterministic sender targeting is applied via inbound cache; reactions are consistently resolved.

  ## Evidence

  Attach at least one:

  - [x] Failing test/log before + passing after
  - [x] Trace/log snippets
  - [ ] Screenshot/recording
  - [ ] Perf numbers (if relevant)

  ## Human Verification (required)

  What you personally verified (not just CI), and how:

  - Verified scenarios:
      - Group reaction target hydration from inbound metadata cache.
      - UUID-preferred target selection.
      - Group removal payload shaping using resolved target.
  - Edge cases checked:
      - Missing targetAuthor* with valid groupId + messageId.
      - UUID vs E.164 fallback behavior.
  - What you did not verify:
      - Full matrix across all Signal daemon versions and multi-device clients.

  ## Compatibility / Migration

  - Backward compatible? (Yes)
  - Config/env changes? (No)
  - Migration needed? (No)
  - If yes, exact upgrade steps:

  ## Failure Recovery (if this breaks)

  - How to disable/revert this change quickly:
      - Revert commit cda8b78bbd8d76001d2331596038babb3cb82763.
  - Files/config to restore:
      - src/infra/outbound/message-action-runner.ts
      - src/signal/monitor/event-handler.ts
      - src/signal/send-reactions.ts
      - remove src/signal/reaction-target-cache.ts
  - Known bad symptoms reviewers should watch for:
      - Group react regression to targetAuthor is required errors.
      - Group reactions accepted but not visible in Signal UI.

  ## Risks and Mitigations

  - Risk:
      - Stale cache entry could map message->author incorrectly if identifiers collide.
      - Mitigation:
          - Keyed by exact groupId + messageId, bounded size, TTL expiry, and no cross-group reuse.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes unreliable Signal group reactions by adding a deterministic sender-resolution mechanism. The core change introduces an in-memory reaction-target cache (`reaction-target-cache.ts`) that maps `(groupId, messageId)` to the inbound sender's UUID/E.164, populated during Signal inbound message handling. When an outbound group reaction is triggered without explicit `targetAuthor`/`targetAuthorUuid`, the cache is consulted to resolve the correct author.

- **New cache module** (`src/signal/reaction-target-cache.ts`): bounded (5000 entries), TTL-expiring (24h), properly normalized keys. No persistence, no secret material.
- **Outbound hydration** (`src/infra/outbound/message-action-runner.ts`): Signal react actions now auto-resolve `targetAuthorUuid` from the cache when the agent doesn't explicitly provide it.
- **UUID preference** (`src/signal/send-reactions.ts`): `resolveTargetAuthorParams` now prefers UUID over phone number, and group reactions/removals set `recipients` from the resolved target author when no explicit recipient is provided.
- **Inbound recording** (`src/signal/monitor/event-handler.ts`): group messages now record sender metadata into the cache for later reaction-target resolution.
- Tests cover cache operations, UUID preference, group removal scenarios, and end-to-end hydration flow.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it adds a well-bounded, non-persistent in-memory cache with no external side effects and tightens existing reaction payload logic.
- All changes are narrowly scoped to Signal group reaction handling. The new cache is bounded (5000 entries, 24h TTL), normalization is idempotent and consistent between record and resolve paths, Map deletion during iteration is spec-safe, and the UUID-preference reorder in resolveTargetAuthorParams is correct. Tests cover core scenarios including hydration, UUID preference, phone fallback, prefix normalization, and group removals. No new external network calls, no schema changes, no security surface expansion.
- No files require special attention

<sub>Last reviewed commit: 2ecb41e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->