### PR TITLE
Outbound: preserve plugin-normalized ids for message target resolution

### DIFF
--- a/src/agents/tools/sessions-send-helpers.ts
+++ b/src/agents/tools/sessions-send-helpers.ts
@@ -1,9 +1,9 @@
 import {
-  getChannelPlugin,
   normalizeChannelId as normalizeAnyChannelId,
 } from "../../channels/plugins/index.js";
 import { normalizeChannelId as normalizeChatChannelId } from "../../channels/registry.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import { normalizeTargetForProvider } from "../../infra/outbound/target-normalization.js";
 
 const ANNOUNCE_SKIP_TOKEN = "ANNOUNCE_SKIP";
 const REPLY_SKIP_TOKEN = "REPLY_SKIP";
@@ -61,7 +61,7 @@ export function resolveAnnounceTargetFromKey(sessionKey: string): AnnounceTarget
     return kind === "channel" ? `channel:${id}` : `group:${id}`;
   })();
   const normalized = normalizedChannel
-    ? getChannelPlugin(normalizedChannel)?.messaging?.normalizeTarget?.(kindTarget)
+    ? normalizeTargetForProvider(normalizedChannel, kindTarget)
     : undefined;
   return {
     channel,

--- a/src/agents/tools/sessions-send-helpers.ts
+++ b/src/agents/tools/sessions-send-helpers.ts
@@ -1,8 +1,6 @@
-import {
-  normalizeChannelId as normalizeAnyChannelId,
-} from "../../channels/plugins/index.js";
-import { normalizeChannelId as normalizeChatChannelId } from "../../channels/registry.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import { normalizeChannelId as normalizeAnyChannelId } from "../../channels/plugins/index.js";
+import { normalizeChannelId as normalizeChatChannelId } from "../../channels/registry.js";
 import { normalizeTargetForProvider } from "../../infra/outbound/target-normalization.js";
 
 const ANNOUNCE_SKIP_TOKEN = "ANNOUNCE_SKIP";

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -267,8 +267,16 @@ export type ChannelThreadingToolContext = {
   skipCrossContextDecoration?: boolean;
 };
 
+export type ChannelNormalizedTargetResult =
+  | string
+  | {
+      ok?: boolean;
+      to?: string;
+      target?: string;
+    };
+
 export type ChannelMessagingAdapter = {
-  normalizeTarget?: (raw: string) => string | undefined;
+  normalizeTarget?: (raw: string) => ChannelNormalizedTargetResult | undefined;
   targetResolver?: {
     looksLikeId?: (raw: string, normalized?: string) => boolean;
     hint?: string;

--- a/src/infra/outbound/target-normalization.ts
+++ b/src/infra/outbound/target-normalization.ts
@@ -11,8 +11,28 @@ export function normalizeTargetForProvider(provider: string, raw?: string): stri
   }
   const providerId = normalizeChannelId(provider);
   const plugin = providerId ? getChannelPlugin(providerId) : undefined;
-  const normalized = plugin?.messaging?.normalizeTarget?.(raw) ?? (raw.trim() || undefined);
+  const normalized = readNormalizedTarget(plugin?.messaging?.normalizeTarget?.(raw)) ?? raw.trim();
   return normalized || undefined;
+}
+
+function readNormalizedTarget(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed || undefined;
+  }
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const targetObj = value as { to?: unknown; target?: unknown; ok?: unknown };
+  if ("ok" in targetObj && targetObj.ok === false) {
+    return undefined;
+  }
+  const candidate = typeof targetObj.to === "string" ? targetObj.to : targetObj.target;
+  if (typeof candidate !== "string") {
+    return undefined;
+  }
+  const trimmed = candidate.trim();
+  return trimmed || undefined;
 }
 
 export function buildTargetResolverSignature(channel: ChannelId): string {

--- a/src/infra/outbound/target-resolver.test.ts
+++ b/src/infra/outbound/target-resolver.test.ts
@@ -75,4 +75,33 @@ describe("resolveMessagingTarget (directory fallback)", () => {
     expect(mocks.listGroups).not.toHaveBeenCalled();
     expect(mocks.listGroupsLive).not.toHaveBeenCalled();
   });
+
+  it("accepts object-style normalizeTarget results from plugins", async () => {
+    mocks.getChannelPlugin.mockReturnValue({
+      messaging: {
+        normalizeTarget: (raw: string) => ({ ok: true, to: raw.replace(/^qqbot:/i, "") }),
+        targetResolver: {
+          looksLikeId: (id: string) => /^[A-F0-9]{32}$/i.test(id.replace(/^qqbot:/i, "")),
+        },
+      },
+      directory: {
+        listGroups: mocks.listGroups,
+        listGroupsLive: mocks.listGroupsLive,
+      },
+    });
+
+    const result = await resolveMessagingTarget({
+      cfg,
+      channel: "discord",
+      input: "152BF619E18BD4CE359F3A25C9023836",
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.target.source).toBe("normalized");
+      expect(result.target.to).toBe("152BF619E18BD4CE359F3A25C9023836");
+    }
+    expect(mocks.listGroups).not.toHaveBeenCalled();
+    expect(mocks.listGroupsLive).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
Fix target resolution when plugins return object-style values from messaging.normalizeTarget (for example { ok: true, to: "..." }).

## Changes
- Harden 
ormalizeTargetForProvider to coerce both string and object-style normalize results.
- Support { to } / { target } object shapes and ignore { ok: false }.
- Add regression coverage in 	arget-resolver tests.

## Validation
- corepack pnpm exec vitest run src/infra/outbound/target-resolver.test.ts
- Result: 3 tests passed.

Closes #18864

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added support for object-style return values from plugin `normalizeTarget` functions, which previously only supported strings. The new `readNormalizedTarget` helper function coerces both string and object results (with `{ to }` or `{ target }` fields) into normalized string targets, and correctly handles `{ ok: false }` by returning `undefined`.

**Key changes:**
- Introduced `readNormalizedTarget` function to parse both string and object-style plugin responses
- Supports `{ to: string }` and `{ target: string }` object shapes with `to` taking precedence
- Treats `{ ok: false }` as a normalization failure (returns `undefined`)
- Falls back to `raw.trim()` if plugin normalization returns `undefined`
- Added test coverage for object-style `normalizeTarget` results

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor considerations about type definitions
- The implementation is well-structured and handles multiple object formats defensively. The code properly validates types and handles edge cases like `{ ok: false }` and non-string values. Test coverage demonstrates the happy path works correctly. However, the TypeScript type definition for `normalizeTarget` in `types.core.ts` still declares `string | undefined` as the return type but wasn't updated to reflect that plugins can now return objects, which could cause type mismatches for plugin implementations
- Check that `src/channels/plugins/types.core.ts` has the correct type definition for `normalizeTarget` to allow object returns

<sub>Last reviewed commit: 4f3db94</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->