### PR TITLE
fix(telegram): persist streamMode off setting

### DIFF
--- a/src/config/config.legacy-config-detection.rejects-routing-allowfrom.e2e.test.ts
+++ b/src/config/config.legacy-config-detection.rejects-routing-allowfrom.e2e.test.ts
@@ -374,11 +374,11 @@ describe("legacy config detection", () => {
       expect(res.config.channels?.telegram?.groupPolicy).toBe("allowlist");
     }
   });
-  it("defaults telegram.streamMode to partial when telegram section exists", async () => {
+  it("defaults telegram.streamMode to undefined (runtime default handles partial) when telegram section exists", async () => {
     const res = validateConfigObject({ channels: { telegram: {} } });
     expect(res.ok).toBe(true);
     if (res.ok) {
-      expect(res.config.channels?.telegram?.streamMode).toBe("partial");
+      expect(res.config.channels?.telegram?.streamMode).toBeUndefined();
     }
   });
   it('rejects whatsapp.dmPolicy="open" without allowFrom "*"', async () => {

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -114,7 +114,7 @@ export const TelegramAccountSchemaBase = z
     blockStreaming: z.boolean().optional(),
     draftChunk: BlockStreamingChunkSchema.optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
-    streamMode: z.enum(["off", "partial", "block"]).optional().default("partial"),
+    streamMode: z.enum(["off", "partial", "block"]).optional(),
     mediaMaxMb: z.number().positive().optional(),
     timeoutSeconds: z.number().int().positive().optional(),
     retry: RetryConfigSchema,


### PR DESCRIPTION
Fixes #17871. Removing default 'partial' from schema allows explicit 'off' to persist.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a bug where setting `streamMode: "off"` in Telegram config would not persist because Zod's `.default("partial")` on the schema field overwrote the explicit `"off"` value during config re-parsing/validation. The fix removes the schema-level default and relies on the existing runtime fallback in `resolveTelegramStreamMode()` (`src/telegram/bot/helpers.ts:157-164`), which already returns `"partial"` when `streamMode` is `undefined`.

- Removed `.default("partial")` from `streamMode` in `TelegramAccountSchemaBase` so explicit `"off"` values survive round-trip validation
- Updated the e2e test to expect `undefined` instead of `"partial"` for the schema-level default, reflecting the new behavior

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, well-scoped fix with correct runtime fallback coverage.
- The change is a single-line schema fix with matching test update. The runtime fallback in `resolveTelegramStreamMode()` already handles `undefined` by returning `"partial"`, so there is no behavioral regression for users who don't set `streamMode`. All `streamMode` consumers go through this resolver function, and the fix directly addresses the reported bug (#17871).
- No files require special attention.

<sub>Last reviewed commit: 74c2b23</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->