### PR TITLE
feat(agent): add embedded MCP server support

### DIFF
--- a/src/acp/session-mapper.test.ts
+++ b/src/acp/session-mapper.test.ts
@@ -1,3 +1,4 @@
+import type { McpServer } from "@agentclientprotocol/sdk";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GatewayClient } from "../gateway/client.js";
 import { parseSessionMeta, resolveSessionKey } from "./session-mapper.js";
@@ -76,5 +77,26 @@ describe("acp session manager", () => {
     const cancelled = store.cancelActiveRun(session.sessionId);
     expect(cancelled).toBe(true);
     expect(store.getSessionByRunId("run-1")).toBeUndefined();
+  });
+
+
+  it("stores ACP mcpServers in session state", () => {
+    const mcpServers = [
+      {
+        name: "lean-lsp",
+        command: "lean-lsp-mcp",
+        args: ["--stdio"],
+        env: [{ name: "LEAN_PATH", value: "/tmp/lean" }],
+      },
+    ] satisfies McpServer[];
+
+    const session = store.createSession({
+      sessionKey: "acp:test",
+      cwd: "/tmp",
+      mcpServers,
+    });
+
+    expect(session.mcpServers).toEqual(mcpServers);
+    expect(store.getSession(session.sessionId)?.mcpServers).toEqual(mcpServers);
   });
 });

