### PR TITLE
feat(gateway): add Mesh workflow orchestration with auto-planning and /mesh command

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ ClawHub is a minimal skill registry. With ClawHub enabled, the agent can search 
 Send these in WhatsApp/Telegram/Slack/Google Chat/Microsoft Teams/WebChat (group commands are owner-only):
 
 - `/status` — compact session status (model + tokens, cost when available)
+- `/mesh <goal>` — auto-plan + run a multi-step workflow (`/mesh plan|run|status|retry` available)
 - `/new` or `/reset` — reset the session
 - `/compact` — compact session context (summary)
 - `/think <level>` — off|minimal|low|medium|high|xhigh (GPT-5.2 + Codex models only)

--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -73,6 +73,7 @@ Text + native (when enabled):
 - `/commands`
 - `/skill <name> [input]` (run a skill by name)
 - `/status` (show current status; includes provider usage/quota for the current model provider when available)
+- `/mesh <goal>` (auto-plan + run a workflow; also `/mesh plan|run|status|retry`, with `/mesh run <mesh-plan-id>` for exact plan replay in the same chat)
 - `/allowlist` (list/add/remove allowlist entries)
 - `/approve <id> allow-once|allow-always|deny` (resolve exec approval prompts)
 - `/context [list|detail|json]` (explain “context”; `detail` shows per-file + per-tool + per-skill + system prompt size)

--- a/src/auto-reply/commands-registry.data.ts
+++ b/src/auto-reply/commands-registry.data.ts
@@ -173,6 +173,15 @@ function buildChatCommands(): ChatCommandDefinition[] {
       category: "status",
     }),
     defineChatCommand({
+      key: "mesh",
+      nativeName: "mesh",
+      description: "Plan and run multi-step workflows.",
+      textAlias: "/mesh",
+      category: "tools",
+      argsParsing: "none",
+      acceptsArgs: true,
+    }),
+    defineChatCommand({
       key: "allowlist",
       description: "List/add/remove allowlist entries.",
       textAlias: "/allowlist",

--- a/src/auto-reply/reply/commands-core.ts
+++ b/src/auto-reply/reply/commands-core.ts
@@ -21,6 +21,7 @@ import {
   handleStatusCommand,
   handleWhoamiCommand,
 } from "./commands-info.js";
+import { handleMeshCommand } from "./commands-mesh.js";
 import { handleModelsCommand } from "./commands-models.js";
 import { handlePluginCommand } from "./commands-plugin.js";
 import {
@@ -51,6 +52,7 @@ export async function handleCommands(params: HandleCommandsParams): Promise<Comm
       handleHelpCommand,
       handleCommandsListCommand,
       handleStatusCommand,
+      handleMeshCommand,
       handleAllowlistCommand,
       handleApproveCommand,
       handleContextCommand,

--- a/src/auto-reply/reply/commands-mesh.ts
+++ b/src/auto-reply/reply/commands-mesh.ts
@@ -1,0 +1,346 @@
+import type { CommandHandler } from "./commands-types.js";
+import { callGateway } from "../../gateway/call.js";
+import { logVerbose } from "../../globals.js";
+import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../../utils/message-channel.js";
+
+type MeshPlanShape = {
+  planId: string;
+  goal: string;
+  createdAt: number;
+  steps: Array<{ id: string; name?: string; prompt: string; dependsOn?: string[] }>;
+};
+type CachedMeshPlan = { plan: MeshPlanShape; createdAt: number };
+
+type ParsedMeshCommand =
+  | { ok: true; action: "help" }
+  | { ok: true; action: "run" | "plan"; target: string }
+  | { ok: true; action: "status"; runId: string }
+  | { ok: true; action: "retry"; runId: string; stepIds?: string[] }
+  | { ok: false; message: string }
+  | null;
+
+const meshPlanCache = new Map<string, CachedMeshPlan>();
+const MAX_CACHED_MESH_PLANS = 200;
+
+function trimMeshPlanCache() {
+  if (meshPlanCache.size <= MAX_CACHED_MESH_PLANS) {
+    return;
+  }
+  const oldest = [...meshPlanCache.entries()]
+    .sort((a, b) => a[1].createdAt - b[1].createdAt)
+    .slice(0, meshPlanCache.size - MAX_CACHED_MESH_PLANS);
+  for (const [key] of oldest) {
+    meshPlanCache.delete(key);
+  }
+}
+
+function parseMeshCommand(commandBody: string): ParsedMeshCommand {
+  const trimmed = commandBody.trim();
+  if (!/^\/mesh\b/i.test(trimmed)) {
+    return null;
+  }
+  const rest = trimmed.replace(/^\/mesh\b:?/i, "").trim();
+  if (!rest || /^help$/i.test(rest)) {
+    return { ok: true, action: "help" };
+  }
+
+  const tokens = rest.split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) {
+    return { ok: true, action: "help" };
+  }
+
+  const actionCandidate = tokens[0]?.toLowerCase() ?? "";
+  const explicitAction =
+    actionCandidate === "run" ||
+    actionCandidate === "plan" ||
+    actionCandidate === "status" ||
+    actionCandidate === "retry"
+      ? actionCandidate
+      : null;
+
+  if (!explicitAction) {
+    // Shorthand: `/mesh <goal>` => auto plan + run
+    return { ok: true, action: "run", target: rest };
+  }
+
+  const actionArgs = rest.slice(tokens[0]?.length ?? 0).trim();
+  if (explicitAction === "plan" || explicitAction === "run") {
+    if (!actionArgs) {
+      return { ok: false, message: `Usage: /mesh ${explicitAction} <goal>` };
+    }
+    return { ok: true, action: explicitAction, target: actionArgs };
+  }
+
+  if (explicitAction === "status") {
+    if (!actionArgs) {
+      return { ok: false, message: "Usage: /mesh status <runId>" };
+    }
+    return { ok: true, action: "status", runId: actionArgs.split(/\s+/)[0] };
+  }
+
+  // retry
+  const argsTokens = actionArgs.split(/\s+/).filter(Boolean);
+  if (argsTokens.length === 0) {
+    return { ok: false, message: "Usage: /mesh retry <runId> [step1,step2,...]" };
+  }
+  const runId = argsTokens[0];
+  const stepArg = argsTokens.slice(1).join(" ").trim();
+  const stepIds =
+    stepArg.length > 0
+      ? stepArg
+          .split(",")
+          .map((entry) => entry.trim())
+          .filter(Boolean)
+      : undefined;
+  return { ok: true, action: "retry", runId, stepIds };
+}
+
+function cacheKeyForPlan(params: Parameters<CommandHandler>[0], planId: string) {
+  const sender = params.command.senderId ?? "unknown";
+  const channel = params.command.channel || "unknown";
+  return `${channel}:${sender}:${planId}`;
+}
+
+function putCachedPlan(params: Parameters<CommandHandler>[0], plan: MeshPlanShape) {
+  meshPlanCache.set(cacheKeyForPlan(params, plan.planId), { plan, createdAt: Date.now() });
+  trimMeshPlanCache();
+}
+
+function getCachedPlan(params: Parameters<CommandHandler>[0], planId: string): MeshPlanShape | null {
+  return meshPlanCache.get(cacheKeyForPlan(params, planId))?.plan ?? null;
+}
+
+function looksLikeMeshPlanId(value: string) {
+  return /^mesh-plan-[a-z0-9-]+$/i.test(value.trim());
+}
+
+function resolveMeshCommandBody(params: Parameters<CommandHandler>[0]) {
+  return (
+    params.ctx.BodyForCommands ??
+    params.ctx.CommandBody ??
+    params.ctx.RawBody ??
+    params.ctx.Body ??
+    params.command.commandBodyNormalized
+  );
+}
+
+function formatPlanSummary(plan: {
+  goal: string;
+  steps: Array<{ id: string; name?: string; prompt: string; dependsOn?: string[] }>;
+}) {
+  const lines = [`🕸️ Mesh Plan`, `Goal: ${plan.goal}`, "", `Steps (${plan.steps.length}):`];
+  for (const step of plan.steps) {
+    const dependsOn = Array.isArray(step.dependsOn) && step.dependsOn.length > 0;
+    const depLine = dependsOn ? ` (depends on: ${step.dependsOn?.join(", ")})` : "";
+    lines.push(`- ${step.id}${step.name ? ` — ${step.name}` : ""}${depLine}`);
+    lines.push(`  ${step.prompt}`);
+  }
+  return lines.join("\n");
+}
+
+function formatRunSummary(payload: {
+  runId: string;
+  status: string;
+  stats?: {
+    total?: number;
+    succeeded?: number;
+    failed?: number;
+    skipped?: number;
+    running?: number;
+    pending?: number;
+  };
+}) {
+  const stats = payload.stats ?? {};
+  return [
+    `🕸️ Mesh Run`,
+    `Run: ${payload.runId}`,
+    `Status: ${payload.status}`,
+    `Steps: total=${stats.total ?? 0}, ok=${stats.succeeded ?? 0}, failed=${stats.failed ?? 0}, skipped=${stats.skipped ?? 0}, running=${stats.running ?? 0}, pending=${stats.pending ?? 0}`,
+  ].join("\n");
+}
+
+function meshUsageText() {
+  return [
+    "🕸️ Mesh command",
+    "Usage:",
+    "- /mesh <goal>  (auto plan + run)",
+    "- /mesh plan <goal>",
+    "- /mesh run <goal|mesh-plan-id>",
+    "- /mesh status <runId>",
+    "- /mesh retry <runId> [step1,step2,...]",
+  ].join("\n");
+}
+
+function resolveMeshClientLabel(params: Parameters<CommandHandler>[0]) {
+  const channel = params.command.channel;
+  const sender = params.command.senderId ?? "unknown";
+  return `Chat mesh (${channel}:${sender})`;
+}
+
+export const handleMeshCommand: CommandHandler = async (params, allowTextCommands) => {
+  if (!allowTextCommands) {
+    return null;
+  }
+  const parsed = parseMeshCommand(resolveMeshCommandBody(params));
+  if (!parsed) {
+    return null;
+  }
+  if (!params.command.isAuthorizedSender) {
+    logVerbose(`Ignoring /mesh from unauthorized sender: ${params.command.senderId || "<unknown>"}`);
+    return { shouldContinue: false };
+  }
+  if (!parsed.ok) {
+    return { shouldContinue: false, reply: { text: parsed.message } };
+  }
+  if (parsed.action === "help") {
+    return { shouldContinue: false, reply: { text: meshUsageText() } };
+  }
+
+  const clientDisplayName = resolveMeshClientLabel(params);
+  const commonGateway = {
+    clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
+    clientDisplayName,
+    mode: GATEWAY_CLIENT_MODES.BACKEND,
+  } as const;
+
+  try {
+    if (parsed.action === "plan") {
+      const planResp = await callGateway<{
+        plan: MeshPlanShape;
+        order?: string[];
+        source?: string;
+      }>({
+        method: "mesh.plan.auto",
+        params: {
+          goal: parsed.target,
+          agentId: params.agentId ?? "main",
+        },
+        ...commonGateway,
+      });
+      putCachedPlan(params, planResp.plan);
+      const sourceLine = planResp.source ? `\nPlanner source: ${planResp.source}` : "";
+      return {
+        shouldContinue: false,
+        reply: {
+          text: `${formatPlanSummary(planResp.plan)}${sourceLine}\n\nRun exact plan: /mesh run ${planResp.plan.planId}`,
+        },
+      };
+    }
+
+    if (parsed.action === "run") {
+      let runPlan: MeshPlanShape;
+      if (looksLikeMeshPlanId(parsed.target)) {
+        const cached = getCachedPlan(params, parsed.target.trim());
+        if (!cached) {
+          return {
+            shouldContinue: false,
+            reply: {
+              text: `Plan ${parsed.target.trim()} not found in this chat.\nCreate one first: /mesh plan <goal>`,
+            },
+          };
+        }
+        runPlan = cached;
+      } else {
+        const planResp = await callGateway<{
+          plan: MeshPlanShape;
+          order?: string[];
+          source?: string;
+        }>({
+          method: "mesh.plan.auto",
+          params: {
+            goal: parsed.target,
+            agentId: params.agentId ?? "main",
+          },
+          ...commonGateway,
+        });
+        putCachedPlan(params, planResp.plan);
+        runPlan = planResp.plan;
+      }
+
+      const runResp = await callGateway<{
+        runId: string;
+        status: string;
+        stats?: {
+          total?: number;
+          succeeded?: number;
+          failed?: number;
+          skipped?: number;
+          running?: number;
+          pending?: number;
+        };
+      }>({
+        method: "mesh.run",
+        params: {
+          plan: runPlan,
+        },
+        ...commonGateway,
+      });
+
+      return {
+        shouldContinue: false,
+        reply: {
+          text: `${formatPlanSummary(runPlan)}\n\n${formatRunSummary(runResp)}`,
+        },
+      };
+    }
+
+    if (parsed.action === "status") {
+      const statusResp = await callGateway<{
+        runId: string;
+        status: string;
+        stats?: {
+          total?: number;
+          succeeded?: number;
+          failed?: number;
+          skipped?: number;
+          running?: number;
+          pending?: number;
+        };
+      }>({
+        method: "mesh.status",
+        params: { runId: parsed.runId },
+        ...commonGateway,
+      });
+      return {
+        shouldContinue: false,
+        reply: { text: formatRunSummary(statusResp) },
+      };
+    }
+
+    if (parsed.action === "retry") {
+      const retryResp = await callGateway<{
+        runId: string;
+        status: string;
+        stats?: {
+          total?: number;
+          succeeded?: number;
+          failed?: number;
+          skipped?: number;
+          running?: number;
+          pending?: number;
+        };
+      }>({
+        method: "mesh.retry",
+        params: {
+          runId: parsed.runId,
+          ...(parsed.stepIds && parsed.stepIds.length > 0 ? { stepIds: parsed.stepIds } : {}),
+        },
+        ...commonGateway,
+      });
+      return {
+        shouldContinue: false,
+        reply: { text: `🔁 Retry submitted\n${formatRunSummary(retryResp)}` },
+      };
+    }
+
+    return null;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      shouldContinue: false,
+      reply: {
+        text: `❌ Mesh command failed: ${message}`,
+      },
+    };
+  }
+};

--- a/src/auto-reply/reply/commands-mesh.ts
+++ b/src/auto-reply/reply/commands-mesh.ts
@@ -21,6 +21,10 @@ type ParsedMeshCommand =
 
 const meshPlanCache = new Map<string, CachedMeshPlan>();
 const MAX_CACHED_MESH_PLANS = 200;
+const MESH_PLAN_CALL_TIMEOUT_MS = 120_000;
+const MESH_RUN_CALL_TIMEOUT_MS = 15 * 60_000;
+const MESH_STATUS_CALL_TIMEOUT_MS = 15_000;
+const MESH_RETRY_CALL_TIMEOUT_MS = 15 * 60_000;
 
 function trimMeshPlanCache() {
   if (meshPlanCache.size <= MAX_CACHED_MESH_PLANS) {
@@ -216,6 +220,7 @@ export const handleMeshCommand: CommandHandler = async (params, allowTextCommand
           agentId: params.agentId ?? "main",
         },
         ...commonGateway,
+        timeoutMs: MESH_PLAN_CALL_TIMEOUT_MS,
       });
       putCachedPlan(params, planResp.plan);
       const sourceLine = planResp.source ? `\nPlanner source: ${planResp.source}` : "";
@@ -252,6 +257,7 @@ export const handleMeshCommand: CommandHandler = async (params, allowTextCommand
             agentId: params.agentId ?? "main",
           },
           ...commonGateway,
+          timeoutMs: MESH_PLAN_CALL_TIMEOUT_MS,
         });
         putCachedPlan(params, planResp.plan);
         runPlan = planResp.plan;
