### PR TITLE
fix: make dangerouslyDisableDeviceAuth bypass device identity checks

### DIFF
--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -430,7 +430,9 @@ export function attachGatewayWsMessageHandler(params: {
           // When dangerouslyDisableDeviceAuth is enabled, preserve scopes so
           // the Control UI can actually operate (read, write, approve, etc.).
           // Without this, scopes get cleared and the connection is useless.
-          if (allowControlUiBypass) {
+          // Note: only for dangerouslyDisableDeviceAuth, NOT allowInsecureAuth
+          // (which permits insecure transport but should not auto-grant scopes).
+          if (disableControlUiDeviceAuth) {
             if (scopes.length === 0) {
               scopes = [
                 "operator.admin",


### PR DESCRIPTION
## Summary

`dangerouslyDisableDeviceAuth: true` is documented to disable device identity requirements for Control UI connections, but currently has two bugs that prevent it from working:

- **`canSkipDevice` ignores the bypass flag** — `canSkipDevice = sharedAuthOk` doesn't consider `allowControlUiBypass`, so connections are still rejected with `"device identity required"` (WebSocket close code 1008) even when the admin explicitly disabled device auth.
- **Scopes unconditionally cleared** — When `!device` (which is `null` when `dangerouslyDisableDeviceAuth` is true), all operator scopes are cleared to `[]`. The Control UI connects successfully but can't perform any operations (no read, write, approve, or admin permissions).

### Changes

1. Include `allowControlUiBypass` in the `canSkipDevice` check so device identity is actually skipped
2. Grant default operator scopes when `allowControlUiBypass` is active instead of clearing them

No change to behavior when `dangerouslyDisableDeviceAuth` is not set — the existing scope-clearing and device-required logic is preserved for all other code paths.

## Reproduction

1. Set `gateway.controlUi.dangerouslyDisableDeviceAuth: true` in `openclaw.json`
2. Set `gateway.auth.mode: "token"` with a valid token
3. Access Control UI from a non-localhost address (e.g., LAN IP or reverse proxy)
4. Connection fails with `"device identity required"` (WebSocket 1008)

After this fix, the connection succeeds and the Control UI is fully functional.

## Testing

- [x] Tested against a production OpenClaw v2026.2.14 gateway deployment
- [x] Verified Control UI connects and operates with full scopes when `dangerouslyDisableDeviceAuth: true`
- [x] Verified existing behavior is unchanged when the flag is not set

Fixes #8529
Fixes #11590

[AI-assisted] Created with Claude Code. Tested in production.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two bugs preventing `dangerouslyDisableDeviceAuth` from working as documented:

1. **Device identity bypass now works**: Changed `canSkipDevice` calculation on line 451 to include `allowControlUiBypass`, enabling connections without device identity when the flag is set
2. **Scopes are preserved**: When `dangerouslyDisableDeviceAuth` is active and no scopes are provided, the code now auto-grants full operator scopes (lines 435-446) instead of clearing them, allowing the Control UI to actually function

The scope auto-granting logic was correctly narrowed to only `disableControlUiDeviceAuth` (not `allowInsecureAuth`) in commit e8008d51, addressing the previous review feedback about unintended scope escalation.

The changes are minimal, well-commented, and preserve existing behavior for all other configurations.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is surgical and well-scoped: it adds one condition to an existing check and implements scope preservation with proper guard conditions. The previous review concern about scope escalation for `allowInsecureAuth` was addressed in commit e8008d51. Existing tests cover this feature, and the changes only affect the specific code path when `dangerouslyDisableDeviceAuth` is enabled.
- No files require special attention

<sub>Last reviewed commit: e8008d5</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->