### PR TITLE
fix(cache): enable cache retention for Google Vertex AI (#15525)

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.e2e.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.e2e.test.ts
@@ -3,6 +3,7 @@ import type { Context, Model, SimpleStreamOptions } from "@mariozechner/pi-ai";
 import { AssistantMessageEventStream } from "@mariozechner/pi-ai";
 import { describe, expect, it } from "vitest";
 import { applyExtraParamsToAgent, resolveExtraParams } from "./pi-embedded-runner.js";
+import { isCacheTtlEligibleProvider } from "./pi-embedded-runner/cache-ttl.js";
 
 describe("resolveExtraParams", () => {
   it("returns undefined with no model config", () => {
@@ -159,5 +160,111 @@ describe("applyExtraParamsToAgent", () => {
     void agent.streamFn?.(model, context, {});
 
     expect(payload.store).toBe(false);
+  });
+
+  it("applies cacheRetention for google-vertex provider", () => {
+    const calls: Array<SimpleStreamOptions | undefined> = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      calls.push(options);
+      return new AssistantMessageEventStream();
+    };
+    const agent = { streamFn: baseStreamFn };
+
+    applyExtraParamsToAgent(
+      agent,
+      {
+        agents: {
+          defaults: {
+            models: {
+              "google-vertex/claude-opus-4-6": {
+                params: { cacheRetention: "short" },
+              },
+            },
+          },
+        },
+      },
+      "google-vertex",
+      "claude-opus-4-6",
+    );
+
+    const model = {
+      api: "anthropic",
+      provider: "google-vertex",
+      id: "claude-opus-4-6",
+    } as Model<"anthropic">;
+    const context: Context = { messages: [] };
+
+    void agent.streamFn?.(model, context, {});
+
+    expect(calls).toHaveLength(1);
+    expect((calls[0] as Record<string, unknown>).cacheRetention).toBe("short");
+  });
+
+  it("does not apply cacheRetention for non-anthropic/non-vertex providers", () => {
+    const calls: Array<SimpleStreamOptions | undefined> = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      calls.push(options);
+      return new AssistantMessageEventStream();
+    };
+    const agent = { streamFn: baseStreamFn };
+
+    applyExtraParamsToAgent(
+      agent,
+      {
+        agents: {
+          defaults: {
+            models: {
+              "openai/gpt-5": {
+                params: { cacheRetention: "short" },
+              },
+            },
+          },
+        },
+      },
+      "openai",
+      "gpt-5",
+    );
+
+    const model = {
+      api: "openai-completions",
+      provider: "openai",
+      id: "gpt-5",
+    } as Model<"openai-completions">;
+    const context: Context = { messages: [] };
+
+    void agent.streamFn?.(model, context, {});
+
+    // streamFn should not have been wrapped with cacheRetention since
+    // the underlying createStreamFnWithExtraParams strips non-applicable params.
+    // The call goes through the OpenAI store wrapper which doesn't add cacheRetention.
+    expect(calls).toHaveLength(1);
+    expect((calls[0] as Record<string, unknown>).cacheRetention).toBeUndefined();
+  });
+});
+
+describe("isCacheTtlEligibleProvider", () => {
+  it("returns true for anthropic provider", () => {
+    expect(isCacheTtlEligibleProvider("anthropic", "claude-opus-4-6")).toBe(true);
+  });
+
+  it("returns true for google-vertex provider", () => {
+    expect(isCacheTtlEligibleProvider("google-vertex", "claude-opus-4-6")).toBe(true);
+  });
+
+  it("returns true for openrouter with anthropic model", () => {
+    expect(isCacheTtlEligibleProvider("openrouter", "anthropic/claude-opus-4-6")).toBe(true);
+  });
+
+  it("returns false for openrouter with non-anthropic model", () => {
+    expect(isCacheTtlEligibleProvider("openrouter", "google/gemini-3-pro")).toBe(false);
+  });
+
+  it("returns false for other providers", () => {
+    expect(isCacheTtlEligibleProvider("openai", "gpt-5")).toBe(false);
+  });
+
+  it("is case-insensitive for provider", () => {
+    expect(isCacheTtlEligibleProvider("Google-Vertex", "claude-opus-4-6")).toBe(true);
+    expect(isCacheTtlEligibleProvider("ANTHROPIC", "claude-opus-4-6")).toBe(true);
   });
 });

--- a/src/agents/pi-embedded-runner/cache-ttl.ts
+++ b/src/agents/pi-embedded-runner/cache-ttl.ts
@@ -11,7 +11,7 @@ export type CacheTtlEntryData = {
 export function isCacheTtlEligibleProvider(provider: string, modelId: string): boolean {
   const normalizedProvider = provider.toLowerCase();
   const normalizedModelId = modelId.toLowerCase();
-  if (normalizedProvider === "anthropic") {
+  if (normalizedProvider === "anthropic" || normalizedProvider === "google-vertex") {
     return true;
   }
   if (normalizedProvider === "openrouter" && normalizedModelId.startsWith("anthropic/")) {

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -40,14 +40,15 @@ type CacheRetentionStreamOptions = Partial<SimpleStreamOptions> & {
  *
  * Mapping: "5m" → "short", "1h" → "long"
  *
- * Only applies to Anthropic provider (OpenRouter uses openai-completions API
- * with hardcoded cache_control, not the cacheRetention stream option).
+ * Only applies to providers that use the Anthropic Messages API natively
+ * (direct Anthropic and Google Vertex AI). OpenRouter uses openai-completions
+ * API with hardcoded cache_control, not the cacheRetention stream option.
  */
 function resolveCacheRetention(
   extraParams: Record<string, unknown> | undefined,
   provider: string,
 ): CacheRetention | undefined {
-  if (provider !== "anthropic") {
+  if (provider !== "anthropic" && provider !== "google-vertex") {
     return undefined;
   }
 


### PR DESCRIPTION
## Summary

Fixes #15525. Vertex AI users get no prompt caching because `resolveCacheRetention()` only checks `provider === "anthropic"` and `isCacheTtlEligibleProvider()` excludes `google-vertex`. Since Vertex AI uses the Anthropic Messages API natively, it supports the same `cacheRetention` stream option.

## Root Cause

In `extra-params.ts`, the provider guard rejects everything except `"anthropic"`:

```ts
if (provider !== "anthropic") {
    return undefined;
}
```

In `cache-ttl.ts`, the eligibility check only allows `"anthropic"` and `"openrouter"` with anthropic models:

```ts
if (normalizedProvider === "anthropic") {
    return true;
}
```

## Fix

Add `google-vertex` to both provider checks:

```ts
// extra-params.ts
if (provider !== "anthropic" && provider !== "google-vertex") {
```

```ts
// cache-ttl.ts
if (normalizedProvider === "anthropic" || normalizedProvider === "google-vertex") {
```

Two-line change across two files. No new dependencies.

## Test plan

- [x] e2e test: `cacheRetention` applied for `google-vertex` provider
- [x] e2e test: `cacheRetention` NOT applied for non-Anthropic providers
- [x] Unit tests for `isCacheTtlEligibleProvider` covering all providers + case insensitivity

## Local Validation

- `pnpm build` ✅
- `pnpm check` (format + tsgo + lint) ✅
- Relevant test suites pass ✅

## Contribution Checklist

- [x] Focused scope — single fix per PR
- [x] Clear "what" + "why" in description
- [x] AI-assisted (Claude) — reviewed and tested by human
- [x] Local validation run (`pnpm build && pnpm check`)

*AI-assisted (Claude). Reviewed and tested by human.*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Enables prompt caching for Google Vertex AI by adding `google-vertex` to provider eligibility checks in two functions (`resolveCacheRetention` in `extra-params.ts:51` and `isCacheTtlEligibleProvider` in `cache-ttl.ts:14`). Since Vertex AI uses the Anthropic Messages API natively (as confirmed by `api: "anthropic"` in tests), it supports the same `cacheRetention` stream option.

- Fixes missing cache retention for `google-vertex` provider
- Comprehensive test coverage: e2e tests verify `cacheRetention` applied correctly for `google-vertex` and rejected for non-eligible providers
- Unit tests cover all provider cases including case-insensitivity
- Implementation is minimal and focused on the specific issue

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are minimal (two provider checks updated), well-tested with comprehensive e2e and unit tests, and technically correct since Google Vertex AI uses the Anthropic Messages API natively. The fix is isolated to cache retention logic with no side effects on other functionality.
- No files require special attention

<sub>Last reviewed commit: afe01c7</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->