### PR TITLE
fix: Windows exec returns empty output when pty=false

### DIFF
--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -62,12 +62,14 @@ export async function createChildAdapter(params: {
   const spawned = await spawnWithFallback({
     argv: resolvedArgv,
     options,
-    fallbacks: [
-      {
-        label: "no-detach",
-        options: { detached: false },
-      },
-    ],
+    fallbacks: options.detached
+      ? [
+          {
+            label: "no-detach",
+            options: { detached: false },
+          },
+        ]
+      : [],
   });
 
   const child = spawned.child as ChildProcessWithoutNullStreams;

--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -46,7 +46,10 @@ export async function createChildAdapter(params: {
     cwd: params.cwd,
     env: params.env ? toStringEnv(params.env) : undefined,
     stdio: ["pipe", "pipe", "pipe"],
-    detached: true,
+    // On Windows, do not detach the process. Detached processes on Windows don't
+    // have proper console handles, causing stdout/stderr to not be captured.
+    // This is especially problematic when running via Scheduled Task.
+    detached: process.platform !== "win32",
     windowsHide: true,
     windowsVerbatimArguments: params.windowsVerbatimArguments,
   };


### PR DESCRIPTION
## Summary

On Windows, the exec tool returns empty output when pty=false (the default) when running via Scheduled Task. This is a regression introduced in the process supervisor refactoring (commit cd44a0d01).

The root cause is that the new child adapter always uses detached: true, but on Windows, detached processes don't have proper console handles for stdout/stderr capture.

## Changes

- Changed detached: true to detached: process.platform !== "win32" in src/process/supervisor/adapters/child.ts
- This restores the previous behavior where Windows used detached: false

## Testing

- All existing tests pass (20 supervisor tests, 5 exec tests, 3 bash-tools.exec tests)

Fixes openclaw/openclaw#17806

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a Windows-specific regression where exec tool returns empty output when `pty=false`. The root cause was that `detached: true` (introduced in the supervisor refactoring at commit cd44a0d01) causes Windows child processes to lose their console handles, preventing stdout/stderr capture — especially when running via Scheduled Task.

- Sets `detached: process.platform !== "win32"` so Windows uses `detached: false` while Unix/macOS retains `detached: true` (needed for process-group kill via `process.kill(-pid)`)
- Conditionally removes the "no-detach" spawn fallback on Windows since it would be redundant when already non-detached
- Process cleanup is unaffected: Windows `killProcessTree` uses `taskkill /T /PID` which works regardless of detach mode

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a focused, well-understood platform fix with no side effects on non-Windows platforms.
- The change is minimal (one file, two small hunks), addresses a clear regression with a well-documented root cause, and preserves existing behavior on Unix/macOS. The fallback guard is logically correct — no redundant fallback when already non-detached. Process cleanup paths on both platforms are unaffected. Existing tests pass because CI runs on Linux where `detached` remains `true`.
- No files require special attention.

<sub>Last reviewed commit: 5a93871</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->