### PR TITLE
fix(context): use getAvailable() to prevent cross-provider model ID collision in MODEL_CACHE

### DIFF
--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -55,7 +55,7 @@ const loadPromise = (async () => {
     const agentDir = resolveOpenClawAgentDir();
     const authStorage = discoverAuthStorage(agentDir);
     const modelRegistry = discoverModels(authStorage, agentDir);
-    const models = modelRegistry.getAll() as ModelEntry[];
+    const models = modelRegistry.getAvailable() as ModelEntry[];
     for (const m of models) {
       if (!m?.id) {
         continue;


### PR DESCRIPTION
## Summary

`lookupContextTokens()` in `src/agents/context.ts` uses `modelRegistry.getAll()` which returns models from **all** built-in providers — including unconfigured ones. When multiple providers define the same model ID (e.g. `claude-sonnet-4-5`) with different `contextWindow` values, the last provider iterated overwrites the correct value in `MODEL_CACHE`.

## Fix

Switch from `getAll()` to `getAvailable()`, which filters to only providers with configured authentication. This prevents unconfigured providers from polluting the cache with incorrect context window values.

## Impact

- `/status` now shows correct context window
- Token budget calculations use accurate context size
- Session `contextTokens` field persisted correctly

## Testing

- Existing `context.test.ts` passes (2/2 tests)
- Build passes cleanly

Fixes #17586

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a cross-provider model ID collision in `MODEL_CACHE` by switching from `modelRegistry.getAll()` to `modelRegistry.getAvailable()` in `src/agents/context.ts`. When multiple providers define the same model ID (e.g. `claude-sonnet-4-5`) with different `contextWindow` values, `getAll()` would let unconfigured providers overwrite the correct value. Using `getAvailable()` filters to only providers with configured authentication, ensuring accurate context window values.

- Minimal one-line change that aligns with how `list.registry.ts` already distinguishes between "all models" (for display) and "available models" (for functional use)
- Both `getAll()` and `getAvailable()` return `Model<Api>[]`, so the existing type cast and downstream iteration logic remain correct
- Existing `context.test.ts` tests cover `applyConfiguredContextWindows` (which runs after the cache is populated) but not the cache population itself — this is acceptable since the fix is a straightforward API swap with the same return type

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, well-targeted one-line fix that uses the correct API for filtering to configured providers.
- The change is a single method call swap from getAll() to getAvailable(), both of which return the same type. The fix directly addresses the documented bug (cross-provider model ID collision) and is consistent with how the rest of the codebase uses getAvailable() for functional/operational purposes. No new code paths, no behavioral changes for correctly-configured providers, and the surrounding error handling remains intact.
- No files require special attention.

<sub>Last reviewed commit: d2eed6e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->