### PR TITLE
feat: support per-model thinkingDefault override in models config

### DIFF
--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -425,10 +425,29 @@ export function resolveThinkingDefault(params: {
   model: string;
   catalog?: ModelCatalogEntry[];
 }): ThinkLevel {
+  // 1. Per-model thinkingDefault (highest priority)
+  // Normalize config keys via parseModelRef (consistent with buildModelAliasIndex,
+  // buildAllowedModelSet, etc.) so aliases like "anthropic/opus-4.6" resolve correctly.
+  const configModels = params.cfg.agents?.defaults?.models ?? {};
+  for (const [rawKey, entry] of Object.entries(configModels)) {
+    const parsed = parseModelRef(rawKey, params.provider);
+    if (
+      parsed &&
+      parsed.provider === params.provider &&
+      parsed.model === params.model &&
+      entry?.thinkingDefault
+    ) {
+      return entry.thinkingDefault as ThinkLevel;
+    }
+  }
+
+  // 2. Global thinkingDefault
   const configured = params.cfg.agents?.defaults?.thinkingDefault;
   if (configured) {
     return configured;
   }
+
+  // 3. Auto-detect from model catalog (reasoning-capable → "low")
   const candidate = params.catalog?.find(
     (entry) => entry.provider === params.provider && entry.id === params.model,
   );

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -18,6 +18,8 @@ export type AgentModelEntryConfig = {
   params?: Record<string, unknown>;
   /** Enable streaming for this model (default: true, false for Ollama to avoid SDK issue #1205). */
   streaming?: boolean;
+  /** Per-model default thinking level (overrides global thinkingDefault). */
+  thinkingDefault?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
 };
 
 export type AgentModelListConfig = {

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -38,6 +38,17 @@ export const AgentDefaultsSchema = z
             params: z.record(z.string(), z.unknown()).optional(),
             /** Enable streaming for this model (default: true, false for Ollama to avoid SDK issue #1205). */
             streaming: z.boolean().optional(),
+            /** Per-model default thinking level (overrides global thinkingDefault). */
+            thinkingDefault: z
+              .union([
+                z.literal("off"),
+                z.literal("minimal"),
+                z.literal("low"),
+                z.literal("medium"),
+                z.literal("high"),
+                z.literal("xhigh"),
+              ])
+              .optional(),
           })
           .strict(),
       )


### PR DESCRIPTION
## Summary

With the recent addition of separate heartbeat model overrides (`heartbeat.model`), users now commonly run different models for heartbeat vs. chat — e.g., a lightweight model like `gemini/gemini-2.5-flash` for periodic heartbeats and a heavier model like `openai/o3` for interactive conversations.

The problem: these models have very different reasoning capabilities, but `thinkingDefault` is a single global setting. Setting `"high"` works great for O3 but wastes tokens (or errors) on Gemini Flash; setting `"off"` globally means O3 never uses its extended thinking. Today the only workaround is manually toggling `/think` per session, which defeats the purpose of autonomous heartbeat runs.

This PR adds an optional `thinkingDefault` field to each model entry under `agents.defaults.models`, so the thinking level resolves automatically based on which model is active.

**Resolution priority:** per-model → global → catalog auto-detect (existing fallback behavior unchanged).

### Config example

```json
{
  "agents": {
    "defaults": {
      "thinkingDefault": "low",
      "models": {
        "anthropic/claude-opus-4-6":   { "thinkingDefault": "high" },
        "google/gemini-2.5-flash":     { "thinkingDefault": "low" },
        "openai/gpt-4o":               { "thinkingDefault": "off" }
      }
    }
  }
}
```

### Changes (3 files, +32 lines)

- `src/config/types.agent-defaults.ts` — Add optional `thinkingDefault` to `AgentModelEntryConfig`
- `src/config/zod-schema.agent-defaults.ts` — Add zod validation for the new field
- `src/agents/model-selection.ts` — Look up per-model entry before falling back to global default in `resolveThinkingDefault()`

### Backward compatible

- New field is fully optional
- Existing configs without per-model `thinkingDefault` behave exactly as before
- No breaking changes to the resolution chain

### Test plan

- [x] `pnpm build` passes
- [x] `tsgo --noEmit` type check passes
- [x] `oxlint` on changed files: 0 errors
- [x] `model-selection.test.ts` (10 tests) passes
- [x] `run.skill-filter.test.ts` (5 tests, imports resolveThinkingDefault) passes
- [x] `config.schema-regressions.test.ts` passes