### PR TITLE
CLI: restore and harden qr --remote pairing behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 - Auto-reply/TTS: keep tool-result media delivery enabled in group chats and native command sessions (while still suppressing tool summary text) so `NO_REPLY` follow-ups do not drop successful TTS audio. (#17991) Thanks @zerone0x.
 - Cron: preserve per-job schedule-error isolation in post-run maintenance recompute so malformed sibling jobs no longer abort persistence of successful runs. (#17852) Thanks @pierreeurope.
 - CLI/Pairing: make `openclaw qr --remote` prefer `gateway.remote.url` over tailscale/public URL resolution and register the `openclaw clawbot qr` legacy alias path. (#18091)
+- CLI/QR: restore fail-fast validation for `openclaw qr --remote` when neither `gateway.remote.url` nor tailscale `serve`/`funnel` is configured, preventing unusable remote pairing QR flows. (#18166) Thanks @mbelinky.
 
 ## 2026.2.15
 

--- a/src/cli/qr-cli.test.ts
+++ b/src/cli/qr-cli.test.ts
@@ -183,6 +183,24 @@ describe("registerQrCli", () => {
     expect(payload.urlSource).toBe("gateway.remote.url");
   });
 
+  it("errors when --remote is set but no remote URL is configured", async () => {
+    loadConfig.mockReturnValue({
+      gateway: {
+        bind: "custom",
+        customBindHost: "gateway.local",
+        auth: { mode: "token", token: "tok" },
+      },
+    });
+
+    const program = new Command();
+    registerQrCli(program);
+
+    await expect(program.parseAsync(["qr", "--remote"], { from: "user" })).rejects.toThrow("exit");
+
+    const output = runtime.error.mock.calls.map((call) => String(call[0] ?? "")).join("\n");
+    expect(output).toContain("qr --remote requires");
+  });
+
   it("prefers gateway.remote.url over tailscale when --remote is set", async () => {
     loadConfig.mockReturnValue({
       gateway: {

--- a/src/cli/qr-cli.ts
+++ b/src/cli/qr-cli.ts
@@ -95,6 +95,17 @@ export function registerQrCli(program: Command) {
             cfg.gateway.auth.token = undefined;
           }
         }
+        if (wantsRemote && !opts.url && !opts.publicUrl) {
+          const tailscaleMode = cfg.gateway?.tailscale?.mode ?? "off";
+          const remoteUrl = cfg.gateway?.remote?.url;
+          const hasRemoteUrl = typeof remoteUrl === "string" && remoteUrl.trim().length > 0;
+          const hasTailscaleServe = tailscaleMode === "serve" || tailscaleMode === "funnel";
+          if (!hasRemoteUrl && !hasTailscaleServe) {
+            throw new Error(
+              "qr --remote requires gateway.remote.url (or gateway.tailscale.mode=serve/funnel).",
+            );
+          }
+        }
 
         const explicitUrl =
           typeof opts.url === "string" && opts.url.trim()


### PR DESCRIPTION
## Summary
Ports CLI QR remote pairing behavior restoration from `ios-new-alpha-core` onto `main`.

## Included
- `openclaw qr --remote` behavior restoration in current main-line implementation
- Keeps existing remote precedence/auth handling already present on main

## Scope
- CLI QR files only

## Testing
- `pnpm exec vitest run src/cli/qr-cli.test.ts src/pairing/setup-code.test.ts --maxWorkers 1`
- Result: pass
- `register.subclis.e2e` broad script path was intentionally not run to keep targeted serial scope

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Restored and hardened QR remote pairing behavior by adding early validation for the `--remote` flag. When `--remote` is specified without URL overrides, the code now validates that either `gateway.remote.url` or tailscale serve/funnel mode is configured before proceeding. This prevents the command from failing later in the resolution process and provides a clearer error message to users.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes add defensive validation logic with proper test coverage. The validation aligns correctly with the underlying URL resolution logic in setup-code.ts. No logical errors, security issues, or edge cases were identified.
- No files require special attention

<sub>Last reviewed commit: efe7d9e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->