### PR TITLE
fix(cron): stagger missed jobs on restart to prevent gateway overload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/config restart guard: validate config before service start/restart and keep post-SIGUSR1 startup failures from crashing the gateway process, reducing invalid-config restart loops and macOS permission loss. Landed from contributor PR #38699 by @lml2468. Thanks @lml2468.
 - Gateway/launchd respawn detection: treat `XPC_SERVICE_NAME` as a launchd supervision hint so macOS restarts exit cleanly under launchd instead of attempting detached self-respawn. Landed from contributor PR #20555 by @dimat. Thanks @dimat.
 - Telegram/poll restart cleanup: abort the in-flight Telegram API fetch when shutdown or forced polling restarts stop a runner, preventing stale `getUpdates` long polls from colliding with the replacement runner. Landed from contributor PR #23950 by @Gkinthecodeland. Thanks @Gkinthecodeland.
+- Cron/restart catch-up staggering: limit immediate missed-job replay on startup and reschedule the deferred remainder from the post-catchup clock so restart bursts do not starve the gateway or silently skip overdue recurring jobs. Landed from contributor PR #18925 by @rexlunae. Thanks @rexlunae.
 - Cron/owner-only tools: pass trusted isolated cron runs into the embedded agent with owner context so `cron`/`gateway` tooling remains available after the owner-auth hardening narrowed direct-message ownership inference.
 
 ## 2026.3.7

--- a/src/cron/service.restart-catchup.test.ts
+++ b/src/cron/service.restart-catchup.test.ts
@@ -2,7 +2,9 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { CronService } from "./service.js";
+import { createCronServiceState } from "./state.js";
 import { setupCronServiceSuite } from "./service.test-harness.js";
+import { runMissedJobs } from "./timer.js";
 
 const { logger: noopLogger, makeStorePath } = setupCronServiceSuite({
   prefix: "openclaw-cron-",
@@ -28,6 +30,21 @@ describe("CronService restart catch-up", () => {
       requestHeartbeatNow: params.requestHeartbeatNow as never,
       runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })) as never,
     });
+  }
+
+  function createOverdueEveryJob(id: string, nextRunAtMs: number) {
+    return {
+      id,
+      name: `job-${id}`,
+      enabled: true,
+      createdAtMs: nextRunAtMs - 60_000,
+      updatedAtMs: nextRunAtMs - 60_000,
+      schedule: { kind: "every", everyMs: 60_000, anchorMs: nextRunAtMs - 60_000 },
+      sessionTarget: "main",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "systemEvent", text: `tick-${id}` },
+      state: { nextRunAtMs },
+    };
   }
 
   it("executes an overdue recurring job immediately on start", async () => {
@@ -349,6 +366,49 @@ describe("CronService restart catch-up", () => {
     expect(requestHeartbeatNow).toHaveBeenCalled();
 
     cron.stop();
+    await store.cleanup();
+  });
+
+  it("reschedules deferred missed jobs from the post-catchup clock so they stay in the future", async () => {
+    const store = await makeStorePath();
+    const startNow = Date.parse("2025-12-13T17:00:00.000Z");
+    let now = startNow;
+
+    await writeStoreJobs(store.storePath, [
+      createOverdueEveryJob("stagger-0", startNow - 60_000),
+      createOverdueEveryJob("stagger-1", startNow - 50_000),
+      createOverdueEveryJob("stagger-2", startNow - 40_000),
+    ]);
+
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => {
+        now += 6_000;
+        return { status: "ok" as const, summary: "ok" };
+      }),
+      maxMissedJobsPerRestart: 1,
+      missedJobStaggerMs: 5_000,
+    });
+
+    await runMissedJobs(state);
+
+    const staggeredJobs = (state.store?.jobs ?? [])
+      .filter((job) => job.id.startsWith("stagger-") && job.id !== "stagger-0")
+      .toSorted((a, b) => (a.state.nextRunAtMs ?? 0) - (b.state.nextRunAtMs ?? 0));
+
+    expect(staggeredJobs).toHaveLength(2);
+    expect(staggeredJobs[0]?.state.nextRunAtMs).toBeGreaterThan(now);
+    expect(staggeredJobs[1]?.state.nextRunAtMs).toBeGreaterThan(
+      staggeredJobs[0]?.state.nextRunAtMs ?? 0,
+    );
+    expect((staggeredJobs[1]?.state.nextRunAtMs ?? 0) - (staggeredJobs[0]?.state.nextRunAtMs ?? 0))
+      .toBe(5_000);
+
     await store.cleanup();
   });
 });

