### PR TITLE
fix(cli): speed up completion plugin loading

### DIFF
--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -36,6 +36,9 @@ Required keys:
 Optional keys:
 
 - `kind` (string): plugin kind (example: `"memory"`).
+- `hasCliCommands` (boolean): optional completion hint for this plugin.
+  - Set to `false` if the plugin does not register CLI commands. This lets completion generation skip loading the plugin module.
+  - Omit the field, or set `true`, if the plugin may register CLI commands.
 - `channels` (array): channel ids registered by this plugin (example: `["matrix"]`).
 - `providers` (array): provider ids registered by this plugin.
 - `skills` (array): skill directories to load (relative to the plugin root).
@@ -66,6 +69,8 @@ Optional keys:
 - The manifest is **required for all plugins**, including local filesystem loads.
 - Runtime still loads the plugin module separately; the manifest is only for
   discovery + validation.
+- `hasCliCommands` is optional. Plugins that do not include it keep the same
+  runtime behavior.
 - If your plugin depends on native modules, document the build steps and any
   package-manager allowlist requirements (for example, pnpm `allow-build-scripts`
   - `pnpm rebuild <package>`).

--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -321,6 +321,10 @@ If stored integrity metadata changes between updates, OpenClaw warns and asks fo
 
 Plugins may also register their own top‑level commands (example: `openclaw voicecall`).
 
+If your plugin does not register any CLI commands, set `"hasCliCommands": false` in
+`openclaw.plugin.json`. This helps `openclaw completion` skip unnecessary plugin
+module loads. This field is optional; omitting it keeps existing behavior.
+
 ## Plugin API (overview)
 
 Plugins export either:

--- a/extensions/device-pair/index.ts
+++ b/extensions/device-pair/index.ts
@@ -1,12 +1,11 @@
 import os from "node:os";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import {
-  approveDevicePairing,
-  listDevicePairing,
   resolveGatewayBindUrl,
   runPluginCommandWithTimeout,
   resolveTailnetHostWithRunner,
 } from "openclaw/plugin-sdk";
