### PR TITLE
fix(cron): resolve accountId from agent bindings in isolated sessions

### DIFF
--- a/src/cron/isolated-agent/delivery-target.test.ts
+++ b/src/cron/isolated-agent/delivery-target.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+
+vi.mock("../../config/sessions.js", () => ({
+  loadSessionStore: vi.fn().mockReturnValue({}),
+  resolveAgentMainSessionKey: vi.fn().mockReturnValue("agent:test:main"),
+  resolveStorePath: vi.fn().mockReturnValue("/tmp/test-store.json"),
+}));
+
+vi.mock("../../infra/outbound/channel-selection.js", () => ({
+  resolveMessageChannelSelection: vi.fn().mockResolvedValue({ channel: "telegram" }),
+}));
+
+import { loadSessionStore } from "../../config/sessions.js";
+import { resolveDeliveryTarget } from "./delivery-target.js";
+
+function makeCfg(overrides?: Partial<OpenClawConfig>): OpenClawConfig {
+  return {
+    bindings: [],
+    channels: {},
+    ...overrides,
+  } as OpenClawConfig;
+}
+
+describe("resolveDeliveryTarget", () => {
+  it("falls back to bound accountId when session has no lastAccountId", async () => {
+    vi.mocked(loadSessionStore).mockReturnValue({});
+
+    const cfg = makeCfg({
+      bindings: [
+        {
+          agentId: "agent-b",
+          match: { channel: "telegram", accountId: "account-b" },
+        },
+      ],
+    });
+
+    const result = await resolveDeliveryTarget(cfg, "agent-b", {
+      channel: "telegram",
+      to: "123456",
+    });
+
+    expect(result.accountId).toBe("account-b");
+  });
+
+  it("preserves session lastAccountId when present", async () => {
+    vi.mocked(loadSessionStore).mockReturnValue({
+      "agent:test:main": {
+        sessionId: "sess-1",
+        updatedAt: 1000,
+        lastChannel: "telegram",
+        lastTo: "123456",
+        lastAccountId: "session-account",
+      },
+    });
+
+    const cfg = makeCfg({
+      bindings: [
+        {
+          agentId: "agent-b",
+          match: { channel: "telegram", accountId: "account-b" },
+        },
+      ],
+    });
+
+    const result = await resolveDeliveryTarget(cfg, "agent-b", {
+      channel: "telegram",
+      to: "123456",
+    });
+
+    // Session-derived accountId should take precedence over binding
+    expect(result.accountId).toBe("session-account");
+  });
+
+  it("returns undefined accountId when no binding and no session", async () => {
+    vi.mocked(loadSessionStore).mockReturnValue({});
+
+    const cfg = makeCfg({ bindings: [] });
+
+    const result = await resolveDeliveryTarget(cfg, "agent-b", {
+      channel: "telegram",
+      to: "123456",
+    });
+
+    expect(result.accountId).toBeUndefined();
+  });
+
+  it("selects correct binding when multiple agents have bindings", async () => {
+    vi.mocked(loadSessionStore).mockReturnValue({});
+
+    const cfg = makeCfg({
+      bindings: [
+        {
+          agentId: "agent-a",
+          match: { channel: "telegram", accountId: "account-a" },
+        },
+        {
+          agentId: "agent-b",
+          match: { channel: "telegram", accountId: "account-b" },
+        },
+      ],
+    });
+
+    const result = await resolveDeliveryTarget(cfg, "agent-b", {
+      channel: "telegram",
+      to: "123456",
+    });
+
+    expect(result.accountId).toBe("account-b");
+  });
+
+  it("ignores bindings for different channels", async () => {
+    vi.mocked(loadSessionStore).mockReturnValue({});
+
+    const cfg = makeCfg({
+      bindings: [
+        {
+          agentId: "agent-b",
+          match: { channel: "discord", accountId: "discord-account" },
+        },
+      ],
+    });
+
+    const result = await resolveDeliveryTarget(cfg, "agent-b", {
+      channel: "telegram",
+      to: "123456",
+    });
+
+    expect(result.accountId).toBeUndefined();
+  });
+});

--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -12,6 +12,8 @@ import {
   resolveOutboundTarget,
   resolveSessionDeliveryTarget,
 } from "../../infra/outbound/targets.js";
