### PR TITLE
feat(feishu): add bitable create app and create field tools

### DIFF
--- a/extensions/feishu/src/bitable.ts
+++ b/extensions/feishu/src/bitable.ts
@@ -224,6 +224,198 @@ async function createRecord(
   };
 }
 
+/** Logger interface for cleanup operations */
+type CleanupLogger = {
+  debug: (msg: string) => void;
+  warn: (msg: string) => void;
+};
+
+/** Default field types created for new Bitable tables (to be cleaned up) */
+const DEFAULT_CLEANUP_FIELD_TYPES = new Set([3, 5, 17]); // SingleSelect, DateTime, Attachment
+
+/** Clean up default placeholder rows and fields in a newly created Bitable table */
+async function cleanupNewBitable(
+  client: ReturnType<typeof createFeishuClient>,
+  appToken: string,
+  tableId: string,
+  tableName: string,
+  logger: CleanupLogger,
+): Promise<{ cleanedRows: number; cleanedFields: number }> {
+  let cleanedRows = 0;
+  let cleanedFields = 0;
+
+  // Step 1: Clean up default fields
+  const fieldsRes = await client.bitable.appTableField.list({
+    path: { app_token: appToken, table_id: tableId },
+  });
+
+  if (fieldsRes.code === 0 && fieldsRes.data?.items) {
+    // Step 1a: Rename primary field to the table name (works for both Feishu and Lark)
+    const primaryField = fieldsRes.data.items.find((f) => f.is_primary);
+    if (primaryField?.field_id) {
+      try {
+        const newFieldName = tableName.length <= 20 ? tableName : "Name";
+        await client.bitable.appTableField.update({
+          path: {
+            app_token: appToken,
+            table_id: tableId,
+            field_id: primaryField.field_id,
+          },
+          data: {
+            field_name: newFieldName,
+            type: 1,
+          },
+        });
+        cleanedFields++;
+      } catch (err) {
+        logger.debug(`Failed to rename primary field: ${err}`);
+      }
+    }
+
+    // Step 1b: Delete default placeholder fields by type (works for both Feishu and Lark)
+    const defaultFieldsToDelete = fieldsRes.data.items.filter(
+      (f) => !f.is_primary && DEFAULT_CLEANUP_FIELD_TYPES.has(f.type ?? 0),
+    );
+
+    for (const field of defaultFieldsToDelete) {
+      if (field.field_id) {
+        try {
+          await client.bitable.appTableField.delete({
+            path: {
+              app_token: appToken,
+              table_id: tableId,
+              field_id: field.field_id,
+            },
+          });
+          cleanedFields++;
+        } catch (err) {
+          logger.debug(`Failed to delete default field ${field.field_name}: ${err}`);
+        }
+      }
+    }
+  }
+
+  // Step 2: Delete empty placeholder rows (batch when possible)
+  const recordsRes = await client.bitable.appTableRecord.list({
+    path: { app_token: appToken, table_id: tableId },
+    params: { page_size: 100 },
+  });
+
+  if (recordsRes.code === 0 && recordsRes.data?.items) {
+    const emptyRecordIds = recordsRes.data.items
+      .filter((r) => !r.fields || Object.keys(r.fields).length === 0)
+      .map((r) => r.record_id)
+      .filter((id): id is string => Boolean(id));
+
+    if (emptyRecordIds.length > 0) {
+      try {
+        await client.bitable.appTableRecord.batchDelete({
+          path: { app_token: appToken, table_id: tableId },
+          data: { records: emptyRecordIds },
+        });
+        cleanedRows = emptyRecordIds.length;
+      } catch {
+        // Fallback: delete one by one if batch API is unavailable
+        for (const recordId of emptyRecordIds) {
+          try {
+            await client.bitable.appTableRecord.delete({
+              path: { app_token: appToken, table_id: tableId, record_id: recordId },
+            });
+            cleanedRows++;
+          } catch (err) {
+            logger.debug(`Failed to delete empty row ${recordId}: ${err}`);
+          }
+        }
+      }
+    }
+  }
+
+  return { cleanedRows, cleanedFields };
+}
+
+async function createApp(
+  client: ReturnType<typeof createFeishuClient>,
+  name: string,
+  folderToken?: string,
+  logger?: CleanupLogger,
+) {
+  const res = await client.bitable.app.create({
+    data: {
+      name,
+      ...(folderToken && { folder_token: folderToken }),
+    },
+  });
+  if (res.code !== 0) {
+    throw new Error(res.msg);
+  }
+
+  const appToken = res.data?.app?.app_token;
+  if (!appToken) {
+    throw new Error("Failed to create Bitable: no app_token returned");
+  }
+
+  const log: CleanupLogger = logger ?? { debug: () => {}, warn: () => {} };
+  let tableId: string | undefined;
+  let cleanedRows = 0;
+  let cleanedFields = 0;
+
+  try {
+    const tablesRes = await client.bitable.appTable.list({
+      path: { app_token: appToken },
+    });
+    if (tablesRes.code === 0 && tablesRes.data?.items && tablesRes.data.items.length > 0) {
+      tableId = tablesRes.data.items[0].table_id ?? undefined;
+      if (tableId) {
+        const cleanup = await cleanupNewBitable(client, appToken, tableId, name, log);
+        cleanedRows = cleanup.cleanedRows;
+        cleanedFields = cleanup.cleanedFields;
+      }
+    }
+  } catch (err) {
+    log.debug(`Cleanup failed (non-critical): ${err}`);
+  }
+
+  return {
+    app_token: appToken,
+    table_id: tableId,
+    name: res.data?.app?.name,
+    url: res.data?.app?.url,
+    cleaned_placeholder_rows: cleanedRows,
+    cleaned_default_fields: cleanedFields,
+    hint: tableId
+      ? `Table created. Use app_token="${appToken}" and table_id="${tableId}" for other bitable tools.`
+      : "Table created. Use feishu_bitable_get_meta to get table_id and field details.",
+  };
+}
+
+async function createField(
+  client: ReturnType<typeof createFeishuClient>,
+  appToken: string,
+  tableId: string,
+  fieldName: string,
+  fieldType: number,
+  property?: Record<string, unknown>,
+) {
+  const res = await client.bitable.appTableField.create({
+    path: { app_token: appToken, table_id: tableId },
+    data: {
+      field_name: fieldName,
+      type: fieldType,
+      ...(property && { property }),
+    },
+  });
+  if (res.code !== 0) {
+    throw new Error(res.msg);
+  }
+
+  return {
+    field_id: res.data?.field?.field_id,
+    field_name: res.data?.field?.field_name,
+    type: res.data?.field?.type,
+    type_name: FIELD_TYPE_NAMES[res.data?.field?.type ?? 0] || `type_${res.data?.field?.type}`,
+  };
+}
+
 async function updateRecord(
   client: ReturnType<typeof createFeishuClient>,
   appToken: string,
@@ -294,6 +486,36 @@ const CreateRecordSchema = Type.Object({
     description:
       "Field values keyed by field name. Format by type: Text='string', Number=123, SingleSelect='Option', MultiSelect=['A','B'], DateTime=timestamp_ms, User=[{id:'ou_xxx'}], URL={text:'Display',link:'https://...'}",
   }),
+});
+
+const CreateAppSchema = Type.Object({
+  name: Type.String({
+    description: "Name for the new Bitable application",
+  }),
+  folder_token: Type.Optional(
+    Type.String({
+      description: "Optional folder token to place the Bitable in a specific folder",
+    }),
+  ),
+});
+
+const CreateFieldSchema = Type.Object({
+  app_token: Type.String({
+    description:
+      "Bitable app token (use feishu_bitable_get_meta to get from URL, or feishu_bitable_create_app to create new)",
+  }),
+  table_id: Type.String({ description: "Table ID (from URL: ?table=YYY)" }),
+  field_name: Type.String({ description: "Name for the new field" }),
+  field_type: Type.Number({
+    description:
+      "Field type ID: 1=Text, 2=Number, 3=SingleSelect, 4=MultiSelect, 5=DateTime, 7=Checkbox, 11=User, 13=Phone, 15=URL, 17=Attachment, 18=SingleLink, 19=Lookup, 20=Formula, 21=DuplexLink, 22=Location, 23=GroupChat, 1001=CreatedTime, 1002=ModifiedTime, 1003=CreatedUser, 1004=ModifiedUser, 1005=AutoNumber",
+    minimum: 1,
+  }),
+  property: Type.Optional(
+    Type.Record(Type.String(), Type.Any(), {
+      description: "Field-specific properties (e.g., options for SingleSelect, format for Number)",
+    }),
+  ),
 });
 
 const UpdateRecordSchema = Type.Object({
@@ -457,5 +679,61 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
     { name: "feishu_bitable_update_record" },
   );
 
-  api.logger.info?.(`feishu_bitable: Registered 6 bitable tools`);
+  // Tool 6: feishu_bitable_create_app
+  api.registerTool(
+    {
+      name: "feishu_bitable_create_app",
+      label: "Feishu Bitable Create App",
+      description: "Create a new Bitable (multidimensional table) application",
+      parameters: CreateAppSchema,
+      async execute(_toolCallId, params) {
+        const { name, folder_token } = params as { name: string; folder_token?: string };
+        try {
+          const result = await createApp(getClient(), name, folder_token, {
+            debug: (msg) => api.logger.debug?.(msg),
+            warn: (msg) => api.logger.warn?.(msg),
+          });
+          return json(result);
+        } catch (err) {
+          return json({ error: err instanceof Error ? err.message : String(err) });
+        }
+      },
+    },
+    { name: "feishu_bitable_create_app" },
+  );
+
+  // Tool 7: feishu_bitable_create_field
+  api.registerTool(
+    {
+      name: "feishu_bitable_create_field",
+      label: "Feishu Bitable Create Field",
+      description: "Create a new field (column) in a Bitable table",
+      parameters: CreateFieldSchema,
+      async execute(_toolCallId, params) {
+        const { app_token, table_id, field_name, field_type, property } = params as {
+          app_token: string;
+          table_id: string;
+          field_name: string;
+          field_type: number;
+          property?: Record<string, unknown>;
+        };
+        try {
+          const result = await createField(
+            getClient(),
+            app_token,
+            table_id,
+            field_name,
+            field_type,
+            property,
+          );
+          return json(result);
+        } catch (err) {
+          return json({ error: err instanceof Error ? err.message : String(err) });
+        }
+      },
+    },
+    { name: "feishu_bitable_create_field" },
+  );
+
+  api.logger.info?.("feishu_bitable: Registered bitable tools");
 }


