### PR TITLE
fix(relay): survive WS disconnects and MV3 worker restarts

### DIFF
--- a/assets/chrome-extension/background.js
+++ b/assets/chrome-extension/background.js
@@ -26,6 +26,10 @@ const childSessionToTab = new Map()
 /** @type {Map<number, {resolve:(v:any)=>void, reject:(e:Error)=>void}>} */
 const pending = new Map()
 
+// ===== FIX #1 & #2: Auto-reconnect state =====
+let reconnectAttempt = 0
+let reconnectTimer = null
+
 function nowStack() {
   try {
     return new Error().stack || ''
@@ -93,6 +97,13 @@ async function ensureRelayConnection() {
       chrome.debugger.onEvent.addListener(onDebuggerEvent)
       chrome.debugger.onDetach.addListener(onDebuggerDetach)
     }
+
+    // ===== FIX #2: Reset reconnect counter on successful connection =====
+    reconnectAttempt = 0
+    if (reconnectTimer) {
+      clearTimeout(reconnectTimer)
+      reconnectTimer = null
+    }
   })()
 
   try {
@@ -104,22 +115,222 @@ async function ensureRelayConnection() {
 
 function onRelayClosed(reason) {
   relayWs = null
+
+  // Reject all pending requests
   for (const [id, p] of pending.entries()) {
     pending.delete(id)
     p.reject(new Error(`Relay disconnected (${reason})`))
   }
 
-  for (const tabId of tabs.keys()) {
-    void chrome.debugger.detach({ tabId }).catch(() => {})
-    setBadge(tabId, 'connecting')
-    void chrome.action.setTitle({
-      tabId,
-      title: 'OpenClaw Browser Relay: disconnected (click to re-attach)',
-    })
+  // ===== FIX #1: DON'T detach debugger sessions on WS drop =====
+  // Keep debugger attached — only update badge to show disconnected state.
+  // When we reconnect, we'll re-announce existing sessions.
+  for (const [tabId, tab] of tabs.entries()) {
+    if (tab.state === 'connected') {
+      setBadge(tabId, 'connecting')
+      void chrome.action.setTitle({
+        tabId,
+        title: 'OpenClaw Browser Relay: reconnecting…',
+      })
+    }
   }
-  tabs.clear()
-  tabBySession.clear()
-  childSessionToTab.clear()
+  // DON'T: tabs.clear(), tabBySession.clear(), childSessionToTab.clear()
+  // DON'T: chrome.debugger.detach()
+
+  // ===== FIX #2: Schedule auto-reconnect =====
+  scheduleReconnect()
+}
+
+function scheduleReconnect() {
+  if (reconnectTimer) return // already scheduled
+
+  const delay = Math.min(1000 * Math.pow(2, reconnectAttempt), 30000) + Math.random() * 500
+  reconnectAttempt++
+
+  console.log(`[OpenClaw Relay] Scheduling reconnect attempt ${reconnectAttempt} in ${Math.round(delay)}ms`)
+
+  reconnectTimer = setTimeout(async () => {
+    reconnectTimer = null
+    try {
+      await ensureRelayConnection()
+      console.log('[OpenClaw Relay] Reconnected successfully')
+
+      // Re-announce all still-attached tabs
+      for (const [tabId, tab] of tabs.entries()) {
+        if (tab.state === 'connected' && tab.sessionId && tab.targetId) {
+          // Verify tab still exists
+          const chromeTab = await chrome.tabs.get(tabId).catch(() => null)
+          if (!chromeTab) {
+            // Tab was closed while disconnected — clean up
+            cleanupTab(tabId)
+            continue
+          }
+
+          // Verify debugger still attached by sending a harmless command
+          try {
+            await chrome.debugger.sendCommand({ tabId }, 'Runtime.evaluate', {
+              expression: '1',
+              returnByValue: true,
+            })
+          } catch {
+            // Debugger was detached (e.g., user dismissed the bar)
+            cleanupTab(tabId)
+            continue
+          }
+
+          // Re-announce to the relay server
+          try {
+            const info = /** @type {any} */ (
+              await chrome.debugger.sendCommand({ tabId }, 'Target.getTargetInfo')
+            )
+            const targetInfo = info?.targetInfo
+            // Update targetId in case it changed (e.g., page navigated)
+            const newTargetId = String(targetInfo?.targetId || '').trim() || tab.targetId
+
+            tab.targetId = newTargetId
+
+            sendToRelay({
+              method: 'forwardCDPEvent',
+              params: {
+                method: 'Target.attachedToTarget',
+                params: {
+                  sessionId: tab.sessionId,
+                  targetInfo: { ...targetInfo, attached: true },
+                  waitingForDebugger: false,
+                },
+              },
+            })
+
+            setBadge(tabId, 'on')
+            void chrome.action.setTitle({
+              tabId,
+              title: 'OpenClaw Browser Relay: attached (click to detach)',
+            })
+            console.log(`[OpenClaw Relay] Re-announced tab ${tabId} (session: ${tab.sessionId})`)
+          } catch (err) {
+            console.warn(`[OpenClaw Relay] Failed to re-announce tab ${tabId}:`, err)
+            cleanupTab(tabId)
+          }
+        }
+      }
+    } catch (err) {
+      console.log(`[OpenClaw Relay] Reconnect failed: ${err instanceof Error ? err.message : err}`)
+      scheduleReconnect()
+    }
+  }, delay)
+}
+
+// ===== FIX #3: Persist state to chrome.storage.session for MV3 worker restarts =====
+async function persistState() {
+  try {
+    const tabEntries = []
+    for (const [tabId, tab] of tabs.entries()) {
+      if (tab.state === 'connected' && tab.sessionId && tab.targetId) {
+        tabEntries.push({ tabId, sessionId: tab.sessionId, targetId: tab.targetId, attachOrder: tab.attachOrder })
+      }
+    }
+    await chrome.storage.session.set({ relayTabs: tabEntries, nextSession })
+  } catch {
+    // chrome.storage.session may not be available in all contexts
+  }
+}
+
+async function restoreState() {
+  try {
+    const stored = await chrome.storage.session.get(['relayTabs', 'nextSession'])
+    if (!stored.relayTabs?.length) return false
+
+    if (stored.nextSession) nextSession = stored.nextSession
+
+    let restored = 0
+    for (const entry of stored.relayTabs) {
+      const { tabId, sessionId, targetId, attachOrder } = entry
+
+      // Verify tab still exists
+      const chromeTab = await chrome.tabs.get(tabId).catch(() => null)
+      if (!chromeTab) continue
+
+      // Verify debugger is still attached, re-attach if needed
+      try {
+        await chrome.debugger.sendCommand({ tabId }, 'Runtime.evaluate', {
+          expression: '1',
+          returnByValue: true,
+        })
+      } catch {
+        // Debugger not attached — try to re-attach
+        console.log(`[OpenClaw Relay] Tab ${tabId} debugger lost — attempting re-attach`)
+        try {
+          await chrome.debugger.attach({ tabId }, '1.3')
+          await chrome.debugger.sendCommand({ tabId }, 'Runtime.enable')
+          await chrome.debugger.sendCommand({ tabId }, 'Network.enable')
+          console.log(`[OpenClaw Relay] Tab ${tabId} re-attached successfully`)
+        } catch (reattachErr) {
+          console.warn(`[OpenClaw Relay] Tab ${tabId} re-attach failed:`, reattachErr)
+          setBadge(tabId, 'off')
+          continue
+        }
+      }
+
+      // Restore in-memory state
+      tabs.set(tabId, { state: 'connected', sessionId, targetId, attachOrder })
+      tabBySession.set(sessionId, tabId)
+      setBadge(tabId, 'on')
+      restored++
+    }
+
+    if (restored > 0) {
+      console.log(`[OpenClaw Relay] Restored ${restored} tab(s) from session storage`)
+
+      // Install debugger listeners
+      if (!debuggerListenersInstalled) {
+        debuggerListenersInstalled = true
+        chrome.debugger.onEvent.addListener(onDebuggerEvent)
+        chrome.debugger.onDetach.addListener(onDebuggerDetach)
+      }
+
+      // Try to reconnect WS and re-announce
+      try {
+        await ensureRelayConnection()
+        for (const [tabId, tab] of tabs.entries()) {
+          if (tab.state === 'connected' && tab.sessionId && tab.targetId) {
+            const info = /** @type {any} */ (
+              await chrome.debugger.sendCommand({ tabId }, 'Target.getTargetInfo')
+            )
+            sendToRelay({
+              method: 'forwardCDPEvent',
+              params: {
+                method: 'Target.attachedToTarget',
+                params: {
+                  sessionId: tab.sessionId,
+                  targetInfo: { ...(info?.targetInfo || {}), attached: true },
+                  waitingForDebugger: false,
+                },
+              },
+            })
+          }
+        }
+      } catch {
+        // WS not available yet — will reconnect later
+        scheduleReconnect()
+      }
+
+      return true
+    }
+  } catch (err) {
+    console.warn('[OpenClaw Relay] Failed to restore state:', err)
+  }
+  return false
+}
+
+function cleanupTab(tabId) {
+  const tab = tabs.get(tabId)
+  if (tab?.sessionId) tabBySession.delete(tab.sessionId)
+  tabs.delete(tabId)
+  for (const [childSessionId, parentTabId] of childSessionToTab.entries()) {
+    if (parentTabId === tabId) childSessionToTab.delete(childSessionId)
+  }
+  setBadge(tabId, 'off')
+  void persistState()
 }
 
 function sendToRelay(payload) {
@@ -243,6 +454,10 @@ async function attachTab(tabId, opts = {}) {
   }
 
   setBadge(tabId, 'on')
+
+  // ===== FIX #3: Persist state after attach =====
+  void persistState()
+
   return { sessionId, targetId }
 }
 
@@ -280,6 +495,9 @@ async function detachTab(tabId, reason) {
     tabId,
     title: 'OpenClaw Browser Relay (click to attach/detach)',
   })
+
+  // ===== FIX #3: Persist state after detach =====
+  void persistState()
 }
 
 async function connectOrToggleForActiveTab() {
@@ -430,9 +648,60 @@ function onDebuggerDetach(source, reason) {
   void detachTab(tabId, reason)
 }
 
+// ===== FIX #4: Tab lifecycle cleanup =====
+chrome.tabs.onRemoved.addListener((tabId) => {
+  if (!tabs.has(tabId)) return
+  console.log(`[OpenClaw Relay] Tab ${tabId} closed — cleaning up`)
+  void detachTab(tabId, 'tab_closed')
+})
+
+chrome.tabs.onReplaced.addListener((addedTabId, removedTabId) => {
+  if (!tabs.has(removedTabId)) return
+  console.log(`[OpenClaw Relay] Tab ${removedTabId} replaced by ${addedTabId} — cleaning up`)
+  void detachTab(removedTabId, 'tab_replaced')
+})
+
 chrome.action.onClicked.addListener(() => void connectOrToggleForActiveTab())
 
 chrome.runtime.onInstalled.addListener(() => {
   // Useful: first-time instructions.
   void chrome.runtime.openOptionsPage()
+  // Start keepalive alarm
+  chrome.alarms.create('relay-keepalive', { periodInMinutes: 4 })
+})
+
+// ===== FIX #5: Keepalive via chrome.alarms =====
+// Prevents MV3 service worker from being terminated, preserving debugger sessions
+chrome.alarms.create('relay-keepalive', { periodInMinutes: 4 })
+
+chrome.alarms.onAlarm.addListener(async (alarm) => {
+  if (alarm.name !== 'relay-keepalive') return
+
+  // Check if we have any attached tabs
+  if (tabs.size === 0) return
+
+  console.log(`[OpenClaw Relay] Keepalive ping — ${tabs.size} tab(s) attached`)
+
+  // Ping each attached tab to keep debugger alive
+  for (const [tabId, tab] of tabs.entries()) {
+    if (tab.state !== 'connected') continue
+    try {
+      await chrome.debugger.sendCommand({ tabId }, 'Runtime.evaluate', {
+        expression: '"keepalive"',
+        returnByValue: true,
+      })
+    } catch {
+      console.warn(`[OpenClaw Relay] Keepalive: tab ${tabId} debugger lost — triggering restore`)
+      void restoreState()
+      break
+    }
+  }
+})
+
+// ===== FIX #3: Restore state on service worker startup =====
+// MV3 service workers can die and restart — restore our state from session storage
+void restoreState().then((restored) => {
+  if (restored) {
+    console.log('[OpenClaw Relay] Service worker restarted — state restored from session storage')
+  }
 })

--- a/assets/chrome-extension/manifest.json
+++ b/assets/chrome-extension/manifest.json
@@ -9,7 +9,7 @@
     "48": "icons/icon48.png",
     "128": "icons/icon128.png"
   },
-  "permissions": ["debugger", "tabs", "activeTab", "storage"],
+  "permissions": ["debugger", "tabs", "activeTab", "storage", "alarms"],
   "host_permissions": ["http://127.0.0.1/*", "http://localhost/*"],
   "background": { "service_worker": "background.js", "type": "module" },
   "action": {


### PR DESCRIPTION
## Summary

The Browser Relay extension frequently loses connection and fails to recover, requiring manual re-attach. This PR adds 5 fixes to make the relay resilient to WebSocket drops, MV3 service worker termination, and tab lifecycle events.

Related issues: #15099, #15989, #11142

## Problem

The current `background.js` has several failure modes:

1. **WebSocket drop → debugger detach**: When the relay WebSocket closes (e.g., OpenClaw restart, network blip), `onRelayClosed()` immediately detaches all debugger sessions and clears state. The user must manually click the toolbar icon again to re-attach.
2. **No auto-reconnect**: After a WS disconnect, the extension makes no attempt to reconnect. It silently goes dead.
3. **MV3 service worker death**: Chrome/Edge can terminate the service worker at any time. All in-memory state (tabs, sessions) is lost.
4. **Tab close/replace not handled**: Stale entries remain in the maps.
5. **Service worker termination**: Without periodic activity, Chrome terminates the MV3 service worker after ~30s of inactivity.

## Fixes

| # | Fix | Description |
|---|-----|-------------|
| 1 | **Don't detach on WS drop** | Keep debugger attached, show reconnecting badge, re-announce on reconnect |
| 2 | **Auto-reconnect** | Exponential backoff (1s → 30s cap) with jitter, re-announce all tabs on success |
| 3 | **Session storage persistence** | Save/restore state via `chrome.storage.session` for MV3 worker restarts, with debugger re-attach |
| 4 | **Tab lifecycle cleanup** | `onRemoved` / `onReplaced` listeners to clean up stale entries |
| 5 | **Keepalive alarm** | `chrome.alarms` every 4 min to prevent worker termination + detect stale debuggers |

### manifest.json
- Added `"alarms"` to permissions array (required for Fix #5)

## Testing

Tested on Edge (Chromium-based) with an automated pipeline running via cron at 3:00 AM and 3:00 PM daily:

- **12+ hours continuous uptime** without disconnects
- Survived multiple OpenClaw gateway restarts (auto-reconnect worked)
- Survived Edge Sleeping Tabs (keepalive prevented worker termination)
- Cron jobs successfully connected to the relay without manual intervention
- Badge correctly shows ⏳ during reconnect, ✅ on recovery

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes the Browser Relay extension resilient to WebSocket disconnects, MV3 service worker termination, and tab lifecycle events by adding five fixes: keeping debugger sessions alive across WS drops, auto-reconnect with exponential backoff, session storage persistence, tab lifecycle cleanup, and a keepalive alarm.

- **Fix #1 (Don't detach on WS drop)**: `onRelayClosed` no longer tears down debugger sessions — it updates badges and preserves in-memory state for reconnection.
- **Fix #2 (Auto-reconnect)**: `scheduleReconnect` uses exponential backoff (1s–30s cap) with jitter. On success, it re-validates and re-announces all tabs with thorough per-tab error handling.
- **Fix #3 (Session storage persistence)**: State is persisted to `chrome.storage.session` after attach/detach and restored on service worker startup, including debugger re-attach if needed.
- **Fix #4 (Tab lifecycle cleanup)**: `onRemoved` and `onReplaced` listeners clean up stale entries.
- **Fix #5 (Keepalive alarm)**: 4-minute `chrome.alarms` interval pings debuggers and triggers state restore if a debugger is lost.
- **Issue**: The `restoreState` re-announce loop (lines 313–330) lacks per-tab error handling — a single tab failure aborts re-announcement for all remaining tabs, unlike the analogous loop in `scheduleReconnect`.
- **Note**: `childSessionToTab` is not persisted, so child sessions (iframes, service workers) will be lost across service worker restarts. New child session events will re-populate the map, but the relay server may hold stale references in the interim.

<h3>Confidence Score: 3/5</h3>

- This PR introduces significant resilience improvements but has several race conditions and error-handling gaps that could cause unexpected behavior under concurrent failure scenarios.
- The core logic is well-structured and addresses real failure modes effectively. However, the re-announce loop in restoreState lacks per-tab error handling (new finding), and previous review threads identified race conditions in onRelayClosed (socket identity), reconnect guard disarming, and keepalive-triggered restoreState clobbering — all of which remain unresolved. The manifest change is minimal and correct.
- `assets/chrome-extension/background.js` — the `restoreState` function (lines 310–334) and the race conditions noted in previous review threads

<sub>Last reviewed commit: 7ab237e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->