### PR TITLE
fix(test): [Bug Fix] update heartbeat runner expectations to resolve CI failure

### DIFF
--- a/src/infra/heartbeat-runner.model-override.test.ts
+++ b/src/infra/heartbeat-runner.model-override.test.ts
@@ -116,6 +116,7 @@ describe("runHeartbeatOnce – heartbeat model override", () => {
       expect.objectContaining({
         isHeartbeat: true,
         heartbeatModelOverride: "ollama/llama3.2:1b",
+        suppressToolErrorWarnings: false,
       }),
     );
   });

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -544,8 +544,11 @@ describe("runHeartbeatOnce", () => {
         expect.objectContaining({
           Body: expect.stringMatching(/Ops check[\s\S]*Current time: /),
           SessionKey: sessionKey,
+          From: "+1555",
+          To: "+1555",
+          Provider: "heartbeat",
         }),
-        expect.objectContaining({ isHeartbeat: true }),
+        expect.objectContaining({ isHeartbeat: true, suppressToolErrorWarnings: false }),
         cfg,
       );
     } finally {
@@ -621,8 +624,13 @@ describe("runHeartbeatOnce", () => {
       expect(sendWhatsApp).toHaveBeenCalledTimes(1);
       expect(sendWhatsApp).toHaveBeenCalledWith("+1555", "Final alert", expect.any(Object));
       expect(replySpy).toHaveBeenCalledWith(
-        expect.objectContaining({ SessionKey: sessionKey }),
-        expect.objectContaining({ isHeartbeat: true }),
+        expect.objectContaining({
+          SessionKey: sessionKey,
+          From: "+1555",
+          To: "+1555",
+          Provider: "heartbeat",
+        }),
+        expect.objectContaining({ isHeartbeat: true, suppressToolErrorWarnings: false }),
         cfg,
       );
     } finally {
@@ -699,8 +707,13 @@ describe("runHeartbeatOnce", () => {
       expect(sendWhatsApp).toHaveBeenCalledTimes(1);
       expect(sendWhatsApp).toHaveBeenCalledWith(groupId, "Group alert", expect.any(Object));
       expect(replySpy).toHaveBeenCalledWith(
-        expect.objectContaining({ SessionKey: groupSessionKey }),
-        expect.objectContaining({ isHeartbeat: true }),
+        expect.objectContaining({
+          SessionKey: groupSessionKey,
+          From: groupId,
+          To: groupId,
+          Provider: "heartbeat",
+        }),
+        expect.objectContaining({ isHeartbeat: true, suppressToolErrorWarnings: false }),
         cfg,
       );
     } finally {


### PR DESCRIPTION
**Description**
Fixes upstream CI failures caused by recent changes to `heartbeat-runner` that introduced new properties (`suppressToolErrorWarnings`, etc.) which were missing from the unit test expectations.

**Changes**
- Updated `src/infra/heartbeat-runner.returns-default-unset.test.ts`
- Updated `src/infra/heartbeat-runner.model-override.test.ts`

**Verification**
- Verified locally that tests pass with these changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updated heartbeat runner test assertions to match current implementation after recent changes introduced new properties.

The tests were failing because:
- `suppressToolErrorWarnings: false` was added to reply options in commit 72e228e1 but tests weren't fully updated
- Context payload fields (`From`, `To`, `Provider`) were present in the implementation but missing from test assertions

All changes correctly reflect the actual values passed by `heartbeat-runner.ts` to `getReplyFromConfig` (lines 492-547).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The changes are purely test maintenance updates that align test expectations with the actual implementation. All added fields match what the code actually does, and the author verified the tests pass locally. No functional code changes were made.
- No files require special attention

<sub>Last reviewed commit: b25d9ac</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->