### PR TITLE
fix(memory): format

### DIFF
--- a/src/memory/backend-config.test.ts
+++ b/src/memory/backend-config.test.ts
@@ -96,8 +96,12 @@ describe("resolveMemoryBackendConfig", () => {
     } as OpenClawConfig;
     const mainResolved = resolveMemoryBackendConfig({ cfg, agentId: "main" });
     const devResolved = resolveMemoryBackendConfig({ cfg, agentId: "dev" });
-    const mainNames = new Set((mainResolved.qmd?.collections ?? []).map((collection) => collection.name));
-    const devNames = new Set((devResolved.qmd?.collections ?? []).map((collection) => collection.name));
+    const mainNames = new Set(
+      (mainResolved.qmd?.collections ?? []).map((collection) => collection.name),
+    );
+    const devNames = new Set(
+      (devResolved.qmd?.collections ?? []).map((collection) => collection.name),
+    );
     expect(mainNames.has("memory-dir-main")).toBe(true);
     expect(devNames.has("memory-dir-dev")).toBe(true);
     expect(mainNames.has("workspace-main")).toBe(true);

--- a/src/memory/qmd-manager.test.ts
+++ b/src/memory/qmd-manager.test.ts
@@ -321,7 +321,9 @@ describe("QmdMemoryManager", () => {
         emitAndClose(
           child,
           "stdout",
-          JSON.stringify([{ name: sessionCollectionName, path: wrongSessionsPath, mask: "**/*.md" }]),
+          JSON.stringify([
+            { name: sessionCollectionName, path: wrongSessionsPath, mask: "**/*.md" },
+          ]),
         );
         return child;
       }
@@ -340,7 +342,8 @@ describe("QmdMemoryManager", () => {
 
     const commands = spawnMock.mock.calls.map((call) => call[1] as string[]);
     const removeSessions = commands.find(
-      (args) => args[0] === "collection" && args[1] === "remove" && args[2] === sessionCollectionName,
+      (args) =>
+        args[0] === "collection" && args[1] === "remove" && args[2] === sessionCollectionName,
     );
     expect(removeSessions).toBeDefined();
 
@@ -373,7 +376,11 @@ describe("QmdMemoryManager", () => {
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "collection" && args[1] === "list") {
         const child = createMockChild({ autoClose: false });
-        emitAndClose(child, "stdout", JSON.stringify([`workspace-${agentId}`, sessionCollectionName]));
+        emitAndClose(
+          child,
+          "stdout",
+          JSON.stringify([`workspace-${agentId}`, sessionCollectionName]),
+        );
         return child;
       }
       return createMockChild();
@@ -384,7 +391,8 @@ describe("QmdMemoryManager", () => {
 
     const commands = spawnMock.mock.calls.map((call) => call[1] as string[]);
     const removeSessions = commands.find(
-      (args) => args[0] === "collection" && args[1] === "remove" && args[2] === sessionCollectionName,
+      (args) =>
+        args[0] === "collection" && args[1] === "remove" && args[2] === sessionCollectionName,
     );
     expect(removeSessions).toBeDefined();
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: CI fail

## Change Type (select all)

-  Format fix


## Test:

pnpm format:check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Formatting-only fix for two memory test files (`backend-config.test.ts` and `qmd-manager.test.ts`) to resolve CI `pnpm format:check` failures.

- Lines exceeding the configured line length in `backend-config.test.ts` and `qmd-manager.test.ts` are wrapped to multiple lines with trailing commas, matching the project's oxfmt formatting rules.
- No logic, test behavior, or semantic changes are introduced.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it contains only auto-formatter whitespace changes with zero impact on logic or behavior.
- All changes are purely formatting (line wrapping for line-length compliance). No logic, imports, or test assertions were modified. The resulting files match expected formatter output.
- No files require special attention.

<sub>Last reviewed commit: 31ed224</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->