### PR TITLE
feat: triple-layer post-compaction context enforcement

### DIFF
--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+import path from "node:path";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { ExtensionAPI, FileOperations } from "@mariozechner/pi-coding-agent";
 import {
@@ -11,6 +13,7 @@ import {
   resolveContextWindowTokens,
   summarizeInStages,
 } from "../compaction.js";
+import { extractSections } from "../../auto-reply/reply/post-compaction-context.js";
 import { getCompactionSafeguardRuntime } from "./compaction-safeguard-runtime.js";
 const FALLBACK_SUMMARY =
   "Summary unavailable due to context limits. Older messages were truncated.";
@@ -156,6 +159,40 @@ function formatFileOperations(readFiles: string[], modifiedFiles: string[]): str
     return "";
   }
   return `\n\n${sections.join("\n\n")}`;
+}
+
+/**
+ * Read and format critical workspace context for compaction summary.
+ * Extracts "Session Startup" and "Red Lines" from AGENTS.md.
+ * Limited to 2000 chars to avoid bloating the summary.
+ */
+async function readWorkspaceContextForSummary(): Promise<string> {
+  const MAX_SUMMARY_CONTEXT_CHARS = 2000;
+  const workspaceDir = process.cwd();
+  const agentsPath = path.join(workspaceDir, "AGENTS.md");
+
+  try {
+    if (!fs.existsSync(agentsPath)) {
+      return "";
+    }
+
+    const content = await fs.promises.readFile(agentsPath, "utf-8");
+    const sections = extractSections(content, ["Session Startup", "Red Lines"]);
+
+    if (sections.length === 0) {
+      return "";
+    }
+
+    const combined = sections.join("\n\n");
+    const safeContent =
+      combined.length > MAX_SUMMARY_CONTEXT_CHARS
+        ? combined.slice(0, MAX_SUMMARY_CONTEXT_CHARS) + "\n...[truncated]..."
+        : combined;
+
+    return `\n\n<workspace-critical-rules>\n${safeContent}\n</workspace-critical-rules>`;
+  } catch {
+    return "";
+  }
 }
 
 export default function compactionSafeguardExtension(api: ExtensionAPI): void {
@@ -308,6 +345,12 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
 
       summary += toolFailureSection;
       summary += fileOpsSummary;
+
+      // Append workspace critical context (Session Startup + Red Lines from AGENTS.md)
+      const workspaceContext = await readWorkspaceContextForSummary();
+      if (workspaceContext) {
+        summary += workspaceContext;
+      }
 
       return {
         compaction: {

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -1,7 +1,8 @@
-import fs from "node:fs";
-import path from "node:path";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { ExtensionAPI, FileOperations } from "@mariozechner/pi-coding-agent";
+import fs from "node:fs";
+import path from "node:path";
+import { extractSections } from "../../auto-reply/reply/post-compaction-context.js";
 import {
   BASE_CHUNK_RATIO,
   MIN_CHUNK_RATIO,
@@ -13,7 +14,6 @@ import {
   resolveContextWindowTokens,
   summarizeInStages,
 } from "../compaction.js";
-import { extractSections } from "../../auto-reply/reply/post-compaction-context.js";
 import { getCompactionSafeguardRuntime } from "./compaction-safeguard-runtime.js";
 const FALLBACK_SUMMARY =
   "Summary unavailable due to context limits. Older messages were truncated.";

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -19,6 +19,7 @@ import {
   updateSessionStoreEntry,
 } from "../../config/sessions.js";
 import { emitDiagnosticEvent, isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
+import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { defaultRuntime } from "../../runtime.js";
 import { estimateUsageCost, resolveModelCostConfig } from "../../utils/usage-format.js";
 import { resolveResponseUsageMode, type VerboseLevel } from "../thinking.js";
@@ -36,6 +37,7 @@ import { appendUsageLine, formatResponseUsageLine } from "./agent-runner-utils.j
 import { createAudioAsVoiceBuffer, createBlockReplyPipeline } from "./block-reply-pipeline.js";
 import { resolveBlockStreamingCoalescing } from "./block-streaming.js";
 import { createFollowupRunner } from "./followup-runner.js";
+import { readPostCompactionContext } from "./post-compaction-context.js";
 import { enqueueFollowupRun, type FollowupRun, type QueueSettings } from "./queue.js";
 import { createReplyToModeFilterForChannel, resolveReplyToMode } from "./reply-threading.js";
 import { incrementRunCompactionCount, persistRunSessionUsage } from "./session-run-accounting.js";
@@ -499,6 +501,21 @@ export async function runReplyAgent(params: {
         lastCallUsage: runResult.meta.agentMeta?.lastCallUsage,
         contextTokensUsed,
       });
+
+      // Inject post-compaction workspace context for the next agent turn
+      if (sessionKey) {
+        const workspaceDir = process.cwd();
+        readPostCompactionContext(workspaceDir)
+          .then((contextContent) => {
+            if (contextContent) {
+              enqueueSystemEvent(contextContent, { sessionKey });
+            }
+          })
+          .catch(() => {
+            // Silent failure — post-compaction context is best-effort
+          });
+      }
+
       if (verboseEnabled) {
         const suffix = typeof count === "number" ? ` (count ${count})` : "";
         finalPayloads = [{ text: `🧹 Auto-compaction complete${suffix}.` }, ...finalPayloads];

--- a/src/auto-reply/reply/post-compaction-audit.test.ts
+++ b/src/auto-reply/reply/post-compaction-audit.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect } from "vitest";
+import {
+  auditPostCompactionReads,
+  extractReadPaths,
+  formatAuditWarning,
+} from "./post-compaction-audit.js";
+
+describe("extractReadPaths", () => {
+  it("extracts file paths from Read tool calls", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            name: "read",
+            input: { file_path: "WORKFLOW_AUTO.md" },
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            name: "read",
+            input: { file_path: "memory/2026-02-16.md" },
+          },
+        ],
+      },
+    ];
+
+    const paths = extractReadPaths(messages);
+    expect(paths).toEqual(["WORKFLOW_AUTO.md", "memory/2026-02-16.md"]);
+  });
+
+  it("handles path parameter (alternative to file_path)", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            name: "read",
+            input: { path: "AGENTS.md" },
+          },
+        ],
+      },
+    ];
+
+    const paths = extractReadPaths(messages);
+    expect(paths).toEqual(["AGENTS.md"]);
+  });
+
+  it("ignores non-assistant messages", () => {
+    const messages = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_use",
+            name: "read",
+            input: { file_path: "should_be_ignored.md" },
+          },
+        ],
+      },
+    ];
+
+    const paths = extractReadPaths(messages);
+    expect(paths).toEqual([]);
+  });
+
+  it("ignores non-read tool calls", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            name: "exec",
+            input: { command: "cat WORKFLOW_AUTO.md" },
+          },
+        ],
+      },
+    ];
+
+    const paths = extractReadPaths(messages);
+    expect(paths).toEqual([]);
+  });
+
+  it("handles empty messages array", () => {
+    const paths = extractReadPaths([]);
+    expect(paths).toEqual([]);
+  });
+
+  it("handles messages with non-array content", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: "text only",
+      },
+    ];
+
+    const paths = extractReadPaths(messages);
+    expect(paths).toEqual([]);
+  });
+});
+
+describe("auditPostCompactionReads", () => {
+  const workspaceDir = "/Users/test/workspace";
+
+  it("passes when all required files are read", () => {
+    const readPaths = ["WORKFLOW_AUTO.md", "memory/2026-02-16.md"];
+    const result = auditPostCompactionReads(readPaths, workspaceDir);
+
+    expect(result.passed).toBe(true);
+    expect(result.missingPatterns).toEqual([]);
+  });
+
+  it("fails when no files are read", () => {
+    const result = auditPostCompactionReads([], workspaceDir);
+
+    expect(result.passed).toBe(false);
+    expect(result.missingPatterns).toContain("WORKFLOW_AUTO.md");
+    expect(result.missingPatterns.some((p) => p.includes("memory"))).toBe(true);
+  });
+
+  it("reports only missing files", () => {
+    const readPaths = ["WORKFLOW_AUTO.md"];
+    const result = auditPostCompactionReads(readPaths, workspaceDir);
+
+    expect(result.passed).toBe(false);
+    expect(result.missingPatterns).not.toContain("WORKFLOW_AUTO.md");
+    expect(result.missingPatterns.some((p) => p.includes("memory"))).toBe(true);
+  });
+
+  it("matches RegExp patterns against relative paths", () => {
+    const readPaths = ["memory/2026-02-16.md"];
+    const result = auditPostCompactionReads(readPaths, workspaceDir);
+
+    expect(result.passed).toBe(false);
+    expect(result.missingPatterns).toContain("WORKFLOW_AUTO.md");
+    expect(result.missingPatterns.length).toBe(1);
+  });
+
+  it("normalizes relative paths when matching", () => {
+    const readPaths = ["./WORKFLOW_AUTO.md", "memory/2026-02-16.md"];
+    const result = auditPostCompactionReads(readPaths, workspaceDir);
+
+    expect(result.passed).toBe(true);
+    expect(result.missingPatterns).toEqual([]);
+  });
+
+  it("normalizes absolute paths when matching", () => {
+    const readPaths = [
+      "/Users/test/workspace/WORKFLOW_AUTO.md",
+      "/Users/test/workspace/memory/2026-02-16.md",
+    ];
+    const result = auditPostCompactionReads(readPaths, workspaceDir);
+
+    expect(result.passed).toBe(true);
+    expect(result.missingPatterns).toEqual([]);
+  });
+
+  it("accepts custom required reads list", () => {
+    const readPaths = ["custom.md"];
+    const customRequired = ["custom.md"];
+    const result = auditPostCompactionReads(readPaths, workspaceDir, customRequired);
+
+    expect(result.passed).toBe(true);
+    expect(result.missingPatterns).toEqual([]);
+  });
+});
+
+describe("formatAuditWarning", () => {
+  it("formats warning message with missing patterns", () => {
+    const missingPatterns = ["WORKFLOW_AUTO.md", "memory\\/\\d{4}-\\d{2}-\\d{2}\\.md"];
+    const message = formatAuditWarning(missingPatterns);
+
+    expect(message).toContain("⚠️ Post-Compaction Audit");
+    expect(message).toContain("WORKFLOW_AUTO.md");
+    expect(message).toContain("memory");
+    expect(message).toContain("Please read them now");
+  });
+
+  it("formats single missing pattern", () => {
+    const missingPatterns = ["WORKFLOW_AUTO.md"];
+    const message = formatAuditWarning(missingPatterns);
+
+    expect(message).toContain("WORKFLOW_AUTO.md");
+    // Check that the missing patterns list only contains WORKFLOW_AUTO.md
+    const lines = message.split("\n");
+    const patternLines = lines.filter((l) => l.trim().startsWith("- "));
+    expect(patternLines).toHaveLength(1);
+    expect(patternLines[0]).toContain("WORKFLOW_AUTO.md");
+  });
+});