@@ -274,6 +280,7 @@ export const handleMeshCommand: CommandHandler = async (params, allowTextCommand
           plan: runPlan,
         },
         ...commonGateway,
+        timeoutMs: MESH_RUN_CALL_TIMEOUT_MS,
       });
 
       return {
@@ -300,6 +307,7 @@ export const handleMeshCommand: CommandHandler = async (params, allowTextCommand
         method: "mesh.status",
         params: { runId: parsed.runId },
         ...commonGateway,
+        timeoutMs: MESH_STATUS_CALL_TIMEOUT_MS,
       });
       return {
         shouldContinue: false,
@@ -326,6 +334,7 @@ export const handleMeshCommand: CommandHandler = async (params, allowTextCommand
           ...(parsed.stepIds && parsed.stepIds.length > 0 ? { stepIds: parsed.stepIds } : {}),
         },
         ...commonGateway,
+        timeoutMs: MESH_RETRY_CALL_TIMEOUT_MS,
       });
       return {
         shouldContinue: false,

--- a/src/auto-reply/reply/commands.test.ts
+++ b/src/auto-reply/reply/commands.test.ts
@@ -287,6 +287,154 @@ describe("/approve command", () => {
   });
 });
 
+describe("/mesh command", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    callGatewayMock.mockReset();
+  });
+
+  it("shows usage for bare /mesh", async () => {
+    const cfg = {
+      commands: { text: true },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+    } as OpenClawConfig;
+    const params = buildParams("/mesh", cfg);
+    const result = await handleCommands(params);
+    expect(result.shouldContinue).toBe(false);
+    expect(result.reply?.text).toContain("Mesh command");
+    expect(result.reply?.text).toContain("/mesh run <goal|mesh-plan-id>");
+    expect(callGatewayMock).not.toHaveBeenCalled();
+  });
+
+  it("runs auto plan + run for /mesh <goal>", async () => {
+    const cfg = {
+      commands: { text: true },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+    } as OpenClawConfig;
+    const params = buildParams("/mesh build a landing animation", cfg);
+
+    callGatewayMock
+      .mockResolvedValueOnce({
+        plan: {
+          planId: "mesh-plan-1",
+          goal: "build a landing animation",
+          createdAt: Date.now(),
+          steps: [
+            { id: "design", prompt: "Design animation" },
+            { id: "mobile-test", prompt: "Test mobile", dependsOn: ["design"] },
+          ],
+        },
+        order: ["design", "mobile-test"],
+        source: "llm",
+      })
+      .mockResolvedValueOnce({
+        runId: "mesh-run-1",
+        status: "completed",
+        stats: { total: 2, succeeded: 2, failed: 0, skipped: 0, running: 0, pending: 0 },
+      });
+
+    const result = await handleCommands(params);
+    expect(result.shouldContinue).toBe(false);
+    expect(result.reply?.text).toContain("Mesh Plan");
+    expect(result.reply?.text).toContain("Mesh Run");
+    expect(callGatewayMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        method: "mesh.plan.auto",
+        params: expect.objectContaining({
+          goal: "build a landing animation",
+        }),
+      }),
+    );
+    expect(callGatewayMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        method: "mesh.run",
+      }),
+    );
+  });
+
+  it("returns status via /mesh status <runId>", async () => {
+    const cfg = {
+      commands: { text: true },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+    } as OpenClawConfig;
+    const params = buildParams("/mesh status mesh-run-77", cfg);
+
+    callGatewayMock.mockResolvedValueOnce({
+      runId: "mesh-run-77",
+      status: "failed",
+      stats: { total: 3, succeeded: 1, failed: 1, skipped: 1, running: 0, pending: 0 },
+    });
+
+    const result = await handleCommands(params);
+    expect(result.shouldContinue).toBe(false);
+    expect(result.reply?.text).toContain("Run: mesh-run-77");
+    expect(result.reply?.text).toContain("Status: failed");
+    expect(callGatewayMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "mesh.status",
+        params: { runId: "mesh-run-77" },
+      }),
+    );
+  });
+
+  it("runs a previously planned mesh plan id without re-planning", async () => {
+    const cfg = {
+      commands: { text: true },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+    } as OpenClawConfig;
+    const planParams = buildParams("/mesh plan Build Hero Animation", cfg);
+
+    callGatewayMock.mockResolvedValueOnce({
+      plan: {
+        planId: "mesh-plan-abc",
+        goal: "Build Hero Animation",
+        createdAt: Date.now(),
+        steps: [{ id: "design", prompt: "Design hero animation" }],
+      },
+      order: ["design"],
+      source: "llm",
+    });
+
+    const planResult = await handleCommands(planParams);
+    expect(planResult.shouldContinue).toBe(false);
+    expect(planResult.reply?.text).toContain("Run exact plan: /mesh run mesh-plan-abc");
+    expect(callGatewayMock).toHaveBeenCalledTimes(1);
+    expect(callGatewayMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "mesh.plan.auto",
+        params: expect.objectContaining({
+          goal: "Build Hero Animation",
+        }),
+      }),
+    );
+
+    callGatewayMock.mockReset();
+    callGatewayMock.mockResolvedValueOnce({
+      runId: "mesh-run-abc",
+      status: "completed",
+      stats: { total: 1, succeeded: 1, failed: 0, skipped: 0, running: 0, pending: 0 },
+    });
+
+    const runParams = buildParams("/mesh run mesh-plan-abc", cfg);
+    const runResult = await handleCommands(runParams);
+    expect(runResult.shouldContinue).toBe(false);
+    expect(callGatewayMock).toHaveBeenCalledTimes(1);
+    expect(callGatewayMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "mesh.run",
+        params: expect.objectContaining({
+          plan: expect.objectContaining({
+            planId: "mesh-plan-abc",
+            goal: "Build Hero Animation",
+          }),
+        }),
+      }),
+    );
+  });
+});
+
 describe("/compact command", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/gateway/protocol/index.ts
+++ b/src/gateway/protocol/index.ts
@@ -128,6 +128,16 @@ import {
   LogsTailParamsSchema,
   type LogsTailResult,
   LogsTailResultSchema,
+  type MeshPlanParams,
+  MeshPlanParamsSchema,
+  type MeshRetryParams,
+  MeshRetryParamsSchema,
+  type MeshRunParams,
+  MeshRunParamsSchema,
+  type MeshStatusParams,
+  MeshStatusParamsSchema,
+  type MeshWorkflowPlan,
+  MeshWorkflowPlanSchema,
   type ModelsListParams,
   ModelsListParamsSchema,
   type NodeDescribeParams,
@@ -358,6 +368,10 @@ export const validateExecApprovalsNodeSetParams = ajv.compile<ExecApprovalsNodeS
   ExecApprovalsNodeSetParamsSchema,
 );
 export const validateLogsTailParams = ajv.compile<LogsTailParams>(LogsTailParamsSchema);
+export const validateMeshPlanParams = ajv.compile<MeshPlanParams>(MeshPlanParamsSchema);
+export const validateMeshRunParams = ajv.compile<MeshRunParams>(MeshRunParamsSchema);
+export const validateMeshStatusParams = ajv.compile<MeshStatusParams>(MeshStatusParamsSchema);
+export const validateMeshRetryParams = ajv.compile<MeshRetryParams>(MeshRetryParamsSchema);
 export const validateChatHistoryParams = ajv.compile(ChatHistoryParamsSchema);
 export const validateChatSendParams = ajv.compile(ChatSendParamsSchema);
 export const validateChatAbortParams = ajv.compile<ChatAbortParams>(ChatAbortParamsSchema);
@@ -417,6 +431,11 @@ export {
   StateVersionSchema,
   AgentEventSchema,
   ChatEventSchema,
+  MeshPlanParamsSchema,
+  MeshWorkflowPlanSchema,
+  MeshRunParamsSchema,
+  MeshStatusParamsSchema,
+  MeshRetryParamsSchema,
   SendParamsSchema,
   PollParamsSchema,
   AgentParamsSchema,
@@ -516,6 +535,11 @@ export type {
   AgentIdentityResult,
   AgentWaitParams,
   ChatEvent,
+  MeshPlanParams,
+  MeshWorkflowPlan,
+  MeshRunParams,
+  MeshStatusParams,
+  MeshRetryParams,
   TickEvent,
   ShutdownEvent,
   WakeParams,

--- a/src/gateway/protocol/index.ts
+++ b/src/gateway/protocol/index.ts
@@ -130,6 +130,8 @@ import {
   LogsTailResultSchema,
   type MeshPlanParams,
   MeshPlanParamsSchema,
+  type MeshPlanAutoParams,
+  MeshPlanAutoParamsSchema,
   type MeshRetryParams,
   MeshRetryParamsSchema,
   type MeshRunParams,
@@ -369,6 +371,7 @@ export const validateExecApprovalsNodeSetParams = ajv.compile<ExecApprovalsNodeS
 );
 export const validateLogsTailParams = ajv.compile<LogsTailParams>(LogsTailParamsSchema);
 export const validateMeshPlanParams = ajv.compile<MeshPlanParams>(MeshPlanParamsSchema);
+export const validateMeshPlanAutoParams = ajv.compile<MeshPlanAutoParams>(MeshPlanAutoParamsSchema);
 export const validateMeshRunParams = ajv.compile<MeshRunParams>(MeshRunParamsSchema);
 export const validateMeshStatusParams = ajv.compile<MeshStatusParams>(MeshStatusParamsSchema);
 export const validateMeshRetryParams = ajv.compile<MeshRetryParams>(MeshRetryParamsSchema);
@@ -432,6 +435,7 @@ export {
   AgentEventSchema,
   ChatEventSchema,
   MeshPlanParamsSchema,
+  MeshPlanAutoParamsSchema,
   MeshWorkflowPlanSchema,
   MeshRunParamsSchema,
   MeshStatusParamsSchema,
@@ -536,6 +540,7 @@ export type {
   AgentWaitParams,
   ChatEvent,
   MeshPlanParams,
+  MeshPlanAutoParams,
   MeshWorkflowPlan,
   MeshRunParams,
   MeshStatusParams,

--- a/src/gateway/protocol/schema.ts
+++ b/src/gateway/protocol/schema.ts
@@ -8,6 +8,7 @@ export * from "./schema/exec-approvals.js";
 export * from "./schema/devices.js";
 export * from "./schema/frames.js";
 export * from "./schema/logs-chat.js";
+export * from "./schema/mesh.js";
 export * from "./schema/nodes.js";
 export * from "./schema/protocol-schemas.js";
 export * from "./schema/sessions.js";

--- a/src/gateway/protocol/schema/mesh.ts
+++ b/src/gateway/protocol/schema/mesh.ts
@@ -61,6 +61,19 @@ export const MeshRunParamsSchema = Type.Object(
   { additionalProperties: false },
 );
 
+export const MeshPlanAutoParamsSchema = Type.Object(
+  {
+    goal: NonEmptyString,
+    maxSteps: Type.Optional(Type.Integer({ minimum: 1, maximum: 16 })),
+    agentId: Type.Optional(NonEmptyString),
+    sessionKey: Type.Optional(NonEmptyString),
+    thinking: Type.Optional(Type.String()),
+    timeoutMs: Type.Optional(Type.Integer({ minimum: 1_000, maximum: 3_600_000 })),
+    lane: Type.Optional(Type.String()),
+  },
+  { additionalProperties: false },
+);
+
 export const MeshStatusParamsSchema = Type.Object(
   {
     runId: NonEmptyString,
@@ -79,5 +92,6 @@ export const MeshRetryParamsSchema = Type.Object(
 export type MeshPlanParams = Static<typeof MeshPlanParamsSchema>;
 export type MeshWorkflowPlan = Static<typeof MeshWorkflowPlanSchema>;
 export type MeshRunParams = Static<typeof MeshRunParamsSchema>;
+export type MeshPlanAutoParams = Static<typeof MeshPlanAutoParamsSchema>;
 export type MeshStatusParams = Static<typeof MeshStatusParamsSchema>;
 export type MeshRetryParams = Static<typeof MeshRetryParamsSchema>;

--- a/src/gateway/protocol/schema/mesh.ts
+++ b/src/gateway/protocol/schema/mesh.ts
@@ -1,0 +1,83 @@
+import { Type, type Static } from "@sinclair/typebox";
+import { NonEmptyString } from "./primitives.js";
+
+export const MeshPlanStepSchema = Type.Object(
+  {
+    id: NonEmptyString,
+    name: Type.Optional(NonEmptyString),
+    prompt: NonEmptyString,
+    dependsOn: Type.Optional(Type.Array(NonEmptyString, { maxItems: 64 })),
+    agentId: Type.Optional(NonEmptyString),
+    sessionKey: Type.Optional(NonEmptyString),
+    thinking: Type.Optional(Type.String()),
+    timeoutMs: Type.Optional(Type.Integer({ minimum: 1_000, maximum: 3_600_000 })),
+  },
+  { additionalProperties: false },
+);
+
+export const MeshWorkflowPlanSchema = Type.Object(
+  {
+    planId: NonEmptyString,
+    goal: NonEmptyString,
+    createdAt: Type.Integer({ minimum: 0 }),
+    steps: Type.Array(MeshPlanStepSchema, { minItems: 1, maxItems: 128 }),
+  },
+  { additionalProperties: false },
+);
+
+export const MeshPlanParamsSchema = Type.Object(
+  {
+    goal: NonEmptyString,
+    steps: Type.Optional(
+      Type.Array(
+        Type.Object(
+          {
+            id: Type.Optional(NonEmptyString),
+            name: Type.Optional(NonEmptyString),
+            prompt: NonEmptyString,
+            dependsOn: Type.Optional(Type.Array(NonEmptyString, { maxItems: 64 })),
+            agentId: Type.Optional(NonEmptyString),
+            sessionKey: Type.Optional(NonEmptyString),
+            thinking: Type.Optional(Type.String()),
+            timeoutMs: Type.Optional(Type.Integer({ minimum: 1_000, maximum: 3_600_000 })),
+          },
+          { additionalProperties: false },
+        ),
+        { minItems: 1, maxItems: 128 },
+      ),
+    ),
+  },
+  { additionalProperties: false },
+);
+
+export const MeshRunParamsSchema = Type.Object(
+  {
+    plan: MeshWorkflowPlanSchema,
+    continueOnError: Type.Optional(Type.Boolean()),
+    maxParallel: Type.Optional(Type.Integer({ minimum: 1, maximum: 16 })),
+    defaultStepTimeoutMs: Type.Optional(Type.Integer({ minimum: 1_000, maximum: 3_600_000 })),
+    lane: Type.Optional(Type.String()),
+  },
+  { additionalProperties: false },
+);
+
+export const MeshStatusParamsSchema = Type.Object(
+  {
+    runId: NonEmptyString,
+  },
+  { additionalProperties: false },
+);
+
+export const MeshRetryParamsSchema = Type.Object(
+  {
+    runId: NonEmptyString,
+    stepIds: Type.Optional(Type.Array(NonEmptyString, { minItems: 1, maxItems: 128 })),
+  },
+  { additionalProperties: false },
+);
+
+export type MeshPlanParams = Static<typeof MeshPlanParamsSchema>;
+export type MeshWorkflowPlan = Static<typeof MeshWorkflowPlanSchema>;
+export type MeshRunParams = Static<typeof MeshRunParamsSchema>;
+export type MeshStatusParams = Static<typeof MeshStatusParamsSchema>;
+export type MeshRetryParams = Static<typeof MeshRetryParamsSchema>;

--- a/src/gateway/protocol/schema/protocol-schemas.ts
+++ b/src/gateway/protocol/schema/protocol-schemas.ts
@@ -104,6 +104,13 @@ import {
   LogsTailResultSchema,
 } from "./logs-chat.js";
 import {
+  MeshPlanParamsSchema,
+  MeshRetryParamsSchema,
+  MeshRunParamsSchema,
+  MeshStatusParamsSchema,
+  MeshWorkflowPlanSchema,
+} from "./mesh.js";
+import {
   NodeDescribeParamsSchema,
   NodeEventParamsSchema,
   NodeInvokeParamsSchema,
@@ -254,6 +261,11 @@ export const ProtocolSchemas: Record<string, TSchema> = {
   ChatAbortParams: ChatAbortParamsSchema,
   ChatInjectParams: ChatInjectParamsSchema,
   ChatEvent: ChatEventSchema,
+  MeshPlanParams: MeshPlanParamsSchema,
+  MeshWorkflowPlan: MeshWorkflowPlanSchema,
+  MeshRunParams: MeshRunParamsSchema,
+  MeshStatusParams: MeshStatusParamsSchema,
+  MeshRetryParams: MeshRetryParamsSchema,
   UpdateRunParams: UpdateRunParamsSchema,
   TickEvent: TickEventSchema,
   ShutdownEvent: ShutdownEventSchema,

--- a/src/gateway/protocol/schema/protocol-schemas.ts
+++ b/src/gateway/protocol/schema/protocol-schemas.ts
@@ -104,6 +104,7 @@ import {
   LogsTailResultSchema,
 } from "./logs-chat.js";
 import {
+  MeshPlanAutoParamsSchema,
   MeshPlanParamsSchema,
   MeshRetryParamsSchema,
   MeshRunParamsSchema,
@@ -262,6 +263,7 @@ export const ProtocolSchemas: Record<string, TSchema> = {
   ChatInjectParams: ChatInjectParamsSchema,
   ChatEvent: ChatEventSchema,
   MeshPlanParams: MeshPlanParamsSchema,
+  MeshPlanAutoParams: MeshPlanAutoParamsSchema,
   MeshWorkflowPlan: MeshWorkflowPlanSchema,
   MeshRunParams: MeshRunParamsSchema,
   MeshStatusParams: MeshStatusParamsSchema,

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -85,6 +85,10 @@ const BASE_METHODS = [
   "agent",
   "agent.identity.get",
   "agent.wait",
+  "mesh.plan",
+  "mesh.run",
+  "mesh.status",
+  "mesh.retry",
   "browser.request",
   // WebChat WebSocket-native chat methods
   "chat.history",

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -86,6 +86,7 @@ const BASE_METHODS = [
   "agent.identity.get",
   "agent.wait",
   "mesh.plan",
+  "mesh.plan.auto",
   "mesh.run",
   "mesh.status",
   "mesh.retry",

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -12,6 +12,7 @@ import { deviceHandlers } from "./server-methods/devices.js";
 import { execApprovalsHandlers } from "./server-methods/exec-approvals.js";
 import { healthHandlers } from "./server-methods/health.js";
 import { logsHandlers } from "./server-methods/logs.js";
+import { meshHandlers } from "./server-methods/mesh.js";
 import { modelsHandlers } from "./server-methods/models.js";
 import { nodeHandlers } from "./server-methods/nodes.js";
 import { sendHandlers } from "./server-methods/send.js";
@@ -78,6 +79,8 @@ const READ_METHODS = new Set([
   "chat.history",
   "config.get",
   "talk.config",
+  "mesh.plan",
+  "mesh.status",
 ]);
 const WRITE_METHODS = new Set([
   "send",
@@ -94,6 +97,8 @@ const WRITE_METHODS = new Set([
   "chat.send",
   "chat.abort",
   "browser.request",
+  "mesh.run",
+  "mesh.retry",
 ]);
 
 function authorizeGatewayMethod(method: string, client: GatewayRequestOptions["client"]) {
@@ -171,6 +176,7 @@ function authorizeGatewayMethod(method: string, client: GatewayRequestOptions["c
 export const coreGatewayHandlers: GatewayRequestHandlers = {
   ...connectHandlers,
   ...logsHandlers,
+  ...meshHandlers,
   ...voicewakeHandlers,
   ...healthHandlers,
   ...channelsHandlers,

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -97,6 +97,7 @@ const WRITE_METHODS = new Set([
   "chat.send",
   "chat.abort",
   "browser.request",
+  "mesh.plan.auto",
   "mesh.run",
   "mesh.retry",
 ]);

--- a/src/gateway/server-methods/mesh.test.ts
+++ b/src/gateway/server-methods/mesh.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { GatewayRequestContext } from "./types.js";
+import { __resetMeshRunsForTest, meshHandlers } from "./mesh.js";
+
+const mocks = vi.hoisted(() => ({
+  agent: vi.fn(),
+  agentWait: vi.fn(),
+}));
+
+vi.mock("./agent.js", () => ({
+  agentHandlers: {
+    agent: (...args: unknown[]) => mocks.agent(...args),
+    "agent.wait": (...args: unknown[]) => mocks.agentWait(...args),
+  },
+}));
+
+const makeContext = (): GatewayRequestContext =>
+  ({
+    dedupe: new Map(),
+    addChatRun: vi.fn(),
+    logGateway: { info: vi.fn(), error: vi.fn() },
+  }) as unknown as GatewayRequestContext;
+
+async function callMesh(method: keyof typeof meshHandlers, params: Record<string, unknown>) {
+  return await new Promise<{ ok: boolean; payload?: unknown; error?: unknown }>((resolve) => {
+    void meshHandlers[method]({
+      req: { type: "req", id: `test-${method}`, method },
+      params,
+      respond: (ok, payload, error) => resolve({ ok, payload, error }),
+      context: makeContext(),
+      client: null,
+      isWebchatConnect: () => false,
+    });
+  });
+}
+
+afterEach(() => {
+  __resetMeshRunsForTest();
+  mocks.agent.mockReset();
+  mocks.agentWait.mockReset();
+});
+
+describe("mesh handlers", () => {
+  it("builds a default single-step plan", async () => {
+    const res = await callMesh("mesh.plan", { goal: "Write release notes" });
+    expect(res.ok).toBe(true);
+    const payload = res.payload as { plan: { goal: string; steps: Array<{ id: string }> } };
+    expect(payload.plan.goal).toBe("Write release notes");
+    expect(payload.plan.steps).toHaveLength(1);
+    expect(payload.plan.steps[0]?.id).toBe("step-1");
+  });
+
+  it("rejects cyclic plans", async () => {
+    const cyclePlan = {
+      planId: "mesh-plan-1",
+      goal: "cycle",
+      createdAt: Date.now(),
+      steps: [
+        { id: "a", prompt: "a", dependsOn: ["b"] },
+        { id: "b", prompt: "b", dependsOn: ["a"] },
+      ],
+    };
+    const res = await callMesh("mesh.run", { plan: cyclePlan });
+    expect(res.ok).toBe(false);
+  });
+
+  it("runs steps in DAG order and supports retrying failed steps", async () => {
+    const runState = new Map<string, "ok" | "error">();
+    mocks.agent.mockImplementation(
+      (opts: { params: { idempotencyKey: string }; respond: (ok: boolean, payload?: unknown) => void }) => {
+        const agentRunId = `agent-${opts.params.idempotencyKey}`;
+        runState.set(agentRunId, "ok");
+        if (opts.params.idempotencyKey.includes(":review:1")) {
+          runState.set(agentRunId, "error");
+        }
+        opts.respond(true, { runId: agentRunId, status: "accepted" });
+      },
+    );
+    mocks.agentWait.mockImplementation(
+      (opts: { params: { runId: string }; respond: (ok: boolean, payload?: unknown) => void }) => {
+        const status = runState.get(opts.params.runId) ?? "error";
+        if (status === "ok") {
+          opts.respond(true, { runId: opts.params.runId, status: "ok" });
+          return;
+        }
+        opts.respond(true, {
+          runId: opts.params.runId,
+          status: "error",
+          error: "simulated failure",
+        });
+      },
+    );
+
+    const plan = {
+      planId: "mesh-plan-2",
+      goal: "Ship patch",
+      createdAt: Date.now(),
+      steps: [
+        { id: "research", prompt: "Research requirements" },
+        { id: "build", prompt: "Build feature", dependsOn: ["research"] },
+        { id: "review", prompt: "Review result", dependsOn: ["build"] },
+      ],
+    };
+
+    const runRes = await callMesh("mesh.run", { plan });
+    expect(runRes.ok).toBe(true);
+    const runPayload = runRes.payload as {
+      runId: string;
+      status: string;
+      stats: { failed: number };
+    };
+    expect(runPayload.status).toBe("failed");
+    expect(runPayload.stats.failed).toBe(1);
+
+    // Make subsequent retries succeed
+    mocks.agent.mockImplementation(
+      (opts: { params: { idempotencyKey: string }; respond: (ok: boolean, payload?: unknown) => void }) => {
+        const agentRunId = `agent-${opts.params.idempotencyKey}`;
+        runState.set(agentRunId, "ok");
+        opts.respond(true, { runId: agentRunId, status: "accepted" });
+      },
+    );
+
+    const retryRes = await callMesh("mesh.retry", {
+      runId: runPayload.runId,
+      stepIds: ["review"],
+    });
+    expect(retryRes.ok).toBe(true);
+    const retryPayload = retryRes.payload as { status: string; stats: { failed: number } };
+    expect(retryPayload.status).toBe("completed");
+    expect(retryPayload.stats.failed).toBe(0);
+
+    const statusRes = await callMesh("mesh.status", { runId: runPayload.runId });
+    expect(statusRes.ok).toBe(true);
+    const statusPayload = statusRes.payload as { status: string };
+    expect(statusPayload.status).toBe("completed");
+  });
+});

--- a/src/gateway/server-methods/mesh.ts
+++ b/src/gateway/server-methods/mesh.ts
@@ -1,0 +1,706 @@
+import { randomUUID } from "node:crypto";
+import type { GatewayRequestHandlerOptions, GatewayRequestHandlers, RespondFn } from "./types.js";
+import {
+  ErrorCodes,
+  errorShape,
+  formatValidationErrors,
+  validateMeshPlanParams,
+  validateMeshRetryParams,
+  validateMeshRunParams,
+  validateMeshStatusParams,
+  type MeshRunParams,
+  type MeshWorkflowPlan,
+} from "../protocol/index.js";
+import { agentHandlers } from "./agent.js";
+
+type MeshStepStatus = "pending" | "running" | "succeeded" | "failed" | "skipped";
+type MeshRunStatus = "pending" | "running" | "completed" | "failed";
+
+type MeshStepRuntime = {
+  id: string;
+  name?: string;
+  prompt: string;
+  dependsOn: string[];
+  agentId?: string;
+  sessionKey?: string;
+  thinking?: string;
+  timeoutMs?: number;
+  status: MeshStepStatus;
+  attempts: number;
+  startedAt?: number;
+  endedAt?: number;
+  agentRunId?: string;
+  error?: string;
+};
+
+type MeshRunRecord = {
+  runId: string;
+  plan: MeshWorkflowPlan;
+  status: MeshRunStatus;
+  startedAt: number;
+  endedAt?: number;
+  continueOnError: boolean;
+  maxParallel: number;
+  defaultStepTimeoutMs: number;
+  lane?: string;
+  stepOrder: string[];
+  steps: Record<string, MeshStepRuntime>;
+  history: Array<{ ts: number; type: string; stepId?: string; data?: Record<string, unknown> }>;
+};
+
+const meshRuns = new Map<string, MeshRunRecord>();
+const MAX_KEEP_RUNS = 200;
+
+function trimMap() {
+  if (meshRuns.size <= MAX_KEEP_RUNS) {
+    return;
+  }
+  const sorted = [...meshRuns.values()].sort((a, b) => a.startedAt - b.startedAt);
+  const overflow = meshRuns.size - MAX_KEEP_RUNS;
+  for (const stale of sorted.slice(0, overflow)) {
+    meshRuns.delete(stale.runId);
+  }
+}
+
+function normalizeDependsOn(dependsOn: string[] | undefined): string[] {
+  if (!Array.isArray(dependsOn)) {
+    return [];
+  }
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+  for (const raw of dependsOn) {
+    const trimmed = String(raw ?? "").trim();
+    if (!trimmed || seen.has(trimmed)) {
+      continue;
+    }
+    seen.add(trimmed);
+    normalized.push(trimmed);
+  }
+  return normalized;
+}
+
+function normalizePlan(plan: MeshWorkflowPlan): MeshWorkflowPlan {
+  return {
+    planId: plan.planId.trim(),
+    goal: plan.goal.trim(),
+    createdAt: plan.createdAt,
+    steps: plan.steps.map((step) => ({
+      id: step.id.trim(),
+      name: typeof step.name === "string" ? step.name.trim() || undefined : undefined,
+      prompt: step.prompt.trim(),
+      dependsOn: normalizeDependsOn(step.dependsOn),
+      agentId: typeof step.agentId === "string" ? step.agentId.trim() || undefined : undefined,
+      sessionKey:
+        typeof step.sessionKey === "string" ? step.sessionKey.trim() || undefined : undefined,
+      thinking: typeof step.thinking === "string" ? step.thinking : undefined,
+      timeoutMs:
+        typeof step.timeoutMs === "number" && Number.isFinite(step.timeoutMs)
+          ? Math.max(1_000, Math.floor(step.timeoutMs))
+          : undefined,
+    })),
+  };
+}
+
+function createPlanFromParams(params: {
+  goal: string;
+  steps?: Array<{
+    id?: string;
+    name?: string;
+    prompt: string;
+    dependsOn?: string[];
+    agentId?: string;
+    sessionKey?: string;
+    thinking?: string;
+    timeoutMs?: number;
+  }>;
+}): MeshWorkflowPlan {
+  const now = Date.now();
+  const goal = params.goal.trim();
+  const sourceSteps = params.steps?.length
+    ? params.steps
+    : [
+        {
+          id: "step-1",
+          name: "Primary Task",
+          prompt: goal,
+        },
+      ];
+
+  const steps = sourceSteps.map((step, index) => {
+    const stepId = step.id?.trim() || `step-${index + 1}`;
+    return {
+      id: stepId,
+      name: step.name?.trim() || undefined,
+      prompt: step.prompt.trim(),
+      dependsOn: normalizeDependsOn(step.dependsOn),
+      agentId: step.agentId?.trim() || undefined,
+      sessionKey: step.sessionKey?.trim() || undefined,
+      thinking: typeof step.thinking === "string" ? step.thinking : undefined,
+      timeoutMs:
+        typeof step.timeoutMs === "number" && Number.isFinite(step.timeoutMs)
+          ? Math.max(1_000, Math.floor(step.timeoutMs))
+          : undefined,
+    };
+  });
+
+  return {
+    planId: `mesh-plan-${randomUUID()}`,
+    goal,
+    createdAt: now,
+    steps,
+  };
+}
+
+function validatePlanGraph(plan: MeshWorkflowPlan): { ok: true; order: string[] } | { ok: false; error: string } {
+  const ids = new Set<string>();
+  for (const step of plan.steps) {
+    if (ids.has(step.id)) {
+      return { ok: false, error: `duplicate step id: ${step.id}` };
+    }
+    ids.add(step.id);
+  }
+
+  for (const step of plan.steps) {
+    for (const depId of step.dependsOn ?? []) {
+      if (!ids.has(depId)) {
+        return { ok: false, error: `unknown dependency "${depId}" on step "${step.id}"` };
+      }
+      if (depId === step.id) {
+        return { ok: false, error: `step "${step.id}" cannot depend on itself` };
+      }
+    }
+  }
+
+  const inDegree = new Map<string, number>();
+  const outgoing = new Map<string, string[]>();
+  for (const step of plan.steps) {
+    inDegree.set(step.id, 0);
+    outgoing.set(step.id, []);
+  }
+  for (const step of plan.steps) {
+    for (const dep of step.dependsOn ?? []) {
+      inDegree.set(step.id, (inDegree.get(step.id) ?? 0) + 1);
+      const list = outgoing.get(dep);
+      if (list) {
+        list.push(step.id);
+      }
+    }
+  }
+
+  const queue = plan.steps.filter((step) => (inDegree.get(step.id) ?? 0) === 0).map((s) => s.id);
+  const order: string[] = [];
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (!current) {
+      continue;
+    }
+    order.push(current);
+    const targets = outgoing.get(current) ?? [];
+    for (const next of targets) {
+      const degree = (inDegree.get(next) ?? 0) - 1;
+      inDegree.set(next, degree);
+      if (degree === 0) {
+        queue.push(next);
+      }
+    }
+  }
+
+  if (order.length !== plan.steps.length) {
+    return { ok: false, error: "workflow contains a dependency cycle" };
+  }
+  return { ok: true, order };
+}
+
+async function callGatewayHandler(
+  handler: (opts: GatewayRequestHandlerOptions) => Promise<void> | void,
+  opts: GatewayRequestHandlerOptions,
+): Promise<{ ok: boolean; payload?: unknown; error?: unknown; meta?: Record<string, unknown> }> {
+  return await new Promise((resolve) => {
+    let settled = false;
+    const settle = (result: { ok: boolean; payload?: unknown; error?: unknown; meta?: Record<string, unknown> }) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      resolve(result);
+    };
+    const respond: RespondFn = (ok, payload, error, meta) => {
+      settle({ ok, payload, error, meta });
+    };
+    void Promise.resolve(
+      handler({
+        ...opts,
+        respond,
+      }),
+    ).catch((err) => {
+      settle({ ok: false, error: err });
+    });
+  });
+}
+
+function buildStepPrompt(step: MeshStepRuntime, run: MeshRunRecord): string {
+  if (step.dependsOn.length === 0) {
+    return step.prompt;
+  }
+  const lines = step.dependsOn.map((depId) => {
+    const dep = run.steps[depId];
+    const details = dep.agentRunId ? ` runId=${dep.agentRunId}` : "";
+    return `- ${depId}: ${dep.status}${details}`;
+  });
+  return `${step.prompt}\n\nDependency context:\n${lines.join("\n")}`;
+}
+
+function resolveStepTimeoutMs(step: MeshStepRuntime, run: MeshRunRecord): number {
+  if (typeof step.timeoutMs === "number" && Number.isFinite(step.timeoutMs)) {
+    return Math.max(1_000, Math.floor(step.timeoutMs));
+  }
+  return run.defaultStepTimeoutMs;
+}
+
+async function executeStep(params: {
+  run: MeshRunRecord;
+  step: MeshStepRuntime;
+  opts: GatewayRequestHandlerOptions;
+}) {
+  const { run, step, opts } = params;
+  step.status = "running";
+  step.startedAt = Date.now();
+  step.endedAt = undefined;
+  step.error = undefined;
+  step.attempts += 1;
+  run.history.push({ ts: Date.now(), type: "step.start", stepId: step.id });
+
+  const agentRequestId = `${run.runId}:${step.id}:${step.attempts}`;
+  const prompt = buildStepPrompt(step, run);
+  const timeoutMs = resolveStepTimeoutMs(step, run);
+  const timeoutSeconds = Math.ceil(timeoutMs / 1000);
+
+  const accepted = await callGatewayHandler(agentHandlers.agent, {
+    ...opts,
+    req: {
+      type: "req",
+      id: `${agentRequestId}:agent`,
+      method: "agent",
+      params: {},
+    },
+    params: {
+      message: prompt,
+      idempotencyKey: agentRequestId,
+      ...(step.agentId ? { agentId: step.agentId } : {}),
+      ...(step.sessionKey ? { sessionKey: step.sessionKey } : {}),
+      ...(step.thinking ? { thinking: step.thinking } : {}),
+      ...(run.lane ? { lane: run.lane } : {}),
+      timeout: timeoutSeconds,
+      deliver: false,
+    },
+  });
+
+  if (!accepted.ok) {
+    step.status = "failed";
+    step.endedAt = Date.now();
+    step.error = String(accepted.error ?? "agent request failed");
+    run.history.push({
+      ts: Date.now(),
+      type: "step.error",
+      stepId: step.id,
+      data: { error: step.error },
+    });
+    return;
+  }
+
+  const runId = (() => {
+    const candidate = accepted.payload as { runId?: unknown } | undefined;
+    return typeof candidate?.runId === "string" ? candidate.runId : undefined;
+  })();
+  step.agentRunId = runId;
+
+  if (!runId) {
+    step.status = "failed";
+    step.endedAt = Date.now();
+    step.error = "agent did not return runId";
+    run.history.push({
+      ts: Date.now(),
+      type: "step.error",
+      stepId: step.id,
+      data: { error: step.error },
+    });
+    return;
+  }
+
+  const waited = await callGatewayHandler(agentHandlers["agent.wait"], {
+    ...opts,
+    req: {
+      type: "req",
+      id: `${agentRequestId}:wait`,
+      method: "agent.wait",
+      params: {},
+    },
+    params: {
+      runId,
+      timeoutMs,
+    },
+  });
+
+  const waitPayload = waited.payload as { status?: unknown; error?: unknown } | undefined;
+  const waitStatus = typeof waitPayload?.status === "string" ? waitPayload.status : "error";
+  if (waited.ok && waitStatus === "ok") {
+    step.status = "succeeded";
+    step.endedAt = Date.now();
+    run.history.push({ ts: Date.now(), type: "step.ok", stepId: step.id, data: { runId } });
+    return;
+  }
+
+  step.status = "failed";
+  step.endedAt = Date.now();
+  step.error =
+    typeof waitPayload?.error === "string"
+      ? waitPayload.error
+      : String(waited.error ?? `agent.wait returned status ${waitStatus}`);
+  run.history.push({
+    ts: Date.now(),
+    type: "step.error",
+    stepId: step.id,
+    data: { runId, status: waitStatus, error: step.error },
+  });
+}
+
+function createRunRecord(params: {
+  runId: string;
+  plan: MeshWorkflowPlan;
+  order: string[];
+  continueOnError: boolean;
+  maxParallel: number;
+  defaultStepTimeoutMs: number;
+  lane?: string;
+}): MeshRunRecord {
+  const steps: Record<string, MeshStepRuntime> = {};
+  for (const step of params.plan.steps) {
+    steps[step.id] = {
+      id: step.id,
+      name: step.name,
+      prompt: step.prompt,
+      dependsOn: step.dependsOn ?? [],
+      agentId: step.agentId,
+      sessionKey: step.sessionKey,
+      thinking: step.thinking,
+      timeoutMs: step.timeoutMs,
+      status: "pending",
+      attempts: 0,
+    };
+  }
+  return {
+    runId: params.runId,
+    plan: params.plan,
+    status: "pending",
+    startedAt: Date.now(),
+    continueOnError: params.continueOnError,
+    maxParallel: params.maxParallel,
+    defaultStepTimeoutMs: params.defaultStepTimeoutMs,
+    lane: params.lane,
+    stepOrder: params.order,
+    steps,
+    history: [],
+  };
+}
+
+function findReadySteps(run: MeshRunRecord): MeshStepRuntime[] {
+  const ready: MeshStepRuntime[] = [];
+  for (const stepId of run.stepOrder) {
+    const step = run.steps[stepId];
+    if (!step || step.status !== "pending") {
+      continue;
+    }
+    const deps = step.dependsOn.map((depId) => run.steps[depId]).filter(Boolean);
+    if (deps.some((dep) => dep.status === "failed" || dep.status === "skipped")) {
+      step.status = "skipped";
+      step.endedAt = Date.now();
+      step.error = "dependency failed";
+      continue;
+    }
+    if (deps.every((dep) => dep.status === "succeeded")) {
+      ready.push(step);
+    }
+  }
+  return ready;
+}
+
+async function runWorkflow(run: MeshRunRecord, opts: GatewayRequestHandlerOptions) {
+  run.status = "running";
+  run.history.push({ ts: Date.now(), type: "run.start" });
+
+  const inFlight = new Set<Promise<void>>();
+  let stopScheduling = false;
+  while (true) {
+    const failed = Object.values(run.steps).some((step) => step.status === "failed");
+    if (failed && !run.continueOnError) {
+      stopScheduling = true;
+    }
+
+    if (!stopScheduling) {
+      const ready = findReadySteps(run);
+      for (const step of ready) {
+        if (inFlight.size >= run.maxParallel) {
+          break;
+        }
+        const task = executeStep({ run, step, opts }).finally(() => {
+          inFlight.delete(task);
+        });
+        inFlight.add(task);
+      }
+    }
+
+    if (inFlight.size > 0) {
+      await Promise.race(inFlight);
+      continue;
+    }
+
+    const pending = Object.values(run.steps).filter((step) => step.status === "pending");
+    if (pending.length === 0) {
+      break;
+    }
+    for (const step of pending) {
+      step.status = "skipped";
+      step.endedAt = Date.now();
+      step.error = stopScheduling ? "cancelled after failure" : "unresolvable dependencies";
+    }
+    break;
+  }
+
+  const hasFailure = Object.values(run.steps).some((step) => step.status === "failed");
+  run.status = hasFailure ? "failed" : "completed";
+  run.endedAt = Date.now();
+  run.history.push({
+    ts: Date.now(),
+    type: "run.end",
+    data: { status: run.status },
+  });
+}
+
+function resolveStepIdsForRetry(run: MeshRunRecord, requested?: string[]): string[] {
+  if (Array.isArray(requested) && requested.length > 0) {
+    return requested.map((stepId) => stepId.trim()).filter(Boolean);
+  }
+  return Object.values(run.steps)
+    .filter((step) => step.status === "failed" || step.status === "skipped")
+    .map((step) => step.id);
+}
+
+function descendantsOf(run: MeshRunRecord, roots: Set<string>): Set<string> {
+  const descendants = new Set<string>();
+  const queue = [...roots];
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (!current) {
+      continue;
+    }
+    for (const step of Object.values(run.steps)) {
+      if (!step.dependsOn.includes(current) || descendants.has(step.id)) {
+        continue;
+      }
+      descendants.add(step.id);
+      queue.push(step.id);
+    }
+  }
+  return descendants;
+}
+
+function resetStepsForRetry(run: MeshRunRecord, stepIds: string[]) {
+  const rootSet = new Set(stepIds);
+  const descendants = descendantsOf(run, rootSet);
+  const resetIds = new Set([...rootSet, ...descendants]);
+  for (const stepId of resetIds) {
+    const step = run.steps[stepId];
+    if (!step) {
+      continue;
+    }
+    if (step.status === "succeeded" && !rootSet.has(stepId)) {
+      continue;
+    }
+    step.status = "pending";
+    step.startedAt = undefined;
+    step.endedAt = undefined;
+    step.error = undefined;
+    if (rootSet.has(stepId)) {
+      step.agentRunId = undefined;
+    }
+  }
+}
+
+function summarizeRun(run: MeshRunRecord) {
+  return {
+    runId: run.runId,
+    plan: run.plan,
+    status: run.status,
+    startedAt: run.startedAt,
+    endedAt: run.endedAt,
+    stats: {
+      total: Object.keys(run.steps).length,
+      succeeded: Object.values(run.steps).filter((step) => step.status === "succeeded").length,
+      failed: Object.values(run.steps).filter((step) => step.status === "failed").length,
+      skipped: Object.values(run.steps).filter((step) => step.status === "skipped").length,
+      running: Object.values(run.steps).filter((step) => step.status === "running").length,
+      pending: Object.values(run.steps).filter((step) => step.status === "pending").length,
+    },
+    steps: run.stepOrder.map((stepId) => run.steps[stepId]),
+    history: run.history,
+  };
+}
+
+export const meshHandlers: GatewayRequestHandlers = {
+  "mesh.plan": ({ params, respond }) => {
+    if (!validateMeshPlanParams(params)) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          `invalid mesh.plan params: ${formatValidationErrors(validateMeshPlanParams.errors)}`,
+        ),
+      );
+      return;
+    }
+    const p = params;
+    const plan = normalizePlan(
+      createPlanFromParams({
+        goal: p.goal,
+        steps: p.steps,
+      }),
+    );
+    const graph = validatePlanGraph(plan);
+    if (!graph.ok) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, graph.error));
+      return;
+    }
+    respond(
+      true,
+      {
+        plan,
+        order: graph.order,
+      },
+      undefined,
+    );
+  },
+  "mesh.run": async (opts) => {
+    const { params, respond } = opts;
+    if (!validateMeshRunParams(params)) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          `invalid mesh.run params: ${formatValidationErrors(validateMeshRunParams.errors)}`,
+        ),
+      );
+      return;
+    }
+    const p = params as MeshRunParams;
+    const plan = normalizePlan(p.plan);
+    const graph = validatePlanGraph(plan);
+    if (!graph.ok) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, graph.error));
+      return;
+    }
+
+    const maxParallel =
+      typeof p.maxParallel === "number" && Number.isFinite(p.maxParallel)
+        ? Math.min(16, Math.max(1, Math.floor(p.maxParallel)))
+        : 2;
+    const defaultStepTimeoutMs =
+      typeof p.defaultStepTimeoutMs === "number" && Number.isFinite(p.defaultStepTimeoutMs)
+        ? Math.max(1_000, Math.floor(p.defaultStepTimeoutMs))
+        : 120_000;
+    const runId = `mesh-run-${randomUUID()}`;
+    const record = createRunRecord({
+      runId,
+      plan,
+      order: graph.order,
+      continueOnError: p.continueOnError === true,
+      maxParallel,
+      defaultStepTimeoutMs,
+      lane: typeof p.lane === "string" ? p.lane : undefined,
+    });
+    meshRuns.set(runId, record);
+    trimMap();
+
+    await runWorkflow(record, opts);
+    respond(true, summarizeRun(record), undefined);
+  },
+  "mesh.status": ({ params, respond }) => {
+    if (!validateMeshStatusParams(params)) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          `invalid mesh.status params: ${formatValidationErrors(validateMeshStatusParams.errors)}`,
+        ),
+      );
+      return;
+    }
+    const run = meshRuns.get(params.runId.trim());
+    if (!run) {
+      respond(false, undefined, errorShape(ErrorCodes.NOT_FOUND, "mesh run not found"));
+      return;
+    }
+    respond(true, summarizeRun(run), undefined);
+  },
+  "mesh.retry": async (opts) => {
+    const { params, respond } = opts;
+    if (!validateMeshRetryParams(params)) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          `invalid mesh.retry params: ${formatValidationErrors(validateMeshRetryParams.errors)}`,
+        ),
+      );
+      return;
+    }
+    const runId = params.runId.trim();
+    const run = meshRuns.get(runId);
+    if (!run) {
+      respond(false, undefined, errorShape(ErrorCodes.NOT_FOUND, "mesh run not found"));
+      return;
+    }
+    if (run.status === "running") {
+      respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, "mesh run is currently running"));
+      return;
+    }
+    const stepIds = resolveStepIdsForRetry(run, params.stepIds);
+    if (stepIds.length === 0) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "no failed or skipped steps available to retry"),
+      );
+      return;
+    }
+    for (const stepId of stepIds) {
+      if (!run.steps[stepId]) {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.INVALID_REQUEST, `unknown retry step id: ${stepId}`),
+        );
+        return;
+      }
+    }
+
+    resetStepsForRetry(run, stepIds);
+    run.status = "pending";
+    run.endedAt = undefined;
+    run.history.push({
+      ts: Date.now(),
+      type: "run.retry",
+      data: { stepIds },
+    });
+    await runWorkflow(run, opts);
+    respond(true, summarizeRun(run), undefined);
+  },
+};
+
+export function __resetMeshRunsForTest() {
+  meshRuns.clear();
+}

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -489,6 +489,50 @@ describe("gateway healthHandlers.status scope handling", () => {
   });
 });
 
