### PR TITLE
fix: don't rotate auth profile on timeout during active tool use

### DIFF
--- a/src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts
+++ b/src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts
@@ -1,7 +1,7 @@
-import type { AssistantMessage } from "@mariozechner/pi-ai";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import type { AssistantMessage } from "@mariozechner/pi-ai";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import type { EmbeddedRunAttemptResult } from "./pi-embedded-runner/run/types.js";

--- a/src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts
+++ b/src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts
@@ -341,6 +341,112 @@ describe("runEmbeddedPiAgent auth profile rotation", () => {
     }
   });
 
+  it("does not rotate on timeout when agent had tool activity", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-agent-"));
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-"));
+    try {
+      await writeAuthStore(agentDir);
+
+      runEmbeddedAttemptMock.mockResolvedValueOnce(
+        makeAttempt({
+          aborted: true,
+          timedOut: true,
+          timedOutDuringCompaction: false,
+          assistantTexts: ["partial response"],
+          toolMetas: [{ toolName: "exec", meta: "ls -la" }],
+          lastAssistant: buildAssistant({
+            stopReason: "stop",
+            content: [{ type: "text", text: "partial response" }],
+          }),
+        }),
+      );
+
+      const result = await runEmbeddedPiAgent({
+        sessionId: "session:test",
+        sessionKey: "agent:test:tool-activity-timeout",
+        sessionFile: path.join(workspaceDir, "session.jsonl"),
+        workspaceDir,
+        agentDir,
+        config: makeConfig(),
+        prompt: "hello",
+        provider: "openai",
+        model: "mock-1",
+        authProfileId: "openai:p1",
+        authProfileIdSource: "auto",
+        timeoutMs: 5_000,
+        runId: "run:tool-activity-timeout",
+      });
+
+      // Should NOT rotate — agent was doing real work, not stalled on an API call
+      expect(runEmbeddedAttemptMock).toHaveBeenCalledTimes(1);
+      expect(result.meta.aborted).toBe(true);
+
+      const stored = JSON.parse(
+        await fs.readFile(path.join(agentDir, "auth-profiles.json"), "utf-8"),
+      ) as { usageStats?: Record<string, { lastUsed?: number }> };
+      // p2 should NOT have been advanced to
+      expect(stored.usageStats?.["openai:p2"]?.lastUsed).toBe(2);
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rotates on timeout when no tool activity occurred", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-agent-"));
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-"));
+    try {
+      await writeAuthStore(agentDir);
+
+      runEmbeddedAttemptMock
+        .mockResolvedValueOnce(
+          makeAttempt({
+            aborted: true,
+            timedOut: true,
+            timedOutDuringCompaction: false,
+            assistantTexts: [],
+            toolMetas: [],
+          }),
+        )
+        .mockResolvedValueOnce(
+          makeAttempt({
+            assistantTexts: ["ok"],
+            lastAssistant: buildAssistant({
+              stopReason: "stop",
+              content: [{ type: "text", text: "ok" }],
+            }),
+          }),
+        );
+
+      await runEmbeddedPiAgent({
+        sessionId: "session:test",
+        sessionKey: "agent:test:no-activity-timeout",
+        sessionFile: path.join(workspaceDir, "session.jsonl"),
+        workspaceDir,
+        agentDir,
+        config: makeConfig(),
+        prompt: "hello",
+        provider: "openai",
+        model: "mock-1",
+        authProfileId: "openai:p1",
+        authProfileIdSource: "auto",
+        timeoutMs: 5_000,
+        runId: "run:no-activity-timeout",
+      });
+
+      // SHOULD rotate — no tool activity means likely an API stall
+      expect(runEmbeddedAttemptMock).toHaveBeenCalledTimes(2);
+
+      const stored = JSON.parse(
+        await fs.readFile(path.join(agentDir, "auth-profiles.json"), "utf-8"),
+      ) as { usageStats?: Record<string, { lastUsed?: number }> };
+      expect(typeof stored.usageStats?.["openai:p2"]?.lastUsed).toBe("number");
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
   it("does not rotate for user-pinned profiles", async () => {
     const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-agent-"));
     const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-"));

--- a/src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts
+++ b/src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts
@@ -1,7 +1,7 @@
+import type { AssistantMessage } from "@mariozechner/pi-ai";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import type { AssistantMessage } from "@mariozechner/pi-ai";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import type { EmbeddedRunAttemptResult } from "./pi-embedded-runner/run/types.js";
@@ -381,11 +381,7 @@ describe("runEmbeddedPiAgent auth profile rotation", () => {
       expect(runEmbeddedAttemptMock).toHaveBeenCalledTimes(1);
       expect(result.meta.aborted).toBe(true);
 
-      const stored = JSON.parse(
-        await fs.readFile(path.join(agentDir, "auth-profiles.json"), "utf-8"),
-      ) as { usageStats?: Record<string, { lastUsed?: number }> };
-      // p2 should NOT have been advanced to
-      expect(stored.usageStats?.["openai:p2"]?.lastUsed).toBe(2);
+      await expectProfileP2UsageUnchanged(agentDir);
     } finally {
       await fs.rm(agentDir, { recursive: true, force: true });
       await fs.rm(workspaceDir, { recursive: true, force: true });

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1,7 +1,5 @@
 import fs from "node:fs/promises";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
-import type { RunEmbeddedPiAgentParams } from "./run/params.js";
-import type { EmbeddedPiAgentMeta, EmbeddedPiRunResult } from "./types.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { enqueueCommandInLane } from "../../process/command-queue.js";
 import { isMarkdownCapableMessageChannel } from "../../utils/message-channel.js";
@@ -52,11 +50,13 @@ import { resolveGlobalLane, resolveSessionLane } from "./lanes.js";
 import { log } from "./logger.js";
 import { resolveModel } from "./model.js";
 import { runEmbeddedAttempt } from "./run/attempt.js";
+import type { RunEmbeddedPiAgentParams } from "./run/params.js";
 import { buildEmbeddedRunPayloads } from "./run/payloads.js";
 import {
   truncateOversizedToolResultsInSession,
   sessionLikelyHasOversizedToolResults,
 } from "./tool-result-truncation.js";
+import type { EmbeddedPiAgentMeta, EmbeddedPiRunResult } from "./types.js";
 import { describeUnknownError } from "./utils.js";
 
 type ApiKeyInfo = ResolvedProviderAuth;

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1,5 +1,7 @@
 import fs from "node:fs/promises";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
+import type { RunEmbeddedPiAgentParams } from "./run/params.js";
+import type { EmbeddedPiAgentMeta, EmbeddedPiRunResult } from "./types.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { enqueueCommandInLane } from "../../process/command-queue.js";
 import { isMarkdownCapableMessageChannel } from "../../utils/message-channel.js";
@@ -50,13 +52,11 @@ import { resolveGlobalLane, resolveSessionLane } from "./lanes.js";
 import { log } from "./logger.js";
 import { resolveModel } from "./model.js";
 import { runEmbeddedAttempt } from "./run/attempt.js";
-import type { RunEmbeddedPiAgentParams } from "./run/params.js";
 import { buildEmbeddedRunPayloads } from "./run/payloads.js";
 import {
   truncateOversizedToolResultsInSession,
   sessionLikelyHasOversizedToolResults,
 } from "./tool-result-truncation.js";
-import type { EmbeddedPiAgentMeta, EmbeddedPiRunResult } from "./types.js";
 import { describeUnknownError } from "./utils.js";
 
 type ApiKeyInfo = ResolvedProviderAuth;
@@ -905,7 +905,7 @@ export async function runEmbeddedPiAgent(
             (!aborted && failoverFailure) ||
             (timedOut && !timedOutDuringCompaction && !hadToolActivity);
 
-          if (hadToolActivity && !isProbeSession) {
+          if (hadToolActivity && !timedOutDuringCompaction && !isProbeSession) {
             log.info(
               `Run timed out during active tool use (not an API stall). ` +
                 `tools=${attempt.toolMetas.length} texts=${attempt.assistantTexts.length} ` +

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -894,10 +894,24 @@ export async function runEmbeddedPiAgent(
             );
           }
 
-          // Treat timeout as potential rate limit (Antigravity hangs on rate limit)
-          // But exclude post-prompt compaction timeouts (model succeeded; no profile issue)
+          // Treat timeout as potential rate limit (Antigravity hangs on rate limit).
+          // Exclude post-prompt compaction timeouts (model succeeded; no profile issue)
+          // AND timeouts during active tool use (agent was doing legitimate work via
+          // exec/sub-agents, not stalled on an API call). The streaming inactivity
+          // watchdog already catches genuine API hangs.
+          const hadToolActivity =
+            timedOut && (attempt.toolMetas.length > 0 || attempt.assistantTexts.length > 0);
           const shouldRotate =
-            (!aborted && failoverFailure) || (timedOut && !timedOutDuringCompaction);
+            (!aborted && failoverFailure) ||
+            (timedOut && !timedOutDuringCompaction && !hadToolActivity);
+
+          if (hadToolActivity && !isProbeSession) {
+            log.info(
+              `Run timed out during active tool use (not an API stall). ` +
+                `tools=${attempt.toolMetas.length} texts=${attempt.assistantTexts.length} ` +
+                `runId=${params.runId} sessionId=${params.sessionId} — skipping profile rotation.`,
+            );
+          }
 
           if (shouldRotate) {
             if (lastProfileId) {


### PR DESCRIPTION
Fixes #17555
Related: #14228, #11715

## Problem

When an embedded run times out while the agent is **actively executing tool calls** (e.g., long-running `exec`, sub-agents), the timeout is treated as an API rate limit stall. This triggers `markAuthProfileFailure()` with exponential backoff cooldown (1min → 5min → 25min → 1hr) and auth profile rotation — even though the API responded successfully and the agent was doing legitimate work.

On single-account setups this causes a crash loop:
1. Agent spawns long-running exec (>timeoutSeconds)
2. Run timer fires → `timedOut = true`
3. `shouldRotate` evaluates true → profile marked failed → rotation attempted → no fallback
4. Session stuck in `processing` → gateway self-restarts → repeat

## Fix

Check for tool activity before deciding to rotate:

```typescript
const hadToolActivity =
  timedOut && (attempt.toolMetas.length > 0 || attempt.assistantTexts.length > 0);
const shouldRotate =
  (!aborted && failoverFailure) ||
  (timedOut && !timedOutDuringCompaction && !hadToolActivity);
```

**Rationale:** If `toolMetas` or `assistantTexts` are populated, the API responded and the agent was actively working. The timeout is from long tool execution, not an API stall. The existing streaming inactivity watchdog (90s silence) already catches genuine API hangs separately.

This follows the same pattern as the existing `timedOutDuringCompaction` guard — both exclude cases where the timeout fired during legitimate post-response work.

## Testing

- Verified on self-hosted instance running Google Antigravity / Claude Opus 4.6
- Workload: agent spawning Claude Code sub-agents via exec (turns regularly 5–15 minutes)
- Before: 6 gateway restarts in 2 hours from false-positive profile cooldowns
- After: stable, no false cooldowns, genuine API stalls still caught by inactivity watchdog

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prevents false-positive auth profile rotation when an embedded run times out during active tool execution (e.g., long-running `exec` or sub-agents). Previously, any timeout triggered `markAuthProfileFailure()` with exponential backoff cooldown, even when the API had responded successfully and the agent was doing legitimate work. On single-account setups, this caused a crash loop.

The fix introduces a `hadToolActivity` guard that checks whether `toolMetas` or `assistantTexts` are populated before deciding to rotate. This follows the existing `timedOutDuringCompaction` pattern — both exclude cases where the timeout fired during legitimate post-response work, while the streaming inactivity watchdog (90s silence) still catches genuine API hangs.

- Adds `hadToolActivity` check to the `shouldRotate` condition in `src/agents/pi-embedded-runner/run.ts`
- Adds an informational log message when rotation is skipped due to tool activity (gated on `!timedOutDuringCompaction` to avoid overlap with compaction timeout logging)
- Adds two well-structured e2e tests: one verifying rotation is suppressed with tool activity, one verifying rotation still occurs without tool activity

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — the change is narrowly scoped, logically sound, and well-tested.
- The fix is a minimal, focused guard added to an existing condition. The logic correctly distinguishes between API stalls (no tool activity → rotate) and legitimate long-running work (tool activity present → skip rotation). It follows the existing `timedOutDuringCompaction` pattern. Both positive and negative cases are covered by new e2e tests. The log gating was correctly refined per prior review feedback. No regressions are introduced to existing behavior paths.
- No files require special attention

<sub>Last reviewed commit: e8312be</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->