### PR TITLE
feat: add pr-dedup skill for duplicate PR detection and quality ranking

### DIFF
--- a/skills/pr-dedup/SKILL.md
+++ b/skills/pr-dedup/SKILL.md
@@ -1,14 +1,7 @@
 ---
 name: pr-dedup
 description: Incremental GitHub PR+Issue dedup with quality ranking, vision alignment checks, deep diff review, and cache-backed cron operation using only `gh` + native agent reasoning.
-metadata:
-  {
-    "openclaw":
-      {
-        "emoji": "🧹",
-        "requires": { "bins": ["gh"] },
-      },
-  }
+metadata: { "openclaw": { "emoji": "🧹", "requires": { "bins": ["gh"] } } }
 ---
 
 # PR + Issue Dedup (Incremental, Cache-Backed, Cron-First)
@@ -16,6 +9,7 @@ metadata:
 Use this skill when you need to continuously detect duplicate work across **pull requests and issues**, pick canonical threads, and keep repositories clean at scale.
 
 This skill is designed for:
+
 - high-volume repos
 - autonomous agent + human overlap
 - incremental cron runs (every ~15 minutes)
@@ -71,6 +65,7 @@ Example:
 ### Minimum item fields (required by spec)
 
 Store all scanned items with at least:
+
 - `number`
 - `title`
 - `files` (empty array for issues unless inferred/linked)
@@ -157,6 +152,7 @@ Recommended extended schema:
 Build initial cache in batches of 100.
 
 Collect:
+
 - all open PRs
 - all open issues
 - merged/closed PRs and issues updated in last `LOOKBACK_DAYS`
