### PR TITLE
fix(security): block prototype-polluting keys in deepMerge

### DIFF
--- a/src/config/includes.ts
+++ b/src/config/includes.ts
@@ -10,9 +10,9 @@
  * ```
  */
 
+import JSON5 from "json5";
 import fs from "node:fs";
 import path from "node:path";
-import JSON5 from "json5";
 import { isPlainObject } from "../utils.js";
 
 export const INCLUDE_KEY = "$include";
@@ -53,6 +53,8 @@ export class CircularIncludeError extends ConfigIncludeError {
 // Utilities
 // ============================================================================
 
+const BLOCKED_MERGE_KEYS = new Set(["__proto__", "prototype", "constructor"]);
+
 /** Deep merge: arrays concatenate, objects merge recursively, primitives: source wins */
 export function deepMerge(target: unknown, source: unknown): unknown {
   if (Array.isArray(target) && Array.isArray(source)) {
@@ -61,6 +63,9 @@ export function deepMerge(target: unknown, source: unknown): unknown {
   if (isPlainObject(target) && isPlainObject(source)) {
     const result: Record<string, unknown> = { ...target };
     for (const key of Object.keys(source)) {
+      if (BLOCKED_MERGE_KEYS.has(key)) {
+        continue;
+      }
       result[key] = key in result ? deepMerge(result[key], source[key]) : source[key];
     }
     return result;


### PR DESCRIPTION
## Summary
The `deepMerge` utility in `src/config/includes.ts` did not guard against prototype-polluting keys (`__proto__`, `prototype`, `constructor`). An attacker who controls a merged config object could inject properties onto `Object.prototype`, affecting all downstream code. This fix adds a blocklist that silently skips those keys during merge.

## Test plan
- [x] Verify typecheck passes (`pnpm tsgo`)
- [ ] Verify build succeeds
- [ ] Confirm `deepMerge({}, JSON.parse('{"__proto__":{"polluted":true}}'))` does not pollute `Object.prototype`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds prototype pollution protection to the `deepMerge` utility by blocking dangerous keys (`__proto__`, `prototype`, `constructor`) during object merging. This prevents attackers who control merged config objects from injecting properties onto `Object.prototype` that would affect all downstream code. The fix silently skips these keys during the merge operation, which is the appropriate defensive behavior for a configuration system.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - it's a targeted security fix with no breaking changes
- The fix correctly addresses a prototype pollution vulnerability with minimal code changes. The blocklist approach is standard, the implementation is correct, and the silent skip behavior is appropriate for config merging. Import reordering is a non-functional style change.
- No files require special attention

<sub>Last reviewed commit: 16c2ce3</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->