### PR TITLE
fix(telegram): restore DM topic thread ids with send-path fallback

### DIFF
--- a/src/telegram/bot/helpers.test.ts
+++ b/src/telegram/bot/helpers.test.ts
@@ -43,7 +43,7 @@ describe("buildTelegramThreadParams", () => {
     });
   });
 
-  it("includes thread id for dm topics", () => {
+  it("includes thread id for dm topic threads", () => {
     expect(buildTelegramThreadParams({ id: 1, scope: "dm" })).toEqual({
       message_thread_id: 1,
     });
@@ -52,9 +52,13 @@ describe("buildTelegramThreadParams", () => {
     });
   });
 
-  it("normalizes dm thread ids and skips non-positive values", () => {
-    expect(buildTelegramThreadParams({ id: 0, scope: "dm" })).toBeUndefined();
-    expect(buildTelegramThreadParams({ id: -1, scope: "dm" })).toBeUndefined();
+  it("normalizes thread id for dm topic threads even with edge values", () => {
+    expect(buildTelegramThreadParams({ id: 0, scope: "dm" })).toEqual({
+      message_thread_id: 0,
+    });
+    expect(buildTelegramThreadParams({ id: -1, scope: "dm" })).toEqual({
+      message_thread_id: -1,
+    });
     expect(buildTelegramThreadParams({ id: 1.9, scope: "dm" })).toEqual({
       message_thread_id: 1,
     });

--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -114,7 +114,7 @@ export function resolveTelegramThreadSpec(params: {
  * Build thread params for Telegram API calls (messages, media).
  *
  * IMPORTANT: Thread IDs behave differently based on chat type:
- * - DMs (private chats): Include message_thread_id when present (DM topics)
+ * - DMs (private chats): include thread_id when present; send path retries without thread on failure
  * - Forum topics: Skip thread_id=1 (General topic), include others
  * - Regular groups: Thread IDs are ignored by Telegram
  *
@@ -130,11 +130,12 @@ export function buildTelegramThreadParams(thread?: TelegramThreadSpec | null) {
   }
   const normalized = Math.trunc(thread.id);
 
+  // For DM topics, include thread id and let send path retry without thread on API rejection.
   if (thread.scope === "dm") {
-    return normalized > 0 ? { message_thread_id: normalized } : undefined;
+    return { message_thread_id: normalized };
   }
 
-  // Telegram rejects message_thread_id=1 for General forum topic
+  // Telegram rejects message_thread_id=1 for General topic
   if (normalized === TELEGRAM_GENERAL_TOPIC_ID) {
     return undefined;
   }


### PR DESCRIPTION
## Summary

Restores DM topic reply targeting by including `message_thread_id` for `scope: "dm"` in `buildTelegramThreadParams()`.

This keeps private-topic/thread UX working while preserving existing send-path fallback behavior (retry without thread id on Telegram rejection).

## Why

`2026.2.15` omitted DM `message_thread_id` to avoid `400 Bad Request: message thread not found`.
That fixed delivery failures, but can cause replies in Telegram private topics to appear in the main tab instead of the active topic.

## Changes

- `src/telegram/bot/helpers.ts`
  - For `thread.scope === "dm"`, return `{ message_thread_id }` instead of omitting.
  - Keep General forum topic (`id=1`) omission behavior unchanged.
- `src/telegram/bot/helpers.test.ts`
  - Update DM-thread expectations to include/normalize `message_thread_id`.

## Related

- Follow-up regression report: #17960
- Prior fix: #10942

## Notes

I could not run the full test suite in this environment because project test deps/tooling are not fully installed in the sandbox PATH, but the updated unit tests reflect the new behavior.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR re-enables `message_thread_id` for DM-scoped threads in `buildTelegramThreadParams`, restoring proper reply targeting in Telegram private topic/thread conversations. The prior fix (#10942) had omitted this field entirely to avoid `400 Bad Request: message thread not found` errors, but that caused replies to land in the main chat tab instead of the active topic.

- `buildTelegramThreadParams` now returns `{ message_thread_id }` for `scope: "dm"` instead of `undefined`
- Tests updated to assert thread ID inclusion and normalization for DM threads
- The `send.ts` path has `withTelegramThreadFallback` to retry without the thread ID on rejection, but the `delivery.ts` path (bot reply delivery) does not have this fallback — this was already discussed in a prior review thread

<h3>Confidence Score: 3/5</h3>

- This PR is a targeted behavior change with a known gap in fallback coverage on one send path.
- The code change itself is small and correct for its stated purpose. Tests are consistent with the implementation. However, the `delivery.ts` send path (used for bot reply delivery) lacks the `withTelegramThreadFallback` mechanism that `send.ts` has, meaning if a DM topic thread ID becomes stale, replies through `delivery.ts` will fail without retry. This was the exact scenario the prior fix was protecting against. The score of 3 reflects that the change works correctly for valid DM topics but reintroduces a partial regression risk on one delivery path.
- `src/telegram/bot/delivery.ts` — uses `buildTelegramThreadParams` directly without `withTelegramThreadFallback`, meaning DM thread ID failures won't be retried on this path.

<sub>Last reviewed commit: 17d256b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->