### PR TITLE
feat(browser): add extraArgs config for custom Chrome launch args

### DIFF
--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -1,5 +1,4 @@
 import crypto from "node:crypto";
-import type { SandboxBrowserContext, SandboxConfig } from "./types.js";
 import { startBrowserBridgeServer, stopBrowserBridgeServer } from "../../browser/bridge-server.js";
 import { type ResolvedBrowserConfig, resolveProfile } from "../../browser/config.js";
 import {
@@ -22,6 +21,7 @@ import {
 import { readBrowserRegistry, updateBrowserRegistry } from "./registry.js";
 import { resolveSandboxAgentId, slugifySessionKey } from "./shared.js";
 import { isToolAllowed } from "./tool-policy.js";
+import type { SandboxBrowserContext, SandboxConfig } from "./types.js";
 
 const HOT_BROWSER_WINDOW_MS = 5 * 60 * 1000;
 
@@ -70,6 +70,7 @@ function buildSandboxBrowserResolvedConfig(params: {
     noSandbox: false,
     attachOnly: true,
     defaultProfile: DEFAULT_OPENCLAW_BROWSER_PROFILE_NAME,
+    extraArgs: [],
     profiles: {
       [DEFAULT_OPENCLAW_BROWSER_PROFILE_NAME]: {
         cdpPort: params.cdpPort,

--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -1,4 +1,5 @@
 import crypto from "node:crypto";
+import type { SandboxBrowserContext, SandboxConfig } from "./types.js";
 import { startBrowserBridgeServer, stopBrowserBridgeServer } from "../../browser/bridge-server.js";
 import { type ResolvedBrowserConfig, resolveProfile } from "../../browser/config.js";
 import {
@@ -21,7 +22,6 @@ import {
 import { readBrowserRegistry, updateBrowserRegistry } from "./registry.js";
 import { resolveSandboxAgentId, slugifySessionKey } from "./shared.js";
 import { isToolAllowed } from "./tool-policy.js";
-import type { SandboxBrowserContext, SandboxConfig } from "./types.js";
 
 const HOT_BROWSER_WINDOW_MS = 5 * 60 * 1000;
 

--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -3,7 +3,6 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import WebSocket from "ws";
-import type { ResolvedBrowserConfig, ResolvedBrowserProfile } from "./config.js";
 import { ensurePortAvailable } from "../infra/ports.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { CONFIG_DIR } from "../utils.js";
@@ -18,6 +17,7 @@ import {
   ensureProfileCleanExit,
   isProfileDecorated,
 } from "./chrome.profile-decoration.js";
+import type { ResolvedBrowserConfig, ResolvedBrowserProfile } from "./config.js";
 import {
   DEFAULT_OPENCLAW_BROWSER_COLOR,
   DEFAULT_OPENCLAW_BROWSER_PROFILE_NAME,

--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -217,6 +217,11 @@ export async function launchOpenClawChrome(
     // Stealth: hide navigator.webdriver from automation detection (#80)
     args.push("--disable-blink-features=AutomationControlled");
 
+    // Append user-configured extra arguments (e.g., stealth flags, window size)
+    if (resolved.extraArgs.length > 0) {
+      args.push(...resolved.extraArgs);
+    }
+
     // Always open a blank tab to ensure a target exists.
     args.push("about:blank");
 

--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import WebSocket from "ws";
+import type { ResolvedBrowserConfig, ResolvedBrowserProfile } from "./config.js";
 import { ensurePortAvailable } from "../infra/ports.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { CONFIG_DIR } from "../utils.js";
@@ -17,7 +18,6 @@ import {
   ensureProfileCleanExit,
   isProfileDecorated,
 } from "./chrome.profile-decoration.js";
-import type { ResolvedBrowserConfig, ResolvedBrowserProfile } from "./config.js";
 import {
   DEFAULT_OPENCLAW_BROWSER_COLOR,
   DEFAULT_OPENCLAW_BROWSER_PROFILE_NAME,

--- a/src/browser/config.test.ts
+++ b/src/browser/config.test.ts
@@ -149,4 +149,37 @@ describe("browser config", () => {
     expect(resolveProfile(resolved, "chrome")).toBe(null);
     expect(resolved.defaultProfile).toBe("openclaw");
   });
+
+  it("defaults extraArgs to empty array when not provided", () => {
+    const resolved = resolveBrowserConfig(undefined);
+    expect(resolved.extraArgs).toEqual([]);
+  });
+
+  it("passes through valid extraArgs strings", () => {
+    const resolved = resolveBrowserConfig({
+      extraArgs: ["--no-sandbox", "--disable-gpu"],
+    });
+    expect(resolved.extraArgs).toEqual(["--no-sandbox", "--disable-gpu"]);
+  });
+
+  it("filters out empty strings and whitespace-only entries from extraArgs", () => {
+    const resolved = resolveBrowserConfig({
+      extraArgs: ["--flag", "", "  ", "--other"],
+    });
+    expect(resolved.extraArgs).toEqual(["--flag", "--other"]);
+  });
+
+  it("filters out non-string entries from extraArgs", () => {
+    const resolved = resolveBrowserConfig({
+      extraArgs: ["--flag", 42, null, undefined, true, "--other"] as unknown as string[],
+    });
+    expect(resolved.extraArgs).toEqual(["--flag", "--other"]);
+  });
+
+  it("defaults extraArgs to empty array when set to non-array", () => {
+    const resolved = resolveBrowserConfig({
+      extraArgs: "not-an-array" as unknown as string[],
+    });
+    expect(resolved.extraArgs).toEqual([]);
+  });
 });

--- a/src/browser/config.ts
+++ b/src/browser/config.ts
@@ -31,6 +31,7 @@ export type ResolvedBrowserConfig = {
   attachOnly: boolean;
   defaultProfile: string;
   profiles: Record<string, BrowserProfileConfig>;
+  extraArgs: string[];
 };
 
 export type ResolvedBrowserProfile = {
@@ -196,6 +197,10 @@ export function resolveBrowserConfig(
       ? DEFAULT_BROWSER_DEFAULT_PROFILE_NAME
       : DEFAULT_OPENCLAW_BROWSER_PROFILE_NAME);
 
+  const extraArgs = Array.isArray(cfg?.extraArgs)
+    ? cfg.extraArgs.filter((a): a is string => typeof a === "string" && a.trim().length > 0)
+    : [];
+
   return {
     enabled,
     evaluateEnabled,
@@ -212,6 +217,7 @@ export function resolveBrowserConfig(
     attachOnly,
     defaultProfile,
     profiles,
+    extraArgs,
   };
 }
 

--- a/src/config/types.browser.ts
+++ b/src/config/types.browser.ts
@@ -38,4 +38,10 @@ export type BrowserConfig = {
   profiles?: Record<string, BrowserProfileConfig>;
   /** Default snapshot options (applied by the browser tool/CLI when unset). */
   snapshotDefaults?: BrowserSnapshotDefaults;
+  /**
+   * Additional Chrome launch arguments.
+   * Useful for stealth flags, window size overrides, or custom user-agent strings.
+   * Example: ["--window-size=1920,1080", "--disable-infobars"]
+   */
+  extraArgs?: string[];
 };


### PR DESCRIPTION
## Summary
- Adds `browser.extraArgs` config option (string array) for custom Chrome launch arguments
- Passed through to Chrome's spawn args before the final `about:blank` argument
- Enables stealth flags, window sizing, user-agent overrides without source patching

## Context
When using OpenClaw's browser for automation tasks (e.g., social media, web scraping), sites often detect default Chrome automation signatures. Currently the only way to add stealth flags like `--window-size`, `--disable-infobars`, or custom `--user-agent` is to patch the compiled source code on every container start.

This config option makes it declarative:
```json
{
  "browser": {
    "extraArgs": [
      "--window-size=1920,1080",
      "--disable-infobars",
      "--user-agent=Mozilla/5.0 ..."
    ]
  }
}
```

## Changes
- `src/config/types.browser.ts`: Added `extraArgs?: string[]` to `BrowserConfig`
- `src/browser/config.ts`: Added `extraArgs` to `ResolvedBrowserConfig`, parsed from config
- `src/browser/chrome.ts`: Appends `extraArgs` to Chrome launch args

## Test plan
- [ ] Set `browser.extraArgs: ["--window-size=1920,1080"]` → verify Chrome launches with flag
- [ ] Empty/missing `extraArgs` → no change in behavior (backward compatible)
- [ ] Invalid entries (non-string) are filtered out

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a new `browser.extraArgs` configuration option that allows users to pass custom Chrome launch arguments. This enables declarative configuration of stealth flags, window sizing, and user-agent overrides without patching source code. The implementation correctly filters non-string and empty values, uses secure spawn with array arguments, and places extra args before the final `about:blank` argument. The feature is backward compatible and follows existing config patterns.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk - it adds a simple, well-scoped configuration option with proper input filtering
- The implementation is clean and secure (uses spawn with array args, filters inputs properly). Score is 4 rather than 5 due to missing tests for the new functionality and no CHANGELOG entry, which are project conventions per AGENTS.md
- No files require special attention - the changes are straightforward and follow existing patterns

<sub>Last reviewed commit: 1495d95</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->