### PR TITLE
fix: make tool exit code handling less aggressive (fixes #18283)

### DIFF
--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -507,8 +507,9 @@ export async function runExecProcess(opts: {
     .wait()
     .then((exit): ExecProcessOutcome => {
       const durationMs = Date.now() - startedAt;
-      const status: "completed" | "failed" =
-        exit.exitCode === 0 && exit.reason === "exit" ? "completed" : "failed";
+      const isNormalExit = exit.reason === "exit";
+      const status: "completed" | "failed" = isNormalExit ? "completed" : "failed";
+
       markExited(session, exit.exitCode, exit.exitSignal, status);
       maybeNotifyOnExit(session, status);
       if (!session.child && session.stdin) {
@@ -516,12 +517,14 @@ export async function runExecProcess(opts: {
       }
       const aggregated = session.aggregated.trim();
       if (status === "completed") {
+        const exitCode = exit.exitCode ?? 0;
+        const exitMsg = exitCode !== 0 ? `\n\n(Command exited with code ${exitCode})` : "";
         return {
           status: "completed",
-          exitCode: exit.exitCode ?? 0,
+          exitCode,
           exitSignal: exit.exitSignal,
           durationMs,
-          aggregated,
+          aggregated: aggregated + exitMsg,
           timedOut: false,
         };
       }
@@ -532,9 +535,7 @@ export async function runExecProcess(opts: {
             ? "Command timed out waiting for output"
             : exit.exitSignal != null
               ? `Command aborted by signal ${exit.exitSignal}`
-              : exit.exitCode == null
-                ? "Command aborted before exit code was captured"
-                : `Command exited with code ${exit.exitCode}`;
+              : "Command aborted before exit code was captured";
       return {
         status: "failed",
         exitCode: exit.exitCode,


### PR DESCRIPTION
This PR addresses issue #18283 by updating the tool execution runtime to distinguish between normal process exits and hard infrastructure failures.

- Normal process exits (reason: 'exit') are now treated as 'completed' results, even with non-zero exit codes.
- This prevents standard behaviors (like 'grep' returning exit code 1 when no match is found) from triggering 'Tool Failure' warnings in the UI.
- The exit code is still appended to the output text if non-zero, ensuring the assistant is aware of the command outcome.
- Timeouts and signal-based terminations are still correctly identified as failures.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updated tool execution runtime to treat normal process exits (`reason: 'exit'`) as completed, regardless of exit code. Non-zero exit codes are still captured and appended to output text for the assistant's awareness. Timeouts and signal-based terminations remain correctly identified as failures.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change correctly distinguishes between normal process exits and infrastructure failures. The logic is sound and well-implemented - normal exits are now treated as completed regardless of exit code (addressing the grep exit code 1 issue), while still preserving the exit code in the output. Timeouts and signal-based terminations are still properly identified as failures.
- No files require special attention

<sub>Last reviewed commit: 3645a9b</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->