### PR TITLE
fix(telegram): fall back to plain text when HTML formatter produces empty output

### DIFF
--- a/src/telegram/bot/delivery.test.ts
+++ b/src/telegram/bot/delivery.test.ts
@@ -1,6 +1,7 @@
 import type { Bot } from "grammy";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { RuntimeEnv } from "../../runtime.js";
+import * as telegramFormat from "../format.js";
 import { deliverReplies } from "./delivery.js";
 
 const loadWebMedia = vi.fn();
@@ -223,6 +224,35 @@ describe("deliverReplies", () => {
         message_thread_id: 42,
       }),
     );
+  });
+
+  it("falls back to plain text when formatter returns empty HTML", async () => {
+    const runtime = { error: vi.fn(), log: vi.fn() };
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 44,
+      chat: { id: "123" },
+    });
+    const bot = { api: { sendMessage } } as unknown as Bot;
+    const chunksSpy = vi
+      .spyOn(telegramFormat, "markdownToTelegramChunks")
+      .mockReturnValue([{ html: "", text: "[]()" }]);
+
+    try {
+      await deliverReplies({
+        replies: [{ text: "[]()" }],
+        chatId: "123",
+        token: "tok",
+        runtime,
+        bot,
+        replyToMode: "off",
+        textLimit: 4000,
+      });
+    } finally {
+      chunksSpy.mockRestore();
+    }
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledWith("123", "[]()");
   });
 
   it("does not include link_preview_options when linkPreview is true", async () => {

--- a/src/telegram/bot/delivery.ts
+++ b/src/telegram/bot/delivery.ts
@@ -550,6 +550,26 @@ async function sendTelegramText(
   const linkPreviewOptions = linkPreviewEnabled ? undefined : { is_disabled: true };
   const textMode = opts?.textMode ?? "markdown";
   const htmlText = textMode === "html" ? text : markdownToTelegramHtml(text);
+  const fallbackText = opts?.plainText ?? text;
+  const plainParams = {
+    ...(linkPreviewOptions ? { link_preview_options: linkPreviewOptions } : {}),
+    ...(opts?.replyMarkup ? { reply_markup: opts.replyMarkup } : {}),
+    ...baseParams,
+  };
+  const hasPlainParams = Object.keys(plainParams).length > 0;
+
+  if (!htmlText.trim() && fallbackText.trim()) {
+    runtime.log?.("telegram formatter returned empty HTML; retrying without formatting");
+    const res = await withTelegramApiErrorLogging({
+      operation: "sendMessage",
+      runtime,
+      fn: () =>
+        hasPlainParams
+          ? bot.api.sendMessage(chatId, fallbackText, plainParams)
+          : bot.api.sendMessage(chatId, fallbackText),
+    });
+    return res.message_id;
+  }
   try {
     const res = await withTelegramApiErrorLogging({
       operation: "sendMessage",
@@ -569,16 +589,13 @@ async function sendTelegramText(
     const errText = formatErrorMessage(err);
     if (PARSE_ERR_RE.test(errText)) {
       runtime.log?.(`telegram HTML parse failed; retrying without formatting: ${errText}`);
-      const fallbackText = opts?.plainText ?? text;
       const res = await withTelegramApiErrorLogging({
         operation: "sendMessage",
         runtime,
         fn: () =>
-          bot.api.sendMessage(chatId, fallbackText, {
-            ...(linkPreviewOptions ? { link_preview_options: linkPreviewOptions } : {}),
-            ...(opts?.replyMarkup ? { reply_markup: opts.replyMarkup } : {}),
-            ...baseParams,
-          }),
+          hasPlainParams
+            ? bot.api.sendMessage(chatId, fallbackText, plainParams)
+            : bot.api.sendMessage(chatId, fallbackText),
       });
       runtime.log?.(`telegram sendMessage ok chat=${chatId} message=${res.message_id} (plain)`);
       return res.message_id;

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -517,7 +517,7 @@ export async function sendMessageTelegram(
         // still reaches the user.
         if (!htmlText.trim() && rawText.trim()) {
           if (opts.verbose) {
-            console.warn("telegram formatter returned empty HTML, retrying as plain text");
+            diagLogger.warn("telegram formatter returned empty HTML, retrying as plain text");
           }
           const fallback = fallbackText ?? rawText;
           const plainParams = hasBaseParams

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -512,6 +512,25 @@ export async function sendMessageTelegram(
           baseParams.link_preview_options = linkPreviewOptions;
         }
         const hasBaseParams = Object.keys(baseParams).length > 0;
+        // When the HTML formatter returns empty output but the raw text was
+        // non-empty, skip HTML entirely and send as plain text so the message
+        // still reaches the user.
+        if (!htmlText.trim() && rawText.trim()) {
+          if (opts.verbose) {
+            console.warn("telegram formatter returned empty HTML, retrying as plain text");
+          }
+          const fallback = fallbackText ?? rawText;
+          const plainParams = hasBaseParams
+            ? (baseParams as Parameters<typeof api.sendMessage>[2])
+            : undefined;
+          return await requestWithChatNotFound(
+            () =>
+              plainParams
+                ? api.sendMessage(chatId, fallback, plainParams)
+                : api.sendMessage(chatId, fallback),
+            `${label}-plain-empty`,
+          );
+        }
         const sendParams = {
           parse_mode: "HTML" as const,
           ...baseParams,


### PR DESCRIPTION
Fixes #6652

## Problem

When a reply contains markdown tables or certain markdown constructs (e.g. bare `[]()` links), the Telegram HTML formatter can produce empty output. This results in a `400: Bad Request: message text is empty` error from the Telegram API, and the message is silently lost.

## Fix Approach

Three layers of defense against empty HTML output:

1. **Auto-detect markdown tables** — `format.ts` now detects markdown table syntax (pipe-delimited rows with a divider line) and automatically applies `tableMode: "code"` to render them inside `<pre><code>` blocks instead of dropping them.

2. **`ensureNonEmptyTelegramHtml()` safety net** — Both `markdownToTelegramHtml()` and `markdownToTelegramChunks()` now check if the rendered HTML is empty. If so, they fall back to HTML-escaped plain text, ensuring output is never silently empty.

3. **Delivery-level fallback** — Both `delivery.ts` (bot mode) and `send.ts` (direct API mode) now check for empty HTML *before* calling the Telegram API. If detected, they send the message as unformatted plain text instead, logging a warning.

## Changed Files

- **`src/telegram/format.ts`** — Added table auto-detection (`hasMarkdownTableSyntax`, `resolveTelegramTableMode`), `ensureNonEmptyTelegramHtml()` fallback, applied to both `markdownToTelegramHtml` and `markdownToTelegramChunks`
- **`src/telegram/bot/delivery.ts`** — Pre-send empty HTML check with plain text fallback; refactored parse-error fallback to share params
- **`src/telegram/send.ts`** — Same pre-send empty HTML check for the direct send path
- **`src/telegram/format.test.ts`** — Tests for table auto-detection, empty-render fallback, and chunk fallback
- **`src/telegram/bot/delivery.test.ts`** — Test for delivery-level empty HTML fallback

## Test Results

All 3 new test cases pass. 158 lines changed across 5 files.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds three-layer defense against empty HTML output from markdown formatter in Telegram integration:
- Auto-detects markdown tables and renders them in code blocks to prevent empty output
- `ensureNonEmptyTelegramHtml()` fallback in `format.ts` returns HTML-escaped plain text when rendering produces empty output
- Pre-send empty HTML checks in both `delivery.ts` and `send.ts` to send as plain text instead of failing with Telegram API error

The fix comprehensively addresses the issue of messages being silently lost when markdown constructs like bare `[]()` links or tables produce empty HTML, ensuring users always receive their messages.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it adds defensive fallback logic without breaking existing functionality
- The changes are well-structured defensive programming that prevents message loss. The implementation includes comprehensive test coverage for the new fallback logic, maintains backward compatibility by only activating fallbacks when HTML is empty, and follows existing patterns in the codebase. The three-layer approach (table auto-detection, format-level fallback, delivery-level fallback) ensures robustness.
- No files require special attention

<sub>Last reviewed commit: 0700167</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->