### PR TITLE
fix(skills): augment PATH with /etc/paths on macOS for binary detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Skills/macOS: augment PATH with `/etc/paths`, `/etc/paths.d/*`, and common Homebrew prefixes when detecting skill binaries, so the macOS app finds tools installed via Homebrew. (#17890)
 - Security: replace deprecated SHA-1 sandbox configuration hashing with SHA-256 for deterministic sandbox cache identity and recreation checks. Thanks @kexinoh.
 - Security/Logging: redact Telegram bot tokens from error messages and uncaught stack traces to prevent accidental secret leakage into logs. Thanks @aether-ai-agent.
 - Sandbox/Security: block dangerous sandbox Docker config (bind mounts, host networking, unconfined seccomp/apparmor) to prevent container escape via config injection. Thanks @aether-ai-agent.

--- a/src/commands/onboard-helpers.detect-binary.test.ts
+++ b/src/commands/onboard-helpers.detect-binary.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { detectBinary } from "./onboard-helpers.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("detectBinary", () => {
+  it("returns false for empty name", async () => {
+    expect(await detectBinary("")).toBe(false);
+    expect(await detectBinary("  ")).toBe(false);
+  });
+
+  it("finds a standard binary (ls) with any PATH", async () => {
+    expect(await detectBinary("ls")).toBe(true);
+  });
+
+  it("returns false for a nonexistent binary", async () => {
+    expect(await detectBinary("__nonexistent_binary_xyz__")).toBe(false);
+  });
+
+  it("finds an absolute path binary", async () => {
+    expect(await detectBinary("/usr/bin/env")).toBe(true);
+  });
+
+  it("returns false for a missing absolute path", async () => {
+    expect(await detectBinary("/usr/bin/__nonexistent__")).toBe(false);
+  });
+
+  it("finds Homebrew binaries with restricted PATH on macOS (#17890)", async () => {
+    if (process.platform !== "darwin") {
+      return;
+    }
+    const originalPath = process.env.PATH;
+    // Simulate macOS app's restricted PATH
+    process.env.PATH = "/usr/bin:/bin:/usr/sbin:/sbin";
+    try {
+      // brew is at /opt/homebrew/bin/brew on Apple Silicon
+      const found = await detectBinary("brew");
+      expect(found).toBe(true);
+    } finally {
+      process.env.PATH = originalPath;
+    }
+  });
+});

--- a/src/commands/onboard-helpers.detect-binary.test.ts
+++ b/src/commands/onboard-helpers.detect-binary.test.ts
@@ -31,11 +31,15 @@ describe("detectBinary", () => {
     if (process.platform !== "darwin") {
       return;
     }
+    // Skip if brew is not installed on this machine at all
+    const hasBrew = await detectBinary("brew");
+    if (!hasBrew) {
+      return;
+    }
     const originalPath = process.env.PATH;
     // Simulate macOS app's restricted PATH
     process.env.PATH = "/usr/bin:/bin:/usr/sbin:/sbin";
     try {
-      // brew is at /opt/homebrew/bin/brew on Apple Silicon
       const found = await detectBinary("brew");
       expect(found).toBe(true);
     } finally {

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -339,8 +339,14 @@ export async function handleReset(scope: ResetScope, workspaceDir: string, runti
   }
 }
 
+let cachedSystemPath: string | undefined | null = null;
+
 async function resolveSystemPath(): Promise<string | undefined> {
+  if (cachedSystemPath !== null) {
+    return cachedSystemPath;
+  }
   if (process.platform !== "darwin") {
+    cachedSystemPath = undefined;
     return undefined;
   }
   try {
@@ -369,8 +375,10 @@ async function resolveSystemPath(): Promise<string | undefined> {
         dirs.push(brewDir);
       }
     }
-    return dirs.length > 0 ? dirs.join(":") : undefined;
+    cachedSystemPath = dirs.length > 0 ? dirs.join(":") : undefined;
+    return cachedSystemPath;
   } catch {
+    cachedSystemPath = undefined;
     return undefined;
   }
 }


### PR DESCRIPTION
## Summary

Fixes #17890.

`detectBinary` uses `/usr/bin/env which <name>` to locate binaries, but inherits `process.env.PATH` from the parent process. When launched as a macOS app (not from a shell), the process PATH is restricted to `/usr/bin:/bin:/usr/sbin:/sbin`, which excludes `/opt/homebrew/bin` (Homebrew on Apple Silicon) and `/usr/local/bin`.

## Root Cause

`detectBinary` spawns `which` via `runCommandWithTimeout`, which passes `process.env` to the child process. macOS app processes do not inherit shell-configured PATH, so Homebrew-installed binaries are invisible.

## Fix

Add a `resolveSystemPath()` helper that reads `/etc/paths` and `/etc/paths.d/*` on macOS, plus common Homebrew prefixes (`/opt/homebrew/bin`, `/usr/local/bin`) as fallbacks. The merged PATH is passed to the `which` subprocess via the `env` option.

## Before

```
detectBinary("brew") with restricted PATH: false
❌ FAIL: detectBinary cannot find brew with restricted PATH
```

## After

```
detectBinary("brew") with restricted PATH: true
✅ PASS: detectBinary finds brew with restricted PATH after fix
```

## Test Plan

- Added `onboard-helpers.detect-binary.test.ts` with 6 tests covering empty names, standard binaries, absolute paths, nonexistent binaries, and the macOS restricted-PATH regression case.
- All tests pass locally.
- Lint passes (`pnpm lint` — 0 warnings, 0 errors).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes `detectBinary` failing to find Homebrew-installed binaries when the process runs as a macOS app (not from a shell), where `process.env.PATH` is restricted to `/usr/bin:/bin:/usr/sbin:/sbin`.

- Adds a `resolveSystemPath()` helper that reads `/etc/paths` and `/etc/paths.d/*` on macOS, plus common Homebrew prefixes (`/opt/homebrew/bin`, `/usr/local/bin`) as fallbacks
- The resolved system PATH is cached at module level to avoid repeated file I/O across multiple `detectBinary` calls
- The merged PATH is passed via the `env` option to `runCommandWithTimeout`, which correctly merges it with `process.env` (preserving all other environment variables)
- The fix is macOS-only — on other platforms, `resolveSystemPath()` returns `undefined` and the original behavior is preserved
- Adds a new test file with 6 test cases covering edge cases and the macOS restricted-PATH regression

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a well-scoped macOS-only fix with proper caching, error handling, and no behavioral change on other platforms.
- The fix is narrowly targeted to macOS binary detection, correctly reads standard system PATH configuration files, caches the result to avoid repeated I/O, and preserves existing behavior on all non-macOS platforms. The `runCommandWithTimeout` function properly merges the custom env with `process.env`, so all other environment variables are preserved. Error paths fall back gracefully to `undefined`. The test covers relevant edge cases and the specific regression scenario.
- No files require special attention.

<sub>Last reviewed commit: 68a25bb</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->