--- a/src/acp/session.ts
+++ b/src/acp/session.ts
@@ -1,8 +1,14 @@
+import type { McpServer } from "@agentclientprotocol/sdk";
 import { randomUUID } from "node:crypto";
 import type { AcpSession } from "./types.js";
 
 export type AcpSessionStore = {
-  createSession: (params: { sessionKey: string; cwd: string; sessionId?: string }) => AcpSession;
+  createSession: (params: {
+    sessionKey: string;
+    cwd: string;
+    sessionId?: string;
+    mcpServers?: McpServer[];
+  }) => AcpSession;
   getSession: (sessionId: string) => AcpSession | undefined;
   getSessionByRunId: (runId: string) => AcpSession | undefined;
   setActiveRun: (sessionId: string, runId: string, abortController: AbortController) => void;
@@ -22,6 +28,7 @@ export function createInMemorySessionStore(): AcpSessionStore {
       sessionKey: params.sessionKey,
       cwd: params.cwd,
       createdAt: Date.now(),
+      mcpServers: [...(params.mcpServers ?? [])],
       abortController: null,
       activeRunId: null,
     };

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -121,10 +121,6 @@ export class AcpGatewayAgent implements Agent {
   }
 
   async newSession(params: NewSessionRequest): Promise<NewSessionResponse> {
-    if (params.mcpServers.length > 0) {
-      this.log(`ignoring ${params.mcpServers.length} MCP servers`);
-    }
-
     const sessionId = randomUUID();
     const meta = parseSessionMeta(params._meta);
     const sessionKey = await resolveSessionKey({
@@ -144,6 +140,7 @@ export class AcpGatewayAgent implements Agent {
       sessionId,
       sessionKey,
       cwd: params.cwd,
+      mcpServers: params.mcpServers,
     });
     this.log(`newSession: ${session.sessionId} -> ${session.sessionKey}`);
     await this.sendAvailableCommands(session.sessionId);
@@ -151,10 +148,6 @@ export class AcpGatewayAgent implements Agent {
   }
 
   async loadSession(params: LoadSessionRequest): Promise<LoadSessionResponse> {
-    if (params.mcpServers.length > 0) {
-      this.log(`ignoring ${params.mcpServers.length} MCP servers`);
-    }
-
     const meta = parseSessionMeta(params._meta);
     const sessionKey = await resolveSessionKey({
       meta,
@@ -173,6 +166,7 @@ export class AcpGatewayAgent implements Agent {
       sessionId: params.sessionId,
       sessionKey,
       cwd: params.cwd,
+      mcpServers: params.mcpServers,
     });
     this.log(`loadSession: ${session.sessionId} -> ${session.sessionKey}`);
     await this.sendAvailableCommands(session.sessionId);
@@ -263,6 +257,7 @@ export class AcpGatewayAgent implements Agent {
             thinking: readString(params._meta, ["thinking", "thinkingLevel"]),
             deliver: readBool(params._meta, ["deliver"]),
             timeoutMs: readNumber(params._meta, ["timeoutMs"]),
+            mcpServers: session.mcpServers.length > 0 ? session.mcpServers : undefined,
           },
           { expectFinal: true },
         )

--- a/src/acp/types.ts
+++ b/src/acp/types.ts
@@ -1,4 +1,4 @@
-import type { SessionId } from "@agentclientprotocol/sdk";
+import type { McpServer, SessionId } from "@agentclientprotocol/sdk";
 import { VERSION } from "../version.js";
 
 export type AcpSession = {
@@ -6,6 +6,7 @@ export type AcpSession = {
   sessionKey: string;
   cwd: string;
   createdAt: number;
+  mcpServers: McpServer[];
   abortController: AbortController | null;
   activeRunId: string | null;
 };

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -23,6 +23,7 @@ type ResolvedAgentConfig = {
   memorySearch?: AgentEntry["memorySearch"];
   humanDelay?: AgentEntry["humanDelay"];
   heartbeat?: AgentEntry["heartbeat"];
+  mcpServers?: AgentEntry["mcpServers"];
   identity?: AgentEntry["identity"];
   groupChat?: AgentEntry["groupChat"];
   subagents?: AgentEntry["subagents"];
@@ -117,6 +118,7 @@ export function resolveAgentConfig(
     memorySearch: entry.memorySearch,
     humanDelay: entry.humanDelay,
     heartbeat: entry.heartbeat,
+    mcpServers: Array.isArray(entry.mcpServers) ? entry.mcpServers : undefined,
     identity: entry.identity,
     groupChat: entry.groupChat,
     subagents: typeof entry.subagents === "object" && entry.subagents ? entry.subagents : undefined,
@@ -130,6 +132,21 @@ export function resolveAgentSkillsFilter(
   agentId: string,
 ): string[] | undefined {
   return normalizeSkillFilter(resolveAgentConfig(cfg, agentId)?.skills);
+}
+
+export function resolveAgentMcpServers(
+  cfg: OpenClawConfig,
+  agentId: string,
+): unknown[] | undefined {
+  const defaults = cfg.agents?.defaults?.mcpServers;
+  const overrides = resolveAgentConfig(cfg, agentId)?.mcpServers;
+  if (Array.isArray(overrides)) {
+    return overrides;
+  }
+  if (Array.isArray(defaults)) {
+    return defaults;
+  }
+  return undefined;
 }
 
 export function resolveAgentModelPrimary(cfg: OpenClawConfig, agentId: string): string | undefined {

--- a/src/agents/mcp-client.test.ts
+++ b/src/agents/mcp-client.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { initMcpRuntime } from "./mcp-client.js";
+
+const MOCK_MCP_SERVER_SCRIPT = [
+  'process.stdin.setEncoding("utf8");',
+  'let buffer = "";',
+  'const send = (payload) => process.stdout.write(JSON.stringify({ jsonrpc: "2.0", ...payload }) + "\\n");',
+  'process.stdin.on("data", (chunk) => {',
+  '  buffer += String(chunk);',
+  '  let newline = buffer.indexOf("\\n");',
+  '  while (newline >= 0) {',
+  '    const raw = buffer.slice(0, newline).trim();',
+  '    buffer = buffer.slice(newline + 1);',
+  '    newline = buffer.indexOf("\\n");',
+  '    if (!raw) continue;',
+  '    const msg = JSON.parse(raw);',
+  '    if (msg.method === "initialize") {',
+  '      send({ id: msg.id, result: { protocolVersion: "2024-11-05", capabilities: { tools: {} }, serverInfo: { name: "mock", version: "1.0.0" } } });',
+  '      continue;',
+  '    }',
+  '    if (msg.method === "tools/list") {',
+  '      send({ id: msg.id, result: { tools: [{ name: "ping", description: "Ping tool", inputSchema: { type: "object", properties: { text: { type: "string" } } } }] } });',
+  '      continue;',
+  '    }',
+  '    if (msg.method === "tools/call") {',
+  '      send({ id: msg.id, result: { ok: true, tool: msg.params?.name, args: msg.params?.arguments ?? {} } });',
+  '      continue;',
+  '    }',
+  '    if (msg.method === "notifications/initialized") {',
+  '      continue;',
+  '    }',
+  '    send({ id: msg.id, error: { code: -32601, message: "method not found" } });',
+  '  }',
+  '});',
+].join("\n");
+
+function mockServerConfig(name: string) {
+  return {
+    name,
+    type: "stdio",
+    command: process.execPath,
+    args: ["-e", MOCK_MCP_SERVER_SCRIPT],
+  } as const;
+}
+
+describe("mcp client runtime", () => {
+  it("loads stdio MCP tools and calls them", async () => {
+    const runtime = await initMcpRuntime({
+      mcpServers: [mockServerConfig("mock")],
+    });
+
+    try {
+      expect(runtime.tools).toHaveLength(1);
+      expect(runtime.tools[0].name).toBe("ping");
+
+      const result = await runtime.tools[0].call({ text: "hello" });
+      expect(result).toMatchObject({
+        ok: true,
+        tool: "ping",
+        args: {
+          text: "hello",
+        },
+      });
+    } finally {
+      await runtime.cleanup();
+    }
+  });
+
+  it("uniquifies MCP tool names across servers", async () => {
+    const runtime = await initMcpRuntime({
+      mcpServers: [mockServerConfig("mock-a"), mockServerConfig("mock-b")],
+    });
+
+    try {
+      expect(runtime.tools.map((tool) => tool.name)).toEqual(["ping", "ping-2"]);
+      expect(runtime.tools.map((tool) => tool.serverName)).toEqual(["mock-a", "mock-b"]);
+    } finally {
+      await runtime.cleanup();
+    }
+  });
+});

--- a/src/agents/mcp-client.ts
+++ b/src/agents/mcp-client.ts
@@ -61,7 +61,7 @@ export type McpRuntime = {
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function toErrorMessage(error: unknown): string {

--- a/src/agents/mcp-client.ts
+++ b/src/agents/mcp-client.ts
@@ -1,0 +1,722 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { createInterface, type Interface as ReadlineInterface } from "node:readline";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { parseMcpServers, resolveUniqueMcpName, type McpServerConfig } from "./mcp-common.js";
+
+const log = createSubsystemLogger("agent/mcp");
+
+const DEFAULT_MCP_TIMEOUT_MS = 30_000;
+const MCP_PROTOCOL_VERSION = "2024-11-05";
+
+type McpRequestOptions = {
+  timeoutMs?: number;
+  signal?: AbortSignal;
+};
+
+type PendingRequest = {
+  resolve: (value: unknown) => void;
+  reject: (error: Error) => void;
+  cleanupAbort?: () => void;
+};
+
+type JsonRpcErrorObject = {
+  code?: unknown;
+  message?: unknown;
+  data?: unknown;
+};
+
+type JsonRpcEnvelope = {
+  id?: unknown;
+  result?: unknown;
+  error?: unknown;
+};
+
+export type McpToolDescriptor = {
+  name: string;
+  description?: string;
+  inputSchema?: Record<string, unknown>;
+};
+
+export type McpToolHandle = {
+  /** Unique tool name exposed to the embedded runner. */
+  name: string;
+  /** Original MCP tool name (before uniquifying). */
+  mcpName: string;
+  serverName: string;
+  description?: string;
+  inputSchema?: Record<string, unknown>;
+  call: (params: Record<string, unknown>, opts?: McpRequestOptions) => Promise<unknown>;
+};
+
+type McpClient = {
+  start: () => Promise<void>;
+  stop: () => Promise<void>;
+  listTools: (opts?: McpRequestOptions) => Promise<McpToolDescriptor[]>;
+  callTool: (name: string, args: Record<string, unknown>, opts?: McpRequestOptions) => Promise<unknown>;
+};
+
+export type McpRuntime = {
+  tools: McpToolHandle[];
+  cleanup: () => Promise<void>;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function toErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message || String(error);
+  }
+  return String(error);
+}
+
+function toJsonRpcError(error: unknown): JsonRpcErrorObject | null {
+  return isRecord(error) ? (error as JsonRpcErrorObject) : null;
+}
+
+function formatJsonRpcError(error: unknown): string {
+  const rpcErr = toJsonRpcError(error);
+  if (!rpcErr) {
+    return typeof error === "string" ? error : "JSON-RPC error";
+  }
+  const code = typeof rpcErr.code === "number" ? ` (${rpcErr.code})` : "";
+  const message = typeof rpcErr.message === "string" ? rpcErr.message : "JSON-RPC error";
+  return `${message}${code}`;
+}
+
+function normalizeToolsPayload(payload: unknown): McpToolDescriptor[] {
+  if (!isRecord(payload) || !Array.isArray(payload.tools)) {
+    return [];
+  }
+
+  const tools: McpToolDescriptor[] = [];
+  for (const raw of payload.tools) {
+    if (!isRecord(raw)) {
+      continue;
+    }
+    const name = typeof raw.name === "string" ? raw.name.trim() : "";
+    if (!name) {
+      continue;
+    }
+    const description = typeof raw.description === "string" ? raw.description.trim() : "";
+    const inputSchema = isRecord(raw.inputSchema) ? raw.inputSchema : undefined;
+    tools.push({
+      name,
+      ...(description ? { description } : {}),
+      ...(inputSchema ? { inputSchema } : {}),
+    });
+  }
+
+  return tools;
+}
+
+function parseJsonRpcEnvelope(raw: unknown): JsonRpcEnvelope {
+  if (!isRecord(raw)) {
+    throw new Error("MCP response was not a JSON object");
+  }
+  return {
+    id: raw.id,
+    result: raw.result,
+    error: raw.error,
+  };
+}
+
+function parseSseFrames(raw: string): string[] {
+  const frames: string[] = [];
+  const lines = raw.split(/\r?\n/);
+  let dataLines: string[] = [];
+
+  for (const line of lines) {
+    if (line.startsWith("data:")) {
+      dataLines.push(line.slice(5).trimStart());
+      continue;
+    }
+    if (line.trim().length === 0) {
+      if (dataLines.length > 0) {
+        frames.push(dataLines.join("\n"));
+        dataLines = [];
+      }
+    }
+  }
+
+  if (dataLines.length > 0) {
+    frames.push(dataLines.join("\n"));
+  }
+
+  return frames;
+}
+
+function parseHttpJsonRpcBody(rawBody: string): JsonRpcEnvelope {
+  const trimmed = rawBody.trim();
+  if (!trimmed) {
+    throw new Error("MCP HTTP response body was empty");
+  }
+
+  if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+    return parseJsonRpcEnvelope(JSON.parse(trimmed));
+  }
+
+  const frames = parseSseFrames(trimmed);
+  for (let i = frames.length - 1; i >= 0; i -= 1) {
+    const frame = frames[i]?.trim();
+    if (!frame || frame === "[DONE]") {
+      continue;
+    }
+    return parseJsonRpcEnvelope(JSON.parse(frame));
+  }
+
+  throw new Error("MCP HTTP response did not contain JSON-RPC payload");
+}
+
+function resolveTimeoutMs(timeoutMs: number | undefined): number {
+  const resolved = Number.isFinite(timeoutMs) ? Number(timeoutMs) : DEFAULT_MCP_TIMEOUT_MS;
+  return Math.max(1, resolved);
+}
+
+async function awaitProcessSpawn(
+  proc: ChildProcessWithoutNullStreams,
+  serverName: string,
+): Promise<void> {
+  if (proc.pid) {
+    return;
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    const onSpawn = () => {
+      cleanup();
+      resolve();
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(new Error(`Failed to start MCP server ${serverName}: ${error.message}`));
+    };
+    const cleanup = () => {
+      proc.off("spawn", onSpawn);
+      proc.off("error", onError);
+    };
+
+    proc.once("spawn", onSpawn);
+    proc.once("error", onError);
+  });
+}
+
+class StdioMcpClient implements McpClient {
+  private proc: ChildProcessWithoutNullStreams | null = null;
+  private lines: ReadlineInterface | null = null;
+  private pending = new Map<number, PendingRequest>();
+  private nextId = 1;
+  private closed = false;
+
+  constructor(
+    private readonly serverName: string,
+    private readonly config: Extract<McpServerConfig, { type: "stdio" }>,
+  ) {}
+
+  async start(): Promise<void> {
+    if (this.proc) {
+      return;
+    }
+
+    const env = {
+      ...process.env,
+      ...(this.config.env ?? {}),
+    };
+
+    const proc = spawn(this.config.command, this.config.args ?? [], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env,
+    });
+
+    this.proc = proc;
+    this.closed = false;
+
+    proc.on("error", (error) => {
+      this.rejectAllPending(
+        new Error(`MCP server ${this.serverName} process error: ${toErrorMessage(error)}`),
+      );
+    });
+
+    proc.on("exit", (code, signal) => {
+      if (this.closed) {
+        return;
+      }
+      const detail = signal ? `signal ${signal}` : `code ${code ?? "unknown"}`;
+      this.rejectAllPending(new Error(`MCP server ${this.serverName} exited (${detail})`));
+    });
+
+    proc.stderr.on("data", (chunk) => {
+      const text = String(chunk ?? "").trim();
+      if (!text) {
+        return;
+      }
+      log.warn(`mcp stderr (${this.serverName}): ${text.slice(0, 500)}`);
+    });
+
+    this.lines = createInterface({
+      input: proc.stdout,
+      crlfDelay: Infinity,
+    });
+
+    this.lines.on("line", (line) => {
+      this.handleLine(line);
+    });
+
+    await awaitProcessSpawn(proc, this.serverName);
+    await this.initialize();
+  }
+
+  async stop(): Promise<void> {
+    this.closed = true;
+    this.rejectAllPending(new Error(`MCP server ${this.serverName} stopped`));
+
+    this.lines?.close();
+    this.lines = null;
+
+    const proc = this.proc;
+    this.proc = null;
+
+    if (!proc) {
+      return;
+    }
+
+    if (proc.exitCode !== null || proc.signalCode !== null) {
+      return;
+    }
+
+    const exited = new Promise<void>((resolve) => {
+      proc.once("exit", () => resolve());
+    });
+
+    proc.kill("SIGTERM");
+
+    await Promise.race([
+      exited,
+      new Promise<void>((resolve) => {
+        setTimeout(resolve, 1_000);
+      }),
+    ]);
+
+    if (proc.exitCode === null && proc.signalCode === null) {
+      proc.kill("SIGKILL");
+      await exited;
+    }
+  }
+
+  async listTools(opts?: McpRequestOptions): Promise<McpToolDescriptor[]> {
+    const result = await this.request("tools/list", {}, opts);
+    return normalizeToolsPayload(result);
+  }
+
+  async callTool(
+    name: string,
+    args: Record<string, unknown>,
+    opts?: McpRequestOptions,
+  ): Promise<unknown> {
+    return this.request(
+      "tools/call",
+      {
+        name,
+        arguments: args,
+      },
+      opts,
+    );
+  }
+
+  private async initialize(): Promise<void> {
+    try {
+      await this.request(
+        "initialize",
+        {
+          protocolVersion: MCP_PROTOCOL_VERSION,
+          capabilities: {},
+          clientInfo: {
+            name: "openclaw",
+            version: "embedded",
+          },
+        },
+        { timeoutMs: 15_000 },
+      );
+    } catch (error) {
+      log.warn(`mcp initialize failed (${this.serverName}): ${toErrorMessage(error)}`);
+    }
+
+    try {
+      this.notify("notifications/initialized", {});
+    } catch {
+      // Ignore notification failures; some servers are permissive here.
+    }
+  }
+
+  private notify(method: string, params: unknown) {
+    const proc = this.proc;
+    if (!proc || this.closed) {
+      return;
+    }
+
+    const payload = JSON.stringify({
+      jsonrpc: "2.0",
+      method,
+      params,
+    });
+
+    proc.stdin.write(`${payload}\n`);
+  }
+
+  private async request(
+    method: string,
+    params: unknown,
+    opts?: McpRequestOptions,
+  ): Promise<unknown> {
+    const proc = this.proc;
+    if (!proc || this.closed) {
+      throw new Error(`MCP server ${this.serverName} is not running`);
+    }
+
+    if (opts?.signal?.aborted) {
+      throw new Error(`MCP request aborted before send: ${method}`);
+    }
+
+    const id = this.nextId;
+    this.nextId += 1;
+    const timeoutMs = resolveTimeoutMs(opts?.timeoutMs);
+
+    return new Promise<unknown>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        const pending = this.pending.get(id);
+        if (!pending) {
+          return;
+        }
+        this.pending.delete(id);
+        pending.cleanupAbort?.();
+        reject(new Error(`MCP request timed out after ${timeoutMs}ms: ${this.serverName}.${method}`));
+      }, timeoutMs);
+
+      const pending: PendingRequest = {
+        resolve: (value) => {
+          clearTimeout(timer);
+          pending.cleanupAbort?.();
+          resolve(value);
+        },
+        reject: (error) => {
+          clearTimeout(timer);
+          pending.cleanupAbort?.();
+          reject(error);
+        },
+      };
+
+      if (opts?.signal) {
+        const onAbort = () => {
+          const current = this.pending.get(id);
+          if (!current) {
+            return;
+          }
+          this.pending.delete(id);
+          current.reject(new Error(`MCP request aborted: ${this.serverName}.${method}`));
+        };
+        opts.signal.addEventListener("abort", onAbort, { once: true });
+        pending.cleanupAbort = () => {
+          opts.signal?.removeEventListener("abort", onAbort);
+        };
+      }
+
+      this.pending.set(id, pending);
+
+      const payload = JSON.stringify({
+        jsonrpc: "2.0",
+        id,
+        method,
+        params,
+      });
+
+      proc.stdin.write(`${payload}\n`, (error) => {
+        if (!error) {
+          return;
+        }
+        const current = this.pending.get(id);
+        if (!current) {
+          return;
+        }
+        this.pending.delete(id);
+        current.reject(
+          new Error(`Failed to write MCP request ${this.serverName}.${method}: ${error.message}`),
+        );
+      });
+    });
+  }
+
+  private handleLine(line: string) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      return;
+    }
+
+    let envelope: JsonRpcEnvelope;
+    try {
+      envelope = parseJsonRpcEnvelope(JSON.parse(trimmed));
+    } catch {
+      return;
+    }
+
+    const id =
+      typeof envelope.id === "number"
+        ? envelope.id
+        : typeof envelope.id === "string" && /^\d+$/.test(envelope.id)
+          ? Number(envelope.id)
+          : null;
+    if (id === null) {
+      return;
+    }
+
+    const pending = this.pending.get(id);
+    if (!pending) {
+      return;
+    }
+    this.pending.delete(id);
+
+    if (envelope.error !== undefined) {
+      pending.reject(new Error(formatJsonRpcError(envelope.error)));
+      return;
+    }
+
+    pending.resolve(envelope.result);
+  }
+
+  private rejectAllPending(reason: Error) {
+    for (const [id, pending] of this.pending.entries()) {
+      this.pending.delete(id);
+      pending.reject(reason);
+    }
+  }
+}
+
+class HttpMcpClient implements McpClient {
+  private nextId = 1;
+
+  constructor(
+    private readonly serverName: string,
+    private readonly config: Extract<McpServerConfig, { type: "http" | "sse" }>,
+  ) {}
+
+  async start(): Promise<void> {
+    await this.initialize();
+  }
+
+  async stop(): Promise<void> {
+    // HTTP/SSE transport has no local child process to clean up.
+  }
+
+  async listTools(opts?: McpRequestOptions): Promise<McpToolDescriptor[]> {
+    const result = await this.request("tools/list", {}, opts);
+    return normalizeToolsPayload(result);
+  }
+
+  async callTool(
+    name: string,
+    args: Record<string, unknown>,
+    opts?: McpRequestOptions,
+  ): Promise<unknown> {
+    return this.request(
+      "tools/call",
+      {
+        name,
+        arguments: args,
+      },
+      opts,
+    );
+  }
+
+  private async initialize(): Promise<void> {
+    try {
+      await this.request(
+        "initialize",
+        {
+          protocolVersion: MCP_PROTOCOL_VERSION,
+          capabilities: {},
+          clientInfo: {
+            name: "openclaw",
+            version: "embedded",
+          },
+        },
+        { timeoutMs: 15_000 },
+      );
+    } catch (error) {
+      log.warn(`mcp initialize failed (${this.serverName}): ${toErrorMessage(error)}`);
+    }
+
+    try {
+      await this.notify("notifications/initialized", {});
+    } catch {
+      // Ignore initialization notification failures.
+    }
+  }
+
+  private async notify(method: string, params: unknown): Promise<void> {
+    const headers: Record<string, string> = {
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+      ...(this.config.headers ?? {}),
+    };
+
+    await fetch(this.config.url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        method,
+        params,
+      }),
+    });
+  }
+
+  private async request(
+    method: string,
+    params: unknown,
+    opts?: McpRequestOptions,
+  ): Promise<unknown> {
+    if (opts?.signal?.aborted) {
+      throw new Error(`MCP request aborted before send: ${method}`);
+    }
+
+    const id = this.nextId;
+    this.nextId += 1;
+    const timeoutMs = resolveTimeoutMs(opts?.timeoutMs);
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => {
+      controller.abort(new Error(`timeout`));
+    }, timeoutMs);
+
+    const onAbort = () => {
+      controller.abort(new Error("aborted"));
+    };
+    opts?.signal?.addEventListener("abort", onAbort, { once: true });
+
+    try {
+      const headers: Record<string, string> = {
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+        ...(this.config.headers ?? {}),
+      };
+
+      const response = await fetch(this.config.url, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id,
+          method,
+          params,
+        }),
+        signal: controller.signal,
+      });
+
+      const rawBody = await response.text();
+      if (!response.ok) {
+        throw new Error(
+          `MCP HTTP request failed (${response.status} ${response.statusText}): ${rawBody.slice(0, 500)}`,
+        );
+      }
+
+      const envelope = parseHttpJsonRpcBody(rawBody);
+      if (envelope.error !== undefined) {
+        throw new Error(formatJsonRpcError(envelope.error));
+      }
+
+      if (envelope.id !== undefined && envelope.id !== id && String(envelope.id) !== String(id)) {
+        throw new Error(
+          `MCP response id mismatch for ${this.serverName}.${method}: expected ${id}, got ${String(envelope.id)}`,
+        );
+      }
+
+      return envelope.result;
+    } catch (error) {
+      if (controller.signal.aborted && !opts?.signal?.aborted) {
+        throw new Error(`MCP request timed out after ${timeoutMs}ms: ${this.serverName}.${method}`);
+      }
+      throw error;
+    } finally {
+      clearTimeout(timer);
+      opts?.signal?.removeEventListener("abort", onAbort);
+    }
+  }
+}
+
+function createMcpClient(serverName: string, config: McpServerConfig): McpClient {
+  if (config.type === "stdio") {
+    return new StdioMcpClient(serverName, config);
+  }
+  return new HttpMcpClient(serverName, config);
+}
+
+export async function initMcpRuntime(params: {
+  mcpServers?: unknown[];
+  existingToolNames?: Iterable<string>;
+  toolCallTimeoutMs?: number;
+}): Promise<McpRuntime> {
+  const parsed = parseMcpServers(params.mcpServers);
+  const serverEntries = Object.entries(parsed);
+
+  if (serverEntries.length === 0) {
+    return {
+      tools: [],
+      cleanup: async () => {},
+    };
+  }
+
+  const activeClients: Array<{ serverName: string; client: McpClient }> = [];
+  const toolHandles: McpToolHandle[] = [];
+  const nameRegistry = new Set<string>(params.existingToolNames ?? []);
+
+  for (const [serverName, config] of serverEntries) {
+    const client = createMcpClient(serverName, config);
+    try {
+      await client.start();
+    } catch (error) {
+      log.warn(`mcp server failed to start (${serverName}): ${toErrorMessage(error)}`);
+      await client.stop().catch(() => {});
+      continue;
+    }
+
+    activeClients.push({ serverName, client });
+
+    let tools: McpToolDescriptor[] = [];
+    try {
+      tools = await client.listTools({ timeoutMs: 15_000 });
+    } catch (error) {
+      log.warn(`mcp tools/list failed (${serverName}): ${toErrorMessage(error)}`);
+      continue;
+    }
+
+    for (const tool of tools) {
+      const originalName = tool.name.trim();
+      if (!originalName) {
+        continue;
+      }
+
+      const uniqueName = resolveUniqueMcpName(originalName, nameRegistry);
+      nameRegistry.add(uniqueName);
+
+      toolHandles.push({
+        name: uniqueName,
+        mcpName: originalName,
+        serverName,
+        description: tool.description,
+        inputSchema: tool.inputSchema,
+        call: async (toolParams, opts) => {
+          return client.callTool(originalName, toolParams, {
+            timeoutMs: opts?.timeoutMs ?? params.toolCallTimeoutMs,
+            signal: opts?.signal,
+          });
+        },
+      });
+    }
+  }
+
+  return {
+    tools: toolHandles,
+    cleanup: async () => {
+      await Promise.allSettled(activeClients.map((entry) => entry.client.stop()));
+    },
+  };
+}

