### PR TITLE
fix(cli): use resolveEffectiveUpdateChannel for git install default (#18702)

### DIFF
--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -9,9 +9,9 @@ import { readConfigFileSnapshot, writeConfigFile } from "../../config/config.js"
 import { resolveGatewayService } from "../../daemon/service.js";
 import {
   channelToNpmTag,
-  DEFAULT_GIT_CHANNEL,
   DEFAULT_PACKAGE_CHANNEL,
   normalizeUpdateChannel,
+  resolveEffectiveUpdateChannel,
 } from "../../infra/update-channels.js";
 import {
   compareSemverStrings,
@@ -498,7 +498,15 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
     requestedChannel !== null && requestedChannel !== "dev" && installKind === "git";
   const updateInstallKind = switchToGit ? "git" : switchToPackage ? "package" : installKind;
   const defaultChannel =
-    updateInstallKind === "git" ? DEFAULT_GIT_CHANNEL : DEFAULT_PACKAGE_CHANNEL;
+    updateInstallKind === "git"
+      ? resolveEffectiveUpdateChannel({
+          installKind: "git",
+          git: {
+            tag: updateStatus.git?.tag ?? null,
+            branch: updateStatus.git?.branch ?? null,
+          },
+        }).channel
+      : DEFAULT_PACKAGE_CHANNEL;
   const channel = requestedChannel ?? storedChannel ?? defaultChannel;
 
   const explicitTag = normalizeTag(opts.tag);


### PR DESCRIPTION
## Problem

Fixes #18702.

When a user installs OpenClaw from git and checks out a release tag (e.g. `v1.2.3` or `v1.2.3-beta.1`), `openclaw update` incorrectly defaults to the `dev` channel. This happens because the default was hardcoded to `DEFAULT_GIT_CHANNEL` (`"dev"`) regardless of the current git tag.

## Fix

Replace the naive hardcoded default with a call to the existing `resolveEffectiveUpdateChannel()` (from `src/infra/update-channels.ts`), passing in the current git tag and branch from `updateStatus.git`. That function already implements the correct logic:

| Situation | Channel |
|---|---|
| On a stable release tag (e.g. `v1.2.3`) | `stable` |
| On a beta release tag (e.g. `v1.2.3-beta.1`) | `beta` |
| On a branch (e.g. `main`) | `dev` |
| Untracked / no git info | `dev` |

The fix only affects the *default* channel resolution — any explicitly requested channel (`--channel`) or stored config channel takes precedence as before.

## Testing

- Existing tests in `src/cli/update-cli/` pass.
- No behavioral change for non-tag git installs (branch/untracked stays `dev`).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces the hardcoded `DEFAULT_GIT_CHANNEL` (`"dev"`) default with a call to `resolveEffectiveUpdateChannel()` so that `openclaw update` correctly defaults to `stable` or `beta` when on a release tag (e.g. `v1.2.3` or `v1.2.3-beta.1`), instead of always falling back to `dev`.

- The fix correctly omits `configChannel` from the `resolveEffectiveUpdateChannel` call since the stored config channel is already handled in the fallback chain (`requestedChannel ?? storedChannel ?? defaultChannel`).
- The `switchToGit` edge case (where `updateInstallKind` is `"git"` but `updateStatus.git` is undefined) is handled safely via optional chaining with null fallbacks, which causes `resolveEffectiveUpdateChannel` to return `"dev"` — the expected behavior when switching to a git install.
- The unused `DEFAULT_GIT_CHANNEL` import is cleanly removed.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a small, focused fix that reuses an existing well-tested utility function.
- The change is minimal (one file, ~10 lines), replaces a hardcoded constant with an existing utility function that already implements the correct logic, handles edge cases properly, and preserves existing behavior for non-tag git installs. The fallback chain for channel resolution (`requestedChannel ?? storedChannel ?? defaultChannel`) remains unchanged.
- No files require special attention.

<sub>Last reviewed commit: 834dd0c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->