### PR TITLE
feat(telegram): add channel_post support for bot-to-bot communication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ Docs: https://docs.openclaw.ai
 - Plugins: expose `llm_input` and `llm_output` hook payloads so extensions can observe prompt/input context and model output usage details. (#16724) Thanks @SecondThread.
 - Subagents: nested sub-agents (sub-sub-agents) with configurable depth. Set `agents.defaults.subagents.maxSpawnDepth: 2` to allow sub-agents to spawn their own children. Includes `maxChildrenPerAgent` limit (default 5), depth-aware tool policy, and proper announce chain routing. (#14447) Thanks @tyler6204.
 - Slack/Discord/Telegram: add per-channel ack reaction overrides (account/channel-level) to support platform-specific emoji formats. (#17092) Thanks @zerone0x.
+- Telegram: add `channel_post` inbound support for channel-based bot-to-bot wake/trigger flows, with channel allowlist gating and message/media batching parity.
 - Cron/Gateway: add finished-run webhook delivery toggle (`notify`) and dedicated webhook auth token support (`cron.webhookToken`) for outbound cron webhook posts. (#14535) Thanks @advaitpaliwal.
 - Channels: deduplicate probe/token resolution base types across core + extensions while preserving per-channel error typing. (#16986) Thanks @iyoda and @thewilloftheshadow.
 - Memory: add MMR (Maximal Marginal Relevance) re-ranking for hybrid search diversity. Configurable via `memorySearch.query.hybrid.mmr`. Thanks @rodrigouroz.

--- a/src/telegram/allowed-updates.ts
+++ b/src/telegram/allowed-updates.ts
@@ -7,5 +7,8 @@ export function resolveTelegramAllowedUpdates(): ReadonlyArray<TelegramUpdateTyp
   if (!updates.includes("message_reaction")) {
     updates.push("message_reaction");
   }
+  if (!updates.includes("channel_post")) {
+    updates.push("channel_post");
+  }
   return updates;
 }

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -1,4 +1,7 @@
 import type { Message, ReactionTypeEmoji } from "@grammyjs/types";
+import type { TelegramGroupConfig, TelegramTopicConfig } from "../config/types.js";
+import type { TelegramMediaRef } from "./bot-message-context.js";
+import type { TelegramContext } from "./bot/types.js";
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { hasControlCommand } from "../auto-reply/command-detection.js";
 import {
@@ -14,7 +17,6 @@ import { resolveChannelConfigWrites } from "../channels/plugins/config-writes.js
 import { loadConfig } from "../config/config.js";
 import { writeConfigFile } from "../config/io.js";
 import { loadSessionStore, resolveStorePath } from "../config/sessions.js";
-import type { TelegramGroupConfig, TelegramTopicConfig } from "../config/types.js";
 import { danger, logVerbose, warn } from "../globals.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { readChannelAllowFromStore } from "../pairing/pairing-store.js";
@@ -27,7 +29,6 @@ import {
   normalizeAllowFromWithStore,
   type NormalizedAllowFrom,
 } from "./bot-access.js";
-import type { TelegramMediaRef } from "./bot-message-context.js";
 import { RegisterTelegramHandlerParams } from "./bot-native-commands.js";
 import { MEDIA_GROUP_TIMEOUT_MS, type MediaGroupEntry } from "./bot-updates.js";
 import { resolveMedia } from "./bot/delivery.js";
@@ -37,7 +38,6 @@ import {
   resolveTelegramForumThreadId,
   resolveTelegramGroupAllowFromContext,
 } from "./bot/helpers.js";
-import type { TelegramContext } from "./bot/types.js";
 import {
   evaluateTelegramGroupBaseAccess,
   evaluateTelegramGroupPolicyAccess,

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -1092,12 +1092,8 @@ export const registerTelegramHandlers = ({
         groupAllowFrom,
         resolveTelegramGroupConfig,
       });
-      const {
-        storeAllowFrom,
-        groupConfig,
-        effectiveGroupAllow,
-        hasGroupAllowOverride,
-      } = groupAllowContext;
+      const { storeAllowFrom, groupConfig, effectiveGroupAllow, hasGroupAllowOverride } =
+        groupAllowContext;
 
       // Check group allowlist (channels use the same groups config)
       const groupAllowlist = resolveGroupPolicy(chatId);

--- a/src/telegram/bot.create-telegram-bot.test.ts
+++ b/src/telegram/bot.create-telegram-bot.test.ts
@@ -1,7 +1,7 @@
-import type { Chat, Message } from "@grammyjs/types";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import type { Chat, Message } from "@grammyjs/types";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { escapeRegExp, formatEnvelopeTimestamp } from "../../test/helpers/envelope-timestamp.js";
 import {

--- a/src/telegram/bot.create-telegram-bot.test.ts
+++ b/src/telegram/bot.create-telegram-bot.test.ts
@@ -1,7 +1,7 @@
+import type { Chat, Message } from "@grammyjs/types";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import type { Chat, Message } from "@grammyjs/types";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { escapeRegExp, formatEnvelopeTimestamp } from "../../test/helpers/envelope-timestamp.js";
 import {

--- a/src/telegram/bot.create-telegram-bot.test.ts
+++ b/src/telegram/bot.create-telegram-bot.test.ts
@@ -45,6 +45,14 @@ const mockMessage = (message: Pick<Message, "chat"> & Partial<Message>): Message
     date: 0,
     ...message,
   }) as Message;
+const TELEGRAM_TEST_TIMINGS = {
+  mediaGroupFlushMs: 20,
+  textFragmentGapMs: 30,
+} as const;
+
+const sleep = async (ms: number) => {
+  await new Promise<void>((resolve) => setTimeout(resolve, ms));
+};
 
 describe("createTelegramBot", () => {
   beforeEach(() => {
@@ -1863,6 +1871,168 @@ describe("createTelegramBot", () => {
 
     expect(sendMessageSpy).toHaveBeenCalledTimes(1);
     expect(sendMessageSpy.mock.calls[0]?.[1]).toContain("final reply");
+  });
+  it("buffers channel_post media groups and processes them together", async () => {
+    onSpy.mockReset();
+    replySpy.mockReset();
+
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: {
+          groupPolicy: "open",
+          groups: {
+            "-100777111222": {
+              enabled: true,
+              requireMention: false,
+            },
+          },
+        },
+      },
+    });
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch" as never).mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: { get: () => "image/png" },
+      arrayBuffer: async () => new Uint8Array([0x89, 0x50, 0x4e, 0x47]).buffer,
+    } as Response);
+
+    createTelegramBot({ token: "tok", testTimings: TELEGRAM_TEST_TIMINGS });
+    const handler = getOnHandler("channel_post") as (ctx: Record<string, unknown>) => Promise<void>;
+
+    const first = handler({
+      channelPost: {
+        chat: { id: -100777111222, type: "channel", title: "Wake Channel" },
+        message_id: 201,
+        caption: "album caption",
+        date: 1736380800,
+        media_group_id: "channel-album-1",
+        photo: [{ file_id: "p1" }],
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ file_path: "photos/p1.jpg" }),
+    });
+
+    const second = handler({
+      channelPost: {
+        chat: { id: -100777111222, type: "channel", title: "Wake Channel" },
+        message_id: 202,
+        date: 1736380801,
+        media_group_id: "channel-album-1",
+        photo: [{ file_id: "p2" }],
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ file_path: "photos/p2.jpg" }),
+    });
+
+    await Promise.all([first, second]);
+    expect(replySpy).not.toHaveBeenCalled();
+    await sleep(TELEGRAM_TEST_TIMINGS.mediaGroupFlushMs + 80);
+
+    expect(replySpy).toHaveBeenCalledTimes(1);
+    const payload = replySpy.mock.calls[0]?.[0] as { Body?: string; MediaPaths?: string[] };
+    expect(payload.Body).toContain("album caption");
+    expect(payload.MediaPaths).toHaveLength(2);
+
+    fetchSpy.mockRestore();
+  });
+  it("coalesces channel_post near-limit text fragments into one message", async () => {
+    onSpy.mockReset();
+    replySpy.mockReset();
+
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: {
+          groupPolicy: "open",
+          groups: {
+            "-100777111222": {
+              enabled: true,
+              requireMention: false,
+            },
+          },
+        },
+      },
+    });
+
+    createTelegramBot({ token: "tok", testTimings: TELEGRAM_TEST_TIMINGS });
+    const handler = getOnHandler("channel_post") as (ctx: Record<string, unknown>) => Promise<void>;
+
+    const part1 = "A".repeat(4050);
+    const part2 = "B".repeat(50);
+
+    await handler({
+      channelPost: {
+        chat: { id: -100777111222, type: "channel", title: "Wake Channel" },
+        message_id: 301,
+        date: 1736380800,
+        text: part1,
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({}),
+    });
+
+    await handler({
+      channelPost: {
+        chat: { id: -100777111222, type: "channel", title: "Wake Channel" },
+        message_id: 302,
+        date: 1736380801,
+        text: part2,
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({}),
+    });
+
+    expect(replySpy).not.toHaveBeenCalled();
+    await sleep(TELEGRAM_TEST_TIMINGS.textFragmentGapMs + 100);
+
+    expect(replySpy).toHaveBeenCalledTimes(1);
+    const payload = replySpy.mock.calls[0]?.[0] as { RawBody?: string };
+    expect(payload.RawBody).toContain(part1.slice(0, 32));
+    expect(payload.RawBody).toContain(part2.slice(0, 32));
+  });
+  it("drops oversized channel_post media instead of dispatching a placeholder message", async () => {
+    onSpy.mockReset();
+    replySpy.mockReset();
+
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: {
+          groupPolicy: "open",
+          groups: {
+            "-100777111222": {
+              enabled: true,
+              requireMention: false,
+            },
+          },
+        },
+      },
+    });
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch" as never).mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: { get: () => "image/jpeg" },
+      arrayBuffer: async () => new Uint8Array([0xff, 0xd8, 0xff, 0x00]).buffer,
+    } as Response);
+
+    createTelegramBot({ token: "tok", mediaMaxMb: 0 });
+    const handler = getOnHandler("channel_post") as (ctx: Record<string, unknown>) => Promise<void>;
+
+    await handler({
+      channelPost: {
+        chat: { id: -100777111222, type: "channel", title: "Wake Channel" },
+        message_id: 401,
+        date: 1736380800,
+        photo: [{ file_id: "oversized" }],
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ file_path: "photos/oversized.jpg" }),
+    });
+
+    expect(replySpy).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
   });
   it("dedupes duplicate message updates by update_id", async () => {
     onSpy.mockReset();

--- a/src/telegram/bot.create-telegram-bot.test.ts
+++ b/src/telegram/bot.create-telegram-bot.test.ts
@@ -1890,13 +1890,13 @@ describe("createTelegramBot", () => {
       },
     });
 
-    const fetchSpy = vi.spyOn(globalThis, "fetch" as never).mockResolvedValue({
-      ok: true,
-      status: 200,
-      statusText: "OK",
-      headers: { get: () => "image/png" },
-      arrayBuffer: async () => new Uint8Array([0x89, 0x50, 0x4e, 0x47]).buffer,
-    } as Response);
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(
+      async () =>
+        new Response(new Uint8Array([0x89, 0x50, 0x4e, 0x47]), {
+          status: 200,
+          headers: { "content-type": "image/png" },
+        }),
+    );
 
     createTelegramBot({ token: "tok", testTimings: TELEGRAM_TEST_TIMINGS });
     const handler = getOnHandler("channel_post") as (ctx: Record<string, unknown>) => Promise<void>;
@@ -2009,13 +2009,13 @@ describe("createTelegramBot", () => {
       },
     });
 
