### PR TITLE
fix(feishu): remove workspace protocol from devDependencies to fix in…

### DIFF
--- a/extensions/feishu/package.json
+++ b/extensions/feishu/package.json
@@ -8,9 +8,6 @@
     "@sinclair/typebox": "0.34.48",
     "zod": "^4.3.6"
   },
-  "devDependencies": {
-    "openclaw": "workspace:*"
-  },
   "openclaw": {
     "extensions": [
       "./index.ts"


### PR DESCRIPTION
…stall

Fix this error below: 
```shell
(base) ➜ extensions openclaw plugins install @openclaw/feishu

🦞 OpenClaw 2026.2.15 (3fe22ea) — Because texting yourself reminders is so 2024.

Downloading @openclaw/feishu…
Extracting /var/folders/c8/5frzt85179j3971snbl9206r0000gp/T/openclaw-npm-pack-biP271/openclaw-feishu-2026.2.15.tgz…
Installing to /Users/xx/.openclaw/extensions/feishu…
Installing plugin dependencies…
npm install failed:
```


```shell
cd /users/xx/.opencloaw/extension/feishu
npm install
npm error code EUNSUPPORTEDPROTOCOL
npm error Unsupported URL Type "workspace:": workspace:*
npm error A complete log of this run can be found in: /Users/xx/.npm/_logs/2026-02-16T15_56_17_133Z-debug-0.log
```

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes the `"openclaw": "workspace:*"` entry from `devDependencies` in the feishu extension's `package.json` to fix plugin installation failures. The `workspace:*` protocol is only valid within the pnpm monorepo and causes an `EUNSUPPORTEDPROTOCOL` error when users install the plugin via `openclaw plugins install @openclaw/feishu` (which runs `npm install --omit=dev` in the target directory). Since the plugin loader resolves `openclaw/plugin-sdk` imports at runtime via jiti aliases, the `openclaw` dependency is not needed at install time or runtime.

- **Fix**: Removed `devDependencies` block containing `"openclaw": "workspace:*"` from `extensions/feishu/package.json`
- **Root cause**: npm cannot resolve the `workspace:*` protocol outside of a pnpm workspace, causing `npm install` to fail even with `--omit=dev` (npm still parses all dependency sections)
- **Note**: 30 other extensions still have the same `"openclaw": "workspace:*"` in their `devDependencies` and may encounter the same issue when installed from npm

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it removes a broken dependency entry that was preventing plugin installation.
- The change is minimal (removing 3 lines from a single package.json), directly fixes a user-facing installation error, and aligns with the project's documented architecture (jiti aliases resolve plugin-sdk imports at runtime, making the openclaw devDependency unnecessary). The plugin install process uses `npm install --omit=dev` which skips devDependencies, but npm still fails when encountering the unsupported `workspace:*` protocol. No runtime behavior changes.
- No files require special attention. The other 30 extensions with the same `workspace:*` pattern in devDependencies may need the same fix in a follow-up PR.

<sub>Last reviewed commit: fde2030</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))

<!-- /greptile_comment -->