### PR TITLE
feat: add Knowledge Graph tab to Control UI

### DIFF
--- a/src/gateway/server-knowledge-graph.ts
+++ b/src/gateway/server-knowledge-graph.ts
@@ -1,0 +1,62 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import fs from "node:fs";
+import path from "node:path";
+
+const GRAPH_PATH_PREFIX = "/api/knowledge-graph/";
+
+export function handleKnowledgeGraphHttpRequest(
+    req: IncomingMessage,
+    res: ServerResponse,
+    workspaceDir: string | undefined,
+): boolean {
+    if (!workspaceDir) {
+        return false;
+    }
+
+    const urlRaw = req.url;
+    if (!urlRaw || !urlRaw.startsWith(GRAPH_PATH_PREFIX)) {
+        return false;
+    }
+
+    const relPath = urlRaw.slice(GRAPH_PATH_PREFIX.length);
+    if (!relPath || relPath.includes("..") || relPath.startsWith("/") || relPath.includes("\0")) {
+        res.statusCode = 400;
+        res.end("Invalid path");
+        return true;
+    }
+
+    const skillDir = path.join(workspaceDir, "skills", "knowledge-graph");
+    const filePath = path.join(skillDir, relPath);
+
+    if (!fs.existsSync(filePath) || !fs.statSync(filePath).isFile()) {
+        res.statusCode = 404;
+        res.end("Not Found");
+        return true;
+    }
+
+    const ext = path.extname(filePath).toLowerCase();
+    const contentType = contentTypeForExt(ext);
+    res.setHeader("Content-Type", contentType);
+    res.setHeader("Cache-Control", "no-cache");
+    res.end(fs.readFileSync(filePath));
+    return true;
+}
+
+function contentTypeForExt(ext: string): string {
+    switch (ext) {
+        case ".html":
+            return "text/html; charset=utf-8";
+        case ".js":
+            return "application/javascript; charset=utf-8";
+        case ".css":
+            return "text/css; charset=utf-8";
+        case ".json":
+            return "application/json; charset=utf-8";
+        case ".svg":
+            return "image/svg+xml";
+        case ".png":
+            return "image/png";
+        default:
+            return "application/octet-stream";
+    }
+}

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -55,6 +55,7 @@ export async function createGatewayRuntimeState(params: {
   log: { info: (msg: string) => void; warn: (msg: string) => void };
   logHooks: ReturnType<typeof createSubsystemLogger>;
   logPlugins: ReturnType<typeof createSubsystemLogger>;
+  workspaceDir: string;
 }): Promise<{
   canvasHost: CanvasHostHandler | null;
   httpServer: HttpServer;
@@ -131,6 +132,7 @@ export async function createGatewayRuntimeState(params: {
       handleHooksRequest,
       handlePluginRequest,
       resolvedAuth: params.resolvedAuth,
+      workspaceDir: params.workspaceDir,
       rateLimiter: params.rateLimiter,
       tlsOptions: params.gatewayTls?.enabled ? params.gatewayTls.tlsOptions : undefined,
     });

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -204,8 +204,8 @@ export async function startGatewayServer(
     const issues =
       configSnapshot.issues.length > 0
         ? configSnapshot.issues
-            .map((issue) => `${issue.path || "<root>"}: ${issue.message}`)
-            .join("\n")
+          .map((issue) => `${issue.path || "<root>"}: ${issue.message}`)
+          .join("\n")
         : "Unknown validation issue.";
     throw new Error(
       `Invalid config at ${configSnapshot.path}.\n${issues}\nRun "${formatCliCommand("openclaw doctor")}" to repair, then retry.`,
@@ -243,12 +243,12 @@ export async function startGatewayServer(
   const { pluginRegistry, gatewayMethods: baseGatewayMethods } = minimalTestGateway
     ? { pluginRegistry: emptyPluginRegistry, gatewayMethods: baseMethods }
     : loadGatewayPlugins({
-        cfg: cfgAtStart,
-        workspaceDir: defaultWorkspaceDir,
-        log,
-        coreGatewayHandlers,
-        baseMethods,
-      });
+      cfg: cfgAtStart,
+      workspaceDir: defaultWorkspaceDir,
+      log,
+      coreGatewayHandlers,
+      baseMethods,
+    });
   const channelLogs = Object.fromEntries(
     listChannelPlugins().map((plugin) => [plugin.id, logChannels.child(plugin.id)]),
   ) as Record<ChannelId, ReturnType<typeof createSubsystemLogger>>;
@@ -372,6 +372,7 @@ export async function startGatewayServer(
     log,
     logHooks,
     logPlugins,
+    workspaceDir: defaultWorkspaceDir,
   });
   let bonjourStop: (() => Promise<void>) | null = null;
   const nodeRegistry = new NodeRegistry();
@@ -436,22 +437,22 @@ export async function startGatewayServer(
   let skillsRefreshTimer: ReturnType<typeof setTimeout> | null = null;
   const skillsRefreshDelayMs = 30_000;
   const skillsChangeUnsub = minimalTestGateway
-    ? () => {}
+    ? () => { }
     : registerSkillsChangeListener((event) => {
-        if (event.reason === "remote-node") {
-          return;
-        }
-        if (skillsRefreshTimer) {
-          clearTimeout(skillsRefreshTimer);
-        }
-        skillsRefreshTimer = setTimeout(() => {
-          skillsRefreshTimer = null;
-          const latest = loadConfig();
-          void refreshRemoteBinsForConnectedNodes(latest);
-        }, skillsRefreshDelayMs);
-      });
+      if (event.reason === "remote-node") {
+        return;
+      }
+      if (skillsRefreshTimer) {
+        clearTimeout(skillsRefreshTimer);
+      }
+      skillsRefreshTimer = setTimeout(() => {
+        skillsRefreshTimer = null;
+        const latest = loadConfig();
+        void refreshRemoteBinsForConnectedNodes(latest);
+      }, skillsRefreshDelayMs);
+    });
 
-  const noopInterval = () => setInterval(() => {}, 1 << 30);
+  const noopInterval = () => setInterval(() => { }, 1 << 30);
   let tickInterval = noopInterval();
   let healthInterval = noopInterval();
   let dedupeCleanup = noopInterval();