+import { approveDevicePairing, listDevicePairing } from "openclaw/plugin-sdk/device-pairing";
 import qrcode from "qrcode-terminal";
 
 function renderQrAscii(data: string): Promise<string> {

--- a/extensions/device-pair/openclaw.plugin.json
+++ b/extensions/device-pair/openclaw.plugin.json
@@ -2,6 +2,7 @@
   "id": "device-pair",
   "name": "Device Pairing",
   "description": "Generate setup codes and approve device pairing requests.",
+  "hasCliCommands": false,
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/extensions/memory-core/index.ts
+++ b/extensions/memory-core/index.ts
@@ -1,5 +1,5 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
-import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
+import { emptyPluginConfigSchema } from "openclaw/plugin-sdk/config-schema";
 
 const memoryCorePlugin = {
   id: "memory-core",

--- a/extensions/phone-control/openclaw.plugin.json
+++ b/extensions/phone-control/openclaw.plugin.json
@@ -2,6 +2,7 @@
   "id": "phone-control",
   "name": "Phone Control",
   "description": "Arm/disarm high-risk phone node commands (camera/screen/writes) with an optional auto-expiry.",
+  "hasCliCommands": false,
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/extensions/talk-voice/openclaw.plugin.json
+++ b/extensions/talk-voice/openclaw.plugin.json
@@ -2,6 +2,7 @@
   "id": "talk-voice",
   "name": "Talk Voice",
   "description": "Manage Talk voice selection (list/set).",
+  "hasCliCommands": false,
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/extensions/telegram/index.ts
+++ b/extensions/telegram/index.ts
@@ -1,5 +1,5 @@
 import type { ChannelPlugin, OpenClawPluginApi } from "openclaw/plugin-sdk";
-import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
+import { emptyPluginConfigSchema } from "openclaw/plugin-sdk/config-schema";
 import { telegramPlugin } from "./src/channel.js";
 import { setTelegramRuntime } from "./src/runtime.js";
 

--- a/extensions/telegram/openclaw.plugin.json
+++ b/extensions/telegram/openclaw.plugin.json
@@ -1,5 +1,6 @@
 {
   "id": "telegram",
+  "hasCliCommands": false,
   "channels": ["telegram"],
   "configSchema": {
     "type": "object",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,14 @@
       "types": "./dist/plugin-sdk/account-id.d.ts",
       "default": "./dist/plugin-sdk/account-id.js"
     },
+    "./plugin-sdk/device-pairing": {
+      "types": "./dist/plugin-sdk/device-pairing.d.ts",
+      "default": "./dist/plugin-sdk/device-pairing.js"
+    },
+    "./plugin-sdk/config-schema": {
+      "types": "./dist/plugin-sdk/config-schema.d.ts",
+      "default": "./dist/plugin-sdk/config-schema.js"
+    },
     "./cli-entry": "./openclaw.mjs"
   },
   "scripts": {

--- a/scripts/write-plugin-sdk-entry-dts.ts
+++ b/scripts/write-plugin-sdk-entry-dts.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 //
 // Our package export map points subpath `types` at `dist/plugin-sdk/<entry>.d.ts`, so we
 // generate stable entry d.ts files that re-export the real declarations.
-const entrypoints = ["index", "account-id"] as const;
+const entrypoints = ["index", "account-id", "device-pairing", "config-schema"] as const;
 for (const entry of entrypoints) {
   const out = path.join(process.cwd(), `dist/plugin-sdk/${entry}.d.ts`);
   fs.mkdirSync(path.dirname(out), { recursive: true });

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -263,14 +263,14 @@ export function registerCompletionCli(program: Command) {
         }
       }
 
-      // Eagerly register all subcommands to build the full tree
+      // Eagerly register all subcommands to build the full tree.
       const entries = getSubCliEntries();
       for (const entry of entries) {
         // Skip completion command itself to avoid cycle if we were to add it to the list
         if (entry.name === "completion") {
           continue;
         }
-        await registerSubCliByName(program, entry.name);
+        await registerSubCliByName(program, entry.name, { forCompletion: true });
       }
 
       if (options.writeState) {

--- a/src/cli/pairing-cli.ts
+++ b/src/cli/pairing-cli.ts
@@ -49,8 +49,27 @@ async function notifyApproved(channel: PairingChannel, id: string) {
   await notifyPairingApproved({ channelId: channel, id, cfg });
 }
 
-export function registerPairingCli(program: Command) {
-  const channels = listPairingChannels();
+type PairingCliRegisterOptions = {
+  forCompletionBuild?: boolean;
+};
+
+function resolveChannelHelpLabel(forCompletionBuild = false): string {
+  if (forCompletionBuild) {
+    return "Channel id";
+  }
+  try {
+    const channels = listPairingChannels();
+    if (channels.length > 0) {
+      return `Channel (${channels.join(", ")})`;
+    }
+  } catch {
+    // Fall back to generic label when plugins are unavailable.
+  }
+  return "Channel id";
+}
+
+export function registerPairingCli(program: Command, options: PairingCliRegisterOptions = {}) {
+  const channelHelpLabel = resolveChannelHelpLabel(options.forCompletionBuild);
   const pairing = program
     .command("pairing")
     .description("Secure DM pairing (approve inbound requests)")
@@ -63,11 +82,12 @@ export function registerPairingCli(program: Command) {
   pairing
     .command("list")
     .description("List pending pairing requests")
-    .option("--channel <channel>", `Channel (${channels.join(", ")})`)
+    .option("--channel <channel>", channelHelpLabel)
     .option("--account <accountId>", "Account id (for multi-account channels)")
-    .argument("[channel]", `Channel (${channels.join(", ")})`)
+    .argument("[channel]", channelHelpLabel)
     .option("--json", "Print JSON", false)
     .action(async (channelArg, opts) => {
+      const channels = listPairingChannels();
       const channelRaw = opts.channel ?? channelArg ?? (channels.length === 1 ? channels[0] : "");
       if (!channelRaw) {
         throw new Error(
@@ -114,12 +134,13 @@ export function registerPairingCli(program: Command) {
   pairing
     .command("approve")
     .description("Approve a pairing code and allow that sender")
-    .option("--channel <channel>", `Channel (${channels.join(", ")})`)
+    .option("--channel <channel>", channelHelpLabel)
     .option("--account <accountId>", "Account id (for multi-account channels)")
     .argument("<codeOrChannel>", "Pairing code (or channel when using 2 args)")
     .argument("[code]", "Pairing code (when channel is passed as the 1st arg)")
     .option("--notify", "Notify the requester on the same channel", false)
     .action(async (codeOrChannel, code, opts) => {
+      const channels = listPairingChannels();
       const defaultChannel = channels.length === 1 ? channels[0] : "";
       const usingExplicitChannel = Boolean(opts.channel);
       const hasPositionalCode = code != null;

--- a/src/cli/program/preaction.ts
+++ b/src/cli/program/preaction.ts
@@ -28,6 +28,7 @@ const PLUGIN_REQUIRED_COMMANDS = new Set([
   "agents",
   "configure",
   "onboard",
+  "pairing",
 ]);
 
 function getRootCommand(command: Command): Command {

--- a/src/plugin-sdk/config-schema.ts
+++ b/src/plugin-sdk/config-schema.ts
@@ -1,0 +1,1 @@
+export { emptyPluginConfigSchema } from "../plugins/config-schema.js";

--- a/src/plugin-sdk/device-pairing.ts
+++ b/src/plugin-sdk/device-pairing.ts
@@ -1,0 +1,15 @@
+export type {
+  DeviceAuthTokenSummary,
+  DevicePairingList,
+  DevicePairingPendingRequest,
+  PairedDevice,
+} from "../infra/device-pairing.js";
+export {
+  approveDevicePairing,
+  listDevicePairing,
+  rejectDevicePairing,
+  requestDevicePairing,
+  rotateDeviceToken,
+  revokeDeviceToken,
+  verifyDeviceToken,
+} from "../infra/device-pairing.js";

--- a/src/plugins/cli.ts
+++ b/src/plugins/cli.ts
@@ -21,6 +21,7 @@ export function registerPluginCliCommands(program: Command, cfg?: OpenClawConfig
     config,
     workspaceDir,
     logger,
+    mode: "cli",
   });
 
   const existingCommands = new Set(program.commands.map((cmd) => cmd.name()));

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -148,6 +148,131 @@ afterAll(() => {
 });
 
 describe("loadOpenClawPlugins", () => {
+  it("skips module import in cli mode when manifest declares no CLI commands", () => {
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = "/nonexistent/bundled/plugins";
+    const dir = makeTempDir();
+    const file = path.join(dir, "no-cli.js");
+    fs.writeFileSync(
+      file,
+      `throw new Error("should not import module in cli mode when hasCliCommands is false");`,
+      "utf-8",
+    );
+    fs.writeFileSync(
+      path.join(dir, "openclaw.plugin.json"),
+      JSON.stringify(
+        {
+          id: "no-cli",
+          hasCliCommands: false,
+          configSchema: EMPTY_PLUGIN_SCHEMA,
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      mode: "cli",
+      workspaceDir: dir,
+      config: {
+        plugins: {
+          load: { paths: [file] },
+          allow: ["no-cli"],
+        },
+      },
+    });
+
+    const plugin = registry.plugins.find((entry) => entry.id === "no-cli");
+    expect(plugin?.status).toBe("loaded");
+    expect(plugin?.error).toBeUndefined();
+  });
+
+  it("still imports plugin module in cli mode when manifest does not declare hasCliCommands", () => {
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = "/nonexistent/bundled/plugins";
+    const dir = makeTempDir();
+    const file = path.join(dir, "legacy-manifest.js");
+    fs.writeFileSync(file, `throw new Error("legacy manifest import path exercised");`, "utf-8");
+    fs.writeFileSync(
+      path.join(dir, "openclaw.plugin.json"),
+      JSON.stringify(
+        {
+          id: "legacy-manifest",
+          configSchema: EMPTY_PLUGIN_SCHEMA,
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      mode: "cli",
+      workspaceDir: dir,
+      config: {
+        plugins: {
+          load: { paths: [file] },
+          allow: ["legacy-manifest"],
+        },
+      },
+    });
+
+    const plugin = registry.plugins.find((entry) => entry.id === "legacy-manifest");
+    expect(plugin?.status).toBe("error");
+    expect(plugin?.error).toContain("legacy manifest import path exercised");
+  });
+
+  it("uses separate cache entries for cli and full modes", () => {
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = "/nonexistent/bundled/plugins";
+    const dir = makeTempDir();
+    const file = path.join(dir, "cache-mode-separation.js");
+    fs.writeFileSync(file, `throw new Error("full mode import path exercised");`, "utf-8");
+    fs.writeFileSync(
+      path.join(dir, "openclaw.plugin.json"),
+      JSON.stringify(
+        {
+          id: "cache-mode-separation",
+          hasCliCommands: false,
+          configSchema: EMPTY_PLUGIN_SCHEMA,
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    const cliRegistry = loadOpenClawPlugins({
+      mode: "cli",
+      workspaceDir: dir,
+      config: {
+        plugins: {
+          load: { paths: [file] },
+          allow: ["cache-mode-separation"],
+        },
+      },
+    });
+
+    const cliPlugin = cliRegistry.plugins.find((entry) => entry.id === "cache-mode-separation");
+    expect(cliPlugin?.status).toBe("loaded");
+    expect(cliPlugin?.error).toBeUndefined();
+
+    const fullRegistry = loadOpenClawPlugins({
+      mode: "full",
+      workspaceDir: dir,
+      config: {
+        plugins: {
+          load: { paths: [file] },
+          allow: ["cache-mode-separation"],
+        },
+      },
+    });
+
+    const fullPlugin = fullRegistry.plugins.find((entry) => entry.id === "cache-mode-separation");
+    expect(fullPlugin?.status).toBe("error");
+    expect(fullPlugin?.error).toContain("full mode import path exercised");
+  });
+
   it("disables bundled plugins by default", () => {
     const bundledDir = makeTempDir();
     writePlugin({

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -38,7 +38,7 @@ export type PluginLoadOptions = {
   logger?: PluginLogger;
   coreGatewayHandlers?: Record<string, GatewayRequestHandler>;
   cache?: boolean;
-  mode?: "full" | "validate";
+  mode?: "full" | "validate" | "cli";
 };
 
 const registryCache = new Map<string, PluginRegistry>();
@@ -86,12 +86,28 @@ const resolvePluginSdkAccountIdAlias = (): string | null => {
   return resolvePluginSdkAliasFile({ srcFile: "account-id.ts", distFile: "account-id.js" });
 };
 
+const resolvePluginSdkDevicePairingAlias = (): string | null => {
+  return resolvePluginSdkAliasFile({
+    srcFile: "device-pairing.ts",
+    distFile: "device-pairing.js",
+  });
+};
+
+const resolvePluginSdkConfigSchemaAlias = (): string | null => {
+  return resolvePluginSdkAliasFile({
+    srcFile: "config-schema.ts",
+    distFile: "config-schema.js",
+  });
+};
+
 function buildCacheKey(params: {
   workspaceDir?: string;
   plugins: NormalizedPluginsConfig;
+  mode: PluginLoadOptions["mode"];
 }): string {
   const workspaceKey = params.workspaceDir ? resolveUserPath(params.workspaceDir) : "";
-  return `${workspaceKey}::${JSON.stringify(params.plugins)}`;
+  const mode = params.mode ?? "full";
+  return `${workspaceKey}::${mode}::${JSON.stringify(params.plugins)}`;
 }
 
 function validatePluginConfig(params: {
@@ -362,10 +378,12 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
   const cfg = applyTestPluginDefaults(options.config ?? {}, process.env);
   const logger = options.logger ?? defaultLogger();
   const validateOnly = options.mode === "validate";
+  const cliOnly = options.mode === "cli";
   const normalized = normalizePluginsConfig(cfg.plugins);
   const cacheKey = buildCacheKey({
     workspaceDir: options.workspaceDir,
     plugins: normalized,
+    mode: options.mode,
   });
   const cacheEnabled = options.cache !== false;
   if (cacheEnabled) {
@@ -421,16 +439,27 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     }
     const pluginSdkAlias = resolvePluginSdkAlias();
     const pluginSdkAccountIdAlias = resolvePluginSdkAccountIdAlias();
+    const pluginSdkDevicePairingAlias = resolvePluginSdkDevicePairingAlias();
+    const pluginSdkConfigSchemaAlias = resolvePluginSdkConfigSchemaAlias();
     jitiLoader = createJiti(import.meta.url, {
       interopDefault: true,
       extensions: [".ts", ".tsx", ".mts", ".cts", ".mtsx", ".ctsx", ".js", ".mjs", ".cjs", ".json"],
-      ...(pluginSdkAlias || pluginSdkAccountIdAlias
+      ...(pluginSdkAlias ||
+      pluginSdkAccountIdAlias ||
+      pluginSdkDevicePairingAlias ||
+      pluginSdkConfigSchemaAlias
         ? {
             alias: {
-              ...(pluginSdkAlias ? { "openclaw/plugin-sdk": pluginSdkAlias } : {}),
               ...(pluginSdkAccountIdAlias
                 ? { "openclaw/plugin-sdk/account-id": pluginSdkAccountIdAlias }
                 : {}),
+              ...(pluginSdkDevicePairingAlias
+                ? { "openclaw/plugin-sdk/device-pairing": pluginSdkDevicePairingAlias }
+                : {}),
+              ...(pluginSdkConfigSchemaAlias
+                ? { "openclaw/plugin-sdk/config-schema": pluginSdkConfigSchemaAlias }
+                : {}),
+              ...(pluginSdkAlias ? { "openclaw/plugin-sdk": pluginSdkAlias } : {}),
             },
           }
         : {}),
@@ -513,6 +542,12 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         source: record.source,
         message: record.error,
       });
+      continue;
+    }
+
+    if (cliOnly && manifestRecord.hasCliCommands === false) {
+      registry.plugins.push(record);
+      seenIds.set(pluginId, candidate.origin);
       continue;
     }
 

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -26,6 +26,7 @@ export type PluginManifestRecord = {
   description?: string;
   version?: string;
   kind?: PluginKind;
+  hasCliCommands?: boolean;
   channels: string[];
   providers: string[];
   skills: string[];
@@ -117,6 +118,7 @@ function buildRecord(params: {
       normalizeManifestLabel(params.manifest.description) ?? params.candidate.packageDescription,
     version: normalizeManifestLabel(params.manifest.version) ?? params.candidate.packageVersion,
     kind: params.manifest.kind,
+    hasCliCommands: params.manifest.hasCliCommands,
     channels: params.manifest.channels ?? [],
     providers: params.manifest.providers ?? [],
     skills: params.manifest.skills ?? [],

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -11,6 +11,7 @@ export type PluginManifest = {
   id: string;
   configSchema: Record<string, unknown>;
   kind?: PluginKind;
+  hasCliCommands?: boolean;
   channels?: string[];
   providers?: string[];
   skills?: string[];
@@ -69,6 +70,11 @@ export function loadPluginManifest(rootDir: string): PluginManifestLoadResult {
   }
 
   const kind = typeof raw.kind === "string" ? (raw.kind as PluginKind) : undefined;
+  const hasCliCommands = Object.prototype.hasOwnProperty.call(raw, "hasCliCommands")
+    ? typeof raw.hasCliCommands === "boolean"
+      ? raw.hasCliCommands
+      : undefined
+    : undefined;
   const name = typeof raw.name === "string" ? raw.name.trim() : undefined;
   const description = typeof raw.description === "string" ? raw.description.trim() : undefined;
   const version = typeof raw.version === "string" ? raw.version.trim() : undefined;
@@ -87,6 +93,7 @@ export function loadPluginManifest(rootDir: string): PluginManifestLoadResult {
       id,
       configSchema,
       kind,
+      hasCliCommands,
       channels,
       providers,
       skills,

--- a/tsconfig.plugin-sdk.dts.json
+++ b/tsconfig.plugin-sdk.dts.json
@@ -10,6 +10,12 @@
     "rootDir": "src",
     "tsBuildInfoFile": "dist/plugin-sdk/.tsbuildinfo"
   },
-  "include": ["src/plugin-sdk/index.ts", "src/plugin-sdk/account-id.ts", "src/types/**/*.d.ts"],
+  "include": [
+    "src/plugin-sdk/index.ts",
+    "src/plugin-sdk/account-id.ts",
+    "src/plugin-sdk/device-pairing.ts",
+    "src/plugin-sdk/config-schema.ts",
+    "src/types/**/*.d.ts"
+  ],
   "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
 }

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -45,6 +45,20 @@ export default defineConfig([
     platform: "node",
   },
   {
+    entry: "src/plugin-sdk/device-pairing.ts",
+    outDir: "dist/plugin-sdk",
+    env,
+    fixedExtension: false,
+    platform: "node",
+  },
+  {
+    entry: "src/plugin-sdk/config-schema.ts",
+    outDir: "dist/plugin-sdk",
+    env,
+    fixedExtension: false,
+    platform: "node",
+  },
+  {
     entry: "src/extensionAPI.ts",
     env,
     fixedExtension: false,


### PR DESCRIPTION
## Summary

- `openclaw completion` now passes an explicit completion flag while it eagerly registers subcommands, so completion builds can skip pairing-only registration work.
- Plugin CLI registration loads plugins in a dedicated `cli` mode. In that mode, manifests may declare `hasCliCommands: false` to avoid importing plugin modules that never register CLI commands.
- The plugin loader cache key now includes load mode, and bundled manifests/docs were updated for the new hint.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related https://github.com/forketyfork/openclaw/pull/2

## User-visible / Behavior Changes

- Completion generation trims some unnecessary plugin and pairing setup work.
- Plugin authors can add `hasCliCommands: false` to `openclaw.plugin.json` when a plugin never registers CLI commands.
- Normal pairing command execution still resolves channels at runtime; completion builds use the generic channel label and skip that lookup.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Darwin 25.3.0
- Runtime/container: Node v25.8.1
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): clean archives of `upstream/main` and this branch; plus one isolated config enabling `device-pair`, `phone-control`, `talk-voice`, and `telegram`

### Steps

1. `pnpm build` in clean archives of `upstream/main` and this branch.
2. Benchmark `node openclaw.mjs completion --shell zsh >/dev/null` with `hyperfine`.
3. Repeat with `NODE_DISABLE_COMPILE_CACHE=1`.
4. Repeat with the isolated plugin config above.

### Expected

- Completion generation stays at least neutral on current `main`, with small wins where skipped plugin work matters.

### Actual

- On current `main`, the measured impact is flat to slightly positive depending on cache/config.

## Evidence

- [x] Perf numbers (if relevant)

### Benchmarks (`completion --shell zsh`, 7 runs each)

| Scenario | `upstream/main` | This branch | Result |
| --- | ---: | ---: | --- |
| Default env | 1.686 s | 1.676 s | 0.6% faster |
| `NODE_DISABLE_COMPILE_CACHE=1` | 1.965 s | 1.849 s | 6.0% faster |
| Plugin config | 1.240 s | 1.254 s | 1.1% slower |
| Plugin config + `NODE_DISABLE_COMPILE_CACHE=1` | 1.362 s | 1.343 s | 1.4% faster |

## Human Verification (required)

What I personally verified (not just CI), and how:

- Verified scenarios:
  - `node openclaw.mjs completion --shell zsh` works from built output.
  - `node openclaw.mjs pairing approve --help` still renders normally; in this environment it falls back to `Channel id`.
  - Clean benchmarks against `upstream/main` after rebuilding both trees.
- Edge cases checked:
  - `src/plugins/loader.test.ts` covers `hasCliCommands: false` and `cli` vs `full` cache separation.
  - `src/cli/pairing-cli.test.ts` covers deferred channel resolution during completion builds.
- What you did **not** verify:
  - Live end-to-end behavior for every channel/plugin combination.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `src/cli/completion-cli.ts`, `src/cli/pairing-cli.ts`, `src/cli/program/register.subclis.ts`, `src/plugins/cli.ts`, `src/plugins/loader.ts`
- Known bad symptoms reviewers should watch for:
  - Missing plugin CLI commands when a manifest incorrectly declares `hasCliCommands: false`.
  - Completion or pairing help regressions.

## Risks and Mitigations

- Risk:
  - A plugin manifest could incorrectly opt out of CLI loading.
  - Mitigation:
    - The field is optional, bundled manifests were updated explicitly, and targeted tests cover the skip path plus cache separation.

## AI Assistance

- [x] AI-assisted PR
- Testing degree: Rebased + targeted tests already green, plus fresh clean benchmarks against `upstream/main`
