### PR TITLE
Add exiting functionality to doctor.ts

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -6,9 +6,9 @@ import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { loadModelCatalog } from "../agents/model-catalog.js";
 import {
-  getModelRefStatus,
-  resolveConfiguredModelRef,
-  resolveHooksGmailModel,
+    getModelRefStatus,
+    resolveConfiguredModelRef,
+    resolveHooksGmailModel,
 } from "../agents/model-selection.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { CONFIG_PATH, readConfigFileSnapshot, writeConfigFile } from "../config/config.js";
@@ -22,32 +22,32 @@ import { note } from "../terminal/note.js";
 import { stylePromptTitle } from "../terminal/prompt-style.js";
 import { shortenHomePath } from "../utils.js";
 import {
-  maybeRemoveDeprecatedCliAuthProfiles,
-  maybeRepairAnthropicOAuthProfileId,
-  noteAuthProfileHealth,
+    maybeRemoveDeprecatedCliAuthProfiles,
+    maybeRepairAnthropicOAuthProfileId,
+    noteAuthProfileHealth,
 } from "./doctor-auth.js";
 import { doctorShellCompletion } from "./doctor-completion.js";
 import { loadAndMaybeMigrateDoctorConfig } from "./doctor-config-flow.js";
 import { maybeRepairGatewayDaemon } from "./doctor-gateway-daemon-flow.js";
 import { checkGatewayHealth } from "./doctor-gateway-health.js";
 import {
-  maybeRepairGatewayServiceConfig,
-  maybeScanExtraGatewayServices,
+    maybeRepairGatewayServiceConfig,
+    maybeScanExtraGatewayServices,
 } from "./doctor-gateway-services.js";
 import { noteSourceInstallIssues } from "./doctor-install.js";
 import { noteMemorySearchHealth } from "./doctor-memory-search.js";
 import {
-  noteMacLaunchAgentOverrides,
-  noteMacLaunchctlGatewayEnvOverrides,
-  noteDeprecatedLegacyEnvVars,
+    noteMacLaunchAgentOverrides,
+    noteMacLaunchctlGatewayEnvOverrides,
+    noteDeprecatedLegacyEnvVars,
 } from "./doctor-platform-notes.js";
 import { createDoctorPrompter, type DoctorOptions } from "./doctor-prompter.js";
 import { maybeRepairSandboxImages, noteSandboxScopeWarnings } from "./doctor-sandbox.js";
 import { noteSecurityWarnings } from "./doctor-security.js";
 import { noteStateIntegrity, noteWorkspaceBackupTip } from "./doctor-state-integrity.js";
 import {
-  detectLegacyStateMigrations,
-  runLegacyStateMigrations,
+    detectLegacyStateMigrations,
+    runLegacyStateMigrations,
 } from "./doctor-state-migrations.js";
 import { maybeRepairUiProtocolFreshness } from "./doctor-ui.js";
 import { maybeOfferUpdateBeforeDoctor } from "./doctor-update.js";
