### PR TITLE
fix(agents): guard against undefined paths in injectedFiles

### DIFF
--- a/src/agents/system-prompt-report.test.ts
+++ b/src/agents/system-prompt-report.test.ts
@@ -64,6 +64,26 @@ describe("buildSystemPromptReport", () => {
     expect(report.injectedWorkspaceFiles[0]?.truncated).toBe(true);
   });
 
+  it("does not crash when injectedFiles contain entries with undefined path", () => {
+    const file = makeBootstrapFile({ path: "/tmp/workspace/AGENTS.md" });
+    const report = buildSystemPromptReport({
+      source: "run",
+      generatedAt: 0,
+      bootstrapMaxChars: 20_000,
+      systemPrompt: "system",
+      bootstrapFiles: [file],
+      injectedFiles: [
+        { path: undefined as unknown as string, content: "content" },
+        { path: "", content: "empty" },
+        { path: "/tmp/workspace/AGENTS.md", content: "valid" },
+      ],
+      skillsPrompt: "",
+      tools: [],
+    });
+
+    expect(report.injectedWorkspaceFiles[0]?.injectedChars).toBe("valid".length);
+  });
+
   it("includes both bootstrap caps in the report payload", () => {
     const file = makeBootstrapFile({ path: "/tmp/workspace/policies/AGENTS.md" });
     const report = buildSystemPromptReport({

--- a/src/agents/system-prompt-report.ts
+++ b/src/agents/system-prompt-report.ts
@@ -41,7 +41,7 @@ function buildInjectedWorkspaceFiles(params: {
   injectedFiles: EmbeddedContextFile[];
 }): SessionSystemPromptReport["injectedWorkspaceFiles"] {
   const safeInjectedFiles = (params.injectedFiles ?? []).filter(
-    (f) => typeof f.path === "string" && f.path.length > 0,
+    (f) => typeof f.path === "string" && f.path.trim().length > 0,
   );
   const injectedByPath = new Map(safeInjectedFiles.map((f) => [f.path, f.content]));
   const injectedByBaseName = new Map<string, string>();

--- a/src/agents/system-prompt-report.ts
+++ b/src/agents/system-prompt-report.ts
@@ -40,9 +40,12 @@ function buildInjectedWorkspaceFiles(params: {
   bootstrapFiles: WorkspaceBootstrapFile[];
   injectedFiles: EmbeddedContextFile[];
 }): SessionSystemPromptReport["injectedWorkspaceFiles"] {
-  const injectedByPath = new Map(params.injectedFiles.map((f) => [f.path, f.content]));
+  const safeInjectedFiles = (params.injectedFiles ?? []).filter(
+    (f) => typeof f.path === "string" && f.path.length > 0,
+  );
+  const injectedByPath = new Map(safeInjectedFiles.map((f) => [f.path, f.content]));
   const injectedByBaseName = new Map<string, string>();
-  for (const file of params.injectedFiles) {
+  for (const file of safeInjectedFiles) {
     const normalizedPath = file.path.replace(/\\/g, "/");
     const baseName = path.posix.basename(normalizedPath);
     if (!injectedByBaseName.has(baseName)) {


### PR DESCRIPTION
## Summary

- Filter `injectedFiles` to exclude entries with `undefined` or empty `path` before iterating in `buildInjectedWorkspaceFiles`, preventing a `TypeError: Cannot read properties of undefined (reading 'replace')` crash
- Matches the existing guard pattern already applied in `system-prompt.ts` (`validContextFiles` filter at line 603)
- Adds regression test verifying the function handles `undefined` and empty paths without crashing

## Root Cause

When workspace bootstrap files exceed `bootstrapMaxChars`, the bootstrap context builder can produce `EmbeddedContextFile` entries where `path` is `undefined`. The `buildInjectedWorkspaceFiles` function in `system-prompt-report.ts` calls `file.path.replace(/\\/g, "/")` without checking for this, causing a TypeError that crashes **all agents** before any API call.

The same guard was already added to `buildAgentSystemPrompt` in `system-prompt.ts` (the `validContextFiles` filter), but was missing from the report builder.

## Test plan

- [x] Added test: `does not crash when injectedFiles contain entries with undefined path`
- [x] All 5 tests in `system-prompt-report.test.ts` pass
- [x] Verified fix resolves the crash on a live gateway (v2026.2.15) with Gemini agents

Fixes #17947

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a defensive filter in `buildInjectedWorkspaceFiles` (`system-prompt-report.ts`) to exclude `EmbeddedContextFile` entries with `undefined` or empty `path` before iterating. This prevents a `TypeError` crash when `file.path.replace(/\\\\/g, "/")` is called on an undefined path — a scenario that occurs when workspace bootstrap files exceed `bootstrapMaxChars`.

- Mirrors the existing `validContextFiles` guard already present in `system-prompt.ts:603`
- Includes a regression test covering both `undefined` and empty-string path cases
- Minimal, focused change that addresses a real production crash

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it adds a defensive filter that prevents a runtime crash without changing any existing behavior for valid inputs.
- The change is minimal, well-scoped, and follows an established pattern already used elsewhere in the codebase (system-prompt.ts:603). It only filters out invalid entries that would cause a TypeError, and includes a regression test. No risk of breaking existing functionality.
- No files require special attention.

<sub>Last reviewed commit: 8ea6a4e</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->