### PR TITLE
fix(discord): honor proxy for app-id and allowlist REST resolution

### DIFF
--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -304,7 +304,7 @@ export const FIELD_HELP: Record<string, string> = {
   "channels.discord.configWrites":
     "Allow Discord to write config in response to channel events/commands (default: true).",
   "channels.discord.proxy":
-    "Proxy URL for Discord gateway WebSocket connections. Set per account via channels.discord.accounts.<id>.proxy.",
+    "Proxy URL for Discord gateway + API requests (app-id lookup and allowlist resolution). Set per account via channels.discord.accounts.<id>.proxy.",
   "channels.whatsapp.configWrites":
     "Allow WhatsApp to write config in response to channel events/commands (default: true).",
   "channels.signal.configWrites":

--- a/src/discord/monitor/provider.rest-proxy.test.ts
+++ b/src/discord/monitor/provider.rest-proxy.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+
+const { undiciFetchMock, proxyAgentSpy } = vi.hoisted(() => ({
+  undiciFetchMock: vi.fn(),
+  proxyAgentSpy: vi.fn(),
+}));
+
+vi.mock("undici", () => {
+  class ProxyAgent {
+    proxyUrl: string;
+    constructor(proxyUrl: string) {
+      if (proxyUrl === "bad-proxy") {
+        throw new Error("bad proxy");
+      }
+      this.proxyUrl = proxyUrl;
+      proxyAgentSpy(proxyUrl);
+    }
+  }
+  return {
+    ProxyAgent,
+    fetch: undiciFetchMock,
+  };
+});
+
+describe("resolveDiscordRestFetch", () => {
+  it("uses undici proxy fetch when a proxy URL is configured", async () => {
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+    } as const;
+    undiciFetchMock.mockReset().mockResolvedValue(new Response("ok", { status: 200 }));
+    proxyAgentSpy.mockReset();
+
+    const { __testing } = await import("./provider.js");
+    const fetcher = __testing.resolveDiscordRestFetch("http://proxy.test:8080", runtime);
+
+    await fetcher("https://discord.com/api/v10/oauth2/applications/@me");
+
+    expect(proxyAgentSpy).toHaveBeenCalledWith("http://proxy.test:8080");
+    expect(undiciFetchMock).toHaveBeenCalledWith(
+      "https://discord.com/api/v10/oauth2/applications/@me",
+      expect.objectContaining({
+        dispatcher: expect.objectContaining({ proxyUrl: "http://proxy.test:8080" }),
+      }),
+    );
+    expect(runtime.log).toHaveBeenCalledWith("discord: rest proxy enabled");
+    expect(runtime.error).not.toHaveBeenCalled();
+  });
+
+  it("falls back to global fetch when proxy URL is invalid", async () => {
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+    } as const;
+    const { __testing } = await import("./provider.js");
+
+    const fetcher = __testing.resolveDiscordRestFetch("bad-proxy", runtime);
+
+    expect(fetcher).toBe(fetch);
+    expect(runtime.error).toHaveBeenCalled();
+    expect(runtime.log).not.toHaveBeenCalled();
+  });
+});

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -29,10 +29,10 @@ import {
 import { loadConfig } from "../../config/config.js";
 import { danger, logVerbose, shouldLogVerbose, warn } from "../../globals.js";
 import { formatErrorMessage } from "../../infra/errors.js";
+import { wrapFetchWithAbortSignal } from "../../infra/fetch.js";
 import { createDiscordRetryRunner } from "../../infra/retry-policy.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { createNonExitingRuntime, type RuntimeEnv } from "../../runtime.js";
-import { wrapFetchWithAbortSignal } from "../../infra/fetch.js";
 import { resolveDiscordAccount } from "../accounts.js";
 import { attachDiscordGatewayLogging } from "../gateway-logging.js";
 import { getDiscordGatewayEmitter, waitForDiscordGatewayStop } from "../monitor.gateway.js";


### PR DESCRIPTION
## Summary
- apply `channels.discord.proxy` to Discord REST calls made during monitor startup
- route application-id lookup and allowlist resolvers through the same proxy used by gateway config
- update config help text to clarify proxy now covers gateway + API requests
- add unit tests for REST proxy fetch wiring and invalid-proxy fallback

## Why
In restricted networks, gateway proxy could be enabled while startup REST calls still used direct network access, causing:
- `Failed to resolve Discord application id`
- allowlist resolution failures before monitor fully starts

This change makes startup behavior consistent with proxy configuration.

## Testing
- `pnpm vitest run --config vitest.unit.config.ts src/discord/monitor/provider.rest-proxy.test.ts src/discord/monitor/provider.proxy.test.ts src/discord/monitor/provider.skill-dedupe.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Routes Discord startup REST calls (application-id lookup and allowlist resolution) through the same proxy configured via `channels.discord.proxy`, fixing failures in restricted networks where the gateway proxy was enabled but REST calls used direct access.

- Adds `resolveDiscordRestFetch()` in `provider.ts` using `undici.ProxyAgent` — mirrors the established pattern in `src/telegram/proxy.ts`
- Threads the proxy-aware fetcher into `resolveDiscordChannelAllowlist`, `resolveDiscordUserAllowlist`, and `fetchDiscordApplicationId`
- Gracefully falls back to global `fetch` on invalid proxy URLs with error logging
- Updates config help text to clarify the proxy scope now covers gateway + API requests
- Adds unit tests covering valid proxy routing and invalid-proxy fallback

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it follows established proxy patterns from the Telegram provider and all downstream consumers already accept an optional fetcher parameter.
- The changes are straightforward and follow the exact same proxy pattern used in `src/telegram/proxy.ts`. The new `resolveDiscordRestFetch` function mirrors `makeProxyFetch`, the type casting is identical, and the error-handling fallback is robust. All three call sites (`fetchDiscordApplicationId`, `resolveDiscordChannelAllowlist`, `resolveDiscordUserAllowlist`) already accept an optional `fetcher` parameter, so the plumbing is seamless. The help text update is accurate. Tests cover both the happy path and error fallback.
- No files require special attention.

<sub>Last reviewed commit: 6043f56</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->