### PR TITLE
fix: register poll action gate for Telegram adapter (#17528)

### DIFF
--- a/src/channels/plugins/actions/telegram.ts
+++ b/src/channels/plugins/actions/telegram.ts
@@ -12,6 +12,7 @@ import {
   listEnabledTelegramAccounts,
 } from "../../../telegram/accounts.js";
 import { isTelegramInlineButtonsEnabled } from "../../../telegram/inline-buttons.js";
+import { sendPollTelegram } from "../../../telegram/send.js";
 import type { ChannelMessageActionAdapter, ChannelMessageActionName } from "../types.js";
 
 const providerId = "telegram";
@@ -68,6 +69,9 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
     if (gate("sticker", false)) {
       actions.add("sticker");
       actions.add("sticker-search");
+    }
+    if (gate("polls")) {
+      actions.add("poll");
     }
     if (gate("createForumTopic")) {
       actions.add("topic-create");
@@ -221,6 +225,31 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
         },
         cfg,
       );
+    }
+
+    if (action === "poll") {
+      const to = readStringParam(params, "to", { required: true });
+      const question = readStringParam(params, "pollQuestion", { required: true });
+      const options = readStringArrayParam(params, "pollOption", { required: true }) ?? [];
+      const allowMultiselect = typeof params.pollMulti === "boolean" ? params.pollMulti : undefined;
+      const durationSeconds = readNumberParam(params, "pollDurationSeconds", {
+        integer: true,
+      });
+      const messageThreadId = readNumberParam(params, "threadId", { integer: true });
+      const result = await sendPollTelegram(
+        to,
+        {
+          question,
+          options,
+          maxSelections: allowMultiselect ? Math.max(2, options.length) : 1,
+          durationSeconds: durationSeconds ?? undefined,
+        },
+        {
+          accountId: accountId ?? undefined,
+          messageThreadId: messageThreadId ?? undefined,
+        },
+      );
+      return { ok: true, ...result };
     }
 
     throw new Error(`Action ${action} is not supported for provider ${providerId}.`);


### PR DESCRIPTION
## Problem

`sendPollTelegram` was added in #16209 but the Telegram action adapter's `listActions` did not include `gate('polls')` to register the poll action. This caused:

```
Error: Action poll is not supported for provider telegram
```

Discord polls work correctly because `discord.ts` has `gate('polls')` → `actions.add('poll')`.

## Fix

- Added `gate('polls')` check to `telegramMessageActions.listActions` (matching Discord pattern)
- Added `poll` action handler in `handleAction` that calls `sendPollTelegram` with proper params
- Supports question, options, multiselect, duration, and thread ID

Fixes #17528

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added missing poll action support for Telegram adapter by registering `gate('polls')` in `listActions` and implementing the `poll` action handler in `handleAction`. The handler correctly calls `sendPollTelegram` with proper parameter mapping, including the fixed `maxSelections` logic that matches the Discord pattern (`allowMultiselect ? Math.max(2, options.length) : 1`).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no issues found
- The implementation correctly follows the established Discord pattern, properly gates the action, maps all parameters correctly, and the previously identified `maxSelections` issue has been fixed. The changes are minimal, focused, and align with existing codebase patterns.
- No files require special attention

<sub>Last reviewed commit: 9cbb199</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->