### PR TITLE
feat(discord): Add resolveUser action for username-based user lookup

### DIFF
--- a/src/agents/tools/discord-actions-guild.ts
+++ b/src/agents/tools/discord-actions-guild.ts
@@ -1,5 +1,7 @@
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import type { DiscordActionConfig } from "../../config/config.js";
+import { loadConfig } from "../../config/config.js";
+import { resolveDiscordAccount } from "../../discord/accounts.js";
 import { getPresence } from "../../discord/monitor/presence-cache.js";
 import { resolveDiscordUserAllowlist } from "../../discord/resolve-users.js";
 import {
@@ -70,13 +72,13 @@ export async function handleDiscordGuildAction(
         throw new Error("Discord user resolution is disabled.");
       }
       const query = readStringParam(params, "query", { required: true });
-      const cfg = await import("../../config/config.js");
-      const token = cfg.default.channels?.discord?.token;
-      if (!token) {
+      const cfg = loadConfig();
+      const account = resolveDiscordAccount({ cfg, accountId });
+      if (!account.token) {
         throw new Error("Discord token not configured.");
       }
       const results = await resolveDiscordUserAllowlist({
-        token,
+        token: account.token,
         entries: [query],
       });
       return jsonResult({ ok: true, results });

--- a/src/agents/tools/discord-actions.ts
+++ b/src/agents/tools/discord-actions.ts
@@ -28,6 +28,7 @@ const messagingActions = new Set([
 
 const guildActions = new Set([
   "memberInfo",
+  "resolveUser",
   "roleInfo",
   "emojiList",
   "emojiUpload",

--- a/src/channels/plugins/actions/discord/handle-action.ts
+++ b/src/channels/plugins/actions/discord/handle-action.ts
@@ -202,6 +202,18 @@ export async function handleDiscordMessageAction(
     );
   }
 
+  if (action === "resolveUser") {
+    const query = readStringParam(params, "query", { required: true });
+    return await handleDiscordAction(
+      {
+        action: "resolveUser",
+        accountId: accountId ?? undefined,
+        query,
+      },
+      cfg,
+    );
+  }
+
   if (action === "thread-create") {
     const name = readStringParam(params, "threadName", { required: true });
     const messageId = readStringParam(params, "messageId");

--- a/src/channels/plugins/message-action-names.ts
+++ b/src/channels/plugins/message-action-names.ts
@@ -20,6 +20,7 @@ export const CHANNEL_MESSAGE_ACTION_NAMES = [
   "unpin",
   "list-pins",
   "permissions",
+  "resolveUser",
   "thread-create",
   "thread-list",
   "thread-reply",

--- a/src/infra/outbound/message-action-spec.ts
+++ b/src/infra/outbound/message-action-spec.ts
@@ -25,6 +25,7 @@ export const MESSAGE_ACTION_TARGET_MODE: Record<ChannelMessageActionName, Messag
     unpin: "to",
     "list-pins": "to",
     permissions: "to",
+    resolveUser: "none",
     "thread-create": "to",
     "thread-list": "none",
     "thread-reply": "to",

--- a/test-resolve-user.ts
+++ b/test-resolve-user.ts
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+
+// Test script for Discord user resolution
+import { loadConfig } from "./src/config/config.ts";
+import { resolveDiscordAccount } from "./src/discord/accounts.ts";
+import { resolveDiscordUserAllowlist } from "./src/discord/resolve-users.ts";
+
+async function testResolveUser() {
+  console.log("Loading config...");
+  const cfg = loadConfig();
+
+  console.log("Resolving Discord account...");
+  const account = resolveDiscordAccount({ cfg });
+
+  if (!account.token) {
+    console.error("❌ No Discord token found in config");
+    console.log("Set it with: openclaw configure discord");
+    process.exit(1);
+  }
+
+  console.log("✓ Discord token found");
+
+  const testUser = process.argv[2] || "ahsan";
+  console.log(`\n🔍 Resolving user: "${testUser}"\n`);
+
+  try {
+    const results = await resolveDiscordUserAllowlist({
+      token: account.token,
+      entries: [testUser],
+    });
+
+    console.log("Results:");
+    console.log(JSON.stringify(results, null, 2));
+
+    const resolved = results.find((r) => r.resolved);
+    if (resolved) {
+      console.log(`\n✅ SUCCESS! Found user:`);
+      console.log(`   ID: ${resolved.id}`);
+      console.log(`   Name: ${resolved.name}`);
+      console.log(`   Guild: ${resolved.guildName || "N/A"} (${resolved.guildId || "N/A"})`);
+      if (resolved.note) {
+        console.log(`   Note: ${resolved.note}`);
+      }
+    } else {
+      console.log(`\n❌ User "${testUser}" not found`);
+    }
+  } catch (error: unknown) {
+    console.error(`\n❌ Error: ${error instanceof Error ? error.message : String(error)}`);
+    if (error instanceof Error) {
+      console.error(error.stack);
+    }
+  }
+}
+
+testResolveUser().catch(console.error);


### PR DESCRIPTION
## Summary

Adds a new `resolveUser` action to the Discord integration that allows searching for Discord users by username across servers where the bot is a member.

## Problem

Previously, Discord user lookup was only possible by user ID. Users had to manually copy User IDs from Discord to reference other users through the bot, which was cumbersome and not user-friendly.

## Solution

Leverages the existing `resolveDiscordUserAllowlist` function which uses Discord's `/guilds/{guild.id}/members/search` API to search for users by username, nickname, or global name across all accessible guilds.

## Usage

```json
{
  action: resolveUser,
  query: username           // or "guild/username", "@username", or "user:ID"
}
```

**Examples:**
- `query: "ahsan"` - searches all guilds for username
- `query: "MyServer/ahsan"` - searches specific guild
- `query: "@ahsan"` - searches with @ prefix
- `query: "user:123456789"` - resolves by ID directly

## Response

```json
{
  "ok": true,
  "results": [
    {
      "input": "ahsan",
      "resolved": true,
      "id": "1473015907243790509",
      "name": "Ahsan",
      "guildId": "1472551850682089534",
      "guildName": "AhsanDev",
      "note": "multiple matches; chose best"
    }
  ]
}
```

## Changes

- `src/agents/tools/discord-actions-guild.ts` - Added resolveUser action handler
- `src/agents/tools/discord-actions.ts` - Registered resolveUser in guildActions
- `src/channels/plugins/actions/discord/handle-action.ts` - Exposed resolveUser through message tool
- `src/channels/plugins/message-action-names.ts` - Added to action names list
- `src/infra/outbound/message-action-spec.ts` - Added target mode specification
- `test-resolve-user.ts` - Added test script for verification

## Testing

Tested locally with:
```bash
npx tsx test-resolve-user.ts ahsan
```

Successfully resolves users across shared Discord servers.

## Limitations

- Users must be in at least one Discord server where the bot is a member
- Bot requires "Server Intent: Members" permission
- Cannot search Discord's global user database (Discord privacy feature)
- Users not in shared servers cannot be found by username

## Notes

This feature works within Discord's privacy model - it can only search members of servers the bot has access to, which is the only supported method for username-based user lookup.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a `resolveUser` action to the Discord integration, allowing username-based user lookup across guilds where the bot is a member. The implementation leverages the existing `resolveDiscordUserAllowlist` function and wires it through the guild action handler, message action handler, and action name/spec registries.

- The action name `resolveUser` uses camelCase in `message-action-names.ts`, which is inconsistent with the kebab-case convention used by all other Discord-specific actions (`member-info`, `role-info`, `channel-create`, etc.). It should be `resolve-user` with a mapping in `handle-action.guild-admin.ts`.
- A manual test script (`test-resolve-user.ts`) is committed at the project root, which is non-standard — all other test files live inside `src/`, `test/`, `scripts/`, or `extensions/`.
- The `resolveUser` action is gated behind the `memberInfo` permission flag without a dedicated config key, meaning operators cannot independently control this capability.

<h3>Confidence Score: 3/5</h3>

- Functionally correct but has naming convention inconsistencies and a stray test file that should be addressed before merging.
- The core logic is sound — it correctly uses the existing `resolveDiscordUserAllowlist` function and properly validates the token. However, the naming convention inconsistency (camelCase vs kebab-case) breaks the established pattern for Discord actions and the handler placement diverges from the existing guild-admin pattern. The committed root-level test script is a development artifact.
- `src/channels/plugins/message-action-names.ts` (naming convention), `test-resolve-user.ts` (should not be at project root), `src/channels/plugins/actions/discord/handle-action.ts` (handler placement diverges from pattern)

<sub>Last reviewed commit: 68b61ec</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->