### PR TITLE
Fix Signal reaction notification missing sender (support legacy 'source' field)

### DIFF
--- a/src/signal/identity.ts
+++ b/src/signal/identity.ts
@@ -30,8 +30,10 @@ function stripSignalPrefix(value: string): string {
 export function resolveSignalSender(params: {
   sourceNumber?: string | null;
   sourceUuid?: string | null;
+  // Legacy support for older signal-cli versions or raw 'source' field
+  source?: string | null;
 }): SignalSender | null {
-  const sourceNumber = params.sourceNumber?.trim();
+  const sourceNumber = (params.sourceNumber || params.source)?.trim();
   if (sourceNumber) {
     return {
       kind: "phone",

--- a/src/signal/monitor/event-handler.reaction-sender.test.ts
+++ b/src/signal/monitor/event-handler.reaction-sender.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { resolveSignalSender } from "../identity.js";
+
+describe("Signal Reaction Handler (Sender Resolution)", () => {
+  it("should resolve sender from sourceNumber", () => {
+    const sender = resolveSignalSender({ sourceNumber: "+1234567890" });
+    expect(sender).toEqual({
+      kind: "phone",
+      raw: "+1234567890",
+      e164: "+1234567890",
+    });
+  });
+
+  it("should resolve sender from source (legacy field)", () => {
+    // This simulates older signal-cli versions or cases where 'source' is used instead of sourceNumber
+    const sender = resolveSignalSender({ source: "+1987654321" });
+    expect(sender).toEqual({
+      kind: "phone",
+      raw: "+1987654321",
+      e164: "+1987654321",
+    });
+  });
+
+  it("should prioritize sourceNumber over source if both present", () => {
+    const sender = resolveSignalSender({
+      sourceNumber: "+1111111111",
+      source: "+2222222222",
+    });
+    expect(sender).toEqual({
+      kind: "phone",
+      raw: "+1111111111",
+      e164: "+1111111111",
+    });
+  });
+
+  it("should resolve sender from sourceUuid", () => {
+    const sender = resolveSignalSender({ sourceUuid: "uuid-123" });
+    expect(sender).toEqual({ kind: "uuid", raw: "uuid-123" });
+  });
+
+  it("should return null if neither present", () => {
+    const sender = resolveSignalSender({});
+    expect(sender).toBeNull();
+  });
+});

--- a/src/signal/monitor/event-handler.types.ts
+++ b/src/signal/monitor/event-handler.types.ts
@@ -9,6 +9,8 @@ export type SignalEnvelope = {
   sourceNumber?: string | null;
   sourceUuid?: string | null;
   sourceName?: string | null;
+  // Legacy field support
+  source?: string | null;
   timestamp?: number | null;
   dataMessage?: SignalDataMessage | null;
   editMessage?: { dataMessage?: SignalDataMessage | null } | null;


### PR DESCRIPTION
## Description
Some versions of `signal-cli` (or when communicating with older peers) may send the sender's phone number in the legacy `source` field instead of `sourceNumber`. This caused `resolveSignalSender` to return null, silently dropping the reaction notification.

## Fix
Update `resolveSignalSender` to check `source` as a fallback for `sourceNumber`.

## Tests
Added `src/signal/monitor/event-handler.reaction-sender.test.ts` verifying:
- `sourceNumber` is preferred
- `source` (legacy) is accepted as fallback
- `sourceUuid` still works (for unknown contacts)

## AI Transparency
- **Assisted by**: OpenClaw Agent (Claude 3.5 Sonnet / Opus)
- **Testing level**: Fully tested with new unit tests (`src/signal/monitor/event-handler.reaction-sender.test.ts`)
- **Prompt strategy**: Self-correction loop based on codebase analysis

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where Signal reaction notifications were silently dropped when using older `signal-cli` versions or communicating with older peers that send the sender's phone number in the legacy `source` field instead of `sourceNumber`.

- Updated `resolveSignalSender` in `src/signal/identity.ts:36` to check `source` as a fallback when `sourceNumber` is not present
- Added the `source` field to `SignalEnvelope` type definition for proper type safety
- Added comprehensive unit tests covering all sender resolution scenarios including the new fallback behavior

The fix is minimal, backward-compatible, and correctly prioritizes `sourceNumber` over the legacy `source` field when both are present.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk - it's a focused backward-compatibility fix with comprehensive test coverage
- The fix is minimal (one-line logic change), well-tested with 5 comprehensive test cases covering all scenarios, maintains backward compatibility, follows existing code patterns, and includes proper TypeScript type updates. The fallback logic correctly prioritizes the newer field over the legacy field.
- No files require special attention

<sub>Last reviewed commit: c7bfeb2</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->