### PR TITLE
feat(messages): add suppressToolErrorWarnings config option

### DIFF
--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -1,10 +1,9 @@
 import type { AssistantMessage } from "@mariozechner/pi-ai";
-import type { ReasoningLevel, VerboseLevel } from "../../../auto-reply/thinking.js";
-import type { OpenClawConfig } from "../../../config/config.js";
-import type { ToolResultFormat } from "../../pi-embedded-subscribe.js";
 import { parseReplyDirectives } from "../../../auto-reply/reply/reply-directives.js";
+import type { ReasoningLevel, VerboseLevel } from "../../../auto-reply/thinking.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../../auto-reply/tokens.js";
 import { formatToolAggregate } from "../../../auto-reply/tool-meta.js";
+import type { OpenClawConfig } from "../../../config/config.js";
 import {
   BILLING_ERROR_USER_MESSAGE,
   formatAssistantErrorText,
@@ -13,6 +12,7 @@ import {
   isRawApiErrorPayload,
   normalizeTextForComparison,
 } from "../../pi-embedded-helpers.js";
+import type { ToolResultFormat } from "../../pi-embedded-subscribe.js";
 import {
   extractAssistantText,
   extractAssistantThinking,
@@ -252,10 +252,12 @@ export function buildEmbeddedRunPayloads(params: {
       lastToolError: params.lastToolError,
       hasUserFacingReply: hasUserFacingAssistantReply,
       suppressToolErrors: Boolean(params.config?.messages?.suppressToolErrors),
-      suppressToolErrorWarnings: params.suppressToolErrorWarnings,
+      suppressToolErrorWarnings:
+        params.suppressToolErrorWarnings ??
+        Boolean(params.config?.messages?.suppressToolErrorWarnings),
     });
 
-    // Always surface mutating tool failures so we do not silently confirm actions that did not happen.
+    // Surface mutating tool failures unless suppressToolErrorWarnings is enabled.
     // Otherwise, keep the previous behavior and only surface non-recoverable failures when no reply exists.
     if (shouldShowToolError) {
       const toolSummary = formatToolAggregate(

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -358,7 +358,9 @@ export const FIELD_HELP: Record<string, string> = {
   "channels.telegram.customCommands":
     "Additional Telegram bot menu commands (merged with native; conflicts ignored).",
   "messages.suppressToolErrors":
-    "When true, suppress ⚠️ tool-error warnings from being shown to the user. The agent already sees errors in context and can retry. Default: false.",
+    "When true, suppress ⚠️ tool-error warnings for non-mutating tools. The agent already sees errors in context and can retry. Default: false.",
+  "messages.suppressToolErrorWarnings":
+    "When true, suppress ALL ⚠️ tool-error warnings including mutating tools (exec, write, message, etc.). Useful when the agent handles errors gracefully and the raw warnings are noise. Default: false.",
   "messages.ackReaction": "Emoji reaction used to acknowledge inbound messages (empty disables).",
   "messages.ackReactionScope":
     'When to send ack reactions ("group-mentions", "group-all", "direct", "all").',

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -234,6 +234,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "session.dmScope": "DM Session Scope",
   "session.agentToAgent.maxPingPongTurns": "Agent-to-Agent Ping-Pong Turns",
   "messages.suppressToolErrors": "Suppress Tool Error Warnings",
+  "messages.suppressToolErrorWarnings": "Suppress All Tool Error Warnings (Including Mutating)",
   "messages.ackReaction": "Ack Reaction Emoji",
   "messages.ackReactionScope": "Ack Reaction Scope",
   "messages.inbound.debounceMs": "Inbound Message Debounce (ms)",

--- a/src/config/types.messages.ts
+++ b/src/config/types.messages.ts
@@ -82,8 +82,10 @@ export type MessagesConfig = {
   ackReactionScope?: "group-mentions" | "group-all" | "direct" | "all";
   /** Remove ack reaction after reply is sent (default: false). */
   removeAckAfterReply?: boolean;
-  /** When true, suppress ⚠️ tool-error warnings from being shown to the user. Default: false. */
+  /** When true, suppress ⚠️ tool-error warnings for non-mutating tools. Default: false. */
   suppressToolErrors?: boolean;
+  /** When true, suppress ALL ⚠️ tool-error warnings including mutating tools (exec, write, etc.). Default: false. */
+  suppressToolErrorWarnings?: boolean;
   /** Text-to-speech settings for outbound replies. */
   tts?: TtsConfig;
 };

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -115,6 +115,7 @@ export const MessagesSchema = z
     ackReactionScope: z.enum(["group-mentions", "group-all", "direct", "all"]).optional(),
     removeAckAfterReply: z.boolean().optional(),
     suppressToolErrors: z.boolean().optional(),
+    suppressToolErrorWarnings: z.boolean().optional(),
     tts: TtsConfigSchema,
   })
   .strict()


### PR DESCRIPTION
## Problem

When `messages.suppressToolErrors: true` is configured, non-mutating tool errors are correctly suppressed. However, **mutating tool errors** (`exec`, `write`, `message`, `sessions_send`, etc.) always bypass this setting and emit `⚠️` warnings to the chat channel — even when the agent already handled the error and retried successfully.

This is noisy for end users who see raw error output like:

```
⚠️ 🛠️ Exec: grep pattern file failed: Command exited with code 1
```

...for errors the agent already recovered from in the next turn.

Closes #18630

## Solution

Add `messages.suppressToolErrorWarnings: true` config option that suppresses **all** tool-error warnings, including mutating tools.

The internal `suppressToolErrorWarnings` parameter already existed in the runner pipeline — it was used by heartbeat sessions via `agents.defaults.heartbeat.suppressToolErrorWarnings`. This PR exposes it as a top-level messages config option so regular sessions benefit too.

## Changes

5 files, +15/-7 lines:

1. **Config type** (`types.messages.ts`): Add `suppressToolErrorWarnings?: boolean`
2. **Zod schema** (`zod-schema.session.ts`): Add validation
3. **Labels + help** (`schema.labels.ts`, `schema.help.ts`): Add UI label and description
4. **Payloads** (`payloads.ts`): Fall back to config value when param is not explicitly set by caller

## Backwards compatible

- Default is `false` — no behavior change unless explicitly enabled
- Existing `messages.suppressToolErrors` behavior is unchanged
- `suppressToolErrorWarnings` overrides and suppresses all warnings when enabled

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR exposes an existing internal parameter `suppressToolErrorWarnings` as a user-configurable option under `messages.suppressToolErrorWarnings`. When enabled, it suppresses all tool-error warnings (including mutating tools like `exec`, `write`, `message`) that are shown to end users, allowing agents to handle errors gracefully without noisy `⚠️` warnings appearing in the chat.

The implementation adds:
- Config type definition in `types.messages.ts` with clear documentation
- Zod schema validation in `zod-schema.session.ts`
- UI labels and help text in `schema.labels.ts` and `schema.help.ts`
- Fallback logic in `payloads.ts` that uses the config value when the parameter isn't explicitly set

The change is backwards compatible (default: `false`) and properly integrated with the existing `messages.suppressToolErrors` option, which only suppresses non-mutating tool errors.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is straightforward, well-tested, and follows existing patterns. It exposes an internal parameter that was already being used by heartbeat sessions, extends it to regular sessions via config fallback, includes proper type definitions, validation, documentation, and test coverage. The changes are minimal (5 files, +15/-7 lines), backwards compatible, and the logic correctly implements the nullish coalescing operator to fall back from explicit parameter to config value.
- No files require special attention

<sub>Last reviewed commit: 3d110d8</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->