### PR TITLE
feat(discord): add broadcast group support for multi-agent fan-out

### DIFF
--- a/src/agents/tools/discord-actions.ts
+++ b/src/agents/tools/discord-actions.ts
@@ -65,7 +65,7 @@ export async function handleDiscordAction(
   const isActionEnabled = createActionGate(account.config.actions);
 
   if (messagingActions.has(action)) {
-    return await handleDiscordMessagingAction(action, params, isActionEnabled);
+    return await handleDiscordMessagingAction(action, params, isActionEnabled, cfg);
   }
   if (guildActions.has(action)) {
     return await handleDiscordGuildAction(action, params, isActionEnabled);

--- a/src/discord/monitor/broadcast.ts
+++ b/src/discord/monitor/broadcast.ts
@@ -1,12 +1,12 @@
 import type { HistoryEntry } from "../../auto-reply/reply/history.js";
 import type { DiscordMessagePreflightContext } from "./message-handler.preflight.js";
+import { getChildLogger } from "../../logging.js";
 import { buildAgentSessionKey } from "../../routing/resolve-route.js";
 import {
   buildAgentMainSessionKey,
   DEFAULT_MAIN_KEY,
   normalizeAgentId,
 } from "../../routing/session-key.js";
-import { getChildLogger } from "../../logging.js";
 import { formatError } from "../../web/session.js";
 
 const discordBroadcastLog = getChildLogger({ module: "discord-auto-reply" });

--- a/src/discord/monitor/broadcast.ts
+++ b/src/discord/monitor/broadcast.ts
@@ -1,0 +1,98 @@
+import type { HistoryEntry } from "../../auto-reply/reply/history.js";
+import type { DiscordMessagePreflightContext } from "./message-handler.preflight.js";
+import { buildAgentSessionKey } from "../../routing/resolve-route.js";
+import {
+  buildAgentMainSessionKey,
+  DEFAULT_MAIN_KEY,
+  normalizeAgentId,
+} from "../../routing/session-key.js";
+import { getChildLogger } from "../../logging.js";
+import { formatError } from "../../web/session.js";
+
+const discordBroadcastLog = getChildLogger({ module: "discord-auto-reply" });
+
+export async function maybeBroadcastDiscordMessage(params: {
+  ctx: DiscordMessagePreflightContext;
+  processMessage: (
+    ctx: DiscordMessagePreflightContext,
+    opts?: {
+      guildHistory?: HistoryEntry[];
+      suppressGuildHistoryClear?: boolean;
+    },
+  ) => Promise<void>;
+}) {
+  if (!params.ctx.isGuildMessage) {
+    return false;
+  }
+
+  const broadcastAgents = params.ctx.cfg.broadcast?.[params.ctx.messageChannelId];
+  if (!broadcastAgents || !Array.isArray(broadcastAgents)) {
+    return false;
+  }
+  if (broadcastAgents.length === 0) {
+    return false;
+  }
+
+  const strategy = params.ctx.cfg.broadcast?.strategy || "parallel";
+  discordBroadcastLog.info(
+    `Broadcasting message to ${broadcastAgents.length} agents (${strategy})`,
+  );
+
+  const agentIds = params.ctx.cfg.agents?.list?.map((agent) => normalizeAgentId(agent.id));
+  const hasKnownAgents = (agentIds?.length ?? 0) > 0;
+  const guildHistorySnapshot = params.ctx.guildHistories.get(params.ctx.messageChannelId) ?? [];
+
+  const processForAgent = async (agentId: string): Promise<void> => {
+    const normalizedAgentId = normalizeAgentId(agentId);
+    if (hasKnownAgents && !agentIds?.includes(normalizedAgentId)) {
+      discordBroadcastLog.warn(`Broadcast agent ${agentId} not found in agents.list; skipping`);
+      return;
+    }
+
+    const agentRoute = {
+      ...params.ctx.route,
+      agentId: normalizedAgentId,
+      sessionKey: buildAgentSessionKey({
+        agentId: normalizedAgentId,
+        channel: "discord",
+        accountId: params.ctx.route.accountId,
+        peer: {
+          kind: "channel",
+          id: params.ctx.messageChannelId,
+        },
+        dmScope: params.ctx.cfg.session?.dmScope,
+        identityLinks: params.ctx.cfg.session?.identityLinks,
+      }),
+      mainSessionKey: buildAgentMainSessionKey({
+        agentId: normalizedAgentId,
+        mainKey: DEFAULT_MAIN_KEY,
+      }),
+    };
+
+    const agentCtx: DiscordMessagePreflightContext = {
+      ...params.ctx,
+      route: agentRoute,
+      baseSessionKey: agentRoute.sessionKey,
+    };
+
+    try {
+      await params.processMessage(agentCtx, {
+        guildHistory: guildHistorySnapshot,
+        suppressGuildHistoryClear: true,
+      });
+    } catch (err) {
+      discordBroadcastLog.error(`Broadcast agent ${agentId} failed: ${formatError(err)}`);
+    }
+  };
+
+  if (strategy === "sequential") {
+    for (const agentId of broadcastAgents) {
+      await processForAgent(agentId);
+    }
+  } else {
+    await Promise.allSettled(broadcastAgents.map(processForAgent));
+  }
+
+  params.ctx.guildHistories.set(params.ctx.messageChannelId, []);
+  return true;
+}

--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -561,7 +561,7 @@ export async function preflightDiscordMessage(
   logDebug(
     `[discord-preflight] shouldRequireMention=${shouldRequireMention} mentionGate.shouldSkip=${mentionGate.shouldSkip} wasMentioned=${wasMentioned}`,
   );
-  if (isGuildMessage && shouldRequireMention) {
+  if (isGuildMessage && shouldRequireMention && !ownWebhookUsername) {
     if (botId && mentionGate.shouldSkip) {
       logDebug(`[discord-preflight] drop: no-mention`);
       logVerbose(`discord: drop guild message (mention required, botId=${botId})`);
@@ -582,7 +582,7 @@ export async function preflightDiscordMessage(
     }
   }
 
-  if (isGuildMessage && hasAccessRestrictions && !memberAllowed) {
+  if (isGuildMessage && hasAccessRestrictions && !memberAllowed && !ownWebhookUsername) {
     logDebug(`[discord-preflight] drop: member not allowed`);
     logVerbose(`Blocked discord guild sender ${sender.id} (not in users/roles allowlist)`);
     return null;

--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -54,6 +54,7 @@ import {
   resolveDiscordMessageText,
 } from "./message-utils.js";
 import { resolveDiscordSenderIdentity, resolveDiscordWebhookId } from "./sender-identity.js";
+import { isOwnWebhookId } from "../webhook-cache.js";
 import { resolveDiscordSystemEvent } from "./system-events.js";
 import { resolveDiscordThreadChannel, resolveDiscordThreadParentInfo } from "./threading.js";
 
@@ -88,6 +89,17 @@ export async function preflightDiscordMessage(
 
   const pluralkitConfig = params.discordConfig?.pluralkit;
   const webhookId = resolveDiscordWebhookId(message);
+
+  // Detect messages from our own broadcast webhooks — these should be processed
+  // by OTHER agents (not the sender) to enable agent-to-agent communication.
+  let ownWebhookUsername: string | undefined;
+  if (webhookId && isOwnWebhookId(webhookId)) {
+    if (!allowBots) {
+      return null; // own webhook but bots not allowed — skip
+    }
+    ownWebhookUsername = author.username ?? undefined;
+    logVerbose(`discord: own-webhook message from "${ownWebhookUsername}" (webhook ${webhookId})`);
+  }
   const shouldCheckPluralKit = Boolean(pluralkitConfig?.enabled) && !webhookId;
   let pluralkitInfo: Awaited<ReturnType<typeof fetchPluralKitMessageInfo>> = null;
   if (shouldCheckPluralKit) {
@@ -651,5 +663,6 @@ export async function preflightDiscordMessage(
     effectiveWasMentioned,
     canDetectMention,
     historyEntry,
+    ownWebhookUsername,
   };
 }

--- a/src/discord/monitor/message-handler.preflight.types.ts
+++ b/src/discord/monitor/message-handler.preflight.types.ts
@@ -79,6 +79,9 @@ export type DiscordMessagePreflightContext = {
   canDetectMention: boolean;
 
   historyEntry?: HistoryEntry;
+
+  /** If this message was sent by one of our own broadcast webhooks, the display name used (e.g. "Pronghorn 🦌"). */
+  ownWebhookUsername?: string;
 };
 
 export type DiscordMessagePreflightParams = {

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -423,7 +423,7 @@ export async function processDiscordMessage(
   });
   const shouldIncludeChannelHistory =
     !isDirectMessage && !(isGuildMessage && channelConfig?.autoThread && !threadChannel);
-  const guildHistoryEntries = opts?.guildHistory ?? (guildHistories.get(messageChannelId) ?? []);
+  const guildHistoryEntries = opts?.guildHistory ?? guildHistories.get(messageChannelId) ?? [];
   if (shouldIncludeChannelHistory) {
     combinedBody = buildPendingHistoryContextFromMap({
       historyMap: new Map([[messageChannelId, guildHistoryEntries]]),

--- a/src/discord/monitor/message-handler.process.webhook.test.ts
+++ b/src/discord/monitor/message-handler.process.webhook.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createBaseDiscordMessageContext } from "./message-handler.test-harness.js";
+
+const reactMessageDiscord = vi.fn(async () => {});
+const removeReactionDiscord = vi.fn(async () => {});
+const deliverDiscordReply = vi.fn(async () => {});
+const getOrCreateWebhook = vi.fn(async () => null);
+const sendWebhookMessage = vi.fn(async () => {});
+
+vi.mock("../send.js", () => ({
+  reactMessageDiscord: (...args: unknown[]) => reactMessageDiscord(...args),
+  removeReactionDiscord: (...args: unknown[]) => removeReactionDiscord(...args),
+}));
+
+vi.mock("./reply-delivery.js", () => ({
+  deliverDiscordReply: (...args: unknown[]) => deliverDiscordReply(...args),
+}));
+
+vi.mock("../webhook-cache.js", () => ({
+  getOrCreateWebhook: (...args: unknown[]) => getOrCreateWebhook(...args),
+}));
+
+vi.mock("../send.webhook.js", () => ({
+  sendWebhookMessage: (...args: unknown[]) => sendWebhookMessage(...args),
+}));
+
+vi.mock("../../auto-reply/reply/dispatch-from-config.js", () => ({
+  dispatchReplyFromConfig: vi.fn(async ({ dispatcher }) => {
+    dispatcher.sendFinalReply({ text: "hello" });
+    return {
+      queuedFinal: true,
+      counts: { final: 1, tool: 0, block: 0 },
+    };
+  }),
+}));
+
+const { processDiscordMessage } = await import("./message-handler.process.js");
+
+beforeEach(() => {
+  reactMessageDiscord.mockClear();
+  removeReactionDiscord.mockClear();
+  deliverDiscordReply.mockClear();
+  getOrCreateWebhook.mockClear();
+  sendWebhookMessage.mockClear();
+});
+
+describe("processDiscordMessage webhook delivery", () => {
+  it("uses webhook delivery for broadcast agents and skips responsePrefix", async () => {
+    const ctx = await createBaseDiscordMessageContext();
+    ctx.cfg.messages = { ...ctx.cfg.messages, responsePrefix: "PFX" };
+    getOrCreateWebhook.mockResolvedValueOnce({ id: "wh_1", token: "tok_1" });
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await processDiscordMessage(ctx as any, {
+      agentIdentity: {
+        name: "Coder",
+        emoji: "💻",
+        avatar: "https://example.com/avatar.png",
+      },
+    });
+
+    expect(getOrCreateWebhook).toHaveBeenCalledWith("c1", {});
+    expect(sendWebhookMessage).toHaveBeenCalledTimes(1);
+    expect(sendWebhookMessage).toHaveBeenCalledWith(
+      "wh_1",
+      "tok_1",
+      "hello",
+      expect.objectContaining({
+        username: "Coder 💻",
+        avatarUrl: "https://example.com/avatar.png",
+      }),
+    );
+    expect(deliverDiscordReply).not.toHaveBeenCalled();
+  });
+
+  it("falls back to default delivery (with responsePrefix) when webhook creation fails", async () => {
+    const ctx = await createBaseDiscordMessageContext();
+    ctx.cfg.messages = { ...ctx.cfg.messages, responsePrefix: "PFX" };
+    getOrCreateWebhook.mockResolvedValueOnce(null);
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await processDiscordMessage(ctx as any, {
+      agentIdentity: {
+        name: "Coder",
+      },
+    });
+
+    expect(sendWebhookMessage).not.toHaveBeenCalled();
+    expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
+    const call = deliverDiscordReply.mock.calls[0]?.[0] as { replies?: Array<{ text?: string }> };
+    expect(call.replies?.[0]?.text ?? "").toMatch(/^PFX /);
+  });
+});

--- a/src/discord/monitor/message-handler.ts
+++ b/src/discord/monitor/message-handler.ts
@@ -5,6 +5,7 @@ import {
   resolveInboundDebounceMs,
 } from "../../auto-reply/inbound-debounce.js";
 import { danger } from "../../globals.js";
+import { maybeBroadcastDiscordMessage } from "./broadcast.js";
 import type { DiscordMessageEvent, DiscordMessageHandler } from "./listeners.js";
 import { preflightDiscordMessage } from "./message-handler.preflight.js";
 import type { DiscordMessagePreflightParams } from "./message-handler.preflight.types.js";
@@ -70,6 +71,13 @@ export function createDiscordMessageHandler(
         if (!ctx) {
           return;
         }
+        const didBroadcast = await maybeBroadcastDiscordMessage({
+          ctx,
+          processMessage: processDiscordMessage,
+        });
+        if (didBroadcast) {
+          return;
+        }
         await processDiscordMessage(ctx);
         return;
       }
@@ -113,6 +121,13 @@ export function createDiscordMessageHandler(
           ctxBatch.MessageSidFirst = ids[0];
           ctxBatch.MessageSidLast = ids[ids.length - 1];
         }
+      }
+      const didBroadcast = await maybeBroadcastDiscordMessage({
+        ctx,
+        processMessage: processDiscordMessage,
+      });
+      if (didBroadcast) {
+        return;
       }
       await processDiscordMessage(ctx);
     },

--- a/src/discord/monitor/sender-identity.ts
+++ b/src/discord/monitor/sender-identity.ts
@@ -19,10 +19,16 @@ export type DiscordSenderIdentity = {
 type DiscordWebhookMessageLike = {
   webhookId?: string | null;
   webhook_id?: string | null;
+  rawData?: { webhook_id?: string | null };
+  raw?: { webhook_id?: string | null };
 };
 
 export function resolveDiscordWebhookId(message: DiscordWebhookMessageLike): string | null {
-  const candidate = message.webhookId ?? message.webhook_id;
+  const candidate =
+    message.webhookId ??
+    message.webhook_id ??
+    message.rawData?.webhook_id ??
+    message.raw?.webhook_id;
   return typeof candidate === "string" && candidate.trim() ? candidate.trim() : null;
 }
 

--- a/src/discord/send.outbound.ts
+++ b/src/discord/send.outbound.ts
@@ -35,6 +35,8 @@ import {
   type DiscordSendEmbeds,
 } from "./send.shared.js";
 import type { DiscordSendResult } from "./send.types.js";
+import { sendWebhookMessage } from "./send.webhook.js";
+import { getOrCreateWebhook } from "./webhook-cache.js";
 import {
   ensureOggOpus,
   getVoiceMessageMetadata,
@@ -53,6 +55,8 @@ type DiscordSendOpts = {
   components?: DiscordSendComponents;
   embeds?: DiscordSendEmbeds;
   silent?: boolean;
+  /** When set, send via webhook with this display identity instead of regular bot message. */
+  webhookIdentity?: { name: string; emoji?: string; avatar?: string };
 };
 
 /** Discord thread names are capped at 100 characters. */
@@ -214,6 +218,43 @@ export async function sendMessageDiscord(
       messageId: messageId ? String(messageId) : "unknown",
       channelId: String(resultChannelId ?? channelId),
     };
+  }
+
+  // Webhook delivery path: when webhookIdentity is set, send via webhook for
+  // distinct agent display name and to enable agent-to-agent message triggering.
+  if (opts.webhookIdentity) {
+    const webhookAuth = await getOrCreateWebhook(channelId, rest);
+    if (webhookAuth) {
+      const displayName = [opts.webhookIdentity.name, opts.webhookIdentity.emoji]
+        .filter(Boolean)
+        .join(" ")
+        .trim() || "OpenClaw Agent";
+      try {
+        await sendWebhookMessage(webhookAuth.id, webhookAuth.token, textWithTables, {
+          username: displayName,
+          avatarUrl: opts.webhookIdentity.avatar,
+          rest,
+          mediaUrl: opts.mediaUrl,
+          mediaLocalRoots: opts.mediaLocalRoots,
+          maxLinesPerMessage: accountInfo.config.maxLinesPerMessage,
+          chunkMode,
+        });
+      } catch (err) {
+        throw await buildDiscordSendError(err, {
+          channelId,
+          rest,
+          token,
+          hasMedia: Boolean(opts.mediaUrl),
+        });
+      }
+      recordChannelActivity({
+        channel: "discord",
+        accountId: accountInfo.accountId,
+        direction: "outbound",
+      });
+      return { messageId: "webhook", channelId };
+    }
+    // Fall through to regular send if webhook creation failed.
   }
 
   let result: { id: string; channel_id: string } | { id: string | null; channel_id: string };

--- a/src/discord/send.webhook.ts
+++ b/src/discord/send.webhook.ts
@@ -1,0 +1,127 @@
+import { serializePayload, type MessagePayloadFile, type RequestClient } from "@buape/carbon";
+import type { ChunkMode } from "../auto-reply/chunk.js";
+import { loadWebMedia } from "../web/media.js";
+import { chunkDiscordTextWithMode } from "./chunk.js";
+import { buildDiscordMessagePayload, stripUndefinedFields } from "./send.shared.js";
+
+const DISCORD_WEBHOOK_TEXT_LIMIT = 2000;
+
+type SendWebhookMessageOpts = {
+  username?: string;
+  avatarUrl?: string;
+  rest: RequestClient;
+  mediaUrl?: string;
+  mediaLocalRoots?: readonly string[];
+  maxLinesPerMessage?: number;
+  chunkMode?: ChunkMode;
+};
+
+function webhookExecuteUrl(webhookId: string, webhookToken: string) {
+  return `https://discord.com/api/v10/webhooks/${encodeURIComponent(webhookId)}/${encodeURIComponent(webhookToken)}?wait=true`;
+}
+
+function chunkWebhookText(
+  text: string,
+  opts: Pick<SendWebhookMessageOpts, "maxLinesPerMessage" | "chunkMode">,
+): string[] {
+  const chunks = chunkDiscordTextWithMode(text, {
+    maxChars: DISCORD_WEBHOOK_TEXT_LIMIT,
+    maxLines: opts.maxLinesPerMessage,
+    chunkMode: opts.chunkMode,
+  });
+  if (!chunks.length && text) {
+    chunks.push(text);
+  }
+  return chunks;
+}
+
+function buildWebhookMeta(opts: Pick<SendWebhookMessageOpts, "username" | "avatarUrl">) {
+  return stripUndefinedFields({
+    username: opts.username?.trim() || undefined,
+    avatar_url: opts.avatarUrl?.trim() || undefined,
+  });
+}
+
+async function executeWebhook(
+  webhookId: string,
+  webhookToken: string,
+  body: Record<string, unknown>,
+  rest: RequestClient,
+) {
+  await rest.post(webhookExecuteUrl(webhookId, webhookToken), { body });
+}
+
+async function buildWebhookFile(
+  mediaUrl: string,
+  mediaLocalRoots?: readonly string[],
+): Promise<MessagePayloadFile> {
+  const media = await loadWebMedia(mediaUrl, { localRoots: mediaLocalRoots });
+  let data: Blob;
+  if (media.buffer instanceof Blob) {
+    data = media.buffer;
+  } else {
+    const arrayBuffer = new ArrayBuffer(media.buffer.byteLength);
+    new Uint8Array(arrayBuffer).set(media.buffer);
+    data = new Blob([arrayBuffer]);
+  }
+  return {
+    data,
+    name: media.fileName ?? "upload",
+  };
+}
+
+export async function sendWebhookMessage(
+  webhookId: string,
+  webhookToken: string,
+  text: string,
+  opts: SendWebhookMessageOpts,
+) {
+  const meta = buildWebhookMeta(opts);
+  const chunks = text ? chunkWebhookText(text, opts) : [];
+  const trimmedChunks = chunks.map((chunk) => chunk.trim()).filter(Boolean);
+
+  if (opts.mediaUrl) {
+    const file = await buildWebhookFile(opts.mediaUrl, opts.mediaLocalRoots);
+    const caption = trimmedChunks[0] ?? "";
+    const payload = buildDiscordMessagePayload({
+      text: caption,
+      files: [file],
+    });
+    await executeWebhook(
+      webhookId,
+      webhookToken,
+      stripUndefinedFields({
+        ...serializePayload(payload),
+        ...meta,
+      }),
+      opts.rest,
+    );
+    for (const chunk of trimmedChunks.slice(1)) {
+      await executeWebhook(
+        webhookId,
+        webhookToken,
+        stripUndefinedFields({
+          content: chunk,
+          ...meta,
+        }),
+        opts.rest,
+      );
+    }
+    return;
+  }
+
+  if (trimmedChunks.length === 0) {
+    return;
+  }
+  for (const chunk of trimmedChunks) {
+    await executeWebhook(
+      webhookId,
+      webhookToken,
+      stripUndefinedFields({
+        content: chunk,
+        ...meta,
+      }),
+      opts.rest,
+    );
+  }
+}

--- a/src/discord/send.webhook.ts
+++ b/src/discord/send.webhook.ts
@@ -17,7 +17,7 @@ type SendWebhookMessageOpts = {
 };
 
 function webhookExecuteUrl(webhookId: string, webhookToken: string) {
-  return `https://discord.com/api/v10/webhooks/${encodeURIComponent(webhookId)}/${encodeURIComponent(webhookToken)}?wait=true`;
+  return `/webhooks/${encodeURIComponent(webhookId)}/${encodeURIComponent(webhookToken)}?wait=true`;
 }
 
 function chunkWebhookText(

--- a/src/discord/webhook-cache.ts
+++ b/src/discord/webhook-cache.ts
@@ -1,0 +1,47 @@
+import type { RequestClient } from "@buape/carbon";
+import { Routes } from "discord-api-types/v10";
+
+export type DiscordWebhookAuth = {
+  id: string;
+  token: string;
+};
+
+const channelWebhookCache = new Map<string, DiscordWebhookAuth>();
+
+function normalizeWebhookAuth(raw: {
+  id?: string;
+  token?: string | null;
+}): DiscordWebhookAuth | null {
+  const id = raw.id?.trim();
+  const token = raw.token?.trim();
+  if (!id || !token) {
+    return null;
+  }
+  return { id, token };
+}
+
+export async function getOrCreateWebhook(
+  channelId: string,
+  rest: RequestClient,
+): Promise<DiscordWebhookAuth | null> {
+  const cached = channelWebhookCache.get(channelId);
+  if (cached) {
+    return cached;
+  }
+
+  try {
+    const created = (await rest.post(Routes.channelWebhooks(channelId), {
+      body: {
+        name: "OpenClaw Agent",
+      },
+    })) as { id?: string; token?: string | null };
+    const normalized = normalizeWebhookAuth(created);
+    if (!normalized) {
+      return null;
+    }
+    channelWebhookCache.set(channelId, normalized);
+    return normalized;
+  } catch {
+    return null;
+  }
+}

--- a/src/discord/webhook-cache.ts
+++ b/src/discord/webhook-cache.ts
@@ -8,6 +8,14 @@ export type DiscordWebhookAuth = {
 
 const channelWebhookCache = new Map<string, DiscordWebhookAuth>();
 
+/** Set of webhook IDs created by this gateway — used to detect self-webhook messages. */
+const ownWebhookIds = new Set<string>();
+
+/** Check if a webhook ID belongs to this gateway. */
+export function isOwnWebhookId(webhookId: string): boolean {
+  return ownWebhookIds.has(webhookId);
+}
+
 function normalizeWebhookAuth(raw: {
   id?: string;
   token?: string | null;
@@ -40,6 +48,7 @@ export async function getOrCreateWebhook(
       return null;
     }
     channelWebhookCache.set(channelId, normalized);
+    ownWebhookIds.add(normalized.id);
     return normalized;
   } catch {
     return null;


### PR DESCRIPTION
## Summary

Port the existing WhatsApp broadcast pattern to Discord guild channels, enabling multiple agents to independently process the same message in a Discord channel.

## Motivation

Broadcast groups are a powerful feature for multi-agent setups where specialized agents (coder, reviewer, researcher, etc.) collaborate in the same channel. This is currently supported for WhatsApp but not Discord, despite Discord being a natural fit for project-based multi-agent workflows.

## Changes

### New: `src/discord/monitor/broadcast.ts`
- `maybeBroadcastDiscordMessage()` — checks `config.broadcast[channelId]` and fans out to all listed agents
- Only applies to guild/channel messages (never DMs)
- Rebuilds route per agent with correct `agentId`, `sessionKey`, and `mainSessionKey`
- Supports `parallel` (default) and `sequential` strategies
- Per-agent error handling — one agent failure doesn't block others
- Snapshots guild history before fan-out, clears once after all agents finish

### Modified: `src/discord/monitor/message-handler.ts`
- Imports and calls `maybeBroadcastDiscordMessage()` in both flush paths (single-message and debounced-batch)
- If broadcast returns `true`, skips normal single-agent processing

### Modified: `src/discord/monitor/message-handler.process.ts`
- Extended `processDiscordMessage()` signature with optional `opts` parameter:
  - `guildHistory?: HistoryEntry[]` — use snapshotted history instead of live map
  - `suppressGuildHistoryClear?: boolean` — prevent per-agent history clearing during broadcast
- Imported `HistoryEntry` type

## Config example

Uses the same `BroadcastConfig` type — no schema changes needed. Discord channel IDs work as peer IDs:

```json5
{
  broadcast: {
    strategy: "parallel",
    "123456789012345678": ["coder", "reviewer", "researcher"],
    "987654321098765432": ["pm", "coder", "qa"],
  }
}
```

## Testing

- All 96 existing Discord monitor tests pass
- Zero TypeScript errors
- No changes to WhatsApp broadcast, config types, or zod schema

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Ports WhatsApp broadcast pattern to Discord, enabling multi-agent fan-out in guild channels. Each broadcast agent receives the same message with independent processing, snapshotted history, and per-agent identity via Discord webhooks.

**Key changes:**
- New `maybeBroadcastDiscordMessage()` function in `src/discord/monitor/broadcast.ts` checks `config.broadcast[channelId]` and fans out to configured agents
- Modified `processDiscordMessage()` to accept optional `guildHistory`, `suppressGuildHistoryClear`, and `agentIdentity` parameters for broadcast support
- Webhook delivery (`send.webhook.ts` + `webhook-cache.ts`) enables per-agent identity (username/avatar/emoji) for broadcast agents
- Guild history is snapshotted before broadcast and cleared once after all agents complete, preventing race conditions
- Supports both `parallel` (default) and `sequential` broadcast strategies with per-agent error isolation

**Implementation follows WhatsApp broadcast pattern** (`src/web/auto-reply/monitor/broadcast.ts`) with Discord-specific adaptations for webhook delivery and guild channel handling.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - clean port of existing WhatsApp pattern with comprehensive test coverage and no breaking changes
- Implementation faithfully follows the proven WhatsApp broadcast pattern with proper error isolation, history snapshotting, and TypeScript type safety. The webhook delivery feature is well-encapsulated with fallback to standard delivery. All 96 existing Discord tests pass, and the PR includes dedicated webhook delivery tests. No schema changes required since `BroadcastConfig` already supports the pattern.
- No files require special attention - implementation is clean and follows established patterns

<sub>Last reviewed commit: 8741759</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->