### PR TITLE
Slack: show picker values in interaction confirmations

### DIFF
--- a/src/slack/monitor/events/interactions.ts
+++ b/src/slack/monitor/events/interactions.ts
@@ -580,20 +580,18 @@ export function registerSlackInteractionEvents(params: { ctx: SlackMonitorContex
     },
   );
 
-  const viewClosed = (
-    ctx.app as unknown as {
-      viewClosed?: (
-        matcher: RegExp,
-        handler: (args: { ack: () => Promise<void>; body: unknown }) => Promise<void>,
-      ) => void;
-    }
-  ).viewClosed;
-  if (typeof viewClosed !== "function") {
+  const appWithViewClosed = ctx.app as unknown as {
+    viewClosed?: (
+      matcher: RegExp,
+      handler: (args: { ack: () => Promise<void>; body: unknown }) => Promise<void>,
+    ) => void;
+  };
+  if (typeof appWithViewClosed.viewClosed !== "function") {
     return;
   }
 
   // Handle modal close events so agent workflows can react to cancelled forms.
-  viewClosed(
+  appWithViewClosed.viewClosed(
     new RegExp(`^${OPENCLAW_ACTION_PREFIX}`),
     async ({ ack, body }: { ack: () => Promise<void>; body: unknown }) => {
       await ack();


### PR DESCRIPTION
## Summary
Improves picker interaction UX by rendering selected date/time/datetime values in confirmation rows.

- include selected `datepicker` value in confirmation text
- include selected `timepicker` value in confirmation text
- include selected `datetimepicker` value (ISO UTC) in confirmation text
- add regression tests for date/time/datetime row confirmation rendering

## Scope
- `src/slack/monitor/events/interactions.ts`
- `src/slack/monitor/events/interactions.test.ts`

## Validation
- `pnpm test src/slack/monitor/events/interactions.test.ts`
- `pnpm check`

## Dependency
Depends on:
- #18180 Slack: improve Block Kit interaction handling (foundation)
- #18234 feat(slack): capture Block Kit view_closed lifecycle events
- #18242 feat(slack): use static_select for large slash arg menus
- #18252 feat(slack): route modal interactions with private metadata
- #18257 feat(slack): support Block Kit blocks in sendMessage
- #18262 feat(slack): support Block Kit blocks in editMessage
- #18268 feat(slack): support blocks in plugin send action
- #18278 feat(slack): support blocks in plugin edit action
- #18284 feat(slack): centralize Block Kit input validation
- #18290 fix(slack): add blocks+media send guardrails
- #18372 test(slack): cover sendMessage Block Kit paths
- #18409 refactor(slack): centralize modal private_metadata utilities
- #18413 Slack: expand interaction payload normalization coverage
- #18416 Slack: validate runtime blocks in send and edit paths
- #18423 Slack: dedupe normalized interaction selections
- #18431 Slack: enrich block action context payloads
- #18439 Slack: add overflow menus for slash arg choices
- #18448 Slack: update action rows for select interactions
- #18455 Slack: enrich modal input payload normalization
- #18458 Slack: add header and context blocks to arg menus

If reviewing before dependencies merge, review tip commit: `ce272b0ca`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Refactored `viewClosed` method access to preserve proper `this` binding by storing the app reference rather than extracting the method directly. Previously, extracting `viewClosed` as a standalone function could lose the method's context, potentially causing runtime issues when the method is invoked.

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no risk
- Simple refactoring that improves code correctness by preserving method binding context. The change is minimal (extracting to variable vs calling as method), well-tested with comprehensive test coverage for the `viewClosed` handler, and follows JavaScript best practices for maintaining proper `this` context.
- No files require special attention

<sub>Last reviewed commit: 5043302</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->