### PR TITLE
fix(gateway): stop update.run restart leaking to wrong channel (#18239)

### DIFF
--- a/src/gateway/server-methods/update.test.ts
+++ b/src/gateway/server-methods/update.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from "vitest";
+import type { RestartSentinelPayload } from "../../infra/restart-sentinel.js";
+
+// Capture the sentinel payload written during update.run
+let capturedPayload: RestartSentinelPayload | undefined;
+
+vi.mock("../../config/config.js", () => ({
+  loadConfig: () => ({ update: {} }),
+}));
+
+vi.mock("../../config/sessions.js", () => ({
+  extractDeliveryInfo: (sessionKey: string | undefined) => {
+    if (!sessionKey) {
+      return { deliveryContext: undefined, threadId: undefined };
+    }
+    // Simulate a threaded Slack session
+    if (sessionKey.includes(":thread:")) {
+      return {
+        deliveryContext: { channel: "slack", to: "slack:C0123ABC", accountId: "workspace-1" },
+        threadId: "1234567890.123456",
+      };
+    }
+    return {
+      deliveryContext: { channel: "webchat", to: "webchat:user-123", accountId: "default" },
+      threadId: undefined,
+    };
+  },
+}));
+
+vi.mock("../../infra/openclaw-root.js", () => ({
+  resolveOpenClawPackageRoot: async () => "/tmp/openclaw",
+}));
+
+vi.mock("../../infra/restart-sentinel.js", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...(actual as Record<string, unknown>),
+    writeRestartSentinel: async (payload: RestartSentinelPayload) => {
+      capturedPayload = payload;
+      return "/tmp/sentinel.json";
+    },
+  };
+});
+
+vi.mock("../../infra/restart.js", () => ({
+  scheduleGatewaySigusr1Restart: () => ({ scheduled: true }),
+}));
+
+vi.mock("../../infra/update-channels.js", () => ({
+  normalizeUpdateChannel: () => undefined,
+}));
+
+vi.mock("../../infra/update-runner.js", () => ({
+  runGatewayUpdate: async () => ({
+    status: "ok",
+    mode: "npm",
+    steps: [],
+    durationMs: 100,
+  }),
+}));
+
+vi.mock("../protocol/index.js", () => ({
+  validateUpdateRunParams: () => true,
+}));
+
+vi.mock("./restart-request.js", () => ({
+  parseRestartRequestParams: (params: Record<string, unknown>) => ({
+    sessionKey: params.sessionKey,
+    note: params.note,
+    restartDelayMs: undefined,
+  }),
+}));
+
+vi.mock("./validation.js", () => ({
+  assertValidParams: () => true,
+}));
+
+describe("update.run sentinel deliveryContext", () => {
+  it("includes deliveryContext in sentinel payload when sessionKey is provided", async () => {
+    capturedPayload = undefined;
+    const { updateHandlers } = await import("./update.js");
+    const handler = updateHandlers["update.run"];
+
+    let responded = false;
+    await handler({
+      params: { sessionKey: "agent:main:webchat:dm:user-123" },
+      respond: () => {
+        responded = true;
+      },
+    } as never);
+
+    expect(responded).toBe(true);
+    expect(capturedPayload).toBeDefined();
+    expect(capturedPayload!.deliveryContext).toEqual({
+      channel: "webchat",
+      to: "webchat:user-123",
+      accountId: "default",
+    });
+  });
+
+  it("omits deliveryContext when no sessionKey is provided", async () => {
+    capturedPayload = undefined;
+    const { updateHandlers } = await import("./update.js");
+    const handler = updateHandlers["update.run"];
+
+    await handler({
+      params: {},
+      respond: () => {},
+    } as never);
+
+    expect(capturedPayload).toBeDefined();
+    expect(capturedPayload!.deliveryContext).toBeUndefined();
+    expect(capturedPayload!.threadId).toBeUndefined();
+  });
+
+  it("includes threadId in sentinel payload for threaded sessions", async () => {
+    capturedPayload = undefined;
+    const { updateHandlers } = await import("./update.js");
+    const handler = updateHandlers["update.run"];
+
+    await handler({
+      params: { sessionKey: "agent:main:slack:dm:C0123ABC:thread:1234567890.123456" },
+      respond: () => {},
+    } as never);
+
+    expect(capturedPayload).toBeDefined();
+    expect(capturedPayload!.deliveryContext).toEqual({
+      channel: "slack",
+      to: "slack:C0123ABC",
+      accountId: "workspace-1",
+    });
+    expect(capturedPayload!.threadId).toBe("1234567890.123456");
+  });
+});

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -1,5 +1,6 @@
 import type { GatewayRequestHandlers } from "./types.js";
 import { loadConfig } from "../../config/config.js";
