### PR TITLE
feat(skills): add cross-platform install fallback for non-brew environments

### DIFF
--- a/src/agents/skills-status.ts
+++ b/src/agents/skills-status.ts
@@ -74,7 +74,9 @@ function selectPreferredInstallSpec(
   const goSpec = findKind("go");
   const uvSpec = findKind("uv");
 
-  if (prefs.preferBrew && hasBinary("brew") && brewSpec) {
+  const brewAvailable = hasBinary("brew");
+
+  if (prefs.preferBrew && brewAvailable && brewSpec) {
     return brewSpec;
   }
   if (uvSpec) {
@@ -83,11 +85,24 @@ function selectPreferredInstallSpec(
   if (nodeSpec) {
     return nodeSpec;
   }
-  if (brewSpec) {
+  // Only prefer brew when it is actually installed; otherwise skip to
+  // alternatives so Linux/Docker environments without brew get a working
+  // install option instead of a guaranteed failure.
+  if (brewSpec && brewAvailable) {
     return brewSpec;
   }
   if (goSpec) {
     return goSpec;
+  }
+  // Prefer download over an unavailable brew spec.
+  const downloadSpec = findKind("download");
+  if (downloadSpec) {
+    return downloadSpec;
+  }
+  // Last resort: return brew spec even without brew so the caller can
+  // surface a descriptive error rather than "no installer found".
+  if (brewSpec) {
+    return brewSpec;
   }
   return indexed[0];
 }

--- a/src/agents/skills/types.ts
+++ b/src/agents/skills/types.ts
@@ -2,7 +2,7 @@ import type { Skill } from "@mariozechner/pi-coding-agent";
 
 export type SkillInstallSpec = {
   id?: string;
-  kind: "brew" | "node" | "go" | "uv" | "download";
+  kind: "brew" | "node" | "go" | "uv" | "download" | "apt" | "dnf" | "pacman" | "apk";
   label?: string;
   bins?: string[];
   os?: string[];

--- a/src/infra/package-managers.test.ts
+++ b/src/infra/package-managers.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import {
+  detectLinuxDistroFamily,
+  getAvailablePackageManagers,
+  getNativePackageManager,
+  hasPackageManager,
+} from "./package-managers.js";
+
+describe("package-managers", () => {
+  describe("detectLinuxDistroFamily", () => {
+    it("returns unknown on non-Linux platforms", () => {
+      if (process.platform !== "linux") {
+        expect(detectLinuxDistroFamily()).toBe("unknown");
+      }
+    });
+
+    it("detects Linux distro family on Linux", () => {
+      if (process.platform === "linux") {
+        const family = detectLinuxDistroFamily();
+        expect(family).toMatch(/^(debian|rhel|arch|alpine|unknown)$/);
+      }
+    });
+  });
+
+  describe("hasPackageManager", () => {
+    it("checks for package manager availability", () => {
+      // These should always return boolean
+      expect(typeof hasPackageManager("brew")).toBe("boolean");
+      expect(typeof hasPackageManager("apt")).toBe("boolean");
+      expect(typeof hasPackageManager("npm")).toBe("boolean");
+    });
+
+    it("returns false for non-existent package managers on current platform", () => {
+      // On most systems, at least one of these won't be available
+      const results = [
+        hasPackageManager("pacman"),
+        hasPackageManager("apk"),
+        hasPackageManager("dnf"),
+      ];
+      // At least one should be false (unless running on a very unusual system)
+      expect(results.some((r) => !r)).toBe(true);
+    });
+  });
+
+  describe("getNativePackageManager", () => {
+    it("returns appropriate package manager for current platform", () => {
+      const native = getNativePackageManager();
+
+      if (process.platform === "darwin") {
+        // On macOS, should return brew if available, otherwise undefined
+        if (native) {
+          expect(native).toBe("brew");
+        }
+      } else if (process.platform === "linux") {
+        // On Linux, should return one of the native package managers or undefined
+        if (native) {
+          expect(["apt", "dnf", "pacman", "apk"]).toContain(native);
+        }
+      }
+    });
+  });
+
+  describe("getAvailablePackageManagers", () => {
+    it("returns an array of available package managers", () => {
+      const available = getAvailablePackageManagers();
+      expect(Array.isArray(available)).toBe(true);
+
+      // Should contain only valid package manager names
+      const validPMs = [
+        "brew",
+        "apt",
+        "dnf",
+        "pacman",
+        "apk",
+        "npm",
+        "pnpm",
+        "yarn",
+        "bun",
+        "go",
+        "uv",
+      ];
+      for (const pm of available) {
+        expect(validPMs).toContain(pm);
+      }
+    });
+
+    it("returns package managers in priority order", () => {
+      const available = getAvailablePackageManagers();
+
+      // On macOS, brew should come first if available
+      if (process.platform === "darwin" && available.includes("brew")) {
+        expect(available[0]).toBe("brew");
+      }
+
+      // On Linux, native PM should come before brew
+      if (process.platform === "linux") {
+        const nativeIndex = available.findIndex((pm) =>
+          ["apt", "dnf", "pacman", "apk"].includes(pm),
+        );
+        const brewIndex = available.indexOf("brew");
+
+        if (nativeIndex !== -1 && brewIndex !== -1) {
+          expect(nativeIndex).toBeLessThan(brewIndex);
+        }
+      }
+    });
+  });
+});

--- a/src/infra/package-managers.ts
+++ b/src/infra/package-managers.ts
@@ -1,0 +1,190 @@
+import fs from "node:fs";
+import { hasBinary } from "../shared/config-eval.js";
+
+export type PackageManager =
+  | "brew"
+  | "apt"
+  | "dnf"
+  | "pacman"
+  | "apk"
+  | "npm"
+  | "pnpm"
+  | "yarn"
+  | "bun"
+  | "go"
+  | "uv";
+
+export type LinuxDistroFamily = "debian" | "rhel" | "arch" | "alpine" | "unknown";
+
+/**
+ * Detect the Linux distribution family by reading /etc/os-release.
+ */
+export function detectLinuxDistroFamily(): LinuxDistroFamily {
+  if (process.platform !== "linux") {
+    return "unknown";
+  }
+
+  try {
+    const osRelease = fs.readFileSync("/etc/os-release", "utf-8");
+    const lines = osRelease.split("\n");
+    let id = "";
+    let idLike = "";
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (trimmed.startsWith("ID=")) {
+        id = trimmed.slice(3).replace(/"/g, "").toLowerCase();
+      } else if (trimmed.startsWith("ID_LIKE=")) {
+        idLike = trimmed.slice(8).replace(/"/g, "").toLowerCase();
+      }
+    }
+
+    // Check ID_LIKE first (more specific)
+    if (idLike.includes("debian") || idLike.includes("ubuntu")) {
+      return "debian";
+    }
+    if (idLike.includes("rhel") || idLike.includes("fedora") || idLike.includes("centos")) {
+      return "rhel";
+    }
+    if (idLike.includes("arch")) {
+      return "arch";
+    }
+    if (idLike.includes("alpine")) {
+      return "alpine";
+    }
+
+    // Fallback to ID
+    if (id === "debian" || id === "ubuntu") {
+      return "debian";
+    }
+    if (id === "fedora" || id === "rhel" || id === "centos" || id === "rocky" || id === "alma") {
+      return "rhel";
+    }
+    if (id === "arch" || id === "manjaro") {
+      return "arch";
+    }
+    if (id === "alpine") {
+      return "alpine";
+    }
+
+    return "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+/**
+ * Check if a specific package manager is available on the system.
+ */
+export function hasPackageManager(pm: PackageManager): boolean {
+  switch (pm) {
+    case "brew":
+      return hasBinary("brew");
+    case "apt":
+      return hasBinary("apt-get");
+    case "dnf":
+      return hasBinary("dnf");
+    case "pacman":
+      return hasBinary("pacman");
+    case "apk":
+      return hasBinary("apk");
+    case "npm":
+      return hasBinary("npm");
+    case "pnpm":
+      return hasBinary("pnpm");
+    case "yarn":
+      return hasBinary("yarn");
+    case "bun":
+      return hasBinary("bun");
+    case "go":
+      return hasBinary("go");
+    case "uv":
+      return hasBinary("uv");
+    default:
+      return false;
+  }
+}
+
+/**
+ * Get the native package manager for the current platform.
+ * Returns undefined if not on a supported Linux distro or macOS.
+ */
+export function getNativePackageManager(): PackageManager | undefined {
+  const platform = process.platform;
+
+  if (platform === "darwin") {
+    return hasPackageManager("brew") ? "brew" : undefined;
+  }
+
+  if (platform === "linux") {
+    const distro = detectLinuxDistroFamily();
+    switch (distro) {
+      case "debian":
+        return hasPackageManager("apt") ? "apt" : undefined;
+      case "rhel":
+        return hasPackageManager("dnf") ? "dnf" : undefined;
+      case "arch":
+        return hasPackageManager("pacman") ? "pacman" : undefined;
+      case "alpine":
+        return hasPackageManager("apk") ? "apk" : undefined;
+      default:
+        return undefined;
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Get available package managers in priority order for the current platform.
+ * This helps determine the install fallback chain.
+ */
+export function getAvailablePackageManagers(): PackageManager[] {
+  const available: PackageManager[] = [];
+  const platform = process.platform;
+
+  if (platform === "darwin") {
+    // macOS: prefer brew
+    if (hasPackageManager("brew")) {
+      available.push("brew");
+    }
+  } else if (platform === "linux") {
+    // Linux: prefer native package manager, then brew (Linuxbrew)
+    const native = getNativePackageManager();
+    if (native) {
+      available.push(native);
+    }
+    if (hasPackageManager("brew")) {
+      available.push("brew");
+    }
+  } else {
+    // Windows or other: check for brew
+    if (hasPackageManager("brew")) {
+      available.push("brew");
+    }
+  }
+
+  // Add language-specific package managers
+  if (hasPackageManager("uv")) {
+    available.push("uv");
+  }
+  if (hasPackageManager("go")) {
+    available.push("go");
+  }
+
+  // Add Node package managers
+  if (hasPackageManager("pnpm")) {
+    available.push("pnpm");
+  }
+  if (hasPackageManager("yarn")) {
+    available.push("yarn");
+  }
+  if (hasPackageManager("bun")) {
+    available.push("bun");
+  }
+  if (hasPackageManager("npm")) {
+    available.push("npm");
+  }
+
+  return available;
+}


### PR DESCRIPTION
## Summary

- **Problem:** Skill installation fails on Linux/Docker with "brew not installed" because the installer hard-depends on Homebrew, which isn't available on most Linux systems.
- **Why it matters:** OpenClaw claims "Any OS. Any Platform." but skills can't install on Linux — the second most common server/dev platform.
- **What changed:** Install preference selection now skips brew when it's not available, falling back to alternative install methods (go, node, uv, download). Error messages are now platform-aware with actionable guidance. Added `uv` auto-install via curl and `go` auto-install via apt as fallbacks. Added platform detection utilities for future native PM support.
- **What did NOT change (scope boundary):** Individual SKILL.md files are untouched. macOS behavior is identical — brew is still preferred when available.

## Change Type

- [x] Bug fix
- [x] Feature

## Scope

- [x] Skills / tool execution

## Linked Issues

- Closes #9420
- Related #3987, #2478, #6654

## User-visible / Behavior Changes

- Skills with multiple install methods (e.g. brew + go) now auto-select a working method on Linux instead of failing
- Error message when brew is missing now includes platform-specific install guidance
- `uv` dependency auto-installs via official curl installer when brew is unavailable
- `go` dependency auto-installs via `apt-get` on Debian/Ubuntu when brew is unavailable

## Security Impact

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `Yes` — curl to `https://astral.sh/uv/install.sh` (official uv installer) when uv is needed but unavailable.
- Command/tool execution surface changed? `Yes` — adds `sudo apt-get install -y golang-go` fallback for go install. Only on Debian/Ubuntu when go is missing.
- Risk + mitigation: The curl-pipe-sh pattern for uv install uses the official astral.sh endpoint. The apt fallback uses standard system packages.

## Testing

- **Platform:** Ubuntu 24.04.4 LTS (x86_64), no Homebrew
- **Build:** ✅ clean
- **Format:** ✅ clean  
- **Tests:** 778/780 test files pass (2 pre-existing failures in server-runtime-config.test.ts — unrelated). 6648 passed, 1 skipped.
- New `package-managers.test.ts` (108 lines) passes on Linux and is macOS-aware.

## Compatibility

- Backward compatible: Yes
- Config/env changes: None
- Migration needed: None

## Files Changed

| File | Changes |
|---|---|
| `src/agents/skills-status.ts` | Skip brew when unavailable; add download fallback |
| `src/agents/skills-install.ts` | Platform-aware errors; uv/go auto-install fallbacks |
| `src/agents/skills/types.ts` | Extended kind union with apt/dnf/pacman/apk |
| `src/infra/package-managers.ts` | **New** — platform detection utilities |
| `src/infra/package-managers.test.ts` | **New** — test suite |

---
AI-assisted: Yes (Claude). Fully tested on target platform (Ubuntu 24.04, no brew).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds cross-platform fallback support for skill installation when Homebrew is unavailable. The changes enable Linux/Docker environments to auto-install `uv` (via curl) and `go` (via apt-get) instead of failing with "brew not installed" errors.

**Key Changes:**
- `skills-status.ts`: Skip brew in install method selection when unavailable, prefer download/go fallbacks
- `skills-install.ts`: Add platform-aware error messages, `uv` curl installer fallback, `go` apt-get fallback
- `skills/types.ts`: Extended install spec types to include apt/dnf/pacman/apk (not yet used)
- `package-managers.ts`: New module with platform detection utilities (not yet integrated)

**Critical Issues Found:**
1. **Security: curl-pipe-sh pattern** - Line 621 executes remote script without verification, contradicting the project's own security tests that flag this pattern
2. **Sudo reliability** - Line 688 runs `sudo apt-get` without checking sudo availability or handling password prompts

**Scope Note:**
The new `package-managers.ts` module is tested but not yet used in the install flow - it appears to be infrastructure for future native package manager support.

<h3>Confidence Score: 2/5</h3>

- This PR has critical security concerns that must be addressed before merge
- Score reflects two critical security/reliability issues: (1) curl-pipe-sh remote code execution without verification contradicts the project's own security tests, and (2) sudo apt-get may hang on password prompts or fail without proper error handling. The functional changes are sound and well-tested, but the security posture needs improvement.
- Pay close attention to `src/agents/skills-install.ts` lines 621 and 688 for security hardening

<sub>Last reviewed commit: fdf7998</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->