### PR TITLE
fix(gateway): add shared-secret fallback to trusted-proxy auth dispatcher

### DIFF
--- a/src/gateway/auth.test.ts
+++ b/src/gateway/auth.test.ts
@@ -633,3 +633,191 @@ describe("trusted-proxy auth", () => {
     expect(res.user).toBe("nick@example.com");
   });
 });
+
+describe("trusted-proxy shared-secret fallback", () => {
+  const trustedProxyConfig = {
+    userHeader: "x-forwarded-user",
+  };
+
+  const untrustedReq = {
+    socket: { remoteAddress: "127.0.0.1" },
+    headers: {
+      host: "gateway.local",
+      "x-forwarded-user": "nick@example.com",
+    },
+  } as never;
+
+  // trustedProxies: ["10.0.0.1"] means 127.0.0.1 is NOT trusted
+  const untrustedProxies = ["10.0.0.1"];
+
+  it("trusted-proxy via proxy succeeds (unchanged)", async () => {
+    const res = await authorizeGatewayConnect({
+      auth: {
+        mode: "trusted-proxy",
+        allowTailscale: false,
+        trustedProxy: trustedProxyConfig,
+        token: "server-token",
+      },
+      connectAuth: null,
+      trustedProxies: ["10.0.0.1"],
+      req: {
+        socket: { remoteAddress: "10.0.0.1" },
+        headers: {
+          host: "gateway.local",
+          "x-forwarded-user": "nick@example.com",
+        },
+      } as never,
+    });
+
+    expect(res.ok).toBe(true);
+    expect(res.method).toBe("trusted-proxy");
+    expect(res.user).toBe("nick@example.com");
+  });
+
+  it("rejects untrusted IP when no token/password configured (unchanged)", async () => {
+    const res = await authorizeGatewayConnect({
+      auth: {
+        mode: "trusted-proxy",
+        allowTailscale: false,
+        trustedProxy: trustedProxyConfig,
+      },
+      connectAuth: null,
+      trustedProxies: untrustedProxies,
+      req: untrustedReq,
+    });
+
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe("trusted_proxy_untrusted_source");
+  });
+
+  it("falls back to token when untrusted IP provides valid token", async () => {
+    const res = await authorizeGatewayConnect({
+      auth: {
+        mode: "trusted-proxy",
+        allowTailscale: false,
+        trustedProxy: trustedProxyConfig,
+        token: "server-token",
+      },
+      connectAuth: { token: "server-token" },
+      trustedProxies: untrustedProxies,
+      req: untrustedReq,
+    });
+
+    expect(res.ok).toBe(true);
+    expect(res.method).toBe("token");
+  });
+
+  it("rejects untrusted IP with invalid token", async () => {
+    const res = await authorizeGatewayConnect({
+      auth: {
+        mode: "trusted-proxy",
+        allowTailscale: false,
+        trustedProxy: trustedProxyConfig,
+        token: "server-token",
+      },
+      connectAuth: { token: "wrong-token" },
+      trustedProxies: untrustedProxies,
+      req: untrustedReq,
+    });
+
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe("token_mismatch");
+  });
+
+  it("falls back to password when untrusted IP provides valid password", async () => {
+    const res = await authorizeGatewayConnect({
+      auth: {
+        mode: "trusted-proxy",
+        allowTailscale: false,
+        trustedProxy: trustedProxyConfig,
+        password: "server-pass",
+      },
+      connectAuth: { password: "server-pass" },
+      trustedProxies: untrustedProxies,
+      req: untrustedReq,
+    });
+
+    expect(res.ok).toBe(true);
+    expect(res.method).toBe("password");
+  });
+
+  it("rejects untrusted IP with invalid password", async () => {
+    const res = await authorizeGatewayConnect({
+      auth: {
+        mode: "trusted-proxy",
+        allowTailscale: false,
+        trustedProxy: trustedProxyConfig,
+        password: "server-pass",
+      },
+      connectAuth: { password: "wrong-pass" },
+      trustedProxies: untrustedProxies,
+      req: untrustedReq,
+    });
+
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe("password_mismatch");
+  });
+
+  it("rejects when client provides token but no server token configured", async () => {
+    const res = await authorizeGatewayConnect({
+      auth: {
+        mode: "trusted-proxy",
+        allowTailscale: false,
+        trustedProxy: trustedProxyConfig,
+        // no token or password configured on server
+      },
+      connectAuth: { token: "client-token" },
+      trustedProxies: untrustedProxies,
+      req: untrustedReq,
+    });
+
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe("trusted_proxy_untrusted_source");
+  });
+
+  it("rejects when rate limited during fallback", async () => {
+    const limiter = createLimiterSpy();
+    limiter.check.mockReturnValue({ allowed: false, remaining: 0, retryAfterMs: 5000 });
+
+    const res = await authorizeGatewayConnect({
+      auth: {
+        mode: "trusted-proxy",
+        allowTailscale: false,
+        trustedProxy: trustedProxyConfig,
+        token: "server-token",
+      },
+      connectAuth: { token: "server-token" },
+      trustedProxies: untrustedProxies,
+      req: untrustedReq,
+      rateLimiter: limiter,
+    });
+
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe("rate_limited");
+    expect(res.rateLimited).toBe(true);
+  });
+
+  it("uses proxy method when request comes from trusted proxy even if token is provided", async () => {
+    const res = await authorizeGatewayConnect({
+      auth: {
+        mode: "trusted-proxy",
+        allowTailscale: false,
+        trustedProxy: trustedProxyConfig,
+        token: "server-token",
+      },
+      connectAuth: { token: "server-token" },
+      trustedProxies: ["127.0.0.1"],
+      req: {
+        socket: { remoteAddress: "127.0.0.1" },
+        headers: {
+          host: "gateway.local",
+          "x-forwarded-user": "nick@example.com",
+        },
+      } as never,
+    });
+
+    expect(res.ok).toBe(true);
+    expect(res.method).toBe("trusted-proxy");
+    expect(res.user).toBe("nick@example.com");
+  });
+});

