### PR TITLE
Fix media store cleanup ignoring subdirectories (e.g. inbound)

### DIFF
--- a/src/media/cleanup.test.ts
+++ b/src/media/cleanup.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { cleanOldMedia, ensureMediaDir, resetCleanupThrottleForTest } from "./store.js";
+
+// We'll set process.env.OPENCLAW_STATE_DIR to redirect the config dir
+const originalStateDir = process.env.OPENCLAW_STATE_DIR;
+let tempDir: string;
+
+describe("Media Store Cleanup", () => {
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-media-test-"));
+    process.env.OPENCLAW_STATE_DIR = tempDir;
+    resetCleanupThrottleForTest();
+  });
+
+  afterEach(async () => {
+    if (originalStateDir) {
+      process.env.OPENCLAW_STATE_DIR = originalStateDir;
+    } else {
+      delete process.env.OPENCLAW_STATE_DIR;
+    }
+    // Clean up temp dir
+    await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it("cleans up old files in the root media directory", async () => {
+    const mediaDir = await ensureMediaDir();
+    const filePath = path.join(mediaDir, "old-file.txt");
+    await fs.writeFile(filePath, "test content");
+    
+    // Set mtime to 1 hour ago
+    const oldTime = new Date(Date.now() - 60 * 60 * 1000);
+    await fs.utimes(filePath, oldTime, oldTime);
+
+    // Clean files older than 30 minutes
+    await cleanOldMedia(30 * 60 * 1000);
+
+    // Should be gone
+    await expect(fs.access(filePath)).rejects.toThrow();
+  });
+
+  it("recursively cleans up files in subdirectories (e.g. inbound)", async () => {
+    // This demonstrates the bug fix: cleanOldMedia is now recursive
+    const mediaDir = await ensureMediaDir();
+    const inboundDir = path.join(mediaDir, "inbound");
+    await fs.mkdir(inboundDir, { recursive: true });
+    
+    const filePath = path.join(inboundDir, "old-inbound-file.txt");
+    await fs.writeFile(filePath, "test content");
+    
+    // Set mtime to 1 hour ago
+    const oldTime = new Date(Date.now() - 60 * 60 * 1000);
+    await fs.utimes(filePath, oldTime, oldTime);
+
+    // Clean files older than 30 minutes
+    await cleanOldMedia(30 * 60 * 1000);
+
+    // Should be deleted now
+    await expect(fs.access(filePath)).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Description
The `cleanOldMedia` function only scanned the root media directory, ignoring subdirectories like `inbound/` where Matrix, Signal, and other plugins store received media. This caused the `media/inbound` directory to grow indefinitely.

## Fix
1. Made `cleanOldMedia` recursive.
2. Trigger cleanup on inbound media save (was only on outbound).
3. Added throttling (max once per minute) to prevent excessive filesystem scanning.

## Tests
Added `src/media/cleanup.test.ts` verifying:
- Root files are cleaned up
- Subdirectory files are cleaned up (failed before fix)

## AI Transparency
- **Assisted by**: OpenClaw Agent (Claude 3.5 Sonnet / Opus)
- **Testing level**: Fully tested with new unit tests (`src/media/cleanup.test.ts`)
- **Prompt strategy**: Self-correction loop based on codebase analysis

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Made `cleanOldMedia` recursive to scan subdirectories (like `media/inbound/`) instead of only the root `media/` directory. Added cleanup call in `saveMediaBuffer` so inbound media triggers cleanup. Added throttling (max once per minute) to prevent excessive filesystem scanning.

**Key changes:**
- Recursive directory scanning now cleans files in all subdirectories
- Throttle mechanism prevents cleanup from running more than once per 60 seconds
- `saveMediaBuffer` now triggers cleanup (previously only `saveMediaSource` did)
- Added test coverage for both root and subdirectory cleanup

**Note:** One inline comment about a potential race condition in the throttle mechanism is incorrect - the throttle is safe because the check and update happen synchronously before any `await` points in Node.js's single-threaded event loop.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one incorrect inline comment that can be disregarded
- The implementation correctly makes cleanup recursive and adds throttling. Tests verify the fix works. One inline comment about a race condition is technically incorrect (the throttle is actually safe in Node's single-threaded model), but the code itself is correct. The fire-and-forget pattern in `saveMediaBuffer` (void + catch) is appropriate.
- No files require special attention - the implementation is sound despite one mistaken inline comment

<sub>Last reviewed commit: 1f63416</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->