### PR TITLE
fix(ui): avoid chat bubble flicker after streaming completes

### DIFF
--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -1,9 +1,9 @@
 import { html, nothing } from "lit";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import type { AssistantIdentity } from "../assistant-identity.ts";
+import type { MessageGroup } from "../types/chat-types.ts";
 import { toSanitizedMarkdownHtml } from "../markdown.ts";
 import { detectTextDirection } from "../text-direction.ts";
-import type { MessageGroup } from "../types/chat-types.ts";
 import { renderCopyAsMarkdownButton } from "./copy-as-markdown.ts";
 import {
   extractTextCached,
@@ -247,7 +247,6 @@ function renderGroupedMessage(
     "chat-bubble",
     canCopyMarkdown ? "has-copy" : "",
     opts.isStreaming ? "streaming" : "",
-    "fade-in",
   ]
     .filter(Boolean)
     .join(" ");

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -154,4 +154,26 @@ describe("chat view", () => {
     expect(onNewSession).toHaveBeenCalledTimes(1);
     expect(container.textContent).not.toContain("Stop");
   });
+
+  it("renders assistant bubbles without fade-in class", () => {
+    const container = document.createElement("div");
+    render(
+      renderChat(
+        createProps({
+          messages: [
+            {
+              role: "assistant",
+              content: [{ type: "text", text: "Final reply" }],
+              timestamp: 1,
+            },
+          ],
+        }),
+      ),
+      container,
+    );
+
+    const bubble = container.querySelector(".chat-bubble");
+    expect(bubble).not.toBeNull();
+    expect(bubble?.classList.contains("fade-in")).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
The WebUI chat view could visibly flicker at the end of assistant streaming: the streaming bubble disappeared, then a full-content bubble appeared immediately after.

## Root Cause
On `chat` `final` events, the controller cleared stream state before materializing the final assistant message in local chat state. The subsequent history refresh then reintroduced the same message as a separate render pass.

## What Changed
- `ui/src/ui/controllers/chat.ts`
  - On `final`, append an assistant message from payload when valid, otherwise fallback to streamed text, before clearing stream state.
- `ui/src/ui/chat/grouped-render.ts`
  - Remove `fade-in` class from chat bubbles to avoid end-of-stream flash during stream-to-final transition.
- Tests
  - `ui/src/ui/controllers/chat.test.ts`: cover `final` message materialization and payload-vs-stream fallback behavior.
  - `ui/src/ui/views/chat.test.ts`: assert assistant bubbles are rendered without `fade-in`.

## Validation
- `pnpm -C ui exec vitest run src/ui/controllers/chat.test.ts --config vitest.config.ts --browser.enabled false`
- `pnpm -C ui exec vitest run src/ui/views/chat.test.ts --config vitest.config.ts`
