### PR TITLE
Agents: wire command poll backoff into process poll

### DIFF
--- a/src/agents/bash-tools.process.poll-timeout.test.ts
+++ b/src/agents/bash-tools.process.poll-timeout.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, expect, test, vi } from "vitest";
 import type { ProcessSession } from "./bash-process-registry.js";
+import { resetDiagnosticSessionStateForTest } from "../logging/diagnostic-session-state.js";
 import {
   addSession,
   appendOutput,
@@ -7,7 +8,6 @@ import {
   resetProcessRegistryForTests,
 } from "./bash-process-registry.js";
 import { createProcessTool } from "./bash-tools.process.js";
-import { resetDiagnosticSessionStateForTest } from "../logging/diagnostic-session-state.js";
 
 afterEach(() => {
   resetProcessRegistryForTests();

--- a/src/agents/bash-tools.process.poll-timeout.test.ts
+++ b/src/agents/bash-tools.process.poll-timeout.test.ts
@@ -7,9 +7,11 @@ import {
   resetProcessRegistryForTests,
 } from "./bash-process-registry.js";
 import { createProcessTool } from "./bash-tools.process.js";
+import { resetDiagnosticSessionStateForTest } from "../logging/diagnostic-session-state.js";
 
 afterEach(() => {
   resetProcessRegistryForTests();
+  resetDiagnosticSessionStateForTest();
 });
 
 function createBackgroundSession(id: string): ProcessSession {
@@ -97,4 +99,80 @@ test("process poll accepts string timeout values", async () => {
   } finally {
     vi.useRealTimers();
   }
+});
+
+test("process poll exposes adaptive retryInMs for repeated no-output polls", async () => {
+  const processTool = createProcessTool();
+  const sessionId = "sess-retry";
+  const session = createBackgroundSession(sessionId);
+  addSession(session);
+
+  const poll1 = await processTool.execute("toolcall-1", {
+    action: "poll",
+    sessionId,
+  });
+  const poll2 = await processTool.execute("toolcall-2", {
+    action: "poll",
+    sessionId,
+  });
+  const poll3 = await processTool.execute("toolcall-3", {
+    action: "poll",
+    sessionId,
+  });
+  const poll4 = await processTool.execute("toolcall-4", {
+    action: "poll",
+    sessionId,
+  });
+  const poll5 = await processTool.execute("toolcall-5", {
+    action: "poll",
+    sessionId,
+  });
+
+  expect((poll1.details as { retryInMs?: number }).retryInMs).toBe(5000);
+  expect((poll2.details as { retryInMs?: number }).retryInMs).toBe(10000);
+  expect((poll3.details as { retryInMs?: number }).retryInMs).toBe(30000);
+  expect((poll4.details as { retryInMs?: number }).retryInMs).toBe(60000);
+  expect((poll5.details as { retryInMs?: number }).retryInMs).toBe(60000);
+});
+
+test("process poll resets retryInMs when output appears and clears on completion", async () => {
+  const processTool = createProcessTool();
+  const sessionId = "sess-reset";
+  const session = createBackgroundSession(sessionId);
+  addSession(session);
+
+  const poll1 = await processTool.execute("toolcall-1", {
+    action: "poll",
+    sessionId,
+  });
+  const poll2 = await processTool.execute("toolcall-2", {
+    action: "poll",
+    sessionId,
+  });
+  expect((poll1.details as { retryInMs?: number }).retryInMs).toBe(5000);
+  expect((poll2.details as { retryInMs?: number }).retryInMs).toBe(10000);
+
+  appendOutput(session, "stdout", "step complete\n");
+  const pollWithOutput = await processTool.execute("toolcall-output", {
+    action: "poll",
+    sessionId,
+  });
+  expect((pollWithOutput.details as { retryInMs?: number }).retryInMs).toBe(5000);
+
+  markExited(session, 0, null, "completed");
+  const pollCompleted = await processTool.execute("toolcall-completed", {
+    action: "poll",
+    sessionId,
+  });
+  const completedDetails = pollCompleted.details as { status?: string; retryInMs?: number };
+  expect(completedDetails.status).toBe("completed");
+  expect(completedDetails.retryInMs).toBeUndefined();
+
+  const pollFinished = await processTool.execute("toolcall-finished", {
+    action: "poll",
+    sessionId,
+  });
+  const finishedDetails = pollFinished.details as { status?: string; retryInMs?: number };
+  expect(finishedDetails.status).toBe("completed");
+  expect(finishedDetails.retryInMs).toBeUndefined();
 });

--- a/src/agents/bash-tools.process.ts
+++ b/src/agents/bash-tools.process.ts
@@ -4,7 +4,6 @@ import { formatDurationCompact } from "../infra/format-time/format-duration.ts";
 import { getDiagnosticSessionState } from "../logging/diagnostic-session-state.js";
 import { killProcessTree } from "../process/kill-tree.js";
 import { getProcessSupervisor } from "../process/supervisor/index.js";
-import { recordCommandPoll, resetCommandPollCount } from "./command-poll-backoff.js";
 import {
   type ProcessSession,
   deleteSession,
@@ -17,6 +16,7 @@ import {
   setJobTtlMs,
 } from "./bash-process-registry.js";
 import { deriveSessionName, pad, sliceLogLines, truncateMiddle } from "./bash-tools.shared.js";
+import { recordCommandPoll, resetCommandPollCount } from "./command-poll-backoff.js";
 import { encodeKeySequence, encodePaste } from "./pty-keys.js";
 
 export type ProcessToolDefaults = {

--- a/src/agents/bash-tools.process.ts
+++ b/src/agents/bash-tools.process.ts
@@ -1,8 +1,10 @@
 import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
 import { Type } from "@sinclair/typebox";
 import { formatDurationCompact } from "../infra/format-time/format-duration.ts";
+import { getDiagnosticSessionState } from "../logging/diagnostic-session-state.js";
 import { killProcessTree } from "../process/kill-tree.js";
 import { getProcessSupervisor } from "../process/supervisor/index.js";
+import { recordCommandPoll, resetCommandPollCount } from "./command-poll-backoff.js";
 import {
   type ProcessSession,
   deleteSession,
@@ -94,6 +96,24 @@ function failText(text: string): AgentToolResult<unknown> {
     ],
     details: { status: "failed" },
   };
+}
+
+function recordPollRetrySuggestion(sessionId: string, hasNewOutput: boolean): number | undefined {
+  try {
+    const sessionState = getDiagnosticSessionState({ sessionId });
+    return recordCommandPoll(sessionState, sessionId, hasNewOutput);
+  } catch {
+    return undefined;
+  }
+}
+
+function resetPollRetrySuggestion(sessionId: string): void {
+  try {
+    const sessionState = getDiagnosticSessionState({ sessionId });
+    resetCommandPollCount(sessionState, sessionId);
+  } catch {
+    // Ignore diagnostics state failures for process tool behavior.
+  }
 }
 
 export function createProcessTool(
@@ -262,6 +282,7 @@ export function createProcessTool(
         case "poll": {
           if (!scopedSession) {
             if (scopedFinished) {
+              resetPollRetrySuggestion(params.sessionId);
               return {
                 content: [
                   {
@@ -287,6 +308,7 @@ export function createProcessTool(
                 },
               };
             }
+            resetPollRetrySuggestion(params.sessionId);
             return failText(`No session found for ${params.sessionId}`);
           }
           if (!scopedSession.backgrounded) {
@@ -320,6 +342,13 @@ export function createProcessTool(
               : "failed"
             : "running";
           const output = [stdout.trimEnd(), stderr.trimEnd()].filter(Boolean).join("\n").trim();
+          const hasNewOutput = output.length > 0;
+          const retryInMs = exited
+            ? undefined
+            : recordPollRetrySuggestion(params.sessionId, hasNewOutput);
+          if (exited) {
+            resetPollRetrySuggestion(params.sessionId);
+          }
           return {
             content: [
               {
@@ -339,6 +368,7 @@ export function createProcessTool(
               exitCode: exited ? exitCode : undefined,
               aggregated: scopedSession.aggregated,
               name: deriveSessionName(scopedSession.command),
+              ...(typeof retryInMs === "number" ? { retryInMs } : {}),
             },
           };
         }
@@ -549,6 +579,7 @@ export function createProcessTool(
             }
             markExited(scopedSession, null, "SIGKILL", "failed");
           }
+          resetPollRetrySuggestion(params.sessionId);
           return {
             content: [
               {
@@ -567,6 +598,7 @@ export function createProcessTool(
 
         case "clear": {
           if (scopedFinished) {
+            resetPollRetrySuggestion(params.sessionId);
             deleteSession(params.sessionId);
             return {
               content: [{ type: "text", text: `Cleared session ${params.sessionId}.` }],
@@ -601,6 +633,7 @@ export function createProcessTool(
               markExited(scopedSession, null, "SIGKILL", "failed");
               deleteSession(params.sessionId);
             }
+            resetPollRetrySuggestion(params.sessionId);
             return {
               content: [
                 {
@@ -617,6 +650,7 @@ export function createProcessTool(
             };
           }
           if (scopedFinished) {
+            resetPollRetrySuggestion(params.sessionId);
             deleteSession(params.sessionId);
             return {
               content: [{ type: "text", text: `Removed session ${params.sessionId}.` }],


### PR DESCRIPTION
## Summary
- wire command poll backoff into the runtime `process` tool poll flow
- include `retryInMs` in `process(action=poll)` details when the session is still running
- reset poll backoff state when sessions complete or are cleared/removed/killed
- add poll-timeout tests covering retry progression and reset behavior

## Testing
- pnpm exec vitest run --config vitest.unit.config.ts src/agents/bash-tools.process.poll-timeout.test.ts
- pnpm exec vitest run --config vitest.unit.config.ts src/agents/command-poll-backoff.test.ts src/agents/bash-tools.process.supervisor.test.ts

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Wires command poll backoff into the runtime `process` tool's poll action. The implementation adds adaptive retry delays (`retryInMs`) to poll responses when sessions are still running, using an exponential backoff schedule (5s → 10s → 30s → 60s) based on consecutive no-output polls. The backoff state resets when output appears or when sessions complete/clear/remove/kill.

- Adds `retryInMs` field to poll action `details` when session is still running
- Backoff count increments on consecutive no-output polls and resets on new output
- Poll state clears when sessions exit, are cleared, killed, or removed
- Test coverage validates retry progression (5s/10s/30s/60s caps), reset on output, and clearing on completion
- Wraps diagnostic state access in try-catch to prevent failures from breaking process tool behavior

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is clean, well-tested, and defensive. Try-catch blocks prevent diagnostic state failures from affecting process tool behavior. Test coverage is thorough, including edge cases like output resets and completion cleanup. The backoff logic is straightforward and matches the existing command-poll-backoff implementation that already has comprehensive unit tests.
- No files require special attention

<sub>Last reviewed commit: d361f91</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->