### PR TITLE
fix(pairing): isolate allowFrom store per accountId

### DIFF
--- a/src/auto-reply/reply/commands-allowlist.ts
+++ b/src/auto-reply/reply/commands-allowlist.ts
@@ -356,7 +356,7 @@ export const handleAllowlistCommand: CommandHandler = async (params, allowTextCo
     const pairingChannels = listPairingChannels();
     const supportsStore = pairingChannels.includes(channelId);
     const storeAllowFrom = supportsStore
-      ? await readChannelAllowFromStore(channelId).catch(() => [])
+      ? await readChannelAllowFromStore(channelId, accountId).catch(() => [])
       : [];
 
     let dmAllowFrom: string[] = [];
@@ -669,9 +669,13 @@ export const handleAllowlistCommand: CommandHandler = async (params, allowTextCo
 
     if (shouldTouchStore) {
       if (parsed.action === "add") {
-        await addChannelAllowFromStoreEntry({ channel: channelId, entry: parsed.entry });
+        await addChannelAllowFromStoreEntry({ channel: channelId, accountId, entry: parsed.entry });
       } else if (parsed.action === "remove") {
-        await removeChannelAllowFromStoreEntry({ channel: channelId, entry: parsed.entry });
+        await removeChannelAllowFromStoreEntry({
+          channel: channelId,
+          accountId,
+          entry: parsed.entry,
+        });
       }
     }
 
@@ -701,9 +705,9 @@ export const handleAllowlistCommand: CommandHandler = async (params, allowTextCo
   }
 
   if (parsed.action === "add") {
-    await addChannelAllowFromStoreEntry({ channel: channelId, entry: parsed.entry });
+    await addChannelAllowFromStoreEntry({ channel: channelId, accountId, entry: parsed.entry });
   } else if (parsed.action === "remove") {
-    await removeChannelAllowFromStoreEntry({ channel: channelId, entry: parsed.entry });
+    await removeChannelAllowFromStoreEntry({ channel: channelId, accountId, entry: parsed.entry });
   }
 
   const actionLabel = parsed.action === "add" ? "added" : "removed";

--- a/src/cli/pairing-cli.test.ts
+++ b/src/cli/pairing-cli.test.ts
@@ -91,7 +91,7 @@ describe("pairing cli", () => {
     registerPairingCli(program);
     await program.parseAsync(["pairing", "list", "telegram"], { from: "user" });
 
-    expect(listChannelPairingRequests).toHaveBeenCalledWith("telegram");
+    expect(listChannelPairingRequests).toHaveBeenCalledWith("telegram", undefined);
   });
 
   it("normalizes channel aliases", async () => {
@@ -104,7 +104,7 @@ describe("pairing cli", () => {
     await program.parseAsync(["pairing", "list", "imsg"], { from: "user" });
 
     expect(normalizeChannelId).toHaveBeenCalledWith("imsg");
-    expect(listChannelPairingRequests).toHaveBeenCalledWith("imessage");
+    expect(listChannelPairingRequests).toHaveBeenCalledWith("imessage", undefined);
   });
 
   it("accepts extension channels outside the registry", async () => {
@@ -117,7 +117,7 @@ describe("pairing cli", () => {
     await program.parseAsync(["pairing", "list", "zalo"], { from: "user" });
 
     expect(normalizeChannelId).toHaveBeenCalledWith("zalo");
-    expect(listChannelPairingRequests).toHaveBeenCalledWith("zalo");
+    expect(listChannelPairingRequests).toHaveBeenCalledWith("zalo", undefined);
   });
 
   it("labels Discord ids as discordUserId", async () => {
@@ -166,6 +166,7 @@ describe("pairing cli", () => {
 
     expect(approveChannelPairingCode).toHaveBeenCalledWith({
       channel: "telegram",
+      accountId: undefined,
       code: "ABCDEFGH",
     });
     expect(log).toHaveBeenCalledWith(expect.stringContaining("Approved"));

--- a/src/cli/pairing-cli.ts
+++ b/src/cli/pairing-cli.ts
@@ -66,6 +66,7 @@ export function registerPairingCli(program: Command) {
     .option("--channel <channel>", `Channel (${channels.join(", ")})`)
     .argument("[channel]", `Channel (${channels.join(", ")})`)
     .option("--json", "Print JSON", false)
+    .option("--account <account>", "Account ID (for multi-account isolation)")
     .action(async (channelArg, opts) => {
       const channelRaw = opts.channel ?? channelArg;
       if (!channelRaw) {
@@ -74,7 +75,8 @@ export function registerPairingCli(program: Command) {
         );
       }
       const channel = parseChannel(channelRaw, channels);
-      const requests = await listChannelPairingRequests(channel);
+      const accountId: string | undefined = opts.account;
+      const requests = await listChannelPairingRequests(channel, accountId);
       if (opts.json) {
         defaultRuntime.log(JSON.stringify({ channel, requests }, null, 2));
         return;
@@ -114,6 +116,7 @@ export function registerPairingCli(program: Command) {
     .argument("<codeOrChannel>", "Pairing code (or channel when using 2 args)")
     .argument("[code]", "Pairing code (when channel is passed as the 1st arg)")
     .option("--notify", "Notify the requester on the same channel", false)
+    .option("--account <account>", "Account ID (for multi-account isolation)")
     .action(async (codeOrChannel, code, opts) => {
       const channelRaw = opts.channel ?? codeOrChannel;
       const resolvedCode = opts.channel ? codeOrChannel : code;
@@ -128,8 +131,10 @@ export function registerPairingCli(program: Command) {
         );
       }
       const channel = parseChannel(channelRaw, channels);
+      const accountId: string | undefined = opts.account;
       const approved = await approveChannelPairingCode({
         channel,
+        accountId,
         code: String(resolvedCode),
       });
       if (!approved) {

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -128,6 +128,7 @@ async function resolveTelegramCommandAuth(params: {
   bot: Bot;
   cfg: OpenClawConfig;
   telegramCfg: TelegramAccountConfig;
+  accountId?: string;
   allowFrom?: Array<string | number>;
   groupAllowFrom?: Array<string | number>;
   useAccessGroups: boolean;
@@ -143,6 +144,7 @@ async function resolveTelegramCommandAuth(params: {
     bot,
     cfg,
     telegramCfg,
+    accountId,
     allowFrom,
     groupAllowFrom,
     useAccessGroups,
@@ -372,6 +374,7 @@ export const registerTelegramNativeCommands = ({
             bot,
             cfg,
             telegramCfg,
+            accountId,
             allowFrom,
             groupAllowFrom,
             useAccessGroups,
@@ -624,6 +627,7 @@ export const registerTelegramNativeCommands = ({
             bot,
             cfg,
             telegramCfg,
+            accountId,
             allowFrom,
             groupAllowFrom,
             useAccessGroups,


### PR DESCRIPTION
- This is created and tested by Opus 4.6
- degree of testing: lightly tested
- yes I understand what the code does
- session history:
```
spawned the coding agent on Opus to fix this. it'll dig into the code and implement the per-account pairing fix.

in the meantime, here's what we found:

Security bug confirmed:

• ~/.openclaw/credentials/telegram-allowFrom.json contains both your ID and YY's ID
• this is a shared global file — anyone paired with ANY telegram bot can access ALL telegram bots
• the pairing code doesn't scope allowlists by accountId

the fix:

• change telegram-allowFrom.json → telegram-<accountId>-allowFrom.json
• update all pairing functions to accept accountId parameter
• update callers (telegram bot, CLI, auto-reply) to pass the account context

i'll ping you when the coding agent finishes. want me to also file this as a GitHub issue so it gets tracked upstream? 👀
```

## Summary

Fixes #17631 — pairing allowFrom was stored globally per channel, causing users approved for one Telegram bot to access all Telegram bots on the same gateway.

## Changes

### Core fix: `src/pairing/pairing-store.ts`
- Added `safeAccountKey()` helper to sanitize accountId for filenames
- Added `buildStoreFilename()` to construct filenames with optional accountId segment
- Added optional `accountId?: string` parameter to all path resolution and public functions
- File naming: with accountId → `telegram-yy-allowFrom.json`; without → `telegram-allowFrom.json` (backwards compatible)
- **Migration fallback**: when reading with accountId, also merges entries from legacy global file to prevent lockouts during upgrade

### Callers updated:
- `src/telegram/bot-native-commands.ts` — passes `accountId` to `readChannelAllowFromStore`
- `src/auto-reply/reply/commands-allowlist.ts` — passes `accountId` to read/add/remove store functions
- `src/cli/pairing-cli.ts` — added `--account` option to `list` and `approve` subcommands

### Tests:
- Added 4 tests verifying account isolation for allowFrom, pairing requests, approve flow, and migration fallback
- All 8 pairing store tests pass

## Migration path

Existing users upgrading:
1. Legacy `telegram-allowFrom.json` entries are automatically merged when reading with accountId
2. New approvals write to account-specific files
3. No manual migration required — existing access preserved, new access properly isolated

## Follow-up (out of scope)

Other channel callers (discord, slack, signal, whatsapp, line, imessage) still call without accountId — they work via backwards compatibility but should be updated in follow-up PRs for full multi-account isolation.

## Testing

```bash
npx vitest run src/pairing/pairing-store.test.ts
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a security issue where pairing `allowFrom` was stored globally per channel, allowing users approved for one Telegram bot to access all Telegram bots on the same gateway. The fix adds `accountId` isolation to pairing stores, ensuring proper multi-account separation.

**Key changes:**
- Added `safeAccountKey()` helper and `buildStoreFilename()` to construct account-specific filenames (`telegram-yy-allowFrom.json` vs `telegram-allowFrom.json`)
- Threaded optional `accountId` parameter through all pairing store functions
- Implemented migration fallback that only reads legacy global file when account-specific file doesn't exist yet (prevents removals from being ineffective)
- Updated callers in telegram, auto-reply, and CLI to pass `accountId`
- Added 4 comprehensive tests verifying account isolation and migration behavior

**Migration path:**
Existing users automatically get legacy entries when reading with `accountId` (before account-specific file exists). Once an account-specific file is created via add/approve operations, the legacy file is no longer consulted, allowing removals to work correctly.

**Follow-up noted:**
Other channel callers (discord, slack, signal, whatsapp, line, imessage) still call without `accountId` and rely on backwards compatibility.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk - it fixes a security isolation issue and includes comprehensive test coverage
- The implementation properly addresses the security issue with account isolation. Previous review comments have been addressed (accountId threading and migration logic gating). The migration path preserves existing access while ensuring removals work correctly. Comprehensive test coverage validates all scenarios. Minor points: other channels still need accountId threading (noted as follow-up), and the code is straightforward with clear comments.
- No files require special attention

<sub>Last reviewed commit: 8ce9f1e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->