### PR TITLE
fix: abort child run on subagent timeout + retry with backoff + stale detection

### DIFF
--- a/src/agents/subagent-registry.abort-on-timeout.test.ts
+++ b/src/agents/subagent-registry.abort-on-timeout.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const noop = () => {};
+let lifecycleHandler:
+  | ((evt: { stream?: string; runId: string; data?: { phase?: string } }) => void)
+  | undefined;
+
+const callGatewaySpy = vi.fn(async (opts: unknown) => {
+  const request = opts as { method?: string };
+  if (request.method === "agent.wait") {
+    // Simulate a timeout response from the gateway.
+    return { status: "timeout" };
+  }
+  return {};
+});
+
+vi.mock("../gateway/call.js", () => ({
+  callGateway: (...args: unknown[]) => callGatewaySpy(...args),
+}));
+
+vi.mock("../infra/agent-events.js", () => ({
+  onAgentEvent: vi.fn((handler: typeof lifecycleHandler) => {
+    lifecycleHandler = handler;
+    return noop;
+  }),
+}));
+
+vi.mock("../config/config.js", () => ({
+  loadConfig: vi.fn(() => ({
+    agents: { defaults: { subagents: { archiveAfterMinutes: 0 }, timeoutSeconds: 60 } },
+  })),
+}));
+
+vi.mock("../config/sessions.js", () => ({
+  loadSessionStore: vi.fn(() => ({
+    "agent:main:subagent:child-timeout": { sessionId: "session-abc" },
+  })),
+  resolveAgentIdFromSessionKey: vi.fn(() => "main"),
+  resolveStorePath: vi.fn(() => "/tmp/test-store"),
+}));
+
+const abortSpy = vi.fn(() => true);
+vi.mock("./pi-embedded.js", () => ({
+  abortEmbeddedPiRun: (...args: unknown[]) => abortSpy(...args),
+}));
+
+const announceSpy = vi.fn(async () => true);
+vi.mock("./subagent-announce.js", () => ({
+  runSubagentAnnounceFlow: (...args: unknown[]) => announceSpy(...args),
+}));
+
+vi.mock("./subagent-registry.store.js", () => ({
+  loadSubagentRegistryFromDisk: vi.fn(() => new Map()),
+  saveSubagentRegistryToDisk: vi.fn(() => {}),
+}));
+
+vi.mock("../runtime.js", () => ({
+  defaultRuntime: { error: vi.fn() },
+}));
+
+describe("subagent abort on timeout", () => {
+  let mod: typeof import("./subagent-registry.js");
+
+  beforeAll(async () => {
+    mod = await import("./subagent-registry.js");
+  });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    callGatewaySpy.mockReset();
+    callGatewaySpy.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string };
+      if (request.method === "agent.wait") {
+        return { status: "timeout" };
+      }
+      return {};
+    });
+    abortSpy.mockReset();
+    abortSpy.mockReturnValue(true);
+    announceSpy.mockReset();
+    announceSpy.mockResolvedValue(true);
+    mod.resetSubagentRegistryForTests({ persist: false });
+  });
+
+  it("aborts the child run when wait times out", async () => {
+    mod.registerSubagentRun({
+      runId: "run-timeout-1",
+      childSessionKey: "agent:main:subagent:child-timeout",
+      requesterSessionKey: "main",
+      requesterDisplayKey: "main",
+      task: "long running task",
+      cleanup: "keep",
+    });
+
+    // Wait for the waitForSubagentCompletion to fire and get timeout.
+    await vi.advanceTimersByTimeAsync(100);
+
+    // Should have called abortEmbeddedPiRun with the child's sessionId.
+    expect(abortSpy).toHaveBeenCalledWith("session-abc");
+
+    // Announce flow should have been triggered with timeout outcome.
+    expect(announceSpy).toHaveBeenCalled();
+    const announceArgs = announceSpy.mock.calls[0]?.[0] as Record<string, unknown> | undefined;
+    expect(announceArgs?.outcome).toEqual({ status: "timeout" });
+  });
+
+  it("does not abort when wait completes successfully", async () => {
+    callGatewaySpy.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string };
+      if (request.method === "agent.wait") {
+        return { status: "ok", startedAt: Date.now(), endedAt: Date.now() };
+      }
+      return {};
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-ok-1",
+      childSessionKey: "agent:main:subagent:child-timeout",
+      requesterSessionKey: "main",
+      requesterDisplayKey: "main",
+      task: "quick task",
+      cleanup: "keep",
+    });
+
+    await vi.advanceTimersByTimeAsync(100);
+
+    // Should NOT have called abort.
+    expect(abortSpy).not.toHaveBeenCalled();
+
+    // Announce should still fire with ok status.
+    expect(announceSpy).toHaveBeenCalled();
+    const announceArgs = announceSpy.mock.calls[0]?.[0] as Record<string, unknown> | undefined;
+    expect(announceArgs?.outcome).toEqual({ status: "ok" });
+  });
+});

