### PR TITLE
fix: merge consecutive same-role messages for all providers #17124

### DIFF
--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -57,6 +57,7 @@ export {
   mergeConsecutiveUserTurns,
   validateAnthropicTurns,
   validateGeminiTurns,
+  validateStrictTurns,
 } from "./pi-embedded-helpers/turns.js";
 export type { EmbeddedContextFile, FailoverReason } from "./pi-embedded-helpers/types.js";
 

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -37,6 +37,7 @@ import {
   ensureSessionHeader,
   validateAnthropicTurns,
   validateGeminiTurns,
+  validateStrictTurns,
 } from "../pi-embedded-helpers.js";
 import {
   ensurePiCompactionReserveTokens,
@@ -567,9 +568,12 @@ export async function compactEmbeddedPiSessionDirect(
         const validatedGemini = transcriptPolicy.validateGeminiTurns
           ? validateGeminiTurns(prior)
           : prior;
-        const validated = transcriptPolicy.validateAnthropicTurns
+        const validatedAnthropic = transcriptPolicy.validateAnthropicTurns
           ? validateAnthropicTurns(validatedGemini)
           : validatedGemini;
+        const validated = transcriptPolicy.validateStrictTurns
+          ? validateStrictTurns(validatedAnthropic)
+          : validatedAnthropic;
         // Capture full message history BEFORE limiting — plugins need the complete conversation
         const preCompactionMessages = [...session.messages];
         const truncated = limitHistoryTurns(

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -41,6 +41,7 @@ import {
   resolveBootstrapMaxChars,
   validateAnthropicTurns,
   validateGeminiTurns,
+  validateStrictTurns,
 } from "../../pi-embedded-helpers.js";
 import { subscribeEmbeddedPiSession } from "../../pi-embedded-subscribe.js";
 import {
@@ -648,9 +649,12 @@ export async function runEmbeddedAttempt(
         const validatedGemini = transcriptPolicy.validateGeminiTurns
           ? validateGeminiTurns(prior)
           : prior;
-        const validated = transcriptPolicy.validateAnthropicTurns
+        const validatedAnthropic = transcriptPolicy.validateAnthropicTurns
           ? validateAnthropicTurns(validatedGemini)
           : validatedGemini;
+        const validated = transcriptPolicy.validateStrictTurns
+          ? validateStrictTurns(validatedAnthropic)
+          : validatedAnthropic;
         const truncated = limitHistoryTurns(
           validated,
           getDmHistoryLimitFromSessionKey(params.sessionKey, params.config),

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -18,6 +18,7 @@ export type TranscriptPolicy = {
   applyGoogleTurnOrdering: boolean;
   validateGeminiTurns: boolean;
   validateAnthropicTurns: boolean;
+  validateStrictTurns: boolean;
   allowSyntheticToolResults: boolean;
 };
 
@@ -93,6 +94,7 @@ export function resolveTranscriptPolicy(params: {
     modelId,
   });
 
+  const isMinimax = provider === "minimax";
   const needsNonImageSanitize = isGoogle || isAnthropic || isMistral || isOpenRouterGemini;
 
   const sanitizeToolCallIds = isGoogle || isMistral || isAnthropic;
@@ -118,6 +120,11 @@ export function resolveTranscriptPolicy(params: {
     applyGoogleTurnOrdering: !isOpenAi && isGoogle,
     validateGeminiTurns: !isOpenAi && isGoogle,
     validateAnthropicTurns: !isOpenAi && isAnthropic,
+    // MiniMax uses anthropic-messages API, so isAnthropic is also true.
+    // validateAnthropicTurns merges consecutive user messages first,
+    // then validateStrictTurns catches any remaining same-role pairs (developer, assistant, system).
+    // This two-layer composition is intentional.
+    validateStrictTurns: isMinimax,
     allowSyntheticToolResults: !isOpenAi && (isGoogle || isAnthropic),
   };
 }

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -94,7 +94,6 @@ export function resolveTranscriptPolicy(params: {
     modelId,
   });
 
-  const isMinimax = provider === "minimax";
   const needsNonImageSanitize = isGoogle || isAnthropic || isMistral || isOpenRouterGemini;
 
   const sanitizeToolCallIds = isGoogle || isMistral || isAnthropic;
@@ -120,11 +119,10 @@ export function resolveTranscriptPolicy(params: {
     applyGoogleTurnOrdering: !isOpenAi && isGoogle,
     validateGeminiTurns: !isOpenAi && isGoogle,
     validateAnthropicTurns: !isOpenAi && isAnthropic,
-    // MiniMax uses anthropic-messages API, so isAnthropic is also true.
-    // validateAnthropicTurns merges consecutive user messages first,
-    // then validateStrictTurns catches any remaining same-role pairs (developer, assistant, system).
-    // This two-layer composition is intentional.
-    validateStrictTurns: isMinimax,
+    // Merge any remaining consecutive same-role messages (developer, assistant, system).
+    // Many providers (MiniMax, DeepSeek, Mistral, etc.) require strict role alternation.
+    // This is safe for all providers since merging consecutive same-role messages is semantically neutral.
+    validateStrictTurns: true,
     allowSyntheticToolResults: !isOpenAi && (isGoogle || isAnthropic),
   };
 }


### PR DESCRIPTION
Consecutive same-role messages can cause errors with strict providers (MiniMax, DeepSeek, Mistral, etc.). Instead of hardcoding per-provider, enable `validateStrictTurns` universally since merging consecutive same-role messages is semantically safe for all providers.

Fixes #17124