### PR TITLE
fix(sessions): skip cache when initializing session state

### DIFF
--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -123,7 +123,11 @@ export async function initSessionState(params: {
   const sessionScope = sessionCfg?.scope ?? "per-sender";
   const storePath = resolveStorePath(sessionCfg?.store, { agentId });
 
-  const sessionStore: Record<string, SessionEntry> = loadSessionStore(storePath);
+  // CRITICAL: Skip cache to ensure fresh data when resolving session identity.
+  // Stale cache (especially with multiple gateway processes or on Windows where
+  // mtime granularity may miss rapid writes) can cause incorrect sessionId
+  // generation, leading to orphaned transcript files. See #17971.
+  const sessionStore: Record<string, SessionEntry> = loadSessionStore(storePath, { skipCache: true });
   let sessionKey: string | undefined;
   let sessionEntry: SessionEntry;
 


### PR DESCRIPTION
## Summary

Fixes #17971 - Session rotation on every Discord message (Windows)

## Problem

When `initSessionState()` reads the session store, it uses the cached version by default. The cache is:
- Process-local (each gateway process has its own)
- Invalidated by mtime comparison (which can miss rapid writes or have coarse granularity on Windows)

When multiple gateway processes run simultaneously, or messages arrive in quick succession, one process may read stale cache and not find the session entry → generates new sessionId → creates new transcript file.

**Symptoms:**
- 134+ orphaned `.jsonl` transcript files, each with only 1 exchange
- Session rotates even 6-8 seconds apart
- Bot "forgets" context after every message

## Solution

Add `skipCache: true` when loading the session store in `initSessionState()`. This ensures session identity (sessionId) is always resolved from the latest on-disk state.

## Why This Is Safe

1. `initSessionState` is already on the critical path for every message
2. The disk read is fast (small JSON file)
3. The `updateSessionStore` call later in the function already uses locking and `skipCache: true`
4. This matches the behavior of other critical session operations

## Testing

- The fix is minimal (1 line + comment)
- Addresses the root cause identified in #17971
- Performance impact is negligible (JSON read instead of cache lookup)

## Compatibility

- Backward compatible: Yes
- No config changes required
- No migration needed

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes session rotation on every Discord message (particularly on Windows) by adding `skipCache: true` to the `loadSessionStore()` call in `initSessionState()`. The in-memory cache uses mtime-based validation which can miss rapid writes (Windows mtime granularity is ~2 seconds), and each gateway process maintains its own cache — causing stale reads, spurious new sessionId generation, and orphaned transcript files.

- Adds `skipCache: true` to `loadSessionStore()` in `initSessionState()`, ensuring session identity is always resolved from the latest on-disk state
- Aligns with existing patterns: `updateSessionStore` already uses `skipCache: true` internally, as do other critical callers like `appendAssistantMessageToSessionTranscript` and `snapshotMainSessionMapping`
- Performance impact is negligible — the session store is a small JSON file read once per message

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, well-targeted fix that aligns with existing patterns in the codebase.
- The change is a single-line addition of `skipCache: true` to an existing function call, with no behavioral changes other than ensuring fresh disk reads. The pattern is already used by `updateSessionStore` and other critical callers. The fix directly addresses the root cause of #17971 (stale cache causing orphaned transcripts). Performance impact is negligible for a small JSON file read once per message.
- No files require special attention.

<sub>Last reviewed commit: 94cbeb7</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->