### PR TITLE
feat: add subagents.allowedBy for bidirectional spawn authorization

### DIFF
--- a/src/agents/openclaw-tools.subagents.sessions-spawn.allowed-by.e2e.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.allowed-by.e2e.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import "./test-helpers/fast-core-tools.js";
+import {
+  getCallGatewayMock,
+  getSessionsSpawnTool,
+  resetSessionsSpawnConfigOverride,
+  setSessionsSpawnConfigOverride,
+} from "./openclaw-tools.subagents.sessions-spawn.test-harness.js";
+import { resetSubagentRegistryForTests } from "./subagent-registry.js";
+
+const callGatewayMock = getCallGatewayMock();
+
+describe("openclaw-tools: subagents (sessions_spawn allowedBy)", () => {
+  function setConfig(opts: { requesterAllowAgents?: string[]; targetAllowedBy?: string[] }) {
+    setSessionsSpawnConfigOverride({
+      session: {
+        mainKey: "main",
+        scope: "per-sender",
+      },
+      agents: {
+        list: [
+          {
+            id: "requester",
+            subagents: {
+              allowAgents: opts.requesterAllowAgents ?? ["*"],
+            },
+          },
+          {
+            id: "target",
+            subagents: {
+              allowedBy: opts.targetAllowedBy,
+            },
+          },
+        ],
+      },
+    });
+  }
+
+  function mockAcceptedSpawn(acceptedAt: number) {
+    let childSessionKey: string | undefined;
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: unknown };
+      if (request.method === "agent") {
+        const params = request.params as { sessionKey?: string } | undefined;
+        childSessionKey = params?.sessionKey;
+        return { runId: "run-1", status: "accepted", acceptedAt };
+      }
+      if (request.method === "agent.wait") {
+        return { status: "timeout" };
+      }
+      return {};
+    });
+    return () => childSessionKey;
+  }
+
+  async function executeSpawn(callId: string) {
+    const tool = await getSessionsSpawnTool({
+      agentSessionKey: "agent:requester:main",
+      agentChannel: "whatsapp",
+    });
+    return tool.execute(callId, { task: "do thing", agentId: "target" });
+  }
+
+  beforeEach(() => {
+    resetSessionsSpawnConfigOverride();
+    resetSubagentRegistryForTests();
+    callGatewayMock.mockReset();
+  });
+
+  it("allows any spawner when allowedBy is not set (backwards compatible)", async () => {
+    setConfig({});
+    mockAcceptedSpawn(Date.now());
+    const result = await executeSpawn("c1");
+    expect(result.details).toMatchObject({ status: "accepted" });
+  });
+
+  it("forbids when allowedBy excludes the requester", async () => {
+    setConfig({ targetAllowedBy: ["other-agent"] });
+    const result = await executeSpawn("c2");
+    expect(result.details).toMatchObject({ status: "forbidden" });
+    expect(callGatewayMock).not.toHaveBeenCalled();
+  });
+
+  it("allows when allowedBy includes the requester", async () => {
+    setConfig({ targetAllowedBy: ["requester"] });
+    mockAcceptedSpawn(Date.now());
+    const result = await executeSpawn("c3");
+    expect(result.details).toMatchObject({ status: "accepted" });
+  });
+
+  it("allows any spawner with wildcard ['*']", async () => {
+    setConfig({ targetAllowedBy: ["*"] });
+    mockAcceptedSpawn(Date.now());
+    const result = await executeSpawn("c4");
+    expect(result.details).toMatchObject({ status: "accepted" });
+  });
+
+  it("normalizes agent ids (case-insensitive)", async () => {
+    setConfig({ targetAllowedBy: ["REQUESTER"] });
+    mockAcceptedSpawn(Date.now());
+    const result = await executeSpawn("c5");
+    expect(result.details).toMatchObject({ status: "accepted" });
+  });
+
+  it("skips check for same-agent spawns", async () => {
+    setSessionsSpawnConfigOverride({
+      session: {
+        mainKey: "main",
+        scope: "per-sender",
+      },
+      agents: {
+        list: [
+          {
+            id: "requester",
+            subagents: {
+              allowAgents: ["*"],
+              allowedBy: ["nobody"],
+            },
+          },
+        ],
+      },
+    });
+    mockAcceptedSpawn(Date.now());
+    const tool = await getSessionsSpawnTool({
+      agentSessionKey: "agent:requester:main",
+      agentChannel: "whatsapp",
+    });
+    const result = await tool.execute("c6", { task: "do thing" });
+    expect(result.details).toMatchObject({ status: "accepted" });
+  });
+});

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -268,6 +268,29 @@ export async function spawnSubagentDirect(
       };
     }
   }
