### PR TITLE
fix: resolve guild entry using guild_id fallback for MESSAGE_CREATE events

### DIFF
--- a/src/discord/monitor/allow-list.ts
+++ b/src/discord/monitor/allow-list.ts
@@ -273,9 +273,10 @@ export function resolveDiscordCommandAuthorized(params: {
 
 export function resolveDiscordGuildEntry(params: {
   guild?: Guild<true> | Guild | null;
+  guildId?: string;
   guildEntries?: Record<string, DiscordGuildEntryResolved>;
 }): DiscordGuildEntryResolved | null {
-  const guild = params.guild;
+  const guild = params.guild ?? (params.guildId ? { id: params.guildId, name: params.guildId } : void 0);
   const entries = params.guildEntries;
   if (!guild || !entries) {
     return null;

--- a/src/discord/monitor/listeners.ts
+++ b/src/discord/monitor/listeners.ts
@@ -189,6 +189,7 @@ async function handleDiscordReactionEvent(params: {
     const guildInfo = isGuildMessage
       ? resolveDiscordGuildEntry({
           guild: data.guild ?? undefined,
+          guildId: data.guild_id ?? undefined,
           guildEntries,
         })
       : null;

--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -276,6 +276,7 @@ export async function preflightDiscordMessage(
   const guildInfo = isGuildMessage
     ? resolveDiscordGuildEntry({
         guild: params.data.guild ?? undefined,
+        guildId: params.data.guild_id ?? undefined,
         guildEntries: params.guildEntries,
       })
     : null;


### PR DESCRIPTION
## Bug

`resolveDiscordGuildEntry()` fails to match guilds when a `guilds` config block is present in the Discord configuration. All guild messages are silently dropped.

## Root Cause

Discord gateway `MESSAGE_CREATE` events provide `guild_id` (a string) but NOT a full `guild` object. The function receives `data.guild` which is always `undefined` for these events, so it returns `null`. When a `guilds` config exists and the lookup returns `null`, the message handler bails out early.

Interaction-based handlers (slash commands, components) are unaffected because Discord.js resolves `interaction.guild` properly.

## Reproduction

1. Configure a `guilds` block in your Discord config (e.g., mapping a guild ID or name)
2. Send a message in that guild without @mentioning the bot
3. The message is silently dropped — never reaches the agent

## Fix

1. Added an optional `guildId` parameter to `resolveDiscordGuildEntry()` that constructs a minimal `{id, name}` object as a fallback when `guild` is undefined
2. Updated caller sites in `listeners.ts` and `message-handler.preflight.ts` to pass `data.guild_id`

## Files Changed

- `src/discord/monitor/allow-list.ts` — fallback logic in `resolveDiscordGuildEntry()`
- `src/discord/monitor/listeners.ts` — pass `guildId` at call site
- `src/discord/monitor/message-handler.preflight.ts` — pass `guildId` at call site

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes guild message filtering by adding `guild_id` fallback to `resolveDiscordGuildEntry()`. Discord `MESSAGE_CREATE` events provide `guild_id` (string) but not the full `guild` object, causing all guild messages to be silently dropped when a `guilds` config block exists. The fix constructs a minimal guild object from `guild_id` when `guild` is undefined, allowing ID-based guild matching to work correctly.

- Added optional `guildId` parameter to `resolveDiscordGuildEntry()` with fallback logic
- Updated call sites in `listeners.ts` and `message-handler.preflight.ts` to pass `data.guild_id`
- ID-based matching (most common config pattern) works immediately with the fallback

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one minor consideration about interaction handlers
- The fix correctly addresses the root cause for MESSAGE_CREATE events. The fallback logic is sound since ID-based matching happens first. However, there's an existing P1 comment in `agent-components.ts:209` indicating interaction handlers may have a similar issue, though the PR author claims they're unaffected. The fix is well-targeted and the implementation is correct for the stated scope.
- No files require special attention - the changes are straightforward and logically sound

<sub>Last reviewed commit: a73a6f6</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->