--- a/src/gateway/auth.ts
+++ b/src/gateway/auth.ts
@@ -268,8 +268,7 @@ export function resolveGatewayAuth(params: {
   }
 
   const allowTailscale =
-    authConfig.allowTailscale ??
-    (params.tailscaleMode === "serve" && mode !== "password" && mode !== "trusted-proxy");
+    authConfig.allowTailscale ?? (params.tailscaleMode === "serve" && mode !== "password");
 
   return {
     mode,
@@ -378,6 +377,13 @@ export async function authorizeGatewayConnect(
     params.allowRealIpFallback === true,
   );
 
+  const limiter = params.rateLimiter;
+  const ip =
+    params.clientIp ??
+    resolveRequestClientIp(req, trustedProxies, params.allowRealIpFallback === true) ??
+    req?.socket?.remoteAddress;
+  const rateLimitScope = params.rateLimitScope ?? AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET;
+
   if (auth.mode === "trusted-proxy") {
     if (!auth.trustedProxy) {
       return { ok: false, reason: "trusted_proxy_config_missing" };
@@ -395,6 +401,48 @@ export async function authorizeGatewayConnect(
     if ("user" in result) {
       return { ok: true, method: "trusted-proxy", user: result.user };
     }
+
+    // Trusted-proxy auth failed — try shared-secret fallback for internal
+    // services (CLI, node host, ACP) that bypass the reverse proxy.
+    // If no token/password is configured, there's no fallback available.
+    if (!auth.token && !auth.password) {
+      return { ok: false, reason: result.reason };
+    }
+
+    // Rate-limit fallback attempts
+    if (limiter) {
+      const rlCheck: RateLimitCheckResult = limiter.check(ip, rateLimitScope);
+      if (!rlCheck.allowed) {
+        return {
+          ok: false,
+          reason: "rate_limited",
+          rateLimited: true,
+          retryAfterMs: rlCheck.retryAfterMs,
+        };
+      }
+    }
+
+    // Try token fallback
+    if (connectAuth?.token && auth.token) {
+      if (safeEqualSecret(connectAuth.token, auth.token)) {
+        limiter?.reset(ip, rateLimitScope);
+        return { ok: true, method: "token" };
+      }
+      limiter?.recordFailure(ip, rateLimitScope);
+      return { ok: false, reason: "token_mismatch" };
+    }
+
+    // Try password fallback
+    if (connectAuth?.password && auth.password) {
+      if (safeEqualSecret(connectAuth.password, auth.password)) {
+        limiter?.reset(ip, rateLimitScope);
+        return { ok: true, method: "password" };
+      }
+      limiter?.recordFailure(ip, rateLimitScope);
+      return { ok: false, reason: "password_mismatch" };
+    }
+
+    // Client didn't provide matching credentials — return original proxy failure
     return { ok: false, reason: result.reason };
   }
 
@@ -402,12 +450,6 @@ export async function authorizeGatewayConnect(
     return { ok: true, method: "none" };
   }
 
-  const limiter = params.rateLimiter;
-  const ip =
-    params.clientIp ??
-    resolveRequestClientIp(req, trustedProxies, params.allowRealIpFallback === true) ??
-    req?.socket?.remoteAddress;
-  const rateLimitScope = params.rateLimitScope ?? AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET;
   if (limiter) {
     const rlCheck: RateLimitCheckResult = limiter.check(ip, rateLimitScope);
     if (!rlCheck.allowed) {


### PR DESCRIPTION
## Summary

Fixes #17761.

> **Note:** The device-pairing bypass for trusted-proxy connections (previously PR #17705) has been absorbed upstream via the `connect-policy.ts` refactoring (`isTrustedProxyControlUiOperatorAuth`, `evaluateMissingDeviceIdentity`, `shouldSkipControlUiPairing`). This PR is now based directly on main and focuses solely on the shared-secret auth fallback.

The gateway's `authorizeGatewayConnect` dispatcher treats `trusted-proxy` as a single-mode gate: when proxy auth fails (e.g. internal services connecting directly without the reverse proxy), the function early-returns before reaching the shared-secret (token/password) or Tailscale code paths. This breaks all internal consumers — node host, CLI RPC, ACP, TUI, agent tools, etc.

This PR adds an inline shared-secret fallback within the trusted-proxy block:

- When proxy auth fails and a token/password is configured, attempt shared-secret auth before returning failure
- Rate-limit fallback attempts using the existing `AuthRateLimiter`
- Preserve proxy auth priority (successful proxy auth still short-circuits)
- Fix `allowTailscale` default to not exclude `trusted-proxy` mode

## Root Cause

When `auth.mode === "trusted-proxy"`, the `authorizeGatewayConnect` function enters the trusted-proxy block and either succeeds or returns a failure reason. It never falls through to the shared-secret (token/password) block below. Internal services that connect directly (without the reverse proxy) always fail because they can't provide the proxy headers.

## Changes

**`src/gateway/auth.ts`**:

1. Hoist `limiter`/`ip`/`rateLimitScope` above the trusted-proxy block so the fallback can reuse them:
```diff
+  const limiter = params.rateLimiter;
+  const ip =
+    params.clientIp ??
+    resolveRequestClientIp(req, trustedProxies, params.allowRealIpFallback === true) ??
+    req?.socket?.remoteAddress;
+  const rateLimitScope = params.rateLimitScope ?? AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET;
+
   if (auth.mode === "trusted-proxy") {
```

2. Add shared-secret fallback after proxy auth failure:
```diff
     if ("user" in result) {
       return { ok: true, method: "trusted-proxy", user: result.user };
     }
+
+    // Trusted-proxy auth failed — try shared-secret fallback for internal
+    // services (CLI, node host, ACP) that bypass the reverse proxy.
+    if (!auth.token && !auth.password) {
+      return { ok: false, reason: result.reason };
+    }
+
+    // Rate-limit fallback attempts
+    if (limiter) { ... }
+
+    // Try token fallback
+    if (connectAuth?.token && auth.token) {
+      if (safeEqualSecret(connectAuth.token, auth.token)) {
+        limiter?.reset(ip, rateLimitScope);
+        return { ok: true, method: "token" };
+      }
+      ...
+    }
+
+    // Try password fallback
+    if (connectAuth?.password && auth.password) { ... }
+
+    // Client didn't provide matching credentials — return original proxy failure
     return { ok: false, reason: result.reason };
```

3. Fix `allowTailscale` default to not exclude `trusted-proxy` mode:
```diff
-    authConfig.allowTailscale ??
-    (params.tailscaleMode === "serve" && mode !== "password" && mode !== "trusted-proxy");
+    authConfig.allowTailscale ?? (params.tailscaleMode === "serve" && mode !== "password");
```

**`src/gateway/auth.test.ts`**: 9 new unit tests for the fallback path (success, rejection, rate limiting, priority)

**`src/gateway/server.auth.e2e.test.ts`**: 3 new e2e tests for internal connections with token fallback + device identity

### Connection flow (after fix)

```
Client connects to gateway (mode=trusted-proxy)
├─ From trusted proxy with user header? → Authenticated (trusted-proxy)
├─ Proxy auth failed, token/password configured?
│  ├─ Rate-limited? → Rejected (rate_limited)
│  ├─ Valid token? → Authenticated (token) → device-pairing works
│  ├─ Valid password? → Authenticated (password) → device-pairing works
│  └─ No match → Original proxy failure reason
└─ No fallback credentials configured → Original proxy failure reason
```

## Related Issues

- #17761 — this bug report
- #1560 — original trusted-proxy auth implementation
- #17270 — device_token_mismatch errors in trusted-proxy setups
- #17106 — `canSkipDevice`/`skipPairing` gate logic
- #10382 — auth mode configuration
- #4833 — GatewayClient reconnect behavior
- #5559 — rate limiting for auth

## Test Plan

- [x] 9 unit tests for shared-secret fallback (proxy success unchanged, token/password fallback, rejection, rate limiting, priority)
- [x] 3 e2e tests for internal connections (token + device identity, token + no device, proxy priority)
- [x] All existing 30 unit tests pass
- [x] All existing 33 e2e tests pass
- [x] `oxlint` — 0 errors
- [x] `oxfmt` — clean
- [x] `tsgo` — clean

Closes #17761
Related: #8529, #7384, #4833

---

## Rebase History

| Date | Base | Upstream Commits | Notes |
|------|------|-----------------|-------|
| 2026-03-23 | `d5917d37c54a` (post-v2026.3.23) | 929 | Rebased cleanly. Tip commit (typing fix) now empty — upstream absorbed that change. |
| 2026-03-13 | `330631a0eb39` (v2026.3.12) | - | Clean rebase. Upstream extracted `resolveRequestClientIp` to `net.ts` and added bootstrap tokens. No conflicts. Commits: `55d625971175`, `ddd1db37ffa0`, `f0cf25e4a891`. |
| 2026-03-08 | `eb0758e1722c` (v2026.3.7) | - | Clean rebase, no conflicts. Upstream hardened gateway auth resolution across systemd/discord/node host, unified SecretRef credential readers, and added auth rate limiting — all complementary to this PR's shared-secret fallback. Commits: `fbec3dcadecb`, `f8b31778c1ad`, `c448c932f6d5`. |
| 2026-02-27 | Previous base | - | Rebased directly onto `main` after `fix/trusted-proxy-device-pairing` was absorbed upstream via `connect-policy.ts` refactoring. |


