### PR TITLE
fix: correct MiniMax model pricing constants (#17548)

### DIFF
--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -41,10 +41,17 @@ const MINIMAX_DEFAULT_MAX_TOKENS = 8192;
 const MINIMAX_OAUTH_PLACEHOLDER = "minimax-oauth";
 // Pricing: MiniMax doesn't publish public rates. Override in models.json for accurate costs.
 const MINIMAX_API_COST = {
-  input: 15,
-  output: 60,
-  cacheRead: 2,
-  cacheWrite: 10,
+  input: 0.2,
+  output: 1.1,
+  cacheRead: 0.02,
+  cacheWrite: 0.25,
+};
+
+const MINIMAX_M25_API_COST = {
+  input: 0.3,
+  output: 1.2,
+  cacheRead: 0.03,
+  cacheWrite: 0.375,
 };
 
 type ProviderModelConfig = NonNullable<ProviderConfig["models"]>[number];
@@ -54,13 +61,14 @@ function buildMinimaxModel(params: {
   name: string;
   reasoning: boolean;
   input: ProviderModelConfig["input"];
+  cost?: typeof MINIMAX_API_COST;
 }): ProviderModelConfig {
   return {
     id: params.id,
     name: params.name,
     reasoning: params.reasoning,
     input: params.input,
-    cost: MINIMAX_API_COST,
+    cost: params.cost ?? MINIMAX_API_COST,
     contextWindow: MINIMAX_DEFAULT_CONTEXT_WINDOW,
     maxTokens: MINIMAX_DEFAULT_MAX_TOKENS,
   };
@@ -70,6 +78,7 @@ function buildMinimaxTextModel(params: {
   id: string;
   name: string;
   reasoning: boolean;
+  cost?: typeof MINIMAX_API_COST;
 }): ProviderModelConfig {
   return buildMinimaxModel({ ...params, input: ["text"] });
 }
@@ -436,11 +445,13 @@ function buildMinimaxProvider(): ProviderConfig {
         id: "MiniMax-M2.5",
         name: "MiniMax M2.5",
         reasoning: true,
+        cost: MINIMAX_M25_API_COST,
       }),
       buildMinimaxTextModel({
         id: "MiniMax-M2.5-Lightning",
         name: "MiniMax M2.5 Lightning",
         reasoning: true,
+        cost: MINIMAX_M25_API_COST,
       }),
     ],
   };
@@ -460,6 +471,7 @@ function buildMinimaxPortalProvider(): ProviderConfig {
         id: "MiniMax-M2.5",
         name: "MiniMax M2.5",
         reasoning: true,
+        cost: MINIMAX_M25_API_COST,
       }),
     ],
   };


### PR DESCRIPTION
## Problem

`MINIMAX_API_COST` had incorrect pricing values (~75x inflated):
- input: 15 → 0.20
- output: 60 → 1.10
- cacheRead: 2 → 0.02
- cacheWrite: 10 → 0.25

All MiniMax models also shared a single cost constant, but M2.5/M2.5-Lightning have different pricing from M2.1/VL-01.

## Fix

- Corrected `MINIMAX_API_COST` to accurate M2.1/VL-01 pricing
- Added separate `MINIMAX_M25_API_COST` for M2.5 and M2.5-Lightning (input: 0.30, output: 1.20, cacheRead: 0.03, cacheWrite: 0.375)
- Updated `buildMinimaxModel`/`buildMinimaxTextModel` to accept optional `cost` param
- Applied correct cost to each model variant in both provider configs

Fixes #17548

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Corrects MiniMax model pricing constants in `models-config.providers.ts` — the base `MINIMAX_API_COST` was ~75x too high and has been fixed to M2.1 pricing. A new `MINIMAX_M25_API_COST` constant is added for M2.5 models, and the builder functions now accept an optional `cost` parameter.

- The fix correctly updates `MINIMAX_API_COST` and adds per-model cost differentiation via optional `cost` param on `buildMinimaxModel`/`buildMinimaxTextModel`.
- **Issue:** The PR description says M2.5 Lightning should cost $2.40/1M output tokens (vs $1.20 for M2.5), but the code uses the same `MINIMAX_M25_API_COST` for both — no `MINIMAX_M25_LIGHTNING_API_COST` was defined despite being mentioned in the description.
- **Issue:** A duplicate `MINIMAX_API_COST` in `src/commands/onboard-auth.models.ts` still has the old inflated pricing (`input: 15, output: 60`). The onboarding flow uses this via `buildMinimaxApiModelDefinition()`, so costs will still be wrong for models configured through onboarding.

<h3>Confidence Score: 2/5</h3>

- This PR partially fixes the pricing issue but leaves a duplicate cost constant in the onboarding flow untouched and may undercharge M2.5 Lightning.
- Score of 2 reflects two concrete issues: (1) the duplicate MINIMAX_API_COST in onboard-auth.models.ts still has inflated pricing and will affect models configured through onboarding, and (2) M2.5 Lightning uses the same cost constant as M2.5 despite the PR description explicitly stating it should have double the output cost ($2.40 vs $1.20).
- Pay attention to `src/commands/onboard-auth.models.ts` which has a duplicate `MINIMAX_API_COST` with the old inflated values that was not updated in this PR.

<sub>Last reviewed commit: e867266</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->