### PR TITLE
message send: preserve components payload instead of dropping it                                 

### DIFF
--- a/src/cli/program/message/register.send.ts
+++ b/src/cli/program/message/register.send.ts
@@ -19,6 +19,7 @@ export function registerMessageSendCommand(message: Command, helpers: MessageCli
           "--buttons <json>",
           "Telegram inline keyboard buttons as JSON (array of button rows)",
         )
+        .option("--components <json>", "Discord components payload as JSON")
         .option("--card <json>", "Adaptive Card JSON object (when supported by the channel)")
         .option("--reply-to <id>", "Reply-to message id")
         .option("--thread-id <id>", "Thread id (Telegram forum thread)")

--- a/src/infra/outbound/message-action-params.ts
+++ b/src/infra/outbound/message-action-params.ts
@@ -369,3 +369,20 @@ export function parseCardParam(params: Record<string, unknown>): void {
     throw new Error("--card must be valid JSON");
   }
 }
+
+export function parseComponentsParam(params: Record<string, unknown>): void {
+  const raw = params.components;
+  if (typeof raw !== "string") {
+    return;
+  }
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    delete params.components;
+    return;
+  }
+  try {
+    params.components = JSON.parse(trimmed) as unknown;
+  } catch {
+    throw new Error("--components must be valid JSON");
+  }
+}

--- a/src/infra/outbound/message-action-runner.test.ts
+++ b/src/infra/outbound/message-action-runner.test.ts
@@ -756,6 +756,77 @@ describe("runMessageAction card-only send behavior", () => {
   });
 });
 
+describe("runMessageAction components parsing", () => {
+  const handleAction = vi.fn(async ({ params }: { params: Record<string, unknown> }) =>
+    jsonResult({
+      ok: true,
+      components: params.components ?? null,
+    }),
+  );
+
+  const componentsPlugin: ChannelPlugin = {
+    id: "discord",
+    meta: {
+      id: "discord",
+      label: "Discord",
+      selectionLabel: "Discord",
+      docsPath: "/channels/discord",
+      blurb: "Discord components send test plugin.",
+    },
+    capabilities: { chatTypes: ["direct"] },
+    config: {
+      listAccountIds: () => ["default"],
+      resolveAccount: () => ({}),
+      isConfigured: () => true,
+    },
+    actions: {
+      listActions: () => ["send"],
+      supportsAction: ({ action }) => action === "send",
+      handleAction,
+    },
+  };
+
+  beforeEach(() => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "discord",
+          source: "test",
+          plugin: componentsPlugin,
+        },
+      ]),
+    );
+    handleAction.mockClear();
+  });
+
+  afterEach(() => {
+    setActivePluginRegistry(createTestRegistry([]));
+    vi.clearAllMocks();
+  });
+
+  it("parses components JSON strings before plugin dispatch", async () => {
+    const components = {
+      text: "hello",
+      buttons: [{ label: "A", customId: "a" }],
+    };
+    const result = await runMessageAction({
+      cfg: {} as OpenClawConfig,
+      action: "send",
+      params: {
+        channel: "discord",
+        target: "channel:123",
+        message: "hi",
+        components: JSON.stringify(components),
+      },
+      dryRun: false,
+    });
+
+    expect(result.kind).toBe("send");
+    expect(handleAction).toHaveBeenCalled();
+    expect(result.payload).toMatchObject({ ok: true, components });
+  });
+});
+
 describe("runMessageAction accountId defaults", () => {
   const handleAction = vi.fn(async () => jsonResult({ ok: true }));
   const accountPlugin: ChannelPlugin = {

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -34,6 +34,7 @@ import {
   normalizeSandboxMediaParams,
   parseButtonsParam,
   parseCardParam,
+  parseComponentsParam,
   readBooleanParam,
   resolveSlackAutoThreadId,
   resolveTelegramAutoThreadId,
@@ -697,6 +698,7 @@ export async function runMessageAction(
       : undefined);
   parseButtonsParam(params);
   parseCardParam(params);
+  parseComponentsParam(params);
 
   const action = input.action;
   if (action === "broadcast") {


### PR DESCRIPTION
Fixes `openclaw message send` dropping `components` when passed as JSON string.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes `openclaw message send` dropping the `--components` payload by adding JSON string parsing for the `components` parameter, mirroring the existing `parseButtonsParam` and `parseCardParam` patterns.

- Adds `--components <json>` CLI option to `register.send.ts`, consistent with existing `--buttons` and `--card` options
- Adds `parseComponentsParam()` in `message-action-params.ts`, following the identical parse-or-throw pattern used by `parseButtonsParam` and `parseCardParam`
- Calls `parseComponentsParam(params)` in `runMessageAction()` alongside the existing button/card parsers, ensuring JSON string components are deserialized before plugin dispatch
- Adds an integration test verifying that stringified components are correctly parsed and forwarded to the Discord plugin handler

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it adds a straightforward JSON parsing path for components that mirrors existing, well-tested patterns.
- All changes follow the exact same pattern as existing `parseButtonsParam` and `parseCardParam`. The new `parseComponentsParam` is structurally identical. The CLI option registration, runner integration, and test coverage are all consistent with existing code. No new logic paths, no edge cases missed, and downstream consumers already handle `components` as objects.
- No files require special attention.

<sub>Last reviewed commit: 9dccb3a</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->