### PR TITLE
fix: add catalog validation to `models set` command

### DIFF
--- a/src/commands/models/set.ts
+++ b/src/commands/models/set.ts
@@ -1,12 +1,46 @@
 import type { RuntimeEnv } from "../../runtime.js";
+import { loadModelCatalog } from "../../agents/model-catalog.js";
+import { modelKey } from "../../agents/model-selection.js";
+import { readConfigFileSnapshot } from "../../config/config.js";
 import { logConfigUpdated } from "../../config/logging.js";
-import { applyDefaultModelPrimaryUpdate, updateConfig } from "./shared.js";
+import { applyDefaultModelPrimaryUpdate, resolveModelTarget, updateConfig } from "./shared.js";
 
 export async function modelsSetCommand(modelRaw: string, runtime: RuntimeEnv) {
-  const updated = await updateConfig((cfg) => {
-    return applyDefaultModelPrimaryUpdate({ cfg, modelRaw, field: "model" });
+  // 1. Read config and resolve the model reference
+  const snapshot = await readConfigFileSnapshot();
+  if (!snapshot.valid) {
+    const issues = snapshot.issues.map((i) => `- ${i.path}: ${i.message}`).join("\n");
+    throw new Error(`Invalid config at ${snapshot.path}\n${issues}`);
+  }
+  const cfg = snapshot.config;
+  const resolved = resolveModelTarget({ raw: modelRaw, cfg });
+  const key = `${resolved.provider}/${resolved.model}`;
+
+  // 2. Validate against catalog (skip when catalog is empty — initial setup)
+  const catalog = await loadModelCatalog({ config: cfg });
+  if (catalog.length > 0) {
+    const catalogKeys = new Set(catalog.map((e) => modelKey(e.provider, e.id)));
+    if (!catalogKeys.has(key)) {
+      throw new Error(
+        `Unknown model: ${key}\nModel not found in catalog. Run "openclaw models list" to see available models.`,
+      );
+    }
+  }
+
+  // 3. Track whether this is a new entry
+  const isNewEntry = !cfg.agents?.defaults?.models?.[key];
+
+  // 4. Update config (using upstream's helper for the actual mutation)
+  const updated = await updateConfig((c) => {
+    return applyDefaultModelPrimaryUpdate({ cfg: c, modelRaw, field: "model" });
   });
 
+  // 5. Warn and log
+  if (isNewEntry) {
+    runtime.log(
+      `Warning: "${key}" had no entry in models config. Added with empty config (no provider routing).`,
+    );
+  }
   logConfigUpdated(runtime);
   runtime.log(`Default model: ${updated.agents?.defaults?.model?.primary ?? modelRaw}`);
 }


### PR DESCRIPTION
## Summary

- Problem: `models set` accepts any string as model ID — typos silently persist in config and fail at runtime with "Unknown model"
- Why it matters: Silent misconfiguration is hard to diagnose; empty `{}` entries bypass provider routing constraints configured for other models
- What changed: Added catalog validation (rejects unknown model IDs) and a warning when adding models with no existing config entry
- What did NOT change (scope boundary): No changes to `/model` chat command, `models list`, or the allowlist/routing logic itself

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #17183

## User-visible / Behavior Changes

- `openclaw models set <invalid-model>` now exits with an error: `Unknown model: <id>` (previously succeeded silently)
- `openclaw models set <valid-model-without-config>` now prints a warning before applying (previously silent)
- When the catalog is empty (initial setup before first gateway connection), validation is skipped to avoid blocking setup

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Amazon Linux 2023 (aarch64)
- Runtime/container: Node.js v22, npm global install
- Model/provider: OpenRouter
- Integration/channel (if any): Slack (socket mode)
- Relevant config (redacted): `agents.defaults.models` with provider routing entries

### Steps

1. `openclaw models set openrouter/nonexistent/fake-model-v99`
2. Observe error message
3. `openclaw models set openrouter/openai/gpt-4o` (valid model not in config)
4. Observe warning + successful update

### Expected

- Step 1: Error with "Unknown model" message
- Step 3: Warning about empty config, then success

### Actual

- Before fix: Both steps succeed silently
- After fix: Matches expected behavior

## Evidence

- [x] Trace/log snippets

Before:
```
$ openclaw models set openrouter/typo/nonexistent
Config updated.
Default model: openrouter/typo/nonexistent
```

After:
```
$ openclaw models set openrouter/typo/nonexistent
Error: Unknown model: openrouter/typo/nonexistent
Model not found in catalog. Run "openclaw models list" to see available models.
```

## Human Verification (required)

- Verified scenarios: Typo rejection, valid model switch, new model addition warning
- Edge cases checked: Empty catalog (initial setup) — validation is skipped
- What you did **not** verify: Interaction with `--force` or `--skip-validation` flags (none exist)

## Compatibility / Migration

- Backward compatible? `Yes` — existing valid configurations are unaffected
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this single commit
- Files/config to restore: `src/commands/models/set.ts`
- Known bad symptoms reviewers should watch for: False rejections of valid model IDs (would indicate catalog loading failure)

## Risks and Mitigations

- Risk: Catalog loading may fail in offline/air-gapped environments, causing all `models set` to be rejected
  - Mitigation: Catalog is skipped when empty (length === 0), which covers initial setup and environments where the gateway hasn't been contacted

✍️ Author: Claude Code with @carrotRakko (AI-written, human-approved)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added validation to reject invalid model IDs in `models set` command by checking against the catalog loaded from `loadModelCatalog`. The validation is skipped when the catalog is empty to allow initial setup scenarios. The implementation also warns when adding models that don't have existing config entries.

The change prevents typos from being silently persisted in config by validating model IDs against the catalog before applying updates. The warning for new entries helps users understand when models are being added without explicit provider routing configuration.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with only minor concerns about test coverage
- The implementation is straightforward and follows existing patterns. The validation logic is sound and includes proper edge case handling (empty catalog). However, the new validation logic lacks test coverage, which prevents a score of 5.
- Consider adding tests that mock `loadModelCatalog` to verify the validation behavior in `src/commands/models.set.e2e.test.ts`

<sub>Last reviewed commit: 11aab35</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->