### PR TITLE
feat(telegram): support local Bot API server via `apiRoot` config

### DIFF
--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -381,6 +381,7 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
         account.token,
         timeoutMs,
         account.config.proxy,
+        account.config.apiRoot,
       ),
     auditAccount: async ({ account, timeoutMs, probe, cfg }) => {
       const groups =
@@ -408,6 +409,7 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
         groupIds,
         proxyUrl: account.config.proxy,
         timeoutMs,
+        apiRoot: account.config.apiRoot,
       });
       return { ...audit, unresolvedGroups, hasWildcardUnmentionedGroups };
     },
@@ -472,6 +474,7 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
           token,
           2500,
           account.config.proxy,
+          account.config.apiRoot,
         );
         const username = probe.ok ? probe.bot?.username?.trim() : null;
         if (username) {

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -127,6 +127,24 @@ export type TelegramAccountConfig = {
   retry?: OutboundRetryConfig;
   /** Network transport overrides for Telegram. */
   network?: TelegramNetworkConfig;
+  /**
+   * Custom Telegram Bot API base URL (for local Bot API server).
+   * Example: "http://localhost:8081"
+   * Default: "https://api.telegram.org"
+   *
+   * When set, SSRF protection is relaxed for this account and file
+   * downloads from the local Bot API are read directly from disk when
+   * the file_path is an absolute path (scoped to `localApiDataDir`).
+   */
+  apiRoot?: string;
+  /**
+   * Allowed base directory for local Bot API server file reads.
+   * Required when `apiRoot` is set and the server returns absolute
+   * file paths.  Disk reads are restricted to files under this
+   * directory (symlinks resolved, `..` blocked).  No default —
+   * must be set explicitly.
+   */
+  localApiDataDir?: string;
   proxy?: string;
   webhookUrl?: string;
   webhookSecret?: string;

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -164,6 +164,8 @@ export const TelegramAccountSchemaBase = z
       })
       .strict()
       .optional(),
+    apiRoot: z.string().url().optional(),
+    localApiDataDir: z.string().optional(),
     proxy: z.string().optional(),
     webhookUrl: z.string().optional(),
     webhookSecret: z.string().optional().register(sensitive),

