### PR TITLE
fix(cli): suppress file logging during completion to prevent log noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/Completion: suppress file logging during `openclaw completion` so the completion script and module-loading output do not pollute the shared gateway log file. (#18108)
+
 - Security/Sessions: create new session transcript JSONL files with user-only (`0o600`) permissions and extend `openclaw security audit --fix` to remediate existing transcript file permissions.
 - Infra/Fetch: ensure foreign abort-signal listener cleanup never masks original fetch successes/failures, while still preventing detached-finally unhandled rejection noise in `wrapFetchWithAbortSignal`. Thanks @Jackten.
 - Gateway/Config: prevent `config.patch` object-array merges from falling back to full-array replacement when some patch entries lack `id`, so partial `agents.list` updates no longer drop unrelated agents. (#17989) Thanks @stakeswky.
@@ -36,6 +38,8 @@ Docs: https://docs.openclaw.ai
 - Channels: deduplicate probe/token resolution base types across core + extensions while preserving per-channel error typing. (#16986) Thanks @iyoda and @thewilloftheshadow.
 
 ### Fixes
+
+- CLI/Completion: suppress file logging during `openclaw completion` so the completion script and module-loading output do not pollute the shared gateway log file. (#18108)
 
 - Security: replace deprecated SHA-1 sandbox configuration hashing with SHA-256 for deterministic sandbox cache identity and recreation checks. Thanks @kexinoh.
 - Security/Logging: redact Telegram bot tokens from error messages and uncaught stack traces to prevent accidental secret leakage into logs. Thanks @aether-ai-agent.
@@ -93,6 +97,8 @@ Docs: https://docs.openclaw.ai
 - Agents: add optional `messages.suppressToolErrors` config to hide non-mutating tool-failure warnings from user-facing chat while still surfacing mutating failures. (#16620) Thanks @vai-oro.
 
 ### Fixes
+
+- CLI/Completion: suppress file logging during `openclaw completion` so the completion script and module-loading output do not pollute the shared gateway log file. (#18108)
 
 - Security/Sessions/Telegram: restrict session tool targeting by default to the current session tree (`tools.sessions.visibility`, default `tree`) with sandbox clamping, and pass configured per-account Telegram webhook secrets in webhook mode when no explicit override is provided. Thanks @aether-ai-agent.
 - CLI/Plugins: ensure `openclaw message send` exits after successful delivery across plugin-backed channels so one-shot sends do not hang. (#16491) Thanks @yinghaosang.
@@ -250,6 +256,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/Completion: suppress file logging during `openclaw completion` so the completion script and module-loading output do not pollute the shared gateway log file. (#18108)
+
 - Gateway/Auth: add trusted-proxy mode hardening follow-ups by keeping `OPENCLAW_GATEWAY_*` env compatibility, auto-normalizing invalid setup combinations in interactive `gateway configure` (trusted-proxy forces `bind=lan` and disables Tailscale serve/funnel), and suppressing shared-secret/rate-limit audit findings that do not apply to trusted-proxy deployments. (#15940) Thanks @nickytonline.
 - Docs/Hooks: update hooks documentation URLs to the new `/automation/hooks` location. (#16165) Thanks @nicholascyh.
 - Security/Audit: warn when `gateway.tools.allow` re-enables default-denied tools over HTTP `POST /tools/invoke`, since this can increase RCE blast radius if the gateway is reachable.
@@ -366,6 +374,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/Completion: suppress file logging during `openclaw completion` so the completion script and module-loading output do not pollute the shared gateway log file. (#18108)
+
 - Gateway/OpenResponses: harden URL-based `input_file`/`input_image` handling with explicit SSRF deny policy, hostname allowlists (`files.urlAllowlist` / `images.urlAllowlist`), per-request URL input caps (`maxUrlParts`), blocked-fetch audit logging, and regression coverage/docs updates.
 - Sessions: guard `withSessionStoreLock` against undefined `storePath` to prevent `path.dirname` crash. (#14717)
 - Security: fix unauthenticated Nostr profile API remote config tampering. (#13719) Thanks @coygeek.
@@ -474,6 +484,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/Completion: suppress file logging during `openclaw completion` so the completion script and module-loading output do not pollute the shared gateway log file. (#18108)
+
 - Cron: prevent one-shot `at` jobs from re-firing on gateway restart when previously skipped or errored. (#13845)
 - Discord: add exec approval cleanup option to delete DMs after approval/denial/timeout. (#13205) Thanks @thewilloftheshadow.
 - Sessions: prune stale entries, cap session store size, rotate large stores, accept duration/size thresholds, default to warn-only maintenance, and prune cron run sessions after retention windows. (#13083) Thanks @skyfallsin, @Glucksberg, @gumadeiras.
@@ -562,6 +574,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/Completion: suppress file logging during `openclaw completion` so the completion script and module-loading output do not pollute the shared gateway log file. (#18108)
+
 - TTS: add missing OpenAI voices (ballad, cedar, juniper, marin, verse) to the allowlist so they are recognized instead of silently falling back to Edge TTS. (#2393)
 - Cron: scheduler reliability (timer drift, restart catch-up, lock contention, stale running markers). (#10776) Thanks @tyler6204.
 - Cron: store migration hardening (legacy field migration, parse error handling, explicit delivery mode persistence). (#10776) Thanks @tyler6204.
@@ -598,6 +612,8 @@ Docs: https://docs.openclaw.ai
 - Cron: avoid duplicate deliveries when isolated runs send messages directly.
 
 ### Fixes
+
+- CLI/Completion: suppress file logging during `openclaw completion` so the completion script and module-loading output do not pollute the shared gateway log file. (#18108)
 
 - Control UI: add hardened fallback for asset resolution in global npm installs. (#4855) Thanks @anapivirtua.
 - Update: remove dead restore control-ui step that failed on gitignored dist/ output.
@@ -636,6 +652,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/Completion: suppress file logging during `openclaw completion` so the completion script and module-loading output do not pollute the shared gateway log file. (#18108)
+
 - Update: ship legacy daemon-cli shim for pre-tsdown update imports (fixes daemon restart after npm update).
 
 ## 2026.2.2-2
@@ -646,11 +664,15 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/Completion: suppress file logging during `openclaw completion` so the completion script and module-loading output do not pollute the shared gateway log file. (#18108)
+
 - CLI status: resolve build-info from bundled dist output (fixes "unknown" commit in npm builds).
 
 ## 2026.2.2-1
 
 ### Fixes
+
+- CLI/Completion: suppress file logging during `openclaw completion` so the completion script and module-loading output do not pollute the shared gateway log file. (#18108)
 
 - CLI status: fall back to build-info for version detection (fixes "unknown" in beta builds). Thanks @gumadeira.
 
@@ -668,6 +690,8 @@ Docs: https://docs.openclaw.ai
 - Docs: add zh-CN i18n guardrails to avoid editing generated translations. (#8416) Thanks @joshp123.
 
 ### Fixes
+
+- CLI/Completion: suppress file logging during `openclaw completion` so the completion script and module-loading output do not pollute the shared gateway log file. (#18108)
 
 - Docs: finish renaming the QMD memory docs to reference the OpenClaw state dir.
 - Onboarding: keep TUI flow exclusive (skip completion prompt + background Web UI seed).
@@ -720,6 +744,8 @@ Docs: https://docs.openclaw.ai
 - CI: add formal conformance + alias consistency checks. (#5723, #5807)
 
 ### Fixes
+
+- CLI/Completion: suppress file logging during `openclaw completion` so the completion script and module-loading output do not pollute the shared gateway log file. (#18108)
 
 - Security: guard remote media fetches with SSRF protections (block private/localhost, DNS pinning).
 - Updates: clean stale global install rename dirs and extend gateway update timeouts to avoid npm ENOTEMPTY failures.
@@ -780,6 +806,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/Completion: suppress file logging during `openclaw completion` so the completion script and module-loading output do not pollute the shared gateway log file. (#18108)
+
 - Security: guard remote media fetches with SSRF protections (block private/localhost, DNS pinning).
 - Updates: clean stale global install rename dirs and extend gateway update timeouts to avoid npm ENOTEMPTY failures.
 - Plugins: validate plugin/hook install paths and reject traversal-like names.
@@ -836,6 +864,8 @@ Docs: https://docs.openclaw.ai
 - Docker E2E: stabilize gateway readiness, plugin installs/manifests, and cleanup/doctor switch entrypoint checks.
 
 ### Fixes
+
+- CLI/Completion: suppress file logging during `openclaw completion` so the completion script and module-loading output do not pollute the shared gateway log file. (#18108)
 
 - Security: restrict local path extraction in media parser to prevent LFI. (#4880)
 - Gateway: prevent token defaults from becoming the literal "undefined". (#4873) Thanks @Hisleren.
@@ -927,6 +957,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/Completion: suppress file logging during `openclaw completion` so the completion script and module-loading output do not pollute the shared gateway log file. (#18108)
+
 - Skills: update session-logs paths to use ~/.openclaw. (#4502) Thanks @bonald.
 - Telegram: avoid silent empty replies by tracking normalization skips before fallback. (#3796)
 - Mentions: honor mentionPatterns even when explicit mentions are present. (#3303) Thanks @HirokiKobayashi-R.
@@ -981,6 +1013,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/Completion: suppress file logging during `openclaw completion` so the completion script and module-loading output do not pollute the shared gateway log file. (#18108)
+
 - Slack: fix image downloads failing due to missing Authorization header on cross-origin redirects. (#1936) Thanks @sanderhelgesen.
 - Gateway: harden reverse proxy handling for local-client detection and unauthenticated proxied connects. (#1795) Thanks @orlyjamie.
 - Security audit: flag loopback Control UI with auth disabled as critical. (#1795) Thanks @orlyjamie.
@@ -990,11 +1024,15 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/Completion: suppress file logging during `openclaw completion` so the completion script and module-loading output do not pollute the shared gateway log file. (#18108)
+
 - Packaging: include dist/link-understanding output in npm tarball (fixes missing apply.js import on install).
 
 ## 2026.1.24-1
 
 ### Fixes
+
+- CLI/Completion: suppress file logging during `openclaw completion` so the completion script and module-loading output do not pollute the shared gateway log file. (#18108)
 
 - Packaging: include dist/shared output in npm tarball (fixes missing reasoning-tags import on install).
 
@@ -1028,6 +1066,8 @@ Docs: https://docs.openclaw.ai
 - Dev: add prek pre-commit hooks + dependabot config for weekly updates. (#1720) Thanks @dguido.
 
 ### Fixes
+
+- CLI/Completion: suppress file logging during `openclaw completion` so the completion script and module-loading output do not pollute the shared gateway log file. (#18108)
 
 - Web UI: fix config/debug layout overflow, scrolling, and code block sizing. (#1715) Thanks @saipreetham589.
 - Web UI: show Stop button during active runs, swap back to New session when idle. (#1664) Thanks @ndbroadbent.
@@ -1073,6 +1113,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/Completion: suppress file logging during `openclaw completion` so the completion script and module-loading output do not pollute the shared gateway log file. (#18108)
+
 - Packaging: include dist/tts output in npm tarball (fixes missing dist/tts/tts.js).
 
 ## 2026.1.23
@@ -1101,6 +1143,8 @@ Docs: https://docs.openclaw.ai
 - Docs: clarify HEARTBEAT.md empty file skips heartbeats, missing file still runs. (#1535) Thanks @JustYannicc. https://docs.openclaw.ai/gateway/heartbeat
 
 ### Fixes
+
+- CLI/Completion: suppress file logging during `openclaw completion` so the completion script and module-loading output do not pollute the shared gateway log file. (#18108)
 
 - Sessions: accept non-UUID sessionIds for history/send/status while preserving agent scoping. (#1518)
 - Heartbeat: accept plugin channel ids for heartbeat target validation + UI hints.
@@ -1149,6 +1193,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/Completion: suppress file logging during `openclaw completion` so the completion script and module-loading output do not pollute the shared gateway log file. (#18108)
+
 - BlueBubbles: stop typing indicator on idle/no-reply. (#1439) Thanks @Nicell.
 - Message tool: keep path/filePath as-is for send; hydrate buffers only for sendAttachment. (#1444) Thanks @hopyky.
 - Auto-reply: only report a model switch when session state is available. (#1465) Thanks @robbyczgw-cla.
@@ -1179,6 +1225,8 @@ Docs: https://docs.openclaw.ai
 ## 2026.1.21-2
 
 ### Fixes
+
+- CLI/Completion: suppress file logging during `openclaw completion` so the completion script and module-loading output do not pollute the shared gateway log file. (#18108)
 
 - Control UI: ignore bootstrap identity placeholder text for avatar values and fall back to the default avatar. https://docs.openclaw.ai/cli/agents https://docs.openclaw.ai/web/control-ui
 - Slack: remove deprecated `filetype` field from `files.uploadV2` to eliminate API warnings. (#1447)
@@ -1214,6 +1262,8 @@ Docs: https://docs.openclaw.ai
 - **BREAKING:** Envelope and system event timestamps now default to host-local time (was UTC) so agents don’t have to constantly convert.
 
 ### Fixes
+
+- CLI/Completion: suppress file logging during `openclaw completion` so the completion script and module-loading output do not pollute the shared gateway log file. (#18108)
 
 - Nodes/macOS: prompt on allowlist miss for node exec approvals, persist allowlist decisions, and flatten node invoke errors. (#1394) Thanks @ngutman.
 - Gateway: keep auto bind loopback-first and add explicit tailnet binding to avoid Tailscale taking over local UI. (#1380)
@@ -1320,6 +1370,8 @@ Docs: https://docs.openclaw.ai
 - **BREAKING:** Reject invalid/unknown config entries and refuse to start the gateway for safety. Run `openclaw doctor --fix` to repair, then update plugins (`openclaw plugins update`) if you use any.
 
 ### Fixes
+
+- CLI/Completion: suppress file logging during `openclaw completion` so the completion script and module-loading output do not pollute the shared gateway log file. (#18108)
 
 - Discovery: shorten Bonjour DNS-SD service type to `_moltbot-gw._tcp` and update discovery clients/docs.
 - Diagnostics: export OTLP logs, correct queue depth tracking, and document message-flow telemetry.
@@ -1482,6 +1534,8 @@ Thanks @AlexMikhalev, @CoreyH, @John-Rood, @KrauseFx, @MaudeBot, @Nachx639, @Nic
 
 ### Fixes
 
+- CLI/Completion: suppress file logging during `openclaw completion` so the completion script and module-loading output do not pollute the shared gateway log file. (#18108)
+
 - macOS: drain subprocess pipes before waiting to avoid deadlocks. (#1081) — thanks @thesash.
 - Verbose: wrap tool summaries/output in markdown only for markdown-capable channels.
 - Tools: include provider/session context in elevated exec denial errors.
@@ -1592,6 +1646,8 @@ Thanks @AlexMikhalev, @CoreyH, @John-Rood, @KrauseFx, @MaudeBot, @Nachx639, @Nic
 
 ### Fixes
 
+- CLI/Completion: suppress file logging during `openclaw completion` so the completion script and module-loading output do not pollute the shared gateway log file. (#18108)
+
 - Messages: make `/stop` clear queued followups and pending session lane work for a hard abort.
 - Messages: make `/stop` abort active sub-agent runs spawned from the requester session and report how many were stopped.
 - WhatsApp: report linked status consistently in channel status. (#1050) — thanks @YuriNachos.
@@ -1653,6 +1709,8 @@ Thanks @AlexMikhalev, @CoreyH, @John-Rood, @KrauseFx, @MaudeBot, @Nachx639, @Nic
 
 ### Fixes
 
+- CLI/Completion: suppress file logging during `openclaw completion` so the completion script and module-loading output do not pollute the shared gateway log file. (#18108)
+
 - Sessions: refactor session store updates to lock + mutate per-entry, add chat.inject, and harden subagent cleanup flow. (#944) — thanks @tyler6204.
 - Browser: add tests for snapshot labels/efficient query params and labeled image responses.
 - Google: downgrade unsigned thinking blocks before send to avoid missing signature errors.
@@ -1682,6 +1740,8 @@ Thanks @AlexMikhalev, @CoreyH, @John-Rood, @KrauseFx, @MaudeBot, @Nachx639, @Nic
 - Config: add `channels.<provider>.configWrites` gating for channel-initiated config writes; migrate Slack channel IDs.
 
 ### Fixes
+
+- CLI/Completion: suppress file logging during `openclaw completion` so the completion script and module-loading output do not pollute the shared gateway log file. (#18108)
 
 - Mac: pass auth token/password to dashboard URL for authenticated access. (#918) — thanks @rahthakor.
 - UI: use application-defined WebSocket close code (browser compatibility). (#918) — thanks @rahthakor.
@@ -1725,12 +1785,16 @@ Thanks @AlexMikhalev, @CoreyH, @John-Rood, @KrauseFx, @MaudeBot, @Nachx639, @Nic
 
 ### Fixes
 
+- CLI/Completion: suppress file logging during `openclaw completion` so the completion script and module-loading output do not pollute the shared gateway log file. (#18108)
+
 - Postinstall: treat already-applied pnpm patches as no-ops to avoid npm/bun install failures.
 - Packaging: pin `@mariozechner/pi-ai` to 0.45.7 and refresh patched dependency to match npm resolution.
 
 ## 2026.1.12-2
 
 ### Fixes
+
+- CLI/Completion: suppress file logging during `openclaw completion` so the completion script and module-loading output do not pollute the shared gateway log file. (#18108)
 
 - Packaging: include `dist/memory/**` in the npm tarball (fixes `ERR_MODULE_NOT_FOUND` for `dist/memory/index.js`).
 - Agents: persist sub-agent registry across gateway restarts and resume announce flow safely. (#831) — thanks @roshanasingh4.
@@ -1739,6 +1803,8 @@ Thanks @AlexMikhalev, @CoreyH, @John-Rood, @KrauseFx, @MaudeBot, @Nachx639, @Nic
 ## 2026.1.12-1
 
 ### Fixes
+
+- CLI/Completion: suppress file logging during `openclaw completion` so the completion script and module-loading output do not pollute the shared gateway log file. (#18108)
 
 - Packaging: include `dist/channels/**` in the npm tarball (fixes `ERR_MODULE_NOT_FOUND` for `dist/channels/registry.js`).
 
@@ -1772,6 +1838,8 @@ Thanks @AlexMikhalev, @CoreyH, @John-Rood, @KrauseFx, @MaudeBot, @Nachx639, @Nic
 - Install: run `openclaw doctor --non-interactive` after git installs/updates and nudge daemon restarts when detected.
 
 ### Fixes
+
+- CLI/Completion: suppress file logging during `openclaw completion` so the completion script and module-loading output do not pollute the shared gateway log file. (#18108)
 
 - Doctor: warn on pnpm workspace mismatches, missing Control UI assets, and missing tsx binaries; offer UI rebuilds.
 - Tools: apply global tool allow/deny even when agent-specific tool policy is set.
@@ -1858,6 +1926,8 @@ Thanks @AlexMikhalev, @CoreyH, @John-Rood, @KrauseFx, @MaudeBot, @Nachx639, @Nic
 
 ### Fixes
 
+- CLI/Completion: suppress file logging during `openclaw completion` so the completion script and module-loading output do not pollute the shared gateway log file. (#18108)
+
 - Models/Onboarding: configure MiniMax (minimax.io) via Anthropic-compatible `/anthropic` endpoint by default (keep `minimax-api` as a legacy alias).
 - Models: normalize Gemini 3 Pro/Flash IDs to preview names for live model lookups. (#769) — thanks @steipete.
 - CLI: fix guardCancel typing for configure prompts. (#769) — thanks @steipete.
@@ -1918,6 +1988,8 @@ Thanks @AlexMikhalev, @CoreyH, @John-Rood, @KrauseFx, @MaudeBot, @Nachx639, @Nic
 - Docker: allow optional home volume + extra bind mounts in `docker-setup.sh`. (#679) — thanks @gabriel-trigo.
 
 ### Fixes
+
+- CLI/Completion: suppress file logging during `openclaw completion` so the completion script and module-loading output do not pollute the shared gateway log file. (#18108)
 
 - Auto-reply: suppress draft/typing streaming for `NO_REPLY` (silent system ops) so it doesn’t leak partial output.
 - CLI/Status: expand tables to full terminal width; clarify provider setup vs runtime warnings; richer per-provider detail; token previews in `status` while keeping `status --all` redacted; add troubleshooting link footer; keep log tails pasteable; show gateway auth used when reachable; surface provider runtime errors (Signal/iMessage/Slack); harden `tailscale status --json` parsing; make `status --all` scan progress determinate; and replace the footer with a 3-line “Next steps” recommendation (share/debug/probe).
@@ -2031,6 +2103,8 @@ Thanks @AlexMikhalev, @CoreyH, @John-Rood, @KrauseFx, @MaudeBot, @Nachx639, @Nic
 
 ### Fixes
 
+- CLI/Completion: suppress file logging during `openclaw completion` so the completion script and module-loading output do not pollute the shared gateway log file. (#18108)
+
 - Packaging: include MS Teams send module in npm tarball.
 - Sandbox/Browser: auto-start CDP endpoint; proxy CDP out of container for attachOnly; relax Bun fetch typing; align sandbox list output with config images.
 - Agents/Runtime: gate heartbeat prompt to default sessions; /stop aborts between tool calls; require explicit system-event session keys; guard small context windows; fix model fallback stringification; sessions_spawn inherits provider; failover on billing/credits; respect auth cooldown ordering; restore Anthropic OAuth tool dispatch + tool-name bypass; avoid OpenAI invalid reasoning replay; harden Gmail hook model defaults.
@@ -2083,6 +2157,8 @@ Thanks @AlexMikhalev, @CoreyH, @John-Rood, @KrauseFx, @MaudeBot, @Nachx639, @Nic
 
 ### Fixes
 
+- CLI/Completion: suppress file logging during `openclaw completion` so the completion script and module-loading output do not pollute the shared gateway log file. (#18108)
+
 - **CLI/Gateway/Doctor:** daemon runtime selection + improved logs/status/health/errors; auth/password handling for local CLI; richer close/timeout details; auto-migrate legacy config/sessions/state; integrity checks + repair prompts; `--yes`/`--non-interactive`; `--deep` gateway scans; better restart/service hints.
 - **Agent loop + compaction:** compaction/pruning tuning, overflow handling, safer bootstrap context, and per-provider threading/confirmations; opt-in tool-result pruning + compact tracking.
 - **Sandbox + tools:** per-agent sandbox overrides, workspaceAccess controls, session tool visibility, tool policy overrides, process isolation, and tool schema/timeout/reaction unification.
@@ -2110,6 +2186,8 @@ Thanks @AlexMikhalev, @CoreyH, @John-Rood, @KrauseFx, @MaudeBot, @Nachx639, @Nic
 - Bun: optional local install/build workflow without maintaining a Bun lockfile (see `docs/bun.md`).
 
 ### Fixes
+
+- CLI/Completion: suppress file logging during `openclaw completion` so the completion script and module-loading output do not pollute the shared gateway log file. (#18108)
 
 - Control UI: render Markdown in tool result cards.
 - Control UI: prevent overlapping action buttons in Discord guild rules on narrow layouts.

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { resolveStateDir } from "../config/paths.js";
 import { routeLogsToStderr } from "../logging/console.js";
+import { loggingState } from "../logging/state.js";
 import { pathExists } from "../utils.js";
 import { getCoreCliCommandNames, registerCoreCliByName } from "./program/command-registry.js";
 import { getProgramContext } from "./program/program-context.js";
@@ -241,6 +242,8 @@ export function registerCompletionCli(program: Command) {
       // Route logs to stderr so plugin loading messages do not corrupt
       // the completion script written to stdout.
       routeLogsToStderr();
+      // Suppress file logging so completion output does not pollute the shared gateway log file.
+      loggingState.overrideSettings = { level: "silent" };
       const shell = options.shell ?? "zsh";
 
       // Completion needs the full Commander command tree (including nested subcommands).


### PR DESCRIPTION
## Summary

- Suppress file logging during `openclaw completion` so module-loading output does not pollute the shared gateway log file at `/tmp/openclaw/openclaw-*.log`.

Fixes #18108

## Changes

- `src/cli/completion-cli.ts`: Import `loggingState` and set `overrideSettings = { level: "silent" }` at the start of the completion action handler, before any subcommand registration triggers module loading. This prevents the lazily-initialized file logger from ever being created.
- `CHANGELOG.md`: Added entry under Fixes.

## Root cause

`enableConsoleCapture()` in `index.ts` patches all `console.*` calls to also write to a shared rolling log file. When `openclaw completion` runs (e.g. on every zsh tab-complete), eagerly registering all subcommands triggers module loading that uses `console.log`, which gets captured to the same log file the gateway uses. Setting the file log level to silent before registration prevents this.

## Test plan

- [x] Verified `loggingState.overrideSettings` is checked by `resolveSettings()` in `logger.ts` before the file logger is created
- [x] Linter passes
- [ ] Manual test: run `openclaw completion --shell zsh` then check `/tmp/openclaw/openclaw-*.log` -- no completion output should appear

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Prevents shell completion from polluting the shared gateway log file by setting file log level to silent before module loading triggers `console.log` calls.

The fix correctly leverages the existing `loggingState.overrideSettings` mechanism that is checked by `resolveSettings()` in `logger.ts:55` before the file logger is lazily initialized. By setting `level: "silent"` at the start of the completion action handler (line 246), any subsequent module loading that triggers console output will see the override and skip file logging entirely.

**Important note**: The CHANGELOG entry has been duplicated across all 39 historical version sections instead of only appearing in the current unreleased `2026.2.16` section. This duplication was already flagged in a previous review thread and needs to be addressed.

<h3>Confidence Score: 5/5</h3>

- Safe to merge after fixing the CHANGELOG duplication issue
- The code change is minimal, well-targeted, and uses an existing mechanism correctly. The fix prevents log file pollution by setting the override before any module loading occurs, which is the proper timing based on the lazy logger initialization pattern. The only issue is the CHANGELOG duplication which is trivial to fix.
- CHANGELOG.md needs cleanup to remove duplicate entries from historical versions

<sub>Last reviewed commit: 57e1574</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->