### PR TITLE
fix(bluebubbles): skip typing indicators when Private API is disabled

### DIFF
--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -1159,12 +1159,14 @@ export async function processMessage(
       if (!streamingActive) {
         return;
       }
-      sendBlueBubblesTyping(chatGuidForActions, true, {
-        cfg: config,
-        accountId: account.accountId,
-      }).catch((err) => {
-        runtime.error?.(`[bluebubbles] typing restart failed: ${String(err)}`);
-      });
+      if (privateApiEnabled) {
+        sendBlueBubblesTyping(chatGuidForActions, true, {
+          cfg: config,
+          accountId: account.accountId,
+        }).catch((err) => {
+          runtime.error?.(`[bluebubbles] typing restart failed: ${String(err)}`);
+        });
+      }
     }, typingRestartDelayMs);
   };
   try {
@@ -1306,10 +1308,12 @@ export async function processMessage(
           streamingActive = true;
           clearTypingRestartTimer();
           try {
-            await sendBlueBubblesTyping(chatGuidForActions, true, {
-              cfg: config,
-              accountId: account.accountId,
-            });
+            if (privateApiEnabled) {
+              await sendBlueBubblesTyping(chatGuidForActions, true, {
+                cfg: config,
+                accountId: account.accountId,
+              });
+            }
           } catch (err) {
             runtime.error?.(`[bluebubbles] typing start failed: ${String(err)}`);
           }
@@ -1364,7 +1368,7 @@ export async function processMessage(
         },
       });
     }
-    if (shouldStopTyping && chatGuidForActions) {
+    if (shouldStopTyping && chatGuidForActions && privateApiEnabled) {
       // Stop typing after streaming completes to avoid a stuck indicator.
       sendBlueBubblesTyping(chatGuidForActions, false, {
         cfg: config,

--- a/extensions/bluebubbles/src/monitor.test.ts
+++ b/extensions/bluebubbles/src/monitor.test.ts
@@ -43,6 +43,10 @@ vi.mock("./history.js", () => ({
   fetchBlueBubblesHistory: vi.fn().mockResolvedValue({ entries: [], resolved: true }),
 }));
 
+vi.mock("./probe.js", () => ({
+  isBlueBubblesPrivateApiEnabled: vi.fn().mockReturnValue(true),
+}));
+
 // Mock runtime
 const mockEnqueueSystemEvent = vi.fn();
 const mockBuildPairingReply = vi.fn(() => "Pairing code: TESTCODE");


### PR DESCRIPTION
## Problem

When BlueBubbles Private API is unavailable (e.g. macOS Tahoe / macOS 26 with SIP enabled), the three typing indicator call sites in `monitor-processing.ts` fire unconditionally. Since the BlueBubbles typing endpoint requires Private API, every call fails and spams the error log with `typing restart failed` / `typing start failed` messages on every single inbound message.

The send path (`send.ts`) already correctly gates on `privateApiEnabled` via `getCachedBlueBubblesPrivateApiStatus`, but the typing indicators were missed.

## Fix

Wraps the three `sendBlueBubblesTyping` call sites in `monitor-processing.ts` with the existing `privateApiEnabled` check:

1. **`restartTypingSoon`** timer callback — typing restart between streaming blocks
2. **`onReplyStart`** — typing indicator at start of reply
3. **`finally` block** — typing stop after reply completes

When `privateApiEnabled` is `false`, typing calls are simply skipped. No behavioral change when Private API is available.

## Testing

- Tested on Mac mini running macOS Tahoe (26.0) with SIP enabled, BlueBubbles server reporting `private_api: false`
- Confirmed typing error log spam is eliminated
- Confirmed messages still send and receive correctly via AppleScript fallback
- Confirmed no change in behavior when Private API is enabled (typing indicators still work normally)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `privateApiEnabled` guard checks before three `sendBlueBubblesTyping` call sites to skip typing indicators when BlueBubbles Private API is unavailable, matching the existing pattern in `send.ts:line 347`. 

- All three call sites (typing restart timer, `onReplyStart`, and `finally` block) now check `privateApiEnabled` before attempting to send typing indicators
- When Private API is disabled, typing calls are silently skipped instead of making API requests that would fail
- Eliminates error log spam on systems running macOS Tahoe / macOS 26 with SIP enabled where Private API is unavailable
- No functional change when Private API is available — typing indicators continue to work normally
- Implementation is consistent with the defensive pattern used elsewhere in the codebase

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The changes are minimal, focused, and add defensive guards that only skip optional typing indicator calls when Private API is unavailable. The implementation correctly mirrors the existing pattern from `send.ts`, uses the same `getCachedBlueBubblesPrivateApiStatus` check already present in the codebase, and adds no new logic or side effects. All three guard placements are appropriate and the behavior change is purely to eliminate unnecessary API calls (and resulting error logs) when Private API is disabled, with zero functional impact when it's enabled.
- No files require special attention

<sub>Last reviewed commit: 1522505</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->