### PR TITLE
Add log types (feat/cfg/dbg) to implementation logs

### DIFF
--- a/scripts/new-feature.sh
+++ b/scripts/new-feature.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+set -euo pipefail
+
+# new-feature.sh — Create a feature branch and scaffold an implementation log
+#
+# Usage: ./scripts/new-feature.sh [--type feat|cfg|dbg] <name>
+# Example: ./scripts/new-feature.sh fix-auth-redirect
+# Example: ./scripts/new-feature.sh --type dbg gateway-startup
+#
+# This will:
+#   1. Ensure you're on main and it's clean
+#   2. Create branch feature/<name>
+#   3. Create _work/implementation_log/MMDDYY-HHMM-<type>-<name>.md from template
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PROJECT_ROOT="$(cd "$REPO_ROOT/.." && pwd)"
+LOG_DIR="$PROJECT_ROOT/_work/implementation_log"
+TEMPLATE="$LOG_DIR/_TEMPLATE.md"
+
+LOG_TYPE="feat"
+
+# Parse --type flag
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --type)
+      LOG_TYPE="$2"
+      if [[ "$LOG_TYPE" != "feat" && "$LOG_TYPE" != "cfg" && "$LOG_TYPE" != "dbg" ]]; then
+        echo "ERROR: Invalid type '$LOG_TYPE'. Must be: feat, cfg, or dbg"
+        exit 1
+      fi
+      shift 2
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+if [ $# -lt 1 ]; then
+  echo "Usage: ./scripts/new-feature.sh [--type feat|cfg|dbg] <name>"
+  echo "  Types: feat (default), cfg (config/settings), dbg (troubleshooting)"
+  echo "Example: ./scripts/new-feature.sh fix-auth-redirect"
+  echo "Example: ./scripts/new-feature.sh --type dbg gateway-startup"
+  exit 1
+fi
+
+FEATURE_NAME="$1"
+BRANCH_NAME="feature/$FEATURE_NAME"
+
+cd "$REPO_ROOT"
+
+# Check for clean working tree
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo "ERROR: Working tree is not clean. Commit or stash your changes first."
+  exit 1
+fi
+
+# Check we're on main
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+if [ "$CURRENT_BRANCH" != "main" ]; then
+  echo "WARNING: You're on '$CURRENT_BRANCH', not 'main'."
+  read -rp "Switch to main before branching? [Y/n] " answer
+  if [ "${answer,,}" != "n" ]; then
+    git checkout main
+  fi
+fi
+
+# Create the feature branch
+echo "Creating branch: $BRANCH_NAME"
+git checkout -b "$BRANCH_NAME"
+
+# Generate the log file
+TIMESTAMP="$(date +%m%d%y-%H%M)"
+LOG_FILE="$LOG_DIR/${TIMESTAMP}-${LOG_TYPE}-${FEATURE_NAME}.md"
+
+mkdir -p "$LOG_DIR"
+
+if [ -f "$TEMPLATE" ]; then
+  # Copy template and fill in known values
+  sed \
+    -e "s/<Name>/${FEATURE_NAME}/g" \
+    -e "s/YYYY-MM-DD HH:MM/$(date '+%Y-%m-%d %H:%M')/g" \
+    -e "s/feat | cfg | dbg/${LOG_TYPE}/g" \
+    -e "s|feature/<name>|${BRANCH_NAME}|g" \
+    "$TEMPLATE" > "$LOG_FILE"
+else
+  # Fallback if template is missing
+  cat > "$LOG_FILE" <<EOF
+# Implementation Log: ${FEATURE_NAME}
+
+**Date started:** $(date '+%Y-%m-%d %H:%M')
+**Type:** ${LOG_TYPE}
+**Branch:** \`${BRANCH_NAME}\`
+**Status:** In Progress
+**Date completed:** —
+
+---
+
+## Goal
+
+## Desired Outcome
+
+## Plan
+
+## Progress
+
+## Testing
+
+## Files Changed
+
+## Notes
+EOF
+fi
+
+echo ""
+echo "=== Feature setup complete ==="
+echo "Branch:  $BRANCH_NAME"
+echo "Log:     $LOG_FILE"
+echo ""
+echo "Next steps:"
+echo "  1. Edit the implementation log with your plan"
+echo "  2. Implement the change"
+echo "  3. Test: pnpm build && pnpm check && pnpm test"
+echo "  4. Push: git push -u origin $BRANCH_NAME"
+echo "  5. Open PR: gh pr create"

--- a/scripts/sync-upstream.sh
+++ b/scripts/sync-upstream.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "=== OpenClaw Upstream Sync ==="
+
+# Ensure we're in the repo root
+cd "$(git rev-parse --show-toplevel)"
+
+# Ensure working tree is clean
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo "ERROR: Working tree is not clean. Commit or stash your changes first."
+  exit 1
+fi
+
+# Save current branch
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+
+echo "1/6  Fetching upstream..."
+git fetch upstream
+
+echo "2/6  Switching to main..."
+git checkout main
+
+echo "3/6  Rebasing main onto upstream/main..."
+git rebase upstream/main
+# If rebase fails, it will exit here due to set -e.
+# User resolves conflicts manually, then re-runs the script.
+
+echo "4/6  Force-pushing main to origin..."
+# Temporarily disable branch protection
+gh api repos/AlbinB/openclaw/branches/main/protection \
+  --method DELETE --silent 2>/dev/null || true
+
+OPENCLAW_SYNC=1 git push origin main --force-with-lease
+
+# Re-enable branch protection
+gh api repos/AlbinB/openclaw/branches/main/protection \
+  --method PUT --silent --input - <<'GHEOF' 2>/dev/null || true
+{
+  "required_pull_request_reviews": {
+    "required_approving_review_count": 0
+  },
+  "enforce_admins": true,
+  "required_status_checks": null,
+  "restrictions": null
+}
+GHEOF
+
+echo "5/6  Installing dependencies & building..."
+pnpm install
+pnpm ui:build
+pnpm build
+
+echo "6/6  Installing globally..."
+pnpm link --global
+
+echo ""
+echo "=== Sync complete! ==="
+echo "Your commits on top of upstream:"
+git log upstream/main..main --oneline
+
+# Return to previous branch
+if [ "$CURRENT_BRANCH" != "main" ]; then
+  git checkout "$CURRENT_BRANCH"
+  echo "Returned to branch: $CURRENT_BRANCH"
+fi


### PR DESCRIPTION
## Summary
- Adds `--type feat|cfg|dbg` flag to `new-feature.sh` (defaults to `feat`)
- Updates filename format from `MMDDYYYY-HHMM-<name>` to `MMDDYY-HHMM-<type>-<name>`
- Tracks `sync-upstream.sh` in the repo

Also updated outside the git repo (not in this PR):
- `CLAUDE.md` — documents new naming convention and log types
- `_TEMPLATE.md` — added Type field
- Retroactive debug log for gateway startup troubleshooting
- `MEMORY.md` — updated naming convention

Implementation log: `_work/implementation_log/021626-0035-cfg-log-types.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds log type categorization (feat/cfg/dbg) to the `new-feature.sh` script and tracks `sync-upstream.sh` in the repository. The `new-feature.sh` changes look good - the flag parsing is correct, date format updated to MMDDYY-HHMM, and the type is properly integrated into the filename and template. 

**Critical issue**: `sync-upstream.sh` contains hardcoded personal repository references (`AlbinB/openclaw`) on lines 31 and 37 that should be replaced with dynamic repository detection to work correctly in the upstream `openclaw/openclaw` repository.

<h3>Confidence Score: 2/5</h3>

- This PR contains critical hardcoded repository references that will cause the sync script to fail in the upstream repository
- The `new-feature.sh` implementation is solid, but `sync-upstream.sh` has hardcoded personal repo paths (`AlbinB/openclaw`) that must be fixed before merging to the upstream repository, as they will cause the script to fail or behave incorrectly
- `scripts/sync-upstream.sh` requires immediate attention to fix hardcoded repository references

<sub>Last reviewed commit: e1d5761</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->