### PR TITLE
fix(gateway): avoid agent crash on malformed injected files

### DIFF
--- a/src/agents/pi-embedded-helpers.buildbootstrapcontextfiles.e2e.test.ts
+++ b/src/agents/pi-embedded-helpers.buildbootstrapcontextfiles.e2e.test.ts
@@ -17,7 +17,7 @@ describe("buildBootstrapContextFiles", () => {
   it("skips malformed bootstrap file entries at runtime", () => {
     let warned = false;
     const result = buildBootstrapContextFiles(
-      [{ name: DEFAULT_AGENTS_FILENAME, missing: false } as any],
+      [{ name: DEFAULT_AGENTS_FILENAME, missing: false } as unknown as WorkspaceBootstrapFile],
       { warn: () => (warned = true) },
     );
     expect(result).toEqual([]);

--- a/src/agents/pi-embedded-helpers.buildbootstrapcontextfiles.e2e.test.ts
+++ b/src/agents/pi-embedded-helpers.buildbootstrapcontextfiles.e2e.test.ts
@@ -14,6 +14,16 @@ const makeFile = (overrides: Partial<WorkspaceBootstrapFile>): WorkspaceBootstra
   ...overrides,
 });
 describe("buildBootstrapContextFiles", () => {
+  it("skips malformed bootstrap file entries at runtime", () => {
+    let warned = false;
+    const result = buildBootstrapContextFiles(
+      [{ name: DEFAULT_AGENTS_FILENAME, missing: false } as any],
+      { warn: () => (warned = true) },
+    );
+    expect(result).toEqual([]);
+    expect(warned).toBe(true);
+  });
+
   it("keeps missing markers", () => {
     const files = [makeFile({ missing: true, content: undefined })];
     expect(buildBootstrapContextFiles(files)).toEqual([

--- a/src/agents/pi-embedded-helpers/bootstrap.ts
+++ b/src/agents/pi-embedded-helpers/bootstrap.ts
@@ -196,6 +196,11 @@ export function buildBootstrapContextFiles(
   let remainingTotalChars = totalMaxChars;
   const result: EmbeddedContextFile[] = [];
   for (const file of files) {
+    // Defensive: internal hooks can mutate bootstrapFiles at runtime; ensure required fields.
+    if (typeof file?.path !== "string" || file.path.trim().length === 0) {
+      opts?.warn?.("workspace bootstrap file missing path; skipping");
+      continue;
+    }
     if (remainingTotalChars <= 0) {
       break;
     }

--- a/src/agents/system-prompt-report.test.ts
+++ b/src/agents/system-prompt-report.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { EmbeddedContextFile } from "./pi-embedded-helpers.js";
 import type { WorkspaceBootstrapFile } from "./workspace.js";
 import { buildSystemPromptReport } from "./system-prompt-report.js";
 
@@ -43,5 +44,21 @@ describe("buildSystemPromptReport", () => {
     });
 
     expect(report.injectedWorkspaceFiles[0]?.injectedChars).toBe("trimmed".length);
+  });
+
+  it("does not crash when injected file records are malformed at runtime", () => {
+    const file = makeBootstrapFile({ path: "/tmp/workspace/policies/AGENTS.md" });
+    const report = buildSystemPromptReport({
+      source: "run",
+      generatedAt: 0,
+      bootstrapMaxChars: 20_000,
+      systemPrompt: "system",
+      bootstrapFiles: [file],
+      injectedFiles: [{ content: "trimmed" } as unknown as EmbeddedContextFile],
+      skillsPrompt: "",
+      tools: [],
+    });
+
+    expect(report.injectedWorkspaceFiles[0]?.injectedChars).toBe(0);
   });
 });

--- a/src/agents/system-prompt-report.test.ts
+++ b/src/agents/system-prompt-report.test.ts
@@ -61,4 +61,23 @@ describe("buildSystemPromptReport", () => {
 
     expect(report.injectedWorkspaceFiles[0]?.injectedChars).toBe(0);
   });
+
+  it("allows empty-string injected file content without falling back to basename matches", () => {
+    const file = makeBootstrapFile({ path: "/tmp/workspace/policies/AGENTS.md" });
+    const report = buildSystemPromptReport({
+      source: "run",
+      generatedAt: 0,
+      bootstrapMaxChars: 20_000,
+      systemPrompt: "system",
+      bootstrapFiles: [file],
+      injectedFiles: [
+        { path: "/tmp/workspace/policies/AGENTS.md", content: "" },
+        { path: "AGENTS.md", content: "fallback" },
+      ],
+      skillsPrompt: "",
+      tools: [],
+    });
+
+    expect(report.injectedWorkspaceFiles[0]?.injectedChars).toBe(0);
+  });
 });

--- a/src/agents/system-prompt-report.ts
+++ b/src/agents/system-prompt-report.ts
@@ -46,10 +46,15 @@ function buildInjectedWorkspaceFiles(params: {
   const injectedByBaseName = new Map<string, string>();
   for (const file of params.injectedFiles) {
     const injectedPath = typeof file?.path === "string" ? file.path : "";
-    const injectedContent = typeof file?.content === "string" ? file.content : "";
-    if (!injectedPath || !injectedContent) {
+    if (!injectedPath) {
       continue;
     }
+    // Allow empty-string content (a legitimate "inject blank file" override), but
+    // skip non-string/malformed records.
+    if (typeof file?.content !== "string") {
+      continue;
+    }
+    const injectedContent = file.content;
     injectedByPath.set(injectedPath, injectedContent);
 
     const normalizedPath = injectedPath.replace(/\\/g, "/");

--- a/src/process/child-process-bridge.test.ts
+++ b/src/process/child-process-bridge.test.ts
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import path from "node:path";
 import process from "node:process";
+import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import { attachChildProcessBridge } from "./child-process-bridge.js";
 
@@ -63,7 +64,8 @@ describe("attachChildProcessBridge", () => {
   });
 
   it("forwards SIGTERM to the wrapped child", async () => {
-    const childPath = path.resolve(process.cwd(), "test/fixtures/child-process-bridge/child.js");
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    const childPath = path.resolve(here, "../../test/fixtures/child-process-bridge/child.js");
 
     const beforeSigterm = new Set(process.listeners("SIGTERM"));
     const child = spawn(process.execPath, [childPath], {

--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -100,8 +100,13 @@ function drainLane(lane: string) {
           const completedCurrentGeneration = completeTask(state, taskId, taskGeneration);
           const isProbeLane = lane.startsWith("auth-probe:") || lane.startsWith("session:probe-");
           if (!isProbeLane) {
+            const errorMeta =
+              err instanceof Error
+                ? { name: err.name, message: err.message, stack: err.stack }
+                : { value: String(err) };
             diag.error(
               `lane task error: lane=${lane} durationMs=${Date.now() - startTime} error="${String(err)}"`,
+              { error: errorMeta },
             );
           }
           if (completedCurrentGeneration) {


### PR DESCRIPTION
## Summary
Fixes a gateway crash during `agent` RPC when injected/bootstrap file records are malformed (missing `path`), which can make the TUI appear hung. The fix defensively skips malformed records, preserves valid empty-string injected content overrides, and improves lane task error diagnostics by including stack traces.

Supersedes `openclaw/openclaw#17617` (rebased onto current `main` to resolve merge conflicts).

## Checklist
- Gateway `agent` RPC must not crash when injected/bootstrap file records are malformed (missing `path`).
- Gateway logs for lane task failures must include stack traces so crashes are actionable.
- Add regression coverage for malformed injected workspace file records.
- Keep behavior stable: malformed records are skipped rather than causing hard failures.

## Must-nots
- Must not leak secrets in logs/tests.
- Must not change normal injected/bootstrap behavior for valid file records.
- Must not introduce new required config / operator steps.

## Evidence
- `pnpm -s check`
- `pnpm -s test src/agents/system-prompt-report.test.ts src/process/command-queue.test.ts`
- `npx -y vitest run --config vitest.e2e.config.ts src/agents/pi-embedded-helpers.buildbootstrapcontextfiles.e2e.test.ts`
- `pnpm -s test src/infra/gateway-lock.test.ts src/process/child-process-bridge.test.ts`
- `pnpm -C ui -s test src/ui/controllers/cron.test.ts`

## Assumptions
- The malformed injected record can originate from internal hooks/plugins mutating bootstrap/injected file arrays at runtime.
- Skipping malformed records is preferable to crashing the gateway (TUI has no embedded fallback, so crash looks like hang).
