### PR TITLE
fix: persist channels.telegram.streamMode across restarts

### DIFF
--- a/src/config/config.legacy-config-detection.rejects-routing-allowfrom.e2e.test.ts
+++ b/src/config/config.legacy-config-detection.rejects-routing-allowfrom.e2e.test.ts
@@ -378,11 +378,11 @@ describe("legacy config detection", () => {
       expect(res.config.channels?.telegram?.groupPolicy).toBe("allowlist");
     }
   });
-  it("defaults telegram.streamMode to partial when telegram section exists", async () => {
+  it("leaves telegram.streamMode undefined when not set (runtime default applied later)", async () => {
     const res = validateConfigObject({ channels: { telegram: {} } });
     expect(res.ok).toBe(true);
     if (res.ok) {
-      expect(res.config.channels?.telegram?.streamMode).toBe("partial");
+      expect(res.config.channels?.telegram?.streamMode).toBeUndefined();
     }
   });
   it('rejects whatsapp.dmPolicy="open" without allowFrom "*"', async () => {

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -121,7 +121,7 @@ export const TelegramAccountSchemaBase = z
     blockStreaming: z.boolean().optional(),
     draftChunk: BlockStreamingChunkSchema.optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
-    streamMode: z.enum(["off", "partial", "block"]).optional().default("partial"),
+    streamMode: z.enum(["off", "partial", "block"]).optional(),
     mediaMaxMb: z.number().positive().optional(),
     timeoutSeconds: z.number().int().positive().optional(),
     retry: RetryConfigSchema,


### PR DESCRIPTION
Fixes #17871

## Problem

`config.patch` changes to `channels.telegram.streamMode` don't persist across gateway restarts. The value always reverts to `"partial"`.

## Root Cause

The Zod schema used `.default("partial")` on the `streamMode` field. During config validation (on startup and `doctor --fix`), Zod injects this default before the user's config.patch is merged, overwriting the user's value.

## Fix

Remove `.default("partial")` from the Zod schema. The runtime default is already handled by `resolveTelegramStreamMode()` in `src/telegram/bot/helpers.ts`, which returns `"partial"` when the value is undefined.

## Changes

- `src/config/zod-schema.providers-core.ts`: Remove `.default("partial")` from streamMode
- Updated test to expect `undefined` instead of `"partial"` from schema validation

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removed `.default("partial")` from the `channels.telegram.streamMode` Zod schema field to fix persistence issue where user's `config.patch` changes were being overwritten by schema defaults on gateway restart.

## Key Changes
- **src/config/zod-schema.providers-core.ts:117**: Removed `.default("partial")` from `streamMode` field, leaving it as `.optional()`
- **src/config/config.legacy-config-detection.rejects-routing-allowfrom.e2e.test.ts:377-381**: Updated test to expect `undefined` instead of `"partial"` when `streamMode` is not explicitly set

## Why This Works
The runtime default is correctly handled by `resolveTelegramStreamMode()` in `src/telegram/bot/helpers.ts:157-165`, which returns `"partial"` when the value is `undefined`. The Zod default was causing the schema validation (which runs during config load and `config.patch` operations) to inject `"partial"` before the user's patch was merged, effectively overwriting the user's intended value.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix correctly addresses the root cause by removing the Zod default that was prematurely injecting values during validation. The runtime default logic in `resolveTelegramStreamMode()` already handles undefined values properly, and the test update confirms the expected behavior. No other code paths are affected.
- No files require special attention

<sub>Last reviewed commit: 93107de</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->