### PR TITLE
fix(web-search): skip invalid bare ui_lang codes in Brave Search requests

### DIFF
--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -1,9 +1,9 @@
 import { Type } from "@sinclair/typebox";
-import type { OpenClawConfig } from "../../config/config.js";
-import type { AnyAgentTool } from "./common.js";
 import { formatCliCommand } from "../../cli/command-format.js";
+import type { OpenClawConfig } from "../../config/config.js";
 import { wrapWebContent } from "../../security/external-content.js";
 import { normalizeSecretInput } from "../../utils/normalize-secret-input.js";
+import type { AnyAgentTool } from "./common.js";
 import { jsonResult, readNumberParam, readStringParam } from "./common.js";
 import {
   CacheEntry,

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -1,9 +1,9 @@
 import { Type } from "@sinclair/typebox";
-import { formatCliCommand } from "../../cli/command-format.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import type { AnyAgentTool } from "./common.js";
+import { formatCliCommand } from "../../cli/command-format.js";
 import { wrapWebContent } from "../../security/external-content.js";
 import { normalizeSecretInput } from "../../utils/normalize-secret-input.js";
-import type { AnyAgentTool } from "./common.js";
 import { jsonResult, readNumberParam, readStringParam } from "./common.js";
 import {
   CacheEntry,
@@ -650,7 +650,9 @@ async function runWebSearch(params: {
   if (params.search_lang) {
     url.searchParams.set("search_lang", params.search_lang);
   }
-  if (params.ui_lang) {
+  if (params.ui_lang && params.ui_lang.includes("-")) {
+    // Brave requires full locale codes (e.g. "en-US"), not bare language
+    // codes (e.g. "en"). Skip invalid values and let the API use its default.
     url.searchParams.set("ui_lang", params.ui_lang);
   }
   if (params.freshness) {


### PR DESCRIPTION
## Summary

Brave Search API requires full locale codes (e.g. `en-US`), not bare language codes (e.g. `en`). When the model generates a bare code, the API returns a 422 validation error, breaking web search entirely for all Brave users.

Fixes #18795

## Changes

`src/agents/tools/web-search.ts`: Add a hyphen check on `ui_lang` before passing it to the Brave API. Bare language codes are silently skipped, letting the API fall back to its default (`en-US`).

## Test plan

- [x] `oxfmt --check` passes
- [x] `oxlint` passes (0 warnings, 0 errors)
- [x] Manual: send a web search query via Brave — should no longer 422