### PR TITLE
Fix crash on transient Discord gateway zombie connection errors

### DIFF
--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -2,7 +2,7 @@ import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { loadDotEnv } from "../infra/dotenv.js";
 import { normalizeEnv } from "../infra/env.js";
-import { formatUncaughtError } from "../infra/errors.js";
+import { formatUncaughtError, isTransientGatewayError } from "../infra/errors.js";
 import { isMainModule } from "../infra/is-main.js";
 import { ensureOpenClawCliOnPath } from "../infra/path-env.js";
 import { assertSupportedRuntime } from "../infra/runtime-guard.js";
@@ -87,6 +87,10 @@ export async function runCli(argv: string[] = process.argv) {
   installUnhandledRejectionHandler();
 
   process.on("uncaughtException", (error) => {
+    if (isTransientGatewayError(error)) {
+      console.warn("[openclaw] Transient gateway error (non-fatal):", formatUncaughtError(error));
+      return;
+    }
     console.error("[openclaw] Uncaught exception:", formatUncaughtError(error));
     process.exit(1);
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ import {
 import { ensureBinary } from "./infra/binaries.js";
 import { loadDotEnv } from "./infra/dotenv.js";
 import { normalizeEnv } from "./infra/env.js";
-import { formatUncaughtError } from "./infra/errors.js";
+import { formatUncaughtError, isTransientGatewayError } from "./infra/errors.js";
 import { isMainModule } from "./infra/is-main.js";
 import { ensureOpenClawCliOnPath } from "./infra/path-env.js";
 import {
@@ -82,6 +82,10 @@ if (isMain) {
   installUnhandledRejectionHandler();
 
   process.on("uncaughtException", (error) => {
+    if (isTransientGatewayError(error)) {
+      console.warn("[openclaw] Transient gateway error (non-fatal):", formatUncaughtError(error));
+      return;
+    }
     console.error("[openclaw] Uncaught exception:", formatUncaughtError(error));
     process.exit(1);
   });

--- a/src/infra/errors.test.ts
+++ b/src/infra/errors.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { isTransientGatewayError } from "./errors.js";
+
+describe("isTransientGatewayError", () => {
+  it("returns true for zombie connection error", () => {
+    const err = new Error(
+      "Attempted to reconnect zombie connection after disconnecting first (this shouldn't be possible)",
+    );
+    expect(isTransientGatewayError(err)).toBe(true);
+  });
+
+  it("returns true for gateway reconnect-after-disconnect error", () => {
+    const err = new Error(
+      "Attempted to reconnect gateway after disconnecting first (this shouldn't be possible)",
+    );
+    expect(isTransientGatewayError(err)).toBe(true);
+  });
+
+  it("returns false for unrelated errors", () => {
+    expect(isTransientGatewayError(new Error("something else"))).toBe(false);
+    expect(isTransientGatewayError(new Error("Max reconnect attempts"))).toBe(false);
+    expect(isTransientGatewayError(new Error("Fatal Gateway error"))).toBe(false);
+  });
+
+  it("returns false for non-Error values", () => {
+    expect(isTransientGatewayError("zombie")).toBe(false);
+    expect(isTransientGatewayError(null)).toBe(false);
+    expect(isTransientGatewayError(undefined)).toBe(false);
+    expect(isTransientGatewayError(42)).toBe(false);
+  });
+});

--- a/src/infra/errors.ts
+++ b/src/infra/errors.ts
@@ -47,6 +47,23 @@ export function formatErrorMessage(err: unknown): string {
   return redactSensitiveText(formatted);
 }
 
+/**
+ * Detect transient Discord gateway errors thrown by `@buape/carbon` inside
+ * `setTimeout`/`setInterval` callbacks (e.g. heartbeat reconnect on zombie
+ * connections).  These surface as uncaught exceptions but are non-fatal –
+ * the gateway's own reconnection logic will recover.
+ */
+export function isTransientGatewayError(err: unknown): boolean {
+  if (!(err instanceof Error)) {
+    return false;
+  }
+  const msg = err.message ?? "";
+  return (
+    msg.includes("Attempted to reconnect zombie connection") ||
+    msg.includes("Attempted to reconnect gateway after disconnecting first")
+  );
+}
+
 export function formatUncaughtError(err: unknown): string {
   if (extractErrorCode(err) === "INVALID_CONFIG") {
     return formatErrorMessage(err);

--- a/src/infra/errors.ts
+++ b/src/infra/errors.ts
@@ -57,7 +57,7 @@ export function isTransientGatewayError(err: unknown): boolean {
   if (!(err instanceof Error)) {
     return false;
   }
-  const msg = err.message ?? "";
+  const msg = err.message;
   return (
     msg.includes("Attempted to reconnect zombie connection") ||
     msg.includes("Attempted to reconnect gateway after disconnecting first")

--- a/src/macos/relay.ts
+++ b/src/macos/relay.ts
@@ -57,7 +57,7 @@ async function main() {
 
   const { assertSupportedRuntime } = await import("../infra/runtime-guard.js");
   assertSupportedRuntime();
-  const { formatUncaughtError } = await import("../infra/errors.js");
+  const { formatUncaughtError, isTransientGatewayError } = await import("../infra/errors.js");
   const { installUnhandledRejectionHandler } = await import("../infra/unhandled-rejections.js");
 
   const { buildProgram } = await import("../cli/program.js");
@@ -66,6 +66,10 @@ async function main() {
   installUnhandledRejectionHandler();
 
   process.on("uncaughtException", (error) => {
+    if (isTransientGatewayError(error)) {
+      console.warn("[openclaw] Transient gateway error (non-fatal):", formatUncaughtError(error));
+      return;
+    }
     console.error("[openclaw] Uncaught exception:", formatUncaughtError(error));
     process.exit(1);
   });


### PR DESCRIPTION
## Summary

- **Problem:** `@buape/carbon`'s heartbeat timer throws `"Attempted to reconnect zombie connection"` inside a `setTimeout` callback when the WebSocket drops (e.g. network proxy switching nodes). This surfaces as an uncaught exception → `process.exit(1)`.
- **Why it matters:** Any transient network interruption kills the gateway; the built-in reconnect logic (50 attempts, exponential backoff) never gets a chance to recover.
- **What changed:** The three `uncaughtException` handlers now detect this specific error class and log a warning instead of crashing.
- **What did NOT change:** No changes to `@buape/carbon`, gateway reconnection logic, or any other error handling paths.

## Change Type (select all)

- [x] Bug fix

## User-visible / Behavior Changes

Gateway no longer crashes when network proxy tools (Clash, etc.) switch nodes mid-connection. A warning is logged instead:
```
[openclaw] Transient gateway error (non-fatal): Attempted to reconnect zombie connection...
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime/container: Node 22+
- Integration/channel: Discord

### Steps

1. Run gateway with Discord connected
2. Switch network proxy node (or simulate WebSocket drop during heartbeat interval)
3. Observe gateway behavior

### Expected

- Warning logged, gateway reconnects automatically

### Actual (before fix)

- `process.exit(1)` on uncaught exception

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

New test file `src/infra/errors.test.ts` — 4 tests covering `isTransientGatewayError` for both carbon error variants, unrelated errors, and non-Error values.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Risks and Mitigations

- **Risk:** Swallowing an error that _should_ be fatal if the gateway is truly unrecoverable.
  - **Mitigation:** Detection is narrowly scoped to two exact substrings from carbon's source. The gateway's own reconnect logic (50 attempts + backoff) handles recovery; if that also fails, `"Max reconnect attempts"` still triggers a fatal exit.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds targeted error handling for transient Discord gateway zombie connection errors thrown by `@buape/carbon` during heartbeat reconnection attempts. The fix prevents unnecessary process crashes by catching these specific non-fatal errors in three entry points (`src/index.ts`, `src/cli/run-main.ts`, `src/macos/relay.ts`), logging a warning instead, and allowing the gateway's built-in reconnection logic (50 attempts with exponential backoff) to recover automatically.

**Key changes:**
- Added `isTransientGatewayError()` function that detects two specific error message patterns from the carbon library
- Integrated detection into existing `uncaughtException` handlers before the fatal `process.exit(1)` path
- Comprehensive test coverage with 4 test cases validating both matching and non-matching scenarios
- Narrowly scoped to avoid swallowing truly fatal errors like "Max reconnect attempts"

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is narrowly scoped with string-based detection of specific transient errors, well-tested with comprehensive coverage, and properly integrated into existing error handling paths without disrupting fatal error detection like "Max reconnect attempts"
- No files require special attention

<sub>Last reviewed commit: 1cfe8e9</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->