### PR TITLE
fix: lookupContextTokens() returns wrong contextWindow due to cross-provider model ID collision

### DIFF
--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -55,7 +55,7 @@ const loadPromise = (async () => {
     const agentDir = resolveOpenClawAgentDir();
     const authStorage = discoverAuthStorage(agentDir);
     const modelRegistry = discoverModels(authStorage, agentDir);
-    const models = modelRegistry.getAll() as ModelEntry[];
+    const models = modelRegistry.getAvailable() as ModelEntry[];
     for (const m of models) {
       if (!m?.id) {
         continue;


### PR DESCRIPTION
## Summary

Changed `lookupContextTokens()` in `src/agents/context.ts` to use `modelRegistry.getAvailable()` instead of `modelRegistry.getAll()`. This ensures the MODEL_CACHE only includes models from providers with configured authentication, preventing the last-write-wins behavior that caused incorrect context window values when the same model ID exists across multiple providers with different context windows.

## Changes

- `src/agents/context.ts`: Changed `modelRegistry.getAll()` to `modelRegistry.getAvailable()` on line 58

## Testing

- Ran existing tests in `src/agents/context.test.ts` - all 4 tests pass
- The fix is a one-line change that follows the existing code pattern

Fixes openclaw/openclaw#17586

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Single-line fix in `src/agents/context.ts` that changes the `MODEL_CACHE` population from `modelRegistry.getAll()` to `modelRegistry.getAvailable()`. This prevents incorrect context window values caused by cross-provider model ID collisions — when the same model ID exists across multiple providers with different context windows, `getAll()` would include models from unconfigured providers, and the last-write-wins iteration could cache the wrong value. Using `getAvailable()` filters to only authenticated providers, which is consistent with how the method is used in `src/commands/models/list.registry.ts`.

- **Fix**: `getAll()` → `getAvailable()` on line 58 of `src/agents/context.ts`
- The call is already wrapped in a try-catch, so error handling for `getAvailable()` failures is covered
- Existing tests in `context.test.ts` pass (they test the `applyConfiguredContextWindows` helper, not the `loadPromise` IIFE directly)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a minimal, well-scoped one-line fix that aligns with existing codebase patterns.
- The change is a single method call swap (`getAll()` → `getAvailable()`) in a try-catch block. The fix correctly narrows model discovery to only authenticated providers, preventing the documented cross-provider collision bug. The pattern is already established in the codebase (e.g., `list.registry.ts`). No new code paths, no API changes, and no risk of regression.
- No files require special attention.

<sub>Last reviewed commit: 002c013</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->