### PR TITLE
(feat): MMR and temporal decay / bring back schema changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 - Slack: pass `recipient_team_id` / `recipient_user_id` through Slack native streaming calls so `chat.startStream`/`appendStream`/`stopStream` work reliably across DMs and Slack Connect setups, and disable block streaming when native streaming is active. (#20988) Thanks @Dithilli. Earlier recipient-ID groundwork was contributed in #20377 by @AsserAl1012.
 - CLI/Config: add canonical `--strict-json` parsing for `config set` and keep `--json` as a legacy alias to reduce help/behavior drift. (#21332) thanks @adhitShet.
 - CLI: keep `openclaw -v` as a root-only version alias so subcommand `-v, --verbose` flags (for example ACP/hooks/skills) are no longer intercepted globally. (#21303) thanks @adhitShet.
+- Config/Memory: restore schema help/label metadata for hybrid `mmr` and `temporalDecay` settings so configuration surfaces show correct names and guidance. (#18786) Thanks @rodrigouroz.
 
 - Discord/Gateway: handle close code 4014 (missing privileged gateway intents) without crashing the gateway. Thanks @thewilloftheshadow.
 - Security/Net: strip sensitive headers (`Authorization`, `Proxy-Authorization`, `Cookie`, `Cookie2`) on cross-origin redirects in `fetchWithSsrFGuard` to prevent credential forwarding across origin boundaries. (#20313) Thanks @afurm.

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -215,6 +215,14 @@ export const FIELD_HELP: Record<string, string> = {
     "Weight for BM25 text relevance when merging results (0-1).",
   "agents.defaults.memorySearch.query.hybrid.candidateMultiplier":
     "Multiplier for candidate pool size (default: 4).",
+  "agents.defaults.memorySearch.query.hybrid.mmr.enabled":
+    "Enable MMR re-ranking to reduce near-duplicate memory hits (default: false).",
+  "agents.defaults.memorySearch.query.hybrid.mmr.lambda":
+    "MMR relevance/diversity balance (0 = max diversity, 1 = max relevance, default: 0.7).",
+  "agents.defaults.memorySearch.query.hybrid.temporalDecay.enabled":
+    "Enable exponential recency decay for hybrid scoring (default: false).",
+  "agents.defaults.memorySearch.query.hybrid.temporalDecay.halfLifeDays":
+    "Half-life in days for temporal decay (default: 30).",
   "agents.defaults.memorySearch.cache.enabled":
     "Cache chunk embeddings in SQLite to speed up reindexing and frequent updates (default: true).",
   memory: "Memory backend configuration (global).",

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -166,6 +166,11 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.memorySearch.query.hybrid.textWeight": "Memory Search Text Weight",
   "agents.defaults.memorySearch.query.hybrid.candidateMultiplier":
     "Memory Search Hybrid Candidate Multiplier",
+  "agents.defaults.memorySearch.query.hybrid.mmr.enabled": "Memory Search MMR Re-ranking",
+  "agents.defaults.memorySearch.query.hybrid.mmr.lambda": "Memory Search MMR Lambda",
+  "agents.defaults.memorySearch.query.hybrid.temporalDecay.enabled": "Memory Search Temporal Decay",
+  "agents.defaults.memorySearch.query.hybrid.temporalDecay.halfLifeDays":
+    "Memory Search Temporal Decay Half-life (Days)",
   "agents.defaults.memorySearch.cache.enabled": "Memory Search Embedding Cache",
   "agents.defaults.memorySearch.cache.maxEntries": "Memory Search Embedding Cache Max Entries",
   memory: "Memory",


### PR DESCRIPTION
## Summary

This is the follow up of the revert from https://github.com/openclaw/openclaw/pull/18097 where only the schema changes have been reverted.

This applies it back.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Re-applies the schema UI metadata (help text and display labels) for MMR re-ranking and temporal decay config keys under `agents.defaults.memorySearch.query.hybrid`, which were previously reverted as part of PR #18097.

- Adds 4 help text entries in `schema.help.ts` for `mmr.enabled`, `mmr.lambda`, `temporalDecay.enabled`, and `temporalDecay.halfLifeDays`
- Adds 4 corresponding display labels in `schema.labels.ts`
- All config key paths, default values, and descriptions are consistent with the existing Zod schema (`zod-schema.agent-runtime.ts`), TypeScript types (`types.tools.ts`), and implementation code (`memory/mmr.ts`, `memory/temporal-decay.ts`, `memory/hybrid.ts`, `agents/memory-search.ts`)
- No issues found; this is a clean re-application of previously reverted metadata-only changes

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it only adds static UI metadata (help text and labels) for config keys that are already fully defined in the schema and implemented in the codebase.
- The changes are purely additive, static string entries in two metadata files. All config key paths match the existing Zod schema and TypeScript type definitions exactly. The implementation code for MMR and temporal decay is already present and working. No logic, no runtime behavior, and no API surface is changed.
- No files require special attention.

<sub>Last reviewed commit: 4e329b2</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->