### PR TITLE
gateway: hard-cap chat.history oversized payloads

### DIFF
--- a/src/gateway/server.chat.gateway-server-chat-b.e2e.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.e2e.test.ts
@@ -124,6 +124,66 @@ describe("gateway server chat", () => {
     }
   });
 
+  test("chat.history hard-caps single oversized nested payloads", async () => {
+    const tempDirs: string[] = [];
+    const { server, ws } = await startServerWithClient();
+    try {
+      const historyMaxBytes = 64 * 1024;
+      __setMaxChatHistoryMessagesBytesForTest(historyMaxBytes);
+      await connectOk(ws);
+
+      const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+      tempDirs.push(sessionDir);
+      testState.sessionStorePath = path.join(sessionDir, "sessions.json");
+
+      await writeSessionStore({
+        entries: {
+          main: { sessionId: "sess-main", updatedAt: Date.now() },
+        },
+      });
+
+      const hugeNestedText = "n".repeat(450_000);
+      const oversizedLine = JSON.stringify({
+        message: {
+          role: "assistant",
+          timestamp: Date.now(),
+          content: [
+            {
+              type: "tool_result",
+              toolUseId: "tool-1",
+              output: {
+                nested: {
+                  payload: hugeNestedText,
+                },
+              },
+            },
+          ],
+        },
+      });
+      await fs.writeFile(path.join(sessionDir, "sess-main.jsonl"), `${oversizedLine}\n`, "utf-8");
+
+      const historyRes = await rpcReq<{ messages?: unknown[] }>(ws, "chat.history", {
+        sessionKey: "main",
+        limit: 1000,
+      });
+      expect(historyRes.ok).toBe(true);
+      const messages = historyRes.payload?.messages ?? [];
+      expect(messages.length).toBe(1);
+
+      const serialized = JSON.stringify(messages);
+      const bytes = Buffer.byteLength(serialized, "utf8");
+      expect(bytes).toBeLessThanOrEqual(historyMaxBytes);
+      expect(serialized).toContain("[chat.history omitted: message too large]");
+      expect(serialized.includes(hugeNestedText.slice(0, 256))).toBe(false);
+    } finally {
+      __setMaxChatHistoryMessagesBytesForTest();
+      testState.sessionStorePath = undefined;
+      ws.close();
+      await server.close();
+      await Promise.all(tempDirs.map((dir) => fs.rm(dir, { recursive: true, force: true })));
+    }
+  });
+
   test("smoke: supports abort and idempotent completion", async () => {
     const tempDirs: string[] = [];
     const { server, ws } = await startServerWithClient();


### PR DESCRIPTION
## Summary

- Problem: `chat.history` could return oversized nested payloads (for example large `tool_result` objects) that cause WebChat to freeze/blank.
- Why it matters: users cannot open/use Chat for affected long-running sessions.
- What changed:
  - Added `chat.history` sanitization for oversized/high-cost fields.
  - Added hard-cap fallback so response size always stays within configured byte cap, including single-oversized-message cases.
  - Added regression e2e test for single oversized nested payload.
- What did NOT change (scope boundary):
  - No session file format migration.
  - No model/tool execution path changes.
  - No config schema changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #18481

## User-visible / Behavior Changes

- `chat.history` now remains bounded under configured byte cap even when history contains a single oversized nested payload.
- Oversized message entries may be replaced with a lightweight placeholder (`[chat.history omitted: message too large]`) instead of returning huge raw payloads.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No

## Repo + Verification

### Environment

- OS: macOS (arm64)
- Runtime/container: Node.js + pnpm
- Model/provider: N/A
- Integration/channel (if any): Gateway WebChat
- Relevant config (redacted): default + test byte cap override in e2e

### Steps

1. Create a session transcript containing one oversized nested `tool_result` payload.
2. Call `chat.history` with high `limit`.
3. Observe returned payload size and message content.

### Expected

- History response is returned promptly and remains within max byte cap.

### Actual

- Before fix: response could include oversized payload and freeze/blank WebChat.
- After fix: oversized message is bounded/sanitized and response remains under cap.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Passing checks run for this PR:

- `pnpm vitest run --config vitest.e2e.config.ts src/gateway/server.chat.gateway-server-chat-b.e2e.test.ts`
- `pnpm oxfmt --check src/gateway/server-methods/chat.ts src/gateway/server.chat.gateway-server-chat-b.e2e.test.ts`

Changed files:

- `src/gateway/server-methods/chat.ts`
- `src/gateway/server.chat.gateway-server-chat-b.e2e.test.ts`

## Human Verification (required)

- Verified scenarios:
  - Single oversized nested history message is hard-capped safely.
  - Existing history cap behavior still works.
- Edge cases checked:
  - Single-item oversized history.
  - Placeholder fallback path.
- What I did **not** verify:
  - Full cross-channel manual UX on all platforms.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No

## Failure Recovery (if this breaks)

- How to disable/revert quickly: revert this PR commit.
- Files/config to restore:
  - `src/gateway/server-methods/chat.ts`
  - `src/gateway/server.chat.gateway-server-chat-b.e2e.test.ts`
- Known bad symptoms reviewers should watch for:
  - Missing expected history fields in edge clients that rely on oversized raw nested payloads.

## Risks and Mitigations

- Risk: Some oversized nested history detail is no longer returned verbatim.
- Mitigation: Preserve response stability and explicit placeholder marker; keep regression test coverage for cap guarantees.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds multi-layer sanitization to `chat.history` to prevent oversized payloads from freezing WebChat. The approach is layered: (1) field-level truncation of known large text fields at 12K chars, (2) stripping metadata fields (`details`, `usage`, `cost`, `thinkingSignature`), (3) image data omission, (4) per-message 128KB hard cap with placeholder replacement, and (5) a final byte-budget enforcement pass. The defensive fallback chain ensures the response always stays within the configured byte limit, even for single oversized messages that `capArrayByJsonBytes` alone cannot trim.

- Adds `sanitizeChatHistoryMessages` pipeline (field-level truncation + metadata stripping) before the existing byte-cap logic
- Adds `enforceChatHistoryHardCap` as a post-cap safety net that replaces individual messages exceeding 128KB with lightweight placeholders
- Adds regression e2e test covering the single-oversized-nested-payload scenario
- No config schema or session format changes; backward compatible

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk — it adds read-path sanitization with no changes to session storage or model execution.
- The changes are well-scoped to the chat.history read path only, with multiple defensive fallback layers. The logic is sound and handles edge cases properly. The only minor concern is that `jsonUtf8Bytes` is duplicated from `session-utils.fs.ts` rather than reused, but this is a style issue, not a correctness issue. The e2e test validates the core scenario.
- No files require special attention. The changes in `src/gateway/server-methods/chat.ts` are additive sanitization functions with a clear fallback chain.

<sub>Last reviewed commit: 8634fe1</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->