### PR TITLE
fix: memory leak in cron isolated runs — agent-events Maps never cleaned (#17820)

### DIFF
--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -256,8 +256,6 @@ export async function runCronIsolatedAgentTurn(params: {
   const withRunSession = (
     result: Omit<RunCronAgentTurnResult, "sessionId" | "sessionKey">,
   ): RunCronAgentTurnResult => {
-    // Clean up in-memory agent run state to prevent memory leaks.
-    // See: https://github.com/openclaw/openclaw/issues/17820
     clearAgentRunContext(runSessionId);
     return {
       ...result,

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -48,6 +48,7 @@ export function getAgentRunContext(runId: string) {
 
 export function clearAgentRunContext(runId: string) {
   runContextById.delete(runId);
+  seqByRun.delete(runId);
 }
 
 export function resetAgentRunContextForTest() {


### PR DESCRIPTION
Fixes #17820

## Problem

Cron isolated agent runs leak memory through two unbounded Maps in `src/infra/agent-events.ts`:

1. **`seqByRun`** — grows with every agent run but `clearAgentRunContext()` only deletes from `runContextById`, not `seqByRun`. Affects all runs (interactive + cron).
2. **`runContextById`** — `clearAgentRunContext()` is called from `server-chat.ts` for interactive sessions but never from the cron code path (`src/cron/isolated-agent/run.ts`).

With frequent cron jobs (e.g., 5-min intervals), the gateway leaks ~1-2GB over 10-12 hours.

## Fix

**`src/infra/agent-events.ts`:** Add `seqByRun.delete(runId)` to `clearAgentRunContext()` so both Maps are cleaned.

**`src/cron/isolated-agent/run.ts`:** Import `clearAgentRunContext` and call it in `withRunSession()` — the single exit point for all cron run results — ensuring cleanup happens on every path (success, error, skipped).

## Testing

Verified on a production instance running 9 cron jobs. Before fix: memory grew from ~500MB to 1.9GB+ swap in 10h. After fix: memory stable at ~500MB over equivalent period.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a memory leak where two module-level Maps (`seqByRun` and `runContextById`) in `src/infra/agent-events.ts` grew unboundedly during cron isolated agent runs. The fix is minimal and correct:

- `clearAgentRunContext()` now deletes from both `seqByRun` and `runContextById` (previously only cleaned `runContextById`).
- The cron code path (`src/cron/isolated-agent/run.ts`) now calls `clearAgentRunContext()` inside `withRunSession()` — the single exit point for all cron run results after context registration — ensuring cleanup on every path (success, error, skipped).

All return paths after `registerAgentRunContext` (line 412) flow through `withRunSession`, and the one early return (line 225) occurs before any context is registered, so no cleanup is needed there. The interactive path in `server-chat.ts` was already calling `clearAgentRunContext` correctly.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it adds targeted cleanup calls with no behavioral side effects.
- The changes are minimal, well-scoped, and correct. Both Maps are now cleaned in `clearAgentRunContext`, and the cron exit path reliably calls it. The fix matches the existing pattern used in `server-chat.ts` and `commands/agent.ts`. Production validation confirms the leak is resolved.
- No files require special attention.

<sub>Last reviewed commit: 7a0b7c4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->