### PR TITLE
fix: include forward-compat models in model catalog for allowlist val…

### DIFF
--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -91,4 +91,90 @@ describe("loadModelCatalog", () => {
     expect(spark?.name).toBe("gpt-5.3-codex-spark");
     expect(spark?.reasoning).toBe(true);
   });
+
+  it("synthesizes google-antigravity/claude-opus-4-6 from claude-opus-4-5 template", async () => {
+    __setModelCatalogImportForTest(
+      async () =>
+        ({
+          AuthStorage: class {},
+          ModelRegistry: class {
+            getAll() {
+              return [
+                {
+                  id: "claude-opus-4-5",
+                  provider: "google-antigravity",
+                  name: "Claude Opus 4.5",
+                  reasoning: true,
+                  contextWindow: 200000,
+                  input: ["text", "image"],
+                },
+                {
+                  id: "claude-opus-4-5-thinking",
+                  provider: "google-antigravity",
+                  name: "Claude Opus 4.5 Thinking",
+                  reasoning: true,
+                  contextWindow: 200000,
+                  input: ["text", "image"],
+                },
+                {
+                  id: "gemini-3-pro",
+                  provider: "google-antigravity",
+                  name: "Gemini 3 Pro",
+                },
+              ];
+            }
+          },
+        }) as unknown as PiSdkModule,
+    );
+
+    const result = await loadModelCatalog({ config: {} as OpenClawConfig });
+
+    // claude-opus-4-6 synthesized from claude-opus-4-5
+    const opus46 = result.find(
+      (e) => e.provider === "google-antigravity" && e.id === "claude-opus-4-6",
+    );
+    expect(opus46).toBeDefined();
+    expect(opus46?.name).toBe("claude-opus-4-6");
+    expect(opus46?.reasoning).toBe(true);
+    expect(opus46?.contextWindow).toBe(200000);
+
+    // claude-opus-4-6-thinking synthesized from claude-opus-4-5-thinking
+    const opus46Thinking = result.find(
+      (e) => e.provider === "google-antigravity" && e.id === "claude-opus-4-6-thinking",
+    );
+    expect(opus46Thinking).toBeDefined();
+    expect(opus46Thinking?.name).toBe("claude-opus-4-6-thinking");
+  });
+
+  it("does not duplicate claude-opus-4-6 when already in catalog", async () => {
+    __setModelCatalogImportForTest(
+      async () =>
+        ({
+          AuthStorage: class {},
+          ModelRegistry: class {
+            getAll() {
+              return [
+                {
+                  id: "claude-opus-4-5",
+                  provider: "google-antigravity",
+                  name: "Claude Opus 4.5",
+                },
+                {
+                  id: "claude-opus-4-6",
+                  provider: "google-antigravity",
+                  name: "Claude Opus 4.6 (native)",
+                },
+              ];
+            }
+          },
+        }) as unknown as PiSdkModule,
+    );
+
+    const result = await loadModelCatalog({ config: {} as OpenClawConfig });
+    const opus46Entries = result.filter(
+      (e) => e.provider === "google-antigravity" && e.id === "claude-opus-4-6",
+    );
+    expect(opus46Entries).toHaveLength(1);
+    expect(opus46Entries[0]?.name).toBe("Claude Opus 4.6 (native)");
+  });
 });

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -56,6 +56,47 @@ function applyOpenAICodexSparkFallback(models: ModelCatalogEntry[]): void {
   });
 }
 
