### PR TITLE
fix: preserve env-var apiKey references in models.json

### DIFF
--- a/src/agents/models-config.preserves-env-var-apikey.e2e.test.ts
+++ b/src/agents/models-config.preserves-env-var-apikey.e2e.test.ts
@@ -1,0 +1,94 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveOpenClawAgentDir } from "./agent-paths.js";
+import {
+  installModelsConfigTestHooks,
+  withModelsTempHome as withTempHome,
+} from "./models-config.e2e-harness.js";
+import { ensureOpenClawModelsJson } from "./models-config.js";
+
+installModelsConfigTestHooks();
+
+describe("models-config", () => {
+  it("preserves env-var apiKey references when rewriting models.json", async () => {
+    await withTempHome(async () => {
+      const prevKey = process.env.MINIMAX_API_KEY;
+      process.env.MINIMAX_API_KEY = "sk-minimax-real-secret";
+      try {
+        const agentDir = resolveOpenClawAgentDir();
+        await fs.mkdir(agentDir, { recursive: true });
+
+        // Seed models.json with an env-var name as apiKey.
+        await fs.writeFile(
+          path.join(agentDir, "models.json"),
+          JSON.stringify(
+            {
+              providers: {
+                minimax: {
+                  baseUrl: "https://api.minimax.io/anthropic",
+                  api: "anthropic-messages",
+                  apiKey: "MINIMAX_API_KEY",
+                  models: [
+                    {
+                      id: "MiniMax-M2.1",
+                      name: "MiniMax M2.1",
+                      reasoning: false,
+                      input: ["text"],
+                      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                      contextWindow: 200000,
+                      maxTokens: 8192,
+                    },
+                  ],
+                },
+              },
+            },
+            null,
+            2,
+          ),
+          "utf8",
+        );
+
+        const cfg: OpenClawConfig = {
+          models: {
+            providers: {
+              minimax: {
+                baseUrl: "https://api.minimax.io/anthropic",
+                api: "anthropic-messages",
+                models: [
+                  {
+                    id: "MiniMax-M2.1",
+                    name: "MiniMax M2.1",
+                    reasoning: false,
+                    input: ["text"],
+                    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                    contextWindow: 200000,
+                    maxTokens: 8192,
+                  },
+                ],
+              },
+            },
+          },
+        };
+
+        await ensureOpenClawModelsJson(cfg);
+
+        const raw = await fs.readFile(path.join(agentDir, "models.json"), "utf8");
+        const parsed = JSON.parse(raw) as {
+          providers: Record<string, { apiKey?: string }>;
+        };
+
+        // The env-var name should be preserved, NOT replaced with the resolved secret.
+        expect(parsed.providers.minimax?.apiKey).toBe("MINIMAX_API_KEY");
+        expect(raw).not.toContain("sk-minimax-real-secret");
+      } finally {
+        if (prevKey === undefined) {
+          delete process.env.MINIMAX_API_KEY;
+        } else {
+          process.env.MINIMAX_API_KEY = prevKey;
+        }
+      }
+    });
+  });
+});

--- a/src/agents/models-config.preserves-env-var-apikey.e2e.test.ts
+++ b/src/agents/models-config.preserves-env-var-apikey.e2e.test.ts
@@ -5,6 +5,8 @@ import type { OpenClawConfig } from "../config/config.js";
 import { resolveOpenClawAgentDir } from "./agent-paths.js";
 import {
   installModelsConfigTestHooks,
+  MODELS_CONFIG_IMPLICIT_ENV_VARS,
+  unsetEnv,
   withModelsTempHome as withTempHome,
 } from "./models-config.e2e-harness.js";
 import { ensureOpenClawModelsJson } from "./models-config.js";
