### PR TITLE
feat(plugins): Add registerStreamFnWrapper and updatePluginConfig APIs

### DIFF
--- a/extensions/lobster/src/lobster-tool.test.ts
+++ b/extensions/lobster/src/lobster-tool.test.ts
@@ -38,6 +38,9 @@ function fakeApi(overrides: Partial<OpenClawPluginApi> = {}): OpenClawPluginApi 
     registerHttpRoute() {},
     registerCommand() {},
     on() {},
+    registerStreamFnWrapper() {},
+    updatePluginConfig: async () => {},
+    updatePluginEnabled: async () => {},
     resolvePath: (p) => p,
     ...overrides,
   };

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -658,6 +658,17 @@ export async function runEmbeddedAttempt(
         );
       }
 
+      // Apply plugin-registered streamFn wrappers
+      {
+        const { getGlobalPluginRegistry } = await import("../../../plugins/hook-runner-global.js");
+        const pluginRegistry = getGlobalPluginRegistry();
+        if (pluginRegistry?.streamFnWrappers?.length) {
+          for (const { wrapper } of pluginRegistry.streamFnWrappers) {
+            activeSession.agent.streamFn = wrapper(activeSession.agent.streamFn);
+          }
+        }
+      }
+
       try {
         const prior = await sanitizeSessionHistory({
           messages: activeSession.messages,

--- a/src/auto-reply/reply/route-reply.test.ts
+++ b/src/auto-reply/reply/route-reply.test.ts
@@ -74,6 +74,7 @@ const createRegistry = (channels: PluginRegistry["channels"]): PluginRegistry =>
   httpRoutes: [],
   cliRegistrars: [],
   services: [],
+  streamFnWrappers: [],
   diagnostics: [],
 });
 

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -22,6 +22,7 @@ const createRegistry = (diagnostics: PluginDiagnostic[]): PluginRegistry => ({
   httpRoutes: [],
   cliRegistrars: [],
   services: [],
+  streamFnWrappers: [],
   diagnostics,
 });
 

--- a/src/gateway/server.agent.gateway-server-agent.mocks.ts
+++ b/src/gateway/server.agent.gateway-server-agent.mocks.ts
@@ -16,6 +16,7 @@ export const registryState: { registry: PluginRegistry } = {
     cliRegistrars: [],
     services: [],
     commands: [],
+    streamFnWrappers: [],
     diagnostics: [],
   } as PluginRegistry,
 };

--- a/src/gateway/test-helpers.mocks.ts
+++ b/src/gateway/test-helpers.mocks.ts
@@ -151,6 +151,7 @@ const createStubPluginRegistry = (): PluginRegistry => ({
   cliRegistrars: [],
   services: [],
   commands: [],
+  streamFnWrappers: [],
   diagnostics: [],
 });
 

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -68,7 +68,9 @@ export type {
   OpenClawPluginServiceContext,
   ProviderAuthContext,
   ProviderAuthResult,
+  StreamFnWrapperFn,
 } from "../plugins/types.js";
