### PR TITLE
fix(slack): add auth header when downloading forwarded attachment images

### DIFF
--- a/src/slack/monitor/media.ts
+++ b/src/slack/monitor/media.ts
@@ -273,8 +273,10 @@ export async function resolveSlackAttachmentContent(params: {
     const imageUrl = resolveForwardedAttachmentImageUrl(att);
     if (imageUrl) {
       try {
+        const fetchImpl = createSlackMediaFetch(params.token);
         const fetched = await fetchRemoteMedia({
           url: imageUrl,
+          fetchImpl,
           maxBytes: params.maxBytes,
         });
         if (fetched.buffer.byteLength <= params.maxBytes) {


### PR DESCRIPTION
## Summary

Forwarded-message attachment images (`attachment.image_url`) are downloaded without the Slack bot token. Slack returns its HTML sign-in/redirect page (~53 KB) instead of the actual file, so every saved image is broken.

The direct-file download path at L188 already uses `createSlackMediaFetch(token)` to attach the `Authorization: Bearer` header. This PR applies the same one-liner to the attachment-image path.

### Root cause

`resolveSlackAttachmentContent()` calls `fetchRemoteMedia()` without a `fetchImpl`, so it falls back to `globalThis.fetch` which has no Slack credentials. The fix mirrors the existing pattern at L188.

### Test plan

- [x] `vitest run src/slack/monitor/media.test.ts` — 24 tests pass
- [x] `tsc --noEmit` — no new errors

Closes #18642

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds missing Slack authentication when downloading forwarded message attachment images. Previously, `attachment.image_url` downloads fell back to `globalThis.fetch` without credentials, causing Slack to return its HTML redirect page (~53KB) instead of actual image files. The fix applies the same `createSlackMediaFetch(token)` pattern already used for direct file downloads at L210.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a minimal, well-tested bug fix that mirrors an existing working pattern in the same file. It adds only 2 lines to pass the required auth credentials, fixing a clear defect where images were broken. Tests pass and the implementation matches the established pattern at L210.
- No files require special attention

<sub>Last reviewed commit: 7fb69e4</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->