### PR TITLE
feat(dashboard): add Uninstall button for bundled skills

### DIFF
--- a/src/gateway/protocol/index.ts
+++ b/src/gateway/protocol/index.ts
@@ -188,6 +188,8 @@ import {
   SkillsInstallParamsSchema,
   type SkillsStatusParams,
   SkillsStatusParamsSchema,
+  type SkillsUninstallParams,
+  SkillsUninstallParamsSchema,
   type SkillsUpdateParams,
   SkillsUpdateParamsSchema,
   type Snapshot,
@@ -316,6 +318,9 @@ export const validateSkillsStatusParams = ajv.compile<SkillsStatusParams>(Skills
 export const validateSkillsBinsParams = ajv.compile<SkillsBinsParams>(SkillsBinsParamsSchema);
 export const validateSkillsInstallParams =
   ajv.compile<SkillsInstallParams>(SkillsInstallParamsSchema);
+export const validateSkillsUninstallParams = ajv.compile<SkillsUninstallParams>(
+  SkillsUninstallParamsSchema,
+);
 export const validateSkillsUpdateParams = ajv.compile<SkillsUpdateParams>(SkillsUpdateParamsSchema);
 export const validateCronListParams = ajv.compile<CronListParams>(CronListParamsSchema);
 export const validateCronStatusParams = ajv.compile<CronStatusParams>(CronStatusParamsSchema);
@@ -477,6 +482,7 @@ export {
   ModelsListParamsSchema,
   SkillsStatusParamsSchema,
   SkillsInstallParamsSchema,
+  SkillsUninstallParamsSchema,
   SkillsUpdateParamsSchema,
   CronJobSchema,
   CronListParamsSchema,
@@ -567,6 +573,7 @@ export type {
   SkillsBinsParams,
   SkillsBinsResult,
   SkillsInstallParams,
+  SkillsUninstallParams,
   SkillsUpdateParams,
   NodePairRejectParams,
   NodePairVerifyParams,

--- a/src/gateway/protocol/schema/agents-models-skills.ts
+++ b/src/gateway/protocol/schema/agents-models-skills.ts
@@ -198,6 +198,13 @@ export const SkillsInstallParamsSchema = Type.Object(
   { additionalProperties: false },
 );
 
+export const SkillsUninstallParamsSchema = Type.Object(
+  {
+    name: NonEmptyString,
+  },
+  { additionalProperties: false },
+);
+
 export const SkillsUpdateParamsSchema = Type.Object(
   {
     skillKey: NonEmptyString,

--- a/src/gateway/protocol/schema/types.ts
+++ b/src/gateway/protocol/schema/types.ts
@@ -31,6 +31,7 @@ import type {
   SkillsBinsResultSchema,
   SkillsInstallParamsSchema,
   SkillsStatusParamsSchema,
+  SkillsUninstallParamsSchema,
   SkillsUpdateParamsSchema,
 } from "./agents-models-skills.js";
 import type {
@@ -212,6 +213,7 @@ export type SkillsStatusParams = Static<typeof SkillsStatusParamsSchema>;
 export type SkillsBinsParams = Static<typeof SkillsBinsParamsSchema>;
 export type SkillsBinsResult = Static<typeof SkillsBinsResultSchema>;
 export type SkillsInstallParams = Static<typeof SkillsInstallParamsSchema>;
+export type SkillsUninstallParams = Static<typeof SkillsUninstallParamsSchema>;
 export type SkillsUpdateParams = Static<typeof SkillsUpdateParamsSchema>;
 export type CronJob = Static<typeof CronJobSchema>;
 export type CronListParams = Static<typeof CronListParamsSchema>;

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -153,6 +153,7 @@ function authorizeGatewayMethod(method: string, client: GatewayRequestOptions["c
     method === "agents.update" ||
     method === "agents.delete" ||
     method === "skills.install" ||
+    method === "skills.uninstall" ||
     method === "skills.update" ||
     method === "cron.add" ||
     method === "cron.update" ||

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -47,6 +47,7 @@ import {
   installSkill,
   loadSkills,
   saveSkillApiKey,
+  uninstallSkill,
   updateSkillEdit,
   updateSkillEnabled,
 } from "./controllers/skills.ts";
@@ -697,6 +698,7 @@ export function renderApp(state: AppViewState) {
                 onSaveKey: (key) => saveSkillApiKey(state, key),
                 onInstall: (skillKey, name, installId) =>
                   installSkill(state, skillKey, name, installId),
+                onUninstall: (skillKey, name) => uninstallSkill(state, skillKey, name),
               })
             : nothing
         }

--- a/ui/src/ui/controllers/skills.ts
+++ b/ui/src/ui/controllers/skills.ts
@@ -122,6 +122,33 @@ export async function saveSkillApiKey(state: SkillsState, skillKey: string) {
   }
 }
 
+export async function uninstallSkill(state: SkillsState, skillKey: string, name: string) {
+  if (!state.client || !state.connected) {
+    return;
+  }
+  state.skillsBusyKey = skillKey;
+  state.skillsError = null;
+  try {
+    const result = await state.client.request<{ message?: string }>("skills.uninstall", {
+      name,
+    });
+    await loadSkills(state);
+    setSkillMessage(state, skillKey, {
+      kind: "success",
+      message: result?.message ?? "Uninstalled",
+    });
+  } catch (err) {
+    const message = getErrorMessage(err);
+    state.skillsError = message;
+    setSkillMessage(state, skillKey, {
+      kind: "error",
+      message,
+    });
+  } finally {
+    state.skillsBusyKey = null;
+  }
+}
+
 export async function installSkill(
   state: SkillsState,
   skillKey: string,

--- a/ui/src/ui/views/skills.ts
+++ b/ui/src/ui/views/skills.ts
@@ -23,6 +23,7 @@ export type SkillsProps = {
   onEdit: (skillKey: string, value: string) => void;
   onSaveKey: (skillKey: string) => void;
   onInstall: (skillKey: string, name: string, installId: string) => void;
+  onUninstall: (skillKey: string, name: string) => void;
 };
 
 export function renderSkills(props: SkillsProps) {
@@ -145,6 +146,17 @@ function renderSkill(skill: SkillStatusEntry, props: SkillsProps) {
                 @click=${() => props.onInstall(skill.skillKey, skill.name, skill.install[0].id)}
               >
                 ${busy ? "Installing…" : skill.install[0].label}
+              </button>`
+              : nothing
+          }
+          ${
+            skill.source === "openclaw-bundled" && !skill.disabled
+              ? html`<button
+                class="btn danger"
+                ?disabled=${busy}
+                @click=${() => props.onUninstall(skill.skillKey, skill.name)}
+              >
+                ${busy ? "Uninstalling…" : "Uninstall"}
               </button>`
               : nothing
           }


### PR DESCRIPTION
## Summary

- Adds a `skills.uninstall` gateway RPC method that removes a bundled skill directory and appends it to `.gitignore` (preventing it from returning on `git pull`/update)
- Adds an "Uninstall" button (danger style) in the Skills dashboard view for bundled skills
- Follows the same patterns as the existing `skills.install` flow

## Changes

### Backend
- **`src/gateway/protocol/schema/agents-models-skills.ts`** — New `SkillsUninstallParamsSchema`
- **`src/gateway/protocol/schema/types.ts`** — New `SkillsUninstallParams` type
- **`src/gateway/protocol/index.ts`** — Register validator + exports
- **`src/gateway/server-methods/skills.ts`** — `skills.uninstall` handler (validates params, resolves bundled dir, deletes skill folder, appends to `.gitignore`)
- **`src/gateway/server-methods.ts`** — Add `skills.uninstall` to admin-scoped methods

### Frontend
- **`ui/src/ui/controllers/skills.ts`** — `uninstallSkill()` controller function
- **`ui/src/ui/views/skills.ts`** — "Uninstall" button for `openclaw-bundled` skills
- **`ui/src/ui/app-render.ts`** — Wire `onUninstall` handler

## Motivation

Currently, removing a bundled skill requires manually deleting its folder and editing `.gitignore`. This PR automates the process with a single click from the dashboard.

## Test plan

- [ ] Open dashboard → Skills → Built-in Skills
- [ ] Click "Uninstall" on a bundled skill
- [ ] Verify skill folder is deleted
- [ ] Verify `skills/<name>/` is appended to `.gitignore`
- [ ] Verify skill disappears from list after refresh
- [ ] Verify non-bundled skills do not show the button
- [ ] Verify disabled skills do not show the button

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a `skills.uninstall` RPC endpoint and corresponding dashboard UI to allow one-click removal of bundled skills. The backend handler resolves the bundled skills directory, deletes the skill folder, and attempts to append the path to `.gitignore` to prevent the skill from returning on `git pull`. The frontend adds a "danger"-styled Uninstall button for `openclaw-bundled` skills, following the same controller/view patterns as the existing `skills.install` flow.

- Two critical issues were previously flagged and remain unresolved: **path traversal vulnerability** (no validation that the resolved path stays within the bundled directory) and **`.gitignore` update silently never executes** (`resolveOpenClawPackageRootSync({})` is called with empty options, causing it to always return `null`)
- Protocol schema, type exports, validator registration, and admin authorization are all wired correctly following existing conventions
- Frontend controller and view changes cleanly mirror the existing install flow

<h3>Confidence Score: 1/5</h3>

- This PR has two unresolved critical issues — a path traversal vulnerability that enables arbitrary directory deletion, and a `.gitignore` update that silently never executes.
- Score of 1 reflects two previously-flagged but unresolved critical issues: (1) The `name` parameter is only validated as a non-empty string, allowing values like `../../etc` to escape the bundled directory and trigger recursive deletion of arbitrary directories via `fs.promises.rm`. (2) `resolveOpenClawPackageRootSync({})` is called with an empty options object, which means all candidate resolution paths are empty and it always returns `null`, silently skipping the `.gitignore` update — one of the two stated goals of the feature. The frontend and protocol changes are clean and follow existing patterns.
- `src/gateway/server-methods/skills.ts` needs path traversal protection on the resolved skill directory (line 173) and correct options passed to `resolveOpenClawPackageRootSync` (line 185).

<sub>Last reviewed commit: b141a6f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->