### PR TITLE
feat: show transcript file size in session status

### DIFF
--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -3,7 +3,7 @@ import type { OpenClawConfig } from "../../config/config.js";
 import type { AnyAgentTool } from "./common.js";
 import { normalizeGroupActivation } from "../../auto-reply/group-activation.js";
 import { getFollowupQueueDepth, resolveQueueSettings } from "../../auto-reply/reply/queue.js";
-import { buildStatusMessage } from "../../auto-reply/status.js";
+import { buildStatusMessage, getTranscriptInfo } from "../../auto-reply/status.js";
 import { loadConfig } from "../../config/config.js";
 import {
   loadSessionStore,
@@ -458,6 +458,13 @@ export function createSessionStatusTool(opts?: {
           showDetails: queueOverrides,
         },
         includeTranscriptUsage: false,
+        transcriptInfo: getTranscriptInfo({
+          sessionId: resolved.entry?.sessionId,
+          sessionEntry: resolved.entry,
+          agentId,
+          sessionKey: resolved.key,
+          storePath,
+        }),
       });
 
       return {

--- a/src/auto-reply/reply/commands-status.ts
+++ b/src/auto-reply/reply/commands-status.ts
@@ -28,7 +28,7 @@ import {
   resolveUsageProviderId,
 } from "../../infra/provider-usage.js";
 import { normalizeGroupActivation } from "../group-activation.js";
-import { buildStatusMessage } from "../status.js";
+import { buildStatusMessage, getTranscriptInfo } from "../status.js";
 import { getFollowupQueueDepth, resolveQueueSettings } from "./queue.js";
 import { resolveSubagentLabel } from "./subagents-utils.js";
 
@@ -247,6 +247,13 @@ export async function buildStatusReply(params: {
     subagentsLine,
     mediaDecisions: params.mediaDecisions,
     includeTranscriptUsage: false,
+    transcriptInfo: getTranscriptInfo({
+      sessionId: sessionEntry?.sessionId,
+      sessionEntry,
+      agentId: statusAgentId,
+      sessionKey,
+      storePath,
+    }),
   });
 
   return { text: statusText };

--- a/src/auto-reply/status.transcript.test.ts
+++ b/src/auto-reply/status.transcript.test.ts
@@ -1,0 +1,112 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../config/sessions.js", () => ({
+  resolveSessionFilePath: vi.fn((_sessionId: string) => ""),
+  resolveSessionFilePathOptions: vi.fn(() => ({})),
+  resolveMainSessionKey: vi.fn(() => "main"),
+}));
+
+const sessions = await import("../config/sessions.js");
+const resolveSessionFilePathMock = vi.mocked(sessions.resolveSessionFilePath);
+
+const { getTranscriptInfo, buildStatusMessage } = await import("./status.js");
+
+describe("getTranscriptInfo", () => {
+  let tmpDir: string;
+  let testFilePath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "transcript-test-"));
+    testFilePath = path.join(tmpDir, "test-session.jsonl");
+    resolveSessionFilePathMock.mockReturnValue(testFilePath);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns undefined when sessionId is missing", () => {
+    expect(getTranscriptInfo({})).toBeUndefined();
+  });
+
+  it("returns undefined when file does not exist", () => {
+    resolveSessionFilePathMock.mockReturnValue(path.join(tmpDir, "nonexistent.jsonl"));
+    expect(getTranscriptInfo({ sessionId: "abc" })).toBeUndefined();
+  });
+
+  it("returns size and message count for a transcript file", () => {
+    const lines = [
+      JSON.stringify({ message: { role: "user", content: "hello" } }),
+      JSON.stringify({ message: { role: "assistant", content: "hi" } }),
+      "",
+    ];
+    fs.writeFileSync(testFilePath, lines.join("\n"));
+    const info = getTranscriptInfo({ sessionId: "abc" });
+    expect(info).toBeDefined();
+    expect(info!.messageCount).toBe(2);
+    expect(info!.sizeBytes).toBeGreaterThan(0);
+    expect(info!.filePath).toBe(testFilePath);
+  });
+
+  it("counts only non-empty lines", () => {
+    const content = '{"a":1}\n\n\n{"b":2}\n{"c":3}\n\n';
+    fs.writeFileSync(testFilePath, content);
+    const info = getTranscriptInfo({ sessionId: "abc" });
+    expect(info!.messageCount).toBe(3);
+  });
+});
+
+describe("transcript line in buildStatusMessage", () => {
+  it("includes transcript line when transcriptInfo is provided", () => {
+    const info = {
+      sizeBytes: 512_000,
+      messageCount: 42,
+      filePath: "/tmp/test.jsonl",
+    };
+    const result = buildStatusMessage({
+      agent: {},
+      transcriptInfo: info,
+    });
+    expect(result).toContain("📄 Transcript:");
+    expect(result).toContain("500.0 KB");
+    expect(result).toContain("42 messages");
+  });
+
+  it("shows warning emoji for large transcripts", () => {
+    const info = {
+      sizeBytes: 2 * 1024 * 1024,
+      messageCount: 600,
+      filePath: "/tmp/test.jsonl",
+    };
+    const result = buildStatusMessage({
+      agent: {},
+      transcriptInfo: info,
+    });
+    expect(result).toContain("⚠️");
+    expect(result).toContain("2.0 MB");
+  });
+
+  it("omits transcript line when transcriptInfo is undefined", () => {
+    const result = buildStatusMessage({
+      agent: {},
+    });
+    expect(result).not.toContain("📄 Transcript:");
+  });
+
+  it("handles singular message count", () => {
+    const info = {
+      sizeBytes: 100,
+      messageCount: 1,
+      filePath: "/tmp/test.jsonl",
+    };
+    const result = buildStatusMessage({
+      agent: {},
+      transcriptInfo: info,
+    });
+    expect(result).toContain("1 message");
+    expect(result).not.toContain("1 messages");
+  });
+});


