### PR TITLE
fix(discord): route audioAsVoice payloads through voice message API

### DIFF
--- a/src/discord/monitor/reply-delivery.ts
+++ b/src/discord/monitor/reply-delivery.ts
@@ -5,7 +5,7 @@ import type { MarkdownTableMode } from "../../config/types.base.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { convertMarkdownTables } from "../../markdown/tables.js";
 import { chunkDiscordTextWithMode } from "../chunk.js";
-import { sendMessageDiscord } from "../send.js";
+import { sendMessageDiscord, sendVoiceMessageDiscord } from "../send.js";
 
 export async function deliverDiscordReply(params: {
   replies: ReplyPayload[];
@@ -62,6 +62,35 @@ export async function deliverDiscordReply(params: {
     if (!firstMedia) {
       continue;
     }
+
+    // Voice message path: audioAsVoice flag routes through sendVoiceMessageDiscord
+    if (payload.audioAsVoice) {
+      await sendVoiceMessageDiscord(params.target, firstMedia, {
+        token: params.token,
+        rest: params.rest,
+        accountId: params.accountId,
+        replyTo,
+      });
+      // Voice messages cannot include text; send remaining text separately if present
+      if (text.trim()) {
+        await sendMessageDiscord(params.target, text, {
+          token: params.token,
+          rest: params.rest,
+          accountId: params.accountId,
+        });
+      }
+      // Additional media items are sent as regular attachments (voice is single-file only)
+      for (const extra of mediaList.slice(1)) {
+        await sendMessageDiscord(params.target, "", {
+          token: params.token,
+          rest: params.rest,
+          mediaUrl: extra,
+          accountId: params.accountId,
+        });
+      }
+      continue;
+    }
+
     await sendMessageDiscord(params.target, text, {
       token: params.token,
       rest: params.rest,


### PR DESCRIPTION
## Summary
`deliverDiscordReply` now checks `payload.audioAsVoice` and routes through `sendVoiceMessageDiscord` instead of `sendMessageDiscord` when true.

## Changes
- Import `sendVoiceMessageDiscord` in reply-delivery.ts
- Add branch in media handling to check `audioAsVoice` flag
- Voice messages send text separately (Discord voice messages can't include text)
- Additional media items still sent as regular attachments

## Testing
- Verified import resolves correctly (tsc --noEmit passes)
- Logic mirrors existing Telegram implementation (delivery.ts:203)

Fixes #17990

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Routes Discord audio messages with `audioAsVoice` flag through `sendVoiceMessageDiscord` API instead of regular attachments. Voice messages are sent first with the `replyTo` parameter, then text is sent separately (Discord voice messages cannot include text), followed by any additional media as regular attachments. This matches the existing Telegram implementation pattern in `src/telegram/bot/delivery.ts:203`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation follows established patterns from the Telegram voice message implementation, properly handles the separation of voice/text/media, and uses existing well-tested APIs. The change is focused and addresses a specific feature request without modifying core logic.
- No files require special attention

<sub>Last reviewed commit: c50a1c1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->