### PR TITLE
fix(heartbeat): prune transcript for HEARTBEAT_OK turns

### DIFF
--- a/src/infra/heartbeat-runner.transcript-prune.test.ts
+++ b/src/infra/heartbeat-runner.transcript-prune.test.ts
@@ -1,0 +1,188 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { telegramPlugin } from "../../extensions/telegram/src/channel.js";
+import { setTelegramRuntime } from "../../extensions/telegram/src/runtime.js";
+import * as replyModule from "../auto-reply/reply.js";
+import { resolveMainSessionKey } from "../config/sessions.js";
+import { setActivePluginRegistry } from "../plugins/runtime.js";
+import { createPluginRuntime } from "../plugins/runtime/index.js";
+import { createTestRegistry } from "../test-utils/channel-plugins.js";
+import { runHeartbeatOnce } from "./heartbeat-runner.js";
+
+// Avoid pulling optional runtime deps during isolated runs.
+vi.mock("jiti", () => ({ createJiti: () => () => ({}) }));
+
+beforeEach(() => {
+  const runtime = createPluginRuntime();
+  setTelegramRuntime(runtime);
+  setActivePluginRegistry(
+    createTestRegistry([
+      { pluginId: "telegram", plugin: telegramPlugin, source: "test" },
+    ]),
+  );
+});
+
+describe("heartbeat transcript pruning", () => {
+  async function seedSessionStore(
+    storePath: string,
+    sessionKey: string,
+    session: {
+      sessionId?: string;
+      updatedAt?: number;
+      lastChannel: string;
+      lastProvider: string;
+      lastTo: string;
+    },
+  ) {
+    await fs.writeFile(
+      storePath,
+      JSON.stringify(
+        {
+          [sessionKey]: {
+            sessionId: session.sessionId ?? "sid",
+            updatedAt: session.updatedAt ?? Date.now(),
+            ...session,
+          },
+        },
+        null,
+        2,
+      ),
+    );
+  }
+
+  async function createTranscriptWithContent(transcriptPath: string, sessionId: string) {
+    const header = {
+      type: "session",
+      version: 3,
+      id: sessionId,
+      timestamp: new Date().toISOString(),
+      cwd: process.cwd(),
+    };
+    const existingContent = `${JSON.stringify(header)}\n{"role":"user","content":"Hello"}\n{"role":"assistant","content":"Hi there"}\n`;
+    await fs.mkdir(path.dirname(transcriptPath), { recursive: true });
+    await fs.writeFile(transcriptPath, existingContent);
+    return existingContent;
+  }
+
+  async function withTempHeartbeatSandbox<T>(
+    fn: (ctx: {
+      tmpDir: string;
+      storePath: string;
+      replySpy: ReturnType<typeof vi.spyOn>;
+    }) => Promise<T>,
+  ) {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-hb-prune-"));
+    const storePath = path.join(tmpDir, "sessions.json");
+    const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
+    const prevTelegramToken = process.env.TELEGRAM_BOT_TOKEN;
+    process.env.TELEGRAM_BOT_TOKEN = "";
+    try {
+      return await fn({ tmpDir, storePath, replySpy });
+    } finally {
+      replySpy.mockRestore();
+      if (prevTelegramToken === undefined) {
+        delete process.env.TELEGRAM_BOT_TOKEN;
+      } else {
+        process.env.TELEGRAM_BOT_TOKEN = prevTelegramToken;
+      }
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  }
+
+  it("prunes transcript when heartbeat returns HEARTBEAT_OK", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const sessionKey = resolveMainSessionKey(undefined);
+      const sessionId = "test-session-prune";
+      const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
+
+      // Create a transcript with some existing content
+      const originalContent = await createTranscriptWithContent(transcriptPath, sessionId);
+      const originalSize = (await fs.stat(transcriptPath)).size;
+
+      // Seed session store
+      await seedSessionStore(storePath, sessionKey, {
+        sessionId,
+        lastChannel: "telegram",
+        lastProvider: "telegram",
+        lastTo: "user123",
+      });
+
+      // Mock reply to return HEARTBEAT_OK (which triggers pruning)
+      replySpy.mockResolvedValueOnce({
+        text: "HEARTBEAT_OK",
+        usage: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 },
+      });
+
+      // Run heartbeat
+      const cfg: OpenClawConfig = {
+        version: 1,
+        model: "test-model",
+        agent: { workspace: tmpDir },
+        sessionStore: storePath,
+        channels: { telegram: { showOk: true, showAlerts: true } },
+      };
+
+      await runHeartbeatOnce({
+        agentId: undefined,
+        reason: "test",
+        cfg,
+        deps: { sendTelegram: vi.fn() },
+      });
+
+      // Verify transcript was truncated back to original size
+      const finalContent = await fs.readFile(transcriptPath, "utf-8");
+      expect(finalContent).toBe(originalContent);
+      const finalSize = (await fs.stat(transcriptPath)).size;
+      expect(finalSize).toBe(originalSize);
+    });
+  });
+
+  it("does not prune transcript when heartbeat returns meaningful content", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const sessionKey = resolveMainSessionKey(undefined);
+      const sessionId = "test-session-no-prune";
+      const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
+
+      // Create a transcript with some existing content
+      const originalContent = await createTranscriptWithContent(transcriptPath, sessionId);
+      const originalSize = (await fs.stat(transcriptPath)).size;
+
+      // Seed session store
+      await seedSessionStore(storePath, sessionKey, {
+        sessionId,
+        lastChannel: "telegram",
+        lastProvider: "telegram",
+        lastTo: "user123",
+      });
+
+      // Mock reply to return meaningful content (should NOT trigger pruning)
+      replySpy.mockResolvedValueOnce({
+        text: "Alert: Something needs your attention!",
+        usage: { inputTokens: 10, outputTokens: 20, cacheReadTokens: 0, cacheWriteTokens: 0 },
+      });
+
+      // Run heartbeat
+      const cfg: OpenClawConfig = {
+        version: 1,
+        model: "test-model",
+        agent: { workspace: tmpDir },
+        sessionStore: storePath,
+        channels: { telegram: { showOk: true, showAlerts: true } },
+      };
+
+      await runHeartbeatOnce({
+        agentId: undefined,
+        reason: "test",
+        cfg,
+        deps: { sendTelegram: vi.fn() },
+      });
+
+      // Verify transcript was NOT truncated (it may have grown with new entries)
+      const finalSize = (await fs.stat(transcriptPath)).size;
+      expect(finalSize).toBeGreaterThanOrEqual(originalSize);
+    });
+  });
+});

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -31,6 +31,7 @@ import {
   loadSessionStore,
   resolveAgentIdFromSessionKey,
   resolveAgentMainSessionKey,
+  resolveSessionFilePath,
   resolveStorePath,
   saveSessionStore,
   updateSessionStore,
@@ -350,6 +351,58 @@ async function restoreHeartbeatUpdatedAt(params: {
   });
 }
 
