### PR TITLE
feat(edit): return current file content on match failure

### DIFF
--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -344,7 +344,54 @@ export function createSandboxedEditTool(params: SandboxToolParams) {
   const base = createEditTool(params.root, {
     operations: createSandboxEditOperations(params),
   }) as unknown as AnyAgentTool;
-  return wrapToolParamNormalization(base, CLAUDE_PARAM_GROUPS.edit);
+  const normalized = wrapToolParamNormalization(base, CLAUDE_PARAM_GROUPS.edit);
+
+  // Wrap to return current file content on match failure (optimistic concurrency improvement)
+  // See https://github.com/openclaw/openclaw/issues/18132
+  return {
+    ...normalized,
+    execute: async (toolCallId, args, signal, onUpdate) => {
+      try {
+        return await normalized.execute(toolCallId, args, signal, onUpdate);
+      } catch (error) {
+        // If the edit failed due to text mismatch, return the current file content
+        // so the agent can retry without a separate Read call
+        if (error instanceof Error && error.message.includes("Could not find the exact text in")) {
+          const normalizedArgs = normalizeToolParams(args);
+          const record =
+            normalizedArgs ??
+            (args && typeof args === "object" ? (args as Record<string, unknown>) : undefined);
+          const filePath = record?.path;
+
+          if (typeof filePath === "string" && filePath.trim()) {
+            try {
+              const content = await params.bridge.readFile({
+                filePath,
+                cwd: params.root,
+              });
+              const contentStr = content.toString("utf-8");
+
+              // Return error with current file content
+              return {
+                isError: true,
+                content: [
+                  {
+                    type: "text",
+                    text: `${error.message}\n\nCurrent file content:\n${contentStr}`,
+                  },
+                ],
+              };
+            } catch {
+              // If we can't read the file, just throw the original error
+              throw error;
+            }
+          }
+        }
+        // For all other errors, rethrow
+        throw error;
+      }
+    },
+  };
 }
 
 export function createOpenClawReadTool(base: AnyAgentTool): AnyAgentTool {


### PR DESCRIPTION
## Summary

When the Edit tool fails because `oldText` doesn't match the file content, the agent currently has to make a separate `Read` call to see the current state before retrying. This wastes tokens and context window.

**This PR wraps the Edit tool's `execute` method to return the current file content alongside the error message when a text mismatch occurs.** The agent can immediately see what changed and retry — no extra Read needed.

## Changes

- `src/agents/pi-tools.read.ts`: Wrap `createSandboxedEditTool` execute to catch "Could not find the exact text" errors and append current file content to the error response.

## Impact

- Saves 1 tool call (Read) per failed Edit retry
- Reduces token usage and context window consumption
- No behavior change for successful edits or non-mismatch errors

Closes #18132