-    const fetchSpy = vi.spyOn(globalThis, "fetch" as never).mockResolvedValue({
-      ok: true,
-      status: 200,
-      statusText: "OK",
-      headers: { get: () => "image/jpeg" },
-      arrayBuffer: async () => new Uint8Array([0xff, 0xd8, 0xff, 0x00]).buffer,
-    } as Response);
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(
+      async () =>
+        new Response(new Uint8Array([0xff, 0xd8, 0xff, 0x00]), {
+          status: 200,
+          headers: { "content-type": "image/jpeg" },
+        }),
+    );
 
     createTelegramBot({ token: "tok", mediaMaxMb: 0 });
     const handler = getOnHandler("channel_post") as (ctx: Record<string, unknown>) => Promise<void>;


### PR DESCRIPTION
Telegram bots cannot see messages from other bots in groups — this is a hard platform limitation. However, bots CAN see other bot messages in Telegram channels (broadcast channels).

This patch:
- Adds 'channel_post' to the allowed Telegram update types
- Registers a channel_post handler that normalizes channel posts into the existing message pipeline via synthetic message/context objects
- Enables bot-to-bot wake signals via private Telegram channels

Use case: external services (APIs, CRMs) can send wake/trigger signals to an OpenClaw bot through a dedicated Telegram channel using a second bot, without exposing the gateway.

