### PR TITLE
fix: replace anyOf union type in image tool schema

### DIFF
--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -376,7 +376,7 @@ export function createImageTool(options?: {
     description,
     parameters: Type.Object({
       prompt: Type.Optional(Type.String()),
-      image: Type.Union([Type.String(), Type.Array(Type.String())]),
+      image: Type.String(),
       model: Type.Optional(Type.String()),
       maxBytesMb: Type.Optional(Type.Number()),
       maxImages: Type.Optional(Type.Number()),


### PR DESCRIPTION
Fixes #17868

## Problem
The `image` tool parameter used `Type.Union([Type.String(), Type.Array(Type.String())])` which generates an `anyOf` in JSON Schema. Claude API rejects `anyOf` in tool schemas.

## Solution
Replace with `Type.String()`. The runtime normalization already handles both string and array inputs gracefully.

## Changes
- `src/agents/tools/image-tool.ts`: Replace `Type.Union([Type.String(), Type.Array(Type.String())])` with `Type.String()`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaced `Type.Union` with `Type.String()` in the `image` tool parameter schema to fix Claude API compatibility (which rejects `anyOf` schemas). The runtime normalization (src/agents/tools/image-tool.ts:387-397) already handles both string and array inputs gracefully, so this change only affects the JSON Schema definition without impacting functionality.

- Aligns with repository style guide (AGENTS.md:179) that prohibits `Type.Union` in tool schemas
- Runtime continues to accept both string and array inputs via existing normalization logic
- Fixes issue #17868

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is minimal (one line), well-documented, and follows repository guidelines. The runtime normalization code ensures backward compatibility with both string and array inputs. The fix addresses a concrete API compatibility issue and aligns with established coding patterns in the repository.
- No files require special attention

<sub>Last reviewed commit: 79feb94</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))

<!-- /greptile_comment -->