### PR TITLE
fix(zalo): replace console.log/error with runtime logging

### DIFF
--- a/extensions/zalo/src/monitor.ts
+++ b/extensions/zalo/src/monitor.ts
@@ -218,7 +218,7 @@ function startPollingLoop(params: {
       if (err instanceof ZaloApiError && err.isPollingTimeout) {
         // no updates
       } else if (!isStopped() && !abortSignal.aborted) {
-        console.error(`[${account.accountId}] Zalo polling error:`, err);
+        runtime.error?.(`[${account.accountId}] Zalo polling error: ${String(err)}`);
         await new Promise((resolve) => setTimeout(resolve, 5000));
       }
     }
@@ -265,10 +265,12 @@ async function processUpdate(
       );
       break;
     case "message.sticker.received":
-      console.log(`[${account.accountId}] Received sticker from ${message.from.id}`);
+      logVerbose(core, runtime, `[${account.accountId}] Received sticker from ${message.from.id}`);
       break;
     case "message.unsupported.received":
-      console.log(
+      logVerbose(
+        core,
+        runtime,
         `[${account.accountId}] Received unsupported message type from ${message.from.id}`,
       );
       break;
@@ -334,7 +336,7 @@ async function handleImageMessage(
       mediaPath = saved.path;
       mediaType = saved.contentType;
     } catch (err) {
-      console.error(`[${account.accountId}] Failed to download Zalo image:`, err);
+      runtime.error?.(`[${account.accountId}] Failed to download Zalo image: ${String(err)}`);
     }
   }
 


### PR DESCRIPTION
Using console methods directly bypasses the structured logging system and runtime controls (like verbose mode).

Fix: Replace console.log/error with runtime.log/error and logVerbose helper.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces the last 4 direct `console.log`/`console.error` calls in the Zalo extension's monitor module with the structured logging system (`runtime.error?.()` for errors, `logVerbose()` for informational messages). This aligns the Zalo extension with the standard logging patterns used across other extensions (msteams, matrix) and ensures all log output respects runtime controls like verbose mode.

- 2 `console.error` calls converted to `runtime.error?.()` with `String(err)` serialization (consistent with existing error logging in the same file)
- 2 `console.log` calls converted to `logVerbose(core, runtime, ...)` which gates output behind `core.logging.shouldLogVerbose()`
- No remaining `console.*` calls in `extensions/zalo/src/monitor.ts` after this change

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a minimal, mechanical logging migration with no behavioral changes.
- All 4 changes follow the exact same patterns already established in the file and across other extensions. The `logVerbose` helper and `runtime.error?.()` calls are well-tested conventions. No logic, control flow, or error handling behavior is altered. No remaining direct console calls in the file.
- No files require special attention

<sub>Last reviewed commit: e97dc7d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->