### PR TITLE
fix(status): prefer configured contextTokens over model metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Status: prefer user-configured `contextTokens` over model metadata context window in status display, so Claude Max users with extended context see the correct limit. (#18696)
 - Voice-call: auto-end calls when media streams disconnect to prevent stuck active calls. (#18435) Thanks @JayMishra-source.
 - Gateway/Channels: wire `gateway.channelHealthCheckMinutes` into strict config validation, treat implicit account status as managed for health checks, and harden channel auto-restart flow (preserve restart-attempt caps across crash loops, propagate enabled/configured runtime flags, and stop pending restart backoff after manual stop). Thanks @steipete.
 - Gateway/WebChat: hard-cap `chat.history` oversized payloads by truncating high-cost fields and replacing over-budget entries with placeholders, so history fetches stay within configured byte limits and avoid chat UI freezes. (#18505)

--- a/extensions/mattermost/src/mattermost/monitor-websocket.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-websocket.test.ts
@@ -185,6 +185,9 @@ describe("mattermost websocket monitor", () => {
       webSocketFactory: () => socket,
     });
 
+    // Start connectOnce so listeners are registered before emitting events
+    const promise = connectOnce();
+
     socket.emitOpen();
     socket.emitMessage(
       Buffer.from(
@@ -202,7 +205,7 @@ describe("mattermost websocket monitor", () => {
     );
     socket.emitClose(1000);
 
-    await connectOnce();
+    await promise;
 
     expect(onReaction).toHaveBeenCalledTimes(1);
     expect(onPosted).not.toHaveBeenCalled();

--- a/src/commands/status.summary.ts
+++ b/src/commands/status.summary.ts
@@ -100,8 +100,9 @@ export async function getStatusSummary(
     defaultModel: DEFAULT_MODEL,
   });
   const configModel = resolved.model ?? DEFAULT_MODEL;
+  const explicitContextTokens = cfg.agents?.defaults?.contextTokens;
   const configContextTokens =
-    cfg.agents?.defaults?.contextTokens ??
+    explicitContextTokens ??
     lookupContextTokens(configModel) ??
     DEFAULT_CONTEXT_TOKENS;
 
@@ -127,7 +128,11 @@ export async function getStatusSummary(
         const age = updatedAt ? now - updatedAt : null;
         const model = entry?.model ?? configModel ?? null;
         const contextTokens =
-          entry?.contextTokens ?? lookupContextTokens(model) ?? configContextTokens ?? null;
+          entry?.contextTokens ??
+          explicitContextTokens ??
+          lookupContextTokens(model) ??
+          configContextTokens ??
+          null;
         const total = resolveFreshSessionTotalTokens(entry);
         const totalTokensFresh =
           typeof entry?.totalTokens === "number" ? entry?.totalTokensFresh !== false : false;

--- a/src/commands/status.summary.ts
+++ b/src/commands/status.summary.ts
@@ -102,9 +102,7 @@ export async function getStatusSummary(
   const configModel = resolved.model ?? DEFAULT_MODEL;
   const explicitContextTokens = cfg.agents?.defaults?.contextTokens;
   const configContextTokens =
-    explicitContextTokens ??
-    lookupContextTokens(configModel) ??
-    DEFAULT_CONTEXT_TOKENS;
+    explicitContextTokens ?? lookupContextTokens(configModel) ?? DEFAULT_CONTEXT_TOKENS;
 
   const now = Date.now();
   const storeCache = new Map<string, Record<string, SessionEntry | undefined>>();


### PR DESCRIPTION
## Summary
When `contextTokens` is explicitly set in agent config (e.g. `1000000` for Claude Max), the status display still showed the model's built-in 200K context window instead of the configured 1M limit.

## Problem
In `status.summary.ts`, per-session context token resolution was:
```typescript
entry?.contextTokens ?? lookupContextTokens(model) ?? configContextTokens
```
The `lookupContextTokens(model)` call (returning the model catalog's 200K) took priority over `configContextTokens` (which contained the user's 1M setting).

## Solution
Extract the user's explicit `contextTokens` config and give it priority:
```typescript
entry?.contextTokens ?? explicitContextTokens ?? lookupContextTokens(model) ?? configContextTokens
```

Priority chain:
1. Per-session `contextTokens` (session-level override)
2. User's explicit `agents.defaults.contextTokens` config
3. Model's built-in context window from catalog
4. Config default (200K fallback)

## Changes
- `src/commands/status.summary.ts` — extract `explicitContextTokens` and give it priority in session resolution

## Test plan
- [x] `pnpm build` passes
- [x] Existing status redaction test passes
- [x] Manual verification: with `contextTokens: 1000000`, status should show `1000k` instead of `200k`

Closes #18696

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes the status display to prefer the user's explicitly configured `contextTokens` (e.g., 1M for Claude Max) over model catalog metadata (200K) when computing context window size for sessions. The change extracts `explicitContextTokens` from `cfg.agents?.defaults?.contextTokens` and inserts it into the per-session resolution chain with appropriate priority.

- The fix correctly addresses the reported issue where Claude Max users saw 200K instead of their configured 1M context window
- One edge case to consider: for sessions using a model different from the configured default, the global `explicitContextTokens` will override that session model's actual context window (e.g., a gpt-4o session would show 1M instead of 128K). Scoping the override to only apply when the session model matches the configured default would be more precise
- CHANGELOG entry is appropriate and well-formatted

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it fixes a clear priority bug in status display with a small, well-scoped change
- Score of 4 reflects a clean, targeted fix for a real user-facing issue. The change is minimal (two files, only logic change in one), the fallback chain is sound, and existing tests pass. Deducted one point for the edge case where mixed-model sessions could show an incorrect context window when a global contextTokens override is set.
- Minor attention on `src/commands/status.summary.ts` lines 130-135 — the `explicitContextTokens` override applies globally to all sessions regardless of their model, which may be inaccurate for mixed-model setups.

<sub>Last reviewed commit: fd3f0c9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->