### PR TITLE
fix(telegram): stale offset causes silent message loss after bot token swap (#18233)

### DIFF
--- a/src/commands/channels.adds-non-default-telegram-account.e2e.test.ts
+++ b/src/commands/channels.adds-non-default-telegram-account.e2e.test.ts
@@ -11,6 +11,10 @@ const authMocks = vi.hoisted(() => ({
   loadAuthProfileStore: vi.fn(),
 }));
 
+const offsetMocks = vi.hoisted(() => ({
+  deleteTelegramUpdateOffset: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock("../config/config.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../config/config.js")>();
   return {
@@ -28,6 +32,14 @@ vi.mock("../agents/auth-profiles.js", async (importOriginal) => {
   };
 });
 
+vi.mock("../telegram/update-offset-store.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../telegram/update-offset-store.js")>();
+  return {
+    ...actual,
+    deleteTelegramUpdateOffset: offsetMocks.deleteTelegramUpdateOffset,
+  };
+});
+
 import {
   channelsAddCommand,
   channelsListCommand,
@@ -42,6 +54,7 @@ describe("channels command", () => {
     configMocks.readConfigFileSnapshot.mockReset();
     configMocks.writeConfigFile.mockClear();
     authMocks.loadAuthProfileStore.mockReset();
+    offsetMocks.deleteTelegramUpdateOffset.mockClear();
     runtime.log.mockClear();
     runtime.error.mockClear();
     runtime.exit.mockClear();
@@ -455,5 +468,71 @@ describe("channels command", () => {
       },
     });
     expect(disconnected.join("\n")).toMatch(/disconnected/i);
+  });
+
+  it("cleans up telegram update offset when deleting a telegram account", async () => {
+    configMocks.readConfigFileSnapshot.mockResolvedValue({
+      ...baseConfigSnapshot,
+      config: {
+        channels: {
+          telegram: { botToken: "123:abc", enabled: true },
+        },
+      },
+    });
+
+    await channelsRemoveCommand(
+      { channel: "telegram", account: "default", delete: true },
+      runtime,
+      {
+        hasFlags: true,
+      },
+    );
+
+    expect(offsetMocks.deleteTelegramUpdateOffset).toHaveBeenCalledWith({ accountId: "default" });
+  });
+
+  it("does not clean up offset when deleting a non-telegram channel", async () => {
+    configMocks.readConfigFileSnapshot.mockResolvedValue({
+      ...baseConfigSnapshot,
+      config: {
+        channels: {
+          discord: {
+            accounts: {
+              default: { token: "d0" },
+            },
+          },
+        },
+      },
+    });
+
+    await channelsRemoveCommand({ channel: "discord", account: "default", delete: true }, runtime, {
+      hasFlags: true,
+    });
+
+    expect(offsetMocks.deleteTelegramUpdateOffset).not.toHaveBeenCalled();
+  });
+
+  it("does not clean up offset when disabling (not deleting) a telegram account", async () => {
+    configMocks.readConfigFileSnapshot.mockResolvedValue({
+      ...baseConfigSnapshot,
+      config: {
+        channels: {
+          telegram: { botToken: "123:abc", enabled: true },
+        },
+      },
+    });
+
+    const prompt = { confirm: vi.fn().mockResolvedValue(true) };
+    const prompterModule = await import("../wizard/clack-prompter.js");
+    const promptSpy = vi
+      .spyOn(prompterModule, "createClackPrompter")
+      .mockReturnValue(prompt as never);
+
+    await channelsRemoveCommand({ channel: "telegram", account: "default" }, runtime, {
+      hasFlags: true,
+    });
+
+    expect(offsetMocks.deleteTelegramUpdateOffset).not.toHaveBeenCalled();
+    promptSpy.mockRestore();
   });
 });

