### PR TITLE
fix: deduplicate TTS audio delivered via tool results

### DIFF
--- a/src/agents/pi-embedded-runner/run.overflow-compaction.fixture.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.fixture.ts
@@ -16,6 +16,7 @@ export function makeAttemptResult(
     didSendViaMessagingTool: false,
     messagingToolSentTexts: [],
     messagingToolSentTargets: [],
+    toolResultMediaPaths: [],
     cloudCodeAssistFormatError: false,
     ...overrides,
   };

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -946,6 +946,7 @@ export async function runEmbeddedPiAgent(
               didSendViaMessagingTool: attempt.didSendViaMessagingTool,
               messagingToolSentTexts: attempt.messagingToolSentTexts,
               messagingToolSentTargets: attempt.messagingToolSentTargets,
+              toolResultMediaPaths: attempt.toolResultMediaPaths,
             };
           }
 
@@ -987,6 +988,7 @@ export async function runEmbeddedPiAgent(
             didSendViaMessagingTool: attempt.didSendViaMessagingTool,
             messagingToolSentTexts: attempt.messagingToolSentTexts,
             messagingToolSentTargets: attempt.messagingToolSentTargets,
+            toolResultMediaPaths: attempt.toolResultMediaPaths,
           };
         }
       } finally {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -756,6 +756,7 @@ export async function runEmbeddedAttempt(
         waitForCompactionRetry,
         getMessagingToolSentTexts,
         getMessagingToolSentTargets,
+        getToolResultMediaPaths,
         didSendViaMessagingTool,
         getLastToolError,
         getUsageTotals,
@@ -1169,6 +1170,7 @@ export async function runEmbeddedAttempt(
         didSendViaMessagingTool: didSendViaMessagingTool(),
         messagingToolSentTexts: getMessagingToolSentTexts(),
         messagingToolSentTargets: getMessagingToolSentTargets(),
+        toolResultMediaPaths: getToolResultMediaPaths(),
         cloudCodeAssistFormatError: Boolean(
           lastAssistant?.errorMessage && isCloudCodeAssistFormatError(lastAssistant.errorMessage),
         ),

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -43,6 +43,7 @@ export type EmbeddedRunAttemptResult = {
   didSendViaMessagingTool: boolean;
   messagingToolSentTexts: string[];
   messagingToolSentTargets: MessagingToolSend[];
+  toolResultMediaPaths: string[];
   cloudCodeAssistFormatError: boolean;
   attemptUsage?: NormalizedUsage;
   compactionCount?: number;

--- a/src/agents/pi-embedded-runner/types.ts
+++ b/src/agents/pi-embedded-runner/types.ts
@@ -65,6 +65,8 @@ export type EmbeddedPiRunResult = {
   messagingToolSentTexts?: string[];
   // Messaging tool targets that successfully sent a message during the run.
   messagingToolSentTargets?: MessagingToolSend[];
+  // Media paths already delivered via tool results (for dedup against follow-up messages).
+  toolResultMediaPaths?: string[];
 };
 
 export type EmbeddedPiCompactResult = {

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -70,6 +70,7 @@ export type EmbeddedPiSubscribeState = {
   messagingToolSentTexts: string[];
   messagingToolSentTextsNormalized: string[];
   messagingToolSentTargets: MessagingToolSend[];
+  toolResultMediaPaths: string[];
   pendingMessagingTexts: Map<string, string>;
   pendingMessagingTargets: Map<string, MessagingToolSend>;
   lastAssistant?: AgentMessage;

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -71,6 +71,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     messagingToolSentTexts: [],
     messagingToolSentTextsNormalized: [],
     messagingToolSentTargets: [],
+    toolResultMediaPaths: [],
     pendingMessagingTexts: new Map(),
     pendingMessagingTargets: new Map(),
   };
@@ -576,6 +577,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     messagingToolSentTexts.length = 0;
     messagingToolSentTextsNormalized.length = 0;
     messagingToolSentTargets.length = 0;
+    state.toolResultMediaPaths.length = 0;
     pendingMessagingTexts.clear();
     pendingMessagingTargets.clear();
     resetAssistantMessageState(0);
@@ -662,6 +664,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     isCompactionInFlight: () => state.compactionInFlight,
     getMessagingToolSentTexts: () => messagingToolSentTexts.slice(),
     getMessagingToolSentTargets: () => messagingToolSentTargets.slice(),
+    getToolResultMediaPaths: () => state.toolResultMediaPaths.slice(),
     // Returns true if any messaging tool successfully sent a message.
     // Used to suppress agent's confirmation text (e.g., "Respondi no Telegram!")
     // which is generated AFTER the tool sends the actual answer.

--- a/src/agents/tools/tts-tool.ts
+++ b/src/agents/tools/tts-tool.ts
@@ -21,7 +21,8 @@ export function createTtsTool(opts?: {
     label: "TTS",
     name: "tts",
     description:
-      "Convert text to speech and return a MEDIA: path. Use when the user requests audio or TTS is enabled. Copy the MEDIA line exactly.",
+      "Convert text to speech and return a MEDIA: path. Use when the user requests audio or TTS is enabled. The audio is delivered automatically from the tool result; do not repeat the MEDIA line in your reply.",
+
     parameters: TtsToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -27,6 +27,7 @@ export function buildReplyPayloads(params: {
   currentMessageId?: string;
   messageProvider?: string;
   messagingToolSentTexts?: string[];
+  toolResultMediaPaths?: string[];
   messagingToolSentTargets?: Parameters<
     typeof shouldSuppressMessagingToolReplies
   >[0]["messagingToolSentTargets"];
@@ -92,6 +93,7 @@ export function buildReplyPayloads(params: {
   const dedupedPayloads = filterMessagingToolDuplicates({
     payloads: replyTaggedPayloads,
     sentTexts: messagingToolSentTexts,
+    sentMediaPaths: params.toolResultMediaPaths ?? [],
   });
   // Filter out payloads already sent via pipeline or directly during tool flush.
   const filteredPayloads = shouldDropFinalPayloads

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -409,6 +409,7 @@ export async function runReplyAgent(params: {
       currentMessageId: sessionCtx.MessageSidFull ?? sessionCtx.MessageSid,
       messageProvider: followupRun.run.messageProvider,
       messagingToolSentTexts: runResult.messagingToolSentTexts,
+      toolResultMediaPaths: runResult.toolResultMediaPaths,
       messagingToolSentTargets: runResult.messagingToolSentTargets,
       originatingTo: sessionCtx.OriginatingTo ?? sessionCtx.To,
       accountId: sessionCtx.AccountId,

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -250,6 +250,7 @@ export function createFollowupRunner(params: {
       const dedupedPayloads = filterMessagingToolDuplicates({
         payloads: replyTaggedPayloads,
         sentTexts: runResult.messagingToolSentTexts ?? [],
+        sentMediaPaths: runResult.toolResultMediaPaths ?? [],
       });
       const suppressMessagingToolReplies = shouldSuppressMessagingToolReplies({
         messageProvider: queued.run.messageProvider,

--- a/src/auto-reply/reply/reply-payloads.media-dedup.test.ts
+++ b/src/auto-reply/reply/reply-payloads.media-dedup.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import type { ReplyPayload } from "../types.js";
+import { filterMessagingToolDuplicates } from "./reply-payloads.js";
+
+describe("filterMessagingToolDuplicates – media path dedup", () => {
+  it("drops payload whose only content is a duplicate media path", () => {
+    const payloads: ReplyPayload[] = [{ mediaUrl: "/tmp/tts-123/voice.mp3" }];
+    const result = filterMessagingToolDuplicates({
+      payloads,
+      sentTexts: [],
+      sentMediaPaths: ["/tmp/tts-123/voice.mp3"],
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("keeps payload with duplicate media but meaningful text", () => {
+    const payloads: ReplyPayload[] = [
+      { text: "Here is the audio", mediaUrl: "/tmp/tts-123/voice.mp3" },
+    ];
+    const result = filterMessagingToolDuplicates({
+      payloads,
+      sentTexts: [],
+      sentMediaPaths: ["/tmp/tts-123/voice.mp3"],
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].text).toBe("Here is the audio");
+  });
+
+  it("is case-insensitive for media path comparison", () => {
+    const payloads: ReplyPayload[] = [{ mediaUrl: "/tmp/TTS-123/Voice.mp3" }];
+    const result = filterMessagingToolDuplicates({
+      payloads,
+      sentTexts: [],
+      sentMediaPaths: ["/tmp/tts-123/voice.mp3"],
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("keeps payload when media path is not in sentMediaPaths", () => {
+    const payloads: ReplyPayload[] = [{ mediaUrl: "/tmp/tts-456/voice.mp3" }];
+    const result = filterMessagingToolDuplicates({
+      payloads,
+      sentTexts: [],
+      sentMediaPaths: ["/tmp/tts-123/voice.mp3"],
+    });
+    expect(result).toHaveLength(1);
+  });
+
+  it("works with no sentMediaPaths (backward compat)", () => {
+    const payloads: ReplyPayload[] = [{ text: "hello world this is a test" }];
+    const result = filterMessagingToolDuplicates({
+      payloads,
+      sentTexts: [],
+    });
+    expect(result).toHaveLength(1);
+  });
+
+  it("combines text and media dedup", () => {
+    const payloads: ReplyPayload[] = [
+      { text: "already sent this text message" },
+      { mediaUrl: "/tmp/tts-123/voice.mp3" },
+      { text: "new message" },
+    ];
+    const result = filterMessagingToolDuplicates({
+      payloads,
+      sentTexts: ["already sent this text message"],
+      sentMediaPaths: ["/tmp/tts-123/voice.mp3"],
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].text).toBe("new message");
+  });
+
+  it("drops media-only payload with whitespace-only text", () => {
+    const payloads: ReplyPayload[] = [{ text: "  \n  ", mediaUrl: "/tmp/tts-123/voice.mp3" }];
+    const result = filterMessagingToolDuplicates({
+      payloads,
+      sentTexts: [],
+      sentMediaPaths: ["/tmp/tts-123/voice.mp3"],
+    });
+    expect(result).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem

When the TTS tool returns a `MEDIA:` path, the audio is delivered immediately from the tool result. However, the model often echoes the `MEDIA:` line in its follow-up assistant message (encouraged by the old "Copy the MEDIA line exactly" instruction), causing the same audio file to be sent to the user twice.

Closes #17991

## Root Cause

Two issues:
1. **TTS tool description** explicitly instructs the model to "Copy the MEDIA line exactly" — directly causing the duplicate
2. **`filterMessagingToolDuplicates`** only deduplicates text content, not media paths — so even if the model echoes the MEDIA path, there's no safety net

## Fix

Two-layer approach:

### Layer 1: Prevent (tool description)
Updated TTS tool description to tell the model the audio is delivered automatically and NOT to repeat the MEDIA line.

### Layer 2: Catch (media path dedup)
Added `toolResultMediaPaths` tracking through the full pipeline:
- `pi-embedded-subscribe` state tracks media paths extracted from tool results
- Paths flow through: subscribe → attempt result → run result → dedup callsites
- `filterMessagingToolDuplicates` now accepts optional `sentMediaPaths` and drops payloads whose only content is a duplicate media path
- Payloads with duplicate media but meaningful text are kept (only media stripped conceptually)

### Files Changed
- `tts-tool.ts` — updated description
- `pi-embedded-subscribe.handlers.tools.ts` — track delivered media paths in both `emitToolOutput` and direct `onToolResult` paths
- `pi-embedded-subscribe.handlers.types.ts` — added `toolResultMediaPaths` to state type
- `pi-embedded-subscribe.ts` — init + reset + expose getter
- `run/attempt.ts` — destructure + pass through
- `run/types.ts` — added to attempt result type
- `run.ts` — pass through to run result (both code paths)
- `pi-embedded-runner/types.ts` — added to run result type
- `agent-runner.ts` — pass to `buildReplyPayloads`
- `agent-runner-payloads.ts` — accept + forward to dedup
- `followup-runner.ts` — forward to dedup
- `reply-payloads.ts` — enhanced `filterMessagingToolDuplicates`
- `reply-payloads.media-dedup.test.ts` — 7 new tests

## Testing
- 7 new unit tests covering media path dedup (case insensitivity, text+media combos, backward compat, whitespace-only text)
- All 389 existing tests pass with zero regressions

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes duplicate TTS audio delivery with a well-structured two-layer approach: (1) updating the TTS tool description to stop telling the model to echo `MEDIA:` lines, and (2) adding a dedup safety net that tracks media paths delivered via tool results and filters them out of follow-up assistant messages.

- **Layer 1 (Prevention):** The TTS tool description in `tts-tool.ts` is updated to tell the model the audio is delivered automatically, removing the "Copy the MEDIA line exactly" instruction that was directly causing duplicates.
- **Layer 2 (Safety net):** `toolResultMediaPaths` tracking is plumbed through the full pipeline: subscribe state → attempt result → run result → `buildReplyPayloads` → `filterMessagingToolDuplicates`. The dedup function now accepts optional `sentMediaPaths` and drops payloads whose only content is a duplicate media path (case-insensitive matching). Payloads with meaningful text alongside duplicate media are preserved.
- **Testing:** 7 new unit tests cover the key dedup scenarios. The fixture file is updated for type compliance.
- **Minor gap:** The dedup only checks `mediaUrl` (singular), not `mediaUrls` (plural). Since `mediaUrl` is always set to the first element when `mediaUrls` is present, this covers the primary TTS use case but wouldn't catch secondary media paths in multi-media payloads.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk — changes are additive and backward-compatible, with good test coverage.
- Score of 4 reflects: clean two-layer approach with both prevention and safety net, consistent plumbing through a complex pipeline, 7 new tests with zero regressions, and backward compatibility (sentMediaPaths is optional with default []). Docked one point for the minor mediaUrls (plural) dedup gap, though it doesn't affect the primary TTS use case.
- `src/auto-reply/reply/reply-payloads.ts` — the core dedup logic only checks `mediaUrl` (singular), not `mediaUrls` (plural), which could matter for future multi-media tool results.

<sub>Last reviewed commit: 3bc21bb</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->