### PR TITLE
fix(security): block prototype chain traversal in hook template resolution

### DIFF
--- a/src/gateway/hooks-mapping.ts
+++ b/src/gateway/hooks-mapping.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { CONFIG_PATH, type HookMappingConfig, type HooksConfig } from "../config/config.js";
 import type { HookMessageChannel } from "./hooks.js";
+import { CONFIG_PATH, type HookMappingConfig, type HooksConfig } from "../config/config.js";
 
 export type HookMappingResolved = {
   id: string;
@@ -437,6 +437,8 @@ function resolveTemplateExpr(expr: string, ctx: HookMappingContext) {
   return getByPath(ctx.payload, expr);
 }
 
+const BLOCKED_TRAVERSE_KEYS = new Set(["__proto__", "prototype", "constructor"]);
+
 function getByPath(input: Record<string, unknown>, pathExpr: string): unknown {
   if (!pathExpr) {
     return undefined;
@@ -463,6 +465,9 @@ function getByPath(input: Record<string, unknown>, pathExpr: string): unknown {
       }
       current = current[part] as unknown;
       continue;
+    }
+    if (BLOCKED_TRAVERSE_KEYS.has(part)) {
+      return undefined;
     }
     if (typeof current !== "object") {
       return undefined;


### PR DESCRIPTION
## Summary
The `getByPath` function used for resolving template variables in webhook hook mappings did not guard against prototype-polluting path segments (`__proto__`, `prototype`, `constructor`). A crafted webhook payload could use these segments to traverse the prototype chain and access unintended properties. This fix adds a blocklist that returns `undefined` for those keys.

## Test plan
- [x] Verify typecheck passes (`pnpm tsgo`)
- [ ] Verify build succeeds
- [ ] Confirm template expressions with `__proto__` or `constructor` path segments resolve to `undefined`
- [ ] Confirm legitimate nested payload access still works (e.g., `payload.data.name`)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Blocks prototype pollution vulnerability in webhook template variable resolution by preventing traversal through `__proto__`, `prototype`, and `constructor` keys.

- Added `BLOCKED_TRAVERSE_KEYS` Set containing dangerous prototype chain property names
- Modified `getByPath` function to return `undefined` when encountering blocked keys, preventing malicious payloads from accessing prototype chain properties
- Protection applies to all template contexts: `payload`, `headers`, and `query` parameters
- Import order standardized (type imports grouped together)

<h3>Confidence Score: 4/5</h3>

- Safe to merge - addresses critical security vulnerability with a focused, well-placed fix
- The fix correctly blocks prototype pollution by preventing access to dangerous keys at the right point in the path traversal logic. The blocklist is comprehensive for JavaScript prototype chain exploitation. Minor deduction for missing test coverage that was mentioned in the PR test plan
- No files require special attention - the security fix is localized and correctly implemented

<sub>Last reviewed commit: b31b3c0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->