### PR TITLE
fix: filter error payloads from user-facing messages

### DIFF
--- a/src/auto-reply/reply/reply-payloads.test.ts
+++ b/src/auto-reply/reply/reply-payloads.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { isRenderablePayload } from "./reply-payloads.js";
+
+describe("isRenderablePayload", () => {
+  it("returns true for payload with text", () => {
+    expect(isRenderablePayload({ text: "hello" })).toBe(true);
+  });
+
+  it("returns true for payload with mediaUrl", () => {
+    expect(isRenderablePayload({ mediaUrl: "https://example.com/img.png" })).toBe(true);
+  });
+
+  it("returns true for payload with mediaUrls", () => {
+    expect(isRenderablePayload({ mediaUrls: ["https://example.com/a.png"] })).toBe(true);
+  });
+
+  it("returns true for payload with audioAsVoice", () => {
+    expect(isRenderablePayload({ audioAsVoice: true })).toBe(true);
+  });
+
+  it("returns true for payload with channelData", () => {
+    expect(isRenderablePayload({ channelData: { key: "value" } })).toBe(true);
+  });
+
+  it("returns false for empty payload", () => {
+    expect(isRenderablePayload({})).toBe(false);
+  });
+
+  it("returns false for error payload even with text", () => {
+    expect(isRenderablePayload({ text: "Context overflow error", isError: true })).toBe(false);
+  });
+
+  it("returns false for error payload with media", () => {
+    expect(isRenderablePayload({ mediaUrl: "https://example.com/img.png", isError: true })).toBe(
+      false,
+    );
+  });
+
+  it("returns true for non-error payload with isError explicitly false", () => {
+    expect(isRenderablePayload({ text: "hello", isError: false })).toBe(true);
+  });
+});

--- a/src/auto-reply/reply/reply-payloads.ts
+++ b/src/auto-reply/reply/reply-payloads.ts
@@ -45,6 +45,9 @@ export function applyReplyTagsToPayload(
 }
 
 export function isRenderablePayload(payload: ReplyPayload): boolean {
+  if (payload.isError) {
+    return false;
+  }
   return Boolean(
     payload.text ||
     payload.mediaUrl ||


### PR DESCRIPTION
## Summary

- `isRenderablePayload()` did not check the `isError` flag on payloads
- Internal error results (context overflow, tool failures, role ordering conflicts) were being sent to users on all messaging channels
- These errors are meant to stay in the agent context for self-correction, not be delivered to end users

## Changes

- Added early return in `isRenderablePayload()` when `payload.isError` is true
- Added test coverage for `isRenderablePayload` covering all payload types and the isError filtering

Fixes #17828

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Prevents internal error messages from being sent to end users by filtering out error payloads. The fix adds an early return in `isRenderablePayload()` to check the `isError` flag, ensuring that context overflow errors, tool failures, and role ordering conflicts stay in the agent context for self-correction rather than being delivered on messaging channels.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a simple, well-tested guard clause that prevents a clear bug (error messages leaking to users). The change is minimal, isolated to a single function, and includes comprehensive test coverage. No edge cases or regressions identified.
- No files require special attention

<sub>Last reviewed commit: b981813</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->