### PR TITLE
feat: add first-class Claude Code CLI auth path + CLI model UX hardening

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -303,7 +303,7 @@ Options:
 - `--non-interactive`
 - `--mode <local|remote>`
 - `--flow <quickstart|advanced|manual>` (manual is an alias for advanced)
-- `--auth-choice <setup-token|token|chutes|openai-codex|openai-api-key|openrouter-api-key|ai-gateway-api-key|moonshot-api-key|moonshot-api-key-cn|kimi-code-api-key|synthetic-api-key|venice-api-key|gemini-api-key|zai-api-key|apiKey|minimax-api|minimax-api-lightning|opencode-zen|custom-api-key|skip>`
+- `--auth-choice <setup-token|token|claude-code-cli|chutes|openai-codex|openai-api-key|openrouter-api-key|ai-gateway-api-key|moonshot-api-key|moonshot-api-key-cn|kimi-code-api-key|synthetic-api-key|venice-api-key|gemini-api-key|zai-api-key|apiKey|minimax-api|minimax-api-lightning|opencode-zen|custom-api-key|skip>`
 - `--token-provider <id>` (non-interactive; used with `--auth-choice token`)
 - `--token <token>` (non-interactive; used with `--auth-choice token`)
 - `--token-profile-id <id>` (non-interactive; default: `<provider>:manual`)
@@ -746,12 +746,18 @@ Tip: when calling `config.set`/`config.apply`/`config.patch` directly, pass `bas
 
 See [/concepts/models](/concepts/models) for fallback behavior and scanning strategy.
 
-Preferred Anthropic auth (setup-token):
+Preferred Anthropic subscription auth (Claude Code OAuth):
+
+```bash
+openclaw onboard --auth-choice claude-code-cli
+openclaw models status
+```
+
+Setup-token fallback:
 
 ```bash
 claude setup-token
 openclaw models auth setup-token --provider anthropic
-openclaw models status
 ```
 
 ### `models` (root)

--- a/docs/cli/onboard.md
+++ b/docs/cli/onboard.md
@@ -26,6 +26,13 @@ openclaw onboard --flow manual
 openclaw onboard --mode remote --remote-url ws://gateway-host:18789
 ```
 