--- a/src/agents/subagent-registry.abort-on-timeout.test.ts
+++ b/src/agents/subagent-registry.abort-on-timeout.test.ts
@@ -29,6 +29,7 @@ vi.mock("../config/config.js", () => ({
   loadConfig: vi.fn(() => ({
     agents: { defaults: { subagents: { archiveAfterMinutes: 0 }, timeoutSeconds: 60 } },
   })),
+  STATE_DIR: "/tmp/openclaw-test",
 }));
 
 vi.mock("../config/sessions.js", () => ({
@@ -37,6 +38,10 @@ vi.mock("../config/sessions.js", () => ({
   })),
   resolveAgentIdFromSessionKey: vi.fn(() => "main"),
   resolveStorePath: vi.fn(() => "/tmp/test-store"),
+}));
+
+vi.mock("../runtime.js", () => ({
+  defaultRuntime: { error: vi.fn() },
 }));
 
 const abortSpy = vi.fn(() => true);
@@ -52,10 +57,6 @@ vi.mock("./subagent-announce.js", () => ({
 vi.mock("./subagent-registry.store.js", () => ({
   loadSubagentRegistryFromDisk: vi.fn(() => new Map()),
   saveSubagentRegistryToDisk: vi.fn(() => {}),
-}));
-
-vi.mock("../runtime.js", () => ({
-  defaultRuntime: { error: vi.fn() },
 }));
 
 describe("subagent abort on timeout", () => {

--- a/src/agents/subagent-registry.nested.test.ts
+++ b/src/agents/subagent-registry.nested.test.ts
@@ -18,6 +18,21 @@ vi.mock("../config/config.js", () => ({
   loadConfig: vi.fn(() => ({
     agents: { defaults: { subagents: { archiveAfterMinutes: 0 } } },
   })),
+  STATE_DIR: "/tmp/openclaw-test",
+}));
+
+vi.mock("../config/sessions.js", () => ({
+  loadSessionStore: vi.fn(() => ({ sessions: new Map() })),
+  resolveAgentIdFromSessionKey: vi.fn(() => undefined),
+  resolveStorePath: vi.fn(() => "/tmp/openclaw-test/sessions"),
+}));
+
+vi.mock("../runtime.js", () => ({
+  defaultRuntime: { arch: "x64", platform: "linux" },
+}));
+
+vi.mock("./pi-embedded.js", () => ({
+  abortEmbeddedPiRun: vi.fn(),
 }));
 
 vi.mock("./subagent-announce.js", () => ({

--- a/src/agents/subagent-registry.steer-restart.test.ts
+++ b/src/agents/subagent-registry.steer-restart.test.ts
@@ -26,6 +26,21 @@ vi.mock("../config/config.js", () => ({
   loadConfig: vi.fn(() => ({
     agents: { defaults: { subagents: { archiveAfterMinutes: 0 } } },
   })),
+  STATE_DIR: "/tmp/openclaw-test",
+}));
+
+vi.mock("../config/sessions.js", () => ({
+  loadSessionStore: vi.fn(() => ({ sessions: new Map() })),
+  resolveAgentIdFromSessionKey: vi.fn(() => undefined),
+  resolveStorePath: vi.fn(() => "/tmp/openclaw-test/sessions"),
+}));
+
+vi.mock("../runtime.js", () => ({
+  defaultRuntime: { arch: "x64", platform: "linux" },
+}));
+
+vi.mock("./pi-embedded.js", () => ({
+  abortEmbeddedPiRun: vi.fn(),
 }));
 
 const announceSpy = vi.fn(async () => true);

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -431,9 +431,7 @@ export function replaceSubagentRunAfterSteer(params: {
   subagentRuns.set(nextRunId, next);
   ensureListener();
   persistSubagentRuns();
-  if (archiveAtMs) {
-    startSweeper();
-  }
+  startSweeper();
   void waitForSubagentCompletion(nextRunId, waitTimeoutMs);
   return true;
 }

--- a/src/agents/subagent-registry.wait-retry.test.ts
+++ b/src/agents/subagent-registry.wait-retry.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const noop = () => {};
+let lifecycleHandler:
+  | ((evt: { stream?: string; runId: string; data?: { phase?: string } }) => void)
+  | undefined;
+
+const callGatewaySpy = vi.fn(async (opts: unknown) => {
+  const request = opts as { method?: string };
+  if (request.method === "agent.wait") {
+    throw new Error("gateway unreachable");
+  }
+  return {};
+});
+
+vi.mock("../gateway/call.js", () => ({
+  callGateway: (...args: unknown[]) => callGatewaySpy(...args),
+}));
+
+vi.mock("../infra/agent-events.js", () => ({
+  onAgentEvent: vi.fn((handler: typeof lifecycleHandler) => {
+    lifecycleHandler = handler;
+    return noop;
+  }),
+}));
+
+vi.mock("../config/config.js", () => ({
+  loadConfig: vi.fn(() => ({
+    agents: { defaults: { subagents: { archiveAfterMinutes: 0 }, timeoutSeconds: 60 } },
+  })),
+}));
+
+const announceSpy = vi.fn(async () => true);
+vi.mock("./subagent-announce.js", () => ({
+  runSubagentAnnounceFlow: (...args: unknown[]) => announceSpy(...args),
+}));
+
+vi.mock("./subagent-registry.store.js", () => ({
+  loadSubagentRegistryFromDisk: vi.fn(() => new Map()),
+  saveSubagentRegistryToDisk: vi.fn(() => {}),
+}));
+
+const errorSpy = vi.fn();
+vi.mock("../runtime.js", () => ({
+  defaultRuntime: { error: (...args: unknown[]) => errorSpy(...args) },
+}));
+
+vi.mock("../config/sessions.js", () => ({
+  loadSessionStore: vi.fn(() => ({})),
+  resolveAgentIdFromSessionKey: vi.fn(() => "main"),
+  resolveStorePath: vi.fn(() => "/tmp/test-store"),
+}));
+
+vi.mock("./pi-embedded.js", () => ({
+  abortEmbeddedPiRun: vi.fn(() => false),
+}));
+
+describe("subagent wait retry on RPC failure", () => {
+  let mod: typeof import("./subagent-registry.js");
+
+  beforeAll(async () => {
+    mod = await import("./subagent-registry.js");
+  });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    callGatewaySpy.mockReset();
+    callGatewaySpy.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string };
+      if (request.method === "agent.wait") {
+        throw new Error("gateway unreachable");
+      }
+      return {};
+    });
+    announceSpy.mockReset();
+    announceSpy.mockResolvedValue(true);
+    errorSpy.mockReset();
+    lifecycleHandler = undefined;
+    mod.resetSubagentRegistryForTests({ persist: false });
+  });
+
+  it("logs an error and schedules retry when agent.wait throws", async () => {
+    mod.registerSubagentRun({
+      runId: "run-1",
+      childSessionKey: "agent:main:subagent:child-1",
+      requesterSessionKey: "main",
+      requesterDisplayKey: "main",
+      task: "test task",
+      cleanup: "keep",
+    });
+
+    // Wait for the initial waitForSubagentCompletion to fire and fail.
+    await vi.advanceTimersByTimeAsync(100);
+
+    // Should have logged an error about the RPC failure.
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Subagent wait RPC failed for run-1"),
+    );
+
+    // Should have logged scheduling a retry.
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("scheduling retry 1/3"));
+  });
+
+  it("marks run as failed after exhausting retries", async () => {
+    mod.registerSubagentRun({
+      runId: "run-2",
+      childSessionKey: "agent:main:subagent:child-2",
+      requesterSessionKey: "main",
+      requesterDisplayKey: "main",
+      task: "test task 2",
+      cleanup: "keep",
+    });
+
+    // Initial call fails, retry 1 scheduled at 5s.
+    await vi.advanceTimersByTimeAsync(100);
+
+    // Advance past retry 1 (5s).
+    await vi.advanceTimersByTimeAsync(6_000);
+
+    // Advance past retry 2 (10s).
+    await vi.advanceTimersByTimeAsync(11_000);
+
+    // Advance past retry 3 (20s).
+    await vi.advanceTimersByTimeAsync(21_000);
+
+    // After 3 retries, should be marked as failed.
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("failed after 3 retries"));
+
+    // Announce flow should have been triggered with error status.
+    expect(announceSpy).toHaveBeenCalled();
+  });
+
+  it("clears retry state on successful wait", async () => {
+    // Start with failures, then succeed.
+    let callCount = 0;
+    callGatewaySpy.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string };
+      if (request.method === "agent.wait") {
+        callCount += 1;
+        if (callCount <= 1) {
+          throw new Error("gateway unreachable");
+        }
+        return { status: "ok", startedAt: Date.now(), endedAt: Date.now() };
+      }
+      return {};
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-3",
+      childSessionKey: "agent:main:subagent:child-3",
+      requesterSessionKey: "main",
+      requesterDisplayKey: "main",
+      task: "test task 3",
+      cleanup: "keep",
+    });
+
+    // Initial call fails.
+    await vi.advanceTimersByTimeAsync(100);
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("scheduling retry 1/3"));
+
+    // Advance past retry 1 — this time it succeeds.
+    await vi.advanceTimersByTimeAsync(6_000);
+
+    // Announce flow should be triggered with ok status.
+    expect(announceSpy).toHaveBeenCalled();
+
+    // Should NOT have logged exhausted retries.
+    const exhaustedCalls = errorSpy.mock.calls.filter(
+      (args: unknown[]) => typeof args[0] === "string" && args[0].includes("failed after"),
+    );
+    expect(exhaustedCalls).toHaveLength(0);
+  });
+});

