### PR TITLE
Agents: make bootstrap prompt caps opt-in by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/Chat: harden `chat.send` inbound message handling by rejecting null bytes, stripping unsafe control characters, and normalizing Unicode to NFC before dispatch. (#8593) Thanks @fr33d3m0n.
 - Gateway/Send: return an actionable error when `send` targets internal-only `webchat`, guiding callers to use `chat.send` or a deliverable channel. (#15703) Thanks @rodrigouroz.
 - Control UI: prevent stored XSS via assistant name/avatar by removing inline script injection, serving bootstrap config as JSON, and enforcing `script-src 'self'`. Thanks @Adam55A-code.
+- Agents/Context: make bootstrap prompt limits opt-in (`bootstrapMaxChars`/`bootstrapTotalMaxChars`), preserve full core bootstrap content by default, and surface both per-file and total bootstrap caps in `/context` reports.
 - Agents/Security: sanitize workspace paths before embedding into LLM prompts (strip Unicode control/format chars) to prevent instruction injection via malicious directory names. Thanks @aether-ai-agent.
 - Agents/Sandbox: clarify system prompt path guidance so sandbox `bash/exec` uses container paths (for example `/workspace`) while file tools keep host-bridge mapping, avoiding first-attempt path misses from host-only absolute paths in sandbox command execution. (#17693) Thanks @app/juniordevbot.
 - Agents/Context: apply configured model `contextWindow` overrides after provider discovery so `lookupContextTokens()` honors operator config values (including discovery-failure paths). (#17404) Thanks @michaelbship and @vignesh07.

--- a/docs/concepts/agent-workspace.md
+++ b/docs/concepts/agent-workspace.md
@@ -116,7 +116,8 @@ See [Memory](/concepts/memory) for the workflow and automatic memory flush.
 
 If any bootstrap file is missing, OpenClaw injects a "missing file" marker into
 the session and continues. Large bootstrap files are truncated when injected;
-adjust the limit with `agents.defaults.bootstrapMaxChars` (default: 20000).
+adjust limits with `agents.defaults.bootstrapMaxChars` and/or
+`agents.defaults.bootstrapTotalMaxChars` (unset = unlimited).
 `openclaw setup` can recreate missing defaults without overwriting existing
 files.
 

--- a/docs/concepts/context.md
+++ b/docs/concepts/context.md
@@ -112,7 +112,11 @@ By default, OpenClaw injects a fixed set of workspace files (if present):
 - `HEARTBEAT.md`
 - `BOOTSTRAP.md` (first-run only)
 
-Large files are truncated per-file using `agents.defaults.bootstrapMaxChars` (default `20000` chars). OpenClaw also enforces a total bootstrap injection cap across files with `agents.defaults.bootstrapTotalMaxChars` (default `24000` chars). `/context` shows **raw vs injected** sizes and whether truncation happened.
+Large files are truncated only when limits are configured. Use
+`agents.defaults.bootstrapMaxChars` for per-file limits and
+`agents.defaults.bootstrapTotalMaxChars` for total bootstrap limits (unset =
+unlimited). `/context` shows **raw vs injected** sizes and whether truncation
+happened.
 
 ## Skills: what’s injected vs loaded on-demand
 

--- a/docs/concepts/system-prompt.md
+++ b/docs/concepts/system-prompt.md
@@ -70,10 +70,11 @@ compaction.
 > are accessed on demand via the `memory_search` and `memory_get` tools, so they
 > do not count against the context window unless the model explicitly reads them.
 
-Large files are truncated with a marker. The max per-file size is controlled by
-`agents.defaults.bootstrapMaxChars` (default: 20000). Total injected bootstrap
-content across files is capped by `agents.defaults.bootstrapTotalMaxChars`
-(default: 24000). Missing files inject a short missing-file marker.
+Large files are truncated with a marker only when limits are configured. Use
+`agents.defaults.bootstrapMaxChars` for a per-file cap and
+`agents.defaults.bootstrapTotalMaxChars` for a total cap across all injected
+bootstrap files. If both are unset, bootstrap injection is unlimited. Missing
+files inject a short missing-file marker.
 
 Sub-agent sessions only inject `AGENTS.md` and `TOOLS.md` (other bootstrap files
 are filtered out to keep the sub-agent context small).

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -579,7 +579,7 @@ Disables automatic creation of workspace bootstrap files (`AGENTS.md`, `SOUL.md`
 
 ### `agents.defaults.bootstrapMaxChars`
 
-Max characters per workspace bootstrap file before truncation. Default: `20000`.
+Optional max characters per workspace bootstrap file before truncation. If unset, per-file bootstrap injection is unlimited.
 
 ```json5
 {
@@ -589,7 +589,7 @@ Max characters per workspace bootstrap file before truncation. Default: `20000`.
 
 ### `agents.defaults.bootstrapTotalMaxChars`
 
-Max total characters injected across all workspace bootstrap files. Default: `24000`.
+Optional max total characters injected across all workspace bootstrap files. If unset, total bootstrap injection is unlimited.
 
 ```json5
 {

--- a/docs/reference/token-use.md
+++ b/docs/reference/token-use.md
@@ -18,7 +18,7 @@ OpenClaw assembles its own system prompt on every run. It includes:
 - Tool list + short descriptions
 - Skills list (only metadata; instructions are loaded on demand with `read`)
 - Self-update instructions
-- Workspace + bootstrap files (`AGENTS.md`, `SOUL.md`, `TOOLS.md`, `IDENTITY.md`, `USER.md`, `HEARTBEAT.md`, `BOOTSTRAP.md` when new, plus `MEMORY.md` and/or `memory.md` when present). Large files are truncated by `agents.defaults.bootstrapMaxChars` (default: 20000), and total bootstrap injection is capped by `agents.defaults.bootstrapTotalMaxChars` (default: 24000). `memory/*.md` files are on-demand via memory tools and are not auto-injected.
+- Workspace + bootstrap files (`AGENTS.md`, `SOUL.md`, `TOOLS.md`, `IDENTITY.md`, `USER.md`, `HEARTBEAT.md`, `BOOTSTRAP.md` when new, plus `MEMORY.md` and/or `memory.md` when present). Per-file and total bootstrap truncation only apply when configured via `agents.defaults.bootstrapMaxChars` and/or `agents.defaults.bootstrapTotalMaxChars` (unset = unlimited). `memory/*.md` files are on-demand via memory tools and are not auto-injected.
 - Time (UTC + user timezone)
 - Reply tags + heartbeat behavior
 - Runtime metadata (host/OS/model/thinking)

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -1,7 +1,5 @@
 export {
   buildBootstrapContextFiles,
-  DEFAULT_BOOTSTRAP_MAX_CHARS,
-  DEFAULT_BOOTSTRAP_TOTAL_MAX_CHARS,
   ensureSessionHeader,
   resolveBootstrapMaxChars,
   resolveBootstrapTotalMaxChars,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -39,6 +39,7 @@ import { createOllamaStreamFn, OLLAMA_NATIVE_BASE_URL } from "../../ollama-strea
 import {
   isCloudCodeAssistFormatError,
   resolveBootstrapMaxChars,
+  resolveBootstrapTotalMaxChars,
   validateAnthropicTurns,
   validateGeminiTurns,
 } from "../../pi-embedded-helpers.js";
@@ -462,6 +463,7 @@ export async function runEmbeddedAttempt(
       model: params.modelId,
       workspaceDir: effectiveWorkspace,
       bootstrapMaxChars: resolveBootstrapMaxChars(params.config),
+      bootstrapTotalMaxChars: resolveBootstrapTotalMaxChars(params.config),
       sandbox: (() => {
         const runtime = resolveSandboxRuntimeStatus({
           cfg: params.config,

--- a/src/agents/system-prompt-report.test.ts
+++ b/src/agents/system-prompt-report.test.ts
@@ -44,4 +44,40 @@ describe("buildSystemPromptReport", () => {
 
     expect(report.injectedWorkspaceFiles[0]?.injectedChars).toBe("trimmed".length);
   });
+
+  it("marks workspace files truncated when injected chars are smaller than raw chars", () => {
+    const file = makeBootstrapFile({
+      path: "/tmp/workspace/policies/AGENTS.md",
+      content: "abcdefghijklmnopqrstuvwxyz",
+    });
+    const report = buildSystemPromptReport({
+      source: "run",
+      generatedAt: 0,
+      systemPrompt: "system",
+      bootstrapFiles: [file],
+      injectedFiles: [{ path: "/tmp/workspace/policies/AGENTS.md", content: "trimmed" }],
+      skillsPrompt: "",
+      tools: [],
+    });
+
+    expect(report.injectedWorkspaceFiles[0]?.truncated).toBe(true);
+  });
+
+  it("includes both bootstrap caps in the report payload", () => {
+    const file = makeBootstrapFile({ path: "/tmp/workspace/policies/AGENTS.md" });
+    const report = buildSystemPromptReport({
+      source: "run",
+      generatedAt: 0,
+      bootstrapMaxChars: 11_111,
+      bootstrapTotalMaxChars: 22_222,
+      systemPrompt: "system",
+      bootstrapFiles: [file],
+      injectedFiles: [{ path: "AGENTS.md", content: "trimmed" }],
+      skillsPrompt: "",
+      tools: [],
+    });
+
+    expect(report.bootstrapMaxChars).toBe(11_111);
+    expect(report.bootstrapTotalMaxChars).toBe(22_222);
+  });
 });

--- a/src/agents/system-prompt-report.ts
+++ b/src/agents/system-prompt-report.ts
@@ -39,7 +39,6 @@ function parseSkillBlocks(skillsPrompt: string): Array<{ name: string; blockChar
 function buildInjectedWorkspaceFiles(params: {
   bootstrapFiles: WorkspaceBootstrapFile[];
   injectedFiles: EmbeddedContextFile[];
-  bootstrapMaxChars: number;
 }): SessionSystemPromptReport["injectedWorkspaceFiles"] {
   const injectedByPath = new Map(params.injectedFiles.map((f) => [f.path, f.content]));
   const injectedByBaseName = new Map<string, string>();
@@ -57,7 +56,7 @@ function buildInjectedWorkspaceFiles(params: {
       injectedByPath.get(file.name) ??
       injectedByBaseName.get(file.name);
     const injectedChars = injected ? injected.length : 0;
-    const truncated = !file.missing && rawChars > params.bootstrapMaxChars;
+    const truncated = !file.missing && injectedChars < rawChars;
     return {
       name: file.name,
       path: file.path,
@@ -118,7 +117,8 @@ export function buildSystemPromptReport(params: {
   provider?: string;
   model?: string;
   workspaceDir?: string;
-  bootstrapMaxChars: number;
+  bootstrapMaxChars?: number;
+  bootstrapTotalMaxChars?: number;
   sandbox?: SessionSystemPromptReport["sandbox"];
   systemPrompt: string;
   bootstrapFiles: WorkspaceBootstrapFile[];
@@ -148,6 +148,7 @@ export function buildSystemPromptReport(params: {
     model: params.model,
     workspaceDir: params.workspaceDir,
     bootstrapMaxChars: params.bootstrapMaxChars,
+    bootstrapTotalMaxChars: params.bootstrapTotalMaxChars,
     sandbox: params.sandbox,
     systemPrompt: {
       chars: systemPrompt.length,
@@ -157,7 +158,6 @@ export function buildSystemPromptReport(params: {
     injectedWorkspaceFiles: buildInjectedWorkspaceFiles({
       bootstrapFiles: params.bootstrapFiles,
       injectedFiles: params.injectedFiles,
-      bootstrapMaxChars: params.bootstrapMaxChars,
     }),
     skills: {
       promptChars: params.skillsPrompt.length,

--- a/src/auto-reply/reply/commands-context-report.ts
+++ b/src/auto-reply/reply/commands-context-report.ts
@@ -4,7 +4,10 @@ import type { HandleCommandsParams } from "./commands-types.js";
 import { resolveSessionAgentIds } from "../../agents/agent-scope.js";
 import { resolveBootstrapContextForRun } from "../../agents/bootstrap-files.js";
 import { resolveDefaultModelForAgent } from "../../agents/model-selection.js";
-import { resolveBootstrapMaxChars } from "../../agents/pi-embedded-helpers.js";
+import {
+  resolveBootstrapMaxChars,
+  resolveBootstrapTotalMaxChars,
+} from "../../agents/pi-embedded-helpers.js";
 import { createOpenClawCodingTools } from "../../agents/pi-tools.js";
 import { resolveSandboxRuntimeStatus } from "../../agents/sandbox.js";
 import { buildWorkspaceSkillSnapshot } from "../../agents/skills.js";
@@ -59,6 +62,7 @@ async function resolveContextReport(
 
   const workspaceDir = params.workspaceDir;
   const bootstrapMaxChars = resolveBootstrapMaxChars(params.cfg);
+  const bootstrapTotalMaxChars = resolveBootstrapTotalMaxChars(params.cfg);
   const { bootstrapFiles, contextFiles: injectedFiles } = await resolveBootstrapContextForRun({
     workspaceDir,
     config: params.cfg,
@@ -169,6 +173,7 @@ async function resolveContextReport(
     model: params.model,
     workspaceDir,
     bootstrapMaxChars,
+    bootstrapTotalMaxChars,
     sandbox: { mode: sandboxRuntime.mode, sandboxed: sandboxRuntime.sandboxed },
     systemPrompt,
     bootstrapFiles,
@@ -249,7 +254,11 @@ export async function buildContextReply(params: HandleCommandsParams): Promise<R
   const bootstrapMaxLabel =
     typeof report.bootstrapMaxChars === "number"
       ? `${formatInt(report.bootstrapMaxChars)} chars`
-      : "? chars";
+      : "unlimited (unset)";
+  const bootstrapTotalLabel =
+    typeof report.bootstrapTotalMaxChars === "number"
+      ? `${formatInt(report.bootstrapTotalMaxChars)} chars`
+      : "unlimited (unset)";
 
   const totalsLine =
     session.totalTokens != null
@@ -280,6 +289,7 @@ export async function buildContextReply(params: HandleCommandsParams): Promise<R
         "🧠 Context breakdown (detailed)",
         `Workspace: ${workspaceLabel}`,
         `Bootstrap max/file: ${bootstrapMaxLabel}`,
+        `Bootstrap max/total: ${bootstrapTotalLabel}`,
         sandboxLine,
         systemPromptLine,
         "",
@@ -317,6 +327,7 @@ export async function buildContextReply(params: HandleCommandsParams): Promise<R
       "🧠 Context breakdown",
       `Workspace: ${workspaceLabel}`,
       `Bootstrap max/file: ${bootstrapMaxLabel}`,
+      `Bootstrap max/total: ${bootstrapTotalLabel}`,
       sandboxLine,
       systemPromptLine,
       "",

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -143,9 +143,9 @@ export const FIELD_HELP: Record<string, string> = {
   "auth.cooldowns.billingMaxHours": "Cap (hours) for billing backoff (default: 24).",
   "auth.cooldowns.failureWindowHours": "Failure window (hours) for backoff counters (default: 24).",
   "agents.defaults.bootstrapMaxChars":
-    "Max characters of each workspace bootstrap file injected into the system prompt before truncation (default: 20000).",
+    "Optional max characters of each workspace bootstrap file injected into the system prompt before truncation.",
   "agents.defaults.bootstrapTotalMaxChars":
-    "Max total characters across all injected workspace bootstrap files (default: 24000).",
+    "Optional max total characters across all injected workspace bootstrap files.",
   "agents.defaults.repoRoot":
     "Optional repository root shown in the system prompt runtime line (overrides auto-detect).",
   "agents.defaults.envelopeTimezone":

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -143,9 +143,9 @@ export const FIELD_HELP: Record<string, string> = {
   "auth.cooldowns.billingMaxHours": "Cap (hours) for billing backoff (default: 24).",
   "auth.cooldowns.failureWindowHours": "Failure window (hours) for backoff counters (default: 24).",
   "agents.defaults.bootstrapMaxChars":
-    "Optional max characters of each workspace bootstrap file injected into the system prompt before truncation.",
+    "Optional max characters of each workspace bootstrap file injected into the system prompt before truncation (unset: unlimited).",
   "agents.defaults.bootstrapTotalMaxChars":
-    "Optional max total characters across all injected workspace bootstrap files.",
+    "Optional max total characters across all injected workspace bootstrap files (unset: unlimited).",
   "agents.defaults.repoRoot":
     "Optional repository root shown in the system prompt runtime line (overrides auto-detect).",
   "agents.defaults.envelopeTimezone":

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -159,6 +159,7 @@ export type SessionSystemPromptReport = {
   model?: string;
   workspaceDir?: string;
   bootstrapMaxChars?: number;
+  bootstrapTotalMaxChars?: number;
   sandbox?: {
     mode?: string;
     sandboxed?: boolean;

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -134,9 +134,9 @@ export type AgentDefaultsConfig = {
   repoRoot?: string;
   /** Skip bootstrap (BOOTSTRAP.md creation, etc.) for pre-configured deployments. */
   skipBootstrap?: boolean;
-  /** Max chars for injected bootstrap files before truncation (default: 20000). */
+  /** Optional max chars for each injected bootstrap file before truncation. */
   bootstrapMaxChars?: number;
-  /** Max total chars across all injected bootstrap files (default: 24000). */
+  /** Optional max total chars across all injected bootstrap files. */
   bootstrapTotalMaxChars?: number;
   /** Optional IANA timezone for the user (used in system prompt; defaults to host timezone). */
   userTimezone?: string;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: bootstrap context limits (`agents.defaults.bootstrapMaxChars`/`bootstrapTotalMaxChars`) were applied by default, which could truncate core files (for example `SOUL.md`, `IDENTITY.md`, `USER.md`) even when users never configured limits.
- Why it matters: core persona/identity context should stay complete by default; truncation should only happen when an operator explicitly opts in.
- What changed: made both bootstrap limits opt-in (`unset => unlimited`), preserved strict truncation behavior when limits are configured, updated `/context` reporting to surface both per-file and total caps, and aligned docs/help/changelog.
- What did NOT change (scope boundary): no change to bootstrap file discovery/order/filtering, no change to system-prompt section layout, no new tools/permissions/network paths.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #None
- Related #16539

## User-visible / Behavior Changes

- By default, bootstrap files are no longer truncated/capped unless users explicitly set `agents.defaults.bootstrapMaxChars` and/or `agents.defaults.bootstrapTotalMaxChars`.
- `/context list` and `/context detail` now show both `Bootstrap max/file` and `Bootstrap max/total` values.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/Bun toolchain
- Model/provider: N/A (prompt assembly/reporting path)
- Integration/channel (if any): N/A
- Relevant config (redacted): tested unset limits and explicit configured limits

### Steps

1. Build bootstrap context with large files and no bootstrap limit config.
2. Inspect injected context and `/context` report fields.
3. Re-run with configured per-file and total limits.

### Expected

- Unset limits keep full bootstrap content.
- Configured limits still truncate/cap deterministically.
- `/context` clearly reports configured/unset per-file and total limits.

### Actual

- Matches expected.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: default-unlimited bootstrap injection; configured per-file cap; configured total cap; strict total cap behavior with truncation marker overhead; `/context` cap labels.
- Edge cases checked: tiny total budgets; missing-file marker handling under budget; report truncation detection based on injected-vs-raw chars.
- What you did **not** verify: full end-to-end live channel run with extremely large real-world bootstrap files.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: set explicit limits (`agents.defaults.bootstrapMaxChars` and/or `agents.defaults.bootstrapTotalMaxChars`) or revert this PR.
- Files/config to restore: `src/agents/pi-embedded-helpers/bootstrap.ts`, `src/agents/system-prompt-report.ts`, `/context` reporting file.
- Known bad symptoms reviewers should watch for: unexpected context/token growth when limits are intentionally left unset on large workspaces.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: sessions with very large bootstrap files may consume more context by default.
  - Mitigation: explicit configurable per-file and total caps remain supported; docs and `/context` now make cap status visible.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Makes bootstrap prompt limits (`bootstrapMaxChars` / `bootstrapTotalMaxChars`) opt-in by default, so core bootstrap files (e.g. `SOUL.md`, `IDENTITY.md`, `USER.md`) are no longer truncated unless an operator explicitly configures limits.

- Removes hardcoded defaults (`DEFAULT_BOOTSTRAP_MAX_CHARS` = 20,000 and `DEFAULT_BOOTSTRAP_TOTAL_MAX_CHARS` = 24,000) and makes both resolve functions return `undefined` when unconfigured, causing `buildBootstrapContextFiles` to skip all truncation logic.
- Improves truncation detection in `buildSystemPromptReport` from config-based comparison (`rawChars > bootstrapMaxChars`) to actual observation-based detection (`injectedChars < rawChars`), which is more accurate and no longer depends on the config value being defined.
- Adds `bootstrapTotalMaxChars` to the system prompt report type and plumbs it through `attempt.ts` and `commands-context-report.ts`, so `/context` now surfaces both per-file and total bootstrap caps.
- Docs, help text, and changelog are consistently updated to reflect "unset = unlimited" semantics.
- Test coverage is updated with cases for both unconfigured (no truncation) and configured (truncation applies) scenarios.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it cleanly removes hardcoded defaults in favor of opt-in limits with consistent type handling and good test coverage.
- The changes are well-structured and narrowly scoped. All callers of the modified resolve functions handle the new number | undefined return type correctly. The truncation detection improvement in system-prompt-report.ts is more accurate than the previous config-based check. Test coverage is thorough, covering both the default-unlimited and configured-limits paths. Type changes propagate consistently through the config types, report types, and all consumer sites. No new security surface, no behavioral regressions for users who explicitly configure limits.
- No files require special attention. The core logic in `src/agents/pi-embedded-helpers/bootstrap.ts` has the most significant changes but is well-tested.

<sub>Last reviewed commit: a2df9de</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->