### PR TITLE
CLI: add interactive fuzzy command selector

### DIFF
--- a/src/cli/program/command-questionnaire.test.ts
+++ b/src/cli/program/command-questionnaire.test.ts
@@ -1,0 +1,37 @@
+import { Option } from "commander";
+import { describe, expect, it } from "vitest";
+import {
+  preferredOptionFlag,
+  shouldPromptForOption,
+  splitMultiValueInput,
+} from "./command-questionnaire.js";
+
+describe("command-questionnaire", () => {
+  it("splits multi-value input by spaces and commas", () => {
+    expect(splitMultiValueInput("a b, c,,d")).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("prefers long option flags", () => {
+    const option = new Option("-p, --provider <name>");
+    expect(preferredOptionFlag(option)).toBe("--provider");
+  });
+
+  it("falls back to short flag when long is absent", () => {
+    const option = new Option("-f");
+    expect(preferredOptionFlag(option)).toBe("-f");
+  });
+
+  it("skips internal and hidden options", () => {
+    expect(shouldPromptForOption(new Option("-h, --help"))).toBe(false);
+    expect(shouldPromptForOption(new Option("-V, --version"))).toBe(false);
+    expect(shouldPromptForOption(new Option("-i, --interactive"))).toBe(false);
+
+    const hidden = new Option("--secret");
+    hidden.hideHelp(true);
+    expect(shouldPromptForOption(hidden)).toBe(false);
+  });
+
+  it("prompts for regular options", () => {
+    expect(shouldPromptForOption(new Option("--provider <name>"))).toBe(true);
+  });
+});

--- a/src/cli/program/command-questionnaire.test.ts
+++ b/src/cli/program/command-questionnaire.test.ts
@@ -1,6 +1,8 @@
-import { Option } from "commander";
+import { Command, Option } from "commander";
 import { describe, expect, it } from "vitest";
 import {
+  buildOptionalParameterEntries,
+  isRequiredOption,
   preferredOptionFlag,
   shouldPromptForOption,
   splitMultiValueInput,
@@ -33,5 +35,28 @@ describe("command-questionnaire", () => {
 
   it("prompts for regular options", () => {
     expect(shouldPromptForOption(new Option("--provider <name>"))).toBe(true);
+  });
+
+  it("detects required options", () => {
+    const required = new Option("--provider <name>").makeOptionMandatory(true);
+    const optional = new Option("--verbose");
+
+    expect(isRequiredOption(required)).toBe(true);
+    expect(isRequiredOption(optional)).toBe(false);
+  });
+
+  it("builds optional parameter entries from optional options and arguments", () => {
+    const command = new Command("demo")
+      .argument("<target>")
+      .argument("[note]")
+      .addOption(new Option("--provider <name>").makeOptionMandatory(true))
+      .option("--verbose", "Verbose output");
+
+    const entries = buildOptionalParameterEntries(command);
+
+    expect(entries.map((entry) => entry.label)).toContain("--verbose");
+    expect(entries.map((entry) => entry.label)).toContain("[note]");
+    expect(entries.map((entry) => entry.label)).not.toContain("--provider");
+    expect(entries.map((entry) => entry.label)).not.toContain("<target>");
   });
 });

--- a/src/cli/program/command-questionnaire.ts
+++ b/src/cli/program/command-questionnaire.ts
@@ -1,0 +1,246 @@
+import type { Argument, Command, Option } from "commander";
+import {
+  confirm as clackConfirm,
+  isCancel,
+  select as clackSelect,
+  text as clackText,
+} from "@clack/prompts";
+import { stylePromptHint, stylePromptMessage } from "../../terminal/prompt-style.js";
+import { resolveCommandByPath } from "./command-selector.js";
+
+const INTERNAL_OPTION_NAMES = new Set(["help", "version", "interactive"]);
+
+type PromptResult = string[] | null;
+
+export function splitMultiValueInput(raw: string): string[] {
+  return raw
+    .split(/[\s,]+/)
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+}
+
+export function preferredOptionFlag(option: Option): string {
+  return option.long ?? option.short ?? option.flags.split(/[ ,|]+/)[0] ?? option.flags;
+}
+
+export function shouldPromptForOption(option: Option): boolean {
+  if (option.hidden) {
+    return false;
+  }
+  return !INTERNAL_OPTION_NAMES.has(option.name());
+}
+
+async function askValue(params: {
+  message: string;
+  placeholder?: string;
+  required?: boolean;
+}): Promise<string | null> {
+  const value = await clackText({
+    message: stylePromptMessage(params.message) ?? params.message,
+    placeholder: params.placeholder,
+    validate: params.required
+      ? (input) => {
+          if (!input || input.trim().length === 0) {
+            return "Value required";
+          }
+          return undefined;
+        }
+      : undefined,
+  });
+  if (isCancel(value)) {
+    return null;
+  }
+  return String(value ?? "").trim();
+}
+
+async function askChoice(params: {
+  message: string;
+  choices: readonly string[];
+  hint?: string;
+}): Promise<string | null> {
+  const choice = await clackSelect<string>({
+    message: stylePromptMessage(params.message) ?? params.message,
+    options: params.choices.map((value) => ({
+      value,
+      label: value,
+      hint: params.hint ? stylePromptHint(params.hint) : undefined,
+    })),
+  });
+  if (isCancel(choice)) {
+    return null;
+  }
+  return choice;
+}
+
+async function promptArgumentValue(argument: Argument): Promise<PromptResult> {
+  const label = argument.name();
+  const suffix = argument.description ? ` — ${argument.description}` : "";
+
+  if (!argument.required) {
+    const include = await clackConfirm({
+      message:
+        stylePromptMessage(`Provide optional argument <${label}>?${suffix}`) ??
+        `Provide optional argument <${label}>?${suffix}`,
+      initialValue: false,
+    });
+    if (isCancel(include)) {
+      return null;
+    }
+    if (!include) {
+      return [];
+    }
+  }
+
+  if (argument.argChoices && argument.argChoices.length > 0 && !argument.variadic) {
+    const choice = await askChoice({
+      message: `Select value for <${label}>`,
+      choices: argument.argChoices,
+      hint: argument.description,
+    });
+    return choice === null ? null : [choice];
+  }
+
+  if (argument.variadic) {
+    const raw = await askValue({
+      message: `Values for <${label}...> (space/comma-separated)${suffix}`,
+      placeholder: argument.required ? "value1 value2" : "optional",
+      required: argument.required,
+    });
+    if (raw === null) {
+      return null;
+    }
+    const values = splitMultiValueInput(raw);
+    if (argument.required && values.length === 0) {
+      return null;
+    }
+    return values;
+  }
+
+  const value = await askValue({
+    message: `Value for <${label}>${suffix}`,
+    required: argument.required,
+  });
+  if (value === null) {
+    return null;
+  }
+  if (!value && !argument.required) {
+    return [];
+  }
+  return [value];
+}
+
+async function promptOptionValue(option: Option): Promise<PromptResult> {
+  const flag = preferredOptionFlag(option);
+  const description = option.description ? ` — ${option.description}` : "";
+
+  if (option.isBoolean()) {
+    const verb = option.negate ? "Disable" : "Enable";
+    const enabled = await clackConfirm({
+      message:
+        stylePromptMessage(`${verb} ${flag}?${description}`) ?? `${verb} ${flag}?${description}`,
+      initialValue: false,
+    });
+    if (isCancel(enabled)) {
+      return null;
+    }
+    return enabled ? [flag] : [];
+  }
+
+  const shouldAsk =
+    option.mandatory ||
+    (await clackConfirm({
+      message: stylePromptMessage(`Set ${flag}?${description}`) ?? `Set ${flag}?${description}`,
+      initialValue: false,
+    }));
+  if (isCancel(shouldAsk)) {
+    return null;
+  }
+  if (!shouldAsk) {
+    return [];
+  }
+
+  if (option.argChoices && option.argChoices.length > 0 && !option.variadic) {
+    const choice = await askChoice({
+      message: `Select value for ${flag}`,
+      choices: option.argChoices,
+      hint: option.description,
+    });
+    return choice === null ? null : [flag, choice];
+  }
+
+  if (option.optional) {
+    const raw = await askValue({
+      message: `Optional value for ${flag} (leave empty for flag only)${description}`,
+      required: false,
+    });
+    if (raw === null) {
+      return null;
+    }
+    return raw.length > 0 ? [flag, raw] : [flag];
+  }
+
+  if (option.variadic) {
+    const raw = await askValue({
+      message: `Values for ${flag} (space/comma-separated)${description}`,
+      placeholder: "value1 value2",
+      required: option.mandatory || option.required,
+    });
+    if (raw === null) {
+      return null;
+    }
+    const values = splitMultiValueInput(raw);
+    if (values.length === 0) {
+      return option.mandatory || option.required ? null : [flag];
+    }
+    const tokens: string[] = [];
+    for (const value of values) {
+      tokens.push(flag, value);
+    }
+    return tokens;
+  }
+
+  const value = await askValue({
+    message: `Value for ${flag}${description}`,
+    required: option.mandatory || option.required,
+  });
+  if (value === null) {
+    return null;
+  }
+  if (!value && !(option.mandatory || option.required)) {
+    return [];
+  }
+  return [flag, value];
+}
+
+export async function runCommandQuestionnaire(params: {
+  program: Command;
+  commandPath: string[];
+}): Promise<string[] | null> {
+  const command = resolveCommandByPath(params.program, params.commandPath);
+  if (!command) {
+    return [];
+  }
+
+  const optionTokens: string[] = [];
+  for (const option of command.options) {
+    if (!shouldPromptForOption(option)) {
+      continue;
+    }
+    const tokens = await promptOptionValue(option);
+    if (tokens === null) {
+      return null;
+    }
+    optionTokens.push(...tokens);
+  }
+
+  const argumentTokens: string[] = [];
+  for (const argument of command.registeredArguments) {
+    const tokens = await promptArgumentValue(argument);
+    if (tokens === null) {
+      return null;
+    }
+    argumentTokens.push(...tokens);
+  }
+
+  return [...optionTokens, ...argumentTokens];
+}

--- a/src/cli/program/command-selector.test.ts
+++ b/src/cli/program/command-selector.test.ts
@@ -65,7 +65,11 @@ describe("command-selector", () => {
   it("detects commands that require subcommands", () => {
     const program = new Command();
     const models = program.command("models").description("Model commands");
-    models.command("auth").description("Auth command");
+    const auth = models
+      .command("auth")
+      .description("Auth command")
+      .action(() => undefined);
+    auth.command("login").description("Login auth profile");
 
     const status = program
       .command("status")
@@ -73,6 +77,7 @@ describe("command-selector", () => {
       .action(() => undefined);
 
     expect(commandRequiresSubcommand(models)).toBe(true);
+    expect(commandRequiresSubcommand(auth)).toBe(true);
     expect(commandRequiresSubcommand(status)).toBe(false);
   });
 

--- a/src/cli/program/command-selector.test.ts
+++ b/src/cli/program/command-selector.test.ts
@@ -1,0 +1,51 @@
+import { Command } from "commander";
+import { describe, expect, it } from "vitest";
+import {
+  collectCommandSelectorCandidates,
+  rankCommandSelectorCandidates,
+} from "./command-selector.js";
+
+describe("command-selector", () => {
+  it("collects nested command paths", () => {
+    const program = new Command();
+    const message = program.command("message").description("Manage messages");
+    message.command("send").description("Send a message");
+    message.command("read").description("Read messages");
+    program.command("status").description("Show status");
+
+    const candidates = collectCommandSelectorCandidates(program);
+    const labels = candidates.map((candidate) => candidate.label);
+
+    expect(labels).toContain("message");
+    expect(labels).toContain("message send");
+    expect(labels).toContain("message read");
+    expect(labels).toContain("status");
+  });
+
+  it("skips hidden commands", () => {
+    const program = new Command();
+    program.command("visible").description("Visible command");
+    const secret = program.command("secret").description("Secret command");
+    (secret as Command & { _hidden?: boolean })._hidden = true;
+
+    const candidates = collectCommandSelectorCandidates(program);
+    const labels = candidates.map((candidate) => candidate.label);
+
+    expect(labels).toContain("visible");
+    expect(labels).not.toContain("secret");
+  });
+
+  it("supports fuzzy ranking", () => {
+    const program = new Command();
+    const message = program.command("message").description("Manage messages");
+    message.command("send").description("Send a message");
+    message.command("search").description("Search messages");
+    program.command("status").description("Show status");
+
+    const candidates = collectCommandSelectorCandidates(program);
+    const ranked = rankCommandSelectorCandidates(candidates, "msg snd");
+
+    expect(ranked[0]?.label).toBe("message send");
+    expect(ranked.some((candidate) => candidate.label === "status")).toBe(false);
+  });
+});

--- a/src/cli/program/command-selector.ts
+++ b/src/cli/program/command-selector.ts
@@ -7,6 +7,7 @@ import { getProgramContext } from "./program-context.js";
 import { getSubCliEntries, registerSubCliByName } from "./register.subclis.js";
 
 const SHOW_HELP_VALUE = "__show_help__";
+const BACK_TO_MAIN_VALUE = "__back_to_main__";
 const PATH_SEPARATOR = "\u0000";
 const MAX_RESULTS = 200;
 
@@ -21,9 +22,21 @@ type PreparedCommandSelectorCandidate = CommandSelectorCandidate & {
   searchTextLower: string;
 };
 
+type SelectorPromptResult = string[] | "back_to_main" | null;
+
 function isHiddenCommand(command: Command): boolean {
   // Commander stores hidden state on a private field.
   return Boolean((command as Command & { _hidden?: boolean })._hidden);
+}
+
+function shouldSkipCommand(command: Command, parentDepth: number): boolean {
+  if (isHiddenCommand(command) || command.name() === "help") {
+    return true;
+  }
+  if (parentDepth === 0 && command.name() === "interactive") {
+    return true;
+  }
+  return false;
 }
 
 function resolveCommandDescription(command: Command): string {
@@ -38,6 +51,14 @@ function resolveCommandDescription(command: Command): string {
   return "Run this command";
 }
 
+function prepareSortedCandidates(
+  raw: CommandSelectorCandidate[],
+): PreparedCommandSelectorCandidate[] {
+  const prepared = prepareSearchItems(raw);
+  prepared.sort((a, b) => a.label.localeCompare(b.label));
+  return prepared;
+}
+
 function collectCandidatesRecursive(params: {
   command: Command;
   parentPath: string[];
@@ -45,10 +66,7 @@ function collectCandidatesRecursive(params: {
   out: CommandSelectorCandidate[];
 }): void {
   for (const child of params.command.commands) {
-    if (isHiddenCommand(child) || child.name() === "help") {
-      continue;
-    }
-    if (params.parentPath.length === 0 && child.name() === "interactive") {
+    if (shouldSkipCommand(child, params.parentPath.length)) {
       continue;
     }
     const path = [...params.parentPath, child.name()];
@@ -78,9 +96,56 @@ export function collectCommandSelectorCandidates(
   const seen = new Set<string>();
   const raw: CommandSelectorCandidate[] = [];
   collectCandidatesRecursive({ command: program, parentPath: [], seen, out: raw });
-  const prepared = prepareSearchItems(raw);
-  prepared.sort((a, b) => a.label.localeCompare(b.label));
-  return prepared;
+  return prepareSortedCandidates(raw);
+}
+
+export function resolveCommandByPath(program: Command, path: string[]): Command | null {
+  let current: Command = program;
+  for (const segment of path) {
+    const next = current.commands.find((child) => child.name() === segment);
+    if (!next) {
+      return null;
+    }
+    current = next;
+  }
+  return current;
+}
+
+function hasActionHandler(command: Command): boolean {
+  return Boolean((command as Command & { _actionHandler?: unknown })._actionHandler);
+}
+
+export function commandRequiresSubcommand(command: Command): boolean {
+  const visibleChildren = command.commands.filter((child) => !shouldSkipCommand(child, 1));
+  if (visibleChildren.length === 0) {
+    return false;
+  }
+  return !hasActionHandler(command);
+}
+
+export function collectDirectSubcommandSelectorCandidates(
+  program: Command,
+  basePath: string[],
+): PreparedCommandSelectorCandidate[] {
+  const parent = resolveCommandByPath(program, basePath);
+  if (!parent) {
+    return [];
+  }
+
+  const raw: CommandSelectorCandidate[] = [];
+  for (const child of parent.commands) {
+    if (shouldSkipCommand(child, basePath.length)) {
+      continue;
+    }
+    const path = [...basePath, child.name()];
+    raw.push({
+      path,
+      label: child.name(),
+      description: resolveCommandDescription(child),
+      searchText: `${child.name()} ${path.join(" ")}`,
+    });
+  }
+  return prepareSortedCandidates(raw);
 }
 
 export function rankCommandSelectorCandidates(
@@ -115,30 +180,48 @@ async function hydrateProgramCommandsForSelector(program: Command): Promise<void
   }
 }
 
-export async function runInteractiveCommandSelector(program: Command): Promise<string[] | null> {
-  await hydrateProgramCommandsForSelector(program);
+function serializePath(path: string[]): string {
+  return path.join(PATH_SEPARATOR);
+}
 
-  const candidates = collectCommandSelectorCandidates(program);
-  if (candidates.length === 0) {
-    return null;
-  }
+function deserializePath(value: string): string[] {
+  return value
+    .split(PATH_SEPARATOR)
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+}
 
+async function promptForCommandSelection(params: {
+  message: string;
+  placeholder: string;
+  candidates: PreparedCommandSelectorCandidate[];
+  includeBackToMain?: boolean;
+}): Promise<SelectorPromptResult> {
   const selection = await clackAutocomplete<string>({
-    message: stylePromptMessage("Find and run a command") ?? "Find and run a command",
-    placeholder: "Type to fuzzy-search (e.g. msg snd)",
+    message: params.message,
+    placeholder: params.placeholder,
     maxItems: 10,
     // We pre-rank the list with our fuzzy scorer, then opt out of clack's own
     // filter so item order stays stable and score-based.
     filter: () => true,
     options() {
       const query = this.userInput.trim();
-      const ranked = rankCommandSelectorCandidates(candidates, query).slice(0, MAX_RESULTS);
+      const ranked = rankCommandSelectorCandidates(params.candidates, query).slice(0, MAX_RESULTS);
       return [
         ...ranked.map((candidate) => ({
-          value: candidate.path.join(PATH_SEPARATOR),
+          value: serializePath(candidate.path),
           label: candidate.label,
           hint: stylePromptHint(candidate.description),
         })),
+        ...(params.includeBackToMain
+          ? [
+              {
+                value: BACK_TO_MAIN_VALUE,
+                label: "../",
+                hint: stylePromptHint("Back to main command selector"),
+              },
+            ]
+          : []),
         {
           value: SHOW_HELP_VALUE,
           label: "Show help",
@@ -151,9 +234,62 @@ export async function runInteractiveCommandSelector(program: Command): Promise<s
   if (isCancel(selection) || selection === SHOW_HELP_VALUE) {
     return null;
   }
+  if (selection === BACK_TO_MAIN_VALUE) {
+    return "back_to_main";
+  }
+  return deserializePath(selection);
+}
 
-  return selection
-    .split(PATH_SEPARATOR)
-    .map((segment) => segment.trim())
-    .filter(Boolean);
+export async function runInteractiveCommandSelector(program: Command): Promise<string[] | null> {
+  await hydrateProgramCommandsForSelector(program);
+
+  const mainCandidates = collectCommandSelectorCandidates(program);
+  if (mainCandidates.length === 0) {
+    return null;
+  }
+
+  while (true) {
+    const mainSelection = await promptForCommandSelection({
+      message: stylePromptMessage("Find and run a command") ?? "Find and run a command",
+      placeholder: "Type to fuzzy-search (e.g. msg snd)",
+      candidates: mainCandidates,
+    });
+    if (!mainSelection || mainSelection === "back_to_main") {
+      return null;
+    }
+
+    let selectedPath = mainSelection;
+    let selectedCommand = resolveCommandByPath(program, selectedPath);
+    if (!selectedCommand || !commandRequiresSubcommand(selectedCommand)) {
+      return selectedPath;
+    }
+
+    while (true) {
+      const subcommandCandidates = collectDirectSubcommandSelectorCandidates(program, selectedPath);
+      if (subcommandCandidates.length === 0) {
+        return selectedPath;
+      }
+
+      const subSelection = await promptForCommandSelection({
+        message:
+          stylePromptMessage(`Select subcommand for ${selectedPath.join(" ")}`) ??
+          `Select subcommand for ${selectedPath.join(" ")}`,
+        placeholder: "Type to fuzzy-search subcommands",
+        candidates: subcommandCandidates,
+        includeBackToMain: true,
+      });
+      if (!subSelection) {
+        return null;
+      }
+      if (subSelection === "back_to_main") {
+        break;
+      }
+
+      selectedPath = subSelection;
+      selectedCommand = resolveCommandByPath(program, selectedPath);
+      if (!selectedCommand || !commandRequiresSubcommand(selectedCommand)) {
+        return selectedPath;
+      }
+    }
+  }
 }

--- a/src/cli/program/command-selector.ts
+++ b/src/cli/program/command-selector.ts
@@ -1,16 +1,14 @@
 import type { Command } from "commander";
-import { isCancel, select as clackSelect, text as clackText } from "@clack/prompts";
+import { autocomplete as clackAutocomplete, isCancel } from "@clack/prompts";
 import { stylePromptHint, stylePromptMessage } from "../../terminal/prompt-style.js";
-import { theme } from "../../terminal/theme.js";
 import { fuzzyFilterLower, prepareSearchItems } from "../../tui/components/fuzzy-filter.js";
 import { getCoreCliCommandNames, registerCoreCliByName } from "./command-registry.js";
 import { getProgramContext } from "./program-context.js";
 import { getSubCliEntries, registerSubCliByName } from "./register.subclis.js";
 
-const SEARCH_AGAIN_VALUE = "__search_again__";
 const SHOW_HELP_VALUE = "__show_help__";
 const PATH_SEPARATOR = "\u0000";
-const MAX_MATCHES = 24;
+const MAX_RESULTS = 200;
 
 type CommandSelectorCandidate = {
   path: string[];
@@ -122,64 +120,37 @@ export async function runInteractiveCommandSelector(program: Command): Promise<s
     return null;
   }
 
-  let lastQuery = "";
-
-  while (true) {
-    const queryResult = await clackText({
-      message: stylePromptMessage("Find a command (fuzzy)") ?? "Find a command (fuzzy)",
-      placeholder: "message send",
-      defaultValue: lastQuery,
-    });
-    if (isCancel(queryResult)) {
-      return null;
-    }
-
-    const query = String(queryResult ?? "").trim();
-    lastQuery = query;
-
-    const matches = rankCommandSelectorCandidates(candidates, query);
-    if (matches.length === 0) {
-      console.error(theme.warn("No matching commands. Try a different search."));
-      continue;
-    }
-
-    const shown = matches.slice(0, MAX_MATCHES);
-    const selection = await clackSelect<string>({
-      message:
-        stylePromptMessage(
-          shown.length === matches.length
-            ? `Select a command (${matches.length} matches)`
-            : `Select a command (showing ${shown.length} of ${matches.length} matches)`,
-        ) ?? "Select a command",
-      options: [
-        ...shown.map((candidate) => ({
+  const selection = await clackAutocomplete<string>({
+    message: stylePromptMessage("Find and run a command") ?? "Find and run a command",
+    placeholder: "Type to fuzzy-search (e.g. msg snd)",
+    maxItems: 10,
+    // We pre-rank the list with our fuzzy scorer, then opt out of clack's own
+    // filter so item order stays stable and score-based.
+    filter: () => true,
+    options() {
+      const query = this.userInput.trim();
+      const ranked = rankCommandSelectorCandidates(candidates, query).slice(0, MAX_RESULTS);
+      return [
+        ...ranked.map((candidate) => ({
           value: candidate.path.join(PATH_SEPARATOR),
           label: candidate.label,
           hint: stylePromptHint(candidate.description),
         })),
         {
-          value: SEARCH_AGAIN_VALUE,
-          label: "Search again",
-          hint: stylePromptHint("Change your fuzzy query"),
-        },
-        {
           value: SHOW_HELP_VALUE,
           label: "Show help",
           hint: stylePromptHint("Skip selector and print CLI help"),
         },
-      ],
-    });
+      ];
+    },
+  });
 
-    if (isCancel(selection) || selection === SHOW_HELP_VALUE) {
-      return null;
-    }
-    if (selection === SEARCH_AGAIN_VALUE) {
-      continue;
-    }
-
-    return selection
-      .split(PATH_SEPARATOR)
-      .map((segment) => segment.trim())
-      .filter(Boolean);
+  if (isCancel(selection) || selection === SHOW_HELP_VALUE) {
+    return null;
   }
+
+  return selection
+    .split(PATH_SEPARATOR)
+    .map((segment) => segment.trim())
+    .filter(Boolean);
 }

--- a/src/cli/program/command-selector.ts
+++ b/src/cli/program/command-selector.ts
@@ -31,14 +31,8 @@ function isHiddenCommand(command: Command): boolean {
   return Boolean((command as Command & { _hidden?: boolean })._hidden);
 }
 
-function shouldSkipCommand(command: Command, parentDepth: number): boolean {
-  if (isHiddenCommand(command) || command.name() === "help") {
-    return true;
-  }
-  if (parentDepth === 0 && command.name() === "interactive") {
-    return true;
-  }
-  return false;
+function shouldSkipCommand(command: Command, _parentDepth: number): boolean {
+  return isHiddenCommand(command) || command.name() === "help";
 }
 
 function resolveCommandDescription(command: Command): string {

--- a/src/cli/program/command-selector.ts
+++ b/src/cli/program/command-selector.ts
@@ -1,0 +1,185 @@
+import type { Command } from "commander";
+import { isCancel, select as clackSelect, text as clackText } from "@clack/prompts";
+import { stylePromptHint, stylePromptMessage } from "../../terminal/prompt-style.js";
+import { theme } from "../../terminal/theme.js";
+import { fuzzyFilterLower, prepareSearchItems } from "../../tui/components/fuzzy-filter.js";
+import { getCoreCliCommandNames, registerCoreCliByName } from "./command-registry.js";
+import { getProgramContext } from "./program-context.js";
+import { getSubCliEntries, registerSubCliByName } from "./register.subclis.js";
+
+const SEARCH_AGAIN_VALUE = "__search_again__";
+const SHOW_HELP_VALUE = "__show_help__";
+const PATH_SEPARATOR = "\u0000";
+const MAX_MATCHES = 24;
+
+type CommandSelectorCandidate = {
+  path: string[];
+  label: string;
+  description: string;
+  searchText: string;
+};
+
+type PreparedCommandSelectorCandidate = CommandSelectorCandidate & {
+  searchTextLower: string;
+};
+
+function isHiddenCommand(command: Command): boolean {
+  // Commander stores hidden state on a private field.
+  return Boolean((command as Command & { _hidden?: boolean })._hidden);
+}
+
+function resolveCommandDescription(command: Command): string {
+  const summary = typeof command.summary === "function" ? command.summary().trim() : "";
+  if (summary) {
+    return summary;
+  }
+  const description = command.description().trim();
+  if (description) {
+    return description;
+  }
+  return "Run this command";
+}
+
+function collectCandidatesRecursive(params: {
+  command: Command;
+  parentPath: string[];
+  seen: Set<string>;
+  out: CommandSelectorCandidate[];
+}): void {
+  for (const child of params.command.commands) {
+    if (isHiddenCommand(child) || child.name() === "help") {
+      continue;
+    }
+    const path = [...params.parentPath, child.name()];
+    const label = path.join(" ");
+    if (!params.seen.has(label)) {
+      params.seen.add(label);
+      params.out.push({
+        path,
+        label,
+        description: resolveCommandDescription(child),
+        searchText: path.join(" "),
+      });
+    }
+
+    collectCandidatesRecursive({
+      command: child,
+      parentPath: path,
+      seen: params.seen,
+      out: params.out,
+    });
+  }
+}
+
+export function collectCommandSelectorCandidates(
+  program: Command,
+): PreparedCommandSelectorCandidate[] {
+  const seen = new Set<string>();
+  const raw: CommandSelectorCandidate[] = [];
+  collectCandidatesRecursive({ command: program, parentPath: [], seen, out: raw });
+  const prepared = prepareSearchItems(raw);
+  prepared.sort((a, b) => a.label.localeCompare(b.label));
+  return prepared;
+}
+
+export function rankCommandSelectorCandidates(
+  candidates: PreparedCommandSelectorCandidate[],
+  query: string,
+): PreparedCommandSelectorCandidate[] {
+  const queryLower = query.trim().toLowerCase();
+  if (!queryLower) {
+    return candidates;
+  }
+  return fuzzyFilterLower(candidates, queryLower);
+}
+
+async function hydrateProgramCommandsForSelector(program: Command): Promise<void> {
+  const ctx = getProgramContext(program);
+  if (ctx) {
+    for (const name of getCoreCliCommandNames()) {
+      try {
+        await registerCoreCliByName(program, ctx, name);
+      } catch {
+        // Keep selector usable even if one registrar fails in this environment.
+      }
+    }
+  }
+
+  for (const entry of getSubCliEntries()) {
+    try {
+      await registerSubCliByName(program, entry.name);
+    } catch {
+      // Keep selector usable even if one registrar fails in this environment.
+    }
+  }
+}
+
+export async function runInteractiveCommandSelector(program: Command): Promise<string[] | null> {
+  await hydrateProgramCommandsForSelector(program);
+
+  const candidates = collectCommandSelectorCandidates(program);
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  let lastQuery = "";
+
+  while (true) {
+    const queryResult = await clackText({
+      message: stylePromptMessage("Find a command (fuzzy)") ?? "Find a command (fuzzy)",
+      placeholder: "message send",
+      defaultValue: lastQuery,
+    });
+    if (isCancel(queryResult)) {
+      return null;
+    }
+
+    const query = String(queryResult ?? "").trim();
+    lastQuery = query;
+
+    const matches = rankCommandSelectorCandidates(candidates, query);
+    if (matches.length === 0) {
+      console.error(theme.warn("No matching commands. Try a different search."));
+      continue;
+    }
+
+    const shown = matches.slice(0, MAX_MATCHES);
+    const selection = await clackSelect<string>({
+      message:
+        stylePromptMessage(
+          shown.length === matches.length
+            ? `Select a command (${matches.length} matches)`
+            : `Select a command (showing ${shown.length} of ${matches.length} matches)`,
+        ) ?? "Select a command",
+      options: [
+        ...shown.map((candidate) => ({
+          value: candidate.path.join(PATH_SEPARATOR),
+          label: candidate.label,
+          hint: stylePromptHint(candidate.description),
+        })),
+        {
+          value: SEARCH_AGAIN_VALUE,
+          label: "Search again",
+          hint: stylePromptHint("Change your fuzzy query"),
+        },
+        {
+          value: SHOW_HELP_VALUE,
+          label: "Show help",
+          hint: stylePromptHint("Skip selector and print CLI help"),
+        },
+      ],
+    });
+
+    if (isCancel(selection) || selection === SHOW_HELP_VALUE) {
+      return null;
+    }
+    if (selection === SEARCH_AGAIN_VALUE) {
+      continue;
+    }
+
+    return selection
+      .split(PATH_SEPARATOR)
+      .map((segment) => segment.trim())
+      .filter(Boolean);
+  }
+}

--- a/src/cli/program/command-selector.ts
+++ b/src/cli/program/command-selector.ts
@@ -48,6 +48,9 @@ function collectCandidatesRecursive(params: {
     if (isHiddenCommand(child) || child.name() === "help") {
       continue;
     }
+    if (params.parentPath.length === 0 && child.name() === "interactive") {
+      continue;
+    }
     const path = [...params.parentPath, child.name()];
     const label = path.join(" ");
     if (!params.seen.has(label)) {

--- a/src/cli/program/command-selector.ts
+++ b/src/cli/program/command-selector.ts
@@ -1,5 +1,5 @@
-import type { Command } from "commander";
 import { autocomplete as clackAutocomplete, isCancel } from "@clack/prompts";
+import type { Command } from "commander";
 import { stylePromptHint, stylePromptMessage } from "../../terminal/prompt-style.js";
 import { fuzzyFilterLower, prepareSearchItems } from "../../tui/components/fuzzy-filter.js";
 import { getCoreCliCommandNames, registerCoreCliByName } from "./command-registry.js";
@@ -31,7 +31,7 @@ function isHiddenCommand(command: Command): boolean {
   return Boolean((command as Command & { _hidden?: boolean })._hidden);
 }
 
-function shouldSkipCommand(command: Command, _parentDepth: number): boolean {
+function shouldSkipCommand(command: Command): boolean {
   return isHiddenCommand(command) || command.name() === "help";
 }
 
@@ -62,7 +62,7 @@ function collectCandidatesRecursive(params: {
   out: CommandSelectorCandidate[];
 }): void {
   for (const child of params.command.commands) {
-    if (shouldSkipCommand(child, params.parentPath.length)) {
+    if (shouldSkipCommand(child)) {
       continue;
     }
     const path = [...params.parentPath, child.name()];
@@ -108,8 +108,7 @@ export function resolveCommandByPath(program: Command, path: string[]): Command 
 }
 
 export function commandRequiresSubcommand(command: Command): boolean {
-  const visibleChildren = command.commands.filter((child) => !shouldSkipCommand(child, 1));
-  return visibleChildren.length > 0;
+  return command.commands.some((child) => !shouldSkipCommand(child));
 }
 
 export function collectDirectSubcommandSelectorCandidates(
@@ -123,7 +122,7 @@ export function collectDirectSubcommandSelectorCandidates(
 
   const raw: CommandSelectorCandidate[] = [];
   for (const child of parent.commands) {
-    if (shouldSkipCommand(child, basePath.length)) {
+    if (shouldSkipCommand(child)) {
       continue;
     }
     const path = [...basePath, child.name()];

--- a/src/cli/program/help.ts
+++ b/src/cli/program/help.ts
@@ -53,7 +53,8 @@ export function configureProgramHelp(program: Command, ctx: ProgramContext) {
     .option(
       "--profile <name>",
       "Use a named profile (isolates OPENCLAW_STATE_DIR/OPENCLAW_CONFIG_PATH under ~/.openclaw-<name>)",
-    );
+    )
+    .option("-i, --interactive", "Open interactive command selector");
 
   program.option("--no-color", "Disable ANSI colors", false);
   program.helpOption("-h, --help", "Display help for command");

--- a/src/cli/run-main.test.ts
+++ b/src/cli/run-main.test.ts
@@ -116,14 +116,24 @@ describe("shouldUseInteractiveCommandSelector", () => {
     ).toBe(true);
   });
 
-  it("enables selector for interactive command", () => {
+  it("enables selector for --interactive", () => {
+    expect(
+      shouldUseInteractiveCommandSelector({
+        argv: ["node", "openclaw", "--interactive"],
+        stdinIsTTY: true,
+        stdoutIsTTY: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not enable selector for interactive command name", () => {
     expect(
       shouldUseInteractiveCommandSelector({
         argv: ["node", "openclaw", "interactive"],
         stdinIsTTY: true,
         stdoutIsTTY: true,
       }),
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it("keeps default no-arg invocation on fast help path", () => {
@@ -164,7 +174,7 @@ describe("shouldUseInteractiveCommandSelector", () => {
     ).toBe(false);
     expect(
       shouldUseInteractiveCommandSelector({
-        argv: ["node", "openclaw", "interactive"],
+        argv: ["node", "openclaw", "--interactive"],
         stdinIsTTY: true,
         stdoutIsTTY: true,
         disableSelectorEnv: "1",
@@ -188,10 +198,11 @@ describe("stripInteractiveSelectorArgs", () => {
     expect(stripInteractiveSelectorArgs(["node", "openclaw", "-i"])).toEqual(["node", "openclaw"]);
   });
 
-  it("removes interactive command from root invocations", () => {
+  it("keeps non-flag command arguments unchanged", () => {
     expect(stripInteractiveSelectorArgs(["node", "openclaw", "interactive"])).toEqual([
       "node",
       "openclaw",
+      "interactive",
     ]);
   });
 

--- a/src/cli/run-main.test.ts
+++ b/src/cli/run-main.test.ts
@@ -4,6 +4,7 @@ import {
   shouldEnsureCliPath,
   shouldRegisterPrimarySubcommand,
   shouldSkipPluginCommandRegistration,
+  shouldUseInteractiveCommandSelector,
 } from "./run-main.js";
 
 describe("rewriteUpdateFlagArgv", () => {
@@ -98,6 +99,64 @@ describe("shouldSkipPluginCommandRegistration", () => {
         argv: ["node", "openclaw", "voicecall", "status"],
         primary: "voicecall",
         hasBuiltinPrimary: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("shouldUseInteractiveCommandSelector", () => {
+  it("enables selector for plain no-arg interactive invocations", () => {
+    expect(
+      shouldUseInteractiveCommandSelector({
+        argv: ["node", "openclaw"],
+        stdinIsTTY: true,
+        stdoutIsTTY: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("disables selector when a command is already present", () => {
+    expect(
+      shouldUseInteractiveCommandSelector({
+        argv: ["node", "openclaw", "status"],
+        stdinIsTTY: true,
+        stdoutIsTTY: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("disables selector for non-interactive terminals or CI", () => {
+    expect(
+      shouldUseInteractiveCommandSelector({
+        argv: ["node", "openclaw"],
+        stdinIsTTY: false,
+        stdoutIsTTY: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldUseInteractiveCommandSelector({
+        argv: ["node", "openclaw"],
+        stdinIsTTY: true,
+        stdoutIsTTY: true,
+        ciEnv: "1",
+      }),
+    ).toBe(false);
+    expect(
+      shouldUseInteractiveCommandSelector({
+        argv: ["node", "openclaw"],
+        stdinIsTTY: true,
+        stdoutIsTTY: true,
+        disableSelectorEnv: "1",
+      }),
+    ).toBe(false);
+  });
+
+  it("disables selector for help/version invocations", () => {
+    expect(
+      shouldUseInteractiveCommandSelector({
+        argv: ["node", "openclaw", "--help"],
+        stdinIsTTY: true,
+        stdoutIsTTY: true,
       }),
     ).toBe(false);
   });

--- a/src/cli/run-main.test.ts
+++ b/src/cli/run-main.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  isCommanderExitError,
   rewriteUpdateFlagArgv,
   shouldEnsureCliPath,
   shouldRegisterPrimarySubcommand,
@@ -7,6 +8,19 @@ import {
   shouldUseInteractiveCommandSelector,
   stripInteractiveSelectorArgs,
 } from "./run-main.js";
+
+describe("isCommanderExitError", () => {
+  it("detects commander exit errors", () => {
+    expect(isCommanderExitError({ code: "commander.helpDisplayed" })).toBe(true);
+    expect(isCommanderExitError({ code: "commander.unknownOption" })).toBe(true);
+  });
+
+  it("ignores non-commander errors", () => {
+    expect(isCommanderExitError(new Error("boom"))).toBe(false);
+    expect(isCommanderExitError({ code: "custom.error" })).toBe(false);
+    expect(isCommanderExitError(null)).toBe(false);
+  });
+});
 
 describe("rewriteUpdateFlagArgv", () => {
   it("leaves argv unchanged when --update is absent", () => {

--- a/src/cli/run-main.test.ts
+++ b/src/cli/run-main.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   isCommanderExitError,
   rewriteUpdateFlagArgv,
+  scanInteractiveRootArgv,
   shouldEnsureCliPath,
   shouldRegisterPrimarySubcommand,
   shouldSkipPluginCommandRegistration,
@@ -116,6 +117,27 @@ describe("shouldSkipPluginCommandRegistration", () => {
         hasBuiltinPrimary: false,
       }),
     ).toBe(false);
+  });
+});
+
+describe("scanInteractiveRootArgv", () => {
+  it("extracts interactive flag, primary, and stripped argv in one pass", () => {
+    expect(
+      scanInteractiveRootArgv(["node", "openclaw", "-i", "--profile", "dev"]).hasInteractiveFlag,
+    ).toBe(true);
+    expect(
+      scanInteractiveRootArgv(["node", "openclaw", "-i", "--profile", "dev"]).primary,
+    ).toBeNull();
+    expect(
+      scanInteractiveRootArgv(["node", "openclaw", "-i", "--profile", "dev"]).strippedArgv,
+    ).toEqual(["node", "openclaw", "--profile", "dev"]);
+  });
+
+  it("detects primary commands while stripping interactive flags", () => {
+    const scanned = scanInteractiveRootArgv(["node", "openclaw", "-i", "status", "--json"]);
+    expect(scanned.hasInteractiveFlag).toBe(true);
+    expect(scanned.primary).toBe("status");
+    expect(scanned.strippedArgv).toEqual(["node", "openclaw", "status", "--json"]);
   });
 });
 


### PR DESCRIPTION
## Summary
- add an explicit interactive entrypoint (`openclaw interactive`) and `-i/--interactive` option while keeping plain `openclaw` on the fast help path
- switch the command picker to true autocomplete-based fuzzy selection
- add nested subcommand fuzzy selection when a selected command requires a child command
- add `../` in the subcommand picker to jump back to the main command picker
- preserve direct CLI behavior outside interactive mode (for example, `openclaw models auth` still shows command help), while `openclaw -i` now drills into a subcommand picker for the same selection

## Testing
- pnpm exec vitest run src/cli/program/command-selector.test.ts src/cli/run-main.test.ts src/cli/program/command-registry.test.ts
- pnpm tsgo

## TODO 

- [ ] Add asciicinema for how it works 
- [ ] Fix some ergonomics around subcommand fuzzy find
- [ ] Make commands executable interactively by asking the params they need  via clack/prompts
