### PR TITLE
feat(memory): add native Telnyx embedding provider

### DIFF
--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -92,7 +92,8 @@ Defaults:
   2. `openai` if an OpenAI key can be resolved.
   3. `gemini` if a Gemini key can be resolved.
   4. `voyage` if a Voyage key can be resolved.
-  5. Otherwise memory search stays disabled until configured.
+  5. `telnyx` if a Telnyx key can be resolved.
+  6. Otherwise memory search stays disabled until configured.
 - Local mode uses node-llama-cpp and may require `pnpm approve-builds`.
 - Uses sqlite-vec (when available) to accelerate vector search inside SQLite.
 
@@ -101,8 +102,35 @@ resolves keys from auth profiles, `models.providers.*.apiKey`, or environment
 variables. Codex OAuth only covers chat/completions and does **not** satisfy
 embeddings for memory search. For Gemini, use `GEMINI_API_KEY` or
 `models.providers.google.apiKey`. For Voyage, use `VOYAGE_API_KEY` or
-`models.providers.voyage.apiKey`. When using a custom OpenAI-compatible endpoint,
+`models.providers.voyage.apiKey`. For Telnyx, use `TELNYX_API_KEY` or
+`models.providers.telnyx.apiKey`. When using a custom OpenAI-compatible endpoint,
 set `memorySearch.remote.apiKey` (and optional `memorySearch.remote.headers`).
+
+### Telnyx embeddings (native)
+
+Set the provider to `telnyx` to use the Telnyx embeddings API directly:
+
+```json5
+agents: {
+  defaults: {
+    memorySearch: {
+      provider: "telnyx",
+      model: "thenlper/gte-large",   // or "intfloat/multilingual-e5-large" for multilingual
+      remote: {
+        apiKey: "YOUR_TELNYX_API_KEY"
+      }
+    }
+  }
+}
+```
+
+Notes:
+
+- `remote.baseUrl` is optional (defaults to `https://api.telnyx.com/v2/ai/openai`).
+- `remote.headers` lets you add extra headers if needed.
+- Default model: `thenlper/gte-large` (1024 dimensions).
+- Token limit: 512 per chunk (enforced automatically).
+- Set `TELNYX_API_KEY` in your environment, or use `remote.apiKey` in config.
 
 ### QMD backend (experimental)
 
@@ -315,7 +343,7 @@ If you don't want to set an API key, use `memorySearch.provider = "local"` or se
 
 Fallbacks:
 
-- `memorySearch.fallback` can be `openai`, `gemini`, `local`, or `none`.
+- `memorySearch.fallback` can be `openai`, `gemini`, `voyage`, `telnyx`, `local`, or `none`.
 - The fallback provider is only used when the primary embedding provider fails.
 
 Batch indexing (OpenAI + Gemini + Voyage):

--- a/docs/reference/api-usage-costs.md
+++ b/docs/reference/api-usage-costs.md
@@ -67,6 +67,7 @@ Semantic memory search uses **embedding APIs** when configured for remote provid
 - `memorySearch.provider = "openai"` → OpenAI embeddings
 - `memorySearch.provider = "gemini"` → Gemini embeddings
 - `memorySearch.provider = "voyage"` → Voyage embeddings
