### PR TITLE
refactor(channels): extract account listing boilerplate into factory

### DIFF
--- a/extensions/bluebubbles/src/accounts.ts
+++ b/extensions/bluebubbles/src/accounts.ts
@@ -1,5 +1,6 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
-import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-id";
+import { createAccountListHelpers } from "openclaw/plugin-sdk";
+import { normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import { normalizeBlueBubblesServerUrl, type BlueBubblesAccountConfig } from "./types.js";
 
 export type ResolvedBlueBubblesAccount = {
@@ -11,29 +12,9 @@ export type ResolvedBlueBubblesAccount = {
   baseUrl?: string;
 };
 
-function listConfiguredAccountIds(cfg: OpenClawConfig): string[] {
-  const accounts = cfg.channels?.bluebubbles?.accounts;
-  if (!accounts || typeof accounts !== "object") {
-    return [];
-  }
-  return Object.keys(accounts).filter(Boolean);
-}
-
-export function listBlueBubblesAccountIds(cfg: OpenClawConfig): string[] {
-  const ids = listConfiguredAccountIds(cfg);
-  if (ids.length === 0) {
-    return [DEFAULT_ACCOUNT_ID];
-  }
-  return ids.toSorted((a, b) => a.localeCompare(b));
-}
-
-export function resolveDefaultBlueBubblesAccountId(cfg: OpenClawConfig): string {
-  const ids = listBlueBubblesAccountIds(cfg);
-  if (ids.includes(DEFAULT_ACCOUNT_ID)) {
-    return DEFAULT_ACCOUNT_ID;
-  }
-  return ids[0] ?? DEFAULT_ACCOUNT_ID;
-}
+const { listAccountIds, resolveDefaultAccountId } = createAccountListHelpers("bluebubbles");
+export const listBlueBubblesAccountIds = listAccountIds;
+export const resolveDefaultBlueBubblesAccountId = resolveDefaultAccountId;
 
 function resolveAccountConfig(
   cfg: OpenClawConfig,

--- a/extensions/feishu/src/accounts.ts
+++ b/extensions/feishu/src/accounts.ts
@@ -1,5 +1,6 @@
 import type { ClawdbotConfig } from "openclaw/plugin-sdk";
-import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-id";
+import { createAccountListHelpers } from "openclaw/plugin-sdk";
+import { normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import type {
   FeishuConfig,
   FeishuAccountConfig,
@@ -7,40 +8,9 @@ import type {
   ResolvedFeishuAccount,
 } from "./types.js";
 
-/**
- * List all configured account IDs from the accounts field.
- */
-function listConfiguredAccountIds(cfg: ClawdbotConfig): string[] {
-  const accounts = (cfg.channels?.feishu as FeishuConfig)?.accounts;
-  if (!accounts || typeof accounts !== "object") {
-    return [];
-  }
-  return Object.keys(accounts).filter(Boolean);
-}
-
-/**
- * List all Feishu account IDs.
- * If no accounts are configured, returns [DEFAULT_ACCOUNT_ID] for backward compatibility.
- */
-export function listFeishuAccountIds(cfg: ClawdbotConfig): string[] {
-  const ids = listConfiguredAccountIds(cfg);
-  if (ids.length === 0) {
-    // Backward compatibility: no accounts configured, use default
-    return [DEFAULT_ACCOUNT_ID];
-  }
-  return [...ids].toSorted((a, b) => a.localeCompare(b));
-}
-
-/**
- * Resolve the default account ID.
- */
-export function resolveDefaultFeishuAccountId(cfg: ClawdbotConfig): string {
-  const ids = listFeishuAccountIds(cfg);
-  if (ids.includes(DEFAULT_ACCOUNT_ID)) {
-    return DEFAULT_ACCOUNT_ID;
-  }
-  return ids[0] ?? DEFAULT_ACCOUNT_ID;
-}
+const { listAccountIds, resolveDefaultAccountId } = createAccountListHelpers("feishu");
+export const listFeishuAccountIds = listAccountIds;
+export const resolveDefaultFeishuAccountId = resolveDefaultAccountId;
 
 /**
  * Get the raw account-specific config.

--- a/extensions/googlechat/src/accounts.ts
+++ b/extensions/googlechat/src/accounts.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { createAccountListHelpers } from "openclaw/plugin-sdk";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import type { GoogleChatAccountConfig } from "./types.config.js";
 
@@ -17,21 +18,8 @@ export type ResolvedGoogleChatAccount = {
 const ENV_SERVICE_ACCOUNT = "GOOGLE_CHAT_SERVICE_ACCOUNT";
 const ENV_SERVICE_ACCOUNT_FILE = "GOOGLE_CHAT_SERVICE_ACCOUNT_FILE";
 
-function listConfiguredAccountIds(cfg: OpenClawConfig): string[] {
-  const accounts = cfg.channels?.["googlechat"]?.accounts;
-  if (!accounts || typeof accounts !== "object") {
-    return [];
-  }
-  return Object.keys(accounts).filter(Boolean);
-}
-
-export function listGoogleChatAccountIds(cfg: OpenClawConfig): string[] {
-  const ids = listConfiguredAccountIds(cfg);
-  if (ids.length === 0) {
-    return [DEFAULT_ACCOUNT_ID];
-  }
-  return ids.toSorted((a, b) => a.localeCompare(b));
-}
+const { listAccountIds } = createAccountListHelpers("googlechat");
+export const listGoogleChatAccountIds = listAccountIds;
 
 export function resolveDefaultGoogleChatAccountId(cfg: OpenClawConfig): string {
   const channel = cfg.channels?.["googlechat"];

--- a/extensions/mattermost/src/mattermost/accounts.ts
+++ b/extensions/mattermost/src/mattermost/accounts.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { createAccountListHelpers } from "openclaw/plugin-sdk";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import type { MattermostAccountConfig, MattermostChatMode } from "../types.js";
 import { normalizeMattermostBaseUrl } from "./client.js";
@@ -23,29 +24,9 @@ export type ResolvedMattermostAccount = {
   blockStreamingCoalesce?: MattermostAccountConfig["blockStreamingCoalesce"];
 };
 
-function listConfiguredAccountIds(cfg: OpenClawConfig): string[] {
-  const accounts = cfg.channels?.mattermost?.accounts;
-  if (!accounts || typeof accounts !== "object") {
-    return [];
-  }
-  return Object.keys(accounts).filter(Boolean);
-}
-
-export function listMattermostAccountIds(cfg: OpenClawConfig): string[] {
-  const ids = listConfiguredAccountIds(cfg);
-  if (ids.length === 0) {
-    return [DEFAULT_ACCOUNT_ID];
-  }
-  return ids.toSorted((a, b) => a.localeCompare(b));
-}
-
-export function resolveDefaultMattermostAccountId(cfg: OpenClawConfig): string {
-  const ids = listMattermostAccountIds(cfg);
-  if (ids.includes(DEFAULT_ACCOUNT_ID)) {
-    return DEFAULT_ACCOUNT_ID;
-  }
-  return ids[0] ?? DEFAULT_ACCOUNT_ID;
-}
+const { listAccountIds, resolveDefaultAccountId } = createAccountListHelpers("mattermost");
+export const listMattermostAccountIds = listAccountIds;
+export const resolveDefaultMattermostAccountId = resolveDefaultAccountId;
 
 function resolveAccountConfig(
   cfg: OpenClawConfig,

--- a/extensions/zalo/src/accounts.ts
+++ b/extensions/zalo/src/accounts.ts
@@ -1,25 +1,13 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { createAccountListHelpers } from "openclaw/plugin-sdk";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import type { ResolvedZaloAccount, ZaloAccountConfig, ZaloConfig } from "./types.js";
 import { resolveZaloToken } from "./token.js";
 
 export type { ResolvedZaloAccount };
 
-function listConfiguredAccountIds(cfg: OpenClawConfig): string[] {
-  const accounts = (cfg.channels?.zalo as ZaloConfig | undefined)?.accounts;
-  if (!accounts || typeof accounts !== "object") {
-    return [];
-  }
-  return Object.keys(accounts).filter(Boolean);
-}
-
-export function listZaloAccountIds(cfg: OpenClawConfig): string[] {
-  const ids = listConfiguredAccountIds(cfg);
-  if (ids.length === 0) {
-    return [DEFAULT_ACCOUNT_ID];
-  }
-  return ids.toSorted((a, b) => a.localeCompare(b));
-}
+const { listAccountIds } = createAccountListHelpers("zalo");
+export const listZaloAccountIds = listAccountIds;
 
 export function resolveDefaultZaloAccountId(cfg: OpenClawConfig): string {
   const zaloConfig = cfg.channels?.zalo as ZaloConfig | undefined;

--- a/src/channels/plugins/account-helpers.test.ts
+++ b/src/channels/plugins/account-helpers.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import { createAccountListHelpers } from "./account-helpers.js";
+
+const { listConfiguredAccountIds, listAccountIds, resolveDefaultAccountId } =
+  createAccountListHelpers("testchannel");
+
+function cfg(accounts?: Record<string, unknown> | null): OpenClawConfig {
+  if (accounts === null) {
+    return { channels: { testchannel: {} } } as unknown as OpenClawConfig;
+  }
+  if (accounts === undefined) {
+    return {} as unknown as OpenClawConfig;
+  }
+  return { channels: { testchannel: { accounts } } } as unknown as OpenClawConfig;
+}
+
+describe("createAccountListHelpers", () => {
+  describe("listConfiguredAccountIds", () => {
+    it("returns empty for missing config", () => {
+      expect(listConfiguredAccountIds({} as OpenClawConfig)).toEqual([]);
+    });
+
+    it("returns empty when no accounts key", () => {
+      expect(listConfiguredAccountIds(cfg(null))).toEqual([]);
+    });
+
+    it("returns empty for empty accounts object", () => {
+      expect(listConfiguredAccountIds(cfg({}))).toEqual([]);
+    });
+
+    it("filters out empty keys", () => {
+      expect(listConfiguredAccountIds(cfg({ "": {}, a: {} }))).toEqual(["a"]);
+    });
+
+    it("returns account keys", () => {
+      expect(listConfiguredAccountIds(cfg({ work: {}, personal: {} }))).toEqual([
+        "work",
+        "personal",
+      ]);
+    });
+  });
+
+  describe("listAccountIds", () => {
+    it('returns ["default"] for empty config', () => {
+      expect(listAccountIds({} as OpenClawConfig)).toEqual(["default"]);
+    });
+
+    it('returns ["default"] for empty accounts', () => {
+      expect(listAccountIds(cfg({}))).toEqual(["default"]);
+    });
+
+    it("returns sorted ids", () => {
+      expect(listAccountIds(cfg({ z: {}, a: {}, m: {} }))).toEqual(["a", "m", "z"]);
+    });
+  });
+
+  describe("resolveDefaultAccountId", () => {
+    it('returns "default" when present', () => {
+      expect(resolveDefaultAccountId(cfg({ default: {}, other: {} }))).toBe("default");
+    });
+
+    it("returns first sorted id when no default", () => {
+      expect(resolveDefaultAccountId(cfg({ beta: {}, alpha: {} }))).toBe("alpha");
+    });
+
+    it('returns "default" for empty config', () => {
+      expect(resolveDefaultAccountId({} as OpenClawConfig)).toBe("default");
+    });
+  });
+});

--- a/src/channels/plugins/account-helpers.ts
+++ b/src/channels/plugins/account-helpers.ts
@@ -1,0 +1,31 @@
+import type { OpenClawConfig } from "../../config/config.js";
+import { DEFAULT_ACCOUNT_ID } from "../../routing/session-key.js";
+
+export function createAccountListHelpers(channelKey: string) {
+  function listConfiguredAccountIds(cfg: OpenClawConfig): string[] {
+    const channel = cfg.channels?.[channelKey];
+    const accounts = (channel as Record<string, unknown> | undefined)?.accounts;
+    if (!accounts || typeof accounts !== "object") {
+      return [];
+    }
+    return Object.keys(accounts as Record<string, unknown>).filter(Boolean);
+  }
+
+  function listAccountIds(cfg: OpenClawConfig): string[] {
+    const ids = listConfiguredAccountIds(cfg);
+    if (ids.length === 0) {
+      return [DEFAULT_ACCOUNT_ID];
+    }
+    return ids.toSorted((a, b) => a.localeCompare(b));
+  }
+
+  function resolveDefaultAccountId(cfg: OpenClawConfig): string {
+    const ids = listAccountIds(cfg);
+    if (ids.includes(DEFAULT_ACCOUNT_ID)) {
+      return DEFAULT_ACCOUNT_ID;
+    }
+    return ids[0] ?? DEFAULT_ACCOUNT_ID;
+  }
+
+  return { listConfiguredAccountIds, listAccountIds, resolveDefaultAccountId };
+}

--- a/src/discord/accounts.ts
+++ b/src/discord/accounts.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "../config/config.js";
 import type { DiscordAccountConfig } from "../config/types.js";
-import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../routing/session-key.js";
+import { createAccountListHelpers } from "../channels/plugins/account-helpers.js";
+import { normalizeAccountId } from "../routing/session-key.js";
 import { resolveDiscordToken } from "./token.js";
 
 export type ResolvedDiscordAccount = {
@@ -12,29 +13,9 @@ export type ResolvedDiscordAccount = {
   config: DiscordAccountConfig;
 };
 
-function listConfiguredAccountIds(cfg: OpenClawConfig): string[] {
-  const accounts = cfg.channels?.discord?.accounts;
-  if (!accounts || typeof accounts !== "object") {
-    return [];
-  }
-  return Object.keys(accounts).filter(Boolean);
-}
-
-export function listDiscordAccountIds(cfg: OpenClawConfig): string[] {
-  const ids = listConfiguredAccountIds(cfg);
-  if (ids.length === 0) {
-    return [DEFAULT_ACCOUNT_ID];
-  }
-  return ids.toSorted((a, b) => a.localeCompare(b));
-}
-
-export function resolveDefaultDiscordAccountId(cfg: OpenClawConfig): string {
-  const ids = listDiscordAccountIds(cfg);
-  if (ids.includes(DEFAULT_ACCOUNT_ID)) {
-    return DEFAULT_ACCOUNT_ID;
-  }
-  return ids[0] ?? DEFAULT_ACCOUNT_ID;
-}
+const { listAccountIds, resolveDefaultAccountId } = createAccountListHelpers("discord");
+export const listDiscordAccountIds = listAccountIds;
+export const resolveDefaultDiscordAccountId = resolveDefaultAccountId;
 
 function resolveAccountConfig(
   cfg: OpenClawConfig,

--- a/src/imessage/accounts.ts
+++ b/src/imessage/accounts.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "../config/config.js";
 import type { IMessageAccountConfig } from "../config/types.js";
-import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../routing/session-key.js";
+import { createAccountListHelpers } from "../channels/plugins/account-helpers.js";
+import { normalizeAccountId } from "../routing/session-key.js";
 
 export type ResolvedIMessageAccount = {
   accountId: string;
@@ -10,29 +11,9 @@ export type ResolvedIMessageAccount = {
   configured: boolean;
 };
 
-function listConfiguredAccountIds(cfg: OpenClawConfig): string[] {
-  const accounts = cfg.channels?.imessage?.accounts;
-  if (!accounts || typeof accounts !== "object") {
-    return [];
-  }
-  return Object.keys(accounts).filter(Boolean);
-}
-
-export function listIMessageAccountIds(cfg: OpenClawConfig): string[] {
-  const ids = listConfiguredAccountIds(cfg);
-  if (ids.length === 0) {
-    return [DEFAULT_ACCOUNT_ID];
-  }
-  return ids.toSorted((a, b) => a.localeCompare(b));
-}
-
-export function resolveDefaultIMessageAccountId(cfg: OpenClawConfig): string {
-  const ids = listIMessageAccountIds(cfg);
-  if (ids.includes(DEFAULT_ACCOUNT_ID)) {
-    return DEFAULT_ACCOUNT_ID;
-  }
-  return ids[0] ?? DEFAULT_ACCOUNT_ID;
-}
+const { listAccountIds, resolveDefaultAccountId } = createAccountListHelpers("imessage");
+export const listIMessageAccountIds = listAccountIds;
+export const resolveDefaultIMessageAccountId = resolveDefaultAccountId;
 
 function resolveAccountConfig(
   cfg: OpenClawConfig,

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -1,3 +1,4 @@
+export { createAccountListHelpers } from "../channels/plugins/account-helpers.js";
 export { CHANNEL_MESSAGE_ACTION_NAMES } from "../channels/plugins/message-action-names.js";
 export {
   BLUEBUBBLES_ACTIONS,

--- a/src/signal/accounts.ts
+++ b/src/signal/accounts.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "../config/config.js";
 import type { SignalAccountConfig } from "../config/types.js";
-import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../routing/session-key.js";
+import { createAccountListHelpers } from "../channels/plugins/account-helpers.js";
+import { normalizeAccountId } from "../routing/session-key.js";
 
 export type ResolvedSignalAccount = {
   accountId: string;
@@ -11,29 +12,9 @@ export type ResolvedSignalAccount = {
   config: SignalAccountConfig;
 };
 
-function listConfiguredAccountIds(cfg: OpenClawConfig): string[] {
-  const accounts = cfg.channels?.signal?.accounts;
-  if (!accounts || typeof accounts !== "object") {
-    return [];
-  }
-  return Object.keys(accounts).filter(Boolean);
-}
-
-export function listSignalAccountIds(cfg: OpenClawConfig): string[] {
-  const ids = listConfiguredAccountIds(cfg);
-  if (ids.length === 0) {
-    return [DEFAULT_ACCOUNT_ID];
-  }
-  return ids.toSorted((a, b) => a.localeCompare(b));
-}
-
-export function resolveDefaultSignalAccountId(cfg: OpenClawConfig): string {
-  const ids = listSignalAccountIds(cfg);
-  if (ids.includes(DEFAULT_ACCOUNT_ID)) {
-    return DEFAULT_ACCOUNT_ID;
-  }
-  return ids[0] ?? DEFAULT_ACCOUNT_ID;
-}
+const { listAccountIds, resolveDefaultAccountId } = createAccountListHelpers("signal");
+export const listSignalAccountIds = listAccountIds;
+export const resolveDefaultSignalAccountId = resolveDefaultAccountId;
 
 function resolveAccountConfig(
   cfg: OpenClawConfig,

--- a/src/slack/accounts.ts
+++ b/src/slack/accounts.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "../config/config.js";
 import type { SlackAccountConfig } from "../config/types.js";
 import { normalizeChatType } from "../channels/chat-type.js";
+import { createAccountListHelpers } from "../channels/plugins/account-helpers.js";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../routing/session-key.js";
 import { resolveSlackAppToken, resolveSlackBotToken } from "./token.js";
 
@@ -28,29 +29,9 @@ export type ResolvedSlackAccount = {
   channels?: SlackAccountConfig["channels"];
 };
 
-function listConfiguredAccountIds(cfg: OpenClawConfig): string[] {
-  const accounts = cfg.channels?.slack?.accounts;
-  if (!accounts || typeof accounts !== "object") {
-    return [];
-  }
-  return Object.keys(accounts).filter(Boolean);
-}
-
-export function listSlackAccountIds(cfg: OpenClawConfig): string[] {
-  const ids = listConfiguredAccountIds(cfg);
-  if (ids.length === 0) {
-    return [DEFAULT_ACCOUNT_ID];
-  }
-  return ids.toSorted((a, b) => a.localeCompare(b));
-}
-
-export function resolveDefaultSlackAccountId(cfg: OpenClawConfig): string {
-  const ids = listSlackAccountIds(cfg);
-  if (ids.includes(DEFAULT_ACCOUNT_ID)) {
-    return DEFAULT_ACCOUNT_ID;
-  }
-  return ids[0] ?? DEFAULT_ACCOUNT_ID;
-}
+const { listAccountIds, resolveDefaultAccountId } = createAccountListHelpers("slack");
+export const listSlackAccountIds = listAccountIds;
+export const resolveDefaultSlackAccountId = resolveDefaultAccountId;
 
 function resolveAccountConfig(
   cfg: OpenClawConfig,

--- a/src/web/accounts.ts
+++ b/src/web/accounts.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import type { OpenClawConfig } from "../config/config.js";
 import type { DmPolicy, GroupPolicy, WhatsAppAccountConfig } from "../config/types.js";
+import { createAccountListHelpers } from "../channels/plugins/account-helpers.js";
 import { resolveOAuthDir } from "../config/paths.js";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../routing/session-key.js";
 import { resolveUserPath } from "../utils.js";
@@ -29,13 +30,10 @@ export type ResolvedWhatsAppAccount = {
   debounceMs?: number;
 };
 
-function listConfiguredAccountIds(cfg: OpenClawConfig): string[] {
-  const accounts = cfg.channels?.whatsapp?.accounts;
-  if (!accounts || typeof accounts !== "object") {
-    return [];
-  }
-  return Object.keys(accounts).filter(Boolean);
-}
+const { listConfiguredAccountIds, listAccountIds, resolveDefaultAccountId } =
+  createAccountListHelpers("whatsapp");
+export const listWhatsAppAccountIds = listAccountIds;
+export const resolveDefaultWhatsAppAccountId = resolveDefaultAccountId;
 
 export function listWhatsAppAuthDirs(cfg: OpenClawConfig): string[] {
   const oauthDir = resolveOAuthDir();
@@ -64,22 +62,6 @@ export function listWhatsAppAuthDirs(cfg: OpenClawConfig): string[] {
 
 export function hasAnyWhatsAppAuth(cfg: OpenClawConfig): boolean {
   return listWhatsAppAuthDirs(cfg).some((authDir) => hasWebCredsSync(authDir));
-}
-
-export function listWhatsAppAccountIds(cfg: OpenClawConfig): string[] {
-  const ids = listConfiguredAccountIds(cfg);
-  if (ids.length === 0) {
-    return [DEFAULT_ACCOUNT_ID];
-  }
-  return ids.toSorted((a, b) => a.localeCompare(b));
-}
-
-export function resolveDefaultWhatsAppAccountId(cfg: OpenClawConfig): string {
-  const ids = listWhatsAppAccountIds(cfg);
-  if (ids.includes(DEFAULT_ACCOUNT_ID)) {
-    return DEFAULT_ACCOUNT_ID;
-  }
-  return ids[0] ?? DEFAULT_ACCOUNT_ID;
 }
 
 function resolveAccountConfig(


### PR DESCRIPTION
## Summary

10 channel `accounts.ts` files had identical `listConfiguredAccountIds` / `list*AccountIds` / `resolveDefault*AccountId` three-piece boilerplate — only the channel key string differed. Extracted a `createAccountListHelpers(channelKey)` factory, replaced the copy-paste with one-liner re-exports.

lobster-biscuit

## Why

Every time someone adds or tweaks account listing logic, they need to touch 10 files with the same change. That's a maintenance trap — easy to miss one and end up with subtle inconsistencies. The factory makes the pattern single-source.

## What changed

New file: `src/channels/plugins/account-helpers.ts` — factory function that takes a channel key and returns `{ listConfiguredAccountIds, listAccountIds, resolveDefaultAccountId }`.

Re-exported from `src/plugin-sdk/index.ts` so extensions can import it.

**Migrated (full three-piece):** discord, signal, imessage, slack, whatsapp, bluebubbles, mattermost, feishu

**Migrated (two-piece only — `resolveDefault*AccountId` has custom `defaultAccount` logic):** googlechat, zalo

**Not migrated (different logic entirely):** telegram (merges bound account IDs), line (different pattern), nextcloud-talk/irc/matrix (uses `normalizeAccountId` + Set), nostr (single-account), msteams (no accounts file)

## Impact

- All exported function names and signatures are unchanged — zero breaking changes for callers.
- `src/web/accounts.ts`: `listConfiguredAccountIds` is still available via the factory return (used internally by `listWhatsAppAuthDirs`).
- Net diff: +147 / -230 lines across 13 files.

## Tests

- 11 new unit tests in `account-helpers.test.ts` covering all branches (empty config, no accounts, empty accounts, empty key filtering, sorting, default fallback).
- All existing channel-level tests pass (83 test files, 700+ tests across discord/signal/imessage/slack/web directories).
- `pnpm check` (format + types + lint) passes clean.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extracted account listing boilerplate from 10 channel `accounts.ts` files into a reusable `createAccountListHelpers(channelKey)` factory. The factory returns three functions (`listConfiguredAccountIds`, `listAccountIds`, `resolveDefaultAccountId`) that previously existed as identical copy-paste across discord, signal, imessage, slack, whatsapp, bluebubbles, mattermost, feishu, googlechat, and zalo channels.

**Key changes:**
- New factory in `src/channels/plugins/account-helpers.ts` with comprehensive test coverage (11 tests)
- Exported via `src/plugin-sdk/index.ts` for extension use
- Migrated 8 channels (full three-piece): discord, signal, imessage, slack, whatsapp, bluebubbles, mattermost, feishu
- Migrated 2 channels (two-piece only): googlechat and zalo retain custom `resolveDefault*AccountId` with `defaultAccount` logic
- Preserved internal use of `listConfiguredAccountIds` in `src/web/accounts.ts:43` for `listWhatsAppAuthDirs`
- All exported function names and signatures unchanged (zero breaking changes)

The refactoring eliminates maintenance burden by ensuring future account listing changes only need to touch one location instead of 10+ files.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Clean refactoring with no logic changes - the factory implementation is a direct extraction of identical boilerplate code. All exported function names and signatures remain unchanged, ensuring zero breaking changes for callers. Comprehensive test coverage (11 unit tests covering all branches including empty configs, sorting, and default fallback). The PR description correctly identifies which channels were migrated and why some weren't (telegram merges bound account IDs, others have different patterns). Internal use of `listConfiguredAccountIds` is preserved where needed (web/accounts.ts).
- No files require special attention

<sub>Last reviewed commit: d187369</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->