@@ -188,6 +184,7 @@ If result volumes exceed 100, process in additional 100-item batches (adjust sea
 ## B) Incremental run (every ~15 min, primary)
 
 Read cache and compute:
+
 - `SINCE = last_incremental_scan`
 
 Fetch only updates:
@@ -201,6 +198,7 @@ gh issue list --repo owner/repo --state all --search "updated:>=${SINCE}" --limi
 ```
 
 Then:
+
 1. Upsert changed items into cache.
 2. Recompute clusters only for touched items + related cached neighbors.
 3. Skip untouched clusters.
@@ -251,6 +249,7 @@ gh issue view <N> --repo owner/repo --json number,title,body,labels,state,create
 ```
 
 Also infer linked PRs from:
+
 - issue timeline (optional, when needed):
   ```bash
   gh api repos/owner/repo/issues/<N>/timeline
@@ -273,6 +272,7 @@ Cluster candidates using weighted signals:
 6. **Branch naming similarity** (PR-only)
 
 Confidence buckets:
+
 - `high`
 - `medium`
 - `low`
@@ -304,6 +304,7 @@ If you agree, we should consolidate discussion there.
 ## 4) Vision / Roadmap Alignment
 
 Try root docs in this order:
+
 1. `VISION.md`
 2. `ROADMAP.md`
 3. `CONTRIBUTING.md`
@@ -323,11 +324,13 @@ gh api repos/owner/repo/contents/CONTRIBUTING.md --jq .content | base64 --decode
 If none exist, skip vision scoring and note it.
 
 For each PR/issue, score `vision_alignment` (0-100):
+
 - Does it support stated goals?
 - Is it the right priority tier?
 - Is scope consistent with roadmap constraints?
 
 If clearly misaligned:
+
 - add `out-of-scope` label
 - leave explanation comment
 
@@ -349,6 +352,7 @@ Recommend moving this to a separate proposal/discussion thread.
 Do not rely on metadata alone. For candidate PRs, analyze actual diff content (`gh pr diff`).
 
 Evaluate and score:
+
 - `correctness_risk` (0 low risk → 100 high risk)
 - `test_adequacy` (0 poor → 100 strong)
 - `scope_creep` (0 tight → 100 sprawling)
@@ -356,6 +360,7 @@ Evaluate and score:
 - `quality` (overall 0-100)
 
 Signals to inspect in diffs:
+
 - architectural consistency
 - error handling and edge cases
 - API contract changes and migration risk
@@ -372,6 +377,7 @@ Use native reasoning and explain scores briefly, with concrete evidence.
 Within each duplicate cluster, rank PRs/issues and select canonical thread.
 
 Suggested weighted output:
+
 - CI health
 - review outcomes
 - deep diff risk profile
@@ -382,6 +388,7 @@ Suggested weighted output:
 - vision alignment
 
 Return concise per-item summary:
+
 - strengths
 - blockers
 - why canonical or why duplicate-candidate
@@ -401,6 +408,7 @@ gh pr close <dup_pr> --repo owner/repo --comment "Closing as stale duplicate: is
 Also update cache status to `stale-duplicate-closed`.
 
 Safety rule:
+
 - Auto-close only when confidence is high and merged canonical clearly resolves the same issue.
 - Otherwise, comment + label and escalate for human confirmation.
 
@@ -467,6 +475,7 @@ Every 15 minutes:
 8. Emit concise run summary.
 
 If cache file is missing/corrupt:
+
 - rebuild bootstrap cache
 - continue incremental cadence on next run
 

--- a/skills/pr-dedup/SKILL.md
+++ b/skills/pr-dedup/SKILL.md
@@ -1,0 +1,233 @@
+---
+name: pr-dedup
+description: Detect likely duplicate GitHub pull requests and rank competing PRs by quality signals (CI, approvals, scope, tests, freshness, and bot reviews) using only the `gh` CLI. Use when asked to scan one or more repos for duplicate PR work, choose a preferred PR, label/comment/close weaker duplicates, or produce a daily duplicate-and-quality leaderboard report.
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🧹",
+        "requires": { "bins": ["gh"] },
+      },
+  }
+---
+
+# PR Dedup + Quality Rank (GitHub)
+
+Use this skill to find duplicate open PRs, pick the strongest candidate in each duplicate cluster, and optionally take action (comment, label, close, and publish a leaderboard summary).
+
+## Core operating rules
+
+- Use only `gh` commands for GitHub interaction (`gh pr list`, `gh pr view`, `gh pr diff`, `gh api`, `gh pr comment`, `gh pr edit`, `gh pr close`, `gh issue create`, `gh issue comment`).
+- Prefer `--json` / `--jq` outputs over parsing raw text.
+- Default to **analysis + report first**. Ask for confirmation before state-changing actions (label/comment/close/create issue) unless the user explicitly requested auto-apply.
+- Always pass `--repo owner/repo` unless already in the target repository.
+- For multi-repo runs, iterate repos and produce a per-repo section plus a global summary.
+
+## 1) Authenticate and collect targets
+
+Check auth once:
+
+```bash
+gh auth status
+```
+
+Target repos can come from user text (e.g. `owner/repo owner2/repo2`) or current git remote.
+
+For each repo, collect open PR basics:
+
+```bash
+gh pr list \
+  --repo owner/repo \
+  --state open \
+  --limit 200 \
+  --json number,title,headRefName,author,body,createdAt,updatedAt,isDraft,additions,deletions,changedFiles,url
+```
+
+If fewer than 2 open PRs, report and skip dedup logic for that repo.
+
+## 2) Pull enrichment for each PR
+
+For each PR number `N` in each repo, gather:
+
+### Files changed
+
+```bash
+gh pr diff N --repo owner/repo --name-only
+```
+
+### Reviews/approvals
+
+```bash
+gh pr view N --repo owner/repo --json reviews
+```
+
+Count approvals and change requests from `reviews[].state`.
+
+### CI/check status
+
+```bash
+gh pr checks N --repo owner/repo
+```
+
+Use this to classify: passing / failing / pending / no-checks.
+
+### Linked issues / references (body + commits)
+
+Use PR body and title references (`#123`, `owner/repo#123`, `fixes #123`, etc.) from `gh pr list --json body,title`.
+Optionally inspect timeline cross-references:
+
+```bash
+gh api repos/owner/repo/issues/N/timeline
+```
+
+(Use only when needed; timeline can be noisy.)
+
+### Bot review signals
+
+From reviews data, detect bot actors (`login` ending in `[bot]`) and classify:
+- bot requested changes
+- bot warning/nit style comments
+- bot approval/neutral
+
+## 3) Duplicate detection heuristics
+
+Build pairwise comparisons of open PRs in the same repo. Create a duplicate confidence bucket: **high**, **medium**, **low**, **none**.
+
+### Signal A: file overlap (strongest)
+
+Compute overlap from `gh pr diff --name-only` file sets.
+- High overlap: substantial intersection (especially same core files)
+- Medium overlap: partial overlap with same feature area
+- Low overlap: little overlap
+
+### Signal B: issue-reference overlap
+
+If two PRs reference same issue(s), increase duplicate confidence.
+
+### Signal C: title/body semantic similarity
+
+Use native model reasoning over title/body intent:
+- same bug/feature phrasing
+- same acceptance criteria or scope
+- same error strings/feature names
+
+### Signal D: branch name similarity
+
+Compare `headRefName` patterns (e.g., `fix/login-timeout`, `bugfix/login-timeout-v2`).
+
+### Signal E: author/context
+
+Different authors tackling same issue concurrently can still be duplicates; do not down-rank solely by author.
+
+### Decision rule
+
+Mark as likely duplicate cluster when:
+- Signal A is high, or
+- Signal B matches and either Signal C or D is medium/high, or
+- Signal C + D are both high even with partial file overlap.
+
+Provide a short rationale per cluster (2-4 bullets).
+
+## 4) Quality scoring for ranked winner selection
+
+Within each duplicate cluster, score each PR 0-100 and choose a preferred PR.
+
+Suggested rubric (tune per repo norms):
+
+- **CI health (0-25):** passing full checks highest; failing checks penalized heavily.
+- **Review quality (0-20):** approvals and constructive review outcomes.
+- **Scope efficiency (0-15):** fewer, focused changes favored over excessively broad diffs.
+- **Test evidence (0-15):** test files added/updated (`test`, `spec`, `__tests__`, etc.) or explicit test notes.
+- **Freshness (0-15):** recently updated PRs with active iteration favored over stale PRs.
+- **Bot-review signal (0-10):** no unresolved bot-requested changes scores higher.
+
+Use `additions`, `deletions`, `changedFiles`, checks status, review states, timestamps, changed filenames, and review authors to justify each score.
+
+Output table per cluster:
+
+- PR # / URL
+- Duplicate confidence
+- Quality score
+- Key strengths
+- Risks/blockers
+- Recommended action (keep / label duplicate / close candidate)
+
+## 5) Action mode (optional, explicit)
+
+After reporting, if user requests action, apply in this order:
+
+### A) Comment on weaker duplicates
+
+```bash
+gh pr comment <pr> --repo owner/repo --body "This PR appears to overlap with #<winner>.\n\nReasoning:\n- ...\n\nRecommended next step: merge work into #<winner> or close this PR if superseded."
+```
+
+### B) Add duplicate label(s)
+
+```bash
+gh pr edit <pr> --repo owner/repo --add-label duplicate
+```
+
+If team uses a stronger label, add both (e.g. `duplicate,candidate-close`).
+
+### C) Optionally close weaker PR
+
+Only when user explicitly asks to close:
+
+```bash
+gh pr close <pr> --repo owner/repo --comment "Closing as duplicate of #<winner>. Consolidating work there."
+```
+
+Never auto-close without explicit instruction.
+
+### D) Leaderboard / summary issue
+
+Create or update a daily summary issue with ranked clusters:
+
+```bash
+gh issue create \
+  --repo owner/repo \
+  --title "PR Dedup Report - YYYY-MM-DD" \
+  --body "<markdown summary with clusters, winners, and actions>"
+```
+
+If an issue already exists for the day, append via:
+
+```bash
+gh issue comment <issue-number> --repo owner/repo --body "<updated summary>"
+```
+
+## 6) Daily summary mode (cron-friendly)
+
+When prompted with: "Run PR dedup scan on these repos: ..."
+
+1. Run read-only scan across all repos.
+2. Produce:
+   - repos scanned
+   - total open PRs
+   - duplicate clusters found
+   - recommended winners
+   - action plan (what would be labeled/commented/closed)
+3. If prompt includes auto-apply, perform actions and include an execution log.
+4. Optionally post a summary issue per repo.
+
+Recommended summary sections:
+
+- Executive summary
+- Cluster leaderboard (highest-confidence duplicates first)
+- Winner ranking by quality score
+- Actions taken (or pending approval)
+- Follow-ups for maintainers
+
+## 7) Output contract
+
+For every run, return:
+
+- Inputs: repos scanned, PR count
+- Duplicate clusters with confidence + rationale
+- Ranked PRs with quality scoring details
+- Clear winner per cluster
+- Exact actions taken (or proposed)
+- Any commands that failed + error text
+
+Keep the report concise but decision-oriented so maintainers can act immediately.


### PR DESCRIPTION
## Why
OpenClaw is getting a high volume of overlapping PR/issue work from both humans and autonomous agents. Peter asked for AI support that can dedupe this work, identify the strongest implementation, and keep maintainers focused on the right thread.

This PR expands the skill to cover that full scope with a practical, gh-only workflow.

## What this now includes

### 1) PR + Issue dedup (cross-type clustering)
- Scans open **issues and PRs together**
- Detects duplicates across:
  - issue ↔ issue
  - PR ↔ PR
  - issue ↔ PR
- Uses `gh issue list` / `gh issue view` alongside PR commands
- Compares with multiple signals:
  - title/body semantic similarity
  - labels overlap
  - referenced files/code
  - linked PR/issue graph
  - issue refs and branch similarity (for PRs)
- Comments on duplicate issues linking the canonical item
- Labels weaker issues/PRs as `duplicate-candidate`

### 2) Vision/Roadmap alignment
- Supports repo-root alignment docs with fallback order:
  1. `VISION.md`
  2. `ROADMAP.md`
  3. `CONTRIBUTING.md`
- Fetches via `gh api repos/{owner}/{repo}/contents/<file>`
- Scores each PR/issue for alignment with project direction
- Flags misaligned work with `out-of-scope`
- Adds rationale comments for maintainers

### 3) Deep diff-native review
- Goes beyond metadata and analyzes actual code changes via:
  - `gh pr diff {number}`
- Adds explicit scoring guidance for:
  - correctness risk
  - test adequacy
  - scope creep
  - complexity
  - overall quality
- Uses native agent reasoning (no external package requirements)

### 4) Scale + incremental operation
- Batching guidance at 100 items
- Date prefiltering (`updated:>=...`) with default 7-day lookback (configurable)
- Search-based prefiltering for large repos
- Incremental mode so only new/updated items are processed

### 5) Local cache (new, required for cron)
- Persists scanned items at:
  - `~/.openclaw/pr-dedup-cache/{owner}-{repo}.json`
- Cache stores scanned items with required fields:
  - number, title, files, status, score, last_checked
- Also tracks enrichment and cluster metadata
- Subsequent runs only fetch/recompute items updated since last run
- Unchanged items are skipped (no redundant re-processing)

### 6) Merged-fix stale duplicate cleanup
- Detects when a merged PR resolves issue #X
- Finds remaining open duplicate PRs tied to the same issue/cluster
- Auto-closes stale duplicates in cron mode when confidence is high
- Updates cache state for closed stale duplicates

### 7) Cron-first runbook (primary use case)
- First run: bootstrap cache
- Ongoing runs (every ~15 min): incremental updates only
- Recompute only impacted clusters (changed items + neighbors)
- Emit concise action log each run

## Implementation notes
- Skill file updated: `skills/pr-dedup/SKILL.md`
- Uses only `gh` CLI + agent reasoning
- No npm dependencies
- Maintainer-first default behavior with clear action mode instructions
