### PR TITLE
feat(messages): extend suppressToolErrors to accept "all" mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Messages: extend `suppressToolErrors` to accept `"all"` to suppress ALL tool-error warnings including mutating tools (exec, write, edit). (#18630)
 - Voice-call: auto-end calls when media streams disconnect to prevent stuck active calls. (#18435) Thanks @JayMishra-source.
 - Gateway/Channels: wire `gateway.channelHealthCheckMinutes` into strict config validation, treat implicit account status as managed for health checks, and harden channel auto-restart flow (preserve restart-attempt caps across crash loops, propagate enabled/configured runtime flags, and stop pending restart backoff after manual stop). Thanks @steipete.
 - Gateway/WebChat: hard-cap `chat.history` oversized payloads by truncating high-cost fields and replacing over-budget entries with placeholders, so history fetches stay within configured byte limits and avoid chat UI freezes. (#18505)
@@ -95,6 +96,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Messages: extend `suppressToolErrors` to accept `"all"` to suppress ALL tool-error warnings including mutating tools (exec, write, edit). (#18630)
 - Discord: send initial content when creating non-forum threads so `thread-create` content is delivered. (#18117) Thanks @zerone0x.
 - Security: replace deprecated SHA-1 sandbox configuration hashing with SHA-256 for deterministic sandbox cache identity and recreation checks. Thanks @kexinoh.
 - Security/Logging: redact Telegram bot tokens from error messages and uncaught stack traces to prevent accidental secret leakage into logs. Thanks @aether-ai-agent.
@@ -159,6 +161,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Messages: extend `suppressToolErrors` to accept `"all"` to suppress ALL tool-error warnings including mutating tools (exec, write, edit). (#18630)
 - Security/Sessions/Telegram: restrict session tool targeting by default to the current session tree (`tools.sessions.visibility`, default `tree`) with sandbox clamping, and pass configured per-account Telegram webhook secrets in webhook mode when no explicit override is provided. Thanks @aether-ai-agent.
 - CLI/Plugins: ensure `openclaw message send` exits after successful delivery across plugin-backed channels so one-shot sends do not hang. (#16491) Thanks @yinghaosang.
 - CLI/Plugins: run registered plugin `gateway_stop` hooks before `openclaw message` exits (success and failure paths), so plugin-backed channels can clean up one-shot CLI resources. (#16580) Thanks @gumadeiras.
@@ -315,6 +318,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Messages: extend `suppressToolErrors` to accept `"all"` to suppress ALL tool-error warnings including mutating tools (exec, write, edit). (#18630)
 - Gateway/Auth: add trusted-proxy mode hardening follow-ups by keeping `OPENCLAW_GATEWAY_*` env compatibility, auto-normalizing invalid setup combinations in interactive `gateway configure` (trusted-proxy forces `bind=lan` and disables Tailscale serve/funnel), and suppressing shared-secret/rate-limit audit findings that do not apply to trusted-proxy deployments. (#15940) Thanks @nickytonline.
 - Docs/Hooks: update hooks documentation URLs to the new `/automation/hooks` location. (#16165) Thanks @nicholascyh.
 - Security/Audit: warn when `gateway.tools.allow` re-enables default-denied tools over HTTP `POST /tools/invoke`, since this can increase RCE blast radius if the gateway is reachable.
@@ -431,6 +435,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Messages: extend `suppressToolErrors` to accept `"all"` to suppress ALL tool-error warnings including mutating tools (exec, write, edit). (#18630)
 - Gateway/OpenResponses: harden URL-based `input_file`/`input_image` handling with explicit SSRF deny policy, hostname allowlists (`files.urlAllowlist` / `images.urlAllowlist`), per-request URL input caps (`maxUrlParts`), blocked-fetch audit logging, and regression coverage/docs updates.
 - Sessions: guard `withSessionStoreLock` against undefined `storePath` to prevent `path.dirname` crash. (#14717)
 - Security: fix unauthenticated Nostr profile API remote config tampering. (#13719) Thanks @coygeek.
@@ -541,6 +546,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Messages: extend `suppressToolErrors` to accept `"all"` to suppress ALL tool-error warnings including mutating tools (exec, write, edit). (#18630)
 - Cron: prevent one-shot `at` jobs from re-firing on gateway restart when previously skipped or errored. (#13845)
 - Discord: add exec approval cleanup option to delete DMs after approval/denial/timeout. (#13205) Thanks @thewilloftheshadow.
 - Sessions: prune stale entries, cap session store size, rotate large stores, accept duration/size thresholds, default to warn-only maintenance, and prune cron run sessions after retention windows. (#13083) Thanks @skyfallsin, @Glucksberg, @gumadeiras.
@@ -630,6 +636,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Messages: extend `suppressToolErrors` to accept `"all"` to suppress ALL tool-error warnings including mutating tools (exec, write, edit). (#18630)
 - TTS: add missing OpenAI voices (ballad, cedar, juniper, marin, verse) to the allowlist so they are recognized instead of silently falling back to Edge TTS. (#2393)
 - Cron: scheduler reliability (timer drift, restart catch-up, lock contention, stale running markers). (#10776) Thanks @tyler6204.
 - Cron: store migration hardening (legacy field migration, parse error handling, explicit delivery mode persistence). (#10776) Thanks @tyler6204.
@@ -667,6 +674,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Messages: extend `suppressToolErrors` to accept `"all"` to suppress ALL tool-error warnings including mutating tools (exec, write, edit). (#18630)
 - Control UI: add hardened fallback for asset resolution in global npm installs. (#4855) Thanks @anapivirtua.
 - Update: remove dead restore control-ui step that failed on gitignored dist/ output.
 - Update: avoid wiping prebuilt Control UI assets during dev auto-builds (`tsdown --no-clean`), run update doctor via `openclaw.mjs`, and auto-restore missing UI assets after doctor. (#10146) Thanks @gumadeiras.
@@ -704,6 +712,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Messages: extend `suppressToolErrors` to accept `"all"` to suppress ALL tool-error warnings including mutating tools (exec, write, edit). (#18630)
 - Update: ship legacy daemon-cli shim for pre-tsdown update imports (fixes daemon restart after npm update).
 
 ## 2026.2.2-2
@@ -714,12 +723,14 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Messages: extend `suppressToolErrors` to accept `"all"` to suppress ALL tool-error warnings including mutating tools (exec, write, edit). (#18630)
 - CLI status: resolve build-info from bundled dist output (fixes "unknown" commit in npm builds).
 
 ## 2026.2.2-1
 
 ### Fixes
 
+- Messages: extend `suppressToolErrors` to accept `"all"` to suppress ALL tool-error warnings including mutating tools (exec, write, edit). (#18630)
 - CLI status: fall back to build-info for version detection (fixes "unknown" in beta builds). Thanks @gumadeira.
 
 ## 2026.2.2
@@ -737,6 +748,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Messages: extend `suppressToolErrors` to accept `"all"` to suppress ALL tool-error warnings including mutating tools (exec, write, edit). (#18630)
 - Docs: finish renaming the QMD memory docs to reference the OpenClaw state dir.
 - Onboarding: keep TUI flow exclusive (skip completion prompt + background Web UI seed).
 - Onboarding: drop completion prompt now handled by install/update.
@@ -789,6 +801,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Messages: extend `suppressToolErrors` to accept `"all"` to suppress ALL tool-error warnings including mutating tools (exec, write, edit). (#18630)
 - Security: guard remote media fetches with SSRF protections (block private/localhost, DNS pinning).
 - Updates: clean stale global install rename dirs and extend gateway update timeouts to avoid npm ENOTEMPTY failures.
 - Security/Plugins/Hooks: validate install paths and reject traversal-like names (prevents path traversal outside the state dir). Thanks @logicx24.
@@ -848,6 +861,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Messages: extend `suppressToolErrors` to accept `"all"` to suppress ALL tool-error warnings including mutating tools (exec, write, edit). (#18630)
 - Security: guard remote media fetches with SSRF protections (block private/localhost, DNS pinning).
 - Updates: clean stale global install rename dirs and extend gateway update timeouts to avoid npm ENOTEMPTY failures.
 - Plugins: validate plugin/hook install paths and reject traversal-like names.
@@ -905,6 +919,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Messages: extend `suppressToolErrors` to accept `"all"` to suppress ALL tool-error warnings including mutating tools (exec, write, edit). (#18630)
 - Security: restrict local path extraction in media parser to prevent LFI. (#4880)
 - Gateway: prevent token defaults from becoming the literal "undefined". (#4873) Thanks @Hisleren.
 - Control UI: fix assets resolution for npm global installs. (#4909) Thanks @YuriNachos.
@@ -995,6 +1010,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Messages: extend `suppressToolErrors` to accept `"all"` to suppress ALL tool-error warnings including mutating tools (exec, write, edit). (#18630)
 - Skills: update session-logs paths to use ~/.openclaw. (#4502) Thanks @bonald.
 - Telegram: avoid silent empty replies by tracking normalization skips before fallback. (#3796)
 - Mentions: honor mentionPatterns even when explicit mentions are present. (#3303) Thanks @HirokiKobayashi-R.
@@ -1049,6 +1065,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Messages: extend `suppressToolErrors` to accept `"all"` to suppress ALL tool-error warnings including mutating tools (exec, write, edit). (#18630)
 - Slack: fix image downloads failing due to missing Authorization header on cross-origin redirects. (#1936) Thanks @sanderhelgesen.
 - Gateway: harden reverse proxy handling for local-client detection and unauthenticated proxied connects. (#1795) Thanks @orlyjamie.
 - Security audit: flag loopback Control UI with auth disabled as critical. (#1795) Thanks @orlyjamie.
@@ -1058,12 +1075,14 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Messages: extend `suppressToolErrors` to accept `"all"` to suppress ALL tool-error warnings including mutating tools (exec, write, edit). (#18630)
 - Packaging: include dist/link-understanding output in npm tarball (fixes missing apply.js import on install).
 
 ## 2026.1.24-1
 
 ### Fixes
 
+- Messages: extend `suppressToolErrors` to accept `"all"` to suppress ALL tool-error warnings including mutating tools (exec, write, edit). (#18630)
 - Packaging: include dist/shared output in npm tarball (fixes missing reasoning-tags import on install).
 
 ## 2026.1.24
@@ -1097,6 +1116,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Messages: extend `suppressToolErrors` to accept `"all"` to suppress ALL tool-error warnings including mutating tools (exec, write, edit). (#18630)
 - Web UI: fix config/debug layout overflow, scrolling, and code block sizing. (#1715) Thanks @saipreetham589.
 - Web UI: show Stop button during active runs, swap back to New session when idle. (#1664) Thanks @ndbroadbent.
 - Web UI: clear stale disconnect banners on reconnect; allow form saves with unsupported schema paths but block missing schema. (#1707) Thanks @Glucksberg.
@@ -1141,6 +1161,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Messages: extend `suppressToolErrors` to accept `"all"` to suppress ALL tool-error warnings including mutating tools (exec, write, edit). (#18630)
 - Packaging: include dist/tts output in npm tarball (fixes missing dist/tts/tts.js).
 
 ## 2026.1.23
@@ -1170,6 +1191,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Messages: extend `suppressToolErrors` to accept `"all"` to suppress ALL tool-error warnings including mutating tools (exec, write, edit). (#18630)
 - Sessions: accept non-UUID sessionIds for history/send/status while preserving agent scoping. (#1518)
 - Heartbeat: accept plugin channel ids for heartbeat target validation + UI hints.
 - Messaging/Sessions: mirror outbound sends into target session keys (threads + dmScope), create session entries on send, and normalize session key casing. (#1520, commit 4b6cdd1d3)
@@ -1217,6 +1239,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Messages: extend `suppressToolErrors` to accept `"all"` to suppress ALL tool-error warnings including mutating tools (exec, write, edit). (#18630)
 - BlueBubbles: stop typing indicator on idle/no-reply. (#1439) Thanks @Nicell.
 - Message tool: keep path/filePath as-is for send; hydrate buffers only for sendAttachment. (#1444) Thanks @hopyky.
 - Auto-reply: only report a model switch when session state is available. (#1465) Thanks @robbyczgw-cla.
@@ -1248,6 +1271,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Messages: extend `suppressToolErrors` to accept `"all"` to suppress ALL tool-error warnings including mutating tools (exec, write, edit). (#18630)
 - Control UI: ignore bootstrap identity placeholder text for avatar values and fall back to the default avatar. https://docs.openclaw.ai/cli/agents https://docs.openclaw.ai/web/control-ui
 - Slack: remove deprecated `filetype` field from `files.uploadV2` to eliminate API warnings. (#1447)
 
@@ -1283,6 +1307,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Messages: extend `suppressToolErrors` to accept `"all"` to suppress ALL tool-error warnings including mutating tools (exec, write, edit). (#18630)
 - Nodes/macOS: prompt on allowlist miss for node exec approvals, persist allowlist decisions, and flatten node invoke errors. (#1394) Thanks @ngutman.
 - Gateway: keep auto bind loopback-first and add explicit tailnet binding to avoid Tailscale taking over local UI. (#1380)
 - Memory: prevent CLI hangs by deferring vector probes, adding sqlite-vec/embedding timeouts, and showing sync progress early.
@@ -1389,6 +1414,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Messages: extend `suppressToolErrors` to accept `"all"` to suppress ALL tool-error warnings including mutating tools (exec, write, edit). (#18630)
 - Discovery: shorten Bonjour DNS-SD service type to `_moltbot-gw._tcp` and update discovery clients/docs.
 - Diagnostics: export OTLP logs, correct queue depth tracking, and document message-flow telemetry.
 - Diagnostics: emit message-flow diagnostics across channels via shared dispatch. (#1244)
@@ -1550,6 +1576,7 @@ Thanks @AlexMikhalev, @CoreyH, @John-Rood, @KrauseFx, @MaudeBot, @Nachx639, @Nic
 
 ### Fixes
 
+- Messages: extend `suppressToolErrors` to accept `"all"` to suppress ALL tool-error warnings including mutating tools (exec, write, edit). (#18630)
 - macOS: drain subprocess pipes before waiting to avoid deadlocks. (#1081) — thanks @thesash.
 - Verbose: wrap tool summaries/output in markdown only for markdown-capable channels.
 - Tools: include provider/session context in elevated exec denial errors.
@@ -1660,6 +1687,7 @@ Thanks @AlexMikhalev, @CoreyH, @John-Rood, @KrauseFx, @MaudeBot, @Nachx639, @Nic
 
 ### Fixes
 
+- Messages: extend `suppressToolErrors` to accept `"all"` to suppress ALL tool-error warnings including mutating tools (exec, write, edit). (#18630)
 - Messages: make `/stop` clear queued followups and pending session lane work for a hard abort.
 - Messages: make `/stop` abort active sub-agent runs spawned from the requester session and report how many were stopped.
 - WhatsApp: report linked status consistently in channel status. (#1050) — thanks @YuriNachos.
@@ -1721,6 +1749,7 @@ Thanks @AlexMikhalev, @CoreyH, @John-Rood, @KrauseFx, @MaudeBot, @Nachx639, @Nic
 
 ### Fixes
 
+- Messages: extend `suppressToolErrors` to accept `"all"` to suppress ALL tool-error warnings including mutating tools (exec, write, edit). (#18630)
 - Sessions: refactor session store updates to lock + mutate per-entry, add chat.inject, and harden subagent cleanup flow. (#944) — thanks @tyler6204.
 - Browser: add tests for snapshot labels/efficient query params and labeled image responses.
 - Google: downgrade unsigned thinking blocks before send to avoid missing signature errors.
@@ -1751,6 +1780,7 @@ Thanks @AlexMikhalev, @CoreyH, @John-Rood, @KrauseFx, @MaudeBot, @Nachx639, @Nic
 
 ### Fixes
 
+- Messages: extend `suppressToolErrors` to accept `"all"` to suppress ALL tool-error warnings including mutating tools (exec, write, edit). (#18630)
 - Mac: pass auth token/password to dashboard URL for authenticated access. (#918) — thanks @rahthakor.
 - UI: use application-defined WebSocket close code (browser compatibility). (#918) — thanks @rahthakor.
 - TUI: render picker overlays via the overlay stack so /models and /settings display. (#921) — thanks @grizzdank.
@@ -1793,6 +1823,7 @@ Thanks @AlexMikhalev, @CoreyH, @John-Rood, @KrauseFx, @MaudeBot, @Nachx639, @Nic
 
 ### Fixes
 
+- Messages: extend `suppressToolErrors` to accept `"all"` to suppress ALL tool-error warnings including mutating tools (exec, write, edit). (#18630)
 - Postinstall: treat already-applied pnpm patches as no-ops to avoid npm/bun install failures.
 - Packaging: pin `@mariozechner/pi-ai` to 0.45.7 and refresh patched dependency to match npm resolution.
 
@@ -1800,6 +1831,7 @@ Thanks @AlexMikhalev, @CoreyH, @John-Rood, @KrauseFx, @MaudeBot, @Nachx639, @Nic
 
 ### Fixes
 
+- Messages: extend `suppressToolErrors` to accept `"all"` to suppress ALL tool-error warnings including mutating tools (exec, write, edit). (#18630)
 - Packaging: include `dist/memory/**` in the npm tarball (fixes `ERR_MODULE_NOT_FOUND` for `dist/memory/index.js`).
 - Agents: persist sub-agent registry across gateway restarts and resume announce flow safely. (#831) — thanks @roshanasingh4.
 - Agents: strip invalid Gemini thought signatures from OpenRouter history to avoid 400s. (#841, #845) — thanks @MatthieuBizien.
@@ -1808,6 +1840,7 @@ Thanks @AlexMikhalev, @CoreyH, @John-Rood, @KrauseFx, @MaudeBot, @Nachx639, @Nic
 
 ### Fixes
 
+- Messages: extend `suppressToolErrors` to accept `"all"` to suppress ALL tool-error warnings including mutating tools (exec, write, edit). (#18630)
 - Packaging: include `dist/channels/**` in the npm tarball (fixes `ERR_MODULE_NOT_FOUND` for `dist/channels/registry.js`).
 
 ## 2026.1.12
@@ -1841,6 +1874,7 @@ Thanks @AlexMikhalev, @CoreyH, @John-Rood, @KrauseFx, @MaudeBot, @Nachx639, @Nic
 
 ### Fixes
 
+- Messages: extend `suppressToolErrors` to accept `"all"` to suppress ALL tool-error warnings including mutating tools (exec, write, edit). (#18630)
 - Doctor: warn on pnpm workspace mismatches, missing Control UI assets, and missing tsx binaries; offer UI rebuilds.
 - Tools: apply global tool allow/deny even when agent-specific tool policy is set.
 - Models/Providers: treat credential validation failures as auth errors to trigger fallback; normalize `${ENV_VAR}` apiKey values and auto-fill missing provider keys; preserve explicit GitHub Copilot provider config + agent-dir auth profiles. (#822) — thanks @sebslight; (#705) — thanks @TAGOOZ.
@@ -1926,6 +1960,7 @@ Thanks @AlexMikhalev, @CoreyH, @John-Rood, @KrauseFx, @MaudeBot, @Nachx639, @Nic
 
 ### Fixes
 
+- Messages: extend `suppressToolErrors` to accept `"all"` to suppress ALL tool-error warnings including mutating tools (exec, write, edit). (#18630)
 - Models/Onboarding: configure MiniMax (minimax.io) via Anthropic-compatible `/anthropic` endpoint by default (keep `minimax-api` as a legacy alias).
 - Models: normalize Gemini 3 Pro/Flash IDs to preview names for live model lookups. (#769) — thanks @steipete.
 - CLI: fix guardCancel typing for configure prompts. (#769) — thanks @steipete.
@@ -1987,6 +2022,7 @@ Thanks @AlexMikhalev, @CoreyH, @John-Rood, @KrauseFx, @MaudeBot, @Nachx639, @Nic
 
 ### Fixes
 
+- Messages: extend `suppressToolErrors` to accept `"all"` to suppress ALL tool-error warnings including mutating tools (exec, write, edit). (#18630)
 - Auto-reply: suppress draft/typing streaming for `NO_REPLY` (silent system ops) so it doesn’t leak partial output.
 - CLI/Status: expand tables to full terminal width; clarify provider setup vs runtime warnings; richer per-provider detail; token previews in `status` while keeping `status --all` redacted; add troubleshooting link footer; keep log tails pasteable; show gateway auth used when reachable; surface provider runtime errors (Signal/iMessage/Slack); harden `tailscale status --json` parsing; make `status --all` scan progress determinate; and replace the footer with a 3-line “Next steps” recommendation (share/debug/probe).
 - CLI/Gateway: clarify that `openclaw gateway status` reports RPC health (connect + RPC) and shows RPC failures separately from connect failures.
@@ -2099,6 +2135,7 @@ Thanks @AlexMikhalev, @CoreyH, @John-Rood, @KrauseFx, @MaudeBot, @Nachx639, @Nic
 
 ### Fixes
 
+- Messages: extend `suppressToolErrors` to accept `"all"` to suppress ALL tool-error warnings including mutating tools (exec, write, edit). (#18630)
 - Packaging: include MS Teams send module in npm tarball.
 - Sandbox/Browser: auto-start CDP endpoint; proxy CDP out of container for attachOnly; relax Bun fetch typing; align sandbox list output with config images.
 - Agents/Runtime: gate heartbeat prompt to default sessions; /stop aborts between tool calls; require explicit system-event session keys; guard small context windows; fix model fallback stringification; sessions_spawn inherits provider; failover on billing/credits; respect auth cooldown ordering; restore Anthropic OAuth tool dispatch + tool-name bypass; avoid OpenAI invalid reasoning replay; harden Gmail hook model defaults.
@@ -2151,6 +2188,7 @@ Thanks @AlexMikhalev, @CoreyH, @John-Rood, @KrauseFx, @MaudeBot, @Nachx639, @Nic
 
 ### Fixes
 
+- Messages: extend `suppressToolErrors` to accept `"all"` to suppress ALL tool-error warnings including mutating tools (exec, write, edit). (#18630)
 - **CLI/Gateway/Doctor:** daemon runtime selection + improved logs/status/health/errors; auth/password handling for local CLI; richer close/timeout details; auto-migrate legacy config/sessions/state; integrity checks + repair prompts; `--yes`/`--non-interactive`; `--deep` gateway scans; better restart/service hints.
 - **Agent loop + compaction:** compaction/pruning tuning, overflow handling, safer bootstrap context, and per-provider threading/confirmations; opt-in tool-result pruning + compact tracking.
 - **Sandbox + tools:** per-agent sandbox overrides, workspaceAccess controls, session tool visibility, tool policy overrides, process isolation, and tool schema/timeout/reaction unification.
@@ -2179,6 +2217,7 @@ Thanks @AlexMikhalev, @CoreyH, @John-Rood, @KrauseFx, @MaudeBot, @Nachx639, @Nic
 
 ### Fixes
 
+- Messages: extend `suppressToolErrors` to accept `"all"` to suppress ALL tool-error warnings including mutating tools (exec, write, edit). (#18630)
 - Control UI: render Markdown in tool result cards.
 - Control UI: prevent overlapping action buttons in Discord guild rules on narrow layouts.
 - Android: tapping the foreground service notification brings the app to the front. (#179) — thanks @Syhids

--- a/extensions/mattermost/src/mattermost/monitor-websocket.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-websocket.test.ts
@@ -185,6 +185,9 @@ describe("mattermost websocket monitor", () => {
       webSocketFactory: () => socket,
     });
 
+    // Start connectOnce so listeners are registered before emitting events
+    const promise = connectOnce();
+
     socket.emitOpen();
     socket.emitMessage(
       Buffer.from(
@@ -202,7 +205,7 @@ describe("mattermost websocket monitor", () => {
     );
     socket.emitClose(1000);
 
-    await connectOnce();
+    await promise;
 
     expect(onReaction).toHaveBeenCalledTimes(1);
     expect(onPosted).not.toHaveBeenCalled();

--- a/src/agents/pi-embedded-runner/run/payloads.e2e.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.e2e.test.ts
@@ -261,6 +261,24 @@ describe("buildEmbeddedRunPayloads", () => {
     expect(payloads).toHaveLength(0);
   });
 
+  it('suppresses mutating tool errors when suppressToolErrors is "all"', () => {
+    const payloads = buildPayloads({
+      lastToolError: { toolName: "exec", error: "command not found", mutatingAction: true },
+      config: { messages: { suppressToolErrors: "all" } },
+    });
+
+    expect(payloads).toHaveLength(0);
+  });
+
+  it('suppresses non-mutating tool errors when suppressToolErrors is "all"', () => {
+    const payloads = buildPayloads({
+      lastToolError: { toolName: "browser", error: "timeout" },
+      config: { messages: { suppressToolErrors: "all" } },
+    });
+
+    expect(payloads).toHaveLength(0);
+  });
+
   it("shows recoverable tool errors for mutating tools", () => {
     const payloads = buildPayloads({
       lastToolError: { toolName: "message", meta: "reply", error: "text required" },

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -47,10 +47,13 @@ function isRecoverableToolError(error: string | undefined): boolean {
 function shouldShowToolErrorWarning(params: {
   lastToolError: LastToolError;
   hasUserFacingReply: boolean;
-  suppressToolErrors: boolean;
+  suppressToolErrors: boolean | "all";
   suppressToolErrorWarnings?: boolean;
 }): boolean {
   if (params.suppressToolErrorWarnings) {
+    return false;
+  }
+  if (params.suppressToolErrors === "all") {
     return false;
   }
   const isMutatingToolError =
@@ -251,7 +254,7 @@ export function buildEmbeddedRunPayloads(params: {
     const shouldShowToolError = shouldShowToolErrorWarning({
       lastToolError: params.lastToolError,
       hasUserFacingReply: hasUserFacingAssistantReply,
-      suppressToolErrors: Boolean(params.config?.messages?.suppressToolErrors),
+      suppressToolErrors: params.config?.messages?.suppressToolErrors === "all" ? "all" : Boolean(params.config?.messages?.suppressToolErrors),
       suppressToolErrorWarnings: params.suppressToolErrorWarnings,
     });
 

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -254,7 +254,10 @@ export function buildEmbeddedRunPayloads(params: {
     const shouldShowToolError = shouldShowToolErrorWarning({
       lastToolError: params.lastToolError,
       hasUserFacingReply: hasUserFacingAssistantReply,
-      suppressToolErrors: params.config?.messages?.suppressToolErrors === "all" ? "all" : Boolean(params.config?.messages?.suppressToolErrors),
+      suppressToolErrors:
+        params.config?.messages?.suppressToolErrors === "all"
+          ? "all"
+          : Boolean(params.config?.messages?.suppressToolErrors),
       suppressToolErrorWarnings: params.suppressToolErrorWarnings,
     });
 

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -36,4 +36,24 @@ describe("config schema regressions", () => {
 
     expect(res.ok).toBe(true);
   });
+
+  it('accepts suppressToolErrors "all" mode', () => {
+    const res = validateConfigObject({
+      messages: {
+        suppressToolErrors: "all",
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("accepts suppressToolErrors boolean true", () => {
+    const res = validateConfigObject({
+      messages: {
+        suppressToolErrors: true,
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
 });

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -348,7 +348,7 @@ export const FIELD_HELP: Record<string, string> = {
   "channels.telegram.customCommands":
     "Additional Telegram bot menu commands (merged with native; conflicts ignored).",
   "messages.suppressToolErrors":
-    "When true, suppress ⚠️ tool-error warnings from being shown to the user. The agent already sees errors in context and can retry. Default: false.",
+    'Suppress ⚠️ tool-error warnings (true = non-mutating only; "all" = all errors including mutating tools). Default: false.',
   "messages.ackReaction": "Emoji reaction used to acknowledge inbound messages (empty disables).",
   "messages.ackReactionScope":
     'When to send ack reactions ("group-mentions", "group-all", "direct", "all").',

--- a/src/config/types.messages.ts
+++ b/src/config/types.messages.ts
@@ -82,8 +82,13 @@ export type MessagesConfig = {
   ackReactionScope?: "group-mentions" | "group-all" | "direct" | "all";
   /** Remove ack reaction after reply is sent (default: false). */
   removeAckAfterReply?: boolean;
-  /** When true, suppress ⚠️ tool-error warnings from being shown to the user. Default: false. */
-  suppressToolErrors?: boolean;
+  /**
+   * Suppress ⚠️ tool-error warnings from being shown to the user.
+   * - `true`: suppress non-mutating tool errors only
+   * - `"all"`: suppress ALL tool errors including mutating (exec, write, edit)
+   * Default: false.
+   */
+  suppressToolErrors?: boolean | "all";
   /** Text-to-speech settings for outbound replies. */
   tts?: TtsConfig;
 };

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -114,7 +114,7 @@ export const MessagesSchema = z
     ackReaction: z.string().optional(),
     ackReactionScope: z.enum(["group-mentions", "group-all", "direct", "all"]).optional(),
     removeAckAfterReply: z.boolean().optional(),
-    suppressToolErrors: z.boolean().optional(),
+    suppressToolErrors: z.union([z.boolean(), z.literal("all")]).optional(),
     tts: TtsConfigSchema,
   })
   .strict()


### PR DESCRIPTION
## Summary
The existing `messages.suppressToolErrors: true` only suppressed non-mutating tool errors. Mutating tools (exec, write, edit) always emitted warning messages even when the assistant handles errors gracefully. This adds `"all"` mode to suppress everything.

## Problem
Users running always-on assistants via Telegram/Discord see raw tool error messages for transient errors that the assistant already retried or handled in-context.

## Solution
Extend `suppressToolErrors` to accept a string mode:
- `false` (default): current behavior
- `true`: suppress non-mutating tool errors only (unchanged)
- `"all"`: suppress ALL tool errors including mutating

Backward-compatible — existing boolean configs work unchanged.

## Changes
- `src/config/types.messages.ts` — widen type to `boolean | "all"`
- `src/config/zod-schema.session.ts` — accept union of boolean and `"all"` literal
- `src/agents/pi-embedded-runner/run/payloads.ts` — handle `"all"` mode in `shouldShowToolErrorWarning()`
- `src/config/schema.help.ts` — update help text
- `src/config/config.schema-regressions.test.ts` — 2 new schema tests
- `src/agents/pi-embedded-runner/run/payloads.e2e.test.ts` — 2 new behavioral tests

## Test plan
- [x] Schema regression: `suppressToolErrors: "all"` validates
- [x] Schema regression: `suppressToolErrors: true` still validates
- [x] All 4 schema regression tests pass
- [x] `pnpm build` passes

Closes #18630

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extends `messages.suppressToolErrors` from a boolean to `boolean | "all"`, allowing users to suppress all tool-error warnings — including mutating tools (exec, write, edit) — for always-on assistants that handle transient errors in-context. The type, Zod schema, and core `shouldShowToolErrorWarning()` logic are updated correctly with full backward compatibility.

- **CHANGELOG duplication**: The changelog entry is inserted 39 times (once in every release section). It should only appear under `2026.2.16 (Unreleased)`.
- **Help text not updated**: `src/config/schema.help.ts` still describes only the boolean behavior and doesn't mention the new `"all"` mode, so users discovering the setting via help/docs won't know about it.
- **Tests**: 4 new tests (2 schema regressions, 2 behavioral e2e) cover the new mode well.

<h3>Confidence Score: 2/5</h3>

- Core logic is sound but the CHANGELOG has 38 erroneous duplicate entries across all historical releases that must be removed before merge.
- The actual feature implementation (type, schema, runtime logic, tests) is correct and backward-compatible. However, the CHANGELOG.md has the same entry duplicated 39 times under every release section, which is clearly a mistake and would corrupt the release history. Additionally, the help text was not updated to reflect the new option. These issues are straightforward to fix but should be addressed before merging.
- CHANGELOG.md has 38 duplicate entries that must be cleaned up. src/config/schema.help.ts needs its help text updated for the new "all" mode.

<sub>Last reviewed commit: 1b47d7f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->