### PR TITLE
feat(inbound-meta): expose sender_id in trusted system metadata

### DIFF
--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -32,6 +32,35 @@ describe("buildInboundMetaSystemPrompt", () => {
     expect(payload["channel"]).toBe("telegram");
   });
 
+  it("includes sender_id when provided", () => {
+    const prompt = buildInboundMetaSystemPrompt({
+      MessageSid: "456",
+      SenderId: "289522496",
+      OriginatingTo: "telegram:-1001249586642",
+      OriginatingChannel: "telegram",
+      Provider: "telegram",
+      Surface: "telegram",
+      ChatType: "group",
+    } as TemplateContext);
+
+    const payload = parseInboundMetaPayload(prompt);
+    expect(payload["sender_id"]).toBe("289522496");
+  });
+
+  it("omits sender_id when not provided", () => {
+    const prompt = buildInboundMetaSystemPrompt({
+      MessageSid: "789",
+      OriginatingTo: "telegram:5494292670",
+      OriginatingChannel: "telegram",
+      Provider: "telegram",
+      Surface: "telegram",
+      ChatType: "direct",
+    } as TemplateContext);
+
+    const payload = parseInboundMetaPayload(prompt);
+    expect(payload["sender_id"]).toBeUndefined();
+  });
+
   it("keeps message_id_full only when it differs from message_id", () => {
     const prompt = buildInboundMetaSystemPrompt({
       MessageSid: "short-id",

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -24,6 +24,7 @@ export function buildInboundMetaSystemPrompt(ctx: TemplateContext): string {
     schema: "openclaw.inbound_meta.v1",
     message_id: messageId,
     message_id_full: messageIdFull && messageIdFull !== messageId ? messageIdFull : undefined,
+    sender_id: safeTrim(ctx.SenderId),
     chat_id: chatId,
     reply_to_id: replyToId,
     channel: safeTrim(ctx.OriginatingChannel) ?? safeTrim(ctx.Surface) ?? safeTrim(ctx.Provider),


### PR DESCRIPTION
## Summary

Adds `sender_id` (`ctx.SenderId`) to the `openclaw.inbound_meta.v1` system prompt payload.

## Motivation

`message_id` and `chat_id` are already exposed in the trusted inbound metadata, but `sender_id` is missing. This makes it impossible for agents to perform moderation actions (ban, kick, timeout) that require a numeric user ID.

**Use case:** A spam-detection agent monitoring Telegram group chats needs `sender_id` to populate inline button callbacks for delete/ban actions. Without it, the agent only has the sender's display name and username (untrusted, user-controlled text) — insufficient for API actions.

## Changes

- `src/auto-reply/reply/inbound-meta.ts`: Add `sender_id: safeTrim(ctx.SenderId)` to the trusted payload (1 line)
- `src/auto-reply/reply/inbound-meta.test.ts`: Add 2 tests — presence when provided, omission when absent

## Example output

```json
{
  "schema": "openclaw.inbound_meta.v1",
  "message_id": "16698",
  "sender_id": "289522496",
  "chat_id": "telegram:-1001249586642",
  "channel": "telegram",
  "provider": "telegram",
  "surface": "telegram",
  "chat_type": "group"
}
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `sender_id` (from `ctx.SenderId`) to the `openclaw.inbound_meta.v1` trusted system metadata payload, alongside the existing `message_id` and `chat_id` fields. This enables agents to perform moderation actions (ban, kick, timeout) that require a numeric user ID rather than untrusted display names.

- `sender_id` is added via `safeTrim(ctx.SenderId)` in `buildInboundMetaSystemPrompt`, following the same pattern as other platform-assigned IDs in the trusted payload
- Two tests cover presence and omission of the field
- Correctly places `sender_id` in trusted metadata (platform-assigned numeric ID) rather than the untrusted user context block (which holds user-controlled strings like `SenderName`, `SenderUsername`)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — minimal, well-tested addition of a single field to existing metadata payload.
- The change is a single-line addition using the established `safeTrim` pattern already used by every other field in the payload. The `SenderId` type is correctly defined as `string | undefined` in TemplateContext. Tests cover both presence and absence. The trusted/untrusted boundary is respected (numeric platform ID in trusted metadata, display names in untrusted context). No logic changes, no new dependencies, no security concerns.
- No files require special attention.

<sub>Last reviewed commit: a8c35a4</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->