### PR TITLE
feat(infra): Adaptive SSH Environment Wrapper (ARE)

### DIFF
--- a/src/daemon/launchd.integration.test.ts
+++ b/src/daemon/launchd.integration.test.ts
@@ -1,0 +1,112 @@
+import { spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { PassThrough } from "node:stream";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  installLaunchAgent,
+  readLaunchAgentRuntime,
+  restartLaunchAgent,
+  resolveLaunchAgentPlistPath,
+  uninstallLaunchAgent,
+} from "./launchd.js";
+import type { GatewayServiceEnv } from "./service-types.js";
+
+const WAIT_INTERVAL_MS = 200;
+const WAIT_TIMEOUT_MS = 15_000;
+
+function canRunLaunchdIntegration(): boolean {
+  if (process.platform !== "darwin") {
+    return false;
+  }
+  if (typeof process.getuid !== "function") {
+    return false;
+  }
+  const domain = `gui/${process.getuid()}`;
+  const probe = spawnSync("launchctl", ["print", domain], { encoding: "utf8" });
+  if (probe.error) {
+    return false;
+  }
+  return probe.status === 0;
+}
+
+const describeLaunchdIntegration = canRunLaunchdIntegration() ? describe : describe.skip;
+
+async function waitForRunningRuntime(params: {
+  env: GatewayServiceEnv;
+  pidNot?: number;
+  timeoutMs?: number;
+}): Promise<{ pid: number }> {
+  const timeoutMs = params.timeoutMs ?? WAIT_TIMEOUT_MS;
+  const deadline = Date.now() + timeoutMs;
+  let lastStatus = "unknown";
+  let lastPid: number | undefined;
+  while (Date.now() < deadline) {
+    const runtime = await readLaunchAgentRuntime(params.env);
+    lastStatus = runtime.status ?? "unknown";
+    lastPid = runtime.pid;
+    if (
+      runtime.status === "running" &&
+      typeof runtime.pid === "number" &&
+      runtime.pid > 1 &&
+      (params.pidNot === undefined || runtime.pid !== params.pidNot)
+    ) {
+      return { pid: runtime.pid };
+    }
+    await new Promise((resolve) => {
+      setTimeout(resolve, WAIT_INTERVAL_MS);
+    });
+  }
+  throw new Error(
+    `Timed out waiting for launchd runtime (status=${lastStatus}, pid=${lastPid ?? "none"})`,
+  );
+}
+
+describeLaunchdIntegration("launchd integration", () => {
+  let env: GatewayServiceEnv | undefined;
+  let homeDir = "";
+  const stdout = new PassThrough();
+
+  beforeAll(async () => {
+    const testId = randomUUID().slice(0, 8);
+    homeDir = await fs.mkdtemp(path.join(os.tmpdir(), `openclaw-launchd-int-${testId}-`));
+    env = {
+      HOME: homeDir,
+      OPENCLAW_LAUNCHD_LABEL: `ai.openclaw.launchd-int-${testId}`,
+      OPENCLAW_LOG_PREFIX: `gateway-launchd-int-${testId}`,
+    };
+    await installLaunchAgent({
+      env,
+      stdout,
+      programArguments: [process.execPath, "-e", "setInterval(() => {}, 1000);"],
+    });
+    await waitForRunningRuntime({ env });
+  }, 30_000);
+
+  afterAll(async () => {
+    if (env) {
+      try {
+        await uninstallLaunchAgent({ env, stdout });
+      } catch {
+        // Best-effort cleanup in case launchctl state already changed.
+      }
+    }
+    if (homeDir) {
+      await fs.rm(homeDir, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  it("restarts launchd service and keeps it running with a new pid", async () => {
+    if (!env) {
+      throw new Error("launchd integration env was not initialized");
+    }
+    const before = await waitForRunningRuntime({ env });
+    await restartLaunchAgent({ env, stdout });
+    const after = await waitForRunningRuntime({ env, pidNot: before.pid });
+    expect(after.pid).toBeGreaterThan(1);
+    expect(after.pid).not.toBe(before.pid);
+    await fs.access(resolveLaunchAgentPlistPath(env));
+  }, 30_000);
+});

--- a/src/infra/adaptive-ssh.ts
+++ b/src/infra/adaptive-ssh.ts
@@ -3,20 +3,27 @@
  * Provides self-healing PATH and environment discovery for remote command execution.
  */
 
-export const ARE_PREAMBLE = `
-# Adaptive Remote Executor Preamble
-[ -f /etc/profile ] && . /etc/profile
-[ -f ~/.profile ] && . ~/.profile
-SEARCH_PATHS="/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin:$HOME/Library/pnpm:$HOME/.pnpm-global/bin:$HOME/.local/bin"
-if [ "$(uname -s)" = "Darwin" ]; then
-    PW_NODE=$(ls -d $HOME/Library/Caches/ms-playwright-go/*/node 2>/dev/null | head -n 1)
-    [ -n "$PW_NODE" ] && SEARCH_PATHS="$SEARCH_PATHS:$(dirname "$PW_NODE")"
-fi
-export PATH=$(echo "$SEARCH_PATHS:$PATH" | tr ':' '\\n' | awk '!x[$0]++' | tr '\\n' ':' | sed 's/:$//')
-`.trim();
+export const ARE_PREAMBLE = [
+  "# Adaptive Remote Executor Preamble",
+  '[ -f /etc/profile ] && . /etc/profile',
+  '[ -f ~/.profile ] && . ~/.profile',
+  'SEARCH_PATHS="/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin:$HOME/Library/pnpm:$HOME/.pnpm-global/bin:$HOME/.local/bin"',
+  'if [ "$(uname -s)" = "Darwin" ]; then',
+  '    PW_NODE=$(ls -d $HOME/Library/Caches/ms-playwright-go/*/node 2>/dev/null | head -n 1)',
+  '    [ -n "$PW_NODE" ] && SEARCH_PATHS="$SEARCH_PATHS:$(dirname "$PW_NODE")"',
+  "fi",
+  "export PATH=$(echo \"$SEARCH_PATHS:$PATH\" | tr ':' '\\n' | awk '!x[$0]++' | tr '\\n' ':' | sed 's/:$//')",
+].join("\n");
 
 /**
- * Wraps a shell command with the ARE preamble.
+ * Wraps a shell command with the ARE preamble so that common binary
+ * locations are available in the remote PATH.
+ *
+ * **Security note:** `command` is concatenated into a shell script without
+ * escaping. Callers MUST ensure the value is trusted (i.e. constructed
+ * internally, never from raw user input). This mirrors the existing
+ * `spawn("/usr/bin/ssh", ...)` pattern used elsewhere in the codebase
+ * where the command string is always built by OpenClaw itself.
  */
 export function wrapAdaptiveCommand(command: string): string {
   return `${ARE_PREAMBLE}\n${command}`;

--- a/src/infra/adaptive-ssh.ts
+++ b/src/infra/adaptive-ssh.ts
@@ -1,0 +1,23 @@
+/**
+ * Adaptive SSH Environment Wrapper
+ * Provides self-healing PATH and environment discovery for remote command execution.
+ */
+
+export const ARE_PREAMBLE = `
+# Adaptive Remote Executor Preamble
+[ -f /etc/profile ] && . /etc/profile
+[ -f ~/.profile ] && . ~/.profile
+SEARCH_PATHS="/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin:$HOME/Library/pnpm:$HOME/.pnpm-global/bin:$HOME/.local/bin"
+if [ "$(uname -s)" = "Darwin" ]; then
+    PW_NODE=$(ls -d $HOME/Library/Caches/ms-playwright-go/*/node 2>/dev/null | head -n 1)
+    [ -n "$PW_NODE" ] && SEARCH_PATHS="$SEARCH_PATHS:$(dirname "$PW_NODE")"
+fi
+export PATH=$(echo "$SEARCH_PATHS:$PATH" | tr ':' '\\n' | awk '!x[$0]++' | tr '\\n' ':' | sed 's/:$//')
+`.trim();
+
+/**
+ * Wraps a shell command with the ARE preamble.
+ */
+export function wrapAdaptiveCommand(command: string): string {
+  return `${ARE_PREAMBLE}\n${command}`;
+}

--- a/src/infra/adaptive-ssh.ts
+++ b/src/infra/adaptive-ssh.ts
@@ -5,11 +5,11 @@
 
 export const ARE_PREAMBLE = [
   "# Adaptive Remote Executor Preamble",
-  '[ -f /etc/profile ] && . /etc/profile',
-  '[ -f ~/.profile ] && . ~/.profile',
+  "[ -f /etc/profile ] && . /etc/profile",
+  "[ -f ~/.profile ] && . ~/.profile",
   'SEARCH_PATHS="/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin:$HOME/Library/pnpm:$HOME/.pnpm-global/bin:$HOME/.local/bin"',
   'if [ "$(uname -s)" = "Darwin" ]; then',
-  '    PW_NODE=$(ls -d $HOME/Library/Caches/ms-playwright-go/*/node 2>/dev/null | head -n 1)',
+  "    PW_NODE=$(ls -d $HOME/Library/Caches/ms-playwright-go/*/node 2>/dev/null | head -n 1)",
   '    [ -n "$PW_NODE" ] && SEARCH_PATHS="$SEARCH_PATHS:$(dirname "$PW_NODE")"',
   "fi",
   "export PATH=$(echo \"$SEARCH_PATHS:$PATH\" | tr ':' '\\n' | awk '!x[$0]++' | tr '\\n' ':' | sed 's/:$//')",


### PR DESCRIPTION
## Summary
Add an adaptive environment-probing wrapper for SSH-based remote command execution. This solves the common `command not found` (Exit 127) issues caused by incomplete non-interactive login shells.

## The Problem
When OpenClaw connects to remote nodes (e.g. macOS via Homebrew, custom Linux distros) via SSH, the non-interactive session often lacks a full `PATH`. Tools like `node`, `openclaw`, or `pnpm` are frequently missing from the environment, leading to failed task executions.

## Solution
Inject a lightweight shell preamble into SSH commands:
1. Safely loads `/etc/profile` and `~/.profile` (avoids zsh-specific configs that break under `sh`)
2. Probes common binary locations (`/opt/homebrew`, `Library/pnpm`, `~/.local/bin`, etc.)
3. Handles macOS-specific paths (Playwright cache, Homebrew)
4. Deduplicates PATH entries
5. Exports `wrapAdaptiveCommand()` API for wrapping any shell command

## Testing
Tested on:
- **macOS (Darwin)**: Successfully discovered `node` at `/opt/homebrew/bin/node` and `openclaw` at `/usr/local/bin/openclaw`
- **Linux (arm64)**: Verified profile loading and PATH construction

## Files Changed
- `src/infra/adaptive-ssh.ts` (new file)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a lightweight shell preamble wrapper for SSH remote commands to solve `command not found` errors in non-interactive SSH sessions. The implementation loads standard profile files and probes common binary locations (Homebrew, pnpm, Playwright cache) to construct a complete PATH, then deduplicates entries using shell commands.

**Changes made:**
- New `src/infra/adaptive-ssh.ts` file with `ARE_PREAMBLE` constant and `wrapAdaptiveCommand()` export
- Addresses previous review feedback by switching from template literal to array-based string construction to clarify escaping behavior
- Added comprehensive security documentation in JSDoc warning about shell injection risks

**Key implementation details:**
- Uses array `.join("\n")` approach instead of template literals for clearer escape sequence handling
- PATH deduplication using `tr`, `awk`, and `sed` pipeline
- macOS-specific Playwright binary discovery with `ls -d` and fallback handling
- Safe profile loading that avoids zsh-specific configs under `sh`

The code is not yet integrated anywhere in the codebase - this appears to be preparatory infrastructure for future SSH remote execution features.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk - it introduces new infrastructure code that is not yet integrated
- The code properly addresses previous review feedback regarding escaping and security documentation. The shell pipeline logic is sound, and the security risks are well-documented. Score is 4 rather than 5 because: (1) the code has no tests or integration points to validate behavior, (2) it's unclear how callers will ensure command sanitization despite the JSDoc warning, and (3) there's no validation that the generated shell script actually works across target environments
- No files require special attention - this is a small, isolated infrastructure addition

<sub>Last reviewed commit: 5482c85</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->