### PR TITLE
Slack: validate runtime blocks in send and edit paths

### DIFF
--- a/src/slack/monitor/events/interactions.ts
+++ b/src/slack/monitor/events/interactions.ts
@@ -580,20 +580,18 @@ export function registerSlackInteractionEvents(params: { ctx: SlackMonitorContex
     },
   );
 
-  const viewClosed = (
-    ctx.app as unknown as {
-      viewClosed?: (
-        matcher: RegExp,
-        handler: (args: { ack: () => Promise<void>; body: unknown }) => Promise<void>,
-      ) => void;
-    }
-  ).viewClosed;
-  if (typeof viewClosed !== "function") {
+  const appWithViewClosed = ctx.app as unknown as {
+    viewClosed?: (
+      matcher: RegExp,
+      handler: (args: { ack: () => Promise<void>; body: unknown }) => Promise<void>,
+    ) => void;
+  };
+  if (typeof appWithViewClosed.viewClosed !== "function") {
     return;
   }
 
   // Handle modal close events so agent workflows can react to cancelled forms.
-  viewClosed(
+  appWithViewClosed.viewClosed(
     new RegExp(`^${OPENCLAW_ACTION_PREFIX}`),
     async ({ ack, body }: { ack: () => Promise<void>; body: unknown }) => {
       await ack();


### PR DESCRIPTION
## Summary
Extends Slack Block Kit validation to runtime send/edit paths so all call paths enforce the same payload rules.

- export shared `validateSlackBlocksArray` helper
- validate runtime `sendMessageSlack(..., { blocks })` payloads
- validate runtime `editSlackMessage(..., { blocks })` payloads
- add regression tests for malformed/empty/oversized runtime block arrays

## Scope
- `src/slack/blocks-input.ts`
- `src/slack/send.ts`
- `src/slack/actions.ts`
- `src/slack/send.blocks.test.ts`
- `src/slack/actions.blocks.test.ts`

## Validation
- `pnpm test src/slack/send.blocks.test.ts src/slack/actions.blocks.test.ts`
- `pnpm check`

## Dependency
Depends on:
- #18180 Slack: improve Block Kit interaction handling (foundation)
- #18234 feat(slack): capture Block Kit view_closed lifecycle events
- #18242 feat(slack): use static_select for large slash arg menus
- #18252 feat(slack): route modal interactions with private metadata
- #18257 feat(slack): support Block Kit blocks in sendMessage
- #18262 feat(slack): support Block Kit blocks in editMessage
- #18268 feat(slack): support blocks in plugin send action
- #18278 feat(slack): support blocks in plugin edit action
- #18284 feat(slack): centralize Block Kit input validation
- #18290 fix(slack): add blocks+media send guardrails
- #18372 test(slack): cover sendMessage Block Kit paths
- #18409 refactor(slack): centralize modal private_metadata utilities
- #18413 Slack: expand interaction payload normalization coverage

If reviewing before dependencies merge, review tip commit: `e88b0f53f`.
