### PR TITLE
fix(cli): display correct model for sub-agents in sessions list

### DIFF
--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -1,7 +1,7 @@
 import type { RuntimeEnv } from "../runtime.js";
 import { lookupContextTokens } from "../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
-import { resolveConfiguredModelRef } from "../agents/model-selection.js";
+import { parseModelRef, resolveConfiguredModelRef } from "../agents/model-selection.js";
 import { loadConfig } from "../config/config.js";
 import {
   loadSessionStore,
@@ -33,6 +33,9 @@ type SessionRow = {
   totalTokens?: number;
   totalTokensFresh?: boolean;
   model?: string;
+  modelProvider?: string;
+  providerOverride?: string;
+  modelOverride?: string;
   contextTokens?: number;
 };
 
@@ -114,6 +117,35 @@ const formatModelCell = (model: string | null | undefined, rich: boolean) => {
   return rich ? theme.info(label) : label;
 };
 
+const resolveEntryModel = (
+  entry:
+    | {
+        model?: string;
+        modelProvider?: string;
+        modelOverride?: string;
+        providerOverride?: string;
+      }
+    | undefined,
+  fallbackModel: string,
+  fallbackProvider: string,
+): string => {
+  const runtimeModel = entry?.model?.trim();
+  const runtimeProvider = entry?.modelProvider?.trim();
+  if (runtimeModel) {
+    const parsedRuntime = parseModelRef(runtimeModel, runtimeProvider || fallbackProvider);
+    return parsedRuntime ? parsedRuntime.model : runtimeModel;
+  }
+
+  const overrideModel = entry?.modelOverride?.trim();
+  if (overrideModel) {
+    const overrideProvider = entry?.providerOverride?.trim() || fallbackProvider;
+    const parsedOverride = parseModelRef(overrideModel, overrideProvider);
+    return parsedOverride ? parsedOverride.model : overrideModel;
+  }
+
+  return fallbackModel;
+};
+
 const formatFlagsCell = (row: SessionRow, rich: boolean) => {
   const flags = [
     row.thinkingLevel ? `think:${row.thinkingLevel}` : null,
@@ -153,6 +185,9 @@ function toRows(store: Record<string, SessionEntry>): SessionRow[] {
         totalTokens: entry?.totalTokens,
         totalTokensFresh: entry?.totalTokensFresh,
         model: entry?.model,
+        modelProvider: entry?.modelProvider,
+        providerOverride: entry?.providerOverride,
+        modelOverride: entry?.modelOverride,
         contextTokens: entry?.contextTokens,
       } satisfies SessionRow;
     })
@@ -205,15 +240,18 @@ export async function sessionsCommand(
           path: storePath,
           count: rows.length,
           activeMinutes: activeMinutes ?? null,
-          sessions: rows.map((r) => ({
-            ...r,
-            totalTokens: resolveFreshSessionTotalTokens(r) ?? null,
-            totalTokensFresh:
-              typeof r.totalTokens === "number" ? r.totalTokensFresh !== false : false,
-            contextTokens:
-              r.contextTokens ?? lookupContextTokens(r.model) ?? configContextTokens ?? null,
-            model: r.model ?? configModel ?? null,
-          })),
+          sessions: rows.map((r) => {
+            const model = resolveEntryModel(r, configModel, resolved.provider ?? DEFAULT_PROVIDER);
+            return {
+              ...r,
+              totalTokens: resolveFreshSessionTotalTokens(r) ?? null,
+              totalTokensFresh:
+                typeof r.totalTokens === "number" ? r.totalTokensFresh !== false : false,
+              contextTokens:
+                r.contextTokens ?? lookupContextTokens(model) ?? configContextTokens ?? null,
+              model,
+            };
+          }),
         },
         null,
         2,
@@ -245,7 +283,7 @@ export async function sessionsCommand(
   runtime.log(rich ? theme.heading(header) : header);
 
   for (const row of rows) {
-    const model = row.model ?? configModel;
+    const model = resolveEntryModel(row, configModel, resolved.provider ?? DEFAULT_PROVIDER);
     const contextTokens = row.contextTokens ?? lookupContextTokens(model) ?? configContextTokens;
     const total = resolveFreshSessionTotalTokens(row);
 

--- a/src/commands/status.summary.ts
+++ b/src/commands/status.summary.ts
@@ -10,7 +10,11 @@ import {
   resolveStorePath,
   type SessionEntry,
 } from "../config/sessions.js";
-import { classifySessionKey, listAgentsForGateway } from "../gateway/session-utils.js";
+import {
+  classifySessionKey,
+  listAgentsForGateway,
+  resolveSessionModelRef,
+} from "../gateway/session-utils.js";
 import { buildChannelSummary } from "../infra/channel-summary.js";
 import { resolveHeartbeatSummaryForAgent } from "../infra/heartbeat-runner.js";
 import { peekSystemEvents } from "../infra/system-events.js";
@@ -125,7 +129,8 @@ export async function getStatusSummary(
       .map(([key, entry]) => {
         const updatedAt = entry?.updatedAt ?? null;
         const age = updatedAt ? now - updatedAt : null;
-        const model = entry?.model ?? configModel ?? null;
+        const resolvedModel = resolveSessionModelRef(cfg, entry, opts.agentIdOverride);
+        const model = resolvedModel.model ?? configModel ?? null;
         const contextTokens =
           entry?.contextTokens ?? lookupContextTokens(model) ?? configContextTokens ?? null;
         const total = resolveFreshSessionTotalTokens(entry);

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -10,6 +10,7 @@ import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent
 import { lookupContextTokens } from "../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import {
+  parseModelRef,
   resolveConfiguredModelRef,
   resolveDefaultModelForAgent,
 } from "../agents/model-selection.js";
@@ -653,12 +654,41 @@ export function resolveSessionModelRef(
         defaultProvider: DEFAULT_PROVIDER,
         defaultModel: DEFAULT_MODEL,
       });
+
+  // Prefer the last runtime model recorded on the session entry.
+  // This is the actual model used by the latest run and must win over defaults.
   let provider = resolved.provider;
   let model = resolved.model;
+  const runtimeModel = entry?.model?.trim();
+  const runtimeProvider = entry?.modelProvider?.trim();
+  if (runtimeModel) {
+    const parsedRuntime = parseModelRef(
+      runtimeModel,
+      runtimeProvider || provider || DEFAULT_PROVIDER,
+    );
+    if (parsedRuntime) {
+      provider = parsedRuntime.provider;
+      model = parsedRuntime.model;
+    } else {
+      provider = runtimeProvider || provider;
+      model = runtimeModel;
+    }
+    return { provider, model };
+  }
+
+  // Fall back to explicit per-session override (set at spawn/model-patch time),
+  // then finally to configured defaults.
   const storedModelOverride = entry?.modelOverride?.trim();
   if (storedModelOverride) {
-    provider = entry?.providerOverride?.trim() || provider;
-    model = storedModelOverride;
+    const overrideProvider = entry?.providerOverride?.trim() || provider || DEFAULT_PROVIDER;
+    const parsedOverride = parseModelRef(storedModelOverride, overrideProvider);
+    if (parsedOverride) {
+      provider = parsedOverride.provider;
+      model = parsedOverride.model;
+    } else {
+      provider = overrideProvider;
+      model = storedModelOverride;
+    }
   }
   return { provider, model };
 }


### PR DESCRIPTION
Fixes #18451

## Problem

`openclaw status` and `sessions list` displayed the primary/default model (e.g. `claude-sonnet-4-5`) for sub-agent sessions, even when those sub-agents were actually running on a different model (e.g. `openai-codex/gpt-5.3-codex`).

This made debugging and monitoring confusing — the displayed model didn't match what was actually being used.

## Solution

Updated session model resolution logic to prefer:
1. Runtime session model (the actual model being used)
2. Session override (if explicitly set)
3. Configured default model (fallback)

Previously, the code was falling back to the default model too early, ignoring the runtime model that was already recorded in the session.

## Changes

- `src/gateway/session-utils.ts`: Enhanced `resolveSessionModelRef()` to prioritize runtime model
- `src/commands/status.summary.ts`: Updated status display to use corrected resolution
- `src/commands/sessions.ts`: Updated sessions list to show runtime model
- `src/gateway/session-utils.test.ts`: Added tests for model resolution priority

## Testing

- Ran targeted tests: `pnpm vitest run src/gateway/session-utils.test.ts`
- All tests passing ✅

---

🤖 *AI-assisted: Code changes by gpt-5.3-codex, PR description and verification by claude-sonnet-4-5*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes the `sessions list` and `status` commands to display the actual runtime model for sub-agent sessions instead of always showing the configured default model.

The core change in `resolveSessionModelRef` (`src/gateway/session-utils.ts`) introduces a correct 3-tier priority: runtime model (what actually ran) → session override (set at spawn time) → configured defaults. Previously, `modelOverride` was checked but the runtime `model`/`modelProvider` fields recorded on the session entry were ignored, causing the display to revert to defaults.

- `src/gateway/session-utils.ts`: Core resolution logic updated with runtime model priority and proper `parseModelRef` parsing at each tier
- `src/commands/status.summary.ts`: Now uses the centralized `resolveSessionModelRef` instead of raw `entry.model` fallback
- `src/commands/sessions.ts`: Adds a local `resolveEntryModel` helper with the same priority logic for the CLI sessions display
- `src/gateway/session-utils.test.ts`: Two new test cases covering runtime priority and override fallback

**Note:** `sessions.ts` introduces a local `resolveEntryModel` that duplicates logic from `resolveSessionModelRef` without per-agent model defaults support — see inline comment.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it fixes a clear display bug with correct priority logic and good test coverage for the main code path.
- Score of 4 reflects that the core fix is correct and well-tested, with one minor concern: `resolveEntryModel` in `sessions.ts` duplicates model resolution logic rather than reusing `resolveSessionModelRef`, which could lead to future drift. No functional bugs were found.
- `src/commands/sessions.ts` — contains duplicated model resolution logic that could diverge from `resolveSessionModelRef` over time.

<sub>Last reviewed commit: 6d71a7e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->