### PR TITLE
fix(daemon): gateway install on macOS ignores fnm/nvm node (#18090)

### DIFF
--- a/src/commands/daemon-install-helpers.ts
+++ b/src/commands/daemon-install-helpers.ts
@@ -42,6 +42,7 @@ export async function buildGatewayInstallPlan(params: {
     (await resolvePreferredNodePath({
       env: params.env,
       runtime: params.runtime,
+      processExecPath: process.execPath,
     }));
   const { programArguments, workingDirectory } = await resolveGatewayProgramArguments({
     port: params.port,

--- a/src/commands/node-daemon-install-helpers.ts
+++ b/src/commands/node-daemon-install-helpers.ts
@@ -37,6 +37,7 @@ export async function buildNodeInstallPlan(params: {
     (await resolvePreferredNodePath({
       env: params.env,
       runtime: params.runtime,
+      processExecPath: process.execPath,
     }));
   const { programArguments, workingDirectory } = await resolveNodeProgramArguments({
     host: params.host,

--- a/src/daemon/runtime-paths.test.ts
+++ b/src/daemon/runtime-paths.test.ts
@@ -66,6 +66,196 @@ describe("resolvePreferredNodePath", () => {
     expect(execFile).toHaveBeenCalledTimes(1);
   });
 
+  it("prefers process.execPath over system node when it is a supported version-managed node", async () => {
+    const fnmNode = "/Users/me/.fnm/node-versions/v24.11.1/installation/bin/node";
+
+    fsMocks.access.mockImplementation(async (target: string) => {
+      if (target === darwinNode || target === fnmNode) {
+        return;
+      }
+      throw new Error("missing");
+    });
+
+    const execFile = vi.fn().mockImplementation(async (bin: string) => {
+      if (bin === fnmNode) {
+        return { stdout: "24.11.1\n", stderr: "" };
+      }
+      if (bin === darwinNode) {
+        return { stdout: "25.5.0\n", stderr: "" };
+      }
+      throw new Error("not found");
+    });
+
+    const result = await resolvePreferredNodePath({
+      env: {},
+      runtime: "node",
+      platform: "darwin",
+      execFile,
+      processExecPath: fnmNode,
+    });
+
+    expect(result).toBe(fnmNode);
+  });
+
+  it("falls back to system node when processExecPath is not provided", async () => {
+    fsMocks.access.mockImplementation(async (target: string) => {
+      if (target === darwinNode) {
+        return;
+      }
+      throw new Error("missing");
+    });
+
+    const execFile = vi.fn().mockResolvedValue({ stdout: "22.12.0\n", stderr: "" });
+
+    const result = await resolvePreferredNodePath({
+      env: {},
+      runtime: "node",
+      platform: "darwin",
+      execFile,
+    });
+
+    expect(result).toBe(darwinNode);
+  });
+
+  it("falls back to system node when processExecPath node is unsupported", async () => {
+    const oldFnmNode = "/Users/me/.fnm/node-versions/v18.0.0/installation/bin/node";
+
+    fsMocks.access.mockImplementation(async (target: string) => {
+      if (target === darwinNode || target === oldFnmNode) {
+        return;
+      }
+      throw new Error("missing");
+    });
+
+    const execFile = vi.fn().mockImplementation(async (bin: string) => {
+      if (bin === oldFnmNode) {
+        return { stdout: "18.0.0\n", stderr: "" };
+      }
+      if (bin === darwinNode) {
+        return { stdout: "22.12.0\n", stderr: "" };
+      }
+      throw new Error("not found");
+    });
+
+    const result = await resolvePreferredNodePath({
+      env: {},
+      runtime: "node",
+      platform: "darwin",
+      execFile,
+      processExecPath: oldFnmNode,
+    });
+
+    expect(result).toBe(darwinNode);
+  });
+
+  it("falls back to system node when processExecPath version check fails", async () => {
+    const brokenNode = "/Users/me/.nvm/versions/node/v22.0.0/bin/node";
+
+    fsMocks.access.mockImplementation(async (target: string) => {
+      if (target === darwinNode) {
+        return;
+      }
+      throw new Error("missing");
+    });
+
+    const execFile = vi.fn().mockImplementation(async (bin: string) => {
+      if (bin === brokenNode) {
+        throw new Error("ENOENT");
+      }
+      if (bin === darwinNode) {
+        return { stdout: "22.12.0\n", stderr: "" };
+      }
+      throw new Error("not found");
+    });
+
+    const result = await resolvePreferredNodePath({
+      env: {},
+      runtime: "node",
+      platform: "darwin",
+      execFile,
+      processExecPath: brokenNode,
+    });
+
+    expect(result).toBe(darwinNode);
+  });
+
+  it("falls back to system node when processExecPath returns empty version", async () => {
+    const weirdNode = "/Users/me/.volta/bin/node";
+
+    fsMocks.access.mockImplementation(async (target: string) => {
+      if (target === darwinNode) {
+        return;
+      }
+      throw new Error("missing");
+    });
+
+    const execFile = vi.fn().mockImplementation(async (bin: string) => {
+      if (bin === weirdNode) {
+        return { stdout: "", stderr: "" };
+      }
+      if (bin === darwinNode) {
+        return { stdout: "22.12.0\n", stderr: "" };
+      }
+      throw new Error("not found");
+    });
+
+    const result = await resolvePreferredNodePath({
+      env: {},
+      runtime: "node",
+      platform: "darwin",
+      execFile,
+      processExecPath: weirdNode,
+    });
+
+    expect(result).toBe(darwinNode);
+  });
+
+  it("returns undefined when runtime is not node even with processExecPath", async () => {
+    const execFile = vi.fn();
+
+    const result = await resolvePreferredNodePath({
+      env: {},
+      runtime: "bun",
+      platform: "darwin",
+      execFile,
+      processExecPath: "/Users/me/.fnm/node-versions/v24.0.0/installation/bin/node",
+    });
+
+    expect(result).toBeUndefined();
+    expect(execFile).not.toHaveBeenCalled();
+  });
+
+  it("prefers processExecPath on Linux too", async () => {
+    const nvmNode = "/home/user/.nvm/versions/node/v22.12.0/bin/node";
+
+    fsMocks.access.mockImplementation(async (target: string) => {
+      if (target === "/usr/local/bin/node") {
+        return;
+      }
+      throw new Error("missing");
+    });
+
+    const execFile = vi.fn().mockImplementation(async (bin: string) => {
+      if (bin === nvmNode) {
+        return { stdout: "22.12.0\n", stderr: "" };
+      }
+      if (bin === "/usr/local/bin/node") {
+        return { stdout: "22.12.0\n", stderr: "" };
+      }
+      throw new Error("not found");
+    });
+
+    const result = await resolvePreferredNodePath({
+      env: {},
+      runtime: "node",
+      platform: "linux",
+      execFile,
+      processExecPath: nvmNode,
+    });
+
+    expect(result).toBe(nvmNode);
+  });
+
   it("returns undefined when no system node is found", async () => {
     fsMocks.access.mockRejectedValue(new Error("missing"));
 


### PR DESCRIPTION
## Summary

`openclaw gateway install` on macOS hardcodes `/opt/homebrew/bin/node` in the launchd plist even when the user runs the command under fnm/nvm. The node that's actually running the install gets ignored.

Closes #18090

lobster-biscuit

## Root Cause

`resolvePreferredNodePath` in `runtime-paths.ts` only checks hardcoded system candidates (`/opt/homebrew/bin/node`, `/usr/local/bin/node`, `/usr/bin/node`). It never looks at `process.execPath` — the node actually executing the install command. So fnm/nvm users always get Homebrew's node in their plist.

## Changes

- Before: plist always uses the first accessible system node candidate, regardless of what node is running the CLI
- After: checks `process.execPath` first — if it's a supported version (22+), uses it; otherwise falls back to system node as before

Files touched:
- `src/daemon/runtime-paths.ts` — added `processExecPath` param, version-check it before system fallback
- `src/commands/daemon-install-helpers.ts` — pass `process.execPath` to the resolver
- `src/commands/node-daemon-install-helpers.ts` — same

Note: the second half of #18090 (extending version manager PATH dirs to macOS in `service-env.ts`) is already covered by open PR #4709, so I left that alone.

## Tests

- `runtime-paths.test.ts` — 5 new tests covering: fnm node preferred over system node, fallback when execPath not provided, fallback when execPath version is too old, fallback when version check throws, fallback on empty version string, runtime !== "node" short-circuit, Linux platform behavior. All fail before fix, pass after.
- `pnpm build && pnpm check` pass
- All 89 daemon directory tests pass

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed `openclaw gateway install` on macOS to respect the Node.js binary currently executing the install command (from fnm/nvm) instead of always defaulting to Homebrew's system node. The fix checks `process.execPath` first and only falls back to system node candidates if the executing node is unsupported or not provided.

Key changes:
- Added `processExecPath` parameter to `resolvePreferredNodePath` function
- Version-checks `process.execPath` before falling back to system node paths
- Passes `process.execPath` from install commands to the resolver
- Added comprehensive test coverage (7 new tests) covering happy path, fallbacks, error cases, and Linux platform

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is straightforward, well-tested with 7 new comprehensive test cases, follows existing patterns in the codebase, and gracefully handles edge cases (missing files, unsupported versions, error conditions). The fix is minimal and focused, adding only the necessary logic to check `process.execPath` before falling back to system node
- No files require special attention

<sub>Last reviewed commit: 28b8219</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->