### PR TITLE
fix(ui): reset session key to main after /new in webchat

### DIFF
--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -1,5 +1,29 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { connectGateway } from "./app-gateway.ts";
+import { connectGateway, handleGatewayEvent } from "./app-gateway.ts";
+
+vi.mock("./app-tool-stream.ts", () => ({
+  handleAgentEvent: vi.fn(),
+  resetToolStream: vi.fn(),
+}));
+vi.mock("./controllers/chat.ts", () => ({
+  loadChatHistory: vi.fn(),
+  handleChatEvent: vi.fn(() => "final"),
+  sendChatMessage: vi.fn(),
+  abortChatRun: vi.fn(),
+}));
+vi.mock("./controllers/sessions.ts", () => ({
+  loadSessions: vi.fn(),
+}));
+vi.mock("./app-settings.ts", () => ({
+  applySettings: vi.fn(),
+  loadCron: vi.fn(),
+  refreshActiveTab: vi.fn(),
+  setLastActiveSessionKey: vi.fn(),
+}));
+vi.mock("./app-chat.ts", () => ({
+  CHAT_SESSIONS_ACTIVE_MINUTES: 120,
+  flushChatQueueForEvent: vi.fn(),
+}));
 
 type GatewayClientMock = {
   start: ReturnType<typeof vi.fn>;
@@ -142,5 +166,27 @@ describe("connectGateway", () => {
 
     secondClient.emitClose(1005);
     expect(host.lastError).toBe("disconnected (1005): no reason");
+  });
+});
+
+describe("handleGatewayEvent", () => {
+  it("resets sessionKey to main after /new completes", () => {
+    const host = createHost() as Record<string, unknown>;
+    const runId = "run-123";
+    host.sessionKey = "agent:main:direct:user456";
+    host.chatRunId = runId;
+    (host.refreshSessionsAfterChat as Set<string>).add(runId);
+    host.hello = {
+      snapshot: {
+        sessionDefaults: { mainSessionKey: "agent:main:main" },
+      },
+    };
+
+    handleGatewayEvent(host as unknown as Parameters<typeof handleGatewayEvent>[0], {
+      event: "chat",
+      payload: { runId, state: "final" },
+    });
+
+    expect(host.sessionKey).toBe("agent:main:main");
   });
 });

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -224,6 +224,17 @@ function handleGatewayEventUnsafe(host: GatewayHost, evt: GatewayEventFrame) {
           void loadSessions(host as unknown as OpenClawApp, {
             activeMinutes: CHAT_SESSIONS_ACTIVE_MINUTES,
           });
+          // After /new, reset to the main session so subsequent messages
+          // don't go into a previously-selected sidebar session.
+          const defaults = (
+            host.hello?.snapshot as { sessionDefaults?: SessionDefaultsSnapshot } | undefined
+          )?.sessionDefaults;
+          const mainSessionKey = defaults?.mainSessionKey?.trim() || "agent:main:main";
+          host.sessionKey = mainSessionKey;
+          setLastActiveSessionKey(
+            host as unknown as Parameters<typeof setLastActiveSessionKey>[0],
+            mainSessionKey,
+          );
         }
       }
     }


### PR DESCRIPTION
## Summary

Fixes #18078

When a user sends `/new` in the webchat Control UI, the server creates a new session and the chat run completes. The UI refreshes the sessions sidebar via `loadSessions()`, but **never resets `host.sessionKey`** back to the main session. This means subsequent messages are still routed to whichever sidebar session was previously selected — not the newly created main session.

- After `/new` completes (state `"final"` + `refreshSessionsAfterChat` flag), reset `host.sessionKey` to the main session key from `hello.snapshot.sessionDefaults`
- Also call `setLastActiveSessionKey()` so the setting persists across page reloads
- Falls back to `"agent:main:main"` if no session defaults are available

## Test plan

- [x] Added unit test in `app-gateway.node.test.ts` verifying `sessionKey` resets to `mainSessionKey` after a `/new` chat run completes
- [x] All 4 existing + new gateway tests pass (`pnpm vitest run --config vitest.node.config.ts src/ui/app-gateway.node.test.ts`)
- [ ] Manual: Open Control UI → select a sidebar session → send `/new` → verify the session key resets and next message goes to the main session

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes the bug where sending `/new` in webchat Control UI didn't reset the session key to main, causing subsequent messages to route to the wrong session. The fix correctly resets `host.sessionKey` and calls `setLastActiveSessionKey()` after a `/new` command completes (when `state === "final"` and the run ID is in `refreshSessionsAfterChat`). Includes proper fallback to `"agent:main:main"` when session defaults are unavailable.

**Changes:**
- Added session key reset logic in `app-gateway.ts` after `/new` completion
- Extracts main session key from `hello.snapshot.sessionDefaults.mainSessionKey` with trim and fallback
- Persists the reset via `setLastActiveSessionKey()` for page reload persistence
- Added comprehensive unit tests covering both normal and fallback scenarios

**Minor issue:**
- Second test could verify `setLastActiveSessionKey` was called (like the first test does) for consistency

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no blocking issues
- The fix is targeted, well-tested, and addresses the reported bug correctly. The logic properly resets the session key to main after `/new` completes, with appropriate fallback handling. Tests verify both the happy path and edge cases. The only suggestion is a minor style improvement to make test coverage more consistent.
- No files require special attention

<sub>Last reviewed commit: 19c1936</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->