### PR TITLE
fix(daemon): warn on token drift during restart (#18018)

### DIFF
--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -1,5 +1,7 @@
 import type { GatewayService } from "../../daemon/service.js";
+import { loadConfig } from "../../config/config.js";
 import { resolveIsNixMode } from "../../config/paths.js";
+import { checkTokenDrift } from "../../daemon/service-audit.js";
 import { renderSystemdUnavailableHints } from "../../daemon/systemd-hints.js";
 import { isSystemdUserServiceAvailable } from "../../daemon/systemd.js";
 import { isWSL } from "../../infra/wsl.js";
@@ -255,6 +257,27 @@ export async function runServiceRestart(params: {
     });
     return false;
   }
+
+  // Check for token drift before restart (service token vs config token)
+  try {
+    const command = await params.service.readCommand(process.env);
+    const serviceToken = command?.environment?.OPENCLAW_GATEWAY_TOKEN;
+    const cfg = loadConfig();
+    const configToken =
+      cfg.gateway?.auth?.token ||
+      process.env.OPENCLAW_GATEWAY_TOKEN ||
+      process.env.CLAWDBOT_GATEWAY_TOKEN;
+    const driftIssue = checkTokenDrift({ serviceToken, configToken });
+    if (driftIssue && !json) {
+      defaultRuntime.log(`\n⚠️  ${driftIssue.message}`);
+      if (driftIssue.detail) {
+        defaultRuntime.log(`   ${driftIssue.detail}\n`);
+      }
+    }
+  } catch {
+    // Non-fatal: token drift check is best-effort
+  }
+
   try {
     await params.service.restart({ env: process.env, stdout });
     let restarted = true;

--- a/src/daemon/service-audit.test.ts
+++ b/src/daemon/service-audit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { auditGatewayServiceConfig, SERVICE_AUDIT_CODES } from "./service-audit.js";
+import { auditGatewayServiceConfig, checkTokenDrift, SERVICE_AUDIT_CODES } from "./service-audit.js";
 import { buildMinimalServicePath } from "./service-env.js";
 
 describe("auditGatewayServiceConfig", () => {
@@ -59,5 +59,41 @@ describe("auditGatewayServiceConfig", () => {
     expect(
       audit.issues.some((issue) => issue.code === SERVICE_AUDIT_CODES.gatewayPathMissingDirs),
     ).toBe(false);
+  });
+});
+
+describe("checkTokenDrift", () => {
+  it("returns null when both tokens are undefined", () => {
+    const result = checkTokenDrift({ serviceToken: undefined, configToken: undefined });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when both tokens are empty strings", () => {
+    const result = checkTokenDrift({ serviceToken: "", configToken: "" });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when tokens match", () => {
+    const result = checkTokenDrift({ serviceToken: "same-token", configToken: "same-token" });
+    expect(result).toBeNull();
+  });
+
+  it("detects drift when config has token but service has different token", () => {
+    const result = checkTokenDrift({ serviceToken: "old-token", configToken: "new-token" });
+    expect(result).not.toBeNull();
+    expect(result?.code).toBe(SERVICE_AUDIT_CODES.gatewayTokenDrift);
+    expect(result?.message).toContain("differs from service token");
+  });
+
+  it("detects drift when config has token but service has no token", () => {
+    const result = checkTokenDrift({ serviceToken: undefined, configToken: "new-token" });
+    expect(result).not.toBeNull();
+    expect(result?.code).toBe(SERVICE_AUDIT_CODES.gatewayTokenDrift);
+  });
+
+  it("returns null when service has token but config does not", () => {
+    // This is not really drift - service will work, just config is incomplete
+    const result = checkTokenDrift({ serviceToken: "service-token", configToken: undefined });
+    expect(result).toBeNull();
   });
 });

--- a/src/daemon/service-audit.ts
+++ b/src/daemon/service-audit.ts
@@ -37,6 +37,7 @@ export const SERVICE_AUDIT_CODES = {
   gatewayRuntimeBun: "gateway-runtime-bun",
   gatewayRuntimeNodeVersionManager: "gateway-runtime-node-version-manager",
   gatewayRuntimeNodeSystemMissing: "gateway-runtime-node-system-missing",
+  gatewayTokenDrift: "gateway-token-drift",
   launchdKeepAlive: "launchd-keep-alive",
   launchdRunAtLoad: "launchd-run-at-load",
   systemdAfterNetworkOnline: "systemd-after-network-online",
@@ -335,6 +336,35 @@ async function auditGatewayRuntime(
       }
     }
   }
