### PR TITLE
Google Chat: use agent identity.name for typing indicator

### DIFF
--- a/extensions/googlechat/src/monitor.display-name.test.ts
+++ b/extensions/googlechat/src/monitor.display-name.test.ts
@@ -1,0 +1,85 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { describe, expect, it } from "vitest";
+import { resolveBotDisplayName } from "./monitor.js";
+
+describe("resolveBotDisplayName", () => {
+  it("prefers explicit account name", () => {
+    const config = {
+      agents: {
+        list: [
+          {
+            id: "main",
+            identity: { name: "Identity Agent" },
+          },
+        ],
+      },
+    } as OpenClawConfig;
+
+    const name = resolveBotDisplayName({
+      accountName: "Google Chat Bot",
+      agentId: "main",
+      config,
+    });
+
+    expect(name).toBe("Google Chat Bot");
+  });
+
+  it("uses agent identity name when account name is not set", () => {
+    const config = {
+      agents: {
+        list: [
+          {
+            id: "main",
+            identity: { name: "Identity Agent" },
+          },
+        ],
+      },
+    } as OpenClawConfig;
+
+    const name = resolveBotDisplayName({
+      agentId: "main",
+      config,
+    });
+
+    expect(name).toBe("Identity Agent");
+  });
+
+  it("falls back to legacy agent name when identity is not set", () => {
+    const config = {
+      agents: {
+        list: [
+          {
+            id: "main",
+            name: "Legacy Agent Name",
+          },
+        ],
+      },
+    } as OpenClawConfig;
+
+    const name = resolveBotDisplayName({
+      agentId: "main",
+      config,
+    });
+
+    expect(name).toBe("Legacy Agent Name");
+  });
+
+  it("falls back to OpenClaw when no name is configured", () => {
+    const config = {
+      agents: {
+        list: [
+          {
+            id: "main",
+          },
+        ],
+      },
+    } as OpenClawConfig;
+
+    const name = resolveBotDisplayName({
+      agentId: "main",
+      config,
+    });
+
+    expect(name).toBe("OpenClaw");
+  });
+});

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -365,10 +365,11 @@ function extractMentionInfo(annotations: GoogleChatAnnotation[], botUser?: strin
 /**
  * Resolve bot display name with fallback chain:
  * 1. Account config name
- * 2. Agent name from config
+ * 2. Agent identity.name from config
+ * 3. Agent name from config (legacy)
  * 3. "OpenClaw" as generic fallback
  */
-function resolveBotDisplayName(params: {
+export function resolveBotDisplayName(params: {
   accountName?: string;
   agentId: string;
   config: OpenClawConfig;
@@ -378,6 +379,9 @@ function resolveBotDisplayName(params: {
     return accountName.trim();
   }
   const agent = config.agents?.list?.find((a) => a.id === agentId);
+  if (agent?.identity?.name?.trim()) {
+    return agent.identity.name.trim();
+  }
   if (agent?.name?.trim()) {
     return agent.name.trim();
   }

--- a/extensions/whatsapp/src/channel.send-options.test.ts
+++ b/extensions/whatsapp/src/channel.send-options.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { whatsappPlugin } from "./channel.js";
 
 // Mock runtime
-const mockSendMessageWhatsApp = vi.fn().mockResolvedValue({ messageId: "123", toJid: "123@s.whatsapp.net" });
+const mockSendMessageWhatsApp = vi
+  .fn()
+  .mockResolvedValue({ messageId: "123", toJid: "123@s.whatsapp.net" });
 
 vi.mock("./runtime.js", () => ({
   getWhatsAppRuntime: () => ({
@@ -35,7 +37,7 @@ describe("whatsappPlugin.outbound.sendText", () => {
       "http://example.com",
       expect.objectContaining({
         linkPreview: false,
-      })
+      }),
     );
   });
 
@@ -50,7 +52,7 @@ describe("whatsappPlugin.outbound.sendText", () => {
       "hello",
       expect.objectContaining({
         linkPreview: undefined,
-      })
+      }),
     );
   });
 });

--- a/scripts/cron_usage_report.ts
+++ b/scripts/cron_usage_report.ts
@@ -91,7 +91,8 @@ export async function main() {
   const args = parseArgs(process.argv);
   const store = typeof args.store === "string" ? args.store : undefined;
   const runsDirArg = typeof args.runsDir === "string" ? args.runsDir : undefined;
-  const runsDir = runsDirArg ?? (store ? path.join(path.dirname(path.resolve(store)), "runs") : null);
+  const runsDir =
+    runsDirArg ?? (store ? path.join(path.dirname(path.resolve(store)), "runs") : null);
   if (!runsDir) {
     usageAndExit(2);
   }
@@ -150,7 +151,9 @@ export async function main() {
 
       const jobId = entry.jobId;
       const usage = entry.usage;
-      const hasUsage = Boolean(usage && (usage.total_tokens ?? usage.input_tokens ?? usage.output_tokens) !== undefined);
+      const hasUsage = Boolean(
+        usage && (usage.total_tokens ?? usage.input_tokens ?? usage.output_tokens) !== undefined,
+      );
 
       const jobAgg = (totalsByJob[jobId] ??= {
         jobId,

--- a/src/agents/pi-embedded-runner/extra-params.zai-tool-stream.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.zai-tool-stream.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it, vi } from "vitest";
 import type { StreamFn } from "@mariozechner/pi-agent-core";
 import type { Context, Model } from "@mariozechner/pi-ai";
+import { describe, expect, it, vi } from "vitest";
 import { applyExtraParamsToAgent } from "./extra-params.js";
 
 // Mock streamSimple for testing
@@ -42,14 +42,17 @@ describe("extra-params: Z.AI tool_stream support", () => {
   });
 
   it("should not inject tool_stream for non-zai providers", () => {
-    const mockStreamFn: StreamFn = vi.fn(() => ({
-      push: vi.fn(),
-      result: vi.fn().mockResolvedValue({
-        role: "assistant",
-        content: [{ type: "text", text: "ok" }],
-        stopReason: "stop",
-      }),
-    } as any));
+    const mockStreamFn: StreamFn = vi.fn(
+      () =>
+        ({
+          push: vi.fn(),
+          result: vi.fn().mockResolvedValue({
+            role: "assistant",
+            content: [{ type: "text", text: "ok" }],
+            stopReason: "stop",
+          }),
+        }) as any,
+    );
 
     const agent = { streamFn: mockStreamFn };
     const cfg = {};
@@ -61,14 +64,17 @@ describe("extra-params: Z.AI tool_stream support", () => {
   });
 
   it("should allow disabling tool_stream via params", () => {
-    const mockStreamFn: StreamFn = vi.fn(() => ({
-      push: vi.fn(),
-      result: vi.fn().mockResolvedValue({
-        role: "assistant",
-        content: [{ type: "text", text: "ok" }],
-        stopReason: "stop",
-      }),
-    } as any));
+    const mockStreamFn: StreamFn = vi.fn(
+      () =>
+        ({
+          push: vi.fn(),
+          result: vi.fn().mockResolvedValue({
+            role: "assistant",
+            content: [{ type: "text", text: "ok" }],
+            stopReason: "stop",
+          }),
+        }) as any,
+    );
 
     const agent = { streamFn: mockStreamFn };
     const cfg = {

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -1,10 +1,10 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { TextContent } from "@mariozechner/pi-ai";
+import type { SessionManager } from "@mariozechner/pi-coding-agent";
 import type {
   PluginHookBeforeMessageWriteEvent,
   PluginHookBeforeMessageWriteResult,
 } from "../plugins/types.js";
-import type { TextContent } from "@mariozechner/pi-ai";
-import type { SessionManager } from "@mariozechner/pi-coding-agent";
 import { emitSessionTranscriptUpdate } from "../sessions/transcript-events.js";
 import { HARD_MAX_TOOL_RESULT_CHARS } from "./pi-embedded-runner/tool-result-truncation.js";
 import { makeMissingToolResult, sanitizeToolCallInputs } from "./session-transcript-repair.js";

--- a/src/auto-reply/reply/commands-mesh.ts
+++ b/src/auto-reply/reply/commands-mesh.ts
@@ -110,7 +110,10 @@ function putCachedPlan(params: Parameters<CommandHandler>[0], plan: MeshPlanShap
   trimMeshPlanCache();
 }
 
-function getCachedPlan(params: Parameters<CommandHandler>[0], planId: string): MeshPlanShape | null {
+function getCachedPlan(
+  params: Parameters<CommandHandler>[0],
+  planId: string,
+): MeshPlanShape | null {
   return meshPlanCache.get(cacheKeyForPlan(params, planId))?.plan ?? null;
 }
 
@@ -190,7 +193,9 @@ export const handleMeshCommand: CommandHandler = async (params, allowTextCommand
     return null;
   }
   if (!params.command.isAuthorizedSender) {
-    logVerbose(`Ignoring /mesh from unauthorized sender: ${params.command.senderId || "<unknown>"}`);
+    logVerbose(
+      `Ignoring /mesh from unauthorized sender: ${params.command.senderId || "<unknown>"}`,
+    );
     return { shouldContinue: false };
   }
   if (!parsed.ok) {

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -171,10 +171,7 @@ export function loadSessionStore(
   let store: Record<string, SessionEntry> = {};
   let mtimeMs = getFileMtimeMs(storePath);
   const maxReadAttempts = process.platform === "win32" ? 3 : 1;
-  const retryBuf =
-    maxReadAttempts > 1
-      ? new Int32Array(new SharedArrayBuffer(4))
-      : undefined;
+  const retryBuf = maxReadAttempts > 1 ? new Int32Array(new SharedArrayBuffer(4)) : undefined;
   for (let attempt = 0; attempt < maxReadAttempts; attempt++) {
     try {
       const raw = fs.readFileSync(storePath, "utf-8");
@@ -587,9 +584,7 @@ async function saveSessionStoreUnlocked(
           // Final attempt failed — skip this save.  The write lock ensures
           // the next save will retry with fresh data.  Log for diagnostics.
           if (i === 4) {
-            console.warn(
-              `[session-store] rename failed after 5 attempts: ${storePath}`,
-            );
+            console.warn(`[session-store] rename failed after 5 attempts: ${storePath}`);
           }
         }
       }

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -641,7 +641,13 @@ export async function runCronIsolatedAgentTurn(params: {
         }
       } catch (err) {
         if (!deliveryBestEffort) {
-          return withRunSession({ status: "error", summary, outputText, error: String(err), ...telemetry });
+          return withRunSession({
+            status: "error",
+            summary,
+            outputText,
+            error: String(err),
+            ...telemetry,
+          });
         }
       }
     } else if (synthesizedText) {
@@ -739,7 +745,13 @@ export async function runCronIsolatedAgentTurn(params: {
         }
       } catch (err) {
         if (!deliveryBestEffort) {
-          return withRunSession({ status: "error", summary, outputText, error: String(err), ...telemetry });
+          return withRunSession({
+            status: "error",
+            summary,
+            outputText,
+            error: String(err),
+            ...telemetry,
+          });
         }
         logWarn(`[cron:${params.job.id}] ${String(err)}`);
       }

--- a/src/cron/run-log.ts
+++ b/src/cron/run-log.ts
@@ -117,16 +117,23 @@ export async function readCronRunLogEntries(
         durationMs: obj.durationMs,
         nextRunAtMs: obj.nextRunAtMs,
         model: typeof obj.model === "string" && obj.model.trim() ? obj.model : undefined,
-        provider: typeof obj.provider === "string" && obj.provider.trim() ? obj.provider : undefined,
+        provider:
+          typeof obj.provider === "string" && obj.provider.trim() ? obj.provider : undefined,
         usage:
           obj.usage && typeof obj.usage === "object"
             ? {
                 input_tokens:
-                  typeof (obj.usage as any).input_tokens === "number" ? (obj.usage as any).input_tokens : undefined,
+                  typeof (obj.usage as any).input_tokens === "number"
+                    ? (obj.usage as any).input_tokens
+                    : undefined,
                 output_tokens:
-                  typeof (obj.usage as any).output_tokens === "number" ? (obj.usage as any).output_tokens : undefined,
+                  typeof (obj.usage as any).output_tokens === "number"
+                    ? (obj.usage as any).output_tokens
+                    : undefined,
                 total_tokens:
-                  typeof (obj.usage as any).total_tokens === "number" ? (obj.usage as any).total_tokens : undefined,
+                  typeof (obj.usage as any).total_tokens === "number"
+                    ? (obj.usage as any).total_tokens
+                    : undefined,
                 cache_read_tokens:
                   typeof (obj.usage as any).cache_read_tokens === "number"
                     ? (obj.usage as any).cache_read_tokens

--- a/src/discord/monitor/threading.auto-thread.test.ts
+++ b/src/discord/monitor/threading.auto-thread.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from "vitest";
 import { ChannelType } from "@buape/carbon";
+import { describe, it, expect, vi } from "vitest";
 import { maybeCreateDiscordAutoThread } from "./threading.js";
 
 describe("maybeCreateDiscordAutoThread", () => {

--- a/src/gateway/server-methods/mesh.test.ts
+++ b/src/gateway/server-methods/mesh.test.ts
@@ -73,7 +73,10 @@ describe("mesh handlers", () => {
   it("runs steps in DAG order and supports retrying failed steps", async () => {
     const runState = new Map<string, "ok" | "error">();
     mocks.agent.mockImplementation(
-      (opts: { params: { idempotencyKey: string }; respond: (ok: boolean, payload?: unknown) => void }) => {
+      (opts: {
+        params: { idempotencyKey: string };
+        respond: (ok: boolean, payload?: unknown) => void;
+      }) => {
         const agentRunId = `agent-${opts.params.idempotencyKey}`;
         runState.set(agentRunId, "ok");
         if (opts.params.idempotencyKey.includes(":review:1")) {
@@ -120,7 +123,10 @@ describe("mesh handlers", () => {
 
     // Make subsequent retries succeed
     mocks.agent.mockImplementation(
-      (opts: { params: { idempotencyKey: string }; respond: (ok: boolean, payload?: unknown) => void }) => {
+      (opts: {
+        params: { idempotencyKey: string };
+        respond: (ok: boolean, payload?: unknown) => void;
+      }) => {
         const agentRunId = `agent-${opts.params.idempotencyKey}`;
         runState.set(agentRunId, "ok");
         opts.respond(true, { runId: agentRunId, status: "accepted" });

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -526,8 +526,9 @@ describe("gateway mesh.plan.auto scope handling", () => {
   it("allows operator.write clients for mesh.plan.auto", async () => {
     const { handleGatewayRequest } = await import("../server-methods.js");
     const respond = vi.fn();
-    const handler = vi.fn(({ respond: send }: { respond: (ok: boolean, payload?: unknown) => void }) =>
-      send(true, { ok: true }),
+    const handler = vi.fn(
+      ({ respond: send }: { respond: (ok: boolean, payload?: unknown) => void }) =>
+        send(true, { ok: true }),
     );
 
     await handleGatewayRequest({

--- a/src/infra/system-presence.ts
+++ b/src/infra/system-presence.ts
@@ -50,7 +50,11 @@ function resolvePrimaryIPv4(): string | undefined {
 function initSelfPresence() {
   const host = os.hostname();
   const ip = resolvePrimaryIPv4() ?? undefined;
-  const version = process.env.OPENCLAW_VERSION ?? process.env.OPENCLAW_SERVICE_VERSION ?? process.env.npm_package_version ?? "unknown";
+  const version =
+    process.env.OPENCLAW_VERSION ??
+    process.env.OPENCLAW_SERVICE_VERSION ??
+    process.env.npm_package_version ??
+    "unknown";
   const modelIdentifier = (() => {
     const p = os.platform();
     if (p === "darwin") {

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -414,7 +414,6 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     return { message: current };
   }
 
-
   // =========================================================================
   // Message Write Hooks
   // =========================================================================

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -502,7 +502,7 @@ export type PluginHookBeforeMessageWriteEvent = {
 };
 
 export type PluginHookBeforeMessageWriteResult = {
-  block?: boolean;      // If true, message is NOT written to JSONL
+  block?: boolean; // If true, message is NOT written to JSONL
   message?: AgentMessage; // Optional: modified message to write instead
 };
 

--- a/src/routing/session-key.continuity.test.ts
+++ b/src/routing/session-key.continuity.test.ts
@@ -63,7 +63,7 @@ describe("Discord Session Key Continuity", () => {
     });
 
     expect(missingIdKey).toContain("unknown");
-    
+
     // Should still be distinct from main
     expect(missingIdKey).not.toBe("agent:main:main");
   });

--- a/src/web/inbound/send-api.ts
+++ b/src/web/inbound/send-api.ts
@@ -1,4 +1,8 @@
-import type { AnyMessageContent, MiscMessageGenerationOptions, WAPresence } from "@whiskeysockets/baileys";
+import type {
+  AnyMessageContent,
+  MiscMessageGenerationOptions,
+  WAPresence,
+} from "@whiskeysockets/baileys";
 import type { ActiveWebSendOptions } from "../active-listener.js";
 import { recordChannelActivity } from "../../infra/channel-activity.js";
 import { toWhatsappJid } from "../../utils.js";

--- a/src/web/outbound.ts
+++ b/src/web/outbound.ts
@@ -83,9 +83,7 @@ export async function sendMessageWhatsApp(
         ? {
             ...(options.gifPlayback ? { gifPlayback: true } : {}),
             ...(documentFileName ? { fileName: documentFileName } : {}),
-            ...(options.linkPreview !== undefined
-              ? { linkPreview: options.linkPreview }
-              : {}),
+            ...(options.linkPreview !== undefined ? { linkPreview: options.linkPreview } : {}),
             accountId,
           }
         : undefined;


### PR DESCRIPTION
## Summary
- fix Google Chat typing indicator display name resolution to prefer `agents.list[].identity.name`
- retain backward compatibility by falling back to legacy `agents.list[].name`
- keep existing account-level display name override as highest priority
- add unit tests covering all fallback levels

Closes #18580

## Testing
- `pnpm test extensions/googlechat/src/monitor.display-name.test.ts`
- `pnpm test extensions/googlechat/src/monitor.test.ts extensions/googlechat/src/monitor.webhook-routing.test.ts`
- `pnpm tsgo`
- `pnpm lint`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the Google Chat typing indicator to resolve the bot display name from `agents.list[].identity.name` (the agent's identity configuration) before falling back to the legacy `agents.list[].name` field. The account-level display name remains the highest priority override, and "OpenClaw" remains the final fallback.

- **Core change** (`extensions/googlechat/src/monitor.ts`): Inserts a new check for `agent.identity.name` in `resolveBotDisplayName`, maintaining backward compatibility with the existing `agent.name` fallback.
- **New tests** (`monitor.display-name.test.ts`): Covers all four levels of the fallback chain (account name > identity name > legacy name > "OpenClaw"). Function was exported to enable direct unit testing.
- **Formatting** (18 other files): Two formatting commits apply `oxfmt` to CI-flagged files — no behavioral changes outside the Google Chat monitor.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — the logic change is minimal, well-tested, and backward compatible.
- The feature change is a small, additive modification to a display-name fallback chain with proper null/whitespace guards and full test coverage. The remaining 18 files are formatting-only changes from oxfmt. Only minor issue is a doc comment numbering typo.
- No files require special attention. The core logic change in `extensions/googlechat/src/monitor.ts` is straightforward and well-covered by tests.

<sub>Last reviewed commit: 99b18dd</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->