### PR TITLE
fix(ui): consistent visual styling

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -3066,3 +3066,12 @@
     display: flex;
   }
 }
+
+/* ===========================================
+   Status chip utility
+   =========================================== */
+
+.status-chip {
+  width: 54px;
+  text-align: center;
+}

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1214,6 +1214,11 @@
   border-color: rgba(59, 130, 246, 0.3);
 }
 
+.log-level.ok {
+  color: var(--ok);
+  border-color: var(--ok-subtle);
+}
+
 .log-level.warn {
   color: var(--warn);
   border-color: var(--warn-subtle);

--- a/ui/src/ui/views/channels.shared.ts
+++ b/ui/src/ui/views/channels.shared.ts
@@ -36,3 +36,17 @@ export function renderChannelAccountCount(
   }
   return html`<div class="account-count">Accounts (${count})</div>`;
 }
+
+export function statusChip(
+  value: boolean | null | undefined,
+  yesLabel = "YES",
+  noLabel = "NO",
+  naLabel = "N/A",
+) {
+  if (value === null || value === undefined) {
+    return html`<span class="log-level status-chip">${naLabel}</span>`;
+  }
+  return value
+    ? html`<span class="log-level ok status-chip">${yesLabel}</span>`
+    : html`<span class="log-level warn status-chip">${noLabel}</span>`;
+}


### PR DESCRIPTION
This PR adds utilities for consistent visual styling across UI components.

**Changes:**
- Added statusChip() function for consistent boolean status display  
- Added .status-chip CSS class with fixed width and center alignment
- Uses semantic color classes (ok/warn) for better accessibility
- Provides reusable utility for future consistent styling needs

**Based on automated review feedback:**
- Addresses need for consistent visual styling across components
- Replaces potential inline style patterns with maintainable CSS classes
- Provides foundation for semantic color coding (green=ok, amber=warn)

**Testing:**
- Build check passed ✓
- No personal paths in diff ✓

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `statusChip()` utility function and `.status-chip` CSS class for consistent boolean status display across UI components.

**Key Changes:**
- New `statusChip()` function in `channels.shared.ts` for YES/NO/N/A status display with semantic colors
- New `.status-chip` CSS class with fixed 54px width and center alignment

**Issues Found:**
- CSS mismatch: function uses `.log-level.ok` class but only `.log-level.warn` is defined in the stylesheet (line 1037 of `components.css`). The `ok` variant needs to be added or use existing `.stat-value.ok` pattern instead.
- Worktree submodule commits included in PR shouldn't be committed per repository guidelines (AGENTS.md line 167)

<h3>Confidence Score: 2/5</h3>

- PR has a CSS class mismatch that will cause styling bugs in production
- The function references `.log-level.ok` which doesn't exist in the stylesheet, causing the positive status chips to render without proper styling. The worktree submodules also shouldn't be included in the PR.
- Pay close attention to `ui/src/ui/views/channels.shared.ts` (missing CSS class) and remove worktree submodule references

<sub>Last reviewed commit: 2283cc1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->