### PR TITLE
macOS daemon: bootstrap LaunchAgent on gateway start after stop

### DIFF
--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeepLinksIPv6Tests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeepLinksIPv6Tests.swift
@@ -1,0 +1,37 @@
+import Foundation
+import OpenClawKit
+import Testing
+
+@Suite struct DeepLinksIPv6Tests {
+    @Test func setupCodeFromIPv6PreservesConnectableWebsocketURL() {
+        let payload = #"{"url":"wss://[fd7a:115c:a1e0::1]:443","token":"tok"}"#
+        let encoded = Self.base64UrlEncode(payload)
+
+        let link = GatewayConnectDeepLink.fromSetupCode(encoded)
+
+        #expect(link?.host == "fd7a:115c:a1e0::1")
+        #expect(link?.port == 443)
+        #expect(link?.tls == true)
+        #expect(link?.websocketURL?.absoluteString == "wss://[fd7a:115c:a1e0::1]:443")
+    }
+
+    @Test func websocketURLSupportsBracketedIPv6HostInput() {
+        let link = GatewayConnectDeepLink(
+            host: "[fd7a:115c:a1e0::1]",
+            port: 18789,
+            tls: false,
+            token: nil,
+            password: nil
+        )
+
+        #expect(link.websocketURL?.absoluteString == "ws://[fd7a:115c:a1e0::1]:18789")
+    }
+
+    private static func base64UrlEncode(_ input: String) -> String {
+        Data(input.utf8)
+            .base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}

--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -150,22 +150,27 @@ export async function runServiceStart(params: {
     return;
   }
   if (!loaded) {
-    await handleServiceNotLoaded({
-      serviceNoun: params.serviceNoun,
-      service: params.service,
-      loaded,
-      renderStartHints: params.renderStartHints,
-      json,
-      emit,
-    });
-    return;
-  }
-  try {
-    await params.service.restart({ env: process.env, stdout });
-  } catch (err) {
-    const hints = params.renderStartHints();
-    fail(`${params.serviceNoun} start failed: ${String(err)}`, hints);
-    return;
+    try {
+      await params.service.start({ env: process.env, stdout });
+    } catch {
+      await handleServiceNotLoaded({
+        serviceNoun: params.serviceNoun,
+        service: params.service,
+        loaded,
+        renderStartHints: params.renderStartHints,
+        json,
+        emit,
+      });
+      return;
+    }
+  } else {
+    try {
+      await params.service.restart({ env: process.env, stdout });
+    } catch (err) {
+      const hints = params.renderStartHints();
+      fail(`${params.serviceNoun} start failed: ${String(err)}`, hints);
+      return;
+    }
   }
 
   let started = true;

--- a/src/daemon/node-service.ts
+++ b/src/daemon/node-service.ts
@@ -57,6 +57,9 @@ export function resolveNodeService(): GatewayService {
     restart: async (args) => {
       return base.restart({ ...args, env: withNodeServiceEnv(args.env ?? {}) });
     },
+    start: async (args) => {
+      return base.start({ ...args, env: withNodeServiceEnv(args.env ?? {}) });
+    },
     isLoaded: async (args) => {
       return base.isLoaded({ env: withNodeServiceEnv(args.env ?? {}) });
     },

--- a/src/daemon/service.ts
+++ b/src/daemon/service.ts
@@ -5,6 +5,7 @@ import {
   readLaunchAgentProgramArguments,
   readLaunchAgentRuntime,
   restartLaunchAgent,
+  startLaunchAgent,
   stopLaunchAgent,
   uninstallLaunchAgent,
 } from "./launchd.js";
@@ -53,6 +54,10 @@ export type GatewayService = {
     env?: Record<string, string | undefined>;
     stdout: NodeJS.WritableStream;
   }) => Promise<void>;
+  start: (args: {
+    env?: Record<string, string | undefined>;
+    stdout: NodeJS.WritableStream;
+  }) => Promise<void>;
   isLoaded: (args: { env?: Record<string, string | undefined> }) => Promise<boolean>;
   readCommand: (env: Record<string, string | undefined>) => Promise<{
     programArguments: string[];
@@ -87,6 +92,12 @@ export function resolveGatewayService(): GatewayService {
           env: args.env,
         });
       },
+      start: async (args) => {
+        await startLaunchAgent({
+          stdout: args.stdout,
+          env: args.env,
+        });
+      },
       isLoaded: async (args) => isLaunchAgentLoaded(args),
       readCommand: readLaunchAgentProgramArguments,
       readRuntime: readLaunchAgentRuntime,
@@ -116,6 +127,12 @@ export function resolveGatewayService(): GatewayService {
           env: args.env,
         });
       },
+      start: async (args) => {
+        await restartSystemdService({
+          stdout: args.stdout,
+          env: args.env,
+        });
+      },
       isLoaded: async (args) => isSystemdServiceEnabled(args),
       readCommand: readSystemdServiceExecStart,
       readRuntime: async (env) => await readSystemdServiceRuntime(env),
