### PR TITLE
cron: route reminders by session namespace

### DIFF
--- a/src/agents/bash-tools.process.poll-timeout.test.ts
+++ b/src/agents/bash-tools.process.poll-timeout.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, expect, test, vi } from "vitest";
 import type { ProcessSession } from "./bash-process-registry.js";
+import { resetDiagnosticSessionStateForTest } from "../logging/diagnostic-session-state.js";
 import {
   addSession,
   appendOutput,
@@ -7,7 +8,6 @@ import {
   resetProcessRegistryForTests,
 } from "./bash-process-registry.js";
 import { createProcessTool } from "./bash-tools.process.js";
-import { resetDiagnosticSessionStateForTest } from "../logging/diagnostic-session-state.js";
 
 afterEach(() => {
   resetProcessRegistryForTests();

--- a/src/agents/bash-tools.process.poll-timeout.test.ts
+++ b/src/agents/bash-tools.process.poll-timeout.test.ts
@@ -7,9 +7,11 @@ import {
   resetProcessRegistryForTests,
 } from "./bash-process-registry.js";
 import { createProcessTool } from "./bash-tools.process.js";
+import { resetDiagnosticSessionStateForTest } from "../logging/diagnostic-session-state.js";
 
 afterEach(() => {
   resetProcessRegistryForTests();
+  resetDiagnosticSessionStateForTest();
 });
 
 function createBackgroundSession(id: string): ProcessSession {
@@ -97,4 +99,80 @@ test("process poll accepts string timeout values", async () => {
   } finally {
     vi.useRealTimers();
   }
+});
+
+test("process poll exposes adaptive retryInMs for repeated no-output polls", async () => {
+  const processTool = createProcessTool();
+  const sessionId = "sess-retry";
+  const session = createBackgroundSession(sessionId);
+  addSession(session);
+
+  const poll1 = await processTool.execute("toolcall-1", {
+    action: "poll",
+    sessionId,
+  });
+  const poll2 = await processTool.execute("toolcall-2", {
+    action: "poll",
+    sessionId,
+  });
+  const poll3 = await processTool.execute("toolcall-3", {
+    action: "poll",
+    sessionId,
+  });
+  const poll4 = await processTool.execute("toolcall-4", {
+    action: "poll",
+    sessionId,
+  });
+  const poll5 = await processTool.execute("toolcall-5", {
+    action: "poll",
+    sessionId,
+  });
+
+  expect((poll1.details as { retryInMs?: number }).retryInMs).toBe(5000);
+  expect((poll2.details as { retryInMs?: number }).retryInMs).toBe(10000);
+  expect((poll3.details as { retryInMs?: number }).retryInMs).toBe(30000);
+  expect((poll4.details as { retryInMs?: number }).retryInMs).toBe(60000);
+  expect((poll5.details as { retryInMs?: number }).retryInMs).toBe(60000);
+});
+
+test("process poll resets retryInMs when output appears and clears on completion", async () => {
+  const processTool = createProcessTool();
+  const sessionId = "sess-reset";
+  const session = createBackgroundSession(sessionId);
+  addSession(session);
+
+  const poll1 = await processTool.execute("toolcall-1", {
+    action: "poll",
+    sessionId,
+  });
+  const poll2 = await processTool.execute("toolcall-2", {
+    action: "poll",
+    sessionId,
+  });
+  expect((poll1.details as { retryInMs?: number }).retryInMs).toBe(5000);
+  expect((poll2.details as { retryInMs?: number }).retryInMs).toBe(10000);
+
+  appendOutput(session, "stdout", "step complete\n");
+  const pollWithOutput = await processTool.execute("toolcall-output", {
+    action: "poll",
+    sessionId,
+  });
+  expect((pollWithOutput.details as { retryInMs?: number }).retryInMs).toBe(5000);
+
+  markExited(session, 0, null, "completed");
+  const pollCompleted = await processTool.execute("toolcall-completed", {
+    action: "poll",
+    sessionId,
+  });
+  const completedDetails = pollCompleted.details as { status?: string; retryInMs?: number };
+  expect(completedDetails.status).toBe("completed");
+  expect(completedDetails.retryInMs).toBeUndefined();
+
+  const pollFinished = await processTool.execute("toolcall-finished", {
+    action: "poll",
+    sessionId,
+  });
+  const finishedDetails = pollFinished.details as { status?: string; retryInMs?: number };
+  expect(finishedDetails.status).toBe("completed");
+  expect(finishedDetails.retryInMs).toBeUndefined();
 });

--- a/src/agents/bash-tools.process.ts
+++ b/src/agents/bash-tools.process.ts
@@ -4,7 +4,6 @@ import { formatDurationCompact } from "../infra/format-time/format-duration.ts";
 import { getDiagnosticSessionState } from "../logging/diagnostic-session-state.js";
 import { killProcessTree } from "../process/kill-tree.js";
 import { getProcessSupervisor } from "../process/supervisor/index.js";
-import { recordCommandPoll, resetCommandPollCount } from "./command-poll-backoff.js";
 import {
   type ProcessSession,
   deleteSession,
@@ -17,6 +16,7 @@ import {
   setJobTtlMs,
 } from "./bash-process-registry.js";
 import { deriveSessionName, pad, sliceLogLines, truncateMiddle } from "./bash-tools.shared.js";
+import { recordCommandPoll, resetCommandPollCount } from "./command-poll-backoff.js";
 import { encodeKeySequence, encodePaste } from "./pty-keys.js";
 
 export type ProcessToolDefaults = {

--- a/src/agents/bash-tools.process.ts
+++ b/src/agents/bash-tools.process.ts
@@ -1,8 +1,10 @@
 import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
 import { Type } from "@sinclair/typebox";
 import { formatDurationCompact } from "../infra/format-time/format-duration.ts";
+import { getDiagnosticSessionState } from "../logging/diagnostic-session-state.js";
 import { killProcessTree } from "../process/kill-tree.js";
 import { getProcessSupervisor } from "../process/supervisor/index.js";
+import { recordCommandPoll, resetCommandPollCount } from "./command-poll-backoff.js";
 import {
   type ProcessSession,
   deleteSession,
@@ -94,6 +96,24 @@ function failText(text: string): AgentToolResult<unknown> {
     ],
     details: { status: "failed" },
   };
+}
+
+function recordPollRetrySuggestion(sessionId: string, hasNewOutput: boolean): number | undefined {
+  try {
+    const sessionState = getDiagnosticSessionState({ sessionId });
+    return recordCommandPoll(sessionState, sessionId, hasNewOutput);
+  } catch {
+    return undefined;
+  }
+}
+
+function resetPollRetrySuggestion(sessionId: string): void {
+  try {
+    const sessionState = getDiagnosticSessionState({ sessionId });
+    resetCommandPollCount(sessionState, sessionId);
+  } catch {
+    // Ignore diagnostics state failures for process tool behavior.
+  }
 }
 
 export function createProcessTool(
@@ -262,6 +282,7 @@ export function createProcessTool(
         case "poll": {
           if (!scopedSession) {
             if (scopedFinished) {
+              resetPollRetrySuggestion(params.sessionId);
               return {
                 content: [
                   {
@@ -287,6 +308,7 @@ export function createProcessTool(
                 },
               };
             }
+            resetPollRetrySuggestion(params.sessionId);
             return failText(`No session found for ${params.sessionId}`);
           }
           if (!scopedSession.backgrounded) {
@@ -320,6 +342,13 @@ export function createProcessTool(
               : "failed"
             : "running";
           const output = [stdout.trimEnd(), stderr.trimEnd()].filter(Boolean).join("\n").trim();
+          const hasNewOutput = output.length > 0;
+          const retryInMs = exited
+            ? undefined
+            : recordPollRetrySuggestion(params.sessionId, hasNewOutput);
+          if (exited) {
+            resetPollRetrySuggestion(params.sessionId);
+          }
           return {
             content: [
               {
@@ -339,6 +368,7 @@ export function createProcessTool(
               exitCode: exited ? exitCode : undefined,
               aggregated: scopedSession.aggregated,
               name: deriveSessionName(scopedSession.command),
+              ...(typeof retryInMs === "number" ? { retryInMs } : {}),
             },
           };
         }
@@ -549,6 +579,7 @@ export function createProcessTool(
             }
             markExited(scopedSession, null, "SIGKILL", "failed");
           }
+          resetPollRetrySuggestion(params.sessionId);
           return {
             content: [
               {
@@ -567,6 +598,7 @@ export function createProcessTool(
 
         case "clear": {
           if (scopedFinished) {
+            resetPollRetrySuggestion(params.sessionId);
             deleteSession(params.sessionId);
             return {
               content: [{ type: "text", text: `Cleared session ${params.sessionId}.` }],
@@ -601,6 +633,7 @@ export function createProcessTool(
               markExited(scopedSession, null, "SIGKILL", "failed");
               deleteSession(params.sessionId);
             }
+            resetPollRetrySuggestion(params.sessionId);
             return {
               content: [
                 {
@@ -617,6 +650,7 @@ export function createProcessTool(
             };
           }
           if (scopedFinished) {
+            resetPollRetrySuggestion(params.sessionId);
             deleteSession(params.sessionId);
             return {
               content: [{ type: "text", text: `Removed session ${params.sessionId}.` }],

--- a/src/agents/tools/cron-tool.e2e.test.ts
+++ b/src/agents/tools/cron-tool.e2e.test.ts
@@ -144,6 +144,46 @@ describe("cron tool", () => {
     expect(call?.params?.agentId).toBeNull();
   });
 
+  it("stamps cron.add with caller sessionKey when missing", async () => {
+    callGatewayMock.mockResolvedValueOnce({ ok: true });
+
+    const callerSessionKey = "agent:main:discord:channel:ops";
+    const tool = createCronTool({ agentSessionKey: callerSessionKey });
+    await tool.execute("call-session-key", {
+      action: "add",
+      job: {
+        name: "wake-up",
+        schedule: { at: new Date(123).toISOString() },
+        payload: { kind: "systemEvent", text: "hello" },
+      },
+    });
+
+    const call = callGatewayMock.mock.calls[0]?.[0] as {
+      params?: { sessionKey?: string };
+    };
+    expect(call?.params?.sessionKey).toBe(callerSessionKey);
+  });
+
+  it("preserves explicit job.sessionKey on add", async () => {
+    callGatewayMock.mockResolvedValueOnce({ ok: true });
+
+    const tool = createCronTool({ agentSessionKey: "agent:main:discord:channel:ops" });
+    await tool.execute("call-explicit-session-key", {
+      action: "add",
+      job: {
+        name: "wake-up",
+        schedule: { at: new Date(123).toISOString() },
+        sessionKey: "agent:main:telegram:group:-100123:topic:99",
+        payload: { kind: "systemEvent", text: "hello" },
+      },
+    });
+
+    const call = callGatewayMock.mock.calls[0]?.[0] as {
+      params?: { sessionKey?: string };
+    };
+    expect(call?.params?.sessionKey).toBe("agent:main:telegram:group:-100123:topic:99");
+  });
+
   it("adds recent context for systemEvent reminders when contextMessages > 0", async () => {
     callGatewayMock
       .mockResolvedValueOnce({

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -332,13 +332,22 @@ Use jobId as the canonical identifier; id is accepted for compatibility. Use con
             throw new Error("job required");
           }
           const job = normalizeCronJobCreate(params.job) ?? params.job;
-          if (job && typeof job === "object" && !("agentId" in job)) {
+          if (job && typeof job === "object") {
             const cfg = loadConfig();
-            const agentId = opts?.agentSessionKey
-              ? resolveSessionAgentId({ sessionKey: opts.agentSessionKey, config: cfg })
+            const { mainKey, alias } = resolveMainSessionAlias(cfg);
+            const resolvedSessionKey = opts?.agentSessionKey
+              ? resolveInternalSessionKey({ key: opts.agentSessionKey, alias, mainKey })
               : undefined;
-            if (agentId) {
-              (job as { agentId?: string }).agentId = agentId;
+            if (!("agentId" in job)) {
+              const agentId = opts?.agentSessionKey
+                ? resolveSessionAgentId({ sessionKey: opts.agentSessionKey, config: cfg })
+                : undefined;
+              if (agentId) {
+                (job as { agentId?: string }).agentId = agentId;
+              }
+            }
+            if (!("sessionKey" in job) && resolvedSessionKey) {
+              (job as { sessionKey?: string }).sessionKey = resolvedSessionKey;
             }
           }
 

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -301,6 +301,20 @@ export function normalizeCronJobInput(
     }
   }
 
+  if ("sessionKey" in base) {
+    const sessionKey = base.sessionKey;
+    if (sessionKey === null) {
+      next.sessionKey = null;
+    } else if (typeof sessionKey === "string") {
+      const trimmed = sessionKey.trim();
+      if (trimmed) {
+        next.sessionKey = trimmed;
+      } else {
+        delete next.sessionKey;
+      }
+    }
+  }
+
   if ("enabled" in base) {
     const enabled = base.enabled;
     if (typeof enabled === "boolean") {

--- a/src/cron/service.store.migration.test.ts
+++ b/src/cron/service.store.migration.test.ts
@@ -58,6 +58,7 @@ describe("cron store migration", () => {
     const legacyJob = {
       id: "job-1",
       agentId: undefined,
+      sessionKey: "  agent:main:discord:channel:ops  ",
       name: "Legacy job",
       description: null,
       enabled: true,
@@ -82,6 +83,7 @@ describe("cron store migration", () => {
     await fs.writeFile(store.storePath, JSON.stringify({ version: 1, jobs: [legacyJob] }, null, 2));
 
     const migrated = await migrateAndLoadFirstJob(store.storePath);
+    expect(migrated.sessionKey).toBe("agent:main:discord:channel:ops");
     expect(migrated.delivery).toEqual({
       mode: "announce",
       channel: "telegram",

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -14,6 +14,7 @@ import { computeNextRunAtMs } from "../schedule.js";
 import { normalizeHttpWebhookUrl } from "../webhook-url.js";
 import {
   normalizeOptionalAgentId,
+  normalizeOptionalSessionKey,
   normalizeOptionalText,
   normalizePayloadToSystemText,
   normalizeRequiredName,
@@ -287,6 +288,7 @@ export function createJob(state: CronServiceState, input: CronJobCreate): CronJo
   const job: CronJob = {
     id,
     agentId: normalizeOptionalAgentId(input.agentId),
+    sessionKey: normalizeOptionalSessionKey((input as { sessionKey?: unknown }).sessionKey),
     name: normalizeRequiredName(input.name),
     description: normalizeOptionalText(input.description),
     enabled,
@@ -355,6 +357,9 @@ export function applyJobPatch(job: CronJob, patch: CronJobPatch) {
   }
   if ("agentId" in patch) {
     job.agentId = normalizeOptionalAgentId((patch as { agentId?: unknown }).agentId);
+  }
+  if ("sessionKey" in patch) {
+    job.sessionKey = normalizeOptionalSessionKey((patch as { sessionKey?: unknown }).sessionKey);
   }
   assertSupportedJobSpec(job);
   assertDeliverySupport(job);

--- a/src/cron/service/normalize.ts
+++ b/src/cron/service/normalize.ts
@@ -39,6 +39,14 @@ export function normalizeOptionalAgentId(raw: unknown) {
   return normalizeAgentId(trimmed);
 }
 
+export function normalizeOptionalSessionKey(raw: unknown) {
+  if (typeof raw !== "string") {
+    return undefined;
+  }
+  const trimmed = raw.trim();
+  return trimmed || undefined;
+}
+
 export function inferLegacyName(job: {
   schedule?: { kind?: unknown; everyMs?: unknown; expr?: unknown };
   payload?: { kind?: unknown; text?: unknown; message?: unknown };

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -35,9 +35,16 @@ export type CronServiceDeps = {
   resolveSessionStorePath?: (agentId?: string) => string;
   /** Path to the session store (sessions.json) for reaper use. */
   sessionStorePath?: string;
-  enqueueSystemEvent: (text: string, opts?: { agentId?: string; contextKey?: string }) => void;
-  requestHeartbeatNow: (opts?: { reason?: string }) => void;
-  runHeartbeatOnce?: (opts?: { reason?: string; agentId?: string }) => Promise<HeartbeatRunResult>;
+  enqueueSystemEvent: (
+    text: string,
+    opts?: { agentId?: string; sessionKey?: string; contextKey?: string },
+  ) => void;
+  requestHeartbeatNow: (opts?: { reason?: string; agentId?: string; sessionKey?: string }) => void;
+  runHeartbeatOnce?: (opts?: {
+    reason?: string;
+    agentId?: string;
+    sessionKey?: string;
+  }) => Promise<HeartbeatRunResult>;
   /**
    * WakeMode=now: max time to wait for runHeartbeatOnce to stop returning
    * { status:"skipped", reason:"requests-in-flight" } before falling back to

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -264,6 +264,15 @@ export async function ensureLoaded(
       mutated = true;
     }
 
+    if ("sessionKey" in raw) {
+      const sessionKey =
+        typeof raw.sessionKey === "string" ? normalizeOptionalText(raw.sessionKey) : undefined;
+      if (raw.sessionKey !== sessionKey) {
+        raw.sessionKey = sessionKey;
+        mutated = true;
+      }
+    }
+
     if (typeof raw.enabled !== "boolean") {
       raw.enabled = true;
       mutated = true;

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -441,6 +441,7 @@ async function executeJobCore(
     }
     state.deps.enqueueSystemEvent(text, {
       agentId: job.agentId,
+      sessionKey: job.sessionKey,
       contextKey: `cron:${job.id}`,
     });
     if (job.wakeMode === "now" && state.deps.runHeartbeatOnce) {
@@ -452,7 +453,11 @@ async function executeJobCore(
 
       let heartbeatResult: HeartbeatRunResult;
       for (;;) {
-        heartbeatResult = await state.deps.runHeartbeatOnce({ reason, agentId: job.agentId });
+        heartbeatResult = await state.deps.runHeartbeatOnce({
+          reason,
+          agentId: job.agentId,
+          sessionKey: job.sessionKey,
+        });
         if (
           heartbeatResult.status !== "skipped" ||
           heartbeatResult.reason !== "requests-in-flight"
@@ -460,7 +465,11 @@ async function executeJobCore(
           break;
         }
         if (state.deps.nowMs() - waitStartedAt > maxWaitMs) {
-          state.deps.requestHeartbeatNow({ reason });
+          state.deps.requestHeartbeatNow({
+            reason,
+            agentId: job.agentId,
+            sessionKey: job.sessionKey,
+          });
           return { status: "ok", summary: text };
         }
         await delay(retryDelayMs);
@@ -474,7 +483,11 @@ async function executeJobCore(
         return { status: "error", error: heartbeatResult.reason, summary: text };
       }
     } else {
-      state.deps.requestHeartbeatNow({ reason: `cron:${job.id}` });
+      state.deps.requestHeartbeatNow({
+        reason: `cron:${job.id}`,
+        agentId: job.agentId,
+        sessionKey: job.sessionKey,
+      });
       return { status: "ok", summary: text };
     }
   }
@@ -502,10 +515,15 @@ async function executeJobCore(
       res.status === "error" ? `${prefix} (error): ${summaryText}` : `${prefix}: ${summaryText}`;
     state.deps.enqueueSystemEvent(label, {
       agentId: job.agentId,
+      sessionKey: job.sessionKey,
       contextKey: `cron:${job.id}`,
     });
     if (job.wakeMode === "now") {
-      state.deps.requestHeartbeatNow({ reason: `cron:${job.id}` });
+      state.deps.requestHeartbeatNow({
+        reason: `cron:${job.id}`,
+        agentId: job.agentId,
+        sessionKey: job.sessionKey,
+      });
     }
   }
 

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -68,6 +68,8 @@ export type CronJobState = {
 export type CronJob = {
   id: string;
   agentId?: string;
+  /** Origin session namespace for reminder delivery and wake routing. */
+  sessionKey?: string;
   name: string;
   description?: string;
   enabled: boolean;

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -135,6 +135,7 @@ export const CronJobSchema = Type.Object(
   {
     id: NonEmptyString,
     agentId: Type.Optional(NonEmptyString),
+    sessionKey: Type.Optional(NonEmptyString),
     name: NonEmptyString,
     description: Type.Optional(Type.String()),
     enabled: Type.Boolean(),
@@ -164,6 +165,7 @@ export const CronAddParamsSchema = Type.Object(
   {
     name: NonEmptyString,
     agentId: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+    sessionKey: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
     description: Type.Optional(Type.String()),
     enabled: Type.Optional(Type.Boolean()),
     deleteAfterRun: Type.Optional(Type.Boolean()),
@@ -180,6 +182,7 @@ export const CronJobPatchSchema = Type.Object(
   {
     name: Type.Optional(NonEmptyString),
     agentId: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
+    sessionKey: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
     description: Type.Optional(Type.String()),
     enabled: Type.Optional(Type.Boolean()),
     deleteAfterRun: Type.Optional(Type.Boolean()),

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -1,7 +1,11 @@
 import type { CliDeps } from "../cli/deps.js";
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { loadConfig } from "../config/config.js";
-import { resolveAgentMainSessionKey } from "../config/sessions.js";
+import {
+  canonicalizeMainSessionAlias,
+  resolveAgentIdFromSessionKey,
+  resolveAgentMainSessionKey,
+} from "../config/sessions.js";
 import { resolveStorePath } from "../config/sessions/paths.js";
 import { runCronIsolatedAgentTurn } from "../cron/isolated-agent.js";
 import { appendCronRunLog, resolveCronRunLogPath } from "../cron/run-log.js";
@@ -82,6 +86,35 @@ export function buildGatewayCronService(params: {
     return { agentId, cfg: runtimeConfig };
   };
 
+  const resolveCronSessionKey = (params: {
+    runtimeConfig: ReturnType<typeof loadConfig>;
+    agentId: string;
+    requestedSessionKey?: string | null;
+  }) => {
+    const requested = params.requestedSessionKey?.trim();
+    if (!requested) {
+      return resolveAgentMainSessionKey({
+        cfg: params.runtimeConfig,
+        agentId: params.agentId,
+      });
+    }
+    const canonical = canonicalizeMainSessionAlias({
+      cfg: params.runtimeConfig,
+      agentId: params.agentId,
+      sessionKey: requested,
+    });
+    if (canonical !== "global") {
+      const sessionAgentId = resolveAgentIdFromSessionKey(canonical);
+      if (normalizeAgentId(sessionAgentId) !== normalizeAgentId(params.agentId)) {
+        return resolveAgentMainSessionKey({
+          cfg: params.runtimeConfig,
+          agentId: params.agentId,
+        });
+      }
+    }
+    return canonical;
+  };
+
   const defaultAgentId = resolveDefaultAgentId(params.cfg);
   const resolveSessionStorePath = (agentId?: string) =>
     resolveStorePath(params.cfg.session?.store, {
@@ -99,20 +132,58 @@ export function buildGatewayCronService(params: {
     sessionStorePath,
     enqueueSystemEvent: (text, opts) => {
       const { agentId, cfg: runtimeConfig } = resolveCronAgent(opts?.agentId);
-      const sessionKey = resolveAgentMainSessionKey({
-        cfg: runtimeConfig,
+      const sessionKey = resolveCronSessionKey({
+        runtimeConfig,
         agentId,
+        requestedSessionKey: opts?.sessionKey,
       });
       enqueueSystemEvent(text, { sessionKey, contextKey: opts?.contextKey });
     },
-    requestHeartbeatNow,
+    requestHeartbeatNow: (opts) => {
+      const runtimeConfig = loadConfig();
+      const requestedAgentId = opts?.agentId ? resolveCronAgent(opts.agentId).agentId : undefined;
+      const derivedAgentId =
+        requestedAgentId ??
+        (opts?.sessionKey
+          ? normalizeAgentId(resolveAgentIdFromSessionKey(opts.sessionKey))
+          : undefined);
+      const agentId = derivedAgentId || undefined;
+      const sessionKey =
+        opts?.sessionKey && agentId
+          ? resolveCronSessionKey({
+              runtimeConfig,
+              agentId,
+              requestedSessionKey: opts.sessionKey,
+            })
+          : undefined;
+      requestHeartbeatNow({
+        reason: opts?.reason,
+        agentId,
+        sessionKey,
+      });
+    },
     runHeartbeatOnce: async (opts) => {
       const runtimeConfig = loadConfig();
-      const agentId = opts?.agentId ? resolveCronAgent(opts.agentId).agentId : undefined;
+      const requestedAgentId = opts?.agentId ? resolveCronAgent(opts.agentId).agentId : undefined;
+      const derivedAgentId =
+        requestedAgentId ??
+        (opts?.sessionKey
+          ? normalizeAgentId(resolveAgentIdFromSessionKey(opts.sessionKey))
+          : undefined);
+      const agentId = derivedAgentId || undefined;
+      const sessionKey =
+        opts?.sessionKey && agentId
+          ? resolveCronSessionKey({
+              runtimeConfig,
+              agentId,
+              requestedSessionKey: opts.sessionKey,
+            })
+          : undefined;
       return await runHeartbeatOnce({
         cfg: runtimeConfig,
         reason: opts?.reason,
         agentId,
+        sessionKey,
         deps: { ...params.deps, runtime: defaultRuntime },
       });
     },

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -708,6 +708,81 @@ describe("runHeartbeatOnce", () => {
     }
   });
 
+  it("runs heartbeats in forced session key overrides passed at call time", async () => {
+    const tmpDir = await createCaseDir("hb-forced-session-override");
+    const storePath = path.join(tmpDir, "sessions.json");
+    const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
+    try {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: {
+              every: "5m",
+              target: "last",
+            },
+          },
+        },
+        channels: { whatsapp: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const mainSessionKey = resolveMainSessionKey(cfg);
+      const agentId = resolveAgentIdFromSessionKey(mainSessionKey);
+      const forcedSessionKey = buildAgentPeerSessionKey({
+        agentId,
+        channel: "whatsapp",
+        peerKind: "dm",
+        peerId: "+15559990000",
+      });
+
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [mainSessionKey]: {
+            sessionId: "sid-main",
+            updatedAt: Date.now(),
+            lastChannel: "whatsapp",
+            lastTo: "+1555",
+          },
+          [forcedSessionKey]: {
+            sessionId: "sid-forced",
+            updatedAt: Date.now() + 10_000,
+            lastChannel: "whatsapp",
+            lastTo: "+15559990000",
+          },
+        }),
+      );
+
+      replySpy.mockResolvedValue([{ text: "Forced alert" }]);
+      const sendWhatsApp = vi.fn().mockResolvedValue({
+        messageId: "m1",
+        toJid: "jid",
+      });
+
+      await runHeartbeatOnce({
+        cfg,
+        sessionKey: forcedSessionKey,
+        deps: {
+          sendWhatsApp,
+          getQueueSize: () => 0,
+          nowMs: () => 0,
+          webAuthExists: async () => true,
+          hasActiveWebListener: () => true,
+        },
+      });
+
+      expect(sendWhatsApp).toHaveBeenCalledTimes(1);
+      expect(sendWhatsApp).toHaveBeenCalledWith("+15559990000", "Forced alert", expect.any(Object));
+      expect(replySpy).toHaveBeenCalledWith(
+        expect.objectContaining({ SessionKey: forcedSessionKey }),
+        expect.objectContaining({ isHeartbeat: true }),
+        cfg,
+      );
+    } finally {
+      replySpy.mockRestore();
+    }
+  });
+
   it("suppresses duplicate heartbeat payloads within 24h", async () => {
     const tmpDir = await createCaseDir("hb-dup-suppress");
     const storePath = path.join(tmpDir, "sessions.json");

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -257,6 +257,7 @@ function resolveHeartbeatSession(
   cfg: OpenClawConfig,
   agentId?: string,
   heartbeat?: HeartbeatConfig,
+  forcedSessionKey?: string,
 ) {
   const sessionCfg = cfg.session;
   const scope = sessionCfg?.scope ?? "per-sender";
@@ -272,6 +273,31 @@ function resolveHeartbeatSession(
 
   if (scope === "global") {
     return { sessionKey: mainSessionKey, storePath, store, entry: mainEntry };
+  }
+
+  const forced = forcedSessionKey?.trim();
+  if (forced) {
+    const forcedCandidate = toAgentStoreSessionKey({
+      agentId: resolvedAgentId,
+      requestKey: forced,
+      mainKey: cfg.session?.mainKey,
+    });
+    const forcedCanonical = canonicalizeMainSessionAlias({
+      cfg,
+      agentId: resolvedAgentId,
+      sessionKey: forcedCandidate,
+    });
+    if (forcedCanonical !== "global") {
+      const sessionAgentId = resolveAgentIdFromSessionKey(forcedCanonical);
+      if (sessionAgentId === normalizeAgentId(resolvedAgentId)) {
+        return {
+          sessionKey: forcedCanonical,
+          storePath,
+          store,
+          entry: store[forcedCanonical],
+        };
+      }
+    }
   }
 
   const trimmed = heartbeat?.session?.trim() ?? "";
@@ -377,6 +403,7 @@ function normalizeHeartbeatReply(
 export async function runHeartbeatOnce(opts: {
   cfg?: OpenClawConfig;
   agentId?: string;
+  sessionKey?: string;
   heartbeat?: HeartbeatConfig;
   reason?: string;
   deps?: HeartbeatDeps;
@@ -433,7 +460,12 @@ export async function runHeartbeatOnce(opts: {
     // The LLM prompt says "if it exists" so this is expected behavior.
   }
 
-  const { entry, sessionKey, storePath } = resolveHeartbeatSession(cfg, agentId, heartbeat);
+  const { entry, sessionKey, storePath } = resolveHeartbeatSession(
+    cfg,
+    agentId,
+    heartbeat,
+    opts.sessionKey,
+  );
   const previousUpdatedAt = entry?.updatedAt;
   const delivery = resolveHeartbeatDeliveryTarget({ cfg, entry, heartbeat });
   const heartbeatAccountId = heartbeat?.accountId?.trim();
@@ -896,10 +928,44 @@ export function startHeartbeatRunner(opts: {
     }
 
     const reason = params?.reason;
+    const requestedAgentId = params?.agentId ? normalizeAgentId(params.agentId) : undefined;
+    const requestedSessionKey = params?.sessionKey?.trim() || undefined;
     const isInterval = reason === "interval";
     const startedAt = Date.now();
     const now = startedAt;
     let ran = false;
+
+    if (requestedSessionKey || requestedAgentId) {
+      const targetAgentId = requestedAgentId ?? resolveAgentIdFromSessionKey(requestedSessionKey);
+      const targetAgent = state.agents.get(targetAgentId);
+      if (!targetAgent) {
+        scheduleNext();
+        return { status: "skipped", reason: "disabled" };
+      }
+      try {
+        const res = await runOnce({
+          cfg: state.cfg,
+          agentId: targetAgent.agentId,
+          heartbeat: targetAgent.heartbeat,
+          reason,
+          sessionKey: requestedSessionKey,
+          deps: { runtime: state.runtime },
+        });
+        if (res.status !== "skipped" || res.reason !== "disabled") {
+          advanceAgentSchedule(targetAgent, now);
+        }
+        scheduleNext();
+        return res.status === "ran" ? { status: "ran", durationMs: Date.now() - startedAt } : res;
+      } catch (err) {
+        const errMsg = formatErrorMessage(err);
+        log.error(`heartbeat runner: targeted runOnce threw unexpectedly: ${errMsg}`, {
+          error: errMsg,
+        });
+        advanceAgentSchedule(targetAgent, now);
+        scheduleNext();
+        return { status: "failed", reason: errMsg };
+      }
+    }
 
     for (const agent of state.agents.values()) {
       if (isInterval && now < agent.nextDueMs) {
@@ -943,7 +1009,12 @@ export function startHeartbeatRunner(opts: {
     return { status: "skipped", reason: isInterval ? "not-due" : "disabled" };
   };
 
-  const wakeHandler: HeartbeatWakeHandler = async (params) => run({ reason: params.reason });
+  const wakeHandler: HeartbeatWakeHandler = async (params) =>
+    run({
+      reason: params.reason,
+      agentId: params.agentId,
+      sessionKey: params.sessionKey,
+    });
   const disposeWakeHandler = setHeartbeatWakeHandler(wakeHandler);
   updateConfig(state.cfg);
 

--- a/src/infra/heartbeat-wake.test.ts
+++ b/src/infra/heartbeat-wake.test.ts
@@ -247,4 +247,36 @@ describe("heartbeat-wake", () => {
     expect(handler).toHaveBeenCalledWith({ reason: "manual" });
     expect(hasPendingHeartbeatWake()).toBe(false);
   });
+
+  it("forwards wake target fields and preserves them across retries", async () => {
+    vi.useFakeTimers();
+    const handler = vi
+      .fn()
+      .mockResolvedValueOnce({ status: "skipped", reason: "requests-in-flight" })
+      .mockResolvedValueOnce({ status: "ran", durationMs: 1 });
+    setHeartbeatWakeHandler(handler);
+
+    requestHeartbeatNow({
+      reason: "cron:job-1",
+      agentId: "ops",
+      sessionKey: "agent:ops:discord:channel:alerts",
+      coalesceMs: 0,
+    });
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler.mock.calls[0]?.[0]).toEqual({
+      reason: "cron:job-1",
+      agentId: "ops",
+      sessionKey: "agent:ops:discord:channel:alerts",
+    });
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(handler.mock.calls[1]?.[0]).toEqual({
+      reason: "cron:job-1",
+      agentId: "ops",
+      sessionKey: "agent:ops:discord:channel:alerts",
+    });
+  });
 });

--- a/src/slack/monitor.tool-result.test.ts
+++ b/src/slack/monitor.tool-result.test.ts
@@ -24,6 +24,29 @@ beforeEach(() => {
 });
 
 describe("monitorSlackProvider tool results", () => {
+  type SlackMessageEvent = {
+    type: "message";
+    user: string;
+    text: string;
+    ts: string;
+    channel: string;
+    channel_type: "im" | "channel";
+    thread_ts?: string;
+    parent_user_id?: string;
+  };
+
+  function makeSlackMessageEvent(overrides: Partial<SlackMessageEvent> = {}): SlackMessageEvent {
+    return {
+      type: "message",
+      user: "U1",
+      text: "hello",
+      ts: "123",
+      channel: "C1",
+      channel_type: "im",
+      ...overrides,
+    };
+  }
+
   function setDirectMessageReplyMode(replyToMode: "off" | "all" | "first") {
     slackTestState.config = {
       messages: {
@@ -42,29 +65,18 @@ describe("monitorSlackProvider tool results", () => {
 
   async function runDirectMessageEvent(ts: string, extraEvent: Record<string, unknown> = {}) {
     await runSlackMessageOnce(monitorSlackProvider, {
-      event: {
-        type: "message",
-        user: "U1",
-        text: "hello",
-        ts,
-        channel: "C1",
-        channel_type: "im",
-        ...extraEvent,
-      },
+      event: makeSlackMessageEvent({ ts, ...extraEvent }),
     });
   }
 
   async function runChannelThreadReplyEvent() {
     await runSlackMessageOnce(monitorSlackProvider, {
-      event: {
-        type: "message",
-        user: "U1",
+      event: makeSlackMessageEvent({
         text: "thread reply",
         ts: "123.456",
         thread_ts: "111.222",
-        channel: "C1",
         channel_type: "channel",
-      },
+      }),
     });
   }
 
@@ -72,14 +84,7 @@ describe("monitorSlackProvider tool results", () => {
     replyMock.mockResolvedValue({ text: "final reply" });
 
     await runSlackMessageOnce(monitorSlackProvider, {
-      event: {
-        type: "message",
-        user: "U1",
-        text: "hello",
-        ts: "123",
-        channel: "C1",
-        channel_type: "im",
-      },
+      event: makeSlackMessageEvent(),
     });
 
     expect(sendMock).toHaveBeenCalledTimes(1);
@@ -101,14 +106,7 @@ describe("monitorSlackProvider tool results", () => {
       monitorSlackProvider,
       {
         body: { api_app_id: "A2", team_id: "T1" },
-        event: {
-          type: "message",
-          user: "U1",
-          text: "hello",
-          ts: "123",
-          channel: "C1",
-          channel_type: "im",
-        },
+        event: makeSlackMessageEvent(),
       },
       { appToken: "xapp-1-A1-abc" },
     );
@@ -150,14 +148,7 @@ describe("monitorSlackProvider tool results", () => {
     replyMock.mockResolvedValue({ text: "final reply" });
 
     await runSlackMessageOnce(monitorSlackProvider, {
-      event: {
-        type: "message",
-        user: "U1",
-        text: "hello",
-        ts: "123",
-        channel: "C1",
-        channel_type: "im",
-      },
+      event: makeSlackMessageEvent(),
     });
 
     expect(sendMock).toHaveBeenCalledTimes(1);
@@ -289,14 +280,7 @@ describe("monitorSlackProvider tool results", () => {
     });
 
     await runSlackMessageOnce(monitorSlackProvider, {
-      event: {
-        type: "message",
-        user: "U1",
-        text: "hello",
-        ts: "123",
-        channel: "C1",
-        channel_type: "im",
-      },
+      event: makeSlackMessageEvent(),
     });
 
     const client = getSlackClient() as {
@@ -334,14 +318,10 @@ describe("monitorSlackProvider tool results", () => {
     replyMock.mockResolvedValue({ text: "hi" });
 
     await runSlackMessageOnce(monitorSlackProvider, {
-      event: {
-        type: "message",
-        user: "U1",
+      event: makeSlackMessageEvent({
         text,
-        ts: "123",
-        channel: "C1",
         channel_type: "channel",
-      },
+      }),
     });
 
     expect(replyMock).toHaveBeenCalledTimes(1);
@@ -368,16 +348,13 @@ describe("monitorSlackProvider tool results", () => {
     replyMock.mockResolvedValue({ text: "hi" });
 
     await runSlackMessageOnce(monitorSlackProvider, {
-      event: {
-        type: "message",
-        user: "U1",
+      event: makeSlackMessageEvent({
         text: "following up",
         ts: "124",
         thread_ts: "123",
         parent_user_id: "bot-user",
-        channel: "C1",
         channel_type: "channel",
-      },
+      }),
     });
 
     expect(replyMock).toHaveBeenCalledTimes(1);
@@ -397,14 +374,9 @@ describe("monitorSlackProvider tool results", () => {
     replyMock.mockResolvedValue({ text: "hi" });
 
     await runSlackMessageOnce(monitorSlackProvider, {
-      event: {
-        type: "message",
-        user: "U1",
-        text: "hello",
-        ts: "123",
-        channel: "C1",
+      event: makeSlackMessageEvent({
         channel_type: "channel",
-      },
+      }),
     });
 
     expect(replyMock).toHaveBeenCalledTimes(1);
@@ -416,14 +388,10 @@ describe("monitorSlackProvider tool results", () => {
     replyMock.mockResolvedValue({ text: "ok" });
 
     await runSlackMessageOnce(monitorSlackProvider, {
-      event: {
-        type: "message",
-        user: "U1",
+      event: makeSlackMessageEvent({
         text: "/elevated off",
-        ts: "123",
-        channel: "C1",
         channel_type: "channel",
-      },
+      }),
     });
 
     expect(replyMock).toHaveBeenCalledTimes(1);
@@ -472,14 +440,9 @@ describe("monitorSlackProvider tool results", () => {
     };
 
     await runSlackMessageOnce(monitorSlackProvider, {
-      event: {
-        type: "message",
-        user: "U1",
-        text: "hello",
+      event: makeSlackMessageEvent({
         ts: "789",
-        channel: "C1",
-        channel_type: "im",
-      },
+      }),
     });
 
     expect(sendMock).toHaveBeenCalledTimes(1);
@@ -500,14 +463,11 @@ describe("monitorSlackProvider tool results", () => {
     });
 
     await runSlackMessageOnce(monitorSlackProvider, {
-      event: {
-        type: "message",
-        user: "U1",
+      event: makeSlackMessageEvent({
         text: "<@bot-user> hello",
         ts: "456",
-        channel: "C1",
         channel_type: "channel",
-      },
+      }),
     });
 
     expect(reactMock).toHaveBeenCalledWith({
@@ -530,14 +490,7 @@ describe("monitorSlackProvider tool results", () => {
     };
 
     await runSlackMessageOnce(monitorSlackProvider, {
-      event: {
-        type: "message",
-        user: "U1",
-        text: "hello",
-        ts: "123",
-        channel: "C1",
-        channel_type: "im",
-      },
+      event: makeSlackMessageEvent(),
     });
 
     expect(replyMock).not.toHaveBeenCalled();
@@ -565,14 +518,7 @@ describe("monitorSlackProvider tool results", () => {
     const { controller, run } = startSlackMonitor(monitorSlackProvider);
     const handler = await getSlackHandlerOrThrow("message");
 
-    const baseEvent = {
-      type: "message",
-      user: "U1",
-      text: "hello",
-      ts: "123",
-      channel: "C1",
-      channel_type: "im",
-    };
+    const baseEvent = makeSlackMessageEvent();
 
     await handler({ event: baseEvent });
     await handler({ event: { ...baseEvent, ts: "124", text: "hello again" } });
@@ -595,16 +541,10 @@ describe("monitorSlackProvider tool results", () => {
     replyMock.mockResolvedValue({ text: "thread reply" });
 
     await runSlackMessageOnce(monitorSlackProvider, {
-      event: {
-        type: "message",
-        user: "U1",
-        text: "hello",
-        ts: "123",
+      event: makeSlackMessageEvent({
         thread_ts: "123",
         parent_user_id: "U2",
-        channel: "C1",
-        channel_type: "im",
-      },
+      }),
     });
 
     expect(replyMock).toHaveBeenCalledTimes(1);
@@ -631,15 +571,10 @@ describe("monitorSlackProvider tool results", () => {
     };
 
     await runSlackMessageOnce(monitorSlackProvider, {
-      event: {
-        type: "message",
-        user: "U1",
-        text: "hello",
-        ts: "123",
+      event: makeSlackMessageEvent({
         thread_ts: "111.222",
-        channel: "C1",
         channel_type: "channel",
-      },
+      }),
     });
 
     expect(replyMock).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Summary
- add `sessionKey` support to cron job types/schemas/normalization/store migration
- stamp cron jobs created from tool calls with caller `sessionKey` (without overriding explicit values)
- propagate `sessionKey` through cron main-session execution (`enqueueSystemEvent`, `runHeartbeatOnce`, `requestHeartbeatNow`)
- carry wake targets (`agentId`, `sessionKey`) through heartbeat wake queue/retries and targeted heartbeat runner execution
- fix gateway cron bridge so session-scoped wake routing also works when a job has `sessionKey` but no explicit `agentId`

## Tests
- `pnpm test src/infra/heartbeat-wake.test.ts src/infra/heartbeat-runner.scheduler.test.ts src/infra/heartbeat-runner.returns-default-unset.test.ts src/cron/normalize.test.ts src/cron/service.runs-one-shot-main-job-disables-it.test.ts src/cron/service.store.migration.test.ts`
- `pnpm exec vitest run --config vitest.e2e.config.ts src/agents/tools/cron-tool.e2e.test.ts src/gateway/server.cron.e2e.test.ts`
- `pnpm check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `sessionKey` support to the cron job system, enabling reminders and wake events to be routed to the originating session namespace rather than always going to the main session.

- Adds `sessionKey` field to `CronJob` type, gateway protocol schemas, normalization, and store migration
- The cron tool auto-stamps new jobs with the caller's `sessionKey` (without overriding explicit values), mirroring the existing `agentId` stamping pattern
- Propagates `sessionKey` through `enqueueSystemEvent`, `runHeartbeatOnce`, and `requestHeartbeatNow` in the cron timer execution path
- Extends the heartbeat wake queue and runner to carry `agentId`/`sessionKey` targets, including a new fast-path in the runner for targeted wakes that bypasses the round-robin agent loop
- Adds `resolveCronSessionKey` in the gateway cron bridge to derive the correct session key even when only `sessionKey` (no explicit `agentId`) is present
- Comprehensive test coverage across all layers: normalization, store migration, cron tool stamping, heartbeat wake forwarding, targeted heartbeat runner execution, and forced session key overrides

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it extends existing patterns consistently across the stack with thorough test coverage.
- The changes follow established patterns (`agentId` handling), have comprehensive tests at each layer, and include proper validation/normalization. The duplicated agent derivation logic in `server-cron.ts` is a minor style concern but functionally correct. No security issues or logic errors found.
- `src/gateway/server-cron.ts` has duplicated agent derivation logic in the `requestHeartbeatNow` and `runHeartbeatOnce` callbacks that could be extracted into a shared helper.

<sub>Last reviewed commit: a9dc254</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->