### PR TITLE
fix(nano-banana-pro): remove space after MEDIA: token

### DIFF
--- a/skills/nano-banana-pro/scripts/generate_image.py
+++ b/skills/nano-banana-pro/scripts/generate_image.py
@@ -169,8 +169,9 @@ def main():
         if image_saved:
             full_path = output_path.resolve()
             print(f"\nImage saved: {full_path}")
-            # OpenClaw parses MEDIA tokens and will attach the file on supported providers.
-            print(f"MEDIA: {full_path}")
+            # OpenClaw parses MEDIA: tokens (line-start, no space after colon)
+            # and will attach the file on supported chat providers.
+            print(f"MEDIA:{full_path}")
         else:
             print("Error: No image was generated in the response.", file=sys.stderr)
             sys.exit(1)


### PR DESCRIPTION
## Summary

The `generate_image.py` script in the `nano-banana-pro` skill prints `MEDIA: /path` (with a space after the colon), which does not match the canonical `MEDIA:/path` format used by all other skills and tested throughout the codebase.

## Problem

OpenClaw's `splitMediaFromOutput` parser (in `src/media/parse.ts`) and `extractToolResultMediaPaths` (in `src/agents/pi-embedded-subscribe.tools.ts`) extract media file paths from lines starting with `MEDIA:`. While the regex `MEDIA:\s*` tolerates an optional space, every other skill and test uses the no-space format:

- `openai-image-gen` outputs paths without the space
- `pi-embedded-subscribe.tools.media.test.ts` tests `MEDIA:/tmp/screenshot.png` (no space)
- `media/parse.test.ts` tests `MEDIA:/Users/pete/My File.png` (no space)

The space caused inconsistency and could interact poorly with downstream consumers that expect the canonical format.

## Changes

- **`skills/nano-banana-pro/scripts/generate_image.py`**: Changed `print(f"MEDIA: {full_path}")` to `print(f"MEDIA:{full_path}")`
- Updated the comment to clarify the no-space, line-start format constraint

## Testing

- Verified the change matches the format in `SKILL.md` ("The script prints a `MEDIA:` line")
- Confirmed alignment with all existing tests in the codebase

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes the `MEDIA:` token format in `nano-banana-pro`'s `generate_image.py` by removing the space after the colon, aligning it with the canonical `MEDIA:{path}` format used by every other media token producer in the codebase (`tts-tool.ts`, `nodes-tool.ts`, `common.ts`) and expected by all tests.

- Removed trailing space in `print(f"MEDIA: {full_path}")` → `print(f"MEDIA:{full_path}")` in `generate_image.py:174`
- Updated the inline comment to document the no-space, line-start format constraint
- The `MEDIA_TOKEN_RE` regex in `src/media/parse.ts` tolerates optional whitespace via `\s*`, so the old format worked but was inconsistent with all other producers and tests

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a minimal one-line format fix that aligns with all existing conventions.
- The change is a trivial, well-motivated format fix: removing a single space in a print statement to match the canonical MEDIA token format used everywhere else. The parser already handles both formats, so there is zero risk of breakage. The comment update is accurate and helpful.
- No files require special attention.

<sub>Last reviewed commit: 80174c8</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->