### PR TITLE
fix(cron): set secure file permissions (0o600) on jobs.json

### DIFF
--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -1,9 +1,9 @@
+import JSON5 from "json5";
 import fs from "node:fs";
 import path from "node:path";
-import JSON5 from "json5";
+import type { CronStoreFile } from "./types.js";
 import { expandHomePrefix } from "../infra/home-dir.js";
 import { CONFIG_DIR } from "../utils.js";
-import type { CronStoreFile } from "./types.js";
 
 export const DEFAULT_CRON_DIR = path.join(CONFIG_DIR, "cron");
 export const DEFAULT_CRON_STORE_PATH = path.join(DEFAULT_CRON_DIR, "jobs.json");
@@ -51,10 +51,11 @@ export async function saveCronStore(storePath: string, store: CronStoreFile) {
   await fs.promises.mkdir(path.dirname(storePath), { recursive: true });
   const tmp = `${storePath}.${process.pid}.${Math.random().toString(16).slice(2)}.tmp`;
   const json = JSON.stringify(store, null, 2);
-  await fs.promises.writeFile(tmp, json, "utf-8");
+  await fs.promises.writeFile(tmp, json, { encoding: "utf-8", mode: 0o600 });
   await fs.promises.rename(tmp, storePath);
   try {
     await fs.promises.copyFile(storePath, `${storePath}.bak`);
+    await fs.promises.chmod(`${storePath}.bak`, 0o600);
   } catch {
     // best-effort
   }


### PR DESCRIPTION
Fixes #18866

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enhances security by setting strict file permissions (`0o600`, user-only read/write) on the cron jobs store file (`jobs.json`) and its backup. The change ensures that cron job data—which may contain sensitive information like agent messages, session keys, and delivery configuration—is only accessible to the file owner.

The implementation follows the established pattern used throughout the codebase for sensitive files (credentials, sessions, config files). The atomic write operation now sets `mode: 0o600` when creating the temporary file, and the backup file receives the same permissions via `chmod` after creation.

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no concerns
- The change is a straightforward security improvement that follows the well-established pattern used throughout the codebase for handling sensitive files. The implementation is correct, adds no new logic complexity, and the import reordering is standard formatting cleanup.
- No files require special attention

<sub>Last reviewed commit: b617264</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->