### PR TITLE
fix(payloads): place tool warnings before assistant reply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/Payloads: place tool failure warnings before the assistant reply in the output array so the final answer is always the last (most visible) message sent to the channel. (#18687)
 - Voice-call: auto-end calls when media streams disconnect to prevent stuck active calls. (#18435) Thanks @JayMishra-source.
 - Gateway/Channels: wire `gateway.channelHealthCheckMinutes` into strict config validation, treat implicit account status as managed for health checks, and harden channel auto-restart flow (preserve restart-attempt caps across crash loops, propagate enabled/configured runtime flags, and stop pending restart backoff after manual stop). Thanks @steipete.
 - Gateway/WebChat: hard-cap `chat.history` oversized payloads by truncating high-cost fields and replacing over-budget entries with placeholders, so history fetches stay within configured byte limits and avoid chat UI freezes. (#18505)

--- a/extensions/mattermost/src/mattermost/monitor-websocket.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-websocket.test.ts
@@ -185,6 +185,9 @@ describe("mattermost websocket monitor", () => {
       webSocketFactory: () => socket,
     });
 
+    // Start connectOnce so listeners are registered before emitting events
+    const promise = connectOnce();
+
     socket.emitOpen();
     socket.emitMessage(
       Buffer.from(
@@ -202,7 +205,7 @@ describe("mattermost websocket monitor", () => {
     );
     socket.emitClose(1000);
 
-    await connectOnce();
+    await promise;
 
     expect(onReaction).toHaveBeenCalledTimes(1);
     expect(onPosted).not.toHaveBeenCalled();

--- a/src/agents/pi-embedded-runner/run/payloads.e2e.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.e2e.test.ts
@@ -271,7 +271,7 @@ describe("buildEmbeddedRunPayloads", () => {
     expect(payloads[0]?.text).toContain("required");
   });
 
-  it("shows mutating tool errors even when assistant output exists", () => {
+  it("shows mutating tool errors before assistant output for visibility", () => {
     const payloads = buildPayloads({
       assistantTexts: ["Done."],
       lastAssistant: { stopReason: "end_turn" } as unknown as AssistantMessage,
@@ -279,9 +279,10 @@ describe("buildEmbeddedRunPayloads", () => {
     });
 
     expect(payloads).toHaveLength(2);
-    expect(payloads[0]?.text).toBe("Done.");
-    expect(payloads[1]?.isError).toBe(true);
-    expect(payloads[1]?.text).toContain("missing");
+    // Warning comes first so the assistant's actual reply is the last (most visible) item
+    expect(payloads[0]?.isError).toBe(true);
+    expect(payloads[0]?.text).toContain("missing");
+    expect(payloads[1]?.text).toBe("Done.");
   });
 
   it("does not treat session_status read failures as mutating when explicitly flagged", () => {


### PR DESCRIPTION
## Summary

- Reorder payload items so tool failure warnings (`⚠️ ... failed`) appear **before** the assistant's final reply text in the output array
- Previously, the warning was appended after the reply, making it the last (most visible) message in channels like Telegram that deliver messages sequentially — this overshadowed the actual answer
- Now the assistant's reply is always the last item sent, ensuring it's the most visible
- Dedup logic extended to check `answerTexts` in addition to already-emitted items, preserving the behavior where identical warning text in the assistant output prevents duplicate messages

Closes #18687

## Test plan

- [x] Updated e2e test expectation: "shows mutating tool errors before assistant output for visibility" verifies `[warning, reply]` order
- [x] `pnpm build` passes (TypeScript + lint)
- [x] All existing payload tests remain compatible (dedup, suppression, recoverable errors, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Reorders the `buildEmbeddedRunPayloads` output so tool failure warnings (`⚠️ ... failed`) appear **before** the assistant's reply text, making the final answer the last (most visible) message in sequential-delivery channels like Telegram.

- Moved the `answerTexts` processing loop to after the tool-error-warning block, so warnings are appended to `replyItems` first
- Pre-computed `hasUserFacingAssistantReply` via `.some()` since the decision needs to happen before answer items are pushed
- Extended dedup logic with a new `duplicateInAnswers` check against raw `answerTexts`, compensating for answer texts not yet being in `replyItems` at dedup time
- Updated the e2e test to verify `[warning, reply]` ordering and added a changelog entry

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk — it's a well-scoped reordering of output items with preserved dedup semantics and updated tests.
- The change is focused and well-tested. The reordering logic is straightforward: tool warnings are pushed before answer texts instead of after. The pre-computed hasUserFacingAssistantReply preserves the same boolean semantics. The extended duplicateInAnswers check correctly compensates for answer texts not yet being in replyItems. One minor subtlety — the new dedup compares against raw answerTexts rather than parseReplyDirectives-cleaned text — is inconsequential for the warning text format. All existing tests pass and the updated test verifies the new ordering.
- No files require special attention

<sub>Last reviewed commit: f9a9b28</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->