### PR TITLE
feat: add before_message_write plugin hook

### DIFF
--- a/src/agents/session-tool-result-guard-wrapper.ts
+++ b/src/agents/session-tool-result-guard-wrapper.ts
@@ -29,6 +29,15 @@ export function guardSessionManager(
   }
 
   const hookRunner = getGlobalHookRunner();
+  const beforeMessageWrite = hookRunner?.hasHooks("before_message_write")
+    ? (event: { message: import("@mariozechner/pi-agent-core").AgentMessage }) => {
+        return hookRunner.runBeforeMessageWrite(event, {
+          agentId: opts?.agentId,
+          sessionKey: opts?.sessionKey,
+        });
+      }
+    : undefined;
+
   const transform = hookRunner?.hasHooks("tool_result_persist")
     ? // oxlint-disable-next-line typescript/no-explicit-any
       (message: any, meta: { toolCallId?: string; toolName?: string; isSynthetic?: boolean }) => {
@@ -55,6 +64,7 @@ export function guardSessionManager(
       applyInputProvenanceToUserMessage(message, opts?.inputProvenance),
     transformToolResultForPersistence: transform,
     allowSyntheticToolResults: opts?.allowSyntheticToolResults,
+    beforeMessageWriteHook: beforeMessageWrite,
   });
   (sessionManager as GuardedSessionManager).flushPendingToolResults = guard.flushPendingToolResults;
   return sessionManager as GuardedSessionManager;

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -1,4 +1,8 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type {
+  PluginHookBeforeMessageWriteEvent,
+  PluginHookBeforeMessageWriteResult,
+} from "../plugins/types.js";
 import type { TextContent } from "@mariozechner/pi-ai";
 import type { SessionManager } from "@mariozechner/pi-coding-agent";
 import { emitSessionTranscriptUpdate } from "../sessions/transcript-events.js";
