### PR TITLE
Gateway: hide BOOTSTRAP in agent files after onboarding completes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Web UI/Agents: hide `BOOTSTRAP.md` in the Agents Files list after onboarding is completed, avoiding confusing missing-file warnings for completed workspaces. (#17491) Thanks @gumadeiras.
 - Telegram: omit `message_thread_id` for DM sends/draft previews and keep forum-topic handling (`id=1` general omitted, non-general kept), preventing DM failures with `400 Bad Request: message thread not found`. (#10942) Thanks @garnetlyx.
 - Subagents/Models: preserve `agents.defaults.model.fallbacks` when subagent sessions carry a model override, so subagent runs fail over to configured fallback models instead of retrying only the overridden primary model.
 - Config/Gateway: make sensitive-key whitelist suffix matching case-insensitive while preserving `passwordFile` path exemptions, preventing accidental redaction of non-secret config values like `maxTokens` and IRC password-file paths. (#16042) Thanks @akramcodez.

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -102,11 +102,6 @@ type WorkspaceOnboardingState = {
   onboardingCompletedAt?: string;
 };
 
-export type WorkspaceOnboardingStateSnapshot = {
-  bootstrapSeededAt?: string;
-  onboardingCompletedAt?: string;
-};
-
 /** Set of recognized bootstrap filenames for runtime validation */
 const VALID_BOOTSTRAP_NAMES: ReadonlySet<string> = new Set([
   DEFAULT_AGENTS_FILENAME,
@@ -189,15 +184,9 @@ async function readWorkspaceOnboardingState(statePath: string): Promise<Workspac
   }
 }
 
-export async function readWorkspaceOnboardingStateForDir(
-  dir: string,
-): Promise<WorkspaceOnboardingStateSnapshot> {
+async function readWorkspaceOnboardingStateForDir(dir: string): Promise<WorkspaceOnboardingState> {
   const statePath = resolveWorkspaceStatePath(resolveUserPath(dir));
-  const state = await readWorkspaceOnboardingState(statePath);
-  return {
-    bootstrapSeededAt: state.bootstrapSeededAt,
-    onboardingCompletedAt: state.onboardingCompletedAt,
-  };
+  return await readWorkspaceOnboardingState(statePath);
 }
 
 export async function isWorkspaceOnboardingCompleted(dir: string): Promise<boolean> {

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -102,6 +102,11 @@ type WorkspaceOnboardingState = {
   onboardingCompletedAt?: string;
 };
 
+export type WorkspaceOnboardingStateSnapshot = {
+  bootstrapSeededAt?: string;
+  onboardingCompletedAt?: string;
+};
+
 /** Set of recognized bootstrap filenames for runtime validation */
 const VALID_BOOTSTRAP_NAMES: ReadonlySet<string> = new Set([
   DEFAULT_AGENTS_FILENAME,
@@ -182,6 +187,24 @@ async function readWorkspaceOnboardingState(statePath: string): Promise<Workspac
       version: WORKSPACE_STATE_VERSION,
     };
   }
+}
+
+export async function readWorkspaceOnboardingStateForDir(
+  dir: string,
+): Promise<WorkspaceOnboardingStateSnapshot> {
+  const statePath = resolveWorkspaceStatePath(resolveUserPath(dir));
+  const state = await readWorkspaceOnboardingState(statePath);
+  return {
+    bootstrapSeededAt: state.bootstrapSeededAt,
+    onboardingCompletedAt: state.onboardingCompletedAt,
+  };
+}
+
+export async function isWorkspaceOnboardingCompleted(dir: string): Promise<boolean> {
+  const state = await readWorkspaceOnboardingStateForDir(dir);
+  return (
+    typeof state.onboardingCompletedAt === "string" && state.onboardingCompletedAt.trim().length > 0
+  );
 }
 
 async function writeWorkspaceOnboardingState(

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -25,6 +25,8 @@ const mocks = vi.hoisted(() => ({
   fsAccess: vi.fn(async () => {}),
   fsMkdir: vi.fn(async () => undefined),
   fsAppendFile: vi.fn(async () => {}),
+  fsReadFile: vi.fn(async () => ""),
+  fsStat: vi.fn(async () => null),
 }));
 
 vi.mock("../../config/config.js", () => ({
@@ -81,6 +83,8 @@ vi.mock("node:fs/promises", async () => {
     access: mocks.fsAccess,
     mkdir: mocks.fsMkdir,
     appendFile: mocks.fsAppendFile,
+    readFile: mocks.fsReadFile,
+    stat: mocks.fsStat,
   };
   return { ...patched, default: patched };
 });
@@ -108,6 +112,21 @@ function makeCall(method: keyof typeof agentsHandlers, params: Record<string, un
   });
   return { respond, promise };
 }
+
+function createEnoentError() {
+  const err = new Error("ENOENT") as NodeJS.ErrnoException;
+  err.code = "ENOENT";
+  return err;
+}
+
+beforeEach(() => {
+  mocks.fsReadFile.mockImplementation(async () => {
+    throw createEnoentError();
+  });
+  mocks.fsStat.mockImplementation(async () => {
+    throw createEnoentError();
+  });
+});
 
 /* ------------------------------------------------------------------ */
 /* Tests                                                              */
@@ -369,5 +388,39 @@ describe("agents.delete", () => {
       undefined,
       expect.objectContaining({ message: expect.stringContaining("invalid") }),
     );
+  });
+});
+
+describe("agents.files.list", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.loadConfigReturn = {};
+  });
+
+  it("includes BOOTSTRAP.md when onboarding has not completed", async () => {
+    const { respond, promise } = makeCall("agents.files.list", { agentId: "main" });
+    await promise;
+
+    const [, result] = respond.mock.calls[0] ?? [];
+    const files = (result as { files: Array<{ name: string }> }).files;
+    expect(files.some((file) => file.name === "BOOTSTRAP.md")).toBe(true);
+  });
+
+  it("hides BOOTSTRAP.md when workspace onboarding is complete", async () => {
+    mocks.fsReadFile.mockImplementation(async (filePath: string | URL | number) => {
+      if (String(filePath).endsWith("workspace-state.json")) {
+        return JSON.stringify({
+          onboardingCompletedAt: "2026-02-15T14:00:00.000Z",
+        });
+      }
+      throw createEnoentError();
+    });
+
+    const { respond, promise } = makeCall("agents.files.list", { agentId: "main" });
+    await promise;
+
+    const [, result] = respond.mock.calls[0] ?? [];
+    const files = (result as { files: Array<{ name: string }> }).files;
+    expect(files.some((file) => file.name === "BOOTSTRAP.md")).toBe(false);
   });
 });

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -53,7 +53,7 @@ const BOOTSTRAP_FILE_NAMES = [
   DEFAULT_HEARTBEAT_FILENAME,
   DEFAULT_BOOTSTRAP_FILENAME,
 ] as const;
