### PR TITLE
fix: correct config path in sessions_spawn error hint (v2)

### DIFF
--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -159,9 +159,13 @@ export function createSessionsSpawnTool(opts?: {
             : allowSet.size > 0
               ? Array.from(allowSet).join(", ")
               : "none";
+          const configHint =
+            allowSet.size === 0
+              ? ` Configure agents.defaults.subagents.allowAgents: ["${targetAgentId}"] or allowAgents: ["*"] to enable.`
+              : "";
           return jsonResult({
             status: "forbidden",
-            error: `agentId is not allowed for sessions_spawn (allowed: ${allowedText})`,
+            error: `agentId is not allowed for sessions_spawn (allowed: ${allowedText}).${configHint}`,
           });
         }
       }

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -161,7 +161,7 @@ export function createSessionsSpawnTool(opts?: {
               : "none";
           const configHint =
             allowSet.size === 0
-              ? ` Configure agents.defaults.subagents.allowAgents: ["${targetAgentId}"] or allowAgents: ["*"] to enable.`
+              ? ` Configure agents.list[].subagents.allowAgents: ["${targetAgentId}"] or allowAgents: ["*"] to enable.`
               : "";
           return jsonResult({
             status: "forbidden",


### PR DESCRIPTION
## Summary

Fix incorrect config path in error message.

## Changes
- Correct config path: `agents.list[].subagents.allowAgents` (not `agents.defaults.subagents.allowAgents`)

## Testing
- pnpm build
- pnpm check

## AI-assisted
Yes

Fixes #17390

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes the config path in the `sessions_spawn` error hint from the incorrect `agents.defaults.subagents.allowAgents` to the correct `agents.list[].subagents.allowAgents`. The `allowAgents` setting is a per-agent config defined on individual agent entries in `agents.list[]` (see `AgentConfig.subagents.allowAgents` in `src/config/types.agents.ts`), not on `agents.defaults`. The corrected path is consistent with all existing documentation (`docs/tools/subagents.md`, `docs/concepts/session-tool.md`, `docs/tools/index.md`).

- Corrected config path in the error hint shown when `agentId` is not in the allowlist and the allowlist is empty
- No functional behavior change beyond the error message content

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it only corrects a string literal in an error message.
- The change is a single-line fix to a config path in an error hint string. No logic, control flow, or behavior is modified. The corrected path (`agents.list[].subagents.allowAgents`) is verified against the type definitions and documentation.
- No files require special attention.

<sub>Last reviewed commit: e10a5cf</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->