### PR TITLE
Fix webchat URL loopback and canonical session 

### DIFF
--- a/src/commands/onboard-helpers.e2e.test.ts
+++ b/src/commands/onboard-helpers.e2e.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  buildWebchatUrl,
   normalizeGatewayTokenInput,
   openUrl,
   resolveBrowserOpenCommand,
   resolveControlUiLinks,
+  resolveLocalBrowserControlUiLinks,
   validateGatewayPasswordInput,
 } from "./onboard-helpers.js";
 
@@ -106,6 +108,35 @@ describe("resolveControlUiLinks", () => {
     });
     expect(links.httpUrl).toBe("http://127.0.0.1:18789/");
     expect(links.wsUrl).toBe("ws://127.0.0.1:18789");
+  });
+
+  it("coerces lan bind to loopback for local browser links", () => {
+    const links = resolveLocalBrowserControlUiLinks({
+      port: 18789,
+      bind: "lan",
+    });
+    expect(links.httpUrl).toBe("http://127.0.0.1:18789/");
+    expect(links.wsUrl).toBe("ws://127.0.0.1:18789");
+  });
+});
+
+describe("buildWebchatUrl", () => {
+  it("encodes canonical session key exactly once", () => {
+    const url = buildWebchatUrl({
+      httpUrl: "http://127.0.0.1:18789/",
+      sessionKey: "agent:main:main",
+    });
+    expect(url).toBe("http://127.0.0.1:18789/chat?session=agent%3Amain%3Amain");
+  });
+
+  it("preserves base path and appends token in fragment", () => {
+    const url = buildWebchatUrl({
+      httpUrl: "http://127.0.0.1:18789/ui/",
+      sessionKey: "agent:main:main",
+      token: "abc 123",
+    });
+    expect(url).toBe("http://127.0.0.1:18789/ui/chat?session=agent%3Amain%3Amain#token=abc%20123");
+    expect(url).not.toContain("%2520");
   });
 });
 

