### PR TITLE
fix(cron): clear stuck runningAtMs after timeout and add maintenance ticks

### DIFF
--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -19,7 +19,7 @@ import {
   normalizeRequiredName,
 } from "./normalize.js";
 
-const STUCK_RUN_MS = 2 * 60 * 60 * 1000;
+const STUCK_RUN_MS = 30 * 60 * 1000;
 
 function resolveEveryAnchorMs(params: {
   schedule: { everyMs: number; anchorMs?: number };

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -556,7 +556,7 @@ export async function executeJob(
     sessionKey?: string;
   };
   try {
-    let timeoutId: NodeJS.Timeout;
+    let timeoutId: NodeJS.Timeout | undefined;
     coreResult = await Promise.race([
       executeJobCore(state, job),
       new Promise<never>((_, reject) => {
@@ -565,7 +565,7 @@ export async function executeJob(
           jobTimeoutMs,
         );
       }),
-    ]).finally(() => clearTimeout(timeoutId!));
+    ]).finally(() => timeoutId && clearTimeout(timeoutId));
   } catch (err) {
     coreResult = { status: "error", error: String(err) };
   }

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -126,7 +126,13 @@ export function armTimer(state: CronServiceState) {
     return;
   }
   const nextAt = nextWakeAtMs(state);
-  if (!nextAt) {
+  // Even when no jobs are due, schedule a periodic maintenance tick to clear
+  // stuck runningAtMs markers that survived crashes or hung executions (#18120).
+  const MAINTENANCE_TICK_MS = 5 * 60_000; // 5 minutes
+  const hasStuckJobs = (state.store?.jobs ?? []).some(
+    (j) => j.enabled && typeof j.state.runningAtMs === "number",
+  );
+  if (!nextAt && !hasStuckJobs) {
     const jobCount = state.store?.jobs.length ?? 0;
     const enabledCount = state.store?.jobs.filter((j) => j.enabled).length ?? 0;
     const withNextRun =
@@ -139,7 +145,8 @@ export function armTimer(state: CronServiceState) {
     return;
   }
   const now = state.deps.nowMs();
-  const delay = Math.max(nextAt - now, 0);
+  const effectiveNextAt = nextAt ?? now + MAINTENANCE_TICK_MS;
+  const delay = Math.max(effectiveNextAt - now, 0);
   // Wake at least once a minute to avoid schedule drift and recover quickly
   // when the process was paused or wall-clock time jumps.
   const clampedDelay = Math.min(delay, MAX_TIMER_DELAY_MS);
@@ -152,7 +159,7 @@ export function armTimer(state: CronServiceState) {
     });
   }, clampedDelay);
   state.deps.log.debug(
-    { nextAt, delayMs: clampedDelay, clamped: delay > MAX_TIMER_DELAY_MS },
+    { nextAt: nextAt ?? null, delayMs: clampedDelay, clamped: delay > MAX_TIMER_DELAY_MS, maintenance: !nextAt },
     "cron: timer armed",
   );
 }
@@ -536,6 +543,11 @@ export async function executeJob(
   job.state.lastError = undefined;
   emit(state, { jobId: job.id, action: "started", runAtMs: startedAt });
 
+  const jobTimeoutMs =
+    job.payload.kind === "agentTurn" && typeof job.payload.timeoutSeconds === "number"
+      ? job.payload.timeoutSeconds * 1_000
+      : DEFAULT_JOB_TIMEOUT_MS;
+
   let coreResult: {
     status: "ok" | "error" | "skipped";
     error?: string;
@@ -544,7 +556,16 @@ export async function executeJob(
     sessionKey?: string;
   };
   try {
-    coreResult = await executeJobCore(state, job);
+    let timeoutId: NodeJS.Timeout;
+    coreResult = await Promise.race([
+      executeJobCore(state, job),
+      new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(
+          () => reject(new Error("cron: job execution timed out")),
+          jobTimeoutMs,
+        );
+      }),
+    ]).finally(() => clearTimeout(timeoutId!));
   } catch (err) {
     coreResult = { status: "error", error: String(err) };
   }


### PR DESCRIPTION
## Problem

When a cron job fires and the spawned session times out or crashes, `runningAtMs` is never cleared, permanently blocking that cron job from executing again. The only recovery is manually toggling the job's `enabled` flag.

## Root Cause

Three gaps in the cron scheduler:

### 1. `executeJob()` has no timeout
The `onTimer()` code path wraps `executeJobCore()` in `Promise.race` with a timeout — but `executeJob()` (used by manual `cron run` and `runMissedJobs` on startup) calls `executeJobCore()` directly without any timeout. A hung execution leaves `runningAtMs` set indefinitely.

### 2. `armTimer()` stops scheduling when only stuck jobs remain
When the only enabled job has `runningAtMs` set, `nextWakeAtMs()` returns `undefined` (the stuck job isn't counted as having a valid `nextRunAtMs`). `armTimer()` then skips scheduling entirely, so the `STUCK_RUN_MS` safety net in `recomputeNextRuns()` never fires — no timer tick, no cleanup.

### 3. `STUCK_RUN_MS` is too conservative (2 hours)
Most cron jobs complete in seconds to minutes. A 2-hour stuck marker window is unnecessarily long.

## Fix

1. **Add `Promise.race` timeout to `executeJob()`** — mirrors the existing pattern in `onTimer()`, using `payload.timeoutSeconds` or `DEFAULT_JOB_TIMEOUT_MS` (10 min).

2. **Schedule maintenance ticks in `armTimer()` when stuck jobs exist** — detects enabled jobs with `runningAtMs` set and schedules a 5-minute maintenance tick so `recomputeNextRuns()` can clear expired markers.

3. **Reduce `STUCK_RUN_MS` from 2 hours to 30 minutes** — still generous as a safety net, but much more practical.

## Testing

The existing test suites for cron service/jobs should continue to pass. The `executeJob` timeout follows the exact same pattern already tested in `onTimer`.

Fixes #18120

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a critical issue where cron jobs become permanently blocked when execution times out or crashes. The PR addresses three gaps: adds timeout protection to `executeJob()`, schedules maintenance ticks to clear stuck markers when regular jobs aren't due, and reduces the stuck-marker threshold from 2 hours to 30 minutes for faster recovery.

<h3>Confidence Score: 4/5</h3>

- Safe to merge - fixes critical recovery gap with well-tested timeout pattern
- The changes follow existing patterns, address a real production issue, and the timeout logic is actually safer than the existing implementation. Minor deduction because the maintenance tick adds a new periodic scheduling path that hasn't been battle-tested yet.
- No files require special attention

<sub>Last reviewed commit: 63413e1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->