### PR TITLE
Onboarding: preserve Discord allowFrom direct ids

### DIFF
--- a/src/agents/pi-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/pi-tools.before-tool-call.e2e.test.ts
@@ -176,8 +176,15 @@ describe("before_tool_call hook deduplication (#15502)", () => {
     });
     const withAbort = wrapToolWithAbortSignal(wrapped, abortController.signal);
     const [def] = toToolDefinitions([withAbort]);
+    const extensionContext = {} as Parameters<typeof def.execute>[4];
 
-    await def.execute("call-abort-dedup", { command: "ls" }, undefined, undefined, undefined);
+    await def.execute(
+      "call-abort-dedup",
+      { command: "ls" },
+      undefined,
+      undefined,
+      extensionContext,
+    );
 
     expect(hookRunner.runBeforeToolCall).toHaveBeenCalledTimes(1);
   });

--- a/src/agents/pi-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/pi-tools.before-tool-call.e2e.test.ts
@@ -218,7 +218,14 @@ describe("before_tool_call hook integration for client tools", () => {
       { agentId: "main", sessionKey: "main" },
     );
     const extensionContext = {} as Parameters<typeof tool.execute>[4];
-    await tool.execute("client-call-1", { value: "ok" }, undefined, undefined, extensionContext);
+    const beforeToolUpdate = undefined as unknown as Parameters<typeof tool.execute>[3];
+    await tool.execute(
+      "client-call-1",
+      { value: "ok" },
+      undefined,
+      beforeToolUpdate,
+      extensionContext,
+    );
 
     expect(onClientToolCall).toHaveBeenCalledWith("client_tool", {
       value: "ok",

--- a/src/channels/plugins/onboarding/discord.test.ts
+++ b/src/channels/plugins/onboarding/discord.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveDiscordAllowFromEntries } from "./discord.js";
+
+describe("resolveDiscordAllowFromEntries", () => {
+  it("keeps direct user ids when token is present and no username lookup is needed", async () => {
+    const resolveUsers = vi.fn(async () => []);
+    const result = await resolveDiscordAllowFromEntries({
+      token: "token",
+      entries: ["994979735488692324", "<@123456789012345678>", "discord:777"],
+      resolveUsers,
+    });
+
+    expect(result.lookupFailed).toBe(false);
+    expect(result.unresolved).toEqual([]);
+    expect(result.ids).toEqual(["994979735488692324", "123456789012345678", "777"]);
+    expect(resolveUsers).not.toHaveBeenCalled();
+  });
+
+  it("resolves usernames and preserves direct ids in the same input list", async () => {
+    const resolveUsers = vi.fn(async () => [
+      {
+        input: "@alice",
+        resolved: true,
+        id: "111111111111111111",
+      },
+    ]);
+    const result = await resolveDiscordAllowFromEntries({
+      token: "token",
+      entries: ["@alice", "222222222222222222"],
+      resolveUsers,
+    });
+
+    expect(result.lookupFailed).toBe(false);
+    expect(result.unresolved).toEqual([]);
+    expect(result.ids).toEqual(["222222222222222222", "111111111111111111"]);
+    expect(resolveUsers).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports unresolved usernames when token is missing", async () => {
+    const resolveUsers = vi.fn(async () => []);
+    const result = await resolveDiscordAllowFromEntries({
+      entries: ["@alice", "333333333333333333"],
+      resolveUsers,
+    });
+
+    expect(result.lookupFailed).toBe(false);
+    expect(result.unresolved).toEqual(["@alice"]);
+    expect(result.ids).toEqual(["333333333333333333"]);
+    expect(resolveUsers).not.toHaveBeenCalled();
+  });
+});

--- a/src/channels/plugins/onboarding/discord.ts
+++ b/src/channels/plugins/onboarding/discord.ts
@@ -1,6 +1,8 @@
 import type { OpenClawConfig } from "../../../config/config.js";
 import type { DiscordGuildEntry } from "../../../config/types.discord.js";
 import type { DmPolicy } from "../../../config/types.js";
+import type { WizardPrompter } from "../../../wizard/prompts.js";
+import type { ChannelOnboardingAdapter, ChannelOnboardingDmPolicy } from "../onboarding-types.js";
 import {
   listDiscordAccountIds,
   resolveDefaultDiscordAccountId,
@@ -14,8 +16,6 @@ import {
 import { resolveDiscordUserAllowlist } from "../../../discord/resolve-users.js";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../../../routing/session-key.js";
 import { formatDocsLink } from "../../../terminal/links.js";
-import type { WizardPrompter } from "../../../wizard/prompts.js";
-import type { ChannelOnboardingAdapter, ChannelOnboardingDmPolicy } from "../onboarding-types.js";
 import { promptChannelAccessConfig } from "./channel-access.js";
 import { addWildcardAllowFrom, mergeAllowFromEntries, promptAccountId } from "./helpers.js";
 
@@ -207,7 +207,9 @@ export async function resolveDiscordAllowFromEntries(params: {
       token: params.token,
       entries: usernames,
     });
-    const resolvedIds = results.filter((res) => res.resolved && res.id).map((res) => res.id as string);
+    const resolvedIds = results
+      .filter((res) => res.resolved && res.id)
+      .map((res) => res.id as string);
     const unresolved = results.filter((res) => !res.resolved || !res.id).map((res) => res.input);
     return {
       ids: [...directIds, ...resolvedIds],

--- a/src/channels/plugins/onboarding/discord.ts
+++ b/src/channels/plugins/onboarding/discord.ts
@@ -45,10 +45,10 @@ function setDiscordDmPolicy(cfg: OpenClawConfig, dmPolicy: DmPolicy) {
 async function noteDiscordTokenHelp(prompter: WizardPrompter): Promise<void> {
   await prompter.note(
     [
-      "1) Discord Developer Portal -> Applications -> New Application",
-      "2) Bot -> Add Bot -> Reset Token -> copy token",
-      "3) OAuth2 -> URL Generator -> scope 'bot' -> invite to your server",
-      "Tip: enable Message Content Intent if you need message text. (Bot -> Privileged Gateway Intents -> Message Content Intent)",
+      "1) Discord Developer Portal → Applications → New Application",
+      "2) Bot → Add Bot → Reset Token → copy token",
+      "3) OAuth2 → URL Generator → scope 'bot' → invite to your server",
+      "Tip: enable Message Content Intent if you need message text. (Bot → Privileged Gateway Intents → Message Content Intent)",
       `Docs: ${formatDocsLink("/discord", "discord")}`,
     ].join("\n"),
     "Discord bot token",

--- a/src/channels/plugins/onboarding/discord.ts
+++ b/src/channels/plugins/onboarding/discord.ts
@@ -45,10 +45,10 @@ function setDiscordDmPolicy(cfg: OpenClawConfig, dmPolicy: DmPolicy) {
 async function noteDiscordTokenHelp(prompter: WizardPrompter): Promise<void> {
   await prompter.note(
     [
-      "1) Discord Developer Portal → Applications → New Application",
-      "2) Bot → Add Bot → Reset Token → copy token",
-      "3) OAuth2 → URL Generator → scope 'bot' → invite to your server",
-      "Tip: enable Message Content Intent if you need message text. (Bot → Privileged Gateway Intents → Message Content Intent)",
+      "1) Discord Developer Portal -> Applications -> New Application",
+      "2) Bot -> Add Bot -> Reset Token -> copy token",
+      "3) OAuth2 -> URL Generator -> scope 'bot' -> invite to your server",
+      "Tip: enable Message Content Intent if you need message text. (Bot -> Privileged Gateway Intents -> Message Content Intent)",
       `Docs: ${formatDocsLink("/discord", "discord")}`,
     ].join("\n"),
     "Discord bot token",

--- a/src/channels/plugins/onboarding/discord.ts
+++ b/src/channels/plugins/onboarding/discord.ts
@@ -1,8 +1,6 @@
 import type { OpenClawConfig } from "../../../config/config.js";
 import type { DiscordGuildEntry } from "../../../config/types.discord.js";
 import type { DmPolicy } from "../../../config/types.js";
-import type { WizardPrompter } from "../../../wizard/prompts.js";
-import type { ChannelOnboardingAdapter, ChannelOnboardingDmPolicy } from "../onboarding-types.js";
 import {
   listDiscordAccountIds,
   resolveDefaultDiscordAccountId,
@@ -16,6 +14,8 @@ import {
 import { resolveDiscordUserAllowlist } from "../../../discord/resolve-users.js";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../../../routing/session-key.js";
 import { formatDocsLink } from "../../../terminal/links.js";
+import type { WizardPrompter } from "../../../wizard/prompts.js";
+import type { ChannelOnboardingAdapter, ChannelOnboardingDmPolicy } from "../onboarding-types.js";
 import { promptChannelAccessConfig } from "./channel-access.js";
 import { addWildcardAllowFrom, mergeAllowFromEntries, promptAccountId } from "./helpers.js";
 


### PR DESCRIPTION
## Summary
Fix Discord onboarding allowFrom parsing so direct user IDs are preserved even when username resolution fails.

Closes #18955

## What changed
- Add 
esolveDiscordAllowFromEntries to:
  - accept direct IDs (123..., <@...>, discord:..., user:...) immediately
  - resolve only username-like entries via API
  - preserve direct IDs when token is missing or lookup fails
- Update promptDiscordAllowFrom to use the helper and keep existing UX/error prompts
- Add tests covering:
  - direct IDs bypass resolver
  - mixed usernames + IDs
  - missing token behavior

## Validation
- itest src/channels/plugins/onboarding/discord.test.ts (3 passed)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extracts the Discord allowFrom ID-parsing logic into a standalone `resolveDiscordAllowFromEntries` helper that separates direct user IDs (numeric, `<@...>`, `discord:...`, `user:...`) from username-like entries before attempting API resolution. Direct IDs are preserved immediately, and only usernames are sent through the resolver — so direct IDs survive even when the bot token is missing or the API lookup fails. The `promptDiscordAllowFrom` wizard is simplified to use this helper while keeping the same UX error prompts. Tests cover direct-ID-only, mixed username+ID, and missing-token scenarios.

- Extracted `parseDiscordUserId` from `promptDiscordAllowFrom` to module scope for reuse by the new helper
- New exported `resolveDiscordAllowFromEntries` cleanly separates concerns: ID parsing vs. API resolution
- `promptDiscordAllowFrom` now delegates to the helper, reducing inline branching

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a clean refactor with correct logic and good test coverage.
- The changes extract existing inline ID-parsing logic into a well-tested helper function. The refactored `promptDiscordAllowFrom` preserves all existing UX behavior (retry prompts, error messages). Edge cases (no token, API failure, mixed IDs/usernames) are correctly handled and tested. No new security concerns, no breaking changes to public interfaces beyond the new export.
- No files require special attention.

<sub>Last reviewed commit: e4846ce</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->