--- a/src/wizard/onboarding.finalize.test.ts
+++ b/src/wizard/onboarding.finalize.test.ts
@@ -1,0 +1,124 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OnboardOptions } from "../commands/onboard-types.js";
+import type { RuntimeEnv } from "../runtime.js";
+import type { WizardPrompter } from "./prompts.js";
+import { finalizeOnboardingWizard } from "./onboarding.finalize.js";
+
+const mocks = vi.hoisted(() => ({
+  detectBrowserOpenSupport: vi.fn(async () => ({ ok: true })),
+  openUrl: vi.fn(async () => true),
+  probeGatewayReachable: vi.fn(async () => ({ ok: true })),
+  ensureControlUiAssetsBuilt: vi.fn(async () => ({ ok: true })),
+  setupOnboardingShellCompletion: vi.fn(async () => {}),
+  runTui: vi.fn(async () => {}),
+}));
+
+vi.mock("../commands/onboard-helpers.js", async (importActual) => {
+  const actual = await importActual<typeof import("../commands/onboard-helpers.js")>();
+  return {
+    ...actual,
+    detectBrowserOpenSupport: mocks.detectBrowserOpenSupport,
+    openUrl: mocks.openUrl,
+    probeGatewayReachable: mocks.probeGatewayReachable,
+  };
+});
+
+vi.mock("../infra/control-ui-assets.js", () => ({
+  ensureControlUiAssetsBuilt: mocks.ensureControlUiAssetsBuilt,
+}));
+
+vi.mock("./onboarding.completion.js", () => ({
+  setupOnboardingShellCompletion: mocks.setupOnboardingShellCompletion,
+}));
+
+vi.mock("../tui/tui.js", () => ({
+  runTui: mocks.runTui,
+}));
+
+function createPrompter(overrides?: Partial<WizardPrompter>): WizardPrompter {
+  const select: WizardPrompter["select"] = vi.fn(async (params) => {
+    if (params.message === "How do you want to hatch your bot?") {
+      return "web" as never;
+    }
+    return (params.initialValue ?? params.options[0]?.value) as never;
+  });
+  const multiselect: WizardPrompter["multiselect"] = vi.fn(async () => []);
+
+  return {
+    intro: vi.fn(async () => {}),
+    outro: vi.fn(async () => {}),
+    note: vi.fn(async () => {}),
+    select,
+    multiselect,
+    text: vi.fn(async () => ""),
+    confirm: vi.fn(async () => false),
+    progress: vi.fn(() => ({
+      update: vi.fn(),
+      stop: vi.fn(),
+    })),
+    ...overrides,
+  };
+}
+
+function createRuntime(): RuntimeEnv {
+  return {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn((code: number): never => {
+      throw new Error(`exit:${code}`);
+    }),
+  };
+}
+
+describe("finalizeOnboardingWizard", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    mocks.detectBrowserOpenSupport.mockClear();
+    mocks.openUrl.mockClear();
+    mocks.probeGatewayReachable.mockClear();
+    mocks.ensureControlUiAssetsBuilt.mockClear();
+    mocks.setupOnboardingShellCompletion.mockClear();
+    mocks.runTui.mockClear();
+  });
+
+  it("opens loopback webchat URL with canonical main session key when bind=lan", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-onboarding-finalize-"));
+
+    const opts: OnboardOptions = {
+      installDaemon: false,
+      skipHealth: true,
+      skipProviders: true,
+      skipSkills: true,
+    };
+    const prompter = createPrompter();
+    const runtime = createRuntime();
+
+    await finalizeOnboardingWizard({
+      flow: "quickstart",
+      opts,
+      baseConfig: {},
+      nextConfig: {},
+      workspaceDir,
+      settings: {
+        port: 18789,
+        bind: "lan",
+        authMode: "token",
+        gatewayToken: "test token",
+        tailscaleMode: "off",
+        tailscaleResetOnExit: false,
+      },
+      prompter,
+      runtime,
+    });
+
+    expect(mocks.openUrl).toHaveBeenCalledWith(
+      "http://127.0.0.1:18789/chat?session=agent%3Amain%3Amain#token=test%20token",
+    );
+
+    await fs.rm(workspaceDir, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
## Fixes #18259 
Fix onboarding web launch URL generation so local `openclaw onboard` opens WebChat on loopback with canonical session identity.

## Root cause
- Onboarding link resolution reused generic control UI host selection, where `bind=lan` resolves to LAN IP.
- Onboarding opened control UI root instead of an explicit `/chat?session=<canonical>` URL.
- Control UI defaults to `sessionKey="main"` and syncs that alias into URL query, which fails in this flow.

## Fix
- Added onboarding URL helpers:
  - local browser link resolver that coerces `lan -> loopback` for browser targets
  - canonical main session key resolver
  - canonical `buildWebchatUrl(...)` builder (`/chat`, single-encoded session query, optional token in hash)
- Updated `finalizeOnboardingWizard(...)` to:
  - use loopback-preferred browser host for web open
  - open WebChat URL with canonical session key (default `agent:main:main`)
  - keep TUI path and gateway probing behavior unchanged
- Kept scope onboarding-only; no global bind behavior changes outside onboarding web-open path.

## Tests
- Added/updated tests:
  - `src/commands/onboard-helpers.e2e.test.ts`
    - lan bind -> loopback for local browser links
    - canonical session query encoding
    - basePath + token hash behavior, no double encoding
  - `src/wizard/onboarding.finalize.test.ts`
    - regression: onboarding web open uses
      `http://127.0.0.1:18789/chat?session=agent%3Amain%3Amain` (with token hash when enabled)
- Verification commands:
  - `pnpm install` ✅
  - `pnpm check` ✅
  - `pnpm test` ✅
  - `pnpm build` ✅

## Notes
- This change intentionally does not alter non-onboarding dashboard/status/configure host resolution behavior.
- Remote onboarding mode behavior remains unchanged.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the onboarding web launch URL generation to open WebChat on loopback with the canonical session identity.

**Key changes:**
- Added `resolveLocalBrowserControlUiLinks(...)` to coerce `lan` bind to `loopback` for local browser links
- Added `buildWebchatUrl(...)` helper to build `/chat?session=<canonical>` URLs with single-encoded session query and optional token in hash
- Updated `finalizeOnboardingWizard(...)` to use these helpers for opening WebChat with the canonical main session key
- Added comprehensive test coverage for URL building logic and loopback coercion

The implementation correctly addresses the root cause where onboarding was opening the control UI root with a generic session key instead of the canonical session identity. The fix ensures local onboarding opens WebChat on loopback (127.0.0.1) with the proper session identity.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are focused, well-tested, and address a specific onboarding issue. The implementation includes new helper functions with comprehensive unit tests, proper URL encoding logic, and maintains backward compatibility for non-onboarding paths. The PR has already passed all verification commands (pnpm check, pnpm test, pnpm build).
- No files require special attention

<sub>Last reviewed commit: 0915479</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->