### PR TITLE
fix(auth/session): preserve override reset behavior and repair oauth profile-id drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 - Discord/Gateway: handle close code 4014 (missing privileged gateway intents) without crashing the gateway. Thanks @thewilloftheshadow.
 - Security/Net: strip sensitive headers (`Authorization`, `Proxy-Authorization`, `Cookie`, `Cookie2`) on cross-origin redirects in `fetchWithSsrFGuard` to prevent credential forwarding across origin boundaries. (#20313) Thanks @afurm.
 - Auto-reply/Runner: emit `onAgentRunStart` only after agent lifecycle or tool activity begins (and only once per run), so fallback preflight errors no longer mark runs as started. (#21165) Thanks @shakkernerd.
+- Agents/Failover: treat non-default override runs as direct fallback-to-configured-primary (skip configured fallback chain), normalize default-model detection for provider casing/whitespace, and add regression coverage for override/auth error paths. (#18820) Thanks @Glucksberg.
 - Auto-reply/Tool results: serialize tool-result delivery and keep the delivery chain progressing after individual failures so concurrent tool outputs preserve user-visible ordering. (#21231) thanks @ahdernasr.
 - Auto-reply/Prompt caching: restore prefix-cache stability by keeping inbound system metadata session-stable and moving per-message IDs (`message_id`, `message_id_full`, `reply_to_id`, `sender_id`) into untrusted conversation context. (#20597) Thanks @anisoptera.
 - CLI/Onboarding: fix Anthropic-compatible custom provider verification by normalizing base URLs to avoid duplicate `/v1` paths during setup checks. (#21336) Thanks @17jmumford.

--- a/src/agents/auth-profiles/order.ts
+++ b/src/agents/auth-profiles/order.ts
@@ -37,7 +37,7 @@ export function resolveAuthProfileOrder(params: {
     return [];
   }
 
-  const filtered = baseOrder.filter((profileId) => {
+  const isValidProfile = (profileId: string): boolean => {
     const cred = store.profiles[profileId];
     if (!cred) {
       return false;
@@ -78,7 +78,18 @@ export function resolveAuthProfileOrder(params: {
       return Boolean(cred.access?.trim() || cred.refresh?.trim());
     }
     return false;
-  });
+  };
+  let filtered = baseOrder.filter(isValidProfile);
+
+  // Repair config/store profile-id drift from older onboarding flows:
+  // if configured profile ids no longer exist in auth-profiles.json, scan the
+  // provider's stored credentials and use any valid entries.
+  const allBaseProfilesMissing = baseOrder.every((profileId) => !store.profiles[profileId]);
+  if (filtered.length === 0 && explicitProfiles.length > 0 && allBaseProfilesMissing) {
+    const storeProfiles = listProfilesForProvider(store, providerKey);
+    filtered = storeProfiles.filter(isValidProfile);
+  }
+
   const deduped = dedupeProfileIds(filtered);
 
   // If user specified explicit order (store override or config), respect it

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -205,9 +205,18 @@ function resolveFallbackCandidates(params: {
 
   addCandidate(normalizedPrimary, false);
 
+  // When the model being run is a user-selected override (different from the
+  // configured primary), skip the config fallback chain entirely and fall back
+  // directly to the default. The fallback chain is designed for when the
+  // primary model itself is unavailable — not for arbitrary overrides.
+  const isRunningDefault = providerRaw === defaultProvider && modelRaw === defaultModel;
+
   const modelFallbacks = (() => {
     if (params.fallbacksOverride !== undefined) {
       return params.fallbacksOverride;
+    }
+    if (!isRunningDefault) {
+      return []; // Override model failed → go straight to configured default
     }
     const model = params.cfg?.agents?.defaults?.model as
       | { fallbacks?: string[] }

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 import { resolveSessionAuthProfileOverride } from "../../agents/auth-profiles/session-override.js";
 import type { ExecToolDefaults } from "../../agents/bash-tools.js";
+import { resolveModelAuthLabel } from "../../agents/model-auth-label.js";
 import {
   abortEmbeddedPiRun,
   isEmbeddedPiRunActive,
@@ -325,10 +326,18 @@ export async function runPreparedReply(
     if (channel && to) {
       const modelLabel = `${provider}/${model}`;
       const defaultLabel = `${defaultProvider}/${defaultModel}`;
+      const modelAuthLabel = resolveModelAuthLabel({
+        provider,
+        cfg,
+        sessionEntry,
+        agentDir,
+      });
+      const authSuffix =
+        modelAuthLabel && modelAuthLabel !== "unknown" ? ` · 🔑 ${modelAuthLabel}` : "";
       const text =
         modelLabel === defaultLabel
-          ? `✅ New session started · model: ${modelLabel}`
-          : `✅ New session started · model: ${modelLabel} (default: ${defaultLabel})`;
+          ? `✅ New session started · model: ${modelLabel}${authSuffix}`
+          : `✅ New session started · model: ${modelLabel} (default: ${defaultLabel})${authSuffix}`;
       await routeReply({
         payload: { text },
         channel,

--- a/src/auto-reply/reply/session-run-accounting.ts
+++ b/src/auto-reply/reply/session-run-accounting.ts
@@ -13,19 +13,7 @@ type IncrementRunCompactionCountParams = Omit<
 };
 
 export async function persistRunSessionUsage(params: PersistRunSessionUsageParams): Promise<void> {
-  await persistSessionUsageUpdate({
-    storePath: params.storePath,
-    sessionKey: params.sessionKey,
-    usage: params.usage,
-    lastCallUsage: params.lastCallUsage,
-    promptTokens: params.promptTokens,
-    modelUsed: params.modelUsed,
-    providerUsed: params.providerUsed,
-    contextTokensUsed: params.contextTokensUsed,
-    systemPromptReport: params.systemPromptReport,
-    cliSessionId: params.cliSessionId,
-    logLabel: params.logLabel,
-  });
+  await persistSessionUsageUpdate(params);
 }
 
 export async function incrementRunCompactionCount(

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -256,6 +256,8 @@ export async function initSessionState(params: {
       persistedVerbose = entry.verboseLevel;
       persistedReasoning = entry.reasoningLevel;
       persistedTtsAuto = entry.ttsAuto;
+      persistedModelOverride = entry.modelOverride;
+      persistedProviderOverride = entry.providerOverride;
     }
   }
 

--- a/src/commands/auth-choice.apply.oauth.ts
+++ b/src/commands/auth-choice.apply.oauth.ts
@@ -68,11 +68,7 @@ export async function applyAuthChoiceOAuth(
       });
 
       spin.stop("Chutes OAuth complete");
-      const email =
-        typeof creds.email === "string" && creds.email.trim() ? creds.email.trim() : "default";
-      const profileId = `chutes:${email}`;
-
-      await writeOAuthCredentials("chutes", creds, params.agentDir);
+      const profileId = await writeOAuthCredentials("chutes", creds, params.agentDir);
       nextConfig = applyAuthProfileConfig(nextConfig, {
         profileId,
         provider: "chutes",

--- a/src/commands/auth-choice.apply.openai.ts
+++ b/src/commands/auth-choice.apply.openai.ts
@@ -117,9 +117,9 @@ export async function applyAuthChoiceOpenAI(
       return { config: nextConfig, agentModelOverride };
     }
     if (creds) {
-      await writeOAuthCredentials("openai-codex", creds, params.agentDir);
+      const profileId = await writeOAuthCredentials("openai-codex", creds, params.agentDir);
       nextConfig = applyAuthProfileConfig(nextConfig, {
-        profileId: "openai-codex:default",
+        profileId,
         provider: "openai-codex",
         mode: "oauth",
       });

--- a/src/commands/onboard-auth.credentials.ts
+++ b/src/commands/onboard-auth.credentials.ts
@@ -10,11 +10,12 @@ export async function writeOAuthCredentials(
   provider: string,
   creds: OAuthCredentials,
   agentDir?: string,
-): Promise<void> {
+): Promise<string> {
   const email =
     typeof creds.email === "string" && creds.email.trim() ? creds.email.trim() : "default";
+  const profileId = `${provider}:${email}`;
   upsertAuthProfile({
-    profileId: `${provider}:${email}`,
+    profileId,
     credential: {
       type: "oauth",
       provider,
@@ -22,6 +23,7 @@ export async function writeOAuthCredentials(
     },
     agentDir: resolveAuthAgentDir(agentDir),
   });
+  return profileId;
 }
 
 export async function setAnthropicApiKey(key: string, agentDir?: string) {

--- a/src/sessions/model-overrides.ts
+++ b/src/sessions/model-overrides.ts
@@ -64,7 +64,11 @@ export function applyModelOverrideToSessionEntry(params: {
     }
   }
 
+  // Clear stale fallback notice when the user explicitly switches models.
   if (updated) {
+    delete entry.fallbackNoticeSelectedModel;
+    delete entry.fallbackNoticeActiveModel;
+    delete entry.fallbackNoticeReason;
     entry.updatedAt = Date.now();
   }
 


### PR DESCRIPTION
## Context

This PR started as a very small fix: preserve the user's model/provider override across `/new` and `/reset`.

At first, this looked isolated to the reset path. But while tracing `resetTriggered`, I found we were preserving other session-level overrides (`thinking`, `verbose`, `tts`, etc.) and silently dropping model/provider overrides. That made `/model` feel unreliable right after reset, so the first fix was straightforward: carry those overrides forward the same way we do for the others.

Then came the first bigger issue: fallback behavior.
When a user-selected override model failed (for example due to auth), the system was walking the full configured fallback chain before eventually returning to default. That chain is useful when the **primary/default** model fails, but it's the wrong behavior for an explicit user override. So now the logic is split:

- override fails → go directly back to configured default
- default fails → use configured fallback chain as before

While validating this end-to-end, a deeper auth problem surfaced: OAuth profile-id drift. In some flows, profile IDs stored in config no longer matched credentials in `auth-profiles.json`, especially around OpenAI Codex. This caused inconsistent model/auth resolution and hard-to-debug behavior. I changed credential write/apply flow to persist the actual returned profile ID and added repair logic when config references stale/missing IDs. Also added e2e coverage around these paths.

Finally, after fixing behavior, visibility was still weak. Users couldn't always tell which auth/model state was active after `/new`, `/models`, or fallback transitions. So this PR also improves runtime transparency:

- show model auth label in `/new` and `/models`
- clear fallback notice state when user explicitly switches models via `/models`
- simplify `persistRunSessionUsage` passthrough to forward params directly

So this evolved from a one-line-style reset fix into a broader reliability pass across session reset, fallback semantics, auth profile consistency, and status visibility.
The goal is simple: if a user chooses a model, the system should behave predictably — and make its current state obvious.

## Related issues

Fixes #19810 — `/status` reports configured model instead of actual after fallback
Fixes #20438 — Runtime metadata shows stale model after `/new` or model handoff
Partially addresses #19730 — Session model override persists after fallback
Partially addresses #13982 — `/model default` resolves to wrong value
Partially addresses #5733 — Model-level authProfileId override not respected

## Test plan

- [x] All existing tests pass (`pnpm build` + `pnpm test`)
- [x] Manual testing: `/new` preserves model override
- [x] Manual testing: override model failure falls back to default (not full chain)
- [x] Manual testing: OAuth profile-id drift repaired on credential apply
- [x] Manual testing: `/new` and `/models` show auth label
- [x] Manual testing: `/models` switch clears stale fallback notice
- [x] e2e tests added for auth profile resolution and onboard-auth flows