### PR TITLE
Slack: expand interaction payload normalization coverage

### DIFF
--- a/src/slack/monitor/events/interactions.ts
+++ b/src/slack/monitor/events/interactions.ts
@@ -580,20 +580,18 @@ export function registerSlackInteractionEvents(params: { ctx: SlackMonitorContex
     },
   );
 
-  const viewClosed = (
-    ctx.app as unknown as {
-      viewClosed?: (
-        matcher: RegExp,
-        handler: (args: { ack: () => Promise<void>; body: unknown }) => Promise<void>,
-      ) => void;
-    }
-  ).viewClosed;
-  if (typeof viewClosed !== "function") {
+  const appWithViewClosed = ctx.app as unknown as {
+    viewClosed?: (
+      matcher: RegExp,
+      handler: (args: { ack: () => Promise<void>; body: unknown }) => Promise<void>,
+    ) => void;
+  };
+  if (typeof appWithViewClosed.viewClosed !== "function") {
     return;
   }
 
   // Handle modal close events so agent workflows can react to cancelled forms.
-  viewClosed(
+  appWithViewClosed.viewClosed(
     new RegExp(`^${OPENCLAW_ACTION_PREFIX}`),
     async ({ ack, body }: { ack: () => Promise<void>; body: unknown }) => {
       await ack();


### PR DESCRIPTION
## Summary
Improves Slack interaction payload normalization coverage so downstream workflows receive complete, consistent data.

- include single-select option labels in `selectedLabels`
- cover mixed select payload variants (`selected_options`, users, channels, conversations)
- cover picker payload variants (`selected_date`, `selected_time`, `selected_date_time`)
- verify modal state normalization across select + picker field types

## Scope
- `src/slack/monitor/events/interactions.ts`
- `src/slack/monitor/events/interactions.test.ts`

## Validation
- `pnpm test src/slack/monitor/events/interactions.test.ts`
- `pnpm check`

## Dependency
Depends on:
- #18180 Slack: improve Block Kit interaction handling (foundation)
- #18234 feat(slack): capture Block Kit view_closed lifecycle events
- #18242 feat(slack): use static_select for large slash arg menus
- #18252 feat(slack): route modal interactions with private metadata
- #18257 feat(slack): support Block Kit blocks in sendMessage
- #18262 feat(slack): support Block Kit blocks in editMessage
- #18268 feat(slack): support blocks in plugin send action
- #18278 feat(slack): support blocks in plugin edit action
- #18284 feat(slack): centralize Block Kit input validation
- #18290 fix(slack): add blocks+media send guardrails
- #18372 test(slack): cover sendMessage Block Kit paths
- #18409 refactor(slack): centralize modal private_metadata utilities

If reviewing before dependencies merge, review tip commit: `2451e726e`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a `this`-binding bug in the `viewClosed` handler registration. The previous code destructured the `viewClosed` method from the cast `ctx.app` object, which detaches it from its receiver and loses the `this` context. The new code stores a reference to the object and calls `viewClosed` as a method, preserving `this` binding — consistent with how `ctx.app.action(...)` and `ctx.app.view(...)` are already called elsewhere in the same function.

- Replaced destructured `viewClosed` function reference with method call on `appWithViewClosed` object
- No behavioral change beyond preserving correct `this` binding at runtime
- Aligns the `viewClosed` registration pattern with the existing `action` and `view` registration patterns

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it fixes a real `this`-binding issue with a minimal, well-scoped change.
- The change is a 2-line refactor that fixes a method binding bug. It follows an existing pattern already used for `action()` and `view()` in the same function. No new logic, no new dependencies, no behavioral changes beyond the binding fix.
- No files require special attention.

<sub>Last reviewed commit: de5e226</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->