+describe("gateway mesh.plan.auto scope handling", () => {
+  it("rejects operator.read clients for mesh.plan.auto", async () => {
+    const { handleGatewayRequest } = await import("../server-methods.js");
+    const respond = vi.fn();
+    const handler = vi.fn();
+
+    await handleGatewayRequest({
+      req: { id: "req-mesh-read", type: "req", method: "mesh.plan.auto", params: {} },
+      respond,
+      context: {} as Parameters<typeof handleGatewayRequest>[0]["context"],
+      client: { connect: { role: "operator", scopes: ["operator.read"] } },
+      isWebchatConnect: () => false,
+      extraHandlers: { "mesh.plan.auto": handler },
+    });
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: "missing scope: operator.write" }),
+    );
+  });
+
+  it("allows operator.write clients for mesh.plan.auto", async () => {
+    const { handleGatewayRequest } = await import("../server-methods.js");
+    const respond = vi.fn();
+    const handler = vi.fn(({ respond: send }: { respond: (ok: boolean, payload?: unknown) => void }) =>
+      send(true, { ok: true }),
+    );
+
+    await handleGatewayRequest({
+      req: { id: "req-mesh-write", type: "req", method: "mesh.plan.auto", params: {} },
+      respond,
+      context: {} as Parameters<typeof handleGatewayRequest>[0]["context"],
+      client: { connect: { role: "operator", scopes: ["operator.write"] } },
+      isWebchatConnect: () => false,
+      extraHandlers: { "mesh.plan.auto": handler },
+    });
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(respond).toHaveBeenCalledWith(true, { ok: true });
+  });
+});
+
 describe("logs.tail", () => {
   const logsNoop = () => false;
 


### PR DESCRIPTION
## What is Mesh?

Mesh is a workflow orchestration layer on top of OpenClaw's existing agent runtime.

Instead of handling a complex request as one large prompt/run, Mesh models work as:

1. A goal
2. A dependency-aware step graph (DAG)
3. A tracked run with step-level state and retry controls

Mesh does not replace OpenClaw agents. It coordinates them.

## What this PR adds

### Gateway methods

- `mesh.plan`
- `mesh.plan.auto`
- `mesh.run`
- `mesh.status`
- `mesh.retry`

### Planner integration

- `mesh.plan.auto` uses OpenClaw's LLM runtime (`agentCommand`) to generate executable steps.
- If planner output is invalid, Mesh falls back to a safe single-step plan.

### Workflow engine

- DAG validation (duplicate ids, unknown deps, self-deps, cycles)
- Topological execution order
- Step-level state machine:
  - `pending`, `running`, `succeeded`, `failed`, `skipped`
- Step-level retry with dependency-aware reset
- Run history + stats snapshots via `mesh.status`

### Chat UX

- `/mesh <goal>` (auto plan + run)
- `/mesh plan <goal>`
- `/mesh run <goal|mesh-plan-id>`
- `/mesh status <runId>`
- `/mesh retry <runId> [step1,step2,...]`

### Deterministic replay

- `/mesh plan` returns a plan id
- `/mesh run <mesh-plan-id>` reuses that exact plan in the same chat (no re-planning call)

### Hardening

- `mesh.plan.auto` requires `operator.write` scope (not read)
- Planner defaults to isolated session key `agent:<agentId>:mesh-planner` to avoid polluting normal chat memory
- Caller-provided planner `sessionKey` remains supported

## Mesh vs OpenClaw subagents

OpenClaw subagents and Mesh solve different problems.

Subagents:

- Parallel/isolated execution units for a single broader task
- Good for delegation and concurrency inside one conversational objective
- Focused on "who does the work"

Mesh:

- Explicit workflow orchestration with dependencies and run lifecycle
- Good for ordered multi-step execution and operational recoverability
- Focused on "what order the work runs in" and "what to retry after failure"

They are complementary:

- Mesh can orchestrate step sequencing
- Each step executes through existing OpenClaw agent primitives (`agent` + `agent.wait`), and can target different `agentId` / `sessionKey` contexts

So this PR is not introducing a new agent-to-agent transport protocol. It adds a deterministic orchestration layer over existing agent execution.

## What Mesh adds that OpenClaw did not have

Before Mesh, OpenClaw had strong single-run execution but no first-class workflow runtime with:

- explicit DAG planning
- explicit per-step lifecycle visibility
- targeted step retries without re-running successful upstream work

This PR adds those capabilities while reusing existing agent execution pathways.

## Practical flow example

Goal:

`Build a landing page animation, test mobile, then write release notes.`

Flow:

1. `mesh.plan.auto` creates steps:
   - `build-animation`
   - `test-mobile` depends on `build-animation`
   - `write-release-notes` depends on `test-mobile`
2. `mesh.run` executes in order.
3. If `test-mobile` fails, user runs `mesh.retry` for that step.
4. Mesh reruns required failed/downstream steps; successful upstream steps are reused.

## Known limitations

- Mesh run store is in-memory (not persisted across restart)
- Chat plan-id cache is in-memory and scoped to same chat
- Auto-plan quality depends on model output (fallback exists)

## Compatibility / risk

- Additive change; no behavior change for non-Mesh flows
- Scope tightening is intentional: read-only clients cannot call `mesh.plan.auto`

## Validation

- `pnpm -s tsc -p tsconfig.json --noEmit`
- `pnpm vitest run src/gateway/server-methods/mesh.test.ts`
- `pnpm vitest run src/gateway/server-methods/server-methods.test.ts`
- `pnpm vitest run src/auto-reply/reply/commands.test.ts`
- `pnpm vitest run src/auto-reply/commands-registry.test.ts src/auto-reply/command-control.test.ts`
- `pnpm vitest run src/gateway/protocol/index.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a Mesh workflow orchestration layer with gateway methods (`mesh.plan`, `mesh.plan.auto`, `mesh.run`, `mesh.status`, `mesh.retry`) and a chat-native `/mesh` command family. The implementation is well-structured: DAG validation with topological ordering, step-level state tracking, targeted retry with descendant propagation, and an LLM-based auto-planner with fallback. Auth scoping is correctly split between read (`mesh.plan`, `mesh.status`) and write (`mesh.plan.auto`, `mesh.run`, `mesh.retry`) operations.

- **Bug: Missing `timeoutMs` on `callGateway` calls in `commands-mesh.ts`** — All four `callGateway` calls default to a 10-second WebSocket timeout, but the server-side operations (LLM planning at ~90s, workflow execution at potentially minutes) will far exceed this. Compare with `commands-subagents.ts` which explicitly sets `timeoutMs` for long-running calls.
- `mesh.ts` is 894 LOC, exceeding the ~700 LOC guideline in `AGENTS.md`. The DAG validation, auto-planner, and workflow execution logic could be extracted into separate modules.
- Run state and plan caches are in-memory only (acknowledged in PR description as a known limitation).

<h3>Confidence Score: 3/5</h3>

- The gateway server-side logic is solid, but the chat command UX layer has a timeout bug that will cause `/mesh` commands to fail in practice.
- Score of 3 reflects that the core orchestration engine (DAG validation, execution, retry) is well-implemented and tested, but the chat command integration has a significant bug: missing `timeoutMs` on `callGateway` calls means `/mesh` commands will timeout after 10 seconds instead of waiting for the much longer server-side operations. The gateway methods themselves work correctly when called directly (e.g., from external clients that set appropriate timeouts).
- Pay close attention to `src/auto-reply/reply/commands-mesh.ts` — the missing `timeoutMs` on `callGateway` calls will cause chat commands to fail in production.

<sub>Last reviewed commit: 50d0276</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))

<!-- /greptile_comment -->