--- a/src/agents/mcp-common.ts
+++ b/src/agents/mcp-common.ts
@@ -1,0 +1,111 @@
+export type McpServerConfig =
+  | {
+      type: "stdio";
+      command: string;
+      args?: string[];
+      env?: Record<string, string>;
+    }
+  | {
+      type: "http" | "sse";
+      url: string;
+      headers?: Record<string, string>;
+    };
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function readNameValuePairs(value: unknown): Record<string, string> {
+  if (isRecord(value)) {
+    return Object.fromEntries(
+      Object.entries(value).filter(
+        (entry): entry is [string, string] =>
+          typeof entry[0] === "string" && typeof entry[1] === "string",
+      ),
+    );
+  }
+  if (!Array.isArray(value)) {
+    return {};
+  }
+  const out: Record<string, string> = {};
+  for (const entry of value) {
+    if (!isRecord(entry)) {
+      continue;
+    }
+    const name = typeof entry.name === "string" ? entry.name.trim() : "";
+    const data = typeof entry.value === "string" ? entry.value : "";
+    if (!name) {
+      continue;
+    }
+    out[name] = data;
+  }
+  return out;
+}
+
+function hasName(name: string, existing: Record<string, unknown> | Set<string>): boolean {
+  return existing instanceof Set ? existing.has(name) : name in existing;
+}
+
+export function resolveUniqueMcpName(
+  name: string,
+  existing: Record<string, unknown> | Set<string>,
+): string {
+  if (!hasName(name, existing)) {
+    return name;
+  }
+  let next = 2;
+  while (hasName(`${name}-${next}`, existing)) {
+    next += 1;
+  }
+  return `${name}-${next}`;
+}
+
+export function parseMcpServers(mcpServers: unknown[] | undefined): Record<string, McpServerConfig> {
+  const out: Record<string, McpServerConfig> = {};
+  if (!Array.isArray(mcpServers)) {
+    return out;
+  }
+
+  for (const rawServer of mcpServers) {
+    if (!isRecord(rawServer)) {
+      continue;
+    }
+    const baseName = typeof rawServer.name === "string" ? rawServer.name.trim() : "";
+    if (!baseName) {
+      continue;
+    }
+    const name = resolveUniqueMcpName(baseName, out);
+    const type = typeof rawServer.type === "string" ? rawServer.type.trim().toLowerCase() : "";
+
+    if (type === "http" || type === "sse") {
+      const url = typeof rawServer.url === "string" ? rawServer.url.trim() : "";
+      if (!url) {
+        continue;
+      }
+      const headers = readNameValuePairs(rawServer.headers);
+      out[name] = {
+        type,
+        url,
+        ...(Object.keys(headers).length > 0 ? { headers } : {}),
+      };
+      continue;
+    }
+
+    const command = typeof rawServer.command === "string" ? rawServer.command.trim() : "";
+    if (!command) {
+      continue;
+    }
+    const args = Array.isArray(rawServer.args)
+      ? rawServer.args.filter((entry): entry is string => typeof entry === "string")
+      : [];
+    const env = readNameValuePairs(rawServer.env);
+    out[name] = {
+      type: "stdio",
+      command,
+      ...(args.length > 0 ? { args } : {}),
+      ...(Object.keys(env).length > 0 ? { env } : {}),
+    };
+  }
+
+  return out;
+}

