### PR TITLE
feat(infra): add LLM endpoint concurrency limiting (mutex)

### DIFF
--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -41,6 +41,28 @@ export type ModelDefinitionConfig = {
   compat?: ModelCompatConfig;
 };
 
+export type ProviderConcurrencyConfig = {
+  /**
+   * Maximum concurrent requests allowed for this provider/endpoint.
+   * Especially useful for local LLMs (llamacpp, vllm) that struggle with concurrent requests.
+   * Set to 1 for strict serialization, higher numbers for limited concurrency.
+   * Default: Infinity (no limit)
+   */
+  maxConcurrent?: number;
+
+  /**
+   * Maximum time (ms) a request can wait in the queue before timing out.
+   * Default: 30000 (30 seconds)
+   */
+  queueTimeoutMs?: number;
+
+  /**
+   * Whether to enable verbose logging for this provider's concurrency limiting.
+   * Default: false
+   */
+  verbose?: boolean;
+};
+
 export type ModelProviderConfig = {
   baseUrl: string;
   apiKey?: string;
@@ -49,6 +71,11 @@ export type ModelProviderConfig = {
   headers?: Record<string, string>;
   authHeader?: boolean;
   models: ModelDefinitionConfig[];
+  /**
+   * Concurrency limiting config for this provider.
+   * Prevents resource contention when multiple agents compete for the same endpoint.
+   */
+  concurrency?: ProviderConcurrencyConfig;
 };
 
 export type BedrockDiscoveryConfig = {
@@ -64,4 +91,9 @@ export type ModelsConfig = {
   mode?: "merge" | "replace";
   providers?: Record<string, ModelProviderConfig>;
   bedrockDiscovery?: BedrockDiscoveryConfig;
+  /**
+   * Default concurrency limiting config applied to all providers unless overridden.
+   * Example: { maxConcurrent: 1 } to serialize all LLM requests globally.
+   */
+  defaultConcurrency?: ProviderConcurrencyConfig;
 };

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -1,12 +1,14 @@
+import type { CliDeps } from "../cli/deps.js";
+import type { loadConfig } from "../config/config.js";
+import type { HeartbeatRunner } from "../infra/heartbeat-runner.js";
+import type { ChannelKind, GatewayReloadPlan } from "./config-reload.js";
 import { getActiveEmbeddedRunCount } from "../agents/pi-embedded-runner/runs.js";
 import { getTotalPendingReplies } from "../auto-reply/reply/dispatcher-registry.js";
-import type { CliDeps } from "../cli/deps.js";
 import { resolveAgentMaxConcurrent, resolveSubagentMaxConcurrent } from "../config/agent-limits.js";
-import type { loadConfig } from "../config/config.js";
 import { startGmailWatcher, stopGmailWatcher } from "../hooks/gmail-watcher.js";
 import { isTruthyEnvValue } from "../infra/env.js";
-import type { HeartbeatRunner } from "../infra/heartbeat-runner.js";
 import { resetDirectoryCache } from "../infra/outbound/target-resolver.js";
+import { loadProviderConcurrencyConfig } from "../infra/provider-concurrency-loader.js";
 import {
   deferGatewayRestartUntilIdle,
   emitGatewayRestart,
@@ -14,7 +16,6 @@ import {
 } from "../infra/restart.js";
 import { setCommandLaneConcurrency, getTotalQueueSize } from "../process/command-queue.js";
 import { CommandLane } from "../process/lanes.js";
-import type { ChannelKind, GatewayReloadPlan } from "./config-reload.js";
 import { resolveHooksConfig } from "./hooks.js";
 import { startBrowserControlServerIfEnabled } from "./server-browser.js";
 import { buildGatewayCronService, type GatewayCronState } from "./server-cron.js";
@@ -48,6 +49,10 @@ export function createGatewayReloadHandlers(params: {
     nextConfig: ReturnType<typeof loadConfig>,
   ) => {
     setGatewaySigusr1RestartPolicy({ allowExternal: nextConfig.commands?.restart === true });
+
+    // Reload provider concurrency configuration
+    loadProviderConcurrencyConfig(nextConfig);
+
     const state = params.getState();
     const nextState = { ...state };
 

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -1,10 +1,14 @@
 import path from "node:path";
+import type { CanvasHostServer } from "../canvas-host/server.js";
+import type { PluginServicesHandle } from "../plugins/services.js";
+import type { RuntimeEnv } from "../runtime.js";
+import type { ControlUiRootState } from "./control-ui.js";
+import type { startBrowserControlServerIfEnabled } from "./server-browser.js";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { getActiveEmbeddedRunCount } from "../agents/pi-embedded-runner/runs.js";
 import { registerSkillsChangeListener } from "../agents/skills/refresh.js";
 import { initSubagentRegistry } from "../agents/subagent-registry.js";
 import { getTotalPendingReplies } from "../auto-reply/reply/dispatcher-registry.js";
-import type { CanvasHostServer } from "../canvas-host/server.js";
 import { type ChannelId, listChannelPlugins } from "../channels/plugins/index.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { createDefaultDeps } from "../cli/deps.js";
@@ -30,6 +34,7 @@ import { onHeartbeatEvent } from "../infra/heartbeat-events.js";
 import { startHeartbeatRunner, type HeartbeatRunner } from "../infra/heartbeat-runner.js";
 import { getMachineDisplayName } from "../infra/machine-name.js";
 import { ensureOpenClawCliOnPath } from "../infra/path-env.js";
+import { loadProviderConcurrencyConfig } from "../infra/provider-concurrency-loader.js";
 import { setGatewaySigusr1RestartPolicy, setPreRestartDeferralCheck } from "../infra/restart.js";
 import {
   primeRemoteSkillsCache,
@@ -41,17 +46,13 @@ import { startDiagnosticHeartbeat, stopDiagnosticHeartbeat } from "../logging/di
 import { createSubsystemLogger, runtimeForLogger } from "../logging/subsystem.js";
 import { getGlobalHookRunner, runGlobalGatewayStopSafely } from "../plugins/hook-runner-global.js";
 import { createEmptyPluginRegistry } from "../plugins/registry.js";
-import type { PluginServicesHandle } from "../plugins/services.js";
 import { getTotalQueueSize } from "../process/command-queue.js";
-import type { RuntimeEnv } from "../runtime.js";
 import { runOnboardingWizard } from "../wizard/onboarding.js";
 import { createAuthRateLimiter, type AuthRateLimiter } from "./auth-rate-limit.js";
 import { startChannelHealthMonitor } from "./channel-health-monitor.js";
 import { startGatewayConfigReloader } from "./config-reload.js";
-import type { ControlUiRootState } from "./control-ui.js";
 import { ExecApprovalManager } from "./exec-approval-manager.js";
 import { NodeRegistry } from "./node-registry.js";
-import type { startBrowserControlServerIfEnabled } from "./server-browser.js";
 import { createChannelManager } from "./server-channels.js";
 import { createAgentEventHandler } from "./server-chat.js";
 import { createGatewayCloseHandler } from "./server-close.js";
@@ -228,6 +229,10 @@ export async function startGatewayServer(
   }
 
   const cfgAtStart = loadConfig();
+
+  // Initialize provider concurrency limiting
+  loadProviderConcurrencyConfig(cfgAtStart);
+
   const diagnosticsEnabled = isDiagnosticsEnabled(cfgAtStart);
   if (diagnosticsEnabled) {
     startDiagnosticHeartbeat();

--- a/src/infra/provider-concurrency-limiter.test.ts
+++ b/src/infra/provider-concurrency-limiter.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  providerConcurrencyLimiter,
+  normalizeProviderId,
+  withProviderConcurrency,
+  type ProviderConcurrencyLimits,
+} from "./provider-concurrency-limiter.js";
+
+describe("ProviderConcurrencyLimiter", () => {
+  beforeEach(() => {
+    providerConcurrencyLimiter.reset();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    providerConcurrencyLimiter.reset();
+    vi.useRealTimers();
+  });
+
+  describe("normalizeProviderId", () => {
+    it("extracts provider from model string", () => {
+      expect(normalizeProviderId("llamacpp/qwen")).toBe("llamacpp");
+      expect(normalizeProviderId("anthropic/claude-3")).toBe("anthropic");
+      expect(normalizeProviderId("vllm/model")).toBe("vllm");
+    });
+
+    it("extracts host from baseUrl", () => {
+      expect(normalizeProviderId("llamacpp/qwen", "http://localhost:8000")).toBe("localhost:8000");
+      expect(normalizeProviderId("vllm/model", "http://192.168.1.100:5001/v1")).toBe(
+        "192.168.1.100:5001",
+      );
+    });
+
+    it("handles invalid URLs gracefully", () => {
+      expect(normalizeProviderId("llamacpp/qwen", "not-a-url")).toBe("not-a-url");
+    });
+  });
+
+  describe("acquire and release", () => {
+    it("acquires immediately when under limit", async () => {
+      providerConcurrencyLimiter.configure({
+        providers: { test: { maxConcurrent: 2 } },
+      });
+
+      const token1 = await providerConcurrencyLimiter.acquire("test");
+      expect(token1).toBeDefined();
+
+      const token2 = await providerConcurrencyLimiter.acquire("test");
+      expect(token2).toBeDefined();
+
+      expect(providerConcurrencyLimiter.getStats("test").active).toBe(2);
+    });
+
+    it("queues requests when at limit", async () => {
+      providerConcurrencyLimiter.configure({
+        providers: { test: { maxConcurrent: 1 } },
+      });
+
+      const token1 = await providerConcurrencyLimiter.acquire("test");
+      expect(providerConcurrencyLimiter.getStats("test").active).toBe(1);
+
+      // Second request should queue
+      const promise2 = providerConcurrencyLimiter.acquire("test");
+
+      // Process next tick to ensure promise is queued
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(providerConcurrencyLimiter.getStats("test").active).toBe(1);
+      expect(providerConcurrencyLimiter.getStats("test").queued).toBe(1);
+
+      // Release first token
+      providerConcurrencyLimiter.release("test", token1);
+
+      // Second request should now acquire
+      const token2 = await promise2;
+      expect(token2).toBeDefined();
+      expect(providerConcurrencyLimiter.getStats("test").active).toBe(1);
+      expect(providerConcurrencyLimiter.getStats("test").queued).toBe(0);
+    });
+
+    it("processes queue in priority order", async () => {
+      providerConcurrencyLimiter.configure({
+        providers: { test: { maxConcurrent: 1 } },
+      });
+
+      const token1 = await providerConcurrencyLimiter.acquire("test");
+
+      // Queue three requests with different priorities
+      const promise1 = providerConcurrencyLimiter.acquire("test", { priority: 0 });
+      const promise2 = providerConcurrencyLimiter.acquire("test", { priority: 10 }); // Highest
+      const promise3 = providerConcurrencyLimiter.acquire("test", { priority: 5 });
+
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(providerConcurrencyLimiter.getStats("test").queued).toBe(3);
+
+      const resolved: number[] = [];
+
+      void promise1.then(() => resolved.push(1));
+      void promise2.then(() => resolved.push(2));
+      void promise3.then(() => resolved.push(3));
+
+      // Release and let them process
+      providerConcurrencyLimiter.release("test", token1);
+      const token2 = await promise2; // Highest priority
+
+      providerConcurrencyLimiter.release("test", token2);
+      const token3 = await promise3; // Middle priority
+
+      providerConcurrencyLimiter.release("test", token3);
+      await promise1; // Lowest priority
+
+      expect(resolved).toEqual([2, 3, 1]);
+    });
+
+    it("times out queued requests", async () => {
+      providerConcurrencyLimiter.configure({
+        providers: { test: { maxConcurrent: 1, queueTimeoutMs: 1000 } },
+      });
+
+      const token1 = await providerConcurrencyLimiter.acquire("test");
+
+      const promise2 = providerConcurrencyLimiter.acquire("test");
+
+      // Wait for promise to be queued
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Advance past timeout and wait for rejection to be handled
+      const timeoutPromise = vi.advanceTimersByTimeAsync(1100);
+
+      await expect(promise2).rejects.toThrow("timed out after 1000ms in queue");
+      await timeoutPromise;
+
+      // Queue should be empty
+      expect(providerConcurrencyLimiter.getStats("test").queued).toBe(0);
+
+      // Cleanup
+      providerConcurrencyLimiter.release("test", token1);
+    });
+
+    it("handles concurrent releases correctly", async () => {
+      providerConcurrencyLimiter.configure({
+        providers: { test: { maxConcurrent: 2 } },
+      });
+
+      const token1 = await providerConcurrencyLimiter.acquire("test");
+      const token2 = await providerConcurrencyLimiter.acquire("test");
+
+      expect(providerConcurrencyLimiter.getStats("test").active).toBe(2);
+
+      providerConcurrencyLimiter.release("test", token1);
+      providerConcurrencyLimiter.release("test", token2);
+
+      expect(providerConcurrencyLimiter.getStats("test").active).toBe(0);
+    });
+  });
+
+  describe("withProviderConcurrency", () => {
+    it("wraps function execution with concurrency limiting", async () => {
+      providerConcurrencyLimiter.configure({
+        providers: { test: { maxConcurrent: 1 } },
+      });
+
+      let activeCount = 0;
+      let maxActiveCount = 0;
+
+      const fn = async () => {
+        activeCount++;
+        maxActiveCount = Math.max(maxActiveCount, activeCount);
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        activeCount--;
+        return "done";
+      };
+
+      // Start 3 concurrent calls
+      const promises = [
+        withProviderConcurrency("test", fn),
+        withProviderConcurrency("test", fn),
+        withProviderConcurrency("test", fn),
+      ];
+
+      // Process timers
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Should have 1 active, 2 queued
+      expect(providerConcurrencyLimiter.getStats("test").active).toBe(1);
+      expect(providerConcurrencyLimiter.getStats("test").queued).toBe(2);
+
+      // Complete all
+      await vi.advanceTimersByTimeAsync(300);
+      const results = await Promise.all(promises);
+
+      expect(results).toEqual(["done", "done", "done"]);
+      expect(maxActiveCount).toBe(1); // Never more than 1 concurrent
+    });
+
+    it("releases on function error", async () => {
+      providerConcurrencyLimiter.configure({
+        providers: { test: { maxConcurrent: 1 } },
+      });
+
+      const error = new Error("test error");
+
+      await expect(
+        withProviderConcurrency("test", async () => {
+          throw error;
+        }),
+      ).rejects.toThrow(error);
+
+      // Should have released the lock
+      expect(providerConcurrencyLimiter.getStats("test").active).toBe(0);
+    });
+  });
+
+  describe("configuration", () => {
+    it("uses provider-specific config over default", () => {
+      const config: ProviderConcurrencyLimits = {
+        default: { maxConcurrent: 5, queueTimeoutMs: 10000 },
+        providers: {
+          llamacpp: { maxConcurrent: 1, queueTimeoutMs: 5000 },
+        },
+      };
+
+      providerConcurrencyLimiter.configure(config);
+
+      const llamacppConfig = providerConcurrencyLimiter.getConfig("llamacpp");
+      expect(llamacppConfig.maxConcurrent).toBe(1);
+      expect(llamacppConfig.queueTimeoutMs).toBe(5000);
+
+      const otherConfig = providerConcurrencyLimiter.getConfig("anthropic");
+      expect(otherConfig.maxConcurrent).toBe(5);
+      expect(otherConfig.queueTimeoutMs).toBe(10000);
+    });
+
+    it("falls back to infinity when no config provided", () => {
+      providerConcurrencyLimiter.configure({});
+
+      const config = providerConcurrencyLimiter.getConfig("unconfigured");
+      expect(config.maxConcurrent).toBe(Infinity);
+      expect(config.queueTimeoutMs).toBe(30000);
+    });
+  });
+
+  describe("stats", () => {
+    it("tracks queue and active counts", async () => {
+      providerConcurrencyLimiter.configure({
+        providers: { test: { maxConcurrent: 1 } },
+      });
+
+      const token1 = await providerConcurrencyLimiter.acquire("test");
+      void providerConcurrencyLimiter.acquire("test");
+      void providerConcurrencyLimiter.acquire("test");
+
+      await vi.advanceTimersByTimeAsync(0);
+
+      const stats = providerConcurrencyLimiter.getStats("test");
+      expect(stats.active).toBe(1);
+      expect(stats.queued).toBe(2);
+      expect(stats.requestCount).toBe(3);
+
+      providerConcurrencyLimiter.release("test", token1);
+    });
+  });
+});

--- a/src/infra/provider-concurrency-limiter.ts
+++ b/src/infra/provider-concurrency-limiter.ts
@@ -1,0 +1,333 @@
+/**
+ * Provider Concurrency Limiter
+ *
+ * Prevents resource contention when multiple agent sessions compete for the same LLM endpoint.
+ * Especially critical for local LLMs (llamacpp, vllm) that struggle with concurrent requests.
+ *
+ * Features:
+ * - Per-endpoint queuing with configurable concurrency limits
+ * - Priority support for time-sensitive agents (e.g., heartbeat)
+ * - Timeout handling for stuck requests
+ * - Metrics for queue depth and wait times
+ */
+
+import { logInfo, logWarn } from "../logger.js";
+
+export type ProviderConcurrencyConfig = {
+  /**
+   * Maximum concurrent requests allowed for this provider/endpoint.
+   * Default: Infinity (no limit)
+   */
+  maxConcurrent?: number;
+
+  /**
+   * Maximum time (ms) a request can wait in the queue before timing out.
+   * Default: 30000 (30 seconds)
+   */
+  queueTimeoutMs?: number;
+
+  /**
+   * Whether to enable verbose logging for this provider.
+   * Default: false
+   */
+  verbose?: boolean;
+};
+
+export type ProviderConcurrencyLimits = {
+  /**
+   * Default config for all providers
+   */
+  default?: ProviderConcurrencyConfig;
+
+  /**
+   * Provider-specific overrides by provider name or endpoint URL
+   * Examples:
+   *   - "llamacpp" or "localhost:8000"
+   *   - "vllm" or "localhost:5001"
+   */
+  providers?: Record<string, ProviderConcurrencyConfig>;
+};
+
+type QueuedRequest = {
+  providerId: string;
+  priority: number;
+  enqueueTime: number;
+  resolve: () => void;
+  reject: (err: Error) => void;
+  timeoutHandle: NodeJS.Timeout | null;
+};
+
+type ProviderStats = {
+  active: number;
+  queued: number;
+  totalWaitMs: number;
+  requestCount: number;
+};
+
+/**
+ * Global registry of provider concurrency limiters
+ */
+class ProviderConcurrencyLimiterRegistry {
+  private activeRequests: Map<string, Set<symbol>> = new Map();
+  private requestQueues: Map<string, QueuedRequest[]> = new Map();
+  private config: ProviderConcurrencyLimits = {};
+
+  configure(config: ProviderConcurrencyLimits): void {
+    this.config = config;
+  }
+
+  getConfig(providerId: string): ProviderConcurrencyConfig {
+    // Check provider-specific config first
+    const providerConfig = this.config.providers?.[providerId];
+    if (providerConfig) {
+      return {
+        maxConcurrent:
+          providerConfig.maxConcurrent ?? this.config.default?.maxConcurrent ?? Infinity,
+        queueTimeoutMs:
+          providerConfig.queueTimeoutMs ?? this.config.default?.queueTimeoutMs ?? 30000,
+        verbose: providerConfig.verbose ?? this.config.default?.verbose ?? false,
+      };
+    }
+
+    // Fall back to default config
+    return {
+      maxConcurrent: this.config.default?.maxConcurrent ?? Infinity,
+      queueTimeoutMs: this.config.default?.queueTimeoutMs ?? 30000,
+      verbose: this.config.default?.verbose ?? false,
+    };
+  }
+
+  /**
+   * Acquire a slot for the provider. Returns a release token.
+   * May queue the request if the concurrency limit is reached.
+   */
+  async acquire(
+    providerId: string,
+    options?: { priority?: number; timeoutMs?: number },
+  ): Promise<symbol> {
+    const config = this.getConfig(providerId);
+    const priority = options?.priority ?? 0;
+    const timeoutMs = options?.timeoutMs ?? config.queueTimeoutMs;
+
+    const active = this.activeRequests.get(providerId);
+    const activeCount = active?.size ?? 0;
+
+    // If under the limit, acquire immediately
+    if (activeCount < config.maxConcurrent) {
+      const token = Symbol(`provider:${providerId}:${Date.now()}`);
+      if (!active) {
+        this.activeRequests.set(providerId, new Set([token]));
+      } else {
+        active.add(token);
+      }
+
+      if (config.verbose) {
+        logInfo(
+          `[provider-concurrency] ${providerId}: acquired immediately (${activeCount + 1}/${config.maxConcurrent})`,
+        );
+      }
+
+      return token;
+    }
+
+    // Otherwise, queue the request
+    if (config.verbose) {
+      logInfo(
+        `[provider-concurrency] ${providerId}: queuing request (${activeCount}/${config.maxConcurrent} active)`,
+      );
+    }
+
+    return new Promise<symbol>((resolve, reject) => {
+      const enqueueTime = Date.now();
+
+      const timeoutHandle = setTimeout(() => {
+        this.removeFromQueue(providerId, queuedRequest);
+        reject(new Error(`Provider ${providerId} request timed out after ${timeoutMs}ms in queue`));
+      }, timeoutMs);
+
+      const queuedRequest: QueuedRequest = {
+        providerId,
+        priority,
+        enqueueTime,
+        timeoutHandle,
+        resolve: () => {
+          const token = Symbol(`provider:${providerId}:${Date.now()}`);
+          const active = this.activeRequests.get(providerId);
+          if (!active) {
+            this.activeRequests.set(providerId, new Set([token]));
+          } else {
+            active.add(token);
+          }
+
+          const waitMs = Date.now() - enqueueTime;
+          if (config.verbose) {
+            logInfo(`[provider-concurrency] ${providerId}: dequeued after ${waitMs}ms`);
+          }
+
+          resolve(token);
+        },
+        reject,
+      };
+
+      const queue = this.requestQueues.get(providerId);
+      if (!queue) {
+        this.requestQueues.set(providerId, [queuedRequest]);
+      } else {
+        // Insert in priority order (higher priority first)
+        const insertIndex = queue.findIndex((req) => req.priority < priority);
+        if (insertIndex === -1) {
+          queue.push(queuedRequest);
+        } else {
+          queue.splice(insertIndex, 0, queuedRequest);
+        }
+      }
+    });
+  }
+
+  /**
+   * Release a previously acquired slot.
+   */
+  release(providerId: string, token: symbol): void {
+    const active = this.activeRequests.get(providerId);
+    if (!active || !active.has(token)) {
+      logWarn(`[provider-concurrency] ${providerId}: attempted to release unknown token`);
+      return;
+    }
+
+    active.delete(token);
+
+    const config = this.getConfig(providerId);
+    if (config.verbose) {
+      logInfo(
+        `[provider-concurrency] ${providerId}: released (${active.size}/${config.maxConcurrent})`,
+      );
+    }
+
+    // Process next queued request
+    this.processQueue(providerId);
+  }
+
+  private processQueue(providerId: string): void {
+    const queue = this.requestQueues.get(providerId);
+    if (!queue || queue.length === 0) {
+      return;
+    }
+
+    const config = this.getConfig(providerId);
+    const active = this.activeRequests.get(providerId);
+    const activeCount = active?.size ?? 0;
+
+    if (activeCount >= config.maxConcurrent) {
+      return; // Still at limit
+    }
+
+    // Dequeue the highest priority request
+    const next = queue.shift();
+    if (!next) {
+      return;
+    }
+
+    // Clear timeout
+    if (next.timeoutHandle) {
+      clearTimeout(next.timeoutHandle);
+    }
+
+    // Resolve the promise (which will add to active set)
+    next.resolve();
+
+    // Continue processing queue if there's room
+    if (queue.length > 0 && activeCount + 1 < config.maxConcurrent) {
+      this.processQueue(providerId);
+    }
+  }
+
+  private removeFromQueue(providerId: string, request: QueuedRequest): void {
+    const queue = this.requestQueues.get(providerId);
+    if (!queue) {
+      return;
+    }
+
+    const index = queue.indexOf(request);
+    if (index !== -1) {
+      queue.splice(index, 1);
+    }
+  }
+
+  /**
+   * Get current stats for a provider
+   */
+  getStats(providerId: string): ProviderStats {
+    const active = this.activeRequests.get(providerId);
+    const queue = this.requestQueues.get(providerId);
+
+    const totalWaitMs = queue?.reduce((sum, req) => sum + (Date.now() - req.enqueueTime), 0) ?? 0;
+
+    return {
+      active: active?.size ?? 0,
+      queued: queue?.length ?? 0,
+      totalWaitMs,
+      requestCount: (active?.size ?? 0) + (queue?.length ?? 0),
+    };
+  }
+
+  /**
+   * Clear all queues and active requests (for testing)
+   */
+  reset(): void {
+    // Clear all timeouts
+    for (const queue of this.requestQueues.values()) {
+      for (const req of queue) {
+        if (req.timeoutHandle) {
+          clearTimeout(req.timeoutHandle);
+        }
+      }
+    }
+
+    this.activeRequests.clear();
+    this.requestQueues.clear();
+  }
+}
+
+/**
+ * Global singleton instance
+ */
+export const providerConcurrencyLimiter = new ProviderConcurrencyLimiterRegistry();
+
+/**
+ * Helper to normalize provider ID from model string
+ * Examples:
+ *   - "llamacpp/qwen" -> "llamacpp"
+ *   - "localhost:8000/v1" -> "localhost:8000"
+ *   - "anthropic/claude-3" -> "anthropic"
+ */
+export function normalizeProviderId(model: string, baseUrl?: string): string {
+  if (baseUrl) {
+    // Extract host from base URL
+    try {
+      const url = new URL(baseUrl);
+      return url.host; // e.g., "localhost:8000"
+    } catch {
+      return baseUrl;
+    }
+  }
+
+  // Extract provider from model string
+  const parts = model.split("/");
+  return parts[0] ?? model;
+}
+
+/**
+ * Execute a function with provider concurrency limiting
+ */
+export async function withProviderConcurrency<T>(
+  providerId: string,
+  fn: () => Promise<T>,
+  options?: { priority?: number; timeoutMs?: number },
+): Promise<T> {
+  const token = await providerConcurrencyLimiter.acquire(providerId, options);
+  try {
+    return await fn();
+  } finally {
+    providerConcurrencyLimiter.release(providerId, token);
+  }
+}

--- a/src/infra/provider-concurrency-loader.ts
+++ b/src/infra/provider-concurrency-loader.ts
@@ -1,0 +1,47 @@
+/**
+ * Provider Concurrency Configuration Loader
+ *
+ * Loads concurrency limits from OpenClaw config and applies them to the provider concurrency limiter.
+ */
+
+import type { OpenClawConfig } from "../config/types.js";
+import {
+  providerConcurrencyLimiter,
+  type ProviderConcurrencyLimits,
+} from "./provider-concurrency-limiter.js";
+
+/**
+ * Load provider concurrency configuration from OpenClaw config
+ */
+export function loadProviderConcurrencyConfig(config: OpenClawConfig): void {
+  const limits: ProviderConcurrencyLimits = {};
+
+  // Apply default concurrency config if provided
+  if (config.models?.defaultConcurrency) {
+    limits.default = config.models.defaultConcurrency;
+  }
+
+  // Apply provider-specific configs
+  if (config.models?.providers) {
+    limits.providers = {};
+
+    for (const [providerId, providerConfig] of Object.entries(config.models.providers)) {
+      if (providerConfig.concurrency) {
+        limits.providers[providerId] = providerConfig.concurrency;
+      }
+
+      // Also index by baseUrl host if available
+      if (providerConfig.baseUrl && providerConfig.concurrency) {
+        try {
+          const url = new URL(providerConfig.baseUrl);
+          limits.providers[url.host] = providerConfig.concurrency;
+        } catch {
+          // Invalid URL, skip
+        }
+      }
+    }
+  }
+
+  // Configure the global limiter
+  providerConcurrencyLimiter.configure(limits);
+}


### PR DESCRIPTION
# Add LLM Endpoint Concurrency Limiting (Mutex)

## Problem
When multiple isolated agents run concurrently and share the same LLM endpoint (especially local LLMs like `llamacpp` or `vllm`), they compete for resources. This often leads to significant slowdowns, timeouts, and resource exhaustion. For example, the `heartbeat-agent` frequently times out when multiple agent sessions overlap on a single-concurrency local model.

## Solution
This PR introduces a **Provider Concurrency Limiter** that provides a mutex/queuing mechanism at the provider endpoint level. It ensures that requests to the same endpoint are serialized or limited to a configurable concurrency level.

### Key Features
- **Per-Endpoint Queuing:** Requests are queued based on the normalized provider ID (host/port for local URLs, or provider name for cloud services).
- **Configurable Limits:** Users can set `maxConcurrent` and `queueTimeoutMs` globally or per-provider.
- **Hot Reload Support:** Concurrency settings are applied instantly during gateway config hot-reloads.
- **Priority Support:** (Internal) Support for priority-based dequeuing (useful for future time-sensitive agent needs).
- **Safe Integration:** Wraps agent execution attempts without modifying the underlying provider API implementations.

## New Configuration Options

Add the following to your `config.yaml` under the `models` section:

```yaml
models:
  # Global default concurrency limit
  defaultConcurrency:
    maxConcurrent: 2
    queueTimeoutMs: 60000 # 1 minute
    verbose: true

  providers:
    llamacpp:
      baseUrl: "http://localhost:8000"
      concurrency:
        maxConcurrent: 1 # Strict serialization for local model
        queueTimeoutMs: 30000
```

## Implementation Details
- `src/infra/provider-concurrency-limiter.ts`: Core registry and semaphore logic.
- `src/infra/provider-concurrency-loader.ts`: Translates OpenClaw config to limiter settings.
- `src/gateway/server.impl.ts` & `src/gateway/server-reload-handlers.ts`: Initialization and hot-reload logic.
- `src/commands/agent.ts`: Wrapped `runAgentAttempt` to enforce limits during agent execution.

## Testing
- Added comprehensive unit tests in `src/infra/provider-concurrency-limiter.test.ts`.
- Verified hot-reload behavior in a live gateway environment.
- Confirmed that concurrent agent requests queue up correctly when `maxConcurrent: 1` is set for a specific provider.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Introduces a provider-level concurrency limiter (mutex/semaphore) to prevent resource contention when multiple agents share the same LLM endpoint. The implementation adds a global singleton registry with per-provider queuing, priority support, and configurable timeouts, wired into both gateway startup and hot-reload paths.

- The concurrency limiter wraps the **entire agent execution** (`runCliAgent`/`runEmbeddedPiAgent`), not individual LLM API calls. For `maxConcurrent: 1`, this means only one agent session can run at a time per provider — even during tool execution when the LLM is idle. This is a significant design choice worth documenting explicitly.
- No validation on `maxConcurrent` value — setting `maxConcurrent: 0` silently causes all requests to queue indefinitely until timeout, with no warning.
- Previously flagged: provider ID resolution uses `modelOverride` instead of `providerOverride`, which can cause the limiter to be bypassed for per-provider configs.
- Previously flagged: `ProviderConcurrencyConfig` type is duplicated between `types.models.ts` and `provider-concurrency-limiter.ts`.
- Test coverage is solid, covering core semaphore semantics, priority ordering, timeout behavior, and error handling.

<h3>Confidence Score: 3/5</h3>

- This PR is functional but has design concerns around lock granularity and a configuration edge case that should be addressed before merging.
- The core semaphore logic is correct and well-tested. However, the concurrency slot wraps the entire agent run (not individual LLM calls), which may cause unexpected blocking. The maxConcurrent: 0 edge case silently deadlocks all requests. Previously flagged issues (provider ID mismatch, duplicate type) also remain relevant.
- Pay close attention to `src/commands/agent.ts` (lock scope and provider ID resolution) and `src/infra/provider-concurrency-limiter.ts` (missing maxConcurrent validation).

<sub>Last reviewed commit: 0a407e2</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->