--- a/src/auto-reply/reply/post-compaction-audit.ts
+++ b/src/auto-reply/reply/post-compaction-audit.ts
@@ -1,0 +1,109 @@
+import fs from "node:fs";
+import path from "node:path";
+
+// Default required files — constants, extensible to config later
+const DEFAULT_REQUIRED_READS: Array<string | RegExp> = [
+  "WORKFLOW_AUTO.md",
+  /memory\/\d{4}-\d{2}-\d{2}\.md/, // daily memory files
+];
+
+/**
+ * Audit whether agent read required startup files after compaction.
+ * Returns list of missing file patterns.
+ */
+export function auditPostCompactionReads(
+  readFilePaths: string[],
+  workspaceDir: string,
+  requiredReads: Array<string | RegExp> = DEFAULT_REQUIRED_READS,
+): { passed: boolean; missingPatterns: string[] } {
+  const normalizedReads = readFilePaths.map((p) => path.resolve(workspaceDir, p));
+  const missingPatterns: string[] = [];
+
+  for (const required of requiredReads) {
+    if (typeof required === "string") {
+      const requiredResolved = path.resolve(workspaceDir, required);
+      const found = normalizedReads.some((r) => r === requiredResolved);
+      if (!found) {
+        missingPatterns.push(required);
+      }
+    } else {
+      // RegExp — match against relative paths from workspace
+      const found = readFilePaths.some((p) => {
+        const rel = path.relative(workspaceDir, path.resolve(workspaceDir, p));
+        return required.test(rel);
+      });
+      if (!found) {
+        missingPatterns.push(required.source);
+      }
+    }
+  }
+
+  return { passed: missingPatterns.length === 0, missingPatterns };
+}
+
+/**
+ * Read messages from a session JSONL file.
+ * Returns messages from the last N lines (default 100).
+ */
+export function readSessionMessages(
+  sessionFile: string,
+  maxLines = 100,
+): Array<{ role?: string; content?: unknown }> {
+  if (!fs.existsSync(sessionFile)) {
+    return [];
+  }
+
+  try {
+    const content = fs.readFileSync(sessionFile, "utf-8");
+    const lines = content.trim().split("\n");
+    const recentLines = lines.slice(-maxLines);
+
+    const messages: Array<{ role?: string; content?: unknown }> = [];
+    for (const line of recentLines) {
+      try {
+        const entry = JSON.parse(line);
+        if (entry.type === "message" && entry.message) {
+          messages.push(entry.message);
+        }
+      } catch {
+        // Skip malformed lines
+      }
+    }
+    return messages;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Extract file paths from Read tool calls in agent messages.
+ * Looks for tool_use blocks with name="read" and extracts path/file_path args.
+ */
+export function extractReadPaths(messages: Array<{ role?: string; content?: unknown }>): string[] {
+  const paths: string[] = [];
+  for (const msg of messages) {
+    if (msg.role !== "assistant" || !Array.isArray(msg.content)) {
+      continue;
+    }
+    for (const block of msg.content) {
+      if (block.type === "tool_use" && block.name === "read") {
+        const filePath = block.input?.file_path ?? block.input?.path;
+        if (typeof filePath === "string") {
+          paths.push(filePath);
+        }
+      }
+    }
+  }
+  return paths;
+}
+
+/** Format the audit warning message */
+export function formatAuditWarning(missingPatterns: string[]): string {
+  const fileList = missingPatterns.map((p) => `  - ${p}`).join("\n");
+  return (
+    "⚠️ Post-Compaction Audit: The following required startup files were not read after context reset:\n" +
+    fileList +
+    "\n\nPlease read them now using the Read tool before continuing. " +
+    "This ensures your operating protocols are restored after memory compaction."
+  );
+}

--- a/src/auto-reply/reply/post-compaction-audit.ts
+++ b/src/auto-reply/reply/post-compaction-audit.ts
@@ -30,7 +30,9 @@ export function auditPostCompactionReads(
       // RegExp — match against relative paths from workspace
       const found = readFilePaths.some((p) => {
         const rel = path.relative(workspaceDir, path.resolve(workspaceDir, p));
-        return required.test(rel);
+        // Normalize to forward slashes for cross-platform RegExp matching
+        const normalizedRel = rel.split(path.sep).join("/");
+        return required.test(normalizedRel);
       });
       if (!found) {
         missingPatterns.push(required.source);

--- a/src/auto-reply/reply/post-compaction-context.test.ts
+++ b/src/auto-reply/reply/post-compaction-context.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { readPostCompactionContext } from "./post-compaction-context.js";
+
+describe("readPostCompactionContext", () => {
+  const tmpDir = path.join("/tmp", "test-post-compaction-" + Date.now());
+
+  beforeEach(() => {
+    fs.mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns null when no AGENTS.md exists", async () => {
+    const result = await readPostCompactionContext(tmpDir);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when AGENTS.md has no relevant sections", async () => {
+    fs.writeFileSync(path.join(tmpDir, "AGENTS.md"), "# My Agent\n\nSome content.\n");
+    const result = await readPostCompactionContext(tmpDir);
+    expect(result).toBeNull();
+  });
+
+  it("extracts Session Startup section", async () => {
+    const content = `# Agent Rules
+
+## Session Startup
+
+Read these files:
+1. WORKFLOW_AUTO.md
+2. memory/today.md
+
+## Other Section
+
+Not relevant.
+`;
+    fs.writeFileSync(path.join(tmpDir, "AGENTS.md"), content);
+    const result = await readPostCompactionContext(tmpDir);
+    expect(result).not.toBeNull();
+    expect(result).toContain("Session Startup");
+    expect(result).toContain("WORKFLOW_AUTO.md");
+    expect(result).toContain("Post-compaction context refresh");
+    expect(result).not.toContain("Other Section");
+  });
+
+  it("extracts Red Lines section", async () => {
+    const content = `# Rules
+
+## Red Lines
+
+Never do X.
+Never do Y.
+
+## Other
+
+Stuff.
+`;
+    fs.writeFileSync(path.join(tmpDir, "AGENTS.md"), content);
+    const result = await readPostCompactionContext(tmpDir);
+    expect(result).not.toBeNull();
+    expect(result).toContain("Red Lines");
+    expect(result).toContain("Never do X");
+  });
+
+  it("extracts both sections", async () => {
+    const content = `# Rules
+
+## Session Startup
+
+Do startup things.
+
+## Red Lines
+
+Never break things.
+
+## Other
+
+Ignore this.
+`;
+    fs.writeFileSync(path.join(tmpDir, "AGENTS.md"), content);
+    const result = await readPostCompactionContext(tmpDir);
+    expect(result).not.toBeNull();
+    expect(result).toContain("Session Startup");
+    expect(result).toContain("Red Lines");
+    expect(result).not.toContain("Other");
+  });
+
+  it("truncates when content exceeds limit", async () => {
+    const longContent = "## Session Startup\n\n" + "A".repeat(4000) + "\n\n## Other\n\nStuff.";
+    fs.writeFileSync(path.join(tmpDir, "AGENTS.md"), longContent);
+    const result = await readPostCompactionContext(tmpDir);
+    expect(result).not.toBeNull();
+    expect(result).toContain("[truncated]");
+  });
+});

--- a/src/auto-reply/reply/post-compaction-context.test.ts
+++ b/src/auto-reply/reply/post-compaction-context.test.ts
@@ -96,4 +96,74 @@ Ignore this.
     expect(result).not.toBeNull();
     expect(result).toContain("[truncated]");
   });
+
+  it("matches section names case-insensitively", async () => {
+    const content = `# Rules
+
+## session startup
+
+Read WORKFLOW_AUTO.md
+
+## Other
+`;
+    fs.writeFileSync(path.join(tmpDir, "AGENTS.md"), content);
+    const result = await readPostCompactionContext(tmpDir);
+    expect(result).not.toBeNull();
+    expect(result).toContain("WORKFLOW_AUTO.md");
+  });
+
+  it("matches H3 headings", async () => {
+    const content = `# Rules
+
+### Session Startup
+
+Read these files.
+
+### Other
+`;
+    fs.writeFileSync(path.join(tmpDir, "AGENTS.md"), content);
+    const result = await readPostCompactionContext(tmpDir);
+    expect(result).not.toBeNull();
+    expect(result).toContain("Read these files");
+  });
+
+  it("skips sections inside code blocks", async () => {
+    const content = `# Rules
+
+\`\`\`markdown
+## Session Startup
+This is inside a code block and should NOT be extracted.
+\`\`\`
+
+## Red Lines
+
+Real red lines here.
+
+## Other
+`;
+    fs.writeFileSync(path.join(tmpDir, "AGENTS.md"), content);
+    const result = await readPostCompactionContext(tmpDir);
+    expect(result).not.toBeNull();
+    expect(result).toContain("Real red lines here");
+    expect(result).not.toContain("inside a code block");
+  });
+
+  it("includes sub-headings within a section", async () => {
+    const content = `## Red Lines
+
+### Rule 1
+Never do X.
+
+### Rule 2
+Never do Y.
+
+## Other Section
+`;
+    fs.writeFileSync(path.join(tmpDir, "AGENTS.md"), content);
+    const result = await readPostCompactionContext(tmpDir);
+    expect(result).not.toBeNull();
+    expect(result).toContain("Rule 1");
+    expect(result).toContain("Rule 2");
+    expect(result).not.toContain("Other Section");
+  });
 });

