### PR TITLE
fix(gateway): preserve unbracketed IPv6 host headers

### DIFF
--- a/src/gateway/net.test.ts
+++ b/src/gateway/net.test.ts
@@ -5,7 +5,20 @@ import {
   isTrustedProxyAddress,
   pickPrimaryLanIPv4,
   resolveGatewayListenHosts,
+  resolveHostName,
 } from "./net.js";
+
+describe("resolveHostName", () => {
+  it("returns hostname without port for IPv4/hostnames", () => {
+    expect(resolveHostName("localhost:18789")).toBe("localhost");
+    expect(resolveHostName("127.0.0.1:18789")).toBe("127.0.0.1");
+  });
+
+  it("handles bracketed and unbracketed IPv6 loopback hosts", () => {
+    expect(resolveHostName("[::1]:18789")).toBe("::1");
+    expect(resolveHostName("::1")).toBe("::1");
+  });
+});
 
 describe("isTrustedProxyAddress", () => {
   describe("exact IP matching", () => {

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -40,6 +40,10 @@ export function resolveHostName(hostHeader?: string): string {
       return host.slice(1, end);
     }
   }
+  // Unbracketed IPv6 host (e.g. "::1") has no port and should be returned as-is.
+  if (net.isIP(host) === 6) {
+    return host;
+  }
   const [name] = host.split(":");
   return name ?? "";
 }


### PR DESCRIPTION
## Summary
- fix `resolveHostName` to preserve unbracketed IPv6 host headers (e.g. `::1`)
- add targeted tests for IPv4/hostname + bracketed/unbracketed IPv6 host parsing

## Problem
`resolveHostName` currently splits on `":"` for non-bracketed hosts.

For unbracketed IPv6 hosts like `::1`, this returns an empty hostname instead of the actual address.

## Root cause
The parser assumes `:` indicates a host:port separator, but IPv6 literals also contain `:`.

## Fix
- before splitting by `:`, detect unbracketed IPv6 using `net.isIP(host) === 6`
- return the IPv6 host as-is in that case

## Validation
- added tests in `src/gateway/net.test.ts`:
  - `localhost:18789` / `127.0.0.1:18789`
  - `[::1]:18789`
  - `::1`

## AI-assisted
This PR was AI-assisted.

## Testing level
Lightly tested (targeted unit test update; full suite not run in this local environment).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed `resolveHostName` to correctly handle unbracketed IPv6 host headers like `::1`. The previous implementation incorrectly split on `:` which caused IPv6 addresses to be truncated to empty strings.

- Added IPv6 detection using `net.isIP(host) === 6` before splitting on `:`
- Preserves existing behavior for IPv4, hostnames, and bracketed IPv6 addresses
- Includes comprehensive test coverage for all supported formats

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a targeted, well-tested solution to a specific parsing bug. The logic is sound (using `net.isIP()` to detect IPv6 before splitting), the change is minimal and well-placed in the parsing flow, and comprehensive test coverage has been added for all relevant cases (IPv4, hostname, bracketed/unbracketed IPv6). The fix preserves all existing behavior while correctly handling the previously broken unbracketed IPv6 case.
- No files require special attention

<sub>Last reviewed commit: 3308939</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->