@@ -140,6 +157,12 @@ export function resolveGatewayService(): GatewayService {
         });
       },
       restart: async (args) => {
+        await restartScheduledTask({
+          stdout: args.stdout,
+          env: args.env,
+        });
+      },
+      start: async (args) => {
         await restartScheduledTask({
           stdout: args.stdout,
           env: args.env,

--- a/src/pairing/setup-code.test.ts
+++ b/src/pairing/setup-code.test.ts
@@ -146,4 +146,29 @@ describe("pairing setup code", () => {
     });
     expect(runCommandWithTimeout).not.toHaveBeenCalled();
   });
+
+  it("preserves IPv6 brackets when normalizing remote URL", async () => {
+    const resolved = await resolvePairingSetupFromConfig(
+      {
+        gateway: {
+          remote: { url: "wss://[fd7a:115c:a1e0::1]:443" },
+          auth: { mode: "token", token: "tok_123" },
+        },
+      },
+      {
+        preferRemoteUrl: true,
+      },
+    );
+
+    expect(resolved).toEqual({
+      ok: true,
+      payload: {
+        url: "wss://[fd7a:115c:a1e0::1]",
+        token: "tok_123",
+        password: undefined,
+      },
+      authLabel: "token",
+      urlSource: "gateway.remote.url",
+    });
+  });
 });

--- a/src/pairing/setup-code.ts
+++ b/src/pairing/setup-code.ts
@@ -69,12 +69,11 @@ function normalizeUrl(raw: string, schemeFallback: "ws" | "wss"): string | null 
     if (resolvedScheme !== "ws" && resolvedScheme !== "wss") {
       return null;
     }
-    const host = parsed.hostname;
+    const host = parsed.host;
     if (!host) {
       return null;
     }
-    const port = parsed.port ? `:${parsed.port}` : "";
-    return `${resolvedScheme}://${host}${port}`;
+    return `${resolvedScheme}://${host}`;
   } catch {
     // Fall through to host:port parsing.
   }


### PR DESCRIPTION
## Summary
Fixes a macOS daemon lifecycle bug where `openclaw gateway start` incorrectly reported the service as not installed after `openclaw gateway stop`.

Closes #17763.

## Root cause
On macOS, `gateway stop` runs `launchctl bootout`, which unloads the LaunchAgent but does not remove its plist.
The start flow only handled the `loaded` case (restart), and when unloaded it returned early with install hints instead of attempting bootstrap.

## Changes
- Added explicit `start` operation to the `GatewayService` interface.
- Implemented macOS `start` behavior via `startLaunchAgent`:
  - if loaded: restart with `kickstart -k`
  - if unloaded and plist exists: `bootstrap` + `kickstart -k`
  - if plist missing: throw clear error
- Updated CLI lifecycle start path to call `service.start(...)` when service is unloaded before falling back to hints.
- Added regression test coverage for unloaded-but-installed LaunchAgent start behavior.

## Verification
### Automated
- `pnpm test src/daemon/launchd.test.ts`

### Manual repro (macOS)
```bash
export OPENCLAW_PROFILE=bug17763
export OPENCLAW_STATE_DIR="$HOME/.openclaw-bug17763"

pnpm openclaw gateway install --force
pnpm openclaw gateway stop
pnpm openclaw gateway start
pnpm openclaw gateway status --no-probe
```

Observed after fix:
- `gateway start` reports `Started LaunchAgent: gui/<uid>/ai.openclaw.bug17763`
- `gateway status --no-probe` reports `Service: LaunchAgent (loaded)`
- no reinstall required between stop and start

## Commits
- `Daemon: start launch agent when unloaded`
- `Tests: cover launchd start bootstrap path`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes macOS daemon lifecycle bug where `gateway start` failed after `gateway stop` by adding explicit `start` operation that bootstraps unloaded LaunchAgents. Also fixes IPv6 websocket URL handling in pairing setup codes and Swift deep links.

**Main Changes:**
- Added `start()` method to `GatewayService` interface across all platforms (macOS/Linux/Windows)
- macOS `startLaunchAgent`: bootstraps + kickstarts when plist exists but service is unloaded
- CLI lifecycle: calls `service.start()` when unloaded, only shows install hints if that fails with expected errors
- Swift `GatewayConnectDeepLink`: normalizes IPv6 hosts (strips/adds brackets as needed) for proper websocket URL construction
- TypeScript pairing: changed from `hostname` to `host` to preserve port in IPv6 URLs

**Test Coverage:**
- New test for unloaded LaunchAgent bootstrap path
- Swift IPv6 deep link tests for setup code parsing and bracketed host input
- TypeScript pairing test for IPv6 URL preservation

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk
- The PR addresses a clear bug with well-scoped changes. The daemon lifecycle fix follows the existing pattern (restart/stop) and adds proper error handling. IPv6 fixes are straightforward string manipulation. Test coverage is good for both changes. The only minor concern is that the CLI error handling catches errors broadly, but this is mitigated by the `isExpectedNotLoadedStartError` check.
- No files require special attention

<sub>Last reviewed commit: 8d59787</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->