### PR TITLE
refactor(security): extract shared normalizeAllowFromList into audit-helpers

### DIFF
--- a/src/security/audit-channel.ts
+++ b/src/security/audit-channel.ts
@@ -10,13 +10,7 @@ import {
 import { formatCliCommand } from "../cli/command-format.js";
 import { resolveNativeCommandsEnabled, resolveNativeSkillsEnabled } from "../config/commands.js";
 import { readChannelAllowFromStore } from "../pairing/pairing-store.js";
-
-function normalizeAllowFromList(list: Array<string | number> | undefined | null): string[] {
-  if (!Array.isArray(list)) {
-    return [];
-  }
-  return list.map((v) => String(v).trim()).filter(Boolean);
-}
+import { normalizeAllowFromList } from "./audit-helpers.js";
 
 function classifyChannelWarningSeverity(message: string): SecurityAuditSeverity {
   const s = message.toLowerCase();

--- a/src/security/audit-helpers.test.ts
+++ b/src/security/audit-helpers.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { normalizeAllowFromList } from "./audit-helpers.js";
+
+describe("normalizeAllowFromList", () => {
+  it("returns empty array for undefined", () => {
+    expect(normalizeAllowFromList(undefined)).toEqual([]);
+  });
+
+  it("returns empty array for null", () => {
+    expect(normalizeAllowFromList(null)).toEqual([]);
+  });
+
+  it("returns empty array for non-array value", () => {
+    expect(normalizeAllowFromList("not-an-array" as unknown as string[])).toEqual([]);
+  });
+
+  it("coerces numbers to strings", () => {
+    expect(normalizeAllowFromList([123, 456])).toEqual(["123", "456"]);
+  });
+
+  it("trims whitespace", () => {
+    expect(normalizeAllowFromList(["  alice ", " bob"])).toEqual(["alice", "bob"]);
+  });
+
+  it("filters empty strings after trim", () => {
+    expect(normalizeAllowFromList(["alice", "", "  ", "bob"])).toEqual(["alice", "bob"]);
+  });
+
+  it("handles mixed string and number entries", () => {
+    expect(normalizeAllowFromList(["*", 12345, "user@example.com"])).toEqual([
+      "*",
+      "12345",
+      "user@example.com",
+    ]);
+  });
+});

--- a/src/security/audit-helpers.ts
+++ b/src/security/audit-helpers.ts
@@ -1,0 +1,6 @@
+export function normalizeAllowFromList(list: Array<string | number> | undefined | null): string[] {
+  if (!Array.isArray(list)) {
+    return [];
+  }
+  return list.map((v) => String(v).trim()).filter(Boolean);
+}

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -35,6 +35,7 @@ import {
   formatPermissionRemediation,
   inspectPathPermissions,
 } from "./audit-fs.js";
+import { normalizeAllowFromList } from "./audit-helpers.js";
 import { DEFAULT_GATEWAY_HTTP_TOOL_DENY } from "./dangerous-tools.js";
 
 export type SecurityAuditSeverity = "info" | "warn" | "critical";
@@ -103,13 +104,6 @@ function countBySeverity(findings: SecurityAuditFinding[]): SecurityAuditSummary
     }
   }
   return { critical, warn, info };
-}
-
-function normalizeAllowFromList(list: Array<string | number> | undefined | null): string[] {
-  if (!Array.isArray(list)) {
-    return [];
-  }
-  return list.map((v) => String(v).trim()).filter(Boolean);
 }
 
 async function collectFilesystemFindings(params: {


### PR DESCRIPTION
## Summary

- Problem: `normalizeAllowFromList` was duplicated identically in `src/security/audit.ts` and `src/security/audit-channel.ts`
- Why it matters: Duplicated logic risks divergence during future edits — one copy could be updated while the other is missed
- What changed: Extracted the shared function into a new `src/security/audit-helpers.ts` module; both files now import from it. Added 7 unit tests for the extracted function.
- What did NOT change (scope boundary): No behavioral changes. The `normalizeAllowFromList` in `pairing-store.ts` (different signature, different purpose) is NOT touched.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #17770, #17793, #17865, #17878, #17887, #17897 (prior refactor PRs in the same series)

## User-visible / Behavior Changes

None

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS (darwin)
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. `corepack pnpm tsgo` — zero errors
2. `corepack pnpm build` — succeeds
3. `corepack pnpm vitest run src/security/audit-helpers.test.ts src/security/audit.test.ts` — 73 tests pass (7 new + 66 existing)

### Expected

- Type check, build, and all security audit tests pass with no changes in behavior

### Actual

- All pass

## Evidence

- [x] Failing test/log before + passing after — 7 new unit tests for `normalizeAllowFromList` cover: undefined, null, non-array, numeric coercion, whitespace trimming, empty-string filtering, mixed entries
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `tsgo` clean, `build` succeeds, 73 tests pass (audit + audit-helpers)
- Edge cases checked: Circular dependency avoidance (audit.ts imports audit-channel.ts; both now import from audit-helpers.ts — no cycle)
- What you did **not** verify: Runtime gateway behavior (refactor only, no logic change)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit, inline the function back into both files
- Files/config to restore: `src/security/audit.ts`, `src/security/audit-channel.ts`
- Known bad symptoms reviewers should watch for: Import resolution errors in `audit-helpers.js`

## Risks and Mitigations

None — pure extraction of identical code with no behavioral change.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extracted identical `normalizeAllowFromList` function from `audit.ts` and `audit-channel.ts` into new shared module `audit-helpers.ts`. Both files now import from the helper module, eliminating duplication. Added 7 comprehensive unit tests covering undefined/null inputs, type coercion, whitespace handling, and edge cases. No behavioral changes—pure refactor to prevent future divergence.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Perfect refactor: extracted byte-for-byte identical duplicated function into shared module with no logic changes, no circular dependencies (audit-channel.ts only imports types from audit.ts), comprehensive test coverage (7 tests), and verified import structure is clean
- No files require special attention

<sub>Last reviewed commit: 79de6cd</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->