### PR TITLE
scaffolds: Phase 1 executor (g-v-p) + gates + manifests

### DIFF
--- a/docs/scaffolds-rfc.md
+++ b/docs/scaffolds-rfc.md
@@ -1,0 +1,51 @@
+---
+title: Scaffolds RFC (Phase 0/1)
+description: Phase 0 plumbing for deterministic scaffolded execution; Phase 1 introduces generate-verify-patch.
+---
+
+# Scaffolds RFC (Phase 0/1)
+
+## Why this exists
+
+We need a **deterministic** and **testable** mechanism to interpose “scaffolds” (generate → verify → patch loops, etc.) between a tool/skill request and the underlying model call.
+
+Phase 0 intentionally ships **plumbing only**: wiring, config parsing, and tests that prove the adapter is a **no-op passthrough**.
+
+## Goals
+
+- Provide a stable interface for future scaffold executors.
+- Keep Phase 0 behavior _zero_ (no output changes).
+- Make Phase 1+ behavior deterministic (ordering, budgets, error templates) to avoid flaky tests and nondeterministic prompts.
+
+## Non-goals (Phase 0)
+
+- No generate/verify/patch loop.
+- No retries/budgets enforcement.
+- No manifest loading.
+
+## Phase 0 behavior (truth table)
+
+**In Phase 0, the scaffold adapter is always passthrough.**
+
+| Condition              | Result                       |
+| ---------------------- | ---------------------------- |
+| Any config value       | Output is unchanged          |
+| Any skill/tool request | Output is unchanged          |
+| Any scaffold id        | Ignored; output is unchanged |
+
+More explicitly:
+
+- The config field is parsed and validated.
+- The adapter is invoked.
+- The adapter returns the original text unchanged.
+
+This PR is therefore **pure plumbing** for Phase 1.
+
+## Architecture sketch
+
+- **Adapter** (Phase 0): thin wrapper that can be called by the runtime; returns input unchanged.
+- **Executor** (Phase 1+): orchestration layer that can run a scaffold loop and return the final text.
+
+## Related work
+
+- See the Phase 0 scaffolds wiring/tests in `src/scaffolds/**`.

--- a/src/agents/pi-embedded-runner/run.scaffolds-phase0.test.ts
+++ b/src/agents/pi-embedded-runner/run.scaffolds-phase0.test.ts
@@ -1,0 +1,147 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import "../test-helpers/fast-coding-tools.js";
+import type { OpenClawConfig } from "../../config/config.js";
+import { ensureOpenClawModelsJson } from "../models-config.js";
+
+vi.mock("../../scaffolds/index.js", () => {
+  return {
+    applyEmbeddedRunScaffolds: vi.fn(({ payloads }) =>
+      payloads.map((p: { text?: string }) => ({
+        ...p,
+        text: p.text ? `${p.text} [scaffolded]` : p.text,
+      })),
+    ),
+  };
+});
+
+vi.mock("@mariozechner/pi-ai", async () => {
+  const actual = await vi.importActual<typeof import("@mariozechner/pi-ai")>("@mariozechner/pi-ai");
+
+  const buildAssistantMessage = (model: { api: string; provider: string; id: string }) => ({
+    role: "assistant" as const,
+    content: [{ type: "text" as const, text: "ok" }],
+    stopReason: "stop" as const,
+    api: model.api,
+    provider: model.provider,
+    model: model.id,
+    usage: {
+      input: 1,
+      output: 1,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 2,
+      cost: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        total: 0,
+      },
+    },
+    timestamp: Date.now(),
+  });
+
+  return {
+    ...actual,
+    complete: async (model: { api: string; provider: string; id: string }) =>
+      buildAssistantMessage(model),
+    completeSimple: async (model: { api: string; provider: string; id: string }) =>
+      buildAssistantMessage(model),
+    streamSimple: (model: { api: string; provider: string; id: string }) => {
+      const stream = new actual.AssistantMessageEventStream();
+      queueMicrotask(() => {
+        stream.push({ type: "done", reason: "stop", message: buildAssistantMessage(model) });
+        stream.end();
+      });
+      return stream;
+    },
+  };
+});
+
+let runEmbeddedPiAgent: typeof import("./run.js").runEmbeddedPiAgent;
+let tempRoot: string | undefined;
+let agentDir: string;
+let workspaceDir: string;
+let sessionCounter = 0;
+
+beforeAll(async () => {
+  vi.useRealTimers();
+  ({ runEmbeddedPiAgent } = await import("./run.js"));
+  tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-scaffolds-phase0-"));
+  agentDir = path.join(tempRoot, "agent");
+  workspaceDir = path.join(tempRoot, "workspace");
+  await fs.mkdir(agentDir, { recursive: true });
+  await fs.mkdir(workspaceDir, { recursive: true });
+}, 20_000);
+
+afterAll(async () => {
+  if (!tempRoot) {
+    return;
+  }
+  await fs.rm(tempRoot, { recursive: true, force: true });
+  tempRoot = undefined;
+});
+
+const nextSessionFile = () => {
+  sessionCounter += 1;
+  return path.join(workspaceDir, `session-${sessionCounter}.jsonl`);
+};
+
+const immediateEnqueue = async <T>(task: () => Promise<T>) => task();
+
+const makeOpenAiConfig = (): OpenClawConfig =>
+  ({
+    models: {
+      providers: {
+        openai: {
+          api: "openai-responses",
+          apiKey: "sk-test",
+          baseUrl: "https://example.com",
+          models: [
+            {
+              id: "mock-1",
+              name: "Mock",
+              reasoning: false,
+              input: ["text"],
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              contextWindow: 16_000,
+              maxTokens: 2048,
+            },
+          ],
+        },
+      },
+    },
+    scaffolds: {
+      reasoning: {
+        enabled: true,
+        phase: 0,
+      },
+    },
+  }) as unknown as OpenClawConfig;
+
+describe("runEmbeddedPiAgent scaffolds (phase 0)", () => {
+  it("runs payloads through scaffold adapter after buildEmbeddedRunPayloads", async () => {
+    const cfg = makeOpenAiConfig();
+    await ensureOpenClawModelsJson(cfg, agentDir);
+
+    const sessionFile = nextSessionFile();
+    const result = await runEmbeddedPiAgent({
+      sessionId: "session:test",
+      sessionKey: "agent:test:scaffolds",
+      sessionFile,
+      workspaceDir,
+      config: cfg,
+      prompt: "hi",
+      provider: "openai",
+      model: "mock-1",
+      timeoutMs: 5_000,
+      agentDir,
+      enqueue: immediateEnqueue,
+    });
+
+    expect(result.payloads?.[0]?.text).toBe("ok [scaffolded]");
+  });
+});

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -3,6 +3,7 @@ import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import type { RunEmbeddedPiAgentParams } from "./run/params.js";
 import type { EmbeddedPiAgentMeta, EmbeddedPiRunResult } from "./types.js";
 import { enqueueCommandInLane } from "../../process/command-queue.js";
+import { applyEmbeddedRunScaffolds } from "../../scaffolds/index.js";
 import { isMarkdownCapableMessageChannel } from "../../utils/message-channel.js";
 import { resolveOpenClawAgentDir } from "../agent-paths.js";
 import {
@@ -818,6 +819,12 @@ export async function runEmbeddedPiAgent(
             inlineToolResultsAllowed: false,
           });
 
+          const scaffoldedPayloads = applyEmbeddedRunScaffolds({
+            payloads,
+            // Phase 0: config key is not yet part of OpenClawConfig's public type.
+            config: params.config as any,
+          });
+
           log.debug(
             `embedded run done: runId=${params.runId} sessionId=${params.sessionId} durationMs=${Date.now() - started} aborted=${aborted}`,
           );