--- a/src/agents/subagent-registry.wait-retry.test.ts
+++ b/src/agents/subagent-registry.wait-retry.test.ts
@@ -28,6 +28,22 @@ vi.mock("../config/config.js", () => ({
   loadConfig: vi.fn(() => ({
     agents: { defaults: { subagents: { archiveAfterMinutes: 0 }, timeoutSeconds: 60 } },
   })),
+  STATE_DIR: "/tmp/openclaw-test",
+}));
+
+vi.mock("../config/sessions.js", () => ({
+  loadSessionStore: vi.fn(() => ({})),
+  resolveAgentIdFromSessionKey: vi.fn(() => "main"),
+  resolveStorePath: vi.fn(() => "/tmp/test-store"),
+}));
+
+const errorSpy = vi.fn();
+vi.mock("../runtime.js", () => ({
+  defaultRuntime: { error: (...args: unknown[]) => errorSpy(...args) },
+}));
+
+vi.mock("./pi-embedded.js", () => ({
+  abortEmbeddedPiRun: vi.fn(() => false),
 }));
 
 const announceSpy = vi.fn(async () => true);
@@ -38,21 +54,6 @@ vi.mock("./subagent-announce.js", () => ({
 vi.mock("./subagent-registry.store.js", () => ({
   loadSubagentRegistryFromDisk: vi.fn(() => new Map()),
   saveSubagentRegistryToDisk: vi.fn(() => {}),
-}));
-
-const errorSpy = vi.fn();
-vi.mock("../runtime.js", () => ({
-  defaultRuntime: { error: (...args: unknown[]) => errorSpy(...args) },
-}));
-
-vi.mock("../config/sessions.js", () => ({
-  loadSessionStore: vi.fn(() => ({})),
-  resolveAgentIdFromSessionKey: vi.fn(() => "main"),
-  resolveStorePath: vi.fn(() => "/tmp/test-store"),
-}));
-
-vi.mock("./pi-embedded.js", () => ({
-  abortEmbeddedPiRun: vi.fn(() => false),
 }));
 
 describe("subagent wait retry on RPC failure", () => {


### PR DESCRIPTION
## Problem

When a sub-agent's `agent.wait` times out, the child run continues executing indefinitely in the background, consuming resources. The parent records a timeout outcome but never sends an abort signal to stop the child.

Additionally, if the gateway RPC itself fails (e.g., during a gateway restart), the error is silently swallowed with an empty `catch {}`, leaving the run in limbo until the 60-minute archive sweeper cleans it up.

## Changes

### 1. Abort child on timeout
When `waitForSubagentCompletion` receives a timeout response, it now calls `abortEmbeddedPiRun()` to actively stop the child run. This prevents zombie sub-agents from burning tokens after the parent has given up.

### 2. Retry with exponential backoff
RPC failures in `waitForSubagentCompletion` now trigger up to 3 retries with exponential backoff (5s → 10s → 20s). If all retries fail, the run is marked as failed and the announce flow notifies the requester. This handles transient gateway restarts gracefully.

### 3. Stale run detection
The sweeper now detects runs that have been active for >2 hours without completion. These are marked as failed, aborted, and announced to the requester. This catches edge cases where both the wait RPC and the lifecycle listener miss the completion event.

### 4. Tests
- New `abort-on-timeout.test.ts` — verifies abort is called on timeout and not on success
- Updated `wait-retry.test.ts` — added mocks for new imports

## Impact
- No more zombie sub-agents running after timeout
- Resilient to gateway restarts during sub-agent execution
- Orphaned runs are detected and cleaned up within 2 hours
- All changes are backward-compatible (new fields on SubagentRunRecord are optional)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds three critical reliability improvements to subagent run management: abort on timeout, retry with exponential backoff, and stale run detection. The implementation prevents zombie subagents from running indefinitely when the parent times out by calling `abortChildRun()` when `wait.status === "timeout"` (line 601-602). RPC failures now trigger up to 3 retries with exponential backoff (5s → 10s → 20s) via `scheduleWaitRetry()`, and the sweeper detects runs active for >2 hours without completion to mark them as failed. All new optional fields (`waitRetryCount`, `lastWaitRetryAt`) are backward-compatible, and comprehensive tests verify abort behavior and retry logic.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-designed with proper error handling, backward-compatible changes, and comprehensive test coverage for all three features (abort-on-timeout, retry logic, stale detection). The logic correctly handles edge cases like clearing retry state on success and preventing double-announces.
- No files require special attention

<sub>Last reviewed commit: 8c6600c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->