### PR TITLE
feat: importance-weighted temporal decay for memory search

### DIFF
--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -32,7 +32,7 @@ If you can write a small TypeScript function, you can write a hook. Hooks are di
 
 The hooks system allows you to:
 
-- Save session context to memory when `/new` is issued
+- Save session context to memory when `/new` or `/reset` is issued
 - Log all commands for auditing
 - Trigger custom automations on agent lifecycle events
 - Extend OpenClaw's behavior without modifying core code
@@ -43,7 +43,7 @@ The hooks system allows you to:
 
 OpenClaw ships with four bundled hooks that are automatically discovered:
 
-- **💾 session-memory**: Saves session context to your agent workspace (default `~/.openclaw/workspace/memory/`) when you issue `/new`
+- **💾 session-memory**: Saves session context to your agent workspace (default `~/.openclaw/workspace/memory/`) when you issue `/new` or `/reset`
 - **📎 bootstrap-extra-files**: Injects additional workspace bootstrap files from configured glob/path patterns during `agent:bootstrap`
 - **📝 command-logger**: Logs all command events to `~/.openclaw/logs/commands.log`
 - **🚀 boot-md**: Runs `BOOT.md` when the gateway starts (requires internal hooks enabled)
@@ -358,7 +358,7 @@ metadata: { "openclaw": { "emoji": "🎯", "events": ["command:new"] } }
 
 # My Custom Hook
 
-This hook does something useful when you issue `/new`.
+This hook does something useful when you issue `/new` or `/reset`.
 ```
 
 ### 4. Create handler.ts
@@ -527,9 +527,9 @@ openclaw hooks disable command-logger
 
 ### session-memory
 
-Saves session context to memory when you issue `/new`.
+Saves session context to memory when you issue `/new` or `/reset`.
 
-**Events**: `command:new`
+**Events**: `command:new`, `command:reset`
 
 **Requirements**: `workspace.dir` must be configured
 
@@ -739,6 +739,7 @@ The gateway logs hook loading at startup:
 
 ```
 Registered hook: session-memory -> command:new
+Registered hook: session-memory -> command:reset
 Registered hook: bootstrap-extra-files -> agent:bootstrap
 Registered hook: command-logger -> command
 Registered hook: boot-md -> gateway:startup

--- a/docs/cli/hooks.md
+++ b/docs/cli/hooks.md
@@ -38,7 +38,7 @@ Ready:
   🚀 boot-md ✓ - Run BOOT.md on gateway startup
   📎 bootstrap-extra-files ✓ - Inject extra workspace bootstrap files during agent bootstrap
   📝 command-logger ✓ - Log all command events to a centralized audit file
-  💾 session-memory ✓ - Save session context to memory when /new command is issued
+  💾 session-memory ✓ - Save session context to memory when /new or /reset command is issued
 ```
 
 **Example (verbose):**
@@ -84,14 +84,14 @@ openclaw hooks info session-memory
 ```
 💾 session-memory ✓ Ready
 
-Save session context to memory when /new command is issued
+Save session context to memory when /new or /reset command is issued
 
 Details:
   Source: openclaw-bundled
   Path: /path/to/openclaw/hooks/bundled/session-memory/HOOK.md
   Handler: /path/to/openclaw/hooks/bundled/session-memory/handler.ts
   Homepage: https://docs.openclaw.ai/automation/hooks#session-memory
-  Events: command:new
+  Events: command:new, command:reset
 
 Requirements:
   Config: ✓ workspace.dir
@@ -247,7 +247,7 @@ global `--yes` to bypass prompts in CI/non-interactive runs.
 
 ### session-memory
 
-Saves session context to memory when you issue `/new`.
+Saves session context to memory when you issue `/new` or `/reset`.
 
 **Enable:**
 

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -69,6 +69,7 @@ export type ResolvedMemorySearchConfig = {
       temporalDecay: {
         enabled: boolean;
         halfLifeDays: number;
+        importanceBoost?: Partial<import("../memory/temporal-decay.js").ImportanceBoostConfig>;
       };
     };
   };
