### PR TITLE
fix(daemon): prefer current node and add macOS version manager paths to service PATH

### DIFF
--- a/src/daemon/runtime-paths.test.ts
+++ b/src/daemon/runtime-paths.test.ts
@@ -21,6 +21,53 @@ afterEach(() => {
 
 describe("resolvePreferredNodePath", () => {
   const darwinNode = "/opt/homebrew/bin/node";
+  const fnmNode = "/Users/test/.fnm/node-versions/v24.11.1/installation/bin/node";
+
+  it("prefers execPath (version manager node) over system node", async () => {
+    fsMocks.access.mockImplementation(async (target: string) => {
+      if (target === darwinNode) {
+        return;
+      }
+      throw new Error("missing");
+    });
+
+    const execFile = vi.fn().mockResolvedValue({ stdout: "24.11.1\n", stderr: "" });
+
+    const result = await resolvePreferredNodePath({
+      env: {},
+      runtime: "node",
+      platform: "darwin",
+      execFile,
+      execPath: fnmNode,
+    });
+
+    expect(result).toBe(fnmNode);
+    expect(execFile).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to system node when execPath version is unsupported", async () => {
+    fsMocks.access.mockImplementation(async (target: string) => {
+      if (target === darwinNode) {
+        return;
+      }
+      throw new Error("missing");
+    });
+
+    const execFile = vi.fn()
+      .mockResolvedValueOnce({ stdout: "18.0.0\n", stderr: "" }) // execPath too old
+      .mockResolvedValueOnce({ stdout: "22.12.0\n", stderr: "" }); // system node ok
+
+    const result = await resolvePreferredNodePath({
+      env: {},
+      runtime: "node",
+      platform: "darwin",
+      execFile,
+      execPath: "/some/old/node",
+    });
+
+    expect(result).toBe(darwinNode);
+    expect(execFile).toHaveBeenCalledTimes(2);
+  });
 
   it("uses system node when it meets the minimum version", async () => {
     fsMocks.access.mockImplementation(async (target: string) => {
@@ -38,6 +85,7 @@ describe("resolvePreferredNodePath", () => {
       runtime: "node",
       platform: "darwin",
       execFile,
+      execPath: darwinNode,
     });
 
     expect(result).toBe(darwinNode);
@@ -60,6 +108,7 @@ describe("resolvePreferredNodePath", () => {
       runtime: "node",
       platform: "darwin",
       execFile,
+      execPath: "",
     });
 
     expect(result).toBeUndefined();
@@ -69,17 +118,17 @@ describe("resolvePreferredNodePath", () => {
   it("returns undefined when no system node is found", async () => {
     fsMocks.access.mockRejectedValue(new Error("missing"));
 
-    const execFile = vi.fn();
+    const execFile = vi.fn().mockRejectedValue(new Error("not found"));
 
     const result = await resolvePreferredNodePath({
       env: {},
       runtime: "node",
       platform: "darwin",
       execFile,
+      execPath: "",
     });
 
     expect(result).toBeUndefined();
-    expect(execFile).not.toHaveBeenCalled();
   });
 });
 

--- a/src/daemon/runtime-paths.test.ts
+++ b/src/daemon/runtime-paths.test.ts
@@ -53,7 +53,8 @@ describe("resolvePreferredNodePath", () => {
       throw new Error("missing");
     });
 
-    const execFile = vi.fn()
+    const execFile = vi
+      .fn()
       .mockResolvedValueOnce({ stdout: "18.0.0\n", stderr: "" }) // execPath too old
       .mockResolvedValueOnce({ stdout: "22.12.0\n", stderr: "" }); // system node ok
 

--- a/src/daemon/runtime-paths.ts
+++ b/src/daemon/runtime-paths.ts
@@ -152,10 +152,24 @@ export async function resolvePreferredNodePath(params: {
   runtime?: string;
   platform?: NodeJS.Platform;
   execFile?: ExecFileAsync;
+  execPath?: string;
 }): Promise<string | undefined> {
   if (params.runtime !== "node") {
     return undefined;
   }
+
+  // Prefer the node that is currently running `openclaw gateway install`.
+  // This respects the user's active version manager (fnm/nvm/volta/etc.).
+  const currentExecPath = params.execPath ?? process.execPath;
+  if (currentExecPath) {
+    const execFileImpl = params.execFile ?? execFileAsync;
+    const version = await resolveNodeVersion(currentExecPath, execFileImpl);
+    if (isSupportedNodeVersion(version)) {
+      return currentExecPath;
+    }
+  }
+
+  // Fall back to system node.
   const systemNode = await resolveSystemNodeInfo(params);
   if (!systemNode?.supported) {
     return undefined;

--- a/src/daemon/service-env.test.ts
+++ b/src/daemon/service-env.test.ts
@@ -148,7 +148,9 @@ describe("getMinimalServicePathParts - Linux user directories", () => {
     });
 
     // fnm on macOS defaults to ~/Library/Application Support/fnm
-    const fnmIndex = result.indexOf("/Users/testuser/Library/Application Support/fnm/aliases/default/bin");
+    const fnmIndex = result.indexOf(
+      "/Users/testuser/Library/Application Support/fnm/aliases/default/bin",
+    );
     const homebrewIndex = result.indexOf("/opt/homebrew/bin");
 
     expect(fnmIndex).toBeGreaterThan(-1);


### PR DESCRIPTION
## Summary

On macOS, `openclaw gateway install` hardcodes the system node (/opt/homebrew/bin/node) in the launchd plist, ignoring the node from version managers (fnm/nvm/volta). This causes the Gateway to run a different node version than the user's shell environment.

## Fix

1. `resolvePreferredNodePath` now checks `process.execPath` first. If the currently running node is a supported version, use it directly. This respects the user's active version manager selection.

2. `buildMinimalServicePath` now includes version manager bin directories on macOS (fnm, nvm, volta, pnpm, bun), matching the existing Linux behavior.

Fixes #18090
Related: #6061, #6064

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes macOS Gateway installation to respect the user's active node version manager (fnm/nvm/volta/etc.) instead of hardcoding the system node path. The fix has two key components:

- **`resolvePreferredNodePath`** now checks `process.execPath` first and uses it if the version is supported (≥22.12.0), falling back to system node only if needed
- **`buildMinimalServicePath`** now includes macOS version manager bin directories (fnm, nvm, volta, pnpm, bun, asdf), matching existing Linux behavior

The changes are well-tested with new test cases covering both the preferred execPath behavior and the fallback logic. The implementation correctly handles the platform differences between macOS and Linux (e.g., fnm uses `~/Library/Application Support/fnm/aliases/default/bin` on macOS vs `~/.fnm/current/bin` on Linux).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are focused, well-tested, and directly address the reported issue. The implementation follows existing patterns (Linux version manager support), includes comprehensive test coverage for both new and existing behavior, and maintains backward compatibility by falling back to system node when needed.
- No files require special attention

<sub>Last reviewed commit: ef54fe6</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->