### PR TITLE
fix: Control UI unusable over HTTP - missing scopes

### DIFF
--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -140,7 +140,13 @@ export class GatewayBrowserClient {
     // Gateways may reject this unless gateway.controlUi.allowInsecureAuth is enabled.
     const isSecureContext = typeof crypto !== "undefined" && !!crypto.subtle;
 
-    const scopes = ["operator.admin", "operator.approvals", "operator.pairing"];
+    const scopes = [
+      "operator.admin",
+      "operator.approvals",
+      "operator.pairing",
+      "operator.read",
+      "operator.write",
+    ];
     const role = "operator";
     let deviceIdentity: Awaited<ReturnType<typeof loadOrCreateDeviceIdentity>> | null = null;
     let canFallbackToShared = false;


### PR DESCRIPTION
## Summary

Fixed Control UI scope issues that made it unusable over HTTP:
- Added missing operator.read and operator.write scopes to the Control UI scope list

Note: The gateway scope-clearing fix (checking allowControlUiBypass) is already present in the source code at `src/gateway/server/ws-connection/message-handler.ts` but the dist files are outdated and need rebuilding.

## Changes

- Added operator.read and operator.write to the hardcoded scope list in Control UI (`ui/src/ui/gateway.ts`)

## Testing

- Verified the fix adds the missing scopes that were causing node.list, chat.history, and other RPC calls to fail with "missing scope: operator.read" errors

Fixes openclaw/openclaw#17750

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added missing `operator.read` and `operator.write` scopes to the Control UI's hardcoded scope list in `ui/src/ui/gateway.ts`. This fixes Control UI failures over HTTP when using bypass modes (`allowInsecureAuth` or `dangerouslyDisableDeviceAuth`) where the gateway preserves requested scopes but the UI was only requesting `["operator.admin", "operator.approvals", "operator.pairing"]`. 

The gateway's scope preservation logic for Control UI bypass modes (at `src/gateway/server/ws-connection/message-handler.ts:430`) was already correct, but the Control UI frontend was missing the necessary scopes to call read methods like `node.list` and `chat.history` (which require `operator.read` per `src/gateway/server-methods.ts:76,78,126-127`) and write methods like `chat.send` (which require `operator.write` per `src/gateway/server-methods.ts:94,129-130`).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a straightforward addition of two missing scopes to an array that matches the authorization requirements defined in the gateway's server-methods.ts. The fix directly addresses the root cause of the reported issue where Control UI RPC calls were failing with "missing scope: operator.read" errors over HTTP. The change is minimal, well-understood, and aligns with existing patterns used in other clients (iOS app requests the same scopes at `apps/ios/Sources/Model/NodeAppModel.swift:1753`)
- No files require special attention

<sub>Last reviewed commit: a01b6c0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->