### PR TITLE
fix: handle forum/topics in Telegram DM thread routing

### DIFF
--- a/src/telegram/bot/helpers.test.ts
+++ b/src/telegram/bot/helpers.test.ts
@@ -5,6 +5,7 @@ import {
   expandTextLinks,
   normalizeForwardedContext,
   resolveTelegramForumThreadId,
+  resolveTelegramThreadSpec,
 } from "./helpers.js";
 
 describe("resolveTelegramForumThreadId", () => {
@@ -29,6 +30,34 @@ describe("resolveTelegramForumThreadId", () => {
 
   it("returns the topic id for forum groups with messageThreadId", () => {
     expect(resolveTelegramForumThreadId({ isForum: true, messageThreadId: 99 })).toBe(99);
+  });
+});
+
+describe("resolveTelegramThreadSpec", () => {
+  it("returns dm scope for plain DM (no forum, no thread id)", () => {
+    expect(resolveTelegramThreadSpec({ isGroup: false })).toEqual({ scope: "dm" });
+  });
+
+  it("preserves thread id with dm scope when DM has thread id but is not a forum", () => {
+    expect(
+      resolveTelegramThreadSpec({ isGroup: false, isForum: false, messageThreadId: 42 }),
+    ).toEqual({ id: 42, scope: "dm" });
+  });
+
+  it("returns forum scope when DM has isForum and thread id", () => {
+    expect(
+      resolveTelegramThreadSpec({ isGroup: false, isForum: true, messageThreadId: 99 }),
+    ).toEqual({ id: 99, scope: "forum" });
+  });
+
+  it("falls back to dm scope when DM has isForum but no thread id", () => {
+    expect(resolveTelegramThreadSpec({ isGroup: false, isForum: true })).toEqual({ scope: "dm" });
+  });
+
+  it("delegates to group path for groups", () => {
+    expect(
+      resolveTelegramThreadSpec({ isGroup: true, isForum: true, messageThreadId: 50 }),
+    ).toEqual({ id: 50, scope: "forum" });
   });
 });
 

--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -101,13 +101,15 @@ export function resolveTelegramThreadSpec(params: {
       scope: params.isForum ? "forum" : "none",
     };
   }
-  if (params.messageThreadId == null) {
-    return { scope: "dm" };
+  // DM with forum/topics enabled — treat like a forum, not a flat DM
+  if (params.isForum && params.messageThreadId != null) {
+    return { id: params.messageThreadId, scope: "forum" };
   }
-  return {
-    id: params.messageThreadId,
-    scope: "dm",
-  };
+  // Preserve thread ID for non-forum DM threads (session routing, #8891)
+  if (params.messageThreadId != null) {
+    return { id: params.messageThreadId, scope: "dm" };
+  }
+  return { scope: "dm" };
 }
 
 /**


### PR DESCRIPTION
Fixes #17980

## Problem

`resolveTelegramThreadSpec` did not check `isForum` in the non-group (DM) path. When a Telegram DM chat has forum/topics enabled (e.g. Saved Messages, business accounts), messages arrive with `is_forum: true` and a `message_thread_id`, but the function returned `scope: "dm"` — causing all topics to collapse into a single flat session.

## Fix

Added an `isForum` check in the DM path of `resolveTelegramThreadSpec`:

- **DM + `isForum` + `messageThreadId`** → returns `{ id, scope: "forum" }` so each topic gets its own session and `buildTelegramThreadParams` includes `message_thread_id` in API calls.
- **DM + `messageThreadId` (no forum)** → unchanged behavior, returns `{ id, scope: "dm" }` preserving thread session routing (#8891).
- **Plain DM** → unchanged, returns `{ scope: "dm" }`.

## Tests

Added 5 new test cases for `resolveTelegramThreadSpec` covering all DM/group/forum combinations. All existing tests (39 total across 3 related test files) pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed `resolveTelegramThreadSpec` to properly handle DM chats with forum/topics enabled (e.g., Saved Messages, business accounts). The function now checks `isForum` in the DM path and returns `scope: "forum"` when both `isForum` and `messageThreadId` are present, ensuring each topic gets its own session. This prevents all topics from collapsing into a single flat DM session while preserving existing thread session routing behavior for non-forum DM threads (issue #8891).

Key changes:
- Added `isForum` check in DM path before evaluating `messageThreadId`
- DM + `isForum` + `messageThreadId` → returns `{ id, scope: "forum" }`
- DM + `messageThreadId` (no forum) → unchanged, returns `{ id, scope: "dm" }`
- Plain DM → unchanged, returns `{ scope: "dm" }`
- Added comprehensive test coverage with 5 new test cases covering all DM/forum/thread combinations

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is narrowly scoped, well-tested, and logically sound. It adds a single `isForum` check to correctly route DM forum topics while preserving all existing behaviors. The 5 new tests comprehensively cover all DM/group/forum/thread combinations, and the change aligns perfectly with how `buildTelegramThreadParams` already handles the `forum` vs `dm` scope distinction. The logic correctly prioritizes the forum check before the non-forum thread check, preventing forum topics from incorrectly falling through to the DM thread path.
- No files require special attention

<sub>Last reviewed commit: 405f507</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->