### PR TITLE
fix(cli): suppress file logging during completion to prevent log noise

### DIFF
--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -1,9 +1,10 @@
+import { Command, Option } from "commander";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { Command, Option } from "commander";
 import { resolveStateDir } from "../config/paths.js";
 import { routeLogsToStderr } from "../logging/console.js";
+import { loggingState } from "../logging/state.js";
 import { pathExists } from "../utils.js";
 import { getCoreCliCommandNames, registerCoreCliByName } from "./program/command-registry.js";
 import { getProgramContext } from "./program/program-context.js";
@@ -241,6 +242,8 @@ export function registerCompletionCli(program: Command) {
       // Route logs to stderr so plugin loading messages do not corrupt
       // the completion script written to stdout.
       routeLogsToStderr();
+      // Suppress file logging so completion output does not pollute the shared gateway log file.
+      loggingState.overrideSettings = { level: "silent" };
       const shell = options.shell ?? "zsh";
 
       // Completion needs the full Commander command tree (including nested subcommands).


### PR DESCRIPTION
## Summary

- Suppress file logging during `openclaw completion` so module-loading output does not pollute the shared gateway log file at `/tmp/openclaw/openclaw-*.log`.

Fixes #18108

## Changes

- `src/cli/completion-cli.ts`: Import `loggingState` and set `overrideSettings = { level: "silent" }` at the start of the completion action handler, before any subcommand registration triggers module loading. This prevents the lazily-initialized file logger from ever being created.

## Root cause

`enableConsoleCapture()` in `index.ts` patches all `console.*` calls to also write to a shared rolling log file. When `openclaw completion` runs (e.g. on every zsh tab-complete), eagerly registering all subcommands triggers module loading that uses `console.log`, which gets captured to the same log file the gateway uses. Setting the file log level to silent before registration prevents this.

## Test plan

- [x] Verified `loggingState.overrideSettings` is checked by `resolveSettings()` in `logger.ts` before the file logger is created
- [x] Linter passes
- [ ] Manual test: run `openclaw completion --shell zsh` then check `/tmp/openclaw/openclaw-*.log` -- no completion output should appear