### PR TITLE
fix(heartbeat): clamp setTimeout delay to prevent 32-bit overflow spin-loop

### DIFF
--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -925,7 +925,12 @@ export function startHeartbeatRunner(opts: {
     if (!Number.isFinite(nextDue)) {
       return;
     }
-    const delay = Math.max(0, nextDue - now);
+    // Cap delay to avoid setTimeout 32-bit overflow (max ~24.8 days).
+    // When the capped timer fires before the agent is actually due,
+    // the run handler skips agents where `now < nextDueMs` and
+    // scheduleNext() re-arms for the remaining time.
+    const MAX_TIMEOUT_MS = 0x7fff_ffff; // 2^31 - 1
+    const delay = Math.min(Math.max(0, nextDue - now), MAX_TIMEOUT_MS);
     state.timer = setTimeout(() => {
       state.timer = null;
       requestHeartbeatNow({ reason: "interval", coalesceMs: 0 });


### PR DESCRIPTION
## Problem

Heartbeat intervals that exceed ~24.8 days cause a tight spin-loop that starves the event loop, blocking all Telegram message processing and other I/O.

The symptom is thousands of `TimeoutOverflowWarning` entries per second in the journal:

```
(node:PID) TimeoutOverflowWarning: 31535831833 does not fit into a 32-bit signed integer.
Timeout duration was set to 1.
```

Repro: set `agents.defaults.heartbeat.every` to any value >24.8 days, e.g. `"8760h"` (1 year, used to effectively disable periodic heartbeats while keeping the heartbeat system available for on-demand wakes).

## Root Cause

`scheduleNext()` in `heartbeat-runner.ts` passes the raw delay to `setTimeout()`:

```ts
const delay = Math.max(0, nextDue - now); // e.g. 31,536,000,000 ms (365 days)
state.timer = setTimeout(() => { ... }, delay);
```

`setTimeout` stores the delay as a 32-bit signed integer (max 2,147,483,647 ms ≈ 24.8 days). Values above this overflow, Node.js clamps them to 1 ms, and the timer fires immediately. The callback path is:

1. Timer fires → `requestHeartbeatNow({ reason: "interval" })`
2. Run handler checks `now < agent.nextDueMs` → skips (correct)
3. `scheduleNext()` re-arms with the same overflowed delay → fires in 1 ms
4. Goto 1 — ~200 iterations/sec

The cron service timer (`timer.ts`) already guards against this with a `MAX_TIMER_DELAY_MS` clamp. The heartbeat scheduler was missing the equivalent.

## Fix

Cap the `setTimeout` delay at `2^31 - 1` ms (`0x7FFF_FFFF`). When the capped timer fires before an agent is actually due, the run handler's existing `now < nextDueMs` guard skips the heartbeat and `scheduleNext()` re-arms for the remaining time — converging correctly without spin.

All 63 heartbeat runner tests pass.



## Testing
- Targeted heartbeat runner tests pass locally (63 tests).
- CI checks are running.

## AI-Assisted
Yes — implemented and reviewed with AI assistance.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Clamps `setTimeout` delay in the heartbeat runner's `scheduleNext()` to `0x7FFF_FFFF` (2^31-1 ms, ~24.8 days) to prevent Node.js 32-bit signed integer overflow. Without this, heartbeat intervals exceeding ~24.8 days cause `setTimeout` to silently clamp the delay to 1ms, resulting in a tight spin-loop (~200 iterations/sec) that starves the event loop.

- The fix is a single-line addition (`Math.min(delay, MAX_TIMEOUT_MS)`) with a local constant and clear comment.
- The existing `now < agent.nextDueMs` guard in the run handler correctly skips early-firing capped timers, and `scheduleNext()` re-arms for the remaining time — so convergence is correct.
- The cron service timer (`src/cron/service/timer.ts`) already has an analogous `MAX_TIMER_DELAY_MS` clamp (at 60s for drift reasons); this fills the equivalent gap in the heartbeat scheduler.
- No test specifically validates the overflow clamping path, though all existing 63 heartbeat tests continue to pass.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, correct one-line fix for a well-understood Node.js platform limitation.
- The change is a single arithmetic clamp on a setTimeout delay value. The fix addresses a real, reproducible bug (32-bit overflow causing spin-loop). The convergence path is validated by the existing `now < nextDueMs` guard in the run handler. The change is consistent with the existing pattern in the cron timer. No new code paths, side effects, or behavioral changes for intervals within the normal range.
- No files require special attention.

<sub>Last reviewed commit: e590285</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

## Local Validation

```bash
pnpm build && pnpm check && pnpm test
```

Build passes. Lint passes. 4743/4747 tests pass (4 pre-existing env-isolation failures fixed by #16658).

## Local Validation

```bash
pnpm build && pnpm check
```

Build passes. Lint passes. Note: 4 pre-existing test failures in `provider-usage.auth.normalizes-keys.test.ts` (this is what PR #16658 fixes).