### PR TITLE
Slack: add overflow menus for slash arg choices

### DIFF
--- a/src/slack/monitor/events/interactions.ts
+++ b/src/slack/monitor/events/interactions.ts
@@ -580,20 +580,18 @@ export function registerSlackInteractionEvents(params: { ctx: SlackMonitorContex
     },
   );
 
-  const viewClosed = (
-    ctx.app as unknown as {
-      viewClosed?: (
-        matcher: RegExp,
-        handler: (args: { ack: () => Promise<void>; body: unknown }) => Promise<void>,
-      ) => void;
-    }
-  ).viewClosed;
-  if (typeof viewClosed !== "function") {
+  const appWithViewClosed = ctx.app as unknown as {
+    viewClosed?: (
+      matcher: RegExp,
+      handler: (args: { ack: () => Promise<void>; body: unknown }) => Promise<void>,
+    ) => void;
+  };
+  if (typeof appWithViewClosed.viewClosed !== "function") {
     return;
   }
 
   // Handle modal close events so agent workflows can react to cancelled forms.
-  viewClosed(
+  appWithViewClosed.viewClosed(
     new RegExp(`^${OPENCLAW_ACTION_PREFIX}`),
     async ({ ack, body }: { ack: () => Promise<void>; body: unknown }) => {
       await ack();


### PR DESCRIPTION
## Summary
Adds compact Slack `overflow` menus for native slash argument selection when choice counts are mid-sized.

- render `overflow` menus for command arg choices in the compact range
- keep existing behavior for small (`button`) and large (`static_select`) menus
- preserve existing action routing by reusing encoded command arg values
- add tests for overflow rendering and overflow selection dispatch

## Scope
- `src/slack/monitor/slash.ts`
- `src/slack/monitor/slash.test.ts`

## Validation
- `pnpm test src/slack/monitor/slash.test.ts`
- `pnpm check`

## Dependency
Depends on:
- #18180 Slack: improve Block Kit interaction handling (foundation)
- #18234 feat(slack): capture Block Kit view_closed lifecycle events
- #18242 feat(slack): use static_select for large slash arg menus
- #18252 feat(slack): route modal interactions with private metadata
- #18257 feat(slack): support Block Kit blocks in sendMessage
- #18262 feat(slack): support Block Kit blocks in editMessage
- #18268 feat(slack): support blocks in plugin send action
- #18278 feat(slack): support blocks in plugin edit action
- #18284 feat(slack): centralize Block Kit input validation
- #18290 fix(slack): add blocks+media send guardrails
- #18372 test(slack): cover sendMessage Block Kit paths
- #18409 refactor(slack): centralize modal private_metadata utilities
- #18413 Slack: expand interaction payload normalization coverage
- #18416 Slack: validate runtime blocks in send and edit paths
- #18423 Slack: dedupe normalized interaction selections
- #18431 Slack: enrich block action context payloads

If reviewing before dependencies merge, review tip commit: `05e4b9ed7`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes `this` binding for the `viewClosed` method on the Slack Bolt app instance. The previous code destructured `viewClosed` into a standalone variable before calling it, which would lose the method's `this` context if the implementation references `this` internally (standard for Bolt listener registration methods). The new code stores the cast app reference as `appWithViewClosed` and calls `appWithViewClosed.viewClosed(...)`, preserving the correct receiver.

- Refactored `viewClosed` extraction from inline destructuring to a named variable (`appWithViewClosed`) with method-call syntax
- No behavioral changes to handler logic, event payloads, or session routing

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a minimal, correct fix that preserves method binding without altering any handler logic.
- The change is a single, well-scoped refactor (8 insertions, 10 deletions) in one file that fixes a potential `this` binding issue when calling the `viewClosed` method. No handler logic, event payloads, or routing behavior is modified. The existing test suite covers `viewClosed` registration and invocation. The fix follows standard JavaScript patterns for preserving method context.
- No files require special attention

<sub>Last reviewed commit: 8ca13de</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->