### PR TITLE
fix: clean up agent-events maps after cron runs

### DIFF
--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -48,6 +48,7 @@ export function getAgentRunContext(runId: string) {
 
 export function clearAgentRunContext(runId: string) {
   runContextById.delete(runId);
+  seqByRun.delete(runId);
 }
 
 export function resetAgentRunContextForTest() {


### PR DESCRIPTION
## Summary

- `seqByRun` map in `agent-events.ts` was never cleaned up, leaking one entry per agent run
- Cron isolated runner never called `clearAgentRunContext` after runs completed
- Together these cause unbounded memory growth in long-running gateways with frequent cron jobs (reported as 1-2GB over 10-12 hours with 2 jobs every 5 minutes)

## Changes

- Added `seqByRun.delete(runId)` to `clearAgentRunContext()` so both maps are cleaned
- Hoisted `cronRunId` and `registerAgentRunContext` before the try block in cron runner
- Added `finally` block to ensure cleanup on all exit paths (success, error, timeout)

Fixes #17820

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a memory leak in long-running gateways caused by two issues: the `seqByRun` map in `agent-events.ts` was never cleaned up by `clearAgentRunContext()`, and the cron isolated runner never called `clearAgentRunContext` at all — so both `seqByRun` and `runContextById` leaked one entry per cron run indefinitely.

- `clearAgentRunContext()` now deletes from both `runContextById` and `seqByRun`, matching the contract that all per-run state is cleaned up
- The cron runner hoists `cronRunId` and `registerAgentRunContext` before the `try` block and adds a `finally` block to ensure `clearAgentRunContext` runs on all exit paths (success, error, timeout)
- The pattern matches the existing cleanup approach in `src/commands/agent.ts` and the gateway event handler in `src/gateway/server-chat.ts`

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a targeted memory leak fix with no behavioral changes beyond cleanup.
- Both changes are minimal, correct, and follow established patterns already used in commands/agent.ts. The seqByRun cleanup in clearAgentRunContext is clearly the right fix — the map was always meant to be cleaned alongside runContextById. The finally block in the cron runner guarantees cleanup on all exit paths. No new functionality, no risk of regression.
- No files require special attention.

<sub>Last reviewed commit: d010a9a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->