### PR TITLE
fix(ios): gateway reliability + chat session fixes

### DIFF
--- a/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
+++ b/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
@@ -32,12 +32,9 @@ struct IOSGatewayChatTransport: OpenClawChatTransport, Sendable {
         return try JSONDecoder().decode(OpenClawChatSessionsListResponse.self, from: res)
     }
 
-    func setActiveSessionKey(_ sessionKey: String) async throws {
-        struct Subscribe: Codable { var sessionKey: String }
-        let data = try JSONEncoder().encode(Subscribe(sessionKey: sessionKey))
-        let json = String(data: data, encoding: .utf8)
-        await self.gateway.sendEvent(event: "chat.subscribe", payloadJSON: json)
-    }
+    // No-op: chat events are broadcast to all connected clients. The old implementation
+    // sent chat.subscribe via node.event, which fails on operator connections (node-only method).
+    func setActiveSessionKey(_ sessionKey: String) async throws {}
 
     func requestHistory(sessionKey: String) async throws -> OpenClawChatHistoryPayload {
         struct Params: Codable { var sessionKey: String }

--- a/apps/ios/Sources/RootCanvas.swift
+++ b/apps/ios/Sources/RootCanvas.swift
@@ -60,7 +60,7 @@ struct RootCanvas: View {
             case .chat:
                 ChatSheet(
                     gateway: self.appModel.operatorSession,
-                    sessionKey: self.appModel.mainSessionKey,
+                    sessionKey: self.appModel.chatSessionKey,
                     agentName: self.appModel.activeAgentName,
                     userAccent: self.appModel.seamColor)
             }

--- a/apps/ios/Sources/Status/StatusActivityBuilder.swift
+++ b/apps/ios/Sources/Status/StatusActivityBuilder.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 
+@MainActor
 enum StatusActivityBuilder {
     static func build(
         appModel: NodeAppModel,


### PR DESCRIPTION
## Summary

- **Ping/pong handler**: Respond to server pings with pong frames to prevent connection drops
- **Conditional tick watcher**: Only start tick monitoring when the server provides `tickIntervalMs`
- **Timeout tuning**: Connect timeout 6→15s, challenge timeout 3→8s for slower networks
- **WebSocket background keepalive**: `beginBackgroundTask` keeps pong handler alive ~30s when app backgrounds
- **Reconnect resilience**: Synthetic seqGap on reconnect triggers automatic chat history refresh
- **Dedicated iOS chat session key**: Separate `ios` session key avoids conflicts with Discord/other integrations
- **Remove chat.subscribe/unsubscribe**: Chat events use broadcast model; old subscribe calls failed on operator connections
- **setActiveSessionKey no-op**: Same broadcast fix for the chat transport layer
- **seqGap handling**: Refresh history instead of showing error text
- **isRunMatch fix**: Don't skip chat events matching our pending runId (fixes cross-session event filtering)
- **Bool type preservation**: `anyCodablePreservingBool` prevents NSNumber→Int coercion for booleans in JSON
- **TTS default mp3_44100**: Switch from PCM to MP3 default output format
- **Bluetooth A2DP support**: Add `.allowBluetoothA2DP` option + auto-select Bluetooth input
- **@MainActor on StatusActivityBuilder**: Fix concurrency annotation
- **includeDeviceIdentity**: Enable device identity for operator connections

## Test plan
- [ ] Connect to gateway, verify ping/pong keeps connection alive (check server logs for pong frames)
- [ ] Background app briefly (<30s), return — connection should stay alive
- [ ] Background app >30s, return — should reconnect within ~3s
- [ ] Send chat message, verify response arrives on iOS `ios` session key
- [ ] Disconnect/reconnect gateway — chat should auto-refresh history (no "Event stream interrupted" error)
- [ ] Verify Bluetooth audio routing works with AirPods for talk mode
- [ ] Confirm no `GatewayDiagnostics.log` or `chatUILogger.info` additions in diff

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves iOS gateway connection reliability and fixes chat session handling through several coordinated changes:

- **Gateway keepalive**: Adds ping/pong frame handling in `GatewayChannel` and iOS background task keepalive (~30s) to prevent server-side connection drops during brief app suspensions
- **Conditional tick watcher**: Only starts tick monitoring when the server provides `tickIntervalMs`, avoiding unnecessary reconnect cycles on servers that don't send ticks
- **Dedicated iOS chat session key**: Introduces `chatSessionKey` (base "ios") separate from `mainSessionKey` (base "main") to avoid conflicts with Discord/other integrations sharing the same gateway session
- **Cross-session event filtering fix**: Reorders `isRunMatch` check before the session key filter in `ChatViewModel.handleChatEvent` so events matching a pending runId aren't dropped even if the session key differs — critical for the new "ios" session key to work
- **Reconnect resilience**: Broadcasts a synthetic `seqGap` on reconnection (not first connect) to trigger automatic chat history refresh, replacing the old "Event stream interrupted" error message
- **Broadcast model cleanup**: Makes `setActiveSessionKey`, `subscribeChatIfNeeded`, and `unsubscribeAllChats` no-ops since chat events use a broadcast model; the old `chat.subscribe` via `node.event` failed on operator connections
- **Bool type preservation**: Adds `anyCodablePreservingBool` to prevent NSNumber→Int coercion for booleans in JSON payloads from `JSONSerialization`
- **TTS + Audio**: Switches default output format from PCM to MP3, adds Bluetooth A2DP support with auto-selection of Bluetooth input
- **Timeout tuning**: Connect timeout 6→15s, challenge timeout 3→8s for slower networks
- **`@MainActor` on `StatusActivityBuilder`**: Fixes concurrency annotation for accessing MainActor-bound properties

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — the changes are well-coordinated, address real reliability issues, and the logic is sound across all modified files.
- Score reflects that the changes are logically correct with clear rationale. The ping/pong handler, conditional tick watcher, session key separation, and cross-session event filtering fix all address real issues. The only minor concerns are: (1) `hasEverConnected` not being reset on full `disconnect()` (causes a harmless spurious seqGap when connecting to a different gateway), and (2) the `onFailure` closure parameter renamed from `_` to `failures` but not used (minor style). No security concerns, no breaking API changes.
- `apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift` deserves a closer look due to the `hasEverConnected` lifetime flag behavior across disconnect/reconnect cycles, and `apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift` for the event filtering logic change.

<sub>Last reviewed commit: 9397cde</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->