+export type { StreamFn } from "@mariozechner/pi-agent-core";
 export type {
   GatewayRequestHandler,
   GatewayRequestHandlerOptions,

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -2,7 +2,6 @@ import path from "node:path";
 import type { AnyAgentTool } from "../agents/tools/common.js";
 import type { ChannelDock } from "../channels/dock.js";
 import type { ChannelPlugin } from "../channels/plugins/types.js";
-import { loadConfig, writeConfigFile } from "../config/io.js";
 import type {
   GatewayRequestHandler,
   GatewayRequestHandlers,
@@ -481,7 +480,8 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
   };
 
   const updatePluginConfig = async (record: PluginRecord, newConfig: Record<string, unknown>) => {
-    // Read fresh config to avoid overwriting concurrent changes
+    // Dynamic import to avoid side effects at module load time
+    const { loadConfig, writeConfigFile } = await import("../config/io.js");
     const currentConfig = loadConfig();
     const updated = {
       ...currentConfig,
@@ -500,7 +500,8 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
   };
 
   const updatePluginEnabled = async (record: PluginRecord, enabled: boolean) => {
-    // Read fresh config to avoid overwriting concurrent changes
+    // Dynamic import to avoid side effects at module load time
+    const { loadConfig, writeConfigFile } = await import("../config/io.js");
     const currentConfig = loadConfig();
     const updated = {
       ...currentConfig,

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import type { AnyAgentTool } from "../agents/tools/common.js";
 import type { ChannelDock } from "../channels/dock.js";
 import type { ChannelPlugin } from "../channels/plugins/types.js";
+import { loadConfig, writeConfigFile } from "../config/io.js";
 import type {
   GatewayRequestHandler,
   GatewayRequestHandlers,
@@ -34,7 +35,6 @@ import type {
   PluginHookRegistration as TypedPluginHookRegistration,
   StreamFnWrapperFn,
 } from "./types.js";
-import { loadConfig, writeConfigFile } from "../config/io.js";
 
 export type PluginToolRegistration = {
   pluginId: string;
@@ -480,10 +480,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     });
   };
 
-  const updatePluginConfig = async (
-    record: PluginRecord,
-    newConfig: Record<string, unknown>,
-  ) => {
+  const updatePluginConfig = async (record: PluginRecord, newConfig: Record<string, unknown>) => {
     // Read fresh config to avoid overwriting concurrent changes
     const currentConfig = loadConfig();
     const updated = {
@@ -502,10 +499,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     await writeConfigFile(updated);
   };
 
-  const updatePluginEnabled = async (
-    record: PluginRecord,
-    enabled: boolean,
-  ) => {
+  const updatePluginEnabled = async (record: PluginRecord, enabled: boolean) => {
     // Read fresh config to avoid overwriting concurrent changes
     const currentConfig = loadConfig();
     const updated = {

--- a/src/test-utils/channel-plugins.ts
+++ b/src/test-utils/channel-plugins.ts
@@ -25,6 +25,7 @@ export const createTestRegistry = (channels: TestChannelRegistration[] = []): Pl
   cliRegistrars: [],
   services: [],
   commands: [],
+  streamFnWrappers: [],
   diagnostics: [],
 });
 

--- a/src/utils/message-channel.test.ts
+++ b/src/utils/message-channel.test.ts
@@ -17,6 +17,7 @@ const createRegistry = (channels: PluginRegistry["channels"]): PluginRegistry =>
   httpRoutes: [],
   cliRegistrars: [],
   services: [],
+  streamFnWrappers: [],
   diagnostics: [],
 });
 


### PR DESCRIPTION
## Summary

Adds two new methods to the plugin API:

1. **`api.registerStreamFnWrapper()`** — lets plugins wrap the agent's `streamFn` to intercept, modify, or proxy LLM API calls
2. **`api.updatePluginConfig()`** — lets plugins write to their own config section

**Why:** Memory/proxy plugins need to route LLM calls through external services and let users configure them via CLI commands. Today's plugin hooks can observe but not modify LLM calls, and plugins have no way to persist their own configuration.

---

## 1. registerStreamFnWrapper

### Problem

Plugins that need to proxy LLM calls (memory services, observability, cost tracking) have no way to intercept the actual HTTP request. The existing hooks are:

- `llm_input` / `llm_output` — read-only observation, can't modify anything
- `before_agent_start` — can prepend context, but can't change the endpoint URL or add HTTP headers

Internally, OpenClaw already wraps `streamFn` for cache tracing, extra params, and payload logging — but this mechanism isn't exposed to plugins.

### API

```typescript
api.registerStreamFnWrapper((next: StreamFn) => {
  return (model, context, options) => {
    const proxiedModel = { ...model, baseUrl: "https://my-proxy.example.com" };
    const proxiedOptions = {
      ...options,
      headers: { ...options?.headers, "X-Custom-Header": "value" },
    };
    return next(proxiedModel, context, proxiedOptions);
  };
});
```

### Use Cases

1. **Memory proxy** — Route through MemoryRouter/Supermemory to inject recalled context and capture conversations
2. **Observability** — Log/trace all LLM calls to an external service (Langfuse, Helicone, etc.)
3. **Cost tracking** — Monitor token usage per-request
4. **Custom routing** — Route specific models through different endpoints
5. **Header injection** — Add auth tokens, correlation IDs, or metadata

---

## 2. updatePluginConfig

### Problem

Plugins can read their config (`api.pluginConfig`) but have no way to write it. This means plugins that need user-facing CLI setup commands (like `openclaw mr <key>` to set an API key or `openclaw mr off` to disable) can't persist changes — users have to manually edit `~/.openclaw/openclaw.json`.

### API

```typescript
// Write to the plugin's own config section only
await api.updatePluginConfig({ key: "mk_xxx" });

// Enable/disable the plugin itself
await api.updatePluginEnabled(true);
```

### Scope & Security

- **Scoped to own config only.** A plugin can only write to `plugins.entries.<its-own-id>.config`. It cannot modify other plugins' config or core OpenClaw settings.
- **Fresh read before write.** Config is read at write time to avoid overwriting concurrent changes.

---

## Changes

4 files changed, ~104 lines added:

| File | Change |
|------|--------|
| `src/plugins/types.ts` | Add `StreamFnWrapperFn` type, add `registerStreamFnWrapper` and `updatePluginConfig`/`updatePluginEnabled` to `OpenClawPluginApi` |
| `src/plugins/registry.ts` | Add `PluginStreamFnWrapperRegistration` type, `streamFnWrappers` array, registration functions, config write implementation |
| `src/agents/pi-embedded-runner/run/attempt.ts` | Apply registered wrappers after existing internal wrappers |
| `src/plugin-sdk/index.ts` | Export `StreamFnWrapperFn` type for plugin authors |

## Breaking Changes

None. New additive API only.

## Local Validation

- ✅ `pnpm build` — clean
- ✅ Proof-of-concept plugin tested end-to-end (MemoryRouter)
- Existing tests unaffected (no wrappers registered = no behavior change)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds two new plugin API methods to enable plugins to intercept LLM calls and persist their own configuration.

**Key changes:**
- `registerStreamFnWrapper()` allows plugins to wrap the agent's `streamFn` and intercept/modify/proxy LLM API calls
- `updatePluginConfig()` and `updatePluginEnabled()` let plugins write to their own config section

**Implementation details:**
- Wrappers are applied after internal wrappers (cache trace, payload logger) in the correct composition order
- Config updates are scoped to `plugins.entries.<pluginId>.config` only - plugins cannot modify other plugins or core settings
- Dynamic imports used for config/io to avoid test side effects
- All test mocks updated to include new API methods
- Types exported through plugin-sdk for external plugin authors

**Use cases enabled:**
- Memory proxy plugins (route calls through MemoryRouter/Supermemory)
- Observability (log/trace all LLM calls to external services)
- Cost tracking (monitor token usage per-request)
- Custom routing (route specific models through different endpoints)
- CLI setup commands (persist API keys and enable/disable state)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no critical issues found
- The implementation is well-architected with proper security scoping, type safety, test coverage, and follows established patterns. Config updates are scoped to plugin-only sections, wrappers compose correctly with existing internal wrappers, dynamic imports prevent test side effects, and all test mocks are comprehensively updated.
- No files require special attention

<sub>Last reviewed commit: 37cde57</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->