### PR TITLE
fix(gateway): preserve scopes for shared-auth clients without device identity (#17408)

### DIFF
--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -427,7 +427,7 @@ export function attachGatewayWsMessageHandler(params: {
           close(1008, truncateCloseReason(authMessage));
         };
         if (!device) {
-          if (scopes.length > 0) {
+          if (scopes.length > 0 && !sharedAuthOk) {
             scopes = [];
             connectParams.scopes = scopes;
           }


### PR DESCRIPTION
## Summary

Fixes #17408. Clients authenticating with a valid shared `auth.token` (no device identity) have their requested scopes silently cleared to `[]`, causing `missing scope: operator.write` errors on `chat.send` and other operations.

## Root Cause

In `message-handler.ts`, the `!device` branch unconditionally clears all scopes:

```ts
if (!device) {
  if (scopes.length > 0) {
    scopes = [];              // ← clears scopes even when token auth succeeded
    connectParams.scopes = scopes;
  }
```

This affects webchat clients, Tauri apps, and any client using token-based auth without device pairing.

## Fix

Only clear scopes when shared auth also failed — preserving the security intent (unauthenticated clients get no scopes) while allowing properly authenticated token-based clients to keep their requested scopes:

```ts
if (scopes.length > 0 && !sharedAuthOk) {
```

One-line change, no new dependencies, no behaviour change for unauthenticated clients.


## Local Validation

- `pnpm build` ✅
- `pnpm check` (oxlint) ✅
- Relevant test suites pass ✅

## Contribution Checklist

- [x] Focused scope — single fix per PR
- [x] Clear "what" + "why" in description
- [x] AI-assisted (Codex/Claude) — reviewed and tested by human
- [x] Local validation run (`pnpm build && pnpm check`)

*AI-assisted (Claude). Reviewed by human.*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Preserves scopes for token-authenticated clients without device identity. Previously, the code unconditionally cleared scopes when `!device`, preventing properly authenticated shared-token clients (webchat, Tauri) from executing operations like `chat.send` that require `operator.write` scope. The fix adds `&& !sharedAuthOk` to only clear scopes when shared authentication failed, maintaining the security intent (unauthenticated clients get no scopes) while allowing authenticated token-based clients to use their requested scopes.

**Changes:**
- Modified scope-clearing logic in `message-handler.ts:430` to check both `!device` and `!sharedAuthOk`
- Aligns with existing pattern: `canSkipDevice = sharedAuthOk` on line 434 already uses the same condition

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Single-line logical fix that correctly preserves the security model (only clears scopes when authentication fails) while fixing the bug (preserves scopes when shared auth succeeds). The condition `!sharedAuthOk` already exists and is used on line 434 for the same purpose, indicating this pattern is established and correct. No new dependencies, no behavior change for unauthenticated clients
- No files require special attention

<sub>Last reviewed commit: cd2c66d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->