### PR TITLE
docs(notion): add file upload documentation to Notion skill

### DIFF
--- a/skills/notion/SKILL.md
+++ b/skills/notion/SKILL.md
@@ -168,7 +168,7 @@ Common property formats for database items:
 
 Upload files (images, PDFs, etc.) directly to Notion-managed storage via the API. Three steps: create upload → send file → attach to block/page.
 
-> **Note:** File upload requires `Notion-Version: 2022-06-28` or later. Max 20 MB per file for direct upload. For larger files, use [multi-part uploads](https://developers.notion.com/guides/data-apis/sending-larger-files).
+> **Note:** Max 20 MB per file for direct upload. For larger files, use [multi-part uploads](https://developers.notion.com/guides/data-apis/sending-larger-files).
 
 **Step 1 — Create a file upload object:**
 
@@ -176,18 +176,18 @@ Upload files (images, PDFs, etc.) directly to Notion-managed storage via the API
 curl -X POST "https://api.notion.com/v1/file_uploads" \
   -H "Authorization: Bearer $NOTION_KEY" \
   -H "Content-Type: application/json" \
-  -H "Notion-Version: 2022-06-28" \
+  -H "Notion-Version: 2025-09-03" \
   -d '{}'
 ```
 
-Save the returned `id` and `upload_url`.
+Save the returned `id`.
 
 **Step 2 — Upload the file binary:**
 
 ```bash
 curl -X POST "https://api.notion.com/v1/file_uploads/{file_upload_id}/send" \
   -H "Authorization: Bearer $NOTION_KEY" \
-  -H "Notion-Version: 2022-06-28" \
+  -H "Notion-Version: 2025-09-03" \
   -F "file=@/path/to/file.pdf"
 ```
 
@@ -200,7 +200,7 @@ Status changes from `pending` → `uploaded`. Note: this endpoint expects `multi
 curl -X PATCH "https://api.notion.com/v1/blocks/{page_id}/children" \
   -H "Authorization: Bearer $NOTION_KEY" \
   -H "Content-Type: application/json" \
-  -H "Notion-Version: 2022-06-28" \
+  -H "Notion-Version: 2025-09-03" \
   -d '{
     "children": [{
       "type": "file",
@@ -219,7 +219,7 @@ Works with `file`, `image`, `video`, `audio`, and `pdf` block types. Also works 
 curl -X PATCH "https://api.notion.com/v1/pages/{page_id}" \
   -H "Authorization: Bearer $NOTION_KEY" \
   -H "Content-Type: application/json" \
-  -H "Notion-Version: 2022-06-28" \
+  -H "Notion-Version: 2025-09-03" \
   -d '{
     "properties": {
       "Attachments": {
@@ -234,6 +234,7 @@ curl -X PATCH "https://api.notion.com/v1/pages/{page_id}" \
 ```
 
 **Tips:**
+
 - Files must be attached within **1 hour** of creation or they expire
 - Upload once, attach many times — the same `file_upload` ID is reusable
 - After first attachment, the file becomes permanent (no more expiry)

--- a/skills/notion/SKILL.md
+++ b/skills/notion/SKILL.md
@@ -164,6 +164,81 @@ Common property formats for database items:
 - **Parent in responses:** Pages show `parent.data_source_id` alongside `parent.database_id`
 - **Finding the data_source_id:** Search for the database, or call `GET /v1/data_sources/{data_source_id}`
 
+## File Uploads
+
+Upload files (images, PDFs, etc.) directly to Notion-managed storage via the API. Three steps: create upload → send file → attach to block/page.
+
+> **Note:** File upload requires `Notion-Version: 2022-06-28` or later. Max 20 MB per file for direct upload. For larger files, use [multi-part uploads](https://developers.notion.com/guides/data-apis/sending-larger-files).
+
+**Step 1 — Create a file upload object:**
+
+```bash
+curl -X POST "https://api.notion.com/v1/file_uploads" \
+  -H "Authorization: Bearer $NOTION_KEY" \
+  -H "Content-Type: application/json" \
+  -H "Notion-Version: 2022-06-28" \
+  -d '{}'
+```
+
+Save the returned `id` and `upload_url`.
+
+**Step 2 — Upload the file binary:**
+
+```bash
+curl -X POST "https://api.notion.com/v1/file_uploads/{file_upload_id}/send" \
+  -H "Authorization: Bearer $NOTION_KEY" \
+  -H "Notion-Version: 2022-06-28" \
+  -F "file=@/path/to/file.pdf"
+```
+
+Status changes from `pending` → `uploaded`. Note: this endpoint expects `multipart/form-data`, not JSON.
+
+**Step 3 — Attach to a page or block:**
+
+```bash
+# As a file block
+curl -X PATCH "https://api.notion.com/v1/blocks/{page_id}/children" \
+  -H "Authorization: Bearer $NOTION_KEY" \
+  -H "Content-Type: application/json" \
+  -H "Notion-Version: 2022-06-28" \
+  -d '{
+    "children": [{
+      "type": "file",
+      "file": {
+        "type": "file_upload",
+        "file_upload": {"id": "file_upload_id"},
+        "name": "document.pdf"
+      }
+    }]
+  }'
+```
+
+Works with `file`, `image`, `video`, `audio`, and `pdf` block types. Also works with `files` properties on database pages:
+
+```bash
+curl -X PATCH "https://api.notion.com/v1/pages/{page_id}" \
+  -H "Authorization: Bearer $NOTION_KEY" \
+  -H "Content-Type: application/json" \
+  -H "Notion-Version: 2022-06-28" \
+  -d '{
+    "properties": {
+      "Attachments": {
+        "files": [{
+          "type": "file_upload",
+          "file_upload": {"id": "file_upload_id"},
+          "name": "receipt.pdf"
+        }]
+      }
+    }
+  }'
+```
+
+**Tips:**
+- Files must be attached within **1 hour** of creation or they expire
+- Upload once, attach many times — the same `file_upload` ID is reusable
+- After first attachment, the file becomes permanent (no more expiry)
+- Download URLs from Notion expire after 1 hour — re-fetch the block to refresh
+
 ## Notes
 
 - Page/database IDs are UUIDs (with or without dashes)


### PR DESCRIPTION
## Summary

Adds a **File Uploads** section to the Notion skill (`skills/notion/SKILL.md`) documenting the native Notion API file upload flow.

## What changed

New section covering:
- **3-step upload process**: create file upload object → send binary → attach to block/page
- **curl examples** for file blocks, image blocks, and database file properties
- **Tips** on expiry (1-hour attachment deadline), file reuse, and download URL refresh
- **Link to multi-part upload docs** for files > 20 MB

## Why

The Notion API now supports native file uploads (`POST /v1/file_uploads`), eliminating the need for external hosting workarounds (S3, Google Drive, etc.). The existing skill documentation didn't mention this capability, which meant agents defaulted to external file hosting or told users uploads weren't possible via the API.

## Testing

Verified the 3-step flow works end-to-end: uploaded two PDFs (3 MB and 6 MB) as native Notion file blocks using the documented curl commands.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a new **File Uploads** section to the Notion skill documentation (`skills/notion/SKILL.md`) covering the native Notion API file upload flow (`POST /v1/file_uploads`). The section documents a clear 3-step process (create upload object → send binary → attach to block/page), includes curl examples for file blocks and database file properties, and provides practical tips on expiry, reuse, and download URL refresh. This fills a gap where agents previously had no guidance on Notion-native file uploads and would default to external hosting workarounds.

- New section follows existing documentation conventions (consistent `Notion-Version: 2025-09-03` header, `$NOTION_KEY` variable usage, curl example format)
- Previous review feedback (API version inconsistency and misleading `upload_url` field) has been addressed in the follow-up commit
- No code changes; documentation-only PR

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a documentation-only addition with no code changes.
- Score of 5 reflects that this is a documentation-only change adding a well-structured File Uploads section to an existing skill file. The new content follows all existing conventions (consistent API version headers, variable usage, curl example formatting). Previous review feedback has been addressed. No logic, code, or configuration changes are involved.
- No files require special attention.

<sub>Last reviewed commit: b339e1e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->