### PR TITLE
CLI: improve command descriptions in help output

### DIFF
--- a/src/cli/channels-cli.ts
+++ b/src/cli/channels-cli.ts
@@ -16,6 +16,7 @@ import { runChannelLogin, runChannelLogout } from "./channel-auth.js";
 import { formatCliChannelOptions } from "./channel-options.js";
 import { runCommandWithRuntime } from "./cli-utils.js";
 import { hasExplicitOptions } from "./command-options.js";
+import { formatHelpExamples } from "./help-format.js";
 
 const optionNamesAdd = [
   "channel",
@@ -70,11 +71,19 @@ export function registerChannelsCli(program: Command) {
   const channelNames = formatCliChannelOptions();
   const channels = program
     .command("channels")
-    .description("Manage chat channel accounts")
+    .description("Manage connected chat channels and accounts")
     .addHelpText(
       "after",
       () =>
-        `\n${theme.muted("Docs:")} ${formatDocsLink(
+        `\n${theme.heading("Examples:")}\n${formatHelpExamples([
+          ["openclaw channels list", "List configured channels and auth profiles."],
+          ["openclaw channels status --probe", "Run channel status checks and probes."],
+          [
+            "openclaw channels add --channel telegram --token <token>",
+            "Add or update a channel account non-interactively.",
+          ],
+          ["openclaw channels login --channel whatsapp", "Link a WhatsApp Web account."],
+        ])}\n\n${theme.muted("Docs:")} ${formatDocsLink(
           "/cli/channels",
           "docs.openclaw.ai/cli/channels",
         )}\n`,

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -280,7 +280,9 @@ export async function runConfigUnset(opts: { path: string; runtime?: RuntimeEnv 
 export function registerConfigCli(program: Command) {
   const cmd = program
     .command("config")
-    .description("Config helpers (get/set/unset). Run without subcommand for the wizard.")
+    .description(
+      "Non-interactive config helpers (get/set/unset). Run without subcommand for the setup wizard.",
+    )
     .addHelpText(
       "after",
       () =>

--- a/src/cli/directory-cli.ts
+++ b/src/cli/directory-cli.ts
@@ -8,6 +8,7 @@ import { defaultRuntime } from "../runtime.js";
 import { formatDocsLink } from "../terminal/links.js";
 import { renderTable } from "../terminal/table.js";
 import { theme } from "../terminal/theme.js";
+import { formatHelpExamples } from "./help-format.js";
 
 function parseLimit(value: unknown): number | null {
   if (typeof value === "number" && Number.isFinite(value)) {
@@ -64,11 +65,22 @@ function printDirectoryList(params: {
 export function registerDirectoryCli(program: Command) {
   const directory = program
     .command("directory")
-    .description("Directory lookups (self, peers, groups) for channels that support it")
+    .description("Lookup contact and group IDs (self, peers, groups) for supported chat channels")
     .addHelpText(
       "after",
       () =>
-        `\n${theme.muted("Docs:")} ${formatDocsLink(
+        `\n${theme.heading("Examples:")}\n${formatHelpExamples([
+          ["openclaw directory self --channel slack", "Show the connected account identity."],
+          [
+            'openclaw directory peers list --channel slack --query "alice"',
+            "Search contact/user IDs by name.",
+          ],
+          ["openclaw directory groups list --channel discord", "List available groups/channels."],
+          [
+            "openclaw directory groups members --channel discord --group-id <id>",
+            "List members for a specific group.",
+          ],
+        ])}\n\n${theme.muted("Docs:")} ${formatDocsLink(
           "/cli/directory",
           "docs.openclaw.ai/cli/directory",
         )}\n`,

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -13,6 +13,7 @@ import { colorize, isRich, theme } from "../../terminal/theme.js";
 import { formatTokenCount, formatUsd } from "../../utils/usage-format.js";
 import { runCommandWithRuntime } from "../cli-utils.js";
 import { addGatewayServiceCommands } from "../daemon-cli.js";
+import { formatHelpExamples } from "../help-format.js";
 import { withProgress } from "../progress.js";
 import { callGatewayCli, gatewayCallOpts } from "./call.js";
 import {
@@ -75,11 +76,16 @@ export function registerGatewayCli(program: Command) {
   const gateway = addGatewayRunCommand(
     program
       .command("gateway")
-      .description("Run the WebSocket Gateway")
+      .description("Run, inspect, and query the WebSocket Gateway")
       .addHelpText(
         "after",
         () =>
-          `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/gateway", "docs.openclaw.ai/cli/gateway")}\n`,
+          `\n${theme.heading("Examples:")}\n${formatHelpExamples([
+            ["openclaw gateway run", "Run the gateway in the foreground."],
+            ["openclaw gateway status", "Show service status and probe reachability."],
+            ["openclaw gateway discover", "Find local and wide-area gateway beacons."],
+            ["openclaw gateway call health", "Call a gateway RPC method directly."],
+          ])}\n\n${theme.muted("Docs:")} ${formatDocsLink("/cli/gateway", "docs.openclaw.ai/cli/gateway")}\n`,
       ),
   );
 

--- a/src/cli/memory-cli.ts
+++ b/src/cli/memory-cli.ts
@@ -15,6 +15,7 @@ import { formatDocsLink } from "../terminal/links.js";
 import { colorize, isRich, theme } from "../terminal/theme.js";
 import { shortenHomeInString, shortenHomePath } from "../utils.js";
 import { formatErrorMessage, withManager } from "./cli-utils.js";
+import { formatHelpExamples } from "./help-format.js";
 import { withProgress, withProgressTotals } from "./progress.js";
 
 type MemoryCommandOptions = {
@@ -515,11 +516,16 @@ export async function runMemoryStatus(opts: MemoryCommandOptions) {
 export function registerMemoryCli(program: Command) {
   const memory = program
     .command("memory")
-    .description("Memory search tools")
+    .description("Search, inspect, and reindex memory files")
     .addHelpText(
       "after",
       () =>
-        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/memory", "docs.openclaw.ai/cli/memory")}\n`,
+        `\n${theme.heading("Examples:")}\n${formatHelpExamples([
+          ["openclaw memory status", "Show index and provider status."],
+          ["openclaw memory index --force", "Force a full reindex."],
+          ['openclaw memory search --query "deployment notes"', "Search indexed memory entries."],
+          ["openclaw memory status --json", "Output machine-readable JSON."],
+        ])}\n\n${theme.muted("Docs:")} ${formatDocsLink("/cli/memory", "docs.openclaw.ai/cli/memory")}\n`,
     );
 
   memory

--- a/src/cli/node-cli/register.ts
+++ b/src/cli/node-cli/register.ts
@@ -4,6 +4,7 @@ import { runNodeHost } from "../../node-host/runner.js";
 import { formatDocsLink } from "../../terminal/links.js";
 import { theme } from "../../terminal/theme.js";
 import { parsePort } from "../daemon-cli/shared.js";
+import { formatHelpExamples } from "../help-format.js";
 import {
   runNodeDaemonInstall,
   runNodeDaemonRestart,
@@ -20,11 +21,19 @@ function parsePortWithFallback(value: unknown, fallback: number): number {
 export function registerNodeCli(program: Command) {
   const node = program
     .command("node")
-    .description("Run a headless node host (system.run/system.which)")
+    .description("Run and manage the headless node host service")
     .addHelpText(
       "after",
       () =>
-        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/node", "docs.openclaw.ai/cli/node")}\n`,
+        `\n${theme.heading("Examples:")}\n${formatHelpExamples([
+          [
+            "openclaw node run --host 127.0.0.1 --port 18789",
+            "Run the node host in the foreground.",
+          ],
+          ["openclaw node status", "Check node host service status."],
+          ["openclaw node install", "Install the node host service."],
+          ["openclaw node restart", "Restart the installed node host service."],
+        ])}\n\n${theme.muted("Docs:")} ${formatDocsLink("/cli/node", "docs.openclaw.ai/cli/node")}\n`,
     );
 
   node

--- a/src/cli/nodes-cli/register.ts
+++ b/src/cli/nodes-cli/register.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 import { formatDocsLink } from "../../terminal/links.js";
 import { theme } from "../../terminal/theme.js";
+import { formatHelpExamples } from "../help-format.js";
 import { registerNodesCameraCommands } from "./register.camera.js";
 import { registerNodesCanvasCommands } from "./register.canvas.js";
 import { registerNodesInvokeCommands } from "./register.invoke.js";
@@ -13,11 +14,16 @@ import { registerNodesStatusCommands } from "./register.status.js";
 export function registerNodesCli(program: Command) {
   const nodes = program
     .command("nodes")
-    .description("Manage gateway-owned node pairing")
+    .description("Manage gateway-owned nodes (pairing, status, invoke, and media)")
     .addHelpText(
       "after",
       () =>
-        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/nodes", "docs.openclaw.ai/cli/nodes")}\n`,
+        `\n${theme.heading("Examples:")}\n${formatHelpExamples([
+          ["openclaw nodes status", "List known nodes with live status."],
+          ["openclaw nodes pairing pending", "Show pending node pairing requests."],
+          ['openclaw nodes run --node <id> --raw "uname -a"', "Run a shell command on a node."],
+          ["openclaw nodes camera snap --node <id>", "Capture a photo from a node camera."],
+        ])}\n\n${theme.muted("Docs:")} ${formatDocsLink("/cli/nodes", "docs.openclaw.ai/cli/nodes")}\n`,
     );
 
   registerNodesStatusCommands(nodes);

--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -163,7 +163,7 @@ function logSlotWarnings(warnings: string[]) {
 export function registerPluginsCli(program: Command) {
   const plugins = program
     .command("plugins")
-    .description("Manage OpenClaw plugins/extensions")
+    .description("Manage OpenClaw plugins and extensions")
     .addHelpText(
       "after",
       () =>

--- a/src/cli/program/command-registry.ts
+++ b/src/cli/program/command-registry.ts
@@ -29,14 +29,19 @@ const shouldRegisterCorePrimaryOnly = (argv: string[]) => {
 
 const coreEntries: CoreCliEntry[] = [
   {
-    commands: [{ name: "setup", description: "Setup helpers" }],
+    commands: [{ name: "setup", description: "Initialize local config and agent workspace" }],
     register: async ({ program }) => {
       const mod = await import("./register.setup.js");
       mod.registerSetupCommand(program);
     },
   },
   {
-    commands: [{ name: "onboard", description: "Onboarding helpers" }],
+    commands: [
+      {
+        name: "onboard",
+        description: "Interactive onboarding wizard for gateway, workspace, and skills",
+      },
+    ],
     register: async ({ program }) => {
       const mod = await import("./register.onboard.js");
       mod.registerOnboardCommand(program);
@@ -100,7 +105,7 @@ const coreEntries: CoreCliEntry[] = [
     },
   },
   {
-    commands: [{ name: "memory", description: "Memory commands" }],
+    commands: [{ name: "memory", description: "Search and reindex memory files" }],
     register: async ({ program }) => {
       const mod = await import("../memory-cli.js");
       mod.registerMemoryCli(program);
@@ -108,8 +113,8 @@ const coreEntries: CoreCliEntry[] = [
   },
   {
     commands: [
-      { name: "agent", description: "Agent commands" },
-      { name: "agents", description: "Manage isolated agents" },
+      { name: "agent", description: "Run one agent turn via the Gateway" },
+      { name: "agents", description: "Manage isolated agents (workspaces, auth, routing)" },
     ],
     register: async ({ program, ctx }) => {
       const mod = await import("./register.agent.js");
@@ -120,9 +125,9 @@ const coreEntries: CoreCliEntry[] = [
   },
   {
     commands: [
-      { name: "status", description: "Gateway status" },
-      { name: "health", description: "Gateway health" },
-      { name: "sessions", description: "Session management" },
+      { name: "status", description: "Show channel health and recent session recipients" },
+      { name: "health", description: "Fetch health from the running gateway" },
+      { name: "sessions", description: "List stored conversation sessions" },
     ],
     register: async ({ program }) => {
       const mod = await import("./register.status-health-sessions.js");
@@ -130,7 +135,9 @@ const coreEntries: CoreCliEntry[] = [
     },
   },
   {
-    commands: [{ name: "browser", description: "Browser tools" }],
+    commands: [
+      { name: "browser", description: "Manage OpenClaw's dedicated browser (Chrome/Chromium)" },
+    ],
     register: async ({ program }) => {
       const mod = await import("../browser-cli.js");
       mod.registerBrowserCli(program);

--- a/src/cli/program/command-registry.ts
+++ b/src/cli/program/command-registry.ts
@@ -43,14 +43,26 @@ const coreEntries: CoreCliEntry[] = [
     },
   },
   {
-    commands: [{ name: "configure", description: "Configure wizard" }],
+    commands: [
+      {
+        name: "configure",
+        description:
+          "Interactive setup wizard for credentials, channels, gateway, and agent defaults",
+      },
+    ],
     register: async ({ program }) => {
       const mod = await import("./register.configure.js");
       mod.registerConfigureCommand(program);
     },
   },
   {
-    commands: [{ name: "config", description: "Config helpers" }],
+    commands: [
+      {
+        name: "config",
+        description:
+          "Non-interactive config helpers (get/set/unset). Default: starts setup wizard.",
+      },
+    ],
     register: async ({ program }) => {
       const mod = await import("../config-cli.js");
       mod.registerConfigCli(program);
@@ -58,9 +70,18 @@ const coreEntries: CoreCliEntry[] = [
   },
   {
     commands: [
-      { name: "doctor", description: "Health checks + quick fixes for the gateway and channels" },
-      { name: "dashboard", description: "Open the Control UI with your current token" },
-      { name: "reset", description: "Reset local config/state (keeps the CLI installed)" },
+      {
+        name: "doctor",
+        description: "Health checks + quick fixes for the gateway and channels",
+      },
+      {
+        name: "dashboard",
+        description: "Open the Control UI with your current token",
+      },
+      {
+        name: "reset",
+        description: "Reset local config/state (keeps the CLI installed)",
+      },
       {
         name: "uninstall",
         description: "Uninstall the gateway service + local data (CLI remains)",
@@ -92,7 +113,9 @@ const coreEntries: CoreCliEntry[] = [
     ],
     register: async ({ program, ctx }) => {
       const mod = await import("./register.agent.js");
-      mod.registerAgentCommands(program, { agentChannelOptions: ctx.agentChannelOptions });
+      mod.registerAgentCommands(program, {
+        agentChannelOptions: ctx.agentChannelOptions,
+      });
     },
   },
   {

--- a/src/cli/program/help.ts
+++ b/src/cli/program/help.ts
@@ -12,6 +12,7 @@ const ROOT_COMMANDS_WITH_SUBCOMMANDS = new Set([
   "approvals",
   "browser",
   "channels",
+  "clawbot",
   "config",
   "cron",
   "daemon",

--- a/src/cli/program/help.ts
+++ b/src/cli/program/help.ts
@@ -4,36 +4,13 @@ import { formatDocsLink } from "../../terminal/links.js";
 import { isRich, theme } from "../../terminal/theme.js";
 import { formatCliBannerLine, hasEmittedCliBanner } from "../banner.js";
 import { replaceCliName, resolveCliName } from "../cli-name.js";
+import { getCoreCliCommandsWithSubcommands } from "./command-registry.js";
+import { getSubCliCommandsWithSubcommands } from "./register.subclis.js";
 
 const CLI_NAME = resolveCliName();
 const ROOT_COMMANDS_WITH_SUBCOMMANDS = new Set([
-  "acp",
-  "agents",
-  "approvals",
-  "browser",
-  "channels",
-  "clawbot",
-  "config",
-  "cron",
-  "daemon",
-  "devices",
-  "directory",
-  "dns",
-  "gateway",
-  "hooks",
-  "memory",
-  "message",
-  "models",
-  "node",
-  "nodes",
-  "pairing",
-  "plugins",
-  "sandbox",
-  "security",
-  "skills",
-  "system",
-  "update",
-  "webhooks",
+  ...getCoreCliCommandsWithSubcommands(),
+  ...getSubCliCommandsWithSubcommands(),
 ]);
 const ROOT_COMMANDS_HINT =
   "Hint: commands suffixed with * have subcommands. Run <command> --help for details.";

--- a/src/cli/program/help.ts
+++ b/src/cli/program/help.ts
@@ -2,12 +2,14 @@ import type { Command } from "commander";
 import type { ProgramContext } from "./context.js";
 import { formatDocsLink } from "../../terminal/links.js";
 import { isRich, theme } from "../../terminal/theme.js";
+import { escapeRegExp } from "../../utils.js";
 import { formatCliBannerLine, hasEmittedCliBanner } from "../banner.js";
 import { replaceCliName, resolveCliName } from "../cli-name.js";
 import { getCoreCliCommandsWithSubcommands } from "./command-registry.js";
 import { getSubCliCommandsWithSubcommands } from "./register.subclis.js";
 
 const CLI_NAME = resolveCliName();
+const CLI_NAME_PATTERN = escapeRegExp(CLI_NAME);
 const ROOT_COMMANDS_WITH_SUBCOMMANDS = new Set([
   ...getCoreCliCommandsWithSubcommands(),
   ...getSubCliCommandsWithSubcommands(),
@@ -70,7 +72,7 @@ export function configureProgramHelp(program: Command, ctx: ProgramContext) {
   const formatHelpOutput = (str: string) => {
     let output = str;
     const isRootHelp = new RegExp(
-      `^Usage:\\s+${CLI_NAME}\\s+\\[options\\]\\s+\\[command\\]\\s*$`,
+      `^Usage:\\s+${CLI_NAME_PATTERN}\\s+\\[options\\]\\s+\\[command\\]\\s*$`,
       "m",
     ).test(output);
     if (isRootHelp && /^Commands:/m.test(output)) {

--- a/src/cli/program/help.ts
+++ b/src/cli/program/help.ts
@@ -6,6 +6,8 @@ import { formatCliBannerLine, hasEmittedCliBanner } from "../banner.js";
 import { replaceCliName, resolveCliName } from "../cli-name.js";
 
 const CLI_NAME = resolveCliName();
+const ROOT_COMMANDS_HINT =
+  "Hint: get help on flags and subcommands by calling --help on each command.";
 
 const EXAMPLES = [
   [
@@ -56,7 +58,16 @@ export function configureProgramHelp(program: Command, ctx: ProgramContext) {
 
   program.configureOutput({
     writeOut: (str) => {
-      const colored = str
+      let output = str;
+      const isRootHelp = new RegExp(
+        `^Usage:\\s+${CLI_NAME}\\s+\\[options\\]\\s+\\[command\\]\\s*$`,
+        "m",
+      ).test(output);
+      if (isRootHelp && /^Commands:/m.test(output)) {
+        output = output.replace(/^Commands:/m, `Commands:\n  ${theme.muted(ROOT_COMMANDS_HINT)}`);
+      }
+
+      const colored = output
         .replace(/^Usage:/gm, theme.heading("Usage:"))
         .replace(/^Options:/gm, theme.heading("Options:"))
         .replace(/^Commands:/gm, theme.heading("Commands:"));

--- a/src/cli/program/help.ts
+++ b/src/cli/program/help.ts
@@ -6,8 +6,36 @@ import { formatCliBannerLine, hasEmittedCliBanner } from "../banner.js";
 import { replaceCliName, resolveCliName } from "../cli-name.js";
 
 const CLI_NAME = resolveCliName();
+const ROOT_COMMANDS_WITH_SUBCOMMANDS = new Set([
+  "acp",
+  "agents",
+  "approvals",
+  "browser",
+  "channels",
+  "config",
+  "cron",
+  "daemon",
+  "devices",
+  "directory",
+  "dns",
+  "gateway",
+  "hooks",
+  "memory",
+  "message",
+  "models",
+  "node",
+  "nodes",
+  "pairing",
+  "plugins",
+  "sandbox",
+  "security",
+  "skills",
+  "system",
+  "update",
+  "webhooks",
+]);
 const ROOT_COMMANDS_HINT =
-  "Hint: get help on flags and subcommands by calling --help on each command.";
+  "Hint: commands suffixed with * have subcommands. Run <command> --help for details.";
 
 const EXAMPLES = [
   ["openclaw models --help", "Show detailed help for the models command."],
@@ -54,7 +82,11 @@ export function configureProgramHelp(program: Command, ctx: ProgramContext) {
     sortSubcommands: true,
     sortOptions: true,
     optionTerm: (option) => theme.option(option.flags),
-    subcommandTerm: (cmd) => theme.command(cmd.name()),
+    subcommandTerm: (cmd) => {
+      const isRootCommand = cmd.parent === program;
+      const hasSubcommands = isRootCommand && ROOT_COMMANDS_WITH_SUBCOMMANDS.has(cmd.name());
+      return theme.command(hasSubcommands ? `${cmd.name()} *` : cmd.name());
+    },
   });
 
   const formatHelpOutput = (str: string) => {

--- a/src/cli/program/help.ts
+++ b/src/cli/program/help.ts
@@ -56,24 +56,29 @@ export function configureProgramHelp(program: Command, ctx: ProgramContext) {
     subcommandTerm: (cmd) => theme.command(cmd.name()),
   });
 
+  const formatHelpOutput = (str: string) => {
+    let output = str;
+    const isRootHelp = new RegExp(
+      `^Usage:\\s+${CLI_NAME}\\s+\\[options\\]\\s+\\[command\\]\\s*$`,
+      "m",
+    ).test(output);
+    if (isRootHelp && /^Commands:/m.test(output)) {
+      output = output.replace(/^Commands:/m, `Commands:\n  ${theme.muted(ROOT_COMMANDS_HINT)}`);
+    }
+
+    return output
+      .replace(/^Usage:/gm, theme.heading("Usage:"))
+      .replace(/^Options:/gm, theme.heading("Options:"))
+      .replace(/^Commands:/gm, theme.heading("Commands:"));
+  };
+
   program.configureOutput({
     writeOut: (str) => {
-      let output = str;
-      const isRootHelp = new RegExp(
-        `^Usage:\\s+${CLI_NAME}\\s+\\[options\\]\\s+\\[command\\]\\s*$`,
-        "m",
-      ).test(output);
-      if (isRootHelp && /^Commands:/m.test(output)) {
-        output = output.replace(/^Commands:/m, `Commands:\n  ${theme.muted(ROOT_COMMANDS_HINT)}`);
-      }
-
-      const colored = output
-        .replace(/^Usage:/gm, theme.heading("Usage:"))
-        .replace(/^Options:/gm, theme.heading("Options:"))
-        .replace(/^Commands:/gm, theme.heading("Commands:"));
-      process.stdout.write(colored);
+      process.stdout.write(formatHelpOutput(str));
     },
-    writeErr: (str) => process.stderr.write(str),
+    writeErr: (str) => {
+      process.stderr.write(formatHelpOutput(str));
+    },
     outputError: (str, write) => write(theme.error(str)),
   });
 

--- a/src/cli/program/help.ts
+++ b/src/cli/program/help.ts
@@ -10,6 +10,7 @@ const ROOT_COMMANDS_HINT =
   "Hint: get help on flags and subcommands by calling --help on each command.";
 
 const EXAMPLES = [
+  ["openclaw models --help", "Show detailed help for the models command."],
   [
     "openclaw channels login --verbose",
     "Link personal WhatsApp Web and show QR + connection logs.",

--- a/src/cli/program/register.configure.ts
+++ b/src/cli/program/register.configure.ts
@@ -11,7 +11,7 @@ import { runCommandWithRuntime } from "../cli-utils.js";
 export function registerConfigureCommand(program: Command) {
   program
     .command("configure")
-    .description("Interactive prompt to set up credentials, devices, and agent defaults")
+    .description("Interactive setup wizard for credentials, channels, gateway, and agent defaults")
     .addHelpText(
       "after",
       () =>

--- a/src/cli/program/register.message.ts
+++ b/src/cli/program/register.message.ts
@@ -24,7 +24,7 @@ import { registerMessageThreadCommands } from "./message/register.thread.js";
 export function registerMessageCommands(program: Command, ctx: ProgramContext) {
   const message = program
     .command("message")
-    .description("Send messages and channel actions")
+    .description("Send, read, and manage messages and channel actions")
     .addHelpText(
       "after",
       () =>

--- a/src/cli/program/register.subclis.ts
+++ b/src/cli/program/register.subclis.ts
@@ -9,6 +9,7 @@ type SubCliRegistrar = (program: Command) => Promise<void> | void;
 type SubCliEntry = {
   name: string;
   description: string;
+  hasSubcommands: boolean;
   register: SubCliRegistrar;
 };
 
@@ -31,10 +32,14 @@ const loadConfig = async (): Promise<OpenClawConfig> => {
   return mod.loadConfig();
 };
 
+// Note for humans and agents:
+// If you update the list of commands, also check whether they have subcommands
+// and set the flag accordingly.
 const entries: SubCliEntry[] = [
   {
     name: "acp",
     description: "Agent Control Protocol tools",
+    hasSubcommands: true,
     register: async (program) => {
       const mod = await import("../acp-cli.js");
       mod.registerAcpCli(program);
@@ -43,6 +48,7 @@ const entries: SubCliEntry[] = [
   {
     name: "gateway",
     description: "Run, inspect, and query the WebSocket Gateway",
+    hasSubcommands: true,
     register: async (program) => {
       const mod = await import("../gateway-cli.js");
       mod.registerGatewayCli(program);
@@ -51,6 +57,7 @@ const entries: SubCliEntry[] = [
   {
     name: "daemon",
     description: "Gateway service (legacy alias)",
+    hasSubcommands: true,
     register: async (program) => {
       const mod = await import("../daemon-cli.js");
       mod.registerDaemonCli(program);
@@ -59,6 +66,7 @@ const entries: SubCliEntry[] = [
   {
     name: "logs",
     description: "Tail gateway file logs via RPC",
+    hasSubcommands: false,
     register: async (program) => {
       const mod = await import("../logs-cli.js");
       mod.registerLogsCli(program);
@@ -67,6 +75,7 @@ const entries: SubCliEntry[] = [
   {
     name: "system",
     description: "System events, heartbeat, and presence",
+    hasSubcommands: true,
     register: async (program) => {
       const mod = await import("../system-cli.js");
       mod.registerSystemCli(program);
@@ -75,6 +84,7 @@ const entries: SubCliEntry[] = [
   {
     name: "models",
     description: "Discover, scan, and configure models",
+    hasSubcommands: true,
     register: async (program) => {
       const mod = await import("../models-cli.js");
       mod.registerModelsCli(program);
@@ -83,6 +93,7 @@ const entries: SubCliEntry[] = [
   {
     name: "approvals",
     description: "Manage exec approvals (gateway or node host)",
+    hasSubcommands: true,
     register: async (program) => {
       const mod = await import("../exec-approvals-cli.js");
       mod.registerExecApprovalsCli(program);
@@ -91,6 +102,7 @@ const entries: SubCliEntry[] = [
   {
     name: "nodes",
     description: "Manage gateway-owned node pairing and node commands",
+    hasSubcommands: true,
     register: async (program) => {
       const mod = await import("../nodes-cli.js");
       mod.registerNodesCli(program);
@@ -99,6 +111,7 @@ const entries: SubCliEntry[] = [
   {
     name: "devices",
     description: "Device pairing + token management",
+    hasSubcommands: true,
     register: async (program) => {
       const mod = await import("../devices-cli.js");
       mod.registerDevicesCli(program);
@@ -107,6 +120,7 @@ const entries: SubCliEntry[] = [
   {
     name: "node",
     description: "Run and manage the headless node host service",
+    hasSubcommands: true,
     register: async (program) => {
       const mod = await import("../node-cli.js");
       mod.registerNodeCli(program);
@@ -115,6 +129,7 @@ const entries: SubCliEntry[] = [
   {
     name: "sandbox",
     description: "Manage sandbox containers for agent isolation",
+    hasSubcommands: true,
     register: async (program) => {
       const mod = await import("../sandbox-cli.js");
       mod.registerSandboxCli(program);
@@ -123,6 +138,7 @@ const entries: SubCliEntry[] = [
   {
     name: "tui",
     description: "Open a terminal UI connected to the Gateway",
+    hasSubcommands: false,
     register: async (program) => {
       const mod = await import("../tui-cli.js");
       mod.registerTuiCli(program);
@@ -131,6 +147,7 @@ const entries: SubCliEntry[] = [
   {
     name: "cron",
     description: "Manage cron jobs via the Gateway scheduler",
+    hasSubcommands: true,
     register: async (program) => {
       const mod = await import("../cron-cli.js");
       mod.registerCronCli(program);
@@ -139,6 +156,7 @@ const entries: SubCliEntry[] = [
   {
     name: "dns",
     description: "DNS helpers for wide-area discovery (Tailscale + CoreDNS)",
+    hasSubcommands: true,
     register: async (program) => {
       const mod = await import("../dns-cli.js");
       mod.registerDnsCli(program);
@@ -147,6 +165,7 @@ const entries: SubCliEntry[] = [
   {
     name: "docs",
     description: "Search the live OpenClaw docs",
+    hasSubcommands: false,
     register: async (program) => {
       const mod = await import("../docs-cli.js");
       mod.registerDocsCli(program);
@@ -155,6 +174,7 @@ const entries: SubCliEntry[] = [
   {
     name: "hooks",
     description: "Manage internal agent hooks",
+    hasSubcommands: true,
     register: async (program) => {
       const mod = await import("../hooks-cli.js");
       mod.registerHooksCli(program);
@@ -163,6 +183,7 @@ const entries: SubCliEntry[] = [
   {
     name: "webhooks",
     description: "Webhook helpers and integrations",
+    hasSubcommands: true,
     register: async (program) => {
       const mod = await import("../webhooks-cli.js");
       mod.registerWebhooksCli(program);
@@ -171,6 +192,7 @@ const entries: SubCliEntry[] = [
   {
     name: "qr",
     description: "Generate iOS pairing QR/setup code",
+    hasSubcommands: false,
     register: async (program) => {
       const mod = await import("../qr-cli.js");
       mod.registerQrCli(program);
@@ -179,6 +201,7 @@ const entries: SubCliEntry[] = [
   {
     name: "clawbot",
     description: "Legacy clawbot command aliases",
+    hasSubcommands: true,
     register: async (program) => {
       const mod = await import("../clawbot-cli.js");
       mod.registerClawbotCli(program);
@@ -187,6 +210,7 @@ const entries: SubCliEntry[] = [
   {
     name: "pairing",
     description: "Secure DM pairing (approve inbound requests)",
+    hasSubcommands: true,
     register: async (program) => {
       // Initialize plugins before registering pairing CLI.
       // The pairing CLI calls listPairingChannels() at registration time,
@@ -200,6 +224,7 @@ const entries: SubCliEntry[] = [
   {
     name: "plugins",
     description: "Manage OpenClaw plugins and extensions",
+    hasSubcommands: true,
     register: async (program) => {
       const mod = await import("../plugins-cli.js");
       mod.registerPluginsCli(program);
@@ -210,6 +235,7 @@ const entries: SubCliEntry[] = [
   {
     name: "channels",
     description: "Manage connected chat channels (Telegram, Discord, etc.)",
+    hasSubcommands: true,
     register: async (program) => {
       const mod = await import("../channels-cli.js");
       mod.registerChannelsCli(program);
@@ -218,6 +244,7 @@ const entries: SubCliEntry[] = [
   {
     name: "directory",
     description: "Lookup contact and group IDs (self, peers, groups) for supported chat channels",
+    hasSubcommands: true,
     register: async (program) => {
       const mod = await import("../directory-cli.js");
       mod.registerDirectoryCli(program);
@@ -226,6 +253,7 @@ const entries: SubCliEntry[] = [
   {
     name: "security",
     description: "Security tools and local config audits",
+    hasSubcommands: true,
     register: async (program) => {
       const mod = await import("../security-cli.js");
       mod.registerSecurityCli(program);
@@ -234,6 +262,7 @@ const entries: SubCliEntry[] = [
   {
     name: "skills",
     description: "List and inspect available skills",
+    hasSubcommands: true,
     register: async (program) => {
       const mod = await import("../skills-cli.js");
       mod.registerSkillsCli(program);
@@ -242,6 +271,7 @@ const entries: SubCliEntry[] = [
   {
     name: "update",
     description: "Update OpenClaw and inspect update channel status",
+    hasSubcommands: true,
     register: async (program) => {
       const mod = await import("../update-cli.js");
       mod.registerUpdateCli(program);
@@ -250,6 +280,7 @@ const entries: SubCliEntry[] = [
   {
     name: "completion",
     description: "Generate shell completion script",
+    hasSubcommands: false,
     register: async (program) => {
       const mod = await import("../completion-cli.js");
       mod.registerCompletionCli(program);
@@ -259,6 +290,10 @@ const entries: SubCliEntry[] = [
 
 export function getSubCliEntries(): SubCliEntry[] {
   return entries;
+}
+
+export function getSubCliCommandsWithSubcommands(): string[] {
+  return entries.filter((entry) => entry.hasSubcommands).map((entry) => entry.name);
 }
 
 function removeCommand(program: Command, command: Command) {

--- a/src/cli/program/register.subclis.ts
+++ b/src/cli/program/register.subclis.ts
@@ -42,7 +42,7 @@ const entries: SubCliEntry[] = [
   },
   {
     name: "gateway",
-    description: "Gateway control",
+    description: "Run, inspect, and query the WebSocket Gateway",
     register: async (program) => {
       const mod = await import("../gateway-cli.js");
       mod.registerGatewayCli(program);
@@ -58,7 +58,7 @@ const entries: SubCliEntry[] = [
   },
   {
     name: "logs",
-    description: "Gateway logs",
+    description: "Tail gateway file logs via RPC",
     register: async (program) => {
       const mod = await import("../logs-cli.js");
       mod.registerLogsCli(program);
@@ -74,7 +74,7 @@ const entries: SubCliEntry[] = [
   },
   {
     name: "models",
-    description: "Model configuration",
+    description: "Discover, scan, and configure models",
     register: async (program) => {
       const mod = await import("../models-cli.js");
       mod.registerModelsCli(program);
@@ -82,7 +82,7 @@ const entries: SubCliEntry[] = [
   },
   {
     name: "approvals",
-    description: "Exec approvals",
+    description: "Manage exec approvals (gateway or node host)",
     register: async (program) => {
       const mod = await import("../exec-approvals-cli.js");
       mod.registerExecApprovalsCli(program);
@@ -90,7 +90,7 @@ const entries: SubCliEntry[] = [
   },
   {
     name: "nodes",
-    description: "Node commands",
+    description: "Manage gateway-owned node pairing and node commands",
     register: async (program) => {
       const mod = await import("../nodes-cli.js");
       mod.registerNodesCli(program);
@@ -106,7 +106,7 @@ const entries: SubCliEntry[] = [
   },
   {
     name: "node",
-    description: "Node control",
+    description: "Run and manage the headless node host service",
     register: async (program) => {
       const mod = await import("../node-cli.js");
       mod.registerNodeCli(program);
@@ -114,7 +114,7 @@ const entries: SubCliEntry[] = [
   },
   {
     name: "sandbox",
-    description: "Sandbox tools",
+    description: "Manage sandbox containers for agent isolation",
     register: async (program) => {
       const mod = await import("../sandbox-cli.js");
       mod.registerSandboxCli(program);
@@ -122,7 +122,7 @@ const entries: SubCliEntry[] = [
   },
   {
     name: "tui",
-    description: "Terminal UI",
+    description: "Open a terminal UI connected to the Gateway",
     register: async (program) => {
       const mod = await import("../tui-cli.js");
       mod.registerTuiCli(program);
@@ -130,7 +130,7 @@ const entries: SubCliEntry[] = [
   },
   {
     name: "cron",
-    description: "Cron scheduler",
+    description: "Manage cron jobs via the Gateway scheduler",
     register: async (program) => {
       const mod = await import("../cron-cli.js");
       mod.registerCronCli(program);
@@ -138,7 +138,7 @@ const entries: SubCliEntry[] = [
   },
   {
     name: "dns",
-    description: "DNS helpers",
+    description: "DNS helpers for wide-area discovery (Tailscale + CoreDNS)",
     register: async (program) => {
       const mod = await import("../dns-cli.js");
       mod.registerDnsCli(program);
@@ -146,7 +146,7 @@ const entries: SubCliEntry[] = [
   },
   {
     name: "docs",
-    description: "Docs helpers",
+    description: "Search the live OpenClaw docs",
     register: async (program) => {
       const mod = await import("../docs-cli.js");
       mod.registerDocsCli(program);
@@ -154,7 +154,7 @@ const entries: SubCliEntry[] = [
   },
   {
     name: "hooks",
-    description: "Hooks tooling",
+    description: "Manage internal agent hooks",
     register: async (program) => {
       const mod = await import("../hooks-cli.js");
       mod.registerHooksCli(program);
@@ -162,7 +162,7 @@ const entries: SubCliEntry[] = [
   },
   {
     name: "webhooks",
-    description: "Webhook helpers",
+    description: "Webhook helpers and integrations",
     register: async (program) => {
       const mod = await import("../webhooks-cli.js");
       mod.registerWebhooksCli(program);
@@ -186,7 +186,7 @@ const entries: SubCliEntry[] = [
   },
   {
     name: "pairing",
-    description: "Pairing helpers",
+    description: "Secure DM pairing (approve inbound requests)",
     register: async (program) => {
       // Initialize plugins before registering pairing CLI.
       // The pairing CLI calls listPairingChannels() at registration time,
@@ -199,7 +199,7 @@ const entries: SubCliEntry[] = [
   },
   {
     name: "plugins",
-    description: "Plugin management",
+    description: "Manage OpenClaw plugins and extensions",
     register: async (program) => {
       const mod = await import("../plugins-cli.js");
       mod.registerPluginsCli(program);
@@ -209,7 +209,7 @@ const entries: SubCliEntry[] = [
   },
   {
     name: "channels",
-    description: "Channel management",
+    description: "Manage connected chat channels (Telegram, Discord, etc.)",
     register: async (program) => {
       const mod = await import("../channels-cli.js");
       mod.registerChannelsCli(program);
@@ -217,7 +217,7 @@ const entries: SubCliEntry[] = [
   },
   {
     name: "directory",
-    description: "Directory commands",
+    description: "Lookup contact and group IDs (self, peers, groups) for supported chat channels",
     register: async (program) => {
       const mod = await import("../directory-cli.js");
       mod.registerDirectoryCli(program);
@@ -225,7 +225,7 @@ const entries: SubCliEntry[] = [
   },
   {
     name: "security",
-    description: "Security helpers",
+    description: "Security tools and local config audits",
     register: async (program) => {
       const mod = await import("../security-cli.js");
       mod.registerSecurityCli(program);
@@ -233,7 +233,7 @@ const entries: SubCliEntry[] = [
   },
   {
     name: "skills",
-    description: "Skills management",
+    description: "List and inspect available skills",
     register: async (program) => {
       const mod = await import("../skills-cli.js");
       mod.registerSkillsCli(program);
@@ -241,7 +241,7 @@ const entries: SubCliEntry[] = [
   },
   {
     name: "update",
-    description: "CLI update helpers",
+    description: "Update OpenClaw and inspect update channel status",
     register: async (program) => {
       const mod = await import("../update-cli.js");
       mod.registerUpdateCli(program);

--- a/src/cli/security-cli.ts
+++ b/src/cli/security-cli.ts
@@ -7,6 +7,7 @@ import { formatDocsLink } from "../terminal/links.js";
 import { isRich, theme } from "../terminal/theme.js";
 import { shortenHomeInString, shortenHomePath } from "../utils.js";
 import { formatCliCommand } from "./command-format.js";
+import { formatHelpExamples } from "./help-format.js";
 
 type SecurityAuditOptions = {
   json?: boolean;
@@ -29,11 +30,16 @@ function formatSummary(summary: { critical: number; warn: number; info: number }
 export function registerSecurityCli(program: Command) {
   const security = program
     .command("security")
-    .description("Security tools (audit)")
+    .description("Audit local config and state for common security foot-guns")
     .addHelpText(
       "after",
       () =>
-        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/security", "docs.openclaw.ai/cli/security")}\n`,
+        `\n${theme.heading("Examples:")}\n${formatHelpExamples([
+          ["openclaw security audit", "Run a local security audit."],
+          ["openclaw security audit --deep", "Include best-effort live Gateway probe checks."],
+          ["openclaw security audit --fix", "Apply safe remediations and file-permission fixes."],
+          ["openclaw security audit --json", "Output machine-readable JSON."],
+        ])}\n\n${theme.muted("Docs:")} ${formatDocsLink("/cli/security", "docs.openclaw.ai/cli/security")}\n`,
     );
 
   security

--- a/src/cli/update-cli.ts
+++ b/src/cli/update-cli.ts
@@ -18,7 +18,7 @@ export type { UpdateCommandOptions, UpdateStatusOptions, UpdateWizardOptions };
 export function registerUpdateCli(program: Command) {
   const update = program
     .command("update")
-    .description("Update OpenClaw to the latest version")
+    .description("Update OpenClaw and inspect update channel status")
     .option("--json", "Output result as JSON", false)
     .option("--no-restart", "Skip restarting the gateway service after a successful update")
     .option("--channel <stable|beta|dev>", "Persist update channel (git + npm)")


### PR DESCRIPTION
This PR improves CLI help clarity and discoverability with a small UX pass.

- Clarifies `config` vs `configure` intent in top-level help and command help.
- Rewrites short top-level command descriptions to be more descriptive.
- Improves direct command help prose and adds concise examples for key commands (`channels`, `directory`, `security`, `memory`, `gateway`, `node`, `nodes`).
- Adds a root-only Commands hint (shown for both `openclaw` and `openclaw --help`, not subcommand help).
- Marks top-level commands with subcommands using `*` (for example `models *`) and explains the marker in the hint.
- Adds a root help example for command-specific help: `openclaw models --help`.

## Screenshots 

**Old descriptions 1 (non-speaking)** 
<img width="472" height="210" alt="image" src="https://github.com/user-attachments/assets/25d29d00-e114-4a5c-802b-db76d77ae7c4" />

**New command hint and descriptions**
<img width="818" height="232" alt="SCR-20260216-ryjp" src="https://github.com/user-attachments/assets/681f11c6-aa4c-4f05-808a-8dbd9d428a47" />

## Example improvement 

"config - config helpers" => "config - Non-interactive config helpers (get/set/unset). Default: starts setup wizard."

## Remarks by @bjesuiter 

- if the descriptions are too long now, we may shorten them. But i'd rather have these more descriptive ones than completely useless ones at the top-level help, especially since we don't see the detailed helps for the commands (would be too much, but are really helpful to infer the usage!)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a UX-focused pass on CLI help output — rewriting terse/generic command descriptions to be more descriptive and actionable, adding concise usage examples to key subcommand help pages, and marking commands that have subcommands with `*` in the root help listing.

- Rewrites top-level and subcommand descriptions across 15 files — e.g. `"Config helpers"` → `"Non-interactive config helpers (get/set/unset). Default: starts setup wizard."`, `"Memory commands"` → `"Search, inspect, and reindex memory files"`.
- Adds inline examples (via existing `formatHelpExamples` utility) to `channels`, `directory`, `security`, `memory`, `gateway`, `node`, and `nodes` help output.
- Introduces a hardcoded `ROOT_COMMANDS_WITH_SUBCOMMANDS` set in `help.ts` to suffix `*` markers on commands that have subcommands, with a hint line explaining the convention.
- Adds `formatHelpOutput` to both `writeOut` and `writeErr` handlers in Commander config, applying heading theming and the root-only hint consistently.
- Adds `"openclaw models --help"` as the first example in the root help to encourage command-specific help discovery.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — all changes are to help text strings and formatting, with no behavioral or logic changes.
- All 15 changed files contain only description string rewrites, help example additions, and a new formatting helper in help.ts. No runtime logic, control flow, or data handling is modified. The hardcoded ROOT_COMMANDS_WITH_SUBCOMMANDS set is accurate for current commands but introduces a maintenance obligation. The regex-based root help detection is correct. Score is 4 instead of 5 due to the maintenance risk of the hardcoded set and the unescaped regex interpolation (low risk but worth noting).
- src/cli/program/help.ts — contains new logic (ROOT_COMMANDS_WITH_SUBCOMMANDS set and formatHelpOutput function) that could drift if commands are added/removed without updating the set.

<sub>Last reviewed commit: c525f88</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->