### PR TITLE
fix(compaction): disable extended thinking for non-direct Anthropic endpoints

### DIFF
--- a/src/agents/compaction.normalize-model.test.ts
+++ b/src/agents/compaction.normalize-model.test.ts
@@ -80,6 +80,24 @@ describe("normalizeModelForCompaction", () => {
       baseUrl: "https://gateway.portkey.ai/v1",
     });
     const result = normalizeModelForCompaction(model);
+    expect(result).toBe(model);
+    expect(result.reasoning).toBe(false);
+  });
+
+  it("rejects spoofed anthropic.com subdomain in proxy URL", () => {
+    const model = makeModel({
+      baseUrl: "https://anthropic.com.evil.example",
+    });
+    const result = normalizeModelForCompaction(model);
+    expect(result).not.toBe(model);
+    expect(result.reasoning).toBe(false);
+  });
+
+  it("treats malformed baseUrl as proxy", () => {
+    const model = makeModel({
+      baseUrl: "not-a-valid-url",
+    });
+    const result = normalizeModelForCompaction(model);
     expect(result).not.toBe(model);
     expect(result.reasoning).toBe(false);
   });

--- a/src/agents/compaction.normalize-model.test.ts
+++ b/src/agents/compaction.normalize-model.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { normalizeModelForCompaction } from "./compaction.js";
+
+function makeModel(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "claude-opus-4-6",
+    name: "Claude Opus 4.6",
+    api: "anthropic-messages",
+    provider: "anthropic",
+    baseUrl: "https://api.anthropic.com",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 200000,
+    maxTokens: 128000,
+    ...overrides,
+  } as Parameters<typeof normalizeModelForCompaction>[0];
+}
+
+describe("normalizeModelForCompaction", () => {
+  it("preserves model for direct Anthropic endpoint", () => {
+    const model = makeModel();
+    const result = normalizeModelForCompaction(model);
+    expect(result).toBe(model);
+    expect(result.reasoning).toBe(true);
+  });
+
+  it("preserves model when baseUrl is empty (defaults to direct)", () => {
+    const model = makeModel({ baseUrl: "" });
+    const result = normalizeModelForCompaction(model);
+    expect(result).toBe(model);
+  });
+
+  it("preserves model when baseUrl is undefined (defaults to direct)", () => {
+    const model = makeModel({ baseUrl: undefined });
+    const result = normalizeModelForCompaction(model);
+    expect(result).toBe(model);
+  });
+
+  it("disables reasoning for non-Anthropic proxy endpoint", () => {
+    const model = makeModel({
+      baseUrl: "https://gateway.portkey.ai/v1",
+    });
+    const result = normalizeModelForCompaction(model);
+    expect(result).not.toBe(model);
+    expect(result.reasoning).toBe(false);
+    expect(result.id).toBe("claude-opus-4-6");
+  });
+
+  it("disables reasoning for Vertex AI endpoint", () => {
+    const model = makeModel({
+      baseUrl: "https://us-central1-aiplatform.googleapis.com/v1",
+    });
+    const result = normalizeModelForCompaction(model);
+    expect(result.reasoning).toBe(false);
+  });
+
+  it("preserves model for non-anthropic-messages API", () => {
+    const model = makeModel({
+      api: "google-vertex",
+      baseUrl: "https://some-proxy.example.com",
+    });
+    const result = normalizeModelForCompaction(model);
+    expect(result).toBe(model);
+    expect(result.reasoning).toBe(true);
+  });
+
+  it("preserves model for bedrock API", () => {
+    const model = makeModel({
+      api: "bedrock-converse-stream",
+      baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+    });
+    const result = normalizeModelForCompaction(model);
+    expect(result).toBe(model);
+  });
+
+  it("preserves non-reasoning model unchanged", () => {
+    const model = makeModel({
+      reasoning: false,
+      baseUrl: "https://gateway.portkey.ai/v1",
+    });
+    const result = normalizeModelForCompaction(model);
+    expect(result).not.toBe(model);
+    expect(result.reasoning).toBe(false);
+  });
+});

