### PR TITLE
fix: add anthropic/claude-opus-4-6 to XHIGH_MODEL_REFS

### DIFF
--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -4,6 +4,7 @@ import {
   listThinkingLevels,
   normalizeReasoningLevel,
   normalizeThinkLevel,
+  supportsXHighThinking,
 } from "./thinking.js";
 
 describe("normalizeThinkLevel", () => {
@@ -56,8 +57,30 @@ describe("listThinkingLevels", () => {
     expect(listThinkingLevels("github-copilot", "gpt-5.2-codex")).toContain("xhigh");
   });
 
+  it("includes xhigh for anthropic claude-opus-4-6", () => {
+    expect(listThinkingLevels("anthropic", "claude-opus-4-6")).toContain("xhigh");
+  });
+
   it("excludes xhigh for non-codex models", () => {
     expect(listThinkingLevels(undefined, "gpt-4.1-mini")).not.toContain("xhigh");
+  });
+});
+
+describe("supportsXHighThinking", () => {
+  it("returns true for anthropic/claude-opus-4-6", () => {
+    expect(supportsXHighThinking("anthropic", "claude-opus-4-6")).toBe(true);
+  });
+
+  it("returns true for codex models", () => {
+    expect(supportsXHighThinking("openai-codex", "gpt-5.3-codex")).toBe(true);
+  });
+
+  it("returns false for anthropic sonnet", () => {
+    expect(supportsXHighThinking("anthropic", "claude-sonnet-4-5")).toBe(false);
+  });
+
+  it("returns false for non-xhigh models", () => {
+    expect(supportsXHighThinking("openai", "gpt-4.1-mini")).toBe(false);
   });
 });
 

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -29,6 +29,7 @@ export const XHIGH_MODEL_REFS = [
   "openai-codex/gpt-5.1-codex",
   "github-copilot/gpt-5.2-codex",
   "github-copilot/gpt-5.2",
+  "anthropic/claude-opus-4-6",
 ] as const;
 
 const XHIGH_MODEL_SET = new Set(XHIGH_MODEL_REFS.map((entry) => entry.toLowerCase()));


### PR DESCRIPTION
## Problem

Claude Opus 4.6 supports adaptive thinking with `effort: "max"` (its highest reasoning tier), but `XHIGH_MODEL_REFS` only includes OpenAI/Codex/Copilot models. This means `xhigh` is silently downgraded to `high` for every Anthropic user.

### The silent downgrade path

```
config: thinkingDefault: "xhigh"
  → normalizeThinkLevel("xhigh") → "xhigh"                           ✅
  → supportsXHighThinking("anthropic", "claude-opus-4-6") → false     ❌ not in allowlist
  → shouldDowngradeXHigh = true
  → sessionEntry.thinkingLevel = "high"                               ❌ silently downgraded
  → mapThinkingLevelToEffort("high") → "high"
  → API: thinking: {type: "adaptive"} + output_config: {effort: "high"}
```

The user sees `Think: xhigh` in their session status, but the API call sends `effort: "high"` — never `"max"`. There is no error, no warning in logs, and no way to reach `effort: "max"` for Opus 4.6.

### Why this matters

Anthropic's `effort: "max"` is the equivalent of OpenAI's `xhigh` — it's the highest reasoning tier available for the model. Opus 4.6 users who set `xhigh` are explicitly asking for maximum reasoning depth but silently receiving one tier below it.

## Fix

Add `"anthropic/claude-opus-4-6"` to `XHIGH_MODEL_REFS`. One line.

### The corrected path after this PR

```
config: thinkingDefault: "xhigh"
  → normalizeThinkLevel("xhigh") → "xhigh"                           ✅
  → supportsXHighThinking("anthropic", "claude-opus-4-6") → true      ✅ now in allowlist
  → shouldDowngradeXHigh = false                                       ✅ no downgrade
  → mapThinkingLevelToEffort("xhigh") → "max"                         ✅
  → API: thinking: {type: "adaptive"} + output_config: {effort: "max"} ✅
```

Everything downstream already works — `supportsAdaptiveThinking()` returns `true` for Opus 4.6, `mapThinkingLevelToEffort("xhigh")` already maps to `"max"`, and the API construction already builds the correct `thinking` + `output_config` payload. The only missing piece was the allowlist entry.

## Changes

- **`src/auto-reply/thinking.ts`**: Add `"anthropic/claude-opus-4-6"` to `XHIGH_MODEL_REFS`
- **`src/auto-reply/thinking.test.ts`**: Add tests for `supportsXHighThinking` (Opus 4.6 true, Sonnet false) and `listThinkingLevels` (Opus 4.6 includes xhigh)

## Testing

- New unit tests cover `supportsXHighThinking` for Opus 4.6
- Verified locally: patched all 4 dist bundles, restarted gateway, confirmed `effort: "max"` reaches the Anthropic API

## Context

- No existing PR addresses this for Anthropic — every XHIGH_MODEL_REFS PR to date has been OpenAI/Codex/Copilot only (#7137, #11646, #11651, #6013)
- Related: #7228 (add `max` level option) would also benefit from this, as `max` resolves to `xhigh` for supported models

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `anthropic/claude-opus-4-6` to the `XHIGH_MODEL_REFS` allowlist, enabling Anthropic users to access the highest reasoning tier (`effort: "max"`) when they set `thinkingLevel: "xhigh"`.

**Key changes:**
- Added one entry to `XHIGH_MODEL_REFS` array in `src/auto-reply/thinking.ts:32`
- Added comprehensive test coverage in `src/auto-reply/thinking.test.ts` for both `supportsXHighThinking` and `listThinkingLevels` functions

**Verification:**
- The implementation correctly follows the existing pattern used for OpenAI and Copilot models
- The `supportsXHighThinking` function at line 78 properly checks against `XHIGH_MODEL_SET` which includes the new entry
- The downstream code in `src/auto-reply/reply/directive-handling.impl.ts:265-268` already has the downgrade logic that this PR fixes
- Tests verify both positive (Opus 4.6 returns true) and negative cases (Sonnet returns false)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change is minimal (one line addition), follows existing patterns exactly, has comprehensive test coverage, and fixes a clear functional bug where Anthropic users couldn't access the highest reasoning tier they were requesting
- No files require special attention

<sub>Last reviewed commit: 148c697</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->