### PR TITLE
cron: separate webhook POST delivery from announce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 - Subagents: nested sub-agents (sub-sub-agents) with configurable depth. Set `agents.defaults.subagents.maxSpawnDepth: 2` to allow sub-agents to spawn their own children. Includes `maxChildrenPerAgent` limit (default 5), depth-aware tool policy, and proper announce chain routing. (#14447) Thanks @tyler6204.
 - Slack/Discord/Telegram: add per-channel ack reaction overrides (account/channel-level) to support platform-specific emoji formats. (#17092) Thanks @zerone0x.
 - Cron/Gateway: add finished-run webhook delivery toggle (`notify`) and dedicated webhook auth token support (`cron.webhookToken`) for outbound cron webhook posts. (#14535) Thanks @advaitpaliwal.
+- Cron/Gateway: separate per-job webhook delivery (`delivery.mode = "webhook"`) from announce delivery, enforce valid HTTP(S) webhook URLs, and keep a temporary legacy `notify + cron.webhook` fallback for stored jobs. (#17901) Thanks @advaitpaliwal.
 - Channels: deduplicate probe/token resolution base types across core + extensions while preserving per-channel error typing. (#16986) Thanks @iyoda and @thewilloftheshadow.
 
 ### Fixes

--- a/apps/macos/Sources/OpenClaw/CronModels.swift
+++ b/apps/macos/Sources/OpenClaw/CronModels.swift
@@ -21,6 +21,7 @@ enum CronWakeMode: String, CaseIterable, Identifiable, Codable {
 enum CronDeliveryMode: String, CaseIterable, Identifiable, Codable {
     case none
     case announce
+    case webhook
 
     var id: String {
         self.rawValue

--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2087,7 +2087,6 @@ public struct CronJob: Codable, Sendable {
     public let name: String
     public let description: String?
     public let enabled: Bool
-    public let notify: Bool?
     public let deleteafterrun: Bool?
     public let createdatms: Int
     public let updatedatms: Int
@@ -2095,7 +2094,7 @@ public struct CronJob: Codable, Sendable {
     public let sessiontarget: AnyCodable
     public let wakemode: AnyCodable
     public let payload: AnyCodable
-    public let delivery: [String: AnyCodable]?
+    public let delivery: AnyCodable?
     public let state: [String: AnyCodable]
 
     public init(
@@ -2104,7 +2103,6 @@ public struct CronJob: Codable, Sendable {
         name: String,
         description: String?,
         enabled: Bool,
-        notify: Bool?,
         deleteafterrun: Bool?,
         createdatms: Int,
         updatedatms: Int,
@@ -2112,7 +2110,7 @@ public struct CronJob: Codable, Sendable {
         sessiontarget: AnyCodable,
         wakemode: AnyCodable,
         payload: AnyCodable,
-        delivery: [String: AnyCodable]?,
+        delivery: AnyCodable?,
         state: [String: AnyCodable]
     ) {
         self.id = id
@@ -2120,7 +2118,6 @@ public struct CronJob: Codable, Sendable {
         self.name = name
         self.description = description
         self.enabled = enabled
-        self.notify = notify
         self.deleteafterrun = deleteafterrun
         self.createdatms = createdatms
         self.updatedatms = updatedatms
@@ -2137,7 +2134,6 @@ public struct CronJob: Codable, Sendable {
         case name
         case description
         case enabled
-        case notify
         case deleteafterrun = "deleteAfterRun"
         case createdatms = "createdAtMs"
         case updatedatms = "updatedAtMs"
@@ -2171,32 +2167,29 @@ public struct CronAddParams: Codable, Sendable {
     public let agentid: AnyCodable?
     public let description: String?
     public let enabled: Bool?
-    public let notify: Bool?
     public let deleteafterrun: Bool?
     public let schedule: AnyCodable
     public let sessiontarget: AnyCodable
     public let wakemode: AnyCodable
     public let payload: AnyCodable
-    public let delivery: [String: AnyCodable]?
+    public let delivery: AnyCodable?
 
     public init(
         name: String,
         agentid: AnyCodable?,
         description: String?,
         enabled: Bool?,
-        notify: Bool?,
         deleteafterrun: Bool?,
         schedule: AnyCodable,
         sessiontarget: AnyCodable,
         wakemode: AnyCodable,
         payload: AnyCodable,
-        delivery: [String: AnyCodable]?
+        delivery: AnyCodable?
     ) {
         self.name = name
         self.agentid = agentid
         self.description = description
         self.enabled = enabled
-        self.notify = notify
         self.deleteafterrun = deleteafterrun
         self.schedule = schedule
         self.sessiontarget = sessiontarget
@@ -2209,7 +2202,6 @@ public struct CronAddParams: Codable, Sendable {
         case agentid = "agentId"
         case description
         case enabled
-        case notify
         case deleteafterrun = "deleteAfterRun"
         case schedule
         case sessiontarget = "sessionTarget"

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2087,7 +2087,6 @@ public struct CronJob: Codable, Sendable {
     public let name: String
     public let description: String?
     public let enabled: Bool
-    public let notify: Bool?
     public let deleteafterrun: Bool?
     public let createdatms: Int
     public let updatedatms: Int
@@ -2095,7 +2094,7 @@ public struct CronJob: Codable, Sendable {
     public let sessiontarget: AnyCodable
     public let wakemode: AnyCodable
     public let payload: AnyCodable
-    public let delivery: [String: AnyCodable]?
+    public let delivery: AnyCodable?
     public let state: [String: AnyCodable]
 
     public init(
@@ -2104,7 +2103,6 @@ public struct CronJob: Codable, Sendable {
         name: String,
         description: String?,
         enabled: Bool,
-        notify: Bool?,
         deleteafterrun: Bool?,
         createdatms: Int,
         updatedatms: Int,
@@ -2112,7 +2110,7 @@ public struct CronJob: Codable, Sendable {
         sessiontarget: AnyCodable,
         wakemode: AnyCodable,
         payload: AnyCodable,
-        delivery: [String: AnyCodable]?,
+        delivery: AnyCodable?,
         state: [String: AnyCodable]
     ) {
         self.id = id
@@ -2120,7 +2118,6 @@ public struct CronJob: Codable, Sendable {
         self.name = name
         self.description = description
         self.enabled = enabled
-        self.notify = notify
         self.deleteafterrun = deleteafterrun
         self.createdatms = createdatms
         self.updatedatms = updatedatms
@@ -2137,7 +2134,6 @@ public struct CronJob: Codable, Sendable {
         case name
         case description
         case enabled
-        case notify
         case deleteafterrun = "deleteAfterRun"
         case createdatms = "createdAtMs"
         case updatedatms = "updatedAtMs"
@@ -2171,32 +2167,29 @@ public struct CronAddParams: Codable, Sendable {
     public let agentid: AnyCodable?
     public let description: String?
     public let enabled: Bool?
-    public let notify: Bool?
     public let deleteafterrun: Bool?
     public let schedule: AnyCodable
     public let sessiontarget: AnyCodable
     public let wakemode: AnyCodable
     public let payload: AnyCodable
-    public let delivery: [String: AnyCodable]?
+    public let delivery: AnyCodable?
 
     public init(
         name: String,
         agentid: AnyCodable?,
         description: String?,
         enabled: Bool?,
-        notify: Bool?,
         deleteafterrun: Bool?,
         schedule: AnyCodable,
         sessiontarget: AnyCodable,
         wakemode: AnyCodable,
         payload: AnyCodable,
-        delivery: [String: AnyCodable]?
+        delivery: AnyCodable?
     ) {
         self.name = name
         self.agentid = agentid
         self.description = description
         self.enabled = enabled
-        self.notify = notify
         self.deleteafterrun = deleteafterrun
         self.schedule = schedule
         self.sessiontarget = sessiontarget
@@ -2209,7 +2202,6 @@ public struct CronAddParams: Codable, Sendable {
         case agentid = "agentId"
         case description
         case enabled
-        case notify
         case deleteafterrun = "deleteAfterRun"
         case schedule
         case sessiontarget = "sessionTarget"

--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -28,6 +28,7 @@ Troubleshooting: [/automation/troubleshooting](/automation/troubleshooting)
   - **Isolated**: run a dedicated agent turn in `cron:<jobId>`, with delivery (announce by default or none).
 - Wakeups are first-class: a job can request “wake now” vs “next heartbeat”.
 - Webhook posting is per job via `delivery.mode = "webhook"` + `delivery.to = "<url>"`.
+- Legacy fallback remains for stored jobs with `notify: true` when `cron.webhook` is set, migrate those jobs to webhook delivery mode.
 
 ## Quick start (actionable)
 
@@ -200,10 +201,11 @@ When `delivery.mode = "webhook"`, cron posts the finished event payload to `deli
 
 Behavior details:
 
-- The endpoint must be an HTTP(S) URL.
+- The endpoint must be a valid HTTP(S) URL.
 - No channel delivery is attempted in webhook mode.
 - No main-session summary is posted in webhook mode.
 - If `cron.webhookToken` is set, auth header is `Authorization: Bearer <cron.webhookToken>`.
+- Deprecated fallback: stored legacy jobs with `notify: true` still post to `cron.webhook` (if configured), with a warning so you can migrate to `delivery.mode = "webhook"`.
 
 ### Model and thinking overrides
 
@@ -347,6 +349,7 @@ Notes:
     enabled: true, // default true
     store: "~/.openclaw/cron/jobs.json",
     maxConcurrentRuns: 1, // default 1
+    webhook: "https://example.invalid/legacy", // deprecated fallback for stored notify:true jobs
     webhookToken: "replace-with-dedicated-webhook-token", // optional bearer token for webhook mode
   },
 }
@@ -355,9 +358,11 @@ Notes:
 Webhook behavior:
 
 - Preferred: set `delivery.mode: "webhook"` with `delivery.to: "https://..."` per job.
+- Webhook URLs must be valid `http://` or `https://` URLs.
 - Payload is the cron finished event JSON.
 - If `cron.webhookToken` is set, auth header is `Authorization: Bearer <cron.webhookToken>`.
 - If `cron.webhookToken` is not set, no `Authorization` header is sent.
+- Deprecated fallback: stored legacy jobs with `notify: true` still use `cron.webhook` when present.
 
 Disable cron entirely:
 

--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -27,7 +27,7 @@ Troubleshooting: [/automation/troubleshooting](/automation/troubleshooting)
   - **Main session**: enqueue a system event, then run on the next heartbeat.
   - **Isolated**: run a dedicated agent turn in `cron:<jobId>`, with delivery (announce by default or none).
 - Wakeups are first-class: a job can request “wake now” vs “next heartbeat”.
-- Webhook posting is opt-in per job: set `notify: true` and configure `cron.webhook`.
+- Webhook posting is per job via `delivery.mode = "webhook"` + `delivery.to = "<url>"`.
 
 ## Quick start (actionable)
 
@@ -100,7 +100,7 @@ A cron job is a stored record with:
 
 - a **schedule** (when it should run),
 - a **payload** (what it should do),
-- optional **delivery mode** (announce or none).
+- optional **delivery mode** (`announce`, `webhook`, or `none`).
 - optional **agent binding** (`agentId`): run the job under a specific agent; if
   missing or unknown, the gateway falls back to the default agent.
 
@@ -141,8 +141,9 @@ Key behaviors:
 - Prompt is prefixed with `[cron:<jobId> <job name>]` for traceability.
 - Each run starts a **fresh session id** (no prior conversation carry-over).
 - Default behavior: if `delivery` is omitted, isolated jobs announce a summary (`delivery.mode = "announce"`).
-- `delivery.mode` (isolated-only) chooses what happens:
+- `delivery.mode` chooses what happens:
   - `announce`: deliver a summary to the target channel and post a brief summary to the main session.
+  - `webhook`: POST the finished event payload to `delivery.to`.
   - `none`: internal only (no delivery, no main-session summary).
 - `wakeMode` controls when the main-session summary posts:
   - `now`: immediate heartbeat.
@@ -164,11 +165,11 @@ Common `agentTurn` fields:
 - `model` / `thinking`: optional overrides (see below).
 - `timeoutSeconds`: optional timeout override.
 
-Delivery config (isolated jobs only):
+Delivery config:
 
-- `delivery.mode`: `none` | `announce`.
+- `delivery.mode`: `none` | `announce` | `webhook`.
 - `delivery.channel`: `last` or a specific channel.
-- `delivery.to`: channel-specific target (phone/chat/channel id).
+- `delivery.to`: channel-specific target (announce) or webhook URL (webhook mode).
 - `delivery.bestEffort`: avoid failing the job if announce delivery fails.
 
 Announce delivery suppresses messaging tool sends for the run; use `delivery.channel`/`delivery.to`
@@ -193,6 +194,17 @@ Behavior details:
 - The main-session summary respects `wakeMode`: `now` triggers an immediate heartbeat and
   `next-heartbeat` waits for the next scheduled heartbeat.
 
+#### Webhook delivery flow
+
+When `delivery.mode = "webhook"`, cron posts the finished event payload to `delivery.to`.
+
+Behavior details:
+
+- The endpoint must be an HTTP(S) URL.
+- No channel delivery is attempted in webhook mode.
+- No main-session summary is posted in webhook mode.
+- If `cron.webhookToken` is set, auth header is `Authorization: Bearer <cron.webhookToken>`.
+
 ### Model and thinking overrides
 
 Isolated jobs (`agentTurn`) can override the model and thinking level:
@@ -214,11 +226,12 @@ Resolution priority:
 
 Isolated jobs can deliver output to a channel via the top-level `delivery` config:
 
-- `delivery.mode`: `announce` (deliver a summary) or `none`.
+- `delivery.mode`: `announce` (channel delivery), `webhook` (HTTP POST), or `none`.
 - `delivery.channel`: `whatsapp` / `telegram` / `discord` / `slack` / `mattermost` (plugin) / `signal` / `imessage` / `last`.
 - `delivery.to`: channel-specific recipient target.
 
-Delivery config is only valid for isolated jobs (`sessionTarget: "isolated"`).
+`announce` delivery is only valid for isolated jobs (`sessionTarget: "isolated"`).
+`webhook` delivery is valid for both main and isolated jobs.
 
 If `delivery.channel` or `delivery.to` is omitted, cron can fall back to the main session’s
 “last route” (the last place the agent replied).
@@ -289,7 +302,7 @@ Notes:
 - `schedule.at` accepts ISO 8601 (timezone optional; treated as UTC when omitted).
 - `everyMs` is milliseconds.
 - `sessionTarget` must be `"main"` or `"isolated"` and must match `payload.kind`.
-- Optional fields: `agentId`, `description`, `enabled`, `notify`, `deleteAfterRun` (defaults to true for `at`),
+- Optional fields: `agentId`, `description`, `enabled`, `deleteAfterRun` (defaults to true for `at`),
   `delivery`.
 - `wakeMode` defaults to `"now"` when omitted.
 
@@ -334,18 +347,19 @@ Notes:
     enabled: true, // default true
     store: "~/.openclaw/cron/jobs.json",
     maxConcurrentRuns: 1, // default 1
-    webhook: "https://example.invalid/cron-finished", // optional finished-run webhook endpoint
-    webhookToken: "replace-with-dedicated-webhook-token", // optional, do not reuse gateway auth token
+    webhook: "https://example.invalid/cron-finished", // legacy fallback for old jobs using notify=true
+    webhookToken: "replace-with-dedicated-webhook-token", // optional bearer token for webhook mode
   },
 }
 ```
 
 Webhook behavior:
 
-- The Gateway posts finished run events to `cron.webhook` only when the job has `notify: true`.
+- Preferred: set `delivery.mode: "webhook"` with `delivery.to: "https://..."` per job.
 - Payload is the cron finished event JSON.
 - If `cron.webhookToken` is set, auth header is `Authorization: Bearer <cron.webhookToken>`.
 - If `cron.webhookToken` is not set, no `Authorization` header is sent.
+- `cron.webhook` remains as a legacy fallback only for existing jobs that still have `notify: true`.
 
 Disable cron entirely:
 

--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -347,7 +347,6 @@ Notes:
     enabled: true, // default true
     store: "~/.openclaw/cron/jobs.json",
     maxConcurrentRuns: 1, // default 1
-    webhook: "https://example.invalid/cron-finished", // legacy fallback for old jobs using notify=true
     webhookToken: "replace-with-dedicated-webhook-token", // optional bearer token for webhook mode
   },
 }
@@ -359,7 +358,6 @@ Webhook behavior:
 - Payload is the cron finished event JSON.
 - If `cron.webhookToken` is set, auth header is `Authorization: Bearer <cron.webhookToken>`.
 - If `cron.webhookToken` is not set, no `Authorization` header is sent.
-- `cron.webhook` remains as a legacy fallback only for existing jobs that still have `notify: true`.
 
 Disable cron entirely:
 

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -2320,6 +2320,7 @@ Current builds no longer include the TCP bridge. Nodes connect over the Gateway 
   cron: {
     enabled: true,
     maxConcurrentRuns: 2,
+    webhook: "https://example.invalid/legacy", // deprecated fallback for stored notify:true jobs
     webhookToken: "replace-with-dedicated-token", // optional bearer token for outbound webhook auth
     sessionRetention: "24h", // duration string or false
   },
@@ -2328,6 +2329,7 @@ Current builds no longer include the TCP bridge. Nodes connect over the Gateway 
 
 - `sessionRetention`: how long to keep completed cron sessions before pruning. Default: `24h`.
 - `webhookToken`: bearer token used for cron webhook POST delivery (`delivery.mode = "webhook"`), if omitted no auth header is sent.
+- `webhook`: deprecated legacy fallback webhook URL (http/https) used only for stored jobs that still have `notify: true`.
 
 See [Cron Jobs](/automation/cron-jobs).
 

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -2320,7 +2320,7 @@ Current builds no longer include the TCP bridge. Nodes connect over the Gateway 
   cron: {
     enabled: true,
     maxConcurrentRuns: 2,
-    webhook: "https://example.invalid/cron-finished", // optional, must be http:// or https://
+    webhook: "https://example.invalid/cron-finished", // legacy fallback endpoint for old notify=true jobs
     webhookToken: "replace-with-dedicated-token", // optional bearer token for outbound webhook auth
     sessionRetention: "24h", // duration string or false
   },
@@ -2328,8 +2328,8 @@ Current builds no longer include the TCP bridge. Nodes connect over the Gateway 
 ```
 
 - `sessionRetention`: how long to keep completed cron sessions before pruning. Default: `24h`.
-- `webhook`: finished-run webhook endpoint, only used when the job has `notify: true`.
-- `webhookToken`: dedicated bearer token for webhook auth, if omitted no auth header is sent.
+- `webhook`: legacy fallback endpoint for existing jobs that still use `notify: true`.
+- `webhookToken`: bearer token used for cron webhook POST delivery (`delivery.mode = "webhook"`), if omitted no auth header is sent.
 
 See [Cron Jobs](/automation/cron-jobs).
 

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -2320,7 +2320,6 @@ Current builds no longer include the TCP bridge. Nodes connect over the Gateway 
   cron: {
     enabled: true,
     maxConcurrentRuns: 2,
-    webhook: "https://example.invalid/cron-finished", // legacy fallback endpoint for old notify=true jobs
     webhookToken: "replace-with-dedicated-token", // optional bearer token for outbound webhook auth
     sessionRetention: "24h", // duration string or false
   },
@@ -2328,7 +2327,6 @@ Current builds no longer include the TCP bridge. Nodes connect over the Gateway 
 ```
 
 - `sessionRetention`: how long to keep completed cron sessions before pruning. Default: `24h`.
-- `webhook`: legacy fallback endpoint for existing jobs that still use `notify: true`.
 - `webhookToken`: bearer token used for cron webhook POST delivery (`delivery.mode = "webhook"`), if omitted no auth header is sent.
 
 See [Cron Jobs](/automation/cron-jobs).

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -83,9 +83,10 @@ Cron jobs panel notes:
 
 - For isolated jobs, delivery defaults to announce summary. You can switch to none if you want internal-only runs.
 - Channel/target fields appear when announce is selected.
-- Webhook mode uses `delivery.mode = "webhook"` with `delivery.to` set to the webhook URL.
+- Webhook mode uses `delivery.mode = "webhook"` with `delivery.to` set to a valid HTTP(S) webhook URL.
 - For main-session jobs, webhook and none delivery modes are available.
 - Set `cron.webhookToken` to send a dedicated bearer token, if omitted the webhook is sent without an auth header.
+- Deprecated fallback: stored legacy jobs with `notify: true` can still use `cron.webhook` until migrated.
 
 ## Chat behavior
 

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -83,8 +83,8 @@ Cron jobs panel notes:
 
 - For isolated jobs, delivery defaults to announce summary. You can switch to none if you want internal-only runs.
 - Channel/target fields appear when announce is selected.
-- New job form includes a **Notify webhook** toggle (`notify` on the job).
-- Gateway webhook posting requires both `notify: true` on the job and `cron.webhook` in config.
+- Webhook mode uses `delivery.mode = "webhook"` with `delivery.to` set to the webhook URL.
+- For main-session jobs, webhook and none delivery modes are available.
 - Set `cron.webhookToken` to send a dedicated bearer token, if omitted the webhook is sent without an auth header.
 
 ## Chat behavior

--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -154,15 +154,26 @@ describe("gateway.tools config", () => {
 });
 
 describe("cron webhook schema", () => {
-  it("accepts cron.webhookToken", () => {
+  it("accepts cron.webhookToken and legacy cron.webhook", () => {
     const res = OpenClawSchema.safeParse({
       cron: {
         enabled: true,
+        webhook: "https://example.invalid/legacy-cron-webhook",
         webhookToken: "secret-token",
       },
     });
 
     expect(res.success).toBe(true);
+  });
+
+  it("rejects non-http cron.webhook URLs", () => {
+    const res = OpenClawSchema.safeParse({
+      cron: {
+        webhook: "ftp://example.invalid/legacy-cron-webhook",
+      },
+    });
+
+    expect(res.success).toBe(false);
   });
 });
 

--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -154,26 +154,15 @@ describe("gateway.tools config", () => {
 });
 
 describe("cron webhook schema", () => {
-  it("accepts cron.webhook and cron.webhookToken", () => {
+  it("accepts cron.webhookToken", () => {
     const res = OpenClawSchema.safeParse({
       cron: {
         enabled: true,
-        webhook: "https://example.invalid/cron",
         webhookToken: "secret-token",
       },
     });
 
     expect(res.success).toBe(true);
-  });
-
-  it("rejects non-http(s) cron.webhook URLs", () => {
-    const res = OpenClawSchema.safeParse({
-      cron: {
-        webhook: "ftp://example.invalid/cron",
-      },
-    });
-
-    expect(res.success).toBe(false);
   });
 });
 

--- a/src/config/types.cron.ts
+++ b/src/config/types.cron.ts
@@ -2,6 +2,11 @@ export type CronConfig = {
   enabled?: boolean;
   store?: string;
   maxConcurrentRuns?: number;
+  /**
+   * Deprecated legacy fallback webhook URL used only for stored jobs with notify=true.
+   * Prefer per-job delivery.mode="webhook" with delivery.to.
+   */
+  webhook?: string;
   /** Bearer token for cron webhook POST delivery. */
   webhookToken?: string;
   /**

--- a/src/config/types.cron.ts
+++ b/src/config/types.cron.ts
@@ -2,8 +2,6 @@ export type CronConfig = {
   enabled?: boolean;
   store?: string;
   maxConcurrentRuns?: number;
-  /** Legacy fallback endpoint for older jobs that still use notify=true. */
-  webhook?: string;
   /** Bearer token for cron webhook POST delivery. */
   webhookToken?: string;
   /**

--- a/src/config/types.cron.ts
+++ b/src/config/types.cron.ts
@@ -2,7 +2,9 @@ export type CronConfig = {
   enabled?: boolean;
   store?: string;
   maxConcurrentRuns?: number;
+  /** Legacy fallback endpoint for older jobs that still use notify=true. */
   webhook?: string;
+  /** Bearer token for cron webhook POST delivery. */
   webhookToken?: string;
   /**
    * How long to retain completed cron run sessions before automatic pruning.

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -93,6 +93,14 @@ const MemorySchema = z
   .strict()
   .optional();
 
+const HttpUrlSchema = z
+  .string()
+  .url()
+  .refine((value) => {
+    const protocol = new URL(value).protocol;
+    return protocol === "http:" || protocol === "https:";
+  }, "Expected http:// or https:// URL");
+
 export const OpenClawSchema = z
   .object({
     $schema: z.string().optional(),
@@ -295,6 +303,7 @@ export const OpenClawSchema = z
         enabled: z.boolean().optional(),
         store: z.string().optional(),
         maxConcurrentRuns: z.number().int().positive().optional(),
+        webhook: HttpUrlSchema.optional(),
         webhookToken: z.string().optional().register(sensitive),
         sessionRetention: z.union([z.string(), z.literal(false)]).optional(),
       })

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -93,14 +93,6 @@ const MemorySchema = z
   .strict()
   .optional();
 
-const HttpUrlSchema = z
-  .string()
-  .url()
-  .refine((value) => {
-    const protocol = new URL(value).protocol;
-    return protocol === "http:" || protocol === "https:";
-  }, "Expected http:// or https:// URL");
-
 export const OpenClawSchema = z
   .object({
     $schema: z.string().optional(),
@@ -303,7 +295,6 @@ export const OpenClawSchema = z
         enabled: z.boolean().optional(),
         store: z.string().optional(),
         maxConcurrentRuns: z.number().int().positive().optional(),
-        webhook: HttpUrlSchema.optional(),
         webhookToken: z.string().optional().register(sensitive),
         sessionRetention: z.union([z.string(), z.literal(false)]).optional(),
       })

--- a/src/cron/delivery.test.ts
+++ b/src/cron/delivery.test.ts
@@ -42,4 +42,16 @@ describe("resolveCronDeliveryPlan", () => {
     expect(plan.mode).toBe("none");
     expect(plan.requested).toBe(false);
   });
+
+  it("resolves webhook mode without channel routing", () => {
+    const plan = resolveCronDeliveryPlan(
+      makeJob({
+        delivery: { mode: "webhook", to: "https://example.invalid/cron" },
+      }),
+    );
+    expect(plan.mode).toBe("webhook");
+    expect(plan.requested).toBe(false);
+    expect(plan.channel).toBeUndefined();
+    expect(plan.to).toBe("https://example.invalid/cron");
+  });
 });

--- a/src/cron/delivery.ts
+++ b/src/cron/delivery.ts
@@ -2,7 +2,7 @@ import type { CronDeliveryMode, CronJob, CronMessageChannel } from "./types.js";
 
 export type CronDeliveryPlan = {
   mode: CronDeliveryMode;
-  channel: CronMessageChannel;
+  channel?: CronMessageChannel;
   to?: string;
   source: "delivery" | "payload";
   requested: boolean;
@@ -36,11 +36,13 @@ export function resolveCronDeliveryPlan(job: CronJob): CronDeliveryPlan {
   const mode =
     normalizedMode === "announce"
       ? "announce"
-      : normalizedMode === "none"
-        ? "none"
-        : normalizedMode === "deliver"
-          ? "announce"
-          : undefined;
+      : normalizedMode === "webhook"
+        ? "webhook"
+        : normalizedMode === "none"
+          ? "none"
+          : normalizedMode === "deliver"
+            ? "announce"
+            : undefined;
 
   const payloadChannel = normalizeChannel(payload?.channel);
   const payloadTo = normalizeTo(payload?.to);
@@ -55,7 +57,7 @@ export function resolveCronDeliveryPlan(job: CronJob): CronDeliveryPlan {
     const resolvedMode = mode ?? "announce";
     return {
       mode: resolvedMode,
-      channel,
+      channel: resolvedMode === "announce" ? channel : undefined,
       to,
       source: "delivery",
       requested: resolvedMode === "announce",

--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -163,6 +163,25 @@ describe("normalizeCronJobCreate", () => {
     expect(delivery.to).toBe("7200373102");
   });
 
+  it("normalizes webhook delivery mode and target URL", () => {
+    const normalized = normalizeCronJobCreate({
+      name: "webhook delivery",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "main",
+      wakeMode: "now",
+      payload: { kind: "systemEvent", text: "hello" },
+      delivery: {
+        mode: " WeBhOoK ",
+        to: " https://example.invalid/cron ",
+      },
+    }) as unknown as Record<string, unknown>;
+
+    const delivery = normalized.delivery as Record<string, unknown>;
+    expect(delivery.mode).toBe("webhook");
+    expect(delivery.to).toBe("https://example.invalid/cron");
+  });
+
   it("defaults isolated agentTurn delivery to announce", () => {
     const normalized = normalizeCronJobCreate({
       name: "default-announce",

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -151,7 +151,7 @@ function coerceDelivery(delivery: UnknownRecord) {
     const mode = delivery.mode.trim().toLowerCase();
     if (mode === "deliver") {
       next.mode = "announce";
-    } else if (mode === "announce" || mode === "none") {
+    } else if (mode === "announce" || mode === "none" || mode === "webhook") {
       next.mode = mode;
     } else {
       delete next.mode;

--- a/src/cron/service.get-job.test.ts
+++ b/src/cron/service.get-job.test.ts
@@ -44,42 +44,25 @@ describe("CronService.getJob", () => {
     }
   });
 
-  it("preserves notify on create for true, false, and omitted", async () => {
+  it("preserves webhook delivery on create", async () => {
     const { storePath } = await makeStorePath();
     const cron = createCronService(storePath);
     await cron.start();
 
     try {
-      const notifyTrue = await cron.add({
-        name: "notify-true",
-        enabled: true,
-        notify: true,
-        schedule: { kind: "every", everyMs: 60_000 },
-        sessionTarget: "main",
-        wakeMode: "next-heartbeat",
-        payload: { kind: "systemEvent", text: "ping" },
-      });
-      const notifyFalse = await cron.add({
-        name: "notify-false",
-        enabled: true,
-        notify: false,
-        schedule: { kind: "every", everyMs: 60_000 },
-        sessionTarget: "main",
-        wakeMode: "next-heartbeat",
-        payload: { kind: "systemEvent", text: "ping" },
-      });
-      const notifyOmitted = await cron.add({
-        name: "notify-omitted",
+      const webhookJob = await cron.add({
+        name: "webhook-job",
         enabled: true,
         schedule: { kind: "every", everyMs: 60_000 },
         sessionTarget: "main",
         wakeMode: "next-heartbeat",
         payload: { kind: "systemEvent", text: "ping" },
+        delivery: { mode: "webhook", to: "https://example.invalid/cron" },
       });
-
-      expect(cron.getJob(notifyTrue.id)?.notify).toBe(true);
-      expect(cron.getJob(notifyFalse.id)?.notify).toBe(false);
-      expect(cron.getJob(notifyOmitted.id)?.notify).toBeUndefined();
+      expect(cron.getJob(webhookJob.id)?.delivery).toEqual({
+        mode: "webhook",
+        to: "https://example.invalid/cron",
+      });
     } finally {
       cron.stop();
     }

--- a/src/cron/service.jobs.test.ts
+++ b/src/cron/service.jobs.test.ts
@@ -126,4 +126,28 @@ describe("applyJobPatch", () => {
       bestEffort: undefined,
     });
   });
+
+  it("rejects webhook delivery without a target URL", () => {
+    const now = Date.now();
+    const job: CronJob = {
+      id: "job-webhook-invalid",
+      name: "job-webhook-invalid",
+      enabled: true,
+      createdAtMs: now,
+      updatedAtMs: now,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "main",
+      wakeMode: "now",
+      payload: { kind: "systemEvent", text: "ping" },
+      delivery: { mode: "webhook" },
+      state: {},
+    };
+
+    expect(() => applyJobPatch(job, { enabled: true })).toThrow(
+      "cron webhook delivery requires non-empty delivery.to",
+    );
+    expect(() => applyJobPatch(job, { delivery: { mode: "webhook", to: "" } })).toThrow(
+      "cron webhook delivery requires non-empty delivery.to",
+    );
+  });
 });

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -11,6 +11,7 @@ import type {
 import type { CronServiceState } from "./state.js";
 import { parseAbsoluteTimeMs } from "../parse.js";
 import { computeNextRunAtMs } from "../schedule.js";
+import { normalizeHttpWebhookUrl } from "../webhook-url.js";
 import {
   normalizeOptionalAgentId,
   normalizeOptionalText,
@@ -45,10 +46,11 @@ function assertDeliverySupport(job: Pick<CronJob, "sessionTarget" | "delivery">)
     return;
   }
   if (job.delivery.mode === "webhook") {
-    const target = typeof job.delivery.to === "string" ? job.delivery.to.trim() : "";
+    const target = normalizeHttpWebhookUrl(job.delivery.to);
     if (!target) {
-      throw new Error("cron webhook delivery requires non-empty delivery.to");
+      throw new Error("cron webhook delivery requires delivery.to to be a valid http(s) URL");
     }
+    job.delivery.to = target;
     return;
   }
   if (job.sessionTarget !== "isolated") {

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -45,6 +45,10 @@ function assertDeliverySupport(job: Pick<CronJob, "sessionTarget" | "delivery">)
     return;
   }
   if (job.delivery.mode === "webhook") {
+    const target = typeof job.delivery.to === "string" ? job.delivery.to.trim() : "";
+    if (!target) {
+      throw new Error('cron webhook delivery requires non-empty delivery.to');
+    }
     return;
   }
   if (job.sessionTarget !== "isolated") {

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -47,7 +47,7 @@ function assertDeliverySupport(job: Pick<CronJob, "sessionTarget" | "delivery">)
   if (job.delivery.mode === "webhook") {
     const target = typeof job.delivery.to === "string" ? job.delivery.to.trim() : "";
     if (!target) {
-      throw new Error('cron webhook delivery requires non-empty delivery.to');
+      throw new Error("cron webhook delivery requires non-empty delivery.to");
     }
     return;
   }

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -10,7 +10,7 @@ export type CronWakeMode = "next-heartbeat" | "now";
 
 export type CronMessageChannel = ChannelId | "last";
 
-export type CronDeliveryMode = "none" | "announce";
+export type CronDeliveryMode = "none" | "announce" | "webhook";
 
 export type CronDelivery = {
   mode: CronDeliveryMode;
@@ -71,7 +71,6 @@ export type CronJob = {
   name: string;
   description?: string;
   enabled: boolean;
-  notify?: boolean;
   deleteAfterRun?: boolean;
   createdAtMs: number;
   updatedAtMs: number;

--- a/src/cron/webhook-url.ts
+++ b/src/cron/webhook-url.ts
@@ -1,0 +1,22 @@
+function isAllowedWebhookProtocol(protocol: string) {
+  return protocol === "http:" || protocol === "https:";
+}
+
+export function normalizeHttpWebhookUrl(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+  try {
+    const parsed = new URL(trimmed);
+    if (!isAllowedWebhookProtocol(parsed.protocol)) {
+      return null;
+    }
+    return trimmed;
+  } catch {
+    return null;
+  }
+}

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -67,26 +67,51 @@ export const CronPayloadPatchSchema = Type.Union([
   cronAgentTurnPayloadSchema({ message: Type.Optional(NonEmptyString) }),
 ]);
 
-const CronDeliveryBaseProperties = {
+const CronDeliverySharedProperties = {
   channel: Type.Optional(Type.Union([Type.Literal("last"), NonEmptyString])),
-  to: Type.Optional(Type.String()),
   bestEffort: Type.Optional(Type.Boolean()),
 };
 
-export const CronDeliverySchema = Type.Object(
+const CronDeliveryNoopSchema = Type.Object(
   {
-    mode: Type.Union([Type.Literal("none"), Type.Literal("announce"), Type.Literal("webhook")]),
-    ...CronDeliveryBaseProperties,
+    mode: Type.Literal("none"),
+    ...CronDeliverySharedProperties,
+    to: Type.Optional(Type.String()),
   },
   { additionalProperties: false },
 );
+
+const CronDeliveryAnnounceSchema = Type.Object(
+  {
+    mode: Type.Literal("announce"),
+    ...CronDeliverySharedProperties,
+    to: Type.Optional(Type.String()),
+  },
+  { additionalProperties: false },
+);
+
+const CronDeliveryWebhookSchema = Type.Object(
+  {
+    mode: Type.Literal("webhook"),
+    ...CronDeliverySharedProperties,
+    to: NonEmptyString,
+  },
+  { additionalProperties: false },
+);
+
+export const CronDeliverySchema = Type.Union([
+  CronDeliveryNoopSchema,
+  CronDeliveryAnnounceSchema,
+  CronDeliveryWebhookSchema,
+]);
 
 export const CronDeliveryPatchSchema = Type.Object(
   {
     mode: Type.Optional(
       Type.Union([Type.Literal("none"), Type.Literal("announce"), Type.Literal("webhook")]),
     ),
-    ...CronDeliveryBaseProperties,
+    ...CronDeliverySharedProperties,
+    to: Type.Optional(Type.String()),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -75,7 +75,7 @@ const CronDeliveryBaseProperties = {
 
 export const CronDeliverySchema = Type.Object(
   {
-    mode: Type.Union([Type.Literal("none"), Type.Literal("announce")]),
+    mode: Type.Union([Type.Literal("none"), Type.Literal("announce"), Type.Literal("webhook")]),
     ...CronDeliveryBaseProperties,
   },
   { additionalProperties: false },
@@ -83,7 +83,9 @@ export const CronDeliverySchema = Type.Object(
 
 export const CronDeliveryPatchSchema = Type.Object(
   {
-    mode: Type.Optional(Type.Union([Type.Literal("none"), Type.Literal("announce")])),
+    mode: Type.Optional(
+      Type.Union([Type.Literal("none"), Type.Literal("announce"), Type.Literal("webhook")]),
+    ),
     ...CronDeliveryBaseProperties,
   },
   { additionalProperties: false },
@@ -111,7 +113,6 @@ export const CronJobSchema = Type.Object(
     name: NonEmptyString,
     description: Type.Optional(Type.String()),
     enabled: Type.Boolean(),
-    notify: Type.Optional(Type.Boolean()),
     deleteAfterRun: Type.Optional(Type.Boolean()),
     createdAtMs: Type.Integer({ minimum: 0 }),
     updatedAtMs: Type.Integer({ minimum: 0 }),
@@ -140,7 +141,6 @@ export const CronAddParamsSchema = Type.Object(
     agentId: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
     description: Type.Optional(Type.String()),
     enabled: Type.Optional(Type.Boolean()),
-    notify: Type.Optional(Type.Boolean()),
     deleteAfterRun: Type.Optional(Type.Boolean()),
     schedule: CronScheduleSchema,
     sessionTarget: Type.Union([Type.Literal("main"), Type.Literal("isolated")]),
@@ -157,7 +157,6 @@ export const CronJobPatchSchema = Type.Object(
     agentId: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
     description: Type.Optional(Type.String()),
     enabled: Type.Optional(Type.Boolean()),
-    notify: Type.Optional(Type.Boolean()),
     deleteAfterRun: Type.Optional(Type.Boolean()),
     schedule: Type.Optional(CronScheduleSchema),
     sessionTarget: Type.Optional(Type.Union([Type.Literal("main"), Type.Literal("isolated")])),

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -7,6 +7,7 @@ import { runCronIsolatedAgentTurn } from "../cron/isolated-agent.js";
 import { appendCronRunLog, resolveCronRunLogPath } from "../cron/run-log.js";
 import { CronService } from "../cron/service.js";
 import { resolveCronStorePath } from "../cron/store.js";
+import { normalizeHttpWebhookUrl } from "../cron/webhook-url.js";
 import { runHeartbeatOnce } from "../infra/heartbeat-runner.js";
 import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
@@ -31,14 +32,29 @@ function redactWebhookUrl(url: string): string {
   }
 }
 
+type CronWebhookTarget = {
+  url: string;
+  source: "delivery" | "legacy";
+};
+
 function resolveCronWebhookTarget(params: {
   delivery?: { mode?: string; to?: string };
-}): string | null {
+  legacyNotify?: boolean;
+  legacyWebhook?: string;
+}): CronWebhookTarget | null {
   const mode = params.delivery?.mode?.trim().toLowerCase();
   if (mode === "webhook") {
-    const url = params.delivery?.to?.trim();
-    return url ? url : null;
+    const url = normalizeHttpWebhookUrl(params.delivery?.to);
+    return url ? { url, source: "delivery" } : null;
   }
+
+  if (params.legacyNotify) {
+    const legacyUrl = normalizeHttpWebhookUrl(params.legacyWebhook);
+    if (legacyUrl) {
+      return { url: legacyUrl, source: "legacy" };
+    }
+  }
+
   return null;
 }
 
@@ -72,6 +88,7 @@ export function buildGatewayCronService(params: {
       agentId: agentId ?? defaultAgentId,
     });
   const sessionStorePath = resolveSessionStorePath(defaultAgentId);
+  const warnedLegacyWebhookJobs = new Set<string>();
 
   const cron = new CronService({
     storePath,
@@ -116,14 +133,40 @@ export function buildGatewayCronService(params: {
       params.broadcast("cron", evt, { dropIfSlow: true });
       if (evt.action === "finished") {
         const webhookToken = params.cfg.cron?.webhookToken?.trim();
+        const legacyWebhook = params.cfg.cron?.webhook?.trim();
         const job = cron.getJob(evt.jobId);
-        const webhookUrl = resolveCronWebhookTarget({
+        const legacyNotify = (job as { notify?: unknown } | undefined)?.notify === true;
+        const webhookTarget = resolveCronWebhookTarget({
           delivery:
             job?.delivery && typeof job.delivery.mode === "string"
               ? { mode: job.delivery.mode, to: job.delivery.to }
               : undefined,
+          legacyNotify,
+          legacyWebhook,
         });
-        if (webhookUrl && evt.summary) {
+
+        if (!webhookTarget && job?.delivery?.mode === "webhook") {
+          cronLogger.warn(
+            {
+              jobId: evt.jobId,
+              deliveryTo: job.delivery.to,
+            },
+            "cron: skipped webhook delivery, delivery.to must be a valid http(s) URL",
+          );
+        }
+
+        if (webhookTarget?.source === "legacy" && !warnedLegacyWebhookJobs.has(evt.jobId)) {
+          warnedLegacyWebhookJobs.add(evt.jobId);
+          cronLogger.warn(
+            {
+              jobId: evt.jobId,
+              legacyWebhook: redactWebhookUrl(webhookTarget.url),
+            },
+            "cron: deprecated notify+cron.webhook fallback in use, migrate to delivery.mode=webhook with delivery.to",
+          );
+        }
+
+        if (webhookTarget && evt.summary) {
           const headers: Record<string, string> = {
             "Content-Type": "application/json",
           };
@@ -134,7 +177,7 @@ export function buildGatewayCronService(params: {
           const timeout = setTimeout(() => {
             abortController.abort();
           }, CRON_WEBHOOK_TIMEOUT_MS);
-          void fetch(webhookUrl, {
+          void fetch(webhookTarget.url, {
             method: "POST",
             headers,
             body: JSON.stringify(evt),
@@ -145,7 +188,7 @@ export function buildGatewayCronService(params: {
                 {
                   err: String(err),
                   jobId: evt.jobId,
-                  webhookUrl: redactWebhookUrl(webhookUrl),
+                  webhookUrl: redactWebhookUrl(webhookTarget.url),
                 },
                 "cron: webhook delivery failed",
               );

--- a/ui/src/ui/app-defaults.ts
+++ b/ui/src/ui/app-defaults.ts
@@ -15,7 +15,6 @@ export const DEFAULT_CRON_FORM: CronFormState = {
   description: "",
   agentId: "",
   enabled: true,
-  notify: false,
   scheduleKind: "every",
   scheduleAt: "",
   everyAmount: "30",

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -24,6 +24,7 @@ import {
   runCronJob,
   removeCronJob,
   addCronJob,
+  normalizeCronFormState,
 } from "./controllers/cron.ts";
 import { loadDebug, callDebugMethod } from "./controllers/debug.ts";
 import {
@@ -323,7 +324,8 @@ export function renderApp(state: AppViewState) {
                 channelMeta: state.channelsSnapshot?.channelMeta ?? [],
                 runsJobId: state.cronRunsJobId,
                 runs: state.cronRuns,
-                onFormChange: (patch) => (state.cronForm = { ...state.cronForm, ...patch }),
+                onFormChange: (patch) =>
+                  (state.cronForm = normalizeCronFormState({ ...state.cronForm, ...patch })),
                 onRefresh: () => state.loadCron(),
                 onAdd: () => addCronJob(state),
                 onToggle: (job, enabled) => toggleCronJob(state, job, enabled),

--- a/ui/src/ui/controllers/cron.test.ts
+++ b/ui/src/ui/controllers/cron.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { DEFAULT_CRON_FORM } from "../app-defaults.ts";
-import { addCronJob, type CronState } from "./cron.ts";
+import { addCronJob, normalizeCronFormState, type CronState } from "./cron.ts";
 
 function createState(overrides: Partial<CronState> = {}): CronState {
   return {
@@ -19,6 +19,28 @@ function createState(overrides: Partial<CronState> = {}): CronState {
 }
 
 describe("cron controller", () => {
+  it("normalizes stale announce mode when session/payload no longer support announce", () => {
+    const normalized = normalizeCronFormState({
+      ...DEFAULT_CRON_FORM,
+      sessionTarget: "main",
+      payloadKind: "systemEvent",
+      deliveryMode: "announce",
+    });
+
+    expect(normalized.deliveryMode).toBe("none");
+  });
+
+  it("keeps announce mode when isolated agentTurn supports announce", () => {
+    const normalized = normalizeCronFormState({
+      ...DEFAULT_CRON_FORM,
+      sessionTarget: "isolated",
+      payloadKind: "agentTurn",
+      deliveryMode: "announce",
+    });
+
+    expect(normalized.deliveryMode).toBe("announce");
+  });
+
   it("forwards webhook delivery in cron.add payload", async () => {
     const request = vi.fn(async (method: string, _payload?: unknown) => {
       if (method === "cron.add") {
@@ -60,5 +82,49 @@ describe("cron controller", () => {
       name: "webhook job",
       delivery: { mode: "webhook", to: "https://example.invalid/cron" },
     });
+  });
+
+  it("does not submit stale announce delivery when unsupported", async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "cron.add") {
+        return { id: "job-2" };
+      }
+      if (method === "cron.list") {
+        return { jobs: [] };
+      }
+      if (method === "cron.status") {
+        return { enabled: true, jobs: 0, nextWakeAtMs: null };
+      }
+      return {};
+    });
+
+    const state = createState({
+      client: {
+        request,
+      } as unknown as CronState["client"],
+      cronForm: {
+        ...DEFAULT_CRON_FORM,
+        name: "main job",
+        scheduleKind: "every",
+        everyAmount: "1",
+        everyUnit: "minutes",
+        sessionTarget: "main",
+        wakeMode: "next-heartbeat",
+        payloadKind: "systemEvent",
+        payloadText: "run this",
+        deliveryMode: "announce",
+        deliveryTo: "buddy",
+      },
+    });
+
+    await addCronJob(state);
+
+    const addCall = request.mock.calls.find(([method]) => method === "cron.add");
+    expect(addCall).toBeDefined();
+    expect(addCall?.[1]).toMatchObject({
+      name: "main job",
+    });
+    expect((addCall?.[1] as { delivery?: unknown } | undefined)?.delivery).toBeUndefined();
+    expect(state.cronForm.deliveryMode).toBe("none");
   });
 });

--- a/ui/src/ui/controllers/cron.test.ts
+++ b/ui/src/ui/controllers/cron.test.ts
@@ -19,7 +19,7 @@ function createState(overrides: Partial<CronState> = {}): CronState {
 }
 
 describe("cron controller", () => {
-  it("forwards notify in cron.add payload", async () => {
+  it("forwards webhook delivery in cron.add payload", async () => {
     const request = vi.fn(async (method: string, _payload?: unknown) => {
       if (method === "cron.add") {
         return { id: "job-1" };
@@ -39,15 +39,16 @@ describe("cron controller", () => {
       } as unknown as CronState["client"],
       cronForm: {
         ...DEFAULT_CRON_FORM,
-        name: "notify job",
-        notify: true,
+        name: "webhook job",
         scheduleKind: "every",
         everyAmount: "1",
         everyUnit: "minutes",
-        sessionTarget: "main",
+        sessionTarget: "isolated",
         wakeMode: "next-heartbeat",
-        payloadKind: "systemEvent",
-        payloadText: "ping",
+        payloadKind: "agentTurn",
+        payloadText: "run this",
+        deliveryMode: "webhook",
+        deliveryTo: "https://example.invalid/cron",
       },
     });
 
@@ -56,8 +57,8 @@ describe("cron controller", () => {
     const addCall = request.mock.calls.find(([method]) => method === "cron.add");
     expect(addCall).toBeDefined();
     expect(addCall?.[1]).toMatchObject({
-      notify: true,
-      name: "notify job",
+      name: "webhook job",
+      delivery: { mode: "webhook", to: "https://example.invalid/cron" },
     });
   });
 });

--- a/ui/src/ui/controllers/cron.ts
+++ b/ui/src/ui/controllers/cron.ts
@@ -106,13 +106,20 @@ export async function addCronJob(state: CronState) {
   try {
     const schedule = buildCronSchedule(state.cronForm);
     const payload = buildCronPayload(state.cronForm);
+    const supportsAnnounce =
+      state.cronForm.sessionTarget === "isolated" && state.cronForm.payloadKind === "agentTurn";
+    const selectedDeliveryMode =
+      state.cronForm.deliveryMode === "announce" && !supportsAnnounce
+        ? "none"
+        : state.cronForm.deliveryMode;
     const delivery =
-      state.cronForm.sessionTarget === "isolated" &&
-      state.cronForm.payloadKind === "agentTurn" &&
-      state.cronForm.deliveryMode
+      selectedDeliveryMode && selectedDeliveryMode !== "none"
         ? {
-            mode: state.cronForm.deliveryMode === "announce" ? "announce" : "none",
-            channel: state.cronForm.deliveryChannel.trim() || "last",
+            mode: selectedDeliveryMode,
+            channel:
+              selectedDeliveryMode === "announce"
+                ? state.cronForm.deliveryChannel.trim() || "last"
+                : undefined,
             to: state.cronForm.deliveryTo.trim() || undefined,
           }
         : undefined;
@@ -122,7 +129,6 @@ export async function addCronJob(state: CronState) {
       description: state.cronForm.description.trim() || undefined,
       agentId: agentId || undefined,
       enabled: state.cronForm.enabled,
-      notify: state.cronForm.notify,
       schedule,
       sessionTarget: state.cronForm.sessionTarget,
       wakeMode: state.cronForm.wakeMode,

--- a/ui/src/ui/presenter.ts
+++ b/ui/src/ui/presenter.ts
@@ -71,9 +71,13 @@ export function formatCronPayload(job: CronJob) {
   const delivery = job.delivery;
   if (delivery && delivery.mode !== "none") {
     const target =
-      delivery.channel || delivery.to
-        ? ` (${delivery.channel ?? "last"}${delivery.to ? ` -> ${delivery.to}` : ""})`
-        : "";
+      delivery.mode === "webhook"
+        ? delivery.to
+          ? ` (${delivery.to})`
+          : ""
+        : delivery.channel || delivery.to
+          ? ` (${delivery.channel ?? "last"}${delivery.to ? ` -> ${delivery.to}` : ""})`
+          : "";
     return `${base} · ${delivery.mode}${target}`;
   }
   return base;

--- a/ui/src/ui/types.ts
+++ b/ui/src/ui/types.ts
@@ -452,7 +452,7 @@ export type CronPayload =
     };
 
 export type CronDelivery = {
-  mode: "none" | "announce";
+  mode: "none" | "announce" | "webhook";
   channel?: string;
   to?: string;
   bestEffort?: boolean;
@@ -473,7 +473,6 @@ export type CronJob = {
   name: string;
   description?: string;
   enabled: boolean;
-  notify?: boolean;
   deleteAfterRun?: boolean;
   createdAtMs: number;
   updatedAtMs: number;

--- a/ui/src/ui/ui-types.ts
+++ b/ui/src/ui/ui-types.ts
@@ -19,7 +19,6 @@ export type CronFormState = {
   description: string;
   agentId: string;
   enabled: boolean;
-  notify: boolean;
   scheduleKind: "at" | "every" | "cron";
   scheduleAt: string;
   everyAmount: string;
@@ -30,7 +29,7 @@ export type CronFormState = {
   wakeMode: "next-heartbeat" | "now";
   payloadKind: "systemEvent" | "agentTurn";
   payloadText: string;
-  deliveryMode: "none" | "announce";
+  deliveryMode: "none" | "announce" | "webhook";
   deliveryChannel: string;
   deliveryTo: string;
   timeoutSeconds: string;

--- a/ui/src/ui/views/cron.test.ts
+++ b/ui/src/ui/views/cron.test.ts
@@ -176,6 +176,31 @@ describe("cron view", () => {
     expect(options).toContain("Webhook POST");
   });
 
+  it("normalizes stale announce selection in the form when unsupported", () => {
+    const container = document.createElement("div");
+    render(
+      renderCron(
+        createProps({
+          form: {
+            ...DEFAULT_CRON_FORM,
+            sessionTarget: "main",
+            payloadKind: "systemEvent",
+            deliveryMode: "announce",
+          },
+        }),
+      ),
+      container,
+    );
+
+    const options = Array.from(container.querySelectorAll("option")).map((opt) =>
+      (opt.textContent ?? "").trim(),
+    );
+    expect(options).not.toContain("Announce summary (default)");
+    expect(options).toContain("Webhook POST");
+    expect(options).toContain("None (internal)");
+    expect(container.querySelector('input[placeholder="https://example.invalid/cron"]')).toBeNull();
+  });
+
   it("shows webhook delivery details for jobs", () => {
     const container = document.createElement("div");
     const job = {

--- a/ui/src/ui/views/cron.test.ts
+++ b/ui/src/ui/views/cron.test.ts
@@ -159,37 +159,31 @@ describe("cron view", () => {
     expect(summaries[1]).toBe("older run");
   });
 
-  it("forwards notify checkbox updates from the form", () => {
+  it("shows webhook delivery option in the form", () => {
     const container = document.createElement("div");
-    const onFormChange = vi.fn();
     render(
       renderCron(
         createProps({
-          onFormChange,
+          form: { ...DEFAULT_CRON_FORM, payloadKind: "agentTurn" },
         }),
       ),
       container,
     );
 
-    const notifyLabel = Array.from(container.querySelectorAll("label.field.checkbox")).find(
-      (label) => label.querySelector("span")?.textContent?.trim() === "Notify webhook",
+    const options = Array.from(container.querySelectorAll("option")).map((opt) =>
+      (opt.textContent ?? "").trim(),
     );
-    const notifyInput =
-      notifyLabel?.querySelector<HTMLInputElement>('input[type="checkbox"]') ?? null;
-    expect(notifyInput).not.toBeNull();
-
-    if (!notifyInput) {
-      return;
-    }
-    notifyInput.checked = true;
-    notifyInput.dispatchEvent(new Event("change", { bubbles: true }));
-
-    expect(onFormChange).toHaveBeenCalledWith({ notify: true });
+    expect(options).toContain("Webhook POST");
   });
 
-  it("shows notify chip for webhook-enabled jobs", () => {
+  it("shows webhook delivery details for jobs", () => {
     const container = document.createElement("div");
-    const job = { ...createJob("job-2"), notify: true };
+    const job = {
+      ...createJob("job-2"),
+      sessionTarget: "isolated" as const,
+      payload: { kind: "agentTurn" as const, message: "do it" },
+      delivery: { mode: "webhook" as const, to: "https://example.invalid/cron" },
+    };
     render(
       renderCron(
         createProps({
@@ -199,9 +193,8 @@ describe("cron view", () => {
       container,
     );
 
-    const chips = Array.from(container.querySelectorAll(".chip")).map((el) =>
-      (el.textContent ?? "").trim(),
-    );
-    expect(chips).toContain("notify");
+    expect(container.textContent).toContain("Delivery");
+    expect(container.textContent).toContain("webhook");
+    expect(container.textContent).toContain("https://example.invalid/cron");
   });
 });

--- a/ui/src/ui/views/cron.ts
+++ b/ui/src/ui/views/cron.ts
@@ -60,6 +60,10 @@ export function renderCron(props: CronProps) {
     props.runsJobId == null ? undefined : props.jobs.find((job) => job.id === props.runsJobId);
   const selectedRunTitle = selectedJob?.name ?? props.runsJobId ?? "(select a job)";
   const orderedRuns = props.runs.toSorted((a, b) => b.ts - a.ts);
+  const supportsAnnounce =
+    props.form.sessionTarget === "isolated" && props.form.payloadKind === "agentTurn";
+  const selectedDeliveryMode =
+    props.form.deliveryMode === "announce" && !supportsAnnounce ? "none" : props.form.deliveryMode;
   return html`
     <section class="grid grid-cols-2">
       <div class="card">
@@ -202,7 +206,7 @@ export function renderCron(props: CronProps) {
           <label class="field">
             <span>Delivery</span>
             <select
-              .value=${props.form.deliveryMode}
+              .value=${selectedDeliveryMode}
               @change=${(e: Event) =>
                 props.onFormChange({
                   deliveryMode: (e.target as HTMLSelectElement)
@@ -210,7 +214,7 @@ export function renderCron(props: CronProps) {
                 })}
             >
               ${
-                props.form.sessionTarget === "isolated" && props.form.payloadKind === "agentTurn"
+                supportsAnnounce
                   ? html`
                       <option value="announce">Announce summary (default)</option>
                     `
@@ -237,12 +241,12 @@ export function renderCron(props: CronProps) {
               : nothing
           }
           ${
-            props.form.deliveryMode !== "none"
+            selectedDeliveryMode !== "none"
               ? html`
                   <label class="field">
-                    <span>${props.form.deliveryMode === "webhook" ? "Webhook URL" : "Channel"}</span>
+                    <span>${selectedDeliveryMode === "webhook" ? "Webhook URL" : "Channel"}</span>
                     ${
-                      props.form.deliveryMode === "webhook"
+                      selectedDeliveryMode === "webhook"
                         ? html`
                             <input
                               .value=${props.form.deliveryTo}
@@ -272,7 +276,7 @@ export function renderCron(props: CronProps) {
                     }
                   </label>
                   ${
-                    props.form.deliveryMode === "announce"
+                    selectedDeliveryMode === "announce"
                       ? html`
                           <label class="field">
                             <span>To</span>


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: cron used `notify: true` + global `cron.webhook` for webhook POSTs, while `delivery.mode="announce"` handled channel delivery; this split caused confusion and duplicated concepts.
- Why it matters: webhook POST and channel announce are different transport paths, and users need per-job webhook URLs.
- What changed: added `delivery.mode="webhook"` (with `delivery.to` as URL), removed `notify` from cron job schema/types/UI/tool docs, and kept a legacy fallback for old `notify` jobs via `cron.webhook`.
- What did NOT change (scope boundary): channel announce behavior (`delivery.mode="announce"`) and isolated-run delivery mechanics remain unchanged.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [x] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #15026

## User-visible / Behavior Changes

- Cron jobs now support `delivery.mode: "webhook"` + `delivery.to: "https://..."` for finished-run webhook POST delivery.
- `delivery.mode: "announce"` remains channel delivery only.
- Cron job `notify` is removed from add/update/list contracts and Control UI form.
- `cron.webhook` is now documented/used as a legacy fallback only for older jobs that still contain `notify: true`.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`Yes`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  - Risk: user-provided webhook URL can fail/timeout.
  - Mitigation: existing 10s timeout + error logging remains; `cron.webhookToken` can be used for auth.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): Gateway cron + Control UI
- Relevant config (redacted): optional `cron.webhookToken`

### Steps

1. Create cron job with `delivery.mode="webhook"` and `delivery.to` URL.
2. Force-run the job.
3. Confirm webhook POST payload is emitted only for webhook-mode jobs with summary.

### Expected

- Webhook jobs POST finished event payload to `delivery.to`.
- Non-webhook jobs do not POST.
- Announce mode remains channel delivery behavior.

### Actual

- Matches expected.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - webhook-mode finished POST for main and isolated cron jobs.
  - announce-mode and none-mode behavior unchanged in delivery planner/UI rendering.
  - protocol/UI/Swift delivery mode conformance includes `webhook`.
- Edge cases checked:
  - no-summary run does not POST.
  - legacy notify fallback still posts via `cron.webhook` when present in stored jobs.
- What you did **not** verify:
  - full end-to-end manual webhook receiver outside test mocks.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - set cron job delivery to `none` or remove webhook delivery fields.
  - rollback to previous commit.
- Files/config to restore:
  - `src/cron/*`, `src/gateway/server-cron.ts`, `src/gateway/protocol/schema/cron.ts`, `ui/src/ui/*`.
- Known bad symptoms reviewers should watch for:
  - missing webhook POSTs when `delivery.mode="webhook"` is set.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: existing automation may still set `notify` in add/update payloads.
  - Mitigation: legacy store fallback remains for persisted jobs; docs/UI/tool schema now steer to delivery webhook mode.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Separates webhook POST delivery from channel announce delivery by adding `delivery.mode="webhook"` with `delivery.to` URL support, removing the deprecated `notify` field from the cron job schema, and maintaining backward compatibility for legacy jobs via `cron.webhook` fallback.

Key changes:
- Added `"webhook"` as a new `CronDeliveryMode` alongside `"announce"` and `"none"`
- Webhook mode now explicitly requires `delivery.to` URL instead of relying on global `cron.webhook` + `notify` flag
- Removed `notify` field from protocol schema, UI forms, tool documentation, and type definitions
- Legacy fallback preserved: stored jobs with `notify: true` continue to POST via `cron.webhook` config
- Updated `assertDeliverySupport` to allow webhook mode for both `main` and `isolated` session targets, while restricting `announce` mode to `isolated` only
- Channel routing (`delivery.channel`) correctly excluded for webhook mode
- Documentation and UI updated to reflect webhook as a delivery mode rather than a separate notification mechanism

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor attention to edge case handling
- The refactor is well-structured with comprehensive test coverage, proper backward compatibility via legacy fallback, and clean separation of concerns. The score of 4 (not 5) reflects one edge case: webhook mode with missing URL returns null but doesn't fail fast at job creation time, which could lead to silent failures at runtime.
- Review `src/gateway/server-cron.ts:41-42` for webhook URL validation - consider adding validation at job creation time rather than silently returning null at runtime

<sub>Last reviewed commit: 9c549c6</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->