### PR TITLE
fix(browser): catch unhandled promise rejection in dialog handling

### DIFF
--- a/src/browser/pw-tools-core.dialog-errors.test.ts
+++ b/src/browser/pw-tools-core.dialog-errors.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  installPwToolsCoreTestHooks,
+  setPwToolsCoreCurrentPage,
+} from "./pw-tools-core.test-harness.js";
+
+installPwToolsCoreTestHooks();
+const mod = await import("./pw-tools-core.js");
+
+describe("pw-tools-core dialog errors", () => {
+  it("swallows errors when dialog.accept fails (e.g. dialog already closed)", async () => {
+    const error = new Error("Protocol error (Page.handleJavaScriptDialog): No dialog is showing");
+    const accept = vi.fn(async () => {
+      throw error;
+    });
+    const dismiss = vi.fn(async () => {});
+    const dialog = { accept, dismiss };
+    
+    // waitForEvent resolves successfully with the dialog
+    const waitForEvent = vi.fn(async () => dialog);
+    
+    setPwToolsCoreCurrentPage({
+      waitForEvent,
+    });
+
+    // Should not throw
+    await mod.armDialogViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      accept: true,
+      promptText: "x",
+    });
+    
+    expect(accept).toHaveBeenCalledWith("x");
+    expect(dismiss).not.toHaveBeenCalled();
+  });
+
+  it("swallows errors when dialog.dismiss fails", async () => {
+    const error = new Error("Protocol error (Page.handleJavaScriptDialog): No dialog is showing");
+    const accept = vi.fn(async () => {});
+    const dismiss = vi.fn(async () => {
+      throw error;
+    });
+    const dialog = { accept, dismiss };
+    
+    const waitForEvent = vi.fn(async () => dialog);
+    
+    setPwToolsCoreCurrentPage({
+      waitForEvent,
+    });
+
+    // Should not throw
+    await mod.armDialogViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      accept: false,
+    });
+    
+    expect(dismiss).toHaveBeenCalled();
+    expect(accept).not.toHaveBeenCalled();
+  });
+});

--- a/src/browser/pw-tools-core.dialog-errors.test.ts
+++ b/src/browser/pw-tools-core.dialog-errors.test.ts
@@ -15,10 +15,10 @@ describe("pw-tools-core dialog errors", () => {
     });
     const dismiss = vi.fn(async () => {});
     const dialog = { accept, dismiss };
-    
+
     // waitForEvent resolves successfully with the dialog
     const waitForEvent = vi.fn(async () => dialog);
-    
+
     setPwToolsCoreCurrentPage({
       waitForEvent,
     });
@@ -29,7 +29,7 @@ describe("pw-tools-core dialog errors", () => {
       accept: true,
       promptText: "x",
     });
-    
+
     expect(accept).toHaveBeenCalledWith("x");
     expect(dismiss).not.toHaveBeenCalled();
   });
@@ -41,9 +41,9 @@ describe("pw-tools-core dialog errors", () => {
       throw error;
     });
     const dialog = { accept, dismiss };
-    
+
     const waitForEvent = vi.fn(async () => dialog);
-    
+
     setPwToolsCoreCurrentPage({
       waitForEvent,
     });
@@ -53,7 +53,7 @@ describe("pw-tools-core dialog errors", () => {
       cdpUrl: "http://127.0.0.1:18792",
       accept: false,
     });
-    
+
     expect(dismiss).toHaveBeenCalled();
     expect(accept).not.toHaveBeenCalled();
   });

--- a/src/browser/pw-tools-core.downloads.ts
+++ b/src/browser/pw-tools-core.downloads.ts
@@ -171,10 +171,14 @@ export async function armDialogViaPlaywright(opts: {
       if (state.armIdDialog !== armId) {
         return;
       }
-      if (opts.accept) {
-        await dialog.accept(opts.promptText);
-      } else {
-        await dialog.dismiss();
+      try {
+        if (opts.accept) {
+          await dialog.accept(opts.promptText);
+        } else {
+          await dialog.dismiss();
+        }
+      } catch {
+        // Ignore errors; the dialog may have closed or navigated away.
       }
     })
     .catch(() => {


### PR DESCRIPTION
# Fix: Unhandled Promise Rejection in Browser Dialog Handler

Fixes #17499

## Summary
This PR fixes an issue where `armDialogViaPlaywright` would throw an unhandled promise rejection if the dialog was closed (e.g. via navigation or auto-dismissal) before `dialog.accept()` or `dialog.dismiss()` could be called.

The fix wraps the `dialog.accept()`/`dismiss()` calls in a `try/catch` block to suppress errors when the dialog is no longer available, which is the expected behavior (best-effort handling).

## Changes
- Modified `src/browser/pw-tools-core.downloads.ts` to catch errors during dialog interaction.
- Added regression test `src/browser/pw-tools-core.dialog-errors.test.ts` to verify that `accept`/`dismiss` errors are gracefully handled.

## Verification
- Ran new regression test: `npm run test:fast -- src/browser/pw-tools-core.dialog-errors.test.ts` (Passed)
- Ran existing tests: `npm run test:fast -- src/browser/pw-tools-core.last-file-chooser-arm-wins.test.ts` (Passed)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added error handling to catch promise rejections when dialogs close before `accept()` or `dismiss()` can be called. The fix wraps dialog interactions in a try-catch block (lines 174-182) to gracefully handle cases where dialogs are closed via navigation or auto-dismissal, which is consistent with the existing best-effort pattern used for file chooser handling in the same module.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix addresses a real issue with a minimal, focused change that follows existing patterns in the codebase. The try-catch wrapping is consistent with similar error handling in `armFileUploadViaPlaywright` and includes comprehensive regression tests covering both accept and dismiss failure scenarios.
- No files require special attention

<sub>Last reviewed commit: 50a1cec</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->