### PR TITLE
fix(webchat): strip reply/audio directive tags before rendering #18079

### DIFF
--- a/ui/src/ui/chat/message-extract.test.ts
+++ b/ui/src/ui/chat/message-extract.test.ts
@@ -25,6 +25,48 @@ describe("extractTextCached", () => {
   });
 });
 
+describe("extractText strips directive tags from assistant messages", () => {
+  it("strips [[reply_to_current]]", () => {
+    const message = {
+      role: "assistant",
+      content: "Hello there [[reply_to_current]]",
+    };
+    expect(extractText(message)).toBe("Hello there");
+  });
+
+  it("strips [[reply_to:<id>]]", () => {
+    const message = {
+      role: "assistant",
+      content: [{ type: "text", text: "Done [[reply_to: abc123]]" }],
+    };
+    expect(extractText(message)).toBe("Done");
+  });
+
+  it("strips [[audio_as_voice]]", () => {
+    const message = {
+      role: "assistant",
+      content: "Listen up [[audio_as_voice]]",
+    };
+    expect(extractText(message)).toBe("Listen up");
+  });
+
+  it("does not strip tags from user messages", () => {
+    const message = {
+      role: "user",
+      content: "Hello [[reply_to_current]]",
+    };
+    expect(extractText(message)).toBe("Hello [[reply_to_current]]");
+  });
+
+  it("strips tag from .text property", () => {
+    const message = {
+      role: "assistant",
+      text: "Hi [[reply_to_current]]",
+    };
+    expect(extractText(message)).toBe("Hi");
+  });
+});
+
 describe("extractThinkingCached", () => {
   it("matches extractThinking output", () => {
     const message = {


### PR DESCRIPTION
## Problem

The webchat UI renders `[[reply_to_current]]`, `[[reply_to:<id>]]`, and `[[audio_as_voice]]` tags as literal text in assistant messages. These inline directive tags should be silently consumed per the system prompt documentation.

## Root Cause

`extractText()` in `ui/src/ui/chat/message-extract.ts` passes assistant content through `stripThinkingTags()` but never strips inline directive tags. The backend streaming path (`createStreamingDirectiveAccumulator`) strips them during live streaming, but messages loaded from the session transcript (history view) bypass that path entirely.

## Fix

Add `stripDirectiveTags()` to the UI chat layer that mirrors the regex from `src/utils/directive-tags.ts`. Apply it to all three `extractText()` code paths (string content, content array, `.text` property) for assistant messages only.

- 2 files changed, ~65 insertions
- 5 new test cases covering all tag variants + user message passthrough

## Testing

- `npx vitest run src/ui/chat/message-extract.test.ts` — 9/9 pass
- Verified regex matches the canonical patterns in `src/utils/directive-tags.ts`

Fixes #18079

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds client-side stripping of inline directive tags (`[[reply_to_current]]`, `[[reply_to:<id>]]`, `[[audio_as_voice]]`) in the webchat UI's `extractText()` function, fixing #18079 where these tags rendered as literal text in assistant messages loaded from session history.

- A new `stripDirectiveTags()` function is applied to all three `extractText()` code paths (string content, content array, `.text` property) for assistant messages only
- The regex and whitespace normalization logic are duplicated from `src/utils/directive-tags.ts` rather than imported — consider reusing `parseInlineDirectives` from the canonical source (the file already imports from `../../../../src/shared/`, so the path is accessible) to avoid divergence
- **Bug**: The replacement string is `""` (empty) instead of `" "` (space) as used in the canonical `parseInlineDirectives`, which will merge adjacent words when tags lack surrounding whitespace
- 5 new test cases provide good coverage of the main scenarios

<h3>Confidence Score: 3/5</h3>

- The PR addresses a valid UI rendering bug but introduces a subtle word-merging regression when directive tags lack surrounding whitespace.
- The overall approach is correct and well-tested for the common case. However, replacing tags with an empty string instead of a space (diverging from the canonical implementation) can merge adjacent words. This is a low-severity display bug but should be fixed before merging to maintain behavioral parity with the backend.
- `ui/src/ui/chat/message-extract.ts` — the `stripDirectiveTags` replacement string should be `" "` instead of `""` to match canonical behavior.

<sub>Last reviewed commit: aba9943</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->