### PR TITLE
fix(telegram): send reasoning before main text in stream mode

### DIFF
--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -291,6 +291,31 @@ export const dispatchTelegramMessage = async ({
     replyQuoteText,
   };
 
+  // Buffer reasoning text so it can be sent before the first block/final reply.
+  let reasoningBuffer = "";
+  let reasoningFlushed = false;
+  const flushReasoning = async () => {
+    if (reasoningFlushed || !reasoningBuffer) {
+      return;
+    }
+    reasoningFlushed = true;
+    await deliverReplies({
+      replies: [{ text: reasoningBuffer }],
+      chatId: String(chatId),
+      token: opts.token,
+      runtime,
+      bot,
+      mediaLocalRoots,
+      replyToMode,
+      textLimit,
+      thread: threadSpec,
+      tableMode,
+      chunkMode,
+      linkPreview: telegramCfg.linkPreview,
+      replyQuoteText,
+    });
+  };
+
   let queuedFinal = false;
   try {
     ({ queuedFinal } = await dispatchReplyWithBufferedBlockDispatcher({
@@ -299,6 +324,9 @@ export const dispatchTelegramMessage = async ({
       dispatcherOptions: {
         ...prefixOptions,
         deliver: async (payload, info) => {
+          // Flush buffered reasoning before the first block or final reply,
+          // so thinking content appears before the main text in Telegram.
+          await flushReasoning();
           if (info.kind === "final") {
             await flushDraft();
             const hasMedia = Boolean(payload.mediaUrl) || (payload.mediaUrls?.length ?? 0) > 0;
@@ -450,6 +478,11 @@ export const dispatchTelegramMessage = async ({
               draftChunker?.reset();
             }
           : undefined,
+        onReasoningStream: (payload) => {
+          if (payload.text) {
+            reasoningBuffer = payload.text;
+          }
+        },
         onModelSelected,
       },
     }));


### PR DESCRIPTION
## Summary
- Telegram's `/reasoning stream` mode was not displaying thinking content because the `onReasoningStream` callback was never provided
- When set to `/reasoning on`, thinking appeared **after** the main text due to block streaming delivering text in real-time while reasoning was appended post-run
- Added `onReasoningStream` callback to Telegram's reply options that buffers reasoning text and flushes it before the first block/final reply delivery

## How it works
1. `onReasoningStream` callback accumulates reasoning text into a buffer during the model's thinking phase
2. Before the first `deliver()` call (block or final), `flushReasoning()` sends the buffered reasoning as a separate Telegram message
3. In `stream` mode, the core layer automatically suppresses block streaming when `onReasoningStream` is present, so the main text arrives as a final payload after reasoning

## Test plan
- [x] Set `/reasoning stream` in Telegram DM
- [x] Send a message and verify thinking content appears **before** the main text reply
- [x] Verify `/reasoning off` still works (no reasoning displayed)
- [x] Verify `/reasoning on` still works (reasoning displayed after text, existing behavior)
- [x] TypeScript compilation passes with no new errors
- [x] Lint passes with 0 warnings/errors

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed `/reasoning stream` mode in Telegram by adding `onReasoningStream` callback that buffers and flushes reasoning text before the main reply.

- Added `reasoningBuffer` to accumulate thinking text as it streams from the model
- Added `flushReasoning()` function that sends buffered reasoning as a separate message before the first block/final reply
- Hook `flushReasoning()` is called at the start of the `deliver()` callback to ensure ordering
- The core layer automatically suppresses block streaming when `onReasoningStream` is present (per `agent-runner-execution.ts:105-107`), ensuring the main text arrives as a final payload after reasoning

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no issues found
- The implementation correctly integrates with the existing reasoning stream infrastructure. The buffer correctly stores cumulative reasoning text (not deltas), the flush guard prevents duplicates, and the integration point in the deliver callback ensures proper ordering. The approach aligns with the core layer's behavior of suppressing block streaming when onReasoningStream is present.
- No files require special attention

<sub>Last reviewed commit: e337497</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->