### PR TITLE
feat(tools): add URL allowlist for web_search and web_fetch

### DIFF
--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -2,7 +2,11 @@ import { Type } from "@sinclair/typebox";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { AnyAgentTool } from "./common.js";
 import { fetchWithSsrFGuard } from "../../infra/net/fetch-guard.js";
-import { SsrFBlockedError } from "../../infra/net/ssrf.js";
+import {
+  matchesHostnameAllowlist,
+  normalizeHostnameAllowlist,
+  SsrFBlockedError,
+} from "../../infra/net/ssrf.js";
 import { logDebug } from "../../logger.js";
 import { wrapExternalContent, wrapWebContent } from "../../security/external-content.js";
 import { normalizeSecretInput } from "../../utils/normalize-secret-input.js";
@@ -67,6 +71,32 @@ type WebFetchConfig = NonNullable<OpenClawConfig["tools"]>["web"] extends infer 
     ? Fetch
     : undefined
   : undefined;
+
+type WebConfig = NonNullable<OpenClawConfig["tools"]>["web"];
+
+export function resolveFetchUrlAllowlist(web?: WebConfig): string[] | undefined {
+  if (!web || typeof web !== "object") {
+    return undefined;
+  }
+  if (!("urlAllowlist" in web)) {
+    return undefined;
+  }
+  const allowlist = web.urlAllowlist;
+  if (!Array.isArray(allowlist)) {
+    return undefined;
+  }
+  return allowlist.length > 0 ? allowlist : undefined;
+}
+
+export function isUrlAllowedByAllowlist(url: string, allowlist: string[]): boolean {
+  try {
+    const hostname = new URL(url).hostname;
+    const normalizedAllowlist = normalizeHostnameAllowlist(allowlist);
+    return matchesHostnameAllowlist(hostname, normalizedAllowlist);
+  } catch {
+    return false;
+  }
+}
 
 type FirecrawlFetchConfig =
   | {
@@ -732,6 +762,7 @@ export function createWebFetchTool(options?: {
     (fetch && "userAgent" in fetch && typeof fetch.userAgent === "string" && fetch.userAgent) ||
     DEFAULT_FETCH_USER_AGENT;
   const maxResponseBytes = resolveFetchMaxResponseBytes(fetch);
+  const urlAllowlist = resolveFetchUrlAllowlist(options?.config?.tools?.web);
   return {
     label: "Web Fetch",
     name: "web_fetch",
@@ -741,6 +772,25 @@ export function createWebFetchTool(options?: {
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;
       const url = readStringParam(params, "url", { required: true });
+
+      // Check URL against allowlist if configured
+      if (urlAllowlist && urlAllowlist.length > 0) {
+        if (!isUrlAllowedByAllowlist(url, urlAllowlist)) {
+          let hostname: string;
+          try {
+            hostname = new URL(url).hostname;
+          } catch {
+            hostname = url;
+          }
+          return jsonResult({
+            error: "url_not_allowed",
+            message: `URL not in allowlist. Allowed domains: ${urlAllowlist.join(", ")}`,
+            blockedUrl: url,
+            blockedHostname: hostname,
+          });
+        }
+      }
+
       const extractMode = readStringParam(params, "extractMode") === "text" ? "text" : "markdown";
       const maxChars = readNumberParam(params, "maxChars", { integer: true });
       const maxCharsCap = resolveFetchMaxCharsCap(fetch);

--- a/src/agents/tools/web-tools.url-allowlist.test.ts
+++ b/src/agents/tools/web-tools.url-allowlist.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { isUrlAllowedByAllowlist, resolveFetchUrlAllowlist } from "./web-fetch.js";
+import { filterResultsByAllowlist, resolveUrlAllowlist } from "./web-search.js";
+
+describe("web-search urlAllowlist", () => {
+  describe("resolveUrlAllowlist", () => {
+    it("returns undefined when web config is undefined", () => {
+      const result = resolveUrlAllowlist(undefined);
+      expect(result).toBeUndefined();
+    });
+
+    it("returns undefined when urlAllowlist is not set", () => {
+      const result = resolveUrlAllowlist({ search: { enabled: true } });
+      expect(result).toBeUndefined();
+    });
+
+    it("returns undefined when urlAllowlist is empty array", () => {
+      const result = resolveUrlAllowlist({ urlAllowlist: [], search: { enabled: true } });
+      expect(result).toBeUndefined();
+    });
+
+    it("returns the allowlist when configured", () => {
+      const result = resolveUrlAllowlist({
+        urlAllowlist: ["example.com", "*.github.com"],
+        search: { enabled: true },
+      });
+      expect(result).toEqual(["example.com", "*.github.com"]);
+    });
+  });
+
+  describe("filterResultsByAllowlist", () => {
+    const results = [
+      { url: "https://example.com/page", siteName: "example.com" },
+      { url: "https://api.github.com/user/repo", siteName: "api.github.com" },
+      { url: "https://docs.openclaw.ai/guide", siteName: "docs.openclaw.ai" },
+      { url: "https://blocked.org/page", siteName: "blocked.org" },
+      { url: undefined, siteName: "unknown" }, // entry without URL
+    ];
+
+    it("returns all results when allowlist is empty", () => {
+      const result = filterResultsByAllowlist(results, []);
+      expect(result).toHaveLength(5);
+    });
+
+    it("filters results by exact domain match", () => {
+      const result = filterResultsByAllowlist(results, ["example.com"]);
+      expect(result).toHaveLength(2); // example.com + entry without URL
+      expect(result.map((r) => r.url)).toContain("https://example.com/page");
+      expect(result.map((r) => r.url)).not.toContain("https://api.github.com/user/repo");
+    });
+
+    it("filters results by wildcard pattern", () => {
+      const result = filterResultsByAllowlist(results, ["*.github.com"]);
+      expect(result).toHaveLength(2); // api.github.com + entry without URL
+      expect(result.map((r) => r.url)).toContain("https://api.github.com/user/repo");
+      expect(result.map((r) => r.url)).not.toContain("https://example.com/page");
+    });
+
+    it("filters results with multiple patterns", () => {
+      const result = filterResultsByAllowlist(results, ["example.com", "*.github.com"]);
+      expect(result).toHaveLength(3); // example.com + api.github.com + entry without URL
+      expect(result.map((r) => r.url)).toContain("https://example.com/page");
+      expect(result.map((r) => r.url)).toContain("https://api.github.com/user/repo");
+      expect(result.map((r) => r.url)).not.toContain("https://blocked.org/page");
+    });
+
+    it("keeps entries without URLs and entries not in blocklist", () => {
+      const result = filterResultsByAllowlist(results, ["blocked.org"]);
+      // With allowlist ["blocked.org"], we ONLY keep blocked.org URLs and entries without URLs
+      expect(result).toHaveLength(2); // blocked.org + entry without URL
+      expect(result.map((r) => r.url)).toContain("https://blocked.org/page");
+    });
+  });
+});
+
+describe("web-fetch urlAllowlist", () => {
+  describe("resolveFetchUrlAllowlist", () => {
+    it("returns undefined when web config is undefined", () => {
+      const result = resolveFetchUrlAllowlist(undefined);
+      expect(result).toBeUndefined();
+    });
+
+    it("returns undefined when urlAllowlist is not set", () => {
+      const result = resolveFetchUrlAllowlist({ fetch: { enabled: true } });
+      expect(result).toBeUndefined();
+    });
+
+    it("returns undefined when urlAllowlist is empty array", () => {
+      const result = resolveFetchUrlAllowlist({ urlAllowlist: [], fetch: { enabled: true } });
+      expect(result).toBeUndefined();
+    });
+
+    it("returns the allowlist when configured", () => {
+      const result = resolveFetchUrlAllowlist({
+        urlAllowlist: ["example.com", "*.github.com"],
+        fetch: { enabled: true },
+      });
+      expect(result).toEqual(["example.com", "*.github.com"]);
+    });
+  });
+
+  describe("isUrlAllowedByAllowlist", () => {
+    it("allows any URL when allowlist is empty", () => {
+      const result = isUrlAllowedByAllowlist("https://example.com/page", []);
+      expect(result).toBe(true);
+    });
+
+    it("blocks URLs not in allowlist", () => {
+      const result = isUrlAllowedByAllowlist("https://blocked.com/page", ["example.com"]);
+      expect(result).toBe(false);
+    });
+
+    it("allows URLs matching exact domain", () => {
+      const result = isUrlAllowedByAllowlist("https://example.com/page", ["example.com"]);
+      expect(result).toBe(true);
+    });
+
+    it("allows URLs matching wildcard pattern", () => {
+      const result = isUrlAllowedByAllowlist("https://api.github.com/users", ["*.github.com"]);
+      expect(result).toBe(true);
+    });
+
+    it("blocks URLs not matching wildcard pattern", () => {
+      const result = isUrlAllowedByAllowlist("https://github.com", ["*.github.com"]);
+      // Exact match "github.com" should not match "*.github.com" pattern
+      // because *.github.com requires at least one subdomain
+      expect(result).toBe(false);
+    });
+
+    it("allows subdomain with wildcard pattern", () => {
+      const result = isUrlAllowedByAllowlist("https://docs.openclaw.ai/guide", ["*.openclaw.ai"]);
+      expect(result).toBe(true);
+    });
+
+    it("handles URLs without protocol", () => {
+      const result = isUrlAllowedByAllowlist("not-a-url", ["example.com"]);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("web_fetch error response", () => {
+    // This test verifies the error format returned when URL is blocked
+    it("returns correct error format for blocked URL", () => {
+      // Simulate the error response format
+      const urlAllowlist = ["example.com"];
+      const url = "https://blocked.com/page";
+
+      if (!isUrlAllowedByAllowlist(url, urlAllowlist)) {
+        const hostname = new URL(url).hostname;
+        const errorResponse = {
+          error: "url_not_allowed",
+          message: `URL not in allowlist. Allowed domains: ${urlAllowlist.join(", ")}`,
+          blockedUrl: url,
+          blockedHostname: hostname,
+        };
+
+        expect(errorResponse.error).toBe("url_not_allowed");
+        expect(errorResponse.message).toContain("example.com");
+        expect(errorResponse.blockedUrl).toBe("https://blocked.com/page");
+        expect(errorResponse.blockedHostname).toBe("blocked.com");
+      }
+    });
+  });
+});
+
+describe("integration with config", () => {
+  it("reads urlAllowlist from tools.web config", () => {
+    const config: OpenClawConfig = {
+      tools: {
+        web: {
+          urlAllowlist: ["example.com", "*.github.com"],
+          search: { enabled: true },
+          fetch: { enabled: true },
+        },
+      },
+    };
+
+    const searchAllowlist = resolveUrlAllowlist(config.tools?.web);
+    const fetchAllowlist = resolveFetchUrlAllowlist(config.tools?.web);
+
+    expect(searchAllowlist).toEqual(["example.com", "*.github.com"]);
+    expect(fetchAllowlist).toEqual(["example.com", "*.github.com"]);
+  });
+
+  it("works with undefined config", () => {
+    const searchAllowlist = resolveUrlAllowlist(undefined);
+    const fetchAllowlist = resolveFetchUrlAllowlist(undefined);
+
+    expect(searchAllowlist).toBeUndefined();
+    expect(fetchAllowlist).toBeUndefined();
+  });
+});

--- a/src/agents/tools/web-tools.url-allowlist.test.ts
+++ b/src/agents/tools/web-tools.url-allowlist.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { OpenClawConfig } from "../config/config.js";
+import type { OpenClawConfig } from "../../config/config.js";
 import { isUrlAllowedByAllowlist, resolveFetchUrlAllowlist } from "./web-fetch.js";
 import { filterResultsByAllowlist, resolveUrlAllowlist } from "./web-search.js";
 

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -93,13 +93,18 @@ export const FIELD_HELP: Record<string, string> = {
   "tools.web.search.enabled": "Enable the web_search tool (requires a provider API key).",
   "tools.web.search.provider": 'Search provider ("brave" or "perplexity").',
   "tools.web.search.apiKey": "Brave Search API key (fallback: BRAVE_API_KEY env var).",
-  "tools.web.search.urlAllowlist":
-    "Optional URL/domain allowlist for web_search. When configured, Brave search results are filtered to only include URLs from allowed domains.",
+  "tools.web.search.maxResults": "Default number of results to return (1-10).",
+  "tools.web.search.timeoutSeconds": "Timeout in seconds for web_search requests.",
+  "tools.web.search.cacheTtlMinutes": "Cache TTL in minutes for web_search results.",
+  "tools.web.search.perplexity.apiKey":
+    "Perplexity or OpenRouter API key (fallback: PERPLEXITY_API_KEY or OPENROUTER_API_KEY env var).",
+  "tools.web.search.perplexity.baseUrl":
+    "Perplexity base URL override (default: https://openrouter.ai/api/v1 or https://api.perplexity.ai).",
+  "tools.web.search.perplexity.model":
+    'Perplexity model override (default: "perplexity/sonar-pro").',
   "tools.web.urlAllowlist":
-    "Optional URL/domain allowlist shared by web_search and web_fetch. Accepts domain patterns like 'example.com', '*.github.com', 'docs.openclaw.ai'. When configured, only matching URLs are allowed.",
+    "Optional URL/domain allowlist shared by web_search and web_fetch. Accepts domain patterns like 'example.com', '*.github.com'. When configured, only matching URLs are allowed.",
   "tools.web.fetch.enabled": "Enable the web_fetch tool (lightweight HTTP fetch).",
-  "tools.web.fetch.urlAllowlist":
-    "Optional URL/domain allowlist for web_fetch. When configured, only URLs matching these patterns can be fetched.",
   "tools.web.fetch.maxChars": "Max characters returned by web_fetch (truncated).",
   "tools.web.fetch.maxCharsCap":
     "Hard cap for web_fetch maxChars (applies to config and tool calls).",

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -93,16 +93,13 @@ export const FIELD_HELP: Record<string, string> = {
   "tools.web.search.enabled": "Enable the web_search tool (requires a provider API key).",
   "tools.web.search.provider": 'Search provider ("brave" or "perplexity").',
   "tools.web.search.apiKey": "Brave Search API key (fallback: BRAVE_API_KEY env var).",
-  "tools.web.search.maxResults": "Default number of results to return (1-10).",
-  "tools.web.search.timeoutSeconds": "Timeout in seconds for web_search requests.",
-  "tools.web.search.cacheTtlMinutes": "Cache TTL in minutes for web_search results.",
-  "tools.web.search.perplexity.apiKey":
-    "Perplexity or OpenRouter API key (fallback: PERPLEXITY_API_KEY or OPENROUTER_API_KEY env var).",
-  "tools.web.search.perplexity.baseUrl":
-    "Perplexity base URL override (default: https://openrouter.ai/api/v1 or https://api.perplexity.ai).",
-  "tools.web.search.perplexity.model":
-    'Perplexity model override (default: "perplexity/sonar-pro").',
+  "tools.web.search.urlAllowlist":
+    "Optional URL/domain allowlist for web_search. When configured, Brave search results are filtered to only include URLs from allowed domains.",
+  "tools.web.urlAllowlist":
+    "Optional URL/domain allowlist shared by web_search and web_fetch. Accepts domain patterns like 'example.com', '*.github.com', 'docs.openclaw.ai'. When configured, only matching URLs are allowed.",
   "tools.web.fetch.enabled": "Enable the web_fetch tool (lightweight HTTP fetch).",
+  "tools.web.fetch.urlAllowlist":
+    "Optional URL/domain allowlist for web_fetch. When configured, only URLs matching these patterns can be fetched.",
   "tools.web.fetch.maxChars": "Max characters returned by web_fetch (truncated).",
   "tools.web.fetch.maxCharsCap":
     "Hard cap for web_fetch maxChars (applies to config and tool calls).",

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -355,6 +355,8 @@ export type ToolsConfig = {
   /** Optional tool policy overrides keyed by provider id or "provider/model". */
   byProvider?: Record<string, ToolPolicyConfig>;
   web?: {
+    /** Optional URL/domain allowlist for web tools. When configured, only URLs matching these patterns are allowed. */
+    urlAllowlist?: string[];
     search?: {
       /** Enable web search tool (default: true when API key is present). */
       enabled?: boolean;

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -267,6 +267,7 @@ export const ToolsWebFetchSchema = z
 
 export const ToolsWebSchema = z
   .object({
+    urlAllowlist: z.array(z.string()).optional(),
     search: ToolsWebSearchSchema,
     fetch: ToolsWebFetchSchema,
   })

--- a/src/infra/net/ssrf.ts
+++ b/src/infra/net/ssrf.ts
@@ -33,7 +33,7 @@ function normalizeHostnameSet(values?: string[]): Set<string> {
   return new Set(values.map((value) => normalizeHostname(value)).filter(Boolean));
 }
 
-function normalizeHostnameAllowlist(values?: string[]): string[] {
+export function normalizeHostnameAllowlist(values?: string[]): string[] {
   if (!values || values.length === 0) {
     return [];
   }
@@ -57,7 +57,7 @@ function isHostnameAllowedByPattern(hostname: string, pattern: string): boolean 
   return hostname === pattern;
 }
 
-function matchesHostnameAllowlist(hostname: string, allowlist: string[]): boolean {
+export function matchesHostnameAllowlist(hostname: string, allowlist: string[]): boolean {
   if (allowlist.length === 0) {
     return true;
   }


### PR DESCRIPTION
## Summary

- Problem: No way to restrict which URLs/domains `web_search` and `web_fetch` tools can access
- Why it matters: Users in controlled environments need to limit web access to approved domains only
- What changed: Added optional `urlAllowlist` config at `tools.web` level; web_fetch blocks non-matching URLs, web_search filters Brave results
- What did NOT change: Default behavior (no allowlist = all URLs allowed), Perplexity/Grok search providers (return prose, not filterable URLs)

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related # N/A

## User-visible / Behavior Changes

- New config option `tools.web.urlAllowlist` (string array, optional)
- Accepts exact domains (`example.com`) and wildcard patterns (`*.github.com`)
- `web_fetch`: returns `url_not_allowed` error for non-matching URLs
- `web_search`: filters Brave results to only matching domains
- When not configured: no change in behavior (fully backwards compatible)

Example config:
```json
{
  "tools": {
    "web": {
      "urlAllowlist": ["example.com", "*.github.com"]
    }
  }
}
```

## Security Impact (required)

- New permissions/capabilities? `No` (restricts access, does not expand)
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `Yes` — adds optional URL filtering before fetch/after search
  - Risk: Misconfigured allowlist could block all web access
  - Mitigation: Empty/undefined allowlist preserves current allow-all behavior
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux (Proxmox LXC)
- Runtime/container: Node v22
- Model/provider: Any
- Integration/channel: Any
- Relevant config: `tools.web.urlAllowlist: ["example.com", "*.github.com"]`

### Steps

1. Set `tools.web.urlAllowlist` in config
2. Use `web_fetch` with an allowed URL → succeeds
3. Use `web_fetch` with a blocked URL → returns `url_not_allowed` error
4. Use `web_search` → Brave results filtered to allowed domains only

### Expected

- Allowed URLs pass through normally
- Blocked URLs return clear error with list of allowed domains

### Actual

- As expected (verified via unit tests)

## Evidence

- [x] Failing test/log before + passing after
- 23 new unit tests in `web-tools.url-allowlist.test.ts`

## Human Verification (required)

- Verified scenarios: Unit tests for allowlist resolution, wildcard matching, fetch blocking, search result filtering
- Edge cases checked: Empty allowlist, undefined allowlist, URLs without hostname, wildcard patterns
- What you did **not** verify: End-to-end with live Brave/Perplexity/Grok APIs

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `Yes` — new optional `tools.web.urlAllowlist` field
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Remove `urlAllowlist` from config (or set to empty array)
- Files/config to restore: `tools.web` section in openclaw config
- Known bad symptoms: web_fetch returning unexpected `url_not_allowed` errors, web_search returning empty results

## Risks and Mitigations

- Risk: User sets allowlist and forgets, then wonders why web tools are restricted
  - Mitigation: Error message clearly lists allowed domains
- Risk: Wildcard patterns could be confusing (`*.example.com` does NOT match `example.com` itself)
  - Mitigation: Reuses existing well-tested hostname matching from SSRF module

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an optional `urlAllowlist` configuration at `tools.web` level to restrict which domains `web_search` (Brave) and `web_fetch` can access. The implementation cleanly reuses existing `normalizeHostnameAllowlist` and `matchesHostnameAllowlist` from the SSRF infrastructure, and the Zod schema and TypeScript type additions are correct.

- **Test file has a wrong import path** — `../config/config.js` should be `../../config/config.js`, which will cause compilation failure
- **`schema.help.ts` accidentally deletes 6 existing help entries** for `tools.web.search.maxResults`, `tools.web.search.timeoutSeconds`, `tools.web.search.cacheTtlMinutes`, and three Perplexity sub-keys (`perplexity.apiKey`, `perplexity.baseUrl`, `perplexity.model`). These fields still exist in the schema and types.
- **Phantom help entries** — `tools.web.search.urlAllowlist` and `tools.web.fetch.urlAllowlist` are documented in `schema.help.ts` but don't correspond to actual schema fields (the property lives only at `tools.web.urlAllowlist`)

<h3>Confidence Score: 2/5</h3>

- PR has a broken test import and accidentally removes existing config help entries — should be fixed before merging.
- The core allowlist logic in web-fetch.ts and web-search.ts is sound and well-integrated, but the test file has an incorrect import path that will prevent compilation, and schema.help.ts has an unintended regression removing 6 existing help entries for active configuration fields.
- Pay close attention to `src/agents/tools/web-tools.url-allowlist.test.ts` (broken import) and `src/config/schema.help.ts` (deleted help entries).

<sub>Last reviewed commit: 8f66004</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->