### PR TITLE
fix(gateway): remove watch-mode build/start race

### DIFF
--- a/docs/help/debugging.md
+++ b/docs/help/debugging.md
@@ -34,13 +34,13 @@ Examples:
 For fast iteration, run the gateway under the file watcher:
 
 ```bash
-pnpm gateway:watch --force
+pnpm gateway:watch
 ```
 
 This maps to:
 
 ```bash
-tsx watch src/entry.ts gateway --force
+node --watch-path src --watch-path tsconfig.json --watch-path package.json --watch-preserve-output scripts/run-node.mjs gateway --force
 ```
 
 Add any gateway CLI flags after `gateway:watch` and they will be passed through
@@ -113,13 +113,13 @@ This is the best way to see whether reasoning is arriving as plain text deltas
 Enable it via CLI:
 
 ```bash
-pnpm gateway:watch --force --raw-stream
+pnpm gateway:watch --raw-stream
 ```
 
 Optional path override:
 
 ```bash
-pnpm gateway:watch --force --raw-stream --raw-stream-path ~/.openclaw/logs/raw-stream.jsonl
+pnpm gateway:watch --raw-stream --raw-stream-path ~/.openclaw/logs/raw-stream.jsonl
 ```
 
 Equivalent env vars:

--- a/scripts/run-node.mjs
+++ b/scripts/run-node.mjs
@@ -8,7 +8,7 @@ import { pathToFileURL } from "node:url";
 const compiler = "tsdown";
 const compilerArgs = ["exec", compiler, "--no-clean"];
 
