### PR TITLE
fix(config): downgrade unknown bundled plugin references to warnings

### DIFF
--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -222,6 +222,7 @@ describe("config plugin validation", () => {
       } else {
         process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = prevBundledDir;
       }
+      clearPluginManifestRegistryCache();
     }
   });
 });

--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
+import { clearPluginManifestRegistryCache } from "../plugins/manifest-registry.js";
 import { validateConfigObjectWithPlugins } from "./config.js";
 
 async function writePluginFixture(params: {
@@ -175,6 +176,52 @@ describe("config plugin validation", () => {
         path: "agents.defaults.heartbeat.target",
         message: "unknown heartbeat target: not-a-channel",
       });
+    }
+  });
+
+  it("downgrades unknown plugin to warning when it matches a configured channel key", async () => {
+    const home = await createCaseHome();
+    // Point bundled plugins dir to an empty directory so feishu is NOT
+    // discovered automatically — simulates a deployment where the
+    // extensions directory is missing or incomplete.
+    const emptyPluginsDir = path.join(home, "empty-extensions");
+    await fs.mkdir(emptyPluginsDir, { recursive: true });
+    const prevBundledDir = process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = emptyPluginsDir;
+    clearPluginManifestRegistryCache();
+    try {
+      const res = validateInHome(home, {
+        agents: { list: [{ id: "pi" }] },
+        channels: { feishu: { appId: "x", appSecret: "y" } },
+        plugins: {
+          enabled: false,
+          entries: { feishu: { enabled: true } },
+          allow: ["feishu"],
+          slots: { memory: "none" },
+        },
+      });
+      // Should NOT be a hard error — the channel key makes it a known channel plugin
+      expect(res.ok).toBe(true);
+      if (res.ok) {
+        expect(res.warnings).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              path: "plugins.entries.feishu",
+              message: expect.stringContaining("may be a bundled plugin"),
+            }),
+            expect.objectContaining({
+              path: "plugins.allow",
+              message: expect.stringContaining("may be a bundled plugin"),
+            }),
+          ]),
+        );
+      }
+    } finally {
+      if (prevBundledDir === undefined) {
+        delete process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
+      } else {
+        process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = prevBundledDir;
+      }
     }
   });
 });


### PR DESCRIPTION
## Problem

When a bundled plugin's directory is missing or unresolvable (e.g. after upgrading from an external plugin to a stock/bundled one), config validation treats the plugin reference as a hard error and blocks startup. This affects users who have `plugins.entries`, `plugins.allow`, or `channels` referencing a plugin like `feishu` that was previously external but is now bundled — if the `extensions/` directory is incomplete, the application refuses to start.

## Solution

Downgrade "plugin not found" and "unknown channel id" errors to warnings when the referenced ID is clearly associated with a configured channel plugin:

- **Channel validation**: when an unknown channel key is also referenced in `plugins.entries` or `plugins.allow`, emit a warning instead of a hard error
- **Plugin entries/allow/deny validation**: when an unknown plugin ID matches a channel key in `config.channels` or a channel declared by a discovered plugin, emit a warning instead of a hard error

The warning message includes guidance that the entry can be removed.

## Test Plan

- Added test case that simulates a missing bundled plugins directory (`OPENCLAW_BUNDLED_PLUGINS_DIR` pointed to an empty dir)
- Verifies `feishu` referenced in `plugins.entries`, `plugins.allow`, and `channels` produces warnings (not errors) and `res.ok === true`
- All 362 existing config tests pass with zero regressions

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Downgrades "plugin not found" and "unknown channel id" config validation errors to warnings when the referenced ID is cross-referenced in both channel and plugin configuration. This prevents startup failures when a bundled plugin's directory is temporarily missing (e.g., after migrating from an external to a stock/bundled plugin).

- `src/config/validation.ts`: Channel validation now emits a warning (instead of an error) when an unknown channel key is also referenced in `plugins.entries` or `plugins.allow`. Plugin `entries`/`allow`/`deny` validation similarly downgrades to a warning when the unknown plugin ID matches a configured channel key or a channel declared by a discovered plugin. A new `isKnownChannelPlugin` helper centralizes this check.
- `src/config/config.plugin-validation.test.ts`: Adds a test simulating a missing bundled plugins directory (`OPENCLAW_BUNDLED_PLUGINS_DIR` pointed to an empty dir), verifying that `feishu` referenced across `plugins.entries`, `plugins.allow`, and `channels` produces warnings (not errors) and `res.ok === true`.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk — it only relaxes validation from hard errors to warnings for a specific, well-scoped scenario.
- The changes are well-structured and narrowly scoped. The validation downgrade only applies when there is a clear cross-reference between channel config and plugin config, making accidental bypasses unlikely. Existing tests pass and a new test covers the target scenario. One minor test hygiene suggestion was noted (clearing the registry cache in the finally block) but it does not affect correctness.
- No files require special attention.

<sub>Last reviewed commit: c2b384a</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->