### PR TITLE
Automated issue dedupe with Codex Action

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,5 @@
+[sandbox_workspace_write]
+network_access = true
+
+[shell_environment_policy]
+inherit = "all"

--- a/.github/workflows/auto-close-duplicates.yml
+++ b/.github/workflows/auto-close-duplicates.yml
@@ -1,0 +1,22 @@
+name: Auto Close Duplicates
+
+on:
+  schedule:
+    - cron: "0 9 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  auto-close:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - run: bun run scripts/auto-close-duplicates.ts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/codex-dedupe-issues.yml
+++ b/.github/workflows/codex-dedupe-issues.yml
@@ -1,0 +1,57 @@
+name: Codex Dedupe Issues
+
+on:
+  issues:
+    types: [opened]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Issue number to check for duplicates"
+        required: true
+        type: number
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  dedupe:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Determine issue number
+        id: issue
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "number=${{ inputs.issue_number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: openai/codex-action@v1
+        with:
+          prompt: |
+            Find up to 3 likely duplicate issues for GitHub issue openclaw/openclaw#${{ steps.issue.outputs.number }}.
+
+            1. Use `gh issue view ${{ steps.issue.outputs.number }} --repo openclaw/openclaw` to read the issue.
+               If it is closed, already has a "possible duplicate" comment, or is broad
+               feedback without a specific solution — stop.
+            2. Summarize the issue.
+            3. Thoroughly search for duplicates using `gh search issues` and `gh issue view`.
+               Use diverse query strategies. Inspect promising candidates to verify similarity.
+            4. Filter false positives — only keep issues genuinely about the same problem.
+            5. If duplicates remain, run:
+               ./scripts/comment-on-duplicates.sh --base-issue ${{ steps.issue.outputs.number }} --potential-duplicates <dup1> [dup2] [dup3]
+
+            Notes:
+            - Use only `gh` and the comment script. No other tools.
+            - The repo is openclaw/openclaw.
+          sandbox: workspace-write
+          codex-home: .codex
+          allow-users: "*"
+          effort: high
+          model: gpt-5.2-codex
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/auto-close-duplicates.ts
+++ b/scripts/auto-close-duplicates.ts
@@ -200,20 +200,6 @@ async function autoCloseDuplicates(): Promise<void> {
       )} days)`
     );
 
-    const commentsAfterDupe = comments.filter(
-      (comment) => new Date(comment.created_at) > dupeCommentDate
-    );
-    console.log(
-      `[DEBUG] Issue #${issue.number} - ${commentsAfterDupe.length} comments after duplicate detection`
-    );
-
-    if (commentsAfterDupe.length > 0) {
-      console.log(
-        `[DEBUG] Issue #${issue.number} - has activity after duplicate comment, skipping`
-      );
-      continue;
-    }
-
     console.log(
       `[DEBUG] Issue #${issue.number} - checking reactions on duplicate comment...`
     );
@@ -225,17 +211,16 @@ async function autoCloseDuplicates(): Promise<void> {
       `[DEBUG] Issue #${issue.number} - duplicate comment has ${reactions.length} reactions`
     );
 
