### PR TITLE
fix(telegram): normalize command names by replacing hyphens with underscores

### DIFF
--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -310,7 +310,7 @@ export const registerTelegramNativeCommands = ({
       })
     : [];
   const reservedCommands = new Set(
-    listNativeCommandSpecs().map((command) => command.name.toLowerCase()),
+    listNativeCommandSpecs().map((command) => command.name.replace(/-/g, "_").toLowerCase()),
   );
   for (const command of skillCommands) {
     reservedCommands.add(command.name.toLowerCase());
@@ -326,7 +326,7 @@ export const registerTelegramNativeCommands = ({
   const pluginCommandSpecs = getPluginCommandSpecs();
   const existingCommands = new Set(
     [
-      ...nativeCommands.map((command) => command.name),
+      ...nativeCommands.map((command) => command.name.replace(/-/g, "_")),
       ...customCommands.map((command) => command.command),
     ].map((command) => command.toLowerCase()),
   );

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -339,7 +339,7 @@ export const registerTelegramNativeCommands = ({
   }
   const allCommandsFull: Array<{ command: string; description: string }> = [
     ...nativeCommands.map((command) => ({
-      command: command.name,
+      command: command.name.replace(/-/g, "_"),
       description: command.description,
     })),
     ...(nativeEnabled ? pluginCatalog.commands : []),
@@ -419,7 +419,8 @@ export const registerTelegramNativeCommands = ({
       logVerbose("telegram: bot.command unavailable; skipping native handlers");
     } else {
       for (const command of nativeCommands) {
-        bot.command(command.name, async (ctx: TelegramNativeCommandContext) => {
+        const normalizedCommandName = command.name.replace(/-/g, "_");
+        bot.command(normalizedCommandName, async (ctx: TelegramNativeCommandContext) => {
           const msg = ctx.message;
           if (!msg) {
             return;
@@ -480,8 +481,8 @@ export const registerTelegramNativeCommands = ({
           const prompt = commandDefinition
             ? buildCommandTextFromArgs(commandDefinition, commandArgs)
             : rawText
-              ? `/${command.name} ${rawText}`
-              : `/${command.name}`;
+              ? `/${normalizedCommandName} ${rawText}`
+              : `/${normalizedCommandName}`;
           const menu = commandDefinition
             ? resolveCommandArgMenu({
                 command: commandDefinition,

--- a/src/telegram/bot.test.ts
+++ b/src/telegram/bot.test.ts
@@ -69,7 +69,7 @@ describe("createTelegramBot", () => {
     }>;
     const skillCommands = resolveSkillCommands(config);
     const native = listNativeCommandSpecsForConfig(config, { skillCommands }).map((command) => ({
-      command: command.name,
+      command: command.name.replace(/-/g, "_"),
       description: command.description,
     }));
     expect(registered.slice(0, native.length)).toEqual(native);

--- a/src/telegram/bot.test.ts
+++ b/src/telegram/bot.test.ts
@@ -110,7 +110,7 @@ describe("createTelegramBot", () => {
     }>;
     const skillCommands = resolveSkillCommands(config);
     const native = listNativeCommandSpecsForConfig(config, { skillCommands }).map((command) => ({
-      command: command.name,
+      command: command.name.replace(/-/g, "_"),
       description: command.description,
     }));
     const nativeStatus = native.find((command) => command.command === "status");


### PR DESCRIPTION
## Summary

Telegram bot command names must match `/^[a-z0-9_]{1,32}$/` (only lowercase letters, numbers, and underscores). The `export-session` native command (introduced in add3afb7) contains a hyphen, causing `setMyCommands` to fail with `400 Bad Request: BOT_COMMAND_INVALID`.

This PR normalizes all native command names by replacing hyphens with underscores before registering them with Telegram's Bot API, making `export-session` accessible as `/export_session`.

## Context

**This is a regression fix introduced in commit add3afb7 (2026-02-17).**

- **Affected**: Users running from `main` branch (developers using `pnpm dev`)
- **Not affected**: Stable release users (v2026.2.15 and earlier)
- **Impact**: Command registration fails completely, preventing all Telegram commands from appearing in the bot menu

Without this fix, the next stable release would ship with broken Telegram command registration.

## Changes

- **Menu registration**: Convert hyphens to underscores when building `allCommandsFull` for Telegram command menu
- **Handler registration**: Use normalized command name when registering bot command handlers  
- **Prompt building**: Use normalized command name in generated prompts for consistency

## Why normalize at registration time?

Instead of renaming `export-session` to `export_session` in the command registry, normalization at registration:
- ✅ Prevents future issues if other hyphenated commands are added
- ✅ Keeps command IDs consistent across providers (other channels may allow hyphens)
- ✅ Maintains backward compatibility with existing command definitions
- ✅ Localizes the fix to Telegram-specific code

## Testing

- [x] Code builds without errors
- [x] All 457 Telegram tests pass
- [ ] Manual test: verify `/export_session` command registers and works in Telegram

## Fixes

Closes #18683

## AI-assisted

Yes - AI-assisted with human review
