### PR TITLE
fix(mattermost): restore runtime compatibility for plugin-sdk helper imports

### DIFF
--- a/extensions/mattermost/src/mattermost/accounts.import-path.test.ts
+++ b/extensions/mattermost/src/mattermost/accounts.import-path.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+
+describe("mattermost account-id import path", () => {
+  test("accounts.ts must import normalizeAccountId from plugin-sdk barrel", () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const accountsPath = resolve(here, "./accounts.ts");
+    const source = readFileSync(accountsPath, "utf8");
+
+    expect(source).not.toContain('"openclaw/plugin-sdk/account-id"');
+    expect(source).toContain('"openclaw/plugin-sdk"');
+  });
+});

--- a/extensions/mattermost/src/mattermost/accounts.ts
+++ b/extensions/mattermost/src/mattermost/accounts.ts
@@ -1,5 +1,5 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
-import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-id";
+import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk";
 import type { MattermostAccountConfig, MattermostChatMode } from "../types.js";
 import { normalizeMattermostBaseUrl } from "./client.js";
 

--- a/extensions/mattermost/src/mattermost/monitor-helpers.create-dedupe-cache.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-helpers.create-dedupe-cache.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "vitest";
+import { createDedupeCache } from "./monitor-helpers.js";
+
+describe("monitor-helpers createDedupeCache", () => {
+  test("exports a working dedupe cache function", () => {
+    expect(typeof createDedupeCache).toBe("function");
+
+    const cache = createDedupeCache({ ttlMs: 60_000, maxSize: 10 });
+    expect(cache.check("abc", 1)).toBe(false);
+    expect(cache.check("abc", 2)).toBe(true);
+    expect(cache.check("def", 3)).toBe(false);
+  });
+});

--- a/extensions/mattermost/src/mattermost/monitor-helpers.import-path.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-helpers.import-path.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+
+describe("monitor-helpers dedupe implementation", () => {
+  test("does not re-export createDedupeCache from plugin-sdk barrel", () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const filePath = resolve(here, "./monitor-helpers.ts");
+    const source = readFileSync(filePath, "utf8");
+
+    expect(source).not.toContain('export { createDedupeCache } from "openclaw/plugin-sdk";');
+  });
+});

--- a/extensions/mattermost/src/mattermost/monitor-helpers.ts
+++ b/extensions/mattermost/src/mattermost/monitor-helpers.ts
@@ -1,5 +1,58 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
-export { createDedupeCache, rawDataToString } from "openclaw/plugin-sdk";
+export { rawDataToString } from "openclaw/plugin-sdk";
+
+type DedupeCache = {
+  check: (key: string | undefined | null, now?: number) => boolean;
+};
+
+export function createDedupeCache(options: { ttlMs: number; maxSize: number }): DedupeCache {
+  const ttlMs = Math.max(0, options.ttlMs);
+  const maxSize = Math.max(0, Math.floor(options.maxSize));
+  const cache = new Map<string, number>();
+
+  const touch = (key: string, now: number) => {
+    cache.delete(key);
+    cache.set(key, now);
+  };
+
+  const prune = (now: number) => {
+    const cutoff = ttlMs > 0 ? now - ttlMs : undefined;
+    if (cutoff !== undefined) {
+      for (const [entryKey, entryTs] of cache) {
+        if (entryTs < cutoff) {
+          cache.delete(entryKey);
+        }
+      }
+    }
+    if (maxSize <= 0) {
+      cache.clear();
+      return;
+    }
+    while (cache.size > maxSize) {
+      const oldestKey = cache.keys().next().value as string | undefined;
+      if (!oldestKey) {
+        break;
+      }
+      cache.delete(oldestKey);
+    }
+  };
+
+  return {
+    check: (key, now = Date.now()) => {
+      if (!key) {
+        return false;
+      }
+      const existing = cache.get(key);
+      if (existing !== undefined && (ttlMs <= 0 || now - existing < ttlMs)) {
+        touch(key, now);
+        return true;
+      }
+      touch(key, now);
+      prune(now);
+      return false;
+    },
+  };
+}
 
 export type ResponsePrefixContext = {
   model?: string;

--- a/extensions/mattermost/src/mattermost/monitor.media-payload-import.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.media-payload-import.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+
+describe("monitor media payload compatibility", () => {
+  test("monitor.ts should not import buildAgentMediaPayload from plugin-sdk", () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const filePath = resolve(here, "./monitor.ts");
+    const source = readFileSync(filePath, "utf8");
+
+    expect(source).not.toContain("buildAgentMediaPayload");
+  });
+});

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -6,7 +6,6 @@ import type {
   RuntimeEnv,
 } from "openclaw/plugin-sdk";
 import {
-  buildAgentMediaPayload,
   createReplyPrefixOptions,
   createTypingCallbacks,
   logInboundDrop,
@@ -178,6 +177,27 @@ function buildMattermostAttachmentPlaceholder(mediaList: MattermostMediaInfo[]):
   const suffix = mediaList.length === 1 ? label : `${label}s`;
   const tag = allImages ? "<media:image>" : "<media:document>";
   return `${tag} (${mediaList.length} ${suffix})`;
+}
+
+function buildMattermostMediaPayload(mediaList: MattermostMediaInfo[]): {
+  MediaPath?: string;
+  MediaType?: string;
+  MediaUrl?: string;
+  MediaPaths?: string[];
+  MediaUrls?: string[];
+  MediaTypes?: string[];
+} {
+  const first = mediaList[0];
+  const mediaPaths = mediaList.map((media) => media.path);
+  const mediaTypes = mediaList.map((media) => media.contentType).filter(Boolean) as string[];
+  return {
+    MediaPath: first?.path,
+    MediaType: first?.contentType,
+    MediaUrl: first?.path,
+    MediaPaths: mediaPaths.length > 0 ? mediaPaths : undefined,
+    MediaUrls: mediaPaths.length > 0 ? mediaPaths : undefined,
+    MediaTypes: mediaTypes.length > 0 ? mediaTypes : undefined,
+  };
 }
 
 function buildMattermostWsUrl(baseUrl: string): string {
@@ -630,7 +650,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
     }
 
     const to = kind === "direct" ? `user:${senderId}` : `channel:${channelId}`;
