### PR TITLE
fix(browser): rewrite 0.0.0.0 and [::] wildcard addresses in CDP WebSocket URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 - Sessions/model switch: clear stale cached `contextTokens` when a session changes models so status and runtime paths recompute against the active model window. (#38044) thanks @yuweuii.
 - ACP/session history: persist transcripts for successful ACP child runs, preserve exact transcript text, record ACP spawned-session lineage, and keep spawn-time transcript-path persistence best-effort so history storage failures do not block execution. (#40137) thanks @mbelinky.
 - Browser/CDP: normalize loopback direct WebSocket CDP URLs back to HTTP(S) for `/json/*` tab operations so local `ws://` / `wss://` profiles can still list, focus, open, and close tabs after the new direct-WS support lands. (#31085) Thanks @shrey150.
+- Browser/CDP: rewrite wildcard `ws://0.0.0.0` and `ws://[::]` debugger URLs from remote `/json/version` responses back to the external CDP host/port, fixing Browserless-style container endpoints. (#17760) Thanks @joeharouni.
 - Context engine registry/bundled builds: share the registry state through a `globalThis` singleton so duplicated bundled module copies can resolve engines registered by each other at runtime, with regression coverage for duplicate-module imports. (#40115) thanks @jalehman.
 
 ## 2026.3.7

--- a/src/browser/cdp.test.ts
+++ b/src/browser/cdp.test.ts
@@ -320,6 +320,22 @@ describe("cdp", () => {
     expect(normalized).toBe("wss://user:pass@example.com/devtools/browser/ABC?token=abc");
   });
 
+  it("rewrites 0.0.0.0 wildcard bind address to remote CDP host", () => {
+    const normalized = normalizeCdpWsUrl(
+      "ws://0.0.0.0:3000/devtools/browser/ABC",
+      "http://192.168.1.202:18850?token=secret",
+    );
+    expect(normalized).toBe("ws://192.168.1.202:18850/devtools/browser/ABC?token=secret");
+  });
+
+  it("rewrites :: wildcard bind address to remote CDP host", () => {
+    const normalized = normalizeCdpWsUrl(
+      "ws://[::]:3000/devtools/browser/ABC",
+      "http://192.168.1.202:18850",
+    );
+    expect(normalized).toBe("ws://192.168.1.202:18850/devtools/browser/ABC");
+  });
+
   it("upgrades ws to wss when CDP uses https", () => {
     const normalized = normalizeCdpWsUrl(
       "ws://production-sfo.browserless.io",

--- a/src/browser/cdp.ts
+++ b/src/browser/cdp.ts
@@ -19,7 +19,11 @@ export {
 export function normalizeCdpWsUrl(wsUrl: string, cdpUrl: string): string {
   const ws = new URL(wsUrl);
   const cdp = new URL(cdpUrl);
-  if (isLoopbackHost(ws.hostname) && !isLoopbackHost(cdp.hostname)) {
+  // Treat 0.0.0.0 and :: as wildcard bind addresses that need rewriting.
+  // Containerized browsers (e.g. browserless) report ws://0.0.0.0:<internal-port>
+  // in /json/version — these must be rewritten to the external cdpUrl host:port.
+  const isWildcardBind = ws.hostname === "0.0.0.0" || ws.hostname === "[::]";
+  if ((isLoopbackHost(ws.hostname) || isWildcardBind) && !isLoopbackHost(cdp.hostname)) {
     ws.hostname = cdp.hostname;
     const cdpPort = cdp.port || (cdp.protocol === "https:" ? "443" : "80");
     if (cdpPort) {


### PR DESCRIPTION
## Summary

When a containerized browser (e.g. [browserless](https://github.com/browserless/browserless)) reports its `webSocketDebuggerUrl` in `/json/version`, Chrome binds to all interfaces and returns addresses like `ws://0.0.0.0:3000/devtools/browser/...` or `ws://[::]:3000/...`. These are wildcard bind addresses, not routable endpoints.

`normalizeCdpWsUrl` already rewrites loopback addresses (`127.0.0.1`, `::1`, `localhost`) to the external `cdpUrl` host and port, but it does not handle `0.0.0.0` or `[::]`. This causes OpenClaw to attempt a literal WebSocket connection to `ws://0.0.0.0:3000`, which fails.

## Changes

- Treat `0.0.0.0` and `[::]` as wildcard bind addresses that need the same host/port/protocol rewriting as loopback addresses
- Added two test cases covering both wildcard forms

## Testing

- All existing tests pass (`pnpm test` — 8/8)
- `pnpm check` passes (formatting, type checking, linting)
- Verified end-to-end with a remote browserless instance reporting `ws://0.0.0.0:3000` — after the fix, the URL is correctly rewritten to the external CDP host and port

Fixes #17752

---

> **AI Disclosure**: This PR was developed with AI assistance (Claude). The author understands the changes, has verified them locally against a live browserless integration, and all tests pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Clean, well-scoped bug fix that extends `normalizeCdpWsUrl` to handle wildcard bind addresses (`0.0.0.0` and `[::]`) reported by containerized browsers in their `webSocketDebuggerUrl`. These addresses are now rewritten to the external CDP host/port, matching the existing behavior for loopback addresses.

- Adds `isWildcardBind` check for `0.0.0.0` and `[::]` in `normalizeCdpWsUrl`, integrated into the existing loopback rewriting condition
- Two new test cases cover both IPv4 and IPv6 wildcard forms with host, port, query param, and protocol rewriting verification
- No logic issues found; the implementation correctly aligns with `isLoopbackHost` which explicitly excludes wildcard addresses from loopback detection

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, well-tested fix that extends existing rewriting logic to cover two additional hostname patterns.
- The change is small (one new boolean, one expanded condition) and purely additive — it cannot break existing loopback rewriting behavior. The new wildcard detection logic is correct for Node.js URL parsing semantics (verified in the previous thread). Both wildcard forms have dedicated test coverage. The fix addresses a real bug (literal connection to ws://0.0.0.0) confirmed by end-to-end testing with a live browserless instance.
- No files require special attention.

<sub>Last reviewed commit: fb1382d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->