### PR TITLE
fix: use $HOME as cwd for global update to prevent path-dedot panic

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -394,6 +394,7 @@ public struct SendParams: Codable, Sendable {
     public let gifplayback: Bool?
     public let channel: String?
     public let accountid: String?
+    public let threadid: String?
     public let sessionkey: String?
     public let idempotencykey: String
 
@@ -405,6 +406,7 @@ public struct SendParams: Codable, Sendable {
         gifplayback: Bool?,
         channel: String?,
         accountid: String?,
+        threadid: String?,
         sessionkey: String?,
         idempotencykey: String
     ) {
@@ -415,6 +417,7 @@ public struct SendParams: Codable, Sendable {
         self.gifplayback = gifplayback
         self.channel = channel
         self.accountid = accountid
+        self.threadid = threadid
         self.sessionkey = sessionkey
         self.idempotencykey = idempotencykey
     }
@@ -426,6 +429,7 @@ public struct SendParams: Codable, Sendable {
         case gifplayback = "gifPlayback"
         case channel
         case accountid = "accountId"
+        case threadid = "threadId"
         case sessionkey = "sessionKey"
         case idempotencykey = "idempotencyKey"
     }

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -394,6 +394,7 @@ public struct SendParams: Codable, Sendable {
     public let gifplayback: Bool?
     public let channel: String?
     public let accountid: String?
+    public let threadid: String?
     public let sessionkey: String?
     public let idempotencykey: String
 
@@ -405,6 +406,7 @@ public struct SendParams: Codable, Sendable {
         gifplayback: Bool?,
         channel: String?,
         accountid: String?,
+        threadid: String?,
         sessionkey: String?,
         idempotencykey: String
     ) {
@@ -415,6 +417,7 @@ public struct SendParams: Codable, Sendable {
         self.gifplayback = gifplayback
         self.channel = channel
         self.accountid = accountid
+        self.threadid = threadid
         self.sessionkey = sessionkey
         self.idempotencykey = idempotencykey
     }
@@ -426,6 +429,7 @@ public struct SendParams: Codable, Sendable {
         case gifplayback = "gifPlayback"
         case channel
         case accountid = "accountId"
+        case threadid = "threadId"
         case sessionkey = "sessionKey"
         case idempotencykey = "idempotencyKey"
     }

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -1,5 +1,5 @@
-import { confirm, isCancel } from "@clack/prompts";
 import path from "node:path";
+import { confirm, isCancel } from "@clack/prompts";
 import {
   checkShellCompletionStatus,
   ensureCompletionCacheExists,

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -1,5 +1,5 @@
-import path from "node:path";
 import { confirm, isCancel } from "@clack/prompts";
+import path from "node:path";
 import {
   checkShellCompletionStatus,
   ensureCompletionCacheExists,

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -20,7 +20,7 @@ import {
 } from "../../infra/update-check.js";
 import {
   cleanupGlobalRenameDirs,
-  globalInstallArgs,
+  globalInstallConfig,
   resolveGlobalPackageRoot,
 } from "../../infra/update-global.js";
 import { runGatewayUpdate, type UpdateRunResult } from "../../infra/update-runner.js";
@@ -168,9 +168,11 @@ async function runPackageInstallUpdate(params: {
     });
   }
 
+  const install = globalInstallConfig(manager, `${packageName}@${params.tag}`);
   const updateStep = await runUpdateStep({
     name: "global update",
-    argv: globalInstallArgs(manager, `${packageName}@${params.tag}`),
+    argv: install.argv,
+    cwd: install.cwd,
     timeoutMs: params.timeoutMs,
     progress: params.progress,
   });
@@ -260,10 +262,11 @@ async function runGitUpdate(params: {
       installKind: params.installKind,
       timeoutMs: effectiveTimeout,
     });
+    const globalInstall = globalInstallConfig(manager, updateRoot);
     const installStep = await runUpdateStep({
       name: "global install",
-      argv: globalInstallArgs(manager, updateRoot),
-      cwd: updateRoot,
+      argv: globalInstall.argv,
+      cwd: globalInstall.cwd,
       timeoutMs: effectiveTimeout,
       progress: params.progress,
     });

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -1,13 +1,12 @@
-import type { ZodIssue } from "zod";
 import fs from "node:fs/promises";
 import path from "node:path";
-import type { OpenClawConfig } from "../config/config.js";
-import type { DoctorOptions } from "./doctor-prompter.js";
+import type { ZodIssue } from "zod";
 import {
   isNumericTelegramUserId,
   normalizeTelegramAllowFromEntry,
 } from "../channels/telegram/allow-from.js";
 import { formatCliCommand } from "../cli/command-format.js";
+import type { OpenClawConfig } from "../config/config.js";
 import {
   OpenClawSchema,
   CONFIG_PATH,
@@ -19,6 +18,7 @@ import { listTelegramAccountIds, resolveTelegramAccount } from "../telegram/acco
 import { note } from "../terminal/note.js";
 import { isRecord, resolveHomeDir } from "../utils.js";
 import { normalizeLegacyConfigValues } from "./doctor-legacy-config.js";
+import type { DoctorOptions } from "./doctor-prompter.js";
 import { autoMigrateLegacyStateDir } from "./doctor-state-migrations.js";
 
 type UnrecognizedKeysIssue = ZodIssue & {

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,7 +1,5 @@
-import { intro as clackIntro, outro as clackOutro } from "@clack/prompts";
 import fs from "node:fs";
-import type { OpenClawConfig } from "../config/config.js";
-import type { RuntimeEnv } from "../runtime.js";
+import { intro as clackIntro, outro as clackOutro } from "@clack/prompts";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { loadModelCatalog } from "../agents/model-catalog.js";
@@ -11,12 +9,14 @@ import {
   resolveHooksGmailModel,
 } from "../agents/model-selection.js";
 import { formatCliCommand } from "../cli/command-format.js";
+import type { OpenClawConfig } from "../config/config.js";
 import { CONFIG_PATH, readConfigFileSnapshot, writeConfigFile } from "../config/config.js";
 import { logConfigUpdated } from "../config/logging.js";
 import { resolveGatewayService } from "../daemon/service.js";
 import { resolveGatewayAuth } from "../gateway/auth.js";
 import { buildGatewayConnectionDetails } from "../gateway/call.js";
 import { resolveOpenClawPackageRoot } from "../infra/openclaw-root.js";
+import type { RuntimeEnv } from "../runtime.js";
 import { defaultRuntime } from "../runtime.js";
 import { note } from "../terminal/note.js";
 import { stylePromptTitle } from "../terminal/prompt-style.js";

--- a/src/infra/exec-approvals-allowlist.ts
+++ b/src/infra/exec-approvals-allowlist.ts
@@ -1,6 +1,5 @@
 import fs from "node:fs";
 import path from "node:path";
-import type { ExecAllowlistEntry } from "./exec-approvals.js";
 import {
   DEFAULT_SAFE_BINS,
   analyzeShellCommand,
@@ -12,6 +11,7 @@ import {
   type CommandResolution,
   type ExecCommandSegment,
 } from "./exec-approvals-analysis.js";
+import type { ExecAllowlistEntry } from "./exec-approvals.js";
 import { isTrustedSafeBinPath } from "./exec-safe-bin-trust.js";
 
 function isPathLikeToken(value: string): boolean {

--- a/src/infra/update-global.ts
+++ b/src/infra/update-global.ts
@@ -136,6 +136,23 @@ export function globalInstallArgs(manager: GlobalInstallManager, spec: string): 
   return ["npm", "i", "-g", spec];
 }
 
+/**
+ * Returns argv **and** a safe cwd for a global install command.
+ *
+ * Global installs determine the target directory via the package manager's
+ * prefix config (not cwd), so the child process cwd is functionally
+ * irrelevant. We use `$HOME` to guarantee the directory won't vanish
+ * mid-install — the previous approach of using the package install directory
+ * caused post-install hooks (e.g. mise reshim) to panic when npm replaced
+ * that directory during the update. (#7135)
+ */
+export function globalInstallConfig(
+  manager: GlobalInstallManager,
+  spec: string,
+): { argv: string[]; cwd: string } {
+  return { argv: globalInstallArgs(manager, spec), cwd: os.homedir() };
+}
+
 export async function cleanupGlobalRenameDirs(params: {
   globalRoot: string;
   packageName: string;

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -382,6 +382,51 @@ describe("runGatewayUpdate", () => {
     expect(calls.some((call) => call === expectedInstallCommand)).toBe(true);
   });
 
+  it("runs global update with $HOME as cwd, not the install directory", async () => {
+    const nodeModules = path.join(tempDir, "node_modules");
+    const pkgRoot = path.join(nodeModules, "openclaw");
+    await fs.mkdir(pkgRoot, { recursive: true });
+    await fs.writeFile(
+      path.join(pkgRoot, "package.json"),
+      JSON.stringify({ name: "openclaw", version: "1.0.0" }),
+      "utf-8",
+    );
+
+    const cwds: string[] = [];
+    const runCommand = async (argv: string[], options: { cwd?: string }) => {
+      const key = argv.join(" ");
+      if (key === `git -C ${pkgRoot} rev-parse --show-toplevel`) {
+        return { stdout: "", stderr: "not a git repository", code: 128 };
+      }
+      if (key === "npm root -g") {
+        return { stdout: nodeModules, stderr: "", code: 0 };
+      }
+      if (key === "pnpm root -g") {
+        return { stdout: "", stderr: "", code: 1 };
+      }
+      if (key === "npm i -g openclaw@latest") {
+        if (options.cwd) {
+          cwds.push(options.cwd);
+        }
+        return { stdout: "ok", stderr: "", code: 0 };
+      }
+      return { stdout: "", stderr: "", code: 0 };
+    };
+
+    await runGatewayUpdate({
+      cwd: pkgRoot,
+      runCommand: async (argv, options) => runCommand(argv, options),
+      timeoutMs: 5000,
+    });
+
+    // The global update command must NOT run inside the install directory,
+    // because npm replaces it during the update which causes post-install
+    // hooks (e.g. mise reshim) to panic when their cwd disappears.
+    expect(cwds).toHaveLength(1);
+    expect(cwds[0]).toBe(os.homedir());
+    expect(cwds[0]).not.toBe(pkgRoot);
+  });
+
   it("cleans stale npm rename dirs before global update", async () => {
     const nodeModules = path.join(tempDir, "node_modules");
     const pkgRoot = path.join(nodeModules, "openclaw");

--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -21,7 +21,7 @@ import { compareSemverStrings } from "./update-check.js";
 import {
   cleanupGlobalRenameDirs,
   detectGlobalInstallManagerForRoot,
-  globalInstallArgs,
+  globalInstallConfig,
 } from "./update-global.js";
 
 export type UpdateStepResult = {
@@ -875,11 +875,12 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
     const channel = opts.channel ?? DEFAULT_PACKAGE_CHANNEL;
     const tag = normalizeTag(opts.tag ?? channelToNpmTag(channel));
     const spec = `${packageName}@${tag}`;
+    const install = globalInstallConfig(globalManager, spec);
     const updateStep = await runStep({
       runCommand,
       name: "global update",
-      argv: globalInstallArgs(globalManager, spec),
-      cwd: pkgRoot,
+      argv: install.argv,
+      cwd: install.cwd,
       timeoutMs,
       progress,
       stepIndex: 0,


### PR DESCRIPTION
## Summary

Fixes #7135.

During `openclaw update` for global npm/pnpm/bun installs, the update step's `cwd` was set to the package install directory (`pkgRoot`). When `npm i -g` replaces that directory, any post-install hooks (e.g. `mise reshim`) find their working directory has vanished, causing `path-dedot` to panic on `unwrap()` of `std::env::current_dir()`.

## Approach

Instead of patching each call site individually, this PR introduces `globalInstallConfig()` in `update-global.ts` — a centralised helper that returns both `argv` and a safe `cwd` (`os.homedir()`). The `-g` flag already determines the install target via the package manager's global prefix config, so the child process `cwd` is irrelevant to where packages are installed. Encapsulating this in one place ensures future call sites automatically get a stable `cwd` without needing to know about this edge case.

## Changes

| File | Change |
|------|--------|
| `src/infra/update-global.ts` | Added `globalInstallConfig()` that returns `{ argv, cwd: os.homedir() }` |
| `src/infra/update-runner.ts` | Switched from `globalInstallArgs()` + `cwd: pkgRoot` to `globalInstallConfig()` |
| `src/cli/update-cli/update-command.ts` | Switched both global update and global install call sites to `globalInstallConfig()` |
| `src/infra/update-runner.test.ts` | Added regression test asserting the global update step runs with `$HOME` as cwd, not the install directory |

## Test plan

- [x] Existing `update-runner.test.ts` tests pass (14/14)
- [x] New regression test verifies cwd is `os.homedir()`, not `pkgRoot`
- [x] `pnpm lint` passes (0 errors)
- [x] `pnpm build` passes

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a `path-dedot` panic during `openclaw update` for global npm/pnpm/bun installs by changing the child process `cwd` from the package install directory (`pkgRoot`) to `$HOME`. The package install directory can be deleted and recreated by `npm i -g` during the update, which causes post-install hooks (e.g. `mise reshim`) to fail when they call `std::env::current_dir()` on a non-existent path.

- Introduced `globalInstallConfig()` in `src/infra/update-global.ts` that bundles both `argv` and a safe `cwd` (`os.homedir()`) into a single return value, replacing direct calls to `globalInstallArgs()` + manual `cwd` at each call site
- Updated all three global install call sites (`update-runner.ts`, two in `update-command.ts`) to use the new helper
- Added a regression test asserting the global update command runs with `os.homedir()` as cwd, not the install directory

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a targeted, well-tested bug fix with no behavioral side effects.
- The change is minimal and focused: it replaces an unsafe `cwd` (the package install directory that can vanish mid-update) with `os.homedir()`, which is always stable. The `-g` flag makes the actual install target independent of cwd, so this change has no effect on where packages are installed. All three call sites are updated consistently, a regression test is added, and the PR description clearly explains the root cause. No new dependencies, no architectural changes, no risk of regressions.
- No files require special attention

<sub>Last reviewed commit: 20e5c37</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->