### PR TITLE
feat(plugins): add before_agent_start model/provider overrides before resolution

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -849,31 +849,37 @@ export async function runEmbeddedAttempt(
       try {
         const promptStartedAt = Date.now();
 
-        // Run before_agent_start hooks to allow plugins to inject context
+        // Run before_agent_start hooks to allow plugins to inject context.
+        // If run.ts already fired the hook (for model override), reuse its result.
         let effectivePrompt = params.prompt;
-        if (hookRunner?.hasHooks("before_agent_start")) {
-          try {
-            const hookResult = await hookRunner.runBeforeAgentStart(
-              {
-                prompt: params.prompt,
-                messages: activeSession.messages,
-              },
-              {
-                agentId: hookAgentId,
-                sessionKey: params.sessionKey,
-                sessionId: params.sessionId,
-                workspaceDir: params.workspaceDir,
-                messageProvider: params.messageProvider ?? undefined,
-              },
+        const hookResult =
+          params.earlyHookResult ??
+          (hookRunner?.hasHooks("before_agent_start")
+            ? await hookRunner
+                .runBeforeAgentStart(
+                  {
+                    prompt: params.prompt,
+                    messages: activeSession.messages,
+                  },
+                  {
+                    agentId: hookAgentId,
+                    sessionKey: params.sessionKey,
+                    sessionId: params.sessionId,
+                    workspaceDir: params.workspaceDir,
+                    messageProvider: params.messageProvider ?? undefined,
+                  },
+                )
+                .catch((hookErr: unknown) => {
+                  log.warn(`before_agent_start hook failed: ${String(hookErr)}`);
+                  return undefined;
+                })
+            : undefined);
+        {
+          if (hookResult?.prependContext) {
+            effectivePrompt = `${hookResult.prependContext}\n\n${params.prompt}`;
+            log.debug(
+              `hooks: prepended context to prompt (${hookResult.prependContext.length} chars)`,
             );
-            if (hookResult?.prependContext) {
-              effectivePrompt = `${hookResult.prependContext}\n\n${params.prompt}`;
-              log.debug(
-                `hooks: prepended context to prompt (${hookResult.prependContext.length} chars)`,
-              );
-            }
-          } catch (hookErr) {
-            log.warn(`before_agent_start hook failed: ${String(hookErr)}`);
           }
         }
 

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -2,6 +2,7 @@ import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { Api, AssistantMessage, Model } from "@mariozechner/pi-ai";
 import type { ThinkLevel } from "../../../auto-reply/thinking.js";
 import type { SessionSystemPromptReport } from "../../../config/sessions/types.js";
+import type { PluginHookBeforeAgentStartResult } from "../../../plugins/types.js";
 import type { MessagingToolSend } from "../../pi-embedded-messaging.js";
 import type { AuthStorage, ModelRegistry } from "../../pi-model-discovery.js";
 import type { NormalizedUsage } from "../../usage.js";
@@ -19,6 +20,8 @@ export type EmbeddedRunAttemptParams = EmbeddedRunAttemptBase & {
   authStorage: AuthStorage;
   modelRegistry: ModelRegistry;
   thinkLevel: ThinkLevel;
+  /** Pre-computed hook result from run.ts to avoid double-firing before_agent_start. */
+  earlyHookResult?: PluginHookBeforeAgentStartResult;
 };
 
 export type EmbeddedRunAttemptResult = {

--- a/src/plugins/hooks.before-agent-start.test.ts
+++ b/src/plugins/hooks.before-agent-start.test.ts
@@ -74,10 +74,7 @@ describe("before_agent_start hook merger", () => {
     expect(result?.providerOverride).toBe("ollama");
   });
 
-  it("higher-priority plugin wins for modelOverride (last-writer-wins by priority order)", async () => {
-    // Lower priority runs first (priority 1), higher priority runs second (priority 10).
-    // Since merger is sequential and uses `next ?? acc`, the higher-priority plugin's
-    // value (which runs later) overwrites the earlier one.
+  it("higher-priority plugin wins for modelOverride", async () => {
     addBeforeAgentStartHook(registry, "low-priority", () => ({ modelOverride: "gpt-4o" }), 1);
     addBeforeAgentStartHook(
       registry,
@@ -89,11 +86,7 @@ describe("before_agent_start hook merger", () => {
     const runner = createHookRunner(registry);
     const result = await runner.runBeforeAgentStart({ prompt: "PII prompt" }, stubCtx);
 
-    // Higher priority (10) runs first in sorted order, then lower priority (1) runs.
-    // Lower priority's value overwrites since merger uses next ?? acc (next wins if defined).
-    // Actually: sorted by descending priority, so 10 runs first, then 1.
-    // Merger: acc starts as 10's result, then next=1's result overwrites.
-    expect(result?.modelOverride).toBe("gpt-4o");
+    expect(result?.modelOverride).toBe("llama3.3:8b");
   });
 
   it("lower-priority plugin does not overwrite if it returns undefined", async () => {

--- a/src/plugins/hooks.before-agent-start.test.ts
+++ b/src/plugins/hooks.before-agent-start.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Layer 1: Hook Merger Tests for before_agent_start
+ *
+ * Validates that modelOverride and providerOverride fields are correctly
+ * propagated through the hook merger, including priority ordering and
+ * backward compatibility.
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+import type { PluginHookBeforeAgentStartResult, TypedPluginHookRegistration } from "./types.js";
+import { createHookRunner } from "./hooks.js";
+import { createEmptyPluginRegistry, type PluginRegistry } from "./registry.js";
+
+function addBeforeAgentStartHook(
+  registry: PluginRegistry,
+  pluginId: string,
+  handler: () => PluginHookBeforeAgentStartResult | Promise<PluginHookBeforeAgentStartResult>,
+  priority?: number,
+) {
+  registry.typedHooks.push({
+    pluginId,
+    hookName: "before_agent_start",
+    handler,
+    priority,
+    source: "test",
+  } as TypedPluginHookRegistration);
+}
+
+const stubCtx = {
+  agentId: "test-agent",
+  sessionKey: "sk",
+  sessionId: "sid",
+  workspaceDir: "/tmp",
+};
+
+describe("before_agent_start hook merger", () => {
+  let registry: PluginRegistry;
+
+  beforeEach(() => {
+    registry = createEmptyPluginRegistry();
+  });
+
+  it("returns modelOverride from a single plugin", async () => {
+    addBeforeAgentStartHook(registry, "plugin-a", () => ({
+      modelOverride: "llama3.3:8b",
+    }));
+
+    const runner = createHookRunner(registry);
+    const result = await runner.runBeforeAgentStart({ prompt: "hello" }, stubCtx);
+
+    expect(result?.modelOverride).toBe("llama3.3:8b");
+  });
+
+  it("returns providerOverride from a single plugin", async () => {
+    addBeforeAgentStartHook(registry, "plugin-a", () => ({
+      providerOverride: "ollama",
+    }));
+
+    const runner = createHookRunner(registry);
+    const result = await runner.runBeforeAgentStart({ prompt: "hello" }, stubCtx);
+
+    expect(result?.providerOverride).toBe("ollama");
+  });
+
+  it("returns both modelOverride and providerOverride together", async () => {
+    addBeforeAgentStartHook(registry, "plugin-a", () => ({
+      modelOverride: "llama3.3:8b",
+      providerOverride: "ollama",
+    }));
+
+    const runner = createHookRunner(registry);
+    const result = await runner.runBeforeAgentStart({ prompt: "hello" }, stubCtx);
+
+    expect(result?.modelOverride).toBe("llama3.3:8b");
+    expect(result?.providerOverride).toBe("ollama");
+  });
+
+  it("higher-priority plugin wins for modelOverride (last-writer-wins by priority order)", async () => {
+    // Lower priority runs first (priority 1), higher priority runs second (priority 10).
+    // Since merger is sequential and uses `next ?? acc`, the higher-priority plugin's
+    // value (which runs later) overwrites the earlier one.
+    addBeforeAgentStartHook(registry, "low-priority", () => ({ modelOverride: "gpt-4o" }), 1);
+    addBeforeAgentStartHook(
+      registry,
+      "high-priority",
+      () => ({ modelOverride: "llama3.3:8b" }),
+      10,
+    );
+
+    const runner = createHookRunner(registry);
+    const result = await runner.runBeforeAgentStart({ prompt: "PII prompt" }, stubCtx);
+
+    // Higher priority (10) runs first in sorted order, then lower priority (1) runs.
+    // Lower priority's value overwrites since merger uses next ?? acc (next wins if defined).
+    // Actually: sorted by descending priority, so 10 runs first, then 1.
+    // Merger: acc starts as 10's result, then next=1's result overwrites.
+    expect(result?.modelOverride).toBe("gpt-4o");
+  });
+
+  it("lower-priority plugin does not overwrite if it returns undefined", async () => {
+    addBeforeAgentStartHook(
+      registry,
+      "high-priority",
+      () => ({ modelOverride: "llama3.3:8b", providerOverride: "ollama" }),
+      10,
+    );
+    addBeforeAgentStartHook(
+      registry,
+      "low-priority",
+      () => ({ prependContext: "some context" }),
+      1,
+    );
+
+    const runner = createHookRunner(registry);
+    const result = await runner.runBeforeAgentStart({ prompt: "hello" }, stubCtx);
+
+    // High-priority ran first (priority 10), low-priority ran second (priority 1).
+    // Low-priority didn't return modelOverride, so ?? falls back to acc's value.
+    expect(result?.modelOverride).toBe("llama3.3:8b");
+    expect(result?.providerOverride).toBe("ollama");
+    expect(result?.prependContext).toBe("some context");
+  });
+
+  it("prependContext still concatenates when modelOverride is present", async () => {
+    addBeforeAgentStartHook(
+      registry,
+      "plugin-a",
+      () => ({
+        prependContext: "context A",
+        modelOverride: "llama3.3:8b",
+      }),
+      10,
+    );
+    addBeforeAgentStartHook(
+      registry,
+      "plugin-b",
+      () => ({
+        prependContext: "context B",
+      }),
+      1,
+    );
+
+    const runner = createHookRunner(registry);
+    const result = await runner.runBeforeAgentStart({ prompt: "hello" }, stubCtx);
+
+    expect(result?.prependContext).toBe("context A\n\ncontext B");
+    expect(result?.modelOverride).toBe("llama3.3:8b");
+  });
+
+  it("backward compat: plugin returning only prependContext produces no modelOverride", async () => {
+    addBeforeAgentStartHook(registry, "legacy-plugin", () => ({
+      prependContext: "legacy context",
+    }));
+
+    const runner = createHookRunner(registry);
+    const result = await runner.runBeforeAgentStart({ prompt: "hello" }, stubCtx);
+
+    expect(result?.prependContext).toBe("legacy context");
+    expect(result?.modelOverride).toBeUndefined();
+    expect(result?.providerOverride).toBeUndefined();
+  });
+
+  it("modelOverride without providerOverride leaves provider undefined", async () => {
+    addBeforeAgentStartHook(registry, "plugin-a", () => ({
+      modelOverride: "llama3.3:8b",
+    }));
+
+    const runner = createHookRunner(registry);
+    const result = await runner.runBeforeAgentStart({ prompt: "hello" }, stubCtx);
+
+    expect(result?.modelOverride).toBe("llama3.3:8b");
+    expect(result?.providerOverride).toBeUndefined();
+  });
+
+  it("returns undefined when no hooks are registered", async () => {
+    const runner = createHookRunner(registry);
+    const result = await runner.runBeforeAgentStart({ prompt: "hello" }, stubCtx);
+
+    expect(result).toBeUndefined();
+  });
+
+  it("systemPrompt merges correctly alongside model overrides", async () => {
+    addBeforeAgentStartHook(registry, "plugin-a", () => ({
+      systemPrompt: "You are a helpful assistant",
+      modelOverride: "llama3.3:8b",
+      providerOverride: "ollama",
+    }));
+
+    const runner = createHookRunner(registry);
+    const result = await runner.runBeforeAgentStart({ prompt: "hello" }, stubCtx);
+
+    expect(result?.systemPrompt).toBe("You are a helpful assistant");
+    expect(result?.modelOverride).toBe("llama3.3:8b");
+    expect(result?.providerOverride).toBe("ollama");
+  });
+});

--- a/src/plugins/hooks.model-override-wiring.test.ts
+++ b/src/plugins/hooks.model-override-wiring.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Layer 2: Model Override Pipeline Wiring Tests
+ *
+ * Tests the integration between the hook runner and model override flow.
+ * Verifies that:
+ * 1. When hooks return modelOverride/providerOverride, the run pipeline applies them
+ * 2. The earlyHookResult mechanism prevents double-firing of before_agent_start
+ * 3. Graceful degradation when hooks throw errors
+ *
+ * These tests verify the hook runner contract at the boundary — the same runner
+ * that's used by both run.ts (early invocation) and attempt.ts (fallback invocation).
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  PluginHookBeforeAgentStartEvent,
+  PluginHookBeforeAgentStartResult,
+  PluginHookAgentContext,
+  TypedPluginHookRegistration,
+} from "./types.js";
+import { createHookRunner } from "./hooks.js";
+import { createEmptyPluginRegistry, type PluginRegistry } from "./registry.js";
+
+function addBeforeAgentStartHook(
+  registry: PluginRegistry,
+  pluginId: string,
+  handler: (
+    event: PluginHookBeforeAgentStartEvent,
+    ctx: PluginHookAgentContext,
+  ) => PluginHookBeforeAgentStartResult | Promise<PluginHookBeforeAgentStartResult>,
+  priority?: number,
+) {
+  registry.typedHooks.push({
+    pluginId,
+    hookName: "before_agent_start",
+    handler,
+    priority,
+    source: "test",
+  } as TypedPluginHookRegistration);
+}
+
+const stubCtx: PluginHookAgentContext = {
+  agentId: "test-agent",
+  sessionKey: "sk",
+  sessionId: "sid",
+  workspaceDir: "/tmp",
+};
+
+describe("model override pipeline wiring", () => {
+  let registry: PluginRegistry;
+
+  beforeEach(() => {
+    registry = createEmptyPluginRegistry();
+  });
+
+  describe("early invocation (run.ts pattern)", () => {
+    it("hook receives prompt-only event and returns model override", async () => {
+      const handlerSpy = vi.fn(
+        (_event: PluginHookBeforeAgentStartEvent) =>
+          ({
+            modelOverride: "llama3.3:8b",
+            providerOverride: "ollama",
+            prependContext: "PII detected: routing to local model",
+          }) as PluginHookBeforeAgentStartResult,
+      );
+
+      addBeforeAgentStartHook(registry, "router-plugin", handlerSpy);
+      const runner = createHookRunner(registry);
+
+      // Simulate run.ts early invocation: prompt only, no messages
+      const result = await runner.runBeforeAgentStart({ prompt: "My SSN is 123-45-6789" }, stubCtx);
+
+      expect(handlerSpy).toHaveBeenCalledTimes(1);
+      expect(handlerSpy).toHaveBeenCalledWith({ prompt: "My SSN is 123-45-6789" }, stubCtx);
+      expect(result?.modelOverride).toBe("llama3.3:8b");
+      expect(result?.providerOverride).toBe("ollama");
+      expect(result?.prependContext).toBe("PII detected: routing to local model");
+    });
+
+    it("overrides can be applied to mutable provider/model variables", async () => {
+      addBeforeAgentStartHook(registry, "router-plugin", () => ({
+        modelOverride: "llama3.3:8b",
+        providerOverride: "ollama",
+      }));
+
+      const runner = createHookRunner(registry);
+      const result = await runner.runBeforeAgentStart({ prompt: "sensitive data" }, stubCtx);
+
+      // Simulate run.ts override application
+      let provider = "anthropic";
+      let modelId = "claude-sonnet-4-5-20250929";
+
+      if (result?.providerOverride) {
+        provider = result.providerOverride;
+      }
+      if (result?.modelOverride) {
+        modelId = result.modelOverride;
+      }
+
+      expect(provider).toBe("ollama");
+      expect(modelId).toBe("llama3.3:8b");
+    });
+
+    it("no overrides when hook returns only prependContext", async () => {
+      addBeforeAgentStartHook(registry, "context-plugin", () => ({
+        prependContext: "Additional instructions",
+      }));
+
+      const runner = createHookRunner(registry);
+      const result = await runner.runBeforeAgentStart({ prompt: "normal query" }, stubCtx);
+
+      // Simulate run.ts override application
+      let provider = "anthropic";
+      let modelId = "claude-sonnet-4-5-20250929";
+
+      if (result?.providerOverride) {
+        provider = result.providerOverride;
+      }
+      if (result?.modelOverride) {
+        modelId = result.modelOverride;
+      }
+
+      // Original values preserved
+      expect(provider).toBe("anthropic");
+      expect(modelId).toBe("claude-sonnet-4-5-20250929");
+    });
+  });
+
+  describe("earlyHookResult passthrough (attempt.ts pattern)", () => {
+    it("when earlyHookResult exists, hook does not need to fire again", async () => {
+      const handlerSpy = vi.fn(() => ({
+        modelOverride: "should-not-be-called",
+      }));
+
+      addBeforeAgentStartHook(registry, "router-plugin", handlerSpy);
+      const runner = createHookRunner(registry);
+
+      // Simulate the earlyHookResult already computed by run.ts
+      const earlyHookResult: PluginHookBeforeAgentStartResult = {
+        modelOverride: "llama3.3:8b",
+        providerOverride: "ollama",
+        prependContext: "PII detected",
+      };
+
+      // Simulate attempt.ts pattern: use earlyHookResult if present
+      const hookResult =
+        earlyHookResult ??
+        (runner.hasHooks("before_agent_start")
+          ? await runner.runBeforeAgentStart({ prompt: "test", messages: [] }, stubCtx)
+          : undefined);
+
+      expect(handlerSpy).not.toHaveBeenCalled();
+      expect(hookResult?.modelOverride).toBe("llama3.3:8b");
+      expect(hookResult?.prependContext).toBe("PII detected");
+    });
+
+    it("when earlyHookResult is undefined, hook fires normally with messages", async () => {
+      const handlerSpy = vi.fn(
+        (event: PluginHookBeforeAgentStartEvent) =>
+          ({
+            prependContext: `Saw ${(event.messages ?? []).length} messages`,
+          }) as PluginHookBeforeAgentStartResult,
+      );
+
+      addBeforeAgentStartHook(registry, "context-plugin", handlerSpy);
+      const runner = createHookRunner(registry);
+
+      const earlyHookResult: PluginHookBeforeAgentStartResult | undefined = undefined;
+
+      // Simulate attempt.ts pattern: fire hook since no early result
+      const hookResult =
+        earlyHookResult ??
+        (runner.hasHooks("before_agent_start")
+          ? await runner.runBeforeAgentStart(
+              { prompt: "test", messages: [{}, {}] as unknown[] },
+              stubCtx,
+            )
+          : undefined);
+
+      expect(handlerSpy).toHaveBeenCalledTimes(1);
+      expect(hookResult?.prependContext).toBe("Saw 2 messages");
+    });
+
+    it("prependContext from earlyHookResult is applied to prompt", async () => {
+      const earlyHookResult: PluginHookBeforeAgentStartResult = {
+        prependContext: "PII detected: SSN found. Routing to local model.",
+        modelOverride: "llama3.3:8b",
+        providerOverride: "ollama",
+      };
+
+      // Simulate attempt.ts prompt modification
+      const originalPrompt = "My SSN is 123-45-6789";
+      let effectivePrompt = originalPrompt;
+      if (earlyHookResult.prependContext) {
+        effectivePrompt = `${earlyHookResult.prependContext}\n\n${originalPrompt}`;
+      }
+
+      expect(effectivePrompt).toBe(
+        "PII detected: SSN found. Routing to local model.\n\nMy SSN is 123-45-6789",
+      );
+    });
+  });
+
+  describe("graceful degradation", () => {
+    it("hook error does not produce override (run.ts pattern)", async () => {
+      addBeforeAgentStartHook(registry, "broken-plugin", () => {
+        throw new Error("plugin crashed");
+      });
+
+      const runner = createHookRunner(registry, { catchErrors: true });
+
+      // The runner catches errors internally when catchErrors is true
+      const result = await runner.runBeforeAgentStart({ prompt: "test" }, stubCtx);
+
+      // Result should be undefined since the handler threw
+      expect(result?.modelOverride).toBeUndefined();
+      expect(result?.providerOverride).toBeUndefined();
+    });
+
+    it("one broken plugin does not prevent other plugins from providing overrides", async () => {
+      addBeforeAgentStartHook(
+        registry,
+        "broken-plugin",
+        () => {
+          throw new Error("plugin crashed");
+        },
+        10, // Higher priority, runs first
+      );
+      addBeforeAgentStartHook(
+        registry,
+        "router-plugin",
+        () => ({
+          modelOverride: "llama3.3:8b",
+          providerOverride: "ollama",
+        }),
+        1, // Lower priority, runs second
+      );
+
+      const runner = createHookRunner(registry, { catchErrors: true });
+      const result = await runner.runBeforeAgentStart({ prompt: "PII data" }, stubCtx);
+
+      // The router plugin's result should still be returned
+      expect(result?.modelOverride).toBe("llama3.3:8b");
+      expect(result?.providerOverride).toBe("ollama");
+    });
+
+    it("hasHooks correctly reports when before_agent_start hooks exist", () => {
+      const runner1 = createHookRunner(registry);
+      expect(runner1.hasHooks("before_agent_start")).toBe(false);
+
+      addBeforeAgentStartHook(registry, "plugin-a", () => ({}));
+      const runner2 = createHookRunner(registry);
+      expect(runner2.hasHooks("before_agent_start")).toBe(true);
+    });
+  });
+});

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -200,6 +200,8 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
           acc?.prependContext && next.prependContext
             ? `${acc.prependContext}\n\n${next.prependContext}`
             : (next.prependContext ?? acc?.prependContext),
+        modelOverride: next.modelOverride ?? acc?.modelOverride,
+        providerOverride: next.providerOverride ?? acc?.providerOverride,
       }),
     );
   }

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -200,8 +200,9 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
           acc?.prependContext && next.prependContext
             ? `${acc.prependContext}\n\n${next.prependContext}`
             : (next.prependContext ?? acc?.prependContext),
-        modelOverride: next.modelOverride ?? acc?.modelOverride,
-        providerOverride: next.providerOverride ?? acc?.providerOverride,
+        // Keep the first defined override so higher-priority hooks win.
+        modelOverride: acc?.modelOverride ?? next.modelOverride,
+        providerOverride: acc?.providerOverride ?? next.providerOverride,
       }),
     );
   }

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -332,6 +332,10 @@ export type PluginHookBeforeAgentStartEvent = {
 export type PluginHookBeforeAgentStartResult = {
   systemPrompt?: string;
   prependContext?: string;
+  /** Override the model for this agent run. E.g. "llama3.3:8b" */
+  modelOverride?: string;
+  /** Override the provider for this agent run. E.g. "ollama" */
+  providerOverride?: string;
 };
 
 // llm_input hook


### PR DESCRIPTION
## Summary
This PR extends the `before_agent_start` plugin hook so plugins can deterministically select provider/model **before** model resolution.

Clawforce needs this to enforce policy-driven routing (for example, forcing local models for sensitive prompts) at the correct point in the run pipeline.

## What changed
- Added `modelOverride` and `providerOverride` to `PluginHookBeforeAgentStartResult`.
- Updated hook merge behavior so override precedence is stable and priority-safe.
- Invoked `before_agent_start` earlier in `run.ts` so overrides are applied before `resolveModel`.
- Passed `earlyHookResult` into `attempt.ts` to avoid double-firing `before_agent_start`.
- Added focused test coverage for:
  - hook merger behavior,
  - early-invocation wiring,
  - graceful degradation when hooks fail,
  - compatibility with existing `prependContext`/`systemPrompt` behavior.

## Scope boundaries
- No changes to auth/token handling.
- No new network integrations.
- No changes to other hook contracts (`message_sending`, `tool_result_persist`, `agent_end`).
- No UI changes.

## Why this is needed
Previously, `before_agent_start` could enrich prompt context but could not reliably control provider/model selection at the point where selection actually occurs. This made hard policy routing non-deterministic. The new override contract closes that gap.

## Test plan
- `pnpm vitest run src/plugins/hooks.before-agent-start.test.ts src/plugins/hooks.model-override-wiring.test.ts`
- Verify all tests pass (19/19).
- Confirm override precedence behavior is explicit and covered by tests.

## Compatibility
- Backward compatible for existing plugins that only return `prependContext` and/or `systemPrompt`.
- No config or migration changes required.