### PR TITLE
fix: normalize /v1/responses input for clients that omit type field

### DIFF
--- a/src/gateway/open-responses.schema.ts
+++ b/src/gateway/open-responses.schema.ts
@@ -196,7 +196,7 @@ export const CreateResponseBodySchema = z
       .optional(),
     truncation: z.enum(["auto", "disabled"]).optional(),
   })
-  .strict();
+  .strip();
 
 export type CreateResponseBody = z.infer<typeof CreateResponseBodySchema>;
 

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -269,6 +269,47 @@ async function runResponsesAgentCommand(params: {
   );
 }
 
+/**
+ * Normalize the raw request body before Zod validation so that clients which
+ * omit the `type` discriminator (e.g. n8n) still pass schema validation.
+ *
+ * Rules:
+ *  - Items with `role` but no `type` get `type: "message"` (OpenAI infers this).
+ *  - Content parts with `type: "text"` are rewritten to `type: "input_text"`.
+ */
+function normalizeResponseInput(body: unknown): unknown {
+  if (typeof body !== "object" || body === null) {
+    return body;
+  }
+  const obj = body as Record<string, unknown>;
+  if (!Array.isArray(obj.input)) {
+    return body;
+  }
+  obj.input = obj.input.map((item: unknown) => {
+    if (typeof item !== "object" || item === null) {
+      return item;
+    }
+    const it = item as Record<string, unknown>;
+    if (it.role && !it.type) {
+      it.type = "message";
+    }
+    if (it.type === "message" && Array.isArray(it.content)) {
+      it.content = (it.content as unknown[]).map((part: unknown) => {
+        if (typeof part !== "object" || part === null) {
+          return part;
+        }
+        const p = part as Record<string, unknown>;
+        if (p.type === "text") {
+          p.type = "input_text";
+        }
+        return p;
+      });
+    }
+    return it;
+  });
+  return body;
+}
+
 export async function handleOpenResponsesHttpRequest(
   req: IncomingMessage,
   res: ServerResponse,
@@ -295,8 +336,9 @@ export async function handleOpenResponsesHttpRequest(
     return true;
   }
 
-  // Validate request body with Zod
-  const parseResult = CreateResponseBodySchema.safeParse(handled.body);
+  // Normalize input for clients that omit `type` on message items (e.g. n8n)
+  // then validate with Zod.
+  const parseResult = CreateResponseBodySchema.safeParse(normalizeResponseInput(handled.body));
   if (!parseResult.success) {
     const issue = parseResult.error.issues[0];
     const message = issue ? `${issue.path.join(".")}: ${issue.message}` : "Invalid request body";


### PR DESCRIPTION
## Summary

Fixes `400 Bad Request` ("input: Invalid input") when OpenAI SDK clients send
`/v1/responses` input messages without the `type: "message"` discriminator field.

- n8n (v2.2.4+), and potentially other clients, send `{"role":"user","content":"hello"}`
  without `type` — OpenAI's API accepts this, but the Zod `discriminatedUnion("type", [...])`
  schema rejects it
- Adds a `normalizeResponseInput()` pre-processing step before Zod validation
- Also normalizes `type: "text"` content parts to `type: "input_text"` for clients that
  use the Chat Completions content format
- Changes `CreateResponseBodySchema` from `.strict()` to `.strip()` so unknown top-level
  fields (e.g. `parallel_tool_calls`, `background`) forwarded by clients are silently
  discarded instead of causing validation errors

## Changes

**`src/gateway/openresponses-http.ts`:**
- Adds `normalizeResponseInput()` function (~25 lines)
- Wraps the existing `CreateResponseBodySchema.safeParse()` call with normalization

**`src/gateway/open-responses.schema.ts`:**
- Changes `.strict()` to `.strip()` on `CreateResponseBodySchema`

## Normalization rules

| Client sends | Normalized to | Why |
|---|---|---|
| `{"role":"user","content":"..."}` (no `type`) | `{"type":"message","role":"user","content":"..."}` | OpenAI infers `type: "message"` when `role` is present |
| `{"type":"text","text":"..."}` in content array | `{"type":"input_text","text":"..."}` | Some clients use Chat Completions content format |

## Test Plan

- [x] `POST /v1/responses` with `[{"role":"user","content":"hello"}]` (no type) — was 400, now accepted
- [x] `POST /v1/responses` with `[{"type":"message","role":"user","content":[{"type":"text","text":"hello"}]}]` — was 400, now accepted
- [x] `POST /v1/responses` with correct format still works
- [x] `POST /v1/responses` with string input still works
- [x] Tested with n8n v2.2.4 OpenAI Chat Model node (Responses API mode)
- [x] `pnpm build` passes with zero errors
- [x] Rebased onto current main

## AI Disclosure 🤖

- **AI-assisted**: Yes — written with Claude (Opus), with human review and testing
- **Testing level**: Build-verified (`pnpm build` zero errors); endpoint tested with n8n v2.2.4 OpenAI Chat Model node
- **Understanding**: The author understands the code — it pre-processes the raw request body to infer `type: "message"` for items that have `role` but no `type`, matching OpenAI's own inference behavior, and rewrites `type: "text"` content parts to the `input_text` variant expected by the Zod schema