@@ -60,256 +60,257 @@ const intro = (message: string) => clackIntro(stylePromptTitle(message) ?? messa
 const outro = (message: string) => clackOutro(stylePromptTitle(message) ?? message);
 
 function resolveMode(cfg: OpenClawConfig): "local" | "remote" {
-  return cfg.gateway?.mode === "remote" ? "remote" : "local";
+    return cfg.gateway?.mode === "remote" ? "remote" : "local";
 }
 
 export async function doctorCommand(
-  runtime: RuntimeEnv = defaultRuntime,
-  options: DoctorOptions = {},
+    runtime: RuntimeEnv = defaultRuntime,
+    options: DoctorOptions = {},
 ) {
-  const prompter = createDoctorPrompter({ runtime, options });
-  printWizardHeader(runtime);
-  intro("OpenClaw doctor");
+    const prompter = createDoctorPrompter({ runtime, options });
+    printWizardHeader(runtime);
+    intro("OpenClaw doctor");
 
-  const root = await resolveOpenClawPackageRoot({
-    moduleUrl: import.meta.url,
-    argv1: process.argv[1],
-    cwd: process.cwd(),
-  });
-
-  const updateResult = await maybeOfferUpdateBeforeDoctor({
-    runtime,
-    options,
-    root,
-    confirm: (p) => prompter.confirm(p),
-    outro,
-  });
-  if (updateResult.handled) {
-    return;
-  }
-
-  await maybeRepairUiProtocolFreshness(runtime, prompter);
-  noteSourceInstallIssues(root);
-  noteDeprecatedLegacyEnvVars();
-
-  const configResult = await loadAndMaybeMigrateDoctorConfig({
-    options,
-    confirm: (p) => prompter.confirm(p),
-  });
-  let cfg: OpenClawConfig = configResult.cfg;
-
-  const configPath = configResult.path ?? CONFIG_PATH;
-  if (!cfg.gateway?.mode) {
-    const lines = [
-      "gateway.mode is unset; gateway start will be blocked.",
-      `Fix: run ${formatCliCommand("openclaw configure")} and set Gateway mode (local/remote).`,
-      `Or set directly: ${formatCliCommand("openclaw config set gateway.mode local")}`,
-    ];
-    if (!fs.existsSync(configPath)) {
-      lines.push(`Missing config: run ${formatCliCommand("openclaw setup")} first.`);
-    }
-    note(lines.join("\n"), "Gateway");
-  }
-
-  cfg = await maybeRepairAnthropicOAuthProfileId(cfg, prompter);
-  cfg = await maybeRemoveDeprecatedCliAuthProfiles(cfg, prompter);
-  await noteAuthProfileHealth({
-    cfg,
-    prompter,
-    allowKeychainPrompt: options.nonInteractive !== true && Boolean(process.stdin.isTTY),
-  });
-  const gatewayDetails = buildGatewayConnectionDetails({ config: cfg });
-  if (gatewayDetails.remoteFallbackNote) {
-    note(gatewayDetails.remoteFallbackNote, "Gateway");
-  }
-  if (resolveMode(cfg) === "local") {
-    const auth = resolveGatewayAuth({
-      authConfig: cfg.gateway?.auth,
-      tailscaleMode: cfg.gateway?.tailscale?.mode ?? "off",
+    const root = await resolveOpenClawPackageRoot({
+        moduleUrl: import.meta.url,
+        argv1: process.argv[1],
+        cwd: process.cwd(),
     });
-    const needsToken = auth.mode !== "password" && (auth.mode !== "token" || !auth.token);
-    if (needsToken) {
-      note(
-        "Gateway auth is off or missing a token. Token auth is now the recommended default (including loopback).",
-        "Gateway auth",
-      );
-      const shouldSetToken =
-        options.generateGatewayToken === true
-          ? true
-          : options.nonInteractive === true
-            ? false
-            : await prompter.confirmRepair({
-                message: "Generate and configure a gateway token now?",
-                initialValue: true,
-              });
-      if (shouldSetToken) {
-        const nextToken = randomToken();
-        cfg = {
-          ...cfg,
-          gateway: {
-            ...cfg.gateway,
-            auth: {
-              ...cfg.gateway?.auth,
-              mode: "token",
-              token: nextToken,
-            },
-          },
-        };
-        note("Gateway token configured.", "Gateway auth");
-      }
-    }
-  }
 
-  const legacyState = await detectLegacyStateMigrations({ cfg });
-  if (legacyState.preview.length > 0) {
-    note(legacyState.preview.join("\n"), "Legacy state detected");
-    const migrate =
-      options.nonInteractive === true
-        ? true
-        : await prompter.confirm({
-            message: "Migrate legacy state (sessions/agent/WhatsApp auth) now?",
-            initialValue: true,
-          });
-    if (migrate) {
-      const migrated = await runLegacyStateMigrations({
-        detected: legacyState,
-      });
-      if (migrated.changes.length > 0) {
-        note(migrated.changes.join("\n"), "Doctor changes");
-      }
-      if (migrated.warnings.length > 0) {
-        note(migrated.warnings.join("\n"), "Doctor warnings");
-      }
-    }
-  }
-
-  await noteStateIntegrity(cfg, prompter, configResult.path ?? CONFIG_PATH);
-
-  cfg = await maybeRepairSandboxImages(cfg, runtime, prompter);
-  noteSandboxScopeWarnings(cfg);
-
-  await maybeScanExtraGatewayServices(options, runtime, prompter);
-  await maybeRepairGatewayServiceConfig(cfg, resolveMode(cfg), runtime, prompter);
-  await noteMacLaunchAgentOverrides();
-  await noteMacLaunchctlGatewayEnvOverrides(cfg);
-
-  await noteSecurityWarnings(cfg);
-
-  if (cfg.hooks?.gmail?.model?.trim()) {
-    const hooksModelRef = resolveHooksGmailModel({
-      cfg,
-      defaultProvider: DEFAULT_PROVIDER,
-    });
-    if (!hooksModelRef) {
-      note(`- hooks.gmail.model "${cfg.hooks.gmail.model}" could not be resolved`, "Hooks");
-    } else {
-      const { provider: defaultProvider, model: defaultModel } = resolveConfiguredModelRef({
-        cfg,
-        defaultProvider: DEFAULT_PROVIDER,
-        defaultModel: DEFAULT_MODEL,
-      });
-      const catalog = await loadModelCatalog({ config: cfg });
-      const status = getModelRefStatus({
-        cfg,
-        catalog,
-        ref: hooksModelRef,
-        defaultProvider,
-        defaultModel,
-      });
-      const warnings: string[] = [];
-      if (!status.allowed) {
-        warnings.push(
-          `- hooks.gmail.model "${status.key}" not in agents.defaults.models allowlist (will use primary instead)`,
-        );
-      }
-      if (!status.inCatalog) {
-        warnings.push(
-          `- hooks.gmail.model "${status.key}" not in the model catalog (may fail at runtime)`,
-        );
-      }
-      if (warnings.length > 0) {
-        note(warnings.join("\n"), "Hooks");
-      }
-    }
-  }
-
-  if (
-    options.nonInteractive !== true &&
-    process.platform === "linux" &&
-    resolveMode(cfg) === "local"
-  ) {
-    const service = resolveGatewayService();
-    let loaded = false;
-    try {
-      loaded = await service.isLoaded({ env: process.env });
-    } catch {
-      loaded = false;
-    }
-    if (loaded) {
-      await ensureSystemdUserLingerInteractive({
+    const updateResult = await maybeOfferUpdateBeforeDoctor({
         runtime,
-        prompter: {
-          confirm: async (p) => prompter.confirm(p),
-          note,
-        },
-        reason:
-          "Gateway runs as a systemd user service. Without lingering, systemd stops the user session on logout/idle and kills the Gateway.",
-        requireConfirm: true,
-      });
+        options,
+        root,
+        confirm: (p) => prompter.confirm(p),
+        outro,
+    });
+    if (updateResult.handled) {
+        return;
     }
-  }
 
-  noteWorkspaceStatus(cfg);
-  await noteMemorySearchHealth(cfg);
+    await maybeRepairUiProtocolFreshness(runtime, prompter);
+    noteSourceInstallIssues(root);
+    noteDeprecatedLegacyEnvVars();
 
-  // Check and fix shell completion
-  await doctorShellCompletion(runtime, prompter, {
-    nonInteractive: options.nonInteractive,
-  });
+    const configResult = await loadAndMaybeMigrateDoctorConfig({
+        options,
+        confirm: (p) => prompter.confirm(p),
+    });
+    let cfg: OpenClawConfig = configResult.cfg;
 
-  const { healthOk } = await checkGatewayHealth({
-    runtime,
-    cfg,
-    timeoutMs: options.nonInteractive === true ? 3000 : 10_000,
-  });
-  await maybeRepairGatewayDaemon({
-    cfg,
-    runtime,
-    prompter,
-    options,
-    gatewayDetailsMessage: gatewayDetails.message,
-    healthOk,
-  });
-
-  const shouldWriteConfig = prompter.shouldRepair || configResult.shouldWriteConfig;
-  if (shouldWriteConfig) {
-    cfg = applyWizardMetadata(cfg, { command: "doctor", mode: resolveMode(cfg) });
-    await writeConfigFile(cfg);
-    logConfigUpdated(runtime);
-    const backupPath = `${CONFIG_PATH}.bak`;
-    if (fs.existsSync(backupPath)) {
-      runtime.log(`Backup: ${shortenHomePath(backupPath)}`);
+    const configPath = configResult.path ?? CONFIG_PATH;
+    if (!cfg.gateway?.mode) {
+        const lines = [
+            "gateway.mode is unset; gateway start will be blocked.",
+            `Fix: run ${formatCliCommand("openclaw configure")} and set Gateway mode (local/remote).`,
+            `Or set directly: ${formatCliCommand("openclaw config set gateway.mode local")}`,
+        ];
+        if (!fs.existsSync(configPath)) {
+            lines.push(`Missing config: run ${formatCliCommand("openclaw setup")} first.`);
+        }
+        note(lines.join("\n"), "Gateway");
     }
-  } else {
-    runtime.log(`Run "${formatCliCommand("openclaw doctor --fix")}" to apply changes.`);
-  }
 
-  if (options.workspaceSuggestions !== false) {
-    const workspaceDir = resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg));
-    noteWorkspaceBackupTip(workspaceDir);
-    if (await shouldSuggestMemorySystem(workspaceDir)) {
-      note(MEMORY_SYSTEM_PROMPT, "Workspace");
+    cfg = await maybeRepairAnthropicOAuthProfileId(cfg, prompter);
+    cfg = await maybeRemoveDeprecatedCliAuthProfiles(cfg, prompter);
+    await noteAuthProfileHealth({
+        cfg,
+        prompter,
+        allowKeychainPrompt: options.nonInteractive !== true && Boolean(process.stdin.isTTY),
+    });
+    const gatewayDetails = buildGatewayConnectionDetails({ config: cfg });
+    if (gatewayDetails.remoteFallbackNote) {
+        note(gatewayDetails.remoteFallbackNote, "Gateway");
     }
-  }
-
-  const finalSnapshot = await readConfigFileSnapshot();
-  if (finalSnapshot.exists && !finalSnapshot.valid) {
-    runtime.error("Invalid config:");
-    for (const issue of finalSnapshot.issues) {
-      const path = issue.path || "<root>";
-      runtime.error(`- ${path}: ${issue.message}`);
+    if (resolveMode(cfg) === "local") {
+        const auth = resolveGatewayAuth({
+            authConfig: cfg.gateway?.auth,
+            tailscaleMode: cfg.gateway?.tailscale?.mode ?? "off",
+        });
+        const needsToken = auth.mode !== "password" && (auth.mode !== "token" || !auth.token);
+        if (needsToken) {
+            note(
+                "Gateway auth is off or missing a token. Token auth is now the recommended default (including loopback).",
+                "Gateway auth",
+            );
+            const shouldSetToken =
+                options.generateGatewayToken === true
+                    ? true
+                    : options.nonInteractive === true
+                        ? false
+                        : await prompter.confirmRepair({
+                            message: "Generate and configure a gateway token now?",
+                            initialValue: true,
+                        });
+            if (shouldSetToken) {
+                const nextToken = randomToken();
+                cfg = {
+                    ...cfg,
+                    gateway: {
+                        ...cfg.gateway,
+                        auth: {
+                            ...cfg.gateway?.auth,
+                            mode: "token",
+                            token: nextToken,
+                        },
+                    },
+                };
+                note("Gateway token configured.", "Gateway auth");
+            }
+        }
     }
-  }
 
-  outro("Doctor complete.");
+    const legacyState = await detectLegacyStateMigrations({ cfg });
+    if (legacyState.preview.length > 0) {
+        note(legacyState.preview.join("\n"), "Legacy state detected");
+        const migrate =
+            options.nonInteractive === true
+                ? true
+                : await prompter.confirm({
+                    message: "Migrate legacy state (sessions/agent/WhatsApp auth) now?",
+                    initialValue: true,
+                });
+        if (migrate) {
+            const migrated = await runLegacyStateMigrations({
+                detected: legacyState,
+            });
+            if (migrated.changes.length > 0) {
+                note(migrated.changes.join("\n"), "Doctor changes");
+            }
+            if (migrated.warnings.length > 0) {
+                note(migrated.warnings.join("\n"), "Doctor warnings");
+            }
+        }
+    }
+
+    await noteStateIntegrity(cfg, prompter, configResult.path ?? CONFIG_PATH);
+
+    cfg = await maybeRepairSandboxImages(cfg, runtime, prompter);
+    noteSandboxScopeWarnings(cfg);
+
+    await maybeScanExtraGatewayServices(options, runtime, prompter);
+    await maybeRepairGatewayServiceConfig(cfg, resolveMode(cfg), runtime, prompter);
+    await noteMacLaunchAgentOverrides();
+    await noteMacLaunchctlGatewayEnvOverrides(cfg);
+
+    await noteSecurityWarnings(cfg);
+
+    if (cfg.hooks?.gmail?.model?.trim()) {
+        const hooksModelRef = resolveHooksGmailModel({
+            cfg,
+            defaultProvider: DEFAULT_PROVIDER,
+        });
+        if (!hooksModelRef) {
+            note(`- hooks.gmail.model "${cfg.hooks.gmail.model}" could not be resolved`, "Hooks");
+        } else {
+            const { provider: defaultProvider, model: defaultModel } = resolveConfiguredModelRef({
+                cfg,
+                defaultProvider: DEFAULT_PROVIDER,
+                defaultModel: DEFAULT_MODEL,
+            });
+            const catalog = await loadModelCatalog({ config: cfg });
+            const status = getModelRefStatus({
+                cfg,
+                catalog,
+                ref: hooksModelRef,
+                defaultProvider,
+                defaultModel,
+            });
+            const warnings: string[] = [];
+            if (!status.allowed) {
+                warnings.push(
+                    `- hooks.gmail.model "${status.key}" not in agents.defaults.models allowlist (will use primary instead)`,
+                );
+            }
+            if (!status.inCatalog) {
+                warnings.push(
+                    `- hooks.gmail.model "${status.key}" not in the model catalog (may fail at runtime)`,
+                );
+            }
+            if (warnings.length > 0) {
+                note(warnings.join("\n"), "Hooks");
+            }
+        }
+    }
+
+    if (
+        options.nonInteractive !== true &&
+        process.platform === "linux" &&
+        resolveMode(cfg) === "local"
+    ) {
+        const service = resolveGatewayService();
+        let loaded = false;
+        try {
+            loaded = await service.isLoaded({ env: process.env });
+        } catch {
+            loaded = false;
+        }
+        if (loaded) {
+            await ensureSystemdUserLingerInteractive({
+                runtime,
+                prompter: {
+                    confirm: async (p) => prompter.confirm(p),
+                    note,
+                },
+                reason:
+                    "Gateway runs as a systemd user service. Without lingering, systemd stops the user session on logout/idle and kills the Gateway.",
+                requireConfirm: true,
+            });
+        }
+    }
+
+    noteWorkspaceStatus(cfg);
+    await noteMemorySearchHealth(cfg);
+
+    // Check and fix shell completion
+    await doctorShellCompletion(runtime, prompter, {
+        nonInteractive: options.nonInteractive,
+    });
+
+    const { healthOk } = await checkGatewayHealth({
+        runtime,
+        cfg,
+        timeoutMs: options.nonInteractive === true ? 3000 : 10_000,
+    });
+    await maybeRepairGatewayDaemon({
+        cfg,
+        runtime,
+        prompter,
+        options,
+        gatewayDetailsMessage: gatewayDetails.message,
+        healthOk,
+    });
+
+    const shouldWriteConfig = prompter.shouldRepair || configResult.shouldWriteConfig;
+    if (shouldWriteConfig) {
+        cfg = applyWizardMetadata(cfg, { command: "doctor", mode: resolveMode(cfg) });
+        await writeConfigFile(cfg);
+        logConfigUpdated(runtime);
+        const backupPath = `${CONFIG_PATH}.bak`;
+        if (fs.existsSync(backupPath)) {
+            runtime.log(`Backup: ${shortenHomePath(backupPath)}`);
+        }
+    } else {
+        runtime.log(`Run "${formatCliCommand("openclaw doctor --fix")}" to apply changes.`);
+    }
+
+    if (options.workspaceSuggestions !== false) {
+        const workspaceDir = resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg));
+        noteWorkspaceBackupTip(workspaceDir);
+        if (await shouldSuggestMemorySystem(workspaceDir)) {
+            note(MEMORY_SYSTEM_PROMPT, "Workspace");
+        }
+    }
+
+    const finalSnapshot = await readConfigFileSnapshot();
+    if (finalSnapshot.exists && !finalSnapshot.valid) {
+        runtime.error("Invalid config:");
+        for (const issue of finalSnapshot.issues) {
+            const path = issue.path || "<root>";
+            runtime.error(`- ${path}: ${issue.message}`);
+        }
+    }
+
+    outro("Doctor complete.");
+    runtime.exit(0);
 }

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -6,9 +6,9 @@ import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { loadModelCatalog } from "../agents/model-catalog.js";
 import {
-    getModelRefStatus,
-    resolveConfiguredModelRef,
-    resolveHooksGmailModel,
+  getModelRefStatus,
+  resolveConfiguredModelRef,
+  resolveHooksGmailModel,
 } from "../agents/model-selection.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { CONFIG_PATH, readConfigFileSnapshot, writeConfigFile } from "../config/config.js";
@@ -22,32 +22,32 @@ import { note } from "../terminal/note.js";
 import { stylePromptTitle } from "../terminal/prompt-style.js";
 import { shortenHomePath } from "../utils.js";
 import {
-    maybeRemoveDeprecatedCliAuthProfiles,
-    maybeRepairAnthropicOAuthProfileId,
-    noteAuthProfileHealth,
+  maybeRemoveDeprecatedCliAuthProfiles,
+  maybeRepairAnthropicOAuthProfileId,
+  noteAuthProfileHealth,
 } from "./doctor-auth.js";
 import { doctorShellCompletion } from "./doctor-completion.js";
 import { loadAndMaybeMigrateDoctorConfig } from "./doctor-config-flow.js";
 import { maybeRepairGatewayDaemon } from "./doctor-gateway-daemon-flow.js";
 import { checkGatewayHealth } from "./doctor-gateway-health.js";
 import {
-    maybeRepairGatewayServiceConfig,
-    maybeScanExtraGatewayServices,
+  maybeRepairGatewayServiceConfig,
+  maybeScanExtraGatewayServices,
 } from "./doctor-gateway-services.js";
 import { noteSourceInstallIssues } from "./doctor-install.js";
 import { noteMemorySearchHealth } from "./doctor-memory-search.js";
 import {
-    noteMacLaunchAgentOverrides,
-    noteMacLaunchctlGatewayEnvOverrides,
-    noteDeprecatedLegacyEnvVars,
+  noteMacLaunchAgentOverrides,
+  noteMacLaunchctlGatewayEnvOverrides,
+  noteDeprecatedLegacyEnvVars,
 } from "./doctor-platform-notes.js";
 import { createDoctorPrompter, type DoctorOptions } from "./doctor-prompter.js";
 import { maybeRepairSandboxImages, noteSandboxScopeWarnings } from "./doctor-sandbox.js";
 import { noteSecurityWarnings } from "./doctor-security.js";
 import { noteStateIntegrity, noteWorkspaceBackupTip } from "./doctor-state-integrity.js";
 import {
-    detectLegacyStateMigrations,
-    runLegacyStateMigrations,
+  detectLegacyStateMigrations,
+  runLegacyStateMigrations,
 } from "./doctor-state-migrations.js";
 import { maybeRepairUiProtocolFreshness } from "./doctor-ui.js";
 import { maybeOfferUpdateBeforeDoctor } from "./doctor-update.js";
@@ -60,257 +60,257 @@ const intro = (message: string) => clackIntro(stylePromptTitle(message) ?? messa
 const outro = (message: string) => clackOutro(stylePromptTitle(message) ?? message);
 
 function resolveMode(cfg: OpenClawConfig): "local" | "remote" {
-    return cfg.gateway?.mode === "remote" ? "remote" : "local";
+  return cfg.gateway?.mode === "remote" ? "remote" : "local";
 }
 
 export async function doctorCommand(
-    runtime: RuntimeEnv = defaultRuntime,
-    options: DoctorOptions = {},
+  runtime: RuntimeEnv = defaultRuntime,
+  options: DoctorOptions = {},
 ) {
-    const prompter = createDoctorPrompter({ runtime, options });
-    printWizardHeader(runtime);
-    intro("OpenClaw doctor");
+  const prompter = createDoctorPrompter({ runtime, options });
+  printWizardHeader(runtime);
+  intro("OpenClaw doctor");
 
-    const root = await resolveOpenClawPackageRoot({
-        moduleUrl: import.meta.url,
-        argv1: process.argv[1],
-        cwd: process.cwd(),
-    });
+  const root = await resolveOpenClawPackageRoot({
+    moduleUrl: import.meta.url,
+    argv1: process.argv[1],
+    cwd: process.cwd(),
+  });
 
-    const updateResult = await maybeOfferUpdateBeforeDoctor({
-        runtime,
-        options,
-        root,
-        confirm: (p) => prompter.confirm(p),
-        outro,
-    });
-    if (updateResult.handled) {
-        return;
+  const updateResult = await maybeOfferUpdateBeforeDoctor({
+    runtime,
+    options,
+    root,
+    confirm: (p) => prompter.confirm(p),
+    outro,
+  });
+  if (updateResult.handled) {
+    return;
+  }
+
+  await maybeRepairUiProtocolFreshness(runtime, prompter);
+  noteSourceInstallIssues(root);
+  noteDeprecatedLegacyEnvVars();
+
+  const configResult = await loadAndMaybeMigrateDoctorConfig({
+    options,
+    confirm: (p) => prompter.confirm(p),
+  });
+  let cfg: OpenClawConfig = configResult.cfg;
+
+  const configPath = configResult.path ?? CONFIG_PATH;
+  if (!cfg.gateway?.mode) {
+    const lines = [
+      "gateway.mode is unset; gateway start will be blocked.",
+      `Fix: run ${formatCliCommand("openclaw configure")} and set Gateway mode (local/remote).`,
+      `Or set directly: ${formatCliCommand("openclaw config set gateway.mode local")}`,
+    ];
+    if (!fs.existsSync(configPath)) {
+      lines.push(`Missing config: run ${formatCliCommand("openclaw setup")} first.`);
     }
+    note(lines.join("\n"), "Gateway");
+  }
 
-    await maybeRepairUiProtocolFreshness(runtime, prompter);
-    noteSourceInstallIssues(root);
-    noteDeprecatedLegacyEnvVars();
-
-    const configResult = await loadAndMaybeMigrateDoctorConfig({
-        options,
-        confirm: (p) => prompter.confirm(p),
+  cfg = await maybeRepairAnthropicOAuthProfileId(cfg, prompter);
+  cfg = await maybeRemoveDeprecatedCliAuthProfiles(cfg, prompter);
+  await noteAuthProfileHealth({
+    cfg,
+    prompter,
+    allowKeychainPrompt: options.nonInteractive !== true && Boolean(process.stdin.isTTY),
+  });
+  const gatewayDetails = buildGatewayConnectionDetails({ config: cfg });
+  if (gatewayDetails.remoteFallbackNote) {
+    note(gatewayDetails.remoteFallbackNote, "Gateway");
+  }
+  if (resolveMode(cfg) === "local") {
+    const auth = resolveGatewayAuth({
+      authConfig: cfg.gateway?.auth,
+      tailscaleMode: cfg.gateway?.tailscale?.mode ?? "off",
     });
-    let cfg: OpenClawConfig = configResult.cfg;
-
-    const configPath = configResult.path ?? CONFIG_PATH;
-    if (!cfg.gateway?.mode) {
-        const lines = [
-            "gateway.mode is unset; gateway start will be blocked.",
-            `Fix: run ${formatCliCommand("openclaw configure")} and set Gateway mode (local/remote).`,
-            `Or set directly: ${formatCliCommand("openclaw config set gateway.mode local")}`,
-        ];
-        if (!fs.existsSync(configPath)) {
-            lines.push(`Missing config: run ${formatCliCommand("openclaw setup")} first.`);
-        }
-        note(lines.join("\n"), "Gateway");
+    const needsToken = auth.mode !== "password" && (auth.mode !== "token" || !auth.token);
+    if (needsToken) {
+      note(
+        "Gateway auth is off or missing a token. Token auth is now the recommended default (including loopback).",
+        "Gateway auth",
+      );
+      const shouldSetToken =
+        options.generateGatewayToken === true
+          ? true
+          : options.nonInteractive === true
+            ? false
+            : await prompter.confirmRepair({
+                message: "Generate and configure a gateway token now?",
+                initialValue: true,
+              });
+      if (shouldSetToken) {
+        const nextToken = randomToken();
+        cfg = {
+          ...cfg,
+          gateway: {
+            ...cfg.gateway,
+            auth: {
+              ...cfg.gateway?.auth,
+              mode: "token",
+              token: nextToken,
+            },
+          },
+        };
+        note("Gateway token configured.", "Gateway auth");
+      }
     }
+  }
 
-    cfg = await maybeRepairAnthropicOAuthProfileId(cfg, prompter);
-    cfg = await maybeRemoveDeprecatedCliAuthProfiles(cfg, prompter);
-    await noteAuthProfileHealth({
-        cfg,
-        prompter,
-        allowKeychainPrompt: options.nonInteractive !== true && Boolean(process.stdin.isTTY),
+  const legacyState = await detectLegacyStateMigrations({ cfg });
+  if (legacyState.preview.length > 0) {
+    note(legacyState.preview.join("\n"), "Legacy state detected");
+    const migrate =
+      options.nonInteractive === true
+        ? true
+        : await prompter.confirm({
+            message: "Migrate legacy state (sessions/agent/WhatsApp auth) now?",
+            initialValue: true,
+          });
+    if (migrate) {
+      const migrated = await runLegacyStateMigrations({
+        detected: legacyState,
+      });
+      if (migrated.changes.length > 0) {
+        note(migrated.changes.join("\n"), "Doctor changes");
+      }
+      if (migrated.warnings.length > 0) {
+        note(migrated.warnings.join("\n"), "Doctor warnings");
+      }
+    }
+  }
+
+  await noteStateIntegrity(cfg, prompter, configResult.path ?? CONFIG_PATH);
+
+  cfg = await maybeRepairSandboxImages(cfg, runtime, prompter);
+  noteSandboxScopeWarnings(cfg);
+
+  await maybeScanExtraGatewayServices(options, runtime, prompter);
+  await maybeRepairGatewayServiceConfig(cfg, resolveMode(cfg), runtime, prompter);
+  await noteMacLaunchAgentOverrides();
+  await noteMacLaunchctlGatewayEnvOverrides(cfg);
+
+  await noteSecurityWarnings(cfg);
+
+  if (cfg.hooks?.gmail?.model?.trim()) {
+    const hooksModelRef = resolveHooksGmailModel({
+      cfg,
+      defaultProvider: DEFAULT_PROVIDER,
     });
-    const gatewayDetails = buildGatewayConnectionDetails({ config: cfg });
-    if (gatewayDetails.remoteFallbackNote) {
-        note(gatewayDetails.remoteFallbackNote, "Gateway");
-    }
-    if (resolveMode(cfg) === "local") {
-        const auth = resolveGatewayAuth({
-            authConfig: cfg.gateway?.auth,
-            tailscaleMode: cfg.gateway?.tailscale?.mode ?? "off",
-        });
-        const needsToken = auth.mode !== "password" && (auth.mode !== "token" || !auth.token);
-        if (needsToken) {
-            note(
-                "Gateway auth is off or missing a token. Token auth is now the recommended default (including loopback).",
-                "Gateway auth",
-            );
-            const shouldSetToken =
-                options.generateGatewayToken === true
-                    ? true
-                    : options.nonInteractive === true
-                        ? false
-                        : await prompter.confirmRepair({
-                            message: "Generate and configure a gateway token now?",
-                            initialValue: true,
-                        });
-            if (shouldSetToken) {
-                const nextToken = randomToken();
-                cfg = {
-                    ...cfg,
-                    gateway: {
-                        ...cfg.gateway,
-                        auth: {
-                            ...cfg.gateway?.auth,
-                            mode: "token",
-                            token: nextToken,
-                        },
-                    },
-                };
-                note("Gateway token configured.", "Gateway auth");
-            }
-        }
-    }
-
-    const legacyState = await detectLegacyStateMigrations({ cfg });
-    if (legacyState.preview.length > 0) {
-        note(legacyState.preview.join("\n"), "Legacy state detected");
-        const migrate =
-            options.nonInteractive === true
-                ? true
-                : await prompter.confirm({
-                    message: "Migrate legacy state (sessions/agent/WhatsApp auth) now?",
-                    initialValue: true,
-                });
-        if (migrate) {
-            const migrated = await runLegacyStateMigrations({
-                detected: legacyState,
-            });
-            if (migrated.changes.length > 0) {
-                note(migrated.changes.join("\n"), "Doctor changes");
-            }
-            if (migrated.warnings.length > 0) {
-                note(migrated.warnings.join("\n"), "Doctor warnings");
-            }
-        }
-    }
-
-    await noteStateIntegrity(cfg, prompter, configResult.path ?? CONFIG_PATH);
-
-    cfg = await maybeRepairSandboxImages(cfg, runtime, prompter);
-    noteSandboxScopeWarnings(cfg);
-
-    await maybeScanExtraGatewayServices(options, runtime, prompter);
-    await maybeRepairGatewayServiceConfig(cfg, resolveMode(cfg), runtime, prompter);
-    await noteMacLaunchAgentOverrides();
-    await noteMacLaunchctlGatewayEnvOverrides(cfg);
-
-    await noteSecurityWarnings(cfg);
-
-    if (cfg.hooks?.gmail?.model?.trim()) {
-        const hooksModelRef = resolveHooksGmailModel({
-            cfg,
-            defaultProvider: DEFAULT_PROVIDER,
-        });
-        if (!hooksModelRef) {
-            note(`- hooks.gmail.model "${cfg.hooks.gmail.model}" could not be resolved`, "Hooks");
-        } else {
-            const { provider: defaultProvider, model: defaultModel } = resolveConfiguredModelRef({
-                cfg,
-                defaultProvider: DEFAULT_PROVIDER,
-                defaultModel: DEFAULT_MODEL,
-            });
-            const catalog = await loadModelCatalog({ config: cfg });
-            const status = getModelRefStatus({
-                cfg,
-                catalog,
-                ref: hooksModelRef,
-                defaultProvider,
-                defaultModel,
-            });
-            const warnings: string[] = [];
-            if (!status.allowed) {
-                warnings.push(
-                    `- hooks.gmail.model "${status.key}" not in agents.defaults.models allowlist (will use primary instead)`,
-                );
-            }
-            if (!status.inCatalog) {
-                warnings.push(
-                    `- hooks.gmail.model "${status.key}" not in the model catalog (may fail at runtime)`,
-                );
-            }
-            if (warnings.length > 0) {
-                note(warnings.join("\n"), "Hooks");
-            }
-        }
-    }
-
-    if (
-        options.nonInteractive !== true &&
-        process.platform === "linux" &&
-        resolveMode(cfg) === "local"
-    ) {
-        const service = resolveGatewayService();
-        let loaded = false;
-        try {
-            loaded = await service.isLoaded({ env: process.env });
-        } catch {
-            loaded = false;
-        }
-        if (loaded) {
-            await ensureSystemdUserLingerInteractive({
-                runtime,
-                prompter: {
-                    confirm: async (p) => prompter.confirm(p),
-                    note,
-                },
-                reason:
-                    "Gateway runs as a systemd user service. Without lingering, systemd stops the user session on logout/idle and kills the Gateway.",
-                requireConfirm: true,
-            });
-        }
-    }
-
-    noteWorkspaceStatus(cfg);
-    await noteMemorySearchHealth(cfg);
-
-    // Check and fix shell completion
-    await doctorShellCompletion(runtime, prompter, {
-        nonInteractive: options.nonInteractive,
-    });
-
-    const { healthOk } = await checkGatewayHealth({
-        runtime,
-        cfg,
-        timeoutMs: options.nonInteractive === true ? 3000 : 10_000,
-    });
-    await maybeRepairGatewayDaemon({
-        cfg,
-        runtime,
-        prompter,
-        options,
-        gatewayDetailsMessage: gatewayDetails.message,
-        healthOk,
-    });
-
-    const shouldWriteConfig = prompter.shouldRepair || configResult.shouldWriteConfig;
-    if (shouldWriteConfig) {
-        cfg = applyWizardMetadata(cfg, { command: "doctor", mode: resolveMode(cfg) });
-        await writeConfigFile(cfg);
-        logConfigUpdated(runtime);
-        const backupPath = `${CONFIG_PATH}.bak`;
-        if (fs.existsSync(backupPath)) {
-            runtime.log(`Backup: ${shortenHomePath(backupPath)}`);
-        }
+    if (!hooksModelRef) {
+      note(`- hooks.gmail.model "${cfg.hooks.gmail.model}" could not be resolved`, "Hooks");
     } else {
-        runtime.log(`Run "${formatCliCommand("openclaw doctor --fix")}" to apply changes.`);
+      const { provider: defaultProvider, model: defaultModel } = resolveConfiguredModelRef({
+        cfg,
+        defaultProvider: DEFAULT_PROVIDER,
+        defaultModel: DEFAULT_MODEL,
+      });
+      const catalog = await loadModelCatalog({ config: cfg });
+      const status = getModelRefStatus({
+        cfg,
+        catalog,
+        ref: hooksModelRef,
+        defaultProvider,
+        defaultModel,
+      });
+      const warnings: string[] = [];
+      if (!status.allowed) {
+        warnings.push(
+          `- hooks.gmail.model "${status.key}" not in agents.defaults.models allowlist (will use primary instead)`,
+        );
+      }
+      if (!status.inCatalog) {
+        warnings.push(
+          `- hooks.gmail.model "${status.key}" not in the model catalog (may fail at runtime)`,
+        );
+      }
+      if (warnings.length > 0) {
+        note(warnings.join("\n"), "Hooks");
+      }
     }
+  }
 
-    if (options.workspaceSuggestions !== false) {
-        const workspaceDir = resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg));
-        noteWorkspaceBackupTip(workspaceDir);
-        if (await shouldSuggestMemorySystem(workspaceDir)) {
-            note(MEMORY_SYSTEM_PROMPT, "Workspace");
-        }
+  if (
+    options.nonInteractive !== true &&
+    process.platform === "linux" &&
+    resolveMode(cfg) === "local"
+  ) {
+    const service = resolveGatewayService();
+    let loaded = false;
+    try {
+      loaded = await service.isLoaded({ env: process.env });
+    } catch {
+      loaded = false;
     }
-
-    const finalSnapshot = await readConfigFileSnapshot();
-    if (finalSnapshot.exists && !finalSnapshot.valid) {
-        runtime.error("Invalid config:");
-        for (const issue of finalSnapshot.issues) {
-            const path = issue.path || "<root>";
-            runtime.error(`- ${path}: ${issue.message}`);
-        }
+    if (loaded) {
+      await ensureSystemdUserLingerInteractive({
+        runtime,
+        prompter: {
+          confirm: async (p) => prompter.confirm(p),
+          note,
+        },
+        reason:
+          "Gateway runs as a systemd user service. Without lingering, systemd stops the user session on logout/idle and kills the Gateway.",
+        requireConfirm: true,
+      });
     }
+  }
 
-    outro("Doctor complete.");
-    runtime.exit(0);
+  noteWorkspaceStatus(cfg);
+  await noteMemorySearchHealth(cfg);
+
+  // Check and fix shell completion
+  await doctorShellCompletion(runtime, prompter, {
+    nonInteractive: options.nonInteractive,
+  });
+
+  const { healthOk } = await checkGatewayHealth({
+    runtime,
+    cfg,
+    timeoutMs: options.nonInteractive === true ? 3000 : 10_000,
+  });
+  await maybeRepairGatewayDaemon({
+    cfg,
+    runtime,
+    prompter,
+    options,
+    gatewayDetailsMessage: gatewayDetails.message,
+    healthOk,
+  });
+
+  const shouldWriteConfig = prompter.shouldRepair || configResult.shouldWriteConfig;
+  if (shouldWriteConfig) {
+    cfg = applyWizardMetadata(cfg, { command: "doctor", mode: resolveMode(cfg) });
+    await writeConfigFile(cfg);
+    logConfigUpdated(runtime);
+    const backupPath = `${CONFIG_PATH}.bak`;
+    if (fs.existsSync(backupPath)) {
+      runtime.log(`Backup: ${shortenHomePath(backupPath)}`);
+    }
+  } else {
+    runtime.log(`Run "${formatCliCommand("openclaw doctor --fix")}" to apply changes.`);
+  }
+
+  if (options.workspaceSuggestions !== false) {
+    const workspaceDir = resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg));
+    noteWorkspaceBackupTip(workspaceDir);
+    if (await shouldSuggestMemorySystem(workspaceDir)) {
+      note(MEMORY_SYSTEM_PROMPT, "Workspace");
+    }
+  }
+
+  const finalSnapshot = await readConfigFileSnapshot();
+  if (finalSnapshot.exists && !finalSnapshot.valid) {
+    runtime.error("Invalid config:");
+    for (const issue of finalSnapshot.issues) {
+      const path = issue.path || "<root>";
+      runtime.error(`- ${path}: ${issue.message}`);
+    }
+  }
+
+  outro("Doctor complete.");
+  runtime.exit(0);
 }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Doctor process keeps running even after reporting "Doctor complete."
- Why it matters: `openclaw doctor --fix` hangs after "Doctor complete", leaving zombie processes that break CI/automation (as per #18502). 
- What changed: Add `runtime.exit(0)` to end of `doctor.ts`
- What did NOT change (scope boundary):

## Change Type (select all)

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [X] CI/CD / infra

## Linked Issue/PR

- Closes #18502

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment
- OS: Ubuntu 24.04.4 LTS (Noble Numbat)
- Runtime/container: none
- Model/provider: Not needed
- Integration/channel (if any): Not needed
- Relevant config (redacted): Not needed

Kernel: 6.8.0-100-generic

### Steps

1. Run `openclaw doctor --fix`
2. After doctor finishes, run `ps -Ao pid,ppid,etime,command | rg 'openclaw-doctor|openclaw'`

### Expected

- Only gateway process is open

### Actual

- Only gateway process is open

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [X] Screenshot/recording
- [ ] Perf numbers (if relevant)

<img width="938" height="138" alt="image" src="https://github.com/user-attachments/assets/e81bbc5d-8af6-4836-b64c-4b36b3602093" />

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: After running doctor, the process has quit.
- What you did **not** verify: Whether this breaks any other functionality in openclaw

## Compatibility / Migration

- Backward compatible? `No`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Remove `runtime.exit(0)` in `doctor.ts`

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

`None`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `runtime.exit(0)` at the end of `doctorCommand()` to fix a process-hang issue (#18502) where `openclaw doctor --fix` doesn't exit after printing "Doctor complete."

While this fixes the hang when `doctor` is run as a standalone CLI command, it introduces a regression: `doctorCommand` is also called as a **sub-step** inside the `update` command (`src/cli/update-cli/update-command.ts:407`). There, `defaultRuntime.exit(0)` will call `process.exit(0)`, which:

- Kills the process before the `finally` block (line 412-413) can clean up `process.env.OPENCLAW_UPDATE_IN_PROGRESS`
- Prevents the update command from completing its remaining post-doctor logic
- Cannot be caught by the surrounding `try/catch`

A safer approach would be to either:
1. Move the `runtime.exit(0)` to the CLI action handler in `register.maintenance.ts` so it only fires when doctor is the top-level command
2. Investigate and fix the root cause of the event loop staying alive (likely an open handle or timer)

<h3>Confidence Score: 2/5</h3>

- This PR fixes the standalone doctor hang but will break the update command's post-doctor cleanup flow.
- The change introduces a `process.exit(0)` inside a reusable function that is called from multiple contexts. In the update-command path, it will terminate the process before cleanup code runs. The fix is correct in intent but incorrect in placement.
- `src/commands/doctor.ts` — the `runtime.exit(0)` call needs to be moved to the top-level CLI handler or replaced with a root-cause fix for the hanging event loop.

<sub>Last reviewed commit: 5f7604e</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->