### PR TITLE
fix(security): eliminate timing side-channel length leak in safeEqualSecret

### DIFF
--- a/src/security/secret-equal.ts
+++ b/src/security/secret-equal.ts
@@ -1,4 +1,4 @@
-import { timingSafeEqual } from "node:crypto";
+import { createHash, timingSafeEqual } from "node:crypto";
 
 export function safeEqualSecret(
   provided: string | undefined | null,
@@ -7,10 +7,6 @@ export function safeEqualSecret(
   if (typeof provided !== "string" || typeof expected !== "string") {
     return false;
   }
-  const providedBuffer = Buffer.from(provided);
-  const expectedBuffer = Buffer.from(expected);
-  if (providedBuffer.length !== expectedBuffer.length) {
-    return false;
-  }
-  return timingSafeEqual(providedBuffer, expectedBuffer);
+  const hash = (s: string) => createHash("sha256").update(s).digest();
+  return timingSafeEqual(hash(provided), hash(expected));
 }


### PR DESCRIPTION
## Summary
`safeEqualSecret` previously returned early when the two input buffers had different lengths, leaking the expected secret's length via a timing side-channel. This fix hashes both inputs with SHA-256 before calling `timingSafeEqual`, ensuring fixed-length (32-byte) buffers and constant-time comparison regardless of input lengths.

## Test plan
- [x] Verify typecheck passes (`pnpm tsgo`)
- [ ] Verify build succeeds
- [ ] Confirm equal strings still return `true` and unequal strings return `false`
- [ ] Confirm different-length inputs no longer short-circuit (both paths take equal time)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a timing side-channel vulnerability in `safeEqualSecret` where the previous implementation returned early when input buffers had different lengths, leaking the expected secret's length to an attacker. The fix hashes both inputs with SHA-256 before passing them to `timingSafeEqual`, ensuring constant-time comparison with fixed 32-byte buffers regardless of input length.

- Replaced `Buffer.from()` + length check + `timingSafeEqual` with `createHash("sha256").update(s).digest()` + `timingSafeEqual`
- The function is used across authentication paths (`auth.ts`, `server-http.ts`, `http-auth.ts`, `pairing-token.ts`), so this fix hardens all secret comparisons in the application
- Existing tests for equal, unequal, different-length, and null/undefined inputs remain valid with the new implementation
- Note: `extensions/bluebubbles/src/monitor.ts` contains a separate local `safeEqualSecret` with the same length-leak pattern that is not addressed in this PR

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a focused, correct security fix with no functional regressions.
- The change is minimal (net -4 lines), uses well-established cryptographic patterns (HMAC-compare via SHA-256 + timingSafeEqual), and the existing test suite covers all relevant cases. No new dependencies are introduced. The implementation is correct: `digest()` returns a Buffer, SHA-256 output is always 32 bytes, and `timingSafeEqual` gets equal-length inputs.
- No files require special attention. The single changed file is clean and correct.

<sub>Last reviewed commit: 7e52ff6</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->