### PR TITLE
cron: log model + token usage per run

### DIFF
--- a/scripts/cron_usage_report.ts
+++ b/scripts/cron_usage_report.ts
@@ -1,0 +1,248 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+type Usage = {
+  input_tokens?: number;
+  output_tokens?: number;
+  total_tokens?: number;
+  cache_read_tokens?: number;
+  cache_write_tokens?: number;
+};
+
+type CronRunLogEntry = {
+  ts: number;
+  jobId: string;
+  action: "finished";
+  status?: "ok" | "error" | "skipped";
+  model?: string;
+  provider?: string;
+  usage?: Usage;
+};
+
+function parseArgs(argv: string[]) {
+  const args: Record<string, string | boolean> = {};
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i] ?? "";
+    if (!a.startsWith("--")) {
+      continue;
+    }
+    const key = a.slice(2);
+    const next = argv[i + 1];
+    if (next && !next.startsWith("--")) {
+      args[key] = next;
+      i++;
+    } else {
+      args[key] = true;
+    }
+  }
+  return args;
+}
+
+function usageAndExit(code: number): never {
+  console.error(
+    [
+      "cron_usage_report.ts",
+      "",
+      "Required (choose one):",
+      "  --store <path-to-cron-store-json>   (derive runs dir as dirname(store)/runs)",
+      "  --runsDir <path-to-runs-dir>",
+      "",
+      "Time window:",
+      "  --hours <n>        (default 24)",
+      "  --from <iso>       (overrides --hours)",
+      "  --to <iso>         (default now)",
+      "",
+      "Filters:",
+      "  --jobId <id>",
+      "  --model <name>",
+      "",
+      "Output:",
+      "  --json             (emit JSON)",
+    ].join("\n"),
+  );
+  process.exit(code);
+}
+
+async function listJsonlFiles(dir: string): Promise<string[]> {
+  const entries = await fs.readdir(dir, { withFileTypes: true }).catch(() => []);
+  return entries
+    .filter((e) => e.isFile() && e.name.endsWith(".jsonl"))
+    .map((e) => path.join(dir, e.name));
+}
+
+function safeParseLine(line: string): CronRunLogEntry | null {
+  try {
+    const obj = JSON.parse(line) as Partial<CronRunLogEntry> | null;
+    if (!obj || typeof obj !== "object") return null;
+    if (obj.action !== "finished") return null;
+    if (typeof obj.ts !== "number" || !Number.isFinite(obj.ts)) return null;
+    if (typeof obj.jobId !== "string" || !obj.jobId.trim()) return null;
+    return obj as CronRunLogEntry;
+  } catch {
+    return null;
+  }
+}
+
+function fmtInt(n: number) {
+  return new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 }).format(n);
+}
+
+export async function main() {
+  const args = parseArgs(process.argv);
+  const store = typeof args.store === "string" ? args.store : undefined;
+  const runsDirArg = typeof args.runsDir === "string" ? args.runsDir : undefined;
+  const runsDir = runsDirArg ?? (store ? path.join(path.dirname(path.resolve(store)), "runs") : null);
+  if (!runsDir) {
+    usageAndExit(2);
+  }
+
+  const hours = typeof args.hours === "string" ? Number(args.hours) : 24;
+  const toMs = typeof args.to === "string" ? Date.parse(args.to) : Date.now();
+  const fromMs =
+    typeof args.from === "string"
+      ? Date.parse(args.from)
+      : toMs - Math.max(1, Number.isFinite(hours) ? hours : 24) * 60 * 60 * 1000;
+
+  if (!Number.isFinite(fromMs) || !Number.isFinite(toMs)) {
+    console.error("Invalid --from/--to timestamp");
+    process.exit(2);
+  }
+
+  const filterJobId = typeof args.jobId === "string" ? args.jobId.trim() : "";
+  const filterModel = typeof args.model === "string" ? args.model.trim() : "";
+  const asJson = args.json === true;
+
+  const files = await listJsonlFiles(runsDir);
+  const totalsByJob: Record<
+    string,
+    {
+      jobId: string;
+      runs: number;
+      models: Record<
+        string,
+        {
+          model: string;
+          runs: number;
+          input_tokens: number;
+          output_tokens: number;
+          total_tokens: number;
+          missingUsageRuns: number;
+        }
+      >;
+      input_tokens: number;
+      output_tokens: number;
+      total_tokens: number;
+      missingUsageRuns: number;
+    }
+  > = {};
+
+  for (const file of files) {
+    const raw = await fs.readFile(file, "utf-8").catch(() => "");
+    if (!raw.trim()) continue;
+    const lines = raw.split("\n");
+    for (const line of lines) {
+      const entry = safeParseLine(line.trim());
+      if (!entry) continue;
+      if (entry.ts < fromMs || entry.ts > toMs) continue;
+      if (filterJobId && entry.jobId !== filterJobId) continue;
+      const model = (entry.model ?? "<unknown>").trim() || "<unknown>";
+      if (filterModel && model !== filterModel) continue;
+
+      const jobId = entry.jobId;
+      const usage = entry.usage;
+      const hasUsage = Boolean(usage && (usage.total_tokens ?? usage.input_tokens ?? usage.output_tokens) !== undefined);
+
+      const jobAgg = (totalsByJob[jobId] ??= {
+        jobId,
+        runs: 0,
+        models: {},
+        input_tokens: 0,
+        output_tokens: 0,
+        total_tokens: 0,
+        missingUsageRuns: 0,
+      });
+      jobAgg.runs++;
+
+      const modelAgg = (jobAgg.models[model] ??= {
+        model,
+        runs: 0,
+        input_tokens: 0,
+        output_tokens: 0,
+        total_tokens: 0,
+        missingUsageRuns: 0,
+      });
+      modelAgg.runs++;
+
+      if (!hasUsage) {
+        jobAgg.missingUsageRuns++;
+        modelAgg.missingUsageRuns++;
+        continue;
+      }
+
+      const input = Math.max(0, Math.trunc(usage?.input_tokens ?? 0));
+      const output = Math.max(0, Math.trunc(usage?.output_tokens ?? 0));
+      const total = Math.max(0, Math.trunc(usage?.total_tokens ?? input + output));
+
+      jobAgg.input_tokens += input;
+      jobAgg.output_tokens += output;
+      jobAgg.total_tokens += total;
+
+      modelAgg.input_tokens += input;
+      modelAgg.output_tokens += output;
+      modelAgg.total_tokens += total;
+    }
+  }
+
+  const rows = Object.values(totalsByJob)
+    .map((r) => ({
+      ...r,
+      models: Object.values(r.models).toSorted((a, b) => b.total_tokens - a.total_tokens),
+    }))
+    .toSorted((a, b) => b.total_tokens - a.total_tokens);
+
+  if (asJson) {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          from: new Date(fromMs).toISOString(),
+          to: new Date(toMs).toISOString(),
+          runsDir,
+          jobs: rows,
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+    return;
+  }
+
+  console.log(`Cron usage report`);
+  console.log(`  runsDir: ${runsDir}`);
+  console.log(`  window: ${new Date(fromMs).toISOString()} → ${new Date(toMs).toISOString()}`);
+  if (filterJobId) console.log(`  filter jobId: ${filterJobId}`);
+  if (filterModel) console.log(`  filter model: ${filterModel}`);
+  console.log("");
+
+  if (rows.length === 0) {
+    console.log("No matching cron run entries found.");
+    return;
+  }
+
+  for (const job of rows) {
+    console.log(`jobId: ${job.jobId}`);
+    console.log(`  runs: ${fmtInt(job.runs)} (missing usage: ${fmtInt(job.missingUsageRuns)})`);
+    console.log(
+      `  tokens: total ${fmtInt(job.total_tokens)} (in ${fmtInt(job.input_tokens)} / out ${fmtInt(job.output_tokens)})`,
+    );
+    for (const m of job.models) {
+      console.log(
+        `    model ${m.model}: runs ${fmtInt(m.runs)} (missing usage: ${fmtInt(m.missingUsageRuns)}), total ${fmtInt(m.total_tokens)} (in ${fmtInt(m.input_tokens)} / out ${fmtInt(m.output_tokens)})`,
+      );
+    }
+    console.log("");
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  void main();
+}

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -585,6 +585,7 @@ export async function runCronIsolatedAgentTurn(params: {
           error: resolvedDelivery.error.message,
           summary,
           outputText,
+          ...telemetry,
         });
       }
       logWarn(`[cron:${params.job.id}] ${resolvedDelivery.error.message}`);
