### PR TITLE
fix(ui): iOS Safari mobile layout — session selector, scroll, sessions table

### DIFF
--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -14,6 +14,8 @@
   background: transparent !important;
   border: none !important;
   box-shadow: none !important;
+  /* iOS Safari: ensure the flex container respects bounds */
+  max-height: 100%;
 }
 
 /* Chat header - fixed at top, transparent */
@@ -57,6 +59,7 @@
   min-height: 0; /* Allow shrinking for flex scroll behavior */
   border-radius: 12px;
   background: transparent;
+  -webkit-overflow-scrolling: touch; /* iOS Safari momentum scrolling */
 }
 
 /* Focus mode exit button */

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -966,12 +966,13 @@
   display: grid;
   gap: 4px;
   min-width: 0;
+  overflow: hidden;
 }
 
 .session-key-cell .session-link,
 .session-key-display-name {
   overflow-wrap: anywhere;
-  word-break: break-word;
+  word-break: break-all;
 }
 
 .session-key-display-name {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -441,6 +441,9 @@
   gap: 24px;
   overflow: hidden;
   padding-bottom: 0;
+  /* iOS Safari fix: ensure flex children can shrink */
+  min-height: 0;
+  height: 100%;
 }
 
 .content--chat > * + * {
@@ -577,12 +580,18 @@
       "content";
   }
 
+  /* On tablet, the shell is stacked — content must be scrollable */
+  .shell--chat {
+    overflow: hidden;
+  }
+
   .nav {
     position: static;
     max-height: none;
     display: flex;
     gap: 6px;
     overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
     border-right: none;
     border-bottom: 1px solid var(--border);
     padding: 10px 14px;
@@ -617,5 +626,14 @@
 
   .list-item {
     grid-template-columns: 1fr;
+  }
+
+  /* Ensure content area doesn't overflow on iOS Safari */
+  .content {
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .content--chat {
+    min-height: 0;
   }
 }

--- a/ui/src/styles/layout.mobile.css
+++ b/ui/src/styles/layout.mobile.css
@@ -127,9 +127,73 @@
     display: none;
   }
 