--- a/src/cron/service.restart-catchup.test.ts
+++ b/src/cron/service.restart-catchup.test.ts
@@ -2,9 +2,9 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { CronService } from "./service.js";
-import { createCronServiceState } from "./state.js";
 import { setupCronServiceSuite } from "./service.test-harness.js";
-import { runMissedJobs } from "./timer.js";
+import { createCronServiceState } from "./service/state.js";
+import { runMissedJobs } from "./service/timer.js";
 
 const { logger: noopLogger, makeStorePath } = setupCronServiceSuite({
   prefix: "openclaw-cron-",
@@ -406,8 +406,9 @@ describe("CronService restart catch-up", () => {
     expect(staggeredJobs[1]?.state.nextRunAtMs).toBeGreaterThan(
       staggeredJobs[0]?.state.nextRunAtMs ?? 0,
     );
-    expect((staggeredJobs[1]?.state.nextRunAtMs ?? 0) - (staggeredJobs[0]?.state.nextRunAtMs ?? 0))
-      .toBe(5_000);
+    expect(
+      (staggeredJobs[1]?.state.nextRunAtMs ?? 0) - (staggeredJobs[0]?.state.nextRunAtMs ?? 0),
+    ).toBe(5_000);
 
     await store.cleanup();
   });

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -48,6 +48,18 @@ export type CronServiceDeps = {
   resolveSessionStorePath?: (agentId?: string) => string;
   /** Path to the session store (sessions.json) for reaper use. */
   sessionStorePath?: string;
+  /**
+   * Delay in ms between missed job executions on startup.
+   * Prevents overwhelming the gateway when many jobs are overdue.
+   * See: https://github.com/openclaw/openclaw/issues/18892
+   */
+  missedJobStaggerMs?: number;
+  /**
+   * Maximum number of missed jobs to run immediately on startup.
+   * Additional missed jobs will be rescheduled to fire gradually.
+   * See: https://github.com/openclaw/openclaw/issues/18892
+   */
+  maxMissedJobsPerRestart?: number;
   enqueueSystemEvent: (
     text: string,
     opts?: { agentId?: string; sessionKey?: string; contextKey?: string },

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -38,6 +38,9 @@ const MAX_TIMER_DELAY_MS = 60_000;
  * but always breaks an infinite re-trigger cycle.  (See #17821)
  */
 const MIN_REFIRE_GAP_MS = 2_000;
+
+const DEFAULT_MISSED_JOB_STAGGER_MS = 5_000;
+const DEFAULT_MAX_MISSED_JOBS_PER_RESTART = 5;
 const DEFAULT_FAILURE_ALERT_AFTER = 2;
 const DEFAULT_FAILURE_ALERT_COOLDOWN_MS = 60 * 60_000; // 1 hour
 
@@ -829,10 +832,18 @@ export async function runMissedJobs(
   state: CronServiceState,
   opts?: { skipJobIds?: ReadonlySet<string> },
 ) {
-  const startupCandidates = await locked(state, async () => {
+  const staggerMs = Math.max(0, state.deps.missedJobStaggerMs ?? DEFAULT_MISSED_JOB_STAGGER_MS);
+  const maxImmediate = Math.max(
+    0,
+    state.deps.maxMissedJobsPerRestart ?? DEFAULT_MAX_MISSED_JOBS_PER_RESTART,
+  );
+  const selection = await locked(state, async () => {
     await ensureLoaded(state, { skipRecompute: true });
     if (!state.store) {
-      return [] as Array<{ jobId: string; job: CronJob }>;
+      return {
+        deferredJobIds: [] as string[],
+        startupCandidates: [] as Array<{ jobId: string; job: CronJob }>,
+      };
     }
     const now = state.deps.nowMs();
     const skipJobIds = opts?.skipJobIds;
@@ -842,26 +853,47 @@ export async function runMissedJobs(
       allowCronMissedRunByLastRun: true,
     });
     if (missed.length === 0) {
-      return [] as Array<{ jobId: string; job: CronJob }>;
+      return {
+        deferredJobIds: [] as string[],
+        startupCandidates: [] as Array<{ jobId: string; job: CronJob }>,
+      };
     }
-    state.deps.log.info(
-      { count: missed.length, jobIds: missed.map((j) => j.id) },
-      "cron: running missed jobs after restart",
-    );
-    for (const job of missed) {
+    const sorted = missed.toSorted((a, b) => (a.state.nextRunAtMs ?? 0) - (b.state.nextRunAtMs ?? 0));
+    const startupCandidates = sorted.slice(0, maxImmediate);
+    const deferred = sorted.slice(maxImmediate);
+    if (deferred.length > 0) {
+      state.deps.log.info(
+        {
+          immediateCount: startupCandidates.length,
+          deferredCount: deferred.length,
+          totalMissed: missed.length,
+        },
+        "cron: staggering missed jobs to prevent gateway overload",
+      );
+    }
+    if (startupCandidates.length > 0) {
+      state.deps.log.info(
+        { count: startupCandidates.length, jobIds: startupCandidates.map((j) => j.id) },
+        "cron: running missed jobs after restart",
+      );
+    }
+    for (const job of startupCandidates) {
       job.state.runningAtMs = now;
       job.state.lastError = undefined;
     }
     await persist(state);
-    return missed.map((job) => ({ jobId: job.id, job }));
+    return {
+      deferredJobIds: deferred.map((job) => job.id),
+      startupCandidates: startupCandidates.map((job) => ({ jobId: job.id, job })),
+    };
   });
 
-  if (startupCandidates.length === 0) {
+  if (selection.startupCandidates.length === 0 && selection.deferredJobIds.length === 0) {
     return;
   }
 
   const outcomes: Array<TimedCronRunOutcome> = [];
-  for (const candidate of startupCandidates) {
+  for (const candidate of selection.startupCandidates) {
     const startedAt = state.deps.nowMs();
     emit(state, { jobId: candidate.job.id, action: "started", runAtMs: startedAt });
     try {
@@ -899,6 +931,19 @@ export async function runMissedJobs(
 
     for (const result of outcomes) {
       applyOutcomeToStoredJob(state, result);
+    }
+
+    if (selection.deferredJobIds.length > 0) {
+      const baseNow = state.deps.nowMs();
+      let offset = staggerMs;
+      for (const jobId of selection.deferredJobIds) {
+        const job = state.store.jobs.find((entry) => entry.id === jobId);
+        if (!job || !job.enabled) {
+          continue;
+        }
+        job.state.nextRunAtMs = baseNow + offset;
+        offset += staggerMs;
+      }
     }
 
     // Preserve any new past-due nextRunAtMs values that became due while

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -858,7 +858,9 @@ export async function runMissedJobs(
         startupCandidates: [] as Array<{ jobId: string; job: CronJob }>,
       };
     }
-    const sorted = missed.toSorted((a, b) => (a.state.nextRunAtMs ?? 0) - (b.state.nextRunAtMs ?? 0));
+    const sorted = missed.toSorted(
+      (a, b) => (a.state.nextRunAtMs ?? 0) - (b.state.nextRunAtMs ?? 0),
+    );
     const startupCandidates = sorted.slice(0, maxImmediate);
     const deferred = sorted.slice(maxImmediate);
     if (deferred.length > 0) {


### PR DESCRIPTION
When the gateway restarts with many overdue cron jobs, they are now executed with staggered delays to prevent overwhelming the gateway.

- Add missedJobStaggerMs config (default 5s between jobs)
- Add maxMissedJobsPerRestart limit (default 5 jobs immediately)
- Prioritize most overdue jobs by sorting by nextRunAtMs
- Reschedule deferred jobs to fire gradually via normal timer

Fixes #18892

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses #18892 by staggering the execution of missed cron jobs when the gateway restarts with many overdue jobs. Previously, all missed jobs fired simultaneously, potentially overwhelming the gateway.

- Adds `missedJobStaggerMs` (default 5s) and `maxMissedJobsPerRestart` (default 5) as configurable options on `CronServiceDeps`
- Sorts missed jobs by `nextRunAtMs` (most overdue first), splits into immediate and deferred batches
- Immediate batch runs sequentially with stagger delays between executions; deferred batch gets rescheduled to staggered future `nextRunAtMs` values picked up by the normal timer
- The stagger scheduling is safe with respect to the `locked()` mechanism and `recomputeNextRuns` (which preserves future `nextRunAtMs` values)
- **Issue**: deferred job stagger offsets start at `staggerMs` instead of `maxImmediate * staggerMs`, so the first deferred jobs will be past-due by the time `armTimer` runs (after the immediate batch completes), causing them to fire back-to-back without the intended staggering

<h3>Confidence Score: 3/5</h3>

- The PR is safe to merge but the deferred job stagger timing has an overlap issue that reduces its effectiveness under default settings.
- The overall approach is sound and well-structured — sorting by overdue priority, splitting into immediate/deferred batches, and leveraging the existing timer mechanism for deferred execution. However, the deferred stagger offset calculation starts too early (at `staggerMs` from `now`), meaning the first several deferred jobs will be past-due by the time `armTimer` runs after the immediate batch completes, causing them to fire back-to-back and partially defeating the stagger purpose. The fix is straightforward (start offset at `maxImmediate * staggerMs`).
- `src/cron/service/timer.ts` — the deferred job stagger offset calculation in `runMissedJobs` needs adjustment to account for immediate batch execution time.

<sub>Last reviewed commit: eabeee0</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->