+
+  // Check target agent's allowedBy restriction (bidirectional authorization)
+  if (targetAgentId !== requesterAgentId) {
+    const targetConfig = resolveAgentConfig(cfg, targetAgentId);
+    const allowedBy = targetConfig?.subagents?.allowedBy;
+    if (allowedBy != null) {
+      const allowedByAny = allowedBy.some((v) => v.trim() === "*");
+      if (!allowedByAny) {
+        const normalizedRequesterId = requesterAgentId.toLowerCase();
+        const allowedBySet = new Set(
+          allowedBy
+            .filter((v) => v.trim() && v.trim() !== "*")
+            .map((v) => normalizeAgentId(v).toLowerCase()),
+        );
+        if (!allowedBySet.has(normalizedRequesterId)) {
+          return {
+            status: "forbidden",
+            error: `Target agent "${targetAgentId}" does not allow being spawned by "${requesterAgentId}"`,
+          };
+        }
+      }
+    }
+  }
   const childSessionKey = `agent:${targetAgentId}:subagent:${crypto.randomUUID()}`;
   const childDepth = callerDepth + 1;
   const spawnedByKey = requesterInternalKey;

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -24,6 +24,8 @@ export type AgentConfig = {
   subagents?: {
     /** Allow spawning sub-agents under other agent ids. Use "*" to allow any. */
     allowAgents?: string[];
+    /** Restrict which agents are allowed to spawn this agent. Use "*" to allow any. When unset, any agent can spawn this one. */
+    allowedBy?: string[];
     /** Per-agent default model for spawned sub-agents (string or {primary,fallbacks}). */
     model?: AgentModelConfig;
   };

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -687,6 +687,7 @@ export const AgentEntrySchema = z
     subagents: z
       .object({
         allowAgents: z.array(z.string()).optional(),
+        allowedBy: z.array(z.string()).optional(),
         model: z
           .union([
             z.string(),

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -194,7 +194,7 @@ export function buildGatewayCronService(params: {
         );
       const baseHeartbeat = {
         ...runtimeConfig.agents?.defaults?.heartbeat,
-        ...agentEntry?.heartbeat,
+        ...(agentEntry && typeof agentEntry !== "boolean" ? agentEntry.heartbeat : undefined),
       };
       const heartbeatOverride = opts?.heartbeat
         ? { ...baseHeartbeat, ...opts.heartbeat }

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -194,7 +194,7 @@ export function buildGatewayCronService(params: {
         );
       const baseHeartbeat = {
         ...runtimeConfig.agents?.defaults?.heartbeat,
-        ...(agentEntry && typeof agentEntry !== "boolean" ? agentEntry.heartbeat : undefined),
+        ...agentEntry?.heartbeat,
       };
       const heartbeatOverride = opts?.heartbeat
         ? { ...baseHeartbeat, ...opts.heartbeat }


### PR DESCRIPTION
## Summary

Adds a `subagents.allowedBy` config key on the target agent, enabling bidirectional spawn authorization. Currently only the spawning agent controls who it can target (`allowAgents`). This adds the inverse — the target agent can restrict who is allowed to spawn it.

## Motivation

As agent teams grow, managing spawn permissions becomes increasingly difficult with `allowAgents` alone. Consider a project with an admin orchestrator and 10+ specialized sub-agents (coding, research, design, QA, etc.). Today, to prevent sub-agents from spawning the orchestrator, you must explicitly list every sibling in each agent's `allowAgents` — and update all of them whenever a new agent is added.

With `allowedBy`, the orchestrator simply declares who can spawn it. Sub-agents don't need `allowAgents` at all — they just declare who is allowed to spawn them. This scales naturally: adding a new sub-agent requires zero config changes on existing agents.

### Example: project-based agent hierarchy

```json5
{
  agents: {
    list: [
      // Admin coordinator — can spawn project orchestrators
      {
        id: "admin",
        subagents: { allowAgents: ["project-a-orchestrator", "project-b-orchestrator"] }
      },

      // Project orchestrator — only admin can spawn it
      {
        id: "project-a-orchestrator",
        subagents: {
          allowAgents: ["*"],                  // can spawn any sub-agent
          allowedBy: ["admin"]                 // only admin can spawn me
        }
      },

      // Sub-agents — can spawn each other freely
      { id: "project-a-coding",   subagents: { allowedBy: ["project-a-orchestrator"] } },
      { id: "project-a-research", subagents: { allowedBy: ["project-a-orchestrator"] } },
      { id: "project-a-design",   subagents: { allowedBy: ["project-a-orchestrator"] } },
      // ... adding more sub-agents requires no config changes above
    ]
  }
}
```

Without `allowedBy`, this setup requires either:
- Explicit sibling lists on every agent (breaks when adding/removing agents)
- `allowAgents: ["*"]` everywhere (no hierarchy enforcement)

> **Note:** A wildcard/prefix syntax for `allowAgents` (e.g. `"project-a-*"`) would further improve scalability for the same reasons, but that is out of scope for this PR and will be investigated separately.

## Config

```json5
{
  agents: {
    list: [
      {
        id: "worker-coding",
        subagents: {
          allowedBy: ["orchestrator"]  // only orchestrator can spawn me
        }
      }
    ]
  }
}
```

## Behavior

- `allowedBy` **not set** → any agent can spawn (backwards compatible)
- `allowedBy: ["agent-a"]` → only `agent-a` can spawn this agent
- `allowedBy: ["*"]` → explicitly allow any spawner
- Both `allowAgents` (sender) and `allowedBy` (target) must pass for cross-agent spawns

## Changes

- `src/config/types.agents.ts` — Added `allowedBy?: string[]` to subagents type
- `src/config/zod-schema.agent-runtime.ts` — Added zod validation
- `src/agents/subagent-spawn.ts` — Added allowedBy check after existing allowAgents check
- `src/agents/openclaw-tools.subagents.sessions-spawn.allowed-by.e2e.test.ts` — 6 E2E tests

## Tests

6 e2e tests covering:
- Allows any spawner when allowedBy not set (backwards compat)
- Forbids when allowedBy excludes requester
- Allows when allowedBy includes requester
- Allows any with wildcard `["*"]`
- Normalizes agent ids (case-insensitive)
- Skips check for same-agent spawns

## Error

When rejected: `Target agent "X" does not allow being spawned by "Y"`

## CI Note

The `check` job fails on a pre-existing upstream type error in `src/gateway/server-cron.ts` (not introduced by this PR).