### PR TITLE
fix(telegram): enable autoSelectFamily by default for Node.js 22+

### DIFF
--- a/src/telegram/fetch.ts
+++ b/src/telegram/fetch.ts
@@ -7,7 +7,8 @@ import { resolveTelegramAutoSelectFamilyDecision } from "./network-config.js";
 let appliedAutoSelectFamily: boolean | null = null;
 const log = createSubsystemLogger("telegram/network");
 
-// Node 22 workaround: disable autoSelectFamily to avoid Happy Eyeballs timeouts.
+// Node 22 workaround: enable autoSelectFamily to allow IPv4 fallback on broken IPv6 networks.
+// Many networks have IPv6 configured but not routed, causing "Network is unreachable" errors.
 // See: https://github.com/nodejs/node/issues/54359
 function applyTelegramNetworkWorkarounds(network?: TelegramNetworkConfig): void {
   const decision = resolveTelegramAutoSelectFamilyDecision({ network });

--- a/src/telegram/network-config.test.ts
+++ b/src/telegram/network-config.test.ts
@@ -36,9 +36,9 @@ describe("resolveTelegramAutoSelectFamilyDecision", () => {
     expect(decision).toEqual({ value: true, source: "config" });
   });
 
-  it("defaults to disable on Node 22", () => {
+  it("defaults to enable on Node 22", () => {
     const decision = resolveTelegramAutoSelectFamilyDecision({ env: {}, nodeMajor: 22 });
-    expect(decision).toEqual({ value: false, source: "default-node22" });
+    expect(decision).toEqual({ value: true, source: "default-node22" });
   });
 
   it("returns null when no decision applies", () => {

--- a/src/telegram/network-config.ts
+++ b/src/telegram/network-config.ts
@@ -32,7 +32,7 @@ export function resolveTelegramAutoSelectFamilyDecision(params?: {
     return { value: params.network.autoSelectFamily, source: "config" };
   }
   if (Number.isFinite(nodeMajor) && nodeMajor >= 22) {
-    return { value: false, source: "default-node22" };
+    return { value: true, source: "default-node22" };
   }
   return { value: null };
 }


### PR DESCRIPTION
## Problem

Telegram plugin fails to send messages when IPv6 is configured but not functional on the network (common in many regions, especially Latin America).

**Fixes #18279**

### Symptoms
- ❌ Health check shows: `Telegram │ WARN │ failed (unknown) - fetch failed`
- ❌ Bot receives messages but **cannot send replies**
- ❌ Logs: `Network request for 'sendMessage' failed`
- ❌ IPv6 connection attempt: `Network is unreachable`

### Root Cause
The current default (`autoSelectFamily=false` for Node.js 22+) prevents Node from falling back to IPv4 when IPv6 fails. This breaks Telegram on networks where:
1. IPv6 is **configured** in the OS
2. But **not properly routed** by ISP/router
3. Curl with `-4` works fine, but Node.js fails

### Solution
Change the default from `false` to `true` for Node.js 22+:
```diff
- return { value: false, source: "default-node22" };
+ return { value: true, source: "default-node22" };
```

This enables automatic IPv4 fallback when IPv6 fails, matching standard Node.js behavior.

### Backward Compatibility
- ✅ Config option `channels.telegram.network.autoSelectFamily` still available for override
- ✅ Environment variables `OPENCLAW_TELEGRAM_ENABLE_AUTO_SELECT_FAMILY` and `OPENCLAW_TELEGRAM_DISABLE_AUTO_SELECT_FAMILY` still work
- ✅ No breaking changes

### Testing
Tested on:
- macOS 26.2 (Sequoia)
- Node.js v22.15.0
- OpenClaw 2026.2.12
- Network: IPv6 configured but not routed

**Before fix:**
```
$ openclaw status --deep
Telegram │ WARN │ failed (unknown) - fetch failed
```

**After fix:**
```
$ openclaw status --deep
Telegram │ OK │ ok (@bot:default:1540ms)
```

### Changes in this PR
- `src/telegram/network-config.ts`: Change default from `false` to `true`
- `src/telegram/network-config.test.ts`: Update test expectation
- `src/telegram/fetch.ts`: Update comment to reflect new behavior

---

**Note:** The original hardcoded `false` was likely added as a workaround for Node.js 22 compatibility, but it causes more problems than it solves. The `true` default is safer for most networks and matches standard Node.js behavior.