### PR TITLE
fix(message): support react current alias and suppress leaked react errors

### DIFF
--- a/src/agents/pi-embedded-runner/run/payloads.e2e.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.e2e.test.ts
@@ -262,6 +262,20 @@ describe("buildEmbeddedRunPayloads", () => {
     expect(payloads[0]?.text).toContain("required");
   });
 
+  it("suppresses message react tool errors from user-visible output", () => {
+    const payloads = buildPayloads({
+      lastToolError: {
+        toolName: "message",
+        meta: "react",
+        error: "messageId required",
+        mutatingAction: true,
+        actionFingerprint: "tool=message|action=react|target=123",
+      },
+    });
+
+    expect(payloads).toHaveLength(0);
+  });
+
   it("shows mutating tool errors even when assistant output exists", () => {
     const payloads = buildPayloads({
       assistantTexts: ["Done."],

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -44,11 +44,24 @@ function isRecoverableToolError(error: string | undefined): boolean {
   return RECOVERABLE_TOOL_ERROR_KEYWORDS.some((keyword) => errorLower.includes(keyword));
 }
 
+function isSuppressedSideEffectToolError(lastToolError: LastToolError): boolean {
+  const tool = lastToolError.toolName.trim().toLowerCase();
+  const meta = (lastToolError.meta ?? "").trim().toLowerCase();
+  const fingerprint = (lastToolError.actionFingerprint ?? "").trim().toLowerCase();
+  return (
+    (tool === "message" && meta === "react") ||
+    (tool === "message" && fingerprint.includes("|action=react"))
+  );
+}
+
 function shouldShowToolErrorWarning(params: {
   lastToolError: LastToolError;
   hasUserFacingReply: boolean;
   suppressToolErrors: boolean;
 }): boolean {
+  if (isSuppressedSideEffectToolError(params.lastToolError)) {
+    return false;
+  }
   const isMutatingToolError =
     params.lastToolError.mutatingAction ?? isLikelyMutatingToolName(params.lastToolError.toolName);
   if (isMutatingToolError) {

--- a/src/infra/outbound/message-action-params.ts
+++ b/src/infra/outbound/message-action-params.ts
@@ -34,6 +34,22 @@ export function readBooleanParam(
   return undefined;
 }
 
+export function readCurrentMessageIdAlias(params: {
+  args: Record<string, unknown>;
+  key: string;
+  currentMessageId?: string;
+}): string | undefined {
+  const raw = readStringParam(params.args, params.key);
+  if (!raw) {
+    return undefined;
+  }
+  const normalized = raw.trim().toLowerCase();
+  if (normalized !== "current") {
+    return raw;
+  }
+  return params.currentMessageId?.trim() || undefined;
+}
+
 export function resolveSlackAutoThreadId(params: {
   to: string;
   toolContext?: ChannelThreadingToolContext;

--- a/src/infra/outbound/message-action-runner.test.ts
+++ b/src/infra/outbound/message-action-runner.test.ts
@@ -882,4 +882,24 @@ describe("runMessageAction react current message alias", () => {
     const ctx = handleAction.mock.calls[0]?.[0] as { params: Record<string, unknown> };
     expect(ctx.params.messageId).toBe("987654321");
   });
+
+  it("throws when messageId=current cannot be resolved", async () => {
+    await expect(
+      runMessageAction({
+        cfg: {} as OpenClawConfig,
+        action: "react",
+        params: {
+          channel: "discord",
+          target: "channel:123",
+          messageId: "current",
+          emoji: "✅",
+        },
+        toolContext: {
+          currentChannelId: "channel:123",
+          currentChannelProvider: "discord",
+        },
+        dryRun: false,
+      }),
+    ).rejects.toThrow("Cannot resolve 'current'");
+  });
 });

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -35,6 +35,7 @@ import {
   parseButtonsParam,
   parseCardParam,
   readBooleanParam,
+  readCurrentMessageIdAlias,
   resolveSlackAutoThreadId,
   resolveTelegramAutoThreadId,
 } from "./message-action-params.js";
@@ -741,6 +742,18 @@ export async function runMessageAction(
   }
 
   applyTargetToParams({ action, args: params });
+
+  if (action === "react") {
+    const resolvedMessageId = readCurrentMessageIdAlias({
+      args: params,
+      key: "messageId",
+      currentMessageId: input.toolContext?.currentThreadTs,
+    });
+    if (resolvedMessageId) {
+      params.messageId = resolvedMessageId;
+    }
+  }
+
   if (actionRequiresTarget(action)) {
     if (!actionHasTarget(action, params)) {
       throw new Error(`Action ${action} requires a target.`);

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -744,6 +744,7 @@ export async function runMessageAction(
   applyTargetToParams({ action, args: params });
 
   if (action === "react") {
+    const rawMessageId = readStringParam(params, "messageId");
     const resolvedMessageId = readCurrentMessageIdAlias({
       args: params,
       key: "messageId",
@@ -751,6 +752,10 @@ export async function runMessageAction(
     });
     if (resolvedMessageId) {
       params.messageId = resolvedMessageId;
+    } else if (rawMessageId?.trim().toLowerCase() === "current") {
+      throw new Error(
+        "Cannot resolve 'current' — no triggering message ID available in this context",
+      );
     }
   }
 


### PR DESCRIPTION
Fixes #18154

## Problem
Two issues with `message react`:
1. React errors (e.g. invalid emoji, missing permissions) leak as visible Discord messages instead of being handled silently
2. No shortcut to react to the current/triggering message — users must manually pass message IDs

## Changes
- **message-action-params.ts**: Added `readCurrentMessageIdAlias()` — resolves `messageId: "current"` to the triggering message's ID from tool context
- **message-action-runner.ts**: Maps `messageId=current` before dispatching to channel plugin
- **payloads.ts**: Added `isSuppressedSideEffectToolError()` — suppresses react failures from user-visible output (still logged internally)
- **Tests**: Added unit tests for both current-alias resolution and error suppression

## Tests
All 27 unit tests pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two issues with the `message react` action: (1) adds a `"current"` alias for `messageId` that resolves to the triggering message's ID from tool context, and (2) suppresses react failure errors from user-visible output while still logging them internally.

- **`readCurrentMessageIdAlias`** in `message-action-params.ts` cleanly resolves `messageId: "current"` to the actual message ID from `currentThreadTs` in the tool context
- **`isSuppressedSideEffectToolError`** in `payloads.ts` prevents react errors (invalid emoji, missing permissions, etc.) from appearing as visible Discord messages to the user
- **Integration** in `message-action-runner.ts` hooks the alias resolution into the react action path, placed correctly after `applyTargetToParams`
- **Tests** cover the alias resolution and error suppression paths
- **Issue**: When `currentThreadTs` is not available (e.g., channels without `buildToolContext` or outside thread context), the `"current"` alias silently falls through as a literal string, which will fail at the API level and then be suppressed by the new error suppression — resulting in completely silent no-op behavior with no user feedback

<h3>Confidence Score: 3/5</h3>

- PR is mostly safe but has a silent failure mode when the "current" alias cannot be resolved
- The core logic is sound and well-tested for the happy path. The main concern is an edge case where the "current" alias cannot be resolved (when currentThreadTs is unavailable), resulting in a literal "current" string being passed to the channel API. Combined with the new error suppression, this creates a completely silent failure with no user feedback. The score reflects this unhandled edge case in an otherwise clean PR.
- Pay close attention to `src/infra/outbound/message-action-runner.ts` — the alias resolution fallback path when `currentThreadTs` is unavailable needs handling.

<sub>Last reviewed commit: 8f74619</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->