### PR TITLE
fix: clear stale device-auth token on token mismatch

### DIFF
--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -1,7 +1,11 @@
 import { randomUUID } from "node:crypto";
 import { WebSocket, type ClientOptions, type CertMeta } from "ws";
 import type { DeviceIdentity } from "../infra/device-identity.js";
-import { loadDeviceAuthToken, storeDeviceAuthToken } from "../infra/device-auth-store.js";
+import {
+  clearDeviceAuthToken,
+  loadDeviceAuthToken,
+  storeDeviceAuthToken,
+} from "../infra/device-auth-store.js";
 import {
   loadOrCreateDeviceIdentity,
   publicKeyRawBase64UrlFromPem,
@@ -150,6 +154,16 @@ export class GatewayClient {
     this.ws.on("close", (code, reason) => {
       const reasonText = rawDataToString(reason);
       this.ws = null;
+      // If closed due to device token mismatch, clear the stored token so next attempt can get a fresh one
+      if (
+        code === 1008 &&
+        reasonText.includes("device token mismatch") &&
+        this.opts.deviceIdentity
+      ) {
+        const role = this.opts.role ?? "operator";
+        clearDeviceAuthToken({ deviceId: this.opts.deviceIdentity.deviceId, role });
+        logDebug(`cleared stale device-auth token for device ${this.opts.deviceIdentity.deviceId}`);
+      }
       this.flushPendingErrors(new Error(`gateway closed (${code}): ${reasonText}`));
       this.scheduleReconnect();
       this.opts.onClose?.(code, reasonText);


### PR DESCRIPTION
When the gateway connection fails due to device token mismatch (e.g., after re-pairing the device), clear the stored device-auth token so that subsequent connection attempts can obtain a fresh token.

This fixes the cron tool failing with 'device token mismatch' error after running `openclaw configure` to re-pair the device.

Fixes #18175

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a bug where the `GatewayClient` would get stuck in an infinite reconnect loop with a stale device-auth token after re-pairing the device (e.g., via `openclaw configure`). When the gateway server rejects the connection with close code 1008 and reason "device token mismatch", the client now clears the stored device-auth token before reconnecting, allowing a fresh token to be obtained on the next successful handshake.

- Imports `clearDeviceAuthToken` from `device-auth-store` and calls it in the WebSocket `close` handler when a device token mismatch is detected
- The string matching (`reasonText.includes("device token mismatch")`) correctly aligns with the server's `formatGatewayAuthFailureMessage` output for the `device_token_mismatch` reason
- Follows the same pattern already used in the UI gateway client (`ui/src/ui/gateway.ts`) for clearing stale device tokens

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it adds a targeted, low-risk fix for a specific error condition in the reconnect flow.
- The change is minimal (10 lines of logic), well-scoped to a single error case, and follows an established pattern from the UI gateway client. The close code (1008) and reason string ("device token mismatch") are both controlled by the same repository. The `clearDeviceAuthToken` function is well-tested in other call sites and performs safe file operations. No risk of infinite loops — after clearing, the next connect attempt either succeeds with a fresh token or fails with a different error.
- No files require special attention.

<sub>Last reviewed commit: e87f7e6</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->