### PR TITLE
gateway: fix browser control service not binding to port

### DIFF
--- a/src/gateway/server-browser.ts
+++ b/src/gateway/server-browser.ts
@@ -11,7 +11,7 @@ export async function startBrowserControlServerIfEnabled(): Promise<BrowserContr
   // Lazy import: keeps startup fast, but still bundles for the embedded
   // gateway (bun --compile) via the static specifier path.
   const override = process.env.OPENCLAW_BROWSER_CONTROL_MODULE?.trim();
-  const mod = override ? await import(override) : await import("../browser/control-service.js");
+  const mod = override ? await import(override) : await import("../browser/server.js");
   const start =
     typeof (mod as { startBrowserControlServiceFromConfig?: unknown })
       .startBrowserControlServiceFromConfig === "function"


### PR DESCRIPTION
## Summary

- **Problem:** Browser control service logs "ready" but never actually binds to port 18800, causing all browser tool calls to timeout
- **Why it matters:** Browser control is completely broken - users cannot use any browser automation features
- **What changed:** Changed import in `server-browser.ts` from `control-service.js` (which only sets state) to `server.js` (which actually binds HTTP server)
- **What did NOT change:** No other files, no config changes, no behavior changes to working functionality

## Change Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope
- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #18686

## User-visible / Behavior Changes
- Browser control service now properly binds to configured port (default 18800)
- Previously "ready" log appeared but port was never listening - now actual listening confirmation will appear

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No (just fixes binding that was missing)
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment
- OS: Ubuntu 24.04 LTS (Linux)
- Runtime: Node 22.22.0
- Integration: Browser control

### Steps
1. Enable browser in config
2. Start gateway
3. Check if port 18800 is listening (`ss -ltnp | grep 18800`)
4. Attempt browser tool call

### Expected
Port 18800 should be listening and responding

### Actual (before fix)
Port 18800 never binds despite "ready" log

## Evidence
The bug is in `src/gateway/server-browser.ts` line 11 - it imports from `control-service.js` which has no HTTP server code, instead of `server.js` which has the actual Express server with port binding.

## Human Verification
- Verified by code inspection that `control-service.ts` sets `server: null` and never starts HTTP
- Verified that `server.ts` has proper `app.listen(port)` call that binds to configured port

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to disable/revert this change quickly: Revert the one-line change in `server-browser.ts`
- Files to restore: Just `src/gateway/server-browser.ts`

## Risks and Mitigations
- None - this is a straightforward import path correction to use the file that actually implements the server

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes the browser control service not binding to its configured HTTP port (default 18800) by correcting the lazy import in `src/gateway/server-browser.ts`.

- The default import path was `../browser/control-service.js`, which initializes browser state (`server: null`) but never starts an HTTP server — it logged "ready" without actually listening on any port
- Changed to `../browser/server.js`, which creates an Express app, binds to `127.0.0.1:<port>`, installs auth middleware, and registers browser routes
- The existing dual function-name resolution logic (`startBrowserControlServiceFromConfig` then `startBrowserControlServerFromConfig`) correctly picks up the right export from the new module
- Other files that import from `control-service.ts` for in-process dispatch are unaffected — they don't need a bound port

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a one-line import path correction that restores intended functionality.
- The change is a single import path fix with clear evidence of the bug: control-service.ts sets server: null and never calls app.listen(), while server.ts properly creates and binds an Express HTTP server. The dual function-name fallback logic in server-browser.ts already handles both modules correctly. No other files are affected. The change is minimal, well-scoped, and clearly correct.
- No files require special attention.

<sub>Last reviewed commit: af5328b</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->