### PR TITLE
fix: prevent Slack auth errors from crashing the entire gateway

### DIFF
--- a/src/slack/monitor/provider.ts
+++ b/src/slack/monitor/provider.ts
@@ -358,14 +358,12 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
             `The Slack channel will stop working until tokens are updated. ` +
             `Other channels are unaffected.`,
         );
-      } else {
-        runtime.error?.(
-          `[slack] Suppressed Slack API error (non-fatal): ${dataError}`,
-        );
+        return true; // handled — don't crash the gateway
       }
-      return true; // handled — don't crash the gateway
+      // Let other platform errors (channel_not_found, missing_scope, etc.)
+      // bubble up — they may indicate real issues worth surfacing.
     }
-    return false; // not a Slack error — let other handlers decide
+    return false; // not handled — let other handlers decide
   });
 
   const stopOnAbort = () => {

--- a/src/slack/monitor/provider.ts
+++ b/src/slack/monitor/provider.ts
@@ -1,5 +1,7 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import SlackBolt from "@slack/bolt";
+import type { SessionScope } from "../../config/sessions.js";
+import type { MonitorSlackOpts } from "./types.js";
 import { resolveTextChunkLimit } from "../../auto-reply/chunk.js";
 import { DEFAULT_GROUP_HISTORY_LIMIT } from "../../auto-reply/reply/history.js";
 import {
@@ -10,7 +12,6 @@ import {
   summarizeMapping,
 } from "../../channels/allowlists/resolve-utils.js";
 import { loadConfig } from "../../config/config.js";
-import type { SessionScope } from "../../config/sessions.js";
 import { warn } from "../../globals.js";
 import { installRequestBodyLimitGuard } from "../../infra/http-body.js";
 import { registerUnhandledRejectionHandler } from "../../infra/unhandled-rejections.js";
@@ -33,7 +34,6 @@ import {
   getSlackErrorCode,
 } from "./slack-error-detection.js";
 import { registerSlackMonitorSlashCommands } from "./slash.js";
-import type { MonitorSlackOpts } from "./types.js";
 
 const slackBoltModule = SlackBolt as typeof import("@slack/bolt") & {
   default?: typeof import("@slack/bolt");

--- a/src/slack/monitor/provider.unhandled-rejection.test.ts
+++ b/src/slack/monitor/provider.unhandled-rejection.test.ts
@@ -29,8 +29,8 @@ describe("Slack unhandled rejection handler integration", () => {
   beforeEach(() => {
     // Register the same handler that monitorSlackProvider() uses
     unregister = registerUnhandledRejectionHandler((reason) => {
-      if (isSlackPlatformError(reason)) {
-        return true; // handled
+      if (isSlackPlatformError(reason) && isSlackUnrecoverableAuthError(reason)) {
+        return true; // handled — only suppress unrecoverable auth errors
       }
       return false;
     });
@@ -65,9 +65,9 @@ describe("Slack unhandled rejection handler integration", () => {
     expect(isUnhandledRejectionHandled(err)).toBe(true);
   });
 
-  it("catches non-auth Slack platform errors too (e.g. channel_not_found)", () => {
+  it("does NOT catch non-auth Slack platform errors (e.g. channel_not_found)", () => {
     const err = createSlackPlatformError("channel_not_found");
-    expect(isUnhandledRejectionHandled(err)).toBe(true);
+    expect(isUnhandledRejectionHandled(err)).toBe(false);
   });
 
   it("does not catch non-Slack errors", () => {

--- a/src/slack/monitor/provider.unhandled-rejection.test.ts
+++ b/src/slack/monitor/provider.unhandled-rejection.test.ts
@@ -3,10 +3,7 @@ import {
   registerUnhandledRejectionHandler,
   isUnhandledRejectionHandled,
 } from "../../infra/unhandled-rejections.js";
-import {
-  isSlackPlatformError,
-  isSlackUnrecoverableAuthError,
-} from "./slack-error-detection.js";
+import { isSlackPlatformError, isSlackUnrecoverableAuthError } from "./slack-error-detection.js";
 
 /**
  * These tests verify the Slack-specific unhandled rejection handler integration.
@@ -97,12 +94,16 @@ describe("Slack unhandled rejection handler integration", () => {
 
   describe("distinguishes auth errors from other platform errors", () => {
     it("identifies unrecoverable auth errors", () => {
-      expect(isSlackUnrecoverableAuthError(createSlackPlatformError("account_inactive"))).toBe(true);
+      expect(isSlackUnrecoverableAuthError(createSlackPlatformError("account_inactive"))).toBe(
+        true,
+      );
       expect(isSlackUnrecoverableAuthError(createSlackPlatformError("invalid_auth"))).toBe(true);
     });
 
     it("identifies non-auth platform errors", () => {
-      expect(isSlackUnrecoverableAuthError(createSlackPlatformError("channel_not_found"))).toBe(false);
+      expect(isSlackUnrecoverableAuthError(createSlackPlatformError("channel_not_found"))).toBe(
+        false,
+      );
       expect(isSlackUnrecoverableAuthError(createSlackPlatformError("missing_scope"))).toBe(false);
     });
   });

--- a/src/slack/monitor/provider.unhandled-rejection.test.ts
+++ b/src/slack/monitor/provider.unhandled-rejection.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  registerUnhandledRejectionHandler,
+  isUnhandledRejectionHandled,
+} from "../../infra/unhandled-rejections.js";
+import {
+  isSlackPlatformError,
+  isSlackUnrecoverableAuthError,
+} from "./slack-error-detection.js";
+
+/**
+ * These tests verify the Slack-specific unhandled rejection handler integration.
+ * Detection function unit tests are in slack-error-detection.test.ts;
+ * these tests verify the handler registration works correctly with the
+ * global unhandled rejection system.
+ */
+
+/** Creates a mock Slack Web API platform error (as thrown by @slack/web-api). */
+function createSlackPlatformError(apiError: string) {
+  return Object.assign(new Error(`An API error occurred: ${apiError}`), {
+    code: "slack_webapi_platform_error",
+    data: { ok: false, error: apiError },
+  });
+}
+
+describe("Slack unhandled rejection handler integration", () => {
+  let unregister: () => void;
+
+  beforeEach(() => {
+    // Register the same handler that monitorSlackProvider() uses
+    unregister = registerUnhandledRejectionHandler((reason) => {
+      if (isSlackPlatformError(reason)) {
+        return true; // handled
+      }
+      return false;
+    });
+  });
+
+  afterEach(() => {
+    unregister();
+  });
+
+  it("catches Slack account_inactive as handled", () => {
+    const err = createSlackPlatformError("account_inactive");
+    expect(isUnhandledRejectionHandled(err)).toBe(true);
+  });
+
+  it("catches Slack invalid_auth as handled", () => {
+    const err = createSlackPlatformError("invalid_auth");
+    expect(isUnhandledRejectionHandled(err)).toBe(true);
+  });
+
+  it("catches Slack not_authed as handled", () => {
+    const err = createSlackPlatformError("not_authed");
+    expect(isUnhandledRejectionHandled(err)).toBe(true);
+  });
+
+  it("catches Slack team_disabled as handled", () => {
+    const err = createSlackPlatformError("team_disabled");
+    expect(isUnhandledRejectionHandled(err)).toBe(true);
+  });
+
+  it("catches Slack user_removed_from_team as handled", () => {
+    const err = createSlackPlatformError("user_removed_from_team");
+    expect(isUnhandledRejectionHandled(err)).toBe(true);
+  });
+
+  it("catches non-auth Slack platform errors too (e.g. channel_not_found)", () => {
+    const err = createSlackPlatformError("channel_not_found");
+    expect(isUnhandledRejectionHandled(err)).toBe(true);
+  });
+
+  it("does not catch non-Slack errors", () => {
+    expect(isUnhandledRejectionHandled(new Error("unrelated"))).toBe(false);
+  });
+
+  it("does not catch network errors (left for other handlers)", () => {
+    const err = Object.assign(new Error("connect failed"), { code: "ECONNRESET" });
+    expect(isUnhandledRejectionHandled(err)).toBe(false);
+  });
+
+  it("does not catch rate-limited errors from Slack (different code)", () => {
+    const err = Object.assign(new Error("rate limited"), {
+      code: "slack_webapi_rate_limited_error",
+      data: { ok: false, error: "ratelimited" },
+    });
+    expect(isUnhandledRejectionHandled(err)).toBe(false);
+  });
+
+  it("stops catching after unregister", () => {
+    unregister();
+    const err = createSlackPlatformError("account_inactive");
+    expect(isUnhandledRejectionHandled(err)).toBe(false);
+    // Re-register for afterEach cleanup
+    unregister = registerUnhandledRejectionHandler(() => false);
+  });
+
+  describe("distinguishes auth errors from other platform errors", () => {
+    it("identifies unrecoverable auth errors", () => {
+      expect(isSlackUnrecoverableAuthError(createSlackPlatformError("account_inactive"))).toBe(true);
+      expect(isSlackUnrecoverableAuthError(createSlackPlatformError("invalid_auth"))).toBe(true);
+    });
+
+    it("identifies non-auth platform errors", () => {
+      expect(isSlackUnrecoverableAuthError(createSlackPlatformError("channel_not_found"))).toBe(false);
+      expect(isSlackUnrecoverableAuthError(createSlackPlatformError("missing_scope"))).toBe(false);
+    });
+  });
+});

--- a/src/slack/monitor/slack-error-detection.test.ts
+++ b/src/slack/monitor/slack-error-detection.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import {
+  isSlackPlatformError,
+  isSlackUnrecoverableAuthError,
+  getSlackErrorCode,
+} from "./slack-error-detection.js";
+
+/**
+ * Creates a mock Slack Web API PlatformError matching the structure from @slack/web-api.
+ * See: @slack/web-api/src/errors.ts → platformErrorFromResult()
+ */
+function createSlackPlatformError(apiError: string): Error & { code: string; data: { error: string } } {
+  const error = Object.assign(new Error(`An API error occurred: ${apiError}`), {
+    code: "slack_webapi_platform_error" as const,
+    data: { error: apiError },
+  });
+  return error;
+}
+
+describe("isSlackPlatformError", () => {
+  it("returns true for Slack platform errors", () => {
+    expect(isSlackPlatformError(createSlackPlatformError("account_inactive"))).toBe(true);
+    expect(isSlackPlatformError(createSlackPlatformError("invalid_auth"))).toBe(true);
+    expect(isSlackPlatformError(createSlackPlatformError("some_other_error"))).toBe(true);
+  });
+
+  it("returns false for non-Slack errors", () => {
+    expect(isSlackPlatformError(new Error("something"))).toBe(false);
+    expect(isSlackPlatformError(Object.assign(new Error("test"), { code: "ECONNRESET" }))).toBe(false);
+  });
+
+  it("returns false for null, undefined, and primitives", () => {
+    expect(isSlackPlatformError(null)).toBe(false);
+    expect(isSlackPlatformError(undefined)).toBe(false);
+    expect(isSlackPlatformError("string")).toBe(false);
+    expect(isSlackPlatformError(42)).toBe(false);
+  });
+});
+
+describe("isSlackUnrecoverableAuthError", () => {
+  it("returns true for all unrecoverable auth errors", () => {
+    const unrecoverableErrors = [
+      "not_authed",
+      "invalid_auth",
+      "account_inactive",
+      "user_removed_from_team",
+      "team_disabled",
+    ];
+    for (const apiError of unrecoverableErrors) {
+      expect(
+        isSlackUnrecoverableAuthError(createSlackPlatformError(apiError)),
+        `expected true for ${apiError}`,
+      ).toBe(true);
+    }
+  });
+
+  it("returns false for other Slack platform errors", () => {
+    expect(isSlackUnrecoverableAuthError(createSlackPlatformError("channel_not_found"))).toBe(false);
+    expect(isSlackUnrecoverableAuthError(createSlackPlatformError("rate_limited"))).toBe(false);
+    expect(isSlackUnrecoverableAuthError(createSlackPlatformError("missing_scope"))).toBe(false);
+  });
+
+  it("returns false for non-Slack errors", () => {
+    expect(isSlackUnrecoverableAuthError(new Error("invalid_auth"))).toBe(false);
+    expect(isSlackUnrecoverableAuthError(null)).toBe(false);
+  });
+});
+
+describe("getSlackErrorCode", () => {
+  it("extracts the API error string from platform errors", () => {
+    expect(getSlackErrorCode(createSlackPlatformError("account_inactive"))).toBe("account_inactive");
+    expect(getSlackErrorCode(createSlackPlatformError("invalid_auth"))).toBe("invalid_auth");
+  });
+
+  it("returns undefined for non-Slack errors", () => {
+    expect(getSlackErrorCode(new Error("test"))).toBeUndefined();
+    expect(getSlackErrorCode(null)).toBeUndefined();
+  });
+});

--- a/src/slack/monitor/slack-error-detection.test.ts
+++ b/src/slack/monitor/slack-error-detection.test.ts
@@ -9,7 +9,9 @@ import {
  * Creates a mock Slack Web API PlatformError matching the structure from @slack/web-api.
  * See: @slack/web-api/src/errors.ts → platformErrorFromResult()
  */
-function createSlackPlatformError(apiError: string): Error & { code: string; data: { error: string } } {
+function createSlackPlatformError(
+  apiError: string,
+): Error & { code: string; data: { error: string } } {
   const error = Object.assign(new Error(`An API error occurred: ${apiError}`), {
     code: "slack_webapi_platform_error" as const,
     data: { error: apiError },
@@ -26,7 +28,9 @@ describe("isSlackPlatformError", () => {
 
   it("returns false for non-Slack errors", () => {
     expect(isSlackPlatformError(new Error("something"))).toBe(false);
-    expect(isSlackPlatformError(Object.assign(new Error("test"), { code: "ECONNRESET" }))).toBe(false);
+    expect(isSlackPlatformError(Object.assign(new Error("test"), { code: "ECONNRESET" }))).toBe(
+      false,
+    );
   });
 
   it("returns false for null, undefined, and primitives", () => {
@@ -55,7 +59,9 @@ describe("isSlackUnrecoverableAuthError", () => {
   });
 
   it("returns false for other Slack platform errors", () => {
-    expect(isSlackUnrecoverableAuthError(createSlackPlatformError("channel_not_found"))).toBe(false);
+    expect(isSlackUnrecoverableAuthError(createSlackPlatformError("channel_not_found"))).toBe(
+      false,
+    );
     expect(isSlackUnrecoverableAuthError(createSlackPlatformError("rate_limited"))).toBe(false);
     expect(isSlackUnrecoverableAuthError(createSlackPlatformError("missing_scope"))).toBe(false);
   });
@@ -68,7 +74,9 @@ describe("isSlackUnrecoverableAuthError", () => {
 
 describe("getSlackErrorCode", () => {
   it("extracts the API error string from platform errors", () => {
-    expect(getSlackErrorCode(createSlackPlatformError("account_inactive"))).toBe("account_inactive");
+    expect(getSlackErrorCode(createSlackPlatformError("account_inactive"))).toBe(
+      "account_inactive",
+    );
     expect(getSlackErrorCode(createSlackPlatformError("invalid_auth"))).toBe("invalid_auth");
   });
 

--- a/src/slack/monitor/slack-error-detection.ts
+++ b/src/slack/monitor/slack-error-detection.ts
@@ -1,0 +1,47 @@
+/**
+ * Slack API errors that @slack/socket-mode treats as unrecoverable during reconnection.
+ * When these occur during an internal reconnect attempt, the socket-mode client throws
+ * an error that escapes the promise chain and becomes an unhandled rejection.
+ * See: @slack/socket-mode/src/UnrecoverableSocketModeStartError.ts
+ */
+const SLACK_UNRECOVERABLE_AUTH_ERRORS = new Set([
+  "not_authed",
+  "invalid_auth",
+  "account_inactive",
+  "user_removed_from_team",
+  "team_disabled",
+]);
+
+/**
+ * Detects Slack Web API platform errors (code: "slack_webapi_platform_error").
+ * These are thrown by @slack/web-api when the Slack API returns an error response,
+ * and may escape as unhandled rejections during socket-mode reconnection.
+ */
+export function isSlackPlatformError(err: unknown): boolean {
+  if (!err || typeof err !== "object") {
+    return false;
+  }
+  return (err as { code?: string }).code === "slack_webapi_platform_error";
+}
+
+/**
+ * Checks if a Slack platform error is an auth/account error that the socket-mode
+ * client considers unrecoverable (and therefore throws instead of retrying).
+ */
+export function isSlackUnrecoverableAuthError(err: unknown): boolean {
+  if (!isSlackPlatformError(err)) {
+    return false;
+  }
+  const dataError = (err as { data?: { error?: string } }).data?.error;
+  return dataError !== undefined && SLACK_UNRECOVERABLE_AUTH_ERRORS.has(dataError);
+}
+
+/**
+ * Extracts the Slack API error string from a platform error, if present.
+ */
+export function getSlackErrorCode(err: unknown): string | undefined {
+  if (!isSlackPlatformError(err)) {
+    return undefined;
+  }
+  return (err as { data?: { error?: string } }).data?.error;
+}


### PR DESCRIPTION
## Problem

When `@slack/socket-mode`'s internal reconnection fails with an unrecoverable auth error (`account_inactive`, `invalid_auth`, etc.), the error escapes as an unhandled promise rejection. The global handler then calls `process.exit(1)`, crashing the **entire gateway** — including healthy channels like Telegram.

In practice this causes a crash loop: every restart hits the same auth error, exits again, repeat. The only fix is manual intervention (removing Slack config).

## Root Cause

`@slack/socket-mode`'s `delayReconnectAttempt()` calls `cb.apply(this).then(res)` with **no `.catch()`**. When `retrieveWSSURL()` throws an `UnrecoverableSocketModeStartError` (for errors like `account_inactive`, `invalid_auth`, `team_disabled`), the rejection is never caught.

OpenClaw's global unhandled rejection handler sees this isn't a transient network error → `process.exit(1)`.

## Fix

Register a Slack-specific unhandled rejection handler that catches Slack platform errors and logs them instead of crashing. This follows the **exact same pattern** already used by the Telegram provider for Grammy HTTP errors.

The handler:
- Catches all `slack_webapi_platform_error` rejections
- Logs clearly whether it's an auth error ("channel will stop working until tokens are updated") or a transient API error
- Returns `true` to prevent `process.exit(1)`
- Is scoped to the provider lifecycle (registered on start, unregistered in `finally`)

## Changes

| File | Description |
|------|-------------|
| `src/slack/monitor/slack-error-detection.ts` | Detection helpers: `isSlackPlatformError()`, `isSlackUnrecoverableAuthError()`, `getSlackErrorCode()` |
| `src/slack/monitor/slack-error-detection.test.ts` | 8 unit tests for detection functions |
| `src/slack/monitor/provider.ts` | Registers the unhandled rejection handler |
| `src/slack/monitor/provider.unhandled-rejection.test.ts` | 12 integration tests with the global rejection system |

## Testing

- 195 tests pass across all Slack + unhandled rejection test suites
- Zero breakage in existing tests
- TypeScript compiles cleanly

Fixes #6867

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Prevents Slack authentication errors from crashing the entire gateway by registering a scoped unhandled rejection handler. When `@slack/socket-mode` encounters unrecoverable auth errors (`account_inactive`, `invalid_auth`, etc.) during reconnection, these now log clearly instead of causing `process.exit(1)`.

- Follows the exact same pattern already used by the Telegram provider for Grammy HTTP errors
- Only suppresses unrecoverable auth errors; other Slack platform errors (like `channel_not_found`, `missing_scope`) correctly bubble up
- Handler properly unregistered in `finally` block to prevent memory leaks
- Well-tested with 20 unit and integration tests covering auth errors, non-auth platform errors, cleanup, and edge cases

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is surgical and well-tested. It follows an existing proven pattern from the Telegram provider, only suppresses the specific unrecoverable auth errors that cause crash loops, and has comprehensive test coverage. The previous reviewer concern about suppressing all Slack platform errors has been addressed - the code now only returns `true` for unrecoverable auth errors (lines 355-361 in provider.ts) and explicitly lets other platform errors bubble up.
- No files require special attention

<sub>Last reviewed commit: a7d4bb3</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->