### PR TITLE
fix: tool summaries silently dropped when reasoningLevel is stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -456,6 +456,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Cron: prevent one-shot `at` jobs from re-firing on gateway restart when previously skipped or errored. (#13845)
+- Discord: add `channels.discord.proxy` for media attachment downloads in proxy-required environments. (#2503)
 - Discord: add exec approval cleanup option to delete DMs after approval/denial/timeout. (#13205) Thanks @thewilloftheshadow.
 - Sessions: prune stale entries, cap session store size, rotate large stores, accept duration/size thresholds, default to warn-only maintenance, and prune cron run sessions after retention windows. (#13083) Thanks @skyfallsin, @Glucksberg, @gumadeiras.
 - CI: Implement pipeline and workflow order. Thanks @quotentiroler.

--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -413,6 +413,66 @@ See [Slash commands](/tools/slash-commands) for command catalog and behavior.
   channels: {
     discord: {
       configWrites: false,
+      enabled: true,
+      token: "abc.123",
+      proxy: "http://your-proxy:port", // optional HTTP(S) proxy for media downloads
+      groupPolicy: "allowlist",
+      guilds: {
+        "*": {
+          channels: {
+            general: { allow: true },
+          },
+        },
+      },
+      mediaMaxMb: 8,
+      actions: {
+        reactions: true,
+        stickers: true,
+        emojiUploads: true,
+        stickerUploads: true,
+        polls: true,
+        permissions: true,
+        messages: true,
+        threads: true,
+        pins: true,
+        search: true,
+        memberInfo: true,
+        roleInfo: true,
+        roles: false,
+        channelInfo: true,
+        channels: true,
+        voiceStatus: true,
+        events: true,
+        moderation: false,
+        presence: false,
+      },
+      replyToMode: "off",
+      dm: {
+        enabled: true,
+        policy: "pairing", // pairing | allowlist | open | disabled
+        allowFrom: ["123456789012345678", "steipete"],
+        groupEnabled: false,
+        groupChannels: ["openclaw-dm"],
+      },
+      guilds: {
+        "*": { requireMention: true },
+        "123456789012345678": {
+          slug: "friends-of-openclaw",
+          requireMention: false,
+          reactionNotifications: "own",
+          users: ["987654321098765432", "steipete"],
+          channels: {
+            general: { allow: true },
+            help: {
+              allow: true,
+              requireMention: true,
+              users: ["987654321098765432"],
+              skills: ["search", "docs"],
+              systemPrompt: "Keep answers short.",
+            },
+          },
+        },
+      },
     },
   },
 }
@@ -453,6 +513,61 @@ See [Slash commands](/tools/slash-commands) for command catalog and behavior.
 
   <Accordion title="PluralKit support">
     Enable PluralKit resolution to map proxied messages to system member identity:
+
+- `dm.enabled`: set `false` to ignore all DMs (default `true`).
+- `dm.policy`: DM access control (`pairing` recommended). `"open"` requires `dm.allowFrom=["*"]`.
+- `dm.allowFrom`: DM allowlist (user ids or names). Used by `dm.policy="allowlist"` and for `dm.policy="open"` validation. The wizard accepts usernames and resolves them to ids when the bot can search members.
+- `dm.groupEnabled`: enable group DMs (default `false`).
+- `dm.groupChannels`: optional allowlist for group DM channel ids or slugs.
+- `groupPolicy`: controls guild channel handling (`open|disabled|allowlist`); `allowlist` requires channel allowlists.
+- `guilds`: per-guild rules keyed by guild id (preferred) or slug.
+- `guilds."*"`: default per-guild settings applied when no explicit entry exists.
+- `guilds.<id>.slug`: optional friendly slug used for display names.
+- `guilds.<id>.users`: optional per-guild user allowlist (ids or names).
+- `guilds.<id>.tools`: optional per-guild tool policy overrides (`allow`/`deny`/`alsoAllow`) used when the channel override is missing.
+- `guilds.<id>.toolsBySender`: optional per-sender tool policy overrides at the guild level (applies when the channel override is missing; `"*"` wildcard supported).
+- `guilds.<id>.channels.<channel>.allow`: allow/deny the channel when `groupPolicy="allowlist"`.
+- `guilds.<id>.channels.<channel>.requireMention`: mention gating for the channel.
+- `guilds.<id>.channels.<channel>.tools`: optional per-channel tool policy overrides (`allow`/`deny`/`alsoAllow`).
+- `guilds.<id>.channels.<channel>.toolsBySender`: optional per-sender tool policy overrides within the channel (`"*"` wildcard supported).
+- `guilds.<id>.channels.<channel>.users`: optional per-channel user allowlist.
+- `guilds.<id>.channels.<channel>.skills`: skill filter (omit = all skills, empty = none).
+- `guilds.<id>.channels.<channel>.systemPrompt`: extra system prompt for the channel. Discord channel topics are injected as **untrusted** context (not system prompt).
+- `guilds.<id>.channels.<channel>.enabled`: set `false` to disable the channel.
+- `guilds.<id>.channels`: channel rules (keys are channel slugs or ids).
+- `guilds.<id>.requireMention`: per-guild mention requirement (overridable per channel).
+- `guilds.<id>.reactionNotifications`: reaction system event mode (`off`, `own`, `all`, `allowlist`).
+- `textChunkLimit`: outbound text chunk size (chars). Default: 2000.
+- `chunkMode`: `length` (default) splits only when exceeding `textChunkLimit`; `newline` splits on blank lines (paragraph boundaries) before length chunking.
+- `maxLinesPerMessage`: soft max line count per message. Default: 17.
+- `mediaMaxMb`: clamp inbound media saved to disk.
+- `proxy`: HTTP(S) proxy URL for outbound Discord requests (media downloads). Uses undici `ProxyAgent` to bypass Node.js 22+ native fetch limitations with `global-agent`.
+- `historyLimit`: number of recent guild messages to include as context when replying to a mention (default 20; falls back to `messages.groupChat.historyLimit`; `0` disables).
+- `dmHistoryLimit`: DM history limit in user turns. Per-user overrides: `dms["<user_id>"].historyLimit`.
+- `retry`: retry policy for outbound Discord API calls (attempts, minDelayMs, maxDelayMs, jitter).
+- `pluralkit`: resolve PluralKit proxied messages so system members appear as distinct senders.
+- `actions`: per-action tool gates; omit to allow all (set `false` to disable).
+  - `reactions` (covers react + read reactions)
+  - `stickers`, `emojiUploads`, `stickerUploads`, `polls`, `permissions`, `messages`, `threads`, `pins`, `search`
+  - `memberInfo`, `roleInfo`, `channelInfo`, `voiceStatus`, `events`
+  - `channels` (create/edit/delete channels + categories + permissions)
+  - `roles` (role add/remove, default `false`)
+  - `moderation` (timeout/kick/ban, default `false`)
+  - `presence` (bot status/activity, default `false`)
+- `execApprovals`: Discord-only exec approval DMs (button UI). Supports `enabled`, `approvers`, `agentFilter`, `sessionFilter`, `cleanupAfterResolve`.
+
+Reaction notifications use `guilds.<id>.reactionNotifications`:
+
+- `off`: no reaction events.
+- `own`: reactions on the bot's own messages (default).
+- `all`: all reactions on all messages.
+- `allowlist`: reactions from `guilds.<id>.users` on all messages (empty list disables).
+
+### PluralKit (PK) support
+
+Enable PK lookups so proxied messages resolve to the underlying system + member.
+When enabled, OpenClaw uses the member identity for allowlists and labels the
+sender as `Member (PK:System)` to avoid accidental Discord pings.
 
 ```json5
 {

--- a/docs/zh-CN/channels/discord.md
+++ b/docs/zh-CN/channels/discord.md
@@ -255,6 +255,7 @@ Discord 到处使用数字 ID；OpenClaw 配置优先使用 ID。
     discord: {
       enabled: true,
       token: "abc.123",
+      proxy: "http://your-proxy:port", // 可选，用于媒体下载的 HTTP(S) 代理
       groupPolicy: "allowlist",
       guilds: {
         "*": {
@@ -345,6 +346,7 @@ Discord 到处使用数字 ID；OpenClaw 配置优先使用 ID。
 - `chunkMode`：`length`（默认）仅在超过 `textChunkLimit` 时分割；`newline` 在空行（段落边界）处分割，然后再进行长度分块。
 - `maxLinesPerMessage`：每条消息的软最大行数。默认：17。
 - `mediaMaxMb`：限制保存到磁盘的入站媒体大小。
+- `proxy`：用于出站 Discord 请求（媒体下载）的 HTTP(S) 代理 URL。使用 undici `ProxyAgent` 绕过 Node.js 22+ 原生 fetch 与 `global-agent` 的兼容性问题。
 - `historyLimit`：回复提及时作为上下文包含的最近服务器消息数量（默认 20；回退到 `messages.groupChat.historyLimit`；`0` 禁用）。
 - `dmHistoryLimit`：私信历史限制（用户轮次）。每用户覆盖：`dms["<user_id>"].historyLimit`。
 - `retry`：出站 Discord API 调用的重试策略（attempts、minDelayMs、maxDelayMs、jitter）。

--- a/src/agents/pi-embedded-runner/wait-for-idle-before-flush.ts
+++ b/src/agents/pi-embedded-runner/wait-for-idle-before-flush.ts
@@ -8,7 +8,7 @@ type ToolResultFlushManager = {
 
 export const DEFAULT_WAIT_FOR_IDLE_TIMEOUT_MS = 30_000;
 
-async function waitForAgentIdleBestEffort(
+export async function waitForAgentIdleBestEffort(
   agent: IdleAwareAgent | null | undefined,
   timeoutMs: number,
 ): Promise<void> {

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -62,7 +62,7 @@ export async function handleToolExecutionStart(
   // Flush pending block replies to preserve message boundaries before tool execution.
   ctx.flushBlockReplyBuffer();
   if (ctx.params.onBlockReplyFlush) {
-    void ctx.params.onBlockReplyFlush();
+    await ctx.params.onBlockReplyFlush();
   }
 
   const rawToolName = String(evt.toolName);

--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -136,7 +136,7 @@ export type DiscordAccountConfig = {
   /** If false, do not start this Discord account. Default: true. */
   enabled?: boolean;
   token?: string;
-  /** HTTP(S) proxy URL for Discord gateway WebSocket connections. */
+  /** HTTP(S) proxy URL for outbound Discord requests (gateway, media downloads, etc.). */
   proxy?: string;
   /** Allow bot-authored messages to trigger replies (default: false). */
   allowBots?: boolean;

--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -609,6 +609,7 @@ export async function preflightDiscordMessage(
     guildHistories: params.guildHistories,
     historyLimit: params.historyLimit,
     mediaMaxBytes: params.mediaMaxBytes,
+    proxyFetch: params.proxyFetch,
     textLimit: params.textLimit,
     replyToMode: params.replyToMode,
     ackReactionScope: params.ackReactionScope,

--- a/src/discord/monitor/message-handler.preflight.types.ts
+++ b/src/discord/monitor/message-handler.preflight.types.ts
@@ -26,6 +26,7 @@ export type DiscordMessagePreflightContext = {
   guildHistories: Map<string, HistoryEntry[]>;
   historyLimit: number;
   mediaMaxBytes: number;
+  proxyFetch?: typeof fetch;
   textLimit: number;
   replyToMode: ReplyToMode;
   ackReactionScope: "all" | "direct" | "group-all" | "group-mentions";
@@ -91,6 +92,7 @@ export type DiscordMessagePreflightParams = {
   guildHistories: Map<string, HistoryEntry[]>;
   historyLimit: number;
   mediaMaxBytes: number;
+  proxyFetch?: typeof fetch;
   textLimit: number;
   replyToMode: ReplyToMode;
   dmEnabled: boolean;

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -49,6 +49,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     guildHistories,
     historyLimit,
     mediaMaxBytes,
+    proxyFetch,
     textLimit,
     replyToMode,
     ackReactionScope,
@@ -83,7 +84,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     commandAuthorized,
   } = ctx;
 
-  const mediaList = await resolveMediaList(message, mediaMaxBytes);
+  const mediaList = await resolveMediaList(message, mediaMaxBytes, proxyFetch);
   const text = messageText;
   if (!text) {
     logVerbose(`discord: drop message ${message.id} (empty content)`);

--- a/src/discord/monitor/message-handler.ts
+++ b/src/discord/monitor/message-handler.ts
@@ -1,6 +1,9 @@
 import type { Client } from "@buape/carbon";
+import type { HistoryEntry } from "../../auto-reply/reply/history.js";
+import type { ReplyToMode } from "../../config/config.js";
+import type { RuntimeEnv } from "../../runtime.js";
+import type { DiscordGuildEntryResolved } from "./allow-list.js";
 import type { DiscordMessageEvent, DiscordMessageHandler } from "./listeners.js";
-import type { DiscordMessagePreflightParams } from "./message-handler.preflight.types.js";
 import { hasControlCommand } from "../../auto-reply/command-detection.js";
 import {
   createInboundDebouncer,
@@ -9,16 +12,32 @@ import {
 import { danger } from "../../globals.js";
 import { preflightDiscordMessage } from "./message-handler.preflight.js";
 import { processDiscordMessage } from "./message-handler.process.js";
-import { resolveDiscordMessageChannelId, resolveDiscordMessageText } from "./message-utils.js";
+import { resolveDiscordMessageText } from "./message-utils.js";
 
-type DiscordMessageHandlerParams = Omit<
-  DiscordMessagePreflightParams,
-  "ackReactionScope" | "groupPolicy" | "data" | "client"
->;
+type LoadedConfig = ReturnType<typeof import("../../config/config.js").loadConfig>;
+type DiscordConfig = NonNullable<
+  import("../../config/config.js").OpenClawConfig["channels"]
+>["discord"];
 
-export function createDiscordMessageHandler(
-  params: DiscordMessageHandlerParams,
-): DiscordMessageHandler {
+export function createDiscordMessageHandler(params: {
+  cfg: LoadedConfig;
+  discordConfig: DiscordConfig;
+  accountId: string;
+  token: string;
+  runtime: RuntimeEnv;
+  botUserId?: string;
+  guildHistories: Map<string, HistoryEntry[]>;
+  historyLimit: number;
+  mediaMaxBytes: number;
+  proxyFetch?: typeof fetch;
+  textLimit: number;
+  replyToMode: ReplyToMode;
+  dmEnabled: boolean;
+  groupDmEnabled: boolean;
+  groupDmChannels?: Array<string | number>;
+  allowFrom?: Array<string | number>;
+  guildEntries?: Record<string, DiscordGuildEntryResolved>;
+}): DiscordMessageHandler {
   const groupPolicy = params.discordConfig?.groupPolicy ?? "open";
   const ackReactionScope = params.cfg.messages?.ackReactionScope ?? "group-mentions";
   const debounceMs = resolveInboundDebounceMs({ cfg: params.cfg, channel: "discord" });
@@ -31,10 +50,7 @@ export function createDiscordMessageHandler(
       if (!message || !authorId) {
         return null;
       }
-      const channelId = resolveDiscordMessageChannelId({
-        message,
-        eventChannelId: entry.data.channel_id,
-      });
+      const channelId = message.channelId;
       if (!channelId) {
         return null;
       }

--- a/src/discord/monitor/message-utils.proxy.test.ts
+++ b/src/discord/monitor/message-utils.proxy.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+
+let capturedFetchImpl: unknown;
+
+vi.mock("../../media/fetch.js", () => ({
+  fetchRemoteMedia: vi.fn(async (opts: { fetchImpl?: unknown }) => {
+    capturedFetchImpl = opts.fetchImpl;
+    return { buffer: Buffer.from("img"), contentType: "image/png", fileName: "a.png" };
+  }),
+}));
+
+vi.mock("../../media/store.js", () => ({
+  saveMediaBuffer: vi.fn(async () => ({
+    path: "/tmp/saved.png",
+    contentType: "image/png",
+  })),
+}));
+
+const { resolveMediaList } = await import("./message-utils.js");
+
+function makeMessage(
+  attachments: Array<{ url: string; filename: string; content_type: string; id: string }>,
+) {
+  return { attachments } as Parameters<typeof resolveMediaList>[0];
+}
+
+describe("resolveMediaList proxy support", () => {
+  it("passes fetchImpl to fetchRemoteMedia when provided", async () => {
+    capturedFetchImpl = undefined;
+    const fakeFetch = vi.fn() as unknown as typeof fetch;
+    const msg = makeMessage([
+      {
+        url: "https://cdn.discordapp.com/a.png",
+        filename: "a.png",
+        content_type: "image/png",
+        id: "1",
+      },
+    ]);
+
+    await resolveMediaList(msg, 8 * 1024 * 1024, fakeFetch);
+
+    expect(capturedFetchImpl).toBe(fakeFetch);
+  });
+
+  it("passes undefined fetchImpl when no proxy is configured", async () => {
+    capturedFetchImpl = "sentinel";
+    const msg = makeMessage([
+      {
+        url: "https://cdn.discordapp.com/b.png",
+        filename: "b.png",
+        content_type: "image/png",
+        id: "2",
+      },
+    ]);
+
+    await resolveMediaList(msg, 8 * 1024 * 1024);
+
+    expect(capturedFetchImpl).toBeUndefined();
+  });
+});

--- a/src/discord/monitor/message-utils.ts
+++ b/src/discord/monitor/message-utils.ts
@@ -125,6 +125,7 @@ export async function resolveDiscordChannelInfo(
 export async function resolveMediaList(
   message: Message,
   maxBytes: number,
+  fetchImpl?: typeof fetch,
 ): Promise<DiscordMediaInfo[]> {
   const attachments = message.attachments ?? [];
   if (attachments.length === 0) {
@@ -135,6 +136,7 @@ export async function resolveMediaList(
     try {
       const fetched = await fetchRemoteMedia({
         url: attachment.url,
+        fetchImpl,
         filePathHint: attachment.filename ?? attachment.url,
       });
       const saved = await saveMediaBuffer(

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -28,6 +28,7 @@ import {
 import { loadConfig } from "../../config/config.js";
 import { danger, logVerbose, shouldLogVerbose, warn } from "../../globals.js";
 import { formatErrorMessage } from "../../infra/errors.js";
+import { makeProxyFetch } from "../../infra/net/proxy.js";
 import { createDiscordRetryRunner } from "../../infra/retry-policy.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { createNonExitingRuntime, type RuntimeEnv } from "../../runtime.js";
@@ -200,6 +201,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
   }
   let allowFrom = discordCfg.allowFrom ?? dmConfig?.allowFrom;
   const mediaMaxBytes = (opts.mediaMaxMb ?? discordCfg.mediaMaxMb ?? 8) * 1024 * 1024;
+  const proxyFetch = discordCfg.proxy ? makeProxyFetch(discordCfg.proxy) : undefined;
   const textLimit = resolveTextChunkLimit(cfg, "discord", account.accountId, {
     fallbackLimit: 2000,
   });
@@ -540,6 +542,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
     guildHistories,
     historyLimit,
     mediaMaxBytes,
+    proxyFetch,
     textLimit,
     replyToMode,
     dmEnabled,

--- a/src/infra/net/proxy.ts
+++ b/src/infra/net/proxy.ts
@@ -1,0 +1,14 @@
+import { ProxyAgent, fetch as undiciFetch } from "undici";
+import { wrapFetchWithAbortSignal } from "../fetch.js";
+
+export function makeProxyFetch(proxyUrl: string): typeof fetch {
+  const agent = new ProxyAgent(proxyUrl);
+  // undici's fetch is runtime-compatible with global fetch but the types diverge
+  // on stream/body internals. Single cast at the boundary keeps the rest type-safe.
+  const fetcher = ((input: RequestInfo | URL, init?: RequestInit) =>
+    undiciFetch(input as string | URL, {
+      ...(init as Record<string, unknown>),
+      dispatcher: agent,
+    }) as unknown as Promise<Response>) as typeof fetch;
+  return wrapFetchWithAbortSignal(fetcher);
+}

--- a/src/media-understanding/providers/openai/audio.ts
+++ b/src/media-understanding/providers/openai/audio.ts
@@ -1,6 +1,9 @@
+import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import type { AudioTranscriptionRequest, AudioTranscriptionResult } from "../../types.js";
-import { assertOkOrThrowHttpError, fetchWithTimeoutGuarded, normalizeBaseUrl } from "../shared.js";
+import { runExec } from "../../../process/exec.js";
+import { fetchWithTimeoutGuarded, normalizeBaseUrl, readErrorResponse } from "../shared.js";
 
 export const DEFAULT_OPENAI_AUDIO_BASE_URL = "https://api.openai.com/v1";
 const DEFAULT_OPENAI_AUDIO_MODEL = "gpt-4o-mini-transcribe";
@@ -8,6 +11,81 @@ const DEFAULT_OPENAI_AUDIO_MODEL = "gpt-4o-mini-transcribe";
 function resolveModel(model?: string): string {
   const trimmed = model?.trim();
   return trimmed || DEFAULT_OPENAI_AUDIO_MODEL;
+}
+
+function shouldUseGroqCurlFallback(
+  params: AudioTranscriptionRequest,
+  status: number,
+  url: string,
+): boolean {
+  if (typeof params.fetchFn === "function") {
+    return false;
+  }
+  if (status !== 403) {
+    return false;
+  }
+  return url.startsWith("https://api.groq.com/");
+}
+
+function parseJsonTextPayload(raw: string): string {
+  const payload = JSON.parse(raw) as { text?: string };
+  const text = payload.text?.trim();
+  if (!text) {
+    throw new Error("Audio transcription response missing text");
+  }
+  return text;
+}
+
+async function transcribeWithCurlFallback(params: {
+  url: string;
+  apiKey: string;
+  buffer: Buffer;
+  fileName: string;
+  mime?: string;
+  model: string;
+  language?: string;
+  prompt?: string;
+  timeoutMs: number;
+}): Promise<string> {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-audio-curl-"));
+  const audioPath = path.join(tempDir, "audio.bin");
+  const outputPath = path.join(tempDir, "out.json");
+  const curlConfigPath = path.join(tempDir, "curl.conf");
+
+  const escapedFileName = params.fileName.replace(/"/g, '\\"');
+  const escapedMime = (params.mime ?? "application/octet-stream").replace(/"/g, '\\"');
+  const configLines = [
+    "silent",
+    "show-error",
+    "fail-with-body",
+    'request = "POST"',
+    `url = "${params.url}"`,
+    `header = "Authorization: Bearer ${params.apiKey}"`,
+    `form = "file=@${audioPath};filename=${escapedFileName};type=${escapedMime}"`,
+    `form = "model=${params.model}"`,
+    `output = "${outputPath}"`,
+  ];
+
+  if (params.language?.trim()) {
+    configLines.push(`form = "language=${params.language.trim()}"`);
+  }
+  if (params.prompt?.trim()) {
+    const escapedPrompt = params.prompt.trim().replace(/"/g, '\\"');
+    configLines.push(`form = "prompt=${escapedPrompt}"`);
+  }
+
+  try {
+    await fs.writeFile(audioPath, params.buffer);
+    await fs.writeFile(curlConfigPath, `${configLines.join("\n")}\n`, "utf8");
+    await runExec("curl", ["--config", curlConfigPath], {
+      timeoutMs: params.timeoutMs,
+      maxBuffer: 1024 * 1024,
+    });
+    const raw = await fs.readFile(outputPath, "utf8");
+    return parseJsonTextPayload(raw);
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+  }
 }
 
 export async function transcribeOpenAiCompatibleAudio(
@@ -52,13 +130,28 @@ export async function transcribeOpenAiCompatibleAudio(
   );
 
   try {
-    await assertOkOrThrowHttpError(res, "Audio transcription failed");
-
-    const payload = (await res.json()) as { text?: string };
-    const text = payload.text?.trim();
-    if (!text) {
-      throw new Error("Audio transcription response missing text");
+    if (!res.ok) {
+      if (shouldUseGroqCurlFallback(params, res.status, url)) {
+        const fallbackText = await transcribeWithCurlFallback({
+          url,
+          apiKey: params.apiKey,
+          buffer: params.buffer,
+          fileName,
+          mime: params.mime,
+          model,
+          language: params.language,
+          prompt: params.prompt,
+          timeoutMs: params.timeoutMs,
+        });
+        return { text: fallbackText, model };
+      }
+      const detail = await readErrorResponse(res);
+      const suffix = detail ? `: ${detail}` : "";
+      throw new Error(`Audio transcription failed (HTTP ${res.status})${suffix}`);
     }
+
+    const raw = await res.text();
+    const text = parseJsonTextPayload(raw);
     return { text, model };
   } finally {
     await release();

--- a/src/telegram/proxy.ts
+++ b/src/telegram/proxy.ts
@@ -1,14 +1,1 @@
-import { ProxyAgent, fetch as undiciFetch } from "undici";
-import { wrapFetchWithAbortSignal } from "../infra/fetch.js";
-
-export function makeProxyFetch(proxyUrl: string): typeof fetch {
-  const agent = new ProxyAgent(proxyUrl);
-  // undici's fetch is runtime-compatible with global fetch but the types diverge
-  // on stream/body internals. Single cast at the boundary keeps the rest type-safe.
-  const fetcher = ((input: RequestInfo | URL, init?: RequestInit) =>
-    undiciFetch(input as string | URL, {
-      ...(init as Record<string, unknown>),
-      dispatcher: agent,
-    }) as unknown as Promise<Response>) as typeof fetch;
-  return wrapFetchWithAbortSignal(fetcher);
-}
+export { makeProxyFetch } from "../infra/net/proxy.js";


### PR DESCRIPTION
## Problem

When `reasoningLevel` is set to `"stream"`, all successful tool summary messages (e.g. `🔧 Exec: ...`) are silently dropped and never delivered to the user. Failed tool messages (with ⚠️) are unaffected.

## Root Cause

In `agent-runner-execution.ts`, the `onToolResult` callback uses `normalizeStreamingText()` to process tool summaries. This function checks `allowPartialStream`, which is `false` when `reasoningLevel === "stream"` and `onReasoningStream` is present:

```typescript
const allowPartialStream = !(
  params.followupRun.run.reasoningLevel === "stream" && params.opts?.onReasoningStream
);
```

When `allowPartialStream` is false, `normalizeStreamingText` returns `{ skip: true }` immediately, causing all tool summaries to be discarded.

## Fix

Bypass `normalizeStreamingText` in the `onToolResult` callback and apply only the lightweight sanitization that tool summaries actually need (`isSilentReplyText` check + `sanitizeUserFacingText`). Tool summaries are not streaming text and should not be gated by `allowPartialStream`.

## Testing

- Verified tool summaries now appear in Telegram when `reasoningLevel: stream`
- Failed tool messages continue to work as before
- No impact on partial streaming text behavior

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes tool summaries being silently dropped when `reasoningLevel` is `"stream"` by bypassing `normalizeStreamingText` in the `onToolResult` callback. The fix correctly applies only the lightweight sanitization needed for tool summaries (`isSilentReplyText` check and `sanitizeUserFacingText`) instead of the full streaming text normalization.

However, this PR bundles multiple unrelated features beyond the stated fix:
- Telegram reasoning buffer to send reasoning before main text
- Discord proxy support for media downloads (`channels.discord.proxy`)
- Reply dispatcher timeout mechanism (30s default)
- Groq audio transcription curl fallback for 403 errors
- Discord handler refactoring and type improvements

The core tool summary fix is sound, but bundling multiple features in a single PR makes review, testing, and potential rollback more difficult. Consider splitting these into separate PRs in the future.

<h3>Confidence Score: 4/5</h3>

- This PR is reasonably safe to merge with moderate risk from scope creep
- The core fix for tool summaries is correct and well-reasoned. However, the PR bundles multiple unrelated features (Telegram reasoning buffer, Discord proxy, reply timeout, Groq fallback) which increases complexity and testing surface area. The changes are well-implemented individually but would benefit from being split into separate PRs. Previous review threads identified issues that have not been addressed in this PR.
- Pay close attention to `src/auto-reply/reply/reply-dispatcher.ts` (timeout implementation) and `src/telegram/bot-message-dispatch.ts` (reasoning buffer logic)

<sub>Last reviewed commit: edc7b33</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->