### PR TITLE
fix(slack): pass threadId in extension read action

### DIFF
--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -299,6 +299,7 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
 
       if (action === "read") {
         const limit = readNumberParam(params, "limit", { integer: true });
+        const threadId = readStringParam(params, "threadId");
         return await getSlackRuntime().channel.slack.handleSlackAction(
           {
             action: "readMessages",
@@ -306,6 +307,7 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
             limit,
             before: readStringParam(params, "before"),
             after: readStringParam(params, "after"),
+            threadId: threadId ?? undefined,
             accountId: accountId ?? undefined,
           },
           cfg,


### PR DESCRIPTION
Problem

The Slack extension's read action in extensions/slack/src/channel.ts does not forward the threadId parameter to the underlying readMessages handler. This makes it impossible to fetch thread replies via the message read tool — it always returns channel-level messages.

The core handler in src/agents/tools/slack-actions.ts already reads threadId and passes it to readSlackMessages, so the underlying API support is there. The extension channel plugin just doesn't wire it through.

Fix

Two-line change in extensions/slack/src/channel.ts:

1. Read threadId from params
2. Pass it to the readMessages action payload
Usage

{
  "action": "read",
  "channelId": "C028LJAEELQ",
  "threadId": "1771067122.553539",
  "limit": 20
}
Returns thread replies instead of channel messages.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes Slack extension's `read` action to properly forward the `threadId` parameter to the underlying message handler, enabling thread reply fetching via the message read tool.

- Added `threadId` parameter extraction on line 302 using `readStringParam`
- Passed `threadId` to the `handleSlackAction` payload on line 310
- Change integrates cleanly with existing handler in `src/agents/tools/slack-actions.ts:236` which already supports `threadId`
- Existing test coverage validates the integration at the handler level (see `slack-actions.e2e.test.ts:359-371`)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Two-line change that follows established patterns, integrates with existing infrastructure that already handles `threadId`, has existing test coverage at the handler level, and directly addresses the stated problem without side effects
- No files require special attention

<sub>Last reviewed commit: 34c7b41</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->