@@ -835,7 +842,7 @@ export async function runEmbeddedPiAgent(
             });
           }
           return {
-            payloads: payloads.length ? payloads : undefined,
+            payloads: scaffoldedPayloads.length ? scaffoldedPayloads : undefined,
             meta: {
               durationMs: Date.now() - started,
               agentMeta,

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
+import type { OpenClawConfigWithScaffolds } from "../../scaffolds/index.js";
 import type { RunEmbeddedPiAgentParams } from "./run/params.js";
 import type { EmbeddedPiAgentMeta, EmbeddedPiRunResult } from "./types.js";
 import { enqueueCommandInLane } from "../../process/command-queue.js";
@@ -822,7 +823,7 @@ export async function runEmbeddedPiAgent(
           const scaffoldedPayloads = applyEmbeddedRunScaffolds({
             payloads,
             // Phase 0: config key is not yet part of OpenClawConfig's public type.
-            config: params.config as any,
+            config: params.config as unknown as OpenClawConfigWithScaffolds,
           });
 
           log.debug(

--- a/src/agents/skills/types.ts
+++ b/src/agents/skills/types.ts
@@ -1,4 +1,5 @@
 import type { Skill } from "@mariozechner/pi-coding-agent";
+import type { SkillScaffoldManifestV1 } from "../../scaffolds/manifests/skill-scaffold-manifest.v1.js";
 
 export type SkillInstallSpec = {
   id?: string;
@@ -68,6 +69,9 @@ export type SkillEntry = {
   frontmatter: ParsedSkillFrontmatter;
   metadata?: OpenClawSkillMetadata;
   invocation?: SkillInvocationPolicy;
+
+  scaffoldManifest?: SkillScaffoldManifestV1;
+  scaffoldManifestError?: { path: string; error: string };
 };
 
 export type SkillEligibilityContext = {

--- a/src/config/config.scaffolds.test.ts
+++ b/src/config/config.scaffolds.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { OpenClawSchema } from "./zod-schema.js";
+
+describe("config scaffolds (phase 0)", () => {
+  it("accepts scaffolds.reasoning.enabled + phase=0", () => {
+    const res = OpenClawSchema.safeParse({
+      scaffolds: {
+        reasoning: {
+          enabled: true,
+          phase: 0,
+        },
+      },
+    });
+
+    expect(res.success).toBe(true);
+  });
+
+  it("rejects scaffolds.reasoning.phase != 0", () => {
+    const res = OpenClawSchema.safeParse({
+      scaffolds: {
+        reasoning: {
+          enabled: true,
+          phase: 1,
+        },
+      },
+    });
+
+    expect(res.success).toBe(false);
+  });
+});

--- a/src/config/redact-snapshot.ts
+++ b/src/config/redact-snapshot.ts
@@ -1,4 +1,5 @@
 import type { ConfigFileSnapshot } from "./types.openclaw.js";
+import { isSensitiveKey } from "./sensitive.js";
 
 /**
  * Sentinel value used to replace sensitive config fields in gateway responses.
@@ -10,13 +11,8 @@ export const REDACTED_SENTINEL = "__OPENCLAW_REDACTED__";
 
 /**
  * Patterns that identify sensitive config field names.
- * Aligned with the UI-hint logic in schema.ts.
+ * Kept in sync with the UI-hint logic in schema.ts via {@link isSensitiveKey}.
  */
-const SENSITIVE_KEY_PATTERNS = [/token/i, /password/i, /secret/i, /api.?key/i];
-
-function isSensitiveKey(key: string): boolean {
-  return SENSITIVE_KEY_PATTERNS.some((pattern) => pattern.test(key));
-}
 
 /**
  * Deep-walk an object and replace values whose key matches a sensitive pattern

--- a/src/config/schema.field-metadata.ts
+++ b/src/config/schema.field-metadata.ts
@@ -429,7 +429,7 @@ export const FIELD_HELP: Record<string, string> = {
     'Text suffix for cross-context markers (supports "{channel}").',
   "tools.message.broadcast.enabled": "Enable broadcast action (default: true).",
   "tools.web.search.enabled": "Enable the web_search tool (requires a provider API key).",
-  "tools.web.search.provider": 'Search provider ("brave" or "perplexity").',
+  "tools.web.search.provider": 'Search provider ("brave", "perplexity", or "grok").',
   "tools.web.search.apiKey": "Brave Search API key (fallback: BRAVE_API_KEY env var).",
   "tools.web.search.maxResults": "Default number of results to return (1-10).",
   "tools.web.search.timeoutSeconds": "Timeout in seconds for web_search requests.",

--- a/src/config/schema.field-metadata.ts
+++ b/src/config/schema.field-metadata.ts
@@ -1,3 +1,5 @@
+import { DEFAULT_SENSITIVE_KEY_PATTERNS, isSensitiveKey } from "./sensitive.js";
+
 export const GROUP_LABELS: Record<string, string> = {
   wizard: "Wizard",
   update: "Update",
@@ -731,8 +733,8 @@ export const FIELD_PLACEHOLDERS: Record<string, string> = {
   "agents.list[].identity.avatar": "avatars/openclaw.png",
 };
 
-export const SENSITIVE_PATTERNS = [/token/i, /password/i, /secret/i, /api.?key/i];
+export const SENSITIVE_PATTERNS = DEFAULT_SENSITIVE_KEY_PATTERNS;
 
 export function isSensitivePath(path: string): boolean {
-  return SENSITIVE_PATTERNS.some((pattern) => pattern.test(path));
+  return isSensitiveKey(path);
 }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -476,7 +476,7 @@ const FIELD_HELP: Record<string, string> = {
     'Text suffix for cross-context markers (supports "{channel}").',
   "tools.message.broadcast.enabled": "Enable broadcast action (default: true).",
   "tools.web.search.enabled": "Enable the web_search tool (requires a provider API key).",
-  "tools.web.search.provider": 'Search provider ("brave" or "perplexity").',
+  "tools.web.search.provider": 'Search provider ("brave", "perplexity", or "grok").',
   "tools.web.search.apiKey": "Brave Search API key (fallback: BRAVE_API_KEY env var).",
   "tools.web.search.maxResults": "Default number of results to return (1-10).",
   "tools.web.search.timeoutSeconds": "Timeout in seconds for web_search requests.",

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,5 +1,6 @@
 import { CHANNEL_IDS } from "../channels/registry.js";
 import { VERSION } from "../version.js";
+import { isSensitiveKey } from "./sensitive.js";
 import { OpenClawSchema } from "./zod-schema.js";
 
 export type ConfigUiHint = {
@@ -778,10 +779,8 @@ const FIELD_PLACEHOLDERS: Record<string, string> = {
   "agents.list[].identity.avatar": "avatars/openclaw.png",
 };
 
-const SENSITIVE_PATTERNS = [/token/i, /password/i, /secret/i, /api.?key/i];
-
 function isSensitivePath(path: string): boolean {
-  return SENSITIVE_PATTERNS.some((pattern) => pattern.test(path));
+  return isSensitiveKey(path);
 }
 
 type JsonSchemaObject = JsonSchemaNode & {

--- a/src/config/sensitive.ts
+++ b/src/config/sensitive.ts
@@ -1,0 +1,21 @@
+/**
+ * Shared helpers for detecting sensitive config keys.
+ *
+ * Keep this aligned across:
+ * - config schema UI hints (marking fields as `sensitive`)
+ * - config snapshot redaction logic
+ */
+
+export const DEFAULT_SENSITIVE_KEY_PATTERNS: RegExp[] = [
+  /token/i,
+  /password/i,
+  /secret/i,
+  /api.?key/i,
+];
+
+export function isSensitiveKey(
+  key: string,
+  patterns: readonly RegExp[] = DEFAULT_SENSITIVE_KEY_PATTERNS,
+): boolean {
+  return patterns.some((pattern) => pattern.test(key));
+}

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -22,6 +22,7 @@ import type {
 import type { ModelsConfig } from "./types.models.js";
 import type { NodeHostConfig } from "./types.node-host.js";
 import type { PluginsConfig } from "./types.plugins.js";
+import type { ScaffoldsConfig } from "./types.scaffolds.js";
 import type { SkillsConfig } from "./types.skills.js";
 import type { ToolsConfig } from "./types.tools.js";
 
@@ -75,6 +76,7 @@ export type OpenClawConfig = {
       avatar?: string;
     };
   };
+  scaffolds?: ScaffoldsConfig;
   skills?: SkillsConfig;
   plugins?: PluginsConfig;
   models?: ModelsConfig;

--- a/src/config/types.scaffolds.ts
+++ b/src/config/types.scaffolds.ts
@@ -1,15 +1,4 @@
-import type { OpenClawConfig } from "../config/types.js";
-
-export type EmbeddedRunPayload = {
-  text?: string;
-  mediaUrl?: string;
-  mediaUrls?: string[];
-  replyToId?: string;
-  isError?: boolean;
-  audioAsVoice?: boolean;
-  replyToTag?: boolean;
-  replyToCurrent?: boolean;
-};
+// --- Scaffolds ------------------------------------------------------------
 
 export type ReasoningScaffoldsPhase0Config = {
   /** Gate for Phase 0 scaffolds (no-op placeholder in this phase). */
@@ -22,8 +11,4 @@ export type ScaffoldsConfig = {
   reasoning?: ReasoningScaffoldsPhase0Config;
   /** Phase 1 kill switch: enables executor-based routing for skills with manifests. */
   executorsEnabled?: boolean;
-};
-
-export type OpenClawConfigWithScaffolds = OpenClawConfig & {
-  scaffolds?: ScaffoldsConfig;
 };

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -29,3 +29,16 @@ export * from "./types.tts.js";
 export * from "./types.tools.js";
 export * from "./types.whatsapp.js";
 export * from "./types.memory.js";
+
+// --- Scaffolds (Phase 0) -------------------------------------------------
+
+export type ReasoningScaffoldsPhase0Config = {
+  /** Gate for Phase 0 scaffolds (no-op placeholder in this phase). */
+  enabled?: boolean;
+  /** Reserved for forward compatibility; must be 0 when set. */
+  phase?: 0;
+};
+
+export type ScaffoldsConfig = {
+  reasoning?: ReasoningScaffoldsPhase0Config;
+};

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -29,16 +29,4 @@ export * from "./types.tts.js";
 export * from "./types.tools.js";
 export * from "./types.whatsapp.js";
 export * from "./types.memory.js";
-
-// --- Scaffolds (Phase 0) -------------------------------------------------
-
-export type ReasoningScaffoldsPhase0Config = {
-  /** Gate for Phase 0 scaffolds (no-op placeholder in this phase). */
-  enabled?: boolean;
-  /** Reserved for forward compatibility; must be 0 when set. */
-  phase?: 0;
-};
-
-export type ScaffoldsConfig = {
-  reasoning?: ReasoningScaffoldsPhase0Config;
-};
+export * from "./types.scaffolds.js";

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -91,6 +91,19 @@ const MemorySchema = z
   .strict()
   .optional();
 
+const ScaffoldsSchema = z
+  .object({
+    reasoning: z
+      .object({
+        enabled: z.boolean().optional(),
+        phase: z.literal(0).optional(),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict()
+  .optional();
+
 export const OpenClawSchema = z
   .object({
     meta: z
@@ -243,6 +256,7 @@ export const OpenClawSchema = z
       })
       .strict()
       .optional(),
+    scaffolds: ScaffoldsSchema,
     auth: z
       .object({
         profiles: z

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -100,6 +100,7 @@ const ScaffoldsSchema = z
       })
       .strict()
       .optional(),
+    executorsEnabled: z.boolean().optional(),
   })
   .strict()
   .optional();

--- a/src/scaffolds/adapter.ts
+++ b/src/scaffolds/adapter.ts
@@ -1,0 +1,16 @@
+import type { EmbeddedRunPayload, OpenClawConfigWithScaffolds } from "./types.js";
+import { applyReasoningScaffoldsPhase0 } from "./phase0.js";
+
+export function applyEmbeddedRunScaffolds(params: {
+  payloads: EmbeddedRunPayload[];
+  config?: OpenClawConfigWithScaffolds;
+}): EmbeddedRunPayload[] {
+  const cfg = params.config;
+  const phase0Enabled = cfg?.scaffolds?.reasoning?.enabled ?? false;
+
+  if (!phase0Enabled) {
+    return params.payloads;
+  }
+
+  return applyReasoningScaffoldsPhase0(params.payloads);
+}

--- a/src/scaffolds/budgets/budget-counter.test.ts
+++ b/src/scaffolds/budgets/budget-counter.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { BudgetCounter, BudgetExceeded } from "./budget-counter.js";
+
+describe("BudgetCounter", () => {
+  it("increments within limits", () => {
+    const b = new BudgetCounter({ maxLlmCalls: 2, maxRetries: 1 });
+    expect(b.snapshot()).toEqual({ llmCalls: 0, retries: 0 });
+    b.consumeLlmCall();
+    expect(b.snapshot()).toEqual({ llmCalls: 1, retries: 0 });
+    b.consumeRetry();
+    expect(b.snapshot()).toEqual({ llmCalls: 1, retries: 1 });
+    b.consumeLlmCall();
+    expect(b.snapshot()).toEqual({ llmCalls: 2, retries: 1 });
+  });
+
+  it("throws BudgetExceeded with correct kind", () => {
+    const b = new BudgetCounter({ maxLlmCalls: 1, maxRetries: 0 });
+    b.consumeLlmCall();
+    expect(() => b.consumeLlmCall()).toThrowError(BudgetExceeded);
+    try {
+      b.consumeLlmCall();
+    } catch (err) {
+      expect(err).toBeInstanceOf(BudgetExceeded);
+      expect((err as BudgetExceeded).kind).toBe("llmCalls");
+    }
+
+    const r = new BudgetCounter({ maxLlmCalls: 99, maxRetries: 0 });
+    expect(() => r.consumeRetry()).toThrowError(BudgetExceeded);
+    try {
+      r.consumeRetry();
+    } catch (err) {
+      expect(err).toBeInstanceOf(BudgetExceeded);
+      expect((err as BudgetExceeded).kind).toBe("retries");
+    }
+  });
+
+  it("is deterministic under async interleaving (sync consume methods)", async () => {
+    const b = new BudgetCounter({ maxLlmCalls: 2, maxRetries: 1 });
+
+    const steps: Array<() => void> = [
+      () => b.consumeLlmCall(),
+      () => b.consumeRetry(),
+      () => b.consumeLlmCall(),
+    ];
+
+    await Promise.all(
+      steps.map(
+        (fn) =>
+          new Promise<void>((resolve) => {
+            setTimeout(() => {
+              fn();
+              resolve();
+            }, 0);
+          }),
+      ),
+    );
+
+    expect(b.snapshot()).toEqual({ llmCalls: 2, retries: 1 });
+  });
+});

--- a/src/scaffolds/budgets/budget-counter.ts
+++ b/src/scaffolds/budgets/budget-counter.ts
@@ -1,0 +1,42 @@
+export type BudgetSpec = {
+  maxLlmCalls: number;
+  maxRetries: number;
+};
+
+export class BudgetExceeded extends Error {
+  override name = "BudgetExceeded";
+
+  constructor(
+    public readonly kind: "llmCalls" | "retries",
+    message?: string,
+  ) {
+    super(message ?? `Budget exceeded: ${kind}`);
+  }
+}
+
+export class BudgetCounter {
+  private llmCalls = 0;
+  private retries = 0;
+
+  constructor(private readonly spec: BudgetSpec) {}
+
+  snapshot(): { llmCalls: number; retries: number } {
+    return { llmCalls: this.llmCalls, retries: this.retries };
+  }
+
+  consumeLlmCall(): void {
+    const next = this.llmCalls + 1;
+    if (next > this.spec.maxLlmCalls) {
+      throw new BudgetExceeded("llmCalls");
+    }
+    this.llmCalls = next;
+  }
+
+  consumeRetry(): void {
+    const next = this.retries + 1;
+    if (next > this.spec.maxRetries) {
+      throw new BudgetExceeded("retries");
+    }
+    this.retries = next;
+  }
+}

--- a/src/scaffolds/executors/gvp-executor.test.ts
+++ b/src/scaffolds/executors/gvp-executor.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import type { SkillScaffoldManifestV1 } from "../manifests/skill-scaffold-manifest.v1.js";
+import { BudgetCounter } from "../budgets/budget-counter.js";
+import { GvpExecutor } from "./gvp-executor.js";
+
+describe("GvpExecutor", () => {
+  const baseManifest: SkillScaffoldManifestV1 = {
+    version: 1,
+    scaffolds: {
+      executor: "g-v-p",
+      budgets: { maxLlmCalls: 3, maxRetries: 2 },
+      output: {
+        answerField: "answer",
+        schema: {
+          type: "object",
+          additionalProperties: false,
+          required: ["answer"],
+          properties: { answer: { type: "string" } },
+        },
+        invariants: [{ id: "no_placeholders" }],
+      },
+    },
+  };
+
+  it("returns extracted answer on first valid artifact", async () => {
+    const exec = new GvpExecutor();
+    const budgets = new BudgetCounter({ maxLlmCalls: 1, maxRetries: 0 });
+
+    const callModel = async () => ({ text: JSON.stringify({ answer: "ok" }) });
+
+    const res = await exec.execute({
+      ctx: { sessionId: "s", prompt: "do" },
+      manifest: {
+        ...baseManifest,
+        scaffolds: { ...baseManifest.scaffolds, budgets: { maxLlmCalls: 1, maxRetries: 0 } },
+      },
+      callModel,
+      budgets,
+    });
+
+    expect(res.text).toBe("ok");
+  });
+
+  it("patches after failure and succeeds", async () => {
+    const exec = new GvpExecutor();
+
+    const budgets = new BudgetCounter({ maxLlmCalls: 2, maxRetries: 1 });
+
+    const outputs = [JSON.stringify({ answer: "TODO" }), JSON.stringify({ answer: "done" })];
+    let idx = 0;
+    const callModel = async () => ({ text: outputs[idx++] ?? "" });
+
+    const res = await exec.execute({
+      ctx: { sessionId: "s", prompt: "do" },
+      manifest: {
+        ...baseManifest,
+        scaffolds: { ...baseManifest.scaffolds, budgets: { maxLlmCalls: 2, maxRetries: 1 } },
+      },
+      callModel,
+      budgets,
+    });
+
+    expect(res.text).toBe("done");
+  });
+
+  it("returns budget exceeded template", async () => {
+    const exec = new GvpExecutor();
+    const budgets = new BudgetCounter({ maxLlmCalls: 1, maxRetries: 1 });
+
+    const callModel = async () => ({ text: JSON.stringify({ answer: "TODO" }) });
+
+    const res = await exec.execute({
+      ctx: { sessionId: "s", prompt: "do" },
+      manifest: {
+        ...baseManifest,
+        scaffolds: { ...baseManifest.scaffolds, budgets: { maxLlmCalls: 1, maxRetries: 1 } },
+      },
+      callModel,
+      budgets,
+    });
+
+    expect(res.text).toBe("Scaffold error: budget exceeded (E_BUDGET_EXCEEDED).");
+  });
+
+  it("returns verify failed template when retries exhausted", async () => {
+    const exec = new GvpExecutor();
+    const budgets = new BudgetCounter({ maxLlmCalls: 2, maxRetries: 1 });
+
+    const callModel = async () => ({ text: JSON.stringify({ answer: "TODO" }) });
+
+    const res = await exec.execute({
+      ctx: { sessionId: "s", prompt: "do" },
+      manifest: {
+        ...baseManifest,
+        scaffolds: { ...baseManifest.scaffolds, budgets: { maxLlmCalls: 2, maxRetries: 1 } },
+      },
+      callModel,
+      budgets,
+    });
+
+    expect(res.text).toBe("Scaffold error: could not produce a valid answer (E_VERIFY_FAILED).");
+  });
+});

--- a/src/scaffolds/executors/gvp-executor.ts
+++ b/src/scaffolds/executors/gvp-executor.ts
@@ -1,0 +1,222 @@
+import type { GateFailure } from "../gates/types.js";
+import type { SkillScaffoldManifestV1 } from "../manifests/skill-scaffold-manifest.v1.js";
+import type {
+  CallModelFn,
+  ScaffoldExecutionContext,
+  ScaffoldExecutor,
+  ScaffoldExecutorResult,
+} from "./types.js";
+import { BudgetExceeded, type BudgetCounter } from "../budgets/budget-counter.js";
+import { runGatePipeline } from "../gates/gate-pipeline.js";
+
+function stripWholeMarkdownFence(text: string): string {
+  const trimmed = text.trim();
+  const match = trimmed.match(/^```(?:json)?\s*\n([\s\S]*?)\n```\s*$/i);
+  if (!match) {
+    return text;
+  }
+  return match[1] ?? "";
+}
+
+function tryParseJsonStrict(
+  text: string,
+): { ok: true; value: unknown } | { ok: false; failure: GateFailure } {
+  const candidate = stripWholeMarkdownFence(text);
+  try {
+    const value = JSON.parse(candidate);
+    return { ok: true, value };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      failure: {
+        gate: "json_parse",
+        id: "json_parse",
+        message: `invalid JSON: ${message}`,
+        path: "$",
+      },
+    };
+  }
+}
+
+function formatFailuresForPatch(failures: GateFailure[]): string {
+  const lines = failures.map((f) => {
+    const p = f.path ? ` ${f.path}` : "";
+    return `- [${f.gate}:${f.id}]${p}: ${f.message}`;
+  });
+  return lines.join("\n");
+}
+
+function buildGenerateMessages(params: {
+  userPrompt: string;
+  schema: unknown;
+  answerField: string;
+  invariants: SkillScaffoldManifestV1["scaffolds"]["output"]["invariants"];
+}): Array<{ role: "system" | "user" | "assistant"; content: string }> {
+  const system = [
+    "You are producing a JSON artifact.",
+    "Return valid JSON only.",
+    "Do not wrap in markdown fences.",
+    `The final user-visible answer must be in the string field "${params.answerField}".`,
+  ].join(" ");
+
+  const schemaBlock = JSON.stringify(params.schema);
+  const invariantsBlock = JSON.stringify(params.invariants);
+
+  const user = [
+    "Task:",
+    params.userPrompt,
+    "\nJSON Schema:",
+    schemaBlock,
+    "\nInvariants:",
+    invariantsBlock,
+  ].join("\n");
+
+  return [
+    { role: "system", content: system },
+    { role: "user", content: user },
+  ];
+}
+
+function buildPatchMessages(params: {
+  failures: GateFailure[];
+  previousJsonText: string;
+}): Array<{ role: "system" | "user" | "assistant"; content: string }> {
+  const system = [
+    "You are patching a JSON artifact.",
+    "Return corrected JSON only.",
+    "Do not wrap in markdown fences.",
+  ].join(" ");
+
+  const user1 = `The JSON artifact failed validation:\n${formatFailuresForPatch(params.failures)}`;
+  const assistant = params.previousJsonText.trim();
+  const user2 = "Fix the artifact to satisfy the failures. Return JSON only (no markdown).";
+
+  return [
+    { role: "system", content: system },
+    { role: "user", content: user1 },
+    { role: "assistant", content: assistant },
+    { role: "user", content: user2 },
+  ];
+}
+
+function extractAnswer(params: { artifact: unknown; answerField: string }): string | null {
+  const obj = params.artifact as Record<string, unknown> | null;
+  if (!obj || typeof obj !== "object" || Array.isArray(obj)) {
+    return null;
+  }
+  const val = obj[params.answerField];
+  return typeof val === "string" ? val : null;
+}
+
+export class GvpExecutor implements ScaffoldExecutor {
+  readonly id = "g-v-p" as const;
+
+  async execute(params: {
+    ctx: ScaffoldExecutionContext;
+    manifest: SkillScaffoldManifestV1;
+    callModel: CallModelFn;
+    budgets: BudgetCounter;
+  }): Promise<ScaffoldExecutorResult> {
+    const manifest = params.manifest;
+    const answerField = manifest.scaffolds.output.answerField;
+    const schema = manifest.scaffolds.output.schema;
+    const invariants = manifest.scaffolds.output.invariants;
+
+    const userPrompt = params.ctx.prompt ?? "";
+
+    let lastArtifactText = "";
+    let lastArtifact: unknown = undefined;
+    let lastFailures: GateFailure[] = [];
+
+    try {
+      params.budgets.consumeLlmCall();
+      const gen = await params.callModel({
+        messages: buildGenerateMessages({
+          userPrompt,
+          schema,
+          answerField,
+          invariants,
+        }),
+      });
+
+      lastArtifactText = gen.text;
+      const parsed0 = tryParseJsonStrict(gen.text);
+      if (!parsed0.ok) {
+        lastFailures = [parsed0.failure];
+      } else {
+        lastArtifact = parsed0.value;
+        const gate0 = runGatePipeline({
+          artifact: lastArtifact,
+          schema,
+          answerField,
+          invariants,
+        });
+        if (gate0.ok) {
+          const answer = extractAnswer({ artifact: lastArtifact, answerField });
+          if (typeof answer === "string") {
+            return { text: answer, meta: { applied: [this.id] } };
+          }
+        } else {
+          lastFailures = gate0.failures;
+        }
+      }
+
+      for (let i = 0; i < manifest.scaffolds.budgets.maxRetries; i += 1) {
+        params.budgets.consumeRetry();
+        params.budgets.consumeLlmCall();
+
+        const patch = await params.callModel({
+          messages: buildPatchMessages({
+            failures: lastFailures,
+            previousJsonText: lastArtifactText,
+          }),
+        });
+
+        lastArtifactText = patch.text;
+        const parsed = tryParseJsonStrict(patch.text);
+        if (!parsed.ok) {
+          lastFailures = [parsed.failure];
+          continue;
+        }
+
+        lastArtifact = parsed.value;
+        const gate = runGatePipeline({
+          artifact: lastArtifact,
+          schema,
+          answerField,
+          invariants,
+        });
+        if (gate.ok) {
+          const answer = extractAnswer({ artifact: lastArtifact, answerField });
+          if (typeof answer === "string") {
+            return { text: answer, meta: { applied: [this.id] } };
+          }
+          lastFailures = [
+            {
+              gate: "extract",
+              id: "answer_field_missing",
+              message: `answerField '${answerField}' must be a string`,
+              path: `$/` + answerField,
+            },
+          ];
+          continue;
+        }
+        lastFailures = gate.failures;
+      }
+
+      return {
+        text: "Scaffold error: could not produce a valid answer (E_VERIFY_FAILED).",
+        meta: { applied: [this.id] },
+      };
+    } catch (err) {
+      if (err instanceof BudgetExceeded) {
+        return {
+          text: "Scaffold error: budget exceeded (E_BUDGET_EXCEEDED).",
+          meta: { applied: [this.id] },
+        };
+      }
+      throw err;
+    }
+  }
+}

--- a/src/scaffolds/executors/types.ts
+++ b/src/scaffolds/executors/types.ts
@@ -1,0 +1,50 @@
+import type { BudgetCounter } from "../budgets/budget-counter.js";
+import type { SkillScaffoldManifestV1 } from "../manifests/skill-scaffold-manifest.v1.js";
+
+export type ScaffoldExecutorId = "g-v-p";
+
+export type ScaffoldExecutionContext = {
+  sessionId: string;
+  sessionKey?: string;
+  runId?: string;
+  agentId?: string;
+  provider?: string;
+  modelId?: string;
+  messageChannel?: string;
+  workspaceDir?: string;
+
+  skillId?: string;
+  skillName?: string;
+
+  // Convenience: the user-visible prompt that triggered the scaffold.
+  prompt?: string;
+};
+
+export type ScaffoldModelMessage = {
+  role: "system" | "user" | "assistant";
+  content: string;
+};
+
+export type CallModelFn = (params: {
+  messages: ScaffoldModelMessage[];
+}) => Promise<{ text: string }>;
+
+export type ScaffoldExecutorResult = {
+  text: string;
+  meta?: {
+    applied?: string[];
+    warnings?: string[];
+    debug?: Record<string, unknown>;
+  };
+};
+
+export interface ScaffoldExecutor {
+  readonly id: ScaffoldExecutorId;
+
+  execute(params: {
+    ctx: ScaffoldExecutionContext;
+    manifest: SkillScaffoldManifestV1;
+    callModel: CallModelFn;
+    budgets: BudgetCounter;
+  }): Promise<ScaffoldExecutorResult>;
+}

--- a/src/scaffolds/gates/ajv.ts
+++ b/src/scaffolds/gates/ajv.ts
@@ -1,0 +1,49 @@
+import type { ValidateFunction } from "ajv";
+import * as Ajv2020Mod from "ajv/dist/2020.js";
+import crypto from "node:crypto";
+
+type AjvCtor = new (opts?: unknown) => { compile: (schema: object) => ValidateFunction };
+const Ajv2020 = (Ajv2020Mod as unknown as { default: AjvCtor }).default;
+
+// Canonical JSON: deterministic stringify with recursively sorted object keys.
+export function canonicalJson(value: unknown): string {
+  const normalize = (v: unknown): unknown => {
+    if (Array.isArray(v)) {
+      return v.map((x) => normalize(x));
+    }
+    if (v && typeof v === "object") {
+      const obj = v as Record<string, unknown>;
+      const out: Record<string, unknown> = {};
+      for (const k of Object.keys(obj).toSorted()) {
+        out[k] = normalize(obj[k]);
+      }
+      return out;
+    }
+    return v;
+  };
+
+  return JSON.stringify(normalize(value));
+}
+
+function sha256Hex(input: string): string {
+  return crypto.createHash("sha256").update(input).digest("hex");
+}
+
+const ajvSingleton = new Ajv2020({
+  allErrors: true,
+  strict: false,
+  allowUnionTypes: true,
+});
+
+const compiledByKey = new Map<string, ValidateFunction>();
+
+export function compileSchemaCached(schema: unknown): ValidateFunction {
+  const key = sha256Hex(canonicalJson(schema));
+  const hit = compiledByKey.get(key);
+  if (hit) {
+    return hit;
+  }
+  const validate = ajvSingleton.compile(schema as object);
+  compiledByKey.set(key, validate);
+  return validate;
+}

--- a/src/scaffolds/gates/gate-pipeline.test.ts
+++ b/src/scaffolds/gates/gate-pipeline.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import type { SkillScaffoldInvariantSpecV1 } from "../manifests/skill-scaffold-manifest.v1.js";
+import { runGatePipeline } from "./gate-pipeline.js";
+
+describe("runGatePipeline", () => {
+  it("returns schema failures deterministically (sorted) and skips extract", () => {
+    const schema = {
+      type: "object",
+      additionalProperties: false,
+      required: ["answer"],
+      properties: {
+        answer: { type: "string", minLength: 3 },
+      },
+    };
+
+    const invariants: SkillScaffoldInvariantSpecV1[] = [{ id: "no_placeholders" }];
+
+    const res = runGatePipeline({
+      artifact: { answer: 1, extra: true },
+      schema,
+      answerField: "answer",
+      invariants,
+    });
+
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      // schema failures only
+      expect(res.failures[0]?.gate).toBe("schema");
+      // extract should not be present when schema fails
+      expect(res.failures.some((f) => f.gate === "extract")).toBe(false);
+      // deterministic sort: paths increasing
+      const paths = res.failures.map((f) => f.path ?? "");
+      expect(paths.toSorted()).toEqual(paths);
+    }
+  });
+
+  it("emits extract failure only if schema passes", () => {
+    const schema = {
+      type: "object",
+      additionalProperties: false,
+      required: ["title"],
+      properties: {
+        title: { type: "string" },
+      },
+    };
+
+    const res = runGatePipeline({
+      artifact: { title: "ok" },
+      schema,
+      answerField: "answer",
+      invariants: [],
+    });
+
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.failures).toHaveLength(1);
+      expect(res.failures[0]).toMatchObject({
+        gate: "extract",
+        id: "answer_field_missing",
+        path: "$/answer",
+      });
+    }
+  });
+
+  it("runs invariants in manifest order after schema+extract", () => {
+    const schema = {
+      type: "object",
+      additionalProperties: false,
+      required: ["answer"],
+      properties: {
+        answer: { type: "string" },
+      },
+    };
+
+    const invariants: SkillScaffoldInvariantSpecV1[] = [
+      { id: "no_placeholders" },
+      { id: "max_length", params: { field: "answer", max: 3 } },
+    ];
+
+    const res = runGatePipeline({
+      artifact: { answer: "TODO and long" },
+      schema,
+      answerField: "answer",
+      invariants,
+    });
+
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.failures.map((f) => `${f.gate}:${f.id}`)).toEqual([
+        "invariant:no_placeholders",
+        "invariant:max_length",
+      ]);
+    }
+  });
+});

--- a/src/scaffolds/gates/gate-pipeline.ts
+++ b/src/scaffolds/gates/gate-pipeline.ts
@@ -1,0 +1,45 @@
+import type { SkillScaffoldInvariantSpecV1 } from "../manifests/skill-scaffold-manifest.v1.js";
+import type { GateFailure, GateResult } from "./types.js";
+import { runInvariant } from "./invariants/index.js";
+import { runSchemaGate } from "./schema-gate.js";
+
+export function runGatePipeline(params: {
+  artifact: unknown;
+  schema: unknown;
+  answerField: string;
+  invariants: SkillScaffoldInvariantSpecV1[];
+}): GateResult {
+  const failures: GateFailure[] = [];
+
+  // 1) schema
+  const schemaResult = runSchemaGate({ artifact: params.artifact, schema: params.schema });
+  if (!schemaResult.ok) {
+    failures.push(...schemaResult.failures);
+    return { ok: false, failures };
+  }
+
+  // 2) extract (only if schema passed)
+  const obj = params.artifact as Record<string, unknown> | null;
+  const answerVal =
+    obj && typeof obj === "object" && !Array.isArray(obj) ? obj[params.answerField] : undefined;
+  if (typeof answerVal !== "string") {
+    failures.push({
+      gate: "extract",
+      id: "answer_field_missing",
+      message: `answerField '${params.answerField}' must be a string`,
+      path: `$/` + params.answerField,
+    });
+    return { ok: false, failures };
+  }
+
+  // 3) invariants in manifest order
+  for (const inv of params.invariants) {
+    failures.push(...runInvariant({ artifact: params.artifact, spec: inv }));
+  }
+
+  if (failures.length > 0) {
+    return { ok: false, failures };
+  }
+
+  return { ok: true };
+}

--- a/src/scaffolds/gates/invariants/index.ts
+++ b/src/scaffolds/gates/invariants/index.ts
@@ -1,0 +1,26 @@
+import type { SkillScaffoldInvariantSpecV1 } from "../../manifests/skill-scaffold-manifest.v1.js";
+import type { GateFailure } from "../types.js";
+import { runMaxLengthInvariant } from "./max-length.js";
+import { runNoPlaceholdersInvariant } from "./no-placeholders.js";
+
+export function runInvariant(params: {
+  artifact: unknown;
+  spec: SkillScaffoldInvariantSpecV1;
+}): GateFailure[] {
+  if (params.spec.id === "no_placeholders") {
+    return runNoPlaceholdersInvariant({ artifact: params.artifact, params: params.spec.params });
+  }
+  if (params.spec.id === "max_length") {
+    return runMaxLengthInvariant({ artifact: params.artifact, params: params.spec.params });
+  }
+
+  // Should never happen due to manifest parsing (fail-closed).
+  return [
+    {
+      gate: "invariant",
+      id: "unknown_invariant",
+      message: `Unknown invariant id: ${(params.spec as { id?: string }).id}`,
+      path: "$",
+    },
+  ];
+}

--- a/src/scaffolds/gates/invariants/max-length.ts
+++ b/src/scaffolds/gates/invariants/max-length.ts
@@ -1,0 +1,37 @@
+import type { GateFailure } from "../types.js";
+
+type Params = {
+  field: string;
+  max: number;
+};
+
+export function runMaxLengthInvariant(params: {
+  artifact: unknown;
+  params: Params;
+}): GateFailure[] {
+  const artifact = params.artifact as Record<string, unknown> | null;
+  if (!artifact || typeof artifact !== "object" || Array.isArray(artifact)) {
+    return [];
+  }
+
+  const field = params.params.field;
+  const max = params.params.max;
+  const val = artifact[field];
+  if (typeof val !== "string") {
+    return [];
+  }
+
+  if (val.length <= max) {
+    return [];
+  }
+
+  return [
+    {
+      gate: "invariant",
+      id: "max_length",
+      message: `exceeds max length ${max}`,
+      path: `$/` + field,
+      details: { field, max, length: val.length },
+    },
+  ];
+}

--- a/src/scaffolds/gates/invariants/no-placeholders.ts
+++ b/src/scaffolds/gates/invariants/no-placeholders.ts
@@ -1,0 +1,65 @@
+import type { GateFailure } from "../types.js";
+
+type Params = {
+  tokens?: string[];
+};
+
+const DEFAULT_TOKENS = ["TODO", "TBD", "<placeholder>", "..."];
+
+function toPath(parts: Array<string | number>): string {
+  if (parts.length === 0) {
+    return "$";
+  }
+  return `$/` + parts.map((p) => String(p)).join("/");
+}
+
+export function runNoPlaceholdersInvariant(params: {
+  artifact: unknown;
+  params?: Params;
+}): GateFailure[] {
+  const tokens = (params.params?.tokens?.length ? params.params.tokens : DEFAULT_TOKENS).map((t) =>
+    String(t),
+  );
+  const tokensLower = tokens.map((t) => t.toLowerCase());
+
+  const failures: GateFailure[] = [];
+
+  const visit = (value: unknown, pathParts: Array<string | number>): void => {
+    if (typeof value === "string") {
+      const lower = value.toLowerCase();
+      for (let i = 0; i < tokensLower.length; i += 1) {
+        const tokLower = tokensLower[i];
+        if (tokLower && lower.includes(tokLower)) {
+          const tok = tokens[i] ?? tokLower;
+          failures.push({
+            gate: "invariant",
+            id: "no_placeholders",
+            message: `contains "${tok}"`,
+            path: toPath(pathParts),
+            details: { token: tok },
+          });
+          break;
+        }
+      }
+      return;
+    }
+
+    if (Array.isArray(value)) {
+      for (let i = 0; i < value.length; i += 1) {
+        visit(value[i], [...pathParts, i]);
+      }
+      return;
+    }
+
+    if (value && typeof value === "object") {
+      const obj = value as Record<string, unknown>;
+      for (const k of Object.keys(obj).toSorted()) {
+        visit(obj[k], [...pathParts, k]);
+      }
+    }
+  };
+
+  visit(params.artifact, []);
+
+  return failures;
+}

--- a/src/scaffolds/gates/schema-gate.ts
+++ b/src/scaffolds/gates/schema-gate.ts
@@ -1,0 +1,103 @@
+import type { ErrorObject } from "ajv";
+import type { GateFailure, GateResult } from "./types.js";
+import { compileSchemaCached } from "./ajv.js";
+
+function toDollarPath(instancePath: string | undefined): string {
+  const p = instancePath ?? "";
+  if (!p) {
+    return "$";
+  }
+  if (p.startsWith("/")) {
+    return `$${p}`;
+  }
+  return `$/${p}`;
+}
+
+function stableAjvMessage(err: ErrorObject): { id: string; message: string; path: string } {
+  const keyword = err.keyword;
+  const basePath = toDollarPath(err.instancePath);
+
+  if (keyword === "required") {
+    const missing = (err.params as { missingProperty?: string } | undefined)?.missingProperty;
+    const path = missing ? `${basePath}/${missing}` : basePath;
+    return { id: "required", message: "is required", path };
+  }
+
+  if (keyword === "type") {
+    const type = (err.params as { type?: string } | undefined)?.type;
+    return { id: "type", message: type ? `must be ${type}` : "must match type", path: basePath };
+  }
+
+  if (keyword === "minLength") {
+    const limit = (err.params as { limit?: number } | undefined)?.limit;
+    return {
+      id: "minLength",
+      message: limit !== undefined ? `must have minLength ${limit}` : "minLength violated",
+      path: basePath,
+    };
+  }
+
+  if (keyword === "maxLength") {
+    const limit = (err.params as { limit?: number } | undefined)?.limit;
+    return {
+      id: "maxLength",
+      message: limit !== undefined ? `must have maxLength ${limit}` : "maxLength violated",
+      path: basePath,
+    };
+  }
+
+  if (keyword === "additionalProperties") {
+    const prop = (err.params as { additionalProperty?: string } | undefined)?.additionalProperty;
+    const path = prop ? `${basePath}/${prop}` : basePath;
+    return { id: "additionalProperties", message: "additional properties not allowed", path };
+  }
+
+  if (keyword === "enum") {
+    return { id: "enum", message: "must be one of the allowed values", path: basePath };
+  }
+
+  if (keyword === "const") {
+    return { id: "const", message: "must match the required value", path: basePath };
+  }
+
+  return { id: keyword, message: "schema validation failed", path: basePath };
+}
+
+export function runSchemaGate(params: { artifact: unknown; schema: unknown }): GateResult {
+  const validate = compileSchemaCached(params.schema);
+  const ok = validate(params.artifact);
+  if (ok) {
+    return { ok: true };
+  }
+
+  const errors: ErrorObject[] = validate.errors ?? [];
+  const failures: GateFailure[] = errors.map((err) => {
+    const stable = stableAjvMessage(err);
+    return {
+      gate: "schema",
+      id: stable.id,
+      message: stable.message,
+      path: stable.path,
+      details: {
+        schemaPath: err.schemaPath,
+        params: err.params,
+      },
+    };
+  });
+
+  const sorted = failures.toSorted((a, b) => {
+    const pa = a.path ?? "";
+    const pb = b.path ?? "";
+    if (pa !== pb) {
+      return pa.localeCompare(pb);
+    }
+    if (a.id !== b.id) {
+      return a.id.localeCompare(b.id);
+    }
+    const sa = (a.details as { schemaPath?: string } | undefined)?.schemaPath ?? "";
+    const sb = (b.details as { schemaPath?: string } | undefined)?.schemaPath ?? "";
+    return sa.localeCompare(sb);
+  });
+
+  return { ok: false, failures: sorted };
+}

--- a/src/scaffolds/gates/types.ts
+++ b/src/scaffolds/gates/types.ts
@@ -1,0 +1,14 @@
+export type GateFailure = {
+  gate: "schema" | "invariant" | "extract" | "json_parse";
+  id: string;
+  message: string;
+  path?: string;
+  details?: unknown;
+};
+
+export type GateResult =
+  | { ok: true }
+  | {
+      ok: false;
+      failures: GateFailure[];
+    };

--- a/src/scaffolds/index.ts
+++ b/src/scaffolds/index.ts
@@ -1,0 +1,7 @@
+export { applyEmbeddedRunScaffolds } from "./adapter.js";
+export type {
+  EmbeddedRunPayload,
+  OpenClawConfigWithScaffolds,
+  ReasoningScaffoldsPhase0Config,
+  ScaffoldsConfig,
+} from "./types.js";

--- a/src/scaffolds/index.ts
+++ b/src/scaffolds/index.ts
@@ -5,3 +5,12 @@ export type {
   ReasoningScaffoldsPhase0Config,
   ScaffoldsConfig,
 } from "./types.js";
+
+// Phase 1
+export * from "./budgets/budget-counter.js";
+export * from "./executors/types.js";
+export * from "./executors/gvp-executor.js";
+export * from "./gates/types.js";
+export * from "./gates/gate-pipeline.js";
+export * from "./manifests/skill-scaffold-manifest.v1.js";
+export * from "./registry.executors.js";

--- a/src/scaffolds/manifests/skill-scaffold-manifest.v1.ts
+++ b/src/scaffolds/manifests/skill-scaffold-manifest.v1.ts
@@ -1,0 +1,91 @@
+import { z } from "zod";
+
+export type SkillScaffoldInvariantSpecV1 =
+  | { id: "no_placeholders"; params?: { tokens?: string[] } }
+  | { id: "max_length"; params: { field: string; max: number } };
+
+export type SkillScaffoldManifestV1 = {
+  version: 1;
+  scaffolds: {
+    executor: "g-v-p";
+    budgets: {
+      maxLlmCalls: number;
+      maxRetries: number;
+    };
+    output: {
+      answerField: string;
+      // JSON Schema (draft-agnostic passthrough)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      schema: any;
+      invariants: SkillScaffoldInvariantSpecV1[];
+    };
+  };
+};
+
+const InvariantSchema = z
+  .union([
+    z
+      .object({
+        id: z.literal("no_placeholders"),
+        params: z
+          .object({
+            tokens: z.array(z.string()).optional(),
+          })
+          .strict()
+          .optional(),
+      })
+      .strict(),
+    z
+      .object({
+        id: z.literal("max_length"),
+        params: z
+          .object({
+            field: z.string().min(1),
+            max: z.number().int().positive(),
+          })
+          .strict(),
+      })
+      .strict(),
+  ])
+  .describe("Skill scaffold invariant");
+
+const BudgetsSchema = z
+  .object({
+    maxLlmCalls: z.number().int().positive(),
+    maxRetries: z.number().int().nonnegative(),
+  })
+  .strict()
+  .superRefine((val, ctx) => {
+    // Phase 1 algorithm: 1 generate + up to maxRetries patch calls
+    if (val.maxLlmCalls < 1 + val.maxRetries) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "budgets.maxLlmCalls must be >= 1 + budgets.maxRetries",
+        path: ["maxLlmCalls"],
+      });
+    }
+  });
+
+const SkillScaffoldManifestV1Schema = z
+  .object({
+    version: z.literal(1),
+    scaffolds: z
+      .object({
+        executor: z.literal("g-v-p"),
+        budgets: BudgetsSchema,
+        output: z
+          .object({
+            answerField: z.string().min(1),
+            schema: z.unknown(),
+            invariants: z.array(InvariantSchema),
+          })
+          .strict(),
+      })
+      .strict(),
+  })
+  .strict();
+
+export function parseSkillScaffoldManifestV1(value: unknown): SkillScaffoldManifestV1 {
+  // Fail-closed: no coercion, strict objects only.
+  return SkillScaffoldManifestV1Schema.parse(value) as SkillScaffoldManifestV1;
+}

