### PR TITLE
feat(voice-call): add configurable stale call reaper

### DIFF
--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -273,6 +273,14 @@ export const VoiceCallConfigSchema = z
     /** Maximum call duration in seconds */
     maxDurationSeconds: z.number().int().positive().default(300),
 
+    /**
+     * Maximum age of a call in seconds before it is automatically reaped.
+     * Catches calls stuck in unexpected states (e.g., notify-mode calls that
+     * never receive a terminal webhook). Set to 0 to disable.
+     * Default: 0 (disabled). Recommended: 120-300 for production.
+     */
+    staleCallReaperSeconds: z.number().int().nonnegative().default(0),
+
     /** Silence timeout for end-of-speech detection (ms) */
     silenceTimeoutMs: z.number().int().positive().default(800),
 

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -230,7 +230,9 @@ export class VoiceCallWebhookServer {
           console.log(
             `[voice-call] Reaping stale call ${call.callId} (age: ${Math.round(age / 1000)}s, state: ${call.state})`,
           );
-          void this.manager.endCall(call.callId).catch(() => {});
+          void this.manager.endCall(call.callId).catch((err) => {
+            console.warn(`[voice-call] Reaper failed to end call ${call.callId}:`, err);
+          });
         }
       }
     }, CHECK_INTERVAL_MS);

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -28,6 +28,7 @@ export class VoiceCallWebhookServer {
   private manager: CallManager;
   private provider: VoiceCallProvider;
   private coreConfig: CoreConfig | null;
+  private staleCallReaperInterval: ReturnType<typeof setInterval> | null = null;
 
   /** Media stream handler for bidirectional audio (when streaming enabled) */
   private mediaStreamHandler: MediaStreamHandler | null = null;
@@ -200,14 +201,49 @@ export class VoiceCallWebhookServer {
           console.log(`[voice-call] Media stream WebSocket on ws://${bind}:${port}${streamPath}`);
         }
         resolve(url);
+
+        // Start the stale call reaper if configured
+        this.startStaleCallReaper();
       });
     });
+  }
+
+  /**
+   * Start a periodic reaper that ends calls older than the configured threshold.
+   * Catches calls stuck in unexpected states (e.g., notify-mode calls that never
+   * receive a terminal webhook from the provider).
+   */
+  private startStaleCallReaper(): void {
+    const maxAgeSeconds = this.config.staleCallReaperSeconds;
+    if (!maxAgeSeconds || maxAgeSeconds <= 0) {
+      return;
+    }
+
+    const CHECK_INTERVAL_MS = 30_000; // Check every 30 seconds
+    const maxAgeMs = maxAgeSeconds * 1000;
+
+    this.staleCallReaperInterval = setInterval(() => {
+      const now = Date.now();
+      for (const call of this.manager.getActiveCalls()) {
+        const age = now - call.startedAt;
+        if (age > maxAgeMs) {
+          console.log(
+            `[voice-call] Reaping stale call ${call.callId} (age: ${Math.round(age / 1000)}s, state: ${call.state})`,
+          );
+          void this.manager.endCall(call.callId).catch(() => {});
+        }
+      }
+    }, CHECK_INTERVAL_MS);
   }
 
   /**
    * Stop the webhook server.
    */
   async stop(): Promise<void> {
+    if (this.staleCallReaperInterval) {
+      clearInterval(this.staleCallReaperInterval);
+      this.staleCallReaperInterval = null;
+    }
     return new Promise((resolve) => {
       if (this.server) {
         this.server.close(() => {


### PR DESCRIPTION
## Summary
- Adds a periodic reaper that automatically ends calls older than a configurable threshold
- New config: `staleCallReaperSeconds` (default: 0 = disabled, recommended: 120-300)
- Catches notify-mode calls and edge cases where terminal webhooks never arrive

## Context
In production with Twilio, notify-mode calls sometimes don't receive terminal webhooks (completed/failed). These calls remain active indefinitely, blocking concurrent call slots and consuming resources. Currently requires manual intervention to clear.

The reaper checks every 30 seconds and ends any call exceeding the configured max age.

## Test plan
- [ ] Set `staleCallReaperSeconds: 120`, make a call, verify it ends normally (before reaper)
- [ ] Simulate a stuck call (mock provider that never sends terminal event) → verify reaper cleans it up after configured timeout
- [ ] Verify reaper is disabled when `staleCallReaperSeconds: 0` (default)
- [ ] Verify interval is cleared on server stop

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a periodic stale call reaper to the voice-call webhook server that automatically ends calls exceeding a configurable age threshold (`staleCallReaperSeconds`). This complements the existing per-call `maxDurationTimer` (which only starts on `call.answered`) by catching calls stuck in pre-answer states or notify-mode calls that never receive terminal webhooks from providers like Twilio.

- New Zod config field `staleCallReaperSeconds` (default 0 = disabled) with nonnegative integer validation
- Reaper checks every 30s via `setInterval`, iterates active calls, and ends any exceeding the max age
- Interval is properly cleared in `stop()` to prevent leaks
- The `endCall` path already handles terminal-state and not-found calls gracefully, so concurrent reaping is safe
- One minor concern: reaper errors are silently swallowed (`.catch(() => {})`), which could hide provider failures in production

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk — the reaper is disabled by default and the implementation is sound.
- The change is small, well-scoped, and disabled by default (staleCallReaperSeconds: 0). The reaper logic correctly uses a snapshot of active calls, and the endCall path handles edge cases (terminal state, missing calls) gracefully. The interval is cleaned up on stop(). The only minor concern is silent error swallowing in the catch handler, which is a style/debugging issue rather than a correctness problem.
- No files require special attention — both changes are straightforward.

<sub>Last reviewed commit: 5db2d83</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->