### PR TITLE
Fix Feishu card button callback parameters dropped (missing handler)

### DIFF
--- a/extensions/feishu/src/bot.card-action.test.ts
+++ b/extensions/feishu/src/bot.card-action.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from "vitest";
+import { handleFeishuCardAction, type FeishuCardActionEvent } from "./card-action.js";
+
+// Mock resolveFeishuAccount
+vi.mock("./accounts.js", () => ({
+  resolveFeishuAccount: vi.fn().mockReturnValue({ accountId: "mock-account" }),
+}));
+
+// Mock bot.js to verify handleFeishuMessage call
+vi.mock("./bot.js", () => ({
+  handleFeishuMessage: vi.fn(),
+}));
+
+import { handleFeishuMessage } from "./bot.js";
+
+describe("Feishu Card Action Handler", () => {
+  const cfg = {} as any; // Minimal mock
+  const runtime = { log: vi.fn(), error: vi.fn() } as any;
+
+  it("handles card action with text payload", async () => {
+    const event: FeishuCardActionEvent = {
+      operator: { open_id: "u123", user_id: "uid1", union_id: "un1" },
+      token: "tok1",
+      action: { value: { text: "/ping" }, tag: "button" },
+      context: { open_id: "u123", user_id: "uid1", chat_id: "chat1" },
+    };
+
+    await handleFeishuCardAction({ cfg, event, runtime });
+
+    expect(handleFeishuMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: expect.objectContaining({
+          message: expect.objectContaining({
+            content: '{"text":"/ping"}',
+            chat_id: "chat1",
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("handles card action with JSON object payload", async () => {
+    const event: FeishuCardActionEvent = {
+      operator: { open_id: "u123", user_id: "uid1", union_id: "un1" },
+      token: "tok2",
+      action: { value: { key: "val" }, tag: "button" },
+      context: { open_id: "u123", user_id: "uid1", chat_id: "" },
+    };
+
+    await handleFeishuCardAction({ cfg, event, runtime });
+
+    expect(handleFeishuMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: expect.objectContaining({
+          message: expect.objectContaining({
+            content: '{"text":"{\\"key\\":\\"val\\"}"}',
+            chat_id: "u123", // Fallback to open_id
+          }),
+        }),
+      }),
+    );
+  });
+});

--- a/extensions/feishu/src/card-action.ts
+++ b/extensions/feishu/src/card-action.ts
@@ -1,0 +1,77 @@
+import type { ClawdbotConfig, RuntimeEnv } from "openclaw/plugin-sdk";
+import { resolveFeishuAccount } from "./accounts.js";
+import { handleFeishuMessage, type FeishuMessageEvent } from "./bot.js";
+
+export type FeishuCardActionEvent = {
+  operator: {
+    open_id: string;
+    user_id: string;
+    union_id: string;
+  };
+  token: string;
+  action: {
+    value: Record<string, unknown>;
+    tag: string;
+  };
+  context: {
+    open_id: string;
+    user_id: string;
+    chat_id: string;
+  };
+};
+
+export async function handleFeishuCardAction(params: {
+  cfg: ClawdbotConfig;
+  event: FeishuCardActionEvent;
+  botOpenId?: string;
+  runtime?: RuntimeEnv;
+  accountId?: string;
+}): Promise<void> {
+  const { cfg, event, runtime, accountId } = params;
+  const account = resolveFeishuAccount({ cfg, accountId });
+  const log = runtime?.log ?? console.log;
+
+  // Extract action value
+  const actionValue = event.action.value;
+  let content = "";
+  if (typeof actionValue === "object" && actionValue !== null) {
+    if ("text" in actionValue && typeof actionValue.text === "string") {
+      content = actionValue.text;
+    } else if ("command" in actionValue && typeof actionValue.command === "string") {
+      content = actionValue.command;
+    } else {
+      content = JSON.stringify(actionValue);
+    }
+  } else {
+    content = String(actionValue);
+  }
+
+  // Construct a synthetic message event
+  const messageEvent: FeishuMessageEvent = {
+    sender: {
+      sender_id: {
+        open_id: event.operator.open_id,
+        user_id: event.operator.user_id,
+        union_id: event.operator.union_id,
+      },
+    },
+    message: {
+      message_id: `card-action-${event.token}`,
+      chat_id: event.context.chat_id || event.operator.open_id,
+      chat_type: event.context.chat_id ? "group" : "p2p",
+      message_type: "text",
+      content: JSON.stringify({ text: content }),
+    },
+  };
+
+  log(`feishu[${account.accountId}]: handling card action from ${event.operator.open_id}: ${content}`);
+
+  // Dispatch as normal message
+  await handleFeishuMessage({
+    cfg,
+    event: messageEvent,
+    botOpenId: params.botOpenId,
+    runtime,
+    accountId,
+  });
+}

--- a/extensions/feishu/src/monitor.ts
+++ b/extensions/feishu/src/monitor.ts
@@ -9,6 +9,7 @@ import {
 } from "openclaw/plugin-sdk";
 import { resolveFeishuAccount, listEnabledFeishuAccounts } from "./accounts.js";
 import { handleFeishuMessage, type FeishuMessageEvent, type FeishuBotAddedEvent } from "./bot.js";
+import { handleFeishuCardAction, type FeishuCardActionEvent } from "./card-action.js";
 import { createFeishuWSClient, createEventDispatcher } from "./client.js";
 import { probeFeishu } from "./probe.js";
 import { getMessageFeishu } from "./send.js";
@@ -349,6 +350,27 @@ function registerEventHandlers(
     },
     "im.message.reaction.deleted_v1": async () => {
       // Ignore reaction removals
+    },
+    "card.action.trigger": async (data) => {
+      try {
+        const event = data as unknown as FeishuCardActionEvent;
+        const promise = handleFeishuCardAction({
+          cfg,
+          event,
+          botOpenId: botOpenIds.get(accountId),
+          runtime,
+          accountId,
+        });
+        if (fireAndForget) {
+          promise.catch((err) => {
+            error(`feishu[${accountId}]: error handling card action: ${String(err)}`);
+          });
+        } else {
+          await promise;
+        }
+      } catch (err) {
+        error(`feishu[${accountId}]: error handling card action: ${String(err)}`);
+      }
     },
   });
 }


### PR DESCRIPTION
## Description
Feishu card interactions (button clicks) trigger a `card.action.trigger` event, which was previously ignored by the bot monitor. This meant button clicks had no effect and parameters were lost.

## Fix
- Registered handler for `card.action.trigger`.
- Added adapter (`src/feishu/card-action.ts`) to convert card actions into synthetic message events so they can be processed by the agent (supporting `value` as text or JSON).

## Tests
Added `extensions/feishu/src/bot.card-action.test.ts` verifying:
- Card action with `text` payload is converted to message
- Card action with JSON object payload is converted to message

## AI Transparency
- **Assisted by**: OpenClaw Agent (Claude 3.5 Sonnet / Opus)
- **Testing level**: Fully tested with new unit tests (`extensions/feishu/src/bot.card-action.test.ts`)
- **Prompt strategy**: Self-correction loop based on codebase analysis

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a handler for Feishu card button click events (`card.action.trigger`), which were previously silently ignored. The new `card-action.ts` adapter converts card action payloads into synthetic `FeishuMessageEvent` objects so they can be processed through the existing message pipeline. The monitor registers the new event handler following the same pattern as existing handlers.

- **Critical bug**: The synthetic `message_id` is built from `event.token`, which is the app's verification token (shared across all events), not a unique event identifier. This will cause the dedup module (`tryRecordMessage`) to silently drop all card actions after the first one within a 30-minute window.
- Tests cover text and JSON payload conversion but don't exercise the dedup interaction, so they don't catch the token reuse issue.
- The overall adapter pattern (converting card actions into synthetic messages) is a clean approach that reuses the existing message handling pipeline effectively.

<h3>Confidence Score: 2/5</h3>

- This PR has a bug that will cause card button clicks to stop working after the first click — should be fixed before merge.
- The dedup bug with `event.token` being the app verification token (not a unique event ID) means only the first card button click will be processed; all subsequent clicks within 30 minutes will be silently dropped. This effectively renders the feature broken after one use per app.
- `extensions/feishu/src/card-action.ts` line 59 — the `message_id` generation using `event.token` needs to use a unique identifier instead.

<sub>Last reviewed commit: d85762b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->