### PR TITLE
fix(discord): onboard allowlist rejects numeric user IDs when guild lookup fails

### DIFF
--- a/src/discord/resolve-users.test.ts
+++ b/src/discord/resolve-users.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import { resolveDiscordUserAllowlist } from "./resolve-users.js";
+
+const unauthorizedFetcher = async () =>
+  new Response(JSON.stringify({ message: "401: Unauthorized" }), { status: 401 });
+
+const emptyGuildsFetcher = async (url: string) => {
+  if (url.includes("/users/@me/guilds")) {
+    return new Response(JSON.stringify([]), { status: 200 });
+  }
+  return new Response(JSON.stringify([]), { status: 200 });
+};
+
+const workingFetcher = async (url: string) => {
+  if (url.includes("/users/@me/guilds")) {
+    return new Response(JSON.stringify([{ id: "111", name: "TestGuild" }]), { status: 200 });
+  }
+  if (url.includes("/members/search")) {
+    return new Response(
+      JSON.stringify([
+        {
+          user: { id: "994979735488692324", username: "tonic_1", global_name: "Tonic" },
+          nick: null,
+        },
+      ]),
+      { status: 200 },
+    );
+  }
+  return new Response(JSON.stringify([]), { status: 200 });
+};
+
+describe("resolveDiscordUserAllowlist", () => {
+  it("resolves numeric user IDs without any API call", async () => {
+    const results = await resolveDiscordUserAllowlist({
+      token: "invalid-token",
+      entries: ["994979735488692324"],
+      fetcher: unauthorizedFetcher as unknown as typeof fetch,
+    });
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      input: "994979735488692324",
+      resolved: true,
+      id: "994979735488692324",
+    });
+  });
+
+  it("resolves mention-format IDs without any API call", async () => {
+    const results = await resolveDiscordUserAllowlist({
+      token: "invalid-token",
+      entries: ["<@994979735488692324>"],
+      fetcher: unauthorizedFetcher as unknown as typeof fetch,
+    });
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      resolved: true,
+      id: "994979735488692324",
+    });
+  });
+
+  it("returns unresolved with note when guild lookup fails for usernames", async () => {
+    const results = await resolveDiscordUserAllowlist({
+      token: "bad-token",
+      entries: ["tonic_1"],
+      fetcher: unauthorizedFetcher as unknown as typeof fetch,
+    });
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      input: "tonic_1",
+      resolved: false,
+      note: "guild lookup failed",
+    });
+  });
+
+  it("preserves resolved numeric IDs even when username lookup fails", async () => {
+    const results = await resolveDiscordUserAllowlist({
+      token: "bad-token",
+      entries: ["994979735488692324", "tonic_1"],
+      fetcher: unauthorizedFetcher as unknown as typeof fetch,
+    });
+    expect(results).toHaveLength(2);
+    expect(results[0]).toMatchObject({
+      input: "994979735488692324",
+      resolved: true,
+      id: "994979735488692324",
+    });
+    expect(results[1]).toMatchObject({
+      input: "tonic_1",
+      resolved: false,
+    });
+  });
+
+  it("returns unresolved for username when bot has no guilds", async () => {
+    const results = await resolveDiscordUserAllowlist({
+      token: "valid-token",
+      entries: ["tonic_1"],
+      fetcher: emptyGuildsFetcher as unknown as typeof fetch,
+    });
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      input: "tonic_1",
+      resolved: false,
+    });
+  });
+
+  it("resolves username via guild member search", async () => {
+    const results = await resolveDiscordUserAllowlist({
+      token: "valid-token",
+      entries: ["tonic_1"],
+      fetcher: workingFetcher as unknown as typeof fetch,
+    });
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      resolved: true,
+      id: "994979735488692324",
+      name: "Tonic",
+    });
+  });
+
+  it("returns unresolved for empty token", async () => {
+    const results = await resolveDiscordUserAllowlist({
+      token: "",
+      entries: ["tonic_1"],
+      fetcher: unauthorizedFetcher as unknown as typeof fetch,
+    });
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      input: "tonic_1",
+      resolved: false,
+    });
+  });
+});

--- a/src/discord/resolve-users.test.ts
+++ b/src/discord/resolve-users.test.ts
@@ -57,7 +57,7 @@ describe("resolveDiscordUserAllowlist", () => {
     });
   });
 
