### PR TITLE
feat(openrouter): pass provider routing params via model params

### DIFF
--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -172,6 +172,37 @@ function createOpenRouterHeadersWrapper(baseStreamFn: StreamFn | undefined): Str
     });
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function createOpenRouterProviderRoutingWrapper(
+  baseStreamFn: StreamFn | undefined,
+  extraParams: Record<string, unknown> | undefined,
+): StreamFn {
+  const routing = extraParams?.provider;
+  if (!isRecord(routing)) {
+    return baseStreamFn ?? streamSimple;
+  }
+
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) => {
+    const originalOnPayload = options?.onPayload;
+    return underlying(model, context, {
+      ...options,
+      onPayload: (payload) => {
+        if (isRecord(payload)) {
+          payload.provider = {
+            ...routing,
+            ...(isRecord(payload.provider) ? payload.provider : {}),
+          };
+        }
+        originalOnPayload?.(payload);
+      },
+    });
+  };
+}
+
 /**
  * Apply extra params (like temperature) to an agent's streamFn.
  * Also adds OpenRouter app attribution headers when using the OpenRouter provider.
@@ -205,6 +236,11 @@ export function applyExtraParamsToAgent(
   }
 
   if (provider === "openrouter") {
+    if (isRecord(merged.provider)) {
+      log.debug(`applying OpenRouter provider routing for ${provider}/${modelId}`);
+      agent.streamFn = createOpenRouterProviderRoutingWrapper(agent.streamFn, merged);
+    }
+
     log.debug(`applying OpenRouter app attribution headers for ${provider}/${modelId}`);
     agent.streamFn = createOpenRouterHeadersWrapper(agent.streamFn);
   }


### PR DESCRIPTION
## Summary
Enable OpenRouter provider routing (e.g. `order`, `allow_fallbacks`) from `agents.defaults.models["openrouter/..."].params.provider` by injecting it into the outbound payload in the embedded runner.

## Changes
- Add OpenRouter payload wrapper that merges `params.provider` into outbound request payload.
- Keep existing OpenRouter attribution headers.
- Add e2e test for routing payload passthrough.

## Why
OpenClaw accepted arbitrary model params in config, but runtime only forwarded `temperature`/`maxTokens`; OpenRouter routing params were ignored.

## Notes
- Behavior change is scoped to `provider === "openrouter"`.
- Existing non-OpenRouter providers are untouched.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added OpenRouter provider routing support by passing `params.provider` from model config into the outbound payload. The implementation wraps the streamFn to inject routing parameters (like `order` and `allow_fallbacks`) from config into API requests, enabling fine-grained control over OpenRouter's provider selection.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-tested with comprehensive e2e tests covering the new functionality. The behavior change is scoped to only OpenRouter provider and doesn't affect other providers. The logic correctly merges config-based routing params with runtime payload options.
- No files require special attention

<sub>Last reviewed commit: 5d54a3f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->