--- a/src/agents/mcp-tool-adapter.test.ts
+++ b/src/agents/mcp-tool-adapter.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+import { toMcpToolDefinitions } from "./mcp-tool-adapter.js";
+
+describe("mcp tool adapter", () => {
+  it("adapts MCP tools and passes params through", async () => {
+    const call = vi.fn(async (params: Record<string, unknown>) => ({ ok: true, params }));
+    const defs = toMcpToolDefinitions([
+      {
+        name: "lean_check",
+        mcpName: "lean_check",
+        serverName: "lean-lsp",
+        description: "Check Lean source",
+        inputSchema: {
+          type: "object",
+          properties: {
+            source: { type: "string" },
+          },
+        },
+        call,
+      },
+    ]);
+
+    const result = await defs[0].execute("call1", { source: "#check Nat" }, undefined, undefined);
+
+    expect(call).toHaveBeenCalledWith(
+      {
+        source: "#check Nat",
+      },
+      {
+        timeoutMs: undefined,
+        signal: undefined,
+      },
+    );
+    expect(result.details).toMatchObject({
+      ok: true,
+      params: { source: "#check Nat" },
+    });
+  });
+
+  it("wraps execution failures into a structured error tool result", async () => {
+    const defs = toMcpToolDefinitions([
+      {
+        name: "lean_check",
+        mcpName: "lean_check",
+        serverName: "lean-lsp",
+        inputSchema: undefined,
+        call: async () => {
+          throw new Error("server down");
+        },
+      },
+    ]);
+
+    const result = await defs[0].execute("call2", { source: "#check Nat" }, undefined, undefined);
+
+    expect(result.details).toMatchObject({
+      status: "error",
+      tool: "lean_check",
+      server: "lean-lsp",
+      error: "server down",
+    });
+  });
+});

