### PR TITLE
fix(discord): send initial message for non-forum thread creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Discord: send initial content when creating non-forum threads so `thread-create` content is delivered. (#18117) Thanks @zerone0x.
 - Security: replace deprecated SHA-1 sandbox configuration hashing with SHA-256 for deterministic sandbox cache identity and recreation checks. Thanks @kexinoh.
 - Security/Logging: redact Telegram bot tokens from error messages and uncaught stack traces to prevent accidental secret leakage into logs. Thanks @aether-ai-agent.
 - Sandbox/Security: block dangerous sandbox Docker config (bind mounts, host networking, unconfined seccomp/apparmor) to prevent container escape via config injection. Thanks @aether-ai-agent.


### PR DESCRIPTION
## Background

While building an automated workflow where Clawdbot creates threads in Discord channels, I discovered that the `message` parameter in `thread-create` was silently ignored. The thread was created successfully, but the initial message never appeared. After multiple failed attempts, I documented the workaround in my memory files:

> ❌ `thread-create` with `message` parameter — creates thread but message doesn't go in
> ❌ `thread-reply` — sends to main channel instead of thread
> ✅ Workaround: `thread-create` (no message) + `send` (target=threadId)

This two-step workaround works but is unintuitive. The `message` parameter should just work.

## Problem

When creating a thread in a non-forum channel with the `content` parameter, the content was silently ignored. This happened because only forum/media channels support the `message` field in the Discord thread creation API request body.

**Example that didn't work:**
```
message action=thread-create messageId=xxx threadName="Discussion" message="Hello!"
```
The thread was created, but "Hello!" never appeared.

## Solution

After creating the thread, if:
1. The channel is NOT a forum/media channel, AND
2. The `content` parameter is provided and non-empty

We now send the initial message as a separate API call to the newly created thread.

## Changes

- `src/discord/send.messages.ts`: Added follow-up message send for non-forum threads
- `src/discord/send.creates-thread.test.ts`: Added two test cases covering this behavior

## Testing

Added tests for:
- Creating a standalone thread with content (non-forum channel)
- Creating a message-attached thread with content

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes thread creation with initial messages in non-forum Discord channels. Previously, the `content` parameter was silently ignored when creating threads in text channels because only forum/media channels support the `message` field in the thread creation API. The fix sends the initial message as a separate API call after thread creation for non-forum channels, while maintaining the existing behavior for forum/media channels. Test coverage includes both standalone threads and message-attached threads.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation correctly handles the Discord API limitation where non-forum channels don't support the `message` field during thread creation. The fix is minimal, well-tested with comprehensive test coverage for both standalone and message-attached threads, and maintains backward compatibility for forum/media channels. The logic correctly skips channel type detection for message-attached threads (which can't exist in forums) and only sends the follow-up message when appropriate.
- No files require special attention

<sub>Last reviewed commit: 857424b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->