### PR TITLE
fix: remove false-positive billing error rewrite on normal assistant text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Doctor/State integrity: only require/create the OAuth credentials directory when WhatsApp or pairing-backed channels are configured, and downgrade fresh-install missing-dir noise to an informational warning.
+- Agents/Sanitization: stop rewriting billing-shaped assistant text outside explicit error context so normal replies about billing/credits/payment are preserved across messaging channels. (#17834, fixes #11359)
 - Security/Agents: cap embedded Pi runner outer retry loop with a higher profile-aware dynamic limit (32-160 attempts) and return an explicit `retry_limit` error payload when retries never converge, preventing unbounded internal retry cycles (`GHSA-76m6-pj3w-v7mf`).
 - Telegram: detect duplicate bot-token ownership across Telegram accounts at startup/status time, mark secondary accounts as not configured with an explicit fix message, and block duplicate account startup before polling to avoid endless `getUpdates` conflict loops.
 - Agents/Tool images: include source filenames in `agents/tool-images` resize logs so compression events can be traced back to specific files.

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.e2e.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.e2e.test.ts
@@ -72,9 +72,14 @@ describe("sanitizeUserFacingText", () => {
     expect(sanitizeUserFacingText(text)).toBe(text);
   });
 
-  it("rewrites billing error-shaped text", () => {
+  it("does not rewrite billing error-shaped text without errorContext", () => {
     const text = "billing: please upgrade your plan";
-    expect(sanitizeUserFacingText(text)).toContain("billing error");
+    expect(sanitizeUserFacingText(text)).toBe(text);
+  });
+
+  it("rewrites billing error-shaped text with errorContext", () => {
+    const text = "billing: please upgrade your plan";
+    expect(sanitizeUserFacingText(text, { errorContext: true })).toContain("billing error");
   });
 
   it("sanitizes raw API error payloads", () => {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -244,18 +244,6 @@ function shouldRewriteContextOverflowText(raw: string): boolean {
   );
 }
 
-function shouldRewriteBillingText(raw: string): boolean {
-  if (!isBillingErrorMessage(raw)) {
-    return false;
-  }
-  return (
-    isRawApiErrorPayload(raw) ||
-    isLikelyHttpErrorText(raw) ||
-    ERROR_PREFIX_RE.test(raw) ||
-    BILLING_ERROR_HEAD_RE.test(raw)
-  );
-}
-
 type ErrorPayload = Record<string, unknown>;
 
 function isErrorPayloadObject(payload: unknown): payload is ErrorPayload {
@@ -550,13 +538,6 @@ export function sanitizeUserFacingText(text: string, opts?: { errorContext?: boo
       }
       return formatRawAssistantErrorForUi(trimmed);
     }
-  }
-
-  // Preserve legacy behavior for explicit billing-head text outside known
-  // error contexts (e.g., "billing: please upgrade your plan"), while
-  // keeping conversational billing mentions untouched.
-  if (shouldRewriteBillingText(trimmed)) {
-    return BILLING_ERROR_USER_MESSAGE;
   }
 
   // Strip leading blank lines (including whitespace-only lines) without clobbering indentation on


### PR DESCRIPTION
Fixes #11359

When an assistant response discusses billing, credits, or payment topics in normal conversation, `sanitizeUserFacingText` was replacing the entire response with the billing error banner. This was happening on Telegram, Discord, and WhatsApp channels — the web UI was unaffected because it receives raw WebSocket events without the sanitization pass.

The root cause is the `shouldRewriteBillingText` fallback that ran outside the `errorContext` guard. Even though it required the text to also look error-shaped (start with "billing:", match API error JSON, etc.), it was still too aggressive for real-world assistant responses.

Since the `errorContext` block already handles genuine billing errors correctly (the caller sets `errorContext: true` when delivering known error payloads), the outside fallback is no longer needed.

Changes:
- Removed the `shouldRewriteBillingText` call and function outside the `errorContext` block
- Updated tests to verify billing-shaped text is preserved without `errorContext`, and still rewritten with `errorContext: true`
- All 51 existing tests pass

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes a false-positive billing error rewrite in `sanitizeUserFacingText` that was replacing normal assistant responses discussing billing/credits/payment topics with the billing error banner on messaging channels (Telegram, Discord, WhatsApp). The removed `shouldRewriteBillingText` fallback ran outside the `errorContext` guard and matched billing-shaped patterns even in conversational text. Since genuine billing errors are already correctly handled inside the `errorContext` block (where callers set `errorContext: true` for known error payloads), the outside fallback was redundant and harmful. Tests are updated to verify billing-shaped text is preserved without `errorContext` and still rewritten with it.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it removes a well-understood false-positive code path while preserving correct error handling.
- The change is minimal and well-scoped: it removes one function and its call site that was causing false positives. The genuine billing error handling inside the errorContext guard remains intact. All callers of sanitizeUserFacingText already correctly set errorContext based on error state. Tests are updated to cover both the preserved and rewritten cases. No dead code is introduced.
- No files require special attention.

<sub>Last reviewed commit: 1b7aa39</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->