### PR TITLE
fix: doctor --fix auto-repairs dmPolicy="open" missing allowFrom wildcard

### DIFF
--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -571,10 +571,7 @@ function maybeRepairOpenPolicyAllowFrom(cfg: OpenClawConfig): {
   const next = structuredClone(cfg);
   const changes: string[] = [];
 
-  const ensureWildcard = (
-    account: Record<string, unknown>,
-    prefix: string,
-  ) => {
+  const ensureWildcard = (account: Record<string, unknown>, prefix: string) => {
     const dmPolicy =
       (account.dmPolicy as string | undefined) ??
       ((account.dm as Record<string, unknown> | undefined)?.policy as string | undefined);
@@ -622,10 +619,7 @@ function maybeRepairOpenPolicyAllowFrom(cfg: OpenClawConfig): {
     if (accounts && typeof accounts === "object") {
       for (const [accountName, accountConfig] of Object.entries(accounts)) {
         if (accountConfig && typeof accountConfig === "object") {
-          ensureWildcard(
-            accountConfig,
-            `channels.${channelName}.accounts.${accountName}`,
-          );
+          ensureWildcard(accountConfig, `channels.${channelName}.accounts.${accountName}`);
         }
       }
     }

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -572,7 +572,6 @@ function maybeRepairOpenPolicyAllowFrom(cfg: OpenClawConfig): {
   const changes: string[] = [];
 
   const ensureWildcard = (
-    channelName: string,
     account: Record<string, unknown>,
     prefix: string,
   ) => {
@@ -616,7 +615,7 @@ function maybeRepairOpenPolicyAllowFrom(cfg: OpenClawConfig): {
     }
 
     // Check the top-level channel config
-    ensureWildcard(channelName, channelConfig, `channels.${channelName}`);
+    ensureWildcard(channelConfig, `channels.${channelName}`);
 
     // Check per-account configs (e.g. channels.discord.accounts.mybot)
     const accounts = channelConfig.accounts as Record<string, Record<string, unknown>> | undefined;
@@ -624,7 +623,6 @@ function maybeRepairOpenPolicyAllowFrom(cfg: OpenClawConfig): {
       for (const [accountName, accountConfig] of Object.entries(accounts)) {
         if (accountConfig && typeof accountConfig === "object") {
           ensureWildcard(
-            channelName,
             accountConfig,
             `channels.${channelName}.accounts.${accountName}`,
           );


### PR DESCRIPTION
## Summary

When a channel is configured with `dmPolicy: "open"` but without `allowFrom: ["*"]`, the gateway rejects the config and crashes on startup with:

```
Config invalid
File: ~/.openclaw/openclaw.json
Problem:
  - channels.discord.dm.allowFrom: channels.discord.dmPolicy="open" requires
    channels.discord.allowFrom (or channels.discord.dm.allowFrom) to include "*"
Run: openclaw doctor --fix
```

The error message tells users to run `openclaw doctor --fix`, but the doctor has no repair logic for this case — it just reports the same error again.

### Changes

Adds `maybeRepairOpenPolicyAllowFrom()` to the doctor's repair flow that:

1. Scans all channel configs (discord, slack, telegram, etc.) for `dmPolicy: "open"` without `allowFrom` containing `"*"`
2. If `allowFrom` array exists, appends `"*"` to it
3. If no `allowFrom` exists, creates `allowFrom: ["*"]`
4. Handles both top-level (`channels.X.allowFrom`) and nested (`channels.X.dm.allowFrom`) paths
5. Handles per-account configs (`channels.X.accounts.Y.allowFrom`)

This also fixes the gateway startup crash, since the gateway runs doctor in best-effort mode before starting — with this fix, the doctor will auto-repair the config and the gateway will start successfully.

## Reproduction

1. Set this in `openclaw.json`:
   ```json
   {
     "channels": {
       "discord": {
         "token": "your-bot-token",
         "dmPolicy": "open",
         "groupPolicy": "open"
       }
     }
   }
   ```
2. Run `openclaw gateway` — crashes with config invalid error
3. Run `openclaw doctor --fix` — reports the same error, doesn't fix it

After this fix:
- `openclaw doctor --fix` adds `allowFrom: ["*"]` automatically
- `openclaw gateway` starts successfully (doctor auto-repairs during startup)

## Testing

- [x] All existing doctor config tests pass
- [x] 5 new test cases covering: missing allowFrom, existing allowFrom array, nested dm.allowFrom, already-valid config (no-op), and per-account configs
- [x] Tested against a production OpenClaw v2026.2.15 gateway deployment where this exact crash occurred

[AI-assisted] Created with Claude Code. Tested in production.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds auto-repair logic to `openclaw doctor --fix` for the case where `dmPolicy: "open"` is set without `allowFrom: ["*"]`, which causes the schema validator to reject the config and crash the gateway on startup. The new `maybeRepairOpenPolicyAllowFrom()` function scans all channel configs (including per-account and nested `dm.allowFrom` paths) and adds the required wildcard entry. The non-repair path (running doctor without `--fix`) now also detects this misconfiguration and suggests the fix command.

- Repair logic correctly mirrors the schema validation in `requireOpenAllowFrom` (checks both `account.dmPolicy` and `account.dm.policy`)
- Handles three cases: appending `"*"` to existing top-level `allowFrom`, appending to nested `dm.allowFrom`, or creating new `allowFrom: ["*"]`
- 5 new test cases covering the key scenarios
- Minor style issue: unused `channelName` parameter in the `ensureWildcard` helper

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it adds a targeted repair for a known crash scenario with correct logic and good test coverage.
- The repair function correctly handles all the dmPolicy resolution paths that the schema validator checks (top-level dmPolicy, nested dm.policy, top-level allowFrom, nested dm.allowFrom, per-account configs). The structuredClone approach ensures no unintended mutation. Tests cover the main scenarios. One minor style issue (unused parameter) does not affect correctness.
- No files require special attention — both changed files are straightforward additions to existing patterns.

<sub>Last reviewed commit: 2151684</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->