### PR TITLE
Slack: expand advanced modal controls payloads and confirms

### DIFF
--- a/src/slack/monitor/events/interactions.ts
+++ b/src/slack/monitor/events/interactions.ts
@@ -580,20 +580,18 @@ export function registerSlackInteractionEvents(params: { ctx: SlackMonitorContex
     },
   );
 
-  const viewClosed = (
-    ctx.app as unknown as {
-      viewClosed?: (
-        matcher: RegExp,
-        handler: (args: { ack: () => Promise<void>; body: unknown }) => Promise<void>,
-      ) => void;
-    }
-  ).viewClosed;
-  if (typeof viewClosed !== "function") {
+  const appWithViewClosed = ctx.app as unknown as {
+    viewClosed?: (
+      matcher: RegExp,
+      handler: (args: { ack: () => Promise<void>; body: unknown }) => Promise<void>,
+    ) => void;
+  };
+  if (typeof appWithViewClosed.viewClosed !== "function") {
     return;
   }
 
   // Handle modal close events so agent workflows can react to cancelled forms.
-  viewClosed(
+  appWithViewClosed.viewClosed(
     new RegExp(`^${OPENCLAW_ACTION_PREFIX}`),
     async ({ ack, body }: { ack: () => Promise<void>; body: unknown }) => {
       await ack();


### PR DESCRIPTION
## Summary
Delivers an advanced modal-controls bundle by adding richer structured select payloads and native confirm dialogs for slash arg menus.

- add structured selection arrays in interaction payloads:
  - `selectedUsers`
  - `selectedChannels`
  - `selectedConversations`
- keep existing unified `selectedValues` while preserving per-entity detail
- add native Slack `confirm` dialogs to slash arg menu elements:
  - `button`
  - `overflow`
  - `static_select`
- extend interactions/slash tests to validate both structured payloads and confirm-dialog emission

## Scope
- `src/slack/monitor/events/interactions.ts`
- `src/slack/monitor/events/interactions.test.ts`
- `src/slack/monitor/slash.ts`
- `src/slack/monitor/slash.test.ts`

## Validation
- `pnpm test src/slack/monitor/events/interactions.test.ts src/slack/monitor/slash.test.ts`
- `pnpm check`

## Dependency
Depends on:
- #18180 Slack: improve Block Kit interaction handling (foundation)
- #18234 feat(slack): capture Block Kit view_closed lifecycle events
- #18242 feat(slack): use static_select for large slash arg menus
- #18252 feat(slack): route modal interactions with private metadata
- #18257 feat(slack): support Block Kit blocks in sendMessage
- #18262 feat(slack): support Block Kit blocks in editMessage
- #18268 feat(slack): support blocks in plugin send action
- #18278 feat(slack): support blocks in plugin edit action
- #18284 feat(slack): centralize Block Kit input validation
- #18290 fix(slack): add blocks+media send guardrails
- #18372 test(slack): cover sendMessage Block Kit paths
- #18409 refactor(slack): centralize modal private_metadata utilities
- #18413 Slack: expand interaction payload normalization coverage
- #18416 Slack: validate runtime blocks in send and edit paths
- #18423 Slack: dedupe normalized interaction selections
- #18431 Slack: enrich block action context payloads
- #18439 Slack: add overflow menus for slash arg choices
- #18448 Slack: update action rows for select interactions
- #18455 Slack: enrich modal input payload normalization
- #18458 Slack: add header and context blocks to arg menus
- #18465 Slack: show picker values in interaction confirmations

If reviewing before dependencies merge, review tip commit: `4d343a427`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a `this`-binding bug in the `viewClosed` handler registration. The old code destructured `viewClosed` from the type-cast `ctx.app` object, which detaches the method from its receiver and loses the `this` context when invoked. The new code retains a reference to the cast object (`appWithViewClosed`) and calls `viewClosed` as a method on it, preserving the correct `this` binding for the Slack Bolt `App` instance.

- Replaces destructured method extraction with method-call-on-object pattern for `viewClosed`
- No functional changes to handler logic, type signatures, or event routing
- Single focused commit that matches the actual code change

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a small, focused fix that preserves method binding with no behavioral changes.
- The change is a single-commit, minimal refactor that fixes a potential this-binding issue. The transformation is mechanical (destructured method → method call on object), the type signatures are unchanged, and existing tests cover the viewClosed handler registration path. No new logic, no removed safety checks, no risk of regression.
- No files require special attention.

<sub>Last reviewed commit: c028c42</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->