### PR TITLE
Slack: enrich block action context payloads

### DIFF
--- a/src/slack/monitor/events/interactions.ts
+++ b/src/slack/monitor/events/interactions.ts
@@ -580,20 +580,18 @@ export function registerSlackInteractionEvents(params: { ctx: SlackMonitorContex
     },
   );
 
-  const viewClosed = (
-    ctx.app as unknown as {
-      viewClosed?: (
-        matcher: RegExp,
-        handler: (args: { ack: () => Promise<void>; body: unknown }) => Promise<void>,
-      ) => void;
-    }
-  ).viewClosed;
-  if (typeof viewClosed !== "function") {
+  const appWithViewClosed = ctx.app as unknown as {
+    viewClosed?: (
+      matcher: RegExp,
+      handler: (args: { ack: () => Promise<void>; body: unknown }) => Promise<void>,
+    ) => void;
+  };
+  if (typeof appWithViewClosed.viewClosed !== "function") {
     return;
   }
 
   // Handle modal close events so agent workflows can react to cancelled forms.
-  viewClosed(
+  appWithViewClosed.viewClosed(
     new RegExp(`^${OPENCLAW_ACTION_PREFIX}`),
     async ({ ack, body }: { ack: () => Promise<void>; body: unknown }) => {
       await ack();


### PR DESCRIPTION
## Summary
Enriches Slack `block_action` interaction events with additional context fields and safer channel/message fallbacks.

- include `teamId`, `triggerId`, `responseUrl`, and `threadTs` in block action payloads
- fall back to `container.channel_id`/`container.message_ts` when `channel`/`message` are absent
- add regression coverage for container-based fallback payload resolution

## Scope
- `src/slack/monitor/events/interactions.ts`
- `src/slack/monitor/events/interactions.test.ts`

## Validation
- `pnpm test src/slack/monitor/events/interactions.test.ts`
- `pnpm check`

## Dependency
Depends on:
- #18180 Slack: improve Block Kit interaction handling (foundation)
- #18234 feat(slack): capture Block Kit view_closed lifecycle events
- #18242 feat(slack): use static_select for large slash arg menus
- #18252 feat(slack): route modal interactions with private metadata
- #18257 feat(slack): support Block Kit blocks in sendMessage
- #18262 feat(slack): support Block Kit blocks in editMessage
- #18268 feat(slack): support blocks in plugin send action
- #18278 feat(slack): support blocks in plugin edit action
- #18284 feat(slack): centralize Block Kit input validation
- #18290 fix(slack): add blocks+media send guardrails
- #18372 test(slack): cover sendMessage Block Kit paths
- #18409 refactor(slack): centralize modal private_metadata utilities
- #18413 Slack: expand interaction payload normalization coverage
- #18416 Slack: validate runtime blocks in send and edit paths
- #18423 Slack: dedupe normalized interaction selections

If reviewing before dependencies merge, review tip commit: `a0d55470b`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Refactors the `viewClosed` method call in `registerSlackInteractionEvents` to preserve `this` binding. The previous code extracted `viewClosed` from the type-cast `ctx.app` object into a standalone variable, then called it directly — which would lose the method's `this` context if the underlying implementation depends on it. The new code keeps a reference to the whole cast object (`appWithViewClosed`) and invokes `appWithViewClosed.viewClosed(...)`, preserving correct method dispatch.

- **Fix**: `viewClosed` is now called as a method on the object rather than as a detached function, preventing potential `this`-binding bugs
- **No functional logic changes**: the type guard (`typeof ... !== "function"`) and handler registration remain identical
- **Note**: The PR title references "enrich block action context payloads" but the diff at this commit range only contains the `viewClosed` binding fix. The enrichment changes may be in dependent PRs not yet merged into the base.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a small, well-scoped refactoring that fixes a potential this-binding issue with no behavioral changes.
- The change is minimal (8 insertions, 10 deletions), purely mechanical, and correctly preserves the method's this binding. The type guard and handler logic are unchanged. No new code paths, no new dependencies, no risk of regression.
- No files require special attention.

<sub>Last reviewed commit: 22baace</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->