### PR TITLE
fix: formal_conformance comment step should not fail job on fork PRs

### DIFF
--- a/.github/workflows/formal-conformance.yml
+++ b/.github/workflows/formal-conformance.yml
@@ -108,6 +108,7 @@ jobs:
 
       - name: Comment on PR (informational)
         if: steps.drift.outputs.drift == 'true'
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
The 'Comment on PR (informational)' step in formal-conformance.yml fails on fork PRs with 'Resource not accessible by integration' because fork PR tokens don't have write access to the base repo. This fails the entire job even though all actual model checks (green suite + negative suite) pass successfully.

The comment is already described as 'informational' and 'not blocking merges yet', so it should use continue-on-error: true to match that intent.

Affects all external contributor PRs (e.g. #16399, #16700).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `continue-on-error: true` to the "Comment on PR (informational)" step in `.github/workflows/formal-conformance.yml:111` to prevent fork PR failures when the GitHub token lacks write permissions to the base repository.

- Fixes `Resource not accessible by integration` errors on external contributor PRs
- Aligns behavior with the step's documented intent (informational, non-blocking)
- Consistent with the workflow's existing use of `continue-on-error` for the negative suite (line 81)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change is a single-line addition that prevents job failure when permissions are insufficient, matching the step's documented intent as "informational" and "not blocking merges yet". The fix follows an established pattern in the same workflow (negative suite at line 81) and resolves a real issue affecting external contributors without altering any actual validation logic.
- No files require special attention

<sub>Last reviewed commit: 0c9ca1b</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->