### PR TITLE
fix(sandbox): restore SHA-1 in slugifySessionKey to preserve workspace dirs

### DIFF
--- a/src/agents/sandbox/shared.test.ts
+++ b/src/agents/sandbox/shared.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { slugifySessionKey } from "./shared.js";
+
+describe("slugifySessionKey", () => {
+  it("produces stable SHA-1 based slugs for existing workspace directories", () => {
+    // Hash stability is critical: changing the hash algorithm orphans existing
+    // sandbox workspace directories on upgrade (see #18503).
+    const slug = slugifySessionKey("agent:clawfront-dev:direct:23057054725");
+    expect(slug).toBe("agent-clawfront-dev-direct-23057-906dfaef");
+  });
+
+  it("uses fallback for empty input", () => {
+    const slug = slugifySessionKey("");
+    expect(slug).toContain("session-");
+  });
+
+  it("uses fallback for whitespace-only input", () => {
+    const slug = slugifySessionKey("   ");
+    expect(slug).toContain("session-");
+  });
+
+  it("truncates base to 32 chars", () => {
+    const long = "a".repeat(100);
+    const slug = slugifySessionKey(long);
+    // 32 char base + "-" + 8 char hash = 41 chars
+    expect(slug.length).toBe(41);
+  });
+});

--- a/src/agents/sandbox/shared.ts
+++ b/src/agents/sandbox/shared.ts
@@ -1,12 +1,14 @@
+import crypto from "node:crypto";
 import path from "node:path";
 import { normalizeAgentId } from "../../routing/session-key.js";
 import { resolveUserPath } from "../../utils.js";
 import { resolveAgentIdFromSessionKey } from "../agent-scope.js";
-import { hashTextSha256 } from "./hash.js";
 
 export function slugifySessionKey(value: string) {
   const trimmed = value.trim() || "session";
-  const hash = hashTextSha256(trimmed).slice(0, 8);
+  // SHA-1 is intentional: this is a non-security slug differentiator and changing
+  // the algorithm orphans existing workspace directories on upgrade (#18503).
+  const hash = crypto.createHash("sha1").update(trimmed).digest("hex").slice(0, 8);
   const safe = trimmed
     .toLowerCase()
     .replace(/[^a-z0-9._-]+/g, "-")


### PR DESCRIPTION
## Summary

Re-applies the fix from #18503, which was subsequently reverted by the `revert(sandbox): revert SHA-1 slug restoration` commit.

### Problem

`slugifySessionKey` in `src/agents/sandbox/shared.ts` was changed from SHA-1 to SHA-256. Because this hash is used to derive workspace directory names, swapping the algorithm **orphans all existing sandbox workspace directories** for every user on upgrade — their data is still on disk but the agent can no longer locate it.

### Why SHA-1 is intentional here

This hash is a **non-security slug differentiator**, not a cryptographic primitive. Its only job is to produce a stable 8-character suffix that distinguishes workspace directories from each other. SHA-1 is perfectly adequate for this use and must remain stable across releases.

### Changes

- `src/agents/sandbox/shared.ts` — switches `hashTextSha256` back to an inline `crypto.createHash("sha1")` call, with a comment explaining the stability requirement
- `src/agents/sandbox/shared.test.ts` — new test file with 4 cases, including a **stability test that pins the exact SHA-1 output** for a known input, so any future algorithm change will fail loudly

### Relation to previous work

| Commit | Description |
|---|---|
| `f2756118` | Original fix (merged as #18503) |
| `7a00f056a` | Revert of the fix |
| this PR | Re-applies `f2756118` on top of current main |

The revert left upstream/main with the SHA-256 behaviour that breaks existing workspace directories. This PR restores the correct behaviour.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Restores SHA-1 hashing in `slugifySessionKey` to maintain backward compatibility with existing sandbox workspace directories. The previous change from SHA-1 to SHA-256 caused workspace directories to be orphaned on upgrade since the hash is used to derive directory names. Includes comprehensive test coverage with a stability test that will catch any future algorithm changes.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - restores critical backward compatibility without introducing new risks
- This is a well-justified revert that fixes a real data loss issue (orphaned workspace directories). The SHA-1 algorithm is appropriate for non-cryptographic slug generation, the implementation is correct, and comprehensive tests prevent future regressions. The inline comment clearly documents why SHA-1 must remain stable.
- No files require special attention

<sub>Last reviewed commit: 98583fc</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->