+  /* Keep chat controls visible on mobile — session selector is critical */
+  .content--chat .content-header {
+    display: flex !important;
+    padding: 4px;
+    margin-bottom: 0;
+    gap: 4px;
+    max-height: none !important;
+    opacity: 1 !important;
+    transform: none !important;
+    pointer-events: auto !important;
+  }
+
+  /* Hide title/subtitle but keep controls */
+  .content--chat .content-header > div:first-child {
+    display: none;
+  }
+
+  .content--chat .content-header .page-meta {
+    width: 100%;
+    flex: 1;
+  }
+
+  .content--chat .chat-controls {
+    width: 100%;
+    flex-wrap: nowrap;
+    gap: 6px;
+  }
+
+  .content--chat .chat-controls__session {
+    flex: 1;
+    min-width: 0;
+    max-width: none;
+  }
+
+  .content--chat .chat-controls__session select {
+    width: 100%;
+    max-width: 100%;
+    font-size: 12px;
+    padding: 6px 8px;
+  }
+
+  .content--chat .chat-controls__separator {
+    display: none;
+  }
+
+  /* Override focus-mode header hiding for chat on mobile —
+     session selector must remain accessible */
+  .shell--chat-focus .content--chat .content-header {
+    display: flex !important;
+    opacity: 1 !important;
+    transform: none !important;
+    max-height: none !important;
+    padding: 4px !important;
+    pointer-events: auto !important;
+  }
+
+  /* iOS Safari: ensure content area is scrollable */
   .content {
     padding: 4px 4px 16px;
     gap: 12px;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  /* iOS Safari: fix content being clipped */
+  .content--chat {
+    overflow: visible;
+    -webkit-overflow-scrolling: touch;
   }
 
   /* Cards */
@@ -191,6 +255,73 @@
   .pill {
     padding: 4px 10px;
     font-size: 12px;
+  }
+
+  /* Sessions table — card layout on mobile */
+  .table-head {
+    display: none !important;
+  }
+
+  .table-row {
+    display: flex !important;
+    flex-direction: column;
+    gap: 8px;
+    padding: 12px;
+  }
+
+  .table-row > div {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    min-width: 0;
+  }
+
+  /* Label each cell using ::before with data-label */
+  .table-row > div[data-label]::before {
+    content: attr(data-label);
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--muted);
+    min-width: 70px;
+    flex-shrink: 0;
+    padding-top: 2px;
+  }
+
+  .table-row > div input,
+  .table-row > div select {
+    width: 100%;
+    min-width: 0;
+  }
+
+  /* Session key needs word break */
+  .table-row .session-key-cell {
+    font-size: 12px;
+    word-break: break-all;
+  }
+
+  .table-row .session-key-cell .mono {
+    font-size: 12px;
+  }
+
+  /* Delete button full width on mobile */
+  .table-row .btn.danger {
+    width: 100%;
+  }
+
+  /* Filters wrap vertically on mobile */
+  .filters {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .filters .field {
+    width: 100%;
+  }
+
+  .filters .field.checkbox {
+    flex-direction: row;
+    align-items: center;
+    gap: 8px;
   }
 
   /* Chat */

--- a/ui/src/ui/views/sessions.ts
+++ b/ui/src/ui/views/sessions.ts
@@ -243,11 +243,11 @@ function renderRow(
 
   return html`
     <div class="table-row">
-      <div class="mono session-key-cell">
+      <div class="mono session-key-cell" data-label="Key">
         ${canLink ? html`<a href=${chatUrl} class="session-link">${row.key}</a>` : row.key}
         ${showDisplayName ? html`<span class="muted session-key-display-name">${displayName}</span>` : nothing}
       </div>
-      <div>
+      <div data-label="Label">
         <input
           .value=${row.label ?? ""}
           ?disabled=${disabled}
@@ -258,10 +258,10 @@ function renderRow(
           }}
         />
       </div>
-      <div>${row.kind}</div>
-      <div>${updated}</div>
-      <div>${formatSessionTokens(row)}</div>
-      <div>
+      <div data-label="Kind">${row.kind}</div>
+      <div data-label="Updated">${updated}</div>
+      <div data-label="Tokens">${formatSessionTokens(row)}</div>
+      <div data-label="Thinking">
         <select
           ?disabled=${disabled}
           @change=${(e: Event) => {
@@ -279,7 +279,7 @@ function renderRow(
           )}
         </select>
       </div>
-      <div>
+      <div data-label="Verbose">
         <select
           ?disabled=${disabled}
           @change=${(e: Event) => {
@@ -295,7 +295,7 @@ function renderRow(
           )}
         </select>
       </div>
-      <div>
+      <div data-label="Reasoning">
         <select
           ?disabled=${disabled}
           @change=${(e: Event) => {
@@ -311,7 +311,7 @@ function renderRow(
           )}
         </select>
       </div>
-      <div>
+      <div data-label="">
         <button class="btn danger" ?disabled=${disabled} @click=${() => onDelete(row.key)}>
           Delete
         </button>


### PR DESCRIPTION
Fixes #17983

## Summary

The Control UI dashboard has several layout issues on iOS Safari (iPhone) that make it unusable on mobile. This PR fixes all three:

### 1. Chat tab: Session selector hidden on mobile
- `content-header { display: none }` at `≤600px` hid the entire header including the session `<select>` dropdown — users couldn't switch sessions at all
- `shell--chat-focus` mode also hid it via `opacity: 0; max-height: 0`
- **Fix:** Override to keep chat controls visible (hide only the title/subtitle), including in focus mode

### 2. iOS Safari scroll/overflow issues
- `100vh` doesn't account for Safari's dynamic toolbar
- Nested flex containers missing `min-height: 0` prevent children from shrinking on WebKit
- No momentum scrolling (`-webkit-overflow-scrolling: touch`) on scroll areas
- **Fix:** Add proper flex sizing constraints and touch scrolling to chat thread, nav, and content areas

### 3. Sessions tab: Table overflows, delete button clipped
- 9-column CSS grid far too wide for mobile — rightmost columns (including Delete) clipped off-screen
- Session keys (long monospace strings) don't break properly
- **Fix:** Convert to stacked card layout on mobile with `data-label` attributes rendered via CSS `::before`. Keys use `break-all`. Filters stack vertically.

## Files Changed
- `ui/src/styles/layout.css` — tablet iOS fixes, `.content--chat` sizing
- `ui/src/styles/layout.mobile.css` — mobile chat controls, session table cards, iOS scroll
- `ui/src/styles/chat/layout.css` — touch scrolling, max-height
- `ui/src/styles/components.css` — session key cell overflow/word-break
- `ui/src/ui/views/sessions.ts` — `data-label` attributes on table row cells

## Testing
Tested on iOS Safari (iPhone) — session switching works, content scrolls properly, sessions table fully usable with all controls accessible.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed three critical iOS Safari mobile layout issues preventing the Control UI dashboard from being usable on iPhone. The session selector was completely hidden on mobile, iOS Safari's dynamic toolbar broke scrolling behavior, and the sessions table overflowed off-screen with the delete button inaccessible.

- Added `max-height: 100%` to `.chat` container and `-webkit-overflow-scrolling: touch` to scrollable areas (`chat-thread`, `nav`, `content`) for proper iOS Safari momentum scrolling
- Added `min-height: 0` to flex containers (`.content--chat`, `.shell--chat`) to allow proper shrinking on WebKit
- Overrode mobile CSS to keep `.content--chat .content-header` visible with session selector controls (previously hidden via `display: none` at ≤600px)
- Overrode focus mode header hiding for chat on mobile to ensure session selector remains accessible
- Converted sessions table to stacked card layout on mobile using `data-label` attributes and CSS `::before` for labels
- Changed `word-break` from `break-word` to `break-all` for session keys to prevent overflow of long monospace strings
- Made filters stack vertically and delete button full-width on mobile

All changes are CSS-only except for adding `data-label` attributes to table cells in `sessions.ts` for the mobile card layout. The TypeScript changes are purely presentational (HTML attributes) with no logic changes.

<h3>Confidence Score: 5/5</h3>

- Safe to merge with minimal risk
- Changes are well-scoped mobile CSS fixes targeting specific iOS Safari issues with proper WebKit prefixes and responsive breakpoints. The TypeScript changes only add HTML attributes for styling purposes with no logic modifications. All changes follow established patterns and have clear comments explaining the iOS Safari fixes.
- No files require special attention

<sub>Last reviewed commit: 6af658b</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->