### PR TITLE
fix(doctor): reconcile gateway service token drift after re-pair

### DIFF
--- a/src/commands/doctor-gateway-services.test.ts
+++ b/src/commands/doctor-gateway-services.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+
+const mocks = vi.hoisted(() => ({
+  readCommand: vi.fn(),
+  install: vi.fn(),
+  auditGatewayServiceConfig: vi.fn(),
+  buildGatewayInstallPlan: vi.fn(),
+  resolveGatewayPort: vi.fn(() => 18789),
+  resolveIsNixMode: vi.fn(() => false),
+  note: vi.fn(),
+}));
+
+vi.mock("../config/paths.js", () => ({
+  resolveGatewayPort: mocks.resolveGatewayPort,
+  resolveIsNixMode: mocks.resolveIsNixMode,
+}));
+
+vi.mock("../daemon/inspect.js", () => ({
+  findExtraGatewayServices: vi.fn().mockResolvedValue([]),
+  renderGatewayServiceCleanupHints: vi.fn().mockReturnValue([]),
+}));
+
+vi.mock("../daemon/runtime-paths.js", () => ({
+  renderSystemNodeWarning: vi.fn().mockReturnValue(undefined),
+  resolveSystemNodeInfo: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("../daemon/service-audit.js", () => ({
+  auditGatewayServiceConfig: mocks.auditGatewayServiceConfig,
+  needsNodeRuntimeMigration: vi.fn(() => false),
+  SERVICE_AUDIT_CODES: {
+    gatewayEntrypointMismatch: "gateway-entrypoint-mismatch",
+  },
+}));
+
+vi.mock("../daemon/service.js", () => ({
+  resolveGatewayService: () => ({
+    readCommand: mocks.readCommand,
+    install: mocks.install,
+  }),
+}));
+
+vi.mock("../terminal/note.js", () => ({
+  note: mocks.note,
+}));
+
+vi.mock("./daemon-install-helpers.js", () => ({
+  buildGatewayInstallPlan: mocks.buildGatewayInstallPlan,
+}));
+
+import { maybeRepairGatewayServiceConfig } from "./doctor-gateway-services.js";
+
+describe("maybeRepairGatewayServiceConfig", () => {
+  it("treats gateway.auth.token as source of truth for service token repairs", async () => {
+    mocks.readCommand.mockResolvedValue({
+      programArguments: ["/usr/bin/node", "/usr/local/bin/openclaw", "gateway", "--port", "18789"],
+      environment: {
+        OPENCLAW_GATEWAY_TOKEN: "stale-token",
+      },
+    });
+    mocks.auditGatewayServiceConfig.mockResolvedValue({
+      ok: false,
+      issues: [
+        {
+          code: "gateway-token-mismatch",
+          message: "Gateway service OPENCLAW_GATEWAY_TOKEN does not match gateway.auth.token",
+          level: "recommended",
+        },
+      ],
+    });
+    mocks.buildGatewayInstallPlan.mockResolvedValue({
+      programArguments: ["/usr/bin/node", "/usr/local/bin/openclaw", "gateway", "--port", "18789"],
+      workingDirectory: "/tmp",
+      environment: {
+        OPENCLAW_GATEWAY_TOKEN: "config-token",
+      },
+    });
+    mocks.install.mockResolvedValue(undefined);
+
+    const cfg: OpenClawConfig = {
+      gateway: {
+        auth: {
+          mode: "token",
+          token: "config-token",
+        },
+      },
+    };
+
+    await maybeRepairGatewayServiceConfig(
+      cfg,
+      "local",
+      { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      {
+        confirm: vi.fn().mockResolvedValue(true),
+        confirmRepair: vi.fn().mockResolvedValue(true),
+        confirmAggressive: vi.fn().mockResolvedValue(true),
+        confirmSkipInNonInteractive: vi.fn().mockResolvedValue(true),
+        select: vi.fn().mockResolvedValue("node"),
+        shouldRepair: false,
+        shouldForce: false,
+      },
+    );
+
+    expect(mocks.auditGatewayServiceConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expectedGatewayToken: "config-token",
+      }),
+    );
+    expect(mocks.buildGatewayInstallPlan).toHaveBeenCalledWith(
+      expect.objectContaining({
+        token: "config-token",
+      }),
+    );
+    expect(mocks.install).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/commands/doctor-gateway-services.ts
+++ b/src/commands/doctor-gateway-services.ts
@@ -118,6 +118,7 @@ export async function maybeRepairGatewayServiceConfig(
   const audit = await auditGatewayServiceConfig({
     env: process.env,
     command,
+    expectedGatewayToken: cfg.gateway?.auth?.token,
   });
   const needsNodeRuntime = needsNodeRuntimeMigration(audit.issues);
   const systemNodeInfo = needsNodeRuntime

--- a/src/daemon/service-audit.test.ts
+++ b/src/daemon/service-audit.test.ts
@@ -60,4 +60,40 @@ describe("auditGatewayServiceConfig", () => {
       audit.issues.some((issue) => issue.code === SERVICE_AUDIT_CODES.gatewayPathMissingDirs),
     ).toBe(false);
   });
+
+  it("flags gateway token mismatch when service token is stale", async () => {
+    const audit = await auditGatewayServiceConfig({
+      env: { HOME: "/tmp" },
+      platform: "linux",
+      expectedGatewayToken: "new-token",
+      command: {
+        programArguments: ["/usr/bin/node", "gateway"],
+        environment: {
+          PATH: "/usr/local/bin:/usr/bin:/bin",
+          OPENCLAW_GATEWAY_TOKEN: "old-token",
+        },
+      },
+    });
+    expect(
+      audit.issues.some((issue) => issue.code === SERVICE_AUDIT_CODES.gatewayTokenMismatch),
+    ).toBe(true);
+  });
+
+  it("does not flag gateway token mismatch when service token matches config token", async () => {
+    const audit = await auditGatewayServiceConfig({
+      env: { HOME: "/tmp" },
+      platform: "linux",
+      expectedGatewayToken: "new-token",
+      command: {
+        programArguments: ["/usr/bin/node", "gateway"],
+        environment: {
+          PATH: "/usr/local/bin:/usr/bin:/bin",
+          OPENCLAW_GATEWAY_TOKEN: "new-token",
+        },
+      },
+    });
+    expect(
+      audit.issues.some((issue) => issue.code === SERVICE_AUDIT_CODES.gatewayTokenMismatch),
+    ).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

- Problem: after re-pairing or token rotation, the gateway service environment token (`OPENCLAW_GATEWAY_TOKEN`) can drift from `gateway.auth.token` in `openclaw.json`.
- Why it matters: doctor audited service runtime/path settings but did not detect token drift, so local gateway auth could fail with unauthorized token mismatch during cron/tool calls.
- What changed: added token-drift auditing in service audit (`gateway-token-mismatch`) and wired doctor service audit to pass `cfg.gateway.auth.token` as the expected authoritative token.
- What did NOT change (scope boundary): no changes to pairing token format/protocol, no auth mode defaults, no channel routing behavior changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #18175
- Related #18175

## User-visible / Behavior Changes

- `openclaw doctor` now detects when the installed gateway service token env is stale or missing compared to `gateway.auth.token` in config, and offers the existing service repair/update flow.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`Yes`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  - Risk: false-positive token mismatch prompts service reinstall.
  - Mitigation: drift check only applies when config token exists; repair remains behind existing doctor confirmation flow.

## Repro + Verification

### Environment

- OS: macOS (development)
- Runtime/container: Node + pnpm + Vitest
- Model/provider: N/A
- Integration/channel (if any): local gateway service config path
- Relevant config (redacted): `gateway.auth.mode=token`, `gateway.auth.token=<redacted>`

### Steps

1. Configure `gateway.auth.token` with a new value in `openclaw.json`.
2. Leave installed gateway service with old `OPENCLAW_GATEWAY_TOKEN` env value.
3. Run doctor service audit/repair path.

### Expected

- Doctor reports token drift and repairs service env to match config token.

### Actual

- After this change, audit emits `gateway-token-mismatch` and doctor uses config token as source of truth when rebuilding service environment.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Tests:
- `pnpm test src/daemon/service-audit.test.ts src/commands/doctor-gateway-services.test.ts`
- Result: 2 files passed, 6 tests passed

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - mismatch is flagged when service token differs from config token
  - no mismatch when tokens match
  - doctor service repair passes config token into audit/install plan
- Edge cases checked:
  - expected token unset => no mismatch check
  - service token missing => mismatch flagged
- What you did **not** verify:
  - live end-to-end systemd repair on Linux host in this change
  - full `pnpm build && pnpm check && pnpm test` suite run

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - revert this PR commit
- Files/config to restore:
  - `src/daemon/service-audit.ts`
  - `src/commands/doctor-gateway-services.ts`
- Known bad symptoms reviewers should watch for:
  - doctor repeatedly flags token mismatch despite synchronized service config and config token

## Risks and Mitigations

- Risk:
  - Over-triggered repair prompts in custom service setups.
  - Mitigation:
  - Repair is still confirmation-gated and the issue level remains recommended.

AI-assistance disclosure:
- [x] AI-assisted PR
- Testing level: lightly tested (targeted tests for changed areas)
- Reviewed and understood changed code paths

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds token drift detection to the gateway service audit, treating `gateway.auth.token` in `openclaw.json` as the authoritative source. When `openclaw doctor` runs, it now compares the service's `OPENCLAW_GATEWAY_TOKEN` environment variable against the config token and flags mismatches for repair.

- Added `gatewayTokenMismatch` audit code to detect when service token differs from config token
- New `auditGatewayToken` function performs the comparison (only when expected token is set)
- `maybeRepairGatewayServiceConfig` now passes `cfg.gateway?.auth?.token` to audit
- Token repair uses the same confirmation-gated service install flow as other service issues
- Tests cover both mismatch detection and matching token scenarios

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is well-scoped, adds a straightforward comparison check, includes comprehensive tests, and follows existing patterns. The token comparison logic correctly handles edge cases (missing/empty tokens) and only triggers when an expected token is provided. The repair flow is already confirmation-gated.
- No files require special attention

<sub>Last reviewed commit: ab9860f</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->