### PR TITLE
fix(voice-call): auto-end call on media stream disconnect

### DIFF
--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -10,11 +10,11 @@ import type { VoiceCallConfig } from "./config.js";
 import type { CoreConfig } from "./core-bridge.js";
 import type { CallManager } from "./manager.js";
 import type { MediaStreamConfig } from "./media-stream.js";
-import { MediaStreamHandler } from "./media-stream.js";
 import type { VoiceCallProvider } from "./providers/base.js";
-import { OpenAIRealtimeSTTProvider } from "./providers/stt-openai-realtime.js";
 import type { TwilioProvider } from "./providers/twilio.js";
 import type { NormalizedEvent, WebhookContext } from "./types.js";
+import { MediaStreamHandler } from "./media-stream.js";
+import { OpenAIRealtimeSTTProvider } from "./providers/stt-openai-realtime.js";
 
 const MAX_WEBHOOK_BODY_BYTES = 1024 * 1024;
 

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -151,6 +151,13 @@ export class VoiceCallWebhookServer {
       },
       onDisconnect: (callId) => {
         console.log(`[voice-call] Media stream disconnected: ${callId}`);
+        // Auto-end call when media stream disconnects to prevent stuck calls.
+        // Without this, calls can remain active indefinitely after the stream closes.
+        const disconnectedCall = this.manager.getCallByProviderCallId(callId);
+        if (disconnectedCall) {
+          console.log(`[voice-call] Auto-ending call ${disconnectedCall.callId} on stream disconnect`);
+          void this.manager.endCall(disconnectedCall.callId).catch(() => {});
+        }
         if (this.provider.name === "twilio") {
           (this.provider as TwilioProvider).unregisterCallStream(callId);
         }

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -158,7 +158,9 @@ export class VoiceCallWebhookServer {
           console.log(
             `[voice-call] Auto-ending call ${disconnectedCall.callId} on stream disconnect`,
           );
-          void this.manager.endCall(disconnectedCall.callId).catch(() => {});
+          void this.manager.endCall(disconnectedCall.callId).catch((err) => {
+            console.warn(`[voice-call] Failed to auto-end call ${disconnectedCall.callId}:`, err);
+          });
         }
         if (this.provider.name === "twilio") {
           (this.provider as TwilioProvider).unregisterCallStream(callId);

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -10,11 +10,11 @@ import type { VoiceCallConfig } from "./config.js";
 import type { CoreConfig } from "./core-bridge.js";
 import type { CallManager } from "./manager.js";
 import type { MediaStreamConfig } from "./media-stream.js";
+import { MediaStreamHandler } from "./media-stream.js";
 import type { VoiceCallProvider } from "./providers/base.js";
+import { OpenAIRealtimeSTTProvider } from "./providers/stt-openai-realtime.js";
 import type { TwilioProvider } from "./providers/twilio.js";
 import type { NormalizedEvent, WebhookContext } from "./types.js";
-import { MediaStreamHandler } from "./media-stream.js";
-import { OpenAIRealtimeSTTProvider } from "./providers/stt-openai-realtime.js";
 
 const MAX_WEBHOOK_BODY_BYTES = 1024 * 1024;
 
@@ -155,7 +155,9 @@ export class VoiceCallWebhookServer {
         // Without this, calls can remain active indefinitely after the stream closes.
         const disconnectedCall = this.manager.getCallByProviderCallId(callId);
         if (disconnectedCall) {
-          console.log(`[voice-call] Auto-ending call ${disconnectedCall.callId} on stream disconnect`);
+          console.log(
+            `[voice-call] Auto-ending call ${disconnectedCall.callId} on stream disconnect`,
+          );
           void this.manager.endCall(disconnectedCall.callId).catch(() => {});
         }
         if (this.provider.name === "twilio") {


### PR DESCRIPTION
## Summary
- When a Twilio media stream disconnects (caller hangs up, network drop, etc.), the call was left in active state indefinitely — a "stuck call"
- Now automatically ends the call when `onDisconnect` fires, matching expected lifecycle
- Prevents resource leaks and blocked concurrent call slots

## Context
Running OpenClaw with Twilio voice calls in a Docker deployment. When the media stream disconnects (common with network issues or normal hangup), the call record stays active. Over time, this accumulates stuck calls that must be manually cleared.

The fix adds `manager.endCall()` in the `onDisconnect` handler before unregistering the stream, so the call is properly cleaned up.

## Test plan
- [ ] Make a voice call, hang up normally → call should end immediately
- [ ] Simulate network drop during active call → call should end when stream disconnects
- [ ] Verify no duplicate end-call attempts (endCall is idempotent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds automatic call cleanup when a Twilio media stream disconnects, preventing "stuck calls" that remain active indefinitely after the WebSocket closes (e.g., caller hangup, network drop). The fix inserts `manager.endCall()` in the `onDisconnect` handler before stream unregistration.

- The change is safe: `endCall` is idempotent — it returns early if the call is already in a terminal state or missing from `activeCalls`, and Twilio's `hangupCall` uses `allowNotFound: true` for the REST API call
- Race conditions with the `call.ended` webhook path are handled correctly — both paths converge on the same `endCall` which guards against double cleanup
- Ordering with `unregisterCallStream` is correct — `endCall`/`hangupCall` cleans up auth tokens and webhook URLs, while `unregisterCallStream` cleans up the stream mapping with no overlap
- Minor style note: the `.catch(() => {})` silently swallows errors, unlike similar fire-and-forget patterns elsewhere in this codebase that log warnings

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — the fix is minimal, well-targeted, and the auto-end logic is protected by idempotency guards.
- Score of 4 reflects a clean, low-risk bug fix. The change is small (7 lines), correctly leverages existing idempotency in endCall, and handles race conditions with webhook events safely. Only deducting one point for the silent error swallowing pattern which deviates from codebase conventions, though it's not a functional issue.
- No files require special attention. The single changed file (`extensions/voice-call/src/webhook.ts`) has a minor style suggestion but no functional issues.

<sub>Last reviewed commit: c0cd3c2</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->