--- a/src/scaffolds/phase0.ts
+++ b/src/scaffolds/phase0.ts
@@ -1,0 +1,8 @@
+import type { EmbeddedRunPayload } from "./types.js";
+
+export function applyReasoningScaffoldsPhase0(
+  payloads: EmbeddedRunPayload[],
+): EmbeddedRunPayload[] {
+  // Phase 0: wiring + config only. Intentionally a no-op.
+  return payloads;
+}

--- a/src/scaffolds/registry.executors.ts
+++ b/src/scaffolds/registry.executors.ts
@@ -1,0 +1,10 @@
+import type { ScaffoldExecutor, ScaffoldExecutorId } from "./executors/types.js";
+import { GvpExecutor } from "./executors/gvp-executor.js";
+
+const executors: Record<ScaffoldExecutorId, ScaffoldExecutor> = {
+  "g-v-p": new GvpExecutor(),
+};
+
+export function getScaffoldExecutor(id: ScaffoldExecutorId): ScaffoldExecutor {
+  return executors[id];
+}

--- a/src/scaffolds/types.ts
+++ b/src/scaffolds/types.ts
@@ -1,0 +1,27 @@
+import type { OpenClawConfig } from "../config/types.js";
+
+export type EmbeddedRunPayload = {
+  text?: string;
+  mediaUrl?: string;
+  mediaUrls?: string[];
+  replyToId?: string;
+  isError?: boolean;
+  audioAsVoice?: boolean;
+  replyToTag?: boolean;
+  replyToCurrent?: boolean;
+};
+
+export type ReasoningScaffoldsPhase0Config = {
+  /** Gate for Phase 0 scaffolds (no-op placeholder in this phase). */
+  enabled?: boolean;
+  /** Reserved for forward compatibility; must be 0 when set. */
+  phase?: 0;
+};
+
+export type ScaffoldsConfig = {
+  reasoning?: ReasoningScaffoldsPhase0Config;
+};
+
+export type OpenClawConfigWithScaffolds = OpenClawConfig & {
+  scaffolds?: ScaffoldsConfig;
+};