### PR DESCRIPTION
## Summary

Adds transcript size monitoring to `/status` and the `session_status` tool. This surfaces the JSONL transcript file size and message count directly in the status card, helping users catch sessions that are growing dangerously large before they hit the compaction death spiral described in #13624.

## What it does

- **New `getTranscriptInfo()` helper** — reads transcript file stat (size in bytes) and counts non-empty JSONL lines (messages)
- **Status card integration** — both `/status` command and `session_status` tool now show:
  ```
  📄 Transcript: 1.2 MB, 627 messages
  ```
- **Warning threshold** — shows ⚠️ when transcript exceeds 1 MB, giving users early warning before context overflow becomes unrecoverable
- **8 new tests** covering file reading, formatting, singular/plural, warning threshold, and edge cases

## Example output

```
🦞 OpenClaw 2026.2.6
🧠 Model: anthropic/claude-opus-4-6 · 🔑 api-key
📚 Context: 108k/200k · 🧹 Compactions: 0
📄 Transcript: 2.4 MB, 627 messages ⚠️
🧵 Session: agent:main · updated 5m ago
⚙️ Runtime: agent=main · Think: off
```

## Motivation

Issue #13624 describes a death spiral where sessions with large transcripts (2.4 MB+) enter unrecoverable context overflow loops. The `/status` context counter showed 108k/200k (54%) while the actual prompt assembly exceeded 200k. Having the raw transcript file size visible makes this problem immediately apparent.

## Changes

| File | Change |
|------|--------|
| `src/auto-reply/status.ts` | Added `getTranscriptInfo()`, `formatTranscriptLine()`, `TranscriptInfo` type |
| `src/auto-reply/reply/commands-status.ts` | Wire transcript info into `/status` |
| `src/agents/tools/session-status-tool.ts` | Wire transcript info into `session_status` tool |
| `src/auto-reply/status.transcript.test.ts` | 8 new tests |

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds transcript file size monitoring to the `/status` command and `session_status` tool, helping users identify large transcripts before they cause context overflow issues. The implementation introduces a new `getTranscriptInfo()` helper that reads transcript file metadata (size and message count) and displays it in status output with a warning emoji when files exceed 1 MB.

**Key changes:**
- Added `getTranscriptInfo()` function that reads transcript file size and counts non-empty JSONL lines
- Integrated transcript info into both `/status` command and `session_status` tool
- Added `formatTranscriptLine()` to display size (with KB/MB formatting), message count, and warning emoji
- Comprehensive test coverage (8 tests) covering edge cases, formatting, and warning thresholds
- Follows existing patterns from `readUsageFromSessionLog()` for consistency

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-tested, follows existing codebase patterns, handles errors gracefully with try-catch blocks, and addresses a real user pain point described in issue #13624. The code is simple, defensive, and includes comprehensive test coverage.
- No files require special attention

<sub>Last reviewed commit: 3a7a0c6</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->