### PR TITLE
feat(slack): support blocks in plugin send action

### DIFF
--- a/src/slack/monitor/events/interactions.ts
+++ b/src/slack/monitor/events/interactions.ts
@@ -580,20 +580,18 @@ export function registerSlackInteractionEvents(params: { ctx: SlackMonitorContex
     },
   );
 
-  const viewClosed = (
-    ctx.app as unknown as {
-      viewClosed?: (
-        matcher: RegExp,
-        handler: (args: { ack: () => Promise<void>; body: unknown }) => Promise<void>,
-      ) => void;
-    }
-  ).viewClosed;
-  if (typeof viewClosed !== "function") {
+  const appWithViewClosed = ctx.app as unknown as {
+    viewClosed?: (
+      matcher: RegExp,
+      handler: (args: { ack: () => Promise<void>; body: unknown }) => Promise<void>,
+    ) => void;
+  };
+  if (typeof appWithViewClosed.viewClosed !== "function") {
     return;
   }
 
   // Handle modal close events so agent workflows can react to cancelled forms.
-  viewClosed(
+  appWithViewClosed.viewClosed(
     new RegExp(`^${OPENCLAW_ACTION_PREFIX}`),
     async ({ ack, body }: { ack: () => Promise<void>; body: unknown }) => {
       await ack();


### PR DESCRIPTION
## Why
Slack Block Kit support should work not only from direct tool calls, but also from the channel plugin action adapter (`action: send`).

## Dependency
- Depends on #18180, #18234, #18242, #18252, #18257, and #18262.
- If reviewing before dependencies merge, review tip commit: `4c2049166`.

## What This PR Adds
- In `/Users/solvely/Projects/OpenClaw/src/plugin-sdk/slack-message-actions.ts`:
  - `send` action now accepts optional `blocks`.
  - `blocks` can be JSON string or array.
  - validates `blocks` shape (`array`) and JSON parse errors.
  - validates at least one of `message`, `blocks`, or `media` is present.
  - forwards normalized payload to Slack tool invoke (`sendMessage`).

- In `/Users/solvely/Projects/OpenClaw/src/channels/plugins/actions/actions.test.ts`:
  - adds Slack adapter tests for:
    - forwarding blocks from JSON string
    - forwarding blocks from array
    - rejecting invalid blocks JSON

## Behavior
- Existing `send` behavior remains unchanged for text/media.
- Plugin callers can now provide Block Kit blocks consistently.

## Validation
- `pnpm test src/channels/plugins/actions/actions.test.ts`
- `pnpm check`

## Reviewer Focus
- `src/plugin-sdk/slack-message-actions.ts`
- `src/channels/plugins/actions/actions.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a `this` binding issue when calling the `viewClosed` method on Slack's Bolt App. The change extracts the typed app object into a variable (`appWithViewClosed`) and calls `viewClosed` as a method on that object, rather than extracting the function reference and calling it standalone.

**Note**: The PR description mentions adding Slack Block Kit support to plugin send actions, but those changes are not present in this PR. The actual change is limited to the `viewClosed` method binding fix in `src/slack/monitor/events/interactions.ts`.

- Fixed `this` binding preservation by calling `appWithViewClosed.viewClosed(...)` as a method instead of extracting and calling the function
- No logical issues found with the implementation
- The fix properly addresses the issue identified in the previous review thread

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a straightforward bug fix that properly preserves method binding by storing the typed object reference and calling `viewClosed` as a method. The fix directly addresses the `this` binding issue identified in previous review, and the implementation is correct. The only concern is the PR description mismatch, but the actual code change itself is sound.
- No files require special attention

<sub>Last reviewed commit: e32a5ad</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->