--- a/src/agents/compaction.proxy-thinking.test.ts
+++ b/src/agents/compaction.proxy-thinking.test.ts
@@ -1,0 +1,165 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import * as piCodingAgent from "@mariozechner/pi-coding-agent";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { summarizeWithFallback } from "./compaction.js";
+
+// Mock generateSummary so we can inspect the model argument it receives.
+vi.mock("@mariozechner/pi-coding-agent", async (importOriginal) => {
+  const actual = await importOriginal<typeof piCodingAgent>();
+  return {
+    ...actual,
+    generateSummary: vi.fn(),
+  };
+});
+
+const mockGenerateSummary = vi.mocked(piCodingAgent.generateSummary);
+
+const testMessages: AgentMessage[] = [
+  { role: "user", content: "Hello, can you help me?" },
+  { role: "assistant", content: "Of course! What do you need?" },
+];
+
+function makeModel(
+  overrides: Record<string, unknown> = {},
+): NonNullable<ExtensionContext["model"]> {
+  return {
+    id: "claude-opus-4-6",
+    name: "Claude Opus 4.6",
+    api: "anthropic-messages",
+    provider: "anthropic",
+    baseUrl: "https://api.anthropic.com",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 200000,
+    maxTokens: 128000,
+    ...overrides,
+  } as NonNullable<ExtensionContext["model"]>;
+}
+
+describe("compaction proxy thinking normalization (integration)", () => {
+  beforeEach(() => {
+    mockGenerateSummary.mockClear();
+    mockGenerateSummary.mockResolvedValue("Test summary");
+  });
+
+  it("passes model with reasoning=true for direct Anthropic endpoint", async () => {
+    const model = makeModel({ baseUrl: "https://api.anthropic.com" });
+
+    await summarizeWithFallback({
+      messages: testMessages,
+      model,
+      apiKey: "test-key",
+      signal: new AbortController().signal,
+      reserveTokens: 4000,
+      maxChunkTokens: 100000,
+      contextWindow: 200000,
+    });
+
+    expect(mockGenerateSummary).toHaveBeenCalledTimes(1);
+    const receivedModel = mockGenerateSummary.mock.calls[0][1];
+    expect(receivedModel.reasoning).toBe(true);
+  });
+
+  it("passes model with reasoning=false for Portkey proxy endpoint", async () => {
+    const model = makeModel({ baseUrl: "https://gateway.portkey.ai/v1" });
+
+    await summarizeWithFallback({
+      messages: testMessages,
+      model,
+      apiKey: "test-key",
+      signal: new AbortController().signal,
+      reserveTokens: 4000,
+      maxChunkTokens: 100000,
+      contextWindow: 200000,
+    });
+
+    expect(mockGenerateSummary).toHaveBeenCalledTimes(1);
+    const receivedModel = mockGenerateSummary.mock.calls[0][1];
+    expect(receivedModel.reasoning).toBe(false);
+  });
+
+  it("passes model with reasoning=false for Vertex AI proxy endpoint", async () => {
+    const model = makeModel({
+      baseUrl: "https://us-central1-aiplatform.googleapis.com/v1",
+    });
+
+    await summarizeWithFallback({
+      messages: testMessages,
+      model,
+      apiKey: "test-key",
+      signal: new AbortController().signal,
+      reserveTokens: 4000,
+      maxChunkTokens: 100000,
+      contextWindow: 200000,
+    });
+
+    expect(mockGenerateSummary).toHaveBeenCalledTimes(1);
+    const receivedModel = mockGenerateSummary.mock.calls[0][1];
+    expect(receivedModel.reasoning).toBe(false);
+  });
+
+  it("preserves original model id when disabling reasoning", async () => {
+    const model = makeModel({ baseUrl: "https://gateway.portkey.ai/v1" });
+
+    await summarizeWithFallback({
+      messages: testMessages,
+      model,
+      apiKey: "test-key",
+      signal: new AbortController().signal,
+      reserveTokens: 4000,
+      maxChunkTokens: 100000,
+      contextWindow: 200000,
+    });
+
+    const receivedModel = mockGenerateSummary.mock.calls[0][1];
+    expect(receivedModel.id).toBe("claude-opus-4-6");
+    expect(receivedModel.reasoning).toBe(false);
+  });
+
+  it("does not modify model for non-anthropic-messages API", async () => {
+    const model = makeModel({
+      api: "google-vertex",
+      baseUrl: "https://some-proxy.example.com",
+    });
+
+    await summarizeWithFallback({
+      messages: testMessages,
+      model,
+      apiKey: "test-key",
+      signal: new AbortController().signal,
+      reserveTokens: 4000,
+      maxChunkTokens: 100000,
+      contextWindow: 200000,
+    });
+
+    expect(mockGenerateSummary).toHaveBeenCalledTimes(1);
+    const receivedModel = mockGenerateSummary.mock.calls[0][1];
+    expect(receivedModel.reasoning).toBe(true);
+  });
+
+  it("normalizes across retry attempts consistently", async () => {
+    const model = makeModel({ baseUrl: "https://gateway.portkey.ai/v1" });
+
+    mockGenerateSummary
+      .mockRejectedValueOnce(new Error("transient"))
+      .mockResolvedValueOnce("Summary after retry");
+
+    await summarizeWithFallback({
+      messages: testMessages,
+      model,
+      apiKey: "test-key",
+      signal: new AbortController().signal,
+      reserveTokens: 4000,
+      maxChunkTokens: 100000,
+      contextWindow: 200000,
+    });
+
+    expect(mockGenerateSummary).toHaveBeenCalledTimes(2);
+    // Both calls should receive the normalized model
+    for (const call of mockGenerateSummary.mock.calls) {
+      expect(call[1].reasoning).toBe(false);
+    }
+  });
+});

--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -5,6 +5,32 @@ import { retryAsync } from "../infra/retry.js";
 import { DEFAULT_CONTEXT_TOKENS } from "./defaults.js";
 import { repairToolUseResultPairing, stripToolResultDetails } from "./session-transcript-repair.js";
 
