### PR TITLE
fix(plugins): discover bundled plugins from symlink overlays

### DIFF
--- a/src/plugins/discovery.test.ts
+++ b/src/plugins/discovery.test.ts
@@ -130,7 +130,10 @@ describe("discoverOpenClawPlugins", () => {
     const targetDir = makeTempDir();
     fs.mkdirSync(globalExt, { recursive: true });
     fs.writeFileSync(path.join(targetDir, "actual.ts"), "export default function () {}", "utf-8");
-    const created = symlinkFile(path.join(targetDir, "actual.ts"), path.join(globalExt, "gamma.ts"));
+    const created = symlinkFile(
+      path.join(targetDir, "actual.ts"),
+      path.join(globalExt, "gamma.ts"),
+    );
     if (!created) {
       return;
     }
@@ -147,7 +150,10 @@ describe("discoverOpenClawPlugins", () => {
     const stateDir = makeTempDir();
     const globalExt = path.join(stateDir, "extensions");
     fs.mkdirSync(globalExt, { recursive: true });
-    const created = symlinkFile(path.join(globalExt, "missing.ts"), path.join(globalExt, "broken.ts"));
+    const created = symlinkFile(
+      path.join(globalExt, "missing.ts"),
+      path.join(globalExt, "broken.ts"),
+    );
     if (!created) {
       return;
     }

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -324,13 +324,13 @@ function resolveDirentKind(entry: fs.Dirent, fullPath: string): {
   let isFile = entry.isFile();
   let isDirectory = entry.isDirectory();
 
-  if (!isFile && !isDirectory && entry.isSymbolicLink()) {
+  if (!isFile && !isDirectory) {
     try {
       const stats = fs.statSync(fullPath);
       isFile = stats.isFile();
       isDirectory = stats.isDirectory();
     } catch {
-      // Broken symlink or inaccessible target; keep defaults.
+      // Broken symlink, inaccessible target, or unknown dirent type.
     }
   }
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: In LaunchAgent setups where `OPENCLAW_BUNDLED_PLUGINS_DIR` points to a symlink overlay (for example `/tmp/openclaw-bundled-overlay`), `discoverInDirectory()` relied on `Dirent.isDirectory()` / `isFile()` only. Symlinked plugin directories were skipped, causing bundled plugins (such as `discord` and `memory-core`) to be reported as `plugin not found` (see #18488).
- Why it matters: Gateway can fail config validation and exit at startup in service-managed dev/worktree environments.
- What changed:
  - Added `resolveDirentKind()` in `src/plugins/discovery.ts`: when a `Dirent` type is not directly known, it falls back to `fs.statSync()` to resolve the target type (covers symlinked directories, symlinked files, and unknown dirent types).
  - Added regression tests in `src/plugins/discovery.test.ts` for:
    1) bundled plugins discovered from symlinked directories;
    2) symlinked file plugins discovered;
    3) broken symlinks safely ignored;
    4) graceful test fallback on Windows when file-symlink creation is restricted.
- What did NOT change (scope boundary):
  - No changes to plugin precedence, config schema, plugin package format, or channel behavior.
  - No new env/config switches.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #18488
- Related #

## User-visible / Behavior Changes

- In deployments where `OPENCLAW_BUNDLED_PLUGINS_DIR` points to a symlink overlay, bundled plugins are now discovered correctly and Gateway no longer fails startup with `plugin not found` for this case.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (Darwin arm64)
- Runtime/container: Node.js + LaunchAgent
- Model/provider: N/A
- Integration/channel (if any): bundled plugin discovery (`discord` / `memory-core`)
- Relevant config (redacted): `OPENCLAW_BUNDLED_PLUGINS_DIR=/tmp/openclaw-bundled-overlay`

### Steps

1. Prepare a symlink overlay directory (each plugin entry is a symlink to real `extensions/<plugin>`).
2. Start Gateway via LaunchAgent with the overlay path in `OPENCLAW_BUNDLED_PLUGINS_DIR`.
3. Observe plugin discovery and Gateway startup state.

### Expected

- Bundled plugins are discovered from the symlink overlay and Gateway starts normally.

### Actual

- Before fix: startup failed with `plugins.entries.discord: plugin not found: discord` and `plugins.slots.memory: plugin not found: memory-core`.
- After fix: `discord` / `memory-core` are discovered and LaunchAgent process remains `running`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Compared `origin/main...HEAD`; PR contains only two changed files (`src/plugins/discovery.ts`, `src/plugins/discovery.test.ts`).
  - Ran `pnpm -s vitest run src/plugins/discovery.test.ts` -> 7/7 passing.
  - Reproduced LaunchAgent + symlink overlay scenario locally; Gateway started and stayed running.
- Edge cases checked:
  - symlink to directory;
  - symlink to file plugin;
  - broken symlink ignored;
  - Windows restricted file-symlink test fallback.
- What you did **not** verify:
  - No end-to-end `systemd` validation on Linux in this PR.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR's two commits (`src/plugins/discovery.ts` + `src/plugins/discovery.test.ts`).
- Files/config to restore:
  - `src/plugins/discovery.ts`
  - `src/plugins/discovery.test.ts`
- Known bad symptoms reviewers should watch for:
  - unexpected plugin discovery drops or spikes;
  - `plugin not found` still reproducible in symlink overlay setups.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Minor extra I/O from `statSync` when dirent type is unknown.
  - Mitigation: fallback only runs when both `isFile` and `isDirectory` are false; normal paths are unchanged.
