### PR TITLE
fix: include OPENCLAW_SERVICE_VERSION in system presence version detection

### DIFF
--- a/src/infra/system-presence.ts
+++ b/src/infra/system-presence.ts
@@ -50,7 +50,7 @@ function resolvePrimaryIPv4(): string | undefined {
 function initSelfPresence() {
   const host = os.hostname();
   const ip = resolvePrimaryIPv4() ?? undefined;
-  const version = process.env.OPENCLAW_VERSION ?? process.env.npm_package_version ?? "unknown";
+  const version = process.env.OPENCLAW_VERSION ?? process.env.OPENCLAW_SERVICE_VERSION ?? process.env.npm_package_version ?? "unknown";
   const modelIdentifier = (() => {
     const p = os.platform();
     if (p === "darwin") {


### PR DESCRIPTION
## Summary

The gateway's  was not detecting the version when OpenClaw is run as a launchd service, because  sets  but  only checked  and .

This caused `openclaw status` to show 'unknown' for the version.

## Fix

Added `OPENCLAW_SERVICE_VERSION` to the fallback chain in :

```typescript
const version = process.env.OPENCLAW_VERSION ?? process.env.OPENCLAW_SERVICE_VERSION ?? process.env.npm_package_version ?? "unknown";
```

## Testing

Verified locally - the gateway now reports the correct version (2026.2.15) in system presence.

Fixes #18456

🤖 AI-assisted (lightly tested)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `OPENCLAW_SERVICE_VERSION` to the version detection fallback chain in `initSelfPresence()` to fix `openclaw status` showing 'unknown' when running as a launchd service.

The service environment builder (`src/daemon/service-env.ts`) sets `OPENCLAW_SERVICE_VERSION` but the system presence code only checked `OPENCLAW_VERSION` and `npm_package_version`, causing version detection to fail for service deployments. The fix correctly positions `OPENCLAW_SERVICE_VERSION` between `OPENCLAW_VERSION` and `npm_package_version` in the fallback chain.

- One minor inconsistency: the WebSocket handler at `src/gateway/server/ws-connection/message-handler.ts:830` doesn't include this environment variable check and may benefit from the same update for consistency.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a simple, well-targeted fix that adds a missing environment variable to an existing fallback chain. The logic is correct, follows established patterns in the codebase (service environment variables are set in service-env.ts), and has been locally verified. The change is minimal (one line), doesn't introduce any new logic or side effects, and addresses a specific bug where version detection failed in service deployments.
- No files require special attention

<sub>Last reviewed commit: 6291aa0</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->