### PR TITLE
fix(config): default elevatedDefault to 'off' when unset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Docs: https://docs.openclaw.ai
 - CLI/QR: restore fail-fast validation for `openclaw qr --remote` when neither `gateway.remote.url` nor tailscale `serve`/`funnel` is configured, preventing unusable remote pairing QR flows. (#18166) Thanks @mbelinky.
 - OpenClawKit/iOS ChatUI: accept canonical session-key completion events for local pending runs and preserve message IDs across history refreshes, preventing stuck "thinking" state and message flicker after gateway replies. (#18165) Thanks @mbelinky.
 - iOS/Talk: harden mobile talk config handling by ignoring redacted/env-placeholder API keys, support secure local keychain override, improve accessibility motion/contrast behavior in status UI, and tighten ATS to local-network allowance. (#18163) Thanks @mbelinky.
+- Config/Elevated: default `elevatedDefault` to `"off"` when no explicit override is set, preventing all exec calls from routing through the elevated approval gate when only `tools.elevated.enabled` is true. (#18177)
 
 ## 2026.2.15
 

--- a/src/auto-reply/reply/directive-handling.levels.test.ts
+++ b/src/auto-reply/reply/directive-handling.levels.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { resolveCurrentDirectiveLevels } from "./directive-handling.levels.js";
+
+describe("resolveCurrentDirectiveLevels", () => {
+  const resolveDefaultThinkingLevel = async () => undefined;
+
+  it("returns undefined elevated level when no session or config override", async () => {
+    const result = await resolveCurrentDirectiveLevels({
+      sessionEntry: {},
+      agentCfg: {},
+      resolveDefaultThinkingLevel,
+    });
+    expect(result.currentElevatedLevel).toBeUndefined();
+  });
+
+  it("returns session elevated level when set", async () => {
+    const result = await resolveCurrentDirectiveLevels({
+      sessionEntry: { elevatedLevel: "ask" },
+      agentCfg: {},
+      resolveDefaultThinkingLevel,
+    });
+    expect(result.currentElevatedLevel).toBe("ask");
+  });
+
+  it("returns config elevatedDefault when session has no override", async () => {
+    const result = await resolveCurrentDirectiveLevels({
+      sessionEntry: {},
+      agentCfg: { elevatedDefault: "on" },
+      resolveDefaultThinkingLevel,
+    });
+    expect(result.currentElevatedLevel).toBe("on");
+  });
+
+  it("session elevated level takes precedence over config default", async () => {
+    const result = await resolveCurrentDirectiveLevels({
+      sessionEntry: { elevatedLevel: "full" },
+      agentCfg: { elevatedDefault: "ask" },
+      resolveDefaultThinkingLevel,
+    });
+    expect(result.currentElevatedLevel).toBe("full");
+  });
+
+  it("does not default elevated level to 'on' when both session and config are empty", async () => {
+    const result = await resolveCurrentDirectiveLevels({
+      sessionEntry: undefined,
+      agentCfg: undefined,
+      resolveDefaultThinkingLevel,
+    });
+    expect(result.currentElevatedLevel).toBeUndefined();
+  });
+});

--- a/src/auto-reply/reply/directive-handling.persist.ts
+++ b/src/auto-reply/reply/directive-handling.persist.ts
@@ -70,7 +70,7 @@ export async function persistInlineDirectives(params: {
     const prevElevatedLevel =
       (sessionEntry.elevatedLevel as ElevatedLevel | undefined) ??
       (agentCfg?.elevatedDefault as ElevatedLevel | undefined) ??
-      (elevatedAllowed ? ("on" as ElevatedLevel) : ("off" as ElevatedLevel));
+      "off";
     const prevReasoningLevel = (sessionEntry.reasoningLevel as ReasoningLevel | undefined) ?? "off";
     let elevatedChanged =
       directives.hasElevatedDirective &&

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -353,7 +353,7 @@ export async function resolveReplyDirectives(params: {
     ? (directives.elevatedLevel ??
       (sessionEntry?.elevatedLevel as ElevatedLevel | undefined) ??
       (agentCfg?.elevatedDefault as ElevatedLevel | undefined) ??
-      "on")
+      "off")
     : "off";
   const resolvedBlockStreaming =
     opts?.disableBlockStreaming === true

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -84,7 +84,7 @@ describe("buildStatusMessage", () => {
     expect(normalized).toContain("Runtime: direct");
     expect(normalized).toContain("Think: medium");
     expect(normalized).not.toContain("verbose");
-    expect(normalized).toContain("elevated");
+    expect(normalized).not.toContain("elevated");
     expect(normalized).toContain("Queue: collect");
   });
 

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -385,7 +385,7 @@ export function buildStatusMessage(args: StatusArgs): string {
     args.resolvedElevated ??
     args.sessionEntry?.elevatedLevel ??
     args.agent?.elevatedDefault ??
-    "on";
+    "off";
 
   const runtime = { label: resolveRuntimeLabel(args) };
 


### PR DESCRIPTION
## Summary
- Fix `elevatedDefault` incorrectly defaulting to `"on"` when `tools.elevated.enabled` is true but no explicit `elevatedDefault` is configured
- Change the fallback from `"on"` to `"off"` in three locations: runtime resolution (`get-reply-directives.ts`), change detection (`directive-handling.persist.ts`), and status display (`status.ts`)
- Add unit tests for directive level resolution

## Problem
When `tools.elevated.enabled: true` is set in `openclaw.json`, all `exec` calls are routed through the elevated approval gate (`exec.approval.request`), which times out after 120 seconds since there is no interactive host to approve them. This breaks cron jobs and non-interactive agent sessions.

Closes #18177

## Test plan
- [x] Unit tests for `resolveCurrentDirectiveLevels` (5 tests, all pass)
- [x] `status.test.ts` updated to reflect correct default (21 tests, all pass)
- [x] `agent-runner.misc.runreplyagent.test.ts` (16 tests, all pass)
- [x] `agent-runner.runreplyagent.test.ts` + `followup-runner.test.ts` (29 tests, all pass)
- [x] Verified `/bash` command `defaultLevel: "on"` is intentionally correct (user-initiated elevated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes `elevatedDefault` incorrectly defaulting to `"on"` when `tools.elevated.enabled` is true but no explicit `elevatedDefault` is configured. The change correctly updates the fallback from `"on"` to `"off"` in three locations: runtime resolution (`get-reply-directives.ts`), change detection (`directive-handling.persist.ts`), and status display (`status.ts`). This prevents cron jobs and non-interactive agent sessions from breaking due to exec calls being routed through the elevated approval gate with a 120-second timeout.

- **Core fix**: Changed the default `elevatedLevel` fallback from `"on"` to `"off"` in three files, ensuring exec calls run normally when no explicit `elevatedDefault` is configured
- **Tests added**: New `directive-handling.levels.test.ts` with 5 tests validating the resolution chain for `resolveCurrentDirectiveLevels`, plus an updated assertion in `status.test.ts`
- **Missed location**: `directive-handling.impl.ts:270-273` contains the same `elevatedAllowed ? "on" : "off"` fallback pattern for `prevElevatedLevel` that was not updated — this affects mode-switch event emission in the directive-only fast-lane path

<h3>Confidence Score: 3/5</h3>

- The core fix is correct and addresses the reported issue, but a fourth location with the same stale fallback pattern was missed.
- The three updated locations correctly change the elevated default from "on" to "off", and the fix is well-tested. However, `directive-handling.impl.ts:270-273` contains the identical `elevatedAllowed ? "on" : "off"` fallback that should also be updated for full consistency. While this missed location only affects mode-switch event emission (not the critical runtime routing), it represents an incomplete fix across the codebase.
- Pay attention to `src/auto-reply/reply/directive-handling.impl.ts` — it contains the same stale fallback pattern at line 273 that was fixed in the other three files.

<sub>Last reviewed commit: 2885ee2</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->