### PR TITLE
fix(telegram): handle large file errors gracefully

### DIFF
--- a/src/telegram/bot/delivery.ts
+++ b/src/telegram/bot/delivery.ts
@@ -6,7 +6,7 @@ import type { RuntimeEnv } from "../../runtime.js";
 import type { TelegramInlineButtons } from "../button-types.js";
 import type { StickerMetadata, TelegramContext } from "./types.js";
 import { chunkMarkdownTextWithMode, type ChunkMode } from "../../auto-reply/chunk.js";
-import { danger, logVerbose } from "../../globals.js";
+import { danger, logVerbose, warn } from "../../globals.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { retryAsync } from "../../infra/retry.js";
 import { mediaKindFromMime } from "../../media/constants.js";
@@ -34,6 +34,7 @@ import {
 
 const PARSE_ERR_RE = /can't parse entities|parse entities|find end of the entity/i;
 const VOICE_FORBIDDEN_RE = /VOICE_MESSAGES_FORBIDDEN/;
+const FILE_TOO_BIG_RE = /file is too big/i;
 
 export async function deliverReplies(params: {
   replies: ReplyPayload[];
@@ -414,10 +415,20 @@ export async function resolveMedia(
       maxDelayMs: 4000,
       jitter: 0.2,
       label: "telegram:getFile",
+      shouldRetry: isRetryableGetFileError,
       onRetry: ({ attempt, maxAttempts }) =>
         logVerbose(`telegram: getFile retry ${attempt}/${maxAttempts}`),
     });
   } catch (err) {
+    // Handle "file is too big" separately - Telegram Bot API has a 20MB download limit
+    if (isFileTooBigError(err)) {
+      logVerbose(
+        warn(
+          "telegram: getFile failed - file exceeds Telegram Bot API 20MB limit; skipping attachment",
+        ),
+      );
+      return null;
+    }
     // All retries exhausted — return null so the message still reaches the agent
     // with a type-based placeholder (e.g. <media:audio>) instead of being dropped.
     logVerbose(`telegram: getFile failed after retries: ${String(err)}`);
@@ -440,6 +451,31 @@ function isVoiceMessagesForbidden(err: unknown): boolean {
     return VOICE_FORBIDDEN_RE.test(err.description);
   }
   return VOICE_FORBIDDEN_RE.test(formatErrorMessage(err));
+}
+
+/**
+ * Returns true if the error is Telegram's "file is too big" error.
+ * This happens when trying to download files >20MB via the Bot API.
+ * Unlike network errors, this is a permanent error and should not be retried.
+ */
+function isFileTooBigError(err: unknown): boolean {
+  if (err instanceof GrammyError) {
+    return FILE_TOO_BIG_RE.test(err.description);
+  }
+  return FILE_TOO_BIG_RE.test(formatErrorMessage(err));
+}
+
+/**
+ * Returns true if the error is a transient network error that should be retried.
+ * Returns false for permanent errors like "file is too big" (400 Bad Request).
+ */
+function isRetryableGetFileError(err: unknown): boolean {
+  // Don't retry "file is too big" - it's a permanent 400 error
+  if (isFileTooBigError(err)) {
+    return false;
+  }
+  // Retry all other errors (network issues, timeouts, etc.)
+  return true;
 }
 
 async function sendTelegramVoiceFallbackText(opts: {


### PR DESCRIPTION
Fixes #18518

## What
Gracefully handle Telegram Bot API's 20MB file size limit by catching `getFile` errors and continuing to process the message text.

## Why
When users send files >20MB via Telegram, `getFile` throws `GrammyError: 400 Bad Request: file is too big`. The unhandled exception crashes the handler and drops the **entire message**, including any text content.

## How
- Add `FILE_TOO_BIG_RE` regex to detect 'file is too big' errors
- Add `isFileTooBigError()` helper to check for this specific error
- Add `isRetryableGetFileError()` to skip retrying permanent 400 errors
- Pass `shouldRetry` to `retryAsync()` to avoid wasteful retries on permanent errors
- Log a specific warning when file size limit is hit
- Return `null` so the message text is still processed by the agent

## Testing
- [x] `pnpm check` passes
- [x] `pnpm test -- src/telegram/bot/delivery.resolve-media-retry.test.ts` passes (9 tests)
- Added 4 new test cases for 'file is too big' error handling

## AI-Assisted 🤖
This PR was built with AI assistance (Claude via OpenClaw).
- [x] Code reviewed and understood
- [x] Tests added and passing
- [x] Session available on request

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Gracefully handles Telegram Bot API's 20MB file size limit by catching `getFile` "file is too big" errors and returning `null` instead of crashing the handler. This ensures the message text is still processed even when the attachment cannot be downloaded.

- Adds `isFileTooBigError()` helper and `isRetryableGetFileError()` callback to prevent wasteful retries on permanent 400 errors
- Passes `shouldRetry` to `retryAsync()` so the "file is too big" error short-circuits immediately
- Logs a specific warning when the file size limit is hit
- Follows the existing error-handling pattern established by `isVoiceMessagesForbidden()`
- Adds 4 new test cases covering video, audio, and voice media types

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it adds defensive error handling for a known Telegram API limitation with no changes to existing happy-path behavior.
- The changes are well-scoped: a new regex, two small helper functions, and a `shouldRetry` callback integrated into the existing retry flow. The logic correctly differentiates permanent 400 errors from transient failures. The catch block already returned null for exhausted retries, so the new code path is consistent. Tests cover the key scenarios. No risk of regression to existing behavior.
- No files require special attention.

<sub>Last reviewed commit: d05c68b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->