### PR TITLE
fix(memory): qmd onBoot only initializes for default agent, skipping agents.list entries

### DIFF
--- a/src/gateway/server-startup-memory.test.ts
+++ b/src/gateway/server-startup-memory.test.ts
@@ -47,6 +47,22 @@ describe("startGatewayMemoryBackend", () => {
     expect(log.warn).not.toHaveBeenCalled();
   });
 
+  it("initializes qmd backend for all agents in agents.list", async () => {
+    const cfg = {
+      agents: { list: [{ id: "ops", default: true }, { id: "helper" }] },
+      memory: { backend: "qmd", qmd: {} },
+    } as OpenClawConfig;
+    const log = { info: vi.fn(), warn: vi.fn() };
+    getMemorySearchManagerMock.mockResolvedValue({ manager: { search: vi.fn() } });
+
+    await startGatewayMemoryBackend({ cfg, log });
+
+    expect(getMemorySearchManagerMock).toHaveBeenCalledWith({ cfg, agentId: "ops" });
+    expect(getMemorySearchManagerMock).toHaveBeenCalledWith({ cfg, agentId: "helper" });
+    expect(getMemorySearchManagerMock).toHaveBeenCalledTimes(2);
+    expect(log.info).toHaveBeenCalledTimes(2);
+  });
+
   it("logs a warning when qmd manager init fails", async () => {
     const cfg = {
       agents: { list: [{ id: "main", default: true }] },

--- a/src/gateway/server-startup-memory.ts
+++ b/src/gateway/server-startup-memory.ts
@@ -1,5 +1,6 @@
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { normalizeAgentId } from "../routing/session-key.js";
 import { resolveMemoryBackendConfig } from "../memory/backend-config.js";
 import { getMemorySearchManager } from "../memory/index.js";
 
@@ -7,18 +8,24 @@ export async function startGatewayMemoryBackend(params: {
   cfg: OpenClawConfig;
   log: { info?: (msg: string) => void; warn: (msg: string) => void };
 }): Promise<void> {
-  const agentId = resolveDefaultAgentId(params.cfg);
-  const resolved = resolveMemoryBackendConfig({ cfg: params.cfg, agentId });
-  if (resolved.backend !== "qmd" || !resolved.qmd) {
-    return;
-  }
+  const agentIds = new Set([
+    resolveDefaultAgentId(params.cfg),
+    ...(params.cfg.agents?.list ?? []).map((e) => normalizeAgentId(e?.id)),
+  ]);
 
-  const { manager, error } = await getMemorySearchManager({ cfg: params.cfg, agentId });
-  if (!manager) {
-    params.log.warn(
-      `qmd memory startup initialization failed for agent "${agentId}": ${error ?? "unknown error"}`,
-    );
-    return;
+  for (const agentId of agentIds) {
+    const resolved = resolveMemoryBackendConfig({ cfg: params.cfg, agentId });
+    if (resolved.backend !== "qmd" || !resolved.qmd) {
+      continue;
+    }
+
+    const { manager, error } = await getMemorySearchManager({ cfg: params.cfg, agentId });
+    if (!manager) {
+      params.log.warn(
+        `qmd memory startup initialization failed for agent "${agentId}": ${error ?? "unknown error"}`,
+      );
+      continue;
+    }
+    params.log.info?.(`qmd memory startup initialization armed for agent "${agentId}"`);
   }
-  params.log.info?.(`qmd memory startup initialization armed for agent "${agentId}"`);
 }

--- a/src/gateway/server-startup-memory.ts
+++ b/src/gateway/server-startup-memory.ts
@@ -1,17 +1,13 @@
 import type { OpenClawConfig } from "../config/config.js";
-import { resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { listAgentIds } from "../agents/agent-scope.js";
 import { resolveMemoryBackendConfig } from "../memory/backend-config.js";
 import { getMemorySearchManager } from "../memory/index.js";
-import { normalizeAgentId } from "../routing/session-key.js";
 
 export async function startGatewayMemoryBackend(params: {
   cfg: OpenClawConfig;
   log: { info?: (msg: string) => void; warn: (msg: string) => void };
 }): Promise<void> {
-  const agentIds = new Set([
-    resolveDefaultAgentId(params.cfg),
-    ...(params.cfg.agents?.list ?? []).map((e) => normalizeAgentId(e?.id)),
-  ]);
+  const agentIds = listAgentIds(params.cfg);
 
   for (const agentId of agentIds) {
     const resolved = resolveMemoryBackendConfig({ cfg: params.cfg, agentId });

--- a/src/gateway/server-startup-memory.ts
+++ b/src/gateway/server-startup-memory.ts
@@ -1,8 +1,8 @@
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
-import { normalizeAgentId } from "../routing/session-key.js";
 import { resolveMemoryBackendConfig } from "../memory/backend-config.js";
 import { getMemorySearchManager } from "../memory/index.js";
+import { normalizeAgentId } from "../routing/session-key.js";
 
 export async function startGatewayMemoryBackend(params: {
   cfg: OpenClawConfig;


### PR DESCRIPTION
## Problem

`startGatewayMemoryBackend` only called `resolveDefaultAgentId(cfg)` and initialized qmd for that single agent. Any additional agents defined in `cfg.agents.list` were silently skipped during boot.

## Fix

Collect all unique agent IDs (default agent + all entries from `cfg.agents.list`) into a `Set`, then loop over each to resolve and initialize qmd where configured.

## Test

Added test verifying `getMemorySearchManager` is called for every agent in the list, not just the default.

Fixes #17663

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where `startGatewayMemoryBackend` only initialized qmd memory for the default agent, silently skipping all other agents defined in `cfg.agents.list`. The fix replaces `resolveDefaultAgentId(cfg)` with `listAgentIds(cfg)` (an existing helper that collects all unique, normalized agent IDs) and loops over each to resolve and initialize qmd where configured.

- **Bug fix**: All agents in `agents.list` now get their qmd memory backend initialized on boot, not just the default agent
- **Clean refactor**: Uses the existing `listAgentIds` helper which already handles deduplication and `DEFAULT_AGENT_ID` fallback, avoiding code duplication
- **Test coverage**: New test verifies `getMemorySearchManager` is called for every agent in the list with correct call count assertions

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a straightforward, well-scoped bug fix with proper test coverage.
- The change is minimal and focused: it replaces a single-agent initialization with a loop over all agents using an existing, well-tested helper function (`listAgentIds`). The control flow change from `return` to `continue` is correct. The `resolveMemoryBackendConfig` and `getMemorySearchManager` functions already accept per-agent parameters, so no new integration surface is introduced. A new test explicitly verifies multi-agent initialization.
- No files require special attention.

<sub>Last reviewed commit: 8eb5934</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->