@@ -598,6 +599,7 @@ export async function runCronIsolatedAgentTurn(params: {
           error: message,
           summary,
           outputText,
+          ...telemetry,
         });
       }
       logWarn(`[cron:${params.job.id}] ${message}`);
@@ -635,7 +637,7 @@ export async function runCronIsolatedAgentTurn(params: {
         }
       } catch (err) {
         if (!deliveryBestEffort) {
-          return withRunSession({ status: "error", summary, outputText, error: String(err) });
+          return withRunSession({ status: "error", summary, outputText, error: String(err), ...telemetry });
         }
       }
     } else if (synthesizedText) {
@@ -726,13 +728,14 @@ export async function runCronIsolatedAgentTurn(params: {
               summary,
               outputText,
               error: message,
+              ...telemetry,
             });
           }
           logWarn(`[cron:${params.job.id}] ${message}`);
         }
       } catch (err) {
         if (!deliveryBestEffort) {
-          return withRunSession({ status: "error", summary, outputText, error: String(err) });
+          return withRunSession({ status: "error", summary, outputText, error: String(err), ...telemetry });
         }
         logWarn(`[cron:${params.job.id}] ${String(err)}`);
       }

--- a/src/cron/run-log.ts
+++ b/src/cron/run-log.ts
@@ -13,6 +13,17 @@ export type CronRunLogEntry = {
   runAtMs?: number;
   durationMs?: number;
   nextRunAtMs?: number;
+
+  // Telemetry (best-effort)
+  model?: string;
+  provider?: string;
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    total_tokens?: number;
+    cache_read_tokens?: number;
+    cache_write_tokens?: number;
+  };
 };
 
 export function resolveCronRunLogPath(params: { storePath: string; jobId: string }) {
@@ -105,6 +116,27 @@ export async function readCronRunLogEntries(
         runAtMs: obj.runAtMs,
         durationMs: obj.durationMs,
         nextRunAtMs: obj.nextRunAtMs,
+        model: typeof obj.model === "string" && obj.model.trim() ? obj.model : undefined,
+        provider: typeof obj.provider === "string" && obj.provider.trim() ? obj.provider : undefined,
+        usage:
+          obj.usage && typeof obj.usage === "object"
+            ? {
+                input_tokens:
+                  typeof (obj.usage as any).input_tokens === "number" ? (obj.usage as any).input_tokens : undefined,
+                output_tokens:
+                  typeof (obj.usage as any).output_tokens === "number" ? (obj.usage as any).output_tokens : undefined,
+                total_tokens:
+                  typeof (obj.usage as any).total_tokens === "number" ? (obj.usage as any).total_tokens : undefined,
+                cache_read_tokens:
+                  typeof (obj.usage as any).cache_read_tokens === "number"
+                    ? (obj.usage as any).cache_read_tokens
+                    : undefined,
+                cache_write_tokens:
+                  typeof (obj.usage as any).cache_write_tokens === "number"
+                    ? (obj.usage as any).cache_write_tokens
+                    : undefined,
+              }
+            : undefined,
       };
       if (typeof obj.sessionId === "string" && obj.sessionId.trim().length > 0) {
         entry.sessionId = obj.sessionId;

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -13,6 +13,17 @@ export type CronEvent = {
   sessionId?: string;
   sessionKey?: string;
   nextRunAtMs?: number;
+
+  // Telemetry (best-effort)
+  model?: string;
+  provider?: string;
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    total_tokens?: number;
+    cache_read_tokens?: number;
+    cache_write_tokens?: number;
+  };
 };
 
 export type Logger = {
@@ -60,6 +71,17 @@ export type CronServiceDeps = {
      * https://github.com/openclaw/openclaw/issues/15692
      */
     delivered?: boolean;
+
+    // Telemetry (best-effort)
+    model?: string;
+    provider?: string;
+    usage?: {
+      input_tokens?: number;
+      output_tokens?: number;
+      total_tokens?: number;
+      cache_read_tokens?: number;
+      cache_write_tokens?: number;
+    };
   }>;
   onEvent?: (evt: CronEvent) => void;
 };

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -216,6 +216,15 @@ export async function onTimer(state: CronServiceState) {
       summary?: string;
       sessionId?: string;
       sessionKey?: string;
+      model?: string;
+      provider?: string;
+      usage?: {
+        input_tokens?: number;
+        output_tokens?: number;
+        total_tokens?: number;
+        cache_read_tokens?: number;
+        cache_write_tokens?: number;
+      };
       startedAt: number;
       endedAt: number;
     }> = [];
@@ -426,6 +435,15 @@ async function executeJobCore(
   summary?: string;
   sessionId?: string;
   sessionKey?: string;
+  model?: string;
+  provider?: string;
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    total_tokens?: number;
+    cache_read_tokens?: number;
+    cache_write_tokens?: number;
+  };
 }> {
   if (job.sessionTarget === "main") {
     const text = resolveJobPayloadTextForMain(job);
@@ -515,6 +533,9 @@ async function executeJobCore(
     summary: res.summary,
     sessionId: res.sessionId,
     sessionKey: res.sessionKey,
+    model: res.model,
+    provider: res.provider,
+    usage: res.usage,
   };
 }
 
@@ -542,6 +563,15 @@ export async function executeJob(
     summary?: string;
     sessionId?: string;
     sessionKey?: string;
+    model?: string;
+    provider?: string;
+    usage?: {
+      input_tokens?: number;
+      output_tokens?: number;
+      total_tokens?: number;
+      cache_read_tokens?: number;
+      cache_write_tokens?: number;
+    };
   };
   try {
     coreResult = await executeJobCore(state, job);
@@ -574,6 +604,15 @@ function emitJobFinished(
     summary?: string;
     sessionId?: string;
     sessionKey?: string;
+    model?: string;
+    provider?: string;
+    usage?: {
+      input_tokens?: number;
+      output_tokens?: number;
+      total_tokens?: number;
+      cache_read_tokens?: number;
+      cache_write_tokens?: number;
+    };
   },
   runAtMs: number,
 ) {
@@ -588,6 +627,9 @@ function emitJobFinished(
     runAtMs,
     durationMs: job.state.lastDurationMs,
     nextRunAtMs: job.state.nextRunAtMs,
+    model: result.model,
+    provider: result.provider,
+    usage: result.usage,
   });
 }
 

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -213,6 +213,9 @@ export function buildGatewayCronService(params: {
           runAtMs: evt.runAtMs,
           durationMs: evt.durationMs,
           nextRunAtMs: evt.nextRunAtMs,
+          model: evt.model,
+          provider: evt.provider,
+          usage: evt.usage,
         }).catch((err) => {
           cronLogger.warn({ err: String(err), logPath }, "cron: run log append failed");
         });


