### PR TITLE
Fix #18937: Don't leak API errors to user channel

### DIFF
--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -413,6 +413,11 @@ export function formatRawAssistantErrorForUi(raw?: string): string {
 
   const httpMatch = trimmed.match(HTTP_STATUS_PREFIX_RE);
   if (httpMatch) {
+    const code = Number(httpMatch[1]);
+    // Don't leak auth-related HTTP error bodies (401/403) to the user.
+    if (code === 401 || code === 403) {
+      return "Authentication error — please check your API credentials.";
+    }
     const rest = httpMatch[2].trim();
     if (!rest.startsWith("{")) {
       return `HTTP ${httpMatch[1]}: ${rest}`;
@@ -500,6 +505,10 @@ export function formatAssistantErrorText(
 
   if (isBillingErrorMessage(raw)) {
     return formatBillingErrorMessage(opts?.provider);
+  }
+
+  if (isAuthErrorMessage(raw)) {
+    return "Authentication error — please check your API credentials.";
   }
 
   if (isLikelyHttpErrorText(raw) || isRawApiErrorPayload(raw)) {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -536,6 +536,16 @@ export async function runAgentTurnWithFallback(params: {
       }
 
       defaultRuntime.error(`Embedded agent failed before reply: ${message}`);
+
+      // For heartbeat runs, silently swallow errors instead of leaking API
+      // error details (e.g. "401 User not found") to the user channel.
+      if (params.isHeartbeat) {
+        return {
+          kind: "final",
+          payload: { text: "" },
+        };
+      }
+
       const safeMessage = isTransientHttp
         ? sanitizeUserFacingText(message, { errorContext: true })
         : message;


### PR DESCRIPTION
## Problem
API error messages (e.g. `401 User not found`) were being sent directly to users' WhatsApp/Telegram channels instead of being kept internal.

## Changes
1. **Heartbeat error suppression** (`agent-runner-execution.ts`): When a heartbeat run fails, return an empty payload instead of forwarding the error text to the user channel. Errors are still logged via `defaultRuntime.error()`.

2. **Auth error sanitization** (`errors.ts`): 
   - `formatRawAssistantErrorForUi`: HTTP 401/403 errors now return a generic "Authentication error" message instead of the raw error body
   - `formatAssistantErrorText`: Added early auth error detection before the generic fallback

Fixes #18937

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prevents API error messages from leaking to user channels by sanitizing authentication errors and suppressing heartbeat failures.

**Changes:**
- `formatRawAssistantErrorForUi` now returns a generic "Authentication error" message for HTTP 401/403 errors instead of exposing raw error bodies like "401 User not found"
- `formatAssistantErrorText` adds early auth error detection before the generic fallback
- Heartbeat runs that fail now return empty payload instead of forwarding error text to user channel (errors still logged via `defaultRuntime.error()`)

The implementation correctly addresses the security issue by catching auth errors in multiple places and preventing sensitive API error details from reaching end users.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified issues
- The changes are focused security improvements that prevent API error leakage. The implementation leverages existing error detection patterns (`isAuthErrorMessage` already includes 401/403 patterns), adds appropriate sanitization in two key locations, and maintains backward compatibility by only affecting error display logic without changing error handling behavior. Errors are still logged internally for debugging.
- No files require special attention

<sub>Last reviewed commit: 3774c38</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->