### PR TITLE
fix(slack): add blocks+media send guardrails

### DIFF
--- a/src/slack/monitor/events/interactions.ts
+++ b/src/slack/monitor/events/interactions.ts
@@ -580,20 +580,18 @@ export function registerSlackInteractionEvents(params: { ctx: SlackMonitorContex
     },
   );
 
-  const viewClosed = (
-    ctx.app as unknown as {
-      viewClosed?: (
-        matcher: RegExp,
-        handler: (args: { ack: () => Promise<void>; body: unknown }) => Promise<void>,
-      ) => void;
-    }
-  ).viewClosed;
-  if (typeof viewClosed !== "function") {
+  const appWithViewClosed = ctx.app as unknown as {
+    viewClosed?: (
+      matcher: RegExp,
+      handler: (args: { ack: () => Promise<void>; body: unknown }) => Promise<void>,
+    ) => void;
+  };
+  if (typeof appWithViewClosed.viewClosed !== "function") {
     return;
   }
 
   // Handle modal close events so agent workflows can react to cancelled forms.
-  viewClosed(
+  appWithViewClosed.viewClosed(
     new RegExp(`^${OPENCLAW_ACTION_PREFIX}`),
     async ({ ack, body }: { ack: () => Promise<void>; body: unknown }) => {
       await ack();


### PR DESCRIPTION
## Why
Slack API does not support mixing rich Block Kit `blocks` with file-upload media sends in our current send flow. We already enforce this lower in `send.ts`; this PR adds earlier guardrails in tool/plugin layers for faster, clearer failures.

## Dependency
- Depends on #18180, #18234, #18242, #18252, #18257, #18262, #18268, #18278, and #18284.
- If reviewing before dependencies merge, review tip commit: `7fc427cd0`.

## What This PR Adds
- In `/Users/solvely/Projects/OpenClaw/src/agents/tools/slack-actions.ts`:
  - reject `sendMessage` when both `mediaUrl` and `blocks` are provided

- In `/Users/solvely/Projects/OpenClaw/src/plugin-sdk/slack-message-actions.ts`:
  - reject plugin `send` when both `media` and `blocks` are provided

- Tests added:
  - `/Users/solvely/Projects/OpenClaw/src/agents/tools/slack-actions.e2e.test.ts`
  - `/Users/solvely/Projects/OpenClaw/src/channels/plugins/actions/actions.test.ts`

## Behavior
- Valid text/media-only and text/blocks-only sends remain unchanged.
- Invalid mixed `blocks + media` now fails earlier with clear errors.

## Validation
- `pnpm test src/channels/plugins/actions/actions.test.ts`
- `pnpm exec vitest run --config vitest.e2e.config.ts src/agents/tools/slack-actions.e2e.test.ts`
- `pnpm check`

## Reviewer Focus
- `src/agents/tools/slack-actions.ts`
- `src/plugin-sdk/slack-message-actions.ts`
- `src/agents/tools/slack-actions.e2e.test.ts`
- `src/channels/plugins/actions/actions.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Despite the PR title referencing "blocks+media send guardrails," the actual diff in this PR is a single commit (`eaf2ee66`) that fixes `viewClosed` method binding in `src/slack/monitor/events/interactions.ts`. The other changes mentioned in the description belong to dependent PRs.

- **Method binding fix**: The `viewClosed` method on the Slack Bolt app was previously destructured into a standalone variable, losing its `this` context. The fix stores the cast object reference (`appWithViewClosed`) and calls the method on it directly (`appWithViewClosed.viewClosed(...)`), preserving proper method binding.
- No logic changes, no new features — this is a targeted correctness fix for method invocation.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, correct fix that preserves method binding without changing any behavior.
- The change is a 2-line refactor that replaces destructured method extraction with a proper method call on an object reference. It preserves the existing type cast, guard check, and invocation pattern. No new logic is introduced, no existing behavior is altered for working cases, and the fix addresses a real potential runtime issue (lost `this` binding).
- No files require special attention.

<sub>Last reviewed commit: 1126db4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->