### PR TITLE
fix: route /compact through retry wrapper

### DIFF
--- a/src/agents/compaction.retry.test.ts
+++ b/src/agents/compaction.retry.test.ts
@@ -1,0 +1,182 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import * as piCodingAgent from "@mariozechner/pi-coding-agent";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { retryAsync } from "../infra/retry.js";
+
+// Mock the external generateSummary function
+vi.mock("@mariozechner/pi-coding-agent", async (importOriginal) => {
+  const actual = await importOriginal<typeof piCodingAgent>();
+  return {
+    ...actual,
+    generateSummary: vi.fn(),
+  };
+});
+
+const mockGenerateSummary = vi.mocked(piCodingAgent.generateSummary);
+
+describe("compaction retry integration", () => {
+  beforeEach(() => {
+    mockGenerateSummary.mockClear();
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+  const testMessages: AgentMessage[] = [
+    { role: "user", content: "Test message" },
+    { role: "assistant", content: "Test response" },
+  ];
+
+  const testModel: NonNullable<ExtensionContext["model"]> = {
+    provider: "anthropic",
+    model: "claude-3-opus",
+  };
+
+  it("should successfully call generateSummary with retry wrapper", async () => {
+    mockGenerateSummary.mockResolvedValueOnce("Test summary");
+
+    const result = await retryAsync(
+      () =>
+        mockGenerateSummary(
+          testMessages,
+          testModel,
+          1000,
+          "test-api-key",
+          new AbortController().signal,
+        ),
+      {
+        attempts: 3,
+        minDelayMs: 500,
+        maxDelayMs: 5000,
+        jitter: 0.2,
+        label: "compaction/generateSummary",
+      },
+    );
+
+    expect(result).toBe("Test summary");
+    expect(mockGenerateSummary).toHaveBeenCalledTimes(1);
+  });
+
+  it("should retry on transient error and succeed", async () => {
+    mockGenerateSummary
+      .mockRejectedValueOnce(new Error("Network timeout"))
+      .mockResolvedValueOnce("Success after retry");
+
+    const result = await retryAsync(
+      () =>
+        mockGenerateSummary(
+          testMessages,
+          testModel,
+          1000,
+          "test-api-key",
+          new AbortController().signal,
+        ),
+      {
+        attempts: 3,
+        minDelayMs: 0,
+        maxDelayMs: 0,
+        label: "compaction/generateSummary",
+      },
+    );
+
+    expect(result).toBe("Success after retry");
+    expect(mockGenerateSummary).toHaveBeenCalledTimes(2);
+  });
+
+  it("should NOT retry on user abort", async () => {
+    const abortErr = new Error("aborted");
+    abortErr.name = "AbortError";
+    (abortErr as { cause?: unknown }).cause = { source: "user" };
+
+    mockGenerateSummary.mockRejectedValueOnce(abortErr);
+
+    await expect(
+      retryAsync(
+        () =>
+          mockGenerateSummary(
+            testMessages,
+            testModel,
+            1000,
+            "test-api-key",
+            new AbortController().signal,
+          ),
+        {
+          attempts: 3,
+          minDelayMs: 0,
+          label: "compaction/generateSummary",
+          shouldRetry: (err: unknown) => !(err instanceof Error && err.name === "AbortError"),
+        },
+      ),
+    ).rejects.toThrow("aborted");
+
+    // Should NOT retry on user cancellation (AbortError filtered by shouldRetry)
+    expect(mockGenerateSummary).toHaveBeenCalledTimes(1);
+  });
+
+  it("should retry up to 3 times and then fail", async () => {
+    mockGenerateSummary.mockRejectedValue(new Error("Persistent API error"));
+
+    await expect(
+      retryAsync(
+        () =>
+          mockGenerateSummary(
+            testMessages,
+            testModel,
+            1000,
+            "test-api-key",
+            new AbortController().signal,
+          ),
+        {
+          attempts: 3,
+          minDelayMs: 0,
+          maxDelayMs: 0,
+          label: "compaction/generateSummary",
+        },
+      ),
+    ).rejects.toThrow("Persistent API error");
+
+    expect(mockGenerateSummary).toHaveBeenCalledTimes(3);
+  });
+
+  it("should apply exponential backoff", async () => {
+    vi.useFakeTimers();
+
+    mockGenerateSummary
+      .mockRejectedValueOnce(new Error("Error 1"))
+      .mockRejectedValueOnce(new Error("Error 2"))
+      .mockResolvedValueOnce("Success on 3rd attempt");
+
+    const delays: number[] = [];
+    const promise = retryAsync(
+      () =>
+        mockGenerateSummary(
+          testMessages,
+          testModel,
+          1000,
+          "test-api-key",
+          new AbortController().signal,
+        ),
+      {
+        attempts: 3,
+        minDelayMs: 500,
+        maxDelayMs: 5000,
+        jitter: 0,
+        label: "compaction/generateSummary",
+        onRetry: (info) => delays.push(info.delayMs),
+      },
+    );
+
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toBe("Success on 3rd attempt");
+    expect(mockGenerateSummary).toHaveBeenCalledTimes(3);
+    // First retry: 500ms, second retry: 1000ms
+    expect(delays[0]).toBe(500);
+    expect(delays[1]).toBe(1000);
+
+    vi.useRealTimers();
+  });
+});


### PR DESCRIPTION
`/compact` currently bypasses the standard retry wrapper used by other user-facing LLM operations.
This wires `/compact` through the existing `retryAsync` path (no fallback changes), so transient failures
are handled consistently and we avoid a single-point "zero fault tolerance" path.

## Scope
- Minimal wiring only (no behavior changes outside retry handling)
- No new dependencies
- `shouldRetry` callback skips `AbortError` (user cancellation) — no retry on intentional abort
- Tests included for retry wrapper integration and non-retryable errors

## Test plan
- [x] `npx vitest run src/agents/compaction.retry.test.ts` — 5/5 passed
- [x] `npx vitest run src/agents/` — 254/254 passed (no regression)
- [x] `npx oxfmt --check` — clean

Related: #14543

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Wraps `/compact` command's `generateSummary` calls through the existing `retryAsync` wrapper to handle transient failures consistently with other LLM operations. The change adds retry logic with exponential backoff (3 attempts, 500-5000ms delays) and properly skips retries on `AbortError` to respect user cancellations.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - minimal, well-tested change that improves resilience
- The change is minimal and focused, wrapping a single call path with existing retry infrastructure. Tests comprehensively cover success, retry, abort handling, and backoff behavior. The retry config matches patterns used elsewhere in the codebase (telegram, discord). The `shouldRetry` callback correctly filters `AbortError` to prevent retrying user cancellations, consistent with how other parts of the codebase handle aborts.
- No files require special attention

<sub>Last reviewed commit: 3fd58cb</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->