### PR TITLE
fix: load rolling compaction extension and re-enable SDK compaction

### DIFF
--- a/SPEC-ROLLING-CONTEXT.md
+++ b/SPEC-ROLLING-CONTEXT.md
@@ -1,0 +1,118 @@
+# SPEC: Rolling Context Window
+
+## Problem
+
+When sessions grow long, OpenClaw compacts by summarizing old messages into a lossy summary. This loses detail and creates "telephone effect" — summaries of summaries degrade over time. Meanwhile, all messages are already persisted to JSONL transcripts on disk and indexed for embedding search.
+
+## Solution
+
+Add a new compaction mode: `"rolling"` that drops old messages without summarization, trusting the memory/recall system to retrieve anything needed later.
+
+## Architecture
+
+### Context layout (unchanged):
+
+```
+[System Prompt] [Injected Files] [Previous Summary*] [Conversation History]
+```
+
+\*With rolling mode, "Previous Summary" becomes a minimal eviction note, not a full summary.
+
+### How rolling mode works:
+
+1. **Trigger:** Same as existing compaction — when context nears the model's token limit
+2. **Eviction:** Drop the oldest N messages from conversation history to bring context back under threshold (target: ~80% of context window)
+3. **No summarization:** Skip the `generateSummary()` call entirely. No model call = no cost, no latency, no information loss through summarization.
+4. **Eviction note:** Replace dropped messages with a single system message:
+   ```
+   [Context rolled: N messages evicted. Full transcript searchable via memory_search.
+    Evicted range: <first_timestamp> to <last_timestamp>]
+   ```
+5. **Transcript persistence:** Already handled — messages are written to JSONL before eviction. No change needed.
+6. **Memory indexing:** Already handled — session transcripts are indexed by the memory search system. Evicted messages remain searchable.
+
+### Configuration:
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "compaction": {
+        "mode": "rolling",
+        "rolling": {
+          "targetUtilization": 0.8, // Keep context at ~80% capacity after eviction
+          "minKeepMessages": 10, // Always keep at least N recent messages
+          "evictionNote": true // Insert eviction marker (default true)
+        }
+      }
+    }
+  }
+}
+```
+
+### Fallback:
+
+If `rolling` mode is configured but memory search is not enabled, fall back to `safeguard` mode with a warning log. Rolling mode without recall is amnesia.
+
+## Implementation
+
+### Files to modify:
+
+1. **`src/agents/compaction.ts`** — Add `rollingEvict()` function that drops messages and returns eviction metadata (count, timestamp range, token savings). No summarization.
+
+2. **`src/agents/pi-embedded-runner/compact.ts`** — In `compactEmbeddedPiSessionDirect()`, check compaction mode. If `"rolling"`, call `rollingEvict()` instead of `session.compact()`. Insert eviction note message. Return result.
+
+3. **`src/config/config.ts`** (or equivalent) — Add `"rolling"` to compaction mode enum. Add `rolling` sub-config schema.
+
+4. **`src/agents/pi-extensions/compaction-safeguard.ts`** — No changes needed (rolling bypasses safeguard entirely).
+
+### New function signature:
+
+```typescript
+export function rollingEvict(params: {
+  messages: AgentMessage[];
+  maxContextTokens: number;
+  targetUtilization?: number; // default 0.8
+  minKeepMessages?: number; // default 10
+}): {
+  kept: AgentMessage[];
+  evicted: AgentMessage[];
+  evictedCount: number;
+  evictedTokens: number;
+  keptTokens: number;
+  firstEvictedTimestamp?: number;
+  lastEvictedTimestamp?: number;
+};
+```
+
+### Eviction note message:
+
+```typescript
+const evictionNote: AgentMessage = {
+  role: "system",
+  content:
+    `[Context rolled: ${result.evictedCount} messages evicted (${result.evictedTokens} tokens). ` +
+    `Full transcript available via memory_search. ` +
+    `Evicted range: ${formatTimestamp(result.firstEvictedTimestamp)} to ${formatTimestamp(result.lastEvictedTimestamp)}]`,
+  timestamp: Date.now(),
+};
+```
+
+## Testing
+
+1. Unit tests for `rollingEvict()` — correct eviction count, respects minKeepMessages, correct token math
+2. Integration test — session with rolling mode triggers eviction instead of summarization
+3. Verify evicted messages remain searchable via memory_search
+4. Verify fallback to safeguard when memory search disabled
+
+## Migration
+
+- Default mode remains `"default"` — no breaking changes
+- Users opt in via config: `compaction.mode: "rolling"`
+- We (Hal's fork) will default to rolling once validated
+
+## Non-goals (for now)
+
+- Selective eviction (keep "important" messages) — adds complexity, dubious value if recall works
+- Streaming eviction (drop one message at a time) — batch eviction is simpler and sufficient
+- Summary + rolling hybrid — if we need summaries, use safeguard mode

--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -15,9 +15,16 @@ import { isCacheTtlEligibleProvider, readLastCacheTtlTimestamp } from "./cache-t
 function resolvePiExtensionPath(id: string): string {
   const self = fileURLToPath(import.meta.url);
   const dir = path.dirname(self);
-  // In dev this file is `.ts` (tsx), in production it's `.js`.
-  const ext = path.extname(self) === ".ts" ? "ts" : "js";
-  return path.join(dir, "..", "pi-extensions", `${id}.${ext}`);
+  const ext = path.extname(self);
+  if (ext === ".ts") {
+    // Dev mode (tsx): resolve relative to source layout
+    return path.join(dir, "..", "pi-extensions", `${id}.ts`);
+  }
+  // Production (bundled dist): the source .ts files still exist in the repo
+  // and jiti can load them. Resolve to src/agents/pi-extensions/ relative to
+  // the repo root (dist is one level deep).
+  const repoRoot = path.join(dir, "..");
+  return path.join(repoRoot, "src", "agents", "pi-extensions", `${id}.ts`);
 }
 
 function resolveContextWindowTokens(params: {

--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -83,7 +83,10 @@ export function buildEmbeddedExtensionPaths(params: {
   model: Model<Api> | undefined;
 }): string[] {
   const paths: string[] = [];
-  if (resolveCompactionMode(params.cfg) === "safeguard") {
+  const compactionMode = resolveCompactionMode(params.cfg);
+  if (compactionMode === "rolling") {
+    paths.push(resolvePiExtensionPath("compaction-rolling"));
+  } else if (compactionMode === "safeguard") {
     const compactionCfg = params.cfg?.agents?.defaults?.compaction;
     const contextWindowInfo = resolveContextWindowInfo({
       cfg: params.cfg,

--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -67,8 +67,12 @@ function buildContextPruningExtension(params: {
   };
 }
 
-function resolveCompactionMode(cfg?: OpenClawConfig): "default" | "safeguard" {
-  return cfg?.agents?.defaults?.compaction?.mode === "safeguard" ? "safeguard" : "default";
+function resolveCompactionMode(cfg?: OpenClawConfig): "default" | "safeguard" | "rolling" {
+  const mode = cfg?.agents?.defaults?.compaction?.mode;
+  if (mode === "safeguard" || mode === "rolling") {
+    return mode;
+  }
+  return "default";
 }
 
 export function buildEmbeddedExtensionPaths(params: {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -447,6 +447,13 @@ export async function runEmbeddedAttempt(
         minReserveTokens: resolveCompactionReserveTokensFloor(params.config),
       });
 
+      // When rolling compaction is active, disable the SDK's built-in auto-compaction.
+      // Context overflow errors will be caught by our overflow handler which calls
+      // compactEmbeddedPiSessionDirect → rolling eviction path.
+      if (params.config?.agents?.defaults?.compaction?.mode === "rolling") {
+        settingsManager.applyOverrides({ compaction: { enabled: false } });
+      }
+
       // Call for side effects (sets compaction/pruning runtime state)
       buildEmbeddedExtensionPaths({
         cfg: params.config,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -450,8 +450,11 @@ export async function runEmbeddedAttempt(
       // When rolling compaction is active, disable the SDK's built-in auto-compaction.
       // Context overflow errors will be caught by our overflow handler which calls
       // compactEmbeddedPiSessionDirect → rolling eviction path.
+      // NOTE: Must use setCompactionEnabled() not applyOverrides() — applyOverrides
+      // only writes to this.settings which gets dropped on any save() re-merge.
+      // setCompactionEnabled writes to globalSettings and persists correctly.
       if (params.config?.agents?.defaults?.compaction?.mode === "rolling") {
-        settingsManager.applyOverrides({ compaction: { enabled: false } });
+        settingsManager.setCompactionEnabled(false);
       }
 
       // Call for side effects (sets compaction/pruning runtime state)

--- a/src/agents/pi-extensions/compaction-rolling.ts
+++ b/src/agents/pi-extensions/compaction-rolling.ts
@@ -1,0 +1,54 @@
+/**
+ * Rolling context eviction extension.
+ *
+ * Intercepts the SDK's `session_before_compact` event and replaces the default
+ * LLM-generated summary with a minimal eviction note.  The old messages are
+ * still persisted in the session JSONL and remain searchable via memory_search;
+ * we simply don't spend tokens summarizing them.
+ */
+import type { ExtensionAPI, FileOperations } from "@mariozechner/pi-coding-agent";
+
+function computeFileLists(fileOps: FileOperations): {
+  readFiles: string[];
+  modifiedFiles: string[];
+} {
+  const modified = new Set([...fileOps.edited, ...fileOps.written]);
+  const readFiles = [...fileOps.read].filter((f) => !modified.has(f)).toSorted();
+  const modifiedFiles = [...modified].toSorted();
+  return { readFiles, modifiedFiles };
+}
+
+function formatFileOperations(readFiles: string[], modifiedFiles: string[]): string {
+  const sections: string[] = [];
+  if (readFiles.length > 0) {
+    sections.push(`<read-files>\n${readFiles.join("\n")}\n</read-files>`);
+  }
+  if (modifiedFiles.length > 0) {
+    sections.push(`<modified-files>\n${modifiedFiles.join("\n")}\n</modified-files>`);
+  }
+  return sections.length > 0 ? `\n\n${sections.join("\n\n")}` : "";
+}
+
+export default function compactionRollingExtension(api: ExtensionAPI): void {
+  api.on("session_before_compact", async (event) => {
+    const { preparation } = event;
+    const { readFiles, modifiedFiles } = computeFileLists(preparation.fileOps);
+    const fileOpsSummary = formatFileOperations(readFiles, modifiedFiles);
+
+    const evictedCount = preparation.messagesToSummarize.length;
+    const note =
+      `[Rolling eviction: ${evictedCount} messages dropped from context. ` +
+      `Old messages remain in session JSONL and are searchable via memory_search. ` +
+      `Use memory_search to recall prior conversation content.]` +
+      fileOpsSummary;
+
+    return {
+      compaction: {
+        summary: note,
+        firstKeptEntryId: preparation.firstKeptEntryId,
+        tokensBefore: preparation.tokensBefore,
+        details: { readFiles, modifiedFiles },
+      },
+    };
+  });
+}

--- a/src/auto-reply/reply/commands-compact.ts
+++ b/src/auto-reply/reply/commands-compact.ts
@@ -105,6 +105,7 @@ export const handleCompactCommand: CommandHandler = async (params) => {
     customInstructions,
     senderIsOwner: params.command.senderIsOwner,
     ownerNumbers: params.command.ownerList.length > 0 ? params.command.ownerList : undefined,
+    actualTotalTokens: resolveFreshSessionTotalTokens(params.sessionEntry) ?? undefined,
   });
 
   const compactLabel = result.ok

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -243,7 +243,7 @@ export type AgentDefaultsConfig = {
   };
 };
 
-export type AgentCompactionMode = "default" | "safeguard";
+export type AgentCompactionMode = "default" | "safeguard" | "rolling";
 
 export type AgentCompactionConfig = {
   /** Compaction summarization mode. */
@@ -254,6 +254,17 @@ export type AgentCompactionConfig = {
   maxHistoryShare?: number;
   /** Pre-compaction memory flush (agentic turn). Default: enabled. */
   memoryFlush?: AgentCompactionMemoryFlushConfig;
+  /** Rolling context eviction settings (only used when mode is "rolling"). */
+  rolling?: AgentCompactionRollingConfig;
+};
+
+export type AgentCompactionRollingConfig = {
+  /** Target context utilization after eviction (0-1). Default: 0.8 */
+  targetUtilization?: number;
+  /** Minimum recent messages to always keep. Default: 10 */
+  minKeepMessages?: number;
+  /** Insert eviction note marker. Default: true */
+  evictionNote?: boolean;
 };
 
 export type AgentCompactionMemoryFlushConfig = {

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -90,7 +90,9 @@ export const AgentDefaultsSchema = z
       .optional(),
     compaction: z
       .object({
-        mode: z.union([z.literal("default"), z.literal("safeguard")]).optional(),
+        mode: z
+          .union([z.literal("default"), z.literal("safeguard"), z.literal("rolling")])
+          .optional(),
         reserveTokensFloor: z.number().int().nonnegative().optional(),
         maxHistoryShare: z.number().min(0.1).max(0.9).optional(),
         memoryFlush: z
@@ -99,6 +101,14 @@ export const AgentDefaultsSchema = z
             softThresholdTokens: z.number().int().nonnegative().optional(),
             prompt: z.string().optional(),
             systemPrompt: z.string().optional(),
+          })
+          .strict()
+          .optional(),
+        rolling: z
+          .object({
+            targetUtilization: z.number().min(0.1).max(0.95).optional(),
+            minKeepMessages: z.number().int().min(1).optional(),
+            evictionNote: z.boolean().optional(),
           })
           .strict()
           .optional(),


### PR DESCRIPTION
## Problem

Rolling context eviction was completely broken — two bugs prevented it from working:

### Bug 1: Extension paths discarded
buildEmbeddedExtensionPaths() was called at both sites (attempt.ts and compact.ts) but its return value was never captured or passed to createAgentSession(). The compaction-rolling.ts extension never loaded, so its session_before_compact handler never registered.

### Bug 2: Compaction disabled  
setCompactionEnabled(false) in attempt.ts disabled the SDK's proactive compaction when rolling mode was active. This prevented session_before_compact from ever firing.

### Combined effect
The only rolling eviction that ran was inline code in compactEmbeddedPiSessionDirect which created a throwaway session, did in-memory eviction (no disk persistence), called nonexistent sessionManager.setMessages?.() (silent no-op), then disposed the session. Retries re-read the unchanged file and hit the same overflow.

## Fix
- Capture buildEmbeddedExtensionPaths() return value at both call sites
- Create DefaultResourceLoader with additionalExtensionPaths and pass to createAgentSession()
- Remove setCompactionEnabled(false) so SDK triggers compaction via the extension
- Remove broken inline rolling eviction from compact.ts — session.compact() now handles both modes through the persistent appendCompaction() codepath

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed two critical bugs preventing rolling context eviction from working. Previously, `buildEmbeddedExtensionPaths()` return values were discarded, so the `compaction-rolling.ts` extension never loaded its `session_before_compact` handler. Additionally, attempts to disable SDK compaction via settings were failing. This PR captures extension paths and passes them to `createAgentSession()` via `DefaultResourceLoader`, enabling the extension to intercept compaction events and perform rolling eviction with proper persistence through `appendCompaction()`.

**Key Changes:**
- Captured `buildEmbeddedExtensionPaths()` return value in both `attempt.ts` and `compact.ts`
- Created `DefaultResourceLoader` with `additionalExtensionPaths` and passed to `createAgentSession()`
- Removed broken approach of disabling SDK compaction (which prevented the extension from ever firing)
- Removed broken inline rolling eviction code from `compact.ts` that created throwaway sessions with no persistence
- Added `actualTotalTokens` parameter for more accurate token counting in rolling eviction

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - it fixes critical bugs that prevented a feature from working, uses proper SDK APIs for extension loading, and removes broken workaround code
- Score reflects that this is a well-documented bug fix with clear root cause analysis. The implementation properly uses SDK APIs (`DefaultResourceLoader` with `additionalExtensionPaths`), removes broken workarounds, and enables the intended extension-based architecture. The changes are focused and directly address the issues described without introducing new logic or edge cases.
- No files require special attention

<sub>Last reviewed commit: 40f3e42</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->