### PR TITLE
feat(config): add support for config warnings and improve validation 

### DIFF
--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -1,10 +1,11 @@
+import type { HeartbeatEventPayload } from "../infra/heartbeat-events.js";
+import type { RuntimeEnv } from "../runtime.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { withProgress } from "../cli/progress.js";
 import { resolveGatewayPort } from "../config/config.js";
 import { buildGatewayConnectionDetails, callGateway } from "../gateway/call.js";
 import { info } from "../globals.js";
 import { formatTimeAgo } from "../infra/format-time/format-relative.ts";
-import type { HeartbeatEventPayload } from "../infra/heartbeat-events.js";
 import { formatUsageReportLines, loadProviderUsageSummary } from "../infra/provider-usage.js";
 import { normalizeUpdateChannel, resolveUpdateChannelDisplay } from "../infra/update-channels.js";
 import { formatGitInstallLabel } from "../infra/update-check.js";
@@ -14,7 +15,6 @@ import {
   resolveMemoryVectorState,
   type Tone,
 } from "../memory/status-format.js";
-import type { RuntimeEnv } from "../runtime.js";
 import { runSecurityAudit } from "../security/audit.js";
 import { renderTable } from "../terminal/table.js";
 import { theme } from "../terminal/theme.js";
@@ -59,6 +59,7 @@ export async function statusCommand(
   );
   const {
     cfg,
+    configWarnings,
     osSummary,
     tailscaleMode,
     tailscaleDns,
@@ -355,6 +356,18 @@ export async function statusCommand(
   const overviewRows = [
     { Item: "Dashboard", Value: dashboard },
     { Item: "OS", Value: `${osSummary.label} · node ${process.versions.node}` },
+    ...(configWarnings.length > 0
+      ? [
+          {
+            Item: "Model providers",
+            Value: warn(
+              configWarnings
+                .map((w) => `${w.path.replace(/^models\.providers\./, "")}: ${w.message}`)
+                .join("; "),
+            ),
+          },
+        ]
+      : []),
     {
       Item: "Tailscale",
       Value:

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -13,6 +13,17 @@ export const ModelApiSchema = z.union([
   z.literal("ollama"),
 ]);
 
+/** Supported model API types; useful for error messages when validation fails. */
+export const MODEL_API_VALUES: readonly string[] = [
+  "openai-completions",
+  "openai-responses",
+  "anthropic-messages",
+  "google-generative-ai",
+  "github-copilot",
+  "bedrock-converse-stream",
+  "ollama",
+];
+
 export const ModelCompatSchema = z
   .object({
     supportsStore: z.boolean().optional(),

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -13,16 +13,10 @@ export const ModelApiSchema = z.union([
   z.literal("ollama"),
 ]);
 
-/** Supported model API types; useful for error messages when validation fails. */
-export const MODEL_API_VALUES: readonly string[] = [
-  "openai-completions",
-  "openai-responses",
-  "anthropic-messages",
-  "google-generative-ai",
-  "github-copilot",
-  "bedrock-converse-stream",
-  "ollama",
-];
+/** Supported model API types; derived from ModelApiSchema so error messages stay in sync. */
+export const MODEL_API_VALUES: readonly string[] = (
+  ModelApiSchema as { options: Array<{ value: string }> }
+).options.map((opt) => opt.value);
 
 export const ModelCompatSchema = z
   .object({


### PR DESCRIPTION
Fixes #18968 — Graceful handling of invalid models.providers.<key>.api
When openclaw.json had an invalid value for models.providers.<provider>.api (e.g. "google-genai" instead of "google-generative-ai"), the Gateway exited on Zod validation and went into a crash loop.
Validation: If the only validation errors are under models.providers.<key>, we now strip those providers and re-validate instead of failing the whole config. The snapshot is valid, so the Gateway starts and other providers keep working.
Warnings: Disabled providers are recorded as config warnings (path + message, with supported API types when the error is about .api).
Status: openclaw status shows a “Model providers” row when any provider was disabled due to invalid config.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds graceful handling for invalid model provider configurations by stripping problematic providers and displaying warnings rather than crashing the Gateway.

- Introduced `tryValidateConfigRawWithLenientModelProviders` that validates configs and strips invalid providers if they're the only validation errors
- Config warnings are now surfaced in `openclaw status` command under "Model providers" when providers are disabled
- Updated `MODEL_API_VALUES` to derive from `ModelApiSchema` as previously suggested, ensuring error messages stay in sync
- Added comprehensive test coverage for the new validation behavior

<h3>Confidence Score: 5/5</h3>

- Safe to merge with thorough implementation and good test coverage
- The implementation is well-designed with proper error handling, fallback logic for `structuredClone`, comprehensive validation flow, and appropriate test coverage. The graceful degradation approach prevents crashes while maintaining system functionality.
- No files require special attention

<sub>Last reviewed commit: d923068</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->