### PR TITLE
fix: use 0o644 for inbound media files to allow sandbox read access

### DIFF
--- a/src/media/store.redirect.test.ts
+++ b/src/media/store.redirect.test.ts
@@ -90,7 +90,8 @@ describe("media store redirects", () => {
     expect(path.extname(saved.path)).toBe(".txt");
     expect(await fs.readFile(saved.path, "utf8")).toBe("redirected");
     const stat = await fs.stat(saved.path);
-    expect(stat.mode & 0o777).toBe(0o644);
+    const expectedMode = process.platform === "win32" ? 0o666 : 0o644;
+    expect(stat.mode & 0o777).toBe(expectedMode);
   });
 
   it("fails when redirect response omits location header", async () => {

--- a/src/media/store.redirect.test.ts
+++ b/src/media/store.redirect.test.ts
@@ -89,6 +89,8 @@ describe("media store redirects", () => {
     expect(saved.contentType).toBe("text/plain");
     expect(path.extname(saved.path)).toBe(".txt");
     expect(await fs.readFile(saved.path, "utf8")).toBe("redirected");
+    const stat = await fs.stat(saved.path);
+    expect(stat.mode & 0o777).toBe(0o644);
   });
 
   it("fails when redirect response omits location header", async () => {

--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -170,7 +170,7 @@ async function downloadToFile(
           let total = 0;
           const sniffChunks: Buffer[] = [];
           let sniffLen = 0;
-          const out = createWriteStream(dest, { mode: 0o600 });
+          const out = createWriteStream(dest, { mode: 0o644 });
           res.on("data", (chunk) => {
             total += chunk.length;
             if (sniffLen < 16384) {
@@ -284,7 +284,7 @@ export async function saveMediaSource(
     const ext = extensionForMime(mime) ?? path.extname(source);
     const id = ext ? `${baseId}${ext}` : baseId;
     const dest = path.join(dir, id);
-    await fs.writeFile(dest, buffer, { mode: 0o600 });
+    await fs.writeFile(dest, buffer, { mode: 0o644 });
     return { id, path: dest, size: stat.size, contentType: mime };
   } catch (err) {
     if (err instanceof SafeOpenError) {
@@ -323,6 +323,6 @@ export async function saveMediaBuffer(
   }
 
   const dest = path.join(dir, id);
-  await fs.writeFile(dest, buffer, { mode: 0o600 });
+  await fs.writeFile(dest, buffer, { mode: 0o644 });
   return { id, path: dest, size: buffer.byteLength, contentType: mime };
 }

--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -14,6 +14,9 @@ const resolveMediaDir = () => path.join(resolveConfigDir(), "media");
 export const MEDIA_MAX_BYTES = 5 * 1024 * 1024; // 5MB default
 const MAX_BYTES = MEDIA_MAX_BYTES;
 const DEFAULT_TTL_MS = 2 * 60 * 1000; // 2 minutes
+// Files are intentionally readable by non-owner UIDs so Docker sandbox containers can access
+// inbound media. The containing state/media directories remain 0o700, which is the trust boundary.
+const MEDIA_FILE_MODE = 0o644;
 type RequestImpl = typeof httpRequest;
 type ResolvePinnedHostnameImpl = typeof resolvePinnedHostname;
 
@@ -170,7 +173,7 @@ async function downloadToFile(
           let total = 0;
           const sniffChunks: Buffer[] = [];
           let sniffLen = 0;
-          const out = createWriteStream(dest, { mode: 0o644 });
+          const out = createWriteStream(dest, { mode: MEDIA_FILE_MODE });
           res.on("data", (chunk) => {
             total += chunk.length;
             if (sniffLen < 16384) {
@@ -284,7 +287,7 @@ export async function saveMediaSource(
     const ext = extensionForMime(mime) ?? path.extname(source);
     const id = ext ? `${baseId}${ext}` : baseId;
     const dest = path.join(dir, id);
-    await fs.writeFile(dest, buffer, { mode: 0o644 });
+    await fs.writeFile(dest, buffer, { mode: MEDIA_FILE_MODE });
     return { id, path: dest, size: stat.size, contentType: mime };
   } catch (err) {
     if (err instanceof SafeOpenError) {
@@ -323,6 +326,6 @@ export async function saveMediaBuffer(
   }
 
   const dest = path.join(dir, id);
-  await fs.writeFile(dest, buffer, { mode: 0o644 });
+  await fs.writeFile(dest, buffer, { mode: MEDIA_FILE_MODE });
   return { id, path: dest, size: buffer.byteLength, contentType: mime };
 }


### PR DESCRIPTION
## Summary
Fixes #17941

Inbound media files were saved with `0o600` permissions (`-rw-------`), making them unreadable from Docker sandbox containers running as different users.

## Changes
- Change file mode from `0o600` to `0o644` in `saveMediaSource()` and `saveMediaBuffer()`

## Why 0o644?
- Owner can read/write
- Group and others can read (required for sandbox access)
- The containing directory already uses `0o700`, so only users with directory access can see filenames
- Media files are not sensitive credentials — they're user-uploaded attachments

---
🤖 Generated with Claude Code

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes media file permissions from `0o600` to `0o644` in `saveMediaSource()` (local file path) and `saveMediaBuffer()` to allow Docker sandbox containers running as different users to read inbound media files. The rationale is sound — media files are user-uploaded attachments (not credentials), and the parent directory already uses `0o700` to restrict directory-level access.

However, the fix is **incomplete for URL-sourced media**:

- The `downloadToFile` helper at line 152 still uses `createWriteStream(dest, { mode: 0o600 })`. When `saveMediaSource` processes a URL, it calls `downloadToFile` to write a `.tmp` file, then renames it. Since `fs.rename` preserves permissions, the final file retains `0o600` — leaving URL-downloaded media unreadable from the sandbox.

<h3>Confidence Score: 2/5</h3>

- This PR partially fixes the sandbox read-access issue but misses the URL download path, leaving the bug unfixed for a significant code path.
- The two changed lines are correct on their own, but the `downloadToFile` function (line 152) was not updated, which means URL-sourced media still gets `0o600` permissions. This is a functional gap that undermines the stated goal of the PR.
- `src/media/store.ts` — the `downloadToFile` function at line 152 still uses `0o600` and needs to be updated to `0o644`.

<sub>Last reviewed commit: 7c006bb</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->