### PR TITLE
feat(hooks): add responseUrl callback with security hardening

### DIFF
--- a/src/agents/anthropic-payload-log.ts
+++ b/src/agents/anthropic-payload-log.ts
@@ -1,8 +1,8 @@
+import type { AgentMessage, StreamFn } from "@mariozechner/pi-agent-core";
+import type { Api, Model } from "@mariozechner/pi-ai";
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
-import type { AgentMessage, StreamFn } from "@mariozechner/pi-agent-core";
-import type { Api, Model } from "@mariozechner/pi-ai";
 import { resolveStateDir } from "../config/paths.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveUserPath } from "../utils.js";

--- a/src/agents/cache-trace.ts
+++ b/src/agents/cache-trace.ts
@@ -1,7 +1,7 @@
+import type { AgentMessage, StreamFn } from "@mariozechner/pi-agent-core";
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
-import type { AgentMessage, StreamFn } from "@mariozechner/pi-agent-core";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
 import { resolveUserPath } from "../utils.js";

--- a/src/agents/tools/canvas-tool.ts
+++ b/src/agents/tools/canvas-tool.ts
@@ -1,6 +1,6 @@
+import { Type } from "@sinclair/typebox";
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
-import { Type } from "@sinclair/typebox";
 import { writeBase64ToFile } from "../../cli/nodes-camera.js";
 import { canvasSnapshotTempPath, parseCanvasSnapshotPayload } from "../../cli/nodes-canvas.js";
 import { imageMimeFromFormat } from "../../media/mime.js";

