### PR TITLE
enhance: elevate special context files (soul.md, identity.md, user.md, memory.md) into dedicated prompt sections

### DIFF
--- a/src/agents/system-prompt.e2e.test.ts
+++ b/src/agents/system-prompt.e2e.test.ts
@@ -321,12 +321,13 @@ describe("buildAgentSystemPrompt", () => {
         { path: "IDENTITY.md", content: "Bravo" },
       ],
     });
-
     expect(prompt).toContain("# Project Context");
     expect(prompt).toContain("## AGENTS.md");
     expect(prompt).toContain("Alpha");
-    expect(prompt).toContain("## IDENTITY.md");
+    // IDENTITY.md is now elevated to its own section
+    expect(prompt).toContain("## Identity");
     expect(prompt).toContain("Bravo");
+    expect(prompt).not.toContain("## IDENTITY.md");
   });
 
   it("ignores context files with missing or blank paths", () => {
@@ -354,11 +355,20 @@ describe("buildAgentSystemPrompt", () => {
         { path: "dir\\SOUL.md", content: "Persona Windows" },
       ],
     });
-
+    // Soul.md elevated to Doctrine section with new preamble
+    expect(prompt).toContain("## Doctrine");
     expect(prompt).toContain(
-      "If SOUL.md is present, embody its persona and tone. Avoid stiff, generic replies; follow its guidance unless higher-priority instructions override it.",
+      "Embody the persona and tone defined below to keep the assistant's unique voice.",
+    );
+    expect(prompt).toContain("Persona");
+    // Duplicate soul.md from different path is suppressed (has-based filter)
+    expect(prompt).not.toContain("Persona Windows");
+    // Old preamble is gone
+    expect(prompt).not.toContain(
+      "If SOUL.md is present, embody its persona and tone. Avoid stiff, generic replies",
     );
   });
+
 
   it("summarizes the message tool when available", () => {
     const prompt = buildAgentSystemPrompt({

--- a/src/agents/system-prompt.e2e.test.ts
+++ b/src/agents/system-prompt.e2e.test.ts
@@ -369,7 +369,6 @@ describe("buildAgentSystemPrompt", () => {
     );
   });
 
-
   it("summarizes the message tool when available", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -1,9 +1,9 @@
 import type { ReasoningLevel, ThinkLevel } from "../auto-reply/thinking.js";
-import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import type { MemoryCitationsMode } from "../config/types.memory.js";
-import { listDeliverableMessageChannels } from "../utils/message-channel.js";
 import type { ResolvedTimeFormat } from "./date-time.js";
 import type { EmbeddedContextFile } from "./pi-embedded-helpers.js";
+import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
+import { listDeliverableMessageChannels } from "../utils/message-channel.js";
 import { sanitizeForPromptLiteral } from "./sanitize-for-prompt.js";
 
 /**

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -624,7 +624,7 @@ export function buildAgentSystemPrompt(params: {
   // Project Context section - only include non-elevated files to save tokens
   const projectContextFiles = validContextFiles.filter((file) => {
     const base = basename(file.path);
-    return specialFiles.get(base) !== file;
+    return !specialFiles.has(base);
   });
 
   if (projectContextFiles.length > 0) {

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -628,7 +628,12 @@ export function buildAgentSystemPrompt(params: {
   });
 
   if (projectContextFiles.length > 0) {
-    lines.push("# Project Context", "", "The following project context files have been loaded:", "");
+    lines.push(
+      "# Project Context",
+      "",
+      "The following project context files have been loaded:",
+      "",
+    );
     for (const file of projectContextFiles) {
       lines.push(`## ${file.path}`, "", file.content, "");
     }


### PR DESCRIPTION
Closes #17810

Elevates `soul.md`, `identity.md`, `user.md`, and `memory.md` out of the flat `# Project Context` list into dedicated sections (`## Doctrine`,` ## Identity`, `## User Context`, `## Memory`) with scoped preambles. Non-special files render in Project Context as before; elevated files are filtered out to save tokens.

Running in production since 2026.2.3 across all releases up to and including 2026.2.15 with zero conflicts or regressions.

See issue #17810 for full design rationale and patch documentation.

**AI Disclosure:** This patch was developed with AI assistance (Claude) for code review, syntax fixes, type safety refinements, and documentation.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR elevates four special context files (`soul.md`, `identity.md`, `user.md`, `memory.md`) from the flat `# Project Context` list into dedicated sections with descriptive names (`## Doctrine`, `## Identity`, `## User Context`, `## Memory`) and scoped preambles for soul.md and identity.md. Non-special files continue to render in `# Project Context` as before. The implementation correctly:
- Uses case-insensitive, normalized path matching to identify special files
- Handles duplicate special files by keeping only the first occurrence
- Filters all special files (including duplicates) out of the `# Project Context` section using `Map.has()` 
- Renders special sections in deterministic order
- Includes comprehensive test coverage validating the new behavior including duplicate suppression

The change has been running in production since 2026.2.3 with no reported issues.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no significant risk
- The implementation is clean, well-tested, and has been validated in production for 12+ days across multiple releases. The logic correctly handles edge cases (duplicates, case sensitivity, path normalization), and the test suite validates all key behaviors including duplicate suppression. The previous thread's concern has already been resolved by the current implementation.
- No files require special attention

<sub>Last reviewed commit: ab61cb3</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->