### PR TITLE
TTS: default to eleven_flash_v2_5, drop eleven_monolingual_v1, add model/voice to tool

### DIFF
--- a/src/agents/tools/tts-tool.ts
+++ b/src/agents/tools/tts-tool.ts
@@ -1,16 +1,28 @@
 import { Type } from "@sinclair/typebox";
-import { SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import type { OpenClawConfig } from "../../config/config.js";
-import { loadConfig } from "../../config/config.js";
-import { textToSpeech } from "../../tts/tts.js";
 import type { GatewayMessageChannel } from "../../utils/message-channel.js";
 import type { AnyAgentTool } from "./common.js";
+import { SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
+import { loadConfig } from "../../config/config.js";
+import { textToSpeech } from "../../tts/tts.js";
 import { readStringParam } from "./common.js";
 
 const TtsToolSchema = Type.Object({
   text: Type.String({ description: "Text to convert to speech." }),
   channel: Type.Optional(
     Type.String({ description: "Optional channel id to pick output format (e.g. telegram)." }),
+  ),
+  modelId: Type.Optional(
+    Type.String({
+      description:
+        "ElevenLabs model (e.g. eleven_flash_v2_5, eleven_multilingual_v2). Ignored for non-ElevenLabs provider.",
+    }),
+  ),
+  voiceId: Type.Optional(
+    Type.String({
+      description:
+        "ElevenLabs voice ID. Ignored for non-ElevenLabs provider. Use any free-tier voice ID.",
+    }),
   ),
 });
 
@@ -27,11 +39,18 @@ export function createTtsTool(opts?: {
       const params = args as Record<string, unknown>;
       const text = readStringParam(params, "text", { required: true });
       const channel = readStringParam(params, "channel");
+      const modelId = readStringParam(params, "modelId");
+      const voiceId = readStringParam(params, "voiceId");
       const cfg = opts?.config ?? loadConfig();
+      const overrides =
+        (modelId ?? voiceId)
+          ? { elevenlabs: { ...(modelId && { modelId }), ...(voiceId && { voiceId }) } }
+          : undefined;
       const result = await textToSpeech({
         text,
         cfg,
         channel: channel ?? opts?.agentChannel,
+        overrides,
       });
 
       if (result.success && result.audioPath) {

--- a/src/gateway/server-methods/tts.ts
+++ b/src/gateway/server-methods/tts.ts
@@ -1,3 +1,4 @@
+import type { GatewayRequestHandlers } from "./types.js";
 import { loadConfig } from "../../config/config.js";
 import {
   OPENAI_TTS_MODELS,
@@ -16,7 +17,6 @@ import {
 } from "../../tts/tts.js";
 import { ErrorCodes, errorShape } from "../protocol/index.js";
 import { formatForLog } from "../ws-log.js";
-import type { GatewayRequestHandlers } from "./types.js";
 
 export const ttsHandlers: GatewayRequestHandlers = {
   "tts.status": async ({ respond }) => {
@@ -139,7 +139,12 @@ export const ttsHandlers: GatewayRequestHandlers = {
             id: "elevenlabs",
             name: "ElevenLabs",
             configured: Boolean(resolveTtsApiKey(config, "elevenlabs")),
-            models: ["eleven_multilingual_v2", "eleven_turbo_v2_5", "eleven_monolingual_v1"],
+            models: [
+              "eleven_flash_v2_5",
+              "eleven_flash_v2",
+              "eleven_multilingual_v2",
+              "eleven_turbo_v2_5",
+            ],
           },
           {
             id: "edge",

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -11,7 +11,6 @@ import {
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type { ReplyPayload } from "../auto-reply/types.js";
-import { normalizeChannelId } from "../channels/plugins/index.js";
 import type { ChannelId } from "../channels/plugins/types.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type {
@@ -21,6 +20,7 @@ import type {
   TtsProvider,
   TtsModelOverrideConfig,
 } from "../config/types.tts.js";
+import { normalizeChannelId } from "../channels/plugins/index.js";
 import { logVerbose } from "../globals.js";
 import { stripMarkdown } from "../line/markdown-to-line.js";
 import { isVoiceCompatibleAudio } from "../media/audio.js";
@@ -48,7 +48,8 @@ const DEFAULT_MAX_TEXT_LENGTH = 4096;
 
 const DEFAULT_ELEVENLABS_BASE_URL = "https://api.elevenlabs.io";
 const DEFAULT_ELEVENLABS_VOICE_ID = "pMsXgVXv3BLzUgSXRplE";
-const DEFAULT_ELEVENLABS_MODEL_ID = "eleven_multilingual_v2";
+// Prefer flash v2.5 for free tier (lower cost, fast); multilingual_v2 and turbo_v2_5 also supported.
+const DEFAULT_ELEVENLABS_MODEL_ID = "eleven_flash_v2_5";
 const DEFAULT_OPENAI_MODEL = "gpt-4o-mini-tts";
 const DEFAULT_OPENAI_VOICE = "alloy";
 const DEFAULT_EDGE_VOICE = "en-US-MichelleNeural";


### PR DESCRIPTION
TTS: default ElevenLabs model is now eleven_flash_v2_5 (free-tier friendly); deprecated eleven_monolingual_v1 removed from options; TTS tool accepts optional modelId and voiceId.

fix #18895

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updated ElevenLabs TTS to use `eleven_flash_v2_5` as the default model (better free-tier compatibility) and removed deprecated `eleven_monolingual_v1`. Added optional `modelId` and `voiceId` parameters to the TTS tool, allowing agents to customize voice output per request.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor documentation inconsistencies
- The code changes are straightforward and well-implemented. The default model change aligns with the goal of free-tier friendliness. The new tool parameters follow existing patterns and include proper override handling. However, documentation in multiple files still references the old default model.
- No files require special attention

<sub>Last reviewed commit: aac696c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->