--- a/src/agents/mcp-tool-adapter.ts
+++ b/src/agents/mcp-tool-adapter.ts
@@ -1,0 +1,118 @@
+import type {
+  AgentToolResult,
+  AgentToolUpdateCallback,
+} from "@mariozechner/pi-agent-core";
+import type { ToolDefinition } from "@mariozechner/pi-coding-agent";
+import { logError } from "../logger.js";
+import { isPlainObject } from "../utils.js";
+import type { McpToolHandle } from "./mcp-client.js";
+import { jsonResult } from "./tools/common.js";
+
+type ToolExecuteArgsCurrent = [
+  string,
+  unknown,
+  AgentToolUpdateCallback<unknown> | undefined,
+  unknown,
+  AbortSignal | undefined,
+];
+
+type ToolExecuteArgsLegacy = [
+  string,
+  unknown,
+  AbortSignal | undefined,
+  AgentToolUpdateCallback<unknown> | undefined,
+  unknown,
+];
+
+type ToolExecuteArgs = ToolDefinition["execute"] extends (...args: infer P) => unknown
+  ? P
+  : ToolExecuteArgsCurrent;
+
+type ToolExecuteArgsAny = ToolExecuteArgs | ToolExecuteArgsLegacy | ToolExecuteArgsCurrent;
+
+function isAbortSignal(value: unknown): value is AbortSignal {
+  return typeof value === "object" && value !== null && "aborted" in value;
+}
+
+function isLegacyToolExecuteArgs(args: ToolExecuteArgsAny): args is ToolExecuteArgsLegacy {
+  const third = args[2];
+  const fourth = args[3];
+  return isAbortSignal(third) || typeof fourth === "function";
+}
+
+function splitToolExecuteArgs(args: ToolExecuteArgsAny): {
+  toolCallId: string;
+  params: unknown;
+  signal: AbortSignal | undefined;
+} {
+  if (isLegacyToolExecuteArgs(args)) {
+    const [toolCallId, params, signal] = args;
+    return { toolCallId, params, signal };
+  }
+
+  const [toolCallId, params, _onUpdate, _ctx, signal] = args;
+  return { toolCallId, params, signal };
+}
+
+function resolveToolParameters(schema: Record<string, unknown> | undefined): Record<string, unknown> {
+  if (!schema) {
+    return {
+      type: "object",
+      properties: {},
+      additionalProperties: true,
+    };
+  }
+  return schema;
+}
+
+function describeToolError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message?.trim() ? error.message : String(error);
+  }
+  return String(error);
+}
+
+export function toMcpToolDefinitions(
+  tools: McpToolHandle[],
+  opts?: { timeoutMs?: number },
+): ToolDefinition[] {
+  return tools.map((tool) => {
+    const description = tool.description?.trim()
+      ? tool.description
+      : `MCP tool from server \"${tool.serverName}\"`;
+
+    return {
+      name: tool.name,
+      label: tool.name,
+      description,
+      // oxlint-disable-next-line typescript/no-explicit-any
+      parameters: resolveToolParameters(tool.inputSchema) as any,
+      execute: async (...args: ToolExecuteArgs): Promise<AgentToolResult<unknown>> => {
+        const { params, signal } = splitToolExecuteArgs(args);
+        const callArgs = isPlainObject(params) ? params : {};
+
+        try {
+          const result = await tool.call(callArgs, {
+            timeoutMs: opts?.timeoutMs,
+            signal,
+          });
+          return jsonResult(result);
+        } catch (error) {
+          if (signal?.aborted) {
+            throw error;
+          }
+
+          const message = describeToolError(error);
+          logError(`[tools] ${tool.name} (mcp:${tool.serverName}) failed: ${message}`);
+
+          return jsonResult({
+            status: "error",
+            tool: tool.name,
+            server: tool.serverName,
+            error: message,
+          });
+        }
+      },
+    } satisfies ToolDefinition;
+  });
+}

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -4,6 +4,7 @@ import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { enqueueCommandInLane } from "../../process/command-queue.js";
 import { isMarkdownCapableMessageChannel } from "../../utils/message-channel.js";
 import { resolveOpenClawAgentDir } from "../agent-paths.js";
