### PR TITLE
Slack: dedupe normalized interaction selections

### DIFF
--- a/src/slack/monitor/events/interactions.ts
+++ b/src/slack/monitor/events/interactions.ts
@@ -580,20 +580,18 @@ export function registerSlackInteractionEvents(params: { ctx: SlackMonitorContex
     },
   );
 
-  const viewClosed = (
-    ctx.app as unknown as {
-      viewClosed?: (
-        matcher: RegExp,
-        handler: (args: { ack: () => Promise<void>; body: unknown }) => Promise<void>,
-      ) => void;
-    }
-  ).viewClosed;
-  if (typeof viewClosed !== "function") {
+  const appWithViewClosed = ctx.app as unknown as {
+    viewClosed?: (
+      matcher: RegExp,
+      handler: (args: { ack: () => Promise<void>; body: unknown }) => Promise<void>,
+    ) => void;
+  };
+  if (typeof appWithViewClosed.viewClosed !== "function") {
     return;
   }
 
   // Handle modal close events so agent workflows can react to cancelled forms.
-  viewClosed(
+  appWithViewClosed.viewClosed(
     new RegExp(`^${OPENCLAW_ACTION_PREFIX}`),
     async ({ ack, body }: { ack: () => Promise<void>; body: unknown }) => {
       await ack();


### PR DESCRIPTION
## Summary
Hardens normalized Slack interaction payloads by deduplicating selected values/labels while preserving first-seen order.

- dedupe normalized `selectedValues`
- dedupe normalized `selectedLabels`
- add regression coverage for duplicate mixed-select payload inputs

## Scope
- `src/slack/monitor/events/interactions.ts`
- `src/slack/monitor/events/interactions.test.ts`

## Validation
- `pnpm test src/slack/monitor/events/interactions.test.ts`
- `pnpm check`

## Dependency
Depends on:
- #18180 Slack: improve Block Kit interaction handling (foundation)
- #18234 feat(slack): capture Block Kit view_closed lifecycle events
- #18242 feat(slack): use static_select for large slash arg menus
- #18252 feat(slack): route modal interactions with private metadata
- #18257 feat(slack): support Block Kit blocks in sendMessage
- #18262 feat(slack): support Block Kit blocks in editMessage
- #18268 feat(slack): support blocks in plugin send action
- #18278 feat(slack): support blocks in plugin edit action
- #18284 feat(slack): centralize Block Kit input validation
- #18290 fix(slack): add blocks+media send guardrails
- #18372 test(slack): cover sendMessage Block Kit paths
- #18409 refactor(slack): centralize modal private_metadata utilities
- #18413 Slack: expand interaction payload normalization coverage
- #18416 Slack: validate runtime blocks in send and edit paths

If reviewing before dependencies merge, review tip commit: `215dc56b9`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds deduplication to Slack Block Kit interaction payload normalization, preventing duplicate values/labels when Slack sends redundant selections across singular and plural fields (e.g., `selected_user` + `selected_users`). Uses first-seen order preservation via Set-based deduplication with trimming.

- Introduced `uniqueNonEmptyStrings` helper with defensive type guards
- Applied deduplication to `selectedValues`, `selectedLabels`, `selectedUsers`, `selectedChannels`, and `selectedConversations`
- Shared across both block actions and modal submissions via `summarizeAction`
- Added regression test coverage with mixed duplicate inputs

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The implementation is clean, well-tested, and defensive. The deduplication logic correctly preserves first-seen order, handles edge cases (empty strings, non-strings), and applies consistently across all interaction types. Test coverage validates the exact scenario described (duplicates across singular/plural fields). No breaking changes or side effects.
- No files require special attention

<sub>Last reviewed commit: 7446c0a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->