### PR TITLE
Build: add runtime-only build target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Build: add `pnpm build:runtime` for packagers/runtime builds to skip plugin-sdk declaration generation when types are not needed. (#17636) Thanks @joshp123.
 - Cron/Gateway: add finished-run webhook delivery toggle (`notify`) and dedicated webhook auth token support (`cron.webhookToken`) for outbound cron webhook posts. (#14535) Thanks @advaitpaliwal.
 - Plugins: expose `llm_input` and `llm_output` hook payloads so extensions can observe prompt/input context and model output usage details. (#16724) Thanks @SecondThread.
 - Subagents: nested sub-agents (sub-sub-agents) with configurable depth. Set `agents.defaults.subagents.maxSpawnDepth: 2` to allow sub-agents to spawn their own children. Includes `maxChildrenPerAgent` limit (default 5), depth-aware tool policy, and proper announce chain routing. (#14447) Thanks @tyler6204.

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "android:test": "cd apps/android && ./gradlew :app:testDebugUnitTest",
     "build": "pnpm canvas:a2ui:bundle && tsdown && pnpm build:plugin-sdk:dts && node --import tsx scripts/write-plugin-sdk-entry-dts.ts && node --import tsx scripts/canvas-a2ui-copy.ts && node --import tsx scripts/copy-hook-metadata.ts && node --import tsx scripts/write-build-info.ts && node --import tsx scripts/write-cli-compat.ts",
     "build:plugin-sdk:dts": "tsc -p tsconfig.plugin-sdk.dts.json",
+    "build:runtime": "pnpm canvas:a2ui:bundle && tsdown && node --import tsx scripts/canvas-a2ui-copy.ts && node --import tsx scripts/copy-hook-metadata.ts && node --import tsx scripts/write-build-info.ts && node --import tsx scripts/write-cli-compat.ts",
     "canvas:a2ui:bundle": "bash scripts/bundle-a2ui.sh",
     "check": "pnpm format:check && pnpm tsgo && pnpm lint",
     "check:docs": "pnpm format:docs:check && pnpm lint:docs && pnpm docs:check-links",


### PR DESCRIPTION
## Summary

- Adds `pnpm build:runtime` for packagers/runtime builds.
- `pnpm build` remains unchanged (still generates plugin-sdk d.ts for TS consumers).

## Why

Packagers that build from source in clean environments often do not need plugin SDK declaration output for runtime packaging, but the declaration build can be expensive.

## Tests

- `pnpm -s build:runtime`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a `pnpm build:runtime` script that runs the full build pipeline minus the plugin-sdk TypeScript declaration generation (`tsc` + entry `.d.ts` stub writing). This lets packagers building from source in clean environments skip the expensive declaration emit when only runtime JS output is needed. The existing `pnpm build` remains unchanged.

- Adds `build:runtime` script in `package.json` that mirrors `build` but omits `build:plugin-sdk:dts` and `write-plugin-sdk-entry-dts.ts`
- Adds corresponding changelog entry under the unreleased section
- No runtime-critical build steps are missing from the new target — all skipped steps produce only `.d.ts` files

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it adds a new build target without modifying existing build behavior.
- The change is minimal and additive: a single new npm script that is a strict subset of the existing `build` script, plus a changelog entry. No existing scripts, runtime code, or build outputs are modified. The skipped steps produce only `.d.ts` declaration files that have no runtime impact. The existing `build` and `prepack` scripts remain unchanged.
- No files require special attention.

<sub>Last reviewed commit: 3254bae</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->