### PR TITLE
CLI: normalize help command description casing

### DIFF
--- a/src/cli/program/help.ts
+++ b/src/cli/program/help.ts
@@ -56,6 +56,8 @@ export function configureProgramHelp(program: Command, ctx: ProgramContext) {
     );
 
   program.option("--no-color", "Disable ANSI colors", false);
+  program.helpOption("-h, --help", "Display help for command");
+  program.helpCommand("help [command]", "Display help for command");
 
   program.configureHelp({
     // sort options and subcommands alphabetically


### PR DESCRIPTION
## Summary
- follow up on #18486
- unify help text casing by making Commander’s built-in help descriptions start with uppercase `Display`
- keeps root help output stylistically consistent with other command descriptions

## Changes
- `src/cli/program/help.ts`
  - `program.helpOption("-h, --help", "Display help for command")`
  - `program.helpCommand("help [command]", "Display help for command")`

## Validation
- `pnpm check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Normalizes Commander.js built-in help descriptions to use uppercase "Display" prefix, maintaining consistency with other command descriptions throughout the CLI which follow sentence case conventions (e.g., "Manage connected chat channels", "Show gateway channel status").

- Customizes `program.helpOption()` description from default lowercase "display help" to "Display help for command"
- Customizes `program.helpCommand()` description from default lowercase to "Display help for command"
- Follows up on #18486 which standardized command descriptions across the CLI

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The changes are purely cosmetic string updates to standardize help text casing. The modifications only affect two description strings for Commander.js help options, with no logic changes, no new dependencies, and no behavioral impacts beyond text display consistency.
- No files require special attention

<sub>Last reviewed commit: ddff0c7</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->