### PR TITLE
feat: dequeue followup messages on source message deletion

### DIFF
--- a/src/auto-reply/reply/queue.ts
+++ b/src/auto-reply/reply/queue.ts
@@ -2,7 +2,11 @@ export { extractQueueDirective } from "./queue/directive.js";
 export { clearSessionQueues } from "./queue/cleanup.js";
 export type { ClearSessionQueueResult } from "./queue/cleanup.js";
 export { scheduleFollowupDrain } from "./queue/drain.js";
-export { enqueueFollowupRun, getFollowupQueueDepth } from "./queue/enqueue.js";
+export {
+  enqueueFollowupRun,
+  getFollowupQueueDepth,
+  removeFollowupRunByMessageId,
+} from "./queue/enqueue.js";
 export { resolveQueueSettings } from "./queue/settings.js";
 export { clearFollowupQueue } from "./queue/state.js";
 export type {

--- a/src/auto-reply/reply/queue/enqueue.ts
+++ b/src/auto-reply/reply/queue/enqueue.ts
@@ -56,6 +56,26 @@ export function enqueueFollowupRun(
   return true;
 }
 
+/**
+ * Remove queued followup items matching a provider message ID.
+ * Scans all active queues — messageIds are unique per provider so
+ * a global scan is safe and avoids needing a session-key lookup.
+ * Returns the number of items removed.
+ */
+export function removeFollowupRunByMessageId(messageId: string): number {
+  const trimmed = messageId.trim();
+  if (!trimmed) {
+    return 0;
+  }
+  let removed = 0;
+  for (const queue of FOLLOWUP_QUEUES.values()) {
+    const before = queue.items.length;
+    queue.items = queue.items.filter((item) => item.messageId?.trim() !== trimmed);
+    removed += before - queue.items.length;
+  }
+  return removed;
+}
+
 export function getFollowupQueueDepth(key: string): number {
   const cleaned = key.trim();
   if (!cleaned) {

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -56,6 +56,7 @@ import { createDiscordGatewayPlugin } from "./gateway-plugin.js";
 import { registerGateway, unregisterGateway } from "./gateway-registry.js";
 import {
   DiscordMessageListener,
+  DiscordMessageDeletedListener,
   DiscordPresenceListener,
   DiscordReactionListener,
   DiscordReactionRemoveListener,
@@ -576,6 +577,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
   });
 
   registerDiscordListener(client.listeners, new DiscordMessageListener(messageHandler, logger));
+  registerDiscordListener(client.listeners, new DiscordMessageDeletedListener({ logger }));
   registerDiscordListener(
     client.listeners,
     new DiscordReactionListener({

--- a/src/slack/monitor/events/messages.ts
+++ b/src/slack/monitor/events/messages.ts
@@ -1,4 +1,5 @@
 import type { SlackEventMiddlewareArgs } from "@slack/bolt";
+import { removeFollowupRunByMessageId } from "../../../auto-reply/reply/queue.js";
 import { danger } from "../../../globals.js";
 import { enqueueSystemEvent } from "../../../infra/system-events.js";
 import type { SlackAppMentionEvent, SlackMessageEvent } from "../../types.js";
@@ -66,6 +67,10 @@ export function registerSlackMessageEvents(params: {
       if (message.subtype === "message_deleted") {
         const deleted = event as SlackMessageDeletedEvent;
         const channelId = deleted.channel;
+        const deletedTs = deleted.deleted_ts;
+        if (deletedTs) {
+          removeFollowupRunByMessageId(deletedTs);
+        }
         const target = await resolveSlackChannelSystemEventTarget(channelId);
         if (!target) {
           return;

--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -1,5 +1,5 @@
-import type { Bot } from "grammy";
 import path from "node:path";
+import type { Bot } from "grammy";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { STATE_DIR } from "../config/paths.js";
 

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -1,10 +1,4 @@
 import type { Bot } from "grammy";
-import type { OpenClawConfig, ReplyToMode, TelegramAccountConfig } from "../config/types.js";
-import type { RuntimeEnv } from "../runtime.js";
-import type { TelegramMessageContext } from "./bot-message-context.js";
-import type { TelegramBotOptions } from "./bot.js";
-import type { TelegramStreamMode } from "./bot/types.js";
-import type { TelegramInlineButtons } from "./button-types.js";
 import { resolveAgentDir } from "../agents/agent-scope.js";
 import {
   findModelInCatalog,
@@ -21,9 +15,15 @@ import { logAckFailure, logTypingFailure } from "../channels/logging.js";
 import { createReplyPrefixOptions } from "../channels/reply-prefix.js";
 import { createTypingCallbacks } from "../channels/typing.js";
 import { resolveMarkdownTableMode } from "../config/markdown-tables.js";
+import type { OpenClawConfig, ReplyToMode, TelegramAccountConfig } from "../config/types.js";
 import { danger, logVerbose } from "../globals.js";
 import { getAgentScopedMediaLocalRoots } from "../media/local-roots.js";
+import type { RuntimeEnv } from "../runtime.js";
+import type { TelegramMessageContext } from "./bot-message-context.js";
+import type { TelegramBotOptions } from "./bot.js";
 import { deliverReplies } from "./bot/delivery.js";
+import type { TelegramStreamMode } from "./bot/types.js";
+import type { TelegramInlineButtons } from "./button-types.js";
 import { resolveTelegramDraftStreamingChunking } from "./draft-chunking.js";
 import { createTelegramDraftStream } from "./draft-stream.js";
 import { editMessageTelegram } from "./send.js";


### PR DESCRIPTION
## Summary

- Problem: When the agent is busy and a user deletes a queued message, the deleted message still gets delivered in the next agent turn
- Why it matters: Users expect unsend to work; responding to deleted messages is confusing
- What changed: Added `removeFollowupRunByMessageId()` to the queue module and wired it into Slack (`message_deleted` event) and Discord (new `MessageDeleteListener`)
- What did NOT change: Telegram (Bot API limitation), Signal, WhatsApp, iMessage

## Change Type (select all)

- [x] Feature

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #18928

## User-visible / Behavior Changes

- **Slack**: Deleted messages while agent is busy are dequeued before the next turn
- **Discord**: Same behavior via a new `messageDelete` listener
- **Telegram/Signal/WhatsApp/iMessage**: No change (no delete event APIs available)

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Evidence

- 4 new unit tests in `reply-flow.test.ts`
- Build + lint + format all pass

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: Global queue scan on every delete event
  - Mitigation: O(queues x items) is trivially small; only items with matching messageId are affected

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added dequeuing of followup messages when users delete messages in Slack and Discord. When the agent is busy processing and a user deletes a queued message, the new `removeFollowupRunByMessageId()` function scans all queues and removes matching items before they're delivered in the next agent turn.

- Implemented `removeFollowupRunByMessageId()` in `queue/enqueue.ts` with global queue scanning
- Wired Slack's `message_deleted` event to call the dequeue function using `deleted_ts` as messageId
- Created `DiscordMessageDeletedListener` class to handle Discord message deletions
- Added 4 comprehensive unit tests covering single queue removal, multi-queue removal, empty/missing messageId cases
- Telegram changes are import reordering only (no functional change, as noted in PR description)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is straightforward and well-tested. The new `removeFollowupRunByMessageId()` function uses a simple global scan with proper null/empty checks. Integration points in Slack and Discord are minimal and well-isolated. The 4 new tests provide good coverage of edge cases (empty messageId, missing messageId, multi-queue removal). The global queue scan is acceptable given the small queue sizes mentioned in the PR description. No security concerns, no breaking changes, and backward compatible.
- No files require special attention

<sub>Last reviewed commit: 41be6ab</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->