### PR TITLE
fix(test): stabilize media root guard test against tmpdir HOME overlap

### DIFF
--- a/src/web/media.test.ts
+++ b/src/web/media.test.ts
@@ -445,15 +445,28 @@ describe("local media root guard", () => {
   });
 
   it("rejects default OpenClaw state per-agent workspace-* roots without explicit local roots", async () => {
-    const stateDir = resolveStateDir();
-    const readFile = vi.fn(async () => Buffer.from("generated-media"));
+    // The test harness may set HOME to a temp directory under os.tmpdir(),
+    // making all homedir-relative paths fall under the tmpdir default root.
+    // Use an absolute path outside /tmp to ensure no default root matches.
+    const stateDir = "/var/openclaw-guard-reject-test";
+    const prev = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    try {
+      const readFile = vi.fn(async () => Buffer.from("generated-media"));
 
-    await expect(
-      loadWebMedia(path.join(stateDir, "workspace-clawdy", "tmp", "render.bin"), {
-        maxBytes: 1024 * 1024,
-        readFile,
-      }),
-    ).rejects.toMatchObject({ code: "path-not-allowed" });
+      await expect(
+        loadWebMedia(path.join(stateDir, "workspace-clawdy", "tmp", "render.bin"), {
+          maxBytes: 1024 * 1024,
+          readFile,
+        }),
+      ).rejects.toMatchObject({ code: "path-not-allowed" });
+    } finally {
+      if (prev === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = prev;
+      }
+    }
   });
 
   it("allows per-agent workspace-* paths with explicit local roots", async () => {


### PR DESCRIPTION
## fix(test): stabilize media root guard test

### Problem

The test `rejects default OpenClaw state per-agent workspace-* roots without explicit local roots` in `src/web/media.test.ts` **fails on every CI run** (bun + node), including on `main`.

### Root Cause

The test harness sets `HOME` to a temp directory under `os.tmpdir()`:

```
HOME=/tmp/openclaw-test-home-xC06Jb
```

Since `os.tmpdir()` (`/tmp`) is a default allowed media root, **all paths** under the test's `HOME` directory match the tmpdir root:

```
testPath: /tmp/openclaw-test-home-xC06Jb/.openclaw-guard-reject-test/workspace-clawdy/tmp/render.bin
root /tmp → MATCH (startsWith /tmp/)
```

The test expects a rejection but gets a successful resolve because the path is "allowed" via tmpdir.

### Fix

Pin `OPENCLAW_STATE_DIR` to `/var/openclaw-guard-reject-test` (outside `/tmp`) for the duration of the test. This is the same pattern used in `be9b5cefb` for the `web media loading` describe block, which was missing from the separate `local media root guard` describe block.

### Changed Files

| File | Change |
|------|--------|
| `src/web/media.test.ts` | Pin OPENCLAW_STATE_DIR in the failing test |

### Testing

- All 22 media tests pass (previously 21 pass / 1 fail)
- This fixes the CI failure visible on `main` and all open PRs

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Pinned `OPENCLAW_STATE_DIR` to `/var/openclaw-guard-reject-test` during the test to prevent `/tmp` from being a parent directory, ensuring the media root guard properly rejects `workspace-*` paths without explicit local roots. The fix mirrors the existing pattern from the `web media loading` test block and resolves a test failure that occurred when the test harness set `HOME` to a temp directory under `os.tmpdir()`.

- Applied the same environment pinning pattern used in `src/web/media.test.ts:116-130`
- Properly restores the previous `OPENCLAW_STATE_DIR` value in a finally block
- Handles both undefined and defined previous values correctly

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The fix is minimal, well-documented, follows an existing pattern in the same file, and properly handles cleanup. It addresses a real test failure by fixing a test environment setup issue without changing any production code.
- No files require special attention

<sub>Last reviewed commit: 86343cf</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->