### PR TITLE
fix(tts): collect all provider errors instead of only the last

### DIFF
--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -551,14 +551,14 @@ export async function textToSpeech(params: {
   const provider = overrideProvider ?? userProvider;
   const providers = resolveTtsProviderOrder(provider);
 
-  let lastError: string | undefined;
+  const errors: string[] = [];
 
   for (const provider of providers) {
     const providerStart = Date.now();
     try {
       if (provider === "edge") {
         if (!config.edge.enabled) {
-          lastError = "edge: disabled";
+          errors.push("edge: disabled");
           continue;
         }
 
@@ -626,7 +626,7 @@ export async function textToSpeech(params: {
 
       const apiKey = resolveTtsApiKey(config, provider);
       if (!apiKey) {
-        lastError = `No API key for ${provider}`;
+        errors.push(`${provider}: no API key`);
         continue;
       }
 
@@ -683,13 +683,13 @@ export async function textToSpeech(params: {
         voiceCompatible: output.voiceCompatible,
       };
     } catch (err) {
-      lastError = formatTtsProviderError(provider, err);
+      errors.push(formatTtsProviderError(provider, err));
     }
   }
 
   return {
     success: false,
-    error: `TTS conversion failed: ${lastError || "no providers available"}`,
+    error: `TTS conversion failed: ${errors.join("; ") || "no providers available"}`,
   };
 }
 
@@ -711,19 +711,19 @@ export async function textToSpeechTelephony(params: {
   const userProvider = getTtsProvider(config, prefsPath);
   const providers = resolveTtsProviderOrder(userProvider);
 
-  let lastError: string | undefined;
+  const errors: string[] = [];
 
   for (const provider of providers) {
     const providerStart = Date.now();
     try {
       if (provider === "edge") {
-        lastError = "edge: unsupported for telephony";
+        errors.push("edge: unsupported for telephony");
         continue;
       }
 
       const apiKey = resolveTtsApiKey(config, provider);
       if (!apiKey) {
-        lastError = `No API key for ${provider}`;
+        errors.push(`${provider}: no API key`);
         continue;
       }
 
@@ -772,13 +772,13 @@ export async function textToSpeechTelephony(params: {
         sampleRate: output.sampleRate,
       };
     } catch (err) {
-      lastError = formatTtsProviderError(provider, err);
+      errors.push(formatTtsProviderError(provider, err));
     }
   }
 
   return {
     success: false,
-    error: `TTS conversion failed: ${lastError || "no providers available"}`,
+    error: `TTS conversion failed: ${errors.join("; ") || "no providers available"}`,
   };
 }
 


### PR DESCRIPTION
## Summary
- When TTS conversion fails across multiple providers, the error message now includes **all** provider failures instead of only the last one
- Previously, `lastError` was overwritten by each failing provider, so the final error message could be misleading (e.g. showing `edge: disabled` when the real issue was an ElevenLabs timeout)
- Changed `lastError: string` to `errors: string[]` in both `textToSpeech` and `textToSpeechTelephony`

## Test plan
- [x] `pnpm build` passes
- [x] All 40 tests pass (`pnpm test`)
- [ ] Verify error messages in logs when multiple TTS providers fail

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changed error collection from `lastError: string` to `errors: string[]` in both `textToSpeech` and `textToSpeechTelephony` functions. When multiple TTS providers fail, the error message now includes all provider failures joined with `"; "` instead of only showing the last one. This prevents misleading error messages (e.g., showing "edge: disabled" when the real issue was an ElevenLabs timeout).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is straightforward, well-tested (all 40 tests pass), and improves error reporting without changing core logic. Error messages are now consistently formatted as `${provider}: <description>`, and the implementation correctly accumulates and joins all provider errors
- No files require special attention

<sub>Last reviewed commit: 9e4576d</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->