### PR TITLE
fix(agents): validate base64 image data before LLM API submission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/Images: validate base64 data and strip data-URL prefixes in `sanitizeContentBlocksImages` before sending to the LLM API, preventing invalid image payloads from crashing sessions permanently. (#18212)
 - Security/Sessions: create new session transcript JSONL files with user-only (`0o600`) permissions and extend `openclaw security audit --fix` to remediate existing transcript file permissions.
 - Infra/Fetch: ensure foreign abort-signal listener cleanup never masks original fetch successes/failures, while still preventing detached-finally unhandled rejection noise in `wrapFetchWithAbortSignal`. Thanks @Jackten.
 - Gateway/Config: prevent `config.patch` object-array merges from falling back to full-array replacement when some patch entries lack `id`, so partial `agents.list` updates no longer drop unrelated agents. (#17989) Thanks @stakeswky.

--- a/src/agents/tool-images.validation.test.ts
+++ b/src/agents/tool-images.validation.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeContentBlocksImages } from "./tool-images.js";
+
+describe("sanitizeContentBlocksImages base64 validation", () => {
+  it("drops image blocks with invalid base64 data", async () => {
+    const blocks = [
+      {
+        type: "image" as const,
+        data: "not!!valid==base64",
+        mimeType: "image/jpeg",
+      },
+    ];
+
+    const out = await sanitizeContentBlocksImages(blocks, "test");
+    expect(out).toHaveLength(1);
+    expect(out[0].type).toBe("text");
+    expect((out[0] as { text: string }).text).toContain("invalid base64");
+  });
+
+  it("drops image blocks with truncated base64 (length not multiple of 4)", async () => {
+    const blocks = [
+      {
+        type: "image" as const,
+        data: "abc",
+        mimeType: "image/png",
+      },
+    ];
+
+    const out = await sanitizeContentBlocksImages(blocks, "test");
+    expect(out).toHaveLength(1);
+    expect(out[0].type).toBe("text");
+    expect((out[0] as { text: string }).text).toContain("invalid base64");
+  });
+
+  it("strips data URL prefix before validation", async () => {
+    // A valid 4x4 red JPEG in base64, wrapped in data URL prefix
+    // We use a minimal valid base64 string that passes validation
+    const validBase64 = "/9j/4AAQ"; // 8 chars, valid base64 (JPEG magic)
+    const blocks = [
+      {
+        type: "image" as const,
+        data: `data:image/jpeg;base64,${validBase64}`,
+        mimeType: "image/jpeg",
+      },
+    ];
+
+    const out = await sanitizeContentBlocksImages(blocks, "test");
+    // The data URL prefix is stripped; the base64 content is processed
+    // (it may fail during resize since it's not a real image, but it should
+    // NOT fail on the "invalid base64" check)
+    expect(out).toHaveLength(1);
+    if (out[0].type === "text") {
+      // If it becomes text, it's from the resize step, not from base64 validation
+      expect((out[0] as { text: string }).text).not.toContain("invalid base64");
+    }
+  });
+
+  it("replaces empty image blocks with descriptive text", async () => {
+    const blocks = [
+      {
+        type: "image" as const,
+        data: "   ",
+        mimeType: "image/png",
+      },
+    ];
+
+    const out = await sanitizeContentBlocksImages(blocks, "test");
+    expect(out).toHaveLength(1);
+    expect(out[0].type).toBe("text");
+    expect((out[0] as { text: string }).text).toContain("empty image payload");
+  });
+
+  it("passes through non-image blocks unchanged", async () => {
+    const blocks = [
+      {
+        type: "text" as const,
+        text: "Hello world",
+      },
+    ];
+
+    const out = await sanitizeContentBlocksImages(blocks, "test");
+    expect(out).toHaveLength(1);
+    expect(out[0]).toEqual({ type: "text", text: "Hello world" });
+  });
+});


### PR DESCRIPTION
## Summary
- Add base64 format validation in `sanitizeContentBlocksImages()` — invalid image blocks are replaced with descriptive text instead of being sent to Anthropic (which rejects them with 400 and permanently breaks the session).
- Strip `data:<mime>;base64,` prefixes before validation, handling a common source of "invalid base64" errors.
- Reuse the same validation pattern (`length % 4 === 0`, valid charset `[A-Za-z0-9+/=]`) already used in `chat-attachments.ts`.

Closes #18212

## Test plan
- [x] New `tool-images.validation.test.ts` with 5 tests: invalid base64 dropped, truncated base64 dropped, data URL prefix stripped, empty blocks handled, non-image blocks pass through
- [x] All existing tool-images tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds base64 validation to `sanitizeContentBlocksImages()` to prevent malformed image data from reaching the Anthropic API and permanently breaking agent sessions. The fix strips `data:<mime>;base64,` prefixes before validation and replaces invalid blocks with descriptive text fallbacks. Validation logic (`length % 4 === 0`, `[A-Za-z0-9+/=]` charset) matches the existing pattern in `src/gateway/chat-attachments.ts:44-46`, ensuring consistency across the codebase.

- Prevents session-breaking 400 errors from Anthropic API when invalid base64 is submitted
- Strips data URL prefixes (common source of validation failures) before checking base64 format
- Replaces invalid/empty image blocks with informative text placeholders
- Maintains existing behavior for valid images (resize/compression logic unchanged)
- Test suite covers key scenarios: invalid charset, truncated data, data URL stripping, empty payloads, non-image passthrough

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no risk
- The implementation is a defensive guard that prevents invalid data from reaching the API. The validation logic directly matches existing patterns in the codebase (`chat-attachments.ts`), comprehensive test coverage validates all edge cases, and the fallback behavior (converting to text blocks) is safe and informative.
- No files require special attention

<sub>Last reviewed commit: dc1fb74</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->