### PR TITLE
fix: Display error messages instead of (no output) for non-Claude models

### DIFF
--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -172,12 +172,17 @@ export function createEventHandlers(context: EventHandlerContext) {
           : "";
 
       const finalText = streamAssembler.finalize(evt.runId, evt.message, state.showThinking);
+      // Never suppress messages that have an error - always show the error to the user
+      const hasError = stopReason === "error";
+      // If finalText is "(no output)" but we have an error, try to extract the error message directly
+      const displayText =
+        finalText === "(no output)" && hasError ? extractTextFromMessage(evt.message) : finalText;
       const suppressEmptyExternalPlaceholder =
-        finalText === "(no output)" && !isLocalRunId?.(evt.runId);
+        displayText === "(no output)" && !isLocalRunId?.(evt.runId) && !hasError;
       if (suppressEmptyExternalPlaceholder) {
         chatLog.dropAssistant(evt.runId);
       } else {
-        chatLog.finalizeAssistant(finalText, evt.runId);
+        chatLog.finalizeAssistant(displayText, evt.runId);
       }
       noteFinalizedRun(evt.runId);
       clearActiveRunIfMatch(evt.runId);


### PR DESCRIPTION
## Summary

When non-Claude models (Groq, MiniMax, Kimi) return errors, the error was being silently suppressed and users saw "(no output)" instead of the actual error message. This fix ensures that errors are always displayed to users.

## Changes

- Modified `src/tui/tui-event-handlers.ts` to:
  1. Never suppress messages that have `stopReason="error"`
  2. If `finalText` is "(no output)" but there is an error, directly extract and display the error message using `extractTextFromMessage()`

## Testing

- Existing tests in `src/tui/tui-event-handlers.test.ts` pass
- Existing tests in `src/tui/tui-formatters.test.ts` pass

Fixes openclaw/openclaw#17598

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a defensive fallback to ensure error messages from non-Claude models (Groq, MiniMax, Kimi) are always displayed to users instead of showing "(no output)". When `streamAssembler.finalize()` returns "(no output)" but the message has `stopReason="error"`, the code now directly extracts the error message using `extractTextFromMessage()` as a fallback. The suppression logic was also updated to never suppress messages with errors.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a focused defensive fix that adds a fallback mechanism for error display. The logic is sound: it only triggers when finalText is "(no output)" AND there's an error, then extracts the error message. The suppression logic correctly checks for errors to prevent hiding them. Existing tests pass, and the change doesn't modify any core logic paths.
- No files require special attention

<sub>Last reviewed commit: 92b0dfe</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->