--- a/src/agents/tools/nodes-tool.ts
+++ b/src/agents/tools/nodes-tool.ts
@@ -1,6 +1,7 @@
-import crypto from "node:crypto";
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import { Type } from "@sinclair/typebox";
+import crypto from "node:crypto";
+import type { OpenClawConfig } from "../../config/config.js";
 import {
   type CameraFacing,
   cameraTempPath,
@@ -16,7 +17,6 @@ import {
   writeScreenRecordToFile,
 } from "../../cli/nodes-screen.js";
 import { parseDurationMs } from "../../cli/parse-duration.js";
-import type { OpenClawConfig } from "../../config/config.js";
 import { imageMimeFromFormat } from "../../media/mime.js";
 import { resolveSessionAgentId } from "../agent-scope.js";
 import { optionalStringEnum, stringEnum } from "../schema/typebox.js";

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -1,5 +1,6 @@
 import { Type } from "@sinclair/typebox";
 import type { OpenClawConfig } from "../../config/config.js";
+import type { AnyAgentTool } from "./common.js";
 import { fetchWithSsrFGuard } from "../../infra/net/fetch-guard.js";
 import {
   matchesHostnameAllowlist,
@@ -10,7 +11,6 @@ import { logDebug } from "../../logger.js";
 import { wrapExternalContent, wrapWebContent } from "../../security/external-content.js";
 import { normalizeSecretInput } from "../../utils/normalize-secret-input.js";
 import { stringEnum } from "../schema/typebox.js";
-import type { AnyAgentTool } from "./common.js";
 import { jsonResult, readNumberParam, readStringParam } from "./common.js";
 import {
   extractReadableContent,

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -1,10 +1,10 @@
 import { Type } from "@sinclair/typebox";
-import { formatCliCommand } from "../../cli/command-format.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import type { AnyAgentTool } from "./common.js";
+import { formatCliCommand } from "../../cli/command-format.js";
 import { matchesHostnameAllowlist, normalizeHostnameAllowlist } from "../../infra/net/ssrf.js";
 import { wrapWebContent } from "../../security/external-content.js";
 import { normalizeSecretInput } from "../../utils/normalize-secret-input.js";
-import type { AnyAgentTool } from "./common.js";
 import { jsonResult, readNumberParam, readStringParam } from "./common.js";
 import {
   CacheEntry,

--- a/src/commands/status-all.ts
+++ b/src/commands/status-all.ts
@@ -1,10 +1,11 @@
+import type { GatewayService } from "../daemon/service.js";
+import type { RuntimeEnv } from "../runtime.js";
 import { buildWorkspaceSkillStatus } from "../agents/skills-status.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { withProgress } from "../cli/progress.js";
 import { loadConfig, readConfigFileSnapshot, resolveGatewayPort } from "../config/config.js";
 import { readLastGatewayErrorLine } from "../daemon/diagnostics.js";
 import { resolveNodeService } from "../daemon/node-service.js";
-import type { GatewayService } from "../daemon/service.js";
 import { resolveGatewayService } from "../daemon/service.js";
 import { buildGatewayConnectionDetails, callGateway } from "../gateway/call.js";
 import { normalizeControlUiBasePath } from "../gateway/control-ui-shared.js";
@@ -28,7 +29,6 @@ import {
   formatGitInstallLabel,
 } from "../infra/update-check.js";
 import { runExec } from "../process/exec.js";
-import type { RuntimeEnv } from "../runtime.js";
 import { VERSION } from "../version.js";
 import { resolveControlUiLinks } from "./onboard-helpers.js";
 import { getAgentLocalStatuses } from "./status-all/agents.js";

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -1,10 +1,11 @@
+import type { HeartbeatEventPayload } from "../infra/heartbeat-events.js";
+import type { RuntimeEnv } from "../runtime.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { withProgress } from "../cli/progress.js";
 import { resolveGatewayPort } from "../config/config.js";
 import { buildGatewayConnectionDetails, callGateway } from "../gateway/call.js";
 import { info } from "../globals.js";
 import { formatTimeAgo } from "../infra/format-time/format-relative.ts";
-import type { HeartbeatEventPayload } from "../infra/heartbeat-events.js";
 import { formatUsageReportLines, loadProviderUsageSummary } from "../infra/provider-usage.js";
 import {
   formatUpdateChannelLabel,
@@ -18,7 +19,6 @@ import {
   resolveMemoryVectorState,
   type Tone,
 } from "../memory/status-format.js";
-import type { RuntimeEnv } from "../runtime.js";
 import { runSecurityAudit } from "../security/audit.js";
 import { renderTable } from "../terminal/table.js";
 import { theme } from "../terminal/theme.js";

--- a/src/config/types.hooks.ts
+++ b/src/config/types.hooks.ts
@@ -38,6 +38,8 @@ export type HookMappingConfig = {
   model?: string;
   thinking?: string;
   timeoutSeconds?: number;
+  responseUrl?: string;
+  responseSecret?: string;
   transform?: HookMappingTransform;
 };
 

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -1,3 +1,7 @@
+import type { MessagingToolSend } from "../../agents/pi-embedded-messaging.js";
+import type { OpenClawConfig } from "../../config/config.js";
+import type { AgentDefaultsConfig } from "../../config/types.js";
+import type { CronJob } from "../types.js";
 import {
   resolveAgentConfig,
   resolveAgentDir,
@@ -20,7 +24,6 @@ import {
   resolveHooksGmailModel,
   resolveThinkingDefault,
 } from "../../agents/model-selection.js";
-import type { MessagingToolSend } from "../../agents/pi-embedded-messaging.js";
 import { runEmbeddedPiAgent } from "../../agents/pi-embedded.js";
 import { runSubagentAnnounceFlow } from "../../agents/subagent-announce.js";
 import { countActiveDescendantRuns } from "../../agents/subagent-registry.js";
@@ -34,13 +37,11 @@ import {
 } from "../../auto-reply/thinking.js";
 import { SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import { createOutboundSendDeps, type CliDeps } from "../../cli/outbound-send-deps.js";
-import type { OpenClawConfig } from "../../config/config.js";
 import {
   resolveAgentMainSessionKey,
   resolveSessionTranscriptPath,
   updateSessionStore,
 } from "../../config/sessions.js";
-import type { AgentDefaultsConfig } from "../../config/types.js";
 import { registerAgentRunContext } from "../../infra/agent-events.js";
 import { deliverOutboundPayloads } from "../../infra/outbound/deliver.js";
 import { resolveAgentOutboundIdentity } from "../../infra/outbound/identity.js";
@@ -53,7 +54,6 @@ import {
   isExternalHookSession,
 } from "../../security/external-content.js";
 import { resolveCronDeliveryPlan } from "../delivery.js";
-import type { CronJob } from "../types.js";
 import { resolveDeliveryTarget } from "./delivery-target.js";
 import {
   isHeartbeatOnlyResponse,

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -1,8 +1,9 @@
 import type { HeartbeatRunResult } from "../../infra/heartbeat-wake.js";
+import type { CronJob } from "../types.js";
+import type { CronEvent, CronServiceState } from "./state.js";
 import { DEFAULT_AGENT_ID } from "../../routing/session-key.js";
 import { resolveCronDeliveryPlan } from "../delivery.js";
 import { sweepCronRunSessions } from "../session-reaper.js";
-import type { CronJob } from "../types.js";
 import {
   computeJobNextRunAtMs,
   nextWakeAtMs,
@@ -10,7 +11,6 @@ import {
   resolveJobPayloadTextForMain,
 } from "./jobs.js";
 import { locked } from "./locked.js";
-import type { CronEvent, CronServiceState } from "./state.js";
 import { ensureLoaded, persist } from "./store.js";
 
 const MAX_TIMER_DELAY_MS = 60_000;

--- a/src/gateway/hooks-mapping.ts
+++ b/src/gateway/hooks-mapping.ts
@@ -21,6 +21,8 @@ export type HookMappingResolved = {
   model?: string;
   thinking?: string;
   timeoutSeconds?: number;
+  responseUrl?: string;
+  responseSecret?: string;
   transform?: HookMappingTransformResolved;
 };
 
@@ -56,6 +58,8 @@ export type HookAction =
       model?: string;
       thinking?: string;
       timeoutSeconds?: number;
+      responseUrl?: string;
+      responseSecret?: string;
     };
 
 export type HookMappingResult =

--- a/src/gateway/hooks-mapping.ts
+++ b/src/gateway/hooks-mapping.ts
@@ -220,6 +220,8 @@ function normalizeHookMapping(
     model: mapping.model,
     thinking: mapping.thinking,
     timeoutSeconds: mapping.timeoutSeconds,
+    responseUrl: mapping.responseUrl,
+    responseSecret: mapping.responseSecret,
     transform,
   };
 }
@@ -271,6 +273,8 @@ function buildActionFromMapping(
       model: renderOptional(mapping.model, ctx),
       thinking: renderOptional(mapping.thinking, ctx),
       timeoutSeconds: mapping.timeoutSeconds,
+      responseUrl: renderOptional(mapping.responseUrl, ctx),
+      responseSecret: mapping.responseSecret,
     },
   };
 }
@@ -312,6 +316,8 @@ function mergeAction(
     model: override.model ?? baseAgent?.model,
     thinking: override.thinking ?? baseAgent?.thinking,
     timeoutSeconds: override.timeoutSeconds ?? baseAgent?.timeoutSeconds,
+    responseUrl: baseAgent?.responseUrl,
+    responseSecret: baseAgent?.responseSecret,
   });
 }
 

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -231,6 +231,8 @@ export type HookAgentPayload = {
   model?: string;
   thinking?: string;
   timeoutSeconds?: number;
+  responseUrl?: string;
+  responseSecret?: string;
 };
 
 const listHookChannelValues = () => ["last", ...listChannelPlugins().map((plugin) => plugin.id)];
@@ -366,6 +368,14 @@ export function normalizeAgentPayload(payload: Record<string, unknown>):
     typeof timeoutRaw === "number" && Number.isFinite(timeoutRaw) && timeoutRaw > 0
       ? Math.floor(timeoutRaw)
       : undefined;
+  const responseUrlRaw = payload.responseUrl;
+  const responseUrl =
+    typeof responseUrlRaw === "string" && responseUrlRaw.trim() ? responseUrlRaw.trim() : undefined;
+  const responseSecretRaw = payload.responseSecret;
+  const responseSecret =
+    typeof responseSecretRaw === "string" && responseSecretRaw.trim()
+      ? responseSecretRaw.trim()
+      : undefined;
   return {
     ok: true,
     value: {
@@ -380,6 +390,8 @@ export function normalizeAgentPayload(payload: Record<string, unknown>):
       model,
       thinking,
       timeoutSeconds,
+      responseUrl,
+      responseSecret,
     },
   };
 }

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -1,9 +1,9 @@
-import { randomUUID } from "node:crypto";
 import type { IncomingMessage } from "node:http";
-import { listAgentIds, resolveDefaultAgentId } from "../agents/agent-scope.js";
-import { listChannelPlugins } from "../channels/plugins/index.js";
+import { randomUUID } from "node:crypto";
 import type { ChannelId } from "../channels/plugins/types.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { listAgentIds, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { listChannelPlugins } from "../channels/plugins/index.js";
 import { readJsonBodyWithLimit, requestBodyErrorToText } from "../infra/http-body.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { normalizeMessageChannel } from "../utils/message-channel.js";
@@ -371,6 +371,17 @@ export function normalizeAgentPayload(payload: Record<string, unknown>):
   const responseUrlRaw = payload.responseUrl;
   const responseUrl =
     typeof responseUrlRaw === "string" && responseUrlRaw.trim() ? responseUrlRaw.trim() : undefined;
+  if (responseUrl) {
+    let parsedUrl: URL;
+    try {
+      parsedUrl = new URL(responseUrl);
+    } catch {
+      return { ok: false, error: "responseUrl is not a valid URL" };
+    }
+    if (parsedUrl.protocol !== "https:") {
+      return { ok: false, error: "responseUrl must use HTTPS" };
+    }
+  }
   const responseSecretRaw = payload.responseSecret;
   const responseSecret =
     typeof responseSecretRaw === "string" && responseSecretRaw.trim()

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -6,13 +6,15 @@
  * @see https://www.open-responses.com/
  */
 
-import { randomUUID } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { randomUUID } from "node:crypto";
 import type { ClientToolDefinition } from "../agents/pi-embedded-runner/run/params.js";
-import { createDefaultDeps } from "../cli/deps.js";
-import { agentCommand } from "../commands/agent.js";
 import type { ImageContent } from "../commands/agent/types.js";
 import type { GatewayHttpResponsesConfig } from "../config/types.gateway.js";
+import type { AuthRateLimiter } from "./auth-rate-limit.js";
+import type { ResolvedGatewayAuth } from "./auth.js";
+import { createDefaultDeps } from "../cli/deps.js";
+import { agentCommand } from "../commands/agent.js";
 import { emitAgentEvent, onAgentEvent } from "../infra/agent-events.js";
 import { logWarn } from "../logger.js";
 import {
@@ -39,8 +41,6 @@ import {
   buildAgentMessageFromConversationEntries,
   type ConversationEntry,
 } from "./agent-prompt.js";
-import type { AuthRateLimiter } from "./auth-rate-limit.js";
-import type { ResolvedGatewayAuth } from "./auth.js";
 import { sendJson, setSseHeaders, writeDone } from "./http-common.js";
 import { handleGatewayPostJsonEndpoint } from "./http-endpoint-helpers.js";
 import { resolveAgentIdForRequest, resolveSessionKey } from "./http-utils.js";

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -78,6 +78,8 @@ type HookDispatchers = {
     thinking?: string;
     timeoutSeconds?: number;
     allowUnsafeExternalContent?: boolean;
+    responseUrl?: string;
+    responseSecret?: string;
   }) => string;
 };
 
@@ -417,6 +419,8 @@ export function createHooksRequestHandler(
             thinking: mapped.action.thinking,
             timeoutSeconds: mapped.action.timeoutSeconds,
             allowUnsafeExternalContent: mapped.action.allowUnsafeExternalContent,
+            responseUrl: mapped.action.responseUrl,
+            responseSecret: mapped.action.responseSecret,
           });
           sendJson(res, 202, { ok: true, runId });
           return true;

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHmac, randomUUID } from "node:crypto";
 import type { CliDeps } from "../../cli/deps.js";
 import { loadConfig } from "../../config/config.js";
 import { resolveMainSessionKeyFromConfig } from "../../config/sessions.js";
