### PR TITLE
Fix process tree kill leaving orphans on Unix (manual traversal fallback)

### DIFF
--- a/src/process/kill-tree.ts
+++ b/src/process/kill-tree.ts
@@ -1,9 +1,31 @@
-import { spawn } from "node:child_process";
+import { spawn, execSync } from "node:child_process";
+
+/**
+ * Get all child PIDs for a given PID on Unix using pgrep.
+ */
+function getChildrenUnix(pid: number): number[] {
+  try {
+    // pgrep -P <pid> returns child PIDs, one per line.
+    // Use stdio: 'pipe' to capture output, 'ignore' stderr.
+    const output = execSync(`pgrep -P ${pid}`, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return output
+      .trim()
+      .split(/\s+/)
+      .map((s) => Number.parseInt(s, 10))
+      .filter((n) => Number.isFinite(n) && n > 0);
+  } catch {
+    // pgrep returns exit code 1 if no processes found, which throws error.
+    return [];
+  }
+}
 
 /**
  * Best-effort process-tree termination.
  * - Windows: use taskkill /T to include descendants.
- * - Unix: try process-group kill first, then direct pid kill.
+ * - Unix: try process-group kill first; if that fails (e.g. shared group), manual tree traversal using pgrep.
  */
 export function killProcessTree(pid: number): void {
   if (!Number.isFinite(pid) || pid <= 0) {
@@ -22,13 +44,48 @@ export function killProcessTree(pid: number): void {
     return;
   }
 
+  // Unix: Try process group kill first (most efficient)
   try {
     process.kill(-pid, "SIGKILL");
-  } catch {
-    try {
-      process.kill(pid, "SIGKILL");
-    } catch {
-      // process already gone or inaccessible
+    return; // Success (pid was group leader)
+  } catch (err) {
+    // ESRCH: process not found or group not found
+    // EPERM: permission denied (shouldn't happen if we own it)
+    // If pid is not a group leader, process.kill(-pid) fails.
+    // Fall back to manual tree traversal.
+  }
+
+  // Collect all descendants first (snapshot)
+  const descendants: number[] = [];
+  const queue = [pid];
+  const seen = new Set<number>();
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    if (seen.has(current)) {
+      continue;
     }
+    seen.add(current);
+    const children = getChildrenUnix(current);
+    for (const child of children) {
+      descendants.push(child);
+      queue.push(child);
+    }
+  }
+
+  // Kill descendants (reverse order not strictly necessary for SIGKILL, but good practice)
+  for (const childPid of descendants.reverse()) {
+    try {
+      process.kill(childPid, "SIGKILL");
+    } catch {
+      // ignore
+    }
+  }
+
+  // Finally kill the root
+  try {
+    process.kill(pid, "SIGKILL");
+  } catch {
+    // process already gone or inaccessible
   }
 }

--- a/src/process/kill-tree.unix.test.ts
+++ b/src/process/kill-tree.unix.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { spawn, execSync, type ChildProcess } from "node:child_process";
+import { killProcessTree } from "./kill-tree.js";
+
+// Skip on Windows for now (requires different test strategy)
+const isWindows = process.platform === "win32";
+
+describe.skipIf(isWindows)("killProcessTree (Unix)", () => {
+  const children: ChildProcess[] = [];
+
+  afterEach(() => {
+    for (const child of children) {
+      if (child.pid) {
+        try {
+          process.kill(child.pid, "SIGKILL");
+        } catch {}
+      }
+    }
+    children.length = 0;
+  });
+
+  it("kills a process tree using manual traversal when group kill fails", async () => {
+    // Spawn a parent process that spawns a child
+    // We use a shell script that ignores SIGTERM to ensure we need SIGKILL
+    // and creates a child that stays alive.
+    const script = `
+      sh -c 'sleep 100' &
+      child_pid=$!
+      echo $child_pid
+      trap "echo ignoring signal" TERM
+      sleep 100
+    `;
+    
+    // Spawn shell. NOT detached, so shares our PGID.
+    // killProcessTree(-pid) should fail, triggering manual traversal.
+    const parent = spawn("sh", ["-c", script], { stdio: ["pipe", "pipe", "pipe"] });
+    children.push(parent);
+
+    const parentPid = parent.pid!;
+    expect(parentPid).toBeDefined();
+
+    // Wait for child PID output
+    const childPidStr = await new Promise<string>((resolve) => {
+      parent.stdout.once("data", (d) => resolve(d.toString().trim()));
+    });
+    const childPid = Number.parseInt(childPidStr, 10);
+    expect(childPid).toBeGreaterThan(0);
+
+    // Verify both are running
+    expect(() => process.kill(parentPid, 0)).not.toThrow();
+    expect(() => process.kill(childPid, 0)).not.toThrow();
+
+    // Kill the tree
+    killProcessTree(parentPid);
+
+    // Wait a bit for system to process signals
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // Verify both are dead
+    let parentAlive = true;
+    try {
+      process.kill(parentPid, 0);
+    } catch {
+      parentAlive = false;
+    }
+
+    let childAlive = true;
+    try {
+      process.kill(childPid, 0);
+    } catch {
+      childAlive = false;
+    }
+
+    expect(parentAlive).toBe(false);
+    expect(childAlive).toBe(false);
+  });
+});


### PR DESCRIPTION
## Description
Previously, `killProcessTree` tried `process.kill(-pid)` which only works if the pid is a process group leader. When processes are spawned without `detached: true`, they share the parent's group, so this call fails. Fallback was `process.kill(pid)`, which left children orphaned.

## Fix
Added manual descendant discovery using `pgrep -P` when group kill fails, ensuring the entire tree is terminated.

## AI Transparency
- **Assisted by**: OpenClaw Agent (Claude 3.5 Sonnet / Opus)
- **Testing level**: Fully tested with new unit tests
- **Prompt strategy**: Self-correction loop based on codebase analysis

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes orphaned child processes on Unix by adding `pgrep -P` based manual tree traversal when `process.kill(-pid, "SIGKILL")` fails (i.e., when the target process is not a process group leader). The implementation uses a BFS to discover all descendants before killing them bottom-up, then kills the root process last.

- Adds `getChildrenUnix()` helper using `execSync('pgrep -P <pid>')` for child PID discovery
- Replaces the old SIGTERM → grace period → SIGKILL flow with immediate SIGKILL (consistent with how all callers use this function — they only invoke it when SIGKILL is intended)
- Adds a new Unix-specific integration test verifying tree termination via the manual traversal path
- **Important**: A duplicate `killProcessTree` in `src/agents/shell-utils.ts` (used by `auto-reply/reply/bash-command.ts` and e2e tests) still has the old orphan-producing fallback and was not updated

<h3>Confidence Score: 3/5</h3>

- The core fix is sound but the duplicate implementation in shell-utils.ts means the orphan bug persists for some callers.
- The pgrep-based tree traversal is a correct fix for the orphan problem, and the test validates the new path. Score is 3 rather than higher because the same bug exists in a duplicate killProcessTree in src/agents/shell-utils.ts that was not updated, leaving some call sites still vulnerable to orphaned processes.
- src/agents/shell-utils.ts contains a duplicate killProcessTree that was not updated with the same fix and still orphans children.

<sub>Last reviewed commit: e4f4d21</sub>

<!-- greptile_other_comments_section -->

<sub>(1/5) You can manually trigger the agent by mentioning @greptileai in a comment!</sub>

<!-- /greptile_comment -->