### PR TITLE
fix(infra): avoid detached finally unhandled rejection in fetch wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Docs: https://docs.openclaw.ai
 - Skills/Security: restrict `download` installer `targetDir` to the per-skill tools directory to prevent arbitrary file writes. Thanks @Adam55A-code.
 - Skills/Linux: harden go installer fallback on apt-based systems by handling root/no-sudo environments safely, doing best-effort apt index refresh, and returning actionable errors instead of failing with spawn errors. (#17687) Thanks @mcrolly.
 - Web Fetch/Security: cap downloaded response body size before HTML parsing to prevent memory exhaustion from oversized or deeply nested pages. Thanks @xuemian168.
+- Infra/Fetch: ensure foreign abort-signal listener cleanup never masks original fetch successes/failures, while still preventing detached-finally unhandled rejection noise in `wrapFetchWithAbortSignal`. Thanks @Jackten.
 - Config/Gateway: make sensitive-key whitelist suffix matching case-insensitive while preserving `passwordFile` path exemptions, preventing accidental redaction of non-secret config values like `maxTokens` and IRC password-file paths. (#16042) Thanks @akramcodez.
 - Gateway/Config: prevent `config.patch` from falling back to full-array replacement when an object-array patch includes entries without `id`, so partial `agents.list` updates no longer risk deleting unrelated agents. (#17989) Thanks @stakeswky.
 - Dev tooling: harden git `pre-commit` hook against option injection from malicious filenames (for example `--force`), preventing accidental staging of ignored files. Thanks @mrthankyou.


### PR DESCRIPTION
AI-assisted: This PR was implemented with Codex assistance. I reviewed and verified the code changes and test behavior manually.

## Summary

- Problem: `wrapFetchWithAbortSignal` used a detached cleanup chain (`void response.finally(...)`) in `src/infra/fetch.ts`.
- Why it matters: if fetch rejects, the detached `.finally()` chain can emit extra unhandled-rejection noise even when the original rejection is handled.
- What changed:
  - Reworked cleanup to be attached to the returned chain: `return response.finally(cleanup)`.
  - Added `try/catch` so cleanup also runs when `fetchImpl` throws synchronously.
  - Added regression tests for async reject and sync throw cleanup behavior.
- What did NOT change (scope boundary):
  - No API/config/type changes.
  - No changes to unhandled-rejection classification policy.
  - No broader network resiliency refactor.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #6067
- Related #7195

## User-visible / Behavior Changes

None (internal reliability hardening only).

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  - N/A

## Repro + Verification

### Environment

- OS: Ubuntu 25.10
- Runtime/container: Node + pnpm workspace (repo local)
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Wrap a rejecting `fetchImpl` with `wrapFetchWithAbortSignal`.
2. Handle the returned rejection in caller code.
3. Observe whether wrapper internals emit an additional unhandled rejection.

### Expected

- Caller receives the rejection.
- No extra unhandled rejection emitted from wrapper cleanup internals.
- Abort listener cleanup still occurs.

### Actual

- With this patch, expected behavior is met.
- Added regression tests now enforce this.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Test runs:
- `pnpm vitest src/infra/fetch.test.ts`
- `pnpm vitest src/infra/unhandled-rejections.test.ts src/infra/unhandled-rejections.fatal-detection.test.ts`
- `pnpm exec oxfmt --check src/infra/fetch.ts src/infra/fetch.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Async fetch rejection path preserves caller rejection and avoids extra unhandled-rejection noise.
  - Sync throw path still cleans up listener and rethrows.
- Edge cases checked:
  - Existing foreign-signal conversion and duplex tests still pass.
- What you did **not** verify:
  - Full repo-wide `pnpm check` / `pnpm test` in this working tree due unrelated pre-existing formatting changes outside this PR scope.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:
  - N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this commit.
- Files/config to restore:
  - `src/infra/fetch.ts`
  - `src/infra/fetch.test.ts`
- Known bad symptoms reviewers should watch for:
  - Unexpected changes in fetch rejection propagation.
  - Missing abort-listener cleanup in reject/throw paths.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Returning `response.finally(cleanup)` returns a chained promise object instead of the original promise reference.
  - Mitigation:
    - Resolved/rejected outcome is preserved; regression tests cover reject/throw behavior and listener cleanup.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed unhandled rejection noise from `wrapFetchWithAbortSignal` by attaching cleanup to the returned promise chain (`response.finally(cleanup)`) instead of using a detached void chain. Added `try/catch` to handle synchronous throws. Two regression tests added to verify cleanup occurs correctly in both async rejection and sync throw paths.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - well-tested internal reliability fix
- The change correctly addresses the detached promise issue by attaching cleanup to the returned chain. Both async rejection and sync throw paths are covered by comprehensive tests that verify cleanup occurs and no unhandled rejections leak. The logic is sound: `finally()` runs cleanup regardless of resolution or rejection, and the `try/catch` ensures sync throws also clean up. No API changes or behavioral regressions for callers.
- No files require special attention

<sub>Last reviewed commit: deebf3e</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->