### PR TITLE
fix: clear QMD manager cache on in-process restart (SIGUSR1)

### DIFF
--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -8,13 +8,13 @@ import {
   markGatewaySigusr1RestartHandled,
 } from "../../infra/restart.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { clearQmdManagerCache } from "../../memory/search-manager.js";
 import {
   getActiveTaskCount,
   resetAllLanes,
   waitForActiveTasks,
 } from "../../process/command-queue.js";
 import { createRestartIterationHook } from "../../process/restart-recovery.js";
-import { clearQmdManagerCache } from "../../memory/search-manager.js";
 
 const gatewayLog = createSubsystemLogger("gateway");
 

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -14,6 +14,7 @@ import {
   waitForActiveTasks,
 } from "../../process/command-queue.js";
 import { createRestartIterationHook } from "../../process/restart-recovery.js";
+import { clearQmdManagerCache } from "../../memory/search-manager.js";
 
 const gatewayLog = createSubsystemLogger("gateway");
 
@@ -145,6 +146,11 @@ export async function runGatewayLoop(params: {
       // coordinator level — rather than inside individual subsystem init
       // functions, to avoid surprising cross-cutting side effects.
       resetAllLanes();
+
+      // Clear the QMD memory manager cache so that config changes (scope,
+      // collections, command path, etc.) take effect immediately after an
+      // in-process restart without requiring a full process kill.
+      clearQmdManagerCache();
     });
 
     // Keep process alive; SIGUSR1 triggers an in-process restart (no supervisor required).

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -112,6 +112,19 @@ describe("buildGatewayReloadPlan", () => {
     const plan = buildGatewayReloadPlan(["unknownField"]);
     expect(plan.restartGateway).toBe(true);
   });
