### PR TITLE
Telegram: keep DM topic replies in the originating thread

### DIFF
--- a/src/telegram/bot/delivery.test.ts
+++ b/src/telegram/bot/delivery.test.ts
@@ -167,7 +167,7 @@ describe("deliverReplies", () => {
     );
   });
 
-  it("does not include message_thread_id for DMs (threads don't exist in private chats)", async () => {
+  it("includes message_thread_id for DM topics", async () => {
     const runtime = createRuntime();
     const sendMessage = vi.fn().mockResolvedValue({
       message_id: 4,
@@ -179,14 +179,14 @@ describe("deliverReplies", () => {
       replies: [{ text: "Hello" }],
       runtime,
       bot,
-      thread: { id: 1, scope: "dm" },
+      thread: { id: 42, scope: "dm" },
     });
 
     expect(sendMessage).toHaveBeenCalledWith(
       "123",
       expect.any(String),
-      expect.not.objectContaining({
-        message_thread_id: 1,
+      expect.objectContaining({
+        message_thread_id: 42,
       }),
     );
   });

--- a/src/telegram/bot/helpers.test.ts
+++ b/src/telegram/bot/helpers.test.ts
@@ -43,15 +43,21 @@ describe("buildTelegramThreadParams", () => {
     });
   });
 
-  it("skips thread id for dm threads (DMs don't have threads)", () => {
-    expect(buildTelegramThreadParams({ id: 1, scope: "dm" })).toBeUndefined();
-    expect(buildTelegramThreadParams({ id: 2, scope: "dm" })).toBeUndefined();
+  it("includes thread id for dm topics", () => {
+    expect(buildTelegramThreadParams({ id: 1, scope: "dm" })).toEqual({
+      message_thread_id: 1,
+    });
+    expect(buildTelegramThreadParams({ id: 2, scope: "dm" })).toEqual({
+      message_thread_id: 2,
+    });
   });
 
-  it("normalizes and skips thread id for dm threads even with edge values", () => {
+  it("normalizes dm thread ids and skips non-positive values", () => {
     expect(buildTelegramThreadParams({ id: 0, scope: "dm" })).toBeUndefined();
     expect(buildTelegramThreadParams({ id: -1, scope: "dm" })).toBeUndefined();
-    expect(buildTelegramThreadParams({ id: 1.9, scope: "dm" })).toBeUndefined();
+    expect(buildTelegramThreadParams({ id: 1.9, scope: "dm" })).toEqual({
+      message_thread_id: 1,
+    });
   });
 
   it("handles thread id 0 for non-dm scopes", () => {

--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -114,7 +114,7 @@ export function resolveTelegramThreadSpec(params: {
  * Build thread params for Telegram API calls (messages, media).
  *
  * IMPORTANT: Thread IDs behave differently based on chat type:
- * - DMs (private chats): Never send thread_id (threads don't exist)
+ * - DMs (private chats): Include message_thread_id when present (DM topics)
  * - Forum topics: Skip thread_id=1 (General topic), include others
  * - Regular groups: Thread IDs are ignored by Telegram
  *
@@ -130,9 +130,8 @@ export function buildTelegramThreadParams(thread?: TelegramThreadSpec | null) {
   }
   const normalized = Math.trunc(thread.id);
 
-  // Never send thread_id for DMs (threads don't exist in private chats)
   if (thread.scope === "dm") {
-    return undefined;
+    return normalized > 0 ? { message_thread_id: normalized } : undefined;
   }
 
   // Telegram rejects message_thread_id=1 for General forum topic

--- a/src/telegram/draft-stream.test.ts
+++ b/src/telegram/draft-stream.test.ts
@@ -86,12 +86,14 @@ describe("createTelegramDraftStream", () => {
     await vi.waitFor(() => expect(api.sendMessage).toHaveBeenCalledWith(123, "Hello", undefined));
   });
 
-  it("omits message_thread_id for dm threads and clears preview on cleanup", async () => {
+  it("includes message_thread_id for dm threads and clears preview on cleanup", async () => {
     const api = createMockDraftApi();
-    const stream = createThreadedDraftStream(api, { id: 1, scope: "dm" });
+    const stream = createThreadedDraftStream(api, { id: 42, scope: "dm" });
 
     stream.update("Hello");
-    await vi.waitFor(() => expect(api.sendMessage).toHaveBeenCalledWith(123, "Hello", undefined));
+    await vi.waitFor(() =>
+      expect(api.sendMessage).toHaveBeenCalledWith(123, "Hello", { message_thread_id: 42 }),
+    );
     await stream.clear();
 
     expect(api.deleteMessage).toHaveBeenCalledWith(123, 17);


### PR DESCRIPTION
## Summary
- include `message_thread_id` for DM-scoped Telegram threads in `buildTelegramThreadParams`
- keep existing forum behavior (`thread_id=1` still omitted for forum sends)
- update Telegram delivery and draft-stream tests to assert DM topic thread IDs are sent
- update helper tests to cover DM topic inclusion + normalization guardrails

## Regression coverage
- `src/telegram/bot/helpers.test.ts`
- `src/telegram/bot/delivery.test.ts`
- `src/telegram/draft-stream.test.ts`

## Validation
- `pnpm test -- src/telegram`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes Telegram DM topic thread routing by including `message_thread_id` in API calls for DM-scoped threads. Previously, `buildTelegramThreadParams` unconditionally dropped thread IDs for DM scope because Telegram private chats historically didn't support topics. Telegram now supports "Topics in Private Chats," so the helper is updated to include `message_thread_id` when the normalized thread ID is positive, while still omitting non-positive values (0, negative) as invalid.

- `buildTelegramThreadParams` now returns `{ message_thread_id: normalized }` for DM threads with positive IDs, instead of always returning `undefined`
- DM thread ID `1` is correctly included (unlike forum scope where `1` is the General topic and must be skipped)
- Tests across delivery, draft-stream, and helpers are updated to assert the new DM topic inclusion behavior
- Edge case normalization (truncation, non-positive values) is preserved and tested

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk — it's a targeted behavioral fix with comprehensive test coverage.
- The change is a small, well-scoped fix to a single function (`buildTelegramThreadParams`) with a clear behavioral rationale (Telegram now supports DM topics). The implementation correctly handles edge cases (non-positive IDs, truncation), maintains forum behavior (General topic id=1 still omitted), and all three test files are updated to cover the new behavior. No new dependencies, no architectural changes, and the diff is minimal.
- No files require special attention.

<sub>Last reviewed commit: fd055a0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->