### PR TITLE
fix: prevent voice message loss during concurrent update processing

### DIFF
--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -37,6 +37,9 @@ import {
   type TelegramUpdateKeyContext,
 } from "./bot-updates.js";
 import {
+  createUpdateOffsetWatermark,
+} from "./update-offset-watermark.js";
+import {
   buildTelegramGroupPeerId,
   buildTelegramParentPeer,
   resolveTelegramForumThreadId,
@@ -151,8 +154,17 @@ export function createTelegramBot(opts: TelegramBotOptions) {
   });
 
   const recentUpdates = createTelegramUpdateDedupe();
-  let lastUpdateId =
+  const initialOffset =
     typeof opts.updateOffset?.lastUpdateId === "number" ? opts.updateOffset.lastUpdateId : null;
+
+  // Use contiguous watermark tracker to prevent out-of-order completion
+  // from advancing the offset past still-in-flight updates.
+  const offsetWatermark = createUpdateOffsetWatermark(initialOffset, (offset) => {
+    void opts.updateOffset?.onUpdateId?.(offset);
+  });
+
+  // Kept for shouldSkipUpdate compatibility
+  let lastUpdateId = initialOffset;
 
   const recordUpdateId = (ctx: TelegramUpdateKeyContext) => {
     const updateId = resolveTelegramUpdateId(ctx);
@@ -162,8 +174,11 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     if (lastUpdateId !== null && updateId <= lastUpdateId) {
       return;
     }
-    lastUpdateId = updateId;
-    void opts.updateOffset?.onUpdateId?.(updateId);
+    offsetWatermark.markCompleted(updateId);
+    const newOffset = offsetWatermark.getCurrentOffset();
+    if (newOffset !== null && (lastUpdateId === null || newOffset > lastUpdateId)) {
+      lastUpdateId = newOffset;
+    }
   };
 
   const shouldSkipUpdate = (ctx: TelegramUpdateKeyContext) => {
@@ -217,6 +232,10 @@ export function createTelegramBot(opts: TelegramBotOptions) {
       } catch (err) {
         rawUpdateLogger.debug(`telegram update log failed: ${String(err)}`);
       }
+    }
+    const updateId = resolveTelegramUpdateId(ctx);
+    if (typeof updateId === "number") {
+      offsetWatermark.markStarted(updateId);
     }
     await next();
     recordUpdateId(ctx);

--- a/src/telegram/update-offset-watermark.test.ts
+++ b/src/telegram/update-offset-watermark.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from "vitest";
+import { createUpdateOffsetWatermark } from "./update-offset-watermark.js";
+
+describe("createUpdateOffsetWatermark", () => {
+  it("should not advance offset past incomplete lower update IDs (race condition regression)", () => {
+    // Regression test: When updates are processed concurrently and a higher update_id
+    // completes before a lower one, the offset should NOT jump ahead.
+    // Previously, the offset tracked MAX completed update_id, which could skip
+    // lower-numbered in-flight updates on crash/restart.
+
+    const onPersist = vi.fn();
+    const wm = createUpdateOffsetWatermark(null, onPersist);
+
+    // Batch: update 100 (voice, chat A) and update 101 (text, chat B) start concurrently
+    wm.markStarted(100);
+    wm.markStarted(101);
+
+    // Update 101 finishes first (text is fast)
+    wm.markCompleted(101);
+
+    // Offset should NOT advance to 101 because 100 is still in-flight
+    expect(onPersist).not.toHaveBeenCalled();
+    expect(wm.getCurrentOffset()).toBeNull();
+
+    // Update 100 finishes (voice processing done)
+    wm.markCompleted(100);
+
+    // NOW offset should advance to 101 (both 100 and 101 are complete)
+    expect(onPersist).toHaveBeenCalledWith(101);
+    expect(wm.getCurrentOffset()).toBe(101);
+  });
+
+  it("should advance offset immediately when updates complete in order", () => {
+    const onPersist = vi.fn();
+    const wm = createUpdateOffsetWatermark(null, onPersist);
+
+    wm.markStarted(100);
+    wm.markCompleted(100);
+    expect(onPersist).toHaveBeenCalledWith(100);
+
+    wm.markStarted(101);
+    wm.markCompleted(101);
+    expect(onPersist).toHaveBeenCalledWith(101);
+  });
+
+  it("should respect initial offset and not regress", () => {
+    const onPersist = vi.fn();
+    const wm = createUpdateOffsetWatermark(99, onPersist);
+
+    wm.markStarted(100);
+    wm.markStarted(101);
+    wm.markCompleted(101);
+    expect(onPersist).not.toHaveBeenCalled();
+
+    wm.markCompleted(100);
+    expect(onPersist).toHaveBeenCalledWith(101);
+    expect(wm.getCurrentOffset()).toBe(101);
+  });
+
+  it("should handle gaps in update IDs", () => {
+    const onPersist = vi.fn();
+    const wm = createUpdateOffsetWatermark(99, onPersist);
+
+    // Telegram can skip update IDs
+    wm.markStarted(100);
+    wm.markStarted(105);
+
+    wm.markCompleted(100);
+    // Advances to 100 only (105 still in-flight, and 101-104 were never seen)
+    expect(onPersist).toHaveBeenCalledWith(100);
+
+    wm.markCompleted(105);
+    // Now 105 completes, but 101-104 were never started — they advance through
+    expect(onPersist).toHaveBeenCalledWith(105);
+  });
+});

