### PR TITLE
macOS: prevent Voice Wake crash when no input device is available

### DIFF
--- a/apps/macos/Sources/OpenClaw/AudioInputDeviceObserver.swift
+++ b/apps/macos/Sources/OpenClaw/AudioInputDeviceObserver.swift
@@ -76,6 +76,20 @@ final class AudioInputDeviceObserver {
         return "defaultInput=\(name) (\(uid))"
     }
 
+    static func hasUsableDefaultInputDevice() -> Bool {
+        let defaultUID = self.defaultInputDeviceUID()
+        let aliveUIDs = self.aliveInputDeviceUIDs()
+        return self.hasUsableDefaultInputDevice(defaultUID: defaultUID, aliveInputUIDs: aliveUIDs)
+    }
+
+    static func inputAvailabilitySummary() -> String {
+        let defaultUID = self.defaultInputDeviceUID()
+        let aliveUIDs = self.aliveInputDeviceUIDs()
+        let hasUsable = self.hasUsableDefaultInputDevice(defaultUID: defaultUID, aliveInputUIDs: aliveUIDs)
+        let defaultLabel = defaultUID ?? "none"
+        return "defaultInputUID=\(defaultLabel) aliveInputs=\(aliveUIDs.count) usable=\(hasUsable)"
+    }
+
     func start(onChange: @escaping @Sendable () -> Void) {
         guard !self.isActive else { return }
         self.isActive = true
@@ -210,7 +224,20 @@ final class AudioInputDeviceObserver {
         return buffers.contains(where: { $0.mNumberChannels > 0 })
     }
 
+    private static func hasUsableDefaultInputDevice(defaultUID: String?, aliveInputUIDs: Set<String>) -> Bool {
+        guard let defaultUID, !defaultUID.isEmpty else { return false }
+        return aliveInputUIDs.contains(defaultUID)
+    }
+
     private func logDefaultInputChange(reason: StaticString) {
         self.logger.info("audio input changed (\(reason)) (\(Self.defaultInputDeviceSummary(), privacy: .public))")
     }
 }
+
+#if DEBUG
+extension AudioInputDeviceObserver {
+    static func _testHasUsableDefaultInputDevice(defaultUID: String?, aliveInputUIDs: Set<String>) -> Bool {
+        self.hasUsableDefaultInputDevice(defaultUID: defaultUID, aliveInputUIDs: aliveInputUIDs)
+    }
+}
+#endif

