### PR TITLE
Refactor: share allowlist normalization

### DIFF
--- a/src/channels/allowlists/normalize.test.ts
+++ b/src/channels/allowlists/normalize.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { normalizeAllowList, stripChannelPrefix } from "./normalize.js";
+
+describe("normalizeAllowList", () => {
+  it("trims entries and drops blanks", () => {
+    expect(normalizeAllowList([" a ", "", "  ", "b"])).toEqual(["a", "b"]);
+  });
+
+  it("returns an empty array for nullish input", () => {
+    expect(normalizeAllowList()).toEqual([]);
+    expect(normalizeAllowList(null)).toEqual([]);
+  });
+});
+
+describe("stripChannelPrefix", () => {
+  it("removes a matching prefix", () => {
+    expect(stripChannelPrefix("tg:123", /^(telegram|tg):/i)).toBe("123");
+  });
+
+  it("returns the original value when no prefix matches", () => {
+    expect(stripChannelPrefix("123", /^(telegram|tg):/i)).toBe("123");
+  });
+});

--- a/src/channels/allowlists/normalize.ts
+++ b/src/channels/allowlists/normalize.ts
@@ -1,0 +1,7 @@
+export function normalizeAllowList(list?: Array<string | number> | null): string[] {
+  return (list ?? []).map((entry) => String(entry).trim()).filter(Boolean);
+}
+
+export function stripChannelPrefix(value: string, pattern: RegExp): string {
+  return value.replace(pattern, "");
+}

--- a/src/imessage/monitor/monitor-provider.ts
+++ b/src/imessage/monitor/monitor-provider.ts
@@ -14,6 +14,7 @@ import {
   type HistoryEntry,
 } from "../../auto-reply/reply/history.js";
 import { createReplyDispatcher } from "../../auto-reply/reply/reply-dispatcher.js";
+import { normalizeAllowList } from "../../channels/allowlists/normalize.js";
 import { createReplyPrefixOptions } from "../../channels/reply-prefix.js";
 import { recordInboundSession } from "../../channels/session.js";
 import { loadConfig } from "../../config/config.js";
@@ -39,7 +40,7 @@ import {
   resolveIMessageInboundDecision,
 } from "./inbound-processing.js";
 import { parseIMessageNotification } from "./parse-notification.js";
-import { normalizeAllowList, resolveRuntime } from "./runtime.js";
+import { resolveRuntime } from "./runtime.js";
 
 /**
  * Try to detect remote host from an SSH wrapper script like:

--- a/src/imessage/monitor/runtime.ts
+++ b/src/imessage/monitor/runtime.ts
@@ -4,7 +4,3 @@ import { createNonExitingRuntime, type RuntimeEnv } from "../../runtime.js";
 export function resolveRuntime(opts: MonitorIMessageOpts): RuntimeEnv {
   return opts.runtime ?? createNonExitingRuntime();
 }
-
-export function normalizeAllowList(list?: Array<string | number>) {
-  return (list ?? []).map((entry) => String(entry).trim()).filter(Boolean);
-}

--- a/src/signal/monitor.ts
+++ b/src/signal/monitor.ts
@@ -3,6 +3,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import type { SignalReactionNotificationMode } from "../config/types.js";
 import { chunkTextWithMode, resolveChunkMode, resolveTextChunkLimit } from "../auto-reply/chunk.js";
 import { DEFAULT_GROUP_HISTORY_LIMIT, type HistoryEntry } from "../auto-reply/reply/history.js";
+import { normalizeAllowList } from "../channels/allowlists/normalize.js";
 import { loadConfig } from "../config/config.js";
 import { waitForTransportReady } from "../infra/transport-ready.js";
 import { saveMediaBuffer } from "../media/store.js";
@@ -58,10 +59,6 @@ export type MonitorSignalOpts = {
 
 function resolveRuntime(opts: MonitorSignalOpts): RuntimeEnv {
   return opts.runtime ?? createNonExitingRuntime();
-}
-
-function normalizeAllowList(raw?: Array<string | number>): string[] {
-  return (raw ?? []).map((entry) => String(entry).trim()).filter(Boolean);
 }
 
 type SignalReactionTarget = {

--- a/src/slack/monitor/allow-list.ts
+++ b/src/slack/monitor/allow-list.ts
@@ -1,4 +1,7 @@
 import type { AllowlistMatch } from "../../channels/allowlist-match.js";
+import { normalizeAllowList as normalizeAllowListShared } from "../../channels/allowlists/normalize.js";
+
+export { normalizeAllowList } from "../../channels/allowlists/normalize.js";
 
 export function normalizeSlackSlug(raw?: string) {
   const trimmed = raw?.trim().toLowerCase() ?? "";
@@ -10,12 +13,8 @@ export function normalizeSlackSlug(raw?: string) {
   return cleaned.replace(/-{2,}/g, "-").replace(/^[-.]+|[-.]+$/g, "");
 }
 
-export function normalizeAllowList(list?: Array<string | number>) {
-  return (list ?? []).map((entry) => String(entry).trim()).filter(Boolean);
-}
-
 export function normalizeAllowListLower(list?: Array<string | number>) {
-  return normalizeAllowList(list).map((entry) => entry.toLowerCase());
+  return normalizeAllowListShared(list).map((entry) => entry.toLowerCase());
 }
 
 export type SlackAllowListMatch = AllowlistMatch<


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: multiple channels implement identical allowlist normalization logic.
- Why it matters: duplicates increase drift risk and make fixes error-prone.
- What changed: added shared normalize helpers and reused them in Slack/Signal/iMessage.
- What did NOT change (scope boundary): allowlist semantics, policy decisions, or runtime behavior.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (darwin)
- Runtime/container: Node 22 + pnpm (corepack)
- Model/provider: N/A
- Integration/channel (if any): Slack, Signal, iMessage
- Relevant config (redacted): N/A

### Steps

1. pnpm tsgo
2. pnpm build
3. pnpm test src/channels/allowlists/normalize.test.ts src/signal/monitor.test.ts src/imessage/monitor.gating.test.ts src/slack/monitor.test.ts

### Expected

- Commands complete successfully.

### Actual

- Commands completed successfully.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: typecheck, build, and targeted tests listed above.
- Edge cases checked: N/A (refactor only).
- What you did **not** verify: manual channel runtime behavior.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the four refactor commits on this branch.
- Files/config to restore: allowlists helper + Slack/Signal/iMessage usage sites.
- Known bad symptoms reviewers should watch for: unexpected allowlist normalization.

## Risks and Mitigations

None.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extracted duplicate `normalizeAllowList` implementations from Slack, Signal, and iMessage channels into a shared utility at `src/channels/allowlists/normalize.ts`. All three channels now import and use the same normalization logic, ensuring consistency across allowlist handling.

- Removed identical `normalizeAllowList` functions from `src/imessage/monitor/runtime.ts`, `src/signal/monitor.ts`, and `src/slack/monitor/allow-list.ts`
- Created shared `normalizeAllowList` helper with added `| null` type support (backward compatible)
- Added `stripChannelPrefix` helper (tested but not yet used in codebase)
- Slack re-exports `normalizeAllowList` from shared module to maintain existing import paths
- All tests pass per PR description verification

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Pure refactoring that extracts identical logic without changing behavior. The shared implementation is functionally identical to all three original implementations (only adds `| null` type support which is backward compatible). Test coverage added for the new shared module, and existing channel tests verify behavior preservation.
- No files require special attention

<sub>Last reviewed commit: df1d8b9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->