### PR TITLE
feat(hooks): add deliver: "auto" mode for webhook mappings

### DIFF
--- a/src/config/types.hooks.ts
+++ b/src/config/types.hooks.ts
@@ -19,7 +19,7 @@ export type HookMappingConfig = {
   sessionKey?: string;
   messageTemplate?: string;
   textTemplate?: string;
-  deliver?: boolean;
+  deliver?: boolean | "auto";
   /** DANGEROUS: Disable external content safety wrapping for this hook. */
   allowUnsafeExternalContent?: boolean;
   channel?:

--- a/src/config/zod-schema.hooks.ts
+++ b/src/config/zod-schema.hooks.ts
@@ -47,7 +47,7 @@ export const HookMappingSchema = z
     sessionKey: z.string().optional().register(sensitive),
     messageTemplate: z.string().optional(),
     textTemplate: z.string().optional(),
-    deliver: z.boolean().optional(),
+    deliver: z.union([z.boolean(), z.literal("auto")]).optional(),
     allowUnsafeExternalContent: z.boolean().optional(),
     channel: z
       .union([

--- a/src/cron/delivery.ts
+++ b/src/cron/delivery.ts
@@ -65,7 +65,7 @@ export function resolveCronDeliveryPlan(job: CronJob): CronDeliveryPlan {
   }
 
   const legacyMode =
-    payload?.deliver === true ? "explicit" : payload?.deliver === false ? "off" : "auto";
+    payload?.deliver === true ? "explicit" : payload?.deliver === false ? "off" : payload?.deliver === "auto" ? "explicit" : "auto";
   const hasExplicitTarget = Boolean(to);
   const requested = legacyMode === "explicit" || (legacyMode === "auto" && hasExplicitTarget);
 

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -593,7 +593,12 @@ export async function runCronIsolatedAgentTurn(params: {
   const isAutoDeliver = params.job.payload.kind === "agentTurn" && params.job.payload.deliver === "auto";
   const skipAutoDeliverAck = isAutoDeliver && (() => {
     if (payloads.length === 0) return true;
-    const lastText = (payloads[payloads.length - 1]?.text ?? "").trim().toLowerCase().replace(/[^a-z0-9_\s]/g, "");
+    const lastPayload = payloads[payloads.length - 1];
+    // Don't skip if there's media or structured content
+    const hasMedia = Boolean(lastPayload?.mediaUrl) || (lastPayload?.mediaUrls?.length ?? 0) > 0;
+    const hasChannelData = Object.keys(lastPayload?.channelData ?? {}).length > 0;
+    if (hasMedia || hasChannelData) return false;
+    const lastText = (lastPayload?.text ?? "").trim().toLowerCase().replace(/[^a-z0-9_\s]/g, "");
     const ackPatterns = ["ok", "no_reply", "noreply", "no reply", "heartbeat_ok", "acknowledged", "ack", "noted", "done", "ignored"];
     return ackPatterns.includes(lastText) || lastText.length <= 3;
   })();

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -61,7 +61,7 @@ export type CronPayload =
       thinking?: string;
       timeoutSeconds?: number;
       allowUnsafeExternalContent?: boolean;
-      deliver?: boolean;
+      deliver?: boolean | "auto";
       channel?: CronMessageChannel;
       to?: string;
       bestEffortDeliver?: boolean;
@@ -76,7 +76,7 @@ export type CronPayloadPatch =
       thinking?: string;
       timeoutSeconds?: number;
       allowUnsafeExternalContent?: boolean;
-      deliver?: boolean;
+      deliver?: boolean | "auto";
       channel?: CronMessageChannel;
       to?: string;
       bestEffortDeliver?: boolean;

--- a/src/gateway/hooks-mapping.ts
+++ b/src/gateway/hooks-mapping.ts
@@ -14,7 +14,7 @@ export type HookMappingResolved = {
   sessionKey?: string;
   messageTemplate?: string;
   textTemplate?: string;
-  deliver?: boolean;
+  deliver?: boolean | "auto";
   allowUnsafeExternalContent?: boolean;
   channel?: HookMessageChannel;
   to?: string;
@@ -49,7 +49,7 @@ export type HookAction =
       agentId?: string;
       wakeMode: "now" | "next-heartbeat";
       sessionKey?: string;
-      deliver?: boolean;
+      deliver?: boolean | "auto";
       allowUnsafeExternalContent?: boolean;
       channel?: HookMessageChannel;
       to?: string;
@@ -89,7 +89,7 @@ type HookTransformResult = Partial<{
   wakeMode: "now" | "next-heartbeat";
   name: string;
   sessionKey: string;
-  deliver: boolean;
+  deliver: boolean | "auto";
   allowUnsafeExternalContent: boolean;
   channel: HookMessageChannel;
   to: string;
@@ -298,7 +298,7 @@ function mergeAction(
     name: override.name ?? baseAgent?.name,
     agentId: override.agentId ?? baseAgent?.agentId,
     sessionKey: override.sessionKey ?? baseAgent?.sessionKey,
-    deliver: typeof override.deliver === "boolean" ? override.deliver : baseAgent?.deliver,
+    deliver: override.deliver === "auto" ? "auto" : typeof override.deliver === "boolean" ? override.deliver : baseAgent?.deliver,
     allowUnsafeExternalContent:
       typeof override.allowUnsafeExternalContent === "boolean"
         ? override.allowUnsafeExternalContent

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -225,7 +225,7 @@ export type HookAgentPayload = {
   agentId?: string;
   wakeMode: "now" | "next-heartbeat";
   sessionKey?: string;
-  deliver: boolean;
+  deliver: boolean | "auto";
   channel: HookMessageChannel;
   to?: string;
   model?: string;
@@ -254,7 +254,8 @@ export function resolveHookChannel(raw: unknown): HookMessageChannel | null {
   return normalized as HookMessageChannel;
 }
 
-export function resolveHookDeliver(raw: unknown): boolean {
+export function resolveHookDeliver(raw: unknown): boolean | "auto" {
+  if (raw === "auto") return "auto";
   return raw !== false;
 }
 


### PR DESCRIPTION
## Summary

Adds `deliver: "auto"` as a new option for webhook hook mappings. When set, the isolated agent's response is delivered to the channel **unless** the response is a short acknowledgment (like "ok", "noted", "done", etc.).

## Use case

For noisy webhook sources like Gmail, the agent should silently handle routine emails (spam, newsletters, notifications) but deliver real content when there's something worth surfacing. Currently `deliver: true` always notifies and `deliver: false` never does — there's no middle ground.

With `deliver: "auto"`, the agent processes every webhook but only delivers when it has real content. Short acks (≤3 chars or matching common patterns like "ok", "noted", "done", "acknowledged", "heartbeat_ok", etc.) are silently dropped.

## Approach

The skip logic lives in the isolated agent run (`src/cron/isolated-agent/run.ts`), after the existing `skipHeartbeatDelivery` and `skipMessagingToolDelivery` checks. When `deliver` is `"auto"`:
- Empty responses → skip delivery
- Short ack responses (≤3 chars or matching known patterns) → skip delivery  
- Everything else → deliver normally

The delivery planner (`src/cron/delivery.ts`) treats `"auto"` as `requested: true` so the delivery pipeline is set up — the actual skip decision happens later when we can inspect the agent's response.

## Changes

| File | Change |
|------|--------|
| `src/config/zod-schema.hooks.ts` | Schema accepts `boolean \| "auto"` |
| `src/config/types.hooks.ts` | Type updated to `boolean \| "auto"` |
| `src/gateway/hooks.ts` | `resolveHookDeliver` passes through `"auto"`; `HookAgentPayload.deliver` type updated |
| `src/gateway/hooks-mapping.ts` | All `deliver` types updated; `mergeAction` handles `"auto"` |
| `src/cron/isolated-agent/run.ts` | New `skipAutoDeliverAck` check after existing skip checks |
| `src/cron/delivery.ts` | Legacy mode resolution treats `"auto"` as `"explicit"` |
| `src/cron/types.ts` | `CronPayload` and `CronPayloadPatch` deliver types updated |

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `deliver: "auto"` mode for webhook mappings to enable intelligent delivery based on agent response content. When set, responses are delivered unless they're short acknowledgments like "ok", "noted", "done" (≤3 chars or matching predefined patterns).

**Changes**:
- Schema/types updated across 7 files to accept `boolean | "auto"` for `deliver` field
- `resolveCronDeliveryPlan` treats `"auto"` as `"explicit"` to enable delivery pipeline
- New skip logic in `runCronIsolatedAgentTurn` filters out short acks after existing skip checks
- `resolveHookDeliver` correctly passes through `"auto"` string literal
- `mergeAction` properly handles `"auto"` value in deliver field merge logic

**Issues found**:
- Critical: Auto-deliver skip logic doesn't check for media attachments - responses with media/structured content should always deliver regardless of text (see inline comment)

<h3>Confidence Score: 3/5</h3>

- Safe to merge after fixing media handling bug in auto-deliver logic
- The implementation is well-structured and follows existing patterns, but contains a logical bug where auto-deliver mode doesn't check for media content before skipping delivery. This could cause responses with images or structured data to be incorrectly suppressed. The fix is straightforward and follows the established pattern in `isHeartbeatOnlyResponse`.
- Pay attention to `src/cron/isolated-agent/run.ts` - the auto-deliver skip logic needs media checking

<sub>Last reviewed commit: ebe21d6</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->