@@ -477,29 +478,29 @@ export async function startGatewayServer(
   const agentUnsub = minimalTestGateway
     ? null
     : onAgentEvent(
-        createAgentEventHandler({
-          broadcast,
-          broadcastToConnIds,
-          nodeSendToSession,
-          agentRunSeq,
-          chatRunState,
-          resolveSessionKeyForRun,
-          clearAgentRunContext,
-          toolEventRecipients,
-        }),
-      );
+      createAgentEventHandler({
+        broadcast,
+        broadcastToConnIds,
+        nodeSendToSession,
+        agentRunSeq,
+        chatRunState,
+        resolveSessionKeyForRun,
+        clearAgentRunContext,
+        toolEventRecipients,
+      }),
+    );
 
   const heartbeatUnsub = minimalTestGateway
     ? null
     : onHeartbeatEvent((evt) => {
-        broadcast("heartbeat", evt, { dropIfSlow: true });
-      });
+      broadcast("heartbeat", evt, { dropIfSlow: true });
+    });
 
   let heartbeatRunner: HeartbeatRunner = minimalTestGateway
     ? {
-        stop: () => {},
-        updateConfig: () => {},
-      }
+      stop: () => { },
+      updateConfig: () => { },
+    }
     : startHeartbeatRunner({ cfg: cfgAtStart });
 
   if (!minimalTestGateway) {
@@ -603,12 +604,12 @@ export async function startGatewayServer(
   const tailscaleCleanup = minimalTestGateway
     ? null
     : await startGatewayTailscaleExposure({
-        tailscaleMode,
-        resetOnExit: tailscaleConfig.resetOnExit,
-        port,
-        controlUiBasePath,
-        logTailscale,
-      });
+      tailscaleMode,
+      resetOnExit: tailscaleConfig.resetOnExit,
+      port,
+      controlUiBasePath,
+      logTailscale,
+    });
 
   let browserControl: Awaited<ReturnType<typeof startBrowserControlServerIfEnabled>> = null;
   if (!minimalTestGateway) {
@@ -636,47 +637,47 @@ export async function startGatewayServer(
   }
 
   const configReloader = minimalTestGateway
-    ? { stop: async () => {} }
+    ? { stop: async () => { } }
     : (() => {
-        const { applyHotReload, requestGatewayRestart } = createGatewayReloadHandlers({
-          deps,
-          broadcast,
-          getState: () => ({
-            hooksConfig,
-            heartbeatRunner,
-            cronState,
-            browserControl,
-          }),
-          setState: (nextState) => {
-            hooksConfig = nextState.hooksConfig;
-            heartbeatRunner = nextState.heartbeatRunner;
-            cronState = nextState.cronState;
-            cron = cronState.cron;
-            cronStorePath = cronState.storePath;
-            browserControl = nextState.browserControl;
-          },
-          startChannel,
-          stopChannel,
-          logHooks,
-          logBrowser,
-          logChannels,
-          logCron,
-          logReload,
-        });
+      const { applyHotReload, requestGatewayRestart } = createGatewayReloadHandlers({
+        deps,
+        broadcast,
+        getState: () => ({
+          hooksConfig,
+          heartbeatRunner,
+          cronState,
+          browserControl,
+        }),
+        setState: (nextState) => {
+          hooksConfig = nextState.hooksConfig;
+          heartbeatRunner = nextState.heartbeatRunner;
+          cronState = nextState.cronState;
+          cron = cronState.cron;
+          cronStorePath = cronState.storePath;
+          browserControl = nextState.browserControl;
+        },
+        startChannel,
+        stopChannel,
+        logHooks,
+        logBrowser,
+        logChannels,
+        logCron,
+        logReload,
+      });
 
-        return startGatewayConfigReloader({
-          initialConfig: cfgAtStart,
-          readSnapshot: readConfigFileSnapshot,
-          onHotReload: applyHotReload,
-          onRestart: requestGatewayRestart,
-          log: {
-            info: (msg) => logReload.info(msg),
-            warn: (msg) => logReload.warn(msg),
-            error: (msg) => logReload.error(msg),
-          },
-          watchPath: CONFIG_PATH,
-        });
-      })();
+      return startGatewayConfigReloader({
+        initialConfig: cfgAtStart,
+        readSnapshot: readConfigFileSnapshot,
+        onHotReload: applyHotReload,
+        onRestart: requestGatewayRestart,
+        log: {
+          info: (msg) => logReload.info(msg),
+          warn: (msg) => logReload.warn(msg),
+          error: (msg) => logReload.error(msg),
+        },
+        watchPath: CONFIG_PATH,
+      });
+    })();
 
   const close = createGatewayCloseHandler({
     bonjourStop,

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -67,6 +67,7 @@ import { renderNodes } from "./views/nodes.ts";
 import { renderOverview } from "./views/overview.ts";
 import { renderSessions } from "./views/sessions.ts";
 import { renderSkills } from "./views/skills.ts";
+import { renderGraph } from "./views/graph.ts";
 
 const AVATAR_DATA_RE = /^data:/i;
 const AVATAR_HTTP_RE = /^https?:\/\//i;
@@ -113,10 +114,10 @@ export function renderApp(state: AppViewState) {
           <button
             class="nav-collapse-toggle"
             @click=${() =>
-              state.applySettings({
-                ...state.settings,
-                navCollapsed: !state.settings.navCollapsed,
-              })}
+      state.applySettings({
+        ...state.settings,
+        navCollapsed: !state.settings.navCollapsed,
+      })}
             title="${state.settings.navCollapsed ? "Expand sidebar" : "Collapse sidebar"}"
             aria-label="${state.settings.navCollapsed ? "Expand sidebar" : "Collapse sidebar"}"
           >
@@ -143,20 +144,20 @@ export function renderApp(state: AppViewState) {
       </header>
       <aside class="nav ${state.settings.navCollapsed ? "nav--collapsed" : ""}">
         ${TAB_GROUPS.map((group) => {
-          const isGroupCollapsed = state.settings.navGroupsCollapsed[group.label] ?? false;
-          const hasActiveTab = group.tabs.some((tab) => tab === state.tab);
-          return html`
+        const isGroupCollapsed = state.settings.navGroupsCollapsed[group.label] ?? false;
+        const hasActiveTab = group.tabs.some((tab) => tab === state.tab);
+        return html`
             <div class="nav-group ${isGroupCollapsed && !hasActiveTab ? "nav-group--collapsed" : ""}">
               <button
                 class="nav-label"
                 @click=${() => {
-                  const next = { ...state.settings.navGroupsCollapsed };
-                  next[group.label] = !isGroupCollapsed;
-                  state.applySettings({
-                    ...state.settings,
-                    navGroupsCollapsed: next,
-                  });
-                }}
+            const next = { ...state.settings.navGroupsCollapsed };
+            next[group.label] = !isGroupCollapsed;
+            state.applySettings({
+              ...state.settings,
+              navGroupsCollapsed: next,
+            });
+          }}
                 aria-expanded=${!isGroupCollapsed}
               >
                 <span class="nav-label__text">${group.label}</span>
@@ -167,7 +168,7 @@ export function renderApp(state: AppViewState) {
               </div>
             </div>
           `;
-        })}
+      })}
         <div class="nav-group nav-group--links">
           <div class="nav-label nav-label--static">
             <span class="nav-label__text">Resources</span>
@@ -198,752 +199,747 @@ export function renderApp(state: AppViewState) {
           </div>
         </section>
 
-        ${
-          state.tab === "overview"
-            ? renderOverview({
-                connected: state.connected,
-                hello: state.hello,
-                settings: state.settings,
-                password: state.password,
-                lastError: state.lastError,
-                presenceCount,
-                sessionsCount,
-                cronEnabled: state.cronStatus?.enabled ?? null,
-                cronNext,
-                lastChannelsRefresh: state.channelsLastSuccess,
-                onSettingsChange: (next) => state.applySettings(next),
-                onPasswordChange: (next) => (state.password = next),
-                onSessionKeyChange: (next) => {
-                  state.sessionKey = next;
-                  state.chatMessage = "";
-                  state.resetToolStream();
-                  state.applySettings({
-                    ...state.settings,
-                    sessionKey: next,
-                    lastActiveSessionKey: next,
-                  });
-                  void state.loadAssistantIdentity();
-                },
-                onConnect: () => state.connect(),
-                onRefresh: () => state.loadOverview(),
-              })
-            : nothing
-        }
+        ${state.tab === "overview"
+      ? renderOverview({
+        connected: state.connected,
+        hello: state.hello,
+        settings: state.settings,
+        password: state.password,
+        lastError: state.lastError,
+        presenceCount,
+        sessionsCount,
+        cronEnabled: state.cronStatus?.enabled ?? null,
+        cronNext,
+        lastChannelsRefresh: state.channelsLastSuccess,
+        onSettingsChange: (next) => state.applySettings(next),
+        onPasswordChange: (next) => (state.password = next),
+        onSessionKeyChange: (next) => {
+          state.sessionKey = next;
+          state.chatMessage = "";
+          state.resetToolStream();
+          state.applySettings({
+            ...state.settings,
+            sessionKey: next,
+            lastActiveSessionKey: next,
+          });
+          void state.loadAssistantIdentity();
+        },
+        onConnect: () => state.connect(),
+        onRefresh: () => state.loadOverview(),
+      })
+      : nothing
+    }
 
-        ${
-          state.tab === "channels"
-            ? renderChannels({
-                connected: state.connected,
-                loading: state.channelsLoading,
-                snapshot: state.channelsSnapshot,
-                lastError: state.channelsError,
-                lastSuccessAt: state.channelsLastSuccess,
-                whatsappMessage: state.whatsappLoginMessage,
-                whatsappQrDataUrl: state.whatsappLoginQrDataUrl,
-                whatsappConnected: state.whatsappLoginConnected,
-                whatsappBusy: state.whatsappBusy,
-                configSchema: state.configSchema,
-                configSchemaLoading: state.configSchemaLoading,
-                configForm: state.configForm,
-                configUiHints: state.configUiHints,
-                configSaving: state.configSaving,
-                configFormDirty: state.configFormDirty,
-                nostrProfileFormState: state.nostrProfileFormState,
-                nostrProfileAccountId: state.nostrProfileAccountId,
-                onRefresh: (probe) => loadChannels(state, probe),
-                onWhatsAppStart: (force) => state.handleWhatsAppStart(force),
-                onWhatsAppWait: () => state.handleWhatsAppWait(),
-                onWhatsAppLogout: () => state.handleWhatsAppLogout(),
-                onConfigPatch: (path, value) => updateConfigFormValue(state, path, value),
-                onConfigSave: () => state.handleChannelConfigSave(),
-                onConfigReload: () => state.handleChannelConfigReload(),
-                onNostrProfileEdit: (accountId, profile) =>
-                  state.handleNostrProfileEdit(accountId, profile),
-                onNostrProfileCancel: () => state.handleNostrProfileCancel(),
-                onNostrProfileFieldChange: (field, value) =>
-                  state.handleNostrProfileFieldChange(field, value),
-                onNostrProfileSave: () => state.handleNostrProfileSave(),
-                onNostrProfileImport: () => state.handleNostrProfileImport(),
-                onNostrProfileToggleAdvanced: () => state.handleNostrProfileToggleAdvanced(),
-              })
-            : nothing
-        }
+        ${state.tab === "graph"
+      ? renderGraph({
+        basePath: state.basePath ?? "",
+      })
+      : nothing
+    }
 
-        ${
-          state.tab === "instances"
-            ? renderInstances({
-                loading: state.presenceLoading,
-                entries: state.presenceEntries,
-                lastError: state.presenceError,
-                statusMessage: state.presenceStatus,
-                onRefresh: () => loadPresence(state),
-              })
-            : nothing
-        }
+        ${state.tab === "channels"
+      ? renderChannels({
+        connected: state.connected,
+        loading: state.channelsLoading,
+        snapshot: state.channelsSnapshot,
+        lastError: state.channelsError,
+        lastSuccessAt: state.channelsLastSuccess,
+        whatsappMessage: state.whatsappLoginMessage,
+        whatsappQrDataUrl: state.whatsappLoginQrDataUrl,
+        whatsappConnected: state.whatsappLoginConnected,
+        whatsappBusy: state.whatsappBusy,
+        configSchema: state.configSchema,
+        configSchemaLoading: state.configSchemaLoading,
+        configForm: state.configForm,
+        configUiHints: state.configUiHints,
+        configSaving: state.configSaving,
+        configFormDirty: state.configFormDirty,
+        nostrProfileFormState: state.nostrProfileFormState,
+        nostrProfileAccountId: state.nostrProfileAccountId,
+        onRefresh: (probe) => loadChannels(state, probe),
+        onWhatsAppStart: (force) => state.handleWhatsAppStart(force),
+        onWhatsAppWait: () => state.handleWhatsAppWait(),
+        onWhatsAppLogout: () => state.handleWhatsAppLogout(),
+        onConfigPatch: (path, value) => updateConfigFormValue(state, path, value),
+        onConfigSave: () => state.handleChannelConfigSave(),
+        onConfigReload: () => state.handleChannelConfigReload(),
+        onNostrProfileEdit: (accountId, profile) =>
+          state.handleNostrProfileEdit(accountId, profile),
+        onNostrProfileCancel: () => state.handleNostrProfileCancel(),
+        onNostrProfileFieldChange: (field, value) =>
+          state.handleNostrProfileFieldChange(field, value),
+        onNostrProfileSave: () => state.handleNostrProfileSave(),
+        onNostrProfileImport: () => state.handleNostrProfileImport(),
+        onNostrProfileToggleAdvanced: () => state.handleNostrProfileToggleAdvanced(),
+      })
+      : nothing
+    }
 
-        ${
-          state.tab === "sessions"
-            ? renderSessions({
-                loading: state.sessionsLoading,
-                result: state.sessionsResult,
-                error: state.sessionsError,
-                activeMinutes: state.sessionsFilterActive,
-                limit: state.sessionsFilterLimit,
-                includeGlobal: state.sessionsIncludeGlobal,
-                includeUnknown: state.sessionsIncludeUnknown,
-                basePath: state.basePath,
-                onFiltersChange: (next) => {
-                  state.sessionsFilterActive = next.activeMinutes;
-                  state.sessionsFilterLimit = next.limit;
-                  state.sessionsIncludeGlobal = next.includeGlobal;
-                  state.sessionsIncludeUnknown = next.includeUnknown;
-                },
-                onRefresh: () => loadSessions(state),
-                onPatch: (key, patch) => patchSession(state, key, patch),
-                onDelete: (key) => deleteSession(state, key),
-              })
-            : nothing
-        }
+        ${state.tab === "instances"
+      ? renderInstances({
+        loading: state.presenceLoading,
+        entries: state.presenceEntries,
+        lastError: state.presenceError,
+        statusMessage: state.presenceStatus,
+        onRefresh: () => loadPresence(state),
+      })
+      : nothing
+    }
+
+        ${state.tab === "sessions"
+      ? renderSessions({
+        loading: state.sessionsLoading,
+        result: state.sessionsResult,
+        error: state.sessionsError,
+        activeMinutes: state.sessionsFilterActive,
+        limit: state.sessionsFilterLimit,
+        includeGlobal: state.sessionsIncludeGlobal,
+        includeUnknown: state.sessionsIncludeUnknown,
+        basePath: state.basePath,
+        onFiltersChange: (next) => {
+          state.sessionsFilterActive = next.activeMinutes;
+          state.sessionsFilterLimit = next.limit;
+          state.sessionsIncludeGlobal = next.includeGlobal;
+          state.sessionsIncludeUnknown = next.includeUnknown;
+        },
+        onRefresh: () => loadSessions(state),
+        onPatch: (key, patch) => patchSession(state, key, patch),
+        onDelete: (key) => deleteSession(state, key),
+      })
+      : nothing
+    }
 
         ${renderUsageTab(state)}
 
-        ${
-          state.tab === "cron"
-            ? renderCron({
-                basePath: state.basePath,
-                loading: state.cronLoading,
-                status: state.cronStatus,
-                jobs: state.cronJobs,
-                error: state.cronError,
-                busy: state.cronBusy,
-                form: state.cronForm,
-                channels: state.channelsSnapshot?.channelMeta?.length
-                  ? state.channelsSnapshot.channelMeta.map((entry) => entry.id)
-                  : (state.channelsSnapshot?.channelOrder ?? []),
-                channelLabels: state.channelsSnapshot?.channelLabels ?? {},
-                channelMeta: state.channelsSnapshot?.channelMeta ?? [],
-                runsJobId: state.cronRunsJobId,
-                runs: state.cronRuns,
-                onFormChange: (patch) =>
-                  (state.cronForm = normalizeCronFormState({ ...state.cronForm, ...patch })),
-                onRefresh: () => state.loadCron(),
-                onAdd: () => addCronJob(state),
-                onToggle: (job, enabled) => toggleCronJob(state, job, enabled),
-                onRun: (job) => runCronJob(state, job),
-                onRemove: (job) => removeCronJob(state, job),
-                onLoadRuns: (jobId) => loadCronRuns(state, jobId),
-              })
-            : nothing
-        }
+        ${state.tab === "cron"
+      ? renderCron({
+        basePath: state.basePath,
+        loading: state.cronLoading,
+        status: state.cronStatus,
+        jobs: state.cronJobs,
+        error: state.cronError,
+        busy: state.cronBusy,
+        form: state.cronForm,
+        channels: state.channelsSnapshot?.channelMeta?.length
+          ? state.channelsSnapshot.channelMeta.map((entry) => entry.id)
+          : (state.channelsSnapshot?.channelOrder ?? []),
+        channelLabels: state.channelsSnapshot?.channelLabels ?? {},
+        channelMeta: state.channelsSnapshot?.channelMeta ?? [],
+        runsJobId: state.cronRunsJobId,
+        runs: state.cronRuns,
+        onFormChange: (patch) =>
+          (state.cronForm = normalizeCronFormState({ ...state.cronForm, ...patch })),
+        onRefresh: () => state.loadCron(),
+        onAdd: () => addCronJob(state),
+        onToggle: (job, enabled) => toggleCronJob(state, job, enabled),
+        onRun: (job) => runCronJob(state, job),
+        onRemove: (job) => removeCronJob(state, job),
+        onLoadRuns: (jobId) => loadCronRuns(state, jobId),
+      })
+      : nothing
+    }
 
-        ${
-          state.tab === "agents"
-            ? renderAgents({
-                loading: state.agentsLoading,
-                error: state.agentsError,
-                agentsList: state.agentsList,
-                selectedAgentId: resolvedAgentId,
-                activePanel: state.agentsPanel,
-                configForm: configValue,
-                configLoading: state.configLoading,
-                configSaving: state.configSaving,
-                configDirty: state.configFormDirty,
-                channelsLoading: state.channelsLoading,
-                channelsError: state.channelsError,
-                channelsSnapshot: state.channelsSnapshot,
-                channelsLastSuccess: state.channelsLastSuccess,
-                cronLoading: state.cronLoading,
-                cronStatus: state.cronStatus,
-                cronJobs: state.cronJobs,
-                cronError: state.cronError,
-                agentFilesLoading: state.agentFilesLoading,
-                agentFilesError: state.agentFilesError,
-                agentFilesList: state.agentFilesList,
-                agentFileActive: state.agentFileActive,
-                agentFileContents: state.agentFileContents,
-                agentFileDrafts: state.agentFileDrafts,
-                agentFileSaving: state.agentFileSaving,
-                agentIdentityLoading: state.agentIdentityLoading,
-                agentIdentityError: state.agentIdentityError,
-                agentIdentityById: state.agentIdentityById,
-                agentSkillsLoading: state.agentSkillsLoading,
-                agentSkillsReport: state.agentSkillsReport,
-                agentSkillsError: state.agentSkillsError,
-                agentSkillsAgentId: state.agentSkillsAgentId,
-                skillsFilter: state.skillsFilter,
-                onRefresh: async () => {
-                  await loadAgents(state);
-                  const agentIds = state.agentsList?.agents?.map((entry) => entry.id) ?? [];
-                  if (agentIds.length > 0) {
-                    void loadAgentIdentities(state, agentIds);
-                  }
-                },
-                onSelectAgent: (agentId) => {
-                  if (state.agentsSelectedId === agentId) {
-                    return;
-                  }
-                  state.agentsSelectedId = agentId;
-                  state.agentFilesList = null;
-                  state.agentFilesError = null;
-                  state.agentFilesLoading = false;
-                  state.agentFileActive = null;
-                  state.agentFileContents = {};
-                  state.agentFileDrafts = {};
-                  state.agentSkillsReport = null;
-                  state.agentSkillsError = null;
-                  state.agentSkillsAgentId = null;
-                  void loadAgentIdentity(state, agentId);
-                  if (state.agentsPanel === "files") {
-                    void loadAgentFiles(state, agentId);
-                  }
-                  if (state.agentsPanel === "skills") {
-                    void loadAgentSkills(state, agentId);
-                  }
-                },
-                onSelectPanel: (panel) => {
-                  state.agentsPanel = panel;
-                  if (panel === "files" && resolvedAgentId) {
-                    if (state.agentFilesList?.agentId !== resolvedAgentId) {
-                      state.agentFilesList = null;
-                      state.agentFilesError = null;
-                      state.agentFileActive = null;
-                      state.agentFileContents = {};
-                      state.agentFileDrafts = {};
-                      void loadAgentFiles(state, resolvedAgentId);
-                    }
-                  }
-                  if (panel === "skills") {
-                    if (resolvedAgentId) {
-                      void loadAgentSkills(state, resolvedAgentId);
-                    }
-                  }
-                  if (panel === "channels") {
-                    void loadChannels(state, false);
-                  }
-                  if (panel === "cron") {
-                    void state.loadCron();
-                  }
-                },
-                onLoadFiles: (agentId) => loadAgentFiles(state, agentId),
-                onSelectFile: (name) => {
-                  state.agentFileActive = name;
-                  if (!resolvedAgentId) {
-                    return;
-                  }
-                  void loadAgentFileContent(state, resolvedAgentId, name);
-                },
-                onFileDraftChange: (name, content) => {
-                  state.agentFileDrafts = { ...state.agentFileDrafts, [name]: content };
-                },
-                onFileReset: (name) => {
-                  const base = state.agentFileContents[name] ?? "";
-                  state.agentFileDrafts = { ...state.agentFileDrafts, [name]: base };
-                },
-                onFileSave: (name) => {
-                  if (!resolvedAgentId) {
-                    return;
-                  }
-                  const content =
-                    state.agentFileDrafts[name] ?? state.agentFileContents[name] ?? "";
-                  void saveAgentFile(state, resolvedAgentId, name, content);
-                },
-                onToolsProfileChange: (agentId, profile, clearAllow) => {
-                  if (!configValue) {
-                    return;
-                  }
-                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  if (!Array.isArray(list)) {
-                    return;
-                  }
-                  const index = list.findIndex(
-                    (entry) =>
-                      entry &&
-                      typeof entry === "object" &&
-                      "id" in entry &&
-                      (entry as { id?: string }).id === agentId,
-                  );
-                  if (index < 0) {
-                    return;
-                  }
-                  const basePath = ["agents", "list", index, "tools"];
-                  if (profile) {
-                    updateConfigFormValue(state, [...basePath, "profile"], profile);
-                  } else {
-                    removeConfigFormValue(state, [...basePath, "profile"]);
-                  }
-                  if (clearAllow) {
-                    removeConfigFormValue(state, [...basePath, "allow"]);
-                  }
-                },
-                onToolsOverridesChange: (agentId, alsoAllow, deny) => {
-                  if (!configValue) {
-                    return;
-                  }
-                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  if (!Array.isArray(list)) {
-                    return;
-                  }
-                  const index = list.findIndex(
-                    (entry) =>
-                      entry &&
-                      typeof entry === "object" &&
-                      "id" in entry &&
-                      (entry as { id?: string }).id === agentId,
-                  );
-                  if (index < 0) {
-                    return;
-                  }
-                  const basePath = ["agents", "list", index, "tools"];
-                  if (alsoAllow.length > 0) {
-                    updateConfigFormValue(state, [...basePath, "alsoAllow"], alsoAllow);
-                  } else {
-                    removeConfigFormValue(state, [...basePath, "alsoAllow"]);
-                  }
-                  if (deny.length > 0) {
-                    updateConfigFormValue(state, [...basePath, "deny"], deny);
-                  } else {
-                    removeConfigFormValue(state, [...basePath, "deny"]);
-                  }
-                },
-                onConfigReload: () => loadConfig(state),
-                onConfigSave: () => saveConfig(state),
-                onChannelsRefresh: () => loadChannels(state, false),
-                onCronRefresh: () => state.loadCron(),
-                onSkillsFilterChange: (next) => (state.skillsFilter = next),
-                onSkillsRefresh: () => {
-                  if (resolvedAgentId) {
-                    void loadAgentSkills(state, resolvedAgentId);
-                  }
-                },
-                onAgentSkillToggle: (agentId, skillName, enabled) => {
-                  if (!configValue) {
-                    return;
-                  }
-                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  if (!Array.isArray(list)) {
-                    return;
-                  }
-                  const index = list.findIndex(
-                    (entry) =>
-                      entry &&
-                      typeof entry === "object" &&
-                      "id" in entry &&
-                      (entry as { id?: string }).id === agentId,
-                  );
-                  if (index < 0) {
-                    return;
-                  }
-                  const entry = list[index] as { skills?: unknown };
-                  const normalizedSkill = skillName.trim();
-                  if (!normalizedSkill) {
-                    return;
-                  }
-                  const allSkills =
-                    state.agentSkillsReport?.skills?.map((skill) => skill.name).filter(Boolean) ??
-                    [];
-                  const existing = Array.isArray(entry.skills)
-                    ? entry.skills.map((name) => String(name).trim()).filter(Boolean)
-                    : undefined;
-                  const base = existing ?? allSkills;
-                  const next = new Set(base);
-                  if (enabled) {
-                    next.add(normalizedSkill);
-                  } else {
-                    next.delete(normalizedSkill);
-                  }
-                  updateConfigFormValue(state, ["agents", "list", index, "skills"], [...next]);
-                },
-                onAgentSkillsClear: (agentId) => {
-                  if (!configValue) {
-                    return;
-                  }
-                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  if (!Array.isArray(list)) {
-                    return;
-                  }
-                  const index = list.findIndex(
-                    (entry) =>
-                      entry &&
-                      typeof entry === "object" &&
-                      "id" in entry &&
-                      (entry as { id?: string }).id === agentId,
-                  );
-                  if (index < 0) {
-                    return;
-                  }
-                  removeConfigFormValue(state, ["agents", "list", index, "skills"]);
-                },
-                onAgentSkillsDisableAll: (agentId) => {
-                  if (!configValue) {
-                    return;
-                  }
-                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  if (!Array.isArray(list)) {
-                    return;
-                  }
-                  const index = list.findIndex(
-                    (entry) =>
-                      entry &&
-                      typeof entry === "object" &&
-                      "id" in entry &&
-                      (entry as { id?: string }).id === agentId,
-                  );
-                  if (index < 0) {
-                    return;
-                  }
-                  updateConfigFormValue(state, ["agents", "list", index, "skills"], []);
-                },
-                onModelChange: (agentId, modelId) => {
-                  if (!configValue) {
-                    return;
-                  }
-                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  if (!Array.isArray(list)) {
-                    return;
-                  }
-                  const index = list.findIndex(
-                    (entry) =>
-                      entry &&
-                      typeof entry === "object" &&
-                      "id" in entry &&
-                      (entry as { id?: string }).id === agentId,
-                  );
-                  if (index < 0) {
-                    return;
-                  }
-                  const basePath = ["agents", "list", index, "model"];
-                  if (!modelId) {
-                    removeConfigFormValue(state, basePath);
-                    return;
-                  }
-                  const entry = list[index] as { model?: unknown };
-                  const existing = entry?.model;
-                  if (existing && typeof existing === "object" && !Array.isArray(existing)) {
-                    const fallbacks = (existing as { fallbacks?: unknown }).fallbacks;
-                    const next = {
-                      primary: modelId,
-                      ...(Array.isArray(fallbacks) ? { fallbacks } : {}),
-                    };
-                    updateConfigFormValue(state, basePath, next);
-                  } else {
-                    updateConfigFormValue(state, basePath, modelId);
-                  }
-                },
-                onModelFallbacksChange: (agentId, fallbacks) => {
-                  if (!configValue) {
-                    return;
-                  }
-                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  if (!Array.isArray(list)) {
-                    return;
-                  }
-                  const index = list.findIndex(
-                    (entry) =>
-                      entry &&
-                      typeof entry === "object" &&
-                      "id" in entry &&
-                      (entry as { id?: string }).id === agentId,
-                  );
-                  if (index < 0) {
-                    return;
-                  }
-                  const basePath = ["agents", "list", index, "model"];
-                  const entry = list[index] as { model?: unknown };
-                  const normalized = fallbacks.map((name) => name.trim()).filter(Boolean);
-                  const existing = entry.model;
-                  const resolvePrimary = () => {
-                    if (typeof existing === "string") {
-                      return existing.trim() || null;
-                    }
-                    if (existing && typeof existing === "object" && !Array.isArray(existing)) {
-                      const primary = (existing as { primary?: unknown }).primary;
-                      if (typeof primary === "string") {
-                        const trimmed = primary.trim();
-                        return trimmed || null;
-                      }
-                    }
-                    return null;
-                  };
-                  const primary = resolvePrimary();
-                  if (normalized.length === 0) {
-                    if (primary) {
-                      updateConfigFormValue(state, basePath, primary);
-                    } else {
-                      removeConfigFormValue(state, basePath);
-                    }
-                    return;
-                  }
-                  const next = primary
-                    ? { primary, fallbacks: normalized }
-                    : { fallbacks: normalized };
-                  updateConfigFormValue(state, basePath, next);
-                },
-              })
-            : nothing
-        }
+        ${state.tab === "agents"
+      ? renderAgents({
+        loading: state.agentsLoading,
+        error: state.agentsError,
+        agentsList: state.agentsList,
+        selectedAgentId: resolvedAgentId,
+        activePanel: state.agentsPanel,
+        configForm: configValue,
+        configLoading: state.configLoading,
+        configSaving: state.configSaving,
+        configDirty: state.configFormDirty,
+        channelsLoading: state.channelsLoading,
+        channelsError: state.channelsError,
+        channelsSnapshot: state.channelsSnapshot,
+        channelsLastSuccess: state.channelsLastSuccess,
+        cronLoading: state.cronLoading,
+        cronStatus: state.cronStatus,
+        cronJobs: state.cronJobs,
+        cronError: state.cronError,
+        agentFilesLoading: state.agentFilesLoading,
+        agentFilesError: state.agentFilesError,
+        agentFilesList: state.agentFilesList,
+        agentFileActive: state.agentFileActive,
+        agentFileContents: state.agentFileContents,
+        agentFileDrafts: state.agentFileDrafts,
+        agentFileSaving: state.agentFileSaving,
+        agentIdentityLoading: state.agentIdentityLoading,
+        agentIdentityError: state.agentIdentityError,
+        agentIdentityById: state.agentIdentityById,
+        agentSkillsLoading: state.agentSkillsLoading,
+        agentSkillsReport: state.agentSkillsReport,
+        agentSkillsError: state.agentSkillsError,
+        agentSkillsAgentId: state.agentSkillsAgentId,
+        skillsFilter: state.skillsFilter,
+        onRefresh: async () => {
+          await loadAgents(state);
+          const agentIds = state.agentsList?.agents?.map((entry) => entry.id) ?? [];
+          if (agentIds.length > 0) {
+            void loadAgentIdentities(state, agentIds);
+          }
+        },
+        onSelectAgent: (agentId) => {
+          if (state.agentsSelectedId === agentId) {
+            return;
+          }
+          state.agentsSelectedId = agentId;
+          state.agentFilesList = null;
+          state.agentFilesError = null;
+          state.agentFilesLoading = false;
+          state.agentFileActive = null;
+          state.agentFileContents = {};
+          state.agentFileDrafts = {};
+          state.agentSkillsReport = null;
+          state.agentSkillsError = null;
+          state.agentSkillsAgentId = null;
+          void loadAgentIdentity(state, agentId);
+          if (state.agentsPanel === "files") {
+            void loadAgentFiles(state, agentId);
+          }
+          if (state.agentsPanel === "skills") {
+            void loadAgentSkills(state, agentId);
+          }
+        },
+        onSelectPanel: (panel) => {
+          state.agentsPanel = panel;
+          if (panel === "files" && resolvedAgentId) {
+            if (state.agentFilesList?.agentId !== resolvedAgentId) {
+              state.agentFilesList = null;
+              state.agentFilesError = null;
+              state.agentFileActive = null;
+              state.agentFileContents = {};
+              state.agentFileDrafts = {};
+              void loadAgentFiles(state, resolvedAgentId);
+            }
+          }
+          if (panel === "skills") {
+            if (resolvedAgentId) {
+              void loadAgentSkills(state, resolvedAgentId);
+            }
+          }
+          if (panel === "channels") {
+            void loadChannels(state, false);
+          }
+          if (panel === "cron") {
+            void state.loadCron();
+          }
+        },
+        onLoadFiles: (agentId) => loadAgentFiles(state, agentId),
+        onSelectFile: (name) => {
+          state.agentFileActive = name;
+          if (!resolvedAgentId) {
+            return;
+          }
+          void loadAgentFileContent(state, resolvedAgentId, name);
+        },
+        onFileDraftChange: (name, content) => {
+          state.agentFileDrafts = { ...state.agentFileDrafts, [name]: content };
+        },
+        onFileReset: (name) => {
+          const base = state.agentFileContents[name] ?? "";
+          state.agentFileDrafts = { ...state.agentFileDrafts, [name]: base };
+        },
+        onFileSave: (name) => {
+          if (!resolvedAgentId) {
+            return;
+          }
+          const content =
+            state.agentFileDrafts[name] ?? state.agentFileContents[name] ?? "";
+          void saveAgentFile(state, resolvedAgentId, name, content);
+        },
+        onToolsProfileChange: (agentId, profile, clearAllow) => {
+          if (!configValue) {
+            return;
+          }
+          const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
+          if (!Array.isArray(list)) {
+            return;
+          }
+          const index = list.findIndex(
+            (entry) =>
+              entry &&
+              typeof entry === "object" &&
+              "id" in entry &&
+              (entry as { id?: string }).id === agentId,
+          );
+          if (index < 0) {
+            return;
+          }
+          const basePath = ["agents", "list", index, "tools"];
+          if (profile) {
+            updateConfigFormValue(state, [...basePath, "profile"], profile);
+          } else {
+            removeConfigFormValue(state, [...basePath, "profile"]);
+          }
+          if (clearAllow) {
+            removeConfigFormValue(state, [...basePath, "allow"]);
+          }
+        },
+        onToolsOverridesChange: (agentId, alsoAllow, deny) => {
+          if (!configValue) {
+            return;
+          }
+          const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
+          if (!Array.isArray(list)) {
+            return;
+          }
+          const index = list.findIndex(
+            (entry) =>
+              entry &&
+              typeof entry === "object" &&
+              "id" in entry &&
+              (entry as { id?: string }).id === agentId,
+          );
+          if (index < 0) {
+            return;
+          }
+          const basePath = ["agents", "list", index, "tools"];
+          if (alsoAllow.length > 0) {
+            updateConfigFormValue(state, [...basePath, "alsoAllow"], alsoAllow);
+          } else {
+            removeConfigFormValue(state, [...basePath, "alsoAllow"]);
+          }
+          if (deny.length > 0) {
+            updateConfigFormValue(state, [...basePath, "deny"], deny);
+          } else {
+            removeConfigFormValue(state, [...basePath, "deny"]);
+          }
+        },
+        onConfigReload: () => loadConfig(state),
+        onConfigSave: () => saveConfig(state),
+        onChannelsRefresh: () => loadChannels(state, false),
+        onCronRefresh: () => state.loadCron(),
+        onSkillsFilterChange: (next) => (state.skillsFilter = next),
+        onSkillsRefresh: () => {
+          if (resolvedAgentId) {
+            void loadAgentSkills(state, resolvedAgentId);
+          }
+        },
+        onAgentSkillToggle: (agentId, skillName, enabled) => {
+          if (!configValue) {
+            return;
+          }
+          const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
+          if (!Array.isArray(list)) {
+            return;
+          }
+          const index = list.findIndex(
+            (entry) =>
+              entry &&
+              typeof entry === "object" &&
+              "id" in entry &&
+              (entry as { id?: string }).id === agentId,
+          );
+          if (index < 0) {
+            return;
+          }
+          const entry = list[index] as { skills?: unknown };
+          const normalizedSkill = skillName.trim();
+          if (!normalizedSkill) {
+            return;
+          }
+          const allSkills =
+            state.agentSkillsReport?.skills?.map((skill) => skill.name).filter(Boolean) ??
+            [];
+          const existing = Array.isArray(entry.skills)
+            ? entry.skills.map((name) => String(name).trim()).filter(Boolean)
+            : undefined;
+          const base = existing ?? allSkills;
+          const next = new Set(base);
+          if (enabled) {
+            next.add(normalizedSkill);
+          } else {
+            next.delete(normalizedSkill);
+          }
+          updateConfigFormValue(state, ["agents", "list", index, "skills"], [...next]);
+        },
+        onAgentSkillsClear: (agentId) => {
+          if (!configValue) {
+            return;
+          }
+          const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
+          if (!Array.isArray(list)) {
+            return;
+          }
+          const index = list.findIndex(
+            (entry) =>
+              entry &&
+              typeof entry === "object" &&
+              "id" in entry &&
+              (entry as { id?: string }).id === agentId,
+          );
+          if (index < 0) {
+            return;
+          }
+          removeConfigFormValue(state, ["agents", "list", index, "skills"]);
+        },
+        onAgentSkillsDisableAll: (agentId) => {
+          if (!configValue) {
+            return;
+          }
+          const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
+          if (!Array.isArray(list)) {
+            return;
+          }
+          const index = list.findIndex(
+            (entry) =>
+              entry &&
+              typeof entry === "object" &&
+              "id" in entry &&
+              (entry as { id?: string }).id === agentId,
+          );
+          if (index < 0) {
+            return;
+          }
+          updateConfigFormValue(state, ["agents", "list", index, "skills"], []);
+        },
+        onModelChange: (agentId, modelId) => {
+          if (!configValue) {
+            return;
+          }
+          const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
+          if (!Array.isArray(list)) {
+            return;
+          }
+          const index = list.findIndex(
+            (entry) =>
+              entry &&
+              typeof entry === "object" &&
+              "id" in entry &&
+              (entry as { id?: string }).id === agentId,
+          );
+          if (index < 0) {
+            return;
+          }
+          const basePath = ["agents", "list", index, "model"];
+          if (!modelId) {
+            removeConfigFormValue(state, basePath);
+            return;
+          }
+          const entry = list[index] as { model?: unknown };
+          const existing = entry?.model;
+          if (existing && typeof existing === "object" && !Array.isArray(existing)) {
+            const fallbacks = (existing as { fallbacks?: unknown }).fallbacks;
+            const next = {
+              primary: modelId,
+              ...(Array.isArray(fallbacks) ? { fallbacks } : {}),
+            };
+            updateConfigFormValue(state, basePath, next);
+          } else {
+            updateConfigFormValue(state, basePath, modelId);
+          }
+        },
+        onModelFallbacksChange: (agentId, fallbacks) => {
+          if (!configValue) {
+            return;
+          }
+          const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
+          if (!Array.isArray(list)) {
+            return;
+          }
+          const index = list.findIndex(
+            (entry) =>
+              entry &&
+              typeof entry === "object" &&
+              "id" in entry &&
+              (entry as { id?: string }).id === agentId,
+          );
+          if (index < 0) {
+            return;
+          }
+          const basePath = ["agents", "list", index, "model"];
+          const entry = list[index] as { model?: unknown };
+          const normalized = fallbacks.map((name) => name.trim()).filter(Boolean);
+          const existing = entry.model;
+          const resolvePrimary = () => {
+            if (typeof existing === "string") {
+              return existing.trim() || null;
+            }
+            if (existing && typeof existing === "object" && !Array.isArray(existing)) {
+              const primary = (existing as { primary?: unknown }).primary;
+              if (typeof primary === "string") {
+                const trimmed = primary.trim();
+                return trimmed || null;
+              }
+            }
+            return null;
+          };
+          const primary = resolvePrimary();
+          if (normalized.length === 0) {
+            if (primary) {
+              updateConfigFormValue(state, basePath, primary);
+            } else {
+              removeConfigFormValue(state, basePath);
+            }
+            return;
+          }
+          const next = primary
+            ? { primary, fallbacks: normalized }
+            : { fallbacks: normalized };
+          updateConfigFormValue(state, basePath, next);
+        },
+      })
+      : nothing
+    }
 
-        ${
-          state.tab === "skills"
-            ? renderSkills({
-                loading: state.skillsLoading,
-                report: state.skillsReport,
-                error: state.skillsError,
-                filter: state.skillsFilter,
-                edits: state.skillEdits,
-                messages: state.skillMessages,
-                busyKey: state.skillsBusyKey,
-                onFilterChange: (next) => (state.skillsFilter = next),
-                onRefresh: () => loadSkills(state, { clearMessages: true }),
-                onToggle: (key, enabled) => updateSkillEnabled(state, key, enabled),
-                onEdit: (key, value) => updateSkillEdit(state, key, value),
-                onSaveKey: (key) => saveSkillApiKey(state, key),
-                onInstall: (skillKey, name, installId) =>
-                  installSkill(state, skillKey, name, installId),
-              })
-            : nothing
-        }
+        ${state.tab === "skills"
+      ? renderSkills({
+        loading: state.skillsLoading,
+        report: state.skillsReport,
+        error: state.skillsError,
+        filter: state.skillsFilter,
+        edits: state.skillEdits,
+        messages: state.skillMessages,
+        busyKey: state.skillsBusyKey,
+        onFilterChange: (next) => (state.skillsFilter = next),
+        onRefresh: () => loadSkills(state, { clearMessages: true }),
+        onToggle: (key, enabled) => updateSkillEnabled(state, key, enabled),
+        onEdit: (key, value) => updateSkillEdit(state, key, value),
+        onSaveKey: (key) => saveSkillApiKey(state, key),
+        onInstall: (skillKey, name, installId) =>
+          installSkill(state, skillKey, name, installId),
+      })
+      : nothing
+    }
 
-        ${
-          state.tab === "nodes"
-            ? renderNodes({
-                loading: state.nodesLoading,
-                nodes: state.nodes,
-                devicesLoading: state.devicesLoading,
-                devicesError: state.devicesError,
-                devicesList: state.devicesList,
-                configForm:
-                  state.configForm ??
-                  (state.configSnapshot?.config as Record<string, unknown> | null),
-                configLoading: state.configLoading,
-                configSaving: state.configSaving,
-                configDirty: state.configFormDirty,
-                configFormMode: state.configFormMode,
-                execApprovalsLoading: state.execApprovalsLoading,
-                execApprovalsSaving: state.execApprovalsSaving,
-                execApprovalsDirty: state.execApprovalsDirty,
-                execApprovalsSnapshot: state.execApprovalsSnapshot,
-                execApprovalsForm: state.execApprovalsForm,
-                execApprovalsSelectedAgent: state.execApprovalsSelectedAgent,
-                execApprovalsTarget: state.execApprovalsTarget,
-                execApprovalsTargetNodeId: state.execApprovalsTargetNodeId,
-                onRefresh: () => loadNodes(state),
-                onDevicesRefresh: () => loadDevices(state),
-                onDeviceApprove: (requestId) => approveDevicePairing(state, requestId),
-                onDeviceReject: (requestId) => rejectDevicePairing(state, requestId),
-                onDeviceRotate: (deviceId, role, scopes) =>
-                  rotateDeviceToken(state, { deviceId, role, scopes }),
-                onDeviceRevoke: (deviceId, role) => revokeDeviceToken(state, { deviceId, role }),
-                onLoadConfig: () => loadConfig(state),
-                onLoadExecApprovals: () => {
-                  const target =
-                    state.execApprovalsTarget === "node" && state.execApprovalsTargetNodeId
-                      ? { kind: "node" as const, nodeId: state.execApprovalsTargetNodeId }
-                      : { kind: "gateway" as const };
-                  return loadExecApprovals(state, target);
-                },
-                onBindDefault: (nodeId) => {
-                  if (nodeId) {
-                    updateConfigFormValue(state, ["tools", "exec", "node"], nodeId);
-                  } else {
-                    removeConfigFormValue(state, ["tools", "exec", "node"]);
-                  }
-                },
-                onBindAgent: (agentIndex, nodeId) => {
-                  const basePath = ["agents", "list", agentIndex, "tools", "exec", "node"];
-                  if (nodeId) {
-                    updateConfigFormValue(state, basePath, nodeId);
-                  } else {
-                    removeConfigFormValue(state, basePath);
-                  }
-                },
-                onSaveBindings: () => saveConfig(state),
-                onExecApprovalsTargetChange: (kind, nodeId) => {
-                  state.execApprovalsTarget = kind;
-                  state.execApprovalsTargetNodeId = nodeId;
-                  state.execApprovalsSnapshot = null;
-                  state.execApprovalsForm = null;
-                  state.execApprovalsDirty = false;
-                  state.execApprovalsSelectedAgent = null;
-                },
-                onExecApprovalsSelectAgent: (agentId) => {
-                  state.execApprovalsSelectedAgent = agentId;
-                },
-                onExecApprovalsPatch: (path, value) =>
-                  updateExecApprovalsFormValue(state, path, value),
-                onExecApprovalsRemove: (path) => removeExecApprovalsFormValue(state, path),
-                onSaveExecApprovals: () => {
-                  const target =
-                    state.execApprovalsTarget === "node" && state.execApprovalsTargetNodeId
-                      ? { kind: "node" as const, nodeId: state.execApprovalsTargetNodeId }
-                      : { kind: "gateway" as const };
-                  return saveExecApprovals(state, target);
-                },
-              })
-            : nothing
-        }
+        ${state.tab === "nodes"
+      ? renderNodes({
+        loading: state.nodesLoading,
+        nodes: state.nodes,
+        devicesLoading: state.devicesLoading,
+        devicesError: state.devicesError,
+        devicesList: state.devicesList,
+        configForm:
+          state.configForm ??
+          (state.configSnapshot?.config as Record<string, unknown> | null),
+        configLoading: state.configLoading,
+        configSaving: state.configSaving,
+        configDirty: state.configFormDirty,
+        configFormMode: state.configFormMode,
+        execApprovalsLoading: state.execApprovalsLoading,
+        execApprovalsSaving: state.execApprovalsSaving,
+        execApprovalsDirty: state.execApprovalsDirty,
+        execApprovalsSnapshot: state.execApprovalsSnapshot,
+        execApprovalsForm: state.execApprovalsForm,
+        execApprovalsSelectedAgent: state.execApprovalsSelectedAgent,
+        execApprovalsTarget: state.execApprovalsTarget,
+        execApprovalsTargetNodeId: state.execApprovalsTargetNodeId,
+        onRefresh: () => loadNodes(state),
+        onDevicesRefresh: () => loadDevices(state),
+        onDeviceApprove: (requestId) => approveDevicePairing(state, requestId),
+        onDeviceReject: (requestId) => rejectDevicePairing(state, requestId),
+        onDeviceRotate: (deviceId, role, scopes) =>
+          rotateDeviceToken(state, { deviceId, role, scopes }),
+        onDeviceRevoke: (deviceId, role) => revokeDeviceToken(state, { deviceId, role }),
+        onLoadConfig: () => loadConfig(state),
+        onLoadExecApprovals: () => {
+          const target =
+            state.execApprovalsTarget === "node" && state.execApprovalsTargetNodeId
+              ? { kind: "node" as const, nodeId: state.execApprovalsTargetNodeId }
+              : { kind: "gateway" as const };
+          return loadExecApprovals(state, target);
+        },
+        onBindDefault: (nodeId) => {
+          if (nodeId) {
+            updateConfigFormValue(state, ["tools", "exec", "node"], nodeId);
+          } else {
+            removeConfigFormValue(state, ["tools", "exec", "node"]);
+          }
+        },
+        onBindAgent: (agentIndex, nodeId) => {
+          const basePath = ["agents", "list", agentIndex, "tools", "exec", "node"];
+          if (nodeId) {
+            updateConfigFormValue(state, basePath, nodeId);
+          } else {
+            removeConfigFormValue(state, basePath);
+          }
+        },
+        onSaveBindings: () => saveConfig(state),
+        onExecApprovalsTargetChange: (kind, nodeId) => {
+          state.execApprovalsTarget = kind;
+          state.execApprovalsTargetNodeId = nodeId;
+          state.execApprovalsSnapshot = null;
+          state.execApprovalsForm = null;
+          state.execApprovalsDirty = false;
+          state.execApprovalsSelectedAgent = null;
+        },
+        onExecApprovalsSelectAgent: (agentId) => {
+          state.execApprovalsSelectedAgent = agentId;
+        },
+        onExecApprovalsPatch: (path, value) =>
+          updateExecApprovalsFormValue(state, path, value),
+        onExecApprovalsRemove: (path) => removeExecApprovalsFormValue(state, path),
+        onSaveExecApprovals: () => {
+          const target =
+            state.execApprovalsTarget === "node" && state.execApprovalsTargetNodeId
+              ? { kind: "node" as const, nodeId: state.execApprovalsTargetNodeId }
+              : { kind: "gateway" as const };
+          return saveExecApprovals(state, target);
+        },
+      })
+      : nothing
+    }
 
-        ${
-          state.tab === "chat"
-            ? renderChat({
-                sessionKey: state.sessionKey,
-                onSessionKeyChange: (next) => {
-                  state.sessionKey = next;
-                  state.chatMessage = "";
-                  state.chatAttachments = [];
-                  state.chatStream = null;
-                  state.chatStreamStartedAt = null;
-                  state.chatRunId = null;
-                  state.chatQueue = [];
-                  state.resetToolStream();
-                  state.resetChatScroll();
-                  state.applySettings({
-                    ...state.settings,
-                    sessionKey: next,
-                    lastActiveSessionKey: next,
-                  });
-                  void state.loadAssistantIdentity();
-                  void loadChatHistory(state);
-                  void refreshChatAvatar(state);
-                },
-                thinkingLevel: state.chatThinkingLevel,
-                showThinking,
-                loading: state.chatLoading,
-                sending: state.chatSending,
-                compactionStatus: state.compactionStatus,
-                assistantAvatarUrl: chatAvatarUrl,
-                messages: state.chatMessages,
-                toolMessages: state.chatToolMessages,
-                stream: state.chatStream,
-                streamStartedAt: state.chatStreamStartedAt,
-                draft: state.chatMessage,
-                queue: state.chatQueue,
-                connected: state.connected,
-                canSend: state.connected,
-                disabledReason: chatDisabledReason,
-                error: state.lastError,
-                sessions: state.sessionsResult,
-                focusMode: chatFocus,
-                onRefresh: () => {
-                  state.resetToolStream();
-                  return Promise.all([loadChatHistory(state), refreshChatAvatar(state)]);
-                },
-                onToggleFocusMode: () => {
-                  if (state.onboarding) {
-                    return;
-                  }
-                  state.applySettings({
-                    ...state.settings,
-                    chatFocusMode: !state.settings.chatFocusMode,
-                  });
-                },
-                onChatScroll: (event) => state.handleChatScroll(event),
-                onDraftChange: (next) => (state.chatMessage = next),
-                attachments: state.chatAttachments,
-                onAttachmentsChange: (next) => (state.chatAttachments = next),
-                onSend: () => state.handleSendChat(),
-                canAbort: Boolean(state.chatRunId),
-                onAbort: () => void state.handleAbortChat(),
-                onQueueRemove: (id) => state.removeQueuedMessage(id),
-                onNewSession: () => state.handleSendChat("/new", { restoreDraft: true }),
-                showNewMessages: state.chatNewMessagesBelow && !state.chatManualRefreshInFlight,
-                onScrollToBottom: () => state.scrollToBottom(),
-                // Sidebar props for tool output viewing
-                sidebarOpen: state.sidebarOpen,
-                sidebarContent: state.sidebarContent,
-                sidebarError: state.sidebarError,
-                splitRatio: state.splitRatio,
-                onOpenSidebar: (content: string) => state.handleOpenSidebar(content),
-                onCloseSidebar: () => state.handleCloseSidebar(),
-                onSplitRatioChange: (ratio: number) => state.handleSplitRatioChange(ratio),
-                assistantName: state.assistantName,
-                assistantAvatar: state.assistantAvatar,
-              })
-            : nothing
-        }
+        ${state.tab === "chat"
+      ? renderChat({
+        sessionKey: state.sessionKey,
+        onSessionKeyChange: (next) => {
+          state.sessionKey = next;
+          state.chatMessage = "";
+          state.chatAttachments = [];
+          state.chatStream = null;
+          state.chatStreamStartedAt = null;
+          state.chatRunId = null;
+          state.chatQueue = [];
+          state.resetToolStream();
+          state.resetChatScroll();
+          state.applySettings({
+            ...state.settings,
+            sessionKey: next,
+            lastActiveSessionKey: next,
+          });
+          void state.loadAssistantIdentity();
+          void loadChatHistory(state);
+          void refreshChatAvatar(state);
+        },
+        thinkingLevel: state.chatThinkingLevel,
+        showThinking,
+        loading: state.chatLoading,
+        sending: state.chatSending,
+        compactionStatus: state.compactionStatus,
+        assistantAvatarUrl: chatAvatarUrl,
+        messages: state.chatMessages,
+        toolMessages: state.chatToolMessages,
+        stream: state.chatStream,
+        streamStartedAt: state.chatStreamStartedAt,
+        draft: state.chatMessage,
+        queue: state.chatQueue,
+        connected: state.connected,
+        canSend: state.connected,
+        disabledReason: chatDisabledReason,
+        error: state.lastError,
+        sessions: state.sessionsResult,
+        focusMode: chatFocus,
+        onRefresh: () => {
+          state.resetToolStream();
+          return Promise.all([loadChatHistory(state), refreshChatAvatar(state)]);
+        },
+        onToggleFocusMode: () => {
+          if (state.onboarding) {
+            return;
+          }
+          state.applySettings({
+            ...state.settings,
+            chatFocusMode: !state.settings.chatFocusMode,
+          });
+        },
+        onChatScroll: (event) => state.handleChatScroll(event),
+        onDraftChange: (next) => (state.chatMessage = next),
+        attachments: state.chatAttachments,
+        onAttachmentsChange: (next) => (state.chatAttachments = next),
+        onSend: () => state.handleSendChat(),
+        canAbort: Boolean(state.chatRunId),
+        onAbort: () => void state.handleAbortChat(),
+        onQueueRemove: (id) => state.removeQueuedMessage(id),
+        onNewSession: () => state.handleSendChat("/new", { restoreDraft: true }),
+        showNewMessages: state.chatNewMessagesBelow && !state.chatManualRefreshInFlight,
+        onScrollToBottom: () => state.scrollToBottom(),
+        // Sidebar props for tool output viewing
+        sidebarOpen: state.sidebarOpen,
+        sidebarContent: state.sidebarContent,
+        sidebarError: state.sidebarError,
+        splitRatio: state.splitRatio,
+        onOpenSidebar: (content: string) => state.handleOpenSidebar(content),
+        onCloseSidebar: () => state.handleCloseSidebar(),
+        onSplitRatioChange: (ratio: number) => state.handleSplitRatioChange(ratio),
+        assistantName: state.assistantName,
+        assistantAvatar: state.assistantAvatar,
+      })
+      : nothing
+    }
 
-        ${
-          state.tab === "config"
-            ? renderConfig({
-                raw: state.configRaw,
-                originalRaw: state.configRawOriginal,
-                valid: state.configValid,
-                issues: state.configIssues,
-                loading: state.configLoading,
-                saving: state.configSaving,
-                applying: state.configApplying,
-                updating: state.updateRunning,
-                connected: state.connected,
-                schema: state.configSchema,
-                schemaLoading: state.configSchemaLoading,
-                uiHints: state.configUiHints,
-                formMode: state.configFormMode,
-                formValue: state.configForm,
-                originalValue: state.configFormOriginal,
-                searchQuery: state.configSearchQuery,
-                activeSection: state.configActiveSection,
-                activeSubsection: state.configActiveSubsection,
-                onRawChange: (next) => {
-                  state.configRaw = next;
-                },
-                onFormModeChange: (mode) => (state.configFormMode = mode),
-                onFormPatch: (path, value) => updateConfigFormValue(state, path, value),
-                onSearchChange: (query) => (state.configSearchQuery = query),
-                onSectionChange: (section) => {
-                  state.configActiveSection = section;
-                  state.configActiveSubsection = null;
-                },
-                onSubsectionChange: (section) => (state.configActiveSubsection = section),
-                onReload: () => loadConfig(state),
-                onSave: () => saveConfig(state),
-                onApply: () => applyConfig(state),
-                onUpdate: () => runUpdate(state),
-              })
-            : nothing
-        }
+        ${state.tab === "config"
+      ? renderConfig({
+        raw: state.configRaw,
+        originalRaw: state.configRawOriginal,
+        valid: state.configValid,
+        issues: state.configIssues,
+        loading: state.configLoading,
+        saving: state.configSaving,
+        applying: state.configApplying,
+        updating: state.updateRunning,
+        connected: state.connected,
+        schema: state.configSchema,
+        schemaLoading: state.configSchemaLoading,
+        uiHints: state.configUiHints,
+        formMode: state.configFormMode,
+        formValue: state.configForm,
+        originalValue: state.configFormOriginal,
+        searchQuery: state.configSearchQuery,
+        activeSection: state.configActiveSection,
+        activeSubsection: state.configActiveSubsection,
+        onRawChange: (next) => {
+          state.configRaw = next;
+        },
+        onFormModeChange: (mode) => (state.configFormMode = mode),
+        onFormPatch: (path, value) => updateConfigFormValue(state, path, value),
+        onSearchChange: (query) => (state.configSearchQuery = query),
+        onSectionChange: (section) => {
+          state.configActiveSection = section;
+          state.configActiveSubsection = null;
+        },
+        onSubsectionChange: (section) => (state.configActiveSubsection = section),
+        onReload: () => loadConfig(state),
+        onSave: () => saveConfig(state),
+        onApply: () => applyConfig(state),
+        onUpdate: () => runUpdate(state),
+      })
+      : nothing
+    }
 
-        ${
-          state.tab === "debug"
-            ? renderDebug({
-                loading: state.debugLoading,
-                status: state.debugStatus,
-                health: state.debugHealth,
-                models: state.debugModels,
-                heartbeat: state.debugHeartbeat,
-                eventLog: state.eventLog,
-                callMethod: state.debugCallMethod,
-                callParams: state.debugCallParams,
-                callResult: state.debugCallResult,
-                callError: state.debugCallError,
-                onCallMethodChange: (next) => (state.debugCallMethod = next),
-                onCallParamsChange: (next) => (state.debugCallParams = next),
-                onRefresh: () => loadDebug(state),
-                onCall: () => callDebugMethod(state),
-              })
-            : nothing
-        }
+        ${state.tab === "debug"
+      ? renderDebug({
+        loading: state.debugLoading,
+        status: state.debugStatus,
+        health: state.debugHealth,
+        models: state.debugModels,
+        heartbeat: state.debugHeartbeat,
+        eventLog: state.eventLog,
+        callMethod: state.debugCallMethod,
+        callParams: state.debugCallParams,
+        callResult: state.debugCallResult,
+        callError: state.debugCallError,
+        onCallMethodChange: (next) => (state.debugCallMethod = next),
+        onCallParamsChange: (next) => (state.debugCallParams = next),
+        onRefresh: () => loadDebug(state),
+        onCall: () => callDebugMethod(state),
+      })
+      : nothing
+    }
 
-        ${
-          state.tab === "logs"
-            ? renderLogs({
-                loading: state.logsLoading,
-                error: state.logsError,
-                file: state.logsFile,
-                entries: state.logsEntries,
-                filterText: state.logsFilterText,
-                levelFilters: state.logsLevelFilters,
-                autoFollow: state.logsAutoFollow,
-                truncated: state.logsTruncated,
-                onFilterTextChange: (next) => (state.logsFilterText = next),
-                onLevelToggle: (level, enabled) => {
-                  state.logsLevelFilters = { ...state.logsLevelFilters, [level]: enabled };
-                },
-                onToggleAutoFollow: (next) => (state.logsAutoFollow = next),
-                onRefresh: () => loadLogs(state, { reset: true }),
-                onExport: (lines, label) => state.exportLogs(lines, label),
-                onScroll: (event) => state.handleLogsScroll(event),
-              })
-            : nothing
-        }
+        ${state.tab === "logs"
+      ? renderLogs({
+        loading: state.logsLoading,
+        error: state.logsError,
+        file: state.logsFile,
+        entries: state.logsEntries,
+        filterText: state.logsFilterText,
+        levelFilters: state.logsLevelFilters,
+        autoFollow: state.logsAutoFollow,
+        truncated: state.logsTruncated,
+        onFilterTextChange: (next) => (state.logsFilterText = next),
+        onLevelToggle: (level, enabled) => {
+          state.logsLevelFilters = { ...state.logsLevelFilters, [level]: enabled };
+        },
+        onToggleAutoFollow: (next) => (state.logsAutoFollow = next),
+        onRefresh: () => loadLogs(state, { reset: true }),
+        onExport: (lines, label) => state.exportLogs(lines, label),
+        onScroll: (event) => state.handleLogsScroll(event),
+      })
+      : nothing
+    }
       </main>
       ${renderExecApprovalPrompt(state)}
       ${renderGatewayUrlConfirmation(state)}

--- a/ui/src/ui/navigation.ts
+++ b/ui/src/ui/navigation.ts
@@ -4,7 +4,7 @@ export const TAB_GROUPS = [
   { label: "Chat", tabs: ["chat"] },
   {
     label: "Control",
-    tabs: ["overview", "channels", "instances", "sessions", "usage", "cron"],
+    tabs: ["overview", "graph", "channels", "instances", "sessions", "usage", "cron"],
   },
   { label: "Agent", tabs: ["agents", "skills", "nodes"] },
   { label: "Settings", tabs: ["config", "debug", "logs"] },
@@ -13,6 +13,7 @@ export const TAB_GROUPS = [
 export type Tab =
   | "agents"
   | "overview"
+  | "graph"
   | "channels"
   | "instances"
   | "sessions"
@@ -28,6 +29,7 @@ export type Tab =
 const TAB_PATHS: Record<Tab, string> = {
   agents: "/agents",
   overview: "/overview",
+  graph: "/graph",
   channels: "/channels",
   instances: "/instances",
   sessions: "/sessions",
@@ -130,6 +132,8 @@ export function iconForTab(tab: Tab): IconName {
       return "messageSquare";
     case "overview":
       return "barChart";
+    case "graph":
+      return "share2";
     case "channels":
       return "link";
     case "instances":
@@ -161,6 +165,8 @@ export function titleForTab(tab: Tab) {
       return "Agents";
     case "overview":
       return "Overview";
+    case "graph":
+      return "Knowledge Graph";
     case "channels":
       return "Channels";
     case "instances":
@@ -194,6 +200,8 @@ export function subtitleForTab(tab: Tab) {
       return "Manage agent workspaces, tools, and identities.";
     case "overview":
       return "Gateway status, entry points, and a fast health read.";
+    case "graph":
+      return "Visualize relationships and knowledge connections.";
     case "channels":
       return "Manage channels and settings.";
     case "instances":

--- a/ui/src/ui/views/graph.ts
+++ b/ui/src/ui/views/graph.ts
@@ -1,0 +1,23 @@
+import { html } from "lit";
+
+export type GraphProps = {
+    basePath: string;
+};
+
+export function renderGraph(props: GraphProps) {
+    const graphUrl = `${props.basePath}/api/knowledge-graph/graph_view.html`;
+
+    return html`
+    <section class="card" style="height: calc(100vh - 160px); display: flex; flex-direction: column; padding: 0; overflow: hidden;">
+      <div style="padding: 16px; border-bottom: 1px solid var(--border-color);">
+        <div class="card-title">Knowledge Graph</div>
+        <div class="card-sub">Visualizing relationships between knowledge items and agents.</div>
+      </div>
+      <iframe 
+        src="${graphUrl}" 
+        style="flex: 1; border: none; width: 100%; height: 100%;"
+        title="Knowledge Graph"
+      ></iframe>
+    </section>
+  `;
+}


### PR DESCRIPTION
- Add Knowledge Graph navigation tab under Control category
- Create graph.ts view component with iframe embedding
- Wire graph view into app-render.ts rendering loop
- Add server-knowledge-graph.ts backend handler to serve graph assets from workspace
- Register knowledge-graph handler in server-http.ts and pass workspaceDir
- Graph visualization files (graph_view.html, graph_data.json) live in workspace and are served directly from disk

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a "Knowledge Graph" tab to the Control UI that renders an iframe pointing to `/api/knowledge-graph/graph_view.html`, served by a new backend handler (`server-knowledge-graph.ts`) that reads files from `{workspaceDir}/skills/knowledge-graph/` on disk. Navigation, routing, and rendering are wired correctly.

- **Security: No authentication on the file-serving endpoint.** The `handleKnowledgeGraphHttpRequest` handler is placed in the request chain before all auth-protected API routes and serves workspace files without any credentials check. Every other `/api/*` handler (`handleToolsInvokeHttpRequest`, `handleOpenAiHttpRequest`, channel plugins) enforces `authorizeGatewayConnect`. When the gateway is exposed via Tailscale or non-loopback binding, this allows unauthenticated file reads from the workspace.
- **Bug: Query strings not stripped from `req.url`.** The handler slices `req.url` directly without parsing out query parameters. A request like `/api/knowledge-graph/graph_view.html?v=2` produces `relPath = "graph_view.html?v=2"`, causing `fs.existsSync` to fail and returning a 404. The established pattern (used in `control-ui.ts`) is to parse via `new URL(urlRaw, "http://localhost").pathname`.
- **Path validation is weaker than codebase patterns.** Uses `includes("..")` instead of the `path.posix.normalize()` + `startsWith` approach used by `control-ui.ts`, and lacks a post-join containment check (`filePath.startsWith(root)`).
- **Extensive unrelated re-indentation** in `server.impl.ts` (~200 lines) and `app-render.ts` (~700 lines) inflates the diff and increases merge conflict risk.
- **New files use 4-space indentation** instead of the codebase's 2-space convention (`pnpm format:fix` should correct this).

<h3>Confidence Score: 2/5</h3>

- This PR introduces an unauthenticated file-serving endpoint and has a query-string parsing bug that prevents normal operation; both issues should be addressed before merging.
- Score of 2 reflects two material issues: (1) the knowledge graph endpoint serves workspace files without authentication, breaking the auth pattern used by every other API handler; (2) query strings in req.url are not stripped, causing the handler to 404 on any request with query parameters. The extensive unrelated reformatting also makes it harder to verify no accidental logic changes were introduced.
- `src/gateway/server-knowledge-graph.ts` needs authentication and URL parsing fixes. `src/gateway/server-http.ts` places the handler before auth-gated routes. `server.impl.ts` and `app-render.ts` have large unrelated formatting changes that should be verified.

<sub>Last reviewed commit: 2d72475</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))

<!-- /greptile_comment -->