-const BOOTSTRAP_FILE_NAMES_WITHOUT_ONBOARDING = BOOTSTRAP_FILE_NAMES.filter(
+const BOOTSTRAP_FILE_NAMES_POST_ONBOARDING = BOOTSTRAP_FILE_NAMES.filter(
   (name) => name !== DEFAULT_BOOTSTRAP_FILENAME,
 );
 
@@ -122,7 +122,7 @@ async function listAgentFiles(workspaceDir: string, options?: { hideBootstrap?: 
   }> = [];
 
   const bootstrapFileNames = options?.hideBootstrap
-    ? BOOTSTRAP_FILE_NAMES_WITHOUT_ONBOARDING
+    ? BOOTSTRAP_FILE_NAMES_POST_ONBOARDING
     : BOOTSTRAP_FILE_NAMES;
   for (const name of bootstrapFileNames) {
     const filePath = path.join(workspaceDir, name);

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -17,6 +17,7 @@ import {
   DEFAULT_TOOLS_FILENAME,
   DEFAULT_USER_FILENAME,
   ensureAgentWorkspace,
+  isWorkspaceOnboardingCompleted,
 } from "../../agents/workspace.js";
 import { movePathToTrash } from "../../browser/trash.js";
 import {
@@ -52,6 +53,9 @@ const BOOTSTRAP_FILE_NAMES = [
   DEFAULT_HEARTBEAT_FILENAME,
   DEFAULT_BOOTSTRAP_FILENAME,
 ] as const;
+const BOOTSTRAP_FILE_NAMES_WITHOUT_ONBOARDING = BOOTSTRAP_FILE_NAMES.filter(
+  (name) => name !== DEFAULT_BOOTSTRAP_FILENAME,
+);
 
 const MEMORY_FILE_NAMES = [DEFAULT_MEMORY_FILENAME, DEFAULT_MEMORY_ALT_FILENAME] as const;
 
@@ -108,7 +112,7 @@ async function statFile(filePath: string): Promise<FileMeta | null> {
   }
 }
 
-async function listAgentFiles(workspaceDir: string) {
+async function listAgentFiles(workspaceDir: string, options?: { hideBootstrap?: boolean }) {
   const files: Array<{
     name: string;
     path: string;
@@ -117,7 +121,10 @@ async function listAgentFiles(workspaceDir: string) {
     updatedAtMs?: number;
   }> = [];
 
-  for (const name of BOOTSTRAP_FILE_NAMES) {
+  const bootstrapFileNames = options?.hideBootstrap
+    ? BOOTSTRAP_FILE_NAMES_WITHOUT_ONBOARDING
+    : BOOTSTRAP_FILE_NAMES;
+  for (const name of bootstrapFileNames) {
     const filePath = path.join(workspaceDir, name);
     const meta = await statFile(filePath);
     if (meta) {
@@ -417,7 +424,13 @@ export const agentsHandlers: GatewayRequestHandlers = {
       return;
     }
     const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
-    const files = await listAgentFiles(workspaceDir);
+    let hideBootstrap = false;
+    try {
+      hideBootstrap = await isWorkspaceOnboardingCompleted(workspaceDir);
+    } catch {
+      // Fall back to showing BOOTSTRAP if workspace state cannot be read.
+    }
+    const files = await listAgentFiles(workspaceDir, { hideBootstrap });
     respond(true, { agentId, workspace: workspaceDir, files }, undefined);
   },
   "agents.files.get": async ({ params, respond }) => {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: The Agents tab `Files` panel listed `BOOTSTRAP.md` as missing after onboarding completion, which is expected runtime state but looked like an actionable error.
- Why it matters: It creates confusion in Web UI because users see a persistent missing file warning for a file that should no longer be relevant.
- What changed: `agents.files.list` now checks workspace onboarding completion from `.openclaw/workspace-state.json` and hides `BOOTSTRAP.md` when `onboardingCompletedAt` is present.
- What did NOT change (scope boundary): No behavior change for `agents.files.get/set`; no changes to onboarding completion semantics or template generation flow.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- In Web UI Agents -> Files, `BOOTSTRAP.md` is no longer listed after onboarding has completed for that agent workspace.
- If onboarding is not completed (or state file is missing), `BOOTSTRAP.md` remains listed as before.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): Gateway RPC
- Relevant config (redacted): Multi-agent and single-agent workspaces

### Steps

1. Prepare an agent workspace with `.openclaw/workspace-state.json` containing `onboardingCompletedAt` and no `BOOTSTRAP.md`.
2. Call `agents.files.list` for that agent.
3. Repeat with onboarding incomplete/no state marker.

### Expected

- Completed onboarding: `BOOTSTRAP.md` should be omitted from `files`.
- Incomplete onboarding: `BOOTSTRAP.md` should still appear.

### Actual

- Matches expected after this change.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Gateway test run:

- `pnpm vitest run --config vitest.gateway.config.ts src/gateway/server-methods/agents-mutate.test.ts`
- Result: pass (18 tests)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `agents.files.list` includes/excludes `BOOTSTRAP.md` based on onboarding completion marker.
- Edge cases checked: missing/unreadable workspace state falls back to previous behavior (show BOOTSTRAP).
- What you did **not** verify: Full UI click-through in browser session.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR commit.
- Files/config to restore: `src/gateway/server-methods/agents.ts`, `src/agents/workspace.ts`, `src/gateway/server-methods/agents-mutate.test.ts`
- Known bad symptoms reviewers should watch for: `BOOTSTRAP.md` incorrectly hidden before onboarding completion.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Onboarding state read fails unexpectedly and could affect listing behavior.
  - Mitigation: Handler catches read errors and preserves previous behavior by showing `BOOTSTRAP.md`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hides `BOOTSTRAP.md` from the `agents.files.list` API response when workspace onboarding has been completed (determined by the presence of `onboardingCompletedAt` in `.openclaw/workspace-state.json`). When onboarding is incomplete or the state file cannot be read, `BOOTSTRAP.md` remains visible — preserving backward compatibility.

- Adds `isWorkspaceOnboardingCompleted()` in `workspace.ts` as a public helper that reads workspace state and checks for the `onboardingCompletedAt` marker
- `agents.files.list` handler uses this check with a conservative try/catch fallback (defaults to showing BOOTSTRAP on any error)
- `agents.files.get` and `agents.files.set` are intentionally unaffected — BOOTSTRAP.md can still be read/written directly
- Two new tests cover the include/exclude branches for `agents.files.list`

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a small, well-scoped bug fix with conservative error handling and no behavior changes outside the targeted API.
- The change is minimal in scope (3 files), adds a simple conditional filter to one handler, uses an existing internal state mechanism, and falls back safely on any error. The new exported functions follow established patterns in workspace.ts. Tests cover both branches.
- No files require special attention.

<sub>Last reviewed commit: 639ea44</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->