### PR TITLE
fix(browser): handle EADDRINUSE with automatic port fallback

### DIFF
--- a/src/browser/extension-relay.ts
+++ b/src/browser/extension-relay.ts
@@ -6,6 +6,9 @@ import { createServer } from "node:http";
 import WebSocket, { WebSocketServer } from "ws";
 import { isLoopbackAddress, isLoopbackHost } from "../gateway/net.js";
 import { rawDataToString } from "../infra/ws.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+
+const logService = createSubsystemLogger("browser").child("relay");
 
 type CdpCommand = {
   id: number;
@@ -703,10 +706,37 @@ export async function ensureChromeExtensionRelayServer(opts: {
     });
   });
 
-  await new Promise<void>((resolve, reject) => {
-    server.listen(info.port, info.host, () => resolve());
-    server.once("error", reject);
-  });
+  // Try to bind to the requested port, with automatic fallback on EADDRINUSE.
+  let boundPort = info.port;
+  const maxRetries = 10;
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const onError = (err: Error) => {
+          server.removeListener("listening", resolve);
+          reject(err);
+        };
+        const onListening = () => {
+          server.removeListener("error", onError);
+          resolve();
+        };
+        server.once("error", onError);
+        server.once("listening", onListening);
+        server.listen(boundPort, info.host);
+      });
+      // Successfully bound
+      break;
+    } catch (err) {
+      const isAddrInUse = (err as { code?: string }).code === "EADDRINUSE";
+      if (isAddrInUse && attempt < maxRetries - 1) {
+        // Try a random port in the dynamic range (49152-65535)
+        boundPort = Math.floor(Math.random() * (65535 - 49152 + 1)) + 49152;
+        logService.warn(`Port ${info.port} is in use, trying alternative port ${boundPort}...`);
+      } else {
+        throw err;
+      }
+    }
+  }
 
   const addr = server.address() as AddressInfo | null;
   const port = addr?.port ?? info.port;


### PR DESCRIPTION
When the Chrome extension relay server fails to bind due to port conflict (EADDRINUSE), automatically try alternative ports in the dynamic range (49152-65535) instead of failing immediately.

This resolves issues where stale processes hold onto port 18792 after gateway restarts or crashes.

Fixes potential issues related to #8926, #13867, #17584

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added automatic port fallback for the Chrome extension relay server when `EADDRINUSE` occurs. When port 18792 is unavailable, the code now retries up to 10 times with random ports in the dynamic range (49152-65535).

**Critical Issue Found:**
- The port fallback creates a key mismatch in `serversByPort`. When a server binds to a fallback port, it's stored under the actual bound port, but lookups and cleanup operations still use the original requested port from the cdpUrl. This breaks server reuse (line 188) and prevents proper cleanup via `stopChromeExtensionRelayServer` (line 782).
- Impact: Multiple server instances may be created for the same profile, and servers on fallback ports cannot be stopped through the normal API.

**Additional Notes:**
- The retry logic itself is well-structured with proper error handling
- Logging was appropriately added to track fallback attempts

<h3>Confidence Score: 1/5</h3>

- Critical logic error will cause resource leaks and broken functionality
- The port fallback mechanism has a fundamental flaw where the server registry uses different keys for storage vs lookup. This will prevent proper server reuse and cleanup, causing multiple servers to be created and making them impossible to stop via the standard API. The issue affects core functionality and will manifest immediately when port conflicts occur.
- Critical attention needed for `src/browser/extension-relay.ts` - the port mapping logic must be fixed before merge

<sub>Last reviewed commit: 58f5561</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->