### PR TITLE
feat: add FogClaw plugin -- PII detection & custom entity redaction

### DIFF
--- a/extensions/fogclaw/index.ts
+++ b/extensions/fogclaw/index.ts
@@ -1,0 +1,175 @@
+import { Scanner } from "./src/scanner.js";
+import { redact } from "./src/redactor.js";
+import { loadConfig } from "./src/config.js";
+import type { GuardrailAction } from "./src/types.js";
+
+const fogclaw = {
+  id: "fogclaw",
+  name: "FogClaw",
+  description: "PII detection & custom entity redaction powered by DataFog",
+
+  async register(api: any) {
+    const rawConfig = api.pluginConfig ?? {};
+    const config = loadConfig(rawConfig);
+
+    if (!config.enabled) {
+      api.logger?.info("[fogclaw] Plugin disabled via config");
+      return;
+    }
+
+    const scanner = new Scanner(config);
+    await scanner.initialize();
+
+    // --- HOOK: Guardrail on incoming messages ---
+    api.on("before_agent_start", async (event: any, ctx: any) => {
+      const message = event.query ?? event.message ?? "";
+      const result = await scanner.scan(message);
+
+      if (result.entities.length === 0) return;
+
+      // Check for any "block" actions
+      for (const entity of result.entities) {
+        const action: GuardrailAction =
+          config.entityActions[entity.label] ?? config.guardrail_mode;
+
+        if (action === "block") {
+          ctx?.reply?.(
+            `Message blocked: detected ${entity.label}. Please rephrase without sensitive information.`,
+          );
+          return { abort: true };
+        }
+      }
+
+      // Check for any "warn" actions
+      const warnings = result.entities.filter((e) => {
+        const action = config.entityActions[e.label] ?? config.guardrail_mode;
+        return action === "warn";
+      });
+      if (warnings.length > 0) {
+        const types = [...new Set(warnings.map((w) => w.label))].join(", ");
+        ctx?.notify?.(`PII detected: ${types}`);
+      }
+
+      // Apply redaction for "redact" action entities
+      const toRedact = result.entities.filter((e) => {
+        const action = config.entityActions[e.label] ?? config.guardrail_mode;
+        return action === "redact";
+      });
+      if (toRedact.length > 0) {
+        const redacted = redact(message, toRedact, config.redactStrategy);
+        return { prependContext: redacted.redacted_text };
+      }
+    });
+
+    // --- TOOL: On-demand scan ---
+    api.registerTool({
+      name: "fogclaw_scan",
+      label: "Scan for PII",
+      description:
+        "Scan text for PII and custom entities. Returns detected entities with types, positions, and confidence scores.",
+      parameters: {
+        type: "object",
+        properties: {
+          text: {
+            type: "string",
+            description: "Text to scan for entities",
+          },
+          custom_labels: {
+            type: "array",
+            items: { type: "string" },
+            description:
+              "Additional entity labels for zero-shot detection (e.g., ['competitor name', 'project codename'])",
+          },
+        },
+        required: ["text"],
+      },
+      async execute(
+        _toolCallId: string,
+        params: { text: string; custom_labels?: string[] },
+      ) {
+        const result = await scanner.scan(params.text, params.custom_labels);
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(
+                {
+                  entities: result.entities,
+                  count: result.entities.length,
+                  summary:
+                    result.entities.length > 0
+                      ? `Found ${result.entities.length} entities: ${[...new Set(result.entities.map((e) => e.label))].join(", ")}`
+                      : "No entities detected",
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      },
+    });
+
+    // --- TOOL: On-demand redact ---
+    api.registerTool({
+      name: "fogclaw_redact",
+      label: "Redact PII",
+      description:
+        "Scan and redact PII/custom entities from text. Returns sanitized text with entities replaced.",
+      parameters: {
+        type: "object",
+        properties: {
+          text: {
+            type: "string",
+            description: "Text to scan and redact",
+          },
+          strategy: {
+            type: "string",
+            description:
+              'Redaction strategy: "token" ([EMAIL_1]), "mask" (****), or "hash" ([EMAIL_a1b2c3...])',
+            enum: ["token", "mask", "hash"],
+          },
+          custom_labels: {
+            type: "array",
+            items: { type: "string" },
+            description: "Additional entity labels for zero-shot detection",
+          },
+        },
+        required: ["text"],
+      },
+      async execute(
+        _toolCallId: string,
+        params: { text: string; strategy?: "token" | "mask" | "hash"; custom_labels?: string[] },
+      ) {
+        const result = await scanner.scan(params.text, params.custom_labels);
+        const redacted = redact(
+          params.text,
+          result.entities,
+          params.strategy ?? config.redactStrategy,
+        );
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(
+                {
+                  redacted_text: redacted.redacted_text,
+                  entities_found: result.entities.length,
+                  mapping: redacted.mapping,
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      },
+    });
+
+    api.logger?.info(
+      `[fogclaw] Plugin registered — guardrail: ${config.guardrail_mode}, model: ${config.model}, custom entities: ${config.custom_entities.length}`,
+    );
+  },
+};
+
+export default fogclaw;

--- a/extensions/fogclaw/openclaw.plugin.json
+++ b/extensions/fogclaw/openclaw.plugin.json
@@ -1,0 +1,61 @@
+{
+  "id": "fogclaw",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "enabled": {
+        "type": "boolean"
+      },
+      "guardrail_mode": {
+        "type": "string",
+        "enum": ["redact", "block", "warn"]
+      },
+      "redactStrategy": {
+        "type": "string",
+        "enum": ["token", "mask", "hash"]
+      },
+      "model": {
+        "type": "string"
+      },
+      "confidence_threshold": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1
+      },
+      "custom_entities": {
+        "type": "array",
+        "items": { "type": "string" }
+      },
+      "entityActions": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string",
+          "enum": ["redact", "block", "warn"]
+        }
+      }
+    }
+  },
+  "uiHints": {
+    "guardrail_mode": {
+      "label": "Guardrail Mode",
+      "help": "Default action when PII is detected: redact, block, or warn."
+    },
+    "redactStrategy": {
+      "label": "Redaction Strategy",
+      "help": "How to redact: token ([EMAIL_1]), mask (****), or hash ([EMAIL_a1b2c3...])."
+    },
+    "model": {
+      "label": "GLiNER Model",
+      "help": "HuggingFace ONNX model path for zero-shot NER."
+    },
+    "confidence_threshold": {
+      "label": "Confidence Threshold",
+      "help": "Minimum confidence score for GLiNER detections (0-1)."
+    },
+    "custom_entities": {
+      "label": "Custom Entity Labels",
+      "help": "Additional entity types for zero-shot detection (e.g., 'project codename')."
+    }
+  }
+}

--- a/extensions/fogclaw/package.json
+++ b/extensions/fogclaw/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@openclaw/fogclaw",
+  "version": "2026.2.16",
+  "description": "OpenClaw PII detection & custom entity redaction plugin powered by DataFog",
+  "type": "module",
+  "dependencies": {
+    "gliner": "^0.0.19",
+    "onnxruntime-node": "^1.20.0"
+  },
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/fogclaw/src/config.ts
+++ b/extensions/fogclaw/src/config.ts
@@ -1,0 +1,46 @@
+import type { FogClawConfig, GuardrailAction, RedactStrategy } from "./types.js";
+
+const VALID_GUARDRAIL_MODES: GuardrailAction[] = ["redact", "block", "warn"];
+const VALID_REDACT_STRATEGIES: RedactStrategy[] = ["token", "mask", "hash"];
+
+export const DEFAULT_CONFIG: FogClawConfig = {
+  enabled: true,
+  guardrail_mode: "redact",
+  redactStrategy: "token",
+  model: "onnx-community/gliner_large-v2.1",
+  confidence_threshold: 0.5,
+  custom_entities: [],
+  entityActions: {},
+};
+
+export function loadConfig(overrides: Partial<FogClawConfig>): FogClawConfig {
+  const config: FogClawConfig = { ...DEFAULT_CONFIG, ...overrides };
+
+  if (!VALID_GUARDRAIL_MODES.includes(config.guardrail_mode)) {
+    throw new Error(
+      `Invalid guardrail_mode "${config.guardrail_mode}". Must be one of: ${VALID_GUARDRAIL_MODES.join(", ")}`,
+    );
+  }
+
+  if (!VALID_REDACT_STRATEGIES.includes(config.redactStrategy)) {
+    throw new Error(
+      `Invalid redactStrategy "${config.redactStrategy}". Must be one of: ${VALID_REDACT_STRATEGIES.join(", ")}`,
+    );
+  }
+
+  if (config.confidence_threshold < 0 || config.confidence_threshold > 1) {
+    throw new Error(
+      `confidence_threshold must be between 0 and 1, got ${config.confidence_threshold}`,
+    );
+  }
+
+  for (const [entityType, action] of Object.entries(config.entityActions)) {
+    if (!VALID_GUARDRAIL_MODES.includes(action)) {
+      throw new Error(
+        `Invalid action "${action}" for entity type "${entityType}". Must be one of: ${VALID_GUARDRAIL_MODES.join(", ")}`,
+      );
+    }
+  }
+
+  return config;
+}