### PR DESCRIPTION
## Summary
Phase 1 “reasoning scaffolds”: adds manifest-driven **Generate → Verify → Patch** execution for opted-in skills.

Key properties:
- Executor owns prompts (no app system prompt injection).
- Model calls are **tool-less** and **messages[]**-based.
- Deterministic local verification (AJV schema + invariant gates) + conservative JSON fence stripping.
- Manifest parsing is strict and **fail-closed when executors are enabled**.

## RFC
- `docs/scaffolds-rfc.md`

## Activation / behavior
- Default behavior is unchanged.
- New behavior only activates when:
  1) `config.scaffolds.executorsEnabled === true`, **and**
  2) the invoked skill has a valid `scaffold.manifest.json` adjacent to `SKILL.md`.
- If `executorsEnabled === true` and a manifest is **present-but-invalid** → fail closed with:
  - `Scaffold error: invalid manifest (E_MANIFEST_INVALID).`

## What’s included
- Manifest loading + validation in `src/agents/skills/workspace.ts`
- Budgets (`BudgetCounter`) with validation rule `maxLlmCalls >= 1 + maxRetries`
- Gate pipeline:
  - AJV schema validation with normalized, deterministically-sorted failures
  - invariants: `no_placeholders`, `max_length`
  - deterministic failure ordering
