### PR TITLE
test: isolate env-dependent gateway/auth fixtures

### DIFF
--- a/src/browser/server.post-tabs-open-profile-unknown-returns-404.test.ts
+++ b/src/browser/server.post-tabs-open-profile-unknown-returns-404.test.ts
@@ -16,6 +16,9 @@ const state = getBrowserControlServerTestState();
 const cdpMocks = getCdpMocks();
 const pwMocks = getPwMocks();
 
+let prevGatewayToken: string | undefined;
+let prevGatewayPassword: string | undefined;
+
 describe("browser control server", () => {
   installBrowserControlServerHooks();
 
@@ -50,6 +53,10 @@ describe("profile CRUD endpoints", () => {
     state.cdpBaseUrl = `http://127.0.0.1:${state.testPort + 1}`;
     state.prevGatewayPort = process.env.OPENCLAW_GATEWAY_PORT;
     process.env.OPENCLAW_GATEWAY_PORT = String(state.testPort - 2);
+    prevGatewayToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+    prevGatewayPassword = process.env.OPENCLAW_GATEWAY_PASSWORD;
+    delete process.env.OPENCLAW_GATEWAY_TOKEN;
+    delete process.env.OPENCLAW_GATEWAY_PASSWORD;
 
     vi.stubGlobal(
       "fetch",
@@ -70,6 +77,16 @@ describe("profile CRUD endpoints", () => {
       delete process.env.OPENCLAW_GATEWAY_PORT;
     } else {
       process.env.OPENCLAW_GATEWAY_PORT = state.prevGatewayPort;
+    }
+    if (prevGatewayToken === undefined) {
+      delete process.env.OPENCLAW_GATEWAY_TOKEN;
+    } else {
+      process.env.OPENCLAW_GATEWAY_TOKEN = prevGatewayToken;
+    }
+    if (prevGatewayPassword === undefined) {
+      delete process.env.OPENCLAW_GATEWAY_PASSWORD;
+    } else {
+      process.env.OPENCLAW_GATEWAY_PASSWORD = prevGatewayPassword;
     }
     await stopBrowserControlServer();
   });

--- a/src/gateway/server-runtime-config.test.ts
+++ b/src/gateway/server-runtime-config.test.ts
@@ -79,6 +79,11 @@ describe("resolveGatewayRuntimeConfig", () => {
 
   describe("token/password auth modes", () => {
     it("should reject token mode without token configured", async () => {
+      const prevToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+      const prevPassword = process.env.OPENCLAW_GATEWAY_PASSWORD;
+      delete process.env.OPENCLAW_GATEWAY_TOKEN;
+      delete process.env.OPENCLAW_GATEWAY_PASSWORD;
+
       const cfg = {
         gateway: {
           bind: "lan" as const,
@@ -88,12 +93,25 @@ describe("resolveGatewayRuntimeConfig", () => {
         },
       };
 
-      await expect(
-        resolveGatewayRuntimeConfig({
-          cfg,
-          port: 18789,
-        }),
-      ).rejects.toThrow("gateway auth mode is token, but no token was configured");
+      try {
+        await expect(
+          resolveGatewayRuntimeConfig({
+            cfg,
+            port: 18789,
+          }),
+        ).rejects.toThrow("gateway auth mode is token, but no token was configured");
+      } finally {
+        if (prevToken === undefined) {
+          delete process.env.OPENCLAW_GATEWAY_TOKEN;
+        } else {
+          process.env.OPENCLAW_GATEWAY_TOKEN = prevToken;
+        }
+        if (prevPassword === undefined) {
+          delete process.env.OPENCLAW_GATEWAY_PASSWORD;
+        } else {
+          process.env.OPENCLAW_GATEWAY_PASSWORD = prevPassword;
+        }
+      }
     });
 
     it("should allow lan binding with token", async () => {

--- a/test/helpers/temp-home.ts
+++ b/test/helpers/temp-home.ts
@@ -11,6 +11,8 @@ type EnvSnapshot = {
   homePath: string | undefined;
   openclawHome: string | undefined;
   stateDir: string | undefined;
+  agentDir: string | undefined;
+  piCodingAgentDir: string | undefined;
 };
 
 function snapshotEnv(): EnvSnapshot {
@@ -21,6 +23,8 @@ function snapshotEnv(): EnvSnapshot {
     homePath: process.env.HOMEPATH,
     openclawHome: process.env.OPENCLAW_HOME,
     stateDir: process.env.OPENCLAW_STATE_DIR,
+    agentDir: process.env.OPENCLAW_AGENT_DIR,
+    piCodingAgentDir: process.env.PI_CODING_AGENT_DIR,
   };
 }
 
@@ -38,6 +42,8 @@ function restoreEnv(snapshot: EnvSnapshot) {
   restoreKey("HOMEPATH", snapshot.homePath);
   restoreKey("OPENCLAW_HOME", snapshot.openclawHome);
   restoreKey("OPENCLAW_STATE_DIR", snapshot.stateDir);
+  restoreKey("OPENCLAW_AGENT_DIR", snapshot.agentDir);
+  restoreKey("PI_CODING_AGENT_DIR", snapshot.piCodingAgentDir);
 }
 
 function snapshotExtraEnv(keys: string[]): Record<string, string | undefined> {
@@ -61,8 +67,10 @@ function restoreExtraEnv(snapshot: Record<string, string | undefined>) {
 function setTempHome(base: string) {
   process.env.HOME = base;
   process.env.USERPROFILE = base;
-  // Ensure tests using HOME isolation aren't affected by leaked OPENCLAW_HOME.
+  // Ensure tests using HOME isolation aren't affected by leaked OpenClaw env overrides.
   delete process.env.OPENCLAW_HOME;
+  delete process.env.OPENCLAW_AGENT_DIR;
+  delete process.env.PI_CODING_AGENT_DIR;
   process.env.OPENCLAW_STATE_DIR = path.join(base, ".openclaw");
 
   if (process.platform !== "win32") {


### PR DESCRIPTION
## Summary

- isolate browser profile CRUD tests from host gateway token/password env vars
- isolate runtime auth test from host token/password env vars
- ensure `withTempHome` clears/restores `OPENCLAW_AGENT_DIR` and `PI_CODING_AGENT_DIR` so auth-profile tests use temp home paths

## Why

Several tests were reading host env vars (`OPENCLAW_GATEWAY_TOKEN`, `OPENCLAW_AGENT_DIR`) and became non-deterministic across machines/runners. This caused:

- Tests passing on some machines but failing on others
- Tests that depended on host configuration
- Flaky CI behavior

## What Changed

- `withTempHome` now explicitly clears and restores `OPENCLAW_AGENT_DIR` and `PI_CODING_AGENT_DIR`
- Browser profile tests explicitly unset `OPENCLAW_GATEWAY_TOKEN` and `OPENCLAW_GATEWAY_PASSWORD`
- Runtime config tests isolate from host credentials

## Testing

The fix targets the test infrastructure itself. Validation:

```bash
npx vitest run src/browser/server.post-tabs-open-profile-unknown-returns-404.test.ts src/gateway/server-runtime-config.test.ts src/infra/provider-usage.auth.normalizes-keys.test.ts
```

All previously failing tests now pass.

## Local Validation

```bash
pnpm build && pnpm check && pnpm test
```

Build passes. Lint passes. **All tests pass** (including the 4 that were failing without this fix).

## AI-Assisted

This PR was prepared with assistance from Claude Opus 4.5.

Fixes #16657