### PR TITLE
Improve unknown-model errors for provider/model misconfiguration

### DIFF
--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -302,7 +302,7 @@ describe("resolveModel", () => {
     const result = resolveModel("google-antigravity", "claude-opus-4-6-thinking", "/tmp/agent");
 
     expect(result.model).toBeUndefined();
-    expect(result.error).toBe("Unknown model: google-antigravity/claude-opus-4-6-thinking");
+    expect(result.error).toContain("Unknown model: google-antigravity/claude-opus-4-6-thinking");
   });
 
   it("keeps unknown-model errors when no antigravity non-thinking template exists", () => {
@@ -313,13 +313,13 @@ describe("resolveModel", () => {
     const result = resolveModel("google-antigravity", "claude-opus-4-6", "/tmp/agent");
 
     expect(result.model).toBeUndefined();
-    expect(result.error).toBe("Unknown model: google-antigravity/claude-opus-4-6");
+    expect(result.error).toContain("Unknown model: google-antigravity/claude-opus-4-6");
   });
 
   it("keeps unknown-model errors for non-gpt-5 openai-codex ids", () => {
     const result = resolveModel("openai-codex", "gpt-4.1-mini", "/tmp/agent");
     expect(result.model).toBeUndefined();
-    expect(result.error).toBe("Unknown model: openai-codex/gpt-4.1-mini");
+    expect(result.error).toContain("Unknown model: openai-codex/gpt-4.1-mini");
   });
 
   it("uses codex fallback even when openai-codex provider is configured", () => {
@@ -347,5 +347,24 @@ describe("resolveModel", () => {
     expect(result.model?.api).toBe("openai-codex-responses");
     expect(result.model?.id).toBe("gpt-5.3-codex");
     expect(result.model?.provider).toBe("openai-codex");
+  });
+
+  it("includes configured provider hint when provider prefix is missing", () => {
+    const cfg = {
+      models: {
+        providers: {
+          lmproxy: {
+            baseUrl: "http://localhost:1234/v1",
+            models: [{ id: "minicpm-o-4_5", name: "MiniCPM" }],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = resolveModel("lmstudio", "minicpm-o-4_5", "/tmp/agent", cfg);
+
+    expect(result.model).toBeUndefined();
+    expect(result.error).toContain("Unknown model: lmstudio/minicpm-o-4_5.");
+    expect(result.error).toContain('Configured custom providers: "lmproxy".');
   });
 });

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -92,8 +92,25 @@ export function resolveModel(
       } as Model<Api>);
       return { model: fallbackModel, authStorage, modelRegistry };
     }
+
+    const configuredProviders = Object.keys(providers)
+      .map((id) => id.trim())
+      .filter(Boolean)
+      .sort();
+    const normalizedRequested = normalizeProviderId(provider);
+    const normalizedMatches = configuredProviders.filter(
+      (id) => normalizeProviderId(id) === normalizedRequested,
+    );
+
+    const detail =
+      normalizedMatches.length > 0
+        ? ` Provider mismatch: requested \"${provider}\" but configured as ${normalizedMatches.map((id) => `\"${id}\"`).join(", ")}.`
+        : configuredProviders.length > 0
+          ? ` Configured custom providers: ${configuredProviders.map((id) => `\"${id}\"`).join(", ")}.`
+          : "";
+
     return {
-      error: `Unknown model: ${provider}/${modelId}`,
+      error: `Unknown model: ${provider}/${modelId}.${detail}`,
       authStorage,
       modelRegistry,
     };


### PR DESCRIPTION
## Summary
Improve diagnostics when a model references a provider prefix that isn't configured (common local proxy misconfiguration like `lmstudio/...` vs `models.providers.lmproxy`).

## What changed
- `resolveModel()` now appends actionable hints to unknown-model errors:
  - Lists configured custom providers when provider is missing.
  - Detects normalized provider mismatch and reports the configured key(s).
- Added test coverage in `src/agents/pi-embedded-runner/model.test.ts` for provider-hint behavior.
- Relaxed a few brittle equality assertions to `toContain` in unknown-model tests.

## Why
Today this failure mode can look like transport/network trouble ("no socket opened") even though resolution failed pre-transport. This patch makes failures immediate and obvious so users can fix config quickly.

## Example
Before:
- `Unknown model: lmstudio/minicpm-o-4_5`

After:
- `Unknown model: lmstudio/minicpm-o-4_5. Configured custom providers: "lmproxy".`

## Notes
- I couldn't run vitest in this environment because `pnpm` is not installed on this host.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Enhanced error diagnostics in `resolveModel()` to provide actionable hints when a model references an unconfigured provider prefix. The implementation correctly handles two scenarios: detecting normalized provider mismatches (e.g., requesting `lmstudio` when `lmproxy` is configured) and listing all configured custom providers when no match is found.

**Key changes:**
- Error messages now append helpful context: configured provider names or mismatch details (lines 96-113 in model.ts)
- Unit tests relaxed from `.toBe()` to `.toContain()` to accommodate variable error suffixes
- New test case validates provider hint behavior for common misconfiguration scenario

**Issues found:**
- E2e test at model.e2e.test.ts:61 still uses strict `.toBe()` assertion and will fail with the new error format that includes a trailing period

<h3>Confidence Score: 4/5</h3>

- Safe to merge after fixing the e2e test assertion
- The implementation logic is sound and well-tested, with appropriate normalization and matching. The error message construction is clear and helpful. However, the e2e test will fail due to a brittle assertion that wasn't updated alongside the unit tests, preventing a clean merge until fixed.
- model.e2e.test.ts requires the assertion fix before merge

<sub>Last reviewed commit: 241a058</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->