### PR TITLE
Agent: guard reminder promises behind cron scheduling

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -948,6 +948,7 @@ export async function runEmbeddedPiAgent(
               didSendViaMessagingTool: attempt.didSendViaMessagingTool,
               messagingToolSentTexts: attempt.messagingToolSentTexts,
               messagingToolSentTargets: attempt.messagingToolSentTargets,
+              successfulCronAdds: attempt.successfulCronAdds,
             };
           }
 
@@ -989,6 +990,7 @@ export async function runEmbeddedPiAgent(
             didSendViaMessagingTool: attempt.didSendViaMessagingTool,
             messagingToolSentTexts: attempt.messagingToolSentTexts,
             messagingToolSentTargets: attempt.messagingToolSentTargets,
+            successfulCronAdds: attempt.successfulCronAdds,
           };
         }
       } finally {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -759,6 +759,7 @@ export async function runEmbeddedAttempt(
         waitForCompactionRetry,
         getMessagingToolSentTexts,
         getMessagingToolSentTargets,
+        getSuccessfulCronAdds,
         didSendViaMessagingTool,
         getLastToolError,
         getUsageTotals,
@@ -1172,6 +1173,7 @@ export async function runEmbeddedAttempt(
         didSendViaMessagingTool: didSendViaMessagingTool(),
         messagingToolSentTexts: getMessagingToolSentTexts(),
         messagingToolSentTargets: getMessagingToolSentTargets(),
+        successfulCronAdds: getSuccessfulCronAdds(),
         cloudCodeAssistFormatError: Boolean(
           lastAssistant?.errorMessage && isCloudCodeAssistFormatError(lastAssistant.errorMessage),
         ),

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -43,6 +43,7 @@ export type EmbeddedRunAttemptResult = {
   didSendViaMessagingTool: boolean;
   messagingToolSentTexts: string[];
   messagingToolSentTargets: MessagingToolSend[];
+  successfulCronAdds?: number;
   cloudCodeAssistFormatError: boolean;
   attemptUsage?: NormalizedUsage;
   compactionCount?: number;

--- a/src/agents/pi-embedded-runner/types.ts
+++ b/src/agents/pi-embedded-runner/types.ts
@@ -65,6 +65,8 @@ export type EmbeddedPiRunResult = {
   messagingToolSentTexts?: string[];
   // Messaging tool targets that successfully sent a message during the run.
   messagingToolSentTargets?: MessagingToolSend[];
+  // Count of successful cron.add tool calls in this run.
+  successfulCronAdds?: number;
 };
 
 export type EmbeddedPiCompactResult = {

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -23,6 +23,14 @@ import { normalizeToolName } from "./tool-policy.js";
 /** Track tool execution start times and args for after_tool_call hook */
 const toolStartData = new Map<string, { startTime: number; args: unknown }>();
 
+function isCronAddAction(args: unknown): boolean {
+  if (!args || typeof args !== "object") {
+    return false;
+  }
+  const action = (args as Record<string, unknown>).action;
+  return typeof action === "string" && action.trim().toLowerCase() === "add";
+}
+
 function buildToolCallSummary(toolName: string, args: unknown, meta?: string): ToolCallSummary {
   const mutation = buildToolMutationState(toolName, args, meta);
   return {
@@ -188,6 +196,8 @@ export async function handleToolExecutionEnd(
   const result = evt.result;
   const isToolError = isError || isToolResultError(result);
   const sanitizedResult = sanitizeToolResult(result);
+  const startData = toolStartData.get(toolCallId);
+  toolStartData.delete(toolCallId);
   const callSummary = ctx.state.toolMetaById.get(toolCallId);
   const meta = callSummary?.meta;
   ctx.state.toolMetas.push({ toolName, meta });
@@ -237,6 +247,11 @@ export async function handleToolExecutionEnd(
       ctx.state.messagingToolSentTargets.push(pendingTarget);
       ctx.trimMessagingToolSent();
     }
+  }
+
+  // Track committed reminders only when cron.add completed successfully.
+  if (!isToolError && toolName === "cron" && isCronAddAction(startData?.args)) {
+    ctx.state.successfulCronAdds += 1;
   }
 
   emitAgentEvent({
@@ -290,8 +305,6 @@ export async function handleToolExecutionEnd(
   // Run after_tool_call plugin hook (fire-and-forget)
   const hookRunnerAfter = ctx.hookRunner ?? getGlobalHookRunner();
   if (hookRunnerAfter?.hasHooks("after_tool_call")) {
-    const startData = toolStartData.get(toolCallId);
-    toolStartData.delete(toolCallId);
     const durationMs = startData?.startTime != null ? Date.now() - startData.startTime : undefined;
     const toolArgs = startData?.args;
     const hookEvent: PluginHookAfterToolCallEvent = {
@@ -310,7 +323,5 @@ export async function handleToolExecutionEnd(
       .catch((err) => {
         ctx.log.warn(`after_tool_call hook failed: tool=${toolName} error=${String(err)}`);
       });
-  } else {
-    toolStartData.delete(toolCallId);
   }
 }

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -72,6 +72,7 @@ export type EmbeddedPiSubscribeState = {
   messagingToolSentTargets: MessagingToolSend[];
   pendingMessagingTexts: Map<string, string>;
   pendingMessagingTargets: Map<string, MessagingToolSend>;
+  successfulCronAdds: number;
   lastAssistant?: AgentMessage;
 };
 

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -73,6 +73,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     messagingToolSentTargets: [],
     pendingMessagingTexts: new Map(),
     pendingMessagingTargets: new Map(),
+    successfulCronAdds: 0,
   };
   const usageTotals = {
     input: 0,
@@ -578,6 +579,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     messagingToolSentTargets.length = 0;
     pendingMessagingTexts.clear();
     pendingMessagingTargets.clear();
+    state.successfulCronAdds = 0;
     resetAssistantMessageState(0);
   };
 
@@ -662,6 +664,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     isCompactionInFlight: () => state.compactionInFlight,
     getMessagingToolSentTexts: () => messagingToolSentTexts.slice(),
     getMessagingToolSentTargets: () => messagingToolSentTargets.slice(),
+    getSuccessfulCronAdds: () => state.successfulCronAdds,
     // Returns true if any messaging tool successfully sent a message.
     // Used to suppress agent's confirmation text (e.g., "Respondi no Telegram!")
     // which is generated AFTER the tool sends the actual answer.


### PR DESCRIPTION
## Summary
- track successful `cron.add` calls during embedded tool execution and carry the count through run results
- add a reply-time guard: if the assistant promises a future reminder but no `cron.add` succeeded in that turn, append an explicit note that no automatic reminder was actually scheduled
- add focused tests for cron-add tracking and guarded reminder replies

## Testing
- `pnpm test src/agents/pi-embedded-subscribe.handlers.tools.test.ts src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts`
- `pnpm check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added tracking and validation to prevent misleading reminder commitments. When an agent promises to remind a user but doesn't actually schedule a `cron.add` task, the system now appends a clarifying note that no automatic reminder was set. This prevents users from expecting reminders that won't trigger.

**Key changes:**
- Added `successfulCronAdds` counter throughout the embedded Pi agent execution pipeline to track successful `cron.add` tool calls
- Implemented `isCronAddAction()` helper to identify cron add actions by checking the action parameter
- Added pattern matching in `agent-runner.ts` to detect reminder commitment language (e.g., "I'll remind you", "I will follow up")
- Appends warning note when reminder commitment detected but `successfulCronAdds === 0`
- Includes comprehensive tests for both tracking logic and guarded reply behavior

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk
- The implementation is well-structured with comprehensive test coverage for both the tracking mechanism and the guard logic. The changes follow a clear data flow from tool execution through run results to reply-time guards. The pattern matching uses reasonable regex patterns, though they may occasionally miss edge cases or produce false positives with creative phrasing. The counter reset logic is properly placed in both the main reset and compaction retry paths. Minor deduction for potential pattern matching edge cases, but the overall approach is sound and the worst-case outcome is a harmless extra note or missed detection.
- No files require special attention

<sub>Last reviewed commit: 675a23b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->