### PR TITLE
fix(security): use timingSafeEqual for pairing code comparison

### DIFF
--- a/src/pairing/pairing-store.test.ts
+++ b/src/pairing/pairing-store.test.ts
@@ -277,6 +277,70 @@ describe("pairing store", () => {
     });
   });
 
+  it("approves pairing code via crypto.timingSafeEqual", async () => {
+    const spy = vi.spyOn(crypto, "timingSafeEqual");
+    try {
+      await withTempStateDir(async () => {
+        const created = await upsertChannelPairingRequest({
+          channel: "signal",
+          id: "+15559999999",
+          accountId: DEFAULT_ACCOUNT_ID,
+        });
+        expect(created.created).toBe(true);
+
+        spy.mockClear();
+        const approved = await approveChannelPairingCode({
+          channel: "signal",
+          code: created.code.toLowerCase(),
+          accountId: DEFAULT_ACCOUNT_ID,
+        });
+        expect(approved?.id).toBe("+15559999999");
+        expect(spy).toHaveBeenCalled();
+      });
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("rejects wrong code of same length via timing-safe path", async () => {
+    await withTempStateDir(async () => {
+      await upsertChannelPairingRequest({
+        channel: "signal",
+        id: "+15558888888",
+        accountId: DEFAULT_ACCOUNT_ID,
+      });
+      const rejected = await approveChannelPairingCode({
+        channel: "signal",
+        code: "ZZZZZZZZ",
+        accountId: DEFAULT_ACCOUNT_ID,
+      });
+      expect(rejected).toBeNull();
+    });
+  });
+
+  it("rejects wrong code of different length without timing leak", async () => {
+    const spy = vi.spyOn(crypto, "timingSafeEqual");
+    try {
+      await withTempStateDir(async () => {
+        await upsertChannelPairingRequest({
+          channel: "signal",
+          id: "+15557777777",
+          accountId: DEFAULT_ACCOUNT_ID,
+        });
+        spy.mockClear();
+        const rejected = await approveChannelPairingCode({
+          channel: "signal",
+          code: "ZZZ",
+          accountId: DEFAULT_ACCOUNT_ID,
+        });
+        expect(rejected).toBeNull();
+        expect(spy).toHaveBeenCalled();
+      });
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
   it("stores allowFrom entries per account when accountId is provided", async () => {
     await withTempStateDir(async () => {
       await addChannelAllowFromStoreEntry({

--- a/src/pairing/pairing-store.ts
+++ b/src/pairing/pairing-store.ts
@@ -816,7 +816,15 @@ export async function approveChannelPairingCode(params: {
       const { requests: pruned, removed } = await readPrunedPairingRequests(filePath);
       const normalizedAccountId = normalizePairingAccountId(params.accountId);
       const idx = pruned.findIndex((r) => {
-        if (String(r.code ?? "").toUpperCase() !== code) {
+        const stored = String(r.code ?? "").toUpperCase();
+        const storedBuf = Buffer.from(stored, "utf8");
+        const codeBuf = Buffer.from(code, "utf8");
+        const maxLen = Math.max(storedBuf.length, codeBuf.length);
+        const a = Buffer.alloc(maxLen);
+        const b = Buffer.alloc(maxLen);
+        storedBuf.copy(a);
+        codeBuf.copy(b);
+        if (!crypto.timingSafeEqual(a, b)) {
           return false;
         }
         return requestMatchesAccountId(r, normalizedAccountId);


### PR DESCRIPTION
## Summary

Replace direct string comparison of pairing codes with `crypto.timingSafeEqual` to prevent timing side-channel attacks.

## Problem

The pairing code lookup in `approveChannelPairingCode` uses `===` for comparison:

```ts
String(r.code ?? '').toUpperCase() !== code
```

This is vulnerable to timing attacks — an attacker on the same network could measure response time differences to brute-force valid pairing codes during the approval window.

## Fix

Zero-pad both buffers to `Math.max(a.length, b.length)` before calling `crypto.timingSafeEqual`, so:

1. Length-mismatched inputs **never short-circuit** before the constant-time comparison (no length-leak)
2. `timingSafeEqual` is **always called** regardless of input length
3. No HMAC overhead — avoids the entropy concerns raised in #19864

This approach was suggested by @arosstale in the #19864 review thread as the simplest correct fix.

## Changes

- `src/pairing/pairing-store.ts` — zero-pad both buffers before `timingSafeEqual` in `approveChannelPairingCode`
- `src/pairing/pairing-store.test.ts` — added spy assertion to confirm `timingSafeEqual` is called even for different-length inputs

## Relationship to #19864

That PR addressed `safeEqualSecret` (gateway auth tokens). This PR addresses the separate `approveChannelPairingCode` function, which does not use `safeEqualSecret`. Both functions had the same class of vulnerability.