+const ANTIGRAVITY_PROVIDER = "google-antigravity";
+const ANTIGRAVITY_FORWARD_COMPAT: ReadonlyArray<{
+  id: string;
+  templates: readonly string[];
+}> = [
+  { id: "claude-opus-4-6-thinking", templates: ["claude-opus-4-5-thinking"] },
+  { id: "claude-opus-4-6", templates: ["claude-opus-4-5"] },
+];
+
+/**
+ * Synthesize google-antigravity forward-compat models (claude-opus-4-6 variants)
+ * from their claude-opus-4-5 templates when the newer models are not yet natively
+ * present in the pi-ai model catalog. This mirrors the forward-compat logic in
+ * list.registry.ts → appendAntigravityForwardCompatModels.
+ */
+function applyAntigravityForwardCompat(models: ModelCatalogEntry[]): void {
+  for (const candidate of ANTIGRAVITY_FORWARD_COMPAT) {
+    const exists = models.some(
+      (entry) => entry.provider === ANTIGRAVITY_PROVIDER && entry.id === candidate.id,
+    );
+    if (exists) {
+      continue;
+    }
+
+    const template = candidate.templates
+      .map((tid) =>
+        models.find((entry) => entry.provider === ANTIGRAVITY_PROVIDER && entry.id === tid),
+      )
+      .find(Boolean);
+    if (!template) {
+      continue;
+    }
+
+    models.push({
+      ...template,
+      id: candidate.id,
+      name: candidate.id,
+    });
+  }
+}
+
 export function resetModelCatalogCacheForTest() {
   modelCatalogPromise = null;
   hasLoggedModelCatalogError = false;
@@ -127,6 +168,7 @@ export async function loadModelCatalog(params?: {
         models.push({ id, name, provider, contextWindow, reasoning, input });
       }
       applyOpenAICodexSparkFallback(models);
+      applyAntigravityForwardCompat(models);
 
       if (models.length === 0) {
         // If we found nothing, don't cache this result so we can try again.


### PR DESCRIPTION
## Summary

- **Problem:** `google-antigravity/claude-opus-4-6` shows in `/models list` but switching to it via alias or directly returns "Model is not allowed"
- **Why it matters:** Users who configure this model in their allowlist cannot use it despite it appearing as available
- **What changed:** Added [applyAntigravityForwardCompat()](cci:1://file:///Users/dzmitryarabei/projects/openclaw/src/agents/model-catalog.ts:67:0-97:1) to [loadModelCatalog](cci:1://file:///Users/dzmitryarabei/projects/openclaw/src/agents/model-catalog.ts:110:0-193:1) in [model-catalog.ts](cci:7://file:///Users/dzmitryarabei/projects/openclaw/src/agents/model-catalog.ts:0:0-0:0) — synthesizes `claude-opus-4-6` / `claude-opus-4-6-thinking` from `claude-opus-4-5` templates (same pattern as existing [applyOpenAICodexSparkFallback](cci:1://file:///Users/dzmitryarabei/projects/openclaw/src/agents/model-catalog.ts:33:0-56:1))
- **What did NOT change:** [list.registry.ts](cci:7://file:///Users/dzmitryarabei/projects/openclaw/src/commands/models/list.registry.ts:0:0-0:0), [model-selection.ts](cci:7://file:///Users/dzmitryarabei/projects/openclaw/src/agents/model-selection.ts:0:0-0:0), [model-forward-compat.ts](cci:7://file:///Users/dzmitryarabei/projects/openclaw/src/agents/model-forward-compat.ts:0:0-0:0) — no changes to existing forward-compat or allowlist logic

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: forward-compat model catalog gap for google-antigravity models
- Also closes #16547

## User-visible / Behavior Changes

Users with `google-antigravity/claude-opus-4-6` in `agents.defaults.models` can now switch to this model without getting "Model is not allowed" error.

## Security Impact (required)

- New permissions/capabilities? [No](cci:1://file:///Users/dzmitryarabei/projects/openclaw/src/agents/model-selection.ts:66:0-75:1)
- Secrets/tokens handling changed? [No](cci:1://file:///Users/dzmitryarabei/projects/openclaw/src/agents/model-selection.ts:66:0-75:1)
- New/changed network calls? [No](cci:1://file:///Users/dzmitryarabei/projects/openclaw/src/agents/model-selection.ts:66:0-75:1)
- Command/tool execution surface changed? [No](cci:1://file:///Users/dzmitryarabei/projects/openclaw/src/agents/model-selection.ts:66:0-75:1)
- Data access scope changed? [No](cci:1://file:///Users/dzmitryarabei/projects/openclaw/src/agents/model-selection.ts:66:0-75:1)

## Repro + Verification

### Environment

- OS: Ubuntu (VPS) / macOS
- Runtime/container: Node v22
- Model/provider: google-antigravity
- Integration/channel: Telegram
- Relevant config (redacted):

```json
{
  "agents": {
    "defaults": {
      "models": {
        "google-antigravity/claude-opus-4-6": { "alias": "opus" }
      }
    }
  }
}
```

### Steps

1. Configure `google-antigravity/claude-opus-4-6` with alias "opus" in `agents.defaults.models`
2. Run `/models` — model appears in the list
3. Run `/models opus` or select claude-opus-4-6

### Expected

- Model switches to claude-opus-4-6

### Actual (before fix)

- Error: `Model "google-antigravity/claude-opus-4-6" is not allowed`

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

All 5 tests pass (`vitest run src/agents/model-catalog.test.ts`):
- `synthesizes google-antigravity/claude-opus-4-6 from claude-opus-4-5 template` ✅
- `does not duplicate claude-opus-4-6 when already in catalog` ✅

Tested on live VPS instance — model switching works after fix.

## Human Verification (required)

- Verified scenarios: switching to opus via alias in Telegram, `/models` listing
- Edge cases checked: no duplication when model exists natively in catalog
- What you did **not** verify: full CI pipeline (pre-existing TS errors in unrelated files `telegram.ts`, `send-api.ts` block `build:plugin-sdk:dts`)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? [No](cci:1://file:///Users/dzmitryarabei/projects/openclaw/src/agents/model-selection.ts:66:0-75:1)
- Migration needed? [No](cci:1://file:///Users/dzmitryarabei/projects/openclaw/src/agents/model-selection.ts:66:0-75:1)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert single commit, redeploy
- Files/config to restore: [src/agents/model-catalog.ts](cci:7://file:///Users/dzmitryarabei/projects/openclaw/src/agents/model-catalog.ts:0:0-0:0)
- Known bad symptoms reviewers should watch for: duplicate model entries in catalog

## Risks and Mitigations

- Risk: When `claude-opus-4-6` is added natively to pi-ai catalog, synthesized entry becomes redundant
  - Mitigation: [applyAntigravityForwardCompat](cci:1://file:///Users/dzmitryarabei/projects/openclaw/src/agents/model-catalog.ts:67:0-97:1) checks `exists` before adding — no duplicates. Synthesized entry is silently skipped when native one appears.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes allowlist validation for `google-antigravity/claude-opus-4-6` models by synthesizing catalog entries from `claude-opus-4-5` templates in `loadModelCatalog`. This mirrors the existing forward-compat pattern used in `list.registry.ts` and follows the same duplication-prevention logic as the OpenAI Codex fallback.

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no risk
- The change applies an existing, well-tested pattern (`applyOpenAICodexSparkFallback`) to a new provider. Tests confirm correct synthesis and duplication prevention. The implementation is backward-compatible and includes proper safeguards.
- No files require special attention

<sub>Last reviewed commit: 4b658b6</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->