### PR TITLE
fix(telegram): replace hyphen in export-session nativeName for setMyCommands

### DIFF
--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -77,7 +77,7 @@ Text + native (when enabled):
 - `/allowlist` (list/add/remove allowlist entries)
 - `/approve <id> allow-once|allow-always|deny` (resolve exec approval prompts)
 - `/context [list|detail|json]` (explain “context”; `detail` shows per-file + per-tool + per-skill + system prompt size)
-- `/export-session [path]` (alias: `/export`) (export current session to HTML with full system prompt)
+- `/export-session [path]` (aliases: `/export_session`, `/export`) (export current session to HTML with full system prompt)
 - `/whoami` (show your sender id; alias: `/id`)
 - `/subagents list|kill|log|info|send|steer` (inspect, kill, log, or steer sub-agent runs for the current session)
 - `/kill <id|#|all>` (immediately abort one or all running sub-agents for this session; no confirmation message)

--- a/src/auto-reply/commands-registry.data.ts
+++ b/src/auto-reply/commands-registry.data.ts
@@ -207,9 +207,9 @@ function buildChatCommands(): ChatCommandDefinition[] {
     }),
     defineChatCommand({
       key: "export-session",
-      nativeName: "export-session",
+      nativeName: "export_session",
       description: "Export current session to HTML file with full system prompt.",
-      textAliases: ["/export-session", "/export"],
+      textAliases: ["/export_session", "/export-session", "/export"],
       acceptsArgs: true,
       category: "status",
       args: [

--- a/src/auto-reply/reply/commands-export-session.ts
+++ b/src/auto-reply/reply/commands-export-session.ts
@@ -99,10 +99,14 @@ function generateHtml(sessionData: SessionData): string {
 
 function parseExportArgs(commandBodyNormalized: string): { outputPath?: string } {
   const normalized = commandBodyNormalized.trim();
-  if (normalized === "/export-session" || normalized === "/export") {
+  if (
+    normalized === "/export-session" ||
+    normalized === "/export_session" ||
+    normalized === "/export"
+  ) {
     return {};
   }
-  const args = normalized.replace(/^\/(export-session|export)\s*/, "").trim();
+  const args = normalized.replace(/^\/(export[-_]session|export)\s*/, "").trim();
   // First non-flag argument is the output path
   const outputPath = args.split(/\s+/).find((part) => !part.startsWith("-"));
   return { outputPath };

--- a/src/auto-reply/reply/commands-info.ts
+++ b/src/auto-reply/reply/commands-info.ts
@@ -176,7 +176,9 @@ export const handleExportSessionCommand: CommandHandler = async (params, allowTe
   const normalized = params.command.commandBodyNormalized;
   if (
     normalized !== "/export-session" &&
+    normalized !== "/export_session" &&
     !normalized.startsWith("/export-session ") &&
+    !normalized.startsWith("/export_session ") &&
     normalized !== "/export" &&
     !normalized.startsWith("/export ")
   ) {


### PR DESCRIPTION
## Summary

The `nativeName` change propagates through the command registry, handler guard, argument parser, and documentation, so all four files must remain consistent.

`setMyCommands` fails with `400 BOT_COMMAND_INVALID` because `export-session` contains a hyphen, which violates Telegram's bot command format (`/^[a-z0-9_]{1,32}$/`).

This one-line registration failure silently prevents **all** bot commands from being registered, not just the offending one.

### Changes

- Rename `nativeName` from `export-session` to `export_session`
- Add `/export_session` as a text alias alongside the existing `/export-session` and `/export`
- Update command handler matching to recognize both hyphen and underscore variants

### Test plan

- [x] `vitest run src/auto-reply/reply/commands.test.ts` — 61 tests pass
- [x] `vitest run src/telegram/bot-native-command-menu.test.ts` — 3 tests pass
- [x] `vitest run src/telegram/bot-native-commands.test.ts` — 4 tests pass
- [x] `tsc --noEmit` — no new errors

Closes #18683