--- a/src/telegram/update-offset-watermark.ts
+++ b/src/telegram/update-offset-watermark.ts
@@ -1,0 +1,64 @@
+/**
+ * Contiguous update offset watermark tracker.
+ *
+ * Tracks in-flight and completed Telegram update IDs, and only advances
+ * the persisted offset to the highest contiguous completed update_id.
+ * This prevents out-of-order completion from skipping lower-numbered updates
+ * that are still being processed (TCP ACK window approach).
+ */
+export interface UpdateOffsetWatermark {
+  markStarted(updateId: number): void;
+  markCompleted(updateId: number): void;
+  getCurrentOffset(): number | null;
+}
+
+export function createUpdateOffsetWatermark(
+  initialOffset: number | null,
+  onPersist: (offset: number) => void,
+): UpdateOffsetWatermark {
+  let currentOffset = initialOffset;
+  const inFlight = new Set<number>();
+  const completed = new Set<number>();
+
+  function tryAdvance() {
+    if (completed.size === 0) return;
+
+    let watermark = currentOffset;
+
+    if (inFlight.size === 0) {
+      // No in-flight updates — safe to advance to max completed
+      const maxCompleted = Math.max(...completed);
+      watermark = watermark !== null ? Math.max(watermark, maxCompleted) : maxCompleted;
+      completed.clear();
+    } else {
+      // Advance only up to (minInFlight - 1) using completed IDs
+      const minInFlight = Math.min(...inFlight);
+      // Can safely acknowledge everything below the lowest in-flight
+      for (const id of [...completed].sort((a, b) => a - b)) {
+        if (id < minInFlight) {
+          watermark = watermark !== null ? Math.max(watermark, id) : id;
+          completed.delete(id);
+        }
+      }
+    }
+
+    if (watermark !== null && (currentOffset === null || watermark > currentOffset)) {
+      currentOffset = watermark;
+      onPersist(watermark);
+    }
+  }
+
+  return {
+    markStarted(updateId: number) {
+      inFlight.add(updateId);
+    },
+    markCompleted(updateId: number) {
+      inFlight.delete(updateId);
+      completed.add(updateId);
+      tryAdvance();
+    },
+    getCurrentOffset() {
+      return currentOffset;
+    },
+  };
+}


### PR DESCRIPTION
## Bug Description
When the Telegram polling loop (grammY runner) hits a transient network error, it restarts with backoff. There is a potential race window where update offsets are persisted before voice message processing completes, so if the runner crashes mid-processing, those updates are acknowledged to Telegram but never fully handled. This is a narrow race (~5% occurrence) and users can retry manually, making it low severity. The root cause likely involves the update offset persistence in the runner's fetch cycle vs. the sink's processing pipeline.

