### PR TITLE
feat(hooks): add responseUrl callback with security hardening

### DIFF
--- a/src/gateway/hooks-mapping.ts
+++ b/src/gateway/hooks-mapping.ts
@@ -21,6 +21,8 @@ export type HookMappingResolved = {
   model?: string;
   thinking?: string;
   timeoutSeconds?: number;
+  responseUrl?: string;
+  responseSecret?: string;
   transform?: HookMappingTransformResolved;
 };
 
@@ -56,6 +58,8 @@ export type HookAction =
       model?: string;
       thinking?: string;
       timeoutSeconds?: number;
+      responseUrl?: string;
+      responseSecret?: string;
     };
 
 export type HookMappingResult =

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -231,6 +231,8 @@ export type HookAgentPayload = {
   model?: string;
   thinking?: string;
   timeoutSeconds?: number;
+  responseUrl?: string;
+  responseSecret?: string;
 };
 
 const listHookChannelValues = () => ["last", ...listChannelPlugins().map((plugin) => plugin.id)];
@@ -366,6 +368,14 @@ export function normalizeAgentPayload(payload: Record<string, unknown>):
     typeof timeoutRaw === "number" && Number.isFinite(timeoutRaw) && timeoutRaw > 0
       ? Math.floor(timeoutRaw)
       : undefined;
+  const responseUrlRaw = payload.responseUrl;
+  const responseUrl =
+    typeof responseUrlRaw === "string" && responseUrlRaw.trim() ? responseUrlRaw.trim() : undefined;
+  const responseSecretRaw = payload.responseSecret;
+  const responseSecret =
+    typeof responseSecretRaw === "string" && responseSecretRaw.trim()
+      ? responseSecretRaw.trim()
+      : undefined;
   return {
     ok: true,
     value: {
@@ -380,6 +390,8 @@ export function normalizeAgentPayload(payload: Record<string, unknown>):
       model,
       thinking,
       timeoutSeconds,
+      responseUrl,
+      responseSecret,
     },
   };
 }

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -78,6 +78,8 @@ type HookDispatchers = {
     thinking?: string;
     timeoutSeconds?: number;
     allowUnsafeExternalContent?: boolean;
+    responseUrl?: string;
+    responseSecret?: string;
   }) => string;
 };
 
@@ -417,6 +419,8 @@ export function createHooksRequestHandler(
             thinking: mapped.action.thinking,
             timeoutSeconds: mapped.action.timeoutSeconds,
             allowUnsafeExternalContent: mapped.action.allowUnsafeExternalContent,
+            responseUrl: mapped.action.responseUrl,
+            responseSecret: mapped.action.responseSecret,
           });
           sendJson(res, 202, { ok: true, runId });
           return true;

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHmac, randomUUID } from "node:crypto";
 import type { CliDeps } from "../../cli/deps.js";
 import type { CronJob } from "../../cron/types.js";
 import type { createSubsystemLogger } from "../../logging/subsystem.js";
@@ -9,6 +9,50 @@ import { runCronIsolatedAgentTurn } from "../../cron/isolated-agent.js";
 import { requestHeartbeatNow } from "../../infra/heartbeat-wake.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { createHooksRequestHandler } from "../server-http.js";
+
+const RESPONSE_CALLBACK_TIMEOUT_MS = 10_000;
+
+// Block private/reserved IP ranges to prevent SSRF
+const BLOCKED_IP_PATTERNS = [
+  /^10\./, // 10.0.0.0/8
+  /^172\.(1[6-9]|2[0-9]|3[0-1])\./, // 172.16.0.0/12
+  /^192\.168\./, // 192.168.0.0/16
+  /^127\./, // loopback
+  /^169\.254\./, // link-local
+  /^0\./, // 0.0.0.0/8
+  /^::1$/, // IPv6 loopback
+  /^fc00:/i, // IPv6 unique local
+  /^fe80:/i, // IPv6 link-local
+];
+
+function isBlockedHost(hostname: string): boolean {
+  if (hostname === "localhost" || hostname.endsWith(".localhost")) {
+    return true;
+  }
+  return BLOCKED_IP_PATTERNS.some((pattern) => pattern.test(hostname));
+}
+
+function validateResponseUrl(
+  urlString: string,
+): { ok: true; url: URL } | { ok: false; error: string } {
+  let url: URL;
+  try {
+    url = new URL(urlString);
+  } catch {
+    return { ok: false, error: "invalid URL" };
+  }
+  if (url.protocol !== "https:") {
+    return { ok: false, error: "responseUrl must use HTTPS" };
+  }
+  if (isBlockedHost(url.hostname)) {
+    return { ok: false, error: "responseUrl blocked (private/reserved address)" };
+  }
+  return { ok: true, url };
+}
+
+function signPayload(payload: string, secret: string): string {
+  return createHmac("sha256", secret).update(payload).digest("hex");
+}
 
 type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
 
