### PR TITLE
fix(cli): respect git tags when resolving default update channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/Update: use `resolveEffectiveUpdateChannel()` so git-installed users on a release tag default to `stable` instead of `dev`, preventing unintended jumps to unreleased code. (#18702)
 - Voice-call: auto-end calls when media streams disconnect to prevent stuck active calls. (#18435) Thanks @JayMishra-source.
 - Gateway/Channels: wire `gateway.channelHealthCheckMinutes` into strict config validation, treat implicit account status as managed for health checks, and harden channel auto-restart flow (preserve restart-attempt caps across crash loops, propagate enabled/configured runtime flags, and stop pending restart backoff after manual stop). Thanks @steipete.
 - Gateway/WebChat: hard-cap `chat.history` oversized payloads by truncating high-cost fields and replacing over-budget entries with placeholders, so history fetches stay within configured byte limits and avoid chat UI freezes. (#18505)

--- a/extensions/mattermost/src/mattermost/monitor-websocket.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-websocket.test.ts
@@ -185,6 +185,9 @@ describe("mattermost websocket monitor", () => {
       webSocketFactory: () => socket,
     });
 
+    // Start connectOnce so listeners are registered before emitting events
+    const promise = connectOnce();
+
     socket.emitOpen();
     socket.emitMessage(
       Buffer.from(
@@ -202,7 +205,7 @@ describe("mattermost websocket monitor", () => {
     );
     socket.emitClose(1000);
 
-    await connectOnce();
+    await promise;
 
     expect(onReaction).toHaveBeenCalledTimes(1);
     expect(onPosted).not.toHaveBeenCalled();

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -312,7 +312,43 @@ describe("update-cli", () => {
     expect(parsed.channel.value).toBe("stable");
   });
 
-  it("defaults to dev channel for git installs when unset", async () => {
+  it("defaults to stable channel for tagged git installs when unset", async () => {
+    vi.mocked(runGatewayUpdate).mockResolvedValue({
+      status: "ok",
+      mode: "git",
+      steps: [],
+      durationMs: 100,
+    });
+
+    await updateCommand({});
+
+    const call = vi.mocked(runGatewayUpdate).mock.calls[0]?.[0];
+    expect(call?.channel).toBe("stable");
+  });
+
+  it("defaults to dev channel for untagged git branch installs", async () => {
+    vi.mocked(checkUpdateStatus).mockResolvedValue({
+      root: "/test/path",
+      installKind: "git",
+      packageManager: "pnpm",
+      git: {
+        root: "/test/path",
+        sha: "abcdef1234567890",
+        tag: null,
+        branch: "main",
+        upstream: "origin/main",
+        dirty: false,
+        ahead: 0,
+        behind: 0,
+        fetchOk: true,
+      },
+      deps: {
+        manager: "pnpm",
+        status: "ok",
+        lockfilePath: "/test/path/pnpm-lock.yaml",
+        markerPath: "/test/path/node_modules",
+      },
+    });
     vi.mocked(runGatewayUpdate).mockResolvedValue({
       status: "ok",
       mode: "git",
@@ -324,6 +360,42 @@ describe("update-cli", () => {
 
     const call = vi.mocked(runGatewayUpdate).mock.calls[0]?.[0];
     expect(call?.channel).toBe("dev");
+  });
+
+  it("defaults to beta channel for beta-tagged git installs", async () => {
+    vi.mocked(checkUpdateStatus).mockResolvedValue({
+      root: "/test/path",
+      installKind: "git",
+      packageManager: "pnpm",
+      git: {
+        root: "/test/path",
+        sha: "abcdef1234567890",
+        tag: "v2026.2.15-beta.1",
+        branch: "main",
+        upstream: "origin/main",
+        dirty: false,
+        ahead: 0,
+        behind: 0,
+        fetchOk: true,
+      },
+      deps: {
+        manager: "pnpm",
+        status: "ok",
+        lockfilePath: "/test/path/pnpm-lock.yaml",
+        markerPath: "/test/path/node_modules",
+      },
+    });
+    vi.mocked(runGatewayUpdate).mockResolvedValue({
+      status: "ok",
+      mode: "git",
+      steps: [],
+      durationMs: 100,
+    });
+
+    await updateCommand({});
+
+    const call = vi.mocked(runGatewayUpdate).mock.calls[0]?.[0];
+    expect(call?.channel).toBe("beta");
   });
 
   it("defaults to stable channel for package installs when unset", async () => {

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -9,9 +9,8 @@ import { readConfigFileSnapshot, writeConfigFile } from "../../config/config.js"
 import { resolveGatewayService } from "../../daemon/service.js";
 import {
   channelToNpmTag,
-  DEFAULT_GIT_CHANNEL,
-  DEFAULT_PACKAGE_CHANNEL,
   normalizeUpdateChannel,
+  resolveEffectiveUpdateChannel,
 } from "../../infra/update-channels.js";
 import {
   compareSemverStrings,
@@ -497,8 +496,12 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
   const switchToPackage =
     requestedChannel !== null && requestedChannel !== "dev" && installKind === "git";
   const updateInstallKind = switchToGit ? "git" : switchToPackage ? "package" : installKind;
-  const defaultChannel =
-    updateInstallKind === "git" ? DEFAULT_GIT_CHANNEL : DEFAULT_PACKAGE_CHANNEL;
+  const { channel: defaultChannel } = resolveEffectiveUpdateChannel({
+    installKind: updateInstallKind,
+    git: updateStatus.git
+      ? { tag: updateStatus.git.tag, branch: updateStatus.git.branch }
+      : undefined,
+  });
   const channel = requestedChannel ?? storedChannel ?? defaultChannel;
 
   const explicitTag = normalizeTag(opts.tag);


### PR DESCRIPTION
## Summary
<!-- One-liner: what and why -->
`openclaw update` on a git install always defaulted to the `dev` channel (pulling from `main`) even when checked out to a release tag like `v2026.2.15`. This caused users on stable releases to unexpectedly jump to unreleased code.

## Problem
In `update-command.ts`, the default channel was hardcoded:
```typescript
const defaultChannel =
  updateInstallKind === "git" ? DEFAULT_GIT_CHANNEL : DEFAULT_PACKAGE_CHANNEL;
```
This ignored the current git state entirely. Meanwhile, `resolveEffectiveUpdateChannel()` in `update-channels.ts` already knew how to detect tags and branches but wasn't used here.

## Solution
Replace the hardcoded `DEFAULT_GIT_CHANNEL` fallback with `resolveEffectiveUpdateChannel()`, matching the pattern already used in `wizard.ts`. Now:
- Git install on release tag (e.g. `v2026.2.15`) → defaults to `stable`
- Git install on beta tag (e.g. `v2026.2.15-beta.1`) → defaults to `beta`
- Git install on branch (no tag) → defaults to `dev`

## Changes
- `src/cli/update-cli/update-command.ts` — use `resolveEffectiveUpdateChannel()` instead of `DEFAULT_GIT_CHANNEL`
- `src/cli/update-cli.test.ts` — update existing test expectation for tagged git installs, add tests for branch-only and beta-tagged installs

## Test plan
- [x] Existing test updated: tagged git install now expects `stable` (was `dev`)
- [x] New test: untagged branch-only git install defaults to `dev`
- [x] New test: beta-tagged git install defaults to `beta`
- [x] All 23 update-cli tests pass
- [x] `pnpm build` passes

Closes #18702

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaced hardcoded `DEFAULT_GIT_CHANNEL` with `resolveEffectiveUpdateChannel()` in `update-command.ts` to respect git tags when determining default update channel. Now git installs on release tags default to `stable`, beta tags default to `beta`, and untagged branches default to `dev`, preventing users on stable releases from unexpectedly jumping to unreleased code.

- Changed default channel resolution logic in `src/cli/update-cli/update-command.ts:499-504`
- Updated existing test expectation for tagged git installs (now expects `stable` instead of `dev`)
- Added test coverage for untagged branch installs and beta-tagged installs
- Follows the same pattern already used in `wizard.ts`

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no risk
- The fix is straightforward, well-tested, and follows existing patterns. It replaces hardcoded logic with a tested helper function already used elsewhere in the codebase. All three channel resolution scenarios (stable, beta, dev) have test coverage. The change is minimal and focused on the specific bug.
- No files require special attention

<sub>Last reviewed commit: 7f10873</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->