### PR TITLE
fix(feishu): fix mention detection for post messages with embedded docs

### DIFF
--- a/extensions/feishu/src/bot.checkBotMentioned.test.ts
+++ b/extensions/feishu/src/bot.checkBotMentioned.test.ts
@@ -61,4 +61,46 @@ describe("parseFeishuMessageEvent – mentionedBot", () => {
     const ctx = parseFeishuMessageEvent(event as any, "");
     expect(ctx.mentionedBot).toBe(false);
   });
+
+  it("returns mentionedBot=true for post message with at (no top-level mentions)", () => {
+    const BOT_OPEN_ID = "ou_bot_123";
+    const postContent = JSON.stringify({
+      content: [
+        [{ tag: "at", user_id: BOT_OPEN_ID, user_name: "claw" }],
+        [{ tag: "text", text: "What does this document say" }],
+      ],
+    });
+    const event = {
+      sender: { sender_id: { user_id: "u1", open_id: "ou_sender" } },
+      message: {
+        message_id: "msg_1",
+        chat_id: "oc_chat1",
+        chat_type: "group",
+        message_type: "post",
+        content: postContent,
+        mentions: [],
+      },
+    };
+    const ctx = parseFeishuMessageEvent(event as any, BOT_OPEN_ID);
+    expect(ctx.mentionedBot).toBe(true);
+  });
+
+  it("returns mentionedBot=false for post message with no at", () => {
+    const postContent = JSON.stringify({
+      content: [[{ tag: "text", text: "hello" }]],
+    });
+    const event = {
+      sender: { sender_id: { user_id: "u1", open_id: "ou_sender" } },
+      message: {
+        message_id: "msg_1",
+        chat_id: "oc_chat1",
+        chat_type: "group",
+        message_type: "post",
+        content: postContent,
+        mentions: [],
+      },
+    };
+    const ctx = parseFeishuMessageEvent(event as any, "ou_bot_123");
+    expect(ctx.mentionedBot).toBe(false);
+  });
 });

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -274,7 +274,6 @@ function getMentionedOpenIdsFromPost(content: string): string[] {
 /**
  * Parse post (rich text) content and extract embedded image keys.
  * Post structure: { title?: string, content: [[{ tag, text?, image_key?, ... }]] }
- * or { zh_cn: { title?, content: [...] } } when received from Feishu.
  */
 function parsePostContent(content: string): {
   textContent: string;
@@ -282,9 +281,8 @@ function parsePostContent(content: string): {
 } {
   try {
     const parsed = JSON.parse(content);
-    const locale = parsed.zh_cn ?? parsed;
-    const title = locale.title || "";
-    const contentBlocks = locale.content || [];
+    const title = parsed.title || "";
+    const contentBlocks = parsed.content || [];
     let textContent = title ? `${title}\n\n` : "";
     const imageKeys: string[] = [];
 


### PR DESCRIPTION
## Summary

- Problem: When users send post (rich text) messages with embedded documents
  in Feishu groups, the bot fails to detect @mentions because
  message.mentions array is empty. Messages are only recorded to history
  without triggering bot responses.

- Why it matters: Users cannot interact with the bot when pasting documents
  or sending rich text messages, breaking the expected @mention workflow.

- What changed: Added getMentionedOpenIdsFromPost() to parse "at" elements
  from post content JSON. Updated checkBotMentioned() to fallback to parsing
  post content when message.mentions is empty and message_type is "post".
  Updated parsePostContent() to handle both top-level content and zh_cn
  locale wrapper. Changed Chinese placeholder text to English.

- What did NOT change: Text message mention detection (still uses
  message.mentions). Other message types unchanged. No API changes.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations (Feishu channel)
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## User-visible / Behavior Changes

Bot now correctly responds to @mentions in post (rich text) messages
containing embedded documents. Previously these messages were silently
recorded to history only.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- Integration/channel: Feishu group chat
- Message type: post (rich text) with embedded document

### Steps

1. Send a post message in Feishu group with @claw mention and embedded doc
2. Check gateway logs
3. Verify bot responds instead of only recording to history

### Expected

Bot detects mention and responds.

### Actual (before fix)

Bot logs "did not mention bot, recording to history" and does not respond.

## Evidence

- Added unit tests for post message mention detection
- All existing tests pass (7/7)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where the Feishu bot failed to detect `@mentions` in post (rich text) messages with embedded documents because `message.mentions` was empty in those cases. The fix adds `getMentionedOpenIdsFromPost()` to parse "at" elements directly from the post JSON content, and `checkBotMentioned()` now falls back to this parser when `message.mentions` is empty for post-type messages. Additionally, `parsePostContent()` is updated to handle the `zh_cn` locale wrapper that Feishu uses for post content, and Chinese placeholder text is changed to English.

- The core fix is sound: when `message.mentions` is empty and the message type is `"post"`, the bot now parses the post body for "at" elements to detect mentions
- Minor inconsistency: `getMentionedOpenIdsFromPost()` and `parsePostContent()` resolve the locale wrapper in different priority orders (`content` first vs `zh_cn` first), which could diverge in edge cases
- Two new unit tests cover the happy path and negative case for post mention detection, though the `zh_cn` locale wrapper path is not tested

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it fixes a real user-facing bug with a well-scoped fallback that doesn't affect existing text message mention detection.
- The fix is narrowly scoped to post-type messages with empty mentions arrays, preserving existing behavior for text messages. The locale resolution inconsistency between the two parsing functions is a minor style concern, not a functional bug in practice. Tests cover the main scenarios.
- `extensions/feishu/src/bot.ts` — the locale resolution logic in `getMentionedOpenIdsFromPost()` differs from `parsePostContent()` in priority order.

<sub>Last reviewed commit: 3fb4639</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->