### PR TITLE
fix(discord): respect groupPolicy in channel config fallback (#4555)

### DIFF
--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -369,7 +369,7 @@ export async function preflightDiscordMessage(
     return null;
   }
 
-  if (isGuildMessage && channelConfig?.allowed === false) {
+  if (isGuildMessage && channelConfig?.allowed === false && params.groupPolicy !== "open") {
     logDebug(`[discord-preflight] drop: channelConfig.allowed===false`);
     logVerbose(
       `Blocked discord channel ${message.channelId} not in guild channel allowlist (${channelMatchMeta})`,


### PR DESCRIPTION
## Problem

Discord guild messages are silently dropped when:
1. A guild entry has a `channels` block with at least one entry
2. The incoming message is from a channel NOT listed in that block
3. `groupPolicy` is `"open"`

`resolveDiscordChannelConfigWithFallback()` returns `{ allowed: false }` as a default when no channel entry matches. A second check in the preflight handler (`channelConfig?.allowed === false`) then drops the message — **even though `isDiscordGroupAllowedByPolicy()` already returned `true`** for open policy.

## Why most users are NOT affected

Most users fall into one of these categories that avoid the bug:

- **No `channels` block in guild config** → `resolveDiscordChannelConfigWithFallback` returns `null` (not `{ allowed: false }`), and `null?.allowed === false` evaluates to `false`, so messages pass through
- **Wildcard `"*"` channel entry** → matches everything, returns `{ allowed: true }`
- **Explicit channel entries covering all active channels** → always matches
- **No guild config at all** → `channelConfig` is `null`

The bug only triggers when a user has a **partial** channels config (e.g., configuring `requireMention` for one channel) combined with `groupPolicy: "open"` — the unconfigured channels get silently dropped.

## Fix

Skip the redundant `channelConfig?.allowed === false` check when `groupPolicy === "open"`, since `isDiscordGroupAllowedByPolicy` already approved the message.

**1 line changed** in `message-handler.preflight.ts` + **80 lines of tests** covering the groupPolicy × channel-config matrix.

Fixes #4555

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a bug where Discord guild messages from unlisted channels were silently dropped even when `groupPolicy` is `"open"`. The root cause was a redundant `channelConfig?.allowed === false` check in `preflightDiscordMessage` (line 372) that ran **after** `isDiscordGroupAllowedByPolicy()` had already approved the message for open policy. The fix adds `&& params.groupPolicy !== "open"` to skip this redundant check when the policy is open.

- **1-line fix** in `message-handler.preflight.ts`: skips the `channelConfig.allowed === false` guard when `groupPolicy === "open"`, deferring to the already-evaluated `isDiscordGroupAllowedByPolicy()` result
- **80 lines of tests** in `monitor.test.ts`: covers the `groupPolicy × channelConfig` interaction matrix, documenting the expected behavior for open, allowlist, and disabled policies with matched/unmatched/unconfigured channels
- Non-open policies (`allowlist`, `disabled`) are unaffected — for `allowlist`, unmatched channels are already blocked at the `isDiscordGroupAllowedByPolicy` checkpoint; the redundant check still applies as a belt-and-suspenders guard for non-open policies

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — a minimal, well-targeted 1-line fix with comprehensive test coverage.
- The change is a single additional condition (`&& params.groupPolicy !== "open"`) on an existing guard clause. The fix aligns the redundant check with the already-evaluated `isDiscordGroupAllowedByPolicy()` result. Non-open policies (allowlist, disabled) are unaffected because unmatched channels are already blocked at the earlier checkpoint. The 6 new unit tests cover the key interaction matrix. The logic is straightforward and the risk of regression is minimal.
- No files require special attention

<sub>Last reviewed commit: 9386b3d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->