### PR TITLE
feat: add llms.txt discovery as default agent behavior

### DIFF
--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -147,6 +147,23 @@ function buildVoiceSection(params: { isMinimal: boolean; ttsHint?: string }) {
   return ["## Voice (TTS)", hint, ""];
 }
 
+function buildLlmsTxtSection(params: { isMinimal: boolean; availableTools: Set<string> }) {
+  if (params.isMinimal) {
+    return [];
+  }
+  if (!params.availableTools.has("web_fetch")) {
+    return [];
+  }
+  return [
+    "## llms.txt Discovery",
+    "When exploring a new domain or website (via web_fetch or browser), check for an llms.txt file that describes how AI agents should interact with the site:",
+    "- Try `/llms.txt` or `/.well-known/llms.txt` at the domain root",
+    "- If found, follow its guidance for interacting with that site's content and APIs",
+    "- llms.txt is an emerging standard (like robots.txt for AI) — not all sites have one, so don't warn if missing",
+    "",
+  ];
+}
+
 function buildDocsSection(params: { docsPath?: string; isMinimal: boolean; readToolName: string }) {
   const docsPath = params.docsPath?.trim();
   if (!docsPath || params.isMinimal) {
@@ -540,6 +557,7 @@ export function buildAgentSystemPrompt(params: {
       messageToolHints: params.messageToolHints,
     }),
     ...buildVoiceSection({ isMinimal, ttsHint: params.ttsHint }),
+    ...buildLlmsTxtSection({ isMinimal, availableTools }),
   ];
 
   if (extraSystemPrompt) {

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -736,7 +736,7 @@ export function createWebFetchTool(options?: {
     label: "Web Fetch",
     name: "web_fetch",
     description:
-      "Fetch and extract readable content from a URL (HTML → markdown/text). Use for lightweight page access without browser automation.",
+      "Fetch and extract readable content from a URL (HTML → markdown/text). Use for lightweight page access without browser automation. When exploring a new domain, also check for /llms.txt or /.well-known/llms.txt — these files describe how AI agents should interact with the site.",
     parameters: WebFetchSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;


### PR DESCRIPTION
## Summary

Adds automatic llms.txt awareness so OpenClaw agents check for `/llms.txt` or `/.well-known/llms.txt` when exploring new domains.

## Changes

- **System prompt**: New `llms.txt Discovery` section (full mode only, when `web_fetch` is available) instructing agents to check for llms.txt files when visiting new domains
- **web_fetch tool**: Updated description to mention llms.txt discovery

## Why

[llms.txt](https://llmstxt.org) is an emerging standard (like robots.txt for AI) that helps site owners describe how AI agents should interact with their content and APIs. Making this a default agent behavior:

- Helps the ecosystem adopt agent-native web experiences
- Gives agents better context about how to use a site's resources
- Zero cost when the file doesn't exist (agents just move on)
- Respects site owner preferences for AI interaction

## Details

The system prompt section is:
- Only included in `full` prompt mode (not subagents)
- Only included when `web_fetch` tool is available
- Instructs agents not to warn when llms.txt is missing (most sites don't have one yet)

TypeScript compiles cleanly with no errors.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds automatic llms.txt awareness to OpenClaw agents. When the `web_fetch` tool is available and the prompt mode is `full` (not subagents), the system prompt now includes a new "llms.txt Discovery" section instructing agents to check for `/llms.txt` or `/.well-known/llms.txt` when visiting new domains. The `web_fetch` tool description is also updated to mention this behavior.

- The `buildLlmsTxtSection` function follows the same pattern as other section builders (`buildVoiceSection`, `buildMemorySection`, etc.) with proper `isMinimal` and tool-availability guards
- The section is correctly excluded for subagent/minimal/none prompt modes
- One logic gap: the guard only checks for `web_fetch` availability, but the prompt text mentions "via web_fetch or browser" — agents with only `browser` available won't see this section
- The existing minimal-mode test (`system-prompt.e2e.test.ts`) does not include `web_fetch` in `toolNames` and does not assert that the new section is excluded, so the new behavior has no direct test coverage

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it only adds prompt text and a tool description update with no runtime logic changes.
- The changes are low-risk (prompt text additions only, no runtime behavior changes). The section builder follows established patterns and has proper guards. One minor logic inconsistency exists between the guard condition and the prompt text regarding the `browser` tool, but this won't cause failures — it just means agents with only `browser` available won't get the llms.txt hint. No test coverage was added for the new section.
- `src/agents/system-prompt.ts` — the `buildLlmsTxtSection` guard/text mismatch regarding `browser` tool should be reconciled

<sub>Last reviewed commit: 731963a</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->