### PR TITLE
fix(security): escape backticks in exec-approval Discord embeds

### DIFF
--- a/src/discord/monitor/exec-approvals.ts
+++ b/src/discord/monitor/exec-approvals.ts
@@ -11,19 +11,19 @@ import {
 } from "@buape/carbon";
 import { ButtonStyle, Routes } from "discord-api-types/v10";
 import type { OpenClawConfig } from "../../config/config.js";
-import { loadSessionStore, resolveStorePath } from "../../config/sessions.js";
 import type { DiscordExecApprovalConfig } from "../../config/types.discord.js";
-import { buildGatewayConnectionDetails } from "../../gateway/call.js";
-import { GatewayClient } from "../../gateway/client.js";
 import type { EventFrame } from "../../gateway/protocol/index.js";
 import type {
   ExecApprovalDecision,
   ExecApprovalRequest,
   ExecApprovalResolved,
 } from "../../infra/exec-approvals.js";
+import type { RuntimeEnv } from "../../runtime.js";
+import { loadSessionStore, resolveStorePath } from "../../config/sessions.js";
+import { buildGatewayConnectionDetails } from "../../gateway/call.js";
+import { GatewayClient } from "../../gateway/client.js";
 import { logDebug, logError } from "../../logger.js";
 import { normalizeAccountId, resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
-import type { RuntimeEnv } from "../../runtime.js";
 import {
   GATEWAY_CLIENT_MODES,
   GATEWAY_CLIENT_NAMES,
@@ -230,8 +230,8 @@ function createExecApprovalRequestContainer(params: {
   actionRow?: Row<Button>;
 }): ExecApprovalContainer {
   const commandText = params.request.request.command;
-  const commandPreview =
-    commandText.length > 1000 ? `${commandText.slice(0, 1000)}...` : commandText;
+  const commandRaw = commandText.length > 1000 ? `${commandText.slice(0, 1000)}...` : commandText;
+  const commandPreview = commandRaw.replace(/`/g, "\u200b`");
   const expiresAtSeconds = Math.max(0, Math.floor(params.request.expiresAtMs / 1000));
 
   return new ExecApprovalContainer({
@@ -255,7 +255,8 @@ function createResolvedContainer(params: {
   accountId: string;
 }): ExecApprovalContainer {
   const commandText = params.request.request.command;
-  const commandPreview = commandText.length > 500 ? `${commandText.slice(0, 500)}...` : commandText;
+  const commandRaw = commandText.length > 500 ? `${commandText.slice(0, 500)}...` : commandText;
+  const commandPreview = commandRaw.replace(/`/g, "\u200b`");
 
   const decisionLabel =
     params.decision === "allow-once"
@@ -288,7 +289,8 @@ function createExpiredContainer(params: {
   accountId: string;
 }): ExecApprovalContainer {
   const commandText = params.request.request.command;
-  const commandPreview = commandText.length > 500 ? `${commandText.slice(0, 500)}...` : commandText;
+  const commandRaw = commandText.length > 500 ? `${commandText.slice(0, 500)}...` : commandText;
+  const commandPreview = commandRaw.replace(/`/g, "\u200b`");
 
   return new ExecApprovalContainer({
     cfg: params.cfg,


### PR DESCRIPTION
## Summary
Command text displayed in Discord exec-approval embeds was not sanitized, allowing crafted commands containing backticks to break out of the markdown code block and inject arbitrary Discord formatting. This fix inserts a zero-width space (`\u200b`) before each backtick to neutralize the markdown injection vector. Applied to all three embed constructors (request, resolved, expired).

## Test plan
- [x] Verify typecheck passes (`pnpm tsgo`)
- [ ] Verify build succeeds
- [ ] Confirm commands containing backticks render safely inside the code block in Discord
- [ ] Confirm normal commands without backticks are unaffected

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a Discord markdown injection vulnerability in exec-approval embeds by inserting a zero-width space (`\u200b`) before each backtick in command text. The fix is applied consistently across all three embed constructors (`createExecApprovalRequestContainer`, `createResolvedContainer`, `createExpiredContainer`) that display command previews inside markdown code blocks. The changes also include minor import reordering.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a targeted security patch that addresses a specific markdown injection vector. The implementation is consistent across all three affected functions, uses the same zero-width space technique already present elsewhere in the codebase, and is simple enough to verify correctness by inspection.
- No files require special attention

<sub>Last reviewed commit: 5bb9922</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->