### PR TITLE
fix(canvas): port remaining iOS branch stability fixes

### DIFF
--- a/src/gateway/server-constants.ts
+++ b/src/gateway/server-constants.ts
@@ -1,5 +1,7 @@
-export const MAX_PAYLOAD_BYTES = 8 * 1024 * 1024; // cap incoming frame size (~8 MiB; fits ~5,000,000 decoded bytes as base64 + JSON overhead)
-export const MAX_BUFFERED_BYTES = 16 * 1024 * 1024; // per-connection send buffer limit (2x max payload)
+// Keep server maxPayload aligned with gateway client maxPayload so high-res canvas snapshots
+// don't get disconnected mid-invoke with "Max payload size exceeded".
+export const MAX_PAYLOAD_BYTES = 25 * 1024 * 1024;
+export const MAX_BUFFERED_BYTES = 50 * 1024 * 1024; // per-connection send buffer limit (2x max payload)
 
 const DEFAULT_MAX_CHAT_HISTORY_MESSAGES_BYTES = 6 * 1024 * 1024; // keep history responses comfortably under client WS limits
 let maxChatHistoryMessagesBytes = DEFAULT_MAX_CHAT_HISTORY_MESSAGES_BYTES;

--- a/src/infra/canvas-host-url.ts
+++ b/src/infra/canvas-host-url.ts
@@ -25,14 +25,25 @@ const normalizeHost = (value: HostSource, rejectLoopback: boolean) => {
   return trimmed;
 };
 
-const parseHostHeader = (value: HostSource) => {
+type ParsedHostHeader = {
+  host: string;
+  port?: number;
+};
+
+const parseHostHeader = (value: HostSource): ParsedHostHeader => {
   if (!value) {
-    return "";
+    return { host: "" };
   }
   try {
-    return new URL(`http://${String(value).trim()}`).hostname;
+    const parsed = new URL(`http://${String(value).trim()}`);
+    const portRaw = parsed.port.trim();
+    const port = portRaw ? Number.parseInt(portRaw, 10) : undefined;
+    return {
+      host: parsed.hostname,
+      port: Number.isFinite(port) ? port : undefined,
+    };
   } catch {
-    return "";
+    return { host: "" };
   }
 };
 
@@ -54,13 +65,29 @@ export function resolveCanvasHostUrl(params: CanvasHostUrlParams) {
     (parseForwardedProto(params.forwardedProto)?.trim() === "https" ? "https" : "http");
 
   const override = normalizeHost(params.hostOverride, true);
-  const requestHost = normalizeHost(parseHostHeader(params.requestHost), !!override);
+  const parsedRequestHost = parseHostHeader(params.requestHost);
+  const requestHost = normalizeHost(parsedRequestHost.host, !!override);
   const localAddress = normalizeHost(params.localAddress, Boolean(override || requestHost));
 
   const host = override || requestHost || localAddress;
   if (!host) {
     return undefined;
   }
+
+  // When the websocket is proxied over HTTPS (for example Tailscale Serve), the gateway's
+  // internal listener still runs on 18789. In that case, expose the public port instead of
+  // advertising the internal one back to clients.
+  let exposedPort = port;
+  if (!override && requestHost && port === 18789) {
+    if (parsedRequestHost.port && parsedRequestHost.port > 0) {
+      exposedPort = parsedRequestHost.port;
+    } else if (scheme === "https") {
+      exposedPort = 443;
+    } else if (scheme === "http") {
+      exposedPort = 80;
+    }
+  }
+
   const formatted = host.includes(":") ? `[${host}]` : host;
-  return `${scheme}://${formatted}:${port}`;
+  return `${scheme}://${formatted}:${exposedPort}`;
 }


### PR DESCRIPTION
## Summary
- cherry-pick remaining production fixes from `ios-new-alpha-core`
- include gateway proxy snapshot disconnect prevention
- include `url` alias support for `present` and `navigate` canvas payloads

## Source commits
- `2a3c9f746`
- `674ee86a0`

## Validation
- `pnpm build`
- `pnpm check`
- `pnpm test`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Cherry-picks production stability fixes from the `ios-new-alpha-core` branch, including three key improvements:

- Prevents gateway snapshot disconnects on proxied setups (Tailscale Serve) by exposing the correct public port instead of the internal 18789 port
- Increases WebSocket payload limits from 8MB to 25MB to accommodate high-resolution canvas snapshots without mid-invoke disconnections
- Adds `url`/`target` field aliasing for `present` and `navigate` canvas actions to match common caller expectations and improve API flexibility
- Fixes Swift timeout task cancellation handling to avoid unexpected errors when invoke completes before timeout

All changes are backward-compatible and address real production issues encountered during iOS alpha testing.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - well-tested production fixes with backward compatibility
- Cherry-picked from production branch with clear validation steps (build, check, test). Changes are minimal, focused, and backward-compatible. The payload size increase is documented and justified. Port resolution logic correctly handles edge cases. Swift cancellation handling follows best practices.
- No files require special attention

<sub>Last reviewed commit: 8ed1d34</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->