### PR TITLE
fix(hooks): handle gitignored files in pre-commit re-stage

### DIFF
--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -35,4 +35,4 @@ if [ "${#format_files[@]}" -gt 0 ]; then
   "$RUN_NODE_TOOL" oxfmt --write -- "${format_files[@]}"
 fi
 
-git add -- "${files[@]}"
+git add --ignore-errors -- "${files[@]}"


### PR DESCRIPTION
## Summary
- Fix pre-commit hook failing when staged files match `.gitignore`

## Problem/Context
The pre-commit hook re-stages all originally staged files after oxlint/oxfmt auto-fix (`git add -- "${files[@]}"`). When a merge introduces a path that matches `.gitignore` (e.g. `export-html/vendor`), `git add` exits non-zero and the commit is rejected under `set -euo pipefail`.

## Solution
Use `git add --ignore-errors` so gitignored paths are silently skipped while all other files are still re-staged.

## Test Plan
- [x] Verified: merge commit with gitignored vendor path now succeeds

## Sign-Off
- Models used: Claude Opus 4.6
- Submitter effort summary: Hit the bug during a routine upstream merge, traced to the re-stage line in pre-commit hook.

—Calculon, Actor Extraordinaire (feat. Opus 4.6)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes the pre-commit hook failing when re-staging files that match `.gitignore` patterns. During merge commits, tracked files matching gitignore (e.g., `vendor/`) can be in the staged set; the final `git add` line would exit non-zero under `set -euo pipefail`, rejecting the commit. Adding `--ignore-errors` lets git silently skip unadddable paths while still re-staging all other files after oxlint/oxfmt auto-fixes.

- Adds `--ignore-errors` flag to the `git add` re-stage command in `git-hooks/pre-commit`
- No other files changed; the fix is minimal and well-scoped

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a single-flag addition to an existing git command with clear, well-scoped behavior.
- The change is a one-line addition of `--ignore-errors` to `git add`. The flag is a standard git option that skips unadddable files rather than failing. The files being re-staged come from `git diff --cached` (already staged), so the only scenario where `git add` would fail is gitignored paths during merges — exactly the case this fixes. Risk of masking other errors is negligible in this context.
- No files require special attention.

<sub>Last reviewed commit: e9d7188</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->