### PR TITLE
fix: check plist file existence before marking LaunchAgent as missing

### DIFF
--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -182,10 +182,13 @@ export async function readLaunchAgentRuntime(
   const label = resolveLaunchAgentLabel({ env });
   const res = await execLaunchctl(["print", `${domain}/${label}`]);
   if (res.code !== 0) {
+    // Check if plist file exists - if it does, the service is installed but not currently loaded.
+    // Only mark as missingUnit if the plist file also doesn't exist.
+    const plistExists = await launchAgentPlistExists(env);
     return {
       status: "unknown",
       detail: (res.stderr || res.stdout).trim() || undefined,
-      missingUnit: true,
+      missingUnit: !plistExists,
     };
   }
   const parsed = parseLaunchctlPrint(res.stdout || res.stderr || "");


### PR DESCRIPTION
## Summary

When the gateway LaunchAgent is stopped (via `openclaw gateway stop` or `launchctl bootout`), the service is unloaded from launchd. Previously, when checking the service status, the code would run `launchctl print` which fails when the service is not loaded. The code incorrectly treated this failure as the service being "not installed" and would show "Service not installed. Run: openclaw gateway install" even though the LaunchAgent plist file still exists on disk.

This fix checks if the plist file exists before marking the service as missing. If the plist file exists, the service is considered installed even if it is not currently loaded in launchd.

## Changes

- Modified `readLaunchAgentRuntime` in `src/daemon/launchd.ts` to check if the plist file exists before setting `missingUnit: true`
- Previously: `missingUnit: true` was set unconditionally when `launchctl print` failed
- Now: `missingUnit: !plistExists` - only set to true if the plist file also doesn't exist

## Testing

- All daemon tests pass (122 tests)
- The fix ensures that after a stop/start cycle, the CLI correctly recognizes the LaunchAgent as installed

Fixes openclaw/openclaw#17763

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes incorrect "Service not installed" messaging when a LaunchAgent is stopped but still has its plist file on disk. Previously, `readLaunchAgentRuntime` unconditionally set `missingUnit: true` whenever `launchctl print` failed, but that command also fails for stopped/unloaded services. Now the code checks plist file existence via the existing `launchAgentPlistExists()` helper before determining the `missingUnit` flag.

- **`src/daemon/launchd.ts`**: Added `launchAgentPlistExists(env)` check in the `launchctl print` failure path; `missingUnit` is now `!plistExists` instead of unconditionally `true`
- The fix is consistent with how the function's success path (line 195) already uses `launchAgentPlistExists` for the `cachedLabel` field
- All downstream consumers (`status.print.ts`, `shared.ts`, `doctor-format.ts`, `status.format.ts`, `daemon.ts`) handle the new `missingUnit: false, status: "unknown"` state correctly — no false "Service not installed" prompts

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a small, well-scoped bug fix with no risk of regression.
- The change is minimal (3 lines added, 1 line modified), uses an existing well-tested helper function (`launchAgentPlistExists`), and follows the same pattern already used in the success path of the same function. All downstream consumers of `missingUnit` handle the new state correctly. The fix aligns with how the systemd and schtasks implementations handle the equivalent "service exists but not loaded" scenario.
- No files require special attention.

<sub>Last reviewed commit: 980574e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->