### PR TITLE
Community improvements

### DIFF
--- a/src/agents/bash-process-registry.ts
+++ b/src/agents/bash-process-registry.ts
@@ -13,7 +13,13 @@ function clampTtl(value: number | undefined) {
   return Math.min(Math.max(value, MIN_JOB_TTL_MS), MAX_JOB_TTL_MS);
 }
 
-let jobTtlMs = clampTtl(Number.parseInt(process.env.PI_BASH_JOB_TTL_MS ?? "", 10));
+let jobTtlMs = clampTtl(
+  (() => {
+    const s = process.env.PI_BASH_JOB_TTL_MS?.trim() ?? "";
+    // Require full digit string (no mixed alphanumeric like "100abc", no decimals)
+    return /^\d+$/.test(s) ? Number.parseInt(s, 10) : undefined;
+  })(),
+);
 
 export type ProcessStatus = "running" | "completed" | "failed" | "killed";
 

--- a/src/agents/bash-tools.process.ts
+++ b/src/agents/bash-tools.process.ts
@@ -78,7 +78,12 @@ function resolvePollWaitMs(value: unknown) {
     return Math.max(0, Math.min(MAX_POLL_WAIT_MS, Math.floor(value)));
   }
   if (typeof value === "string") {
-    const parsed = Number.parseInt(value.trim(), 10);
+    const trimmed = value.trim();
+    // Require full digit string (no mixed alphanumeric like "100abc", no decimals)
+    if (!/^\d+$/.test(trimmed)) {
+      return 0;
+    }
+    const parsed = Number.parseInt(trimmed, 10);
     if (Number.isFinite(parsed)) {
       return Math.max(0, Math.min(MAX_POLL_WAIT_MS, parsed));
     }

--- a/src/agents/bash-tools.shared.ts
+++ b/src/agents/bash-tools.shared.ts
@@ -157,7 +157,12 @@ export function readEnvInt(key: string) {
   if (!raw) {
     return undefined;
   }
-  const parsed = Number.parseInt(raw, 10);
+  const trimmed = raw.trim();
+  // Require full digit string (no mixed alphanumeric like "100abc", no decimals)
+  if (!/^\d+$/.test(trimmed)) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(trimmed, 10);
   return Number.isFinite(parsed) ? parsed : undefined;
 }
 

--- a/src/agents/pi-embedded-helpers/errors.test.ts
+++ b/src/agents/pi-embedded-helpers/errors.test.ts
@@ -1,0 +1,352 @@
+import { describe, expect, it } from "vitest";
+import {
+  isContextOverflowError,
+  isLikelyContextOverflowError,
+  isCompactionFailureError,
+  isRateLimitErrorMessage,
+  isTimeoutErrorMessage,
+  isBillingErrorMessage,
+  isAuthErrorMessage,
+  isOverloadedErrorMessage,
+  parseImageDimensionError,
+  parseImageSizeError,
+  classifyFailoverReason,
+  isFailoverErrorMessage,
+  parseApiErrorInfo,
+  isRawApiErrorPayload,
+  getApiErrorPayloadFingerprint,
+  isCloudflareOrHtmlErrorPage,
+  isTransientHttpError,
+} from "./errors.js";
+
+describe("isContextOverflowError", () => {
+  it("detects request_too_large", () => {
+    expect(isContextOverflowError("request_too_large")).toBe(true);
+  });
+
+  it("detects context length exceeded", () => {
+    expect(isContextOverflowError("context length exceeded")).toBe(true);
+  });
+
+  it("detects maximum context length", () => {
+    expect(isContextOverflowError("maximum context length is 200000 tokens")).toBe(true);
+  });
+
+  it("detects prompt is too long", () => {
+    expect(isContextOverflowError("prompt is too long")).toBe(true);
+  });
+
+  it("detects context overflow", () => {
+    expect(isContextOverflowError("context overflow: something")).toBe(true);
+  });
+
+  it("detects 413 too large", () => {
+    expect(isContextOverflowError("413 too large")).toBe(true);
+  });
+
+  it("returns false for empty input", () => {
+    expect(isContextOverflowError("")).toBe(false);
+    expect(isContextOverflowError(undefined)).toBe(false);
+  });
+
+  it("returns false for unrelated errors", () => {
+    expect(isContextOverflowError("invalid api key")).toBe(false);
+    expect(isContextOverflowError("rate limit exceeded")).toBe(false);
+  });
+});
+
+describe("isLikelyContextOverflowError", () => {
+  it("detects context overflow hints", () => {
+    expect(isLikelyContextOverflowError("context window too large")).toBe(true);
+    expect(isLikelyContextOverflowError("input exceeds context limit")).toBe(true);
+  });
+
+  it("excludes rate limit errors that match broad pattern", () => {
+    expect(isLikelyContextOverflowError("request reached organization rate limit")).toBe(false);
+  });
+
+  it("returns false for empty input", () => {
+    expect(isLikelyContextOverflowError("")).toBe(false);
+  });
+});
+
+describe("isCompactionFailureError", () => {
+  it("detects summarization failed with context overflow", () => {
+    expect(isCompactionFailureError("summarization failed: context overflow")).toBe(true);
+  });
+
+  it("detects auto-compaction with context", () => {
+    expect(isCompactionFailureError("auto-compaction: context overflow")).toBe(true);
+  });
+
+  it("detects context overflow with compaction term", () => {
+    expect(isCompactionFailureError("compaction context overflow")).toBe(true);
+  });
+
+  it("returns false for unrelated errors", () => {
+    expect(isCompactionFailureError("invalid api key")).toBe(false);
+  });
+
+  it("returns false for compaction term without overflow", () => {
+    expect(isCompactionFailureError("compaction completed")).toBe(false);
+  });
+});
+
+describe("isRateLimitErrorMessage", () => {
+  it("detects rate limit patterns", () => {
+    expect(isRateLimitErrorMessage("rate limit exceeded")).toBe(true);
+    expect(isRateLimitErrorMessage("too many requests")).toBe(true);
+    expect(isRateLimitErrorMessage("429 Too Many Requests")).toBe(true);
+  });
+
+  it("detects quota patterns", () => {
+    expect(isRateLimitErrorMessage("exceeded your current quota")).toBe(true);
+    expect(isRateLimitErrorMessage("quota exceeded")).toBe(true);
+  });
+
+  it("returns false for unrelated errors", () => {
+    expect(isRateLimitErrorMessage("invalid api key")).toBe(false);
+  });
+
+  it("returns false for empty input", () => {
+    expect(isRateLimitErrorMessage("")).toBe(false);
+  });
+});
+
+describe("isTimeoutErrorMessage", () => {
+  it("detects timeout patterns", () => {
+    expect(isTimeoutErrorMessage("request timed out")).toBe(true);
+    expect(isTimeoutErrorMessage("deadline exceeded")).toBe(true);
+    expect(isTimeoutErrorMessage("context deadline exceeded")).toBe(true);
+  });
+
+  it("detects abort patterns", () => {
+    expect(isTimeoutErrorMessage("stop reason: abort")).toBe(true);
+    expect(isTimeoutErrorMessage("unhandled stop reason: abort")).toBe(true);
+  });
+
+  it("returns false for unrelated errors", () => {
+    expect(isTimeoutErrorMessage("invalid api key")).toBe(false);
+  });
+});
+
+describe("isBillingErrorMessage", () => {
+  it("detects billing error patterns", () => {
+    expect(isBillingErrorMessage("payment required")).toBe(true);
+    expect(isBillingErrorMessage("insufficient credits")).toBe(true);
+    expect(isBillingErrorMessage("credit balance low")).toBe(true);
+  });
+
+  it("detects HTTP 402", () => {
+    expect(isBillingErrorMessage("402 payment required")).toBe(true);
+    expect(isBillingErrorMessage('{"code": 402}')).toBe(true);
+  });
+
+  it("returns false for unrelated errors", () => {
+    expect(isBillingErrorMessage("rate limit exceeded")).toBe(false);
+  });
+});
+
+describe("isAuthErrorMessage", () => {
+  it("detects auth error patterns", () => {
+    expect(isAuthErrorMessage("invalid api key")).toBe(true);
+    expect(isAuthErrorMessage("incorrect api key")).toBe(true);
+    expect(isAuthErrorMessage("authentication failed")).toBe(true);
+    expect(isAuthErrorMessage("unauthorized")).toBe(true);
+  });
+
+  it("detects HTTP 401 and 403", () => {
+    expect(isAuthErrorMessage("401 unauthorized")).toBe(true);
+    expect(isAuthErrorMessage("403 forbidden")).toBe(true);
+  });
+
+  it("detects expired token", () => {
+    expect(isAuthErrorMessage("token has expired")).toBe(true);
+  });
+
+  it("returns false for unrelated errors", () => {
+    expect(isAuthErrorMessage("rate limit exceeded")).toBe(false);
+  });
+});
+
+describe("isOverloadedErrorMessage", () => {
+  it("detects overloaded patterns", () => {
+    expect(isOverloadedErrorMessage("overloaded_error")).toBe(true);
+    expect(isOverloadedErrorMessage("service is overloaded")).toBe(true);
+  });
+
+  it("returns false for unrelated errors", () => {
+    expect(isOverloadedErrorMessage("invalid api key")).toBe(false);
+  });
+});
+
+describe("parseImageDimensionError", () => {
+  it("parses dimension error with pixel limit", () => {
+    const result = parseImageDimensionError(
+      "image dimensions exceed max allowed size for many-image requests: 4096 pixels",
+    );
+    expect(result?.maxDimensionPx).toBe(4096);
+    expect(result?.raw).toContain("image dimensions");
+  });
+
+  it("parses dimension error with path", () => {
+    const result = parseImageDimensionError(
+      "image dimensions exceed max allowed size for many-image requests: 4096 pixels (messages.1.content.2.image)",
+    );
+    expect(result?.maxDimensionPx).toBe(4096);
+    expect(result?.messageIndex).toBe(1);
+    expect(result?.contentIndex).toBe(2);
+  });
+
+  it("returns null for non-dimension errors", () => {
+    expect(parseImageDimensionError("invalid api key")).toBe(null);
+  });
+});
+
+describe("parseImageSizeError", () => {
+  it("parses size error with MB limit", () => {
+    const result = parseImageSizeError("image exceeds 10.5 mb");
+    expect(result?.maxMb).toBe(10.5);
+    expect(result?.raw).toContain("image exceeds");
+  });
+
+  it("returns null for non-size errors", () => {
+    expect(parseImageSizeError("invalid api key")).toBe(null);
+  });
+});
+
+describe("classifyFailoverReason", () => {
+  it("classifies rate limit as rate_limit", () => {
+    expect(classifyFailoverReason("rate limit exceeded")).toBe("rate_limit");
+  });
+
+  it("classifies overloaded as rate_limit", () => {
+    expect(classifyFailoverReason("service is overloaded")).toBe("rate_limit");
+  });
+
+  it("classifies timeout as timeout", () => {
+    expect(classifyFailoverReason("request timed out")).toBe("timeout");
+  });
+
+  it("classifies billing as billing", () => {
+    expect(classifyFailoverReason("payment required")).toBe("billing");
+  });
+
+  it("classifies auth as auth", () => {
+    expect(classifyFailoverReason("invalid api key")).toBe("auth");
+  });
+
+  it("returns null for non-failover errors", () => {
+    expect(classifyFailoverReason("hello world")).toBe(null);
+  });
+
+  it("returns null for image dimension errors (handled specially)", () => {
+    expect(
+      classifyFailoverReason("image dimensions exceed max allowed size for many-image requests"),
+    ).toBe(null);
+  });
+
+  it("returns null for image size errors (handled specially)", () => {
+    expect(classifyFailoverReason("image exceeds 10 mb")).toBe(null);
+  });
+
+  it("treats transient 5xx as timeout", () => {
+    expect(classifyFailoverReason("500 internal server error")).toBe("timeout");
+    expect(classifyFailoverReason("502 bad gateway")).toBe("timeout");
+    expect(classifyFailoverReason("503 service unavailable")).toBe("timeout");
+  });
+});
+
+describe("isFailoverErrorMessage", () => {
+  it("returns true for failover errors", () => {
+    expect(isFailoverErrorMessage("rate limit exceeded")).toBe(true);
+    expect(isFailoverErrorMessage("request timed out")).toBe(true);
+  });
+
+  it("returns false for non-failover errors", () => {
+    expect(isFailoverErrorMessage("hello world")).toBe(false);
+  });
+});
+
+describe("parseApiErrorInfo", () => {
+  it("parses JSON error payload", () => {
+    const result = parseApiErrorInfo(
+      '{"error": {"message": "invalid request", "type": "invalid_request_error"}}',
+    );
+    expect(result?.message).toBe("invalid request");
+    expect(result?.type).toBe("invalid_request_error");
+  });
+
+  it("extracts request_id from payload", () => {
+    const result = parseApiErrorInfo('{"request_id": "abc123", "error": {"message": "fail"}}');
+    expect(result?.requestId).toBe("abc123");
+  });
+
+  it("extracts requestId (camelCase) from payload", () => {
+    const result = parseApiErrorInfo('{"requestId": "xyz789", "error": {"message": "fail"}}');
+    expect(result?.requestId).toBe("xyz789");
+  });
+
+  it("returns null for non-JSON input", () => {
+    expect(parseApiErrorInfo("just some text")).toBe(null);
+  });
+});
+
+describe("isRawApiErrorPayload", () => {
+  it("detects JSON error payloads", () => {
+    expect(isRawApiErrorPayload('{"error": {"message": "fail"}}')).toBe(true);
+  });
+
+  it("returns false for plain text", () => {
+    expect(isRawApiErrorPayload("rate limit exceeded")).toBe(false);
+  });
+});
+
+describe("getApiErrorPayloadFingerprint", () => {
+  it("generates stable fingerprint for error payload", () => {
+    const fp1 = getApiErrorPayloadFingerprint('{"error": {"message": "fail"}}');
+    const fp2 = getApiErrorPayloadFingerprint('{"error": {"message": "fail"}}');
+    expect(fp1).toBe(fp2);
+  });
+
+  it("returns null for non-payload input", () => {
+    expect(getApiErrorPayloadFingerprint("hello")).toBe(null);
+  });
+});
+
+describe("isCloudflareOrHtmlErrorPage", () => {
+  it("detects Cloudflare error codes", () => {
+    expect(isCloudflareOrHtmlErrorPage("521 Origin Down <html>")).toBe(true);
+    expect(isCloudflareOrHtmlErrorPage("522 Connection timed out <html>")).toBe(true);
+  });
+
+  it("detects 5xx with HTML", () => {
+    expect(isCloudflareOrHtmlErrorPage("500 <html><body>Error</body></html>")).toBe(true);
+  });
+
+  it("returns false for non-5xx", () => {
+    expect(isCloudflareOrHtmlErrorPage("404 Not Found")).toBe(false);
+  });
+
+  it("returns false for 5xx without HTML", () => {
+    expect(isCloudflareOrHtmlErrorPage("500 Internal Server Error")).toBe(false);
+  });
+});
+
+describe("isTransientHttpError", () => {
+  it("detects transient error codes", () => {
+    expect(isTransientHttpError("500 internal server error")).toBe(true);
+    expect(isTransientHttpError("502 bad gateway")).toBe(true);
+    expect(isTransientHttpError("503 service unavailable")).toBe(true);
+  });
+
+  it("detects Cloudflare transient codes", () => {
+    expect(isTransientHttpError("521 origin down")).toBe(true);
+    expect(isTransientHttpError("522 connection timed out")).toBe(true);
+  });
+
+  it("returns false for non-transient codes", () => {
+    expect(isTransientHttpError("400 bad request")).toBe(false);
+    expect(isTransientHttpError("404 not found")).toBe(false);
+  });
+});

--- a/src/browser/server.post-tabs-open-profile-unknown-returns-404.test.ts
+++ b/src/browser/server.post-tabs-open-profile-unknown-returns-404.test.ts
@@ -35,9 +35,15 @@ describe("browser control server", () => {
 });
 
 describe("profile CRUD endpoints", () => {
+  let savedGatewayToken: string | undefined;
+
   beforeEach(async () => {
     state.reachable = false;
     state.cfgAttachOnly = false;
+
+    // Clear gateway token so the browser control server doesn't require auth
+    savedGatewayToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+    delete process.env.OPENCLAW_GATEWAY_TOKEN;
 
     for (const fn of Object.values(pwMocks)) {
       fn.mockClear();
@@ -70,6 +76,11 @@ describe("profile CRUD endpoints", () => {
       delete process.env.OPENCLAW_GATEWAY_PORT;
     } else {
       process.env.OPENCLAW_GATEWAY_PORT = state.prevGatewayPort;
+    }
+    if (savedGatewayToken !== undefined) {
+      process.env.OPENCLAW_GATEWAY_TOKEN = savedGatewayToken;
+    } else {
+      delete process.env.OPENCLAW_GATEWAY_TOKEN;
     }
     await stopBrowserControlServer();
   });

--- a/src/cli/argv.test.ts
+++ b/src/cli/argv.test.ts
@@ -68,6 +68,20 @@ describe("argv helpers", () => {
     expect(
       getPositiveIntFlagValue(["node", "openclaw", "status", "--timeout", "nope"], "--timeout"),
     ).toBeUndefined();
+    // Edge cases: reject mixed alphanumeric, decimals, scientific notation
+    expect(
+      getPositiveIntFlagValue(["node", "openclaw", "status", "--timeout", "100abc"], "--timeout"),
+    ).toBeUndefined();
+    expect(
+      getPositiveIntFlagValue(["node", "openclaw", "status", "--timeout", "12.5"], "--timeout"),
+    ).toBeUndefined();
+    expect(
+      getPositiveIntFlagValue(["node", "openclaw", "status", "--timeout", "1e3"], "--timeout"),
+    ).toBeUndefined();
+    // Valid with trim
+    expect(
+      getPositiveIntFlagValue(["node", "openclaw", "status", "--timeout", "  5000  "], "--timeout"),
+    ).toBe(5000);
   });
 
   it("builds parse argv from raw args", () => {

--- a/src/cli/argv.ts
+++ b/src/cli/argv.ts
@@ -20,7 +20,12 @@ function isValueToken(arg: string | undefined): boolean {
 }
 
 function parsePositiveInt(value: string): number | undefined {
-  const parsed = Number.parseInt(value, 10);
+  const trimmed = value.trim();
+  // Require full digit string (no mixed alphanumeric like "100abc")
+  if (!/^\d+$/.test(trimmed)) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(trimmed, 10);
   if (Number.isNaN(parsed) || parsed <= 0) {
     return undefined;
   }

--- a/src/cli/browser-cli-shared.ts
+++ b/src/cli/browser-cli-shared.ts
@@ -32,12 +32,19 @@ export async function callBrowserRequest<T>(
   params: BrowserRequestParams,
   extra?: { timeoutMs?: number; progress?: boolean },
 ): Promise<T> {
-  const resolvedTimeoutMs =
-    typeof extra?.timeoutMs === "number" && Number.isFinite(extra.timeoutMs)
-      ? Math.max(1, Math.floor(extra.timeoutMs))
-      : typeof opts.timeout === "string"
-        ? Number.parseInt(opts.timeout, 10)
-        : undefined;
+  let resolvedTimeoutMs: number | undefined;
+  if (typeof extra?.timeoutMs === "number" && Number.isFinite(extra.timeoutMs)) {
+    resolvedTimeoutMs = Math.max(1, Math.floor(extra.timeoutMs));
+  } else if (typeof opts.timeout === "string") {
+    const s = opts.timeout.trim();
+    // Require full digit string (no mixed alphanumeric like "100abc", no decimals)
+    if (/^\d+$/.test(s)) {
+      const parsed = Number.parseInt(s, 10);
+      if (Number.isFinite(parsed)) {
+        resolvedTimeoutMs = parsed;
+      }
+    }
+  }
   const resolvedTimeout =
     typeof resolvedTimeoutMs === "number" && Number.isFinite(resolvedTimeoutMs)
       ? resolvedTimeoutMs

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -145,7 +145,14 @@ export function registerCronEditCommand(cron: Command) {
               ? opts.thinking.trim()
               : undefined;
           const timeoutSeconds = opts.timeoutSeconds
-            ? Number.parseInt(String(opts.timeoutSeconds), 10)
+            ? (() => {
+                const s = String(opts.timeoutSeconds).trim();
+                // Require full digit string (no mixed alphanumeric like "100abc", no decimals)
+                if (!/^\d+$/.test(s)) {
+                  return undefined;
+                }
+                return Number.parseInt(s, 10);
+              })()
             : undefined;
           const hasTimeoutSeconds = Boolean(timeoutSeconds && Number.isFinite(timeoutSeconds));
           const hasDeliveryModeFlag = opts.announce || typeof opts.deliver === "boolean";

--- a/src/cli/cron-cli/register.cron-simple.ts
+++ b/src/cli/cron-cli/register.cron-simple.ts
@@ -72,7 +72,9 @@ export function registerCronSimpleCommands(cron: Command) {
       .option("--limit <n>", "Max entries (default 50)", "50")
       .action(async (opts) => {
         try {
-          const limitRaw = Number.parseInt(String(opts.limit ?? "50"), 10);
+          const limitStr = String(opts.limit ?? "50").trim();
+          // Require full digit string (no mixed alphanumeric like "100abc", no decimals)
+          const limitRaw = /^\d+$/.test(limitStr) ? Number.parseInt(limitStr, 10) : undefined;
           const limit = Number.isFinite(limitRaw) && limitRaw > 0 ? limitRaw : 50;
           const id = String(opts.id);
           const res = await callGatewayFromCli("cron.runs", opts, {

--- a/src/cli/cron-cli/register.cron-simple.ts
+++ b/src/cli/cron-cli/register.cron-simple.ts
@@ -74,7 +74,7 @@ export function registerCronSimpleCommands(cron: Command) {
         try {
           const limitStr = String(opts.limit ?? "50").trim();
           // Require full digit string (no mixed alphanumeric like "100abc", no decimals)
-          const limitRaw = /^\d+$/.test(limitStr) ? Number.parseInt(limitStr, 10) : undefined;
+          const limitRaw = /^\d+$/.test(limitStr) ? Number.parseInt(limitStr, 10) : NaN;
           const limit = Number.isFinite(limitRaw) && limitRaw > 0 ? limitRaw : 50;
           const id = String(opts.id);
           const res = await callGatewayFromCli("cron.runs", opts, {

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -217,7 +217,9 @@ export async function gatherDaemonStatus(
     { deep: Boolean(opts.deep) },
   ).catch(() => []);
 
-  const timeoutMsRaw = Number.parseInt(String(opts.rpc.timeout ?? "10000"), 10);
+  const timeoutStr = String(opts.rpc.timeout ?? "10000").trim();
+  // Require full digit string (no mixed alphanumeric like "100abc", no decimals)
+  const timeoutMsRaw = /^\d+$/.test(timeoutStr) ? Number.parseInt(timeoutStr, 10) : NaN;
   const timeoutMs = Number.isFinite(timeoutMsRaw) && timeoutMsRaw > 0 ? timeoutMsRaw : 10_000;
 
   const rpc = opts.probe

--- a/src/cli/directory-cli.ts
+++ b/src/cli/directory-cli.ts
@@ -24,6 +24,10 @@ function parseLimit(value: unknown): number | null {
   if (!raw) {
     return null;
   }
+  // Require full digit string (no mixed alphanumeric like "100abc", no decimals)
+  if (!/^\d+$/.test(raw)) {
+    return null;
+  }
   const parsed = Number.parseInt(raw, 10);
   if (!Number.isFinite(parsed) || parsed <= 0) {
     return null;

--- a/src/cli/gateway-cli/discover.ts
+++ b/src/cli/gateway-cli/discover.ts
@@ -22,6 +22,10 @@ export function parseDiscoverTimeoutMs(raw: unknown, fallbackMs: number): number
   if (!value) {
     return fallbackMs;
   }
+  // Require full digit string (no mixed alphanumeric like "100abc", no decimals)
+  if (!/^\d+$/.test(value)) {
+    throw new Error(`invalid --timeout: ${value}`);
+  }
   const parsed = Number.parseInt(value, 10);
   if (!Number.isFinite(parsed) || parsed <= 0) {
     throw new Error(`invalid --timeout: ${value}`);

--- a/src/cli/logs-cli.test.ts
+++ b/src/cli/logs-cli.test.ts
@@ -57,6 +57,30 @@ describe("logs cli", () => {
     expect(stderrWrites.join("")).toContain("Log cursor reset");
   });
 
+  it("falls back to defaults for invalid numeric options", async () => {
+    callGatewayFromCli.mockResolvedValueOnce({ lines: [] });
+
+    await runLogsCli(["logs", "--limit", "20abc", "--max-bytes", "12.5", "--interval", "1e3"]);
+
+    expect(callGatewayFromCli).toHaveBeenCalledTimes(1);
+    expect(callGatewayFromCli.mock.calls[0]?.[2]).toMatchObject({
+      limit: 200,
+      maxBytes: 250_000,
+    });
+  });
+
+  it("accepts trimmed positive integer options", async () => {
+    callGatewayFromCli.mockResolvedValueOnce({ lines: [] });
+
+    await runLogsCli(["logs", "--limit", " 50 ", "--max-bytes", "+1234"]);
+
+    expect(callGatewayFromCli).toHaveBeenCalledTimes(1);
+    expect(callGatewayFromCli.mock.calls[0]?.[2]).toMatchObject({
+      limit: 50,
+      maxBytes: 1234,
+    });
+  });
+
   it("wires --local-time through CLI parsing and emits local timestamps", async () => {
     callGatewayFromCli.mockResolvedValueOnce({
       file: "/tmp/openclaw.log",

--- a/src/cli/logs-cli.ts
+++ b/src/cli/logs-cli.ts
@@ -34,12 +34,18 @@ type LogsCliOptions = {
   expectFinal?: boolean;
 };
 
+const POSITIVE_INT_PATTERN = /^\+?\d+$/;
+
 function parsePositiveInt(value: string | undefined, fallback: number): number {
   if (!value) {
     return fallback;
   }
-  const parsed = Number.parseInt(value, 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+  const trimmed = value.trim();
+  if (!POSITIVE_INT_PATTERN.test(trimmed)) {
+    return fallback;
+  }
+  const parsed = Number(trimmed);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
 }
 
 async function fetchLogs(

--- a/src/cli/nodes-camera.ts
+++ b/src/cli/nodes-camera.ts
@@ -93,7 +93,11 @@ export async function writeUrlToFile(filePath: string, url: string) {
   }
 
   const contentLengthRaw = res.headers.get("content-length");
-  const contentLength = contentLengthRaw ? Number.parseInt(contentLengthRaw, 10) : undefined;
+  const contentLengthStr = typeof contentLengthRaw === "string" ? contentLengthRaw.trim() : "";
+  const contentLength =
+    contentLengthStr && /^\d+$/.test(contentLengthStr)
+      ? Number.parseInt(contentLengthStr, 10)
+      : undefined;
   if (
     typeof contentLength === "number" &&
     Number.isFinite(contentLength) &&

--- a/src/cli/nodes-cli/register.camera.ts
+++ b/src/cli/nodes-cli/register.camera.ts
@@ -116,13 +116,23 @@ export function registerNodesCameraCommands(nodes: Command) {
                     );
                   })();
 
-          const maxWidth = opts.maxWidth ? Number.parseInt(String(opts.maxWidth), 10) : undefined;
-          const quality = opts.quality ? Number.parseFloat(String(opts.quality)) : undefined;
-          const delayMs = opts.delayMs ? Number.parseInt(String(opts.delayMs), 10) : undefined;
+          const maxWidthStr = typeof opts.maxWidth === "string" ? opts.maxWidth.trim() : "";
+          const maxWidth =
+            maxWidthStr && /^\d+$/.test(maxWidthStr) ? Number.parseInt(maxWidthStr, 10) : undefined;
+          const qualityStr = typeof opts.quality === "string" ? opts.quality.trim() : "";
+          // Allow decimals for quality (0-100)
+          const quality =
+            qualityStr && /^\d+(\.\d+)?$/.test(qualityStr)
+              ? Number.parseFloat(qualityStr)
+              : undefined;
+          const delayMsStr = typeof opts.delayMs === "string" ? opts.delayMs.trim() : "";
+          const delayMs =
+            delayMsStr && /^\d+$/.test(delayMsStr) ? Number.parseInt(delayMsStr, 10) : undefined;
           const deviceId = opts.deviceId ? String(opts.deviceId).trim() : undefined;
-          const timeoutMs = opts.invokeTimeout
-            ? Number.parseInt(String(opts.invokeTimeout), 10)
-            : undefined;
+          const timeoutStr =
+            typeof opts.invokeTimeout === "string" ? opts.invokeTimeout.trim() : "";
+          const timeoutMs =
+            timeoutStr && /^\d+$/.test(timeoutStr) ? Number.parseInt(timeoutStr, 10) : undefined;
 
           const results: Array<{
             facing: CameraFacing;
@@ -198,9 +208,10 @@ export function registerNodesCameraCommands(nodes: Command) {
           const facing = parseFacing(String(opts.facing ?? "front"));
           const durationMs = parseDurationMs(String(opts.duration ?? "3000"));
           const includeAudio = opts.audio !== false;
-          const timeoutMs = opts.invokeTimeout
-            ? Number.parseInt(String(opts.invokeTimeout), 10)
-            : undefined;
+          const timeoutStr2 =
+            typeof opts.invokeTimeout === "string" ? opts.invokeTimeout.trim() : "";
+          const timeoutMs =
+            timeoutStr2 && /^\d+$/.test(timeoutStr2) ? Number.parseInt(timeoutStr2, 10) : undefined;
           const deviceId = opts.deviceId ? String(opts.deviceId).trim() : undefined;
 
           const invokeParams = buildNodeInvokeParams({

--- a/src/cli/nodes-cli/register.canvas.ts
+++ b/src/cli/nodes-cli/register.canvas.ts
@@ -50,8 +50,15 @@ export function registerNodesCanvasCommands(nodes: Command) {
             throw new Error(`invalid format: ${String(opts.format)} (expected png|jpg|jpeg)`);
           }
 
-          const maxWidth = opts.maxWidth ? Number.parseInt(String(opts.maxWidth), 10) : undefined;
-          const quality = opts.quality ? Number.parseFloat(String(opts.quality)) : undefined;
+          const maxWidthStr = typeof opts.maxWidth === "string" ? opts.maxWidth.trim() : "";
+          const maxWidth =
+            maxWidthStr && /^\d+$/.test(maxWidthStr) ? Number.parseInt(maxWidthStr, 10) : undefined;
+          const qualityStr = typeof opts.quality === "string" ? opts.quality.trim() : "";
+          // Allow decimals for quality (0-100)
+          const quality =
+            qualityStr && /^\d+(\.\d+)?$/.test(qualityStr)
+              ? Number.parseFloat(qualityStr)
+              : undefined;
           const raw = await invokeCanvas(opts, "canvas.snapshot", {
             format: formatForParams,
             maxWidth: Number.isFinite(maxWidth) ? maxWidth : undefined,
@@ -89,11 +96,18 @@ export function registerNodesCanvasCommands(nodes: Command) {
       .option("--invoke-timeout <ms>", "Node invoke timeout in ms")
       .action(async (opts: NodesRpcOpts) => {
         await runNodesCommand("canvas present", async () => {
+          const xStr = typeof opts.x === "string" ? opts.x.trim() : "";
+          const yStr = typeof opts.y === "string" ? opts.y.trim() : "";
+          const widthStr = typeof opts.width === "string" ? opts.width.trim() : "";
+          const heightStr = typeof opts.height === "string" ? opts.height.trim() : "";
+          // Allow decimals for coordinates/dimensions
+          const floatRegex = /^-?\d+(\.\d+)?$/;
           const placement = {
-            x: opts.x ? Number.parseFloat(opts.x) : undefined,
-            y: opts.y ? Number.parseFloat(opts.y) : undefined,
-            width: opts.width ? Number.parseFloat(opts.width) : undefined,
-            height: opts.height ? Number.parseFloat(opts.height) : undefined,
+            x: xStr && floatRegex.test(xStr) ? Number.parseFloat(xStr) : undefined,
+            y: yStr && floatRegex.test(yStr) ? Number.parseFloat(yStr) : undefined,
+            width: widthStr && floatRegex.test(widthStr) ? Number.parseFloat(widthStr) : undefined,
+            height:
+              heightStr && floatRegex.test(heightStr) ? Number.parseFloat(heightStr) : undefined,
           };
           const params: Record<string, unknown> = {};
           if (opts.target) {

--- a/src/cli/nodes-cli/register.invoke.ts
+++ b/src/cli/nodes-cli/register.invoke.ts
@@ -116,9 +116,11 @@ export function registerNodesInvokeCommands(nodes: Command) {
             return;
           }
           const params = JSON.parse(String(opts.params ?? "{}")) as unknown;
-          const timeoutMs = opts.invokeTimeout
-            ? Number.parseInt(String(opts.invokeTimeout), 10)
-            : undefined;
+          const timeoutStr =
+            typeof opts.invokeTimeout === "string" ? opts.invokeTimeout.trim() : "";
+          // Require full digit string (no mixed alphanumeric like "100abc", no decimals)
+          const timeoutMs =
+            timeoutStr && /^\d+$/.test(timeoutStr) ? Number.parseInt(timeoutStr, 10) : undefined;
 
           const invokeParams: Record<string, unknown> = {
             nodeId,

--- a/src/cli/nodes-cli/register.location.ts
+++ b/src/cli/nodes-cli/register.location.ts
@@ -23,7 +23,9 @@ export function registerNodesLocationCommands(nodes: Command) {
       .action(async (opts: NodesRpcOpts) => {
         await runNodesCommand("location get", async () => {
           const nodeId = await resolveNodeId(opts, String(opts.node ?? ""));
-          const maxAgeMs = opts.maxAge ? Number.parseInt(String(opts.maxAge), 10) : undefined;
+          const maxAgeStr = typeof opts.maxAge === "string" ? opts.maxAge.trim() : "";
+          const maxAgeMs =
+            maxAgeStr && /^\d+$/.test(maxAgeStr) ? Number.parseInt(maxAgeStr, 10) : undefined;
           const desiredAccuracyRaw =
             typeof opts.accuracy === "string" ? opts.accuracy.trim().toLowerCase() : undefined;
           const desiredAccuracy =
@@ -32,12 +34,18 @@ export function registerNodesLocationCommands(nodes: Command) {
             desiredAccuracyRaw === "precise"
               ? desiredAccuracyRaw
               : undefined;
-          const timeoutMs = opts.locationTimeout
-            ? Number.parseInt(String(opts.locationTimeout), 10)
-            : undefined;
-          const invokeTimeoutMs = opts.invokeTimeout
-            ? Number.parseInt(String(opts.invokeTimeout), 10)
-            : undefined;
+          const locationTimeoutStr =
+            typeof opts.locationTimeout === "string" ? opts.locationTimeout.trim() : "";
+          const timeoutMs =
+            locationTimeoutStr && /^\d+$/.test(locationTimeoutStr)
+              ? Number.parseInt(locationTimeoutStr, 10)
+              : undefined;
+          const invokeTimeoutStr =
+            typeof opts.invokeTimeout === "string" ? opts.invokeTimeout.trim() : "";
+          const invokeTimeoutMs =
+            invokeTimeoutStr && /^\d+$/.test(invokeTimeoutStr)
+              ? Number.parseInt(invokeTimeoutStr, 10)
+              : undefined;
 
           const invokeParams: Record<string, unknown> = {
             nodeId,

--- a/src/cli/nodes-cli/register.notify.ts
+++ b/src/cli/nodes-cli/register.notify.ts
@@ -25,9 +25,12 @@ export function registerNodesNotifyCommand(nodes: Command) {
           if (!title && !body) {
             throw new Error("missing --title or --body");
           }
-          const invokeTimeout = opts.invokeTimeout
-            ? Number.parseInt(String(opts.invokeTimeout), 10)
-            : undefined;
+          const invokeTimeoutStr =
+            typeof opts.invokeTimeout === "string" ? opts.invokeTimeout.trim() : "";
+          const invokeTimeout =
+            invokeTimeoutStr && /^\d+$/.test(invokeTimeoutStr)
+              ? Number.parseInt(invokeTimeoutStr, 10)
+              : undefined;
           const invokeParams: Record<string, unknown> = {
             nodeId,
             command: "system.notify",

--- a/src/cli/nodes-cli/register.screen.ts
+++ b/src/cli/nodes-cli/register.screen.ts
@@ -31,11 +31,15 @@ export function registerNodesScreenCommands(nodes: Command) {
         await runNodesCommand("screen record", async () => {
           const nodeId = await resolveNodeId(opts, String(opts.node ?? ""));
           const durationMs = parseDurationMs(opts.duration ?? "");
-          const screenIndex = Number.parseInt(String(opts.screen ?? "0"), 10);
-          const fps = Number.parseFloat(String(opts.fps ?? "10"));
-          const timeoutMs = opts.invokeTimeout
-            ? Number.parseInt(String(opts.invokeTimeout), 10)
-            : undefined;
+          const screenStr = typeof opts.screen === "string" ? opts.screen.trim() : "0";
+          const screenIndex = /^\d+$/.test(screenStr) ? Number.parseInt(screenStr, 10) : 0;
+          const fpsStr = typeof opts.fps === "string" ? opts.fps.trim() : "10";
+          // Allow decimals for fps
+          const fps = /^\d+(\.\d+)?$/.test(fpsStr) ? Number.parseFloat(fpsStr) : undefined;
+          const timeoutStr =
+            typeof opts.invokeTimeout === "string" ? opts.invokeTimeout.trim() : "";
+          const timeoutMs =
+            timeoutStr && /^\d+$/.test(timeoutStr) ? Number.parseInt(timeoutStr, 10) : undefined;
 
           const invokeParams = buildNodeInvokeParams({
             nodeId,

--- a/src/cli/parse-timeout.test.ts
+++ b/src/cli/parse-timeout.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { parseTimeoutMs } from "./parse-timeout";
+
+describe("parseTimeoutMs", () => {
+  it("returns undefined for nullish and blank values", () => {
+    expect(parseTimeoutMs(undefined)).toBeUndefined();
+    expect(parseTimeoutMs(null)).toBeUndefined();
+    expect(parseTimeoutMs("")).toBeUndefined();
+    expect(parseTimeoutMs("   ")).toBeUndefined();
+  });
+
+  it("parses integer values from number, bigint, and trimmed strings", () => {
+    expect(parseTimeoutMs(0)).toBe(0);
+    expect(parseTimeoutMs(1500)).toBe(1500);
+    expect(parseTimeoutMs(1500n)).toBe(1500);
+    expect(parseTimeoutMs(" 1500 ")).toBe(1500);
+    expect(parseTimeoutMs("+42")).toBe(42);
+    expect(parseTimeoutMs("-42")).toBe(-42);
+  });
+
+  it("rejects non-integer or mixed strings", () => {
+    expect(parseTimeoutMs("1500ms")).toBeUndefined();
+    expect(parseTimeoutMs("12.5")).toBeUndefined();
+    expect(parseTimeoutMs("1e3")).toBeUndefined();
+    expect(parseTimeoutMs("0x10")).toBeUndefined();
+    expect(parseTimeoutMs("12_000")).toBeUndefined();
+  });
+
+  it("rejects non-safe integers and non-finite values", () => {
+    expect(parseTimeoutMs(Number.NaN)).toBeUndefined();
+    expect(parseTimeoutMs(Number.POSITIVE_INFINITY)).toBeUndefined();
+    expect(parseTimeoutMs(12.5)).toBeUndefined();
+    expect(parseTimeoutMs(Number.MAX_SAFE_INTEGER + 1)).toBeUndefined();
+    expect(parseTimeoutMs(BigInt(Number.MAX_SAFE_INTEGER) + 1n)).toBeUndefined();
+  });
+});

--- a/src/cli/parse-timeout.ts
+++ b/src/cli/parse-timeout.ts
@@ -1,18 +1,27 @@
+const INTEGER_PATTERN = /^[+-]?\d+$/;
+
 export function parseTimeoutMs(raw: unknown): number | undefined {
   if (raw === undefined || raw === null) {
     return undefined;
   }
+
   let value = Number.NaN;
+
   if (typeof raw === "number") {
     value = raw;
   } else if (typeof raw === "bigint") {
     value = Number(raw);
   } else if (typeof raw === "string") {
     const trimmed = raw.trim();
-    if (!trimmed) {
+    if (!trimmed || !INTEGER_PATTERN.test(trimmed)) {
       return undefined;
     }
-    value = Number.parseInt(trimmed, 10);
+    value = Number(trimmed);
   }
-  return Number.isFinite(value) ? value : undefined;
+
+  if (!Number.isFinite(value) || !Number.isSafeInteger(value)) {
+    return undefined;
+  }
+
+  return value;
 }

--- a/src/cli/program/helpers.test.ts
+++ b/src/cli/program/helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parsePositiveIntOrUndefined } from "./helpers.js";
+import { parsePositiveIntOrUndefined, parseNonNegativeIntOrUndefined } from "./helpers.js";
 
 describe("parsePositiveIntOrUndefined", () => {
   it("returns undefined for undefined", () => {
@@ -69,5 +69,70 @@ describe("parsePositiveIntOrUndefined", () => {
   it("returns undefined for leading zeros that aren't just '0'", () => {
     // Leading zeros are fine for positive integers
     expect(parsePositiveIntOrUndefined("007")).toBe(7);
+  });
+});
+
+describe("parseNonNegativeIntOrUndefined", () => {
+  it("returns undefined for undefined", () => {
+    expect(parseNonNegativeIntOrUndefined(undefined)).toBe(undefined);
+  });
+
+  it("returns undefined for null", () => {
+    expect(parseNonNegativeIntOrUndefined(null)).toBe(undefined);
+  });
+
+  it("returns undefined for empty string", () => {
+    expect(parseNonNegativeIntOrUndefined("")).toBe(undefined);
+  });
+
+  it("returns undefined for whitespace string", () => {
+    expect(parseNonNegativeIntOrUndefined("   ")).toBe(undefined);
+  });
+
+  it("returns undefined for non-numeric string", () => {
+    expect(parseNonNegativeIntOrUndefined("abc")).toBe(undefined);
+  });
+
+  it("returns undefined for mixed alphanumeric string", () => {
+    expect(parseNonNegativeIntOrUndefined("100abc")).toBe(undefined);
+  });
+
+  it("returns undefined for decimal string", () => {
+    expect(parseNonNegativeIntOrUndefined("12.5")).toBe(undefined);
+  });
+
+  it("returns undefined for negative number string", () => {
+    expect(parseNonNegativeIntOrUndefined("-50")).toBe(undefined);
+  });
+
+  it("returns undefined for negative number", () => {
+    expect(parseNonNegativeIntOrUndefined(-5)).toBe(undefined);
+  });
+
+  it("returns undefined for Infinity", () => {
+    expect(parseNonNegativeIntOrUndefined(Infinity)).toBe(undefined);
+  });
+
+  it("returns undefined for NaN", () => {
+    expect(parseNonNegativeIntOrUndefined(NaN)).toBe(undefined);
+  });
+
+  it("parses valid non-negative integer string including zero", () => {
+    expect(parseNonNegativeIntOrUndefined("0")).toBe(0);
+    expect(parseNonNegativeIntOrUndefined("42")).toBe(42);
+  });
+
+  it("parses trimmed string with spaces", () => {
+    expect(parseNonNegativeIntOrUndefined("  42  ")).toBe(42);
+  });
+
+  it("parses valid non-negative integer number", () => {
+    expect(parseNonNegativeIntOrUndefined(0)).toBe(0);
+    expect(parseNonNegativeIntOrUndefined(42)).toBe(42);
+  });
+
+  it("truncates float to integer", () => {
+    expect(parseNonNegativeIntOrUndefined(42.9)).toBe(42);
+    expect(parseNonNegativeIntOrUndefined(0.9)).toBe(0);
   });
 });

--- a/src/cli/program/helpers.test.ts
+++ b/src/cli/program/helpers.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { parsePositiveIntOrUndefined } from "./helpers.js";
+
+describe("parsePositiveIntOrUndefined", () => {
+  it("returns undefined for undefined", () => {
+    expect(parsePositiveIntOrUndefined(undefined)).toBe(undefined);
+  });
+
+  it("returns undefined for null", () => {
+    expect(parsePositiveIntOrUndefined(null)).toBe(undefined);
+  });
+
+  it("returns undefined for empty string", () => {
+    expect(parsePositiveIntOrUndefined("")).toBe(undefined);
+  });
+
+  it("returns undefined for whitespace string", () => {
+    expect(parsePositiveIntOrUndefined("   ")).toBe(undefined);
+  });
+
+  it("returns undefined for non-numeric string", () => {
+    expect(parsePositiveIntOrUndefined("abc")).toBe(undefined);
+  });
+
+  it("returns undefined for mixed alphanumeric string", () => {
+    expect(parsePositiveIntOrUndefined("100abc")).toBe(undefined);
+  });
+
+  it("returns undefined for decimal string", () => {
+    expect(parsePositiveIntOrUndefined("12.5")).toBe(undefined);
+  });
+
+  it("returns undefined for negative number string", () => {
+    expect(parsePositiveIntOrUndefined("-50")).toBe(undefined);
+  });
+
+  it("returns undefined for zero", () => {
+    expect(parsePositiveIntOrUndefined(0)).toBe(undefined);
+  });
+
+  it("returns undefined for negative number", () => {
+    expect(parsePositiveIntOrUndefined(-5)).toBe(undefined);
+  });
+
+  it("returns undefined for Infinity", () => {
+    expect(parsePositiveIntOrUndefined(Infinity)).toBe(undefined);
+  });
+
+  it("returns undefined for NaN", () => {
+    expect(parsePositiveIntOrUndefined(NaN)).toBe(undefined);
+  });
+
+  it("parses valid positive integer string", () => {
+    expect(parsePositiveIntOrUndefined("42")).toBe(42);
+  });
+
+  it("parses trimmed string with spaces", () => {
+    expect(parsePositiveIntOrUndefined("  42  ")).toBe(42);
+  });
+
+  it("parses valid positive integer number", () => {
+    expect(parsePositiveIntOrUndefined(42)).toBe(42);
+  });
+
+  it("truncates float to integer", () => {
+    expect(parsePositiveIntOrUndefined(42.9)).toBe(42);
+  });
+
+  it("returns undefined for leading zeros that aren't just '0'", () => {
+    // Leading zeros are fine for positive integers
+    expect(parsePositiveIntOrUndefined("007")).toBe(7);
+  });
+});

--- a/src/cli/program/helpers.ts
+++ b/src/cli/program/helpers.ts
@@ -14,8 +14,13 @@ export function parsePositiveIntOrUndefined(value: unknown): number | undefined 
     return parsed > 0 ? parsed : undefined;
   }
   if (typeof value === "string") {
-    const parsed = Number.parseInt(value, 10);
-    if (Number.isNaN(parsed) || parsed <= 0) {
+    const trimmed = value.trim();
+    // Require full digit string (no mixed alphanumeric like "100abc", no decimals)
+    if (!/^\d+$/.test(trimmed)) {
+      return undefined;
+    }
+    const parsed = Number.parseInt(trimmed, 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
       return undefined;
     }
     return parsed;

--- a/src/cli/program/helpers.ts
+++ b/src/cli/program/helpers.ts
@@ -28,6 +28,33 @@ export function parsePositiveIntOrUndefined(value: unknown): number | undefined 
   return undefined;
 }
 
+export function parseNonNegativeIntOrUndefined(value: unknown): number | undefined {
+  // Like parsePositiveIntOrUndefined but allows zero
+  if (value === undefined || value === null || value === "") {
+    return undefined;
+  }
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      return undefined;
+    }
+    const parsed = Math.trunc(value);
+    return parsed >= 0 ? parsed : undefined;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    // Require full digit string (no mixed alphanumeric like "100abc", no decimals)
+    if (!/^\d+$/.test(trimmed)) {
+      return undefined;
+    }
+    const parsed = Number.parseInt(trimmed, 10);
+    if (!Number.isFinite(parsed) || parsed < 0) {
+      return undefined;
+    }
+    return parsed;
+  }
+  return undefined;
+}
+
 export function resolveActionArgs(actionCommand?: import("commander").Command): string[] {
   if (!actionCommand) {
     return [];

--- a/src/cli/program/register.onboard.ts
+++ b/src/cli/program/register.onboard.ts
@@ -115,8 +115,11 @@ export function registerOnboardCommand(program: Command) {
       const installDaemon = resolveInstallDaemonFlag(commandRuntime, {
         installDaemon: Boolean(opts.installDaemon),
       });
+      const gatewayPortStr = typeof opts.gatewayPort === "string" ? opts.gatewayPort.trim() : "";
       const gatewayPort =
-        typeof opts.gatewayPort === "string" ? Number.parseInt(opts.gatewayPort, 10) : undefined;
+        gatewayPortStr && /^\d+$/.test(gatewayPortStr)
+          ? Number.parseInt(gatewayPortStr, 10)
+          : undefined;
       await onboardCommand(
         {
           workspace: opts.workspace as string | undefined,

--- a/src/cli/shared/parse-port.test.ts
+++ b/src/cli/shared/parse-port.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { parsePort } from "./parse-port";
+
+describe("parsePort", () => {
+  it("accepts valid numeric ports", () => {
+    expect(parsePort("3000")).toBe(3000);
+    expect(parsePort(" 443 ")).toBe(443);
+    expect(parsePort(8080)).toBe(8080);
+    expect(parsePort(65535n)).toBe(65535);
+  });
+
+  it("rejects invalid or out-of-range ports", () => {
+    expect(parsePort(undefined)).toBeNull();
+    expect(parsePort(null)).toBeNull();
+    expect(parsePort(0)).toBeNull();
+    expect(parsePort(-1)).toBeNull();
+    expect(parsePort("0")).toBeNull();
+    expect(parsePort("65536")).toBeNull();
+    expect(parsePort(65536)).toBeNull();
+    expect(parsePort("99999999999999999999")).toBeNull();
+  });
+
+  it("rejects non-integer and mixed-format inputs", () => {
+    expect(parsePort("3000abc")).toBeNull();
+    expect(parsePort("12.5")).toBeNull();
+    expect(parsePort(12.5)).toBeNull();
+    expect(parsePort("1e3")).toBeNull();
+    expect(parsePort("+80")).toBeNull();
+    expect(parsePort(" ")).toBeNull();
+    expect(parsePort("NaN")).toBeNull();
+    expect(parsePort(Number.NaN)).toBeNull();
+    expect(parsePort(Number.POSITIVE_INFINITY)).toBeNull();
+  });
+});

--- a/src/cli/shared/parse-port.ts
+++ b/src/cli/shared/parse-port.ts
@@ -1,19 +1,25 @@
+const MAX_PORT = 65535;
+
 export function parsePort(raw: unknown): number | null {
   if (raw === undefined || raw === null) {
     return null;
   }
+
   const value =
     typeof raw === "string"
-      ? raw
+      ? raw.trim()
       : typeof raw === "number" || typeof raw === "bigint"
         ? raw.toString()
         : null;
-  if (value === null) {
+
+  if (!value || !/^\d+$/.test(value)) {
     return null;
   }
-  const parsed = Number.parseInt(value, 10);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
+
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0 || parsed > MAX_PORT) {
     return null;
   }
+
   return parsed;
 }

--- a/src/cli/tagline.ts
+++ b/src/cli/tagline.ts
@@ -255,10 +255,13 @@ export function pickTagline(options: TaglineOptions = {}): string {
   const env = options.env ?? process.env;
   const override = env?.OPENCLAW_TAGLINE_INDEX;
   if (override !== undefined) {
-    const parsed = Number.parseInt(override, 10);
-    if (!Number.isNaN(parsed) && parsed >= 0) {
-      const pool = TAGLINES.length > 0 ? TAGLINES : [DEFAULT_TAGLINE];
-      return pool[parsed % pool.length];
+    const overrideStr = String(override).trim();
+    if (/^\d+$/.test(overrideStr)) {
+      const parsed = Number.parseInt(overrideStr, 10);
+      if (parsed >= 0) {
+        const pool = TAGLINES.length > 0 ? TAGLINES : [DEFAULT_TAGLINE];
+        return pool[parsed % pool.length];
+      }
     }
   }
   const pool = activeTaglines(options);

--- a/src/cli/tui-cli.ts
+++ b/src/cli/tui-cli.ts
@@ -30,7 +30,10 @@ export function registerTuiCli(program: Command) {
             `warning: invalid --timeout-ms "${String(opts.timeoutMs)}"; ignoring`,
           );
         }
-        const historyLimit = Number.parseInt(String(opts.historyLimit ?? "200"), 10);
+        const historyLimitStr = String(opts.historyLimit ?? "200").trim();
+        const historyLimit = /^\d+$/.test(historyLimitStr)
+          ? Number.parseInt(historyLimitStr, 10)
+          : NaN;
         await runTui({
           url: opts.url as string | undefined,
           token: opts.token as string | undefined,

--- a/src/cli/update-cli/status.ts
+++ b/src/cli/update-cli/status.ts
@@ -32,7 +32,9 @@ function formatGitStatusLine(params: {
 }
 
 export async function updateStatusCommand(opts: UpdateStatusOptions): Promise<void> {
-  const timeoutMs = opts.timeout ? Number.parseInt(opts.timeout, 10) * 1000 : undefined;
+  const timeoutStr = typeof opts.timeout === "string" ? opts.timeout.trim() : "";
+  const timeoutSec = timeoutStr && /^\d+$/.test(timeoutStr) ? Number.parseInt(timeoutStr, 10) : NaN;
+  const timeoutMs = Number.isFinite(timeoutSec) ? timeoutSec * 1000 : undefined;
   if (timeoutMs !== undefined && (Number.isNaN(timeoutMs) || timeoutMs <= 0)) {
     defaultRuntime.error("--timeout must be a positive integer (seconds)");
     defaultRuntime.exit(1);

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -458,11 +458,18 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
   suppressDeprecations();
 
   const timeoutStr = typeof opts.timeout === "string" ? opts.timeout.trim() : "";
-  const timeoutSec = timeoutStr && /^\d+$/.test(timeoutStr) ? Number.parseInt(timeoutStr, 10) : NaN;
+  const isValidTimeoutFormat = timeoutStr === "" || /^\d+$/.test(timeoutStr);
+  const timeoutSec = isValidTimeoutFormat && timeoutStr ? Number.parseInt(timeoutStr, 10) : NaN;
   const timeoutMs = Number.isFinite(timeoutSec) ? timeoutSec * 1000 : undefined;
   const shouldRestart = opts.restart !== false;
 
-  if (timeoutMs !== undefined && (Number.isNaN(timeoutMs) || timeoutMs <= 0)) {
+  if (timeoutStr && !isValidTimeoutFormat) {
+    defaultRuntime.error("--timeout must be a positive integer (seconds)");
+    defaultRuntime.exit(1);
+    return;
+  }
+
+  if (timeoutMs !== undefined && timeoutMs <= 0) {
     defaultRuntime.error("--timeout must be a positive integer (seconds)");
     defaultRuntime.exit(1);
     return;

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -457,7 +457,9 @@ async function maybeRestartService(params: {
 export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
   suppressDeprecations();
 
-  const timeoutMs = opts.timeout ? Number.parseInt(opts.timeout, 10) * 1000 : undefined;
+  const timeoutStr = typeof opts.timeout === "string" ? opts.timeout.trim() : "";
+  const timeoutSec = timeoutStr && /^\d+$/.test(timeoutStr) ? Number.parseInt(timeoutStr, 10) : NaN;
+  const timeoutMs = Number.isFinite(timeoutSec) ? timeoutSec * 1000 : undefined;
   const shouldRestart = opts.restart !== false;
 
   if (timeoutMs !== undefined && (Number.isNaN(timeoutMs) || timeoutMs <= 0)) {

--- a/src/cli/update-cli/wizard.ts
+++ b/src/cli/update-cli/wizard.ts
@@ -37,7 +37,9 @@ export async function updateWizardCommand(opts: UpdateWizardOptions = {}): Promi
     return;
   }
 
-  const timeoutMs = opts.timeout ? Number.parseInt(opts.timeout, 10) * 1000 : undefined;
+  const timeoutStr = typeof opts.timeout === "string" ? opts.timeout.trim() : "";
+  const timeoutSec = timeoutStr && /^\d+$/.test(timeoutStr) ? Number.parseInt(timeoutStr, 10) : NaN;
+  const timeoutMs = Number.isFinite(timeoutSec) ? timeoutSec * 1000 : undefined;
   if (timeoutMs !== undefined && (Number.isNaN(timeoutMs) || timeoutMs <= 0)) {
     defaultRuntime.error("--timeout must be a positive integer (seconds)");
     defaultRuntime.exit(1);

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -55,10 +55,17 @@ export type AgentCliOpts = {
 };
 
 function parseTimeoutSeconds(opts: { cfg: ReturnType<typeof loadConfig>; timeout?: string }) {
-  const raw =
-    opts.timeout !== undefined
-      ? Number.parseInt(String(opts.timeout), 10)
-      : (opts.cfg.agents?.defaults?.timeoutSeconds ?? 600);
+  let raw: number;
+  if (opts.timeout !== undefined) {
+    const s = String(opts.timeout).trim();
+    // Require full digit string (no mixed alphanumeric like "100abc", no decimals)
+    if (!/^\d+$/.test(s)) {
+      throw new Error("--timeout must be a non-negative integer (seconds; 0 means no timeout)");
+    }
+    raw = Number.parseInt(s, 10);
+  } else {
+    raw = opts.cfg.agents?.defaults?.timeoutSeconds ?? 600;
+  }
   if (Number.isNaN(raw) || raw < 0) {
     throw new Error("--timeout must be a non-negative integer (seconds; 0 means no timeout)");
   }

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -245,12 +245,17 @@ export async function agentCommand(
 
   const laneRaw = typeof opts.lane === "string" ? opts.lane.trim() : "";
   const isSubagentLane = laneRaw === String(AGENT_LANE_SUBAGENT);
-  const timeoutSecondsRaw =
-    opts.timeout !== undefined
-      ? Number.parseInt(String(opts.timeout), 10)
-      : isSubagentLane
-        ? 0
-        : undefined;
+  let timeoutSecondsRaw: number | undefined;
+  if (opts.timeout !== undefined) {
+    const s = String(opts.timeout).trim();
+    // Require full digit string (no mixed alphanumeric like "100abc", no decimals)
+    if (!/^\d+$/.test(s)) {
+      throw new Error("--timeout must be a non-negative integer (seconds; 0 means no timeout)");
+    }
+    timeoutSecondsRaw = Number.parseInt(s, 10);
+  } else {
+    timeoutSecondsRaw = isSubagentLane ? 0 : undefined;
+  }
   if (
     timeoutSecondsRaw !== undefined &&
     (Number.isNaN(timeoutSecondsRaw) || timeoutSecondsRaw < 0)

--- a/src/commands/channels.status-command.test.ts
+++ b/src/commands/channels.status-command.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestRuntime } from "./test-runtime-config-helpers.js";
+
+const mocks = vi.hoisted(() => ({
+  callGateway: vi.fn().mockResolvedValue({ channelAccounts: {} }),
+}));
+
+vi.mock("../gateway/call.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../gateway/call.js")>();
+  return { ...actual, callGateway: mocks.callGateway };
+});
+
+import { channelsStatusCommand } from "./channels/status.js";
+
+const runtime = createTestRuntime();
+
+describe("channelsStatusCommand", () => {
+  beforeEach(() => {
+    mocks.callGateway.mockClear();
+    runtime.log.mockClear();
+    runtime.error.mockClear();
+    runtime.exit.mockClear();
+  });
+
+  it("uses strict timeout parsing and falls back to defaults for invalid values", async () => {
+    await channelsStatusCommand({ json: true, timeout: "1e3" }, runtime as never);
+
+    const req = mocks.callGateway.mock.calls[0]?.[0] as {
+      timeoutMs?: number;
+      params?: { timeoutMs?: number };
+    };
+    expect(req.timeoutMs).toBe(10_000);
+    expect(req.params?.timeoutMs).toBe(10_000);
+  });
+
+  it("uses default timeout for negative values", async () => {
+    await channelsStatusCommand({ json: true, timeout: "-50" }, runtime as never);
+
+    const req = mocks.callGateway.mock.calls[0]?.[0] as {
+      timeoutMs?: number;
+      params?: { timeoutMs?: number };
+    };
+    expect(req.timeoutMs).toBe(10_000);
+    expect(req.params?.timeoutMs).toBe(10_000);
+  });
+
+  it("accepts valid integer timeout values", async () => {
+    await channelsStatusCommand({ json: true, timeout: "2500" }, runtime as never);
+
+    const req = mocks.callGateway.mock.calls[0]?.[0] as {
+      timeoutMs?: number;
+      params?: { timeoutMs?: number };
+    };
+    expect(req.timeoutMs).toBe(2500);
+    expect(req.params?.timeoutMs).toBe(2500);
+  });
+});

--- a/src/commands/channels/add.ts
+++ b/src/commands/channels/add.ts
@@ -155,12 +155,23 @@ export async function channelsAddCommand(
     plugin.setup.resolveAccountId?.({ cfg: nextConfig, accountId: opts.account }) ??
     normalizeAccountId(opts.account);
   const useEnv = opts.useEnv === true;
-  const initialSyncLimit =
-    typeof opts.initialSyncLimit === "number"
-      ? opts.initialSyncLimit
-      : typeof opts.initialSyncLimit === "string" && opts.initialSyncLimit.trim()
-        ? Number.parseInt(opts.initialSyncLimit, 10)
+  const initialSyncLimitRaw = opts.initialSyncLimit;
+  let initialSyncLimit: number | undefined;
+  if (typeof initialSyncLimitRaw === "number") {
+    initialSyncLimit =
+      Number.isFinite(initialSyncLimitRaw) && initialSyncLimitRaw > 0
+        ? Math.floor(initialSyncLimitRaw)
         : undefined;
+  } else if (typeof initialSyncLimitRaw === "string" && initialSyncLimitRaw.trim()) {
+    const trimmed = initialSyncLimitRaw.trim();
+    // Require full digit string (no mixed alphanumeric like "100abc", no decimals)
+    if (/^\d+$/.test(trimmed)) {
+      const parsed = Number.parseInt(trimmed, 10);
+      if (Number.isFinite(parsed) && parsed > 0) {
+        initialSyncLimit = parsed;
+      }
+    }
+  }
   const groupChannels = parseList(opts.groupChannels);
   const dmAllowlist = parseList(opts.dmAllowlist);
 

--- a/src/commands/channels/capabilities.e2e.test.ts
+++ b/src/commands/channels/capabilities.e2e.test.ts
@@ -131,4 +131,38 @@ describe("channelsCapabilitiesCommand", () => {
     expect(output).toContain("ChannelMessage.Read.All (channel history)");
     expect(output).toContain("Files.Read.All (files (OneDrive))");
   });
+
+  it("falls back to default timeout when timeout is not a strict integer", async () => {
+    const plugin = buildPlugin({
+      id: "slack",
+      account: {
+        accountId: "default",
+        botToken: "xoxb-bot",
+      },
+    });
+    vi.mocked(listChannelPlugins).mockReturnValue([plugin]);
+    vi.mocked(getChannelPlugin).mockReturnValue(plugin);
+    vi.mocked(fetchSlackScopes).mockResolvedValue({ ok: true, scopes: ["chat:write"] });
+
+    await channelsCapabilitiesCommand({ channel: "slack", timeout: "1e3" }, runtime);
+
+    expect(fetchSlackScopes).toHaveBeenCalledWith("xoxb-bot", 10_000);
+  });
+
+  it("uses explicit integer timeout values", async () => {
+    const plugin = buildPlugin({
+      id: "slack",
+      account: {
+        accountId: "default",
+        botToken: "xoxb-bot",
+      },
+    });
+    vi.mocked(listChannelPlugins).mockReturnValue([plugin]);
+    vi.mocked(getChannelPlugin).mockReturnValue(plugin);
+    vi.mocked(fetchSlackScopes).mockResolvedValue({ ok: true, scopes: ["chat:write"] });
+
+    await channelsCapabilitiesCommand({ channel: "slack", timeout: "2500" }, runtime);
+
+    expect(fetchSlackScopes).toHaveBeenCalledWith("xoxb-bot", 2500);
+  });
 });

--- a/src/commands/channels/capabilities.ts
+++ b/src/commands/channels/capabilities.ts
@@ -2,6 +2,7 @@ import type { ChannelCapabilities, ChannelPlugin } from "../../channels/plugins/
 import type { OpenClawConfig } from "../../config/config.js";
 import { resolveChannelDefaultAccountId } from "../../channels/plugins/helpers.js";
 import { getChannelPlugin, listChannelPlugins } from "../../channels/plugins/index.js";
+import { parseTimeoutMs } from "../../cli/parse-timeout.js";
 import { fetchChannelPermissionsDiscord } from "../../discord/send.js";
 import { parseDiscordTarget } from "../../discord/targets.js";
 import { danger } from "../../globals.js";
@@ -66,8 +67,8 @@ const TEAMS_GRAPH_PERMISSION_HINTS: Record<string, string> = {
 };
 
 function normalizeTimeout(raw: unknown, fallback = 10_000) {
-  const value = typeof raw === "string" ? Number(raw) : Number(raw);
-  if (!Number.isFinite(value) || value <= 0) {
+  const value = parseTimeoutMs(raw);
+  if (value === undefined || value <= 0) {
     return fallback;
   }
   return value;

--- a/src/commands/channels/logs.ts
+++ b/src/commands/channels/logs.ts
@@ -16,6 +16,20 @@ type LogLine = ReturnType<typeof parseLogLine>;
 const DEFAULT_LIMIT = 200;
 const MAX_BYTES = 1_000_000;
 
+/** Parse a positive integer string. Returns undefined for invalid input. */
+function parsePositiveInt(value: string): number | undefined {
+  const trimmed = value.trim();
+  // Require full digit string (no mixed alphanumeric like "100abc", no decimals)
+  if (!/^\d+$/.test(trimmed)) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(trimmed, 10);
+  if (Number.isNaN(parsed) || parsed <= 0) {
+    return undefined;
+  }
+  return parsed;
+}
+
 const getChannelSet = () =>
   new Set<string>([...listChannelPlugins().map((plugin) => plugin.id), "all"]);
 
@@ -78,7 +92,7 @@ export async function channelsLogsCommand(
   runtime: RuntimeEnv = defaultRuntime,
 ) {
   const channel = parseChannelFilter(opts.channel);
-  const limitRaw = typeof opts.lines === "string" ? Number(opts.lines) : opts.lines;
+  const limitRaw = typeof opts.lines === "string" ? parsePositiveInt(opts.lines) : opts.lines;
   const limit =
     typeof limitRaw === "number" && Number.isFinite(limitRaw) && limitRaw > 0
       ? Math.floor(limitRaw)

--- a/src/commands/channels/status.ts
+++ b/src/commands/channels/status.ts
@@ -2,6 +2,7 @@ import type { ChannelAccountSnapshot } from "../../channels/plugins/types.js";
 import { listChannelPlugins } from "../../channels/plugins/index.js";
 import { buildChannelAccountSnapshot } from "../../channels/plugins/status.js";
 import { formatCliCommand } from "../../cli/command-format.js";
+import { parseTimeoutMs } from "../../cli/parse-timeout.js";
 import { withProgress } from "../../cli/progress.js";
 import { type OpenClawConfig, readConfigFileSnapshot } from "../../config/config.js";
 import { callGateway } from "../../gateway/call.js";
@@ -241,7 +242,8 @@ export async function channelsStatusCommand(
   opts: ChannelsStatusOptions,
   runtime: RuntimeEnv = defaultRuntime,
 ) {
-  const timeoutMs = Number(opts.timeout ?? 10_000);
+  const timeoutMsRaw = parseTimeoutMs(opts.timeout);
+  const timeoutMs = timeoutMsRaw !== undefined && timeoutMsRaw >= 0 ? timeoutMsRaw : 10_000;
   const statusLabel = opts.probe ? "Checking channel status (probe)…" : "Checking channel status…";
   const shouldLogStatus = opts.json !== true && !process.stderr.isTTY;
   if (shouldLogStatus) {

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -25,6 +25,7 @@ import {
   resolveModelRefFromString,
 } from "../../agents/model-selection.js";
 import { formatCliCommand } from "../../cli/command-format.js";
+import { parseTimeoutMs } from "../../cli/parse-timeout.js";
 import { withProgressTotals } from "../../cli/progress.js";
 import { CONFIG_PATH, loadConfig } from "../../config/config.js";
 import {
@@ -205,16 +206,16 @@ export async function modelsStatusCommand(
       .map((value) => value.trim())
       .filter(Boolean);
   })();
-  const probeTimeoutMs = opts.probeTimeout ? Number(opts.probeTimeout) : 8000;
-  if (!Number.isFinite(probeTimeoutMs) || probeTimeoutMs <= 0) {
+  const probeTimeoutMs = opts.probeTimeout ? parseTimeoutMs(opts.probeTimeout) : 8000;
+  if (probeTimeoutMs === undefined || probeTimeoutMs <= 0) {
     throw new Error("--probe-timeout must be a positive number (ms).");
   }
-  const probeConcurrency = opts.probeConcurrency ? Number(opts.probeConcurrency) : 2;
-  if (!Number.isFinite(probeConcurrency) || probeConcurrency <= 0) {
+  const probeConcurrency = opts.probeConcurrency ? parseTimeoutMs(opts.probeConcurrency) : 2;
+  if (probeConcurrency === undefined || probeConcurrency <= 0) {
     throw new Error("--probe-concurrency must be > 0.");
   }
-  const probeMaxTokens = opts.probeMaxTokens ? Number(opts.probeMaxTokens) : 8;
-  if (!Number.isFinite(probeMaxTokens) || probeMaxTokens <= 0) {
+  const probeMaxTokens = opts.probeMaxTokens ? parseTimeoutMs(opts.probeMaxTokens) : 8;
+  if (probeMaxTokens === undefined || probeMaxTokens <= 0) {
     throw new Error("--probe-max-tokens must be > 0.");
   }
 

--- a/src/commands/models/scan.ts
+++ b/src/commands/models/scan.ts
@@ -2,6 +2,7 @@ import { cancel, multiselect as clackMultiselect, isCancel } from "@clack/prompt
 import type { RuntimeEnv } from "../../runtime.js";
 import { resolveApiKeyForProvider } from "../../agents/model-auth.js";
 import { type ModelScanResult, scanOpenRouterModels } from "../../agents/model-scan.js";
+import { parseTimeoutMs } from "../../cli/parse-timeout.js";
 import { withProgressTotals } from "../../cli/progress.js";
 import { loadConfig } from "../../config/config.js";
 import { logConfigUpdated } from "../../config/logging.js";
@@ -14,6 +15,20 @@ import { formatMs, formatTokenK, updateConfig } from "./shared.js";
 
 const MODEL_PAD = 42;
 const CTX_PAD = 8;
+
+/** Parse a non-negative integer string (0, 1, 2, ...). Returns undefined for invalid input. */
+function parseNonNegativeInt(value: string): number | undefined {
+  const trimmed = value.trim();
+  // Require full digit string (no mixed alphanumeric like "100abc", no decimals, no scientific)
+  if (!/^\d+$/.test(trimmed)) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(trimmed, 10);
+  if (Number.isNaN(parsed) || parsed < 0) {
+    return undefined;
+  }
+  return parsed;
+}
 
 const multiselect = <T>(params: Parameters<typeof clackMultiselect<T>>[0]) =>
   clackMultiselect({
@@ -147,24 +162,24 @@ export async function modelsScanCommand(
   },
   runtime: RuntimeEnv,
 ) {
-  const minParams = opts.minParams ? Number(opts.minParams) : undefined;
-  if (minParams !== undefined && (!Number.isFinite(minParams) || minParams < 0)) {
+  const minParams = opts.minParams ? parseNonNegativeInt(opts.minParams) : undefined;
+  if (minParams !== undefined && minParams < 0) {
     throw new Error("--min-params must be >= 0");
   }
-  const maxAgeDays = opts.maxAgeDays ? Number(opts.maxAgeDays) : undefined;
-  if (maxAgeDays !== undefined && (!Number.isFinite(maxAgeDays) || maxAgeDays < 0)) {
+  const maxAgeDays = opts.maxAgeDays ? parseNonNegativeInt(opts.maxAgeDays) : undefined;
+  if (maxAgeDays !== undefined && maxAgeDays < 0) {
     throw new Error("--max-age-days must be >= 0");
   }
-  const maxCandidates = opts.maxCandidates ? Number(opts.maxCandidates) : 6;
-  if (!Number.isFinite(maxCandidates) || maxCandidates <= 0) {
+  const maxCandidates = opts.maxCandidates ? parseNonNegativeInt(opts.maxCandidates) : 6;
+  if (maxCandidates === undefined || maxCandidates <= 0) {
     throw new Error("--max-candidates must be > 0");
   }
-  const timeout = opts.timeout ? Number(opts.timeout) : undefined;
-  if (timeout !== undefined && (!Number.isFinite(timeout) || timeout <= 0)) {
+  const timeout = opts.timeout ? parseTimeoutMs(opts.timeout) : undefined;
+  if (timeout !== undefined && timeout <= 0) {
     throw new Error("--timeout must be > 0");
   }
-  const concurrency = opts.concurrency ? Number(opts.concurrency) : undefined;
-  if (concurrency !== undefined && (!Number.isFinite(concurrency) || concurrency <= 0)) {
+  const concurrency = opts.concurrency ? parseTimeoutMs(opts.concurrency) : undefined;
+  if (concurrency !== undefined && concurrency <= 0) {
     throw new Error("--concurrency must be > 0");
   }
 

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -179,7 +179,14 @@ export async function sessionsCommand(
 
   let activeMinutes: number | undefined;
   if (opts.active !== undefined) {
-    const parsed = Number.parseInt(String(opts.active), 10);
+    const s = String(opts.active).trim();
+    // Require full digit string (no mixed alphanumeric like "100abc", no decimals)
+    if (!/^\d+$/.test(s)) {
+      runtime.error("--active must be a positive integer (minutes)");
+      runtime.exit(1);
+      return;
+    }
+    const parsed = Number.parseInt(s, 10);
     if (Number.isNaN(parsed) || parsed <= 0) {
       runtime.error("--active must be a positive integer (minutes)");
       runtime.exit(1);

--- a/src/gateway/server-runtime-config.test.ts
+++ b/src/gateway/server-runtime-config.test.ts
@@ -1,7 +1,30 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { resolveGatewayRuntimeConfig } from "./server-runtime-config.js";
 
 describe("resolveGatewayRuntimeConfig", () => {
+  let savedToken: string | undefined;
+  let savedPassword: string | undefined;
+
+  beforeEach(() => {
+    savedToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+    savedPassword = process.env.OPENCLAW_GATEWAY_PASSWORD;
+    delete process.env.OPENCLAW_GATEWAY_TOKEN;
+    delete process.env.OPENCLAW_GATEWAY_PASSWORD;
+  });
+
+  afterEach(() => {
+    if (savedToken !== undefined) {
+      process.env.OPENCLAW_GATEWAY_TOKEN = savedToken;
+    } else {
+      delete process.env.OPENCLAW_GATEWAY_TOKEN;
+    }
+    if (savedPassword !== undefined) {
+      process.env.OPENCLAW_GATEWAY_PASSWORD = savedPassword;
+    } else {
+      delete process.env.OPENCLAW_GATEWAY_PASSWORD;
+    }
+  });
+
   describe("trusted-proxy auth mode", () => {
     // This test validates BOTH validation layers:
     // 1. CLI validation in src/cli/gateway-cli/run.ts (line 246)

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -48,6 +48,7 @@ export function getAgentRunContext(runId: string) {
 
 export function clearAgentRunContext(runId: string) {
   runContextById.delete(runId);
+  seqByRun.delete(runId);
 }
 
 export function resetAgentRunContextForTest() {

--- a/src/infra/backoff.test.ts
+++ b/src/infra/backoff.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { computeBackoff } from "./backoff.js";
+
+describe("computeBackoff", () => {
+  const policy = { initialMs: 100, maxMs: 5000, factor: 2, jitter: 0 };
+
+  it("returns initialMs on first attempt", () => {
+    expect(computeBackoff(policy, 1)).toBe(100);
+  });
+
+  it("doubles with factor 2", () => {
+    expect(computeBackoff(policy, 2)).toBe(200);
+    expect(computeBackoff(policy, 3)).toBe(400);
+  });
+
+  it("caps at maxMs", () => {
+    expect(computeBackoff(policy, 100)).toBe(5000);
+  });
+
+  it("handles attempt 0 same as 1", () => {
+    expect(computeBackoff(policy, 0)).toBe(100);
+  });
+
+  it("adds jitter when configured", () => {
+    const jitterPolicy = { initialMs: 100, maxMs: 10000, factor: 2, jitter: 0.5 };
+    const results = new Set<number>();
+    for (let i = 0; i < 20; i++) {
+      results.add(computeBackoff(jitterPolicy, 2));
+    }
+    // With jitter, we should get varying results (statistically very likely)
+    // Base is 200, jitter adds 0-100, so range is 200-300
+    for (const r of results) {
+      expect(r).toBeGreaterThanOrEqual(200);
+      expect(r).toBeLessThanOrEqual(300);
+    }
+  });
+});

--- a/src/infra/dedupe.test.ts
+++ b/src/infra/dedupe.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { createDedupeCache } from "./dedupe.js";
+import { pruneMapToMaxSize } from "./map-size.js";
+
+describe("pruneMapToMaxSize", () => {
+  it("removes oldest entries when over limit", () => {
+    const map = new Map([
+      ["a", 1],
+      ["b", 2],
+      ["c", 3],
+    ]);
+    pruneMapToMaxSize(map, 2);
+    expect(map.size).toBe(2);
+    expect(map.has("a")).toBe(false);
+    expect(map.has("c")).toBe(true);
+  });
+
+  it("clears map when maxSize is 0", () => {
+    const map = new Map([["a", 1]]);
+    pruneMapToMaxSize(map, 0);
+    expect(map.size).toBe(0);
+  });
+
+  it("does nothing when under limit", () => {
+    const map = new Map([["a", 1]]);
+    pruneMapToMaxSize(map, 5);
+    expect(map.size).toBe(1);
+  });
+});
+
+describe("createDedupeCache", () => {
+  it("returns false on first check, true on duplicate", () => {
+    const cache = createDedupeCache({ ttlMs: 10_000, maxSize: 100 });
+    expect(cache.check("key1", 1000)).toBe(false);
+    expect(cache.check("key1", 1001)).toBe(true);
+  });
+
+  it("returns false for null/undefined keys", () => {
+    const cache = createDedupeCache({ ttlMs: 10_000, maxSize: 100 });
+    expect(cache.check(null)).toBe(false);
+    expect(cache.check(undefined)).toBe(false);
+  });
+
+  it("expires entries after TTL", () => {
+    const cache = createDedupeCache({ ttlMs: 100, maxSize: 100 });
+    expect(cache.check("key1", 1000)).toBe(false);
+    expect(cache.check("key1", 1050)).toBe(true); // within TTL
+    expect(cache.check("key1", 1200)).toBe(false); // expired
+  });
+
+  it("respects maxSize", () => {
+    const cache = createDedupeCache({ ttlMs: 10_000, maxSize: 2 });
+    cache.check("a", 1000);
+    cache.check("b", 1001);
+    cache.check("c", 1002); // should evict "a"
+    expect(cache.size()).toBeLessThanOrEqual(2);
+  });
+
+  it("clear resets the cache", () => {
+    const cache = createDedupeCache({ ttlMs: 10_000, maxSize: 100 });
+    cache.check("key1", 1000);
+    cache.clear();
+    expect(cache.size()).toBe(0);
+    expect(cache.check("key1", 1001)).toBe(false);
+  });
+});

--- a/src/infra/diagnostic-flags.test.ts
+++ b/src/infra/diagnostic-flags.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import {
+  isDiagnosticFlagEnabled,
+  matchesDiagnosticFlag,
+  resolveDiagnosticFlags,
+} from "./diagnostic-flags.js";
+
+describe("resolveDiagnosticFlags", () => {
+  it("returns empty for no config or env", () => {
+    expect(resolveDiagnosticFlags(undefined, {})).toEqual([]);
+  });
+
+  it("parses env flags", () => {
+    expect(resolveDiagnosticFlags(undefined, { OPENCLAW_DIAGNOSTICS: "foo,bar" })).toEqual([
+      "foo",
+      "bar",
+    ]);
+  });
+
+  it("treats 'true' as wildcard", () => {
+    expect(resolveDiagnosticFlags(undefined, { OPENCLAW_DIAGNOSTICS: "true" })).toEqual(["*"]);
+  });
+
+  it("treats 'false' as disabled", () => {
+    expect(resolveDiagnosticFlags(undefined, { OPENCLAW_DIAGNOSTICS: "false" })).toEqual([]);
+  });
+
+  it("deduplicates flags", () => {
+    expect(resolveDiagnosticFlags(undefined, { OPENCLAW_DIAGNOSTICS: "foo,foo,bar" })).toEqual([
+      "foo",
+      "bar",
+    ]);
+  });
+});
+
+describe("matchesDiagnosticFlag", () => {
+  it("matches exact flag", () => {
+    expect(matchesDiagnosticFlag("debug", ["debug"])).toBe(true);
+  });
+
+  it("matches wildcard *", () => {
+    expect(matchesDiagnosticFlag("anything", ["*"])).toBe(true);
+  });
+
+  it("matches 'all' as wildcard", () => {
+    expect(matchesDiagnosticFlag("anything", ["all"])).toBe(true);
+  });
+
+  it("matches prefix wildcard", () => {
+    expect(matchesDiagnosticFlag("provider.openai", ["provider*"])).toBe(true);
+    expect(matchesDiagnosticFlag("other", ["provider*"])).toBe(false);
+  });
+
+  it("matches dot-star wildcard", () => {
+    expect(matchesDiagnosticFlag("provider.openai", ["provider.*"])).toBe(true);
+    expect(matchesDiagnosticFlag("provider", ["provider.*"])).toBe(true);
+    expect(matchesDiagnosticFlag("providers", ["provider.*"])).toBe(false);
+  });
+
+  it("returns false for empty flag", () => {
+    expect(matchesDiagnosticFlag("", ["debug"])).toBe(false);
+  });
+
+  it("case insensitive", () => {
+    expect(matchesDiagnosticFlag("DEBUG", ["debug"])).toBe(true);
+  });
+});
+
+describe("isDiagnosticFlagEnabled", () => {
+  it("integrates config and env", () => {
+    expect(isDiagnosticFlagEnabled("test", undefined, { OPENCLAW_DIAGNOSTICS: "test" })).toBe(true);
+    expect(isDiagnosticFlagEnabled("other", undefined, { OPENCLAW_DIAGNOSTICS: "test" })).toBe(
+      false,
+    );
+  });
+});

--- a/src/infra/errors.test.ts
+++ b/src/infra/errors.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { extractErrorCode, formatErrorMessage, hasErrnoCode, isErrno } from "./errors.js";
+
+describe("extractErrorCode", () => {
+  it("extracts string code", () => {
+    expect(extractErrorCode({ code: "ENOENT" })).toBe("ENOENT");
+  });
+
+  it("converts numeric code to string", () => {
+    expect(extractErrorCode({ code: 404 })).toBe("404");
+  });
+
+  it("returns undefined for missing/null/non-object", () => {
+    expect(extractErrorCode(null)).toBeUndefined();
+    expect(extractErrorCode(undefined)).toBeUndefined();
+    expect(extractErrorCode("string")).toBeUndefined();
+    expect(extractErrorCode({})).toBeUndefined();
+  });
+});
+
+describe("isErrno", () => {
+  it("returns true for objects with code", () => {
+    expect(isErrno({ code: "ENOENT" })).toBe(true);
+  });
+
+  it("returns false for non-objects", () => {
+    expect(isErrno(null)).toBe(false);
+    expect(isErrno("err")).toBe(false);
+  });
+});
+
+describe("hasErrnoCode", () => {
+  it("matches specific code", () => {
+    expect(hasErrnoCode({ code: "ENOENT" }, "ENOENT")).toBe(true);
+    expect(hasErrnoCode({ code: "ENOENT" }, "EPERM")).toBe(false);
+  });
+});
+
+describe("formatErrorMessage", () => {
+  it("formats Error instances", () => {
+    expect(formatErrorMessage(new Error("test"))).toBe("test");
+  });
+
+  it("formats strings", () => {
+    expect(formatErrorMessage("oops")).toBe("oops");
+  });
+
+  it("formats numbers", () => {
+    expect(formatErrorMessage(42)).toBe("42");
+  });
+
+  it("formats objects as JSON", () => {
+    const result = formatErrorMessage({ key: "val" });
+    expect(result).toContain("key");
+  });
+});

--- a/src/logging/levels.test.ts
+++ b/src/logging/levels.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { levelToMinLevel, normalizeLogLevel } from "./levels.js";
+
+describe("normalizeLogLevel", () => {
+  it("returns valid levels unchanged", () => {
+    expect(normalizeLogLevel("debug")).toBe("debug");
+    expect(normalizeLogLevel("error")).toBe("error");
+    expect(normalizeLogLevel("silent")).toBe("silent");
+  });
+
+  it("falls back for invalid levels", () => {
+    expect(normalizeLogLevel("invalid")).toBe("info");
+    expect(normalizeLogLevel("invalid", "warn")).toBe("warn");
+  });
+
+  it("falls back for undefined", () => {
+    expect(normalizeLogLevel(undefined)).toBe("info");
+  });
+
+  it("trims whitespace", () => {
+    expect(normalizeLogLevel("  debug  ")).toBe("debug");
+  });
+});
+
+describe("levelToMinLevel", () => {
+  it("returns numeric ordering", () => {
+    expect(levelToMinLevel("fatal")).toBe(0);
+    expect(levelToMinLevel("error")).toBe(1);
+    expect(levelToMinLevel("warn")).toBe(2);
+    expect(levelToMinLevel("info")).toBe(3);
+    expect(levelToMinLevel("debug")).toBe(4);
+    expect(levelToMinLevel("trace")).toBe(5);
+    expect(levelToMinLevel("silent")).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it("maintains ordering: fatal < error < warn < info < debug < trace", () => {
+    expect(levelToMinLevel("fatal")).toBeLessThan(levelToMinLevel("error"));
+    expect(levelToMinLevel("error")).toBeLessThan(levelToMinLevel("warn"));
+    expect(levelToMinLevel("warn")).toBeLessThan(levelToMinLevel("info"));
+    expect(levelToMinLevel("info")).toBeLessThan(levelToMinLevel("debug"));
+    expect(levelToMinLevel("debug")).toBeLessThan(levelToMinLevel("trace"));
+    expect(levelToMinLevel("trace")).toBeLessThan(levelToMinLevel("silent"));
+  });
+});

--- a/src/logging/redact-identifier.test.ts
+++ b/src/logging/redact-identifier.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { redactIdentifier, sha256HexPrefix } from "./redact-identifier.js";
+
+describe("sha256HexPrefix", () => {
+  it("returns deterministic hex prefix", () => {
+    const a = sha256HexPrefix("test");
+    const b = sha256HexPrefix("test");
+    expect(a).toBe(b);
+    expect(a).toHaveLength(12);
+    expect(a).toMatch(/^[0-9a-f]+$/);
+  });
+
+  it("respects custom length", () => {
+    expect(sha256HexPrefix("test", 6)).toHaveLength(6);
+    expect(sha256HexPrefix("test", 32)).toHaveLength(32);
+  });
+
+  it("clamps length to minimum 1", () => {
+    expect(sha256HexPrefix("test", 0)).toHaveLength(1);
+    expect(sha256HexPrefix("test", -5)).toHaveLength(1);
+  });
+
+  it("different inputs give different outputs", () => {
+    expect(sha256HexPrefix("hello")).not.toBe(sha256HexPrefix("world"));
+  });
+});
+
+describe("redactIdentifier", () => {
+  it("returns sha256 prefix for non-empty input", () => {
+    const result = redactIdentifier("user@example.com");
+    expect(result).toMatch(/^sha256:[0-9a-f]{12}$/);
+  });
+
+  it("returns dash for empty/undefined input", () => {
+    expect(redactIdentifier(undefined)).toBe("-");
+    expect(redactIdentifier("")).toBe("-");
+    expect(redactIdentifier("  ")).toBe("-");
+  });
+
+  it("is deterministic", () => {
+    expect(redactIdentifier("test")).toBe(redactIdentifier("test"));
+  });
+
+  it("accepts custom length", () => {
+    const result = redactIdentifier("test", { len: 8 });
+    expect(result).toMatch(/^sha256:[0-9a-f]{8}$/);
+  });
+});

--- a/src/markdown/code-spans.test.ts
+++ b/src/markdown/code-spans.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { buildCodeSpanIndex, createInlineCodeState } from "./code-spans.js";
+
+describe("buildCodeSpanIndex", () => {
+  it("detects inline code spans", () => {
+    const text = "before `code` after";
+    const index = buildCodeSpanIndex(text);
+    // inside backticks
+    expect(index.isInside(8)).toBe(true); // 'c' of code
+    // outside backticks
+    expect(index.isInside(0)).toBe(false);
+    expect(index.isInside(14)).toBe(false);
+  });
+
+  it("detects fenced code blocks", () => {
+    const text = "text\n```\ncode\n```\nafter";
+    const index = buildCodeSpanIndex(text);
+    expect(index.isInside(9)).toBe(true); // inside fence
+    expect(index.isInside(0)).toBe(false); // before fence
+  });
+
+  it("handles double backtick inline code", () => {
+    const text = "say ``hello ` world`` done";
+    const index = buildCodeSpanIndex(text);
+    expect(index.isInside(6)).toBe(true); // inside ``...``
+    expect(index.isInside(22)).toBe(false); // after
+  });
+
+  it("handles empty input", () => {
+    const index = buildCodeSpanIndex("");
+    expect(index.isInside(0)).toBe(false);
+  });
+
+  it("tracks state across calls for streaming", () => {
+    const state = createInlineCodeState();
+    const first = buildCodeSpanIndex("`hello", state);
+    // unclosed backtick — entire rest is "inside"
+    expect(first.isInside(1)).toBe(true);
+    expect(first.inlineState.open).toBe(true);
+  });
+});

--- a/src/markdown/fences.test.ts
+++ b/src/markdown/fences.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { findFenceSpanAt, isSafeFenceBreak, parseFenceSpans } from "./fences.js";
+
+describe("parseFenceSpans", () => {
+  it("parses backtick fenced code block", () => {
+    const input = "before\n```js\ncode\n```\nafter";
+    const spans = parseFenceSpans(input);
+    expect(spans).toHaveLength(1);
+    expect(input.slice(spans[0].start, spans[0].end)).toBe("```js\ncode\n```");
+    expect(spans[0].marker).toBe("```");
+  });
+
+  it("parses tilde fenced code block", () => {
+    const input = "~~~\ncode\n~~~";
+    const spans = parseFenceSpans(input);
+    expect(spans).toHaveLength(1);
+  });
+
+  it("requires matching fence type", () => {
+    const input = "```\ncode\n~~~\n```";
+    const spans = parseFenceSpans(input);
+    expect(spans).toHaveLength(1);
+    // ~~~ is not a matching close for ```, so ``` closes it
+    expect(input.slice(spans[0].start, spans[0].end)).toBe("```\ncode\n~~~\n```");
+  });
+
+  it("handles unclosed fence as extending to end", () => {
+    const input = "```\ncode\nno close";
+    const spans = parseFenceSpans(input);
+    expect(spans).toHaveLength(1);
+    expect(spans[0].end).toBe(input.length);
+  });
+
+  it("parses multiple fenced blocks", () => {
+    const input = "```\na\n```\ntext\n```\nb\n```";
+    const spans = parseFenceSpans(input);
+    expect(spans).toHaveLength(2);
+  });
+
+  it("handles empty input", () => {
+    expect(parseFenceSpans("")).toEqual([]);
+  });
+
+  it("handles no fences", () => {
+    expect(parseFenceSpans("just plain text")).toEqual([]);
+  });
+
+  it("closing fence must have >= same marker length", () => {
+    const input = "````\ncode\n```\n````";
+    const spans = parseFenceSpans(input);
+    expect(spans).toHaveLength(1);
+    // ``` (3) < ```` (4), so doesn't close. ```` (4) >= ```` (4), closes.
+    expect(input.slice(spans[0].start, spans[0].end)).toBe("````\ncode\n```\n````");
+  });
+});
+
+describe("findFenceSpanAt", () => {
+  it("finds span containing index (exclusive of boundaries)", () => {
+    const input = "```\ncode\n```";
+    const spans = parseFenceSpans(input);
+    // index 0 is start, not inside (> start required)
+    expect(findFenceSpanAt(spans, 0)).toBeUndefined();
+    // index 4 is inside
+    expect(findFenceSpanAt(spans, 4)).toBeDefined();
+  });
+
+  it("returns undefined outside spans", () => {
+    const input = "text\n```\ncode\n```\ntext";
+    const spans = parseFenceSpans(input);
+    expect(findFenceSpanAt(spans, 0)).toBeUndefined();
+  });
+});
+
+describe("isSafeFenceBreak", () => {
+  it("returns true outside fences", () => {
+    const input = "text\n```\ncode\n```\nmore";
+    const spans = parseFenceSpans(input);
+    expect(isSafeFenceBreak(spans, 0)).toBe(true);
+  });
+
+  it("returns false inside fence", () => {
+    const input = "```\ncode\n```";
+    const spans = parseFenceSpans(input);
+    expect(isSafeFenceBreak(spans, 5)).toBe(false);
+  });
+});

--- a/src/media-understanding/runner.auto-audio.test.ts
+++ b/src/media-understanding/runner.auto-audio.test.ts
@@ -14,7 +14,9 @@ import {
 describe("runCapability auto audio entries", () => {
   it("uses provider keys to auto-enable audio transcription", async () => {
     const originalPath = process.env.PATH;
-    process.env.PATH = "/usr/bin:/bin";
+    // Use a PATH that excludes local whisper/sherpa-onnx/gemini so the
+    // provider-key auto-detection path is exercised instead of local CLI fallback.
+    process.env.PATH = "/nonexistent-path-for-test";
     const tmpPath = path.join(os.tmpdir(), `openclaw-auto-audio-${Date.now()}.wav`);
     await fs.writeFile(tmpPath, Buffer.from("RIFF"));
     const ctx: MsgContext = { MediaPath: tmpPath, MediaType: "audio/wav" };

--- a/src/media/base64.test.ts
+++ b/src/media/base64.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { estimateBase64DecodedBytes } from "./base64.js";
+
+describe("estimateBase64DecodedBytes", () => {
+  it("returns 0 for empty string", () => {
+    expect(estimateBase64DecodedBytes("")).toBe(0);
+  });
+
+  it("returns 0 for whitespace-only", () => {
+    expect(estimateBase64DecodedBytes("   \n\t  ")).toBe(0);
+  });
+
+  it("estimates correctly for unpadded base64", () => {
+    // "hello" = "aGVsbG8=" (8 chars, 1 padding) → 5 bytes
+    const encoded = Buffer.from("hello").toString("base64");
+    const estimated = estimateBase64DecodedBytes(encoded);
+    expect(estimated).toBe(5);
+  });
+
+  it("estimates correctly with double padding", () => {
+    // "hi" = "aGk=" (4 chars, 1 padding) → 2 bytes
+    const encoded = Buffer.from("hi").toString("base64");
+    expect(estimateBase64DecodedBytes(encoded)).toBe(2);
+  });
+
+  it("handles base64 with embedded whitespace", () => {
+    const encoded = Buffer.from("hello world").toString("base64");
+    const withSpaces = encoded.split("").join(" ");
+    const estimated = estimateBase64DecodedBytes(withSpaces);
+    // Should still give a reasonable estimate
+    expect(estimated).toBeGreaterThan(0);
+  });
+
+  it("handles large inputs efficiently", () => {
+    const large = "A".repeat(100_000);
+    const start = Date.now();
+    const result = estimateBase64DecodedBytes(large);
+    expect(Date.now() - start).toBeLessThan(100);
+    expect(result).toBeGreaterThan(0);
+  });
+});

--- a/src/media/constants.test.ts
+++ b/src/media/constants.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { maxBytesForKind, mediaKindFromMime } from "./constants.js";
+
+describe("mediaKindFromMime", () => {
+  it("classifies image types", () => {
+    expect(mediaKindFromMime("image/png")).toBe("image");
+    expect(mediaKindFromMime("image/jpeg")).toBe("image");
+  });
+
+  it("classifies audio types", () => {
+    expect(mediaKindFromMime("audio/mpeg")).toBe("audio");
+    expect(mediaKindFromMime("audio/ogg")).toBe("audio");
+  });
+
+  it("classifies video types", () => {
+    expect(mediaKindFromMime("video/mp4")).toBe("video");
+  });
+
+  it("classifies document types", () => {
+    expect(mediaKindFromMime("application/pdf")).toBe("document");
+    expect(mediaKindFromMime("text/plain")).toBe("document");
+    expect(mediaKindFromMime("application/json")).toBe("document");
+  });
+
+  it("returns unknown for null/undefined/empty", () => {
+    expect(mediaKindFromMime(null)).toBe("unknown");
+    expect(mediaKindFromMime(undefined)).toBe("unknown");
+    expect(mediaKindFromMime("")).toBe("unknown");
+  });
+
+  it("returns unknown for unrecognized mime", () => {
+    expect(mediaKindFromMime("font/woff2")).toBe("unknown");
+  });
+});
+
+describe("maxBytesForKind", () => {
+  it("returns correct limits for each kind", () => {
+    expect(maxBytesForKind("image")).toBe(6 * 1024 * 1024);
+    expect(maxBytesForKind("audio")).toBe(16 * 1024 * 1024);
+    expect(maxBytesForKind("video")).toBe(16 * 1024 * 1024);
+    expect(maxBytesForKind("document")).toBe(100 * 1024 * 1024);
+    expect(maxBytesForKind("unknown")).toBe(100 * 1024 * 1024);
+  });
+});

--- a/src/routing/session-key.ts
+++ b/src/routing/session-key.ts
@@ -93,23 +93,8 @@ export function normalizeAgentId(value: string | undefined | null): string {
   );
 }
 
-export function sanitizeAgentId(value: string | undefined | null): string {
-  const trimmed = (value ?? "").trim();
-  if (!trimmed) {
-    return DEFAULT_AGENT_ID;
-  }
-  if (VALID_ID_RE.test(trimmed)) {
-    return trimmed.toLowerCase();
-  }
-  return (
-    trimmed
-      .toLowerCase()
-      .replace(INVALID_CHARS_RE, "-")
-      .replace(LEADING_DASH_RE, "")
-      .replace(TRAILING_DASH_RE, "")
-      .slice(0, 64) || DEFAULT_AGENT_ID
-  );
-}
+/** Alias for {@link normalizeAgentId}. */
+export const sanitizeAgentId: (value: string | undefined | null) => string = normalizeAgentId;
 
 export function normalizeAccountId(value: string | undefined | null): string {
   const trimmed = (value ?? "").trim();

--- a/src/shared/device-auth.test.ts
+++ b/src/shared/device-auth.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { normalizeDeviceAuthRole, normalizeDeviceAuthScopes } from "./device-auth.js";
+
+describe("normalizeDeviceAuthRole", () => {
+  it("trims whitespace", () => {
+    expect(normalizeDeviceAuthRole("  admin  ")).toBe("admin");
+  });
+
+  it("returns empty for empty string", () => {
+    expect(normalizeDeviceAuthRole("")).toBe("");
+  });
+});
+
+describe("normalizeDeviceAuthScopes", () => {
+  it("returns empty array for undefined", () => {
+    expect(normalizeDeviceAuthScopes(undefined)).toEqual([]);
+  });
+
+  it("returns empty array for non-array", () => {
+    expect(normalizeDeviceAuthScopes("not-array" as unknown)).toEqual([]);
+  });
+
+  it("trims, deduplicates, and sorts", () => {
+    expect(normalizeDeviceAuthScopes(["  read ", "write", "read", ""])).toEqual(["read", "write"]);
+  });
+
+  it("filters empty strings", () => {
+    expect(normalizeDeviceAuthScopes(["", "  ", "admin"])).toEqual(["admin"]);
+  });
+});

--- a/src/shared/model-param-b.test.ts
+++ b/src/shared/model-param-b.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { inferParamBFromIdOrName } from "./model-param-b.js";
+
+describe("inferParamBFromIdOrName", () => {
+  it("extracts param B from model names", () => {
+    expect(inferParamBFromIdOrName("llama-70b")).toBe(70);
+    expect(inferParamBFromIdOrName("qwen2.5-7b-instruct")).toBe(7);
+    expect(inferParamBFromIdOrName("mistral-0.5b")).toBe(0.5);
+  });
+
+  it("picks largest when multiple matches", () => {
+    expect(inferParamBFromIdOrName("model-7b-fine-70b")).toBe(70);
+  });
+
+  it("returns null for no match", () => {
+    expect(inferParamBFromIdOrName("gpt-4o")).toBeNull();
+    expect(inferParamBFromIdOrName("claude-3")).toBeNull();
+    expect(inferParamBFromIdOrName("")).toBeNull();
+  });
+
+  it("handles decimal B values", () => {
+    expect(inferParamBFromIdOrName("phi-3.8b")).toBe(3.8);
+  });
+});

--- a/src/shared/net/ipv4.test.ts
+++ b/src/shared/net/ipv4.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { validateIPv4AddressInput } from "./ipv4.js";
+
+describe("validateIPv4AddressInput", () => {
+  it("returns undefined for valid addresses", () => {
+    expect(validateIPv4AddressInput("192.168.1.100")).toBeUndefined();
+    expect(validateIPv4AddressInput("0.0.0.0")).toBeUndefined();
+    expect(validateIPv4AddressInput("255.255.255.255")).toBeUndefined();
+    expect(validateIPv4AddressInput("10.0.0.1")).toBeUndefined();
+  });
+
+  it("trims whitespace", () => {
+    expect(validateIPv4AddressInput("  192.168.1.1  ")).toBeUndefined();
+  });
+
+  it("rejects empty/undefined input", () => {
+    expect(validateIPv4AddressInput(undefined)).toBeDefined();
+    expect(validateIPv4AddressInput("")).toBeDefined();
+  });
+
+  it("rejects wrong number of octets", () => {
+    expect(validateIPv4AddressInput("192.168.1")).toBeDefined();
+    expect(validateIPv4AddressInput("192.168.1.1.1")).toBeDefined();
+  });
+
+  it("rejects out-of-range octets", () => {
+    expect(validateIPv4AddressInput("256.0.0.1")).toBeDefined();
+    expect(validateIPv4AddressInput("0.0.0.999")).toBeDefined();
+  });
+
+  it("rejects leading zeros", () => {
+    expect(validateIPv4AddressInput("192.168.01.1")).toBeDefined();
+  });
+
+  it("rejects non-numeric octets", () => {
+    expect(validateIPv4AddressInput("abc.0.0.1")).toBeDefined();
+  });
+});

--- a/src/shared/subagents-format.test.ts
+++ b/src/shared/subagents-format.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatDurationCompact,
+  formatTokenShort,
+  formatTokenUsageDisplay,
+  resolveIoTokens,
+  resolveTotalTokens,
+  truncateLine,
+} from "./subagents-format.js";
+
+describe("formatDurationCompact", () => {
+  it("returns n/a for undefined/zero/negative", () => {
+    expect(formatDurationCompact(undefined)).toBe("n/a");
+    expect(formatDurationCompact(0)).toBe("n/a");
+    expect(formatDurationCompact(-1000)).toBe("n/a");
+    expect(formatDurationCompact(NaN)).toBe("n/a");
+    expect(formatDurationCompact(Infinity)).toBe("n/a");
+  });
+
+  it("formats minutes", () => {
+    expect(formatDurationCompact(30_000)).toBe("1m"); // rounds to min 1
+    expect(formatDurationCompact(60_000)).toBe("1m");
+    expect(formatDurationCompact(5 * 60_000)).toBe("5m");
+    expect(formatDurationCompact(59 * 60_000)).toBe("59m");
+  });
+
+  it("formats hours", () => {
+    expect(formatDurationCompact(60 * 60_000)).toBe("1h");
+    expect(formatDurationCompact(90 * 60_000)).toBe("1h30m");
+    expect(formatDurationCompact(23 * 60 * 60_000)).toBe("23h");
+  });
+
+  it("formats days", () => {
+    expect(formatDurationCompact(24 * 60 * 60_000)).toBe("1d");
+    expect(formatDurationCompact(25 * 60 * 60_000)).toBe("1d1h");
+    expect(formatDurationCompact(48 * 60 * 60_000)).toBe("2d");
+  });
+});
+
+describe("formatTokenShort", () => {
+  it("returns undefined for invalid values", () => {
+    expect(formatTokenShort(undefined)).toBeUndefined();
+    expect(formatTokenShort(0)).toBeUndefined();
+    expect(formatTokenShort(-5)).toBeUndefined();
+    expect(formatTokenShort(NaN)).toBeUndefined();
+  });
+
+  it("formats small numbers", () => {
+    expect(formatTokenShort(1)).toBe("1");
+    expect(formatTokenShort(999)).toBe("999");
+  });
+
+  it("formats thousands with decimal", () => {
+    expect(formatTokenShort(1500)).toBe("1.5k");
+    expect(formatTokenShort(9999)).toBe("10k");
+  });
+
+  it("formats large thousands", () => {
+    expect(formatTokenShort(10_000)).toBe("10k");
+    expect(formatTokenShort(500_000)).toBe("500k");
+  });
+
+  it("formats millions", () => {
+    expect(formatTokenShort(1_000_000)).toBe("1m");
+    expect(formatTokenShort(1_500_000)).toBe("1.5m");
+  });
+});
+
+describe("truncateLine", () => {
+  it("returns short strings unchanged", () => {
+    expect(truncateLine("hello", 10)).toBe("hello");
+  });
+
+  it("truncates with ellipsis", () => {
+    expect(truncateLine("hello world", 5)).toBe("hello...");
+  });
+
+  it("trims trailing whitespace before ellipsis", () => {
+    expect(truncateLine("hi   there", 4)).toBe("hi...");
+  });
+});
+
+describe("resolveTotalTokens", () => {
+  it("returns undefined for missing/invalid input", () => {
+    expect(resolveTotalTokens(undefined)).toBeUndefined();
+    expect(resolveTotalTokens(null as unknown)).toBeUndefined();
+  });
+
+  it("prefers totalTokens", () => {
+    expect(resolveTotalTokens({ totalTokens: 100 })).toBe(100);
+  });
+
+  it("sums input + output when totalTokens missing", () => {
+    expect(resolveTotalTokens({ inputTokens: 50, outputTokens: 30 })).toBe(80);
+  });
+
+  it("returns undefined when sum is 0", () => {
+    expect(resolveTotalTokens({ inputTokens: 0, outputTokens: 0 })).toBeUndefined();
+  });
+});
+
+describe("resolveIoTokens", () => {
+  it("returns undefined for missing input", () => {
+    expect(resolveIoTokens(undefined)).toBeUndefined();
+  });
+
+  it("returns structured tokens", () => {
+    expect(resolveIoTokens({ inputTokens: 100, outputTokens: 50 })).toEqual({
+      input: 100,
+      output: 50,
+      total: 150,
+    });
+  });
+
+  it("returns undefined when both are 0", () => {
+    expect(resolveIoTokens({ inputTokens: 0, outputTokens: 0 })).toBeUndefined();
+  });
+
+  it("handles non-finite values as 0", () => {
+    expect(resolveIoTokens({ inputTokens: NaN, outputTokens: 50 })).toEqual({
+      input: 0,
+      output: 50,
+      total: 50,
+    });
+  });
+});
+
+describe("formatTokenUsageDisplay", () => {
+  it("returns empty string for missing data", () => {
+    expect(formatTokenUsageDisplay(undefined)).toBe("");
+  });
+
+  it("formats io tokens", () => {
+    const result = formatTokenUsageDisplay({ inputTokens: 1000, outputTokens: 500 });
+    expect(result).toContain("tokens");
+    expect(result).toContain("in");
+    expect(result).toContain("out");
+  });
+});

--- a/src/shared/subagents-format.ts
+++ b/src/shared/subagents-format.ts
@@ -25,12 +25,12 @@ export function formatTokenShort(value?: number) {
     return `${n}`;
   }
   if (n < 10_000) {
-    return `${(n / 1_000).toFixed(1).replace(/\\.0$/, "")}k`;
+    return `${(n / 1_000).toFixed(1).replace(/\.0$/, "")}k`;
   }
   if (n < 1_000_000) {
     return `${Math.round(n / 1_000)}k`;
   }
-  return `${(n / 1_000_000).toFixed(1).replace(/\\.0$/, "")}m`;
+  return `${(n / 1_000_000).toFixed(1).replace(/\.0$/, "")}m`;
 }
 
 export function truncateLine(value: string, maxLength: number) {


### PR DESCRIPTION
Various fixes and improvements from community

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR systematically hardens numeric string parsing across the entire CLI surface and several command modules. The core change is replacing bare `Number.parseInt(value, 10)` calls — which silently accept inputs like `"100abc"`, `"12.5"`, and `"1e3"` — with regex-validated parsing that rejects non-integer strings before attempting conversion. This prevents subtle bugs where `parseInt("100abc")` returns `100` instead of failing.

- **Bugfix (regex):** Fixed double-escaped regex `/\\.0$/` → `/\.0$/` in `formatTokenShort` (`src/shared/subagents-format.ts`), which was never stripping trailing `.0` from formatted token counts.
- **Memory leak fix:** `clearAgentRunContext` in `src/infra/agent-events.ts` now also clears the `seqByRun` Map entry, preventing unbounded map growth.
- **Parsing hardening:** ~30+ call sites across CLI modules (`parse-timeout.ts`, `parse-port.ts`, `argv.ts`, `helpers.ts`, and various `register.*.ts` files) now validate inputs with `/^\d+$/` or similar patterns before parsing.
- **New helpers:** Added `parseNonNegativeIntOrUndefined` in `src/cli/program/helpers.ts` and a local `parsePositiveInt` in `src/commands/channels/logs.ts`.
- **Deduplication:** `sanitizeAgentId` was identical to `normalizeAgentId` and is now an alias.
- **Test coverage:** Extensive new test suites added for parsing functions, error classification, infrastructure utilities, media helpers, markdown parsing, and more (~1200+ new test lines across 25+ new/modified test files).
- **Test reliability:** Fixed environment variable leakage in `server-runtime-config.test.ts` and browser control server tests by properly saving/restoring `OPENCLAW_GATEWAY_TOKEN` and `OPENCLAW_GATEWAY_PASSWORD`.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — the changes are defensive improvements that reject previously-accepted invalid inputs, with comprehensive test coverage.
- Score of 4 reflects that all changes are defensive hardening with good test coverage. Minor style issues (semantic misuse of `parseTimeoutMs` for non-timeout values, dead code branches) don't affect correctness. The regex bugfix and memory leak fix are genuine improvements. No behavioral regressions for valid inputs.
- `src/commands/models/list.status-command.ts` uses `parseTimeoutMs` for `probeConcurrency` and `probeMaxTokens` which is semantically misleading. `src/cli/update-cli/status.ts` and `src/cli/update-cli/wizard.ts` contain dead `Number.isNaN` branches.

<sub>Last reviewed commit: 9c2499f</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->