### PR TITLE
fix: preserve workflow rules in compaction summary (#17727)

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -591,6 +591,7 @@ export async function runEmbeddedPiAgent(
                 bashElevated: params.bashElevated,
                 extraSystemPrompt: params.extraSystemPrompt,
                 ownerNumbers: params.ownerNumbers,
+                customInstructions: "Include a 'Workflow Rules' section preserving any established behavioral protocols, constraints, or review requirements mentioned in the conversation (e.g., approval workflows, mandatory reviews, coding standards).",
                 trigger: "overflow",
                 diagId: overflowDiagId,
                 attempt: overflowCompactionAttempts,

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -591,7 +591,8 @@ export async function runEmbeddedPiAgent(
                 bashElevated: params.bashElevated,
                 extraSystemPrompt: params.extraSystemPrompt,
                 ownerNumbers: params.ownerNumbers,
-                customInstructions: "Include a 'Workflow Rules' section preserving any established behavioral protocols, constraints, or review requirements mentioned in the conversation (e.g., approval workflows, mandatory reviews, coding standards).",
+                customInstructions:
+                  "Include a 'Workflow Rules' section preserving any established behavioral protocols, constraints, or review requirements mentioned in the conversation (e.g., approval workflows, mandatory reviews, coding standards).",
                 trigger: "overflow",
                 diagId: overflowDiagId,
                 attempt: overflowCompactionAttempts,


### PR DESCRIPTION
## Problem

Agents forget workflow rules (GATE checks, review requirements) after automatic compaction due to task-focused summaries lacking behavioral constraints.

## Solution

Pass `customInstructions` to compaction call, instructing summary generator to include "Workflow Rules" section preserving behavioral protocols.

## Changes

- `src/agent/run.ts`: Added `customInstructions` parameter to overflow compaction call

Fixes #17727
