### PR TITLE
docs(exec): document pty for TTY-only CLIs (gog), closes #18506

### DIFF
--- a/docs/tools/exec.md
+++ b/docs/tools/exec.md
@@ -20,7 +20,7 @@ Background sessions are scoped per agent; `process` only sees sessions from the 
 - `yieldMs` (default 10000): auto-background after delay
 - `background` (bool): background immediately
 - `timeout` (seconds, default 1800): kill on expiry
-- `pty` (bool): run in a pseudo-terminal when available (TTY-only CLIs, coding agents, terminal UIs)
+- `pty` (bool): run in a pseudo-terminal when available (TTY-only CLIs, coding agents, terminal UIs). Use for CLIs that only print when stdout is a TTY (e.g. gog / Google Workspace CLI).
 - `host` (`sandbox | gateway | node`): where to execute
 - `security` (`deny | allowlist | full`): enforcement mode for `gateway`/`node`
 - `ask` (`off | on-miss | always`): approval prompts for `gateway`/`node`
@@ -41,6 +41,19 @@ Notes:
 - Important: sandboxing is **off by default**. If sandboxing is off, `host=sandbox` runs directly on
   the gateway host (no container) and **does not require approvals**. To require approvals, run with
   `host=gateway` and configure exec approvals (or enable sandboxing).
+
+### TTY-only CLIs (e.g. gog)
+
+Some CLIs write to stdout only when it is a TTY. In non-interactive contexts (exec tool, scripts, CI)
+they exit with code 0 but produce no output. Examples: **gog** (Google Workspace CLI), and other
+tools that use `isatty(stdout)` to decide whether to print. For these, set **`pty: true`** so the
+command runs in a pseudo-terminal and output is captured.
+
+Example:
+
+```json
+{ "tool": "exec", "command": "gog --version", "pty": true }
+```
 
 ## Config
 

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -117,7 +117,7 @@ export const execSchema = Type.Object({
   pty: Type.Optional(
     Type.Boolean({
       description:
-        "Run in a pseudo-terminal (PTY) when available (TTY-required CLIs, coding agents)",
+        "Run in a pseudo-terminal (PTY) when available (TTY-required CLIs e.g. gog, coding agents)",
     }),
   ),
   elevated: Type.Optional(

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -149,7 +149,7 @@ export function createExecTool(
     name: "exec",
     label: "exec",
     description:
-      "Execute shell commands with background continuation. Use yieldMs/background to continue later via process tool. Use pty=true for TTY-required commands (terminal UIs, coding agents).",
+      "Execute shell commands with background continuation. Use yieldMs/background to continue later via process tool. Use pty=true for TTY-required commands (e.g. gog, terminal UIs, coding agents).",
     parameters: execSchema,
     execute: async (_toolCallId, args, signal, onUpdate) => {
       const params = args as {


### PR DESCRIPTION
Documents that `pty: true` fixes no-output when running TTY-only CLIs (e.g. **gog** / Google Workspace CLI) via the exec tool. Adds a "TTY-only CLIs (e.g. gog)" subsection in exec docs and mentions gog in the exec tool description and pty schema so the agent is more likely to use `pty: true` for such commands.

- Closes #18506
- Docs only; no behavior change.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Documents the `pty: true` parameter as a fix for TTY-only CLIs (like `gog` / Google Workspace CLI) that produce no output in non-interactive contexts. The PR adds a dedicated "TTY-only CLIs" subsection in `docs/tools/exec.md` with an example, and mentions `gog` in both the exec tool description and the `pty` schema description so agents are more likely to suggest `pty: true` for such commands.

- Adds "TTY-only CLIs (e.g. gog)" subsection to exec docs with explanation and JSON example
- Updates `pty` schema description in `bash-tools.exec-runtime.ts` to mention `gog` as an example
- Updates exec tool description in `bash-tools.exec.ts` to include `gog` in the parenthetical examples
- No behavioral changes; docs and description strings only

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it contains only documentation and description string changes with no behavioral impact.
- All three changes are purely textual: one doc file update with a new subsection and two tool description string tweaks. No logic, control flow, or runtime behavior is affected. The content is accurate and consistent with existing conventions.
- No files require special attention.

<sub>Last reviewed commit: 5f65c57</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->