### PR DESCRIPTION
#### Summary

Enable programmatic creation of Feishu/Lark Bitable (multidimensional tables) in OpenClaw.

Previously, the feishu bitable toolset could only read/update existing tables — users had no way to create new Bitable applications through the AI agent. This PR adds two new tools and auto-cleanup logic so newly created tables are immediately usable without manual cleanup.
<img width="1334" height="1262" alt="image" src="https://github.com/user-attachments/assets/7862a343-8846-4ac2-a0de-6768decf6b11" />
<img width="1958" height="760" alt="image" src="https://github.com/user-attachments/assets/e1ca4c21-a676-47d0-baa2-f8f3744fca68" />


lobster-biscuit

#### Use Cases

1. **Create a new Bitable via AI agent**: Users can ask the agent to create a multidimensional table directly, without leaving the chat to manually create one in the Feishu/Lark UI.
2. **Add custom fields programmatically**: After creating a table, the agent can add columns with specific types (Text, Number, SingleSelect, etc.) to match the user's needs.
3. **Clean tables out of the box**: Feishu creates ~10 placeholder rows and 3 default columns (SingleSelect, DateTime, Attachment) for every new table. The auto-cleanup removes these so the agent starts with a blank canvas.

#### Behavior Changes

- New tool: `feishu_bitable_create_app` — creates a Bitable application with auto-cleanup:
  - Removes empty placeholder rows (batch delete with sequential fallback)
  - Removes default placeholder fields by field type (compatible with both Feishu CN and Lark intl)
  - Renames primary field to the table name (≤20 chars) or "Name"
  - Returns `table_id` in response so callers skip an extra `get_meta` call