@@ -42,6 +86,8 @@ export function createGatewayHooksRequestHandler(params: {
     thinking?: string;
     timeoutSeconds?: number;
     allowUnsafeExternalContent?: boolean;
+    responseUrl?: string;
+    responseSecret?: string;
   }) => {
     const sessionKey = value.sessionKey.trim();
     const mainSessionKey = resolveMainSessionKeyFromConfig();
@@ -86,6 +132,51 @@ export function createGatewayHooksRequestHandler(params: {
         const summary = result.summary?.trim() || result.error?.trim() || result.status;
         const prefix =
           result.status === "ok" ? `Hook ${value.name}` : `Hook ${value.name} (${result.status})`;
+
+        // POST result to responseUrl if provided
+        if (value.responseUrl) {
+          const urlValidation = validateResponseUrl(value.responseUrl);
+          if (!urlValidation.ok) {
+            logHooks.warn(`hook responseUrl invalid: ${urlValidation.error}`);
+          } else {
+            try {
+              const body = JSON.stringify({
+                runId,
+                status: result.status,
+                summary: result.summary,
+                outputText: result.outputText,
+                error: result.error,
+                sessionKey,
+                jobId,
+                timestamp: Date.now(),
+              });
+              const headers: Record<string, string> = { "Content-Type": "application/json" };
+              if (value.responseSecret) {
+                headers["X-OpenClaw-Signature"] =
+                  `sha256=${signPayload(body, value.responseSecret)}`;
+              }
+              const controller = new AbortController();
+              const timeoutId = setTimeout(() => controller.abort(), RESPONSE_CALLBACK_TIMEOUT_MS);
+              try {
+                await fetch(urlValidation.url.href, {
+                  method: "POST",
+                  headers,
+                  body,
+                  signal: controller.signal,
+                });
+              } finally {
+                clearTimeout(timeoutId);
+              }
+            } catch (callbackErr) {
+              const errMsg =
+                callbackErr instanceof Error && callbackErr.name === "AbortError"
+                  ? "timeout"
+                  : String(callbackErr);
+              logHooks.warn(`hook responseUrl callback failed: ${errMsg}`);
+            }
+          }
+        }
+
         enqueueSystemEvent(`${prefix}: ${summary}`.trim(), {
           sessionKey: mainSessionKey,
         });
@@ -94,6 +185,47 @@ export function createGatewayHooksRequestHandler(params: {
         }
       } catch (err) {
         logHooks.warn(`hook agent failed: ${String(err)}`);
+
+        // Also callback on error if responseUrl provided
+        if (value.responseUrl) {
+          const urlValidation = validateResponseUrl(value.responseUrl);
+          if (urlValidation.ok) {
+            try {
+              const body = JSON.stringify({
+                runId,
+                status: "error",
+                error: String(err),
+                sessionKey,
+                jobId,
+                timestamp: Date.now(),
+              });
+              const headers: Record<string, string> = { "Content-Type": "application/json" };
+              if (value.responseSecret) {
+                headers["X-OpenClaw-Signature"] =
+                  `sha256=${signPayload(body, value.responseSecret)}`;
+              }
+              const controller = new AbortController();
+              const timeoutId = setTimeout(() => controller.abort(), RESPONSE_CALLBACK_TIMEOUT_MS);
+              try {
+                await fetch(urlValidation.url.href, {
+                  method: "POST",
+                  headers,
+                  body,
+                  signal: controller.signal,
+                });
+              } finally {
+                clearTimeout(timeoutId);
+              }
+            } catch (callbackErr) {
+              const errMsg =
+                callbackErr instanceof Error && callbackErr.name === "AbortError"
+                  ? "timeout"
+                  : String(callbackErr);
+              logHooks.warn(`hook responseUrl error callback failed: ${errMsg}`);
+            }
+          }
+        }
+
         enqueueSystemEvent(`Hook ${value.name} (error): ${String(err)}`, {
           sessionKey: mainSessionKey,
         });


### PR DESCRIPTION
Summary

• Problem: No deterministic callback mechanism when /hooks/agent triggers an isolated agent session. Callers have no way to know when the agent finishes or receive the result.
• Why it matters: External systems (CI/CD, n8n/Zapier, multi-agent coordination) need fire-and-forget patterns with callbacks, not polling.
• What changed: Added optional responseUrl and responseSecret fields. When provided, OpenClaw POSTs the agent response to the URL after completion, with security hardening (SSRF protection, HMAC signing, timeout).
• What did NOT change: Existing hook behavior without responseUrl is identical. No changes to session isolation model, delivery, or other hook fields.
Change Type (select all)

• [ ] Bug fix
• [x] Feature
• [ ] Refactor
• [ ] Docs
• [x] Security hardening
• [ ] Chore/infra
Scope (select all touched areas)

• [x] Gateway / orchestration
• [ ] Skills / tool execution
• [ ] Auth / tokens
• [ ] Memory / storage
• [x] Integrations
• [x] API / contracts
• [ ] UI / DX
• [ ] CI/CD / infra
Linked Issue/PR

• Closes: N/A (new feature)
• Related: N/A
User-visible / Behavior Changes

• New optional fields in /hooks/agent payload: responseUrl (string, HTTPS required), responseSecret (string, optional)
• When responseUrl provided, gateway POSTs callback with {runId, status, summary, outputText, error, sessionKey, jobId, timestamp}
• When responseSecret provided, callback includes X-OpenClaw-Signature: sha256=<hmac> header
• No config changes required. Feature is opt-in per request.
Security Impact (required)

• New permissions/capabilities? Yes — Gateway can now make outbound POST requests to user-specified URLs
• Secrets/tokens handling changed? Yes — New responseSecret field used for HMAC signing
• New/changed network calls? Yes — Outbound POST to responseUrl after session completes
• Command/tool execution surface changed? No
• Data access scope changed? No
Risk + Mitigation:

• SSRF risk: Mitigated by HTTPS-only enforcement + blocking RFC 1918, loopback, link-local, and metadata IPs (169.254.x.x)
• Timing attacks: 10s AbortController timeout prevents hanging on slow/malicious endpoints
• Spoofing: Optional HMAC-SHA256 signing allows receivers to verify authenticity
• Replay attacks: Timestamp included in payload; receivers can implement time-window validation
Repro + Verification

Environment

• OS: macOS / Linux (Docker)
• Runtime/container: Node.js 22 / openclaw:local
• Model/provider: Any (Anthropic Claude tested)
• Integration/channel: HTTP hooks
• Relevant config: hooks.enabled: true, hooks.token set
Steps

1. Start gateway with hooks enabled
2. POST to /hooks/agent:
{
  "message": "Say hello",
  "name": "TestHook",
  "responseUrl": "https://httpbin.org/post",
  "responseSecret": "my-secret"
}

3. Observe 202 response with runId
4. Check gateway logs for callback attempt
5. Verify httpbin.org (http://httpbin.org/) received POST with signature header
Expected

• 202 response immediately
• Callback POST to responseUrl after agent completes
• X-OpenClaw-Signature header present when secret provided
Actual

• ✅ Works as expected (verified on production instance)
Evidence

• [x] Trace/log snippets
Gateway log:

Hook CallbackTest: Hello! 👋 This is bass_daddy responding via responseUrl callback.
Job ID: ae26d2b9-7656-482c-a9d2-ab6cb1c2059f

Human Verification (required)

• Verified scenarios: Hook with responseUrl only, hook with responseUrl + responseSecret, hook without either (unchanged behavior)
• Edge cases checked: Invalid URL (rejected), HTTP URL (rejected with "must use HTTPS"), localhost URL (rejected with "blocked")
• What you did not verify: Behavior under heavy concurrent load, DNS rebinding edge cases
Compatibility / Migration

• Backward compatible? Yes — new fields are optional, existing payloads unchanged
• Config/env changes? No
• Migration needed? No
Failure Recovery (if this breaks)

• How to disable/revert: Remove responseUrl from payloads; existing behavior continues

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds optional `responseUrl` and `responseSecret` fields to `/hooks/agent` endpoint, enabling fire-and-forget webhook patterns with callbacks. When `responseUrl` is provided, the gateway POSTs the agent result after completion. The implementation includes comprehensive security hardening: SSRF protection via `fetchWithSsrFGuard` (DNS pinning and resolved-IP validation), HTTPS-only enforcement, optional HMAC-SHA256 signing via `responseSecret`, 10s timeout, and sanitized error messages in callbacks. Previous SSRF and error leakage issues have been resolved. The feature is opt-in with no behavior changes to existing hook flows.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk - the security hardening is comprehensive and previous vulnerabilities have been addressed
- The implementation demonstrates strong security awareness (SSRF protection, HTTPS enforcement, HMAC signing, error sanitization). Both previously identified issues (DNS rebinding bypass and error detail leakage) were properly fixed. The feature is well-isolated with opt-in behavior. Score is 4 rather than 5 due to the security-sensitive nature of making outbound requests to user-provided URLs, which always carries inherent risk despite the mitigations.
- No files require special attention

<sub>Last reviewed commit: 50e0895</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->