### PR TITLE
Slack: add header and context blocks to arg menus

### DIFF
--- a/src/slack/monitor/events/interactions.ts
+++ b/src/slack/monitor/events/interactions.ts
@@ -580,20 +580,18 @@ export function registerSlackInteractionEvents(params: { ctx: SlackMonitorContex
     },
   );
 
-  const viewClosed = (
-    ctx.app as unknown as {
-      viewClosed?: (
-        matcher: RegExp,
-        handler: (args: { ack: () => Promise<void>; body: unknown }) => Promise<void>,
-      ) => void;
-    }
-  ).viewClosed;
-  if (typeof viewClosed !== "function") {
+  const appWithViewClosed = ctx.app as unknown as {
+    viewClosed?: (
+      matcher: RegExp,
+      handler: (args: { ack: () => Promise<void>; body: unknown }) => Promise<void>,
+    ) => void;
+  };
+  if (typeof appWithViewClosed.viewClosed !== "function") {
     return;
   }
 
   // Handle modal close events so agent workflows can react to cancelled forms.
-  viewClosed(
+  appWithViewClosed.viewClosed(
     new RegExp(`^${OPENCLAW_ACTION_PREFIX}`),
     async ({ ack, body }: { ack: () => Promise<void>; body: unknown }) => {
       await ack();


### PR DESCRIPTION
## Summary
Expands native slash argument menus to use more Block Kit primitives by adding `header` and `context` intro blocks.

- add `header` block for command/argument identity
- keep `section` block for menu description text
- add `context` block to provide concise menu guidance
- preserve existing menu interaction behavior (button/overflow/static_select)
- update slash menu tests for the richer block structure

## Scope
- `src/slack/monitor/slash.ts`
- `src/slack/monitor/slash.test.ts`

## Validation
- `pnpm test src/slack/monitor/slash.test.ts`
- `pnpm check`

## Dependency
Depends on:
- #18180 Slack: improve Block Kit interaction handling (foundation)
- #18234 feat(slack): capture Block Kit view_closed lifecycle events
- #18242 feat(slack): use static_select for large slash arg menus
- #18252 feat(slack): route modal interactions with private metadata
- #18257 feat(slack): support Block Kit blocks in sendMessage
- #18262 feat(slack): support Block Kit blocks in editMessage
- #18268 feat(slack): support blocks in plugin send action
- #18278 feat(slack): support blocks in plugin edit action
- #18284 feat(slack): centralize Block Kit input validation
- #18290 fix(slack): add blocks+media send guardrails
- #18372 test(slack): cover sendMessage Block Kit paths
- #18409 refactor(slack): centralize modal private_metadata utilities
- #18413 Slack: expand interaction payload normalization coverage
- #18416 Slack: validate runtime blocks in send and edit paths
- #18423 Slack: dedupe normalized interaction selections
- #18431 Slack: enrich block action context payloads
- #18439 Slack: add overflow menus for slash arg choices
- #18448 Slack: update action rows for select interactions
- #18455 Slack: enrich modal input payload normalization

If reviewing before dependencies merge, review tip commit: `5d5f93916`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors the `viewClosed` method extraction to preserve method binding in the Slack interaction handler. The change stores a reference to the app object (`appWithViewClosed`) instead of extracting the `viewClosed` method directly, ensuring the `this` context is maintained when the method is called.

**Key Changes:**
- Refactored `viewClosed` extraction to call `appWithViewClosed.viewClosed()` instead of storing the method in a variable
- This prevents potential `this` binding issues if the Slack Bolt library's `viewClosed` method relies on internal state

**Important Note:**
The PR title/description mentions "add header and context blocks to arg menus" with changes to `src/slack/monitor/slash.ts`, but the actual commit (f13be1d1) is "preserve viewClosed method binding" affecting `src/slack/monitor/events/interactions.ts`. The commit matching the PR description (5f9a0460) exists on a different branch. The PR metadata should be updated to match the actual changes being merged.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge - the code change is a valid refactoring that preserves method binding
- The code change itself is correct and well-tested (existing tests cover the viewClosed handler). However, there's a significant mismatch between the PR description and actual changes, which creates confusion about what's being merged. The technical implementation is sound, but the PR metadata needs correction.
- No files require special attention - the code change is straightforward and preserves existing behavior

<sub>Last reviewed commit: f13be1d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->