- `g-v-p` executor implementation + tests
- Minimal runner wiring in `src/agents/pi-embedded-runner/run/attempt.ts` to route skill-command invocations through the executor when enabled

## Verification
- `pnpm lint`
- `pnpm check`
- `pnpm -s test`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Phase 1 scaffolds introducing a manifest-driven **Generate → Verify → Patch** executor for opted-in skills. The implementation adds:

- **Manifest-driven activation**: Skills with a valid `scaffold.manifest.json` adjacent to `SKILL.md` are routed through the GVP executor when `config.scaffolds.executorsEnabled === true`. Invalid manifests fail closed.
- **GVP executor**: Generates a JSON artifact, validates via AJV schema + invariant gates, and retries with targeted patch prompts up to the budget limit.
- **Gate pipeline**: Three-stage deterministic validation (schema → extract → invariants) with sorted failure output.
- **Budget enforcement**: `BudgetCounter` with `maxLlmCalls >= 1 + maxRetries` constraint validated at manifest parse time.
- **Config/sensitive refactoring**: DRY extraction of sensitive-key patterns into `src/config/sensitive.ts`.

Key observations:
- Default behavior is preserved; new code paths only activate under explicit opt-in.
- All scaffolded LLM calls record **zero token usage** in session messages — usage tracking will under-report for scaffolded executions.
- The `callModel` adapter and session message recording blocks in `attempt.ts` are quite verbose (~165 lines) with repeated zero-usage boilerplate that could be extracted.
- Unrelated SSRF test additions and search provider doc string update are bundled in the same PR.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — new behavior only activates under explicit opt-in and default paths are preserved.
- The implementation is well-structured with fail-closed semantics, strict manifest parsing, and deterministic validation. The code is gated behind two opt-in conditions (config flag + valid manifest), ensuring no impact on existing behavior. Deductions for: zero token usage tracking in scaffolded executions, verbose boilerplate in attempt.ts, and bundled unrelated changes. No critical logic bugs found beyond what was already flagged in prior review threads.
- `src/agents/pi-embedded-runner/run/attempt.ts` — the scaffold integration adds significant branching complexity to an already large file. `src/scaffolds/executors/gvp-executor.ts` — core execution logic.

<sub>Last reviewed commit: 65c978d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->