### PR TITLE
fix(slack): account for HTTP mode in isConfigured check(#7634)

### DIFF
--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -114,12 +114,13 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
         accountId,
         clearBaseFields: ["botToken", "appToken", "name"],
       }),
-    isConfigured: (account) => Boolean(account.botToken && account.appToken),
+    isConfigured: (account) =>
+      Boolean(account.botToken && (account.appToken || account.config.mode === "http")),
     describeAccount: (account) => ({
       accountId: account.accountId,
       name: account.name,
       enabled: account.enabled,
-      configured: Boolean(account.botToken && account.appToken),
+      configured: Boolean(account.botToken && (account.appToken || account.config.mode === "http")),
       botTokenSource: account.botTokenSource,
       appTokenSource: account.appTokenSource,
     }),


### PR DESCRIPTION
## Summary
- `isConfigured` and `describeAccount.configured` previously required both `botToken` and `appToken`, which meant Slack accounts using HTTP mode were never considered configured
- Updated the condition to accept either `appToken` (socket mode) or `config.mode === "http"` as valid configurations alongside `botToken`

## Test plan
- [ ] Verify a Slack account in HTTP mode (no `appToken`) is reported as configured
- [ ] Verify a Slack account in socket mode still requires both `botToken` and `appToken`
- [ ] Verify `describeAccount` returns `configured: true` for HTTP mode accounts

fix issue #7634 

🤖 Generated with [Claude Code](https://claude.com/claude-code)