+import { resolveAgentMcpServers } from "../agent-scope.js";
 import {
   isProfileInCooldown,
   markAuthProfileFailure,
@@ -204,6 +205,11 @@ export async function runEmbeddedPiAgent(
       const agentDir = params.agentDir ?? resolveOpenClawAgentDir();
       const fallbackConfigured =
         (params.config?.agents?.defaults?.model?.fallbacks?.length ?? 0) > 0;
+      const resolvedMcpServers =
+        params.mcpServers ??
+        (params.config
+          ? resolveAgentMcpServers(params.config, workspaceResolution.agentId)
+          : undefined);
       await ensureOpenClawModelsJson(params.config, agentDir);
 
       // Run before_model_resolve hooks early so plugins can override the
@@ -497,6 +503,8 @@ export async function runEmbeddedPiAgent(
             skillsSnapshot: params.skillsSnapshot,
             prompt,
             images: params.images,
+            clientTools: params.clientTools,
+            mcpServers: resolvedMcpServers,
             disableTools: params.disableTools,
             provider,
             modelId,

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -64,6 +64,8 @@ export type RunEmbeddedPiAgentParams = {
   images?: ImageContent[];
   /** Optional client-provided tools (OpenResponses hosted tools). */
   clientTools?: ClientToolDefinition[];
+  /** Optional MCP server definitions (ACP mcpServers) for embedded tool exposure. */
+  mcpServers?: unknown[];
   /** Disable built-in tools for this run (LLM-only mode). */
   disableTools?: boolean;
   provider?: string;

--- a/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.e2e.test.ts
+++ b/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.e2e.test.ts
@@ -279,7 +279,6 @@ describe("createOpenClawCodingTools", () => {
       "cron",
       "message",
       "gateway",
-      "lean",
       "agents_list",
       "sessions_list",
       "sessions_history",

--- a/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.e2e.test.ts
+++ b/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.e2e.test.ts
@@ -279,6 +279,7 @@ describe("createOpenClawCodingTools", () => {
       "cron",
       "message",
       "gateway",
+      "lean",
       "agents_list",
       "sessions_list",
       "sessions_history",

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -205,6 +205,7 @@ export async function runAgentTurnWithFallback(params: {
                   ownerNumbers: params.followupRun.run.ownerNumbers,
                   cliSessionId,
                   images: params.opts?.images,
+                  mcpServers: params.opts?.mcpServers,
                 });
 
                 // CLI backends don't emit streaming assistant events, so we need to
@@ -307,6 +308,7 @@ export async function runAgentTurnWithFallback(params: {
             timeoutMs: params.followupRun.run.timeoutMs,
             runId,
             images: params.opts?.images,
+            mcpServers: params.opts?.mcpServers,
             abortSignal: params.opts?.abortSignal,
             blockReplyBreak: params.resolvedBlockStreamingBreak,
             blockReplyChunking: params.blockReplyChunking,

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -144,6 +144,7 @@ export async function runMemoryFlushIfNeeded(params: {
           bashElevated: params.followupRun.run.bashElevated,
           timeoutMs: params.followupRun.run.timeoutMs,
           runId: flushRunId,
+          mcpServers: params.opts?.mcpServers,
           onAgentEvent: (evt) => {
             if (evt.stream === "compaction") {
               const phase = typeof evt.data.phase === "string" ? evt.data.phase : "";

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -171,6 +171,7 @@ export function createFollowupRunner(params: {
               bashElevated: queued.run.bashElevated,
               timeoutMs: queued.run.timeoutMs,
               runId,
+              mcpServers: opts?.mcpServers,
               blockReplyBreak: queued.run.blockReplyBreak,
               onAgentEvent: (evt) => {
                 if (evt.stream !== "compaction") {

--- a/src/auto-reply/types.ts
+++ b/src/auto-reply/types.ts
@@ -20,6 +20,8 @@ export type GetReplyOptions = {
   abortSignal?: AbortSignal;
   /** Optional inbound images (used for webchat attachments). */
   images?: ImageContent[];
+  /** Optional ACP-provided MCP server list forwarded to embedded and CLI runners. */
+  mcpServers?: unknown[];
   /** Notifies when an agent run actually starts (useful for webchat command handling). */
   onAgentRunStart?: (runId: string) => void;
   onReplyStart?: () => Promise<void> | void;

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -160,6 +160,8 @@ export type AgentDefaultsConfig = {
   contextTokens?: number;
   /** Optional CLI backends for text-only fallback (claude-cli, etc.). */
   cliBackends?: Record<string, CliBackendConfig>;
+  /** Optional MCP server list (ACP mcpServers shape) for CLI and embedded runners. */
+  mcpServers?: unknown[];
   /** Opt-in: prune old tool results from the LLM context to reduce token usage. */
   contextPruning?: AgentContextPruningConfig;
   /** Compaction tuning and pre-compaction memory flush behavior. */

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -32,6 +32,8 @@ export type AgentConfig = {
   humanDelay?: HumanDelayConfig;
   /** Optional per-agent heartbeat overrides. */
   heartbeat?: AgentDefaultsConfig["heartbeat"];
+  /** Optional per-agent MCP server overrides. */
+  mcpServers?: AgentDefaultsConfig["mcpServers"];
   identity?: IdentityConfig;
   groupChat?: GroupChatConfig;
   subagents?: {

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -3,6 +3,7 @@ import {
   HeartbeatSchema,
   AgentSandboxSchema,
   AgentModelSchema,
+  McpServersSchema,
   MemorySearchSchema,
 } from "./zod-schema.agent-runtime.js";
 import {
@@ -65,6 +66,7 @@ export const AgentDefaultsSchema = z
     envelopeElapsed: z.union([z.literal("on"), z.literal("off")]).optional(),
     contextTokens: z.number().int().positive().optional(),
     cliBackends: z.record(z.string(), CliBackendSchema).optional(),
+    mcpServers: McpServersSchema,
     memorySearch: MemorySearchSchema,
     contextPruning: z
       .object({

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -88,6 +88,8 @@ export const HeartbeatSchema = z
   })
   .optional();
 
+export const McpServersSchema = z.array(z.unknown()).optional();
+
 export const SandboxDockerSchema = z
   .object({
     image: z.string().optional(),
@@ -592,6 +594,7 @@ export const AgentEntrySchema = z
     memorySearch: MemorySearchSchema,
     humanDelay: HumanDelaySchema.optional(),
     heartbeat: HeartbeatSchema,
+    mcpServers: McpServersSchema,
     identity: IdentitySchema,
     groupChat: GroupChatSchema,
     subagents: z

--- a/src/gateway/protocol/schema/logs-chat.ts
+++ b/src/gateway/protocol/schema/logs-chat.ts
@@ -39,6 +39,7 @@ export const ChatSendParamsSchema = Type.Object(
     deliver: Type.Optional(Type.Boolean()),
     attachments: Type.Optional(Type.Array(Type.Unknown())),
     timeoutMs: Type.Optional(Type.Integer({ minimum: 0 })),
+    mcpServers: Type.Optional(Type.Array(Type.Unknown())),
     idempotencyKey: NonEmptyString,
   },
   { additionalProperties: false },

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -725,6 +725,7 @@ export const chatHandlers: GatewayRequestHandlers = {
         content?: unknown;
       }>;
       timeoutMs?: number;
+      mcpServers?: unknown[];
       idempotencyKey: string;
     };
     const sanitizedMessageResult = sanitizeChatSendMessageInput(p.message);
@@ -899,6 +900,7 @@ export const chatHandlers: GatewayRequestHandlers = {
           abortSignal: abortController.signal,
           images: parsedImages.length > 0 ? parsedImages : undefined,
           disableBlockStreaming: true,
+          mcpServers: p.mcpServers,
           onAgentRunStart: (runId) => {
             agentRunStarted = true;
             const connId = typeof client?.connId === "string" ? client.connId : undefined;


### PR DESCRIPTION
## Summary

- Adds embedded MCP (Model Context Protocol) server support so externally configured MCP servers are available as tools inside both the embedded PI runner and CLI backends
- New modules: `mcp-client.ts` (stdio + HTTP/SSE transports, JSON-RPC protocol, tool discovery/invocation), `mcp-common.ts` (shared types, parser, name deduplication), `mcp-tool-adapter.ts` (MCP → ToolDefinition converter)
- Wires `mcpServers` through ACP sessions, gateway chat endpoint, config schema (defaults + per-agent), CLI runner (`--mcp-config` temp file), and embedded runner (`initMcpRuntime()`)

## Test plan

- [ ] Unit tests for MCP client (stdio transport spawn, tool listing, tool invocation, error handling)
- [ ] Unit tests for MCP tool adapter (schema conversion, error formatting)
- [ ] Unit tests for ACP session (mcpServers stored and retrieved)
- [ ] Unit tests for CLI runner (MCP config file generation, merge with existing `--mcp-config`)
- [ ] Integration: configure an MCP server in agent defaults, verify tools appear in agent session
- [ ] Integration: verify CLI backend receives `--mcp-config` flag with correct server definitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds embedded MCP (Model Context Protocol) server support, enabling externally configured MCP servers to provide tools inside both the embedded PI runner and CLI backends.

- **New modules**: `mcp-client.ts` implements stdio and HTTP/SSE transports with JSON-RPC protocol, tool discovery, and invocation. `mcp-common.ts` provides shared types, config parsing, and name deduplication. `mcp-tool-adapter.ts` converts MCP tool handles into the framework's `ToolDefinition` format with legacy/current arg detection.
- **Config plumbing**: `mcpServers` is threaded through ACP sessions, the gateway chat endpoint, config schema (defaults + per-agent), CLI runner (`--mcp-config` temp file with merge), and embedded runner (`initMcpRuntime()`).
- **Lifecycle management**: MCP clients are started/stopped with proper cleanup in `finally` blocks. stdio servers get graceful shutdown (SIGTERM → 1s wait → SIGKILL). Temp config files are cleaned up after CLI runs.
- **Name collision handling**: Tool names are deduplicated across servers and existing built-in tools using a `nameRegistry` set.
- Tests cover stdio transport spawning, tool listing/invocation, array inputSchema rejection (regression test for the fixed `isRecord` bug), tool adapter schema conversion and error formatting, ACP session storage, and CLI runner config file generation/merge.

<h3>Confidence Score: 4/5</h3>

- This PR is well-structured with proper error handling, cleanup, and test coverage; safe to merge with minor considerations.
- Score of 4 reflects: (1) clean architecture with proper separation between client, adapter, and common modules, (2) thorough lifecycle management with graceful shutdown and cleanup in finally blocks, (3) good test coverage including a regression test for the array isRecord bug, (4) consistent config plumbing throughout the stack. Minor deductions for: unconsumed HTTP response body in HttpMcpClient.notify(), and a phantom "lean" entry in the pi-tools test coreTools set that doesn't correspond to an actual tool.
- `src/agents/mcp-client.ts` is the core implementation (722 lines) and warrants extra scrutiny for the JSON-RPC protocol handling and process lifecycle management.

<sub>Last reviewed commit: c8ddf18</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->