### PR TITLE
fix(slack): honour replyToMode off for typing indicator

### DIFF
--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -10,7 +10,7 @@ import { createTypingCallbacks } from "../../../channels/typing.js";
 import { resolveStorePath, updateLastRoute } from "../../../config/sessions.js";
 import { danger, logVerbose, shouldLogVerbose } from "../../../globals.js";
 import { removeSlackReaction } from "../../actions.js";
-import { resolveSlackThreadContext, resolveSlackThreadTargets } from "../../threading.js";
+import { resolveSlackThreadTargets } from "../../threading.js";
 import { createSlackReplyDeliveryPlan, deliverReplies } from "../replies.js";
 
 export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessage) {
@@ -35,11 +35,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     });
   }
 
-  const { statusThreadTs } = resolveSlackThreadTargets({
-    message,
-    replyToMode: ctx.replyToMode,
-  });
-  const { isThreadReply } = resolveSlackThreadContext({
+  const { statusThreadTs, isThreadReply } = resolveSlackThreadTargets({
     message,
     replyToMode: ctx.replyToMode,
   });

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -10,7 +10,7 @@ import { createTypingCallbacks } from "../../../channels/typing.js";
 import { resolveStorePath, updateLastRoute } from "../../../config/sessions.js";
 import { danger, logVerbose, shouldLogVerbose } from "../../../globals.js";
 import { removeSlackReaction } from "../../actions.js";
-import { resolveSlackThreadTargets } from "../../threading.js";
+import { resolveSlackThreadContext, resolveSlackThreadTargets } from "../../threading.js";
 import { createSlackReplyDeliveryPlan, deliverReplies } from "../replies.js";
 
 export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessage) {
@@ -39,6 +39,10 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     message,
     replyToMode: ctx.replyToMode,
   });
+  const { isThreadReply } = resolveSlackThreadContext({
+    message,
+    replyToMode: ctx.replyToMode,
+  });
 
   const messageTs = message.ts ?? message.event_ts;
   const incomingThreadTs = message.thread_ts;
@@ -52,6 +56,8 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     incomingThreadTs,
     messageTs,
     hasRepliedRef,
+    chatType: prepared.isDirectMessage ? "direct" : "channel",
+    isThreadReply,
   });
 
   const typingTarget = statusThreadTs ? `${message.channel}/${statusThreadTs}` : message.channel;

