### PR TITLE
fix(message): use currentMessageId for react fallback and suppress recoverable react warnings

### DIFF
--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -49,6 +49,8 @@ export function createOpenClawTools(options?: {
   currentChannelId?: string;
   /** Current thread timestamp for auto-threading (Slack). */
   currentThreadTs?: string;
+  /** Current message id for reaction/reply helpers. */
+  currentMessageId?: string;
   /** Reply-to mode for Slack auto-threading. */
   replyToMode?: "off" | "first" | "all";
   /** Mutable ref to track if a reply was sent (for "first" mode). */
@@ -96,6 +98,7 @@ export function createOpenClawTools(options?: {
         currentChannelId: options?.currentChannelId,
         currentChannelProvider: options?.agentChannel,
         currentThreadTs: options?.currentThreadTs,
+        currentMessageId: options?.currentMessageId,
         replyToMode: options?.replyToMode,
         hasRepliedRef: options?.hasRepliedRef,
         sandboxRoot: options?.sandboxRoot,

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -553,6 +553,7 @@ export async function runEmbeddedPiAgent(
             senderIsOwner: params.senderIsOwner,
             currentChannelId: params.currentChannelId,
             currentThreadTs: params.currentThreadTs,
+            currentMessageId: params.currentMessageId,
             replyToMode: params.replyToMode,
             hasRepliedRef: params.hasRepliedRef,
             sessionFile: params.sessionFile,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -389,6 +389,7 @@ export async function runEmbeddedAttempt(
           modelAuthMode: resolveModelAuthMode(params.model.provider, params.config),
           currentChannelId: params.currentChannelId,
           currentThreadTs: params.currentThreadTs,
+          currentMessageId: params.currentMessageId,
           replyToMode: params.replyToMode,
           hasRepliedRef: params.hasRepliedRef,
           modelHasVision,

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -48,6 +48,8 @@ export type RunEmbeddedPiAgentParams = {
   currentChannelId?: string;
   /** Current thread timestamp for auto-threading (Slack). */
   currentThreadTs?: string;
+  /** Current message id for reaction/reply helpers. */
+  currentMessageId?: string;
   /** Reply-to mode for Slack auto-threading. */
   replyToMode?: "off" | "first" | "all";
   /** Mutable ref to track if a reply was sent (for "first" mode). */

--- a/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
@@ -277,6 +277,20 @@ describe("buildEmbeddedRunPayloads", () => {
     expectSingleToolErrorPayload(payloads, { title, absentDetail });
   });
 
+  it("suppresses recoverable message react input errors", () => {
+    const payloads = buildPayloads({
+      lastToolError: {
+        toolName: "message",
+        meta: "react · to=group:123",
+        error: "messageId required",
+        mutatingAction: true,
+        actionFingerprint: "tool=message|action=react|to=group:123",
+      },
+    });
+
+    expect(payloads).toHaveLength(0);
+  });
+
   it("shows mutating tool errors even when assistant output exists", () => {
     const payloads = buildPayloads({
       assistantTexts: ["Done."],

--- a/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
@@ -304,7 +304,8 @@ describe("buildEmbeddedRunPayloads", () => {
 
     expect(payloads).toHaveLength(1);
     expect(payloads[0]?.isError).toBe(true);
-    expect(payloads[0]?.text).toContain("emoji required");
+    expect(payloads[0]?.text).toContain("Message: react");
+    expect(payloads[0]?.text).not.toContain("emoji required");
   });
 
   it("shows mutating tool errors even when assistant output exists", () => {

--- a/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
@@ -291,6 +291,22 @@ describe("buildEmbeddedRunPayloads", () => {
     expect(payloads).toHaveLength(0);
   });
 
+  it("does not suppress non-messageId react input errors", () => {
+    const payloads = buildPayloads({
+      lastToolError: {
+        toolName: "message",
+        meta: "react · to=group:123",
+        error: "emoji required",
+        mutatingAction: true,
+        actionFingerprint: "tool=message|action=react|to=group:123",
+      },
+    });
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.isError).toBe(true);
+    expect(payloads[0]?.text).toContain("emoji required");
+  });
+
   it("shows mutating tool errors even when assistant output exists", () => {
     const payloads = buildPayloads({
       assistantTexts: ["Done."],

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -196,6 +196,8 @@ export function createOpenClawCodingTools(options?: {
   currentChannelId?: string;
   /** Current thread timestamp for auto-threading (Slack). */
   currentThreadTs?: string;
+  /** Current message id for reaction/reply helpers. */
+  currentMessageId?: string;
   /** Group id for channel-level tool policy resolution. */
   groupId?: string | null;
   /** Group channel label (e.g. #general) for channel-level tool policy resolution. */
@@ -459,6 +461,7 @@ export function createOpenClawCodingTools(options?: {
       ]),
       currentChannelId: options?.currentChannelId,
       currentThreadTs: options?.currentThreadTs,
+      currentMessageId: options?.currentMessageId,
       replyToMode: options?.replyToMode,
       hasRepliedRef: options?.hasRepliedRef,
       modelHasVision: options?.modelHasVision,

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -51,6 +51,33 @@ describe("message tool agent routing", () => {
     expect(call?.agentId).toBe("alpha");
     expect(call?.sessionKey).toBe("agent:alpha:main");
   });
+
+  it("forwards currentMessageId into tool context for react fallback", async () => {
+    mocks.runMessageAction.mockClear();
+    mocks.runMessageAction.mockResolvedValue({
+      kind: "action",
+      action: "react",
+      channel: "telegram",
+      handledBy: "plugin",
+      payload: { ok: true },
+      dryRun: true,
+    } satisfies MessageActionRunResult);
+
+    const tool = createMessageTool({
+      config: {} as never,
+      currentChannelProvider: "telegram",
+      currentMessageId: "chat:99:123",
+    });
+
+    await tool.execute("1", {
+      action: "react",
+      target: "chat:99",
+      emoji: "✅",
+    });
+
+    const call = mocks.runMessageAction.mock.calls[0]?.[0];
+    expect(call?.toolContext?.currentMessageId).toBe("chat:99:123");
+  });
 });
 
 describe("message tool path passthrough", () => {

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -425,6 +425,7 @@ type MessageToolOptions = {
   currentChannelId?: string;
   currentChannelProvider?: string;
   currentThreadTs?: string;
+  currentMessageId?: string;
   replyToMode?: "off" | "first" | "all";
   hasRepliedRef?: { value: boolean };
   sandboxRoot?: string;
@@ -638,12 +639,14 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
         options?.currentChannelId ||
         options?.currentChannelProvider ||
         options?.currentThreadTs ||
+        options?.currentMessageId ||
         options?.replyToMode ||
         options?.hasRepliedRef
           ? {
               currentChannelId: options?.currentChannelId,
               currentChannelProvider: options?.currentChannelProvider,
               currentThreadTs: options?.currentThreadTs,
+              currentMessageId: options?.currentMessageId,
               replyToMode: options?.replyToMode,
               hasRepliedRef: options?.hasRepliedRef,
               // Direct tool invocations should not add cross-context decoration.

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -22,6 +22,7 @@ export function buildThreadingToolContext(params: {
   hasRepliedRef: { value: boolean } | undefined;
 }): ChannelThreadingToolContext {
   const { sessionCtx, config, hasRepliedRef } = params;
+  const currentMessageId = sessionCtx.MessageSidFull ?? sessionCtx.MessageSid;
   if (!config) {
     return {};
   }
@@ -36,6 +37,7 @@ export function buildThreadingToolContext(params: {
     return {
       currentChannelId: sessionCtx.To?.trim() || undefined,
       currentChannelProvider: provider ?? (rawProvider as ChannelId),
+      ...(currentMessageId ? { currentMessageId } : {}),
       hasRepliedRef,
     };
   }
@@ -57,6 +59,7 @@ export function buildThreadingToolContext(params: {
   return {
     ...context,
     currentChannelProvider: provider!, // guaranteed non-null since dock exists
+    ...(currentMessageId ? { currentMessageId } : {}),
   };
 }
 

--- a/src/auto-reply/reply/reply-plumbing.test.ts
+++ b/src/auto-reply/reply/reply-plumbing.test.ts
@@ -145,6 +145,23 @@ describe("buildThreadingToolContext", () => {
     expect(result.currentChannelId).toBe("C1");
     expect(result.currentThreadTs).toBe("123.456");
   });
+
+  it("exposes current message id for action tools", () => {
+    const sessionCtx = {
+      Provider: "telegram",
+      To: "chat:99",
+      MessageSid: "123",
+      MessageSidFull: "chat:99:123",
+    } as TemplateContext;
+
+    const result = buildThreadingToolContext({
+      sessionCtx,
+      config: cfg,
+      hasRepliedRef: undefined,
+    });
+
+    expect(result.currentMessageId).toBe("chat:99:123");
+  });
 });
 
 describe("applyReplyThreading auto-threading", () => {

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -258,6 +258,7 @@ export type ChannelThreadingContext = {
 export type ChannelThreadingToolContext = {
   currentChannelId?: string;
   currentChannelProvider?: ChannelId;
+  currentMessageId?: string;
   currentThreadTs?: string;
   replyToMode?: "off" | "first" | "all";
   hasRepliedRef?: { value: boolean };

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -745,6 +745,13 @@ export async function runMessageAction(
   }
 
   applyTargetToParams({ action, args: params });
+  if (action === "react") {
+    const messageId = readStringParam(params, "messageId");
+    const currentMessageId = input.toolContext?.currentMessageId?.trim();
+    if (!messageId && currentMessageId) {
+      params.messageId = currentMessageId;
+    }
+  }
   if (actionRequiresTarget(action)) {
     if (!actionHasTarget(action, params)) {
       throw new Error(`Action ${action} requires a target.`);


### PR DESCRIPTION
## Summary
Improve agent-initiated `message(action=react)` behavior by wiring `currentMessageId` through the embedded tool pipeline and using it as the fallback source when `messageId` is missing.

Also suppresses recoverable react input warnings (for example `messageId required`) from user-visible payloads to avoid noisy error text leaks.

## Changes
- Add `currentMessageId` to `ChannelThreadingToolContext` and threading context builder.
- In `runMessageAction`, for `react`, fill `params.messageId` from `toolContext.currentMessageId` when missing.
- Wire `currentMessageId` through embedded runner/tool creation path:
  - `run/params.ts`, `run.ts`, `run/attempt.ts`
  - `pi-tools.ts`, `openclaw-tools.ts`, `message-tool.ts`
- Add/adjust tests:
  - `message-action-runner.test.ts`
  - `reply-plumbing.test.ts`
  - `message-tool.e2e.test.ts`
  - `payloads.e2e.test.ts`

## Validation
- `pnpm vitest run src/infra/outbound/message-action-runner.test.ts src/auto-reply/reply/reply-plumbing.test.ts`
- `pnpm vitest run --config vitest.e2e.config.ts src/agents/pi-embedded-runner/run/payloads.e2e.test.ts src/agents/tools/message-tool.e2e.test.ts`
- `pnpm build`

Refs #18154
Refs #17782
Refs #17651

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires `currentMessageId` through the embedded tool pipeline so that `message(action=react)` can use it as a fallback when the LLM omits `messageId`. It also adds a suppression mechanism for recoverable react input errors in the payload builder to avoid leaking noisy warnings into user-facing chats.

- Adds `currentMessageId` to `ChannelThreadingToolContext` and propagates it through `buildThreadingToolContext`, `RunEmbeddedPiAgentParams`, `createOpenClawCodingTools`, `createOpenClawTools`, `createMessageTool`, and the embedded runner/attempt pipeline.
- In `runMessageAction`, fills `params.messageId` from `toolContext.currentMessageId` when the action is `react` and `messageId` is missing — this is the core behavior fix.
- Adds `isRecoverableMessageReactInputError` in `payloads.ts` to suppress user-visible warning payloads for react input errors. **However, the suppression is overly broad**: it matches any `RECOVERABLE_TOOL_ERROR_KEYWORDS` (e.g., "required", "missing", "invalid") for react actions, not just `messageId`-related ones. This could silently hide legitimate errors like Discord's `"emoji required"` when the emoji string is empty.
- Tests cover the new `messageId` inference, context forwarding, and suppression behavior, though the suppression test only exercises the `"messageId required"` case.

<h3>Confidence Score: 3/5</h3>

- The core `messageId` fallback logic is correct and well-tested, but the error suppression in `payloads.ts` is too broad and could hide legitimate react errors.
- The plumbing of `currentMessageId` through the pipeline (12 of 14 files) is clean, consistent with existing patterns (`currentChannelId`, `currentThreadTs`), and well-tested. The `runMessageAction` fallback logic is correctly placed and guarded. However, `isRecoverableMessageReactInputError` suppresses all recoverable-keyword errors for react actions, not just `messageId`-specific ones — this could silently hide errors like "emoji required" from Discord. Score reflects the one meaningful logic concern in an otherwise well-executed PR.
- `src/agents/pi-embedded-runner/run/payloads.ts` — the `isRecoverableMessageReactInputError` function's error matching is too broad and should be narrowed to `messageId`-related errors specifically.

<sub>Last reviewed commit: 42a1f41</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->