### PR TITLE
Fix: align DEFAULT_BROWSER_CONTROL_PORT with base+2 derivation logic …

### DIFF
--- a/src/config/port-defaults.ts
+++ b/src/config/port-defaults.ts
@@ -13,7 +13,7 @@ function derivePort(base: number, offset: number, fallback: number): number {
 }
 
 export const DEFAULT_BRIDGE_PORT = 18790;
-export const DEFAULT_BROWSER_CONTROL_PORT = 18791;
+export const DEFAULT_BROWSER_CONTROL_PORT = 18792;
 export const DEFAULT_CANVAS_HOST_PORT = 18793;
 export const DEFAULT_BROWSER_CDP_PORT_RANGE_START = 18800;
 export const DEFAULT_BROWSER_CDP_PORT_RANGE_END = 18899;

--- a/src/config/port-defaults.ts
+++ b/src/config/port-defaults.ts
@@ -13,7 +13,7 @@ function derivePort(base: number, offset: number, fallback: number): number {
 }
 
 export const DEFAULT_BRIDGE_PORT = 18790;
-export const DEFAULT_BROWSER_CONTROL_PORT = 18792;
+export const DEFAULT_BROWSER_CONTROL_PORT = 18791;
 export const DEFAULT_CANVAS_HOST_PORT = 18793;
 export const DEFAULT_BROWSER_CDP_PORT_RANGE_START = 18800;
 export const DEFAULT_BROWSER_CDP_PORT_RANGE_END = 18899;
@@ -23,7 +23,7 @@ export function deriveDefaultBridgePort(gatewayPort: number): number {
 }
 
 export function deriveDefaultBrowserControlPort(gatewayPort: number): number {
-  return derivePort(gatewayPort, 2, DEFAULT_BROWSER_CONTROL_PORT);
+  return derivePort(gatewayPort, 1, DEFAULT_BROWSER_CONTROL_PORT);
 }
 
 export function deriveDefaultCanvasHostPort(gatewayPort: number): number {


### PR DESCRIPTION
Fix: align DEFAULT_BROWSER_CONTROL_PORT with base+2 derivation logic

## Summary

- **Problem:** `DEFAULT_BROWSER_CONTROL_PORT` was hardcoded to `18791` (offset of 1), but the `deriveDefaultBrowserControlPort` function calculates it using an offset of `2`.
- **Why it matters:** This inconsistency causes port mismatch errors when the browser service attempts to bind to the wrong port.
- **What changed:** Updated `DEFAULT_BROWSER_CONTROL_PORT` in `src/config/port-defaults.ts` from `18791` to `18792`.
- **What did NOT change:** No logic changes were made; only the default constant was aligned to match the existing logic.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

this PR attempts to fix port alignment but introduces a mathematical error that will break existing functionality.

**Issues found:**
- `DEFAULT_BROWSER_CONTROL_PORT` changed from `18791` to `18792`, but the correct value is `18791` (gateway `18789` + offset `2`)
- this change breaks the test at `src/browser/config.test.ts:8` which expects `18791`
- contradicts documentation stating "default: `18791`, which is gateway + 2"
- disrupts the port allocation scheme where browser control uses `18791` and the relay uses the next port (`18792`)

**Root cause:**
the PR description claims the old value `18791` was "offset of 1" but this is incorrect - `18791 = 18789 + 2`, which correctly matches the offset of 2 used in `deriveDefaultBrowserControlPort`.

<h3>Confidence Score: 0/5</h3>

- This PR contains a critical mathematical error that will break functionality
- Score of 0 because the change is mathematically incorrect (18789 + 2 = 18791, not 18792), will break existing tests, contradicts documentation, and disrupts the established port allocation scheme
- src/config/port-defaults.ts requires correction - the value must be reverted to 18791

<sub>Last reviewed commit: 715fc1d</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->