- New tool: `feishu_bitable_create_field` — creates a custom field (column) with type and properties
- Total bitable tools: 6 → 8
- No changes to existing tools; fully backward compatible

#### Existing Functionality Check

- [x] I searched the codebase for existing functionality.
      Searches performed:
  - Searched `extensions/feishu/src/bitable.ts` — confirmed no existing create_app or create_field tools
  - Searched `bitable.app.create` across codebase — no prior usage
  - Checked Feishu SDK types for `batchDelete` support on `appTableRecord`

#### Tests

- Manually tested multiple table creations with various Chinese and English names
- Verified auto-cleanup correctly removes placeholder rows and default fields
- Verified compatibility: field matching uses type IDs (not locale-dependent field names)
- No unit tests added (Feishu tools require live API credentials; consistent with existing bitable tools which also have no unit tests)
- `pnpm test`: 594/595 files passed, 4760/4761 tests passed. Unrelated flaky test failure in `src/process/exec.test.ts` (pre-existing timing issue, not caused by this change).

#### Manual Testing

### Prerequisites

- Feishu/Lark app with `bitable:app` scope (including `base:app:create`)
- OpenClaw configured with valid `channels.feishu.appId` and `appSecret`

### Steps

1. `openclaw gateway start`
2. Ask the agent: "Create a new Bitable called 'Test Table'"
3. Verify: table is created, placeholder rows/fields are cleaned, `table_id` is returned
4. Ask the agent: "Add a Number field called 'Score' to the table"
5. Verify: field is created with correct type

