### PR TITLE
fix: syncs all credential types to agent auth.json

### DIFF
--- a/src/agents/pi-auth-json.test.ts
+++ b/src/agents/pi-auth-json.test.ts
@@ -39,4 +39,153 @@ describe("ensurePiAuthJsonFromAuthProfiles", () => {
     const second = await ensurePiAuthJsonFromAuthProfiles(agentDir);
     expect(second.wrote).toBe(false);
   });
+
+  it("writes api_key credentials into auth.json", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-agent-"));
+
+    saveAuthProfileStore(
+      {
+        version: 1,
+        profiles: {
+          "openrouter:default": {
+            type: "api_key",
+            provider: "openrouter",
+            key: "sk-or-v1-test-key",
+          },
+        },
+      },
+      agentDir,
+    );
+
+    const result = await ensurePiAuthJsonFromAuthProfiles(agentDir);
+    expect(result.wrote).toBe(true);
+
+    const authPath = path.join(agentDir, "auth.json");
+    const auth = JSON.parse(await fs.readFile(authPath, "utf8")) as Record<string, unknown>;
+    expect(auth["openrouter"]).toMatchObject({
+      type: "api_key",
+      key: "sk-or-v1-test-key",
+    });
+  });
+
+  it("writes token credentials as api_key into auth.json", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-agent-"));
+
+    saveAuthProfileStore(
+      {
+        version: 1,
+        profiles: {
+          "anthropic:default": {
+            type: "token",
+            provider: "anthropic",
+            token: "sk-ant-test-token",
+          },
+        },
+      },
+      agentDir,
+    );
+
+    const result = await ensurePiAuthJsonFromAuthProfiles(agentDir);
+    expect(result.wrote).toBe(true);
+
+    const authPath = path.join(agentDir, "auth.json");
+    const auth = JSON.parse(await fs.readFile(authPath, "utf8")) as Record<string, unknown>;
+    expect(auth["anthropic"]).toMatchObject({
+      type: "api_key",
+      key: "sk-ant-test-token",
+    });
+  });
+
+  it("syncs multiple providers at once", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-agent-"));
+
+    saveAuthProfileStore(
+      {
+        version: 1,
+        profiles: {
+          "openrouter:default": {
+            type: "api_key",
+            provider: "openrouter",
+            key: "sk-or-key",
+          },
+          "anthropic:default": {
+            type: "token",
+            provider: "anthropic",
+            token: "sk-ant-token",
+          },
+          "openai-codex:default": {
+            type: "oauth",
+            provider: "openai-codex",
+            access: "access",
+            refresh: "refresh",
+            expires: Date.now() + 60_000,
+          },
+        },
+      },
+      agentDir,
+    );
+
+    const result = await ensurePiAuthJsonFromAuthProfiles(agentDir);
+    expect(result.wrote).toBe(true);
+
+    const authPath = path.join(agentDir, "auth.json");
+    const auth = JSON.parse(await fs.readFile(authPath, "utf8")) as Record<string, unknown>;
+
+    expect(auth["openrouter"]).toMatchObject({ type: "api_key", key: "sk-or-key" });
+    expect(auth["anthropic"]).toMatchObject({ type: "api_key", key: "sk-ant-token" });
+    expect(auth["openai-codex"]).toMatchObject({ type: "oauth", access: "access" });
+  });
+
+  it("skips profiles with empty keys", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-agent-"));
+
+    saveAuthProfileStore(
+      {
+        version: 1,
+        profiles: {
+          "openrouter:default": {
+            type: "api_key",
+            provider: "openrouter",
+            key: "",
+          },
+        },
+      },
+      agentDir,
+    );
+
+    const result = await ensurePiAuthJsonFromAuthProfiles(agentDir);
+    expect(result.wrote).toBe(false);
+  });
+
+  it("preserves existing auth.json entries not in auth-profiles", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-agent-"));
+    const authPath = path.join(agentDir, "auth.json");
+
+    // Pre-populate auth.json with an entry
+    await fs.mkdir(agentDir, { recursive: true });
+    await fs.writeFile(
+      authPath,
+      JSON.stringify({ "legacy-provider": { type: "api_key", key: "legacy-key" } }),
+    );
+
+    saveAuthProfileStore(
+      {
+        version: 1,
+        profiles: {
+          "openrouter:default": {
+            type: "api_key",
+            provider: "openrouter",
+            key: "new-key",
+          },
+        },
+      },
+      agentDir,
+    );
+
+    await ensurePiAuthJsonFromAuthProfiles(agentDir);
+
+    const auth = JSON.parse(await fs.readFile(authPath, "utf8")) as Record<string, unknown>;
+    expect(auth["legacy-provider"]).toMatchObject({ type: "api_key", key: "legacy-key" });
+    expect(auth["openrouter"]).toMatchObject({ type: "api_key", key: "new-key" });
+  });
 });

