### PR TITLE
fix: Memory indexer skips session files

### DIFF
--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -180,6 +180,7 @@ export class MemoryIndexManager implements MemorySearchManager {
     this.ensureIntervalSync();
     const statusOnly = params.purpose === "status";
     this.dirty = this.sources.has("memory") && (statusOnly ? !meta : true);
+    this.sessionsDirty = this.sources.has("sessions") && (statusOnly ? !meta : true);
     this.batch = this.resolveBatchConfig();
   }
 


### PR DESCRIPTION
## Summary

When the MemoryManager is constructed, the `dirty` flag is set to true for memory sources to ensure files get indexed on first sync. However, the `sessionsDirty` flag was never initialized, causing session files to never be indexed unless `--force` was used or session files changed externally.

This fix adds the same initialization pattern for `sessionsDirty`: it is set to true when sessions is in sources (for non-status operations). This ensures session files are indexed on first sync, matching the behavior of memory files.

## Changes

- Added initialization of `sessionsDirty` flag in `MemoryManager` constructor: `this.sessionsDirty = this.sources.has("sessions") && (statusOnly ? !meta : true);`

## Testing

- All existing memory tests pass: index.test.ts, manager.async-search.test.ts, session-files.test.ts, memory-cli.test.ts
- The fix follows the same pattern as the existing `dirty` flag initialization for memory files

Fixes openclaw/openclaw#17576

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Initialized `sessionsDirty` flag in `MemoryManager` constructor to match the existing `dirty` flag pattern, ensuring session files are indexed on first sync when sessions source is configured.

- **What Changed**: Added initialization of `sessionsDirty` flag following the same logic as `dirty` flag initialization
- **Why This Matters**: Without this initialization, session files were never indexed on first sync unless `--force` was used or files changed externally
- **Pattern Match**: The fix correctly mirrors the existing `dirty` flag pattern: `this.sources.has("sessions") && (statusOnly ? !meta : true)`
- **Integration**: The `sessionsDirty` flag is properly used throughout the sync logic in `manager-sync-ops.ts` via `shouldSyncSessions()` method

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The fix is a single-line addition that follows the exact same pattern as the existing `dirty` flag initialization. The logic is correct, consistent with the existing codebase, and addresses a clear bug where session files were skipped on first sync. The change integrates seamlessly with existing sync logic that already checks `sessionsDirty` throughout the codebase.
- No files require special attention.

<sub>Last reviewed commit: be1605f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->