### PR TITLE
Fix misleading gateway stop hints for standalone listeners

### DIFF
--- a/src/infra/ports-format.ts
+++ b/src/infra/ports-format.ts
@@ -27,7 +27,7 @@ export function buildPortHints(listeners: PortListener[], port: number): string[
   const hints: string[] = [];
   if (kinds.has("gateway")) {
     hints.push(
-      `Gateway already running locally. Stop it (${formatCliCommand("openclaw gateway stop")}) or use a different port.`,
+      `Gateway already running locally. Stop the existing listener (or run ${formatCliCommand(`openclaw gateway --force --port ${port}`)}) or use a different port.`,
     );
   }
   if (kinds.has("ssh")) {

--- a/src/infra/ports.test.ts
+++ b/src/infra/ports.test.ts
@@ -76,6 +76,12 @@ describe("ports helpers", () => {
     ).toBe("gateway");
   });
 
+  it("builds standalone-safe gateway hints", () => {
+    const hints = buildPortHints([{ pid: 321, commandLine: "openclaw-gateway" }], 18789);
+    expect(hints.join("\n")).toContain("openclaw gateway --force --port 18789");
+    expect(hints.join("\n")).not.toContain("openclaw gateway stop");
+  });
+
   it("formats port diagnostics with hints", () => {
     const diagnostics = {
       port: 18789,

--- a/src/web/test-helpers.ts
+++ b/src/web/test-helpers.ts
@@ -92,21 +92,29 @@ export function resetBaileysMocks() {
   (globalThis as Record<PropertyKey, unknown>)[Symbol.for("openclaw:lastSocket")] =
     recreated.lastSocket;
 
+  const recreatedMakeWASocket = recreated.mod
+    .makeWASocket as unknown as typeof baileys.makeWASocket;
   const makeWASocket = vi.mocked(baileys.makeWASocket);
   makeWASocket.mockReset();
-  makeWASocket.mockImplementation(recreated.mod.makeWASocket);
+  makeWASocket.mockImplementation(recreatedMakeWASocket);
 
+  const recreatedUseMultiFileAuthState = recreated.mod
+    .useMultiFileAuthState as unknown as typeof baileys.useMultiFileAuthState;
   const useMultiFileAuthState = vi.mocked(baileys.useMultiFileAuthState);
   useMultiFileAuthState.mockReset();
-  useMultiFileAuthState.mockImplementation(recreated.mod.useMultiFileAuthState);
+  useMultiFileAuthState.mockImplementation(recreatedUseMultiFileAuthState);
 
+  const recreatedFetchLatestBaileysVersion = recreated.mod
+    .fetchLatestBaileysVersion as unknown as typeof baileys.fetchLatestBaileysVersion;
   const fetchLatestBaileysVersion = vi.mocked(baileys.fetchLatestBaileysVersion);
   fetchLatestBaileysVersion.mockReset();
-  fetchLatestBaileysVersion.mockImplementation(recreated.mod.fetchLatestBaileysVersion);
+  fetchLatestBaileysVersion.mockImplementation(recreatedFetchLatestBaileysVersion);
 
+  const recreatedMakeCacheableSignalKeyStore = recreated.mod
+    .makeCacheableSignalKeyStore as unknown as typeof baileys.makeCacheableSignalKeyStore;
   const makeCacheableSignalKeyStore = vi.mocked(baileys.makeCacheableSignalKeyStore);
   makeCacheableSignalKeyStore.mockReset();
-  makeCacheableSignalKeyStore.mockImplementation(recreated.mod.makeCacheableSignalKeyStore);
+  makeCacheableSignalKeyStore.mockImplementation(recreatedMakeCacheableSignalKeyStore);
 }
 
 export function getLastSocket(): MockBaileysSocket {


### PR DESCRIPTION
## Problem
On macOS, users can end up with a standalone `openclaw-gateway` process (not launchd-managed) still listening on the gateway port.

In that state:
- `openclaw gateway stop` / `openclaw gateway start` report `service not loaded`
- `openclaw gateway` lock-error output still suggested `openclaw gateway stop`
- port hints also assumed service-managed stop behavior

That combination sends users into a dead-end.

## Root Cause
Two messaging paths were service-assumptive:
1. GatewayLockError handling in `gateway run`
2. Generic gateway port hints in `infra/ports-format`

Neither checked whether the listener was standalone while service state was `not loaded`.

## What This PR Changes
### 1) Context-aware lock-error guidance
In `src/cli/gateway-cli/run.ts`:
- Added standalone listener detection:
  - port is busy
  - listener classifies as gateway
  - service `isLoaded()` is `false`
- When detected, prints explicit standalone remediation:
  - `openclaw gateway --force --port <port>`
  - or stop listed PID manually
- Preserves existing service-oriented hints when service is actually loaded.

### 2) Safer generic port hint text
In `src/infra/ports-format.ts`:
- Updated gateway hint to process-oriented guidance instead of always suggesting `openclaw gateway stop`.

### 3) Regression coverage
- `src/cli/gateway-cli.coverage.e2e.test.ts`
  - Added scenario for GatewayLockError + service not loaded + gateway listener.
  - Asserts standalone guidance is shown and loaded-service wording is not.
- `src/infra/ports.test.ts`
  - Added assertion that gateway hints include `--force --port` and no longer require `gateway stop` wording.

## Validation
- `pnpm --dir /Users/connorcallison/code/openclaw exec vitest run --config vitest.unit.config.ts src/infra/ports.test.ts`
- `pnpm --dir /Users/connorcallison/code/openclaw exec vitest run --config vitest.e2e.config.ts src/cli/gateway-cli.coverage.e2e.test.ts`

Both pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes misleading error messages when users have standalone `openclaw-gateway` processes (not service-managed) listening on the gateway port on macOS.

**Key changes:**
- Added context-aware lock-error guidance in `src/cli/gateway-cli/run.ts:61-103` that detects standalone gateway listeners and provides appropriate remediation steps
- Updated generic port hint text in `src/infra/ports-format.ts:30` to suggest `--force --port` instead of always suggesting `gateway stop`
- Added comprehensive test coverage for the standalone listener scenario in both e2e and unit tests

The solution correctly distinguishes between service-managed and standalone gateway processes by checking `service.isLoaded()` and only showing standalone guidance when the service is not loaded but a gateway listener is detected on the port.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is clean, well-tested, and follows existing patterns. The new `maybeExplainStandaloneGatewayProcess` function has proper error handling with try-catch blocks, early returns for edge cases, and defensive checks. Test coverage includes both the new standalone scenario and ensures the existing service-managed scenario still works correctly. The change is localized to error messaging logic and doesn't affect core gateway functionality.
- No files require special attention

<sub>Last reviewed commit: 9861829</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->