### PR TITLE
fix(subagent): route nested announce to parent even when parent run ended

### DIFF
--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -822,4 +822,102 @@ describe("subagent announce formatting", () => {
     expect(call?.params?.channel).toBe("bluebubbles");
     expect(call?.params?.to).toBe("bluebubbles:chat_guid:123");
   });
+
+  it("routes to parent subagent when parent run ended but session still exists (#18037)", async () => {
+    // Scenario: Newton (depth-1) spawns Birdie (depth-2). Newton's agent turn ends
+    // after spawning but Newton's SESSION still exists (waiting for Birdie's result).
+    // Birdie completes → Birdie's announce should go to Newton, NOT to Jaris (depth-0).
+    const { runSubagentAnnounceFlow } = await import("./subagent-announce.js");
+    embeddedRunMock.isEmbeddedPiRunActive.mockReturnValue(false);
+    embeddedRunMock.isEmbeddedPiRunStreaming.mockReturnValue(false);
+
+    // Parent's run has ended (no active run)
+    subagentRegistryMock.isSubagentSessionRunActive.mockReturnValue(false);
+    // BUT parent session still exists in the store
+    sessionStore = {
+      "agent:main:subagent:newton": {
+        sessionId: "newton-session-id-alive",
+        inputTokens: 100,
+        outputTokens: 50,
+      },
+      "agent:main:subagent:newton:subagent:birdie": {
+        sessionId: "birdie-session-id",
+        inputTokens: 20,
+        outputTokens: 10,
+      },
+    };
+    // Fallback would be available to Jaris (grandparent)
+    subagentRegistryMock.resolveRequesterForChildSession.mockReturnValue({
+      requesterSessionKey: "agent:main:main",
+      requesterOrigin: { channel: "discord" },
+    });
+
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:newton:subagent:birdie",
+      childRunId: "run-birdie",
+      requesterSessionKey: "agent:main:subagent:newton",
+      requesterDisplayKey: "subagent:newton",
+      task: "QA the outline",
+      timeoutMs: 1000,
+      cleanup: "keep",
+      waitForCompletion: false,
+      startedAt: 10,
+      endedAt: 20,
+      outcome: { status: "ok" },
+    });
+
+    expect(didAnnounce).toBe(true);
+    // Verify announce went to Newton (the parent), NOT to Jaris (grandparent fallback)
+    const call = agentSpy.mock.calls[0]?.[0] as { params?: Record<string, unknown> };
+    expect(call?.params?.sessionKey).toBe("agent:main:subagent:newton");
+    // deliver=false because Newton is a subagent (internal injection)
+    expect(call?.params?.deliver).toBe(false);
+    // Should NOT have used the grandparent fallback
+    expect(call?.params?.sessionKey).not.toBe("agent:main:main");
+  });
+
+  it("falls back to grandparent only when parent session is deleted (#18037)", async () => {
+    // Scenario: Parent session was cleaned up. Only then should we fallback.
+    const { runSubagentAnnounceFlow } = await import("./subagent-announce.js");
+    embeddedRunMock.isEmbeddedPiRunActive.mockReturnValue(false);
+    embeddedRunMock.isEmbeddedPiRunStreaming.mockReturnValue(false);
+
+    // Parent's run ended AND session is gone
+    subagentRegistryMock.isSubagentSessionRunActive.mockReturnValue(false);
+    // Parent session does NOT exist (was deleted)
+    sessionStore = {
+      "agent:main:subagent:birdie": {
+        sessionId: "birdie-session-id",
+        inputTokens: 20,
+        outputTokens: 10,
+      },
+      // Newton's entry is MISSING (session was deleted)
+    };
+    subagentRegistryMock.resolveRequesterForChildSession.mockReturnValue({
+      requesterSessionKey: "agent:main:main",
+      requesterOrigin: { channel: "discord", accountId: "jaris-account" },
+    });
+
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:birdie",
+      childRunId: "run-birdie-orphan",
+      requesterSessionKey: "agent:main:subagent:newton",
+      requesterDisplayKey: "subagent:newton",
+      task: "QA task",
+      timeoutMs: 1000,
+      cleanup: "keep",
+      waitForCompletion: false,
+      startedAt: 10,
+      endedAt: 20,
+      outcome: { status: "ok" },
+    });
+
+    expect(didAnnounce).toBe(true);
+    // Verify announce fell back to Jaris (grandparent) since Newton is gone
+    const call = agentSpy.mock.calls[0]?.[0] as { params?: Record<string, unknown> };
+    expect(call?.params?.sessionKey).toBe("agent:main:main");
+    // deliver=true because Jaris is main (user-facing)
+    expect(call?.params?.deliver).toBe(true);
+    expect(call?.params?.channel).toBe("discord");
+  });
 });

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -507,23 +507,39 @@ export async function runSubagentAnnounceFlow(params: {
     let requesterIsSubagent = requesterDepth >= 1;
     // If the requester subagent has already finished, bubble the announce to its
     // requester (typically main) so descendant completion is not silently lost.
+    // BUT: only fallback if the parent SESSION is deleted, not just if the current
+    // run ended. A parent waiting for child results has no active run but should
+    // still receive the announce — injecting will start a new agent turn.
     if (requesterIsSubagent) {
       const { isSubagentSessionRunActive, resolveRequesterForChildSession } =
         await import("./subagent-registry.js");
       if (!isSubagentSessionRunActive(targetRequesterSessionKey)) {
-        const fallback = resolveRequesterForChildSession(targetRequesterSessionKey);
-        if (!fallback?.requesterSessionKey) {
-          // Without a requester fallback we cannot safely deliver this nested
-          // completion. Keep cleanup retryable so a later registry restore can
-          // recover and re-announce instead of silently dropping the result.
-          shouldDeleteChildSession = false;
-          return false;
+        // Parent run has ended. Check if parent SESSION still exists.
+        // If it does, the parent may be waiting for child results — inject there.
+        const parentSessionEntry = loadSessionEntryByKey(targetRequesterSessionKey);
+        const parentSessionAlive =
+          parentSessionEntry &&
+          typeof parentSessionEntry.sessionId === "string" &&
+          parentSessionEntry.sessionId.trim();
+
+        if (!parentSessionAlive) {
+          // Parent session is truly gone — fallback to grandparent
+          const fallback = resolveRequesterForChildSession(targetRequesterSessionKey);
+          if (!fallback?.requesterSessionKey) {
+            // Without a requester fallback we cannot safely deliver this nested
+            // completion. Keep cleanup retryable so a later registry restore can
+            // recover and re-announce instead of silently dropping the result.
+            shouldDeleteChildSession = false;
+            return false;
+          }
+          targetRequesterSessionKey = fallback.requesterSessionKey;
+          targetRequesterOrigin =
+            normalizeDeliveryContext(fallback.requesterOrigin) ?? targetRequesterOrigin;
+          requesterDepth = getSubagentDepthFromSessionStore(targetRequesterSessionKey);
+          requesterIsSubagent = requesterDepth >= 1;
         }
-        targetRequesterSessionKey = fallback.requesterSessionKey;
-        targetRequesterOrigin =
-          normalizeDeliveryContext(fallback.requesterOrigin) ?? targetRequesterOrigin;
-        requesterDepth = getSubagentDepthFromSessionStore(targetRequesterSessionKey);
-        requesterIsSubagent = requesterDepth >= 1;
+        // If parent session is alive (just has no active run), continue with parent
+        // as target. Injecting the announce will start a new agent turn for processing.
       }
     }
 


### PR DESCRIPTION
## Summary

- **Problem:** Nested subagent announcements bypass the parent and go directly to grandparent. When Newton (depth-1) spawns Birdie (depth-2), Birdie's result announces to Jaris (main) instead of Newton, leaving Newton waiting forever.
- **Why it matters:** Completely breaks the new nested subagent spawning feature — parent orchestrators never receive child results
- **What changed:** Only fallback to grandparent when parent SESSION is deleted, not just when parent run has ended

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration (subagent announce routing)

## Linked Issue/PR

- Closes #18037

## User-visible / Behavior Changes

Nested subagent results now correctly route to their immediate parent:

Previous behavior: Birdie → ~~Newton~~ → Jaris (bypassed parent)
New behavior: Birdie → Newton → Jaris (proper parent-child chain)

This enables the autonomous delegation workflow:
- Newton spawns Birdie for QA
- Birdie approves/rejects
- Newton receives Birdie's result, acts on it
- Newton reports final result to Jaris

## Security Impact

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

## Root Cause Analysis

In `runSubagentAnnounceFlow()`, when `isSubagentSessionRunActive(parent)` returns false, the code immediately fell back to grandparent. But "run ended" ≠ "session gone":

- Newton's run ends after spawning Birdie (agent turn completes)
- Newton's SESSION is still alive, waiting for child results
- `isSubagentSessionRunActive(Newton)` → false (no active run)
- Code fell back to Jaris ❌

**Fix:** Before falling back, check if parent SESSION still exists via `loadSessionEntryByKey()`. Only fallback when session is truly deleted.

## Evidence

- [x] 2 new regression tests in `subagent-announce.format.e2e.test.ts`:
  - `routes to parent subagent when parent run ended but session still exists`
  - `falls back to grandparent only when parent session is deleted`

## Compatibility / Migration

- Backward compatible? **Yes** - fixes incorrect behavior without changing expected paths
- Config/env changes? **No**
- Migration needed? **No**

## Risks and Mitigations

- **Risk:** Parent session exists but is abandoned (not actually listening)
- **Mitigation:** This is already handled by the session timeout/cleanup mechanism. If parent is abandoned long enough, session entry gets deleted → fallback triggers correctly.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes nested subagent announce routing so that child results are delivered to their immediate parent subagent instead of incorrectly bypassing to the grandparent. The root cause was that `runSubagentAnnounceFlow` fell back to the grandparent whenever `isSubagentSessionRunActive(parent)` returned false, but a parent whose run has ended may still have an active session waiting for child results. The fix adds a `loadSessionEntryByKey` check: only fall back to the grandparent when the parent session entry is truly gone (no valid `sessionId`), not merely when the parent has no active run.

- **`src/agents/subagent-announce.ts`**: Before falling back to the grandparent, checks if the parent session entry still exists with a valid `sessionId`. If the session is alive, the announce is delivered to the parent (which starts a new agent turn). Fallback only occurs when the session is deleted.
- **`src/agents/subagent-announce.format.e2e.test.ts`**: Adds two regression tests covering both branches: routing to a parent whose run ended but session exists, and falling back to grandparent when the parent session is deleted.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it narrows a fallback condition with a well-scoped check and includes comprehensive regression tests.
- The change is minimal and surgical: it adds one additional check (`loadSessionEntryByKey` for parent session existence) before triggering the grandparent fallback path. The logic is sound — distinguishing "run ended" from "session deleted" is the correct fix for the described bug. Existing tests remain compatible because the test fixture's Proxy returns entries without `sessionId` for auto-generated subagent keys, preserving the original fallback behavior in those scenarios. Two new regression tests directly validate both branches of the fix.
- No files require special attention

<sub>Last reviewed commit: 1bc812c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->