### PR TITLE
fix(gateway): trim trusted proxy entries before matching

### DIFF
--- a/src/gateway/net.test.ts
+++ b/src/gateway/net.test.ts
@@ -22,6 +22,10 @@ describe("isTrustedProxyAddress", () => {
         true,
       );
     });
+
+    it("ignores surrounding whitespace in exact IP entries", () => {
+      expect(isTrustedProxyAddress("10.0.0.5", [" 10.0.0.5 "])).toBe(true);
+    });
   });
 
   describe("CIDR subnet matching", () => {
@@ -100,6 +104,10 @@ describe("isTrustedProxyAddress", () => {
       expect(isTrustedProxyAddress("10.42.0.59", ["10.42.0.0/33"])).toBe(false); // invalid prefix
       expect(isTrustedProxyAddress("10.42.0.59", ["10.42.0.0/-1"])).toBe(false); // negative prefix
       expect(isTrustedProxyAddress("10.42.0.59", ["invalid/24"])).toBe(false); // invalid IP
+    });
+
+    it("ignores surrounding whitespace in CIDR entries", () => {
+      expect(isTrustedProxyAddress("10.42.0.59", [" 10.42.0.0/24 "])).toBe(true);
     });
   });
 });

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -210,12 +210,16 @@ export function isTrustedProxyAddress(ip: string | undefined, trustedProxies?: s
   }
 
   return trustedProxies.some((proxy) => {
+    const candidate = proxy.trim();
+    if (!candidate) {
+      return false;
+    }
     // Handle CIDR notation
-    if (proxy.includes("/")) {
-      return ipMatchesCIDR(normalized, proxy);
+    if (candidate.includes("/")) {
+      return ipMatchesCIDR(normalized, candidate);
     }
     // Exact IP match
-    return normalizeIp(proxy) === normalized;
+    return normalizeIp(candidate) === normalized;
   });
 }
 


### PR DESCRIPTION
## Summary
- trim `trustedProxies` entries before exact/CIDR matching
- add tests to ensure whitespace-padded config values still match

## Problem
`isTrustedProxyAddress` currently uses `trustedProxies` values as-is.

If config entries contain leading/trailing whitespace (common in copied env/config values), proxy matching fails even for valid IP/CIDR entries.

## Root cause
Proxy entries were not normalized with `.trim()` before `includes("/")`, CIDR matching, or exact IP normalization.

## Fix
- trim each proxy candidate before matching
- skip empty entries after trimming

## Validation
Added tests in `src/gateway/net.test.ts` for:
- exact IP with surrounding whitespace
- CIDR with surrounding whitespace

## AI-assisted
This PR was AI-assisted.

## Testing level
Lightly tested (targeted unit test updates; full suite not run locally).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Trims whitespace from `trustedProxies` config entries before matching in `isTrustedProxyAddress`, preventing proxy authentication failures when config values contain leading/trailing whitespace. The fix normalizes both exact IP and CIDR entries, and skips empty strings after trimming. Tests added for both exact IP and CIDR matching with surrounding whitespace.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a focused bug fix that adds defensive normalization (trimming whitespace) to improve robustness when handling user-provided config values. The implementation is simple, correct, and well-tested with no side effects on existing functionality.
- No files require special attention

<sub>Last reviewed commit: 53f7721</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->