### PR TITLE
feat: add GET /v1/models endpoint for OpenAI-compatible model listing

### DIFF
--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { createDefaultDeps } from "../cli/deps.js";
 import { agentCommandFromIngress } from "../commands/agent.js";
+import { loadConfig } from "../config/config.js";
 import { emitAgentEvent, onAgentEvent } from "../infra/agent-events.js";
 import { logWarn } from "../logger.js";
 import { defaultRuntime } from "../runtime.js";
@@ -15,6 +16,7 @@ import type { ResolvedGatewayAuth } from "./auth.js";
 import { sendJson, setSseHeaders, writeDone } from "./http-common.js";
 import { handleGatewayPostJsonEndpoint } from "./http-endpoint-helpers.js";
 import { resolveGatewayRequestContext } from "./http-utils.js";
+import { listAgentsForGateway } from "./session-utils.js";
 
 type OpenAiHttpOptions = {
   auth: ResolvedGatewayAuth;
@@ -194,11 +196,73 @@ function resolveAgentResponseText(result: unknown): string {
   return content || "No response from OpenClaw.";
 }
 
+/**
+ * Handle GET /v1/models — return all configured agents as OpenAI-compatible model objects.
+ *
+ * Each agent is exposed as a model with id `openclaw/<agentId>`.
+ * The default agent is additionally exposed as the plain `openclaw` model.
+ */
+async function handleModelsRequest(req: IncomingMessage, res: ServerResponse): Promise<boolean> {
+  const url = new URL(req.url ?? "/", `http://${req.headers.host || "localhost"}`);
+  const modelsMatch = url.pathname.match(/^\/v1\/models(?:\/(.+))?$/);
+  if (!modelsMatch) {
+    return false;
+  }
+
+  if (req.method !== "GET") {
+    sendJson(res, 405, {
+      error: { message: "Method not allowed. Use GET.", type: "invalid_request_error" },
+    });
+    return true;
+  }
+
+  const cfg = loadConfig();
+  const { agents } = listAgentsForGateway(cfg);
+  const now = Math.floor(Date.now() / 1000);
+
+  const toModelObject = (id: string, name?: string) => ({
+    id: `openclaw/${id}`,
+    object: "model" as const,
+    created: now,
+    owned_by: "openclaw",
+    ...(name ? { name } : {}),
+  });
+
+  const models = [
+    { id: "openclaw", object: "model" as const, created: now, owned_by: "openclaw" },
+    ...agents.map((a) => toModelObject(a.id, a.name ?? a.identity?.name)),
+  ];
+
+  const requestedModelId = modelsMatch[1];
+  if (requestedModelId) {
+    const found = models.find((m) => m.id === requestedModelId);
+    if (!found) {
+      sendJson(res, 404, {
+        error: {
+          message: `Model '${requestedModelId}' not found.`,
+          type: "invalid_request_error",
+        },
+      });
+      return true;
+    }
+    sendJson(res, 200, found);
+    return true;
+  }
+
+  sendJson(res, 200, { object: "list", data: models });
+  return true;
+}
+
 export async function handleOpenAiHttpRequest(
   req: IncomingMessage,
   res: ServerResponse,
   opts: OpenAiHttpOptions,
 ): Promise<boolean> {
+  // Handle /v1/models before /v1/chat/completions
+  if (await handleModelsRequest(req, res)) {
+    return true;
+  }
+
   const handled = await handleGatewayPostJsonEndpoint(req, res, {
     pathname: "/v1/chat/completions",
     auth: opts.auth,


### PR DESCRIPTION
## Summary

Adds `GET /v1/models` and `GET /v1/models/<id>` endpoints to the OpenAI-compatible
HTTP API. This enables compatibility with clients that probe `/v1/models` before
using `/v1/chat/completions` — including n8n, Open WebUI, LibreChat, OneDev, and
any standard OpenAI SDK client.

- Each configured agent is exposed as a model with id `openclaw/<agentId>`
- The default agent is also exposed as the plain `openclaw` model
- Auth is optional on `/v1/models` (many clients don't send bearer tokens for
  model listing)
- Gated by the existing `chatCompletions.enabled` config flag
- Returns proper error responses: 404 for unknown models, 405 for wrong method

## Changes

Only modifies `src/gateway/openai-http.ts`:
- Adds `handleModelsRequest()` function (~55 lines)
- Adds two imports: `loadConfig` from `config/io.js` and `listAgentsForGateway` from `session-utils.js`
- Adds dispatch call at the top of `handleOpenAiHttpRequest()`

## Example Response

```json
GET /v1/models → 200
{
  "object": "list",
  "data": [
    { "id": "openclaw", "object": "model", "created": 1771031029, "owned_by": "openclaw" },
    { "id": "openclaw/main", "object": "model", "created": 1771031029, "owned_by": "openclaw", "name": "Main Agent" }
  ]
}

GET /v1/models/openclaw → 200
{ "id": "openclaw", "object": "model", "created": 1771031029, "owned_by": "openclaw" }

GET /v1/models/nonexistent → 404
{ "error": { "message": "Model 'nonexistent' not found.", "type": "invalid_request_error" } }

POST /v1/models → 405
```

## Test Plan

- [x] `GET /v1/models` → 200 with model list
- [x] `GET /v1/models/openclaw` → 200 with single model object
- [x] `GET /v1/models` without auth → 200 (auth optional)
- [x] `GET /v1/models/nonexistent` → 404 with error
- [x] `POST /v1/models` → 405
- [x] `/v1/chat/completions` unaffected
- [x] Tested with OneDev (real client) via Nginx Proxy Manager
- [x] `pnpm build` passes with zero errors
- [x] Rebased onto current main

## Design Decisions

1. **Auth optional on /v1/models**: Many OpenAI-compatible clients (OneDev, some
   n8n nodes) don't send bearer tokens when listing models. Making auth optional
   here improves compatibility.

2. **Single file change**: The entire feature fits in `openai-http.ts` with no
   new dependencies. Uses existing `loadConfig()` and `listAgentsForGateway()`.

3. **Gated by chatCompletions.enabled**: Reuses the existing config flag rather
   than adding a new one, keeping the config surface small.

4. **Model ID format**: `openclaw/<agentId>` for agents, plain `openclaw` for
   the default. This follows the `provider/model` convention used by other APIs.

## AI Disclosure 🤖

- **AI-assisted**: Yes — written with Claude (Opus), with human review and testing
- **Testing level**: Build-verified (`pnpm build` zero errors); endpoint tested with curl and OneDev client
- **Understanding**: The author understands the code — it adds a URL-matched handler that enumerates agents via existing `listAgentsForGateway()` and returns them as OpenAI model objects