### PR TITLE
feat(heartbeat): add agentId to route default heartbeat to a specific agent

### DIFF
--- a/docs/gateway/heartbeat.md
+++ b/docs/gateway/heartbeat.md
@@ -85,6 +85,7 @@ and logged; a message that is only `HEARTBEAT_OK` is dropped.
     defaults: {
       heartbeat: {
         every: "30m", // default: 30m (0m disables)
+        agentId: "ops", // optional: route default heartbeat to a specific agent
         model: "anthropic/claude-opus-4-6",
         includeReasoning: false, // default: false (deliver separate Reasoning: message when available)
         target: "last", // last | none | <channel id> (core or plugin, e.g. "bluebubbles")
@@ -97,6 +98,34 @@ and logged; a message that is only `HEARTBEAT_OK` is dropped.
   },
 }
 ```
+
+### Default heartbeat agent routing
+
+By default, when no per-agent `heartbeat` blocks exist, the heartbeat runs as the
+default agent. Set `agents.defaults.heartbeat.agentId` to route the default
+heartbeat to a different agent — without needing to duplicate the heartbeat config
+into per-agent blocks:
+
+```json5
+{
+  agents: {
+    defaults: {
+      heartbeat: {
+        every: "30m",
+        agentId: "ops", // heartbeat runs as "ops" agent
+        target: "last",
+      },
+    },
+    list: [{ id: "main", default: true }, { id: "ops" }],
+  },
+}
+```
+
+This is simpler than the alternative of disabling the main heartbeat (`every: "0m"`)
+and adding a separate `heartbeat` block to the ops agent.
+
+**Note:** if any `agents.list[]` entry has a `heartbeat` block, `agentId` is
+ignored — per-agent blocks take full control of which agents run heartbeats.
 
 ### Scope and precedence
 
@@ -194,6 +223,7 @@ Use `accountId` to target a specific account on multi-account channels like Tele
 
 ### Field notes
 
+- `agentId`: optional agent id to run the default heartbeat as. Ignored when per-agent heartbeat blocks exist.
 - `every`: heartbeat interval (duration string; default unit = minutes).
 - `model`: optional model override for heartbeat runs (`provider/model`).
 - `includeReasoning`: when enabled, also deliver the separate `Reasoning:` message when available (same shape as `/reasoning on`).

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -167,6 +167,20 @@ export type AgentDefaultsConfig = {
   typingMode?: TypingMode;
   /** Periodic background heartbeat runs. */
   heartbeat?: {
+    /**
+     * Agent id to run heartbeats as (when no per-agent heartbeat blocks exist).
+     *
+     * By default, the heartbeat runs as the default agent. Set this to route
+     * the default heartbeat to a different agent without needing to duplicate
+     * the heartbeat config into `agents.list[].heartbeat`.
+     *
+     * Example: `agentId: "ops"` — heartbeats run as the "ops" agent using
+     * the defaults heartbeat config, without needing a per-agent block.
+     *
+     * Note: if any `agents.list[]` entry has a `heartbeat` block, this field
+     * is ignored (per-agent heartbeat blocks take full control).
+     */
+    agentId?: string;
     /** Heartbeat interval (duration string, default unit: minutes; default: 30m). */
     every?: string;
     /** Optional active-hours window (local time); heartbeats run only inside this window. */

--- a/src/infra/heartbeat-runner.agent-routing.test.ts
+++ b/src/infra/heartbeat-runner.agent-routing.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.js";
+import { isHeartbeatEnabledForAgent } from "./heartbeat-runner.js";
+
+describe("heartbeat agent routing via agents.defaults.heartbeat.agentId", () => {
+  it("routes heartbeat to the default agent when agentId is not set", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          heartbeat: { every: "30m" },
+        },
+        list: [{ id: "main", default: true }, { id: "ops" }],
+      },
+    };
+
+    expect(isHeartbeatEnabledForAgent(cfg, "main")).toBe(true);
+    expect(isHeartbeatEnabledForAgent(cfg, "ops")).toBe(false);
+  });
+
+  it("routes heartbeat to the specified agentId", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          heartbeat: { every: "30m", agentId: "ops" },
+        },
+        list: [{ id: "main", default: true }, { id: "ops" }],
+      },
+    };
+
+    expect(isHeartbeatEnabledForAgent(cfg, "main")).toBe(false);
+    expect(isHeartbeatEnabledForAgent(cfg, "ops")).toBe(true);
+  });
+
+  it("per-agent heartbeat blocks take precedence over agentId", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          heartbeat: { every: "30m", agentId: "ops" },
+        },
+        list: [
+          { id: "main", default: true },
+          { id: "ops" },
+          { id: "monitor", heartbeat: { every: "1h" } },
+        ],
+      },
+    };
+
+    // agentId is ignored when per-agent heartbeat blocks exist
+    expect(isHeartbeatEnabledForAgent(cfg, "main")).toBe(false);
+    expect(isHeartbeatEnabledForAgent(cfg, "ops")).toBe(false);
+    expect(isHeartbeatEnabledForAgent(cfg, "monitor")).toBe(true);
+  });
+
+  it("works with no agents list (single agent)", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          heartbeat: { every: "30m", agentId: "ops" },
+        },
+      },
+    };
+
+    expect(isHeartbeatEnabledForAgent(cfg, "ops")).toBe(true);
+    expect(isHeartbeatEnabledForAgent(cfg, "main")).toBe(false);
+  });
+});

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -130,6 +130,11 @@ export function isHeartbeatEnabledForAgent(cfg: OpenClawConfig, agentId?: string
       (entry) => Boolean(entry?.heartbeat) && normalizeAgentId(entry?.id) === resolvedAgentId,
     );
   }
+  // When agents.defaults.heartbeat.agentId is set, only that agent runs heartbeats.
+  const defaultHeartbeatAgentId = cfg.agents?.defaults?.heartbeat?.agentId;
+  if (defaultHeartbeatAgentId) {
+    return resolvedAgentId === normalizeAgentId(defaultHeartbeatAgentId);
+  }
   return resolvedAgentId === resolveDefaultAgentId(cfg);
 }
 
@@ -207,7 +212,11 @@ function resolveHeartbeatAgents(cfg: OpenClawConfig): HeartbeatAgent[] {
       })
       .filter((entry) => entry.agentId);
   }
-  const fallbackId = resolveDefaultAgentId(cfg);
+  // Use agents.defaults.heartbeat.agentId if set, otherwise fall back to the default agent.
+  const defaultHeartbeatAgentId = cfg.agents?.defaults?.heartbeat?.agentId;
+  const fallbackId = defaultHeartbeatAgentId
+    ? normalizeAgentId(defaultHeartbeatAgentId)
+    : resolveDefaultAgentId(cfg);
   return [{ agentId: fallbackId, heartbeat: resolveHeartbeatConfig(cfg, fallbackId) }];
 }
 


### PR DESCRIPTION
## Problem

To run heartbeats as a non-default agent, users currently have to either:

1. **Disable the main heartbeat** (`every: "0m"`) and duplicate the entire heartbeat config into the target agent's `agents.list[].heartbeat` block
2. **Make the target agent the default** — which changes routing for everything else too

This is unnecessarily complex for a common use case: "I want my heartbeat to run as my `ops` agent, not my `main` agent."

## Solution

Add `agents.defaults.heartbeat.agentId` — a single field that routes the default heartbeat to a specific agent:

```json5
{
  agents: {
    defaults: {
      heartbeat: {
        every: "30m",
        agentId: "ops",   // ← just add this
        target: "last",
      },
    },
    list: [
      { id: "main", default: true },
      { id: "ops" },
    ],
  },
}
```

**Before:** disable main heartbeat + duplicate config into per-agent block
**After:** one field, same defaults config, different agent

### Precedence

- If any `agents.list[]` entry has a `heartbeat` block → `agentId` is ignored (per-agent blocks take full control, same as today)
- If no per-agent heartbeat blocks exist → heartbeat runs as `agentId` (or the default agent if `agentId` is not set)

This is fully backward compatible — the behavior when `agentId` is not set is identical to today.

## Implementation

- **`src/config/types.agent-defaults.ts`** — Added `agentId?: string` to heartbeat config type with JSDoc
- **`src/infra/heartbeat-runner.ts`** — Updated `resolveHeartbeatAgents()` and `isHeartbeatEnabledForAgent()` to respect `agentId`
- **`docs/gateway/heartbeat.md`** — Documented `agentId` field, added routing section, updated config example and field notes
- **`src/infra/heartbeat-runner.agent-routing.test.ts`** — 4 tests covering: default routing, agentId routing, per-agent precedence, single-agent setup

## Testing

- [x] 4 new tests for agent routing (all passing)
- [x] 98 existing heartbeat tests still pass
- [x] Build passes
- [x] Lint passes
- [x] Backward compatible

## Notes

- AI-assisted PR (Claude) — fully tested
- This is a feature proposal — happy to adjust naming or behavior based on maintainer feedback
- Discussion: https://github.com/openclaw/openclaw/discussions/17553

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `agents.defaults.heartbeat.agentId` field to route the default heartbeat to a specific agent without needing per-agent heartbeat blocks. This simplifies configuration for the common use case of running heartbeats as a non-default agent (e.g., running as "ops" instead of "main").

**Changes:**
- Added `agentId?: string` to the heartbeat config type with comprehensive JSDoc explaining behavior and precedence rules (src/config/types.agent-defaults.ts:183)
- Updated `isHeartbeatEnabledForAgent()` to check `agentId` when no per-agent heartbeat blocks exist (src/infra/heartbeat-runner.ts:134-136)
- Updated `resolveHeartbeatAgents()` to use `agentId` as fallback before defaulting to the default agent (src/infra/heartbeat-runner.ts:216-218)
- Documented the feature with examples and precedence rules in docs/gateway/heartbeat.md
- Added 4 test cases covering default routing, `agentId` routing, per-agent precedence, and single-agent setup

**Backward compatibility:** Fully backward compatible - when `agentId` is not set, behavior is identical to current implementation.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is simple, well-tested (4 new tests covering key scenarios), fully backward compatible, and follows existing patterns in the codebase. The change only affects heartbeat routing logic when the new optional field is set, with clear precedence rules. All existing tests pass according to the PR description.
- No files require special attention

<sub>Last reviewed commit: 1335cb8</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->