### PR TITLE
fix: tighten permissions on cron/, browser/, settings/, logs/ in doctor --fix

### DIFF
--- a/src/security/fix.ts
+++ b/src/security/fix.ts
@@ -440,6 +440,25 @@ export async function fixSecurityFootguns(opts?: {
   actions.push(await applyPerms({ path: stateDir, mode: 0o700, require: "dir" }));
   actions.push(await applyPerms({ path: configPath, mode: 0o600, require: "file" }));
 
+  // Tighten permissions on sensitive subdirectories and files (#18866)
+  const cronDir = path.join(stateDir, "cron");
+  actions.push(await applyPerms({ path: cronDir, mode: 0o700, require: "dir" }));
+  actions.push(
+    await applyPerms({ path: path.join(cronDir, "jobs.json"), mode: 0o600, require: "file" }),
+  );
+  actions.push(
+    await applyPerms({ path: path.join(cronDir, "jobs.json.bak"), mode: 0o600, require: "file" }),
+  );
+  actions.push(
+    await applyPerms({ path: path.join(stateDir, "browser"), mode: 0o700, require: "dir" }),
+  );
+  actions.push(
+    await applyPerms({ path: path.join(stateDir, "settings"), mode: 0o700, require: "dir" }),
+  );
+  actions.push(
+    await applyPerms({ path: path.join(stateDir, "logs"), mode: 0o700, require: "dir" }),
+  );
+
   if (snap.exists) {
     const includePaths = await collectIncludePathsRecursive({
       configPath: snap.path,


### PR DESCRIPTION
## Summary

Fixes #18866

`fixSecurityFootguns()` already secures `stateDir` (700), `configPath` (600), `credentials/` (700/600), and `agents/*/sessions` (700/600) — but the `cron/`, `browser/`, `settings/`, and `logs/` subdirectories were created with default world-readable permissions and never tightened by `doctor --fix`.

This adds `applyPerms` calls for:
- `cron/` → 700
- `cron/jobs.json` → 600
- `cron/jobs.json.bak` → 600
- `browser/` → 700
- `settings/` → 700
- `logs/` → 700

The existing `safeChmod` helper already handles missing paths gracefully (`skipped: "missing"`), so these calls are safe even if the directories don't exist yet.

## Changes
- **`src/security/fix.ts`**: Added permission tightening for `cron/`, `browser/`, `settings/`, and `logs/` subdirectories and sensitive files within `fixSecurityFootguns()`
- **`src/security/fix.test.ts`**: Added test verifying all new paths get tightened from 755/644 to 700/600

## Test plan
- [x] `npx vitest run src/security/fix.test.ts` — all 6 tests pass (5 existing + 1 new)
- [ ] Manual: run `openclaw doctor --fix`, verify `cron/`, `browser/`, `settings/`, `logs/` are 700 and `cron/jobs.json` is 600

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extends `fixSecurityFootguns()` to tighten permissions on four previously unprotected state subdirectories (`cron/`, `browser/`, `settings/`, `logs/`) and two sensitive cron files (`jobs.json`, `jobs.json.bak`). These directories were created with default world-readable permissions and never hardened by `doctor --fix`, despite containing user configuration and runtime data.

- Directories `cron/`, `browser/`, `settings/`, `logs/` are now set to `0o700` (owner-only access)
- `cron/jobs.json` and `cron/jobs.json.bak` are now set to `0o600` (owner read/write only)
- Correctly uses the `applyPerms` wrapper which handles both Unix (`safeChmod`) and Windows (`safeAclReset`)
- New test verifies all paths are tightened from 755/644 to 700/600
- No issues found in this PR

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk — it adds straightforward permission tightening using existing, well-tested helpers.
- The changes are minimal, follow established patterns exactly, use existing safe helpers that gracefully handle missing paths, and include a thorough test. The `applyPerms` wrapper correctly handles both Unix and Windows platforms. No logical errors, no security concerns, no edge cases missed.
- No files require special attention.

<sub>Last reviewed commit: 3185d75</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->