### PR TITLE
fix: improve type safety and error handling

### DIFF
--- a/src/agents/session-tool-result-guard-wrapper.ts
+++ b/src/agents/session-tool-result-guard-wrapper.ts
@@ -1,3 +1,4 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { SessionManager } from "@mariozechner/pi-coding-agent";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import {
@@ -30,8 +31,10 @@ export function guardSessionManager(
 
   const hookRunner = getGlobalHookRunner();
   const transform = hookRunner?.hasHooks("tool_result_persist")
-    ? // oxlint-disable-next-line typescript/no-explicit-any
-      (message: any, meta: { toolCallId?: string; toolName?: string; isSynthetic?: boolean }) => {
+    ? (
+        message: AgentMessage,
+        meta: { toolCallId?: string; toolName?: string; isSynthetic?: boolean },
+      ) => {
         const out = hookRunner.runToolResultPersist(
           {
             toolName: meta.toolName,

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -72,9 +72,13 @@ function startSubagentAnnounceCleanupFlow(runId: string, entry: SubagentRunRecor
     endedAt: entry.endedAt,
     label: entry.label,
     outcome: entry.outcome,
-  }).then((didAnnounce) => {
-    finalizeSubagentCleanup(runId, entry.cleanup, didAnnounce);
-  });
+  })
+    .then((didAnnounce) => {
+      finalizeSubagentCleanup(runId, entry.cleanup, didAnnounce);
+    })
+    .catch((err) => {
+      console.error(`[openclaw] subagent announce/cleanup failed for ${runId}: ${String(err)}`);
+    });
   return true;
 }
 

--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -65,8 +65,7 @@ export type InlineActionResult =
       abortedLastRun: boolean;
     };
 
-// oxlint-disable-next-line typescript/no-explicit-any
-function extractTextFromToolResult(result: any): string | null {
+function extractTextFromToolResult(result: unknown): string | null {
   if (!result || typeof result !== "object") {
     return null;
   }

--- a/src/discord/monitor/sender-identity.ts
+++ b/src/discord/monitor/sender-identity.ts
@@ -16,6 +16,11 @@ export type DiscordSenderIdentity = {
   };
 };
 
+/** Minimal structural type for a Discord guild member (Carbon GuildMember or raw API data). */
+type DiscordMemberLike = {
+  nickname?: string | null;
+};
+
 type DiscordWebhookMessageLike = {
   webhookId?: string | null;
   webhook_id?: string | null;
@@ -28,8 +33,7 @@ export function resolveDiscordWebhookId(message: DiscordWebhookMessageLike): str
 
 export function resolveDiscordSenderIdentity(params: {
   author: User;
-  // oxlint-disable-next-line typescript/no-explicit-any
-  member?: any;
+  member?: DiscordMemberLike | null;
   pluralkitInfo?: PluralKitMessageInfo | null;
 }): DiscordSenderIdentity {
   const pkInfo = params.pluralkitInfo ?? null;
@@ -74,8 +78,7 @@ export function resolveDiscordSenderIdentity(params: {
 
 export function resolveDiscordSenderLabel(params: {
   author: User;
-  // oxlint-disable-next-line typescript/no-explicit-any
-  member?: any;
+  member?: DiscordMemberLike | null;
   pluralkitInfo?: PluralKitMessageInfo | null;
 }): string {
   return resolveDiscordSenderIdentity(params).label;

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -292,7 +292,9 @@ export function createExecApprovalForwarder(
         pending.delete(request.id);
         const expiredText = buildExpiredMessage(request);
         await deliverToTargets({ cfg, targets: entry.targets, text: expiredText, deliver });
-      })();
+      })().catch((err) => {
+        log.error(`exec-approval expiry delivery failed: ${String(err)}`);
+      });
     }, expiresInMs);
     timeoutId.unref?.();
 


### PR DESCRIPTION
## Summary

This PR improves type safety by replacing `any` types with proper TypeScript types, and fixes several error handling gaps.

## Type Safety

- **`src/discord/monitor/sender-identity.ts`**: Replace `member?: any` with a structural `DiscordMemberLike` type (`{ nickname?: string | null }`) in `resolveDiscordSenderIdentity` and `resolveDiscordSenderLabel`. Removes 2 `oxlint-disable` comments.
- **`src/agents/session-tool-result-guard-wrapper.ts`**: Replace `message: any` with `AgentMessage` from `@mariozechner/pi-agent-core`, matching the type already defined in `installSessionToolResultGuard`. Removes 1 `oxlint-disable` comment.
- **`src/auto-reply/reply/get-reply-inline-actions.ts`**: Replace `result: any` with `unknown` in `extractTextFromToolResult` (function already does runtime type narrowing). Removes 1 `oxlint-disable` comment.

## Error Handling

- **`src/pairing/pairing-store.ts` (`writeJsonFile`)**: Add try-catch to clean up dangling temp files on failure (e.g. disk full, permission errors).
- **`src/pairing/pairing-store.ts` (`readJsonFile`)**: Fix silent swallowing of non-ENOENT errors (e.g. `EACCES`, `EIO`). Previously both error branches returned the same fallback, masking real filesystem problems.
- **`src/infra/exec-approval-forwarder.ts`**: Add `.catch()` to fire-and-forget async IIFE in approval expiry timeout to prevent unhandled promise rejections.
- **`src/agents/subagent-registry.ts`**: Add `.catch()` to `runSubagentAnnounceFlow` promise chain to prevent unhandled rejections.

## Verification

- `pnpm check` passes (formatting, types, linting: 0 warnings, 0 errors)
- `pnpm test` passes (760/761 files, 6511/6513 tests; 1 pre-existing flaky failure in `src/process/exec.test.ts`)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaced explicit `any` types with proper TypeScript types in 4 files, removing all `oxlint-disable` comments for type safety. Added error handling improvements in 2 files to prevent unhandled promise rejections and properly handle filesystem errors.

Type safety improvements successfully eliminate unsafe type annotations while maintaining runtime behavior:
- `src/discord/monitor/sender-identity.ts`: Introduced `DiscordMemberLike` structural type to properly type Discord member objects
- `src/agents/session-tool-result-guard-wrapper.ts`: Used imported `AgentMessage` type matching existing function signature
- `src/auto-reply/reply/get-reply-inline-actions.ts`: Changed to `unknown` which correctly reflects runtime type narrowing pattern

Error handling improvements address real failure scenarios:
- `src/pairing/pairing-store.ts` (`writeJsonFile`): Added try-catch with temp file cleanup on failure
- `src/pairing/pairing-store.ts` (`readJsonFile`): Now properly throws non-ENOENT errors instead of silently swallowing them
- `src/infra/exec-approval-forwarder.ts`: Added `.catch()` handler for fire-and-forget async IIFE
- `src/agents/subagent-registry.ts`: Added `.catch()` handler to promise chain

All changes are backwards compatible with no behavioral changes to success paths.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- All changes improve code quality without altering behavior. Type safety improvements remove unsafe `any` types with proper alternatives. Error handling additions prevent real failure scenarios (dangling temp files, masked filesystem errors, unhandled promise rejections). The PR author verified `pnpm check` passes with 0 warnings/errors and `pnpm test` passes 6511/6513 tests with only 1 pre-existing flaky failure.
- No files require special attention

<sub>Last reviewed commit: 2e87803</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->