+}
+
+/**
+ * Check if the service's embedded token differs from the config file token.
+ * Returns an issue if drift is detected (service will use old token after restart).
+ */
+export function checkTokenDrift(params: {
+  serviceToken: string | undefined;
+  configToken: string | undefined;
+}): ServiceConfigIssue | null {
+  const { serviceToken, configToken } = params;
+
+  // No drift if both are undefined/empty
+  if (!serviceToken && !configToken) {
+    return null;
+  }
+
+  // Drift: config has token, service has different or no token
+  if (configToken && serviceToken !== configToken) {
+    return {
+      code: SERVICE_AUDIT_CODES.gatewayTokenDrift,
+      message:
+        "Config token differs from service token. The daemon will use the old token after restart.",
+      detail: "Run `openclaw gateway install --force` to sync the token.",
+      level: "recommended",
+    };
+  }
+
+  return null;
 }
 
 export async function auditGatewayServiceConfig(params: {


### PR DESCRIPTION
## Summary

When the gateway token in config differs from the token embedded in the service plist/unit file, `restart` will not apply the new token. This can cause silent auth failures after OAuth token switches.

## Changes

- Add `checkTokenDrift()` to `service-audit.ts` - compares service token vs config token
- Call it in `runServiceRestart()` before restarting the service
- Warn user with suggestion to run `openclaw gateway install --force`

## Test Plan

- Added unit tests for `checkTokenDrift()` covering:
  - Matching tokens (no warning)
  - Different tokens (warning)
  - Missing tokens (appropriate behavior)

## Reproduction Steps (from issue)

1. Install gateway with token A
2. Change config to use token B (e.g., OAuth refresh)
3. Run `openclaw gateway restart`
4. Observe: no warning, but gateway still uses token A

With this fix, step 3 will show:
```
⚠️  Config token differs from service token. The daemon will use the old token after restart.
   Run `openclaw gateway install --force` to sync the token.
```

Closes #18018

cc @EmpireCreator - this should address the issue you reported

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a token drift detection mechanism to the daemon restart flow. When a user runs `openclaw gateway restart`, it now compares the token embedded in the service file (plist/systemd unit) against the current config/environment token. If they differ, a warning is displayed suggesting `openclaw gateway install --force` to sync.

- Adds `checkTokenDrift()` to `service-audit.ts` following the existing `ServiceConfigIssue` audit pattern
- Integrates the check into `runServiceRestart()` in `lifecycle-core.ts` as a non-fatal, best-effort operation
- Token resolution fallback chain (`cfg.gateway.auth.token` → `OPENCLAW_GATEWAY_TOKEN` → `CLAWDBOT_GATEWAY_TOKEN`) is consistent with the install flow
- Good test coverage for all meaningful token combination edge cases
- Minor gap: drift warning is suppressed in `--json` mode without being included in the JSON response `warnings` array, so programmatic consumers won't see it

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — the new check is non-fatal and wrapped in try/catch, with no impact on the restart flow itself.
- Score of 4 reflects a well-structured, low-risk change that follows existing patterns. The token drift check is best-effort and cannot break the restart flow. One minor gap (JSON mode suppression) prevents a score of 5 but is not a blocker.
- No files require special attention. The changes are straightforward and well-tested.

<sub>Last reviewed commit: 8add764</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->