### PR TITLE
fix: skip embedding provider check in doctor when QMD backend is configured (#17263)

### DIFF
--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -1,9 +1,9 @@
 import fsSync from "node:fs";
-import type { OpenClawConfig } from "../config/config.js";
 import { resolveAgentDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { resolveMemorySearchConfig } from "../agents/memory-search.js";
 import { resolveApiKeyForProvider } from "../agents/model-auth.js";
 import { formatCliCommand } from "../cli/command-format.js";
+import type { OpenClawConfig } from "../config/config.js";
 import { note } from "../terminal/note.js";
 import { resolveUserPath } from "../utils.js";
 


### PR DESCRIPTION
## Problem

`openclaw doctor` falsely warns "Memory search is enabled but no embedding provider is configured" when `memory.backend` is set to `qmd`. QMD handles embeddings internally using its own model (e.g. embeddinggemma), so no OpenClaw-managed embedding provider (OpenAI/Gemini/Voyage/local modelPath) is needed.

## Fix

Skip the embedding provider check entirely when `cfg.memory?.backend === "qmd"`. QMD users don't need OpenClaw to manage embeddings.

## Checklist

- [x] Local validation: `oxlint` (type-aware) + `oxfmt` passed
- [x] Focused scope: Single check added to `doctor-memory-search.ts`
- [x] AI-assistance: AI-assisted for codebase exploration; manually verified

Fixes #17263

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a false warning in `openclaw doctor` where users with `memory.backend` set to `"qmd"` were incorrectly told "Memory search is enabled but no embedding provider is configured." Since QMD handles embeddings internally (e.g., via embeddinggemma), no OpenClaw-managed embedding provider is needed.

- Adds `cfg.memory?.backend === "qmd"` early-return check in the `provider === "local"` branch and the `provider === "auto"` fallback resolution in `doctor-memory-search.ts`
- No test coverage was added for the new QMD backend check; the existing test file uses `cfg = {} as OpenClawConfig` with no `memory` property, so the QMD paths are untested
- The explicit remote provider branch (`"openai"` / `"gemini"` / `"voyage"`, lines 48-66) is not guarded — QMD users who also explicitly set a remote embedding provider will still see API key warnings, though this is a less likely configuration

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk — it only adds early-return guards to a diagnostic command.
- The change is small, well-scoped, and logically correct for the two most common provider configurations (local and auto). It's a config-only diagnostic path with no side effects on runtime behavior. Deducting one point for the absence of test coverage for the new QMD paths.
- No files require special attention — the single changed file is a diagnostic helper with no runtime impact.

<sub>Last reviewed commit: 007c10e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->