### PR TITLE
feat(slack): add configurable rateLimitPolicy for Slack API calls

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -516,7 +516,7 @@ Primary reference:
   - channel access: `groupPolicy`, `channels.*`, `channels.*.users`, `channels.*.requireMention`
   - threading/history: `replyToMode`, `replyToModeByChatType`, `thread.*`, `historyLimit`, `dmHistoryLimit`, `dms.*.historyLimit`
   - delivery: `textChunkLimit`, `chunkMode`, `mediaMaxMb`, `streaming`, `nativeStreaming`
-  - ops/features: `configWrites`, `commands.native`, `slashCommand.*`, `actions.*`, `userToken`, `userTokenReadOnly`
+  - ops/features: `configWrites`, `commands.native`, `slashCommand.*`, `actions.*`, `userToken`, `userTokenReadOnly`, `rateLimitPolicy`
 
 ## Related
 

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -369,6 +369,7 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
       streaming: "partial", // off | partial | block | progress (preview mode)
       nativeStreaming: true, // use Slack native streaming API when streaming=partial
       mediaMaxMb: 20,
+      rateLimitPolicy: "retry", // retry (default) | fail-fast
     },
   },
 }
@@ -378,6 +379,7 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
 - **HTTP mode** requires `botToken` plus `signingSecret` (at root or per-account).
 - `configWrites: false` blocks Slack-initiated config writes.
 - `channels.slack.streaming` is the canonical stream mode key. Legacy `streamMode` and boolean `streaming` values are auto-migrated.
+- `rateLimitPolicy: "fail-fast"` uses targeted APIs (`users.info`, `conversations.info`) for ID entries instead of paginating all workspace users/channels. Prevents 429 retry loops from starving the WebSocket connection on large workspaces.
 - Use `user:<id>` (DM) or `channel:<id>` for delivery targets.
 
 **Reaction notification modes:** `off`, `own` (default), `all`, `allowlist` (from `reactionAllowlist`).