--- a/src/telegram/api-base.test.ts
+++ b/src/telegram/api-base.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, writeFile, symlink, mkdir } from "node:fs/promises";
+import { mkdtemp, realpath, writeFile, symlink, mkdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import nodePath from "node:path";
 import { beforeEach, describe, expect, it } from "vitest";
@@ -88,7 +88,8 @@ describe("validateLocalFilePath", () => {
     await writeFile(filePath, "audio-data");
 
     const result = await validateLocalFilePath(filePath, baseDir);
-    expect(result).toBe(filePath);
+    // realpath resolves symlinks and Windows 8.3 short names (e.g. RUNNER~1)
+    expect(result).toBe(await realpath(filePath));
   });
 
   it("rejects a path that escapes the allowed directory via ..", async () => {

--- a/src/telegram/api-base.test.ts
+++ b/src/telegram/api-base.test.ts
@@ -1,0 +1,144 @@
+import { mkdtemp, writeFile, symlink, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import nodePath from "node:path";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  getTelegramApiBase,
+  isCustomTelegramApi,
+  isLocalBotApiFilePath,
+  validateLocalFilePath,
+} from "./api-base.js";
+
+describe("getTelegramApiBase", () => {
+  it("returns default when no override", () => {
+    expect(getTelegramApiBase()).toBe("https://api.telegram.org");
+  });
+
+  it("returns default for undefined override", () => {
+    expect(getTelegramApiBase(undefined)).toBe("https://api.telegram.org");
+  });
+
+  it("returns default for empty-string override", () => {
+    expect(getTelegramApiBase("")).toBe("https://api.telegram.org");
+  });
+
+  it("returns default for whitespace-only override", () => {
+    expect(getTelegramApiBase("   ")).toBe("https://api.telegram.org");
+  });
+
+  it("uses explicit override", () => {
+    expect(getTelegramApiBase("http://localhost:8081")).toBe("http://localhost:8081");
+  });
+
+  it("strips trailing slashes from override", () => {
+    expect(getTelegramApiBase("http://localhost:8081///")).toBe("http://localhost:8081");
+  });
+
+  it("trims whitespace from override", () => {
+    expect(getTelegramApiBase("  http://localhost:8081  ")).toBe("http://localhost:8081");
+  });
+});
+
+describe("isCustomTelegramApi", () => {
+  it("returns false for default API base", () => {
+    expect(isCustomTelegramApi("https://api.telegram.org")).toBe(false);
+  });
+
+  it("returns false for default with trailing slash", () => {
+    expect(isCustomTelegramApi("https://api.telegram.org/")).toBe(false);
+  });
+
+  it("returns true for localhost", () => {
+    expect(isCustomTelegramApi("http://localhost:8081")).toBe(true);
+  });
+
+  it("returns true for custom domain", () => {
+    expect(isCustomTelegramApi("https://tg-api.example.com")).toBe(true);
+  });
+});
+
+describe("isLocalBotApiFilePath", () => {
+  it("returns true for absolute path", () => {
+    expect(isLocalBotApiFilePath("/tmp/telegram-bot-api/file_0.oga")).toBe(true);
+  });
+
+  it("returns false for relative path", () => {
+    expect(isLocalBotApiFilePath("voice/file_0.oga")).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(isLocalBotApiFilePath("")).toBe(false);
+  });
+
+  it("returns true for Windows absolute path", () => {
+    expect(isLocalBotApiFilePath("C:\\telegram-bot-api\\file.oga")).toBe(true);
+  });
+});
+
+describe("validateLocalFilePath", () => {
+  let baseDir: string;
+
+  beforeEach(async () => {
+    baseDir = await mkdtemp(nodePath.join(tmpdir(), "tg-api-test-"));
+    await mkdir(nodePath.join(baseDir, "subdir"), { recursive: true });
+  });
+
+  it("accepts a file inside the allowed directory", async () => {
+    const filePath = nodePath.join(baseDir, "subdir", "voice.oga");
+    await writeFile(filePath, "audio-data");
+
+    const result = await validateLocalFilePath(filePath, baseDir);
+    expect(result).toBe(filePath);
+  });
+
+  it("rejects a path that escapes the allowed directory via ..", async () => {
+    // Create a real file outside the allowed dir so realpath resolves.
+    const outsideFile = nodePath.join(tmpdir(), "secret.txt");
+    await writeFile(outsideFile, "secret");
+
+    const traversal = nodePath.join(baseDir, "subdir", "..", "..", nodePath.basename(outsideFile));
+
+    await expect(validateLocalFilePath(traversal, baseDir)).rejects.toThrow(
+      "escapes allowed directory",
+    );
+  });
+
+  it("rejects a symlink that points outside the allowed directory", async () => {
+    const outsideFile = nodePath.join(tmpdir(), "secret-target.txt");
+    await writeFile(outsideFile, "secret");
+
+    const link = nodePath.join(baseDir, "sneaky-link.txt");
+    await symlink(outsideFile, link);
+
+    await expect(validateLocalFilePath(link, baseDir)).rejects.toThrow("escapes allowed directory");
+  });
+
+  it("rejects a path to a non-existent file (realpath fails)", async () => {
+    const missing = nodePath.join(baseDir, "does-not-exist.oga");
+    await expect(validateLocalFilePath(missing, baseDir)).rejects.toThrow();
+  });
+
+  it("throws when localApiDataDir resolves to filesystem root", async () => {
+    const filePath = nodePath.join(baseDir, "subdir", "voice.oga");
+    await writeFile(filePath, "audio-data");
+
+    await expect(validateLocalFilePath(filePath, "/")).rejects.toThrow(
+      "localApiDataDir must not resolve to the filesystem root",
+    );
+  });
+
+  it("throws when localApiDataDir is not configured", async () => {
+    const filePath = nodePath.join(baseDir, "subdir", "voice.oga");
+    await writeFile(filePath, "audio-data");
+
+    await expect(validateLocalFilePath(filePath)).rejects.toThrow(
+      "localApiDataDir must be configured",
+    );
+    await expect(validateLocalFilePath(filePath, "")).rejects.toThrow(
+      "localApiDataDir must be configured",
+    );
+    await expect(validateLocalFilePath(filePath, "   ")).rejects.toThrow(
+      "localApiDataDir must be configured",
+    );
+  });
+});

--- a/src/telegram/api-base.ts
+++ b/src/telegram/api-base.ts
@@ -1,0 +1,74 @@
+/**
+ * Resolve the Telegram Bot API base URL.
+ *
+ * Returns the explicit override when provided, otherwise the default.
+ * Strips trailing slashes so callers can do `${apiBase}/bot${token}/...`.
+ */
+
+import { realpath } from "node:fs/promises";
+import nodePath from "node:path";
+
+const DEFAULT_API_BASE = "https://api.telegram.org";
+
+function normalize(url: string): string {
+  return url.trim().replace(/\/+$/, "");
+}
+
+export function getTelegramApiBase(override?: string): string {
+  if (override?.trim()) {
+    return normalize(override);
+  }
+  return DEFAULT_API_BASE;
+}
+
+/**
+ * Returns true when the resolved API base is NOT the default Telegram cloud API,
+ * i.e. a local or custom Bot API server is in use.
+ */
+export function isCustomTelegramApi(apiBase: string): boolean {
+  return normalize(apiBase) !== DEFAULT_API_BASE;
+}
+
+/**
+ * Returns true when a file_path from getFile looks like an absolute disk path
+ * (local Bot API server returns these instead of relative paths).
+ */
+export function isLocalBotApiFilePath(filePath: string): boolean {
+  return nodePath.posix.isAbsolute(filePath) || nodePath.win32.isAbsolute(filePath);
+}
+
+/**
+ * Validate that an absolute file path returned by a local Bot API server
+ * actually lives under an allowed data directory.  Resolves symlinks and
+ * normalizes `..` to prevent path-traversal attacks (a compromised local
+ * server could otherwise trick us into reading arbitrary files).
+ *
+ * @param filePath  The raw `file_path` from `getFile`.
+ * @param allowedDir  Explicit data directory (from config `localApiDataDir`).
+ *                    Required — there is no default; callers must configure it.
+ * @returns The resolved real path if it is inside the allowed directory.
+ * @throws If `allowedDir` is not set, or the path escapes the allowed directory.
+ */
+export async function validateLocalFilePath(
+  filePath: string,
+  allowedDir?: string,
+): Promise<string> {
+  if (!allowedDir?.trim()) {
+    throw new Error(
+      "localApiDataDir must be configured when using a local Bot API server with disk reads",
+    );
+  }
+  const baseDir = nodePath.resolve(allowedDir.trim());
+  if (baseDir === nodePath.parse(baseDir).root) {
+    throw new Error("localApiDataDir must not resolve to the filesystem root");
+  }
+  // Resolve symlinks + normalise ".." segments.
+  const real = await realpath(filePath);
+  const normalBase = baseDir.endsWith(nodePath.sep) ? baseDir : `${baseDir}${nodePath.sep}`;
+  if (!real.startsWith(normalBase) && real !== baseDir) {
+    throw new Error(
+      `Local Bot API file path escapes allowed directory: ${filePath} resolved to ${real} (allowed: ${baseDir})`,
+    );
+  }
+  return real;
+}

--- a/src/telegram/api-base.ts
+++ b/src/telegram/api-base.ts
@@ -62,12 +62,14 @@ export async function validateLocalFilePath(
   if (baseDir === nodePath.parse(baseDir).root) {
     throw new Error("localApiDataDir must not resolve to the filesystem root");
   }
-  // Resolve symlinks + normalise ".." segments.
+  // Resolve symlinks + normalise ".." segments (also resolve baseDir so
+  // Windows 8.3 short names like RUNNER~1 match the long-name realpath).
   const real = await realpath(filePath);
-  const normalBase = baseDir.endsWith(nodePath.sep) ? baseDir : `${baseDir}${nodePath.sep}`;
-  if (!real.startsWith(normalBase) && real !== baseDir) {
+  const realBase = await realpath(baseDir);
+  const normalBase = realBase.endsWith(nodePath.sep) ? realBase : `${realBase}${nodePath.sep}`;
+  if (!real.startsWith(normalBase) && real !== realBase) {
     throw new Error(
-      `Local Bot API file path escapes allowed directory: ${filePath} resolved to ${real} (allowed: ${baseDir})`,
+      `Local Bot API file path escapes allowed directory: ${filePath} resolved to ${real} (allowed: ${realBase})`,
     );
   }
   return real;

--- a/src/telegram/audit.ts
+++ b/src/telegram/audit.ts
@@ -1,7 +1,6 @@
 import type { TelegramGroupConfig } from "../config/types.js";
 import { isRecord } from "../utils.js";
-
-const TELEGRAM_API_BASE = "https://api.telegram.org";
+import { getTelegramApiBase } from "./api-base.js";
 
 export type TelegramGroupMembershipAuditEntry = {
   chatId: string;
@@ -71,6 +70,7 @@ export async function auditTelegramGroupMembership(params: {
   groupIds: string[];
   proxyUrl?: string;
   timeoutMs: number;
+  apiRoot?: string;
 }): Promise<TelegramGroupMembershipAudit> {
   const started = Date.now();
   const token = params.token?.trim() ?? "";
@@ -91,7 +91,7 @@ export async function auditTelegramGroupMembership(params: {
     ? (await import("./proxy.js")).makeProxyFetch(params.proxyUrl)
     : fetch;
   const { fetchWithTimeout } = await import("../utils/fetch-timeout.js");
-  const base = `${TELEGRAM_API_BASE}/bot${token}`;
+  const base = `${getTelegramApiBase(params.apiRoot)}/bot${token}`;
   const groups: TelegramGroupMembershipAuditEntry[] = [];
 
   for (const chatId of params.groupIds) {

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -316,7 +316,14 @@ export const registerTelegramHandlers = ({
       for (const { ctx } of entry.messages) {
         let media;
         try {
-          media = await resolveMedia(ctx, mediaMaxBytes, opts.token, opts.proxyFetch);
+          media = await resolveMedia(
+            ctx,
+            mediaMaxBytes,
+            opts.token,
+            opts.proxyFetch,
+            telegramCfg.apiRoot,
+            telegramCfg.localApiDataDir,
+          );
         } catch (mediaErr) {
           if (!isRecoverableMediaGroupError(mediaErr)) {
             throw mediaErr;
@@ -861,7 +868,14 @@ export const registerTelegramHandlers = ({
 
     let media: Awaited<ReturnType<typeof resolveMedia>> = null;
     try {
-      media = await resolveMedia(ctx, mediaMaxBytes, opts.token, opts.proxyFetch);
+      media = await resolveMedia(
+        ctx,
+        mediaMaxBytes,
+        opts.token,
+        opts.proxyFetch,
+        telegramCfg.apiRoot,
+        telegramCfg.localApiDataDir,
+      );
     } catch (mediaErr) {
       if (isMediaSizeLimitError(mediaErr)) {
         if (sendOversizeWarning) {

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -3,8 +3,6 @@ import { apiThrottler } from "@grammyjs/transformer-throttler";
 import { type Message, type UserFromGetMe } from "@grammyjs/types";
 import type { ApiClientOptions } from "grammy";
 import { Bot, webhookCallback } from "grammy";
-import type { OpenClawConfig, ReplyToMode } from "../config/config.js";
-import { createNonExitingRuntime, type RuntimeEnv } from "../runtime.js";
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { resolveTextChunkLimit } from "../auto-reply/chunk.js";
 import { isAbortRequestText } from "../auto-reply/reply/abort.js";
@@ -14,6 +12,7 @@ import {
   resolveNativeCommandsEnabled,
   resolveNativeSkillsEnabled,
 } from "../config/commands.js";
+import type { OpenClawConfig, ReplyToMode } from "../config/config.js";
 import { loadConfig } from "../config/config.js";
 import {
   resolveChannelGroupPolicy,
@@ -24,6 +23,7 @@ import { danger, logVerbose, shouldLogVerbose } from "../globals.js";
 import { formatUncaughtError } from "../infra/errors.js";
 import { getChildLogger } from "../logging.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { createNonExitingRuntime, type RuntimeEnv } from "../runtime.js";
 import { resolveTelegramAccount } from "./accounts.js";
 import { getTelegramApiBase, isCustomTelegramApi } from "./api-base.js";
 import { registerTelegramHandlers } from "./bot-handlers.js";

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -1,7 +1,7 @@
-import type { ApiClientOptions } from "grammy";
 import { sequentialize } from "@grammyjs/runner";
 import { apiThrottler } from "@grammyjs/transformer-throttler";
 import { type Message, type UserFromGetMe } from "@grammyjs/types";
+import type { ApiClientOptions } from "grammy";
 import { Bot, webhookCallback } from "grammy";
 import type { OpenClawConfig, ReplyToMode } from "../config/config.js";
 import { createNonExitingRuntime, type RuntimeEnv } from "../runtime.js";

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -1,8 +1,10 @@
+import type { ApiClientOptions } from "grammy";
 import { sequentialize } from "@grammyjs/runner";
 import { apiThrottler } from "@grammyjs/transformer-throttler";
 import { type Message, type UserFromGetMe } from "@grammyjs/types";
-import type { ApiClientOptions } from "grammy";
 import { Bot, webhookCallback } from "grammy";
+import type { OpenClawConfig, ReplyToMode } from "../config/config.js";
+import { createNonExitingRuntime, type RuntimeEnv } from "../runtime.js";
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { resolveTextChunkLimit } from "../auto-reply/chunk.js";
 import { isAbortRequestText } from "../auto-reply/reply/abort.js";
@@ -12,7 +14,6 @@ import {
   resolveNativeCommandsEnabled,
   resolveNativeSkillsEnabled,
 } from "../config/commands.js";
-import type { OpenClawConfig, ReplyToMode } from "../config/config.js";
 import { loadConfig } from "../config/config.js";
 import {
   resolveChannelGroupPolicy,
@@ -23,8 +24,8 @@ import { danger, logVerbose, shouldLogVerbose } from "../globals.js";
 import { formatUncaughtError } from "../infra/errors.js";
 import { getChildLogger } from "../logging.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { createNonExitingRuntime, type RuntimeEnv } from "../runtime.js";
 import { resolveTelegramAccount } from "./accounts.js";
+import { getTelegramApiBase, isCustomTelegramApi } from "./api-base.js";
 import { registerTelegramHandlers } from "./bot-handlers.js";
 import { createTelegramMessageProcessor } from "./bot-message.js";
 import { registerTelegramNativeCommands } from "./bot-native-commands.js";
@@ -141,7 +142,13 @@ export function createTelegramBot(opts: TelegramBotOptions) {
         }
       : undefined;
 
-  const bot = new Bot(opts.token, client ? { client } : undefined);
+  const apiRoot = getTelegramApiBase(telegramCfg.apiRoot);
+  const clientWithApiRoot: ApiClientOptions = {
+    ...client,
+    ...(isCustomTelegramApi(apiRoot) ? { apiRoot } : {}),
+  };
+  const hasClientOpts = Object.keys(clientWithApiRoot).length > 0;
+  const bot = new Bot(opts.token, hasClientOpts ? { client: clientWithApiRoot } : undefined);
   bot.api.config.use(apiThrottler());
   // Catch all errors from bot middleware to prevent unhandled rejections
   bot.catch((err) => {

--- a/src/telegram/bot/delivery.resolve-media-local-api.test.ts
+++ b/src/telegram/bot/delivery.resolve-media-local-api.test.ts
@@ -38,7 +38,7 @@ vi.mock("../sticker-cache.js", () => ({
 
 // Partially mock api-base: keep real helpers, override validateLocalFilePath.
 vi.mock("../api-base.js", async (importOriginal) => {
-  const actual = await importOriginal();
+  const actual = await importOriginal<Record<string, unknown>>();
   return {
     ...actual,
     validateLocalFilePath: (...args: unknown[]) => validateLocalFilePathMock(...args),
@@ -56,7 +56,12 @@ function makeVoiceCtx(getFile: TelegramContext["getFile"]): TelegramContext {
       chat: { id: 1, type: "private" },
       voice: { file_id: "v1", duration: 5, file_unique_id: "u1" },
     } as Message,
-    me: { id: 1, is_bot: true, first_name: "bot", username: "bot" },
+    me: {
+      id: 1,
+      is_bot: true as const,
+      first_name: "bot",
+      username: "bot",
+    } as TelegramContext["me"],
     getFile,
   };
 }

--- a/src/telegram/bot/delivery.resolve-media-local-api.test.ts
+++ b/src/telegram/bot/delivery.resolve-media-local-api.test.ts
@@ -1,0 +1,197 @@
+import type { Message } from "@grammyjs/types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { TelegramContext } from "./types.js";
+
+const saveMediaBuffer = vi.fn();
+const fetchRemoteMedia = vi.fn();
+const readFileMock = vi.fn();
+const detectMimeMock = vi.fn();
+const validateLocalFilePathMock = vi.fn();
+
+vi.mock("../../media/store.js", () => ({
+  saveMediaBuffer: (...args: unknown[]) => saveMediaBuffer(...args),
+}));
+
+vi.mock("../../media/fetch.js", () => ({
+  fetchRemoteMedia: (...args: unknown[]) => fetchRemoteMedia(...args),
+}));
+
+vi.mock("../../media/mime.js", () => ({
+  detectMime: (...args: unknown[]) => detectMimeMock(...args),
+  isGifMedia: () => false,
+}));
+
+vi.mock("node:fs/promises", () => ({
+  readFile: (...args: unknown[]) => readFileMock(...args),
+  realpath: vi.fn((p: string) => Promise.resolve(p)),
+}));
+
+vi.mock("../../globals.js", () => ({
+  danger: (s: string) => s,
+  logVerbose: () => {},
+}));
+
+vi.mock("../sticker-cache.js", () => ({
+  cacheSticker: () => {},
+  getCachedSticker: () => null,
+}));
+
+// Partially mock api-base: keep real helpers, override validateLocalFilePath.
+vi.mock("../api-base.js", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    validateLocalFilePath: (...args: unknown[]) => validateLocalFilePathMock(...args),
+  };
+});
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+const { resolveMedia } = await import("./delivery.js");
+
+function makeVoiceCtx(getFile: TelegramContext["getFile"]): TelegramContext {
+  return {
+    message: {
+      message_id: 1,
+      date: 0,
+      chat: { id: 1, type: "private" },
+      voice: { file_id: "v1", duration: 5, file_unique_id: "u1" },
+    } as Message,
+    me: { id: 1, is_bot: true, first_name: "bot", username: "bot" },
+    getFile,
+  };
+}
+
+describe("resolveMedia with local Bot API server", () => {
+  beforeEach(() => {
+    fetchRemoteMedia.mockReset();
+    saveMediaBuffer.mockReset();
+    readFileMock.mockReset();
+    detectMimeMock.mockReset();
+    validateLocalFilePathMock.mockReset();
+  });
+
+  it("reads file from disk when apiRoot is set and file_path is absolute", async () => {
+    const absPath = "/var/lib/telegram-bot-api/botdata/file_0.oga";
+    const getFile = vi.fn().mockResolvedValue({ file_path: absPath });
+    const audioBuf = Buffer.from("audio-data");
+
+    validateLocalFilePathMock.mockResolvedValueOnce(absPath);
+    readFileMock.mockResolvedValueOnce(audioBuf);
+    detectMimeMock.mockResolvedValueOnce("audio/ogg");
+    saveMediaBuffer.mockResolvedValueOnce({
+      path: "/saved/file_0.oga",
+      contentType: "audio/ogg",
+    });
+
+    const result = await resolveMedia(
+      makeVoiceCtx(getFile),
+      10_000_000,
+      "tok123",
+      undefined, // proxyFetch
+      "http://localhost:8081", // apiRoot — explicit per-account
+      "/var/lib/telegram-bot-api", // localApiDataDir
+    );
+
+    expect(validateLocalFilePathMock).toHaveBeenCalledWith(absPath, "/var/lib/telegram-bot-api");
+    expect(readFileMock).toHaveBeenCalledWith(absPath);
+    expect(fetchRemoteMedia).not.toHaveBeenCalled();
+    expect(result).toEqual(
+      expect.objectContaining({ path: "/saved/file_0.oga", placeholder: "<media:audio>" }),
+    );
+  });
+
+  it("rejects disk read when path escapes the allowed directory", async () => {
+    const maliciousPath = "/etc/shadow";
+    const getFile = vi.fn().mockResolvedValue({ file_path: maliciousPath });
+
+    validateLocalFilePathMock.mockRejectedValueOnce(
+      new Error("Local Bot API file path escapes allowed directory"),
+    );
+
+    await expect(
+      resolveMedia(
+        makeVoiceCtx(getFile),
+        10_000_000,
+        "tok123",
+        undefined,
+        "http://localhost:8081",
+        "/var/lib/telegram-bot-api",
+      ),
+    ).rejects.toThrow("escapes allowed directory");
+
+    expect(readFileMock).not.toHaveBeenCalled();
+    expect(fetchRemoteMedia).not.toHaveBeenCalled();
+  });
+
+  it("fetches via HTTP with relaxed SSRF when apiRoot is set and file_path is relative", async () => {
+    const getFile = vi.fn().mockResolvedValue({ file_path: "voice/file_0.oga" });
+
+    fetchRemoteMedia.mockResolvedValueOnce({
+      buffer: Buffer.from("audio"),
+      contentType: "audio/ogg",
+      fileName: "file_0.oga",
+    });
+    saveMediaBuffer.mockResolvedValueOnce({
+      path: "/saved/file_0.oga",
+      contentType: "audio/ogg",
+    });
+
+    await resolveMedia(
+      makeVoiceCtx(getFile),
+      10_000_000,
+      "tok123",
+      undefined,
+      "http://localhost:8081",
+    );
+
+    expect(validateLocalFilePathMock).not.toHaveBeenCalled();
+    expect(readFileMock).not.toHaveBeenCalled();
+    expect(fetchRemoteMedia).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "http://localhost:8081/file/bottok123/voice/file_0.oga",
+        ssrfPolicy: { allowPrivateNetwork: true },
+      }),
+    );
+  });
+
+  it("does NOT relax SSRF when apiRoot is not set (env-var only)", async () => {
+    const getFile = vi.fn().mockResolvedValue({ file_path: "voice/file_0.oga" });
+
+    fetchRemoteMedia.mockResolvedValueOnce({
+      buffer: Buffer.from("audio"),
+      contentType: "audio/ogg",
+      fileName: "file_0.oga",
+    });
+    saveMediaBuffer.mockResolvedValueOnce({
+      path: "/saved/file_0.oga",
+      contentType: "audio/ogg",
+    });
+
+    // No apiRoot passed — simulates env-var-only scenario.
+    await resolveMedia(makeVoiceCtx(getFile), 10_000_000, "tok123");
+
+    const callArgs = fetchRemoteMedia.mock.calls[0][0];
+    expect(callArgs.ssrfPolicy).toBeUndefined();
+  });
+
+  it("does NOT read from disk when apiRoot is not set even if file_path is absolute", async () => {
+    const getFile = vi.fn().mockResolvedValue({ file_path: "/tmp/sneaky/path.oga" });
+
+    fetchRemoteMedia.mockResolvedValueOnce({
+      buffer: Buffer.from("audio"),
+      contentType: "audio/ogg",
+      fileName: "path.oga",
+    });
+    saveMediaBuffer.mockResolvedValueOnce({
+      path: "/saved/path.oga",
+      contentType: "audio/ogg",
+    });
+
+    // No apiRoot — should use HTTP, not disk read.
+    await resolveMedia(makeVoiceCtx(getFile), 10_000_000, "tok123");
+
+    expect(validateLocalFilePathMock).not.toHaveBeenCalled();
+    expect(readFileMock).not.toHaveBeenCalled();
+    expect(fetchRemoteMedia).toHaveBeenCalled();
+  });
+});

--- a/src/telegram/bot/delivery.ts
+++ b/src/telegram/bot/delivery.ts
@@ -1,13 +1,10 @@
-import { type Bot, GrammyError, InputFile } from "grammy";
 import { readFile } from "node:fs/promises";
 import nodePath from "node:path";
+import { type Bot, GrammyError, InputFile } from "grammy";
+import { chunkMarkdownTextWithMode, type ChunkMode } from "../../auto-reply/chunk.js";
 import type { ReplyPayload } from "../../auto-reply/types.js";
 import type { ReplyToMode } from "../../config/config.js";
 import type { MarkdownTableMode } from "../../config/types.base.js";
-import type { RuntimeEnv } from "../../runtime.js";
-import type { TelegramInlineButtons } from "../button-types.js";
-import type { StickerMetadata, TelegramContext } from "./types.js";
-import { chunkMarkdownTextWithMode, type ChunkMode } from "../../auto-reply/chunk.js";
 import { danger, logVerbose, warn } from "../../globals.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { retryAsync } from "../../infra/retry.js";
@@ -15,6 +12,7 @@ import { mediaKindFromMime } from "../../media/constants.js";
 import { fetchRemoteMedia } from "../../media/fetch.js";
 import { isGifMedia } from "../../media/mime.js";
 import { saveMediaBuffer } from "../../media/store.js";
+import type { RuntimeEnv } from "../../runtime.js";
 import { loadWebMedia } from "../../web/media.js";
 import {
   getTelegramApiBase,
@@ -23,6 +21,7 @@ import {
   validateLocalFilePath,
 } from "../api-base.js";
 import { withTelegramApiErrorLogging } from "../api-logging.js";
+import type { TelegramInlineButtons } from "../button-types.js";
 import { splitTelegramCaption } from "../caption.js";
 import {
   markdownToTelegramChunks,
@@ -39,6 +38,7 @@ import {
   resolveTelegramReplyId,
   type TelegramThreadSpec,
 } from "./helpers.js";
+import type { StickerMetadata, TelegramContext } from "./types.js";
 
 const PARSE_ERR_RE = /can't parse entities|parse entities|find end of the entity/i;
 const EMPTY_TEXT_ERR_RE = /message text is empty/i;

--- a/src/telegram/bot/delivery.ts
+++ b/src/telegram/bot/delivery.ts
@@ -1,8 +1,13 @@
 import { type Bot, GrammyError, InputFile } from "grammy";
-import { chunkMarkdownTextWithMode, type ChunkMode } from "../../auto-reply/chunk.js";
+import { readFile } from "node:fs/promises";
+import nodePath from "node:path";
 import type { ReplyPayload } from "../../auto-reply/types.js";
 import type { ReplyToMode } from "../../config/config.js";
 import type { MarkdownTableMode } from "../../config/types.base.js";
+import type { RuntimeEnv } from "../../runtime.js";
+import type { TelegramInlineButtons } from "../button-types.js";
+import type { StickerMetadata, TelegramContext } from "./types.js";
+import { chunkMarkdownTextWithMode, type ChunkMode } from "../../auto-reply/chunk.js";
 import { danger, logVerbose, warn } from "../../globals.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { retryAsync } from "../../infra/retry.js";
@@ -10,10 +15,14 @@ import { mediaKindFromMime } from "../../media/constants.js";
 import { fetchRemoteMedia } from "../../media/fetch.js";
 import { isGifMedia } from "../../media/mime.js";
 import { saveMediaBuffer } from "../../media/store.js";
-import type { RuntimeEnv } from "../../runtime.js";
 import { loadWebMedia } from "../../web/media.js";
+import {
+  getTelegramApiBase,
+  isCustomTelegramApi,
+  isLocalBotApiFilePath,
+  validateLocalFilePath,
+} from "../api-base.js";
 import { withTelegramApiErrorLogging } from "../api-logging.js";
-import type { TelegramInlineButtons } from "../button-types.js";
 import { splitTelegramCaption } from "../caption.js";
 import {
   markdownToTelegramChunks,
@@ -30,7 +39,6 @@ import {
   resolveTelegramReplyId,
   type TelegramThreadSpec,
 } from "./helpers.js";
-import type { StickerMetadata, TelegramContext } from "./types.js";
 
 const PARSE_ERR_RE = /can't parse entities|parse entities|find end of the entity/i;
 const EMPTY_TEXT_ERR_RE = /message text is empty/i;
@@ -313,6 +321,8 @@ export async function resolveMedia(
   maxBytes: number,
   token: string,
   proxyFetch?: typeof fetch,
+  apiRoot?: string,
+  localApiDataDir?: string,
 ): Promise<{
   path: string;
   contentType?: string;
@@ -320,14 +330,32 @@ export async function resolveMedia(
   stickerMetadata?: StickerMetadata;
 } | null> {
   const msg = ctx.message;
+  const apiBase = getTelegramApiBase(apiRoot);
+  // Relax SSRF / enable direct disk reads when the resolved API base is
+  // not the default Telegram cloud API — i.e. the per-account `apiRoot`
+  // config field signals an explicit opt-in to a private/local server.
+  const isLocal = isCustomTelegramApi(apiBase);
+
   const downloadAndSaveTelegramFile = async (filePath: string, fetchImpl: typeof fetch) => {
-    const url = `https://api.telegram.org/file/bot${token}/${filePath}`;
+    // Local Bot API: absolute disk paths — validate the path is inside the
+    // allowed data directory, then read directly from disk.
+    if (isLocal && isLocalBotApiFilePath(filePath)) {
+      const safePath = await validateLocalFilePath(filePath, localApiDataDir);
+      const array = await readFile(safePath);
+      const buf = Buffer.from(array);
+      const { detectMime: detectMimeLocal } = await import("../../media/mime.js");
+      const mime = await detectMimeLocal({ buffer: buf, filePath: safePath });
+      return saveMediaBuffer(buf, mime, "inbound", maxBytes, nodePath.basename(safePath));
+    }
+
+    const url = `${apiBase}/file/bot${token}/${filePath}`;
     const fetched = await fetchRemoteMedia({
       url,
       fetchImpl,
       filePathHint: filePath,
       maxBytes,
-      ssrfPolicy: TELEGRAM_MEDIA_SSRF_POLICY,
+      // Relax SSRF for custom/local Bot API servers; standard API uses named policy.
+      ssrfPolicy: isLocal ? { allowPrivateNetwork: true } : TELEGRAM_MEDIA_SSRF_POLICY,
     });
     const originalName = fetched.fileName ?? filePath;
     return saveMediaBuffer(fetched.buffer, fetched.contentType, "inbound", maxBytes, originalName);

--- a/src/telegram/probe.ts
+++ b/src/telegram/probe.ts
@@ -1,8 +1,7 @@
 import type { BaseProbeResult } from "../channels/plugins/types.js";
 import { fetchWithTimeout } from "../utils/fetch-timeout.js";
+import { getTelegramApiBase } from "./api-base.js";
 import { makeProxyFetch } from "./proxy.js";
-
-const TELEGRAM_API_BASE = "https://api.telegram.org";
 
 export type TelegramProbe = BaseProbeResult & {
   status?: number | null;
@@ -21,10 +20,11 @@ export async function probeTelegram(
   token: string,
   timeoutMs: number,
   proxyUrl?: string,
+  apiRoot?: string,
 ): Promise<TelegramProbe> {
   const started = Date.now();
   const fetcher = proxyUrl ? makeProxyFetch(proxyUrl) : fetch;
-  const base = `${TELEGRAM_API_BASE}/bot${token}`;
+  const base = `${getTelegramApiBase(apiRoot)}/bot${token}`;
   const retryDelayMs = Math.max(50, Math.min(1000, timeoutMs));
 
   const result: TelegramProbe = {

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -5,8 +5,6 @@ import type {
   ReactionTypeEmoji,
 } from "@grammyjs/types";
 import { type ApiClientOptions, Bot, HttpError, InputFile } from "grammy";
-import type { RetryConfig } from "../infra/retry.js";
-import type { TelegramInlineButtons } from "./button-types.js";
 import { loadConfig } from "../config/config.js";
 import { resolveMarkdownTableMode } from "../config/markdown-tables.js";
 import { logVerbose } from "../globals.js";
@@ -14,6 +12,7 @@ import { recordChannelActivity } from "../infra/channel-activity.js";
 import { isDiagnosticFlagEnabled } from "../infra/diagnostic-flags.js";
 import { formatErrorMessage, formatUncaughtError } from "../infra/errors.js";
 import { createTelegramRetryRunner } from "../infra/retry-policy.js";
+import type { RetryConfig } from "../infra/retry.js";
 import { redactSensitiveText } from "../logging/redact.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { mediaKindFromMime } from "../media/constants.js";
@@ -24,6 +23,7 @@ import { type ResolvedTelegramAccount, resolveTelegramAccount } from "./accounts
 import { getTelegramApiBase, isCustomTelegramApi } from "./api-base.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { buildTelegramThreadParams } from "./bot/helpers.js";
+import type { TelegramInlineButtons } from "./button-types.js";
 import { splitTelegramCaption } from "./caption.js";
 import { resolveTelegramFetch } from "./fetch.js";
 import { renderTelegramHtmlText } from "./format.js";

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -5,6 +5,8 @@ import type {
   ReactionTypeEmoji,
 } from "@grammyjs/types";
 import { type ApiClientOptions, Bot, HttpError, InputFile } from "grammy";
+import type { RetryConfig } from "../infra/retry.js";
+import type { TelegramInlineButtons } from "./button-types.js";
 import { loadConfig } from "../config/config.js";
 import { resolveMarkdownTableMode } from "../config/markdown-tables.js";
 import { logVerbose } from "../globals.js";
@@ -12,7 +14,6 @@ import { recordChannelActivity } from "../infra/channel-activity.js";
 import { isDiagnosticFlagEnabled } from "../infra/diagnostic-flags.js";
 import { formatErrorMessage, formatUncaughtError } from "../infra/errors.js";
 import { createTelegramRetryRunner } from "../infra/retry-policy.js";
-import type { RetryConfig } from "../infra/retry.js";
 import { redactSensitiveText } from "../logging/redact.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { mediaKindFromMime } from "../media/constants.js";
@@ -20,9 +21,9 @@ import { isGifMedia } from "../media/mime.js";
 import { normalizePollInput, type PollInput } from "../polls.js";
 import { loadWebMedia } from "../web/media.js";
 import { type ResolvedTelegramAccount, resolveTelegramAccount } from "./accounts.js";
+import { getTelegramApiBase, isCustomTelegramApi } from "./api-base.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { buildTelegramThreadParams } from "./bot/helpers.js";
-import type { TelegramInlineButtons } from "./button-types.js";
 import { splitTelegramCaption } from "./caption.js";
 import { resolveTelegramFetch } from "./fetch.js";
 import { renderTelegramHtmlText } from "./format.js";
@@ -131,10 +132,13 @@ function resolveTelegramClientOptions(
     Number.isFinite(account.config.timeoutSeconds)
       ? Math.max(1, Math.floor(account.config.timeoutSeconds))
       : undefined;
-  return fetchImpl || timeoutSeconds
+  const apiRoot = getTelegramApiBase(account.config.apiRoot);
+  const hasCustomApiRoot = isCustomTelegramApi(apiRoot);
+  return fetchImpl || timeoutSeconds || hasCustomApiRoot
     ? {
         ...(fetchImpl ? { fetch: fetchImpl as unknown as ApiClientOptions["fetch"] } : {}),
         ...(timeoutSeconds ? { timeoutSeconds } : {}),
+        ...(hasCustomApiRoot ? { apiRoot } : {}),
       }
     : undefined;
 }


### PR DESCRIPTION
Add a per-account `apiRoot` option so all Telegram HTTP calls route
through a self-hosted Bot API server instead of the default
`https://api.telegram.org`/.

Key changes:
- New `src/telegram/api-base.ts` module: `getTelegramApiBase()` resolves
  the base URL (explicit config override > default), `isCustomTelegramApi()`
  and `isLocalBotApiFilePath()` helpers for downstream branching,
  `validateLocalFilePath()` for path-traversal protection.
- Config: `apiRoot` and `localApiDataDir` fields added to
  `TelegramAccountConfig` type and Zod schema (`apiRoot` validated as URL).
- Bot, send, audit, and probe modules all thread the per-account
  `apiRoot` config through to the grammy API client and
  `getTelegramApiBase()`.  `bot.ts` and `send.ts` use
  `isCustomTelegramApi()` for custom-API detection.
- File downloads (voice notes, media): when a local Bot API server
  returns an absolute disk path in `file_path`, the path is validated
  against the required `localApiDataDir` config using `realpath` to
  block symlink and `..` traversal attacks, then read directly from disk.
- SSRF relaxation is scoped to accounts that explicitly set `apiRoot`
  in config (not env vars); accounts without `apiRoot` always use the
  default cloud endpoint with full SSRF protection.

Security:
- Disk reads require `localApiDataDir` to be explicitly configured —
  there is no default.  Without it, absolute file paths returned by the
  local server are rejected.
- `realpath` resolves symlinks before the prefix check, preventing
  symlink-based escapes.
- A compromised local Bot API server cannot trick the gateway into
  reading arbitrary files (e.g. /etc/shadow, ~/.ssh/id_rsa).

Tests:
- `api-base.test.ts`: covers URL resolution priority, normalization,
  `isCustomTelegramApi`, `isLocalBotApiFilePath`, and
  `validateLocalFilePath` (happy path, `..` traversal, symlink escape,
  missing file, missing config).
- `delivery.resolve-media-local-api.test.ts`: covers direct disk read
  for absolute paths, path-traversal rejection, HTTP with relaxed SSRF
  for relative paths, and verifies SSRF stays strict when `apiRoot` is
  not set in config.

Tested with a local Bot API server; confirmed voice-note file downloads
work end-to-end via both the direct disk-read and HTTP paths.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Local bot API server not supported
- Why it matters: Adding support for this increases privacy significantly, and allows enhanced telegram integration.
- What changed: Integrated local bot api server use. SSRF relaxation on for telegram allowing SCOPED local disk access.
- What did NOT change (scope boundary): Other messaging frameworks.

## Change Type (select all)

- [ ] Bug fix
- [X] Feature
- [ ] Refactor
- [ ] Docs
- [X] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [X] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  config: apiRoot, and localApiDataDir (required for local disk access).
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes`)
- If any `Yes`, explain risk + mitigation: Risk: more disk access triggered by bot api server, mitigation: only allow a configured api data dir, mandatory config, otherwise all disk read fails.

## Repro + Verification

### Environment

- OS: Gentoo
- Runtime/container: Local
- Model/provider: Claude Opus 4.6
- Integration/channel (if any): Telegram
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:
I personally verified voice note receipt from Telegram in a direct message with my bot.

- Verified scenarios:
- Edge cases checked: Removed api data dir config, and confirmed local disk access blocked.
- What you did **not** verify: download of other media types (document, file, etc.).

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`Yes`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore: openclaw.json
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: SSRF relaxation for Telegram only, per account, not globally
  - Mitigation: Config check, and api data dir scoping.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds support for self-hosted local Telegram Bot API servers via per-account `apiRoot` configuration, enabling direct disk reads for media files with comprehensive path-traversal protection.

**Major changes:**
- New `src/telegram/api-base.ts` module with URL resolution, custom API detection, and `validateLocalFilePath()` using `realpath()` to prevent symlink/`..` escapes
- Config fields `apiRoot` (validated as URL) and `localApiDataDir` added to `TelegramAccountConfig`
- SSRF relaxation scoped to accounts with explicit `apiRoot` config (not env vars)
- Direct disk reads require `localApiDataDir` to be configured (no default); root directory explicitly blocked
- Bot, send, audit, and probe modules thread per-account `apiRoot` through to API clients
- Comprehensive test coverage: `api-base.test.ts` (path validation, Windows paths, root blocking) and `delivery.resolve-media-local-api.test.ts` (disk reads, HTTP fallback, SSRF scoping)

**Security measures verified:**
- `realpath()` resolves symlinks before prefix checks
- Root directory (`/`) rejected as `localApiDataDir`
- Path-traversal with `..` blocked
- Windows absolute paths (`C:\...`) properly detected via `nodePath.win32.isAbsolute()`
- Audit and probe correctly receive per-account `apiRoot` config

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor considerations - security mitigations are comprehensive and well-tested
- All previously identified security issues have been addressed (Windows paths, root directory bypass, per-account config threading). Path validation is robust with `realpath()` + prefix checks. Test coverage is comprehensive. Score not 5 due to complexity of security-sensitive disk access feature and SSRF relaxation, though both are properly scoped and protected.
- No files require special attention - all previous review comments have been addressed

<sub>Last reviewed commit: cda1cee</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->