@@ -9,6 +9,50 @@ import { enqueueSystemEvent } from "../../infra/system-events.js";
 import type { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { HookMessageChannel, HooksConfigResolved } from "../hooks.js";
 import { createHooksRequestHandler } from "../server-http.js";
+
+const RESPONSE_CALLBACK_TIMEOUT_MS = 10_000;
+
+// Block private/reserved IP ranges to prevent SSRF
+const BLOCKED_IP_PATTERNS = [
+  /^10\./, // 10.0.0.0/8
+  /^172\.(1[6-9]|2[0-9]|3[0-1])\./, // 172.16.0.0/12
+  /^192\.168\./, // 192.168.0.0/16
+  /^127\./, // loopback
+  /^169\.254\./, // link-local
+  /^0\./, // 0.0.0.0/8
+  /^::1$/, // IPv6 loopback
+  /^fc00:/i, // IPv6 unique local
+  /^fe80:/i, // IPv6 link-local
+];
+
+function isBlockedHost(hostname: string): boolean {
+  if (hostname === "localhost" || hostname.endsWith(".localhost")) {
+    return true;
+  }
+  return BLOCKED_IP_PATTERNS.some((pattern) => pattern.test(hostname));
+}
+
+function validateResponseUrl(
+  urlString: string,
+): { ok: true; url: URL } | { ok: false; error: string } {
+  let url: URL;
+  try {
+    url = new URL(urlString);
+  } catch {
+    return { ok: false, error: "invalid URL" };
+  }
+  if (url.protocol !== "https:") {
+    return { ok: false, error: "responseUrl must use HTTPS" };
+  }
+  if (isBlockedHost(url.hostname)) {
+    return { ok: false, error: "responseUrl blocked (private/reserved address)" };
+  }
+  return { ok: true, url };
+}
+
+function signPayload(payload: string, secret: string): string {
+  return createHmac("sha256", secret).update(payload).digest("hex");
+}
 
 type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
 
@@ -42,6 +86,8 @@ export function createGatewayHooksRequestHandler(params: {
     thinking?: string;
     timeoutSeconds?: number;
     allowUnsafeExternalContent?: boolean;
+    responseUrl?: string;
+    responseSecret?: string;
   }) => {
     const sessionKey = value.sessionKey.trim();
     const mainSessionKey = resolveMainSessionKeyFromConfig();
@@ -86,6 +132,51 @@ export function createGatewayHooksRequestHandler(params: {
         const summary = result.summary?.trim() || result.error?.trim() || result.status;
         const prefix =
           result.status === "ok" ? `Hook ${value.name}` : `Hook ${value.name} (${result.status})`;
+
+        // POST result to responseUrl if provided
+        if (value.responseUrl) {
+          const urlValidation = validateResponseUrl(value.responseUrl);
+          if (!urlValidation.ok) {
+            logHooks.warn(`hook responseUrl invalid: ${urlValidation.error}`);
+          } else {
+            try {
+              const body = JSON.stringify({
+                runId,
+                status: result.status,
+                summary: result.summary,
+                outputText: result.outputText,
+                error: result.error,
+                sessionKey,
+                jobId,
+                timestamp: Date.now(),
+              });
+              const headers: Record<string, string> = { "Content-Type": "application/json" };
+              if (value.responseSecret) {
+                headers["X-OpenClaw-Signature"] =
+                  `sha256=${signPayload(body, value.responseSecret)}`;
+              }
+              const controller = new AbortController();
+              const timeoutId = setTimeout(() => controller.abort(), RESPONSE_CALLBACK_TIMEOUT_MS);
+              try {
+                await fetch(urlValidation.url.href, {
+                  method: "POST",
+                  headers,
+                  body,
+                  signal: controller.signal,
+                });
+              } finally {
+                clearTimeout(timeoutId);
+              }
+            } catch (callbackErr) {
+              const errMsg =
+                callbackErr instanceof Error && callbackErr.name === "AbortError"
+                  ? "timeout"
+                  : String(callbackErr);
+              logHooks.warn(`hook responseUrl callback failed: ${errMsg}`);
+            }
+          }
+        }
+
         enqueueSystemEvent(`${prefix}: ${summary}`.trim(), {
           sessionKey: mainSessionKey,
         });
@@ -94,6 +185,47 @@ export function createGatewayHooksRequestHandler(params: {
         }
       } catch (err) {
         logHooks.warn(`hook agent failed: ${String(err)}`);
+
+        // Also callback on error if responseUrl provided
+        if (value.responseUrl) {
+          const urlValidation = validateResponseUrl(value.responseUrl);
+          if (urlValidation.ok) {
+            try {
+              const body = JSON.stringify({
+                runId,
+                status: "error",
+                error: String(err),
+                sessionKey,
+                jobId,
+                timestamp: Date.now(),
+              });
+              const headers: Record<string, string> = { "Content-Type": "application/json" };
+              if (value.responseSecret) {
+                headers["X-OpenClaw-Signature"] =
+                  `sha256=${signPayload(body, value.responseSecret)}`;
+              }
+              const controller = new AbortController();
+              const timeoutId = setTimeout(() => controller.abort(), RESPONSE_CALLBACK_TIMEOUT_MS);
+              try {
+                await fetch(urlValidation.url.href, {
+                  method: "POST",
+                  headers,
+                  body,
+                  signal: controller.signal,
+                });
+              } finally {
+                clearTimeout(timeoutId);
+              }
+            } catch (callbackErr) {
+              const errMsg =
+                callbackErr instanceof Error && callbackErr.name === "AbortError"
+                  ? "timeout"
+                  : String(callbackErr);
+              logHooks.warn(`hook responseUrl error callback failed: ${errMsg}`);
+            }
+          }
+        }
+
         enqueueSystemEvent(`Hook ${value.name} (error): ${String(err)}`, {
           sessionKey: mainSessionKey,
         });

--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -1,7 +1,13 @@
 import path from "node:path";
-import { finalizeInboundContext } from "../auto-reply/reply/inbound-context.js";
 import type { MsgContext } from "../auto-reply/templating.js";
 import type { OpenClawConfig } from "../config/config.js";
+import type {
+  MediaUnderstandingCapability,
+  MediaUnderstandingDecision,
+  MediaUnderstandingOutput,
+  MediaUnderstandingProvider,
+} from "./types.js";
+import { finalizeInboundContext } from "../auto-reply/reply/inbound-context.js";
 import { logVerbose, shouldLogVerbose } from "../globals.js";
 import {
   DEFAULT_INPUT_FILE_MAX_BYTES,
@@ -31,12 +37,6 @@ import {
   normalizeMediaAttachments,
   runCapability,
 } from "./runner.js";
-import type {
-  MediaUnderstandingCapability,
-  MediaUnderstandingDecision,
-  MediaUnderstandingOutput,
-  MediaUnderstandingProvider,
-} from "./types.js";
 
 export type ApplyMediaUnderstandingResult = {
   outputs: MediaUnderstandingOutput[];

--- a/src/media/input-files.ts
+++ b/src/media/input-files.ts
@@ -1,5 +1,5 @@
-import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
 import type { SsrFPolicy } from "../infra/net/ssrf.js";
+import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
 import { logWarn } from "../logger.js";
 import { estimateBase64DecodedBytes } from "./base64.js";
 import { readResponseWithLimit } from "./read-response-with-limit.js";


### PR DESCRIPTION
## Summary

- Adds optional `responseUrl` and `responseSecret` fields to hook agent payloads
- When `responseUrl` is set, OpenClaw POSTs the agent result (status, summary, outputText, error) back to the URL after the agent turn completes
- When `responseSecret` is set, the callback includes an `X-OpenClaw-Signature` HMAC-SHA256 header for verification
- SSRF protection: HTTPS-only, blocks private/reserved IP ranges (RFC 1918, loopback, link-local, IPv6 ULA)
- 10-second timeout on callback requests via AbortController
- Fields propagate through the full mapping pipeline (normalizeHookMapping, buildActionFromMapping, mergeAction) so mapping-triggered hooks also fire callbacks
- Added `responseUrl` and `responseSecret` to `HookMappingConfig` type

## Test plan

- [x] Direct `/hooks/agent` payload with `responseUrl` — callback fires on completion
- [x] Direct `/hooks/agent` payload with `responseUrl` + `responseSecret` — callback includes HMAC signature
- [ ] Mapping-triggered hook with `responseUrl` in config — callback fires
- [ ] SSRF: `responseUrl` pointing to private IP returns error
- [ ] SSRF: `responseUrl` with HTTP (not HTTPS) returns error
- [ ] Timeout: unresponsive `responseUrl` doesn't block indefinitely

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds optional `responseUrl` / `responseSecret` fields to hook agent payloads, enabling POST callbacks with HMAC-SHA256 signing after agent turns complete. Fields propagate through the full mapping pipeline.

- **SSRF protection is bypassable**: The custom hostname-based validation in `src/gateway/server/hooks.ts` only checks literal URL strings, not resolved IPs. Attacker-controlled domains resolving to private IPs (DNS rebinding) bypass the check entirely. The codebase already has robust SSRF protection in `src/infra/net/ssrf.ts` (`resolvePinnedHostnameWithPolicy` + `fetchWithSsrFGuard`) with DNS pinning — this should be used instead of the custom regex-based approach.
- **No early validation of `responseUrl`**: Invalid or SSRF-blocked URLs are silently accepted at request time (202 response), only failing later in async callback. Callers get no feedback that their callback URL is bad.
- **Callback logic duplication**: The ~40-line POST callback block is copy-pasted between success and error paths, increasing maintenance risk.

<h3>Confidence Score: 2/5</h3>

- The SSRF protection is insufficient and bypassable via DNS rebinding; this should be addressed before merging.
- The PR introduces a useful feature but the custom SSRF validation is vulnerable to DNS rebinding attacks, where an attacker-controlled domain resolves to private/internal IPs after passing the hostname string check. The codebase already has a robust SSRF solution (src/infra/net/ssrf.ts) with DNS pinning that should be used instead. Additionally, responseUrl validation happens only at callback time rather than at request intake, providing no feedback to callers.
- src/gateway/server/hooks.ts requires the most attention — its SSRF validation logic needs to be replaced with the existing robust implementation from src/infra/net/ssrf.ts

<sub>Last reviewed commit: 1cf4706</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->