### PR TITLE
Feat(slack): add Canvas content reading support 

### DIFF
--- a/src/agents/tools/slack-actions.ts
+++ b/src/agents/tools/slack-actions.ts
@@ -10,6 +10,7 @@ import {
   listSlackReactions,
   pinSlackMessage,
   reactSlackMessage,
+  readSlackCanvas,
   readSlackMessages,
   removeOwnSlackReactions,
   removeSlackReaction,
@@ -342,6 +343,19 @@ export async function handleSlackAction(
     }
     return jsonResult({ ok: true, emojis: result });
   }
-
+if (action === "read-canvas") {
+  if (!isActionEnabled("canvas")) {
+    throw new Error("Slack canvas reading is disabled.");
+  }
+  const fileId = readStringParam(params, "fileId", { required: true });
+  const result = readOpts
+    ? await readSlackCanvas(fileId, readOpts)
+    : await readSlackCanvas(fileId);
+  const markdown = result.sections
+    .map((section) => section.markdown ?? "")
+    .join("\n\n")
+    .trim();
+  return jsonResult({ ok: true, markdown, sections: result.sections });
+}
   throw new Error(`Unknown action: ${action}`);
 }

--- a/src/slack/actions.ts
+++ b/src/slack/actions.ts
@@ -270,4 +270,16 @@ export async function listSlackPins(
   const client = await getClient(opts);
   const result = await client.pins.list({ channel: channelId });
   return (result.items ?? []) as SlackPin[];
+
+  export async function readSlackCanvas(
+  fileId: string,
+  opts: SlackActionClientOpts = {},
+): Promise<{ sections: Array<{ markdown?: string }> }> {
+  const client = await getClient(opts);
+  const result = await client.canvases.sections.lookup({
+    canvas_id: fileId,
+  });
+  return {
+    sections: (result.sections ?? []) as Array<{ markdown?: string }>,
+  }; 
 }

--- a/src/slack/message-actions.ts
+++ b/src/slack/message-actions.ts
@@ -41,9 +41,14 @@ export function listSlackMessageActions(cfg: OpenClawConfig): ChannelMessageActi
   if (isActionEnabled("memberInfo")) {
     actions.add("member-info");
   }
-  if (isActionEnabled("emojiList")) {
+if (isActionEnabled("emojiList")) {
     actions.add("emoji-list");
   }
+
+  if (isActionEnabled("canvas")) {
+    actions.add("read-canvas");
+  }
+
   return Array.from(actions);
 }
 


### PR DESCRIPTION
**## Summary**
- **Problem:** OpenClaw cannot read Slack Canvas documents (including Huddle summaries) even with files:read scope
- **Why it matters:** Users need to access Canvas content programmatically for automation, context gathering, and Huddle summary parsing
- **What changed:** Added read-canvas action using Slack's canvases.sections.lookup API to fetch and parse markdown content
- **What did NOT change:** No changes to existing Slack actions, message sending, or file upload functionality

**## Change Type (select all)**
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

**## Scope (select all touched areas)**
- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

**## Linked Issue/PR**
- [Closes #12601](https://github.com/openclaw/openclaw/issues/12601)

****## User-visible / Behavior Changes****
- New `read-canvas` action available in `message` tool for Slack channels
- Requires `canvases:read` scope in Slack app configuration
- Returns markdown content extracted from Canvas sections
- New config gate: `channels.slack.actions.canvas` (default: enabled)

**## Security Impact (required)**
- New permissions/capabilities? **Yes**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **Yes**
- Command/tool execution surface changed? **No**
- Data access scope changed? **Yes**

****Risk + mitigation:****
- Requires `canvases:read` Slack scope (read-only access to Canvas documents)
- Respects existing Slack action gating via `channels.slack.actions.canvas`
- Uses existing bot/user token resolution logic (no new auth paths)
- Read-only operation, cannot modify or delete Canvases

**## Repro + Verification**

**### Environment**
- OS: Any
- Runtime/container: Node.js (OpenClaw standard)
- Model/provider: N/A (Slack integration)
- Integration/channel: Slack
- Relevant config:
  ```yaml
  channels:
    slack:
     botToken: "xoxb-..."
     actions:
     canvas: true

**Steps**
1. Add canvases:read scope to Slack app
2. Reinstall app to workspace
3. Call message tool:{
  "action": "read-canvas",
  "channel": "slack",
  "fileId": "F0AFQP60601"
}

**Expected**
Returns Canvas content as markdown:

{
  "ok": true,
  "markdown": "# Huddle Notes\n\n- Topic 1\n- Topic 2",
  "sections": [{"markdown": "..."}]
}

**Actual**
(Will be verified after merge)

**Evidence**
• [x] Code changes in 3 files (actions.ts, message-actions.ts, slack-actions.ts)
• [ ] Test added (TODO: would strengthen PR)
• [ ] Verified against live Slack workspace with Canvas documents

**Human Verification**
• Verified scenarios: Code review, API alignment with Slack documentation
• Edge cases checked: Missing sections, empty markdown, missing fileId param
• What you did not verify: Live end-to-end test (no dev environment access)

**Compatibility / Migration**
• Backward compatible? Yes
• Config/env changes? No (new opt-in action)
• Migration needed? No

**Failure Recovery (if this breaks)**
• How to disable: Set channels.slack.actions.canvas: false in config
• Files to restore: Revert 3 files or disable via config
• Known bad symptoms: "Slack canvas reading is disabled" error, or API errors if scope missing

**Risks and Mitigations**
• Risk: Missing canvases:read scope causes API errors
• Mitigation: Clear error message + documented scope requirement
• Risk: Large Canvas documents consume excessive tokens
• Mitigation: Concatenated markdown returned as single string; caller can truncate if needed  
        
        