### PR TITLE
fix(status): avoid bot+app token warning for mattermost

### DIFF
--- a/src/commands/status-all/channels.mattermost-token-summary.test.ts
+++ b/src/commands/status-all/channels.mattermost-token-summary.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ChannelPlugin } from "../../channels/plugins/types.js";
+import { listChannelPlugins } from "../../channels/plugins/index.js";
+import { buildChannelsTable } from "./channels.js";
+
+vi.mock("../../channels/plugins/index.js", () => ({
+  listChannelPlugins: vi.fn(),
+}));
+
+function makeMattermostPlugin(): ChannelPlugin {
+  return {
+    id: "mattermost",
+    meta: {
+      id: "mattermost",
+      label: "Mattermost",
+      selectionLabel: "Mattermost",
+      docsPath: "/channels/mattermost",
+      blurb: "test",
+    },
+    config: {
+      listAccountIds: () => ["echo"],
+      defaultAccountId: () => "echo",
+      resolveAccount: () => ({
+        name: "Echo",
+        enabled: true,
+        botToken: "bot-token-value",
+        baseUrl: "https://mm.example.com",
+      }),
+      isConfigured: () => true,
+      isEnabled: () => true,
+    },
+    actions: {
+      listActions: () => ["send"],
+    },
+  };
+}
+
+describe("buildChannelsTable - mattermost token summary", () => {
+  it("does not require appToken for mattermost accounts", async () => {
+    vi.mocked(listChannelPlugins).mockReturnValue([makeMattermostPlugin()]);
+
+    const table = await buildChannelsTable({ channels: {} } as never, {
+      showSecrets: false,
+    });
+
+    const mattermostRow = table.rows.find((row) => row.id === "mattermost");
+    expect(mattermostRow).toBeDefined();
+    expect(mattermostRow?.state).toBe("ok");
+    expect(mattermostRow?.detail).not.toContain("need bot+app");
+  });
+});

--- a/src/commands/status-all/channels.ts
+++ b/src/commands/status-all/channels.ts
@@ -211,14 +211,15 @@ function summarizeTokenConfig(params: {
   }
 
   const accountRecs = enabled.map((a) => asRecord(a.account));
-  const hasBotOrAppTokenFields = accountRecs.some((r) => "botToken" in r || "appToken" in r);
+  const hasBotTokenField = accountRecs.some((r) => "botToken" in r);
+  const hasAppTokenField = accountRecs.some((r) => "appToken" in r);
   const hasTokenField = accountRecs.some((r) => "token" in r);
 
-  if (!hasBotOrAppTokenFields && !hasTokenField) {
+  if (!hasBotTokenField && !hasAppTokenField && !hasTokenField) {
     return { state: null, detail: null };
   }
 
-  if (hasBotOrAppTokenFields) {
+  if (hasBotTokenField && hasAppTokenField) {
     const ready = enabled.filter((a) => {
       const rec = asRecord(a.account);
       const bot = typeof rec.botToken === "string" ? rec.botToken.trim() : "";
@@ -262,6 +263,30 @@ function summarizeTokenConfig(params: {
     return {
       state: "ok",
       detail: `tokens ok (bot ${botSources.label}, app ${appSources.label})${hint} · accounts ${ready.length}/${enabled.length || 1}`,
+    };
+  }
+
+  if (hasBotTokenField) {
+    const ready = enabled.filter((a) => {
+      const rec = asRecord(a.account);
+      const bot = typeof rec.botToken === "string" ? rec.botToken.trim() : "";
+      return Boolean(bot);
+    });
+
+    if (ready.length === 0) {
+      return { state: "setup", detail: "no bot token" };
+    }
+
+    const sample = ready[0]?.account ? asRecord(ready[0].account) : {};
+    const botToken = typeof sample.botToken === "string" ? sample.botToken : "";
+    const botHint = botToken.trim()
+      ? formatTokenHint(botToken, { showSecrets: params.showSecrets })
+      : "";
+    const hint = botHint ? ` (${botHint})` : "";
+
+    return {
+      state: "ok",
+      detail: `bot token config${hint} · accounts ${ready.length}/${enabled.length || 1}`,
     };
   }
 


### PR DESCRIPTION
## What
Fixes channel token summary so channels that expose only `botToken` (like Mattermost) are not treated as requiring `appToken`.

## Why
`openclaw status` currently shows a false warning for Mattermost:

- `partial tokens (need bot+app)`

Even when Mattermost is correctly configured (`botToken` + `baseUrl`) and connected.

## Changes
- Update `summarizeTokenConfig` in `src/commands/status-all/channels.ts`:
  - bot+app mode only when both fields are present in account shapes
  - bot-only mode when only `botToken` is present
  - preserve existing single `token` mode
- Add regression test:
  - `src/commands/status-all/channels.mattermost-token-summary.test.ts`

## Test
```bash
pnpm --dir /home/echo/openclaw exec vitest run src/commands/status-all/channels.mattermost-token-summary.test.ts
```

## Issue
Closes #18526

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a false warning in `openclaw status` where Mattermost (and other bot-token-only channels like Zalo) were incorrectly flagged as `partial tokens (need bot+app)` despite being properly configured with only `botToken`.

- `summarizeTokenConfig` now distinguishes between bot+app mode (Slack — both `botToken` and `appToken` in account shape) and bot-only mode (Mattermost, Zalo — only `botToken`), instead of treating any presence of `botToken` as requiring `appToken`
- New bot-only branch returns `"ok"` state with `"bot token config"` detail when `botToken` is present and populated
- Regression test verifies a Mattermost-like plugin no longer triggers the `"need bot+app"` warning

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a targeted bug fix with a clear regression test and no risk to existing behavior.
- The change is minimal and well-scoped: it splits a single boolean flag into two granular checks, adds a new code path that follows the exact same pattern as adjacent branches, and includes a focused regression test. The bot+app path (Slack) is unchanged. Verified that only Mattermost and Zalo have botToken without appToken in the codebase, and both benefit from this fix. No edge cases or regressions identified.
- No files require special attention

<sub>Last reviewed commit: f1bb841</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->