### PR TITLE
fix: suppress recoverable mutating tool errors when agent already replied

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,12 +36,10 @@ bin/docs-list
 apps/macos/.build-local/
 apps/macos/.swiftpm/
 apps/shared/MoltbotKit/.swiftpm/
-apps/shared/OpenClawKit/.swiftpm/
 Core/
 apps/ios/*.xcodeproj/
 apps/ios/*.xcworkspace/
 apps/ios/.swiftpm/
-apps/ios/.local-signing.xcconfig
 vendor/
 apps/ios/Clawdbot.xcodeproj/
 apps/ios/Clawdbot.xcodeproj/**
@@ -88,6 +86,4 @@ USER.md
 !.agent/workflows/
 /local/
 package-lock.json
-
-# Local iOS signing overrides
-apps/ios/LocalSigning.xcconfig
+openclaw-*.log


### PR DESCRIPTION
## Problem

When a mutating tool (exec, message, etc.) fails with a recoverable error (missing params, invalid input), the agent typically handles it — retrying, working around, or explaining in its reply. Previously, these errors were **always** surfaced as ⚠️ warnings to the user, even when the agent already addressed the situation. This leads to confusing duplicate error messages in the chat.

**Example:** Agent calls `message(action=react)` without a `messageId`, gets an error, then explains in its reply. The user sees both the agent's explanation AND a raw `⚠️ ✉️ Message: react · 💪 failed: messageId required` line.

## Fix

For mutating tool errors, check if the error is recoverable (contains keywords like `required`, `missing`, `invalid`, etc.) AND the agent already produced a user-facing reply. If both are true, suppress the ⚠️ warning — the agent handled it.

Non-recoverable errors (timeouts, connection failures, etc.) still **always** surface for safety.

Also: `suppressToolErrors` config is now respected for all tool types. Previously, mutating tools bypassed this setting entirely.

## Changes

- `src/agents/pi-embedded-runner/run/payloads.ts` — Updated `shouldShowToolErrorWarning` logic
- `src/agents/pi-embedded-runner/run/payloads.e2e.test.ts` — Updated tests to match new behavior, added test for non-recoverable mutating errors with assistant reply

## Risk

Low. Only suppresses errors the agent already handled. Non-recoverable and unhandled errors still surface.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Improved error handling by suppressing recoverable mutating tool errors when the agent has already provided a user-facing reply, eliminating duplicate error messages in chat. The fix distinguishes between recoverable errors (missing/invalid parameters) and non-recoverable errors (timeouts, connection failures), with only the former being suppressed when the agent handled them. Additionally, the `suppressToolErrors` config now properly applies to all tool types, including mutating tools which previously bypassed this setting entirely.

Key changes:
- Modified `shouldShowToolErrorWarning` to check if errors are recoverable AND agent replied before suppressing mutating tool warnings
- Moved `suppressToolErrors` check to apply globally instead of only to non-mutating tools
- Updated tests to reflect new behavior, including new test case for non-recoverable mutating errors with assistant reply
- Minor `.gitignore` addition for log files

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The logic change is well-contained, thoroughly tested, and improves user experience by eliminating confusing duplicate error messages. The fix maintains safety by always surfacing non-recoverable errors and unhandled errors. The test coverage is comprehensive with multiple test cases covering the new behavior including edge cases for recoverable vs non-recoverable errors with/without assistant replies.
- No files require special attention

<sub>Last reviewed commit: 0e679b8</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->