--- a/src/commands/channels/remove.ts
+++ b/src/commands/channels/remove.ts
@@ -7,6 +7,7 @@ import {
 import { type OpenClawConfig, writeConfigFile } from "../../config/config.js";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../../routing/session-key.js";
 import { defaultRuntime, type RuntimeEnv } from "../../runtime.js";
+import { deleteTelegramUpdateOffset } from "../../telegram/update-offset-store.js";
 import { createClackPrompter } from "../../wizard/clack-prompter.js";
 import { type ChatChannel, channelLabel, requireValidConfig, shouldUseWizard } from "./shared.js";
 
@@ -112,6 +113,11 @@ export async function channelsRemoveCommand(
       cfg: next,
       accountId: resolvedAccountId,
     });
+
+    // Clean up Telegram polling offset to prevent stale offset on bot token change (#18233)
+    if (channel === "telegram") {
+      await deleteTelegramUpdateOffset({ accountId: resolvedAccountId });
+    }
   } else {
     if (!plugin.config.setAccountEnabled) {
       runtime.error(`Channel ${channel} does not support disable.`);

--- a/src/telegram/update-offset-store.test.ts
+++ b/src/telegram/update-offset-store.test.ts
@@ -1,0 +1,55 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  deleteTelegramUpdateOffset,
+  readTelegramUpdateOffset,
+  writeTelegramUpdateOffset,
+} from "./update-offset-store.js";
+
+async function withTempStateDir<T>(fn: (dir: string) => Promise<T>) {
+  const previous = process.env.OPENCLAW_STATE_DIR;
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-tg-offset-"));
+  process.env.OPENCLAW_STATE_DIR = dir;
+  try {
+    return await fn(dir);
+  } finally {
+    if (previous === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = previous;
+    }
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+describe("deleteTelegramUpdateOffset", () => {
+  it("removes the offset file so a new bot starts fresh", async () => {
+    await withTempStateDir(async () => {
+      await writeTelegramUpdateOffset({ accountId: "default", updateId: 432_000_000 });
+      expect(await readTelegramUpdateOffset({ accountId: "default" })).toBe(432_000_000);
+
+      await deleteTelegramUpdateOffset({ accountId: "default" });
+      expect(await readTelegramUpdateOffset({ accountId: "default" })).toBeNull();
+    });
+  });
+
+  it("does not throw when the offset file does not exist", async () => {
+    await withTempStateDir(async () => {
+      await expect(deleteTelegramUpdateOffset({ accountId: "nonexistent" })).resolves.not.toThrow();
+    });
+  });
+
+  it("only removes the targeted account offset, leaving others intact", async () => {
+    await withTempStateDir(async () => {
+      await writeTelegramUpdateOffset({ accountId: "default", updateId: 100 });
+      await writeTelegramUpdateOffset({ accountId: "alerts", updateId: 200 });
+
+      await deleteTelegramUpdateOffset({ accountId: "default" });
+
+      expect(await readTelegramUpdateOffset({ accountId: "default" })).toBeNull();
+      expect(await readTelegramUpdateOffset({ accountId: "alerts" })).toBe(200);
+    });
+  });
+});

--- a/src/telegram/update-offset-store.ts
+++ b/src/telegram/update-offset-store.ts
@@ -80,3 +80,19 @@ export async function writeTelegramUpdateOffset(params: {
   await fs.chmod(tmp, 0o600);
   await fs.rename(tmp, filePath);
 }
+
+export async function deleteTelegramUpdateOffset(params: {
+  accountId?: string;
+  env?: NodeJS.ProcessEnv;
+}): Promise<void> {
+  const filePath = resolveTelegramUpdateOffsetPath(params.accountId, params.env);
+  try {
+    await fs.unlink(filePath);
+  } catch (err) {
+    const code = (err as { code?: string }).code;
+    if (code === "ENOENT") {
+      return;
+    }
+    throw err;
+  }
+}


### PR DESCRIPTION
## Summary

- Problem: `channels remove --channel telegram --delete` only wipes config — the polling offset file (`update-offset-{account}.json`) sticks around. When you add a new bot, the gateway polls with the old bot's offset and every inbound message gets skipped with zero errors.
- Why it matters: completely silent message loss, `channels status --probe` says everything's fine.
- What changed: `deleteTelegramUpdateOffset()` added to the offset store; called from the remove command when channel is telegram + `--delete`.
- What did NOT change: disable path (no `--delete`) doesn't touch the offset. Non-telegram channels unaffected.

lobster-biscuit

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations
- [x] Memory / storage

## Linked Issue/PR

- Closes #18233

## User-visible / Behavior Changes

`openclaw channels remove --channel telegram --delete` now also removes the persisted `getUpdates` offset file. Previously you had to manually `rm ~/.openclaw/telegram/update-offset-*.json` to avoid stale offsets after a bot token swap.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Root Cause

`plugin.config.deleteAccount()` only modifies `openclaw.json`. The offset file at `~/.openclaw/telegram/update-offset-{accountId}.json` is managed by `update-offset-store.ts` and has no delete path. Different bots have independent `update_id` sequences, so a stale high offset from bot A causes `getUpdates` on bot B to return empty arrays forever — indistinguishable from "no new messages."

## Changes

- `src/telegram/update-offset-store.ts` — added `deleteTelegramUpdateOffset()`, mirrors the read/write pattern, swallows ENOENT.
- `src/commands/channels/remove.ts` — calls `deleteTelegramUpdateOffset` after `deleteAccount` when channel is `"telegram"`.

## Repro + Verification

### Environment

- OS: macOS (arm64)
- Runtime/container: Node 22+
- Integration/channel: Telegram (polling mode)

### Steps

1. Have a working Telegram bot (bot A) configured
2. `openclaw channels remove --channel telegram --delete`
3. `openclaw channels add --channel telegram --token <NEW_BOT_TOKEN>` (bot B)
4. Restart gateway, send a message to bot B

### Expected

Gateway receives and processes the message.

### Actual (before fix)

Gateway polls with bot A's offset, Telegram returns empty, all messages dropped. `lastInboundAt` stays null.

## Evidence

- [x] Failing test/log before + passing after

3 unit tests in `update-offset-store.test.ts` — write/delete/read cycle, ENOENT tolerance, account isolation. All fail without the new export, pass after.

3 integration tests in `channels.adds-non-default-telegram-account.e2e.test.ts` — telegram delete triggers cleanup, discord delete doesn't, telegram disable doesn't.

## Human Verification (required)

- Verified scenarios: `pnpm build && pnpm check` pass, all 442 telegram tests pass, all 19 channel e2e tests pass.
- Edge cases checked: ENOENT (file already gone), multi-account isolation (deleting one account's offset doesn't touch another's).
- What I did **not** verify: webhook mode (this bug is polling-specific), actual end-to-end with a real Telegram bot token swap.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert this commit. The offset file will persist again (original behavior).
- No config changes to restore.
- Bad symptom: offset file not being cleaned up (back to the original bug).

## Risks and Mitigations

None — the delete is a single `fs.unlink` on a file that gets recreated on next poll cycle anyway.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `deleteTelegramUpdateOffset()` to clean up the persisted polling offset file when removing a Telegram bot with `--delete`. Previously, the offset file (`update-offset-{account}.json`) persisted after `channels remove --delete`, causing silent message loss when adding a new bot (the gateway polled with the old bot's high offset, and Telegram returned empty arrays).

Key changes:
- Added delete function to `update-offset-store.ts` with ENOENT tolerance
- Wired cleanup into `channels/remove.ts` for Telegram-only, delete-only path
- Added 3 unit tests (write/delete/read cycle, ENOENT, account isolation) and 3 integration tests (telegram delete triggers cleanup, discord delete doesn't, telegram disable doesn't)

The fix is scoped correctly—disable path (no `--delete`) and non-Telegram channels are unaffected.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is simple, well-tested, and addresses a real bug. The new `deleteTelegramUpdateOffset()` function mirrors the existing read/write pattern, includes proper ENOENT error handling, and is only called in the correct context (Telegram channel + delete flag). Tests comprehensively cover the expected behavior and edge cases. The change is minimal and scoped to prevent regressions.
- No files require special attention

<sub>Last reviewed commit: 1812eb8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->