@@ -92,6 +96,14 @@ export function installSessionToolResultGuard(
      * Defaults to true.
      */
     allowSyntheticToolResults?: boolean;
+    /**
+     * Synchronous hook invoked before any message is written to the session JSONL.
+     * If the hook returns { block: true }, the message is silently dropped.
+     * If it returns { message }, the modified message is written instead.
+     */
+    beforeMessageWriteHook?: (
+      event: PluginHookBeforeMessageWriteEvent,
+    ) => PluginHookBeforeMessageWriteResult | undefined;
   },
 ): {
   flushPendingToolResults: () => void;
@@ -113,6 +125,19 @@ export function installSessionToolResultGuard(
   };
 
   const allowSyntheticToolResults = opts?.allowSyntheticToolResults ?? true;
+  const beforeWrite = opts?.beforeMessageWriteHook;
+
+  /**
+   * Run the before_message_write hook. Returns the (possibly modified) message,
+   * or null if the message should be blocked.
+   */
+  const applyBeforeWriteHook = (msg: AgentMessage): AgentMessage | null => {
+    if (!beforeWrite) return msg;
+    const result = beforeWrite({ message: msg });
+    if (result?.block) return null;
+    if (result?.message) return result.message;
+    return msg;
+  };
 
   const flushPendingToolResults = () => {
     if (pending.size === 0) {
@@ -121,13 +146,16 @@ export function installSessionToolResultGuard(
     if (allowSyntheticToolResults) {
       for (const [id, name] of pending.entries()) {
         const synthetic = makeMissingToolResult({ toolCallId: id, toolName: name });
-        originalAppend(
+        const flushed = applyBeforeWriteHook(
           persistToolResult(persistMessage(synthetic), {
             toolCallId: id,
             toolName: name,
             isSynthetic: true,
-          }) as never,
+          }),
         );
+        if (flushed) {
+          originalAppend(flushed as never);
+        }
       }
     }
     pending.clear();
@@ -157,13 +185,15 @@ export function installSessionToolResultGuard(
       // Apply hard size cap before persistence to prevent oversized tool results
       // from consuming the entire context window on subsequent LLM calls.
       const capped = capToolResultSize(persistMessage(nextMessage));
-      return originalAppend(
+      const persisted = applyBeforeWriteHook(
         persistToolResult(capped, {
           toolCallId: id ?? undefined,
           toolName,
           isSynthetic: false,
-        }) as never,
+        }),
       );
+      if (!persisted) return undefined;
+      return originalAppend(persisted as never);
     }
 
     const toolCalls =
@@ -182,7 +212,9 @@ export function installSessionToolResultGuard(
       }
     }
 
-    const result = originalAppend(persistMessage(nextMessage) as never);
+    const finalMessage = applyBeforeWriteHook(persistMessage(nextMessage));
+    if (!finalMessage) return undefined;
+    const result = originalAppend(finalMessage as never);
 
     const sessionFile = (
       sessionManager as { getSessionFile?: () => string | null }

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -36,6 +36,8 @@ import type {
   PluginHookToolResultPersistContext,
   PluginHookToolResultPersistEvent,
   PluginHookToolResultPersistResult,
+  PluginHookBeforeMessageWriteEvent,
+  PluginHookBeforeMessageWriteResult,
 } from "./types.js";
 
 // Re-export types for consumers
@@ -61,6 +63,8 @@ export type {
   PluginHookToolResultPersistContext,
   PluginHookToolResultPersistEvent,
   PluginHookToolResultPersistResult,
+  PluginHookBeforeMessageWriteEvent,
+  PluginHookBeforeMessageWriteResult,
   PluginHookSessionContext,
   PluginHookSessionStartEvent,
   PluginHookSessionEndEvent,
@@ -407,6 +411,84 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     return { message: current };
   }
 
+
+  // =========================================================================
+  // Message Write Hooks
+  // =========================================================================
+
+  /**
+   * Run before_message_write hook.
+   *
+   * This hook is intentionally synchronous: it runs on the hot path where
+   * session transcripts are appended synchronously.
+   *
+   * Handlers are executed sequentially in priority order (higher first).
+   * If any handler returns { block: true }, the message is NOT written
+   * to the session JSONL and we return immediately.
+   * If a handler returns { message }, the modified message replaces the
+   * original for subsequent handlers and the final write.
+   */
+  function runBeforeMessageWrite(
+    event: PluginHookBeforeMessageWriteEvent,
+    ctx: { agentId?: string; sessionKey?: string },
+  ): PluginHookBeforeMessageWriteResult | undefined {
+    const hooks = getHooksForName(registry, "before_message_write");
+    if (hooks.length === 0) {
+      return undefined;
+    }
+
+    let current = event.message;
+
+    for (const hook of hooks) {
+      try {
+        // oxlint-disable-next-line typescript/no-explicit-any
+        const out = (hook.handler as any)({ ...event, message: current }, ctx) as
+          | PluginHookBeforeMessageWriteResult
+          | void
+          | Promise<unknown>;
+
+        // Guard against accidental async handlers (this hook is sync-only).
+        // oxlint-disable-next-line typescript/no-explicit-any
+        if (out && typeof (out as any).then === "function") {
+          const msg =
+            `[hooks] before_message_write handler from ${hook.pluginId} returned a Promise; ` +
+            `this hook is synchronous and the result was ignored.`;
+          if (catchErrors) {
+            logger?.warn?.(msg);
+            continue;
+          }
+          throw new Error(msg);
+        }
+
+        const result = out as PluginHookBeforeMessageWriteResult | undefined;
+
+        // If any handler blocks, return immediately.
+        if (result?.block) {
+          return { block: true };
+        }
+
+        // If handler provided a modified message, use it for subsequent handlers.
+        if (result?.message) {
+          current = result.message;
+        }
+      } catch (err) {
+        const msg = `[hooks] before_message_write handler from ${hook.pluginId} failed: ${String(err)}`;
+        if (catchErrors) {
+          logger?.error(msg);
+        } else {
+          throw new Error(msg, { cause: err });
+        }
+      }
+    }
+
+    // If message was modified by any handler, return it.
+    if (current !== event.message) {
+      return { message: current };
+    }
+
+    return undefined;
+  }
+
   // =========================================================================
   // Session Hooks
   // =========================================================================
@@ -494,6 +576,8 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     runBeforeToolCall,
     runAfterToolCall,
     runToolResultPersist,
+    // Message write hooks
+    runBeforeMessageWrite,
     // Session hooks
     runSessionStart,
     runSessionEnd,

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -309,6 +309,7 @@ export type PluginHookName =
   | "before_tool_call"
   | "after_tool_call"
   | "tool_result_persist"
+  | "before_message_write"
   | "session_start"
   | "session_end"
   | "gateway_start"
@@ -489,6 +490,18 @@ export type PluginHookToolResultPersistResult = {
   message?: AgentMessage;
 };
 
+// before_message_write hook
+export type PluginHookBeforeMessageWriteEvent = {
+  message: AgentMessage;
+  sessionKey?: string;
+  agentId?: string;
+};
+
+export type PluginHookBeforeMessageWriteResult = {
+  block?: boolean;      // If true, message is NOT written to JSONL
+  message?: AgentMessage; // Optional: modified message to write instead
+};
+
 // Session context
 export type PluginHookSessionContext = {
   agentId?: string;
@@ -571,6 +584,10 @@ export type PluginHookHandlerMap = {
     event: PluginHookToolResultPersistEvent,
     ctx: PluginHookToolResultPersistContext,
   ) => PluginHookToolResultPersistResult | void;
+  before_message_write: (
+    event: PluginHookBeforeMessageWriteEvent,
+    ctx: { agentId?: string; sessionKey?: string },
+  ) => PluginHookBeforeMessageWriteResult | void;
   session_start: (
     event: PluginHookSessionStartEvent,
     ctx: PluginHookSessionContext,


### PR DESCRIPTION
## Summary

- Adds a new `before_message_write` plugin hook that fires before any message is written to the session JSONL file
- Plugins can inspect the message and return `{ block: true }` to prevent persistence, or return a modified message
- Hook is synchronous (hot path safe) and runs handlers sequentially in priority order

## Use case

Private mode plugins need to prevent sensitive messages from being written to disk. Currently there is no way for a plugin to intercept session JSONL writes. The existing `tool_result_persist` hook only covers tool results, not user or assistant messages.

With this hook, a plugin can do:

```typescript
api.on('before_message_write', (event) => {
  if (isPrivateMode()) return { block: true };
});
```

## Changes

- `src/plugins/types.ts`: Added hook type, event/result types, handler signature
- `src/plugins/hooks.ts`: Added `runBeforeMessageWrite()` runner (sync, sequential, priority-ordered)
- `src/agents/session-tool-result-guard.ts`: Invoke hook before all 3 `originalAppend()` call sites
- `src/agents/session-tool-result-guard-wrapper.ts`: Wire hook runner to guard

## Test plan

- [ ] Verify existing session persistence works unchanged when no handler is registered
- [ ] Register a handler that returns `{ block: true }` and verify messages are not written to JSONL
- [ ] Register a handler that returns a modified message and verify the modified version is persisted
- [ ] Verify hook runs synchronously and does not impact message processing latency

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a new synchronous `before_message_write` plugin hook that intercepts session JSONL writes, allowing plugins to block or modify messages before persistence. This enables use cases like private-mode plugins that prevent sensitive messages from being written to disk.

The implementation follows the existing `tool_result_persist` hook pattern closely — synchronous execution, priority-ordered sequential handlers, and async-handler guards. The hook is integrated at all three `originalAppend` call sites in the session tool-result guard.

- **Event type declares unused fields**: `PluginHookBeforeMessageWriteEvent` includes `sessionKey` and `agentId` properties that are never populated by the call sites. These values are only available via the handler's context (second parameter). This will confuse plugin authors who reference the event type.
- **Orphaned tool results when blocking assistant messages**: If a plugin blocks an assistant message containing tool calls, the tool results may still be persisted (unless separately blocked), creating an invalid conversation history on session reload. This edge case should be documented or handled defensively.
- **No tests included**: The PR has a test plan checklist but no test files. Given the existing `tool_result_persist` hook has e2e tests, similar coverage for `before_message_write` would be valuable.

<h3>Confidence Score: 3/5</h3>

- Functional and follows existing patterns, but has a misleading event type and an edge case that could corrupt session state
- The core hook implementation is sound and mirrors the existing tool_result_persist pattern. However, the event type declaring fields that are never populated is a bug that will mislead plugin authors, and blocking assistant messages with tool calls can produce orphaned tool results in the session file. No tests are included.
- Pay close attention to `src/plugins/types.ts` (misleading event type fields) and `src/agents/session-tool-result-guard.ts` (orphaned tool result risk)

<sub>Last reviewed commit: 04994d8</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->