+import { extractDeliveryInfo } from "../../config/sessions.js";
 import { resolveOpenClawPackageRoot } from "../../infra/openclaw-root.js";
 import {
   formatDoctorNonInteractiveHint,
@@ -19,6 +20,7 @@ export const updateHandlers: GatewayRequestHandlers = {
       return;
     }
     const { sessionKey, note, restartDelayMs } = parseRestartRequestParams(params);
+    const { deliveryContext, threadId } = extractDeliveryInfo(sessionKey);
     const timeoutMsRaw = (params as { timeoutMs?: unknown }).timeoutMs;
     const timeoutMs =
       typeof timeoutMsRaw === "number" && Number.isFinite(timeoutMsRaw)
@@ -56,6 +58,8 @@ export const updateHandlers: GatewayRequestHandlers = {
       status: result.status,
       ts: Date.now(),
       sessionKey,
+      deliveryContext,
+      threadId,
       message: note ?? null,
       doctorHint: formatDoctorNonInteractiveHint(),
       stats: {


### PR DESCRIPTION
## Summary

`update.run` doesn't capture `deliveryContext` in the restart sentinel payload, so post-restart confirmation messages can get routed to the wrong channel/recipient. The config handlers (`config.patch`, `config.apply`) were already fixed in 410422999 but `update.run` got missed.

Closes #18239

lobster-biscuit

## Root Cause

`update.run` in `src/gateway/server-methods/update.ts` builds a `RestartSentinelPayload` with `sessionKey` but leaves `deliveryContext` and `threadId` undefined. After restart, `scheduleRestartSentinelWake` falls back to the session store's stale delivery route — which can point to a completely different channel/recipient than the one that triggered the update.

## Changes

- Before: `update.run` sentinel payload has no `deliveryContext` — restart handler falls back to stale session store data, potentially sending internal details to external contacts
- After: `update.run` calls `extractDeliveryInfo(sessionKey)` (same pattern as config handlers) and includes both `deliveryContext` and `threadId` in the sentinel payload

## Tests

- `update.test.ts` — 3 cases: deliveryContext with sessionKey, undefined without sessionKey, threadId for threaded sessions. All fail before fix, pass after.
- `pnpm build && pnpm check` pass
- All 83 tests in `src/gateway/server-methods/` pass

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a channel-routing bug where `update.run`'s restart sentinel payload omitted `deliveryContext` and `threadId`, causing post-restart confirmation messages to be routed to the wrong channel/recipient via stale session store data. The fix applies the same `extractDeliveryInfo(sessionKey)` pattern already used by `config.patch` and `config.apply` handlers.

- Added `extractDeliveryInfo` call in `update.run` handler to capture `deliveryContext` and `threadId` from the session key before restart
- Included both fields in the `RestartSentinelPayload` so `scheduleRestartSentinelWake` can route the post-restart message correctly
- Added 3 test cases covering: delivery context with session key, undefined without session key, and thread ID for threaded sessions

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, well-tested bug fix that follows an established pattern.
- The change is a 3-line addition to update.ts that replicates an existing pattern from config.ts handlers. The fix addresses a real routing bug (deliveryContext missing from sentinel payload) with a proven approach. Tests cover all key scenarios. No risk of regression — the added fields are already expected by the RestartSentinelPayload type and consumed by scheduleRestartSentinelWake.
- No files require special attention.

<sub>Last reviewed commit: d4f08a8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->