+Non-interactive Claude Code CLI (use Claude app subscription as primary model):
+
+```bash
+openclaw onboard --non-interactive \
+  --auth-choice claude-code-cli
+```
+
 Non-interactive custom provider:
 
 ```bash

--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -53,10 +53,10 @@ OpenClaw ships with the pi‑ai catalog. These providers require **no**
 ### Anthropic
 
 - Provider: `anthropic`
-- Auth: `ANTHROPIC_API_KEY` or `claude setup-token`
+- Auth: Claude Code OAuth (`claude-code-cli`), `claude setup-token`, or `ANTHROPIC_API_KEY`
 - Optional rotation: `ANTHROPIC_API_KEYS`, `ANTHROPIC_API_KEY_1`, `ANTHROPIC_API_KEY_2`, plus `OPENCLAW_LIVE_ANTHROPIC_KEY` (single override)
 - Example model: `anthropic/claude-opus-4-6`
-- CLI: `openclaw onboard --auth-choice token` (paste setup-token) or `openclaw models auth paste-token --provider anthropic`
+- CLI: `openclaw onboard --auth-choice claude-code-cli` (preferred for subscriptions), `openclaw onboard --auth-choice token` (setup-token paste), or `openclaw models auth paste-token --provider anthropic`
 
 ```json5
 {

--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -42,8 +42,8 @@ openclaw onboard
 ```
 
 It can set up model + auth for common providers, including **OpenAI Code (Codex)
-subscription** (OAuth) and **Anthropic** (API key recommended; `claude
-setup-token` also supported).
+subscription** (OAuth) and **Anthropic** (Claude Code OAuth, API key, or
+`claude setup-token`).
 
 ## Config keys (overview)
 
@@ -160,11 +160,18 @@ JSON includes `auth.oauth` (warn window + profiles) and `auth.providers`
 (effective auth per provider).
 Use `--check` for automation (exit `1` when missing/expired, `2` when expiring).
 
-Preferred Anthropic auth is the Claude Code CLI setup-token (run anywhere; paste on the gateway host if needed):
+Preferred Anthropic subscription auth is Claude Code OAuth:
+
+```bash
+openclaw onboard --auth-choice claude-code-cli
+openclaw models status
+```
+
+If OAuth is unavailable for your environment, use setup-token as a fallback:
 
 ```bash
 claude setup-token
-openclaw models status
+openclaw models auth paste-token --provider anthropic
 ```
 
 ## Scanning (OpenRouter free models)

--- a/docs/concepts/oauth.md
+++ b/docs/concepts/oauth.md
@@ -10,7 +10,7 @@ title: "OAuth"
 
 # OAuth
 
-OpenClaw supports “subscription auth” via OAuth for providers that offer it (notably **OpenAI Codex (ChatGPT OAuth)**). For Anthropic subscriptions, use the **setup-token** flow. This page explains:
+OpenClaw supports subscription auth via OAuth for both **Anthropic (Claude Code CLI credentials)** and **OpenAI Codex (ChatGPT OAuth)**. Anthropic also supports the **setup-token** flow as a manual fallback. This page explains:
 
 - how the OAuth **token exchange** works (PKCE)
 - where tokens are **stored** (and why)
@@ -49,9 +49,15 @@ Legacy import-only file (still supported, but not the main store):
 
 All of the above also respect `$OPENCLAW_STATE_DIR` (state dir override). Full reference: [/gateway/configuration](/gateway/configuration#auth-storage-oauth--api-keys)
 
-## Anthropic setup-token (subscription auth)
+## Anthropic Claude subscription auth
 
-Run `claude setup-token` on any machine, then paste it into OpenClaw:
+Preferred path (official Claude Code OAuth credentials via local `claude` CLI):
+
+```bash
+openclaw onboard --auth-choice claude-code-cli
+```
+
+Manual fallback path (setup-token):
 
 ```bash
 openclaw models auth setup-token --provider anthropic
@@ -73,15 +79,19 @@ openclaw models status
 
 OpenClaw’s interactive login flows are implemented in `@mariozechner/pi-ai` and wired into the wizards/commands.
 
-### Anthropic (Claude Pro/Max) setup-token
+### Anthropic (Claude Pro/Max): Claude Code OAuth or setup-token
 
-Flow shape:
+Preferred flow shape (Claude Code OAuth):
+
+1. choose `openclaw onboard --auth-choice claude-code-cli`
+2. OpenClaw uses the local `claude` CLI auth context on the gateway host
+3. run Claude models via `claude-cli/*` as primary or fallback
+
+Manual fallback flow shape (setup-token):
 
 1. run `claude setup-token`
 2. paste the token into OpenClaw
 3. store as a token auth profile (no refresh)
-
-The wizard path is `openclaw onboard` → auth choice `setup-token` (Anthropic).
 
 ### OpenAI Codex (ChatGPT OAuth)
 

--- a/docs/gateway/authentication.md
+++ b/docs/gateway/authentication.md
@@ -8,12 +8,24 @@ title: "Authentication"
 
 # Authentication
 
-OpenClaw supports OAuth and API keys for model providers. For Anthropic
-accounts, we recommend using an **API key**. For Claude subscription access,
-use the long‑lived token created by `claude setup-token`.
+OpenClaw supports OAuth and API keys for model providers. For Anthropic,
+OpenClaw supports three paths:
+
+1. **Claude Code OAuth** (preferred for Claude subscriptions)
+2. **setup-token** (manual/headless fallback)
+3. **API key** (usage-based billing; common for production/multi-user)
 
 See [/concepts/oauth](/concepts/oauth) for the full OAuth flow and storage
 layout.
+
+## Anthropic: Claude Code OAuth (preferred for subscriptions)
+
+```bash
+openclaw onboard --auth-choice claude-code-cli
+```
+
+This configures `claude-cli/*` models so OpenClaw can use the official local
+`claude` CLI auth context on the gateway host.
 
 ## Recommended Anthropic setup (API key)
 
@@ -49,10 +61,9 @@ API keys for daemon use: `openclaw onboard`.
 See [Help](/help) for details on env inheritance (`env.shellEnv`,
 `~/.openclaw/.env`, systemd/launchd).
 
-## Anthropic: setup-token (subscription auth)
+## Anthropic: setup-token (manual subscription fallback)
 
-For Anthropic, the recommended path is an **API key**. If you’re using a Claude
-subscription, the setup-token flow is also supported. Run it on the **gateway host**:
+If Claude Code OAuth is unavailable for your environment, setup-token is supported. Run it on the **gateway host**:
 
 ```bash
 claude setup-token

--- a/docs/gateway/cli-backends.md
+++ b/docs/gateway/cli-backends.md
@@ -1,24 +1,25 @@
 ---
-summary: "CLI backends: text-only fallback via local AI CLIs"
+summary: "CLI backends: text-only runtime via local AI CLIs (primary or fallback)"
 read_when:
-  - You want a reliable fallback when API providers fail
+  - You want to run local AI CLIs as a primary model path or fallback
   - You are running Claude Code CLI or other local AI CLIs and want to reuse them
   - You need a text-only, tool-free path that still supports sessions and images
 title: "CLI Backends"
 ---
 
-# CLI backends (fallback runtime)
+# CLI backends (text-only runtime)
 
-OpenClaw can run **local AI CLIs** as a **text-only fallback** when API providers are down,
-rate-limited, or temporarily misbehaving. This is intentionally conservative:
+OpenClaw can run **local AI CLIs** as a **text-only model path** — either as your
+primary model or as fallback when API providers are down, rate-limited, or
+temporarily misbehaving. This is intentionally conservative:
 
 - **Tools are disabled** (no tool calls).
 - **Text in → text out** (reliable).
 - **Sessions are supported** (so follow-up turns stay coherent).
 - **Images can be passed through** if the CLI accepts image paths.
 
-This is designed as a **safety net** rather than a primary path. Use it when you
-want “always works” text responses without relying on external APIs.
+Use this when you want reliable text responses without depending entirely on
+external APIs.
 
 ## Beginner-friendly quick start
 
@@ -52,6 +53,31 @@ command path:
 ```
 
 That’s it. No keys, no extra auth config needed beyond the CLI itself.
+
+## Using it as a primary model
+
+If you want Claude Code CLI to be the default path (not only fallback), set it as
+`agents.defaults.model.primary`:
+
+```json5
+{
+  agents: {
+    defaults: {
+      model: {
+        primary: "claude-cli/opus-4.6",
+      },
+      models: {
+        "claude-cli/opus-4.6": { alias: "claude" },
+      },
+      cliBackends: {
+        "claude-cli": {
+          command: "/opt/homebrew/bin/claude", // optional if PATH already includes `claude`
+        },
+      },
+    },
+  },
+}
+```
 
 ## Using it as a fallback
 

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -734,7 +734,7 @@ Z.AI models enable `tool_stream` by default for tool call streaming. Set `agents
 
 ### `agents.defaults.cliBackends`
 
-Optional CLI backends for text-only fallback runs (no tool calls). Useful as a backup when API providers fail.
+Optional CLI backends for text-only runs (no tool calls). You can use them as a primary model path or as fallback when API providers fail.
 
 ```json5
 {
@@ -763,6 +763,8 @@ Optional CLI backends for text-only fallback runs (no tool calls). Useful as a b
 ```
 
 - CLI backends are text-first; tools are always disabled.
+- Set `agents.defaults.model.primary` to `claude-cli/...` (or another CLI provider) to use a CLI backend as your primary model path.
+- Or keep API models primary and add CLI models under `agents.defaults.model.fallbacks`.
 - Sessions supported when `sessionArg` is set.
 - Image pass-through supported when `imageArg` accepts file paths.
 

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -656,7 +656,7 @@ Docs: [Update](/cli/update), [Updating](/install/updating).
 
 `openclaw onboard` is the recommended setup path. In **local mode** it walks you through:
 
-- **Model/auth setup** (Anthropic **setup-token** recommended for Claude subscriptions, OpenAI Codex OAuth supported, API keys optional, LM Studio local models supported)
+- **Model/auth setup** (Anthropic **Claude Code OAuth** or setup-token for Claude subscriptions, OpenAI Codex OAuth supported, API keys optional, LM Studio local models supported)
 - **Workspace** location + bootstrap files
 - **Gateway settings** (bind/port/auth/tailscale)
 - **Providers** (WhatsApp, Telegram, Discord, Mattermost (plugin), Signal, iMessage)
@@ -700,7 +700,12 @@ Copy the token it prints, then choose **Anthropic token (paste setup-token)** in
 
 ### Do you support Claude subscription auth (Claude Pro or Max)
 
-Yes - via **setup-token**. OpenClaw no longer reuses Claude Code CLI OAuth tokens; use a setup-token or an Anthropic API key. Generate the token anywhere and paste it on the gateway host. See [Anthropic](/providers/anthropic) and [OAuth](/concepts/oauth).
+Yes. OpenClaw supports Claude subscription auth via **Claude Code OAuth** (first-class) and **setup-token** (manual fallback).
+
+- Preferred: `openclaw onboard --auth-choice claude-code-cli`
+- Fallback (headless/remote): run `claude setup-token` and paste with `openclaw models auth paste-token --provider anthropic`
+
+See [Anthropic](/providers/anthropic) and [OAuth](/concepts/oauth).
 
 Note: Claude subscription access is governed by Anthropic's terms. For production or multi-user workloads, API keys are usually the safer choice.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,7 +54,7 @@ OpenClaw is a **self-hosted gateway** that connects your favorite chat apps — 
 - **Agent-native**: built for coding agents with tool use, sessions, memory, and multi-agent routing
 - **Open source**: MIT licensed, community-driven
 
-**What do you need?** Node 22+, an API key (Anthropic recommended), and 5 minutes.
+**What do you need?** Node 22+, provider auth (API key or supported subscription OAuth), and 5 minutes.
 
 ## How it works
 

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -1,15 +1,15 @@
 ---
-summary: "Use Anthropic Claude via API keys or setup-token in OpenClaw"
+summary: "Use Anthropic Claude via Claude Code OAuth, API keys, or setup-token in OpenClaw"
 read_when:
   - You want to use Anthropic models in OpenClaw
-  - You want setup-token instead of API keys
+  - You want Claude Code OAuth or setup-token instead of API keys
 title: "Anthropic"
 ---
 
 # Anthropic (Claude)
 
 Anthropic builds the **Claude** model family and provides access via an API.
-In OpenClaw you can authenticate with an API key or a **setup-token**.
+In OpenClaw you can authenticate with **Claude Code OAuth**, an API key, or a **setup-token**.
 
 ## Option A: Anthropic API key
 
@@ -34,6 +34,24 @@ openclaw onboard --anthropic-api-key "$ANTHROPIC_API_KEY"
   agents: { defaults: { model: { primary: "anthropic/claude-opus-4-6" } } },
 }
 ```
+
+## Option B: Claude subscription via Claude Code OAuth
+
+**Best for:** primary Claude subscription auth without an Anthropic API key.
+
+### CLI setup
+
+```bash
+openclaw onboard --auth-choice claude-code-cli
+```
+
+This configures `claude-cli/*` models so OpenClaw can use the official local
+`claude` CLI auth context on the gateway host.
+
+Notes:
+
+- Ensure `claude` is installed, on PATH, and signed in on the gateway host.
+- Use this as primary (`agents.defaults.model.primary = "claude-cli/..."`) or fallback.
 
 ## Prompt caching (Anthropic API)
 
@@ -101,7 +119,7 @@ with `params.context1m: true` for supported Opus/Sonnet models.
 OpenClaw maps this to `anthropic-beta: context-1m-2025-08-07` on Anthropic
 requests.
 
-## Option B: Claude setup-token
+## Option C: Claude setup-token (manual fallback)
 
 **Best for:** using your Claude subscription.
 

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -16,7 +16,7 @@ In OpenClaw you can authenticate with **Claude Code OAuth**, an API key, or a **
 **Best for:** standard API access and usage-based billing.
 Create your API key in the Anthropic Console.
 
-### CLI setup
+### CLI setup (API key)
 
 ```bash
 openclaw onboard
@@ -39,7 +39,7 @@ openclaw onboard --anthropic-api-key "$ANTHROPIC_API_KEY"
 
 **Best for:** primary Claude subscription auth without an Anthropic API key.
 
-### CLI setup
+### CLI setup (Claude Code OAuth)
 
 ```bash
 openclaw onboard --auth-choice claude-code-cli

--- a/docs/reference/wizard.md
+++ b/docs/reference/wizard.md
@@ -29,9 +29,9 @@ For a high-level overview, see [Onboarding Wizard](/start/wizard).
   </Step>
   <Step title="Model/Auth">
     - **Anthropic API key (recommended)**: uses `ANTHROPIC_API_KEY` if present or prompts for a key, then saves it for daemon use.
-    - **Anthropic OAuth (Claude Code CLI)**: on macOS the wizard checks Keychain item "Claude Code-credentials" (choose "Always Allow" so launchd starts don't block); on Linux/Windows it reuses `~/.claude/.credentials.json` if present.
+    - **Claude Code CLI (local app subscription)**: configures `claude-cli/*` models so OpenClaw can use the official local `claude` CLI (primary or fallback) without an Anthropic API key. Ensure `claude` is installed, on PATH, and signed in on the gateway host.
     - **Anthropic token (paste setup-token)**: run `claude setup-token` on any machine, then paste the token (you can name it; blank = default).
-    - **OpenAI Code (Codex) subscription (Codex CLI)**: if `~/.codex/auth.json` exists, the wizard can reuse it.
+    - **OpenAI Code (Codex CLI backend)**: optional local CLI path via `codex-cli/*` model refs; requires a working local Codex CLI login on the host.
     - **OpenAI Code (Codex) subscription (OAuth)**: browser flow; paste the `code#state`.
       - Sets `agents.defaults.model` to `openai-codex/gpt-5.2` when model is unset or `openai/*`.
     - **OpenAI API key**: uses `OPENAI_API_KEY` if present or prompts for a key, then saves it to `~/.openclaw/.env` so launchd can read it.

--- a/docs/start/wizard-cli-automation.md
+++ b/docs/start/wizard-cli-automation.md
@@ -34,6 +34,15 @@ Add `--json` for a machine-readable summary.
 ## Provider-specific examples
 
 <AccordionGroup>
+  <Accordion title="Claude Code CLI example">
+    ```bash
+    openclaw onboard --non-interactive \
+      --mode local \
+      --auth-choice claude-code-cli \
+      --gateway-port 18789 \
+      --gateway-bind loopback
+    ```
+  </Accordion>
   <Accordion title="Gemini example">
     ```bash
     openclaw onboard --non-interactive \

--- a/docs/start/wizard-cli-reference.md
+++ b/docs/start/wizard-cli-reference.md
@@ -16,7 +16,7 @@ For the short guide, see [Onboarding Wizard (CLI)](/start/wizard).
 
 Local mode (default) walks you through:
 
-- Model and auth setup (OpenAI Code subscription OAuth, Anthropic API key or setup token, plus MiniMax, GLM, Moonshot, and AI Gateway options)
+- Model and auth setup (Anthropic Claude Code OAuth, Anthropic setup-token/API key, OpenAI Code subscription OAuth, plus MiniMax, GLM, Moonshot, and AI Gateway options)
 - Workspace location and bootstrap files
 - Gateway settings (port, bind, auth, tailscale)
 - Channels and providers (Telegram, WhatsApp, Discord, Google Chat, Mattermost plugin, Signal)
@@ -118,19 +118,20 @@ What you set:
   <Accordion title="Anthropic API key (recommended)">
     Uses `ANTHROPIC_API_KEY` if present or prompts for a key, then saves it for daemon use.
   </Accordion>
-  <Accordion title="Anthropic OAuth (Claude Code CLI)">
-    - macOS: checks Keychain item "Claude Code-credentials"
-    - Linux and Windows: reuses `~/.claude/.credentials.json` if present
+  <Accordion title="Claude Code CLI (local app subscription)">
+    Configures `claude-cli/*` models so OpenClaw can use the official local `claude` CLI
+    (primary or fallback) without an Anthropic API key.
 
-    On macOS, choose "Always Allow" so launchd starts do not block.
+    Ensure `claude` is installed, on PATH, and signed in on the gateway host.
 
   </Accordion>
   <Accordion title="Anthropic token (setup-token paste)">
     Run `claude setup-token` on any machine, then paste the token.
     You can name it; blank uses default.
   </Accordion>
-  <Accordion title="OpenAI Code subscription (Codex CLI reuse)">
-    If `~/.codex/auth.json` exists, the wizard can reuse it.
+  <Accordion title="OpenAI Code (Codex CLI backend)">
+    Optional local CLI path via `codex-cli/*` model refs.
+    Requires a working local Codex CLI login on the host.
   </Accordion>
   <Accordion title="OpenAI Code subscription (OAuth)">
     Browser flow; paste `code#state`.

--- a/docs/start/wizard.md
+++ b/docs/start/wizard.md
@@ -63,8 +63,8 @@ The wizard starts with **QuickStart** (defaults) vs **Advanced** (full control).
 
 **Local mode (default)** walks you through these steps:
 
-1. **Model/Auth** — Anthropic API key (recommended), OpenAI, or Custom Provider
-   (OpenAI-compatible, Anthropic-compatible, or Unknown auto-detect). Pick a default model.
+1. **Model/Auth** — Anthropic Claude Code OAuth (`claude-code-cli`), Anthropic/OpenAI API keys,
+   setup-token paste, or Custom Provider (OpenAI-compatible, Anthropic-compatible, or Unknown auto-detect). Pick a default model.
 2. **Workspace** — Location for agent files (default `~/.openclaw/workspace`). Seeds bootstrap files.
 3. **Gateway** — Port, bind address, auth mode, Tailscale exposure.
 4. **Channels** — WhatsApp, Telegram, Discord, Google Chat, Mattermost, Signal, BlueBubbles, or iMessage.

--- a/src/agents/cli-backend-readiness.test.ts
+++ b/src/agents/cli-backend-readiness.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveCliBackendReadiness } from "./cli-backend-readiness.js";
+
+describe("resolveCliBackendReadiness", () => {
+  it("returns backend_config_error when backend command is empty", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          cliBackends: {
+            "claude-cli": {
+              command: "   ",
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const readiness = resolveCliBackendReadiness({
+      provider: "claude-cli",
+      cfg,
+    });
+
+    expect(readiness.status).toBe("backend_config_error");
+    expect(readiness.detail).toContain("missing or invalid");
+  });
+
+  it("returns backend_config_error when command includes inline args", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          cliBackends: {
+            "claude-cli": {
+              command: "claude --output-format json",
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const readiness = resolveCliBackendReadiness({
+      provider: "claude-cli",
+      cfg,
+    });
+
+    expect(readiness.status).toBe("backend_config_error");
+    expect(readiness.hint).toContain(".args");
+  });
+
+  it("returns ready for absolute executable command path", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          cliBackends: {
+            "custom-cli": {
+              command: process.execPath,
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const readiness = resolveCliBackendReadiness({
+      provider: "custom-cli",
+      cfg,
+    });
+
+    expect(readiness.status).toBe("ready");
+    expect(readiness.resolvedPath).toBe(process.execPath);
+  });
+});

--- a/src/agents/cli-backend-readiness.ts
+++ b/src/agents/cli-backend-readiness.ts
@@ -1,0 +1,132 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveCliBackendConfig } from "./cli-backends.js";
+
+export type CliBackendReadinessStatus = "ready" | "backend_config_error" | "command_unresolvable";
+
+export type CliBackendReadiness = {
+  provider: string;
+  backendId: string;
+  command: string;
+  resolvedPath?: string;
+  status: CliBackendReadinessStatus;
+  detail: string;
+  hint?: string;
+};
+
+function resolveCommandPath(command: string): string | undefined {
+  const trimmed = command.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  if (trimmed.includes("/") || trimmed.includes("\\")) {
+    return fs.existsSync(trimmed) ? trimmed : undefined;
+  }
+
+  const lookupCommand = process.platform === "win32" ? "where" : "which";
+  const result = spawnSync(lookupCommand, [trimmed], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  if (result.status !== 0) {
+    return undefined;
+  }
+
+  const match = result.stdout
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .find((line) => line.length > 0);
+  return match;
+}
+
+function isLikelyCommandWithArgs(command: string): boolean {
+  const trimmed = command.trim();
+  if (!trimmed) {
+    return false;
+  }
+  return /\s/u.test(trimmed) && !fs.existsSync(trimmed);
+}
+
+function defaultMissingConfig(provider: string): CliBackendReadiness {
+  return {
+    provider,
+    backendId: provider,
+    command: "",
+    status: "backend_config_error",
+    detail: `CLI backend "${provider}" is missing or invalid.`,
+    hint: `Set agents.defaults.cliBackends["${provider}"].command to an installed executable (for example: "claude").`,
+  };
+}
+
+export function resolveCliBackendReadiness(params: {
+  provider: string;
+  cfg: OpenClawConfig;
+}): CliBackendReadiness {
+  const provider = params.provider.trim();
+  const backend = resolveCliBackendConfig(provider, params.cfg);
+  if (!backend) {
+    return defaultMissingConfig(provider);
+  }
+
+  const command = backend.config.command.trim();
+  if (!command) {
+    return {
+      provider,
+      backendId: backend.id,
+      command,
+      status: "backend_config_error",
+      detail: `CLI backend "${backend.id}" command is empty.`,
+      hint: `Set agents.defaults.cliBackends["${backend.id}"].command to an installed executable.`,
+    };
+  }
+
+  if (isLikelyCommandWithArgs(command)) {
+    return {
+      provider,
+      backendId: backend.id,
+      command,
+      status: "backend_config_error",
+      detail: `CLI backend "${backend.id}" command looks like command + flags: ${command}`,
+      hint: `Set only the executable in agents.defaults.cliBackends["${backend.id}"].command and move flags to agents.defaults.cliBackends["${backend.id}"].args.`,
+    };
+  }
+
+  const resolvedPath = resolveCommandPath(command);
+  if (!resolvedPath) {
+    return {
+      provider,
+      backendId: backend.id,
+      command,
+      status: "command_unresolvable",
+      detail: `CLI backend command not found: ${command}`,
+      hint: `Install the CLI or set an absolute command path in agents.defaults.cliBackends["${backend.id}"].command.`,
+    };
+  }
+
+  return {
+    provider,
+    backendId: backend.id,
+    command,
+    resolvedPath,
+    status: "ready",
+    detail: `CLI backend command resolved: ${resolvedPath}`,
+  };
+}
+
+export function resolveCliProvidersReadiness(params: {
+  providers: string[];
+  cfg: OpenClawConfig;
+}): CliBackendReadiness[] {
+  const uniqueProviders = Array.from(
+    new Set(params.providers.map((provider) => provider.trim()).filter(Boolean)),
+  ).toSorted((a, b) => a.localeCompare(b));
+
+  return uniqueProviders.map((provider) =>
+    resolveCliBackendReadiness({
+      provider,
+      cfg: params.cfg,
+    }),
+  );
+}

--- a/src/agents/live-auth-keys.test.ts
+++ b/src/agents/live-auth-keys.test.ts
@@ -19,6 +19,7 @@ describe("isAnthropicBillingError", () => {
     const samples = [
       "HTTP 402 Payment Required",
       "status: 402",
+      "status code 402",
       "error code 402",
       '{"status":402,"type":"error"}',
       '{"code":402,"message":"payment required"}',

--- a/src/agents/live-auth-keys.ts
+++ b/src/agents/live-auth-keys.ts
@@ -192,7 +192,7 @@ export function isAnthropicBillingError(message: string): boolean {
     return true;
   }
   if (
-    /["']?(?:status|code)["']?\s*[:=]\s*402\b|\bhttp\s*402\b|\berror(?:\s+code)?\s*[:=]?\s*402\b|\b(?:got|returned|received)\s+(?:a\s+)?402\b|^\s*402\spayment/i.test(
+    /["']?(?:status(?:\s+code)?|code)["']?(?:\s*[:=]\s*|\s+)402\b|\bhttp\s*402\b|\berror(?:\s+code)?\s*[:=]?\s*402\b|\b(?:got|returned|received)\s+(?:a\s+)?402\b|^\s*402\s+payment/i.test(
       lower,
     )
   ) {

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -236,6 +236,14 @@ describe("runWithModelFallback", () => {
     });
   });
 
+  it("falls back on insufficient_quota billing errors", async () => {
+    await expectFallsBackToHaiku({
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      firstError: new Error("Error: insufficient_quota"),
+    });
+  });
+
   it("falls back to configured primary for override credential validation errors", async () => {
     const cfg = makeCfg();
     const run = vi.fn().mockImplementation(async (provider, model) => {

--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -74,6 +74,16 @@ describe("formatAssistantErrorText", () => {
     const result = formatAssistantErrorText(msg);
     expect(result).toBe(BILLING_ERROR_USER_MESSAGE);
   });
+  it("returns a friendly billing message for insufficient_quota", () => {
+    const msg = makeAssistantError("insufficient_quota");
+    const result = formatAssistantErrorText(msg);
+    expect(result).toBe(BILLING_ERROR_USER_MESSAGE);
+  });
+  it("returns a friendly billing message for credits exhausted", () => {
+    const msg = makeAssistantError("Your credits are exhausted");
+    const result = formatAssistantErrorText(msg);
+    expect(result).toBe(BILLING_ERROR_USER_MESSAGE);
+  });
   it("includes provider and assistant model in billing message when provider is given", () => {
     const msg = makeAssistantError("insufficient credits");
     const result = formatAssistantErrorText(msg, { provider: "Anthropic" });

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -42,6 +42,11 @@ describe("isBillingErrorMessage", () => {
     const samples = [
       "Your credit balance is too low to access the Anthropic API.",
       "insufficient credits",
+      "insufficient_quota",
+      "exceeded your current quota",
+      "billing hard limit reached",
+      "out of credits",
+      "credits exhausted",
       "Payment Required",
       "HTTP 402 Payment Required",
       "plans & billing",
@@ -73,6 +78,7 @@ describe("isBillingErrorMessage", () => {
     const realErrors = [
       "HTTP 402 Payment Required",
       "status: 402",
+      "status code 402",
       "error code 402",
       "http 402",
       "status=402 payment required",
@@ -336,6 +342,8 @@ describe("classifyFailoverReason", () => {
     expect(classifyFailoverReason("no api key found")).toBe("auth");
     expect(classifyFailoverReason("429 too many requests")).toBe("rate_limit");
     expect(classifyFailoverReason("resource has been exhausted")).toBe("rate_limit");
+    expect(classifyFailoverReason("insufficient_quota")).toBe("billing");
+    expect(classifyFailoverReason("exceeded your current quota")).toBe("billing");
     expect(
       classifyFailoverReason(
         '{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -561,7 +561,6 @@ type ErrorPattern = RegExp | string;
 const ERROR_PATTERNS = {
   rateLimit: [
     /rate[_ ]limit|too many requests|429/,
-    "exceeded your current quota",
     "resource has been exhausted",
     "quota exceeded",
     "resource_exhausted",
@@ -584,12 +583,17 @@ const ERROR_PATTERNS = {
     /\bunhandled stop reason:\s*abort\b/i,
   ],
   billing: [
-    /["']?(?:status|code)["']?\s*[:=]\s*402\b|\bhttp\s*402\b|\berror(?:\s+code)?\s*[:=]?\s*402\b|\b(?:got|returned|received)\s+(?:a\s+)?402\b|^\s*402\s+payment/i,
+    /["']?(?:status(?:\s+code)?|code)["']?(?:\s*[:=]\s*|\s+)402\b|\bhttp\s*402\b|\berror(?:\s+code)?\s*[:=]?\s*402\b|\b(?:got|returned|received)\s+(?:a\s+)?402\b|^\s*402\s+payment/i,
     "payment required",
     "insufficient credits",
+    "insufficient_quota",
+    "exceeded your current quota",
     "credit balance",
     "plans & billing",
     "insufficient balance",
+    /\bbilling (?:hard|soft) limit reached\b/i,
+    /\b(?:out of|no)\s+credits?\b/i,
+    /\bcredits?\s+(?:are\s+)?(?:exhausted|depleted)\b/i,
   ],
   auth: [
     /invalid[_ ]?api[_ ]?key/,

--- a/src/cli/program/register.onboard.ts
+++ b/src/cli/program/register.onboard.ts
@@ -40,7 +40,7 @@ function resolveInstallDaemonFlag(
 }
 
 const AUTH_CHOICE_HELP = formatAuthChoiceChoicesForCli({
-  includeLegacyAliases: true,
+  includeLegacyAliases: false,
   includeSkip: true,
 });
 

--- a/src/commands/auth-choice-legacy.test.ts
+++ b/src/commands/auth-choice-legacy.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { isDeprecatedAuthChoice, normalizeLegacyOnboardAuthChoice } from "./auth-choice-legacy.js";
+
+describe("normalizeLegacyOnboardAuthChoice", () => {
+  it("maps oauth to setup-token", () => {
+    expect(normalizeLegacyOnboardAuthChoice("oauth")).toBe("setup-token");
+  });
+
+  it("maps claude-cli to claude-code-cli", () => {
+    expect(normalizeLegacyOnboardAuthChoice("claude-cli")).toBe("claude-code-cli");
+  });
+
+  it("maps codex-cli to openai-codex", () => {
+    expect(normalizeLegacyOnboardAuthChoice("codex-cli")).toBe("openai-codex");
+  });
+
+  it("keeps non-legacy choices unchanged", () => {
+    expect(normalizeLegacyOnboardAuthChoice("claude-code-cli")).toBe("claude-code-cli");
+    expect(normalizeLegacyOnboardAuthChoice("token")).toBe("token");
+  });
+});
+
+describe("isDeprecatedAuthChoice", () => {
+  it("still marks claude-cli and codex-cli as deprecated aliases", () => {
+    expect(isDeprecatedAuthChoice("claude-cli")).toBe(true);
+    expect(isDeprecatedAuthChoice("codex-cli")).toBe(true);
+  });
+
+  it("does not mark current choices as deprecated", () => {
+    expect(isDeprecatedAuthChoice("claude-code-cli")).toBe(false);
+    expect(isDeprecatedAuthChoice("token")).toBe(false);
+  });
+});

--- a/src/commands/auth-choice-legacy.ts
+++ b/src/commands/auth-choice-legacy.ts
@@ -12,8 +12,11 @@ export const AUTH_CHOICE_LEGACY_ALIASES_FOR_CLI: ReadonlyArray<AuthChoice> = [
 export function normalizeLegacyOnboardAuthChoice(
   authChoice: AuthChoice | undefined,
 ): AuthChoice | undefined {
-  if (authChoice === "oauth" || authChoice === "claude-cli") {
+  if (authChoice === "oauth") {
     return "setup-token";
+  }
+  if (authChoice === "claude-cli") {
+    return "claude-code-cli";
   }
   if (authChoice === "codex-cli") {
     return "openai-codex";

--- a/src/commands/auth-choice-options.test.ts
+++ b/src/commands/auth-choice-options.test.ts
@@ -22,10 +22,11 @@ describe("buildAuthChoiceOptions", () => {
     expect(options.find((opt) => opt.value === "github-copilot")).toBeDefined();
   });
 
-  it("includes setup-token option for Anthropic", () => {
+  it("includes setup-token and Claude Code CLI options for Anthropic", () => {
     const options = getOptions();
 
     expect(options.some((opt) => opt.value === "token")).toBe(true);
+    expect(options.some((opt) => opt.value === "claude-code-cli")).toBe(true);
   });
 
   it.each([

--- a/src/commands/auth-choice-options.ts
+++ b/src/commands/auth-choice-options.ts
@@ -31,8 +31,8 @@ const AUTH_CHOICE_GROUP_DEFS: {
   {
     value: "anthropic",
     label: "Anthropic",
-    hint: "setup-token + API key",
-    choices: ["token", "apiKey"],
+    hint: "setup-token + API key + Claude Code CLI",
+    choices: ["token", "apiKey", "claude-code-cli"],
   },
   {
     value: "chutes",
@@ -179,6 +179,11 @@ const BASE_AUTH_CHOICE_OPTIONS: ReadonlyArray<AuthChoiceOption> = [
     value: "token",
     label: "Anthropic token (paste setup-token)",
     hint: "run `claude setup-token` elsewhere, then paste the token here",
+  },
+  {
+    value: "claude-code-cli",
+    label: "Claude Code CLI (local app subscription)",
+    hint: "Use local `claude` CLI as model provider (no Anthropic API key)",
   },
   {
     value: "openai-codex",

--- a/src/commands/auth-choice.apply.claude-code-cli.ts
+++ b/src/commands/auth-choice.apply.claude-code-cli.ts
@@ -1,0 +1,56 @@
+import type { ApplyAuthChoiceParams, ApplyAuthChoiceResult } from "./auth-choice.apply.js";
+import { createAuthChoiceAgentModelNoter } from "./auth-choice.apply-helpers.js";
+import {
+  applyClaudeCodeCliDefaultConfig,
+  applyClaudeCodeCliProviderConfig,
+  CLAUDE_CODE_CLI_DEFAULT_MODEL,
+  resolveClaudeCodeCliCommandPath,
+} from "./auth-choice.claude-code-cli.js";
+import { applyDefaultModelChoice } from "./auth-choice.default-model.js";
+
+export async function applyAuthChoiceClaudeCodeCli(
+  params: ApplyAuthChoiceParams,
+): Promise<ApplyAuthChoiceResult | null> {
+  if (params.authChoice !== "claude-code-cli") {
+    return null;
+  }
+
+  const commandPath = resolveClaudeCodeCliCommandPath();
+  if (commandPath) {
+    await params.prompter.note(
+      `Detected Claude Code CLI at ${commandPath}. OpenClaw will use it for claude-cli models.`,
+      "Claude Code CLI",
+    );
+  } else {
+    await params.prompter.note(
+      [
+        "Claude Code CLI was not detected in PATH.",
+        "OpenClaw can still be configured now; install or add `claude` to PATH before first run.",
+      ].join("\n"),
+      "Claude Code CLI",
+    );
+  }
+
+  const noteAgentModel = createAuthChoiceAgentModelNoter(params);
+  const applied = await applyDefaultModelChoice({
+    config: params.config,
+    setDefaultModel: params.setDefaultModel,
+    defaultModel: CLAUDE_CODE_CLI_DEFAULT_MODEL,
+    applyDefaultConfig: (config) =>
+      applyClaudeCodeCliDefaultConfig(config, {
+        commandPath,
+      }),
+    applyProviderConfig: (config) =>
+      applyClaudeCodeCliProviderConfig(config, {
+        commandPath,
+      }),
+    noteDefault: CLAUDE_CODE_CLI_DEFAULT_MODEL,
+    noteAgentModel,
+    prompter: params.prompter,
+  });
+
+  return {
+    config: applied.config,
+    agentModelOverride: applied.agentModelOverride,
+  };
+}

--- a/src/commands/auth-choice.apply.claude-code-cli.ts
+++ b/src/commands/auth-choice.apply.claude-code-cli.ts
@@ -1,5 +1,5 @@
-import type { ApplyAuthChoiceParams, ApplyAuthChoiceResult } from "./auth-choice.apply.js";
 import { createAuthChoiceAgentModelNoter } from "./auth-choice.apply-helpers.js";
+import type { ApplyAuthChoiceParams, ApplyAuthChoiceResult } from "./auth-choice.apply.js";
 import {
   applyClaudeCodeCliDefaultConfig,
   applyClaudeCodeCliProviderConfig,

--- a/src/commands/auth-choice.apply.ts
+++ b/src/commands/auth-choice.apply.ts
@@ -4,6 +4,7 @@ import type { WizardPrompter } from "../wizard/prompts.js";
 import { applyAuthChoiceAnthropic } from "./auth-choice.apply.anthropic.js";
 import { applyAuthChoiceApiProviders } from "./auth-choice.apply.api-providers.js";
 import { applyAuthChoiceBytePlus } from "./auth-choice.apply.byteplus.js";
+import { applyAuthChoiceClaudeCodeCli } from "./auth-choice.apply.claude-code-cli.js";
 import { applyAuthChoiceCopilotProxy } from "./auth-choice.apply.copilot-proxy.js";
 import { applyAuthChoiceGitHubCopilot } from "./auth-choice.apply.github-copilot.js";
 import { applyAuthChoiceGoogleAntigravity } from "./auth-choice.apply.google-antigravity.js";
@@ -38,6 +39,7 @@ export async function applyAuthChoice(
 ): Promise<ApplyAuthChoiceResult> {
   const handlers: Array<(p: ApplyAuthChoiceParams) => Promise<ApplyAuthChoiceResult | null>> = [
     applyAuthChoiceAnthropic,
+    applyAuthChoiceClaudeCodeCli,
     applyAuthChoiceVllm,
     applyAuthChoiceOpenAI,
     applyAuthChoiceOAuth,

--- a/src/commands/auth-choice.claude-code-cli.ts
+++ b/src/commands/auth-choice.claude-code-cli.ts
@@ -1,0 +1,89 @@
+import { spawnSync } from "node:child_process";
+import type { OpenClawConfig } from "../config/config.js";
+import { ensureModelAllowlistEntry } from "./model-allowlist.js";
+
+export const CLAUDE_CODE_CLI_DEFAULT_MODEL = "claude-cli/opus-4.6";
+
+export function resolveClaudeCodeCliCommandPath(): string | undefined {
+  const command = process.platform === "win32" ? "where" : "which";
+  const result = spawnSync(command, ["claude"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+
+  if (result.status !== 0) {
+    return undefined;
+  }
+
+  const firstMatch = result.stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find(Boolean);
+  return firstMatch || undefined;
+}
+
+export function applyClaudeCodeCliProviderConfig(
+  config: OpenClawConfig,
+  options?: { commandPath?: string },
+): OpenClawConfig {
+  const commandPath = options?.commandPath?.trim();
+
+  // We only materialize a config entry when we have a resolved absolute path.
+  // Otherwise OpenClaw uses the built-in `claude-cli` backend defaults.
+  if (!commandPath) {
+    return config;
+  }
+
+  const existingEntry = config.agents?.defaults?.cliBackends?.["claude-cli"] ?? {};
+
+  return {
+    ...config,
+    agents: {
+      ...config.agents,
+      defaults: {
+        ...config.agents?.defaults,
+        cliBackends: {
+          ...config.agents?.defaults?.cliBackends,
+          "claude-cli": {
+            ...existingEntry,
+            command: commandPath,
+          },
+        },
+      },
+    },
+  };
+}
+
+export function applyClaudeCodeCliDefaultConfig(
+  config: OpenClawConfig,
+  options?: {
+    commandPath?: string;
+    defaultModel?: string;
+  },
+): OpenClawConfig {
+  const defaultModel = options?.defaultModel ?? CLAUDE_CODE_CLI_DEFAULT_MODEL;
+  const withProvider = applyClaudeCodeCliProviderConfig(config, {
+    commandPath: options?.commandPath,
+  });
+  const withAllowlist = ensureModelAllowlistEntry({
+    cfg: withProvider,
+    modelRef: defaultModel,
+  });
+  const existingModel = withAllowlist.agents?.defaults?.model;
+
+  return {
+    ...withAllowlist,
+    agents: {
+      ...withAllowlist.agents,
+      defaults: {
+        ...withAllowlist.agents?.defaults,
+        model: {
+          ...(existingModel && typeof existingModel === "object" && "fallbacks" in existingModel
+            ? { fallbacks: existingModel.fallbacks }
+            : {}),
+          primary: defaultModel,
+        },
+      },
+    },
+  };
+}

--- a/src/commands/auth-choice.model-check.test.ts
+++ b/src/commands/auth-choice.model-check.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  spawnSync: vi.fn(),
+  resolveAgentModelPrimary: vi.fn(() => undefined),
+  ensureAuthProfileStore: vi.fn(() => ({ profiles: {} })),
+  listProfilesForProvider: vi.fn(() => []),
+  resolveCliBackendConfig: vi.fn(() => ({ id: "claude-cli", config: { command: "claude" } })),
+  resolveEnvApiKey: vi.fn(() => null),
+  getCustomProviderApiKey: vi.fn(() => undefined),
+  loadModelCatalog: vi.fn(async () => []),
+  isCliProvider: vi.fn(() => true),
+  resolveConfiguredModelRef: vi.fn(() => ({ provider: "claude-cli", model: "opus-4.6" })),
+}));
+
+vi.mock("node:child_process", () => ({
+  spawnSync: mocks.spawnSync,
+}));
+
+vi.mock("../agents/agent-scope.js", () => ({
+  resolveAgentModelPrimary: mocks.resolveAgentModelPrimary,
+}));
+
+vi.mock("../agents/auth-profiles.js", () => ({
+  ensureAuthProfileStore: mocks.ensureAuthProfileStore,
+  listProfilesForProvider: mocks.listProfilesForProvider,
+}));
+
+vi.mock("../agents/cli-backends.js", () => ({
+  resolveCliBackendConfig: mocks.resolveCliBackendConfig,
+}));
+
+vi.mock("../agents/model-auth.js", () => ({
+  resolveEnvApiKey: mocks.resolveEnvApiKey,
+  getCustomProviderApiKey: mocks.getCustomProviderApiKey,
+}));
+
+vi.mock("../agents/model-catalog.js", () => ({
+  loadModelCatalog: mocks.loadModelCatalog,
+}));
+
+vi.mock("../agents/model-selection.js", () => ({
+  isCliProvider: mocks.isCliProvider,
+  resolveConfiguredModelRef: mocks.resolveConfiguredModelRef,
+}));
+
+import { warnIfModelConfigLooksOff } from "./auth-choice.model-check.js";
+
+describe("warnIfModelConfigLooksOff for CLI providers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.resolveCliBackendConfig.mockReturnValue({
+      id: "claude-cli",
+      config: { command: "claude" },
+    });
+    mocks.isCliProvider.mockReturnValue(true);
+    mocks.resolveConfiguredModelRef.mockReturnValue({ provider: "claude-cli", model: "opus-4.6" });
+    mocks.spawnSync.mockReturnValue({ status: 0, stdout: "/usr/bin/claude\n" });
+  });
+
+  it("skips API auth/catalog warnings for CLI providers", async () => {
+    const note = vi.fn(async () => {});
+
+    await warnIfModelConfigLooksOff(
+      {
+        agents: { defaults: { model: { primary: "claude-cli/opus-4.6" } } },
+      },
+      { note } as never,
+    );
+
+    expect(mocks.loadModelCatalog).not.toHaveBeenCalled();
+    expect(note).not.toHaveBeenCalled();
+  });
+
+  it("warns when CLI backend command is not resolvable", async () => {
+    const note = vi.fn(async () => {});
+    mocks.spawnSync.mockReturnValue({ status: 1, stdout: "" });
+
+    await warnIfModelConfigLooksOff(
+      {
+        agents: { defaults: { model: { primary: "claude-cli/opus-4.6" } } },
+      },
+      { note } as never,
+    );
+
+    expect(note).toHaveBeenCalledTimes(1);
+    expect(String(note.mock.calls[0]?.[0])).toContain("CLI backend command not found");
+  });
+});

--- a/src/commands/auth-choice.model-check.test.ts
+++ b/src/commands/auth-choice.model-check.test.ts
@@ -59,7 +59,7 @@ describe("warnIfModelConfigLooksOff for CLI providers", () => {
   });
 
   it("skips API auth/catalog warnings for CLI providers", async () => {
-    const note = vi.fn(async () => {});
+    const note = vi.fn(async (_message: string, _title?: string) => {});
 
     await warnIfModelConfigLooksOff(
       {
@@ -73,7 +73,7 @@ describe("warnIfModelConfigLooksOff for CLI providers", () => {
   });
 
   it("warns when CLI backend command is not resolvable", async () => {
-    const note = vi.fn(async () => {});
+    const note = vi.fn(async (_message: string, _title?: string) => {});
     mocks.spawnSync.mockReturnValue({ status: 1, stdout: "" });
 
     await warnIfModelConfigLooksOff(

--- a/src/commands/auth-choice.model-check.ts
+++ b/src/commands/auth-choice.model-check.ts
@@ -1,12 +1,31 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
 import { resolveAgentModelPrimary } from "../agents/agent-scope.js";
 import { ensureAuthProfileStore, listProfilesForProvider } from "../agents/auth-profiles.js";
+import { resolveCliBackendConfig } from "../agents/cli-backends.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { getCustomProviderApiKey, resolveEnvApiKey } from "../agents/model-auth.js";
 import { loadModelCatalog } from "../agents/model-catalog.js";
-import { resolveConfiguredModelRef } from "../agents/model-selection.js";
+import { isCliProvider, resolveConfiguredModelRef } from "../agents/model-selection.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import { OPENAI_CODEX_DEFAULT_MODEL } from "./openai-codex-model-default.js";
+
+function isCliCommandResolvable(command: string): boolean {
+  const trimmed = command.trim();
+  if (!trimmed) {
+    return false;
+  }
+  if (trimmed.includes("/") || trimmed.includes("\\")) {
+    return fs.existsSync(trimmed);
+  }
+  const lookupCommand = process.platform === "win32" ? "where" : "which";
+  const result = spawnSync(lookupCommand, [trimmed], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  return result.status === 0;
+}
 
 export async function warnIfModelConfigLooksOff(
   config: OpenClawConfig,
@@ -40,29 +59,44 @@ export async function warnIfModelConfigLooksOff(
     defaultModel: DEFAULT_MODEL,
   });
   const warnings: string[] = [];
-  const catalog = await loadModelCatalog({
-    config: configWithModel,
-    useCache: false,
-  });
-  if (catalog.length > 0) {
-    const known = catalog.some(
-      (entry) => entry.provider === ref.provider && entry.id === ref.model,
-    );
-    if (!known) {
+  const store = ensureAuthProfileStore(options?.agentDir);
+  const cliProvider = isCliProvider(ref.provider, configWithModel);
+
+  if (cliProvider) {
+    const backend = resolveCliBackendConfig(ref.provider, configWithModel);
+    if (!backend) {
       warnings.push(
-        `Model not found: ${ref.provider}/${ref.model}. Update agents.defaults.model or run /models list.`,
+        `CLI backend "${ref.provider}" is missing or invalid. Configure agents.defaults.cliBackends["${ref.provider}"].command.`,
+      );
+    } else if (!isCliCommandResolvable(backend.config.command)) {
+      warnings.push(
+        `CLI backend command not found: ${backend.config.command}. Install it or set an absolute command path in agents.defaults.cliBackends["${backend.id}"].command.`,
       );
     }
-  }
+  } else {
+    const catalog = await loadModelCatalog({
+      config: configWithModel,
+      useCache: false,
+    });
+    if (catalog.length > 0) {
+      const known = catalog.some(
+        (entry) => entry.provider === ref.provider && entry.id === ref.model,
+      );
+      if (!known) {
+        warnings.push(
+          `Model not found: ${ref.provider}/${ref.model}. Update agents.defaults.model or run /models list.`,
+        );
+      }
+    }
 
-  const store = ensureAuthProfileStore(options?.agentDir);
-  const hasProfile = listProfilesForProvider(store, ref.provider).length > 0;
-  const envKey = resolveEnvApiKey(ref.provider);
-  const customKey = getCustomProviderApiKey(config, ref.provider);
-  if (!hasProfile && !envKey && !customKey) {
-    warnings.push(
-      `No auth configured for provider "${ref.provider}". The agent may fail until credentials are added.`,
-    );
+    const hasProfile = listProfilesForProvider(store, ref.provider).length > 0;
+    const envKey = resolveEnvApiKey(ref.provider);
+    const customKey = getCustomProviderApiKey(config, ref.provider);
+    if (!hasProfile && !envKey && !customKey) {
+      warnings.push(
+        `No auth configured for provider "${ref.provider}". The agent may fail until credentials are added.`,
+      );
+    }
   }
 
   if (ref.provider === "openai") {

--- a/src/commands/auth-choice.preferred-provider.ts
+++ b/src/commands/auth-choice.preferred-provider.ts
@@ -5,6 +5,7 @@ const PREFERRED_PROVIDER_BY_AUTH_CHOICE: Partial<Record<AuthChoice, string>> = {
   "setup-token": "anthropic",
   "claude-cli": "anthropic",
   token: "anthropic",
+  "claude-code-cli": "claude-cli",
   apiKey: "anthropic",
   vllm: "vllm",
   "openai-codex": "openai-codex",

--- a/src/commands/auth-choice.test.ts
+++ b/src/commands/auth-choice.test.ts
@@ -180,6 +180,32 @@ describe("applyAuthChoice", () => {
     });
   });
 
+  it("configures Claude Code CLI as the default model path", async () => {
+    await setupTempState();
+
+    const note = vi.fn(async () => {});
+    const prompter = createPrompter({ note });
+    const runtime = createExitThrowingRuntime();
+
+    const result = await applyAuthChoice({
+      authChoice: "claude-code-cli",
+      config: {},
+      prompter,
+      runtime,
+      setDefaultModel: true,
+    });
+
+    expect(result.config.agents?.defaults?.model?.primary).toBe("claude-cli/opus-4.6");
+    expect(result.config.agents?.defaults?.models?.["claude-cli/opus-4.6"]).toBeDefined();
+
+    const backend = result.config.agents?.defaults?.cliBackends?.["claude-cli"];
+    if (backend?.command) {
+      expect(backend.command.length).toBeGreaterThan(0);
+    }
+
+    expect(note).toHaveBeenCalled();
+  });
+
   it("prompts and writes MiniMax API key when selecting minimax-api", async () => {
     await setupTempState();
 
@@ -1265,6 +1291,10 @@ describe("resolvePreferredProviderForAuthChoice", () => {
 
   it("maps qwen-portal to the provider", () => {
     expect(resolvePreferredProviderForAuthChoice("qwen-portal")).toBe("qwen-portal");
+  });
+
+  it("maps claude-code-cli to claude-cli", () => {
+    expect(resolvePreferredProviderForAuthChoice("claude-code-cli")).toBe("claude-cli");
   });
 
   it("returns undefined for unknown choices", () => {

--- a/src/commands/doctor-auth.cli-readiness.e2e.test.ts
+++ b/src/commands/doctor-auth.cli-readiness.e2e.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+
+const note = vi.hoisted(() => vi.fn());
+const store = vi.hoisted(() => ({
+  version: 1,
+  profiles: {
+    "anthropic:default": {
+      type: "token",
+      provider: "anthropic",
+      token: "anthropic-token",
+      expires: Date.now() - 60_000,
+    },
+    "openai-codex:default": {
+      type: "token",
+      provider: "openai-codex",
+      token: "codex-token",
+      expires: Date.now() - 60_000,
+    },
+  },
+  usageStats: {},
+}));
+
+vi.mock("../terminal/note.js", () => ({
+  note,
+}));
+
+vi.mock("../agents/auth-profiles.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../agents/auth-profiles.js")>();
+  return {
+    ...actual,
+    ensureAuthProfileStore: vi.fn(() => store),
+    resolveProfileUnusableUntilForDisplay: vi.fn(() => undefined),
+  };
+});
+
+import { noteAuthProfileHealth, noteCliProviderReadiness } from "./doctor-auth.js";
+
+function createPrompter() {
+  return {
+    confirm: vi.fn().mockResolvedValue(false),
+    confirmRepair: vi.fn().mockResolvedValue(false),
+    confirmAggressive: vi.fn().mockResolvedValue(false),
+    confirmSkipInNonInteractive: vi.fn().mockResolvedValue(false),
+    select: vi.fn().mockResolvedValue(""),
+    shouldRepair: false,
+    shouldForce: false,
+  };
+}
+
+describe("doctor auth provider scoping and cli readiness", () => {
+  beforeEach(() => {
+    note.mockClear();
+  });
+
+  it("skips auth health notes when provider scope is empty", async () => {
+    await noteAuthProfileHealth({
+      cfg: {} as OpenClawConfig,
+      prompter: createPrompter(),
+      allowKeychainPrompt: false,
+      providers: [],
+    });
+
+    expect(note).not.toHaveBeenCalled();
+  });
+
+  it("limits model auth warnings to requested providers", async () => {
+    await noteAuthProfileHealth({
+      cfg: {} as OpenClawConfig,
+      prompter: createPrompter(),
+      allowKeychainPrompt: false,
+      providers: ["openai-codex"],
+    });
+
+    const rendered = note.mock.calls.map((call) => String(call[0])).join("\n");
+    expect(rendered).toContain("openai-codex:default");
+    expect(rendered).not.toContain("anthropic:default");
+  });
+
+  it("notes unresolved cli backend command with actionable hint", async () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          cliBackends: {
+            "claude-cli": {
+              command: "definitely-missing-openclaw-cli",
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    await noteCliProviderReadiness({
+      cfg,
+      providersInUse: ["claude-cli"],
+    });
+
+    expect(note).toHaveBeenCalled();
+    const rendered = note.mock.calls.map((call) => String(call[0])).join("\n");
+    expect(rendered).toContain("claude-cli");
+    expect(rendered).toContain("not found");
+    expect(rendered).toContain('cliBackends["claude-cli"].command');
+  });
+});

--- a/src/commands/models/list.registry.cli-backend.e2e.test.ts
+++ b/src/commands/models/list.registry.cli-backend.e2e.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { toModelRow } from "./list.registry.js";
+
+describe("toModelRow cli backend behavior", () => {
+  it("renders configured cli provider models as non-missing rows", () => {
+    const row = toModelRow({
+      key: "claude-cli/opus-4.6",
+      tags: ["configured"],
+      aliases: ["claude"],
+      cfg: {
+        agents: {
+          defaults: {
+            cliBackends: {
+              "claude-cli": { command: "claude" },
+            },
+          },
+        },
+      },
+    });
+
+    expect(row.missing).toBe(false);
+    expect(row.input).toBe("text");
+    expect(row.local).toBe(true);
+    expect(row.available).toBe(true);
+    expect(row.tags).toContain("cli");
+    expect(row.tags).toContain("alias:claude");
+  });
+
+  it("keeps unknown non-cli models marked as missing", () => {
+    const row = toModelRow({
+      key: "example/nonexistent-model",
+      tags: ["configured"],
+      cfg: {
+        agents: {
+          defaults: {
+            cliBackends: {
+              "claude-cli": { command: "claude" },
+            },
+          },
+        },
+      },
+    });
+
+    expect(row.missing).toBe(true);
+    expect(row.tags).toContain("missing");
+  });
+});

--- a/src/commands/models/list.registry.ts
+++ b/src/commands/models/list.registry.ts
@@ -11,6 +11,7 @@ import {
   ANTIGRAVITY_OPUS_46_FORWARD_COMPAT_CANDIDATES,
   resolveForwardCompatModel,
 } from "../../agents/model-forward-compat.js";
+import { isCliProvider } from "../../agents/model-selection.js";
 import { ensureOpenClawModelsJson } from "../../agents/models-config.js";
 import { ensurePiAuthJsonFromAuthProfiles } from "../../agents/pi-auth-json.js";
 import type { ModelRegistry } from "../../agents/pi-model-discovery.js";
@@ -191,6 +192,22 @@ export function toModelRow(params: {
 }): ModelRow {
   const { model, key, tags, aliases = [], availableKeys, cfg, authStore } = params;
   if (!model) {
+    const slashIndex = key.indexOf("/");
+    const provider = slashIndex > 0 ? key.slice(0, slashIndex) : "";
+    const modelId = slashIndex > 0 ? key.slice(slashIndex + 1) : key;
+    if (provider && isCliProvider(provider, cfg)) {
+      const aliasTags = aliases.length > 0 ? [`alias:${aliases.join(",")}`] : [];
+      return {
+        key,
+        name: modelId || key,
+        input: "text",
+        contextWindow: null,
+        local: true,
+        available: true,
+        tags: [...tags, "cli", ...aliasTags],
+        missing: false,
+      };
+    }
     return {
       key,
       name: key,

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -18,6 +18,7 @@ import {
 import { resolveEnvApiKey } from "../../agents/model-auth.js";
 import {
   buildModelAliasIndex,
+  isCliProvider,
   parseModelRef,
   resolveConfiguredModelRef,
   resolveDefaultModelForAgent,
@@ -193,6 +194,7 @@ export async function modelsStatusCommand(
   const providerAuthMap = new Map(providerAuth.map((entry) => [entry.provider, entry]));
   const missingProvidersInUse = Array.from(providersInUse)
     .filter((provider) => !providerAuthMap.has(provider))
+    .filter((provider) => !isCliProvider(provider, cfg))
     .toSorted((a, b) => a.localeCompare(b));
 
   const probeProfileIds = (() => {

--- a/src/commands/models/list.status.test.ts
+++ b/src/commands/models/list.status.test.ts
@@ -175,6 +175,19 @@ async function withAgentScopeOverrides<T>(
   }
 }
 
+async function withLoadConfigOverride<T>(
+  nextConfig: Record<string, unknown>,
+  run: () => Promise<T>,
+) {
+  const original = mocks.loadConfig.getMockImplementation();
+  mocks.loadConfig.mockReturnValue(nextConfig);
+  try {
+    return await run();
+  } finally {
+    mocks.loadConfig.mockImplementation(original);
+  }
+}
+
 describe("modelsStatusCommand auth overview", () => {
   it("includes masked auth sources in JSON output", async () => {
     await modelsStatusCommand({ json: true }, runtime as never);
@@ -252,6 +265,131 @@ describe("modelsStatusCommand auth overview", () => {
           await modelsStatusCommand({ json: true, agent: "main" }, localRuntime as never);
           const payload = JSON.parse(String((localRuntime.log as vi.Mock).mock.calls[0][0]));
           expect(payload.auth.missingProvidersInUse).toEqual([]);
+        },
+      );
+    } finally {
+      mocks.store.profiles = originalProfiles;
+      mocks.resolveEnvApiKey.mockImplementation(originalEnvImpl);
+    }
+  });
+
+  it("reports cli readiness issue for unresolved command", async () => {
+    const localRuntime = createRuntime();
+    const originalProfiles = { ...mocks.store.profiles };
+    mocks.store.profiles = {};
+    const originalEnvImpl = mocks.resolveEnvApiKey.getMockImplementation();
+    mocks.resolveEnvApiKey.mockImplementation(() => null);
+
+    try {
+      await withLoadConfigOverride(
+        {
+          agents: {
+            defaults: {
+              model: { primary: "claude-cli/opus-4.6", fallbacks: [] },
+              models: { "claude-cli/opus-4.6": { alias: "claude" } },
+              cliBackends: {
+                "claude-cli": {
+                  command: "definitely-missing-openclaw-cli",
+                },
+              },
+            },
+          },
+          models: { providers: {} },
+          env: { shellEnv: { enabled: true } },
+        },
+        async () => {
+          await modelsStatusCommand({ json: true, agent: "main" }, localRuntime as never);
+          const payload = JSON.parse(String((localRuntime.log as vi.Mock).mock.calls[0][0]));
+          expect(payload.auth.missingProvidersInUse).toEqual([]);
+          expect(payload.auth.cliReadiness.providersInUse).toContain("claude-cli");
+          const backend = payload.auth.cliReadiness.backends.find(
+            (entry: { provider: string }) => entry.provider === "claude-cli",
+          );
+          expect(backend?.status).toBe("command_unresolvable");
+          expect(String(backend?.detail ?? "")).toContain("not found");
+          expect(String(backend?.hint ?? "")).toContain('cliBackends["claude-cli"].command');
+        },
+      );
+    } finally {
+      mocks.store.profiles = originalProfiles;
+      mocks.resolveEnvApiKey.mockImplementation(originalEnvImpl);
+    }
+  });
+
+  it("--check exits non-zero on cli readiness failure", async () => {
+    const localRuntime = createRuntime();
+    const originalProfiles = { ...mocks.store.profiles };
+    mocks.store.profiles = {};
+    const originalEnvImpl = mocks.resolveEnvApiKey.getMockImplementation();
+    mocks.resolveEnvApiKey.mockImplementation(() => null);
+
+    try {
+      await withLoadConfigOverride(
+        {
+          agents: {
+            defaults: {
+              model: { primary: "claude-cli/opus-4.6", fallbacks: [] },
+              models: { "claude-cli/opus-4.6": { alias: "claude" } },
+              cliBackends: {
+                "claude-cli": {
+                  command: "definitely-missing-openclaw-cli",
+                },
+              },
+            },
+          },
+          models: { providers: {} },
+          env: { shellEnv: { enabled: true } },
+        },
+        async () => {
+          await modelsStatusCommand(
+            { check: true, plain: true, agent: "main" },
+            localRuntime as never,
+          );
+          expect(localRuntime.exit).toHaveBeenCalledWith(1);
+        },
+      );
+    } finally {
+      mocks.store.profiles = originalProfiles;
+      mocks.resolveEnvApiKey.mockImplementation(originalEnvImpl);
+    }
+  });
+
+  it("--check ignores stale oauth when active providers are cli-only", async () => {
+    const localRuntime = createRuntime();
+    const originalProfiles = { ...mocks.store.profiles };
+    mocks.store.profiles = {
+      ...originalProfiles,
+      "anthropic:default": {
+        ...originalProfiles["anthropic:default"],
+        expires: Date.now() - 60_000,
+      },
+    };
+    const originalEnvImpl = mocks.resolveEnvApiKey.getMockImplementation();
+    mocks.resolveEnvApiKey.mockImplementation(() => null);
+
+    try {
+      await withLoadConfigOverride(
+        {
+          agents: {
+            defaults: {
+              model: { primary: "claude-cli/opus-4.6", fallbacks: [] },
+              models: { "claude-cli/opus-4.6": { alias: "claude" } },
+              cliBackends: {
+                "claude-cli": {
+                  command: process.execPath,
+                },
+              },
+            },
+          },
+          models: { providers: {} },
+          env: { shellEnv: { enabled: true } },
+        },
+        async () => {
+          await modelsStatusCommand(
+            { check: true, plain: true, agent: "main" },
+            localRuntime as never,
+          );
+          expect(localRuntime.exit).toHaveBeenCalledWith(0);
         },
       );
     } finally {

--- a/src/commands/models/list.status.test.ts
+++ b/src/commands/models/list.status.test.ts
@@ -235,6 +235,31 @@ describe("modelsStatusCommand auth overview", () => {
     );
   });
 
+  it("does not mark cli providers as missing auth", async () => {
+    const localRuntime = createRuntime();
+    const originalProfiles = { ...mocks.store.profiles };
+    mocks.store.profiles = {};
+    const originalEnvImpl = mocks.resolveEnvApiKey.getMockImplementation();
+    mocks.resolveEnvApiKey.mockImplementation(() => null);
+
+    try {
+      await withAgentScopeOverrides(
+        {
+          primary: "claude-cli/opus-4.6",
+          fallbacks: [],
+        },
+        async () => {
+          await modelsStatusCommand({ json: true, agent: "main" }, localRuntime as never);
+          const payload = JSON.parse(String((localRuntime.log as vi.Mock).mock.calls[0][0]));
+          expect(payload.auth.missingProvidersInUse).toEqual([]);
+        },
+      );
+    } finally {
+      mocks.store.profiles = originalProfiles;
+      mocks.resolveEnvApiKey.mockImplementation(originalEnvImpl);
+    }
+  });
+
   it("labels defaults when --agent has no overrides", async () => {
     const localRuntime = createRuntime();
     await withAgentScopeOverrides(

--- a/src/commands/onboard-non-interactive.provider-auth.test.ts
+++ b/src/commands/onboard-non-interactive.provider-auth.test.ts
@@ -329,6 +329,17 @@ describe("onboard (non-interactive): provider auth", () => {
     });
   }, 60_000);
 
+  it("shows explicit non-interactive guidance for legacy codex-cli auth choice", async () => {
+    await withOnboardEnv("openclaw-onboard-codex-cli-legacy-", async ({ runtime }) => {
+      await expect(
+        runNonInteractiveOnboardingWithDefaults(runtime, {
+          authChoice: "codex-cli",
+          skipSkills: true,
+        }),
+      ).rejects.toThrow('For non-interactive onboarding, use "--auth-choice openai-api-key".');
+    });
+  }, 60_000);
+
   it("stores OpenAI API key and sets OpenAI default model", async () => {
     await withOnboardEnv("openclaw-onboard-openai-", async (env) => {
       const cfg = await runOnboardingAndReadConfig(env, {

--- a/src/commands/onboard-non-interactive.provider-auth.test.ts
+++ b/src/commands/onboard-non-interactive.provider-auth.test.ts
@@ -33,7 +33,12 @@ let upsertAuthProfile: typeof import("../agents/auth-profiles.js").upsertAuthPro
 
 type ProviderAuthConfigSnapshot = {
   auth?: { profiles?: Record<string, { provider?: string; mode?: string }> };
-  agents?: { defaults?: { model?: { primary?: string } } };
+  agents?: {
+    defaults?: {
+      model?: { primary?: string };
+      cliBackends?: Record<string, { command?: string }>;
+    };
+  };
   models?: {
     providers?: Record<
       string,
@@ -297,6 +302,30 @@ describe("onboard (non-interactive): provider auth", () => {
         expect(profile.provider).toBe("anthropic");
         expect(profile.token).toBe(cleanToken);
       }
+    });
+  }, 60_000);
+
+  it("configures Claude Code CLI as default model in non-interactive mode", async () => {
+    await withOnboardEnv("openclaw-onboard-claude-code-cli-", async (env) => {
+      const cfg = await runOnboardingAndReadConfig(env, {
+        authChoice: "claude-code-cli",
+      });
+
+      expect(cfg.agents?.defaults?.model?.primary).toBe("claude-cli/opus-4.6");
+      const command = cfg.agents?.defaults?.cliBackends?.["claude-cli"]?.command;
+      if (command) {
+        expect(command.toLowerCase()).toContain("claude");
+      }
+    });
+  }, 60_000);
+
+  it("maps legacy claude-cli auth choice to claude-code-cli flow", async () => {
+    await withOnboardEnv("openclaw-onboard-claude-cli-legacy-", async (env) => {
+      const cfg = await runOnboardingAndReadConfig(env, {
+        authChoice: "claude-cli",
+      });
+
+      expect(cfg.agents?.defaults?.model?.primary).toBe("claude-cli/opus-4.6");
     });
   }, 60_000);
 

--- a/src/commands/onboard-non-interactive/local/auth-choice.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.ts
@@ -82,7 +82,11 @@ export async function applyNonInteractiveAuthChoice(params: {
 
   if (authChoice === "codex-cli") {
     runtime.error(
-      ['Auth choice "codex-cli" is deprecated.', 'Use "--auth-choice openai-codex".'].join("\n"),
+      [
+        'Auth choice "codex-cli" is deprecated.',
+        'It maps to OpenAI Codex OAuth ("--auth-choice openai-codex"), which requires interactive mode.',
+        'For non-interactive onboarding, use "--auth-choice openai-api-key".',
+      ].join("\n"),
     );
     runtime.exit(1);
     return null;

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -8,6 +8,7 @@ export type AuthChoice =
   | "setup-token"
   | "claude-cli"
   | "token"
+  | "claude-code-cli"
   | "chutes"
   | "vllm"
   | "openai-codex"

--- a/src/commands/onboard.ts
+++ b/src/commands/onboard.ts
@@ -16,7 +16,11 @@ export async function onboardCommand(opts: OnboardOptions, runtime: RuntimeEnv =
   const normalizedAuthChoice = normalizeLegacyOnboardAuthChoice(originalAuthChoice);
   if (opts.nonInteractive && originalAuthChoice === "codex-cli") {
     runtime.error(
-      ['Auth choice "codex-cli" is deprecated.', 'Use "--auth-choice openai-codex".'].join("\n"),
+      [
+        'Auth choice "codex-cli" is deprecated.',
+        'It maps to OpenAI Codex OAuth ("--auth-choice openai-codex"), which requires interactive mode.',
+        'For non-interactive onboarding, use "--auth-choice openai-api-key".',
+      ].join("\n"),
     );
     runtime.exit(1);
     return;

--- a/src/commands/onboard.ts
+++ b/src/commands/onboard.ts
@@ -4,7 +4,7 @@ import { assertSupportedRuntime } from "../infra/runtime-guard.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { defaultRuntime } from "../runtime.js";
 import { resolveUserPath } from "../utils.js";
-import { isDeprecatedAuthChoice, normalizeLegacyOnboardAuthChoice } from "./auth-choice-legacy.js";
+import { normalizeLegacyOnboardAuthChoice } from "./auth-choice-legacy.js";
 import { DEFAULT_WORKSPACE, handleReset } from "./onboard-helpers.js";
 import { runInteractiveOnboarding } from "./onboard-interactive.js";
 import { runNonInteractiveOnboarding } from "./onboard-non-interactive.js";
@@ -14,18 +14,15 @@ export async function onboardCommand(opts: OnboardOptions, runtime: RuntimeEnv =
   assertSupportedRuntime(runtime);
   const originalAuthChoice = opts.authChoice;
   const normalizedAuthChoice = normalizeLegacyOnboardAuthChoice(originalAuthChoice);
-  if (opts.nonInteractive && isDeprecatedAuthChoice(originalAuthChoice)) {
+  if (opts.nonInteractive && originalAuthChoice === "codex-cli") {
     runtime.error(
-      [
-        `Auth choice "${String(originalAuthChoice)}" is deprecated.`,
-        'Use "--auth-choice token" (Anthropic setup-token) or "--auth-choice openai-codex".',
-      ].join("\n"),
+      ['Auth choice "codex-cli" is deprecated.', 'Use "--auth-choice openai-codex".'].join("\n"),
     );
     runtime.exit(1);
     return;
   }
   if (originalAuthChoice === "claude-cli") {
-    runtime.log('Auth choice "claude-cli" is deprecated; using setup-token flow instead.');
+    runtime.log('Auth choice "claude-cli" is deprecated; using "claude-code-cli" flow instead.');
   }
   if (originalAuthChoice === "codex-cli") {
     runtime.log('Auth choice "codex-cli" is deprecated; using OpenAI Codex OAuth instead.');

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -333,7 +333,8 @@ export const FIELD_HELP: Record<string, string> = {
   "agents.defaults.imageModel.fallbacks": "Ordered fallback image models (provider/model).",
   "agents.defaults.imageMaxDimensionPx":
     "Max image side length in pixels when sanitizing transcript/tool-result image payloads (default: 1200).",
-  "agents.defaults.cliBackends": "Optional CLI backends for text-only fallback (claude-cli, etc.).",
+  "agents.defaults.cliBackends":
+    "Optional CLI backends for text-first provider routing (primary or fallback; claude-cli, etc.).",
   "agents.defaults.humanDelay.mode": 'Delay style for block replies ("off", "natural", "custom").',
   "agents.defaults.humanDelay.minMs": "Minimum delay in ms for custom humanDelay (default: 800).",
   "agents.defaults.humanDelay.maxMs": "Maximum delay in ms for custom humanDelay (default: 2500).",

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -156,7 +156,7 @@ export type AgentDefaultsConfig = {
   envelopeElapsed?: "on" | "off";
   /** Optional context window cap (used for runtime estimates + status %). */
   contextTokens?: number;
-  /** Optional CLI backends for text-only fallback (claude-cli, etc.). */
+  /** Optional CLI backends for text-first provider routing (primary or fallback; e.g. claude-cli). */
   cliBackends?: Record<string, CliBackendConfig>;
   /** Opt-in: prune old tool results from the LLM context to reduce token usage. */
   contextPruning?: AgentContextPruningConfig;

--- a/src/wizard/onboarding.test.ts
+++ b/src/wizard/onboarding.test.ts
@@ -309,7 +309,7 @@ describe("runOnboardingWizard", () => {
     promptDefaultModel.mockClear();
     applyAuthChoice.mockClear();
 
-    const prompter = createWizardPrompter();
+    const prompter = buildWizardPrompter();
     const runtime = createRuntime({ throwsOnExit: true });
 
     await runOnboardingWizard(

--- a/src/wizard/onboarding.test.ts
+++ b/src/wizard/onboarding.test.ts
@@ -304,6 +304,34 @@ describe("runOnboardingWizard", () => {
     expect(runTui).not.toHaveBeenCalled();
   });
 
+  it("does not prompt for a default model after choosing claude-code-cli", async () => {
+    promptAuthChoiceGrouped.mockResolvedValueOnce("claude-code-cli");
+    promptDefaultModel.mockClear();
+    applyAuthChoice.mockClear();
+
+    const prompter = createWizardPrompter();
+    const runtime = createRuntime({ throwsOnExit: true });
+
+    await runOnboardingWizard(
+      {
+        acceptRisk: true,
+        flow: "quickstart",
+        installDaemon: false,
+        skipProviders: true,
+        skipSkills: true,
+        skipHealth: true,
+        skipUi: true,
+      },
+      runtime,
+      prompter,
+    );
+
+    expect(applyAuthChoice).toHaveBeenCalledWith(
+      expect.objectContaining({ authChoice: "claude-code-cli" }),
+    );
+    expect(promptDefaultModel).not.toHaveBeenCalled();
+  });
+
   async function runTuiHatchTest(params: {
     writeBootstrapFile: boolean;
     expectedMessage: string | undefined;

--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -377,7 +377,7 @@ export async function runOnboardingWizard(
     nextConfig = authResult.config;
   }
 
-  if (authChoiceFromPrompt && authChoice !== "custom-api-key") {
+  if (authChoiceFromPrompt && authChoice !== "custom-api-key" && authChoice !== "claude-code-cli") {
     const modelSelection = await promptDefaultModel({
       config: nextConfig,
       prompter,


### PR DESCRIPTION
## Motivation / safety context

This change is partly motivated by provider-policy enforcement around Anthropic subscription credentials.

There are public reports (and recurring issue threads) of users seeing errors such as:

> "This credential is only authorized for use with Claude Code and cannot be used for other API requests."

and, in some cases, account/credential restrictions after attempting to use Claude subscription auth through non-Claude-Code API-style paths.

To reduce that risk, this PR intentionally avoids unsupported token-spoof/reuse patterns and makes the **official Claude Code CLI path** first-class in OpenClaw:

- prefer `claude-code-cli` (official Claude Code harness context)
- keep `setup-token` as manual/headless fallback
- keep API key flow available (often best for production / multi-user)

Net effect: better alignment with provider auth boundaries, fewer accidental policy violations, and clearer user guidance.

---

## Summary

Adds first-class **Claude Code CLI** onboarding/auth support in OpenClaw and hardens related model/auth UX so CLI-backed Claude can be used as either **primary** model path or **fallback**.

Also improves failover billing classification and closes diagnostics gaps for CLI readiness in `models status` and `doctor`.

---

## What changed

### 1) First-class Claude Code CLI auth choice
- New auth choice: `claude-code-cli`
- New apply/wiring:
  - `src/commands/auth-choice.claude-code-cli.ts`
  - `src/commands/auth-choice.apply.claude-code-cli.ts`
  - updates in auth-choice/onboard flows + schema/help text
- Cross-platform command detection for `claude` (`which`/`where`)

### 2) Legacy alias compatibility + clearer guidance
- Map legacy `claude-cli` auth choice to `claude-code-cli`
- Keep legacy aliases accepted internally while de-emphasizing in help
- Clarify non-interactive deprecated `codex-cli` guidance:
  - points users to `openai-api-key` (instead of interactive-only OAuth path)

### 3) Onboarding UX improvements
- Skip redundant default-model reprompt when `claude-code-cli` is selected

### 4) CLI-aware model validation and list/status behavior
- `auth-choice.model-check` now handles CLI providers explicitly
- Avoid false API auth/catalog warnings for CLI selections
- `models list`/status UX no longer mislabels configured CLI models as missing

### 5) CLI readiness diagnostics gap closed
- New shared helper:
  - `src/agents/cli-backend-readiness.ts`
- `models status` enhancements:
  - JSON now includes `auth.cliReadiness.providersInUse` and `auth.cliReadiness.backends`
  - text output includes **CLI backend readiness** section with actionable hints
  - `--check` fails on CLI readiness issues
  - `--check` scopes OAuth expiry/missing checks to **non-CLI providers in use**
- `doctor` enhancements:
  - provider-in-use derivation from model/image primary+fallbacks
  - CLI vs non-CLI split for diagnostics
  - provider-scoped auth health checks
  - CLI readiness notes via `noteCliProviderReadiness(...)`

### 6) Failover/billing robustness
- Expanded billing/credits-exhausted detection patterns
- Billing classification prioritized ahead of generic rate-limit classification
- 402/status-code handling aligned in related auth-key checks

### 7) Docs consistency updates
- Anthropic docs updated to frame **Claude Code OAuth** as first-class subscription path
- setup-token documented as manual/headless fallback
- Fixed markdownlint duplicate-heading issue in `docs/providers/anthropic.md`

---

## Testing

Ran locally (targeted):

```bash
# unit
pnpm exec vitest run --config vitest.unit.config.ts \
  src/commands/auth-choice-legacy.test.ts \
  src/commands/auth-choice.model-check.test.ts \
  src/wizard/onboarding.test.ts \
  src/agents/cli-backend-readiness.test.ts

# e2e/targeted
pnpm exec vitest run --config vitest.e2e.config.ts \
  src/commands/models/list.registry.cli-backend.e2e.test.ts \
  src/commands/onboard-non-interactive.provider-auth.e2e.test.ts \
  src/commands/models/list.status.e2e.test.ts \
  src/commands/doctor-auth.cli-readiness.e2e.test.ts \
  src/commands/auth-choice.e2e.test.ts \
  src/commands/auth-choice-options.e2e.test.ts \
  src/agents/pi-embedded-helpers.isbillingerrormessage.e2e.test.ts \
  src/agents/pi-embedded-helpers.formatassistanterrortext.e2e.test.ts \
  src/agents/model-fallback.e2e.test.ts \
  src/agents/live-auth-keys.e2e.test.ts

# smoke
pnpm exec vitest run --config vitest.e2e.config.ts src/cli/program.smoke.e2e.test.ts
```

---

## Notes

- Earlier bun/windows failures were triaged against near-simultaneous `main` and matched baseline instability (not PR-specific).
- Follow-up branch runs include passing docs + bun/windows lanes after fixes.

