### PR TITLE
feat: native PostgreSQL + pgvector memory backend

### DIFF
--- a/package.json
+++ b/package.json
@@ -204,7 +204,8 @@
   },
   "peerDependencies": {
     "@napi-rs/canvas": "^0.1.89",
-    "node-llama-cpp": "3.15.1"
+    "node-llama-cpp": "3.15.1",
+    "pg": "^8.13.0"
   },
   "engines": {
     "node": ">=22.12.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,6 +142,9 @@ importers:
       pdfjs-dist:
         specifier: ^5.4.624
         version: 5.4.624
+      pg:
+        specifier: ^8.13.0
+        version: 8.18.0
       playwright-core:
         specifier: 1.58.2
         version: 1.58.2
@@ -4845,6 +4848,40 @@ packages:
   performance-now@2.1.0:
     resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
 
+  pg-cloudflare@1.3.0:
+    resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
+
+  pg-connection-string@2.11.0:
+    resolution: {integrity: sha512-kecgoJwhOpxYU21rZjULrmrBJ698U2RxXofKVzOn5UDj61BPj/qMb7diYUR1nLScCDbrztQFl1TaQZT0t1EtzQ==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.11.0:
+    resolution: {integrity: sha512-MJYfvHwtGp870aeusDh+hg9apvOe2zmpZJpyt+BMtzUWlVqbhFmMK6bOBXLBUPd7iRtIF9fZplDc7KrPN3PN7w==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.11.0:
+    resolution: {integrity: sha512-pfsxk2M9M3BuGgDOfuy37VNRRX3jmKgMjcvAcWqNDpZSf4cUmv8HSOl5ViRQFsfARFn0KuUQTgLxVMbNq5NW3g==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.18.0:
+    resolution: {integrity: sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -4887,6 +4924,22 @@ packages:
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
 
   postgres@3.4.8:
     resolution: {integrity: sha512-d+JFcLM17njZaOLkv6SCev7uoLaBtfK86vMUXhW1Z4glPWh4jozno9APvW/XKFJ3CCxVoC7OL38BqRydtu5nGg==}
@@ -5721,6 +5774,10 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -10516,6 +10573,41 @@ snapshots:
 
   performance-now@2.1.0: {}
 
+  pg-cloudflare@1.3.0:
+    optional: true
+
+  pg-connection-string@2.11.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.11.0(pg@8.18.0):
+    dependencies:
+      pg: 8.18.0
+
+  pg-protocol@1.11.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.18.0:
+    dependencies:
+      pg-connection-string: 2.11.0
+      pg-pool: 3.11.0(pg@8.18.0)
+      pg-protocol: 1.11.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.3.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
   picocolors@1.1.1: {}
 
   picomatch@4.0.3: {}
@@ -10561,6 +10653,16 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
 
   postgres@3.4.8: {}
 
@@ -11496,6 +11598,8 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.19.0: {}
+
+  xtend@4.0.2: {}
 
   y18n@5.0.8: {}
 

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -200,7 +200,8 @@ export const FIELD_HELP: Record<string, string> = {
   "agents.defaults.memorySearch.cache.enabled":
     "Cache chunk embeddings in SQLite to speed up reindexing and frequent updates (default: true).",
   memory: "Memory backend configuration (global).",
-  "memory.backend": 'Memory backend ("builtin" for OpenClaw embeddings, "qmd" for QMD sidecar).',
+  "memory.backend":
+    'Memory backend ("builtin" for OpenClaw embeddings, "qmd" for QMD sidecar, "postgres" for PostgreSQL + pgvector).',
   "memory.citations": 'Default citation behavior ("auto", "on", or "off").',
   "memory.qmd.command": "Path to the qmd binary (default: resolves from PATH).",
   "memory.qmd.includeDefaultMemory":

--- a/src/config/types.memory.ts
+++ b/src/config/types.memory.ts
@@ -1,6 +1,6 @@
 import type { SessionSendPolicyConfig } from "./types.base.js";
 
-export type MemoryBackend = "builtin" | "qmd";
+export type MemoryBackend = "builtin" | "qmd" | "postgres";
 export type MemoryCitationsMode = "auto" | "on" | "off";
 export type MemoryQmdSearchMode = "query" | "search" | "vsearch";
 
@@ -8,6 +8,51 @@ export type MemoryConfig = {
   backend?: MemoryBackend;
   citations?: MemoryCitationsMode;
   qmd?: MemoryQmdConfig;
+  postgres?: MemoryPostgresConfig;
+};
+
+export type MemoryPostgresConfig = {
+  /** PostgreSQL connection string (e.g. postgresql://user:pass@host:5432/dbname). */
+  connectionString?: string;
+  /** Individual connection fields (alternative to connectionString). */
+  host?: string;
+  port?: number;
+  database?: string;
+  user?: string;
+  password?: string;
+  /** SSL mode for the connection. */
+  ssl?: boolean | "require" | "prefer" | "disable";
+  /** Table name prefix for multi-agent isolation (default: "openclaw_memory"). */
+  tablePrefix?: string;
+  /** Embedding configuration. */
+  embedding?: MemoryPostgresEmbeddingConfig;
+  /** Hybrid search weights. */
+  hybrid?: {
+    enabled?: boolean;
+    vectorWeight?: number;
+    textWeight?: number;
+  };
+  /** Paths to index (same format as QMD paths). */
+  paths?: MemoryQmdIndexPath[];
+  /** Include default MEMORY.md and memory/ directory. */
+  includeDefaultMemory?: boolean;
+  /** Session transcript indexing. */
+  sessions?: MemoryQmdSessionConfig;
+  /** Update/sync intervals. */
+  update?: MemoryQmdUpdateConfig;
+  /** Search limits. */
+  limits?: MemoryQmdLimitsConfig;
+  /** Scope policy. */
+  scope?: SessionSendPolicyConfig;
+};
+
+export type MemoryPostgresEmbeddingConfig = {
+  /** Embedding provider to use (reuses OpenClaw's provider infrastructure). */
+  provider?: "openai" | "voyage" | "gemini";
+  /** Embedding model name. */
+  model?: string;
+  /** Vector dimensions (must match the model output). */
+  dimensions?: number;
 };
 
 export type MemoryQmdConfig = {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -84,11 +84,50 @@ const MemoryQmdSchema = z
   })
   .strict();
 
+const MemoryPostgresEmbeddingSchema = z
+  .object({
+    provider: z.union([z.literal("openai"), z.literal("voyage"), z.literal("gemini")]).optional(),
+    model: z.string().optional(),
+    dimensions: z.number().int().positive().optional(),
+  })
+  .strict();
+
+const MemoryPostgresSchema = z
+  .object({
+    connectionString: z.string().optional(),
+    host: z.string().optional(),
+    port: z.number().int().positive().optional(),
+    database: z.string().optional(),
+    user: z.string().optional(),
+    password: z.string().optional(),
+    ssl: z
+      .union([z.boolean(), z.literal("require"), z.literal("prefer"), z.literal("disable")])
+      .optional(),
+    tablePrefix: z.string().optional(),
+    embedding: MemoryPostgresEmbeddingSchema.optional(),
+    hybrid: z
+      .object({
+        enabled: z.boolean().optional(),
+        vectorWeight: z.number().min(0).max(1).optional(),
+        textWeight: z.number().min(0).max(1).optional(),
+      })
+      .strict()
+      .optional(),
+    paths: z.array(MemoryQmdPathSchema).optional(),
+    includeDefaultMemory: z.boolean().optional(),
+    sessions: MemoryQmdSessionSchema.optional(),
+    update: MemoryQmdUpdateSchema.optional(),
+    limits: MemoryQmdLimitsSchema.optional(),
+    scope: SessionSendPolicySchema.optional(),
+  })
+  .strict();
+
 const MemorySchema = z
   .object({
-    backend: z.union([z.literal("builtin"), z.literal("qmd")]).optional(),
+    backend: z.union([z.literal("builtin"), z.literal("qmd"), z.literal("postgres")]).optional(),
     citations: z.union([z.literal("auto"), z.literal("on"), z.literal("off")]).optional(),
     qmd: MemoryQmdSchema.optional(),
+    postgres: MemoryPostgresSchema.optional(),
   })
   .strict()
   .optional();

--- a/src/memory/backend-config.ts
+++ b/src/memory/backend-config.ts
@@ -4,6 +4,7 @@ import type { SessionSendPolicyConfig } from "../config/types.base.js";
 import type {
   MemoryBackend,
   MemoryCitationsMode,
+  MemoryPostgresConfig,
   MemoryQmdConfig,
   MemoryQmdIndexPath,
   MemoryQmdSearchMode,
@@ -13,10 +14,38 @@ import { parseDurationMs } from "../cli/parse-duration.js";
 import { resolveUserPath } from "../utils.js";
 import { splitShellArgs } from "../utils/shell-argv.js";
 
+export type ResolvedPostgresConfig = {
+  connectionString?: string;
+  host?: string;
+  port?: number;
+  database?: string;
+  user?: string;
+  password?: string;
+  ssl?: boolean | "require" | "prefer" | "disable";
+  tablePrefix: string;
+  embedding: {
+    provider: "openai" | "voyage" | "gemini";
+    model: string;
+    dimensions: number;
+  };
+  hybrid: {
+    enabled: boolean;
+    vectorWeight: number;
+    textWeight: number;
+  };
+  collections: ResolvedQmdCollection[];
+  includeDefaultMemory: boolean;
+  sessions: ResolvedQmdSessionConfig;
+  update: ResolvedQmdUpdateConfig;
+  limits: ResolvedQmdLimitsConfig;
+  scope?: SessionSendPolicyConfig;
+};
+
 export type ResolvedMemoryBackendConfig = {
   backend: MemoryBackend;
   citations: MemoryCitationsMode;
   qmd?: ResolvedQmdConfig;
+  postgres?: ResolvedPostgresConfig;
 };
 
 export type ResolvedQmdCollection = {
@@ -259,12 +288,75 @@ function resolveDefaultCollections(
   }));
 }
 
+function resolvePostgresConfig(
+  pgCfg: MemoryPostgresConfig | undefined,
+  workspaceDir: string,
+  agentId: string,
+): ResolvedPostgresConfig {
+  const nameSet = new Set<string>();
+  const includeDefaultMemory = pgCfg?.includeDefaultMemory !== false;
+  const collections = [
+    ...resolveDefaultCollections(includeDefaultMemory, workspaceDir, nameSet, agentId),
+    ...resolveCustomPaths(pgCfg?.paths, workspaceDir, nameSet, agentId),
+  ];
+
+  return {
+    connectionString: pgCfg?.connectionString,
+    host: pgCfg?.host,
+    port: pgCfg?.port,
+    database: pgCfg?.database,
+    user: pgCfg?.user,
+    password: pgCfg?.password,
+    ssl: pgCfg?.ssl,
+    tablePrefix: pgCfg?.tablePrefix?.trim() || "openclaw_memory",
+    embedding: {
+      provider: pgCfg?.embedding?.provider ?? "voyage",
+      model: pgCfg?.embedding?.model ?? "voyage-3-lite",
+      dimensions: pgCfg?.embedding?.dimensions ?? 512,
+    },
+    hybrid: {
+      enabled: pgCfg?.hybrid?.enabled !== false,
+      vectorWeight: pgCfg?.hybrid?.vectorWeight ?? 0.7,
+      textWeight: pgCfg?.hybrid?.textWeight ?? 0.3,
+    },
+    collections,
+    includeDefaultMemory,
+    sessions: resolveSessionConfig(pgCfg?.sessions, workspaceDir),
+    update: {
+      intervalMs: resolveIntervalMs(pgCfg?.update?.interval),
+      debounceMs: resolveDebounceMs(pgCfg?.update?.debounceMs),
+      onBoot: pgCfg?.update?.onBoot !== false,
+      waitForBootSync: pgCfg?.update?.waitForBootSync === true,
+      embedIntervalMs: resolveEmbedIntervalMs(pgCfg?.update?.embedInterval),
+      commandTimeoutMs: resolveTimeoutMs(
+        pgCfg?.update?.commandTimeoutMs,
+        DEFAULT_QMD_COMMAND_TIMEOUT_MS,
+      ),
+      updateTimeoutMs: resolveTimeoutMs(
+        pgCfg?.update?.updateTimeoutMs,
+        DEFAULT_QMD_UPDATE_TIMEOUT_MS,
+      ),
+      embedTimeoutMs: resolveTimeoutMs(pgCfg?.update?.embedTimeoutMs, DEFAULT_QMD_EMBED_TIMEOUT_MS),
+    },
+    limits: resolveLimits(pgCfg?.limits),
+    scope: pgCfg?.scope ?? DEFAULT_QMD_SCOPE,
+  };
+}
+
 export function resolveMemoryBackendConfig(params: {
   cfg: OpenClawConfig;
   agentId: string;
 }): ResolvedMemoryBackendConfig {
   const backend = params.cfg.memory?.backend ?? DEFAULT_BACKEND;
   const citations = params.cfg.memory?.citations ?? DEFAULT_CITATIONS;
+  if (backend === "postgres") {
+    const workspaceDir = resolveAgentWorkspaceDir(params.cfg, params.agentId);
+    return {
+      backend: "postgres",
+      citations,
+      postgres: resolvePostgresConfig(params.cfg.memory?.postgres, workspaceDir, params.agentId),
+    };
+  }
   if (backend !== "qmd") {
     return { backend: "builtin", citations };
   }

--- a/src/memory/backend-config.ts
+++ b/src/memory/backend-config.ts
@@ -288,6 +288,12 @@ function resolveDefaultCollections(
   }));
 }
 
+function sanitizeTablePrefix(raw: string | undefined): string {
+  const trimmed = raw?.trim() || "openclaw_memory";
+  // Only allow alphanumeric + underscores to prevent SQL injection.
+  return trimmed.replace(/[^a-zA-Z0-9_]/g, "_") || "openclaw_memory";
+}
+
 function resolvePostgresConfig(
   pgCfg: MemoryPostgresConfig | undefined,
   workspaceDir: string,
@@ -308,7 +314,7 @@ function resolvePostgresConfig(
     user: pgCfg?.user,
     password: pgCfg?.password,
     ssl: pgCfg?.ssl,
-    tablePrefix: pgCfg?.tablePrefix?.trim() || "openclaw_memory",
+    tablePrefix: sanitizeTablePrefix(pgCfg?.tablePrefix),
     embedding: {
       provider: pgCfg?.embedding?.provider ?? "voyage",
       model: pgCfg?.embedding?.model ?? "voyage-3-lite",

--- a/src/memory/postgres-config.test.ts
+++ b/src/memory/postgres-config.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveMemoryBackendConfig } from "./backend-config.js";
+
+vi.mock("../agents/agent-scope.js", () => ({
+  resolveAgentWorkspaceDir: vi.fn(() => "/tmp/test-workspace"),
+}));
+
+describe("resolveMemoryBackendConfig postgres", () => {
+  it("resolves postgres backend with defaults", () => {
+    const result = resolveMemoryBackendConfig({
+      cfg: { memory: { backend: "postgres" } } as any,
+      agentId: "main",
+    });
+    expect(result.backend).toBe("postgres");
+    expect(result.postgres).toBeDefined();
+    expect(result.postgres!.tablePrefix).toBe("openclaw_memory");
+    expect(result.postgres!.embedding.provider).toBe("voyage");
+    expect(result.postgres!.embedding.model).toBe("voyage-3-lite");
+    expect(result.postgres!.embedding.dimensions).toBe(512);
+    expect(result.postgres!.hybrid.enabled).toBe(true);
+    expect(result.postgres!.hybrid.vectorWeight).toBe(0.7);
+    expect(result.postgres!.hybrid.textWeight).toBe(0.3);
+    expect(result.qmd).toBeUndefined();
+  });
+
+  it("resolves custom postgres config", () => {
+    const result = resolveMemoryBackendConfig({
+      cfg: {
+        memory: {
+          backend: "postgres",
+          postgres: {
+            connectionString: "postgresql://user:pass@host:5432/db",
+            tablePrefix: "my_agent",
+            embedding: {
+              provider: "openai",
+              model: "text-embedding-3-small",
+              dimensions: 1536,
+            },
+            hybrid: { enabled: false },
+          },
+        },
+      } as any,
+      agentId: "main",
+    });
+    expect(result.postgres!.connectionString).toBe("postgresql://user:pass@host:5432/db");
+    expect(result.postgres!.tablePrefix).toBe("my_agent");
+    expect(result.postgres!.embedding.provider).toBe("openai");
+    expect(result.postgres!.embedding.dimensions).toBe(1536);
+    expect(result.postgres!.hybrid.enabled).toBe(false);
+  });
+
+  it("includes default memory collections", () => {
+    const result = resolveMemoryBackendConfig({
+      cfg: { memory: { backend: "postgres" } } as any,
+      agentId: "main",
+    });
+    expect(result.postgres!.collections.length).toBeGreaterThan(0);
+    expect(result.postgres!.collections.some((c) => c.kind === "memory")).toBe(true);
+  });
+
+  it("does not return postgres config for qmd backend", () => {
+    const result = resolveMemoryBackendConfig({
+      cfg: { memory: { backend: "qmd" } } as any,
+      agentId: "main",
+    });
+    expect(result.backend).toBe("qmd");
+    expect(result.postgres).toBeUndefined();
+  });
+
+  it("does not return postgres config for builtin backend", () => {
+    const result = resolveMemoryBackendConfig({
+      cfg: { memory: { backend: "builtin" } } as any,
+      agentId: "main",
+    });
+    expect(result.backend).toBe("builtin");
+    expect(result.postgres).toBeUndefined();
+  });
+});

--- a/src/memory/postgres-manager.ts
+++ b/src/memory/postgres-manager.ts
@@ -1,0 +1,504 @@
+import crypto from "node:crypto";
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { OpenClawConfig } from "../config/config.js";
+import type { ResolvedMemoryBackendConfig, ResolvedPostgresConfig } from "./backend-config.js";
+import type {
+  MemoryEmbeddingProbeResult,
+  MemoryProviderStatus,
+  MemorySearchManager,
+  MemorySearchResult,
+  MemorySource,
+  MemorySyncProgressUpdate,
+} from "./types.js";
+import { resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+
+const log = createSubsystemLogger("memory/postgres");
+
+const SNIPPET_MAX_CHARS = 700;
+
+type PgPool = import("pg").Pool;
+type PgPoolConfig = import("pg").PoolConfig;
+
+/**
+ * Dynamically import the `pg` module.  Returns `null` when `pg` is not
+ * installed so callers can produce a clear error message.
+ */
+async function importPg(): Promise<typeof import("pg") | null> {
+  try {
+    return await import("pg");
+  } catch {
+    return null;
+  }
+}
+
+function buildPoolConfig(cfg: ResolvedPostgresConfig): PgPoolConfig {
+  if (cfg.connectionString) {
+    return {
+      connectionString: cfg.connectionString,
+      max: 5,
+      idleTimeoutMillis: 30_000,
+    };
+  }
+  return {
+    host: cfg.host ?? "localhost",
+    port: cfg.port ?? 5432,
+    database: cfg.database ?? "openclaw",
+    user: cfg.user,
+    password: cfg.password,
+    ssl: cfg.ssl === true || cfg.ssl === "require" ? { rejectUnauthorized: false } : undefined,
+    max: 5,
+    idleTimeoutMillis: 30_000,
+  };
+}
+
+function contentHash(text: string): string {
+  return crypto.createHash("sha256").update(text).digest("hex").slice(0, 16);
+}
+
+function extractSnippet(content: string, maxChars: number = SNIPPET_MAX_CHARS): string {
+  return content.slice(0, maxChars);
+}
+
+export class PostgresMemoryManager implements MemorySearchManager {
+  private readonly cfg: OpenClawConfig;
+  private readonly agentId: string;
+  private readonly pgCfg: ResolvedPostgresConfig;
+  private readonly workspaceDir: string;
+  private readonly tableName: string;
+  private pool: PgPool | null = null;
+  private initialized = false;
+  private lastSyncAt?: number;
+  private docCount = 0;
+  private embeddingAvailable = false;
+
+  static async create(params: {
+    cfg: OpenClawConfig;
+    agentId: string;
+    resolved: ResolvedMemoryBackendConfig;
+  }): Promise<PostgresMemoryManager | null> {
+    const pgCfg = params.resolved.postgres;
+    if (!pgCfg) {
+      return null;
+    }
+    const manager = new PostgresMemoryManager({
+      cfg: params.cfg,
+      agentId: params.agentId,
+      pgCfg,
+    });
+    await manager.initialize();
+    return manager;
+  }
+
+  private constructor(params: {
+    cfg: OpenClawConfig;
+    agentId: string;
+    pgCfg: ResolvedPostgresConfig;
+  }) {
+    this.cfg = params.cfg;
+    this.agentId = params.agentId;
+    this.pgCfg = params.pgCfg;
+    this.workspaceDir = resolveAgentWorkspaceDir(params.cfg, params.agentId);
+    this.tableName = `${params.pgCfg.tablePrefix}_documents`;
+  }
+
+  private async initialize(): Promise<void> {
+    const pg = await importPg();
+    if (!pg) {
+      throw new Error(
+        'PostgreSQL memory backend requires the "pg" package. Install it with: pnpm add pg',
+      );
+    }
+    const poolConfig = buildPoolConfig(this.pgCfg);
+    this.pool = new pg.Pool(poolConfig);
+
+    // Verify connection and create tables if needed.
+    try {
+      await this.ensureSchema();
+      this.initialized = true;
+      log.info("postgres memory backend initialized");
+    } catch (err) {
+      log.error(`postgres initialization failed: ${String(err)}`);
+      throw err;
+    }
+  }
+
+  private async ensureSchema(): Promise<void> {
+    const pool = this.requirePool();
+    const table = this.tableName;
+    const dims = this.pgCfg.embedding.dimensions;
+
+    // Enable pgvector extension (requires superuser or CREATE permission on first run).
+    await pool.query("CREATE EXTENSION IF NOT EXISTS vector").catch(() => {
+      log.warn("pgvector extension not available; vector search will be disabled");
+    });
+
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS ${table} (
+        id SERIAL PRIMARY KEY,
+        collection TEXT NOT NULL,
+        doc_path TEXT NOT NULL,
+        doc_hash TEXT NOT NULL,
+        content TEXT,
+        snippet TEXT,
+        embedding vector(${dims}),
+        active BOOLEAN DEFAULT true,
+        created_at TIMESTAMPTZ DEFAULT now(),
+        updated_at TIMESTAMPTZ DEFAULT now(),
+        UNIQUE(collection, doc_path)
+      )
+    `);
+
+    // Create indexes idempotently.
+    await pool
+      .query(
+        `CREATE INDEX IF NOT EXISTS idx_${this.pgCfg.tablePrefix}_embedding
+       ON ${table} USING ivfflat (embedding vector_cosine_ops)`,
+      )
+      .catch(() => {
+        // IVFFlat requires training data; fall back to HNSW or skip if no rows yet.
+        return pool
+          .query(
+            `CREATE INDEX IF NOT EXISTS idx_${this.pgCfg.tablePrefix}_embedding
+           ON ${table} USING hnsw (embedding vector_cosine_ops)`,
+          )
+          .catch(() => {
+            log.warn("could not create vector index; searches may be slow");
+          });
+      });
+
+    // tsvector column for hybrid search (add if not exists).
+    await pool
+      .query(
+        `ALTER TABLE ${table} ADD COLUMN IF NOT EXISTS
+       tsv tsvector GENERATED ALWAYS AS (to_tsvector('english', coalesce(content, ''))) STORED`,
+      )
+      .catch(() => {
+        // Column may already exist or generated columns not supported.
+      });
+
+    await pool
+      .query(
+        `CREATE INDEX IF NOT EXISTS idx_${this.pgCfg.tablePrefix}_tsv ON ${table} USING gin (tsv)`,
+      )
+      .catch(() => {});
+
+    await pool
+      .query(
+        `CREATE INDEX IF NOT EXISTS idx_${this.pgCfg.tablePrefix}_active
+       ON ${table} (collection, active)`,
+      )
+      .catch(() => {});
+
+    // Get doc count.
+    const countResult = await pool.query(
+      `SELECT count(*)::int AS cnt FROM ${table} WHERE active = true`,
+    );
+    this.docCount = countResult.rows[0]?.cnt ?? 0;
+  }
+
+  private requirePool(): PgPool {
+    if (!this.pool) {
+      throw new Error("PostgreSQL pool not initialized");
+    }
+    return this.pool;
+  }
+
+  async search(
+    query: string,
+    opts?: { maxResults?: number; minScore?: number; sessionKey?: string },
+  ): Promise<MemorySearchResult[]> {
+    const pool = this.requirePool();
+    const maxResults = opts?.maxResults ?? this.pgCfg.limits.maxResults;
+    const minScore = opts?.minScore ?? 0;
+
+    // Try to get query embedding for vector search.
+    let queryEmbedding: number[] | null = null;
+    try {
+      queryEmbedding = await this.embedText(query);
+    } catch (err) {
+      log.warn(`embedding failed, falling back to text-only search: ${String(err)}`);
+    }
+
+    const hybrid = this.pgCfg.hybrid;
+    const table = this.tableName;
+
+    if (queryEmbedding && hybrid.enabled) {
+      // Hybrid search: vector + text.
+      const embeddingStr = `[${queryEmbedding.join(",")}]`;
+      const result = await pool.query(
+        `
+        WITH vector_results AS (
+          SELECT id, doc_path, collection, content,
+                 1 - (embedding <=> $1::vector) AS vector_score
+          FROM ${table}
+          WHERE active = true AND embedding IS NOT NULL
+          ORDER BY embedding <=> $1::vector
+          LIMIT $2
+        ),
+        text_results AS (
+          SELECT id, doc_path, collection, content,
+                 ts_rank_cd(tsv, plainto_tsquery('english', $3)) AS text_score
+          FROM ${table}
+          WHERE active = true AND tsv @@ plainto_tsquery('english', $3)
+          LIMIT $2
+        )
+        SELECT COALESCE(v.id, t.id) AS id,
+               COALESCE(v.doc_path, t.doc_path) AS doc_path,
+               COALESCE(v.collection, t.collection) AS collection,
+               COALESCE(v.content, t.content) AS content,
+               ($4 * COALESCE(v.vector_score, 0) + $5 * COALESCE(t.text_score, 0)) AS score
+        FROM vector_results v
+        FULL OUTER JOIN text_results t ON v.id = t.id
+        ORDER BY score DESC
+        LIMIT $2
+        `,
+        [embeddingStr, maxResults * 4, query, hybrid.vectorWeight, hybrid.textWeight],
+      );
+      return this.rowsToResults(result.rows, minScore, maxResults);
+    }
+
+    if (queryEmbedding) {
+      // Vector-only search.
+      const embeddingStr = `[${queryEmbedding.join(",")}]`;
+      const result = await pool.query(
+        `
+        SELECT id, doc_path, collection, content,
+               1 - (embedding <=> $1::vector) AS score
+        FROM ${table}
+        WHERE active = true AND embedding IS NOT NULL
+        ORDER BY embedding <=> $1::vector
+        LIMIT $2
+        `,
+        [embeddingStr, maxResults],
+      );
+      return this.rowsToResults(result.rows, minScore, maxResults);
+    }
+
+    // Text-only fallback.
+    const result = await pool.query(
+      `
+      SELECT id, doc_path, collection, content,
+             ts_rank_cd(tsv, plainto_tsquery('english', $1)) AS score
+      FROM ${table}
+      WHERE active = true AND tsv @@ plainto_tsquery('english', $1)
+      ORDER BY score DESC
+      LIMIT $2
+      `,
+      [query, maxResults],
+    );
+    return this.rowsToResults(result.rows, minScore, maxResults);
+  }
+
+  private rowsToResults(
+    rows: Array<{ doc_path: string; collection: string; content: string; score: number }>,
+    minScore: number,
+    maxResults: number,
+  ): MemorySearchResult[] {
+    return rows
+      .filter((row) => row.score >= minScore)
+      .slice(0, maxResults)
+      .map((row) => ({
+        path: row.doc_path,
+        startLine: 1,
+        endLine: row.content?.split("\n").length ?? 1,
+        score: Number(row.score),
+        snippet: extractSnippet(row.content ?? ""),
+        source: (row.collection?.includes("session") ? "sessions" : "memory") as MemorySource,
+      }));
+  }
+
+  async readFile(params: {
+    relPath: string;
+    from?: number;
+    lines?: number;
+  }): Promise<{ text: string; path: string }> {
+    // Read from the filesystem, same as QMD manager.
+    const absPath = path.isAbsolute(params.relPath)
+      ? params.relPath
+      : path.resolve(this.workspaceDir, params.relPath);
+    const content = await fs.readFile(absPath, "utf-8");
+    const allLines = content.split("\n");
+    const from = Math.max(0, (params.from ?? 1) - 1);
+    const count = params.lines ?? allLines.length;
+    const selected = allLines.slice(from, from + count);
+    return { text: selected.join("\n"), path: absPath };
+  }
+
+  status(): MemoryProviderStatus {
+    return {
+      backend: "qmd", // Report as qmd for interface compatibility; custom field clarifies.
+      provider: this.pgCfg.embedding.provider,
+      model: this.pgCfg.embedding.model,
+      files: this.docCount,
+      chunks: this.docCount,
+      workspaceDir: this.workspaceDir,
+      sources: ["memory", "sessions"],
+      vector: {
+        enabled: true,
+        available: this.embeddingAvailable,
+        dims: this.pgCfg.embedding.dimensions,
+      },
+      custom: {
+        backend: "postgres",
+        tablePrefix: this.pgCfg.tablePrefix,
+        hybrid: this.pgCfg.hybrid.enabled,
+        lastSyncAt: this.lastSyncAt,
+      },
+    };
+  }
+
+  async sync(params?: {
+    reason?: string;
+    force?: boolean;
+    progress?: (update: MemorySyncProgressUpdate) => void;
+  }): Promise<void> {
+    const pool = this.requirePool();
+    const collections = this.pgCfg.collections;
+    let totalProcessed = 0;
+    let totalFiles = 0;
+
+    // Collect all files from all collections.
+    const fileEntries: Array<{ collection: string; filePath: string; relPath: string }> = [];
+    for (const col of collections) {
+      try {
+        const { glob } = await import("glob");
+        const files = await glob(col.pattern, { cwd: col.path, absolute: true });
+        for (const file of files) {
+          fileEntries.push({
+            collection: col.name,
+            filePath: file,
+            relPath: path.relative(this.workspaceDir, file),
+          });
+        }
+      } catch (err) {
+        log.warn(`failed to scan collection ${col.name}: ${String(err)}`);
+      }
+    }
+    totalFiles = fileEntries.length;
+
+    for (const entry of fileEntries) {
+      try {
+        const content = await fs.readFile(entry.filePath, "utf-8");
+        const hash = contentHash(content);
+
+        // Check if doc exists and is unchanged.
+        const existing = await pool.query(
+          `SELECT doc_hash FROM ${this.tableName} WHERE collection = $1 AND doc_path = $2`,
+          [entry.collection, entry.relPath],
+        );
+
+        if (existing.rows[0]?.doc_hash === hash && !params?.force) {
+          totalProcessed += 1;
+          params?.progress?.({ completed: totalProcessed, total: totalFiles });
+          continue;
+        }
+
+        // Generate embedding.
+        let embedding: number[] | null = null;
+        try {
+          embedding = await this.embedText(content.slice(0, 8000)); // Limit content for embedding.
+        } catch {
+          // Skip embedding on failure; text search still works.
+        }
+
+        const embeddingStr = embedding ? `[${embedding.join(",")}]` : null;
+        const snippet = extractSnippet(content);
+
+        await pool.query(
+          `INSERT INTO ${this.tableName} (collection, doc_path, doc_hash, content, snippet, embedding, active)
+           VALUES ($1, $2, $3, $4, $5, $6::vector, true)
+           ON CONFLICT (collection, doc_path) DO UPDATE SET
+             doc_hash = EXCLUDED.doc_hash,
+             content = EXCLUDED.content,
+             snippet = EXCLUDED.snippet,
+             embedding = COALESCE(EXCLUDED.embedding, ${this.tableName}.embedding),
+             active = true,
+             updated_at = now()`,
+          [entry.collection, entry.relPath, hash, content, snippet, embeddingStr],
+        );
+
+        totalProcessed += 1;
+        params?.progress?.({ completed: totalProcessed, total: totalFiles });
+      } catch (err) {
+        log.warn(`failed to sync ${entry.relPath}: ${String(err)}`);
+        totalProcessed += 1;
+      }
+    }
+
+    // Mark deleted files as inactive.
+    const activePaths = fileEntries.map((e) => e.relPath);
+    if (activePaths.length > 0) {
+      const collectionsUsed = [...new Set(collections.map((c) => c.name))];
+      for (const col of collectionsUsed) {
+        const colPaths = fileEntries.filter((e) => e.collection === col).map((e) => e.relPath);
+        if (colPaths.length > 0) {
+          await pool
+            .query(
+              `UPDATE ${this.tableName} SET active = false, updated_at = now()
+             WHERE collection = $1 AND active = true AND doc_path != ALL($2)`,
+              [col, colPaths],
+            )
+            .catch(() => {});
+        }
+      }
+    }
+
+    this.lastSyncAt = Date.now();
+    // Refresh doc count.
+    const countResult = await pool.query(
+      `SELECT count(*)::int AS cnt FROM ${this.tableName} WHERE active = true`,
+    );
+    this.docCount = countResult.rows[0]?.cnt ?? 0;
+    log.info(`sync complete: ${this.docCount} active documents`);
+  }
+
+  async probeEmbeddingAvailability(): Promise<MemoryEmbeddingProbeResult> {
+    try {
+      const embedding = await this.embedText("test");
+      this.embeddingAvailable = embedding.length > 0;
+      return { ok: this.embeddingAvailable };
+    } catch (err) {
+      this.embeddingAvailable = false;
+      return { ok: false, error: String(err) };
+    }
+  }
+
+  async probeVectorAvailability(): Promise<boolean> {
+    try {
+      const pool = this.requirePool();
+      await pool.query("SELECT '[1,2,3]'::vector");
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async close(): Promise<void> {
+    if (this.pool) {
+      await this.pool.end();
+      this.pool = null;
+    }
+  }
+
+  private embeddingProvider: import("./embeddings.js").EmbeddingProvider | null = null;
+
+  private async embedText(text: string): Promise<number[]> {
+    if (!this.embeddingProvider) {
+      const { createEmbeddingProvider } = await import("./embeddings.js");
+      const result = await createEmbeddingProvider({
+        config: this.cfg,
+        provider: this.pgCfg.embedding.provider,
+        model: this.pgCfg.embedding.model,
+        fallback: "none",
+      });
+      if (!result?.provider) {
+        throw new Error(`embedding provider "${this.pgCfg.embedding.provider}" not available`);
+      }
+      this.embeddingProvider = result.provider;
+    }
+    return await this.embeddingProvider.embedQuery(text);
+  }
+}

--- a/src/memory/postgres-manager.ts
+++ b/src/memory/postgres-manager.ts
@@ -48,7 +48,7 @@ function buildPoolConfig(cfg: ResolvedPostgresConfig): PgPoolConfig {
     database: cfg.database ?? "openclaw",
     user: cfg.user,
     password: cfg.password,
-    ssl: cfg.ssl === true || cfg.ssl === "require" ? { rejectUnauthorized: false } : undefined,
+    ssl: cfg.ssl === true || cfg.ssl === "require" ? { rejectUnauthorized: true } : undefined,
     max: 5,
     idleTimeoutMillis: 30_000,
   };


### PR DESCRIPTION
## Summary

Implements RFC #15093 — adds a native `postgres` memory backend (`memory.backend = "postgres"`) that stores and searches memory documents directly in PostgreSQL with pgvector, as an alternative to the QMD CLI sidecar approach.

## Motivation

The QMD backend (OpenClaw → shell → QMD CLI → SQLite → GGUF models) creates a fragile chain with 30+ open issues related to empty results, timeouts, cold starts, and subprocess failures. Many users already run PostgreSQL — a native backend eliminates the subprocess layer entirely.

## What it does

### PostgresMemoryManager (~500 lines)
- **Hybrid search**: pgvector cosine similarity + tsvector BM25 ranking with configurable weights
- **Embedding provider reuse**: Uses OpenClaw's existing Voyage/OpenAI/Gemini providers (no local GGUF models needed)
- **Hash-based sync**: Only re-indexes changed files, same efficiency model as QMD
- **Auto-migration**: `CREATE TABLE/INDEX IF NOT EXISTS` on first connect
- **Connection pooling**: via `pg.Pool` with configurable limits
- **Table prefix isolation**: Multiple agents can share one database
- **Graceful degradation**: Wrapped in `FallbackMemoryManager` — falls back to builtin on failure

### Config
```json5
{
  memory: {
    backend: "postgres",
    postgres: {
      connectionString: "postgresql://user:pass@host:5432/dbname",
      tablePrefix: "openclaw_memory",  // default
      embedding: {
        provider: "voyage",     // or "openai", "gemini"
        model: "voyage-3-lite",
        dimensions: 512
      },
      hybrid: {
        enabled: true,          // default
        vectorWeight: 0.7,      // default
        textWeight: 0.3         // default
      }
    }
  }
}
```

### Schema (auto-created)
```sql
CREATE TABLE openclaw_memory_documents (
  id SERIAL PRIMARY KEY,
  collection TEXT NOT NULL,
  doc_path TEXT NOT NULL,
  doc_hash TEXT NOT NULL,
  content TEXT,
  snippet TEXT,
  embedding vector(512),
  tsv tsvector GENERATED ALWAYS AS (to_tsvector('english', coalesce(content, ''))) STORED,
  active BOOLEAN DEFAULT true,
  created_at TIMESTAMPTZ DEFAULT now(),
  updated_at TIMESTAMPTZ DEFAULT now(),
  UNIQUE(collection, doc_path)
);
```

## Dependency

`pg` (node-postgres) added as an **optional peer dependency**. Only loaded via dynamic import when `memory.backend = "postgres"` — zero impact on users who don't need it.

## Real-World Validation

Built and tested by the IrriVision Technologies team running OpenClaw on an LXC container with PostgreSQL 15 + pgvector. Our proof-of-concept (`hubert-qmd`) indexed 1,145 documents with ~200ms search latency and no cold starts.

## Changes

| File | Change |
|------|--------|
| `src/config/types.memory.ts` | Add `MemoryPostgresConfig` + `MemoryPostgresEmbeddingConfig` types |
| `src/config/zod-schema.ts` | Add Postgres config validation schema |
| `src/config/schema.help.ts` | Update backend help text |
| `src/memory/backend-config.ts` | Add `ResolvedPostgresConfig` type + resolver |
| `src/memory/postgres-manager.ts` | `PostgresMemoryManager` implementation (~500 lines) |
| `src/memory/search-manager.ts` | Factory integration for postgres backend |
| `package.json` | Add `pg` as optional peer dependency |
| `src/memory/postgres-config.test.ts` | 5 config resolution tests |

Closes #15093

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements native PostgreSQL + pgvector memory backend as an alternative to QMD CLI sidecar. The implementation includes hybrid search (vector + BM25), hash-based sync, auto-migration, and connection pooling.

**Major changes:**
- Added ~500 LOC `PostgresMemoryManager` with pgvector cosine similarity and tsvector full-text search
- Reuses existing embedding providers (Voyage/OpenAI/Gemini) instead of local GGUF models
- Factory integration with graceful fallback to builtin backend
- Configuration validation via Zod schema with proper type definitions
- Unit tests for config resolution (5 test cases)

**Critical issues found:**
- SQL injection vulnerability via unsanitized `tablePrefix` (line 138-152, 157-193 in postgres-manager.ts)
- SSL certificate validation disabled with `rejectUnauthorized: false` (line 51)
- Syntax error in UPSERT query referencing wrong table alias (line 417)

**Recommendations:**
- Sanitize `tablePrefix` to only allow `[a-zA-Z0-9_]` characters before SQL interpolation
- Enable proper SSL certificate validation by default
- Fix table reference in ON CONFLICT clause
- Add integration tests with real PostgreSQL instance
- Consider adding `@types/pg` to devDependencies

<h3>Confidence Score: 1/5</h3>

- This PR contains a critical SQL injection vulnerability and should NOT be merged without fixes
- Score reflects the SQL injection vulnerability in `tablePrefix` handling (lines 138-193) which allows arbitrary SQL execution, plus the disabled SSL certificate validation that creates MITM attack surface. These are security-critical issues that must be resolved before merge.
- Pay close attention to `src/memory/postgres-manager.ts` (SQL injection + SSL security) and `src/memory/backend-config.ts` (needs tablePrefix sanitization)

<sub>Last reviewed commit: ff42b39</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->