### PR TITLE
fix: route slug generator LLM call through configured provider

### DIFF
--- a/src/hooks/llm-slug-generator.ts
+++ b/src/hooks/llm-slug-generator.ts
@@ -38,6 +38,14 @@ ${params.sessionContent.slice(0, 2000)}
 
 Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", "bug-fix"`;
 
+    // Extract provider and model from the primary model config (e.g. "litellm/claude-opus-4-6")
+    // so the embedded agent routes through the correct provider instead of attempting
+    // a direct Anthropic call (which fails without an API key).
+    const primaryModel = params.cfg?.agents?.defaults?.model?.primary ?? "";
+    const slashIdx = primaryModel.indexOf("/");
+    const slugProvider = slashIdx > 0 ? primaryModel.slice(0, slashIdx) : undefined;
+    const slugModelId = slashIdx > 0 ? primaryModel.slice(slashIdx + 1) : undefined;
+
     const result = await runEmbeddedPiAgent({
       sessionId: `slug-generator-${Date.now()}`,
       sessionKey: "temp:slug-generator",
@@ -47,6 +55,8 @@ Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", 
       agentDir,
       config: params.cfg,
       prompt,
+      provider: slugProvider,
+      model: slugModelId,
       timeoutMs: 15_000, // 15 second timeout
       runId: `slug-gen-${Date.now()}`,
     });


### PR DESCRIPTION
## Problem

`generateSlugViaLLM()` calls `runEmbeddedPiAgent()` without passing `provider` or `model`, so the embedded agent defaults to a direct Anthropic API call. For users routing through LiteLLM (or other proxies), this silently fails — no API key for Anthropic — and every session falls back to a timestamp slug (e.g. `0231`) instead of a descriptive one (e.g. `slug-bug`).

## Fix

Extract the provider and model from `agents.defaults.model.primary` (e.g. `litellm/claude-opus-4-6` → provider `litellm`, model `claude-opus-4-6`) and pass them to `runEmbeddedPiAgent()`. This ensures the slug generator uses the same model routing as the rest of the app.

## Testing

Before fix: every `/new` produced timestamp slugs (`2026-02-17-0210.md`, `2026-02-17-0220.md`, etc.)
After fix: `/new` produces descriptive slugs (`2026-02-17-slug-bug.md`)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes slug generation for users routing LLM calls through LiteLLM or other proxies by extracting provider and model from `agents.defaults.model.primary` and passing them to `runEmbeddedPiAgent()`. Without this fix, the slug generator defaults to direct Anthropic API calls, which fail for proxy users without Anthropic keys, resulting in timestamp-based slugs instead of descriptive ones.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk
- The fix correctly addresses the root cause by extracting provider/model from config and passing to the embedded agent. The parsing logic is sound (using indexOf + slice), though it differs from the existing splitModelRef utility in subagent-spawn.ts. The fallback behavior (undefined when no slash found) matches the function signature expectations.
- No files require special attention

<sub>Last reviewed commit: 15e3c16</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->