### PR TITLE
docs: add Portuguese translations for glossary, agent concepts, and memory …

### DIFF
--- a/docs/.i18n/glossary.pt-BR.json
+++ b/docs/.i18n/glossary.pt-BR.json
@@ -1,0 +1,1058 @@
+[
+  {
+    "source": "OpenClaw",
+    "target": "OpenClaw"
+  },
+  {
+    "source": "Gateway",
+    "target": "Gateway"
+  },
+  {
+    "source": "Pi",
+    "target": "Pi"
+  },
+  {
+    "source": "Skills",
+    "target": "Skills"
+  },
+  {
+    "source": "Skills config",
+    "target": "configuração de Skills"
+  },
+  {
+    "source": "Skills Config",
+    "target": "configuração de Skills"
+  },
+  {
+    "source": "local loopback",
+    "target": "local loopback"
+  },
+  {
+    "source": "Tailscale",
+    "target": "Tailscale"
+  },
+  {
+    "source": "Getting Started",
+    "target": "Começando"
+  },
+  {
+    "source": "Getting started",
+    "target": "começando"
+  },
+  {
+    "source": "Quick start",
+    "target": "início rápido"
+  },
+  {
+    "source": "Quick Start",
+    "target": "Início Rápido"
+  },
+  {
+    "source": "Docs directory",
+    "target": "diretório de documentação"
+  },
+  {
+    "source": "Credits",
+    "target": "Créditos"
+  },
+  {
+    "source": "Features",
+    "target": "Recursos"
+  },
+  {
+    "source": "DMs",
+    "target": "mensagens diretas"
+  },
+  {
+    "source": "DM",
+    "target": "mensagem direta"
+  },
+  {
+    "source": "sandbox",
+    "target": "área isolada"
+  },
+  {
+    "source": "Sandbox",
+    "target": "Área Isolada"
+  },
+  {
+    "source": "sandboxing",
+    "target": "isolamento em área restrita"
+  },
+  {
+    "source": "Sandboxing",
+    "target": "Isolamento em Área Restrita"
+  },
+  {
+    "source": "sandboxed",
+    "target": "isolado em área restrita"
+  },
+  {
+    "source": "Sandboxed",
+    "target": "Isolado em Área Restrita"
+  },
+  {
+    "source": "Sandboxing note",
+    "target": "nota sobre isolamento em área restrita"
+  },
+  {
+    "source": "Companion apps",
+    "target": "aplicativos complementares"
+  },
+  {
+    "source": "expected keys",
+    "target": "chaves esperadas"
+  },
+  {
+    "source": "block streaming",
+    "target": "transmissão em blocos"
+  },
+  {
+    "source": "Block streaming",
+    "target": "Transmissão em Blocos"
+  },
+  {
+    "source": "Discovery + transports",
+    "target": "Descoberta + transportes"
+  },
+  {
+    "source": "Discovery",
+    "target": "Descoberta"
+  },
+  {
+    "source": "Network model",
+    "target": "Modelo de Rede"
+  },
+  {
+    "source": "for full details",
+    "target": "para mais detalhes"
+  },
+  {
+    "source": "First 60 seconds",
+    "target": "Primeiros 60 segundos"
+  },
+  {
+    "source": "Auth: where it lives (important)",
+    "target": "Autenticação: onde fica (importante)"
+  },
+  {
+    "source": "agent",
+    "target": "agente"
+  },
+  {
+    "source": "channel",
+    "target": "canal"
+  },
+  {
+    "source": "session",
+    "target": "sessão"
+  },
+  {
+    "source": "provider",
+    "target": "provedor"
+  },
+  {
+    "source": "model",
+    "target": "modelo"
+  },
+  {
+    "source": "tool",
+    "target": "ferramenta"
+  },
+  {
+    "source": "CLI",
+    "target": "CLI"
+  },
+  {
+    "source": "install sanity",
+    "target": "verificação de integridade da instalação"
+  },
+  {
+    "source": "get unstuck",
+    "target": "resolver problemas"
+  },
+  {
+    "source": "troubleshooting",
+    "target": "resolução de problemas"
+  },
+  {
+    "source": "FAQ",
+    "target": "Perguntas Frequentes"
+  },
+  {
+    "source": "onboarding",
+    "target": "integração"
+  },
+  {
+    "source": "Onboarding",
+    "target": "Integração"
+  },
+  {
+    "source": "wizard",
+    "target": "assistente"
+  },
+  {
+    "source": "environment variables",
+    "target": "variáveis de ambiente"
+  },
+  {
+    "source": "environment variable",
+    "target": "variável de ambiente"
+  },
+  {
+    "source": "API key",
+    "target": "chave de API"
+  },
+  {
+    "source": "token",
+    "target": "token"
+  },
+  {
+    "source": "webhook",
+    "target": "webhook"
+  },
+  {
+    "source": "webhook trigger",
+    "target": "gatilho de webhook"
+  },
+  {
+    "source": "WhatsApp",
+    "target": "WhatsApp"
+  },
+  {
+    "source": "Telegram",
+    "target": "Telegram"
+  },
+  {
+    "source": "Discord",
+    "target": "Discord"
+  },
+  {
+    "source": "Slack",
+    "target": "Slack"
+  },
+  {
+    "source": "Signal",
+    "target": "Signal"
+  },
+  {
+    "source": "Google Chat",
+    "target": "Google Chat"
+  },
+  {
+    "source": "iMessage",
+    "target": "iMessage"
+  },
+  {
+    "source": "node host",
+    "target": "host de nó"
+  },
+  {
+    "source": "device pair",
+    "target": "emparelhar dispositivo"
+  },
+  {
+    "source": "device pairing",
+    "target": "emparelhamento de dispositivo"
+  },
+  {
+    "source": "web provider",
+    "target": "provedor web"
+  },
+  {
+    "source": "LLM",
+    "target": "LLM"
+  },
+  {
+    "source": "model provider",
+    "target": "provedor de modelo"
+  },
+  {
+    "source": "ACP",
+    "target": "ACP"
+  },
+  {
+    "source": "Anthropic",
+    "target": "Anthropic"
+  },
+  {
+    "source": "Claude",
+    "target": "Claude"
+  },
+  {
+    "source": "OpenAI",
+    "target": "OpenAI"
+  },
+  {
+    "source": "plugin",
+    "target": "plugin"
+  },
+  {
+    "source": "browser automation",
+    "target": "automação de navegador"
+  },
+  {
+    "source": "browser tool",
+    "target": "ferramenta de navegador"
+  },
+  {
+    "source": "Docker",
+    "target": "Docker"
+  },
+  {
+    "source": "HTTP request",
+    "target": "solicitação HTTP"
+  },
+  {
+    "source": "SSH",
+    "target": "SSH"
+  },
+  {
+    "source": "Bonjour",
+    "target": "Bonjour"
+  },
+  {
+    "source": "mDNS",
+    "target": "mDNS"
+  },
+  {
+    "source": "DNS",
+    "target": "DNS"
+  },
+  {
+    "source": "TLS",
+    "target": "TLS"
+  },
+  {
+    "source": "WebSocket",
+    "target": "WebSocket"
+  },
+  {
+    "source": "HTTP",
+    "target": "HTTP"
+  },
+  {
+    "source": "HTTPS",
+    "target": "HTTPS"
+  },
+  {
+    "source": "JSON",
+    "target": "JSON"
+  },
+  {
+    "source": "API",
+    "target": "API"
+  },
+  {
+    "source": "REST",
+    "target": "REST"
+  },
+  {
+    "source": "OAuth",
+    "target": "OAuth"
+  },
+  {
+    "source": "installation",
+    "target": "instalação"
+  },
+  {
+    "source": "activation",
+    "target": "ativação"
+  },
+  {
+    "source": "configuration",
+    "target": "configuração"
+  },
+  {
+    "source": "approvals",
+    "target": "aprovações"
+  },
+  {
+    "source": "allowlist",
+    "target": "lista de permissão"
+  },
+  {
+    "source": "allowlists",
+    "target": "listas de permissão"
+  },
+  {
+    "source": "remote access",
+    "target": "acesso remoto"
+  },
+  {
+    "source": "local access",
+    "target": "acesso local"
+  },
+  {
+    "source": "security",
+    "target": "segurança"
+  },
+  {
+    "source": "authentication",
+    "target": "autenticação"
+  },
+  {
+    "source": "authorization",
+    "target": "autorização"
+  },
+  {
+    "source": "credentials",
+    "target": "credenciais"
+  },
+  {
+    "source": "password",
+    "target": "senha"
+  },
+  {
+    "source": "username",
+    "target": "nome de usuário"
+  },
+  {
+    "source": "service account",
+    "target": "conta de serviço"
+  },
+  {
+    "source": "device token",
+    "target": "token de dispositivo"
+  },
+  {
+    "source": "session key",
+    "target": "chave de sessão"
+  },
+  {
+    "source": "workspace",
+    "target": "espaço de trabalho"
+  },
+  {
+    "source": "configuration file",
+    "target": "arquivo de configuração"
+  },
+  {
+    "source": "config file",
+    "target": "arquivo de configuração"
+  },
+  {
+    "source": "cron job",
+    "target": "tarefa cron"
+  },
+  {
+    "source": "scheduled task",
+    "target": "tarefa agendada"
+  },
+  {
+    "source": "heartbeat",
+    "target": "batida cardíaca"
+  },
+  {
+    "source": "memory",
+    "target": "memória"
+  },
+  {
+    "source": "vector database",
+    "target": "banco de dados vetorial"
+  },
+  {
+    "source": "semantic search",
+    "target": "busca semântica"
+  },
+  {
+    "source": "embedding",
+    "target": "incorporação"
+  },
+  {
+    "source": "prompt",
+    "target": "prompt"
+  },
+  {
+    "source": "system prompt",
+    "target": "prompt de sistema"
+  },
+  {
+    "source": "response",
+    "target": "resposta"
+  },
+  {
+    "source": "output",
+    "target": "saída"
+  },
+  {
+    "source": "input",
+    "target": "entrada"
+  },
+  {
+    "source": "message",
+    "target": "mensagem"
+  },
+  {
+    "source": "conversation",
+    "target": "conversa"
+  },
+  {
+    "source": "thread",
+    "target": "thread"
+  },
+  {
+    "source": "command",
+    "target": "comando"
+  },
+  {
+    "source": "subcommand",
+    "target": "subcomando"
+  },
+  {
+    "source": "flag",
+    "target": "sinalizador"
+  },
+  {
+    "source": "option",
+    "target": "opção"
+  },
+  {
+    "source": "argument",
+    "target": "argumento"
+  },
+  {
+    "source": "parameter",
+    "target": "parâmetro"
+  },
+  {
+    "source": "usage",
+    "target": "uso"
+  },
+  {
+    "source": "example",
+    "target": "exemplo"
+  },
+  {
+    "source": "syntax",
+    "target": "sintaxe"
+  },
+  {
+    "source": "output format",
+    "target": "formato de saída"
+  },
+  {
+    "source": "JSON output",
+    "target": "saída JSON"
+  },
+  {
+    "source": "plain text",
+    "target": "texto simples"
+  },
+  {
+    "source": "log",
+    "target": "registro"
+  },
+  {
+    "source": "logging",
+    "target": "registro de logs"
+  },
+  {
+    "source": "debug",
+    "target": "depuração"
+  },
+  {
+    "source": "debugging",
+    "target": "depuração"
+  },
+  {
+    "source": "error",
+    "target": "erro"
+  },
+  {
+    "source": "error handling",
+    "target": "tratamento de erros"
+  },
+  {
+    "source": "exception",
+    "target": "exceção"
+  },
+  {
+    "source": "timeout",
+    "target": "tempo limite"
+  },
+  {
+    "source": "retry",
+    "target": "tentar novamente"
+  },
+  {
+    "source": "fallback",
+    "target": "alternativa de fallback"
+  },
+  {
+    "source": "status",
+    "target": "status"
+  },
+  {
+    "source": "health check",
+    "target": "verificação de saúde"
+  },
+  {
+    "source": "diagnostic",
+    "target": "diagnóstico"
+  },
+  {
+    "source": "monitoring",
+    "target": "monitoramento"
+  },
+  {
+    "source": "metrics",
+    "target": "métricas"
+  },
+  {
+    "source": "performance",
+    "target": "desempenho"
+  },
+  {
+    "source": "optimization",
+    "target": "otimização"
+  },
+  {
+    "source": "scaling",
+    "target": "dimensionamento"
+  },
+  {
+    "source": "deployment",
+    "target": "implantação"
+  },
+  {
+    "source": "update",
+    "target": "atualização"
+  },
+  {
+    "source": "upgrade",
+    "target": "atualização"
+  },
+  {
+    "source": "migration",
+    "target": "migração"
+  },
+  {
+    "source": "backup",
+    "target": "backup"
+  },
+  {
+    "source": "restore",
+    "target": "restaurar"
+  },
+  {
+    "source": "file system",
+    "target": "sistema de arquivos"
+  },
+  {
+    "source": "directory",
+    "target": "diretório"
+  },
+  {
+    "source": "path",
+    "target": "caminho"
+  },
+  {
+    "source": "permission",
+    "target": "permissão"
+  },
+  {
+    "source": "access control",
+    "target": "controle de acesso"
+  },
+  {
+    "source": "user",
+    "target": "usuário"
+  },
+  {
+    "source": "group",
+    "target": "grupo"
+  },
+  {
+    "source": "role",
+    "target": "função"
+  },
+  {
+    "source": "scope",
+    "target": "escopo"
+  },
+  {
+    "source": "permission scope",
+    "target": "escopo de permissão"
+  },
+  {
+    "source": "rate limit",
+    "target": "limite de taxa"
+  },
+  {
+    "source": "quota",
+    "target": "cota"
+  },
+  {
+    "source": "billing",
+    "target": "faturamento"
+  },
+  {
+    "source": "pricing",
+    "target": "preços"
+  },
+  {
+    "source": "usage",
+    "target": "uso"
+  },
+  {
+    "source": "feedback",
+    "target": "feedback"
+  },
+  {
+    "source": "support",
+    "target": "suporte"
+  },
+  {
+    "source": "community",
+    "target": "comunidade"
+  },
+  {
+    "source": "documentation",
+    "target": "documentação"
+  },
+  {
+    "source": "release notes",
+    "target": "notas de versão"
+  },
+  {
+    "source": "changelog",
+    "target": "registro de alterações"
+  },
+  {
+    "source": "roadmap",
+    "target": "roteiro"
+  },
+  {
+    "source": "feature request",
+    "target": "solicitação de recurso"
+  },
+  {
+    "source": "bug report",
+    "target": "relatório de bug"
+  },
+  {
+    "source": "issue",
+    "target": "problema"
+  },
+  {
+    "source": "pull request",
+    "target": "solicitação de pull"
+  },
+  {
+    "source": "code review",
+    "target": "revisão de código"
+  },
+  {
+    "source": "testing",
+    "target": "testes"
+  },
+  {
+    "source": "test",
+    "target": "teste"
+  },
+  {
+    "source": "unit test",
+    "target": "teste unitário"
+  },
+  {
+    "source": "integration test",
+    "target": "teste de integração"
+  },
+  {
+    "source": "end-to-end test",
+    "target": "teste end-to-end"
+  },
+  {
+    "source": "e2e",
+    "target": "e2e"
+  },
+  {
+    "source": "CI/CD",
+    "target": "CI/CD"
+  },
+  {
+    "source": "continuous integration",
+    "target": "integração contínua"
+  },
+  {
+    "source": "continuous deployment",
+    "target": "implantação contínua"
+  },
+  {
+    "source": "Git",
+    "target": "Git"
+  },
+  {
+    "source": "GitHub",
+    "target": "GitHub"
+  },
+  {
+    "source": "branch",
+    "target": "branch"
+  },
+  {
+    "source": "commit",
+    "target": "commit"
+  },
+  {
+    "source": "merge",
+    "target": "mesclar"
+  },
+  {
+    "source": "rebase",
+    "target": "rebase"
+  },
+  {
+    "source": "stash",
+    "target": "stash"
+  },
+  {
+    "source": "version",
+    "target": "versão"
+  },
+  {
+    "source": "release",
+    "target": "versão"
+  },
+  {
+    "source": "stable",
+    "target": "estável"
+  },
+  {
+    "source": "beta",
+    "target": "beta"
+  },
+  {
+    "source": "alpha",
+    "target": "alfa"
+  },
+  {
+    "source": "dev",
+    "target": "dev"
+  },
+  {
+    "source": "development",
+    "target": "desenvolvimento"
+  },
+  {
+    "source": "production",
+    "target": "produção"
+  },
+  {
+    "source": "staging",
+    "target": "preprodução"
+  },
+  {
+    "source": "environment",
+    "target": "ambiente"
+  },
+  {
+    "source": "dependencies",
+    "target": "dependências"
+  },
+  {
+    "source": "package manager",
+    "target": "gerenciador de pacotes"
+  },
+  {
+    "source": "npm",
+    "target": "npm"
+  },
+  {
+    "source": "pnpm",
+    "target": "pnpm"
+  },
+  {
+    "source": "TypeScript",
+    "target": "TypeScript"
+  },
+  {
+    "source": "JavaScript",
+    "target": "JavaScript"
+  },
+  {
+    "source": "Node.js",
+    "target": "Node.js"
+  },
+  {
+    "source": "server",
+    "target": "servidor"
+  },
+  {
+    "source": "client",
+    "target": "cliente"
+  },
+  {
+    "source": "backend",
+    "target": "backend"
+  },
+  {
+    "source": "frontend",
+    "target": "frontend"
+  },
+  {
+    "source": "database",
+    "target": "banco de dados"
+  },
+  {
+    "source": "cache",
+    "target": "cache"
+  },
+  {
+    "source": "queue",
+    "target": "fila"
+  },
+  {
+    "source": "worker",
+    "target": "worker"
+  },
+  {
+    "source": "background job",
+    "target": "tarefa em segundo plano"
+  },
+  {
+    "source": "async",
+    "target": "assíncrono"
+  },
+  {
+    "source": "asynchronous",
+    "target": "assíncrono"
+  },
+  {
+    "source": "sync",
+    "target": "síncrono"
+  },
+  {
+    "source": "synchronous",
+    "target": "síncrono"
+  },
+  {
+    "source": "callback",
+    "target": "callback"
+  },
+  {
+    "source": "promise",
+    "target": "promise"
+  },
+  {
+    "source": "async/await",
+    "target": "async/await"
+  },
+  {
+    "source": "middleware",
+    "target": "middleware"
+  },
+  {
+    "source": "routing",
+    "target": "roteamento"
+  },
+  {
+    "source": "module",
+    "target": "módulo"
+  },
+  {
+    "source": "package",
+    "target": "pacote"
+  },
+  {
+    "source": "library",
+    "target": "biblioteca"
+  },
+  {
+    "source": "framework",
+    "target": "framework"
+  },
+  {
+    "source": "utility",
+    "target": "utilitário"
+  },
+  {
+    "source": "helper",
+    "target": "auxiliar"
+  },
+  {
+    "source": "interface",
+    "target": "interface"
+  },
+  {
+    "source": "type",
+    "target": "tipo"
+  },
+  {
+    "source": "class",
+    "target": "classe"
+  },
+  {
+    "source": "function",
+    "target": "função"
+  },
+  {
+    "source": "method",
+    "target": "método"
+  },
+  {
+    "source": "property",
+    "target": "propriedade"
+  },
+  {
+    "source": "variable",
+    "target": "variável"
+  },
+  {
+    "source": "constant",
+    "target": "constante"
+  },
+  {
+    "source": "enum",
+    "target": "enumeração"
+  },
+  {
+    "source": "object",
+    "target": "objeto"
+  },
+  {
+    "source": "array",
+    "target": "array"
+  },
+  {
+    "source": "string",
+    "target": "string"
+  },
+  {
+    "source": "number",
+    "target": "número"
+  },
+  {
+    "source": "boolean",
+    "target": "booleano"
+  },
+  {
+    "source": "null",
+    "target": "nulo"
+  },
+  {
+    "source": "undefined",
+    "target": "indefinido"
+  },
+  {
+    "source": "error message",
+    "target": "mensagem de erro"
+  },
+  {
+    "source": "warning message",
+    "target": "mensagem de aviso"
+  },
+  {
+    "source": "info message",
+    "target": "mensagem de informação"
+  },
+  {
+    "source": "success message",
+    "target": "mensagem de sucesso"
+  },
+  {
+    "source": "confirmation",
+    "target": "confirmação"
+  }
+]

