### PR TITLE
fix: correct Sparkle appcast version for 2026.2.15

### DIFF
--- a/appcast.xml
+++ b/appcast.xml
@@ -144,7 +144,7 @@
             <title>2026.2.15</title>
             <pubDate>Mon, 16 Feb 2026 05:04:34 +0100</pubDate>
             <link>https://raw.githubusercontent.com/openclaw/openclaw/main/appcast.xml</link>
-            <sparkle:version>11213</sparkle:version>
+            <sparkle:version>202602150</sparkle:version>
             <sparkle:shortVersionString>2026.2.15</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
             <description><![CDATA[<h2>OpenClaw 2026.2.15</h2>

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -1,7 +1,11 @@
 import { randomUUID } from "node:crypto";
 import { WebSocket, type ClientOptions, type CertMeta } from "ws";
 import type { DeviceIdentity } from "../infra/device-identity.js";
-import { loadDeviceAuthToken, storeDeviceAuthToken } from "../infra/device-auth-store.js";
+import {
+  clearDeviceAuthToken,
+  loadDeviceAuthToken,
+  storeDeviceAuthToken,
+} from "../infra/device-auth-store.js";
 import {
   loadOrCreateDeviceIdentity,
   publicKeyRawBase64UrlFromPem,
@@ -150,6 +154,16 @@ export class GatewayClient {
     this.ws.on("close", (code, reason) => {
       const reasonText = rawDataToString(reason);
       this.ws = null;
+      // If closed due to device token mismatch, clear the stored token so next attempt can get a fresh one
+      if (
+        code === 1008 &&
+        reasonText.includes("device token mismatch") &&
+        this.opts.deviceIdentity
+      ) {
+        const role = this.opts.role ?? "operator";
+        clearDeviceAuthToken({ deviceId: this.opts.deviceIdentity.deviceId, role });
+        logDebug(`cleared stale device-auth token for device ${this.opts.deviceIdentity.deviceId}`);
+      }
       this.flushPendingErrors(new Error(`gateway closed (${code}): ${reasonText}`));
       this.scheduleReconnect();
       this.opts.onClose?.(code, reasonText);


### PR DESCRIPTION
The sparkle:version was incorrectly set to '11213' instead of '202602150', causing the macOS app to not detect the 2026.2.15 update. Sparkle compares versions as strings, so '11213' < '202602140' (2026.2.14's version), preventing the update from being offered to users.

Fixes openclaw/openclaw#18178

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR contains two independent bug fixes: correcting the Sparkle appcast version from `11213` to `202602150` for the 2026.2.15 release, and clearing stale device-auth tokens when the gateway connection fails due to token mismatch. The appcast version fix ensures macOS users can detect the 2026.2.15 update (Sparkle compares versions lexicographically, so `11213` < `202602140`). The device-auth token fix prevents persistent authentication failures after re-pairing a device.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Both fixes are straightforward corrections: the appcast version change uses the correct YYYYMMDD0 format matching existing entries (202602140), and the device-auth token clearing logic follows the established pattern with proper error code checking and role handling
- No files require special attention

<sub>Last reviewed commit: e2e7827</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->