### PR TITLE
fix(cron): reject past timestamps in createJob (defense-in-depth)

### DIFF
--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -10,6 +10,7 @@ import type {
   CronPayload,
   CronPayloadPatch,
 } from "../types.js";
+import { validateScheduleTimestamp } from "../validate-timestamp.js";
 import { normalizeHttpWebhookUrl } from "../webhook-url.js";
 import {
   normalizeOptionalAgentId,
@@ -278,6 +279,16 @@ export function nextWakeAtMs(state: CronServiceState) {
 
 export function createJob(state: CronServiceState, input: CronJobCreate): CronJob {
   const now = state.deps.nowMs();
+
+  // Defense-in-depth: reject kind="at" schedules with past timestamps.
+  // The gateway already validates via validateScheduleTimestamp, but this
+  // guard catches any code path that bypasses the gateway (e.g. direct
+  // service calls, store migrations, or future internal callers).
+  const tsValidation = validateScheduleTimestamp(input.schedule, now);
+  if (!tsValidation.ok) {
+    throw new Error(tsValidation.message);
+  }
+
   const id = crypto.randomUUID();
   const schedule =
     input.schedule.kind === "every"

--- a/src/cron/validate-timestamp.test.ts
+++ b/src/cron/validate-timestamp.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { validateScheduleTimestamp } from "./validate-timestamp.js";
+import type { CronSchedule } from "./types.js";
+
+describe("validateScheduleTimestamp", () => {
+  const NOW = Date.parse("2026-02-16T20:00:00.000Z");
+
+  it("accepts kind='every' without checking timestamps", () => {
+    const schedule = { kind: "every", everyMs: 60_000 } as CronSchedule;
+    expect(validateScheduleTimestamp(schedule, NOW)).toEqual({ ok: true });
+  });
+
+  it("accepts kind='cron' without checking timestamps", () => {
+    const schedule = { kind: "cron", expr: "0 * * * *" } as CronSchedule;
+    expect(validateScheduleTimestamp(schedule, NOW)).toEqual({ ok: true });
+  });
+
+  it("accepts a future at timestamp", () => {
+    const futureDate = new Date(NOW + 3_600_000).toISOString(); // 1 hour ahead
+    const schedule = { kind: "at", at: futureDate } as CronSchedule;
+    expect(validateScheduleTimestamp(schedule, NOW)).toEqual({ ok: true });
+  });
+
+  it("accepts a timestamp within the 1-minute grace period", () => {
+    const recentPast = new Date(NOW - 30_000).toISOString(); // 30 seconds ago
+    const schedule = { kind: "at", at: recentPast } as CronSchedule;
+    expect(validateScheduleTimestamp(schedule, NOW)).toEqual({ ok: true });
+  });
+
+  it("rejects a timestamp more than 1 minute in the past", () => {
+    const pastDate = new Date(NOW - 120_000).toISOString(); // 2 minutes ago
+    const schedule = { kind: "at", at: pastDate } as CronSchedule;
+    const result = validateScheduleTimestamp(schedule, NOW);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toMatch(/in the past/);
+    }
+  });
+
+  it("rejects a timestamp 1 year in the past (the LLM timestamp bug)", () => {
+    // This is the exact bug: LLM computes Feb 16, 2025 instead of Feb 16, 2026
+    const pastDate = new Date("2025-02-16T20:30:00.000Z").toISOString();
+    const schedule = { kind: "at", at: pastDate } as CronSchedule;
+    const result = validateScheduleTimestamp(schedule, NOW);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toMatch(/in the past/);
+      expect(result.message).toMatch(/minutes ago/);
+    }
+  });
+
+  it("rejects a timestamp more than 10 years in the future", () => {
+    const farFuture = new Date(NOW + 11 * 365.25 * 86_400_000).toISOString();
+    const schedule = { kind: "at", at: farFuture } as CronSchedule;
+    const result = validateScheduleTimestamp(schedule, NOW);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toMatch(/too far in the future/);
+    }
+  });
+
+  it("rejects an invalid at value", () => {
+    const schedule = { kind: "at", at: "not-a-date" } as CronSchedule;
+    const result = validateScheduleTimestamp(schedule, NOW);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toMatch(/Invalid schedule\.at/i);
+    }
+  });
+
+  it("rejects missing at field on kind='at'", () => {
+    const schedule = { kind: "at" } as CronSchedule;
+    const result = validateScheduleTimestamp(schedule, NOW);
+    expect(result.ok).toBe(false);
+  });
+
+  it("uses Date.now() as default when nowMs not provided", () => {
+    const farFuture = new Date(Date.now() + 3_600_000).toISOString();
+    const schedule = { kind: "at", at: farFuture } as CronSchedule;
+    // Should use Date.now() internally and accept the future timestamp
+    expect(validateScheduleTimestamp(schedule)).toEqual({ ok: true });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `validateScheduleTimestamp()` call inside `createJob()` as a defense-in-depth guard against `kind="at"` schedules with past timestamps
- The gateway already validates at the API level, but this catches any code path that bypasses the gateway (direct service calls, store migrations, future internal callers)
- Adds comprehensive test suite for `validateScheduleTimestamp` covering 9 scenarios including the LLM timestamp bug (wrong year computation)

### Context

We discovered that LLMs (particularly smaller models) frequently compute incorrect Unix timestamps when creating `kind="at"` cron jobs — often off by ~1 year. While the gateway-level validation in `src/gateway/server-methods/cron.ts` catches this for normal API calls, `createJob()` itself had no validation, leaving internal callers unprotected.

## Test plan

- [x] 9 new test cases in `src/cron/validate-timestamp.test.ts`
- [ ] Existing cron tests still pass
- [ ] `validateScheduleTimestamp` correctly rejects past timestamps (>1 min grace)
- [ ] `validateScheduleTimestamp` correctly rejects far-future timestamps (>10 years)
- [ ] `validateScheduleTimestamp` passes through `kind="every"` and `kind="cron"` without checking timestamps
- [ ] Error messages are descriptive and actionable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds defense-in-depth validation to reject `kind="at"` cron schedules with past timestamps directly in `createJob()`. The gateway already validates at the API level (`src/gateway/server-methods/cron.ts:87`), but this additional guard protects against direct service calls, store migrations, or future internal callers that might bypass the gateway. Includes comprehensive test suite covering edge cases including the LLM year-computation bug.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes follow defense-in-depth security principles by adding validation at the service layer. The implementation is straightforward, error messages are clear and actionable, and test coverage is comprehensive with 9 test cases covering all edge cases including the specific LLM timestamp bug mentioned in the PR description.
- No files require special attention

<sub>Last reviewed commit: cb1476f</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->