### PR TITLE
fix(imessage): honor groupConfig regardless of allowlistEnabled

### DIFF
--- a/src/imessage/monitor/inbound-processing.ts
+++ b/src/imessage/monitor/inbound-processing.ts
@@ -129,9 +129,9 @@ export function resolveIMessageInboundDecision(params: {
 
   // If the owner explicitly configures a chat_id under imessage.groups, treat that thread as a
   // "group" for permission gating + session isolation, even when is_group=false.
-  const treatAsGroupByConfig = Boolean(
-    groupIdCandidate && groupListPolicy.allowlistEnabled && groupListPolicy.groupConfig,
-  );
+  // Note: We check for groupConfig regardless of allowlistEnabled — an explicit group entry is
+  // an admin declaration that the chat is a group, independent of the groupPolicy mode.
+  const treatAsGroupByConfig = Boolean(groupIdCandidate && groupListPolicy.groupConfig);
   const isGroup = Boolean(params.message.is_group) || treatAsGroupByConfig;
   if (isGroup && !chatId) {
     return { kind: "drop", reason: "group without chat_id" };


### PR DESCRIPTION
## Summary
Fixes #18645 — iMessage group messages treated as DMs when `imsg` omits `is_group` field.

## Problem
In `inbound-processing.ts`, the `treatAsGroupByConfig` check requires `groupListPolicy.allowlistEnabled` to be true:

```typescript
const treatAsGroupByConfig = Boolean(
  groupIdCandidate && groupListPolicy.allowlistEnabled && groupListPolicy.groupConfig,
);
```

But `allowlistEnabled` is only `true` when `groupPolicy="allowlist"`. When `groupPolicy="open"` (the default), explicit group configurations under `imessage.groups` are ignored — the chat is treated as a DM even when the admin has explicitly configured it as a group.

## Fix
Remove the `allowlistEnabled` requirement. If there's a `groupConfig` for a `chat_id`, that's an explicit admin declaration that the chat is a group, independent of the `groupPolicy` mode:

```typescript
const treatAsGroupByConfig = Boolean(groupIdCandidate && groupListPolicy.groupConfig);
```

## Impact
**Privacy/Security**: Group conversations can be incorrectly treated as DMs when the `imsg` RPC omits the `is_group` field — this could leak group context to unintended sessions or cause messages to be processed with DM-level permissions.

## Testing
All 26 iMessage tests pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes the `allowlistEnabled` requirement from the `treatAsGroupByConfig` check in `src/imessage/monitor/inbound-processing.ts:134`. When an admin explicitly configures a `chat_id` under `imessage.groups`, that configuration is now honored regardless of the `groupPolicy` mode (open vs allowlist). This fixes a bug where group configurations were ignored when `groupPolicy="open"` (the default), causing group chats to be incorrectly treated as DMs when the iMessage RPC omitted the `is_group` field.

- Correctly decouples explicit group configuration from the allowlist enforcement mechanism
- The downstream allowlist check (line 173) still enforces group allowlist restrictions when needed
- Existing test at line 152-185 validates this exact scenario

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk - it's a well-isolated bug fix with existing test coverage
- The fix correctly addresses the issue by removing an overly restrictive condition. The change is minimal (one line removed, comment added), the logic is sound, existing tests validate the behavior, and all 26 iMessage tests pass. The downstream allowlist enforcement at line 173 remains intact, so no security restrictions are weakened.
- No files require special attention

<sub>Last reviewed commit: 96917db</sub>

<!-- greptile_other_comments_section -->

<sub>(1/5) You can manually trigger the agent by mentioning @greptileai in a comment!</sub>

<!-- /greptile_comment -->