### PR TITLE
fix(configure): update web tools hint to reflect all search providers

### DIFF
--- a/src/commands/configure.shared.ts
+++ b/src/commands/configure.shared.ts
@@ -52,7 +52,7 @@ export const CONFIGURE_SECTION_OPTIONS: Array<{
 }> = [
   { value: "workspace", label: "Workspace", hint: "Set workspace + sessions" },
   { value: "model", label: "Model", hint: "Pick provider + credentials" },
-  { value: "web", label: "Web tools", hint: "Configure Brave search + fetch" },
+  { value: "web", label: "Web tools", hint: "Configure web search provider + fetch" },
   { value: "gateway", label: "Gateway", hint: "Port, bind, auth, tailscale" },
   {
     value: "daemon",

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -85,7 +85,7 @@ export const FIELD_HELP: Record<string, string> = {
     'Text suffix for cross-context markers (supports "{channel}").',
   "tools.message.broadcast.enabled": "Enable broadcast action (default: true).",
   "tools.web.search.enabled": "Enable the web_search tool (requires a provider API key).",
-  "tools.web.search.provider": 'Search provider ("brave" or "perplexity").',
+  "tools.web.search.provider": 'Search provider ("brave", "perplexity", "grok", or "parallel").',
   "tools.web.search.apiKey": "Brave Search API key (fallback: BRAVE_API_KEY env var).",
   "tools.web.search.maxResults": "Default number of results to return (1-10).",
   "tools.web.search.timeoutSeconds": "Timeout in seconds for web_search requests.",
@@ -96,6 +96,17 @@ export const FIELD_HELP: Record<string, string> = {
     "Perplexity base URL override (default: https://openrouter.ai/api/v1 or https://api.perplexity.ai).",
   "tools.web.search.perplexity.model":
     'Perplexity model override (default: "perplexity/sonar-pro").',
+  "tools.web.search.parallel.apiKey":
+    "Parallel API key (fallback: PARALLEL_API_KEY env var). Get a key at https://platform.parallel.ai.",
+  "tools.web.search.parallel.baseUrl":
+    "Parallel API base URL override (default: https://api.parallel.ai/v1beta).",
+  "tools.web.search.parallel.mode":
+    'Search mode: "one-shot" (comprehensive, default), "agentic" (concise, multi-step), or "fast" (~1s latency).',
+  "tools.web.search.parallel.maxResults": "Maximum results to return (1-20, default: 10).",
+  "tools.web.search.parallel.maxCharsPerResult":
+    "Maximum characters per result excerpt (default: 10000).",
+  "tools.web.search.parallel.maxCharsTotal":
+    "Maximum total characters across all excerpts (optional cap).",
   "tools.web.fetch.enabled": "Enable the web_fetch tool (lightweight HTTP fetch).",
   "tools.web.fetch.maxChars": "Max characters returned by web_fetch (truncated).",
   "tools.web.fetch.maxCharsCap":

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -356,8 +356,8 @@ export type ToolsConfig = {
     search?: {
       /** Enable web search tool (default: true when API key is present). */
       enabled?: boolean;
-      /** Search provider ("brave", "perplexity", or "grok"). */
-      provider?: "brave" | "perplexity" | "grok";
+      /** Search provider ("brave", "perplexity", "grok", or "parallel"). */
+      provider?: "brave" | "perplexity" | "grok" | "parallel";
       /** Brave Search API key (optional; defaults to BRAVE_API_KEY env var). */
       apiKey?: string;
       /** Default search results count (1-10). */
@@ -383,6 +383,21 @@ export type ToolsConfig = {
         model?: string;
         /** Include inline citations in response text as markdown links (default: false). */
         inlineCitations?: boolean;
+      };
+      /** Parallel-specific configuration (used when provider="parallel"). */
+      parallel?: {
+        /** API key for Parallel (defaults to PARALLEL_API_KEY env var). */
+        apiKey?: string;
+        /** Base URL for Parallel API (default: https://api.parallel.ai/v1beta). */
+        baseUrl?: string;
+        /** Search mode: one-shot, agentic, or fast (default: "one-shot"). */
+        mode?: "one-shot" | "agentic" | "fast";
+        /** Maximum results to return (1-20, default: 10). */
+        maxResults?: number;
+        /** Maximum characters per result excerpt (default: 10000). */
+        maxCharsPerResult?: number;
+        /** Maximum total characters across all excerpts. */
+        maxCharsTotal?: number;
       };
     };
     fetch?: {

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -226,7 +226,14 @@ export const ToolPolicySchema = ToolPolicyBaseSchema.superRefine((value, ctx) =>
 export const ToolsWebSearchSchema = z
   .object({
     enabled: z.boolean().optional(),
-    provider: z.union([z.literal("brave"), z.literal("perplexity"), z.literal("grok")]).optional(),
+    provider: z
+      .union([
+        z.literal("brave"),
+        z.literal("perplexity"),
+        z.literal("grok"),
+        z.literal("parallel"),
+      ])
+      .optional(),
     apiKey: z.string().optional().register(sensitive),
     maxResults: z.number().int().positive().optional(),
     timeoutSeconds: z.number().int().positive().optional(),
@@ -244,6 +251,17 @@ export const ToolsWebSearchSchema = z
         apiKey: z.string().optional().register(sensitive),
         model: z.string().optional(),
         inlineCitations: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
+    parallel: z
+      .object({
+        apiKey: z.string().optional().register(sensitive),
+        baseUrl: z.string().optional(),
+        mode: z.enum(["one-shot", "agentic", "fast"]).optional(),
+        maxResults: z.number().int().min(1).max(20).optional(),
+        maxCharsPerResult: z.number().optional(),
+        maxCharsTotal: z.number().optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
Update the CLI wizard hint from 'Configure Brave search + fetch' to 'Configure web search provider + fetch' since OpenClaw now supports multiple search providers:

- Brave (default)
- Perplexity
- Grok (xAI)
- Parallel

This is a minor UX fix to ensure the configure menu accurately reflects the available options.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added Parallel as a fourth web search provider alongside Brave, Perplexity, and Grok. The implementation includes:

- Full API integration with Parallel's search endpoint (`/v1beta/search`)
- Configuration support for mode (`one-shot`/`agentic`/`fast`), result limits (1-20), and excerpt sizing
- Updated CLI wizard to present all four providers with descriptive hints
- Schema validation and type definitions for the new provider
- Help text and documentation references

The PR title mentions updating the configure hint, which was accomplished by changing "Configure Brave search + fetch" to "Configure web search provider + fetch" in `configure.shared.ts:55`.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - well-structured feature addition with consistent type safety
- The implementation follows existing patterns for other search providers (Perplexity, Grok), maintains type safety throughout with Zod schemas and TypeScript types, includes proper error handling, and updates all relevant configuration surfaces. The cache key issue mentioned in previous threads is a valid performance consideration but not a blocking issue.
- No files require special attention

<sub>Last reviewed commit: 74ca377</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->