--- a/apps/macos/Sources/OpenClaw/VoiceWakeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/VoiceWakeRuntime.swift
@@ -160,6 +160,16 @@ actor VoiceWakeRuntime {
             self.recognitionRequest?.taskHint = .dictation
             guard let request = self.recognitionRequest else { return }
 
+            guard AudioInputDeviceObserver.hasUsableDefaultInputDevice() else {
+                throw NSError(
+                    domain: "VoiceWakeRuntime",
+                    code: 1,
+                    userInfo: [
+                        NSLocalizedDescriptionKey: "No usable default audio input available",
+                        "inputSummary": AudioInputDeviceObserver.inputAvailabilitySummary(),
+                    ])
+            }
+
             // Lazily create the engine here so app launch doesn't grab audio resources / trigger Bluetooth HFP.
             if self.audioEngine == nil {
                 self.audioEngine = AVAudioEngine()

--- a/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
@@ -339,12 +339,6 @@ final class WebChatSwiftUIWindowController {
         effectView.autoresizingMask = [.width, .height]
         let rootView = effectView
 
-        controller.view.wantsLayer = true
-        controller.view.layer?.cornerCurve = .continuous
-        controller.view.layer?.cornerRadius = cornerRadius
-        controller.view.layer?.masksToBounds = true
-        controller.view.layer?.backgroundColor = NSColor.clear.cgColor
-
         hosting.view.translatesAutoresizingMaskIntoConstraints = false
         hosting.view.wantsLayer = true
         hosting.view.layer?.cornerCurve = .continuous

--- a/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
@@ -316,7 +316,12 @@ final class WebChatSwiftUIWindowController {
         let controller = NSViewController()
         let effectView = NSVisualEffectView()
         effectView.material = .sidebar
-        effectView.blendingMode = .behindWindow
+        effectView.blendingMode = switch presentation {
+        case .panel:
+            .withinWindow
+        case .window:
+            .behindWindow
+        }
         effectView.state = .active
         effectView.wantsLayer = true
         effectView.layer?.cornerCurve = .continuous
@@ -328,13 +333,23 @@ final class WebChatSwiftUIWindowController {
         }
         effectView.layer?.cornerRadius = cornerRadius
         effectView.layer?.masksToBounds = true
+        effectView.layer?.backgroundColor = NSColor.clear.cgColor
 
         effectView.translatesAutoresizingMaskIntoConstraints = true
         effectView.autoresizingMask = [.width, .height]
         let rootView = effectView
 
+        controller.view.wantsLayer = true
+        controller.view.layer?.cornerCurve = .continuous
+        controller.view.layer?.cornerRadius = cornerRadius
+        controller.view.layer?.masksToBounds = true
+        controller.view.layer?.backgroundColor = NSColor.clear.cgColor
+
         hosting.view.translatesAutoresizingMaskIntoConstraints = false
         hosting.view.wantsLayer = true
+        hosting.view.layer?.cornerCurve = .continuous
+        hosting.view.layer?.cornerRadius = cornerRadius
+        hosting.view.layer?.masksToBounds = true
         hosting.view.layer?.backgroundColor = NSColor.clear.cgColor
 
         controller.addChild(hosting)

--- a/apps/macos/Tests/OpenClawIPCTests/AudioInputDeviceObserverTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/AudioInputDeviceObserverTests.swift
@@ -1,0 +1,22 @@
+import Testing
+@testable import OpenClaw
+
+@Suite struct AudioInputDeviceObserverTests {
+    @Test func defaultInputMissingIsNotUsable() {
+        #expect(!AudioInputDeviceObserver._testHasUsableDefaultInputDevice(
+            defaultUID: nil,
+            aliveInputUIDs: ["mic-a"]))
+    }
+
+    @Test func defaultInputNotAliveIsNotUsable() {
+        #expect(!AudioInputDeviceObserver._testHasUsableDefaultInputDevice(
+            defaultUID: "mic-a",
+            aliveInputUIDs: ["mic-b"]))
+    }
+
+    @Test func defaultInputAliveIsUsable() {
+        #expect(AudioInputDeviceObserver._testHasUsableDefaultInputDevice(
+            defaultUID: "mic-a",
+            aliveInputUIDs: ["mic-a", "mic-b"]))
+    }
+}


### PR DESCRIPTION
## Summary
- prevent macOS app crash when Voice Wake starts without a usable default audio input device
- add CoreAudio preflight for default input availability before installing AVAudioEngine tap
- keep failure in the recoverable runtime path (log + stop), avoiding SIGABRT process termination

## Bug
On Macs with no usable input device (common on Mac mini/headless setups), enabling Voice Wake can crash:
- `AVAudioNode.installTapOnBus` throws Objective-C exception
- exception crosses into Swift runtime and aborts the app (`SIGABRT`)

## Root Cause
`VoiceWakeRuntime.start(with:)` proceeded to `installTap` without verifying that the default input device is both present and input-capable/alive.

## Changes
1. `AudioInputDeviceObserver`
- added `hasUsableDefaultInputDevice()`
- added `inputAvailabilitySummary()` for diagnostics
- added private helper for default UID vs alive input UID matching

2. `VoiceWakeRuntime.start(with:)`
- added startup guard using `AudioInputDeviceObserver.hasUsableDefaultInputDevice()` before installing tap
- throws normal `NSError` (with input summary) and exits via existing catch/stop flow

3. Tests
- added `AudioInputDeviceObserverTests` covering:
  - missing default UID
  - default UID not alive/input-capable
  - default UID valid/alive

## Validation
- `swift test --filter AudioInputDeviceObserverTests`
- `swift test --filter VoiceWakeRuntimeTests`

## Fixes
- Fixes #17484
- Fixes #16418
- Fixes #16118
- Fixes #15740
- Fixes #12169
