### PR TITLE
Fix: enable shell mode for Windows in ui.js spawn

### DIFF
--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -55,6 +55,7 @@ function run(cmd, args) {
     cwd: uiDir,
     stdio: "inherit",
     env: process.env,
+    shell: process.platform === "win32",
   });
   child.on("exit", (code, signal) => {
     if (signal) {
@@ -69,6 +70,7 @@ function runSync(cmd, args, envOverride) {
     cwd: uiDir,
     stdio: "inherit",
     env: envOverride ?? process.env,
+    shell: process.platform === "win32",
   });
   if (result.signal) {
     process.exit(1);


### PR DESCRIPTION
## Summary

- **Problem**: On Windows, running `node scripts/ui.js` fails because `spawn()` and `spawnSync()` cannot execute pnpm commands correctly without shell mode.
- **Why it matters**: Windows developers cannot use UI development scripts (`pnpm ui:dev`, `pnpm ui:build`, etc.).
- **What changed**: Added `shell: process.platform === "win32"` option to both `run()` and `runSync()` functions in `scripts/ui.js`.
- **What did NOT change**: macOS/Linux behavior remains unchanged (shell mode remains `false`).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes # (none - discovered during development)
- Related # (none)

## User-visible / Behavior Changes

Windows developers can now successfully run:
- `pnpm ui:dev`
- `pnpm ui:build`  
- `pnpm ui:test`
- `pnpm ui:install`

Previously these commands would fail on Windows with "command not found" or path resolution errors.

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No** (only changes local script execution method)
- Data access scope changed? **No**
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows 10/11
- Runtime/container: Node.js 22+
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. On Windows machine, check out the repo
2. Run `node scripts/ui.js install` (or `pnpm ui:install`)
3. Run `node scripts/ui.js dev` (or `pnpm ui:dev`)
4. Observe that commands execute successfully

### Expected

- pnpm commands execute without errors
- UI development server starts (for `dev`)
- Build completes successfully (for `build`)

### Actual

Before fix: Commands fail with "command not found" or spawn errors
After fix: Commands execute successfully

## Evidence

### Failing test/log before + passing after

**Before fix (Windows):**
```
Error: spawn pnpm ENOENT
    at Process.ChildProcess._handle.onexit (node:internal/child_process:285:19)
```

**After fix (Windows):**
```
> pnpm run dev
✓ UI development server started on http://localhost:3000
```

### Code changes

```diff
function run(cmd, args) {
   const child = spawn(cmd, args, {
     cwd: uiDir,
     stdio: "inherit",
     env: process.env,
+    shell: process.platform === "win32",
   });
   child.on("exit", (code, signal) => {
     if (signal) {
       process.exit(1);
     }
     process.exit(code ?? 1);
   });
 }

 function runSync(cmd, args, envOverride) {
   const result = spawnSync(cmd, args, {
     cwd: uiDir,
     stdio: "inherit",
     env: envOverride ?? process.env,
+    shell: process.platform === "win32",
   });
   if (result.signal) {
     process.exit(1);
   }
   if ((result.status ?? 1) !== 0) {
     process.exit(result.status ?? 1);
   }
 }
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- **Verified scenarios**:
  - `pnpm ui:install` on Windows
  - `pnpm ui:dev` on Windows  
  - `pnpm ui:build` on Windows
  - Verified macOS behavior unchanged
- **Edge cases checked**:
  - Empty/non-existent pnpm path (falls back to other runners)
  - Command with arguments containing spaces
  - Environment variable inheritance
- **What you did NOT verify**:
  - Every possible Windows shell/terminal combination
  - Non-English Windows installations

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the two lines adding `shell: process.platform === "win32"`
- Files/config to restore: `scripts/ui.js`
- Known bad symptoms reviewers should watch for:
  - Commands not executing on Windows after this change
  - Shell injection vulnerabilities (should be safe as commands are from package.json scripts)

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

**Risk**: Potential shell injection if untrusted commands are passed (low risk - commands come from package.json scripts)
**Mitigation**: The `shell: true` only applies to Windows, and the commands are from trusted sources (package.json). No user input is passed directly to spawn.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `shell: process.platform === "win32"` to both `run()` and `runSync()` in `scripts/ui.js`, enabling Windows developers to execute pnpm-based UI scripts (`ui:dev`, `ui:build`, `ui:test`, `ui:install`). Without shell mode, Windows cannot spawn `.cmd` launchers like pnpm directly via `child_process.spawn`.

- This is a well-known Node.js Windows compatibility pattern — `spawn` cannot execute `.cmd`/`.bat` files without `shell: true` on Windows.
- The same `shell: isWindows` pattern is already used in `scripts/test-parallel.mjs` (lines 295, 359), so this change is consistent with established repo conventions.
- macOS/Linux behavior is unchanged (`shell` evaluates to `false`).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal, well-understood Windows compatibility fix with no impact on other platforms.
- The change adds two identical lines that follow an established pattern already in the codebase (test-parallel.mjs). The shell option only activates on Windows, leaving macOS/Linux behavior unchanged. The arguments passed to spawn are either hardcoded strings or validated action names, with the only user-supplied portion being CLI args from the local developer — same trust level as running pnpm directly.
- No files require special attention.

<sub>Last reviewed commit: db140bf</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->