### PR TITLE
fix(discord): strip user:/discord:/pk: prefixes in command allowFrom

### DIFF
--- a/src/channels/dock.ts
+++ b/src/channels/dock.ts
@@ -218,7 +218,17 @@ const DOCKS: Record<ChatChannelId, ChannelDock> = {
           String(entry),
         );
       },
-      formatAllowFrom: ({ allowFrom }) => formatLower(allowFrom),
+      formatAllowFrom: ({ allowFrom }) =>
+        allowFrom
+          .map((entry) => String(entry).trim())
+          .filter(Boolean)
+          .map((entry) =>
+            entry
+              .replace(/^discord:/i, "")
+              .replace(/^user:/i, "")
+              .replace(/^pk:/i, "")
+              .toLowerCase(),
+          ),
     },
     groups: {
       resolveRequireMention: resolveDiscordGroupRequireMention,


### PR DESCRIPTION
## Summary
Discord's `formatAllowFrom` now strips `user:`, `discord:`, and `pk:` prefixes before matching, aligning with `normalizeDiscordAllowList` behavior used in DM admission.

## Problem
`commands.allowFrom` with prefixed IDs (e.g. `"user:123"`) silently failed on Discord because:
- `formatAllowFrom` only did `trim() + toLowerCase()`
- `senderCandidates` produces `["123", "discord:123"]`
- `"user:123"" never matched

## Fix
Strip the same prefixes that `normalizeDiscordAllowList` strips:
- `discord:`
- `user:`
- `pk:`

## Before/After
```
Before: commands.allowFrom: ["user:123"] → no match
After:  commands.allowFrom: ["user:123"] → "123" → matches
```

Fixes #17937

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces the Discord `formatAllowFrom` implementation (previously a plain `formatLower` call that only trimmed and lowercased entries) with prefix-stripping logic that removes `discord:`, `user:`, and `pk:` prefixes before lowercasing. This aligns the command authorization path (`commands.allowFrom`) with the existing `normalizeDiscordAllowList` function used for DM admission, which already strips these same prefixes. Without this fix, prefixed IDs like `"user:123"` in `commands.allowFrom` could never match sender candidates (which are bare IDs like `"123"` or `"discord:123"` after normalization), silently denying command access.

- Fixes prefix mismatch between `formatAllowFrom` and `normalizeDiscordAllowList` for Discord command authorization
- Consistent with how other channels (IRC, Google Chat, Telegram) handle prefix stripping in their `formatAllowFrom` implementations
- No test added for this specific behavior

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a small, focused bug fix that aligns Discord's formatAllowFrom with existing normalization behavior.
- The change is minimal (one function body replacement), follows established patterns used by other channels in the same file (IRC, Google Chat), and aligns with the existing normalizeDiscordAllowList function that already strips these same prefixes. The logic is straightforward regex replacement with no edge cases or risk of regression.
- No files require special attention.

<sub>Last reviewed commit: d7d5ca1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->