### PR TITLE
fix(session): prevent stale threadId leaking into non-thread sessions

### DIFF
--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -258,7 +258,10 @@ export async function initSessionState(params: {
   const lastChannelRaw = (ctx.OriginatingChannel as string | undefined) || baseEntry?.lastChannel;
   const lastToRaw = ctx.OriginatingTo || ctx.To || baseEntry?.lastTo;
   const lastAccountIdRaw = ctx.AccountId || baseEntry?.lastAccountId;
-  const lastThreadIdRaw = ctx.MessageThreadId || baseEntry?.lastThreadId;
+  // Only fall back to persisted threadId for thread sessions.  Non-thread
+  // sessions (e.g. DM without topics) must not inherit a stale threadId from a
+  // previous interaction that happened inside a topic/thread.
+  const lastThreadIdRaw = ctx.MessageThreadId || (isThread ? baseEntry?.lastThreadId : undefined);
   const deliveryFields = normalizeSessionDeliveryFields({
     deliveryContext: {
       channel: lastChannelRaw,


### PR DESCRIPTION
## Summary
- Fix stale `lastThreadId` fallback causing bot to reply in wrong Telegram DM topic
- Add tests for thread ID persistence behavior

## Problem/Context
When a user interacts with the bot inside a DM topic/thread, the session persists `lastThreadId`. If the user later sends a plain DM message (no topic), `ctx.MessageThreadId` is `undefined` and the `||` fallback in `initSessionState` picks up the stale persisted thread ID — causing the bot to reply into the old topic instead of the main conversation.

This is particularly confusing for Telegram DMs with topics enabled, where the bot creates a phantom topic visible only as "#" in the topic list.

## Solution
Only fall back to `baseEntry.lastThreadId` for thread sessions (where `isThread` is true). Non-thread sessions now correctly leave `threadId` unset, preventing cross-session thread ID leakage.

```diff
- const lastThreadIdRaw = ctx.MessageThreadId || baseEntry?.lastThreadId;
+ const lastThreadIdRaw = ctx.MessageThreadId || (isThread ? baseEntry?.lastThreadId : undefined);
```

## Test Plan
- [x] Added test: non-thread session does not inherit stale threadId from a previous thread interaction
- [x] Added test: thread session correctly preserves threadId across messages
- [x] All 37 existing session tests pass

## Sign-Off
- Models used: Claude Opus 4.6
- Submitter effort summary: Discovered while debugging bot replying in invisible Telegram DM topic. Root-caused to stale `lastThreadId` fallback in session state initialization. Verified fix with new tests.
- Agent notes: The `isThread` flag was already computed earlier in `initSessionState` — reusing it for the guard keeps the change minimal.

—Calculon, Actor Extraordinaire (feat. Opus 4.6)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds defensive guard to prevent non-thread sessions from inheriting stale `lastThreadId` from previous thread interactions. The fix correctly scopes the `baseEntry?.lastThreadId` fallback to only apply when `isThread` is true, preventing thread ID leakage between thread and non-thread sessions. Includes comprehensive tests covering both the fix scenario (non-thread not inheriting stale threadId) and the preservation scenario (thread sessions correctly maintaining threadId).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a focused, defensive fix with clear logic: only allowing threadId fallback when actually in a thread session. The implementation is minimal (single line change + comment), the fix prevents a real bug (phantom thread replies), comprehensive tests verify both the fix and preservation behavior, and all 37 existing session tests pass.
- No files require special attention

<sub>Last reviewed commit: 4ba2da4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->