### PR TITLE
fix: include formatted date in buildTimeSection system prompt (#17633)

### DIFF
--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -72,11 +72,16 @@ function buildUserIdentitySection(ownerLine: string | undefined, isMinimal: bool
   return ["## User Identity", ownerLine, ""];
 }
 
-function buildTimeSection(params: { userTimezone?: string }) {
+function buildTimeSection(params: { userTimezone?: string; userTime?: string }) {
   if (!params.userTimezone) {
     return [];
   }
-  return ["## Current Date & Time", `Time zone: ${params.userTimezone}`, ""];
+  const lines = ["## Current Date & Time"];
+  if (params.userTime) {
+    lines.push(`Now: ${params.userTime}`);
+  }
+  lines.push(`Time zone: ${params.userTimezone}`, "");
+  return lines;
 }
 
 function buildReplyTagsSection(isMinimal: boolean) {
@@ -521,6 +526,7 @@ export function buildAgentSystemPrompt(params: {
     ...buildUserIdentitySection(ownerLine, isMinimal),
     ...buildTimeSection({
       userTimezone,
+      userTime: params.userTime?.trim(),
     }),
     "## Workspace Files (injected)",
     "These user-editable files are loaded by OpenClaw and included below in Project Context.",


### PR DESCRIPTION
## Summary

`buildTimeSection` currently only outputs the user's timezone but not the actual date/time, even though `userTime` is available in the prompt params. This means the agent has no awareness of the current date unless it runs a command to check.

This PR passes `params.userTime` into `buildTimeSection` so the system prompt includes a `Now: ...` line when the formatted time is available.

Fixes #17633
Fixes #17603

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds the formatted date/time to the system prompt when available. The `buildTimeSection` function now accepts a `userTime` parameter and displays it as `Now: <formatted-time>` in the `## Current Date & Time` section, giving the agent awareness of the current date without needing to run a command.

- Updated `buildTimeSection` to accept optional `userTime` parameter
- Added conditional `Now:` line when `userTime` is provided
- Passed `params.userTime?.trim()` to `buildTimeSection` in the main system prompt builder

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is straightforward and well-implemented. It adds a missing feature (displaying formatted time in the system prompt) by properly threading through an existing parameter (`userTime`) that was already available but unused. The implementation correctly handles the optional nature of the parameter with a conditional check, maintains backward compatibility when `userTime` is not provided, and follows the existing code patterns in the file.
- No files require special attention

<sub>Last reviewed commit: 916c67c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->