### PR TITLE
fix(openai): preserve reasoning replay follower ids

### DIFF
--- a/src/agents/openai-responses.reasoning-replay.test.ts
+++ b/src/agents/openai-responses.reasoning-replay.test.ts
@@ -115,6 +115,15 @@ describe("openai-responses reasoning replay", () => {
     expect(types).toContain("reasoning");
     expect(types).toContain("function_call");
     expect(types.indexOf("reasoning")).toBeLessThan(types.indexOf("function_call"));
+
+    const functionCall = input.find(
+      (item) =>
+        item &&
+        typeof item === "object" &&
+        (item as Record<string, unknown>).type === "function_call",
+    ) as Record<string, unknown> | undefined;
+    expect(functionCall?.call_id).toBe("call_123");
+    expect(functionCall?.id).toBe("fc_123");
   });
 
   it("still replays reasoning when paired with an assistant message", async () => {

--- a/src/agents/pi-embedded-helpers.sanitize-session-messages-images.removes-empty-assistant-text-blocks-but-preserves.e2e.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitize-session-messages-images.removes-empty-assistant-text-blocks-but-preserves.e2e.test.ts
@@ -160,6 +160,35 @@ describe("sanitizeSessionMessagesImages", () => {
     const toolResult = out[1] as { toolUseId?: string };
     expect(toolResult.toolUseId).toBe("callabcitem123");
   });
+
+  it("does not sanitize tool IDs in images-only mode", async () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_123|fc_456", name: "read", arguments: {} }],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_123|fc_456",
+        toolName: "read",
+        content: [{ type: "text", text: "ok" }],
+        isError: false,
+      },
+    ] satisfies AgentMessage[];
+
+    const out = await sanitizeSessionMessagesImages(input, "test", {
+      sanitizeMode: "images-only",
+      sanitizeToolCallIds: true,
+      toolCallIdMode: "strict",
+    });
+
+    const assistant = out[0] as unknown as { content?: Array<{ type?: string; id?: string }> };
+    const toolCall = assistant.content?.find((b) => b.type === "toolCall");
+    expect(toolCall?.id).toBe("call_123|fc_456");
+
+    const toolResult = out[1] as unknown as { toolCallId?: string };
+    expect(toolResult.toolCallId).toBe("call_123|fc_456");
+  });
   it("filters whitespace-only assistant text blocks", async () => {
     const input = [
       {

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.e2e.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.e2e.test.ts
@@ -294,6 +294,27 @@ describe("downgradeOpenAIReasoningBlocks", () => {
     // oxlint-disable-next-line typescript/no-explicit-any
     expect(downgradeOpenAIReasoningBlocks(input as any)).toEqual(input);
   });
+
+  it("is idempotent for orphaned reasoning cleanup", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "thinking",
+            thinkingSignature: JSON.stringify({ id: "rs_orphan", type: "reasoning" }),
+          },
+        ],
+      },
+      { role: "user", content: "next" },
+    ];
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const once = downgradeOpenAIReasoningBlocks(input as any);
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const twice = downgradeOpenAIReasoningBlocks(once as any);
+    expect(twice).toEqual(once);
+  });
 });
 
 describe("normalizeTextForComparison", () => {

--- a/src/agents/pi-embedded-helpers/images.ts
+++ b/src/agents/pi-embedded-helpers/images.ts
@@ -51,9 +51,10 @@ export async function sanitizeSessionMessagesImages(
   const allowNonImageSanitization = sanitizeMode === "full";
   // We sanitize historical session messages because Anthropic can reject a request
   // if the transcript contains oversized base64 images (see MAX_IMAGE_DIMENSION_PX).
-  const sanitizedIds = options?.sanitizeToolCallIds
-    ? sanitizeToolCallIdsForCloudCodeAssist(messages, options.toolCallIdMode)
-    : messages;
+  const sanitizedIds =
+    allowNonImageSanitization && options?.sanitizeToolCallIds
+      ? sanitizeToolCallIdsForCloudCodeAssist(messages, options.toolCallIdMode)
+      : messages;
   const out: AgentMessage[] = [];
   for (const msg of sanitizedIds) {
     if (!msg || typeof msg !== "object") {

--- a/src/agents/pi-embedded-runner.openai-tool-id-preservation.e2e.test.ts
+++ b/src/agents/pi-embedded-runner.openai-tool-id-preservation.e2e.test.ts
@@ -1,0 +1,50 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { describe, expect, it } from "vitest";
+import {
+  makeInMemorySessionManager,
+  makeModelSnapshotEntry,
+} from "./pi-embedded-runner.sanitize-session-history.test-harness.js";
+import { sanitizeSessionHistory } from "./pi-embedded-runner/google.js";
+
+describe("sanitizeSessionHistory openai tool id preservation", () => {
+  it("keeps canonical call_id|fc_id pairings for same-model openai replay", async () => {
+    const sessionEntries = [
+      makeModelSnapshotEntry({
+        provider: "openai",
+        modelApi: "openai-responses",
+        modelId: "gpt-5.2-codex",
+      }),
+    ];
+    const sessionManager = makeInMemorySessionManager(sessionEntries);
+
+    const messages: AgentMessage[] = [
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_123|fc_123", name: "noop", arguments: {} }],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_123|fc_123",
+        toolName: "noop",
+        content: [{ type: "text", text: "ok" }],
+        isError: false,
+      } as unknown as AgentMessage,
+    ];
+
+    const result = await sanitizeSessionHistory({
+      messages,
+      modelApi: "openai-responses",
+      provider: "openai",
+      modelId: "gpt-5.2-codex",
+      sessionManager,
+      sessionId: "test-session",
+    });
+
+    const assistant = result[0] as { content?: Array<{ type?: string; id?: string }> };
+    const toolCall = assistant.content?.find((block) => block.type === "toolCall");
+    expect(toolCall?.id).toBe("call_123|fc_123");
+
+    const toolResult = result[1] as { toolCallId?: string };
+    expect(toolResult.toolCallId).toBe("call_123|fc_123");
+  });
+});

--- a/src/agents/pi-embedded-runner.sanitize-session-history.e2e.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.e2e.test.ts
@@ -52,7 +52,7 @@ describe("sanitizeSessionHistory e2e smoke", () => {
     );
   });
 
-  it("applies strict tool-call sanitization for openai-responses", async () => {
+  it("keeps images-only sanitize policy without tool-call id rewriting for openai-responses", async () => {
     vi.mocked(helpers.isGoogleModelApi).mockReturnValue(false);
 
     await sanitizeSessionHistory({
@@ -68,8 +68,7 @@ describe("sanitizeSessionHistory e2e smoke", () => {
       "session:history",
       expect.objectContaining({
         sanitizeMode: "images-only",
-        sanitizeToolCallIds: true,
-        toolCallIdMode: "strict",
+        sanitizeToolCallIds: false,
       }),
     );
   });

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -98,7 +98,7 @@ describe("sanitizeSessionHistory", () => {
     );
   });
 
-  it("sanitizes tool call ids for openai-responses while keeping images-only mode", async () => {
+  it("does not sanitize tool call ids for openai-responses", async () => {
     vi.mocked(helpers.isGoogleModelApi).mockReturnValue(false);
 
     await sanitizeSessionHistory({
@@ -112,11 +112,7 @@ describe("sanitizeSessionHistory", () => {
     expect(helpers.sanitizeSessionMessagesImages).toHaveBeenCalledWith(
       mockMessages,
       "session:history",
-      expect.objectContaining({
-        sanitizeMode: "images-only",
-        sanitizeToolCallIds: true,
-        toolCallIdMode: "strict",
-      }),
+      expect.objectContaining({ sanitizeMode: "images-only", sanitizeToolCallIds: false }),
     );
   });
 
@@ -243,7 +239,7 @@ describe("sanitizeSessionHistory", () => {
     expect(result).toEqual(messages);
   });
 
-  it("downgrades openai reasoning only when the model changes", async () => {
+  it("downgrades openai reasoning when the model changes", async () => {
     const sessionEntries = [
       makeModelSnapshotEntry({
         provider: "anthropic",

--- a/src/agents/transcript-policy.e2e.test.ts
+++ b/src/agents/transcript-policy.e2e.test.ts
@@ -2,15 +2,15 @@ import { describe, expect, it } from "vitest";
 import { resolveTranscriptPolicy } from "./transcript-policy.js";
 
 describe("resolveTranscriptPolicy e2e smoke", () => {
-  it("uses strict tool-call sanitization for OpenAI models", () => {
+  it("uses images-only sanitization without tool-call id rewriting for OpenAI models", () => {
     const policy = resolveTranscriptPolicy({
       provider: "openai",
       modelId: "gpt-4o",
       modelApi: "openai",
     });
     expect(policy.sanitizeMode).toBe("images-only");
-    expect(policy.sanitizeToolCallIds).toBe(true);
-    expect(policy.toolCallIdMode).toBe("strict");
+    expect(policy.sanitizeToolCallIds).toBe(false);
+    expect(policy.toolCallIdMode).toBeUndefined();
   });
 
   it("uses strict9 tool-call sanitization for Mistral-family models", () => {

--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -30,13 +30,13 @@ describe("resolveTranscriptPolicy", () => {
     expect(policy.toolCallIdMode).toBe("strict9");
   });
 
-  it("enables sanitizeToolCallIds for OpenAI provider", () => {
+  it("disables sanitizeToolCallIds for OpenAI provider", () => {
     const policy = resolveTranscriptPolicy({
       provider: "openai",
       modelId: "gpt-4o",
       modelApi: "openai",
     });
-    expect(policy.sanitizeToolCallIds).toBe(true);
-    expect(policy.toolCallIdMode).toBe("strict");
+    expect(policy.sanitizeToolCallIds).toBe(false);
+    expect(policy.toolCallIdMode).toBeUndefined();
   });
 });

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -95,7 +95,7 @@ export function resolveTranscriptPolicy(params: {
 
   const needsNonImageSanitize = isGoogle || isAnthropic || isMistral || isOpenRouterGemini;
 
-  const sanitizeToolCallIds = isGoogle || isMistral || isAnthropic || isOpenAi;
+  const sanitizeToolCallIds = isGoogle || isMistral || isAnthropic;
   const toolCallIdMode: ToolCallIdMode | undefined = isMistral
     ? "strict9"
     : sanitizeToolCallIds
@@ -109,7 +109,7 @@ export function resolveTranscriptPolicy(params: {
 
   return {
     sanitizeMode: isOpenAi ? "images-only" : needsNonImageSanitize ? "full" : "images-only",
-    sanitizeToolCallIds,
+    sanitizeToolCallIds: !isOpenAi && sanitizeToolCallIds,
     toolCallIdMode,
     repairToolUseResultPairing: !isOpenAi && repairToolUseResultPairing,
     preserveSignatures: isAntigravityClaudeModel,


### PR DESCRIPTION
# Human written summary:
The intent of this change is, as written by a human:
> fix errors lke 400 Item 'rs_0419e05c76e385a3006992963a50fc81a09d42ed06da8ca0d0' of type 'reasoning' was provided without its required following item. that happened with codex models

_The rest of this PR was written by GPT-5.2-Codex-high, running in the pi harness. Full environment + prompt history appear at the end._

# Changes
- Disable tool-call ID sanitization for OpenAI/OpenAI Codex in transcript policy.
- Apply tool-call ID sanitization only in `sanitizeMode: "full"` (never in `images-only`).
- Keep OpenAI orphan-reasoning downgrade behavior scoped to model-switch replay path.
- Add regression tests covering:
  - OpenAI policy behavior (`sanitizeToolCallIds: false`)
  - images-only path does not rewrite IDs
  - session-history pipeline preserves canonical `call_id|fc_id` IDs for same-model OpenAI replay
  - replay payload keeps canonical `call_id|fc_id` pairing
  - orphan-reasoning cleanup idempotence in helper

# Tests
- `pnpm vitest run src/agents/transcript-policy.test.ts src/agents/pi-embedded-runner.sanitize-session-history.test.ts src/agents/openai-responses.reasoning-replay.test.ts` ✅
- `pnpm vitest run --config vitest.e2e.config.ts src/agents/transcript-policy.e2e.test.ts src/agents/pi-embedded-runner.sanitize-session-history.e2e.test.ts src/agents/pi-embedded-runner.openai-tool-id-preservation.e2e.test.ts src/agents/pi-embedded-helpers.sanitize-session-messages-images.removes-empty-assistant-text-blocks-but-preserves.e2e.test.ts src/agents/pi-embedded-helpers.sanitizeuserfacingtext.e2e.test.ts` ✅
- `pnpm lint` ✅
- `pnpm format:check` ✅
- `pnpm check:docs` ✅
- `pnpm test` ⚠️ fails in local macOS Bash 3.2 env at `test/git-hooks-pre-commit.integration.test.ts` (`mapfile: command not found`); unrelated to this change.

# Risks
- Low: behavior change is isolated to OpenAI/OpenAI Codex transcript sanitization and replay hygiene.
- Existing providers needing strict tool-call ID sanitization (Google/Mistral/Anthropic) remain unchanged.

# Follow-ups
- Optional defense-in-depth in `@mariozechner/pi-ai`: reject or repair orphan reasoning payload items pre-send.

# Prompt History

## Environment
Harness: pi
Model: GPT-5.2-Codex
Thinking level: high
Terminal: zsh
System: macOS

## Prompts
| ISO-8601 | Prompt |
| --- | --- |
| 2026-02-15T20:55:00-08:00 | `but why? this seems lik eits a regression?` |
| 2026-02-15T20:56:00-08:00 | `where did the regression come from? can we find the commit? can we figure it out? does latest master of openclaw already have a fix?` |
| 2026-02-15T20:58:00-08:00 | `ok what change should we PR to openclaw main to fix this then?` |
| 2026-02-15T21:00:00-08:00 | `i dont really understand what you are doing and why, this doesn't seem right? also what was the original PR about? who merged it and when?` |
| 2026-02-15T21:03:00-08:00 | `why not just do the obvious final solution including phase 1 and 2? what's the REAL STRUCTURAL fix?` |
| 2026-02-15T21:06:00-08:00 | `ok but make sure we solve it in the simplest possible scope, but no simpler.` |
| 2026-02-15T21:07:00-08:00 | `go` |
| 2026-02-15T21:35:00-08:00 | `pr it? aynthing missing` |
| 2026-02-15T21:45:00-08:00 | `human written intent: fix errors lke 400 Item 'rs_0419e05c76e385a3006992963a50fc81a09d42ed06da8ca0d0' of type 'reasoning' was provided without its required following item. that happened with codex models` |
| 2026-02-15T21:45:10-08:00 | `no reviewers` |
| 2026-02-15T21:58:00-08:00 | `review pr yourself?` |
| 2026-02-15T22:00:00-08:00 | `why would you add a comment on your own PR? thats stupid. delete it. ... this diff is a red flag` |