### PR TITLE
fix(gateway): auto-restart channels on unexpected exit + debounce SIGUSR1 restarts

### DIFF
--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -1,0 +1,183 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChannelPlugin } from "../channels/plugins/types.js";
+import type { OpenClawConfig } from "../config/config.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { createChannelManager } from "./server-channels.js";
+
+type TestAccount = { enabled: boolean };
+
+const hoisted = vi.hoisted(() => {
+  const startAccount = vi.fn();
+  const stopAccount = vi.fn(async () => {});
+  const computeBackoff = vi.fn((_policy: unknown, attempt: number) => attempt * 100);
+  const sleepWithAbort = vi.fn(async (_ms: number, abortSignal?: AbortSignal) => {
+    if (abortSignal?.aborted) {
+      throw new Error("aborted");
+    }
+  });
+  const resetDirectoryCache = vi.fn();
+
+  const plugin: ChannelPlugin<TestAccount> = {
+    id: "telegram",
+    meta: {
+      id: "telegram",
+      label: "Telegram",
+      selectionLabel: "Telegram",
+      docsPath: "/channels/telegram",
+      blurb: "test channel",
+    },
+    capabilities: { chatTypes: ["direct"] },
+    config: {
+      listAccountIds: () => ["default"],
+      resolveAccount: () => ({ enabled: true }),
+      isEnabled: (account) => account.enabled,
+      isConfigured: async () => true,
+    },
+    gateway: {
+      startAccount: (ctx) => startAccount(ctx),
+      stopAccount: (ctx) => stopAccount(ctx),
+    },
+  };
+
+  return {
+    startAccount,
+    stopAccount,
+    computeBackoff,
+    sleepWithAbort,
+    resetDirectoryCache,
+    plugin,
+  };
+});
+
+vi.mock("../channels/plugins/index.js", () => ({
+  getChannelPlugin: (id: string) => (id === hoisted.plugin.id ? hoisted.plugin : undefined),
+  listChannelPlugins: () => [hoisted.plugin],
+}));
+
+vi.mock("../infra/backoff.js", () => ({
+  computeBackoff: (policy: unknown, attempt: number) => hoisted.computeBackoff(policy, attempt),
+  sleepWithAbort: (ms: number, abortSignal?: AbortSignal) =>
+    hoisted.sleepWithAbort(ms, abortSignal),
+}));
+
+vi.mock("../infra/outbound/target-resolver.js", () => ({
+  resetDirectoryCache: (...args: unknown[]) => hoisted.resetDirectoryCache(...args),
+}));
+
+function waitForAbort(abortSignal: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (abortSignal.aborted) {
+      resolve();
+      return;
+    }
+    abortSignal.addEventListener("abort", () => resolve(), { once: true });
+  });
+}
+
+function createManager() {
+  const log = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+  const runtime: RuntimeEnv = {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: (() => {
+      throw new Error("exit");
+    }) as RuntimeEnv["exit"],
+  };
+  const cfg = {
+    channels: {
+      telegram: {},
+    },
+  } as OpenClawConfig;
+
+  const manager = createChannelManager({
+    loadConfig: () => cfg,
+    channelLogs: {
+      telegram: log,
+    } as unknown as Record<string, typeof log>,
+    channelRuntimeEnvs: {
+      telegram: runtime,
+    } as unknown as Record<string, RuntimeEnv>,
+  });
+
+  return { manager, log };
+}
+
+describe("createChannelManager", () => {
+  beforeEach(() => {
+    hoisted.startAccount.mockReset();
+    hoisted.stopAccount.mockReset();
+    hoisted.computeBackoff.mockReset();
+    hoisted.computeBackoff.mockImplementation((_policy: unknown, attempt: number) => attempt * 100);
+    hoisted.sleepWithAbort.mockReset();
+    hoisted.sleepWithAbort.mockImplementation(async (_ms: number, abortSignal?: AbortSignal) => {
+      if (abortSignal?.aborted) {
+        throw new Error("aborted");
+      }
+    });
+    hoisted.resetDirectoryCache.mockReset();
+  });
+
+  it("auto-restarts channel task after unexpected exit", async () => {
+    const { manager, log } = createManager();
+    hoisted.startAccount
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockImplementationOnce((ctx: { abortSignal: AbortSignal }) => waitForAbort(ctx.abortSignal));
+
+    await manager.startChannel("telegram");
+    await vi.waitFor(() => {
+      expect(hoisted.startAccount).toHaveBeenCalledTimes(2);
+    });
+
+    expect(hoisted.computeBackoff).toHaveBeenCalledWith(expect.any(Object), 1);
+    expect(hoisted.sleepWithAbort).toHaveBeenCalledWith(100, expect.any(AbortSignal));
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("channel exited unexpectedly; restarting in 100ms (attempt 1)"),
+    );
+
+    await manager.stopChannel("telegram");
+  });
+
+  it("does not auto-restart when channel is intentionally stopped", async () => {
+    const { manager } = createManager();
+    hoisted.startAccount.mockImplementation((ctx: { abortSignal: AbortSignal }) =>
+      waitForAbort(ctx.abortSignal),
+    );
+
+    await manager.startChannel("telegram");
+    await vi.waitFor(() => {
+      expect(hoisted.startAccount).toHaveBeenCalledTimes(1);
+    });
+
+    await manager.stopChannel("telegram");
+
+    expect(hoisted.startAccount).toHaveBeenCalledTimes(1);
+    expect(hoisted.computeBackoff).not.toHaveBeenCalled();
+    expect(hoisted.sleepWithAbort).not.toHaveBeenCalled();
+  });
+
+  it("uses exponential retry attempts for repeated unexpected exits", async () => {
+    const { manager } = createManager();
+    let runCount = 0;
+    hoisted.startAccount.mockImplementation((ctx: { abortSignal: AbortSignal }) => {
+      runCount += 1;
+      if (runCount <= 3) {
+        return Promise.reject(new Error(`boom-${runCount}`));
+      }
+      return waitForAbort(ctx.abortSignal);
+    });
+
+    await manager.startChannel("telegram");
+    await vi.waitFor(() => {
+      expect(hoisted.startAccount).toHaveBeenCalledTimes(4);
+    });
+
+    expect(hoisted.computeBackoff.mock.calls.map(([, attempt]) => attempt)).toEqual([1, 2, 3]);
+    expect(hoisted.sleepWithAbort.mock.calls.map(([delayMs]) => delayMs)).toEqual([100, 200, 300]);
+
+    await manager.stopChannel("telegram");
+  });
+});


