### PR TITLE
fix: drop WhatsApp pairing reply for unconfigured accounts

### DIFF
--- a/src/web/inbound/access-control.test.ts
+++ b/src/web/inbound/access-control.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 import {
-  sendMessageMock,
   setAccessControlTestConfig,
   setupAccessControlTestHarness,
   upsertPairingRequestMock,
@@ -19,15 +18,12 @@ async function checkUnauthorizedWorkDmSender() {
     group: false,
     pushName: "Stranger",
     isFromMe: false,
-    sock: { sendMessage: sendMessageMock },
-    remoteJid: "15550001111@s.whatsapp.net",
   });
 }
 
 function expectSilentlyBlocked(result: { allowed: boolean }) {
   expect(result.allowed).toBe(false);
   expect(upsertPairingRequestMock).not.toHaveBeenCalled();
-  expect(sendMessageMock).not.toHaveBeenCalled();
 }
 
 describe("checkInboundAccessControl pairing grace", () => {
@@ -44,8 +40,6 @@ describe("checkInboundAccessControl pairing grace", () => {
       messageTimestampMs,
       connectedAtMs,
       pairingGraceMs: 30_000,
-      sock: { sendMessage: sendMessageMock },
-      remoteJid: "15550001111@s.whatsapp.net",
     });
   }
 
@@ -54,15 +48,13 @@ describe("checkInboundAccessControl pairing grace", () => {
 
     expect(result.allowed).toBe(false);
     expect(upsertPairingRequestMock).not.toHaveBeenCalled();
-    expect(sendMessageMock).not.toHaveBeenCalled();
   });
 
-  it("sends pairing replies for live DMs", async () => {
+  it("records pairing request but does not reply for live DMs", async () => {
     const result = await runPairingGraceCase(1_000_000 - 10_000);
 
     expect(result.allowed).toBe(false);
     expect(upsertPairingRequestMock).toHaveBeenCalled();
-    expect(sendMessageMock).toHaveBeenCalled();
   });
 });
 

--- a/src/web/inbound/monitor.ts
+++ b/src/web/inbound/monitor.ts
@@ -209,8 +209,6 @@ export async function monitorWebInbox(options: {
         isFromMe: Boolean(msg.key?.fromMe),
         messageTimestampMs,
         connectedAtMs,
-        sock: { sendMessage: (jid, content) => sock.sendMessage(jid, content) },
-        remoteJid,
       });
       if (!access.allowed) {
         continue;

--- a/src/web/monitor-inbox.allows-messages-from-senders-allowfrom-list.test.ts
+++ b/src/web/monitor-inbox.allows-messages-from-senders-allowfrom-list.test.ts
@@ -182,13 +182,7 @@ describe("web monitor inbox", () => {
     sock.ev.emit("messages.upsert", upsertBlocked);
     await new Promise((resolve) => setImmediate(resolve));
     expect(onMessage).not.toHaveBeenCalled();
-    expect(sock.sendMessage).toHaveBeenCalledTimes(1);
-    expect(sock.sendMessage).toHaveBeenCalledWith("999@s.whatsapp.net", {
-      text: expect.stringContaining("Your WhatsApp phone number: +999"),
-    });
-    expect(sock.sendMessage).toHaveBeenCalledWith("999@s.whatsapp.net", {
-      text: expect.stringContaining("Pairing code: PAIRCODE"),
-    });
+    expect(sock.sendMessage).not.toHaveBeenCalled();
 
     const upsertBlockedAgain = {
       type: "notify",
@@ -208,7 +202,7 @@ describe("web monitor inbox", () => {
     sock.ev.emit("messages.upsert", upsertBlockedAgain);
     await new Promise((resolve) => setImmediate(resolve));
     expect(onMessage).not.toHaveBeenCalled();
-    expect(sock.sendMessage).toHaveBeenCalledTimes(1);
+    expect(sock.sendMessage).not.toHaveBeenCalled();
 
     // Message from self should be allowed
     const upsertSelf = {

--- a/src/web/monitor-inbox.blocks-messages-from-unauthorized-senders-not-allowfrom.test.ts
+++ b/src/web/monitor-inbox.blocks-messages-from-unauthorized-senders-not-allowfrom.test.ts
@@ -116,13 +116,7 @@ describe("web monitor inbox", () => {
     expect(onMessage).not.toHaveBeenCalled();
     // Should NOT send read receipts for blocked senders (privacy + avoids Baileys Bad MAC churn).
     expect(sock.readMessages).not.toHaveBeenCalled();
-    expect(sock.sendMessage).toHaveBeenCalledTimes(1);
-    expect(sock.sendMessage).toHaveBeenCalledWith("999@s.whatsapp.net", {
-      text: expect.stringContaining("Your WhatsApp phone number: +999"),
-    });
-    expect(sock.sendMessage).toHaveBeenCalledWith("999@s.whatsapp.net", {
-      text: expect.stringContaining("Pairing code: PAIRCODE"),
-    });
+    expect(sock.sendMessage).not.toHaveBeenCalled();
 
     await listener.close();
   });


### PR DESCRIPTION
## Summary
- When WhatsApp pairing is not configured, the bot was replying to every unknown sender with pairing instructions (phone number, pairing code, CLI command). This leaks internal info and is noisy.
- Multiple of my friends were confused on getting a generic error msg while texting a friend.
```
OpenClaw: access not configured.

Your WhatsApp phone number: +xxxxx

Pairing code: xxxx

Ask the bot owner to approve with:
openclaw pairing approve whatsapp xxxx
```
- The pairing request is still recorded so the bot owner can see and approve pending requests via `openclaw pairing approve`.
- Removed the `sendMessage` call and unused `buildPairingReply` import from the WhatsApp access control path.

## Test plan
- [x] Unit tests pass (`pnpm vitest run src/web/inbound/access-control.test.ts` — 4/4)
- [ ] CI checks

AI-assisted (Claude). Lightly tested (unit tests pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the WhatsApp pairing reply message that was sent to unknown senders when pairing is not configured. Previously, the bot would reply with internal details (phone number, pairing code, CLI command) to every unauthorized sender, leaking information and confusing recipients. The pairing request is still silently recorded so the bot owner can approve it via `openclaw pairing approve`.

- Removed `sendMessage` call and `buildPairingReply` import from the WhatsApp access control path in `access-control.ts`
- Removed unused `code` destructuring from `upsertChannelPairingRequest` result
- Updated 4 test files to assert `sendMessage` is **not** called instead of being called with pairing text
- Minor cleanup opportunity: `sock` and `remoteJid` params are now unused in the function signature

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it removes outbound behavior (sending messages) without affecting inbound message processing or pairing request recording.
- The change is a straightforward removal of a `sendMessage` call and its associated import. The pairing request is still upserted and logged, so the approval workflow remains intact. Tests are updated consistently across all 4 files. No logic changes to the access control decision itself.
- No files require special attention.

<sub>Last reviewed commit: 743a883</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->