-    const authorThumbsDown = reactions.some(
-      (reaction) =>
-        reaction.user.id === issue.user.id && reaction.content === "-1"
+    const hasThumbsDown = reactions.some(
+      (reaction) => reaction.content === "-1"
     );
     console.log(
-      `[DEBUG] Issue #${issue.number} - author thumbs down reaction: ${authorThumbsDown}`
+      `[DEBUG] Issue #${issue.number} - thumbs down reaction: ${hasThumbsDown}`
     );
 
-    if (authorThumbsDown) {
+    if (hasThumbsDown) {
       console.log(
-        `[DEBUG] Issue #${issue.number} - author disagreed with duplicate detection, skipping`
+        `[DEBUG] Issue #${issue.number} - someone disagreed with duplicate detection, skipping`
       );
       continue;
     }

--- a/scripts/auto-close-duplicates.ts
+++ b/scripts/auto-close-duplicates.ts
@@ -29,7 +29,7 @@ async function githubRequest<T>(
   endpoint: string,
   token: string,
   method: string = "GET",
-  body?: any,
+  body?: Record<string, unknown>,
 ): Promise<T> {
   const response = await fetch(`https://api.github.com${endpoint}`, {
     method,
@@ -57,7 +57,7 @@ function extractDuplicateIssueNumber(commentBody: string): number | null {
   }
 
   // Try to match GitHub issue URL format: https://github.com/owner/repo/issues/123
-  match = commentBody.match(/github\.com\/[^\/]+\/[^\/]+\/issues\/(\d+)/);
+  match = commentBody.match(/github\.com\/[^/]+\/[^/]+\/issues\/(\d+)/);
   if (match) {
     return parseInt(match[1], 10);
   }
@@ -115,7 +115,9 @@ async function autoCloseDuplicates(): Promise<void> {
       token,
     );
 
-    if (pageIssues.length === 0) break;
+    if (pageIssues.length === 0) {
+      break;
+    }
 
     // Filter for issues created more than 3 days ago
     const oldEnoughIssues = pageIssues.filter(
@@ -126,7 +128,9 @@ async function autoCloseDuplicates(): Promise<void> {
     page++;
 
     // Safety limit to avoid infinite loops
-    if (page > 20) break;
+    if (page > 20) {
+      break;
+    }
   }
 
   const issues = allIssues;
@@ -219,8 +223,10 @@ async function autoCloseDuplicates(): Promise<void> {
       console.log(
         `[SUCCESS] Successfully closed issue #${issue.number} as duplicate of #${duplicateIssueNumber}`,
       );
-    } catch (error) {
-      console.error(`[ERROR] Failed to close issue #${issue.number} as duplicate: ${error}`);
+    } catch (error: unknown) {
+      console.error(
+        `[ERROR] Failed to close issue #${issue.number} as duplicate: ${String(error)}`,
+      );
     }
   }
 
@@ -230,6 +236,3 @@ async function autoCloseDuplicates(): Promise<void> {
 }
 
 autoCloseDuplicates().catch(console.error);
-
-// Make it a module
-export {};

--- a/scripts/auto-close-duplicates.ts
+++ b/scripts/auto-close-duplicates.ts
@@ -1,0 +1,277 @@
+#!/usr/bin/env bun
+
+declare global {
+  var process: {
+    env: Record<string, string | undefined>;
+  };
+}
+
+interface GitHubIssue {
+  number: number;
+  title: string;
+  user: { id: number };
+  created_at: string;
+}
+
+interface GitHubComment {
+  id: number;
+  body: string;
+  created_at: string;
+  user: { type: string; id: number };
+}
+
+interface GitHubReaction {
+  user: { id: number };
+  content: string;
+}
+
+async function githubRequest<T>(endpoint: string, token: string, method: string = 'GET', body?: any): Promise<T> {
+  const response = await fetch(`https://api.github.com${endpoint}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github.v3+json",
+      "User-Agent": "auto-close-duplicates-script",
+      ...(body && { "Content-Type": "application/json" }),
+    },
+    ...(body && { body: JSON.stringify(body) }),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `GitHub API request failed: ${response.status} ${response.statusText}`
+    );
+  }
+
+  return response.json();
+}
+
+function extractDuplicateIssueNumber(commentBody: string): number | null {
+  // Try to match #123 format first
+  let match = commentBody.match(/#(\d+)/);
+  if (match) {
+    return parseInt(match[1], 10);
+  }
+
+  // Try to match GitHub issue URL format: https://github.com/owner/repo/issues/123
+  match = commentBody.match(/github\.com\/[^\/]+\/[^\/]+\/issues\/(\d+)/);
+  if (match) {
+    return parseInt(match[1], 10);
+  }
+
+  return null;
+}
+
+
+async function closeIssueAsDuplicate(
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  duplicateOfNumber: number,
+  token: string
+): Promise<void> {
+  await githubRequest(
+    `/repos/${owner}/${repo}/issues/${issueNumber}`,
+    token,
+    'PATCH',
+    {
+      state: 'closed',
+      state_reason: 'duplicate',
+      labels: ['duplicate']
+    }
+  );
+
+  await githubRequest(
+    `/repos/${owner}/${repo}/issues/${issueNumber}/comments`,
+    token,
+    'POST',
+    {
+      body: `This issue has been automatically closed as a duplicate of #${duplicateOfNumber}.
+
+If this is incorrect, please re-open this issue or create a new one.
+
+🤖 Generated with [Codex](https://openai.com/codex)`
+    }
+  );
+
+}
+
+async function autoCloseDuplicates(): Promise<void> {
+  console.log("[DEBUG] Starting auto-close duplicates script");
+
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) {
+    throw new Error("GITHUB_TOKEN environment variable is required");
+  }
+  console.log("[DEBUG] GitHub token found");
+
+  const owner = process.env.GITHUB_REPOSITORY_OWNER || "openclaw";
+  const repo = process.env.GITHUB_REPOSITORY_NAME || "openclaw";
+  console.log(`[DEBUG] Repository: ${owner}/${repo}`);
+
+  const threeDaysAgo = new Date();
+  threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);
+  console.log(
+    `[DEBUG] Checking for duplicate comments older than: ${threeDaysAgo.toISOString()}`
+  );
+
+  console.log("[DEBUG] Fetching open issues created more than 3 days ago...");
+  const allIssues: GitHubIssue[] = [];
+  let page = 1;
+  const perPage = 100;
+
+  while (true) {
+    const pageIssues: GitHubIssue[] = await githubRequest(
+      `/repos/${owner}/${repo}/issues?state=open&per_page=${perPage}&page=${page}`,
+      token
+    );
+
+    if (pageIssues.length === 0) break;
+
+    // Filter for issues created more than 3 days ago
+    const oldEnoughIssues = pageIssues.filter(issue =>
+      new Date(issue.created_at) <= threeDaysAgo
+    );
+
+    allIssues.push(...oldEnoughIssues);
+    page++;
+
+    // Safety limit to avoid infinite loops
+    if (page > 20) break;
+  }
+
+  const issues = allIssues;
+  console.log(`[DEBUG] Found ${issues.length} open issues`);
+
+  let processedCount = 0;
+  let candidateCount = 0;
+
+  for (const issue of issues) {
+    processedCount++;
+    console.log(
+      `[DEBUG] Processing issue #${issue.number} (${processedCount}/${issues.length}): ${issue.title}`
+    );
+
+    console.log(`[DEBUG] Fetching comments for issue #${issue.number}...`);
+    const comments: GitHubComment[] = await githubRequest(
+      `/repos/${owner}/${repo}/issues/${issue.number}/comments`,
+      token
+    );
+    console.log(
+      `[DEBUG] Issue #${issue.number} has ${comments.length} comments`
+    );
+
+    const dupeComments = comments.filter(
+      (comment) =>
+        comment.body.includes("Found") &&
+        comment.body.includes("possible duplicate") &&
+        comment.user.type === "Bot"
+    );
+    console.log(
+      `[DEBUG] Issue #${issue.number} has ${dupeComments.length} duplicate detection comments`
+    );
+
+    if (dupeComments.length === 0) {
+      console.log(
+        `[DEBUG] Issue #${issue.number} - no duplicate comments found, skipping`
+      );
+      continue;
+    }
+
+    const lastDupeComment = dupeComments[dupeComments.length - 1];
+    const dupeCommentDate = new Date(lastDupeComment.created_at);
+    console.log(
+      `[DEBUG] Issue #${
+        issue.number
+      } - most recent duplicate comment from: ${dupeCommentDate.toISOString()}`
+    );
+
+    if (dupeCommentDate > threeDaysAgo) {
+      console.log(
+        `[DEBUG] Issue #${issue.number} - duplicate comment is too recent, skipping`
+      );
+      continue;
+    }
+    console.log(
+      `[DEBUG] Issue #${
+        issue.number
+      } - duplicate comment is old enough (${Math.floor(
+        (Date.now() - dupeCommentDate.getTime()) / (1000 * 60 * 60 * 24)
+      )} days)`
+    );
+
+    const commentsAfterDupe = comments.filter(
+      (comment) => new Date(comment.created_at) > dupeCommentDate
+    );
+    console.log(
+      `[DEBUG] Issue #${issue.number} - ${commentsAfterDupe.length} comments after duplicate detection`
+    );
+
+    if (commentsAfterDupe.length > 0) {
+      console.log(
+        `[DEBUG] Issue #${issue.number} - has activity after duplicate comment, skipping`
+      );
+      continue;
+    }
+
+    console.log(
+      `[DEBUG] Issue #${issue.number} - checking reactions on duplicate comment...`
+    );
+    const reactions: GitHubReaction[] = await githubRequest(
+      `/repos/${owner}/${repo}/issues/comments/${lastDupeComment.id}/reactions`,
+      token
+    );
+    console.log(
+      `[DEBUG] Issue #${issue.number} - duplicate comment has ${reactions.length} reactions`
+    );
+
+    const authorThumbsDown = reactions.some(
+      (reaction) =>
+        reaction.user.id === issue.user.id && reaction.content === "-1"
+    );
+    console.log(
+      `[DEBUG] Issue #${issue.number} - author thumbs down reaction: ${authorThumbsDown}`
+    );
+
+    if (authorThumbsDown) {
+      console.log(
+        `[DEBUG] Issue #${issue.number} - author disagreed with duplicate detection, skipping`
+      );
+      continue;
+    }
+
+    const duplicateIssueNumber = extractDuplicateIssueNumber(lastDupeComment.body);
+    if (!duplicateIssueNumber) {
+      console.log(
+        `[DEBUG] Issue #${issue.number} - could not extract duplicate issue number from comment, skipping`
+      );
+      continue;
+    }
+
+    candidateCount++;
+    const issueUrl = `https://github.com/${owner}/${repo}/issues/${issue.number}`;
+
+    try {
+      console.log(
+        `[INFO] Auto-closing issue #${issue.number} as duplicate of #${duplicateIssueNumber}: ${issueUrl}`
+      );
+      await closeIssueAsDuplicate(owner, repo, issue.number, duplicateIssueNumber, token);
+      console.log(
+        `[SUCCESS] Successfully closed issue #${issue.number} as duplicate of #${duplicateIssueNumber}`
+      );
+    } catch (error) {
+      console.error(
+        `[ERROR] Failed to close issue #${issue.number} as duplicate: ${error}`
+      );
+    }
+  }
+
+  console.log(
+    `[DEBUG] Script completed. Processed ${processedCount} issues, found ${candidateCount} candidates for auto-close`
+  );
+}
+
+autoCloseDuplicates().catch(console.error);
+
+// Make it a module
+export {};

--- a/scripts/comment-on-duplicates.sh
+++ b/scripts/comment-on-duplicates.sh
@@ -91,7 +91,7 @@ done
 
 BODY+=$'\n'"This issue will be automatically closed as a duplicate in 3 days."$'\n\n'
 BODY+="- If your issue is a duplicate, please close it and 👍 the existing issue instead"$'\n'
-BODY+="- To prevent auto-closure, add a comment or 👎 this comment"$'\n\n'
+BODY+="- To prevent auto-closure, 👎 this comment"$'\n\n'
 BODY+="🤖 Generated with [Codex](https://openai.com/codex)"
 
 # Post the comment

--- a/scripts/comment-on-duplicates.sh
+++ b/scripts/comment-on-duplicates.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# Comments on a GitHub issue with a list of potential duplicates.
+# Usage: ./comment-on-duplicates.sh --base-issue 123 --potential-duplicates 456 789 101
+#
+
+set -euo pipefail
+
+REPO="openclaw/openclaw"
+BASE_ISSUE=""
+DUPLICATES=()
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --base-issue)
+      BASE_ISSUE="$2"
+      shift 2
+      ;;
+    --potential-duplicates)
+      shift
+      while [[ $# -gt 0 && ! "$1" =~ ^-- ]]; do
+        DUPLICATES+=("$1")
+        shift
+      done
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Validate base issue
+if [[ -z "$BASE_ISSUE" ]]; then
+  echo "Error: --base-issue is required" >&2
+  exit 1
+fi
+
+if ! [[ "$BASE_ISSUE" =~ ^[0-9]+$ ]]; then
+  echo "Error: --base-issue must be a number, got: $BASE_ISSUE" >&2
+  exit 1
+fi
+
+# Validate duplicates
+if [[ ${#DUPLICATES[@]} -eq 0 ]]; then
+  echo "Error: --potential-duplicates requires at least one issue number" >&2
+  exit 1
+fi
+
+if [[ ${#DUPLICATES[@]} -gt 3 ]]; then
+  echo "Error: --potential-duplicates accepts at most 3 issues" >&2
+  exit 1
+fi
+
+for dup in "${DUPLICATES[@]}"; do
+  if ! [[ "$dup" =~ ^[0-9]+$ ]]; then
+    echo "Error: duplicate issue must be a number, got: $dup" >&2
+    exit 1
+  fi
+done
+
+# Validate that base issue exists
+if ! gh issue view "$BASE_ISSUE" --repo "$REPO" &>/dev/null; then
+  echo "Error: issue #$BASE_ISSUE does not exist in $REPO" >&2
+  exit 1
+fi
+
+# Validate that all duplicate issues exist
+for dup in "${DUPLICATES[@]}"; do
+  if ! gh issue view "$dup" --repo "$REPO" &>/dev/null; then
+    echo "Error: issue #$dup does not exist in $REPO" >&2
+    exit 1
+  fi
+done
+
+# Build comment body
+COUNT=${#DUPLICATES[@]}
+if [[ $COUNT -eq 1 ]]; then
+  HEADER="Found 1 possible duplicate issue:"
+else
+  HEADER="Found $COUNT possible duplicate issues:"
+fi
+
+BODY="$HEADER"$'\n\n'
+INDEX=1
+for dup in "${DUPLICATES[@]}"; do
+  BODY+="$INDEX. https://github.com/$REPO/issues/$dup"$'\n'
+  ((INDEX++))
+done
+
+BODY+=$'\n'"This issue will be automatically closed as a duplicate in 3 days."$'\n\n'
+BODY+="- If your issue is a duplicate, please close it and 👍 the existing issue instead"$'\n'
+BODY+="- To prevent auto-closure, add a comment or 👎 this comment"$'\n\n'
+BODY+="🤖 Generated with [Codex](https://openai.com/codex)"
+
+# Post the comment
+gh issue comment "$BASE_ISSUE" --repo "$REPO" --body "$BODY"
+
+echo "Posted duplicate comment on issue #$BASE_ISSUE"


### PR DESCRIPTION
## What this does

Every time a new issue is opened, an AI agent searches for duplicates and posts a comment like:

> Found 2 possible duplicate issues:
> 1. https://github.com/openclaw/openclaw/issues/42
> 2. https://github.com/openclaw/openclaw/issues/87
>
> This issue will be automatically closed as a duplicate in 3 days.
> - To prevent auto-closure, 👎 this comment

After 3 days, if nobody thumbs-down reacts, a daily cron job closes it. No human intervention needed for the happy path.

## Why

The repo has a growing issue backlog with many duplicates. Manual triage doesn't scale. This automates the boring part — finding and closing duplicates — while keeping humans in the loop via the 👎 escape hatch.

## Where this pattern comes from

Direct adaptation of [`anthropics/claude-code`](https://github.com/anthropics/claude-code)'s production dedupe system, running on a repo with 5k+ issues. Their implementation:
- [`scripts/comment-on-duplicates.sh`](https://github.com/anthropics/claude-code/blob/main/scripts/comment-on-duplicates.sh) — posts the marker comment
- [`scripts/auto-close-duplicates.ts`](https://github.com/anthropics/claude-code/blob/main/scripts/auto-close-duplicates.ts) — daily cron closer
- [`.claude/commands/dedupe.md`](https://github.com/anthropics/claude-code/blob/main/.claude/commands/dedupe.md) — the AI prompt

We swap Claude for [Codex Action](https://github.com/openai/codex-action) (`openai/codex-action@v1`) since the project has OpenAI credits.

## Files added (5)

| File | What it does |
|------|-------------|
| `scripts/comment-on-duplicates.sh` | Posts the "possible duplicate" comment with 3-day grace period. Called by the AI agent via `gh`. |
| `scripts/auto-close-duplicates.ts` | Daily cron script. Scans open issues for uncontested duplicate comments older than 3 days → closes them. Uses Bun (already in CI via `oven-sh/setup-bun@v2`). |
| `.codex/config.toml` | Sandbox config so Codex can run `gh` (needs network access + env var passthrough). |
| `.github/workflows/codex-dedupe-issues.yml` | Triggers on `issues: [opened]` + `workflow_dispatch` for manual backfill. Runs Codex with an inline prompt to search for duplicates using `gh`. |
| `.github/workflows/auto-close-duplicates.yml` | Daily cron at 09:00 UTC. Runs the TypeScript closer. |

## How auto-close decides

The closer will only close an issue if ALL of these are true:
1. A bot comment containing "Found" + "possible duplicate" exists
2. That comment is older than 3 days
3. Nobody has 👎 reacted to the duplicate comment

Comments don't block closure — only a thumbs-down does. Reviewers can comment on flagged issues without accidentally preventing auto-close.

## Setup required (one secret)

After merging, add this repo secret:

- **`OPENAI_API_KEY`** — for Codex Action to call the model

`GITHUB_TOKEN` is provided automatically by Actions.

## Testing it

1. Merge this PR
2. Add the `OPENAI_API_KEY` secret
3. Go to Actions → "Codex Dedupe Issues" → "Run workflow"
4. Enter an issue number you know has duplicates
5. Watch it post a duplicate comment

The daily closer will pick up uncontested duplicates automatically after 3 days.

---

### CONTRIBUTING.md checklist

- **Local validation:** `pnpm build/check/test` not applicable — this PR adds CI workflows and standalone scripts, no application code changes. Shell script validated with `bash -n`. Real validation is `workflow_dispatch` after merge.
- **Focused scope:** Single feature — automated issue deduplication.
- **Clear what + why:** Above.
- **AI-assisted:** Yes. Research, planning, and implementation done with Claude Code (Opus). Scripts adapted from anthropics/claude-code's production system with repo-specific changes (branding, defaults, auto-close logic). All code reviewed and understood by the contributor.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds automated issue deduplication using OpenAI's Codex Action: a workflow triggers on new issues to search for duplicates and post a warning comment, and a daily cron job auto-closes uncontested duplicates after 3 days. The shell script (`comment-on-duplicates.sh`) is well-structured with proper validation. However, the TypeScript auto-close script has bugs that need fixing before merge:

- **Label replacement bug**: The `closeIssueAsDuplicate` function uses `labels: ["duplicate"]` in a PATCH request, which will **replace all existing labels** on the issue instead of appending. This could silently strip important labels like `bug`, `security`, or `high-priority`.
- **Invalid `state_reason`**: `state_reason: "duplicate"` is not a valid GitHub API value — only `"completed"`, `"not_planned"`, and `"reopened"` are accepted.
- **Non-existent env var**: `GITHUB_REPOSITORY_NAME` is not a GitHub Actions environment variable. The fallback to `"openclaw"` masks this bug for now.
- **Codex sandbox config**: `inherit = "all"` in `.codex/config.toml` passes all environment variables (including secrets) into the sandbox — should be scoped to specific variables.

<h3>Confidence Score: 2/5</h3>

- The auto-close script has bugs that will silently strip labels from closed issues and use an invalid API field — recommend fixing before merge.
- Score of 2 reflects two confirmed API misuse bugs in the auto-close script: (1) label replacement that will destroy existing labels on every issue it closes, and (2) an invalid state_reason value. The GITHUB_REPOSITORY_NAME bug is latent (masked by the fallback). The shell script and workflows are well-structured.
- `scripts/auto-close-duplicates.ts` has the critical bugs — the label replacement and invalid state_reason. `.codex/config.toml` has an overly permissive environment variable policy.

<sub>Last reviewed commit: 96bd492</sub>

<!-- greptile_other_comments_section -->

<sub>(1/5) You can manually trigger the agent by mentioning @greptileai in a comment!</sub>

<!-- /greptile_comment -->