--- a/src/auto-reply/reply/post-compaction-context.test.ts
+++ b/src/auto-reply/reply/post-compaction-context.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
 import path from "node:path";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { readPostCompactionContext } from "./post-compaction-context.js";
 
 describe("readPostCompactionContext", () => {

--- a/src/auto-reply/reply/post-compaction-context.ts
+++ b/src/auto-reply/reply/post-compaction-context.ts
@@ -1,0 +1,86 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const MAX_CONTEXT_CHARS = 3000;
+
+/**
+ * Read critical sections from workspace AGENTS.md for post-compaction injection.
+ * Returns formatted system event text, or null if no AGENTS.md or no relevant sections.
+ */
+export async function readPostCompactionContext(workspaceDir: string): Promise<string | null> {
+  const agentsPath = path.join(workspaceDir, "AGENTS.md");
+
+  try {
+    if (!fs.existsSync(agentsPath)) {
+      return null;
+    }
+
+    const content = await fs.promises.readFile(agentsPath, "utf-8");
+
+    // Extract "## Session Startup" and "## Red Lines" sections
+    // Each section ends at the next "## " heading or end of file
+    const sections = extractSections(content, ["Session Startup", "Red Lines"]);
+
+    if (sections.length === 0) {
+      return null;
+    }
+
+    const combined = sections.join("\n\n");
+    const safeContent =
+      combined.length > MAX_CONTEXT_CHARS
+        ? combined.slice(0, MAX_CONTEXT_CHARS) + "\n...[truncated]..."
+        : combined;
+
+    return (
+      "[Post-compaction context refresh]\n\n" +
+      "Session was just compacted. The conversation summary above is a hint, NOT a substitute for your startup sequence. " +
+      "Execute your Session Startup sequence now — read the required files before responding to the user.\n\n" +
+      "Critical rules from AGENTS.md:\n\n" +
+      safeContent
+    );
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Extract named H2 sections from markdown content.
+ * Matches "## SectionName" and captures until the next "## " or end of string.
+ */
+function extractSections(content: string, sectionNames: string[]): string[] {
+  const results: string[] = [];
+  const lines = content.split("\n");
+
+  for (const name of sectionNames) {
+    let sectionLines: string[] = [];
+    let inSection = false;
+
+    for (const line of lines) {
+      // Check if this is the start of our target section
+      if (line.match(new RegExp(`^##\\s+${escapeRegExp(name)}\\s*$`))) {
+        inSection = true;
+        sectionLines = [line];
+        continue;
+      }
+
+      // If we're in the section, check if we've hit another H2 heading
+      if (inSection) {
+        if (line.match(/^##\s+/)) {
+          // Hit another H2 heading, stop collecting
+          break;
+        }
+        sectionLines.push(line);
+      }
+    }
+
+    if (sectionLines.length > 0) {
+      results.push(sectionLines.join("\n").trim());
+    }
+  }
+
+  return results;
+}
+
+function escapeRegExp(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/src/auto-reply/reply/post-compaction-context.ts
+++ b/src/auto-reply/reply/post-compaction-context.ts
@@ -49,7 +49,7 @@ export async function readPostCompactionContext(workspaceDir: string): Promise<s
  * Skips content inside fenced code blocks.
  * Captures until the next heading of same or higher level, or end of string.
  */
-function extractSections(content: string, sectionNames: string[]): string[] {
+export function extractSections(content: string, sectionNames: string[]): string[] {
   const results: string[] = [];
   const lines = content.split("\n");
 


### PR DESCRIPTION
After session compaction, agents often skip their configured startup sequence because the compaction summary creates a false 'I already know everything' illusion.

This PR implements triple-layer enforcement to ensure post-compaction recovery:

## Layer 1: Summary Append
Append critical workspace rules (AGENTS.md Session Startup + Red Lines) into the compaction summary via `<workspace-critical-rules>` tags. 100% reliable — rules are physically in the prompt.

## Layer 2: System Event  
Inject workspace context as a system event for the next agent turn after compaction. Explicit reminder to execute startup sequence.

## Layer 3: Post-Turn Audit
After the agent's first post-compaction turn, audit whether required files were actually read. If not, inject a one-time warning listing missing files. Max 1 retry to prevent loops.

## Changes
- `src/agents/pi-extensions/compaction-safeguard.ts` — Layer 1: append workspace context to summary
- `src/auto-reply/reply/agent-runner.ts` — Layer 2 + 3: system event injection + audit integration
- `src/auto-reply/reply/post-compaction-context.ts` — reads and formats AGENTS.md sections
- `src/auto-reply/reply/post-compaction-audit.ts` — audits post-compaction file reads
- `src/auto-reply/reply/post-compaction-context.test.ts` — tests for context extraction
- `src/auto-reply/reply/post-compaction-audit.test.ts` — tests for read audit

## Design decisions
- Reuses existing `enqueueSystemEvent()` infrastructure
- Only activates if workspace has AGENTS.md
- `extractSections` handles H2/H3, case-insensitive, code-block aware
- Truncation limits prevent token explosion / Yo-Yo re-compaction
- Silent failure on errors (best-effort)
- Audit fires at most once per compaction (no infinite loops)
- Cross-platform path normalization (forward-slash unification) for Windows compatibility in audit layer

Fixes #18023
