### PR TITLE
fix: add windowsHide: true to spawn in runCommandWithTimeout (#18613)

### DIFF
--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -139,6 +139,7 @@ export async function runCommandWithTimeout(
     cwd,
     env: resolvedEnv,
     windowsVerbatimArguments,
+    windowsHide: true,
     ...(shouldSpawnWithShell({ resolvedCommand, platform: process.platform })
       ? { shell: true }
       : {}),


### PR DESCRIPTION
Fixes flashing conhost.exe windows on Windows when exec module spawns child processes. The windowsHide: true option prevents orphaned conhost.exe processes and eliminates disruptive terminal window flashing.

Closes #18613

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `windowsHide: true` to the `spawn()` call in `runCommandWithTimeout` (`src/process/exec.ts`), preventing conhost.exe windows from flashing when child processes are spawned on Windows. This is a standard Node.js `child_process` option already used consistently across other spawn sites in the codebase (`supervisor/adapters/child.ts`, `node-host/invoke.ts`, `machine-name.ts`, `schtasks-exec.ts`, `launchd.ts`).

- Single-line addition of `windowsHide: true` to the spawn options object
- Consistent with existing patterns in the codebase — this was the one `spawn()` call site in `exec.ts` missing it
- Note: the sibling `runExec` function (which uses `execFileAsync`) also does not set `windowsHide: true` and could exhibit similar conhost.exe flashing on Windows — a potential follow-up improvement

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a single well-understood option addition with no behavioral side effects on non-Windows platforms.
- The change is a single line adding `windowsHide: true` to a spawn options object. This is a well-documented Node.js option that is already used in 6+ other call sites in this codebase. It has no effect on non-Windows platforms. The change is minimal, correct, and follows established patterns.
- No files require special attention.

<sub>Last reviewed commit: 18fe8a9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->