+/**
+ * Prune heartbeat transcript entries by truncating the file back to a previous size.
+ * This removes the user+assistant turns that were written during a HEARTBEAT_OK run,
+ * preventing context pollution from zero-information exchanges.
+ */
+async function pruneHeartbeatTranscript(params: {
+  transcriptPath?: string;
+  preHeartbeatSize?: number;
+}) {
+  const { transcriptPath, preHeartbeatSize } = params;
+  if (!transcriptPath || typeof preHeartbeatSize !== "number" || preHeartbeatSize < 0) {
+    return;
+  }
+  try {
+    const stat = await fs.stat(transcriptPath);
+    // Only truncate if the file has grown during the heartbeat run
+    if (stat.size > preHeartbeatSize) {
+      await fs.truncate(transcriptPath, preHeartbeatSize);
+    }
+  } catch {
+    // File may not exist or may have been removed - ignore errors
+  }
+}
+
+/**
+ * Get the transcript file path and its current size before a heartbeat run.
+ * Returns undefined values if the session or transcript doesn't exist yet.
+ */
+async function captureTranscriptState(params: {
+  storePath: string;
+  sessionKey: string;
+  agentId?: string;
+}): Promise<{ transcriptPath?: string; preHeartbeatSize?: number }> {
+  const { storePath, sessionKey, agentId } = params;
+  try {
+    const store = loadSessionStore(storePath);
+    const entry = store[sessionKey];
+    if (!entry?.sessionId) {
+      return {};
+    }
+    const transcriptPath = resolveSessionFilePath(entry.sessionId, entry, {
+      agentId,
+      sessionsDir: path.dirname(storePath),
+    });
+    const stat = await fs.stat(transcriptPath);
+    return { transcriptPath, preHeartbeatSize: stat.size };
+  } catch {
+    // Session or transcript doesn't exist yet - nothing to prune
+    return {};
+  }
+}
+
 function normalizeHeartbeatReply(
   payload: ReplyPayload,
   responsePrefix: string | undefined,
@@ -539,6 +592,13 @@ export async function runHeartbeatOnce(opts: {
   };
 
   try {
+    // Capture transcript state before the heartbeat run so we can prune if HEARTBEAT_OK
+    const transcriptState = await captureTranscriptState({
+      storePath,
+      sessionKey,
+      agentId,
+    });
+
     const heartbeatModelOverride = heartbeat?.model?.trim() || undefined;
     const replyOpts = heartbeatModelOverride
       ? { isHeartbeat: true, heartbeatModelOverride }
@@ -559,6 +619,8 @@ export async function runHeartbeatOnce(opts: {
         sessionKey,
         updatedAt: previousUpdatedAt,
       });
+      // Prune the transcript to remove HEARTBEAT_OK turns
+      await pruneHeartbeatTranscript(transcriptState);
       const okSent = await maybeSendHeartbeatOk();
       emitHeartbeatEvent({
         status: "ok-empty",
@@ -593,6 +655,8 @@ export async function runHeartbeatOnce(opts: {
         sessionKey,
         updatedAt: previousUpdatedAt,
       });
+      // Prune the transcript to remove HEARTBEAT_OK turns
+      await pruneHeartbeatTranscript(transcriptState);
       const okSent = await maybeSendHeartbeatOk();
       emitHeartbeatEvent({
         status: "ok-token",
@@ -629,6 +693,8 @@ export async function runHeartbeatOnce(opts: {
         sessionKey,
         updatedAt: previousUpdatedAt,
       });
+      // Prune the transcript to remove duplicate heartbeat turns
+      await pruneHeartbeatTranscript(transcriptState);
       emitHeartbeatEvent({
         status: "skipped",
         reason: "duplicate",


### PR DESCRIPTION
## Summary

Fixes #17804 - HEARTBEAT_OK turns polluting session transcript context.

## Problem

When a heartbeat runs and the agent responds with `HEARTBEAT_OK` (nothing to report), delivery is correctly suppressed and `updatedAt` is restored. However, the user+assistant exchange remains in the session transcript, accumulating over time.

With a 30-minute heartbeat interval, this means ~48 zero-information exchanges per day consuming context window tokens and reducing effective thinking room.

## Solution

Prune the transcript back to its pre-heartbeat state when a heartbeat results in:
- `ok-empty`: Empty/null reply
- `ok-token`: HEARTBEAT_OK response with no meaningful content
- `duplicate`: Same payload as previous heartbeat

### Implementation

1. **`captureTranscriptState()`**: Before `getReplyFromConfig`, capture the transcript file path and current size
2. **`pruneHeartbeatTranscript()`**: After determining HEARTBEAT_OK, truncate the file back to the captured size
3. Called in the same three cases that already call `restoreHeartbeatUpdatedAt()`

## Why This Is Safe

- Uses file truncation (atomic on most filesystems)
- Only truncates if file has grown during the heartbeat run
- Gracefully handles missing/deleted files
- Follows the existing pattern: delivery suppression → updatedAt restore → (now) transcript prune
- Only affects HEARTBEAT_OK cases, not meaningful alerts

## Testing

- Added regression test: verifies transcript is truncated when HEARTBEAT_OK
- Added test: verifies transcript is NOT truncated for meaningful content

## Impact

- Reduces context window waste for all heartbeat-enabled agents
- Improves output quality during long conversations
- No behavioral change for meaningful heartbeat responses

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prevents `HEARTBEAT_OK` turns from accumulating in the session transcript, which was causing context window pollution (~48 zero-information exchanges per day with 30-minute heartbeat intervals).

- Adds `captureTranscriptState()` to snapshot the transcript file size before a heartbeat run, and `pruneHeartbeatTranscript()` to truncate the file back to its pre-heartbeat size when the run produces no meaningful output
- Transcript pruning is applied in all three existing HEARTBEAT_OK code paths: `ok-empty` (null/empty reply), `ok-token` (HEARTBEAT_OK response), and `duplicate` (same payload as previous heartbeat)
- The file truncation approach is safe because heartbeat runs are serialized via the `running` flag in `heartbeat-wake.ts`, and heartbeats skip entirely when the main command lane has in-flight requests (preventing concurrent transcript writes)
- Includes two regression tests covering the prune and no-prune cases

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk — the pruning only affects HEARTBEAT_OK cases and is protected by existing serialization guarantees.
- The implementation is clean and follows established patterns in the codebase (same three code paths that already call `restoreHeartbeatUpdatedAt`). The file truncation approach is safe because heartbeat runs are serialized (single `running` flag) and heartbeats skip when requests are in-flight. Error handling is appropriate. Tests cover both the prune and no-prune paths. Score is 4 rather than 5 because the size-based truncation technique, while safe within current concurrency guarantees, would silently corrupt data if those guarantees were ever relaxed.
- No files require special attention

<sub>Last reviewed commit: a9f2343</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->