### PR TITLE
fix(tts): replace deprecated ElevenLabs eleven_monolingual_v1 model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- TTS: replace deprecated `eleven_monolingual_v1` with `eleven_flash_v2_5` in the ElevenLabs model catalogue so free-tier users see a supported model in the UI. (#18895)
+
 - Voice-call: auto-end calls when media streams disconnect to prevent stuck active calls. (#18435) Thanks @JayMishra-source.
 - Gateway/Channels: wire `gateway.channelHealthCheckMinutes` into strict config validation, treat implicit account status as managed for health checks, and harden channel auto-restart flow (preserve restart-attempt caps across crash loops, propagate enabled/configured runtime flags, and stop pending restart backoff after manual stop). Thanks @steipete.
 - Gateway/WebChat: hard-cap `chat.history` oversized payloads by truncating high-cost fields and replacing over-budget entries with placeholders, so history fetches stay within configured byte limits and avoid chat UI freezes. (#18505)

--- a/extensions/mattermost/src/mattermost/monitor-websocket.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-websocket.test.ts
@@ -185,6 +185,9 @@ describe("mattermost websocket monitor", () => {
       webSocketFactory: () => socket,
     });
 
+    // Start connectOnce so listeners are registered before emitting events
+    const promise = connectOnce();
+
     socket.emitOpen();
     socket.emitMessage(
       Buffer.from(
@@ -202,7 +205,7 @@ describe("mattermost websocket monitor", () => {
     );
     socket.emitClose(1000);
 
-    await connectOnce();
+    await promise;
 
     expect(onReaction).toHaveBeenCalledTimes(1);
     expect(onPosted).not.toHaveBeenCalled();

--- a/src/gateway/server-methods/tts.ts
+++ b/src/gateway/server-methods/tts.ts
@@ -139,7 +139,7 @@ export const ttsHandlers: GatewayRequestHandlers = {
             id: "elevenlabs",
             name: "ElevenLabs",
             configured: Boolean(resolveTtsApiKey(config, "elevenlabs")),
-            models: ["eleven_multilingual_v2", "eleven_turbo_v2_5", "eleven_monolingual_v1"],
+            models: ["eleven_multilingual_v2", "eleven_turbo_v2_5", "eleven_flash_v2_5"],
           },
           {
             id: "edge",


### PR DESCRIPTION
## Summary

ElevenLabs deprecated the `eleven_monolingual_v1` model, which is no
longer available on the free tier. The gateway model catalogue still
listed it, so users selecting it from the UI would get unexpected
results (default female voice regardless of voice ID).

Replaces `eleven_monolingual_v1` with `eleven_flash_v2_5` (the modern
equivalent for fast, cost-effective TTS) in the gateway model list.

The runtime default model (`eleven_multilingual_v2`) was already correct
and is unchanged.

Closes #18895

## Changes

- `src/gateway/server-methods/tts.ts` – replace `eleven_monolingual_v1`
  with `eleven_flash_v2_5` in the ElevenLabs model catalogue

## Test plan

- [x] Verified the runtime default (`eleven_multilingual_v2`) is unchanged
- [x] Verified `eleven_flash_v2_5` is a valid ElevenLabs model ID
- [ ] Manual: check the TTS provider list in the Web UI shows the updated model

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces the deprecated ElevenLabs `eleven_monolingual_v1` model with `eleven_flash_v2_5` in the gateway TTS provider catalogue, so the UI no longer lists an unavailable model. The runtime default (`eleven_multilingual_v2`) is unchanged.

- `src/gateway/server-methods/tts.ts`: Swapped `eleven_monolingual_v1` → `eleven_flash_v2_5` in the ElevenLabs model list returned by the `tts.providers` handler.
- `src/telegram/bot.test.ts`: Fixed test assertions to use `normalizeTelegramCommandName()` when comparing native command names, aligning with the production code in `bot-native-command-menu.ts`.
- `CHANGELOG.md`: Added a changelog entry under Fixes for the TTS model replacement.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk — it swaps a deprecated model string and fixes a test assertion.
- All three changes are low-risk: a static string replacement in a model catalogue list, a test fix aligning assertions with production normalization logic, and a changelog entry. No logic, control flow, or runtime defaults are altered. The new model ID (`eleven_flash_v2_5`) is already referenced in the repo's skill docs.
- No files require special attention.

<sub>Last reviewed commit: 427a78d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->