### PR DESCRIPTION
Adds best-effort token telemetry (input/output/total when provider returns usage) to cron run JSONL records and includes a local report script to summarize token usage by job over a time window.

- Persists fields alongside existing cron run history: ~/.openclaw/cron/runs/<jobId>.jsonl
- Adds scripts/cron_usage_report.ts (tokens-only)

No cost estimation included.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds best-effort token telemetry (`model`, `provider`, `usage`) to cron run JSONL records and includes a local `scripts/cron_usage_report.ts` to summarize token usage. The telemetry fields are correctly threaded through the cron service layer (`state.ts` → `timer.ts` → `server-cron.ts`) and the isolated agent runner (`run.ts`).

- **`CronRunLogEntry` type not updated (compile error):** The `CronRunLogEntry` type in `src/cron/run-log.ts` was not extended with `model`, `provider`, and `usage`. The call site in `server-cron.ts:216-218` passes these as an object literal to `appendCronRunLog(filePath, entry: CronRunLogEntry)`, which will fail TypeScript's excess property check. Additionally, `readCronRunLogEntries` explicitly reconstructs entries from only the old fields, so the gateway API will strip telemetry data when reading logs back.
- **Telemetry omitted on delivery error paths:** Several non-best-effort error returns in `run.ts` (lines 583, 596, 638, 724, 735) don't spread `...telemetry`, silently dropping usage data when delivery fails after a successful agent run.

<h3>Confidence Score: 2/5</h3>

- The PR has a type-level defect that likely causes a TypeScript compilation error; the core telemetry plumbing is sound but the persistence layer was not updated to match.
- The `CronRunLogEntry` type in `run-log.ts` lacks the new `model`/`provider`/`usage` fields, which should produce a TS excess-property error when `server-cron.ts` passes them to `appendCronRunLog`. The `readCronRunLogEntries` function also strips these fields on read-back. These are fixable issues but they prevent the feature from working as intended without a follow-up change.
- `src/cron/run-log.ts` needs `CronRunLogEntry` type and `readCronRunLogEntries` updated. `src/cron/isolated-agent/run.ts` error return paths should include telemetry.

<sub>Last reviewed commit: 098a205</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->