### PR TITLE
fix: don't rotate auth profile on timeout during active tool use

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -410,6 +410,7 @@ export async function runEmbeddedPiAgent(
       const usageAccumulator = createUsageAccumulator();
       let lastRunPromptUsage: ReturnType<typeof normalizeUsage> | undefined;
       let autoCompactionCount = 0;
+      let stallNotifyCount = 0;
       try {
         while (true) {
           attemptedThinking.add(thinkLevel);
@@ -469,6 +470,7 @@ export async function runEmbeddedPiAgent(
             onReasoningStream: params.onReasoningStream,
             onToolResult: params.onToolResult,
             onAgentEvent: params.onAgentEvent,
+            onPromptCycleStart: params.onPromptCycleStart,
             extraSystemPrompt: params.extraSystemPrompt,
             inputProvenance: params.inputProvenance,
             streamParams: params.streamParams,
@@ -787,6 +789,14 @@ export async function runEmbeddedPiAgent(
 
             const rotated = await advanceAuthProfile();
             if (rotated) {
+              if (timedOut && params.onBlockReply) {
+                stallNotifyCount++;
+                const msg =
+                  stallNotifyCount === 1
+                    ? "Response stalled \u2014 retrying..."
+                    : `Still waiting for response (retry ${stallNotifyCount})...`;
+                Promise.resolve(params.onBlockReply({ text: msg })).catch(() => {});
+              }
               continue;
             }
 

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -97,6 +97,8 @@ export type RunEmbeddedPiAgentParams = {
   onReasoningStream?: (payload: { text?: string; mediaUrls?: string[] }) => void | Promise<void>;
   onToolResult?: (payload: { text?: string; mediaUrls?: string[] }) => void | Promise<void>;
   onAgentEvent?: (evt: { stream: string; data: Record<string, unknown> }) => void;
+  /** Called before each prompt cycle starts (useful for refreshing typing indicators). */
+  onPromptCycleStart?: () => void;
   lane?: string;
   enqueue?: typeof enqueueCommand;
   extraSystemPrompt?: string;

--- a/src/agents/pi-embedded-subscribe.handlers.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.ts
@@ -21,6 +21,7 @@ import {
 
 export function createEmbeddedPiSessionEventHandler(ctx: EmbeddedPiSubscribeContext) {
   return (evt: EmbeddedPiSubscribeEvent) => {
+    ctx.params.onStreamActivity?.();
     switch (evt.type) {
       case "message_start":
         handleMessageStart(ctx, evt as never);

--- a/src/agents/pi-embedded-subscribe.types.ts
+++ b/src/agents/pi-embedded-subscribe.types.ts
@@ -31,6 +31,8 @@ export type SubscribeEmbeddedPiSessionParams = {
   onPartialReply?: (payload: { text?: string; mediaUrls?: string[] }) => void | Promise<void>;
   onAssistantMessageStart?: () => void | Promise<void>;
   onAgentEvent?: (evt: { stream: string; data: Record<string, unknown> }) => void | Promise<void>;
+  /** Called on every streaming event (message_start, message_update, tool_execution_*, etc.). */
+  onStreamActivity?: () => void;
   enforceFinalTag?: boolean;
 };
 

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -341,6 +341,9 @@ export async function runAgentTurnWithFallback(params: {
                     });
                   }
                 : undefined,
+            onPromptCycleStart: () => {
+              void params.typingSignals.signalToolStart();
+            },
             onAgentEvent: async (evt) => {
               // Trigger typing when tools start executing.
               // Must await to ensure typing indicator starts before tool summaries are emitted.


### PR DESCRIPTION
## Summary

Fixes #17555
Related: #14228, #11715

When an embedded run times out while the agent is **actively executing tool calls**, the timeout was incorrectly treated as an API rate limit stall, triggering auth profile rotation and exponential backoff cooldown.

This caused a crash loop on single-account setups:
1. Agent spawns long-running `exec` (e.g., Claude Code sub-agent, >5 min)
2. Overall run timer fires → `timedOut = true`
3. `shouldRotate = ... || timedOut` → marks profile failed, attempts rotation
4. No fallback account → session stuck in `processing`
5. Gateway self-restarts → kills child processes → repeat

## Fix

Check whether the agent had tool activity before deciding to rotate:

```typescript
const hadToolActivity =
  timedOut && (attempt.toolMetas.length > 0 || attempt.assistantTexts.length > 0);
const shouldRotate = (!aborted && failoverFailure) || (timedOut && !hadToolActivity);
```

If the agent produced assistant text or executed tools, the API responded successfully. The timeout is from legitimate long-running work, not an API stall. The existing stream inactivity watchdog (90s) still catches genuine API hangs.

## Testing

- Verified on self-hosted instance running Antigravity/claude-opus-4-6-thinking
- Agent spawning Claude Code sub-agents via exec (turns regularly 5-15 minutes)
- Before fix: 6 gateway restarts in 2 hours
- After fix: stable, no false profile cooldowns

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bundles three related fixes: (1) preventing false auth profile rotation on timeout during active tool use, (2) adding a 90-second streaming inactivity watchdog, and (3) stripping unsigned Antigravity thinking blocks via `transformContext`. The core rotation fix in `run.ts` is sound — checking `hadToolActivity` before rotating is the correct approach and directly addresses the crash loop described in the issue.

- **Critical bug in `attempt.ts`:** `timedOutDuringCompaction` is referenced at line 945 in the `finally` block but is never declared in this file. This appears to be a cherry-pick/rebase artifact. It will throw a `ReferenceError` on every run, crashing the attempt.
- **Missing type definition:** `onPromptCycleStart` was added to `RunEmbeddedPiAgentParams` but not to `EmbeddedRunAttemptParams` in `types.ts`. This means the callback is passed from `run.ts` but TypeScript excess property checks will reject it, and at runtime it won't fire inside `attempt.ts`.
- The streaming inactivity watchdog, `onStreamActivity` callback wiring, and stall user notifications are well-implemented.

<h3>Confidence Score: 2/5</h3>

- This PR has a critical runtime error in `attempt.ts` that will crash every embedded run — must be fixed before merging.
- The core auth-rotation fix in `run.ts` is correct and well-reasoned. However, `attempt.ts` contains an undeclared variable reference (`timedOutDuringCompaction`) in a `finally` block that executes on every run, which will throw a `ReferenceError` and crash the agent. Additionally, `onPromptCycleStart` is missing from the `EmbeddedRunAttemptParams` type, so the typing indicator refresh feature won't work. These are likely cherry-pick/rebase artifacts that need to be resolved.
- `src/agents/pi-embedded-runner/run/attempt.ts` has an undeclared variable reference that will crash at runtime. `src/agents/pi-embedded-runner/run/types.ts` needs `onPromptCycleStart` added to the `EmbeddedRunAttemptParams` type.

<sub>Last reviewed commit: 2c171c8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->