### PR TITLE
feat(telegram): add /imagequality command for uncompressed image delivery

### DIFF
--- a/src/auto-reply/commands-registry.data.ts
+++ b/src/auto-reply/commands-registry.data.ts
@@ -21,6 +21,7 @@ type DefineChatCommandInput = {
   textAliases?: string[];
   scope?: CommandScope;
   category?: CommandCategory;
+  providers?: string[];
 };
 
 function defineChatCommand(command: DefineChatCommandInput): ChatCommandDefinition {
@@ -43,6 +44,7 @@ function defineChatCommand(command: DefineChatCommandInput): ChatCommandDefiniti
     textAliases: aliases,
     scope,
     category: command.category,
+    providers: command.providers,
   };
 }
 
@@ -241,6 +243,21 @@ function buildChatCommands(): ChatCommandDefinition[] {
       description: "Show your sender id.",
       textAlias: "/whoami",
       category: "status",
+    }),
+    defineChatCommand({
+      key: "imagequality",
+      nativeName: "imagequality",
+      description: "Set Telegram image quality mode.",
+      category: "options",
+      providers: ["telegram"],
+      args: [
+        {
+          name: "quality",
+          description: "high or normal",
+          type: "string",
+          choices: ["high", "normal"],
+        },
+      ],
     }),
     defineChatCommand({
       key: "subagents",

--- a/src/auto-reply/commands-registry.ts
+++ b/src/auto-reply/commands-registry.ts
@@ -125,7 +125,14 @@ export function listNativeCommandSpecs(params?: {
   provider?: string;
 }): NativeCommandSpec[] {
   return listChatCommands({ skillCommands: params?.skillCommands })
-    .filter((command) => command.scope !== "text" && command.nativeName)
+    .filter(
+      (command) =>
+        command.scope !== "text" &&
+        command.nativeName &&
+        (!command.providers ||
+          !params?.provider ||
+          command.providers.includes(params.provider.toLowerCase())),
+    )
     .map((command) => ({
       name: resolveNativeName(command, params?.provider) ?? command.key,
       description: command.description,
@@ -139,7 +146,14 @@ export function listNativeCommandSpecsForConfig(
   params?: { skillCommands?: SkillCommandSpec[]; provider?: string },
 ): NativeCommandSpec[] {
   return listChatCommandsForConfig(cfg, params)
-    .filter((command) => command.scope !== "text" && command.nativeName)
+    .filter(
+      (command) =>
+        command.scope !== "text" &&
+        command.nativeName &&
+        (!command.providers ||
+          !params?.provider ||
+          command.providers.includes(params.provider.toLowerCase())),
+    )
     .map((command) => ({
       name: resolveNativeName(command, params?.provider) ?? command.key,
       description: command.description,
@@ -156,6 +170,7 @@ export function findCommandByNativeName(
   return getChatCommands().find(
     (command) =>
       command.scope !== "text" &&
+      (!command.providers || !provider || command.providers.includes(provider.toLowerCase())) &&
       resolveNativeName(command, provider)?.toLowerCase() === normalized,
   );
 }

--- a/src/auto-reply/commands-registry.types.ts
+++ b/src/auto-reply/commands-registry.types.ts
@@ -61,6 +61,8 @@ export type ChatCommandDefinition = {
   argsMenu?: CommandArgMenuSpec | "auto";
   scope: CommandScope;
   category?: CommandCategory;
+  /** Restrict this command to specific channel providers (e.g. ["telegram"]). Undefined = all. */
+  providers?: string[];
 };
 
 export type NativeCommandSpec = {

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -228,6 +228,7 @@ export const dispatchTelegramMessage = async ({
           onVoiceRecording: sendRecordVoice,
           linkPreview: telegramCfg.linkPreview,
           replyQuoteText,
+          accountId: route.accountId,
         });
       },
       onError: (err, info) => {

--- a/src/telegram/bot/delivery.ts
+++ b/src/telegram/bot/delivery.ts
@@ -134,9 +134,11 @@ export async function deliverReplies(params: {
     });
     for (const mediaUrl of mediaList) {
       const isFirstMedia = first;
-      const media = await loadWebMedia(mediaUrl, undefined, {
-        optimizeImages: imageQuality !== "high",
-      });
+      const media = await loadWebMedia(
+        mediaUrl,
+        imageQuality === "high" ? 50 * 1024 * 1024 : undefined,
+        { optimizeImages: imageQuality !== "high" },
+      );
       const detectedKind = mediaKindFromMime(media.contentType ?? undefined);
       const kind =
         imageQuality === "high" && detectedKind === "image" ? ("document" as const) : detectedKind;

--- a/src/telegram/image-quality-store.ts
+++ b/src/telegram/image-quality-store.ts
@@ -1,0 +1,114 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { resolveStateDir } from "../config/paths.js";
+
+const STORE_VERSION = 1;
+
+export type TelegramImageQuality = "normal" | "high";
+
+type TelegramImageQualityState = {
+  version: number;
+  quality: TelegramImageQuality;
+};
+
+function normalizeAccountId(accountId?: string): string {
+  const trimmed = accountId?.trim();
+  if (!trimmed) return "default";
+  return trimmed.replace(/[^a-z0-9._-]+/gi, "_");
+}
+
+function normalizeChatId(chatId: string | number): string {
+  const normalized = String(chatId).trim();
+  if (!normalized) throw new Error("chatId is required");
+  return normalized;
+}
+
+function resolveTelegramImageQualityPath(
+  chatId: string | number,
+  accountId?: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const stateDir = resolveStateDir(env);
+  const normalizedAccount = normalizeAccountId(accountId);
+  const safeChatId = normalizeChatId(chatId).replace(/[^a-z0-9._-]+/gi, "_");
+  return path.join(stateDir, "telegram", "image-quality", normalizedAccount, `${safeChatId}.json`);
+}
+
+function safeParseState(raw: string): TelegramImageQualityState | null {
+  try {
+    const parsed = JSON.parse(raw) as TelegramImageQualityState;
+    if (parsed?.version !== STORE_VERSION) return null;
+    if (parsed.quality !== "normal" && parsed.quality !== "high") return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+async function readTelegramImageQualityFile(filePath: string): Promise<TelegramImageQuality> {
+  try {
+    const raw = await fs.readFile(filePath, "utf-8");
+    const parsed = safeParseState(raw);
+    return parsed?.quality ?? "normal";
+  } catch (err) {
+    const code = (err as { code?: string }).code;
+    if (code === "ENOENT") return "normal";
+    return "normal";
+  }
+}
+
+async function writeTelegramImageQualityFile(
+  filePath: string,
+  quality: TelegramImageQuality,
+): Promise<void> {
+  if (quality === "normal") {
+    await fs.rm(filePath, { force: true }).catch(() => undefined);
+    return;
+  }
+  const dir = path.dirname(filePath);
+  await fs.mkdir(dir, { recursive: true, mode: 0o700 });
+  const tmp = path.join(dir, `${path.basename(filePath)}.${crypto.randomUUID()}.tmp`);
+  const payload: TelegramImageQualityState = {
+    version: STORE_VERSION,
+    quality,
+  };
+  await fs.writeFile(tmp, `${JSON.stringify(payload, null, 2)}\n`, {
+    encoding: "utf-8",
+  });
+  await fs.chmod(tmp, 0o600);
+  await fs.rename(tmp, filePath);
+}
+
+export function normalizeTelegramImageQuality(
+  value: string | undefined,
+): TelegramImageQuality | null {
+  const normalized = value?.trim().toLowerCase();
+  if (normalized === "normal" || normalized === "high") return normalized;
+  return null;
+}
+
+export async function readTelegramChatImageQuality(params: {
+  chatId: string | number;
+  accountId?: string;
+  env?: NodeJS.ProcessEnv;
+}): Promise<TelegramImageQuality> {
+  const filePath = resolveTelegramImageQualityPath(params.chatId, params.accountId, params.env);
+  return await readTelegramImageQualityFile(filePath);
+}
+
+export async function setTelegramChatImageQuality(params: {
+  chatId: string | number;
+  quality: TelegramImageQuality;
+  accountId?: string;
+  env?: NodeJS.ProcessEnv;
+}): Promise<{ changed: boolean; quality: TelegramImageQuality }> {
+  const filePath = resolveTelegramImageQualityPath(params.chatId, params.accountId, params.env);
+  const current = await readTelegramImageQualityFile(filePath);
+  if (current === params.quality) {
+    return { changed: false, quality: current };
+  }
+  await writeTelegramImageQualityFile(filePath, params.quality);
+  return { changed: true, quality: params.quality };
+}

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -301,9 +301,11 @@ export async function sendMessageTelegram(
       chatId,
       accountId: account.accountId,
     });
-    const media = await loadWebMedia(mediaUrl, opts.maxBytes, {
-      optimizeImages: imageQuality !== "high",
-    });
+    const media = await loadWebMedia(
+      mediaUrl,
+      imageQuality === "high" ? (opts.maxBytes ?? 50 * 1024 * 1024) : opts.maxBytes,
+      { optimizeImages: imageQuality !== "high" },
+    );
     const detectedKind = mediaKindFromMime(media.contentType ?? undefined);
     const kind = imageQuality === "high" && detectedKind === "image" ? "document" : detectedKind;
     const isGif = isGifMedia({

--- a/src/web/media.ts
+++ b/src/web/media.ts
@@ -26,6 +26,8 @@ type WebMediaOptions = {
   optimizeImages?: boolean;
 };
 
+type LoadWebMediaOptions = Pick<WebMediaOptions, "optimizeImages">;
+
 const HEIC_MIME_RE = /^image\/hei[cf]$/i;
 const HEIC_EXT_RE = /\.(heic|heif)$/i;
 const MB = 1024 * 1024;
@@ -217,10 +219,14 @@ async function loadWebMediaInternal(
   });
 }
 
-export async function loadWebMedia(mediaUrl: string, maxBytes?: number): Promise<WebMediaResult> {
+export async function loadWebMedia(
+  mediaUrl: string,
+  maxBytes?: number,
+  options: LoadWebMediaOptions = {},
+): Promise<WebMediaResult> {
   return await loadWebMediaInternal(mediaUrl, {
     maxBytes,
-    optimizeImages: true,
+    optimizeImages: options.optimizeImages ?? true,
   });
 }
 


### PR DESCRIPTION
## Summary

Add a `/imagequality` slash command for Telegram that lets users control whether images are sent as compressed photos (`sendPhoto`) or uncompressed documents (`sendDocument`).

### Problem

Telegram applies lossy compression to images sent via `sendPhoto`. For users sharing high-resolution screenshots, architecture diagrams, or detailed graphics, this double-compression pipeline (OpenClaw optimization + Telegram re-compression) significantly degrades image quality.

There is currently no way for users to opt out of this compression.

### Solution

**New `/imagequality` slash command** with two modes:

| Mode | Behavior |
|------|----------|
| `normal` (default) | Images optimized by OpenClaw and sent via `sendPhoto` — existing behavior, unchanged |
| `high` | Optimization skipped, images sent via `sendDocument` with 50MB cap (Telegram upload limit) — lossless delivery |

**Usage:**
- `/imagequality` — show current setting
- `/imagequality normal` — compressed photos (default)
- `/imagequality high` — uncompressed documents

### Design Decisions

- **Per-chat preference** stored as a JSON file under `<stateDir>/telegram/image-quality/<account>/<chatId>.json`, following the existing file-based state pattern (similar to `update-offset-store`, `pairing-store`).
- **Both send paths patched**: `send.ts` (proactive tool calls) and `bot/delivery.ts` (agent reply media).
- **GIFs unaffected** — always sent via `sendAnimation` regardless of quality setting, preserving auto-play behavior.
- **50MB maxBytes for high mode** — bypasses the default 6MB image cap in `loadWebMedia`, matching Telegram `sendDocument` upload limit.
- **Provider-scoped command** — only registered on Telegram via new `providers` field on `ChatCommandDefinition`, which is a generic mechanism other commands can use in the future.
- **Backward compatible** — default is `normal`, file absence = normal. Zero behavior change for existing users.

### Files Changed (9)

| File | Change |
|------|--------|
| `src/telegram/image-quality-store.ts` | **New** — per-chat quality preference store (read/write/normalize) |
| `src/telegram/send.ts` | Read quality preference; skip optimization + force `sendDocument` when `high`; 50MB cap |
| `src/telegram/bot/delivery.ts` | Same as above for reply delivery path; added `accountId` param; quality read hoisted above media loop |
| `src/telegram/bot-native-commands.ts` | `/imagequality` command handler |
| `src/telegram/bot-message-dispatch.ts` | Pass `accountId` to `deliverReplies` |
| `src/auto-reply/commands-registry.data.ts` | Register `imagequality` command |
| `src/auto-reply/commands-registry.ts` | Filter commands by `providers` field |
| `src/auto-reply/commands-registry.types.ts` | Add `providers?: string[]` to `ChatCommandDefinition` |
| `src/web/media.ts` | Add optional `optimizeImages` param to `loadWebMedia` public API |

### Testing

- `tsc --noEmit` ✅
- `pnpm lint` ✅ (0 errors)
- `pnpm format` ✅
- 57 related tests passing (commands-registry, send, delivery)
- Manual testing: confirmed `sendDocument` delivers uncompressed 4800×13280 PNG via Telegram

### Future Enhancements

This PR establishes the foundation for more granular image quality control. Potential follow-ups:

- **Resolution presets** (`/imagequality 1080p`, `/imagequality 4k`, `/imagequality original`) — resize to specific max dimensions instead of binary compress/raw
- **Per-message override** — `asDocument` parameter on the `message` tool for one-off high-quality sends without changing the default
- **Cross-platform** — extend to WhatsApp (which has similar compression issues) and other channels
- **Config-level default** — `channels.telegram.imageQuality: "high"` for gateway-wide setting

### Related

Closes the image compression quality gap discussed in the community. Telegram's `sendPhoto` compression is a known pain point for users sharing technical diagrams and high-res screenshots.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a `/imagequality` Telegram slash command that lets users toggle between compressed photo delivery (`sendPhoto`, default) and uncompressed document delivery (`sendDocument`) for images. The implementation introduces a generic `providers` field on `ChatCommandDefinition` to scope commands to specific channels.

- New `image-quality-store.ts` provides per-chat quality preferences via file-based JSON state (atomic writes, version-checked reads, path-sanitized IDs), following existing patterns like `pairing-store` and `update-offset-store`
- Both send paths patched: `send.ts` (proactive tool calls) and `bot/delivery.ts` (agent reply media) — each reads the quality preference, disables image optimization when `high`, passes 50MB `maxBytes` for Telegram's `sendDocument` limit, and overrides media kind from `"image"` to `"document"`
- GIFs remain unaffected — `isGif` check takes priority before `kind` routing
- Provider-scoped command filtering added to `listNativeCommandSpecs`, `listNativeCommandSpecsForConfig`, and `findCommandByNativeName` with correct short-circuit logic (no provider = show all, specific provider = filter)
- Backward compatible: default is `normal`, file absence = `normal`, no behavior change for existing users

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — clean implementation following established patterns with no logic errors or regressions.
- All 9 changed files were reviewed thoroughly. The implementation follows existing file-based state patterns, both send paths are correctly patched with proper maxBytes handling (50MB for high-quality mode), the provider-scoping mechanism is correctly implemented with proper filter logic, and the feature is fully backward compatible (default behavior unchanged). The previously flagged 6MB cap issue has been addressed in follow-up commit e4ddffe. No new issues found.
- No files require special attention.

<sub>Last reviewed commit: 9445c77</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->