### PR TITLE
feat: include group_members in inbound user context metadata

### DIFF
--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -68,4 +68,23 @@ describe("buildInboundUserContextPrefix", () => {
     expect(text).toContain("Conversation info (untrusted metadata):");
     expect(text).toContain('"conversation_label": "ops-room"');
   });
+
+  it("includes group_members when GroupMembers is set", () => {
+    const text = buildInboundUserContextPrefix({
+      ChatType: "group",
+      ConversationLabel: "family-chat",
+      GroupMembers: "+15551234567, +15559876543",
+    } as TemplateContext);
+
+    expect(text).toContain('"group_members": "+15551234567, +15559876543"');
+  });
+
+  it("omits group_members when GroupMembers is empty", () => {
+    const text = buildInboundUserContextPrefix({
+      ChatType: "group",
+      ConversationLabel: "work-chat",
+    } as TemplateContext);
+
+    expect(text).not.toContain("group_members");
+  });
 });

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -67,6 +67,7 @@ export function buildInboundUserContextPrefix(ctx: TemplateContext): string {
     thread_label: safeTrim(ctx.ThreadLabel),
     is_forum: ctx.IsForum === true ? true : undefined,
     was_mentioned: ctx.WasMentioned === true ? true : undefined,
+    group_members: safeTrim(ctx.GroupMembers),
   };
   if (Object.values(conversationInfo).some((v) => v !== undefined)) {
     blocks.push(


### PR DESCRIPTION
## Summary
- Adds `group_members` to the `conversationInfo` object in `buildInboundUserContextPrefix`, so the LLM can see group participant identifiers (phone numbers, usernames) in the per-message "Conversation info (untrusted metadata)" block
- The `GroupMembers` field was already populated by channel plugins (WhatsApp, iMessage, BlueBubbles) and used in the system prompt via `buildGroupChatContext`, but was missing from the user-role context prefix — meaning the model couldn't see who was in a group chat from the message metadata

## Motivation
In group chats (especially BlueBubbles/iMessage), the model receives `Sender` metadata showing who sent the current message, but has no visibility into the other participants. This makes it impossible to distinguish or address individual members. The system prompt line from `buildGroupChatContext` ("Participants: ...") helps, but only on first message — per-message context should also carry this information since the roster can change.

## Test plan
- [x] Added two test cases to `inbound-meta.test.ts`:
  - Verifies `group_members` appears when `GroupMembers` is set
  - Verifies `group_members` is omitted when `GroupMembers` is unset
- [ ] Verify existing tests pass (`vitest run src/auto-reply/reply/inbound-meta.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `group_members` field to the per-message conversation info metadata block in `buildInboundUserContextPrefix`. The `GroupMembers` context field was already being populated by channel plugins (BlueBubbles, WhatsApp, iMessage) and used in the system prompt via `buildGroupChatContext`, but was missing from the user-role untrusted metadata that accompanies each message. This enables the model to see the complete list of group participants (phone numbers, usernames) in every message's context, not just in the initial system prompt.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a simple one-line addition that follows established patterns in the codebase. It exposes an existing field (`GroupMembers`) that is already being populated by channel plugins and is properly sanitized via `safeTrim`. The implementation is consistent with other fields in the same object, includes comprehensive test coverage, and addresses a legitimate gap in the per-message context metadata.
- No files require special attention

<sub>Last reviewed commit: 78d11ee</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->