### PR TITLE
fix: preserve scopes when dangerouslyDisableDeviceAuth is enabled

### DIFF
--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -430,7 +430,7 @@ export function attachGatewayWsMessageHandler(params: {
           close(1008, truncateCloseReason(authMessage));
         };
         if (!device) {
-          if (scopes.length > 0) {
+          if (scopes.length > 0 && !disableControlUiDeviceAuth) {
             scopes = [];
             connectParams.scopes = scopes;
           }


### PR DESCRIPTION
## Problem

When `gateway.controlUi.dangerouslyDisableDeviceAuth` is set to `true`, the WebSocket message handler intentionally sets `device = null` (line 349). However, the subsequent `!device` check at line 432 clears all scopes to `[]`, making the flag completely ineffective.

This means Control UI and Studio connections still get `missing scope: operator.read` errors even with the flag enabled.

## Root Cause

```typescript
// Line 349: flag sets device to null
const device = disableControlUiDeviceAuth ? null : deviceRaw;

// Line 432-435: null device clears scopes — defeating the flag
if (!device) {
  if (scopes.length > 0) {  // ← always true, always clears
    scopes = [];
    connectParams.scopes = scopes;
  }
}
```

## Fix

Skip the scope-clearing when `disableControlUiDeviceAuth` is active:

```typescript
if (scopes.length > 0 && !disableControlUiDeviceAuth) {
```

This allows token-authenticated Control UI / Studio connections to retain their requested scopes (`operator.admin`, `operator.read`, etc.) when the flag is enabled.

## Context

This affects loopback/local setups where the browser may not have WebCrypto secure context support (HTTP localhost), making device identity generation fail. The `dangerouslyDisableDeviceAuth` flag exists precisely for this case but was broken.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

One-line fix to preserve client-requested scopes (e.g., `operator.admin`, `operator.read`) when `gateway.controlUi.dangerouslyDisableDeviceAuth` is enabled. Previously, the flag intentionally set `device = null`, but the subsequent `!device` guard unconditionally cleared all scopes to `[]`, making the flag ineffective — Control UI connections still received "missing scope" errors.

- Adds `&& !disableControlUiDeviceAuth` to the scope-clearing condition in `message-handler.ts:433`, so scopes are preserved when the flag is active while still clearing them for genuinely device-less connections.
- The fix is scoped to Control UI clients only (`isControlUi` gate on the flag) and still requires valid shared-secret authentication (`sharedAuthOk`), so no security surface is expanded beyond the flag's stated intent.
- The existing e2e test at `server.auth.e2e.test.ts:658` covers the `dangerouslyDisableDeviceAuth` path but uses `scopes: []`, which wouldn't catch this specific regression. A test with non-empty scopes would strengthen coverage.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it is a minimal, well-scoped fix that restores the intended behavior of an existing configuration flag.
- The change is a single condition addition that directly addresses the documented bug. The logic is correct: scopes are only preserved when the operator has explicitly opted into `dangerouslyDisableDeviceAuth`, and shared-secret auth is still enforced. Score is 4 instead of 5 because there is no new test covering the exact scenario (non-empty scopes + disabled device auth).
- No files require special attention. The single changed file (`src/gateway/server/ws-connection/message-handler.ts`) has a straightforward one-line fix.

<sub>Last reviewed commit: 4ea1102</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->