### PR TITLE
docs: add FogClaw plugin docs for official OpenClaw listing

### DIFF
--- a/docs/plugins/fogclaw.md
+++ b/docs/plugins/fogclaw.md
@@ -1,0 +1,95 @@
+---
+summary: "FogClaw plugin for agent message redaction and PII scanning"
+read_when:
+  - You want optional built-in privacy tooling in OpenClaw
+  - You need configurable redaction, blocking, or warning for sensitive content
+  - You are setting up a custom entity scanner in your agent workflow
+title: "FogClaw Plugin"
+---
+
+# FogClaw (plugin)
+
+FogClaw is an OpenClaw plugin that protects agent workflows by detecting and handling sensitive data before or during tool execution.
+
+It provides both proactive guardrail behavior (via the `before_agent_start` hook) and explicit tools:
+
+- `fogclaw_scan`: scans text for PII and custom entities.
+- `fogclaw_redact`: scans and redacts sensitive matches.
+
+## Install
+
+```bash
+openclaw plugins install @openclaw/fogclaw
+```
+
+After install, restart the Gateway and enable/configure `plugins.entries.fogclaw`.
+
+## Plugin entry
+
+The package exports the plugin manifest and entry as:
+
+- plugin id: `fogclaw`
+- package name: `@openclaw/fogclaw`
+- extension entry: `./dist/index.js`
+
+## What it scans
+
+- Structured PII via regex (for example emails, phone numbers, SSNs, credit cards)
+- Custom named-entity labels via GLiNER zero-shot detection
+
+You can also define custom entity labels and per-entity actions in config (for example `redact`, `block`, or `warn`).
+
+## Behavior at a glance
+
+- Runs as a plugin loaded by the standard OpenClaw plugin pipeline.
+- Supports local-only and hosted environments; works from OpenClaw extensions path.
+- Fails safely to regex-only mode if optional GLiNER model initialization is unavailable.
+
+## Configuration reference
+
+Set plugin config under `plugins.entries.fogclaw.config`:
+
+```json5
+{
+  plugins: {
+    entries: {
+      fogclaw: {
+        enabled: true,
+        config: {
+          enabled: true,
+          guardrail_mode: "redact",
+          redactStrategy: "token",
+          confidence_threshold: 0.5,
+          custom_entities: ["project codename", "competitor name"],
+          entityActions: {
+            EMAIL: "redact",
+            PHONE: "redact",
+            SSN: "block",
+            CREDIT_CARD: "block",
+            PERSON: "warn",
+          },
+        },
+      },
+    },
+  },
+}
+```
+
+## Use in the OpenClaw tool policy
+
+When enabled, the plugin registers the `before_agent_start` hook and two tools:
+
+- `fogclaw_scan`
+- `fogclaw_redact`
+
+These tools accept a required `text` field and optional strategy / custom label overrides.
+
+For install and reproducible package metadata evidence, use the package's `openclaw.extensions` field:
+
+```json
+{
+  "openclaw": {
+    "extensions": ["./dist/index.js"]
+  }
+}
+```


### PR DESCRIPTION
## Summary

This PR submits FogClaw for official OpenClaw plugin intake by adding its plugin documentation and providing reproducible validation evidence for the already-merged `@openclaw/fogclaw` package.

The PR does **not** introduce new runtime behavior changes; plugin logic and scanning/redaction implementation already merged in `DataFog/fogclaw` on main.

## What changed

- Add docs page: `docs/plugins/fogclaw.md`
  - install command: `openclaw plugins install @openclaw/fogclaw`
  - plugin behavior, tools, and config highlights
  - manifest/extension identity details (`@openclaw/fogclaw`, `id: fogclaw`, `extensions: ["./dist/index.js"]`)

## Scope boundary

- No code changes to scanner/redaction logic.
- No changes to GLiNER model loading/regex behavior.
- No changes to `src/index.ts`, tests, or package runtime code.
- Evidence collection only, plus plugin-facing documentation.

## Why this matters

FogClaw provides a stable, opt-in privacy guardrail plugin for OpenClaw and now needs upstream documentation/visibility so it can be discovered and installed through standard OpenClaw plugin flows.

## Security impact

- New permissions/capabilities? **No** (documentation-only PR)
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**
- If any `Yes`, explain risk + mitigation: **Not applicable**

## Evidence (reproducible)

Run from a clean checkout of the upstream-merged plugin state:

```bash
npm test
pnpm build
npm run test:plugin-smoke
npm pkg get openclaw
node - <<'NODE'
import plugin from './dist/index.js';
console.log(`${typeof plugin.register === 'function'} ${plugin.id} ${plugin.name}`);
NODE
```

Observed outputs:

- `npm test`: **pass** (`101` tests, `0` failures)
- `pnpm build`: **pass**
- `npm run test:plugin-smoke`: **pass** (`3` tests)
- `npm pkg get openclaw`: returns:

```json
{
  "extensions": [
    "./dist/index.js"
  ]
}
```

- Node import smoke:

```text
true fogclaw FogClaw
```

Example command for installability path under the docs:

```bash
openclaw plugins install @openclaw/fogclaw
```

(Installability note: package identity is set to `@openclaw/fogclaw` in manifest/package metadata; package manager/registry behavior should be validated by maintainers as part of release/publish steps.)

## Repro + verification

- Environment
  - OS: macOS / Linux
  - Runtime: Node 22+
  - Model/provider: none required
  - Relevant config: none required

- Steps
  1. Validate plugin tests/coverage and smoke checks above.
  2. Confirm `package.json#openclaw.extensions` and manifest consistency.
  3. Confirm this PR only adds `docs/plugins/fogclaw.md`.

- Expected
  - Deterministic green checks for test/build/import evidence.
  - PR provides concrete package identity and installation guidance.

- Actual
  - As expected (above).

## Risks and mitigations

- Risk: package discoverability relies on upstream maintainer-controlled publish cadence.
  - Mitigation: PR is scoped to documentation and explicit manifest identity so maintainers can pair it with release/publish actions.

## Human verification

- Verified commands and outputs above.
- Edge checks performed: `npm pkg get openclaw` and runtime import smoke from `dist/index.js`.
- What not verified: end-to-end OpenClaw publish+install from remote registry (outside this repository scope).
