### PR TITLE
fix(security): prevent ReDoS in session filter patterns (CWE-1333)

### DIFF
--- a/src/discord/monitor/exec-approvals.ts
+++ b/src/discord/monitor/exec-approvals.ts
@@ -361,7 +361,11 @@ export class DiscordExecApprovalHandler {
       if (!session) {
         return false;
       }
-      const matches = config.sessionFilter.some((p) => safePatternMatch(session, p));
+      const matches = config.sessionFilter.some((p) =>
+        safePatternMatch(session, p, {
+          warn: (msg, ctx) => logDebug(`${msg}: ${JSON.stringify(ctx)}`),
+        }),
+      );
       if (!matches) {
         return false;
       }

--- a/src/discord/monitor/exec-approvals.ts
+++ b/src/discord/monitor/exec-approvals.ts
@@ -29,6 +29,7 @@ import {
   GATEWAY_CLIENT_NAMES,
   normalizeMessageChannel,
 } from "../../utils/message-channel.js";
+import { safePatternMatch } from "../../utils/safe-regex.js";
 import { createDiscordClient, stripUndefinedFields } from "../send.shared.js";
 import { DiscordUiContainer } from "../ui.js";
 
@@ -360,13 +361,7 @@ export class DiscordExecApprovalHandler {
       if (!session) {
         return false;
       }
-      const matches = config.sessionFilter.some((p) => {
-        try {
-          return session.includes(p) || new RegExp(p).test(session);
-        } catch {
-          return session.includes(p);
-        }
-      });
+      const matches = config.sessionFilter.some((p) => safePatternMatch(session, p));
       if (!matches) {
         return false;
       }

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -13,6 +13,7 @@ import type {
   ExecApprovalRequest,
   ExecApprovalResolved,
 } from "./exec-approvals.js";
+import { safePatternMatch } from "../utils/safe-regex.js";
 import { deliverOutboundPayloads } from "./outbound/deliver.js";
 import { resolveSessionDeliveryTarget } from "./outbound/targets.js";
 
@@ -51,13 +52,7 @@ function normalizeMode(mode?: ExecApprovalForwardingConfig["mode"]) {
 }
 
 function matchSessionFilter(sessionKey: string, patterns: string[]): boolean {
-  return patterns.some((pattern) => {
-    try {
-      return sessionKey.includes(pattern) || new RegExp(pattern).test(sessionKey);
-    } catch {
-      return sessionKey.includes(pattern);
-    }
-  });
+  return patterns.some((pattern) => safePatternMatch(sessionKey, pattern, log));
 }
 
 function shouldForward(params: {

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -8,12 +8,12 @@ import type {
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { parseAgentSessionKey } from "../routing/session-key.js";
 import { isDeliverableMessageChannel, normalizeMessageChannel } from "../utils/message-channel.js";
+import { safePatternMatch } from "../utils/safe-regex.js";
 import type {
   ExecApprovalDecision,
   ExecApprovalRequest,
   ExecApprovalResolved,
 } from "./exec-approvals.js";
-import { safePatternMatch } from "../utils/safe-regex.js";
 import { deliverOutboundPayloads } from "./outbound/deliver.js";
 import { resolveSessionDeliveryTarget } from "./outbound/targets.js";
 

--- a/src/utils/safe-regex.test.ts
+++ b/src/utils/safe-regex.test.ts
@@ -107,4 +107,22 @@ describe("safePatternMatch", () => {
     // The literal ".*" is found in the string, so regex isn't needed
     expect(safePatternMatch("match .* this", ".*")).toBe(true);
   });
+
+  it("rejects regex matching on very long inputs (defense-in-depth)", () => {
+    const warnings: string[] = [];
+    const logger = { warn: (msg: string) => warnings.push(msg) };
+
+    // Input over 1000 chars should fall back to literal match only
+    const longInput = "a".repeat(1001);
+    const result = safePatternMatch(longInput, "^a+$", logger);
+
+    expect(result).toBe(false); // Literal "^a+$" not found, regex skipped
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("exceeds safe length");
+  });
+
+  it("allows regex on inputs under the length limit", () => {
+    const input = "a".repeat(500);
+    expect(safePatternMatch(input, "^a+$")).toBe(true);
+  });
 });

--- a/src/utils/safe-regex.test.ts
+++ b/src/utils/safe-regex.test.ts
@@ -27,6 +27,18 @@ describe("isSafeRegexPattern", () => {
       expect(isSafeRegexPattern("(a+)+$")).toBe(false);
     });
 
+    it("rejects nested groups ((a+))+", () => {
+      expect(isSafeRegexPattern("((a+))+")).toBe(false);
+    });
+
+    it("rejects curly-brace quantifiers (a{2,10})+", () => {
+      expect(isSafeRegexPattern("(a{2,10})+")).toBe(false);
+    });
+
+    it("rejects curly-brace with nested groups ((a{2,})?)*", () => {
+      expect(isSafeRegexPattern("((a{2,})?)*")).toBe(false);
+    });
+
     it("rejects patterns exceeding 500 characters", () => {
       const longPattern = "a".repeat(501);
       expect(isSafeRegexPattern(longPattern)).toBe(false);

--- a/src/utils/safe-regex.test.ts
+++ b/src/utils/safe-regex.test.ts
@@ -39,6 +39,14 @@ describe("isSafeRegexPattern", () => {
       expect(isSafeRegexPattern("((a{2,})?)*")).toBe(false);
     });
 
+    it("rejects triple-nested groups (((a+)))+", () => {
+      expect(isSafeRegexPattern("(((a+)))+")).toBe(false);
+    });
+
+    it("rejects deeply nested groups ((((a+))))*", () => {
+      expect(isSafeRegexPattern("((((a+))))*")).toBe(false);
+    });
+
     it("rejects patterns exceeding 500 characters", () => {
       const longPattern = "a".repeat(501);
       expect(isSafeRegexPattern(longPattern)).toBe(false);

--- a/src/utils/safe-regex.test.ts
+++ b/src/utils/safe-regex.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { isSafeRegexPattern, safePatternMatch } from "./safe-regex.js";
+
+describe("isSafeRegexPattern", () => {
+  describe("rejects dangerous patterns", () => {
+    it("rejects nested quantifiers (a+)+", () => {
+      expect(isSafeRegexPattern("(a+)+")).toBe(false);
+    });
+
+    it("rejects nested quantifiers (a*)+", () => {
+      expect(isSafeRegexPattern("(a*)+")).toBe(false);
+    });
+
+    it("rejects nested quantifiers (a+)*", () => {
+      expect(isSafeRegexPattern("(a+)*")).toBe(false);
+    });
+
+    it("rejects nested quantifiers (a+)?", () => {
+      expect(isSafeRegexPattern("(a+)?")).toBe(false);
+    });
+
+    it("rejects complex nested quantifiers (a|b+)+", () => {
+      expect(isSafeRegexPattern("(a|b+)+")).toBe(false);
+    });
+
+    it("rejects the classic ReDoS pattern (a+)+$", () => {
+      expect(isSafeRegexPattern("(a+)+$")).toBe(false);
+    });
+
+    it("rejects patterns exceeding 500 characters", () => {
+      const longPattern = "a".repeat(501);
+      expect(isSafeRegexPattern(longPattern)).toBe(false);
+    });
+  });
+
+  describe("accepts safe patterns", () => {
+    it("accepts simple literal strings", () => {
+      expect(isSafeRegexPattern("hello")).toBe(true);
+    });
+
+    it("accepts simple character classes", () => {
+      expect(isSafeRegexPattern("[a-z]+")).toBe(true);
+    });
+
+    it("accepts non-nested quantifiers", () => {
+      expect(isSafeRegexPattern("a+b*c?")).toBe(true);
+    });
+
+    it("accepts groups without nested quantifiers", () => {
+      expect(isSafeRegexPattern("(abc)+")).toBe(true);
+    });
+
+    it("accepts alternation without quantifiers", () => {
+      expect(isSafeRegexPattern("(foo|bar)")).toBe(true);
+    });
+
+    it("accepts common session key patterns", () => {
+      expect(isSafeRegexPattern("^session-.*")).toBe(true);
+      expect(isSafeRegexPattern("user-\\d+")).toBe(true);
+    });
+  });
+});
+
+describe("safePatternMatch", () => {
+  it("matches literal substrings", () => {
+    expect(safePatternMatch("hello world", "world")).toBe(true);
+  });
+
+  it("returns false for non-matching literals", () => {
+    expect(safePatternMatch("hello world", "foo")).toBe(false);
+  });
+
+  it("matches safe regex patterns", () => {
+    expect(safePatternMatch("session-123", "^session-\\d+$")).toBe(true);
+  });
+
+  it("rejects dangerous patterns and returns false", () => {
+    const warnings: string[] = [];
+    const logger = { warn: (msg: string) => warnings.push(msg) };
+
+    // This pattern would hang if executed
+    const result = safePatternMatch("aaaaaaaaaaaaaaaaaaaaaaaaaaaa!", "(a+)+$", logger);
+
+    expect(result).toBe(false);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("dangerous regex pattern");
+  });
+
+  it("handles invalid regex gracefully", () => {
+    // Invalid regex syntax - unclosed group
+    expect(safePatternMatch("test", "(unclosed")).toBe(false);
+  });
+
+  it("prefers literal match over regex for performance", () => {
+    // The literal ".*" is found in the string, so regex isn't needed
+    expect(safePatternMatch("match .* this", ".*")).toBe(true);
+  });
+});

--- a/src/utils/safe-regex.ts
+++ b/src/utils/safe-regex.ts
@@ -4,12 +4,26 @@
  * ReDoS occurs when a regular expression with certain patterns
  * (like nested quantifiers) is matched against crafted input,
  * causing exponential backtracking and CPU exhaustion.
+ *
+ * Defense strategy (belt + suspenders):
+ * 1. Static pattern analysis - instantly reject known-dangerous patterns
+ * 2. Input length limit - bound worst-case execution time for edge cases
+ *
+ * Static analysis catches common ReDoS patterns (nested quantifiers, overlapping
+ * alternations). Input limiting handles exotic patterns that slip through by
+ * ensuring even pathological cases complete in bounded time.
  */
+
+/** Maximum input length for regex matching (defense-in-depth) */
+const MAX_REGEX_INPUT_LENGTH = 1000;
 
 /**
  * Detect potentially dangerous regex patterns that could cause ReDoS.
  * Rejects patterns with nested quantifiers like (a+)+, (a*)+, (a+)*, etc.
  * These can cause exponential backtracking on crafted input.
+ *
+ * Note: Static analysis cannot catch all pathological patterns (halting problem),
+ * but it handles the common cases. Input length limiting provides defense-in-depth.
  *
  * @param pattern - The regex pattern string to validate
  * @returns true if the pattern is considered safe, false otherwise
@@ -43,6 +57,11 @@ export function isSafeRegexPattern(pattern: string): boolean {
  * Safely test if a string matches a pattern.
  * Falls back to literal string matching if the pattern is unsafe or invalid.
  *
+ * Defense layers:
+ * 1. Literal match first (O(n), no regex engine)
+ * 2. Static pattern analysis (reject known-dangerous patterns)
+ * 3. Input length limit (bound worst-case for exotic patterns)
+ *
  * @param input - The string to test
  * @param pattern - The pattern (literal string or regex)
  * @param logger - Optional logger for warnings about rejected patterns
@@ -58,9 +77,21 @@ export function safePatternMatch(
     return true;
   }
 
-  // Only attempt regex if the pattern is safe
+  // Reject known-dangerous patterns via static analysis
   if (!isSafeRegexPattern(pattern)) {
     logger?.warn("Rejecting potentially dangerous regex pattern", { pattern });
+    return false;
+  }
+
+  // Defense-in-depth: limit input length to bound worst-case execution time.
+  // Even exotic patterns that slip through static analysis will complete
+  // in bounded time on limited input. For session keys >1000 chars,
+  // fall back to literal match only (already tried above, so return false).
+  if (input.length > MAX_REGEX_INPUT_LENGTH) {
+    logger?.warn("Input exceeds safe length for regex matching, using literal match only", {
+      inputLength: input.length,
+      maxLength: MAX_REGEX_INPUT_LENGTH,
+    });
     return false;
   }
 

--- a/src/utils/safe-regex.ts
+++ b/src/utils/safe-regex.ts
@@ -16,9 +16,13 @@
  */
 export function isSafeRegexPattern(pattern: string): boolean {
   // Detect nested quantifiers: groups with quantifiers containing quantified content
-  // Patterns like (a+)+, (a*)+, (a+)*, (a|b+)+, etc.
-  const nestedQuantifierRe = /\([^)]*[+*][^)]*\)[+*?]|\([^)]*[+*?]\)[+*]/;
-  if (nestedQuantifierRe.test(pattern)) {
+  // Patterns like (a+)+, (a*)+, (a+)*, (a|b+)+, (a{2,10})+, etc.
+  // Include curly-brace quantifiers {n}, {n,}, {n,m} alongside +*?
+  const nestedQuantifierRe =
+    /\([^)]*[+*{][^)]*\)[+*?{]|\([^)]*[+*?{]\)[+*{]/;
+  // Also detect nested groups with quantifiers: ((a+))+
+  const nestedGroupsRe = /\([^()]*\([^)]*[+*?{][^)]*\)[^()]*\)[+*?{]/;
+  if (nestedQuantifierRe.test(pattern) || nestedGroupsRe.test(pattern)) {
     return false;
   }
 

--- a/src/utils/safe-regex.ts
+++ b/src/utils/safe-regex.ts
@@ -39,6 +39,13 @@ export function isSafeRegexPattern(pattern: string): boolean {
     return false;
   }
 
+  // Detect deeply nested groups (3+ levels) with quantifiers: (((a+)))+
+  // Collapse consecutive closing parens to normalize nesting, then recheck
+  const collapsedPattern = pattern.replace(/\)+/g, ")");
+  if (nestedQuantifierRe.test(collapsedPattern) || nestedGroupsRe.test(collapsedPattern)) {
+    return false;
+  }
+
   // Detect overlapping alternations with quantifiers: (a|a)+, (ab|ab)+
   const overlappingAltRe = /\(([^|)]+)\|\1[^)]*\)[+*]/;
   if (overlappingAltRe.test(pattern)) {

--- a/src/utils/safe-regex.ts
+++ b/src/utils/safe-regex.ts
@@ -1,0 +1,69 @@
+/**
+ * Safe regex utilities to prevent ReDoS (CWE-1333) attacks.
+ *
+ * ReDoS occurs when a regular expression with certain patterns
+ * (like nested quantifiers) is matched against crafted input,
+ * causing exponential backtracking and CPU exhaustion.
+ */
+
+/**
+ * Detect potentially dangerous regex patterns that could cause ReDoS.
+ * Rejects patterns with nested quantifiers like (a+)+, (a*)+, (a+)*, etc.
+ * These can cause exponential backtracking on crafted input.
+ *
+ * @param pattern - The regex pattern string to validate
+ * @returns true if the pattern is considered safe, false otherwise
+ */
+export function isSafeRegexPattern(pattern: string): boolean {
+  // Detect nested quantifiers: groups with quantifiers containing quantified content
+  // Patterns like (a+)+, (a*)+, (a+)*, (a|b+)+, etc.
+  const nestedQuantifierRe = /\([^)]*[+*][^)]*\)[+*?]|\([^)]*[+*?]\)[+*]/;
+  if (nestedQuantifierRe.test(pattern)) {
+    return false;
+  }
+
+  // Detect overlapping alternations with quantifiers: (a|a)+, (ab|ab)+
+  const overlappingAltRe = /\(([^|)]+)\|\1[^)]*\)[+*]/;
+  if (overlappingAltRe.test(pattern)) {
+    return false;
+  }
+
+  // Reject excessively long patterns (defense in depth)
+  if (pattern.length > 500) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Safely test if a string matches a pattern.
+ * Falls back to literal string matching if the pattern is unsafe or invalid.
+ *
+ * @param input - The string to test
+ * @param pattern - The pattern (literal string or regex)
+ * @param logger - Optional logger for warnings about rejected patterns
+ * @returns true if the input matches the pattern
+ */
+export function safePatternMatch(
+  input: string,
+  pattern: string,
+  logger?: { warn: (msg: string, ctx?: Record<string, unknown>) => void },
+): boolean {
+  // Always try literal string match first (fast and safe)
+  if (input.includes(pattern)) {
+    return true;
+  }
+
+  // Only attempt regex if the pattern is safe
+  if (!isSafeRegexPattern(pattern)) {
+    logger?.warn("Rejecting potentially dangerous regex pattern", { pattern });
+    return false;
+  }
+
+  try {
+    return new RegExp(pattern).test(input);
+  } catch {
+    return false;
+  }
+}

--- a/src/utils/safe-regex.ts
+++ b/src/utils/safe-regex.ts
@@ -18,8 +18,7 @@ export function isSafeRegexPattern(pattern: string): boolean {
   // Detect nested quantifiers: groups with quantifiers containing quantified content
   // Patterns like (a+)+, (a*)+, (a+)*, (a|b+)+, (a{2,10})+, etc.
   // Include curly-brace quantifiers {n}, {n,}, {n,m} alongside +*?
-  const nestedQuantifierRe =
-    /\([^)]*[+*{][^)]*\)[+*?{]|\([^)]*[+*?{]\)[+*{]/;
+  const nestedQuantifierRe = /\([^)]*[+*{][^)]*\)[+*?{]|\([^)]*[+*?{]\)[+*{]/;
   // Also detect nested groups with quantifiers: ((a+))+
   const nestedGroupsRe = /\([^()]*\([^)]*[+*?{][^)]*\)[^()]*\)[+*?{]/;
   if (nestedQuantifierRe.test(pattern) || nestedGroupsRe.test(pattern)) {


### PR DESCRIPTION
## Summary

Adds validation for regex patterns in session filters to prevent **accidental ReDoS (Regular Expression Denial of Service)** scenarios (CWE-1333).

A user might write a pattern like `(a+)+` or `(.*)+` in their sessionFilter config without realizing it causes catastrophic backtracking. Crafted or even normal input matching these patterns can freeze the Node.js event loop, and debugging "why is my system hanging" when the cause is regex performance is not obvious.

This validation catches dangerous patterns early with a clear warning, rather than silent CPU exhaustion.

## Changes

- Add `src/utils/safe-regex.ts` with pattern validation utilities:
  - `isSafeRegexPattern()` — detects nested quantifiers like `(a+)+`, `((a+))+`, `(a{2,10})+`, etc.
  - `safePatternMatch()` — tries literal match first, validates regex before execution
- Update `src/infra/exec-approval-forwarder.ts` to use safe matching
- Update `src/discord/monitor/exec-approvals.ts` to use safe matching with logger
- Add 22 comprehensive tests

## Behavior

- Safe patterns: work as before (regex matching)
- Dangerous patterns: rejected with warning, falls back to literal string match only
- Invalid regex: handled gracefully, returns false

## Testing

```
pnpm exec vitest run src/utils/safe-regex.test.ts        # 22/22 passing
pnpm exec vitest run src/infra/exec-approval-forwarder   # 6/6 passing  
pnpm exec vitest run src/discord/monitor/exec-approvals  # 43/43 passing
pnpm lint                                                 # 0 errors
```

## References

- **CWE-1333:** https://cwe.mitre.org/data/definitions/1333.html
- **OWASP ReDoS:** https://owasp.org/www-community/attacks/Regular_expression_Denial_of_Service_-_ReDoS

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a `safePatternMatch` utility to prevent ReDoS (CWE-1333) in session filter regex matching, replacing inline try/catch regex logic in two call sites. The approach is sound: literal match first, then static pattern analysis to reject known-dangerous patterns, then an input length limit as defense-in-depth.

- The static analysis detection regex has a bypass for patterns with 3+ levels of group nesting (e.g., `(((a+)))+`), though the input length limit mitigates the practical impact.
- Integration in both `exec-approval-forwarder.ts` and `exec-approvals.ts` is clean, with correct logger wiring and preserved behavioral semantics.
- Test suite is comprehensive with 22 tests covering dangerous patterns, safe patterns, literal matching, input length limits, and error handling.

<h3>Confidence Score: 3/5</h3>

- This PR is safe to merge with the noted static analysis gap mitigated by the input length limit
- The core defense-in-depth strategy is solid and the integration is clean. Score reflects the detection bypass for triple-nested groups, though the 1000-char input length limit bounds the practical risk. The behavioral change is backward-compatible.
- `src/utils/safe-regex.ts` — the `nestedGroupsRe` regex only handles exactly two levels of nesting and can be bypassed by patterns like `(((a+)))+`

<sub>Last reviewed commit: e78765b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->