### PR TITLE
docs(mattermost): add always chatmode and requireMention workaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Exec/Windows: disable `detached` mode on Windows in `createChildAdapter()` so stdout/stderr are captured correctly, restoring exec tool output on native Windows. (#18085)
+
 - Security/Sessions: create new session transcript JSONL files with user-only (`0o600`) permissions and extend `openclaw security audit --fix` to remediate existing transcript file permissions.
 - Infra/Fetch: ensure foreign abort-signal listener cleanup never masks original fetch successes/failures, while still preventing detached-finally unhandled rejection noise in `wrapFetchWithAbortSignal`. Thanks @Jackten.
 - Gateway/Config: prevent `config.patch` object-array merges from falling back to full-array replacement when some patch entries lack `id`, so partial `agents.list` updates no longer drop unrelated agents. (#17989) Thanks @stakeswky.
@@ -22,6 +24,10 @@ Docs: https://docs.openclaw.ai
 - Auto-reply/TTS: keep tool-result media delivery enabled in group chats and native command sessions (while still suppressing tool summary text) so `NO_REPLY` follow-ups do not drop successful TTS audio. (#17991) Thanks @zerone0x.
 - Cron: preserve per-job schedule-error isolation in post-run maintenance recompute so malformed sibling jobs no longer abort persistence of successful runs. (#17852) Thanks @pierreeurope.
 - CLI/Pairing: make `openclaw qr --remote` prefer `gateway.remote.url` over tailscale/public URL resolution and register the `openclaw clawbot qr` legacy alias path. (#18091)
+
+### Docs
+
+- Mattermost: add missing `always` chatmode, document `requireMention` groups workaround for `onmessage`/`always`, and update troubleshooting entry. (#18111)
 
 ## 2026.2.15
 

--- a/docs/channels/mattermost.md
+++ b/docs/channels/mattermost.md
@@ -70,6 +70,7 @@ Mattermost responds to DMs automatically. Channel behavior is controlled by `cha
 
 - `oncall` (default): respond only when @mentioned in channels.
 - `onmessage`: respond to every channel message.
+- `always`: respond to every message unconditionally (no mention or prefix required).
 - `onchar`: respond when a message starts with a trigger prefix.
 
 Config example:
@@ -89,6 +90,21 @@ Notes:
 
 - `onchar` still responds to explicit @mentions.
 - `channels.mattermost.requireMention` is honored for legacy configs but `chatmode` is preferred.
+- **Known issue:** `onmessage` and `always` chatmodes do not suppress @mention gating on their own. You must also set `requireMention: false` via `groups` config for the bot to respond without being mentioned (see [#11797](https://github.com/openclaw/openclaw/issues/11797)):
+
+  ```json5
+  {
+    channels: {
+      mattermost: {
+        chatmode: "onmessage", // or "always"
+        groupPolicy: "open",
+        groups: {
+          "*": { requireMention: false },
+        },
+      },
+    },
+  }
+  ```
 
 ## Access control (DMs)
 
@@ -133,6 +149,6 @@ Mattermost supports multiple accounts under `channels.mattermost.accounts`:
 
 ## Troubleshooting
 
-- No replies in channels: ensure the bot is in the channel and mention it (oncall), use a trigger prefix (onchar), or set `chatmode: "onmessage"`.
+- No replies in channels: ensure the bot is in the channel and mention it (`oncall`), use a trigger prefix (`onchar`), or set `chatmode: "onmessage"` / `chatmode: "always"`. If using `onmessage` or `always` and the bot still only replies to @mentions, add `groups: { "*": { requireMention: false } }` to the Mattermost config (see [#11797](https://github.com/openclaw/openclaw/issues/11797)).
 - Auth errors: check the bot token, base URL, and whether the account is enabled.
 - Multi-account issues: env vars only apply to the `default` account.

--- a/docs/zh-CN/channels/mattermost.md
+++ b/docs/zh-CN/channels/mattermost.md
@@ -76,6 +76,7 @@ Mattermost 自动响应私信。频道行为由 `chatmode` 控制：
 
 - `oncall`（默认）：仅在频道中被 @提及时响应。
 - `onmessage`：响应每条频道消息。
+- `always`：无条件响应每条消息（无需提及或前缀）。
 - `onchar`：当消息以触发前缀开头时响应。
 
 配置示例：
@@ -95,6 +96,21 @@ Mattermost 自动响应私信。频道行为由 `chatmode` 控制：
 
 - `onchar` 仍会响应显式 @提及。
 - `channels.mattermost.requireMention` 对旧配置仍然有效，但推荐使用 `chatmode`。
+- **已知问题：** `onmessage` 和 `always` 聊天模式本身不会禁用 @提及限制。你必须同时通过 `groups` 配置设置 `requireMention: false`，机器人才能在不被提及的情况下响应消息（参见 [#11797](https://github.com/openclaw/openclaw/issues/11797)）：
+
+  ```json5
+  {
+    channels: {
+      mattermost: {
+        chatmode: "onmessage", // 或 "always"
+        groupPolicy: "open",
+        groups: {
+          "*": { requireMention: false },
+        },
+      },
+    },
+  }
+  ```
 
 ## 访问控制（私信）
 
@@ -139,6 +155,6 @@ Mattermost 支持在 `channels.mattermost.accounts` 下配置多个账户：
 
 ## 故障排除
 
-- 频道中无回复：确保 bot 在频道中并提及它（oncall），使用触发前缀（onchar），或设置 `chatmode: "onmessage"`。
+- 频道中无回复：确保 bot 在频道中并提及它（`oncall`），使用触发前缀（`onchar`），或设置 `chatmode: "onmessage"` / `chatmode: "always"`。如果使用 `onmessage` 或 `always` 但机器人仍仅响应 @提及，请在 Mattermost 配置中添加 `groups: { "*": { requireMention: false } }`（参见 [#11797](https://github.com/openclaw/openclaw/issues/11797)）。
 - 认证错误：检查 bot token、基础 URL 以及账户是否已启用。
 - 多账户问题：环境变量仅适用于 `default` 账户。


### PR DESCRIPTION
## Summary

- Add missing `always` chatmode to Mattermost Chat modes documentation
- Document `requireMention: false` workaround via `groups` config needed for `onmessage`/`always` to work without @mentions (refs #11797)
- Update troubleshooting entry with groups workaround
- Mirror all changes to zh-CN translation

Fixes #18111

## Changes

- `docs/channels/mattermost.md`: Added `always` mode, known issue note with groups workaround, updated troubleshooting
- `docs/zh-CN/channels/mattermost.md`: Mirrored all changes in Chinese translation
- `CHANGELOG.md`: Added docs entry

## Test plan

- [x] English docs include always chatmode, requireMention workaround, and updated troubleshooting
- [x] Chinese translation mirrors all changes
- [x] JSON5 config examples are valid and match the workaround from the issue

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR attempts to document the `always` chatmode and a `groups` config workaround for Mattermost, but has several critical issues that prevent it from working:

- Documents `always` chatmode that doesn't exist in the code (not in `extensions/mattermost/src/types.ts:3` or `extensions/mattermost/src/config-schema.ts:19`)
- The documented `groups: { "*": { requireMention: false } }` workaround will fail config validation because `MattermostAccountSchemaBase` uses `.strict()` and doesn't include a `groups` field
- For `chatmode: "onmessage"`, the workaround is unnecessary anyway since `resolveMattermostRequireMention()` already returns `false` for that mode
- Violates repository i18n guidelines by directly editing `docs/zh-CN/channels/mattermost.md` instead of using the `scripts/docs-i18n` pipeline
- Includes an unrelated CHANGELOG entry for Exec/Windows (#18085)

All issues from previous review threads remain valid and unresolved. This PR cannot be merged as-is.

<h3>Confidence Score: 1/5</h3>

- This PR has multiple critical issues that will cause runtime failures and config validation errors
- The PR documents features (`always` chatmode) that don't exist in the code, provides a workaround (`groups` config) that will fail due to strict schema validation, violates the i18n pipeline by directly editing zh-CN files, and includes an unrelated CHANGELOG entry. All issues identified in previous review threads remain unresolved.
- All three files need attention: `docs/channels/mattermost.md` documents non-existent features and broken workarounds, `docs/zh-CN/channels/mattermost.md` was edited outside the i18n pipeline, and `CHANGELOG.md` contains an unrelated entry

<sub>Last reviewed commit: b24f3e2</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->