-  it("returns unresolved with note when guild lookup fails for usernames", async () => {
+  it("returns unresolved when guild lookup fails for usernames", async () => {
     const results = await resolveDiscordUserAllowlist({
       token: "bad-token",
       entries: ["tonic_1"],
@@ -67,7 +67,6 @@ describe("resolveDiscordUserAllowlist", () => {
     expect(results[0]).toMatchObject({
       input: "tonic_1",
       resolved: false,
-      note: "guild lookup failed",
     });
   });
 

--- a/src/discord/resolve-users.ts
+++ b/src/discord/resolve-users.ts
@@ -88,7 +88,7 @@ export async function resolveDiscordUserAllowlist(params: {
     }));
   }
   const fetcher = params.fetcher ?? fetch;
-  const guilds = await listGuilds(token, fetcher);
+  let guilds: DiscordGuildSummary[] | null = null;
   const results: DiscordUserResolution[] = [];
 
   for (const input of params.entries) {
@@ -106,6 +106,16 @@ export async function resolveDiscordUserAllowlist(params: {
     if (!query) {
       results.push({ input, resolved: false });
       continue;
+    }
+
+    if (guilds === null) {
+      try {
+        guilds = await listGuilds(token, fetcher);
+      } catch {
+        // API unreachable or token invalid — mark remaining username entries as unresolved
+        results.push({ input, resolved: false, note: "guild lookup failed" });
+        continue;
+      }
     }
 
     const guildName = parsed.guildName?.trim();

--- a/src/discord/resolve-users.ts
+++ b/src/discord/resolve-users.ts
@@ -112,9 +112,8 @@ export async function resolveDiscordUserAllowlist(params: {
       try {
         guilds = await listGuilds(token, fetcher);
       } catch {
-        // API unreachable or token invalid — mark remaining username entries as unresolved
-        results.push({ input, resolved: false, note: "guild lookup failed" });
-        continue;
+        // API unreachable or token invalid — set empty sentinel to skip further attempts
+        guilds = [];
       }
     }
 


### PR DESCRIPTION
## Summary

`resolveDiscordUserAllowlist()` called `listGuilds()` unconditionally before processing any entries. When the API call failed (invalid token, missing permissions, network error), the entire function threw — even for numeric user IDs that need no API call at all.

During `openclaw onboard`, this surfaced as an inescapable **"Failed to resolve usernames. Try again."** loop where users could not proceed regardless of input format.

## Changes

- **Defer `listGuilds()`** until a username entry actually requires guild member search (lazy initialization)
- **Catch guild lookup failures per-entry** so already-resolved numeric IDs are preserved in mixed-input scenarios
- Add 7 unit tests covering all combinations (bad token, no guilds, working setup, mixed inputs)

## Before / After

| Input | Before | After |
|-------|--------|-------|
| Bad token + numeric ID `994979...` | ❌ "Failed to resolve" loop | ✅ Resolves immediately, zero API calls |
| Bad token + username `tonic_1` | ❌ "Failed to resolve" loop | ✅ Returns `resolved: false` with note |
| Bad token + mixed | ❌ All entries lost | ✅ Numeric IDs preserved, usernames marked unresolved |
| Valid token + any | ✅ Works | ✅ No change |

## Test plan

- `pnpm vitest run src/discord/resolve-users.test.ts` — 7 tests pass
- `pnpm lint` — clean

Fixes #18955

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where `resolveDiscordUserAllowlist()` called `listGuilds()` eagerly, causing the entire function to throw when the API call failed — even for numeric user IDs that don't need guild lookup. The fix defers `listGuilds()` until a username entry actually requires it (lazy initialization) and catches failures per-entry so numeric IDs are preserved in mixed-input scenarios.

- **Lazy guild lookup**: `listGuilds()` is now called only when a username entry needs guild member search, avoiding unnecessary API calls for numeric-only inputs
- **Per-entry error handling**: Guild lookup failures are caught and the entry is marked `{ resolved: false, note: "guild lookup failed" }` instead of throwing for the entire batch
- **Tests**: 7 new unit tests cover numeric IDs, mention-format, bad tokens, mixed inputs, empty guilds, and working username resolution
- **Bug**: After `listGuilds()` fails, `guilds` stays `null`, so each subsequent username entry retries the API call rather than being immediately marked unresolved — see inline comment

<h3>Confidence Score: 3/5</h3>

- The fix correctly improves resilience for numeric IDs but has a bug that causes repeated failing API calls for multiple username entries with a bad token.
- The core approach (lazy guild lookup + per-entry catch) is sound and the happy paths work correctly. However, the catch block does not update guilds from null, so subsequent username entries each trigger a new failing listGuilds() call. This doesn't cause incorrect results (entries are still marked unresolved) but causes unnecessary network calls and latency. The fix is small and well-tested for the scenarios it covers, but misses the multi-username failure scenario.
- Pay close attention to `src/discord/resolve-users.ts` — the guild lookup catch block at lines 111-118 needs to prevent repeated API calls on failure.

<sub>Last reviewed commit: c131940</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->