--- a/docs/pt-BR/concepts/agent-loop.md
+++ b/docs/pt-BR/concepts/agent-loop.md
@@ -1,0 +1,96 @@
+---
+summary: "Ciclo de vida do loop do agente, streams e semântica de espera"
+read_when:
+  - Você precisa de um walkthrough exato do loop do agente ou eventos de ciclo de vida
+title: "Loop do Agente"
+---
+
+# Loop do Agente (OpenClaw)
+
+Um loop agentic é a execução "real" completa de um agente: intake → montagem de contexto → inferência de modelo → execução de ferramentas → respostas em stream → persistência. É o caminho autoritário que transforma uma mensagem em ações e uma resposta final, mantendo o estado da sessão consistente.
+
+Em OpenClaw, um loop é uma execução única e serializada por sessão que emite eventos de ciclo de vida e stream enquanto o modelo pensa, chama ferramentas e faz stream de saída. Este documento explica como esse loop autêntico é conectado ponta a ponta.
+
+## Pontos de entrada
+
+- Gateway RPC: `agent` e `agent.wait`.
+- CLI: comando `agent`.
+
+## Como funciona (alto nível)
+
+1. `agent` RPC valida parâmetros, resolve sessão (sessionKey/sessionId), persiste metadados de sessão, retorna `{ runId, acceptedAt }` imediatamente.
+2. `agentCommand` executa o agente:
+   - resolve model + padrões thinking/verbose
+   - carrega snapshot de skills
+   - chama `runEmbeddedPiAgent` (runtime pi-agent-core)
+   - emite **lifecycle end/error** se o loop incorporado não emitir um
+3. `runEmbeddedPiAgent`:
+   - serializa execuções via filas por sessão + globais
+   - resolve model + perfil de autenticação e constrói a sessão pi
+   - se inscreve em eventos pi e faz stream de deltas de assistente/ferramenta
+   - força timeout -> aborta execução se excedido
+   - retorna payloads + metadados de uso
+4. `subscribeEmbeddedPiSession` faz a ponte entre eventos pi-agent-core e stream `agent` do OpenClaw:
+   - eventos de ferramenta => `stream: "tool"`
+   - deltas de assistente => `stream: "assistant"`
+   - eventos de ciclo de vida => `stream: "lifecycle"` (`phase: "start" | "end" | "error"`)
+5. `agent.wait` usa `waitForAgentJob`:
+   - aguarda **lifecycle end/error** para `runId`
+   - retorna `{ status: ok|error|timeout, startedAt, endedAt, error? }`
+
+## Fila + concorrência
+
+- Execuções são serializadas por chave de sessão (pista de sessão) e opcionalmente através de uma pista global.
+- Isso previne corridas de ferramenta/sessão e mantém histórico de sessão consistente.
+- Canais de mensagens podem escolher modos de fila (collect/steer/followup) que alimentam este sistema de pista.
+  Veja [Fila de Comando](/concepts/queue).
+
+## Preparação de sessão + workspace
+
+- Workspace é resolvido e criado; execuções em sandbox podem redirecionar para uma raiz de workspace sandbox.
+- Skills são carregadas (ou reutilizadas de um snapshot) e injetadas em env e prompt.
+- Arquivos de bootstrap/contexto são resolvidos e injetados no relatório de prompt do sistema.
+- Um lock de escrita de sessão é adquirido; `SessionManager` é aberto e preparado antes do streaming.
+
+## Montagem de prompt + prompt do sistema
+
+- Prompt do sistema é construído a partir do prompt base do OpenClaw, prompt de skills, contexto de bootstrap e substituições por execução.
+- Limites específicos de modelo e tokens de reserva de compactação são aplicados.
+- Veja [System prompt](/pt-BR/concepts/system-prompt) para o que o modelo vê.
+
+## Pontos de gancho (onde você pode interceptar)
+
+OpenClaw tem dois sistemas de gancho:
+
+- **Ganchos internos** (Ganchos gateway): scripts orientados por eventos para comandos e eventos de ciclo de vida.
+- **Ganchos de plugin**: pontos de extensão dentro do ciclo de vida de agente/ferramenta e pipeline do gateway.
+
+### Ganchos internos (Ganchos gateway)
+
+- **`agent:bootstrap`**: executa durante a construção de arquivos de bootstrap antes do prompt do sistema ser finalizado.
+  Use isso para adicionar/remover arquivos de contexto de bootstrap.
+- **Ganchos de comando**: `/new`, `/reset`, `/stop` e outros eventos de comando (veja documentação de Ganchos).
+
+Veja [Ganchos](/automation/hooks) para setup e exemplos.
+
+### Ganchos de plugin (ciclo de vida de agente + gateway)
+
+Estes executam dentro do loop do agente ou pipeline do gateway:
+
+- **`before_agent_start`**: injeta contexto ou sobrescreve prompt do sistema antes da execução iniciar.
+- **`agent_end`**: inspeciona a lista final de mensagens e metadados de execução após conclusão.
+- **`before_compaction` / `after_compaction`**: observe ou anote ciclos de compactação.
+- **`before_tool_call` / `after_tool_call`**: intercepta parâmetros/resultados de ferramenta.
+- **`tool_result_persist`**: transforma sincronamente resultados de ferramenta antes de serem escritos na transcrição de sessão.
+- **`message_received` / `message_sending` / `message_sent`**: ganchos de mensagem de entrada + saída.
+- **`session_start` / `session_end`**: limites de ciclo de vida de sessão.
+- **`gateway_start` / `gateway_stop`**: eventos de ciclo de vida do gateway.
+
+Veja [Plugins](/tools/plugin#plugin-hooks) para detalhes da API de gancho e registro.
+
+## Streaming + respostas parciais
+
+- Deltas de assistente são feitas em stream a partir de pi-agent-core e emitidas como eventos `assistant`.
+- Block streaming pode emitir respostas parciais em `text_end` ou `message_end`.
+- Streaming de raciocínio pode ser emitido como um stream separado ou como respostas de bloco.
+- Veja [Streaming](/pt-BR/concepts/streaming) para comportamento de chunking e resposta de bloco.

--- a/docs/pt-BR/concepts/agent-workspace.md
+++ b/docs/pt-BR/concepts/agent-workspace.md
@@ -1,0 +1,209 @@
+---
+summary: "Workspace do agente: localização, layout e estratégia de backup"
+read_when:
+  - Você precisa explicar o workspace do agente ou seu layout de arquivo
+  - Você quer fazer backup ou migrar um workspace de agente
+title: "Workspace do Agente"
+---
+
+# Workspace do agente
+
+O workspace é a casa do agente. É o único diretório de trabalho usado para ferramentas de arquivo e para contexto de workspace. Mantenha-o privado e trate-o como memória.
+
+Isso é separado de `~/.openclaw/`, que armazena config, credenciais e sessões.
+
+**Importante:** o workspace é o **cwd padrão**, não um sandbox rígido. Ferramentas resolvem caminhos relativos contra o workspace, mas caminhos absolutos ainda podem alcançar outro lugar no host a menos que sandboxing esteja habilitado. Se você precisar de isolamento, use [`agents.defaults.sandbox`](/gateway/sandboxing) (e/ou config de sandbox por agente).
+Quando sandboxing está habilitado e `workspaceAccess` não é `"rw"`, ferramentas operam dentro de um workspace sandbox sob `~/.openclaw/sandboxes`, não seu workspace de host.
+
+## Localização padrão
+
+- Padrão: `~/.openclaw/workspace`
+- Se `OPENCLAW_PROFILE` estiver definido e não for `"default"`, o padrão se torna `~/.openclaw/workspace-<profile>`.
+- Sobrescrever em `~/.openclaw/openclaw.json`:
+
+```json5
+{
+  agent: {
+    workspace: "~/.openclaw/workspace",
+  },
+}
+```
+
+`openclaw onboard`, `openclaw configure`, ou `openclaw setup` criará o workspace e plantará os arquivos de bootstrap se estiverem faltando.
+
+Se você já gerenciar os arquivos de workspace você mesmo, você pode desabilitar criação de arquivo de bootstrap:
+
+```json5
+{ agent: { skipBootstrap: true } }
+```
+
+## Pastas de workspace extra
+
+Instalações mais antigas podem ter criado `~/openclaw`. Manter vários diretórios de workspace pode causar drift de autenticação confusa ou de estado, porque apenas um workspace está ativo por vez.
+
+**Recomendação:** mantenha um único workspace ativo. Se você não usar mais os folders extras, arquive ou mova-os para a Lixeira (por exemplo `trash ~/openclaw`).
+Se você intencionalmente manter múltiplos workspaces, certifique-se de que `agents.defaults.workspace` aponta para o ativo.
+
+`openclaw doctor` avisa quando detecta diretórios de workspace extras.
+
+## Mapa de arquivo do workspace (o que cada arquivo significa)
+
+Estes são os arquivos padrão que OpenClaw espera dentro do workspace:
+
+- `AGENTS.md`
+  - Instruções operacionais para o agente e como deve usar memória.
+  - Carregado no início de cada sessão.
+  - Um bom lugar para regras, prioridades e detalhes de "como se comportar".
+
+- `SOUL.md`
+  - Persona, tom e limites.
+  - Carregado cada sessão.
+
+- `USER.md`
+  - Quem é o usuário e como abordá-lo.
+  - Carregado cada sessão.
+
+- `IDENTITY.md`
+  - Nome do agente, vibe e emoji.
+  - Criado/atualizado durante o ritual de bootstrap.
+
+- `TOOLS.md`
+  - Notas sobre suas ferramentas locais e convenções.
+  - Não controla disponibilidade de ferramenta; é apenas orientação.
+
+- `HEARTBEAT.md`
+  - Checklist opcional minúsculo para execuções de heartbeat.
+  - Mantenha breve para evitar queima de token.
+
+- `BOOT.md`
+  - Checklist de inicialização opcional executado no reinício do gateway quando ganchos internos estão habilitados.
+  - Mantenha breve; use a ferramenta de mensagem para envios de saída.
+
+- `BOOTSTRAP.md`
+  - Ritual de primeira execução único.
+  - Apenas criado para um workspace totalmente novo.
+  - Exclua-o após o ritual estar completo.
+
+- `memory/YYYY-MM-DD.md`
+  - Log diário de memória (um arquivo por dia).
+  - Recomendado ler hoje + ontem no início da sessão.
+
+- `MEMORY.md` (opcional)
+  - Memória de longo prazo curada.
+  - Só carregue na sessão principal privada (não contextos compartilhados/grupo).
+
+Veja [Memória](/pt-BR/concepts/memory) para fluxo de trabalho e flush de memória automática.
+
+- `skills/` (opcional)
+  - Skills específicas de workspace.
+  - Sobrescreve skills gerenciadas/agrupadas quando nomes colidem.
+
+- `canvas/` (opcional)
+  - Arquivos de UI Canvas para exibições de nó (por exemplo `canvas/index.html`).
+
+Se algum arquivo de bootstrap estiver faltando, OpenClaw injeta um marcador "arquivo faltando" na sessão e continua. Arquivos de bootstrap grandes são truncados quando injetados; ajuste limites com `agents.defaults.bootstrapMaxChars` (padrão: 20000) e `agents.defaults.bootstrapTotalMaxChars` (padrão: 150000).
+`openclaw setup` pode recriar padrões faltando sem sobrescrever arquivos existentes.
+
+## O que NÃO está no workspace
+
+Estes vivem sob `~/.openclaw/` e NÃO devem ser commitados para o repo do workspace:
+
+- `~/.openclaw/openclaw.json` (config)
+- `~/.openclaw/credentials/` (tokens OAuth, chaves de API)
+- `~/.openclaw/agents/<agentId>/sessions/` (transcrições de sessão + metadados)
+- `~/.openclaw/skills/` (skills gerenciadas)
+
+Se você precisar migrar sessões ou config, copie-os separadamente e mantenha-os fora do controle de versão.
+
+## Backup Git (recomendado, privado)
+
+Trate o workspace como memória privada. Coloque-o em um repo git **privado** para que seja feito backup e recuperável.
+
+Execute essas etapas na máquina onde o Gateway é executado (é onde o workspace vive).
+
+### 1) Inicializar o repo
+
+Se git estiver instalado, workspaces novíssimas são inicializadas automaticamente. Se este workspace não é já um repo, execute:
+
+```bash
+cd ~/.openclaw/workspace
+git init
+git add AGENTS.md SOUL.md TOOLS.md IDENTITY.md USER.md HEARTBEAT.md memory/
+git commit -m "Add agent workspace"
+```
+
+### 2) Adicionar um remote privado (opções amigáveis para iniciantes)
+
+Opção A: GitHub web UI
+
+1. Crie um novo repositório **privado** no GitHub.
+2. Não inicialize com um README (evita conflitos de merge).
+3. Copie a URL remota HTTPS.
+4. Adicione o remote e envie:
+
+```bash
+git branch -M main
+git remote add origin <https-url>
+git push -u origin main
+```
+
+Opção B: GitHub CLI (`gh`)
+
+```bash
+gh auth login
+gh repo create openclaw-workspace --private --source . --remote origin --push
+```
+
+Opção C: GitLab web UI
+
+1. Crie um novo repositório **privado** no GitLab.
+2. Não inicialize com um README (evita conflitos de merge).
+3. Copie a URL remota HTTPS.
+4. Adicione o remote e envie:
+
+```bash
+git branch -M main
+git remote add origin <https-url>
+git push -u origin main
+```
+
+### 3) Atualizações contínuas
+
+```bash
+git status
+git add .
+git commit -m "Update memory"
+git push
+```
+
+## Não comita segredos
+
+Mesmo em um repo privado, evite armazenar segredos no workspace:
+
+- Chaves de API, tokens OAuth, senhas ou credenciais privadas.
+- Qualquer coisa sob `~/.openclaw/`.
+- Despejo bruto de chats ou anexos sensíveis.
+
+Se você deve armazenar referências sensíveis, use placeholders e mantenha o segredo real em outro lugar (gerenciador de senhas, variáveis de ambiente, ou `~/.openclaw/`).
+
+Iniciador `.gitignore` sugerido:
+
+```gitignore
+.DS_Store
+.env
+**/*.key
+**/*.pem
+**/secrets*
+```
+
+## Movendo o workspace para uma nova máquina
+
+1. Clone o repo para o caminho desejado (padrão `~/.openclaw/workspace`).
+2. Defina `agents.defaults.workspace` para esse caminho em `~/.openclaw/openclaw.json`.
+3. Execute `openclaw setup --workspace <path>` para plantar qualquer arquivo faltando.
+4. Se você precisar de sessões, copie `~/.openclaw/agents/<agentId>/sessions/` dá máquina antiga separadamente.
+
+## Notas avançadas
+
+- Roteamento multi-agente pode usar diferentes workspaces por agente. Veja [Roteamento de canal](/channels/channel-routing) para configuração de roteamento.
+- Se `agents.defaults.sandbox` estiver habilitado, sessões não-principais podem usar workspaces sandbox por-sessão sob `agents.defaults.sandbox.workspaceRoot`.

--- a/docs/pt-BR/concepts/agent.md
+++ b/docs/pt-BR/concepts/agent.md
@@ -1,0 +1,108 @@
+---
+summary: "Runtime do agente (pi-mono incorporado), contrato do workspace e bootstrap da sessão"
+read_when:
+  - Modificando runtime do agente, bootstrap do workspace ou comportamento da sessão
+title: "Runtime do Agente"
+---
+
+# Runtime do Agente 🤖
+
+OpenClaw executa um único runtime de agente incorporado derivado de **pi-mono**.
+
+## Workspace (obrigatório)
+
+OpenClaw usa um único diretório de workspace do agente (`agents.defaults.workspace`) como o **único** diretório de trabalho (`cwd`) do agente para ferramentas e contexto.
+
+Recomendado: use `openclaw setup` para criar `~/.openclaw/openclaw.json` se não existir e inicializar os arquivos do workspace.
+
+Layout completo do workspace + guia de backup: [Workspace do agente](/pt-BR/concepts/agent-workspace)
+
+Se `agents.defaults.sandbox` estiver habilitado, sessões não principais podem sobrescrever isso com workspaces por sessão sob `agents.defaults.sandbox.workspaceRoot` (veja [Configuração do Gateway](/gateway/configuration)).
+
+## Arquivos de bootstrap (injetados)
+
+Dentro de `agents.defaults.workspace`, OpenClaw espera estes arquivos editáveis pelo usuário:
+
+- `AGENTS.md` — instruções operacionais + "memória"
+- `SOUL.md` — persona, limites, tom
+- `TOOLS.md` — notas de ferramentas mantidas pelo usuário (ex. `imsg`, `sag`, convenções)
+- `BOOTSTRAP.md` — ritual de primeira execução (excluído após conclusão)
+- `IDENTITY.md` — nome/vibe/emoji do agente
+- `USER.md` — perfil do usuário + endereço preferido
+
+Na primeira volta de uma nova sessão, OpenClaw injeta o conteúdo destes arquivos diretamente no contexto do agente.
+
+Arquivos em branco são ignorados. Arquivos grandes são cortados e truncados com um marcador para manter prompts enxutos (leia o arquivo para ver o conteúdo completo).
+
+Se um arquivo estiver faltando, OpenClaw injeta uma única linha de marcador "arquivo faltando" (e `openclaw setup` criará um template padrão seguro).
+
+`BOOTSTRAP.md` é criado apenas para um **workspace totalmente novo** (nenhum outro arquivo de bootstrap presente). Se você o excluir após concluir o ritual, ele não deve ser recriado em reinicializações posteriores.
+
+Para desabilitar completamente a criação de arquivo de bootstrap (para workspaces pré-alimentados), defina:
+
+```json5
+{ agent: { skipBootstrap: true } }
+```
+
+## Ferramentas integradas
+
+As ferramentas principais (read/exec/edit/write e ferramentas de sistema relacionadas) estão sempre disponíveis, sujeitas à política de ferramentas. `apply_patch` é opcional e restrito por `tools.exec.applyPatch`. `TOOLS.md` **não** controla quais ferramentas existem; é orientação sobre como _você_ quer usá-las.
+
+## Skills
+
+OpenClaw carrega skills de três locais (workspace vence em caso de conflito de nome):
+
+- Agrupadas (enviadas com a instalação)
+- Gerenciadas/locais: `~/.openclaw/skills`
+- Workspace: `<workspace>/skills`
+
+Skills podem ser restringidas por config/env (veja `skills` em [Configuração do Gateway](/gateway/configuration)).
+
+## Integração pi-mono
+
+OpenClaw reutiliza pedaços da base de código pi-mono (modelos/ferramentas), mas **gerenciamento de sessão, descoberta e configuração de ferramentas são propriedade do OpenClaw**.
+
+- Sem runtime do agente de codificação pi.
+- Configurações `~/.pi/agent` ou `<workspace>/.pi` não são consultadas.
+
+## Sessões
+
+Transcrições de sessão são armazenadas como JSONL em:
+
+- `~/.openclaw/agents/<agentId>/sessions/<SessionId>.jsonl`
+
+O ID da sessão é estável e escolhido pelo OpenClaw.
+Pastas de sessão legadas Pi/Tau **não** são lidas.
+
+## Direcionamento durante streaming
+
+Quando o modo de fila é `steer`, mensagens de entrada são injetadas na execução atual.
+A fila é verificada **após cada chamada de ferramenta**; se uma mensagem em fila estiver presente, as chamadas de ferramenta restantes da mensagem de assistente atual são ignoradas (resultados de ferramenta de erro com "Skipped due to queued user message."), então a mensagem de usuário em fila é injetada antes da próxima resposta do assistente.
+
+Quando o modo de fila é `followup` ou `collect`, mensagens de entrada são mantidas até o encerramento da volta atual, então uma nova volta de agente começa com as cargas em fila. Veja [Fila](/pt-BR/concepts/queue) para comportamento de modo + debounce/cap.
+
+O streaming de bloco envia blocos de assistente completados assim que terminam; está **desabilitado por padrão** (`agents.defaults.blockStreamingDefault: "off"`).
+Ajuste o limite via `agents.defaults.blockStreamingBreak` (`text_end` vs `message_end`; padrão é text_end).
+Controle o chunking de bloco suave com `agents.defaults.blockStreamingChunk` (padrão de 800–1200 chars; prefere quebras de parágrafo, depois quebras de linha; sentenças por último).
+Coalesce chunks transmitidos com `agents.defaults.blockStreamingCoalesce` para reduzir spam de linha única (fusão baseada em ocioso antes do envio). Canais não-Telegram requerem `*.blockStreaming: true` explícito para habilitar respostas de bloco.
+Resumos de ferramenta detalhados são emitidos no início da ferramenta (sem debounce); Interface de Controle faz stream de saída de ferramenta via eventos do agente quando disponível.
+Mais detalhes: [Streaming + chunking](/pt-BR/concepts/streaming).
+
+## Referências de modelo
+
+Referências de modelo em config (por exemplo `agents.defaults.model` e `agents.defaults.models`) são analisadas dividindo no **primeiro** `/`.
+
+- Use `provider/model` ao configurar modelos.
+- Se o ID do modelo em si contiver `/` (estilo OpenRouter), inclua o prefixo do provedor (exemplo: `openrouter/moonshotai/kimi-k2`).
+- Se você omitir o provedor, OpenClaw trata a entrada como um alias ou um modelo para o **provedor padrão** (funciona apenas quando não há `/` no ID do modelo).
+
+## Configuração (mínima)
+
+No mínimo, defina:
+
+- `agents.defaults.workspace`
+- `channels.whatsapp.allowFrom` (altamente recomendado)
+
+---
+
+_Próximo: [Chats em Grupo](/channels/group-messages)_ 🦞

--- a/docs/pt-BR/concepts/architecture.md
+++ b/docs/pt-BR/concepts/architecture.md
@@ -1,0 +1,123 @@
+---
+summary: "Arquitetura do Gateway WebSocket, componentes e fluxos de cliente"
+read_when:
+  - Trabalhando em protocolo gateway, clientes ou transportes
+title: "Arquitetura do Gateway"
+---
+
+# Arquitetura do Gateway
+
+Última atualização: 2026-01-22
+
+## Visão geral
+
+- Um único **Gateway** de longa duração possui todas as superfícies de mensagem (WhatsApp via Baileys, Telegram via grammY, Slack, Discord, Signal, iMessage, WebChat).
+- Clientes de plano de controle (app macOS, CLI, web UI, automações) se conectam ao Gateway sobre **WebSocket** no host de bind configurado (padrão `127.0.0.1:18789`).
+- **Nós** (macOS/iOS/Android/headless) também se conectam sobre **WebSocket**, mas declaram `role: node` com caps/commands/permissions explícitos.
+- Um Gateway por host; é o único lugar que abre uma sessão WhatsApp.
+- O **canvas host** é servido pelo servidor HTTP do Gateway sob:
+  - `/__openclaw__/canvas/` (HTML/CSS/JS editável por agente)
+  - `/__openclaw__/a2ui/` (host A2UI)
+    Usa a mesma porta que o Gateway (padrão `18789`).
+
+## Componentes e fluxos
+
+### Gateway (daemon)
+
+- Mantém conexões de provedor.
+- Expõe uma API WS digitada (requisições, respostas, eventos server-push).
+- Valida frames de entrada contra JSON Schema.
+- Emite eventos como `agent`, `chat`, `presence`, `health`, `heartbeat`, `cron`.
+
+### Clientes (app mac / CLI / web admin)
+
+- Uma conexão WS por cliente.
+- Enviam requisições (`health`, `status`, `send`, `agent`, `system-presence`).
+- Se inscreem em eventos (`tick`, `agent`, `presence`, `shutdown`).
+
+### Nós (macOS / iOS / Android / headless)
+
+- Se conectam ao **mesmo servidor WS** com `role: node`.
+- Fornecem uma identidade de dispositivo em `connect`; emparelhamento é **baseado em dispositivo** (role `node`) e aprovação vive no armazenamento de emparelhamento de dispositivo.
+- Expõem comandos como `canvas.*`, `camera.*`, `screen.record`, `location.get`.
+
+Detalhes do protocolo:
+
+- [Protocolo Gateway](/gateway/protocol)
+
+### WebChat
+
+- Interface estática que usa a API WS do Gateway para histórico de chat e envios.
+- Em setups remotos, se conecta através do mesmo túnel SSH/Tailscale que outros clientes.
+
+## Ciclo de vida de conexão (cliente único)
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Gateway
+
+    Client->>Gateway: req:connect
+    Gateway-->>Client: res (ok)
+    Note right of Gateway: ou res error + close
+    Note left of Client: payload=hello-ok<br>snapshot: presence + health
+
+    Gateway-->>Client: event:presence
+    Gateway-->>Client: event:tick
+
+    Client->>Gateway: req:agent
+    Gateway-->>Client: res:agent<br>ack {runId, status:"accepted"}
+    Gateway-->>Client: event:agent<br>(streaming)
+    Gateway-->>Client: res:agent<br>final {runId, status, summary}
+```
+
+## Protocolo de fio (resumo)
+
+- Transporte: WebSocket, frames de texto com payloads JSON.
+- Primeiro frame **deve** ser `connect`.
+- Após handshake:
+  - Requisições: `{type:"req", id, method, params}` → `{type:"res", id, ok, payload|error}`
+  - Eventos: `{type:"event", event, payload, seq?, stateVersion?}`
+- Se `OPENCLAW_GATEWAY_TOKEN` (ou `--token`) estiver definido, `connect.params.auth.token` deve corresponder ou o socket fecha.
+- Chaves de idempotência são necessárias para métodos com efeito colateral (`send`, `agent`) para retry seguro; o servidor mantém um cache de dedupe de vida curta.
+- Nós devem incluir `role: "node"` mais caps/commands/permissions em `connect`.
+
+## Emparelhamento + confiança local
+
+- Todos os clientes WS (operadores + nós) incluem uma **identidade de dispositivo** em `connect`.
+- IDs de dispositivo novos requerem aprovação de emparelhamento; o Gateway emite um **dispositivo token** para connects subsequentes.
+- Connects **locais** (loopback ou endereço tailnet do próprio host do gateway) podem ser auto-aprovadas para manter UX suave no mesmo host.
+- Connects **não-locais** devem assinar o nonce `connect.challenge` e requerem aprovação explícita.
+- Auth do Gateway (`gateway.auth.*`) ainda se aplica a **todas** as conexões, locais ou remotas.
+
+Detalhes: [Protocolo Gateway](/gateway/protocol), [Emparelhamento](/channels/pairing), [Segurança](/gateway/security).
+
+## Tipagem de protocolo e codegen
+
+- Schemas TypeBox definem o protocolo.
+- JSON Schema é gerado desses schemas.
+- Modelos Swift são gerados a partir do JSON Schema.
+
+## Acesso remoto
+
+- Preferido: Tailscale ou VPN.
+- Alternativa: Túnel SSH
+
+  ```bash
+  ssh -N -L 18789:127.0.0.1:18789 user@host
+  ```
+
+- O mesmo handshake + token auth se aplicam sobre o túnel.
+- TLS + pinning opcional podem ser habilitados para WS em setups remotos.
+
+## Snapshot de operações
+
+- Iniciar: `openclaw gateway` (foreground, logs para stdout).
+- Health: `health` sobre WS (também incluído em `hello-ok`).
+- Supervisão: launchd/systemd para auto-restart.
+
+## Invariantes
+
+- Exatamente um Gateway controla uma única sessão Baileys por host.
+- Handshake é obrigatório; qualquer frame primeiro que não seja JSON ou não-connect é um hard close.
+- Eventos não são repetidos; clientes devem atualizar em gaps.

--- a/docs/pt-BR/concepts/compaction.md
+++ b/docs/pt-BR/concepts/compaction.md
@@ -1,0 +1,60 @@
+---
+summary: "Janela de contexto + compactação: como OpenClaw mantém sessões dentro de limites de modelo"
+read_when:
+  - Você quer entender auto-compactação e /compact
+  - Você está debugando sessões longas atingindo limites de contexto
+title: "Compactação"
+---
+
+# Janela de Contexto & Compactação
+
+Cada modelo tem uma **janela de contexto** (máximo de tokens que pode ver). Chats de longa duração acumulam mensagens e resultados de ferramentas; uma vez que a janela fica apertada, OpenClaw **compacta** histórico mais antigo para ficar dentro dos limites.
+
+## O que é compactação
+
+Compactação **resume conversa mais antiga** em uma entrada de resumo compacta e mantém mensagens recentes intactas. O resumo é armazenado no histórico de sessão, então requisições futuras usam:
+
+- O resumo de compactação
+- Mensagens recentes após o ponto de compactação
+
+Compactação **persiste** no histórico JSONL da sessão.
+
+## Configuração
+
+Use a configuração `agents.defaults.compaction` em seu `openclaw.json` para configurar comportamento de compactação (modo, tokens alvo, etc.).
+
+## Auto-compactação (padrão ativado)
+
+Quando uma sessão se aproxima ou excede a janela de contexto do modelo, OpenClaw ativa auto-compactação e pode repetir a requisição original usando o contexto compactado.
+
+Você verá:
+
+- `🧹 Auto-compaction complete` em modo verbose
+- `/status` mostrando `🧹 Compactions: <count>`
+
+Antes de compactação, OpenClaw pode executar uma volta de **flush de memória silencioso** para armazenar notas duráveis em disco. Veja [Memória](/pt-BR/concepts/memory) para detalhes e config.
+
+## Compactação manual
+
+Use `/compact` (opcionalmente com instruções) para forçar uma passagem de compactação:
+
+```
+/compact Focus on decisions and open questions
+```
+
+## Fonte de janela de contexto
+
+Janela de contexto é específica do modelo. OpenClaw usa a definição de modelo do catálogo de provedor configurado para determinar limites.
+
+## Compactação vs pruning
+
+- **Compactação**: resume e **persiste** em JSONL.
+- **Session pruning**: aparas resultados de ferramenta **antigos** apenas, **na memória**, por requisição.
+
+Veja [/pt-BR/concepts/session-pruning](/pt-BR/concepts/session-pruning) para detalhes de pruning.
+
+## Dicas
+
+- Use `/compact` quando sessões parecem obsoletas ou contexto está inchado.
+- Saídas de ferramenta grandes já são truncadas; pruning pode reduzir ainda mais o buildup de tool-result.
+- Se você precisar de um slate fresco, `/new` ou `/reset` inicia um novo id de sessão.

--- a/docs/pt-BR/concepts/context.md
+++ b/docs/pt-BR/concepts/context.md
@@ -1,0 +1,161 @@
+---
+summary: "Contexto: o que o modelo vê, como é construído e como inspecioná-lo"
+read_when:
+  - Você quer entender o que "contexto" significa em OpenClaw
+  - Você está debugando por que o modelo "sabe" algo (ou esqueceu)
+  - Você quer reduzir overhead de contexto (/context, /status, /compact)
+title: "Contexto"
+---
+
+# Contexto
+
+"Contexto" é **tudo que OpenClaw envia para o modelo em uma execução**. É limitado pela **janela de contexto** do modelo (limite de token).
+
+Modelo mental iniciante:
+
+- **System prompt** (construído por OpenClaw): regras, ferramentas, lista de skills, tempo/runtime e arquivos de workspace injetados.
+- **Histórico de conversa**: suas mensagens + mensagens do assistente para esta sessão.
+- **Chamadas de ferramentas/resultados + anexos**: saída de comando, leituras de arquivo, imagens/áudio, etc.
+
+Contexto _não é a mesma coisa_ que "memória": memória pode ser armazenada em disco e recarregada mais tarde; contexto é o que está dentro da janela atual do modelo.
+
+## Início rápido (inspeção de contexto)
+
+- `/status` → visualização rápida "quão cheio está minha janela?" + configurações de sessão.
+- `/context list` → o que está injetado + tamanhos aproximados (por arquivo + totais).
+- `/context detail` → breakdown mais profundo: por arquivo, tamanhos de esquema por ferramenta, tamanhos de entrada por skill e tamanho de prompt do sistema.
+- `/usage tokens` → anexar rodapé de uso por resposta a respostas normais.
+- `/compact` → resumir histórico mais antigo em uma entrada compacta para liberar espaço de janela.
+
+Veja também: [Comandos Slash](/tools/slash-commands), [Uso de token & custos](/reference/token-use), [Compactação](/pt-BR/concepts/compaction).
+
+## Saída de exemplo
+
+Valores variam por modelo, provedor, política de ferramenta e o que está em seu workspace.
+
+### `/context list`
+
+```
+🧠 Context breakdown
+Workspace: <workspaceDir>
+Bootstrap max/file: 20,000 chars
+Sandbox: mode=non-main sandboxed=false
+System prompt (run): 38,412 chars (~9,603 tok) (Project Context 23,901 chars (~5,976 tok))
+
+Injected workspace files:
+- AGENTS.md: OK | raw 1,742 chars (~436 tok) | injected 1,742 chars (~436 tok)
+- SOUL.md: OK | raw 912 chars (~228 tok) | injected 912 chars (~228 tok)
+- TOOLS.md: TRUNCATED | raw 54,210 chars (~13,553 tok) | injected 20,962 chars (~5,241 tok)
+- IDENTITY.md: OK | raw 211 chars (~53 tok) | injected 211 chars (~53 tok)
+- USER.md: OK | raw 388 chars (~97 tok) | injected 388 chars (~97 tok)
+- HEARTBEAT.md: MISSING | raw 0 | injected 0
+- BOOTSTRAP.md: OK | raw 0 chars (~0 tok) | injected 0 chars (~0 tok)
+
+Skills list (system prompt text): 2,184 chars (~546 tok) (12 skills)
+Tools: read, edit, write, exec, process, browser, message, sessions_send, …
+Tool list (system prompt text): 1,032 chars (~258 tok)
+Tool schemas (JSON): 31,988 chars (~7,997 tok) (counts toward context; not shown as text)
+Tools: (same as above)
+
+Session tokens (cached): 14,250 total / ctx=32,000
+```
+
+### `/context detail`
+
+```
+🧠 Context breakdown (detailed)
+…
+Top skills (prompt entry size):
+- frontend-design: 412 chars (~103 tok)
+- oracle: 401 chars (~101 tok)
+… (+10 more skills)
+
+Top tools (schema size):
+- browser: 9,812 chars (~2,453 tok)
+- exec: 6,240 chars (~1,560 tok)
+… (+N more tools)
+```
+
+## O que conta para a janela de contexto
+
+Tudo que o modelo recebe conta, incluindo:
+
+- System prompt (todas as seções).
+- Histórico de conversa.
+- Chamadas de ferramenta + resultados de ferramenta.
+- Anexos/transcrições (imagens/áudio/arquivos).
+- Resumos de compactação e artefatos de pruning.
+- Wrappers de provedor ou headers ocultos (não visíveis, ainda contados).
+
+## Como OpenClaw constrói o system prompt
+
+O system prompt é **propriedade do OpenClaw** e reconstruído cada execução. Inclui:
+
+- Lista de ferramenta + descrições curtas.
+- Lista de skills (apenas metadados; veja abaixo).
+- Localização do workspace.
+- Hora (UTC + hora do usuário convertida se configurada).
+- Metadados de runtime (host/OS/model/thinking).
+- Arquivos de bootstrap de workspace injetados sob **Project Context**.
+
+Breakdown completo: [System Prompt](/pt-BR/concepts/system-prompt).
+
+## Arquivos de workspace injetados (Project Context)
+
+Por padrão, OpenClaw injeta um conjunto fixo de arquivos de workspace (se presentes):
+
+- `AGENTS.md`
+- `SOUL.md`
+- `TOOLS.md`
+- `IDENTITY.md`
+- `USER.md`
+- `HEARTBEAT.md`
+- `BOOTSTRAP.md` (primeira execução apenas)
+
+Arquivos grandes são truncados por arquivo usando `agents.defaults.bootstrapMaxChars` (padrão `20000` chars). OpenClaw também impõe um cap total de injeção de bootstrap entre arquivos com `agents.defaults.bootstrapTotalMaxChars` (padrão `150000` chars). `/context` mostra tamanhos **brutos vs injetados** e se truncagem aconteceu.
+
+## Skills: o que é injetado vs carregado sob demanda
+
+O system prompt inclui uma **lista de skills** compacta (nome + descrição + localização). Esta lista tem overhead real.
+
+Instruções de skill _não_ são incluídas por padrão. Espera-se que o modelo `read` o `SKILL.md` da skill **apenas quando necessário**.
+
+## Ferramentas: existem dois custos
+
+Ferramentas afetam contexto de duas formas:
+
+1. **Texto de lista de ferramentas** no system prompt (o que você vê como "Tooling").
+2. **Esquemas de ferramenta** (JSON). Estes são enviados ao modelo para que possa chamar ferramentas. Eles contam para contexto mesmo que você não veja como texto plano.
+
+`/context detail` divide os maiores esquemas de ferramenta para que você veja o que domina.
+
+## Comandos, diretivas e "atalhos inline"
+
+Comandos slash são manipulados pelo Gateway. Existem alguns comportamentos diferentes:
+
+- **Comandos autônomos**: uma mensagem que é apenas `/...` é executada como comando.
+- **Diretivas**: `/think`, `/verbose`, `/reasoning`, `/elevated`, `/model`, `/queue` são removidos antes do modelo ver a mensagem.
+  - Mensagens apenas de diretiva persistem configurações de sessão.
+  - Diretivas inline em uma mensagem normal atuam como dicas por mensagem.
+- **Atalhos inline** (apenas remetentes na lista de permissões): certos tokens `/...` dentro de uma mensagem normal podem ser executados imediatamente (exemplo: "hey /status"), e são removidos antes do modelo ver o texto restante.
+
+Detalhes: [Comandos Slash](/tools/slash-commands).
+
+## Sessões, compactação e pruning (o que persiste)
+
+O que persiste entre mensagens depende do mecanismo:
+
+- **Histórico normal** persiste na transcrição de sessão até ser compactado/podado por política.
+- **Compactação** persiste um resumo na transcrição e mantém mensagens recentes intactas.
+- **Pruning** remove resultados de ferramenta antigos do prompt _na memória_ para uma execução, mas não reescreve a transcrição.
+
+Docs: [Sessão](/pt-BR/concepts/session), [Compactação](/pt-BR/concepts/compaction), [Session pruning](/pt-BR/concepts/session-pruning).
+
+## O que `/context` realmente relata
+
+`/context` prefere o relatório de system prompt **construído por execução** mais recente quando disponível:
+
+- `System prompt (run)` = capturado da última execução incorporada (capaz de ferramenta) e persistido no armazenamento de sessão.
+- `System prompt (estimate)` = computado na mosca quando nenhum relatório de execução existe (ou ao executar via um backend CLI que não gera o relatório).
+
+De qualquer forma, relata tamanhos e principais contribuidores; não **despeja** o prompt do sistema completo ou esquemas de ferramenta.

--- a/docs/pt-BR/concepts/features.md
+++ b/docs/pt-BR/concepts/features.md
@@ -1,0 +1,53 @@
+---
+summary: "Recursos do OpenClaw em canais, roteamento, mídia e experiência do usuário."
+read_when:
+  - Você quer uma lista completa do que o OpenClaw suporta
+title: "Recursos"
+---
+
+## Destaques
+
+<Columns>
+  <Card title="Canais" icon="message-square">
+    WhatsApp, Telegram, Discord e iMessage com um único Gateway.
+  </Card>
+  <Card title="Plugins" icon="plug">
+    Adicione Mattermost e mais com extensões.
+  </Card>
+  <Card title="Roteamento" icon="route">
+    Roteamento multi-agente com sessões isoladas.
+  </Card>
+  <Card title="Mídia" icon="image">
+    Imagens, áudio e documentos de entrada e saída.
+  </Card>
+  <Card title="Apps e Interface" icon="monitor">
+    Interface de Controle Web e app complementar do macOS.
+  </Card>
+  <Card title="Nós móveis" icon="smartphone">
+    Nós iOS e Android com suporte a Canvas.
+  </Card>
+</Columns>
+
+## Lista completa
+
+- Integração WhatsApp via WhatsApp Web (Baileys)
+- Suporte para bot Telegram (grammY)
+- Suporte para bot Discord (channels.discord.js)
+- Suporte para bot Mattermost (plugin)
+- Integração iMessage via CLI imsg local (macOS)
+- Ponte de agente para Pi em modo RPC com streaming de ferramentas
+- Streaming e divisão em chunks para respostas longas
+- Roteamento multi-agente para sessões isoladas por workspace ou remetente
+- Autenticação de assinatura para Anthropic e OpenAI via OAuth
+- Sessões: chats diretos são mesclados em `main` compartilhado; grupos são isolados
+- Suporte para chat em grupo com ativação baseada em menção
+- Suporte para mídia com imagens, áudio e documentos
+- Hook opcional de transcrição de notas de voz
+- WebChat e app menu bar do macOS
+- Nó iOS com emparelhamento e superfície Canvas
+- Nó Android com emparelhamento, Canvas, chat e câmera
+
+<Note>
+Os caminhos legados Claude, Codex, Gemini e Opencode foram removidos. Pi é o único
+caminho de agente de codificação.
+</Note>

--- a/docs/pt-BR/concepts/markdown-formatting.md
+++ b/docs/pt-BR/concepts/markdown-formatting.md
@@ -1,0 +1,73 @@
+---
+summary: "Pipeline de formatação Markdown para canais outbound"
+read_when:
+  - Você está mudando formatting ou chunking markdown para canais outbound
+  - Você está adicionando um novo formatador de canal ou mapeamento de estilo
+  - Você está debugando regressões de formatting entre canais
+title: "Formatação Markdown"
+---
+
+# Formatação Markdown
+
+OpenClaw formata Markdown outbound convertendo-o em uma representação intermediária compartilhada (IR) antes de renderizar saída específica de canal. O IR mantém o texto de origem intacto enquanto leva spans de estilo/link para que chunking e rendering possam permanecer consistentes entre canais.
+
+## Objetivos
+
+- **Consistência:** um parse step, múltiplos renderers.
+- **Chunking seguro:** divide texto antes de renderizar para que formatting inline nunca quebrar através de chunks.
+- **Channel fit:** mapea a mesma IR para Slack mrkdwn, Telegram HTML e Signal style ranges sem re-parsing Markdown.
+
+## Pipeline
+
+1. **Parse Markdown -> IR**
+   - IR é texto plano mais style spans (bold/italic/strike/code/spoiler) e link spans.
+   - Offsets são unidades de código UTF-16 para que Signal style ranges se alinhem com sua API.
+   - Tabelas são parseadas apenas quando um canal opta em conversão de tabela.
+2. **Chunk IR (format-first)**
+   - Chunking acontece no texto IR antes de renderizar.
+   - Formatting inline não divide entre chunks; spans são cortados por chunk.
+3. **Render per canal**
+   - **Slack:** tokens mrkdwn (bold/italic/strike/code), links como `<url|label>`.
+   - **Telegram:** tags HTML (`<b>`, `<i>`, `<s>`, `<code>`, `<pre><code>`, `<a href>`).
+   - **Signal:** texto plano + ranges `text-style`; links se tornam `label (url)` quando label difere.
+
+## Exemplo IR
+
+Input Markdown:
+
+```markdown
+Hello **world** — see [docs](https://docs.openclaw.ai).
+```
+
+IR (esquemático):
+
+```json
+{
+  "text": "Hello world — see docs.",
+  "styles": [{ "start": 6, "end": 11, "style": "bold" }],
+  "links": [{ "start": 19, "end": 23, "href": "https://docs.openclaw.ai" }]
+}
+```
+
+## Onde é usado
+
+- Adaptadores Slack, Telegram e Signal outbound renderizam a partir do IR.
+- Outros canais (WhatsApp, iMessage, MS Teams, Discord) ainda usam texto plano ou suas próprias regras de formatting, com conversão de tabela Markdown aplicada antes de chunking quando habilitado.
+
+## Tratamento de tabela
+
+Tabelas Markdown não são suportadas consistentemente entre clientes de chat. Use `markdown.tables` para controlar conversão por canal (e por conta).
+
+- `code`: renderiza tabelas como code blocks (padrão para a maioria dos canais).
+- `bullets`: converte cada row em bullet points (padrão para Signal + WhatsApp).
+- `off`: desabilita table parsing e conversão; texto de tabela bruto passa através.
+
+Chaves de config:
+
+```yaml
+channels:
+  discord:
+    markdown:
+      tables: code
+    accounts:
+```

--- a/docs/pt-BR/concepts/memory.md
+++ b/docs/pt-BR/concepts/memory.md
@@ -1,0 +1,88 @@
+---
+title: "Memória"
+summary: "Como a memória do OpenClaw funciona (arquivos de workspace + flush automático de memória)"
+read_when:
+  - Você quer o layout e fluxo de arquivo de memória
+  - Você quer ajustar o flush automático de memória pré-compactação
+---
+
+# Memória
+
+A memória do OpenClaw é **Markdown simples no workspace do agente**. Os arquivos são a fonte de verdade; o modelo apenas "lembra" do que é escrito em disco.
+
+Ferramentas de busca de memória são fornecidas pelo plugin de memória ativo (padrão: `memory-core`). Desabilite plugins de memória com `plugins.slots.memory = "none"`.
+
+## Arquivos de memória (Markdown)
+
+O layout de workspace padrão usa duas camadas de memória:
+
+- `memory/YYYY-MM-DD.md`
+  - Log diário (append-only).
+  - Leia hoje + ontem no início da sessão.
+- `MEMORY.md` (opcional)
+  - Memória de longo prazo curada.
+  - **Só carregue na sessão principal privada** (nunca em contextos de grupo).
+
+Esses arquivos vivem sob o workspace (`agents.defaults.workspace`, padrão `~/.openclaw/workspace`). Veja [Workspace do agente](/pt-BR/concepts/agent-workspace) para o layout completo.
+
+## Quando escrever memória
+
+- Decisões, preferências e fatos duráveis vão para `MEMORY.md`.
+- Notas do dia a dia e contexto em execução vão para `memory/YYYY-MM-DD.md`.
+- Se alguém disser "lembre-se disso," escreva (não mantenha em RAM).
+- Esta área ainda está evoluindo. Ajuda a lembrar o modelo de armazenar memórias; ele saberá o que fazer.
+- Se você quer que algo persista, **peça ao bot para escrever** na memória.
+
+## Flush automático de memória (ping pré-compactação)
+
+Quando uma sessão está **perto de auto-compactação**, OpenClaw ativa uma volta **silenciosa e agentic** que lembra o modelo de escrever memória durável **antes** do contexto ser compactado. Os prompts padrão dizem explicitamente que o modelo _pode responder_, mas geralmente `NO_REPLY` é a resposta correta para que o usuário nunca veja essa volta.
+
+Isso é controlado por `agents.defaults.compaction.memoryFlush`:
+
+```json5
+{
+  agents: {
+    defaults: {
+      compaction: {
+        reserveTokensFloor: 20000,
+        memoryFlush: {
+          enabled: true,
+          softThresholdTokens: 4000,
+          systemPrompt: "Session nearing compaction. Store durable memories now.",
+          prompt: "Write any lasting notes to memory/YYYY-MM-DD.md; reply with NO_REPLY if nothing to store.",
+        },
+      },
+    },
+  },
+}
+```
+
+Detalhes:
+
+- **Soft threshold**: flush ativa quando a estimativa de token de sessão cruza `contextWindow - reserveTokensFloor - softThresholdTokens`.
+- **Silencioso** por padrão: prompts incluem `NO_REPLY` para que nada seja entregue.
+- **Dois prompts**: um prompt de usuário plus um append de prompt do sistema o lembrete.
+- **Um flush por ciclo de compactação** (rastreado em `sessions.json`).
+- **Workspace deve ser gravável**: se a sessão executar sandboxed com `workspaceAccess: "ro"` ou `"none"`, o flush é ignorado.
+
+Para o ciclo de vida de compactação completo, veja [Gerenciamento de sessão + compactação](/reference/session-management-compaction).
+
+## Busca de memória vetorial
+
+OpenClaw pode construir um pequeno índice vetorial sobre `MEMORY.md` e `memory/*.md` para que consultas semânticas possam encontrar notas relacionadas mesmo quando a redação difere.
+
+Padrões:
+
+- Habilitado por padrão.
+- Observa arquivos de memória para mudanças (debounced).
+- Configure busca de memória sob `agents.defaults.memorySearch` (não `memorySearch` no nível superior).
+- Usa embeddings remotos por padrão. Se `memorySearch.provider` não estiver definido, OpenClaw auto-seleciona:
+  1. `local` se um `memorySearch.local.modelPath` estiver configurado e o arquivo existir.
+  2. `openai` se uma chave OpenAI puder ser resolvida.
+  3. `gemini` se uma chave Gemini puder ser resolvida.
+  4. `voyage` se uma chave Voyage puder ser resolvida.
+  5. Caso contrário, busca de memória permanece desabilitada até ser configurada.
+- Modo local usa node-llama-cpp e pode exigir `pnpm approve-builds`.
+- Usa sqlite-vec (quando disponível) para acelerar busca vetorial dentro de SQLite.
+
+Embeddings remotos **requerem** uma chave de API para o provedor de embedding. OpenClaw resolve chaves de perfis de autenticação, `models.providers.*.apiKey` ou variáveis de ambiente.

--- a/docs/pt-BR/concepts/messages.md
+++ b/docs/pt-BR/concepts/messages.md
@@ -1,0 +1,89 @@
+---
+summary: "Fluxo de mensagem, sessões, queueing e visibilidade de raciocínio"
+read_when:
+  - Explicando como mensagens de entrada se tornam replies
+  - Esclarecendo sessões, modos de queueing ou comportamento de streaming
+  - Documentando visibilidade de raciocínio e implicações de uso
+title: "Mensagens"
+---
+
+# Mensagens
+
+Essa página vincula como OpenClaw manipula mensagens de entrada, sessões, queueing, streaming e visibilidade de raciocínio.
+
+## Fluxo de mensagem (alto nível)
+
+```
+Mensagem de entrada
+  -> routing/bindings -> session key
+  -> queue (se uma execução está ativa)
+  -> agent run (streaming + tools)
+  -> outbound replies (limites de canal + chunking)
+```
+
+Knobs-chave vivem em configuração:
+
+- `messages.*` para prefixos, queueing e comportamento de grupo.
+- `agents.defaults.*` para padrões block streaming e chunking.
+- Substituições de canal (`channels.whatsapp.*`, `channels.telegram.*`, etc.) para caps e toggles de streaming.
+
+Veja [Configuração](/gateway/configuration) para schema completo.
+
+## Dedupe de entrada
+
+Canais podem re-entregar a mesma mensagem após reconexões. OpenClaw mantém um cache de vida curta keyed por channel/account/peer/session/message id para que entregas duplicadas não acionem outra execução de agente.
+
+## Debouncing de entrada
+
+Mensagens rápidas consecutivas do **mesmo remetente** podem ser batidas em uma única volta de agente via `messages.inbound`. Debouncing é scoped per canal + conversa e usa a mensagem mais recente para reply threading/IDs.
+
+Config (padrão global + substituições por canal):
+
+```json5
+{
+  messages: {
+    inbound: {
+      debounceMs: 2000,
+      byChannel: {
+        whatsapp: 5000,
+        slack: 1500,
+        discord: 1500,
+      },
+    },
+  },
+}
+```
+
+Notas:
+
+- Debounce se aplica a mensagens **text-only**; media/anexos flushes imediatamente.
+- Comandos de controle desviam debouncing para que permaneçam autônomos.
+
+## Sessões e dispositivos
+
+Sessões são possuídas pelo gateway, não pelos clientes.
+
+- Chats diretos colapsam na chave de sessão principal do agente.
+- Grupos/canais recebem suas próprias chaves de sessão.
+- O armazenamento de sessão e transcrições vivem no host do gateway.
+
+Múltiplos dispositivos/canais podem mapear para a mesma sessão, mas histórico não é totalmente sincronizado de volta para cada cliente. Recomendação: use um dispositivo primário para conversas longas para evitar contexto divergente. A Interface de Controle e TUI sempre mostram a transcrição de sessão apoiada por gateway, então são a fonte de verdade.
+
+Detalhes: [Gerenciamento de sessão](/pt-BR/concepts/session).
+
+## Corpos de entrada e contexto de histórico
+
+OpenClaw separa o **prompt body** do **command body**:
+
+- `Body`: texto de prompt enviado ao agente. Isso pode incluir envelopes de canal e wrappers de histórico opcionais.
+- `CommandBody`: texto bruto do usuário para parsing de diretiva/comando.
+- `RawBody`: alias legado para `CommandBody` (mantido para compatibilidade).
+
+Quando um canal fornece histórico, ele usa um wrapper compartilhado:
+
+- `[Chat messages since your last reply - for context]`
+- `[Current message - respond to this]`
+
+Para **chats não-diretos** (grupos/canais/salas), o **corpo de mensagem atual** é prefixado com o rótulo de remetente (mesmo estilo usado para entradas de histórico). Isso mantém mensagens em tempo real e pendentes/histórico consistentes no prompt do agente.
+
+Buffers de histórico são **pending-only**: eles incluem mensagens de grupo que _não_ foram ainda processadas.

--- a/docs/pt-BR/concepts/model-failover.md
+++ b/docs/pt-BR/concepts/model-failover.md
@@ -1,0 +1,142 @@
+---
+summary: "Como OpenClaw rotaciona perfis de autenticação e faz fallback entre modelos"
+read_when:
+  - Diagnosticando rotação de perfil de autenticação, cooldowns ou comportamento de fallback de modelo
+  - Atualizando regras de failover para perfis de autenticação ou modelos
+title: "Failover de Modelo"
+---
+
+# Failover de modelo
+
+OpenClaw manipula falhas em dois estágios:
+
+1. **Rotação de perfil de autenticação** dentro do provedor atual.
+2. **Fallback de modelo** para o próximo modelo em `agents.defaults.model.fallbacks`.
+
+Este documento explica as regras de runtime e os dados que as suportam.
+
+## Armazenamento de autenticação (chaves + OAuth)
+
+OpenClaw usa **perfis de autenticação** para chaves de API e tokens OAuth.
+
+- Segredos vivem em `~/.openclaw/agents/<agentId>/agent/auth-profiles.json` (legado: `~/.openclaw/agent/auth-profiles.json`).
+- Config `auth.profiles` / `auth.order` são **apenas metadados + roteamento** (sem segredos).
+- Arquivo OAuth apenas para importação legada: `~/.openclaw/credentials/oauth.json` (importado para `auth-profiles.json` no primeiro uso).
+
+Mais detalhes: [/pt-BR/concepts/oauth](/pt-BR/concepts/oauth)
+
+Tipos de credencial:
+
+- `type: "api_key"` → `{ provider, key }`
+- `type: "oauth"` → `{ provider, access, refresh, expires, email? }` (+ `projectId`/`enterpriseUrl` para alguns provedores)
+
+## IDs de perfil
+
+Logins OAuth criam perfis distintos para que múltiplas contas possam coexistir.
+
+- Padrão: `provider:default` quando nenhum email está disponível.
+- OAuth com email: `provider:<email>` (por exemplo `google-antigravity:user@gmail.com`).
+
+Perfis vivem em `~/.openclaw/agents/<agentId>/agent/auth-profiles.json` sob `profiles`.
+
+## Ordem de rotação
+
+Quando um provedor tem múltiplos perfis, OpenClaw escolhe uma ordem assim:
+
+1. **Config explícita**: `auth.order[provider]` (se definido).
+2. **Perfis configurados**: `auth.profiles` filtrado por provedor.
+3. **Perfis armazenados**: entradas em `auth-profiles.json` para o provedor.
+
+Se nenhuma ordem explícita é configurada, OpenClaw usa uma ordem round-robin:
+
+- **Primary key:** tipo de perfil (**OAuth antes de chaves de API**).
+- **Secondary key:** `usageStats.lastUsed` (mais antiga primeiro, dentro de cada tipo).
+- **Perfis em cooldown/desabilitados** são movidos para o final, ordenados por expiração mais próxima.
+
+### Aderência de sessão (amigável a cache)
+
+OpenClaw **fixa o perfil de autenticação escolhido por sessão** para manter caches de provedor aquecidos.
+Ele **não** rotaciona em cada requisição. O perfil fixado é reutilizado até:
+
+- a sessão ser resetada (`/new` / `/reset`)
+- uma compactação se completar (contagem de compactação incrementa)
+- o perfil estar em cooldown/desabilitado
+
+Seleção manual via `/model …@<profileId>` define uma **substituição de usuário** para aquela sessão e não é rotacionada automaticamente até uma nova sessão iniciar.
+
+Perfis auto-fixados (selecionados pelo roteador de sessão) são tratados como uma **preferência**:
+eles são tentados primeiro, mas OpenClaw pode rotacionar para outro perfil em rate limits/timeouts.
+Perfis fixados por usuário permanecem travados naquele perfil; se falhar e fallbacks de modelo forem configurados, OpenClaw move para o próximo modelo em vez de trocar perfis.
+
+### Por que OAuth pode "parecer perdido"
+
+Se você tem tanto um perfil OAuth quanto um perfil de chave de API para o mesmo provedor, round-robin pode trocar entre eles entre mensagens a menos que fixado. Para forçar um perfil único:
+
+- Fixe com `auth.order[provider] = ["provider:profileId"]`, ou
+- Use uma substituição por sessão via `/model …` com uma substituição de perfil (quando suportado por sua interface/superfície de chat).
+
+## Cooldowns
+
+Quando um perfil falha devido a erros de autenticação/rate-limit (ou um timeout que parece rate limiting), OpenClaw o marca em cooldown e move para o próximo perfil. Erros de formato/requisição inválida (por exemplo falhas de validação de ID de chamada de ferramenta Cloud Code Assist) são tratados como dignos de failover e usam os mesmos cooldowns.
+
+Cooldowns usam exponential backoff:
+
+- 1 minuto
+- 5 minutos
+- 25 minutos
+- 1 hora (cap)
+
+Estado é armazenado em `auth-profiles.json` sob `usageStats`:
+
+```json
+{
+  "usageStats": {
+    "provider:profile": {
+      "lastUsed": 1736160000000,
+      "cooldownUntil": 1736160600000,
+      "errorCount": 2
+    }
+  }
+}
+```
+
+## Desabilita de faturamento
+
+Falhas de faturamento/crédito (por exemplo "créditos insuficientes" / "saldo de crédito muito baixo") são tratadas como dignas de failover, mas geralmente não são transitórias. Em vez de um cooldown curto, OpenClaw marca o perfil como **desabilitado** (com um backoff mais longo) e rotaciona para o próximo perfil/provedor.
+
+Estado é armazenado em `auth-profiles.json`:
+
+```json
+{
+  "usageStats": {
+    "provider:profile": {
+      "disabledUntil": 1736178000000,
+      "disabledReason": "billing"
+    }
+  }
+}
+```
+
+Padrões:
+
+-backoff de faturamento começa em **5 horas**, dobra por falha de faturamento e caplocks em **24 horas**.
+
+- Contadores de backoff resetam se o perfil não falhou por **24 horas** (configurável).
+
+## Fallback de modelo
+
+Se todos os perfis para um provedor falharem, OpenClaw move para o próximo modelo em `agents.defaults.model.fallbacks`. Isso se aplica a falhas de autenticação, rate limits e timeouts que esgotaram rotação de perfil (outros erros não avançam fallback).
+
+Quando uma execução começa com uma substituição de modelo (ganchos ou CLI), fallbacks ainda acabam em `agents.defaults.model.primary` após tentar qualquer fallback configurado.
+
+## Config relacionada
+
+Veja [Configuração do Gateway](/gateway/configuration) para:
+
+- `auth.profiles` / `auth.order`
+- `auth.cooldowns.billingBackoffHours` / `auth.cooldowns.billingBackoffHoursByProvider`
+- `auth.cooldowns.billingMaxHours` / `auth.cooldowns.failureWindowHours`
+- `agents.defaults.model.primary` / `agents.defaults.model.fallbacks`
+- Roteamento de `agents.defaults.imageModel`
+
+Veja [Modelos](/pt-BR/concepts/models) para a visão geral mais ampla de seleção de modelo e fallback.

--- a/docs/pt-BR/concepts/model-providers.md
+++ b/docs/pt-BR/concepts/model-providers.md
@@ -1,0 +1,125 @@
+---
+summary: "Visão geral de provedor de modelo com configs de exemplo + fluxos CLI"
+read_when:
+  - Você precisa de uma referência de setup de modelo por provedor
+  - Você quer configs de exemplo ou comandos de onboarding CLI para provedores de modelo
+title: "Provedores de Modelo"
+---
+
+# Provedores de modelo
+
+Essa página cobre **provedores de modelo/LLM** (não canais de chat como WhatsApp/Telegram).
+Para regras de seleção de modelo, veja [/pt-BR/concepts/models](/pt-BR/concepts/models).
+
+## Regras rápidas
+
+- Referências de modelo usam `provider/model` (exemplo: `opencode/claude-opus-4-6`).
+- Se você definir `agents.defaults.models`, ele se torna a lista de permissões.
+- Helpers de CLI: `openclaw onboard`, `openclaw models list`, `openclaw models set <provider/model>`.
+
+## Provedores integrados (catálogo pi-ai)
+
+OpenClaw é enviado com o catálogo pi-ai. Esses provedores **não** requerem config `models.providers`; apenas defina autenticação + escolha um modelo.
+
+### OpenAI
+
+- Provedor: `openai`
+- Autenticação: `OPENAI_API_KEY`
+- Modelo de exemplo: `openai/gpt-5.1-codex`
+- CLI: `openclaw onboard --auth-choice openai-api-key`
+
+```json5
+{
+  agents: { defaults: { model: { primary: "openai/gpt-5.1-codex" } } },
+}
+```
+
+### Anthropic
+
+- Provedor: `anthropic`
+- Autenticação: `ANTHROPIC_API_KEY` ou `claude setup-token`
+- Modelo de exemplo: `anthropic/claude-opus-4-6`
+- CLI: `openclaw onboard --auth-choice token` (cola setup-token) ou `openclaw models auth paste-token --provider anthropic`
+
+```json5
+{
+  agents: { defaults: { model: { primary: "anthropic/claude-opus-4-6" } } },
+}
+```
+
+### OpenAI Code (Codex)
+
+- Provedor: `openai-codex`
+- Autenticação: OAuth (ChatGPT)
+- Modelo de exemplo: `openai-codex/gpt-5.3-codex`
+- CLI: `openclaw onboard --auth-choice openai-codex` ou `openclaw models auth login --provider openai-codex`
+
+```json5
+{
+  agents: { defaults: { model: { primary: "openai-codex/gpt-5.3-codex" } } },
+}
+```
+
+### OpenCode Zen
+
+- Provedor: `opencode`
+- Autenticação: `OPENCODE_API_KEY` (ou `OPENCODE_ZEN_API_KEY`)
+- Modelo de exemplo: `opencode/claude-opus-4-6`
+- CLI: `openclaw onboard --auth-choice opencode-zen`
+
+```json5
+{
+  agents: { defaults: { model: { primary: "opencode/claude-opus-4-6" } } },
+}
+```
+
+### Google Gemini (API key)
+
+- Provedor: `google`
+- Autenticação: `GEMINI_API_KEY`
+- Modelo de exemplo: `google/gemini-3-pro-preview`
+- CLI: `openclaw onboard --auth-choice gemini-api-key`
+
+### Google Vertex, Antigravity e Gemini CLI
+
+- Provedores: `google-vertex`, `google-antigravity`, `google-gemini-cli`
+- Autenticação: Vertex usa gcloud ADC; Antigravity/Gemini CLI usam seus fluxos de autenticação respectivos
+- OAuth de Antigravidade é enviado como plugin agrupado (`google-antigravity-auth`, desabilitado por padrão).
+  - Habilite: `openclaw plugins enable google-antigravity-auth`
+  - Login: `openclaw models auth login --provider google-antigravity --set-default`
+- OAuth Gemini CLI é enviado como plugin agrupado (`google-gemini-cli-auth`, desabilitado por padrão).
+  - Habilite: `openclaw plugins enable google-gemini-cli-auth`
+  - Login: `openclaw models auth login --provider google-gemini-cli --set-default`
+  - Nota: você **não** cola um client id ou secret em `openclaw.json`. O fluxo de login de CLI armazena tokens em perfis de autenticação no host do gateway.
+
+### Z.AI (GLM)
+
+- Provedor: `zai`
+- Autenticação: `ZAI_API_KEY`
+- Modelo de exemplo: `zai/glm-4.7`
+- CLI: `openclaw onboard --auth-choice zai-api-key`
+  - Aliases: `z.ai/*` e `z-ai/*` normalizam para `zai/*`
+
+### Vercel AI Gateway
+
+- Provedor: `vercel-ai-gateway`
+- Autenticação: `AI_GATEWAY_API_KEY`
+- Modelo de exemplo: `vercel-ai-gateway/anthropic/claude-opus-4.6`
+- CLI: `openclaw onboard --auth-choice ai-gateway-api-key`
+
+### Outros provedores integrados
+
+- OpenRouter: `openrouter` (`OPENROUTER_API_KEY`)
+- Modelo de exemplo: `openrouter/anthropic/claude-sonnet-4-5`
+- xAI: `xai` (`XAI_API_KEY`)
+- Groq: `groq` (`GROQ_API_KEY`)
+- Cerebras: `cerebras` (`CEREBRAS_API_KEY`)
+  - Modelos GLM em Cerebras usam ids `zai-glm-4.7` e `zai-glm-4.6`.
+  - URL base compatível com OpenAI: `https://api.cerebras.ai/v1`.
+- Mistral: `mistral` (`MISTRAL_API_KEY`)
+- GitHub Copilot: `github-copilot` (`COPILOT_GITHUB_TOKEN` / `GH_TOKEN` / `GITHUB_TOKEN`)
+- Hugging Face Inference: `huggingface` (`HUGGINGFACE_HUB_TOKEN` ou `HF_TOKEN`) — roteador compatível com OpenAI; modelo de exemplo: `huggingface/deepseek-ai/DeepSeek-R1`; CLI: `openclaw onboard --auth-choice huggingface-api-key`. Veja [Hugging Face (Inference)](/providers/huggingface).
+
+## Provedores via `models.providers` (customizado/URL base)
+
+Use `models.providers` (ou `models.json`) para adicionar provedores **customizados** ou proxies compatíveis com OpenAI/Anthropic.

--- a/docs/pt-BR/concepts/models.md
+++ b/docs/pt-BR/concepts/models.md
@@ -1,0 +1,189 @@
+---
+summary: "CLI de Modelos: listar, definir, aliases, fallbacks, scan, status"
+read_when:
+  - Adicionando ou modificando CLI de modelos (models list/set/scan/aliases/fallbacks)
+  - Mudando comportamento de fallback de modelo ou seleção UX
+  - Atualizando probes de scan de modelo (tools/images)
+title: "CLI de Modelos"
+---
+
+# CLI de Modelos
+
+Veja [/pt-BR/concepts/model-failover](/pt-BR/concepts/model-failover) para rotação de perfil de autenticação, cooldowns e como isso interage com fallbacks.
+Visão geral rápida do provedor + exemplos: [/pt-BR/concepts/model-providers](/pt-BR/concepts/model-providers).
+
+## Como funciona a seleção de modelo
+
+OpenClaw seleciona modelos nesta ordem:
+
+1. **Modelo primário** (`agents.defaults.model.primary` ou `agents.defaults.model`).
+2. **Fallbacks** em `agents.defaults.model.fallbacks` (em ordem).
+3. **Failover de autenticação do provedor** acontece dentro de um provedor antes de passar para o próximo modelo.
+
+Relacionado:
+
+- `agents.defaults.models` é a lista de permissões/catálogo de modelos que OpenClaw pode usar (mais aliases).
+- `agents.defaults.imageModel` é usado **apenas quando** o modelo primário não pode aceitar imagens.
+- Padrões por agente podem sobrescrever `agents.defaults.model` via `agents.list[].model` mais bindings (veja [/pt-BR/concepts/multi-agent](/pt-BR/concepts/multi-agent)).
+
+## Escolhas rápidas de modelo (anedótico)
+
+- **GLM**: um pouco melhor para codificação/tool calling.
+- **MiniMax**: melhor para escrita e vibes.
+
+## Assistente de configuração (recomendado)
+
+Se você não quer editar manualmente a config, execute o assistente de onboarding:
+
+```bash
+openclaw onboard
+```
+
+Pode configurar modelo + autenticação para provedores comuns, incluindo **Assinatura OpenAI Code (Codex)** (OAuth) e **Anthropic** (API key recomendada; `claude setup-token` também suportado).
+
+## Chaves de configuração (visão geral)
+
+- `agents.defaults.model.primary` e `agents.defaults.model.fallbacks`
+- `agents.defaults.imageModel.primary` e `agents.defaults.imageModel.fallbacks`
+- `agents.defaults.models` (lista de permissões + aliases + parâmetros do provedor)
+- `models.providers` (provedores personalizados escritos em `models.json`)
+
+Referências de modelo são normalizadas para minúsculas. Aliases do provedor como `z.ai/*` normalizam para `zai/*`.
+
+Exemplos de configuração do provedor (incluindo OpenCode Zen) vivem em [/gateway/configuration](/gateway/configuration#opencode-zen-multi-model-proxy).
+
+## "Modelo não é permitido" (e por que as respostas param)
+
+Se `agents.defaults.models` estiver definido, ele se torna a **lista de permissões** para `/model` e para substituições de sessão. Quando um usuário seleciona um modelo que não está nessa lista de permissões, OpenClaw retorna:
+
+```
+Model "provider/model" is not allowed. Use /model to list available models.
+```
+
+Isso acontece **antes** de uma resposta normal ser gerada, então a mensagem pode parecer que "não respondeu." A solução é:
+
+- Adicionar o modelo a `agents.defaults.models`, ou
+- Limpar a lista de permissões (remover `agents.defaults.models`), ou
+- Escolher um modelo de `/model list`.
+
+Exemplo de configuração de lista de permissões:
+
+```json5
+{
+  agent: {
+    model: { primary: "anthropic/claude-sonnet-4-5" },
+    models: {
+      "anthropic/claude-sonnet-4-5": { alias: "Sonnet" },
+      "anthropic/claude-opus-4-6": { alias: "Opus" },
+    },
+  },
+}
+```
+
+## Trocando modelos no chat (`/model`)
+
+Você pode trocar modelos para a sessão atual sem reiniciar:
+
+```
+/model
+/model list
+/model 3
+/model openai/gpt-5.2
+/model status
+```
+
+Notas:
+
+- `/model` (e `/model list`) é um seletor compacto e numerado (família de modelo + provedores disponíveis).
+- `/model <#>` seleciona a partir desse seletor.
+- `/model status` é a visão detalhada (candidatos de autenticação e, quando configurado, endpoint do provedor `baseUrl` + modo `api`).
+- Referências de modelo são analisadas dividindo no **primeiro** `/`. Use `provider/model` ao digitar `/model <ref>`.
+- Se o ID do modelo em si contiver `/` (estilo OpenRouter), você deve incluir o prefixo do provedor (exemplo: `/model openrouter/moonshotai/kimi-k2`).
+- Se você omitir o provedor, OpenClaw trata a entrada como um alias ou um modelo para o **provedor padrão** (funciona apenas quando não há `/` no ID do modelo).
+
+Comportamento completo do comando/config: [Comandos Slash](/tools/slash-commands).
+
+## Comandos CLI
+
+```bash
+openclaw models list
+openclaw models status
+openclaw models set <provider/model>
+openclaw models set-image <provider/model>
+
+openclaw models aliases list
+openclaw models aliases add <alias> <provider/model>
+openclaw models aliases remove <alias>
+
+openclaw models fallbacks list
+openclaw models fallbacks add <provider/model>
+openclaw models fallbacks remove <provider/model>
+openclaw models fallbacks clear
+
+openclaw models image-fallbacks list
+openclaw models image-fallbacks add <provider/model>
+openclaw models image-fallbacks remove <provider/model>
+openclaw models image-fallbacks clear
+```
+
+`openclaw models` (sem subcomando) é um atalho para `models status`.
+
+### `models list`
+
+Mostra modelos configurados por padrão. Flags úteis:
+
+- `--all`: catálogo completo
+- `--local`: apenas provedores locais
+- `--provider <name>`: filtrar por provedor
+- `--plain`: um modelo por linha
+- `--json`: saída legível por máquina
+
+### `models status`
+
+Mostra o modelo primário resolvido, fallbacks, modelo de imagem e uma visão geral de autenticação de provedores configurados. Também expõe o status de expiração de OAuth para perfis encontrados no armazenamento de autenticação (avisa dentro de 24h por padrão). `--plain` imprime apenas o modelo primário resolvido.
+Status OAuth é sempre mostrado (e incluído na saída `--json`). Se um provedor configurado não tem credenciais, `models status` imprime uma seção **Missing auth**.
+JSON inclui `auth.oauth` (janela de aviso + perfis) e `auth.providers` (auth efetiva por provedor).
+Use `--check` para automação (saída `1` quando faltando/expirado, `2` quando expirando).
+
+Autenticação Anthropic preferida é o setup-token CLI do Claude Code (execute em qualquer lugar; cole no host do gateway se necessário):
+
+```bash
+claude setup-token
+openclaw models status
+```
+
+## Scanning (modelos gratuitos OpenRouter)
+
+`openclaw models scan` inspeciona o **catálogo de modelo gratuito** OpenRouter e pode opcionalmente fazer probe de modelos para suporte a ferramentas e imagens.
+
+Flags principais:
+
+- `--no-probe`: pular probes ao vivo (apenas metadados)
+- `--min-params <b>`: tamanho mínimo de parâmetro (bilhões)
+- `--max-age-days <days>`: pular modelos mais antigos
+- `--provider <name>`: filtro de prefixo de provedor
+- `--max-candidates <n>`: tamanho da lista de fallback
+- `--set-default`: definir `agents.defaults.model.primary` para a primeira seleção
+- `--set-image`: definir `agents.defaults.imageModel.primary` para a primeira seleção de imagem
+
+Probing requer uma chave de API OpenRouter (de perfis de autenticação ou `OPENROUTER_API_KEY`). Sem uma chave, use `--no-probe` para listar apenas candidatos.
+
+Resultados de scan são classificados por:
+
+1. Suporte a imagem
+2. Latência de ferramenta
+3. Tamanho de contexto
+4. Contagem de parâmetro
+
+Entrada
+
+- Lista `/models` OpenRouter (filtro `:free`)
+- Requer chave de API OpenRouter de perfis de autenticação ou `OPENROUTER_API_KEY` (veja [/help/environment](/help/environment))
+- Filtros opcionais: `--max-age-days`, `--min-params`, `--provider`, `--max-candidates`
+- Controles de probe: `--timeout`, `--concurrency`
+
+Quando executado em um TTY, você pode selecionar fallbacks interativamente. Em modo não-interativo, passe `--yes` para aceitar padrões.
+
+## Registro de modelos (`models.json`)
+
+Provedores personalizados em `models.providers` são escritos em `models.json` sob o diretório do agente (padrão `~/.openclaw/agents/<agentId>/models.json`). Este arquivo é mesclado por padrão a menos que `models.mode` seja definido como `replace`.

--- a/docs/pt-BR/concepts/multi-agent.md
+++ b/docs/pt-BR/concepts/multi-agent.md
@@ -1,0 +1,73 @@
+---
+summary: "Roteamento multi-agente: agentes isolados, contas de canal e bindings"
+title: Roteamento Multi-Agente
+read_when: "Você quer múltiplos agentes isolados (workspaces + autenticação) em um processo gateway."
+status: active
+---
+
+# Roteamento Multi-Agente
+
+Objetivo: múltiplos agentes _isolados_ (workspace separado + `agentDir` + sessões), mais múltiplas contas de canal (ex. dois WhatsApps) em um Gateway em execução. Entrada é roteada para um agente via bindings.
+
+## O que é "um agente"?
+
+Um **agente** é um cérebro totalmente scoped com seu próprio:
+
+- **Workspace** (arquivos, AGENTS.md/SOUL.md/USER.md, notas locais, regras de persona).
+- **Diretório de estado** (`agentDir`) para perfis de autenticação, registro de modelo e config por agente.
+- **Armazenamento de sessão** (histórico de chat + estado de roteamento) sob `~/.openclaw/agents/<agentId>/sessions`.
+
+Perfis de autenticação são **por agente**. Cada agente lê de seu próprio:
+
+```
+~/.openclaw/agents/<agentId>/agent/auth-profiles.json
+```
+
+Credenciais do agente principal **não** são compartilhadas automaticamente. Nunca reutilize `agentDir` entre agentes (causa colisões de autenticação/sessão). Se você quer compartilhar credenciais, copie `auth-profiles.json` para o `agentDir` do outro agente.
+
+Skills são por agente via pasta `skills/` do workspace de cada um, com skills compartilhadas disponíveis de `~/.openclaw/skills`. Veja [Skills: por agente vs compartilhadas](/tools/skills#per-agent-vs-shared-skills).
+
+O Gateway pode hospedar **um agente** (padrão) ou **muitos agentes** lado a lado.
+
+**Nota de workspace:** o workspace de cada agente é o **cwd padrão**, não um sandbox rígido. Caminhos relativos resolvem dentro do workspace, mas caminhos absolutos podem alcançar outras localizações de host a menos que sandboxing esteja habilitado. Veja [Sandboxing](/gateway/sandboxing).
+
+## Caminhos (mapa rápido)
+
+- Config: `~/.openclaw/openclaw.json` (ou `OPENCLAW_CONFIG_PATH`)
+- Diretório de estado: `~/.openclaw` (ou `OPENCLAW_STATE_DIR`)
+- Workspace: `~/.openclaw/workspace` (ou `~/.openclaw/workspace-<agentId>`)
+- Diretório de agente: `~/.openclaw/agents/<agentId>/agent` (ou `agents.list[].agentDir`)
+- Sessões: `~/.openclaw/agents/<agentId>/sessions`
+
+### Modo de agente único (padrão)
+
+Se você não fazer nada, OpenClaw executa um único agente:
+
+- `agentId` padrão é **`main`**.
+- Sessões são keyed como `agent:main:<mainKey>`.
+- Workspace padrão é `~/.openclaw/workspace` (ou `~/.openclaw/workspace-<profile>` quando `OPENCLAW_PROFILE` é definido).
+- Estado padrão é `~/.openclaw/agents/main/agent`.
+
+## Assistente de agente
+
+Use o assistente de agente para adicionar um novo agente isolado:
+
+```bash
+openclaw agents add work
+```
+
+Depois adicione `bindings` (ou deixe o assistente fazer) para rotear mensagens de entrada.
+
+Verifique com:
+
+```bash
+openclaw agents list --bindings
+```
+
+## Múltiplos agentes = múltiplas pessoas, múltiplas personalidades
+
+Com **múltiplos agentes**, cada `agentId` se torna uma **persona totalmente isolada**:
+
+- **Diferentes números de telefone/contas** (per canal de conta `accountId`).
+- **Diferentes personalidades** (arquivos de workspace por agente como `AGENTS.md` e `SOUL.md`).
+- **Autenticação separada + sessões** (sem cross-talk a menos que explicitamente habilitado).

--- a/docs/pt-BR/concepts/oauth.md
+++ b/docs/pt-BR/concepts/oauth.md
@@ -1,0 +1,79 @@
+---
+summary: "OAuth em OpenClaw: troca de token, armazenamento e padrões multi-conta"
+read_when:
+  - Você quer entender OAuth do OpenClaw ponta a ponta
+  - Você bate em problemas de invalidação/logout de token
+  - Você quer setup-token ou fluxos de autenticação OAuth
+  - Você quer múltiplas contas ou roteamento de perfil
+title: "OAuth"
+---
+
+# OAuth
+
+OpenClaw suporta "autenticação de assinatura" via OAuth para provedores que o oferecem (notavelmente **OpenAI Codex (ChatGPT OAuth)**). Para assinaturas Anthropic, use o fluxo **setup-token**. Esta página explica:
+
+- como o **troca de token** OAuth funciona (PKCE)
+- onde tokens são **armazenados** (e por que)
+- como manipular **múltiplas contas** (perfis + substituições por sessão)
+
+OpenClaw também suporta **plugins de provedor** que enviam seus próprios OAuth ou fluxos de chave de API. Execute-os via:
+
+```bash
+openclaw models auth login --provider <id>
+```
+
+## O token sink (por que existe)
+
+Provedores OAuth comumente cunham um **novo token de refresh** durante fluxos de login/refresh. Alguns provedores (ou clientes OAuth) podem invalidar tokens de refresh mais antigos quando um novo é emitido para o mesmo usuário/app.
+
+Sintoma prático:
+
+- você faz login via OpenClaw _e_ via Claude Code / Codex CLI → um deles aleatoriamente fica "logged out" depois
+
+Para reduzir isso, OpenClaw trata `auth-profiles.json` como um **token sink**:
+
+- o runtime lê credenciais de **um lugar**
+- podemos manter múltiplos perfis e rotacioná-los deterministicamente
+
+## Armazenamento (onde tokens vivem)
+
+Segredos são armazenados **por agente**:
+
+- Perfis de autenticação (OAuth + chaves de API): `~/.openclaw/agents/<agentId>/agent/auth-profiles.json`
+- Cache de runtime (gerenciado automaticamente; não edite): `~/.openclaw/agents/<agentId>/agent/auth.json`
+
+Arquivo legado apenas para importação (ainda suportado, mas não a principal store):
+
+- `~/.openclaw/credentials/oauth.json` (importado para `auth-profiles.json` no primeiro uso)
+
+Tudo lo acima também respeita `$OPENCLAW_STATE_DIR` (substituição de diretório de estado). Referência completa: [/gateway/configuration](/gateway/configuration#auth-storage-oauth--api-keys)
+
+## Anthropic setup-token (autenticação de assinatura)
+
+Execute `claude setup-token` em qualquer máquina, depois cole em OpenClaw:
+
+```bash
+openclaw models auth setup-token --provider anthropic
+```
+
+Se você gerou o token em outro lugar, cole manualmente:
+
+```bash
+openclaw models auth paste-token --provider anthropic
+```
+
+Verifique:
+
+```bash
+openclaw models status
+```
+
+## Troca OAuth (como login funciona)
+
+Os fluxos de login interativos do OpenClaw são implementados em `@mariozechner/pi-ai` e fiados nos assistentes/comandos.
+
+### Anthropic (Claude Pro/Max) setup-token
+
+Forma de fluxo:
+
+1. execute `claude setup-token`

--- a/docs/pt-BR/concepts/presence.md
+++ b/docs/pt-BR/concepts/presence.md
@@ -1,0 +1,72 @@
+---
+summary: "Como entradas de presença do OpenClaw são produzidas, mescladas e exibidas"
+read_when:
+  - Debugando a aba Instances
+  - Investigando linhas de instância duplicadas ou obsoletas
+  - Mudando beacons de connect WS ou system-event do gateway
+title: "Presença"
+---
+
+# Presença
+
+"Presença" do OpenClaw é uma visão lightweight e best-effort de:
+
+- o **Gateway** em si, e
+- **clientes conectados ao Gateway** (app mac, WebChat, CLI, etc.)
+
+Presença é usada principalmente para renderizar a aba **Instances** do app macOS e fornecer visibilidade rápida de operador.
+
+## Campos de Presença (o que aparece)
+
+Entradas de presença são objetos estruturados com campos como:
+
+- `instanceId` (opcional mas fortemente recomendado): identidade de cliente estável (geralmente `connect.client.instanceId`)
+- `host`: nome de host amigável
+- `ip`: endereço IP best-effort
+- `version`: string de versão do cliente
+- `deviceFamily` / `modelIdentifier`: dicas de hardware
+- `mode`: `ui`, `webchat`, `cli`, `backend`, `probe`, `test`, `node`, ...
+- `lastInputSeconds`: "segundos desde última entrada de usuário" (se conhecido)
+- `reason`: `self`, `connect`, `node-connected`, `periodic`, ...
+- `ts`: último timestamp de atualização (ms desde epoch)
+
+## Produtores (de onde presença vem)
+
+Entradas de presença são produzidas por múltiplas fontes e **mescladas**.
+
+### 1) Entrada self do Gateway
+
+O Gateway sempre planta uma entrada "self" na inicialização para que interfaces mostrem o host do gateway mesmo antes de qualquer cliente conectar.
+
+### 2) WebSocket connect
+
+Cada cliente WS começa com uma requisição `connect`. No handshake bem-sucedido o Gateway upserts uma entrada de presença para aquela conexão.
+
+#### Por que comandos CLI one-off não aparecem
+
+O CLI frequentemente se conecta por comandos curtos e one-off. Para evitar spam na lista de Instances, `client.mode === "cli"` está **não** transformado em uma entrada de presença.
+
+### 3) Beacons `system-event`
+
+Clientes podem enviar beacons periódicos mais ricos via método `system-event`. O app mac usa isso para relatar hostname, IP e `lastInputSeconds`.
+
+### 4) Node connects (role: node)
+
+Quando um nó se conecta sobre o WebSocket do Gateway com `role: node`, o Gateway upserts uma entrada de presença para aquele nó (mesmo fluxo que outros clientes WS).
+
+## Merge + regras de dedupe (por que `instanceId` importa)
+
+Entradas de presença são armazenadas em um único mapa na memória:
+
+- Entradas são keyed por uma **chave de presença**.
+- A melhor chave é um `instanceId` estável (de `connect.client.instanceId`) que sobrevive reinicializações.
+- Chaves são case-insensitive.
+
+Se um cliente se reconecta sem um `instanceId` estável, ele pode aparecer como uma linha **duplicada**.
+
+## TTL e tamanho limitado
+
+Presença é intencionalmente efêmera:
+
+- **TTL:** entradas mais antigas que 5 minutos são podadas
+- **Max entradas:** 200 (mais antigas descartadas primeiro)

--- a/docs/pt-BR/concepts/queue.md
+++ b/docs/pt-BR/concepts/queue.md
@@ -1,0 +1,87 @@
+---
+summary: "Design de fila de comando que serializa execuções de auto-reply de entrada"
+read_when:
+  - Mudando execução ou concorrência de auto-reply
+title: "Fila de Comando"
+---
+
+# Fila de Comando (2026-01-16)
+
+Nós serializamos execuções de auto-reply de entrada (todos os canais) através de uma pequena fila no processo para evitar que múltiplas execuções de agente colidam, enquanto ainda permitimos paralelismo seguro entre sessões.
+
+## Por que
+
+- Execuções de auto-reply podem ser caras (chamadas LLM) e podem colidir quando múltiplas mensagens de entrada chegam perto uma da outra.
+- Serializar evita competição por recursos compartilhados (arquivos de sessão, logs, CLI stdin) e reduz a chance de limites de taxa upstream.
+
+## Como funciona
+
+- Uma fila FIFO com conhecimento de pista drena cada pista com um cap de concorrência configurável (padrão 1 para pistas não configuradas; main padrão para 4, subagente para 8).
+- `runEmbeddedPiAgent` enfileira por **chave de sessão** (pista `session:<key>`) para garantir apenas uma execução ativa por sessão.
+- Cada execução de sessão é então enfileirada na **pista global** (`main` por padrão) para que o paralelismo geral seja capped por `agents.defaults.maxConcurrent`.
+- Quando logging verbose está habilitado, execuções enfileiradas emitem um aviso curto se esperaram mais de ~2s antes de iniciar.
+- Indicadores de digitação ainda disparam imediatamente em enfileiramento (quando suportado pelo canal) para que a experiência do usuário não mude enquanto esperamos nossa vez.
+
+## Modos de fila (por canal)
+
+Mensagens de entrada podem direcionar a execução atual, esperar por uma volta de followup, ou fazer ambas:
+
+- `steer`: injeta imediatamente na execução atual (cancela chamadas de ferramenta pendentes após o próximo limite de ferramenta). Se não estiver em stream, volta para followup.
+- `followup`: enfileira para a próxima volta de agente após a execução atual terminar.
+- `collect`: coalesce todas as mensagens enfileiradas em uma **única** volta de followup (padrão). Se mensagens visam diferentes canais/threads, elas drenam individualmente para preservar roteamento.
+- `steer-backlog` (aka `steer+backlog`): direciona agora **e** preserva a mensagem para uma volta de followup.
+- `interrupt` (legado): aborta a execução ativa para aquela sessão, então executa a mensagem mais nova.
+- `queue` (alias legado): o mesmo que `steer`.
+
+Steer-backlog significa você pode obter uma resposta de followup após a execução direcionada, então superfícies de streaming podem parecer duplicatas. Prefira `collect`/`steer` se você quer uma resposta por mensagem de entrada.
+Envie `/queue collect` como um comando autônomo (por sessão) ou defina `messages.queue.byChannel.discord: "collect"`.
+
+Padrões (quando não configurados):
+
+- Todas as superfícies → `collect`
+
+Configure globalmente ou por canal via `messages.queue`:
+
+```json5
+{
+  messages: {
+    queue: {
+      mode: "collect",
+      debounceMs: 1000,
+      cap: 20,
+      drop: "summarize",
+      byChannel: { discord: "collect" },
+    },
+  },
+}
+```
+
+## Opções de fila
+
+Opções se aplicam a `followup`, `collect` e `steer-backlog` (e a `steer` quando volta para followup):
+
+- `debounceMs`: espera por silence antes de iniciar uma volta de followup (previne "continue, continue").
+- `cap`: máximo de mensagens enfileiradas por sessão.
+- `drop`: política de overflow (`old`, `new`, `summarize`).
+
+Summarize mantém uma lista curta de notas de mensagens descartadas e injeta como um prompt de followup sintético.
+Padrões: `debounceMs: 1000`, `cap: 20`, `drop: summarize`.
+
+## Substituições por sessão
+
+- Envie `/queue <mode>` como um comando autônomo para armazenar o modo para a sessão atual.
+- Opções podem ser combinadas: `/queue collect debounce:2s cap:25 drop:summarize`
+- `/queue default` ou `/queue reset` limpa a substituição de sessão.
+
+## Escopo e garantias
+
+- Se aplica a execuções de auto-reply de agente em todos os canais de entrada que usam o pipeline de reply do gateway (WhatsApp web, Telegram, Slack, Discord, Signal, iMessage, webchat, etc.).
+- Pista padrão (`main`) é process-wide para entrada + heartbeats principais; defina `agents.defaults.maxConcurrent` para permitir múltiplas sessões em paralelo.
+- Pistas adicionais podem existir (por ex. `cron`, `subagent`) para que jobs de background possam executar em paralelo sem bloquear replies de entrada.
+- Pistas por sessão garantem que apenas uma execução de agente toca uma dada sessão por vez.
+- Sem dependências externas ou threads de worker de background; pure TypeScript + promises.
+
+## Troubleshooting
+
+- Se comandos parecem travados, habilite logs verbose e procure por linhas "queued for …ms" para confirmar que a fila está drenando.
+- Se você precisa de profundidade de fila, habilite logs verbose e observe linhas de timing de fila.

--- a/docs/pt-BR/concepts/retry.md
+++ b/docs/pt-BR/concepts/retry.md
@@ -1,0 +1,69 @@
+---
+summary: "Política de retry para chamadas de provedor outbound"
+read_when:
+  - Atualizando comportamento de retry de provedor ou padrões
+  - Debugando erros de envio de provedor ou rate limits
+title: "Política de Retry"
+---
+
+# Política de retry
+
+## Objetivos
+
+- Retry por requisição HTTP, não por fluxo multi-passo.
+- Preservar ordenação retentando apenas o passo atual.
+- Evitar duplicar operações não-idempotentes.
+
+## Padrões
+
+- Tentativas: 3
+- Max delay cap: 30000 ms
+- Jitter: 0.1 (10 percent)
+- Padrões de provedor:
+  - Telegram min delay: 400 ms
+  - Discord min delay: 500 ms
+
+## Comportamento
+
+### Discord
+
+- Retries apenas em erros de rate-limit (HTTP 429).
+- Usa Discord `retry_after` quando disponível, caso contrário exponential backoff.
+
+### Telegram
+
+- Retries em erros transitórios (429, timeout, connect/reset/closed, temporarily unavailable).
+- Usa `retry_after` quando disponível, caso contrário exponential backoff.
+- Erros de parse de Markdown não são retried; eles caem de volta para texto plano.
+
+## Configuração
+
+Defina política de retry por provedor em `~/.openclaw/openclaw.json`:
+
+```json5
+{
+  channels: {
+    telegram: {
+      retry: {
+        attempts: 3,
+        minDelayMs: 400,
+        maxDelayMs: 30000,
+        jitter: 0.1,
+      },
+    },
+    discord: {
+      retry: {
+        attempts: 3,
+        minDelayMs: 500,
+        maxDelayMs: 30000,
+        jitter: 0.1,
+      },
+    },
+  },
+}
+```
+
+## Notas
+
+- Retries se aplicam por requisição (message send, media upload, reaction, poll, sticker).
+- Fluxos compostos não reentam passos completados.

--- a/docs/pt-BR/concepts/session-pruning.md
+++ b/docs/pt-BR/concepts/session-pruning.md
@@ -1,0 +1,80 @@
+---
+title: "Pruning de Sessão"
+summary: "Session pruning: trimming de tool-result para reduzir context bloat"
+read_when:
+  - Você quer reduzir crescimento de contexto LLM de saídas de ferramenta
+  - Você está ajustando agents.defaults.contextPruning
+---
+
+# Pruning de Sessão
+
+Pruning de sessão aparas **resultados de ferramenta antiga** do contexto na memória logo antes de cada chamada de LLM. Ele **não** reescreve o histórico de sessão em disco (`*.jsonl`).
+
+## Quando executa
+
+- Quando `mode: "cache-ttl"` está habilitado e a última chamada Anthropic para a sessão é mais antiga que `ttl`.
+- Apenas afeta mensagens enviadas ao modelo para aquela requisição.
+- Apenas ativo para chamadas da API Anthropic (e modelos Anthropic da OpenRouter).
+- Para melhores resultados, combine `ttl` com seu modelo `cacheControlTtl`.
+- Após um prune, a janela de TTL reseta para que requisições subsequentes mantenham cache até `ttl` expirar novamente.
+
+## Padrões inteligentes (Anthropic)
+
+- **Perfis OAuth ou setup-token**: habilite pruning `cache-ttl` e defina heartbeat para `1h`.
+- **Perfis de chave de API**: habilite pruning `cache-ttl`, defina heartbeat para `30m` e `cacheControlTtl` padrão para `1h` em modelos Anthropic.
+- Se você definir qualquer desses valores explicitamente, OpenClaw **não** os sobrescreve.
+
+## O que melhora (custo + comportamento de cache)
+
+- **Por que prune**: Caching de prompt Anthropic apenas se aplica dentro do TTL. Se uma sessão fica ociosa passada a TTL, a próxima requisição re-cachea o prompt completo a menos que você o corte primeiro.
+- **O que fica mais barato**: pruning reduz o tamanho **cacheWrite** para aquela primeira requisição após a TTL expirar.
+- **Por que o reset de TTL importa**: uma vez que pruning executa, a janela de cache reseta, então requisições de follow-up podem reutilizar o prompt recém-cacheado em vez de re-cachear o histórico completo novamente.
+- **O que não faz**: pruning não adiciona tokens ou "duplica" custos; apenas muda o que é cacheado naquela primeira requisição pós-TTL.
+
+## O que pode ser podado
+
+- Apenas mensagens `toolResult`.
+- Mensagens de usuário + assistente são **nunca** modificadas.
+- As últimas `keepLastAssistants` mensagens de assistente são protegidas; resultados de ferramenta após aquele cutoff não são podados.
+- Se não há assistentes suficientes para estabelecer o cutoff, pruning é ignorado.
+- Resultados de ferramenta contendo **image blocks** são ignorados (nunca trimados/limpos).
+
+## Estimação de janela de contexto
+
+Pruning usa uma janela de contexto estimada (chars ≈ tokens × 4). A janela base é resolvida nesta ordem:
+
+1. Override `models.providers.*.models[].contextWindow`.
+2. Definição de modelo `contextWindow` (do registry de modelo).
+3. Padrão `200000` tokens.
+
+Se `agents.defaults.contextTokens` estiver definido, é tratado como um cap (min) na janela resolvida.
+
+## Modo
+
+### cache-ttl
+
+- Pruning apenas executa se a última chamada Anthropic é mais antiga que `ttl` (padrão `5m`).
+- Quando executa: mesmo comportamento soft-trim + hard-clear como antes.
+
+## Soft vs hard pruning
+
+- **Soft-trim**: apenas para resultados de ferramenta oversized.
+  - Mantém head + tail, insere `...` e anexa uma nota com o tamanho original.
+  - Ignora resultados com image blocks.
+- **Hard-clear**: substitui o resultado de ferramenta inteiro com `hardClear.placeholder`.
+
+## Seleção de ferramenta
+
+- `tools.allow` / `tools.deny` suportam wildcards `*`.
+- Deny vence.
+- Matching é case-insensitive.
+- Lista de allow vazia => todas as ferramentas permitidas.
+
+## Interação com outros limites
+
+- Ferramentas integradas já truncam sua própria saída; session pruning é uma camada extra que previne chats de longa execução de acumular muita saída de ferramenta no contexto do modelo.
+- Compactação é separada: compactação resume e persiste, pruning é transitório por requisição. Veja [/pt-BR/concepts/compaction](/pt-BR/concepts/compaction).
+
+## Padrões (quando habilitado)
+
+- `ttl`: `"5m"`

--- a/docs/pt-BR/concepts/session-tool.md
+++ b/docs/pt-BR/concepts/session-tool.md
@@ -1,0 +1,90 @@
+---
+summary: "Ferramentas de sessão de agente para listar sessões, buscar histórico e enviar mensagens entre sessões"
+read_when:
+  - Adicionando ou modificando ferramentas de sessão
+title: "Ferramentas de Sessão"
+---
+
+# Ferramentas de Sessão
+
+Objetivo: pequeno conjunto de ferramentas difíceis de usar incorretamente para que agentes possam listar sessões, buscar histórico e enviar para outra sessão.
+
+## Nomes de Ferramentas
+
+- `sessions_list`
+- `sessions_history`
+- `sessions_send`
+- `sessions_spawn`
+
+## Modelo chave
+
+- O bucket principal de chat direto é sempre a chave literal `"main"` (resolvida para a chave principal atual do agente).
+- Chats de grupo usam `agent:<agentId>:<channel>:group:<id>` ou `agent:<agentId>:<channel>:channel:<id>` (passa a chave completa).
+- Cron jobs usam `cron:<job.id>`.
+- Ganchos usam `hook:<uuid>` a menos que explicitamente definido.
+- Sessões de nó usam `node-<nodeId>` a menos que explicitamente definido.
+
+`global` e `unknown` são valores reservados e nunca são listados. Se `session.scope = "global"`, nós o aliasamos para `main` para todas as ferramentas para que chamadores nunca vejam `global`.
+
+## sessions_list
+
+Lista sessões como um array de linhas.
+
+Parâmetros:
+
+- `kinds?: string[]` filtro: qualquer de `"main" | "group" | "cron" | "hook" | "node" | "other"`
+- `limit?: number` máximo de linhas (padrão: padrão do servidor, clamp ex. 200)
+- `activeMinutes?: number` apenas sessões atualizadas dentro de N minutos
+- `messageLimit?: number` 0 = sem mensagens (padrão 0); >0 = incluir últimas N mensagens
+
+Comportamento:
+
+- `messageLimit > 0` busca `chat.history` por sessão e inclui as últimas N mensagens.
+- Resultados de ferramenta são filtrados de saída de lista; use `sessions_history` para mensagens de ferramenta.
+- Quando executando em uma sessão de agente **sandboxed**, ferramentas de sessão padrão para **spawned-only visibility** (veja abaixo).
+
+Forma de linha (JSON):
+
+- `key`: chave de sessão (string)
+- `kind`: `main | group | cron | hook | node | other`
+- `channel`: `whatsapp | telegram | discord | signal | imessage | webchat | internal | unknown`
+- `displayName` (rótulo de exibição de grupo se disponível)
+- `updatedAt` (ms)
+- `sessionId`
+- `model`, `contextTokens`, `totalTokens`
+- `thinkingLevel`, `verboseLevel`, `systemSent`, `abortedLastRun`
+- `sendPolicy` (substituição de sessão se definida)
+- `lastChannel`, `lastTo`
+- `deliveryContext` (normalizado `{ channel, to, accountId }` quando disponível)
+- `transcriptPath` (caminho best-effort derivado de store dir + sessionId)
+- `messages?` (apenas quando `messageLimit > 0`)
+
+## sessions_history
+
+Busca transcrição para uma sessão.
+
+Parâmetros:
+
+- `sessionKey` (obrigatório; aceita chave de sessão ou `sessionId` de `sessions_list`)
+- `limit?: number` máximo de mensagens (server clamps)
+- `includeTools?: boolean` (padrão false)
+
+Comportamento:
+
+- `includeTools=false` filtra mensagens `role: "toolResult"`.
+- Retorna array de mensagens no formato de transcrição bruta.
+- Quando dado um `sessionId`, OpenClaw o resolve para a chave de sessão correspondente (ids faltando erro).
+
+## sessions_send
+
+Envia mensagem para outra sessão.
+
+Parâmetros:
+
+- `sessionKey` (obrigatório; aceita chave de sessão ou `sessionId` de `sessions_list`)
+- `message` (obrigatório)
+- `timeoutSeconds?: number` (padrão >0; 0 = fire-and-forget)
+
+Comportamento:
+
+- `timeoutSeconds = 0`: enfilizar e retornar `{ runId, status: "accepted" }`.

--- a/docs/pt-BR/concepts/session.md
+++ b/docs/pt-BR/concepts/session.md
@@ -1,0 +1,197 @@
+---
+summary: "Regras de gerenciamento de sessão, chaves e persistência para chats"
+read_when:
+  - Modificando o tratamento ou armazenamento de sessão
+title: "Gerenciamento de Sessão"
+---
+
+# Gerenciamento de Sessão
+
+OpenClaw trata **uma sessão de chat direto por agente** como primária. Chats diretos colapsam para `agent:<agentId>:<mainKey>` (padrão `main`), enquanto chats de grupo/canal recebem suas próprias chaves. `session.mainKey` é honrado.
+
+Use `session.dmScope` para controlar como **mensagens diretas** são agrupadas:
+
+- `main` (padrão): todas as DMs compartilham a sessão principal para continuidade.
+- `per-peer`: isola por id de remetente entre canais.
+- `per-channel-peer`: isola por canal + remetente (recomendado para caixas de entrada multi-usuário).
+- `per-account-channel-peer`: isola por conta + canal + remetente (recomendado para caixas de entrada multi-conta).
+  Use `session.identityLinks` para mapear ids de peer com prefixo de provedor para uma identidade canônica para que a mesma pessoa compartilhe uma sessão de DM entre canais ao usar `per-peer`, `per-channel-peer`, ou `per-account-channel-peer`.
+
+## Modo DM seguro (recomendado para configurações multi-usuário)
+
+> **Aviso de Segurança:** Se seu agente pode receber DMs de **múltiplas pessoas**, você deve fortemente considerar abilitar modo DM seguro. Sem isso, todos os usuários compartilham o mesmo contexto de conversa, o que pode vazar informações privadas entre usuários.
+
+**Exemplo do problema com configurações padrão:**
+
+- Alice (`<SENDER_A>`) mensagens seu agente sobre um tópico privado (por exemplo, uma consulta médica)
+- Bob (`<SENDER_B>`) mensagens seu agente perguntando "Sobre o que estávamos falando?"
+- Como ambas as DMs compartilham a mesma sessão, o modelo pode responder a Bob usando o contexto anterior de Alice.
+
+**A solução:** Defina `dmScope` para isolar sessões por usuário:
+
+```json5
+// ~/.openclaw/openclaw.json
+{
+  session: {
+    // Modo DM seguro: isola contexto de DM por canal + remetente.
+    dmScope: "per-channel-peer",
+  },
+}
+```
+
+**Quando habilitar isso:**
+
+- Você tem aprovações de emparelhamento para mais de um remetente
+- Você usa uma lista de permissões de DM com múltiplas entradas
+- Você define `dmPolicy: "open"`
+- Múltiplos números de telefone ou contas podem mensagear seu agente
+
+Notas:
+
+- O padrão é `dmScope: "main"` para continuidade (todas as DMs compartilham a sessão principal). Isso é bom para configurações de usuário único.
+- Para caixas de entrada multi-conta no mesmo canal, prefira `per-account-channel-peer`.
+- Se a mesma pessoa o contatar em múltiplos canais, use `session.identityLinks` para colapsar suas sessões de DM em uma identidade canônica.
+- Você pode verificar suas configurações de DM com `openclaw security audit` (veja [security](/cli/security)).
+
+## Gateway é a fonte de verdade
+
+Todo o estado da sessão é **propriedade do gateway** (o "mestre" OpenClaw). Clientes de interface (app macOS, WebChat, etc.) devem consultar o gateway para listas de sessão e contagens de token em vez de ler arquivos locais.
+
+- Em **modo remoto**, o armazenamento de sessão que você se importa vive no host do gateway remoto, não no seu Mac.
+- Contagens de token mostradas nas interfaces vêm dos campos de armazenamento do gateway (`inputTokens`, `outputTokens`, `totalTokens`, `contextTokens`). Clientes não analisam transcrições JSONL para "corrigir" totais.
+
+## Onde o estado vive
+
+- No **host do gateway**:
+  - Arquivo de armazenamento: `~/.openclaw/agents/<agentId>/sessions/sessions.json` (por agente).
+- Transcrições: `~/.openclaw/agents/<agentId>/sessions/<SessionId>.jsonl` (sessões de tópico Telegram usam `.../<SessionId>-topic-<threadId>.jsonl`).
+- O armazenamento é um mapa `sessionKey -> { sessionId, updatedAt, ... }`. Excluir entradas é seguro; elas são recriadas sob demanda.
+- Entradas de grupo podem incluir `displayName`, `channel`, `subject`, `room`, e `space` para rotular sessões em interfaces.
+- Entradas de sessão incluem metadados de `origin` (rótulo + dicas de roteamento) para que interfaces possam explicar de onde uma sessão veio.
+- OpenClaw **não** lê pastas de sessão herdadas Pi/Tau.
+
+## Limpeza de sessão
+
+OpenClaw aparas **resultados de ferramentas antigas** do contexto na memória logo antes de chamadas de LLM por padrão.
+Isso **não** reescreve histórico JSONL. Veja [/pt-BR/concepts/session-pruning](/pt-BR/concepts/session-pruning).
+
+## Flush de memória pré-compactação
+
+Quando uma sessão se aproxima de auto-compactação, OpenClaw pode executar uma volta de **flush de memória silencioso** que lembra o modelo a escrever notas duráveis em disco. Isso só executado quando o workspace é gravável. Veja [Memória](/pt-BR/concepts/memory) e [Compactação](/pt-BR/concepts/compaction).
+
+## Mapeando transportes → chaves de sessão
+
+- Chats diretos segue `session.dmScope` (padrão `main`).
+  - `main`: `agent:<agentId>:<mainKey>` (continuidade entre dispositivos/canais).
+    - Múltiplos números de telefone e canais podem mapear para a mesma chave principal do agente; agem como transportes em uma conversa.
+  - `per-peer`: `agent:<agentId>:dm:<peerId>`.
+  - `per-channel-peer`: `agent:<agentId>:<channel>:dm:<peerId>`.
+  - `per-account-channel-peer`: `agent:<agentId>:<channel>:<accountId>:dm:<peerId>` (accountId padrão é `default`).
+  - Se `session.identityLinks` corresponde a um id de peer com prefixo de provedor (por exemplo `telegram:123`), a chave canônica substitui `<peerId>` para que a mesma pessoa compartilhe uma sessão entre canais.
+- Chats de grupo isolam estado: `agent:<agentId>:<channel>:group:<id>` (salas/canais usam `agent:<agentId>:<channel>:channel:<id>`).
+  - Tópicos de fórum Telegram anexam `:topic:<threadId>` ao id do grupo para isolamento.
+  - Chaves legadas `group:<id>` ainda são reconhecidas para migração.
+- Contextos de entrada ainda podem usar `group:<id>`; o canal é inferido de `Provider` e normalizado para a forma canônica `agent:<agentId>:<channel>:group:<id>`.
+- Outras fontes:
+  - Cron jobs: `cron:<job.id>`
+  - Webhooks: `hook:<uuid>` (a menos que explicitamente definido pelo webhook)
+  - Execuções de nó: `node-<nodeId>`
+
+## Ciclo de vida
+
+- Política de reset: sessões são reutilizadas até expirar, e expiração é avaliada na próxima mensagem de entrada.
+- Reset diário: padrão de **4:00 AM horário local no host do gateway**. Uma sessão fica obsoleta uma vez que sua última atualização é anterior ao tempo de reset diário mais recente.
+- Reset ocioso (opcional): `idleMinutes` adiciona uma janela de ociosidade deslizante. Quando resets diários e ociosos são configurados, **aquele que expira primeiro** força uma nova sessão.
+- Legado somente ocioso: se você definir `session.idleMinutes` sem qualquer configuração `session.reset`/`resetByType`, OpenClaw fica em modo somente ocioso para compatibilidade retroativa.
+- Substituições por tipo (opcional): `resetByType` permite substituir a política para sessões `direct`, `group`, e `thread` (thread = threads Slack/Discord, tópicos Telegram, threads Matrix quando fornecidos pelo conector).
+- Substituições por canal (opcional): `resetByChannel` substitui a política de reset para um canal (aplica a todos os tipos de sessão para esse canal e tem precedência sobre `reset`/`resetByType`).
+- Triggers de reset: exato `/new` ou `/reset` (mais qualquer coisa extra em `resetTriggers`) inicia um id de sessão fresco e passa o resto da mensagem através. `/new <model>` aceita um alias de modelo, `provider/model`, ou nome do provedor (correspondência difusa) para definir o novo modelo de sessão. Se `/new` ou `/reset` é enviado sozinho, OpenClaw executa uma volta de saudação curta "olá" para confirmar o reset.
+- Reset manual: exclua chaves específicas do armazenamento ou remova a transcrição JSONL; a próxima mensagem as recria.
+- Cron jobs isolados sempre cunham um `sessionId` fresco por execução (nenhuma reutilização de ociosidade).
+
+## Política de envio (opcional)
+
+Bloqueia entrega para tipos de sessão específicos sem listar ids individuais.
+
+```json5
+{
+  session: {
+    sendPolicy: {
+      rules: [
+        { action: "deny", match: { channel: "discord", chatType: "group" } },
+        { action: "deny", match: { keyPrefix: "cron:" } },
+        // Corresponde a chave de sessão bruta (incluindo o prefixo `agent:<id>:`).
+        { action: "deny", match: { rawKeyPrefix: "agent:main:discord:" } },
+      ],
+      default: "allow",
+    },
+  },
+}
+```
+
+Substituição de tempo de execução (somente proprietário):
+
+- `/send on` → permitir para esta sessão
+- `/send off` → negar para esta sessão
+- `/send inherit` → limpar substituição e usar regras de configuração
+  Envie essas como mensagens autônomas para que elas se registrem.
+
+## Configuração (exemplo opcional de renomeação)
+
+```json5
+// ~/.openclaw/openclaw.json
+{
+  session: {
+    scope: "per-sender", // mantém chaves de grupo separadas
+    dmScope: "main", // continuidade de DM (defina per-channel-peer/per-account-channel-peer para caixas de entrada compartilhadas)
+    identityLinks: {
+      alice: ["telegram:123456789", "discord:987654321012345678"],
+    },
+    reset: {
+      // Padrões: mode=daily, atHour=4 (horário local do host do gateway).
+      // Se você também definir idleMinutes, o que expira primeiro vence.
+      mode: "daily",
+      atHour: 4,
+      idleMinutes: 120,
+    },
+    resetByType: {
+      thread: { mode: "daily", atHour: 4 },
+      direct: { mode: "idle", idleMinutes: 240 },
+      group: { mode: "idle", idleMinutes: 120 },
+    },
+    resetByChannel: {
+      discord: { mode: "idle", idleMinutes: 10080 },
+    },
+    resetTriggers: ["/new", "/reset"],
+    store: "~/.openclaw/agents/{agentId}/sessions/sessions.json",
+    mainKey: "main",
+  },
+}
+```
+
+## Inspecionando
+
+- `openclaw status` — mostra caminho de armazenamento e sessões recentes.
+- `openclaw sessions --json` — despeja cada entrada (filtro com `--active <minutes>`).
+- `openclaw gateway call sessions.list --params '{}'` — busca sessões do gateway em execução (use `--url`/`--token` para acesso remoto de gateway).
+- Envie `/status` como uma mensagem autônoma no chat para ver se o agente está acessível, quanto do contexto da sessão é usado, toggles de pensamento/verboso atuais, e quando suas credenciais do WhatsApp web foram atualizadas pela última vez (ajuda a detectar necessidades de relink).
+- Envie `/context list` ou `/context detail` para ver o que está no prompt do sistema e arquivos de workspace injetados (e os maiores contribuidores de contexto).
+- Envie `/stop` como uma mensagem autônoma para abortar a execução atual, limpar followups enfileirados para essa sessão, e parar qualquer execução de sub-agente gerada a partir dela (a resposta inclui a contagem parada).
+- Envie `/compact` (instruções opcionais) como uma mensagem autônoma para resumir contexto mais antigo e liberar espaço de janela. Veja [/pt-BR/concepts/compaction](/pt-BR/concepts/compaction).
+- Transcrições JSONL podem ser abertas diretamente para revisar voltas completas.
+
+## Dicas
+
+- Mantenha a chave principal dedicada ao tráfego 1:1; deixe grupos manterem suas próprias chaves.
+- Ao automatizar limpeza, delete chaves individuais em vez de todo o armazenamento para preservar contexto em outro lugar.
+
+## Metadados de origem da sessão
+
+Cada entrada de sessão registra de onde veio (melhor esforço) em `origin`:
+
+- `label`: rótulo humano (resolvido de rótulo de conversa + assunto/canal de grupo)
+- `provider`: id do canal normalizado (incluindo extensões)
+- `from`/`to`: ids de roteamento brutos do envelope de entrada
+- `accountId`: id da conta do provedor (quando multi-conta)
+- `threadId`: id do thread/tópico quando o canal suporta
+  Os campos de origem são preenchidos para mensagens diretas, canais e grupos. Se um conector apenas atualiza roteamento de entrega (por exemplo, para manter uma sessão principal de DM fresca), ainda deve fornecer contexto de entrada para que a sessão mantenha seus metadados de explicador. Extensões podem fazer isso enviando `ConversationLabel`, `GroupSubject`, `GroupChannel`, `GroupSpace`, e `SenderName` no contexto de entrada e chamando `recordSessionMetaFromInbound` (ou passando o mesmo contexto para `updateLastRoute`).

--- a/docs/pt-BR/concepts/sessions.md
+++ b/docs/pt-BR/concepts/sessions.md
@@ -1,0 +1,10 @@
+---
+summary: "Alias para docs de gerenciamento de sessão"
+read_when:
+  - Você procurou por docs/sessions.md; doc canônico vive em docs/session.md
+title: "Sessões"
+---
+
+# Sessões
+
+Docs canônicas de gerenciamento de sessão vivem em [Gerenciamento de Sessão](/pt-BR/concepts/session).

--- a/docs/pt-BR/concepts/streaming.md
+++ b/docs/pt-BR/concepts/streaming.md
@@ -1,0 +1,127 @@
+---
+summary: "Comportamento de Streaming + chunking (block replies, preview streaming Telegram, limites)"
+read_when:
+  - Explicando como streaming ou chunking funciona em canais
+  - Mudando comportamento de block streaming ou chunking de canal
+  - Debugando block replies duplicadas/antecipadas ou preview streaming Telegram
+title: "Streaming e Chunking"
+---
+
+# Streaming + chunking
+
+OpenClaw tem duas camadas de "streaming" separadas:
+
+- **Block streaming (canais):** emite **blocos** completos conforme o assistente escreve. Estes são mensagens de canal normais (não deltas de token).
+- **Token-ish streaming (apenas Telegram):** atualiza uma **mensagem de preview** temporária com texto parcial enquanto gera.
+
+Não existe **streaming verdadeiro de delta de token** para mensagens de canal hoje. Preview streaming do Telegram é a única superfície de partial-stream.
+
+## Block streaming (mensagens de canal)
+
+Block streaming envia saída do assistente em chunks grossos conforme ficam disponíveis.
+
+```
+Saída do modelo
+  └─ text_delta/events
+       ├─ (blockStreamingBreak=text_end)
+       │    └─ chunker emite blocos conforme buffer cresce
+       └─ (blockStreamingBreak=message_end)
+            └─ chunker flushes em message_end
+                   └─ channel send (block replies)
+```
+
+Legenda:
+
+- `text_delta/events`: eventos de stream do modelo (podem ser sparse para modelos não-streaming).
+- `chunker`: `EmbeddedBlockChunker` aplicando limites min/max + preferência de break.
+- `channel send`: mensagens outbound reais (block replies).
+
+**Controles:**
+
+- `agents.defaults.blockStreamingDefault`: `"on"`/`"off"` (padrão off).
+- Substituições de canal: `*.blockStreaming` (e variantes por conta) para forçar `"on"`/`"off"` por canal.
+- `agents.defaults.blockStreamingBreak`: `"text_end"` ou `"message_end"`.
+- `agents.defaults.blockStreamingChunk`: `{ minChars, maxChars, breakPreference? }`.
+- `agents.defaults.blockStreamingCoalesce`: `{ minChars?, maxChars?, idleMs? }` (mescla blocos streamed antes de enviar).
+- Cap rígido de canal: `*.textChunkLimit` (por ex., `channels.whatsapp.textChunkLimit`).
+- Modo chunk de canal: `*.chunkMode` (`length` padrão, `newline` divide em linhas em branco (limites de parágrafo) antes de chunking de comprimento).
+- Cap suave Discord: `channels.discord.maxLinesPerMessage` (padrão 17) divide replies altas para evitar clipping de UI.
+
+**Semântica de limite:**
+
+- `text_end`: faz stream de blocos assim que chunker emite; flushes em cada `text_end`.
+- `message_end`: espera até que mensagem do assistente termine, depois flushes saída bufferizada.
+
+`message_end` ainda usa o chunker se o texto bufferizado exceder `maxChars`, então pode emitir múltiplos chunks no final.
+
+## Algoritmo de chunking (limites baixo/alto)
+
+Block chunking é implementado por `EmbeddedBlockChunker`:
+
+- **Limite baixo:** não emite até buffer >= `minChars` (a menos que forçado).
+- **Limite alto:** prefere splits antes de `maxChars`; se forçado, split em `maxChars`.
+- **Preferência de break:** `paragraph` → `newline` → `sentence` → `whitespace` → hard break.
+- **Code fences:** nunca divide dentro de fences; quando forçado em `maxChars`, fecha + reabre a fence para manter Markdown válido.
+
+`maxChars` é clamped para o canal `textChunkLimit`, então você não pode exceder caps por canal.
+
+## Coalescing (mescla blocos streamed)
+
+Quando block streaming está habilitado, OpenClaw pode **mesclar chunks de bloco consecutivos** antes de enviá-los. Isso reduz "single-line spam" enquanto ainda fornece saída progressiva.
+
+- Coalescing espera por **idle gaps** (`idleMs`) antes de flushes.
+- Buffers são capped por `maxChars` e flushes se excederem.
+- `minChars` previne fragmentos minúsculos de enviar até texto suficiente acumular (final flush sempre envia texto restante).
+- Joiner é derivado de `blockStreamingChunk.breakPreference` (`paragraph` → `\n\n`, `newline` → `\n`, `sentence` → space).
+- Substituições de canal estão disponíveis via `*.blockStreamingCoalesce` (incluindo configs por conta).
+- Padrão coalesce `minChars` é bumped para 1500 para Signal/Slack/Discord a menos que sobrescrito.
+
+## Pacing humano entre blocos
+
+Quando block streaming está habilitado, você pode adicionar uma **pausa aleatorizada** entre block replies (após o primeiro bloco). Isso faz respostas multi-bubble parecerem mais naturais.
+
+- Config: `agents.defaults.humanDelay` (sobrescrever por agente via `agents.list[].humanDelay`).
+- Modos: `off` (padrão), `natural` (800–2500ms), `custom` (`minMs`/`maxMs`).
+- Se aplica apenas a **block replies**, não respostas finais ou resumos de ferramenta.
+
+## "Stream chunks ou tudo"
+
+Isto mapeia para:
+
+- **Stream chunks:** `blockStreamingDefault: "on"` + `blockStreamingBreak: "text_end"` (emite conforme vai). Canais não-Telegram também precisam de `*.blockStreaming: true`.
+- **Stream tudo no final:** `blockStreamingBreak: "message_end"` (flushes uma vez, possivelmente múltiplos chunks se muito longo).
+- **Sem block streaming:** `blockStreamingDefault: "off"` (apenas resposta final).
+
+**Nota de canal:** Para canais não-Telegram, block streaming está **desabilitado a menos que** `*.blockStreaming` seja explicitamente definido como `true`. Telegram pode fazer stream de uma preview ao vivo (`channels.telegram.streamMode`) sem block replies.
+
+Lembrete de localização de config: os padrões `blockStreaming*` vivem sob `agents.defaults`, não a config raiz.
+
+## Telegram preview streaming (token-ish)
+
+Telegram é o único canal com live preview streaming:
+
+- Usa Bot API `sendMessage` (primeira atualização) + `editMessageText` (atualizações subsequentes).
+- `channels.telegram.streamMode: "partial" | "block" | "off"`.
+  - `partial`: preview atualiza com o texto de stream mais recente.
+  - `block`: preview atualiza em blocos chunked (mesmas regras de chunker).
+  - `off`: sem preview streaming.
+- Config de chunk de preview (apenas para `streamMode: "block"`): `channels.telegram.draftChunk` (padrões: `minChars: 200`, `maxChars: 800`).
+- Preview streaming é separado de block streaming.
+- Quando Telegram block streaming está explicitamente habilitado, preview streaming é ignorado para evitar double-streaming.
+- Finais text-only são aplicados editando a mensagem de preview in place.
+- Finais non-text/complex caem de volta para normal de delivery de mensagem final.
+- `/reasoning stream` escreve raciocínio na preview ao vivo (apenas Telegram).
+
+```
+Telegram
+  └─ sendMessage (mensagem de preview temporária)
+       ├─ streamMode=partial → edita texto mais recente
+       └─ streamMode=block   → chunker + edita atualizações
+  └─ resposta final text-only → edit final na mesma mensagem
+  └─ fallback: cleanup preview + normal final delivery (media/complex)
+```
+
+Legenda:
+
+- `preview message`: mensagem Telegram temporária atualizada durante geração.
+- `final edit`: edição in-place na mesma mensagem de preview (text-only).

--- a/docs/pt-BR/concepts/system-prompt.md
+++ b/docs/pt-BR/concepts/system-prompt.md
@@ -1,0 +1,64 @@
+---
+summary: "O que o system prompt OpenClaw contém e como é montado"
+read_when:
+  - Editando texto de system prompt, lista de ferramentas ou seções de tempo/heartbeat
+  - Mudando comportamento de injeção de bootstrap workspace ou skills
+title: "System Prompt"
+---
+
+# System Prompt
+
+OpenClaw constrói um system prompt customizado para cada execução de agente. O prompt é **propriedade do OpenClaw** e não usa o prompt padrão do pi-coding-agent.
+
+O prompt é montado pelo OpenClaw e injetado em cada execução de agente.
+
+## Estrutura
+
+O prompt é intencionalmente compacto e usa seções fixas:
+
+- **Tooling**: lista de ferramentas atual + descrições curtas.
+- **Safety**: lembrança de guardrail curta para evitar comportamento de power-seeking ou bypass de oversight.
+- **Skills** (quando disponível): diz ao modelo como carregar instruções de skill sob demanda.
+- **OpenClaw Self-Update**: como executar `config.apply` e `update.run`.
+- **Workspace**: diretório de trabalho (`agents.defaults.workspace`).
+- **Documentation**: caminho local para docs do OpenClaw (repo ou pacote npm) e quando lê-los.
+- **Workspace Files (injetados)**: indica arquivos de bootstrap estão incluídos abaixo.
+- **Sandbox** (quando habilitado): indica runtime sandboxado, caminhos sandbox e se elevated exec está disponível.
+- **Current Date & Time**: hora local do usuário, timezone e formato de hora.
+- **Reply Tags**: sintaxe opcional de reply tag para provedores suportados.
+- **Heartbeats**: prompt de heartbeat e comportamento de ack.
+- **Runtime**: host, OS, node, model, repo root (quando detectado), thinking level (uma linha).
+- **Reasoning**: nível de visibilidade atual + dica toggle /reasoning.
+
+Guardrails de segurança no system prompt são avisivos. Eles guiam comportamento do modelo mas não aplicam política. Use política de ferramentas, aprovações de exec, sandboxing e allowlists de canal para aplicação rígida; operadores podem desabilitar estes por design.
+
+## Modos de prompt
+
+OpenClaw pode renderizar system prompts menores para sub-agentes. O runtime define um `promptMode` para cada execução (não uma config de um usuário):
+
+- `full` (padrão): inclui todas as seções acima.
+- `minimal`: usado para sub-agentes; omite **Skills**, **Memory Recall**, **OpenClaw Self-Update**, **Model Aliases**, **User Identity**, **Reply Tags**, **Messaging**, **Silent Replies** e **Heartbeats**. Tooling, **Safety**, Workspace, Sandbox, Current Date & Time (quando conhecido), Runtime e contexto injetado permanecem disponíveis.
+- `none`: retorna apenas a linha de identidade base.
+
+Quando `promptMode=minimal`, prompts injetados extras são rotulados **Subagent Context** em vez de **Group Chat Context**.
+
+## Injeção de bootstrap de workspace
+
+Arquivos de bootstrap são cortados e anexados sob **Project Context** para que o modelo veja contexto de identidade e perfil sem precisar de leituras explícitas:
+
+- `AGENTS.md`
+- `SOUL.md`
+- `TOOLS.md`
+- `IDENTITY.md`
+- `USER.md`
+- `HEARTBEAT.md`
+- `BOOTSTRAP.md` (apenas em workspaces novíssimos)
+- `MEMORY.md` e/ou `memory.md` (quando presentes no workspace; um ou ambos podem ser injetados)
+
+Todos esses arquivos estão **injetados na janela de contexto** a cada volta, o que significa que consomem tokens. Mantenha-os concisos — especialmente `MEMORY.md`, que pode crescer ao longo do tempo e levar a uso de contexto inesperadamente alto e compactação mais frequente.
+
+> **Nota:** arquivos diários `memory/*.md` são **não** injetados automaticamente. Eles são acessados sob demanda via ferramentas `memory_search` e `memory_get`, então não contam contra a janela de contexto a menos que o modelo os leia explicitamente.
+
+Arquivos grandes são truncados com um marcador. O tamanho máximo por arquivo é controlado por `agents.defaults.bootstrapMaxChars` (padrão: 20000). Conteúdo de bootstrap injetado total entre arquivos é capped por `agents.defaults.bootstrapTotalMaxChars` (padrão: 150000). Arquivos faltando injetam um marcador curto de arquivo faltando.
+
+Sessões de sub-agent apenas injetam `AGENTS.md` e `TOOLS.md` (outros arquivos de bootstrap são filtrados para manter o contexto de sub-agent pequeno).

--- a/docs/pt-BR/concepts/timezone.md
+++ b/docs/pt-BR/concepts/timezone.md
@@ -1,0 +1,81 @@
+---
+summary: "Tratamento de timezone para agentes, envelopes e prompts"
+read_when:
+  - Você precisa entender como timestamps são normalizados para o modelo
+  - Configurando o timezone do usuário para system prompts
+title: "Timezones"
+---
+
+# Timezones
+
+OpenClaw padroniza timestamps para que o modelo veja um **tempo de referência único**.
+
+## Envelopes de mensagem (local por padrão)
+
+Mensagens de entrada são envoltas em um envelope como:
+
+```
+[Provider ... 2026-01-05 16:26 PST] message text
+```
+
+O timestamp no envelope é **host-local por padrão**, com precisão de minutos.
+
+Você pode sobrescrever com:
+
+```json5
+{
+  agents: {
+    defaults: {
+      envelopeTimezone: "local", // "utc" | "local" | "user" | IANA timezone
+      envelopeTimestamp: "on", // "on" | "off"
+      envelopeElapsed: "on", // "on" | "off"
+    },
+  },
+}
+```
+
+- `envelopeTimezone: "utc"` usa UTC.
+- `envelopeTimezone: "user"` usa `agents.defaults.userTimezone` (volta para timezone de host).
+- Use um timezone IANA explícito (ex. `"Europe/Vienna"`) para um offset fixo.
+- `envelopeTimestamp: "off"` remove timestamps absolutos de headers de envelope.
+- `envelopeElapsed: "off"` remove sufixos de tempo decorrido (o estilo `+2m`).
+
+### Exemplos
+
+**Local (padrão):**
+
+```
+[Signal Alice +1555 2026-01-18 00:19 PST] hello
+```
+
+**Timezone fixo:**
+
+```
+[Signal Alice +1555 2026-01-18 06:19 GMT+1] hello
+```
+
+**Tempo decorrido:**
+
+```
+[Signal Alice +1555 +2m 2026-01-18T05:19Z] follow-up
+```
+
+## Payloads de ferramenta (dados brutos de provedor + campos normalizados)
+
+Chamadas de ferramenta (`channels.discord.readMessages`, `channels.slack.readMessages`, etc.) retornam **timestamps brutos de provedor**.
+Também anexamos campos normalizados para consistência:
+
+- `timestampMs` (UTC epoch milliseconds)
+- `timestampUtc` (string ISO 8601 UTC)
+
+Campos brutos de provedor são preservados.
+
+## Timezone do usuário para o system prompt
+
+Defina `agents.defaults.userTimezone` para dizer ao modelo o fuso horário local do usuário. Se não definido, OpenClaw resolve o **timezone de host em tempo de execução** (sem escrita de config).
+
+```json5
+{
+  agents: { defaults: { userTimezone: "America/Chicago" } },
+}
+```

--- a/docs/pt-BR/concepts/typebox.md
+++ b/docs/pt-BR/concepts/typebox.md
@@ -1,0 +1,72 @@
+---
+summary: "Esquemas TypeBox como a única fonte de verdade para o protocolo do gateway"
+read_when:
+  - Atualizando esquemas de protocolo ou codegen
+title: "TypeBox"
+---
+
+# TypeBox como fonte de verdade de protocolo
+
+Última atualização: 2026-01-10
+
+TypeBox é uma biblioteca de schema TypeScript-first. Nós a usamos para definir o **protocolo WebSocket do Gateway** (handshake, request/response, eventos de servidor). Esses schemas impulsionam **validação de runtime**, **exportação de JSON Schema** e **codegen Swift** para o app macOS. Uma fonte de verdade; tudo mais é gerado.
+
+Se você quer contexto de protocolo de nível mais alto, comece com [Arquitetura do Gateway](/pt-BR/concepts/architecture).
+
+## Modelo mental (30 segundos)
+
+Cada mensagem de WS do Gateway é uma das três frames:
+
+- **Request**: `{ type: "req", id, method, params }`
+- **Response**: `{ type: "res", id, ok, payload | error }`
+- **Event**: `{ type: "event", event, payload, seq?, stateVersion? }`
+
+A primeira frame **deve** ser uma requisição `connect`. Depois disso, clientes podem chamar métodos (ex. `health`, `send`, `chat.send`) e se inscrever em eventos (ex. `presence`, `tick`, `agent`).
+
+Fluxo de conexão (mínimo):
+
+```
+Client                    Gateway
+  |---- req:connect -------->|
+  |<---- res:hello-ok --------|
+  |<---- event:tick ----------|
+  |---- req:health ---------->|
+  |<---- res:health ----------|
+```
+
+Métodos e eventos comuns:
+
+| Categoria | Exemplos                                                  | Notas                                     |
+| --------- | --------------------------------------------------------- | ----------------------------------------- |
+| Core      | `connect`, `health`, `status`                             | `connect` deve ser primeiro               |
+| Messaging | `send`, `poll`, `agent`, `agent.wait`                     | side-effects precisam de `idempotencyKey` |
+| Chat      | `chat.history`, `chat.send`, `chat.abort`, `chat.inject`  | WebChat usa estes                         |
+| Sessions  | `sessions.list`, `sessions.patch`, `sessions.delete`      | admin de sessão                           |
+| Nodes     | `node.list`, `node.invoke`, `node.pair.*`                 | Gateway WS + ações de nó                  |
+| Events    | `tick`, `presence`, `agent`, `chat`, `health`, `shutdown` | server push                               |
+
+A lista autoritária vive em `src/gateway/server.ts` (`METHODS`, `EVENTS`).
+
+## Onde os schemas vivem
+
+- Source: `src/gateway/protocol/schema.ts`
+- Validadores de runtime (AJV): `src/gateway/protocol/index.ts`
+- Handshake de servidor + dispatch de método: `src/gateway/server.ts`
+- Cliente de nó: `src/gateway/client.ts`
+- JSON Schema gerado: `dist/protocol.schema.json`
+- Modelos Swift gerados: `apps/macos/Sources/OpenClawProtocol/GatewayModels.swift`
+
+## Pipeline atual
+
+- `pnpm protocol:gen`
+  - escreve JSON Schema (draft-07) para `dist/protocol.schema.json`
+- `pnpm protocol:gen:swift`
+  - gera modelos gateway Swift
+- `pnpm protocol:check`
+  - executa ambos os geradores e verifica se a saída é committed
+
+## Como os schemas são usados em tempo de execução
+
+- **Lado do servidor**: cada frame de entrada é validado com AJV. O handshake apenas aceita uma requisição `connect` cujos params correspondem a `ConnectParams`.
+- **Lado do cliente**: o cliente JS valida frames de evento e resposta antes de usá-los.
+- **Superfície de método**: o Gateway anuncia os `methods` suportados.

--- a/docs/pt-BR/concepts/typing-indicators.md
+++ b/docs/pt-BR/concepts/typing-indicators.md
@@ -1,0 +1,60 @@
+---
+summary: "Quando OpenClaw mostra indicadores de digitação e como ajustá-los"
+read_when:
+  - Alterando comportamento ou padrões de indicadores de digitação
+title: "Indicadores de Digitação"
+---
+
+# Indicadores de digitação
+
+Indicadores de digitação são enviados para o canal de chat enquanto uma execução está ativa. Use `agents.defaults.typingMode` para controlar **quando** a digitação começa e `typingIntervalSeconds` para controlar **com que frequência** ela se atualiza.
+
+## Padrões
+
+Quando `agents.defaults.typingMode` **não é definido**, OpenClaw mantém o comportamento legado:
+
+- **Chats diretos**: digitação começa imediatamente assim que o loop do modelo começa.
+- **Chats em grupo com uma menção**: digitação começa imediatamente.
+- **Chats em grupo sem uma menção**: digitação começa apenas quando o texto da mensagem começa a fazer streaming.
+- **Execuções de heartbeat**: digitação é desativada.
+
+## Modos
+
+Defina `agents.defaults.typingMode` para um dos:
+
+- `never` — nenhum indicador de digitação, nunca.
+- `instant` — comece a digitação **assim que o loop do modelo começa**, mesmo que a execução posteriormente retorne apenas o token de resposta silenciosa.
+- `thinking` — comece a digitação no **primeiro delta de raciocínio** (requer `reasoningLevel: "stream"` para a execução).
+- `message` — comece a digitação no **primeiro delta de texto não-silencioso** (ignora o token silencioso `NO_REPLY`).
+
+Ordem de "quão cedo dispara":
+`never` → `message` → `thinking` → `instant`
+
+## Configuração
+
+```json5
+{
+  agent: {
+    typingMode: "thinking",
+    typingIntervalSeconds: 6,
+  },
+}
+```
+
+Você pode sobrescrever modo ou cadência por sessão:
+
+```json5
+{
+  session: {
+    typingMode: "message",
+    typingIntervalSeconds: 4,
+  },
+}
+```
+
+## Notas
+
+- O modo `message` não mostrará digitação para respostas apenas-silenciosas (ex. o token `NO_REPLY` usado para suprimir saída).
+- `thinking` apenas dispara se a execução faz streaming de raciocínio (`reasoningLevel: "stream"`). Se o modelo não emitir deltas de raciocínio, a digitação não começará.
+- Heartbeats nunca mostram digitação, independentemente do modo.
+- `typingIntervalSeconds` controla a **cadência de atualização**, não o tempo de início. O padrão é 6 segundos.

--- a/docs/pt-BR/concepts/usage-tracking.md
+++ b/docs/pt-BR/concepts/usage-tracking.md
@@ -1,0 +1,35 @@
+---
+summary: "Superfícies de rastreamento de uso e requisitos de credenciais"
+read_when:
+  - Você está conectando superfícies de uso/cota do provedor
+  - Você precisa explicar comportamento de rastreamento de uso ou requisitos de auth
+title: "Rastreamento de Uso"
+---
+
+# Rastreamento de uso
+
+## O que é
+
+- Puxa uso/cota do provedor diretamente de seus endpoints de uso.
+- Sem custos estimados; apenas as janelas relatadas pelo provedor.
+
+## Onde isso aparece
+
+- `/status` em chats: card de status rico em emoji com tokens de sessão + custo estimado (apenas chave de API). O uso do provedor mostra para o **provedor de modelo atual** quando disponível.
+- `/usage off|tokens|full` em chats: rodapé de uso por resposta (OAuth mostra apenas tokens).
+- `/usage cost` em chats: resumo de custo local agregado dos logs de sessão OpenClaw.
+- CLI: `openclaw status --usage` imprime um resumo completo por provedor.
+- CLI: `openclaw channels list` imprime o mesmo snapshot de uso ao lado da config do provedor (use `--no-usage` para pular).
+- Menu de barra macOS: seção "Usage" sob Context (apenas se disponível).
+
+## Provedores + credenciais
+
+- **Anthropic (Claude)**: Tokens OAuth em perfis de auth.
+- **GitHub Copilot**: Tokens OAuth em perfis de auth.
+- **Gemini CLI**: Tokens OAuth em perfis de auth.
+- **Antigravity**: Tokens OAuth em perfis de auth.
+- **OpenAI Codex**: Tokens OAuth em perfis de auth (accountId usado quando presente).
+- **MiniMax**: Chave de API (chave do plano de codificação; `MINIMAX_CODE_PLAN_KEY` ou `MINIMAX_API_KEY`); usa a janela do plano de codificação de 5 horas.
+- **z.ai**: Chave de API via env/config/auth store.
+
+O uso fica oculto se não existirem credenciais OAuth/API correspondentes.


### PR DESCRIPTION
## Summary                                   
                             
  - **Problem:** Brazilian Portuguese speakers lack localized documentation for OpenClaw   
  concepts
  - **Why it matters:** PT-BR is one of the top 5 languages globally; localized docs       
  improve accessibility and adoption in Brazil/Portugal                                  
  - **What changed:** Added complete PT-BR translation of all concept docs (30 files) +  
  glossary, fixed broken links to point to English fallbacks for untranslated sections
  - **What did NOT change:** No code changes, no config changes, English docs remain
  unchanged

  ## Change Type

  - [ ] Bug fix
  - [ ] Feature
  - [ ] Refactor
  - [x] Docs
  - [ ] Security hardening
  - [ ] Chore/infra

  ## Scope

  - [ ] Gateway / orchestration
  - [ ] Skills / tool execution
  - [ ] Auth / tokens
  - [ ] Memory / storage
  - [ ] Integrations
  - [ ] API / contracts
  - [x] UI / DX
  - [ ] CI/CD / infra

  ## Linked Issue/PR

  - Related to localization effort
  - Follows existing zh-CN translation pattern

  ## User-visible / Behavior Changes

  **User-visible changes:**
  - PT-BR documentation now available at `/pt-BR/concepts/*`
  - Navigation will show Portuguese translations for concept pages
  - Links in PT-BR docs fallback to English for untranslated sections

  **No behavior changes** to gateway, runtime, or functionality.

  ## Security Impact

  - New permissions/capabilities? `No`
  - Secrets/tokens handling changed? `No`
  - New/changed network calls? `No`
  - Command/tool execution surface changed? `No`
  - Data access scope changed? `No`

  ## Repro + Verification

  ### Environment

  - OS: macOS
  - Runtime: Node.js 22.x
  - Verification: Documentation build + link checker

  ### Steps

  1. Run `npm run check:docs`
  2. Verify formatting passes: `pnpm format:docs:check`
  3. Verify linting passes: `pnpm lint:docs`
  4. Verify no broken links: `pnpm docs:check-links`

  ### Expected

  - All docs checks pass
  - 0 broken links (checked 2835 links)
  - All 30 PT-BR concept files formatted correctly

  ### Actual

  ✅ Formatting: All matched files use the correct format
  ✅ Linting: 0 error(s)
  ✅ Link checking: broken_links=0


  ## Evidence

  - [x] Passing test/log: All `check:docs` tests pass
  - [x] Trace/log snippets: CI output shows 0 broken links (was 25 before fix)
  - [ ] Screenshot/recording
  - [ ] Perf numbers (not relevant)

  ## Human Verification

  **Verified scenarios:**
  - All 30 concept docs render correctly in Markdown
  - Internal links within PT-BR concepts work correctly
  - Fallback links to English sections work correctly
  - Glossary file present and properly formatted

  **Edge cases checked:**
  - Links with anchors (e.g., `#plugin-hooks`) preserved
  - Multi-word paths work correctly
  - Mixed PT-BR and English link references work

  **What I did NOT verify:**
  - Actual rendering in Mint docs framework (requires full docs build)
  - Translation accuracy/quality (needs native speaker review)

  ## Compatibility / Migration

  - Backward compatible? `Yes`
  - Config/env changes? `No`
  - Migration needed? `No`

  No migration needed. Purely additive documentation.

  ## Failure Recovery

  **How to disable/revert:**
  ```bash
  git revert <this-commit>
  # Or delete PT-BR files:
  rm -rf docs/pt-BR/
  git checkout docs/.i18n/glossary.pt-BR.json


  Files to restore: docs/pt-BR/* and docs/.i18n/glossary.pt-BR.json

  Known bad symptoms: None expected (docs-only change)

  Risks and Mitigations

  - Risk: Translation quality issues or outdated content as English docs evolve
    - Mitigation: Follow existing zh-CN pattern for maintaining translations; community can
   report issues; link checker prevents broken references
  - Risk: Link checker might flag valid PT-BR internal links as broken if new PT-BR pages
  added without updating refs
    - Mitigation: CI runs docs:check-links on every docs change; will catch issues
  immediately

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added comprehensive Portuguese (PT-BR) translations for all OpenClaw concept documentation (29 files total). The translation covers core agent concepts, memory management, sessions, models, and other foundational topics. Links properly reference PT-BR paths for translated content and fall back to English paths for untranslated sections.

Key changes:
- Added `glossary.pt-BR.json` with 1,058 translation entries covering technical terms, product names, and common phrases
- Translated 28 concept documentation files from English to Portuguese
- Maintained consistent link structure using `/pt-BR/concepts/` prefix for translated pages
- Preserved technical accuracy and formatting (code blocks, YAML frontmatter, markdown syntax)
- Followed existing localization pattern established by `zh-CN` translations

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it only adds documentation translations without changing any code or configuration
- Score reflects that this is a purely additive documentation change with no code modifications, no configuration changes, and no runtime behavior changes. The PR author verified all docs checks pass (formatting, linting, link checking with 0 broken links). The translations follow the established zh-CN pattern and properly handle link references.
- No files require special attention - all changes are straightforward documentation translations

<sub>Last reviewed commit: 0927aea</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->