### PR TITLE
feat(docker): optional Chromium + Xvfb pre-install in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,18 @@ RUN if [ -n "$OPENCLAW_DOCKER_APT_PACKAGES" ]; then \
       rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*; \
     fi
 
+# Optionally install Chromium and Xvfb for browser automation.
+# Build with: docker build --build-arg OPENCLAW_INSTALL_BROWSER=1 ...
+# Adds ~300MB but eliminates the 60-90s Playwright install on every container start.
+ARG OPENCLAW_INSTALL_BROWSER=""
+RUN if [ -n "$OPENCLAW_INSTALL_BROWSER" ]; then \
+      apt-get update && \
+      DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends xvfb && \
+      npx playwright install --with-deps chromium && \
+      apt-get clean && \
+      rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*; \
+    fi
+
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 COPY ui/package.json ./ui/package.json
 COPY patches ./patches


### PR DESCRIPTION
## Summary
- Adds `OPENCLAW_INSTALL_BROWSER` build arg to pre-install Chromium + Xvfb in the Docker image
- Eliminates the 60-90s Playwright install that happens on every container start
- Opt-in only — no change to default image size or behavior

## Context
When browser features are enabled (headless browser tools), Chromium must be installed via Playwright. Currently this happens at runtime on every container start via custom entrypoint scripts, adding 60-90 seconds to startup time. This is especially painful on `docker compose pull` + restart cycles.

With this change, users who need browser features can build a variant image with Chromium pre-installed:
```bash
docker build --build-arg OPENCLAW_INSTALL_BROWSER=1 -t openclaw:browser .
```

The existing `OPENCLAW_DOCKER_APT_PACKAGES` pattern was already in place, so this follows the same opt-in build-arg convention.

## Test plan
- [ ] Build without arg → no Chromium in image (default behavior preserved)
- [ ] Build with `OPENCLAW_INSTALL_BROWSER=1` → Chromium + Xvfb installed
- [ ] Run browser-enabled image → browser tools work without runtime install
- [ ] Verify image size increase is ~300MB (expected for Chromium)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `OPENCLAW_INSTALL_BROWSER` build arg to optionally pre-install Chromium and Xvfb in the Docker image, eliminating the 60-90s Playwright installation that would otherwise occur at runtime.

**Major issues found:**
- The `npx playwright install` command runs before `pnpm install`, so `playwright-core` won't be available in `node_modules` yet - this will cause the build to fail
- Per repository guidelines, should use `node /app/node_modules/playwright-core/cli.js` instead of `npx playwright` to avoid npm override conflicts

**The implementation approach is sound** (follows the existing `OPENCLAW_DOCKER_APT_PACKAGES` pattern), but the placement and command need adjustment.

<h3>Confidence Score: 1/5</h3>

- This PR cannot be merged as-is - it will fail during Docker build
- The Playwright installation command runs before dependencies are installed, which will cause the Docker build to fail. This is a critical ordering issue that makes the feature non-functional.
- Dockerfile requires the browser installation block to be moved after `pnpm install`

<sub>Last reviewed commit: aedf851</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->