**Severity:** low

## Root Cause
The race condition is in bot.ts where recordUpdateId (line ~227) persists the highest update_id after each update's middleware completes, but updates from different chats run concurrently (sequentialize only serializes per-chat). When a batch contains [update 100 (voice, chat A), update 101 (text, chat B)], update 101 can finish first and persist lastUpdateId=101 to disk. If the runner then crashes (network error) before update 100 finishes processing, on restart shouldSkipUpdate sees lastUpdateId=101 and skips update 100 — the voice message is permanently lost. The core issue is that the offset persistence tracks the MAX update_id completed rather than ensuring ALL update_ids up to that point have been processed. Combined with the grammY runner's concurrent sink processing, any out-of-order completion creates a window where lower-numbered updates can be silently dropped.

## Fix
Created src/telegram/update-offset-watermark.ts with contiguous watermark tracker (TCP ACK window approach). Modified src/telegram/bot.ts to use watermark - tracks in-flight update IDs and only persists offset as highest contiguous completed update_id, preventing out-of-order completion from skipping lower-numbered updates.

## Regression Test
Added src/telegram/update-offset-watermark.test.ts with 4 tests: verifies offset doesn't advance past in-flight updates, handles in-order completion, respects initial offset, and handles gaps in update IDs.

## Verification
1) Diff matches claimed changes — 3 files modified (bot.ts, new watermark module + test). 2) Security: .gitignore exists, no sensitive files in diff. 3) All tests pass (1 pre-existing failure on main unrelated to this fix). 4) Regression test covers exact race scenario: out-of-order completion doesn't advance offset past in-flight updates. 5) Fix is minimal and targeted — watermark tracker replaces direct MAX update_id persistence with contiguous-completion tracking (TCP ACK window approach). 6) Fix addresses root cause: offset only advances when all lower update IDs are complete, preventing skipped updates on crash. 7) Test would fail without fix — without watermark, completing update 101 before 100 would immediately persist offset=101.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a contiguous watermark tracker (`update-offset-watermark.ts`) that replaces the previous "max completed update_id" approach with a TCP ACK window pattern, ensuring the persisted offset only advances when all lower-numbered updates have completed. This correctly addresses the race condition where out-of-order completion could cause lower-numbered in-flight updates to be permanently skipped on crash/restart.

- **New module** `update-offset-watermark.ts` cleanly implements the watermark tracker with `markStarted`/`markCompleted`/`getCurrentOffset` API and proper contiguous-completion logic.
- **Integration in `bot.ts`** wires the watermark into the existing middleware pipeline, calling `markStarted` before handler dispatch and `markCompleted` after.
- **Bug found:** `markStarted` is called unconditionally for all updates entering the middleware, but `recordUpdateId` short-circuits (skips `markCompleted`) for re-delivered updates with ID ≤ `lastUpdateId`. This leaves phantom entries in the `inFlight` set that permanently block watermark advancement — effectively the same class of bug this PR aims to fix, but triggered by update re-delivery instead of out-of-order completion.
- **Test coverage** is solid for the watermark module in isolation (4 tests covering the core scenarios) but does not cover the integration-level bug with skipped updates.

<h3>Confidence Score: 2/5</h3>

- The watermark logic is sound in isolation but the bot.ts integration has a bug that can permanently block offset advancement after update re-delivery.
- Score of 2 reflects that while the core watermark module is well-designed and tested, the integration in bot.ts has a logical bug where markStarted is called for re-delivered updates that will never receive a corresponding markCompleted call, causing phantom in-flight entries that block all future watermark advancement. This is the same class of update-loss bug the PR aims to fix.
- src/telegram/bot.ts — the markStarted/markCompleted pairing in the middleware needs to be guarded against re-delivered (already-processed) update IDs.

<sub>Last reviewed commit: e120cd2</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->