### PR TITLE
feat(slack): centralize Block Kit input validation

### DIFF
--- a/src/slack/monitor/events/interactions.ts
+++ b/src/slack/monitor/events/interactions.ts
@@ -580,20 +580,18 @@ export function registerSlackInteractionEvents(params: { ctx: SlackMonitorContex
     },
   );
 
-  const viewClosed = (
-    ctx.app as unknown as {
-      viewClosed?: (
-        matcher: RegExp,
-        handler: (args: { ack: () => Promise<void>; body: unknown }) => Promise<void>,
-      ) => void;
-    }
-  ).viewClosed;
-  if (typeof viewClosed !== "function") {
+  const appWithViewClosed = ctx.app as unknown as {
+    viewClosed?: (
+      matcher: RegExp,
+      handler: (args: { ack: () => Promise<void>; body: unknown }) => Promise<void>,
+    ) => void;
+  };
+  if (typeof appWithViewClosed.viewClosed !== "function") {
     return;
   }
 
   // Handle modal close events so agent workflows can react to cancelled forms.
-  viewClosed(
+  appWithViewClosed.viewClosed(
     new RegExp(`^${OPENCLAW_ACTION_PREFIX}`),
     async ({ ack, body }: { ack: () => Promise<void>; body: unknown }) => {
       await ack();


### PR DESCRIPTION
## Why
Block Kit input parsing/validation is currently duplicated across tool and plugin paths. A shared validator keeps behavior consistent and prevents malformed/empty block payloads from reaching Slack APIs.

## Dependency
- Depends on #18180, #18234, #18242, #18252, #18257, #18262, #18268, and #18278.
- If reviewing before dependencies merge, review tip commit: `3986c59ad`.

## What This PR Adds
- New shared parser/validator:
  - `/Users/solvely/Projects/OpenClaw/src/slack/blocks-input.ts`
- New unit tests:
  - `/Users/solvely/Projects/OpenClaw/src/slack/blocks-input.test.ts`

Validation rules now centralized:
- `blocks` JSON must parse
- `blocks` must be an array
- `blocks` must be non-empty
- max 50 blocks
- each block must be an object with non-empty string `type`

Integrations updated to use the shared parser:
- `/Users/solvely/Projects/OpenClaw/src/agents/tools/slack-actions.ts`
- `/Users/solvely/Projects/OpenClaw/src/plugin-sdk/slack-message-actions.ts`

Additional regression coverage:
- `/Users/solvely/Projects/OpenClaw/src/agents/tools/slack-actions.e2e.test.ts`
- `/Users/solvely/Projects/OpenClaw/src/channels/plugins/actions/actions.test.ts`

## Behavior
- Keeps existing valid block behavior.
- Fails earlier and consistently for malformed/empty blocks.

## Validation
- `pnpm test src/slack/blocks-input.test.ts src/channels/plugins/actions/actions.test.ts`
- `pnpm exec vitest run --config vitest.e2e.config.ts src/agents/tools/slack-actions.e2e.test.ts`
- `pnpm check`

## Reviewer Focus
- `src/slack/blocks-input.ts`
- `src/slack/blocks-input.test.ts`
- `src/agents/tools/slack-actions.ts`
- `src/plugin-sdk/slack-message-actions.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a JavaScript `this`-binding bug in `src/slack/monitor/events/interactions.ts`. The previous code destructured the `viewClosed` method from the app object into a standalone variable, which lost the `this` context when invoked. The fix keeps the method on its parent object (`appWithViewClosed.viewClosed(...)` instead of the bare `viewClosed(...)` call), ensuring proper `this` binding at call time.

- **Bug fix**: `viewClosed` is now invoked as a method on `appWithViewClosed` rather than as a detached function, preserving method binding
- The PR description references broader Block Kit validation changes, but those live in dependency PRs — this commit only contains the `viewClosed` binding fix

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a small, targeted fix that preserves method binding semantics.
- The change is a 2-line behavioral fix (keeping method on its object instead of destructuring it) with no new logic, no new dependencies, and no risk of regression. The pattern matches how other methods (action, view) are already called in the same file.
- No files require special attention.

<sub>Last reviewed commit: ca522b1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->