### PR TITLE
Config: require Discord ID strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Docs: https://docs.openclaw.ai
 - Security/Sessions: create new session transcript JSONL files with user-only (`0o600`) permissions and extend `openclaw security audit --fix` to remediate existing transcript file permissions.
 - Infra/Fetch: ensure foreign abort-signal listener cleanup never masks original fetch successes/failures, while still preventing detached-finally unhandled rejection noise in `wrapFetchWithAbortSignal`. Thanks @Jackten.
 - Gateway/Config: prevent `config.patch` object-array merges from falling back to full-array replacement when some patch entries lack `id`, so partial `agents.list` updates no longer drop unrelated agents. (#17989) Thanks @stakeswky.
-- Config/Discord: require string IDs in Discord allowlists and add doctor repair for numeric entries. (#18220) Thanks @thewilloftheshadow.
+- Config/Discord: require string IDs in Discord allowlists, keep onboarding inputs string-only, and add doctor repair for numeric entries. (#18220) Thanks @thewilloftheshadow.
 - Agents/Models: probe the primary model when its auth-profile cooldown is near expiry (with per-provider throttling), so runs recover from temporary rate limits without staying on fallback models until restart. (#17478) Thanks @PlayerGhost.
 - Telegram: keep draft-stream preview replies attached to the user message for `replyToMode: "all"` in groups and DMs, preserving threaded reply context from preview through finalization. (#17880) Thanks @yinghaosang.
 - Telegram: disable block streaming when `channels.telegram.streamMode` is `off`, preventing newline/content-block replies from splitting into multiple messages. (#17679) Thanks @saivarunk.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 - Security/Sessions: create new session transcript JSONL files with user-only (`0o600`) permissions and extend `openclaw security audit --fix` to remediate existing transcript file permissions.
 - Infra/Fetch: ensure foreign abort-signal listener cleanup never masks original fetch successes/failures, while still preventing detached-finally unhandled rejection noise in `wrapFetchWithAbortSignal`. Thanks @Jackten.
 - Gateway/Config: prevent `config.patch` object-array merges from falling back to full-array replacement when some patch entries lack `id`, so partial `agents.list` updates no longer drop unrelated agents. (#17989) Thanks @stakeswky.
+- Config/Discord: require string IDs in Discord allowlists and add doctor repair for numeric entries. (#18220) Thanks @thewilloftheshadow.
 - Agents/Models: probe the primary model when its auth-profile cooldown is near expiry (with per-provider throttling), so runs recover from temporary rate limits without staying on fallback models until restart. (#17478) Thanks @PlayerGhost.
 - Telegram: keep draft-stream preview replies attached to the user message for `replyToMode: "all"` in groups and DMs, preserving threaded reply context from preview through finalization. (#17880) Thanks @yinghaosang.
 - Telegram: disable block streaming when `channels.telegram.streamMode` is `off`, preventing newline/content-block replies from splitting into multiple messages. (#17679) Thanks @saivarunk.

--- a/src/channels/plugins/onboarding/discord.ts
+++ b/src/channels/plugins/onboarding/discord.ts
@@ -17,14 +17,23 @@ import { resolveDiscordUserAllowlist } from "../../../discord/resolve-users.js";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../../../routing/session-key.js";
 import { formatDocsLink } from "../../../terminal/links.js";
 import { promptChannelAccessConfig } from "./channel-access.js";
-import { addWildcardAllowFrom, promptAccountId } from "./helpers.js";
+import { promptAccountId } from "./helpers.js";
+
+function addDiscordWildcardAllowFrom(allowFrom?: string[] | null): string[] {
+  const next = (allowFrom ?? []).map((entry) => entry.trim()).filter(Boolean);
+  if (!next.includes("*")) {
+    next.push("*");
+  }
+  return next;
+}
 
 const channel = "discord" as const;
 
 function setDiscordDmPolicy(cfg: OpenClawConfig, dmPolicy: DmPolicy) {
   const existingAllowFrom =
     cfg.channels?.discord?.allowFrom ?? cfg.channels?.discord?.dm?.allowFrom;
-  const allowFrom = dmPolicy === "open" ? addWildcardAllowFrom(existingAllowFrom) : undefined;
+  const allowFrom =
+    dmPolicy === "open" ? addDiscordWildcardAllowFrom(existingAllowFrom) : undefined;
   return {
     ...cfg,
     channels: {

--- a/src/commands/doctor-config-flow.e2e.test.ts
+++ b/src/commands/doctor-config-flow.e2e.test.ts
@@ -144,4 +144,113 @@ describe("doctor config flow", () => {
       vi.unstubAllGlobals();
     }
   });
+
+  it("converts numeric discord ids to strings on repair", async () => {
+    await withTempHome(async (home) => {
+      const configDir = path.join(home, ".openclaw");
+      await fs.mkdir(configDir, { recursive: true });
+      await fs.writeFile(
+        path.join(configDir, "openclaw.json"),
+        JSON.stringify(
+          {
+            channels: {
+              discord: {
+                allowFrom: [123],
+                dm: { allowFrom: [456], groupChannels: [789] },
+                execApprovals: { approvers: [321] },
+                guilds: {
+                  "100": {
+                    users: [111],
+                    roles: [222],
+                    channels: {
+                      general: { users: [333], roles: [444] },
+                    },
+                  },
+                },
+                accounts: {
+                  work: {
+                    allowFrom: [555],
+                    dm: { allowFrom: [666], groupChannels: [777] },
+                    execApprovals: { approvers: [888] },
+                    guilds: {
+                      "200": {
+                        users: [999],
+                        roles: [1010],
+                        channels: {
+                          help: { users: [1111], roles: [1212] },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+
+      const result = await loadAndMaybeMigrateDoctorConfig({
+        options: { nonInteractive: true, repair: true },
+        confirm: async () => false,
+      });
+
+      const cfg = result.cfg as unknown as {
+        channels: {
+          discord: {
+            allowFrom: string[];
+            dm: { allowFrom: string[]; groupChannels: string[] };
+            execApprovals: { approvers: string[] };
+            guilds: Record<
+              string,
+              {
+                users: string[];
+                roles: string[];
+                channels: Record<string, { users: string[]; roles: string[] }>;
+              }
+            >;
+            accounts: Record<
+              string,
+              {
+                allowFrom: string[];
+                dm: { allowFrom: string[]; groupChannels: string[] };
+                execApprovals: { approvers: string[] };
+                guilds: Record<
+                  string,
+                  {
+                    users: string[];
+                    roles: string[];
+                    channels: Record<string, { users: string[]; roles: string[] }>;
+                  }
+                >;
+              }
+            >;
+          };
+        };
+      };
+
+      expect(cfg.channels.discord.allowFrom).toEqual(["123"]);
+      expect(cfg.channels.discord.dm.allowFrom).toEqual(["456"]);
+      expect(cfg.channels.discord.dm.groupChannels).toEqual(["789"]);
+      expect(cfg.channels.discord.execApprovals.approvers).toEqual(["321"]);
+      expect(cfg.channels.discord.guilds["100"].users).toEqual(["111"]);
+      expect(cfg.channels.discord.guilds["100"].roles).toEqual(["222"]);
+      expect(cfg.channels.discord.guilds["100"].channels.general.users).toEqual(["333"]);
+      expect(cfg.channels.discord.guilds["100"].channels.general.roles).toEqual(["444"]);
+      expect(cfg.channels.discord.accounts.work.allowFrom).toEqual(["555"]);
+      expect(cfg.channels.discord.accounts.work.dm.allowFrom).toEqual(["666"]);
+      expect(cfg.channels.discord.accounts.work.dm.groupChannels).toEqual(["777"]);
+      expect(cfg.channels.discord.accounts.work.execApprovals.approvers).toEqual(["888"]);
+      expect(cfg.channels.discord.accounts.work.guilds["200"].users).toEqual(["999"]);
+      expect(cfg.channels.discord.accounts.work.guilds["200"].roles).toEqual(["1010"]);
+      expect(cfg.channels.discord.accounts.work.guilds["200"].channels.help.users).toEqual([
+        "1111",
+      ]);
+      expect(cfg.channels.discord.accounts.work.guilds["200"].channels.help.roles).toEqual([
+        "1212",
+      ]);
+    });
+  });
 });

--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -17,11 +17,11 @@ export type DiscordDmConfig = {
   /** Direct message access policy (default: pairing). */
   policy?: DmPolicy;
   /** Allowlist for DM senders (ids or names). */
-  allowFrom?: Array<string | number>;
+  allowFrom?: string[];
   /** If true, allow group DMs (default: false). */
   groupEnabled?: boolean;
   /** Optional allowlist for group DM channels (ids or slugs). */
-  groupChannels?: Array<string | number>;
+  groupChannels?: string[];
 };
 
 export type DiscordGuildChannelConfig = {
@@ -35,9 +35,9 @@ export type DiscordGuildChannelConfig = {
   /** If false, disable the bot for this channel. */
   enabled?: boolean;
   /** Optional allowlist for channel senders (ids or names). */
-  users?: Array<string | number>;
+  users?: string[];
   /** Optional allowlist for channel senders by role ID. */
-  roles?: Array<string | number>;
+  roles?: string[];
   /** Optional system prompt snippet for this channel. */
   systemPrompt?: string;
   /** If false, omit thread starter context for this channel (default: true). */
@@ -55,9 +55,9 @@ export type DiscordGuildEntry = {
   /** Reaction notification mode (off|own|all|allowlist). Default: own. */
   reactionNotifications?: DiscordReactionNotificationMode;
   /** Optional allowlist for guild senders (ids or names). */
-  users?: Array<string | number>;
+  users?: string[];
   /** Optional allowlist for guild senders by role ID. */
-  roles?: Array<string | number>;
+  roles?: string[];
   channels?: Record<string, DiscordGuildChannelConfig>;
 };
 
@@ -95,7 +95,7 @@ export type DiscordExecApprovalConfig = {
   /** Enable exec approval forwarding to Discord DMs. Default: false. */
   enabled?: boolean;
   /** Discord user IDs to receive approval prompts. Required if enabled. */
-  approvers?: Array<string | number>;
+  approvers?: string[];
   /** Only forward approvals for these agent IDs. Omit = all agents. */
   agentFilter?: string[];
   /** Only forward approvals matching these session key patterns (substring or regex). */
@@ -182,7 +182,7 @@ export type DiscordAccountConfig = {
    * Alias for dm.allowFrom (prefer this so it inherits cleanly via base->account shallow merge).
    * Legacy key: channels.discord.dm.allowFrom.
    */
-  allowFrom?: Array<string | number>;
+  allowFrom?: string[];
   dm?: DiscordDmConfig;
   /** New per-guild config keyed by guild id or slug. */
   guilds?: Record<string, DiscordGuildEntry>;

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -25,6 +25,13 @@ import { sensitive } from "./zod-schema.sensitive.js";
 
 const ToolPolicyBySenderSchema = z.record(z.string(), ToolPolicySchema).optional();
 
+const DiscordIdSchema = z
+  .union([z.string(), z.number()])
+  .refine((value) => typeof value === "string", {
+    message: "Discord IDs must be strings (wrap numeric IDs in quotes).",
+  });
+const DiscordIdListSchema = z.array(DiscordIdSchema);
+
 const TelegramInlineButtonsScopeSchema = z.enum(["off", "dm", "group", "all", "allowlist"]);
 
 const TelegramCapabilitiesSchema = z.union([
@@ -214,9 +221,9 @@ export const DiscordDmSchema = z
   .object({
     enabled: z.boolean().optional(),
     policy: DmPolicySchema.optional(),
-    allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+    allowFrom: DiscordIdListSchema.optional(),
     groupEnabled: z.boolean().optional(),
-    groupChannels: z.array(z.union([z.string(), z.number()])).optional(),
+    groupChannels: DiscordIdListSchema.optional(),
   })
   .strict();
 
@@ -228,8 +235,8 @@ export const DiscordGuildChannelSchema = z
     toolsBySender: ToolPolicyBySenderSchema,
     skills: z.array(z.string()).optional(),
     enabled: z.boolean().optional(),
-    users: z.array(z.union([z.string(), z.number()])).optional(),
-    roles: z.array(z.union([z.string(), z.number()])).optional(),
+    users: DiscordIdListSchema.optional(),
+    roles: DiscordIdListSchema.optional(),
     systemPrompt: z.string().optional(),
     includeThreadStarter: z.boolean().optional(),
     autoThread: z.boolean().optional(),
@@ -243,8 +250,8 @@ export const DiscordGuildSchema = z
     tools: ToolPolicySchema,
     toolsBySender: ToolPolicyBySenderSchema,
     reactionNotifications: z.enum(["off", "own", "all", "allowlist"]).optional(),
-    users: z.array(z.union([z.string(), z.number()])).optional(),
-    roles: z.array(z.union([z.string(), z.number()])).optional(),
+    users: DiscordIdListSchema.optional(),
+    roles: DiscordIdListSchema.optional(),
     channels: z.record(z.string(), DiscordGuildChannelSchema.optional()).optional(),
   })
   .strict();
@@ -311,14 +318,14 @@ export const DiscordAccountSchema = z
     // Aliases for channels.discord.dm.policy / channels.discord.dm.allowFrom. Prefer these for
     // inheritance in multi-account setups (shallow merge works; nested dm object doesn't).
     dmPolicy: DmPolicySchema.optional(),
-    allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+    allowFrom: DiscordIdListSchema.optional(),
     dm: DiscordDmSchema.optional(),
     guilds: z.record(z.string(), DiscordGuildSchema.optional()).optional(),
     heartbeat: ChannelHeartbeatVisibilitySchema,
     execApprovals: z
       .object({
         enabled: z.boolean().optional(),
-        approvers: z.array(z.union([z.string(), z.number()])).optional(),
+        approvers: DiscordIdListSchema.optional(),
         agentFilter: z.array(z.string()).optional(),
         sessionFilter: z.array(z.string()).optional(),
         cleanupAfterResolve: z.boolean().optional(),

--- a/src/discord/monitor/agent-components.ts
+++ b/src/discord/monitor/agent-components.ts
@@ -334,7 +334,7 @@ export type AgentComponentContext = {
   token?: string;
   guildEntries?: Record<string, DiscordGuildEntryResolved>;
   /** DM allowlist (from allowFrom config; legacy: dm.allowFrom) */
-  allowFrom?: Array<string | number>;
+  allowFrom?: string[];
   /** DM policy (default: "pairing") */
   dmPolicy?: "open" | "pairing" | "allowlist" | "disabled";
 };

--- a/src/discord/monitor/allow-list.ts
+++ b/src/discord/monitor/allow-list.ts
@@ -21,8 +21,8 @@ export type DiscordGuildEntryResolved = {
   slug?: string;
   requireMention?: boolean;
   reactionNotifications?: "off" | "own" | "all" | "allowlist";
-  users?: Array<string | number>;
-  roles?: Array<string | number>;
+  users?: string[];
+  roles?: string[];
   channels?: Record<
     string,
     {
@@ -30,8 +30,8 @@ export type DiscordGuildEntryResolved = {
       requireMention?: boolean;
       skills?: string[];
       enabled?: boolean;
-      users?: Array<string | number>;
-      roles?: Array<string | number>;
+      users?: string[];
+      roles?: string[];
       systemPrompt?: string;
       includeThreadStarter?: boolean;
       autoThread?: boolean;
@@ -44,8 +44,8 @@ export type DiscordChannelConfigResolved = {
   requireMention?: boolean;
   skills?: string[];
   enabled?: boolean;
-  users?: Array<string | number>;
-  roles?: Array<string | number>;
+  users?: string[];
+  roles?: string[];
   systemPrompt?: string;
   includeThreadStarter?: boolean;
   autoThread?: boolean;
@@ -53,10 +53,7 @@ export type DiscordChannelConfigResolved = {
   matchSource?: ChannelMatchSource;
 };
 
-export function normalizeDiscordAllowList(
-  raw: Array<string | number> | undefined,
-  prefixes: string[],
-) {
+export function normalizeDiscordAllowList(raw: string[] | undefined, prefixes: string[]) {
   if (!raw || raw.length === 0) {
     return null;
   }
@@ -141,7 +138,7 @@ export function resolveDiscordAllowListMatch(params: {
 }
 
 export function resolveDiscordUserAllowed(params: {
-  allowList?: Array<string | number>;
+  allowList?: string[];
   userId: string;
   userName?: string;
   userTag?: string;
@@ -158,10 +155,10 @@ export function resolveDiscordUserAllowed(params: {
 }
 
 export function resolveDiscordRoleAllowed(params: {
-  allowList?: Array<string | number>;
+  allowList?: string[];
   memberRoleIds: string[];
 }) {
-  // Role allowlists accept role IDs only (string or number). Names are ignored.
+  // Role allowlists accept role IDs only. Names are ignored.
   const allowList = normalizeDiscordAllowList(params.allowList, ["role:"]);
   if (!allowList) {
     return true;
@@ -173,8 +170,8 @@ export function resolveDiscordRoleAllowed(params: {
 }
 
 export function resolveDiscordMemberAllowed(params: {
-  userAllowList?: Array<string | number>;
-  roleAllowList?: Array<string | number>;
+  userAllowList?: string[];
+  roleAllowList?: string[];
   memberRoleIds: string[];
   userId: string;
   userName?: string;
@@ -253,7 +250,7 @@ export function resolveDiscordOwnerAllowFrom(params: {
 
 export function resolveDiscordCommandAuthorized(params: {
   isDirectMessage: boolean;
-  allowFrom?: Array<string | number>;
+  allowFrom?: string[];
   guildInfo?: DiscordGuildEntryResolved | null;
   author: User;
 }) {
@@ -478,7 +475,7 @@ export function isDiscordGroupAllowedByPolicy(params: {
 }
 
 export function resolveGroupDmAllow(params: {
-  channels?: Array<string | number>;
+  channels?: string[];
   channelId: string;
   channelName?: string;
   channelSlug: string;
@@ -503,7 +500,7 @@ export function shouldEmitDiscordReactionNotification(params: {
   userId: string;
   userName?: string;
   userTag?: string;
-  allowlist?: Array<string | number>;
+  allowlist?: string[];
 }) {
   const mode = params.mode ?? "own";
   if (mode === "off") {

--- a/src/discord/monitor/exec-approvals.ts
+++ b/src/discord/monitor/exec-approvals.ts
@@ -721,7 +721,7 @@ export class DiscordExecApprovalHandler {
   }
 
   /** Return the list of configured approver IDs. */
-  getApprovers(): Array<string | number> {
+  getApprovers(): string[] {
     return this.opts.config.approvers ?? [];
   }
 }

--- a/src/discord/monitor/message-handler.preflight.types.ts
+++ b/src/discord/monitor/message-handler.preflight.types.ts
@@ -95,8 +95,8 @@ export type DiscordMessagePreflightParams = {
   replyToMode: ReplyToMode;
   dmEnabled: boolean;
   groupDmEnabled: boolean;
-  groupDmChannels?: Array<string | number>;
-  allowFrom?: Array<string | number>;
+  groupDmChannels?: string[];
+  allowFrom?: string[];
   guildEntries?: Record<string, DiscordGuildEntryResolved>;
   ackReactionScope: DiscordMessagePreflightContext["ackReactionScope"];
   groupPolicy: DiscordMessagePreflightContext["groupPolicy"];

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -77,7 +77,7 @@ export type MonitorDiscordOpts = {
   replyToMode?: ReplyToMode;
 };
 
-function summarizeAllowList(list?: Array<string | number>) {
+function summarizeAllowList(list?: string[]) {
   if (!list || list.length === 0) {
     return "any";
   }
@@ -352,7 +352,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
               continue;
             }
             const nextGuild = { ...guildConfig } as Record<string, unknown>;
-            const users = (guildConfig as { users?: Array<string | number> }).users;
+            const users = (guildConfig as { users?: string[] }).users;
             if (Array.isArray(users) && users.length > 0) {
               const additions = resolveAllowlistIdAdditions({ existing: users, resolvedMap });
               nextGuild.users = mergeAllowlist({ existing: users, additions });


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Discord config allowlists accepted numeric IDs, which can be parsed inconsistently across JSON5/users.
- Why it matters: Discord IDs should be treated as strings everywhere to avoid truncation or schema ambiguity.
- What changed: Enforced string-only Discord IDs in config schema/types and added doctor repairs to convert numeric IDs.
- What did NOT change (scope boundary): No changes to non-Discord providers or runtime routing logic beyond type validation.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Discord config now rejects numeric IDs in allowlists; run `openclaw doctor --fix` to convert numeric IDs to strings.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any): Discord
- Relevant config (redacted):

### Steps

1. Set `channels.discord.allowFrom: [123]`.
2. Run config validation or `openclaw doctor`.

### Expected

- Config validation fails with a Discord ID string error, or doctor converts to strings.

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Not run locally.
- Edge cases checked: Not run locally.
- What you did **not** verify: Automated tests and manual Discord flows.

## Compatibility / Migration

- Backward compatible? (No)
- Config/env changes? (Yes)
- Migration needed? (Yes)
- If yes, exact upgrade steps:
  - Run `openclaw doctor --fix` to convert numeric Discord IDs to strings.

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR or remove the schema restriction.
- Files/config to restore: `src/config/zod-schema.providers-core.ts`, `src/commands/doctor-config-flow.ts`.
- Known bad symptoms reviewers should watch for: Discord configs with numeric IDs marked invalid.

## Risks and Mitigations

- Risk: Users with numeric Discord IDs in config will see validation errors.
  - Mitigation: Doctor repair converts numeric IDs to strings.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Enforced string-only Discord IDs across config schema, types, and runtime to prevent JSON parsing inconsistencies and truncation. Added `DiscordIdSchema` validator with `.refine()` that accepts numbers but only passes strings, providing clear error messages. Implemented `maybeRepairDiscordNumericIds()` in doctor flow to auto-convert numeric IDs to strings via `structuredClone` + map transformation across all Discord allowlist paths (DMs, guilds, channels, roles, approvers). Updated 10 files with comprehensive type changes from `Array<string | number>` to `string[]` for type safety.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor migration risk for users with numeric Discord IDs in config
- Well-designed implementation with thorough test coverage, automatic migration via doctor, and clear error messages. Schema validation is sound and type changes are consistent. One concern: users must run `openclaw doctor --fix` to migrate, which could cause friction if not communicated clearly.
- No files require special attention - implementation is clean and well-tested

<sub>Last reviewed commit: e73a3d6</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->