### PR TITLE
fix(cron): preserve model fallbacks when agent overrides primary

### DIFF
--- a/src/cron/isolated-agent/run.model-fallback-preservation.test.ts
+++ b/src/cron/isolated-agent/run.model-fallback-preservation.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import type { AgentDefaultsConfig } from "../../config/types.js";
+
+/**
+ * Tests for the model merge fix in runCronIsolatedAgentTurn.
+ *
+ * Bug: When an agent config defines `model: { primary: "..." }` without
+ * `fallbacks`, the merge into `agentCfg` replaced the entire model object
+ * from defaults—losing `fallbacks`.  This caused cron jobs to have only
+ * one model candidate (the pinned model) plus the global primary, skipping
+ * all intermediate fallbacks.
+ *
+ * Fix: Spread the existing `agentCfg.model` before applying the override,
+ * so keys like `fallbacks` from `agents.defaults.model` survive when the
+ * agent only overrides `primary`.
+ */
+describe("agent model override preserves default fallbacks", () => {
+  // Simulates the merge logic extracted from run.ts lines 148–159
+  function mergeAgentModel(
+    defaults: AgentDefaultsConfig,
+    overrideModel: { primary?: string; fallbacks?: string[] } | string | undefined,
+  ): AgentDefaultsConfig {
+    const agentCfg: AgentDefaultsConfig = { ...defaults };
+
+    // --- FIX: merge instead of replace ---
+    const existingModel =
+      agentCfg.model && typeof agentCfg.model === "object" ? agentCfg.model : {};
+    if (typeof overrideModel === "string") {
+      agentCfg.model = { ...existingModel, primary: overrideModel };
+    } else if (overrideModel) {
+      agentCfg.model = { ...existingModel, ...overrideModel };
+    }
+    return agentCfg;
+  }
+
+  const defaultFallbacks = [
+    "anthropic/claude-opus-4-6",
+    "google-gemini-cli/gemini-3-pro-preview",
+    "nvidia/deepseek-ai/deepseek-v3.2",
+  ];
+
+  const defaults: AgentDefaultsConfig = {
+    model: {
+      primary: "openai-codex/gpt-5.3-codex",
+      fallbacks: defaultFallbacks,
+    },
+  };
+
+  it("preserves fallbacks when agent overrides primary as string", () => {
+    const result = mergeAgentModel(defaults, "anthropic/claude-sonnet-4-5");
+    const model = result.model as { primary?: string; fallbacks?: string[] };
+
+    expect(model.primary).toBe("anthropic/claude-sonnet-4-5");
+    expect(model.fallbacks).toEqual(defaultFallbacks);
+  });
+
+  it("preserves fallbacks when agent overrides primary as object", () => {
+    const result = mergeAgentModel(defaults, {
+      primary: "anthropic/claude-sonnet-4-5",
+    });
+    const model = result.model as { primary?: string; fallbacks?: string[] };
+
+    expect(model.primary).toBe("anthropic/claude-sonnet-4-5");
+    expect(model.fallbacks).toEqual(defaultFallbacks);
+  });
+
+  it("allows agent to explicitly override fallbacks", () => {
+    const customFallbacks = ["nvidia/deepseek-ai/deepseek-v3.2"];
+    const result = mergeAgentModel(defaults, {
+      primary: "anthropic/claude-sonnet-4-5",
+      fallbacks: customFallbacks,
+    });
+    const model = result.model as { primary?: string; fallbacks?: string[] };
+
+    expect(model.primary).toBe("anthropic/claude-sonnet-4-5");
+    expect(model.fallbacks).toEqual(customFallbacks);
+  });
+
+  it("allows agent to explicitly clear fallbacks with empty array", () => {
+    const result = mergeAgentModel(defaults, {
+      primary: "anthropic/claude-sonnet-4-5",
+      fallbacks: [],
+    });
+    const model = result.model as { primary?: string; fallbacks?: string[] };
+
+    expect(model.primary).toBe("anthropic/claude-sonnet-4-5");
+    expect(model.fallbacks).toEqual([]);
+  });
+
+  it("leaves model untouched when override is undefined", () => {
+    const result = mergeAgentModel(defaults, undefined);
+    const model = result.model as { primary?: string; fallbacks?: string[] };
+
+    expect(model.primary).toBe("openai-codex/gpt-5.3-codex");
+    expect(model.fallbacks).toEqual(defaultFallbacks);
+  });
+
+  it("handles missing defaults model gracefully", () => {
+    const emptyDefaults: AgentDefaultsConfig = {};
+    const result = mergeAgentModel(emptyDefaults, "anthropic/claude-sonnet-4-5");
+    const model = result.model as { primary?: string; fallbacks?: string[] };
+
+    expect(model.primary).toBe("anthropic/claude-sonnet-4-5");
+    expect(model.fallbacks).toBeUndefined();
+  });
+});

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -149,10 +149,14 @@ export async function runCronIsolatedAgentTurn(params: {
     params.cfg.agents?.defaults,
     agentOverrideRest as Partial<AgentDefaultsConfig>,
   );
+  // Merge agent model override with defaults instead of replacing, so that
+  // `fallbacks` from `agents.defaults.model` are preserved when the agent
+  // (or its per-cron model pin) only specifies `primary`.
+  const existingModel = agentCfg.model && typeof agentCfg.model === "object" ? agentCfg.model : {};
   if (typeof overrideModel === "string") {
-    agentCfg.model = { primary: overrideModel };
+    agentCfg.model = { ...existingModel, primary: overrideModel };
   } else if (overrideModel) {
-    agentCfg.model = overrideModel;
+    agentCfg.model = { ...existingModel, ...overrideModel };
   }
   const cfgWithAgentDefaults: OpenClawConfig = {
     ...params.cfg,


### PR DESCRIPTION
## Problem

When an agent config specifies `model: { primary: "..." }` without an explicit `fallbacks` array, the cron isolated-agent runner **replaces** the entire model object from `agents.defaults`—discarding the default fallbacks chain.

This causes cron jobs (and agent sessions) to have only **two** model candidates:
1. The pinned model (e.g., `gemini-3-flash-preview`)
2. The global primary as a final fallback (e.g., `gpt-5.3-codex`)

All intermediate fallback models (Opus, DeepSeek, Qwen, Kimi, etc.) are **silently lost**.

### Reproduction

```json
// agents.defaults.model
{ "primary": "codex", "fallbacks": ["opus", "flash", "deepseek", "kimi"] }

// Agent config
{ "model": { "primary": "codex" } }

// Cron job pins model
{ "model": "flash" }
```

**Before fix:** fallback candidates = `[flash, codex]` — 3 models skipped
**After fix:** fallback candidates = `[flash, opus, deepseek, kimi, codex]`

### Impact

Any user with:
- Multiple agents that override `model.primary`
- Cron jobs with per-job `model` pins
- A configured fallback chain in `agents.defaults.model.fallbacks`

...will have their fallback chain silently broken. When the pinned model hits a rate limit (429), the system skips directly to the global primary instead of trying intermediate fallbacks.

## Fix

**3-line change** in `src/cron/isolated-agent/run.ts`: spread the existing `agentCfg.model` before applying the override, so `fallbacks` (and any other model config keys) survive when the agent only overrides `primary`.

```typescript
// Before (replace)
agentCfg.model = { primary: overrideModel };

// After (merge)
const existingModel = agentCfg.model && typeof agentCfg.model === "object" ? agentCfg.model : {};
agentCfg.model = { ...existingModel, primary: overrideModel };
```

Agents can still explicitly override or clear fallbacks by providing their own `fallbacks` array (including `fallbacks: []` to disable).

## Tests

Added `run.model-fallback-preservation.test.ts` with 6 test cases covering:
- String override preserves fallbacks ✅
- Object override preserves fallbacks ✅
- Explicit fallbacks override works ✅
- Empty fallbacks array clears chain ✅
- Undefined override leaves model untouched ✅
- Missing defaults model handled gracefully ✅

All existing tests pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Targeted bug fix that changes the model override logic in the cron isolated-agent runner from a full replace to a shallow merge. Previously, when an agent config specified `model: { primary: "..." }` without `fallbacks`, the entire model object from `agents.defaults` was replaced — silently discarding the default fallback chain. The fix spreads `existingModel` before applying the override, so `fallbacks` survive when only `primary` is overridden.

- **`src/cron/isolated-agent/run.ts`**: 4-line change (including comment) that spreads the existing model config before applying the agent's override, correctly preserving `fallbacks` and any other model keys from defaults.
- **`run.model-fallback-preservation.test.ts`**: 6 well-structured test cases covering string override, object override, explicit fallback override, empty fallback clearing, undefined override, and missing defaults. Tests re-implement the merge logic locally rather than testing the actual exported function, which is a reasonable approach given the function's complex dependencies.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, well-scoped fix with correct semantics and good test coverage.
- The change is a 4-line fix (including a comment) that uses a standard JavaScript spread pattern to merge instead of replace. The logic is straightforward, handles edge cases (non-object model, string override, object override), and doesn't mutate shared config objects. The fix correctly interacts with both the upstream `Object.assign` merge and the downstream `resolveFallbackCandidates` function that reads `cfg.agents.defaults.model.fallbacks`. Six test cases cover the key scenarios. No regressions or side effects identified.
- No files require special attention.

<sub>Last reviewed commit: 7af50ca</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->