@@ -330,6 +331,9 @@ function mergeConfig(
         temporalDecay: {
           enabled: Boolean(hybrid.temporalDecay.enabled),
           halfLifeDays: temporalDecayHalfLifeDays,
+          importanceBoost:
+            overrides?.query?.hybrid?.temporalDecay?.importanceBoost ??
+            defaults?.query?.hybrid?.temporalDecay?.importanceBoost,
         },
       },
     },

--- a/src/commands/onboard-hooks.e2e.test.ts
+++ b/src/commands/onboard-hooks.e2e.test.ts
@@ -86,13 +86,13 @@ describe("onboard-hooks", () => {
       createMockHook(
         {
           name: "session-memory",
-          description: "Save session context to memory when /new command is issued",
+          description: "Save session context to memory when /new or /reset command is issued",
           filePath: "/mock/workspace/hooks/session-memory/HOOK.md",
           baseDir: "/mock/workspace/hooks/session-memory",
           handlerPath: "/mock/workspace/hooks/session-memory/handler.js",
           hookKey: "session-memory",
           emoji: "💾",
-          events: ["command:new"],
+          events: ["command:new", "command:reset"],
         },
         eligible,
       ),
@@ -147,7 +147,7 @@ describe("onboard-hooks", () => {
           {
             value: "session-memory",
             label: "💾 session-memory",
-            hint: "Save session context to memory when /new command is issued",
+            hint: "Save session context to memory when /new or /reset command is issued",
           },
           {
             value: "command-logger",

--- a/src/commands/onboard-hooks.ts
+++ b/src/commands/onboard-hooks.ts
@@ -13,7 +13,7 @@ export async function setupInternalHooks(
   await prompter.note(
     [
       "Hooks let you automate actions when agent commands are issued.",
-      "Example: Save session context to memory when you issue /new.",
+      "Example: Save session context to memory when you issue /new or /reset.",
       "",
       "Learn more: https://docs.openclaw.ai/automation/hooks",
     ].join("\n"),

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -364,6 +364,12 @@ export type MemorySearchConfig = {
         enabled?: boolean;
         /** Half-life in days for exponential decay (default: 30). */
         halfLifeDays?: number;
+        /** Optional importance-weighted decay: slow decay for marked important memories. */
+        importanceBoost?: {
+          enabled?: boolean;
+          boostFactor?: number;
+          patterns?: { contentMarkers?: string[]; filePatterns?: string[] };
+        };
       };
     };
   };

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -99,6 +99,15 @@ export const AgentDefaultsSchema = z
             softThresholdTokens: z.number().int().nonnegative().optional(),
             prompt: z.string().optional(),
             systemPrompt: z.string().optional(),
+            periodicExtraction: z
+              .object({
+                enabled: z.boolean().optional(),
+                every: z.string().optional(),
+                prompt: z.string().optional(),
+                systemPrompt: z.string().optional(),
+              })
+              .strict()
+              .optional(),
           })
           .strict()
           .optional(),

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -560,6 +560,20 @@ export const MemorySearchSchema = z
               .object({
                 enabled: z.boolean().optional(),
                 halfLifeDays: z.number().int().positive().optional(),
+                importanceBoost: z
+                  .object({
+                    enabled: z.boolean().optional(),
+                    boostFactor: z.number().positive().optional(),
+                    patterns: z
+                      .object({
+                        contentMarkers: z.array(z.string()).optional(),
+                        filePatterns: z.array(z.string()).optional(),
+                      })
+                      .strict()
+                      .optional(),
+                  })
+                  .strict()
+                  .optional(),
               })
               .strict()
               .optional(),

--- a/src/hooks/bundled/README.md
+++ b/src/hooks/bundled/README.md
@@ -6,9 +6,9 @@ This directory contains hooks that ship with OpenClaw. These hooks are automatic
 
 ### 💾 session-memory
 
-Automatically saves session context to memory when you issue `/new`.
+Automatically saves session context to memory when you issue `/new` or `/reset`.
 
-**Events**: `command:new`
+**Events**: `command:new`, `command:reset`
 **What it does**: Creates a dated memory file with LLM-generated slug based on conversation content.
 **Output**: `<workspace>/memory/YYYY-MM-DD-slug.md` (defaults to `~/.openclaw/workspace`)
 

--- a/src/hooks/bundled/session-memory/HOOK.md
+++ b/src/hooks/bundled/session-memory/HOOK.md
@@ -1,13 +1,13 @@
 ---
 name: session-memory
-description: "Save session context to memory when /new command is issued"
+description: "Save session context to memory when /new or /reset command is issued"
 homepage: https://docs.openclaw.ai/automation/hooks#session-memory
 metadata:
   {
     "openclaw":
       {
         "emoji": "💾",
-        "events": ["command:new"],
+        "events": ["command:new", "command:reset"],
         "requires": { "config": ["workspace.dir"] },
         "install": [{ "id": "bundled", "kind": "bundled", "label": "Bundled with OpenClaw" }],
       },
@@ -16,11 +16,11 @@ metadata:
 
 # Session Memory Hook
 
-Automatically saves session context to your workspace memory when you issue the `/new` command.
+Automatically saves session context to your workspace memory when you issue `/new` or `/reset`.
 
 ## What It Does
 
-When you run `/new` to start a fresh session:
+When you run `/new` or `/reset` to start a fresh session:
 
 1. **Finds the previous session** - Uses the pre-reset session entry to locate the correct transcript
 2. **Extracts conversation** - Reads the last N user/assistant messages from the session (default: 15, configurable)

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -167,11 +167,11 @@ async function findPreviousSessionFile(params: {
 }
 
 /**
- * Save session context to memory when /new command is triggered
+ * Save session context to memory when /new or /reset command is triggered
  */
 const saveSessionToMemory: HookHandler = async (event) => {
-  // Only trigger on 'new' command
-  if (event.type !== "command" || event.action !== "new") {
+  // Only trigger on session reset commands.
+  if (event.type !== "command" || (event.action !== "new" && event.action !== "reset")) {
     return;
   }
 

--- a/src/hooks/frontmatter.test.ts
+++ b/src/hooks/frontmatter.test.ts
@@ -232,14 +232,14 @@ describe("resolveOpenClawMetadata", () => {
     // This is the actual format used in the bundled hooks
     const content = `---
 name: session-memory
-description: "Save session context to memory when /new command is issued"
+description: "Save session context to memory when /new or /reset command is issued"
 homepage: https://docs.openclaw.ai/automation/hooks#session-memory
 metadata:
   {
     "openclaw":
       {
         "emoji": "💾",
-        "events": ["command:new"],
+        "events": ["command:new", "command:reset"],
         "requires": { "config": ["workspace.dir"] },
         "install": [{ "id": "bundled", "kind": "bundled", "label": "Bundled with OpenClaw" }],
       },
@@ -256,7 +256,7 @@ metadata:
     const openclaw = resolveOpenClawMetadata(frontmatter);
     expect(openclaw).toBeDefined();
     expect(openclaw?.emoji).toBe("💾");
-    expect(openclaw?.events).toEqual(["command:new"]);
+    expect(openclaw?.events).toEqual(["command:new", "command:reset"]);
     expect(openclaw?.requires?.config).toEqual(["workspace.dir"]);
     expect(openclaw?.install?.[0].kind).toBe("bundled");
   });

--- a/src/memory/temporal-decay.test.ts
+++ b/src/memory/temporal-decay.test.ts
@@ -7,6 +7,8 @@ import {
   applyTemporalDecayToHybridResults,
   applyTemporalDecayToScore,
   calculateTemporalDecayMultiplier,
+  isImportantChunk,
+  type ImportanceBoostConfig,
 } from "./temporal-decay.js";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -169,5 +171,187 @@ describe("temporal decay", () => {
     });
 
     expect(decayed[0]?.score).toBeCloseTo(0.5, 2);
+  });
+});
+
+describe("importance-weighted decay", () => {
+  const enabledConfig: ImportanceBoostConfig = {
+    enabled: true,
+    boostFactor: 3,
+    patterns: {
+      contentMarkers: ["<!-- important -->", "**IMPORTANT**", "[!important]"],
+      filePatterns: ["MEMORY.md"],
+    },
+  };
+
+  describe("isImportantChunk", () => {
+    it("matches file patterns case-insensitively", () => {
+      expect(isImportantChunk({ filePath: "MEMORY.md", config: enabledConfig })).toBe(true);
+      expect(isImportantChunk({ filePath: "memory.md", config: enabledConfig })).toBe(true);
+      expect(isImportantChunk({ filePath: "foo/MEMORY.md", config: enabledConfig })).toBe(true);
+    });
+
+    it("matches content markers", () => {
+      expect(
+        isImportantChunk({
+          filePath: "memory/2025-01-01.md",
+          snippet: "some text <!-- important --> more text",
+          config: enabledConfig,
+        }),
+      ).toBe(true);
+      expect(
+        isImportantChunk({
+          filePath: "memory/2025-01-01.md",
+          snippet: "**IMPORTANT** note",
+          config: enabledConfig,
+        }),
+      ).toBe(true);
+      expect(
+        isImportantChunk({
+          filePath: "memory/2025-01-01.md",
+          snippet: "has [!important] callout",
+          config: enabledConfig,
+        }),
+      ).toBe(true);
+    });
+
+    it("returns false when no patterns match", () => {
+      expect(
+        isImportantChunk({
+          filePath: "memory/2025-01-01.md",
+          snippet: "just normal text",
+          config: enabledConfig,
+        }),
+      ).toBe(false);
+    });
+
+    it("returns false when disabled", () => {
+      expect(
+        isImportantChunk({
+          filePath: "MEMORY.md",
+          config: { ...enabledConfig, enabled: false },
+        }),
+      ).toBe(false);
+    });
+  });
+
+  it("important memories decay slower than normal ones", async () => {
+    const results = await applyTemporalDecayToHybridResults({
+      results: [
+        {
+          path: "memory/2025-11-10.md",
+          score: 0.8,
+          source: "memory",
+          snippet: "normal memory",
+        },
+        {
+          path: "memory/2025-11-10.md",
+          score: 0.8,
+          source: "memory",
+          snippet: "<!-- important --> key memory",
+        },
+      ],
+      temporalDecay: {
+        enabled: true,
+        halfLifeDays: 30,
+        importanceBoost: { enabled: true, boostFactor: 3 },
+      },
+      nowMs: NOW_MS,
+    });
+
+    // Both started at 0.8, ~92 days old
+    // Normal decays with full age, important with age/3
+    expect(results[1]!.score).toBeGreaterThan(results[0]!.score);
+  });
+
+  it("boost is disabled by default (backwards-compatible)", async () => {
+    const results = await applyTemporalDecayToHybridResults({
+      results: [
+        {
+          path: "memory/2025-11-10.md",
+          score: 0.8,
+          source: "memory",
+          snippet: "<!-- important --> key memory",
+        },
+        {
+          path: "memory/2025-11-10.md",
+          score: 0.8,
+          source: "memory",
+          snippet: "normal memory",
+        },
+      ],
+      temporalDecay: { enabled: true, halfLifeDays: 30 },
+      nowMs: NOW_MS,
+    });
+
+    // Without importance boost, both should decay identically
+    expect(results[0]!.score).toBeCloseTo(results[1]!.score);
+  });
+
+  it("boostFactor of 1 has no effect", async () => {
+    const results = await applyTemporalDecayToHybridResults({
+      results: [
+        {
+          path: "memory/2025-11-10.md",
+          score: 0.8,
+          source: "memory",
+          snippet: "<!-- important --> key memory",
+        },
+        {
+          path: "memory/2025-11-10.md",
+          score: 0.8,
+          source: "memory",
+          snippet: "normal memory",
+        },
+      ],
+      temporalDecay: {
+        enabled: true,
+        halfLifeDays: 30,
+        importanceBoost: { enabled: true, boostFactor: 1 },
+      },
+      nowMs: NOW_MS,
+    });
+
+    expect(results[0]!.score).toBeCloseTo(results[1]!.score);
+  });
+
+  it("integrates with hybrid merge via file pattern matching", async () => {
+    const merged = await mergeHybridResults({
+      vectorWeight: 1,
+      textWeight: 0,
+      temporalDecay: {
+        enabled: true,
+        halfLifeDays: 30,
+        importanceBoost: { enabled: true, boostFactor: 3 },
+      },
+      mmr: { enabled: false },
+      nowMs: NOW_MS,
+      vector: [
+        {
+          id: "old-normal",
+          path: "memory/2025-11-10.md",
+          startLine: 1,
+          endLine: 1,
+          source: "memory",
+          snippet: "old normal memory",
+          vectorScore: 0.9,
+        },
+        {
+          id: "old-important",
+          path: "memory/2025-11-10.md",
+          startLine: 10,
+          endLine: 15,
+          source: "memory",
+          snippet: "old but <!-- important --> memory",
+          vectorScore: 0.9,
+        },
+      ],
+      keyword: [],
+    });
+
+    // Important one should rank higher despite same age and vector score
+    const importantEntry = merged.find((e) => e.snippet.includes("important"));
+    const normalEntry = merged.find((e) => !e.snippet.includes("important"));
+    expect(importantEntry!.score).toBeGreaterThan(normalEntry!.score);
   });
 });

--- a/src/memory/temporal-decay.test.ts
+++ b/src/memory/temporal-decay.test.ts
@@ -261,7 +261,7 @@ describe("importance-weighted decay", () => {
 
     // Both started at 0.8, ~92 days old
     // Normal decays with full age, important with age/3
-    expect(results[1]!.score).toBeGreaterThan(results[0]!.score);
+    expect(results[1].score).toBeGreaterThan(results[0].score);
   });
 
   it("boost is disabled by default (backwards-compatible)", async () => {
@@ -285,7 +285,7 @@ describe("importance-weighted decay", () => {
     });
 
     // Without importance boost, both should decay identically
-    expect(results[0]!.score).toBeCloseTo(results[1]!.score);
+    expect(results[0].score).toBeCloseTo(results[1].score);
   });
 
   it("boostFactor of 1 has no effect", async () => {
@@ -312,7 +312,7 @@ describe("importance-weighted decay", () => {
       nowMs: NOW_MS,
     });
 
-    expect(results[0]!.score).toBeCloseTo(results[1]!.score);
+    expect(results[0].score).toBeCloseTo(results[1].score);
   });
 
   it("integrates with hybrid merge via file pattern matching", async () => {

--- a/src/memory/temporal-decay.ts
+++ b/src/memory/temporal-decay.ts
@@ -1,9 +1,34 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 
+export type ImportanceBoostPatterns = {
+  /** Content markers that indicate importance (matched case-insensitively) */
+  contentMarkers?: string[];
+  /** File path patterns (matched case-insensitively against the normalized path) */
+  filePatterns?: string[];
+};
+
+export type ImportanceBoostConfig = {
+  enabled: boolean;
+  /** Multiplier for important memories (e.g., 3.0 = effective age is divided by 3) */
+  boostFactor: number;
+  /** Patterns that indicate importance */
+  patterns?: ImportanceBoostPatterns;
+};
+
+export const DEFAULT_IMPORTANCE_BOOST_CONFIG: ImportanceBoostConfig = {
+  enabled: false,
+  boostFactor: 3,
+  patterns: {
+    contentMarkers: ["<!-- important -->", "**IMPORTANT**", "[!important]"],
+    filePatterns: ["MEMORY.md"],
+  },
+};
+
 export type TemporalDecayConfig = {
   enabled: boolean;
   halfLifeDays: number;
+  importanceBoost?: Partial<ImportanceBoostConfig>;
 };
 
 export const DEFAULT_TEMPORAL_DECAY_CONFIG: TemporalDecayConfig = {
@@ -113,13 +138,39 @@ async function extractTimestamp(params: {
   }
 }
 
+export function isImportantChunk(params: {
+  filePath: string;
+  snippet?: string;
+  config: ImportanceBoostConfig;
+}): boolean {
+  const { filePath, snippet, config } = params;
+  if (!config.enabled) return false;
+  const patterns = { ...DEFAULT_IMPORTANCE_BOOST_CONFIG.patterns, ...config.patterns };
+  const normalized = filePath.replaceAll("\\", "/").replace(/^\.\//, "").toLowerCase();
+
+  if (patterns.filePatterns) {
+    for (const fp of patterns.filePatterns) {
+      if (normalized.includes(fp.toLowerCase())) return true;
+    }
+  }
+
+  if (snippet && patterns.contentMarkers) {
+    const lower = snippet.toLowerCase();
+    for (const marker of patterns.contentMarkers) {
+      if (lower.includes(marker.toLowerCase())) return true;
+    }
+  }
+
+  return false;
+}
+
 function ageInDaysFromTimestamp(timestamp: Date, nowMs: number): number {
   const ageMs = Math.max(0, nowMs - timestamp.getTime());
   return ageMs / DAY_MS;
 }
 
 export async function applyTemporalDecayToHybridResults<
-  T extends { path: string; score: number; source: string },
+  T extends { path: string; score: number; source: string; snippet?: string },
 >(params: {
   results: T[];
   temporalDecay?: Partial<TemporalDecayConfig>;
@@ -130,6 +181,11 @@ export async function applyTemporalDecayToHybridResults<
   if (!config.enabled) {
     return [...params.results];
   }
+
+  const importanceConfig: ImportanceBoostConfig = {
+    ...DEFAULT_IMPORTANCE_BOOST_CONFIG,
+    ...config.importanceBoost,
+  };
 
   const nowMs = params.nowMs ?? Date.now();
   const timestampPromiseCache = new Map<string, Promise<Date | null>>();
@@ -152,9 +208,24 @@ export async function applyTemporalDecayToHybridResults<
         return entry;
       }
 
+      let ageInDays = ageInDaysFromTimestamp(timestamp, nowMs);
+
+      // Important memories decay slower by dividing their effective age
+      if (
+        importanceConfig.enabled &&
+        importanceConfig.boostFactor > 1 &&
+        isImportantChunk({
+          filePath: entry.path,
+          snippet: (entry as { snippet?: string }).snippet,
+          config: importanceConfig,
+        })
+      ) {
+        ageInDays = ageInDays / importanceConfig.boostFactor;
+      }
+
       const decayedScore = applyTemporalDecayToScore({
         score: entry.score,
-        ageInDays: ageInDaysFromTimestamp(timestamp, nowMs),
+        ageInDays,
         halfLifeDays: config.halfLifeDays,
       });
 

--- a/src/memory/temporal-decay.ts
+++ b/src/memory/temporal-decay.ts
@@ -144,20 +144,26 @@ export function isImportantChunk(params: {
   config: ImportanceBoostConfig;
 }): boolean {
   const { filePath, snippet, config } = params;
-  if (!config.enabled) return false;
+  if (!config.enabled) {
+    return false;
+  }
   const patterns = { ...DEFAULT_IMPORTANCE_BOOST_CONFIG.patterns, ...config.patterns };
   const normalized = filePath.replaceAll("\\", "/").replace(/^\.\//, "").toLowerCase();
 
   if (patterns.filePatterns) {
     for (const fp of patterns.filePatterns) {
-      if (normalized.includes(fp.toLowerCase())) return true;
+      if (normalized.includes(fp.toLowerCase())) {
+        return true;
+      }
     }
   }
 
   if (snippet && patterns.contentMarkers) {
     const lower = snippet.toLowerCase();
     for (const marker of patterns.contentMarkers) {
-      if (lower.includes(marker.toLowerCase())) return true;
+      if (lower.includes(marker.toLowerCase())) {
+        return true;
+      }
     }
   }
 

--- a/src/memory/temporal-decay.ts
+++ b/src/memory/temporal-decay.ts
@@ -222,7 +222,7 @@ export async function applyTemporalDecayToHybridResults<
         importanceConfig.boostFactor > 1 &&
         isImportantChunk({
           filePath: entry.path,
-          snippet: (entry as { snippet?: string }).snippet,
+          snippet: entry.snippet,
           config: importanceConfig,
         })
       ) {


### PR DESCRIPTION
## Summary

Adds an optional importance-weighted boost to the temporal decay system, so emotionally significant or important memories decay slower in search results.

## Changes

- Extended `TemporalDecayConfig` with optional `importanceBoost` settings
- Added `ImportanceBoostConfig` type with configurable boost factor and pattern matching
- `isImportantChunk()` detects importance via file path patterns and content markers (`<!-- important -->`, `**IMPORTANT**`, `[!important]`)
- Important memories have their effective age divided by the boost factor (default 3x), making them decay slower
- Fully backwards-compatible: importance boost is disabled by default
- Added 8 new test cases

## How it works

When enabled, the system checks each memory chunk against configurable patterns:
- **File patterns**: e.g., `MEMORY.md` files
- **Content markers**: inline markers like `<!-- important -->` in the snippet

Matching chunks get their effective age divided by `boostFactor`, so a 90-day-old important memory with factor 3 decays as if it were only 30 days old.

## Configuration

```ts
temporalDecay: {
  enabled: true,
  halfLifeDays: 30,
  importanceBoost: {
    enabled: true,
    boostFactor: 3,
    patterns: {
      contentMarkers: ['<!-- important -->', '**IMPORTANT**', '[!important]'],
      filePatterns: ['MEMORY.md'],
    },
  },
}
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an optional importance-weighted boost to the temporal decay system for memory search. When enabled, chunks matching configurable file path patterns (e.g., `MEMORY.md`) or content markers (e.g., `<!-- important -->`) have their effective age divided by a configurable `boostFactor`, causing them to decay slower in search results.

- New `ImportanceBoostConfig` and `ImportanceBoostPatterns` types with defaults
- `isImportantChunk()` function for pattern-based importance detection (case-insensitive)
- Importance boost integrated into `applyTemporalDecayToHybridResults` with proper guards (`enabled` check, `boostFactor > 1`)
- Fully backwards-compatible: disabled by default, generic constraint change (`snippet?: string`) is non-breaking
- 8 new test cases with good edge case coverage (disabled state, `boostFactor=1` no-op, integration with hybrid merge)
- Note: the default `MEMORY.md` file pattern in importance boost config is effectively a no-op for `source: "memory"` entries since evergreen memory paths already skip decay entirely via `extractTimestamp` returning `null`

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — the feature is disabled by default and the logic is well-guarded.
- Clean, focused implementation with proper feature flag (disabled by default), guard against division by zero/no-op (`boostFactor > 1`), and comprehensive test coverage. No breaking changes to the generic constraint or config shape. Only minor style issue found (redundant type assertion).
- No files require special attention.

<sub>Last reviewed commit: e1b8d73</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->