### PR TITLE
fix(telegram): prevent non-abort slash commands from racing chat replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Docs: https://docs.openclaw.ai
 - Telegram: retry inbound media `getFile` calls (3 attempts with backoff) and gracefully fall back to placeholder-only processing when retries fail, preventing dropped voice/media messages on transient Telegram network errors. (#16154) Thanks @yinghaosang.
 - Telegram: finalize streaming preview replies in place instead of sending a second final message, preventing duplicate Telegram assistant outputs at stream completion. (#17218) Thanks @obviyus.
 - Telegram: disable block streaming when `channels.telegram.streamMode` is `off`, preventing newline/content-block replies from splitting into multiple messages. (#17679) Thanks @saivarunk.
+- Telegram: route non-abort slash commands on the normal chat/topic sequential lane while keeping true abort requests (`/stop`, `stop`) on the control lane, preventing command/reply race conditions from control-lane bypass. (#17899) Thanks @obviyus.
 - Discord: preserve channel session continuity when runtime payloads omit `message.channelId` by falling back to event/raw `channel_id` values for routing/session keys, so same-channel messages keep history across turns/restarts. Also align diagnostics so active Discord runs no longer appear as `sessionKey=unknown`. (#17622) Thanks @shakkernerd.
 - Discord: dedupe native skill commands by skill name in multi-agent setups to prevent duplicated slash commands with `_2` suffixes. (#17365) Thanks @seewhyme.
 - Discord: ensure role allowlist matching uses raw role IDs for message routing authorization. Thanks @xinhuagu.

--- a/src/auto-reply/reply/abort.test.ts
+++ b/src/auto-reply/reply/abort.test.ts
@@ -6,6 +6,7 @@ import type { OpenClawConfig } from "../../config/config.js";
 import {
   getAbortMemory,
   getAbortMemorySizeForTest,
+  isAbortRequestText,
   isAbortTrigger,
   resetAbortMemoryForTest,
   setAbortMemory,
@@ -73,6 +74,17 @@ describe("abort detection", () => {
     expect(isAbortTrigger("hello")).toBe(false);
     // /stop is NOT matched by isAbortTrigger - it's handled separately
     expect(isAbortTrigger("/stop")).toBe(false);
+  });
+
+  it("isAbortRequestText aligns abort command semantics", () => {
+    expect(isAbortRequestText("/stop")).toBe(true);
+    expect(isAbortRequestText("stop")).toBe(true);
+    expect(isAbortRequestText("/stop@openclaw_bot", { botUsername: "openclaw_bot" })).toBe(true);
+
+    expect(isAbortRequestText("/status")).toBe(false);
+    expect(isAbortRequestText("stop please")).toBe(false);
+    expect(isAbortRequestText("/abort")).toBe(false);
+    expect(isAbortRequestText("/abort now")).toBe(false);
   });
 
   it("removes abort memory entry when flag is reset", () => {

--- a/src/auto-reply/reply/abort.ts
+++ b/src/auto-reply/reply/abort.ts
@@ -19,7 +19,7 @@ import {
 import { logVerbose } from "../../globals.js";
 import { parseAgentSessionKey } from "../../routing/session-key.js";
 import { resolveCommandAuthorization } from "../command-auth.js";
-import { normalizeCommandBody } from "../commands-registry.js";
+import { normalizeCommandBody, type CommandNormalizeOptions } from "../commands-registry.js";
 import { stripMentions, stripStructuralPrefixes } from "./mentions.js";
 import { clearSessionQueues } from "./queue.js";
 
@@ -33,6 +33,17 @@ export function isAbortTrigger(text?: string): boolean {
   }
   const normalized = text.trim().toLowerCase();
   return ABORT_TRIGGERS.has(normalized);
+}
+
+export function isAbortRequestText(text?: string, options?: CommandNormalizeOptions): boolean {
+  if (!text) {
+    return false;
+  }
+  const normalized = normalizeCommandBody(text, options).trim();
+  if (!normalized) {
+    return false;
+  }
+  return normalized.toLowerCase() === "/stop" || isAbortTrigger(normalized);
 }
 
 export function getAbortMemory(key: string): boolean | undefined {
@@ -202,8 +213,7 @@ export async function tryFastAbortFromMessage(params: {
   const raw = stripStructuralPrefixes(ctx.CommandBody ?? ctx.RawBody ?? ctx.Body ?? "");
   const isGroup = ctx.ChatType?.trim().toLowerCase() === "group";
   const stripped = isGroup ? stripMentions(raw, ctx, cfg, agentId) : raw;
-  const normalized = normalizeCommandBody(stripped);
-  const abortRequested = normalized === "/stop" || isAbortTrigger(stripped);
+  const abortRequested = isAbortRequestText(stripped);
   if (!abortRequested) {
     return { handled: false, aborted: false };
   }

--- a/src/telegram/bot.create-telegram-bot.test.ts
+++ b/src/telegram/bot.create-telegram-bot.test.ts
@@ -145,6 +145,21 @@ describe("createTelegramBot", () => {
         message: { chat: { id: 123 }, text: "stop" },
       }),
     ).toBe("telegram:123:control");
+    expect(
+      getTelegramSequentialKey({
+        message: { chat: { id: 123 }, text: "stop please" },
+      }),
+    ).toBe("telegram:123");
+    expect(
+      getTelegramSequentialKey({
+        message: { chat: { id: 123 }, text: "/abort" },
+      }),
+    ).toBe("telegram:123");
+    expect(
+      getTelegramSequentialKey({
+        message: { chat: { id: 123 }, text: "/abort now" },
+      }),
+    ).toBe("telegram:123");
   });
   it("routes callback_query payloads as messages and answers callbacks", async () => {
     onSpy.mockReset();

--- a/src/telegram/bot.create-telegram-bot.test.ts
+++ b/src/telegram/bot.create-telegram-bot.test.ts
@@ -139,7 +139,7 @@ describe("createTelegramBot", () => {
       getTelegramSequentialKey({
         message: { chat: { id: 123 }, text: "/status" },
       }),
-    ).toBe("telegram:123:control");
+    ).toBe("telegram:123");
     expect(
       getTelegramSequentialKey({
         message: { chat: { id: 123 }, text: "stop" },

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -7,7 +7,8 @@ import type { OpenClawConfig, ReplyToMode } from "../config/config.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { resolveTextChunkLimit } from "../auto-reply/chunk.js";
-import { isControlCommandMessage } from "../auto-reply/command-detection.js";
+import { normalizeCommandBody } from "../auto-reply/commands-registry.js";
+import { isAbortTrigger } from "../auto-reply/reply/abort.js";
 import { DEFAULT_GROUP_HISTORY_LIMIT, type HistoryEntry } from "../auto-reply/reply/history.js";
 import {
   isNativeCommandsExplicitlyDisabled,
@@ -44,6 +45,22 @@ import {
 } from "./bot/helpers.js";
 import { resolveTelegramFetch } from "./fetch.js";
 import { wasSentByBot } from "./sent-message-cache.js";
+
+function isAbortControlMessage(rawText?: string, botUsername?: string): boolean {
+  if (!rawText) {
+    return false;
+  }
+  const normalized = normalizeCommandBody(
+    rawText,
+    botUsername ? { botUsername } : undefined,
+  ).toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+  const firstToken = normalized.split(/\s+/, 1)[0] ?? "";
+  const command = firstToken.startsWith("/") ? firstToken.slice(1) : firstToken;
+  return isAbortTrigger(command);
+}
 
 export type TelegramBotOptions = {
   token: string;
@@ -90,10 +107,7 @@ export function getTelegramSequentialKey(ctx: {
   const chatId = msg?.chat?.id ?? ctx.chat?.id;
   const rawText = msg?.text ?? msg?.caption;
   const botUsername = ctx.me?.username;
-  if (
-    rawText &&
-    isControlCommandMessage(rawText, undefined, botUsername ? { botUsername } : undefined)
-  ) {
+  if (isAbortControlMessage(rawText, botUsername)) {
     if (typeof chatId === "number") {
       return `telegram:${chatId}:control`;
     }


### PR DESCRIPTION
## Summary
- narrow Telegram control-lane sequentialization to abort-style commands only
- keep non-abort slash commands (`/status`, `/model`, `/queue`, etc.) on the normal chat/topic lane
- update sequential key test expectation for `/status`

## Root cause
`getTelegramSequentialKey` routed all control commands to `telegram:<chat>:control`, which let non-abort slash commands execute concurrently with in-flight normal message handling. That race could preempt/lose queued follow-up processing from the first run.

## Validation
- `pnpm test src/telegram/bot.create-telegram-bot.test.ts`
- `pnpm test src/telegram/bot.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Narrowed Telegram control-lane sequentialization to abort-style commands only (`stop`, `abort`, `exit`, `wait`, `interrupt`, `esc`), while non-abort slash commands like `/status`, `/model`, `/queue` now execute on the normal chat/topic lane. This prevents non-abort commands from executing concurrently with in-flight message handling, which could cause race conditions and preempt queued follow-up processing.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is well-focused and addresses a specific race condition. The implementation correctly identifies abort commands using the existing `isAbortTrigger` function and properly normalizes command bodies. Tests are updated to match the new behavior. The logic is straightforward and the changes are minimal.
- No files require special attention

<sub>Last reviewed commit: e629902</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->