### PR TITLE
[AI-assisted] fix: use per-account action config for Discord and Telegram gating

### DIFF
--- a/src/agents/tools/discord-actions.ts
+++ b/src/agents/tools/discord-actions.ts
@@ -1,5 +1,6 @@
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import type { OpenClawConfig } from "../../config/config.js";
+import { resolveDiscordAccount } from "../../discord/accounts.js";
 import { createActionGate, readStringParam } from "./common.js";
 import { handleDiscordGuildAction } from "./discord-actions-guild.js";
 import { handleDiscordMessagingAction } from "./discord-actions-messaging.js";
@@ -59,7 +60,9 @@ export async function handleDiscordAction(
   cfg: OpenClawConfig,
 ): Promise<AgentToolResult<unknown>> {
   const action = readStringParam(params, "action", { required: true });
-  const isActionEnabled = createActionGate(cfg.channels?.discord?.actions);
+  const accountId = readStringParam(params, "accountId");
+  const account = resolveDiscordAccount({ cfg, accountId });
+  const isActionEnabled = createActionGate(account.config.actions);
 
   if (messagingActions.has(action)) {
     return await handleDiscordMessagingAction(action, params, isActionEnabled);

--- a/src/agents/tools/telegram-actions.ts
+++ b/src/agents/tools/telegram-actions.ts
@@ -1,5 +1,6 @@
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import type { OpenClawConfig } from "../../config/config.js";
+import { resolveTelegramAccount } from "../../telegram/accounts.js";
 import type { TelegramButtonStyle, TelegramInlineButtons } from "../../telegram/button-types.js";
 import {
   resolveTelegramInlineButtonsScope,
@@ -87,7 +88,8 @@ export async function handleTelegramAction(
 ): Promise<AgentToolResult<unknown>> {
   const action = readStringParam(params, "action", { required: true });
   const accountId = readStringParam(params, "accountId");
-  const isActionEnabled = createActionGate(cfg.channels?.telegram?.actions);
+  const account = resolveTelegramAccount({ cfg, accountId });
+  const isActionEnabled = createActionGate(account.config.actions);
 
   if (action === "react") {
     // Check reaction level first

--- a/src/agents/tools/telegram-actions.ts
+++ b/src/agents/tools/telegram-actions.ts
@@ -1,7 +1,7 @@
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import type { OpenClawConfig } from "../../config/config.js";
-import { resolveTelegramAccount } from "../../telegram/accounts.js";
 import type { TelegramButtonStyle, TelegramInlineButtons } from "../../telegram/button-types.js";
+import { resolveTelegramAccount } from "../../telegram/accounts.js";
 import {
   resolveTelegramInlineButtonsScope,
   resolveTelegramTargetChatType,

--- a/src/channels/plugins/actions/discord.ts
+++ b/src/channels/plugins/actions/discord.ts
@@ -1,3 +1,4 @@
+import type { DiscordActionConfig } from "../../../config/types.discord.js";
 import type { ChannelMessageActionAdapter, ChannelMessageActionName } from "../types.js";
 import { createActionGate } from "../../../agents/tools/common.js";
 import { listEnabledDiscordAccounts } from "../../../discord/accounts.js";
@@ -11,7 +12,10 @@ export const discordMessageActions: ChannelMessageActionAdapter = {
     if (accounts.length === 0) {
       return [];
     }
-    const gate = createActionGate(cfg.channels?.discord?.actions);
+    // Union of all accounts' action gates (any account enabling an action makes it available)
+    const gates = accounts.map((a) => createActionGate(a.config.actions));
+    const gate = (key: keyof DiscordActionConfig, defaultValue = true) =>
+      gates.some((g) => g(key, defaultValue));
     const actions = new Set<ChannelMessageActionName>(["send"]);
     if (gate("polls")) {
       actions.add("poll");

--- a/src/channels/plugins/actions/telegram.ts
+++ b/src/channels/plugins/actions/telegram.ts
@@ -1,3 +1,4 @@
+import type { TelegramActionConfig } from "../../../config/types.telegram.js";
 import type { ChannelMessageActionAdapter, ChannelMessageActionName } from "../types.js";
 import {
   createActionGate,
@@ -46,7 +47,10 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
     if (accounts.length === 0) {
       return [];
     }
-    const gate = createActionGate(cfg.channels?.telegram?.actions);
+    // Union of all accounts' action gates (any account enabling an action makes it available)
+    const gates = accounts.map((a) => createActionGate(a.config.actions));
+    const gate = (key: keyof TelegramActionConfig, defaultValue = true) =>
+      gates.some((g) => g(key, defaultValue));
     const actions = new Set<ChannelMessageActionName>(["send"]);
     if (gate("reactions")) {
       actions.add("react");


### PR DESCRIPTION
## Summary

Per-account action config (`channels.discord.accounts.<id>.actions`) was ignored when listing and executing Discord/Telegram actions. Both `listActions` and `handleDiscordAction`/`handleTelegramAction` read only the top-level `cfg.channels.discord.actions`, so default-false action categories (`moderation`, `roles`, `presence`) could never be enabled per-account.

- **Discord `listActions`**: replaced global gate with per-account iteration using pre-computed gates from `listEnabledDiscordAccounts()` (follows Signal pattern at `signal.ts:54-56`)
- **`handleDiscordAction`**: now resolves per-account config via `resolveDiscordAccount({ cfg, accountId })` instead of reading global config
- **Telegram**: same fix applied to `telegram.ts` and `telegram-actions.ts`

## AI Disclosure

This PR was AI-assisted (Claude). Lightly tested — confirmed working with multiple Discord agents: an agent with `moderation: true` could timeout users, while agents without the permission correctly could not.

## Test plan

- [x] Tested locally with OpenClaw instance on Discord (timeout action with per-account moderation config)
- [x] `pnpm build && pnpm check` passes
- [x] `actions.test.ts` — 32 tests pass (includes new per-account gating tests for Discord and Telegram)
- [x] New tests cover: per-account moderation enabled, union of multiple accounts, account-specific execution gating
- [ ] CI checks

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed per-account action gating for Discord and Telegram channels. Previously, `listActions` and action handlers only checked top-level `cfg.channels.discord.actions`, ignoring per-account config at `cfg.channels.discord.accounts.<id>.actions`. This meant default-false action categories (`moderation`, `roles`, `presence` for Discord; `sticker` for Telegram) couldn't be enabled per-account.

**Key changes:**
- `discord.ts` and `telegram.ts` `listActions` now compute union of all account gates (any account enabling an action makes it available)
- `handleDiscordAction` and `handleTelegramAction` now resolve per-account config via `resolveDiscordAccount` / `resolveTelegramAccount` instead of reading global config
- Pattern follows Signal implementation at `signal.ts:54-56`
- Comprehensive test coverage added for per-account gating scenarios

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix correctly implements per-account action gating by resolving account-specific config instead of using global config. The implementation follows the existing Signal pattern, uses proper account resolution utilities, and includes comprehensive test coverage (32 passing tests including new per-account scenarios). The shallow merge behavior is correctly documented in tests, and the union logic for `listActions` properly enables actions if any account has them enabled.
- No files require special attention

<sub>Last reviewed commit: dfd87b9</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->