### PR TITLE
feat(hooks): add agent and tool lifecycle boundaries

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1471,7 +1471,9 @@ export async function runEmbeddedPiAgent(
               pendingToolCalls: attempt.clientToolCall
                 ? [
                     {
-                      id: randomBytes(5).toString("hex").slice(0, 9),
+                      id:
+                        attempt.clientToolCall.toolCallId.trim() ||
+                        randomBytes(5).toString("hex").slice(0, 9),
                       name: attempt.clientToolCall.name,
                       arguments: JSON.stringify(attempt.clientToolCall.params),
                     },

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -130,6 +130,12 @@ import {
 } from "./compaction-timeout.js";
 import { pruneProcessedHistoryImages } from "./history-image-prune.js";
 import { detectAndLoadPromptImages } from "./images.js";
+import {
+  createInternalAgentHookEmitter,
+  createResponseLifecycleTracker,
+  emitThinkingEnd,
+  emitThinkingStart,
+} from "./lifecycle-hooks.js";
 import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./types.js";
 
 type PromptBuildHookRunner = {
@@ -750,6 +756,9 @@ export async function runEmbeddedAttempt(
   const prevCwd = process.cwd();
   const runAbortController = new AbortController();
   ensureGlobalUndiciStreamTimeouts();
+  const emitInternalAgentHook = createInternalAgentHookEmitter(params, (message) =>
+    log.warn(message),
+  );
 
   log.debug(
     `embedded run start: runId=${params.runId} sessionId=${params.sessionId} provider=${params.provider} model=${params.modelId} thinking=${params.thinkLevel} messageChannel=${params.messageChannel ?? params.messageProvider ?? "unknown"}`,
@@ -1153,7 +1162,11 @@ export async function runEmbeddedAttempt(
       });
 
       // Add client tools (OpenResponses hosted tools) to customTools
-      let clientToolCallDetected: { name: string; params: Record<string, unknown> } | null = null;
+      let clientToolCallDetected: {
+        name: string;
+        params: Record<string, unknown>;
+        toolCallId: string;
+      } | null = null;
       const clientToolLoopDetection = resolveToolLoopDetectionConfig({
         cfg: params.config,
         agentId: sessionAgentId,
@@ -1161,8 +1174,8 @@ export async function runEmbeddedAttempt(
       const clientToolDefs = clientTools
         ? toClientToolDefinitions(
             clientTools,
-            (toolName, toolParams) => {
-              clientToolCallDetected = { name: toolName, params: toolParams };
+            (toolName, toolParams, toolCallId) => {
+              clientToolCallDetected = { name: toolName, params: toolParams, toolCallId };
             },
             {
               agentId: sessionAgentId,
@@ -1507,6 +1520,13 @@ export async function runEmbeddedAttempt(
         });
       };
 
+      const responseLifecycle = createResponseLifecycleTracker({
+        params,
+        emitInternalAgentHook,
+        onAssistantMessageStart: params.onAssistantMessageStart,
+        formatError: describeUnknownError,
+      });
+
       const subscription = subscribeEmbeddedPiSession({
         session: activeSession,
         runId: params.runId,
@@ -1524,7 +1544,7 @@ export async function runEmbeddedAttempt(
         blockReplyBreak: params.blockReplyBreak,
         blockReplyChunking: params.blockReplyChunking,
         onPartialReply: params.onPartialReply,
-        onAssistantMessageStart: params.onAssistantMessageStart,
+        onAssistantMessageStart: responseLifecycle.handleAssistantMessageStart,
         onAgentEvent: params.onAgentEvent,
         enforceFinalTag: params.enforceFinalTag,
         config: params.config,
@@ -1627,6 +1647,7 @@ export async function runEmbeddedAttempt(
       const prePromptMessageCount = activeSession.messages.length;
       try {
         const promptStartedAt = Date.now();
+        void emitThinkingStart(params, emitInternalAgentHook);
 
         // Run before_prompt_build hooks to allow plugins to inject prompt context.
         // Legacy compatibility: before_agent_start is also checked for context fields.
@@ -1788,6 +1809,13 @@ export async function runEmbeddedAttempt(
           log.debug(
             `embedded run prompt end: runId=${params.runId} sessionId=${params.sessionId} durationMs=${Date.now() - promptStartedAt}`,
           );
+          void emitThinkingEnd({
+            lifecycleParams: params,
+            emitInternalAgentHook,
+            promptStartedAt,
+            promptError,
+            formatError: describeUnknownError,
+          });
         }
 
         // Capture snapshot before compaction wait so we have complete messages if timeout occurs
@@ -1941,6 +1969,12 @@ export async function runEmbeddedAttempt(
               : undefined,
         });
         anthropicPayloadLogger?.recordUsage(messagesSnapshot, promptError);
+        const hasResponseOutput =
+          assistantTexts.length > 0 ||
+          didSendViaMessagingTool() ||
+          getMessagingToolSentTexts().length > 0;
+        await responseLifecycle.emitResponseStartIfNeeded(hasResponseOutput);
+        await responseLifecycle.emitResponseEnd(promptError);
 
         // Run agent_end hooks to allow plugins to analyze the conversation
         // This is fire-and-forget, so we don't await

--- a/src/agents/pi-embedded-runner/run/lifecycle-hooks.test.ts
+++ b/src/agents/pi-embedded-runner/run/lifecycle-hooks.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { triggerInternalHook } = vi.hoisted(() => ({
+  triggerInternalHook: vi.fn(async () => {}),
+}));
+
+vi.mock("../../../hooks/internal-hooks.js", async () => {
+  const actual = await vi.importActual<typeof import("../../../hooks/internal-hooks.js")>(
+    "../../../hooks/internal-hooks.js",
+  );
+  return {
+    ...actual,
+    triggerInternalHook,
+  };
+});
+
+import {
+  createInternalAgentHookEmitter,
+  createResponseLifecycleTracker,
+  emitThinkingEnd,
+  emitThinkingStart,
+} from "./lifecycle-hooks.js";
+
+type HookEventRecord = {
+  type?: string;
+  action?: string;
+  sessionKey?: string;
+  context?: Record<string, unknown>;
+};
+
+describe("lifecycle hooks", () => {
+  beforeEach(() => {
+    triggerInternalHook.mockClear();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-07T12:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("emits thinking lifecycle hooks with session fallback and error context", async () => {
+    const warn = vi.fn();
+    const emitInternalAgentHook = createInternalAgentHookEmitter(
+      {
+        sessionKey: "",
+        runId: "run-1",
+      },
+      warn,
+    );
+    const lifecycleParams = {
+      sessionId: "session-1",
+      runId: "run-1",
+      provider: "openai",
+      modelId: "gpt-5",
+      messageProvider: "telegram",
+      messageChannel: "telegram",
+    } as const;
+
+    await emitThinkingStart(lifecycleParams, emitInternalAgentHook);
+    vi.advanceTimersByTime(275);
+    await emitThinkingEnd({
+      lifecycleParams,
+      emitInternalAgentHook,
+      promptStartedAt: Date.now() - 275,
+      promptError: new Error("prompt failed"),
+      formatError: (err) => String(err),
+    });
+
+    expect(warn).not.toHaveBeenCalled();
+    expect(triggerInternalHook).toHaveBeenCalledTimes(2);
+
+    const recordedCalls = triggerInternalHook.mock.calls as unknown as Array<[HookEventRecord]>;
+    const thinkingStart = recordedCalls[0]?.[0];
+    const thinkingEnd = recordedCalls[1]?.[0];
+    expect(thinkingStart?.type).toBe("agent");
+    expect(thinkingStart?.action).toBe("thinking:start");
+    expect(thinkingStart?.sessionKey).toBe("run:run-1");
+    expect(thinkingStart?.context).toMatchObject({
+      sessionId: "session-1",
+      runId: "run-1",
+      provider: "openai",
+      model: "gpt-5",
+      messageProvider: "telegram",
+      messageChannel: "telegram",
+    });
+    expect(thinkingEnd?.type).toBe("agent");
+    expect(thinkingEnd?.action).toBe("thinking:end");
+    expect(thinkingEnd?.context).toMatchObject({
+      sessionId: "session-1",
+      runId: "run-1",
+      provider: "openai",
+      model: "gpt-5",
+      durationMs: 275,
+      error: "Error: prompt failed",
+    });
+  });
+
+  it("emits response hooks only once when assistant output begins", async () => {
+    const warn = vi.fn();
+    const onAssistantMessageStart = vi.fn();
+    const emitInternalAgentHook = createInternalAgentHookEmitter(
+      {
+        sessionKey: "agent:main:session-1",
+        runId: "run-2",
+      },
+      warn,
+    );
+    const tracker = createResponseLifecycleTracker({
+      params: {
+        sessionId: "session-1",
+        runId: "run-2",
+        provider: "openai",
+        modelId: "gpt-5",
+        messageProvider: "discord",
+        messageChannel: "discord",
+      },
+      emitInternalAgentHook,
+      onAssistantMessageStart,
+      formatError: (err) => String(err),
+    });
+
+    await tracker.emitResponseStartIfNeeded(false);
+    expect(triggerInternalHook).not.toHaveBeenCalled();
+
+    tracker.handleAssistantMessageStart();
+    vi.advanceTimersByTime(120);
+    await tracker.emitResponseStartIfNeeded(true);
+    await tracker.emitResponseEnd(undefined);
+
+    expect(warn).not.toHaveBeenCalled();
+    expect(onAssistantMessageStart).toHaveBeenCalledTimes(1);
+    expect(triggerInternalHook).toHaveBeenCalledTimes(2);
+    const recordedCalls = triggerInternalHook.mock.calls as unknown as Array<[HookEventRecord]>;
+    const responseStart = recordedCalls[0]?.[0];
+    const responseEnd = recordedCalls[1]?.[0];
+
+    expect(responseStart).toMatchObject({
+      type: "agent",
+      action: "response:start",
+      sessionKey: "agent:main:session-1",
+      context: {
+        sessionId: "session-1",
+        runId: "run-2",
+        provider: "openai",
+        model: "gpt-5",
+        messageProvider: "discord",
+        messageChannel: "discord",
+      },
+    });
+    expect(responseEnd).toMatchObject({
+      type: "agent",
+      action: "response:end",
+      context: {
+        sessionId: "session-1",
+        runId: "run-2",
+        provider: "openai",
+        model: "gpt-5",
+        durationMs: 120,
+        error: undefined,
+      },
+    });
+  });
+});

--- a/src/agents/pi-embedded-runner/run/lifecycle-hooks.ts
+++ b/src/agents/pi-embedded-runner/run/lifecycle-hooks.ts
@@ -1,0 +1,103 @@
+import { createInternalHookEvent, triggerInternalHook } from "../../../hooks/internal-hooks.js";
+import type { EmbeddedRunAttemptParams } from "./types.js";
+
+type LifecycleParams = Pick<
+  EmbeddedRunAttemptParams,
+  "sessionId" | "runId" | "provider" | "modelId" | "messageProvider" | "messageChannel"
+>;
+
+type EmitInternalAgentHook = (action: string, context: Record<string, unknown>) => Promise<void>;
+
+type ResponseLifecycleTrackerOptions = {
+  params: LifecycleParams;
+  emitInternalAgentHook: EmitInternalAgentHook;
+  onAssistantMessageStart?: () => void;
+  formatError: (err: unknown) => string;
+};
+
+function buildLifecycleContext(params: LifecycleParams): Record<string, unknown> {
+  return {
+    sessionId: params.sessionId,
+    runId: params.runId,
+    provider: params.provider,
+    model: params.modelId,
+    messageProvider: params.messageProvider,
+    messageChannel: params.messageChannel,
+  };
+}
+
+export function createInternalAgentHookEmitter(
+  params: Pick<EmbeddedRunAttemptParams, "sessionKey" | "runId">,
+  warn: (message: string) => void,
+): EmitInternalAgentHook {
+  const hookSessionKey = params.sessionKey?.trim() || `run:${params.runId}`;
+
+  return async (action: string, context: Record<string, unknown>) => {
+    try {
+      const hookEvent = createInternalHookEvent("agent", action, hookSessionKey, context);
+      await triggerInternalHook(hookEvent);
+    } catch (err) {
+      warn(`agent:${action} hook failed: ${String(err)}`);
+    }
+  };
+}
+
+export async function emitThinkingStart(
+  params: LifecycleParams,
+  emitInternalAgentHook: EmitInternalAgentHook,
+): Promise<void> {
+  await emitInternalAgentHook("thinking:start", buildLifecycleContext(params));
+}
+
+export async function emitThinkingEnd(params: {
+  lifecycleParams: LifecycleParams;
+  emitInternalAgentHook: EmitInternalAgentHook;
+  promptStartedAt: number;
+  promptError: unknown;
+  formatError: (err: unknown) => string;
+}): Promise<void> {
+  await params.emitInternalAgentHook("thinking:end", {
+    ...buildLifecycleContext(params.lifecycleParams),
+    durationMs: Date.now() - params.promptStartedAt,
+    error: params.promptError ? params.formatError(params.promptError) : undefined,
+  });
+}
+
+export function createResponseLifecycleTracker(options: ResponseLifecycleTrackerOptions): {
+  handleAssistantMessageStart: () => void;
+  emitResponseStartIfNeeded: (hasResponseOutput: boolean) => Promise<void>;
+  emitResponseEnd: (promptError: unknown) => Promise<void>;
+} {
+  let responseStartedAt: number | null = null;
+
+  const emitResponseStart = async (startedAt: number) => {
+    if (responseStartedAt !== null) {
+      return;
+    }
+    responseStartedAt = startedAt;
+    await options.emitInternalAgentHook("response:start", buildLifecycleContext(options.params));
+  };
+
+  return {
+    handleAssistantMessageStart: () => {
+      void emitResponseStart(Date.now());
+      void options.onAssistantMessageStart?.();
+    },
+    emitResponseStartIfNeeded: async (hasResponseOutput: boolean) => {
+      if (!hasResponseOutput) {
+        return;
+      }
+      await emitResponseStart(Date.now());
+    },
+    emitResponseEnd: async (promptError: unknown) => {
+      if (responseStartedAt === null) {
+        return;
+      }
+      await options.emitInternalAgentHook("response:end", {
+        ...buildLifecycleContext(options.params),
+        durationMs: Date.now() - responseStartedAt,
+        error: promptError ? options.formatError(promptError) : undefined,
+      });
+    },
+  };
+}

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -62,5 +62,5 @@ export type EmbeddedRunAttemptResult = {
   attemptUsage?: NormalizedUsage;
   compactionCount?: number;
   /** Client tool call detected (OpenResponses hosted tools). */
-  clientToolCall?: { name: string; params: Record<string, unknown> };
+  clientToolCall?: { name: string; params: Record<string, unknown>; toolCallId: string };
 };

--- a/src/agents/pi-tool-definition-adapter.ts
+++ b/src/agents/pi-tool-definition-adapter.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import type {
   AgentTool,
   AgentToolResult,
@@ -134,6 +135,11 @@ function splitToolExecuteArgs(args: ToolExecuteArgsAny): {
   };
 }
 
+function resolveClientToolCallId(toolCallId: string): string {
+  const normalized = toolCallId.trim();
+  return normalized || `hook-${randomUUID()}`;
+}
+
 export function toToolDefinitions(tools: AnyAgentTool[]): ToolDefinition[] {
   return tools.map((tool) => {
     const name = tool.name || "tool";
@@ -197,7 +203,11 @@ export function toToolDefinitions(tools: AnyAgentTool[]): ToolDefinition[] {
 // These tools are intercepted to return a "pending" result instead of executing
 export function toClientToolDefinitions(
   tools: ClientToolDefinition[],
-  onClientToolCall?: (toolName: string, params: Record<string, unknown>) => void,
+  onClientToolCall?: (
+    toolName: string,
+    params: Record<string, unknown>,
+    toolCallId: string,
+  ) => void,
   hookContext?: HookContext,
 ): ToolDefinition[] {
   return tools.map((tool) => {
@@ -209,10 +219,11 @@ export function toClientToolDefinitions(
       parameters: func.parameters as ToolDefinition["parameters"],
       execute: async (...args: ToolExecuteArgs): Promise<AgentToolResult<unknown>> => {
         const { toolCallId, params } = splitToolExecuteArgs(args);
+        const effectiveToolCallId = resolveClientToolCallId(toolCallId);
         const outcome = await runBeforeToolCallHook({
           toolName: func.name,
           params,
-          toolCallId,
+          toolCallId: effectiveToolCallId,
           ctx: hookContext,
         });
         if (outcome.blocked) {
@@ -222,12 +233,13 @@ export function toClientToolDefinitions(
         const paramsRecord = isPlainObject(adjustedParams) ? adjustedParams : {};
         // Notify handler that a client tool was called
         if (onClientToolCall) {
-          onClientToolCall(func.name, paramsRecord);
+          onClientToolCall(func.name, paramsRecord, effectiveToolCallId);
         }
         // Return a pending result - the client will execute this tool
         return jsonResult({
           status: "pending",
           tool: func.name,
+          toolCallId: effectiveToolCallId,
           message: "Tool execution delegated to client",
         });
       },

--- a/src/agents/pi-tools.before-tool-call.integration.e2e.test.ts
+++ b/src/agents/pi-tools.before-tool-call.integration.e2e.test.ts
@@ -252,7 +252,7 @@ describe("before_tool_call hook integration for client tools", () => {
     hookRunner = installMockHookRunner();
   });
 
-  it("passes modified params to client tool callbacks", async () => {
+  it("passes modified params and toolCallId to client tool callbacks", async () => {
     hookRunner.hasHooks.mockReturnValue(true);
     hookRunner.runBeforeToolCall.mockResolvedValue({ params: { extra: true } });
     const onClientToolCall = vi.fn();
@@ -273,9 +273,42 @@ describe("before_tool_call hook integration for client tools", () => {
     const extensionContext = {} as Parameters<typeof tool.execute>[4];
     await tool.execute("client-call-1", { value: "ok" }, undefined, undefined, extensionContext);
 
-    expect(onClientToolCall).toHaveBeenCalledWith("client_tool", {
-      value: "ok",
-      extra: true,
+    expect(onClientToolCall).toHaveBeenCalledWith(
+      "client_tool",
+      {
+        value: "ok",
+        extra: true,
+      },
+      "client-call-1",
+    );
+  });
+
+  it("generates a fallback toolCallId for blank client tool ids", async () => {
+    const onClientToolCall = vi.fn();
+    const [tool] = toClientToolDefinitions(
+      [
+        {
+          type: "function",
+          function: {
+            name: "client_tool",
+            description: "Client tool",
+            parameters: { type: "object", properties: {} },
+          },
+        },
+      ],
+      onClientToolCall,
+      { agentId: "main", sessionKey: "main" },
+    );
+    const extensionContext = {} as Parameters<typeof tool.execute>[4];
+    const result = await tool.execute("   ", {}, undefined, undefined, extensionContext);
+
+    expect(onClientToolCall).toHaveBeenCalledTimes(1);
+    const toolCallId = onClientToolCall.mock.calls[0]?.[2];
+    expect(toolCallId).toMatch(/^hook-/);
+    expect(result.details).toMatchObject({
+      status: "pending",
+      tool: "client_tool",
+      toolCallId,
     });
   });
 });


### PR DESCRIPTION
## Why
Agent execution lacked complete lifecycle boundaries around thinking, response generation, and tool execution, reducing traceability for observability and policy systems. This PR adds those boundaries and ensures tool lifecycle hooks carry `toolCallId` context when available. lobster-biscuit

## Split Context
This PR was accidentally closed after a messed up rebase https://github.com/openclaw/openclaw/pull/12583 which was originally split from closed umbrella PR #9761: https://github.com/openclaw/openclaw/pull/9761.

## Detailed Changes
- Added internal agent lifecycle hook emissions:
  - `agent:thinking:start` / `agent:thinking:end`
  - `agent:response:start` / `agent:response:end`
  - `agent:tool:start` / `agent:tool:end`
- Added `runAfterToolCallHook` wiring for tool execution lifecycle completion
- Propagated `toolCallId` through before/after tool hook contexts where available
- Extended client tool definition adapter to pass `toolCallId` and run after-tool hook flow
- Added focused tests for agent lifecycle emissions and tool lifecycle behavior

## Related Links, Issues and Resolution
- Closed source PR: #12583 AND #9761
- Related issues:
  - Closes #7724
  - Closes #7597
  - Closes #5513
  - #7985
  - #6095
  - #6264
  - #6885

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds complete lifecycle boundaries for agent execution (thinking, response generation, and tool execution), improving observability and traceability for policy systems. The implementation propagates `toolCallId` through tool lifecycle hooks and ensures consistent hook firing across different execution paths.

Key improvements:
- Split lifecycle hook logic into dedicated `lifecycle-hooks.ts` module
- Ensured `agent:thinking:start/end` fire for all agent runs
- Added conditional `agent:response:start/end` hooks that only fire when response output is generated
- Propagated `toolCallId` to `before_tool_call` and `after_tool_call` hooks
- Added `runAfterToolCallHook` wiring for both success and error paths in tool execution
- Comprehensive test coverage validates hook emissions in different scenarios

<h3>Confidence Score: 5/5</h3>

- Safe to merge - well-structured refactoring with comprehensive test coverage
- The changes are well-architected with proper error handling throughout. The new `lifecycle-hooks.ts` module cleanly separates concerns, all hook emission paths include error handling that logs warnings without failing execution, and the test coverage validates the core lifecycle hook behavior. The `toolCallId` propagation is handled consistently with proper fallbacks.
- No files require special attention

<sub>Last reviewed commit: d48824c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->