### PR TITLE
fix(agents): resolve relative workspace paths against state dir, not CWD

### DIFF
--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -175,17 +175,34 @@ export function resolveEffectiveModelFallbacks(params: {
   return agentFallbacksOverride ?? defaultFallbacks;
 }
 
+/**
+ * Resolve a workspace path. Relative paths are resolved against the state dir
+ * (e.g. ~/.openclaw/) instead of process.cwd() so that sub-agent workspace
+ * resolution is deterministic regardless of prior process.chdir() calls.
+ */
+function resolveWorkspacePath(input: string): string {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return trimmed;
+  }
+  if (path.isAbsolute(trimmed) || trimmed.startsWith("~")) {
+    return resolveUserPath(trimmed);
+  }
+  const stateDir = resolveStateDir(process.env);
+  return path.resolve(stateDir, trimmed);
+}
+
 export function resolveAgentWorkspaceDir(cfg: OpenClawConfig, agentId: string) {
   const id = normalizeAgentId(agentId);
   const configured = resolveAgentConfig(cfg, id)?.workspace?.trim();
   if (configured) {
-    return resolveUserPath(configured);
+    return resolveWorkspacePath(configured);
   }
   const defaultAgentId = resolveDefaultAgentId(cfg);
   if (id === defaultAgentId) {
     const fallback = cfg.agents?.defaults?.workspace?.trim();
     if (fallback) {
-      return resolveUserPath(fallback);
+      return resolveWorkspacePath(fallback);
     }
     return resolveDefaultAgentWorkspaceDir(process.env);
   }


### PR DESCRIPTION
## Summary

- Fixes #17698 — `agents.list[].workspace` was ignored for sub-agent session CWD
- `resolveAgentWorkspaceDir` used `resolveUserPath` which calls `path.resolve()` against `process.cwd()`. After a parent agent calls `process.chdir()`, relative workspace paths resolved against the wrong directory
- Adds a `resolveWorkspacePath` helper that resolves relative paths against the stable state dir (`~/.openclaw/`) instead, making workspace resolution deterministic regardless of concurrent `process.chdir` calls
- Absolute and `~`-prefixed paths continue to use `resolveUserPath` unchanged

## Test plan

- [x] New tests: relative workspace resolves against state dir, not CWD
- [x] New tests: absolute workspace paths unaffected by CWD changes
- [x] New tests: tilde workspace paths expand correctly
- [x] New tests: defaults workspace resolves relative paths against state dir
- [x] All existing agent-scope, workspace-run, workspace e2e tests pass (31 tests)
- [x] All sessions-spawn e2e tests pass (18 tests)
- [x] All agent unit tests pass (253 tests)
- [x] Build passes
- [x] Lint + format clean

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes workspace path resolution for sub-agents by introducing `resolveWorkspacePath` helper that resolves relative workspace paths against the stable state directory (`~/.openclaw/`) instead of `process.cwd()`. Previously, when parent agents called `process.chdir()`, relative workspace paths would resolve against the wrong directory, making workspace resolution non-deterministic. The fix ensures that absolute and tilde-prefixed paths continue using `resolveUserPath` unchanged, while relative paths now correctly resolve against the state directory.

- Added comprehensive test coverage for relative, absolute, and tilde workspace paths
- Verified that workspace resolution is now immune to concurrent `process.chdir()` calls
- No changes to existing behavior for absolute or tilde-prefixed workspace paths
- All existing agent-scope, workspace-run, and workspace e2e tests continue to pass

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is focused, well-tested, and addresses a clear bug. The new `resolveWorkspacePath` helper is straightforward and only changes behavior for relative paths (the bug case), while preserving existing behavior for absolute and tilde paths. Comprehensive test coverage validates all path resolution scenarios, including the edge case that caused the original issue.
- No files require special attention

<sub>Last reviewed commit: 153d4c8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->