### PR TITLE
fix(security): harden file permissions for remaining session transcript and memory write paths

### DIFF
--- a/src/agents/pi-embedded-runner/session-manager-init.ts
+++ b/src/agents/pi-embedded-runner/session-manager-init.ts
@@ -43,7 +43,7 @@ export async function prepareSessionManagerForRun(params: {
 
   if (params.hadSessionFile && header && !hasAssistant) {
     // Reset file so the first assistant flush includes header+user+assistant in order.
-    await fs.writeFile(params.sessionFile, "", "utf-8");
+    await fs.writeFile(params.sessionFile, "", { encoding: "utf-8", mode: 0o600 });
     sm.fileEntries = [header];
     sm.byId?.clear?.();
     sm.labelsById?.clear?.();

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -122,6 +122,10 @@ describe("initSessionState thread forking", () => {
       parentSession?: string;
     };
     expect(parsedHeader.parentSession).toBe(parentSessionFile);
+    if (process.platform !== "win32") {
+      const mode = (await fs.stat(newSessionFile)).mode & 0o777;
+      expect(mode).toBe(0o600);
+    }
     warn.mockRestore();
   });
 

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -74,6 +74,11 @@ function forkSessionFromParent(params: {
       const sessionFile = manager.createBranchedSession(leafId) ?? manager.getSessionFile();
       const sessionId = manager.getSessionId();
       if (sessionFile && sessionId) {
+        if (process.platform !== "win32") {
+          try {
+            fs.chmodSync(sessionFile, 0o600);
+          } catch {}
+        }
         return { sessionId, sessionFile };
       }
     }
@@ -89,7 +94,10 @@ function forkSessionFromParent(params: {
       cwd: manager.getCwd(),
       parentSession: parentSessionFile,
     };
-    fs.writeFileSync(sessionFile, `${JSON.stringify(header)}\n`, "utf-8");
+    fs.writeFileSync(sessionFile, `${JSON.stringify(header)}\n`, {
+      encoding: "utf-8",
+      mode: 0o600,
+    });
     return { sessionId, sessionFile };
   } catch {
     return null;

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -182,7 +182,7 @@ const saveSessionToMemory: HookHandler = async (event) => {
     const entry = entryParts.join("\n");
 
     // Write to new memory file
-    await fs.writeFile(memoryFilePath, entry, "utf-8");
+    await fs.writeFile(memoryFilePath, entry, { encoding: "utf-8", mode: 0o600 });
     log.debug("Memory file written successfully");
 
     // Log completion (but don't send user-visible confirmation - it's internal housekeeping)


### PR DESCRIPTION
## Problem

PR #18066 hardened the primary session transcript write path to use `0o600` permissions. However, several other code paths that create or write session-related files were missed:

1. **`forkSessionFromParent`** (`src/auto-reply/reply/session.ts`) — branched session files created via `SessionManager.createBranchedSession()` inherit default umask permissions; the fallback `writeFileSync` path also lacked explicit mode
2. **`session-manager-init.ts`** — pi-embedded session file reset writes with default permissions
3. **`session-memory/handler.ts`** — memory hook files containing conversation context written without restricted permissions

## Fix

- `chmod` branched session files to `0o600` after `createBranchedSession()` (external package creates the file)
- Set `mode: 0o600` on the fallback `writeFileSync` in `forkSessionFromParent`
- Set `mode: 0o600` on session-manager-init reset write
- Set `mode: 0o600` on session-memory hook file write
- Added file permission assertion to existing fork-session test

## Test

Extended the "forks a new session from the parent session file" test to verify `0o600` permissions on non-Windows platforms.

Follow-up to #18066.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens file permissions to `0o600` for several session-related write paths that were missed by PR #18066: branched session files in `forkSessionFromParent`, session file resets in `session-manager-init.ts`, and memory hook files in `session-memory/handler.ts`. A test assertion for file permissions was also added.

- The `chmodSync` after `createBranchedSession()` in `session.ts` correctly handles permissions on files created by an external package
- The `writeFileSync` with `mode: 0o600` on the fallback path in `session.ts` is correct since it creates a new file
- The memory hook file write in `handler.ts` is correct since each memory file uses a unique filename
- **Issue**: In `session-manager-init.ts`, the `mode: 0o600` in `writeFile` will not take effect because the file already exists (`hadSessionFile === true`). The POSIX `open()` syscall only applies `mode` on file creation (`O_CREAT`). An explicit `fs.chmod()` after the write is needed, consistent with the pattern used elsewhere in this codebase (e.g., `store.ts`, `device-identity.ts`, `exec-approvals.ts`)

<h3>Confidence Score: 3/5</h3>

- Mostly safe — three of four write paths are correctly hardened, but one path has a POSIX subtlety that leaves permissions unchanged on existing files.
- Three of the four changes correctly harden file permissions. However, `session-manager-init.ts` has a bug where `mode: 0o600` in `writeFile` is ineffective on an already-existing file because the POSIX `open()` syscall ignores the mode argument when the file already exists. This partially undermines the security goal of the PR.
- Pay close attention to `src/agents/pi-embedded-runner/session-manager-init.ts` — the `mode: 0o600` in `writeFile` does not change permissions on the pre-existing session file.

<sub>Last reviewed commit: edd2369</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->