--- a/src/slack/monitor/replies.ts
+++ b/src/slack/monitor/replies.ts
@@ -88,10 +88,19 @@ function createSlackReplyReferencePlanner(params: {
   incomingThreadTs: string | undefined;
   messageTs: string | undefined;
   hasReplied?: boolean;
+  chatType?: "direct" | "channel" | "group";
+  isThreadReply?: boolean;
 }) {
-  // When already inside a Slack thread, always stay in it regardless of
-  // replyToMode — thread_ts is required to keep messages in the thread.
-  const effectiveMode = params.incomingThreadTs ? "all" : params.replyToMode;
+  // When already inside a Slack thread, stay in it — but for DMs where the
+  // "thread" was created by the typing indicator (not a real thread reply),
+  // respect the user's replyToMode setting.
+  // See: https://github.com/openclaw/openclaw/issues/16868
+  const effectiveMode =
+    params.chatType === "direct" && !params.isThreadReply
+      ? params.replyToMode
+      : params.incomingThreadTs
+        ? "all"
+        : params.replyToMode;
   return createReplyReferencePlanner({
     replyToMode: effectiveMode,
     existingId: params.incomingThreadTs,
@@ -105,12 +114,16 @@ export function createSlackReplyDeliveryPlan(params: {
   incomingThreadTs: string | undefined;
   messageTs: string | undefined;
   hasRepliedRef: { value: boolean };
+  chatType?: "direct" | "channel" | "group";
+  isThreadReply?: boolean;
 }): SlackReplyDeliveryPlan {
   const replyReference = createSlackReplyReferencePlanner({
     replyToMode: params.replyToMode,
     incomingThreadTs: params.incomingThreadTs,
     messageTs: params.messageTs,
     hasReplied: params.hasRepliedRef.value,
+    chatType: params.chatType,
+    isThreadReply: params.isThreadReply,
   });
   return {
     nextThreadTs: () => replyReference.use(),

--- a/src/slack/threading.ts
+++ b/src/slack/threading.ts
@@ -38,8 +38,9 @@ export function resolveSlackThreadTargets(params: {
   message: SlackMessageEvent | SlackAppMentionEvent;
   replyToMode: ReplyToMode;
 }) {
-  const { incomingThreadTs, messageTs } = resolveSlackThreadContext(params);
+  const ctx = resolveSlackThreadContext(params);
+  const { incomingThreadTs, messageTs, isThreadReply } = ctx;
   const replyThreadTs = incomingThreadTs ?? (params.replyToMode === "all" ? messageTs : undefined);
   const statusThreadTs = replyThreadTs ?? messageTs;
-  return { replyThreadTs, statusThreadTs };
+  return { replyThreadTs, statusThreadTs, isThreadReply };
 }

--- a/src/slack/threading.ts
+++ b/src/slack/threading.ts
@@ -34,6 +34,14 @@ export function resolveSlackThreadContext(params: {
   };
 }
 
+/**
+ * Resolves Slack thread targeting for replies and status indicators.
+ *
+ * @returns replyThreadTs - Thread timestamp for reply messages
+ * @returns statusThreadTs - Thread timestamp for status indicators (typing, etc.)
+ * @returns isThreadReply - true if this is a genuine user reply in a thread,
+ *                          false if thread_ts comes from a bot status message (e.g. typing indicator)
+ */
 export function resolveSlackThreadTargets(params: {
   message: SlackMessageEvent | SlackAppMentionEvent;
   replyToMode: ReplyToMode;


### PR DESCRIPTION
## Summary

When `replyToMode` is `"off"` in DMs, replies should stay in the main conversation even when the typing indicator creates a thread context.

## Problem

Previously, when `incomingThreadTs` was set (from the typing indicator's thread), `replyToMode` was forced to `"all"`, causing all replies to go into the thread. This created an unexpected UX where:

1. Typing indicator shows in a thread (expected Slack behavior)
2. First reply goes to main channel (respects `replyToMode: off`)
3. User replies → now has `incomingThreadTs` set
4. Subsequent bot replies forced into thread (ignores `replyToMode: off`)

## Solution

For **direct messages**, always respect the user's configured `replyToMode`. For **channels/groups**, preserve existing behavior (stay in thread if already in one).

```typescript
// Before
const effectiveMode = params.incomingThreadTs ? "all" : params.replyToMode;

// After
const effectiveMode =
  params.chatType === "direct"
    ? params.replyToMode  // DMs: always respect user config
    : params.incomingThreadTs
      ? "all"           // Channels: stay in thread
      : params.replyToMode;
```

## Changes

- `src/slack/monitor/replies.ts`: Add `chatType` param, respect `replyToMode` in DMs
- `src/slack/monitor/message-handler/dispatch.ts`: Pass `chatType` to reply planner

## Testing

- [x] Unit tests pass
- [x] Manually verified in Slack DM:
  - ✅ Typing indicator shows
  - ✅ Replies stay in main conversation (no thread)

Fixes #16868

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where Slack DM replies were incorrectly forced into threads when `replyToMode` was set to `"off"`. The typing indicator's status message creates a thread context (`thread_ts`), and previously this caused all subsequent replies to be threaded regardless of user configuration. The fix adds `chatType` and `isThreadReply` parameters to the reply planning logic, so that in DMs where the thread context comes from the typing indicator (not a real user thread reply), the configured `replyToMode` is respected.

- `src/slack/monitor/replies.ts`: Extended `createSlackReplyReferencePlanner` and `createSlackReplyDeliveryPlan` with optional `chatType` and `isThreadReply` params. The `effectiveMode` logic now bypasses thread-sticking for DMs when `isThreadReply` is false.
- `src/slack/monitor/message-handler/dispatch.ts`: Added a call to `resolveSlackThreadContext` to obtain `isThreadReply`, and passes both `chatType` and `isThreadReply` to the reply delivery plan.
- No test changes were included in this PR. The new DM-specific behavior paths (`chatType: "direct"` with/without `isThreadReply`) are not covered by unit tests.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — the logic change is narrowly scoped to DMs and the fallback preserves existing channel behavior.
- The change is well-targeted: the new conditional only activates for DMs (`chatType === "direct"`) with no real thread reply (`!isThreadReply`), and all other code paths remain identical. Default parameter values ensure backward compatibility for existing callers like `resolveSlackThreadTs`. The only concern is the absence of unit tests for the new DM-specific behavior paths, though the author reports manual verification.
- No files require special attention — both files have small, well-scoped changes.

<sub>Last reviewed commit: 6d2a7d8</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->