-const gitWatchedPaths = ["src", "tsconfig.json", "package.json"];
+export const runNodeWatchedPaths = ["src", "tsconfig.json", "package.json"];
 
 const statMtime = (filePath, fsImpl = fs) => {
   try {
@@ -91,7 +91,7 @@ const resolveGitHead = (deps) => {
 
 const hasDirtySourceTree = (deps) => {
   const output = runGit(
-    ["status", "--porcelain", "--untracked-files=normal", "--", ...gitWatchedPaths],
+    ["status", "--porcelain", "--untracked-files=normal", "--", ...runNodeWatchedPaths],
     deps,
   );
   if (output === null) {

--- a/scripts/watch-node.mjs
+++ b/scripts/watch-node.mjs
@@ -1,65 +1,92 @@
 #!/usr/bin/env node
-import { spawn, spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import process from "node:process";
+import { pathToFileURL } from "node:url";
+import { runNodeWatchedPaths } from "./run-node.mjs";
 
-const args = process.argv.slice(2);
-const env = { ...process.env };
-const cwd = process.cwd();
-const compiler = "tsdown";
-const watchSession = `${Date.now()}-${process.pid}`;
-env.OPENCLAW_WATCH_MODE = "1";
-env.OPENCLAW_WATCH_SESSION = watchSession;
-if (args.length > 0) {
-  env.OPENCLAW_WATCH_COMMAND = args.join(" ");
+const WATCH_NODE_RUNNER = "scripts/run-node.mjs";
+
+const buildWatchArgs = (args) => [
+  ...runNodeWatchedPaths.flatMap((watchPath) => ["--watch-path", watchPath]),
+  "--watch-preserve-output",
+  WATCH_NODE_RUNNER,
+  ...args,
+];
+
+export async function runWatchMain(params = {}) {
+  const deps = {
+    spawn: params.spawn ?? spawn,
+    process: params.process ?? process,
+    cwd: params.cwd ?? process.cwd(),
+    args: params.args ?? process.argv.slice(2),
+    env: params.env ? { ...params.env } : { ...process.env },
+    now: params.now ?? Date.now,
+  };
+
+  const childEnv = { ...deps.env };
+  const watchSession = `${deps.now()}-${deps.process.pid}`;
+  childEnv.OPENCLAW_WATCH_MODE = "1";
+  childEnv.OPENCLAW_WATCH_SESSION = watchSession;
+  if (deps.args.length > 0) {
+    childEnv.OPENCLAW_WATCH_COMMAND = deps.args.join(" ");
+  }
+
+  const watchProcess = deps.spawn(deps.process.execPath, buildWatchArgs(deps.args), {
+    cwd: deps.cwd,
+    env: childEnv,
+    stdio: "inherit",
+  });
+
+  let settled = false;
+  let onSigInt;
+  let onSigTerm;
+
+  const settle = (resolve, code) => {
+    if (settled) {
+      return;
+    }
+    settled = true;
+    if (onSigInt) {
+      deps.process.off("SIGINT", onSigInt);
+    }
+    if (onSigTerm) {
+      deps.process.off("SIGTERM", onSigTerm);
+    }
+    resolve(code);
+  };
+
+  return await new Promise((resolve) => {
+    onSigInt = () => {
+      if (typeof watchProcess.kill === "function") {
+        watchProcess.kill("SIGTERM");
+      }
+      settle(resolve, 130);
+    };
+    onSigTerm = () => {
+      if (typeof watchProcess.kill === "function") {
+        watchProcess.kill("SIGTERM");
+      }
+      settle(resolve, 143);
+    };
+
+    deps.process.on("SIGINT", onSigInt);
+    deps.process.on("SIGTERM", onSigTerm);
+
+    watchProcess.on("exit", (code, signal) => {
+      if (signal) {
+        settle(resolve, 1);
+        return;
+      }
+      settle(resolve, code ?? 1);
+    });
+  });
 }
 
-const initialBuild = spawnSync("pnpm", ["exec", compiler], {
-  cwd,
-  env,
-  stdio: "inherit",
-});
-
-if (initialBuild.status !== 0) {
-  process.exit(initialBuild.status ?? 1);
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  void runWatchMain()
+    .then((code) => process.exit(code))
+    .catch((err) => {
+      console.error(err);
+      process.exit(1);
+    });
 }
-
-const compilerProcess = spawn("pnpm", ["exec", compiler, "--watch"], {
-  cwd,
-  env,
-  stdio: "inherit",
-});
-
-const nodeProcess = spawn(process.execPath, ["--watch", "openclaw.mjs", ...args], {
-  cwd,
-  env,
-  stdio: "inherit",
-});
-
-let exiting = false;
-
-function cleanup(code = 0) {
-  if (exiting) {
-    return;
-  }
-  exiting = true;
-  nodeProcess.kill("SIGTERM");
-  compilerProcess.kill("SIGTERM");
-  process.exit(code);
-}
-
-process.on("SIGINT", () => cleanup(130));
-process.on("SIGTERM", () => cleanup(143));
-
-compilerProcess.on("exit", (code) => {
-  if (exiting) {
-    return;
-  }
-  cleanup(code ?? 1);
-});
-
-nodeProcess.on("exit", (code, signal) => {
-  if (signal || exiting) {
-    return;
-  }
-  cleanup(code ?? 1);
-});

--- a/src/infra/watch-node.test.ts
+++ b/src/infra/watch-node.test.ts
@@ -1,0 +1,77 @@
+import { EventEmitter } from "node:events";
+import { describe, expect, it, vi } from "vitest";
+import { runNodeWatchedPaths } from "../../scripts/run-node.mjs";
+import { runWatchMain } from "../../scripts/watch-node.mjs";
+
+const createFakeProcess = () =>
+  Object.assign(new EventEmitter(), {
+    pid: 4242,
+    execPath: "/usr/local/bin/node",
+  }) as unknown as NodeJS.Process;
+
+describe("watch-node script", () => {
+  it("wires node watch to run-node with watched source/config paths", async () => {
+    const child = Object.assign(new EventEmitter(), {
+      kill: vi.fn(),
+    });
+    const spawn = vi.fn(() => child);
+    const fakeProcess = createFakeProcess();
+
+    const runPromise = runWatchMain({
+      args: ["gateway", "--force"],
+      cwd: "/tmp/openclaw",
+      env: { PATH: "/usr/bin" },
+      now: () => 1700000000000,
+      process: fakeProcess,
+      spawn,
+    });
+
+    queueMicrotask(() => child.emit("exit", 0, null));
+    const exitCode = await runPromise;
+
+    expect(exitCode).toBe(0);
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(spawn).toHaveBeenCalledWith(
+      "/usr/local/bin/node",
+      [
+        ...runNodeWatchedPaths.flatMap((watchPath) => ["--watch-path", watchPath]),
+        "--watch-preserve-output",
+        "scripts/run-node.mjs",
+        "gateway",
+        "--force",
+      ],
+      expect.objectContaining({
+        cwd: "/tmp/openclaw",
+        stdio: "inherit",
+        env: expect.objectContaining({
+          PATH: "/usr/bin",
+          OPENCLAW_WATCH_MODE: "1",
+          OPENCLAW_WATCH_SESSION: "1700000000000-4242",
+          OPENCLAW_WATCH_COMMAND: "gateway --force",
+        }),
+      }),
+    );
+  });
+
+  it("terminates child on SIGINT and returns shell interrupt code", async () => {
+    const child = Object.assign(new EventEmitter(), {
+      kill: vi.fn(),
+    });
+    const spawn = vi.fn(() => child);
+    const fakeProcess = createFakeProcess();
+
+    const runPromise = runWatchMain({
+      args: ["gateway", "--force"],
+      process: fakeProcess,
+      spawn,
+    });
+
+    fakeProcess.emit("SIGINT");
+    const exitCode = await runPromise;
+
+    expect(exitCode).toBe(130);
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(fakeProcess.listenerCount("SIGINT")).toBe(0);
+    expect(fakeProcess.listenerCount("SIGTERM")).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `pnpm gateway:watch` can restart the runtime while build output is transiently unavailable, causing `openclaw: missing dist/entry.(m)js (build output)`.
- Why it matters: watch-mode dev loops become flaky/non-deterministic under frequent source edits.
- What changed: `scripts/watch-node.mjs` now uses a single Node watch loop over `src`, `tsconfig.json`, and `package.json`, and restarts through `scripts/run-node.mjs` (single build/start path).
- What changed: shared watched paths are exported from `scripts/run-node.mjs` and reused by `watch-node`; docs in `docs/help/debugging.md` updated to match behavior; regression tests added for watch wiring and signal cleanup.
- What did NOT change (scope boundary): no command rename (`pnpm gateway:watch` stays the same), no protocol/config schema migration.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #9499

## User-visible / Behavior Changes

- `pnpm gateway:watch` now avoids the known watch-race window that surfaced as missing `dist/entry` at restart time.
- Debugging docs now reflect the current `gateway:watch` mapping and remove redundant `--force` examples.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (Apple Silicon)
- Runtime/container: Node 22 + pnpm 10
- Model/provider: N/A
- Integration/channel (if any): Gateway watch mode
- Relevant config (redacted): local gateway config

### Steps

1. Run `pnpm gateway:watch`.
2. Touch watched files repeatedly (for example: `src/entry.ts`, then `src/index.ts`).
3. Observe restart cycles in watch output.

### Expected

- Runtime restarts without `openclaw: missing dist/entry.(m)js`.

### Actual

- Runtime restarts were routed via `scripts/run-node.mjs` and did not hit missing-`dist/entry` errors during the repro loop.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

```text
Before (known failure signature):
Error: openclaw: missing dist/entry.(m)js (build output).
Failed running 'openclaw.mjs gateway --force'. Waiting for file changes before restarting...

After (this branch; watch loop excerpt):
Restarting 'scripts/run-node.mjs gateway --force'
... Build complete ...
... gateway listening on ws://127.0.0.1:18789 ...
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Pre-change scenarios:
  - Ran `pnpm gateway:watch` on a VM from a fresh terminal in the repo, observed restarts through `scripts/run-node.mjs` (see logging included in **Evidence**).

- Post-change scenarios:
  - Started `pnpm gateway:watch` from a fresh terminal in the repo and confirmed the watch loop started normally.
  - Edited watched source files (`src/entry.ts`, then `src/index.ts`) and observed restart cycles routed through `scripts/run-node.mjs`.
  - Verified repeated restart cycles did not emit `openclaw: missing dist/entry.(m)js (build output)`.
  - Stopped watch mode with `Ctrl+C` and confirmed clean shutdown behavior (no stuck child process).

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `5f4f5822e` on this branch (or restore prior `scripts/watch-node.mjs` behavior).
- Files/config to restore:
  - `scripts/watch-node.mjs`
  - `scripts/run-node.mjs`
  - `docs/help/debugging.md`
  - `src/infra/watch-node.test.ts`
- Known bad symptoms reviewers should watch for:
  - `gateway:watch` not restarting on source/config changes.
  - watch mode failing to forward CLI args to runtime.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - A future file-trigger requirement is added but not included in the watch-path list.
  - Mitigation:
    - watch paths are centralized via `runNodeWatchedPaths` and covered by watch-node regression tests.

- Risk:
  - Docs drift from implementation.
  - Mitigation:
    - docs updated in the same change and checked in local doc checks (`pnpm check:docs`).