--- a/src/auto-reply/reply/commands-allowlist.ts
+++ b/src/auto-reply/reply/commands-allowlist.ts
@@ -317,7 +317,11 @@ async function resolveSlackNames(params: {
   if (!token) {
     return new Map<string, string>();
   }
-  const resolved = await resolveSlackUserAllowlist({ token, entries: params.entries });
+  const resolved = await resolveSlackUserAllowlist({
+    token,
+    entries: params.entries,
+    rateLimitPolicy: account.config.rateLimitPolicy,
+  });
   return mapResolvedAllowlistNames(resolved);
 }
 

--- a/src/channels/plugins/onboarding/slack.ts
+++ b/src/channels/plugins/onboarding/slack.ts
@@ -330,6 +330,7 @@ export const slackOnboardingAdapter: ChannelOnboardingAdapter = {
             const resolved = await resolveSlackChannelAllowlist({
               token: accountWithTokens.botToken,
               entries,
+              rateLimitPolicy: accountWithTokens.config.rateLimitPolicy,
             });
             const resolvedKeys = resolved
               .filter((entry) => entry.resolved && entry.id)

--- a/src/channels/plugins/onboarding/slack.ts
+++ b/src/channels/plugins/onboarding/slack.ts
@@ -192,6 +192,7 @@ async function promptSlackAllowFrom(params: {
       resolveSlackUserAllowlist({
         token,
         entries,
+        rateLimitPolicy: resolved.config.rateLimitPolicy,
       }),
   });
 }

--- a/src/config/types.slack.ts
+++ b/src/config/types.slack.ts
@@ -182,6 +182,13 @@ export type SlackAccountConfig = {
    * Slack uses shortcodes (e.g., "eyes") rather than unicode emoji.
    */
   ackReaction?: string;
+  /**
+   * Rate-limit handling policy for bulk Slack API calls.
+   * - "retry" (default): always paginate users.list, retry on 429.
+   * - "fail-fast": use targeted APIs (users.info, users.lookupByEmail) for
+   *   ID/email entries and reject rate-limited bulk calls immediately.
+   */
+  rateLimitPolicy?: "retry" | "fail-fast";
 };
 
 export type SlackConfig = {

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -662,6 +662,7 @@ export const SlackAccountSchema = z
     heartbeat: ChannelHeartbeatVisibilitySchema,
     responsePrefix: z.string().optional(),
     ackReaction: z.string().optional(),
+    rateLimitPolicy: z.enum(["retry", "fail-fast"]).optional(),
   })
   .strict()
   .superRefine((value, ctx) => {

--- a/src/slack/client.ts
+++ b/src/slack/client.ts
@@ -18,3 +18,15 @@ export function resolveSlackWebClientOptions(options: WebClientOptions = {}): We
 export function createSlackWebClient(token: string, options: WebClientOptions = {}) {
   return new WebClient(token, resolveSlackWebClientOptions(options));
 }
+
+/**
+ * Create a WebClient that rejects rate-limited calls immediately instead of
+ * retrying for minutes. Use this for bulk operations (like users.list pagination)
+ * where a 429 retry loop would starve the WebSocket connection.
+ */
+export function createSlackWebClientBulk(token: string, options: WebClientOptions = {}) {
+  return new WebClient(token, {
+    ...resolveSlackWebClientOptions(options),
+    rejectRateLimitedCalls: true,
+  });
+}

--- a/src/slack/monitor/provider.ts
+++ b/src/slack/monitor/provider.ts
@@ -254,6 +254,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
             const resolved = await resolveSlackChannelAllowlist({
               token: resolveToken,
               entries,
+              rateLimitPolicy: account.config.rateLimitPolicy,
             });
             const nextChannels = { ...channelsConfig };
             const mapping: string[] = [];

--- a/src/slack/monitor/provider.ts
+++ b/src/slack/monitor/provider.ts
@@ -287,6 +287,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
           const resolvedUsers = await resolveSlackUserAllowlist({
             token: resolveToken,
             entries: allowEntries.map((entry) => String(entry)),
+            rateLimitPolicy: account.config.rateLimitPolicy,
           });
           const { mapping, unresolved, additions } = buildAllowlistResolutionSummary(
             resolvedUsers,
@@ -318,6 +319,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
             const resolvedUsers = await resolveSlackUserAllowlist({
               token: resolveToken,
               entries: Array.from(userEntries),
+              rateLimitPolicy: account.config.rateLimitPolicy,
             });
             const { resolvedMap, mapping, unresolved } =
               buildAllowlistResolutionSummary(resolvedUsers);

--- a/src/slack/resolve-channels.ts
+++ b/src/slack/resolve-channels.ts
@@ -1,5 +1,5 @@
 import type { WebClient } from "@slack/web-api";
-import { createSlackWebClient } from "./client.js";
+import { createSlackWebClient, createSlackWebClientBulk } from "./client.js";
 
 export type SlackChannelLookup = {
   id: string;
@@ -182,7 +182,11 @@ export async function resolveSlackChannelAllowlist(params: {
   client?: WebClient;
   rateLimitPolicy?: "retry" | "fail-fast";
 }): Promise<SlackChannelResolution[]> {
-  const client = params.client ?? createSlackWebClient(params.token);
+  const client =
+    params.client ??
+    (params.rateLimitPolicy === "fail-fast"
+      ? createSlackWebClientBulk(params.token)
+      : createSlackWebClient(params.token));
 
   if (params.rateLimitPolicy === "fail-fast") {
     return resolveViaTargetedApis(client, params.entries);

--- a/src/slack/resolve-users.ts
+++ b/src/slack/resolve-users.ts
@@ -1,5 +1,5 @@
 import type { WebClient } from "@slack/web-api";
-import { createSlackWebClient } from "./client.js";
+import { createSlackWebClient, createSlackWebClientBulk } from "./client.js";
 
 export type SlackUserLookup = {
   id: string;
@@ -271,7 +271,11 @@ export async function resolveSlackUserAllowlist(params: {
   client?: WebClient;
   rateLimitPolicy?: "retry" | "fail-fast";
 }): Promise<SlackUserResolution[]> {
-  const client = params.client ?? createSlackWebClient(params.token);
+  const client =
+    params.client ??
+    (params.rateLimitPolicy === "fail-fast"
+      ? createSlackWebClientBulk(params.token)
+      : createSlackWebClient(params.token));
 
   if (params.rateLimitPolicy === "fail-fast") {
     return resolveViaTargetedApis(client, params.entries);

--- a/src/slack/resolve-users.ts
+++ b/src/slack/resolve-users.ts
@@ -40,6 +40,20 @@ type SlackListUsersResponse = {
   response_metadata?: { next_cursor?: string };
 };
 
+type SlackUserInfoMember = {
+  id?: string;
+  name?: string;
+  deleted?: boolean;
+  is_bot?: boolean;
+  is_app_user?: boolean;
+  real_name?: string;
+  profile?: {
+    display_name?: string;
+    real_name?: string;
+    email?: string;
+  };
+};
+
 function parseSlackUserInput(raw: string): { id?: string; name?: string; email?: string } {
   const trimmed = raw.trim();
   if (!trimmed) {
@@ -60,6 +74,58 @@ function parseSlackUserInput(raw: string): { id?: string; name?: string; email?:
   return name ? { name } : {};
 }
 
+function memberToLookup(member: SlackUserInfoMember): SlackUserLookup | null {
+  const id = member.id?.trim();
+  const name = member.name?.trim();
+  if (!id || !name) {
+    return null;
+  }
+  const profile = member.profile ?? {};
+  return {
+    id,
+    name,
+    displayName: profile.display_name?.trim() || undefined,
+    realName: profile.real_name?.trim() || member.real_name?.trim() || undefined,
+    email: profile.email?.trim()?.toLowerCase() || undefined,
+    deleted: Boolean(member.deleted),
+    isBot: Boolean(member.is_bot),
+    isAppUser: Boolean(member.is_app_user),
+  };
+}
+
+/** Resolve a single user by ID via users.info (Tier 4 — generous rate limit). */
+async function lookupUserById(client: WebClient, userId: string): Promise<SlackUserLookup | null> {
+  try {
+    const res = (await client.users.info({ user: userId })) as { user?: SlackUserInfoMember };
+    if (!res.user) {
+      return null;
+    }
+    return memberToLookup(res.user);
+  } catch {
+    return null;
+  }
+}
+
+/** Resolve a single user by email via users.lookupByEmail (Tier 3). */
+async function lookupUserByEmail(
+  client: WebClient,
+  email: string,
+): Promise<SlackUserLookup | null> {
+  try {
+    const res = (await client.users.lookupByEmail({ email })) as { user?: SlackUserInfoMember };
+    if (!res.user) {
+      return null;
+    }
+    return memberToLookup(res.user);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Paginate through all workspace users via users.list (Tier 2 — strict rate limit).
+ * Only used when entries contain display names that require fuzzy matching.
+ */
 async function listSlackUsers(client: WebClient): Promise<SlackUserLookup[]> {
   const users: SlackUserLookup[] = [];
   let cursor: string | undefined;
@@ -69,22 +135,10 @@ async function listSlackUsers(client: WebClient): Promise<SlackUserLookup[]> {
       cursor,
     })) as SlackListUsersResponse;
     for (const member of res.members ?? []) {
-      const id = member.id?.trim();
-      const name = member.name?.trim();
-      if (!id || !name) {
-        continue;
+      const lookup = memberToLookup(member);
+      if (lookup) {
+        users.push(lookup);
       }
-      const profile = member.profile ?? {};
-      users.push({
-        id,
-        name,
-        displayName: profile.display_name?.trim() || undefined,
-        realName: profile.real_name?.trim() || member.real_name?.trim() || undefined,
-        email: profile.email?.trim()?.toLowerCase() || undefined,
-        deleted: Boolean(member.deleted),
-        isBot: Boolean(member.is_bot),
-        isAppUser: Boolean(member.is_app_user),
-      });
     }
     const next = res.response_metadata?.next_cursor?.trim();
     cursor = next ? next : undefined;
@@ -136,12 +190,94 @@ function resolveSlackUserFromMatches(
   };
 }
 
+function buildResolutionFromLookup(
+  input: string,
+  id: string,
+  lookup: SlackUserLookup | null,
+): SlackUserResolution {
+  return {
+    input,
+    resolved: true,
+    id,
+    name: lookup ? (lookup.displayName ?? lookup.realName ?? lookup.name) : undefined,
+    email: lookup?.email,
+    deleted: lookup?.deleted,
+    isBot: lookup?.isBot,
+  };
+}
+
+/**
+ * Resolve allowlist entries using targeted APIs (users.info for IDs, users.lookupByEmail
+ * for emails) and only falling back to users.list for name entries.
+ */
+async function resolveViaTargetedApis(
+  client: WebClient,
+  entries: string[],
+): Promise<SlackUserResolution[]> {
+  const parsed = entries.map((input) => ({ input, ...parseSlackUserInput(input) }));
+  const idEntries = parsed.filter((entry) => entry.id);
+  const emailEntries = parsed.filter((entry) => entry.email);
+  const nameEntries = parsed.filter((entry) => entry.name);
+  const emptyEntries = parsed.filter((entry) => !entry.id && !entry.email && !entry.name);
+
+  const results: SlackUserResolution[] = [];
+
+  // Resolve IDs via users.info (Tier 4 — ~100+ req/min).
+  for (const entry of idEntries) {
+    const lookup = await lookupUserById(client, entry.id!);
+    results.push(buildResolutionFromLookup(entry.input, entry.id!, lookup));
+  }
+
+  // Resolve emails via users.lookupByEmail (Tier 3).
+  for (const entry of emailEntries) {
+    const lookup = await lookupUserByEmail(client, entry.email!);
+    if (lookup) {
+      results.push(buildResolutionFromLookup(entry.input, lookup.id, lookup));
+    } else {
+      results.push({ input: entry.input, resolved: false });
+    }
+  }
+
+  // Only paginate through the full user list when there are name entries
+  // that require fuzzy matching — this is the expensive Tier 2 call.
+  if (nameEntries.length > 0) {
+    const users = await listSlackUsers(client);
+    for (const entry of nameEntries) {
+      const target = entry.name!.toLowerCase();
+      const matches = users.filter((user) => {
+        const candidates = [user.name, user.displayName, user.realName]
+          .map((value) => value?.toLowerCase())
+          .filter(Boolean) as string[];
+        return candidates.includes(target);
+      });
+      if (matches.length > 0) {
+        results.push(resolveSlackUserFromMatches(entry.input, matches, { name: entry.name }));
+      } else {
+        results.push({ input: entry.input, resolved: false });
+      }
+    }
+  }
+
+  for (const entry of emptyEntries) {
+    results.push({ input: entry.input, resolved: false });
+  }
+
+  return results;
+}
+
 export async function resolveSlackUserAllowlist(params: {
   token: string;
   entries: string[];
   client?: WebClient;
+  rateLimitPolicy?: "retry" | "fail-fast";
 }): Promise<SlackUserResolution[]> {
   const client = params.client ?? createSlackWebClient(params.token);
+
+  if (params.rateLimitPolicy === "fail-fast") {
+    return resolveViaTargetedApis(client, params.entries);
+  }
+
+  // Default ("retry" or undefined): always use users.list — original behavior.
   const users = await listSlackUsers(client);
   const results: SlackUserResolution[] = [];
 


### PR DESCRIPTION
Slack users.list (Tier 2, ~20 req/min) rate limiting can cause cascading failures: 429 retries starve the WebSocket connection, killing pong replies and eventually DNS resolution. When all allowlist entries are user IDs or emails, we can resolve them with users.info (Tier 4, ~100+ req/min) or users.lookupByEmail (Tier 3) in a single call each.

Add `rateLimitPolicy?: "retry" | "fail-fast"` to SlackAccountConfig:

- "retry" (default): original behavior — always paginate users.list, retry 429s in directory operations. Zero behavioral change.
- "fail-fast": use targeted APIs (users.info, users.lookupByEmail) for ID/email entries, reject rate-limited calls immediately in bulk directory operations. Only falls back to users.list for name entries.

Threaded through all callers: monitor/provider, commands-allowlist, and onboarding wizard.

## Summary

- **Problem:** `resolveSlackUserAllowlist()` always paginates ALL workspace users via `users.list` (Tier 2, ~20 req/min) even when every entry is a user ID resolvable with a single `users.info` call (Tier 4,~100+ req/min).
- **Why it matters:** On large workspaces (i.e enteprise workspace), 429 retry loops starve the WebSocket connection: pong replies time out, then DNS resolution fails, cascading into full disconnection.
- **What changed:** Added `rateLimitPolicy?: "retry" | "fail-fast"` config option. When `"fail-fast"`: IDs resolve via `users.info`, emails via `users.lookupByEmail`, directory ops use `rejectRateLimitedCalls:true`. Names still fall back to `users.list`. Threaded the config through all 5 callers.
- **What did NOT change (scope boundary):** Default behavior is identical: no config means `"retry"`, which is the existing `users.list` + retry path. No changes to Slack event handling, message processing, or WebSocket management.

Issue Example:

```
15:56:25 [slack] [default] starting provider
09:56:25 [WARN]  bolt-app http request failed getaddrinfo ENOTFOUND slack.com
09:56:25 [WARN]  bolt-app http request failed getaddrinfo ENOTFOUND slack.com
09:56:26 [WARN]  bolt-app http request failed getaddrinfo ENOTFOUND slack.com
09:56:26 [WARN]  bolt-app http request failed getaddrinfo ENOTFOUND slack.com
09:56:26 [WARN]  web-api:WebClient:0 http request failed getaddrinfo ENOTFOUND slack.com
09:56:27 [WARN]  web-api:WebClient:0 http request failed getaddrinfo ENOTFOUND slack.com
09:56:27 [WARN]  bolt-app http request failed getaddrinfo ENOTFOUND slack.com
09:56:27 [openclaw] Unhandled promise rejection: Error: A request error occurred: getaddrinfo ENOTFOUND slack.com
    at requestErrorWithOriginal (/Users/mterns/Documents/AI/openclaw/node_modules/.pnpm/@slack+web-api@7.14.0/node_modules/@slack/web-api/src/errors.ts:82:5)
    at WebClient.<anonymous> (/Users/mterns/Documents/AI/openclaw/node_modules/.pnpm/@slack+web-api@7.14.0/node_modules/@slack/web-api/src/WebClient.ts:767:43)
    at Generator.throw (<anonymous>)
    at rejected (/Users/mterns/Documents/AI/openclaw/node_modules/.pnpm/@slack+web-api@7.14.0/node_modules/@slack/web-api/dist/WebClient.js:39:65)
    at processTicksAndRejections (node:internal/process/task_queues:105:5)
 ELIFECYCLE  Command failed with exit code 1.
```

## Change Type (select all)

- [ ] Bug fix
- [ x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ x] Integrations
- [x ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Related: rate-limit cascading failure observed after rebasing with main

## User-visible / Behavior Changes

- New optional config field: `channels.slack.rateLimitPolicy` (`"retry"` | `"fail-fast"`)
- Default (`"retry"` / unset): no change whatsoever
- `"fail-fast"`: allowlist resolution uses targeted APIs instead of full workspace pagination; directory lookups reject 429s immediately instead of retrying

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `Yes` — when `"fail-fast"`, calls `users.info` and `users.lookupByEmail` instead of `users.list`. Same token, same Slack API, narrower scope (single user vs. all users).
- Command/tool execution surface changed? `No`
- Data access scope changed? `No` — targeted APIs return the same user fields as `users.list`, just for one user at a time.

## Repro + Verification

### Environment

- OS: macOS Darwin 25.1.0
- Runtime: Node 22 / pnpm
- Integration: Slack (socket mode)
- Relevant config: `{ "channels": { "slack": { "rateLimitPolicy": "fail-fast" } } }`

### Steps

1. Set `rateLimitPolicy: "fail-fast"` in Slack config with ID-only allowlist entries
2. Start the bot — observe allowlist resolution uses `users.info` per ID (no `users.list` pagination)
3. Remove `rateLimitPolicy` — observe original `users.list` behavior unchanged

### Expected

- `"fail-fast"`: resolves IDs via `users.info`, no `users.list` calls when all entries are IDs
- Default: identical to current main branch behavior

### Actual

- Build passes, tests pass (no new failures)

## Evidence

- [x] `pnpm build` — clean
- [x] `pnpm check` — pre-commit hooks: 0 warnings, 0 errors on all changed files
- [x] `pnpm test` — no new failures (13 failures are pre-existing memory tests on main)

## Human Verification (required)

- **Verified scenarios:** Build, lint, format, full test suite
- **Edge cases checked:** Mixed allowlist (IDs + names) falls back to `users.list` only for the name entries; empty/unset `rateLimitPolicy` preserves exact original code path

## Compatibility / Migration

- Backward compatible? `Yes` — default is `"retry"`, identical to current behavior
- Config/env changes? `Yes` — new optional field `rateLimitPolicy` in `SlackAccountConfig`
- Migration needed? `No` — existing configs work without changes

## Failure Recovery (if this breaks)

- How to disable/revert: remove `rateLimitPolicy` from config (or set to `"retry"`) — reverts to original code path immediately, no restart needed beyond config reload
- Known bad symptoms: if `"fail-fast"` is set and the bot needs name-based resolution on a rate-limited workspace, those name lookups still hit `users.list` and will fail fast instead of retrying

## Risks and Mitigations

- **Risk:** `"fail-fast"` mode rejects 429s in directory operations, so large-workspace directory lookups that previously would have eventually succeeded will now fail.
- **Mitigation:** Opt-in only — users must explicitly set `rateLimitPolicy: "fail-fast"`. Default behavior is unchanged. Removing the config key instantly reverts.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds optional `rateLimitPolicy` config field to prevent Slack rate-limit cascading failures. When set to `"fail-fast"`, resolves allowlist entries using targeted APIs (`users.info`, `users.lookupByEmail`) instead of paginating `users.list`, and rejects 429s immediately in bulk directory operations.

**Key changes:**
- New config field `channels.slack.rateLimitPolicy` (`"retry"` | `"fail-fast"`, default `"retry"`)
- `createSlackWebClientBulk` helper creates clients with `rejectRateLimitedCalls: true`
- `resolveViaTargetedApis` resolves IDs/emails via Tier 3/4 APIs, only falls back to `users.list` for name entries
- Threaded through allowlist resolution, directory lookups, and onboarding

**Critical issue:** `resolve-users.ts:274` doesn't use `createSlackWebClientBulk` for fail-fast mode, so targeted API calls and the `listSlackUsers` fallback will still retry on 429s instead of failing immediately. This undermines the entire purpose of the fail-fast policy.

<h3>Confidence Score: 2/5</h3>

- This PR contains a critical logic bug that breaks the core "fail-fast" functionality
- The implementation has a significant bug in `resolve-users.ts` where the fail-fast policy doesn't actually use a client configured to reject rate-limited calls. This means the feature won't work as intended when `rateLimitPolicy: "fail-fast"` is set - it will still retry on 429s instead of failing fast. The fix is straightforward (use `createSlackWebClientBulk` when fail-fast is enabled), but the bug must be addressed before merging.
- `src/slack/resolve-users.ts` requires immediate fix - the fail-fast client implementation is broken

<sub>Last reviewed commit: 59add71</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->