### PR TITLE
fix(security): secure cron, browser, settings dirs in doctor --fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Security: `doctor --fix` now secures `cron/`, `browser/`, and `settings/` subdirectories (700 for dirs, 600 for files inside `cron/`) that were previously left world-readable. (#18866)
+
 - Voice-call: auto-end calls when media streams disconnect to prevent stuck active calls. (#18435) Thanks @JayMishra-source.
 - Gateway/Channels: wire `gateway.channelHealthCheckMinutes` into strict config validation, treat implicit account status as managed for health checks, and harden channel auto-restart flow (preserve restart-attempt caps across crash loops, propagate enabled/configured runtime flags, and stop pending restart backoff after manual stop). Thanks @steipete.
 - Gateway/WebChat: hard-cap `chat.history` oversized payloads by truncating high-cost fields and replacing over-budget entries with placeholders, so history fetches stay within configured byte limits and avoid chat UI freezes. (#18505)

--- a/extensions/mattermost/src/mattermost/monitor-websocket.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-websocket.test.ts
@@ -185,6 +185,9 @@ describe("mattermost websocket monitor", () => {
       webSocketFactory: () => socket,
     });
 
+    // Start connectOnce so listeners are registered before emitting events
+    const promise = connectOnce();
+
     socket.emitOpen();
     socket.emitMessage(
       Buffer.from(
@@ -202,7 +205,7 @@ describe("mattermost websocket monitor", () => {
     );
     socket.emitClose(1000);
 
-    await connectOnce();
+    await promise;
 
     expect(onReaction).toHaveBeenCalledTimes(1);
     expect(onPosted).not.toHaveBeenCalled();

--- a/src/security/fix.test.ts
+++ b/src/security/fix.test.ts
@@ -242,4 +242,40 @@ describe("security fix", () => {
     expectPerms((await fs.stat(transcriptPath)).mode & 0o777, 0o600);
     expectPerms((await fs.stat(includePath)).mode & 0o777, 0o600);
   });
+
+  it("tightens perms for cron/, browser/, and settings/ subdirectories", async () => {
+    const stateDir = await createStateDir("sensitive-subdirs");
+
+    const configPath = path.join(stateDir, "openclaw.json");
+    await writeJsonConfig(configPath, {});
+
+    // Create cron/ with files
+    const cronDir = path.join(stateDir, "cron");
+    await fs.mkdir(cronDir, { recursive: true });
+    await fs.chmod(cronDir, 0o755);
+    const jobsPath = path.join(cronDir, "jobs.json");
+    await fs.writeFile(jobsPath, "{}\n", "utf-8");
+    await fs.chmod(jobsPath, 0o644);
+    const bakPath = path.join(cronDir, "jobs.json.bak");
+    await fs.writeFile(bakPath, "{}\n", "utf-8");
+    await fs.chmod(bakPath, 0o644);
+
+    // Create browser/ and settings/
+    const browserDir = path.join(stateDir, "browser");
+    await fs.mkdir(browserDir, { recursive: true });
+    await fs.chmod(browserDir, 0o755);
+    const settingsDir = path.join(stateDir, "settings");
+    await fs.mkdir(settingsDir, { recursive: true });
+    await fs.chmod(settingsDir, 0o755);
+
+    const env = createFixEnv(stateDir, configPath);
+    const res = await fixSecurityFootguns({ env, stateDir, configPath });
+    expect(res.ok).toBe(true);
+
+    expectPerms((await fs.stat(cronDir)).mode & 0o777, 0o700);
+    expectPerms((await fs.stat(jobsPath)).mode & 0o777, 0o600);
+    expectPerms((await fs.stat(bakPath)).mode & 0o777, 0o600);
+    expectPerms((await fs.stat(browserDir)).mode & 0o777, 0o700);
+    expectPerms((await fs.stat(settingsDir)).mode & 0o777, 0o700);
+  });
 });


### PR DESCRIPTION
## Summary

`fixSecurityFootguns` already tightened permissions on the state
directory, config file, credentials, and agent session paths. However,
the `cron/`, `browser/`, and `settings/` subdirectories were left with
default permissions (755/644), leaving `cron/jobs.json` (scheduled task
payloads), browser session state/cookies, and settings world-readable.

Closes #18866

## Changes

- `src/security/fix.ts` – after the existing credential/agent hardening,
  iterate over `cron/`, `browser/`, `settings/` subdirectories and apply
  700 permissions; also chmod all files inside `cron/` to 600
- `src/security/fix.test.ts` – new test case that creates all three
  subdirectories with 755/644 permissions and verifies they get tightened
  to 700/600

## Test plan

- [x] New test passes: `pnpm vitest run src/security/fix.test.ts` (6/6)
- [x] All existing security fix tests still pass
- [ ] Manual: run `openclaw doctor --fix` and verify `ls -la ~/.openclaw/cron/` shows 700/600

## QA

- [x] Missing directories are safely skipped (ENOENT handling in `safeChmod`)
- [x] Symlinks are skipped (existing `safeChmod` guard)
- [x] Windows path handled via existing `applyPerms` abstraction (icacls)
- [x] No type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends `fixSecurityFootguns` to tighten permissions on three previously unsecured state subdirectories (`cron/`, `browser/`, `settings/`), closing a gap where sensitive data like cron job payloads, browser session state, and settings were world-readable.

- Applies `0o700` to `cron/`, `browser/`, and `settings/` directories and `0o600` to files inside `cron/` using the existing cross-platform `applyPerms` abstraction (handles both Unix chmod and Windows icacls).
- Adds a comprehensive test verifying all three directories and cron files get tightened from `755`/`644` to `700`/`600`.
- Changelog entry correctly placed under Fixes with issue reference.
- Minor gap: `cron/runs/` subdirectory (containing per-job `.jsonl` run logs) is not recursively secured, though parent `cron/` at `700` provides adequate first-layer protection.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it extends existing permission-hardening patterns with proper error handling and cross-platform support.
- Score of 4 reflects a clean, well-tested security improvement that follows existing patterns. The only gap is the `cron/runs/` subdirectory not being recursively secured, which is a defense-in-depth improvement rather than a vulnerability since the parent directory permissions already prevent unauthorized access.
- `src/security/fix.ts` — the `cron/runs/` subdirectory and its JSONL files are not secured by the new code, though parent directory permissions provide adequate protection.

<sub>Last reviewed commit: 38df423</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->