### PR TITLE
fix(security): remaining session file writes missing 0o600 permissions

### DIFF
--- a/src/agents/pi-embedded-runner/session-manager-init.ts
+++ b/src/agents/pi-embedded-runner/session-manager-init.ts
@@ -43,7 +43,7 @@ export async function prepareSessionManagerForRun(params: {
 
   if (params.hadSessionFile && header && !hasAssistant) {
     // Reset file so the first assistant flush includes header+user+assistant in order.
-    await fs.writeFile(params.sessionFile, "", "utf-8");
+    await fs.writeFile(params.sessionFile, "", { encoding: "utf-8", mode: 0o600 });
     sm.fileEntries = [header];
     sm.byId?.clear?.();
     sm.labelsById?.clear?.();

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -89,7 +89,10 @@ function forkSessionFromParent(params: {
       cwd: manager.getCwd(),
       parentSession: parentSessionFile,
     };
-    fs.writeFileSync(sessionFile, `${JSON.stringify(header)}\n`, "utf-8");
+    fs.writeFileSync(sessionFile, `${JSON.stringify(header)}\n`, {
+      encoding: "utf-8",
+      mode: 0o600,
+    });
     return { sessionId, sessionFile };
   } catch {
     return null;

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -471,7 +471,10 @@ export const sessionsHandlers: GatewayRequestHandlers = {
 
     const archived = archiveFileOnDisk(filePath, "bak");
     const keptLines = lines.slice(-maxLines);
-    fs.writeFileSync(filePath, `${keptLines.join("\n")}\n`, "utf-8");
+    fs.writeFileSync(filePath, `${keptLines.join("\n")}\n`, {
+      encoding: "utf-8",
+      mode: 0o600,
+    });
 
     await updateSessionStore(storePath, (store) => {
       const entryKey = compactTarget.primaryKey;


### PR DESCRIPTION
## Problem

#18066 hardened session transcript creation with `0o600` permissions in `transcript.ts` and `chat.ts`, but three other session file write sites were missed:

1. **`src/auto-reply/reply/session.ts`** — forked session transcript header (`writeFileSync`)
2. **`src/agents/pi-embedded-runner/session-manager-init.ts`** — session file reset (`writeFile`)
3. **`src/gateway/server-methods/sessions.ts`** — compacted transcript rewrite (`writeFileSync`)

All three create or rewrite session transcript files that may contain conversation content.

## Fix

Set `mode: 0o600` on all three write calls, consistent with the pattern established in #18066.

## Test

Existing tests pass. The two pre-existing failures on main (`server.post-tabs-open-profile-unknown-returns-404` and `server-runtime-config`) are unrelated.

Follow-up to #18066.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Follow-up to #18066: applies `mode: 0o600` (owner read/write only) to the three remaining session file write sites that were missed in the initial security hardening. The changes are minimal and mechanical — each converts a string encoding argument to an options object with both `encoding` and `mode` fields, consistent with the pattern already established across the codebase.

- `src/agents/pi-embedded-runner/session-manager-init.ts`: session file reset during embedded runner initialization
- `src/auto-reply/reply/session.ts`: forked session transcript header creation
- `src/gateway/server-methods/sessions.ts`: compacted transcript rewrite

No issues found. All three changes correctly use the Node.js `writeFile`/`writeFileSync` options object API.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it makes minimal, mechanical changes to add file permissions on three session file writes.
- All three changes follow an identical, well-established pattern (converting string encoding to options object with `mode: 0o600`). The changes are purely additive security hardening with no behavioral impact on file content. The Node.js API usage is correct in all cases. No new code paths, no logic changes, no risk of regression.
- No files require special attention.

<sub>Last reviewed commit: 2b43cc5</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->