### PR TITLE
fix(cache): inject cache_control into system prompt for OpenRouter Anthropic (#15151)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- OpenRouter/Anthropic: inject `cache_control` on system prompts for OpenRouter Anthropic models to improve prompt-cache reuse. (#17473) Thanks @rrenamed.
+
 - Providers/OpenRouter: allow pass-through OpenRouter and Opencode model IDs in live model filtering so custom routed model IDs are treated as modern refs. (#14312) Thanks @Joly0.
 - Providers/OpenRouter: default reasoning to enabled when the selected model advertises `reasoning: true` and no session/directive override is set. (#22513) Thanks @zwffff.
 - Providers/OpenRouter: map `/think` levels to `reasoning.effort` in embedded runs while preserving explicit `reasoning.max_tokens` payloads. (#17236) Thanks @robbyczgw-cla.

--- a/src/agents/pi-embedded-runner/extra-params.openrouter-cache-control.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.openrouter-cache-control.test.ts
@@ -1,0 +1,99 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import type { Context, Model } from "@mariozechner/pi-ai";
+import { AssistantMessageEventStream } from "@mariozechner/pi-ai";
+import { describe, expect, it } from "vitest";
+import { applyExtraParamsToAgent } from "./extra-params.js";
+
+describe("extra-params: OpenRouter Anthropic cache_control", () => {
+  it("injects cache_control into system message for OpenRouter Anthropic models", () => {
+    const payload = {
+      messages: [
+        { role: "system", content: "You are a helpful assistant." },
+        { role: "user", content: "Hello" },
+      ],
+    };
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      options?.onPayload?.(payload);
+      return new AssistantMessageEventStream();
+    };
+    const agent = { streamFn: baseStreamFn };
+
+    applyExtraParamsToAgent(agent, undefined, "openrouter", "anthropic/claude-opus-4-6");
+
+    const model = {
+      api: "openai-completions",
+      provider: "openrouter",
+      id: "anthropic/claude-opus-4-6",
+    } as Model<"openai-completions">;
+    const context: Context = { messages: [] };
+
+    void agent.streamFn?.(model, context, {});
+
+    expect(payload.messages[0].content).toEqual([
+      { type: "text", text: "You are a helpful assistant.", cache_control: { type: "ephemeral" } },
+    ]);
+    expect(payload.messages[1].content).toBe("Hello");
+  });
+
+  it("adds cache_control to last content block when system message is already array", () => {
+    const payload = {
+      messages: [
+        {
+          role: "system",
+          content: [
+            { type: "text", text: "Part 1" },
+            { type: "text", text: "Part 2" },
+          ],
+        },
+      ],
+    };
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      options?.onPayload?.(payload);
+      return new AssistantMessageEventStream();
+    };
+    const agent = { streamFn: baseStreamFn };
+
+    applyExtraParamsToAgent(agent, undefined, "openrouter", "anthropic/claude-opus-4-6");
+
+    const model = {
+      api: "openai-completions",
+      provider: "openrouter",
+      id: "anthropic/claude-opus-4-6",
+    } as Model<"openai-completions">;
+    const context: Context = { messages: [] };
+
+    void agent.streamFn?.(model, context, {});
+
+    const content = payload.messages[0].content as Array<Record<string, unknown>>;
+    expect(content[0]).toEqual({ type: "text", text: "Part 1" });
+    expect(content[1]).toEqual({
+      type: "text",
+      text: "Part 2",
+      cache_control: { type: "ephemeral" },
+    });
+  });
+
+  it("does not inject cache_control for OpenRouter non-Anthropic models", () => {
+    const payload = {
+      messages: [{ role: "system", content: "You are a helpful assistant." }],
+    };
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      options?.onPayload?.(payload);
+      return new AssistantMessageEventStream();
+    };
+    const agent = { streamFn: baseStreamFn };
+
+    applyExtraParamsToAgent(agent, undefined, "openrouter", "google/gemini-3-pro");
+
+    const model = {
+      api: "openai-completions",
+      provider: "openrouter",
+      id: "google/gemini-3-pro",
+    } as Model<"openai-completions">;
+    const context: Context = { messages: [] };
+
+    void agent.streamFn?.(model, context, {});
+
+    expect(payload.messages[0].content).toBe("You are a helpful assistant.");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #15151. OpenRouter Anthropic users pay full price for re-processing the system prompt (~18k tokens) on every request because no `cache_control` is injected on the system message.

## Root Cause

The existing OpenRouter integration adds attribution headers (`createOpenRouterHeadersWrapper`) but does not inject Anthropic's `cache_control` field on messages. For direct Anthropic, caching is handled via the `cacheRetention` stream option — but OpenRouter uses the openai-completions API where caching requires explicit `cache_control` on message content blocks.

## Fix

Add `createOpenRouterSystemCacheWrapper()` using the same `onPayload` pattern as `createOpenAIResponsesStoreWrapper()`:

```ts
onPayload: (payload) => {
    for (const msg of messages) {
        if (msg.role !== "system" && msg.role !== "developer") continue;
        if (typeof msg.content === "string") {
            msg.content = [
                { type: "text", text: msg.content, cache_control: { type: "ephemeral" } },
            ];
        } else if (Array.isArray(msg.content)) {
            last.cache_control = { type: "ephemeral" };
        }
    }
};
```

Only applies to `openrouter` provider with `anthropic/*` model IDs. One new wrapper, no new dependencies.

## Test plan

- [x] String system content converted to array with `cache_control`
- [x] Array system content gets `cache_control` on last block only
- [x] Non-Anthropic OpenRouter models not affected
- [x] User messages not modified

## Local Validation

- `pnpm build` ✅
- `pnpm check` (format + tsgo + lint) ✅
- Relevant test suites pass ✅

## Contribution Checklist

- [x] Focused scope — single fix per PR
- [x] Clear "what" + "why" in description
- [x] AI-assisted (Claude) — reviewed and tested by human
- [x] Local validation run (`pnpm build && pnpm check`)

*AI-assisted (Claude). Reviewed and tested by human.*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `createOpenRouterSystemCacheWrapper()` to inject Anthropic's `cache_control: { type: "ephemeral" }` into system/developer messages when using OpenRouter with Anthropic models. This enables prompt caching for the ~18k-token system prompt that was being re-processed on every request, saving cost for OpenRouter Anthropic users.

- New `createOpenRouterSystemCacheWrapper` function follows the existing `onPayload` wrapper pattern used by `createOpenAIResponsesStoreWrapper`
- Handles both string content (converts to array with cache_control) and array content (adds cache_control to last block)
- Gated behind `isOpenRouterAnthropicModel()` check — only applies to `openrouter` provider with `anthropic/*` model IDs
- Well-tested: 3 new test cases covering string content, array content, and non-Anthropic model exclusion

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a targeted, well-tested fix with no risk to non-OpenRouter-Anthropic code paths.
- The change is narrowly scoped to OpenRouter Anthropic models only, follows the established wrapper/onPayload pattern used elsewhere in the file, properly chains with existing wrappers, handles both content formats (string and array), and includes 3 tests covering positive and negative cases. The guard conditions ensure no other providers or model types are affected.
- No files require special attention.

<sub>Last reviewed commit: 32a6941</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->