### PR TITLE
Slack: enrich modal input payload normalization

### DIFF
--- a/src/slack/monitor/events/interactions.ts
+++ b/src/slack/monitor/events/interactions.ts
@@ -580,20 +580,18 @@ export function registerSlackInteractionEvents(params: { ctx: SlackMonitorContex
     },
   );
 
-  const viewClosed = (
-    ctx.app as unknown as {
-      viewClosed?: (
-        matcher: RegExp,
-        handler: (args: { ack: () => Promise<void>; body: unknown }) => Promise<void>,
-      ) => void;
-    }
-  ).viewClosed;
-  if (typeof viewClosed !== "function") {
+  const appWithViewClosed = ctx.app as unknown as {
+    viewClosed?: (
+      matcher: RegExp,
+      handler: (args: { ack: () => Promise<void>; body: unknown }) => Promise<void>,
+    ) => void;
+  };
+  if (typeof appWithViewClosed.viewClosed !== "function") {
     return;
   }
 
   // Handle modal close events so agent workflows can react to cancelled forms.
-  viewClosed(
+  appWithViewClosed.viewClosed(
     new RegExp(`^${OPENCLAW_ACTION_PREFIX}`),
     async ({ ack, body }: { ack: () => Promise<void>; body: unknown }) => {
       await ack();


### PR DESCRIPTION
## Summary
Adds a combined modal-input feature package for Slack interactions by normalizing richer input element payloads.

- normalize modal `number_input` with parsed `inputNumber`
- normalize modal `email_text_input` with `inputEmail`
- normalize modal `url_text_input` with canonical `inputUrl`
- normalize modal `rich_text_input` with `richTextValue`
- expose `inputKind` for text/number/email/url/rich_text input families
- expand modal tests to cover radio buttons, checkboxes, number/email/url, and rich text input payloads

## Scope
- `src/slack/monitor/events/interactions.ts`
- `src/slack/monitor/events/interactions.test.ts`

## Validation
- `pnpm test src/slack/monitor/events/interactions.test.ts`
- `pnpm check`

## Dependency
Depends on:
- #18180 Slack: improve Block Kit interaction handling (foundation)
- #18234 feat(slack): capture Block Kit view_closed lifecycle events
- #18242 feat(slack): use static_select for large slash arg menus
- #18252 feat(slack): route modal interactions with private metadata
- #18257 feat(slack): support Block Kit blocks in sendMessage
- #18262 feat(slack): support Block Kit blocks in editMessage
- #18268 feat(slack): support blocks in plugin send action
- #18278 feat(slack): support blocks in plugin edit action
- #18284 feat(slack): centralize Block Kit input validation
- #18290 fix(slack): add blocks+media send guardrails
- #18372 test(slack): cover sendMessage Block Kit paths
- #18409 refactor(slack): centralize modal private_metadata utilities
- #18413 Slack: expand interaction payload normalization coverage
- #18416 Slack: validate runtime blocks in send and edit paths
- #18423 Slack: dedupe normalized interaction selections
- #18431 Slack: enrich block action context payloads
- #18439 Slack: add overflow menus for slash arg choices
- #18448 Slack: update action rows for select interactions

If reviewing before dependencies merge, review tip commit: `2bd414cc2`.
