### PR TITLE
fix(completion): avoid compdef error in zsh by guarding completion init

### DIFF
--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -95,6 +95,13 @@ function formatCompletionSourceLine(
   binName: string,
   cachePath: string,
 ): string {
+  if (shell === "zsh") {
+    return `if [[ -o interactive ]]; then
+  autoload -Uz compinit
+  (( $+functions[compdef] )) || compinit
+  source "${cachePath}"
+fi`;
+  }
   if (shell === "fish") {
     return `source "${cachePath}"`;
   }


### PR DESCRIPTION
## Summary
- fix `command not found: compdef` for zsh users with minimal shell setup
- make generated zsh completion source block interactive-only
- ensure `compinit` is available before sourcing cached completion script

## What changed
In `src/cli/completion-cli.ts`, `formatCompletionSourceLine(...)` now emits this for zsh:

```zsh
if [[ -o interactive ]]; then
  autoload -Uz compinit
  (( $+functions[compdef] )) || compinit
  source "<cache-path>"
fi
```

## Why
The previous install block only sourced the completion script. In shells where `compinit` had not run yet (common in minimal/clean `~/.zshrc` setups, especially over SSH), the script's `compdef` calls failed.

## Notes
- behavior for bash/fish is unchanged
- this preserves completion behavior for interactive shells while avoiding startup errors in non-interactive contexts

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed `command not found: compdef` error in zsh by wrapping completion initialization in an interactive-only guard that ensures `compinit` is loaded before sourcing the cached completion script.

- Wrapped zsh completion source block with `[[ -o interactive ]]` check
- Added `autoload -Uz compinit` to load the completion system
- Added `(( $+functions[compdef] )) || compinit` to initialize only if `compdef` is missing
- Prevented startup errors in non-interactive contexts (e.g., SSH sessions, minimal `.zshrc` setups)

<h3>Confidence Score: 5/5</h3>

- Safe to merge - addresses a specific zsh initialization error with a standard solution
- The fix follows zsh best practices by checking for interactive mode, loading compinit only when needed, and preserving bash/fish behavior. The implementation is minimal, targeted, and uses standard zsh idioms (`[[ -o interactive ]]`, `autoload -Uz`, `$+functions[compdef]`). No behavior changes for other shells.
- No files require special attention

<sub>Last reviewed commit: e145af6</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->