### PR TITLE
fix: support OAuth for Gemini media understanding

### DIFF
--- a/src/infra/gemini-auth.ts
+++ b/src/infra/gemini-auth.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared Gemini authentication utilities.
+ *
+ * Supports both traditional API keys and OAuth JSON format.
+ */
+
+/**
+ * Parse Gemini API key and return appropriate auth headers.
+ *
+ * OAuth format: `{"token": "...", "projectId": "..."}`
+ *
+ * @param apiKey - Either a traditional API key string or OAuth JSON
+ * @returns Headers object with appropriate authentication
+ */
+export function parseGeminiAuth(apiKey: string): { headers: Record<string, string> } {
+  // Try parsing as OAuth JSON format
+  if (apiKey.startsWith("{")) {
+    try {
+      const parsed = JSON.parse(apiKey) as { token?: string; projectId?: string };
+      if (typeof parsed.token === "string" && parsed.token) {
+        return {
+          headers: {
+            Authorization: `Bearer ${parsed.token}`,
+            "Content-Type": "application/json",
+          },
+        };
+      }
+    } catch {
+      // Parse failed, fallback to API key mode
+    }
+  }
+
+  // Default: traditional API key
+  return {
+    headers: {
+      "x-goog-api-key": apiKey,
+      "Content-Type": "application/json",
+    },
+  };
+}

--- a/src/media-understanding/providers/google/inline-data.ts
+++ b/src/media-understanding/providers/google/inline-data.ts
@@ -1,4 +1,5 @@
 import { normalizeGoogleModelId } from "../../../agents/models-config.providers.js";
+import { parseGeminiAuth } from "../../../infra/gemini-auth.js";
 import { assertOkOrThrowHttpError, fetchWithTimeoutGuarded, normalizeBaseUrl } from "../shared.js";
 
 export async function generateGeminiInlineDataText(params: {
@@ -30,12 +31,12 @@ export async function generateGeminiInlineDataText(params: {
   })();
   const url = `${baseUrl}/models/${model}:generateContent`;
 
+  const authHeaders = parseGeminiAuth(params.apiKey);
   const headers = new Headers(params.headers);
-  if (!headers.has("content-type")) {
-    headers.set("content-type", "application/json");
-  }
-  if (!headers.has("x-goog-api-key")) {
-    headers.set("x-goog-api-key", params.apiKey);
+  for (const [key, value] of Object.entries(authHeaders.headers)) {
+    if (!headers.has(key)) {
+      headers.set(key, value);
+    }
   }
 
   const prompt = (() => {

--- a/src/memory/embeddings-gemini.ts
+++ b/src/memory/embeddings-gemini.ts
@@ -1,6 +1,7 @@
 import type { EmbeddingProvider, EmbeddingProviderOptions } from "./embeddings.js";
 import { requireApiKey, resolveApiKeyForProvider } from "../agents/model-auth.js";
 import { isTruthyEnvValue } from "../infra/env.js";
+import { parseGeminiAuth } from "../infra/gemini-auth.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 
 export type GeminiEmbeddingClient = {
@@ -35,39 +36,6 @@ function resolveRemoteApiKey(remoteApiKey?: string): string | undefined {
     return process.env[trimmed]?.trim();
   }
   return trimmed;
-}
-
-/**
- * Parse Gemini API key and return appropriate auth headers.
- * Supports both traditional API keys and OAuth JSON format.
- *
- * OAuth format: `{"token": "...", "projectId": "..."}`
- */
-function parseGeminiAuth(apiKey: string): { headers: Record<string, string> } {
-  // Try parsing as OAuth JSON format
-  if (apiKey.startsWith("{")) {
-    try {
-      const parsed = JSON.parse(apiKey) as { token?: string; projectId?: string };
-      if (typeof parsed.token === "string" && parsed.token) {
-        return {
-          headers: {
-            Authorization: `Bearer ${parsed.token}`,
-            "Content-Type": "application/json",
-          },
-        };
-      }
-    } catch {
-      // Parse failed, fallback to API key mode
-    }
-  }
-
-  // Default: traditional API key
-  return {
-    headers: {
-      "x-goog-api-key": apiKey,
-      "Content-Type": "application/json",
-    },
-  };
 }
 
 function normalizeGeminiModel(model: string): string {


### PR DESCRIPTION
## Summary
Extract `parseGeminiAuth()` to shared infra module (`src/infra/gemini-auth.ts`) and use it in both:
- `src/memory/embeddings-gemini.ts`  
- `src/media-understanding/providers/google/inline-data.ts`

## Problem
`inline-data.ts` directly set `x-goog-api-key` header without handling OAuth JSON format:
```typescript
if (!headers.has('x-goog-api-key')) {
  headers.set('x-goog-api-key', params.apiKey);
}
```

This broke media understanding when using OAuth authentication (e.g., `{"token": "...", "projectId": "..."}`).

## Solution
- Created `src/infra/gemini-auth.ts` with shared `parseGeminiAuth()` function
- Both files now import and use this shared function
- Properly supports both traditional API keys and OAuth tokens

## Testing
- `pnpm check` passes (format, types, lint)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extracts the `parseGeminiAuth()` function from `src/memory/embeddings-gemini.ts` (added in the prior commit `ac0613cf`) into a shared `src/infra/gemini-auth.ts` module, and applies it to `src/media-understanding/providers/google/inline-data.ts` to fix OAuth authentication for Gemini media understanding (video/image description).

- **New shared module**: `src/infra/gemini-auth.ts` — detects OAuth JSON format (`{"token": "...", "projectId": "..."}`) and returns `Authorization: Bearer` headers, falling back to `x-goog-api-key` for traditional API keys.
- **`inline-data.ts`**: Replaces hardcoded `x-goog-api-key` + `content-type` header logic with `parseGeminiAuth()`, fixing the bug where OAuth JSON was set as a raw API key value.
- **`embeddings-gemini.ts`**: Swaps the local `parseGeminiAuth` implementation for the shared import (no behavioral change).
- Header override semantics are preserved in both call sites — caller-provided headers still take precedence.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a straightforward extract-and-reuse refactor that fixes a real OAuth authentication bug with no behavioral regressions.
- The changes are minimal and well-scoped: a function is extracted verbatim from one file into a shared module and applied to a second call site. The extracted function is identical to the original. Header override semantics are preserved in both consumers. Existing tests (embeddings + video) validate the traditional API key path, and the OAuth path follows the same pattern already proven in the embeddings module. No new attack surface or risky logic introduced.
- No files require special attention.

<sub>Last reviewed commit: 962d59b</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->