### PR TITLE
fix: configure git to use HTTPS instead of SSH for GitHub URLs

### DIFF
--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -840,12 +840,22 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
     const channel = opts.channel ?? DEFAULT_PACKAGE_CHANNEL;
     const tag = normalizeTag(opts.tag ?? channelToNpmTag(channel));
     const spec = `${packageName}@${tag}`;
+    // Configure git to use HTTPS instead of SSH for GitHub URLs.
+    // This fixes "Permission denied (publickey)" errors when npm tries to
+    // install packages with git dependencies (e.g., libsignal-node).
+    const gitHttpsEnv: NodeJS.ProcessEnv = {
+      ...process.env,
+      GIT_CONFIG_PARAMETERS:
+        "'url.https://github.com/.insteadOf=git@github.com:' 'url.https://github.com/.insteadOf=ssh://git@github.com/'",
+    };
+
     const updateStep = await runStep({
       runCommand,
       name: "global update",
       argv: globalInstallArgs(globalManager, spec),
       cwd: pkgRoot,
       timeoutMs,
+      env: gitHttpsEnv,
       progress,
       stepIndex: 0,
       totalSteps: 1,


### PR DESCRIPTION
## Summary

When running `openclaw update` on a non-git install (global npm install), packages with git dependencies (like `whiskeysockets/libsignal-node`) were failing with "Permission denied (publickey)" error because npm tried to access them via SSH.

This fix configures git to use HTTPS instead of SSH for GitHub URLs during the global update step by setting the `GIT_CONFIG_PARAMETERS` environment variable.

## Changes

- Modified `src/infra/update-runner.ts` to pass git HTTPS configuration via environment variable when running global npm/pnpm/bun install

## Testing

- All existing tests in `src/infra/update-runner.test.ts` pass (13 tests)
- TypeScript compilation passes
- Code formatting verified

Fixes openclaw/openclaw#17907

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes SSH authentication errors when installing packages with git dependencies during global `openclaw update` by configuring git to use HTTPS instead of SSH for GitHub URLs via the `GIT_CONFIG_PARAMETERS` environment variable.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is minimal, well-scoped, and addresses a specific SSH authentication issue. It only adds environment configuration for the global update step without modifying any other logic. All existing tests pass, and the solution follows standard git configuration practices.
- No files require special attention

<sub>Last reviewed commit: 863e350</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->