### PR TITLE
fix(matrix): deep-merge groups/rooms per-account config

### DIFF
--- a/extensions/matrix/src/matrix/accounts.test.ts
+++ b/extensions/matrix/src/matrix/accounts.test.ts
@@ -79,4 +79,45 @@ describe("resolveMatrixAccount", () => {
     const account = resolveMatrixAccount({ cfg });
     expect(account.configured).toBe(true);
   });
+
+  it("deep-merges groups/rooms maps for per-account overrides", () => {
+    const cfg: CoreConfig = {
+      channels: {
+        matrix: {
+          homeserver: "https://matrix.example.org",
+          accessToken: "tok-base",
+          groups: {
+            "*": { requireMention: true },
+            "!base:example.org": { requireMention: false },
+          },
+          rooms: {
+            "!legacyBase:example.org": { requireMention: true },
+          },
+          accounts: {
+            alerts: {
+              homeserver: "https://matrix.example.org",
+              accessToken: "tok-alerts",
+              groups: {
+                "!alerts:example.org": { requireMention: false },
+              },
+              rooms: {
+                "!legacyAlerts:example.org": { requireMention: false },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const account = resolveMatrixAccount({ cfg, accountId: "alerts" });
+    expect(account.config.groups).toEqual({
+      "*": { requireMention: true },
+      "!base:example.org": { requireMention: false },
+      "!alerts:example.org": { requireMention: false },
+    });
+    expect(account.config.rooms).toEqual({
+      "!legacyBase:example.org": { requireMention: true },
+      "!legacyAlerts:example.org": { requireMention: false },
+    });
+  });
 });

--- a/extensions/matrix/src/matrix/accounts.ts
+++ b/extensions/matrix/src/matrix/accounts.ts
@@ -7,7 +7,9 @@ import { credentialsMatchConfig, loadMatrixCredentials } from "./credentials.js"
 function mergeAccountConfig(base: MatrixConfig, account: MatrixConfig): MatrixConfig {
   const merged = { ...base, ...account };
   // Deep-merge known nested objects so partial overrides inherit base fields
-  for (const key of ["dm", "actions"] as const) {
+  // (Account configs should be able to add/override rooms/groups without
+  // having to re-specify the full top-level maps.)
+  for (const key of ["dm", "actions", "groups", "rooms"] as const) {
     const b = base[key];
     const o = account[key];
     if (typeof b === "object" && b != null && typeof o === "object" && o != null) {


### PR DESCRIPTION
## Summary

Extends the existing Matrix account config deep-merge functionality to include `groups` and `rooms` maps.

## Context

PR #15116 and related commits added deep-merge support for `dm` and `actions` config fields. However, `groups` and `rooms` were not included, which means per-account configs must fully re-specify these maps instead of being able to add/override individual entries.

## Changes

- Added `"groups"` and `"rooms"` to the deep-merge key list in `mergeAccountConfig()`
- Added comprehensive test case verifying the merge behavior

## Example

**Before:** Per-account config replaces entire groups/rooms maps
```typescript
// Base config has groups: { "*": {requireMention: true}, "!base:ex.org": {...} }
// Account config has groups: { "!alerts:ex.org": {...} }
// Result: Only "!alerts:ex.org" exists (lost base config)
```

**After:** Per-account config merges with base
```typescript
// Result: All three groups exist (base + account merged)
```

## Testing

- ✅ New test case added: `"deep-merges groups/rooms maps for per-account overrides"`
- ✅ Rebased on current main
- ✅ Existing tests pass