### PR TITLE
fix: catch dialog accept/dismiss errors in armDialogViaPlaywright (#17499)

### DIFF
--- a/src/browser/pw-tools-core.downloads.ts
+++ b/src/browser/pw-tools-core.downloads.ts
@@ -1,7 +1,7 @@
-import type { Page } from "playwright-core";
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
+import type { Page } from "playwright-core";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import {
   ensurePageState,

--- a/src/browser/pw-tools-core.downloads.ts
+++ b/src/browser/pw-tools-core.downloads.ts
@@ -1,7 +1,7 @@
+import type { Page } from "playwright-core";
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
-import type { Page } from "playwright-core";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import {
   ensurePageState,
@@ -171,10 +171,14 @@ export async function armDialogViaPlaywright(opts: {
       if (state.armIdDialog !== armId) {
         return;
       }
-      if (opts.accept) {
-        await dialog.accept(opts.promptText);
-      } else {
-        await dialog.dismiss();
+      try {
+        if (opts.accept) {
+          await dialog.accept(opts.promptText);
+        } else {
+          await dialog.dismiss();
+        }
+      } catch {
+        // Dialog may have been dismissed or page navigated away; ignore.
       }
     })
     .catch(() => {


### PR DESCRIPTION
## Problem

`armDialogViaPlaywright` throws unhandled promise rejections when `dialog.accept()`/`dialog.dismiss()` fails because the dialog is already gone (page navigated, dialog auto-dismissed, etc.):

```
Error: Protocol error (Page.handleJavaScriptDialog): No dialog is showing
```

The existing `.catch()` only handles `waitForEvent` timeouts, not errors thrown inside the `.then()` callback.

## Fix

Wrap `dialog.accept()`/`dialog.dismiss()` in a try-catch to gracefully handle the case where the dialog is already gone by the time the listener fires.

Fixes #17499

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes unhandled promise rejections in `armDialogViaPlaywright` when `dialog.accept()`/`dialog.dismiss()` fails because the dialog is already gone (page navigated, dialog auto-dismissed, etc.).

- Wraps `dialog.accept()`/`dialog.dismiss()` in a try-catch inside the `.then()` callback, so errors thrown after `waitForEvent` resolves are gracefully swallowed
- The existing `.catch()` at the end of the chain only caught `waitForEvent` timeouts, not errors thrown inside `.then()` — since the promise is fire-and-forget (`void`), these would surface as unhandled rejections
- Consistent with the same pattern already used in `armFileUploadViaPlaywright` for its best-effort `page.keyboard.press("Escape")` call

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it only adds defensive error handling to a fire-and-forget code path with no behavioral changes to the happy path.
- The change is a 4-line try-catch addition in a single file. It addresses a real race condition that causes unhandled promise rejections. The fix follows an existing pattern already used in the same file. No logic changes, no new code paths, no risk of regression.
- No files require special attention.

<sub>Last reviewed commit: 04b5a9a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->