### PR TITLE
fix(bootstrap): clarify truncation warning with budget context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Bootstrap: clarify truncation warning to distinguish per-file limit from total bootstrap budget exhaustion, so users understand why the effective limit may be lower than `bootstrapMaxChars`. (#18690)
 - Voice-call: auto-end calls when media streams disconnect to prevent stuck active calls. (#18435) Thanks @JayMishra-source.
 - Gateway/Channels: wire `gateway.channelHealthCheckMinutes` into strict config validation, treat implicit account status as managed for health checks, and harden channel auto-restart flow (preserve restart-attempt caps across crash loops, propagate enabled/configured runtime flags, and stop pending restart backoff after manual stop). Thanks @steipete.
 - Gateway/WebChat: hard-cap `chat.history` oversized payloads by truncating high-cost fields and replacing over-budget entries with placeholders, so history fetches stay within configured byte limits and avoid chat UI freezes. (#18505)

--- a/extensions/mattermost/src/mattermost/monitor-websocket.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-websocket.test.ts
@@ -185,6 +185,9 @@ describe("mattermost websocket monitor", () => {
       webSocketFactory: () => socket,
     });
 
+    // Start connectOnce so listeners are registered before emitting events
+    const promise = connectOnce();
+
     socket.emitOpen();
     socket.emitMessage(
       Buffer.from(
@@ -202,7 +205,7 @@ describe("mattermost websocket monitor", () => {
     );
     socket.emitClose(1000);
 
-    await connectOnce();
+    await promise;
 
     expect(onReaction).toHaveBeenCalledTimes(1);
     expect(onPosted).not.toHaveBeenCalled();

--- a/src/agents/pi-embedded-helpers/bootstrap-warning.test.ts
+++ b/src/agents/pi-embedded-helpers/bootstrap-warning.test.ts
@@ -2,9 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { WorkspaceBootstrapFile } from "../workspace.js";
 import { buildBootstrapContextFiles } from "./bootstrap.js";
 
-const makeFile = (
-  overrides: Partial<WorkspaceBootstrapFile>,
-): WorkspaceBootstrapFile => ({
+const makeFile = (overrides: Partial<WorkspaceBootstrapFile>): WorkspaceBootstrapFile => ({
   name: "AGENTS.md",
   path: "/tmp/AGENTS.md",
   content: "",

--- a/src/agents/pi-embedded-helpers/bootstrap-warning.test.ts
+++ b/src/agents/pi-embedded-helpers/bootstrap-warning.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import type { WorkspaceBootstrapFile } from "../workspace.js";
+import { buildBootstrapContextFiles } from "./bootstrap.js";
+
+const makeFile = (
+  overrides: Partial<WorkspaceBootstrapFile>,
+): WorkspaceBootstrapFile => ({
+  name: "AGENTS.md",
+  path: "/tmp/AGENTS.md",
+  content: "",
+  missing: false,
+  ...overrides,
+});
+
+describe("bootstrap truncation warning", () => {
+  it("shows per-file limit when truncated within per-file budget", () => {
+    const files = [makeFile({ name: "MEMORY.md", content: "x".repeat(500) })];
+    const warnings: string[] = [];
+    buildBootstrapContextFiles(files, {
+      maxChars: 200,
+      warn: (msg) => warnings.push(msg),
+    });
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("per-file limit 200");
+    expect(warnings[0]).not.toContain("total remaining");
+  });
+
+  it("shows total budget detail when per-file budget is reduced by earlier files", () => {
+    const files = [
+      makeFile({ name: "AGENTS.md", content: "a".repeat(8_000) }),
+      makeFile({
+        name: "MEMORY.md",
+        path: "/tmp/MEMORY.md",
+        content: "b".repeat(10_000),
+      }),
+    ];
+    const warnings: string[] = [];
+    buildBootstrapContextFiles(files, {
+      maxChars: 20_000,
+      totalMaxChars: 12_000,
+      warn: (msg) => warnings.push(msg),
+    });
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("MEMORY.md");
+    expect(warnings[0]).toContain("total remaining");
+    expect(warnings[0]).toContain("per-file limit 20000");
+    expect(warnings[0]).toContain("of 12000 total");
+  });
+});

--- a/src/agents/pi-embedded-helpers/bootstrap.ts
+++ b/src/agents/pi-embedded-helpers/bootstrap.ts
@@ -225,8 +225,12 @@ export function buildBootstrapContextFiles(
       continue;
     }
     if (trimmed.truncated || contentWithinBudget.length < trimmed.content.length) {
+      const limitDetail =
+        fileMaxChars < maxChars
+          ? `budget ${fileMaxChars} of ${totalMaxChars} total remaining; per-file limit ${maxChars}`
+          : `per-file limit ${trimmed.maxChars}`;
       opts?.warn?.(
-        `workspace bootstrap file ${file.name} is ${trimmed.originalLength} chars (limit ${trimmed.maxChars}); truncating in injected context`,
+        `workspace bootstrap file ${file.name} is ${trimmed.originalLength} chars (${limitDetail}); truncating in injected context`,
       );
     }
     remainingTotalChars = Math.max(0, remainingTotalChars - contentWithinBudget.length);


### PR DESCRIPTION
## Summary

- Fix confusing bootstrap file truncation warning that showed the remaining total budget as "limit N" without context, making users think their `bootstrapMaxChars` was being ignored
- Warning now distinguishes between per-file limit truncation ("per-file limit 20000") and total budget exhaustion ("budget 8728 of 150000 total remaining; per-file limit 20000")

Closes #18690

## Test plan

- [x] New unit tests verify warning message format for both per-file limit and total budget scenarios
- [x] `pnpm build` passes
- [x] Existing e2e tests for `buildBootstrapContextFiles` remain compatible (warning still contains "limit" substring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Improves the bootstrap file truncation warning message to clearly distinguish between per-file limit truncation and total budget exhaustion. Previously, when files were truncated due to the remaining total budget being lower than `bootstrapMaxChars`, the warning only showed "limit N" without context, confusing users who thought their configured `bootstrapMaxChars` was being ignored.

The fix adds conditional warning text: when truncation is due to per-file limit only, it shows "per-file limit 20000"; when the effective limit is reduced by total budget consumption from earlier files, it shows "budget 4000 of 12000 total remaining; per-file limit 20000". This makes the budget allocation transparent to users.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-isolated to warning message formatting with comprehensive test coverage. The logic correctly distinguishes between per-file and total budget truncation scenarios. Existing e2e tests verify backward compatibility (warning still contains "limit" substring), and new unit tests validate both warning message formats. No functional behavior changes to the truncation logic itself.
- No files require special attention

<sub>Last reviewed commit: 20eb125</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->