### PR TITLE
fix(failover): recognize 'abort' stop reason as timeout for model fallback

### DIFF
--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -1,6 +1,7 @@
 import { classifyFailoverReason, type FailoverReason } from "./pi-embedded-helpers.js";
 
-const TIMEOUT_HINT_RE = /timeout|timed out|deadline exceeded|context deadline exceeded/i;
+const TIMEOUT_HINT_RE =
+  /timeout|timed out|deadline exceeded|context deadline exceeded|stop reason:\s*abort|unhandled stop reason:\s*abort/i;
 const ABORT_TIMEOUT_RE = /request was aborted|request aborted/i;
 
 export class FailoverError extends Error {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -599,6 +599,9 @@ const ERROR_PATTERNS = {
     "deadline exceeded",
     "context deadline exceeded",
     /without sending (?:any )?chunks?/i,
+    /\bstop reason:\s*abort\b/i,
+    /\breason:\s*abort\b/i,
+    /\bunhandled stop reason:\s*abort\b/i,
   ],
   billing: [
     /["']?(?:status|code)["']?\s*[:=]\s*402\b|\bhttp\s*402\b|\berror(?:\s+code)?\s*[:=]?\s*402\b|\b(?:got|returned|received)\s+(?:a\s+)?402\b|^\s*402\s+payment/i,


### PR DESCRIPTION
## Problem

When streaming providers (GLM, OpenRouter, NVIDIA NIM, etc.) return `stop reason: abort` due to stream interruption, OpenClaw's failover mechanism did not recognize this as a timeout condition. This prevented fallback models from being triggered, leaving users with failed requests instead of graceful failover to secondary models.

## Root Cause

The timeout error pattern detection in two places did not include abort-related patterns:
- `ERROR_PATTERNS.timeout` in `src/agents/pi-embedded-helpers/errors.ts`
- `TIMEOUT_HINT_RE` in `src/agents/failover-error.ts`

## Solution

Add abort stop reason patterns to both timeout detection regexes:
- `/\bstop reason:\s*abort\b/i`
- `/\breason:\s*abort\b/i`
- `/\bunhandled stop reason:\s*abort\b/i`

## Impact

Affects all users configuring model fallback chains with streaming providers. Before this fix, any abort from the provider would surface as a user-facing error instead of triggering the next model in the fallback chain.

## Testing

- TypeScript compilation passes
- Lint passes
- Pattern logic is unit-testable via existing error classification helpers

Fixes #18453

## AI-Assisted

This PR was prepared with assistance from Claude Opus 4.5.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds abort stop reason pattern detection to both timeout error classification paths (`failover-error.ts` and `errors.ts`), enabling model fallback when streaming providers (GLM, OpenRouter, NVIDIA NIM) return `stop reason: abort` due to stream interruption.

- Adds `stop reason:\s*abort` and `unhandled stop reason:\s*abort` patterns to `TIMEOUT_HINT_RE` in `failover-error.ts`
- Adds three regex patterns (`stop reason:\s*abort`, `reason:\s*abort`, `unhandled stop reason:\s*abort`) to `ERROR_PATTERNS.timeout` in `errors.ts`
- **Inconsistency**: The broader `reason:\s*abort` pattern exists only in `errors.ts` but not in `failover-error.ts`, which means the two timeout detection codepaths (`isTimeoutError` vs `isTimeoutErrorMessage`) will behave differently for error messages containing "reason: abort" without the "stop" prefix

<h3>Confidence Score: 3/5</h3>

- Low-risk regex additions with a minor pattern inconsistency between the two detection paths that could cause edge-case behavioral differences.
- The core change is correct and addresses a real gap in abort detection for streaming providers. However, the `reason:\s*abort` pattern is present in `errors.ts` but missing from `failover-error.ts`, creating an inconsistency between the two timeout classification paths. This means certain error messages may be classified as timeouts in one path but not the other, potentially causing subtle failover behavior differences. The redundant `unhandled stop reason` pattern is a minor style concern.
- `src/agents/failover-error.ts` — missing `reason:\s*abort` pattern that exists in `errors.ts`

<sub>Last reviewed commit: d77099a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

## Local Validation

```bash
pnpm build && pnpm check
```

TypeScript compilation passes. Lint passes. Pattern logic is unit-testable via existing error classification helpers.