### PR TITLE
fix: sanitize schtasks env vars to prevent CRLF command injection

### DIFF
--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -1,12 +1,12 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import type { GatewayServiceRuntime } from "./service-runtime.js";
 import { splitArgsPreservingQuotes } from "./arg-split.js";
 import { resolveGatewayServiceDescription, resolveGatewayWindowsTaskName } from "./constants.js";
 import { formatLine } from "./output.js";
 import { resolveGatewayStateDir } from "./paths.js";
 import { parseKeyValueOutput } from "./runtime-parse.js";
 import { execSchtasks } from "./schtasks-exec.js";
-import type { GatewayServiceRuntime } from "./service-runtime.js";
 
 function resolveTaskName(env: Record<string, string | undefined>): string {
   const override = env.OPENCLAW_WINDOWS_TASK_NAME?.trim();
@@ -132,7 +132,7 @@ export function parseSchtasksQuery(output: string): ScheduledTaskInfo {
   return info;
 }
 
-function buildTaskScript({
+export function buildTaskScript({
   description,
   programArguments,
   workingDirectory,
@@ -155,7 +155,8 @@ function buildTaskScript({
       if (!value) {
         continue;
       }
-      lines.push(`set ${key}=${value}`);
+      // Prevent command injection via line breaks in batch `set` statements.
+      lines.push(`set ${key.replace(/[\r\n]/g, "")}=${value.replace(/[\r\n]/g, "")}`);
     }
   }
   const command = programArguments.map(quoteCmdArg).join(" ");


### PR DESCRIPTION
## Fix Summary

- sanitize CR/LF characters in schtasks batch-script environment keys and values before emitting `set KEY=VALUE`
- prevent newline-based command breakout in generated `.cmd` files
- add regression tests for CRLF and LF payloads in env values and CRLF in env keys

## Issue Linkage

Fixes #18943

## Security Snapshot

- CVSS v3.1: 7.8 (High)
- CVSS v4.0: 8.5 (High)

## Implementation Details

### Files Changed
- `src/daemon/schtasks.test.ts` (+45/-1)
- `src/daemon/schtasks.ts` (+4/-3)

### Technical Analysis
- sanitize CR/LF characters in schtasks batch-script environment keys and values before emitting `set KEY=VALUE`

## Validation Evidence

- Command: `N/A`
- Status: pass/fail state not explicitly provided in original body

## Risk and Compatibility

non-breaking; compatibility impact was not explicitly documented in the original PR body.

## AI-Assisted Disclosure

- AI-assisted: yes
- Model: Unknown

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a CRLF command injection vulnerability in the Windows scheduled task batch script generator (`buildTaskScript` in `src/daemon/schtasks.ts`). Previously, env var keys and values were interpolated into `set` lines without sanitization, allowing a crafted value containing carriage return/line feed to break out of the `set` statement and inject arbitrary commands into the generated `.cmd` file.

- Strips CR and LF characters from both env var keys and values before emitting `set` statements
- Exports `buildTaskScript` to enable direct unit testing
- Adds three regression tests covering CRLF in values, LF-only in values, and CRLF in keys
- Minor import reorder for formatting compliance

The fix is targeted and correct for the primary attack vector (env vars from config files via `collectConfigEnvVars`). A minor defense-in-depth suggestion was left for applying the same sanitization to `description` and `workingDirectory` parameters, which are also interpolated into the script.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it correctly addresses the CRLF injection vulnerability with a minimal, focused change.
- The fix is straightforward and correct: stripping CR/LF from env var keys and values prevents command injection in batch scripts. Tests cover the key scenarios (CRLF, LF-only, key injection). The only minor gap is that other parameters interpolated into the script (description, workingDirectory) are not similarly sanitized, though those vectors are lower risk. No regressions expected from this change.
- No files require special attention — `src/daemon/schtasks.ts` has a minor defense-in-depth suggestion but no blocking issues.

<sub>Last reviewed commit: 8ee677e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->