### PR TITLE
OpenClawKit: stabilize iOS ChatUI updates after gateway replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 - Cron: preserve per-job schedule-error isolation in post-run maintenance recompute so malformed sibling jobs no longer abort persistence of successful runs. (#17852) Thanks @pierreeurope.
 - CLI/Pairing: make `openclaw qr --remote` prefer `gateway.remote.url` over tailscale/public URL resolution and register the `openclaw clawbot qr` legacy alias path. (#18091)
 - CLI/QR: restore fail-fast validation for `openclaw qr --remote` when neither `gateway.remote.url` nor tailscale `serve`/`funnel` is configured, preventing unusable remote pairing QR flows. (#18166) Thanks @mbelinky.
+- OpenClawKit/iOS ChatUI: accept canonical session-key completion events for local pending runs and preserve message IDs across history refreshes, preventing stuck "thinking" state and message flicker after gateway replies. (#18165) Thanks @mbelinky.
 
 ## 2026.2.15
 


### PR DESCRIPTION
## Summary
Ports chat update stabilization for iOS shared OpenClawKit ChatUI.

## Included
- ChatViewModel stability adjustments for gateway reply/session update behavior
- Matching ChatViewModel test updates

## Scope
- Shared OpenClawKit ChatUI source + tests only

## Testing
- `cd apps/shared/OpenClawKit && swift test --filter ChatViewModelTests`
- Result: pass (8 tests)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR stabilizes iOS ChatUI updates after gateway replies with two key changes:

- **Message ID reconciliation**: Adds `reconcileMessageIDs` and `messageIdentityKey` to preserve SwiftUI-stable `UUID`s when messages are re-decoded from history payloads. Without this, every history refresh generates new UUIDs, causing SwiftUI to treat all messages as new items and triggering unnecessary re-renders and visual flicker.
- **Canonical session key handling**: Reorders the session-key guard in `handleChatEvent` so that events belonging to the view's own pending run are never dropped due to a session key mismatch (e.g. gateway publishes `"agent:main:main"` while the view uses `"main"`). This prevents the UI from getting stuck in a "thinking" state.

Both new tests (`acceptsCanonicalSessionKeyEventsForOwnPendingRun`, `preservesMessageIDsAcrossHistoryRefreshes`) directly cover the new behaviors. Note: the pre-existing test `sessionChoicesPreferMainAndRecent` is failing in the test output — this appears unrelated to this PR's changes, but should be investigated separately.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — both changes are well-scoped, correctly implemented, and tested.
- The changes are focused, logically sound, and address real UX issues (UI flicker from unstable message IDs, stuck "thinking" state from canonical key mismatches). The reconcileMessageIDs function handles edge cases like empty arrays and duplicate identity keys correctly. The session key guard reorder is minimal and well-commented. Two new tests directly cover the new behaviors. The only concern is the pre-existing failing test in the test output, which is unrelated to this PR.
- No files require special attention from this PR. The pre-existing `sessionChoicesPreferMainAndRecent` test failure in the test output should be investigated separately.

<sub>Last reviewed commit: 489c9c7</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->