### PR TITLE
fix(ios): gate talk barge-in on isolated audio routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - Cron/Gateway: separate per-job webhook delivery (`delivery.mode = "webhook"`) from announce delivery, enforce valid HTTP(S) webhook URLs, and keep a temporary legacy `notify + cron.webhook` fallback for stored jobs. (#17901) Thanks @advaitpaliwal.
+- iOS/Talk: harden barge-in behavior by disabling interrupt-on-speech when output route is built-in speaker/receiver, reducing false interruptions from local TTS bleed-through. Thanks @zeulewan.
 
 ### Fixes
 

--- a/apps/ios/Sources/Voice/TalkModeManager.swift
+++ b/apps/ios/Sources/Voice/TalkModeManager.swift
@@ -1106,12 +1106,27 @@ final class TalkModeManager: NSObject {
     }
 
     private func shouldInterrupt(with transcript: String) -> Bool {
+        guard self.shouldAllowSpeechInterruptForCurrentRoute() else { return false }
         let trimmed = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
         guard trimmed.count >= 3 else { return false }
         if let spoken = self.lastSpokenText?.lowercased(), spoken.contains(trimmed.lowercased()) {
             return false
         }
         return true
+    }
+
+    private func shouldAllowSpeechInterruptForCurrentRoute() -> Bool {
+        let route = AVAudioSession.sharedInstance().currentRoute
+        // Built-in speaker/receiver often feeds TTS back into STT, causing false interrupts.
+        // Allow barge-in for isolated outputs (headphones/Bluetooth/USB/CarPlay/AirPlay).
+        return !route.outputs.contains { output in
+            switch output.portType {
+            case .builtInSpeaker, .builtInReceiver:
+                return true
+            default:
+                return false
+            }
+        }
     }
 
     private func shouldUseIncrementalTTS() -> Bool {


### PR DESCRIPTION
## Intent
Ship Slice 3 hardening: reduce false Talk Mode interruptions caused by speaker bleed when output is on built-in device audio.

## Changes
- gate `shouldInterrupt(...)` by current audio output route
- disable speech-interrupt barge-in when output route is built-in speaker or built-in receiver
- keep barge-in enabled for isolated routes (headphones/Bluetooth/USB/CarPlay/AirPlay)
- add changelog attribution

## Scope Guardrails
- no background lifecycle changes
- no VoIP entitlement changes
- no chat.push behavior changes

## Attribution
- extracted from the background voice hardening intent in #17319
- Thanks @zeulewan

## Validation
- `pnpm check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds audio route detection to gate Talk Mode barge-in behavior, preventing false interruptions when TTS output plays through built-in speaker/receiver (which can cause feedback loops). Barge-in remains enabled for isolated audio outputs like headphones, Bluetooth, and CarPlay.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - focused hardening change with clear scope and no breaking changes
- Clean implementation of audio route-based gating for speech interrupts. Logic is straightforward, uses standard AVFoundation APIs correctly, includes clear comments, and has proper CHANGELOG attribution. No security concerns, no breaking changes, and aligns with the stated scope guardrails.
- No files require special attention

<sub>Last reviewed commit: 637de5d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->