### PR TITLE
fix(voice-call): replace console.log with runtime logging

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -43,13 +43,18 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       if (!replyToMessageId) {
         return;
       }
-      typingState = await addTypingIndicator({ cfg, messageId: replyToMessageId, accountId });
+      typingState = await addTypingIndicator({
+        cfg,
+        messageId: replyToMessageId,
+        accountId,
+        runtime: params.runtime,
+      });
     },
     stop: async () => {
       if (!typingState) {
         return;
       }
-      await removeTypingIndicator({ cfg, state: typingState, accountId });
+      await removeTypingIndicator({ cfg, state: typingState, accountId, runtime: params.runtime });
       typingState = null;
     },
     onStartError: (err) =>

--- a/extensions/feishu/src/typing.ts
+++ b/extensions/feishu/src/typing.ts
@@ -1,6 +1,7 @@
-import type { ClawdbotConfig } from "openclaw/plugin-sdk";
+import type { ClawdbotConfig, RuntimeEnv } from "openclaw/plugin-sdk";
 import { resolveFeishuAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
+import { getFeishuRuntime } from "./runtime.js";
 
 // Feishu emoji types for typing indicator
 // See: https://open.feishu.cn/document/server-docs/im-v1/message-reaction/emojis-introduce
@@ -19,8 +20,9 @@ export async function addTypingIndicator(params: {
   cfg: ClawdbotConfig;
   messageId: string;
   accountId?: string;
+  runtime?: RuntimeEnv;
 }): Promise<TypingIndicatorState> {
-  const { cfg, messageId, accountId } = params;
+  const { cfg, messageId, accountId, runtime } = params;
   const account = resolveFeishuAccount({ cfg, accountId });
   if (!account.configured) {
     return { messageId, reactionId: null };
@@ -41,7 +43,9 @@ export async function addTypingIndicator(params: {
     return { messageId, reactionId };
   } catch (err) {
     // Silently fail - typing indicator is not critical
-    console.log(`[feishu] failed to add typing indicator: ${err}`);
+    if (getFeishuRuntime().logging.shouldLogVerbose()) {
+      runtime?.log?.(`[feishu] failed to add typing indicator: ${String(err)}`);
+    }
     return { messageId, reactionId: null };
   }
 }
@@ -53,8 +57,9 @@ export async function removeTypingIndicator(params: {
   cfg: ClawdbotConfig;
   state: TypingIndicatorState;
   accountId?: string;
+  runtime?: RuntimeEnv;
 }): Promise<void> {
-  const { cfg, state, accountId } = params;
+  const { cfg, state, accountId, runtime } = params;
   if (!state.reactionId) {
     return;
   }
@@ -75,6 +80,8 @@ export async function removeTypingIndicator(params: {
     });
   } catch (err) {
     // Silently fail - cleanup is not critical
-    console.log(`[feishu] failed to remove typing indicator: ${err}`);
+    if (getFeishuRuntime().logging.shouldLogVerbose()) {
+      runtime?.log?.(`[feishu] failed to remove typing indicator: ${String(err)}`);
+    }
   }
 }

--- a/extensions/nextcloud-talk/src/channel.ts
+++ b/extensions/nextcloud-talk/src/channel.ts
@@ -56,7 +56,9 @@ export const nextcloudTalkPlugin: ChannelPlugin<ResolvedNextcloudTalkAccount> = 
     normalizeAllowEntry: (entry) =>
       entry.replace(/^(nextcloud-talk|nc-talk|nc):/i, "").toLowerCase(),
     notifyApproval: async ({ id }) => {
-      console.log(`[nextcloud-talk] User ${id} approved for pairing`);
+      getNextcloudTalkRuntime()
+        .logging.getChildLogger()
+        .info(`[nextcloud-talk] User ${id} approved for pairing`);
     },
   },
   capabilities: {

--- a/extensions/nextcloud-talk/src/send.ts
+++ b/extensions/nextcloud-talk/src/send.ts
@@ -156,8 +156,10 @@ export async function sendMessageNextcloudTalk(
     // Response parsing failed, but message was sent.
   }
 
-  if (opts.verbose) {
-    console.log(`[nextcloud-talk] Sent message ${messageId} to room ${roomToken}`);
+  if (opts.verbose || getNextcloudTalkRuntime().logging.shouldLogVerbose()) {
+    getNextcloudTalkRuntime()
+      .logging.getChildLogger()
+      .info(`[nextcloud-talk] Sent message ${messageId} to room ${roomToken}`);
   }
 
   getNextcloudTalkRuntime().channel.activity.record({

--- a/extensions/voice-call/src/manager.test.ts
+++ b/extensions/voice-call/src/manager.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { VoiceCallConfigSchema } from "./config.js";
 import { CallManager } from "./manager.js";
+import type { Logger } from "./manager/context.js";
 import type { VoiceCallProvider } from "./providers/base.js";
 import type {
   HangupCallInput,
@@ -40,6 +41,12 @@ class FakeProvider implements VoiceCallProvider {
   async stopListening(_input: StopListeningInput): Promise<void> {}
 }
 
+const logger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+} as unknown as Logger;
+
 describe("CallManager", () => {
   it("upgrades providerCallId mapping when provider ID changes", async () => {
     const config = VoiceCallConfigSchema.parse({
@@ -49,7 +56,7 @@ describe("CallManager", () => {
     });
 
     const storePath = path.join(os.tmpdir(), `openclaw-voice-call-test-${Date.now()}`);
-    const manager = new CallManager(config, storePath);
+    const manager = new CallManager(config, logger, storePath);
     manager.initialize(new FakeProvider(), "https://example.com/voice/webhook");
 
     const { callId, success, error } = await manager.initiateCall("+15550000001");
@@ -83,7 +90,7 @@ describe("CallManager", () => {
 
     const storePath = path.join(os.tmpdir(), `openclaw-voice-call-test-${Date.now()}`);
     const provider = new FakeProvider();
-    const manager = new CallManager(config, storePath);
+    const manager = new CallManager(config, logger, storePath);
     manager.initialize(provider, "https://example.com/voice/webhook");
 
     const { callId, success } = await manager.initiateCall("+15550000002", undefined, {
@@ -117,7 +124,7 @@ describe("CallManager", () => {
 
     const storePath = path.join(os.tmpdir(), `openclaw-voice-call-test-${Date.now()}`);
     const provider = new FakeProvider();
-    const manager = new CallManager(config, storePath);
+    const manager = new CallManager(config, logger, storePath);
     manager.initialize(provider, "https://example.com/voice/webhook");
 
     manager.processEvent({
@@ -146,7 +153,7 @@ describe("CallManager", () => {
 
     const storePath = path.join(os.tmpdir(), `openclaw-voice-call-test-${Date.now()}`);
     const provider = new FakeProvider();
-    const manager = new CallManager(config, storePath);
+    const manager = new CallManager(config, logger, storePath);
     manager.initialize(provider, "https://example.com/voice/webhook");
 
     manager.processEvent({
@@ -176,7 +183,7 @@ describe("CallManager", () => {
 
     const storePath = path.join(os.tmpdir(), `openclaw-voice-call-test-${Date.now()}`);
     const provider = new FakeProvider();
-    const manager = new CallManager(config, storePath);
+    const manager = new CallManager(config, logger, storePath);
     manager.initialize(provider, "https://example.com/voice/webhook");
 
     manager.processEvent({
@@ -205,7 +212,7 @@ describe("CallManager", () => {
 
     const storePath = path.join(os.tmpdir(), `openclaw-voice-call-test-${Date.now()}`);
     const provider = new FakeProvider();
-    const manager = new CallManager(config, storePath);
+    const manager = new CallManager(config, logger, storePath);
     manager.initialize(provider, "https://example.com/voice/webhook");
 
     manager.processEvent({
@@ -245,7 +252,7 @@ describe("CallManager", () => {
     });
 
     const storePath = path.join(os.tmpdir(), `openclaw-voice-call-test-${Date.now()}`);
-    const manager = new CallManager(config, storePath);
+    const manager = new CallManager(config, logger, storePath);
     manager.initialize(new FakeProvider(), "https://example.com/voice/webhook");
 
     manager.processEvent({

--- a/extensions/voice-call/src/manager.ts
+++ b/extensions/voice-call/src/manager.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { VoiceCallConfig } from "./config.js";
-import type { CallManagerContext } from "./manager/context.js";
+import type { CallManagerContext, Logger } from "./manager/context.js";
 import { processEvent as processManagerEvent } from "./manager/events.js";
 import { getCallByProviderCallId as getCallByProviderCallIdFromMaps } from "./manager/lookup.js";
 import {
@@ -46,6 +46,7 @@ export class CallManager {
   private provider: VoiceCallProvider | null = null;
   private config: VoiceCallConfig;
   private storePath: string;
+  private logger: Logger;
   private webhookUrl: string | null = null;
   private transcriptWaiters = new Map<
     CallId,
@@ -57,8 +58,9 @@ export class CallManager {
   >();
   private maxDurationTimers = new Map<CallId, NodeJS.Timeout>();
 
-  constructor(config: VoiceCallConfig, storePath?: string) {
+  constructor(config: VoiceCallConfig, logger: Logger, storePath?: string) {
     this.config = config;
+    this.logger = logger;
     this.storePath = resolveDefaultStoreBase(config, storePath);
   }
 
@@ -137,6 +139,7 @@ export class CallManager {
       config: this.config,
       storePath: this.storePath,
       webhookUrl: this.webhookUrl,
+      logger: this.logger,
       transcriptWaiters: this.transcriptWaiters,
       maxDurationTimers: this.maxDurationTimers,
       onCallAnswered: (call) => {

--- a/extensions/voice-call/src/manager/context.ts
+++ b/extensions/voice-call/src/manager/context.ts
@@ -16,11 +16,19 @@ export type CallManagerRuntimeState = {
   rejectedProviderCallIds: Set<string>;
 };
 
+export type Logger = {
+  info: (message: string) => void;
+  warn: (message: string) => void;
+  error: (message: string) => void;
+  debug?: (message: string) => void;
+};
+
 export type CallManagerRuntimeDeps = {
   provider: VoiceCallProvider | null;
   config: VoiceCallConfig;
   storePath: string;
   webhookUrl: string | null;
+  logger: Logger;
 };
 
 export type CallManagerTransientState = {

--- a/extensions/voice-call/src/manager/events.test.ts
+++ b/extensions/voice-call/src/manager/events.test.ts
@@ -24,6 +24,12 @@ function createContext(overrides: Partial<CallManagerContext> = {}): CallManager
     }),
     storePath,
     webhookUrl: null,
+    logger: {
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      debug: () => {},
+    },
     transcriptWaiters: new Map(),
     maxDurationTimers: new Map(),
     ...overrides,

--- a/extensions/voice-call/src/runtime.ts
+++ b/extensions/voice-call/src/runtime.ts
@@ -124,7 +124,7 @@ export async function createVoiceCallRuntime(params: {
   }
 
   const provider = resolveProvider(config);
-  const manager = new CallManager(config);
+  const manager = new CallManager(config, log);
   const webhookServer = new VoiceCallWebhookServer(config, manager, provider, coreConfig);
 
   const localUrl = await webhookServer.start();

--- a/extensions/zalo/src/monitor.ts
+++ b/extensions/zalo/src/monitor.ts
@@ -218,7 +218,7 @@ function startPollingLoop(params: {
       if (err instanceof ZaloApiError && err.isPollingTimeout) {
         // no updates
       } else if (!isStopped() && !abortSignal.aborted) {
-        console.error(`[${account.accountId}] Zalo polling error:`, err);
+        runtime.error?.(`[${account.accountId}] Zalo polling error: ${String(err)}`);
         await new Promise((resolve) => setTimeout(resolve, 5000));
       }
     }
@@ -265,10 +265,12 @@ async function processUpdate(
       );
       break;
     case "message.sticker.received":
-      console.log(`[${account.accountId}] Received sticker from ${message.from.id}`);
+      logVerbose(core, runtime, `[${account.accountId}] Received sticker from ${message.from.id}`);
       break;
     case "message.unsupported.received":
-      console.log(
+      logVerbose(
+        core,
+        runtime,
         `[${account.accountId}] Received unsupported message type from ${message.from.id}`,
       );
       break;
@@ -334,7 +336,7 @@ async function handleImageMessage(
       mediaPath = saved.path;
       mediaType = saved.contentType;
     } catch (err) {
-      console.error(`[${account.accountId}] Failed to download Zalo image:`, err);
+      runtime.error?.(`[${account.accountId}] Failed to download Zalo image: ${String(err)}`);
     }
   }
 

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -1,9 +1,8 @@
 import { Type } from "@sinclair/typebox";
-import type { OpenClawConfig } from "../../config/config.js";
-import type { AnyAgentTool } from "./common.js";
 import { normalizeGroupActivation } from "../../auto-reply/group-activation.js";
 import { getFollowupQueueDepth, resolveQueueSettings } from "../../auto-reply/reply/queue.js";
 import { buildStatusMessage } from "../../auto-reply/status.js";
+import type { OpenClawConfig } from "../../config/config.js";
 import { loadConfig } from "../../config/config.js";
 import {
   loadSessionStore,
@@ -34,6 +33,7 @@ import {
   resolveDefaultModelForAgent,
   resolveModelRefFromString,
 } from "../model-selection.js";
+import type { AnyAgentTool } from "./common.js";
 import { readStringParam } from "./common.js";
 import {
   shouldResolveSessionIdInput,

--- a/src/agents/tools/telegram-actions.ts
+++ b/src/agents/tools/telegram-actions.ts
@@ -1,7 +1,7 @@
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import type { OpenClawConfig } from "../../config/config.js";
-import type { TelegramButtonStyle, TelegramInlineButtons } from "../../telegram/button-types.js";
 import { createTelegramActionGate } from "../../telegram/accounts.js";
+import type { TelegramButtonStyle, TelegramInlineButtons } from "../../telegram/button-types.js";
 import {
   resolveTelegramInlineButtonsScope,
   resolveTelegramTargetChatType,

--- a/src/auto-reply/reply/commands-status.ts
+++ b/src/auto-reply/reply/commands-status.ts
@@ -1,9 +1,3 @@
-import type { OpenClawConfig } from "../../config/config.js";
-import type { SessionEntry, SessionScope } from "../../config/sessions.js";
-import type { MediaUnderstandingDecision } from "../../media-understanding/types.js";
-import type { ElevatedLevel, ReasoningLevel, ThinkLevel, VerboseLevel } from "../thinking.js";
-import type { ReplyPayload } from "../types.js";
-import type { CommandContext } from "./commands-types.js";
 import {
   resolveAgentDir,
   resolveDefaultAgentId,
@@ -15,14 +9,20 @@ import {
   resolveInternalSessionKey,
   resolveMainSessionAlias,
 } from "../../agents/tools/sessions-helpers.js";
+import type { OpenClawConfig } from "../../config/config.js";
+import type { SessionEntry, SessionScope } from "../../config/sessions.js";
 import { logVerbose } from "../../globals.js";
 import {
   formatUsageWindowSummary,
   loadProviderUsageSummary,
   resolveUsageProviderId,
 } from "../../infra/provider-usage.js";
+import type { MediaUnderstandingDecision } from "../../media-understanding/types.js";
 import { normalizeGroupActivation } from "../group-activation.js";
 import { buildStatusMessage } from "../status.js";
+import type { ElevatedLevel, ReasoningLevel, ThinkLevel, VerboseLevel } from "../thinking.js";
+import type { ReplyPayload } from "../types.js";
+import type { CommandContext } from "./commands-types.js";
 import { getFollowupQueueDepth, resolveQueueSettings } from "./queue.js";
 import { resolveSubagentLabel } from "./subagents-utils.js";
 

--- a/src/auto-reply/reply/commands-subagents-spawn.test.ts
+++ b/src/auto-reply/reply/commands-subagents-spawn.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { SpawnSubagentResult } from "../../agents/subagent-spawn.js";
 import { resetSubagentRegistryForTests } from "../../agents/subagent-registry.js";
+import type { SpawnSubagentResult } from "../../agents/subagent-spawn.js";
 
 const hoisted = vi.hoisted(() => {
   const spawnSubagentDirectMock = vi.fn();

--- a/src/auto-reply/reply/commands-subagents.ts
+++ b/src/auto-reply/reply/commands-subagents.ts
@@ -1,8 +1,7 @@
 import crypto from "node:crypto";
-import type { SubagentRunRecord } from "../../agents/subagent-registry.js";
-import type { CommandHandler } from "./commands-types.js";
 import { AGENT_LANE_SUBAGENT } from "../../agents/lanes.js";
 import { abortEmbeddedPiRun } from "../../agents/pi-embedded.js";
+import type { SubagentRunRecord } from "../../agents/subagent-registry.js";
 import {
   clearSubagentRunSteerRestart,
   listSubagentRunsForRequester,
@@ -36,6 +35,7 @@ import {
 } from "../../shared/subagents-format.js";
 import { INTERNAL_MESSAGE_CHANNEL } from "../../utils/message-channel.js";
 import { stopSubagentsForRequester } from "./abort.js";
+import type { CommandHandler } from "./commands-types.js";
 import { clearSessionQueues } from "./queue.js";
 import { formatRunLabel, formatRunStatus, sortSubagentRuns } from "./subagents-utils.js";
 

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -1,15 +1,12 @@
 import fs from "node:fs";
-import type { SkillCommandSpec } from "../agents/skills.js";
-import type { OpenClawConfig } from "../config/config.js";
-import type { MediaUnderstandingDecision } from "../media-understanding/types.js";
-import type { CommandCategory } from "./commands-registry.types.js";
-import type { ElevatedLevel, ReasoningLevel, ThinkLevel, VerboseLevel } from "./thinking.js";
 import { lookupContextTokens } from "../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { resolveModelAuthMode } from "../agents/model-auth.js";
 import { resolveConfiguredModelRef } from "../agents/model-selection.js";
 import { resolveSandboxRuntimeStatus } from "../agents/sandbox.js";
+import type { SkillCommandSpec } from "../agents/skills.js";
 import { derivePromptTokens, normalizeUsage, type UsageLike } from "../agents/usage.js";
+import type { OpenClawConfig } from "../config/config.js";
 import {
   resolveMainSessionKey,
   resolveSessionFilePath,
@@ -19,6 +16,7 @@ import {
 } from "../config/sessions.js";
 import { formatTimeAgo } from "../infra/format-time/format-relative.ts";
 import { resolveCommitHash } from "../infra/git-commit.js";
+import type { MediaUnderstandingDecision } from "../media-understanding/types.js";
 import { listPluginCommands } from "../plugins/commands.js";
 import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import {
@@ -41,6 +39,8 @@ import {
   listChatCommandsForConfig,
   type ChatCommandDefinition,
 } from "./commands-registry.js";
+import type { CommandCategory } from "./commands-registry.types.js";
+import type { ElevatedLevel, ReasoningLevel, ThinkLevel, VerboseLevel } from "./thinking.js";
 
 type AgentConfig = Partial<NonNullable<NonNullable<OpenClawConfig["agents"]>["defaults"]>>;
 

--- a/src/channels/plugins/actions/discord.ts
+++ b/src/channels/plugins/actions/discord.ts
@@ -1,6 +1,6 @@
 import type { DiscordActionConfig } from "../../../config/types.discord.js";
-import type { ChannelMessageActionAdapter, ChannelMessageActionName } from "../types.js";
 import { createDiscordActionGate, listEnabledDiscordAccounts } from "../../../discord/accounts.js";
+import type { ChannelMessageActionAdapter, ChannelMessageActionName } from "../types.js";
 import { handleDiscordMessageAction } from "./discord/handle-action.js";
 
 export const discordMessageActions: ChannelMessageActionAdapter = {

--- a/src/channels/plugins/actions/telegram.ts
+++ b/src/channels/plugins/actions/telegram.ts
@@ -1,5 +1,3 @@
-import type { TelegramActionConfig } from "../../../config/types.telegram.js";
-import type { ChannelMessageActionAdapter, ChannelMessageActionName } from "../types.js";
 import {
   readNumberParam,
   readStringArrayParam,
@@ -7,12 +5,14 @@ import {
   readStringParam,
 } from "../../../agents/tools/common.js";
 import { handleTelegramAction } from "../../../agents/tools/telegram-actions.js";
+import type { TelegramActionConfig } from "../../../config/types.telegram.js";
 import { extractToolSend } from "../../../plugin-sdk/tool-send.js";
 import {
   createTelegramActionGate,
   listEnabledTelegramAccounts,
 } from "../../../telegram/accounts.js";
 import { isTelegramInlineButtonsEnabled } from "../../../telegram/inline-buttons.js";
+import type { ChannelMessageActionAdapter, ChannelMessageActionName } from "../types.js";
 
 const providerId = "telegram";
 

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -1,9 +1,9 @@
 import fsSync from "node:fs";
-import type { OpenClawConfig } from "../config/config.js";
 import { resolveAgentDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { resolveMemorySearchConfig } from "../agents/memory-search.js";
 import { resolveApiKeyForProvider } from "../agents/model-auth.js";
 import { formatCliCommand } from "../cli/command-format.js";
+import type { OpenClawConfig } from "../config/config.js";
 import { note } from "../terminal/note.js";
 import { resolveUserPath } from "../utils.js";
 

--- a/src/discord/accounts.ts
+++ b/src/discord/accounts.ts
@@ -1,6 +1,6 @@
+import { createAccountListHelpers } from "../channels/plugins/account-helpers.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type { DiscordAccountConfig, DiscordActionConfig } from "../config/types.js";
-import { createAccountListHelpers } from "../channels/plugins/account-helpers.js";
 import { normalizeAccountId } from "../routing/session-key.js";
 import { resolveDiscordToken } from "./token.js";
 

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -2,8 +2,15 @@ import fs from "node:fs";
 import path from "node:path";
 import readline from "node:readline";
 import type { NormalizedUsage, UsageLike } from "../agents/usage.js";
+import { normalizeUsage } from "../agents/usage.js";
 import type { OpenClawConfig } from "../config/config.js";
+import {
+  resolveSessionFilePath,
+  resolveSessionTranscriptsDirForAgent,
+} from "../config/sessions/paths.js";
 import type { SessionEntry } from "../config/sessions/types.js";
+import { countToolResults, extractToolCallNames } from "../utils/transcript-tools.js";
+import { estimateUsageCost, resolveModelCostConfig } from "../utils/usage-format.js";
 import type {
   CostBreakdown,
   CostUsageTotals,
@@ -24,13 +31,6 @@ import type {
   SessionUsageTimePoint,
   SessionUsageTimeSeries,
 } from "./session-cost-usage.types.js";
-import { normalizeUsage } from "../agents/usage.js";
-import {
-  resolveSessionFilePath,
-  resolveSessionTranscriptsDirForAgent,
-} from "../config/sessions/paths.js";
-import { countToolResults, extractToolCallNames } from "../utils/transcript-tools.js";
-import { estimateUsageCost, resolveModelCostConfig } from "../utils/usage-format.js";
 
 export type {
   CostUsageDailyEntry,


### PR DESCRIPTION
Voice call events and outbound logging were using console methods, bypassing structured logs.\n\nFix: Injected logger into CallManager and event contexts, updated tests to mock logger.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR migrates `console.log`/`console.warn`/`console.error` calls to structured runtime logging across four extension modules (voice-call, feishu, nextcloud-talk, zalo) and re-sorts imports in several core `src/` files.

- **voice-call**: Introduces a `Logger` type in `manager/context.ts`, injects it via `CallManager` constructor, and threads it through to `events.ts`. The `shouldAcceptInbound` function and event processing now use `ctx.logger` instead of `console.*`.
- **feishu**: Replaces `console.log` in typing indicator error handlers with `runtime?.log?.()` gated behind verbose logging. Threads `runtime` parameter through `addTypingIndicator`/`removeTypingIndicator`.
- **nextcloud-talk**: Replaces `console.log` with the runtime child logger for pairing approval and verbose send logging.
- **zalo**: Replaces `console.error`/`console.log` with `runtime.error?.()` and the existing `logVerbose()` helper.
- **Import re-ordering**: ~12 files in `src/` have import statements reordered (likely auto-formatter), with no logic changes.

Note: The voice-call migration is partial. Files like `outbound.ts` (7 console calls), `timers.ts` (2 console calls), `webhook.ts` (25+ console calls), `media-stream.ts`, and provider files still use `console.*` directly. The `Logger` type is also duplicated between `runtime.ts` and `manager/context.ts`.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge; it makes a targeted logging refactor with no logic changes.
- The changes are straightforward console-to-logger replacements with proper test updates. The voice-call migration is partial (many console calls remain in other files), but nothing in this PR introduces regressions. Import reordering is cosmetic. The feishu change introduces a minor behavioral shift (errors only logged in verbose mode) that's worth noting but not blocking.
- `extensions/feishu/src/typing.ts` - behavioral change where typing indicator errors are now suppressed unless verbose logging is enabled

<sub>Last reviewed commit: d5fb29f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->