--- a/src/agents/pi-auth-json.ts
+++ b/src/agents/pi-auth-json.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { ensureAuthProfileStore, listProfilesForProvider } from "./auth-profiles.js";
+import type { AuthProfileCredential } from "./auth-profiles/types.js";
+import { ensureAuthProfileStore } from "./auth-profiles.js";
 
 type AuthJsonCredential =
   | {
@@ -31,70 +32,119 @@ async function readAuthJson(filePath: string): Promise<AuthJsonShape> {
 }
 
 /**
- * pi-coding-agent's ModelRegistry/AuthStorage expects OAuth credentials in auth.json.
+ * Convert an OpenClaw auth-profiles credential to pi-coding-agent auth.json format.
+ * Returns null if the credential cannot be converted.
+ */
+function convertCredential(cred: AuthProfileCredential): AuthJsonCredential | null {
+  if (cred.type === "api_key") {
+    const key = typeof cred.key === "string" ? cred.key.trim() : "";
+    if (!key) {
+      return null;
+    }
+    return { type: "api_key", key };
+  }
+
+  if (cred.type === "token") {
+    // pi-coding-agent treats static tokens as api_key type
+    const token = typeof cred.token === "string" ? cred.token.trim() : "";
+    if (!token) {
+      return null;
+    }
+    return { type: "api_key", key: token };
+  }
+
+  if (cred.type === "oauth") {
+    const accessRaw = (cred as { access?: unknown }).access;
+    const refreshRaw = (cred as { refresh?: unknown }).refresh;
+    const expiresRaw = (cred as { expires?: unknown }).expires;
+
+    const access = typeof accessRaw === "string" ? accessRaw.trim() : "";
+    const refresh = typeof refreshRaw === "string" ? refreshRaw.trim() : "";
+    const expires = typeof expiresRaw === "number" ? expiresRaw : Number.NaN;
+
+    if (!access || !refresh || !Number.isFinite(expires) || expires <= 0) {
+      return null;
+    }
+    return { type: "oauth", access, refresh, expires };
+  }
+
+  return null;
+}
+
+/**
+ * Check if two auth.json credentials are equivalent.
+ */
+function credentialsEqual(a: AuthJsonCredential | undefined, b: AuthJsonCredential): boolean {
+  if (!a || typeof a !== "object") {
+    return false;
+  }
+  if (a.type !== b.type) {
+    return false;
+  }
+
+  if (a.type === "api_key" && b.type === "api_key") {
+    return a.key === b.key;
+  }
+
+  if (a.type === "oauth" && b.type === "oauth") {
+    return a.access === b.access && a.refresh === b.refresh && a.expires === b.expires;
+  }
+
+  return false;
+}
+
+/**
+ * pi-coding-agent's ModelRegistry/AuthStorage expects credentials in auth.json.
  *
- * OpenClaw stores OAuth credentials in auth-profiles.json instead. This helper
- * bridges a subset of credentials into agentDir/auth.json so pi-coding-agent can
- * (a) consider the provider authenticated and (b) include built-in models in its
+ * OpenClaw stores credentials in auth-profiles.json instead. This helper
+ * bridges all credentials into agentDir/auth.json so pi-coding-agent can
+ * (a) consider providers authenticated and (b) include built-in models in its
  * registry/catalog output.
  *
- * Currently used for openai-codex.
+ * Syncs all credential types: api_key, token (as api_key), and oauth.
  */
 export async function ensurePiAuthJsonFromAuthProfiles(agentDir: string): Promise<{
   wrote: boolean;
   authPath: string;
 }> {
   const store = ensureAuthProfileStore(agentDir, { allowKeychainPrompt: false });
-  const codexProfiles = listProfilesForProvider(store, "openai-codex");
-  if (codexProfiles.length === 0) {
-    return { wrote: false, authPath: path.join(agentDir, "auth.json") };
-  }
-
-  const profileId = codexProfiles[0];
-  const cred = profileId ? store.profiles[profileId] : undefined;
-  if (!cred || cred.type !== "oauth") {
-    return { wrote: false, authPath: path.join(agentDir, "auth.json") };
-  }
-
-  const accessRaw = (cred as { access?: unknown }).access;
-  const refreshRaw = (cred as { refresh?: unknown }).refresh;
-  const expiresRaw = (cred as { expires?: unknown }).expires;
-
-  const access = typeof accessRaw === "string" ? accessRaw.trim() : "";
-  const refresh = typeof refreshRaw === "string" ? refreshRaw.trim() : "";
-  const expires = typeof expiresRaw === "number" ? expiresRaw : Number.NaN;
-
-  if (!access || !refresh || !Number.isFinite(expires) || expires <= 0) {
-    return { wrote: false, authPath: path.join(agentDir, "auth.json") };
-  }
-
   const authPath = path.join(agentDir, "auth.json");
-  const next = await readAuthJson(authPath);
 
-  const existing = next["openai-codex"];
-  const desired: AuthJsonCredential = {
-    type: "oauth",
-    access,
-    refresh,
-    expires,
-  };
+  // Group profiles by provider, taking the first valid profile for each
+  const providerCredentials = new Map<string, AuthJsonCredential>();
 
-  const isSame =
-    existing &&
-    typeof existing === "object" &&
-    (existing as { type?: unknown }).type === "oauth" &&
-    (existing as { access?: unknown }).access === access &&
-    (existing as { refresh?: unknown }).refresh === refresh &&
-    (existing as { expires?: unknown }).expires === expires;
+  for (const [, cred] of Object.entries(store.profiles)) {
+    const provider = cred.provider;
+    if (!provider || providerCredentials.has(provider)) {
+      continue;
+    }
 
-  if (isSame) {
+    const converted = convertCredential(cred);
+    if (converted) {
+      providerCredentials.set(provider, converted);
+    }
+  }
+
+  if (providerCredentials.size === 0) {
     return { wrote: false, authPath };
   }
 
-  next["openai-codex"] = desired;
+  const existing = await readAuthJson(authPath);
+  let changed = false;
+
+  for (const [provider, cred] of providerCredentials) {
+    if (!credentialsEqual(existing[provider], cred)) {
+      existing[provider] = cred;
+      changed = true;
+    }
+  }
+
+  if (!changed) {
+    return { wrote: false, authPath };
+  }
 
   await fs.mkdir(agentDir, { recursive: true, mode: 0o700 });
-  await fs.writeFile(authPath, `${JSON.stringify(next, null, 2)}\n`, { mode: 0o600 });
+  await fs.writeFile(authPath, `${JSON.stringify(existing, null, 2)}\n`, { mode: 0o600 });
 
   return { wrote: true, authPath };
 }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: The `pi-coding-agent`'s `auth.json` file only synchronized `oauth` credentials for the `openai-codex` provider from OpenClaw's `auth-profiles.json`. Other credential types (like `api_key`, `token`) and providers were not synced.
- Why it matters: This limitation prevented the `pi-coding-agent` from automatically utilizing a wider range of authenticated providers and models configured in `auth-profiles.json`, requiring manual `auth.json` management.
- What changed: The `ensurePiAuthJsonFromAuthProfiles` function now supports syncing all credential types: `api_key`, `token` (converted to `api_key`), and `oauth` for all configured providers in `auth-profiles.json`. It also correctly handles skipping profiles with empty keys and preserves existing `auth.json` entries not managed by `auth-profiles`.
- What did NOT change (scope boundary): The fundamental structure or management of `auth-profiles.json` itself remains unchanged. The change focuses solely on bridging these profiles to `auth.json`.

## Linked Issue/PR

- Closes #18610

## User-visible / Behavior Changes

`pi-coding-agent` will now automatically recognize and use `api_key`, `token` (as `api_key`), and `oauth` credentials configured through OpenClaw's `auth-profiles` for all providers. Previously, this automatic synchronization was limited to `openai-codex` with OAuth. Users no longer need to manually manage `auth.json` for these credential types for the agent.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Generalizes `ensurePiAuthJsonFromAuthProfiles` from syncing only `openai-codex` OAuth credentials to syncing all credential types (`api_key`, `token` as `api_key`, and `oauth`) for all providers configured in `auth-profiles.json`. The refactored code extracts credential conversion and equality comparison into dedicated helper functions (`convertCredential`, `credentialsEqual`), iterates all profiles grouped by provider (first valid wins), merges into existing `auth.json` preserving unmanaged entries, and only writes when changes are detected.

- Adds `convertCredential()` to handle `api_key`, `token` → `api_key`, and `oauth` credential conversion with empty/invalid value guards
- Adds `credentialsEqual()` for type-safe credential comparison, avoiding unnecessary writes
- Iterates all profiles in `store.profiles` rather than filtering by a single provider
- Preserves existing `auth.json` entries not managed by auth-profiles (merge behavior)
- Comprehensive test coverage added for all credential types, multi-provider sync, empty key skipping, and preservation of existing entries

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it cleanly generalizes existing single-provider logic to all providers with good defensive coding and comprehensive tests.
- The changes are well-scoped, refactoring an existing function to be more general. Helper functions are well-isolated and easy to reason about. Edge cases (empty keys, invalid OAuth fields, preserving existing entries) are handled correctly and covered by tests. No regressions to existing behavior (the original openai-codex OAuth test still passes). File permissions for credential storage are preserved. The code follows existing patterns in the codebase.
- No files require special attention.

<sub>Last reviewed commit: 3e2e96c</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->