### PR TITLE
fix(memory-lancedb): add gemini-embedding-001 and baseUrl support

### DIFF
--- a/extensions/memory-lancedb/config.ts
+++ b/extensions/memory-lancedb/config.ts
@@ -7,6 +7,7 @@ export type MemoryConfig = {
     provider: "openai";
     model?: string;
     apiKey: string;
+    baseUrl?: string;
   };
   dbPath?: string;
   autoCapture?: boolean;
@@ -51,6 +52,7 @@ const DEFAULT_DB_PATH = resolveDefaultDbPath();
 const EMBEDDING_DIMENSIONS: Record<string, number> = {
   "text-embedding-3-small": 1536,
   "text-embedding-3-large": 3072,
+  "gemini-embedding-001": 3072,
 };
 
 function assertAllowedKeys(value: Record<string, unknown>, allowed: string[], label: string) {
@@ -101,7 +103,7 @@ export const memoryConfigSchema = {
     if (!embedding || typeof embedding.apiKey !== "string") {
       throw new Error("embedding.apiKey is required");
     }
-    assertAllowedKeys(embedding, ["apiKey", "model"], "embedding config");
+    assertAllowedKeys(embedding, ["apiKey", "model", "baseUrl"], "embedding config");
 
     const model = resolveEmbeddingModel(embedding);
 
@@ -119,6 +121,8 @@ export const memoryConfigSchema = {
         provider: "openai",
         model,
         apiKey: resolveEnvVars(embedding.apiKey),
+        baseUrl:
+          typeof embedding.baseUrl === "string" ? resolveEnvVars(embedding.baseUrl) : undefined,
       },
       dbPath: typeof cfg.dbPath === "string" ? cfg.dbPath : DEFAULT_DB_PATH,
       autoCapture: cfg.autoCapture === true,
@@ -136,7 +140,13 @@ export const memoryConfigSchema = {
     "embedding.model": {
       label: "Embedding Model",
       placeholder: DEFAULT_MODEL,
-      help: "OpenAI embedding model to use",
+      help: "Embedding model to use (OpenAI or Gemini)",
+    },
+    "embedding.baseUrl": {
+      label: "Base URL",
+      placeholder: "https://api.openai.com/v1",
+      help: "Custom base URL for OpenAI-compatible embedding APIs",
+      advanced: true,
     },
     dbPath: {
       label: "Database Path",

--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -120,6 +120,46 @@ describe("memory plugin e2e", () => {
     expect(config?.captureMaxChars).toBe(1800);
   });
 
+  test("config schema accepts gemini-embedding-001 with baseUrl", async () => {
+    const { default: memoryPlugin } = await import("./index.js");
+
+    const config = memoryPlugin.configSchema?.parse?.({
+      embedding: {
+        apiKey: OPENAI_API_KEY,
+        model: "gemini-embedding-001",
+        baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai",
+      },
+      dbPath,
+    });
+
+    expect(config).toBeDefined();
+    expect(config?.embedding?.model).toBe("gemini-embedding-001");
+    expect(config?.embedding?.baseUrl).toBe(
+      "https://generativelanguage.googleapis.com/v1beta/openai",
+    );
+  });
+
+  test("config schema resolves env vars in baseUrl", async () => {
+    const { default: memoryPlugin } = await import("./index.js");
+
+    process.env.TEST_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai";
+
+    const config = memoryPlugin.configSchema?.parse?.({
+      embedding: {
+        apiKey: OPENAI_API_KEY,
+        model: "gemini-embedding-001",
+        baseUrl: "${TEST_BASE_URL}",
+      },
+      dbPath,
+    });
+
+    expect(config?.embedding?.baseUrl).toBe(
+      "https://generativelanguage.googleapis.com/v1beta/openai",
+    );
+
+    delete process.env.TEST_BASE_URL;
+  });
+
   test("config schema keeps autoCapture disabled by default", async () => {
     const { default: memoryPlugin } = await import("./index.js");
 

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -166,8 +166,9 @@ class Embeddings {
   constructor(
     apiKey: string,
     private model: string,
+    baseURL?: string,
   ) {
-    this.client = new OpenAI({ apiKey });
+    this.client = new OpenAI({ apiKey, ...(baseURL && { baseURL }) });
   }
 
   async embed(text: string): Promise<number[]> {
@@ -295,7 +296,11 @@ const memoryPlugin = {
     const resolvedDbPath = api.resolvePath(cfg.dbPath!);
     const vectorDim = vectorDimsForModel(cfg.embedding.model ?? "text-embedding-3-small");
     const db = new MemoryDB(resolvedDbPath, vectorDim);
-    const embeddings = new Embeddings(cfg.embedding.apiKey, cfg.embedding.model!);
+    const embeddings = new Embeddings(
+      cfg.embedding.apiKey,
+      cfg.embedding.model!,
+      cfg.embedding.baseUrl,
+    );
 
     api.logger.info(`memory-lancedb: plugin registered (db: ${resolvedDbPath}, lazy init)`);
 

--- a/extensions/memory-lancedb/openclaw.plugin.json
+++ b/extensions/memory-lancedb/openclaw.plugin.json
@@ -11,7 +11,13 @@
     "embedding.model": {
       "label": "Embedding Model",
       "placeholder": "text-embedding-3-small",
-      "help": "OpenAI embedding model to use"
+      "help": "Embedding model to use (OpenAI or Gemini)"
+    },
+    "embedding.baseUrl": {
+      "label": "Base URL",
+      "placeholder": "https://api.openai.com/v1",
+      "help": "Custom base URL for OpenAI-compatible embedding APIs",
+      "advanced": true
     },
     "dbPath": {
       "label": "Database Path",
@@ -46,7 +52,10 @@
           },
           "model": {
             "type": "string",
-            "enum": ["text-embedding-3-small", "text-embedding-3-large"]
+            "enum": ["text-embedding-3-small", "text-embedding-3-large", "gemini-embedding-001"]
+          },
+          "baseUrl": {
+            "type": "string"
           }
         },
         "required": ["apiKey"]


### PR DESCRIPTION
## Summary

- Adds `gemini-embedding-001` (3072 dims) to the allowed embedding models
- Introduces `baseUrl` config option so users can point to Google's OpenAI-compatible endpoint (`https://generativelanguage.googleapis.com/v1beta/openai`) or any other compatible API
- Applies `resolveEnvVars` to `baseUrl` for `${ENV_VAR}` substitution, consistent with `apiKey` handling

Closes #17650

## Improvements over #17696

This PR addresses review feedback from #17696 that was left unresolved:

1. **`resolveEnvVars` on `baseUrl`** ([Copilot review](https://github.com/openclaw/openclaw/pull/17696#discussion_r2810471760)): `baseUrl` now supports `${ENV_VAR}` substitution, consistent with how `apiKey` is handled
2. **Missing `uiHints` in `config.ts`** ([Greptile review](https://github.com/openclaw/openclaw/pull/17696#issuecomment-3906198131)): Added `embedding.baseUrl` uiHints entry in `config.ts` to match `openclaw.plugin.json`
3. **Inconsistent help text** ([Greptile review](https://github.com/openclaw/openclaw/pull/17696#issuecomment-3906198131)): Updated `embedding.model` help to `"Embedding model to use (OpenAI or Gemini)"` in both `config.ts` and `openclaw.plugin.json`
4. **No test coverage**: Added two new tests — config accepts `gemini-embedding-001` with `baseUrl`, and env var resolution works on `baseUrl`

## Changes

- **config.ts**: Add `gemini-embedding-001` to `EMBEDDING_DIMENSIONS`, add `baseUrl` to type/parser/`assertAllowedKeys`, apply `resolveEnvVars`, add `uiHints`, update model help text
- **index.ts**: Pass `baseUrl` through `Embeddings` constructor to `OpenAI` client
- **openclaw.plugin.json**: Add `gemini-embedding-001` to enum, add `baseUrl` property, add uiHint, update model help text
- **index.test.ts**: Add tests for gemini model + baseUrl config and env var resolution on baseUrl

## Test plan

- [x] `pnpm vitest run extensions/memory-lancedb/` — 13 passed, 1 skipped (live test)
- [x] `pnpm build` passes
- [x] `pnpm oxfmt --check` passes on changed files

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `gemini-embedding-001` (3072 dims) to the memory-lancedb plugin's allowed embedding models and introduces a `baseUrl` config option for pointing to Google's OpenAI-compatible endpoint or other compatible APIs. Environment variable substitution is applied to `baseUrl` consistent with `apiKey` handling.

- `config.ts`: Adds `gemini-embedding-001` to `EMBEDDING_DIMENSIONS`, adds `baseUrl` to the type/parser/allowed keys, applies `resolveEnvVars`, and adds `uiHints`
- `index.ts`: Passes `baseUrl` through the `Embeddings` constructor to the `OpenAI` client as `baseURL`
- `openclaw.plugin.json`: Adds `gemini-embedding-001` to the model enum, adds `baseUrl` property and uiHint
- `index.test.ts`: Adds tests for gemini model + baseUrl config parsing and env var resolution on baseUrl
- All four files are consistent with each other and follow existing patterns in the codebase

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it adds straightforward config options with proper validation and test coverage.
- The changes are well-contained to four files in a single extension, follow existing patterns (env var resolution, allowed keys validation, uiHints), and include test coverage. The new model entry and baseUrl passthrough are simple additions that don't modify existing behavior. No logical errors, security concerns, or breaking changes found.
- No files require special attention.

<sub>Last reviewed commit: e8b770e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->