### PR TITLE
feat: add Gemini OAuth support for embedding & media APIs

### DIFF
--- a/src/infra/gemini-auth.ts
+++ b/src/infra/gemini-auth.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared Gemini authentication utilities.
+ *
+ * Supports both traditional API keys and OAuth JSON format.
+ */
+
+/**
+ * Parse Gemini API key and return appropriate auth headers.
+ *
+ * OAuth format: `{"token": "...", "projectId": "..."}`
+ *
+ * @param apiKey - Either a traditional API key string or OAuth JSON
+ * @returns Headers object with appropriate authentication
+ */
+export function parseGeminiAuth(apiKey: string): { headers: Record<string, string> } {
+  // Try parsing as OAuth JSON format
+  if (apiKey.startsWith("{")) {
+    try {
+      const parsed = JSON.parse(apiKey) as { token?: string; projectId?: string };
+      if (typeof parsed.token === "string" && parsed.token) {
+        return {
+          headers: {
+            Authorization: `Bearer ${parsed.token}`,
+            "Content-Type": "application/json",
+          },
+        };
+      }
+    } catch {
+      // Parse failed, fallback to API key mode
+    }
+  }
+
+  // Default: traditional API key
+  return {
+    headers: {
+      "x-goog-api-key": apiKey,
+      "Content-Type": "application/json",
+    },
+  };
+}

--- a/src/media-understanding/providers/google/inline-data.ts
+++ b/src/media-understanding/providers/google/inline-data.ts
@@ -1,4 +1,5 @@
 import { normalizeGoogleModelId } from "../../../agents/models-config.providers.js";
+import { parseGeminiAuth } from "../../../infra/gemini-auth.js";
 import { assertOkOrThrowHttpError, fetchWithTimeoutGuarded, normalizeBaseUrl } from "../shared.js";
 
 export async function generateGeminiInlineDataText(params: {
@@ -30,12 +31,12 @@ export async function generateGeminiInlineDataText(params: {
   })();
   const url = `${baseUrl}/models/${model}:generateContent`;
 
+  const authHeaders = parseGeminiAuth(params.apiKey);
   const headers = new Headers(params.headers);
-  if (!headers.has("content-type")) {
-    headers.set("content-type", "application/json");
-  }
-  if (!headers.has("x-goog-api-key")) {
-    headers.set("x-goog-api-key", params.apiKey);
+  for (const [key, value] of Object.entries(authHeaders.headers)) {
+    if (!headers.has(key)) {
+      headers.set(key, value);
+    }
   }
 
   const prompt = (() => {

--- a/src/memory/embeddings-gemini.ts
+++ b/src/memory/embeddings-gemini.ts
@@ -1,6 +1,7 @@
 import type { EmbeddingProvider, EmbeddingProviderOptions } from "./embeddings.js";
 import { requireApiKey, resolveApiKeyForProvider } from "../agents/model-auth.js";
 import { isTruthyEnvValue } from "../infra/env.js";
+import { parseGeminiAuth } from "../infra/gemini-auth.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 
 export type GeminiEmbeddingClient = {
@@ -35,39 +36,6 @@ function resolveRemoteApiKey(remoteApiKey?: string): string | undefined {
     return process.env[trimmed]?.trim();
   }
   return trimmed;
-}
-
-/**
- * Parse Gemini API key and return appropriate auth headers.
- * Supports both traditional API keys and OAuth JSON format.
- *
- * OAuth format: `{"token": "...", "projectId": "..."}`
- */
-function parseGeminiAuth(apiKey: string): { headers: Record<string, string> } {
-  // Try parsing as OAuth JSON format
-  if (apiKey.startsWith("{")) {
-    try {
-      const parsed = JSON.parse(apiKey) as { token?: string; projectId?: string };
-      if (typeof parsed.token === "string" && parsed.token) {
-        return {
-          headers: {
-            Authorization: `Bearer ${parsed.token}`,
-            "Content-Type": "application/json",
-          },
-        };
-      }
-    } catch {
-      // Parse failed, fallback to API key mode
-    }
-  }
-
-  // Default: traditional API key
-  return {
-    headers: {
-      "x-goog-api-key": apiKey,
-      "Content-Type": "application/json",
-    },
-  };
 }
 
 function normalizeGeminiModel(model: string): string {


### PR DESCRIPTION
## Summary

Support OAuth authentication for Gemini embedding and media understanding APIs, so memory search and image/audio analysis work without explicit API keys when using OAuth.

### Changes

1. **Gemini Embedding OAuth**: Adds OAuth token support to embedding API calls in memory search
2. **Gemini Media OAuth**: Adds OAuth token support to media understanding API (image/audio analysis)

### Benefits

- Memory search works seamlessly with OAuth-authenticated Gemini sessions
- No need to manage separate API keys when OAuth is configured
- Consistent authentication across all Gemini API features

Fixes #17725 (OAuth part)
Closes #17813