### PR TITLE
ci: avoid Bun setup GitHub tag API rate-limit failures

### DIFF
--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: Whether to install Bun alongside Node.
     required: false
     default: "true"
+  bun-version:
+    description: Bun version to install when install-bun is true.
+    required: false
+    default: "1.3.9"
   frozen-lockfile:
     description: Whether to use --frozen-lockfile for install.
     required: false
@@ -52,7 +56,8 @@ runs:
       if: inputs.install-bun == 'true'
       uses: oven-sh/setup-bun@v2
       with:
-        bun-version: latest
+        bun-version: ${{ inputs.bun-version }}
+        token: ${{ github.token }}
 
     - name: Runtime versions
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,7 +361,8 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.9
+          token: ${{ github.token }}
 
       - name: Runtime versions
         run: |


### PR DESCRIPTION
## Summary
- Identified the Bun resolution paths triggering GitHub API tag lookups in CI:
  - `.github/actions/setup-node-env/action.yml` (composite action used by multiple CI jobs)
  - `.github/workflows/ci.yml` (Windows checks job direct Bun setup)
- Replaced `bun-version: latest` with pinned `1.3.9` so setup-bun does not need to resolve latest via `GET /repos/oven-sh/bun/git/refs/tags` on every run.
- Passed `token: ${{ github.token }}` explicitly to `oven-sh/setup-bun@v2` to keep API calls authenticated when version resolution is needed.

## Failure mode addressed
CI intermittently fails with 403 while resolving Bun tags from the GitHub API (`/repos/oven-sh/bun/git/refs/tags`). Using `latest` forces tag-resolution requests per job, which can hit API limits under CI concurrency.

## Why this fix
- Smallest safe diff, scoped only to Bun setup in CI.
- Pinned Bun version avoids tag API lookups entirely in normal runs.
- Explicit token keeps fallback/resolution requests authenticated.

## Validation
- YAML parse check passed for changed files:
  - `.github/actions/setup-node-env/action.yml`
  - `.github/workflows/ci.yml`
