### PR TITLE
fix(doctor,configure): skip gateway auth for loopback-only setups

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -123,14 +123,18 @@ export async function doctorCommand(
     note(gatewayDetails.remoteFallbackNote, "Gateway");
   }
   if (resolveMode(cfg) === "local") {
+    const gatewayBind = cfg.gateway?.bind ?? "loopback";
+    const tailscaleMode = cfg.gateway?.tailscale?.mode ?? "off";
+    const requireGatewayAuth = gatewayBind !== "loopback" || tailscaleMode !== "off";
     const auth = resolveGatewayAuth({
       authConfig: cfg.gateway?.auth,
-      tailscaleMode: cfg.gateway?.tailscale?.mode ?? "off",
+      tailscaleMode,
     });
-    const needsToken = auth.mode !== "password" && (auth.mode !== "token" || !auth.token);
+    const needsToken =
+      requireGatewayAuth && auth.mode !== "password" && (auth.mode !== "token" || !auth.token);
     if (needsToken) {
       note(
-        "Gateway auth is off or missing a token. Token auth is now the recommended default (including loopback).",
+        "Gateway auth is off or missing a token. Token auth is recommended when the gateway is exposed beyond local loopback.",
         "Gateway auth",
       );
       const shouldSetToken =


### PR DESCRIPTION
Fixes #18225

## Problem
`openclaw doctor` flags missing `gateway.auth` and `openclaw configure` prompts for auth setup even when the gateway is bound to loopback (127.0.0.1) — where auth is unnecessary since it's not network-exposed.

## Changes
- **doctor.ts**: Only warn about missing auth when bind is non-loopback or Tailscale is enabled
- **configure.gateway.ts**: Skip auth mode selection for loopback-only gateways; remove existing `gateway.auth` from config if present
- **configure.gateway.e2e.test.ts**: Added loopback skip test, updated existing tests to use `lan` bind for auth scenarios

## Tests
All 5 related e2e tests pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an issue where `openclaw doctor` and `openclaw configure` unnecessarily flagged missing gateway authentication for loopback-only setups (127.0.0.1) where auth is not required since the gateway is not network-exposed.

**Changes:**
- **doctor.ts:126-134**: Added `requireGatewayAuth` check that evaluates to `false` when `bind=loopback` AND `tailscale.mode=off`, preventing auth warnings for truly local-only gateways
- **configure.gateway.ts:125-163**: Introduced `loopbackOnlyGateway` flag to skip auth mode selection UI for loopback-only setups; when true, the auth config is omitted entirely and any existing `gateway.auth` is removed from config
- **configure.gateway.ts:271-290**: Auth config is only built and included in gateway config when not loopback-only
- **configure.gateway.e2e.test.ts**: Updated test expectations to match new behavior - loopback-only gateways should have no auth config, while exposed gateways (lan/tailnet) still require auth

The implementation correctly aligns with the existing server-side validation in `server-runtime-config.ts:99-102` which already allows loopback binding without auth.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is sound with proper test coverage and aligns with existing server-side validation logic. The loopback-only check (`bind === "loopback" && tailscaleMode === "off"`) correctly identifies truly local-only gateways. The changes maintain backward compatibility for exposed gateways while fixing the UX issue for loopback-only setups. All 5 e2e tests pass.
- No files require special attention

<sub>Last reviewed commit: 4e8e254</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->