### PR TITLE
Telegram actions: let poll fall back to core sender

### DIFF
--- a/src/channels/plugins/actions/actions.test.ts
+++ b/src/channels/plugins/actions/actions.test.ts
@@ -363,6 +363,11 @@ describe("telegramMessageActions", () => {
     expect(actions).not.toContain("sticker-search");
   });
 
+  it("defers unsupported actions (like poll) to non-plugin handlers", () => {
+    expect(telegramMessageActions.supportsAction?.({ action: "send" })).toBe(true);
+    expect(telegramMessageActions.supportsAction?.({ action: "poll" })).toBe(false);
+  });
+
   it("allows media-only sends and passes asVoice", async () => {
     const cfg = telegramCfg();
 

--- a/src/channels/plugins/actions/telegram.ts
+++ b/src/channels/plugins/actions/telegram.ts
@@ -15,6 +15,14 @@ import { isTelegramInlineButtonsEnabled } from "../../../telegram/inline-buttons
 import type { ChannelMessageActionAdapter, ChannelMessageActionName } from "../types.js";
 
 const providerId = "telegram";
+const TELEGRAM_PLUGIN_ACTIONS = new Set<ChannelMessageActionName>([
+  "send",
+  "react",
+  "delete",
+  "edit",
+  "sticker",
+  "sticker-search",
+]);
 
 function readTelegramSendParams(params: Record<string, unknown>) {
   const to = readStringParam(params, "to", { required: true });
@@ -42,6 +50,7 @@ function readTelegramSendParams(params: Record<string, unknown>) {
 }
 
 export const telegramMessageActions: ChannelMessageActionAdapter = {
+  supportsAction: ({ action }) => TELEGRAM_PLUGIN_ACTIONS.has(action),
   listActions: ({ cfg }) => {
     const accounts = listEnabledTelegramAccounts(cfg).filter(
       (account) => account.tokenSource !== "none",


### PR DESCRIPTION
## Summary
- prevent Telegram plugin adapter from intercepting unsupported actions like `poll`
- add an explicit Telegram plugin action whitelist via `supportsAction`
- allow `poll` to correctly fall back to the core outbound `sendPoll` path instead of throwing `Action poll is not supported for provider telegram`
- add regression coverage in `actions.test.ts`

## Testing
- bunx vitest run src/channels/plugins/actions/actions.test.ts
- bunx oxlint --type-aware src/channels/plugins/actions/telegram.ts src/channels/plugins/actions/actions.test.ts
- bunx oxfmt --check src/channels/plugins/actions/telegram.ts src/channels/plugins/actions/actions.test.ts

Fixes #17528

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds explicit action support filtering to the Telegram plugin adapter to prevent it from intercepting unsupported actions like `poll`. The `supportsAction` method now uses a whitelist (`TELEGRAM_PLUGIN_ACTIONS`) containing only the actions this adapter can handle: `send`, `react`, `delete`, `edit`, `sticker`, and `sticker-search`. This allows `poll` actions to correctly fall back to the core outbound `sendPoll` path instead of throwing an error.

- Added `TELEGRAM_PLUGIN_ACTIONS` Set with supported action names
- Implemented `supportsAction` method on the Telegram adapter  
- Added regression test coverage verifying `send` is supported and `poll` is not
- Follows existing pattern used by Signal adapter

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change is minimal, well-tested, and follows established patterns. It adds an explicit whitelist to prevent incorrect action routing, which is a defensive programming practice. The implementation is straightforward with appropriate test coverage, and fixes a clear bug where unsupported actions were being intercepted.
- No files require special attention

<sub>Last reviewed commit: 1d63547</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->