### PR TITLE
feat(docker): add init script support via /openclaw-init.d/

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,11 @@ RUN chown -R node:node /app
 # This reduces the attack surface by preventing container escape via root privileges
 USER node
 
+# Support custom init scripts mounted at /openclaw-init.d/
+# Scripts must be executable. They run before the gateway starts.
+# Example: docker run -v ./my-scripts:/openclaw-init.d:ro openclaw
+ENTRYPOINT ["/app/scripts/docker-entrypoint.sh"]
+
 # Start gateway server with default config.
 # Binds to loopback (127.0.0.1) by default for security.
 #

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -18,7 +18,8 @@ if [ -d "$INIT_DIR" ] && [ "$(ls -A "$INIT_DIR" 2>/dev/null)" ]; then
     [ -f "$script" ] || continue
     if [ -x "$script" ]; then
       echo "[openclaw-init] Running $(basename "$script")..."
-      "$script" 2>&1 | sed "s/^/  /"
+      output=$("$script" 2>&1) || echo "[openclaw-init] WARNING: $(basename "$script") exited with status $?"
+      [ -n "$output" ] && printf '%s\n' "$output" | sed 's/^/  /'
     else
       echo "[openclaw-init] Skipping $(basename "$script") (not executable)"
     fi

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# OpenClaw Docker entrypoint with init script support.
+#
+# Runs any executable scripts found in /openclaw-init.d/ before starting
+# the main process. This allows users to mount custom initialization
+# scripts (e.g., install dependencies, apply patches, start services)
+# without overriding the entire entrypoint.
+#
+# Usage in docker-compose.yml:
+#   volumes:
+#     - ./my-init-scripts:/openclaw-init.d:ro
+
+INIT_DIR="/openclaw-init.d"
+
+if [ -d "$INIT_DIR" ] && [ "$(ls -A "$INIT_DIR" 2>/dev/null)" ]; then
+  echo "[openclaw-init] Running init scripts from $INIT_DIR..."
+  for script in "$INIT_DIR"/*; do
+    [ -f "$script" ] || continue
+    if [ -x "$script" ]; then
+      echo "[openclaw-init] Running $(basename "$script")..."
+      "$script" 2>&1 | sed "s/^/  /"
+    else
+      echo "[openclaw-init] Skipping $(basename "$script") (not executable)"
+    fi
+  done
+  echo "[openclaw-init] Done."
+fi
+
+exec "$@"


### PR DESCRIPTION
## Summary
- Adds a Docker ENTRYPOINT that runs user scripts from `/openclaw-init.d/` before starting the gateway
- Standard Docker pattern (nginx, postgres, etc.) for customizing container startup
- No change to default behavior when no init scripts are mounted

## Context
Currently, customizing container startup (installing packages, patching source, starting Xvfb, etc.) requires overriding the entire Docker entrypoint. This makes upgrades fragile — users must maintain their own entrypoint script and update it when OpenClaw changes.

With init script support, users mount a directory of scripts:
```yaml
services:
  openclaw-gateway:
    volumes:
      - ./my-init-scripts:/openclaw-init.d:ro
```

Scripts run in alphabetical order before the gateway starts. This is the standard Docker convention used by the official nginx, postgres, and redis images.

## Changes
- `scripts/docker-entrypoint.sh`: New entrypoint that runs scripts from `/openclaw-init.d/` then `exec "$@"`
- `Dockerfile`: Set ENTRYPOINT to the new script, keeping CMD unchanged

## Test plan
- [ ] No init scripts mounted → gateway starts normally (no output from entrypoint)
- [ ] Mount a dir with executable scripts → scripts run in order before gateway
- [ ] Non-executable files → skipped with warning message
- [ ] Init script fails → error visible in logs (non-blocking by default)
- [ ] `docker run openclaw echo hello` → init scripts run, then echo (exec passthrough works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Docker init script support via `/openclaw-init.d/`, following the standard Docker convention (nginx, postgres). Users can mount a directory of executable scripts that run before the gateway starts, removing the need to override the entire entrypoint.

- The ENTRYPOINT/CMD interaction is correctly implemented — `exec "$@"` passes through the CMD cleanly
- Existing test scripts and docker-compose services that override `--entrypoint` are unaffected
- The `[ -d "$INIT_DIR" ]` guard means default behavior is unchanged when no scripts are mounted
- **Issue**: The `sed` pipe on line 21 of `docker-entrypoint.sh` silently swallows init script exit codes in POSIX `sh` (no `pipefail`), so the entrypoint cannot detect or report init script failures — contradicting the test plan claim

<h3>Confidence Score: 3/5</h3>

- Low risk to default behavior, but the init script failure detection does not work as described
- The PR introduces a clean, well-scoped feature with no impact when no init scripts are mounted. The ENTRYPOINT/CMD interaction is correct and existing workflows are unaffected. However, the pipeline that runs init scripts silently swallows exit codes, meaning the entrypoint cannot detect or report failures — this contradicts the PR's test plan and could frustrate users debugging init script issues.
- scripts/docker-entrypoint.sh — the sed pipeline on line 21 loses init script exit codes

<sub>Last reviewed commit: 85280c1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->