### PR TITLE
fix(model-fallback): allow cross-provider failover when models allowlist is set

### DIFF
--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -208,7 +208,11 @@ function resolveFallbackCandidates(params: {
     if (!resolved) {
       continue;
     }
-    addCandidate(resolved.ref, true);
+    // Explicitly configured fallbacks always bypass the allowlist: the user
+    // intentionally listed them as fallbacks, so filtering them out via the
+    // model-picker allowlist (agents.defaults.models) would silently break
+    // cross-provider failover.
+    addCandidate(resolved.ref, false);
   }
 
   if (params.fallbacksOverride === undefined && primary?.provider && primary.model) {


### PR DESCRIPTION
## Summary

- Configured fallback models (`agents.defaults.model.fallbacks`) were silently filtered out when an `agents.defaults.models` allowlist was also configured, because fallbacks were validated against the allowlist (`enforceAllowlist: true`). This broke cross-provider failover: a 429 on one provider would show "All models failed (1)" instead of trying the fallback on another provider.
- Changed `enforceAllowlist` from `true` to `false` for explicitly configured fallback models in `resolveFallbackCandidates`, matching the behavior already used for the primary model.
- Fixed a pre-existing test using a cooldown too short to avoid the probe margin.

Closes #5744 #11972 #4350

## Test plan

- [x] New test: primary 429 → successful fallback to different provider
- [x] New test: fallbacks bypass `agents.defaults.models` allowlist (the core regression)
- [x] New test: same-provider fallback in cooldown → different-provider fallback succeeds
- [x] New test: all models fail → error count matches total attempted
- [x] All 25 model-fallback e2e tests pass
- [x] All 11 model-fallback probe tests pass
- [x] Related test suites (failover-error, model-selection, auth-profiles) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)