@@ -14,48 +16,39 @@ installModelsConfigTestHooks();
 describe("models-config", () => {
   it("preserves env-var apiKey references when rewriting models.json", async () => {
     await withTempHome(async () => {
-      const prevKey = process.env.MINIMAX_API_KEY;
-      process.env.MINIMAX_API_KEY = "sk-minimax-real-secret";
-      try {
-        const agentDir = resolveOpenClawAgentDir();
-        await fs.mkdir(agentDir, { recursive: true });
+      // Clear all implicit env vars so resolveEnvApiKeyVarName returns undefined,
+      // forcing the flow through resolveApiKeyFromProfiles (which returns plaintext).
+      unsetEnv(MODELS_CONFIG_IMPLICIT_ENV_VARS);
 
-        // Seed models.json with an env-var name as apiKey.
-        await fs.writeFile(
-          path.join(agentDir, "models.json"),
-          JSON.stringify(
-            {
-              providers: {
-                minimax: {
-                  baseUrl: "https://api.minimax.io/anthropic",
-                  api: "anthropic-messages",
-                  apiKey: "MINIMAX_API_KEY",
-                  models: [
-                    {
-                      id: "MiniMax-M2.1",
-                      name: "MiniMax M2.1",
-                      reasoning: false,
-                      input: ["text"],
-                      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-                      contextWindow: 200000,
-                      maxTokens: 8192,
-                    },
-                  ],
-                },
-              },
+      const agentDir = resolveOpenClawAgentDir();
+      await fs.mkdir(agentDir, { recursive: true });
+
+      // Seed auth-profiles.json with a minimax profile containing a plaintext key.
+      await fs.writeFile(
+        path.join(agentDir, "auth-profiles.json"),
+        JSON.stringify({
+          version: 1,
+          profiles: {
+            "minimax:default": {
+              type: "api_key",
+              key: "sk-minimax-real-secret-key",
+              provider: "minimax",
             },
-            null,
-            2,
-          ),
-          "utf8",
-        );
+          },
+        }),
+        "utf8",
+      );
 
-        const cfg: OpenClawConfig = {
-          models: {
+      // Seed models.json with an env-var name as apiKey.
+      await fs.writeFile(
+        path.join(agentDir, "models.json"),
+        JSON.stringify(
+          {
             providers: {
               minimax: {
                 baseUrl: "https://api.minimax.io/anthropic",
                 api: "anthropic-messages",
+                apiKey: "MINIMAX_API_KEY",
                 models: [
                   {
                     id: "MiniMax-M2.1",
@@ -70,25 +63,44 @@ describe("models-config", () => {
               },
             },
           },
-        };
+          null,
+          2,
+        ),
+        "utf8",
+      );
 
-        await ensureOpenClawModelsJson(cfg);
+      const cfg: OpenClawConfig = {
+        models: {
+          providers: {
+            minimax: {
+              baseUrl: "https://api.minimax.io/anthropic",
+              api: "anthropic-messages",
+              models: [
+                {
+                  id: "MiniMax-M2.1",
+                  name: "MiniMax M2.1",
+                  reasoning: false,
+                  input: ["text"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 200000,
+                  maxTokens: 8192,
+                },
+              ],
+            },
+          },
+        },
+      };
 
-        const raw = await fs.readFile(path.join(agentDir, "models.json"), "utf8");
-        const parsed = JSON.parse(raw) as {
-          providers: Record<string, { apiKey?: string }>;
-        };
+      await ensureOpenClawModelsJson(cfg);
 
-        // The env-var name should be preserved, NOT replaced with the resolved secret.
-        expect(parsed.providers.minimax?.apiKey).toBe("MINIMAX_API_KEY");
-        expect(raw).not.toContain("sk-minimax-real-secret");
-      } finally {
-        if (prevKey === undefined) {
-          delete process.env.MINIMAX_API_KEY;
-        } else {
-          process.env.MINIMAX_API_KEY = prevKey;
-        }
-      }
+      const raw = await fs.readFile(path.join(agentDir, "models.json"), "utf8");
+      const parsed = JSON.parse(raw) as {
+        providers: Record<string, { apiKey?: string }>;
+      };
+
+      // The env-var name should be preserved, NOT replaced with the resolved secret.
+      expect(parsed.providers.minimax?.apiKey).toBe("MINIMAX_API_KEY");
+      expect(raw).not.toContain("sk-minimax-real-secret-key");
     });
   });
 });


### PR DESCRIPTION
Fixes #17329

When `models.json` contains an env-var name as `apiKey` (e.g. `"MINIMAX_API_KEY"`), `ensureOpenClawModelsJson()` overwrites it with the resolved plaintext secret. This makes `models.json` unsafe to version-control.

This PR preserves the original env-var name by checking if it matches `/^[A-Z][A-Z0-9_]*$/` before writing. Backward-compatible — real API keys contain lowercase/hyphens and won't match.

Includes an e2e test.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where `ensureOpenClawModelsJson()` would overwrite env-var names (e.g. `"MINIMAX_API_KEY"`) in `models.json` with the resolved plaintext secret, making the file unsafe to version-control.

- Adds a post-normalization preservation step in `ensureOpenClawModelsJson` that detects when an existing `models.json` entry uses an env-var name as `apiKey` (matched by `/^[A-Z][A-Z0-9_]*$/`) and the newly resolved value is a plaintext secret, then restores the original env-var reference.
- Moves the `readJson(targetPath)` call outside the `mode === "merge"` block so the existing file contents are available for both merging and the new preservation logic.
- Adds an e2e test that seeds `auth-profiles.json` with a plaintext key (clearing all implicit env vars) to force the code path through `resolveApiKeyFromProfiles`, validating that the env-var name in `models.json` is preserved rather than replaced with the resolved secret.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — the change is narrowly scoped, backward-compatible, and well-tested.
- The regex heuristic is sound: real API keys invariably contain lowercase/special characters, so the env-var pattern won't false-positive. The preservation logic runs after normalization and only overwrites when both the old value matches the env-var pattern and the new value does not. The `readJson` call moved outside the merge block is a no-op when the file doesn't exist. The e2e test (after the fix in f5b97be) properly exercises the preservation path by using auth profiles rather than env vars.
- No files require special attention.

<sub>Last reviewed commit: f5b97be</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->