### PR TITLE
Fix Google Chat media upload failure by inferring content-type from filename

### DIFF
--- a/extensions/googlechat/src/api.ts
+++ b/extensions/googlechat/src/api.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import crypto from "node:crypto";
 import type { ResolvedGoogleChatAccount } from "./accounts.js";
 import type { GoogleChatReaction } from "./types.js";
@@ -166,11 +167,16 @@ export async function uploadGoogleChatAttachment(params: {
   buffer: Buffer;
   contentType?: string;
 }): Promise<{ attachmentUploadToken?: string }> {
-  const { account, space, filename, buffer, contentType } = params;
+  const { account, space, filename, buffer } = params;
   const boundary = `openclaw-${crypto.randomUUID()}`;
   const metadata = JSON.stringify({ filename });
+  const contentType =
+    params.contentType ??
+    lookupMimeFromExtension(filename) ??
+    "application/octet-stream";
+
   const header = `--${boundary}\r\nContent-Type: application/json; charset=UTF-8\r\n\r\n${metadata}\r\n`;
-  const mediaHeader = `--${boundary}\r\nContent-Type: ${contentType ?? "application/octet-stream"}\r\n\r\n`;
+  const mediaHeader = `--${boundary}\r\nContent-Type: ${contentType}\r\n\r\n`;
   const footer = `\r\n--${boundary}--\r\n`;
   const body = Buffer.concat([
     Buffer.from(header, "utf8"),
@@ -278,5 +284,26 @@ export async function probeGoogleChat(account: ResolvedGoogleChatAccount): Promi
       ok: false,
       error: err instanceof Error ? err.message : String(err),
     };
+  }
+}
+
+function lookupMimeFromExtension(filename: string): string | undefined {
+  const ext = path.extname(filename).toLowerCase();
+  switch (ext) {
+    case ".jpg":
+    case ".jpeg":
+      return "image/jpeg";
+    case ".png":
+      return "image/png";
+    case ".gif":
+      return "image/gif";
+    case ".webp":
+      return "image/webp";
+    case ".mp4":
+      return "video/mp4";
+    case ".pdf":
+      return "application/pdf";
+    default:
+      return undefined;
   }
 }

--- a/extensions/googlechat/src/api.upload-content-type.test.ts
+++ b/extensions/googlechat/src/api.upload-content-type.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { uploadGoogleChatAttachment } from "./api.js";
+import { getGoogleChatAccessToken } from "./auth.js";
+
+// Mock dependencies
+vi.mock("./auth.js");
+vi.mock("node:crypto", () => ({
+  default: {
+    randomUUID: () => "mock-uuid",
+  },
+}));
+
+// Mock fetch
+const fetchMock = vi.fn();
+global.fetch = fetchMock;
+
+const mockAccount = {
+  accountId: "test",
+  name: "Test",
+  credentialSource: "json" as const,
+  config: {},
+  json: { client_email: "test@example.com", private_key: "key" },
+};
+
+describe("uploadGoogleChatAttachment", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getGoogleChatAccessToken).mockResolvedValue("mock-token");
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ attachmentDataRef: { attachmentUploadToken: "token123" } }),
+    });
+  });
+
+  it("uses provided contentType if present", async () => {
+    await uploadGoogleChatAttachment({
+      account: mockAccount,
+      space: "spaces/AAA",
+      filename: "test.png",
+      buffer: Buffer.from("data"),
+      contentType: "image/custom-png",
+    });
+
+    const call = fetchMock.mock.calls[0];
+    const body = call[1].body as Buffer;
+    const bodyStr = body.toString();
+    
+    expect(bodyStr).toContain("Content-Type: image/custom-png");
+  });
+
+  it("infers contentType from filename extension if missing", async () => {
+    await uploadGoogleChatAttachment({
+      account: mockAccount,
+      space: "spaces/AAA",
+      filename: "photo.jpg",
+      buffer: Buffer.from("data"),
+      // No contentType
+    });
+
+    const call = fetchMock.mock.calls[0];
+    const body = call[1].body as Buffer;
+    const bodyStr = body.toString();
+    
+    expect(bodyStr).toContain("Content-Type: image/jpeg");
+  });
+
+  it("infers contentType from filename extension (png)", async () => {
+    await uploadGoogleChatAttachment({
+      account: mockAccount,
+      space: "spaces/AAA",
+      filename: "image.png",
+      buffer: Buffer.from("data"),
+    });
+
+    const call = fetchMock.mock.calls[0];
+    const body = call[1].body as Buffer;
+    const bodyStr = body.toString();
+    
+    expect(bodyStr).toContain("Content-Type: image/png");
+  });
+
+  it("defaults to application/octet-stream if unknown extension", async () => {
+    await uploadGoogleChatAttachment({
+      account: mockAccount,
+      space: "spaces/AAA",
+      filename: "unknown.xyz",
+      buffer: Buffer.from("data"),
+    });
+
+    const call = fetchMock.mock.calls[0];
+    const body = call[1].body as Buffer;
+    const bodyStr = body.toString();
+    
+    expect(bodyStr).toContain("Content-Type: application/octet-stream");
+  });
+});


### PR DESCRIPTION
## Description
Google Chat API requires correct `image/*` Content-Type for image attachments to be rendered inline. If `contentType` was missing (e.g. download failed to detect it or URL lacked extension), the upload defaulted to `application/octet-stream`, causing images to appear as file downloads or fail validation.

## Fix
Fallback to inferring MIME type from filename extension in `uploadGoogleChatAttachment` if `contentType` is not explicitly provided.

## Tests
Added `extensions/googlechat/src/api.upload-content-type.test.ts` verifying:
- Explicit contentType is respected
- Missing contentType is inferred from filename (jpg/png/etc)
- Defaults to octet-stream for unknown extensions

## AI Transparency
- **Assisted by**: OpenClaw Agent (Claude 3.5 Sonnet / Opus)
- **Testing level**: Fully tested with new unit tests (`extensions/googlechat/src/api.upload-content-type.test.ts`)
- **Prompt strategy**: Self-correction loop based on codebase analysis

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a MIME type inference fallback to `uploadGoogleChatAttachment` so that when `contentType` is not provided by the caller, the function infers it from the filename extension before falling back to `application/octet-stream`. This fixes Google Chat image attachments appearing as generic file downloads when the upstream media fetch didn't detect a content type.

- Added `lookupMimeFromExtension()` helper mapping common extensions (`.jpg`, `.jpeg`, `.png`, `.gif`, `.webp`, `.mp4`, `.pdf`) to MIME types
- Modified `uploadGoogleChatAttachment` to use a three-step resolution: explicit `contentType` → inferred from filename → `application/octet-stream`
- New test file validates all three fallback tiers

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it adds a sensible fallback for content-type detection with no risk to existing behavior.
- The code change is small, focused, and low-risk. The nullish coalescing chain preserves the existing behavior when `contentType` is explicitly provided, and only adds inference as a new fallback. The `lookupMimeFromExtension` helper is straightforward. The test mock account has shape issues flagged in prior threads, but the core logic is sound. Score of 4 rather than 5 because the prior thread notes about the mock account validity and the "attachment" filename edge case remain unresolved.
- The test file `extensions/googlechat/src/api.upload-content-type.test.ts` has a mock account with an invalid shape (flagged in prior review).

<sub>Last reviewed commit: 2617d88</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->