### PR TITLE
feat: support Z.AI tool_stream for real-time tool call streaming

### DIFF
--- a/src/agents/pi-embedded-runner/extra-params.zai-tool-stream.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.zai-tool-stream.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import type { Context, Model } from "@mariozechner/pi-ai";
+import { applyExtraParamsToAgent } from "./extra-params.js";
+
+// Mock streamSimple for testing
+vi.mock("@mariozechner/pi-ai", () => ({
+  streamSimple: vi.fn(() => ({
+    push: vi.fn(),
+    result: vi.fn(),
+  })),
+}));
+
+describe("extra-params: Z.AI tool_stream support", () => {
+  it("should inject tool_stream=true for zai provider by default", () => {
+    const capturedPayloads: unknown[] = [];
+    const mockStreamFn: StreamFn = vi.fn((model, context, options) => {
+      // Capture the payload that would be sent
+      options?.onPayload?.({ model: model.id, messages: [] });
+      return {
+        push: vi.fn(),
+        result: vi.fn().mockResolvedValue({
+          role: "assistant",
+          content: [{ type: "text", text: "ok" }],
+          stopReason: "stop",
+        }),
+      } as any;
+    });
+
+    const agent = { streamFn: mockStreamFn };
+    const cfg = {
+      agents: {
+        defaults: {},
+      },
+    };
+
+    applyExtraParamsToAgent(agent, cfg as any, "zai", "glm-5");
+
+    // The streamFn should be wrapped
+    expect(agent.streamFn).toBeDefined();
+    expect(agent.streamFn).not.toBe(mockStreamFn);
+  });
+
+  it("should not inject tool_stream for non-zai providers", () => {
+    const mockStreamFn: StreamFn = vi.fn(() => ({
+      push: vi.fn(),
+      result: vi.fn().mockResolvedValue({
+        role: "assistant",
+        content: [{ type: "text", text: "ok" }],
+        stopReason: "stop",
+      }),
+    } as any));
+
+    const agent = { streamFn: mockStreamFn };
+    const cfg = {};
+
+    applyExtraParamsToAgent(agent, cfg as any, "anthropic", "claude-opus-4-6");
+
+    // Should remain unchanged (except for OpenAI wrapper)
+    expect(agent.streamFn).toBeDefined();
+  });
+
+  it("should allow disabling tool_stream via params", () => {
+    const mockStreamFn: StreamFn = vi.fn(() => ({
+      push: vi.fn(),
+      result: vi.fn().mockResolvedValue({
+        role: "assistant",
+        content: [{ type: "text", text: "ok" }],
+        stopReason: "stop",
+      }),
+    } as any));
+
+    const agent = { streamFn: mockStreamFn };
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "zai/glm-5": {
+              params: {
+                tool_stream: false,
+              },
+            },
+          },
+        },
+      },
+    };
+
+    applyExtraParamsToAgent(agent, cfg as any, "zai", "glm-5");
+
+    // The tool_stream wrapper should be applied but with enabled=false
+    // In this case, it should just return the underlying streamFn
+    expect(agent.streamFn).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
Add support for Z.AI's `tool_stream` parameter to enable real-time visibility into model reasoning and tool call execution.

## Changes
- Automatically inject `tool_stream: true` for `zai`/`z-ai` providers
- Allow disabling via `params.tool_stream: false` in model config
- Follows existing pattern of `createOpenRouterHeadersWrapper` and `createOpenAIResponsesStoreWrapper`

## Technical Details
Z.AI's API supports the `tool_stream` parameter (along with `stream: true`) to return progressive `tool_calls` deltas during streaming. This allows users to see:
- Real-time reasoning content (`reasoning_content`)
- Progressive tool call execution (`tool_calls` delta)
- Intermediate thinking steps

Reference: https://docs.z.ai/api-reference#streaming

## Implementation
Uses the existing `onPayload` callback mechanism to inject the parameter before the API request is sent, following the same pattern as the OpenAI Responses store wrapper.

## Testing
- Code follows existing patterns in the codebase
- Added unit test file for validation
- Manual testing with Z.AI API pending

## AI Assistance
🤖 This implementation was written with Claude assistance (OpenClaw agent). The code has been reviewed to ensure it:
- Matches existing code patterns
- Follows OpenClaw's contribution guidelines
- Is safe and correct

Closes #18135

## Checklist
- [x] Mark as AI-assisted
- [x] Note testing level: lightly tested (code review + pattern matching)
- [x] I understand what the code does
- [x] Follows CONTRIBUTING.md guidelines

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Z.AI `tool_stream` support by injecting `tool_stream: true` into the API payload for `zai`/`z-ai` providers, following the existing `onPayload` wrapper pattern used by `createOpenAIResponsesStoreWrapper`. The feature is enabled by default and can be disabled via model config `params.tool_stream: false`.

- The production code in `extra-params.ts` is functionally correct and follows established patterns
- The `enabled` parameter on `createZaiToolStreamWrapper` is dead code — the caller already checks `toolStreamEnabled` before invoking the wrapper, so it is always called with `true`
- **The tests don't verify core behavior**: none of the three test cases invoke the wrapped `streamFn` or check that `tool_stream: true` is actually injected into payloads. Compare with the existing e2e tests in `pi-embedded-runner-extraparams.e2e.test.ts` which properly exercise the payload mutation
- The "disable" test has a misleading comment and doesn't actually verify that `tool_stream` is absent from the payload when disabled
- Unused type imports (`Context`, `Model`) in the test file

<h3>Confidence Score: 3/5</h3>

- The production code is safe to merge but the tests provide minimal actual coverage of the new behavior.
- The implementation itself follows established patterns correctly and is low-risk — it only mutates payloads for Z.AI providers. However, the test suite doesn't verify the core payload mutation behavior, has misleading comments, and unused imports. The tests would pass even if the wrapper logic was completely broken, since they only check that `streamFn` is defined/wrapped (which always holds due to the OpenAI Responses wrapper).
- `src/agents/pi-embedded-runner/extra-params.zai-tool-stream.test.ts` needs significant rework to actually verify payload mutation behavior.

<sub>Last reviewed commit: aba438e</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))

<!-- /greptile_comment -->