### PR TITLE
docs(changelog): add @Marvae attribution for iOS QR onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ Docs: https://docs.openclaw.ai
 - OpenClawKit/iOS ChatUI: accept canonical session-key completion events for local pending runs and preserve message IDs across history refreshes, preventing stuck "thinking" state and message flicker after gateway replies. (#18165) Thanks @mbelinky.
 - iOS/Talk: harden mobile talk config handling by ignoring redacted/env-placeholder API keys, support secure local keychain override, improve accessibility motion/contrast behavior in status UI, and tighten ATS to local-network allowance. (#18163) Thanks @mbelinky.
 - iOS/Gateway: stabilize connect/discovery state handling, add onboarding reset recovery in Settings, and fix iOS gateway-controller coverage for command-surface and last-connection persistence behavior. (#18164) Thanks @mbelinky.
-- iOS/Onboarding: add QR-first onboarding wizard with setup-code deep link support, pairing/auth issue guidance, and device-pair QR generation improvements for Telegram/Web/TUI fallback flows. (#18162) Thanks @mbelinky.
+- iOS/Onboarding: add QR-first onboarding wizard with setup-code deep link support, pairing/auth issue guidance, and device-pair QR generation improvements for Telegram/Web/TUI fallback flows. (#18162) Thanks @mbelinky and @Marvae.
 
 ## 2026.2.15
 


### PR DESCRIPTION
One-line attribution correction requested by @Marvae.\n\n- update #18162 changelog entry to credit both @mbelinky and @Marvae

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added co-author attribution for `@Marvae` to the iOS QR onboarding changelog entry (#18162), crediting both `@mbelinky` and `@Marvae` for their contributions.

- Updated attribution from single author to dual attribution
- Follows existing changelog formatting conventions (using "and" between contributors)

<h3>Confidence Score: 5/5</h3>

- This PR is completely safe to merge - it's a one-line documentation correction.
- The change is a trivial documentation update adding co-author attribution. It follows the existing changelog format, matches the pattern used elsewhere (e.g., line 25 shows "Thanks `@Marvae` and `@obviyus`"), and poses zero risk to functionality.
- No files require special attention.

<sub>Last reviewed commit: c5b91cb</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->