### PR TITLE
macOS: fix WebChat panel corner clipping

### DIFF
--- a/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
@@ -339,12 +339,6 @@ final class WebChatSwiftUIWindowController {
         effectView.autoresizingMask = [.width, .height]
         let rootView = effectView
 
-        controller.view.wantsLayer = true
-        controller.view.layer?.cornerCurve = .continuous
-        controller.view.layer?.cornerRadius = cornerRadius
-        controller.view.layer?.masksToBounds = true
-        controller.view.layer?.backgroundColor = NSColor.clear.cgColor
-
         hosting.view.translatesAutoresizingMaskIntoConstraints = false
         hosting.view.wantsLayer = true
         hosting.view.layer?.cornerCurve = .continuous

--- a/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
@@ -316,7 +316,12 @@ final class WebChatSwiftUIWindowController {
         let controller = NSViewController()
         let effectView = NSVisualEffectView()
         effectView.material = .sidebar
-        effectView.blendingMode = .behindWindow
+        effectView.blendingMode = switch presentation {
+        case .panel:
+            .withinWindow
+        case .window:
+            .behindWindow
+        }
         effectView.state = .active
         effectView.wantsLayer = true
         effectView.layer?.cornerCurve = .continuous
@@ -328,13 +333,23 @@ final class WebChatSwiftUIWindowController {
         }
         effectView.layer?.cornerRadius = cornerRadius
         effectView.layer?.masksToBounds = true
+        effectView.layer?.backgroundColor = NSColor.clear.cgColor
 
         effectView.translatesAutoresizingMaskIntoConstraints = true
         effectView.autoresizingMask = [.width, .height]
         let rootView = effectView
 
+        controller.view.wantsLayer = true
+        controller.view.layer?.cornerCurve = .continuous
+        controller.view.layer?.cornerRadius = cornerRadius
+        controller.view.layer?.masksToBounds = true
+        controller.view.layer?.backgroundColor = NSColor.clear.cgColor
+
         hosting.view.translatesAutoresizingMaskIntoConstraints = false
         hosting.view.wantsLayer = true
+        hosting.view.layer?.cornerCurve = .continuous
+        hosting.view.layer?.cornerRadius = cornerRadius
+        hosting.view.layer?.masksToBounds = true
         hosting.view.layer?.backgroundColor = NSColor.clear.cgColor
 
         controller.addChild(hosting)


### PR DESCRIPTION
Fixes #12294

## Summary
- fix bottom-corner rendering artifacts in the macOS WebChat panel
- use `.withinWindow` blending for panel mode to avoid material bleed at rounded edges
- enforce continuous corner clipping on the effect, hosting, and container views

## Verification
- built and ran mac app via documented flow (`scripts/restart-mac.sh --no-sign`)
- manually confirmed the bottom-corner UI glitch is resolved in WebChat panel

## Before

<img width="494" height="36" alt="Screenshot 2026-02-16 at 10 31 38" src="https://github.com/user-attachments/assets/51d8251b-2341-46fe-9cb6-11218ad3d4b3" />

## After

<img width="483" height="45" alt="Screenshot 2026-02-16 at 10 26 05" src="https://github.com/user-attachments/assets/aad42cc1-53d6-418a-b507-24d6db7cef40" />

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes bottom-corner rendering artifacts in the macOS WebChat panel by switching `NSVisualEffectView` blending mode from `.behindWindow` to `.withinWindow` in panel mode, adding continuous corner clipping to the hosting view, and setting a clear background color on the effect view layer.

- Conditionally sets `blendingMode` based on presentation (`.withinWindow` for panel, `.behindWindow` for window) to prevent material bleed at rounded edges
- Applies matching `cornerCurve`, `cornerRadius`, and `masksToBounds` to the `NSHostingController` view so the SwiftUI content also clips to the rounded corners
- Adds explicit `NSColor.clear.cgColor` background to the effect view layer
- Removes dead code that was setting layer properties on `controller.view` before it was overwritten by `controller.view = rootView`

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it makes a focused, low-risk UI fix with no behavioral or API changes.
- The changes are limited to a single file, touch only view layer properties for corner clipping, and follow existing patterns in the codebase. The blending mode change is presentation-specific and preserves existing window-mode behavior. The dead code removal is correct and was identified in prior review. No logic, security, or regression concerns.
- No files require special attention.

<sub>Last reviewed commit: cc9f099</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->