### PR TITLE
feat(ui/usage): show files read during session in context panel

### DIFF
--- a/src/infra/session-cost-usage.types.ts
+++ b/src/infra/session-cost-usage.types.ts
@@ -29,6 +29,7 @@ export type ParsedTranscriptEntry = {
   model?: string;
   stopReason?: string;
   toolNames: string[];
+  fileReadPaths: string[];
   toolResultCounts: { total: number; errors: number };
 };
 
@@ -110,6 +111,12 @@ export type SessionToolUsage = {
   tools: Array<{ name: string; count: number }>;
 };
 
+export type SessionFilesRead = {
+  totalReads: number;
+  uniqueFiles: number;
+  files: Array<{ path: string; count: number }>;
+};
+
 export type SessionModelUsage = {
   provider?: string;
   model?: string;
@@ -130,6 +137,7 @@ export type SessionCostSummary = CostUsageTotals & {
   dailyModelUsage?: SessionDailyModelUsage[];
   messageCounts?: SessionMessageCounts;
   toolUsage?: SessionToolUsage;
+  filesRead?: SessionFilesRead;
   modelUsage?: SessionModelUsage[];
   latency?: SessionLatencyStats;
 };

--- a/src/utils/transcript-tools.test.ts
+++ b/src/utils/transcript-tools.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { countToolResults, extractToolCallNames, hasToolCall } from "./transcript-tools.js";
+import {
+  countToolResults,
+  extractFileReadPaths,
+  extractToolCallNames,
+  hasToolCall,
+} from "./transcript-tools.js";
 
 describe("transcript-tools", () => {
   describe("extractToolCallNames", () => {
@@ -61,6 +66,64 @@ describe("transcript-tools", () => {
 
     it("handles non-array content", () => {
       expect(countToolResults({ content: "nope" })).toEqual({ total: 0, errors: 0 });
+    });
+  });
+
+  describe("extractFileReadPaths", () => {
+    it("extracts file path from Read tool_use block with path", () => {
+      const paths = extractFileReadPaths({
+        content: [{ type: "tool_use", name: "Read", input: { path: "/src/index.ts" } }],
+      });
+      expect(paths).toEqual(["/src/index.ts"]);
+    });
+
+    it("extracts file path from read tool_use block with file_path", () => {
+      const paths = extractFileReadPaths({
+        content: [{ type: "tool_use", name: "read", input: { file_path: "/src/app.ts" } }],
+      });
+      expect(paths).toEqual(["/src/app.ts"]);
+    });
+
+    it("extracts file path from toolCall block with arguments (OpenClaw transcript format)", () => {
+      const paths = extractFileReadPaths({
+        content: [{ type: "toolCall", name: "read", arguments: { file_path: "/src/config.ts" } }],
+      });
+      expect(paths).toEqual(["/src/config.ts"]);
+    });
+
+    it("ignores non-read tool_use blocks", () => {
+      const paths = extractFileReadPaths({
+        content: [
+          { type: "tool_use", name: "write", input: { path: "/src/out.ts" } },
+          { type: "tool_use", name: "exec", input: { command: "ls" } },
+        ],
+      });
+      expect(paths).toEqual([]);
+    });
+
+    it("handles multiple read blocks", () => {
+      const paths = extractFileReadPaths({
+        content: [
+          { type: "tool_use", name: "Read", input: { path: "/a.ts" } },
+          { type: "tool_use", name: "read", input: { path: "/b.ts" } },
+        ],
+      });
+      expect(paths).toEqual(["/a.ts", "/b.ts"]);
+    });
+
+    it("returns empty for non-array content", () => {
+      expect(extractFileReadPaths({ content: "text" })).toEqual([]);
+      expect(extractFileReadPaths({})).toEqual([]);
+    });
+
+    it("skips blocks without input or path", () => {
+      const paths = extractFileReadPaths({
+        content: [
+          { type: "tool_use", name: "read" },
+          { type: "tool_use", name: "Read", input: {} },
+        ],
+      });
+      expect(paths).toEqual([]);
     });
   });
 });

--- a/src/utils/transcript-tools.ts
+++ b/src/utils/transcript-tools.ts
@@ -46,6 +46,45 @@ export const extractToolCallNames = (message: Record<string, unknown>): string[]
 export const hasToolCall = (message: Record<string, unknown>): boolean =>
   extractToolCallNames(message).length > 0;
 
+/**
+ * Extract file paths from Read/Write/Edit tool_use blocks in a message.
+ * Returns an array of absolute file paths that were read during this message.
+ */
+export const extractFileReadPaths = (message: Record<string, unknown>): string[] => {
+  const content = message.content;
+  if (!Array.isArray(content)) {
+    return [];
+  }
+
+  const FILE_TOOL_NAMES = new Set(["read", "Read"]);
+  const paths: string[] = [];
+
+  for (const entry of content) {
+    if (!entry || typeof entry !== "object") {
+      continue;
+    }
+    const block = entry as Record<string, unknown>;
+    const type = normalizeType(block.type);
+    if (!TOOL_CALL_TYPES.has(type)) {
+      continue;
+    }
+    const name = block.name;
+    if (typeof name !== "string" || !FILE_TOOL_NAMES.has(name)) {
+      continue;
+    }
+    const input = (block.input ?? block.arguments) as Record<string, unknown> | undefined;
+    if (!input) {
+      continue;
+    }
+    const filePath = input.path ?? input.file_path ?? input.file;
+    if (typeof filePath === "string" && filePath.trim()) {
+      paths.push(filePath.trim());
+    }
+  }
+
+  return paths;
+};
+
 export const countToolResults = (message: Record<string, unknown>): ToolResultCounts => {
   const content = message.content;
   if (!Array.isArray(content)) {

--- a/ui/src/ui/usage-helpers.ts
+++ b/ui/src/ui/usage-helpers.ts
@@ -294,7 +294,7 @@ export function parseToolSummary(content: string) {
   const toolCounts = new Map<string, number>();
   const nonToolLines: string[] = [];
   for (const line of lines) {
-    const match = /^\[Tool:\s*([^\]]+)\]/.exec(line.trim());
+    const match = /^\[Tool:\s*([^\]\s]+)/.exec(line.trim());
     if (match) {
       const name = match[1];
       toolCounts.set(name, (toolCounts.get(name) ?? 0) + 1);

--- a/ui/src/ui/usage-types.ts
+++ b/ui/src/ui/usage-types.ts
@@ -75,6 +75,11 @@ export type SessionsUsageEntry = {
       uniqueTools: number;
       tools: Array<{ name: string; count: number }>;
     };
+    filesRead?: {
+      totalReads: number;
+      uniqueFiles: number;
+      files: Array<{ path: string; count: number }>;
+    };
     modelUsage?: Array<{
       provider?: string;
       model?: string;
@@ -153,6 +158,11 @@ export type SessionsUsageResult = {
       count: number;
       totals: SessionsUsageTotals;
     }>;
+    filesRead?: {
+      totalReads: number;
+      uniqueFiles: number;
+      files: Array<{ path: string; count: number }>;
+    };
     byAgent: Array<{ agentId: string; totals: SessionsUsageTotals }>;
     byChannel: Array<{ channel: string; totals: SessionsUsageTotals }>;
     latency?: {

--- a/ui/src/ui/views/usage-styles/usageStyles-part1.ts
+++ b/ui/src/ui/views/usage-styles/usageStyles-part1.ts
@@ -675,14 +675,21 @@ export const usageStylesPart1 = `
     gap: 12px;
     font-size: 12px;
     color: var(--text);
-    align-items: flex-start;
+    align-items: baseline;
+  }
+  .usage-list-item > span:first-child {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
   }
   .usage-list-value {
     display: flex;
-    flex-direction: column;
-    align-items: flex-end;
-    gap: 2px;
+    align-items: baseline;
+    gap: 4px;
     text-align: right;
+    white-space: nowrap;
+    flex-shrink: 0;
   }
   .usage-list-sub {
     font-size: 11px;

--- a/ui/src/ui/views/usage-styles/usageStyles-part3.ts
+++ b/ui/src/ui/views/usage-styles/usageStyles-part3.ts
@@ -327,6 +327,10 @@ export const usageStylesPart3 = `
     justify-content: space-between;
     gap: 8px;
   }
+  .files-tree-root {
+    font-size: 10px;
+    margin-bottom: 2px;
+  }
   .context-breakdown-more {
     font-size: 10px;
     color: var(--muted);


### PR DESCRIPTION
## Files Read Tracking & Tree View

Adds file read tracking to the usage dashboard, showing which files were read during a session and how often.

<img width="667" height="872" alt="image" src="https://github.com/user-attachments/assets/d6e60a0f-5f75-46e5-856e-28621fe4051d" />


### Backend
- `extractFileReadPaths()` in transcript-tools.ts (supports tool_use + toolCall formats)
- Per-session and cross-session filesRead aggregation
- File paths included in session log format `[Tool: read /path]`
- New `SessionFilesRead` type

### UI
- Tree view in System Prompt Breakdown with common prefix detection and directory collapsing
- Filter-aware: recalculates from logs when time range cursor active
- Insight list values on single line with ellipsis for long labels

### Tests
- 29 tests pass (14 backend + 15 UI)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added file read tracking to the usage dashboard. Files read during a session are extracted from transcript tool_use blocks, aggregated per-session and cross-session, displayed in a tree view with directory collapsing in the System Prompt Breakdown panel, and recalculated from logs when a timeline filter is active.

**Backend Changes:**
- `extractFileReadPaths()` extracts file paths from Read tool blocks in both tool_use and toolCall formats
- `loadSessionCostSummary()` aggregates filesRead data with counts per file
- Session logs include file paths in format `[Tool: read /path]`
- New `SessionFilesRead` type mirrors `SessionToolUsage` structure

**Frontend Changes:**
- Tree view with common prefix detection and directory collapsing
- Filter-aware: recalculates from logs when timeline cursor is active
- `parseToolSummary()` regex updated to capture only tool name (first word) to prevent file paths from leaking into tool grouping pills
- Compact insight list rendering with ellipsis for long labels

**Testing:**
- 29 passing tests (14 backend + 15 frontend) cover path extraction, aggregation, tree building, and filtering

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-tested with 29 passing tests, follows established patterns in the codebase, includes proper type definitions, handles edge cases (cursor filtering, common prefix detection, tree collapsing), and the previous thread concerns about tool name grouping have been resolved. No security issues, performance concerns, or logical errors detected.
- No files require special attention

<sub>Last reviewed commit: 5d7f7c6</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->