### PR TITLE
chore: normalize UK spelling behaviour → behavior in cron store

### DIFF
--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -384,7 +384,7 @@ export async function ensureLoaded(
         }
       } else if (modeRaw === undefined || modeRaw === null) {
         // Explicitly persist the default so existing jobs don't silently
-        // change behaviour when the runtime default shifts.
+        // change behavior when the runtime default shifts.
         (delivery as { mode?: unknown }).mode = "announce";
         mutated = true;
       }


### PR DESCRIPTION
Normalizes one instance of UK English spelling (`behaviour`) to US English (`behavior`) in `src/cron/service/store.ts` for consistency with the rest of the codebase.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR normalizes a single UK English spelling (`behaviour`) to US English (`behavior`) in a comment within `src/cron/service/store.ts:387`. The change ensures consistency with the rest of the codebase, which uses US English spelling throughout (442 instances of "behavior" found, zero instances of "behaviour" remain after this change).

<h3>Confidence Score: 5/5</h3>

- This PR is completely safe to merge with zero risk
- The change is a trivial spelling correction in a code comment that has no impact on functionality, logic, or runtime behavior. The change aligns with the codebase's existing US English spelling convention (442 instances of "behavior" vs 0 remaining instances of "behaviour").
- No files require special attention

<sub>Last reviewed commit: 0afc6e5</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->