### PR TITLE
fix(security): use YAML core schema to prevent type coercion in frontmatter

### DIFF
--- a/src/markdown/frontmatter.ts
+++ b/src/markdown/frontmatter.ts
@@ -34,7 +34,7 @@ function coerceFrontmatterValue(value: unknown): string | undefined {
 
 function parseYamlFrontmatter(block: string): ParsedFrontmatter | null {
   try {
-    const parsed = YAML.parse(block) as unknown;
+    const parsed = YAML.parse(block, { schema: "core" }) as unknown;
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
       return null;
     }


### PR DESCRIPTION
## Summary
The YAML frontmatter parser used the default YAML 1.1 schema, which silently coerces values like `on`/`off`/`yes`/`no` to booleans and certain numeric strings to octal/hex. This fix explicitly sets `schema: "core"` (YAML 1.2) so only `true`/`false`/`null` are recognized as special values, preventing unexpected type coercion in user-authored frontmatter.

## Test plan
- [x] Verify typecheck passes (`pnpm tsgo`)
- [ ] Verify build succeeds
- [ ] Confirm frontmatter with `on`/`off` values are preserved as strings, not coerced to booleans

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Single-line fix to the YAML frontmatter parser that switches from the default YAML 1.1 schema to the YAML 1.2 Core schema (`schema: "core"`). This prevents silent type coercion of values like `on`/`off`/`yes`/`no` to booleans and octal/hex numeric strings to integers. The change is safe because:

- `coerceFrontmatterValue` already handles both boolean and string types, so `true`/`false` (still recognized by Core schema) continue to work
- Downstream `parseFrontmatterBool` uses `parseBooleanValue` which accepts string values `"on"`, `"off"`, `"yes"`, `"no"` — so frontmatter fields like `enabled: on` still resolve correctly as booleans when needed
- The existing test suite covers the relevant cases (`enabled: true`, `retries: 3`, etc.)

**Notes:**
- Two items in the PR's test plan are unchecked (build verification and `on`/`off` preservation test). Adding a test case for `on`/`off` string preservation would strengthen confidence in this fix.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a single-line, well-scoped fix with no behavioral regressions.
- The change is minimal (one option added to a function call), addresses a real YAML 1.1 type coercion issue, and downstream code handles both pre- and post-change value types correctly. The `yaml` package v2.x fully supports the `"core"` schema option. Existing tests pass for the covered scenarios.
- No files require special attention.

<sub>Last reviewed commit: ca474aa</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->