### PR TITLE
refactor(slack): centralize modal private_metadata utilities

### DIFF
--- a/src/slack/monitor/events/interactions.ts
+++ b/src/slack/monitor/events/interactions.ts
@@ -580,20 +580,18 @@ export function registerSlackInteractionEvents(params: { ctx: SlackMonitorContex
     },
   );
 
-  const viewClosed = (
-    ctx.app as unknown as {
-      viewClosed?: (
-        matcher: RegExp,
-        handler: (args: { ack: () => Promise<void>; body: unknown }) => Promise<void>,
-      ) => void;
-    }
-  ).viewClosed;
-  if (typeof viewClosed !== "function") {
+  const appWithViewClosed = ctx.app as unknown as {
+    viewClosed?: (
+      matcher: RegExp,
+      handler: (args: { ack: () => Promise<void>; body: unknown }) => Promise<void>,
+    ) => void;
+  };
+  if (typeof appWithViewClosed.viewClosed !== "function") {
     return;
   }
 
   // Handle modal close events so agent workflows can react to cancelled forms.
-  viewClosed(
+  appWithViewClosed.viewClosed(
     new RegExp(`^${OPENCLAW_ACTION_PREFIX}`),
     async ({ ack, body }: { ack: () => Promise<void>; body: unknown }) => {
       await ack();


### PR DESCRIPTION
## Why
Modal `private_metadata` parsing is currently embedded in interaction handler logic. A shared utility makes routing metadata consistent and gives us an explicit producer-facing encoder for future modal-open flows.

## Dependency
- Depends on #18180, #18234, #18242, #18252, #18257, #18262, #18268, #18278, #18284, #18290, and #18372.
- If reviewing before dependencies merge, review tip commit: `f7aafce81`.

## What This PR Adds
- New utility module:
  - `/Users/solvely/Projects/OpenClaw/src/slack/modal-metadata.ts`
  - `parseSlackModalPrivateMetadata(raw)`
  - `encodeSlackModalPrivateMetadata(input)`

- Utility behavior:
  - parse: safe JSON parse with known fields (`sessionKey`, `channelId`, `channelType`)
  - encode: normalized payload and Slack size guard (`private_metadata <= 3000 chars`)

- Interaction handler wiring:
  - `/Users/solvely/Projects/OpenClaw/src/slack/monitor/events/interactions.ts` now uses shared parse utility.

- Tests:
  - `/Users/solvely/Projects/OpenClaw/src/slack/modal-metadata.test.ts`
  - existing interactions tests still pass.

## Behavior
- No behavioral regression intended; parsing logic is centralized.
- Adds reusable encoder for upcoming modal-open helper work.

## Validation
- `pnpm test src/slack/modal-metadata.test.ts src/slack/monitor/events/interactions.test.ts`
- `pnpm check`

## Reviewer Focus
- `src/slack/modal-metadata.ts`
- `src/slack/modal-metadata.test.ts`
- `src/slack/monitor/events/interactions.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR preserves the method binding for `viewClosed` in the Slack interaction handler. The change extracts the typed `app` object reference instead of just the method, ensuring the correct `this` context is maintained when calling `viewClosed`. This prevents potential runtime errors from losing the method's binding to its parent object.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a small, focused refactor that fixes a method binding issue. It's well-tested (existing tests cover `viewClosed` functionality), follows established patterns, and has no side effects on other code paths.
- No files require special attention

<sub>Last reviewed commit: 86996a3</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->