### PR TITLE
fix(failover): broaden billing pattern for Venice 402 errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Docs: https://docs.openclaw.ai
 - OpenClawKit/iOS ChatUI: accept canonical session-key completion events for local pending runs and preserve message IDs across history refreshes, preventing stuck "thinking" state and message flicker after gateway replies. (#18165) Thanks @mbelinky.
 - iOS/Talk: harden mobile talk config handling by ignoring redacted/env-placeholder API keys, support secure local keychain override, improve accessibility motion/contrast behavior in status UI, and tighten ATS to local-network allowance. (#18163) Thanks @mbelinky.
 - iOS/Gateway: stabilize connect/discovery state handling, add onboarding reset recovery in Settings, and fix iOS gateway-controller coverage for command-surface and last-connection persistence behavior. (#18164) Thanks @mbelinky.
+- Agents/Failover: broaden billing error pattern to match Venice-style `"Insufficient USD or Diem balance"` where words separate "insufficient" and "balance", enabling automatic model fallback on 402 billing errors. (#18137)
 
 ## 2026.2.15
 

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.e2e.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.e2e.test.ts
@@ -53,6 +53,14 @@ describe("isBillingErrorMessage", () => {
       expect(isBillingErrorMessage(sample)).toBe(true);
     }
   });
+  it("matches Venice billing error with non-adjacent insufficient/balance", () => {
+    expect(
+      isBillingErrorMessage("Insufficient USD or Diem balance to complete request"),
+    ).toBe(true);
+    expect(
+      isBillingErrorMessage("insufficient token balance for this operation"),
+    ).toBe(true);
+  });
   it("ignores unrelated errors", () => {
     expect(isBillingErrorMessage("rate limit exceeded")).toBe(false);
     expect(isBillingErrorMessage("invalid api key")).toBe(false);
@@ -346,5 +354,10 @@ describe("classifyFailoverReason", () => {
     expect(classifyFailoverReason("You have hit your ChatGPT usage limit (plus plan)")).toBe(
       "rate_limit",
     );
+  });
+  it("classifies Venice billing errors as billing", () => {
+    expect(
+      classifyFailoverReason("Insufficient USD or Diem balance to complete request"),
+    ).toBe("billing");
   });
 });

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.e2e.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.e2e.test.ts
@@ -54,12 +54,10 @@ describe("isBillingErrorMessage", () => {
     }
   });
   it("matches Venice billing error with non-adjacent insufficient/balance", () => {
-    expect(
-      isBillingErrorMessage("Insufficient USD or Diem balance to complete request"),
-    ).toBe(true);
-    expect(
-      isBillingErrorMessage("insufficient token balance for this operation"),
-    ).toBe(true);
+    expect(isBillingErrorMessage("Insufficient USD or Diem balance to complete request")).toBe(
+      true,
+    );
+    expect(isBillingErrorMessage("insufficient token balance for this operation")).toBe(true);
   });
   it("ignores unrelated errors", () => {
     expect(isBillingErrorMessage("rate limit exceeded")).toBe(false);
@@ -356,8 +354,8 @@ describe("classifyFailoverReason", () => {
     );
   });
   it("classifies Venice billing errors as billing", () => {
-    expect(
-      classifyFailoverReason("Insufficient USD or Diem balance to complete request"),
-    ).toBe("billing");
+    expect(classifyFailoverReason("Insufficient USD or Diem balance to complete request")).toBe(
+      "billing",
+    );
   });
 });

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -607,6 +607,7 @@ const ERROR_PATTERNS = {
     "credit balance",
     "plans & billing",
     "insufficient balance",
+    /insufficient\b[^.]*\bbalance/i,
   ],
   auth: [
     /invalid[_ ]?api[_ ]?key/,


### PR DESCRIPTION
## Summary
- Add regex `/insufficient\b[^.]*\bbalance/i` to `ERROR_PATTERNS.billing` to match Venice AI's `"Insufficient USD or Diem balance to complete request"` error
- The existing `"insufficient balance"` substring pattern requires adjacent words but Venice has "USD or Diem" between them

## Problem
Venice AI returns HTTP 402 with message `"Insufficient USD or Diem balance to complete request"`. The text-based billing pattern matcher (`classifyFailoverReason`) fails to match because `String.includes("insufficient balance")` requires the substring to be contiguous. This prevents model fallback from triggering.

Closes #18137

## Test plan
- [x] Added test for Venice-style billing error in `isBillingErrorMessage` (2 new cases)
- [x] Added test for `classifyFailoverReason` with Venice error text
- [x] All 33 existing error classification tests pass
- [x] Verified `resolveFailoverReasonFromError` already handles `{ status: 402 }` correctly via status code path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added regex pattern to match Venice AI billing errors where "insufficient" and "balance" are separated by other words (e.g., "Insufficient USD or Diem balance to complete request"). The new pattern `/insufficient\b[^.]*\bbalance/i` complements the existing substring matcher by allowing flexible matching across non-adjacent words, enabling proper model fallback on Venice 402 billing errors.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is well-isolated, adds a single regex pattern to an existing error matching system, includes comprehensive test coverage (2 new test cases for the pattern, 1 for classification flow), and all 33 existing tests pass. The regex pattern is straightforward and the implementation follows established patterns in the codebase.
- No files require special attention

<sub>Last reviewed commit: 63c0004</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->