### PR TITLE
feat(cache): per-agent params for cacheRetention control (#17112)

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.e2e.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.e2e.test.ts
@@ -62,6 +62,79 @@ describe("resolveExtraParams", () => {
 
     expect(result).toBeUndefined();
   });
+
+  it("returns per-agent params when agentId matches", () => {
+    const result = resolveExtraParams({
+      cfg: {
+        agents: {
+          list: [
+            {
+              id: "risk-reviewer",
+              params: { cacheRetention: "none" },
+            },
+          ],
+        },
+      },
+      provider: "anthropic",
+      modelId: "claude-opus-4-6",
+      agentId: "risk-reviewer",
+    });
+
+    expect(result).toEqual({ cacheRetention: "none" });
+  });
+
+  it("merges per-agent params over global model defaults", () => {
+    const result = resolveExtraParams({
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "anthropic/claude-opus-4-6": {
+                params: {
+                  temperature: 0.5,
+                  cacheRetention: "long",
+                },
+              },
+            },
+          },
+          list: [
+            {
+              id: "risk-reviewer",
+              params: { cacheRetention: "none" },
+            },
+          ],
+        },
+      },
+      provider: "anthropic",
+      modelId: "claude-opus-4-6",
+      agentId: "risk-reviewer",
+    });
+
+    expect(result).toEqual({
+      temperature: 0.5,
+      cacheRetention: "none",
+    });
+  });
+
+  it("ignores per-agent params when agentId does not match", () => {
+    const result = resolveExtraParams({
+      cfg: {
+        agents: {
+          list: [
+            {
+              id: "risk-reviewer",
+              params: { cacheRetention: "none" },
+            },
+          ],
+        },
+      },
+      provider: "anthropic",
+      modelId: "claude-opus-4-6",
+      agentId: "main",
+    });
+
+    expect(result).toBeUndefined();
+  });
 });
 
 describe("applyExtraParamsToAgent", () => {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -618,6 +618,7 @@ export async function runEmbeddedAttempt(
         params.provider,
         params.modelId,
         params.streamParams,
+        sessionAgentId,
       );
 
       if (cacheTrace) {

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -63,6 +63,8 @@ export type AgentConfig = {
     prune?: SandboxPruneSettings;
   };
   tools?: AgentToolsConfig;
+  /** Per-agent stream params (e.g., cacheRetention, temperature). Overrides global model defaults. */
+  params?: Record<string, unknown>;
 };
 
 export type AgentsConfig = {


### PR DESCRIPTION
## Summary

Fixes #17112. No way to set `cacheRetention` per-agent. Low-traffic agents (e.g., cron jobs running every 30 min) waste money on cache writes ($1.25/MTok) that expire before the next request.

## Root Cause

`resolveExtraParams()` only reads from global model defaults (`agents.defaults.models["provider/model"].params`). There is no per-agent override — all agents sharing the same model get identical cache settings.

## Fix

Add optional `params` field to `AgentConfig` and resolve it in `resolveExtraParams()`:

```ts
// types.agents.ts
export type AgentConfig = {
  // ...existing fields...
  params?: Record<string, unknown>;
};
```

```ts
// extra-params.ts — resolveExtraParams now accepts agentId
const agentConfig = cfg?.agents?.list?.find((a) => a.id === params.agentId);
return Object.assign({}, globalParams, agentConfig?.params);
```

Agent params merge on top of global model defaults. Three files changed, no new dependencies.

**Config example:**
```json
{
  "agents": {
    "list": [{
      "id": "risk-reviewer",
      "params": { "cacheRetention": "none" }
    }]
  }
}
```

## Test plan

- [x] Per-agent params returned when agentId matches
- [x] Agent params merge over global model defaults (agent wins)
- [x] Unmatched agentId returns undefined (no side effects)

## Local Validation

- `pnpm build` ✅
- `pnpm check` (format + tsgo + lint) ✅
- Relevant test suites pass ✅

## Contribution Checklist

- [x] Focused scope — single feature per PR
- [x] Clear "what" + "why" in description
- [x] AI-assisted (Claude) — reviewed and tested by human
- [x] Local validation run (`pnpm build && pnpm check`)

*AI-assisted (Claude). Reviewed and tested by human.*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds per-agent `params` override support to `resolveExtraParams`, allowing individual agents to customize stream parameters (e.g., `cacheRetention`, `temperature`) that previously could only be set globally per model. Agent-level params merge on top of global model defaults, with agent values winning on conflict.

- Adds optional `params?: Record<string, unknown>` field to `AgentConfig` type
- Extends `resolveExtraParams` and `applyExtraParamsToAgent` with optional `agentId` parameter
- Passes `sessionAgentId` through at the call site in `attempt.ts`
- Three new tests cover match, merge, and no-match scenarios
- Backward-compatible: all new parameters are optional, existing behavior unchanged when `agentId` is not provided

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a small, well-scoped additive feature with proper tests and no breaking changes.
- The change is minimal (4 files, ~50 lines of logic), fully backward-compatible (all new parameters are optional), and well-tested. The merge semantics (Object.assign with agent overriding global) are correct and straightforward. The integration point in attempt.ts correctly passes the already-resolved sessionAgentId. No security concerns, no mutation of config objects, and existing call sites don't need updating.
- No files require special attention.

<sub>Last reviewed commit: 8c13172</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->