### PR TITLE
fix(signal): add per-group configuration schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ Docs: https://docs.openclaw.ai
 - Heartbeat: allow suppressing tool error warning payloads during heartbeat runs via a new heartbeat config flag. (#18497) Thanks @thewilloftheshadow.
 - Heartbeat: include sender metadata (From/To/Provider) in heartbeat prompts so model context matches the delivery target. (#18532) Thanks @dinakars777.
 - Heartbeat/Telegram: strip configured `responsePrefix` before heartbeat ack detection (with boundary-safe matching) so prefixed `HEARTBEAT_OK` replies are correctly suppressed instead of leaking into DMs. (#18602)
+- Signal: add per-group configuration schema (`channels.signal.groups`) matching Telegram/iMessage/WhatsApp patterns, so `requireMention`, `tools`, `skills`, `allowFrom`, `enabled`, and `systemPrompt` can be set per group. (#18635)
 
 ## 2026.2.15
 

--- a/extensions/mattermost/src/mattermost/monitor-websocket.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-websocket.test.ts
@@ -185,6 +185,9 @@ describe("mattermost websocket monitor", () => {
       webSocketFactory: () => socket,
     });
 
+    // Start connectOnce so listeners are registered before emitting events
+    const promise = connectOnce();
+
     socket.emitOpen();
     socket.emitMessage(
       Buffer.from(
@@ -202,7 +205,7 @@ describe("mattermost websocket monitor", () => {
     );
     socket.emitClose(1000);
 
-    await connectOnce();
+    await promise;
 
     expect(onReaction).toHaveBeenCalledTimes(1);
     expect(onPosted).not.toHaveBeenCalled();

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -36,4 +36,58 @@ describe("config schema regressions", () => {
 
     expect(res.ok).toBe(true);
   });
+
+  it("accepts signal groups with per-group config (#18635)", () => {
+    const res = validateConfigObject({
+      channels: {
+        signal: {
+          groupPolicy: "open",
+          groups: {
+            "*": {
+              requireMention: false,
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("accepts signal groups with full per-group overrides", () => {
+    const res = validateConfigObject({
+      channels: {
+        signal: {
+          groupPolicy: "allowlist",
+          groups: {
+            "group-abc-123": {
+              requireMention: true,
+              enabled: true,
+              allowFrom: ["+1234567890"],
+              skills: ["memory"],
+              systemPrompt: "You are a helpful assistant.",
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("rejects signal groups with unknown fields", () => {
+    const res = validateConfigObject({
+      channels: {
+        signal: {
+          groups: {
+            "group-1": {
+              unknownField: true,
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(false);
+  });
 });

--- a/src/config/types.signal.ts
+++ b/src/config/types.signal.ts
@@ -6,6 +6,22 @@ import type {
 } from "./types.base.js";
 import type { ChannelHeartbeatVisibilityConfig } from "./types.channels.js";
 import type { DmConfig } from "./types.messages.js";
+import type { GroupToolPolicyBySenderConfig, GroupToolPolicyConfig } from "./types.tools.js";
+
+export type SignalGroupConfig = {
+  requireMention?: boolean;
+  /** Optional tool policy overrides for this group. */
+  tools?: GroupToolPolicyConfig;
+  toolsBySender?: GroupToolPolicyBySenderConfig;
+  /** If specified, only load these skills for this group. Omit = all skills; empty = no skills. */
+  skills?: string[];
+  /** If false, disable the bot for this group. */
+  enabled?: boolean;
+  /** Optional allowlist for group senders (E.164 numbers). */
+  allowFrom?: Array<string | number>;
+  /** Optional system prompt snippet for this group. */
+  systemPrompt?: string;
+};
 
 export type SignalReactionNotificationMode = "off" | "own" | "all" | "allowlist";
 export type SignalReactionLevel = "off" | "ack" | "minimal" | "extensive";
@@ -51,6 +67,8 @@ export type SignalAccountConfig = {
    * - "allowlist": only allow group messages from senders in groupAllowFrom/allowFrom
    */
   groupPolicy?: GroupPolicy;
+  /** Per-group configuration overrides keyed by group ID. */
+  groups?: Record<string, SignalGroupConfig>;
   /** Max group messages to keep as history context (0 disables). */
   historyLimit?: number;
   /** Max DM turns to keep as history context. */

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -662,6 +662,23 @@ export const SignalAccountSchemaBase = z
     allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
     groupAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
     groupPolicy: GroupPolicySchema.optional().default("allowlist"),
+    groups: z
+      .record(
+        z.string(),
+        z
+          .object({
+            requireMention: z.boolean().optional(),
+            tools: ToolPolicySchema,
+            toolsBySender: ToolPolicyBySenderSchema,
+            skills: z.array(z.string()).optional(),
+            enabled: z.boolean().optional(),
+            allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+            systemPrompt: z.string().optional(),
+          })
+          .strict()
+          .optional(),
+      )
+      .optional(),
     historyLimit: z.number().int().min(0).optional(),
     dmHistoryLimit: z.number().int().min(0).optional(),
     dms: z.record(z.string(), DmConfigSchema.optional()).optional(),


### PR DESCRIPTION
## Summary

- Problem: Signal channel config schema is missing the `groups` field that exists in Telegram, WhatsApp, iMessage, and IRC. Valid config like `channels.signal.groups.*.requireMention` is rejected with "Unrecognized key: groups".
- Why it matters: Users cannot configure per-group settings (requireMention, tools, skills, allowFrom, etc.) for Signal groups, even though the runtime code supports it.
- What changed: Added `SignalGroupConfig` type and `groups` record field to both the Zod validation schema and TypeScript type definitions, matching the pattern used by other channels.
- What did NOT change (scope boundary): No runtime behavior changes — only schema validation is affected. The runtime already supports per-group config when manually patched.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #18635

## User-visible / Behavior Changes

Signal channel now accepts `groups` configuration in `openclaw.json`:
```json
{
  "channels": {
    "signal": {
      "groupPolicy": "open",
      "groups": {
        "*": { "requireMention": false }
      }
    }
  }
}
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Any
- Runtime/container: Node
- Integration/channel: Signal

### Steps

1. Add `channels.signal.groups` config to `openclaw.json`
2. Run `openclaw status` or any command
3. Previously: "Unrecognized key: groups" error
4. Now: Config accepted

### Expected

Config is accepted without validation errors.

### Actual (before fix)

`channels.signal: Unrecognized key: "groups"` error.

## Evidence

- [x] Failing test/log before + passing after

3 new schema regression tests added:
- `accepts signal groups with per-group config (#18635)` — basic wildcard group
- `accepts signal groups with full per-group overrides` — all supported fields
- `rejects signal groups with unknown fields` — strict mode validation

## Human Verification (required)

- Verified scenarios: Schema accepts valid group configs, rejects unknown fields
- Edge cases checked: Wildcard `*` group, named groups, empty groups record, strict mode
- What you did **not** verify: Runtime behavior (runtime already supports groups when schema is patched — confirmed by issue reporter)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No (additive only)
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit
- Files/config to restore: `src/config/types.signal.ts`, `src/config/zod-schema.providers-core.ts`
- Known bad symptoms: Signal group config rejected by schema validation (same as before this fix)

## Risks and Mitigations

None — additive schema change only, matching existing patterns used by Telegram/iMessage/WhatsApp/IRC.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds the missing `groups` field to the Signal channel's Zod validation schema and TypeScript type definitions, fixing #18635. This is a strictly additive schema change that allows per-group configuration overrides (`requireMention`, `tools`, `toolsBySender`, `skills`, `enabled`, `allowFrom`, `systemPrompt`) for Signal groups — matching the existing pattern used by Telegram, iMessage, WhatsApp, IRC, and BlueBubbles channels.

- Added `SignalGroupConfig` type in `types.signal.ts` with proper imports from `types.tools.js`
- Added `groups` Zod record field to `SignalAccountSchemaBase` in `zod-schema.providers-core.ts` with `.strict()` validation
- Added 3 regression tests covering wildcard groups, full overrides, and strict-mode rejection
- Added changelog entry under the unreleased Fixes section
- No runtime behavior changes — the runtime (`group-policy.ts`) already resolves `cfg.channels.[channel].groups` generically

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is an additive schema-only change that follows established patterns with no runtime behavior modifications.
- The change adds a `groups` field to Signal's config schema, exactly mirroring the pattern already used by Telegram, IRC, iMessage, WhatsApp, and BlueBubbles. The Zod schema fields match the TypeScript type definition. All fields use existing, well-tested schema types (ToolPolicySchema, ToolPolicyBySenderSchema). The `.strict()` validator ensures unknown fields are rejected. Three regression tests validate acceptance and rejection. The runtime group resolution code in `group-policy.ts` already handles generic `cfg.channels.[channel].groups` lookups, so no runtime changes were needed.
- No files require special attention.

<sub>Last reviewed commit: 80cf554</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->