### PR TITLE
fix(providers): remove MiniMax from reasoning tag providers

### DIFF
--- a/src/utils/provider-utils.ts
+++ b/src/utils/provider-utils.ts
@@ -27,10 +27,14 @@ export function isReasoningTagProvider(provider: string | undefined | null): boo
     return true;
   }
 
-  // Handle Minimax (M2.1 is chatty/reasoning-like)
-  if (normalized.includes("minimax")) {
-    return true;
-  }
+  // NOTE: MiniMax was previously included here but removed because:
+  // 1. MiniMax models don't reliably output <think>/<final> tags
+  // 2. enforceFinalTag=true causes all content to be stripped → "(no output)"
+  // 3. MiniMax's reasoning is handled differently (not via text stream tags)
+  // See: https://github.com/openclaw/openclaw/issues/4499
+  // if (normalized.includes("minimax")) {
+  //   return true;
+  // }
 
   return false;
 }

--- a/src/utils/utils-misc.test.ts
+++ b/src/utils/utils-misc.test.ts
@@ -61,9 +61,9 @@ describe("isReasoningTagProvider", () => {
     expect(isReasoningTagProvider("google-antigravity/gemini-3")).toBe(true);
   });
 
-  it("returns true for minimax", () => {
-    expect(isReasoningTagProvider("minimax")).toBe(true);
-    expect(isReasoningTagProvider("minimax-cn")).toBe(true);
+  it("returns false for minimax - no <think>/<final> tag support (#4499)", () => {
+    expect(isReasoningTagProvider("minimax")).toBe(false);
+    expect(isReasoningTagProvider("minimax-cn")).toBe(false);
   });
 
   it("returns false for null/undefined/empty", () => {


### PR DESCRIPTION
## Summary

Fixes #4499

MiniMax was incorrectly included in isReasoningTagProvider(), causing enforceFinalTag=true for all MiniMax runs. Since MiniMax models don't output <think>/<final> tags, this caused all streaming content to be discarded, resulting in '(no output)' in the TUI.

## Root Cause

In src/utils/provider-utils.ts, the check for minimax caused enforceFinalTag to be set to true, but MiniMax doesn't output <final> tags, so all content was stripped.

## Changes

- Removed MiniMax from isReasoningTagProvider()
- Added detailed documentation explaining why MiniMax was removed

## Verification

Tested on OpenClaw 2026.2.15 with MiniMax M2.5:
- Before fix: MiniMax responses showed '(no output)' in TUI
- After fix: MiniMax streams responses correctly in real-time

This reproduces and confirms the bug described in #4499.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes MiniMax from `isReasoningTagProvider()` to fix #4499, where MiniMax models returned "(no output)" because `enforceFinalTag=true` was stripping all content from models that don't emit `<think>`/`<final>` tags. The fix is correct and follows the same pattern as the earlier Ollama fix (#2279).

- Removed MiniMax from the reasoning tag provider check in `src/utils/provider-utils.ts`
- Updated tests in `src/utils/utils-misc.test.ts` to assert `false` for MiniMax providers
- Minor style issue: commented-out code block should be deleted entirely per the project's coding style guide (see inline comment)

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it fixes a clear bug with a minimal, well-scoped change.
- The fix is straightforward and correct: MiniMax models don't emit reasoning tags, so including them in isReasoningTagProvider() caused all output to be discarded. The change is small, well-tested, and follows a proven pattern (Ollama fix). Only a minor style nit (commented-out code) prevents a score of 5.
- No files require special attention. The change is minimal and well-tested.

<sub>Last reviewed commit: d0dd4b6</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))

<!-- /greptile_comment -->