-    const mediaPayload = buildAgentMediaPayload(mediaList);
+    const mediaPayload = buildMattermostMediaPayload(mediaList);
     const inboundHistory =
       historyKey && historyLimit > 0
         ? (channelHistories.get(historyKey) ?? []).map((entry) => ({

--- a/extensions/mattermost/src/onboarding.ts
+++ b/extensions/mattermost/src/onboarding.ts
@@ -1,5 +1,5 @@
 import type { ChannelOnboardingAdapter, OpenClawConfig, WizardPrompter } from "openclaw/plugin-sdk";
-import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-id";
+import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk";
 import {
   listMattermostAccountIds,
   resolveDefaultMattermostAccountId,


### PR DESCRIPTION
## Summary
Fixes a regression in Mattermost introduced after `v2026.2.13` where runtime helper imports from `openclaw/plugin-sdk` fail in production execution paths.

This caused three failures in sequence:
1. `Cannot find module .../dist/plugin-sdk/index.js/account-id`
2. `TypeError: createDedupeCache is not a function`
3. `TypeError: buildAgentMediaPayload is not a function` (channels connect but no agent replies)

## What changed
- Switched Mattermost account-id import back to plugin-sdk barrel compatibility path.
- Restored a local `createDedupeCache` helper in `monitor-helpers.ts`.
- Restored a local `buildMattermostMediaPayload` helper in `monitor.ts`.
- Added regression tests for each compatibility path.

## Why
`openclaw/plugin-sdk` subpath/barrel runtime exports are not consistently available in this plugin runtime path on affected installs.
Keeping these helpers local in Mattermost restores behavior and avoids brittle runtime coupling.

## Validation
- Added and ran targeted vitest tests for:
  - account-id import path compatibility
  - dedupe helper availability
  - media payload helper import compatibility
- Verified the regression behavior on a real deployment where:
  - `v2026.2.13` worked
  - `v2026.2.14`/`v2026.2.15` failed
  - this patch restores Mattermost replies

Fixes #18476

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Restores Mattermost runtime compatibility by replacing three failing `openclaw/plugin-sdk` subpath/barrel imports with local implementations. The PR addresses production failures where `plugin-sdk/account-id` subpath import and helper re-exports (`createDedupeCache`, `buildAgentMediaPayload`) were not consistently available in the plugin runtime environment. The fix uses barrel import for `normalizeAccountId` and `DEFAULT_ACCOUNT_ID`, and restores local copies of the two helper functions. All changes are protected by regression tests that enforce the import patterns.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - fixes production regression with isolated, tested changes
- The PR makes minimal, surgical changes to restore runtime compatibility. All three fixes (account-id import path, dedupe helper, media payload helper) are directly tested and address real production failures. The local implementations are functionally identical to their plugin-sdk counterparts, and the regression tests prevent future breakage.
- No files require special attention

<sub>Last reviewed commit: 1e629fd</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->