### PR TITLE
Default token usage footer for Telegram/Matrix sessions

### DIFF
--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -138,6 +138,7 @@ export async function initSessionState(params: {
   let persistedVerbose: string | undefined;
   let persistedReasoning: string | undefined;
   let persistedTtsAuto: TtsAutoMode | undefined;
+  let persistedResponseUsage: SessionEntry["responseUsage"] | undefined;
   let persistedModelOverride: string | undefined;
   let persistedProviderOverride: string | undefined;
 
@@ -250,6 +251,7 @@ export async function initSessionState(params: {
       persistedVerbose = entry.verboseLevel;
       persistedReasoning = entry.reasoningLevel;
       persistedTtsAuto = entry.ttsAuto;
+      persistedResponseUsage = entry.responseUsage;
     }
   }
 
@@ -271,6 +273,17 @@ export async function initSessionState(params: {
   const lastTo = deliveryFields.lastTo ?? lastToRaw;
   const lastAccountId = deliveryFields.lastAccountId ?? lastAccountIdRaw;
   const lastThreadId = deliveryFields.lastThreadId ?? lastThreadIdRaw;
+
+  const defaultResponseUsage: SessionEntry["responseUsage"] | undefined = (() => {
+    const key = String(lastChannel ?? ctx.Surface ?? ctx.Provider ?? "")
+      .trim()
+      .toLowerCase();
+    if (key === "telegram" || key === "matrix") {
+      return "tokens";
+    }
+    return undefined;
+  })();
+
   sessionEntry = {
     ...baseEntry,
     sessionId,
@@ -282,7 +295,7 @@ export async function initSessionState(params: {
     verboseLevel: persistedVerbose ?? baseEntry?.verboseLevel,
     reasoningLevel: persistedReasoning ?? baseEntry?.reasoningLevel,
     ttsAuto: persistedTtsAuto ?? baseEntry?.ttsAuto,
-    responseUsage: baseEntry?.responseUsage,
+    responseUsage: persistedResponseUsage ?? baseEntry?.responseUsage ?? defaultResponseUsage,
     modelOverride: persistedModelOverride ?? baseEntry?.modelOverride,
     providerOverride: persistedProviderOverride ?? baseEntry?.providerOverride,
     sendPolicy: baseEntry?.sendPolicy,


### PR DESCRIPTION
This change defaults session.responseUsage to 'tokens' for Telegram and Matrix sessions so outbound messages include a Usage: <in>/<out> footer without requiring /usage toggle.\n\nMotivation: users want outbound messages to include model/context metadata + token usage; prefix handles model/thinking, footer handles tokens.\n\nNotes:\n- Applies only when initializing sessions whose originating channel is telegram or matrix.\n- Existing sessions can still override via /usage off|tokens|full.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR attempts to default `responseUsage` to "tokens" for Telegram and Matrix sessions, but the implementation has a critical flaw already identified in the previous thread.

**Critical Issue**: The fallback chain `persistedResponseUsage ?? baseEntry?.responseUsage ?? defaultResponseUsage` breaks `/usage off` on Telegram/Matrix. When users run `/usage off`, the code deletes the key (commands-session.ts:218), making it `undefined`. On subsequent messages, all three values in the chain are `undefined`, so it falls back to `defaultResponseUsage` ("tokens"), silently overriding the user's explicit preference.

**Impact**: 
- `/usage off` cannot be persisted on Telegram/Matrix - it reverts to "tokens" on every message
- The same issue occurs across `/new` resets since `persistedResponseUsage` is also `undefined` when the key was deleted

**Root Cause**: The default is applied too broadly in the fallback chain, without distinguishing between "never set" and "explicitly set to off".

<h3>Confidence Score: 1/5</h3>

- This PR has a critical bug that prevents users from disabling the usage footer on Telegram/Matrix
- The implementation introduces a default value that overrides explicit user preferences. When users run `/usage off`, the setting is deleted (becomes undefined), but the fallback chain then applies the default "tokens" value for Telegram/Matrix, silently ignoring the user's choice. This breaks the `/usage off` command entirely on these platforms.
- src/auto-reply/reply/session.ts requires attention - the fallback logic on line 298 needs to be revised to respect explicit user preferences

<sub>Last reviewed commit: 3572243</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->