### PR TITLE
feat(ios): add background listening core toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - Cron/Gateway: separate per-job webhook delivery (`delivery.mode = "webhook"`) from announce delivery, enforce valid HTTP(S) webhook URLs, and keep a temporary legacy `notify + cron.webhook` fallback for stored jobs. (#17901) Thanks @advaitpaliwal.
+- iOS/Talk: add a `Background Listening` toggle that keeps Talk Mode active while the app is backgrounded (off by default for battery safety). Thanks @zeulewan.
 
 ### Fixes
 

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -114,6 +114,7 @@ final class NodeAppModel {
     private var talkVoiceWakeSuspended = false
     private var backgroundVoiceWakeSuspended = false
     private var backgroundTalkSuspended = false
+    private var backgroundTalkKeptActive = false
     private var backgroundedAt: Date?
     private var reconnectAfterBackgroundArmed = false
 
@@ -269,15 +270,18 @@ final class NodeAppModel {
 
 
     func setScenePhase(_ phase: ScenePhase) {
+        let keepTalkActive = UserDefaults.standard.bool(forKey: "talk.background.enabled")
         switch phase {
         case .background:
             self.isBackgrounded = true
             self.stopGatewayHealthMonitor()
             self.backgroundedAt = Date()
             self.reconnectAfterBackgroundArmed = true
-            // Be conservative: release the mic when the app backgrounds.
+            // Release voice wake mic in background.
             self.backgroundVoiceWakeSuspended = self.voiceWake.suspendForExternalAudioCapture()
-            self.backgroundTalkSuspended = self.talkMode.suspendForBackground()
+            let shouldKeepTalkActive = keepTalkActive && self.talkMode.isEnabled
+            self.backgroundTalkKeptActive = shouldKeepTalkActive
+            self.backgroundTalkSuspended = self.talkMode.suspendForBackground(keepActive: shouldKeepTalkActive)
         case .active, .inactive:
             self.isBackgrounded = false
             if self.operatorConnected {
@@ -289,8 +293,12 @@ final class NodeAppModel {
                 Task { [weak self] in
                     guard let self else { return }
                     let suspended = await MainActor.run { self.backgroundTalkSuspended }
-                    await MainActor.run { self.backgroundTalkSuspended = false }
-                    await self.talkMode.resumeAfterBackground(wasSuspended: suspended)
+                    let keptActive = await MainActor.run { self.backgroundTalkKeptActive }
+                    await MainActor.run {
+                        self.backgroundTalkSuspended = false
+                        self.backgroundTalkKeptActive = false
+                    }
+                    await self.talkMode.resumeAfterBackground(wasSuspended: suspended, wasKeptActive: keptActive)
                 }
             }
             if phase == .active, self.reconnectAfterBackgroundArmed {

--- a/apps/ios/Sources/Settings/SettingsTab.swift
+++ b/apps/ios/Sources/Settings/SettingsTab.swift
@@ -15,6 +15,7 @@ struct SettingsTab: View {
     @AppStorage("voiceWake.enabled") private var voiceWakeEnabled: Bool = false
     @AppStorage("talk.enabled") private var talkEnabled: Bool = false
     @AppStorage("talk.button.enabled") private var talkButtonEnabled: Bool = true
+    @AppStorage("talk.background.enabled") private var talkBackgroundEnabled: Bool = false
     @AppStorage("camera.enabled") private var cameraEnabled: Bool = true
     @AppStorage("location.enabledMode") private var locationEnabledModeRaw: String = OpenClawLocationMode.off.rawValue
     @AppStorage("location.preciseEnabled") private var locationPreciseEnabled: Bool = true
@@ -253,6 +254,10 @@ struct SettingsTab: View {
                             .textInputAutocapitalization(.never)
                             .autocorrectionDisabled()
                         Text("Use this local override when gateway config redacts talk.apiKey for mobile clients.")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                        Toggle("Background Listening", isOn: self.$talkBackgroundEnabled)
+                        Text("Keep listening when the app is in the background. Uses more battery.")
                             .font(.footnote)
                             .foregroundStyle(.secondary)
                         // Keep this separate so users can hide the side bubble without disabling Talk Mode.

--- a/apps/ios/Sources/Voice/TalkModeManager.swift
+++ b/apps/ios/Sources/Voice/TalkModeManager.swift
@@ -219,8 +219,12 @@ final class TalkModeManager: NSObject {
 
     /// Suspends microphone usage without disabling Talk Mode.
     /// Used when the app backgrounds (or when we need to temporarily release the mic).
-    func suspendForBackground() -> Bool {
+    func suspendForBackground(keepActive: Bool = false) -> Bool {
         guard self.isEnabled else { return false }
+        if keepActive {
+            self.statusText = self.isListening ? "Listening" : self.statusText
+            return false
+        }
         let wasActive = self.isListening || self.isSpeaking || self.isPushToTalkActive
 
         self.isListening = false
@@ -247,7 +251,8 @@ final class TalkModeManager: NSObject {
         return wasActive
     }
 
-    func resumeAfterBackground(wasSuspended: Bool) async {
+    func resumeAfterBackground(wasSuspended: Bool, wasKeptActive: Bool = false) async {
+        if wasKeptActive { return }
         guard wasSuspended else { return }
         guard self.isEnabled else { return }
         await self.start()


### PR DESCRIPTION
## Intent
Ship Slice 2 only: background listening core for iOS Talk Mode, with minimal lifecycle changes and no broader audio pipeline refactor.

## Changes
- add `Background Listening` toggle in Settings > Device > Features (`talk.background.enabled`)
- on app background, keep Talk Mode active when the toggle is enabled and Talk Mode is on
- on foreground return, skip unnecessary Talk restart when Talk was intentionally kept active
- add changelog entry with attribution

## Scope Guardrails
- no `voip` entitlement changes in this slice
- no route-change handling rewrite
- no chime/push-speech queue additions
- no chat.push behavior changes

## Attribution
- extracted from the background voice intent in #17319
- Thanks @zeulewan

## Validation
- `pnpm check`

## Notes
- This is the conservative core-only behavior slice. Hardening follow-ups (route handling, speaker bleed policy, etc.) will land in Slice 3.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added a conservative Background Listening toggle for iOS Talk Mode that allows the microphone to remain active when the app is backgrounded. The implementation correctly checks both the user preference (`talk.background.enabled`) and the current Talk Mode state before keeping listening active. State is properly tracked through the background/foreground cycle with the new `backgroundTalkKeptActive` flag, ensuring Talk Mode doesn't unnecessarily restart when it was intentionally kept running. The feature is off by default for battery conservation and has appropriate UI messaging about battery usage.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - conservative implementation with proper state management
- The implementation is clean, focused, and follows the stated scope guardrails. The logic correctly gates background listening on both user preference AND Talk Mode being enabled. State management through background/foreground transitions is sound with proper flag tracking. The app already has UIBackgroundModes audio entitlement, so no capability changes needed. Default-off provides safety, and the changelog properly documents the change.
- No files require special attention

<sub>Last reviewed commit: d7cf7b8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->