### PR TITLE
fix: trigger model fallback on network connection errors

### DIFF
--- a/src/agents/auth-profiles/types.ts
+++ b/src/agents/auth-profiles/types.ts
@@ -38,6 +38,7 @@ export type AuthProfileFailureReason =
   | "rate_limit"
   | "billing"
   | "timeout"
+  | "network"
   | "unknown";
 
 /** Per-profile usage statistics for round-robin and cooldown tracking */

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -51,6 +51,8 @@ export function resolveFailoverStatus(reason: FailoverReason): number | undefine
       return 408;
     case "format":
       return 400;
+    case "network":
+      return 503; // Service Unavailable - appropriate for network connectivity issues
     default:
       return undefined;
   }
@@ -166,6 +168,10 @@ export function resolveFailoverReasonFromError(err: unknown): FailoverReason | n
   }
 
   const code = (getErrorCode(err) ?? "").toUpperCase();
+  // Network connectivity errors - trigger fallback to local models
+  if (["ENETUNREACH", "EHOSTUNREACH", "ENOTFOUND", "EAI_AGAIN", "ECONNREFUSED"].includes(code)) {
+    return "network";
+  }
   if (["ETIMEDOUT", "ESOCKETTIMEDOUT", "ECONNRESET", "ECONNABORTED"].includes(code)) {
     return "timeout";
   }

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -643,7 +643,7 @@ const ERROR_PATTERNS = {
     /\beconnrefused\b/i,
     /\bnetwork\s+(?:is\s+)?unreachable\b/i,
     /\bconnection\s+refused\b/i,
-    /\bgetaddrinfo\b.*\bfailed\b/i,
+    /\bgetaddrinfo\b/i,
     /\bfetch\s+failed\b/i,
     /\bno\s+(?:network|internet)\s+connection\b/i,
     /\bdns\s+(?:lookup|resolution)\s+failed\b/i,

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -635,6 +635,19 @@ const ERROR_PATTERNS = {
     "messages.1.content.1.tool_use.id",
     "invalid request format",
   ],
+  network: [
+    /\benetunreach\b/i,
+    /\behostunreach\b/i,
+    /\benotfound\b/i,
+    /\beai_again\b/i,
+    /\beconnrefused\b/i,
+    /\bnetwork\s+(?:is\s+)?unreachable\b/i,
+    /\bconnection\s+refused\b/i,
+    /\bgetaddrinfo\b.*\bfailed\b/i,
+    /\bfetch\s+failed\b/i,
+    /\bno\s+(?:network|internet)\s+connection\b/i,
+    /\bdns\s+(?:lookup|resolution)\s+failed\b/i,
+  ],
 } as const;
 
 const TOOL_CALL_INPUT_MISSING_RE =
@@ -704,6 +717,10 @@ export function isAuthErrorMessage(raw: string): boolean {
 
 export function isOverloadedErrorMessage(raw: string): boolean {
   return matchesErrorPatterns(raw, ERROR_PATTERNS.overloaded);
+}
+
+export function isNetworkErrorMessage(raw: string): boolean {
+  return matchesErrorPatterns(raw, ERROR_PATTERNS.network);
 }
 
 export function parseImageDimensionError(raw: string): {
@@ -794,6 +811,9 @@ export function classifyFailoverReason(raw: string): FailoverReason | null {
   }
   if (isTimeoutErrorMessage(raw)) {
     return "timeout";
+  }
+  if (isNetworkErrorMessage(raw)) {
+    return "network";
   }
   if (isAuthErrorMessage(raw)) {
     return "auth";

--- a/src/agents/pi-embedded-helpers/types.ts
+++ b/src/agents/pi-embedded-helpers/types.ts
@@ -1,3 +1,10 @@
 export type EmbeddedContextFile = { path: string; content: string };
 
-export type FailoverReason = "auth" | "format" | "rate_limit" | "billing" | "timeout" | "unknown";
+export type FailoverReason =
+  | "auth"
+  | "format"
+  | "rate_limit"
+  | "billing"
+  | "timeout"
+  | "network"
+  | "unknown";


### PR DESCRIPTION
## Summary
- Adds detection for network connectivity errors (ENETUNREACH, ECONNREFUSED, ENOTFOUND, EHOSTUNREACH, EAI_AGAIN) to the failover system
- Allows fallback to local models when remote providers are unreachable
- Maps network errors to HTTP 503 status

## Test plan
- [x] All failover-error tests pass (11 tests including 3 new network error tests)
- [x] Type check passes
- [x] Linting passes
- [ ] Manual test: Configure remote primary + local Ollama fallback, disconnect network, verify fallback occurs

Fixes #18868

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new `"network"` failover reason to detect network connectivity errors (`ENETUNREACH`, `ECONNREFUSED`, `ENOTFOUND`, `EHOSTUNREACH`, `EAI_AGAIN`) and trigger model fallback when remote providers are unreachable. The changes are well-structured and follow existing patterns across both the error-code-based detection (`failover-error.ts`) and message-based detection (`pi-embedded-helpers/errors.ts`), with network errors mapped to HTTP 503.

- Adds `"network"` to `FailoverReason` and `AuthProfileFailureReason` union types
- Detects network errors from both Node.js error codes and error message patterns
- Maps network errors to HTTP 503 (Service Unavailable) status
- Includes 3 new test cases with good coverage of code-based and message-based detection
- **Note:** `src/commands/models/list.probe.ts` has a `toStatus()` function and `AuthProbeStatus` type that map failover reasons to probe statuses — neither includes `"network"`, so network errors from `openclaw models list --probe` will report as `"unknown"`. Consider adding `"network"` there as a follow-up.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it extends an existing failover mechanism with a new error category and includes good test coverage.
- The changes are clean, follow established patterns, and have test coverage. The one minor gap is the downstream `list.probe.ts` consumer that doesn't handle the new "network" reason (falling through to "unknown"), which is a low-severity display issue. The core failover logic works correctly.
- No files in this PR require special attention. However, `src/commands/models/list.probe.ts` (not in this PR) should be updated as a follow-up to handle the new "network" reason.

<sub>Last reviewed commit: 1c846c6</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->