### PR DESCRIPTION
Fixes #8140

## Summary

Two-part fix for channel stability: auto-recovery after unexpected exits and SIGUSR1 debouncing.

### Problem

1. **No auto-recovery** — When a channel (e.g. Telegram) exits unexpectedly (network error, API failure), it stays dead until a full gateway restart
2. **Duplicate instances on rapid SIGUSR1** — Quick successive config reloads can spawn overlapping channel instances, causing duplicate message delivery

### Solution

#### 1. Auto-restart with exponential backoff (`server-channels.ts`)

The channel manager now detects unexpected exits (where the abort signal was *not* triggered) and automatically restarts the channel with exponential backoff:

- **Initial delay:** 2s, **max:** 30s, **factor:** 1.8×, **jitter:** 25%
- Backoff resets after 10s of successful uptime (channel considered recovered)
- Intentional stops (via `stopChannel()` / abort signal) skip auto-restart
- Uses existing `computeBackoff` and `sleepWithAbort` infrastructure
- **Generic** — applies to all channel plugins, not just Telegram

#### 2. SIGUSR1 cooldown (`run-loop.ts`)

Added a 2s cooldown after each SIGUSR1-triggered restart. Subsequent SIGUSR1 signals during the cooldown window are logged and ignored, preventing overlapping restart cycles.

### Changes

- `src/gateway/server-channels.ts` — Auto-restart logic with `restartAttempts` tracking per account, backoff delay, abort-aware sleep
- `src/gateway/server-channels.test.ts` — **New:** 3 tests covering auto-restart, intentional stop (no restart), and exponential backoff progression
- `src/cli/gateway-cli/run-loop.ts` — SIGUSR1 cooldown gate
- `src/cli/gateway-cli/run-loop.test.ts` — Updated test to verify cooldown behavior

### Testing

- [x] `pnpm test src/gateway/server-channels.test.ts` — 3 tests pass
- [x] `pnpm test src/cli/gateway-cli/run-loop.test.ts` — 1 test passes
- [x] `pnpm build` verified

### Note on competing PRs

This fix operates at the **gateway channel manager** level (`server-channels.ts`), making it generic for all channel plugins. Existing PRs (#8166, #10850, #14741) address similar symptoms but are Telegram-specific (`monitor.ts`). This approach is complementary — it provides a safety net at the gateway layer regardless of which channel crashes.

### AI Disclosure

- [x] AI-assisted (Claude via OpenClaw)
- [x] All tests pass
- [x] Code reviewed and understood

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two stability improvements to the gateway channel system: automatic restart of crashed channels with exponential backoff, and debouncing of SIGUSR1 restart signals.

The auto-restart logic in `server-channels.ts` detects unexpected channel exits (where the abort signal was not triggered) and automatically attempts to restart with exponential backoff (2s initial, 30s max, 1.8× factor, 25% jitter). The backoff counter resets after 10s of successful uptime. Intentional stops via `stopChannel()` correctly skip the auto-restart path by checking if the abort signal was triggered.

The SIGUSR1 cooldown in `run-loop.ts` adds a 2-second gate after each restart, logging and ignoring subsequent SIGUSR1 signals during the cooldown window to prevent overlapping restart cycles.

Both changes include comprehensive test coverage verifying the expected behavior.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-designed with careful attention to abort signal handling and race conditions. The auto-restart logic correctly distinguishes between intentional stops and unexpected exits. The exponential backoff prevents rapid restart loops. Comprehensive test coverage validates all key behaviors including auto-restart, intentional stop (no restart), exponential backoff progression, and SIGUSR1 cooldown. The changes are generic and non-invasive, applying cleanly to all channel plugins without breaking existing functionality.
- No files require special attention

<sub>Last reviewed commit: 61cb030</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->