+- `memorySearch.provider = "telnyx"` → Telnyx embeddings
 - Optional fallback to a remote provider if local embeddings fail
 
 You can keep it local with `memorySearch.provider = "local"` (no API usage).

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -9,7 +9,7 @@ export type ResolvedMemorySearchConfig = {
   enabled: boolean;
   sources: Array<"memory" | "sessions">;
   extraPaths: string[];
-  provider: "openai" | "local" | "gemini" | "voyage" | "auto";
+  provider: "openai" | "local" | "gemini" | "voyage" | "telnyx" | "auto";
   remote?: {
     baseUrl?: string;
     apiKey?: string;
@@ -25,7 +25,7 @@ export type ResolvedMemorySearchConfig = {
   experimental: {
     sessionMemory: boolean;
   };
-  fallback: "openai" | "gemini" | "local" | "voyage" | "none";
+  fallback: "openai" | "gemini" | "local" | "voyage" | "telnyx" | "none";
   model: string;
   local: {
     modelPath?: string;
@@ -81,6 +81,7 @@ export type ResolvedMemorySearchConfig = {
 const DEFAULT_OPENAI_MODEL = "text-embedding-3-small";
 const DEFAULT_GEMINI_MODEL = "gemini-embedding-001";
 const DEFAULT_VOYAGE_MODEL = "voyage-4-large";
+const DEFAULT_TELNYX_MODEL = "thenlper/gte-large";
 const DEFAULT_CHUNK_TOKENS = 400;
 const DEFAULT_CHUNK_OVERLAP = 80;
 const DEFAULT_WATCH_DEBOUNCE_MS = 1500;
@@ -153,6 +154,7 @@ function mergeConfig(
     provider === "openai" ||
     provider === "gemini" ||
     provider === "voyage" ||
+    provider === "telnyx" ||
     provider === "auto";
   const batch = {
     enabled: overrideRemote?.batch?.enabled ?? defaultRemote?.batch?.enabled ?? false,
@@ -182,7 +184,9 @@ function mergeConfig(
         ? DEFAULT_OPENAI_MODEL
         : provider === "voyage"
           ? DEFAULT_VOYAGE_MODEL
-          : undefined;
+          : provider === "telnyx"
+            ? DEFAULT_TELNYX_MODEL
+            : undefined;
   const model = overrides?.model ?? defaults?.model ?? modelDefault ?? "";
   const local = {
     modelPath: overrides?.local?.modelPath ?? defaults?.local?.modelPath,

--- a/src/agents/model-auth.e2e.test.ts
+++ b/src/agents/model-auth.e2e.test.ts
@@ -388,6 +388,27 @@ describe("getApiKeyForModel", () => {
     }
   });
 
+  it("accepts TELNYX_API_KEY for telnyx", async () => {
+    const previous = process.env.TELNYX_API_KEY;
+
+    try {
+      process.env.TELNYX_API_KEY = "telnyx-test-key";
+
+      const resolved = await resolveApiKeyForProvider({
+        provider: "telnyx",
+        store: { version: 1, profiles: {} },
+      });
+      expect(resolved.apiKey).toBe("telnyx-test-key");
+      expect(resolved.source).toContain("TELNYX_API_KEY");
+    } finally {
+      if (previous === undefined) {
+        delete process.env.TELNYX_API_KEY;
+      } else {
+        process.env.TELNYX_API_KEY = previous;
+      }
+    }
+  });
+
   it("strips embedded CR/LF from ANTHROPIC_API_KEY", async () => {
     const previous = process.env.ANTHROPIC_API_KEY;
 

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -295,6 +295,7 @@ export function resolveEnvApiKey(provider: string): EnvApiKeyResult | null {
     openai: "OPENAI_API_KEY",
     google: "GEMINI_API_KEY",
     voyage: "VOYAGE_API_KEY",
+    telnyx: "TELNYX_API_KEY",
     groq: "GROQ_API_KEY",
     deepgram: "DEEPGRAM_API_KEY",
     cerebras: "CEREBRAS_API_KEY",

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -68,7 +68,7 @@ export async function noteMemorySearchHealth(cfg: OpenClawConfig): Promise<void>
   if (hasLocalEmbeddings(resolved.local)) {
     return;
   }
-  for (const provider of ["openai", "gemini", "voyage"] as const) {
+  for (const provider of ["openai", "gemini", "voyage", "telnyx"] as const) {
     if (hasRemoteApiKey || (await hasApiKeyForProvider(provider, cfg, agentDir))) {
       return;
     }
@@ -80,7 +80,7 @@ export async function noteMemorySearchHealth(cfg: OpenClawConfig): Promise<void>
       "Semantic recall will not work without an embedding provider.",
       "",
       "Fix (pick one):",
-      "- Set OPENAI_API_KEY or GEMINI_API_KEY in your environment",
+      "- Set OPENAI_API_KEY, GEMINI_API_KEY, VOYAGE_API_KEY, or TELNYX_API_KEY in your environment",
       `- Add credentials: ${formatCliCommand("openclaw auth add --provider openai")}`,
       `- For local embeddings: configure agents.defaults.memorySearch.provider and local model path`,
       `- To disable: ${formatCliCommand("openclaw config set agents.defaults.memorySearch.enabled false")}`,
@@ -111,7 +111,7 @@ function hasLocalEmbeddings(local: { modelPath?: string }): boolean {
 }
 
 async function hasApiKeyForProvider(
-  provider: "openai" | "gemini" | "voyage",
+  provider: "openai" | "gemini" | "voyage" | "telnyx",
   cfg: OpenClawConfig,
   agentDir: string,
 ): Promise<boolean> {
@@ -133,6 +133,8 @@ function providerEnvVar(provider: string): string {
       return "GEMINI_API_KEY";
     case "voyage":
       return "VOYAGE_API_KEY";
+    case "telnyx":
+      return "TELNYX_API_KEY";
     default:
       return `${provider.toUpperCase()}_API_KEY`;
   }

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -36,4 +36,32 @@ describe("config schema regressions", () => {
 
     expect(res.ok).toBe(true);
   });
+
+  it('accepts memorySearch provider "telnyx"', () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          memorySearch: {
+            provider: "telnyx",
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it('accepts memorySearch fallback "telnyx"', () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          memorySearch: {
+            fallback: "telnyx",
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
 });

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -181,7 +181,7 @@ export const FIELD_HELP: Record<string, string> = {
   "agents.defaults.memorySearch.experimental.sessionMemory":
     "Enable experimental session transcript indexing for memory search (default: false).",
   "agents.defaults.memorySearch.provider":
-    'Embedding provider ("openai", "gemini", "voyage", or "local").',
+    'Embedding provider ("openai", "gemini", "voyage", "telnyx", or "local").',
   "agents.defaults.memorySearch.remote.baseUrl":
     "Custom base URL for remote embeddings (OpenAI-compatible proxies or Gemini overrides).",
   "agents.defaults.memorySearch.remote.apiKey": "Custom API key for the remote embedding provider.",

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -282,7 +282,7 @@ export type MemorySearchConfig = {
     sessionMemory?: boolean;
   };
   /** Embedding provider mode. */
-  provider?: "openai" | "gemini" | "local" | "voyage";
+  provider?: "openai" | "gemini" | "local" | "voyage" | "telnyx";
   remote?: {
     baseUrl?: string;
     apiKey?: string;
@@ -301,7 +301,7 @@ export type MemorySearchConfig = {
     };
   };
   /** Fallback behavior when embeddings fail. */
-  fallback?: "openai" | "gemini" | "local" | "voyage" | "none";
+  fallback?: "openai" | "gemini" | "local" | "voyage" | "telnyx" | "none";
   /** Embedding model id (remote) or alias (local). */
   model?: string;
   /** Local embedding settings (node-llama-cpp). */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -464,7 +464,13 @@ export const MemorySearchSchema = z
       .strict()
       .optional(),
     provider: z
-      .union([z.literal("openai"), z.literal("local"), z.literal("gemini"), z.literal("voyage")])
+      .union([
+        z.literal("openai"),
+        z.literal("local"),
+        z.literal("gemini"),
+        z.literal("voyage"),
+        z.literal("telnyx"),
+      ])
       .optional(),
     remote: z
       .object({
@@ -490,6 +496,7 @@ export const MemorySearchSchema = z
         z.literal("gemini"),
         z.literal("local"),
         z.literal("voyage"),
+        z.literal("telnyx"),
         z.literal("none"),
       ])
       .optional(),

--- a/src/memory/embedding-model-limits.ts
+++ b/src/memory/embedding-model-limits.ts
@@ -10,6 +10,8 @@ const KNOWN_EMBEDDING_MAX_INPUT_TOKENS: Record<string, number> = {
   "voyage:voyage-3": 32000,
   "voyage:voyage-3-lite": 16000,
   "voyage:voyage-code-3": 32000,
+  "telnyx:thenlper/gte-large": 512,
+  "telnyx:intfloat/multilingual-e5-large": 512,
 };
 
 export function resolveEmbeddingMaxInputTokens(provider: EmbeddingProvider): number {
@@ -29,6 +31,10 @@ export function resolveEmbeddingMaxInputTokens(provider: EmbeddingProvider): num
   // using the OpenAI default for providers with much smaller limits.
   if (provider.id.toLowerCase() === "gemini") {
     return 2048;
+  }
+
+  if (provider.id.toLowerCase() === "telnyx") {
+    return 512;
   }
 
   return DEFAULT_EMBEDDING_MAX_INPUT_TOKENS;

--- a/src/memory/embeddings-remote-client.ts
+++ b/src/memory/embeddings-remote-client.ts
@@ -1,7 +1,7 @@
 import { requireApiKey, resolveApiKeyForProvider } from "../agents/model-auth.js";
 import type { EmbeddingProviderOptions } from "./embeddings.js";
 
-type RemoteEmbeddingProviderId = "openai" | "voyage";
+type RemoteEmbeddingProviderId = "openai" | "voyage" | "telnyx";
 
 export async function resolveRemoteEmbeddingBearerClient(params: {
   provider: RemoteEmbeddingProviderId;

--- a/src/memory/embeddings-telnyx.test.ts
+++ b/src/memory/embeddings-telnyx.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../agents/model-auth.js", () => ({
+  resolveApiKeyForProvider: vi.fn(),
+  requireApiKey: (auth: { apiKey?: string; mode?: string }, provider: string) => {
+    if (auth?.apiKey) {
+      return auth.apiKey;
+    }
+    throw new Error(`No API key resolved for provider "${provider}" (auth mode: ${auth?.mode}).`);
+  },
+}));
+
+const createFetchMock = () =>
+  vi.fn(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({ data: [{ embedding: [0.1, 0.2, 0.3] }] }),
+  })) as unknown as typeof fetch;
+
+describe("telnyx embedding provider", () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+    vi.resetModules();
+    vi.unstubAllGlobals();
+  });
+
+  it("configures client with correct defaults and headers", async () => {
+    vi.stubGlobal("fetch", createFetchMock());
+
+    const { createTelnyxEmbeddingProvider } = await import("./embeddings-telnyx.js");
+    const authModule = await import("../agents/model-auth.js");
+
+    vi.mocked(authModule.resolveApiKeyForProvider).mockResolvedValue({
+      apiKey: "telnyx-key-123",
+      mode: "api-key",
+      source: "test",
+    });
+
+    const result = await createTelnyxEmbeddingProvider({
+      config: {} as never,
+      provider: "telnyx",
+      model: "thenlper/gte-large",
+      fallback: "none",
+    });
+
+    await result.provider.embedQuery("test query");
+
+    expect(authModule.resolveApiKeyForProvider).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: "telnyx" }),
+    );
+
+    const [url, init] = vi.mocked(fetch).mock.calls[0] ?? [];
+    expect(url).toBe("https://api.telnyx.com/v2/ai/openai/embeddings");
+
+    const headers = (init?.headers ?? {}) as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer telnyx-key-123");
+    expect(headers["Content-Type"]).toBe("application/json");
+
+    const body = JSON.parse(init?.body as string);
+    expect(body).toEqual({
+      model: "thenlper/gte-large",
+      input: ["test query"],
+    });
+  });
+
+  it("respects remote overrides for baseUrl and apiKey", async () => {
+    vi.stubGlobal("fetch", createFetchMock());
+
+    const { createTelnyxEmbeddingProvider } = await import("./embeddings-telnyx.js");
+
+    const result = await createTelnyxEmbeddingProvider({
+      config: {} as never,
+      provider: "telnyx",
+      model: "intfloat/multilingual-e5-large",
+      fallback: "none",
+      remote: {
+        baseUrl: "https://proxy.example.com",
+        apiKey: "remote-override-key",
+        headers: { "X-Custom": "123" },
+      },
+    });
+
+    await result.provider.embedQuery("test");
+
+    const [url, init] = vi.mocked(fetch).mock.calls[0] ?? [];
+    expect(url).toBe("https://proxy.example.com/embeddings");
+
+    const headers = (init?.headers ?? {}) as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer remote-override-key");
+    expect(headers["X-Custom"]).toBe("123");
+  });
+
+  it("does not include input_type for embedBatch", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          data: [{ embedding: [0.1, 0.2] }, { embedding: [0.3, 0.4] }],
+        }),
+      })) as unknown as typeof fetch,
+    );
+
+    const { createTelnyxEmbeddingProvider } = await import("./embeddings-telnyx.js");
+    const authModule = await import("../agents/model-auth.js");
+
+    vi.mocked(authModule.resolveApiKeyForProvider).mockResolvedValue({
+      apiKey: "telnyx-key-123",
+      mode: "api-key",
+      source: "test",
+    });
+
+    const result = await createTelnyxEmbeddingProvider({
+      config: {} as never,
+      provider: "telnyx",
+      model: "thenlper/gte-large",
+      fallback: "none",
+    });
+
+    await result.provider.embedBatch(["doc1", "doc2"]);
+
+    const [, init] = vi.mocked(fetch).mock.calls[0] ?? [];
+    const body = JSON.parse(init?.body as string);
+    expect(body).toEqual({
+      model: "thenlper/gte-large",
+      input: ["doc1", "doc2"],
+    });
+    expect(body).not.toHaveProperty("input_type");
+  });
+
+  it("normalizes model names", async () => {
+    const { normalizeTelnyxModel } = await import("./embeddings-telnyx.js");
+    expect(normalizeTelnyxModel("telnyx/gte-large")).toBe("gte-large");
+    expect(normalizeTelnyxModel("thenlper/gte-large")).toBe("thenlper/gte-large");
+    expect(normalizeTelnyxModel("  intfloat/multilingual-e5-large  ")).toBe(
+      "intfloat/multilingual-e5-large",
+    );
+    expect(normalizeTelnyxModel("")).toBe("thenlper/gte-large"); // Default
+  });
+});

--- a/src/memory/embeddings-telnyx.ts
+++ b/src/memory/embeddings-telnyx.ts
@@ -1,0 +1,74 @@
+import { resolveRemoteEmbeddingBearerClient } from "./embeddings-remote-client.js";
+import { fetchRemoteEmbeddingVectors } from "./embeddings-remote-fetch.js";
+import type { EmbeddingProvider, EmbeddingProviderOptions } from "./embeddings.js";
+
+export type TelnyxEmbeddingClient = {
+  baseUrl: string;
+  headers: Record<string, string>;
+  model: string;
+};
+
+export const DEFAULT_TELNYX_EMBEDDING_MODEL = "thenlper/gte-large";
+const DEFAULT_TELNYX_BASE_URL = "https://api.telnyx.com/v2/ai/openai";
+
+export function normalizeTelnyxModel(model: string): string {
+  const trimmed = model.trim();
+  if (!trimmed) {
+    return DEFAULT_TELNYX_EMBEDDING_MODEL;
+  }
+  if (trimmed.startsWith("telnyx/")) {
+    return trimmed.slice("telnyx/".length);
+  }
+  return trimmed;
+}
+
+export async function createTelnyxEmbeddingProvider(
+  options: EmbeddingProviderOptions,
+): Promise<{ provider: EmbeddingProvider; client: TelnyxEmbeddingClient }> {
+  const client = await resolveTelnyxEmbeddingClient(options);
+  const url = `${client.baseUrl.replace(/\/$/, "")}/embeddings`;
+
+  const embed = async (input: string[]): Promise<number[][]> => {
+    if (input.length === 0) {
+      return [];
+    }
+    const body = {
+      model: client.model,
+      input,
+    };
+
+    return await fetchRemoteEmbeddingVectors({
+      url,
+      headers: client.headers,
+      body,
+      errorPrefix: "telnyx embeddings failed",
+    });
+  };
+
+  return {
+    provider: {
+      id: "telnyx",
+      model: client.model,
+      // maxInputTokens resolved from KNOWN_EMBEDDING_MAX_INPUT_TOKENS
+      // in embedding-model-limits.ts (single source of truth)
+      embedQuery: async (text) => {
+        const [vec] = await embed([text]);
+        return vec ?? [];
+      },
+      embedBatch: async (texts) => embed(texts),
+    },
+    client,
+  };
+}
+
+export async function resolveTelnyxEmbeddingClient(
+  options: EmbeddingProviderOptions,
+): Promise<TelnyxEmbeddingClient> {
+  const { baseUrl, headers } = await resolveRemoteEmbeddingBearerClient({
+    provider: "telnyx",
+    options,
+    defaultBaseUrl: DEFAULT_TELNYX_BASE_URL,
+  });
+  const model = normalizeTelnyxModel(options.model);
+  return { baseUrl, headers, model };
+}

--- a/src/memory/embeddings.ts
+++ b/src/memory/embeddings.ts
@@ -5,6 +5,7 @@ import { formatErrorMessage } from "../infra/errors.js";
 import { resolveUserPath } from "../utils.js";
 import { createGeminiEmbeddingProvider, type GeminiEmbeddingClient } from "./embeddings-gemini.js";
 import { createOpenAiEmbeddingProvider, type OpenAiEmbeddingClient } from "./embeddings-openai.js";
+import { createTelnyxEmbeddingProvider, type TelnyxEmbeddingClient } from "./embeddings-telnyx.js";
 import { createVoyageEmbeddingProvider, type VoyageEmbeddingClient } from "./embeddings-voyage.js";
 import { importNodeLlamaCpp } from "./node-llama.js";
 
@@ -19,6 +20,7 @@ function sanitizeAndNormalizeEmbedding(vec: number[]): number[] {
 
 export type { GeminiEmbeddingClient } from "./embeddings-gemini.js";
 export type { OpenAiEmbeddingClient } from "./embeddings-openai.js";
+export type { TelnyxEmbeddingClient } from "./embeddings-telnyx.js";
 export type { VoyageEmbeddingClient } from "./embeddings-voyage.js";
 
 export type EmbeddingProvider = {
@@ -29,11 +31,11 @@ export type EmbeddingProvider = {
   embedBatch: (texts: string[]) => Promise<number[][]>;
 };
 
-export type EmbeddingProviderId = "openai" | "local" | "gemini" | "voyage";
+export type EmbeddingProviderId = "openai" | "local" | "gemini" | "voyage" | "telnyx";
 export type EmbeddingProviderRequest = EmbeddingProviderId | "auto";
 export type EmbeddingProviderFallback = EmbeddingProviderId | "none";
 
-const REMOTE_EMBEDDING_PROVIDER_IDS = ["openai", "gemini", "voyage"] as const;
+const REMOTE_EMBEDDING_PROVIDER_IDS = ["openai", "gemini", "voyage", "telnyx"] as const;
 
 export type EmbeddingProviderResult = {
   provider: EmbeddingProvider | null;
@@ -44,6 +46,7 @@ export type EmbeddingProviderResult = {
   openAi?: OpenAiEmbeddingClient;
   gemini?: GeminiEmbeddingClient;
   voyage?: VoyageEmbeddingClient;
+  telnyx?: TelnyxEmbeddingClient;
 };
 
 export type EmbeddingProviderOptions = {
@@ -153,6 +156,10 @@ export async function createEmbeddingProvider(
     if (id === "voyage") {
       const { provider, client } = await createVoyageEmbeddingProvider(options);
       return { provider, voyage: client };
+    }
+    if (id === "telnyx") {
+      const { provider, client } = await createTelnyxEmbeddingProvider(options);
+      return { provider, telnyx: client };
     }
     const { provider, client } = await createOpenAiEmbeddingProvider(options);
     return { provider, openAi: client };

--- a/src/memory/manager-embedding-ops.ts
+++ b/src/memory/manager-embedding-ops.ts
@@ -240,6 +240,20 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
         }),
       );
     }
+    if (this.provider.id === "telnyx" && this.telnyx) {
+      const entries = Object.entries(this.telnyx.headers)
+        .filter(([key]) => key.toLowerCase() !== "authorization")
+        .toSorted(([a], [b]) => a.localeCompare(b))
+        .map(([key, value]) => [key, value]);
+      return hashText(
+        JSON.stringify({
+          provider: "telnyx",
+          baseUrl: this.telnyx.baseUrl,
+          model: this.telnyx.model,
+          headers: entries,
+        }),
+      );
+    }
     return hashText(JSON.stringify({ provider: this.provider.id, model: this.provider.model }));
   }
 

--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -13,12 +13,14 @@ import { onSessionTranscriptUpdate } from "../sessions/transcript-events.js";
 import { resolveUserPath } from "../utils.js";
 import { DEFAULT_GEMINI_EMBEDDING_MODEL } from "./embeddings-gemini.js";
 import { DEFAULT_OPENAI_EMBEDDING_MODEL } from "./embeddings-openai.js";
+import { DEFAULT_TELNYX_EMBEDDING_MODEL } from "./embeddings-telnyx.js";
 import { DEFAULT_VOYAGE_EMBEDDING_MODEL } from "./embeddings-voyage.js";
 import {
   createEmbeddingProvider,
   type EmbeddingProvider,
   type GeminiEmbeddingClient,
   type OpenAiEmbeddingClient,
+  type TelnyxEmbeddingClient,
   type VoyageEmbeddingClient,
 } from "./embeddings.js";
 import {
@@ -87,10 +89,11 @@ export abstract class MemoryManagerSyncOps {
   protected abstract readonly workspaceDir: string;
   protected abstract readonly settings: ResolvedMemorySearchConfig;
   protected provider: EmbeddingProvider | null = null;
-  protected fallbackFrom?: "openai" | "local" | "gemini" | "voyage";
+  protected fallbackFrom?: "openai" | "local" | "gemini" | "voyage" | "telnyx";
   protected openAi?: OpenAiEmbeddingClient;
   protected gemini?: GeminiEmbeddingClient;
   protected voyage?: VoyageEmbeddingClient;
+  protected telnyx?: TelnyxEmbeddingClient;
   protected abstract batch: {
     enabled: boolean;
     wait: boolean;
@@ -942,7 +945,7 @@ export abstract class MemoryManagerSyncOps {
     if (this.fallbackFrom) {
       return false;
     }
-    const fallbackFrom = this.provider.id as "openai" | "gemini" | "local" | "voyage";
+    const fallbackFrom = this.provider.id as "openai" | "gemini" | "local" | "voyage" | "telnyx";
 
     const fallbackModel =
       fallback === "gemini"
@@ -951,7 +954,9 @@ export abstract class MemoryManagerSyncOps {
           ? DEFAULT_OPENAI_EMBEDDING_MODEL
           : fallback === "voyage"
             ? DEFAULT_VOYAGE_EMBEDDING_MODEL
-            : this.settings.model;
+            : fallback === "telnyx"
+              ? DEFAULT_TELNYX_EMBEDDING_MODEL
+              : this.settings.model;
 
     const fallbackResult = await createEmbeddingProvider({
       config: this.cfg,
@@ -969,6 +974,7 @@ export abstract class MemoryManagerSyncOps {
     this.openAi = fallbackResult.openAi;
     this.gemini = fallbackResult.gemini;
     this.voyage = fallbackResult.voyage;
+    this.telnyx = fallbackResult.telnyx;
     this.providerKey = this.computeProviderKey();
     this.batch = this.resolveBatchConfig();
     log.warn(`memory embeddings: switched to fallback provider (${fallback})`, { reason });

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -13,6 +13,7 @@ import {
   type EmbeddingProviderResult,
   type GeminiEmbeddingClient,
   type OpenAiEmbeddingClient,
+  type TelnyxEmbeddingClient,
   type VoyageEmbeddingClient,
 } from "./embeddings.js";
 import { bm25RankToScore, buildFtsQuery, mergeHybridResults } from "./hybrid.js";
@@ -45,13 +46,14 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   protected readonly workspaceDir: string;
   protected readonly settings: ResolvedMemorySearchConfig;
   protected provider: EmbeddingProvider | null;
-  private readonly requestedProvider: "openai" | "local" | "gemini" | "voyage" | "auto";
-  protected fallbackFrom?: "openai" | "local" | "gemini" | "voyage";
+  private readonly requestedProvider: "openai" | "local" | "gemini" | "voyage" | "telnyx" | "auto";
+  protected fallbackFrom?: "openai" | "local" | "gemini" | "voyage" | "telnyx";
   protected fallbackReason?: string;
   private readonly providerUnavailableReason?: string;
   protected openAi?: OpenAiEmbeddingClient;
   protected gemini?: GeminiEmbeddingClient;
   protected voyage?: VoyageEmbeddingClient;
+  protected telnyx?: TelnyxEmbeddingClient;
   protected batch: {
     enabled: boolean;
     wait: boolean;
@@ -158,6 +160,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     this.openAi = params.providerResult.openAi;
     this.gemini = params.providerResult.gemini;
     this.voyage = params.providerResult.voyage;
+    this.telnyx = params.providerResult.telnyx;
     this.sources = new Set(params.settings.sources);
     this.db = this.openDatabase();
     this.providerKey = this.computeProviderKey();


### PR DESCRIPTION
## Summary

- **Problem:** Telnyx embeddings currently require a `provider: "openai"` + custom `baseUrl` workaround, which hits config redaction bugs and provider resolution fallthrough (see Linked Issues below)
- **Why it matters:** Users with a `TELNYX_API_KEY` (common for voice/messaging) can't reliably use it for embeddings without hitting these issues
- **What changed:** New native `provider: "telnyx"` option — same pattern as the Voyage provider. Raw fetch, no SDK, token limits declared for automatic enforcement
- **What did NOT change:** No changes to existing providers. No new dependencies. The existing `baseUrl` workaround still works
- **Incidental fix:** Added missing `voyage` to the fallback provider list in `docs/concepts/memory.md` (pre-existing omission, not related to the Telnyx feature)

I work at Telnyx and we run OpenClaw internally — happy to own this provider long-term.

## Change Type

- [ ] Bug fix
- [x] Feature
- [x] Docs
- [ ] Refactor
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #7078 (Voyage provider — same pattern followed here)
- Related #11268, #12078 (config redaction corrupts numeric settings in `baseUrl` workaround)
- Related #8131 (provider resolution ignores `remote.baseUrl`, falls through to `OPENAI_API_KEY`)

## User-visible / Behavior Changes

- New config option: `provider: "telnyx"` for `agents.defaults.memorySearch`
- New env var: `TELNYX_API_KEY` (resolved via standard `resolveApiKeyForProvider`)
- `openclaw doctor` auto-detects `TELNYX_API_KEY` when selecting embedding provider
- Models: `thenlper/gte-large` (default, 1024 dims), `intfloat/multilingual-e5-large` (multilingual)

## Security Impact

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No` — uses existing `resolveApiKeyForProvider` path
- New/changed network calls? `Yes` — new outbound HTTPS to `api.telnyx.com/v2/ai/openai/embeddings`
  - Risk: standard embedding API call, same pattern as Voyage (`api.voyageai.com`)
  - Mitigation: only activated when user explicitly sets `provider: "telnyx"`. No calls made otherwise.
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Ubuntu 24.04 (gateway), macOS 15.5 (dev)
- Runtime: Node 22.18.0
- Model/provider: Telnyx `thenlper/gte-large`
- Relevant config:
```json
{
  "provider": "telnyx",
  "model": "thenlper/gte-large"
}
```

### Steps

1. Set `TELNYX_API_KEY` in environment
2. Configure `agents.defaults.memorySearch.provider: "telnyx"` in `openclaw.json`
3. Restart gateway, run `openclaw memory search "test query"`

### Expected

- Memory search returns results using Telnyx embeddings

### Actual

- Memory search returns results, provider confirmed as `telnyx`

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets

Unit tests (7 new, 939 total memory+config+agents tests pass):
```
✓ src/memory/embeddings-telnyx.test.ts (4 tests) 30ms
✓ src/config/config.schema-regressions.test.ts (4 tests) 36ms  [+2 new telnyx]
✓ src/agents/model-auth.e2e.test.ts (13 tests) 48ms  [+1 new telnyx]
Test Files  136 passed (136)
Tests       939 passed (939)
```

Live gateway verification:
```
Provider: telnyx (requested: telnyx)
Model: thenlper/gte-large
Indexed: 19/19 files · 752 chunks
Vector: ready (1024 dims)
Embedding cache: enabled (1133 entries)
```

## Human Verification

- Verified scenarios: native `provider: "telnyx"` config → gateway restart → memory search returns results with correct model and dimensions; `openclaw doctor` detects `TELNYX_API_KEY`
- Edge cases checked: model normalization (`"telnyx/gte-large"` → `"gte-large"`), empty input arrays, missing API key error messages, fallback provider resolution
- What I did **not** verify: batch indexing (Telnyx doesn't expose a batch file-upload endpoint like OpenAI/Gemini/Voyage, so this correctly uses the standard per-request path)

## Compatibility / Migration

- Backward compatible? `Yes` — purely additive, no changes to existing providers
- Config/env changes? `Yes` — new optional `provider: "telnyx"` value, new optional `TELNYX_API_KEY` env var
- Migration needed? `No`

## Failure Recovery

- How to disable/revert: change `provider` back to previous value in `openclaw.json`, restart gateway
- Files/config to restore: `openclaw.json` only
- Known bad symptoms: if `TELNYX_API_KEY` is missing/invalid, `openclaw doctor` will report the missing key and memory search will fail with a clear auth error

## Risks and Mitigations

- Risk: Telnyx API availability/changes
  - Mitigation: raw fetch with standard error handling; I work at Telnyx and will maintain this provider code

## AI Disclosure

This PR was developed with AI assistance.

- **Testing level:** Fully tested — 7 new tests (4 provider unit, 2 schema regression, 1 auth e2e), all 939 existing memory/config/agents tests passing, plus live end-to-end verification on a running gateway.
- **Understanding:** I understand the changes — follows the established Voyage provider pattern (#7078). The provider sends embedding requests to Telnyx's OpenAI-compatible endpoint, with token limits (512) declared in `embedding-model-limits.ts` for automatic chunk enforcement by the existing pipeline.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added native Telnyx embedding provider following the established Voyage pattern. The implementation includes proper API key resolution via `resolveApiKeyForProvider`, token limit enforcement (512 tokens), and complete integration across config schema, docs, and `openclaw doctor`. The PR correctly excludes Telnyx from batch processing since the API does not support batch uploads. All 939 existing tests pass plus 7 new tests.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no significant risk
- The implementation follows the established Voyage provider pattern exactly, is purely additive with no changes to existing providers, includes comprehensive tests (7 new tests + all 939 existing tests passing), has proper error handling and API key resolution, and the author has verified it works end-to-end on a live gateway.
- No files require special attention

<sub>Last reviewed commit: 38169c8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->