#### Evidence

Tested live with real Feishu API and APP— tables created successfully with auto-cleanup.

**Sign-Off**

- [x] AI-assisted: Yes — developed with AI agent assistance (Claude), reviewed and tested by human
- Models used: Claude (Cursor IDE)
- Submitter effort (self-reported): Idea origination, permission configuration, iterative testing, code review
- Degree of testing: Lightly tested (live API, no automated unit tests)
- [x] I understand what the code does

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds two new Feishu Bitable tools (`feishu_bitable_create_app` and `feishu_bitable_create_field`) to enable programmatic creation of Bitable applications and custom fields. The `create_app` tool includes auto-cleanup logic that removes Feishu's default placeholder rows and fields from newly created tables, providing a clean starting point for the AI agent.

- New `cleanupNewBitable` helper renames the primary field, deletes default placeholder fields by type ID (SingleSelect, DateTime, Attachment), and batch-deletes empty placeholder rows with a sequential fallback
- New `createApp` function creates a Bitable app, retrieves the default table, runs cleanup, and returns `app_token` + `table_id` for downstream tool usage
- New `createField` function creates a field with configurable type and properties
- Tool schemas follow existing conventions (`Type.Object`, `Type.Optional`, `Type.Record`) and comply with the repo's schema guardrails (no `Type.Union`, no `format` property names)
- Total registered bitable tools increases from 6 to 8; no changes to existing tools

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it adds new tools without modifying existing ones, follows established patterns, and includes proper error handling.
- Score of 4 reflects that this is a well-structured additive change that follows existing codebase patterns. The new tools are isolated from existing functionality, error handling is thorough with try-catch and graceful fallbacks, and tool schemas comply with the repo's guardrails. The cleanup logic operates only on freshly created tables, minimizing risk of data loss. Deducted 1 point because there are no automated tests (though this is consistent with the existing bitable tools) and the live API dependency makes verification harder.
- No files require special attention. The single changed file (`extensions/feishu/src/bitable.ts`) is additive and doesn't modify existing tool behavior.

<sub>Last reviewed commit: 153027d</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))

<!-- /greptile_comment -->