### PR TITLE
fix(matrix): 2-member group rooms misclassified as DMs

### DIFF
--- a/extensions/matrix/src/matrix/monitor/index.ts
+++ b/extensions/matrix/src/matrix/monitor/index.ts
@@ -256,7 +256,12 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
   const mediaMaxBytes = Math.max(1, mediaMaxMb) * 1024 * 1024;
   const startupMs = Date.now();
   const startupGraceMs = 0;
-  const directTracker = createDirectRoomTracker(client, { log: logVerboseMessage });
+  const directTracker = createDirectRoomTracker(client, {
+    log: logVerboseMessage,
+    configuredGroupRoomIds: new Set(
+      roomsConfig ? Object.keys(roomsConfig).filter((k) => k !== "*") : [],
+    ),
+  });
   registerMatrixAutoJoin({ client, cfg, runtime });
   const warnedEncryptedRooms = new Set<string>();
   const warnedCryptoMissingRooms = new Set<string>();


### PR DESCRIPTION
Fixes #17771

## Problem

Matrix rooms with exactly 2 members that are explicitly configured in the `groups` allowlist get misclassified as DMs. This happens because `createDirectRoomTracker` uses a `memberCount === 2` heuristic that runs before any config awareness — so a 2-person group channel gets routed as a DM session instead of a group session.

## Fix

Pass the set of configured group room IDs (from `channels.matrix.groups`) into `createDirectRoomTracker`. If a room ID is in that set, skip the DM classification entirely and return `false` immediately.

### Changes
- **`extensions/matrix/src/matrix/monitor/direct.ts`** — accept optional `configuredGroupRoomIds` set in options; check it as the first guard in `isDirectMessage()`
- **`extensions/matrix/src/matrix/monitor/index.ts`** — collect room IDs from `roomsConfig` (excluding the `"*"` wildcard) and pass them to the tracker

## Testing
Tested with a 2-member Matrix room (`#openclaw`) in the groups config — correctly classified as group after the patch, was incorrectly classified as DM before.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where 2-member Matrix group rooms configured in `channels.matrix.groups` are incorrectly classified as DMs by the `memberCount === 2` heuristic in `createDirectRoomTracker`. The fix passes a set of configured group room IDs into the tracker so they can be excluded from DM classification as the first check.

- The approach is sound: checking room config before applying the member-count heuristic is the right fix
- **Partial coverage:** The `configuredGroupRoomIds` set is built from `Object.keys(roomsConfig)`, but after resolution these keys can be room aliases (`#name:server`) rather than internal room IDs (`!xxx:server`). Since the Matrix SDK always provides internal `!`-prefixed room IDs to `isDirectMessage`, alias-keyed rooms won't match and will still be misclassified
- The fix works correctly for rooms configured by internal ID or by short name (which gets resolved to an internal ID via `resolveMatrixTargets`)

<h3>Confidence Score: 3/5</h3>

- This PR is safe to merge but has a gap in coverage for alias-configured rooms
- The fix correctly addresses the case where rooms are configured by internal room ID or by short name that gets resolved, but misses the case where rooms are configured by full alias (e.g., #room:server). The code changes are small and non-breaking — worst case, alias-configured rooms behave the same as before the patch.
- `extensions/matrix/src/matrix/monitor/index.ts` — the `configuredGroupRoomIds` set construction needs to account for alias keys vs. internal room IDs

<sub>Last reviewed commit: cb50d35</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->