--- a/extensions/fogclaw/src/engines/gliner.ts
+++ b/extensions/fogclaw/src/engines/gliner.ts
@@ -1,0 +1,88 @@
+import type { Entity } from "../types.js";
+import { canonicalType } from "../types.js";
+
+const DEFAULT_NER_LABELS = [
+  "person",
+  "organization",
+  "location",
+  "address",
+  "date of birth",
+  "medical record number",
+  "account number",
+  "passport number",
+];
+
+export class GlinerEngine {
+  private model: any = null;
+  private modelPath: string;
+  private threshold: number;
+  private customLabels: string[] = [];
+  private initialized = false;
+
+  constructor(modelPath: string, threshold: number = 0.5) {
+    this.modelPath = modelPath;
+    this.threshold = threshold;
+  }
+
+  async initialize(): Promise<void> {
+    if (this.initialized) return;
+
+    try {
+      const { Gliner } = await import("gliner");
+      this.model = new Gliner({
+        tokenizerPath: this.modelPath,
+        onnxSettings: {
+          modelPath: this.modelPath,
+          executionProvider: "cpu",
+        },
+        maxWidth: 12,
+        modelType: "gliner",
+      });
+      await this.model.initialize();
+      this.initialized = true;
+    } catch (err) {
+      throw new Error(
+        `Failed to initialize GLiNER model "${this.modelPath}": ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  setCustomLabels(labels: string[]): void {
+    this.customLabels = labels;
+  }
+
+  async scan(text: string, extraLabels?: string[]): Promise<Entity[]> {
+    if (!text) return [];
+    if (!this.model) {
+      throw new Error("GLiNER engine not initialized. Call initialize() first.");
+    }
+
+    const labels = [
+      ...DEFAULT_NER_LABELS,
+      ...this.customLabels,
+      ...(extraLabels ?? []),
+    ];
+
+    // Deduplicate labels
+    const uniqueLabels = [...new Set(labels)];
+
+    const results = await this.model.inference(text, uniqueLabels, {
+      threshold: this.threshold,
+    });
+
+    return results.map(
+      (r: { text: string; label: string; score: number; start: number; end: number }) => ({
+        text: r.text,
+        label: canonicalType(r.label),
+        start: r.start,
+        end: r.end,
+        confidence: r.score,
+        source: "gliner" as const,
+      }),
+    );
+  }
+
+  get isInitialized(): boolean {
+    return this.initialized;
+  }
+}

--- a/extensions/fogclaw/src/engines/regex.ts
+++ b/extensions/fogclaw/src/engines/regex.ts
@@ -1,0 +1,71 @@
+import type { Entity } from "../types.js";
+
+interface PatternDef {
+  label: string;
+  pattern: RegExp;
+}
+
+const PATTERNS: PatternDef[] = [
+  {
+    label: "EMAIL",
+    pattern:
+      /(?<![A-Za-z0-9._%+\-@])(?![A-Za-z_]{2,20}=)[A-Za-z0-9!#$%&*+\-/=^_`{|}~][A-Za-z0-9!#$%&'*+\-/=?^_`{|}~.]*@(?:\.?[A-Za-z0-9-]+\.)+[A-Za-z]{2,}(?=$|[^A-Za-z])/gi,
+  },
+  {
+    label: "PHONE",
+    pattern:
+      /(?<![A-Za-z0-9])(?:(?:(?:\+?1)[-.\s]?)?(?:\(\d{3}\)|\d{3})[-.\s]?\d{3}[-.\s]?\d{4}|\+\d{1,3}[\s\-.]?\d{1,4}(?:[\s\-.]?\d{2,4}){2,3})(?![-A-Za-z0-9])/gi,
+  },
+  {
+    label: "SSN",
+    pattern:
+      /(?<!\d)(?:(?!000|666)\d{3}-(?!00)\d{2}-(?!0000)\d{4}|(?!000|666)\d{3}(?!00)\d{2}(?!0000)\d{4})(?!\d)/g,
+  },
+  {
+    label: "CREDIT_CARD",
+    pattern:
+      /\b(?:4\d{12}(?:\d{3})?|5[1-5]\d{14}|3[47]\d{13}|(?:(?:4\d{3}|5[1-5]\d{2}|3[47]\d{2})[-\s]?\d{4}[-\s]?\d{4}[-\s]?\d{4})|(?:3[47]\d{2}[-\s]?\d{6}[-\s]?\d{5}))\b/g,
+  },
+  {
+    label: "IP_ADDRESS",
+    pattern:
+      /\b(?:(?:25[0-5]|2[0-4]\d|1?\d?\d)\.(?:25[0-5]|2[0-4]\d|1?\d?\d)\.(?:25[0-5]|2[0-4]\d|1?\d?\d)\.(?:25[0-5]|2[0-4]\d|1?\d?\d))\b/g,
+  },
+  {
+    label: "DATE",
+    pattern:
+      /\b(?:(?:0?[1-9]|1[0-2])[/-](?:0?[1-9]|[12]\d|3[01])[/-](?:\d{2}|\d{4})|(?:\d{4})-(?:0?[1-9]|1[0-2])-(?:0?[1-9]|[12]\d|3[01])|(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:t(?:ember)?)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\s+(?:0?[1-9]|[12]\d|3[01]),\s+(?:19|20)\d{2})\b/gi,
+  },
+  {
+    label: "ZIP_CODE",
+    pattern: /\b\d{5}(?:-\d{4})?\b/g,
+  },
+];
+
+export class RegexEngine {
+  scan(text: string): Entity[] {
+    const entities: Entity[] = [];
+
+    for (const { label, pattern } of PATTERNS) {
+      // Reset lastIndex to avoid stale state from previous calls
+      pattern.lastIndex = 0;
+
+      let match: RegExpExecArray | null;
+      while ((match = pattern.exec(text)) !== null) {
+        entities.push({
+          text: match[0],
+          label,
+          start: match.index,
+          end: match.index + match[0].length,
+          confidence: 1.0,
+          source: "regex",
+        });
+      }
+    }
+
+    // Sort by start position for deterministic output
+    entities.sort((a, b) => a.start - b.start || a.end - b.end);
+
+    return entities;
+  }
+}

--- a/extensions/fogclaw/src/redactor.ts
+++ b/extensions/fogclaw/src/redactor.ts
@@ -1,0 +1,51 @@
+import { createHash } from "node:crypto";
+import type { Entity, RedactResult, RedactStrategy } from "./types.js";
+
+export function redact(
+  text: string,
+  entities: Entity[],
+  strategy: RedactStrategy = "token",
+): RedactResult {
+  if (entities.length === 0) {
+    return { redacted_text: text, mapping: {}, entities: [] };
+  }
+
+  // Sort by start position descending so we replace from end to start
+  // without corrupting earlier offsets
+  const sorted = [...entities].sort((a, b) => b.start - a.start);
+
+  const counters: Record<string, number> = {};
+  const mapping: Record<string, string> = {};
+  let result = text;
+
+  for (const entity of sorted) {
+    const replacement = makeReplacement(entity, strategy, counters);
+    mapping[replacement] = entity.text;
+    result = result.slice(0, entity.start) + replacement + result.slice(entity.end);
+  }
+
+  return { redacted_text: result, mapping, entities };
+}
+
+function makeReplacement(
+  entity: Entity,
+  strategy: RedactStrategy,
+  counters: Record<string, number>,
+): string {
+  switch (strategy) {
+    case "token": {
+      counters[entity.label] = (counters[entity.label] ?? 0) + 1;
+      return `[${entity.label}_${counters[entity.label]}]`;
+    }
+    case "mask": {
+      return "*".repeat(Math.max(entity.text.length, 1));
+    }
+    case "hash": {
+      const digest = createHash("sha256")
+        .update(entity.text)
+        .digest("hex")
+        .slice(0, 12);
+      return `[${entity.label}_${digest}]`;
+    }
+  }
+}

--- a/extensions/fogclaw/src/scanner.ts
+++ b/extensions/fogclaw/src/scanner.ts
@@ -1,0 +1,90 @@
+import type { Entity, FogClawConfig, ScanResult } from "./types.js";
+import { RegexEngine } from "./engines/regex.js";
+import { GlinerEngine } from "./engines/gliner.js";
+
+export class Scanner {
+  private regexEngine: RegexEngine;
+  private glinerEngine: GlinerEngine;
+  private glinerAvailable = false;
+  private config: FogClawConfig;
+
+  constructor(config: FogClawConfig) {
+    this.config = config;
+    this.regexEngine = new RegexEngine();
+    this.glinerEngine = new GlinerEngine(
+      config.model,
+      config.confidence_threshold,
+    );
+    if (config.custom_entities.length > 0) {
+      this.glinerEngine.setCustomLabels(config.custom_entities);
+    }
+  }
+
+  async initialize(): Promise<void> {
+    try {
+      await this.glinerEngine.initialize();
+      this.glinerAvailable = true;
+    } catch (err) {
+      console.warn(
+        `[fogclaw] GLiNER failed to initialize, falling back to regex-only mode: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      this.glinerAvailable = false;
+    }
+  }
+
+  async scan(text: string, extraLabels?: string[]): Promise<ScanResult> {
+    if (!text) return { entities: [], text };
+
+    // Step 1: Regex pass (always runs, synchronous)
+    const regexEntities = this.regexEngine.scan(text);
+
+    // Step 2: GLiNER pass (if available)
+    let glinerEntities: Entity[] = [];
+    if (this.glinerAvailable) {
+      try {
+        glinerEntities = await this.glinerEngine.scan(text, extraLabels);
+      } catch (err) {
+        console.warn(`[fogclaw] GLiNER scan failed, using regex results only: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+
+    // Step 3: Merge and deduplicate
+    const merged = deduplicateEntities([...regexEntities, ...glinerEntities]);
+
+    return { entities: merged, text };
+  }
+}
+
+/**
+ * Remove overlapping entity spans. When two entities overlap,
+ * keep the one with higher confidence. If equal, prefer regex.
+ */
+function deduplicateEntities(entities: Entity[]): Entity[] {
+  if (entities.length <= 1) return entities;
+
+  // Sort by start position, then by confidence descending
+  const sorted = [...entities].sort((a, b) => {
+    if (a.start !== b.start) return a.start - b.start;
+    return b.confidence - a.confidence;
+  });
+
+  const result: Entity[] = [sorted[0]];
+
+  for (let i = 1; i < sorted.length; i++) {
+    const current = sorted[i];
+    const last = result[result.length - 1];
+
+    // Check for overlap
+    if (current.start < last.end) {
+      // Overlapping: keep higher confidence (already in result if first)
+      if (current.confidence > last.confidence) {
+        result[result.length - 1] = current;
+      }
+      // Otherwise keep what's already in result
+    } else {
+      result.push(current);
+    }
+  }
+
+  return result;
+}

--- a/extensions/fogclaw/src/types.ts
+++ b/extensions/fogclaw/src/types.ts
@@ -1,0 +1,52 @@
+export interface Entity {
+  text: string;
+  label: string;
+  start: number;
+  end: number;
+  confidence: number;
+  source: "regex" | "gliner";
+}
+
+export type RedactStrategy = "token" | "mask" | "hash";
+
+export type GuardrailAction = "redact" | "block" | "warn";
+
+export interface FogClawConfig {
+  enabled: boolean;
+  guardrail_mode: GuardrailAction;
+  redactStrategy: RedactStrategy;
+  model: string;
+  confidence_threshold: number;
+  custom_entities: string[];
+  entityActions: Record<string, GuardrailAction>;
+}
+
+export interface ScanResult {
+  entities: Entity[];
+  text: string;
+}
+
+export interface RedactResult {
+  redacted_text: string;
+  mapping: Record<string, string>;
+  entities: Entity[];
+}
+
+export const CANONICAL_TYPE_MAP: Record<string, string> = {
+  DOB: "DATE",
+  ZIP: "ZIP_CODE",
+  PER: "PERSON",
+  ORG: "ORGANIZATION",
+  GPE: "LOCATION",
+  LOC: "LOCATION",
+  FAC: "ADDRESS",
+  PHONE_NUMBER: "PHONE",
+  SOCIAL_SECURITY_NUMBER: "SSN",
+  CREDIT_CARD_NUMBER: "CREDIT_CARD",
+  DATE_OF_BIRTH: "DATE",
+};
+
+export function canonicalType(entityType: string): string {
+  const normalized = entityType.toUpperCase().trim();
+  return CANONICAL_TYPE_MAP[normalized] ?? normalized;
+}

--- a/extensions/fogclaw/tests/config.test.ts
+++ b/extensions/fogclaw/tests/config.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import { loadConfig, DEFAULT_CONFIG } from "../src/config.js";
+
+describe("loadConfig", () => {
+  it("returns defaults when no overrides are provided", () => {
+    const config = loadConfig({});
+    expect(config).toEqual(DEFAULT_CONFIG);
+  });
+
+  it("merges partial overrides with defaults", () => {
+    const config = loadConfig({ guardrail_mode: "block", confidence_threshold: 0.8 });
+
+    expect(config.guardrail_mode).toBe("block");
+    expect(config.confidence_threshold).toBe(0.8);
+    // Unset defaults are preserved
+    expect(config.enabled).toBe(true);
+    expect(config.redactStrategy).toBe("token");
+    expect(config.model).toBe("onnx-community/gliner_large-v2.1");
+    expect(config.custom_entities).toEqual([]);
+    expect(config.entityActions).toEqual({});
+  });
+
+  it("accepts all valid guardrail_mode values", () => {
+    expect(() => loadConfig({ guardrail_mode: "redact" })).not.toThrow();
+    expect(() => loadConfig({ guardrail_mode: "block" })).not.toThrow();
+    expect(() => loadConfig({ guardrail_mode: "warn" })).not.toThrow();
+  });
+
+  it("rejects invalid guardrail_mode", () => {
+    expect(() =>
+      loadConfig({ guardrail_mode: "invalid" as never }),
+    ).toThrowError(
+      'Invalid guardrail_mode "invalid". Must be one of: redact, block, warn',
+    );
+  });
+
+  it("accepts all valid redactStrategy values", () => {
+    expect(() => loadConfig({ redactStrategy: "token" })).not.toThrow();
+    expect(() => loadConfig({ redactStrategy: "mask" })).not.toThrow();
+    expect(() => loadConfig({ redactStrategy: "hash" })).not.toThrow();
+  });
+
+  it("rejects invalid redactStrategy", () => {
+    expect(() =>
+      loadConfig({ redactStrategy: "plaintext" as never }),
+    ).toThrowError(
+      'Invalid redactStrategy "plaintext". Must be one of: token, mask, hash',
+    );
+  });
+
+  it("accepts confidence_threshold at boundaries (0 and 1)", () => {
+    expect(() => loadConfig({ confidence_threshold: 0 })).not.toThrow();
+    expect(() => loadConfig({ confidence_threshold: 1 })).not.toThrow();
+    expect(() => loadConfig({ confidence_threshold: 0.5 })).not.toThrow();
+  });
+
+  it("rejects confidence_threshold below 0", () => {
+    expect(() =>
+      loadConfig({ confidence_threshold: -0.1 }),
+    ).toThrowError("confidence_threshold must be between 0 and 1, got -0.1");
+  });
+
+  it("rejects confidence_threshold above 1", () => {
+    expect(() =>
+      loadConfig({ confidence_threshold: 1.5 }),
+    ).toThrowError("confidence_threshold must be between 0 and 1, got 1.5");
+  });
+
+  it("accepts valid entityActions values", () => {
+    const config = loadConfig({
+      entityActions: { PERSON: "redact", EMAIL: "block", SSN: "warn" },
+    });
+    expect(config.entityActions).toEqual({
+      PERSON: "redact",
+      EMAIL: "block",
+      SSN: "warn",
+    });
+  });
+
+  it("rejects invalid entityActions values", () => {
+    expect(() =>
+      loadConfig({
+        entityActions: { EMAIL: "delete" as never },
+      }),
+    ).toThrowError(
+      'Invalid action "delete" for entity type "EMAIL". Must be one of: redact, block, warn',
+    );
+  });
+
+  it("preserves custom_entities from overrides", () => {
+    const config = loadConfig({ custom_entities: ["EMPLOYEE_ID", "PROJECT_CODE"] });
+    expect(config.custom_entities).toEqual(["EMPLOYEE_ID", "PROJECT_CODE"]);
+  });
+
+  it("preserves model from overrides", () => {
+    const config = loadConfig({ model: "custom/my-model" });
+    expect(config.model).toBe("custom/my-model");
+  });
+
+  it("allows disabling via enabled: false", () => {
+    const config = loadConfig({ enabled: false });
+    expect(config.enabled).toBe(false);
+  });
+});

--- a/extensions/fogclaw/tests/gliner.test.ts
+++ b/extensions/fogclaw/tests/gliner.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the gliner npm package so we don't need the actual 1.4GB model
+vi.mock("gliner", () => {
+  class MockGliner {
+    private config: any;
+
+    constructor(config: any) {
+      this.config = config;
+    }
+
+    async initialize(): Promise<void> {
+      // No-op in mock
+    }
+
+    async inference(
+      text: string,
+      labels: string[],
+      options: { threshold: number },
+    ): Promise<Array<{ text: string; label: string; score: number; start: number; end: number }>> {
+      const results: Array<{ text: string; label: string; score: number; start: number; end: number }> = [];
+
+      // Simulate entity detection for "John Smith"
+      const johnIndex = text.indexOf("John Smith");
+      if (johnIndex !== -1 && labels.includes("person")) {
+        results.push({
+          text: "John Smith",
+          label: "person",
+          score: 0.95,
+          start: johnIndex,
+          end: johnIndex + "John Smith".length,
+        });
+      }
+
+      // Simulate entity detection for "Acme Corp"
+      const acmeIndex = text.indexOf("Acme Corp");
+      if (acmeIndex !== -1 && labels.includes("organization")) {
+        results.push({
+          text: "Acme Corp",
+          label: "organization",
+          score: 0.88,
+          start: acmeIndex,
+          end: acmeIndex + "Acme Corp".length,
+        });
+      }
+
+      // Simulate entity detection for "New York"
+      const nyIndex = text.indexOf("New York");
+      if (nyIndex !== -1 && labels.includes("location")) {
+        results.push({
+          text: "New York",
+          label: "location",
+          score: 0.91,
+          start: nyIndex,
+          end: nyIndex + "New York".length,
+        });
+      }
+
+      return results;
+    }
+  }
+
+  return { Gliner: MockGliner };
+});
+
+import { GlinerEngine } from "../src/engines/gliner.js";
+
+describe("GlinerEngine", () => {
+  let engine: GlinerEngine;
+
+  beforeEach(async () => {
+    engine = new GlinerEngine("onnx-community/gliner_small-v2.5", 0.5);
+    await engine.initialize();
+  });
+
+  it("detects person entities with canonical PERSON label", async () => {
+    const entities = await engine.scan("My name is John Smith and I live here.");
+
+    expect(entities).toHaveLength(1);
+    expect(entities[0].text).toBe("John Smith");
+    expect(entities[0].label).toBe("PERSON");
+  });
+
+  it("detects organization entities with canonical ORGANIZATION label", async () => {
+    const entities = await engine.scan("I work at Acme Corp downtown.");
+
+    expect(entities).toHaveLength(1);
+    expect(entities[0].text).toBe("Acme Corp");
+    expect(entities[0].label).toBe("ORGANIZATION");
+  });
+
+  it("detects multiple entity types in the same text", async () => {
+    const entities = await engine.scan(
+      "John Smith works at Acme Corp in New York.",
+    );
+
+    expect(entities).toHaveLength(3);
+
+    const labels = entities.map((e) => e.label);
+    expect(labels).toContain("PERSON");
+    expect(labels).toContain("ORGANIZATION");
+    expect(labels).toContain("LOCATION");
+  });
+
+  it("returns empty array for text with no entities", async () => {
+    const entities = await engine.scan("Hello world, this is a test.");
+
+    expect(entities).toEqual([]);
+  });
+
+  it("returns empty array for empty string input", async () => {
+    const entities = await engine.scan("");
+
+    expect(entities).toEqual([]);
+  });
+
+  it("allows setting custom labels without crashing", async () => {
+    expect(() => engine.setCustomLabels(["product", "event"])).not.toThrow();
+
+    // Scan still works after setting custom labels
+    const entities = await engine.scan("John Smith attended the event.");
+    expect(entities).toHaveLength(1);
+    expect(entities[0].label).toBe("PERSON");
+  });
+
+  it("applies canonical type mapping (lowercase person -> PERSON)", async () => {
+    // The mock returns lowercase "person" as label; canonicalType should map it to "PERSON"
+    const entities = await engine.scan("John Smith is here.");
+
+    expect(entities[0].label).toBe("PERSON");
+    // Verify it's not lowercase
+    expect(entities[0].label).not.toBe("person");
+  });
+
+  it("sets source to gliner for all detected entities", async () => {
+    const entities = await engine.scan(
+      "John Smith works at Acme Corp in New York.",
+    );
+
+    for (const entity of entities) {
+      expect(entity.source).toBe("gliner");
+    }
+  });
+
+  it("confidence comes from model score", async () => {
+    const entities = await engine.scan(
+      "John Smith works at Acme Corp in New York.",
+    );
+
+    const person = entities.find((e) => e.label === "PERSON");
+    const org = entities.find((e) => e.label === "ORGANIZATION");
+    const loc = entities.find((e) => e.label === "LOCATION");
+
+    // These match the scores set in our mock
+    expect(person?.confidence).toBe(0.95);
+    expect(org?.confidence).toBe(0.88);
+    expect(loc?.confidence).toBe(0.91);
+  });
+
+  it("throws if scan is called before initialize", async () => {
+    const uninitializedEngine = new GlinerEngine("some-model", 0.5);
+
+    await expect(uninitializedEngine.scan("test")).rejects.toThrow(
+      "GLiNER engine not initialized. Call initialize() first.",
+    );
+  });
+
+  it("reports isInitialized correctly", async () => {
+    const freshEngine = new GlinerEngine("some-model", 0.5);
+    expect(freshEngine.isInitialized).toBe(false);
+
+    await freshEngine.initialize();
+    expect(freshEngine.isInitialized).toBe(true);
+  });
+
+  it("includes correct start and end offsets", async () => {
+    const text = "Contact John Smith for details.";
+    const entities = await engine.scan(text);
+
+    expect(entities).toHaveLength(1);
+    expect(entities[0].start).toBe(8); // "Contact " is 8 chars
+    expect(entities[0].end).toBe(18); // 8 + "John Smith".length = 18
+  });
+});

--- a/extensions/fogclaw/tests/redactor.test.ts
+++ b/extensions/fogclaw/tests/redactor.test.ts
@@ -1,0 +1,320 @@
+import { describe, it, expect } from "vitest";
+import { createHash } from "node:crypto";
+import { redact } from "../src/redactor.js";
+import type { Entity } from "../src/types.js";
+
+// Helper to build Entity objects concisely
+function entity(
+  text: string,
+  label: string,
+  start: number,
+  end: number,
+  source: "regex" | "gliner" = "regex",
+  confidence = 1.0,
+): Entity {
+  return { text, label, start, end, confidence, source };
+}
+
+describe("redact", () => {
+  // ── token strategy ──────────────────────────────────────────────
+
+  describe("token strategy", () => {
+    it("replaces a single EMAIL entity with [EMAIL_1]", () => {
+      const text = "Contact john@example.com for info.";
+      const entities: Entity[] = [
+        entity("john@example.com", "EMAIL", 8, 24),
+      ];
+
+      const result = redact(text, entities, "token");
+
+      expect(result.redacted_text).toBe("Contact [EMAIL_1] for info.");
+    });
+
+    it("replaces a single PHONE entity with [PHONE_1]", () => {
+      const text = "Call 555-123-4567 now.";
+      const entities: Entity[] = [
+        entity("555-123-4567", "PHONE", 5, 17),
+      ];
+
+      const result = redact(text, entities, "token");
+
+      expect(result.redacted_text).toBe("Call [PHONE_1] now.");
+    });
+
+    it("increments counter for multiple entities of the same type", () => {
+      const text = "Email alice@a.com and bob@b.com please.";
+      const entities: Entity[] = [
+        entity("alice@a.com", "EMAIL", 6, 17),
+        entity("bob@b.com", "EMAIL", 22, 31),
+      ];
+
+      const result = redact(text, entities, "token");
+
+      // Processing order is descending by start position, so bob@b.com
+      // (start=22) gets [EMAIL_1] and alice@a.com (start=6) gets [EMAIL_2]
+      expect(result.redacted_text).toBe(
+        "Email [EMAIL_2] and [EMAIL_1] please.",
+      );
+      expect(result.mapping["[EMAIL_1]"]).toBe("bob@b.com");
+      expect(result.mapping["[EMAIL_2]"]).toBe("alice@a.com");
+    });
+
+    it("uses separate counters for different entity types", () => {
+      const text = "Email john@example.com or call 555-0000.";
+      const entities: Entity[] = [
+        entity("john@example.com", "EMAIL", 6, 22),
+        entity("555-0000", "PHONE", 31, 39),
+      ];
+
+      const result = redact(text, entities, "token");
+
+      expect(result.redacted_text).toBe(
+        "Email [EMAIL_1] or call [PHONE_1].",
+      );
+    });
+
+    it("defaults to token strategy when none is specified", () => {
+      const text = "Hi john@example.com";
+      const entities: Entity[] = [
+        entity("john@example.com", "EMAIL", 3, 19),
+      ];
+
+      const result = redact(text, entities);
+
+      expect(result.redacted_text).toBe("Hi [EMAIL_1]");
+    });
+  });
+
+  // ── mask strategy ───────────────────────────────────────────────
+
+  describe("mask strategy", () => {
+    it("replaces entity with asterisks matching original length", () => {
+      const text = "Contact john@example.com for info.";
+      //                     ^               ^
+      //                     8              24 (16 chars)
+      const entities: Entity[] = [
+        entity("john@example.com", "EMAIL", 8, 24),
+      ];
+
+      const result = redact(text, entities, "mask");
+
+      expect(result.redacted_text).toBe("Contact **************** for info.");
+      // "john@example.com" is 16 chars -> 16 asterisks
+      expect(result.redacted_text.slice(8, 24)).toBe("*".repeat(16));
+    });
+
+    it("uses at least one asterisk for empty-text entity", () => {
+      const text = "A B";
+      const entities: Entity[] = [
+        entity("", "UNKNOWN", 1, 1),
+      ];
+
+      const result = redact(text, entities, "mask");
+
+      expect(result.redacted_text).toBe("A* B");
+    });
+
+    it("masks multiple entities independently", () => {
+      const text = "Name: Alice, Phone: 12345";
+      const entities: Entity[] = [
+        entity("Alice", "PERSON", 6, 11),
+        entity("12345", "PHONE", 20, 25),
+      ];
+
+      const result = redact(text, entities, "mask");
+
+      expect(result.redacted_text).toBe("Name: *****, Phone: *****");
+    });
+  });
+
+  // ── hash strategy ───────────────────────────────────────────────
+
+  describe("hash strategy", () => {
+    it("replaces entity with [LABEL_sha256prefix]", () => {
+      const text = "Contact john@example.com for info.";
+      const entities: Entity[] = [
+        entity("john@example.com", "EMAIL", 8, 24),
+      ];
+
+      const expectedDigest = createHash("sha256")
+        .update("john@example.com")
+        .digest("hex")
+        .slice(0, 12);
+
+      const result = redact(text, entities, "hash");
+
+      expect(result.redacted_text).toBe(
+        `Contact [EMAIL_${expectedDigest}] for info.`,
+      );
+    });
+
+    it("produces consistent hashes across calls", () => {
+      const text = "Hi john@example.com";
+      const entities: Entity[] = [
+        entity("john@example.com", "EMAIL", 3, 19),
+      ];
+
+      const r1 = redact(text, entities, "hash");
+      const r2 = redact(text, entities, "hash");
+
+      expect(r1.redacted_text).toBe(r2.redacted_text);
+    });
+
+    it("produces different hashes for different entity text", () => {
+      const text1 = "Hi alice@a.com";
+      const text2 = "Hi bobby@b.com";
+      const e1: Entity[] = [entity("alice@a.com", "EMAIL", 3, 14)];
+      const e2: Entity[] = [entity("bobby@b.com", "EMAIL", 3, 14)];
+
+      const r1 = redact(text1, e1, "hash");
+      const r2 = redact(text2, e2, "hash");
+
+      expect(r1.redacted_text).not.toBe(r2.redacted_text);
+    });
+  });
+
+  // ── mapping ─────────────────────────────────────────────────────
+
+  describe("mapping", () => {
+    it("maps replacement tokens back to original text (token strategy)", () => {
+      const text = "Email john@example.com or call 555-0000.";
+      const entities: Entity[] = [
+        entity("john@example.com", "EMAIL", 6, 22),
+        entity("555-0000", "PHONE", 31, 39),
+      ];
+
+      const result = redact(text, entities, "token");
+
+      expect(result.mapping).toEqual({
+        "[EMAIL_1]": "john@example.com",
+        "[PHONE_1]": "555-0000",
+      });
+    });
+
+    it("maps replacement masks back to original text (mask strategy)", () => {
+      const text = "Call 555-0000 now.";
+      const entities: Entity[] = [
+        entity("555-0000", "PHONE", 5, 13),
+      ];
+
+      const result = redact(text, entities, "mask");
+
+      expect(result.mapping["********"]).toBe("555-0000");
+    });
+
+    it("maps replacement hashes back to original text (hash strategy)", () => {
+      const text = "Hi Alice";
+      const entities: Entity[] = [
+        entity("Alice", "PERSON", 3, 8),
+      ];
+
+      const result = redact(text, entities, "hash");
+
+      const digest = createHash("sha256")
+        .update("Alice")
+        .digest("hex")
+        .slice(0, 12);
+      expect(result.mapping[`[PERSON_${digest}]`]).toBe("Alice");
+    });
+  });
+
+  // ── empty entities ──────────────────────────────────────────────
+
+  describe("empty entities", () => {
+    it("returns original text unchanged when entities array is empty", () => {
+      const text = "Nothing to redact here.";
+
+      const result = redact(text, []);
+
+      expect(result.redacted_text).toBe(text);
+      expect(result.mapping).toEqual({});
+      expect(result.entities).toEqual([]);
+    });
+
+    it("returns original text with all strategies when no entities", () => {
+      const text = "Still nothing.";
+
+      for (const strategy of ["token", "mask", "hash"] as const) {
+        const result = redact(text, [], strategy);
+        expect(result.redacted_text).toBe(text);
+        expect(result.mapping).toEqual({});
+      }
+    });
+  });
+
+  // ── entity ordering / offset integrity ──────────────────────────
+
+  describe("entity ordering", () => {
+    it("handles entities given in reverse order without offset corruption", () => {
+      const text = "Name: Alice, Email: alice@a.com";
+      const entities: Entity[] = [
+        // Provided in reverse order (end of string first)
+        entity("alice@a.com", "EMAIL", 20, 31),
+        entity("Alice", "PERSON", 6, 11),
+      ];
+
+      const result = redact(text, entities, "token");
+
+      expect(result.redacted_text).toBe(
+        "Name: [PERSON_1], Email: [EMAIL_1]",
+      );
+    });
+
+    it("handles entities given in forward order without offset corruption", () => {
+      const text = "Name: Alice, Email: alice@a.com";
+      const entities: Entity[] = [
+        entity("Alice", "PERSON", 6, 11),
+        entity("alice@a.com", "EMAIL", 20, 31),
+      ];
+
+      const result = redact(text, entities, "token");
+
+      expect(result.redacted_text).toBe(
+        "Name: [PERSON_1], Email: [EMAIL_1]",
+      );
+    });
+
+    it("handles three entities in random order", () => {
+      const text = "A: Alice B: bob@b.com C: 555-0000";
+      const entities: Entity[] = [
+        entity("bob@b.com", "EMAIL", 12, 21),
+        entity("555-0000", "PHONE", 25, 33),
+        entity("Alice", "PERSON", 3, 8),
+      ];
+
+      const result = redact(text, entities, "token");
+
+      expect(result.redacted_text).toBe(
+        "A: [PERSON_1] B: [EMAIL_1] C: [PHONE_1]",
+      );
+    });
+
+    it("does not mutate the original entities array", () => {
+      const text = "Name: Alice, Email: alice@a.com";
+      const entities: Entity[] = [
+        entity("alice@a.com", "EMAIL", 20, 31),
+        entity("Alice", "PERSON", 6, 11),
+      ];
+      const originalOrder = [...entities];
+
+      redact(text, entities, "token");
+
+      expect(entities).toEqual(originalOrder);
+    });
+  });
+
+  // ── returned entities ───────────────────────────────────────────
+
+  describe("returned entities", () => {
+    it("returns the original entities array in the result", () => {
+      const text = "Hi john@example.com";
+      const entities: Entity[] = [
+        entity("john@example.com", "EMAIL", 3, 19),
+      ];
+
+      const result = redact(text, entities, "token");
+
+      expect(result.entities).toBe(entities);
+    });
+  });
+});

--- a/extensions/fogclaw/tests/regex.test.ts
+++ b/extensions/fogclaw/tests/regex.test.ts
@@ -1,0 +1,345 @@
+import { describe, it, expect } from "vitest";
+import { RegexEngine } from "../src/engines/regex.js";
+
+const engine = new RegexEngine();
+
+/** Helper: assert every returned entity has correct span offsets */
+function assertSpans(text: string) {
+  const entities = engine.scan(text);
+  for (const e of entities) {
+    expect(text.slice(e.start, e.end)).toBe(e.text);
+  }
+  return entities;
+}
+
+// ---------------------------------------------------------------------------
+// EMAIL
+// ---------------------------------------------------------------------------
+describe("EMAIL", () => {
+  it("detects a simple email", () => {
+    const entities = assertSpans("Contact alice@example.com for info.");
+    const emails = entities.filter((e) => e.label === "EMAIL");
+    expect(emails).toHaveLength(1);
+    expect(emails[0].text).toBe("alice@example.com");
+    expect(emails[0].confidence).toBe(1.0);
+    expect(emails[0].source).toBe("regex");
+  });
+
+  it("detects email with subdomains", () => {
+    const entities = assertSpans("Send to bob@mail.example.co.uk now");
+    const emails = entities.filter((e) => e.label === "EMAIL");
+    expect(emails).toHaveLength(1);
+    expect(emails[0].text).toBe("bob@mail.example.co.uk");
+  });
+
+  it("detects email with special chars in local part", () => {
+    const entities = assertSpans("user+tag@example.org");
+    const emails = entities.filter((e) => e.label === "EMAIL");
+    expect(emails).toHaveLength(1);
+    expect(emails[0].text).toBe("user+tag@example.org");
+  });
+
+  it("does not match bare @-signs or partial addresses", () => {
+    const entities = engine.scan("@ or foo@ or @bar");
+    const emails = entities.filter((e) => e.label === "EMAIL");
+    expect(emails).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PHONE
+// ---------------------------------------------------------------------------
+describe("PHONE", () => {
+  it("detects US phone with dashes", () => {
+    const entities = assertSpans("Call 555-123-4567 today.");
+    const phones = entities.filter((e) => e.label === "PHONE");
+    expect(phones).toHaveLength(1);
+    expect(phones[0].text).toBe("555-123-4567");
+  });
+
+  it("detects US phone with parentheses", () => {
+    const entities = assertSpans("Phone: (555) 123-4567");
+    const phones = entities.filter((e) => e.label === "PHONE");
+    expect(phones).toHaveLength(1);
+    expect(phones[0].text).toBe("(555) 123-4567");
+  });
+
+  it("detects +1 prefix", () => {
+    const entities = assertSpans("Reach me at +1-800-555-1234.");
+    const phones = entities.filter((e) => e.label === "PHONE");
+    expect(phones).toHaveLength(1);
+    expect(phones[0].text).toBe("+1-800-555-1234");
+  });
+
+  it("detects international format", () => {
+    const entities = assertSpans("Number: +44 20 7946 0958");
+    const phones = entities.filter((e) => e.label === "PHONE");
+    expect(phones).toHaveLength(1);
+    expect(phones[0].text).toBe("+44 20 7946 0958");
+  });
+
+  it("does not match short digit sequences", () => {
+    const entities = engine.scan("Code 12345 here");
+    const phones = entities.filter((e) => e.label === "PHONE");
+    expect(phones).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SSN
+// ---------------------------------------------------------------------------
+describe("SSN", () => {
+  it("detects a valid SSN with dashes", () => {
+    const entities = assertSpans("SSN: 123-45-6789");
+    const ssns = entities.filter((e) => e.label === "SSN");
+    expect(ssns).toHaveLength(1);
+    expect(ssns[0].text).toBe("123-45-6789");
+  });
+
+  it("detects a valid SSN without dashes", () => {
+    const entities = assertSpans("SSN 123456789 filed.");
+    const ssns = entities.filter((e) => e.label === "SSN");
+    expect(ssns).toHaveLength(1);
+    expect(ssns[0].text).toBe("123456789");
+  });
+
+  it("rejects SSN starting with 000", () => {
+    const entities = engine.scan("Invalid SSN 000-12-3456");
+    const ssns = entities.filter((e) => e.label === "SSN");
+    expect(ssns).toHaveLength(0);
+  });
+
+  it("rejects SSN starting with 666", () => {
+    const entities = engine.scan("Invalid SSN 666-12-3456");
+    const ssns = entities.filter((e) => e.label === "SSN");
+    expect(ssns).toHaveLength(0);
+  });
+
+  it("rejects SSN with 00 in middle group", () => {
+    const entities = engine.scan("Invalid SSN 123-00-6789");
+    const ssns = entities.filter((e) => e.label === "SSN");
+    expect(ssns).toHaveLength(0);
+  });
+
+  it("rejects SSN with 0000 in last group", () => {
+    const entities = engine.scan("Invalid SSN 123-45-0000");
+    const ssns = entities.filter((e) => e.label === "SSN");
+    expect(ssns).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CREDIT_CARD
+// ---------------------------------------------------------------------------
+describe("CREDIT_CARD", () => {
+  it("detects a Visa card (16 digits)", () => {
+    const entities = assertSpans("Card: 4111111111111111");
+    const cards = entities.filter((e) => e.label === "CREDIT_CARD");
+    expect(cards).toHaveLength(1);
+    expect(cards[0].text).toBe("4111111111111111");
+  });
+
+  it("detects a Mastercard", () => {
+    const entities = assertSpans("MC 5500000000000004");
+    const cards = entities.filter((e) => e.label === "CREDIT_CARD");
+    expect(cards).toHaveLength(1);
+    expect(cards[0].text).toBe("5500000000000004");
+  });
+
+  it("detects an Amex card", () => {
+    const entities = assertSpans("Amex 378282246310005");
+    const cards = entities.filter((e) => e.label === "CREDIT_CARD");
+    expect(cards).toHaveLength(1);
+    expect(cards[0].text).toBe("378282246310005");
+  });
+
+  it("detects card number with dashes", () => {
+    const entities = assertSpans("Card 4111-1111-1111-1111 charged");
+    const cards = entities.filter((e) => e.label === "CREDIT_CARD");
+    expect(cards).toHaveLength(1);
+    expect(cards[0].text).toBe("4111-1111-1111-1111");
+  });
+
+  it("detects card number with spaces", () => {
+    const entities = assertSpans("Card 5500 0000 0000 0004 charged");
+    const cards = entities.filter((e) => e.label === "CREDIT_CARD");
+    expect(cards).toHaveLength(1);
+    expect(cards[0].text).toBe("5500 0000 0000 0004");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// IP_ADDRESS
+// ---------------------------------------------------------------------------
+describe("IP_ADDRESS", () => {
+  it("detects a valid IPv4 address", () => {
+    const entities = assertSpans("Server at 192.168.1.1 is up.");
+    const ips = entities.filter((e) => e.label === "IP_ADDRESS");
+    expect(ips).toHaveLength(1);
+    expect(ips[0].text).toBe("192.168.1.1");
+  });
+
+  it("detects 0.0.0.0", () => {
+    const entities = assertSpans("Bind to 0.0.0.0 for all interfaces.");
+    const ips = entities.filter((e) => e.label === "IP_ADDRESS");
+    expect(ips).toHaveLength(1);
+    expect(ips[0].text).toBe("0.0.0.0");
+  });
+
+  it("detects 255.255.255.255", () => {
+    const entities = assertSpans("Broadcast: 255.255.255.255");
+    const ips = entities.filter((e) => e.label === "IP_ADDRESS");
+    expect(ips).toHaveLength(1);
+    expect(ips[0].text).toBe("255.255.255.255");
+  });
+
+  it("rejects IP with octet > 255", () => {
+    const entities = engine.scan("Invalid 256.1.2.3 address");
+    const ips = entities.filter((e) => e.label === "IP_ADDRESS");
+    // Should not match 256.1.2.3 as a complete valid IP
+    for (const ip of ips) {
+      expect(ip.text).not.toBe("256.1.2.3");
+    }
+  });
+
+  it("rejects IP with octet 999", () => {
+    const entities = engine.scan("Bad IP 999.999.999.999");
+    const ips = entities.filter((e) => e.label === "IP_ADDRESS");
+    for (const ip of ips) {
+      expect(ip.text).not.toBe("999.999.999.999");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DATE
+// ---------------------------------------------------------------------------
+describe("DATE", () => {
+  it("detects MM/DD/YYYY format", () => {
+    const entities = assertSpans("Born on 01/15/1990 in NY.");
+    const dates = entities.filter((e) => e.label === "DATE");
+    expect(dates).toHaveLength(1);
+    expect(dates[0].text).toBe("01/15/1990");
+  });
+
+  it("detects YYYY-MM-DD format", () => {
+    const entities = assertSpans("Date: 2024-03-15 confirmed.");
+    const dates = entities.filter((e) => e.label === "DATE");
+    expect(dates).toHaveLength(1);
+    expect(dates[0].text).toBe("2024-03-15");
+  });
+
+  it("detects Month DD, YYYY format", () => {
+    const entities = assertSpans("On January 5, 2023 we met.");
+    const dates = entities.filter((e) => e.label === "DATE");
+    expect(dates).toHaveLength(1);
+    expect(dates[0].text).toBe("January 5, 2023");
+  });
+
+  it("detects abbreviated month", () => {
+    const entities = assertSpans("Meeting: Dec 25, 2022 at noon.");
+    const dates = entities.filter((e) => e.label === "DATE");
+    expect(dates).toHaveLength(1);
+    expect(dates[0].text).toBe("Dec 25, 2022");
+  });
+
+  it("detects MM-DD-YY format", () => {
+    const entities = assertSpans("Filed 03-15-90 in records.");
+    const dates = entities.filter((e) => e.label === "DATE");
+    expect(dates).toHaveLength(1);
+    expect(dates[0].text).toBe("03-15-90");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ZIP_CODE
+// ---------------------------------------------------------------------------
+describe("ZIP_CODE", () => {
+  it("detects a 5-digit ZIP", () => {
+    const entities = assertSpans("ZIP 90210 area.");
+    const zips = entities.filter((e) => e.label === "ZIP_CODE");
+    expect(zips).toHaveLength(1);
+    expect(zips[0].text).toBe("90210");
+  });
+
+  it("detects a ZIP+4", () => {
+    const entities = assertSpans("Mailing: 90210-1234 confirmed.");
+    const zips = entities.filter((e) => e.label === "ZIP_CODE");
+    expect(zips).toHaveLength(1);
+    expect(zips[0].text).toBe("90210-1234");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// COMBINED / EDGE CASES
+// ---------------------------------------------------------------------------
+describe("Multiple entities in one text", () => {
+  it("finds email, phone, and SSN in same text", () => {
+    const text =
+      "Contact alice@example.com or 555-123-4567. SSN: 123-45-6789.";
+    const entities = assertSpans(text);
+
+    const labels = entities.map((e) => e.label);
+    expect(labels).toContain("EMAIL");
+    expect(labels).toContain("PHONE");
+    expect(labels).toContain("SSN");
+  });
+
+  it("finds multiple emails", () => {
+    const text = "Send to a@b.com and c@d.org please.";
+    const entities = assertSpans(text);
+    const emails = entities.filter((e) => e.label === "EMAIL");
+    expect(emails).toHaveLength(2);
+    expect(emails[0].text).toBe("a@b.com");
+    expect(emails[1].text).toBe("c@d.org");
+  });
+});
+
+describe("Empty and no-match inputs", () => {
+  it("returns empty array for empty string", () => {
+    const entities = engine.scan("");
+    expect(entities).toEqual([]);
+  });
+
+  it("returns empty array for text with no PII", () => {
+    const entities = engine.scan("The quick brown fox jumps over the lazy dog.");
+    // Filter out anything that might false-positive
+    const meaningful = entities.filter(
+      (e) => !["ZIP_CODE"].includes(e.label) || e.text.length >= 5
+    );
+    // This sentence has no PII
+    expect(entities).toEqual([]);
+  });
+});
+
+describe("Entity shape", () => {
+  it("every entity has correct confidence and source", () => {
+    const text = "Email: test@test.com Phone: 555-123-4567";
+    const entities = engine.scan(text);
+    for (const e of entities) {
+      expect(e.confidence).toBe(1.0);
+      expect(e.source).toBe("regex");
+      expect(typeof e.start).toBe("number");
+      expect(typeof e.end).toBe("number");
+      expect(e.end).toBeGreaterThan(e.start);
+      expect(typeof e.text).toBe("string");
+      expect(typeof e.label).toBe("string");
+    }
+  });
+
+  it("span offsets are correct for all entity types", () => {
+    const text =
+      "Email: user@site.com, Phone: (800) 555-0199, SSN: 321-54-9876, " +
+      "Card: 4111111111111111, IP: 10.0.0.1, Date: 2024-06-15, ZIP: 60601";
+    assertSpans(text);
+  });
+});
+
+describe("Repeated scan calls (lastIndex reset)", () => {
+  it("produces the same results on consecutive calls", () => {
+    const text = "Email alice@example.com and call 555-123-4567.";
+    const first = engine.scan(text);
+    const second = engine.scan(text);
+    expect(first).toEqual(second);
+  });
+});

--- a/extensions/fogclaw/tests/scanner.test.ts
+++ b/extensions/fogclaw/tests/scanner.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the gliner npm package so we don't need the actual model
+vi.mock("gliner", () => {
+  return {
+    Gliner: class MockGliner {
+      async initialize() {}
+      async inference(
+        text: string,
+        labels: string[],
+        _opts: { threshold: number },
+      ) {
+        const results: any[] = [];
+
+        // Simulate person detection for "John Smith"
+        if (text.includes("John Smith")) {
+          const idx = text.indexOf("John Smith");
+          results.push({
+            text: "John Smith",
+            label: "person",
+            score: 0.95,
+            start: idx,
+            end: idx + 10,
+          });
+        }
+
+        // Simulate organization detection for "Acme Corp"
+        if (text.includes("Acme Corp")) {
+          const idx = text.indexOf("Acme Corp");
+          results.push({
+            text: "Acme Corp",
+            label: "organization",
+            score: 0.88,
+            start: idx,
+            end: idx + 9,
+          });
+        }
+
+        // Only return results whose labels are requested
+        return results.filter((r) => labels.includes(r.label));
+      }
+    },
+  };
+});
+
+import { Scanner } from "../src/scanner.js";
+import { DEFAULT_CONFIG } from "../src/config.js";
+import type { FogClawConfig } from "../src/types.js";
+
+function makeConfig(overrides: Partial<FogClawConfig> = {}): FogClawConfig {
+  return { ...DEFAULT_CONFIG, ...overrides };
+}
+
+describe("Scanner", () => {
+  let scanner: Scanner;
+
+  beforeEach(async () => {
+    scanner = new Scanner(makeConfig());
+    await scanner.initialize();
+  });
+
+  it("detects regex entities (email) without needing GLiNER", async () => {
+    // Even without initialize, regex should work
+    const regexOnly = new Scanner(makeConfig());
+    // Deliberately NOT calling initialize — GLiNER unavailable
+
+    const result = await regexOnly.scan("Contact us at test@example.com please.");
+
+    expect(result.entities.length).toBeGreaterThanOrEqual(1);
+    const email = result.entities.find((e) => e.label === "EMAIL");
+    expect(email).toBeDefined();
+    expect(email!.text).toBe("test@example.com");
+    expect(email!.source).toBe("regex");
+  });
+
+  it("detects GLiNER entities (person names)", async () => {
+    const result = await scanner.scan("My name is John Smith.");
+
+    const person = result.entities.find((e) => e.label === "PERSON");
+    expect(person).toBeDefined();
+    expect(person!.text).toBe("John Smith");
+    expect(person!.source).toBe("gliner");
+    expect(person!.confidence).toBe(0.95);
+  });
+
+  it("merges results from both engines (email + person in same text)", async () => {
+    const result = await scanner.scan(
+      "John Smith can be reached at john@example.com for details.",
+    );
+
+    const person = result.entities.find((e) => e.label === "PERSON");
+    const email = result.entities.find((e) => e.label === "EMAIL");
+
+    expect(person).toBeDefined();
+    expect(email).toBeDefined();
+    expect(person!.source).toBe("gliner");
+    expect(email!.source).toBe("regex");
+  });
+
+  it("deduplicates overlapping spans keeping higher confidence", async () => {
+    // Scan text that might produce overlapping entities
+    // The dedup logic should keep higher confidence when spans overlap
+    const result = await scanner.scan("Contact John Smith today.");
+
+    // We shouldn't have duplicate entities for the same span
+    const starts = result.entities.map((e) => e.start);
+    const uniqueStarts = [...new Set(starts)];
+    // If there were overlapping entities, dedup should have resolved them
+    expect(starts.length).toBe(uniqueStarts.length);
+  });
+
+  it("returns original text in result", async () => {
+    const text = "Hello John Smith, your email is test@example.com.";
+    const result = await scanner.scan(text);
+
+    expect(result.text).toBe(text);
+  });
+
+  it("accepts extra labels at scan time", async () => {
+    // The mock only returns results for labels that are in the labels array
+    // Extra labels get passed through to GLiNER
+    const result = await scanner.scan(
+      "John Smith works at Acme Corp.",
+      ["organization"],
+    );
+
+    // Person is always in default labels, organization should be detected too
+    const person = result.entities.find((e) => e.label === "PERSON");
+    const org = result.entities.find((e) => e.label === "ORGANIZATION");
+
+    expect(person).toBeDefined();
+    expect(org).toBeDefined();
+  });
+
+  it("falls back to regex-only when GLiNER is not initialized", async () => {
+    const fallbackScanner = new Scanner(makeConfig());
+    // Do NOT call initialize — GLiNER stays unavailable
+
+    const result = await fallbackScanner.scan(
+      "John Smith at john@example.com",
+    );
+
+    // Should still find the email via regex
+    const email = result.entities.find((e) => e.label === "EMAIL");
+    expect(email).toBeDefined();
+    expect(email!.source).toBe("regex");
+
+    // Should NOT find person because GLiNER is not available
+    const person = result.entities.find((e) => e.label === "PERSON");
+    expect(person).toBeUndefined();
+  });
+
+  it("empty text returns empty entities", async () => {
+    const result = await scanner.scan("");
+
+    expect(result.entities).toEqual([]);
+    expect(result.text).toBe("");
+  });
+
+  it("entities are sorted by start position after merge", async () => {
+    const result = await scanner.scan(
+      "John Smith can be reached at john@example.com for details.",
+    );
+
+    for (let i = 1; i < result.entities.length; i++) {
+      expect(result.entities[i].start).toBeGreaterThanOrEqual(
+        result.entities[i - 1].start,
+      );
+    }
+  });
+
+  it("passes custom_entities from config to GLiNER engine", async () => {
+    const customScanner = new Scanner(
+      makeConfig({ custom_entities: ["product", "event"] }),
+    );
+    await customScanner.initialize();
+
+    // Should not throw, custom labels are set on the engine
+    const result = await customScanner.scan("John Smith attended the event.");
+    expect(result.entities.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("handles text with only regex-detectable entities", async () => {
+    const result = await scanner.scan(
+      "Send to test@example.com and call 555-123-4567.",
+    );
+
+    expect(result.entities.length).toBeGreaterThanOrEqual(1);
+    const email = result.entities.find((e) => e.label === "EMAIL");
+    expect(email).toBeDefined();
+  });
+
+  it("handles text with no detectable entities", async () => {
+    const result = await scanner.scan("Hello world, this is a simple test.");
+
+    expect(result.entities).toEqual([]);
+    expect(result.text).toBe("Hello world, this is a simple test.");
+  });
+});


### PR DESCRIPTION
## Summary

This PR is for a new OpenClaw plugin called **FogClaw** that detects/redacts PII and custom entities (zero-shot NER).  

- **Dual-engine detection**: regex for structured PII (<1ms) + GLiNER ONNX for zero-shot NER (~50-200ms)
- **Configurable guardrail**: `before_agent_start` hook with per-entity-type actions (redact, block, warn)
- **Two agent tools**: `fogclaw_scan` (detect) and `fogclaw_redact` (detect + redact)
- **Custom entity types**: define any label (e.g., "project codename", "competitor name") — GLiNER detects them with zero training
- **Graceful degradation**: falls back to regex-only if GLiNER model fails to load

### Files

| Area | Files |
|------|-------|
| Extension entry | `extensions/fogclaw/index.ts`, `openclaw.plugin.json`, `package.json` |
| Detection engines | `src/engines/regex.ts` (7 PII patterns), `src/engines/gliner.ts` (ONNX wrapper) |
| Pipeline | `src/scanner.ts` (regex → GLiNER → merge/dedup), `src/redactor.ts` (token/mask/hash) |
| Config | `src/config.ts`, `src/types.ts` |
| Tests | 5 test suites, 98 tests total |

### Detected entity types

**Regex engine**: EMAIL, PHONE, SSN, CREDIT_CARD, IP_ADDRESS, DATE, ZIP_CODE

**GLiNER engine**: person, organization, location, address, date of birth, medical record number, account number, passport number + user-defined custom entities

### Configuration example

```json
{
  "guardrail_mode": "redact",
  "redactStrategy": "token",
  "model": "onnx-community/gliner_large-v2.1",
  "confidence_threshold": 0.5,
  "custom_entities": ["project codename", "competitor name"],
  "entityActions": {
    "SSN": "block",
    "CREDIT_CARD": "block",
    "EMAIL": "redact",
    "PERSON": "warn"
  }
}
```

## Test plan

- [x] 98 tests passing across 5 suites (config, regex, gliner, redactor, scanner)
- [ ] Manual test with OpenClaw gateway (install, enable, send PII-containing message)
- [ ] Verify GLiNER model auto-download on first use
- [ ] Verify regex-only fallback when GLiNER unavailable

