### PR TITLE
fix(google): include 'google' provider in tool schema sanitization

### DIFF
--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -256,8 +256,13 @@ export function sanitizeToolsForGoogle<
   // Cloud Code Assist uses the OpenAPI 3.03 `parameters` field for both Gemini
   // AND Claude models.  This field does not support JSON Schema keywords such as
   // patternProperties, additionalProperties, $ref, etc.  We must clean schemas
-  // for every provider that routes through this path.
-  if (params.provider !== "google-gemini-cli" && params.provider !== "google-antigravity") {
+  // for every provider that routes through this path, including the plain
+  // 'google' provider which also serves Gemini models.
+  if (
+    params.provider !== "google-gemini-cli" &&
+    params.provider !== "google-antigravity" &&
+    params.provider !== "google"
+  ) {
     return params.tools;
   }
   return params.tools.map((tool) => {
@@ -274,7 +279,11 @@ export function sanitizeToolsForGoogle<
 }
 
 export function logToolSchemasForGoogle(params: { tools: AgentTool[]; provider: string }) {
-  if (params.provider !== "google-antigravity" && params.provider !== "google-gemini-cli") {
+  if (
+    params.provider !== "google-antigravity" &&
+    params.provider !== "google-gemini-cli" &&
+    params.provider !== "google"
+  ) {
     return;
   }
   const toolNames = params.tools.map((tool, index) => `${index}:${tool.name}`);

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -257,11 +257,12 @@ export function sanitizeToolsForGoogle<
   // AND Claude models.  This field does not support JSON Schema keywords such as
   // patternProperties, additionalProperties, $ref, etc.  We must clean schemas
   // for every provider that routes through this path, including the plain
-  // 'google' provider which also serves Gemini models.
+  // 'google' and 'google-generative-ai' providers which also serve Gemini models.
   if (
     params.provider !== "google-gemini-cli" &&
     params.provider !== "google-antigravity" &&
-    params.provider !== "google"
+    params.provider !== "google" &&
+    params.provider !== "google-generative-ai"
   ) {
     return params.tools;
   }
@@ -282,7 +283,8 @@ export function logToolSchemasForGoogle(params: { tools: AgentTool[]; provider: 
   if (
     params.provider !== "google-antigravity" &&
     params.provider !== "google-gemini-cli" &&
-    params.provider !== "google"
+    params.provider !== "google" &&
+    params.provider !== "google-generative-ai"
   ) {
     return;
   }


### PR DESCRIPTION
## Summary
Fixes #17826

## Problem
`sanitizeToolsForGoogle()` and `logToolSchemasForGoogle()` only checked for `google-antigravity` and `google-gemini-cli` providers, missing the plain `google` provider.

This caused tools sent to Gemini via the standard Google AI API key to have broken schemas with duplicate parameter names (`path`/`file_path`, `oldText`/`old_string`, `newText`/`new_string`), confusing the model and causing parameter loops.

## Changes
- Added `google` to the provider check in `sanitizeToolsForGoogle()`
- Added `google` to the provider check in `logToolSchemasForGoogle()`

---
🤖 Generated with Claude Code

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds the plain `"google"` provider to the provider check in both `sanitizeToolsForGoogle()` and `logToolSchemasForGoogle()`. Previously, only `"google-antigravity"` and `"google-gemini-cli"` were handled, which meant users authenticating via a standard Google AI API key (provider `"google"`) would send unsanitized tool schemas to Gemini — causing duplicate parameter names and model confusion.

- Added `"google"` to the early-return guard in `sanitizeToolsForGoogle()` so tool schemas are cleaned for the plain Google provider
- Added `"google"` to the early-return guard in `logToolSchemasForGoogle()` so diagnostic logging also fires for the plain Google provider
- The existing test (`google.e2e.test.ts`) only covers `provider: "google-gemini-cli"` — a test case for `provider: "google"` would help prevent regression

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, well-scoped bug fix that adds a missing provider string to two guard clauses.
- The change is a two-line addition (same string added to two parallel guard clauses) that fixes a clear omission. The `"google"` provider is well-established throughout the codebase, and the fix is consistent with how the other two Google providers are already handled. No new logic is introduced, and the risk of regression is negligible.
- No files require special attention.

<sub>Last reviewed commit: df69fc1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->