### PR TITLE
fix(nextcloud-talk): replace console.log with runtime logging

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -43,13 +43,18 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       if (!replyToMessageId) {
         return;
       }
-      typingState = await addTypingIndicator({ cfg, messageId: replyToMessageId, accountId });
+      typingState = await addTypingIndicator({
+        cfg,
+        messageId: replyToMessageId,
+        accountId,
+        runtime: params.runtime,
+      });
     },
     stop: async () => {
       if (!typingState) {
         return;
       }
-      await removeTypingIndicator({ cfg, state: typingState, accountId });
+      await removeTypingIndicator({ cfg, state: typingState, accountId, runtime: params.runtime });
       typingState = null;
     },
     onStartError: (err) =>

--- a/extensions/feishu/src/typing.ts
+++ b/extensions/feishu/src/typing.ts
@@ -1,6 +1,7 @@
-import type { ClawdbotConfig } from "openclaw/plugin-sdk";
+import type { ClawdbotConfig, RuntimeEnv } from "openclaw/plugin-sdk";
 import { resolveFeishuAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
+import { getFeishuRuntime } from "./runtime.js";
 
 // Feishu emoji types for typing indicator
 // See: https://open.feishu.cn/document/server-docs/im-v1/message-reaction/emojis-introduce
@@ -19,8 +20,9 @@ export async function addTypingIndicator(params: {
   cfg: ClawdbotConfig;
   messageId: string;
   accountId?: string;
+  runtime?: RuntimeEnv;
 }): Promise<TypingIndicatorState> {
-  const { cfg, messageId, accountId } = params;
+  const { cfg, messageId, accountId, runtime } = params;
   const account = resolveFeishuAccount({ cfg, accountId });
   if (!account.configured) {
     return { messageId, reactionId: null };
@@ -41,7 +43,9 @@ export async function addTypingIndicator(params: {
     return { messageId, reactionId };
   } catch (err) {
     // Silently fail - typing indicator is not critical
-    console.log(`[feishu] failed to add typing indicator: ${err}`);
+    if (getFeishuRuntime().logging.shouldLogVerbose()) {
+      runtime?.log?.(`[feishu] failed to add typing indicator: ${String(err)}`);
+    }
     return { messageId, reactionId: null };
   }
 }
@@ -53,8 +57,9 @@ export async function removeTypingIndicator(params: {
   cfg: ClawdbotConfig;
   state: TypingIndicatorState;
   accountId?: string;
+  runtime?: RuntimeEnv;
 }): Promise<void> {
-  const { cfg, state, accountId } = params;
+  const { cfg, state, accountId, runtime } = params;
   if (!state.reactionId) {
     return;
   }
@@ -75,6 +80,8 @@ export async function removeTypingIndicator(params: {
     });
   } catch (err) {
     // Silently fail - cleanup is not critical
-    console.log(`[feishu] failed to remove typing indicator: ${err}`);
+    if (getFeishuRuntime().logging.shouldLogVerbose()) {
+      runtime?.log?.(`[feishu] failed to remove typing indicator: ${String(err)}`);
+    }
   }
 }

--- a/extensions/nextcloud-talk/src/channel.ts
+++ b/extensions/nextcloud-talk/src/channel.ts
@@ -56,7 +56,9 @@ export const nextcloudTalkPlugin: ChannelPlugin<ResolvedNextcloudTalkAccount> = 
     normalizeAllowEntry: (entry) =>
       entry.replace(/^(nextcloud-talk|nc-talk|nc):/i, "").toLowerCase(),
     notifyApproval: async ({ id }) => {
-      console.log(`[nextcloud-talk] User ${id} approved for pairing`);
+      getNextcloudTalkRuntime()
+        .logging.getChildLogger()
+        .info(`[nextcloud-talk] User ${id} approved for pairing`);
     },
   },
   capabilities: {

--- a/extensions/nextcloud-talk/src/send.ts
+++ b/extensions/nextcloud-talk/src/send.ts
@@ -156,8 +156,10 @@ export async function sendMessageNextcloudTalk(
     // Response parsing failed, but message was sent.
   }
 
-  if (opts.verbose) {
-    console.log(`[nextcloud-talk] Sent message ${messageId} to room ${roomToken}`);
+  if (opts.verbose || getNextcloudTalkRuntime().logging.shouldLogVerbose()) {
+    getNextcloudTalkRuntime()
+      .logging.getChildLogger()
+      .info(`[nextcloud-talk] Sent message ${messageId} to room ${roomToken}`);
   }
 
   getNextcloudTalkRuntime().channel.activity.record({

--- a/extensions/zalo/src/monitor.ts
+++ b/extensions/zalo/src/monitor.ts
@@ -218,7 +218,7 @@ function startPollingLoop(params: {
       if (err instanceof ZaloApiError && err.isPollingTimeout) {
         // no updates
       } else if (!isStopped() && !abortSignal.aborted) {
-        console.error(`[${account.accountId}] Zalo polling error:`, err);
+        runtime.error?.(`[${account.accountId}] Zalo polling error: ${String(err)}`);
         await new Promise((resolve) => setTimeout(resolve, 5000));
       }
     }
@@ -265,10 +265,12 @@ async function processUpdate(
       );
       break;
     case "message.sticker.received":
-      console.log(`[${account.accountId}] Received sticker from ${message.from.id}`);
+      logVerbose(core, runtime, `[${account.accountId}] Received sticker from ${message.from.id}`);
       break;
     case "message.unsupported.received":
-      console.log(
+      logVerbose(
+        core,
+        runtime,
         `[${account.accountId}] Received unsupported message type from ${message.from.id}`,
       );
       break;
@@ -334,7 +336,7 @@ async function handleImageMessage(
       mediaPath = saved.path;
       mediaType = saved.contentType;
     } catch (err) {
-      console.error(`[${account.accountId}] Failed to download Zalo image:`, err);
+      runtime.error?.(`[${account.accountId}] Failed to download Zalo image: ${String(err)}`);
     }
   }
 


### PR DESCRIPTION
Operational logs (pairing approval, verbose send) were using console.log, which bypasses the structured logger.

Fix: Replace console.log with runtime.logging.getChildLogger().info() and respect verbose configuration.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

replaces `console.log`/`console.error` with structured runtime logging across nextcloud-talk, feishu, and zalo extensions to respect verbose configuration and maintain consistent log formatting.

- nextcloud-talk: replaced pairing approval and verbose send logs with `getNextcloudTalkRuntime().logging.getChildLogger().info()`
- feishu: added verbose check before typing indicator error logs (but has runtime reference issue - see comments)
- zalo: replaced error logs with `runtime.error?.()` and created `logVerbose` helper for consistent verbose logging

**issue**: feishu implementation mixes `getFeishuRuntime()` for verbose checks with `runtime?.log` parameter for actual logging, which references different runtime instances

<h3>Confidence Score: 2/5</h3>

- contains logic error in feishu that will likely cause runtime issues
- the feishu typing.ts has a critical bug where it checks verbose logging on one runtime instance but attempts to log to a different runtime parameter that may be undefined, causing the verbose check to be ineffective or logs to be lost
- `extensions/feishu/src/typing.ts` needs fixing before merge

<sub>Last reviewed commit: fc86ef7</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->