### PR TITLE
fix(cron): add runtime staleness guard for runningAtMs (#17554)

### DIFF
--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -1,4 +1,5 @@
 import type { CronJobCreate, CronJobPatch } from "../types.js";
+import type { CronServiceState } from "./state.js";
 import {
   applyJobPatch,
   computeJobNextRunAtMs,
@@ -10,9 +11,16 @@ import {
   recomputeNextRunsForMaintenance,
 } from "./jobs.js";
 import { locked } from "./locked.js";
-import type { CronServiceState } from "./state.js";
 import { ensureLoaded, persist, warnIfDisabled } from "./store.js";
-import { armTimer, emit, executeJob, runMissedJobs, stopTimer, wake } from "./timer.js";
+import {
+  armTimer,
+  clearStaleRunningMarker,
+  emit,
+  executeJob,
+  runMissedJobs,
+  stopTimer,
+  wake,
+} from "./timer.js";
 
 async function ensureLoadedForRead(state: CronServiceState) {
   await ensureLoaded(state, { skipRecompute: true });
@@ -205,12 +213,19 @@ export async function run(state: CronServiceState, id: string, mode?: "due" | "f
     warnIfDisabled(state, "run");
     await ensureLoaded(state, { skipRecompute: true });
     const job = findJobOrThrow(state, id);
-    if (typeof job.state.runningAtMs === "number") {
-      return { ok: true, ran: false, reason: "already-running" as const };
-    }
     const now = state.deps.nowMs();
+    let clearedStaleMarker = false;
+    if (typeof job.state.runningAtMs === "number") {
+      if (!clearStaleRunningMarker(state, job, now, "run")) {
+        return { ok: true, ran: false, reason: "already-running" as const };
+      }
+      clearedStaleMarker = true;
+    }
     const due = isJobDue(job, now, { forced: mode === "force" });
     if (!due) {
+      if (clearedStaleMarker) {
+        await persist(state);
+      }
       return { ok: true, ran: false, reason: "not-due" as const };
     }
     await executeJob(state, job, now, { forced: mode === "force" });

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -1,8 +1,9 @@
 import type { HeartbeatRunResult } from "../../infra/heartbeat-wake.js";
+import type { CronJob, CronRunOutcome, CronRunStatus, CronRunTelemetry } from "../types.js";
+import type { CronEvent, CronServiceState } from "./state.js";
 import { DEFAULT_AGENT_ID } from "../../routing/session-key.js";
 import { resolveCronDeliveryPlan } from "../delivery.js";
 import { sweepCronRunSessions } from "../session-reaper.js";
-import type { CronJob, CronRunOutcome, CronRunStatus, CronRunTelemetry } from "../types.js";
 import {
   computeJobNextRunAtMs,
   nextWakeAtMs,
@@ -10,7 +11,6 @@ import {
   resolveJobPayloadTextForMain,
 } from "./jobs.js";
 import { locked } from "./locked.js";
-import type { CronEvent, CronServiceState } from "./state.js";
 import { ensureLoaded, persist } from "./store.js";
 
 const MAX_TIMER_DELAY_MS = 60_000;
@@ -61,6 +61,51 @@ const ERROR_BACKOFF_SCHEDULE_MS = [
 function errorBackoffMs(consecutiveErrors: number): number {
   const idx = Math.min(consecutiveErrors - 1, ERROR_BACKOFF_SCHEDULE_MS.length - 1);
   return ERROR_BACKOFF_SCHEDULE_MS[Math.max(0, idx)];
+}
+
+function resolveJobTimeoutMs(job: CronJob, defaultTimeoutMs: number): number | undefined {
+  if (job.payload.kind === "agentTurn" && typeof job.payload.timeoutSeconds === "number") {
+    return job.payload.timeoutSeconds > 0 ? job.payload.timeoutSeconds * 1_000 : undefined;
+  }
+  return defaultTimeoutMs;
+}
+
+function isStaleRunning(job: CronJob, nowMs: number, defaultTimeoutMs: number): boolean {
+  if (typeof job.state.runningAtMs !== "number") {
+    return false;
+  }
+  const jobTimeoutMs = resolveJobTimeoutMs(job, defaultTimeoutMs);
+  if (typeof jobTimeoutMs !== "number") {
+    return false;
+  }
+  return nowMs - job.state.runningAtMs > jobTimeoutMs * 2;
+}
+
+export function clearStaleRunningMarker(
+  state: CronServiceState,
+  job: CronJob,
+  nowMs: number,
+  check: string,
+): boolean {
+  if (!isStaleRunning(job, nowMs, DEFAULT_JOB_TIMEOUT_MS)) {
+    return false;
+  }
+
+  const runningAtMs = job.state.runningAtMs;
+  const jobTimeoutMs = resolveJobTimeoutMs(job, DEFAULT_JOB_TIMEOUT_MS);
+  state.deps.log.warn(
+    {
+      jobId: job.id,
+      jobName: job.name,
+      check,
+      runningAtMs,
+      staleForMs: nowMs - (runningAtMs ?? nowMs),
+      jobTimeoutMs,
+    },
+    "cron: clearing stale running marker at runtime",
+  );
+  job.state.runningAtMs = undefined;
+  return true;
 }
 
 /**
@@ -255,16 +300,7 @@ export async function onTimer(state: CronServiceState) {
       job.state.runningAtMs = startedAt;
       emit(state, { jobId: job.id, action: "started", runAtMs: startedAt });
 
-      const configuredTimeoutMs =
-        job.payload.kind === "agentTurn" && typeof job.payload.timeoutSeconds === "number"
-          ? Math.floor(job.payload.timeoutSeconds * 1_000)
-          : undefined;
-      const jobTimeoutMs =
-        configuredTimeoutMs !== undefined
-          ? configuredTimeoutMs <= 0
-            ? undefined
-            : configuredTimeoutMs
-          : DEFAULT_JOB_TIMEOUT_MS;
+      const jobTimeoutMs = resolveJobTimeoutMs(job, DEFAULT_JOB_TIMEOUT_MS);
 
       try {
         const runAbortController =
@@ -410,6 +446,7 @@ function findDueJobs(state: CronServiceState): CronJob[] {
 }
 
 function isRunnableJob(params: {
+  state: CronServiceState;
   job: CronJob;
   nowMs: number;
   skipJobIds?: ReadonlySet<string>;
@@ -426,7 +463,9 @@ function isRunnableJob(params: {
     return false;
   }
   if (typeof job.state.runningAtMs === "number") {
-    return false;
+    if (!clearStaleRunningMarker(params.state, job, nowMs, "isRunnableJob")) {
+      return false;
+    }
   }
   if (params.skipAtIfAlreadyRan && job.schedule.kind === "at" && job.state.lastStatus) {
     // Any terminal status (ok, error, skipped) means the job already ran at least once.
@@ -448,6 +487,7 @@ function collectRunnableJobs(
   }
   return state.store.jobs.filter((job) =>
     isRunnableJob({
+      state,
       job,
       nowMs,
       skipJobIds: opts?.skipJobIds,


### PR DESCRIPTION
## Problem

Cron jobs can retain a stale `runningAtMs` timestamp after completion, permanently blocking future runs. Manual triggers via `cron.run` return `{"ran": false, "reason": "already-running"}` even though the job finished successfully (`lastStatus: "ok"`, `consecutiveErrors: 0`).

### Root cause

All four scheduling/run paths unconditionally skip jobs where `runningAtMs` is set. A staleness check exists on **startup** (`ops.ts:27-32`) but not at **runtime**, so if a job completes but the marker persists (e.g. due to a race between timer ticks, a session timeout not propagating back, or an unhandled edge case in `executeJobCore`), the job is stuck until manual intervention or a full restart.

### How users hit this

1. Job runs on an `every` schedule and completes successfully
2. `runningAtMs` is not cleared despite `lastStatus: "ok""
3. All subsequent timer ticks and manual `cron.run` calls skip the job
4. Only workaround: manually edit `jobs.json` or restart the gateway

Closes #17554

## Fix

Add a runtime staleness guard: if `runningAtMs` is older than `2 × job timeout`, clear it with a warning log and allow the job to run again. This mirrors the existing startup behavior in `ops.ts`.

### Changes

**`src/cron/service/timer.ts`:**
- `resolveJobTimeoutMs(job, default)` — extracts inline timeout calculation (deduplicates from `onTimer`)
- `isStaleRunning(job, nowMs, default)` — checks if `runningAtMs` exceeds `2 × timeout`
- `clearStaleRunningMarker(state, job, nowMs, check)` — clears marker + warning log (exported for use in ops.ts)
- Applied in all 3 filter functions: `findDueJobs`, `runMissedJobs`, `runDueJobs`

**`src/cron/service/ops.ts`:**
- `run()` function now also applies the staleness guard before returning `already-running` — this was the exact user-facing path reported in #17554

The `2×` multiplier provides a generous buffer — a job must be "running" for twice its timeout before being considered stale, avoiding false positives for legitimately long-running jobs.

## Testing

All 110 existing cron tests pass.

---


## Local Validation

- `pnpm build` ✅
- `pnpm check` (oxlint) ✅
- Relevant test suites pass ✅

## Contribution Checklist

- [x] Focused scope — single fix per PR
- [x] Clear "what" + "why" in description
- [x] AI-assisted (Codex/Claude) — reviewed and tested by human
- [x] Local validation run (`pnpm build && pnpm check`)

*AI-assisted (Codex). Reviewed by human.*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a runtime staleness guard for the per-job `runningAtMs` marker in the cron scheduler. Previously, a stale `runningAtMs` could only be cleared on gateway startup (`ops.ts:start()`); this PR extends that protection to runtime by checking if `runningAtMs` exceeds `2× job timeout` and clearing it with a warning log.

- Extracts `resolveJobTimeoutMs()` helper to deduplicate the inline timeout calculation from `onTimer`
- Adds `isStaleRunning()` and `clearStaleRunningMarker()` functions in `timer.ts`
- Applies the staleness guard in `isRunnableJob()`, covering all three automatic scheduling paths (`findDueJobs`, `runMissedJobs`, `runDueJobs`)
- Applies the staleness guard in `ops.ts:run()` before returning `already-running`, directly fixing the user-facing symptom from #17554
- No new tests were added for the runtime staleness guard; existing tests all pass

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it adds a well-scoped defensive guard that correctly mirrors existing startup behavior.
- The changes are focused, logically sound, and correctly address all four code paths where a stale `runningAtMs` could block job execution. The new staleness threshold (2× job timeout) provides a reasonable buffer against false positives. The helpers are clean and the refactoring of `resolveJobTimeoutMs` reduces duplication. Score is 4 rather than 5 because no new tests were added for the runtime staleness behavior, though the existing 110 tests continue to pass.
- No files require special attention — both changed files are straightforward and well-structured.

<sub>Last reviewed commit: 58490fe</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->