### PR TITLE
fix: add link to settings when chat shows auth error

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -843,6 +843,7 @@ export function renderApp(state: AppViewState) {
                 onAbort: () => void state.handleAbortChat(),
                 onQueueRemove: (id) => state.removeQueuedMessage(id),
                 onNewSession: () => state.handleSendChat("/new", { restoreDraft: true }),
+                onGoToOverview: () => state.setTab("overview"),
                 showNewMessages: state.chatNewMessagesBelow && !state.chatManualRefreshInFlight,
                 onScrollToBottom: () => state.scrollToBottom(),
                 // Sidebar props for tool output viewing

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -276,7 +276,6 @@ export function renderChat(props: ChatProps) {
                 ${
                   props.onGoToOverview &&
                   (props.error.toLowerCase().includes("unauthorized") ||
-                    props.error.toLowerCase().includes("token missing") ||
                     props.error.toLowerCase().includes("connect failed"))
                     ? html`
                         <div style="margin-top: 8px">

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -69,6 +69,7 @@ export type ChatProps = {
   onCloseSidebar?: () => void;
   onSplitRatioChange?: (ratio: number) => void;
   onChatScroll?: (event: Event) => void;
+  onGoToOverview?: () => void;
 };
 
 const COMPACTION_TOAST_DURATION_MS = 5000;
@@ -267,7 +268,36 @@ export function renderChat(props: ChatProps) {
     <section class="card chat">
       ${props.disabledReason ? html`<div class="callout">${props.disabledReason}</div>` : nothing}
 
-      ${props.error ? html`<div class="callout danger">${props.error}</div>` : nothing}
+      ${
+        props.error
+          ? html`
+              <div class="callout danger">
+                ${props.error}
+                ${
+                  props.onGoToOverview &&
+                  (props.error.toLowerCase().includes("unauthorized") ||
+                    props.error.toLowerCase().includes("token missing") ||
+                    props.error.toLowerCase().includes("connect failed"))
+                    ? html`
+                        <div style="margin-top: 8px">
+                          <a
+                            class="session-link"
+                            href="#"
+                            @click=${(e: Event) => {
+                              e.preventDefault();
+                              props.onGoToOverview?.();
+                            }}
+                          >
+                            → Go to Settings to add a gateway token
+                          </a>
+                        </div>
+                      `
+                    : nothing
+                }
+              </div>
+            `
+          : nothing
+      }
 
       ${
         props.focusMode


### PR DESCRIPTION
## Summary

When the Control UI chat tab shows an "unauthorized" or "gateway token missing" error, users now see a clickable link to navigate to Settings where they can add their gateway token.

Previously, users who opened the Control UI directly at `/chat?session=main` would see the auth error but had no way to navigate to settings to add a token - they were stuck in a loop.

## Changes

- Added `onGoToOverview` callback prop to chat view
- When chat shows auth error (unauthorized, token missing, connect failed), displays a "Go to Settings to add a gateway token" link
- Clicking the link navigates to the overview tab where the token input field is available

## Testing

- TypeScript type checks pass
- UI builds without errors

Fixes #17745

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a helpful navigation link when the chat view displays authentication errors. When users see "unauthorized" or "connect failed" errors, they can now click a link to navigate to the overview tab where the gateway token settings are located.

The implementation:
- Adds an optional `onGoToOverview` callback prop to the chat view interface
- Wires the callback to `state.setTab("overview")` in the app render component
- Conditionally displays the "Go to Settings to add a gateway token" link when auth errors are present
- Uses the existing `.session-link` CSS class for consistent styling
- Follows the same error detection pattern as `overview.ts` (checking for "unauthorized" and "connect failed")

The previous review comment about redundant "token missing" check has been addressed in commit `18653b5e`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are simple, well-scoped, and follow existing patterns in the codebase. The implementation adds an optional callback prop and conditionally renders a navigation link, with no breaking changes or complex logic. TypeScript types are properly defined, the CSS class exists, and the tab name is valid. The previous review feedback has been addressed.
- No files require special attention

<sub>Last reviewed commit: 18653b5</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->