### PR TITLE
fix: respect OPENCLAW_HOME for isolated gateway instances

### DIFF
--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import type { GatewayAuthMode } from "../../config/config.js";
 import type { GatewayWsLogStyle } from "../../gateway/ws-logging.js";
 import {
-  CONFIG_PATH,
+  getConfigPath,
   loadConfig,
   readConfigFileSnapshot,
   resolveStateDir,
@@ -161,7 +161,7 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
   const tokenRaw = toOptionString(opts.token);
 
   const snapshot = await readConfigFileSnapshot().catch(() => null);
-  const configExists = snapshot?.exists ?? fs.existsSync(CONFIG_PATH);
+  const configExists = snapshot?.exists ?? fs.existsSync(getConfigPath());
   const configAuditPath = path.join(resolveStateDir(process.env), "logs", "config-audit.jsonl");
   const mode = cfg.gateway?.mode;
   if (!opts.allowUnconfigured && mode !== "local") {

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -182,7 +182,20 @@ export function resolveConfigPath(
   return path.join(stateDir, CONFIG_FILENAME);
 }
 
+/**
+ * @deprecated Use resolveConfigPathCandidate() instead. This constant is evaluated
+ * at module load time and does not respect OPENCLAW_HOME set after import.
+ * Kept for backwards compatibility but should be avoided in new code.
+ */
 export const CONFIG_PATH = resolveConfigPathCandidate();
+
+/**
+ * Runtime-evaluated config path that respects OPENCLAW_HOME.
+ * Use this instead of CONFIG_PATH when OPENCLAW_HOME may be set dynamically.
+ */
+export function getConfigPath(env: NodeJS.ProcessEnv = process.env): string {
+  return resolveConfigPathCandidate(env, envHomedir(env));
+}
 
 /**
  * Resolve default config path candidates across default locations.
@@ -258,6 +271,22 @@ export function resolveGatewayPort(
   cfg?: OpenClawConfig,
   env: NodeJS.ProcessEnv = process.env,
 ): number {
+  // When OPENCLAW_HOME is set (isolated instance), prefer config over inherited env vars.
+  // This prevents a parent gateway's OPENCLAW_GATEWAY_PORT from bleeding through.
+  const isIsolatedInstance = Boolean(env.OPENCLAW_HOME?.trim());
+
+  // Config port takes precedence for isolated instances
+  const configPort = cfg?.gateway?.port;
+  if (
+    isIsolatedInstance &&
+    typeof configPort === "number" &&
+    Number.isFinite(configPort) &&
+    configPort > 0
+  ) {
+    return configPort;
+  }
+
+  // Check env vars (for non-isolated or when config doesn't specify port)
   const envRaw = env.OPENCLAW_GATEWAY_PORT?.trim() || env.CLAWDBOT_GATEWAY_PORT?.trim();
   if (envRaw) {
     const parsed = Number.parseInt(envRaw, 10);
@@ -265,11 +294,11 @@ export function resolveGatewayPort(
       return parsed;
     }
   }
-  const configPort = cfg?.gateway?.port;
-  if (typeof configPort === "number" && Number.isFinite(configPort)) {
-    if (configPort > 0) {
-      return configPort;
-    }
+
+  // Fall back to config for non-isolated instances
+  if (typeof configPort === "number" && Number.isFinite(configPort) && configPort > 0) {
+    return configPort;
   }
+
   return DEFAULT_GATEWAY_PORT;
 }


### PR DESCRIPTION
## Summary

When `OPENCLAW_HOME` is set (indicating an isolated instance), the gateway port should be read from config rather than inheriting `OPENCLAW_GATEWAY_PORT` from a parent process.

## Problem

Running multiple OpenClaw instances (e.g., spawning a sandbox from within another OpenClaw process) fails because:

1. The parent gateway sets `process.env.OPENCLAW_GATEWAY_PORT` in `server.impl.ts`
2. Child processes inherit this environment variable
3. `resolveGatewayPort()` checks env vars before config
4. Child uses parent's port (18789) instead of its own config port (19789)

## Solution

- When `OPENCLAW_HOME` is set, prioritize `config.gateway.port` over inherited env vars
- Added `getConfigPath()` function for runtime-evaluated config path
- Deprecated `CONFIG_PATH` constant with warning about module-load-time evaluation
- Updated gateway run command to use `getConfigPath()`

## Testing

Tested by running a sandbox OpenClaw instance from within another OpenClaw:

```bash
# Before fix: fails with 'port 18789 already in use'
OPENCLAW_HOME=/path/to/sandbox node openclaw.mjs gateway run

# After fix: correctly uses config port (19789)
OPENCLAW_HOME=/path/to/sandbox node openclaw.mjs gateway run
```

## Related

This enables running isolated OpenClaw instances for testing (e.g., A2A channel experiments) without port conflicts.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes port conflicts when running multiple OpenClaw instances by making `resolveGatewayPort()` prioritize config over inherited environment variables when `OPENCLAW_HOME` is set.

**Changes made:**
- Modified `resolveGatewayPort()` to check for isolated instances (`OPENCLAW_HOME`) and prioritize `config.gateway.port` over inherited `OPENCLAW_GATEWAY_PORT` env var
- Added `getConfigPath()` function for runtime-evaluated config paths that respect `OPENCLAW_HOME`
- Deprecated `CONFIG_PATH` constant (module-load-time evaluation doesn't respect dynamic `OPENCLAW_HOME`)
- Updated gateway run command to use `getConfigPath()` instead of deprecated constant

**How it works:**
The parent gateway sets `process.env.OPENCLAW_GATEWAY_PORT` in `server.impl.ts:169`. Without this fix, child processes would inherit that env var and use the parent's port. Now, when `OPENCLAW_HOME` is set (indicating an isolated instance), the code correctly reads the port from the child's config file rather than using the inherited environment variable.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are focused, well-documented, and address a specific bug. The logic correctly handles the precedence order for port resolution: isolated instances use config first, then env vars as fallback. The deprecation of `CONFIG_PATH` is properly documented and backward compatible. No breaking changes or risky refactoring.
- No files require special attention

<sub>Last reviewed commit: 1080882</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->