+import { buildChannelAccountBindings } from "../../routing/bindings.js";
+import { normalizeAgentId } from "../../routing/session-key.js";
 
 export async function resolveDeliveryTarget(
   cfg: OpenClawConfig,
@@ -70,6 +72,20 @@ export async function resolveDeliveryTarget(
   const mode = resolved.mode as "explicit" | "implicit";
   const toCandidate = resolved.to;
 
+  // When the session has no lastAccountId (e.g. first-run isolated cron
+  // session), fall back to the agent's bound account from bindings config.
+  // This ensures the message tool in isolated sessions resolves the correct
+  // bot token for multi-account setups.
+  let accountId = resolved.accountId;
+  if (!accountId && channel) {
+    const bindings = buildChannelAccountBindings(cfg);
+    const byAgent = bindings.get(channel);
+    const boundAccounts = byAgent?.get(normalizeAgentId(agentId));
+    if (boundAccounts && boundAccounts.length > 0) {
+      accountId = boundAccounts[0];
+    }
+  }
+
   // Only carry threadId when delivering to the same recipient as the session's
   // last conversation. This prevents stale thread IDs (e.g. from a Telegram
   // supergroup topic) from being sent to a different target (e.g. a private
@@ -83,7 +99,7 @@ export async function resolveDeliveryTarget(
     return {
       channel,
       to: undefined,
-      accountId: resolved.accountId,
+      accountId,
       threadId,
       mode,
     };
@@ -93,13 +109,13 @@ export async function resolveDeliveryTarget(
     channel,
     to: toCandidate,
     cfg,
-    accountId: resolved.accountId,
+    accountId,
     mode,
   });
   return {
     channel,
     to: docked.ok ? docked.to : undefined,
-    accountId: resolved.accountId,
+    accountId,
     threadId,
     mode,
     error: docked.ok ? undefined : docked.error,


### PR DESCRIPTION
**tl;dr:** 2 files, ~30 lines, 5 new tests — mirrors existing inbound binding resolution for the outbound path.

## Summary

Closes the remaining gap from #12628 / #16259: the **message tool path** in isolated cron sessions now correctly resolves the agent's bound Telegram (or Discord) account.

- When an isolated cron session has no `lastAccountId` (first-run or fresh session), `resolveDeliveryTarget()` now falls back to the agent's bound account from the `bindings` config
- Session-derived `accountId` still takes precedence when present
- Uses the existing `buildChannelAccountBindings()` utility — no new abstractions

## Problem

In multi-account setups (one bot per agent), the `message` tool in isolated cron sessions defaults to `accountId: "default"`. Since named accounts (e.g. `accounts["willy"]`) don't include a `"default"` key, `resolveTelegramToken()` fails with "bot token missing".

PR #16259 fixed the **delivery path** (threading `accountId` through `CronDelivery`), but the **message tool path** (`delivery.mode: "none"` jobs where the agent prompt uses the `message` tool directly) remained broken.

**Resolution chain that fails:**
1. `resolveDeliveryTarget()` → `resolveSessionDeliveryTarget()` → `lastAccountId` is `undefined` (fresh session)
2. `undefined` flows to `runEmbeddedPiAgent()` as `agentAccountId`
3. Message tool defaults to `DEFAULT_ACCOUNT_ID` ("default")
4. `resolveTelegramToken({ accountId: "default" })` → `accounts["default"]` doesn't exist → fail

## Fix

In `resolveDeliveryTarget()`, when `accountId` is undefined and the channel is known, look up the agent's bound account via `buildChannelAccountBindings()`. This mirrors the same binding resolution already used for inbound routing.

```typescript
let accountId = resolved.accountId;
if (!accountId && channel) {
  const bindings = buildChannelAccountBindings(cfg);
  const byAgent = bindings.get(channel);
  const boundAccounts = byAgent?.get(normalizeAgentId(agentId));
  if (boundAccounts && boundAccounts.length > 0) {
    accountId = boundAccounts[0];
  }
}
```

## Changes

| File | Change |
|------|--------|
| `src/cron/isolated-agent/delivery-target.ts` | Fall back to agent binding when session has no `lastAccountId` |
| `src/cron/isolated-agent/delivery-target.test.ts` | 5 test cases covering binding fallback, session precedence, multi-agent, and cross-channel scenarios |

## Test plan

- [x] New unit tests: binding fallback, session precedence, no-binding, multi-agent selection, cross-channel isolation
- [x] All existing cron tests pass (127 tests, 27 files)
- [x] All routing tests pass (45 tests)
- Validated against production multi-agent Telegram setup (3 agents, 3 bots)

Fixes #17889
Related: #12628, #16259, #9503


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes isolated cron sessions to correctly resolve bot account IDs in multi-account setups by falling back to agent bindings when session has no `lastAccountId`. The fix adds a lookup to `buildChannelAccountBindings()` after checking session state, ensuring the message tool can resolve the correct bot token for first-run or fresh cron sessions.

- Adds binding fallback logic in `resolveDeliveryTarget()` (lines 75-87) that checks agent bindings when `accountId` is undefined
- Preserves existing precedence: session-derived `accountId` takes priority over bindings
- Comprehensive test coverage: 5 test cases validate binding fallback, session precedence, multi-agent selection, and cross-channel isolation
- Uses existing utilities (`buildChannelAccountBindings`, `normalizeAgentId`) following established patterns in the codebase

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is well-designed and follows existing patterns. It adds a simple fallback mechanism that only activates when session state is missing, preserving all existing behavior. The comprehensive test suite covers key edge cases (session precedence, multi-agent, cross-channel), and the implementation uses established utilities from the codebase.
- No files require special attention

<sub>Last reviewed commit: 2ff8568</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->