+
+  it("hot-reloads memory config changes without gateway restart", () => {
+    const plan = buildGatewayReloadPlan(["memory.qmd.command"]);
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.restartMemory).toBe(true);
+    expect(plan.hotReasons).toContain("memory.qmd.command");
+  });
+
+  it("hot-reloads memory backend changes without gateway restart", () => {
+    const plan = buildGatewayReloadPlan(["memory.backend"]);
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.restartMemory).toBe(true);
+  });
 });
 
 describe("resolveGatewayReloadSettings", () => {

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -21,6 +21,7 @@ export type GatewayReloadPlan = {
   restartBrowserControl: boolean;
   restartCron: boolean;
   restartHeartbeat: boolean;
+  restartMemory: boolean;
   restartChannels: Set<ChannelKind>;
   noopPaths: string[];
 };
@@ -37,6 +38,7 @@ type ReloadAction =
   | "restart-browser-control"
   | "restart-cron"
   | "restart-heartbeat"
+  | "restart-memory"
   | `restart-channel:${ChannelId}`;
 
 const DEFAULT_RELOAD_SETTINGS: GatewayReloadSettings = {
@@ -61,6 +63,7 @@ const BASE_RELOAD_RULES: ReloadRule[] = [
     kind: "hot",
     actions: ["restart-browser-control"],
   },
+  { prefix: "memory", kind: "hot", actions: ["restart-memory"] },
 ];
 
 const BASE_RELOAD_RULES_TAIL: ReloadRule[] = [
@@ -182,6 +185,7 @@ export function buildGatewayReloadPlan(changedPaths: string[]): GatewayReloadPla
     restartBrowserControl: false,
     restartCron: false,
     restartHeartbeat: false,
+    restartMemory: false,
     restartChannels: new Set(),
     noopPaths: [],
   };
@@ -207,6 +211,9 @@ export function buildGatewayReloadPlan(changedPaths: string[]): GatewayReloadPla
         break;
       case "restart-heartbeat":
         plan.restartHeartbeat = true;
+        break;
+      case "restart-memory":
+        plan.restartMemory = true;
         break;
       default:
         break;

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -13,6 +13,7 @@ import {
   emitGatewayRestart,
   setGatewaySigusr1RestartPolicy,
 } from "../infra/restart.js";
+import { clearQmdManagerCache } from "../memory/search-manager.js";
 import { setCommandLaneConcurrency, getTotalQueueSize } from "../process/command-queue.js";
 import { CommandLane } from "../process/lanes.js";
 import { resolveHooksConfig } from "./hooks.js";
@@ -61,6 +62,10 @@ export function createGatewayReloadHandlers(params: {
 
     if (plan.restartHeartbeat) {
       nextState.heartbeatRunner.updateConfig(nextConfig);
+    }
+
+    if (plan.restartMemory) {
+      clearQmdManagerCache();
     }
 
     resetDirectoryCache();

--- a/src/memory/search-manager.ts
+++ b/src/memory/search-manager.ts
@@ -11,6 +11,18 @@ import { resolveMemoryBackendConfig } from "./backend-config.js";
 const log = createSubsystemLogger("memory");
 const QMD_MANAGER_CACHE = new Map<string, MemorySearchManager>();
 
+/**
+ * Clear the QMD manager cache.  Should be called when the gateway config is
+ * reloaded (e.g. via SIGUSR1) so that scope, collection, and other config
+ * changes take effect without requiring a full process restart.
+ */
+export function clearQmdManagerCache(): void {
+  for (const [key, manager] of QMD_MANAGER_CACHE) {
+    manager.close?.().catch(() => {});
+    QMD_MANAGER_CACHE.delete(key);
+  }
+}
+
 export type MemorySearchManagerResult = {
   manager: MemorySearchManager | null;
   error?: string;


### PR DESCRIPTION
## Problem

The `QMD_MANAGER_CACHE` (module-level `Map` in `search-manager.ts`) persists across in-process restarts triggered by SIGUSR1. Config changes to QMD scope, collections, command path, or other memory settings do not take effect until a full process kill (`kill -9`).

### Reproduction Steps

1. Set `memory.qmd.scope.default: "deny"` (the default)
2. Start the gateway
3. Verify `memory_search` is denied in guild channels (expected)
4. Patch config: `memory.qmd.scope.default: "allow"`
5. Gateway restarts via SIGUSR1
6. `memory_search` is **still denied** in guild channels (bug)
7. Only `kill -9` + restart makes the scope change take effect

### Root Cause

`getMemorySearchManager()` caches managers in a module-level `Map` keyed by `agentId + serialized config`. After SIGUSR1, the gateway reloads config, but the old cached manager (created with the pre-restart config) is still returned for existing sessions because the module-level Map survives the in-process restart.

## Fix

- Export `clearQmdManagerCache()` from `search-manager.ts` that properly closes all cached managers and clears the Map
- Call it from the restart iteration hook in `run-loop.ts`, alongside the existing `resetAllLanes()` call

This ensures QMD scope, collection, and command changes take effect immediately after `config.patch` / `config.apply` restarts.

## Changes

- `src/memory/search-manager.ts`: Add `clearQmdManagerCache()` export
- `src/cli/gateway-cli/run-loop.ts`: Import and call on restart iteration

## Testing

Manually verified on production instance:
1. Changed `scope.default` from `deny` → `allow`
2. Before fix: required `kill -9` to take effect
3. After fix: `config.patch` restart applies immediately

Related: #15093 (QMD reliability improvements)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where the module-level `QMD_MANAGER_CACHE` in `search-manager.ts` persists across in-process restarts (SIGUSR1), causing memory config changes (scope, collections, command path) to not take effect until a full `kill -9`.

The fix introduces `clearQmdManagerCache()` and invokes it from two restart paths:
- **SIGUSR1 in-process restart** (`run-loop.ts`): called in the restart iteration hook alongside `resetAllLanes()`
- **Hot-reload via config file watcher** (`server-reload-handlers.ts`): called when `plan.restartMemory` is true, enabled by a new `"memory"` prefix hot-reload rule in `config-reload.ts`

The implementation follows the established patterns for other subsystem restarts (cron, heartbeat, browser-control). New tests verify that `memory.*` config changes produce a hot-reload plan rather than requiring a full gateway restart.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it adds a targeted cache-clearing mechanism with no impact on the happy path.
- The changes are minimal and well-scoped: a new export function that clears a module-level Map, integrated into two existing restart paths following established patterns. The code is correct (Map delete-during-iteration is spec-safe in JS, fire-and-forget close is appropriate for restart paths). Tests cover the config-reload plan logic. No regressions are likely since clearQmdManagerCache only runs during restart/reload events and the existing getMemorySearchManager logic is unchanged.
- No files require special attention.

<sub>Last reviewed commit: 00ce621</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->