## Summary

- Problem: Telegram bots cannot see messages from other bots in groups (hard platform limitation). OpenClaw only subscribes to `message` updates, so channel messages are silently dropped.
- Why it matters: No way to trigger an OpenClaw bot from another bot or automated system on Telegram without exposing the gateway to the internet.
- What changed: Added `channel_post` to allowed update types and a handler that normalizes channel posts into the existing group message pipeline.
- What did NOT change: No schema changes, no config changes, no modifications to existing message handling logic. Channels use existing `groups.<id>` config.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #17850 

## User-visible / Behavior Changes

Telegram channels (broadcast channels) now deliver messages to OpenClaw when the bot is a channel admin. Channels must be configured in `groups.<channelId>` like any group. No existing behavior changes — this is purely additive.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No — uses existing Telegram polling, just subscribes to one additional update type
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS 23.0.0 (arm64)
- Runtime/container: Node v25.4.0
- Model/provider: Anthropic Claude
- Integration/channel: Telegram (polling mode)
- Relevant config:
```
  {
    "channels": {
      "telegram": {
        "groups": {
          "-100XXXXXXXXXX": {
            "requireMention": false,
            "groupPolicy": "open",
            "enabled": true
          }
        }
      }
    }
  }
```

### Steps

1. Create a private Telegram channel, add the OpenClaw bot as admin
2. Add the channel ID to config under `channels.telegram.groups` with `enabled: true`
3. Send a message to the channel from another bot (or as channel admin)
4. Observe the message is received and processed by OpenClaw