+type CompactionModel = NonNullable<ExtensionContext["model"]>;
+
+/**
+ * Non-direct Anthropic endpoints (Vertex AI, Portkey proxies, etc.) do not
+ * support `thinking: { type: "adaptive" }` — only `"enabled"` / `"disabled"`.
+ * The upstream pi-ai library decides the thinking type based on the model ID,
+ * but has no awareness of the destination endpoint.  Disabling `reasoning` on
+ * the model prevents the library from adding *any* thinking parameters, which
+ * avoids the 400 error on these endpoints at a small quality trade-off for
+ * compaction summarization.
+ *
+ * See: https://github.com/openclaw/openclaw/issues/18634
+ */
+function normalizeModelForCompaction(model: CompactionModel): CompactionModel {
+  if (model.api !== "anthropic-messages") {
+    return model;
+  }
+  const baseUrl = (model.baseUrl ?? "").trim().toLowerCase();
+  const isDirectAnthropic = !baseUrl || baseUrl.includes("anthropic.com");
+  if (isDirectAnthropic) {
+    return model;
+  }
+  // Proxy endpoint — disable reasoning to avoid unsupported thinking params.
+  return { ...model, reasoning: false };
+}
+
 export const BASE_CHUNK_RATIO = 0.4;
 export const MIN_CHUNK_RATIO = 0.15;
 export const SAFETY_MARGIN = 1.2; // 20% buffer for estimateTokens() inaccuracy
@@ -158,13 +184,14 @@ async function summarizeChunks(params: {
   const safeMessages = stripToolResultDetails(params.messages);
   const chunks = chunkMessagesByMaxTokens(safeMessages, params.maxChunkTokens);
   let summary = params.previousSummary;
+  const model = normalizeModelForCompaction(params.model);
 
   for (const chunk of chunks) {
     summary = await retryAsync(
       () =>
         generateSummary(
           chunk,
-          params.model,
+          model,
           params.reserveTokens,
           params.apiKey,
           params.signal,
@@ -387,3 +414,5 @@ export function pruneHistoryForContextShare(params: {
 export function resolveContextWindowTokens(model?: ExtensionContext["model"]): number {
   return Math.max(1, Math.floor(model?.contextWindow ?? DEFAULT_CONTEXT_TOKENS));
 }
+
+export { normalizeModelForCompaction };


### PR DESCRIPTION
## Summary

- Fixes compaction failing with `400: thinking type "adaptive" is not supported` on non-direct Anthropic endpoints (Vertex AI, Portkey proxies, etc.)
- Adds `normalizeModelForCompaction()` that disables `reasoning` on the model when the `baseUrl` is not the direct Anthropic API, preventing the upstream pi-ai library from adding unsupported `thinking` parameters
- Applied in `summarizeChunks()` before calling `generateSummary()`, so all retry attempts use the normalized model consistently

The upstream pi-ai library's `supportsAdaptiveThinking()` only checks the model ID (e.g. "opus-4-6") but has no awareness of the destination endpoint. When a user routes through a proxy like Portkey or Vertex AI, `{ type: "adaptive" }` is sent but rejected by the endpoint. Disabling reasoning entirely on the model object prevents the library from adding any thinking parameters.

## Test plan

- [x] Unit tests for `normalizeModelForCompaction()` (8 tests) — direct Anthropic preserved, proxy endpoints disable reasoning, non-anthropic-messages API preserved, bedrock preserved, empty/undefined baseUrl handled
- [x] Integration tests mocking `generateSummary` through the full `summarizeWithFallback` code path (6 tests) — verifies the model that reaches `generateSummary` has correct `reasoning` value for each endpoint type, including across retries
- [x] Existing `compaction.retry.test.ts` tests still pass

Fixes #18634

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `normalizeModelForCompaction()` to disable extended thinking (`reasoning: false`) for non-direct Anthropic endpoints (Vertex AI, Portkey proxies, etc.) to prevent `400: thinking type "adaptive" is not supported` errors during compaction.

- The upstream `pi-ai` library's `supportsAdaptiveThinking()` only checks model ID but is unaware of the destination endpoint
- When `baseUrl` is not direct Anthropic API (`anthropic.com` or `*.anthropic.com`), reasoning is disabled on the model before calling `generateSummary()`
- Applied in `summarizeChunks()` before retry loop, ensuring all retry attempts use the normalized model consistently
- Comprehensive test coverage: 8 unit tests for `normalizeModelForCompaction()` and 6 integration tests through the full `summarizeWithFallback` code path
- Existing retry tests still pass

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is well-scoped, thoroughly tested, and follows a conservative fail-safe approach. The hostname parsing correctly handles edge cases (malformed URLs, spoofed subdomains, empty/undefined baseUrl). The normalization is applied early in the code path ensuring consistency across retries. Test coverage is comprehensive with both unit and integration tests.
- No files require special attention

<sub>Last reviewed commit: ceed08a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->