### PR TITLE
fix(gateway): resolve authToken before env-var fallbacks

### DIFF
--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -212,11 +212,11 @@ export async function callGateway<T = Record<string, unknown>>(
         ? typeof remote?.token === "string" && remote.token.trim().length > 0
           ? remote.token.trim()
           : undefined
-        : process.env.OPENCLAW_GATEWAY_TOKEN?.trim() ||
-          process.env.CLAWDBOT_GATEWAY_TOKEN?.trim() ||
-          (typeof authToken === "string" && authToken.trim().length > 0
+        : (typeof authToken === "string" && authToken.trim().length > 0
             ? authToken.trim()
-            : undefined)
+            : undefined) ||
+          process.env.OPENCLAW_GATEWAY_TOKEN?.trim() ||
+          process.env.CLAWDBOT_GATEWAY_TOKEN?.trim()
       : undefined);
   const password =
     explicitAuth.password ||

--- a/src/tui/gateway-chat.ts
+++ b/src/tui/gateway-chat.ts
@@ -251,10 +251,9 @@ export function resolveGatewayConnection(opts: GatewayConnectionOptions) {
         ? typeof remote?.token === "string" && remote.token.trim().length > 0
           ? remote.token.trim()
           : undefined
-        : process.env.OPENCLAW_GATEWAY_TOKEN?.trim() ||
-          (typeof authToken === "string" && authToken.trim().length > 0
+        : (typeof authToken === "string" && authToken.trim().length > 0
             ? authToken.trim()
-            : undefined)
+            : undefined) || process.env.OPENCLAW_GATEWAY_TOKEN?.trim()
       : undefined);
 
   const password =


### PR DESCRIPTION
## Summary

- Problem: `callGateway` and `resolveGatewayConnection` checked env vars (`OPENCLAW_GATEWAY_TOKEN` / `CLAWDBOT_GATEWAY_TOKEN`) before the programmatic `authToken` parameter in local (non-remote) mode.
- Why it matters: An env var could silently override an explicitly supplied token, causing unexpected auth failures.
- What changed: Reordered the ternary chain so `authToken` is evaluated first, with env vars as fallback - matching the existing correct behaviour in `gateway/auth.ts`.
- What did NOT change (scope boundary): Remote-mode token resolution (remote token still takes top priority), server-side resolution in `gateway/auth.ts` (already correct).
- AI: I hit this bug on my live OpenClaw deployment and used Claude Code (Opus 4.6) to trace the token flow, identify the affected files (`call.ts`, `gateway-chat.ts`) and suggest a fix.

## Human Verification (required)

- Notes: The fix was straightforward - `gateway/auth.ts` already had the correct resolution order to follow. I reviewed and understand the changes.
- Verified scenarios: Checked both call sites match how `gateway/auth.ts` already does it. Ran the full test suite (all green) on v2026.2.17. Tested on my WSL2 dev box and a live Debian Trixie (6.12.63+deb13-amd64) install.
- Edge cases checked: Remote mode still works as before (remote token takes top priority). Env vars still kick in when no explicit token is set.
- What you did **not** verify: macOS, Docker.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #15722 (similar token precedence fix in `client.ts`) - no overlap, different file (`client.ts` vs `call.ts`/`gateway-chat.ts`)
- Related #17260 (removes env var from service file to avoid override) - complementary, tackles the problem from the service-file side rather than resolution order

## User-visible / Behavior Changes

- When both an explicit `authToken` and `OPENCLAW_GATEWAY_TOKEN` env var are present, the explicit token now wins. Previously the env var won.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? Yes
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any Yes, explain risk + mitigation: Token selection order changed so the programmatic token takes precedence over env vars. This matches the server-side behaviour in `gateway/auth.ts` and reduces the risk of stale env vars overriding intended tokens.

## Repro + Verification

### Environment

- OS: Linux (WSL2)
- Runtime/container: Node.js v24.13.1
- openclaw version: v2026.2.17
- Model/provider: N/A
- Integration/channel (if any): Gateway client
- Relevant config (redacted): `gateway.auth.token` set in config, `OPENCLAW_GATEWAY_TOKEN` also set in environment

### Steps

1. Set `gateway.auth.token` in config to `token-A`.
2. Set `OPENCLAW_GATEWAY_TOKEN=token-B` in environment.
3. Call `callGateway` or `resolveGatewayConnection` in local (non-remote) mode.

### Expected

- `token-A` (the explicit config token) is used.

### Actual

- Before fix: `token-B` (env var) was used.
- After fix: `token-A` is used.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Full local validation passed on v2026.2.17:
- `pnpm build` - passed
- `pnpm check` (format + types + lint) - 1122 pre-existing format issues on main, no new issues from this PR
- `pnpm test` - 702 test files, 5900 tests passed, 0 failures



## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit.
- Files/config to restore: `src/gateway/call.ts`, `src/tui/gateway-chat.ts`
- Known bad symptoms reviewers should watch for: Auth failures when relying on env var token with no config token set (should not happen as env vars remain as fallback).

## Risks and Mitigations

- Risk: Users relying on env var to intentionally override a config token will see different behaviour.
  - Mitigation: This was undocumented behaviour and inconsistent with the server side. Env var still works when no explicit token is provided.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes token resolution order in `callGateway` and `resolveGatewayConnection` to prioritize programmatic `authToken` over environment variables (`OPENCLAW_GATEWAY_TOKEN`/`CLAWDBOT_GATEWAY_TOKEN`) in local mode. Previously, env vars would silently override explicitly supplied tokens, causing unexpected auth failures. The fix aligns client-side resolution with the existing correct behavior in `gateway/auth.ts:186` where config token takes precedence over env vars.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is minimal, focused, and consistent with existing patterns in the codebase. It fixes a clear bug where env vars incorrectly took precedence over programmatic tokens. The fix matches the server-side implementation in `gateway/auth.ts` and preserves all existing behavior including remote mode resolution. All tests pass.
- No files require special attention.

<sub>Last reviewed commit: 3df3ae8</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->

