### PR TITLE
fix(Telegram): usage footer not sent to Telegram when blockStreaming is enabled (#17832)

### DIFF
--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -1085,6 +1085,165 @@ describe("runReplyAgent response usage footer", () => {
   });
 });
 
+describe("runReplyAgent usage footer sent when blockStreaming drops final payloads", () => {
+  function createBlockStreamingRun(params: {
+    responseUsage?: "tokens" | "full" | "off";
+    usage?: { input: number; output: number };
+  }) {
+    const onBlockReply = vi.fn();
+
+    runEmbeddedPiAgentMock.mockImplementationOnce(async (agentParams) => {
+      const block = agentParams.onBlockReply as
+        | ((payload: { text?: string }) => void)
+        | undefined;
+      block?.({ text: "Streamed chunk" });
+      return {
+        payloads: [{ text: "Final message" }],
+        meta: {
+          agentMeta: {
+            provider: "anthropic",
+            model: "claude",
+            usage: params.usage ?? { input: 100, output: 50 },
+          },
+        },
+      };
+    });
+
+    const typing = createMockTypingController();
+    const sessionCtx = {
+      Provider: "telegram",
+      OriginatingTo: "chat:123",
+      AccountId: "primary",
+      MessageSid: "msg",
+    } as unknown as TemplateContext;
+    const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
+
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      responseUsage: params.responseUsage ?? "full",
+    };
+
+    const sessionKey = "agent:main:telegram:dm:123";
+    const followupRun = {
+      prompt: "hello",
+      summaryLine: "hello",
+      enqueuedAt: Date.now(),
+      run: {
+        agentId: "main",
+        agentDir: "/tmp/agent",
+        sessionId: "session",
+        sessionKey,
+        messageProvider: "telegram",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: "/tmp",
+        config: {
+          agents: {
+            defaults: {
+              blockStreamingCoalesce: {
+                minChars: 1,
+                maxChars: 200,
+                idleMs: 0,
+              },
+            },
+          },
+        },
+        skillsSnapshot: {},
+        provider: "anthropic",
+        model: "claude",
+        thinkLevel: "low",
+        verboseLevel: "off",
+        elevatedLevel: "off",
+        bashElevated: {
+          enabled: false,
+          allowed: false,
+          defaultLevel: "off",
+        },
+        timeoutMs: 1_000,
+        blockReplyBreak: "text_end",
+      },
+    } as unknown as FollowupRun;
+
+    const resultPromise = runReplyAgent({
+      commandBody: "hello",
+      followupRun,
+      queueKey: "main",
+      resolvedQueue,
+      shouldSteer: false,
+      shouldFollowup: false,
+      isActive: false,
+      isStreaming: false,
+      opts: { onBlockReply },
+      typing,
+      sessionCtx,
+      sessionEntry,
+      sessionStore: { [sessionKey]: sessionEntry },
+      sessionKey,
+      defaultModel: "anthropic/claude-opus-4-5",
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: true,
+      blockReplyChunking: {
+        minChars: 1,
+        maxChars: 200,
+        breakPreference: "paragraph",
+      },
+      resolvedBlockStreamingBreak: "text_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+    });
+
+    return { resultPromise, onBlockReply, sessionKey };
+  }
+
+  it("sends usage footer as standalone payload when block streaming succeeded", async () => {
+    const { resultPromise, onBlockReply, sessionKey } = createBlockStreamingRun({
+      responseUsage: "full",
+    });
+    const result = await resultPromise;
+
+    expect(onBlockReply).toHaveBeenCalled();
+    expect(result).toBeDefined();
+    const text = String((result as { text?: string })?.text ?? "");
+    expect(text).toContain("Usage:");
+    expect(text).toContain(`· session ${sessionKey}`);
+  });
+
+  it("sends usage footer without session key when responseUsage=tokens", async () => {
+    const { resultPromise, onBlockReply } = createBlockStreamingRun({
+      responseUsage: "tokens",
+    });
+    const result = await resultPromise;
+
+    expect(onBlockReply).toHaveBeenCalled();
+    expect(result).toBeDefined();
+    const text = String((result as { text?: string })?.text ?? "");
+    expect(text).toContain("Usage:");
+    expect(text).not.toContain("· session ");
+  });
+
+  it("returns undefined when responseUsage=off and block streaming drops payloads", async () => {
+    const { resultPromise, onBlockReply } = createBlockStreamingRun({
+      responseUsage: "off",
+    });
+    const result = await resultPromise;
+
+    expect(onBlockReply).toHaveBeenCalled();
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when usage is zero and block streaming drops payloads", async () => {
+    const { resultPromise, onBlockReply } = createBlockStreamingRun({
+      responseUsage: "full",
+      usage: { input: 0, output: 0 },
+    });
+    const result = await resultPromise;
+
+    expect(onBlockReply).toHaveBeenCalled();
+    expect(result).toBeUndefined();
+  });
+});
+
 describe("runReplyAgent transient HTTP retry", () => {
   it("retries once after transient 521 HTML failure and then succeeds", async () => {
     vi.useFakeTimers();

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -416,7 +416,40 @@ export async function runReplyAgent(params: {
     const { replyPayloads } = payloadResult;
     didLogHeartbeatStrip = payloadResult.didLogHeartbeatStrip;
 
+    // Compute usage footer before the empty-payloads early return so it can
+    // still be sent when block streaming dropped the final payloads.
+    const responseUsageRaw =
+      activeSessionEntry?.responseUsage ??
+      (sessionKey ? activeSessionStore?.[sessionKey]?.responseUsage : undefined);
+    const responseUsageMode = resolveResponseUsageMode(responseUsageRaw);
+    if (responseUsageMode !== "off" && hasNonzeroUsage(usage)) {
+      const authMode = resolveModelAuthMode(providerUsed, cfg);
+      const showCost = authMode === "api-key";
+      const costConfig = showCost
+        ? resolveModelCostConfig({
+            provider: providerUsed,
+            model: modelUsed,
+            config: cfg,
+          })
+        : undefined;
+      let formatted = formatResponseUsageLine({
+        usage,
+        showCost,
+        costConfig,
+      });
+      if (formatted && responseUsageMode === "full" && sessionKey) {
+        formatted = `${formatted} · session ${sessionKey}`;
+      }
+      if (formatted) {
+        responseUsageLine = formatted;
+      }
+    }
+
     if (replyPayloads.length === 0) {
+      // When block streaming dropped final payloads, still deliver the usage footer.
+      if (responseUsageLine) {
+        return finalizeWithFollowup({ text: responseUsageLine }, queueKey, runFollowupTurn);
+      }
       return finalizeWithFollowup(undefined, queueKey, runFollowupTurn);
     }
 
@@ -458,33 +491,6 @@ export async function runReplyAgent(params: {
         costUsd,
         durationMs: Date.now() - runStartedAt,
       });
-    }
-
-    const responseUsageRaw =
-      activeSessionEntry?.responseUsage ??
-      (sessionKey ? activeSessionStore?.[sessionKey]?.responseUsage : undefined);
-    const responseUsageMode = resolveResponseUsageMode(responseUsageRaw);
-    if (responseUsageMode !== "off" && hasNonzeroUsage(usage)) {
-      const authMode = resolveModelAuthMode(providerUsed, cfg);
-      const showCost = authMode === "api-key";
-      const costConfig = showCost
-        ? resolveModelCostConfig({
-            provider: providerUsed,
-            model: modelUsed,
-            config: cfg,
-          })
-        : undefined;
-      let formatted = formatResponseUsageLine({
-        usage,
-        showCost,
-        costConfig,
-      });
-      if (formatted && responseUsageMode === "full" && sessionKey) {
-        formatted = `${formatted} · session ${sessionKey}`;
-      }
-      if (formatted) {
-        responseUsageLine = formatted;
-      }
     }
 
     // If verbose is enabled and this is a new session, prepend a session hint.


### PR DESCRIPTION
## Summary

When `blockStreaming: true` is set, the usage footer (`/usage full` or `/usage tokens`) never gets sent to the channel. TUI shows it fine, but Telegram/Discord/etc don't.

Closes #17832

lobster-biscuit

## Root Cause

`buildReplyPayloads` in `agent-runner-payloads.ts` sets `replyPayloads` to `[]` when block streaming succeeded (via `shouldDropFinalPayloads`). Back in `agent-runner.ts`, the `replyPayloads.length === 0` early return fires before the usage footer computation — so `appendUsageLine` is never reached.

## Changes

- Before: usage footer computation happens after the empty-payloads early return — gets skipped when block streaming drops final payloads
- After: usage footer is computed before the early return; if payloads are empty but a footer exists, it's sent as a standalone payload

Only `agent-runner.ts` changed (code motion + 4 new lines at the early return).

## Tests

- `agent-runner.misc.runreplyagent.test.ts` — 4 new tests covering the block streaming + usage footer interaction:
  - `responseUsage=full`: footer sent with session key
  - `responseUsage=tokens`: footer sent without session key
  - `responseUsage=off`: returns undefined, no footer
  - zero usage: returns undefined, no footer
- All 4 fail before fix, pass after
- All 386 tests in `src/auto-reply/reply/` pass

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes the bug where usage footers (`/usage full` or `/usage tokens`) were not sent to Telegram/Discord when `blockStreaming: true` is enabled. The fix moves the usage footer computation logic before the empty-payloads early return, allowing it to be sent as a standalone payload when block streaming drops final payloads.

- Moved usage footer computation (lines 421-446) to execute before the `replyPayloads.length === 0` check
- Added logic to send usage footer as standalone payload when block streaming succeeded but dropped final payloads (lines 450-451)
- Added 4 comprehensive tests covering all usage footer scenarios with block streaming enabled

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a clean code motion that addresses the exact root cause described in the PR. The logic is moved from after the early return to before it, with a simple 4-line addition to handle the edge case. The change is well-tested with 4 new tests covering all scenarios (responseUsage=full/tokens/off, zero usage), and all 386 existing tests pass.
- No files require special attention

<sub>Last reviewed commit: 4917272</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->