### PR TITLE
feat: dynamic header templating for provider config (session.key, age…

### DIFF
--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -332,6 +332,34 @@ Notes:
   - `maxTokens: 8192`
 - Recommended: set explicit values that match your proxy/model limits.
 
+### Provider headers and dynamic templating
+
+You can set optional `headers` on any provider in `models.providers`. Header values support **template placeholders** that are interpolated per run:
+
+- `{{session.key}}` — unique per session (e.g. for cache affinity)
+- `{{agent.id}}` — agent id for the run
+
+Example (Fireworks.ai prompt caching via `x-session-affinity`): each session is pinned to the same replica so cache hits apply:
+
+```json5
+{
+  models: {
+    providers: {
+      fireworks: {
+        baseUrl: "https://api.fireworks.ai/inference/v1",
+        apiKey: "${FIREWORKS_API_KEY}",
+        headers: {
+          "x-session-affinity": "{{session.key}}"
+        },
+        models: [{ id: "accounts/fireworks/models/...", name: "..." }],
+      },
+    },
+  },
+}
+```
+
+Static headers (no placeholders) are also supported and are merged into every request for that provider.
+
 ## CLI examples
 
 ```bash

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -58,6 +58,7 @@ import {
 } from "../skills.js";
 import { resolveTranscriptPolicy } from "../transcript-policy.js";
 import { compactWithSafetyTimeout } from "./compaction-safety-timeout.js";
+import { applyExtraParamsToAgent, applyProviderHeaderTemplatesToAgent } from "./extra-params.js";
 import { buildEmbeddedExtensionPaths } from "./extensions.js";
 import {
   logToolSchemasForGoogle,
@@ -560,6 +561,11 @@ export async function compactEmbeddedPiSessionDirect(
         settingsManager,
       });
       applySystemPromptOverrideToSession(session, systemPromptOverride());
+      applyExtraParamsToAgent(session.agent, params.config, provider, modelId);
+      applyProviderHeaderTemplatesToAgent(session.agent, params.config, provider, {
+        sessionKey: params.sessionKey ?? params.sessionId,
+        agentId: sessionAgentId,
+      });
 
       try {
         const prior = await sanitizeSessionHistory({

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -3,6 +3,11 @@ import type { SimpleStreamOptions } from "@mariozechner/pi-ai";
 import { streamSimple } from "@mariozechner/pi-ai";
 import type { OpenClawConfig } from "../../config/config.js";
 import { log } from "./logger.js";
+import {
+  createProviderHeadersStreamFnWrapper,
+  resolveProviderHeaders,
+  type ProviderHeaderVars,
+} from "./provider-headers.js";
 
 const OPENROUTER_APP_HEADERS: Record<string, string> = {
   "HTTP-Referer": "https://openclaw.ai",
@@ -211,4 +216,31 @@ export function applyExtraParamsToAgent(
   // Force `store=true` for direct OpenAI/OpenAI Codex providers so multi-turn
   // server-side conversation state is preserved.
   agent.streamFn = createOpenAIResponsesStoreWrapper(agent.streamFn);
+}
+
+/**
+ * Apply provider config headers to the agent's streamFn, with optional
+ * template interpolation (e.g. {{session.key}}, {{agent.id}}) when vars are provided.
+ * Call this from the embedded runner with sessionKey and agentId so dynamic
+ * headers (e.g. Fireworks x-session-affinity) work per session.
+ *
+ * @internal Exported for testing and use from run/attempt
+ */
+export function applyProviderHeaderTemplatesToAgent(
+  agent: { streamFn?: StreamFn },
+  cfg: OpenClawConfig | undefined,
+  provider: string,
+  vars?: ProviderHeaderVars,
+): void {
+  const providerConfig = cfg?.models?.providers?.[provider];
+  const rawHeaders = providerConfig?.headers;
+  if (!rawHeaders || Object.keys(rawHeaders).length === 0) {
+    return;
+  }
+  const resolved = resolveProviderHeaders(rawHeaders, vars ?? {});
+  if (Object.keys(resolved).length === 0) {
+    return;
+  }
+  log.debug(`applying provider headers for ${provider} (${Object.keys(resolved).length} header(s))`);
+  agent.streamFn = createProviderHeadersStreamFnWrapper(agent.streamFn, resolved);
 }

--- a/src/agents/pi-embedded-runner/provider-headers.test.ts
+++ b/src/agents/pi-embedded-runner/provider-headers.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import {
+  hasHeaderTemplates,
+  interpolateHeaderValue,
+  resolveProviderHeaders,
+} from "./provider-headers.js";
+
+describe("interpolateHeaderValue", () => {
+  it("replaces {{session.key}} and {{agent.id}}", () => {
+    expect(
+      interpolateHeaderValue("affinity-{{session.key}}-{{agent.id}}", {
+        sessionKey: "sk1",
+        agentId: "agent-a",
+      }),
+    ).toBe("affinity-sk1-agent-a");
+  });
+
+  it("replaces only session.key when agentId missing", () => {
+    expect(
+      interpolateHeaderValue("{{session.key}}", { sessionKey: "s1", agentId: undefined }),
+    ).toBe("s1");
+  });
+
+  it("replaces missing vars with empty string", () => {
+    expect(interpolateHeaderValue("{{session.key}}-{{agent.id}}", {})).toBe("-");
+  });
+
+  it("leaves unknown placeholders unchanged", () => {
+    expect(
+      interpolateHeaderValue("{{session.key}}-{{unknown.var}}", { sessionKey: "s1" }),
+    ).toBe("s1-{{unknown.var}}");
+  });
+
+  it("leaves static values unchanged", () => {
+    expect(interpolateHeaderValue("static-value", { sessionKey: "s1" })).toBe("static-value");
+  });
+});
+
+describe("resolveProviderHeaders", () => {
+  it("returns empty object for undefined or empty headers", () => {
+    expect(resolveProviderHeaders(undefined, { sessionKey: "s1" })).toEqual({});
+    expect(resolveProviderHeaders({}, { sessionKey: "s1" })).toEqual({});
+  });
+
+  it("interpolates all header values", () => {
+    expect(
+      resolveProviderHeaders(
+        {
+          "x-session-affinity": "{{session.key}}",
+          "x-agent-id": "{{agent.id}}",
+        },
+        { sessionKey: "my-session", agentId: "my-agent" },
+      ),
+    ).toEqual({
+      "x-session-affinity": "my-session",
+      "x-agent-id": "my-agent",
+    });
+  });
+
+  it("skips non-string values", () => {
+    const headers = {
+      a: "ok",
+      b: 1 as unknown as string,
+    };
+    expect(resolveProviderHeaders(headers, {})).toEqual({ a: "ok" });
+  });
+});
+
+describe("hasHeaderTemplates", () => {
+  it("returns false for undefined or empty", () => {
+    expect(hasHeaderTemplates(undefined)).toBe(false);
+    expect(hasHeaderTemplates({})).toBe(false);
+  });
+
+  it("returns true when any value contains {{", () => {
+    expect(hasHeaderTemplates({ "x-affinity": "{{session.key}}" })).toBe(true);
+    expect(hasHeaderTemplates({ a: "static", b: "{{agent.id}}" })).toBe(true);
+  });
+
+  it("returns false when no value contains {{", () => {
+    expect(hasHeaderTemplates({ "x-foo": "static" })).toBe(false);
+  });
+});

--- a/src/agents/pi-embedded-runner/provider-headers.ts
+++ b/src/agents/pi-embedded-runner/provider-headers.ts
@@ -1,0 +1,92 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import { streamSimple } from "@mariozechner/pi-ai";
+
+export type ProviderHeaderVars = {
+  /** Session key (unique per session); used for e.g. Fireworks x-session-affinity. */
+  sessionKey?: string;
+  /** Agent id for this run; used for per-agent header values. */
+  agentId?: string;
+};
+
+const PLACEHOLDERS: Array<{ key: string; name: keyof ProviderHeaderVars }> = [
+  { key: "{{session.key}}", name: "sessionKey" },
+  { key: "{{agent.id}}", name: "agentId" },
+];
+
+/**
+ * Interpolate template placeholders in a header value.
+ * Supported: {{session.key}}, {{agent.id}}.
+ * Unknown placeholders are left as-is. Missing values are replaced with empty string.
+ *
+ * @internal Exported for testing
+ */
+export function interpolateHeaderValue(
+  value: string,
+  vars: ProviderHeaderVars,
+): string {
+  let out = value;
+  for (const { key, name } of PLACEHOLDERS) {
+    const v = vars[name];
+    out = out.split(key).join(typeof v === "string" ? v : "");
+  }
+  return out;
+}
+
+/**
+ * Build headers from provider config, interpolating any template placeholders.
+ *
+ * @internal Exported for testing
+ */
+export function resolveProviderHeaders(
+  headers: Record<string, string> | undefined,
+  vars: ProviderHeaderVars,
+): Record<string, string> {
+  if (!headers || Object.keys(headers).length === 0) {
+    return {};
+  }
+  const out: Record<string, string> = {};
+  for (const [name, value] of Object.entries(headers)) {
+    if (typeof value === "string") {
+      out[name] = interpolateHeaderValue(value, vars);
+    }
+  }
+  return out;
+}
+
+/**
+ * Returns true if any header value contains a template placeholder (e.g. {{session.key}}).
+ */
+export function hasHeaderTemplates(headers: Record<string, string> | undefined): boolean {
+  if (!headers) {
+    return false;
+  }
+  for (const value of Object.values(headers)) {
+    if (typeof value === "string" && value.includes("{{")) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Create a streamFn wrapper that merges the given headers into each request's
+ * options.headers. Caller should use resolveProviderHeaders() first to interpolate
+ * templates if needed.
+ */
+export function createProviderHeadersStreamFnWrapper(
+  baseStreamFn: StreamFn | undefined,
+  resolvedHeaders: Record<string, string>,
+): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  if (Object.keys(resolvedHeaders).length === 0) {
+    return underlying;
+  }
+  return (model, context, options) =>
+    underlying(model, context, {
+      ...options,
+      headers: {
+        ...resolvedHeaders,
+        ...options?.headers,
+      },
+    });
+}

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -69,7 +69,7 @@ import { DEFAULT_BOOTSTRAP_FILENAME } from "../../workspace.js";
 import { isRunnerAbortError } from "../abort.js";
 import { appendCacheTtlTimestamp, isCacheTtlEligibleProvider } from "../cache-ttl.js";
 import { buildEmbeddedExtensionPaths } from "../extensions.js";
-import { applyExtraParamsToAgent } from "../extra-params.js";
+import { applyExtraParamsToAgent, applyProviderHeaderTemplatesToAgent } from "../extra-params.js";
 import {
   logToolSchemasForGoogle,
   sanitizeAntigravityThinkingBlocks,
@@ -619,6 +619,10 @@ export async function runEmbeddedAttempt(
         params.modelId,
         params.streamParams,
       );
+      applyProviderHeaderTemplatesToAgent(activeSession.agent, params.config, params.provider, {
+        sessionKey: params.sessionKey ?? params.sessionId,
+        agentId: params.agentId ?? sessionAgentId,
+      });
 
       if (cacheTrace) {
         cacheTrace.recordStage("session:loaded", {


### PR DESCRIPTION
Adds dynamic header templating for models.providers.<id>.headers so provider requests can use per-session and per-agent values (e.g. Fireworks.ai x-session-affinity for prompt caching).
Closes 
What’s included
Placeholders: {{session.key}} and {{agent.id}} in provider headers are interpolated per run. Missing values become empty string; unknown placeholders are left as-is.
Embedded runner: Provider headers are resolved with the current session key and agent id and applied via a streamFn wrapper so every LLM request (including compaction) gets the correct headers.
Implementation: New provider-headers.ts (interpolation + wrapper); applyProviderHeaderTemplatesToAgent() in extra-params.ts; wired in run/attempt.ts and compact.ts. Static headers (no placeholders) still work.
Example (Fireworks.ai prompt caching)
{  "models": {    "providers": {      "fireworks": {        "baseUrl": "https://api.fireworks.ai/inference/v1",        "apiKey": "...",        "headers": {          "x-session-affinity": "{{session.key}}"        },        "models": [...]      }    }  }}
Each session gets a stable x-session-affinity value so requests hit the same replica and prompt caching works (~50% cost and ~80% TTFT improvements), while different sessions can use different replicas.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added dynamic header templating for provider configurations to support per-session and per-agent header values. Implemented `{{session.key}}` and `{{agent.id}}` placeholders for use cases like Fireworks.ai's `x-session-affinity` header for prompt caching.

- New `provider-headers.ts` module handles template interpolation and streamFn wrapping
- Integrated into both `compact.ts` and `run/attempt.ts` via `applyProviderHeaderTemplatesToAgent()`
- Comprehensive test coverage for interpolation logic
- Documentation added to `model-providers.md` with Fireworks.ai example

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one header precedence issue
- Implementation is clean with good test coverage, but the header merging order in `createProviderHeadersStreamFnWrapper` allows `options?.headers` to override provider config headers, which could cause unexpected behavior
- Pay close attention to `src/agents/pi-embedded-runner/provider-headers.ts` line 87-90 for the header merging precedence issue

<sub>Last reviewed commit: 20ea618</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->