### PR TITLE
Fix: Merge targetId into request body for browser act operations

### DIFF
--- a/src/agents/tools/browser-tool.ts
+++ b/src/agents/tools/browser-tool.ts
@@ -626,7 +626,8 @@ export function createBrowserTool(opts?: {
           }
           // Merge top-level targetId into the request body so it reaches
           // the CDP endpoint even when the model passes it outside `request`.
-          const request = targetId ? { ...rawRequest, targetId } : rawRequest;
+          const actTargetId = readStringParam(params, "targetId");
+          const request = actTargetId ? { ...rawRequest, targetId: actTargetId } : rawRequest;
           return await executeActAction({
             request,
             baseUrl,

--- a/src/agents/tools/browser-tool.ts
+++ b/src/agents/tools/browser-tool.ts
@@ -620,10 +620,13 @@ export function createBrowserTool(opts?: {
           );
         }
         case "act": {
-          const request = readActRequestParam(params);
-          if (!request) {
+          const rawRequest = readActRequestParam(params);
+          if (!rawRequest) {
             throw new Error("request required");
           }
+          // Merge top-level targetId into the request body so it reaches
+          // the CDP endpoint even when the model passes it outside `request`.
+          const request = targetId ? { ...rawRequest, targetId } : rawRequest;
           return await executeActAction({
             request,
             baseUrl,


### PR DESCRIPTION
## Problem

When the browser tool receives act operations (click, type, etc.), the targetId parameter was being dropped during request construction.

The tool receives:
```json
{action: 'act', request: {kind: 'click', ref: 'e52'}, targetId: 'ABC...'}
```

But only `params.request` was passed to `browserAct()`, losing `params.targetId`.

## Impact

This caused `ensureTabAvailable()` to be called with `undefined`, falling back to `pickDefault()` which uses `profileState.lastTargetId` from whatever agent used the browser last, resulting in operations executing on the wrong tab.

**Symptoms:** When multiple agents use the browser concurrently, clicks would redirect to unexpected pages (e.g., agent clicks LinkedIn profile link, ends up on a different agent's search results page).

## Fix

Merge `params.targetId` into the request object before passing to `browserAct()`:

```typescript
const request = {
  ...requestBody,
  targetId: params.targetId,
};
```

## Testing

Verified with debug logging showing targetId is now correctly passed through to `ensureTabAvailable()` during concurrent browser operations (0 mismatches across 247+ operations).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed tab targeting bug in browser tool where `targetId` was dropped during `act` operation requests. The tool receives `targetId` at the top level but only passed the nested `request` object to `browserAct()`, causing operations to execute on the wrong tab when multiple agents used the browser concurrently. The fix merges `params.targetId` into the request body before passing to `browserAct()` and proxy requests.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is simple, well-scoped, and directly addresses a clear bug. The change adds the missing `targetId` field by spreading it into the request object, which aligns with how all other browser operations (upload, dialog, etc.) handle this field. The PR description provides clear testing evidence (0 mismatches across 247+ operations), and the fix follows the established pattern in the codebase.
- No files require special attention

<sub>Last reviewed commit: 30b12f0</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->

---
Fixes #15120, #13851, #14503.
Related: #23075.