### PR TITLE
security: fail closed when LINE webhook secret is missing

### DIFF
--- a/src/line/webhook.test.ts
+++ b/src/line/webhook.test.ts
@@ -1,6 +1,6 @@
 import crypto from "node:crypto";
 import { describe, expect, it, vi } from "vitest";
-import { createLineWebhookMiddleware } from "./webhook.js";
+import { createLineWebhookMiddleware, startLineWebhook } from "./webhook.js";
 
 const sign = (body: string, secret: string) =>
   crypto.createHmac("SHA256", secret).update(body).digest("base64");
@@ -18,6 +18,15 @@ const createRes = () => {
 };
 
 describe("createLineWebhookMiddleware", () => {
+  it("rejects startup when channel secret is missing", () => {
+    expect(() =>
+      startLineWebhook({
+        channelSecret: "   ",
+        onEvents: async () => {},
+      }),
+    ).toThrow(/requires a non-empty channel secret/i);
+  });
+
   it("parses JSON from raw string body", async () => {
     const onEvents = vi.fn(async () => {});
     const secret = "secret";

--- a/src/line/webhook.ts
+++ b/src/line/webhook.ts
@@ -101,9 +101,17 @@ export function startLineWebhook(options: StartLineWebhookOptions): {
   path: string;
   handler: (req: Request, res: Response, _next: NextFunction) => Promise<void>;
 } {
+  const channelSecret =
+    typeof options.channelSecret === "string" ? options.channelSecret.trim() : "";
+  if (!channelSecret) {
+    throw new Error(
+      "LINE webhook mode requires a non-empty channel secret. " +
+        "Set channels.line.channelSecret in your config.",
+    );
+  }
   const path = options.path ?? "/line/webhook";
   const middleware = createLineWebhookMiddleware({
-    channelSecret: options.channelSecret,
+    channelSecret,
     onEvents: options.onEvents,
     runtime: options.runtime,
   });


### PR DESCRIPTION
## Problem
LINE webhook startup currently accepts blank `channelSecret` values, which leaves auth validation behavior ambiguous and potentially fail-open.

## What changed
- Added a fail-closed guard in `startLineWebhook` that rejects empty/whitespace channel secrets.
- Reused the trimmed secret in middleware wiring to avoid inconsistent behavior.
- Added regression test coverage for startup failure when secret is missing.

## Validation
- `pnpm vitest src/line/webhook.test.ts`

Refs #17587

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Prevented authentication bypass by failing closed when LINE `channelSecret` is missing or whitespace-only. The guard in `startLineWebhook` now trims and validates the secret at startup, matching the fail-closed pattern already used in `startTelegramWebhook` (src/telegram/webhook.ts:42-48). Test coverage added to verify the startup failure behavior.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The security fix follows established patterns in the codebase (telegram webhook), has comprehensive test coverage including the new fail-closed behavior, and addresses a critical authentication vulnerability. The change is minimal, well-scoped, and doesn't introduce any new risks.
- No files require special attention

<sub>Last reviewed commit: 97d9f5b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->