### PR TITLE
iOS: fix Fatal error: No Observable object of type NodeAppModel in Settings sheet

### DIFF
--- a/apps/ios/Sources/RootCanvas.swift
+++ b/apps/ios/Sources/RootCanvas.swift
@@ -78,6 +78,8 @@ struct RootCanvas: View {
                     userAccent: self.appModel.seamColor)
             case .quickSetup:
                 GatewayQuickSetupSheet()
+                    .environment(self.appModel)
+                    .environment(self.gatewayController)
             }
         }
         .fullScreenCover(isPresented: self.$showOnboarding) {

--- a/apps/ios/Sources/RootCanvas.swift
+++ b/apps/ios/Sources/RootCanvas.swift
@@ -65,6 +65,9 @@ struct RootCanvas: View {
             switch sheet {
             case .settings:
                 SettingsTab()
+                    .environment(self.appModel)
+                    .environment(self.appModel.voiceWake)
+                    .environment(self.gatewayController)
             case .chat:
                 ChatSheet(
                     // Mobile chat UI should use the node role RPC surface (chat.* / sessions.*)


### PR DESCRIPTION
## What & Why

- Problem: Opening the iOS Settings sheet could crash at runtime with `Fatal error: No Observable object of type NodeAppModel found`.
- Fixed by explicitly injecting `NodeAppModel`, `VoiceWakeManager`, and `GatewayConnectionController` environment objects into `SettingsTab` within the `.sheet()` closure.

Error message / Prompt:

Fix 
```
SwiftUICore/Environment+Objects.swift:34: Fatal error: No Observable object of type NodeAppModel found. A View.environmentObject(_:) for NodeAppModel may be missing as an ancestor of this view.
```

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

N/A

## User-visible / Behavior Changes

- Tapping the Settings icon no longer crashes the iOS app in the affected branch.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev machine), iOS app target
- Runtime/container: Xcode local run
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Build and run iOS app from branch `ios-new-alpha-core`.
2. Tap the Settings (gear) icon.
3. Observe behavior before and after this patch.

### Expected

- Settings sheet opens without runtime crash.

### Actual

- Before fix: crash with `SwiftUICore/Environment+Objects.swift:34` missing `NodeAppModel`.
- After fix: Settings sheet opens successfully.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- tested locally

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

N/A

## Risks and Mitigations

None

## Notes

- AI-assisted, tested locally

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a crash when opening the iOS Settings sheet by explicitly injecting `NodeAppModel`, `VoiceWakeManager`, and `GatewayConnectionController` environment objects into `SettingsTab` within the `.sheet()` closure. SwiftUI sheets don't automatically propagate `@Observable` environment objects from the parent view, so these must be passed explicitly — consistent with the existing pattern used for `OnboardingWizardView` in `.fullScreenCover()`.

- The fix for `SettingsTab` is correct and matches existing conventions in this file
- `GatewayQuickSetupSheet` (line 80) has the **same class of bug** — it declares `@Environment(NodeAppModel.self)` and `@Environment(GatewayConnectionController.self)` but receives no `.environment()` modifiers when presented in the same `.sheet()` closure, making it susceptible to the identical crash

<h3>Confidence Score: 3/5</h3>

- The SettingsTab fix is correct, but GatewayQuickSetupSheet has the same unfixed crash bug
- The PR correctly addresses the reported crash for SettingsTab and the pattern matches existing code (OnboardingWizardView). However, GatewayQuickSetupSheet in the same .sheet() closure has the identical missing-environment problem and will crash when presented. This should be fixed in the same PR.
- `apps/ios/Sources/RootCanvas.swift` — `GatewayQuickSetupSheet()` on line 80 needs `.environment()` modifiers to avoid the same crash

<sub>Last reviewed commit: 5d41250</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->