### PR TITLE
feat(agents): add per-agent thinkingDefault override

### DIFF
--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -22,6 +22,7 @@ type ResolvedAgentConfig = {
   skills?: AgentEntry["skills"];
   memorySearch?: AgentEntry["memorySearch"];
   humanDelay?: AgentEntry["humanDelay"];
+  thinkingDefault?: AgentEntry["thinkingDefault"];
   heartbeat?: AgentEntry["heartbeat"];
   identity?: AgentEntry["identity"];
   groupChat?: AgentEntry["groupChat"];
@@ -116,6 +117,7 @@ export function resolveAgentConfig(
     skills: Array.isArray(entry.skills) ? entry.skills : undefined,
     memorySearch: entry.memorySearch,
     humanDelay: entry.humanDelay,
+    thinkingDefault: entry.thinkingDefault,
     heartbeat: entry.heartbeat,
     identity: entry.identity,
     groupChat: entry.groupChat,

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -451,8 +451,14 @@ export function resolveThinkingDefault(params: {
   provider: string;
   model: string;
   catalog?: ModelCatalogEntry[];
+  agentThinkingDefault?: ThinkLevel;
 }): ThinkLevel {
-  // 1. Per-model thinkingDefault (highest priority)
+  // 1. Per-agent thinkingDefault (highest priority)
+  if (params.agentThinkingDefault) {
+    return params.agentThinkingDefault;
+  }
+
+  // 2. Per-model thinkingDefault
   // Normalize config keys via parseModelRef (consistent with buildModelAliasIndex,
   // buildAllowedModelSet, etc.) so aliases like "anthropic/opus-4.6" resolve correctly.
   const configModels = params.cfg.agents?.defaults?.models ?? {};
@@ -468,13 +474,13 @@ export function resolveThinkingDefault(params: {
     }
   }
 
-  // 2. Global thinkingDefault
+  // 3. Global thinkingDefault
   const configured = params.cfg.agents?.defaults?.thinkingDefault;
   if (configured) {
     return configured;
   }
 
-  // 3. Auto-detect from model catalog (reasoning-capable → "low")
+  // 4. Auto-detect from model catalog (reasoning-capable → "low")
   const candidate = params.catalog?.find(
     (entry) => entry.provider === params.provider && entry.id === params.model,
   );

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -9,6 +9,8 @@ import { listSkillCommandsForWorkspace } from "../skill-commands.js";
 import type { MsgContext, TemplateContext } from "../templating.js";
 import type { ElevatedLevel, ReasoningLevel, ThinkLevel, VerboseLevel } from "../thinking.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
+import type { TypingController } from "./typing.js";
+import { resolveAgentConfig } from "../../agents/agent-scope.js";
 import { resolveBlockStreamingChunking } from "./block-streaming.js";
 import { buildCommandContext } from "./commands.js";
 import { type InlineDirectives, parseInlineDirectives } from "./directive-handling.js";
@@ -19,7 +21,6 @@ import { CURRENT_MESSAGE_MARKER, stripMentions, stripStructuralPrefixes } from "
 import { createModelSelectionState, resolveContextTokens } from "./model-selection.js";
 import { formatElevatedUnavailableMessage, resolveElevatedPermissions } from "./reply-elevated.js";
 import { stripInlineStatus } from "./reply-inline.js";
-import type { TypingController } from "./typing.js";
 
 type AgentDefaults = NonNullable<OpenClawConfig["agents"]>["defaults"];
 type ExecOverrides = Pick<ExecToolDefaults, "host" | "security" | "ask" | "node">;
@@ -374,6 +375,9 @@ export async function resolveReplyDirectives(params: {
   const modelState = await createModelSelectionState({
     cfg,
     agentCfg,
+    agentThinkingDefault: resolveAgentConfig(cfg, agentId)?.thinkingDefault as
+      | ThinkLevel
+      | undefined,
     sessionEntry,
     sessionStore,
     sessionKey,

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -261,6 +261,7 @@ function scoreFuzzyMatch(params: {
 export async function createModelSelectionState(params: {
   cfg: OpenClawConfig;
   agentCfg: NonNullable<NonNullable<OpenClawConfig["agents"]>["defaults"]> | undefined;
+  agentThinkingDefault?: ThinkLevel;
   sessionEntry?: SessionEntry;
   sessionStore?: Record<string, SessionEntry>;
   sessionKey?: string;
@@ -391,9 +392,9 @@ export async function createModelSelectionState(params: {
       provider,
       model,
       catalog: catalogForThinking,
+      agentThinkingDefault: params.agentThinkingDefault,
     });
-    defaultThinkingLevel =
-      resolved ?? (agentCfg?.thinkingDefault as ThinkLevel | undefined) ?? "off";
+    defaultThinkingLevel = resolved ?? "off";
     return defaultThinkingLevel;
   };
 

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -1,5 +1,6 @@
 import {
   listAgentIds,
+  resolveAgentConfig,
   resolveAgentDir,
   resolveEffectiveModelFallbacks,
   resolveAgentModelPrimary,
@@ -215,6 +216,7 @@ export async function agentCommand(
   }
   const agentCfg = cfg.agents?.defaults;
   const sessionAgentId = agentIdOverride ?? resolveAgentIdFromSessionKey(opts.sessionKey?.trim());
+  const resolvedAgentCfg = resolveAgentConfig(cfg, sessionAgentId);
   const workspaceDirRaw = resolveAgentWorkspaceDir(cfg, sessionAgentId);
   const agentDir = resolveAgentDir(cfg, sessionAgentId);
   const workspace = await ensureAgentWorkspace({
@@ -297,11 +299,7 @@ export async function agentCommand(
       }
     }
 
-    let resolvedThinkLevel =
-      thinkOnce ??
-      thinkOverride ??
-      persistedThinking ??
-      (agentCfg?.thinkingDefault as ThinkLevel | undefined);
+    let resolvedThinkLevel = thinkOnce ?? thinkOverride ?? persistedThinking;
     const resolvedVerboseLevel =
       verboseOverride ?? persistedVerbose ?? (agentCfg?.verboseDefault as VerboseLevel | undefined);
 
@@ -485,6 +483,7 @@ export async function agentCommand(
         provider,
         model,
         catalog: catalogForThinking,
+        agentThinkingDefault: resolvedAgentCfg?.thinkingDefault as ThinkLevel | undefined,
       });
     }
     if (resolvedThinkLevel === "xhigh" && !supportsXHighThinking(provider, model)) {

--- a/src/config/config.per-agent-thinking-default.test.ts
+++ b/src/config/config.per-agent-thinking-default.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { validateConfigObject } from "./config.js";
+
+describe("per-agent thinkingDefault", () => {
+  it("accepts valid thinkingDefault values on agents.list entries", () => {
+    const res = validateConfigObject({
+      agents: {
+        list: [
+          { id: "main", thinkingDefault: "medium" },
+          { id: "research", thinkingDefault: "xhigh" },
+        ],
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("rejects invalid thinkingDefault values on agents.list entries", () => {
+    const res = validateConfigObject({
+      agents: {
+        list: [{ id: "main", thinkingDefault: "ultra" }],
+      },
+    });
+
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.issues[0]?.path).toBe("agents.list.0.thinkingDefault");
+    }
+  });
+});

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -30,6 +30,8 @@ export type AgentConfig = {
   memorySearch?: MemorySearchConfig;
   /** Human-like delay between block replies for this agent. */
   humanDelay?: HumanDelayConfig;
+  /** Default thinking level when no /think directive or session override is present. */
+  thinkingDefault?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
   /** Optional per-agent heartbeat overrides. */
   heartbeat?: AgentDefaultsConfig["heartbeat"];
   identity?: IdentityConfig;

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -592,6 +592,16 @@ export const AgentEntrySchema = z
     skills: z.array(z.string()).optional(),
     memorySearch: MemorySearchSchema,
     humanDelay: HumanDelaySchema.optional(),
+    thinkingDefault: z
+      .union([
+        z.literal("off"),
+        z.literal("minimal"),
+        z.literal("low"),
+        z.literal("medium"),
+        z.literal("high"),
+        z.literal("xhigh"),
+      ])
+      .optional(),
     heartbeat: HeartbeatSchema,
     identity: IdentitySchema,
     groupChat: GroupChatSchema,

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1,12 +1,13 @@
 import fs from "node:fs";
 import path from "node:path";
+import type { MsgContext } from "../../auto-reply/templating.js";
+import type { GatewayRequestContext, GatewayRequestHandlers } from "./types.js";
+import { resolveAgentConfig, resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { CURRENT_SESSION_VERSION, SessionManager } from "@mariozechner/pi-coding-agent";
-import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { resolveThinkingDefault } from "../../agents/model-selection.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { dispatchInboundMessage } from "../../auto-reply/dispatch.js";
 import { createReplyDispatcher } from "../../auto-reply/reply/reply-dispatcher.js";
-import type { MsgContext } from "../../auto-reply/templating.js";
 import { createReplyPrefixOptions } from "../../channels/reply-prefix.js";
 import { resolveSessionFilePath } from "../../config/sessions.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
@@ -576,20 +577,17 @@ export const chatHandlers: GatewayRequestHandlers = {
     const bounded = enforceChatHistoryHardCap(capped, getMaxChatHistoryMessagesBytes());
     let thinkingLevel = entry?.thinkingLevel;
     if (!thinkingLevel) {
-      const configured = cfg.agents?.defaults?.thinkingDefault;
-      if (configured) {
-        thinkingLevel = configured;
-      } else {
-        const sessionAgentId = resolveSessionAgentId({ sessionKey, config: cfg });
-        const { provider, model } = resolveSessionModelRef(cfg, entry, sessionAgentId);
-        const catalog = await context.loadGatewayModelCatalog();
-        thinkingLevel = resolveThinkingDefault({
-          cfg,
-          provider,
-          model,
-          catalog,
-        });
-      }
+      const sessionAgentId = resolveSessionAgentId({ sessionKey, config: cfg });
+      const agentCfg = resolveAgentConfig(cfg, sessionAgentId);
+      const { provider, model } = resolveSessionModelRef(cfg, entry, sessionAgentId);
+      const catalog = await context.loadGatewayModelCatalog();
+      thinkingLevel = resolveThinkingDefault({
+        cfg,
+        provider,
+        model,
+        catalog,
+        agentThinkingDefault: agentCfg?.thinkingDefault,
+      });
     }
     const verboseLevel = entry?.verboseLevel ?? cfg.agents?.defaults?.verboseDefault;
     respond(true, {


### PR DESCRIPTION
## Summary

Adds a `thinkingDefault` field to per-agent config (`agents.list[].thinkingDefault`) so each agent can have its own default thinking/reasoning level, independent of which model it runs.

**Use case:** A research agent should think deeply (`xhigh`) while a simple chat agent should stay fast (`minimal`) — even if both use the same model. Previously, thinking level could only be set globally or per-model, not per-agent.

This builds on the recently-merged per-model `thinkingDefault` support, extending the resolution chain to a 4-tier priority:

1. **Per-agent** (`agents.list[].thinkingDefault`) — highest priority ← **this PR**
2. **Per-model** (`agents.defaults.models[].thinkingDefault`) — already in main
3. **Global** (`agents.defaults.thinkingDefault`) — already in main
4. **Catalog auto-detect** (reasoning-capable models default to `"low"`) — already in main

All 3 call sites (gateway chat, CLI agent command, auto-reply) now correctly source per-agent config via `resolveAgentConfig()` instead of reading from global defaults.

## Example config

```yaml
agents:
  defaults:
    thinkingDefault: low                          # tier 3: global fallback
    models:
      openai-codex/gpt-5.3-codex:
        thinkingDefault: high                     # tier 2: per-model default
  list:
    - id: research
      thinkingDefault: xhigh                      # tier 1: this agent always thinks deeply
    - id: chat
      thinkingDefault: minimal                    # tier 1: this agent stays fast
```

## Changes

- `agents/agent-scope.ts` — wire `thinkingDefault` through `ResolvedAgentConfig`
- `agents/model-selection.ts` — add `agentThinkingDefault` param to `resolveThinkingDefault()` as tier 1
- `commands/agent.ts` — use `resolveAgentConfig()` for per-agent thinking default
- `auto-reply/reply/get-reply-directives.ts` — pass per-agent thinkingDefault to model selection
- `auto-reply/reply/model-selection.ts` — accept `agentThinkingDefault` param
- `gateway/server-methods/chat.ts` — pass per-agent thinkingDefault from resolved agent config
- `config/types.agents.ts`, `zod-schema.agent-runtime.ts` — add `thinkingDefault` to agent entry schema

## Test plan

- [x] Unit tests for `resolveThinkingDefault` 4-tier priority (5 tests)
- [x] Schema validation tests for `agents.list[].thinkingDefault` (2 tests)
- [x] Existing `agent.test.ts` and `model-selection.inherit-parent.test.ts` pass
- [x] TypeScript type check passes
- [x] Lint passes (oxlint)