### PR TITLE
fix: always drop orphaned OpenAI reasoning blocks

### DIFF
--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -204,7 +204,7 @@ describe("sanitizeSessionHistory", () => {
     expect(result.map((msg) => msg.role)).toEqual(["user"]);
   });
 
-  it("does not downgrade openai reasoning when the model has not changed", async () => {
+  it("downgrades orphaned openai reasoning even when the model has not changed", async () => {
     const sessionEntries = [
       makeModelSnapshotEntry({
         provider: "openai",
@@ -222,7 +222,7 @@ describe("sanitizeSessionHistory", () => {
       sessionManager,
     });
 
-    expect(result).toEqual(messages);
+    expect(result).toEqual([]);
   });
 
   it("downgrades openai reasoning only when the model changes", async () => {

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -457,10 +457,9 @@ export async function sanitizeSessionHistory(params: {
         modelId: params.modelId,
       })
     : false;
-  const sanitizedOpenAI =
-    isOpenAIResponsesApi && modelChanged
-      ? downgradeOpenAIReasoningBlocks(sanitizedToolResults)
-      : sanitizedToolResults;
+  const sanitizedOpenAI = isOpenAIResponsesApi
+    ? downgradeOpenAIReasoningBlocks(sanitizedToolResults)
+    : sanitizedToolResults;
 
   if (hasSnapshot && (!priorSnapshot || modelChanged)) {
     appendModelSnapshot(params.sessionManager, {


### PR DESCRIPTION
## Summary

- `downgradeOpenAIReasoningBlocks` was only called when the model changed, but orphaned reasoning items (e.g. from an aborted stream) can exist without a model switch
- This caused a 400 error: `Item 'rs_...' of type 'reasoning' was provided without its required following item`
- Removed the `modelChanged` guard so orphaned reasoning blocks are always cleaned up for OpenAI Responses API runs

## Test plan

- [x] Updated existing test to expect orphaned reasoning blocks are dropped even without model change
- [x] All `sanitize-session-history` tests pass (11/11)
- [x] All `openai-responses.reasoning-replay` tests pass (2/2)
- [x] Verify the 400 error no longer occurs in a live session with OpenAI Responses API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removed the `modelChanged` guard from `downgradeOpenAIReasoningBlocks` so orphaned OpenAI reasoning blocks are always cleaned up for OpenAI Responses API runs, preventing 400 errors from incomplete reasoning items (e.g., from aborted streams).

- **Core change**: In `src/agents/pi-embedded-runner/google.ts:460-462`, `downgradeOpenAIReasoningBlocks` now runs unconditionally for OpenAI Responses API instead of only when the model changes
- **Test update**: Updated test in `pi-embedded-runner.sanitize-session-history.test.ts:207-226` to verify orphaned reasoning blocks are dropped even without model changes
- **Rationale**: Orphaned reasoning blocks can exist without a model switch (e.g., from aborted streams), and the OpenAI Responses API rejects transcripts containing standalone reasoning item IDs without required following items

The fix aligns with the documented behavior in `docs/reference/transcript-hygiene.md:98` which states that OpenAI should "drop orphaned reasoning signatures" without mentioning model-change as a prerequisite.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a focused bug fix that removes an overly restrictive guard condition. The logic in `downgradeOpenAIReasoningBlocks` already handles all cases correctly - it only drops reasoning blocks that are truly orphaned (lacking a following non-thinking block). The test update confirms the expected behavior, and the fix prevents a real 400 error from OpenAI's API when orphaned reasoning blocks exist from aborted streams.
- No files require special attention

<sub>Last reviewed commit: bda1b51</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->