### PR TITLE
fix: stop LLM retry loop when browser control service is unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ Docs: https://docs.openclaw.ai
 - Web Fetch/Security: cap downloaded response body size before HTML parsing to prevent memory exhaustion from oversized or deeply nested pages. Thanks @xuemian168.
 - Skills/Security: restrict `download` installer `targetDir` to the per-skill tools directory to prevent arbitrary file writes. Thanks @Adam55A-code.
 - Agents: return an explicit timeout error reply when an embedded run times out before producing any payloads, preventing silent dropped turns during slow cache-refresh transitions. (#16659) Thanks @liaosvcaf and @vignesh07.
-- Browser/Agents: when browser control service is unavailable, return explicit non-retry guidance (instead of "try again") so models do not loop on repeated browser tool calls until timeout. (#17673) Thanks @tag-assistant.
+- Browser/Agents: when browser control service is unavailable, return explicit non-retry guidance (instead of "try again") so models do not loop on repeated browser tool calls until timeout. (#17673) Thanks @austenstone.
 - Agents/OpenAI: force `store=true` for direct OpenAI Responses/Codex runs to preserve multi-turn server-side conversation state, while leaving proxy/non-OpenAI endpoints unchanged. (#16803) Thanks @mark9232 and @vignesh07.
 - Agents/Security: sanitize workspace paths before embedding into LLM prompts (strip Unicode control/format chars) to prevent instruction injection via malicious directory names. Thanks @aether-ai-agent.
 - Agents/Context: apply configured model `contextWindow` overrides after provider discovery so `lookupContextTokens()` honors operator config values (including discovery-failure paths). (#17404) Thanks @michaelbship and @vignesh07.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Docs: https://docs.openclaw.ai
 - Web Fetch/Security: cap downloaded response body size before HTML parsing to prevent memory exhaustion from oversized or deeply nested pages. Thanks @xuemian168.
 - Skills/Security: restrict `download` installer `targetDir` to the per-skill tools directory to prevent arbitrary file writes. Thanks @Adam55A-code.
 - Agents: return an explicit timeout error reply when an embedded run times out before producing any payloads, preventing silent dropped turns during slow cache-refresh transitions. (#16659) Thanks @liaosvcaf and @vignesh07.
+- Browser/Agents: when browser control service is unavailable, return explicit non-retry guidance (instead of "try again") so models do not loop on repeated browser tool calls until timeout. (#17673) Thanks @tag-assistant.
 - Agents/OpenAI: force `store=true` for direct OpenAI Responses/Codex runs to preserve multi-turn server-side conversation state, while leaving proxy/non-OpenAI endpoints unchanged. (#16803) Thanks @mark9232 and @vignesh07.
 - Agents/Security: sanitize workspace paths before embedding into LLM prompts (strip Unicode control/format chars) to prevent instruction injection via malicious directory names. Thanks @aether-ai-agent.
 - Agents/Context: apply configured model `contextWindow` overrides after provider discovery so `lookupContextTokens()` honors operator config values (including discovery-failure paths). (#17404) Thanks @michaelbship and @vignesh07.

--- a/src/browser/client-fetch.ts
+++ b/src/browser/client-fetch.ts
@@ -90,9 +90,16 @@ function withLoopbackBrowserAuth(
 }
 
 function enhanceBrowserFetchError(url: string, err: unknown, timeoutMs: number): Error {
-  const hint = isAbsoluteHttp(url)
-    ? "If this is a sandboxed session, ensure the sandbox browser is running and try again."
-    : `Start (or restart) the OpenClaw gateway (OpenClaw.app menubar, or \`${formatCliCommand("openclaw gateway")}\`) and try again.`;
+  const isLocal = !isAbsoluteHttp(url);
+  // Human-facing hint for logs/diagnostics.
+  const operatorHint = isLocal
+    ? `Restart the OpenClaw gateway (OpenClaw.app menubar, or \`${formatCliCommand("openclaw gateway")}\`).`
+    : "If this is a sandboxed session, ensure the sandbox browser is running.";
+  // Model-facing suffix: explicitly tell the LLM NOT to retry.
+  // Without this, models see "try again" and enter an infinite tool-call loop.
+  const modelHint =
+    "Do NOT retry the browser tool — it will keep failing. " +
+    "Use an alternative approach or inform the user that the browser is currently unavailable.";
   const msg = String(err);
   const msgLower = msg.toLowerCase();
   const looksLikeTimeout =
@@ -103,10 +110,12 @@ function enhanceBrowserFetchError(url: string, err: unknown, timeoutMs: number):
     msgLower.includes("aborterror");
   if (looksLikeTimeout) {
     return new Error(
-      `Can't reach the OpenClaw browser control service (timed out after ${timeoutMs}ms). ${hint}`,
+      `Can't reach the OpenClaw browser control service (timed out after ${timeoutMs}ms). ${operatorHint} ${modelHint}`,
     );
   }
-  return new Error(`Can't reach the OpenClaw browser control service. ${hint} (${msg})`);
+  return new Error(
+    `Can't reach the OpenClaw browser control service. ${operatorHint} ${modelHint} (${msg})`,
+  );
 }
 
 async function fetchHttpJson<T>(


### PR DESCRIPTION
## Summary

- **Problem:** When the browser control service is unreachable (e.g. after a gateway restart), the error message tells the LLM to "try again." The model obeys, calls the browser tool again, it fails again, and this loops until the agent timeout (5-10 min) kills it. Users see no response.
- **Why it matters:** A single browser service interruption silently poisons the session — every subsequent message triggers the same infinite tool-call loop, burning through the full agent timeout with no reply.
- **What changed:** Replaced the "try again" language in browser fetch errors with an explicit instruction telling the model NOT to retry and to use alternative approaches instead.

## Change Type

- [x] Bug fix

## Scope

- [x] Tools

## Root Cause

`src/browser/client-fetch.ts` `enhanceBrowserFetchError()` generated error messages containing "try again" — language that LLMs interpret as an instruction to retry the tool call. Combined with pi-agent-core's agent loop having no tool-call iteration cap (`while (true)`), this creates an unbounded retry loop.

## Fix

The error message now includes:

> Do NOT retry the browser tool — it will keep failing. Use an alternative approach or inform the user that the browser is currently unavailable.

Operator-facing hints (restart gateway, check sandbox) are preserved for diagnostics.

## User-visible / Behavior Changes

- When the browser service is down, the agent will inform the user instead of silently timing out
- Existing sessions with poisoned browser errors in context will recover on the next turn (new error text breaks the retry pattern)

## Security Impact

- No new permissions, secrets, network calls, or execution surface changes

## Evidence

Diagnosed from production logs: three consecutive 300s timeouts on the same session, all caused by browser tool then "Can't reach... try again" then model retries then timeout.

## Compatibility

- Backward compatible
- No config changes needed

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Modified error messages in `enhanceBrowserFetchError()` to prevent LLM retry loops when the browser control service is unreachable. The fix replaces "try again" language with explicit instructions telling the model NOT to retry the browser tool and to use alternative approaches instead. This prevents unbounded tool-call loops that previously caused 5-10 minute agent timeouts with no user response.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - fixes critical user-facing issue with no regression risk
- The change is narrowly scoped to error message text only, with no logic changes. It directly addresses a production issue where LLMs interpret "try again" as an instruction to retry, causing timeout loops. The new message explicitly instructs the model NOT to retry while preserving operator-facing diagnostic hints. Backward compatible and immediately improves poisoned sessions.
- No files require special attention

<sub>Last reviewed commit: 7f47d98</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->