### PR TITLE
fix(sandbox): parse Windows bind mounts in fs-path mapping

### DIFF
--- a/src/agents/sandbox/fs-paths.test.ts
+++ b/src/agents/sandbox/fs-paths.test.ts
@@ -52,6 +52,19 @@ describe("parseSandboxBindMount", () => {
       writable: true,
     });
   });
+
+  it("parses Windows drive-letter host paths", () => {
+    expect(parseSandboxBindMount("C:\\Users\\kai\\workspace:/workspace:ro")).toEqual({
+      hostRoot: path.resolve("C:\\Users\\kai\\workspace"),
+      containerRoot: "/workspace",
+      writable: false,
+    });
+    expect(parseSandboxBindMount("D:/data:/workspace-data:rw")).toEqual({
+      hostRoot: path.resolve("D:/data"),
+      containerRoot: "/workspace-data",
+      writable: true,
+    });
+  });
 });
 
 describe("resolveSandboxFsPathWithMounts", () => {


### PR DESCRIPTION
## Summary
- fix Docker bind spec parsing in sandbox fs-path resolution for Windows drive-letter host paths
- add test coverage for `C:\...` and `D:/...` bind specs

## Problem
`parseSandboxBindMount` currently splits bind specs with a naive `split(":")`.

For Windows bind mounts like `C:\\Users\\kai\\workspace:/workspace:ro`, this truncates the host path at `C`, causing bind mounts to be parsed incorrectly.

## Root cause
The parser assumes `:` only appears as a host/container delimiter, but Windows drive letters also contain `:`.

## Fix
- add `splitBindSpec()` helper that handles Windows drive-letter host paths by locating the host/container separator after the drive prefix
- keep existing behavior for Unix bind syntax
- preserve options parsing (`ro`, `rw`, etc.)

## Validation
- existing bind parsing tests still pass logically
- added tests for Windows drive-letter hosts in `src/agents/sandbox/fs-paths.test.ts`

## AI-assisted
This PR was AI-assisted.

## Testing level
Lightly tested (targeted unit test update + static inspection).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes Docker bind spec parsing in sandbox filesystem path resolution for Windows drive-letter host paths (e.g., `C:\Users\kai\workspace:/workspace:ro`). The previous naive `split(":")` approach broke on Windows paths because the drive letter contains a colon.

- Extracts a `splitBindSpec()` helper that detects Windows drive-letter prefixes via regex (`^[A-Za-z]:[\\/]`) and skips the drive-letter colon when finding the host/container separator
- Falls back to the original `split(":")` behavior for Unix bind syntax
- Adds test coverage for both backslash (`C:\...`) and forward-slash (`D:/...`) Windows path variants
- No changes to the public API or behavior for Unix paths

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a targeted bug fix with correct logic and test coverage.
- The change is minimal and well-scoped: it extracts a helper function to handle Windows drive-letter colons during bind spec parsing, while preserving the existing Unix behavior as a fallback. The regex correctly identifies Windows paths, the separator logic skips the drive-letter colon, and the tests symmetrically validate the parsing on any platform. No public API changes, no security implications, and existing tests remain unaffected.
- No files require special attention.

<sub>Last reviewed commit: 5d36576</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->