### PR TITLE
Add xtremeclaw-agentops skill

### DIFF
--- a/skills/xtremeclaw-agentops/SKILL.md
+++ b/skills/xtremeclaw-agentops/SKILL.md
@@ -5,7 +5,19 @@ description: Run XtremeClaw AgentOps to scout fresh AI/Meme token candidates on 
 
 # XtremeClaw AgentOps
 
-Run the toolkit from the repository root.
+This skill targets the repository: `https://github.com/XtremeClaw/xtremeclaw-agentops`.
+
+Use this skill only when that repo is available locally.
+
+- If missing, clone it first:
+
+```bash
+git clone https://github.com/XtremeClaw/xtremeclaw-agentops.git
+cd xtremeclaw-agentops
+npm install
+```
+
+- “Repository root” means the folder containing `package.json` and `src/index.mjs` for `xtremeclaw-agentops`.
 
 ## Core commands
 

--- a/skills/xtremeclaw-agentops/SKILL.md
+++ b/skills/xtremeclaw-agentops/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: xtremeclaw-agentops
+description: Run XtremeClaw AgentOps to scout fresh AI/Meme token candidates on DexScreener with quality filters, risk scoring, confidence tiers, snapshots, backtests, and optional webhook alerts. Use when a user asks for early AI/Meme token discovery, safer watchlist generation, momentum/risk ranking, or periodic scan reporting.
+---
+
+# XtremeClaw AgentOps
+
+Run the toolkit from the repository root.
+
+## Core commands
+
+```bash
+npm run doctor
+npm run scan
+npm run report
+npm run snapshot
+npm run backtest
+npm run alert
+```
+
+## Practical scan modes
+
+- Strict (safer candidates):
+
+```bash
+node src/index.mjs scan --mode strict --chains base,solana --max-picks 10
+```
+
+- Balanced (more candidates):
+
+```bash
+node src/index.mjs scan --mode balanced --chains base,solana --max-picks 15
+```
+
+- Early (aggressive):
+
+```bash
+node src/index.mjs scan --mode early --min-liq 3000 --min-vol1h 250 --min-score 35
+```
+
+## Output fields to prioritize
+
+- `score` (momentum + activity + liquidity + freshness)
+- `riskScore`, `riskReasons`, `safety`
+- `confidence`, `composite`, `positionSize`
+
+Treat picks as decision support. Always do manual contract checks before trading.


### PR DESCRIPTION
## What changed
- Added new skill: `skills/xtremeclaw-agentops/SKILL.md`
- Introduced usage guidance for running XtremeClaw AgentOps:
- AI/Meme token scouting from DexScreener
- quality/risk filtering
- confidence-based ranking
- snapshot/backtest workflow
- optional webhook alerting

## What did NOT change (scope boundary)
- No changes to core OpenClaw runtime
- No changes to existing skills
- No dependency or config changes

## Change Type
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs

## Why
This adds a reusable skill for users/operators who need structured AI/Meme token discovery workflows with practical risk-aware filtering.

## Notes
The skill is intentionally lightweight and focused on operational usage patterns.


This PR only adds one new skill file and is backward-compatible.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a new skill for XtremeClaw AgentOps, a toolkit for scouting AI/Meme tokens on DexScreener with risk filtering and alerting capabilities.

**Key Issues:**
- Missing critical installation/setup instructions - the skill references running commands but doesn't explain where to get the toolkit or how to install it
- Lacks metadata field with installation instructions and requirements (compare with `skills/1password/SKILL.md` or `skills/github/SKILL.md`)
- "Run the toolkit from the repository root" is ambiguous - which repository?
- No homepage/documentation link for users to learn about the toolkit

The skill is well-structured in terms of command examples and output fields, but users won't be able to use it without knowing where to get the XtremeClaw AgentOps toolkit.

<h3>Confidence Score: 3/5</h3>

- Safe to merge with documentation improvements recommended
- The PR adds a single new skill file with no code changes, making it low-risk. However, the skill lacks essential installation and setup documentation, making it incomplete and not immediately usable by others. The commands and structure are well-formatted, but the missing context about what the toolkit is and where to get it significantly reduces its utility.
- skills/xtremeclaw-agentops/SKILL.md requires additional documentation for installation and setup

<sub>Last reviewed commit: f168254</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->