### PR TITLE
feat(slack): add configurable streaming modes for draft previews

### DIFF
--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -327,6 +327,8 @@ export const FIELD_HELP: Record<string, string> = {
   "channels.slack.commands.native": 'Override native commands for Slack (bool or "auto").',
   "channels.slack.commands.nativeSkills":
     'Override native skill commands for Slack (bool or "auto").',
+  "channels.slack.streamMode":
+    "Live stream preview mode for Slack replies (replace | status_final | append).",
   "session.agentToAgent.maxPingPongTurns":
     "Max reply-back turns between requester and target (0–5).",
   "channels.telegram.customCommands":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -279,6 +279,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "channels.slack.appToken": "Slack App Token",
   "channels.slack.userToken": "Slack User Token",
   "channels.slack.userTokenReadOnly": "Slack User Token Read Only",
+  "channels.slack.streamMode": "Slack Stream Mode",
   "channels.slack.thread.historyScope": "Slack Thread History Scope",
   "channels.slack.thread.inheritParent": "Slack Thread Parent Inheritance",
   "channels.slack.thread.initialHistoryLimit": "Slack Thread Initial History Limit",

--- a/src/config/types.slack.ts
+++ b/src/config/types.slack.ts
@@ -45,6 +45,7 @@ export type SlackChannelConfig = {
 };
 
 export type SlackReactionNotificationMode = "off" | "own" | "all" | "allowlist";
+export type SlackStreamMode = "replace" | "status_final" | "append";
 
 export type SlackActionConfig = {
   reactions?: boolean;
@@ -124,6 +125,8 @@ export type SlackAccountConfig = {
   blockStreaming?: boolean;
   /** Merge streamed block replies before sending. */
   blockStreamingCoalesce?: BlockStreamingCoalesceConfig;
+  /** Slack stream preview mode (replace|status_final|append). Default: replace. */
+  streamMode?: SlackStreamMode;
   mediaMaxMb?: number;
   /** Reaction notification mode (off|own|all|allowlist). Default: own. */
   reactionNotifications?: SlackReactionNotificationMode;

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -460,6 +460,7 @@ export const GoogleChatAccountSchema = z
     chunkMode: z.enum(["length", "newline"]).optional(),
     blockStreaming: z.boolean().optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
+    streamMode: z.enum(["replace", "status_final", "append"]).optional().default("replace"),
     mediaMaxMb: z.number().positive().optional(),
     replyToMode: ReplyToModeSchema.optional(),
     actions: z

--- a/src/slack/draft-stream.test.ts
+++ b/src/slack/draft-stream.test.ts
@@ -103,4 +103,54 @@ describe("createSlackDraftStream", () => {
     expect(edit).not.toHaveBeenCalled();
     expect(warn).toHaveBeenCalledTimes(1);
   });
+
+  it("clear removes preview message when one exists", async () => {
+    const send = vi.fn(async () => ({
+      channelId: "C123",
+      messageId: "111.222",
+    }));
+    const edit = vi.fn(async () => {});
+    const remove = vi.fn(async () => {});
+    const stream = createSlackDraftStream({
+      target: "channel:C123",
+      token: "xoxb-test",
+      throttleMs: 250,
+      send,
+      edit,
+      remove,
+    });
+
+    stream.update("hello");
+    await stream.flush();
+    await stream.clear();
+
+    expect(remove).toHaveBeenCalledTimes(1);
+    expect(remove).toHaveBeenCalledWith("C123", "111.222", {
+      token: "xoxb-test",
+      accountId: undefined,
+    });
+    expect(stream.messageId()).toBeUndefined();
+    expect(stream.channelId()).toBeUndefined();
+  });
+
+  it("clear is a no-op when no preview message exists", async () => {
+    const send = vi.fn(async () => ({
+      channelId: "C123",
+      messageId: "111.222",
+    }));
+    const edit = vi.fn(async () => {});
+    const remove = vi.fn(async () => {});
+    const stream = createSlackDraftStream({
+      target: "channel:C123",
+      token: "xoxb-test",
+      throttleMs: 250,
+      send,
+      edit,
+      remove,
+    });
+
+    await stream.clear();
+
+    expect(remove).not.toHaveBeenCalled();
+  });
 });

--- a/src/slack/draft-stream.test.ts
+++ b/src/slack/draft-stream.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from "vitest";
+import { createSlackDraftStream } from "./draft-stream.js";
+
+describe("createSlackDraftStream", () => {
+  it("sends the first update and edits subsequent updates", async () => {
+    const send = vi.fn(async () => ({
+      channelId: "C123",
+      messageId: "111.222",
+    }));
+    const edit = vi.fn(async () => {});
+    const stream = createSlackDraftStream({
+      target: "channel:C123",
+      token: "xoxb-test",
+      throttleMs: 250,
+      send,
+      edit,
+    });
+
+    stream.update("hello");
+    await stream.flush();
+    stream.update("hello world");
+    await stream.flush();
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(edit).toHaveBeenCalledTimes(1);
+    expect(edit).toHaveBeenCalledWith("C123", "111.222", "hello world", {
+      token: "xoxb-test",
+      accountId: undefined,
+    });
+  });
+
+  it("does not send duplicate text", async () => {
+    const send = vi.fn(async () => ({
+      channelId: "C123",
+      messageId: "111.222",
+    }));
+    const edit = vi.fn(async () => {});
+    const stream = createSlackDraftStream({
+      target: "channel:C123",
+      token: "xoxb-test",
+      throttleMs: 250,
+      send,
+      edit,
+    });
+
+    stream.update("same");
+    await stream.flush();
+    stream.update("same");
+    await stream.flush();
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(edit).toHaveBeenCalledTimes(0);
+  });
+
+  it("supports forceNewMessage for subsequent assistant messages", async () => {
+    const send = vi
+      .fn()
+      .mockResolvedValueOnce({ channelId: "C123", messageId: "111.222" })
+      .mockResolvedValueOnce({ channelId: "C123", messageId: "333.444" });
+    const edit = vi.fn(async () => {});
+    const stream = createSlackDraftStream({
+      target: "channel:C123",
+      token: "xoxb-test",
+      throttleMs: 250,
+      send,
+      edit,
+    });
+
+    stream.update("first");
+    await stream.flush();
+    stream.forceNewMessage();
+    stream.update("second");
+    await stream.flush();
+
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(edit).toHaveBeenCalledTimes(0);
+    expect(stream.messageId()).toBe("333.444");
+  });
+
+  it("stops when text exceeds max chars", async () => {
+    const send = vi.fn(async () => ({
+      channelId: "C123",
+      messageId: "111.222",
+    }));
+    const edit = vi.fn(async () => {});
+    const warn = vi.fn();
+    const stream = createSlackDraftStream({
+      target: "channel:C123",
+      token: "xoxb-test",
+      maxChars: 5,
+      throttleMs: 250,
+      send,
+      edit,
+      warn,
+    });
+
+    stream.update("123456");
+    await stream.flush();
+    stream.update("ok");
+    await stream.flush();
+
+    expect(send).not.toHaveBeenCalled();
+    expect(edit).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/slack/draft-stream.ts
+++ b/src/slack/draft-stream.ts
@@ -1,0 +1,172 @@
+import { editSlackMessage } from "./actions.js";
+import { sendMessageSlack } from "./send.js";
+
+const SLACK_STREAM_MAX_CHARS = 4000;
+const DEFAULT_THROTTLE_MS = 1000;
+
+export type SlackDraftStream = {
+  update: (text: string) => void;
+  flush: () => Promise<void>;
+  stop: () => void;
+  forceNewMessage: () => void;
+  messageId: () => string | undefined;
+  channelId: () => string | undefined;
+};
+
+export function createSlackDraftStream(params: {
+  target: string;
+  token: string;
+  accountId?: string;
+  maxChars?: number;
+  throttleMs?: number;
+  resolveThreadTs?: () => string | undefined;
+  onMessageSent?: () => void;
+  log?: (message: string) => void;
+  warn?: (message: string) => void;
+  send?: typeof sendMessageSlack;
+  edit?: typeof editSlackMessage;
+}): SlackDraftStream {
+  const maxChars = Math.min(params.maxChars ?? SLACK_STREAM_MAX_CHARS, SLACK_STREAM_MAX_CHARS);
+  const throttleMs = Math.max(250, params.throttleMs ?? DEFAULT_THROTTLE_MS);
+  const send = params.send ?? sendMessageSlack;
+  const edit = params.edit ?? editSlackMessage;
+
+  let streamMessageId: string | undefined;
+  let streamChannelId: string | undefined;
+  let lastSentText = "";
+  let lastSentAt = 0;
+  let pendingText = "";
+  let inFlightPromise: Promise<void> | undefined;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let stopped = false;
+
+  const sendOrEditStreamMessage = async (text: string) => {
+    if (stopped) {
+      return;
+    }
+    const trimmed = text.trimEnd();
+    if (!trimmed) {
+      return;
+    }
+    if (trimmed.length > maxChars) {
+      stopped = true;
+      params.warn?.(`slack stream preview stopped (text length ${trimmed.length} > ${maxChars})`);
+      return;
+    }
+    if (trimmed === lastSentText) {
+      return;
+    }
+    lastSentText = trimmed;
+    lastSentAt = Date.now();
+    try {
+      if (streamChannelId && streamMessageId) {
+        await edit(streamChannelId, streamMessageId, trimmed, {
+          token: params.token,
+          accountId: params.accountId,
+        });
+        return;
+      }
+      const sent = await send(params.target, trimmed, {
+        token: params.token,
+        accountId: params.accountId,
+        threadTs: params.resolveThreadTs?.(),
+      });
+      streamChannelId = sent.channelId || streamChannelId;
+      streamMessageId = sent.messageId || streamMessageId;
+      if (!streamChannelId || !streamMessageId) {
+        stopped = true;
+        params.warn?.("slack stream preview stopped (missing identifiers from sendMessage)");
+        return;
+      }
+      params.onMessageSent?.();
+    } catch (err) {
+      stopped = true;
+      params.warn?.(
+        `slack stream preview failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  };
+
+  const flush = async () => {
+    if (timer) {
+      clearTimeout(timer);
+      timer = undefined;
+    }
+    while (!stopped) {
+      if (inFlightPromise) {
+        await inFlightPromise;
+        continue;
+      }
+      const text = pendingText;
+      const trimmed = text.trim();
+      if (!trimmed) {
+        pendingText = "";
+        return;
+      }
+      pendingText = "";
+      const current = sendOrEditStreamMessage(text).finally(() => {
+        if (inFlightPromise === current) {
+          inFlightPromise = undefined;
+        }
+      });
+      inFlightPromise = current;
+      await current;
+      if (!pendingText) {
+        return;
+      }
+    }
+  };
+
+  const schedule = () => {
+    if (timer) {
+      return;
+    }
+    const delay = Math.max(0, throttleMs - (Date.now() - lastSentAt));
+    timer = setTimeout(() => {
+      void flush();
+    }, delay);
+  };
+
+  const update = (text: string) => {
+    if (stopped) {
+      return;
+    }
+    pendingText = text;
+    if (inFlightPromise) {
+      schedule();
+      return;
+    }
+    if (!timer && Date.now() - lastSentAt >= throttleMs) {
+      void flush();
+      return;
+    }
+    schedule();
+  };
+
+  const stop = () => {
+    stopped = true;
+    pendingText = "";
+    if (timer) {
+      clearTimeout(timer);
+      timer = undefined;
+    }
+  };
+
+  const forceNewMessage = () => {
+    streamMessageId = undefined;
+    streamChannelId = undefined;
+    lastSentText = "";
+    pendingText = "";
+  };
+
+  params.log?.(`slack stream preview ready (maxChars=${maxChars}, throttleMs=${throttleMs})`);
+
+  return {
+    update,
+    flush,
+    stop,
+    forceNewMessage,
+    messageId: () => streamMessageId,
+    channelId: () => streamChannelId,
+  };
+}

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -123,6 +123,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         draftStream?.stop();
         try {
           await ctx.app.client.chat.update({
+            token: ctx.botToken,
             channel: draftChannelId,
             ts: draftMessageId,
             text: finalText.trim(),

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -135,7 +135,8 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
           );
         }
       } else if (mediaCount > 0) {
-        draftStream?.stop();
+        await draftStream?.clear();
+        hasStreamedMessage = false;
       }
 
       const replyThreadTs = replyPlan.nextThreadTs();
@@ -215,6 +216,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   const anyReplyDelivered = queuedFinal || (counts.block ?? 0) > 0 || (counts.final ?? 0) > 0;
 
   if (!anyReplyDelivered) {
+    await draftStream.clear();
     if (prepared.isRoomish) {
       clearHistoryEntriesIfEnabled({
         historyMap: ctx.channelHistories,

--- a/src/slack/stream-mode.test.ts
+++ b/src/slack/stream-mode.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyAppendOnlyStreamUpdate,
+  buildStatusFinalPreviewText,
+  resolveSlackStreamMode,
+} from "./stream-mode.js";
+
+describe("resolveSlackStreamMode", () => {
+  it("defaults to replace", () => {
+    expect(resolveSlackStreamMode(undefined)).toBe("replace");
+    expect(resolveSlackStreamMode("")).toBe("replace");
+    expect(resolveSlackStreamMode("unknown")).toBe("replace");
+  });
+
+  it("accepts valid modes", () => {
+    expect(resolveSlackStreamMode("replace")).toBe("replace");
+    expect(resolveSlackStreamMode("status_final")).toBe("status_final");
+    expect(resolveSlackStreamMode("append")).toBe("append");
+  });
+});
+
+describe("applyAppendOnlyStreamUpdate", () => {
+  it("starts with first incoming text", () => {
+    const next = applyAppendOnlyStreamUpdate({
+      incoming: "hello",
+      rendered: "",
+      source: "",
+    });
+    expect(next).toEqual({ rendered: "hello", source: "hello", changed: true });
+  });
+
+  it("uses cumulative incoming text when it extends prior source", () => {
+    const next = applyAppendOnlyStreamUpdate({
+      incoming: "hello world",
+      rendered: "hello",
+      source: "hello",
+    });
+    expect(next).toEqual({
+      rendered: "hello world",
+      source: "hello world",
+      changed: true,
+    });
+  });
+
+  it("ignores regressive shorter incoming text", () => {
+    const next = applyAppendOnlyStreamUpdate({
+      incoming: "hello",
+      rendered: "hello world",
+      source: "hello world",
+    });
+    expect(next).toEqual({
+      rendered: "hello world",
+      source: "hello world",
+      changed: false,
+    });
+  });
+
+  it("appends non-prefix incoming chunks", () => {
+    const next = applyAppendOnlyStreamUpdate({
+      incoming: "next chunk",
+      rendered: "hello world",
+      source: "hello world",
+    });
+    expect(next).toEqual({
+      rendered: "hello world\nnext chunk",
+      source: "next chunk",
+      changed: true,
+    });
+  });
+});
+
+describe("buildStatusFinalPreviewText", () => {
+  it("cycles status dots", () => {
+    expect(buildStatusFinalPreviewText(1)).toBe("Status: thinking..");
+    expect(buildStatusFinalPreviewText(2)).toBe("Status: thinking...");
+    expect(buildStatusFinalPreviewText(3)).toBe("Status: thinking.");
+  });
+});

--- a/src/slack/stream-mode.ts
+++ b/src/slack/stream-mode.ts
@@ -1,0 +1,53 @@
+export type SlackStreamMode = "replace" | "status_final" | "append";
+
+const DEFAULT_STREAM_MODE: SlackStreamMode = "replace";
+
+export function resolveSlackStreamMode(raw: unknown): SlackStreamMode {
+  if (typeof raw !== "string") {
+    return DEFAULT_STREAM_MODE;
+  }
+  const normalized = raw.trim().toLowerCase();
+  if (normalized === "replace" || normalized === "status_final" || normalized === "append") {
+    return normalized;
+  }
+  return DEFAULT_STREAM_MODE;
+}
+
+export function applyAppendOnlyStreamUpdate(params: {
+  incoming: string;
+  rendered: string;
+  source: string;
+}): { rendered: string; source: string; changed: boolean } {
+  const incoming = params.incoming.trimEnd();
+  if (!incoming) {
+    return { rendered: params.rendered, source: params.source, changed: false };
+  }
+  if (!params.rendered) {
+    return { rendered: incoming, source: incoming, changed: true };
+  }
+  if (incoming === params.source) {
+    return { rendered: params.rendered, source: params.source, changed: false };
+  }
+
+  // Typical model partials are cumulative prefixes.
+  if (incoming.startsWith(params.source) || incoming.startsWith(params.rendered)) {
+    return { rendered: incoming, source: incoming, changed: incoming !== params.rendered };
+  }
+
+  // Ignore regressive shorter variants of the same stream.
+  if (params.source.startsWith(incoming)) {
+    return { rendered: params.rendered, source: params.source, changed: false };
+  }
+
+  const separator = params.rendered.endsWith("\n") ? "" : "\n";
+  return {
+    rendered: `${params.rendered}${separator}${incoming}`,
+    source: incoming,
+    changed: true,
+  };
+}
+
+export function buildStatusFinalPreviewText(updateCount: number): string {
+  const dots = ".".repeat((Math.max(1, updateCount) % 3) + 1);
+  return `Status: thinking${dots}`;
+}


### PR DESCRIPTION
## Summary
- add Slack draft-stream previews that post once and update via `chat.update`
- add configurable streaming modes so teams can pick UX behavior:
  - `replace`: in-place replacement updates
  - `status_final`: stable status updates + separate final answer
  - `append`: append-only growth (never replaces earlier text)
- add draft preview lifecycle hardening (`clear`, media/no-final cleanup)
- keep multi-account safety by using explicit `token: ctx.botToken` on updates

## Why
Different teams prefer different streaming UX patterns. This change allows Slack users to choose the style that fits them while preventing stale draft artifacts and preserving safe fallback behavior.

## Changes
- Streaming runtime:
  - `src/slack/draft-stream.ts`
  - `src/slack/stream-mode.ts`
  - `src/slack/monitor/message-handler/dispatch.ts`
- Config surface:
  - `src/config/types.slack.ts`
  - `src/config/zod-schema.providers-core.ts`
  - `src/config/schema.help.ts`
  - `src/config/schema.labels.ts`
- Tests:
  - `src/slack/draft-stream.test.ts`
  - `src/slack/stream-mode.test.ts`

## Dependency
Depends on Slack Block Kit foundation stack (starting at #18180 through #18500).
If reviewing before dependencies merge, review tip commit: `865918d96`.

## Validation
- `pnpm vitest run src/slack/stream-mode.test.ts src/slack/draft-stream.test.ts src/slack/monitor/slash.test.ts src/slack/monitor/events/interactions.test.ts`
- `pnpm tsgo`
- `pnpm check`

## Notes
- Slack-only scope; no Discord/webchat streaming behavior changes.
