### PR TITLE
fix(exec): disable detached mode on Windows to restore stdout capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Exec/Windows: disable `detached` mode on Windows in `createChildAdapter()` so stdout/stderr are captured correctly, restoring exec tool output on native Windows. (#18085)
+
 - Security/Sessions: create new session transcript JSONL files with user-only (`0o600`) permissions and extend `openclaw security audit --fix` to remediate existing transcript file permissions.
 - Infra/Fetch: ensure foreign abort-signal listener cleanup never masks original fetch successes/failures, while still preventing detached-finally unhandled rejection noise in `wrapFetchWithAbortSignal`. Thanks @Jackten.
 - Gateway/Config: prevent `config.patch` object-array merges from falling back to full-array replacement when some patch entries lack `id`, so partial `agents.list` updates no longer drop unrelated agents. (#17989) Thanks @stakeswky.

--- a/src/process/supervisor/adapters/child.test.ts
+++ b/src/process/supervisor/adapters/child.test.ts
@@ -50,7 +50,7 @@ describe("createChildAdapter", () => {
       options?: { detached?: boolean };
       fallbacks?: Array<{ options?: { detached?: boolean } }>;
     };
-    expect(spawnArgs.options?.detached).toBe(true);
+    expect(spawnArgs.options?.detached).toBe(process.platform !== "win32");
     expect(spawnArgs.fallbacks?.[0]?.options?.detached).toBe(false);
 
     adapter.kill();

--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -46,7 +46,7 @@ export async function createChildAdapter(params: {
     cwd: params.cwd,
     env: params.env ? toStringEnv(params.env) : undefined,
     stdio: ["pipe", "pipe", "pipe"],
-    detached: true,
+    detached: process.platform !== "win32",
     windowsHide: true,
     windowsVerbatimArguments: params.windowsVerbatimArguments,
   };


### PR DESCRIPTION
## Summary

- Disable detached: true on Windows in createChildAdapter() by using process.platform !== win32 so that stdout/stderr pipes remain connected and exec tool output is captured correctly.

Fixes #18085

## Changes

- src/process/supervisor/adapters/child.ts: Changed detached: true to detached: process.platform !== win32 -- Windows does not support detached child process stdio piping the same way Unix does, causing empty output from all exec tool invocations.
- CHANGELOG.md: Added entry under Fixes.

## Test plan

- [x] Verified the fix is a one-line platform guard consistent with existing resolveCommand() win32 handling in the same file
- [ ] Manual test: run exec tool on Windows -- stdout/stderr should now appear
- [x] Existing tests pass (5/5 on Linux -- the change is a no-op on non-Windows)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Conditionally disables `detached` mode on Windows in `createChildAdapter()` by changing `detached: true` to `detached: process.platform !== "win32"`. This fixes stdout/stderr capture on Windows since Windows doesn't support detached child process stdio piping like Unix systems do. The test assertion was updated to match the new platform-conditional behavior, addressing the previous review comment.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a targeted, well-understood platform-specific fix that mirrors existing `process.platform !== "win32"` checks in the same file (see `resolveCommand()` at line 8). The test was correctly updated to validate the new behavior, and the fix is a no-op on non-Windows platforms where existing tests pass.
- No files require special attention

<sub>Last reviewed commit: 5c94a8f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->