### Expected

- Bot receives channel_post updates and processes them through the group message pipeline.

### Actual

- Works as expected — messages from other bots in the channel are received and handled.

## Evidence

Tested end-to-end with a private Telegram channel used as a transport layer between a NestJS API and OpenClaw. External API sends wake signals via Telegram Bot API → channel → OpenClaw bot receives and processes. Without this patch, messages are silently dropped.

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Bot receives channel_post from another bot, message routes through group pipeline, groupPolicy/requireMention/allowlist all apply correctly
- Edge cases checked: Channel with groupPolicy "allowlist" (blocks unknown senders as expected), channel with requireMention true/false
- What you did not verify: Webhook mode (tested polling only), interactions with Telegram topics/forum channels

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Remove "channel_post" from the allowed updates array in src/telegram/allowed-updates.ts
- Files/config to restore: src/telegram/allowed-updates.ts, src/telegram/bot-handlers.ts
- Known bad symptoms reviewers should watch for: None expected — handler only fires for channel_post events which didn't exist before

## Risks and Mitigations

- Risk: Handler normalizes chat.type from "channel" to "supergroup" — downstream code sees a supergroup that is actually a channel
- Mitigation: Intentional to avoid modifying every isGroup check in the pipeline. Channel behavior is identical to supergroup for message routing. A future refactor could add "channel" as a first-class type if needed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds support for `channel_post` updates to enable bot-to-bot communication via Telegram channels. The implementation normalizes channel posts into the existing message pipeline by creating synthetic message objects with `chat.type` set to `"supergroup"`.

- Added `"channel_post"` to allowed update types in `allowed-updates.ts`
- Created new `channel_post` handler in `bot-handlers.ts` that mirrors the regular message handler
- Handler includes deduplication, full access control (groupPolicy, allowlist, allowFrom), media resolution, and debouncing
- Channels are configured using existing `groups.<channelId>` config (no schema changes)
- All previous review feedback from commit 758243c was addressed

The approach is pragmatic: by normalizing `chat.type` to `"supergroup"`, the handler avoids modifying downstream `isGroup` checks throughout the codebase, though this does mean channels masquerade as supergroups internally.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- All previous review feedback was addressed in commit 758243c. The implementation correctly mirrors the message handler's access control, deduplication, media handling, and debouncing logic. The changes are purely additive (no modifications to existing message handling), well-tested by the author, and the normalization approach (treating channels as supergroups) is pragmatic and avoids risky refactoring across the codebase.
- No files require special attention

<sub>Last reviewed commit: 73f47b5</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->