### PR TITLE
fix(telegram): replace hyphens with underscores in export-session command

### DIFF
--- a/src/auto-reply/commands-registry.data.ts
+++ b/src/auto-reply/commands-registry.data.ts
@@ -1,11 +1,11 @@
-import { listChannelDocks } from "../channels/dock.js";
-import { getActivePluginRegistry } from "../plugins/runtime.js";
-import { COMMAND_ARG_FORMATTERS } from "./commands-args.js";
 import type {
   ChatCommandDefinition,
   CommandCategory,
   CommandScope,
 } from "./commands-registry.types.js";
+import { listChannelDocks } from "../channels/dock.js";
+import { getActivePluginRegistry } from "../plugins/runtime.js";
+import { COMMAND_ARG_FORMATTERS } from "./commands-args.js";
 import { listThinkingLevels } from "./thinking.js";
 
 type DefineChatCommandInput = {
@@ -207,7 +207,7 @@ function buildChatCommands(): ChatCommandDefinition[] {
     }),
     defineChatCommand({
       key: "export-session",
-      nativeName: "export-session",
+      nativeName: "export_session",
       description: "Export current session to HTML file with full system prompt.",
       textAliases: ["/export-session", "/export"],
       acceptsArgs: true,


### PR DESCRIPTION
Telegram does not allow hyphens in bot command names. This fixes the setMyCommands failure (BOT_COMMAND_INVALID) by changing nativeName from 'export-session' to 'export_session'.

Fixes #18683

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changed the `nativeName` from `export-session` to `export_session` to comply with Telegram's bot command naming requirements, which only allow lowercase letters, numbers, and underscores (pattern: `^[a-z0-9_]{1,32}$`). This fixes the `BOT_COMMAND_INVALID` error when calling `setMyCommands`.

- The change is consistent with other commands in the registry (e.g., `dock_${dock.id}` at src/auto-reply/commands-registry.data.ts:54)
- Text aliases (`textAliases: ["/export-session", "/export"]`) correctly remain unchanged, as they can still use hyphens for user-facing commands
- The fix resolves the issue where Telegram would reject the command registration due to invalid character (hyphen) in the native command name

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risks
- The change is a straightforward one-character fix (hyphen to underscore) that directly addresses a documented Telegram API requirement. The fix is consistent with existing patterns in the codebase and all text aliases remain properly functional.
- No files require special attention

<sub>Last reviewed commit: c0288f3</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->