### PR TITLE
fix(config): add maxSpawnDepth/maxChildrenPerAgent to per-agent subagents schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Docs: https://docs.openclaw.ai
 - OpenClawKit/iOS ChatUI: accept canonical session-key completion events for local pending runs and preserve message IDs across history refreshes, preventing stuck "thinking" state and message flicker after gateway replies. (#18165) Thanks @mbelinky.
 - iOS/Talk: harden mobile talk config handling by ignoring redacted/env-placeholder API keys, support secure local keychain override, improve accessibility motion/contrast behavior in status UI, and tighten ATS to local-network allowance. (#18163) Thanks @mbelinky.
 - iOS/Gateway: stabilize connect/discovery state handling, add onboarding reset recovery in Settings, and fix iOS gateway-controller coverage for command-surface and last-connection persistence behavior. (#18164) Thanks @mbelinky.
+- Config/Schema: add `maxSpawnDepth` and `maxChildrenPerAgent` to per-agent `agents.list[].subagents` schema so these documented keys are no longer rejected by strict validation. (#18142)
 
 ## 2026.2.15
 

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -36,4 +36,23 @@ describe("config schema regressions", () => {
 
     expect(res.ok).toBe(true);
   });
+
+  it("accepts per-agent subagents maxSpawnDepth and maxChildrenPerAgent", () => {
+    const res = validateConfigObject({
+      agents: {
+        list: [
+          {
+            id: "orchestrator",
+            subagents: {
+              maxSpawnDepth: 2,
+              maxChildrenPerAgent: 5,
+              allowAgents: ["*"],
+            },
+          },
+        ],
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
 });

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -37,8 +37,14 @@ export type AgentConfig = {
   subagents?: {
     /** Allow spawning sub-agents under other agent ids. Use "*" to allow any. */
     allowAgents?: string[];
+    /** Maximum nesting depth for sub-agent spawning (1 = no nesting, default). */
+    maxSpawnDepth?: number;
+    /** Maximum active children a single agent session can spawn (default: 5). */
+    maxChildrenPerAgent?: number;
     /** Per-agent default model for spawned sub-agents (string or {primary,fallbacks}). */
     model?: string | { primary?: string; fallbacks?: string[] };
+    /** Default thinking level for spawned sub-agents. */
+    thinking?: string;
   };
   sandbox?: {
     mode?: "off" | "non-main" | "all";

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -535,6 +535,24 @@ export const AgentEntrySchema = z
     subagents: z
       .object({
         allowAgents: z.array(z.string()).optional(),
+        maxSpawnDepth: z
+          .number()
+          .int()
+          .min(1)
+          .max(5)
+          .optional()
+          .describe(
+            "Maximum nesting depth for sub-agent spawning. 1 = no nesting (default), 2 = sub-agents can spawn sub-sub-agents.",
+          ),
+        maxChildrenPerAgent: z
+          .number()
+          .int()
+          .min(1)
+          .max(20)
+          .optional()
+          .describe(
+            "Maximum number of active children a single agent session can spawn (default: 5).",
+          ),
         model: z
           .union([
             z.string(),


### PR DESCRIPTION
## Summary
- Add `maxSpawnDepth` and `maxChildrenPerAgent` to the per-agent `agents.list[].subagents` Zod schema and TypeScript type
- These keys were documented in CHANGELOG 2026.2.15 but rejected by strict schema validation when set via `config.patch`

## Problem
Setting nested sub-agent config via `config.patch`:
```json
{"agents": {"list": [{"id": "orchestrator", "subagents": {"maxSpawnDepth": 2, "maxChildrenPerAgent": 5}}]}}
```
Returns an invalid config error because the per-agent schema used `.strict()` and only included `allowAgents`, `model`, and `thinking`.

Closes #18142

## Test plan
- [x] Added schema regression test for per-agent subagents with maxSpawnDepth/maxChildrenPerAgent
- [x] All 3 schema regression tests pass
- [x] Constraints match `agents.defaults.subagents` schema (int, 1-5 / 1-20)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `maxSpawnDepth` and `maxChildrenPerAgent` to the per-agent `agents.list[].subagents` schema to match the documented feature from CHANGELOG 2026.2.15. Previously these fields were only accepted in `agents.defaults.subagents` but rejected when set per-agent via `config.patch` due to strict schema validation. The PR correctly adds both Zod schema validation (with matching `.min(1).max(5)` and `.min(1).max(20)` constraints from the defaults schema) and TypeScript type definitions. Also fixes a pre-existing type mismatch where `thinking` was in the Zod schema but missing from the TypeScript type.

- Added schema validation for `maxSpawnDepth` (1-5) and `maxChildrenPerAgent` (1-20)
- Updated TypeScript types to include both new fields plus previously missing `thinking` field
- Added regression test validating per-agent subagent configuration
- Updated CHANGELOG with fix entry

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The changes are minimal, well-tested, and fix a documented bug. The schema constraints exactly match the existing global defaults schema (maxSpawnDepth: 1-5, maxChildrenPerAgent: 1-20), TypeScript types are properly updated, and a regression test is included. The fix also closes a type mismatch for the `thinking` field. No breaking changes or edge cases.
- No files require special attention

<sub>Last reviewed commit: 5f20413</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->