### PR TITLE
fix(slack): extract text and media from forwarded message attachments

### DIFF
--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -44,6 +44,7 @@ import { resolveSlackChannelConfig } from "../channel-config.js";
 import { stripSlackMentionsForCommandDetection } from "../commands.js";
 import { normalizeSlackChannelType, type SlackMonitorContext } from "../context.js";
 import {
+  resolveSlackAttachmentContent,
   resolveSlackMedia,
   resolveSlackThreadHistory,
   resolveSlackThreadStarter,
@@ -342,8 +343,25 @@ export async function prepareSlackMessage(params: {
     token: ctx.botToken,
     maxBytes: ctx.mediaMaxBytes,
   });
-  const mediaPlaceholder = media ? media.map((m) => m.placeholder).join(" ") : undefined;
-  const rawBody = (message.text ?? "").trim() || mediaPlaceholder || "";
+
+  // Resolve forwarded message content (text + media) from Slack attachments
+  const attachmentContent = await resolveSlackAttachmentContent({
+    attachments: message.attachments,
+    token: ctx.botToken,
+    maxBytes: ctx.mediaMaxBytes,
+  });
+
+  // Merge forwarded media into the message's media array
+  const mergedMedia = [...(media ?? []), ...(attachmentContent?.media ?? [])];
+  const effectiveDirectMedia = mergedMedia.length > 0 ? mergedMedia : null;
+
+  const mediaPlaceholder = effectiveDirectMedia
+    ? effectiveDirectMedia.map((m) => m.placeholder).join(" ")
+    : undefined;
+  const rawBody =
+    [(message.text ?? "").trim(), attachmentContent?.text, mediaPlaceholder]
+      .filter(Boolean)
+      .join("\n") || "";
   if (!rawBody) {
     return null;
   }
@@ -478,7 +496,7 @@ export async function prepareSlackMessage(params: {
       const snippet = starter.text.replace(/\s+/g, " ").slice(0, 80);
       threadLabel = `Slack thread ${roomLabel}${snippet ? `: ${snippet}` : ""}`;
       // If current message has no files but thread starter does, fetch starter's files
-      if (!media && starter.files && starter.files.length > 0) {
+      if (!effectiveDirectMedia && starter.files && starter.files.length > 0) {
         threadStarterMedia = await resolveSlackMedia({
           files: starter.files,
           token: ctx.botToken,
@@ -554,8 +572,8 @@ export async function prepareSlackMessage(params: {
     }
   }
 
-  // Use thread starter media if current message has none
-  const effectiveMedia = media ?? threadStarterMedia;
+  // Use direct media (including forwarded attachment media) if available, else thread starter media
+  const effectiveMedia = effectiveDirectMedia ?? threadStarterMedia;
   const firstMedia = effectiveMedia?.[0];
 
   const inboundHistory =

--- a/src/slack/types.ts
+++ b/src/slack/types.ts
@@ -8,6 +8,26 @@ export type SlackFile = {
   url_private_download?: string;
 };
 
+export type SlackAttachment = {
+  fallback?: string;
+  text?: string;
+  pretext?: string;
+  author_name?: string;
+  author_id?: string;
+  from_url?: string;
+  ts?: string;
+  channel_name?: string;
+  channel_id?: string;
+  is_msg_unfurl?: boolean;
+  is_share?: boolean;
+  image_url?: string;
+  image_width?: number;
+  image_height?: number;
+  thumb_url?: string;
+  files?: SlackFile[];
+  message_blocks?: unknown[];
+};
+
 export type SlackMessageEvent = {
   type: "message";
   user?: string;
@@ -22,6 +42,7 @@ export type SlackMessageEvent = {
   channel: string;
   channel_type?: "im" | "mpim" | "channel" | "group";
   files?: SlackFile[];
+  attachments?: SlackAttachment[];
 };
 
 export type SlackAppMentionEvent = {
@@ -36,4 +57,5 @@ export type SlackAppMentionEvent = {
   parent_user_id?: string;
   channel: string;
   channel_type?: "im" | "mpim" | "channel" | "group";
+  attachments?: SlackAttachment[];
 };


### PR DESCRIPTION
## Summary

- **Problem:** Slack forwarded messages arrive in `message.attachments[]` but OpenClaw completely ignores this field  -  the agent receives an empty message body and silently drops the user's input.
- **Why it matters:** Forwarding messages to an agent is a common Slack workflow (e.g. "what does this mean?" with a forwarded message). Without this fix, the agent cannot see forwarded content at all.
- **What changed:** Added type definitions for Slack attachments, a new `resolveSlackAttachmentContent()` function that extracts text/images/files from forwarded attachments, and integrated it into the message preparation pipeline.
- **What did NOT change (scope boundary):** No changes to the agent runtime, tool execution, or any non-Slack code paths. The existing `resolveSlackMedia` function is reused as-is for file attachments. No changes to Discord or other integrations.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #9963 (text-only fix for the same issue  -  this PR extends it with image and file support)

## User-visible / Behavior Changes

- Forwarded Slack messages now appear in the agent's input as `[Forwarded message from Author]\n<text>` followed by any media placeholders.
- Images from forwarded messages are downloaded and passed to the model as media.
- Files embedded in forwarded attachments are resolved through the existing Slack file pipeline.
- Previously, forwarding a message to an agent produced no response or a confused response about an empty message. Now the agent sees the full forwarded content.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `Yes`  -  `fetchRemoteMedia` is called for `image_url` values from forwarded attachments. These are public Slack CDN URLs (no auth headers sent). The existing `resolveSlackMedia` path (which already sends Slack auth for private file URLs) is reused unchanged for embedded `files[]`.
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- Risk + mitigation: The only new network calls are to public Slack CDN URLs via the existing `fetchRemoteMedia` utility, which already enforces `maxBytes` limits. No new auth tokens are exposed.

## Repro + Verification

### Environment

- OS: macOS (darwin)
- Runtime/container: Node.js via `npm link` (local source build)
- Model/provider: Anthropic Claude (any model)
- Integration/channel: Slack (gateway mode)
- Relevant config: Default Slack gateway config, no special settings required

### Steps

1. Connect OpenClaw to a Slack workspace in gateway mode
2. In any channel/DM the agent monitors, forward a message from another channel (Slack's native forward feature)
3. Observe the agent's response

### Expected

- Agent receives the forwarded message text prefixed with `[Forwarded message from <author>]`
- Any images in the forwarded message are downloaded and included as media
- Agent responds based on the forwarded content

### Actual (before fix)

- Agent receives an empty message body
- Agent either does not respond or responds confused about receiving nothing

## Evidence

- [x] Trace/log snippets  -  Verified via live Slack gateway that forwarded messages now produce correct `rawBody` with author attribution and media attachments are resolved
- [ ] Failing test/log before + passing after
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- **Verified scenarios:** Forwarded text-only messages, forwarded messages with inline images, forwarded messages with file attachments (PDF), forwarded messages in threads, forwarded messages in DMs
- **Edge cases checked:** Attachments with no text and no media (returns null, no change to behavior), attachments with only `fallback` text (no `text` field), multiple forwarded messages in a single Slack event, image download failures (silently skipped)
- **What I did not verify:** None  -  all code paths have been exercised on a live Slack gateway.

## Compatibility / Migration

- Backward compatible? `Yes`  -  attachments field is optional; messages without attachments behave identically to before
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the 3 changed files (`types.ts`, `media.ts`, `prepare.ts`) or revert the single commit
- Files/config to restore: No config changes involved
- Known bad symptoms reviewers should watch for: If `image_url` values are unexpectedly non-public, `fetchRemoteMedia` would fail and the image would be silently skipped (graceful degradation). If `attachments` field shape differs from documented Slack API types, text extraction would return null (no crash).

## Risks and Mitigations

- **Risk:** Slack changes the `attachments` field shape for forwarded messages in a future API update.
  - **Mitigation:** All fields on `SlackAttachment` are optional  -  missing fields gracefully degrade to no-ops. The type is intentionally loose.
- **Risk:** Large forwarded messages with many images could increase media download time.
  - **Mitigation:** Each image is bounded by the existing `maxBytes` limit. Failed downloads are caught and skipped.

---

*This PR was AI-assisted (Claude Code). The code has been manually reviewed, tested on a live Slack gateway, and the author understands all changes.*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds support for forwarded Slack messages by extracting text and media from the `attachments[]` field. The implementation correctly:

- Adds type definitions for `SlackAttachment` with optional fields for graceful degradation
- Implements `resolveSlackAttachmentContent()` to extract text with author attribution (`[Forwarded message from <author>]`), download images from public CDN URLs, and resolve file attachments via existing Slack-authed pipeline
- Integrates forwarded content into the message preparation flow by merging attachment media with direct message media and combining text appropriately
- Reuses existing media download functions (`fetchRemoteMedia`, `resolveSlackMedia`) with proper error handling (failed downloads are silently skipped)

The change is well-scoped to the Slack integration only and maintains backward compatibility (attachments field is optional).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-structured with proper error handling, reuses existing security-vetted functions (fetchRemoteMedia with maxBytes limits), maintains backward compatibility, and follows the existing codebase patterns. All fields are optional for graceful degradation, and the author has thoroughly tested on a live Slack gateway.
- No files require special attention

<sub>Last reviewed commit: 9a4e1c3</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->