### PR TITLE
feat(slack): support blocks in plugin edit action

### DIFF
--- a/src/slack/monitor/events/interactions.ts
+++ b/src/slack/monitor/events/interactions.ts
@@ -580,20 +580,18 @@ export function registerSlackInteractionEvents(params: { ctx: SlackMonitorContex
     },
   );
 
-  const viewClosed = (
-    ctx.app as unknown as {
-      viewClosed?: (
-        matcher: RegExp,
-        handler: (args: { ack: () => Promise<void>; body: unknown }) => Promise<void>,
-      ) => void;
-    }
-  ).viewClosed;
-  if (typeof viewClosed !== "function") {
+  const appWithViewClosed = ctx.app as unknown as {
+    viewClosed?: (
+      matcher: RegExp,
+      handler: (args: { ack: () => Promise<void>; body: unknown }) => Promise<void>,
+    ) => void;
+  };
+  if (typeof appWithViewClosed.viewClosed !== "function") {
     return;
   }
 
   // Handle modal close events so agent workflows can react to cancelled forms.
-  viewClosed(
+  appWithViewClosed.viewClosed(
     new RegExp(`^${OPENCLAW_ACTION_PREFIX}`),
     async ({ ack, body }: { ack: () => Promise<void>; body: unknown }) => {
       await ack();


### PR DESCRIPTION
## Why
Plugin-level Slack `edit` actions should have the same Block Kit capability as tool-level `editMessage`.

## Dependency
- Depends on #18180, #18234, #18242, #18252, #18257, #18262, and #18268.
- If reviewing before dependencies merge, review tip commit: `7548391de`.

## What This PR Adds
- In `/Users/solvely/Projects/OpenClaw/src/plugin-sdk/slack-message-actions.ts`:
  - `edit` now accepts optional `blocks` (JSON string or array)
  - validates at least one of `message` or `blocks` is present
  - forwards normalized payload to `editMessage`

- In `/Users/solvely/Projects/OpenClaw/src/channels/plugins/actions/actions.test.ts`:
  - adds Slack adapter tests for:
    - edit with blocks JSON
    - edit with blocks array
    - reject edit when both message and blocks are missing

## Behavior
- Existing text-only edits still work.
- Plugin callers can now update messages with Block Kit blocks.

## Validation
- `pnpm test src/channels/plugins/actions/actions.test.ts`
- `pnpm check`

## Reviewer Focus
- `src/plugin-sdk/slack-message-actions.ts`
- `src/channels/plugins/actions/actions.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes two changes to `src/slack/monitor/events/interactions.ts`:

- **Fixes `viewClosed` method binding**: The previous code extracted `viewClosed` from `ctx.app` into a standalone variable, which loses the `this` context when invoked. The fix keeps a reference to the cast object (`appWithViewClosed`) and calls the method on it directly (`appWithViewClosed.viewClosed(...)`), preserving binding — consistent with how `ctx.app.action()` and `ctx.app.view()` are already called.
- **Inlines `InteractionSelectionFields` type**: Removes the shared `InteractionSelectionFields` type and duplicates its fields directly into `InteractionSummary` and `ModalInputSummary`. Also reorders import statements (type imports first). This is a purely structural refactor with no behavioral change.

Both changes are low-risk. The binding fix addresses a real bug where Slack Bolt's internal `this` context could be lost during `viewClosed` handler registration.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it fixes a method binding bug and performs a low-risk type refactor.
- The viewClosed binding fix is a clear correctness improvement that aligns with existing patterns in the same file. The type inlining is mechanically correct — all fields from the removed InteractionSelectionFields are present in both destination types. No logic changes, no new runtime behavior beyond the binding fix.
- No files require special attention.

<sub>Last reviewed commit: 4949782</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->